### PR TITLE
Update types/snapshot store to allocate less

### DIFF
--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -1985,7 +1985,7 @@ pub fn canonicalizeExpr(
 
                 // Since expr idx map 1-to-1 to variables, we can get cast the slice
                 // of scratch expr idx and cast them to vars
-                const elems_var_range = try self.can_ir.env.types.appendTupleElems(
+                const elems_var_range = try self.can_ir.env.types.appendVars(
                     @ptrCast(@alignCast(
                         self.can_ir.store.scratch_exprs.slice(scratch_top, self.can_ir.store.scratchExprTop()),
                     )),
@@ -3105,7 +3105,7 @@ fn canonicalizePattern(
 
             // Since pattern idx map 1-to-1 to variables, we can get cast the
             // slice of and cast them to vars
-            const elems_var_range = try self.can_ir.env.types.appendTupleElems(
+            const elems_var_range = try self.can_ir.env.types.appendVars(
                 @ptrCast(@alignCast(self.can_ir.store.slicePatterns(patterns_span))),
             );
 
@@ -6102,7 +6102,7 @@ fn canonicalizeTupleType(self: *Self, tuple: CIR.TypeAnno.Tuple, parent_node_idx
         const elem_var = try self.canonicalizeTypeAnnoToTypeVar(tuple_elem_anno_idx);
         _ = try self.scratch_vars.append(self.can_ir.env.gpa, elem_var);
     }
-    const elem_vars_range = try self.can_ir.env.types.appendTupleElems(
+    const elem_vars_range = try self.can_ir.env.types.appendVars(
         self.scratch_vars.items.items[scratch_elems_start..],
     );
 
@@ -6207,7 +6207,7 @@ fn canonicalizeTagUnionType(self: *Self, tag_union: CIR.TypeAnno.TagUnion, paren
                     const args_end = self.scratch_vars.top();
 
                     // Append the tag args to the types store
-                    const args_range = try self.can_ir.env.types.appendTagArgs(
+                    const args_range = try self.can_ir.env.types.appendVars(
                         self.scratch_vars.slice(args_start, args_end),
                     );
 

--- a/src/check/check_types.zig
+++ b/src/check/check_types.zig
@@ -890,7 +890,7 @@ fn unifyCallWithFunc(
     region: Region,
 ) std.mem.Allocator.Error!void {
     // Unify instantiated argument types with actual arguments
-    const inst_args = self.types.getFuncArgsSlice(func.args);
+    const inst_args = self.types.sliceVars(func.args);
     const arg_vars: []Var = @constCast(@ptrCast(@alignCast(call_args)));
 
     // Only unify arguments if counts match - otherwise let the normal
@@ -956,7 +956,7 @@ fn checkLambdaWithExpected(
         if (instantiated_content == .structure) {
             switch (instantiated_content.structure) {
                 .fn_pure, .fn_effectful, .fn_unbound => |func| {
-                    const expected_args = self.types.getFuncArgsSlice(func.args);
+                    const expected_args = self.types.sliceVars(func.args);
                     // Unify each pattern with its expected type before checking body
                     if (expected_args.len == arg_patterns.len) {
                         for (arg_patterns, expected_args) |pattern_idx, expected_arg| {
@@ -1513,7 +1513,7 @@ test "lambda with record field access infers correct type" {
     try std.testing.expect(resolved_lambda.desc.content.structure == .fn_unbound);
 
     const func = resolved_lambda.desc.content.structure.fn_unbound;
-    const args = module_env.types.getFuncArgsSlice(func.args);
+    const args = module_env.types.sliceVars(func.args);
     try std.testing.expectEqual(@as(usize, 2), args.len);
 
     // Verify that first parameter and return type resolve to the same variable

--- a/src/check/check_types/copy_import.zig
+++ b/src/check/check_types/copy_import.zig
@@ -168,7 +168,7 @@ fn copyTuple(
     dest_idents: *base.Ident.Store,
     allocator: std.mem.Allocator,
 ) std.mem.Allocator.Error!types_mod.Tuple {
-    const elems_slice = source_store.getTupleElemsSlice(tuple.elems);
+    const elems_slice = source_store.sliceVars(tuple.elems);
 
     var dest_elems = std.ArrayList(Var).init(dest_store.gpa);
     defer dest_elems.deinit();
@@ -178,7 +178,7 @@ fn copyTuple(
         try dest_elems.append(dest_elem);
     }
 
-    const dest_range = try dest_store.appendTupleElems(dest_elems.items);
+    const dest_range = try dest_store.appendVars(dest_elems.items);
     return types_mod.Tuple{ .elems = dest_range };
 }
 
@@ -213,7 +213,7 @@ fn copyFunc(
     dest_idents: *base.Ident.Store,
     allocator: std.mem.Allocator,
 ) std.mem.Allocator.Error!Func {
-    const args_slice = source_store.getFuncArgsSlice(func.args);
+    const args_slice = source_store.sliceVars(func.args);
 
     var dest_args = std.ArrayList(Var).init(dest_store.gpa);
     defer dest_args.deinit();
@@ -225,7 +225,7 @@ fn copyFunc(
 
     const dest_ret = try copyVar(source_store, dest_store, func.ret, var_mapping, source_idents, dest_idents, allocator);
 
-    const dest_args_range = try dest_store.appendFuncArgs(dest_args.items);
+    const dest_args_range = try dest_store.appendVars(dest_args.items);
     return Func{
         .args = dest_args_range,
         .ret = dest_ret,
@@ -300,7 +300,7 @@ fn copyTagUnion(
     defer fresh_tags.deinit();
 
     for (tags_slice.items(.name), tags_slice.items(.args)) |name, args_range| {
-        const args_slice = source_store.getTagArgsSlice(args_range);
+        const args_slice = source_store.sliceVars(args_range);
 
         var dest_args = std.ArrayList(Var).init(dest_store.gpa);
         defer dest_args.deinit();
@@ -310,7 +310,7 @@ fn copyTagUnion(
             try dest_args.append(dest_arg);
         }
 
-        const dest_args_range = try dest_store.appendTagArgs(dest_args.items);
+        const dest_args_range = try dest_store.appendVars(dest_args.items);
 
         _ = try fresh_tags.append(.{
             .name = name, // Tag names are local to the union type

--- a/src/check/check_types/cross_module_test.zig
+++ b/src/check/check_types/cross_module_test.zig
@@ -87,7 +87,7 @@ test "cross-module type checking - monomorphic function" {
     try testing.expect(resolved.desc.content.structure == .fn_pure);
 
     const func = resolved.desc.content.structure.fn_pure;
-    const args = module_b_env.types.getFuncArgsSlice(func.args);
+    const args = module_b_env.types.sliceVars(func.args);
     try testing.expectEqual(@as(usize, 2), args.len);
 
     // Check that all arguments and return are I32
@@ -173,7 +173,7 @@ test "cross-module type checking - polymorphic function" {
     try testing.expect(resolved.desc.content.structure == .fn_pure);
 
     const func = resolved.desc.content.structure.fn_pure;
-    const args = module_b_env.types.getFuncArgsSlice(func.args);
+    const args = module_b_env.types.sliceVars(func.args);
     try testing.expectEqual(@as(usize, 1), args.len);
 
     // The function should still be polymorphic (flex var)
@@ -455,7 +455,7 @@ test "cross-module type checking - polymorphic instantiation" {
 
     // The function should accept any list type
     const func = resolved.desc.content.structure.fn_pure;
-    const args = module_b_env.types.getFuncArgsSlice(func.args);
+    const args = module_b_env.types.sliceVars(func.args);
     try testing.expectEqual(@as(usize, 1), args.len);
 
     // The argument should be a list with a flex var
@@ -639,7 +639,7 @@ test "cross-module type checking - three module chain monomorphic" {
     try testing.expect(c_resolved.desc.content.structure == .fn_pure);
 
     const func = c_resolved.desc.content.structure.fn_pure;
-    const args = module_c_env.types.getFuncArgsSlice(func.args);
+    const args = module_c_env.types.sliceVars(func.args);
     try testing.expectEqual(@as(usize, 2), args.len);
 
     // Check that all arguments and return are I32
@@ -743,7 +743,7 @@ test "cross-module type checking - three module chain polymorphic" {
     try testing.expect(c_resolved.desc.content.structure == .fn_pure);
 
     const func = c_resolved.desc.content.structure.fn_pure;
-    const args = module_c_env.types.getFuncArgsSlice(func.args);
+    const args = module_c_env.types.sliceVars(func.args);
     try testing.expectEqual(@as(usize, 1), args.len);
 
     // The function should still be polymorphic
@@ -888,7 +888,7 @@ test "cross-module type checking - partial polymorphic instantiation chain" {
     try testing.expect(c_resolved.desc.content.structure == .fn_pure);
 
     const func = c_resolved.desc.content.structure.fn_pure;
-    const args = module_c_env.types.getFuncArgsSlice(func.args);
+    const args = module_c_env.types.sliceVars(func.args);
     try testing.expectEqual(@as(usize, 2), args.len);
 
     // First argument should be (I32 -> b)
@@ -897,7 +897,7 @@ test "cross-module type checking - partial polymorphic instantiation chain" {
     try testing.expect(mapper_resolved.desc.content.structure == .fn_pure);
 
     const mapper_func = mapper_resolved.desc.content.structure.fn_pure;
-    const mapper_args = module_c_env.types.getFuncArgsSlice(mapper_func.args);
+    const mapper_args = module_c_env.types.sliceVars(mapper_func.args);
     try testing.expectEqual(@as(usize, 1), mapper_args.len);
 
     // The mapper input should be I32
@@ -1390,7 +1390,7 @@ test "cross-module type checking - complex polymorphic chain with unification" {
     try testing.expect(c_resolved.desc.content.structure == .fn_pure);
 
     const func = c_resolved.desc.content.structure.fn_pure;
-    const args = module_c_env.types.getFuncArgsSlice(func.args);
+    const args = module_c_env.types.sliceVars(func.args);
     try testing.expectEqual(@as(usize, 2), args.len);
 
     // First argument should be (Str -> I32)
@@ -1399,7 +1399,7 @@ test "cross-module type checking - complex polymorphic chain with unification" {
     try testing.expect(first_arg_resolved.desc.content.structure == .fn_pure);
 
     const first_func = first_arg_resolved.desc.content.structure.fn_pure;
-    const first_func_args = module_c_env.types.getFuncArgsSlice(first_func.args);
+    const first_func_args = module_c_env.types.sliceVars(first_func.args);
     try testing.expectEqual(@as(usize, 1), first_func_args.len);
 
     const first_func_arg_resolved = module_c_env.types.resolveVar(first_func_args[0]);
@@ -1418,7 +1418,7 @@ test "cross-module type checking - complex polymorphic chain with unification" {
     try testing.expect(second_arg_resolved.desc.content.structure == .fn_pure);
 
     const second_func = second_arg_resolved.desc.content.structure.fn_pure;
-    const second_func_args = module_c_env.types.getFuncArgsSlice(second_func.args);
+    const second_func_args = module_c_env.types.sliceVars(second_func.args);
     try testing.expectEqual(@as(usize, 1), second_func_args.len);
 
     const second_func_arg_resolved = module_c_env.types.resolveVar(second_func_args[0]);
@@ -1434,7 +1434,7 @@ test "cross-module type checking - complex polymorphic chain with unification" {
     try testing.expect(ret_resolved.desc.content.structure == .fn_pure);
 
     const ret_func = ret_resolved.desc.content.structure.fn_pure;
-    const ret_func_args = module_c_env.types.getFuncArgsSlice(ret_func.args);
+    const ret_func_args = module_c_env.types.sliceVars(ret_func.args);
     try testing.expectEqual(@as(usize, 1), ret_func_args.len);
 
     const ret_func_arg_resolved = module_c_env.types.resolveVar(ret_func_args[0]);

--- a/src/check/check_types/instantiate.zig
+++ b/src/check/check_types/instantiate.zig
@@ -140,7 +140,7 @@ fn instantiateTuple(
     tuple: types_mod.Tuple,
     substitution: *VarSubstitution,
 ) std.mem.Allocator.Error!types_mod.Tuple {
-    const elems_slice = store.getTupleElemsSlice(tuple.elems);
+    const elems_slice = store.sliceVars(tuple.elems);
     var fresh_elems = std.ArrayList(Var).init(store.gpa);
     defer fresh_elems.deinit();
 
@@ -149,7 +149,7 @@ fn instantiateTuple(
         try fresh_elems.append(fresh_elem);
     }
 
-    const fresh_elems_range = try store.appendTupleElems(fresh_elems.items);
+    const fresh_elems_range = try store.appendVars(fresh_elems.items);
     return types_mod.Tuple{ .elems = fresh_elems_range };
 }
 
@@ -177,7 +177,7 @@ fn instantiateFunc(
     func: Func,
     substitution: *VarSubstitution,
 ) std.mem.Allocator.Error!Func {
-    const args_slice = store.getFuncArgsSlice(func.args);
+    const args_slice = store.sliceVars(func.args);
     var fresh_args = std.ArrayList(Var).init(store.gpa);
     defer fresh_args.deinit();
 
@@ -187,7 +187,7 @@ fn instantiateFunc(
     }
 
     const fresh_ret = try instantiateVar(store, func.ret, substitution);
-    const fresh_args_range = try store.appendFuncArgs(fresh_args.items);
+    const fresh_args_range = try store.appendVars(fresh_args.items);
     return Func{
         .args = fresh_args_range,
         .ret = fresh_ret,
@@ -255,13 +255,13 @@ fn instantiateTagUnion(
         var fresh_args = std.ArrayList(Var).init(store.gpa);
         defer fresh_args.deinit();
 
-        const args_slice = store.getTagArgsSlice(tag_args);
+        const args_slice = store.sliceVars(tag_args);
         for (args_slice) |arg_var| {
             const fresh_arg = try instantiateVar(store, arg_var, substitution);
             try fresh_args.append(fresh_arg);
         }
 
-        const fresh_args_range = try store.appendTagArgs(fresh_args.items);
+        const fresh_args_range = try store.appendVars(fresh_args.items);
 
         _ = try fresh_tags.append(Tag{
             .name = tag_name,

--- a/src/check/check_types/let_polymorphism_test.zig
+++ b/src/check/check_types/let_polymorphism_test.zig
@@ -196,12 +196,12 @@ test "let-polymorphism with multiple type parameters" {
     try env.store.setVarContent(type_b, types.Content{ .flex_var = null });
 
     // Create input tuple (a, b)
-    const input_elems = try env.store.appendTupleElems(&.{ type_a, type_b });
+    const input_elems = try env.store.appendVars(&.{ type_a, type_b });
     const input_tuple_content = types.Content{ .structure = .{ .tuple = .{ .elems = input_elems } } };
     const input_tuple_var = try env.store.freshFromContent(input_tuple_content);
 
     // Create output tuple (b, a)
-    const output_elems = try env.store.appendTupleElems(&.{ type_b, type_a });
+    const output_elems = try env.store.appendVars(&.{ type_b, type_a });
     const output_tuple_content = types.Content{ .structure = .{ .tuple = .{ .elems = output_elems } } };
     const output_tuple_var = try env.store.freshFromContent(output_tuple_content);
 
@@ -264,12 +264,12 @@ test "let-polymorphism with simple tag union" {
 
     // Create the Some tag with a single argument
     const some_tag_name = try env.module_env.idents.insert(test_allocator, base.Ident.for_text("Some"), base.Region.zero());
-    const some_args = try env.store.appendTagArgs(&.{type_param});
+    const some_args = try env.store.appendVars(&.{type_param});
 
     // Create the None tag with no arguments
     const none_tag_name = try env.module_env.idents.insert(test_allocator, base.Ident.for_text("None"), base.Region.zero());
     // For a tag with no arguments, we use an empty slice
-    const none_args = try env.store.appendTagArgs(&.{});
+    const none_args = try env.store.appendVars(&.{});
 
     // Create tag union
     var tags = std.ArrayList(types.Tag).init(test_allocator);
@@ -311,7 +311,7 @@ test "let-polymorphism interaction with pattern matching" {
     var tags = std.ArrayList(types.Tag).init(test_allocator);
     defer tags.deinit();
 
-    try tags.append(.{ .name = just_tag_name, .args = try env.store.appendTagArgs(&.{type_param}) });
+    try tags.append(.{ .name = just_tag_name, .args = try env.store.appendVars(&.{type_param}) });
     try tags.append(.{ .name = nothing_tag_name, .args = types.Var.SafeList.Range.empty() });
 
     const tags_range = try env.store.appendTags(tags.items);
@@ -349,7 +349,7 @@ test "let-polymorphism preserves sharing within single instantiation" {
     try env.store.setVarContent(type_param, types.Content{ .flex_var = null });
 
     // Create tuple (a, a)
-    const pair_elems = try env.store.appendTupleElems(&.{ type_param, type_param });
+    const pair_elems = try env.store.appendVars(&.{ type_param, type_param });
     const pair_content = types.Content{ .structure = .{ .tuple = .{ .elems = pair_elems } } };
     const pair_var = try env.store.freshFromContent(pair_content);
 

--- a/src/check/check_types/test/nominal_type_origin_test.zig
+++ b/src/check/check_types/test/nominal_type_origin_test.zig
@@ -26,7 +26,7 @@ test "nominal type origin - displays origin in snapshot writer" {
     // Create a nominal type snapshot with origin from a different module
     const nominal_type_backing = snapshot.SnapshotContent{ .structure = .str };
     const nominal_type_backing_idx = try snapshots.contents.append(test_allocator, nominal_type_backing);
-    const vars_range = try snapshots.nominal_type_args.appendSlice(test_allocator, &.{nominal_type_backing_idx});
+    const vars_range = try snapshots.content_indexes.appendSlice(test_allocator, &.{nominal_type_backing_idx});
 
     const nominal_type = snapshot.SnapshotNominalType{
         .ident = types_mod.TypeIdent{ .ident_idx = type_name_ident },
@@ -89,7 +89,7 @@ test "nominal type origin - displays origin in snapshot writer" {
         // Create type arguments
         const str_content = snapshot.SnapshotContent{ .structure = .{ .str = {} } };
         const str_idx = try snapshots.contents.append(test_allocator, str_content);
-        const args_range = try snapshots.nominal_type_args.appendSlice(test_allocator, &.{ nominal_type_backing_idx, str_idx });
+        const args_range = try snapshots.content_indexes.appendSlice(test_allocator, &.{ nominal_type_backing_idx, str_idx });
 
         // Create a nominal type with args from a different module
         const generic_nominal = snapshot.SnapshotNominalType{
@@ -127,7 +127,7 @@ test "nominal type origin - works with no context" {
 
     const nominal_type_backing = snapshot.SnapshotContent{ .structure = .str };
     const nominal_type_backing_idx = try snapshots.contents.append(test_allocator, nominal_type_backing);
-    const vars_range = try snapshots.nominal_type_args.appendSlice(test_allocator, &.{nominal_type_backing_idx});
+    const vars_range = try snapshots.content_indexes.appendSlice(test_allocator, &.{nominal_type_backing_idx});
 
     const nominal_type = snapshot.SnapshotNominalType{
         .ident = types_mod.TypeIdent{ .ident_idx = type_name_ident },

--- a/src/layout/store.zig
+++ b/src/layout/store.zig
@@ -303,7 +303,7 @@ pub const Store = struct {
         self: *Self,
         tuple_type: types.Tuple,
     ) (LayoutError || std.mem.Allocator.Error)!usize {
-        const elem_slice = self.types_store.getTupleElemsSlice(tuple_type.elems);
+        const elem_slice = self.types_store.sliceVars(tuple_type.elems);
         const num_fields = elem_slice.len;
 
         for (elem_slice, 0..) |var_, index| {

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -90,11 +90,8 @@ pub const Store = struct {
     /// Storage for compound type parts
     /// TODO: Consolidate all var lists into 1
     vars: VarSafeList,
-    tuple_elems: VarSafeList,
-    func_args: VarSafeList,
     record_fields: RecordFieldSafeMultiList,
     tags: TagSafeMultiList,
-    tag_args: VarSafeList,
 
     /// Init the unification table
     pub fn init(gpa: Allocator) std.mem.Allocator.Error!Self {
@@ -113,11 +110,8 @@ pub const Store = struct {
 
             // everything else
             .vars = try VarSafeList.initCapacity(gpa, child_capacity),
-            .tuple_elems = try VarSafeList.initCapacity(gpa, child_capacity),
-            .func_args = try VarSafeList.initCapacity(gpa, child_capacity),
             .record_fields = try RecordFieldSafeMultiList.initCapacity(gpa, child_capacity),
             .tags = try TagSafeMultiList.initCapacity(gpa, child_capacity),
-            .tag_args = try VarSafeList.initCapacity(gpa, child_capacity),
         };
     }
 
@@ -135,11 +129,8 @@ pub const Store = struct {
 
         // everything else
         self.vars.deinit(self.gpa);
-        self.tuple_elems.deinit(self.gpa);
-        self.func_args.deinit(self.gpa);
         self.record_fields.deinit(self.gpa);
         self.tags.deinit(self.gpa);
-        self.tag_args.deinit(self.gpa);
     }
 
     /// Return the number of type variables in the store.
@@ -220,7 +211,7 @@ pub const Store = struct {
     /// Make a tag data type
     /// Does not insert content into the types store
     pub fn mkTag(self: *Self, name: base.Ident.Idx, args: []const Var) std.mem.Allocator.Error!Tag {
-        const args_range = try self.appendTagArgs(args);
+        const args_range = try self.appendVars(args);
         return Tag{ .name = name, .args = args_range };
     }
 
@@ -270,7 +261,7 @@ pub const Store = struct {
     // Make a function data type with unbound effectfulness
     // Does not insert content into the types store.
     pub fn mkFuncUnbound(self: *Self, args: []const Var, ret: Var) std.mem.Allocator.Error!Content {
-        const args_range = try self.appendFuncArgs(args);
+        const args_range = try self.appendVars(args);
 
         // Check if any arguments need instantiation
         var needs_inst = false;
@@ -296,7 +287,7 @@ pub const Store = struct {
     // Make a pure function data type (as opposed to an effectful or unbound function)
     // Does not insert content into the types store.
     pub fn mkFuncPure(self: *Self, args: []const Var, ret: Var) std.mem.Allocator.Error!Content {
-        const args_range = try self.appendFuncArgs(args);
+        const args_range = try self.appendVars(args);
 
         // Check if any arguments need instantiation
         var needs_inst = false;
@@ -318,7 +309,7 @@ pub const Store = struct {
     // Make an effectful function data type (as opposed to a pure or unbound function)
     // Does not insert content into the types store.
     pub fn mkFuncEffectful(self: *Self, args: []const Var, ret: Var) std.mem.Allocator.Error!Content {
-        const args_range = try self.appendFuncArgs(args);
+        const args_range = try self.appendVars(args);
 
         // Check if any arguments need instantiation
         var needs_inst = false;
@@ -360,7 +351,7 @@ pub const Store = struct {
             .list => |list_var| self.needsInstantiation(list_var),
             .list_unbound => false,
             .tuple => |tuple| blk: {
-                const elems_slice = self.getTupleElemsSlice(tuple.elems);
+                const elems_slice = self.sliceVars(tuple.elems);
                 for (elems_slice) |elem_var| {
                     if (self.needsInstantiation(elem_var)) break :blk true;
                 }
@@ -404,7 +395,7 @@ pub const Store = struct {
     pub fn needsInstantiationTagUnion(self: *const Self, tag_union: types.TagUnion) bool {
         const tags_slice = self.getTagsSlice(tag_union.tags);
         for (tags_slice.items(.args)) |tag_args| {
-            const args_slice = self.getTagArgsSlice(tag_args);
+            const args_slice = self.sliceVars(tag_args);
             for (args_slice) |arg_var| {
                 if (self.needsInstantiation(arg_var)) return true;
             }
@@ -422,21 +413,6 @@ pub const Store = struct {
     /// Append a var to the backing list, returning the idx
     pub fn appendVars(self: *Self, s: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
         return try self.vars.appendSlice(self.gpa, s);
-    }
-
-    /// Append a tuple elem to the backing list, returning the idx
-    pub fn appendTupleElem(self: *Self, v: Var) std.mem.Allocator.Error!VarSafeList.Idx {
-        return try self.tuple_elems.append(self.gpa, v);
-    }
-
-    /// Append a slice of tuple elems to the backing list, returning the range
-    pub fn appendTupleElems(self: *Self, slice: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
-        return try self.tuple_elems.appendSlice(self.gpa, slice);
-    }
-
-    /// Append a slice of func args to the backing list, returning the range
-    pub fn appendFuncArgs(self: *Self, slice: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
-        return try self.func_args.appendSlice(self.gpa, slice);
     }
 
     /// Append a record field to the backing list, returning the idx
@@ -459,21 +435,11 @@ pub const Store = struct {
         return try self.tags.appendSlice(self.gpa, slice);
     }
 
-    /// Append a slice of tag args to the backing list, returning the range
-    pub fn appendTagArgs(self: *Self, slice: []const Var) std.mem.Allocator.Error!VarSafeList.Range {
-        return try self.tag_args.appendSlice(self.gpa, slice);
-    }
-
     // sub list getters //
 
-    /// Given a range, get a slice of tuple from the backing list
-    pub fn getTupleElemsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
-        return self.tuple_elems.sliceRange(range);
-    }
-
-    /// Given a range, get a slice of func from the backing list
-    pub fn getFuncArgsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
-        return self.func_args.sliceRange(range);
+    /// Given a range, get a slice of vars from the backing array
+    pub fn sliceVars(self: *const Self, range: VarSafeList.Range) []Var {
+        return self.vars.sliceRange(range);
     }
 
     /// Given a range, get a slice of record fields from the backing array
@@ -484,11 +450,6 @@ pub const Store = struct {
     /// Given a range, get a slice of tags from the backing array
     pub fn getTagsSlice(self: *const Self, range: TagSafeMultiList.Range) TagSafeMultiList.Slice {
         return self.tags.sliceRange(range);
-    }
-
-    /// Given a range, get a slice of tag args from the backing list
-    pub fn getTagArgsSlice(self: *const Self, range: VarSafeList.Range) VarSafeList.Slice {
-        return self.tag_args.sliceRange(range);
     }
 
     // helpers - alias types //
@@ -738,15 +699,12 @@ pub const Store = struct {
     pub fn serializedSize(self: *const Self) usize {
         const slots_size = self.slots.serializedSize();
         const descs_size = self.descs.serializedSize();
-        const tuple_elems_size = self.tuple_elems.serializedSize();
-        const func_args_size = self.func_args.serializedSize();
         const record_fields_size = self.record_fields.serializedSize();
         const tags_size = self.tags.serializedSize();
-        const tag_args_size = self.tag_args.serializedSize();
         const vars_size = self.vars.serializedSize();
 
         // Add alignment padding for each component
-        var total_size: usize = @sizeOf(u32) * 8; // size headers
+        var total_size: usize = @sizeOf(u32) * 5; // size headers
         total_size = std.mem.alignForward(usize, total_size, SERIALIZATION_ALIGNMENT);
 
         total_size += slots_size;
@@ -755,19 +713,10 @@ pub const Store = struct {
         total_size += descs_size;
         total_size = std.mem.alignForward(usize, total_size, SERIALIZATION_ALIGNMENT);
 
-        total_size += tuple_elems_size;
-        total_size = std.mem.alignForward(usize, total_size, SERIALIZATION_ALIGNMENT);
-
-        total_size += func_args_size;
-        total_size = std.mem.alignForward(usize, total_size, SERIALIZATION_ALIGNMENT);
-
         total_size += record_fields_size;
         total_size = std.mem.alignForward(usize, total_size, SERIALIZATION_ALIGNMENT);
 
         total_size += tags_size;
-        total_size = std.mem.alignForward(usize, total_size, SERIALIZATION_ALIGNMENT);
-
-        total_size += tag_args_size;
         total_size = std.mem.alignForward(usize, total_size, SERIALIZATION_ALIGNMENT);
 
         total_size += vars_size;
@@ -794,24 +743,12 @@ pub const Store = struct {
         @as(*u32, @ptrCast(@alignCast(buffer.ptr + offset))).* = @intCast(descs_size);
         offset += @sizeOf(u32);
 
-        const tuple_elems_size = self.tuple_elems.serializedSize();
-        @as(*u32, @ptrCast(@alignCast(buffer.ptr + offset))).* = @intCast(tuple_elems_size);
-        offset += @sizeOf(u32);
-
-        const func_args_size = self.func_args.serializedSize();
-        @as(*u32, @ptrCast(@alignCast(buffer.ptr + offset))).* = @intCast(func_args_size);
-        offset += @sizeOf(u32);
-
         const record_fields_size = self.record_fields.serializedSize();
         @as(*u32, @ptrCast(@alignCast(buffer.ptr + offset))).* = @intCast(record_fields_size);
         offset += @sizeOf(u32);
 
         const tags_size = self.tags.serializedSize();
         @as(*u32, @ptrCast(@alignCast(buffer.ptr + offset))).* = @intCast(tags_size);
-        offset += @sizeOf(u32);
-
-        const tag_args_size = self.tag_args.serializedSize();
-        @as(*u32, @ptrCast(@alignCast(buffer.ptr + offset))).* = @intCast(tag_args_size);
         offset += @sizeOf(u32);
 
         const vars_size = self.vars.serializedSize();
@@ -828,16 +765,6 @@ pub const Store = struct {
         offset += descs_slice.len;
 
         offset = std.mem.alignForward(usize, offset, SERIALIZATION_ALIGNMENT);
-        const tuple_elems_buffer = @as([]align(SERIALIZATION_ALIGNMENT) u8, @alignCast(buffer[offset .. offset + tuple_elems_size]));
-        const tuple_elems_slice = try self.tuple_elems.serializeInto(tuple_elems_buffer);
-        offset += tuple_elems_slice.len;
-
-        offset = std.mem.alignForward(usize, offset, SERIALIZATION_ALIGNMENT);
-        const func_args_buffer = @as([]align(SERIALIZATION_ALIGNMENT) u8, @alignCast(buffer[offset .. offset + func_args_size]));
-        const func_args_slice = try self.func_args.serializeInto(func_args_buffer);
-        offset += func_args_slice.len;
-
-        offset = std.mem.alignForward(usize, offset, SERIALIZATION_ALIGNMENT);
         const record_fields_buffer = @as([]align(SERIALIZATION_ALIGNMENT) u8, @alignCast(buffer[offset .. offset + record_fields_size]));
         const record_fields_slice = try self.record_fields.serializeInto(record_fields_buffer);
         offset += record_fields_slice.len;
@@ -846,11 +773,6 @@ pub const Store = struct {
         const tags_buffer = @as([]align(SERIALIZATION_ALIGNMENT) u8, @alignCast(buffer[offset .. offset + tags_size]));
         const tags_slice = try self.tags.serializeInto(tags_buffer);
         offset += tags_slice.len;
-
-        offset = std.mem.alignForward(usize, offset, SERIALIZATION_ALIGNMENT);
-        const tag_args_buffer = @as([]align(SERIALIZATION_ALIGNMENT) u8, @alignCast(buffer[offset .. offset + tag_args_size]));
-        const tag_args_slice = try self.tag_args.serializeInto(tag_args_buffer);
-        offset += tag_args_slice.len;
 
         offset = std.mem.alignForward(usize, offset, SERIALIZATION_ALIGNMENT);
         const vars_buffer = @as([]align(SERIALIZATION_ALIGNMENT) u8, @alignCast(buffer[offset .. offset + vars_size]));
@@ -867,7 +789,7 @@ pub const Store = struct {
 
     /// Deserialize a Store from the provided buffer
     pub fn deserializeFrom(buffer: []const u8, allocator: Allocator) !Self {
-        if (buffer.len < @sizeOf(u32) * 8) return error.BufferTooSmall;
+        if (buffer.len < @sizeOf(u32) * 5) return error.BufferTooSmall;
 
         var offset: usize = 0;
 
@@ -878,19 +800,10 @@ pub const Store = struct {
         const descs_size = @as(*const u32, @ptrCast(@alignCast(buffer.ptr + offset))).*;
         offset += @sizeOf(u32);
 
-        const tuple_elems_size = @as(*const u32, @ptrCast(@alignCast(buffer.ptr + offset))).*;
-        offset += @sizeOf(u32);
-
-        const func_args_size = @as(*const u32, @ptrCast(@alignCast(buffer.ptr + offset))).*;
-        offset += @sizeOf(u32);
-
         const record_fields_size = @as(*const u32, @ptrCast(@alignCast(buffer.ptr + offset))).*;
         offset += @sizeOf(u32);
 
         const tags_size = @as(*const u32, @ptrCast(@alignCast(buffer.ptr + offset))).*;
-        offset += @sizeOf(u32);
-
-        const tag_args_size = @as(*const u32, @ptrCast(@alignCast(buffer.ptr + offset))).*;
         offset += @sizeOf(u32);
 
         const vars_size = @as(*const u32, @ptrCast(@alignCast(buffer.ptr + offset))).*;
@@ -907,16 +820,6 @@ pub const Store = struct {
         offset += descs_size;
 
         offset = std.mem.alignForward(usize, offset, SERIALIZATION_ALIGNMENT);
-        const tuple_elems_buffer = @as([]align(SERIALIZATION_ALIGNMENT) const u8, @alignCast(buffer[offset .. offset + tuple_elems_size]));
-        const tuple_elems = try VarSafeList.deserializeFrom(tuple_elems_buffer, allocator);
-        offset += tuple_elems_size;
-
-        offset = std.mem.alignForward(usize, offset, SERIALIZATION_ALIGNMENT);
-        const func_args_buffer = @as([]align(SERIALIZATION_ALIGNMENT) const u8, @alignCast(buffer[offset .. offset + func_args_size]));
-        const func_args = try VarSafeList.deserializeFrom(func_args_buffer, allocator);
-        offset += func_args_size;
-
-        offset = std.mem.alignForward(usize, offset, SERIALIZATION_ALIGNMENT);
         const record_fields_buffer = @as([]align(SERIALIZATION_ALIGNMENT) const u8, @alignCast(buffer[offset .. offset + record_fields_size]));
         const record_fields = try RecordFieldSafeMultiList.deserializeFrom(record_fields_buffer, allocator);
         offset += record_fields_size;
@@ -927,11 +830,6 @@ pub const Store = struct {
         offset += tags_size;
 
         offset = std.mem.alignForward(usize, offset, SERIALIZATION_ALIGNMENT);
-        const tag_args_buffer = @as([]align(SERIALIZATION_ALIGNMENT) const u8, @alignCast(buffer[offset .. offset + tag_args_size]));
-        const tag_args = try VarSafeList.deserializeFrom(tag_args_buffer, allocator);
-        offset += tag_args_size;
-
-        offset = std.mem.alignForward(usize, offset, SERIALIZATION_ALIGNMENT);
         const vars_buffer = @as([]align(SERIALIZATION_ALIGNMENT) const u8, @alignCast(buffer[offset .. offset + vars_size]));
         const vars = try VarSafeList.deserializeFrom(vars_buffer, allocator);
         offset += vars_size;
@@ -940,11 +838,8 @@ pub const Store = struct {
             .gpa = allocator,
             .slots = slots,
             .descs = descs,
-            .tuple_elems = tuple_elems,
-            .func_args = func_args,
             .record_fields = record_fields,
             .tags = tags,
-            .tag_args = tag_args,
             .vars = vars,
         };
     }

--- a/src/types/test_rigid_instantiation.zig
+++ b/src/types/test_rigid_instantiation.zig
@@ -72,12 +72,12 @@ test "rigid variables need instantiation - multiple type parameters" {
 
     // Create tuple types for the argument and return
     const arg_tuple_var = try store.fresh();
-    const arg_elems_range = try store.appendTupleElems(&.{ rigid_a, rigid_b });
+    const arg_elems_range = try store.appendVars(&.{ rigid_a, rigid_b });
     const arg_tuple_content = types.Content{ .structure = .{ .tuple = .{ .elems = arg_elems_range } } };
     try store.setVarContent(arg_tuple_var, arg_tuple_content);
 
     const ret_tuple_var = try store.fresh();
-    const ret_elems_range = try store.appendTupleElems(&.{ rigid_b, rigid_a });
+    const ret_elems_range = try store.appendVars(&.{ rigid_b, rigid_a });
     const ret_tuple_content = types.Content{ .structure = .{ .tuple = .{ .elems = ret_elems_range } } };
     try store.setVarContent(ret_tuple_var, ret_tuple_content);
 

--- a/src/types/writers.zig
+++ b/src/types/writers.zig
@@ -318,7 +318,7 @@ pub const TypeWriter = struct {
             .list => |sub_var| self.countVar(search_var, sub_var, count),
             .list_unbound, .num => {},
             .tuple => |tuple| {
-                const elems = self.env.types.getTupleElemsSlice(tuple.elems);
+                const elems = self.env.types.sliceVars(tuple.elems);
                 for (elems) |elem| {
                     self.countVar(search_var, elem, count);
                 }
@@ -330,7 +330,7 @@ pub const TypeWriter = struct {
                 }
             },
             .fn_pure, .fn_effectful, .fn_unbound => |func| {
-                const args = self.env.types.getFuncArgsSlice(func.args);
+                const args = self.env.types.sliceVars(func.args);
                 for (args) |arg| {
                     self.countVar(search_var, arg, count);
                 }
@@ -357,7 +357,7 @@ pub const TypeWriter = struct {
                 var iter = tag_union.tags.iterIndices();
                 while (iter.next()) |tag_idx| {
                     const tag = self.env.types.tags.get(tag_idx);
-                    const args = self.env.types.getTagArgsSlice(tag.args);
+                    const args = self.env.types.sliceVars(tag.args);
                     for (args) |arg_var| {
                         self.countVar(search_var, arg_var, count);
                     }
@@ -498,7 +498,7 @@ pub const TypeWriter = struct {
 
     /// Write a tuple type
     fn writeTuple(self: *Self, tuple: types.Tuple, root_var: types.Var) Allocator.Error!void {
-        const elems = self.env.types.getTupleElemsSlice(tuple.elems);
+        const elems = self.env.types.sliceVars(tuple.elems);
         _ = try self.buf.writer().write("(");
         for (elems, 0..) |elem, i| {
             if (i > 0) _ = try self.buf.writer().write(", ");
@@ -557,7 +557,7 @@ pub const TypeWriter = struct {
 
     /// Write a function type with a specific arrow (`->` or `=>`)
     fn writeFuncWithArrow(self: *Self, func: types.Func, arrow: []const u8, root_var: types.Var) Allocator.Error!void {
-        const args = self.env.types.getFuncArgsSlice(func.args);
+        const args = self.env.types.sliceVars(func.args);
 
         // Write arguments
         if (args.len == 0) {
@@ -726,7 +726,7 @@ pub const TypeWriter = struct {
     /// Write a single tag
     fn writeTag(self: *Self, tag: types.Tag, root_var: types.Var) Allocator.Error!void {
         _ = try self.buf.writer().write(self.env.idents.getText(tag.name));
-        const args = self.env.types.getTagArgsSlice(tag.args);
+        const args = self.env.types.sliceVars(tag.args);
         if (args.len > 0) {
             _ = try self.buf.writer().write("(");
             for (args, 0..) |arg, i| {


### PR DESCRIPTION
Update the types store to allocate a single list for all nested variables. That is, instead of having a `tuple_elems` array, a `func_args` array, etc that are all `SafeList(Var)`s, instead use a single `vars: SafeList(Var)` array.

There was no real benefit to having these things split out into separate arrays and joining them into one has the benefits:
* Less allocations (though about the same total memory used)
* Easier to (de)serialize in caching layer

Also does conceptually the same thing for `types/snapshots.zig`.

No snapshots were modified as part of this change.