### PR TITLE
Don't propagate static dispatch error to type being dispatched on

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -3952,7 +3952,6 @@ fn reportConstraintError(
     },
 ) !void {
     const snapshot = try self.snapshots.deepCopyVar(self.types, dispatcher_var);
-
     const constraint_problem = switch (kind) {
         .missing_method => |dispatcher_type| problem.Problem{ .static_dispach = .{
             .dispatcher_does_not_impl_method = .{
@@ -3972,8 +3971,7 @@ fn reportConstraintError(
             },
         } },
     };
-
     _ = try self.problems.appendProblem(self.cir.gpa, constraint_problem);
+
     try self.markConstraintFunctionAsError(constraint);
-    try self.updateVar(dispatcher_var, .err, Rank.generalized);
 }

--- a/test/snapshots/plume_package/Color.md
+++ b/test/snapshots/plume_package/Color.md
@@ -86,6 +86,11 @@ TYPE MISMATCH - Color.md:51:104:51:105
 TYPE DOES NOT HAVE METHODS - Color.md:22:15:22:26
 TYPE DOES NOT HAVE METHODS - Color.md:29:13:29:26
 TYPE DOES NOT HAVE METHODS - Color.md:35:17:35:41
+TYPE DOES NOT HAVE METHODS - Color.md:36:21:36:45
+TYPE DOES NOT HAVE METHODS - Color.md:37:21:37:45
+TYPE DOES NOT HAVE METHODS - Color.md:38:21:38:45
+TYPE DOES NOT HAVE METHODS - Color.md:39:21:39:45
+TYPE DOES NOT HAVE METHODS - Color.md:40:21:40:45
 TYPE DOES NOT HAVE METHODS - Color.md:62:8:62:28
 # PROBLEMS
 **MODULE HEADER DEPRECATED**
@@ -196,6 +201,56 @@ You're trying to call the `is_char_in_hex_range` method on a `Num(Int(_size))`:
                 a.is_char_in_hex_range()
 ```
                 ^^^^^^^^^^^^^^^^^^^^^^^^
+
+But `Num(Int(_size))` doesn't support methods.
+
+**TYPE DOES NOT HAVE METHODS**
+You're trying to call the `is_char_in_hex_range` method on a `Num(Int(_size))`:
+**Color.md:36:21:36:45:**
+```roc
+                and b.is_char_in_hex_range()
+```
+                    ^^^^^^^^^^^^^^^^^^^^^^^^
+
+But `Num(Int(_size))` doesn't support methods.
+
+**TYPE DOES NOT HAVE METHODS**
+You're trying to call the `is_char_in_hex_range` method on a `Num(Int(_size))`:
+**Color.md:37:21:37:45:**
+```roc
+                and c.is_char_in_hex_range()
+```
+                    ^^^^^^^^^^^^^^^^^^^^^^^^
+
+But `Num(Int(_size))` doesn't support methods.
+
+**TYPE DOES NOT HAVE METHODS**
+You're trying to call the `is_char_in_hex_range` method on a `Num(Int(_size))`:
+**Color.md:38:21:38:45:**
+```roc
+                and d.is_char_in_hex_range()
+```
+                    ^^^^^^^^^^^^^^^^^^^^^^^^
+
+But `Num(Int(_size))` doesn't support methods.
+
+**TYPE DOES NOT HAVE METHODS**
+You're trying to call the `is_char_in_hex_range` method on a `Num(Int(_size))`:
+**Color.md:39:21:39:45:**
+```roc
+                and e.is_char_in_hex_range()
+```
+                    ^^^^^^^^^^^^^^^^^^^^^^^^
+
+But `Num(Int(_size))` doesn't support methods.
+
+**TYPE DOES NOT HAVE METHODS**
+You're trying to call the `is_char_in_hex_range` method on a `Num(Int(_size))`:
+**Color.md:40:21:40:45:**
+```roc
+                and f.is_char_in_hex_range()
+```
+                    ^^^^^^^^^^^^^^^^^^^^^^^^
 
 But `Num(Int(_size))` doesn't support methods.
 


### PR DESCRIPTION
Fixes error propagation for static dispatch type. For example:
```
x = y.nonexistant_method()
```
This should:
* Report an error for the `nonexistant_method`
* Set `x` to be an `err`

However currently, `y` is also set to be an `err`. This PR fixes this, since there's actually no type error with `y` here (given that static dispatch is essentially a function call) 