### PR TITLE
Update source ownership and make source come from a consistent place

### DIFF
--- a/src/base/ModuleEnv.zig
+++ b/src/base/ModuleEnv.zig
@@ -60,18 +60,16 @@ pub fn deinit(self: *Self) void {
     self.line_starts.deinit(self.gpa);
     self.exposed_by_str.deinit(self.gpa);
     self.exposed_nodes.deinit(self.gpa);
-
-    self.gpa.free(self.source);
 }
 
 /// Calculate and store line starts from the source text
-pub fn calcLineStarts(self: *Self, source: []const u8) !void {
+pub fn calcLineStarts(self: *Self) !void {
     // Reset line_starts by creating a new SafeList
     self.line_starts.deinit(self.gpa);
     self.line_starts = try collections.SafeList(u32).initCapacity(self.gpa, 256);
 
     // if the source is empty, we're done
-    if (source.len == 0) {
+    if (self.source.len == 0) {
         return;
     }
 
@@ -80,7 +78,7 @@ pub fn calcLineStarts(self: *Self, source: []const u8) !void {
 
     // find all newlines in the source, save their offset
     var pos: u32 = 0;
-    for (source) |c| {
+    for (self.source) |c| {
         if (c == '\n') {
             // next line starts after the newline in the current position
             _ = try self.line_starts.append(self.gpa, pos + 1);

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -80,8 +80,12 @@ fn benchParseOrTokenize(comptime is_parse: bool, gpa: Allocator, path: []const u
         for (roc_files.items) |roc_file| {
             if (is_parse) {
                 // Parse mode
-                var parse_env = try base.ModuleEnv.init(gpa, roc_file.content);
-                var ir = try parse.parse(&parse_env, roc_file.content);
+
+                // ModuleEnv takes ownership of the source code, so we need to dupe it each iteration
+                const source_copy = try gpa.dupe(u8, roc_file.content);
+                var parse_env = try base.ModuleEnv.init(gpa, source_copy);
+
+                var ir = try parse.parse(&parse_env);
                 iteration_tokens += ir.tokens.tokens.len;
                 ir.deinit(gpa);
                 parse_env.deinit();

--- a/src/cache/CacheManager.zig
+++ b/src/cache/CacheManager.zig
@@ -22,11 +22,9 @@ const CIR = canonicalize.CIR;
 pub const CacheResult = union(enum) {
     hit: coordinate_simple.ProcessResult,
     miss: struct {
-        source: []const u8,
+        key: [32]u8,
     },
-    invalid: struct {
-        source: []const u8,
-    },
+    not_enabled,
 };
 
 /// Cache manager using BLAKE3-based keys.
@@ -55,30 +53,21 @@ pub const CacheManager = struct {
     /// Look up a cache entry by content and compiler version.
     ///
     /// Returns CacheResult indicating hit, miss, or invalid entry.
-    /// IMPORTANT: This function takes ownership of source only.
-    /// compiler_version is borrowed (not owned).
-    /// On cache miss/invalid, source is returned in the result for the caller to reuse.
+    /// Both source and compiler_version are borrowed (not owned).
     pub fn loadFromCache(
         self: *Self,
-        source: []const u8,
         compiler_version: []const u8,
+        source: []const u8,
     ) CacheResult {
         if (!self.config.enabled) {
-            return CacheResult{ .miss = .{
-                .source = source,
-            } };
+            return .not_enabled;
         }
 
-        const cache_key = self.generateCacheKey(source, compiler_version) catch {
-            return CacheResult{ .miss = .{
-                .source = source,
-            } };
-        };
-        defer self.allocator.free(cache_key);
+        const cache_key = generateCacheKey(source, compiler_version);
 
         const cache_path = self.getCacheFilePath(cache_key) catch {
             return CacheResult{ .miss = .{
-                .source = source,
+                .key = cache_key,
             } };
         };
         defer self.allocator.free(cache_path);
@@ -88,7 +77,7 @@ pub const CacheManager = struct {
         if (!exists) {
             self.stats.recordMiss();
             return CacheResult{ .miss = .{
-                .source = source,
+                .key = cache_key,
             } };
         }
 
@@ -99,7 +88,7 @@ pub const CacheManager = struct {
             }
             self.stats.recordMiss();
             return CacheResult{ .miss = .{
-                .source = source,
+                .key = cache_key,
             } };
         };
         defer mapped_cache.deinit(self.allocator);
@@ -114,8 +103,8 @@ pub const CacheManager = struct {
                 std.log.debug("Failed to restore from cache {s}: {}", .{ cache_path, err });
             }
             self.stats.recordInvalidation();
-            return CacheResult{ .invalid = .{
-                .source = source,
+            return CacheResult{ .miss = .{
+                .key = cache_key,
             } };
         };
 
@@ -128,16 +117,10 @@ pub const CacheManager = struct {
     ///
     /// Serializes the ProcessResult and stores it in the cache using BLAKE3-based
     /// filenames with subdirectory splitting.
-    pub fn store(self: *Self, content: []const u8, compiler_version: []const u8, process_result: *const coordinate_simple.ProcessResult) !void {
+    pub fn store(self: *Self, cache_key: [32]u8, process_result: *const coordinate_simple.ProcessResult) !void {
         if (!self.config.enabled) {
             return;
         }
-
-        const cache_key = self.generateCacheKey(content, compiler_version) catch {
-            self.stats.recordStoreFailure();
-            return;
-        };
-        defer self.allocator.free(cache_key);
 
         // Ensure cache subdirectory exists
         self.ensureCacheSubdir(cache_key) catch |err| {
@@ -193,32 +176,31 @@ pub const CacheManager = struct {
     }
 
     /// Generate a BLAKE3-based cache key from source and compiler version.
-    fn generateCacheKey(self: *Self, source: []const u8, compiler_version: []const u8) ![]u8 {
-        // Combine source and compiler version
-        const combined = try std.fmt.allocPrint(self.allocator, "{s}|{s}", .{ source, compiler_version });
-        defer self.allocator.free(combined);
-
-        // Hash with BLAKE3
-        const hash = cache_mod.blake3Hash(combined);
-
-        // Convert to hex string
-        const hex_key = try self.allocator.alloc(u8, hash.len * 2);
-        _ = std.fmt.bufPrint(hex_key, "{}", .{std.fmt.fmtSliceHexLower(&hash)}) catch unreachable;
-
-        return hex_key;
+    fn generateCacheKey(source: []const u8, compiler_version: []const u8) [32]u8 {
+        var hasher = std.crypto.hash.Blake3.init(.{});
+        hasher.update(std.mem.asBytes(&compiler_version.len));
+        hasher.update(compiler_version);
+        hasher.update(std.mem.asBytes(&source.len));
+        hasher.update(source);
+        var hash: [32]u8 = undefined;
+        hasher.final(&hash);
+        return hash;
     }
 
     /// Get the full cache file path for a given cache key.
     /// Uses subdirectory splitting: first 2 chars for subdir, rest for filename.
-    fn getCacheFilePath(self: *Self, cache_key: []const u8) ![]u8 {
+    fn getCacheFilePath(self: *Self, cache_key: [32]u8) ![]u8 {
         const entries_dir = try self.config.getCacheEntriesDir(self.allocator);
         defer self.allocator.free(entries_dir);
 
-        if (cache_key.len < 2) return error.InvalidCacheKey;
-
         // Split key: first 2 chars for subdirectory, rest for filename
-        const subdir = cache_key[0..2];
-        const filename = cache_key[2..];
+        var subdir_buf: [2]u8 = undefined;
+        _ = std.fmt.bufPrint(&subdir_buf, "{}", .{std.fmt.fmtSliceHexLower(cache_key[0..1])}) catch unreachable;
+        const subdir = subdir_buf[0..];
+
+        var filename_buf: [62]u8 = undefined;
+        _ = std.fmt.bufPrint(&filename_buf, "{}", .{std.fmt.fmtSliceHexLower(cache_key[1..32])}) catch unreachable;
+        const filename = filename_buf[0..];
 
         const cache_subdir = try std.fs.path.join(self.allocator, &[_][]const u8{ entries_dir, subdir });
         defer self.allocator.free(cache_subdir);
@@ -227,13 +209,14 @@ pub const CacheManager = struct {
     }
 
     /// Ensure the cache subdirectory exists for the given cache key.
-    fn ensureCacheSubdir(self: *Self, cache_key: []const u8) !void {
+    fn ensureCacheSubdir(self: *Self, cache_key: [32]u8) !void {
         const entries_dir = try self.config.getCacheEntriesDir(self.allocator);
         defer self.allocator.free(entries_dir);
 
-        if (cache_key.len < 2) return error.InvalidCacheKey;
-
-        const subdir = cache_key[0..2];
+        // Print the hex of the first byte into a fixed-size buffer for the subdir
+        var subdir_buf: [2]u8 = undefined;
+        _ = std.fmt.bufPrint(&subdir_buf, "{}", .{std.fmt.fmtSliceHexLower(cache_key[0..1])}) catch unreachable;
+        const subdir = subdir_buf[0..];
         const full_subdir = try std.fs.path.join(self.allocator, &[_][]const u8{ entries_dir, subdir });
         defer self.allocator.free(full_subdir);
 
@@ -302,6 +285,8 @@ pub const CacheManager = struct {
         // Create ProcessResult with proper ownership
         const process_result = coordinate_simple.ProcessResult{
             .cir = cir,
+            .source = source,
+            .own_source = true,
             .reports = reports,
             .was_cached = true,
         };
@@ -330,30 +315,17 @@ test "CacheManager initialization" {
 }
 
 test "CacheManager generateCacheKey" {
-    const allocator = testing.allocator;
-    const config = CacheConfig{};
-    const filesystem = Filesystem.testing();
-
-    var manager = CacheManager.init(allocator, config, filesystem);
-
     const content = "module [test]\n\ntest = 42";
     const compiler_version = "roc-zig-0.11.0-debug";
 
-    const key1 = try manager.generateCacheKey(content, compiler_version);
-    defer allocator.free(key1);
-    const key2 = try manager.generateCacheKey(content, compiler_version);
-    defer allocator.free(key2);
+    const key1 = CacheManager.generateCacheKey(compiler_version, content);
+    const key2 = CacheManager.generateCacheKey(compiler_version, content);
 
     // Same input should produce same key
-    try testing.expectEqualStrings(key1, key2);
+    try testing.expectEqualSlices(u8, &key1, &key2);
 
-    // Should be 64 hex characters (32 bytes * 2)
-    try testing.expectEqual(@as(usize, 64), key1.len);
-
-    // Should only contain hex characters
-    for (key1) |char| {
-        try testing.expect(std.ascii.isHex(char));
-    }
+    // Should be 32 bytes
+    try testing.expectEqual(@as(usize, 32), key1.len);
 }
 
 test "CacheManager getCacheFilePath with subdirectory splitting" {
@@ -363,7 +335,12 @@ test "CacheManager getCacheFilePath with subdirectory splitting" {
 
     var manager = CacheManager.init(allocator, config, filesystem);
 
-    const cache_key = "abcdef123456789";
+    const cache_key = [_]u8{
+        0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x90,
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+    };
     const cache_path = try manager.getCacheFilePath(cache_key);
     defer allocator.free(cache_path);
 
@@ -388,13 +365,12 @@ test "CacheManager loadFromCache miss" {
 
     var manager = CacheManager.init(allocator, config, filesystem);
 
-    const source = try allocator.dupe(u8, "module [test]\n\ntest = 42");
+    const source = "module [test]\n\ntest = 42";
 
     const result = manager.loadFromCache(source, "roc-zig-0.11.0-debug");
     switch (result) {
-        .miss => |returned| {
+        .miss => |_| {
             try testing.expect(manager.stats.misses == 1);
-            allocator.free(returned.source);
         },
         else => return error.TestUnexpectedResult,
     }
@@ -407,26 +383,12 @@ test "CacheManager disabled" {
 
     var manager = CacheManager.init(allocator, config, filesystem);
 
-    const source = try allocator.dupe(u8, "module [test]\n\ntest = 42");
+    const source = "module [test]\n\ntest = 42";
 
     const result = manager.loadFromCache(source, "roc-zig-0.11.0-debug");
     switch (result) {
-        .miss => |returned| {
-            allocator.free(returned.source);
-        },
+        .not_enabled => |_| {},
         else => return error.TestUnexpectedResult,
     }
     try testing.expect(manager.stats.getTotalOps() == 0); // No stats recorded when disabled
-}
-
-test "CacheManager short cache key error" {
-    const allocator = testing.allocator;
-    const config = CacheConfig{};
-    const filesystem = Filesystem.testing();
-
-    var manager = CacheManager.init(allocator, config, filesystem);
-
-    const short_key = "x"; // Too short for subdirectory splitting
-    const result = manager.getCacheFilePath(short_key);
-    try testing.expectError(error.InvalidCacheKey, result);
 }

--- a/src/cache/CacheModule.zig
+++ b/src/cache/CacheModule.zig
@@ -265,8 +265,7 @@ pub const CacheModule = struct {
     };
 
     /// Restore ModuleEnv and CIR from the cached data
-    /// IMPORTANT: This function takes ownership of `source`.
-    /// The caller must not free it after calling this function.
+    /// IMPORTANT: This expects source to remain valid for the lifetime of the restored ModuleEnv.
     pub fn restore(self: *const CacheModule, allocator: Allocator, module_name: []const u8, source: []const u8) !RestoredData {
         // Deserialize each component
         var node_store = try NodeStore.deserializeFrom(
@@ -329,7 +328,6 @@ pub const CacheModule = struct {
             .cir = CIR{
                 .env = undefined, // Will be set below
                 .store = node_store,
-                .temp_source_for_sexpr = null,
                 .all_defs = self.header.all_defs,
                 .all_statements = self.header.all_statements,
                 .external_decls = external_decls,
@@ -606,14 +604,14 @@ test "create and restore cache" {
     ;
 
     // Parse the source
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, source));
+    var module_env = try base.ModuleEnv.init(gpa, source);
     defer module_env.deinit();
 
     var cir = try CIR.init(&module_env, "TestModule");
     defer cir.deinit();
 
     // Parse and canonicalize
-    var ast = try parse(&module_env, source);
+    var ast = try parse(&module_env);
     defer ast.deinit(gpa);
 
     var canonicalizer = try canonicalize.init(&cir, &ast, null);
@@ -623,7 +621,7 @@ test "create and restore cache" {
     // Generate original S-expression for comparison
     var original_tree = SExprTree.init(gpa);
     defer original_tree.deinit();
-    try CIR.pushToSExprTree(&cir, null, &original_tree, source);
+    try CIR.pushToSExprTree(&cir, null, &original_tree);
 
     var original_sexpr = std.ArrayList(u8).init(gpa);
     defer original_sexpr.deinit();
@@ -641,7 +639,7 @@ test "create and restore cache" {
 
     // Restore ModuleEnv and CIR
     // Duplicate source since restore takes ownership
-    const restored = try cache.restore(gpa, "TestModule", try gpa.dupe(u8, source));
+    const restored = try cache.restore(gpa, "TestModule", source);
 
     var restored_module_env = restored.module_env;
     defer restored_module_env.deinit();
@@ -655,7 +653,7 @@ test "create and restore cache" {
     var restored_tree = SExprTree.init(gpa);
     defer restored_tree.deinit();
 
-    try CIR.pushToSExprTree(&restored_cir, null, &restored_tree, source);
+    try CIR.pushToSExprTree(&restored_cir, null, &restored_tree);
 
     var restored_sexpr = std.ArrayList(u8).init(gpa);
     defer restored_sexpr.deinit();
@@ -682,14 +680,14 @@ test "cache filesystem roundtrip with in-memory storage" {
     ;
 
     // Parse the source
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, source));
+    var module_env = try base.ModuleEnv.init(gpa, source);
     defer module_env.deinit();
 
     var cir = try CIR.init(&module_env, "TestModule");
     defer cir.deinit();
 
     // Parse and canonicalize
-    var ast = try parse(&module_env, source);
+    var ast = try parse(&module_env);
     defer ast.deinit(gpa);
 
     var canonicalizer = try canonicalize.init(&cir, &ast, null);
@@ -699,7 +697,7 @@ test "cache filesystem roundtrip with in-memory storage" {
     // Generate original S-expression for comparison
     var original_tree = SExprTree.init(gpa);
     defer original_tree.deinit();
-    try CIR.pushToSExprTree(&cir, null, &original_tree, source);
+    try CIR.pushToSExprTree(&cir, null, &original_tree);
 
     var original_sexpr = std.ArrayList(u8).init(gpa);
     defer original_sexpr.deinit();
@@ -783,7 +781,7 @@ test "cache filesystem roundtrip with in-memory storage" {
 
     // Restore from the roundtrip cache
     // Duplicate source since restore takes ownership
-    const restored = try roundtrip_cache.restore(gpa, "TestModule", try gpa.dupe(u8, source));
+    const restored = try roundtrip_cache.restore(gpa, "TestModule", source);
 
     var restored_module_env = restored.module_env;
     defer restored_module_env.deinit();
@@ -797,7 +795,7 @@ test "cache filesystem roundtrip with in-memory storage" {
     var restored_tree = SExprTree.init(gpa);
     defer restored_tree.deinit();
 
-    try CIR.pushToSExprTree(&restored_cir, null, &restored_tree, source);
+    try CIR.pushToSExprTree(&restored_cir, null, &restored_tree);
 
     var restored_sexpr = std.ArrayList(u8).init(gpa);
     defer restored_sexpr.deinit();

--- a/src/check/canonicalize.zig
+++ b/src/check/canonicalize.zig
@@ -6486,7 +6486,7 @@ const ScopeTestContext = struct {
     fn init(gpa: std.mem.Allocator) std.mem.Allocator.Error!ScopeTestContext {
         // heap allocate env for testing
         const env = try gpa.create(base.ModuleEnv);
-        env.* = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        env.* = try base.ModuleEnv.init(gpa, "");
 
         // heap allocate CIR for testing
         const cir = try gpa.create(CIR);
@@ -6799,10 +6799,10 @@ test "hexadecimal integer literals" {
     const gpa = gpa_state.allocator();
 
     for (test_cases) |tc| {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, tc.literal));
+        var env = try base.ModuleEnv.init(gpa, tc.literal);
         defer env.deinit();
 
-        var ast = try parse.parseExpr(&env, tc.literal);
+        var ast = try parse.parseExpr(&env);
         defer ast.deinit(gpa);
 
         var cir = try CIR.init(&env, "Test");
@@ -6889,10 +6889,10 @@ test "binary integer literals" {
     const gpa = gpa_state.allocator();
 
     for (test_cases) |tc| {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, tc.literal));
+        var env = try base.ModuleEnv.init(gpa, tc.literal);
         defer env.deinit();
 
-        var ast = try parse.parseExpr(&env, tc.literal);
+        var ast = try parse.parseExpr(&env);
         defer ast.deinit(gpa);
 
         var cir = try CIR.init(&env, "Test");
@@ -6979,10 +6979,10 @@ test "octal integer literals" {
     const gpa = gpa_state.allocator();
 
     for (test_cases) |tc| {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, tc.literal));
+        var env = try base.ModuleEnv.init(gpa, tc.literal);
         defer env.deinit();
 
-        var ast = try parse.parseExpr(&env, tc.literal);
+        var ast = try parse.parseExpr(&env);
         defer ast.deinit(gpa);
 
         var cir = try CIR.init(&env, "Test");
@@ -7069,10 +7069,10 @@ test "integer literals with uppercase base prefixes" {
     const gpa = gpa_state.allocator();
 
     for (test_cases) |tc| {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, tc.literal));
+        var env = try base.ModuleEnv.init(gpa, tc.literal);
         defer env.deinit();
 
-        var ast = try parse.parseExpr(&env, tc.literal);
+        var ast = try parse.parseExpr(&env);
         defer ast.deinit(gpa);
 
         var cir = try CIR.init(&env, "Test");
@@ -7131,7 +7131,7 @@ test "numeric literal patterns use pattern idx as type var" {
 
     // Test that int literal patterns work and use the pattern index as the type variable
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7176,7 +7176,7 @@ test "numeric literal patterns use pattern idx as type var" {
 
     // Test that f64 literal patterns work
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7228,7 +7228,7 @@ test "numeric pattern types: unbound vs polymorphic" {
 
     // Test int_unbound pattern
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7266,7 +7266,7 @@ test "numeric pattern types: unbound vs polymorphic" {
 
     // Test int_poly pattern (polymorphic integer that can be different int types)
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7316,7 +7316,7 @@ test "numeric pattern types: unbound vs polymorphic" {
 
     // Test num_unbound pattern (can be int or frac)
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7354,7 +7354,7 @@ test "numeric pattern types: unbound vs polymorphic" {
 
     // Test num_poly pattern (polymorphic num that can be int or frac)
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7400,7 +7400,7 @@ test "numeric pattern types: unbound vs polymorphic" {
 
     // Test frac_unbound pattern
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7444,10 +7444,10 @@ test "record literal uses record_unbound" {
     {
         const source1 = "{ x: 42, y: \"hello\" }";
 
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, source1));
+        var env = try base.ModuleEnv.init(gpa, source1);
         defer env.deinit();
 
-        var ast = try parse.parseExpr(&env, source1);
+        var ast = try parse.parseExpr(&env);
         defer ast.deinit(gpa);
 
         var cir = try CIR.init(&env, "Test");
@@ -7482,10 +7482,10 @@ test "record literal uses record_unbound" {
     {
         const source2 = "{}";
 
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, source2));
+        var env = try base.ModuleEnv.init(gpa, source2);
         defer env.deinit();
 
-        var ast = try parse.parseExpr(&env, source2);
+        var ast = try parse.parseExpr(&env);
         defer ast.deinit(gpa);
 
         var cir = try CIR.init(&env, "Test");
@@ -7520,10 +7520,10 @@ test "record literal uses record_unbound" {
     {
         const source3 = "{ value: 123 }";
 
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, source3));
+        var env = try base.ModuleEnv.init(gpa, source3);
         defer env.deinit();
 
-        var ast = try parse.parseExpr(&env, source3);
+        var ast = try parse.parseExpr(&env);
         defer ast.deinit(gpa);
 
         var cir = try CIR.init(&env, "Test");
@@ -7565,10 +7565,10 @@ test "record_unbound basic functionality" {
     const source = "{ x: 42, y: 99 }";
 
     // Test that record literals create record_unbound types
-    var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, source));
+    var env = try base.ModuleEnv.init(gpa, source);
     defer env.deinit();
 
-    var ast = try parse.parseExpr(&env, source);
+    var ast = try parse.parseExpr(&env);
     defer ast.deinit(gpa);
 
     var cir = try CIR.init(&env, "Test");
@@ -7608,11 +7608,11 @@ test "record_unbound with multiple fields" {
     const gpa = std.testing.allocator;
     const source = "{ a: 123, b: 456, c: 789 }";
 
-    var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, source));
+    var env = try base.ModuleEnv.init(gpa, source);
     defer env.deinit();
 
     // Create record_unbound with multiple fields
-    var ast = try parse.parseExpr(&env, source);
+    var ast = try parse.parseExpr(&env);
     defer ast.deinit(gpa);
 
     var cir = try CIR.init(&env, "Test");
@@ -7650,7 +7650,7 @@ test "record_unbound with multiple fields" {
 test "record with extension variable" {
     const gpa = std.testing.allocator;
 
-    var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var env = try base.ModuleEnv.init(gpa, "");
     defer env.deinit();
 
     var cir = try CIR.init(&env, "Test");
@@ -7726,7 +7726,7 @@ test "numeric pattern types: unbound vs polymorphic - frac" {
 
     // Test frac_poly pattern
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7782,7 +7782,7 @@ test "pattern numeric literal value edge cases" {
 
     // Test max/min integer values
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7811,7 +7811,7 @@ test "pattern numeric literal value edge cases" {
 
     // Test small decimal pattern
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7835,7 +7835,7 @@ test "pattern numeric literal value edge cases" {
 
     // Test dec literal pattern
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7857,7 +7857,7 @@ test "pattern numeric literal value edge cases" {
 
     // Test special float values
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7883,7 +7883,7 @@ test "pattern literal type transitions" {
 
     // Test transitioning from unbound to concrete type
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7929,7 +7929,7 @@ test "pattern literal type transitions" {
 
     // Test hex/binary/octal patterns must be integers
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -7975,7 +7975,7 @@ test "pattern type inference with numeric literals" {
 
     // Test that pattern indices work correctly as type variables with type inference
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");
@@ -8044,7 +8044,7 @@ test "pattern type inference with numeric literals" {
 
     // Test patterns with type constraints from context
     {
-        var env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+        var env = try base.ModuleEnv.init(gpa, "");
         defer env.deinit();
 
         var cir = try CIR.init(&env, "Test");

--- a/src/check/canonicalize/CIR.zig
+++ b/src/check/canonicalize/CIR.zig
@@ -43,16 +43,6 @@ env: *ModuleEnv,
 ///
 /// Uses an efficient data structure, and provides helpers for storing and retrieving nodes.
 store: NodeStore,
-/// Temporary source text used for generating SExpr and Reports, required to calculate region info.
-///
-/// This field exists because:
-/// - CIR may be loaded from cache without access to the original source file
-/// - Region info calculation requires the source text to convert byte offsets to line/column
-/// - The source is only needed temporarily during diagnostic reporting or SExpr generation
-///
-/// Lifetime: The caller must ensure the source remains valid for the duration of the
-/// operation (e.g., `toSExprStr` or `diagnosticToReport` calls).
-temp_source_for_sexpr: ?[]const u8 = null,
 /// Diagnostics extracted from the store (needed because getDiagnostics is destructive)
 diagnostics: ?[]CIR.Diagnostic = null,
 /// All the definitions and in the module, populated by calling `canonicalize_file`
@@ -96,7 +86,6 @@ pub fn fromCache(env: *ModuleEnv, cached_store: NodeStore, all_defs: Def.Span, a
     return CIR{
         .env = env,
         .store = cached_store,
-        .temp_source_for_sexpr = null,
         .diagnostics = null,
         .all_defs = all_defs,
         .all_statements = all_statements,
@@ -107,12 +96,8 @@ pub fn fromCache(env: *ModuleEnv, cached_store: NodeStore, all_defs: Def.Span, a
 }
 
 fn literal_from_source(self: *CIR, start_offset: u32, end_offset: u32) []const u8 {
-    if (self.temp_source_for_sexpr) |actual_source| {
-        if (actual_source.len > 0 and end_offset <= actual_source.len and start_offset <= end_offset) {
-            return actual_source[start_offset..end_offset];
-        } else {
-            return "";
-        }
+    if (self.env.source.len > 0 and end_offset <= self.env.source.len and start_offset <= end_offset) {
+        return self.env.source[start_offset..end_offset];
     } else {
         return "";
     }
@@ -196,13 +181,9 @@ pub fn getDiagnostics(self: *CIR) std.mem.Allocator.Error![]CIR.Diagnostic {
 /// The source parameter is not owned by this function - the caller must ensure it
 /// remains valid for the duration of this call. The returned Report will contain
 /// references to the source text but does not own it.
-pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem.Allocator, source: ?[]const u8, filename: []const u8) !reporting.Report {
+pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem.Allocator, filename: []const u8) !reporting.Report {
     const trace = tracy.trace(@src());
     defer trace.end();
-
-    // Set temporary source for calcRegionInfo
-    self.temp_source_for_sexpr = source orelse self.env.source;
-    defer self.temp_source_for_sexpr = null;
 
     return switch (diagnostic) {
         .not_implemented => |data| blk: {
@@ -217,7 +198,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 ident_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -231,7 +212,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 region_info,
                 original_region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -243,7 +224,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 region_info,
                 literal_text,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -255,7 +236,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 ident_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -267,7 +248,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 ident_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -279,7 +260,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 stmt_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -287,17 +268,29 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
             break :blk Diagnostic.buildF64PatternLiteralReport(
                 allocator,
                 data.region,
-                source orelse self.env.source,
+                self.env.source,
             );
         },
         .invalid_single_quote => Diagnostic.buildInvalidSingleQuoteReport(allocator),
         .crash_expects_string => |data| blk: {
             const region_info = self.calcRegionInfo(data.region);
-            break :blk Diagnostic.buildCrashExpectsStringReport(allocator, region_info, filename, self.temp_source_for_sexpr.?, self.env.line_starts.items.items);
+            break :blk Diagnostic.buildCrashExpectsStringReport(
+                allocator,
+                region_info,
+                filename,
+                self.env.source,
+                self.env.line_starts.items.items,
+            );
         },
         .empty_tuple => |data| blk: {
             const region_info = self.calcRegionInfo(data.region);
-            break :blk Diagnostic.buildEmptyTupleReport(allocator, region_info, filename, self.temp_source_for_sexpr.?, self.env.line_starts.items.items);
+            break :blk Diagnostic.buildEmptyTupleReport(
+                allocator,
+                region_info,
+                filename,
+                self.env.source,
+                self.env.line_starts.items.items,
+            );
         },
         .expr_not_canonicalized => |data| blk: {
             const region_info = self.calcRegionInfo(data.region);
@@ -305,7 +298,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 allocator,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -325,7 +318,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 allocator,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -339,7 +332,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 new_region_info,
                 original_region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -353,7 +346,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 original_region_info,
                 redeclared_region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -366,7 +359,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 module_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -380,7 +373,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 value_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -394,7 +387,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 type_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -406,7 +399,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 module_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -417,7 +410,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 data.count,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -429,7 +422,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 type_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -441,7 +434,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 type_var_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -455,7 +448,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 original_region_info,
                 redeclared_region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -469,7 +462,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 original_region_info,
                 redeclared_region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -484,7 +477,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 original_region_info,
                 data.cross_scope,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -500,7 +493,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 region_info,
                 original_region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -512,7 +505,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 region_info,
                 data,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -524,7 +517,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 region_info,
                 data,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -538,7 +531,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 duplicate_region_info,
                 original_region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -552,7 +545,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 suggested_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -566,7 +559,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 suggested_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -580,7 +573,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 suggested_name,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -591,7 +584,7 @@ pub fn diagnosticToReport(self: *CIR, diagnostic: Diagnostic, allocator: std.mem
                 data.is_alias,
                 region_info,
                 filename,
-                self.temp_source_for_sexpr.?,
+                self.env.source,
                 self.env.line_starts.items.items,
             );
         },
@@ -1718,11 +1711,7 @@ pub const IntValue = struct {
 
 /// Helper function to generate the S-expression node for the entire Canonical IR.
 /// If a single expression is provided, only that expression is returned.
-pub fn pushToSExprTree(ir: *CIR, maybe_expr_idx: ?Expr.Idx, tree: *SExprTree, source: ?[]const u8) std.mem.Allocator.Error!void {
-    // Set temporary source for region info calculation during SExpr generation
-    ir.temp_source_for_sexpr = source orelse ir.env.source;
-    defer ir.temp_source_for_sexpr = null;
-
+pub fn pushToSExprTree(ir: *CIR, maybe_expr_idx: ?Expr.Idx, tree: *SExprTree) std.mem.Allocator.Error!void {
     if (maybe_expr_idx) |expr_idx| {
         // Only output the given expression
         try ir.store.getExpr(expr_idx).pushToSExprTree(ir, tree, expr_idx);
@@ -1777,10 +1766,7 @@ pub fn calcRegionInfo(self: *const CIR, region: Region) base.RegionInfo {
 
     // In the Can IR, regions store byte offsets directly, not token indices.
     // We can use these offsets directly to calculate the diagnostic position.
-    const source = self.temp_source_for_sexpr orelse {
-        // No source available, return empty region info
-        return empty;
-    };
+    const source = self.env.source;
 
     const info = base.RegionInfo.position(source, self.env.line_starts.items.items, region.start.offset, region.end.offset) catch {
         // Return a zero position if we can't calculate it
@@ -1832,11 +1818,7 @@ pub fn getNodeRegionInfo(ir: *const CIR, idx: anytype) base.RegionInfo {
 /// Helper function to convert type information from the Canonical IR to an SExpr node
 /// in S-expression format for snapshot testing. Implements the definition-focused
 /// format showing final types for defs, expressions, and builtins.
-pub fn pushTypesToSExprTree(ir: *CIR, maybe_expr_idx: ?Expr.Idx, tree: *SExprTree, source: []const u8) std.mem.Allocator.Error!void {
-    // Set temporary source for region info calculation during SExpr generation
-    ir.temp_source_for_sexpr = source;
-    defer ir.temp_source_for_sexpr = null;
-
+pub fn pushTypesToSExprTree(ir: *CIR, maybe_expr_idx: ?Expr.Idx, tree: *SExprTree) std.mem.Allocator.Error!void {
     const gpa = ir.env.gpa;
 
     // Create TypeWriter for converting types to strings

--- a/src/check/canonicalize/test/exposed_shadowing_test.zig
+++ b/src/check/canonicalize/test/exposed_shadowing_test.zig
@@ -22,10 +22,10 @@ test "exposed but not implemented - values" {
         \\foo = 42
     ;
 
-    var env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    var env = try base.ModuleEnv.init(allocator, source);
     defer env.deinit();
 
-    var ast = try parse.parse(&env, source);
+    var ast = try parse.parse(&env);
     defer ast.deinit(allocator);
 
     var cir = try CIR.init(&env, "Test");
@@ -63,10 +63,10 @@ test "exposed but not implemented - types" {
         \\MyType : [A, B]
     ;
 
-    var env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    var env = try base.ModuleEnv.init(allocator, source);
     defer env.deinit();
 
-    var ast = try parse.parse(&env, source);
+    var ast = try parse.parse(&env);
     defer ast.deinit(allocator);
 
     var cir = try CIR.init(&env, "Test");
@@ -106,10 +106,10 @@ test "redundant exposed entries" {
         \\MyType : [A, B]
     ;
 
-    var env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    var env = try base.ModuleEnv.init(allocator, source);
     defer env.deinit();
 
-    var ast = try parse.parse(&env, source);
+    var ast = try parse.parse(&env);
     defer ast.deinit(allocator);
 
     var cir = try CIR.init(&env, "Test");
@@ -155,10 +155,10 @@ test "shadowing with exposed items" {
         \\y = "second"
     ;
 
-    var env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    var env = try base.ModuleEnv.init(allocator, source);
     defer env.deinit();
 
-    var ast = try parse.parse(&env, source);
+    var ast = try parse.parse(&env);
     defer ast.deinit(allocator);
 
     var cir = try CIR.init(&env, "Test");
@@ -194,10 +194,10 @@ test "shadowing non-exposed items" {
         \\# Shadowing is allowed for non-exposed items
     ;
 
-    var env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    var env = try base.ModuleEnv.init(allocator, source);
     defer env.deinit();
 
-    var ast = try parse.parse(&env, source);
+    var ast = try parse.parse(&env);
     defer ast.deinit(allocator);
 
     var cir = try CIR.init(&env, "Test");
@@ -240,10 +240,10 @@ test "exposed items correctly tracked across shadowing" {
         \\# z is exposed but never defined
     ;
 
-    var env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    var env = try base.ModuleEnv.init(allocator, source);
     defer env.deinit();
 
-    var ast = try parse.parse(&env, source);
+    var ast = try parse.parse(&env);
     defer ast.deinit(allocator);
 
     var cir = try CIR.init(&env, "Test");
@@ -305,10 +305,10 @@ test "complex case with redundant, shadowing, and not implemented" {
         \\c = 100
     ;
 
-    var env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    var env = try base.ModuleEnv.init(allocator, source);
     defer env.deinit();
 
-    var ast = try parse.parse(&env, source);
+    var ast = try parse.parse(&env);
     defer ast.deinit(allocator);
 
     var cir = try CIR.init(&env, "Test");
@@ -365,10 +365,10 @@ test "exposed_by_str is populated correctly" {
         \\MyType : [A, B]
     ;
 
-    var env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    var env = try base.ModuleEnv.init(allocator, source);
     defer env.deinit();
 
-    var ast = try parse.parse(&env, source);
+    var ast = try parse.parse(&env);
     defer ast.deinit(allocator);
 
     var cir = try CIR.init(&env, "Test");
@@ -399,10 +399,10 @@ test "exposed_by_str persists after canonicalization" {
         \\# z is not defined
     ;
 
-    var env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    var env = try base.ModuleEnv.init(allocator, source);
     defer env.deinit();
 
-    var ast = try parse.parse(&env, source);
+    var ast = try parse.parse(&env);
     defer ast.deinit(allocator);
 
     var cir = try CIR.init(&env, "Test");
@@ -433,10 +433,10 @@ test "exposed_by_str never has entries removed" {
         \\baz = 3.14
     ;
 
-    var env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    var env = try base.ModuleEnv.init(allocator, source);
     defer env.deinit();
 
-    var ast = try parse.parse(&env, source);
+    var ast = try parse.parse(&env);
     defer ast.deinit(allocator);
 
     var cir = try CIR.init(&env, "Test");

--- a/src/check/canonicalize/test/frac_test.zig
+++ b/src/check/canonicalize/test/frac_test.zig
@@ -23,10 +23,10 @@ fn parseAndCanonicalizeFrac(allocator: std.mem.Allocator, source: []const u8) !s
     expr_idx: CIR.Expr.Idx,
 } {
     const module_env = try allocator.create(base.ModuleEnv);
-    module_env.* = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    module_env.* = try base.ModuleEnv.init(allocator, source);
 
     const parse_ast = try allocator.create(parse.AST);
-    parse_ast.* = try parse.parseExpr(module_env, source);
+    parse_ast.* = try parse.parseExpr(module_env);
 
     parse_ast.store.emptyScratch();
 
@@ -302,13 +302,13 @@ test "fractional literal - NaN handling" {
     // The parser will fail before canonicalization
     // This test verifies that behavior
     const module_env = try test_allocator.create(base.ModuleEnv);
-    module_env.* = try base.ModuleEnv.init(test_allocator, try test_allocator.dupe(u8, "NaN"));
+    module_env.* = try base.ModuleEnv.init(test_allocator, "NaN");
     defer {
         module_env.deinit();
         test_allocator.destroy(module_env);
     }
 
-    var parse_ast = try parse.parseExpr(module_env, "NaN");
+    var parse_ast = try parse.parseExpr(module_env);
     defer parse_ast.deinit(test_allocator);
 
     // Check if it parsed as an identifier instead of a number
@@ -324,13 +324,13 @@ test "fractional literal - infinity handling" {
     // The parser will fail before canonicalization
     // This test verifies that behavior
     const module_env = try test_allocator.create(base.ModuleEnv);
-    module_env.* = try base.ModuleEnv.init(test_allocator, try test_allocator.dupe(u8, "Infinity"));
+    module_env.* = try base.ModuleEnv.init(test_allocator, "Infinity");
     defer {
         module_env.deinit();
         test_allocator.destroy(module_env);
     }
 
-    var parse_ast = try parse.parseExpr(module_env, "Infinity");
+    var parse_ast = try parse.parseExpr(module_env);
     defer parse_ast.deinit(test_allocator);
 
     // Check if it parsed as an identifier instead of a number

--- a/src/check/canonicalize/test/import_validation_test.zig
+++ b/src/check/canonicalize/test/import_validation_test.zig
@@ -21,7 +21,7 @@ test "import validation - mix of MODULE NOT FOUND, TYPE NOT EXPOSED, VALUE NOT E
     defer module_envs.deinit();
 
     // Create module environment for "Json" module
-    var json_env = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var json_env = base.ModuleEnv.init(allocator, "");
     defer json_env.deinit();
 
     // Add exposed items to Json module
@@ -33,7 +33,7 @@ test "import validation - mix of MODULE NOT FOUND, TYPE NOT EXPOSED, VALUE NOT E
     try module_envs.put("Json", &json_env);
 
     // Create module environment for "Utils" module
-    var utils_env = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var utils_env = base.ModuleEnv.init(allocator, "");
     defer utils_env.deinit();
 
     // Add exposed items to Utils module
@@ -157,7 +157,7 @@ test "import validation - no module_envs provided" {
     defer ast.deinit();
 
     // Canonicalize without module validation (pass null)
-    var env = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var env = base.ModuleEnv.init(allocator, "");
     defer env.deinit();
     try env.calcLineStarts(source);
     var cir = CIR.init(&env, "Test");
@@ -204,7 +204,7 @@ test "import interner - Import.Idx functionality" {
     // Parse the source
     var tokens = try parse.tokenize(allocator, source, .file);
     defer tokens.deinit(allocator);
-    var parse_env = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var parse_env = base.ModuleEnv.init(allocator, "");
     defer parse_env.deinit();
     try parse_env.calcLineStarts(source);
     var ast = try parse.parse(&parse_env, &tokens, allocator, .file);
@@ -292,7 +292,7 @@ test "import interner - comprehensive usage example" {
     // Parse the source
     var tokens = try parse.tokenize(allocator, source, .file);
     defer tokens.deinit(allocator);
-    var parse_env = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var parse_env = base.ModuleEnv.init(allocator, "");
     defer parse_env.deinit();
     try parse_env.calcLineStarts(source);
     var ast = try parse.parse(&parse_env, &tokens, allocator, .file);
@@ -389,7 +389,7 @@ test "module scopes - imports are only available in their scope" {
     // Parse the source
     var tokens = try parse.tokenize(allocator, source, .file);
     defer tokens.deinit(allocator);
-    var parse_env = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var parse_env = base.ModuleEnv.init(allocator, "");
     defer parse_env.deinit();
     try parse_env.calcLineStarts(source);
     var ast = try parse.parse(&parse_env, &tokens, allocator, .file);
@@ -452,7 +452,7 @@ test "module-qualified lookups with e_lookup_external" {
     // Parse the source
     var tokens = try parse.tokenize(allocator, source, .file);
     defer tokens.deinit(allocator);
-    var parse_env = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var parse_env = base.ModuleEnv.init(allocator, "");
     defer parse_env.deinit();
     try parse_env.calcLineStarts(source);
     var ast = try parse.parse(&parse_env, &tokens, allocator, .file);
@@ -516,7 +516,7 @@ test "exposed_nodes - tracking CIR node indices for exposed items" {
     defer module_envs.deinit();
 
     // Create a "MathUtils" module with some exposed definitions
-    var math_env = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var math_env = base.ModuleEnv.init(allocator, "");
     defer math_env.deinit();
 
     // Add exposed items
@@ -548,14 +548,14 @@ test "exposed_nodes - tracking CIR node indices for exposed items" {
     // Parse the source
     var tokens = try parse.tokenize(allocator, source, .file);
     defer tokens.deinit(allocator);
-    var parse_env = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var parse_env = base.ModuleEnv.init(allocator, "");
     defer parse_env.deinit();
     try parse_env.calcLineStarts(source);
     var ast = try parse.parse(&parse_env, &tokens, allocator, .file);
     defer ast.deinit();
 
     // Canonicalize with module environments
-    var env = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var env = base.ModuleEnv.init(allocator, "");
     defer env.deinit();
     try env.calcLineStarts(source);
     var cir = CIR.init(&env, "Test");
@@ -599,7 +599,7 @@ test "exposed_nodes - tracking CIR node indices for exposed items" {
     try expectEqual(true, found_pi_with_idx_300);
 
     // Test case where exposed_nodes is not populated (should get 0)
-    var empty_env = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var empty_env = base.ModuleEnv.init(allocator, "");
     defer empty_env.deinit();
     try empty_env.exposed_by_str.put(allocator, "undefined", {});
     // Don't add to exposed_nodes - should default to 0
@@ -615,13 +615,13 @@ test "exposed_nodes - tracking CIR node indices for exposed items" {
 
     var tokens2 = try parse.tokenize(allocator, source2, .file);
     defer tokens2.deinit(allocator);
-    var parse_env2 = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var parse_env2 = base.ModuleEnv.init(allocator, "");
     defer parse_env2.deinit();
     try parse_env2.calcLineStarts(source2);
     var ast2 = try parse.parse(&parse_env2, &tokens2, allocator, .file);
     defer ast2.deinit();
 
-    var env2 = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var env2 = base.ModuleEnv.init(allocator, "");
     defer env2.deinit();
     env2.source = try allocator.dupe(u8, source2);
     env2.owns_source = true;
@@ -663,10 +663,8 @@ test "export count safety - ensures safe u16 casting" {
     try expectEqual(@as(u32, 65535), std.math.maxInt(u16));
 
     // Test the diagnostic for exactly maxInt(u16) exports
-    var env1 = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var env1 = base.ModuleEnv.init(allocator, "");
     defer env1.deinit();
-    env1.source = try allocator.dupe(u8, source);
-    env1.owns_source = true;
     var cir1 = CIR.init(&env1);
     defer cir1.deinit();
 
@@ -688,7 +686,7 @@ test "export count safety - ensures safe u16 casting" {
     }
 
     // Test the diagnostic for exceeding the limit
-    var env2 = base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var env2 = base.ModuleEnv.init(allocator, "");
     defer env2.deinit();
     var cir2 = CIR.init(&env2);
     defer cir2.deinit();

--- a/src/check/canonicalize/test/int_test.zig
+++ b/src/check/canonicalize/test/int_test.zig
@@ -22,10 +22,10 @@ fn parseAndCanonicalizeInt(allocator: std.mem.Allocator, source: []const u8) !st
     expr_idx: CIR.Expr.Idx,
 } {
     const module_env = try allocator.create(base.ModuleEnv);
-    module_env.* = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    module_env.* = try base.ModuleEnv.init(allocator, source);
 
     const parse_ast = try allocator.create(parse.AST);
-    parse_ast.* = try parse.parseExpr(module_env, source);
+    parse_ast.* = try parse.parseExpr(module_env);
 
     parse_ast.store.emptyScratch();
 

--- a/src/check/canonicalize_bool_test.zig
+++ b/src/check/canonicalize_bool_test.zig
@@ -12,12 +12,11 @@ test "canonicalize True as Bool" {
     const source = "True";
 
     // Initialize ModuleEnv
-    const owned_source = try allocator.dupe(u8, source);
-    var module_env = try base.ModuleEnv.init(allocator, owned_source);
+    var module_env = try base.ModuleEnv.init(allocator, source);
     defer module_env.deinit();
 
     // Parse
-    var parse_ast = try parse.parseExpr(&module_env, source);
+    var parse_ast = try parse.parseExpr(&module_env);
     defer parse_ast.deinit(allocator);
     parse_ast.store.emptyScratch();
 
@@ -53,12 +52,11 @@ test "canonicalize False as Bool" {
     const source = "False";
 
     // Initialize ModuleEnv
-    const owned_source = try allocator.dupe(u8, source);
-    var module_env = try base.ModuleEnv.init(allocator, owned_source);
+    var module_env = try base.ModuleEnv.init(allocator, source);
     defer module_env.deinit();
 
     // Parse
-    var parse_ast = try parse.parseExpr(&module_env, source);
+    var parse_ast = try parse.parseExpr(&module_env);
     defer parse_ast.deinit(allocator);
     parse_ast.store.emptyScratch();
 
@@ -94,12 +92,11 @@ test "canonicalize random tag not as Bool" {
     const source = "SomeTag";
 
     // Initialize ModuleEnv
-    const owned_source = try allocator.dupe(u8, source);
-    var module_env = try base.ModuleEnv.init(allocator, owned_source);
+    var module_env = try base.ModuleEnv.init(allocator, source);
     defer module_env.deinit();
 
     // Parse
-    var parse_ast = try parse.parseExpr(&module_env, source);
+    var parse_ast = try parse.parseExpr(&module_env);
     defer parse_ast.deinit(allocator);
     parse_ast.store.emptyScratch();
 

--- a/src/check/check_types/cross_module_test.zig
+++ b/src/check/check_types/cross_module_test.zig
@@ -20,7 +20,7 @@ test "cross-module type checking - monomorphic function" {
     const allocator = testing.allocator;
 
     // Create module A that exports a simple function
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -53,7 +53,7 @@ test "cross-module type checking - monomorphic function" {
     try modules.append(&module_a_cir);
 
     // Create module B that imports and uses the function from module A
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -110,7 +110,7 @@ test "cross-module type checking - polymorphic function" {
     const allocator = testing.allocator;
 
     // Create module A that exports a polymorphic identity function
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -139,7 +139,7 @@ test "cross-module type checking - polymorphic function" {
     try modules.append(&module_a_cir);
 
     // Create module B that imports and uses the polymorphic function
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -189,7 +189,7 @@ test "cross-module type checking - record type" {
     const allocator = testing.allocator;
 
     // Create module A that exports a record type
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -239,7 +239,7 @@ test "cross-module type checking - record type" {
     try modules.append(&module_a_cir);
 
     // Create module B that imports and uses the record from module A
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -297,7 +297,7 @@ test "cross-module type checking - type mismatch error" {
     const allocator = testing.allocator;
 
     // Create module A that exports an I32
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -316,7 +316,7 @@ test "cross-module type checking - type mismatch error" {
     try module_a_env.types.setVarContent(@enumFromInt(@intFromEnum(func_expr_idx)), i32_content);
 
     // Create module B that imports the I32 but tries to use it as a String
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -375,7 +375,7 @@ test "cross-module type checking - polymorphic instantiation" {
     const allocator = testing.allocator;
 
     // Create module A that exports a polymorphic list function
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -399,7 +399,7 @@ test "cross-module type checking - polymorphic instantiation" {
     try module_a_env.types.setVarContent(@enumFromInt(@intFromEnum(func_expr_idx)), func_content);
 
     // Create module B that imports and uses the function with a specific type
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -468,7 +468,7 @@ test "cross-module type checking - preserves module A types" {
     const allocator = testing.allocator;
 
     // Create module A
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -492,7 +492,7 @@ test "cross-module type checking - preserves module A types" {
     try testing.expect(original_content == .flex_var);
 
     // Create module B
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -552,7 +552,7 @@ test "cross-module type checking - three module chain monomorphic" {
     const allocator = testing.allocator;
 
     // Module A exports a simple function: add : I32, I32 -> I32
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -577,7 +577,7 @@ test "cross-module type checking - three module chain monomorphic" {
     try module_a_env.types.setVarContent(@enumFromInt(@intFromEnum(func_expr_idx)), func_content);
 
     // Module B imports from A and re-exports it
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -595,7 +595,7 @@ test "cross-module type checking - three module chain monomorphic" {
     }, base.Region.zero());
 
     // Module C imports from B
-    var module_c_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_c_env = try base.ModuleEnv.init(allocator, "");
     defer module_c_env.deinit();
 
     var module_c_cir = try CIR.init(&module_c_env, "ModuleC");
@@ -662,7 +662,7 @@ test "cross-module type checking - three module chain polymorphic" {
     const allocator = testing.allocator;
 
     // Module A exports a polymorphic function: identity : a -> a
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -682,7 +682,7 @@ test "cross-module type checking - three module chain polymorphic" {
     try module_a_env.types.setVarContent(@enumFromInt(@intFromEnum(func_expr_idx)), func_content);
 
     // Module B imports from A and re-exports it
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -699,7 +699,7 @@ test "cross-module type checking - three module chain polymorphic" {
     }, base.Region.zero());
 
     // Module C imports from B
-    var module_c_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_c_env = try base.ModuleEnv.init(allocator, "");
     defer module_c_env.deinit();
 
     var module_c_cir = try CIR.init(&module_c_env, "ModuleC");
@@ -759,7 +759,7 @@ test "cross-module type checking - partial polymorphic instantiation chain" {
     const allocator = testing.allocator;
 
     // Module A exports: map : (a -> b), List a -> List b
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -795,7 +795,7 @@ test "cross-module type checking - partial polymorphic instantiation chain" {
     try module_a_env.types.setVarContent(@enumFromInt(@intFromEnum(map_expr_idx)), map_func_content);
 
     // Module B imports map and partially applies it with I32
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -843,7 +843,7 @@ test "cross-module type checking - partial polymorphic instantiation chain" {
     try module_b_env.types.setVarContent(@enumFromInt(@intFromEnum(map_i32_expr_idx)), map_i32_content);
 
     // Module C imports the partially specialized version from B
-    var module_c_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_c_env = try base.ModuleEnv.init(allocator, "");
     defer module_c_env.deinit();
 
     var module_c_cir = try CIR.init(&module_c_env, "ModuleC");
@@ -940,7 +940,7 @@ test "cross-module type checking - record type chain" {
     const allocator = testing.allocator;
 
     // Module A exports a record type: { x: I32, y: Str }
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -978,7 +978,7 @@ test "cross-module type checking - record type chain" {
     try module_a_env.types.setVarContent(@enumFromInt(@intFromEnum(record_expr_idx)), record_content);
 
     // Module B imports and re-exports the record
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -995,7 +995,7 @@ test "cross-module type checking - record type chain" {
     }, base.Region.zero());
 
     // Module C imports from B
-    var module_c_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_c_env = try base.ModuleEnv.init(allocator, "");
     defer module_c_env.deinit();
 
     var module_c_cir = try CIR.init(&module_c_env, "ModuleC");
@@ -1066,7 +1066,7 @@ test "cross-module type checking - polymorphic record chain" {
     const allocator = testing.allocator;
 
     // Module A exports a polymorphic record: { value: a, next: List a }
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -1103,7 +1103,7 @@ test "cross-module type checking - polymorphic record chain" {
     try module_a_env.types.setVarContent(@enumFromInt(@intFromEnum(record_expr_idx)), record_content);
 
     // Module B imports and partially specializes to Str
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -1155,7 +1155,7 @@ test "cross-module type checking - polymorphic record chain" {
     try module_b_env.types.setVarContent(@enumFromInt(@intFromEnum(str_record_expr_idx)), str_record_content);
 
     // Module C imports the specialized version from B
-    var module_c_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_c_env = try base.ModuleEnv.init(allocator, "");
     defer module_c_env.deinit();
 
     var module_c_cir = try CIR.init(&module_c_env, "ModuleC");
@@ -1230,7 +1230,7 @@ test "cross-module type checking - complex polymorphic chain with unification" {
     const allocator = testing.allocator;
 
     // Module A exports: compose : (b -> c), (a -> b) -> (a -> c)
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -1267,7 +1267,7 @@ test "cross-module type checking - complex polymorphic chain with unification" {
     try module_a_env.types.setVarContent(@enumFromInt(@intFromEnum(compose_expr_idx)), compose_content);
 
     // Module B imports compose and partially applies with b = Str
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");
@@ -1319,7 +1319,7 @@ test "cross-module type checking - complex polymorphic chain with unification" {
     try module_b_env.types.setVarContent(@enumFromInt(@intFromEnum(compose_str_expr_idx)), compose_str_content);
 
     // Module C imports the partially specialized version and further specializes c = I32
-    var module_c_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_c_env = try base.ModuleEnv.init(allocator, "");
     defer module_c_env.deinit();
 
     var module_c_cir = try CIR.init(&module_c_env, "ModuleC");
@@ -1454,7 +1454,7 @@ test "cross-module type checking - type mismatch with proper error message" {
     const allocator = testing.allocator;
 
     // Module A: Exports a string value
-    var module_a_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_a_env = try base.ModuleEnv.init(allocator, "");
     defer module_a_env.deinit();
 
     var module_a_cir = try CIR.init(&module_a_env, "ModuleA");
@@ -1471,7 +1471,7 @@ test "cross-module type checking - type mismatch with proper error message" {
     try module_a_env.types.setVarContent(@enumFromInt(@intFromEnum(str_expr_idx)), .{ .structure = .str });
 
     // Module B: Tries to use the string as a number
-    var module_b_env = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    var module_b_env = try base.ModuleEnv.init(allocator, "");
     defer module_b_env.deinit();
 
     var module_b_cir = try CIR.init(&module_b_env, "ModuleB");

--- a/src/check/check_types/let_polymorphism_test.zig
+++ b/src/check/check_types/let_polymorphism_test.zig
@@ -24,7 +24,7 @@ const TestEnv = struct {
 
 fn setupTestEnvironment(allocator: std.mem.Allocator) !TestEnv {
     const module_env = try allocator.create(base.ModuleEnv);
-    module_env.* = try base.ModuleEnv.init(allocator, try allocator.dupe(u8, ""));
+    module_env.* = try base.ModuleEnv.init(allocator, "");
 
     const store = try allocator.create(TypesStore);
     store.* = try TypesStore.init(allocator);

--- a/src/check/check_types/problem.zig
+++ b/src/check/check_types/problem.zig
@@ -168,7 +168,6 @@ pub const ReportBuilder = struct {
         module_env: *const base.ModuleEnv,
         can_ir: *const can.CIR,
         snapshots: *const snapshot.Store,
-        source: []const u8,
         filename: []const u8,
         other_modules: []const *const can.CIR,
     ) Self {
@@ -178,7 +177,7 @@ pub const ReportBuilder = struct {
             .module_env = module_env,
             .can_ir = can_ir,
             .snapshots = snapshots,
-            .source = source,
+            .source = module_env.source,
             .filename = filename,
             .other_modules = other_modules,
         };

--- a/src/check/let_polymorphism_integration_test.zig
+++ b/src/check/let_polymorphism_integration_test.zig
@@ -23,11 +23,11 @@ fn typeCheckExpr(allocator: std.mem.Allocator, source: []const u8) !struct {
 } {
     // Set up module environment
     const module_env = try allocator.create(ModuleEnv);
-    module_env.* = try ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    module_env.* = try ModuleEnv.init(allocator, source);
 
     // Parse
     const parse_ast = try allocator.create(parse.AST);
-    parse_ast.* = try parse.parseExpr(module_env, source);
+    parse_ast.* = try parse.parseExpr(module_env);
 
     // Check for parse errors
     if (parse_ast.hasErrors()) {
@@ -90,11 +90,11 @@ fn typeCheckFile(allocator: std.mem.Allocator, source: []const u8) !struct {
 } {
     // Set up module environment
     const module_env = try allocator.create(ModuleEnv);
-    module_env.* = try ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    module_env.* = try ModuleEnv.init(allocator, source);
 
     // Parse
     const parse_ast = try allocator.create(parse.AST);
-    parse_ast.* = parse.parse(module_env, source);
+    parse_ast.* = parse.parse(module_env);
 
     // Check for parse errors
     if (parse_ast.hasErrors()) {
@@ -162,11 +162,11 @@ fn typeCheckStatement(allocator: std.mem.Allocator, source: []const u8) !struct 
 } {
     // Set up module environment
     const module_env = try allocator.create(ModuleEnv);
-    module_env.* = try ModuleEnv.init(allocator, try allocator.dupe(u8, source));
+    module_env.* = try ModuleEnv.init(allocator, source);
 
     // Parse
     const parse_ast = try allocator.create(parse.AST);
-    parse_ast.* = try parse.parseStatement(module_env, source);
+    parse_ast.* = try parse.parseStatement(module_env);
 
     // Check for parse errors
     if (parse_ast.hasErrors()) {

--- a/src/check/parse.zig
+++ b/src/check/parse.zig
@@ -23,16 +23,16 @@ test {
     _ = @import("parse/test/ast_node_store_test.zig");
 }
 
-fn runParse(env: *base.ModuleEnv, source: []const u8, parserCall: *const fn (*Parser) std.mem.Allocator.Error!u32) std.mem.Allocator.Error!AST {
+fn runParse(env: *base.ModuleEnv, parserCall: *const fn (*Parser) std.mem.Allocator.Error!u32) std.mem.Allocator.Error!AST {
     const trace = tracy.trace(@src());
     defer trace.end();
 
     // Calculate and store line starts for diagnostic position calculation
-    try env.calcLineStarts(source);
+    try env.calcLineStarts();
 
     var messages: [128]tokenize.Diagnostic = undefined;
     const msg_slice = messages[0..];
-    var tokenizer = try tokenize.Tokenizer.init(env, source, msg_slice);
+    var tokenizer = try tokenize.Tokenizer.init(env, env.source, msg_slice);
     try tokenizer.tokenize();
     const result = tokenizer.finishAndDeinit();
 
@@ -57,8 +57,8 @@ fn runParse(env: *base.ModuleEnv, source: []const u8, parserCall: *const fn (*Pa
 
 /// Parses a single Roc file.  The returned AST should be deallocated by calling deinit
 /// after its data is used to create the next IR, or at the end of any test.
-pub fn parse(env: *base.ModuleEnv, source: []const u8) std.mem.Allocator.Error!AST {
-    return try runParse(env, source, parseFileAndReturnIdx);
+pub fn parse(env: *base.ModuleEnv) std.mem.Allocator.Error!AST {
+    return try runParse(env, parseFileAndReturnIdx);
 }
 
 fn parseFileAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
@@ -73,8 +73,8 @@ fn parseExprAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
 
 /// Parses a Roc expression - only for use in snapshots. The returned AST should be deallocated by calling deinit
 /// after its data is used to create the next IR, or at the end of any test.
-pub fn parseExpr(env: *base.ModuleEnv, source: []const u8) std.mem.Allocator.Error!AST {
-    return try runParse(env, source, parseExprAndReturnIdx);
+pub fn parseExpr(env: *base.ModuleEnv) std.mem.Allocator.Error!AST {
+    return try runParse(env, parseExprAndReturnIdx);
 }
 
 fn parseHeaderAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
@@ -84,8 +84,8 @@ fn parseHeaderAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
 
 /// Parses a Roc Header - only for use in snapshots. The returned AST should be deallocated by calling deinit
 /// after its data is used to create the next IR, or at the end of any test.
-pub fn parseHeader(env: *base.ModuleEnv, source: []const u8) std.mem.Allocator.Error!AST {
-    return try runParse(env, source, parseHeaderAndReturnIdx);
+pub fn parseHeader(env: *base.ModuleEnv) std.mem.Allocator.Error!AST {
+    return try runParse(env, parseHeaderAndReturnIdx);
 }
 
 fn parseStatementAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
@@ -98,6 +98,6 @@ fn parseStatementAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
 
 /// Parses a single Roc statement for use in snapshots. The returned AST should be deallocated by calling deinit
 /// after its data is used to create the next IR, or at the end of any test.
-pub fn parseStatement(env: *base.ModuleEnv, source: []const u8) std.mem.Allocator.Error!AST {
-    return try runParse(env, source, parseStatementAndReturnIdx);
+pub fn parseStatement(env: *base.ModuleEnv) std.mem.Allocator.Error!AST {
+    return try runParse(env, parseStatementAndReturnIdx);
 }

--- a/src/coordinate/ModuleGraph.zig
+++ b/src/coordinate/ModuleGraph.zig
@@ -111,7 +111,7 @@ fn loadOrCompileCanIr(
         // We should probably be reading the file on demand or something else. Leaving this
         // comment here so we discuss the plan and make the necessary changes.
         var module_env = base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
-        var parse_ir = parse.parse(&module_env, contents);
+        var parse_ir = parse.parse(&module_env);
         parse_ir.store.emptyScratch();
 
         // TODO Can we init CIR & the types store capacities based on the number

--- a/src/eval/eval_test.zig
+++ b/src/eval/eval_test.zig
@@ -24,12 +24,11 @@ fn parseAndCanonicalizeExpr(allocator: std.mem.Allocator, source: []const u8) st
 } {
     // Initialize the ModuleEnv
     const module_env = try allocator.create(base.ModuleEnv);
-    const owned_source = try allocator.dupe(u8, source);
-    module_env.* = try base.ModuleEnv.init(allocator, owned_source);
+    module_env.* = try base.ModuleEnv.init(allocator, source);
 
     // Parse the source code as an expression
     const parse_ast = try allocator.create(parse.AST);
-    parse_ast.* = try parse.parseExpr(module_env, source);
+    parse_ast.* = try parse.parseExpr(module_env);
 
     // Empty scratch space (required before canonicalization)
     parse_ast.store.emptyScratch();

--- a/src/layout/store_test.zig
+++ b/src/layout/store_test.zig
@@ -18,7 +18,7 @@ test "addTypeVar - str" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -45,7 +45,7 @@ test "addTypeVar - bool" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -71,7 +71,7 @@ test "addTypeVar - list of strings" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -103,7 +103,7 @@ test "addTypeVar - list of box of strings" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -142,7 +142,7 @@ test "addTypeVar - box of flex_var compiles to box of opaque_ptr" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -174,7 +174,7 @@ test "addTypeVar - num u32" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -201,7 +201,7 @@ test "addTypeVar - num f64" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -228,7 +228,7 @@ test "addTypeVar - list of num i128" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -261,7 +261,7 @@ test "addTypeVar - num dec" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -288,7 +288,7 @@ test "addTypeVar - flex num var defaults to i128" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -320,7 +320,7 @@ test "addTypeVar - flex int var defaults to i128" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -352,7 +352,7 @@ test "addTypeVar - flex frac var defaults to dec" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -384,7 +384,7 @@ test "addTypeVar - list of flex num var defaults to list of i128" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -422,7 +422,7 @@ test "addTypeVar - box of flex frac var defaults to box of dec" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -460,7 +460,7 @@ test "addTypeVar - box of rigid_var compiles to box of opaque_ptr" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -493,7 +493,7 @@ test "addTypeVar - box of empty record compiles to box_of_zst" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -522,7 +522,7 @@ test "addTypeVar - list of empty tag union compiles to list_of_zst" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -551,7 +551,7 @@ test "alignment - record alignment is max of field alignments" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -619,7 +619,7 @@ test "alignment - deeply nested record alignment (non-recursive)" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -683,7 +683,7 @@ test "addTypeVar - bare empty record returns error" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -706,7 +706,7 @@ test "addTypeVar - bare empty tag union returns error" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -729,7 +729,7 @@ test "addTypeVar - simple record" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -792,7 +792,7 @@ test "record size calculation" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -846,7 +846,7 @@ test "addTypeVar - nested record" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -934,7 +934,7 @@ test "addTypeVar - list of records" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -999,7 +999,7 @@ test "addTypeVar - record with extension" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -1078,7 +1078,7 @@ test "addTypeVar - record extension with str type fails" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -1109,7 +1109,7 @@ test "addTypeVar - record extension with num type fails" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -1140,7 +1140,7 @@ test "addTypeVar - deeply nested containers with zero-sized inner type" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -1180,7 +1180,7 @@ test "addTypeVar - record with single zero-sized field in container" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -1215,7 +1215,7 @@ test "addTypeVar - record field ordering stability" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -1320,7 +1320,7 @@ test "addTypeVar - empty record in different contexts" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -1366,7 +1366,7 @@ test "addTypeVar - record alignment edge cases" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -1426,7 +1426,7 @@ test "addTypeVar - record with duplicate field in extension (matching types)" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -1500,7 +1500,7 @@ test "addTypeVar - record with duplicate field in extension (mismatched types)" 
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -1567,7 +1567,7 @@ test "addTypeVar - record with invalid extension type" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -1598,7 +1598,7 @@ test "addTypeVar - record with chained extensions" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -1692,7 +1692,7 @@ test "addTypeVar - record with zero-sized fields dropped" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -1757,7 +1757,7 @@ test "addTypeVar - record with all zero-sized fields becomes empty" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -1793,7 +1793,7 @@ test "addTypeVar - box of record with all zero-sized fields" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -1839,7 +1839,7 @@ test "addTypeVar - comprehensive nested record combinations" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -2021,7 +2021,7 @@ test "addTypeVar - nested record with inner record having all zero-sized fields"
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -2071,7 +2071,7 @@ test "addTypeVar - list of record with all zero-sized fields" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -2108,7 +2108,7 @@ test "alignment - record with log2 alignment representation" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -2219,7 +2219,7 @@ test "record fields sorted by alignment then name" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -2299,7 +2299,7 @@ test "record fields with same alignment sorted by name" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     // Create type store
@@ -2370,7 +2370,7 @@ test "addTypeVar - maximum nesting depth" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -2409,7 +2409,7 @@ test "addTypeVar - record with maximum fields" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -2464,7 +2464,7 @@ test "addTypeVar - record field alignments differ between targets" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -2556,7 +2556,7 @@ test "addTypeVar - record field sorting follows alignment then name order" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -2642,7 +2642,7 @@ test "addTypeVar - pointer types have target-dependent alignment" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -2684,7 +2684,7 @@ test "addTypeVar - record with very long field names" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -2726,7 +2726,7 @@ test "addTypeVar - alternating zero-sized and non-zero-sized fields" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -2783,7 +2783,7 @@ test "addTypeVar - record field type changes through alias" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -2833,7 +2833,7 @@ test "addTypeVar - mixed container types" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -2916,7 +2916,7 @@ test "addTypeVar - record size calculation with padding" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -2989,7 +2989,7 @@ test "addTypeVar - all scalar types use scalar optimization" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -3055,7 +3055,7 @@ test "addTypeVar - list of scalar types uses scalar optimization" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -3121,7 +3121,7 @@ test "addTypeVar - box and list of non-scalar types use indexed approach" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -3188,7 +3188,7 @@ test "addTypeVar - host opaque types use scalar optimization" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -3227,7 +3227,7 @@ test "addTypeVar - mixed scalar optimization in nested structures" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -3257,7 +3257,7 @@ test "addTypeVar - all integer precisions use scalar optimization" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -3307,7 +3307,7 @@ test "addTypeVar - all boolean precisions use scalar optimization" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -3353,7 +3353,7 @@ test "addTypeVar - all frac precisions use scalar optimization" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);
@@ -3396,7 +3396,7 @@ test "layouts_by_var uses ArrayListMap with pre-allocation" {
     const testing = std.testing;
     const gpa = testing.allocator;
 
-    var module_env = try base.ModuleEnv.init(gpa, try gpa.dupe(u8, ""));
+    var module_env = try base.ModuleEnv.init(gpa, "");
     defer module_env.deinit();
 
     var type_store = try types_store.Store.init(gpa);

--- a/src/main.zig
+++ b/src/main.zig
@@ -517,7 +517,15 @@ fn rocCheck(gpa: Allocator, args: cli_args.CheckArgs) !void {
     } else null;
 
     // Process the file and get Reports
-    var process_result = coordinate_simple.processFile(gpa, Filesystem.default(), args.path, if (cache_manager) |*cm| cm else null, args.time) catch |err| handleProcessFileError(err, stderr, args.path);
+    var process_result = coordinate_simple.processFile(
+        gpa,
+        Filesystem.default(),
+        args.path,
+        if (cache_manager) |*cm| cm else null,
+        args.time,
+    ) catch |err| {
+        handleProcessFileError(err, stderr, args.path);
+    };
 
     defer process_result.deinit(gpa);
 

--- a/src/playground.zig
+++ b/src/playground.zig
@@ -308,9 +308,8 @@ fn compileSource(source: []const u8) !CompilerStageData {
     if (source.len == 0) {
         // Return empty compiler stage data for completely empty input
         var module_env = try allocator.create(ModuleEnv);
-        const owned_source = try allocator.dupe(u8, source);
-        module_env.* = try ModuleEnv.init(allocator, owned_source);
-        try module_env.calcLineStarts(source);
+        module_env.* = try ModuleEnv.init(allocator, source);
+        try module_env.calcLineStarts();
         return CompilerStageData.init(allocator, module_env);
     }
 
@@ -318,9 +317,8 @@ fn compileSource(source: []const u8) !CompilerStageData {
     if (trimmed_source.len == 0) {
         // Return empty compiler stage data for whitespace-only input
         var module_env = try allocator.create(ModuleEnv);
-        const owned_source = try allocator.dupe(u8, source);
-        module_env.* = try ModuleEnv.init(allocator, owned_source);
-        try module_env.calcLineStarts(source);
+        module_env.* = try ModuleEnv.init(allocator, source);
+        try module_env.calcLineStarts();
         return CompilerStageData.init(allocator, module_env);
     }
 
@@ -329,14 +327,13 @@ fn compileSource(source: []const u8) !CompilerStageData {
 
     // Initialize the ModuleEnv
     var module_env = try allocator.create(ModuleEnv);
-    const owned_source = try allocator.dupe(u8, source);
-    module_env.* = try ModuleEnv.init(allocator, owned_source);
-    try module_env.calcLineStarts(source);
+    module_env.* = try ModuleEnv.init(allocator, source);
+    try module_env.calcLineStarts();
 
     var result = CompilerStageData.init(allocator, module_env);
 
     // Stage 1: Parse (includes tokenization)
-    var parse_ast = try parse.parse(module_env, source);
+    var parse_ast = try parse.parse(module_env);
     result.parse_ast = parse_ast;
 
     // Collect tokenize diagnostics with additional error handling
@@ -379,7 +376,7 @@ fn compileSource(source: []const u8) !CompilerStageData {
     // Collect canonicalization diagnostics
     const can_diags = can_ir.getDiagnostics() catch &.{};
     for (can_diags) |diag| {
-        const report = can_ir.diagnosticToReport(diag, allocator, source, "main.roc") catch continue;
+        const report = can_ir.diagnosticToReport(diag, allocator, "main.roc") catch continue;
         result.can_reports.append(report) catch continue;
     }
 
@@ -399,7 +396,6 @@ fn compileSource(source: []const u8) !CompilerStageData {
             module_env,
             type_can_ir,
             &solver.snapshots,
-            source,
             "main.roc",
             &.{}, // other_modules - empty for playground
         );
@@ -704,7 +700,7 @@ fn writeCanCirResponse(response_buffer: []u8, data: CompilerStageData) usize {
     }
 
     const mutable_cir = @constCast(&cir);
-    can.CIR.pushToSExprTree(mutable_cir, null, &tree, data.module_env.source) catch {};
+    can.CIR.pushToSExprTree(mutable_cir, null, &tree) catch {};
     tree.toHtml(sexpr_writer) catch {};
 
     // Success case - write the response
@@ -868,7 +864,7 @@ fn writeTypesResponse(response_buffer: []u8, data: CompilerStageData) usize {
 
     // Use the same as snapshot system
     const mutable_cir = @constCast(&cir);
-    mutable_cir.pushTypesToSExprTree(null, &tree, data.module_env.source) catch |err| {
+    mutable_cir.pushTypesToSExprTree(null, &tree) catch |err| {
         // If type generation fails, return an error message
         const error_msg = switch (err) {
             error.OutOfMemory => "Out of memory while generating types",

--- a/src/repl/eval.zig
+++ b/src/repl/eval.zig
@@ -39,16 +39,12 @@ pub const Repl = struct {
 
     /// Process a single REPL input and return the output
     pub fn step(self: *Repl, input: []const u8) Allocator.Error![]const u8 {
-        // Trim whitespace from input
-        const trimmed = std.mem.trim(u8, input, " \t\n\r");
-
         // Create a fresh module environment for this evaluation
-        const source = try self.allocator.dupe(u8, trimmed);
-        var module_env = try base.ModuleEnv.init(self.allocator, source);
+        var module_env = try base.ModuleEnv.init(self.allocator, input);
         defer module_env.deinit();
 
         // Parse the expression
-        var parse_ast = parse.parseExpr(&module_env, trimmed) catch |err| {
+        var parse_ast = parse.parseExpr(&module_env) catch |err| {
             return try std.fmt.allocPrint(self.allocator, "Parse error: {}", .{err});
         };
         defer parse_ast.deinit(self.allocator);

--- a/src/test.zig
+++ b/src/test.zig
@@ -30,6 +30,12 @@ test {
     testing.refAllDeclsRecursive(@import("check/check_types/let_polymorphism_test.zig"));
     testing.refAllDeclsRecursive(@import("check/check_types/test/static_dispatch_test.zig"));
     testing.refAllDeclsRecursive(@import("check/check_types/test/nominal_type_origin_test.zig"));
+    // These seem to be broken:
+    // testing.refAllDeclsRecursive(@import("check/canonicalize/test/int_test.zig"));
+    // testing.refAllDeclsRecursive(@import("check/canonicalize/test/node_store_test.zig"));
+    // testing.refAllDeclsRecursive(@import("check/canonicalize/test/frac_test.zig"));
+    // testing.refAllDeclsRecursive(@import("check/canonicalize/test/import_validation_test.zig"));
+    // testing.refAllDeclsRecursive(@import("check/canonicalize/test/exposed_shadowing_test.zig"));
     testing.refAllDeclsRecursive(@import("snapshot.zig"));
     testing.refAllDeclsRecursive(@import("layout/layout.zig"));
     testing.refAllDeclsRecursive(@import("layout/store.zig"));


### PR DESCRIPTION
* ModuleEnv no longer owns the source - instead it expects a higher-level component to own that
* Removes dups from many callsites! (mostly tests)
* When we have a ModuleEnv, get the source directly from that rather than making it be passed in redundantly
