### PR TITLE
Implement higher order functions

### DIFF
--- a/src/check/parse/AST.zig
+++ b/src/check/parse/AST.zig
@@ -193,30 +193,22 @@ pub fn parseDiagnosticToReport(self: *AST, env: *base.ModuleEnv, diagnostic: Dia
     };
 
     const title = switch (diagnostic.tag) {
-        .bad_indent => "BAD INDENTATION",
         .multiple_platforms => "MULTIPLE PLATFORMS",
         .no_platform => "NO PLATFORM",
         .missing_header => "MISSING HEADER",
-        .list_not_closed => "LIST NOT CLOSED",
         .missing_arrow => "MISSING ARROW",
         .expected_exposes => "EXPECTED EXPOSES",
         .expected_exposes_close_square => "EXPECTED CLOSING BRACKET",
         .expected_exposes_open_square => "EXPECTED OPENING BRACKET",
         .expected_imports => "EXPECTED IMPORTS",
-        .expected_imports_close_curly => "EXPECTED CLOSING BRACE",
-        .expected_imports_open_curly => "EXPECTED OPENING BRACE",
-        .header_unexpected_token => "UNEXPECTED TOKEN IN HEADER",
         .pattern_unexpected_token => "UNEXPECTED TOKEN IN PATTERN",
         .pattern_list_rest_old_syntax => "BAD LIST REST PATTERN SYNTAX",
         .pattern_unexpected_eof => "UNEXPECTED END OF FILE IN PATTERN",
         .ty_anno_unexpected_token => "UNEXPECTED TOKEN IN TYPE ANNOTATION",
-        .statement_unexpected_eof => "UNEXPECTED END OF FILE",
-        .statement_unexpected_token => "UNEXPECTED TOKEN",
         .string_unexpected_token => "UNEXPECTED TOKEN IN STRING",
         .expr_unexpected_token => "UNEXPECTED TOKEN IN EXPRESSION",
         .import_must_be_top_level => "IMPORT MUST BE TOP LEVEL",
         .expected_expr_close_square_or_comma => "LIST NOT CLOSED",
-        .where_expected_where => "WHERE CLAUSE ERROR",
         .where_expected_mod_open => "WHERE CLAUSE ERROR",
         .where_expected_var => "WHERE CLAUSE ERROR",
         .where_expected_mod_close => "WHERE CLAUSE ERROR",
@@ -261,18 +253,6 @@ pub fn parseDiagnosticToReport(self: *AST, env: *base.ModuleEnv, diagnostic: Dia
             try report.document.addIndent(1);
             try report.document.addCodeBlock("{ pf: platform \"../basic-cli/platform.roc\" }");
         },
-        .bad_indent => {
-            try report.document.addReflowingText("The indentation here is inconsistent with the surrounding code.");
-            try report.document.addLineBreak();
-            try report.document.addReflowingText("Make sure to use consistent spacing for indentation.");
-        },
-        .list_not_closed => {
-            try report.document.addReflowingText("This list is missing a closing bracket.");
-            try report.document.addLineBreak();
-            try report.document.addText("Add a ");
-            try report.document.addAnnotated("]", .emphasized);
-            try report.document.addText(" to close the list.");
-        },
         .missing_arrow => {
             try report.document.addText("Expected an arrow ");
             try report.document.addAnnotated("->", .emphasized);
@@ -288,24 +268,11 @@ pub fn parseDiagnosticToReport(self: *AST, env: *base.ModuleEnv, diagnostic: Dia
             try report.document.addText("For example: ");
             try report.document.addCodeBlock("module [main, add, subtract]");
         },
-        .expected_imports, .expected_imports_close_curly, .expected_imports_open_curly => {
+        .expected_imports => {
             try report.document.addReflowingText("Import statements must specify what is being imported.");
             try report.document.addLineBreak();
             try report.document.addText("For example: ");
             try report.document.addCodeBlock("import pf.Stdout exposing [line!]");
-        },
-        .header_unexpected_token => {
-            // Try to get the actual token text
-            const token_text = if (diagnostic.region.start != diagnostic.region.end)
-                self.env.source[region.start.offset..region.end.offset]
-            else
-                "<unknown>";
-            const owned_token = try report.addOwnedString(token_text);
-            try report.document.addText("The token ");
-            try report.document.addAnnotated(owned_token, .error_highlight);
-            try report.document.addText(" is not expected in a module header.");
-            try report.document.addLineBreak();
-            try report.document.addReflowingText("Module headers should only contain the module name and exposing list.");
         },
         .pattern_unexpected_token => {
             const token_text = if (diagnostic.region.start != diagnostic.region.end)
@@ -346,23 +313,6 @@ pub fn parseDiagnosticToReport(self: *AST, env: *base.ModuleEnv, diagnostic: Dia
             try report.document.addText(", or ");
             try report.document.addType("List U64");
             try report.document.addText(".");
-        },
-        .statement_unexpected_eof => {
-            try report.document.addReflowingText("This statement is incomplete - the file ended unexpectedly.");
-            try report.document.addLineBreak();
-            try report.document.addReflowingText("Complete the statement or remove the incomplete statement.");
-        },
-        .statement_unexpected_token => {
-            const token_text = if (diagnostic.region.start != diagnostic.region.end)
-                self.env.source[region.start.offset..region.end.offset]
-            else
-                "<unknown>";
-            const owned_token = try report.addOwnedString(token_text);
-            try report.document.addText("The token ");
-            try report.document.addAnnotated(owned_token, .error_highlight);
-            try report.document.addText(" is not expected in a statement.");
-            try report.document.addLineBreak();
-            try report.document.addReflowingText("Statements can be definitions, assignments, or expressions.");
         },
         .string_unexpected_token => {
             const token_text = if (diagnostic.region.start != diagnostic.region.end)
@@ -432,13 +382,6 @@ pub fn parseDiagnosticToReport(self: *AST, env: *base.ModuleEnv, diagnostic: Dia
             try report.document.addLineBreak();
             try report.document.addIndent(1);
             try report.document.addAnnotated("Maybe(List(U64))", .dimmed);
-        },
-        .where_expected_where => {
-            try report.document.addReflowingText("Expected a ");
-            try report.document.addKeyword("where");
-            try report.document.addText(" clause here.");
-            try report.document.addLineBreak();
-            try report.document.addReflowingText("Where clauses define constraints on type variables.");
         },
         .where_expected_mod_open => {
             try report.document.addReflowingText("Expected an opening parenthesis after ");
@@ -569,18 +512,14 @@ pub const Diagnostic = struct {
 
     /// different types of diagnostic errors
     pub const Tag = enum {
-        bad_indent,
         multiple_platforms,
         no_platform,
         missing_header,
-        list_not_closed,
         missing_arrow,
         expected_exposes,
         expected_exposes_close_square,
         expected_exposes_open_square,
         expected_imports,
-        expected_imports_close_curly,
-        expected_imports_open_curly,
         expected_package_or_platform_name,
         expected_package_or_platform_colon,
         expected_package_or_platform_string,
@@ -601,21 +540,16 @@ pub const Diagnostic = struct {
         expected_requires_rigids_open_curly,
         expected_requires_signatures_close_curly,
         expected_requires_signatures_open_curly,
-        expect_closing_paren,
         header_expected_open_square,
         header_expected_close_square,
-        header_unexpected_token,
         pattern_unexpected_token,
         pattern_list_rest_old_syntax,
         pattern_unexpected_eof,
         bad_as_pattern_name,
         ty_anno_unexpected_token,
-        statement_unexpected_eof,
-        statement_unexpected_token,
         string_unexpected_token,
         string_expected_close_interpolation,
         string_unclosed,
-        expr_if_missing_else,
         expr_no_space_dot_int,
         import_exposing_no_open,
         import_exposing_no_close,
@@ -641,10 +575,7 @@ pub const Diagnostic = struct {
         expr_unexpected_token,
         expected_expr_record_field_name,
         expected_ty_apply_close_round,
-        expected_ty_anno_end_of_function,
-        expected_ty_anno_end,
         expected_expr_apply_close_round,
-        where_expected_where,
         where_expected_mod_open,
         where_expected_var,
         where_expected_mod_close,
@@ -664,6 +595,7 @@ pub const Diagnostic = struct {
         for_expected_in,
         match_branch_wrong_arrow,
         match_branch_missing_arrow,
+        expected_ty_anno_close_round,
     };
 };
 

--- a/src/snapshots/formatting/singleline_with_comma/everything.md
+++ b/src/snapshots/formatting/singleline_with_comma/everything.md
@@ -12,8 +12,8 @@ import I1 exposing [I11, I12,]
 import I2 exposing [I21 as Ias1, I22 as Ias2,]
 
 # Where constraint
-A(a) : a where module(a).a1 : (a, a,) -> Str, module(a).a2 : (a, a,) -> Str,
-B(b) : b where module(b).b1 : (b, b,) -> Str, module(b).b2 : (b, b,) -> Str,
+A(a) : a where module(a).a1 : (a, a,) -> Str, module(a).a2 : (a, a,) -> Str
+B(b) : b where module(b).b1 : (b, b,) -> Str, module(b).b2 : (b, b,) -> Str
 
 C(a, b,) : (a, b,)
 D(a, b,) : C(a, b,)
@@ -161,8 +161,8 @@ The unused variable is declared here:
 KwModule(1:1-1:7),OpenSquare(1:8-1:9),CloseSquare(1:9-1:10),
 KwImport(4:1-4:7),UpperIdent(4:8-4:10),KwExposing(4:11-4:19),OpenSquare(4:20-4:21),UpperIdent(4:21-4:24),Comma(4:24-4:25),UpperIdent(4:26-4:29),Comma(4:29-4:30),CloseSquare(4:30-4:31),
 KwImport(5:1-5:7),UpperIdent(5:8-5:10),KwExposing(5:11-5:19),OpenSquare(5:20-5:21),UpperIdent(5:21-5:24),KwAs(5:25-5:27),UpperIdent(5:28-5:32),Comma(5:32-5:33),UpperIdent(5:34-5:37),KwAs(5:38-5:40),UpperIdent(5:41-5:45),Comma(5:45-5:46),CloseSquare(5:46-5:47),
-UpperIdent(8:1-8:2),NoSpaceOpenRound(8:2-8:3),LowerIdent(8:3-8:4),CloseRound(8:4-8:5),OpColon(8:6-8:7),LowerIdent(8:8-8:9),KwWhere(8:10-8:15),KwModule(8:16-8:22),NoSpaceOpenRound(8:22-8:23),LowerIdent(8:23-8:24),CloseRound(8:24-8:25),NoSpaceDotLowerIdent(8:25-8:28),OpColon(8:29-8:30),OpenRound(8:31-8:32),LowerIdent(8:32-8:33),Comma(8:33-8:34),LowerIdent(8:35-8:36),Comma(8:36-8:37),CloseRound(8:37-8:38),OpArrow(8:39-8:41),UpperIdent(8:42-8:45),Comma(8:45-8:46),KwModule(8:47-8:53),NoSpaceOpenRound(8:53-8:54),LowerIdent(8:54-8:55),CloseRound(8:55-8:56),NoSpaceDotLowerIdent(8:56-8:59),OpColon(8:60-8:61),OpenRound(8:62-8:63),LowerIdent(8:63-8:64),Comma(8:64-8:65),LowerIdent(8:66-8:67),Comma(8:67-8:68),CloseRound(8:68-8:69),OpArrow(8:70-8:72),UpperIdent(8:73-8:76),Comma(8:76-8:77),
-UpperIdent(9:1-9:2),NoSpaceOpenRound(9:2-9:3),LowerIdent(9:3-9:4),CloseRound(9:4-9:5),OpColon(9:6-9:7),LowerIdent(9:8-9:9),KwWhere(9:10-9:15),KwModule(9:16-9:22),NoSpaceOpenRound(9:22-9:23),LowerIdent(9:23-9:24),CloseRound(9:24-9:25),NoSpaceDotLowerIdent(9:25-9:28),OpColon(9:29-9:30),OpenRound(9:31-9:32),LowerIdent(9:32-9:33),Comma(9:33-9:34),LowerIdent(9:35-9:36),Comma(9:36-9:37),CloseRound(9:37-9:38),OpArrow(9:39-9:41),UpperIdent(9:42-9:45),Comma(9:45-9:46),KwModule(9:47-9:53),NoSpaceOpenRound(9:53-9:54),LowerIdent(9:54-9:55),CloseRound(9:55-9:56),NoSpaceDotLowerIdent(9:56-9:59),OpColon(9:60-9:61),OpenRound(9:62-9:63),LowerIdent(9:63-9:64),Comma(9:64-9:65),LowerIdent(9:66-9:67),Comma(9:67-9:68),CloseRound(9:68-9:69),OpArrow(9:70-9:72),UpperIdent(9:73-9:76),Comma(9:76-9:77),
+UpperIdent(8:1-8:2),NoSpaceOpenRound(8:2-8:3),LowerIdent(8:3-8:4),CloseRound(8:4-8:5),OpColon(8:6-8:7),LowerIdent(8:8-8:9),KwWhere(8:10-8:15),KwModule(8:16-8:22),NoSpaceOpenRound(8:22-8:23),LowerIdent(8:23-8:24),CloseRound(8:24-8:25),NoSpaceDotLowerIdent(8:25-8:28),OpColon(8:29-8:30),OpenRound(8:31-8:32),LowerIdent(8:32-8:33),Comma(8:33-8:34),LowerIdent(8:35-8:36),Comma(8:36-8:37),CloseRound(8:37-8:38),OpArrow(8:39-8:41),UpperIdent(8:42-8:45),Comma(8:45-8:46),KwModule(8:47-8:53),NoSpaceOpenRound(8:53-8:54),LowerIdent(8:54-8:55),CloseRound(8:55-8:56),NoSpaceDotLowerIdent(8:56-8:59),OpColon(8:60-8:61),OpenRound(8:62-8:63),LowerIdent(8:63-8:64),Comma(8:64-8:65),LowerIdent(8:66-8:67),Comma(8:67-8:68),CloseRound(8:68-8:69),OpArrow(8:70-8:72),UpperIdent(8:73-8:76),
+UpperIdent(9:1-9:2),NoSpaceOpenRound(9:2-9:3),LowerIdent(9:3-9:4),CloseRound(9:4-9:5),OpColon(9:6-9:7),LowerIdent(9:8-9:9),KwWhere(9:10-9:15),KwModule(9:16-9:22),NoSpaceOpenRound(9:22-9:23),LowerIdent(9:23-9:24),CloseRound(9:24-9:25),NoSpaceDotLowerIdent(9:25-9:28),OpColon(9:29-9:30),OpenRound(9:31-9:32),LowerIdent(9:32-9:33),Comma(9:33-9:34),LowerIdent(9:35-9:36),Comma(9:36-9:37),CloseRound(9:37-9:38),OpArrow(9:39-9:41),UpperIdent(9:42-9:45),Comma(9:45-9:46),KwModule(9:47-9:53),NoSpaceOpenRound(9:53-9:54),LowerIdent(9:54-9:55),CloseRound(9:55-9:56),NoSpaceDotLowerIdent(9:56-9:59),OpColon(9:60-9:61),OpenRound(9:62-9:63),LowerIdent(9:63-9:64),Comma(9:64-9:65),LowerIdent(9:66-9:67),Comma(9:67-9:68),CloseRound(9:68-9:69),OpArrow(9:70-9:72),UpperIdent(9:73-9:76),
 UpperIdent(11:1-11:2),NoSpaceOpenRound(11:2-11:3),LowerIdent(11:3-11:4),Comma(11:4-11:5),LowerIdent(11:6-11:7),Comma(11:7-11:8),CloseRound(11:8-11:9),OpColon(11:10-11:11),OpenRound(11:12-11:13),LowerIdent(11:13-11:14),Comma(11:14-11:15),LowerIdent(11:16-11:17),Comma(11:17-11:18),CloseRound(11:18-11:19),
 UpperIdent(12:1-12:2),NoSpaceOpenRound(12:2-12:3),LowerIdent(12:3-12:4),Comma(12:4-12:5),LowerIdent(12:6-12:7),Comma(12:7-12:8),CloseRound(12:8-12:9),OpColon(12:10-12:11),UpperIdent(12:12-12:13),NoSpaceOpenRound(12:13-12:14),LowerIdent(12:14-12:15),Comma(12:15-12:16),LowerIdent(12:17-12:18),Comma(12:18-12:19),CloseRound(12:19-12:20),
 UpperIdent(13:1-13:2),OpColon(13:3-13:4),OpenCurly(13:5-13:6),LowerIdent(13:7-13:8),OpColon(13:9-13:10),UpperIdent(13:11-13:14),Comma(13:14-13:15),LowerIdent(13:16-13:17),OpColon(13:18-13:19),UpperIdent(13:20-13:23),Comma(13:23-13:24),CloseCurly(13:25-13:26),
@@ -196,7 +196,7 @@ CloseCurly(31:1-31:2),EndOfFile(31:2-31:2),
 			(exposing
 				(exposed-upper-ident @5.21-5.32 (text "I21") (as "Ias1"))
 				(exposed-upper-ident @5.34-5.45 (text "I22") (as "Ias2"))))
-		(s-type-decl @8.1-8.77
+		(s-type-decl @8.1-8.76
 			(header @8.1-8.5 (name "A")
 				(args
 					(ty-var @8.3-8.4 (raw "a"))))
@@ -214,7 +214,7 @@ CloseCurly(31:1-31:2),EndOfFile(31:2-31:2),
 							(ty-var @8.63-8.64 (raw "a"))
 							(ty-var @8.66-8.67 (raw "a"))))
 					(ty @8.73-8.76 (name "Str")))))
-		(s-type-decl @9.1-9.77
+		(s-type-decl @9.1-9.76
 			(header @9.1-9.5 (name "B")
 				(args
 					(ty-var @9.3-9.4 (raw "b"))))
@@ -550,7 +550,7 @@ h = |x, y| {
 								(value
 									(e-lookup-local @29.18-29.19
 										(p-assign @29.7-29.8 (ident "a")))))))))))
-	(s-alias-decl @8.1-8.77
+	(s-alias-decl @8.1-8.76
 		(ty-header @8.1-8.5 (name "A")
 			(ty-args
 				(ty-var @8.3-8.4 (name "a"))))
@@ -568,7 +568,7 @@ h = |x, y| {
 						(ty-var @8.63-8.64 (name "a"))
 						(ty-var @8.66-8.67 (name "a"))))
 				(ty @8.73-8.76 (name "Str")))))
-	(s-alias-decl @9.1-9.77
+	(s-alias-decl @9.1-9.76
 		(ty-header @9.1-9.5 (name "B")
 			(ty-args
 				(ty-var @9.3-9.4 (name "b"))))
@@ -642,11 +642,11 @@ h = |x, y| {
 	(defs
 		(patt @18.1-18.2 (type "[Z1((field, field2)), Z2(c, d), Z3(f), Z4(List(elem))]others, [Z1((field3, field4)), Z2(i, j), Z3(k), Z4(List(elem2))]others2 -> _ret")))
 	(type_decls
-		(alias @8.1-8.77 (type "A(a)")
+		(alias @8.1-8.76 (type "A(a)")
 			(ty-header @8.1-8.5 (name "A")
 				(ty-args
 					(ty-var @8.3-8.4 (name "a")))))
-		(alias @9.1-9.77 (type "B(b)")
+		(alias @9.1-9.76 (type "B(b)")
 			(ty-header @9.1-9.5 (name "B")
 				(ty-args
 					(ty-var @9.3-9.4 (name "b")))))

--- a/src/snapshots/fuzz_crash/fuzz_crash_021.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_021.md
@@ -52,7 +52,7 @@ Fli/main.roc" }
 
 
 **PARSE ERROR**
-A parsing error occurred: `expected_ty_anno_end`
+A parsing error occurred: `expected_ty_anno_close_round`
 This is an unexpected parsing error. Please check your syntax.
 
 Here is the problematic code:
@@ -64,7 +64,7 @@ Pair(a, b+ : (
 
 
 **PARSE ERROR**
-A parsing error occurred: `expected_ty_anno_end`
+A parsing error occurred: `expected_ty_anno_close_round`
 This is an unexpected parsing error. Please check your syntax.
 
 Here is the problematic code:
@@ -130,7 +130,7 @@ UpperIdent(3:1-3:5),NoSpaceOpenRound(3:5-3:6),LowerIdent(3:6-3:7),Comma(3:7-3:8)
 		(s-type-decl @3.1-3.15
 			(header @3.1-3.11 (name "<malformed>")
 				(args))
-			(ty-malformed @3.14-3.15 (tag "expected_ty_anno_end")))))
+			(ty-malformed @3.14-3.15 (tag "expected_ty_anno_close_round")))))
 ~~~
 # FORMATTED
 ~~~roc

--- a/src/snapshots/pass/underscore_in_regular_annotations.md
+++ b/src/snapshots/pass/underscore_in_regular_annotations.md
@@ -15,7 +15,7 @@ identity = |x| x
 
 # Function with underscore in annotation
 process : List(_) -> Str
-process = |list| "processed"
+process = |_list| "processed"
 
 # Record with underscore
 get_data : { field: _, other: U32 } -> U32
@@ -35,172 +35,12 @@ map = |_, _| []
 
 # Named underscore type variables
 transform : _a -> _b -> _b
-transform = |_, b| b
+transform = |_| |b| b
 ~~~
 # EXPECTED
-UNEXPECTED TOKEN IN EXPRESSION - underscore_in_regular_annotations.md:26:15:26:16
-PARSE ERROR - underscore_in_regular_annotations.md:26:17:26:21
-PARSE ERROR - underscore_in_regular_annotations.md:26:28:26:32
-UNEXPECTED TOKEN IN EXPRESSION - underscore_in_regular_annotations.md:27:5:27:6
-UNEXPECTED TOKEN IN EXPRESSION - underscore_in_regular_annotations.md:30:22:30:24
-UNUSED VARIABLE - underscore_in_regular_annotations.md:11:12:11:16
-INVALID STATEMENT - underscore_in_regular_annotations.md:26:15:26:16
-INVALID STATEMENT - underscore_in_regular_annotations.md:27:5:27:6
-INVALID STATEMENT - underscore_in_regular_annotations.md:27:7:27:16
-INVALID STATEMENT - underscore_in_regular_annotations.md:30:22:30:24
-INVALID STATEMENT - underscore_in_regular_annotations.md:30:25:30:27
+NIL
 # PROBLEMS
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **,** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**underscore_in_regular_annotations.md:26:15:26:16:**
-```roc
-map : (a -> b), List(a) -> List(b)
-```
-              ^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**underscore_in_regular_annotations.md:26:17:26:21:**
-```roc
-map : (a -> b), List(a) -> List(b)
-```
-                ^^^^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Result(a, Str)`
-    `Maybe(List(U64))`
-
-Here is the problematic code:
-**underscore_in_regular_annotations.md:26:28:26:32:**
-```roc
-map : (a -> b), List(a) -> List(b)
-```
-                           ^^^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **=** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**underscore_in_regular_annotations.md:27:5:27:6:**
-```roc
-map = |_, _| []
-```
-    ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **->** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**underscore_in_regular_annotations.md:30:22:30:24:**
-```roc
-transform : _a -> _b -> _b
-```
-                     ^^
-
-
-**UNUSED VARIABLE**
-Variable `list` is not used anywhere in your code.
-
-If you don't need this variable, prefix it with an underscore like `_list` to suppress this warning.
-The unused variable is declared here:
-**underscore_in_regular_annotations.md:11:12:11:16:**
-```roc
-process = |list| "processed"
-```
-           ^^^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**underscore_in_regular_annotations.md:26:15:26:16:**
-```roc
-map : (a -> b), List(a) -> List(b)
-```
-              ^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**underscore_in_regular_annotations.md:27:5:27:6:**
-```roc
-map = |_, _| []
-```
-    ^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**underscore_in_regular_annotations.md:27:7:27:16:**
-```roc
-map = |_, _| []
-```
-      ^^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**underscore_in_regular_annotations.md:30:22:30:24:**
-```roc
-transform : _a -> _b -> _b
-```
-                     ^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**underscore_in_regular_annotations.md:30:25:30:27:**
-```roc
-transform : _a -> _b -> _b
-```
-                        ^^
-
-
+NIL
 # TOKENS
 ~~~zig
 KwModule(1:1-1:7),OpenSquare(1:8-1:9),CloseSquare(1:9-1:10),
@@ -209,7 +49,7 @@ LowerIdent(4:1-4:5),OpAssign(4:6-4:7),OpBar(4:8-4:9),LowerIdent(4:9-4:10),OpBar(
 LowerIdent(6:1-6:9),OpColon(6:10-6:11),LowerIdent(6:12-6:13),OpArrow(6:14-6:16),LowerIdent(6:17-6:18),
 LowerIdent(7:1-7:9),OpAssign(7:10-7:11),OpBar(7:12-7:13),LowerIdent(7:13-7:14),OpBar(7:14-7:15),LowerIdent(7:16-7:17),
 LowerIdent(10:1-10:8),OpColon(10:9-10:10),UpperIdent(10:11-10:15),NoSpaceOpenRound(10:15-10:16),Underscore(10:16-10:17),CloseRound(10:17-10:18),OpArrow(10:19-10:21),UpperIdent(10:22-10:25),
-LowerIdent(11:1-11:8),OpAssign(11:9-11:10),OpBar(11:11-11:12),LowerIdent(11:12-11:16),OpBar(11:16-11:17),StringStart(11:18-11:19),StringPart(11:19-11:28),StringEnd(11:28-11:29),
+LowerIdent(11:1-11:8),OpAssign(11:9-11:10),OpBar(11:11-11:12),NamedUnderscore(11:12-11:17),OpBar(11:17-11:18),StringStart(11:19-11:20),StringPart(11:20-11:29),StringEnd(11:29-11:30),
 LowerIdent(14:1-14:9),OpColon(14:10-14:11),OpenCurly(14:12-14:13),LowerIdent(14:14-14:19),OpColon(14:19-14:20),Underscore(14:21-14:22),Comma(14:22-14:23),LowerIdent(14:24-14:29),OpColon(14:29-14:30),UpperIdent(14:31-14:34),CloseCurly(14:35-14:36),OpArrow(14:37-14:39),UpperIdent(14:40-14:43),
 LowerIdent(15:1-15:9),OpAssign(15:10-15:11),OpBar(15:12-15:13),LowerIdent(15:13-15:19),OpBar(15:19-15:20),LowerIdent(15:21-15:27),NoSpaceDotLowerIdent(15:27-15:33),
 LowerIdent(18:1-18:14),OpColon(18:15-18:16),UpperIdent(18:17-18:23),NoSpaceOpenRound(18:23-18:24),Underscore(18:24-18:25),Comma(18:25-18:26),UpperIdent(18:27-18:30),CloseRound(18:30-18:31),OpArrow(18:32-18:34),UpperIdent(18:35-18:38),
@@ -221,11 +61,11 @@ CloseCurly(23:5-23:6),
 LowerIdent(26:1-26:4),OpColon(26:5-26:6),OpenRound(26:7-26:8),LowerIdent(26:8-26:9),OpArrow(26:10-26:12),LowerIdent(26:13-26:14),CloseRound(26:14-26:15),Comma(26:15-26:16),UpperIdent(26:17-26:21),NoSpaceOpenRound(26:21-26:22),LowerIdent(26:22-26:23),CloseRound(26:23-26:24),OpArrow(26:25-26:27),UpperIdent(26:28-26:32),NoSpaceOpenRound(26:32-26:33),LowerIdent(26:33-26:34),CloseRound(26:34-26:35),
 LowerIdent(27:1-27:4),OpAssign(27:5-27:6),OpBar(27:7-27:8),Underscore(27:8-27:9),Comma(27:9-27:10),Underscore(27:11-27:12),OpBar(27:12-27:13),OpenSquare(27:14-27:15),CloseSquare(27:15-27:16),
 LowerIdent(30:1-30:10),OpColon(30:11-30:12),NamedUnderscore(30:13-30:15),OpArrow(30:16-30:18),NamedUnderscore(30:19-30:21),OpArrow(30:22-30:24),NamedUnderscore(30:25-30:27),
-LowerIdent(31:1-31:10),OpAssign(31:11-31:12),OpBar(31:13-31:14),Underscore(31:14-31:15),Comma(31:15-31:16),LowerIdent(31:17-31:18),OpBar(31:18-31:19),LowerIdent(31:20-31:21),EndOfFile(31:21-31:21),
+LowerIdent(31:1-31:10),OpAssign(31:11-31:12),OpBar(31:13-31:14),Underscore(31:14-31:15),OpBar(31:15-31:16),OpBar(31:17-31:18),LowerIdent(31:18-31:19),OpBar(31:19-31:20),LowerIdent(31:21-31:22),EndOfFile(31:22-31:22),
 ~~~
 # PARSE
 ~~~clojure
-(file @1.1-31.21
+(file @1.1-31.22
 	(module @1.1-1.10
 		(exposes @1.8-1.10))
 	(statements
@@ -255,13 +95,13 @@ LowerIdent(31:1-31:10),OpAssign(31:11-31:12),OpBar(31:13-31:14),Underscore(31:14
 					(ty @10.11-10.15 (name "List"))
 					(_))
 				(ty @10.22-10.25 (name "Str"))))
-		(s-decl @11.1-11.29
+		(s-decl @11.1-11.30
 			(p-ident @11.1-11.8 (raw "process"))
-			(e-lambda @11.11-11.29
+			(e-lambda @11.11-11.30
 				(args
-					(p-ident @11.12-11.16 (raw "list")))
-				(e-string @11.18-11.29
-					(e-string-part @11.19-11.28 (raw "processed")))))
+					(p-ident @11.12-11.17 (raw "_list")))
+				(e-string @11.19-11.30
+					(e-string-part @11.20-11.29 (raw "processed")))))
 		(s-type-anno @14.1-14.43 (name "get_data")
 			(ty-fn @14.12-14.43
 				(ty-record @14.12-14.36
@@ -302,32 +142,39 @@ LowerIdent(31:1-31:10),OpAssign(31:11-31:12),OpBar(31:13-31:14),Underscore(31:14
 							(p-tag @22.9-22.17 (raw "Err")
 								(p-ident @22.13-22.16 (raw "msg")))
 							(e-ident @22.21-22.24 (raw "msg")))))))
-		(s-type-anno @26.1-26.15 (name "map")
-			(ty-fn @26.8-26.14
-				(ty-var @26.8-26.9 (raw "a"))
-				(ty-var @26.13-26.14 (raw "b"))))
-		(e-malformed @26.15-26.16 (reason "expr_unexpected_token"))
-		(s-malformed @26.17-26.27 (tag "expected_colon_after_type_annotation"))
-		(s-malformed @26.28-27.4 (tag "expected_colon_after_type_annotation"))
-		(e-malformed @27.5-27.6 (reason "expr_unexpected_token"))
-		(e-lambda @27.7-27.16
-			(args
-				(p-underscore)
-				(p-underscore))
-			(e-list @27.14-27.16))
-		(s-type-anno @30.1-30.21 (name "transform")
-			(ty-fn @30.13-30.21
-				(underscore-ty-var @30.13-30.15 (raw "_a"))
-				(underscore-ty-var @30.19-30.21 (raw "_b"))))
-		(e-malformed @30.22-30.24 (reason "expr_unexpected_token"))
-		(e-ident @30.25-30.27 (raw "_b"))
-		(s-decl @31.1-31.21
-			(p-ident @31.1-31.10 (raw "transform"))
-			(e-lambda @31.13-31.21
+		(s-type-anno @26.1-26.35 (name "map")
+			(ty-fn @26.7-26.35
+				(ty-fn @26.8-26.14
+					(ty-var @26.8-26.9 (raw "a"))
+					(ty-var @26.13-26.14 (raw "b")))
+				(ty-apply @26.17-26.24
+					(ty @26.17-26.21 (name "List"))
+					(ty-var @26.22-26.23 (raw "a")))
+				(ty-apply @26.28-26.35
+					(ty @26.28-26.32 (name "List"))
+					(ty-var @26.33-26.34 (raw "b")))))
+		(s-decl @27.1-27.16
+			(p-ident @27.1-27.4 (raw "map"))
+			(e-lambda @27.7-27.16
 				(args
 					(p-underscore)
-					(p-ident @31.17-31.18 (raw "b")))
-				(e-ident @31.20-31.21 (raw "b"))))))
+					(p-underscore))
+				(e-list @27.14-27.16)))
+		(s-type-anno @30.1-30.27 (name "transform")
+			(ty-fn @30.13-30.27
+				(underscore-ty-var @30.13-30.15 (raw "_a"))
+				(ty-fn @30.19-30.27
+					(underscore-ty-var @30.19-30.21 (raw "_b"))
+					(underscore-ty-var @30.25-30.27 (raw "_b")))))
+		(s-decl @31.1-31.22
+			(p-ident @31.1-31.10 (raw "transform"))
+			(e-lambda @31.13-31.22
+				(args
+					(p-underscore))
+				(e-lambda @31.17-31.22
+					(args
+						(p-ident @31.18-31.19 (raw "b")))
+					(e-ident @31.21-31.22 (raw "b")))))))
 ~~~
 # FORMATTED
 ~~~roc
@@ -341,7 +188,7 @@ identity = |x| x
 
 # Function with underscore in annotation
 process : List(_) -> Str
-process = |list| "processed"
+process = |_list| "processed"
 
 # Record with underscore
 get_data : { field : _, other : U32 } -> U32
@@ -356,13 +203,12 @@ handle_result = |result|
 	}
 
 # Underscore in function arguments
-map : (a -> b)
-|_, _| []
+map : (a -> b), List(a) -> List(b)
+map = |_, _| []
 
 # Named underscore type variables
-transform : _a -> _b
-_b
-transform = |_, b| b
+transform : _a -> _b -> _b
+transform = |_| |b| b
 ~~~
 # CANONICALIZE
 ~~~clojure
@@ -393,11 +239,11 @@ transform = |_, b| b
 					(ty-var @6.17-6.18 (name "a"))))))
 	(d-let
 		(p-assign @11.1-11.8 (ident "process"))
-		(e-lambda @11.11-11.29
+		(e-lambda @11.11-11.30
 			(args
-				(p-assign @11.12-11.16 (ident "list")))
-			(e-string @11.18-11.29
-				(e-literal @11.19-11.28 (string "processed"))))
+				(p-assign @11.12-11.17 (ident "_list")))
+			(e-string @11.19-11.30
+				(e-literal @11.20-11.29 (string "processed"))))
 		(annotation @11.1-11.8
 			(declared-type
 				(ty-fn @10.11-10.25 (effectful false)
@@ -455,13 +301,40 @@ transform = |_, b| b
 						(ty @18.27-18.30 (name "Str")))
 					(ty @18.35-18.38 (name "Str"))))))
 	(d-let
-		(p-assign @31.1-31.10 (ident "transform"))
-		(e-lambda @31.13-31.21
+		(p-assign @27.1-27.4 (ident "map"))
+		(e-lambda @27.7-27.16
 			(args
-				(p-underscore @31.14-31.15)
-				(p-assign @31.17-31.18 (ident "b")))
-			(e-lookup-local @31.20-31.21
-				(p-assign @31.17-31.18 (ident "b"))))))
+				(p-underscore @27.8-27.9)
+				(p-underscore @27.11-27.12))
+			(e-empty_list @27.14-27.16))
+		(annotation @27.1-27.4
+			(declared-type
+				(ty-fn @26.7-26.35 (effectful false)
+					(ty-parens @26.7-26.15
+						(ty-fn @26.8-26.14 (effectful false)
+							(ty-var @26.8-26.9 (name "a"))
+							(ty-var @26.13-26.14 (name "b"))))
+					(ty-apply @26.17-26.24 (symbol "List")
+						(ty-var @26.22-26.23 (name "a")))
+					(ty-apply @26.28-26.35 (symbol "List")
+						(ty-var @26.33-26.34 (name "b")))))))
+	(d-let
+		(p-assign @31.1-31.10 (ident "transform"))
+		(e-lambda @31.13-31.22
+			(args
+				(p-underscore @31.14-31.15))
+			(e-lambda @31.17-31.22
+				(args
+					(p-assign @31.18-31.19 (ident "b")))
+				(e-lookup-local @31.21-31.22
+					(p-assign @31.18-31.19 (ident "b")))))
+		(annotation @31.1-31.10
+			(declared-type
+				(ty-fn @30.13-30.27 (effectful false)
+					(ty-var @30.13-30.15 (name "_a"))
+					(ty-fn @30.19-30.27 (effectful false)
+						(ty-var @30.19-30.21 (name "_b"))
+						(ty-var @30.25-30.27 (name "_b"))))))))
 ~~~
 # TYPES
 ~~~clojure
@@ -472,12 +345,14 @@ transform = |_, b| b
 		(patt @11.1-11.8 (type "Error -> Str"))
 		(patt @15.1-15.9 (type "{ field: _field2, other: U32 } -> U32"))
 		(patt @19.1-19.14 (type "Error -> Str"))
-		(patt @31.1-31.10 (type "_arg, _arg2 -> _ret")))
+		(patt @27.1-27.4 (type "a -> b, Error -> Error"))
+		(patt @31.1-31.10 (type "_a -> _b -> _b")))
 	(expressions
 		(expr @4.8-4.13 (type "_arg -> _ret"))
 		(expr @7.12-7.17 (type "a -> a"))
-		(expr @11.11-11.29 (type "Error -> Str"))
+		(expr @11.11-11.30 (type "Error -> Str"))
 		(expr @15.12-15.33 (type "{ field: _field2, other: U32 } -> U32"))
 		(expr @19.17-23.6 (type "Error -> Str"))
-		(expr @31.13-31.21 (type "_arg, _arg2 -> _ret"))))
+		(expr @27.7-27.16 (type "a -> b, Error -> Error"))
+		(expr @31.13-31.22 (type "_a -> _b -> _b"))))
 ~~~

--- a/src/snapshots/type_function_basic.md
+++ b/src/snapshots/type_function_basic.md
@@ -8,67 +8,19 @@ type=file
 app [main!] { pf: platform "../basic-cli/main.roc" }
 
 apply : (_a -> _b) -> _a -> _b
-apply = |fn, x| fn(x)
+apply = |fn| |x| fn(x)
 
 main! = |_| {}
 ~~~
 # EXPECTED
-UNEXPECTED TOKEN IN EXPRESSION - type_function_basic.md:3:20:3:22
-PARSE ERROR - type_function_basic.md:3:29:3:31
-INVALID STATEMENT - type_function_basic.md:3:20:3:22
-INVALID STATEMENT - type_function_basic.md:3:23:3:31
+NIL
 # PROBLEMS
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **->** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**type_function_basic.md:3:20:3:22:**
-```roc
-apply : (_a -> _b) -> _a -> _b
-```
-                   ^^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expr_arrow_expects_ident`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**type_function_basic.md:3:29:3:31:**
-```roc
-apply : (_a -> _b) -> _a -> _b
-```
-                            ^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_function_basic.md:3:20:3:22:**
-```roc
-apply : (_a -> _b) -> _a -> _b
-```
-                   ^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_function_basic.md:3:23:3:31:**
-```roc
-apply : (_a -> _b) -> _a -> _b
-```
-                      ^^^^^^^^
-
-
+NIL
 # TOKENS
 ~~~zig
 KwApp(1:1-1:4),OpenSquare(1:5-1:6),LowerIdent(1:6-1:11),CloseSquare(1:11-1:12),OpenCurly(1:13-1:14),LowerIdent(1:15-1:17),OpColon(1:17-1:18),KwPlatform(1:19-1:27),StringStart(1:28-1:29),StringPart(1:29-1:50),StringEnd(1:50-1:51),CloseCurly(1:52-1:53),
 LowerIdent(3:1-3:6),OpColon(3:7-3:8),OpenRound(3:9-3:10),NamedUnderscore(3:10-3:12),OpArrow(3:13-3:15),NamedUnderscore(3:16-3:18),CloseRound(3:18-3:19),OpArrow(3:20-3:22),NamedUnderscore(3:23-3:25),OpArrow(3:26-3:28),NamedUnderscore(3:29-3:31),
-LowerIdent(4:1-4:6),OpAssign(4:7-4:8),OpBar(4:9-4:10),LowerIdent(4:10-4:12),Comma(4:12-4:13),LowerIdent(4:14-4:15),OpBar(4:15-4:16),LowerIdent(4:17-4:19),NoSpaceOpenRound(4:19-4:20),LowerIdent(4:20-4:21),CloseRound(4:21-4:22),
+LowerIdent(4:1-4:6),OpAssign(4:7-4:8),OpBar(4:9-4:10),LowerIdent(4:10-4:12),OpBar(4:12-4:13),OpBar(4:14-4:15),LowerIdent(4:15-4:16),OpBar(4:16-4:17),LowerIdent(4:18-4:20),NoSpaceOpenRound(4:20-4:21),LowerIdent(4:21-4:22),CloseRound(4:22-4:23),
 LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBar(6:11-6:12),OpenCurly(6:13-6:14),CloseCurly(6:14-6:15),EndOfFile(6:15-6:15),
 ~~~
 # PARSE
@@ -86,21 +38,25 @@ LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBa
 				(e-string @1.28-1.51
 					(e-string-part @1.29-1.50 (raw "../basic-cli/main.roc"))))))
 	(statements
-		(s-type-anno @3.1-3.19 (name "apply")
-			(ty-fn @3.10-3.18
-				(underscore-ty-var @3.10-3.12 (raw "_a"))
-				(underscore-ty-var @3.16-3.18 (raw "_b"))))
-		(e-malformed @3.20-3.22 (reason "expr_unexpected_token"))
-		(e-malformed @3.29-3.31 (reason "expr_arrow_expects_ident"))
-		(s-decl @4.1-4.22
+		(s-type-anno @3.1-3.31 (name "apply")
+			(ty-fn @3.9-3.31
+				(ty-fn @3.10-3.18
+					(underscore-ty-var @3.10-3.12 (raw "_a"))
+					(underscore-ty-var @3.16-3.18 (raw "_b")))
+				(ty-fn @3.23-3.31
+					(underscore-ty-var @3.23-3.25 (raw "_a"))
+					(underscore-ty-var @3.29-3.31 (raw "_b")))))
+		(s-decl @4.1-4.23
 			(p-ident @4.1-4.6 (raw "apply"))
-			(e-lambda @4.9-4.22
+			(e-lambda @4.9-4.23
 				(args
-					(p-ident @4.10-4.12 (raw "fn"))
-					(p-ident @4.14-4.15 (raw "x")))
-				(e-apply @4.17-4.22
-					(e-ident @4.17-4.19 (raw "fn"))
-					(e-ident @4.20-4.21 (raw "x")))))
+					(p-ident @4.10-4.12 (raw "fn")))
+				(e-lambda @4.14-4.23
+					(args
+						(p-ident @4.15-4.16 (raw "x")))
+					(e-apply @4.18-4.23
+						(e-ident @4.18-4.20 (raw "fn"))
+						(e-ident @4.21-4.22 (raw "x"))))))
 		(s-decl @6.1-6.15
 			(p-ident @6.1-6.6 (raw "main!"))
 			(e-lambda @6.9-6.15
@@ -110,28 +66,34 @@ LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBa
 ~~~
 # FORMATTED
 ~~~roc
-app [main!] { pf: platform "../basic-cli/main.roc" }
-
-apply : (_a -> _b)
-
-apply = |fn, x| fn(x)
-
-main! = |_| {}
+NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
 (can-ir
 	(d-let
 		(p-assign @4.1-4.6 (ident "apply"))
-		(e-lambda @4.9-4.22
+		(e-lambda @4.9-4.23
 			(args
-				(p-assign @4.10-4.12 (ident "fn"))
-				(p-assign @4.14-4.15 (ident "x")))
-			(e-call @4.17-4.22
-				(e-lookup-local @4.17-4.19
-					(p-assign @4.10-4.12 (ident "fn")))
-				(e-lookup-local @4.20-4.21
-					(p-assign @4.14-4.15 (ident "x"))))))
+				(p-assign @4.10-4.12 (ident "fn")))
+			(e-lambda @4.14-4.23
+				(args
+					(p-assign @4.15-4.16 (ident "x")))
+				(e-call @4.18-4.23
+					(e-lookup-local @4.18-4.20
+						(p-assign @4.10-4.12 (ident "fn")))
+					(e-lookup-local @4.21-4.22
+						(p-assign @4.15-4.16 (ident "x"))))))
+		(annotation @4.1-4.6
+			(declared-type
+				(ty-fn @3.9-3.31 (effectful false)
+					(ty-parens @3.9-3.19
+						(ty-fn @3.10-3.18 (effectful false)
+							(ty-var @3.10-3.12 (name "_a"))
+							(ty-var @3.16-3.18 (name "_b"))))
+					(ty-fn @3.23-3.31 (effectful false)
+						(ty-var @3.23-3.25 (name "_a"))
+						(ty-var @3.29-3.31 (name "_b")))))))
 	(d-let
 		(p-assign @6.1-6.6 (ident "main!"))
 		(e-lambda @6.9-6.15
@@ -143,9 +105,9 @@ main! = |_| {}
 ~~~clojure
 (inferred-types
 	(defs
-		(patt @4.1-4.6 (type "_arg -> ret, _arg2 -> ret2"))
+		(patt @4.1-4.6 (type "_a -> _b -> _a -> _b"))
 		(patt @6.1-6.6 (type "_arg -> {}")))
 	(expressions
-		(expr @4.9-4.22 (type "_arg -> ret, _arg2 -> ret2"))
+		(expr @4.9-4.23 (type "_a -> _b -> _a -> _b"))
 		(expr @6.9-6.15 (type "_arg -> {}"))))
 ~~~

--- a/src/snapshots/type_function_effectful.md
+++ b/src/snapshots/type_function_effectful.md
@@ -8,91 +8,19 @@ type=file
 app [main!] { pf: platform "../basic-cli/main.roc" }
 
 runEffect! : (_a => _b) -> _a => _b
-runEffect! = |fn!, x| fn!(x)
+runEffect! = |fn!| |x| fn!(x)
 
 main! = |_| {}
 ~~~
 # EXPECTED
-UNEXPECTED TOKEN IN EXPRESSION - type_function_effectful.md:3:25:3:27
-UNEXPECTED TOKEN IN EXPRESSION - type_function_effectful.md:3:31:3:33
-INVALID STATEMENT - type_function_effectful.md:3:25:3:27
-INVALID STATEMENT - type_function_effectful.md:3:28:3:30
-INVALID STATEMENT - type_function_effectful.md:3:31:3:33
-INVALID STATEMENT - type_function_effectful.md:3:34:3:36
+NIL
 # PROBLEMS
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **->** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**type_function_effectful.md:3:25:3:27:**
-```roc
-runEffect! : (_a => _b) -> _a => _b
-```
-                        ^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **=>** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**type_function_effectful.md:3:31:3:33:**
-```roc
-runEffect! : (_a => _b) -> _a => _b
-```
-                              ^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_function_effectful.md:3:25:3:27:**
-```roc
-runEffect! : (_a => _b) -> _a => _b
-```
-                        ^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_function_effectful.md:3:28:3:30:**
-```roc
-runEffect! : (_a => _b) -> _a => _b
-```
-                           ^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_function_effectful.md:3:31:3:33:**
-```roc
-runEffect! : (_a => _b) -> _a => _b
-```
-                              ^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_function_effectful.md:3:34:3:36:**
-```roc
-runEffect! : (_a => _b) -> _a => _b
-```
-                                 ^^
-
-
+NIL
 # TOKENS
 ~~~zig
 KwApp(1:1-1:4),OpenSquare(1:5-1:6),LowerIdent(1:6-1:11),CloseSquare(1:11-1:12),OpenCurly(1:13-1:14),LowerIdent(1:15-1:17),OpColon(1:17-1:18),KwPlatform(1:19-1:27),StringStart(1:28-1:29),StringPart(1:29-1:50),StringEnd(1:50-1:51),CloseCurly(1:52-1:53),
 LowerIdent(3:1-3:11),OpColon(3:12-3:13),OpenRound(3:14-3:15),NamedUnderscore(3:15-3:17),OpFatArrow(3:18-3:20),NamedUnderscore(3:21-3:23),CloseRound(3:23-3:24),OpArrow(3:25-3:27),NamedUnderscore(3:28-3:30),OpFatArrow(3:31-3:33),NamedUnderscore(3:34-3:36),
-LowerIdent(4:1-4:11),OpAssign(4:12-4:13),OpBar(4:14-4:15),LowerIdent(4:15-4:18),Comma(4:18-4:19),LowerIdent(4:20-4:21),OpBar(4:21-4:22),LowerIdent(4:23-4:26),NoSpaceOpenRound(4:26-4:27),LowerIdent(4:27-4:28),CloseRound(4:28-4:29),
+LowerIdent(4:1-4:11),OpAssign(4:12-4:13),OpBar(4:14-4:15),LowerIdent(4:15-4:18),OpBar(4:18-4:19),OpBar(4:20-4:21),LowerIdent(4:21-4:22),OpBar(4:22-4:23),LowerIdent(4:24-4:27),NoSpaceOpenRound(4:27-4:28),LowerIdent(4:28-4:29),CloseRound(4:29-4:30),
 LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBar(6:11-6:12),OpenCurly(6:13-6:14),CloseCurly(6:14-6:15),EndOfFile(6:15-6:15),
 ~~~
 # PARSE
@@ -110,23 +38,25 @@ LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBa
 				(e-string @1.28-1.51
 					(e-string-part @1.29-1.50 (raw "../basic-cli/main.roc"))))))
 	(statements
-		(s-type-anno @3.1-3.24 (name "runEffect!")
-			(ty-fn @3.15-3.23
-				(underscore-ty-var @3.15-3.17 (raw "_a"))
-				(underscore-ty-var @3.21-3.23 (raw "_b"))))
-		(e-malformed @3.25-3.27 (reason "expr_unexpected_token"))
-		(e-ident @3.28-3.30 (raw "_a"))
-		(e-malformed @3.31-3.33 (reason "expr_unexpected_token"))
-		(e-ident @3.34-3.36 (raw "_b"))
-		(s-decl @4.1-4.29
+		(s-type-anno @3.1-3.36 (name "runEffect!")
+			(ty-fn @3.14-3.36
+				(ty-fn @3.15-3.23
+					(underscore-ty-var @3.15-3.17 (raw "_a"))
+					(underscore-ty-var @3.21-3.23 (raw "_b")))
+				(ty-fn @3.28-3.36
+					(underscore-ty-var @3.28-3.30 (raw "_a"))
+					(underscore-ty-var @3.34-3.36 (raw "_b")))))
+		(s-decl @4.1-4.30
 			(p-ident @4.1-4.11 (raw "runEffect!"))
-			(e-lambda @4.14-4.29
+			(e-lambda @4.14-4.30
 				(args
-					(p-ident @4.15-4.18 (raw "fn!"))
-					(p-ident @4.20-4.21 (raw "x")))
-				(e-apply @4.23-4.29
-					(e-ident @4.23-4.26 (raw "fn!"))
-					(e-ident @4.27-4.28 (raw "x")))))
+					(p-ident @4.15-4.18 (raw "fn!")))
+				(e-lambda @4.20-4.30
+					(args
+						(p-ident @4.21-4.22 (raw "x")))
+					(e-apply @4.24-4.30
+						(e-ident @4.24-4.27 (raw "fn!"))
+						(e-ident @4.28-4.29 (raw "x"))))))
 		(s-decl @6.1-6.15
 			(p-ident @6.1-6.6 (raw "main!"))
 			(e-lambda @6.9-6.15
@@ -136,29 +66,34 @@ LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBa
 ~~~
 # FORMATTED
 ~~~roc
-app [main!] { pf: platform "../basic-cli/main.roc" }
-
-runEffect! : (_a => _b)
-_a
-_b
-runEffect! = |fn!, x| fn!(x)
-
-main! = |_| {}
+NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
 (can-ir
 	(d-let
 		(p-assign @4.1-4.11 (ident "runEffect!"))
-		(e-lambda @4.14-4.29
+		(e-lambda @4.14-4.30
 			(args
-				(p-assign @4.15-4.18 (ident "fn!"))
-				(p-assign @4.20-4.21 (ident "x")))
-			(e-call @4.23-4.29
-				(e-lookup-local @4.23-4.26
-					(p-assign @4.15-4.18 (ident "fn!")))
-				(e-lookup-local @4.27-4.28
-					(p-assign @4.20-4.21 (ident "x"))))))
+				(p-assign @4.15-4.18 (ident "fn!")))
+			(e-lambda @4.20-4.30
+				(args
+					(p-assign @4.21-4.22 (ident "x")))
+				(e-call @4.24-4.30
+					(e-lookup-local @4.24-4.27
+						(p-assign @4.15-4.18 (ident "fn!")))
+					(e-lookup-local @4.28-4.29
+						(p-assign @4.21-4.22 (ident "x"))))))
+		(annotation @4.1-4.11
+			(declared-type
+				(ty-fn @3.14-3.36 (effectful false)
+					(ty-parens @3.14-3.24
+						(ty-fn @3.15-3.23 (effectful true)
+							(ty-var @3.15-3.17 (name "_a"))
+							(ty-var @3.21-3.23 (name "_b"))))
+					(ty-fn @3.28-3.36 (effectful true)
+						(ty-var @3.28-3.30 (name "_a"))
+						(ty-var @3.34-3.36 (name "_b")))))))
 	(d-let
 		(p-assign @6.1-6.6 (ident "main!"))
 		(e-lambda @6.9-6.15
@@ -170,9 +105,9 @@ main! = |_| {}
 ~~~clojure
 (inferred-types
 	(defs
-		(patt @4.1-4.11 (type "_arg -> ret, _arg2 -> ret2"))
+		(patt @4.1-4.11 (type "_a => _b -> _a => _b"))
 		(patt @6.1-6.6 (type "_arg -> {}")))
 	(expressions
-		(expr @4.14-4.29 (type "_arg -> ret, _arg2 -> ret2"))
+		(expr @4.14-4.30 (type "_a => _b -> _a => _b"))
 		(expr @6.9-6.15 (type "_arg -> {}"))))
 ~~~

--- a/src/snapshots/type_function_multi_arg.md
+++ b/src/snapshots/type_function_multi_arg.md
@@ -13,70 +13,9 @@ curry = |fn| |x| |y| fn(x, y)
 main! = |_| {}
 ~~~
 # EXPECTED
-UNEXPECTED TOKEN IN EXPRESSION - type_function_multi_arg.md:3:24:3:26
-PARSE ERROR - type_function_multi_arg.md:3:34:3:36
-PARSE ERROR - type_function_multi_arg.md:3:42:3:43
-INVALID STATEMENT - type_function_multi_arg.md:3:24:3:26
-INVALID STATEMENT - type_function_multi_arg.md:3:27:3:43
+NIL
 # PROBLEMS
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **->** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**type_function_multi_arg.md:3:24:3:26:**
-```roc
-curry : (_a, _b -> _c) -> (_a -> _b -> _c)
-```
-                       ^^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expr_arrow_expects_ident`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**type_function_multi_arg.md:3:34:3:36:**
-```roc
-curry : (_a, _b -> _c) -> (_a -> _b -> _c)
-```
-                                 ^^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expected_expr_close_round_or_comma`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**type_function_multi_arg.md:3:42:3:43:**
-```roc
-curry : (_a, _b -> _c) -> (_a -> _b -> _c)
-```
-                                         ^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_function_multi_arg.md:3:24:3:26:**
-```roc
-curry : (_a, _b -> _c) -> (_a -> _b -> _c)
-```
-                       ^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_function_multi_arg.md:3:27:3:43:**
-```roc
-curry : (_a, _b -> _c) -> (_a -> _b -> _c)
-```
-                          ^^^^^^^^^^^^^^^^
-
-
+NIL
 # TOKENS
 ~~~zig
 KwApp(1:1-1:4),OpenSquare(1:5-1:6),LowerIdent(1:6-1:11),CloseSquare(1:11-1:12),OpenCurly(1:13-1:14),LowerIdent(1:15-1:17),OpColon(1:17-1:18),KwPlatform(1:19-1:27),StringStart(1:28-1:29),StringPart(1:29-1:50),StringEnd(1:50-1:51),CloseCurly(1:52-1:53),
@@ -99,13 +38,17 @@ LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBa
 				(e-string @1.28-1.51
 					(e-string-part @1.29-1.50 (raw "../basic-cli/main.roc"))))))
 	(statements
-		(s-type-anno @3.1-3.23 (name "curry")
-			(ty-fn @3.10-3.22
-				(underscore-ty-var @3.10-3.12 (raw "_a"))
-				(underscore-ty-var @3.14-3.16 (raw "_b"))
-				(underscore-ty-var @3.20-3.22 (raw "_c"))))
-		(e-malformed @3.24-3.26 (reason "expr_unexpected_token"))
-		(e-malformed @3.42-3.43 (reason "expected_expr_close_round_or_comma"))
+		(s-type-anno @3.1-3.43 (name "curry")
+			(ty-fn @3.9-3.43
+				(ty-fn @3.10-3.22
+					(underscore-ty-var @3.10-3.12 (raw "_a"))
+					(underscore-ty-var @3.14-3.16 (raw "_b"))
+					(underscore-ty-var @3.20-3.22 (raw "_c")))
+				(ty-fn @3.28-3.42
+					(underscore-ty-var @3.28-3.30 (raw "_a"))
+					(ty-fn @3.34-3.42
+						(underscore-ty-var @3.34-3.36 (raw "_b"))
+						(underscore-ty-var @3.40-3.42 (raw "_c"))))))
 		(s-decl @4.1-4.30
 			(p-ident @4.1-4.6 (raw "curry"))
 			(e-lambda @4.9-4.30
@@ -130,13 +73,7 @@ LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBa
 ~~~
 # FORMATTED
 ~~~roc
-app [main!] { pf: platform "../basic-cli/main.roc" }
-
-curry : (_a, _b -> _c)
-
-curry = |fn| |x| |y| fn(x, y)
-
-main! = |_| {}
+NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
@@ -158,7 +95,21 @@ main! = |_| {}
 						(e-lookup-local @4.25-4.26
 							(p-assign @4.15-4.16 (ident "x")))
 						(e-lookup-local @4.28-4.29
-							(p-assign @4.19-4.20 (ident "y"))))))))
+							(p-assign @4.19-4.20 (ident "y")))))))
+		(annotation @4.1-4.6
+			(declared-type
+				(ty-fn @3.9-3.43 (effectful false)
+					(ty-parens @3.9-3.23
+						(ty-fn @3.10-3.22 (effectful false)
+							(ty-var @3.10-3.12 (name "_a"))
+							(ty-var @3.14-3.16 (name "_b"))
+							(ty-var @3.20-3.22 (name "_c"))))
+					(ty-parens @3.27-3.43
+						(ty-fn @3.28-3.42 (effectful false)
+							(ty-var @3.28-3.30 (name "_a"))
+							(ty-fn @3.34-3.42 (effectful false)
+								(ty-var @3.34-3.36 (name "_b"))
+								(ty-var @3.40-3.42 (name "_c")))))))))
 	(d-let
 		(p-assign @6.1-6.6 (ident "main!"))
 		(e-lambda @6.9-6.15
@@ -170,9 +121,9 @@ main! = |_| {}
 ~~~clojure
 (inferred-types
 	(defs
-		(patt @4.1-4.6 (type "_arg, _arg2 -> ret -> _arg3 -> _arg4 -> ret2"))
+		(patt @4.1-4.6 (type "_a, _b -> _c -> _a -> _b -> _c"))
 		(patt @6.1-6.6 (type "_arg -> {}")))
 	(expressions
-		(expr @4.9-4.30 (type "_arg, _arg2 -> ret -> _arg3 -> _arg4 -> ret2"))
+		(expr @4.9-4.30 (type "_a, _b -> _c -> _a -> _b -> _c"))
 		(expr @6.9-6.15 (type "_arg -> {}"))))
 ~~~

--- a/src/snapshots/type_function_simple.md
+++ b/src/snapshots/type_function_simple.md
@@ -8,67 +8,19 @@ type=file
 app [main!] { pf: platform "../basic-cli/main.roc" }
 
 apply : (_a -> _b) -> _a -> _b
-apply = |fn, x| fn(x)
+apply = |fn| |x| fn(x)
 
 main! = |_| {}
 ~~~
 # EXPECTED
-UNEXPECTED TOKEN IN EXPRESSION - type_function_simple.md:3:20:3:22
-PARSE ERROR - type_function_simple.md:3:29:3:31
-INVALID STATEMENT - type_function_simple.md:3:20:3:22
-INVALID STATEMENT - type_function_simple.md:3:23:3:31
+NIL
 # PROBLEMS
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **->** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**type_function_simple.md:3:20:3:22:**
-```roc
-apply : (_a -> _b) -> _a -> _b
-```
-                   ^^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expr_arrow_expects_ident`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**type_function_simple.md:3:29:3:31:**
-```roc
-apply : (_a -> _b) -> _a -> _b
-```
-                            ^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_function_simple.md:3:20:3:22:**
-```roc
-apply : (_a -> _b) -> _a -> _b
-```
-                   ^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_function_simple.md:3:23:3:31:**
-```roc
-apply : (_a -> _b) -> _a -> _b
-```
-                      ^^^^^^^^
-
-
+NIL
 # TOKENS
 ~~~zig
 KwApp(1:1-1:4),OpenSquare(1:5-1:6),LowerIdent(1:6-1:11),CloseSquare(1:11-1:12),OpenCurly(1:13-1:14),LowerIdent(1:15-1:17),OpColon(1:17-1:18),KwPlatform(1:19-1:27),StringStart(1:28-1:29),StringPart(1:29-1:50),StringEnd(1:50-1:51),CloseCurly(1:52-1:53),
 LowerIdent(3:1-3:6),OpColon(3:7-3:8),OpenRound(3:9-3:10),NamedUnderscore(3:10-3:12),OpArrow(3:13-3:15),NamedUnderscore(3:16-3:18),CloseRound(3:18-3:19),OpArrow(3:20-3:22),NamedUnderscore(3:23-3:25),OpArrow(3:26-3:28),NamedUnderscore(3:29-3:31),
-LowerIdent(4:1-4:6),OpAssign(4:7-4:8),OpBar(4:9-4:10),LowerIdent(4:10-4:12),Comma(4:12-4:13),LowerIdent(4:14-4:15),OpBar(4:15-4:16),LowerIdent(4:17-4:19),NoSpaceOpenRound(4:19-4:20),LowerIdent(4:20-4:21),CloseRound(4:21-4:22),
+LowerIdent(4:1-4:6),OpAssign(4:7-4:8),OpBar(4:9-4:10),LowerIdent(4:10-4:12),OpBar(4:12-4:13),OpBar(4:14-4:15),LowerIdent(4:15-4:16),OpBar(4:16-4:17),LowerIdent(4:18-4:20),NoSpaceOpenRound(4:20-4:21),LowerIdent(4:21-4:22),CloseRound(4:22-4:23),
 LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBar(6:11-6:12),OpenCurly(6:13-6:14),CloseCurly(6:14-6:15),EndOfFile(6:15-6:15),
 ~~~
 # PARSE
@@ -86,21 +38,25 @@ LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBa
 				(e-string @1.28-1.51
 					(e-string-part @1.29-1.50 (raw "../basic-cli/main.roc"))))))
 	(statements
-		(s-type-anno @3.1-3.19 (name "apply")
-			(ty-fn @3.10-3.18
-				(underscore-ty-var @3.10-3.12 (raw "_a"))
-				(underscore-ty-var @3.16-3.18 (raw "_b"))))
-		(e-malformed @3.20-3.22 (reason "expr_unexpected_token"))
-		(e-malformed @3.29-3.31 (reason "expr_arrow_expects_ident"))
-		(s-decl @4.1-4.22
+		(s-type-anno @3.1-3.31 (name "apply")
+			(ty-fn @3.9-3.31
+				(ty-fn @3.10-3.18
+					(underscore-ty-var @3.10-3.12 (raw "_a"))
+					(underscore-ty-var @3.16-3.18 (raw "_b")))
+				(ty-fn @3.23-3.31
+					(underscore-ty-var @3.23-3.25 (raw "_a"))
+					(underscore-ty-var @3.29-3.31 (raw "_b")))))
+		(s-decl @4.1-4.23
 			(p-ident @4.1-4.6 (raw "apply"))
-			(e-lambda @4.9-4.22
+			(e-lambda @4.9-4.23
 				(args
-					(p-ident @4.10-4.12 (raw "fn"))
-					(p-ident @4.14-4.15 (raw "x")))
-				(e-apply @4.17-4.22
-					(e-ident @4.17-4.19 (raw "fn"))
-					(e-ident @4.20-4.21 (raw "x")))))
+					(p-ident @4.10-4.12 (raw "fn")))
+				(e-lambda @4.14-4.23
+					(args
+						(p-ident @4.15-4.16 (raw "x")))
+					(e-apply @4.18-4.23
+						(e-ident @4.18-4.20 (raw "fn"))
+						(e-ident @4.21-4.22 (raw "x"))))))
 		(s-decl @6.1-6.15
 			(p-ident @6.1-6.6 (raw "main!"))
 			(e-lambda @6.9-6.15
@@ -110,28 +66,34 @@ LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBa
 ~~~
 # FORMATTED
 ~~~roc
-app [main!] { pf: platform "../basic-cli/main.roc" }
-
-apply : (_a -> _b)
-
-apply = |fn, x| fn(x)
-
-main! = |_| {}
+NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
 (can-ir
 	(d-let
 		(p-assign @4.1-4.6 (ident "apply"))
-		(e-lambda @4.9-4.22
+		(e-lambda @4.9-4.23
 			(args
-				(p-assign @4.10-4.12 (ident "fn"))
-				(p-assign @4.14-4.15 (ident "x")))
-			(e-call @4.17-4.22
-				(e-lookup-local @4.17-4.19
-					(p-assign @4.10-4.12 (ident "fn")))
-				(e-lookup-local @4.20-4.21
-					(p-assign @4.14-4.15 (ident "x"))))))
+				(p-assign @4.10-4.12 (ident "fn")))
+			(e-lambda @4.14-4.23
+				(args
+					(p-assign @4.15-4.16 (ident "x")))
+				(e-call @4.18-4.23
+					(e-lookup-local @4.18-4.20
+						(p-assign @4.10-4.12 (ident "fn")))
+					(e-lookup-local @4.21-4.22
+						(p-assign @4.15-4.16 (ident "x"))))))
+		(annotation @4.1-4.6
+			(declared-type
+				(ty-fn @3.9-3.31 (effectful false)
+					(ty-parens @3.9-3.19
+						(ty-fn @3.10-3.18 (effectful false)
+							(ty-var @3.10-3.12 (name "_a"))
+							(ty-var @3.16-3.18 (name "_b"))))
+					(ty-fn @3.23-3.31 (effectful false)
+						(ty-var @3.23-3.25 (name "_a"))
+						(ty-var @3.29-3.31 (name "_b")))))))
 	(d-let
 		(p-assign @6.1-6.6 (ident "main!"))
 		(e-lambda @6.9-6.15
@@ -143,9 +105,9 @@ main! = |_| {}
 ~~~clojure
 (inferred-types
 	(defs
-		(patt @4.1-4.6 (type "_arg -> ret, _arg2 -> ret2"))
+		(patt @4.1-4.6 (type "_a -> _b -> _a -> _b"))
 		(patt @6.1-6.6 (type "_arg -> {}")))
 	(expressions
-		(expr @4.9-4.22 (type "_arg -> ret, _arg2 -> ret2"))
+		(expr @4.9-4.23 (type "_a -> _b -> _a -> _b"))
 		(expr @6.9-6.15 (type "_arg -> {}"))))
 ~~~

--- a/src/snapshots/type_higher_order_multiple_vars.md
+++ b/src/snapshots/type_higher_order_multiple_vars.md
@@ -8,130 +8,19 @@ type=file
 app [main!] { pf: platform "../basic-cli/main.roc" }
 
 compose : (_b -> _c) -> (_a -> _b) -> (_a -> _c)
-compose = |f, g| |x| f(g(x))
+compose = |f| |g| |x| f(g(x))
 
 main! = |_| {}
 ~~~
 # EXPECTED
-UNEXPECTED TOKEN IN EXPRESSION - type_higher_order_multiple_vars.md:3:22:3:24
-PARSE ERROR - type_higher_order_multiple_vars.md:3:32:3:34
-PARSE ERROR - type_higher_order_multiple_vars.md:3:39:3:40
-PARSE ERROR - type_higher_order_multiple_vars.md:3:46:3:48
-UNEXPECTED TOKEN IN EXPRESSION - type_higher_order_multiple_vars.md:3:48:3:49
-INVALID STATEMENT - type_higher_order_multiple_vars.md:3:22:3:24
-INVALID STATEMENT - type_higher_order_multiple_vars.md:3:25:3:40
-INVALID STATEMENT - type_higher_order_multiple_vars.md:3:40:3:48
-INVALID STATEMENT - type_higher_order_multiple_vars.md:3:48:3:49
+NIL
 # PROBLEMS
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **->** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**type_higher_order_multiple_vars.md:3:22:3:24:**
-```roc
-compose : (_b -> _c) -> (_a -> _b) -> (_a -> _c)
-```
-                     ^^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expr_arrow_expects_ident`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**type_higher_order_multiple_vars.md:3:32:3:34:**
-```roc
-compose : (_b -> _c) -> (_a -> _b) -> (_a -> _c)
-```
-                               ^^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expr_arrow_expects_ident`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**type_higher_order_multiple_vars.md:3:39:3:40:**
-```roc
-compose : (_b -> _c) -> (_a -> _b) -> (_a -> _c)
-```
-                                      ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `expr_arrow_expects_ident`
-This is an unexpected parsing error. Please check your syntax.
-
-Here is the problematic code:
-**type_higher_order_multiple_vars.md:3:46:3:48:**
-```roc
-compose : (_b -> _c) -> (_a -> _b) -> (_a -> _c)
-```
-                                             ^^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **)** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-Here is the problematic code:
-**type_higher_order_multiple_vars.md:3:48:3:49:**
-```roc
-compose : (_b -> _c) -> (_a -> _b) -> (_a -> _c)
-```
-                                               ^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_higher_order_multiple_vars.md:3:22:3:24:**
-```roc
-compose : (_b -> _c) -> (_a -> _b) -> (_a -> _c)
-```
-                     ^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_higher_order_multiple_vars.md:3:25:3:40:**
-```roc
-compose : (_b -> _c) -> (_a -> _b) -> (_a -> _c)
-```
-                        ^^^^^^^^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_higher_order_multiple_vars.md:3:40:3:48:**
-```roc
-compose : (_b -> _c) -> (_a -> _b) -> (_a -> _c)
-```
-                                       ^^^^^^^^
-
-
-**INVALID STATEMENT**
-The statement `expression` is not allowed at the top level.
-Only definitions, type annotations, and imports are allowed at the top level.
-
-**type_higher_order_multiple_vars.md:3:48:3:49:**
-```roc
-compose : (_b -> _c) -> (_a -> _b) -> (_a -> _c)
-```
-                                               ^
-
-
+NIL
 # TOKENS
 ~~~zig
 KwApp(1:1-1:4),OpenSquare(1:5-1:6),LowerIdent(1:6-1:11),CloseSquare(1:11-1:12),OpenCurly(1:13-1:14),LowerIdent(1:15-1:17),OpColon(1:17-1:18),KwPlatform(1:19-1:27),StringStart(1:28-1:29),StringPart(1:29-1:50),StringEnd(1:50-1:51),CloseCurly(1:52-1:53),
 LowerIdent(3:1-3:8),OpColon(3:9-3:10),OpenRound(3:11-3:12),NamedUnderscore(3:12-3:14),OpArrow(3:15-3:17),NamedUnderscore(3:18-3:20),CloseRound(3:20-3:21),OpArrow(3:22-3:24),OpenRound(3:25-3:26),NamedUnderscore(3:26-3:28),OpArrow(3:29-3:31),NamedUnderscore(3:32-3:34),CloseRound(3:34-3:35),OpArrow(3:36-3:38),OpenRound(3:39-3:40),NamedUnderscore(3:40-3:42),OpArrow(3:43-3:45),NamedUnderscore(3:46-3:48),CloseRound(3:48-3:49),
-LowerIdent(4:1-4:8),OpAssign(4:9-4:10),OpBar(4:11-4:12),LowerIdent(4:12-4:13),Comma(4:13-4:14),LowerIdent(4:15-4:16),OpBar(4:16-4:17),OpBar(4:18-4:19),LowerIdent(4:19-4:20),OpBar(4:20-4:21),LowerIdent(4:22-4:23),NoSpaceOpenRound(4:23-4:24),LowerIdent(4:24-4:25),NoSpaceOpenRound(4:25-4:26),LowerIdent(4:26-4:27),CloseRound(4:27-4:28),CloseRound(4:28-4:29),
+LowerIdent(4:1-4:8),OpAssign(4:9-4:10),OpBar(4:11-4:12),LowerIdent(4:12-4:13),OpBar(4:13-4:14),OpBar(4:15-4:16),LowerIdent(4:16-4:17),OpBar(4:17-4:18),OpBar(4:19-4:20),LowerIdent(4:20-4:21),OpBar(4:21-4:22),LowerIdent(4:23-4:24),NoSpaceOpenRound(4:24-4:25),LowerIdent(4:25-4:26),NoSpaceOpenRound(4:26-4:27),LowerIdent(4:27-4:28),CloseRound(4:28-4:29),CloseRound(4:29-4:30),
 LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBar(6:11-6:12),OpenCurly(6:13-6:14),CloseCurly(6:14-6:15),EndOfFile(6:15-6:15),
 ~~~
 # PARSE
@@ -149,28 +38,34 @@ LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBa
 				(e-string @1.28-1.51
 					(e-string-part @1.29-1.50 (raw "../basic-cli/main.roc"))))))
 	(statements
-		(s-type-anno @3.1-3.21 (name "compose")
-			(ty-fn @3.12-3.20
-				(underscore-ty-var @3.12-3.14 (raw "_b"))
-				(underscore-ty-var @3.18-3.20 (raw "_c"))))
-		(e-malformed @3.22-3.24 (reason "expr_unexpected_token"))
-		(e-malformed @3.39-3.40 (reason "expr_arrow_expects_ident"))
-		(e-malformed @3.46-3.48 (reason "expr_arrow_expects_ident"))
-		(e-malformed @3.48-3.49 (reason "expr_unexpected_token"))
-		(s-decl @4.1-4.29
+		(s-type-anno @3.1-3.49 (name "compose")
+			(ty-fn @3.11-3.49
+				(ty-fn @3.12-3.20
+					(underscore-ty-var @3.12-3.14 (raw "_b"))
+					(underscore-ty-var @3.18-3.20 (raw "_c")))
+				(ty-fn @3.25-3.49
+					(ty-fn @3.26-3.34
+						(underscore-ty-var @3.26-3.28 (raw "_a"))
+						(underscore-ty-var @3.32-3.34 (raw "_b")))
+					(ty-fn @3.40-3.48
+						(underscore-ty-var @3.40-3.42 (raw "_a"))
+						(underscore-ty-var @3.46-3.48 (raw "_c"))))))
+		(s-decl @4.1-4.30
 			(p-ident @4.1-4.8 (raw "compose"))
-			(e-lambda @4.11-4.29
+			(e-lambda @4.11-4.30
 				(args
-					(p-ident @4.12-4.13 (raw "f"))
-					(p-ident @4.15-4.16 (raw "g")))
-				(e-lambda @4.18-4.29
+					(p-ident @4.12-4.13 (raw "f")))
+				(e-lambda @4.15-4.30
 					(args
-						(p-ident @4.19-4.20 (raw "x")))
-					(e-apply @4.22-4.29
-						(e-ident @4.22-4.23 (raw "f"))
-						(e-apply @4.24-4.28
-							(e-ident @4.24-4.25 (raw "g"))
-							(e-ident @4.26-4.27 (raw "x")))))))
+						(p-ident @4.16-4.17 (raw "g")))
+					(e-lambda @4.19-4.30
+						(args
+							(p-ident @4.20-4.21 (raw "x")))
+						(e-apply @4.23-4.30
+							(e-ident @4.23-4.24 (raw "f"))
+							(e-apply @4.25-4.29
+								(e-ident @4.25-4.26 (raw "g"))
+								(e-ident @4.27-4.28 (raw "x"))))))))
 		(s-decl @6.1-6.15
 			(p-ident @6.1-6.6 (raw "main!"))
 			(e-lambda @6.9-6.15
@@ -180,34 +75,46 @@ LowerIdent(6:1-6:6),OpAssign(6:7-6:8),OpBar(6:9-6:10),Underscore(6:10-6:11),OpBa
 ~~~
 # FORMATTED
 ~~~roc
-app [main!] { pf: platform "../basic-cli/main.roc" }
-
-compose : (_b -> _c)
-
-compose = |f, g| |x| f(g(x))
-
-main! = |_| {}
+NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
 (can-ir
 	(d-let
 		(p-assign @4.1-4.8 (ident "compose"))
-		(e-lambda @4.11-4.29
+		(e-lambda @4.11-4.30
 			(args
-				(p-assign @4.12-4.13 (ident "f"))
-				(p-assign @4.15-4.16 (ident "g")))
-			(e-lambda @4.18-4.29
+				(p-assign @4.12-4.13 (ident "f")))
+			(e-lambda @4.15-4.30
 				(args
-					(p-assign @4.19-4.20 (ident "x")))
-				(e-call @4.22-4.29
-					(e-lookup-local @4.22-4.23
-						(p-assign @4.12-4.13 (ident "f")))
-					(e-call @4.24-4.28
-						(e-lookup-local @4.24-4.25
-							(p-assign @4.15-4.16 (ident "g")))
-						(e-lookup-local @4.26-4.27
-							(p-assign @4.19-4.20 (ident "x"))))))))
+					(p-assign @4.16-4.17 (ident "g")))
+				(e-lambda @4.19-4.30
+					(args
+						(p-assign @4.20-4.21 (ident "x")))
+					(e-call @4.23-4.30
+						(e-lookup-local @4.23-4.24
+							(p-assign @4.12-4.13 (ident "f")))
+						(e-call @4.25-4.29
+							(e-lookup-local @4.25-4.26
+								(p-assign @4.16-4.17 (ident "g")))
+							(e-lookup-local @4.27-4.28
+								(p-assign @4.20-4.21 (ident "x"))))))))
+		(annotation @4.1-4.8
+			(declared-type
+				(ty-fn @3.11-3.49 (effectful false)
+					(ty-parens @3.11-3.21
+						(ty-fn @3.12-3.20 (effectful false)
+							(ty-var @3.12-3.14 (name "_b"))
+							(ty-var @3.18-3.20 (name "_c"))))
+					(ty-fn @3.25-3.49 (effectful false)
+						(ty-parens @3.25-3.35
+							(ty-fn @3.26-3.34 (effectful false)
+								(ty-var @3.26-3.28 (name "_a"))
+								(ty-var @3.32-3.34 (name "_b"))))
+						(ty-parens @3.39-3.49
+							(ty-fn @3.40-3.48 (effectful false)
+								(ty-var @3.40-3.42 (name "_a"))
+								(ty-var @3.46-3.48 (name "_c")))))))))
 	(d-let
 		(p-assign @6.1-6.6 (ident "main!"))
 		(e-lambda @6.9-6.15
@@ -219,9 +126,9 @@ main! = |_| {}
 ~~~clojure
 (inferred-types
 	(defs
-		(patt @4.1-4.8 (type "arg -> ret, _arg2 -> ret2 -> _arg3 -> ret3"))
+		(patt @4.1-4.8 (type "_b -> _c -> _a -> _b -> _a -> _c"))
 		(patt @6.1-6.6 (type "_arg -> {}")))
 	(expressions
-		(expr @4.11-4.29 (type "arg -> ret, _arg2 -> ret2 -> _arg3 -> ret3"))
+		(expr @4.11-4.30 (type "_b -> _c -> _a -> _b -> _a -> _c"))
 		(expr @6.9-6.15 (type "_arg -> {}"))))
 ~~~


### PR DESCRIPTION
It uses lookahead to distinguish between higher order functions and tuples.

```roc
f : (_b -> _c) -> (_a, _b) -> (_a -> _c)
```

Closes #7955