### PR TITLE
Don't treat parser's too nested error as a canonicalize error

### DIFF
--- a/test/fuzzing/fuzz-canonicalize.zig
+++ b/test/fuzzing/fuzz-canonicalize.zig
@@ -85,7 +85,10 @@ pub fn zig_fuzz_test_inner(buf: [*]u8, len: isize, debug: bool) void {
         switch (err) {
             error.OutOfMemory => @panic("OOM"),
             error.NoSpaceLeft => @panic("No Space Left"),
-            error.TooNested => @panic("Too much nesting"),
+            error.TooNested => {
+                // This comes from the parser, so don't treat it as a canonicalize error
+                return;
+            },
             else => {},
         }
     };


### PR DESCRIPTION
```
zig build repro-canonicalize -- -b MApwPXt7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3t7e3sw -v
```