### PR TITLE
Expand Flex/Rigid vars to hold static dispatch information

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -602,7 +602,7 @@ pub fn canonicalizeFile(
                     const expect_stmt = Statement{ .s_expect = .{
                         .body = malformed,
                     } };
-                    const expect_stmt_idx = try self.env.addStatementAndTypeVar(expect_stmt, Content{ .flex_var = null }, region);
+                    const expect_stmt_idx = try self.env.addStatementAndTypeVar(expect_stmt, Content{ .flex = types.Flex.init() }, region);
                     try self.env.store.addScratchStatement(expect_stmt_idx);
                     continue;
                 };
@@ -611,7 +611,7 @@ pub fn canonicalizeFile(
                 const expect_stmt = Statement{ .s_expect = .{
                     .body = can_expect.idx,
                 } };
-                const expect_stmt_idx = try self.env.addStatementAndTypeVar(expect_stmt, Content{ .flex_var = null }, region);
+                const expect_stmt_idx = try self.env.addStatementAndTypeVar(expect_stmt, Content{ .flex = types.Flex.init() }, region);
                 try self.env.store.addScratchStatement(expect_stmt_idx);
             },
             .@"for" => |for_stmt| {
@@ -688,7 +688,7 @@ pub fn canonicalizeFile(
                             .where = where_clauses,
                         },
                     };
-                    const type_anno_stmt_idx = try self.env.addStatementAndTypeVar(type_anno_stmt, Content{ .flex_var = null }, region);
+                    const type_anno_stmt_idx = try self.env.addStatementAndTypeVar(type_anno_stmt, Content{ .flex = types.Flex.init() }, region);
                     try self.env.store.addScratchStatement(type_anno_stmt_idx);
                 }
 
@@ -1219,7 +1219,7 @@ fn canonicalizeImportStatement(
         },
     };
 
-    const import_idx = try self.env.addStatementAndTypeVar(cir_import, Content{ .flex_var = null }, self.parse_ir.tokenizedRegionToRegion(import_stmt.region));
+    const import_idx = try self.env.addStatementAndTypeVar(cir_import, Content{ .flex = types.Flex.init() }, self.parse_ir.tokenizedRegionToRegion(import_stmt.region));
     try self.env.store.addScratchStatement(import_idx);
 
     // 8. Add the module to the current scope so it can be used in qualified lookups
@@ -1353,7 +1353,7 @@ fn convertASTExposesToCIR(
             inline else => |payload| payload.region,
         };
         const region = self.parse_ir.tokenizedRegionToRegion(tokenized_region);
-        const cir_exposed_idx = try self.env.addExposedItemAndTypeVar(cir_exposed, .{ .flex_var = null }, region);
+        const cir_exposed_idx = try self.env.addExposedItemAndTypeVar(cir_exposed, .{ .flex = types.Flex.init() }, region);
         try self.env.store.addScratchExposedItem(cir_exposed_idx);
     }
 
@@ -1484,7 +1484,7 @@ fn canonicalizeDeclWithAnnotation(
         .expr = can_expr.idx,
         .annotation = mb_anno_idx,
         .kind = .let,
-    }, Content{ .flex_var = null }, region);
+    }, Content{ .flex = types.Flex.init() }, region);
 
     return def_idx;
 }
@@ -1649,7 +1649,7 @@ fn canonicalizeRecordField(
         .value = can_value.idx,
     };
 
-    return try self.env.addRecordFieldAndTypeVar(cir_field, Content{ .flex_var = null }, self.parse_ir.tokenizedRegionToRegion(field.region));
+    return try self.env.addRecordFieldAndTypeVar(cir_field, Content{ .flex = types.Flex.init() }, self.parse_ir.tokenizedRegionToRegion(field.region));
 }
 
 /// Parse an integer with underscores.
@@ -1768,7 +1768,7 @@ pub fn canonicalizeExpr(
                                 .module_idx = import_idx,
                                 .target_node_idx = target_node_idx,
                                 .region = region,
-                            } }, Content{ .flex_var = null }, region);
+                            } }, Content{ .flex = types.Flex.init() }, region);
                             return CanonicalizedExpr{
                                 .idx = expr_idx,
                                 .free_vars = null,
@@ -2464,7 +2464,7 @@ pub fn canonicalizeExpr(
                         .pattern_idx = pattern_idx,
                         .scope_depth = 0, // This is now unused, but kept for struct compatibility.
                     };
-                    const capture_idx = try self.env.addCaptureAndTypeVar(capture, types.Content{ .flex_var = null }, region);
+                    const capture_idx = try self.env.addCaptureAndTypeVar(capture, types.Content{ .flex = types.Flex.init() }, region);
                     try self.env.store.addScratchCapture(capture_idx);
                 }
 
@@ -2562,7 +2562,7 @@ pub fn canonicalizeExpr(
 
             const expr_idx = try self.env.addExprAndTypeVar(Expr{
                 .e_binop = Expr.Binop.init(op, can_lhs.idx, can_rhs.idx),
-            }, Content{ .flex_var = null }, region);
+            }, Content{ .flex = types.Flex.init() }, region);
 
             const free_vars_slice = self.scratch_free_vars.slice(free_vars_start, self.scratch_free_vars.top());
             return CanonicalizedExpr{ .idx = expr_idx, .free_vars = if (free_vars_slice.len > 0) free_vars_slice else null };
@@ -2587,7 +2587,7 @@ pub fn canonicalizeExpr(
                     // Create unary minus CIR expression
                     const expr_idx = try self.env.addExprAndTypeVar(Expr{
                         .e_unary_minus = Expr.UnaryMinus.init(can_operand.idx),
-                    }, Content{ .flex_var = null }, region);
+                    }, Content{ .flex = types.Flex.init() }, region);
 
                     return CanonicalizedExpr{ .idx = expr_idx, .free_vars = can_operand.free_vars };
                 },
@@ -2598,7 +2598,7 @@ pub fn canonicalizeExpr(
                     // Create unary not CIR expression
                     const expr_idx = try self.env.addExprAndTypeVar(Expr{
                         .e_unary_not = Expr.UnaryNot.init(can_operand.idx),
-                    }, Content{ .flex_var = null }, region);
+                    }, Content{ .flex = types.Flex.init() }, region);
 
                     return CanonicalizedExpr{ .idx = expr_idx, .free_vars = can_operand.free_vars };
                 },
@@ -2650,7 +2650,7 @@ pub fn canonicalizeExpr(
                     .cond = can_cond.idx,
                     .body = can_then.idx,
                 };
-                const if_branch_idx = try self.env.addIfBranchAndTypeVar(if_branch, Content{ .flex_var = null }, self.parse_ir.tokenizedRegionToRegion(current_if.region));
+                const if_branch_idx = try self.env.addIfBranchAndTypeVar(if_branch, Content{ .flex = types.Flex.init() }, self.parse_ir.tokenizedRegionToRegion(current_if.region));
                 try self.env.store.addScratchIfBranch(if_branch_idx);
 
                 // Check if the else clause is another if-then-else
@@ -2683,7 +2683,7 @@ pub fn canonicalizeExpr(
                     .branches = branches_span,
                     .final_else = final_else,
                 },
-            }, Content{ .flex_var = null }, region);
+            }, Content{ .flex = types.Flex.init() }, region);
 
             // Immediately redirect the if expression's type variable to the first branch's body
             const first_branch = self.env.store.getIfBranch(branches[0]);
@@ -2744,7 +2744,7 @@ pub fn canonicalizeExpr(
                                 const branch_pattern_idx = try self.env.addMatchBranchPatternAndTypeVar(Expr.Match.BranchPattern{
                                     .pattern = pattern_idx,
                                     .degenerate = false,
-                                }, Content{ .flex_var = null }, alt_pattern_region);
+                                }, Content{ .flex = types.Flex.init() }, alt_pattern_region);
                                 try self.env.store.addScratchMatchBranchPattern(branch_pattern_idx);
                             }
                         },
@@ -2764,7 +2764,7 @@ pub fn canonicalizeExpr(
                             const branch_pattern_idx = try self.env.addMatchBranchPatternAndTypeVar(Expr.Match.BranchPattern{
                                 .pattern = pattern_idx,
                                 .degenerate = false,
-                            }, Content{ .flex_var = null }, pattern_region);
+                            }, Content{ .flex = types.Flex.init() }, pattern_region);
                             try self.env.store.addScratchMatchBranchPattern(branch_pattern_idx);
                         },
                     }
@@ -2795,7 +2795,7 @@ pub fn canonicalizeExpr(
                         .guard = null,
                         .redundant = @enumFromInt(0), // TODO
                     },
-                    Content{ .flex_var = null },
+                    Content{ .flex = types.Flex.init() },
                     body_region,
                 );
 
@@ -2818,7 +2818,7 @@ pub fn canonicalizeExpr(
             };
 
             // Create initial content for the match expression
-            const initial_content = if (mb_branch_var) |_| Content{ .flex_var = null } else Content{ .err = {} };
+            const initial_content = if (mb_branch_var) |_| Content{ .flex = types.Flex.init() } else Content{ .err = {} };
             const expr_idx = try self.env.addExprAndTypeVar(CIR.Expr{ .e_match = match_expr }, initial_content, region);
 
             // If there is at least 1 branch, then set the root expr to redirect
@@ -2839,7 +2839,7 @@ pub fn canonicalizeExpr(
             // Create debug expression
             const dbg_expr = try self.env.addExprAndTypeVar(Expr{ .e_dbg = .{
                 .expr = can_inner.idx,
-            } }, Content{ .flex_var = null }, region);
+            } }, Content{ .flex = types.Flex.init() }, region);
 
             return CanonicalizedExpr{ .idx = dbg_expr, .free_vars = can_inner.free_vars };
         },
@@ -2853,7 +2853,7 @@ pub fn canonicalizeExpr(
         },
         .ellipsis => |e| {
             const region = self.parse_ir.tokenizedRegionToRegion(e.region);
-            const ellipsis_expr = try self.env.addExprAndTypeVar(Expr{ .e_ellipsis = .{} }, Content{ .flex_var = null }, region);
+            const ellipsis_expr = try self.env.addExprAndTypeVar(Expr{ .e_ellipsis = .{} }, Content{ .flex = types.Flex.init() }, region);
             return CanonicalizedExpr{ .idx = ellipsis_expr, .free_vars = null };
         },
         .block => |e| {
@@ -2911,7 +2911,7 @@ fn canonicalizeTagExpr(self: *Self, e: AST.TagExpr, mb_args: ?AST.Expr.Span, reg
 
     // Create a single tag, open tag union for this variable
     // Use a placeholder ext_var that will be handled during type checking
-    const ext_var = try self.env.addTypeSlotAndTypeVar(@enumFromInt(0), .{ .flex_var = null }, region, TypeVar);
+    const ext_var = try self.env.addTypeSlotAndTypeVar(@enumFromInt(0), .{ .flex = types.Flex.init() }, region, TypeVar);
     const tag = try self.env.types.mkTag(tag_name, @ptrCast(self.env.store.sliceExpr(args_span)));
     const tag_union = try self.env.types.mkTagUnion(&[_]Tag{tag}, ext_var);
 
@@ -3511,7 +3511,7 @@ fn canonicalizePattern(
             // Create the pattern type var first
             const arg_vars: []TypeVar = @ptrCast(self.env.store.slicePatterns(args));
             // We need to create a temporary pattern idx to get the type var
-            const ext_var = try self.env.addTypeSlotAndTypeVar(@enumFromInt(0), .{ .flex_var = null }, region, TypeVar);
+            const ext_var = try self.env.addTypeSlotAndTypeVar(@enumFromInt(0), .{ .flex = types.Flex.init() }, region, TypeVar);
             const tag = try self.env.types.mkTag(tag_name, arg_vars);
             _ = try self.env.types.mkTagUnion(&[_]Tag{tag}, ext_var);
 
@@ -3654,7 +3654,7 @@ fn canonicalizePattern(
                     };
 
                     // Successfully found the target node
-                    break :blk .{ other_module_node_id, Content{ .flex_var = null } };
+                    break :blk .{ other_module_node_id, Content{ .flex = types.Flex.init() } };
                 };
 
                 const nominal_pattern_idx = try self.env.addPatternAndTypeVar(CIR.Pattern{
@@ -4516,7 +4516,7 @@ fn canonicalizeTypeAnnoHelp(self: *Self, anno_idx: AST.TypeAnno.Idx, type_anno_c
                             // Track this type variable for underscore validation
                             try self.scratch_type_var_validation.append(self.env.gpa, name_ident);
 
-                            const content = types.Content{ .rigid_var = name_ident };
+                            const content = types.Content{ .rigid = types.Rigid.init(name_ident) };
                             const new_anno_idx = try self.env.addTypeAnnoAndTypeVar(.{ .rigid_var = .{
                                 .name = name_ident,
                             } }, content, region);
@@ -4574,7 +4574,7 @@ fn canonicalizeTypeAnnoHelp(self: *Self, anno_idx: AST.TypeAnno.Idx, type_anno_c
                             // Track this type variable for underscore validation
                             try self.scratch_type_var_validation.append(self.env.gpa, name_ident);
 
-                            const content = types.Content{ .rigid_var = name_ident };
+                            const content = types.Content{ .rigid = types.Rigid.init(name_ident) };
                             const new_anno_idx = try self.env.addTypeAnnoAndTypeVar(.{ .rigid_var = .{
                                 .name = name_ident,
                             } }, content, region);
@@ -4616,7 +4616,7 @@ fn canonicalizeTypeAnnoHelp(self: *Self, anno_idx: AST.TypeAnno.Idx, type_anno_c
                 if (type_anno_ctx.isTypeDeclAndHasUnderscore()) {
                     break :blk types.Content{ .err = {} };
                 } else {
-                    break :blk types.Content{ .flex_var = null };
+                    break :blk types.Content{ .flex = types.Flex.init() };
                 }
             };
 
@@ -5124,7 +5124,7 @@ fn canonicalizeTypeAnnoTag(
             return try self.env.addTypeAnnoAndTypeVar(.{ .tag = .{
                 .name = type_name,
                 .args = args,
-            } }, Content{ .flex_var = null }, region);
+            } }, Content{ .flex = types.Flex.init() }, region);
         },
         else => {
             return try self.env.pushMalformed(TypeAnno.Idx, Diagnostic{
@@ -5191,7 +5191,7 @@ fn canonicalizeTypeHeader(self: *Self, header_idx: AST.TypeHeader.Idx) std.mem.A
         return try self.env.addTypeHeaderAndTypeVar(.{
             .name = base.Ident.Idx{ .attributes = .{ .effectful = false, .ignored = false, .reassignable = false }, .idx = 0 }, // Invalid identifier
             .args = .{ .span = .{ .start = 0, .len = 0 } },
-        }, Content{ .flex_var = null }, node_region);
+        }, Content{ .flex = types.Flex.init() }, node_region);
     }
 
     const ast_header = self.parse_ir.store.getTypeHeader(header_idx) catch unreachable; // Malformed handled above
@@ -5203,7 +5203,7 @@ fn canonicalizeTypeHeader(self: *Self, header_idx: AST.TypeHeader.Idx) std.mem.A
         return try self.env.addTypeHeaderAndTypeVar(.{
             .name = base.Ident.Idx{ .attributes = .{ .effectful = false, .ignored = false, .reassignable = false }, .idx = 0 }, // Invalid identifier
             .args = .{ .span = .{ .start = 0, .len = 0 } },
-        }, Content{ .flex_var = null }, region);
+        }, Content{ .flex = types.Flex.init() }, region);
     };
 
     // Check if this is a builtin type
@@ -5245,7 +5245,7 @@ fn canonicalizeTypeHeader(self: *Self, header_idx: AST.TypeHeader.Idx) std.mem.A
 
                 const param_anno = try self.env.addTypeAnnoAndTypeVar(.{ .rigid_var = .{
                     .name = param_ident,
-                } }, Content{ .rigid_var = param_ident }, param_region);
+                } }, Content{ .rigid = types.Rigid.init(param_ident) }, param_region);
                 try self.env.store.addScratchTypeAnno(param_anno);
             },
             .underscore => |underscore_param| {
@@ -5292,7 +5292,7 @@ fn canonicalizeTypeHeader(self: *Self, header_idx: AST.TypeHeader.Idx) std.mem.A
     return try self.env.addTypeHeaderAndTypeVar(.{
         .name = name_ident,
         .args = args,
-    }, Content{ .flex_var = null }, region);
+    }, Content{ .flex = types.Flex.init() }, region);
 }
 
 // expr statements //
@@ -5368,13 +5368,13 @@ fn canonicalizeBlock(self: *Self, e: AST.Block) std.mem.Allocator.Error!Canonica
                                         const part_text = self.parse_ir.resolve(first_part.string_part.token);
                                         break :blk try self.env.addExprAndTypeVar(Expr{ .e_crash = .{
                                             .msg = try self.env.insertString(part_text),
-                                        } }, .{ .flex_var = null }, crash_region);
+                                        } }, .{ .flex = types.Flex.init() }, crash_region);
                                     }
                                 }
                                 // Fall back to default if we can't extract
                                 break :blk try self.env.addExprAndTypeVar(Expr{ .e_crash = .{
                                     .msg = try self.env.insertString("crash"),
-                                } }, .{ .flex_var = null }, crash_region);
+                                } }, .{ .flex = types.Flex.init() }, crash_region);
                             },
                             else => {
                                 // For non-string expressions, create a malformed expression
@@ -5484,7 +5484,7 @@ fn canonicalizeBlock(self: *Self, e: AST.Block) std.mem.Allocator.Error!Canonica
             .final_expr = final_expr.idx,
         },
     };
-    const block_idx = try self.env.addExprAndTypeVar(block_expr, Content{ .flex_var = null }, block_region);
+    const block_idx = try self.env.addExprAndTypeVar(block_expr, Content{ .flex = types.Flex.init() }, block_region);
     const block_var = @as(TypeVar, @enumFromInt(@intFromEnum(block_idx)));
 
     // Set the root block expr to redirect to the final expr var
@@ -6701,7 +6701,7 @@ fn canonicalizeWhereClause(self: *Self, ast_where_idx: AST.WhereClause.Idx, type
             defer self.env.gpa.free(module_text);
             const module_name = try self.env.insertIdent(Ident.for_text(module_text));
 
-            const external_type_var = try self.env.addTypeSlotAndTypeVar(@enumFromInt(0), .{ .flex_var = null }, region, TypeVar);
+            const external_type_var = try self.env.addTypeSlotAndTypeVar(@enumFromInt(0), .{ .flex = types.Flex.init() }, region, TypeVar);
             const external_decl = try self.createExternalDeclaration(qualified_name, module_name, method_ident, .value, external_type_var, region);
 
             return try self.env.addWhereClauseAndTypeVar(WhereClause{ .mod_method = .{
@@ -6710,7 +6710,7 @@ fn canonicalizeWhereClause(self: *Self, ast_where_idx: AST.WhereClause.Idx, type
                 .args = args_span,
                 .ret_anno = ret_anno,
                 .external_decl = external_decl,
-            } }, .{ .flex_var = null }, region);
+            } }, .{ .flex = types.Flex.init() }, region);
         },
         .mod_alias => |ma| {
             const region = self.parse_ir.tokenizedRegionToRegion(ma.region);
@@ -6746,14 +6746,14 @@ fn canonicalizeWhereClause(self: *Self, ast_where_idx: AST.WhereClause.Idx, type
             defer self.env.gpa.free(module_text);
             const module_name = try self.env.insertIdent(Ident.for_text(module_text));
 
-            const external_type_var = try self.env.addTypeSlotAndTypeVar(@enumFromInt(0), .{ .flex_var = null }, region, TypeVar);
+            const external_type_var = try self.env.addTypeSlotAndTypeVar(@enumFromInt(0), .{ .flex = types.Flex.init() }, region, TypeVar);
             const external_decl = try self.createExternalDeclaration(qualified_name, module_name, alias_ident, .type, external_type_var, region);
 
             return try self.env.addWhereClauseAndTypeVar(WhereClause{ .mod_alias = .{
                 .var_name = var_ident,
                 .alias_name = alias_ident,
                 .external_decl = external_decl,
-            } }, .{ .flex_var = null }, region);
+            } }, .{ .flex = types.Flex.init() }, region);
         },
         .malformed => |m| {
             const region = self.parse_ir.tokenizedRegionToRegion(m.region);
@@ -6762,7 +6762,7 @@ fn canonicalizeWhereClause(self: *Self, ast_where_idx: AST.WhereClause.Idx, type
             } }, .err);
             return try self.env.addWhereClauseAndTypeVar(WhereClause{ .malformed = .{
                 .diagnostic = diagnostic,
-            } }, .{ .flex_var = null }, region);
+            } }, .{ .flex = types.Flex.init() }, region);
         },
     }
 }
@@ -6861,7 +6861,7 @@ fn tryModuleQualifiedLookup(self: *Self, field_access: AST.BinOp) std.mem.Alloca
         .module_idx = import_idx,
         .target_node_idx = target_node_idx,
         .region = region,
-    } }, Content{ .flex_var = null }, region);
+    } }, Content{ .flex = types.Flex.init() }, region);
     return expr_idx;
 }
 
@@ -6889,7 +6889,7 @@ fn canonicalizeRegularFieldAccess(self: *Self, field_access: AST.BinOp) std.mem.
         },
     };
 
-    const expr_idx = try self.env.addExprAndTypeVar(dot_access_expr, Content{ .flex_var = null }, self.parse_ir.tokenizedRegionToRegion(field_access.region));
+    const expr_idx = try self.env.addExprAndTypeVar(dot_access_expr, Content{ .flex = types.Flex.init() }, self.parse_ir.tokenizedRegionToRegion(field_access.region));
     return expr_idx;
 }
 

--- a/src/canonicalize/test/record_test.zig
+++ b/src/canonicalize/test/record_test.zig
@@ -248,7 +248,7 @@ test "record with extension variable" {
                 // Check that extension is a flex var (open record)
                 const ext_resolved = env.types.resolveVar(record.ext);
                 switch (ext_resolved.desc.content) {
-                    .flex_var => {
+                    .flex => {
                         // Success! The record has an open extension
                     },
                     else => return error.ExpectedFlexVar,

--- a/src/check/copy_import.zig
+++ b/src/check/copy_import.zig
@@ -74,8 +74,8 @@ fn copyContent(
     allocator: std.mem.Allocator,
 ) std.mem.Allocator.Error!Content {
     return switch (content) {
-        .flex_var => |maybe_ident| Content{ .flex_var = maybe_ident },
-        .rigid_var => |ident| Content{ .rigid_var = ident },
+        .flex => |flex| Content{ .flex = flex },
+        .rigid => |rigid| Content{ .rigid = rigid },
         .alias => |alias| Content{ .alias = try copyAlias(source_store, dest_store, alias, var_mapping, source_idents, dest_idents, allocator) },
         .structure => |flat_type| Content{ .structure = try copyFlatType(source_store, dest_store, flat_type, var_mapping, source_idents, dest_idents, allocator) },
         .err => Content.err,

--- a/src/check/occurs.zig
+++ b/src/check/occurs.zig
@@ -230,8 +230,8 @@ const CheckOccurs = struct {
                     const backing_var = self.types_store.getAliasBackingVar(alias);
                     try self.occursSubVar(root, backing_var, ctx);
                 },
-                .flex_var => {},
-                .rigid_var => {},
+                .flex => {},
+                .rigid => {},
                 .err => {},
             }
             self.scratch.popSeen();

--- a/src/check/test/unify_test.zig
+++ b/src/check/test/unify_test.zig
@@ -25,6 +25,8 @@ const Var = types_mod.Var;
 const Desc = types_mod.Descriptor;
 const Rank = types_mod.Rank;
 const Mark = types_mod.Mark;
+const Flex = types_mod.Flex;
+const Rigid = types_mod.Rigid;
 const Content = types_mod.Content;
 const Alias = types_mod.Alias;
 const NominalType = types_mod.NominalType;
@@ -146,7 +148,7 @@ const TestEnv = struct {
     }
 
     fn mkRigidVarFromIdent(ident_idx: Ident.Idx) Content {
-        return .{ .rigid_var = ident_idx };
+        return .{ .rigid = Rigid.init(ident_idx) };
     }
 
     // helpers - alias //
@@ -162,7 +164,7 @@ const TestEnv = struct {
     }
 
     fn mkNumPolyFlex(self: *Self) std.mem.Allocator.Error!Var {
-        const flex_var = try self.module_env.types.freshFromContent(.{ .flex_var = null });
+        const flex_var = try self.module_env.types.freshFromContent(.{ .flex = Flex.init() });
         return try self.module_env.types.freshFromContent(Content{ .structure = .{ .num = .{ .num_poly = flex_var } } });
     }
 
@@ -179,7 +181,7 @@ const TestEnv = struct {
     }
 
     fn mkIntPolyFlex(self: *Self) std.mem.Allocator.Error!Var {
-        const flex_var = try self.module_env.types.freshFromContent(.{ .flex_var = null });
+        const flex_var = try self.module_env.types.freshFromContent(.{ .flex = Flex.init() });
         const int_var = try self.module_env.types.freshFromContent(Content{ .structure = .{ .num = .{ .int_poly = flex_var } } });
         return try self.module_env.types.freshFromContent(Content{ .structure = .{ .num = .{ .num_poly = int_var } } });
     }
@@ -204,7 +206,7 @@ const TestEnv = struct {
     }
 
     fn mkFracPolyFlex(self: *Self) std.mem.Allocator.Error!Var {
-        const flex_var = try self.module_env.types.freshFromContent(.{ .flex_var = null });
+        const flex_var = try self.module_env.types.freshFromContent(.{ .flex = Flex.init() });
         const frac_var = try self.module_env.types.freshFromContent(Content{ .structure = .{ .num = .{ .frac_poly = flex_var } } });
         return try self.module_env.types.freshFromContent(Content{ .structure = .{ .num = .{ .num_poly = frac_var } } });
     }
@@ -278,7 +280,7 @@ const TestEnv = struct {
     }
 
     fn mkRecordOpen(self: *Self, fields: []const RecordField) std.mem.Allocator.Error!RecordInfo {
-        const ext_var = try self.module_env.types.freshFromContent(.{ .flex_var = null });
+        const ext_var = try self.module_env.types.freshFromContent(.{ .flex = Flex.init() });
         return self.mkRecord(fields, ext_var);
     }
 
@@ -307,7 +309,7 @@ const TestEnv = struct {
     }
 
     fn mkTagUnionOpen(self: *Self, tags: []const Tag) std.mem.Allocator.Error!TagUnionInfo {
-        const ext_var = try self.module_env.types.freshFromContent(.{ .flex_var = null });
+        const ext_var = try self.module_env.types.freshFromContent(.{ .flex = Flex.init() });
         return self.mkTagUnion(tags, ext_var);
     }
 
@@ -372,7 +374,7 @@ test "rigid_var - unifies with flex_var" {
     defer env.deinit();
 
     const rigid = try env.mkRigidVar("a");
-    const a = try env.module_env.types.freshFromContent(.{ .flex_var = null });
+    const a = try env.module_env.types.freshFromContent(.{ .flex = Flex.init() });
     const b = try env.module_env.types.freshFromContent(rigid);
 
     const result = try env.unify(a, b);
@@ -388,7 +390,7 @@ test "rigid_var - unifies with flex_var (other way)" {
 
     const rigid = try env.mkRigidVar("a");
     const a = try env.module_env.types.freshFromContent(rigid);
-    const b = try env.module_env.types.freshFromContent(.{ .flex_var = null });
+    const b = try env.module_env.types.freshFromContent(.{ .flex = Flex.init() });
 
     const result = try env.unify(a, b);
     try std.testing.expectEqual(true, result.isOk());
@@ -1895,7 +1897,7 @@ test "unify - identical open records" {
     try std.testing.expectEqual(field_shared.var_, b_record_fields.items(.var_)[0]);
 
     const b_ext = env.module_env.types.resolveVar(b_record.ext).desc.content;
-    try std.testing.expectEqual(Content{ .flex_var = null }, b_ext);
+    try std.testing.expectEqual(Content{ .flex = Flex.init() }, b_ext);
 
     // check that fresh vars are correct
 
@@ -1941,7 +1943,7 @@ test "unify - open record a extends b" {
     try std.testing.expectEqual(field_a_only.var_, b_ext_record_fields.items(.var_)[0]);
 
     const b_ext_ext = env.module_env.types.resolveVar(b_ext_record.ext).desc.content;
-    try std.testing.expectEqual(Content{ .flex_var = null }, b_ext_ext);
+    try std.testing.expectEqual(Content{ .flex = Flex.init() }, b_ext_ext);
 
     // check that fresh vars are correct
 
@@ -1985,7 +1987,7 @@ test "unify - open record b extends a" {
     try std.testing.expectEqual(field_b_only.var_, b_ext_record_fields.items(.var_)[0]);
 
     const b_ext_ext = env.module_env.types.resolveVar(b_ext_record.ext).desc.content;
-    try std.testing.expectEqual(Content{ .flex_var = null }, b_ext_ext);
+    try std.testing.expectEqual(Content{ .flex = Flex.init() }, b_ext_ext);
 
     // check that fresh vars are correct
 
@@ -2026,7 +2028,7 @@ test "unify - both extend open record" {
     try std.testing.expectEqual(field_b_only, b_record_fields.get(2));
 
     const b_ext = env.module_env.types.resolveVar(b_record.ext).desc.content;
-    try std.testing.expectEqual(Content{ .flex_var = null }, b_ext);
+    try std.testing.expectEqual(Content{ .flex = Flex.init() }, b_ext);
 
     // check that fresh vars are correct
 
@@ -2046,7 +2048,7 @@ test "unify - both extend open record" {
 
     const ext_var = env.scratch.fresh_vars.get(@enumFromInt(2)).*;
     const ext_content = env.module_env.types.resolveVar(ext_var).desc.content;
-    try std.testing.expectEqual(Content{ .flex_var = null }, ext_content);
+    try std.testing.expectEqual(Content{ .flex = Flex.init() }, ext_content);
 }
 
 test "unify - record mismatch on shared field (fail)" {
@@ -2367,7 +2369,7 @@ test "unify - identical open tag unions" {
     try std.testing.expectEqual(tag_shared.args, b_tags_args[0]);
 
     const b_ext = env.module_env.types.resolveVar(b_tag_union.ext).desc.content;
-    try std.testing.expectEqual(Content{ .flex_var = null }, b_ext);
+    try std.testing.expectEqual(Content{ .flex = Flex.init() }, b_ext);
 
     // check that fresh vars are correct
 
@@ -2419,7 +2421,7 @@ test "unify - open tag union a extends b" {
     try std.testing.expectEqual(tag_a_only.args, b_ext_tags_args[0]);
 
     const b_ext_ext = env.module_env.types.resolveVar(b_ext_tag_union.ext).desc.content;
-    try std.testing.expectEqual(Content{ .flex_var = null }, b_ext_ext);
+    try std.testing.expectEqual(Content{ .flex = Flex.init() }, b_ext_ext);
 
     // check that fresh vars are correct
 
@@ -2472,7 +2474,7 @@ test "unify - open tag union b extends a" {
     try std.testing.expectEqual(tag_b_only.args, b_ext_tags_args[0]);
 
     const b_ext_ext = env.module_env.types.resolveVar(b_ext_tag_union.ext).desc.content;
-    try std.testing.expectEqual(Content{ .flex_var = null }, b_ext_ext);
+    try std.testing.expectEqual(Content{ .flex = Flex.init() }, b_ext_ext);
 
     // check that fresh vars are correct
 
@@ -2516,7 +2518,7 @@ test "unify - both extend open tag union" {
     try std.testing.expectEqual(tag_b_only, b_tags.get(2));
 
     const b_ext = env.module_env.types.resolveVar(b_tag_union.ext).desc.content;
-    try std.testing.expectEqual(Content{ .flex_var = null }, b_ext);
+    try std.testing.expectEqual(Content{ .flex = Flex.init() }, b_ext);
 
     // check that fresh vars are correct
 
@@ -2536,7 +2538,7 @@ test "unify - both extend open tag union" {
 
     const ext_var = env.scratch.fresh_vars.get(@enumFromInt(2)).*;
     const ext_content = env.module_env.types.resolveVar(ext_var).desc.content;
-    try std.testing.expectEqual(Content{ .flex_var = null }, ext_content);
+    try std.testing.expectEqual(Content{ .flex = Flex.init() }, ext_content);
 }
 
 test "unify - open tag unions a & b have same tag name with diff args (fail)" {

--- a/src/layout/store.zig
+++ b/src/layout/store.zig
@@ -582,8 +582,8 @@ pub const Store = struct {
                 .alias => |alias| {
                     current_ext = self.types_store.getAliasBackingVar(alias);
                 },
-                .flex_var => |_| break,
-                .rigid_var => |_| break,
+                .flex => |_| break,
+                .rigid => |_| break,
                 else => return LayoutError.InvalidRecordExtension,
             }
         }
@@ -860,7 +860,7 @@ pub const Store = struct {
                     },
                     .list => |elem_var| {
                         const elem_content = self.types_store.resolveVar(elem_var).desc.content;
-                        if (elem_content == .flex_var or elem_content == .rigid_var) {
+                        if (elem_content == .flex or elem_content == .rigid) {
                             // For unbound lists (empty lists), use list of zero-sized type
                             const layout = Layout.listOfZst();
                             const idx = try self.insertLayout(layout);
@@ -927,7 +927,7 @@ pub const Store = struct {
                                     const next_type = self.types_store.resolveVar(var_).desc.content;
                                     if (next_type == .structure and next_type.structure == .num) {
                                         num = next_type.structure.num;
-                                    } else if (next_type == .flex_var) {
+                                    } else if (next_type == .flex) {
                                         break :flat_type Layout.int(types.Num.Int.Precision.default);
                                     } else {
                                         return LayoutError.InvalidRecordExtension;
@@ -937,7 +937,7 @@ pub const Store = struct {
                                     const next_type = self.types_store.resolveVar(var_).desc.content;
                                     if (next_type == .structure and next_type.structure == .num) {
                                         num = next_type.structure.num;
-                                    } else if (next_type == .flex_var) {
+                                    } else if (next_type == .flex) {
                                         break :flat_type Layout.int(types.Num.Int.Precision.default);
                                     } else {
                                         return LayoutError.InvalidRecordExtension;
@@ -947,7 +947,7 @@ pub const Store = struct {
                                     const next_type = self.types_store.resolveVar(var_).desc.content;
                                     if (next_type == .structure and next_type.structure == .num) {
                                         num = next_type.structure.num;
-                                    } else if (next_type == .flex_var) {
+                                    } else if (next_type == .flex) {
                                         break :flat_type Layout.frac(types.Num.Frac.Precision.default);
                                     } else {
                                         return LayoutError.InvalidRecordExtension;
@@ -1297,7 +1297,7 @@ pub const Store = struct {
                         return LayoutError.ZeroSizedType;
                     },
                 },
-                .flex_var => |_| blk: {
+                .flex => |_| blk: {
                     // First, check if this flex var is mapped in the TypeScope
                     if (type_scope.lookup(current.var_)) |mapped_var| {
                         // Found a mapping, resolve the mapped variable and continue
@@ -1318,8 +1318,7 @@ pub const Store = struct {
                     // For now, default to I64 for numeric flex vars.
                     break :blk Layout.int(.i64);
                 },
-                .rigid_var => |ident| blk: {
-                    _ = ident;
+                .rigid => |_| blk: {
                     // First, check if this rigid var is mapped in the TypeScope
                     if (type_scope.lookup(current.var_)) |mapped_var| {
                         // Found a mapping, resolve the mapped variable and continue

--- a/src/layout/store_test.zig
+++ b/src/layout/store_test.zig
@@ -118,7 +118,7 @@ test "addTypeVar - host opaque types compile to opaque_ptr" {
     defer lt.deinit();
 
     // Box of flex_var
-    const flex_var = try lt.type_store.freshFromContent(.{ .flex_var = null });
+    const flex_var = try lt.type_store.freshFromContent(.{ .flex = types.Flex.init() });
     const box_flex_var = try lt.type_store.freshFromContent(.{ .structure = .{ .box = flex_var } });
     const box_flex_idx = try lt.layout_store.addTypeVar(box_flex_var, &lt.type_scope);
     const box_flex_layout = lt.layout_store.getLayout(box_flex_idx);
@@ -127,7 +127,7 @@ test "addTypeVar - host opaque types compile to opaque_ptr" {
 
     // Box of rigid_var
     const ident_idx = try lt.module_env.insertIdent(base.Ident.for_text("a"));
-    const rigid_var = try lt.type_store.freshFromContent(.{ .rigid_var = ident_idx });
+    const rigid_var = try lt.type_store.freshFromContent(.{ .rigid = types.Rigid.init(ident_idx) });
     const box_rigid_var = try lt.type_store.freshFromContent(.{ .structure = .{ .box = rigid_var } });
     const box_rigid_idx = try lt.layout_store.addTypeVar(box_rigid_var, &lt.type_scope);
     const box_rigid_layout = lt.layout_store.getLayout(box_rigid_idx);

--- a/src/types/generalize.zig
+++ b/src/types/generalize.zig
@@ -121,7 +121,7 @@ pub const Generalizer = struct {
 
     fn adjustRankContent(self: *Self, content: Content, group_rank: Rank) std.mem.Allocator.Error!Rank {
         return switch (content) {
-            .flex_var, .rigid_var, .err => return group_rank,
+            .flex, .rigid, .err => return group_rank,
             .alias => |alias| {
                 var next_rank = group_rank;
                 var args_iter = self.store.iterAliasArgs(alias);

--- a/src/types/mod.zig
+++ b/src/types/mod.zig
@@ -15,6 +15,8 @@ pub const generalize = @import("generalize.zig");
 pub const TypeWriter = @import("TypeWriter.zig");
 
 pub const Alias = types.Alias;
+pub const Flex = types.Flex;
+pub const Rigid = types.Rigid;
 pub const Content = types.Content;
 pub const FlatType = types.FlatType;
 pub const Func = types.Func;

--- a/src/types/test/test_rigid_instantiation.zig
+++ b/src/types/test/test_rigid_instantiation.zig
@@ -18,6 +18,8 @@ const Var = types_mod.Var;
 const Desc = types_mod.Descriptor;
 const Rank = types_mod.Rank;
 const Mark = types_mod.Mark;
+const Flex = types_mod.Flex;
+const Rigid = types_mod.Rigid;
 const Content = types_mod.Content;
 const Alias = types_mod.Alias;
 const NominalType = types_mod.NominalType;
@@ -48,7 +50,7 @@ test "instantiate - flex var creates new flex var" {
     var env = try TestEnv.init(gpa);
     defer env.deinit();
 
-    const original = try env.types.freshFromContent(.{ .flex_var = null });
+    const original = try env.types.freshFromContent(.{ .flex = Flex.init() });
 
     var instantiator = Instantiator{
         .store = &env.types,
@@ -64,7 +66,7 @@ test "instantiate - flex var creates new flex var" {
 
     // Should still be flex
     const resolved = env.types.resolveVar(instantiated);
-    try std.testing.expect(resolved.desc.content == .flex_var);
+    try std.testing.expect(resolved.desc.content == .flex);
 }
 
 test "instantiate - rigid var with fresh_flex creates flex var" {
@@ -88,7 +90,7 @@ test "instantiate - rigid var with fresh_flex creates flex var" {
 
     // Should now be flex
     const resolved = env.types.resolveVar(instantiated);
-    try std.testing.expect(resolved.desc.content == .flex_var);
+    try std.testing.expect(resolved.desc.content == .flex);
 }
 
 test "instantiate - rigid var with fresh_rigid creates new rigid var" {
@@ -112,7 +114,7 @@ test "instantiate - rigid var with fresh_rigid creates new rigid var" {
 
     // Should still be rigid
     const resolved = env.types.resolveVar(instantiated);
-    try std.testing.expect(resolved.desc.content == .rigid_var);
+    try std.testing.expect(resolved.desc.content == .rigid);
 }
 
 test "instantiate - rigid var with substitute_rigids substitutes correctly" {
@@ -121,7 +123,7 @@ test "instantiate - rigid var with substitute_rigids substitutes correctly" {
     defer env.deinit();
 
     const ident_idx = try env.idents.insert(gpa, Ident.for_text("a"));
-    const original = try env.types.freshFromContent(.{ .rigid_var = ident_idx });
+    const original = try env.types.freshFromContent(.{ .rigid = Rigid.init(ident_idx) });
 
     const substitute_var = try env.types.freshFromContent(.{ .structure = .{ .num = Num.int_u8 } });
 
@@ -519,7 +521,7 @@ const TestEnv = struct {
     }
 
     fn mkRigidVarFromIdent(ident_idx: Ident.Idx) Content {
-        return .{ .rigid_var = ident_idx };
+        return .{ .rigid = Rigid.init(ident_idx) };
     }
 
     // helpers - tuple //
@@ -549,7 +551,7 @@ const TestEnv = struct {
     }
 
     fn mkRecordOpen(self: *Self, fields: []const RecordField) std.mem.Allocator.Error!RecordInfo {
-        const ext_var = try self.types.freshFromContent(.{ .flex_var = null });
+        const ext_var = try self.types.freshFromContent(.{ .flex = Flex.init() });
         return self.mkRecord(fields, ext_var);
     }
 
@@ -584,7 +586,7 @@ const TestEnv = struct {
     }
 
     fn mkTagUnionOpen(self: *Self, tags: []const Tag) std.mem.Allocator.Error!TagUnionInfo {
-        const ext_var = try self.types.freshFromContent(.{ .flex_var = null });
+        const ext_var = try self.types.freshFromContent(.{ .flex = Flex.init() });
         return self.mkTagUnion(tags, ext_var);
     }
 


### PR DESCRIPTION
This PR updates the types store representations to capture static dispatch information. Currently, that information is not populated or unified. This just setups up the types in a straightforward way, so we can merge quickly to reduce likelihood of future merge conflicts

Concretely, this change:
* Rename `.flex_var` and `.rigid_var` to `.flex` and `.rigid`
* Updates the payload on those fields to contain a `Range` into a `StaticDispatchConstraint` array
* Adds a `StaticDispatchConstraint` array to the type `Store`

Intended to be merged after #8273