### PR TITLE
Parse qualified identifiers started by lowercase in type annotations

### DIFF
--- a/src/snapshots/expr/tag_vs_function_calls.md
+++ b/src/snapshots/expr/tag_vs_function_calls.md
@@ -10,38 +10,24 @@ type=expr
     noneTag: None,
     okTag: Ok("hello"),
     errTag: Err("oops"),
-    addOne: \x -> x + 1,
+    addOne: |x| x + 1,
     result: addOne(5),
     nested: Some(Ok(Just(42))),
     tagList: [Some(1), Some(2), None, Some(3)],
 }
 ~~~
 # EXPECTED
-UNEXPECTED TOKEN IN EXPRESSION - tag_vs_function_calls.md:6:13:6:14
-PARSE ERROR - tag_vs_function_calls.md:6:14:6:15
+UNDEFINED VARIABLE - tag_vs_function_calls.md:7:13:7:19
 # PROBLEMS
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **\** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
+**UNDEFINED VARIABLE**
+Nothing is named `addOne` in this scope.
+Is there an `import` or `exposing` missing up-top?
 
-Here is the problematic code:
-**tag_vs_function_calls.md:6:13:6:14:**
+**tag_vs_function_calls.md:7:13:7:19:**
 ```roc
-    addOne: \x -> x + 1,
+    result: addOne(5),
 ```
-            ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expected_expr_close_curly_or_comma`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**tag_vs_function_calls.md:6:14:6:15:**
-```roc
-    addOne: \x -> x + 1,
-```
-             ^
+            ^^^^^^
 
 
 # TOKENS
@@ -51,7 +37,7 @@ LowerIdent(2:5-2:12),OpColon(2:12-2:13),UpperIdent(2:14-2:18),NoSpaceOpenRound(2
 LowerIdent(3:5-3:12),OpColon(3:12-3:13),UpperIdent(3:14-3:18),Comma(3:18-3:19),
 LowerIdent(4:5-4:10),OpColon(4:10-4:11),UpperIdent(4:12-4:14),NoSpaceOpenRound(4:14-4:15),StringStart(4:15-4:16),StringPart(4:16-4:21),StringEnd(4:21-4:22),CloseRound(4:22-4:23),Comma(4:23-4:24),
 LowerIdent(5:5-5:11),OpColon(5:11-5:12),UpperIdent(5:13-5:16),NoSpaceOpenRound(5:16-5:17),StringStart(5:17-5:18),StringPart(5:18-5:22),StringEnd(5:22-5:23),CloseRound(5:23-5:24),Comma(5:24-5:25),
-LowerIdent(6:5-6:11),OpColon(6:11-6:12),OpBackslash(6:13-6:14),LowerIdent(6:14-6:15),OpArrow(6:16-6:18),LowerIdent(6:19-6:20),OpPlus(6:21-6:22),Int(6:23-6:24),Comma(6:24-6:25),
+LowerIdent(6:5-6:11),OpColon(6:11-6:12),OpBar(6:13-6:14),LowerIdent(6:14-6:15),OpBar(6:15-6:16),LowerIdent(6:17-6:18),OpPlus(6:19-6:20),Int(6:21-6:22),Comma(6:22-6:23),
 LowerIdent(7:5-7:11),OpColon(7:11-7:12),LowerIdent(7:13-7:19),NoSpaceOpenRound(7:19-7:20),Int(7:20-7:21),CloseRound(7:21-7:22),Comma(7:22-7:23),
 LowerIdent(8:5-8:11),OpColon(8:11-8:12),UpperIdent(8:13-8:17),NoSpaceOpenRound(8:17-8:18),UpperIdent(8:18-8:20),NoSpaceOpenRound(8:20-8:21),UpperIdent(8:21-8:25),NoSpaceOpenRound(8:25-8:26),Int(8:26-8:28),CloseRound(8:28-8:29),CloseRound(8:29-8:30),CloseRound(8:30-8:31),Comma(8:31-8:32),
 LowerIdent(9:5-9:12),OpColon(9:12-9:13),OpenSquare(9:14-9:15),UpperIdent(9:15-9:19),NoSpaceOpenRound(9:19-9:20),Int(9:20-9:21),CloseRound(9:21-9:22),Comma(9:22-9:23),UpperIdent(9:24-9:28),NoSpaceOpenRound(9:28-9:29),Int(9:29-9:30),CloseRound(9:30-9:31),Comma(9:31-9:32),UpperIdent(9:33-9:37),Comma(9:37-9:38),UpperIdent(9:39-9:43),NoSpaceOpenRound(9:43-9:44),Int(9:44-9:45),CloseRound(9:45-9:46),CloseSquare(9:46-9:47),Comma(9:47-9:48),
@@ -59,19 +45,123 @@ CloseCurly(10:1-10:2),EndOfFile(10:2-10:2),
 ~~~
 # PARSE
 ~~~clojure
-(e-malformed @6.14-6.15 (reason "expected_expr_close_curly_or_comma"))
+(e-record @1.1-10.2
+	(field (field "someTag")
+		(e-apply @2.14-2.22
+			(e-tag @2.14-2.18 (raw "Some"))
+			(e-int @2.19-2.21 (raw "42"))))
+	(field (field "noneTag")
+		(e-tag @3.14-3.18 (raw "None")))
+	(field (field "okTag")
+		(e-apply @4.12-4.23
+			(e-tag @4.12-4.14 (raw "Ok"))
+			(e-string @4.15-4.22
+				(e-string-part @4.16-4.21 (raw "hello")))))
+	(field (field "errTag")
+		(e-apply @5.13-5.24
+			(e-tag @5.13-5.16 (raw "Err"))
+			(e-string @5.17-5.23
+				(e-string-part @5.18-5.22 (raw "oops")))))
+	(field (field "addOne")
+		(e-lambda @6.13-6.22
+			(args
+				(p-ident @6.14-6.15 (raw "x")))
+			(e-binop @6.17-6.22 (op "+")
+				(e-ident @6.17-6.18 (raw "x"))
+				(e-int @6.21-6.22 (raw "1")))))
+	(field (field "result")
+		(e-apply @7.13-7.22
+			(e-ident @7.13-7.19 (raw "addOne"))
+			(e-int @7.20-7.21 (raw "5"))))
+	(field (field "nested")
+		(e-apply @8.13-8.31
+			(e-tag @8.13-8.17 (raw "Some"))
+			(e-apply @8.18-8.30
+				(e-tag @8.18-8.20 (raw "Ok"))
+				(e-apply @8.21-8.29
+					(e-tag @8.21-8.25 (raw "Just"))
+					(e-int @8.26-8.28 (raw "42"))))))
+	(field (field "tagList")
+		(e-list @9.14-9.47
+			(e-apply @9.15-9.22
+				(e-tag @9.15-9.19 (raw "Some"))
+				(e-int @9.20-9.21 (raw "1")))
+			(e-apply @9.24-9.31
+				(e-tag @9.24-9.28 (raw "Some"))
+				(e-int @9.29-9.30 (raw "2")))
+			(e-tag @9.33-9.37 (raw "None"))
+			(e-apply @9.39-9.46
+				(e-tag @9.39-9.43 (raw "Some"))
+				(e-int @9.44-9.45 (raw "3"))))))
 ~~~
 # FORMATTED
 ~~~roc
-
+{
+	someTag: Some(42),
+	noneTag: None,
+	okTag: Ok("hello"),
+	errTag: Err("oops"),
+	addOne: |x| x + 1,
+	result: addOne(5),
+	nested: Some(Ok(Just(42))),
+	tagList: [Some(1), Some(2), None, Some(3)]
+}
 ~~~
 # CANONICALIZE
 ~~~clojure
-(can-ir (empty true))
+(e-record @1.1-10.2
+	(fields
+		(field (name "someTag")
+			(e-tag @2.14-2.18 (name "Some")
+				(args
+					(e-int @2.19-2.21 (value "42")))))
+		(field (name "noneTag")
+			(e-tag @3.14-3.18 (name "None")))
+		(field (name "okTag")
+			(e-tag @4.12-4.14 (name "Ok")
+				(args
+					(e-string @4.15-4.22
+						(e-literal @4.16-4.21 (string "hello"))))))
+		(field (name "errTag")
+			(e-tag @5.13-5.16 (name "Err")
+				(args
+					(e-string @5.17-5.23
+						(e-literal @5.18-5.22 (string "oops"))))))
+		(field (name "addOne")
+			(e-lambda @6.13-6.22
+				(args
+					(p-assign @6.14-6.15 (ident "x")))
+				(e-binop @6.17-6.22 (op "add")
+					(e-lookup-local @6.17-6.18
+						(p-assign @6.14-6.15 (ident "x")))
+					(e-int @6.21-6.22 (value "1")))))
+		(field (name "result")
+			(e-call @7.13-7.22
+				(e-runtime-error (tag "ident_not_in_scope"))
+				(e-int @7.20-7.21 (value "5"))))
+		(field (name "nested")
+			(e-tag @8.13-8.17 (name "Some")
+				(args
+					(e-tag @8.18-8.20 (name "Ok")
+						(args
+							(e-tag @8.21-8.25 (name "Just")
+								(args
+									(e-int @8.26-8.28 (value "42")))))))))
+		(field (name "tagList")
+			(e-list @9.14-9.47
+				(elems
+					(e-tag @9.15-9.19 (name "Some")
+						(args
+							(e-int @9.20-9.21 (value "1"))))
+					(e-tag @9.24-9.28 (name "Some")
+						(args
+							(e-int @9.29-9.30 (value "2"))))
+					(e-tag @9.33-9.37 (name "None"))
+					(e-tag @9.39-9.43 (name "Some")
+						(args
+							(e-int @9.44-9.45 (value "3")))))))))
 ~~~
 # TYPES
 ~~~clojure
-(inferred-types
-	(defs)
-	(expressions))
+(expr @1.1-10.2 (type "{ someTag: [Some(Num(_size))]_others, noneTag: [None]_others2, okTag: [Ok(Str)]_others3, errTag: [Err(Str)]_others4, addOne: _arg -> _ret, result: _field, nested: [Some([Ok([Just(Num(_size2))]_others5)]_others6)]_others7, tagList: List([Some(Num(_size3))][None]_others8) }"))
 ~~~

--- a/src/snapshots/multi_qualified_import.md
+++ b/src/snapshots/multi_qualified_import.md
@@ -14,11 +14,11 @@ json_encoder = Json.Core.Utf8.defaultEncoder
 
 # Test with qualified type in annotation
 process : json.Core.Utf8.Encoder -> Str
-process = \encoder -> "processing"
+process = |encoder| "processing"
 
 # Test with multiple qualifiers
 data : json.Core.Utf8.EncodedData
-data = json.Core.Utf8.encode "hello"
+data = json.Core.Utf8.encode("hello")
 ~~~
 # EXPECTED
 UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:3:17:3:22
@@ -29,10 +29,6 @@ UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:9:25:9:33
 UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:9:34:9:36
 PARSE ERROR - multi_qualified_import.md:10:1:10:8
 UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:10:9:10:10
-UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:10:11:10:12
-PARSE ERROR - multi_qualified_import.md:10:23:10:24
-UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:10:24:10:34
-UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:10:34:10:35
 UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:13:12:13:17
 UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:13:17:13:22
 UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:13:22:13:34
@@ -49,10 +45,7 @@ INVALID STATEMENT - multi_qualified_import.md:9:20:9:25
 INVALID STATEMENT - multi_qualified_import.md:9:25:9:33
 INVALID STATEMENT - multi_qualified_import.md:9:34:9:36
 INVALID STATEMENT - multi_qualified_import.md:10:9:10:10
-INVALID STATEMENT - multi_qualified_import.md:10:11:10:12
-INVALID STATEMENT - multi_qualified_import.md:10:12:10:24
-INVALID STATEMENT - multi_qualified_import.md:10:24:10:34
-INVALID STATEMENT - multi_qualified_import.md:10:34:10:35
+INVALID STATEMENT - multi_qualified_import.md:10:11:10:33
 INVALID STATEMENT - multi_qualified_import.md:13:12:13:17
 INVALID STATEMENT - multi_qualified_import.md:13:17:13:22
 INVALID STATEMENT - multi_qualified_import.md:13:22:13:34
@@ -60,7 +53,7 @@ UNDEFINED VARIABLE - multi_qualified_import.md:14:8:14:12
 INVALID STATEMENT - multi_qualified_import.md:14:12:14:17
 INVALID STATEMENT - multi_qualified_import.md:14:17:14:22
 INVALID STATEMENT - multi_qualified_import.md:14:22:14:29
-INVALID STATEMENT - multi_qualified_import.md:14:30:14:37
+INVALID STATEMENT - multi_qualified_import.md:14:29:14:38
 # PROBLEMS
 **UNEXPECTED TOKEN IN EXPRESSION**
 The token **.Utf8** is not expected in an expression.
@@ -153,7 +146,7 @@ Other valid examples:
 Here is the problematic code:
 **multi_qualified_import.md:10:1:10:8:**
 ```roc
-process = \encoder -> "processing"
+process = |encoder| "processing"
 ```
 ^^^^^^^
 
@@ -165,57 +158,9 @@ Expressions can be identifiers, literals, function calls, or operators.
 Here is the problematic code:
 **multi_qualified_import.md:10:9:10:10:**
 ```roc
-process = \encoder -> "processing"
+process = |encoder| "processing"
 ```
         ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **\** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**multi_qualified_import.md:10:11:10:12:**
-```roc
-process = \encoder -> "processing"
-```
-          ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expr_arrow_expects_ident`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**multi_qualified_import.md:10:23:10:24:**
-```roc
-process = \encoder -> "processing"
-```
-                      ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **processing** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**multi_qualified_import.md:10:24:10:34:**
-```roc
-process = \encoder -> "processing"
-```
-                       ^^^^^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **"** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**multi_qualified_import.md:10:34:10:35:**
-```roc
-process = \encoder -> "processing"
-```
-                                 ^
 
 
 **UNEXPECTED TOKEN IN EXPRESSION**
@@ -261,7 +206,7 @@ Expressions can be identifiers, literals, function calls, or operators.
 Here is the problematic code:
 **multi_qualified_import.md:14:12:14:17:**
 ```roc
-data = json.Core.Utf8.encode "hello"
+data = json.Core.Utf8.encode("hello")
 ```
            ^^^^^
 
@@ -273,7 +218,7 @@ Expressions can be identifiers, literals, function calls, or operators.
 Here is the problematic code:
 **multi_qualified_import.md:14:17:14:22:**
 ```roc
-data = json.Core.Utf8.encode "hello"
+data = json.Core.Utf8.encode("hello")
 ```
                 ^^^^^
 
@@ -285,7 +230,7 @@ Expressions can be identifiers, literals, function calls, or operators.
 Here is the problematic code:
 **multi_qualified_import.md:14:22:14:29:**
 ```roc
-data = json.Core.Utf8.encode "hello"
+data = json.Core.Utf8.encode("hello")
 ```
                      ^^^^^^^
 
@@ -395,7 +340,7 @@ Only definitions, type annotations, and imports are allowed at the top level.
 
 **multi_qualified_import.md:10:9:10:10:**
 ```roc
-process = \encoder -> "processing"
+process = |encoder| "processing"
 ```
         ^
 
@@ -404,44 +349,11 @@ process = \encoder -> "processing"
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
 
-**multi_qualified_import.md:10:11:10:12:**
+**multi_qualified_import.md:10:11:10:33:**
 ```roc
-process = \encoder -> "processing"
+process = |encoder| "processing"
 ```
-          ^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**multi_qualified_import.md:10:12:10:24:**
-```roc
-process = \encoder -> "processing"
-```
-           ^^^^^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**multi_qualified_import.md:10:24:10:34:**
-```roc
-process = \encoder -> "processing"
-```
-                       ^^^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**multi_qualified_import.md:10:34:10:35:**
-```roc
-process = \encoder -> "processing"
-```
-                                 ^
+          ^^^^^^^^^^^^^^^^^^^^^^
 
 
 **INVALID STATEMENT**
@@ -483,7 +395,7 @@ Is there an `import` or `exposing` missing up-top?
 
 **multi_qualified_import.md:14:8:14:12:**
 ```roc
-data = json.Core.Utf8.encode "hello"
+data = json.Core.Utf8.encode("hello")
 ```
        ^^^^
 
@@ -494,7 +406,7 @@ Only definitions, type annotations, and imports are allowed at the top level.
 
 **multi_qualified_import.md:14:12:14:17:**
 ```roc
-data = json.Core.Utf8.encode "hello"
+data = json.Core.Utf8.encode("hello")
 ```
            ^^^^^
 
@@ -505,7 +417,7 @@ Only definitions, type annotations, and imports are allowed at the top level.
 
 **multi_qualified_import.md:14:17:14:22:**
 ```roc
-data = json.Core.Utf8.encode "hello"
+data = json.Core.Utf8.encode("hello")
 ```
                 ^^^^^
 
@@ -516,7 +428,7 @@ Only definitions, type annotations, and imports are allowed at the top level.
 
 **multi_qualified_import.md:14:22:14:29:**
 ```roc
-data = json.Core.Utf8.encode "hello"
+data = json.Core.Utf8.encode("hello")
 ```
                      ^^^^^^^
 
@@ -525,11 +437,11 @@ data = json.Core.Utf8.encode "hello"
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
 
-**multi_qualified_import.md:14:30:14:37:**
+**multi_qualified_import.md:14:29:14:38:**
 ```roc
-data = json.Core.Utf8.encode "hello"
+data = json.Core.Utf8.encode("hello")
 ```
-                             ^^^^^^^
+                            ^^^^^^^^^
 
 
 # TOKENS
@@ -539,13 +451,13 @@ KwImport(3:1-3:7),LowerIdent(3:8-3:12),NoSpaceDotUpperIdent(3:12-3:17),NoSpaceDo
 LowerIdent(5:1-5:13),OpColon(5:14-5:15),UpperIdent(5:16-5:23),
 LowerIdent(6:1-6:13),OpAssign(6:14-6:15),UpperIdent(6:16-6:20),NoSpaceDotUpperIdent(6:20-6:25),NoSpaceDotUpperIdent(6:25-6:30),NoSpaceDotLowerIdent(6:30-6:45),
 LowerIdent(9:1-9:8),OpColon(9:9-9:10),LowerIdent(9:11-9:15),NoSpaceDotUpperIdent(9:15-9:20),NoSpaceDotUpperIdent(9:20-9:25),NoSpaceDotUpperIdent(9:25-9:33),OpArrow(9:34-9:36),UpperIdent(9:37-9:40),
-LowerIdent(10:1-10:8),OpAssign(10:9-10:10),OpBackslash(10:11-10:12),LowerIdent(10:12-10:19),OpArrow(10:20-10:22),StringStart(10:23-10:24),StringPart(10:24-10:34),StringEnd(10:34-10:35),
+LowerIdent(10:1-10:8),OpAssign(10:9-10:10),OpBar(10:11-10:12),LowerIdent(10:12-10:19),OpBar(10:19-10:20),StringStart(10:21-10:22),StringPart(10:22-10:32),StringEnd(10:32-10:33),
 LowerIdent(13:1-13:5),OpColon(13:6-13:7),LowerIdent(13:8-13:12),NoSpaceDotUpperIdent(13:12-13:17),NoSpaceDotUpperIdent(13:17-13:22),NoSpaceDotUpperIdent(13:22-13:34),
-LowerIdent(14:1-14:5),OpAssign(14:6-14:7),LowerIdent(14:8-14:12),NoSpaceDotUpperIdent(14:12-14:17),NoSpaceDotUpperIdent(14:17-14:22),NoSpaceDotLowerIdent(14:22-14:29),StringStart(14:30-14:31),StringPart(14:31-14:36),StringEnd(14:36-14:37),EndOfFile(14:37-14:37),
+LowerIdent(14:1-14:5),OpAssign(14:6-14:7),LowerIdent(14:8-14:12),NoSpaceDotUpperIdent(14:12-14:17),NoSpaceDotUpperIdent(14:17-14:22),NoSpaceDotLowerIdent(14:22-14:29),NoSpaceOpenRound(14:29-14:30),StringStart(14:30-14:31),StringPart(14:31-14:36),StringEnd(14:36-14:37),CloseRound(14:37-14:38),EndOfFile(14:38-14:38),
 ~~~
 # PARSE
 ~~~clojure
-(file @1.1-14.37
+(file @1.1-14.38
 	(module @1.1-1.22
 		(exposes @1.8-1.22
 			(exposed-lower-ident @1.9-1.21
@@ -569,10 +481,11 @@ LowerIdent(14:1-14:5),OpAssign(14:6-14:7),LowerIdent(14:8-14:12),NoSpaceDotUpper
 		(e-malformed @9.34-9.36 (reason "expr_unexpected_token"))
 		(s-malformed @9.37-10.8 (tag "expected_colon_after_type_annotation"))
 		(e-malformed @10.9-10.10 (reason "expr_unexpected_token"))
-		(e-malformed @10.11-10.12 (reason "expr_unexpected_token"))
-		(e-malformed @10.23-10.24 (reason "expr_arrow_expects_ident"))
-		(e-malformed @10.24-10.34 (reason "expr_unexpected_token"))
-		(e-malformed @10.34-10.35 (reason "expr_unexpected_token"))
+		(e-lambda @10.11-10.33
+			(args
+				(p-ident @10.12-10.19 (raw "encoder")))
+			(e-string @10.21-10.33
+				(e-string-part @10.22-10.32 (raw "processing"))))
 		(s-type-anno @13.1-13.12 (name "data")
 			(ty-var @13.8-13.12 (raw "json")))
 		(e-malformed @13.12-13.17 (reason "expr_unexpected_token"))
@@ -584,8 +497,9 @@ LowerIdent(14:1-14:5),OpAssign(14:6-14:7),LowerIdent(14:8-14:12),NoSpaceDotUpper
 		(e-malformed @14.12-14.17 (reason "expr_unexpected_token"))
 		(e-malformed @14.17-14.22 (reason "expr_unexpected_token"))
 		(e-malformed @14.22-14.29 (reason "expr_unexpected_token"))
-		(e-string @14.30-14.37
-			(e-string-part @14.31-14.36 (raw "hello")))))
+		(e-tuple @14.29-14.38
+			(e-string @14.30-14.37
+				(e-string-part @14.31-14.36 (raw "hello"))))))
 ~~~
 # FORMATTED
 ~~~roc
@@ -599,13 +513,13 @@ json_encoder = Json.defaultEncoder
 
 # Test with qualified type in annotation
 process : json
-
+|encoder| "processing"
 
 # Test with multiple qualifiers
 data : json
 
 data = json
-"hello"
+("hello")
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/src/snapshots/multi_qualified_import.md
+++ b/src/snapshots/multi_qualified_import.md
@@ -23,15 +23,6 @@ data = json.Core.Utf8.encode("hello")
 # EXPECTED
 UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:3:17:3:22
 UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:3:23:3:31
-UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:9:15:9:20
-UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:9:20:9:25
-UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:9:25:9:33
-UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:9:34:9:36
-PARSE ERROR - multi_qualified_import.md:10:1:10:8
-UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:10:9:10:10
-UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:13:12:13:17
-UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:13:17:13:22
-UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:13:22:13:34
 UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:14:12:14:17
 UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:14:17:14:22
 UNEXPECTED TOKEN IN EXPRESSION - multi_qualified_import.md:14:22:14:29
@@ -40,15 +31,7 @@ INVALID STATEMENT - multi_qualified_import.md:3:23:3:31
 INVALID STATEMENT - multi_qualified_import.md:3:32:3:41
 UNDECLARED TYPE - multi_qualified_import.md:5:16:5:23
 UNDEFINED VARIABLE - multi_qualified_import.md:6:16:6:45
-INVALID STATEMENT - multi_qualified_import.md:9:15:9:20
-INVALID STATEMENT - multi_qualified_import.md:9:20:9:25
-INVALID STATEMENT - multi_qualified_import.md:9:25:9:33
-INVALID STATEMENT - multi_qualified_import.md:9:34:9:36
-INVALID STATEMENT - multi_qualified_import.md:10:9:10:10
-INVALID STATEMENT - multi_qualified_import.md:10:11:10:33
-INVALID STATEMENT - multi_qualified_import.md:13:12:13:17
-INVALID STATEMENT - multi_qualified_import.md:13:17:13:22
-INVALID STATEMENT - multi_qualified_import.md:13:22:13:34
+UNUSED VARIABLE - multi_qualified_import.md:10:12:10:19
 UNDEFINED VARIABLE - multi_qualified_import.md:14:8:14:12
 INVALID STATEMENT - multi_qualified_import.md:14:12:14:17
 INVALID STATEMENT - multi_qualified_import.md:14:17:14:22
@@ -77,126 +60,6 @@ Here is the problematic code:
 import json.Core.Utf8 exposing [Encoder]
 ```
                       ^^^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **.Core** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**multi_qualified_import.md:9:15:9:20:**
-```roc
-process : json.Core.Utf8.Encoder -> Str
-```
-              ^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **.Utf8** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**multi_qualified_import.md:9:20:9:25:**
-```roc
-process : json.Core.Utf8.Encoder -> Str
-```
-                   ^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **.Encoder** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**multi_qualified_import.md:9:25:9:33:**
-```roc
-process : json.Core.Utf8.Encoder -> Str
-```
-                        ^^^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **->** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**multi_qualified_import.md:9:34:9:36:**
-```roc
-process : json.Core.Utf8.Encoder -> Str
-```
-                                 ^^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**multi_qualified_import.md:10:1:10:8:**
-```roc
-process = |encoder| "processing"
-```
-^^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **=** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**multi_qualified_import.md:10:9:10:10:**
-```roc
-process = |encoder| "processing"
-```
-        ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **.Core** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**multi_qualified_import.md:13:12:13:17:**
-```roc
-data : json.Core.Utf8.EncodedData
-```
-           ^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **.Utf8** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**multi_qualified_import.md:13:17:13:22:**
-```roc
-data : json.Core.Utf8.EncodedData
-```
-                ^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **.EncodedData** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**multi_qualified_import.md:13:22:13:34:**
-```roc
-data : json.Core.Utf8.EncodedData
-```
-                     ^^^^^^^^^^^^
 
 
 **UNEXPECTED TOKEN IN EXPRESSION**
@@ -290,103 +153,16 @@ json_encoder = Json.Core.Utf8.defaultEncoder
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
+**UNUSED VARIABLE**
+Variable `encoder` is not used anywhere in your code.
 
-**multi_qualified_import.md:9:15:9:20:**
-```roc
-process : json.Core.Utf8.Encoder -> Str
-```
-              ^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**multi_qualified_import.md:9:20:9:25:**
-```roc
-process : json.Core.Utf8.Encoder -> Str
-```
-                   ^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**multi_qualified_import.md:9:25:9:33:**
-```roc
-process : json.Core.Utf8.Encoder -> Str
-```
-                        ^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**multi_qualified_import.md:9:34:9:36:**
-```roc
-process : json.Core.Utf8.Encoder -> Str
-```
-                                 ^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**multi_qualified_import.md:10:9:10:10:**
+If you don't need this variable, prefix it with an underscore like _encoder to suppress this warning.
+The unused variable is declared here:
+**multi_qualified_import.md:10:12:10:19:**
 ```roc
 process = |encoder| "processing"
 ```
-        ^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**multi_qualified_import.md:10:11:10:33:**
-```roc
-process = |encoder| "processing"
-```
-          ^^^^^^^^^^^^^^^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**multi_qualified_import.md:13:12:13:17:**
-```roc
-data : json.Core.Utf8.EncodedData
-```
-           ^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**multi_qualified_import.md:13:17:13:22:**
-```roc
-data : json.Core.Utf8.EncodedData
-```
-                ^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**multi_qualified_import.md:13:22:13:34:**
-```roc
-data : json.Core.Utf8.EncodedData
-```
-                     ^^^^^^^^^^^^
+           ^^^^^^^
 
 
 **UNDEFINED VARIABLE**
@@ -473,24 +249,19 @@ LowerIdent(14:1-14:5),OpAssign(14:6-14:7),LowerIdent(14:8-14:12),NoSpaceDotUpper
 		(s-decl @6.1-6.45
 			(p-ident @6.1-6.13 (raw "json_encoder"))
 			(e-ident @6.16-6.45 (raw "Json.Core.Utf8.defaultEncoder")))
-		(s-type-anno @9.1-9.15 (name "process")
-			(ty-var @9.11-9.15 (raw "json")))
-		(e-malformed @9.15-9.20 (reason "expr_unexpected_token"))
-		(e-malformed @9.20-9.25 (reason "expr_unexpected_token"))
-		(e-malformed @9.25-9.33 (reason "expr_unexpected_token"))
-		(e-malformed @9.34-9.36 (reason "expr_unexpected_token"))
-		(s-malformed @9.37-10.8 (tag "expected_colon_after_type_annotation"))
-		(e-malformed @10.9-10.10 (reason "expr_unexpected_token"))
-		(e-lambda @10.11-10.33
-			(args
-				(p-ident @10.12-10.19 (raw "encoder")))
-			(e-string @10.21-10.33
-				(e-string-part @10.22-10.32 (raw "processing"))))
-		(s-type-anno @13.1-13.12 (name "data")
-			(ty-var @13.8-13.12 (raw "json")))
-		(e-malformed @13.12-13.17 (reason "expr_unexpected_token"))
-		(e-malformed @13.17-13.22 (reason "expr_unexpected_token"))
-		(e-malformed @13.22-13.34 (reason "expr_unexpected_token"))
+		(s-type-anno @9.1-9.40 (name "process")
+			(ty-fn @9.11-9.40
+				(ty @9.11-9.33 (name "json.Core.Utf8.Encoder"))
+				(ty @9.37-9.40 (name "Str"))))
+		(s-decl @10.1-10.33
+			(p-ident @10.1-10.8 (raw "process"))
+			(e-lambda @10.11-10.33
+				(args
+					(p-ident @10.12-10.19 (raw "encoder")))
+				(e-string @10.21-10.33
+					(e-string-part @10.22-10.32 (raw "processing")))))
+		(s-type-anno @13.1-13.34 (name "data")
+			(ty @13.8-13.34 (name "json.Core.Utf8.EncodedData")))
 		(s-decl @14.1-14.12
 			(p-ident @14.1-14.5 (raw "data"))
 			(e-ident @14.8-14.12 (raw "json")))
@@ -512,12 +283,11 @@ json_encoder : Encoder
 json_encoder = Json.defaultEncoder
 
 # Test with qualified type in annotation
-process : json
-|encoder| "processing"
+process : json.Core.Utf8.Encoder -> Str
+process = |encoder| "processing"
 
 # Test with multiple qualifiers
-data : json
-
+data : json.Core.Utf8.EncodedData
 data = json
 ("hello")
 ~~~
@@ -531,18 +301,39 @@ data = json
 			(declared-type
 				(ty @5.16-5.23 (name "Encoder")))))
 	(d-let
+		(p-assign @10.1-10.8 (ident "process"))
+		(e-lambda @10.11-10.33
+			(args
+				(p-assign @10.12-10.19 (ident "encoder")))
+			(e-string @10.21-10.33
+				(e-literal @10.22-10.32 (string "processing"))))
+		(annotation @10.1-10.8
+			(declared-type
+				(ty-fn @9.11-9.40 (effectful false)
+					(ty-lookup-external @9.11-9.33
+						(ext-decl @9.11-9.33 (ident "json.Core.Utf8.Encoder") (kind "type")))
+					(ty @9.37-9.40 (name "Str"))))))
+	(d-let
 		(p-assign @14.1-14.5 (ident "data"))
-		(e-runtime-error (tag "ident_not_in_scope")))
+		(e-runtime-error (tag "ident_not_in_scope"))
+		(annotation @14.1-14.5
+			(declared-type
+				(ty-lookup-external @13.8-13.34
+					(ext-decl @13.8-13.34 (ident "json.Core.Utf8.EncodedData") (kind "type"))))))
 	(s-import @3.1-3.17 (module "json.Core") (qualifier "json")
-		(exposes)))
+		(exposes))
+	(ext-decl @9.11-9.33 (ident "json.Core.Utf8.Encoder") (kind "type"))
+	(ext-decl @13.8-13.34 (ident "json.Core.Utf8.EncodedData") (kind "type")))
 ~~~
 # TYPES
 ~~~clojure
 (inferred-types
 	(defs
 		(patt @6.1-6.13 (type "Error"))
+		(patt @10.1-10.8 (type "json.Core.Utf8.Encoder -> Str"))
 		(patt @14.1-14.5 (type "Error")))
 	(expressions
 		(expr @6.16-6.45 (type "Error"))
+		(expr @10.11-10.33 (type "json.Core.Utf8.Encoder -> Str"))
 		(expr @14.8-14.12 (type "Error"))))
 ~~~

--- a/src/snapshots/nominal_type_origin_mismatch.md
+++ b/src/snapshots/nominal_type_origin_mismatch.md
@@ -10,71 +10,16 @@ module []
 import Data exposing [Person]
 
 expectsPerson : Person -> Str
-expectsPerson = \p -> "Got a person"
+expectsPerson = |p| "Got a person"
 
 main =
     # This will cause a type mismatch
     expectsPerson("not a person")
 ~~~
 # EXPECTED
-UNEXPECTED TOKEN IN EXPRESSION - nominal_type_origin_mismatch.md:6:17:6:18
-PARSE ERROR - nominal_type_origin_mismatch.md:6:23:6:24
-UNEXPECTED TOKEN IN EXPRESSION - nominal_type_origin_mismatch.md:6:24:6:36
-UNEXPECTED TOKEN IN EXPRESSION - nominal_type_origin_mismatch.md:6:36:6:37
 UNDECLARED TYPE - nominal_type_origin_mismatch.md:5:17:5:23
-UNKNOWN OPERATOR - :0:0:0:0
-INVALID STATEMENT - nominal_type_origin_mismatch.md:6:18:6:24
-INVALID STATEMENT - nominal_type_origin_mismatch.md:6:24:6:36
-INVALID STATEMENT - nominal_type_origin_mismatch.md:6:36:6:37
+UNUSED VARIABLE - nominal_type_origin_mismatch.md:6:18:6:19
 # PROBLEMS
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **\** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**nominal_type_origin_mismatch.md:6:17:6:18:**
-```roc
-expectsPerson = \p -> "Got a person"
-```
-                ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expr_arrow_expects_ident`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**nominal_type_origin_mismatch.md:6:23:6:24:**
-```roc
-expectsPerson = \p -> "Got a person"
-```
-                      ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **Got a person** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**nominal_type_origin_mismatch.md:6:24:6:36:**
-```roc
-expectsPerson = \p -> "Got a person"
-```
-                       ^^^^^^^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **"** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**nominal_type_origin_mismatch.md:6:36:6:37:**
-```roc
-expectsPerson = \p -> "Got a person"
-```
-                                   ^
-
-
 **UNDECLARED TYPE**
 The type `Person` is not declared in this scope.
 
@@ -86,41 +31,16 @@ expectsPerson : Person -> Str
                 ^^^^^^
 
 
-**UNKNOWN OPERATOR**
-This looks like an operator, but it's not one I recognize!
-Check the spelling and make sure you're using a valid Roc operator.
+**UNUSED VARIABLE**
+Variable `p` is not used anywhere in your code.
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**nominal_type_origin_mismatch.md:6:18:6:24:**
+If you don't need this variable, prefix it with an underscore like _p to suppress this warning.
+The unused variable is declared here:
+**nominal_type_origin_mismatch.md:6:18:6:19:**
 ```roc
-expectsPerson = \p -> "Got a person"
+expectsPerson = |p| "Got a person"
 ```
-                 ^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**nominal_type_origin_mismatch.md:6:24:6:36:**
-```roc
-expectsPerson = \p -> "Got a person"
-```
-                       ^^^^^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**nominal_type_origin_mismatch.md:6:36:6:37:**
-```roc
-expectsPerson = \p -> "Got a person"
-```
-                                   ^
+                 ^
 
 
 # TOKENS
@@ -128,7 +48,7 @@ expectsPerson = \p -> "Got a person"
 KwModule(1:1-1:7),OpenSquare(1:8-1:9),CloseSquare(1:9-1:10),
 KwImport(3:1-3:7),UpperIdent(3:8-3:12),KwExposing(3:13-3:21),OpenSquare(3:22-3:23),UpperIdent(3:23-3:29),CloseSquare(3:29-3:30),
 LowerIdent(5:1-5:14),OpColon(5:15-5:16),UpperIdent(5:17-5:23),OpArrow(5:24-5:26),UpperIdent(5:27-5:30),
-LowerIdent(6:1-6:14),OpAssign(6:15-6:16),OpBackslash(6:17-6:18),LowerIdent(6:18-6:19),OpArrow(6:20-6:22),StringStart(6:23-6:24),StringPart(6:24-6:36),StringEnd(6:36-6:37),
+LowerIdent(6:1-6:14),OpAssign(6:15-6:16),OpBar(6:17-6:18),LowerIdent(6:18-6:19),OpBar(6:19-6:20),StringStart(6:21-6:22),StringPart(6:22-6:34),StringEnd(6:34-6:35),
 LowerIdent(8:1-8:5),OpAssign(8:6-8:7),
 LowerIdent(10:5-10:18),NoSpaceOpenRound(10:18-10:19),StringStart(10:19-10:20),StringPart(10:20-10:32),StringEnd(10:32-10:33),CloseRound(10:33-10:34),EndOfFile(10:34-10:34),
 ~~~
@@ -145,12 +65,13 @@ LowerIdent(10:5-10:18),NoSpaceOpenRound(10:18-10:19),StringStart(10:19-10:20),St
 			(ty-fn @5.17-5.30
 				(ty @5.17-5.23 (name "Person"))
 				(ty @5.27-5.30 (name "Str"))))
-		(s-decl @6.1-6.18
+		(s-decl @6.1-6.35
 			(p-ident @6.1-6.14 (raw "expectsPerson"))
-			(e-malformed @6.17-6.18 (reason "expr_unexpected_token")))
-		(e-malformed @6.23-6.24 (reason "expr_arrow_expects_ident"))
-		(e-malformed @6.24-6.36 (reason "expr_unexpected_token"))
-		(e-malformed @6.36-6.37 (reason "expr_unexpected_token"))
+			(e-lambda @6.17-6.35
+				(args
+					(p-ident @6.18-6.19 (raw "p")))
+				(e-string @6.21-6.35
+					(e-string-part @6.22-6.34 (raw "Got a person")))))
 		(s-decl @8.1-10.34
 			(p-ident @8.1-8.5 (raw "main"))
 			(e-apply @10.5-10.34
@@ -165,8 +86,7 @@ module []
 import Data exposing [Person]
 
 expectsPerson : Person -> Str
-expectsPerson = 
-
+expectsPerson = |p| "Got a person"
 
 main = 
 # This will cause a type mismatch
@@ -177,7 +97,11 @@ main =
 (can-ir
 	(d-let
 		(p-assign @6.1-6.14 (ident "expectsPerson"))
-		(e-runtime-error (tag "expr_not_canonicalized"))
+		(e-lambda @6.17-6.35
+			(args
+				(p-assign @6.18-6.19 (ident "p")))
+			(e-string @6.21-6.35
+				(e-literal @6.22-6.34 (string "Got a person"))))
 		(annotation @6.1-6.14
 			(declared-type
 				(ty-fn @5.17-5.30 (effectful false)
@@ -198,9 +122,9 @@ main =
 ~~~clojure
 (inferred-types
 	(defs
-		(patt @6.1-6.14 (type "Error"))
-		(patt @8.1-8.5 (type "_a")))
+		(patt @6.1-6.14 (type "Error -> Str"))
+		(patt @8.1-8.5 (type "Str")))
 	(expressions
-		(expr @6.17-6.18 (type "Error"))
-		(expr @10.5-10.34 (type "_a"))))
+		(expr @6.17-6.35 (type "Error -> Str"))
+		(expr @10.5-10.34 (type "Str"))))
 ~~~

--- a/src/snapshots/qualified_type_canonicalization.md
+++ b/src/snapshots/qualified_type_canonicalization.md
@@ -19,7 +19,7 @@ import ExternalModule as ExtMod
 
 # Simple qualified type
 simpleQualified : Color.RGB
-simpleQualified = Color.RGB { r: 255, g: 0, b: 0 }
+simpleQualified = Color.RGB({ r: 255, g: 0, b: 0 })
 
 # Aliased qualified type
 aliasedQualified : ExtMod.DataType
@@ -30,70 +30,42 @@ multiLevelQualified : ModuleA.ModuleB.TypeC
 multiLevelQualified = TypeC.new
 
 # Using qualified type with generics
-resultType : Result.Result I32 Str
-resultType = Result.Ok 42
+resultType : Result.Result(I32, Str)
+resultType = Result.Ok(42)
 
 # Function returning qualified type
 getColor : {} -> Color.RGB
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
+getColor = |_| Color.RGB({ r: 0, g: 255, b: 0 })
 
 # Function accepting qualified type
 processColor : Color.RGB -> Str
-processColor = \color ->
+processColor = |color|
     "Color processed"
 
 # Multiple qualified types in a function signature
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-transform = \result ->
-    when result is
-        Result.Ok rgb -> TypeC.fromColor rgb
-        Result.Err err -> TypeC.default
+transform : Result.Result(Color.RGB, ExtMod.Error) -> ModuleA.ModuleB.TypeC
+transform = |result|
+    match result {
+        Result.Ok(rgb) => TypeC.fromColor(rgb)
+        Result.Err(err) => TypeC.default
+    }
 ~~~
 # EXPECTED
 PARSE ERROR - qualified_type_canonicalization.md:8:1:8:7
 PARSE ERROR - qualified_type_canonicalization.md:8:14:8:21
 UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:10:15:10:23
 UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:10:24:10:32
-PARSE ERROR - qualified_type_canonicalization.md:26:32:26:35
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:31:12:31:13
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:31:24:31:28
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:35:16:35:17
-PARSE ERROR - qualified_type_canonicalization.md:36:5:36:6
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:36:6:36:21
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:36:21:36:22
-PARSE ERROR - qualified_type_canonicalization.md:39:32:39:36
-PARSE ERROR - qualified_type_canonicalization.md:39:43:39:49
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:39:50:39:52
-PARSE ERROR - qualified_type_canonicalization.md:39:60:39:68
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:39:68:39:74
-UNEXPECTED TOKEN IN EXPRESSION - qualified_type_canonicalization.md:40:13:40:14
-PARSE ERROR - qualified_type_canonicalization.md:42:15:42:18
-PARSE ERROR - qualified_type_canonicalization.md:43:15:43:19
 INVALID STATEMENT - qualified_type_canonicalization.md:10:15:10:23
 INVALID STATEMENT - qualified_type_canonicalization.md:10:24:10:32
 INVALID STATEMENT - qualified_type_canonicalization.md:10:33:10:40
 UNDEFINED VARIABLE - qualified_type_canonicalization.md:15:19:15:24
-INVALID STATEMENT - qualified_type_canonicalization.md:15:29:15:51
 UNDEFINED VARIABLE - qualified_type_canonicalization.md:19:26:19:35
 UNDEFINED VARIABLE - qualified_type_canonicalization.md:23:23:23:32
-INVALID STATEMENT - qualified_type_canonicalization.md:27:24:27:26
-UNKNOWN OPERATOR - :0:0:0:0
-INVALID STATEMENT - qualified_type_canonicalization.md:31:13:31:24
-INVALID STATEMENT - qualified_type_canonicalization.md:31:24:31:28
-INVALID STATEMENT - qualified_type_canonicalization.md:31:29:31:51
-UNKNOWN OPERATOR - :0:0:0:0
-INVALID STATEMENT - qualified_type_canonicalization.md:35:17:36:6
-INVALID STATEMENT - qualified_type_canonicalization.md:36:6:36:21
-INVALID STATEMENT - qualified_type_canonicalization.md:36:21:36:22
-INVALID STATEMENT - qualified_type_canonicalization.md:39:50:39:52
-INVALID STATEMENT - qualified_type_canonicalization.md:39:68:39:74
-UNKNOWN OPERATOR - :0:0:0:0
-INVALID STATEMENT - qualified_type_canonicalization.md:40:14:41:9
-INVALID STATEMENT - qualified_type_canonicalization.md:41:10:41:16
-INVALID STATEMENT - qualified_type_canonicalization.md:41:17:41:19
-INVALID STATEMENT - qualified_type_canonicalization.md:42:19:42:41
-INVALID STATEMENT - qualified_type_canonicalization.md:42:42:42:45
-INVALID STATEMENT - qualified_type_canonicalization.md:43:20:43:40
+UNDEFINED VARIABLE - qualified_type_canonicalization.md:31:16:31:21
+UNUSED VARIABLE - qualified_type_canonicalization.md:35:17:35:22
+UNDEFINED VARIABLE - qualified_type_canonicalization.md:42:27:42:42
+UNDEFINED VARIABLE - qualified_type_canonicalization.md:43:28:43:41
+UNUSED VARIABLE - qualified_type_canonicalization.md:43:20:43:23
 # PROBLEMS
 **PARSE ERROR**
 A parsing error occurred: `import_exposing_no_close`
@@ -155,258 +127,6 @@ import ModuleA.ModuleB exposing [TypeC]
                        ^^^^^^^^
 
 
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:26:32:26:35:**
-```roc
-resultType : Result.Result I32 Str
-```
-                               ^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **\** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:31:12:31:13:**
-```roc
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
-```
-           ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **.RGB** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:31:24:31:28:**
-```roc
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
-```
-                       ^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **\** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:35:16:35:17:**
-```roc
-processColor = \color ->
-```
-               ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expr_arrow_expects_ident`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:36:5:36:6:**
-```roc
-    "Color processed"
-```
-    ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **Color processed** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:36:6:36:21:**
-```roc
-    "Color processed"
-```
-     ^^^^^^^^^^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **"** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:36:21:36:22:**
-```roc
-    "Color processed"
-```
-                    ^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:39:32:39:36:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                               ^^^^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:39:43:39:49:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                          ^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **->** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:39:50:39:52:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                                 ^^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:39:60:39:68:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                                           ^^^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **.TypeC** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:39:68:39:74:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                                                   ^^^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **\** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:40:13:40:14:**
-```roc
-transform = \result ->
-```
-            ^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:42:15:42:18:**
-```roc
-        Result.Ok rgb -> TypeC.fromColor rgb
-```
-              ^^^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**qualified_type_canonicalization.md:43:15:43:19:**
-```roc
-        Result.Err err -> TypeC.default
-```
-              ^^^^
-
-
 **INVALID STATEMENT**
 The statement **expression** is not allowed at the top level.
 Only definitions, type annotations, and imports are allowed at the top level.
@@ -446,20 +166,9 @@ Is there an `import` or `exposing` missing up-top?
 
 **qualified_type_canonicalization.md:15:19:15:24:**
 ```roc
-simpleQualified = Color.RGB { r: 255, g: 0, b: 0 }
+simpleQualified = Color.RGB({ r: 255, g: 0, b: 0 })
 ```
                   ^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:15:29:15:51:**
-```roc
-simpleQualified = Color.RGB { r: 255, g: 0, b: 0 }
-```
-                            ^^^^^^^^^^^^^^^^^^^^^^
 
 
 **UNDEFINED VARIABLE**
@@ -484,181 +193,61 @@ multiLevelQualified = TypeC.new
                       ^^^^^^^^^
 
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
+**UNDEFINED VARIABLE**
+Nothing is named `Color` in this scope.
+Is there an `import` or `exposing` missing up-top?
 
-**qualified_type_canonicalization.md:27:24:27:26:**
+**qualified_type_canonicalization.md:31:16:31:21:**
 ```roc
-resultType = Result.Ok 42
+getColor = |_| Color.RGB({ r: 0, g: 255, b: 0 })
 ```
-                       ^^
+               ^^^^^
 
 
-**UNKNOWN OPERATOR**
-This looks like an operator, but it's not one I recognize!
-Check the spelling and make sure you're using a valid Roc operator.
+**UNUSED VARIABLE**
+Variable `color` is not used anywhere in your code.
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:31:13:31:24:**
+If you don't need this variable, prefix it with an underscore like _color to suppress this warning.
+The unused variable is declared here:
+**qualified_type_canonicalization.md:35:17:35:22:**
 ```roc
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
+processColor = |color|
 ```
-            ^^^^^^^^^^^
+                ^^^^^
 
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
+**UNDEFINED VARIABLE**
+Nothing is named `fromColor` in this scope.
+Is there an `import` or `exposing` missing up-top?
 
-**qualified_type_canonicalization.md:31:24:31:28:**
+**qualified_type_canonicalization.md:42:27:42:42:**
 ```roc
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
+        Result.Ok(rgb) => TypeC.fromColor(rgb)
 ```
-                       ^^^^
+                          ^^^^^^^^^^^^^^^
 
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
+**UNDEFINED VARIABLE**
+Nothing is named `default` in this scope.
+Is there an `import` or `exposing` missing up-top?
 
-**qualified_type_canonicalization.md:31:29:31:51:**
+**qualified_type_canonicalization.md:43:28:43:41:**
 ```roc
-getColor = \{} -> Color.RGB { r: 0, g: 255, b: 0 }
+        Result.Err(err) => TypeC.default
 ```
-                            ^^^^^^^^^^^^^^^^^^^^^^
+                           ^^^^^^^^^^^^^
 
 
-**UNKNOWN OPERATOR**
-This looks like an operator, but it's not one I recognize!
-Check the spelling and make sure you're using a valid Roc operator.
+**UNUSED VARIABLE**
+Variable `err` is not used anywhere in your code.
 
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:35:17:36:6:**
+If you don't need this variable, prefix it with an underscore like _err to suppress this warning.
+The unused variable is declared here:
+**qualified_type_canonicalization.md:43:20:43:23:**
 ```roc
-processColor = \color ->
-    "Color processed"
+        Result.Err(err) => TypeC.default
 ```
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:36:6:36:21:**
-```roc
-    "Color processed"
-```
-     ^^^^^^^^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:36:21:36:22:**
-```roc
-    "Color processed"
-```
-                    ^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:39:50:39:52:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                                 ^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:39:68:39:74:**
-```roc
-transform : Result.Result Color.RGB ExtMod.Error -> ModuleA.ModuleB.TypeC
-```
-                                                                   ^^^^^^
-
-
-**UNKNOWN OPERATOR**
-This looks like an operator, but it's not one I recognize!
-Check the spelling and make sure you're using a valid Roc operator.
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:40:14:41:9:**
-```roc
-transform = \result ->
-    when result is
-```
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:41:10:41:16:**
-```roc
-    when result is
-```
-         ^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:41:17:41:19:**
-```roc
-    when result is
-```
-                ^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:42:19:42:41:**
-```roc
-        Result.Ok rgb -> TypeC.fromColor rgb
-```
-                  ^^^^^^^^^^^^^^^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:42:42:42:45:**
-```roc
-        Result.Ok rgb -> TypeC.fromColor rgb
-```
-                                         ^^^
-
-
-**INVALID STATEMENT**
-The statement **expression** is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**qualified_type_canonicalization.md:43:20:43:40:**
-```roc
-        Result.Err err -> TypeC.default
-```
-                   ^^^^^^^^^^^^^^^^^^^^
+                   ^^^
 
 
 # TOKENS
@@ -674,27 +263,28 @@ KwImport(9:1-9:7),UpperIdent(9:8-9:13),
 KwImport(10:1-10:7),UpperIdent(10:8-10:15),NoSpaceDotUpperIdent(10:15-10:23),KwExposing(10:24-10:32),OpenSquare(10:33-10:34),UpperIdent(10:34-10:39),CloseSquare(10:39-10:40),
 KwImport(11:1-11:7),UpperIdent(11:8-11:22),KwAs(11:23-11:25),UpperIdent(11:26-11:32),
 LowerIdent(14:1-14:16),OpColon(14:17-14:18),UpperIdent(14:19-14:24),NoSpaceDotUpperIdent(14:24-14:28),
-LowerIdent(15:1-15:16),OpAssign(15:17-15:18),UpperIdent(15:19-15:24),NoSpaceDotUpperIdent(15:24-15:28),OpenCurly(15:29-15:30),LowerIdent(15:31-15:32),OpColon(15:32-15:33),Int(15:34-15:37),Comma(15:37-15:38),LowerIdent(15:39-15:40),OpColon(15:40-15:41),Int(15:42-15:43),Comma(15:43-15:44),LowerIdent(15:45-15:46),OpColon(15:46-15:47),Int(15:48-15:49),CloseCurly(15:50-15:51),
+LowerIdent(15:1-15:16),OpAssign(15:17-15:18),UpperIdent(15:19-15:24),NoSpaceDotUpperIdent(15:24-15:28),NoSpaceOpenRound(15:28-15:29),OpenCurly(15:29-15:30),LowerIdent(15:31-15:32),OpColon(15:32-15:33),Int(15:34-15:37),Comma(15:37-15:38),LowerIdent(15:39-15:40),OpColon(15:40-15:41),Int(15:42-15:43),Comma(15:43-15:44),LowerIdent(15:45-15:46),OpColon(15:46-15:47),Int(15:48-15:49),CloseCurly(15:50-15:51),CloseRound(15:51-15:52),
 LowerIdent(18:1-18:17),OpColon(18:18-18:19),UpperIdent(18:20-18:26),NoSpaceDotUpperIdent(18:26-18:35),
 LowerIdent(19:1-19:17),OpAssign(19:18-19:19),UpperIdent(19:20-19:26),NoSpaceDotUpperIdent(19:26-19:35),NoSpaceDotUpperIdent(19:35-19:43),
 LowerIdent(22:1-22:20),OpColon(22:21-22:22),UpperIdent(22:23-22:30),NoSpaceDotUpperIdent(22:30-22:38),NoSpaceDotUpperIdent(22:38-22:44),
 LowerIdent(23:1-23:20),OpAssign(23:21-23:22),UpperIdent(23:23-23:28),NoSpaceDotLowerIdent(23:28-23:32),
-LowerIdent(26:1-26:11),OpColon(26:12-26:13),UpperIdent(26:14-26:20),NoSpaceDotUpperIdent(26:20-26:27),UpperIdent(26:28-26:31),UpperIdent(26:32-26:35),
-LowerIdent(27:1-27:11),OpAssign(27:12-27:13),UpperIdent(27:14-27:20),NoSpaceDotUpperIdent(27:20-27:23),Int(27:24-27:26),
+LowerIdent(26:1-26:11),OpColon(26:12-26:13),UpperIdent(26:14-26:20),NoSpaceDotUpperIdent(26:20-26:27),NoSpaceOpenRound(26:27-26:28),UpperIdent(26:28-26:31),Comma(26:31-26:32),UpperIdent(26:33-26:36),CloseRound(26:36-26:37),
+LowerIdent(27:1-27:11),OpAssign(27:12-27:13),UpperIdent(27:14-27:20),NoSpaceDotUpperIdent(27:20-27:23),NoSpaceOpenRound(27:23-27:24),Int(27:24-27:26),CloseRound(27:26-27:27),
 LowerIdent(30:1-30:9),OpColon(30:10-30:11),OpenCurly(30:12-30:13),CloseCurly(30:13-30:14),OpArrow(30:15-30:17),UpperIdent(30:18-30:23),NoSpaceDotUpperIdent(30:23-30:27),
-LowerIdent(31:1-31:9),OpAssign(31:10-31:11),OpBackslash(31:12-31:13),OpenCurly(31:13-31:14),CloseCurly(31:14-31:15),OpArrow(31:16-31:18),UpperIdent(31:19-31:24),NoSpaceDotUpperIdent(31:24-31:28),OpenCurly(31:29-31:30),LowerIdent(31:31-31:32),OpColon(31:32-31:33),Int(31:34-31:35),Comma(31:35-31:36),LowerIdent(31:37-31:38),OpColon(31:38-31:39),Int(31:40-31:43),Comma(31:43-31:44),LowerIdent(31:45-31:46),OpColon(31:46-31:47),Int(31:48-31:49),CloseCurly(31:50-31:51),
+LowerIdent(31:1-31:9),OpAssign(31:10-31:11),OpBar(31:12-31:13),Underscore(31:13-31:14),OpBar(31:14-31:15),UpperIdent(31:16-31:21),NoSpaceDotUpperIdent(31:21-31:25),NoSpaceOpenRound(31:25-31:26),OpenCurly(31:26-31:27),LowerIdent(31:28-31:29),OpColon(31:29-31:30),Int(31:31-31:32),Comma(31:32-31:33),LowerIdent(31:34-31:35),OpColon(31:35-31:36),Int(31:37-31:40),Comma(31:40-31:41),LowerIdent(31:42-31:43),OpColon(31:43-31:44),Int(31:45-31:46),CloseCurly(31:47-31:48),CloseRound(31:48-31:49),
 LowerIdent(34:1-34:13),OpColon(34:14-34:15),UpperIdent(34:16-34:21),NoSpaceDotUpperIdent(34:21-34:25),OpArrow(34:26-34:28),UpperIdent(34:29-34:32),
-LowerIdent(35:1-35:13),OpAssign(35:14-35:15),OpBackslash(35:16-35:17),LowerIdent(35:17-35:22),OpArrow(35:23-35:25),
+LowerIdent(35:1-35:13),OpAssign(35:14-35:15),OpBar(35:16-35:17),LowerIdent(35:17-35:22),OpBar(35:22-35:23),
 StringStart(36:5-36:6),StringPart(36:6-36:21),StringEnd(36:21-36:22),
-LowerIdent(39:1-39:10),OpColon(39:11-39:12),UpperIdent(39:13-39:19),NoSpaceDotUpperIdent(39:19-39:26),UpperIdent(39:27-39:32),NoSpaceDotUpperIdent(39:32-39:36),UpperIdent(39:37-39:43),NoSpaceDotUpperIdent(39:43-39:49),OpArrow(39:50-39:52),UpperIdent(39:53-39:60),NoSpaceDotUpperIdent(39:60-39:68),NoSpaceDotUpperIdent(39:68-39:74),
-LowerIdent(40:1-40:10),OpAssign(40:11-40:12),OpBackslash(40:13-40:14),LowerIdent(40:14-40:20),OpArrow(40:21-40:23),
-LowerIdent(41:5-41:9),LowerIdent(41:10-41:16),LowerIdent(41:17-41:19),
-UpperIdent(42:9-42:15),NoSpaceDotUpperIdent(42:15-42:18),LowerIdent(42:19-42:22),OpArrow(42:23-42:25),UpperIdent(42:26-42:31),NoSpaceDotLowerIdent(42:31-42:41),LowerIdent(42:42-42:45),
-UpperIdent(43:9-43:15),NoSpaceDotUpperIdent(43:15-43:19),LowerIdent(43:20-43:23),OpArrow(43:24-43:26),UpperIdent(43:27-43:32),NoSpaceDotLowerIdent(43:32-43:40),EndOfFile(43:40-43:40),
+LowerIdent(39:1-39:10),OpColon(39:11-39:12),UpperIdent(39:13-39:19),NoSpaceDotUpperIdent(39:19-39:26),NoSpaceOpenRound(39:26-39:27),UpperIdent(39:27-39:32),NoSpaceDotUpperIdent(39:32-39:36),Comma(39:36-39:37),UpperIdent(39:38-39:44),NoSpaceDotUpperIdent(39:44-39:50),CloseRound(39:50-39:51),OpArrow(39:52-39:54),UpperIdent(39:55-39:62),NoSpaceDotUpperIdent(39:62-39:70),NoSpaceDotUpperIdent(39:70-39:76),
+LowerIdent(40:1-40:10),OpAssign(40:11-40:12),OpBar(40:13-40:14),LowerIdent(40:14-40:20),OpBar(40:20-40:21),
+KwMatch(41:5-41:10),LowerIdent(41:11-41:17),OpenCurly(41:18-41:19),
+UpperIdent(42:9-42:15),NoSpaceDotUpperIdent(42:15-42:18),NoSpaceOpenRound(42:18-42:19),LowerIdent(42:19-42:22),CloseRound(42:22-42:23),OpFatArrow(42:24-42:26),UpperIdent(42:27-42:32),NoSpaceDotLowerIdent(42:32-42:42),NoSpaceOpenRound(42:42-42:43),LowerIdent(42:43-42:46),CloseRound(42:46-42:47),
+UpperIdent(43:9-43:15),NoSpaceDotUpperIdent(43:15-43:19),NoSpaceOpenRound(43:19-43:20),LowerIdent(43:20-43:23),CloseRound(43:23-43:24),OpFatArrow(43:25-43:27),UpperIdent(43:28-43:33),NoSpaceDotLowerIdent(43:33-43:41),
+CloseCurly(44:5-44:6),EndOfFile(44:6-44:6),
 ~~~
 # PARSE
 ~~~clojure
-(file @1.1-43.40
+(file @1.1-44.6
 	(malformed-header @8.1-8.7 (tag "import_exposing_no_close"))
 	(statements
 		(s-malformed @8.8-8.21 (tag "expected_colon_after_type_annotation"))
@@ -707,16 +297,17 @@ UpperIdent(43:9-43:15),NoSpaceDotUpperIdent(43:15-43:19),LowerIdent(43:20-43:23)
 		(s-import @11.1-11.32 (raw "ExternalModule") (alias "ExtMod"))
 		(s-type-anno @14.1-14.28 (name "simpleQualified")
 			(ty @14.19-14.28 (name "Color.RGB")))
-		(s-decl @15.1-15.28
+		(s-decl @15.1-15.52
 			(p-ident @15.1-15.16 (raw "simpleQualified"))
-			(e-tag @15.19-15.28 (raw "Color.RGB")))
-		(e-record @15.29-15.51
-			(field (field "r")
-				(e-int @15.34-15.37 (raw "255")))
-			(field (field "g")
-				(e-int @15.42-15.43 (raw "0")))
-			(field (field "b")
-				(e-int @15.48-15.49 (raw "0"))))
+			(e-apply @15.19-15.52
+				(e-tag @15.19-15.28 (raw "Color.RGB"))
+				(e-record @15.29-15.51
+					(field (field "r")
+						(e-int @15.34-15.37 (raw "255")))
+					(field (field "g")
+						(e-int @15.42-15.43 (raw "0")))
+					(field (field "b")
+						(e-int @15.48-15.49 (raw "0"))))))
 		(s-type-anno @18.1-18.35 (name "aliasedQualified")
 			(ty @18.20-18.35 (name "ExtMod.DataType")))
 		(s-decl @19.1-19.43
@@ -727,69 +318,70 @@ UpperIdent(43:9-43:15),NoSpaceDotUpperIdent(43:15-43:19),LowerIdent(43:20-43:23)
 		(s-decl @23.1-23.32
 			(p-ident @23.1-23.20 (raw "multiLevelQualified"))
 			(e-ident @23.23-23.32 (raw "TypeC.new")))
-		(s-type-anno @26.1-26.27 (name "resultType")
-			(ty @26.14-26.27 (name "Result.Result")))
-		(s-malformed @26.28-26.35 (tag "expected_colon_after_type_annotation"))
-		(s-decl @27.1-27.23
+		(s-type-anno @26.1-26.37 (name "resultType")
+			(ty-apply @26.14-26.37
+				(ty @26.14-26.27 (name "Result.Result"))
+				(ty @26.28-26.31 (name "I32"))
+				(ty @26.33-26.36 (name "Str"))))
+		(s-decl @27.1-27.27
 			(p-ident @27.1-27.11 (raw "resultType"))
-			(e-tag @27.14-27.23 (raw "Result.Ok")))
-		(e-int @27.24-27.26 (raw "42"))
+			(e-apply @27.14-27.27
+				(e-tag @27.14-27.23 (raw "Result.Ok"))
+				(e-int @27.24-27.26 (raw "42"))))
 		(s-type-anno @30.1-30.27 (name "getColor")
 			(ty-fn @30.12-30.27
 				(ty-record @30.12-30.14)
 				(ty @30.18-30.27 (name "Color.RGB"))))
-		(s-decl @31.1-31.13
+		(s-decl @31.1-31.49
 			(p-ident @31.1-31.9 (raw "getColor"))
-			(e-malformed @31.12-31.13 (reason "expr_unexpected_token")))
-		(e-local-dispatch @31.13-31.24
-			(e-record @31.13-31.15)
-			(e-tag @1.1-1.1 (raw "Color")))
-		(e-malformed @31.24-31.28 (reason "expr_unexpected_token"))
-		(e-record @31.29-31.51
-			(field (field "r")
-				(e-int @31.34-31.35 (raw "0")))
-			(field (field "g")
-				(e-int @31.40-31.43 (raw "255")))
-			(field (field "b")
-				(e-int @31.48-31.49 (raw "0"))))
+			(e-lambda @31.12-31.49
+				(args
+					(p-underscore))
+				(e-apply @31.16-31.49
+					(e-tag @31.16-31.25 (raw "Color.RGB"))
+					(e-record @31.26-31.48
+						(field (field "r")
+							(e-int @31.31-31.32 (raw "0")))
+						(field (field "g")
+							(e-int @31.37-31.40 (raw "255")))
+						(field (field "b")
+							(e-int @31.45-31.46 (raw "0")))))))
 		(s-type-anno @34.1-34.32 (name "processColor")
 			(ty-fn @34.16-34.32
 				(ty @34.16-34.25 (name "Color.RGB"))
 				(ty @34.29-34.32 (name "Str"))))
-		(s-decl @35.1-35.17
+		(s-decl @35.1-36.22
 			(p-ident @35.1-35.13 (raw "processColor"))
-			(e-malformed @35.16-35.17 (reason "expr_unexpected_token")))
-		(e-malformed @36.5-36.6 (reason "expr_arrow_expects_ident"))
-		(e-malformed @36.6-36.21 (reason "expr_unexpected_token"))
-		(e-malformed @36.21-36.22 (reason "expr_unexpected_token"))
-		(s-type-anno @39.1-39.26 (name "transform")
-			(ty @39.13-39.26 (name "Result.Result")))
-		(s-malformed @39.27-39.36 (tag "expected_colon_after_type_annotation"))
-		(s-malformed @39.37-39.49 (tag "expected_colon_after_type_annotation"))
-		(e-malformed @39.50-39.52 (reason "expr_unexpected_token"))
-		(s-malformed @39.53-39.68 (tag "expected_colon_after_type_annotation"))
-		(e-malformed @39.68-39.74 (reason "expr_unexpected_token"))
-		(s-decl @40.1-40.14
+			(e-lambda @35.16-36.22
+				(args
+					(p-ident @35.17-35.22 (raw "color")))
+				(e-string @36.5-36.22
+					(e-string-part @36.6-36.21 (raw "Color processed")))))
+		(s-type-anno @39.1-39.76 (name "transform")
+			(ty-fn @39.13-39.76
+				(ty-apply @39.13-39.51
+					(ty @39.13-39.26 (name "Result.Result"))
+					(ty @39.27-39.36 (name "Color.RGB"))
+					(ty @39.38-39.50 (name "ExtMod.Error")))
+				(ty @39.55-39.76 (name "ModuleA.ModuleB.TypeC"))))
+		(s-decl @40.1-44.6
 			(p-ident @40.1-40.10 (raw "transform"))
-			(e-malformed @40.13-40.14 (reason "expr_unexpected_token")))
-		(e-local-dispatch @40.14-41.9
-			(e-ident @40.14-40.20 (raw "result"))
-			(e-ident @1.1-1.1 (raw "when")))
-		(e-ident @41.10-41.16 (raw "result"))
-		(e-ident @41.17-41.19 (raw "is"))
-		(s-malformed @42.9-42.18 (tag "expected_colon_after_type_annotation"))
-		(e-field-access @42.19-42.41
-			(e-local-dispatch @42.19-42.31
-				(e-ident @42.19-42.22 (raw "rgb"))
-				(e-tag @1.1-1.1 (raw "TypeC")))
-			(e-ident @42.31-42.41 (raw "fromColor")))
-		(e-ident @42.42-42.45 (raw "rgb"))
-		(s-malformed @43.9-43.19 (tag "expected_colon_after_type_annotation"))
-		(e-field-access @43.20-43.40
-			(e-local-dispatch @43.20-43.32
-				(e-ident @43.20-43.23 (raw "err"))
-				(e-tag @1.1-1.1 (raw "TypeC")))
-			(e-ident @43.32-43.40 (raw "default")))))
+			(e-lambda @40.13-44.6
+				(args
+					(p-ident @40.14-40.20 (raw "result")))
+				(e-match
+					(e-ident @41.11-41.17 (raw "result"))
+					(branches
+						(branch @42.9-42.47
+							(p-tag @42.9-42.23 (raw ".Ok")
+								(p-ident @42.19-42.22 (raw "rgb")))
+							(e-apply @42.27-42.47
+								(e-ident @42.27-42.42 (raw "TypeC.fromColor"))
+								(e-ident @42.43-42.46 (raw "rgb"))))
+						(branch @43.9-43.41
+							(p-tag @43.9-43.24 (raw ".Err")
+								(p-ident @43.20-43.23 (raw "err")))
+							(e-ident @43.28-43.41 (raw "TypeC.default")))))))))
 ~~~
 # FORMATTED
 ~~~roc
@@ -803,8 +395,7 @@ import ExternalModule as ExtMod
 
 # Simple qualified type
 simpleQualified : Color.RGB
-simpleQualified = Color.RGB
-{r: 255, g: 0, b: 0}
+simpleQualified = Color.RGB({r: 255, g: 0, b: 0})
 
 # Aliased qualified type
 aliasedQualified : ExtMod.DataType
@@ -815,33 +406,25 @@ multiLevelQualified : ModuleA.ModuleB.TypeC
 multiLevelQualified = TypeC.new
 
 # Using qualified type with generics
-resultType : Result.Result
-
-resultType = Result.Ok
-42
+resultType : Result.Result(I32, Str)
+resultType = Result.Ok(42)
 
 # Function returning qualified type
 getColor : {} -> Color.RGB
-getColor = 
-{}->Color
-{r: 0, g: 255, b: 0}
+getColor = |_| Color.RGB({r: 0, g: 255, b: 0})
 
 # Function accepting qualified type
 processColor : Color.RGB -> Str
-processColor = 
-
+processColor = |color|
+	"Color processed"
 
 # Multiple qualified types in a function signature
-transform : Result.Result
-
-transform = 
-result->
-when
-result
-is
-rgb->TypeC.fromColor
-rgb
-err->TypeC.default
+transform : Result.Result(Color.RGB, ExtMod.Error) -> ModuleA.ModuleB.TypeC
+transform = |result|
+	match result {
+		Ok(rgb) => TypeC.fromColor(rgb)
+		Err(err) => TypeC.default
+	}
 ~~~
 # CANONICALIZE
 ~~~clojure
@@ -870,10 +453,20 @@ err->TypeC.default
 	(d-let
 		(p-assign @27.1-27.11 (ident "resultType"))
 		(e-nominal @27.14-27.20 (nominal "<malformed>")
-			(e-tag @27.14-27.23 (name "Ok"))))
+			(e-tag @27.14-27.23 (name "Ok")
+				(args
+					(e-int @27.24-27.26 (value "42")))))
+		(annotation @27.1-27.11
+			(declared-type
+				(ty-apply @26.14-26.37 (symbol "Result.Result")
+					(ty @26.28-26.31 (name "I32"))
+					(ty @26.33-26.36 (name "Str"))))))
 	(d-let
 		(p-assign @31.1-31.9 (ident "getColor"))
-		(e-runtime-error (tag "expr_not_canonicalized"))
+		(e-lambda @31.12-31.49
+			(args
+				(p-underscore @31.13-31.14))
+			(e-runtime-error (tag "ident_not_in_scope")))
 		(annotation @31.1-31.9
 			(declared-type
 				(ty-fn @30.12-30.27 (effectful false)
@@ -882,7 +475,11 @@ err->TypeC.default
 						(ext-decl @30.18-30.27 (ident "Color.RGB") (kind "type")))))))
 	(d-let
 		(p-assign @35.1-35.13 (ident "processColor"))
-		(e-runtime-error (tag "expr_not_canonicalized"))
+		(e-lambda @35.16-36.22
+			(args
+				(p-assign @35.17-35.22 (ident "color")))
+			(e-string @36.5-36.22
+				(e-literal @36.6-36.21 (string "Color processed"))))
 		(annotation @35.1-35.13
 			(declared-type
 				(ty-fn @34.16-34.32 (effectful false)
@@ -891,7 +488,40 @@ err->TypeC.default
 					(ty @34.29-34.32 (name "Str"))))))
 	(d-let
 		(p-assign @40.1-40.10 (ident "transform"))
-		(e-runtime-error (tag "expr_not_canonicalized")))
+		(e-lambda @40.13-44.6
+			(args
+				(p-assign @40.14-40.20 (ident "result")))
+			(e-match @41.5-44.6
+				(match @41.5-44.6
+					(cond
+						(e-lookup-local @41.11-41.17
+							(p-assign @40.14-40.20 (ident "result"))))
+					(branches
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-applied-tag @42.9-42.23)))
+							(value
+								(e-call @42.27-42.47
+									(e-runtime-error (tag "ident_not_in_scope"))
+									(e-lookup-local @42.43-42.46
+										(p-assign @42.19-42.22 (ident "rgb"))))))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-applied-tag @43.9-43.24)))
+							(value
+								(e-runtime-error (tag "ident_not_in_scope"))))))))
+		(annotation @40.1-40.10
+			(declared-type
+				(ty-fn @39.13-39.76 (effectful false)
+					(ty-apply @39.13-39.51 (symbol "Result.Result")
+						(ty-lookup-external @39.27-39.36
+							(ext-decl @39.27-39.36 (ident "Color.RGB") (kind "type")))
+						(ty-lookup-external @39.38-39.50
+							(ext-decl @39.38-39.50 (ident "ExtMod.Error") (kind "type"))))
+					(ty-lookup-external @39.55-39.76
+						(ext-decl @39.55-39.76 (ident "ModuleA.ModuleB.TypeC") (kind "type")))))))
 	(s-import @9.1-9.13 (module "Color")
 		(exposes))
 	(s-import @10.1-10.15 (module "ModuleA")
@@ -904,7 +534,10 @@ err->TypeC.default
 	(ext-decl @26.14-26.27 (ident "Result.Result") (kind "type"))
 	(ext-decl @30.18-30.27 (ident "Color.RGB") (kind "type"))
 	(ext-decl @34.16-34.25 (ident "Color.RGB") (kind "type"))
-	(ext-decl @39.13-39.26 (ident "Result.Result") (kind "type")))
+	(ext-decl @39.13-39.26 (ident "Result.Result") (kind "type"))
+	(ext-decl @39.27-39.36 (ident "Color.RGB") (kind "type"))
+	(ext-decl @39.38-39.50 (ident "ExtMod.Error") (kind "type"))
+	(ext-decl @39.55-39.76 (ident "ModuleA.ModuleB.TypeC") (kind "type")))
 ~~~
 # TYPES
 ~~~clojure
@@ -914,15 +547,15 @@ err->TypeC.default
 		(patt @19.1-19.17 (type "Error"))
 		(patt @23.1-23.20 (type "Error"))
 		(patt @27.1-27.11 (type "Error"))
-		(patt @31.1-31.9 (type "Error"))
-		(patt @35.1-35.13 (type "Error"))
-		(patt @40.1-40.10 (type "Error")))
+		(patt @31.1-31.9 (type "{  } -> Error"))
+		(patt @35.1-35.13 (type "Color.RGB -> Str"))
+		(patt @40.1-40.10 (type "Error -> Error")))
 	(expressions
 		(expr @15.19-15.24 (type "Error"))
 		(expr @19.26-19.35 (type "Error"))
 		(expr @23.23-23.32 (type "Error"))
 		(expr @27.14-27.20 (type "Error"))
-		(expr @31.12-31.13 (type "Error"))
-		(expr @35.16-35.17 (type "Error"))
-		(expr @40.13-40.14 (type "Error"))))
+		(expr @31.12-31.49 (type "{  } -> Error"))
+		(expr @35.16-36.22 (type "Color.RGB -> Str"))
+		(expr @40.13-44.6 (type "Error -> Error"))))
 ~~~


### PR DESCRIPTION
Implement parsing for qualified identifiers started by lowercase in type annotations such as:
```
process : json.Core.Utf8.Encoder -> Str
```