### PR TITLE
Remove MultilineStringEnd

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -848,9 +848,6 @@ const Formatter = struct {
                         },
                     }
                 }
-                if (!multiline) {
-                    try fmt.pushAll("\"\"\"");
-                }
             },
             .single_quote => |s| {
                 try fmt.pushTokenText(s.token);

--- a/src/parse/HTML.zig
+++ b/src/parse/HTML.zig
@@ -59,7 +59,7 @@ pub fn tokensToHtml(ast: *const AST, env: *const CommonEnv, writer: anytype) !vo
             => "token-keyword",
             .UpperIdent, .LowerIdent, .DotLowerIdent, .DotUpperIdent, .NoSpaceDotLowerIdent, .NoSpaceDotUpperIdent, .NamedUnderscore => "token-keyword",
             .OpPlus, .OpStar, .OpPizza, .OpAssign, .OpBinaryMinus, .OpUnaryMinus, .OpNotEquals, .OpBang, .OpAnd, .OpAmpersand, .OpQuestion, .OpDoubleQuestion, .OpOr, .OpBar, .OpDoubleSlash, .OpSlash, .OpPercent, .OpCaret, .OpGreaterThanOrEq, .OpGreaterThan, .OpLessThanOrEq, .OpBackArrow, .OpLessThan, .OpEquals, .OpColonEqual, .NoSpaceOpQuestion => "token-punctuation",
-            .StringStart, .StringEnd, .MultilineStringStart, .MultilineStringEnd, .StringPart => "token-string",
+            .StringStart, .StringEnd, .MultilineStringStart, .StringPart => "token-string",
             .Float, .Int => "token-number",
             .OpenRound, .CloseRound, .OpenSquare, .CloseSquare, .OpenCurly, .CloseCurly, .OpenStringInterpolation, .CloseStringInterpolation, .NoSpaceOpenRound => "token-punctuation",
             .EndOfFile => "token-default",

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -2315,10 +2315,6 @@ pub fn parseMultiLineStringExpr(self: *Parser) Error!AST.Expr.Idx {
     const scratch_top = self.store.scratchExprTop();
     while (self.peek() != .EndOfFile) {
         switch (self.peek()) {
-            .MultilineStringEnd => {
-                self.advance();
-                break;
-            },
             .MultilineStringStart => {
                 self.advance();
             },

--- a/test/snapshots/multiline_string_complex.md
+++ b/test/snapshots/multiline_string_complex.md
@@ -7,10 +7,10 @@ type=file
 ~~~roc
 module [value1, value2, value3, value4]
 
-value1 = """This is a "string" with just one line"""
+value1 = """This is a "string" with just one line
 
 value2 = 
-	"""This is a "string" with just one line"""
+	"""This is a "string" with just one line
 
 value3 = """This is a string
 	"""With multiple lines
@@ -29,9 +29,9 @@ NIL
 # TOKENS
 ~~~zig
 KwModule(1:1-1:7),OpenSquare(1:8-1:9),LowerIdent(1:9-1:15),Comma(1:15-1:16),LowerIdent(1:17-1:23),Comma(1:23-1:24),LowerIdent(1:25-1:31),Comma(1:31-1:32),LowerIdent(1:33-1:39),CloseSquare(1:39-1:40),
-LowerIdent(3:1-3:7),OpAssign(3:8-3:9),MultilineStringStart(3:10-3:13),StringPart(3:13-3:50),MultilineStringEnd(3:50-3:53),
+LowerIdent(3:1-3:7),OpAssign(3:8-3:9),MultilineStringStart(3:10-3:13),StringPart(3:13-3:50),
 LowerIdent(5:1-5:7),OpAssign(5:8-5:9),
-MultilineStringStart(6:2-6:5),StringPart(6:5-6:42),MultilineStringEnd(6:42-6:45),
+MultilineStringStart(6:2-6:5),StringPart(6:5-6:42),
 LowerIdent(8:1-8:7),OpAssign(8:8-8:9),MultilineStringStart(8:10-8:13),StringPart(8:13-8:29),
 MultilineStringStart(9:2-9:5),StringPart(9:5-9:24),
 MultilineStringStart(10:2-10:5),StringPart(10:5-10:5),OpenStringInterpolation(10:5-10:7),LowerIdent(10:7-10:13),CloseStringInterpolation(10:13-10:14),StringPart(10:14-10:14),
@@ -54,13 +54,13 @@ MultilineStringStart(16:2-16:5),StringPart(16:5-16:5),OpenStringInterpolation(16
 			(exposed-lower-ident @1.33-1.39
 				(text "value4"))))
 	(statements
-		(s-decl @3.1-3.53
+		(s-decl @3.1-3.50
 			(p-ident @3.1-3.7 (raw "value1"))
-			(e-multiline-string @3.10-3.53
+			(e-multiline-string @3.10-3.50
 				(e-string-part @3.13-3.50 (raw "This is a "string" with just one line"))))
-		(s-decl @5.1-6.45
+		(s-decl @5.1-6.42
 			(p-ident @5.1-5.7 (raw "value2"))
-			(e-multiline-string @6.2-6.45
+			(e-multiline-string @6.2-6.42
 				(e-string-part @6.5-6.42 (raw "This is a "string" with just one line"))))
 		(s-decl @8.1-10.14
 			(p-ident @8.1-8.7 (raw "value3"))
@@ -88,11 +88,11 @@ NO CHANGE
 (can-ir
 	(d-let
 		(p-assign @3.1-3.7 (ident "value1"))
-		(e-string @3.10-3.53
+		(e-string @3.10-3.50
 			(e-literal @3.13-3.50 (string "This is a "string" with just one line"))))
 	(d-let
 		(p-assign @5.1-5.7 (ident "value2"))
-		(e-string @6.2-6.45
+		(e-string @6.2-6.42
 			(e-literal @6.5-6.42 (string "This is a "string" with just one line"))))
 	(d-let
 		(p-assign @8.1-8.7 (ident "value3"))
@@ -122,8 +122,8 @@ NO CHANGE
 		(patt @8.1-8.7 (type "Str"))
 		(patt @12.1-12.7 (type "Str")))
 	(expressions
-		(expr @3.10-3.53 (type "Str"))
-		(expr @6.2-6.45 (type "Str"))
+		(expr @3.10-3.50 (type "Str"))
+		(expr @6.2-6.42 (type "Str"))
 		(expr @8.10-10.14 (type "Str"))
 		(expr @13.2-16.14 (type "Str"))))
 ~~~


### PR DESCRIPTION
Removes MultilineStringEnd: everything after """ until the end of the line is part of the string.