### PR TITLE
Fix parse fuzz crash caused by top level open curly

### DIFF
--- a/src/check/parse/AST.zig
+++ b/src/check/parse/AST.zig
@@ -667,6 +667,7 @@ pub const Diagnostic = struct {
         var_expected_equals,
         for_expected_in,
         match_branch_wrong_arrow,
+        unexpected_top_level_open_curly,
     };
 };
 

--- a/src/check/parse/Parser.zig
+++ b/src/check/parse/Parser.zig
@@ -1156,6 +1156,11 @@ fn parseStmtByType(self: *Parser, statementType: StatementType) std.mem.Allocato
                 return statement_idx;
             }
         },
+        .OpenCurly => {
+            if (statementType == .top_level) {
+                return try self.pushMalformed(AST.Statement.Idx, .unexpected_top_level_open_curly, self.pos);
+            }
+        },
         else => {},
     }
 

--- a/src/snapshots/fuzz_crash/fuzz_crash_009.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_009.md
@@ -16,8 +16,13 @@ foo =
 MISMATCHED BRACE - :0:0:0:0
 UNCLOSED STRING - :0:0:0:0
 MISSING HEADER - fuzz_crash_009.md:1:2:1:3
+PARSE ERROR - fuzz_crash_009.md:1:3:1:4
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_009.md:1:5:1:6
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_009.md:2:6:2:7
 PARSE ERROR - fuzz_crash_009.md:6:12:6:12
-INVALID STATEMENT - fuzz_crash_009.md:1:3:2:7
+INVALID STATEMENT - fuzz_crash_009.md:1:4:1:5
+INVALID STATEMENT - fuzz_crash_009.md:1:5:1:6
+INVALID STATEMENT - fuzz_crash_009.md:2:6:2:7
 # PROBLEMS
 **MISMATCHED BRACE**
 This brace does not match the corresponding opening brace.
@@ -42,6 +47,42 @@ Here is the problematic code:
 
 
 **PARSE ERROR**
+A parsing error occurred: `unexpected_top_level_open_curly`
+This is an unexpected parsing error. Please check your syntax.
+
+Here is the problematic code:
+**fuzz_crash_009.md:1:3:1:4:**
+```roc
+ f{o,
+```
+  ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **,** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_009.md:1:5:1:6:**
+```roc
+ f{o,
+```
+    ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **]** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_009.md:2:6:2:7:**
+```roc
+     ]
+```
+     ^
+
+
+**PARSE ERROR**
 A parsing error occurred: `string_unclosed`
 This is an unexpected parsing error. Please check your syntax.
 
@@ -57,11 +98,33 @@ Here is the problematic code:
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
 
-**fuzz_crash_009.md:1:3:2:7:**
+**fuzz_crash_009.md:1:4:1:5:**
 ```roc
  f{o,
+```
+   ^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_009.md:1:5:1:6:**
+```roc
+ f{o,
+```
+    ^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_009.md:2:6:2:7:**
+```roc
      ]
 ```
+     ^
 
 
 # TOKENS
@@ -76,8 +139,10 @@ StringStart(6:5-6:6),StringPart(6:6-6:12),EndOfFile(6:12-6:12),
 (file @1.2-6.12
 	(malformed-header @1.2-1.3 (tag "missing_header"))
 	(statements
-		(e-record @1.3-2.7
-			(field (field "o")))
+		(s-malformed @1.3-1.4 (tag "unexpected_top_level_open_curly"))
+		(e-ident @1.4-1.5 (raw "o"))
+		(e-malformed @1.5-1.6 (reason "expr_unexpected_token"))
+		(e-malformed @2.6-2.7 (reason "expr_unexpected_token"))
 		(s-decl @4.1-6.12
 			(p-ident @4.1-4.4 (raw "foo"))
 			(e-string @6.5-6.12
@@ -85,9 +150,9 @@ StringStart(6:5-6:6),StringPart(6:6-6:12),EndOfFile(6:12-6:12),
 ~~~
 # FORMATTED
 ~~~roc
-{
-	o
-}
+o
+
+
 
 foo = 
 

--- a/src/snapshots/fuzz_crash/fuzz_crash_010.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_010.md
@@ -16,8 +16,13 @@ ASCII CONTROL CHARACTER - :0:0:0:0
 MISMATCHED BRACE - :0:0:0:0
 UNCLOSED STRING - :0:0:0:0
 MISSING HEADER - fuzz_crash_010.md:1:1:1:2
+PARSE ERROR - fuzz_crash_010.md:1:2:1:3
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_010.md:1:4:1:5
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_010.md:2:6:2:7
 PARSE ERROR - fuzz_crash_010.md:5:35:5:35
-INVALID STATEMENT - fuzz_crash_010.md:1:2:2:7
+INVALID STATEMENT - fuzz_crash_010.md:1:3:1:4
+INVALID STATEMENT - fuzz_crash_010.md:1:4:1:5
+INVALID STATEMENT - fuzz_crash_010.md:2:6:2:7
 # PROBLEMS
 **ASCII CONTROL CHARACTER**
 ASCII control characters are not allowed in Roc source code.
@@ -45,6 +50,42 @@ H{o,
 
 
 **PARSE ERROR**
+A parsing error occurred: `unexpected_top_level_open_curly`
+This is an unexpected parsing error. Please check your syntax.
+
+Here is the problematic code:
+**fuzz_crash_010.md:1:2:1:3:**
+```roc
+H{o,
+```
+ ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **,** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_010.md:1:4:1:5:**
+```roc
+H{o,
+```
+   ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **]** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_010.md:2:6:2:7:**
+```roc
+    ]
+```
+     ^
+
+
+**PARSE ERROR**
 A parsing error occurred: `string_unclosed`
 This is an unexpected parsing error. Please check your syntax.
 
@@ -60,11 +101,33 @@ Here is the problematic code:
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
 
-**fuzz_crash_010.md:1:2:2:7:**
+**fuzz_crash_010.md:1:3:1:4:**
 ```roc
 H{o,
+```
+  ^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_010.md:1:4:1:5:**
+```roc
+H{o,
+```
+   ^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_010.md:2:6:2:7:**
+```roc
     ]
 ```
+     ^
 
 
 # TOKENS
@@ -79,8 +142,10 @@ StringStart(5:5-5:6),StringPart(5:6-5:35),EndOfFile(5:35-5:35),
 (file @1.1-5.35
 	(malformed-header @1.1-1.2 (tag "missing_header"))
 	(statements
-		(e-record @1.2-2.7
-			(field (field "o")))
+		(s-malformed @1.2-1.3 (tag "unexpected_top_level_open_curly"))
+		(e-ident @1.3-1.4 (raw "o"))
+		(e-malformed @1.4-1.5 (reason "expr_unexpected_token"))
+		(e-malformed @2.6-2.7 (reason "expr_unexpected_token"))
 		(s-decl @3.1-5.35
 			(p-ident @3.1-3.4 (raw "foo"))
 			(e-string @5.5-5.35
@@ -88,9 +153,9 @@ StringStart(5:5-5:6),StringPart(5:6-5:35),EndOfFile(5:35-5:35),
 ~~~
 # FORMATTED
 ~~~roc
-{
-	o
-}
+o
+
+
 foo = 
 
 	"on        (string 'onmo %')))"

--- a/src/snapshots/fuzz_crash/fuzz_crash_013.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_013.md
@@ -9,8 +9,7 @@ type=file
 ~~~
 # EXPECTED
 MISSING HEADER - fuzz_crash_013.md:1:1:1:2
-PARSE ERROR - fuzz_crash_013.md:1:3:1:3
-INVALID STATEMENT - fuzz_crash_013.md:1:2:1:3
+PARSE ERROR - fuzz_crash_013.md:1:2:1:3
 # PROBLEMS
 **MISSING HEADER**
 Roc files must start with a module header.
@@ -29,21 +28,10 @@ Here is the problematic code:
 
 
 **PARSE ERROR**
-A parsing error occurred: `expected_expr_close_curly_or_comma`
+A parsing error occurred: `unexpected_top_level_open_curly`
 This is an unexpected parsing error. Please check your syntax.
 
 Here is the problematic code:
-**fuzz_crash_013.md:1:3:1:3:**
-```roc
-0{
-```
-  
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
 **fuzz_crash_013.md:1:2:1:3:**
 ```roc
 0{
@@ -60,12 +48,11 @@ Int(1:1-1:2),OpenCurly(1:2-1:3),EndOfFile(1:3-1:3),
 (file @1.1-1.3
 	(malformed-header @1.1-1.2 (tag "missing_header"))
 	(statements
-		(e-block @1.2-1.3
-			(statements))))
+		(s-malformed @1.2-1.3 (tag "unexpected_top_level_open_curly"))))
 ~~~
 # FORMATTED
 ~~~roc
-{}
+
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/src/snapshots/fuzz_crash/fuzz_crash_024.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_024.md
@@ -17,10 +17,15 @@ var t= 0
 UNCLOSED STRING - :0:0:0:0
 MISMATCHED BRACE - :0:0:0:0
 PARSE ERROR - fuzz_crash_024.md:1:9:1:15
+PARSE ERROR - fuzz_crash_024.md:1:18:1:19
 UNEXPECTED TOKEN IN TYPE ANNOTATION - fuzz_crash_024.md:1:24:1:32
+PARSE ERROR - fuzz_crash_024.md:4:1:4:4
 UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_024.md:4:8:4:9
-PARSE ERROR - fuzz_crash_024.md:7:9:7:9
-INVALID STATEMENT - fuzz_crash_024.md:1:18:7:9
+PARSE ERROR - fuzz_crash_024.md:7:1:7:4
+MALFORMED TYPE - :0:0:0:0
+INVALID STATEMENT - fuzz_crash_024.md:1:33:1:53
+UNKNOWN OPERATOR - :0:0:0:0
+DUPLICATE DEFINITION - fuzz_crash_024.md:7:5:7:6
 # PROBLEMS
 **UNCLOSED STRING**
 This string is missing a closing quote.
@@ -40,6 +45,18 @@ module [module ] { pf: platform ".-/main._]where # A
         ^^^^^^
 
 
+**PARSE ERROR**
+A parsing error occurred: `unexpected_top_level_open_curly`
+This is an unexpected parsing error. Please check your syntax.
+
+Here is the problematic code:
+**fuzz_crash_024.md:1:18:1:19:**
+```roc
+module [module ] { pf: platform ".-/main._]where # A
+```
+                 ^
+
+
 **UNEXPECTED TOKEN IN TYPE ANNOTATION**
 The token **platform** is not expected in a type annotation.
 Type annotations should contain types like _Str_, _Num a_, or _List U64_.
@@ -50,6 +67,18 @@ Here is the problematic code:
 module [module ] { pf: platform ".-/main._]where # A
 ```
                        ^^^^^^^^
+
+
+**PARSE ERROR**
+A parsing error occurred: `var_only_allowed_in_a_body`
+This is an unexpected parsing error. Please check your syntax.
+
+Here is the problematic code:
+**fuzz_crash_024.md:4:1:4:4:**
+```roc
+var t= ]
+```
+^^^
 
 
 **UNEXPECTED TOKEN IN EXPRESSION**
@@ -65,31 +94,51 @@ var t= ]
 
 
 **PARSE ERROR**
-A parsing error occurred: `expected_expr_close_curly_or_comma`
+A parsing error occurred: `var_only_allowed_in_a_body`
 This is an unexpected parsing error. Please check your syntax.
 
 Here is the problematic code:
-**fuzz_crash_024.md:7:9:7:9:**
+**fuzz_crash_024.md:7:1:7:4:**
 ```roc
 var t= 0
 ```
-        
+^^^
 
+
+**MALFORMED TYPE**
+This type annotation is malformed or contains invalid syntax.
 
 **INVALID STATEMENT**
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
 
-**fuzz_crash_024.md:1:18:7:9:**
+**fuzz_crash_024.md:1:33:1:53:**
 ```roc
 module [module ] { pf: platform ".-/main._]where # A
+```
+                                ^^^^^^^^^^^^^^^^^^^^
 
-#el
-var t= ]
 
-#el
+**UNKNOWN OPERATOR**
+This looks like an operator, but it's not one I recognize!
+Check the spelling and make sure you're using a valid Roc operator.
+
+**DUPLICATE DEFINITION**
+The name `t` is being redeclared in this scope.
+
+The redeclaration is here:
+**fuzz_crash_024.md:7:5:7:6:**
+```roc
 var t= 0
 ```
+    ^
+
+But `t` was already defined here:
+**fuzz_crash_024.md:4:5:4:6:**
+```roc
+var t= ]
+```
+    ^
 
 
 # TOKENS
@@ -105,38 +154,49 @@ KwVar(7:1-7:4),LowerIdent(7:5-7:6),OpAssign(7:6-7:7),Int(7:8-7:9),EndOfFile(7:9-
 		(exposes @1.8-1.17
 			(exposed-malformed @1.9-1.15 (reason "exposed_item_unexpected_token") @1.9-1.15)))
 	(statements
-		(e-block @1.18-7.9
-			(statements
-				(s-type-anno @1.20-1.32 (name "pf")
-					(ty-malformed @1.24-1.32 (tag "ty_anno_unexpected_token")))
-				(e-string @1.33-1.53
-					(e-string-part @1.34-1.53 (raw ".-/main._]where # A")))
-				(s-var @4.1-4.9 (name "t")
-					(e-malformed @4.8-4.9 (reason "expr_unexpected_token")))
-				(s-var @7.1-7.9 (name "t")
-					(e-int @7.8-7.9 (raw "0")))))))
+		(s-malformed @1.18-1.19 (tag "unexpected_top_level_open_curly"))
+		(s-type-anno @1.20-1.32 (name "pf")
+			(ty-malformed @1.24-1.32 (tag "ty_anno_unexpected_token")))
+		(e-string @1.33-1.53
+			(e-string-part @1.34-1.53 (raw ".-/main._]where # A")))
+		(s-malformed @4.1-4.4 (tag "var_only_allowed_in_a_body"))
+		(s-decl @4.5-4.9
+			(p-ident @4.5-4.6 (raw "t"))
+			(e-malformed @4.8-4.9 (reason "expr_unexpected_token")))
+		(s-malformed @7.1-7.4 (tag "var_only_allowed_in_a_body"))
+		(s-decl @7.5-7.9
+			(p-ident @7.5-7.6 (raw "t"))
+			(e-int @7.8-7.9 (raw "0")))))
 ~~~
 # FORMATTED
 ~~~roc
 module []
-{
-	pf : 
-	".-/main._]where # A"
+pf : 
+".-/main._]where # A"
 
-	# el
-	var t = 
+# el
+t = 
 
-	# el
-	var t = 0
-}
+# el
+t = 0
 ~~~
 # CANONICALIZE
 ~~~clojure
-(can-ir (empty true))
+(can-ir
+	(d-let
+		(p-assign @4.5-4.6 (ident "t"))
+		(e-runtime-error (tag "expr_not_canonicalized")))
+	(d-let
+		(p-assign @7.5-7.6 (ident "t"))
+		(e-int @7.8-7.9 (value "0"))))
 ~~~
 # TYPES
 ~~~clojure
 (inferred-types
-	(defs)
-	(expressions))
+	(defs
+		(patt @4.5-4.6 (type "Error"))
+		(patt @7.5-7.6 (type "Num(_size)")))
+	(expressions
+		(expr @4.8-4.9 (type "Error"))
+		(expr @7.8-7.9 (type "Num(_size)"))))
 ~~~

--- a/src/snapshots/fuzz_crash/fuzz_crash_029.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_029.md
@@ -28,21 +28,34 @@ MISMATCHED BRACE - :0:0:0:0
 PARSE ERROR - fuzz_crash_029.md:4:4:4:5
 PARSE ERROR - fuzz_crash_029.md:5:14:5:17
 PARSE ERROR - fuzz_crash_029.md:5:9:5:13
+PARSE ERROR - fuzz_crash_029.md:5:22:5:23
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_029.md:5:23:5:24
 UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_029.md:5:24:5:25
 UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_029.md:6:4:6:5
 UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_029.md:7:2:7:9
 UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_029.md:10:2:10:10
+PARSE ERROR - fuzz_crash_029.md:12:3:12:4
+UNEXPECTED TOKEN IN TYPE ANNOTATION - fuzz_crash_029.md:13:6:13:7
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_029.md:13:7:13:10
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_029.md:13:10:13:11
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_029.md:13:11:13:12
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_029.md:13:19:13:20
 UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_029.md:14:2:14:10
 PARSE ERROR - fuzz_crash_029.md:17:3:17:4
 LIST NOT CLOSED - fuzz_crash_029.md:17:4:17:4
-INVALID STATEMENT - fuzz_crash_029.md:5:22:5:24
+INVALID STATEMENT - fuzz_crash_029.md:5:23:5:24
 INVALID STATEMENT - fuzz_crash_029.md:5:24:5:25
 INVALID STATEMENT - fuzz_crash_029.md:6:4:6:5
 INVALID STATEMENT - fuzz_crash_029.md:7:2:7:9
 INVALID STATEMENT - fuzz_crash_029.md:8:3:9:4
 INVALID STATEMENT - fuzz_crash_029.md:10:2:10:10
 INVALID STATEMENT - fuzz_crash_029.md:11:3:11:8
-INVALID STATEMENT - fuzz_crash_029.md:12:3:13:20
+MALFORMED TYPE - :0:0:0:0
+INVALID STATEMENT - fuzz_crash_029.md:13:7:13:10
+INVALID STATEMENT - fuzz_crash_029.md:13:10:13:11
+INVALID STATEMENT - fuzz_crash_029.md:13:11:13:12
+INVALID STATEMENT - fuzz_crash_029.md:13:13:13:17
+INVALID STATEMENT - fuzz_crash_029.md:13:19:13:20
 INVALID STATEMENT - fuzz_crash_029.md:14:2:14:10
 INVALID STATEMENT - fuzz_crash_029.md:15:3:17:4
 # PROBLEMS
@@ -97,6 +110,30 @@ Here is the problematic code:
         ^^^^
 
 
+**PARSE ERROR**
+A parsing error occurred: `unexpected_top_level_open_curly`
+This is an unexpected parsing error. Please check your syntax.
+
+Here is the problematic code:
+**fuzz_crash_029.md:5:22:5:23:**
+```roc
+			n! : List(Str) => {}, # ure
+```
+                     ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **}** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_029.md:5:23:5:24:**
+```roc
+			n! : List(Str) => {}, # ure
+```
+                      ^
+
+
 **UNEXPECTED TOKEN IN EXPRESSION**
 The token **,** is not expected in an expression.
 Expressions can be identifiers, literals, function calls, or operators.
@@ -145,6 +182,78 @@ Here is the problematic code:
  ^^^^^^^^
 
 
+**PARSE ERROR**
+A parsing error occurred: `unexpected_top_level_open_curly`
+This is an unexpected parsing error. Please check your syntax.
+
+Here is the problematic code:
+**fuzz_crash_029.md:12:3:12:4:**
+```roc
+		{ # pen
+```
+  ^
+
+
+**UNEXPECTED TOKEN IN TYPE ANNOTATION**
+The token **"** is not expected in a type annotation.
+Type annotations should contain types like _Str_, _Num a_, or _List U64_.
+
+Here is the problematic code:
+**fuzz_crash_029.md:13:6:13:7:**
+```roc
+pkg: "..l", mmen		} # Cose
+```
+     ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **..l** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_029.md:13:7:13:10:**
+```roc
+pkg: "..l", mmen		} # Cose
+```
+      ^^^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **"** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_029.md:13:10:13:11:**
+```roc
+pkg: "..l", mmen		} # Cose
+```
+         ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **,** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_029.md:13:11:13:12:**
+```roc
+pkg: "..l", mmen		} # Cose
+```
+          ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **}** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_029.md:13:19:13:20:**
+```roc
+pkg: "..l", mmen		} # Cose
+```
+                  ^
+
+
 **UNEXPECTED TOKEN IN EXPRESSION**
 The token **provides** is not expected in an expression.
 Expressions can be identifiers, literals, function calls, or operators.
@@ -186,11 +295,11 @@ Here is the problematic code:
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
 
-**fuzz_crash_029.md:5:22:5:24:**
+**fuzz_crash_029.md:5:23:5:24:**
 ```roc
 			n! : List(Str) => {}, # ure
 ```
-                     ^^
+                      ^
 
 
 **INVALID STATEMENT**
@@ -259,15 +368,62 @@ Only definitions, type annotations, and imports are allowed at the top level.
   ^^^^^
 
 
+**MALFORMED TYPE**
+This type annotation is malformed or contains invalid syntax.
+
 **INVALID STATEMENT**
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
 
-**fuzz_crash_029.md:12:3:13:20:**
+**fuzz_crash_029.md:13:7:13:10:**
 ```roc
-		{ # pen
 pkg: "..l", mmen		} # Cose
 ```
+      ^^^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_029.md:13:10:13:11:**
+```roc
+pkg: "..l", mmen		} # Cose
+```
+         ^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_029.md:13:11:13:12:**
+```roc
+pkg: "..l", mmen		} # Cose
+```
+          ^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_029.md:13:13:13:17:**
+```roc
+pkg: "..l", mmen		} # Cose
+```
+            ^^^^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_029.md:13:19:13:20:**
+```roc
+pkg: "..l", mmen		} # Cose
+```
+                  ^
 
 
 **INVALID STATEMENT**
@@ -319,35 +475,38 @@ CloseRound(17:3-17:4),EndOfFile(17:4-17:4),
 	(malformed-header @4.4-5.8 (tag "expected_requires_rigids_close_curly"))
 	(statements
 		(s-malformed @5.9-5.21 (tag "expected_colon_after_type_annotation"))
-		(e-record @5.22-5.24)
+		(s-malformed @5.22-5.23 (tag "unexpected_top_level_open_curly"))
+		(e-malformed @5.23-5.24 (reason "expr_unexpected_token"))
 		(e-malformed @5.24-5.25 (reason "expr_unexpected_token"))
 		(e-malformed @6.4-6.5 (reason "expr_unexpected_token"))
 		(e-malformed @7.2-7.9 (reason "expr_unexpected_token"))
 		(e-list @8.3-9.4)
 		(e-malformed @10.2-10.10 (reason "expr_unexpected_token"))
 		(e-ident @11.3-11.8 (raw "vides"))
-		(e-record @12.3-13.20
-			(field (field "pkg")
-				(e-string @13.6-13.11
-					(e-string-part @13.7-13.10 (raw "..l"))))
-			(field (field "mmen")))
+		(s-malformed @12.3-12.4 (tag "unexpected_top_level_open_curly"))
+		(s-type-anno @13.1-13.7 (name "pkg")
+			(ty-malformed @13.6-13.7 (tag "ty_anno_unexpected_token")))
+		(e-malformed @13.7-13.10 (reason "expr_unexpected_token"))
+		(e-malformed @13.10-13.11 (reason "expr_unexpected_token"))
+		(e-malformed @13.11-13.12 (reason "expr_unexpected_token"))
+		(e-ident @13.13-13.17 (raw "mmen"))
+		(e-malformed @13.19-13.20 (reason "expr_unexpected_token"))
 		(e-malformed @14.2-14.10 (reason "expr_unexpected_token"))
 		(e-malformed @17.4-17.4 (reason "expected_expr_close_square_or_comma"))))
 ~~~
 # FORMATTED
 ~~~roc
 # Co		{	} #ose
-{}
 # ure
 # Ce
 # rd
 [] # Cse
 # Cd
 vides # Cd
-{ # pen
-	pkg: "..l",
-	mmen # Cose
-} # Cose
+# pen
+pkg : 
+mmen
+# Cose
 # Cd
 
 ~~~

--- a/src/snapshots/fuzz_crash/fuzz_crash_035.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_035.md
@@ -9,25 +9,13 @@ module[]{
  
 ~~~
 # EXPECTED
-PARSE ERROR - fuzz_crash_035.md:2:2:2:2
-INVALID STATEMENT - fuzz_crash_035.md:1:9:1:10
+PARSE ERROR - fuzz_crash_035.md:1:9:1:10
 # PROBLEMS
 **PARSE ERROR**
-A parsing error occurred: `expected_expr_close_curly_or_comma`
+A parsing error occurred: `unexpected_top_level_open_curly`
 This is an unexpected parsing error. Please check your syntax.
 
 Here is the problematic code:
-**fuzz_crash_035.md:2:2:2:2:**
-```roc
- 
-```
- 
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
 **fuzz_crash_035.md:1:9:1:10:**
 ```roc
 module[]{
@@ -46,13 +34,12 @@ EndOfFile(2:2-2:2),
 	(module @1.1-1.9
 		(exposes @1.7-1.9))
 	(statements
-		(e-block @1.9-1.10
-			(statements))))
+		(s-malformed @1.9-1.10 (tag "unexpected_top_level_open_curly"))))
 ~~~
 # FORMATTED
 ~~~roc
 module []
-{}
+
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/src/snapshots/fuzz_crash/fuzz_crash_040.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_040.md
@@ -10,20 +10,63 @@ o:0)
 ~~~
 # EXPECTED
 MISMATCHED BRACE - :0:0:0:0
-INVALID STATEMENT - fuzz_crash_040.md:1:20:2:5
+PARSE ERROR - fuzz_crash_040.md:1:20:1:21
+UNEXPECTED TOKEN IN TYPE ANNOTATION - fuzz_crash_040.md:2:3:2:4
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_040.md:2:4:2:5
+MALFORMED TYPE - :0:0:0:0
+INVALID STATEMENT - fuzz_crash_040.md:2:4:2:5
 # PROBLEMS
 **MISMATCHED BRACE**
 This brace does not match the corresponding opening brace.
+
+**PARSE ERROR**
+A parsing error occurred: `unexpected_top_level_open_curly`
+This is an unexpected parsing error. Please check your syntax.
+
+Here is the problematic code:
+**fuzz_crash_040.md:1:20:1:21:**
+```roc
+app[]{f:platform""}{
+```
+                   ^
+
+
+**UNEXPECTED TOKEN IN TYPE ANNOTATION**
+The token **0** is not expected in a type annotation.
+Type annotations should contain types like _Str_, _Num a_, or _List U64_.
+
+Here is the problematic code:
+**fuzz_crash_040.md:2:3:2:4:**
+```roc
+o:0)
+```
+  ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **)** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_040.md:2:4:2:5:**
+```roc
+o:0)
+```
+   ^
+
+
+**MALFORMED TYPE**
+This type annotation is malformed or contains invalid syntax.
 
 **INVALID STATEMENT**
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
 
-**fuzz_crash_040.md:1:20:2:5:**
+**fuzz_crash_040.md:2:4:2:5:**
 ```roc
-app[]{f:platform""}{
 o:0)
 ```
+   ^
 
 
 # TOKENS
@@ -44,16 +87,17 @@ LowerIdent(2:1-2:2),OpColon(2:2-2:3),Int(2:3-2:4),CloseCurly(2:4-2:5),EndOfFile(
 				(e-string @1.17-1.19
 					(e-string-part @1.18-1.18 (raw ""))))))
 	(statements
-		(e-record @1.20-2.5
-			(field (field "o")
-				(e-int @2.3-2.4 (raw "0"))))))
+		(s-malformed @1.20-1.21 (tag "unexpected_top_level_open_curly"))
+		(s-type-anno @2.1-2.4 (name "o")
+			(ty-malformed @2.3-2.4 (tag "ty_anno_unexpected_token")))
+		(e-malformed @2.4-2.5 (reason "expr_unexpected_token"))))
 ~~~
 # FORMATTED
 ~~~roc
 app [] { f: platform "" }
-{
-	o: 0
-}
+
+o : 
+
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/src/snapshots/fuzz_crash/fuzz_crash_043.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_043.md
@@ -9,18 +9,61 @@ app[]{f:platform""}{
 o:0}0
 ~~~
 # EXPECTED
-INVALID STATEMENT - fuzz_crash_043.md:1:20:2:5
+PARSE ERROR - fuzz_crash_043.md:1:20:1:21
+UNEXPECTED TOKEN IN TYPE ANNOTATION - fuzz_crash_043.md:2:3:2:4
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_043.md:2:4:2:5
+MALFORMED TYPE - :0:0:0:0
+INVALID STATEMENT - fuzz_crash_043.md:2:4:2:5
 INVALID STATEMENT - fuzz_crash_043.md:2:5:2:6
 # PROBLEMS
+**PARSE ERROR**
+A parsing error occurred: `unexpected_top_level_open_curly`
+This is an unexpected parsing error. Please check your syntax.
+
+Here is the problematic code:
+**fuzz_crash_043.md:1:20:1:21:**
+```roc
+app[]{f:platform""}{
+```
+                   ^
+
+
+**UNEXPECTED TOKEN IN TYPE ANNOTATION**
+The token **0** is not expected in a type annotation.
+Type annotations should contain types like _Str_, _Num a_, or _List U64_.
+
+Here is the problematic code:
+**fuzz_crash_043.md:2:3:2:4:**
+```roc
+o:0}0
+```
+  ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **}** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_043.md:2:4:2:5:**
+```roc
+o:0}0
+```
+   ^
+
+
+**MALFORMED TYPE**
+This type annotation is malformed or contains invalid syntax.
+
 **INVALID STATEMENT**
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
 
-**fuzz_crash_043.md:1:20:2:5:**
+**fuzz_crash_043.md:2:4:2:5:**
 ```roc
-app[]{f:platform""}{
 o:0}0
 ```
+   ^
 
 
 **INVALID STATEMENT**
@@ -52,17 +95,17 @@ LowerIdent(2:1-2:2),OpColon(2:2-2:3),Int(2:3-2:4),CloseCurly(2:4-2:5),Int(2:5-2:
 				(e-string @1.17-1.19
 					(e-string-part @1.18-1.18 (raw ""))))))
 	(statements
-		(e-record @1.20-2.5
-			(field (field "o")
-				(e-int @2.3-2.4 (raw "0"))))
+		(s-malformed @1.20-1.21 (tag "unexpected_top_level_open_curly"))
+		(s-type-anno @2.1-2.4 (name "o")
+			(ty-malformed @2.3-2.4 (tag "ty_anno_unexpected_token")))
+		(e-malformed @2.4-2.5 (reason "expr_unexpected_token"))
 		(e-int @2.5-2.6 (raw "0"))))
 ~~~
 # FORMATTED
 ~~~roc
 app [] { f: platform "" }
-{
-	o: 0
-}
+
+o : 
 0
 ~~~
 # CANONICALIZE

--- a/src/snapshots/fuzz_crash/fuzz_crash_044.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_044.md
@@ -11,18 +11,94 @@ app[]{f:platform""}{{0
 ""
 ~~~
 # EXPECTED
-INVALID STATEMENT - fuzz_crash_044.md:1:20:2:3
+PARSE ERROR - fuzz_crash_044.md:1:20:1:21
+PARSE ERROR - fuzz_crash_044.md:1:21:1:22
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_044.md:2:1:2:2
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_044.md:2:2:2:3
+INVALID STATEMENT - fuzz_crash_044.md:1:22:1:23
+INVALID STATEMENT - fuzz_crash_044.md:2:1:2:2
+INVALID STATEMENT - fuzz_crash_044.md:2:2:2:3
 INVALID STATEMENT - fuzz_crash_044.md:4:1:4:3
 # PROBLEMS
+**PARSE ERROR**
+A parsing error occurred: `unexpected_top_level_open_curly`
+This is an unexpected parsing error. Please check your syntax.
+
+Here is the problematic code:
+**fuzz_crash_044.md:1:20:1:21:**
+```roc
+app[]{f:platform""}{{0
+```
+                   ^
+
+
+**PARSE ERROR**
+A parsing error occurred: `unexpected_top_level_open_curly`
+This is an unexpected parsing error. Please check your syntax.
+
+Here is the problematic code:
+**fuzz_crash_044.md:1:21:1:22:**
+```roc
+app[]{f:platform""}{{0
+```
+                    ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **}** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_044.md:2:1:2:2:**
+```roc
+}}
+```
+^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **}** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_044.md:2:2:2:3:**
+```roc
+}}
+```
+ ^
+
+
 **INVALID STATEMENT**
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
 
-**fuzz_crash_044.md:1:20:2:3:**
+**fuzz_crash_044.md:1:22:1:23:**
 ```roc
 app[]{f:platform""}{{0
+```
+                     ^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_044.md:2:1:2:2:**
+```roc
 }}
 ```
+^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_044.md:2:2:2:3:**
+```roc
+}}
+```
+ ^
 
 
 **INVALID STATEMENT**
@@ -55,22 +131,19 @@ StringStart(4:1-4:2),StringPart(4:2-4:2),StringEnd(4:2-4:3),EndOfFile(4:3-4:3),
 				(e-string @1.17-1.19
 					(e-string-part @1.18-1.18 (raw ""))))))
 	(statements
-		(e-block @1.20-2.3
-			(statements
-				(e-block @1.21-2.2
-					(statements
-						(e-int @1.22-1.23 (raw "0"))))))
+		(s-malformed @1.20-1.21 (tag "unexpected_top_level_open_curly"))
+		(s-malformed @1.21-1.22 (tag "unexpected_top_level_open_curly"))
+		(e-int @1.22-1.23 (raw "0"))
+		(e-malformed @2.1-2.2 (reason "expr_unexpected_token"))
+		(e-malformed @2.2-2.3 (reason "expr_unexpected_token"))
 		(e-string @4.1-4.3
 			(e-string-part @4.2-4.2 (raw "")))))
 ~~~
 # FORMATTED
 ~~~roc
 app [] { f: platform "" }
-{
-	{
-		0
-	}
-}
+0
+
 
 ""
 ~~~

--- a/src/snapshots/fuzz_crash/fuzz_crash_051.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_051.md
@@ -11,7 +11,12 @@ module[}{0      0)(0}
 MISMATCHED BRACE - :0:0:0:0
 MISMATCHED BRACE - :0:0:0:0
 MISMATCHED BRACE - :0:0:0:0
-INVALID STATEMENT - fuzz_crash_051.md:1:9:1:22
+PARSE ERROR - fuzz_crash_051.md:1:9:1:10
+UNEXPECTED TOKEN IN EXPRESSION - fuzz_crash_051.md:1:18:1:19
+INVALID STATEMENT - fuzz_crash_051.md:1:10:1:11
+INVALID STATEMENT - fuzz_crash_051.md:1:17:1:18
+INVALID STATEMENT - fuzz_crash_051.md:1:18:1:19
+INVALID STATEMENT - fuzz_crash_051.md:1:19:1:22
 # PROBLEMS
 **MISMATCHED BRACE**
 This brace does not match the corresponding opening brace.
@@ -22,15 +27,72 @@ This brace does not match the corresponding opening brace.
 **MISMATCHED BRACE**
 This brace does not match the corresponding opening brace.
 
+**PARSE ERROR**
+A parsing error occurred: `unexpected_top_level_open_curly`
+This is an unexpected parsing error. Please check your syntax.
+
+Here is the problematic code:
+**fuzz_crash_051.md:1:9:1:10:**
+```roc
+module[}{0      0)(0}
+```
+        ^
+
+
+**UNEXPECTED TOKEN IN EXPRESSION**
+The token **)** is not expected in an expression.
+Expressions can be identifiers, literals, function calls, or operators.
+
+Here is the problematic code:
+**fuzz_crash_051.md:1:18:1:19:**
+```roc
+module[}{0      0)(0}
+```
+                 ^
+
+
 **INVALID STATEMENT**
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
 
-**fuzz_crash_051.md:1:9:1:22:**
+**fuzz_crash_051.md:1:10:1:11:**
 ```roc
 module[}{0      0)(0}
 ```
-        ^^^^^^^^^^^^^
+         ^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_051.md:1:17:1:18:**
+```roc
+module[}{0      0)(0}
+```
+                ^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_051.md:1:18:1:19:**
+```roc
+module[}{0      0)(0}
+```
+                 ^
+
+
+**INVALID STATEMENT**
+The statement **expression** is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_051.md:1:19:1:22:**
+```roc
+module[}{0      0)(0}
+```
+                  ^^^
 
 
 # TOKENS
@@ -43,20 +105,19 @@ KwModule(1:1-1:7),OpenSquare(1:7-1:8),CloseSquare(1:8-1:9),OpenCurly(1:9-1:10),I
 	(module @1.1-1.9
 		(exposes @1.7-1.9))
 	(statements
-		(e-apply @1.9-1.22
-			(e-block @1.9-1.19
-				(statements
-					(e-int @1.10-1.11 (raw "0"))
-					(e-int @1.17-1.18 (raw "0"))))
+		(s-malformed @1.9-1.10 (tag "unexpected_top_level_open_curly"))
+		(e-int @1.10-1.11 (raw "0"))
+		(e-int @1.17-1.18 (raw "0"))
+		(e-malformed @1.18-1.19 (reason "expr_unexpected_token"))
+		(e-tuple @1.19-1.22
 			(e-int @1.20-1.21 (raw "0")))))
 ~~~
 # FORMATTED
 ~~~roc
 module []
-{
-	0
-	0
-}(0)
+0
+0
+(0)
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/src/snapshots/fuzz_crash/fuzz_crash_052.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_052.md
@@ -5,20 +5,20 @@ type=file
 ~~~
 # SOURCE
 ~~~roc
-module[]{B
+module[]{C}
 ~~~
 # EXPECTED
-PARSE ERROR - fuzz_crash_036.md:1:9:1:10
-PARSE ERROR - fuzz_crash_036.md:1:11:1:11
+PARSE ERROR - fuzz_crash_052.md:1:9:1:10
+PARSE ERROR - fuzz_crash_052.md:1:11:1:12
 # PROBLEMS
 **PARSE ERROR**
 A parsing error occurred: `unexpected_top_level_open_curly`
 This is an unexpected parsing error. Please check your syntax.
 
 Here is the problematic code:
-**fuzz_crash_036.md:1:9:1:10:**
+**fuzz_crash_052.md:1:9:1:10:**
 ```roc
-module[]{B
+module[]{C}
 ```
         ^
 
@@ -40,25 +40,25 @@ Other valid examples:
     `Maybe(List(U64))`
 
 Here is the problematic code:
-**fuzz_crash_036.md:1:11:1:11:**
+**fuzz_crash_052.md:1:11:1:12:**
 ```roc
-module[]{B
+module[]{C}
 ```
-          
+          ^
 
 
 # TOKENS
 ~~~zig
-KwModule(1:1-1:7),OpenSquare(1:7-1:8),CloseSquare(1:8-1:9),OpenCurly(1:9-1:10),UpperIdent(1:10-1:11),EndOfFile(1:11-1:11),
+KwModule(1:1-1:7),OpenSquare(1:7-1:8),CloseSquare(1:8-1:9),OpenCurly(1:9-1:10),UpperIdent(1:10-1:11),CloseCurly(1:11-1:12),EndOfFile(1:12-1:12),
 ~~~
 # PARSE
 ~~~clojure
-(file @1.1-1.11
+(file @1.1-1.12
 	(module @1.1-1.9
 		(exposes @1.7-1.9))
 	(statements
 		(s-malformed @1.9-1.10 (tag "unexpected_top_level_open_curly"))
-		(s-malformed @1.10-1.11 (tag "expected_colon_after_type_annotation"))))
+		(s-malformed @1.10-1.12 (tag "expected_colon_after_type_annotation"))))
 ~~~
 # FORMATTED
 ~~~roc

--- a/src/snapshots/qualified_type_canonicalization.md
+++ b/src/snapshots/qualified_type_canonicalization.md
@@ -19,7 +19,7 @@ import ExternalModule as ExtMod
 
 # Simple qualified type
 simpleQualified : Color.RGB
-simpleQualified = Color.RGB { r: 255, g: 0, b: 0 }
+simpleQualified = Color.RGB({ r: 255, g: 0, b: 0 })
 
 # Aliased qualified type
 aliasedQualified : ExtMod.DataType
@@ -30,70 +30,42 @@ multiLevelQualified : ModuleA.ModuleB.TypeC
 multiLevelQualified = TypeC.new
 
 # Using qualified type with generics
-resultType : Result.Result I32 Str
-resultType = Result.Ok 42
+resultType : Result.Result(I32, Str)
+resultType = Result.Ok(42)
 
 # Function returning qualified type
 getColor : {} -> Color.RGB
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
+getColor = |_| Color.RGB({ r: 0, g: 255, b: 0 })
 
 # Function accepting qualified type
 processColor : Color.RGB -> Str
-processColor = \color ->
+processColor = |color|
     "Color processed"
 
 # Multiple qualified types in a function signature
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-transform = \result ->
-    when result is
-        Result.Ok rgb -> TypeC.fromColor rgb
-        Result.Err err -> TypeC.default
+transform : Result.Result(Color.RGB, ExtMod.Error) -> ModuleA.ModuleB.TypeC
+transform = |result|
+    match result {
+        Result.Ok(rgb) => TypeC.fromColor(rgb)
+        Result.Err(err) => TypeC.default
+    }
 ~~~
 # EXPECTED
 PARSE ERROR - qualified_type_canonicalization.md:8:1:8:7
 PARSE ERROR - qualified_type_canonicalization.md:8:14:8:21
 UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:10:15:10:23
 UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:10:24:10:32
-PARSE ERROR - qualified_type_canonicalization.md:26:32:26:35
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:31:12:31:13
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:31:24:31:28
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:35:16:35:17
-PARSE ERROR - qualified_type_canonicalization.md:36:5:36:6
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:36:6:36:21
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:36:21:36:22
-PARSE ERROR - qualified_type_canonicalization.md:39:32:39:36
-PARSE ERROR - qualified_type_canonicalization.md:39:43:39:49
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:39:50:39:52
-PARSE ERROR - qualified_type_canonicalization.md:39:60:39:68
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:39:68:39:74
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:40:13:40:14
-PARSE ERROR - qualified_type_canonicalization.md:42:15:42:18
-PARSE ERROR - qualified_type_canonicalization.md:43:15:43:19
 INVALID STATEMENT - qualified_type_canonicalization.md:10:15:10:23
 INVALID STATEMENT - qualified_type_canonicalization.md:10:24:10:32
 INVALID STATEMENT - qualified_type_canonicalization.md:10:33:10:40
 UNDEFINED VARIABLE - qualified_type_canonicalization.md:15:19:15:24
-INVALID STATEMENT - qualified_type_canonicalization.md:15:29:15:51
 UNDEFINED VARIABLE - qualified_type_canonicalization.md:19:26:19:35
 UNDEFINED VARIABLE - qualified_type_canonicalization.md:23:23:23:32
-INVALID STATEMENT - qualified_type_canonicalization.md:27:24:27:26
-UNKNOWN OPERATOR - :0:0:0:0
-INVALID STATEMENT - qualified_type_canonicalization.md:31:13:31:24
-INVALID STATEMENT - qualified_type_canonicalization.md:31:24:31:28
-INVALID STATEMENT - qualified_type_canonicalization.md:31:29:31:51
-UNKNOWN OPERATOR - :0:0:0:0
-INVALID STATEMENT - qualified_type_canonicalization.md:35:17:36:6
-INVALID STATEMENT - qualified_type_canonicalization.md:36:6:36:21
-INVALID STATEMENT - qualified_type_canonicalization.md:36:21:36:22
-INVALID STATEMENT - qualified_type_canonicalization.md:39:50:39:52
-INVALID STATEMENT - qualified_type_canonicalization.md:39:68:39:74
-UNKNOWN OPERATOR - :0:0:0:0
-INVALID STATEMENT - qualified_type_canonicalization.md:40:14:41:9
-INVALID STATEMENT - qualified_type_canonicalization.md:41:10:41:16
-INVALID STATEMENT - qualified_type_canonicalization.md:41:17:41:19
-INVALID STATEMENT - qualified_type_canonicalization.md:42:19:42:41
-INVALID STATEMENT - qualified_type_canonicalization.md:42:42:42:45
-INVALID STATEMENT - qualified_type_canonicalization.md:43:20:43:40
+UNDEFINED VARIABLE - qualified_type_canonicalization.md:31:16:31:21
+UNUSED VARIABLE - qualified_type_canonicalization.md:35:17:35:22
+UNDEFINED VARIABLE - qualified_type_canonicalization.md:42:27:42:42
+UNDEFINED VARIABLE - qualified_type_canonicalization.md:43:28:43:41
+UNUSED VARIABLE - qualified_type_canonicalization.md:43:20:43:23
 # PROBLEMS
 **PARSE ERROR**
 A parsing error occurred: `import_exposing_no_close`
@@ -155,258 +127,6 @@ import ModuleA.ModuleB exposing [TypeC]
                        ^^^^^^^^
 
 
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:26:32:26:35:**
-```roc
-resultType : Result.Result I32 Str
-```
-                               ^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **\** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:31:12:31:13:**
-```roc
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
-```
-           ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **.RGB** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:31:24:31:28:**
-```roc
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
-```
-                       ^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **\** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:35:16:35:17:**
-```roc
-processColor = \color ->
-```
-               ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expr_arrow_expects_ident`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:36:5:36:6:**
-```roc
-    "Color processed"
-```
-    ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **Color processed** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:36:6:36:21:**
-```roc
-    "Color processed"
-```
-     ^^^^^^^^^^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **"** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:36:21:36:22:**
-```roc
-    "Color processed"
-```
-                    ^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:39:32:39:36:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                               ^^^^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:39:43:39:49:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                          ^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **->** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:39:50:39:52:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                                 ^^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:39:60:39:68:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                                           ^^^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **.TypeC** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:39:68:39:74:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                                                   ^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **\** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:40:13:40:14:**
-```roc
-transform = \result ->
-```
-            ^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:42:15:42:18:**
-```roc
-        Result.Ok rgb -> TypeC.fromColor rgb
-```
-              ^^^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:43:15:43:19:**
-```roc
-        Result.Err err -> TypeC.default
-```
-              ^^^^
-
-
 **INVALID STATEMENT**
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
@@ -446,20 +166,9 @@ Is there an `import` or `exposing` missing up-top?
 
 **qualified_type_canonicalization.md:15:19:15:24:**
 ```roc
-simpleQualified = Color.RGB { r: 255, g: 0, b: 0 }
+simpleQualified = Color.RGB({ r: 255, g: 0, b: 0 })
 ```
                   ^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:15:29:15:51:**
-```roc
-simpleQualified = Color.RGB { r: 255, g: 0, b: 0 }
-```
-                            ^^^^^^^^^^^^^^^^^^^^^^
 
 
 **UNDEFINED VARIABLE**
@@ -484,181 +193,61 @@ multiLevelQualified = TypeC.new
                       ^^^^^^^^^
 
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
+**UNDEFINED VARIABLE**
+Nothing is named `Color` in this scope.
+Is there an `import` or `exposing` missing up-top?
 
-**qualified_type_canonicalization.md:27:24:27:26:**
+**qualified_type_canonicalization.md:31:16:31:21:**
 ```roc
-resultType = Result.Ok 42
+getColor = |_| Color.RGB({ r: 0, g: 255, b: 0 })
 ```
-                       ^^
+               ^^^^^
 
 
-**UNKNOWN OPERATOR**
-This looks like an operator, but it's not one I recognize!
-Check the spelling and make sure you're using a valid Roc operator.
+**UNUSED VARIABLE**
+Variable `color` is not used anywhere in your code.
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:31:13:31:24:**
+If you don't need this variable, prefix it with an underscore like _color to suppress this warning.
+The unused variable is declared here:
+**qualified_type_canonicalization.md:35:17:35:22:**
 ```roc
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
+processColor = |color|
 ```
-            ^^^^^^^^^^^
+                ^^^^^
 
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
+**UNDEFINED VARIABLE**
+Nothing is named `fromColor` in this scope.
+Is there an `import` or `exposing` missing up-top?
 
-**qualified_type_canonicalization.md:31:24:31:28:**
+**qualified_type_canonicalization.md:42:27:42:42:**
 ```roc
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
+        Result.Ok(rgb) => TypeC.fromColor(rgb)
 ```
-                       ^^^^
+                          ^^^^^^^^^^^^^^^
 
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
+**UNDEFINED VARIABLE**
+Nothing is named `default` in this scope.
+Is there an `import` or `exposing` missing up-top?
 
-**qualified_type_canonicalization.md:31:29:31:51:**
+**qualified_type_canonicalization.md:43:28:43:41:**
 ```roc
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
+        Result.Err(err) => TypeC.default
 ```
-                            ^^^^^^^^^^^^^^^^^^^^^^
+                           ^^^^^^^^^^^^^
 
 
-**UNKNOWN OPERATOR**
-This looks like an operator, but it's not one I recognize!
-Check the spelling and make sure you're using a valid Roc operator.
+**UNUSED VARIABLE**
+Variable `err` is not used anywhere in your code.
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:35:17:36:6:**
+If you don't need this variable, prefix it with an underscore like _err to suppress this warning.
+The unused variable is declared here:
+**qualified_type_canonicalization.md:43:20:43:23:**
 ```roc
-processColor = \color ->
-    "Color processed"
+        Result.Err(err) => TypeC.default
 ```
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:36:6:36:21:**
-```roc
-    "Color processed"
-```
-     ^^^^^^^^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:36:21:36:22:**
-```roc
-    "Color processed"
-```
-                    ^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:39:50:39:52:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                                 ^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:39:68:39:74:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                                                   ^^^^^^
-
-
-**UNKNOWN OPERATOR**
-This looks like an operator, but it's not one I recognize!
-Check the spelling and make sure you're using a valid Roc operator.
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:40:14:41:9:**
-```roc
-transform = \result ->
-    when result is
-```
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:41:10:41:16:**
-```roc
-    when result is
-```
-         ^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:41:17:41:19:**
-```roc
-    when result is
-```
-                ^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:42:19:42:41:**
-```roc
-        Result.Ok rgb -> TypeC.fromColor rgb
-```
-                  ^^^^^^^^^^^^^^^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:42:42:42:45:**
-```roc
-        Result.Ok rgb -> TypeC.fromColor rgb
-```
-                                         ^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:43:20:43:40:**
-```roc
-        Result.Err err -> TypeC.default
-```
-                   ^^^^^^^^^^^^^^^^^^^^
+                   ^^^
 
 
 # TOKENS
@@ -674,27 +263,28 @@ KwImport(9:1-9:7),UpperIdent(9:8-9:13),
 KwImport(10:1-10:7),UpperIdent(10:8-10:15),NoSpaceDotUpperIdent(10:15-10:23),KwExposing(10:24-10:32),OpenSquare(10:33-10:34),UpperIdent(10:34-10:39),CloseSquare(10:39-10:40),
 KwImport(11:1-11:7),UpperIdent(11:8-11:22),KwAs(11:23-11:25),UpperIdent(11:26-11:32),
 LowerIdent(14:1-14:16),OpColon(14:17-14:18),UpperIdent(14:19-14:24),NoSpaceDotUpperIdent(14:24-14:28),
-LowerIdent(15:1-15:16),OpAssign(15:17-15:18),UpperIdent(15:19-15:24),NoSpaceDotUpperIdent(15:24-15:28),OpenCurly(15:29-15:30),LowerIdent(15:31-15:32),OpColon(15:32-15:33),Int(15:34-15:37),Comma(15:37-15:38),LowerIdent(15:39-15:40),OpColon(15:40-15:41),Int(15:42-15:43),Comma(15:43-15:44),LowerIdent(15:45-15:46),OpColon(15:46-15:47),Int(15:48-15:49),CloseCurly(15:50-15:51),
+LowerIdent(15:1-15:16),OpAssign(15:17-15:18),UpperIdent(15:19-15:24),NoSpaceDotUpperIdent(15:24-15:28),NoSpaceOpenRound(15:28-15:29),OpenCurly(15:29-15:30),LowerIdent(15:31-15:32),OpColon(15:32-15:33),Int(15:34-15:37),Comma(15:37-15:38),LowerIdent(15:39-15:40),OpColon(15:40-15:41),Int(15:42-15:43),Comma(15:43-15:44),LowerIdent(15:45-15:46),OpColon(15:46-15:47),Int(15:48-15:49),CloseCurly(15:50-15:51),CloseRound(15:51-15:52),
 LowerIdent(18:1-18:17),OpColon(18:18-18:19),UpperIdent(18:20-18:26),NoSpaceDotUpperIdent(18:26-18:35),
 LowerIdent(19:1-19:17),OpAssign(19:18-19:19),UpperIdent(19:20-19:26),NoSpaceDotUpperIdent(19:26-19:35),NoSpaceDotUpperIdent(19:35-19:43),
 LowerIdent(22:1-22:20),OpColon(22:21-22:22),UpperIdent(22:23-22:30),NoSpaceDotUpperIdent(22:30-22:38),NoSpaceDotUpperIdent(22:38-22:44),
 LowerIdent(23:1-23:20),OpAssign(23:21-23:22),UpperIdent(23:23-23:28),NoSpaceDotLowerIdent(23:28-23:32),
-LowerIdent(26:1-26:11),OpColon(26:12-26:13),UpperIdent(26:14-26:20),NoSpaceDotUpperIdent(26:20-26:27),UpperIdent(26:28-26:31),UpperIdent(26:32-26:35),
-LowerIdent(27:1-27:11),OpAssign(27:12-27:13),UpperIdent(27:14-27:20),NoSpaceDotUpperIdent(27:20-27:23),Int(27:24-27:26),
+LowerIdent(26:1-26:11),OpColon(26:12-26:13),UpperIdent(26:14-26:20),NoSpaceDotUpperIdent(26:20-26:27),NoSpaceOpenRound(26:27-26:28),UpperIdent(26:28-26:31),Comma(26:31-26:32),UpperIdent(26:33-26:36),CloseRound(26:36-26:37),
+LowerIdent(27:1-27:11),OpAssign(27:12-27:13),UpperIdent(27:14-27:20),NoSpaceDotUpperIdent(27:20-27:23),NoSpaceOpenRound(27:23-27:24),Int(27:24-27:26),CloseRound(27:26-27:27),
 LowerIdent(30:1-30:9),OpColon(30:10-30:11),OpenCurly(30:12-30:13),CloseCurly(30:13-30:14),OpArrow(30:15-30:17),UpperIdent(30:18-30:23),NoSpaceDotUpperIdent(30:23-30:27),
-LowerIdent(31:1-31:9),OpAssign(31:10-31:11),OpBackslash(31:12-31:13),OpenCurly(31:13-31:14),CloseCurly(31:14-31:15),OpArrow(31:16-31:18),UpperIdent(31:19-31:24),NoSpaceDotUpperIdent(31:24-31:28),OpenCurly(31:29-31:30),LowerIdent(31:31-31:32),OpColon(31:32-31:33),Int(31:34-31:35),Comma(31:35-31:36),LowerIdent(31:37-31:38),OpColon(31:38-31:39),Int(31:40-31:43),Comma(31:43-31:44),LowerIdent(31:45-31:46),OpColon(31:46-31:47),Int(31:48-31:49),CloseCurly(31:50-31:51),
+LowerIdent(31:1-31:9),OpAssign(31:10-31:11),OpBar(31:12-31:13),Underscore(31:13-31:14),OpBar(31:14-31:15),UpperIdent(31:16-31:21),NoSpaceDotUpperIdent(31:21-31:25),NoSpaceOpenRound(31:25-31:26),OpenCurly(31:26-31:27),LowerIdent(31:28-31:29),OpColon(31:29-31:30),Int(31:31-31:32),Comma(31:32-31:33),LowerIdent(31:34-31:35),OpColon(31:35-31:36),Int(31:37-31:40),Comma(31:40-31:41),LowerIdent(31:42-31:43),OpColon(31:43-31:44),Int(31:45-31:46),CloseCurly(31:47-31:48),CloseRound(31:48-31:49),
 LowerIdent(34:1-34:13),OpColon(34:14-34:15),UpperIdent(34:16-34:21),NoSpaceDotUpperIdent(34:21-34:25),OpArrow(34:26-34:28),UpperIdent(34:29-34:32),
-LowerIdent(35:1-35:13),OpAssign(35:14-35:15),OpBackslash(35:16-35:17),LowerIdent(35:17-35:22),OpArrow(35:23-35:25),
+LowerIdent(35:1-35:13),OpAssign(35:14-35:15),OpBar(35:16-35:17),LowerIdent(35:17-35:22),OpBar(35:22-35:23),
 StringStart(36:5-36:6),StringPart(36:6-36:21),StringEnd(36:21-36:22),
-LowerIdent(39:1-39:10),OpColon(39:11-39:12),UpperIdent(39:13-39:19),NoSpaceDotUpperIdent(39:19-39:26),UpperIdent(39:27-39:32),NoSpaceDotUpperIdent(39:32-39:36),UpperIdent(39:37-39:43),NoSpaceDotUpperIdent(39:43-39:49),OpArrow(39:50-39:52),UpperIdent(39:53-39:60),NoSpaceDotUpperIdent(39:60-39:68),NoSpaceDotUpperIdent(39:68-39:74),
-LowerIdent(40:1-40:10),OpAssign(40:11-40:12),OpBackslash(40:13-40:14),LowerIdent(40:14-40:20),OpArrow(40:21-40:23),
-LowerIdent(41:5-41:9),LowerIdent(41:10-41:16),LowerIdent(41:17-41:19),
-UpperIdent(42:9-42:15),NoSpaceDotUpperIdent(42:15-42:18),LowerIdent(42:19-42:22),OpArrow(42:23-42:25),UpperIdent(42:26-42:31),NoSpaceDotLowerIdent(42:31-42:41),LowerIdent(42:42-42:45),
-UpperIdent(43:9-43:15),NoSpaceDotUpperIdent(43:15-43:19),LowerIdent(43:20-43:23),OpArrow(43:24-43:26),UpperIdent(43:27-43:32),NoSpaceDotLowerIdent(43:32-43:40),EndOfFile(43:40-43:40),
+LowerIdent(39:1-39:10),OpColon(39:11-39:12),UpperIdent(39:13-39:19),NoSpaceDotUpperIdent(39:19-39:26),NoSpaceOpenRound(39:26-39:27),UpperIdent(39:27-39:32),NoSpaceDotUpperIdent(39:32-39:36),Comma(39:36-39:37),UpperIdent(39:38-39:44),NoSpaceDotUpperIdent(39:44-39:50),CloseRound(39:50-39:51),OpArrow(39:52-39:54),UpperIdent(39:55-39:62),NoSpaceDotUpperIdent(39:62-39:70),NoSpaceDotUpperIdent(39:70-39:76),
+LowerIdent(40:1-40:10),OpAssign(40:11-40:12),OpBar(40:13-40:14),LowerIdent(40:14-40:20),OpBar(40:20-40:21),
+KwMatch(41:5-41:10),LowerIdent(41:11-41:17),OpenCurly(41:18-41:19),
+UpperIdent(42:9-42:15),NoSpaceDotUpperIdent(42:15-42:18),NoSpaceOpenRound(42:18-42:19),LowerIdent(42:19-42:22),CloseRound(42:22-42:23),OpFatArrow(42:24-42:26),UpperIdent(42:27-42:32),NoSpaceDotLowerIdent(42:32-42:42),NoSpaceOpenRound(42:42-42:43),LowerIdent(42:43-42:46),CloseRound(42:46-42:47),
+UpperIdent(43:9-43:15),NoSpaceDotUpperIdent(43:15-43:19),NoSpaceOpenRound(43:19-43:20),LowerIdent(43:20-43:23),CloseRound(43:23-43:24),OpFatArrow(43:25-43:27),UpperIdent(43:28-43:33),NoSpaceDotLowerIdent(43:33-43:41),
+CloseCurly(44:5-44:6),EndOfFile(44:6-44:6),
 ~~~
 # PARSE
 ~~~clojure
-(file @1.1-43.40
+(file @1.1-44.6
 	(malformed-header @8.1-8.7 (tag "import_exposing_no_close"))
 	(statements
 		(s-malformed @8.8-8.21 (tag "expected_colon_after_type_annotation"))
@@ -707,16 +297,17 @@ UpperIdent(43:9-43:15),NoSpaceDotUpperIdent(43:15-43:19),LowerIdent(43:20-43:23)
 		(s-import @11.1-11.32 (raw "ExternalModule") (alias "ExtMod"))
 		(s-type-anno @14.1-14.28 (name "simpleQualified")
 			(ty @14.19-14.28 (name "Color.RGB")))
-		(s-decl @15.1-15.28
+		(s-decl @15.1-15.52
 			(p-ident @15.1-15.16 (raw "simpleQualified"))
-			(e-tag @15.19-15.28 (raw "Color.RGB")))
-		(e-record @15.29-15.51
-			(field (field "r")
-				(e-int @15.34-15.37 (raw "255")))
-			(field (field "g")
-				(e-int @15.42-15.43 (raw "0")))
-			(field (field "b")
-				(e-int @15.48-15.49 (raw "0"))))
+			(e-apply @15.19-15.52
+				(e-tag @15.19-15.28 (raw "Color.RGB"))
+				(e-record @15.29-15.51
+					(field (field "r")
+						(e-int @15.34-15.37 (raw "255")))
+					(field (field "g")
+						(e-int @15.42-15.43 (raw "0")))
+					(field (field "b")
+						(e-int @15.48-15.49 (raw "0"))))))
 		(s-type-anno @18.1-18.35 (name "aliasedQualified")
 			(ty @18.20-18.35 (name "ExtMod.DataType")))
 		(s-decl @19.1-19.43
@@ -727,69 +318,70 @@ UpperIdent(43:9-43:15),NoSpaceDotUpperIdent(43:15-43:19),LowerIdent(43:20-43:23)
 		(s-decl @23.1-23.32
 			(p-ident @23.1-23.20 (raw "multiLevelQualified"))
 			(e-ident @23.23-23.32 (raw "TypeC.new")))
-		(s-type-anno @26.1-26.27 (name "resultType")
-			(ty @26.14-26.27 (name "Result.Result")))
-		(s-malformed @26.28-26.35 (tag "expected_colon_after_type_annotation"))
-		(s-decl @27.1-27.23
+		(s-type-anno @26.1-26.37 (name "resultType")
+			(ty-apply @26.14-26.37
+				(ty @26.14-26.27 (name "Result.Result"))
+				(ty @26.28-26.31 (name "I32"))
+				(ty @26.33-26.36 (name "Str"))))
+		(s-decl @27.1-27.27
 			(p-ident @27.1-27.11 (raw "resultType"))
-			(e-tag @27.14-27.23 (raw "Result.Ok")))
-		(e-int @27.24-27.26 (raw "42"))
+			(e-apply @27.14-27.27
+				(e-tag @27.14-27.23 (raw "Result.Ok"))
+				(e-int @27.24-27.26 (raw "42"))))
 		(s-type-anno @30.1-30.27 (name "getColor")
 			(ty-fn @30.12-30.27
 				(ty-record @30.12-30.14)
 				(ty @30.18-30.27 (name "Color.RGB"))))
-		(s-decl @31.1-31.13
+		(s-decl @31.1-31.49
 			(p-ident @31.1-31.9 (raw "getColor"))
-			(e-malformed @31.12-31.13 (reason "expr_unexpected_token")))
-		(e-local-dispatch @31.13-31.24
-			(e-record @31.13-31.15)
-			(e-tag @1.1-1.1 (raw "Color")))
-		(e-malformed @31.24-31.28 (reason "expr_unexpected_token"))
-		(e-record @31.29-31.51
-			(field (field "r")
-				(e-int @31.34-31.35 (raw "0")))
-			(field (field "g")
-				(e-int @31.40-31.43 (raw "255")))
-			(field (field "b")
-				(e-int @31.48-31.49 (raw "0"))))
+			(e-lambda @31.12-31.49
+				(args
+					(p-underscore))
+				(e-apply @31.16-31.49
+					(e-tag @31.16-31.25 (raw "Color.RGB"))
+					(e-record @31.26-31.48
+						(field (field "r")
+							(e-int @31.31-31.32 (raw "0")))
+						(field (field "g")
+							(e-int @31.37-31.40 (raw "255")))
+						(field (field "b")
+							(e-int @31.45-31.46 (raw "0")))))))
 		(s-type-anno @34.1-34.32 (name "processColor")
 			(ty-fn @34.16-34.32
 				(ty @34.16-34.25 (name "Color.RGB"))
 				(ty @34.29-34.32 (name "Str"))))
-		(s-decl @35.1-35.17
+		(s-decl @35.1-36.22
 			(p-ident @35.1-35.13 (raw "processColor"))
-			(e-malformed @35.16-35.17 (reason "expr_unexpected_token")))
-		(e-malformed @36.5-36.6 (reason "expr_arrow_expects_ident"))
-		(e-malformed @36.6-36.21 (reason "expr_unexpected_token"))
-		(e-malformed @36.21-36.22 (reason "expr_unexpected_token"))
-		(s-type-anno @39.1-39.26 (name "transform")
-			(ty @39.13-39.26 (name "Result.Result")))
-		(s-malformed @39.27-39.36 (tag "expected_colon_after_type_annotation"))
-		(s-malformed @39.37-39.49 (tag "expected_colon_after_type_annotation"))
-		(e-malformed @39.50-39.52 (reason "expr_unexpected_token"))
-		(s-malformed @39.53-39.68 (tag "expected_colon_after_type_annotation"))
-		(e-malformed @39.68-39.74 (reason "expr_unexpected_token"))
-		(s-decl @40.1-40.14
+			(e-lambda @35.16-36.22
+				(args
+					(p-ident @35.17-35.22 (raw "color")))
+				(e-string @36.5-36.22
+					(e-string-part @36.6-36.21 (raw "Color processed")))))
+		(s-type-anno @39.1-39.76 (name "transform")
+			(ty-fn @39.13-39.76
+				(ty-apply @39.13-39.51
+					(ty @39.13-39.26 (name "Result.Result"))
+					(ty @39.27-39.36 (name "Color.RGB"))
+					(ty @39.38-39.50 (name "ExtMod.Error")))
+				(ty @39.55-39.76 (name "ModuleA.ModuleB.TypeC"))))
+		(s-decl @40.1-44.6
 			(p-ident @40.1-40.10 (raw "transform"))
-			(e-malformed @40.13-40.14 (reason "expr_unexpected_token")))
-		(e-local-dispatch @40.14-41.9
-			(e-ident @40.14-40.20 (raw "result"))
-			(e-ident @1.1-1.1 (raw "when")))
-		(e-ident @41.10-41.16 (raw "result"))
-		(e-ident @41.17-41.19 (raw "is"))
-		(s-malformed @42.9-42.18 (tag "expected_colon_after_type_annotation"))
-		(e-field-access @42.19-42.41
-			(e-local-dispatch @42.19-42.31
-				(e-ident @42.19-42.22 (raw "rgb"))
-				(e-tag @1.1-1.1 (raw "TypeC")))
-			(e-ident @42.31-42.41 (raw "fromColor")))
-		(e-ident @42.42-42.45 (raw "rgb"))
-		(s-malformed @43.9-43.19 (tag "expected_colon_after_type_annotation"))
-		(e-field-access @43.20-43.40
-			(e-local-dispatch @43.20-43.32
-				(e-ident @43.20-43.23 (raw "err"))
-				(e-tag @1.1-1.1 (raw "TypeC")))
-			(e-ident @43.32-43.40 (raw "default")))))
+			(e-lambda @40.13-44.6
+				(args
+					(p-ident @40.14-40.20 (raw "result")))
+				(e-match
+					(e-ident @41.11-41.17 (raw "result"))
+					(branches
+						(branch @42.9-42.47
+							(p-tag @42.9-42.23 (raw ".Ok")
+								(p-ident @42.19-42.22 (raw "rgb")))
+							(e-apply @42.27-42.47
+								(e-ident @42.27-42.42 (raw "TypeC.fromColor"))
+								(e-ident @42.43-42.46 (raw "rgb"))))
+						(branch @43.9-43.41
+							(p-tag @43.9-43.24 (raw ".Err")
+								(p-ident @43.20-43.23 (raw "err")))
+							(e-ident @43.28-43.41 (raw "TypeC.default")))))))))
 ~~~
 # FORMATTED
 ~~~roc
@@ -803,8 +395,7 @@ import ExternalModule as ExtMod
 
 # Simple qualified type
 simpleQualified : Color.RGB
-simpleQualified = Color.RGB
-{r: 255, g: 0, b: 0}
+simpleQualified = Color.RGB({r: 255, g: 0, b: 0})
 
 # Aliased qualified type
 aliasedQualified : ExtMod.DataType
@@ -815,33 +406,25 @@ multiLevelQualified : ModuleA.ModuleB.TypeC
 multiLevelQualified = TypeC.new
 
 # Using qualified type with generics
-resultType : Result.Result
-
-resultType = Result.Ok
-42
+resultType : Result.Result(I32, Str)
+resultType = Result.Ok(42)
 
 # Function returning qualified type
 getColor : {} -> Color.RGB
-getColor = 
-{}->Color
-{r: 0, g: 255, b: 0}
+getColor = |_| Color.RGB({r: 0, g: 255, b: 0})
 
 # Function accepting qualified type
 processColor : Color.RGB -> Str
-processColor = 
-
+processColor = |color|
+	"Color processed"
 
 # Multiple qualified types in a function signature
-transform : Result.Result
-
-transform = 
-result->
-when
-result
-is
-rgb->TypeC.fromColor
-rgb
-err->TypeC.default
+transform : Result.Result(Color.RGB, ExtMod.Error) -> ModuleA.ModuleB.TypeC
+transform = |result|
+	match result {
+		Ok(rgb) => TypeC.fromColor(rgb)
+		Err(err) => TypeC.default
+	}
 ~~~
 # CANONICALIZE
 ~~~clojure
@@ -870,10 +453,20 @@ err->TypeC.default
 	(d-let
 		(p-assign @27.1-27.11 (ident "resultType"))
 		(e-nominal @27.14-27.20 (nominal "<malformed>")
-			(e-tag @27.14-27.23 (name "Ok"))))
+			(e-tag @27.14-27.23 (name "Ok")
+				(args
+					(e-int @27.24-27.26 (value "42")))))
+		(annotation @27.1-27.11
+			(declared-type
+				(ty-apply @26.14-26.37 (symbol "Result.Result")
+					(ty @26.28-26.31 (name "I32"))
+					(ty @26.33-26.36 (name "Str"))))))
 	(d-let
 		(p-assign @31.1-31.9 (ident "getColor"))
-		(e-runtime-error (tag "expr_not_canonicalized"))
+		(e-lambda @31.12-31.49
+			(args
+				(p-underscore @31.13-31.14))
+			(e-runtime-error (tag "ident_not_in_scope")))
 		(annotation @31.1-31.9
 			(declared-type
 				(ty-fn @30.12-30.27 (effectful false)
@@ -882,7 +475,11 @@ err->TypeC.default
 						(ext-decl @30.18-30.27 (ident "Color.RGB") (kind "type")))))))
 	(d-let
 		(p-assign @35.1-35.13 (ident "processColor"))
-		(e-runtime-error (tag "expr_not_canonicalized"))
+		(e-lambda @35.16-36.22
+			(args
+				(p-assign @35.17-35.22 (ident "color")))
+			(e-string @36.5-36.22
+				(e-literal @36.6-36.21 (string "Color processed"))))
 		(annotation @35.1-35.13
 			(declared-type
 				(ty-fn @34.16-34.32 (effectful false)
@@ -891,7 +488,40 @@ err->TypeC.default
 					(ty @34.29-34.32 (name "Str"))))))
 	(d-let
 		(p-assign @40.1-40.10 (ident "transform"))
-		(e-runtime-error (tag "expr_not_canonicalized")))
+		(e-lambda @40.13-44.6
+			(args
+				(p-assign @40.14-40.20 (ident "result")))
+			(e-match @41.5-44.6
+				(match @41.5-44.6
+					(cond
+						(e-lookup-local @41.11-41.17
+							(p-assign @40.14-40.20 (ident "result"))))
+					(branches
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-applied-tag @42.9-42.23)))
+							(value
+								(e-call @42.27-42.47
+									(e-runtime-error (tag "ident_not_in_scope"))
+									(e-lookup-local @42.43-42.46
+										(p-assign @42.19-42.22 (ident "rgb"))))))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-applied-tag @43.9-43.24)))
+							(value
+								(e-runtime-error (tag "ident_not_in_scope"))))))))
+		(annotation @40.1-40.10
+			(declared-type
+				(ty-fn @39.13-39.76 (effectful false)
+					(ty-apply @39.13-39.51 (symbol "Result.Result")
+						(ty-lookup-external @39.27-39.36
+							(ext-decl @39.27-39.36 (ident "Color.RGB") (kind "type")))
+						(ty-lookup-external @39.38-39.50
+							(ext-decl @39.38-39.50 (ident "ExtMod.Error") (kind "type"))))
+					(ty-lookup-external @39.55-39.76
+						(ext-decl @39.55-39.76 (ident "ModuleA.ModuleB.TypeC") (kind "type")))))))
 	(s-import @9.1-9.13 (module "Color")
 		(exposes))
 	(s-import @10.1-10.15 (module "ModuleA")
@@ -904,7 +534,10 @@ err->TypeC.default
 	(ext-decl @26.14-26.27 (ident "Result.Result") (kind "type"))
 	(ext-decl @30.18-30.27 (ident "Color.RGB") (kind "type"))
 	(ext-decl @34.16-34.25 (ident "Color.RGB") (kind "type"))
-	(ext-decl @39.13-39.26 (ident "Result.Result") (kind "type")))
+	(ext-decl @39.13-39.26 (ident "Result.Result") (kind "type"))
+	(ext-decl @39.27-39.36 (ident "Color.RGB") (kind "type"))
+	(ext-decl @39.38-39.50 (ident "ExtMod.Error") (kind "type"))
+	(ext-decl @39.55-39.76 (ident "ModuleA.ModuleB.TypeC") (kind "type")))
 ~~~
 # TYPES
 ~~~clojure
@@ -914,15 +547,15 @@ err->TypeC.default
 		(patt @19.1-19.17 (type "Error"))
 		(patt @23.1-23.20 (type "Error"))
 		(patt @27.1-27.11 (type "Error"))
-		(patt @31.1-31.9 (type "Error"))
-		(patt @35.1-35.13 (type "Error"))
-		(patt @40.1-40.10 (type "Error")))
+		(patt @31.1-31.9 (type "{  } -> Error"))
+		(patt @35.1-35.13 (type "Color.RGB -> Str"))
+		(patt @40.1-40.10 (type "Error -> Error")))
 	(expressions
 		(expr @15.19-15.24 (type "Error"))
 		(expr @19.26-19.35 (type "Error"))
 		(expr @23.23-23.32 (type "Error"))
 		(expr @27.14-27.20 (type "Error"))
-		(expr @31.12-31.13 (type "Error"))
-		(expr @35.16-35.17 (type "Error"))
-		(expr @40.13-40.14 (type "Error"))))
+		(expr @31.12-31.49 (type "{  } -> Error"))
+		(expr @35.16-36.22 (type "Color.RGB -> Str"))
+		(expr @40.13-44.6 (type "Error -> Error"))))
 ~~~


### PR DESCRIPTION
```
zig build repro-parse -- -b bW9kdWxlW117Q30= -v
```