### PR TITLE
Use a nesting counter to protect against stack overflow in parser

### DIFF
--- a/src/eval/test/helpers.zig
+++ b/src/eval/test/helpers.zig
@@ -18,6 +18,7 @@ const Layout = layout.Layout;
 const Closure = eval.Closure;
 const testing = std.testing;
 const test_allocator = testing.allocator;
+const ParseError = parse.Parser.Error;
 
 /// Helper function to run an expression and expect a specific error.
 pub fn runExpectError(src: []const u8, expected_error: eval.EvalError, should_trace: enum { trace, no_trace }) !void {
@@ -270,7 +271,7 @@ pub fn runExpectRecord(src: []const u8, expected_fields: []const ExpectedField, 
 }
 
 /// Parse and canonicalize an expression.
-pub fn parseAndCanonicalizeExpr(allocator: std.mem.Allocator, source: []const u8) std.mem.Allocator.Error!struct {
+pub fn parseAndCanonicalizeExpr(allocator: std.mem.Allocator, source: []const u8) ParseError!struct {
     module_env: *ModuleEnv,
     parse_ast: *parse.AST,
     can: *Can,

--- a/src/fmt.zig
+++ b/src/fmt.zig
@@ -2148,7 +2148,12 @@ pub fn moduleFmtsStable(gpa: std.mem.Allocator, input: []const u8, debug: bool) 
         std.debug.print("Original:\n==========\n{s}\n==========\n\n", .{input});
     }
 
-    const formatted = try parseAndFmt(gpa, input, debug);
+    const formatted = parseAndFmt(gpa, input, debug) catch |err| {
+        switch (err) {
+            error.TooNested => return error.ParseFailed,
+            else => return err,
+        }
+    };
     defer gpa.free(formatted);
 
     const formatted_twice = parseAndFmt(gpa, formatted, debug) catch {

--- a/src/fuzz-canonicalize.zig
+++ b/src/fuzz-canonicalize.zig
@@ -74,6 +74,9 @@ pub fn zig_fuzz_test_inner(buf: [*]u8, len: isize, debug: bool) void {
             error.NoSpaceLeft => {
                 @panic("No Space Left");
             },
+            error.TooNested => {
+                @panic("Too much nesting");
+            },
         }
     };
     defer result.deinit(gpa);

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -120,16 +120,18 @@ pub fn peekN(self: *Parser, n: u32) Token.Tag {
 }
 
 const StackError = error{TooNested};
+
+/// The error set that methods of the Parser return
 pub const Error = std.mem.Allocator.Error || StackError;
 
-pub fn nest(self: *Parser) !void {
+fn nest(self: *Parser) !void {
     if (self.nesting_counter == 0) {
         return StackError.TooNested;
     }
     self.nesting_counter = self.nesting_counter - 1;
 }
 
-pub fn unnest(self: *Parser) void {
+fn unnest(self: *Parser) void {
     if (self.nesting_counter >= MAX_NESTING_LEVELS) {
         return;
     }

--- a/src/parse/mod.zig
+++ b/src/parse/mod.zig
@@ -28,7 +28,7 @@ pub const NodeStore = @import("NodeStore.zig");
 /// Represents the intermediate representation or Abstract Syntax Tree (AST) of a parsed Roc file.
 pub const AST = @import("AST.zig");
 
-fn runParse(env: *ModuleEnv, parserCall: *const fn (*Parser) std.mem.Allocator.Error!u32) std.mem.Allocator.Error!AST {
+fn runParse(env: *ModuleEnv, parserCall: *const fn (*Parser) Parser.Error!u32) Parser.Error!AST {
     const trace = tracy.trace(@src());
     defer trace.end();
 
@@ -62,38 +62,38 @@ fn runParse(env: *ModuleEnv, parserCall: *const fn (*Parser) std.mem.Allocator.E
 
 /// Parses a single Roc file.  The returned AST should be deallocated by calling deinit
 /// after its data is used to create the next IR, or at the end of any test.
-pub fn parse(env: *ModuleEnv) std.mem.Allocator.Error!AST {
+pub fn parse(env: *ModuleEnv) Parser.Error!AST {
     return try runParse(env, parseFileAndReturnIdx);
 }
 
-fn parseFileAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
+fn parseFileAndReturnIdx(parser: *Parser) Parser.Error!u32 {
     try parser.parseFile();
     return 0;
 }
 
-fn parseExprAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
+fn parseExprAndReturnIdx(parser: *Parser) Parser.Error!u32 {
     const id = try parser.parseExpr();
     return @intFromEnum(id);
 }
 
 /// Parses a Roc expression - only for use in snapshots. The returned AST should be deallocated by calling deinit
 /// after its data is used to create the next IR, or at the end of any test.
-pub fn parseExpr(env: *ModuleEnv) std.mem.Allocator.Error!AST {
+pub fn parseExpr(env: *ModuleEnv) Parser.Error!AST {
     return try runParse(env, parseExprAndReturnIdx);
 }
 
-fn parseHeaderAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
+fn parseHeaderAndReturnIdx(parser: *Parser) Parser.Error!u32 {
     const id = try parser.parseHeader();
     return @intFromEnum(id);
 }
 
 /// Parses a Roc Header - only for use in snapshots. The returned AST should be deallocated by calling deinit
 /// after its data is used to create the next IR, or at the end of any test.
-pub fn parseHeader(env: *ModuleEnv) std.mem.Allocator.Error!AST {
+pub fn parseHeader(env: *ModuleEnv) Parser.Error!AST {
     return try runParse(env, parseHeaderAndReturnIdx);
 }
 
-fn parseStatementAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
+fn parseStatementAndReturnIdx(parser: *Parser) Parser.Error!u32 {
     const maybe_statement_idx = try parser.parseStmt();
     if (maybe_statement_idx) |idx| {
         return @intFromEnum(idx);
@@ -103,6 +103,6 @@ fn parseStatementAndReturnIdx(parser: *Parser) std.mem.Allocator.Error!u32 {
 
 /// Parses a single Roc statement for use in snapshots. The returned AST should be deallocated by calling deinit
 /// after its data is used to create the next IR, or at the end of any test.
-pub fn parseStatement(env: *ModuleEnv) std.mem.Allocator.Error!AST {
+pub fn parseStatement(env: *ModuleEnv) Parser.Error!AST {
     return try runParse(env, parseStatementAndReturnIdx);
 }


### PR DESCRIPTION
This limits the maximum level of nesting for expressions to 128.

We use a nesting counter that decrements as we nest (enter parseExprWithBp), and increments as we unnest (leaving that same function using `defer`).  When we decrement, if the counter is already at 0 we throw a StackError.TooNested.

This requires the Parser to have it's own named error union and updating all of the parsing functions that can call parseExpr directly or indirectly to use that new error union, and all catches from those functions to handle that new value.

I think this will help the fuzzer in the short term, and is a pretty benign change.  Long term we might want to think about how we can get around this nesting limit -  even if 128 levels of nesting in an expression is probably already past the limits of human understanding.