### PR TITLE
Fix use after free inside rocTest

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1668,11 +1668,11 @@ fn rocTest(gpa: Allocator, args: cli_args.TestArgs) !void {
     const elapsed_ms = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000.0;
 
     // Free allocated error messages
-    for (test_results.items) |test_result| {
+    defer for (test_results.items) |test_result| {
         if (test_result.error_msg) |msg| {
             gpa.free(msg);
         }
-    }
+    };
 
     // Report results
     if (failed == 0) {


### PR DESCRIPTION
rocTest accumulates error messages from `expect`. However, it frees the messages before they are printed, resulting in the use after free.

This PR fixes it.