### PR TITLE
Remove allocation in copy_import and instantiate imported vars

### DIFF
--- a/src/base/Ident.zig
+++ b/src/base/Ident.zig
@@ -190,6 +190,19 @@ pub const Store = struct {
         return self.interner.getText(@enumFromInt(@as(u32, idx.idx)));
     }
 
+    /// Get the attributes for an identifier.
+    pub fn getAttributes(self: *const Store, idx: Idx) Attributes {
+        return self.attributes.items[@as(u32, idx.idx)];
+    }
+
+    /// Get an ident
+    pub fn get(self: *const Store, idx: Idx) Ident {
+        return .{
+            .raw_text = self.getText(idx),
+            .attributes = self.getAttributes(idx),
+        };
+    }
+
     /// Calculate the size needed to serialize this Ident.Store
     pub fn serializedSize(self: *const Store) usize {
         var size: usize = 0;

--- a/src/check/check_types.zig
+++ b/src/check/check_types.zig
@@ -73,7 +73,7 @@ snapshots: snapshot.Store,
 problems: problem.Store,
 unify_scratch: unifier.Scratch,
 occurs_scratch: occurs.Scratch,
-instantiate_subs: instantiate.VarSubstitution,
+var_map: instantiate.VarSubstitution,
 /// Cache for imported types. This cache lives for the entire type-checking session
 /// of a module, so the same imported type can be reused across the entire module.
 import_cache: ImportCache,
@@ -97,7 +97,7 @@ pub fn init(
         .problems = try problem.Store.initCapacity(gpa, 64),
         .unify_scratch = try unifier.Scratch.init(gpa),
         .occurs_scratch = try occurs.Scratch.init(gpa),
-        .instantiate_subs = instantiate.VarSubstitution.init(gpa),
+        .var_map = instantiate.VarSubstitution.init(gpa),
         .import_cache = ImportCache{},
     };
 }
@@ -108,7 +108,7 @@ pub fn deinit(self: *Self) void {
     self.snapshots.deinit();
     self.unify_scratch.deinit();
     self.occurs_scratch.deinit();
-    self.instantiate_subs.deinit();
+    self.var_map.deinit();
     self.import_cache.deinit(self.gpa);
 }
 
@@ -155,19 +155,19 @@ const InstantiateRegionBehavior = union(enum) {
 
 /// Instantiate a variable, writing su
 fn instantiateVar(self: *Self, var_to_instantiate: Var, region_behavior: InstantiateRegionBehavior) std.mem.Allocator.Error!Var {
-    self.instantiate_subs.clearRetainingCapacity();
+    self.var_map.clearRetainingCapacity();
     const instantiated_var = try instantiate.instantiateVar(
         self.types,
         var_to_instantiate,
-        &self.instantiate_subs,
+        &self.var_map,
     );
 
     const root_instantiated_region = self.regions.get(@enumFromInt(@intFromEnum(var_to_instantiate))).*;
 
     // If we had to insert any new type variables, ensure that we have
     // corresponding regions for them. This is essential for error reporting.
-    if (self.instantiate_subs.count() > 0) {
-        var iterator = self.instantiate_subs.iterator();
+    if (self.var_map.count() > 0) {
+        var iterator = self.var_map.iterator();
         while (iterator.next()) |x| {
             // Get the newly created var
             const fresh_var = x.value_ptr.*;
@@ -193,6 +193,44 @@ fn instantiateVar(self: *Self, var_to_instantiate: Var, region_behavior: Instant
     self.debugAssertArraysInSync();
 
     return instantiated_var;
+}
+
+// copy from import //
+
+/// Instantiate a variable, writing su
+fn copyVar(
+    self: *Self,
+    other_module_var: Var,
+    other_module_env: *const ModuleEnv,
+) std.mem.Allocator.Error!Var {
+    self.var_map.clearRetainingCapacity();
+    const copied_var = try copy_import.copyVar(
+        &other_module_env.*.types,
+        self.types,
+        other_module_var,
+        &self.var_map,
+        &other_module_env.*.idents,
+        &self.cir.env.idents,
+        self.gpa,
+    );
+
+    // If we had to insert any new type variables, ensure that we have
+    // corresponding regions for them. This is essential for error reporting.
+    if (self.var_map.count() > 0) {
+        var iterator = self.var_map.iterator();
+        while (iterator.next()) |x| {
+            // Get the newly created var
+            const fresh_var = x.value_ptr.*;
+            try self.fillInRegionsThrough(fresh_var);
+
+            self.setRegionAt(fresh_var, base.Region.zero());
+        }
+    }
+
+    // Assert that we have regions for every type variable
+    self.debugAssertArraysInSync();
+
+    return copied_var;
 }
 
 // regions //
@@ -330,28 +368,18 @@ pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) std.mem.Allocator.Error!bo
 
                 const copied_var = if (self.import_cache.get(cache_key)) |cached_var|
                     // Reuse the previously copied type.
-                    // This is safe because imported types are never modified (preserve mode)
                     cached_var
                 else blk: {
                     // First time importing this type - copy it and cache the result
                     const imported_var = @as(Var, @enumFromInt(@intFromEnum(target_expr_idx)));
-                    const new_copy = try copy_import.copyImportedType(
-                        &other_module_env.*.types,
-                        self.types,
-                        imported_var,
-                        &other_module_env.*.idents,
-                        &self.cir.env.idents,
-                        self.gpa,
-                    );
+                    const new_copy = try self.copyVar(imported_var, other_module_env.*);
                     try self.import_cache.put(self.gpa, cache_key, new_copy);
                     break :blk new_copy;
                 };
+                const instantiated_copy = try self.instantiateVar(copied_var, .use_last_var);
 
                 // Unify our expression with the copied type
-                // Note: This unification uses "preserve" mode internally (via copy_import),
-                // which means the imported type (copied_var) is read-only. This is why
-                // we can safely cache and reuse copied_var for multiple imports.
-                const result = try self.unify(expr_var, copied_var);
+                const result = try self.unify(expr_var, instantiated_copy);
                 if (result.isProblem()) {
                     self.setProblemTypeMismatchDetail(result.problem, .{
                         .cross_module_import = .{
@@ -738,17 +766,11 @@ pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) std.mem.Allocator.Error!bo
                                     else blk: {
                                         // Copy the method's type from the origin module to our type store
                                         const source_var = @as(Var, @enumFromInt(@intFromEnum(target_expr_idx)));
-                                        const new_copy = try copy_import.copyImportedType(
-                                            &module.env.types,
-                                            self.types,
-                                            source_var,
-                                            &module.env.idents,
-                                            &self.cir.env.idents,
-                                            self.gpa,
-                                        );
+                                        const new_copy = try self.copyVar(source_var, module.env);
                                         try self.import_cache.put(self.gpa, cache_key, new_copy);
                                         break :blk new_copy;
                                     };
+                                    const method_instantiated = try self.instantiateVar(method_var, .use_last_var);
 
                                     // Check all arguments
                                     var i: u32 = 0;
@@ -778,7 +800,7 @@ pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) std.mem.Allocator.Error!bo
                                     const expected_func_var = try self.freshFromContent(func_content, expr_region);
 
                                     // Unify with the imported method type
-                                    _ = try self.unify(expected_func_var, method_var);
+                                    _ = try self.unify(expected_func_var, method_instantiated);
 
                                     // Store the resolved method info for code generation
                                     // This will be used by the code generator to emit the correct function call

--- a/src/check/check_types/copy_import.zig
+++ b/src/check/check_types/copy_import.zig
@@ -28,21 +28,7 @@ const VarMapping = std.AutoHashMap(Var, Var);
 
 /// Copy a type from one module's type store to another module's type store.
 /// This creates a completely fresh copy with new variable indices in the destination store.
-pub fn copyImportedType(
-    source_store: *const TypesStore,
-    dest_store: *TypesStore,
-    source_var: Var,
-    source_idents: *const base.Ident.Store,
-    dest_idents: *base.Ident.Store,
-    allocator: std.mem.Allocator,
-) std.mem.Allocator.Error!Var {
-    var var_mapping = VarMapping.init(allocator);
-    defer var_mapping.deinit();
-
-    return copyVar(source_store, dest_store, source_var, &var_mapping, source_idents, dest_idents, allocator);
-}
-
-fn copyVar(
+pub fn copyVar(
     source_store: *const TypesStore,
     dest_store: *TypesStore,
     source_var: Var,
@@ -248,8 +234,9 @@ fn copyRecordFields(
     defer fresh_fields.deinit();
 
     for (source_fields.items(.name), source_fields.items(.var_)) |name, var_| {
+        const translated_name = try dest_idents.insert(allocator, source_idents.get(name), base.Region.zero());
         _ = try fresh_fields.append(.{
-            .name = name, // Field names are local to the record type
+            .name = translated_name, // Field names are local to the record type
             .var_ = try copyVar(source_store, dest_store, var_, var_mapping, source_idents, dest_idents, allocator),
         });
     }
@@ -266,19 +253,16 @@ fn copyRecord(
     dest_idents: *base.Ident.Store,
     allocator: std.mem.Allocator,
 ) std.mem.Allocator.Error!Record {
-    const fields_slice = source_store.getRecordFieldsSlice(record.fields);
+    const fields_range = try copyRecordFields(
+        source_store,
+        dest_store,
+        record.fields,
+        var_mapping,
+        source_idents,
+        dest_idents,
+        allocator,
+    );
 
-    var fresh_fields = std.ArrayList(RecordField).init(allocator);
-    defer fresh_fields.deinit();
-
-    for (fields_slice.items(.name), fields_slice.items(.var_)) |name, var_| {
-        _ = try fresh_fields.append(RecordField{
-            .name = name, // Field names are local to the record type
-            .var_ = try copyVar(source_store, dest_store, var_, var_mapping, source_idents, dest_idents, allocator),
-        });
-    }
-
-    const fields_range = try dest_store.appendRecordFields(fresh_fields.items);
     return Record{
         .fields = fields_range,
         .ext = try copyVar(source_store, dest_store, record.ext, var_mapping, source_idents, dest_idents, allocator),

--- a/src/check/check_types/cross_module_test.zig
+++ b/src/check/check_types/cross_module_test.zig
@@ -382,21 +382,28 @@ test "cross-module type checking - polymorphic instantiation" {
     defer module_a_cir.deinit();
 
     // Store this as an integer literal expression (placeholder)
-    const func_expr_idx = try module_a_cir.store.addExpr(.{ .e_int = .{
-        .value = .{ .bytes = [_]u8{0} ** 16, .kind = .i128 },
-    } }, base.Region.zero());
-
-    // Create a function: listLength : List a -> I64
-    const type_var_a = try module_a_env.types.fresh(); // var 0
-    const list_content = Content{ .structure = .{ .list = type_var_a } };
-    const list_var = try module_a_env.types.freshFromContent(list_content);
-    const i64_var = try module_a_env.types.freshFromContent(Content{ .structure = .{ .num = .{ .int_precision = .i64 } } });
-
+    const type_var_a = try module_a_cir.addTypeSlotAndTypeVar(
+        @enumFromInt(0),
+        Content{ .flex_var = null },
+        base.Region.zero(),
+        types_mod.Var,
+    );
+    const list_var = try module_a_cir.addTypeSlotAndTypeVar(
+        @enumFromInt(0),
+        Content{ .structure = .{ .list = type_var_a } },
+        base.Region.zero(),
+        types_mod.Var,
+    );
+    const i64_var = try module_a_cir.addTypeSlotAndTypeVar(
+        @enumFromInt(0),
+        Content{ .structure = .{ .num = .{ .int_precision = .i64 } } },
+        base.Region.zero(),
+        types_mod.Var,
+    );
     const func_content = try module_a_env.types.mkFuncPure(&[_]Var{list_var}, i64_var);
-
-    // Set the type of expression 0 to our function type (using var 0)
-    try module_a_env.types.testOnlyFillInSlotsThru(@enumFromInt(@intFromEnum(func_expr_idx)));
-    try module_a_env.types.setVarContent(@enumFromInt(@intFromEnum(func_expr_idx)), func_content);
+    const func_expr_idx = try module_a_cir.addExprAndTypeVar(.{ .e_int = .{
+        .value = .{ .bytes = [_]u8{0} ** 16, .kind = .i128 },
+    } }, func_content, base.Region.zero());
 
     // Create module B that imports and uses the function with a specific type
     var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
@@ -409,28 +416,24 @@ test "cross-module type checking - polymorphic instantiation" {
     _ = try module_b_cir.imports.getOrPut(allocator, "ModuleA");
 
     // Create an external lookup expression
-    const external_lookup_expr = try module_b_cir.store.addExpr(.{
+    const external_lookup_expr = try module_b_cir.addExprAndTypeVar(.{
         .e_lookup_external = .{
             .module_idx = @enumFromInt(0), // Direct index to module A in the array
             .target_node_idx = @intCast(@intFromEnum(func_expr_idx)),
             .region = base.Region.zero(),
         },
-    }, base.Region.zero());
-
-    // Ensure we have type variable 0 allocated for external_lookup_expr (expr 0)
-    _ = try module_b_env.types.fresh(); // var 0
+    }, .{ .flex_var = null }, base.Region.zero());
 
     // Create an empty list expression
-    const list_expr = try module_b_cir.store.addExpr(.{
+    const str_var = try module_b_cir.addTypeSlotAndTypeVar(
+        @enumFromInt(0),
+        Content{ .structure = .str },
+        base.Region.zero(),
+        types_mod.Var,
+    );
+    const list_expr = try module_b_cir.addExprAndTypeVar(.{
         .e_empty_list = .{},
-    }, base.Region.zero());
-
-    // Create a list type with strings as elements
-    const str_var = try module_b_env.types.freshFromContent(Content{ .structure = .str });
-    const str_list_content = Content{ .structure = .{ .list = str_var } };
-
-    // Set the list expression's type
-    try module_b_env.types.setVarContent(@enumFromInt(@intFromEnum(list_expr)), str_list_content);
+    }, Content{ .structure = .{ .list = str_var } }, base.Region.zero());
 
     // Create array of module CIRs
     var modules = std.ArrayList(*CIR).init(allocator);
@@ -1043,11 +1046,8 @@ test "cross-module type checking - record type chain" {
     try testing.expectEqual(@as(usize, 2), fields.len);
 
     // Check field names and types
-    const x_ident_c = module_c_env.idents.insert(allocator, base.Ident.for_text("x"), base.Region.zero());
-    const y_ident_c = module_c_env.idents.insert(allocator, base.Ident.for_text("y"), base.Region.zero());
-
-    try testing.expectEqual(x_ident_c, fields.items(.name)[0]);
-    try testing.expectEqual(y_ident_c, fields.items(.name)[1]);
+    try testing.expectEqualSlices(u8, "x", module_c_env.idents.getText(fields.items(.name)[0]));
+    try testing.expectEqualSlices(u8, "y", module_c_env.idents.getText(fields.items(.name)[1]));
 
     // Check field x is I32
     const x_resolved = module_c_env.types.resolveVar(fields.items(.var_)[0]);
@@ -1204,21 +1204,18 @@ test "cross-module type checking - polymorphic record chain" {
     try testing.expectEqual(@as(usize, 2), fields.len);
 
     // Check field names and types
-    const value_ident_c = module_c_env.idents.insert(allocator, base.Ident.for_text("value"), base.Region.zero());
-    const next_ident_c = module_c_env.idents.insert(allocator, base.Ident.for_text("next"), base.Region.zero());
-
-    try testing.expectEqual(value_ident_c, fields.items(.name)[0]);
-    try testing.expectEqual(next_ident_c, fields.items(.name)[1]);
-
-    // Check field value is Str
-    const value_resolved = module_c_env.types.resolveVar(fields.items(.var_)[0]);
-    try testing.expect(value_resolved.desc.content == .structure);
-    try testing.expect(value_resolved.desc.content.structure == .str);
+    try testing.expectEqualSlices(u8, "next", module_c_env.idents.getText(fields.items(.name)[0]));
+    try testing.expectEqualSlices(u8, "value", module_c_env.idents.getText(fields.items(.name)[1]));
 
     // Check field next is List Str
-    const next_resolved = module_c_env.types.resolveVar(fields.items(.var_)[1]);
+    const next_resolved = module_c_env.types.resolveVar(fields.items(.var_)[0]);
     try testing.expect(next_resolved.desc.content == .structure);
     try testing.expect(next_resolved.desc.content.structure == .list);
+
+    // Check field value is Str
+    const value_resolved = module_c_env.types.resolveVar(fields.items(.var_)[1]);
+    try testing.expect(value_resolved.desc.content == .structure);
+    try testing.expect(value_resolved.desc.content.structure == .str);
 
     const list_elem_var = next_resolved.desc.content.structure.list;
     const list_elem_resolved = module_c_env.types.resolveVar(list_elem_var);


### PR DESCRIPTION
This MR updates a couple things:

* After copying types from other modules, we now instantiate them (since the unify preserve mode was removed). This is to not overwrite the original copied variable if unification fails
* Reduces allocations in copy_var by reusing the same hashmap across runs
* Fixes some tests that created CIR & type vars in wrong the order


The biggest question implicit in this change is: is a "preserve" unify mode something we want? 

I originally added it to avoid extra copying of vars, but then removed it because I was worried it was obscuring type bugs and wanted to focus on correctness first. I think long term we do want something like this because it will reduce memory usage, just not sure if we should add it back now.