### PR TITLE
fuzz fix - remove duplicate comments for where clauses

### DIFF
--- a/test/snapshots/formatting/multiline/everything.md
+++ b/test/snapshots/formatting/multiline/everything.md
@@ -566,8 +566,7 @@ import I2 exposing [
 
 # Where constraint
 A(a) : a
-	where
-		[
+	where [
 			a.a1 : (
 			a,
 			a,
@@ -579,8 +578,7 @@ A(a) : a
 		) -> Str
 	]
 B(b) : b
-	where
-		[
+	where [
 			b.b1 : (
 			b,
 			b,
@@ -616,8 +614,7 @@ F : [
 ]
 
 g : e -> e
-	where
-		[
+	where [
 		e.A,
 		e.B
 	]

--- a/test/snapshots/formatting/singleline_with_comma/everything.md
+++ b/test/snapshots/formatting/singleline_with_comma/everything.md
@@ -374,8 +374,7 @@ import I2 exposing [
 
 # Where constraint
 A(a) : a
-	where
-		[a.a1 : (
+	where [a.a1 : (
 			a,
 			a,
 		) -> Str,
@@ -385,8 +384,7 @@ A(a) : a
 		) -> Str
 	]
 B(b) : b
-	where
-		[b.b1 : (
+	where [b.b1 : (
 			b,
 			b,
 		) -> Str,
@@ -420,8 +418,7 @@ F : [
 ]
 
 g : e -> e
-	where
-		[
+	where [
 		e.A,
 		e.B
 	]

--- a/test/snapshots/where_clause/where_clauses_10.md
+++ b/test/snapshots/where_clause/where_clauses_10.md
@@ -10,8 +10,7 @@ import Decode exposing [Decode]
 decode_things # After member name
 	: # After colon
 		List(List(U8)) -> List(a) # After anno
-			where # after where
-				[a.Decode]
+			where [a.Decode]
 ~~~
 # EXPECTED
 MODULE NOT FOUND - where_clauses_10.md:1:1:1:32
@@ -33,8 +32,7 @@ KwImport,UpperIdent,KwExposing,OpenSquare,UpperIdent,CloseSquare,
 LowerIdent,
 OpColon,
 UpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,CloseRound,OpArrow,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
-KwWhere,
-OpenSquare,LowerIdent,NoSpaceDotUpperIdent,CloseSquare,
+KwWhere,OpenSquare,LowerIdent,NoSpaceDotUpperIdent,CloseSquare,
 EndOfFile,
 ~~~
 # PARSE
@@ -60,15 +58,7 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-import Decode exposing [Decode]
-
-decode_things # After member name
-	: # After colon
-		List(List(U8)) -> List(a) # After anno
-			where
-				[
-				a.Decode
-			]
+NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/where_clause/where_clauses_7.md
+++ b/test/snapshots/where_clause/where_clauses_7.md
@@ -85,8 +85,7 @@ EndOfFile,
 Hash(a, hasher) # After header
 	: # After colon
 		a # After var
-			where
-				[ # After where
+			where [ # After where
 					a.hash : hasher # After method
 					-> # After arrow
 						hasher, # After first clause

--- a/test/snapshots/where_clause/where_clauses_comment_before_bracket.md
+++ b/test/snapshots/where_clause/where_clauses_comment_before_bracket.md
@@ -1,0 +1,54 @@
+# META
+~~~ini
+description=where_clauses comment before bracket (silently ignored)
+type=snippet
+~~~
+# SOURCE
+~~~roc
+foo : a
+    where # This comment is silently ignored - not preserved in formatted output
+        [a.Bar]
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpColon,LowerIdent,
+KwWhere,
+OpenSquare,LowerIdent,NoSpaceDotUpperIdent,CloseSquare,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-anno (name "foo")
+			(ty-var (raw "a"))
+			(where
+				(alias (module-of "a") (name "Bar"))))))
+~~~
+# FORMATTED
+~~~roc
+foo : a
+	where [
+		a.Bar
+	]
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(s-type-anno (name "foo")
+		(ty-rigid-var (name "a"))
+		(where
+			(alias (module-of "a") (ident "Bar"))))
+	(ext-decl (ident "a.Bar") (kind "type")))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(expressions))
+~~~


### PR DESCRIPTION
```
$ zig build repro-parse -- -b djphIHdoZXJlWwphLnQ6CmFddD0oKQ== -v
Using bytes as base64 encoded repro: djphIHdoZXJlWwphLnQ6CmFddD0oKQ==
Original:
==========
v:a where[
a.t:
a]t=()
==========

Formatted:
==========
v : a
	where
		[
			a.t :
			a]
t = ()

==========

Formatted:
==========
v : a
	where
		[
			a.t :
			a]
t = ()

==========

```