### PR TITLE
Fix several issues with formatting

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -833,7 +833,7 @@ const Formatter = struct {
                             if (add_newline) {
                                 // Comments could be located before the MultilineStringStart token, not the StringPart token
                                 _ = try fmt.flushCommentsBefore(str.region.start - 1);
-                                try ensureNewline(fmt);
+                                try fmt.ensureNewline();
                                 try fmt.pushIndent();
                                 try fmt.pushAll("\"\"\"");
                             }
@@ -950,23 +950,18 @@ const Formatter = struct {
                         }
                         try fmt.push(',');
                         _ = try fmt.flushCommentsAfter(field_region.end);
-                        try fmt.ensureNewline();
-                        if (i < fields.len - 1) {
-                            try fmt.pushIndent();
+                        if (i == fields.len - 1) {
+                            fmt.curr_indent -= 1;
                         }
+                        try fmt.ensureNewline();
+                        try fmt.pushIndent();
                     } else if (i < fields.len - 1) {
                         try fmt.pushAll(",");
                     }
                 }
 
-                if (has_extension or fields.len > 0) {
-                    if (multiline) {
-                        fmt.curr_indent -= 1;
-                        try fmt.ensureNewline();
-                        try fmt.pushIndent();
-                    } else {
-                        try fmt.push(' ');
-                    }
+                if ((has_extension or fields.len > 0) and !multiline) {
+                    try fmt.push(' ');
                 }
                 try fmt.push('}');
             },
@@ -989,16 +984,14 @@ const Formatter = struct {
                     if (args_are_multiline) {
                         try fmt.push(',');
                         _ = try fmt.flushCommentsAfter(arg_region.end);
-                        try fmt.ensureNewline();
-                        if (i < args.len - 1) {
-                            try fmt.pushIndent();
+                        if (i == args.len - 1) {
+                            fmt.curr_indent -= 1;
                         }
+                        try fmt.ensureNewline();
+                        try fmt.pushIndent();
                     } else if (i < args.len - 1) {
                         try fmt.pushAll(", ");
                     }
-                }
-                if (args_are_multiline) {
-                    fmt.curr_indent -= 1;
                 }
                 try fmt.push('|');
                 if (try fmt.flushCommentsBefore(body_region.start)) {

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -907,8 +907,8 @@ const Formatter = struct {
                 // Handle extension if present
                 if (r.ext) |ext| {
                     if (multiline) {
-                        _ = try fmt.flushCommentsAfter(r.region.start);
                         fmt.curr_indent += 1;
+                        _ = try fmt.flushCommentsAfter(r.region.start);
                         try fmt.ensureNewline();
                         try fmt.pushIndent();
                     } else {
@@ -927,8 +927,8 @@ const Formatter = struct {
 
                 // Format fields
                 if (multiline and !has_extension and fields.len > 0) {
-                    _ = try fmt.flushCommentsAfter(r.region.start);
                     fmt.curr_indent += 1;
+                    _ = try fmt.flushCommentsAfter(r.region.start);
                     try fmt.ensureNewline();
                     try fmt.pushIndent();
                 }

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -915,12 +915,13 @@ const Formatter = struct {
                         try fmt.push(' ');
                     }
                     try fmt.pushAll("..");
-                    _ = try fmt.formatExpr(ext);
+                    const ext_region = try fmt.formatExpr(ext);
                     has_extension = true;
 
                     try fmt.push(',');
                     if (multiline and fields.len > 0) {
-                        try fmt.newline();
+                        _ = try fmt.flushCommentsAfter(ext_region.end);
+                        try fmt.ensureNewline();
                         try fmt.pushIndent();
                     }
                 }

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -1939,7 +1939,7 @@ const Formatter = struct {
                     if (found_comment or newline_count > 0) {
                         try fmt.pushIndent();
                     } else if (!fmt.has_newline) {
-                        try fmt.pushAll(" ");
+                        try fmt.push(' ');
                     }
                     try fmt.push('#');
                     const comment_text = between_text[comment_start..comment_end];
@@ -1950,13 +1950,15 @@ const Formatter = struct {
                     found_comment = true;
                 }
                 try fmt.newline();
-                newline_count += 1;
+                newline_count = 1; // reset count to allow an additional newline after a comment
                 i = comment_end;
                 if (i < between_text.len and (between_text[i] == '\n' or between_text[i] == '\r')) {
                     i += 1; // Skip any additional newlines
                 }
             } else if (between_text[i] == '\n') {
-                try fmt.newline();
+                if (newline_count < 2) {
+                    try fmt.newline();
+                }
                 newline_count += 1;
                 i += 1;
             } else {

--- a/test/snapshots/fuzz_crash/fuzz_crash_027.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_027.md
@@ -1610,7 +1610,6 @@ match_time = |
 		[1, 2, 3, .. as rest] # Aftet
 			=> ment
 
-
 		[1, 2 | 5, 3, .. as rest] => 123
 		[
 			ist,

--- a/test/snapshots/lambda_in_collection.md
+++ b/test/snapshots/lambda_in_collection.md
@@ -1,0 +1,92 @@
+# META
+~~~ini
+description=Lambda inside a collection
+type=expr
+~~~
+# SOURCE
+~~~roc
+(
+	|
+		a,
+		b,
+	| {
+		a + b
+	},
+	|a, b| {
+		a - b
+	},
+)
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+OpenRound(1:1-1:2),
+OpBar(2:2-2:3),
+LowerIdent(3:3-3:4),Comma(3:4-3:5),
+LowerIdent(4:3-4:4),Comma(4:4-4:5),
+OpBar(5:2-5:3),OpenCurly(5:4-5:5),
+LowerIdent(6:3-6:4),OpPlus(6:5-6:6),LowerIdent(6:7-6:8),
+CloseCurly(7:2-7:3),Comma(7:3-7:4),
+OpBar(8:2-8:3),LowerIdent(8:3-8:4),Comma(8:4-8:5),LowerIdent(8:6-8:7),OpBar(8:7-8:8),OpenCurly(8:9-8:10),
+LowerIdent(9:3-9:4),OpBinaryMinus(9:5-9:6),LowerIdent(9:7-9:8),
+CloseCurly(10:2-10:3),Comma(10:3-10:4),
+CloseRound(11:1-11:2),EndOfFile(11:2-11:2),
+~~~
+# PARSE
+~~~clojure
+(e-tuple @1.1-11.2
+	(e-lambda @2.2-7.3
+		(args
+			(p-ident @3.3-3.4 (raw "a"))
+			(p-ident @4.3-4.4 (raw "b")))
+		(e-block @5.4-7.3
+			(statements
+				(e-binop @6.3-6.8 (op "+")
+					(e-ident @6.3-6.4 (raw "a"))
+					(e-ident @6.7-6.8 (raw "b"))))))
+	(e-lambda @8.2-10.3
+		(args
+			(p-ident @8.3-8.4 (raw "a"))
+			(p-ident @8.6-8.7 (raw "b")))
+		(e-block @8.9-10.3
+			(statements
+				(e-binop @9.3-9.8 (op "-")
+					(e-ident @9.3-9.4 (raw "a"))
+					(e-ident @9.7-9.8 (raw "b")))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-tuple @1.1-11.2
+	(elems
+		(e-lambda @2.2-7.3
+			(args
+				(p-assign @3.3-3.4 (ident "a"))
+				(p-assign @4.3-4.4 (ident "b")))
+			(e-block @5.4-7.3
+				(e-binop @6.3-6.8 (op "add")
+					(e-lookup-local @6.3-6.4
+						(p-assign @3.3-3.4 (ident "a")))
+					(e-lookup-local @6.7-6.8
+						(p-assign @4.3-4.4 (ident "b"))))))
+		(e-lambda @8.2-10.3
+			(args
+				(p-assign @8.3-8.4 (ident "a"))
+				(p-assign @8.6-8.7 (ident "b")))
+			(e-block @8.9-10.3
+				(e-binop @9.3-9.8 (op "sub")
+					(e-lookup-local @9.3-9.4
+						(p-assign @8.3-8.4 (ident "a")))
+					(e-lookup-local @9.7-9.8
+						(p-assign @8.6-8.7 (ident "b"))))))))
+~~~
+# TYPES
+~~~clojure
+(expr @1.1-11.2 (type "(Num(_size), Num(_size2) -> Num(_size3), Num(_size4), Num(_size5) -> Num(_size6))"))
+~~~

--- a/test/snapshots/records/record_with_comments.md
+++ b/test/snapshots/records/record_with_comments.md
@@ -1,0 +1,147 @@
+# META
+~~~ini
+description=Record creation with comments
+type=expr
+~~~
+# SOURCE
+~~~roc
+{
+	# comment
+	..item,
+	person: { name: "Alice", age: 30 },
+	address: {
+		# comment
+		street: "123 Main St",
+		city: "Springfield",
+		coordinates: { lat: 42.1234, lng: -71.5678 },
+	},
+	contact: {
+		email: "alice@example.com",
+		phone: { home: "555-1234", work: "555-5678" },
+	},
+}
+~~~
+# EXPECTED
+UNDEFINED VARIABLE - record_with_comments.md:3:4:3:8
+# PROBLEMS
+**UNDEFINED VARIABLE**
+Nothing is named `item` in this scope.
+Is there an `import` or `exposing` missing up-top?
+
+**record_with_comments.md:3:4:3:8:**
+```roc
+	..item,
+```
+	  ^^^^
+
+
+# TOKENS
+~~~zig
+OpenCurly(1:1-1:2),
+DoubleDot(3:2-3:4),LowerIdent(3:4-3:8),Comma(3:8-3:9),
+LowerIdent(4:2-4:8),OpColon(4:8-4:9),OpenCurly(4:10-4:11),LowerIdent(4:12-4:16),OpColon(4:16-4:17),StringStart(4:18-4:19),StringPart(4:19-4:24),StringEnd(4:24-4:25),Comma(4:25-4:26),LowerIdent(4:27-4:30),OpColon(4:30-4:31),Int(4:32-4:34),CloseCurly(4:35-4:36),Comma(4:36-4:37),
+LowerIdent(5:2-5:9),OpColon(5:9-5:10),OpenCurly(5:11-5:12),
+LowerIdent(7:3-7:9),OpColon(7:9-7:10),StringStart(7:11-7:12),StringPart(7:12-7:23),StringEnd(7:23-7:24),Comma(7:24-7:25),
+LowerIdent(8:3-8:7),OpColon(8:7-8:8),StringStart(8:9-8:10),StringPart(8:10-8:21),StringEnd(8:21-8:22),Comma(8:22-8:23),
+LowerIdent(9:3-9:14),OpColon(9:14-9:15),OpenCurly(9:16-9:17),LowerIdent(9:18-9:21),OpColon(9:21-9:22),Float(9:23-9:30),Comma(9:30-9:31),LowerIdent(9:32-9:35),OpColon(9:35-9:36),Float(9:37-9:45),CloseCurly(9:46-9:47),Comma(9:47-9:48),
+CloseCurly(10:2-10:3),Comma(10:3-10:4),
+LowerIdent(11:2-11:9),OpColon(11:9-11:10),OpenCurly(11:11-11:12),
+LowerIdent(12:3-12:8),OpColon(12:8-12:9),StringStart(12:10-12:11),StringPart(12:11-12:28),StringEnd(12:28-12:29),Comma(12:29-12:30),
+LowerIdent(13:3-13:8),OpColon(13:8-13:9),OpenCurly(13:10-13:11),LowerIdent(13:12-13:16),OpColon(13:16-13:17),StringStart(13:18-13:19),StringPart(13:19-13:27),StringEnd(13:27-13:28),Comma(13:28-13:29),LowerIdent(13:30-13:34),OpColon(13:34-13:35),StringStart(13:36-13:37),StringPart(13:37-13:45),StringEnd(13:45-13:46),CloseCurly(13:47-13:48),Comma(13:48-13:49),
+CloseCurly(14:2-14:3),Comma(14:3-14:4),
+CloseCurly(15:1-15:2),EndOfFile(15:2-15:2),
+~~~
+# PARSE
+~~~clojure
+(e-record @1.1-15.2
+	(ext
+		(e-ident @3.4-3.8 (raw "item")))
+	(field (field "person")
+		(e-record @4.10-4.36
+			(field (field "name")
+				(e-string @4.18-4.25
+					(e-string-part @4.19-4.24 (raw "Alice"))))
+			(field (field "age")
+				(e-int @4.32-4.34 (raw "30")))))
+	(field (field "address")
+		(e-record @5.11-10.3
+			(field (field "street")
+				(e-string @7.11-7.24
+					(e-string-part @7.12-7.23 (raw "123 Main St"))))
+			(field (field "city")
+				(e-string @8.9-8.22
+					(e-string-part @8.10-8.21 (raw "Springfield"))))
+			(field (field "coordinates")
+				(e-record @9.16-9.47
+					(field (field "lat")
+						(e-frac @9.23-9.30 (raw "42.1234")))
+					(field (field "lng")
+						(e-frac @9.37-9.45 (raw "-71.5678")))))))
+	(field (field "contact")
+		(e-record @11.11-14.3
+			(field (field "email")
+				(e-string @12.10-12.29
+					(e-string-part @12.11-12.28 (raw "alice@example.com"))))
+			(field (field "phone")
+				(e-record @13.10-13.48
+					(field (field "home")
+						(e-string @13.18-13.28
+							(e-string-part @13.19-13.27 (raw "555-1234"))))
+					(field (field "work")
+						(e-string @13.36-13.46
+							(e-string-part @13.37-13.45 (raw "555-5678")))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-record @1.1-15.2
+	(ext
+		(e-runtime-error (tag "ident_not_in_scope")))
+	(fields
+		(field (name "person")
+			(e-record @4.10-4.36
+				(fields
+					(field (name "name")
+						(e-string @4.18-4.25
+							(e-literal @4.19-4.24 (string "Alice"))))
+					(field (name "age")
+						(e-int @4.32-4.34 (value "30"))))))
+		(field (name "address")
+			(e-record @5.11-10.3
+				(fields
+					(field (name "street")
+						(e-string @7.11-7.24
+							(e-literal @7.12-7.23 (string "123 Main St"))))
+					(field (name "city")
+						(e-string @8.9-8.22
+							(e-literal @8.10-8.21 (string "Springfield"))))
+					(field (name "coordinates")
+						(e-record @9.16-9.47
+							(fields
+								(field (name "lat")
+									(e-frac-dec @9.23-9.30 (value "42.1234")))
+								(field (name "lng")
+									(e-frac-dec @9.37-9.45 (value "-71.5678")))))))))
+		(field (name "contact")
+			(e-record @11.11-14.3
+				(fields
+					(field (name "email")
+						(e-string @12.10-12.29
+							(e-literal @12.11-12.28 (string "alice@example.com"))))
+					(field (name "phone")
+						(e-record @13.10-13.48
+							(fields
+								(field (name "home")
+									(e-string @13.18-13.28
+										(e-literal @13.19-13.27 (string "555-1234"))))
+								(field (name "work")
+									(e-string @13.36-13.46
+										(e-literal @13.37-13.45 (string "555-5678"))))))))))))
+~~~
+# TYPES
+~~~clojure
+(expr @1.1-15.2 (type "{ person: { name: Str, age: Num(_size) }, address: { street: Str, city: Str, coordinates: { lat: Frac(_size2), lng: Frac(_size3) } }, contact: { email: Str, phone: { home: Str, work: Str } } }"))
+~~~

--- a/test/snapshots/records/record_with_comments.md
+++ b/test/snapshots/records/record_with_comments.md
@@ -6,19 +6,27 @@ type=expr
 # SOURCE
 ~~~roc
 {
-	# comment
+	# comment1
 	..item,
-	person: { name: "Alice", age: 30 },
+
+	# comment2
+
+	person: { name: "Alice", age: 30 }, # comment3
 	address: {
-		# comment
+		# comment4
 		street: "123 Main St",
+		# comment5
+
 		city: "Springfield",
 		coordinates: { lat: 42.1234, lng: -71.5678 },
 	},
 	contact: {
+
+		# comment6
 		email: "alice@example.com",
-		phone: { home: "555-1234", work: "555-5678" },
+		phone: { home: "555-1234", work: "555-5678" }, # comment7
 	},
+	# comment8
 }
 ~~~
 # EXPECTED
@@ -39,57 +47,57 @@ Is there an `import` or `exposing` missing up-top?
 ~~~zig
 OpenCurly(1:1-1:2),
 DoubleDot(3:2-3:4),LowerIdent(3:4-3:8),Comma(3:8-3:9),
-LowerIdent(4:2-4:8),OpColon(4:8-4:9),OpenCurly(4:10-4:11),LowerIdent(4:12-4:16),OpColon(4:16-4:17),StringStart(4:18-4:19),StringPart(4:19-4:24),StringEnd(4:24-4:25),Comma(4:25-4:26),LowerIdent(4:27-4:30),OpColon(4:30-4:31),Int(4:32-4:34),CloseCurly(4:35-4:36),Comma(4:36-4:37),
-LowerIdent(5:2-5:9),OpColon(5:9-5:10),OpenCurly(5:11-5:12),
-LowerIdent(7:3-7:9),OpColon(7:9-7:10),StringStart(7:11-7:12),StringPart(7:12-7:23),StringEnd(7:23-7:24),Comma(7:24-7:25),
-LowerIdent(8:3-8:7),OpColon(8:7-8:8),StringStart(8:9-8:10),StringPart(8:10-8:21),StringEnd(8:21-8:22),Comma(8:22-8:23),
-LowerIdent(9:3-9:14),OpColon(9:14-9:15),OpenCurly(9:16-9:17),LowerIdent(9:18-9:21),OpColon(9:21-9:22),Float(9:23-9:30),Comma(9:30-9:31),LowerIdent(9:32-9:35),OpColon(9:35-9:36),Float(9:37-9:45),CloseCurly(9:46-9:47),Comma(9:47-9:48),
-CloseCurly(10:2-10:3),Comma(10:3-10:4),
-LowerIdent(11:2-11:9),OpColon(11:9-11:10),OpenCurly(11:11-11:12),
-LowerIdent(12:3-12:8),OpColon(12:8-12:9),StringStart(12:10-12:11),StringPart(12:11-12:28),StringEnd(12:28-12:29),Comma(12:29-12:30),
-LowerIdent(13:3-13:8),OpColon(13:8-13:9),OpenCurly(13:10-13:11),LowerIdent(13:12-13:16),OpColon(13:16-13:17),StringStart(13:18-13:19),StringPart(13:19-13:27),StringEnd(13:27-13:28),Comma(13:28-13:29),LowerIdent(13:30-13:34),OpColon(13:34-13:35),StringStart(13:36-13:37),StringPart(13:37-13:45),StringEnd(13:45-13:46),CloseCurly(13:47-13:48),Comma(13:48-13:49),
-CloseCurly(14:2-14:3),Comma(14:3-14:4),
-CloseCurly(15:1-15:2),EndOfFile(15:2-15:2),
+LowerIdent(7:2-7:8),OpColon(7:8-7:9),OpenCurly(7:10-7:11),LowerIdent(7:12-7:16),OpColon(7:16-7:17),StringStart(7:18-7:19),StringPart(7:19-7:24),StringEnd(7:24-7:25),Comma(7:25-7:26),LowerIdent(7:27-7:30),OpColon(7:30-7:31),Int(7:32-7:34),CloseCurly(7:35-7:36),Comma(7:36-7:37),
+LowerIdent(8:2-8:9),OpColon(8:9-8:10),OpenCurly(8:11-8:12),
+LowerIdent(10:3-10:9),OpColon(10:9-10:10),StringStart(10:11-10:12),StringPart(10:12-10:23),StringEnd(10:23-10:24),Comma(10:24-10:25),
+LowerIdent(13:3-13:7),OpColon(13:7-13:8),StringStart(13:9-13:10),StringPart(13:10-13:21),StringEnd(13:21-13:22),Comma(13:22-13:23),
+LowerIdent(14:3-14:14),OpColon(14:14-14:15),OpenCurly(14:16-14:17),LowerIdent(14:18-14:21),OpColon(14:21-14:22),Float(14:23-14:30),Comma(14:30-14:31),LowerIdent(14:32-14:35),OpColon(14:35-14:36),Float(14:37-14:45),CloseCurly(14:46-14:47),Comma(14:47-14:48),
+CloseCurly(15:2-15:3),Comma(15:3-15:4),
+LowerIdent(16:2-16:9),OpColon(16:9-16:10),OpenCurly(16:11-16:12),
+LowerIdent(19:3-19:8),OpColon(19:8-19:9),StringStart(19:10-19:11),StringPart(19:11-19:28),StringEnd(19:28-19:29),Comma(19:29-19:30),
+LowerIdent(20:3-20:8),OpColon(20:8-20:9),OpenCurly(20:10-20:11),LowerIdent(20:12-20:16),OpColon(20:16-20:17),StringStart(20:18-20:19),StringPart(20:19-20:27),StringEnd(20:27-20:28),Comma(20:28-20:29),LowerIdent(20:30-20:34),OpColon(20:34-20:35),StringStart(20:36-20:37),StringPart(20:37-20:45),StringEnd(20:45-20:46),CloseCurly(20:47-20:48),Comma(20:48-20:49),
+CloseCurly(21:2-21:3),Comma(21:3-21:4),
+CloseCurly(23:1-23:2),EndOfFile(23:2-23:2),
 ~~~
 # PARSE
 ~~~clojure
-(e-record @1.1-15.2
+(e-record @1.1-23.2
 	(ext
 		(e-ident @3.4-3.8 (raw "item")))
 	(field (field "person")
-		(e-record @4.10-4.36
+		(e-record @7.10-7.36
 			(field (field "name")
-				(e-string @4.18-4.25
-					(e-string-part @4.19-4.24 (raw "Alice"))))
+				(e-string @7.18-7.25
+					(e-string-part @7.19-7.24 (raw "Alice"))))
 			(field (field "age")
-				(e-int @4.32-4.34 (raw "30")))))
+				(e-int @7.32-7.34 (raw "30")))))
 	(field (field "address")
-		(e-record @5.11-10.3
+		(e-record @8.11-15.3
 			(field (field "street")
-				(e-string @7.11-7.24
-					(e-string-part @7.12-7.23 (raw "123 Main St"))))
+				(e-string @10.11-10.24
+					(e-string-part @10.12-10.23 (raw "123 Main St"))))
 			(field (field "city")
-				(e-string @8.9-8.22
-					(e-string-part @8.10-8.21 (raw "Springfield"))))
+				(e-string @13.9-13.22
+					(e-string-part @13.10-13.21 (raw "Springfield"))))
 			(field (field "coordinates")
-				(e-record @9.16-9.47
+				(e-record @14.16-14.47
 					(field (field "lat")
-						(e-frac @9.23-9.30 (raw "42.1234")))
+						(e-frac @14.23-14.30 (raw "42.1234")))
 					(field (field "lng")
-						(e-frac @9.37-9.45 (raw "-71.5678")))))))
+						(e-frac @14.37-14.45 (raw "-71.5678")))))))
 	(field (field "contact")
-		(e-record @11.11-14.3
+		(e-record @16.11-21.3
 			(field (field "email")
-				(e-string @12.10-12.29
-					(e-string-part @12.11-12.28 (raw "alice@example.com"))))
+				(e-string @19.10-19.29
+					(e-string-part @19.11-19.28 (raw "alice@example.com"))))
 			(field (field "phone")
-				(e-record @13.10-13.48
+				(e-record @20.10-20.48
 					(field (field "home")
-						(e-string @13.18-13.28
-							(e-string-part @13.19-13.27 (raw "555-1234"))))
+						(e-string @20.18-20.28
+							(e-string-part @20.19-20.27 (raw "555-1234"))))
 					(field (field "work")
-						(e-string @13.36-13.46
-							(e-string-part @13.37-13.45 (raw "555-5678")))))))))
+						(e-string @20.36-20.46
+							(e-string-part @20.37-20.45 (raw "555-5678")))))))))
 ~~~
 # FORMATTED
 ~~~roc
@@ -97,51 +105,51 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-record @1.1-15.2
+(e-record @1.1-23.2
 	(ext
 		(e-runtime-error (tag "ident_not_in_scope")))
 	(fields
 		(field (name "person")
-			(e-record @4.10-4.36
+			(e-record @7.10-7.36
 				(fields
 					(field (name "name")
-						(e-string @4.18-4.25
-							(e-literal @4.19-4.24 (string "Alice"))))
+						(e-string @7.18-7.25
+							(e-literal @7.19-7.24 (string "Alice"))))
 					(field (name "age")
-						(e-int @4.32-4.34 (value "30"))))))
+						(e-int @7.32-7.34 (value "30"))))))
 		(field (name "address")
-			(e-record @5.11-10.3
+			(e-record @8.11-15.3
 				(fields
 					(field (name "street")
-						(e-string @7.11-7.24
-							(e-literal @7.12-7.23 (string "123 Main St"))))
+						(e-string @10.11-10.24
+							(e-literal @10.12-10.23 (string "123 Main St"))))
 					(field (name "city")
-						(e-string @8.9-8.22
-							(e-literal @8.10-8.21 (string "Springfield"))))
+						(e-string @13.9-13.22
+							(e-literal @13.10-13.21 (string "Springfield"))))
 					(field (name "coordinates")
-						(e-record @9.16-9.47
+						(e-record @14.16-14.47
 							(fields
 								(field (name "lat")
-									(e-frac-dec @9.23-9.30 (value "42.1234")))
+									(e-frac-dec @14.23-14.30 (value "42.1234")))
 								(field (name "lng")
-									(e-frac-dec @9.37-9.45 (value "-71.5678")))))))))
+									(e-frac-dec @14.37-14.45 (value "-71.5678")))))))))
 		(field (name "contact")
-			(e-record @11.11-14.3
+			(e-record @16.11-21.3
 				(fields
 					(field (name "email")
-						(e-string @12.10-12.29
-							(e-literal @12.11-12.28 (string "alice@example.com"))))
+						(e-string @19.10-19.29
+							(e-literal @19.11-19.28 (string "alice@example.com"))))
 					(field (name "phone")
-						(e-record @13.10-13.48
+						(e-record @20.10-20.48
 							(fields
 								(field (name "home")
-									(e-string @13.18-13.28
-										(e-literal @13.19-13.27 (string "555-1234"))))
+									(e-string @20.18-20.28
+										(e-literal @20.19-20.27 (string "555-1234"))))
 								(field (name "work")
-									(e-string @13.36-13.46
-										(e-literal @13.37-13.45 (string "555-5678"))))))))))))
+									(e-string @20.36-20.46
+										(e-literal @20.37-20.45 (string "555-5678"))))))))))))
 ~~~
 # TYPES
 ~~~clojure
-(expr @1.1-15.2 (type "{ person: { name: Str, age: Num(_size) }, address: { street: Str, city: Str, coordinates: { lat: Frac(_size2), lng: Frac(_size3) } }, contact: { email: Str, phone: { home: Str, work: Str } } }"))
+(expr @1.1-23.2 (type "{ person: { name: Str, age: Num(_size) }, address: { street: Str, city: Str, coordinates: { lat: Frac(_size2), lng: Frac(_size3) } }, contact: { email: Str, phone: { home: Str, work: Str } } }"))
 ~~~


### PR DESCRIPTION
I made a few small fixes to the formatter:
- closing `|` of multi line lambda gets indented correctly
- allow only one empty line in the code (same as old compiler)
- change indention of first comment inside a record (same as old compiler)
- doesn't throw away comments after record extension