### PR TITLE
Implement multiline lambda arguments on comma while fixing a parse fuzz crash

### DIFF
--- a/src/check/parse/AST.zig
+++ b/src/check/parse/AST.zig
@@ -60,7 +60,8 @@ pub fn regionIsMultiline(self: *AST, region: TokenizedRegion) bool {
     while (i < region.end) {
         if (tags[i] == .Comma and i + 1 < self.tokens.tokens.len and (tags[i + 1] == .CloseSquare or
             tags[i + 1] == .CloseRound or
-            tags[i + 1] == .CloseCurly))
+            tags[i + 1] == .CloseCurly or
+            tags[i + 1] == .OpBar))
         {
             return true;
         }

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -964,7 +964,7 @@ const Formatter = struct {
                 const args = fmt.ast.store.patternSlice(l.args);
                 const body_region = fmt.nodeRegion(@intFromEnum(l.body));
                 const args_region = fmt.regionInSlice(AST.Pattern.Idx, args);
-                const args_are_multiline = args.len > 0 and fmt.ast.regionIsMultiline(args_region);
+                const args_are_multiline = args.len > 0 and fmt.ast.regionIsMultiline(.{ .start = args_region.start - 1, .end = args_region.end + 1 });
                 try fmt.push('|');
                 if (args_are_multiline) {
                     fmt.curr_indent += 1;

--- a/src/snapshots/formatting/singleline_with_comma/everything.md
+++ b/src/snapshots/formatting/singleline_with_comma/everything.md
@@ -402,7 +402,10 @@ F : [
 
 g : e -> e where module(e).A, module(e).B
 
-h = |x, y| {
+h = |
+	x,
+	y,
+| {
 	h1 = {
 		h11: x,
 		h12: x,

--- a/src/snapshots/fuzz_crash/fuzz_crash_019.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_019.md
@@ -1330,7 +1330,10 @@ add = |num| {
 	}
 }
 
-me = |a, Tb| # As
+me = |
+	a,
+	Tb,
+| # As
 	match a {
 		lue => {
 			x

--- a/src/snapshots/fuzz_crash/fuzz_crash_020.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_020.md
@@ -1326,7 +1326,9 @@ add = |Rum| {
 	}
 }
 
-me = |a| # As
+me = |
+	a, # b,
+| # As
 	match a {
 		lue => {
 			x

--- a/src/snapshots/fuzz_crash/fuzz_crash_062.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_062.md
@@ -1,0 +1,64 @@
+# META
+~~~ini
+description=Higher-order function type annotation without outer parentheses
+type=file
+~~~
+# SOURCE
+~~~roc
+module[}|0
+as s|||0
+~~~
+# EXPECTED
+MISMATCHED BRACE - :0:0:0:0
+INVALID STATEMENT - fuzz_crash_062.md:1:9:2:9
+# PROBLEMS
+**MISMATCHED BRACE**
+This brace does not match the corresponding opening brace.
+
+**INVALID STATEMENT**
+The statement `expression` is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_062.md:1:9:2:9:**
+```roc
+module[}|0
+as s|||0
+```
+
+
+# TOKENS
+~~~zig
+KwModule(1:1-1:7),OpenSquare(1:7-1:8),CloseSquare(1:8-1:9),OpBar(1:9-1:10),Int(1:10-1:11),
+KwAs(2:1-2:3),LowerIdent(2:4-2:5),OpBar(2:5-2:6),OpBar(2:6-2:7),OpBar(2:7-2:8),Int(2:8-2:9),EndOfFile(2:9-2:9),
+~~~
+# PARSE
+~~~clojure
+(file @1.1-2.9
+	(module @1.1-1.9
+		(exposes @1.7-1.9))
+	(statements
+		(e-lambda @1.9-2.9
+			(args
+				(p-as @1.10-2.3 (name "s")
+					(p-int @1.10-1.11 (raw "0"))))
+			(e-lambda @2.6-2.9
+				(args)
+				(e-int @2.8-2.9 (raw "0"))))))
+~~~
+# FORMATTED
+~~~roc
+module []
+|
+	0 as s,
+| || 0
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir (empty true))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(expressions))
+~~~


### PR DESCRIPTION
```
zig build repro-parse -- -b bW9kdWxlW318MAphcyBzfHx8MA== -v
```