### PR TITLE
Fix parse crash caused by single question suffix formatting

### DIFF
--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -2031,6 +2031,13 @@ const Formatter = struct {
 
                         return false;
                     },
+                    .suffix_single_question => |s| {
+                        if (fmt.nodeWillBeMultiline(AST.Expr.Idx, s.expr)) {
+                            return true;
+                        }
+
+                        return false;
+                    },
                     else => return false,
                 }
             },
@@ -2049,7 +2056,9 @@ const Formatter = struct {
                 }
 
                 if (patternRecordField.value) |value| {
-                    return fmt.nodeWillBeMultiline(AST.Pattern.Idx, value);
+                    if (fmt.nodeWillBeMultiline(AST.Pattern.Idx, value)) {
+                        return true;
+                    }
                 }
 
                 return false;
@@ -2069,7 +2078,9 @@ const Formatter = struct {
                 }
 
                 if (recordField.value) |value| {
-                    return fmt.nodeWillBeMultiline(AST.Expr.Idx, value);
+                    if (fmt.nodeWillBeMultiline(AST.Expr.Idx, value)) {
+                        return true;
+                    }
                 }
 
                 return false;

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -1990,33 +1990,21 @@ const Formatter = struct {
                 switch (expr) {
                     .block => return true,
                     .tuple => |t| {
-                        if (fmt.nodesWillBeMultiline(AST.Expr.Idx, fmt.ast.store.exprSlice(t.items))) {
-                            return true;
-                        }
-
-                        return false;
+                        return fmt.nodesWillBeMultiline(AST.Expr.Idx, fmt.ast.store.exprSlice(t.items));
                     },
                     .apply => |a| {
                         if (fmt.nodeWillBeMultiline(AST.Expr.Idx, a.@"fn")) {
                             return true;
                         }
 
-                        if (fmt.nodesWillBeMultiline(AST.Expr.Idx, fmt.ast.store.exprSlice(a.args))) {
-                            return true;
-                        }
-
-                        return false;
+                        return fmt.nodesWillBeMultiline(AST.Expr.Idx, fmt.ast.store.exprSlice(a.args));
                     },
                     .bin_op => |b| {
                         if (fmt.nodeWillBeMultiline(AST.Expr.Idx, b.left)) {
                             return true;
                         }
 
-                        if (fmt.nodeWillBeMultiline(AST.Expr.Idx, b.right)) {
-                            return true;
-                        }
-
-                        return false;
+                        return fmt.nodeWillBeMultiline(AST.Expr.Idx, b.right);
                     },
                     .record => |r| {
                         if (r.ext) |ext| {
@@ -2025,29 +2013,17 @@ const Formatter = struct {
                             }
                         }
 
-                        if (fmt.nodesWillBeMultiline(AST.RecordField.Idx, fmt.ast.store.recordFieldSlice(r.fields))) {
-                            return true;
-                        }
-
-                        return false;
+                        return fmt.nodesWillBeMultiline(AST.RecordField.Idx, fmt.ast.store.recordFieldSlice(r.fields));
                     },
                     .suffix_single_question => |s| {
-                        if (fmt.nodeWillBeMultiline(AST.Expr.Idx, s.expr)) {
-                            return true;
-                        }
-
-                        return false;
+                        return fmt.nodeWillBeMultiline(AST.Expr.Idx, s.expr);
                     },
                     else => return false,
                 }
             },
             AST.Pattern.Idx => {
                 const pattern = fmt.ast.store.getPattern(item);
-                if (fmt.ast.regionIsMultiline(pattern.to_tokenized_region())) {
-                    return true;
-                }
-
-                return false;
+                return fmt.ast.regionIsMultiline(pattern.to_tokenized_region());
             },
             AST.PatternRecordField.Idx => {
                 const patternRecordField = fmt.ast.store.getPatternRecordField(item);
@@ -2065,11 +2041,7 @@ const Formatter = struct {
             },
             AST.ExposedItem.Idx => {
                 const exposedItem = fmt.ast.store.getExposedItem(item);
-                if (fmt.ast.regionIsMultiline(exposedItem.to_tokenized_region())) {
-                    return true;
-                }
-
-                return false;
+                return fmt.ast.regionIsMultiline(exposedItem.to_tokenized_region());
             },
             AST.RecordField.Idx => {
                 const recordField = fmt.ast.store.getRecordField(item);
@@ -2087,11 +2059,7 @@ const Formatter = struct {
             },
             AST.TypeAnno.Idx => {
                 const typeAnno = fmt.ast.store.getTypeAnno(item);
-                if (fmt.ast.regionIsMultiline(typeAnno.to_tokenized_region())) {
-                    return true;
-                }
-
-                return false;
+                return fmt.ast.regionIsMultiline(typeAnno.to_tokenized_region());
             },
             AST.AnnoRecordField.Idx => {
                 const annoRecordField = fmt.ast.store.getAnnoRecordField(item) catch return false;
@@ -2099,19 +2067,11 @@ const Formatter = struct {
                     return true;
                 }
 
-                if (fmt.nodeWillBeMultiline(AST.TypeAnno.Idx, annoRecordField.ty)) {
-                    return true;
-                }
-
-                return false;
+                return fmt.nodeWillBeMultiline(AST.TypeAnno.Idx, annoRecordField.ty);
             },
             AST.WhereClause.Idx => {
                 const whereClause = fmt.ast.store.getWhereClause(item);
-                if (fmt.ast.regionIsMultiline(whereClause.to_tokenized_region())) {
-                    return true;
-                }
-
-                return false;
+                return fmt.ast.regionIsMultiline(whereClause.to_tokenized_region());
             },
             AST.Statement.Idx => {
                 const statement = fmt.ast.store.getStatement(item);
@@ -2121,11 +2081,7 @@ const Formatter = struct {
 
                 switch (statement) {
                     .expr => |e| {
-                        if (fmt.nodeWillBeMultiline(AST.Expr.Idx, e.expr)) {
-                            return true;
-                        }
-
-                        return false;
+                        return fmt.nodeWillBeMultiline(AST.Expr.Idx, e.expr);
                     },
                     else => return false,
                 }
@@ -2136,11 +2092,7 @@ const Formatter = struct {
                     return true;
                 }
 
-                if (fmt.nodesWillBeMultiline(AST.TypeAnno.Idx, fmt.ast.store.typeAnnoSlice(typeHeader.args))) {
-                    return true;
-                }
-
-                return false;
+                return fmt.nodesWillBeMultiline(AST.TypeAnno.Idx, fmt.ast.store.typeAnnoSlice(typeHeader.args));
             },
             AST.Header.Idx => {
                 const header = fmt.ast.store.getHeader(item);
@@ -2154,11 +2106,7 @@ const Formatter = struct {
                             return true;
                         }
 
-                        if (fmt.collectionWillBeMultiline(AST.RecordField.Idx, p.packages)) {
-                            return true;
-                        }
-
-                        return false;
+                        return fmt.collectionWillBeMultiline(AST.RecordField.Idx, p.packages);
                     },
                     else => return false,
                 }

--- a/src/snapshots/fuzz_crash/fuzz_crash_071.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_071.md
@@ -1,0 +1,58 @@
+# META
+~~~ini
+description=fuzz crash
+type=file
+~~~
+# SOURCE
+~~~roc
+package[]{d:{{d:{0}?}}}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+KwPackage(1:1-1:8),OpenSquare(1:8-1:9),CloseSquare(1:9-1:10),OpenCurly(1:10-1:11),LowerIdent(1:11-1:12),OpColon(1:12-1:13),OpenCurly(1:13-1:14),OpenCurly(1:14-1:15),LowerIdent(1:15-1:16),OpColon(1:16-1:17),OpenCurly(1:17-1:18),Int(1:18-1:19),CloseCurly(1:19-1:20),NoSpaceOpQuestion(1:20-1:21),CloseCurly(1:21-1:22),CloseCurly(1:22-1:23),CloseCurly(1:23-1:24),EndOfFile(1:24-1:24),
+~~~
+# PARSE
+~~~clojure
+(file @1.1-1.24
+	(package @1.1-1.24
+		(exposes @1.8-1.10)
+		(packages @1.10-1.24
+			(record-field @1.11-1.23 (name "d")
+				(e-block @1.13-1.23
+					(statements
+						(e-record @1.14-1.22
+							(field (field "d")
+								(e-question-suffix @1.17-1.21
+									(e-block @1.17-1.20
+										(statements
+											(e-int @1.18-1.19 (raw "0"))))))))))))
+	(statements))
+~~~
+# FORMATTED
+~~~roc
+package
+	[]
+	{
+		d: {
+			{
+				d: {
+					0
+				}?,
+			}
+		},
+	}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir (empty true))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(expressions))
+~~~


### PR DESCRIPTION
```
zig build repro-parse -- -b cGFja2FnZVtde2Q6e3tkOnswfT99fX0= -v
```