### PR TITLE
Fix parse crash caused by unary op formatting

### DIFF
--- a/ci/benchmarks/bench-runner/src/main.rs
+++ b/ci/benchmarks/bench-runner/src/main.rs
@@ -139,7 +139,7 @@ fn do_benchmark(branch_name: &'static str) -> HashSet<String> {
     let bench_name_regex = Regex::new(r#"".*""#).expect("Failed to build regex");
 
     for line in stdout_lines {
-        let line_str = line.expect("Failed to get output from banchmark command.");
+        let line_str = line.expect("Failed to get output from benchmark command.");
 
         if line_str.contains("regressed") {
             let regressed_bench_name_line = last_three_lines_queue.get(2).expect(

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -2018,6 +2018,9 @@ const Formatter = struct {
                     .suffix_single_question => |s| {
                         return fmt.nodeWillBeMultiline(AST.Expr.Idx, s.expr);
                     },
+                    .unary_op => |u| {
+                        return fmt.nodeWillBeMultiline(AST.Expr.Idx, u.expr);
+                    },
                     else => return false,
                 }
             },

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -1855,7 +1855,7 @@ pub fn parseExprWithBp(self: *Parser, min_bp: u8) std.mem.Allocator.Error!AST.Ex
                 self.advance(); // consume DoubleDot
 
                 // Parse the extension
-                const ext_expr = try self.parseExprWithBp(0);
+                const ext_expr = try self.parseExpr();
 
                 // Expect comma after extension
                 if (self.peek() != .Comma) {

--- a/src/snapshots/fuzz_crash/fuzz_crash_072.md
+++ b/src/snapshots/fuzz_crash/fuzz_crash_072.md
@@ -1,0 +1,60 @@
+# META
+~~~ini
+description=fuzz crash
+type=file
+~~~
+# SOURCE
+~~~roc
+module[]({})(!{0})
+~~~
+# EXPECTED
+INVALID STATEMENT - fuzz_crash_072.md:1:9:1:19
+# PROBLEMS
+**INVALID STATEMENT**
+The statement `expression` is not allowed at the top level.
+Only definitions, type annotations, and imports are allowed at the top level.
+
+**fuzz_crash_072.md:1:9:1:19:**
+```roc
+module[]({})(!{0})
+```
+        ^^^^^^^^^^
+
+
+# TOKENS
+~~~zig
+KwModule(1:1-1:7),OpenSquare(1:7-1:8),CloseSquare(1:8-1:9),NoSpaceOpenRound(1:9-1:10),OpenCurly(1:10-1:11),CloseCurly(1:11-1:12),CloseRound(1:12-1:13),NoSpaceOpenRound(1:13-1:14),OpBang(1:14-1:15),OpenCurly(1:15-1:16),Int(1:16-1:17),CloseCurly(1:17-1:18),CloseRound(1:18-1:19),EndOfFile(1:19-1:19),
+~~~
+# PARSE
+~~~clojure
+(file @1.1-1.19
+	(module @1.1-1.9
+		(exposes @1.7-1.9))
+	(statements
+		(e-apply @1.9-1.19
+			(e-tuple @1.9-1.13
+				(e-record @1.10-1.12))
+			(unary "!"
+				(e-block @1.15-1.18
+					(statements
+						(e-int @1.16-1.17 (raw "0"))))))))
+~~~
+# FORMATTED
+~~~roc
+module []
+({})(
+	!{
+		0
+	},
+)
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir (empty true))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(expressions))
+~~~


### PR DESCRIPTION
```
zig build repro-parse -- -b bW9kdWxlW10oe30pKCF7MH0p -v
```