### PR TITLE
Support string equality in the interpreter

### DIFF
--- a/src/cli/cli_args.zig
+++ b/src/cli/cli_args.zig
@@ -91,6 +91,7 @@ pub const TestArgs = struct {
     path: []const u8, // the path to the file to be tested
     opt: OptLevel, // the optimization level to be used for test execution
     main: ?[]const u8, // the path to a roc file with an app header to be used to resolve dependencies
+    verbose: bool = false, // enable verbose output showing individual test results
 };
 
 /// Arguments for `roc format`
@@ -449,6 +450,7 @@ fn parseTest(args: []const []const u8) CliArgs {
     var path: ?[]const u8 = null;
     var opt: OptLevel = .dev;
     var main: ?[]const u8 = null;
+    var verbose: bool = false;
     for (args) |arg| {
         if (isHelpFlag(arg)) {
             return CliArgs{ .help = 
@@ -462,6 +464,7 @@ fn parseTest(args: []const []const u8) CliArgs {
             \\Options:
             \\      --opt=<size|speed|dev>  Optimize the build process for binary size, execution speed, or compilation speed. Defaults to compilation speed dev
             \\      --main <main>           The .roc file of the main app/package module to resolve dependencies from
+            \\      --verbose               Enable verbose output showing individual test results
             \\  -h, --help                  Print help
             \\
         };
@@ -481,6 +484,8 @@ fn parseTest(args: []const []const u8) CliArgs {
             } else {
                 return CliArgs{ .problem = CliProblem{ .missing_flag_value = .{ .flag = "--opt" } } };
             }
+        } else if (mem.eql(u8, arg, "--verbose")) {
+            verbose = true;
         } else {
             if (path != null) {
                 return CliArgs{ .problem = CliProblem{ .unexpected_argument = .{ .cmd = "test", .arg = arg } } };
@@ -488,7 +493,7 @@ fn parseTest(args: []const []const u8) CliArgs {
             path = arg;
         }
     }
-    return CliArgs{ .test_cmd = TestArgs{ .path = path orelse "main.roc", .opt = opt, .main = main } };
+    return CliArgs{ .test_cmd = TestArgs{ .path = path orelse "main.roc", .opt = opt, .main = main, .verbose = verbose } };
 }
 
 fn parseRepl(args: []const []const u8) CliArgs {

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1508,6 +1508,9 @@ fn rocTest(gpa: Allocator, args: cli_args.TestArgs) !void {
     const trace = tracy.trace(@src());
     defer trace.end();
 
+    // Start timing
+    const start_time = std.time.nanoTimestamp();
+
     const stdout = std.io.getStdOut().writer();
     const stderr = std.io.getStdErr().writer();
 
@@ -1593,7 +1596,7 @@ fn rocTest(gpa: Allocator, args: cli_args.TestArgs) !void {
         return;
     }
 
-    try stdout.print("Running test(s) in {s}... ", .{args.path});
+    try stdout.print("Running {} test(s) in {s}...\n", .{ expects.items.len, args.path });
 
     // Create interpreter infrastructure for test evaluation
     var stack_memory = eval.Stack.initCapacity(gpa, 1024) catch |err| {
@@ -1618,15 +1621,28 @@ fn rocTest(gpa: Allocator, args: cli_args.TestArgs) !void {
     defer interpreter.deinit(test_env.get_ops());
     test_env.setInterpreter(&interpreter);
 
+    // Track test results for verbose output
+    const TestResult = struct {
+        line_number: u32,
+        passed: bool,
+        error_msg: ?[]const u8 = null,
+    };
+
+    var test_results = std.ArrayList(TestResult).init(gpa);
+    defer test_results.deinit();
+
     // Evaluate each expect statement
     var passed: u32 = 0;
     var failed: u32 = 0;
 
     for (expects.items) |expect_test| {
+        const region_info = env.calcRegionInfo(expect_test.region);
+        const line_number = region_info.start_line_idx + 1;
+
         // Evaluate the expect expression
         const result = interpreter.eval(expect_test.expr_idx, test_env.get_ops()) catch |err| {
-            const region_info = env.calcRegionInfo(expect_test.region);
-            try stderr.print("Test evaluation failed at line {}: {}\n", .{ region_info.start_line_idx + 1, err });
+            const error_msg = try std.fmt.allocPrint(gpa, "Test evaluation failed: {}", .{err});
+            try test_results.append(.{ .line_number = line_number, .passed = false, .error_msg = error_msg });
             failed += 1;
             continue;
         };
@@ -1635,23 +1651,58 @@ fn rocTest(gpa: Allocator, args: cli_args.TestArgs) !void {
         if (result.layout.tag == .scalar and result.layout.data.scalar.tag == .bool) {
             const is_true = result.asBool();
             if (is_true) {
+                try test_results.append(.{ .line_number = line_number, .passed = true });
                 passed += 1;
             } else {
-                const region_info = env.calcRegionInfo(expect_test.region);
-                try stderr.print("Test failed at line {}\n", .{region_info.start_line_idx + 1});
+                try test_results.append(.{ .line_number = line_number, .passed = false });
                 failed += 1;
             }
         } else {
-            // Result is not a boolean - this is a test error
-            const region_info = env.calcRegionInfo(expect_test.region);
-            try stderr.print("Test at line {} did not evaluate to a boolean\n", .{region_info.start_line_idx + 1});
+            const error_msg = try gpa.dupe(u8, "Test did not evaluate to a boolean");
+            try test_results.append(.{ .line_number = line_number, .passed = false, .error_msg = error_msg });
             failed += 1;
         }
     }
 
+    // Calculate elapsed time
+    const end_time = std.time.nanoTimestamp();
+    const elapsed_ns = @as(u64, @intCast(end_time - start_time));
+    const elapsed_ms = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000.0;
+
+    // Free allocated error messages
+    for (test_results.items) |test_result| {
+        if (test_result.error_msg) |msg| {
+            gpa.free(msg);
+        }
+    }
+
     // Report results
-    try stdout.print("{} passed, {} failed\n", .{ passed, failed });
-    if (failed > 0) {
+    if (failed == 0) {
+        // Success case: print nothing, exit with 0
+        if (args.verbose) {
+            for (test_results.items) |test_result| {
+                try stdout.print("PASS: line {}\n", .{test_result.line_number});
+            }
+        }
+        return; // Exit with 0
+    } else {
+        // Failure case: print summary
+        try stderr.print("Ran {} test(s): {} passed, {} failed in {d:.1}ms\n", .{ passed + failed, passed, failed, elapsed_ms });
+
+        if (args.verbose) {
+            for (test_results.items) |test_result| {
+                if (test_result.passed) {
+                    try stderr.print("PASS: line {}\n", .{test_result.line_number});
+                } else {
+                    if (test_result.error_msg) |msg| {
+                        try stderr.print("FAIL: line {} - {s}\n", .{ test_result.line_number, msg });
+                    } else {
+                        try stderr.print("FAIL: line {}\n", .{test_result.line_number});
+                    }
+                }
+            }
+        }
+
         std.process.exit(1);
     }
 }

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1596,8 +1596,6 @@ fn rocTest(gpa: Allocator, args: cli_args.TestArgs) !void {
         return;
     }
 
-    try stdout.print("Running {} test(s) in {s}...\n", .{ expects.items.len, args.path });
-
     // Create interpreter infrastructure for test evaluation
     var stack_memory = eval.Stack.initCapacity(gpa, 1024) catch |err| {
         try stderr.print("Failed to create stack memory: {}\n", .{err});
@@ -1678,15 +1676,17 @@ fn rocTest(gpa: Allocator, args: cli_args.TestArgs) !void {
 
     // Report results
     if (failed == 0) {
-        // Success case: print nothing, exit with 0
+        // Success case: only print if verbose, exit with 0
         if (args.verbose) {
+            try stdout.print("Ran {} test(s): {} passed, 0 failed in {d:.1}ms\n", .{ passed, passed, elapsed_ms });
             for (test_results.items) |test_result| {
                 try stdout.print("PASS: line {}\n", .{test_result.line_number});
             }
         }
+        // Otherwise print nothing at all
         return; // Exit with 0
     } else {
-        // Failure case: print summary
+        // Failure case: always print summary with timing
         try stderr.print("Ran {} test(s): {} passed, {} failed in {d:.1}ms\n", .{ passed + failed, passed, failed, elapsed_ms });
 
         if (args.verbose) {

--- a/src/eval/StackValue.zig
+++ b/src/eval/StackValue.zig
@@ -462,13 +462,8 @@ pub fn asClosure(self: StackValue) *const Closure {
     return @ptrCast(@alignCast(self.ptr.?));
 }
 
-/// Clone this value for binding (handles ref counting)
-pub fn cloneForBinding(self: StackValue) StackValue {
-    if (self.layout.tag == .scalar and self.layout.data.scalar.tag == .str) {
-        const roc_str = self.asRocStr();
-        roc_str.incref(1);
-    }
-    // For non-strings, just reference the same memory
+/// Move this value to binding (transfers ownership, no refcounts change)
+pub fn moveForBinding(self: StackValue) StackValue {
     return self;
 }
 

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -236,7 +236,6 @@ const Binding = struct {
     pub fn cleanup(self: *const Binding, roc_ops: *RocOps) void {
         if (self.value.layout.tag == .scalar and self.value.layout.data.scalar.tag == .str) {
             const roc_str = self.value.asRocStr();
-            // std.debug.print("STR_TRACE: binding cleanup - about to decref string \"{s}\" at {*}\n", .{ roc_str.asSlice(), roc_str });
             roc_str.decref(roc_ops);
         }
     }
@@ -488,7 +487,7 @@ pub const Interpreter = struct {
                     const pattern_idx: CIR.Pattern.Idx = work.extra.decl_pattern_idx;
                     const value = try self.peekStackValue(1); // Don't pop!
 
-                    try self.bindPattern(pattern_idx, value, roc_ops); // Ownership moved to binding (immutable semantics)
+                    try self.bindPattern(pattern_idx, value, roc_ops); // Value stays on stack for the block's lifetime
                 },
                 .w_recursive_bind_init => {
                     const pattern_idx: CIR.Pattern.Idx = work.extra.decl_pattern_idx;
@@ -1200,7 +1199,6 @@ pub const Interpreter = struct {
                 const roc_str: *builtins.str.RocStr = @ptrCast(@alignCast(result_value.ptr.?));
                 self.traceInfo("e_str_segment: About to call RocStr.fromSlice with content: \"{s}\"", .{literal_content});
                 roc_str.* = builtins.str.RocStr.fromSlice(literal_content, roc_ops);
-                self.traceInfo("STR_TRACE: String allocated at {*} with content \"{s}\" (length={})", .{ roc_str, roc_str.asSlice(), roc_str.len() });
                 self.traceInfo("e_str_segment: RocStr initialized successfully", .{});
             },
 

--- a/src/snapshot_tool/main.zig
+++ b/src/snapshot_tool/main.zig
@@ -2494,10 +2494,10 @@ fn generateReplOutputSection(output: *DualOutput, snapshot_path: []const u8, con
 
     // Split by the » character, each section is a separate REPL input
     var parts = std.mem.splitSequence(u8, content.source, "»");
-    
+
     // Skip the first part (before the first »)
     _ = parts.next();
-    
+
     while (parts.next()) |part| {
         // Trim whitespace and newlines
         const trimmed = std.mem.trim(u8, part, " \t\r\n");

--- a/src/snapshot_tool/main.zig
+++ b/src/snapshot_tool/main.zig
@@ -2488,15 +2488,21 @@ fn processReplSnapshot(allocator: Allocator, content: Content, output_path: []co
 
 fn generateReplOutputSection(output: *DualOutput, snapshot_path: []const u8, content: *const Content, config: *const Config) !bool {
     var success = true;
-    // Parse REPL inputs from the source
-    var lines = std.mem.tokenizeScalar(u8, content.source, '\n');
+    // Parse REPL inputs from the source using » as delimiter
     var inputs = std.ArrayList([]const u8).init(output.gpa);
     defer inputs.deinit();
 
-    while (lines.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, " \t\r");
-        if (trimmed.len > 2 and std.mem.startsWith(u8, trimmed, "» ")) {
-            try inputs.append(trimmed[2..]);
+    // Split by the » character, each section is a separate REPL input
+    var parts = std.mem.splitSequence(u8, content.source, "»");
+    
+    // Skip the first part (before the first »)
+    _ = parts.next();
+    
+    while (parts.next()) |part| {
+        // Trim whitespace and newlines
+        const trimmed = std.mem.trim(u8, part, " \t\r\n");
+        if (trimmed.len > 0) {
+            try inputs.append(trimmed);
         }
     }
 

--- a/test/snapshots/repl/string_edge_cases.md
+++ b/test/snapshots/repl/string_edge_cases.md
@@ -1,0 +1,43 @@
+# META
+~~~ini
+description=String comparison edge cases and longer strings
+type=repl
+~~~
+# SOURCE
+~~~roc
+» longStr1 = "This is a very long string that should test the comparison of larger strings that might not fit in small string optimization"
+» longStr2 = "This is a very long string that should test the comparison of larger strings that might not fit in small string optimization"
+» longStr3 = "This is a very long string that should test the comparison of larger strings that might not fit in small string optimizatioN"
+» longStr1 == longStr2
+» longStr1 == longStr3
+» whitespace1 = "hello "
+» whitespace2 = "hello"
+» whitespace1 == whitespace2
+» specialChars1 = "hello\nworld"
+» specialChars2 = "hello\nworld"
+» specialChars1 == specialChars2
+~~~
+# OUTPUT
+assigned `longStr1`
+---
+assigned `longStr2`
+---
+assigned `longStr3`
+---
+True
+---
+False
+---
+assigned `whitespace1`
+---
+assigned `whitespace2`
+---
+False
+---
+assigned `specialChars1`
+---
+assigned `specialChars2`
+---
+True
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/string_equality_basic.md
+++ b/test/snapshots/repl/string_equality_basic.md
@@ -1,0 +1,31 @@
+# META
+~~~ini
+description=Basic string equality comparisons
+type=repl
+~~~
+# SOURCE
+~~~roc
+» "hello" == "hello"
+» "hello" == "world"
+» "hello" != "world"
+» "hello" != "hello"
+» "" == ""
+» "" == "not empty"
+» "same length" == "different.."
+~~~
+# OUTPUT
+True
+---
+False
+---
+True
+---
+False
+---
+True
+---
+False
+---
+False
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/string_interpolation_comparison.md
+++ b/test/snapshots/repl/string_interpolation_comparison.md
@@ -1,0 +1,31 @@
+# META
+~~~ini
+description=String interpolation and concatenation comparisons
+type=repl
+~~~
+# SOURCE
+~~~roc
+» name = "World"
+» "Hello, ${name}!" == "Hello, World!"
+» "Hello, ${name}!" == "Hello, Earth!"
+» prefix = "Got: "
+» suffix = "test"
+» "${prefix}${suffix}" == "Got: test"
+» "${prefix}${suffix}" != "Got: different"
+~~~
+# OUTPUT
+assigned `name`
+---
+True
+---
+False
+---
+assigned `prefix`
+---
+assigned `suffix`
+---
+True
+---
+True
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/string_multiline_comparison.md
+++ b/test/snapshots/repl/string_multiline_comparison.md
@@ -1,0 +1,18 @@
+# META
+~~~ini
+description=Simple multiline string comparison
+type=repl
+~~~
+# SOURCE
+~~~roc
+» foo =
+"""first line
+"""second line
+» foo == "first line\nsecond line"
+~~~
+# OUTPUT
+assigned `foo`
+---
+True
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/string_ordering_unsupported.md
+++ b/test/snapshots/repl/string_ordering_unsupported.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=String ordering operations should fail gracefully (not supported)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» "apple" > "banana"
+» "zoo" < "aardvark"
+» "equal" >= "equal"
+» "first" <= "second"
+~~~
+# OUTPUT
+Evaluation error: error.StringOrderingNotSupported
+---
+Evaluation error: error.StringOrderingNotSupported
+---
+Evaluation error: error.StringOrderingNotSupported
+---
+Evaluation error: error.StringOrderingNotSupported
+# PROBLEMS
+NIL


### PR DESCRIPTION
```
$ zig build run -- test --verbose test_strings.roc
Ran 6 test(s): 6 passed, 0 failed in 0.4ms
PASS: line 9
PASS: line 10
PASS: line 11
PASS: line 12
PASS: line 13
PASS: line 14
```

## test_strings.roc
```roc
module [concat]

concat = |str| "Got: ${str}"

longer =
    """This is a
    """multi-line string!

expect concat("foo") == "Got: foo"
expect concat("bar") == "Got: bar"
expect "hello" == "hello"
expect "hello" != "world"
expect "different" != "strings"
expect concat(longer) == "Got: This is a\nmulti-line string!"
```