### PR TITLE
Do not permit null bytes in platform paths

### DIFF
--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -860,7 +860,15 @@ pub const BuildEnv = struct {
                     }
                 }
 
-                break :blk try buf.toOwnedSlice();
+                const result = try buf.toOwnedSlice();
+                
+                // Check for null bytes in the string, which are invalid in file paths
+                if (std.mem.indexOfScalar(u8, result, 0) != null) {
+                    self.gpa.free(result);
+                    return error.InvalidNullByteInPath;
+                }
+                
+                break :blk result;
             },
             else => error.ExpectedString,
         };


### PR DESCRIPTION
Fuzz fix

```
$ zig build repro-canonicalize -- -b YXBwW117ZzpwbGF0Zm9ybSIAIn0= -v
Using bytes as base64 encoded repro: YXBwW117ZzpwbGF0Zm9ybSIAIn0=
Input:
==========
app[]{g:platform""}
==========

Processing completed with 0 reports
```