### PR TITLE
Freeze interns

### DIFF
--- a/src/base/Ident.zig
+++ b/src/base/Ident.zig
@@ -366,6 +366,7 @@ pub const Store = struct {
             .strings = strings,
             .outer_indices = outer_indices,
             .regions = regions,
+            .frozen = if (std.debug.runtime_safety) false else {},
         };
 
         return Store{

--- a/src/base/Ident.zig
+++ b/src/base/Ident.zig
@@ -377,7 +377,17 @@ pub const Store = struct {
 
     /// Get the region for an identifier.
     pub fn getRegion(self: *const Store, idx: Idx) Region {
-        return self.interner.getRegion(@enumFromInt(@as(u32, idx.idx)));
+        return self.interner.getRegion(@enumFromInt(idx.idx));
+    }
+
+    /// Freeze the identifier store, preventing any new entries from being added.
+    pub fn freeze(self: *Store) void {
+        self.interner.freeze();
+    }
+
+    /// Temporarily unfreeze the identifier store.
+    pub fn unfreeze(self: *Store) void {
+        self.interner.unfreeze();
     }
 };
 

--- a/src/base/Ident.zig
+++ b/src/base/Ident.zig
@@ -384,11 +384,6 @@ pub const Store = struct {
     pub fn freeze(self: *Store) void {
         self.interner.freeze();
     }
-
-    /// Temporarily unfreeze the identifier store.
-    pub fn unfreeze(self: *Store) void {
-        self.interner.unfreeze();
-    }
 };
 
 test "from_bytes validates empty text" {

--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -100,9 +100,3 @@ pub fn freezeInterners(self: *Self) void {
     self.idents.freeze();
     self.strings.freeze();
 }
-
-/// Temporarily unfreeze all interners in this module environment.
-pub fn unfreezeInterners(self: *Self) void {
-    self.idents.unfreeze();
-    self.strings.unfreeze();
-}

--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -95,7 +95,10 @@ pub fn calcRegionInfo(self: *const Self, source: []const u8, begin: u32, end: u3
 }
 
 /// Freeze all interners in this module environment, preventing any new entries from being added.
-/// This should be called after parsing is complete.
+/// This should be called after canonicalization is complete, so that
+/// we know it's safe to serialize/deserialize the part of the interner
+/// that goes from ident to string, because we don't go from string to ident
+/// (or add new entries) in any of the later stages of compilation.
 pub fn freezeInterners(self: *Self) void {
     self.idents.freeze();
     self.strings.freeze();

--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -93,3 +93,16 @@ pub fn calcLineStarts(self: *Self, source: []const u8) !void {
 pub fn calcRegionInfo(self: *const Self, source: []const u8, begin: u32, end: u32) !RegionInfo {
     return RegionInfo.position(source, self.line_starts.items.items, begin, end);
 }
+
+/// Freeze all interners in this module environment, preventing any new entries from being added.
+/// This should be called after parsing is complete.
+pub fn freezeInterners(self: *Self) void {
+    self.idents.freeze();
+    self.strings.freeze();
+}
+
+/// Temporarily unfreeze all interners in this module environment.
+pub fn unfreezeInterners(self: *Self) void {
+    self.idents.unfreeze();
+    self.strings.unfreeze();
+}

--- a/src/base/StringLiteral.zig
+++ b/src/base/StringLiteral.zig
@@ -32,7 +32,9 @@ pub const Store = struct {
     /// continues to the previous byte
     buffer: std.ArrayListUnmanaged(u8) = .{},
     /// When true, no new entries can be added to the store.
-    /// This is set after parsing is complete.
+    /// This is set after canonicalization is complete, so that
+    /// we know it's safe to serialize/deserialize the part of the interner
+    /// that goes from ident to string, because we don't go from string to ident anymore.
     frozen: if (std.debug.runtime_safety) bool else void = if (std.debug.runtime_safety) false else {},
 
     /// Intiizalizes a `StringLiteral.Store` with capacity `bytes` of space.

--- a/src/base/StringLiteral.zig
+++ b/src/base/StringLiteral.zig
@@ -82,13 +82,6 @@ pub const Store = struct {
         }
     }
 
-    /// Temporarily unfreeze the store.
-    pub fn unfreeze(self: *Store) void {
-        if (std.debug.runtime_safety) {
-            self.frozen = false;
-        }
-    }
-
     /// Calculate the size needed to serialize this StringLiteral.Store
     pub fn serializedSize(self: *const Store) usize {
         // Header: 4 bytes for buffer length

--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -779,6 +779,9 @@ pub fn canonicalizeFile(
 
     // Assert that everything is in-sync
     self.can_ir.debugAssertArraysInSync();
+
+    // Freeze the interners after canonicalization is complete
+    self.can_ir.env.freezeInterners();
 }
 
 fn createExposedScope(

--- a/src/check/check_types.zig
+++ b/src/check/check_types.zig
@@ -782,15 +782,12 @@ pub fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx) std.mem.Allocator.Error!bo
                             var origin_module: ?*const CIR = null;
 
                             // Check if it's the current module
-                            const current_module_ident = try self.cir.env.idents.insert(self.gpa, base.Ident.for_text(self.cir.module_name), base.Region.zero());
-                            if (std.mem.eql(u8, origin_module_path, self.cir.env.idents.getText(current_module_ident))) {
+                            if (std.mem.eql(u8, origin_module_path, self.cir.module_name)) {
                                 origin_module = self.cir;
                             } else {
                                 // Search through imported modules
                                 for (self.other_modules, 0..) |other_module, idx| {
-                                    const other_module_ident = try other_module.env.idents.insert(self.gpa, base.Ident.for_text(other_module.module_name), base.Region.zero());
-                                    const other_path = other_module.env.idents.getText(other_module_ident);
-                                    if (std.mem.eql(u8, origin_module_path, other_path)) {
+                                    if (std.mem.eql(u8, origin_module_path, other_module.module_name)) {
                                         origin_module_idx = @enumFromInt(idx);
                                         origin_module = other_module;
                                         break;

--- a/src/check/parse.zig
+++ b/src/check/parse.zig
@@ -98,7 +98,7 @@ fn parseStatementAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
     @panic("Statement to parse was not found in AST");
 }
 
-/// Parses a Roc statement - only for use in snapshots. The returned AST should be deallocated by calling deinit
+/// Parses a single Roc statement for use in snapshots. The returned AST should be deallocated by calling deinit
 /// after its data is used to create the next IR, or at the end of any test.
 pub fn parseStatement(env: *base.ModuleEnv, source: []const u8) std.mem.Allocator.Error!AST {
     return try runParse(env, source, parseStatementAndReturnIdx);

--- a/src/collections/SmallStringInterner.zig
+++ b/src/collections/SmallStringInterner.zig
@@ -123,13 +123,6 @@ pub fn freeze(self: *Self) void {
     }
 }
 
-/// Temporarily unfreeze the interner.
-pub fn unfreeze(self: *Self) void {
-    if (std.debug.runtime_safety) {
-        self.frozen = false;
-    }
-}
-
 /// TODO
 pub const StringIdx = enum(u32) {
     _,

--- a/src/collections/SmallStringInterner.zig
+++ b/src/collections/SmallStringInterner.zig
@@ -22,6 +22,9 @@ strings: StringIdx.Table = .{},
 /// It also maps 1:1 with a region at the same index.
 outer_indices: std.ArrayListUnmanaged(StringIdx) = .{},
 regions: std.ArrayListUnmanaged(Region) = .{},
+/// When true, no new entries can be added to the interner.
+/// This is set after parsing is complete.
+frozen: if (std.debug.runtime_safety) bool else void = if (std.debug.runtime_safety) false else {},
 
 /// A unique index for a deduped string in this interner.
 pub const Idx = enum(u32) { _ };
@@ -58,6 +61,9 @@ pub fn deinit(self: *Self, gpa: std.mem.Allocator) void {
 
 /// Add a string to this interner, returning a unique, serial index.
 pub fn insert(self: *Self, gpa: std.mem.Allocator, string: []const u8, region: Region) std.mem.Allocator.Error!Idx {
+    if (std.debug.runtime_safety) {
+        std.debug.assert(!self.frozen); // Should not insert into a frozen interner
+    }
     const entry = try self.strings.getOrPutContextAdapted(
         gpa,
         string,
@@ -77,6 +83,9 @@ pub fn insert(self: *Self, gpa: std.mem.Allocator, string: []const u8, region: R
 }
 
 fn addOuterIdForStringIndex(self: *Self, gpa: std.mem.Allocator, string_offset: StringIdx, region: Region) std.mem.Allocator.Error!Idx {
+    if (std.debug.runtime_safety) {
+        std.debug.assert(!self.frozen); // Should not add outer IDs to a frozen interner
+    }
     const len: Idx = @enumFromInt(@as(u32, @truncate(self.outer_indices.items.len)));
     try self.outer_indices.append(gpa, string_offset);
     try self.regions.append(gpa, region);
@@ -105,6 +114,20 @@ pub fn getText(self: *const Self, idx: Idx) []u8 {
 /// Get the region for an interned string.
 pub fn getRegion(self: *const Self, idx: Idx) Region {
     return self.regions.items[@as(usize, @intFromEnum(idx))];
+}
+
+/// Freeze the interner, preventing any new entries from being added.
+pub fn freeze(self: *Self) void {
+    if (std.debug.runtime_safety) {
+        self.frozen = true;
+    }
+}
+
+/// Temporarily unfreeze the interner.
+pub fn unfreeze(self: *Self) void {
+    if (std.debug.runtime_safety) {
+        self.frozen = false;
+    }
 }
 
 /// TODO


### PR DESCRIPTION
This makes it so that in debug builds, we "freeze" interns at the end of canonicalization. From then on, any attempts to insert into it cause a panic in debug builds.

The point of this is to maintain the invariant that, after canonicalization is done, interns become readonly; we never modify them again. This in turn means we can get away with serializing/deserializing only the `id -> string` array and not the `string -> id` hash map portion of the interner, which is great because we would very much like to avoid serializing hash maps to/from disk if we can avoid it.