### PR TITLE
Switch to `$` for reusable vars

### DIFF
--- a/src/base/Ident.zig
+++ b/src/base/Ident.zig
@@ -84,7 +84,7 @@ pub const Attributes = packed struct(u3) {
         return .{
             .effectful = std.mem.endsWith(u8, text, "!"),
             .ignored = std.mem.startsWith(u8, text, "_"),
-            .reassignable = false,
+            .reassignable = std.mem.startsWith(u8, text, "$"),
         };
     }
 };
@@ -317,6 +317,14 @@ test "from_bytes creates ignored identifier" {
     try std.testing.expect(result.attributes.effectful == false);
     try std.testing.expect(result.attributes.ignored == true);
     try std.testing.expect(result.attributes.reassignable == false);
+}
+
+test "from_bytes creates reassignable identifier" {
+    const result = try Ident.from_bytes("$reusable");
+    try std.testing.expectEqualStrings("$reusable", result.raw_text);
+    try std.testing.expect(result.attributes.effectful == false);
+    try std.testing.expect(result.attributes.ignored == false);
+    try std.testing.expect(result.attributes.reassignable == true);
 }
 
 test "Ident.Store empty CompactWriter roundtrip" {

--- a/src/canonicalize/Diagnostic.zig
+++ b/src/canonicalize/Diagnostic.zig
@@ -235,7 +235,7 @@ pub const Diagnostic = union(enum) {
         suggested_name: Ident.Idx,
         region: Region,
     },
-    type_var_ending_in_underscore: struct {
+    type_var_starting_with_dollar: struct {
         name: Ident.Idx,
         suggested_name: Ident.Idx,
         region: Region,
@@ -302,7 +302,7 @@ pub const Diagnostic = union(enum) {
             .f64_pattern_literal => |d| d.region,
             .unused_type_var_name => |d| d.region,
             .type_var_marked_unused => |d| d.region,
-            .type_var_ending_in_underscore => |d| d.region,
+            .type_var_starting_with_dollar => |d| d.region,
             .underscore_in_type_declaration => |d| d.region,
         };
     }

--- a/src/canonicalize/Node.zig
+++ b/src/canonicalize/Node.zig
@@ -201,7 +201,7 @@ pub const Tag = enum {
     diag_f64_pattern_literal,
     diag_unused_type_var_name,
     diag_type_var_marked_unused,
-    diag_type_var_ending_in_underscore,
+    diag_type_var_starting_with_dollar,
     diag_underscore_in_type_declaration,
     diagnostic_exposed_but_not_implemented,
     diag_redundant_exposed,

--- a/src/canonicalize/NodeStore.zig
+++ b/src/canonicalize/NodeStore.zig
@@ -2913,8 +2913,8 @@ pub fn addDiagnostic(store: *NodeStore, reason: CIR.Diagnostic) Allocator.Error!
             node.data_1 = @bitCast(r.name);
             node.data_2 = @bitCast(r.suggested_name);
         },
-        .type_var_ending_in_underscore => |r| {
-            node.tag = .diag_type_var_ending_in_underscore;
+        .type_var_starting_with_dollar => |r| {
+            node.tag = .diag_type_var_starting_with_dollar;
             region = r.region;
             node.data_1 = @bitCast(r.name);
             node.data_2 = @bitCast(r.suggested_name);
@@ -3228,7 +3228,7 @@ pub fn getDiagnostic(store: *const NodeStore, diagnostic: CIR.Diagnostic.Idx) CI
             .suggested_name = @bitCast(node.data_2),
             .region = store.getRegionAt(node_idx),
         } },
-        .diag_type_var_ending_in_underscore => return CIR.Diagnostic{ .type_var_ending_in_underscore = .{
+        .diag_type_var_starting_with_dollar => return CIR.Diagnostic{ .type_var_starting_with_dollar = .{
             .name = @bitCast(node.data_1),
             .suggested_name = @bitCast(node.data_2),
             .region = store.getRegionAt(node_idx),

--- a/src/canonicalize/test/node_store_test.zig
+++ b/src/canonicalize/test/node_store_test.zig
@@ -712,7 +712,7 @@ test "NodeStore round trip - Diagnostics" {
     });
 
     try diagnostics.append(gpa, CIR.Diagnostic{
-        .type_var_ending_in_underscore = .{
+        .type_var_starting_with_dollar = .{
             .name = rand_ident_idx(),
             .suggested_name = rand_ident_idx(),
             .region = rand_region(),

--- a/test/snapshots/records/record_different_fields_error.md
+++ b/test/snapshots/records/record_different_fields_error.md
@@ -27,7 +27,6 @@ UNEXPECTED TOKEN IN EXPRESSION - record_different_fields_error.md:4:15:4:16
 UNEXPECTED TOKEN IN EXPRESSION - record_different_fields_error.md:4:25:4:26
 UNEXPECTED TOKEN IN EXPRESSION - record_different_fields_error.md:5:15:5:16
 UNEXPECTED TOKEN IN EXPRESSION - record_different_fields_error.md:5:24:5:25
-UNEXPECTED TOKEN IN EXPRESSION - record_different_fields_error.md:6:10:6:11
 UNEXPECTED TOKEN IN TYPE ANNOTATION - record_different_fields_error.md:6:20:6:21
 UNEXPECTED TOKEN IN EXPRESSION - record_different_fields_error.md:6:21:6:27
 UNEXPECTED TOKEN IN EXPRESSION - record_different_fields_error.md:6:27:6:28
@@ -50,7 +49,6 @@ UNDEFINED VARIABLE - record_different_fields_error.md:5:11:5:15
 UNRECOGNIZED SYNTAX - record_different_fields_error.md:5:15:5:16
 UNRECOGNIZED SYNTAX - record_different_fields_error.md:5:24:5:25
 UNDEFINED VARIABLE - record_different_fields_error.md:6:5:6:10
-UNRECOGNIZED SYNTAX - record_different_fields_error.md:6:10:6:11
 MALFORMED TYPE - record_different_fields_error.md:6:20:6:21
 UNRECOGNIZED SYNTAX - record_different_fields_error.md:6:21:6:27
 UNRECOGNIZED SYNTAX - record_different_fields_error.md:6:27:6:28
@@ -194,17 +192,6 @@ Expressions can be identifiers, literals, function calls, or operators.
     kebab-case: "kebab",
 ```
                        ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **$** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**record_different_fields_error.md:6:10:6:11:**
-```roc
-    field$special: "dollar",
-```
-         ^
 
 
 **UNEXPECTED TOKEN IN TYPE ANNOTATION**
@@ -447,17 +434,6 @@ Is there an `import` or `exposing` missing up-top?
     ^^^^^
 
 
-**UNRECOGNIZED SYNTAX**
-I don't recognize this syntax.
-
-**record_different_fields_error.md:6:10:6:11:**
-```roc
-    field$special: "dollar",
-```
-         ^
-
-This might be a syntax error, an unsupported language feature, or a typo.
-
 **MALFORMED TYPE**
 This type annotation is malformed or contains invalid syntax.
 
@@ -596,7 +572,7 @@ NamedUnderscore,OpColon,StringStart,StringPart,StringEnd,Comma,
 LowerIdent,OpColon,StringStart,StringPart,StringEnd,Comma,
 UpperIdent,OpColon,StringStart,StringPart,StringEnd,Comma,
 LowerIdent,OpUnaryMinus,LowerIdent,OpColon,StringStart,StringPart,StringEnd,Comma,
-LowerIdent,MalformedUnknownToken,LowerIdent,OpColon,StringStart,StringPart,StringEnd,Comma,
+LowerIdent,LowerIdent,OpColon,StringStart,StringPart,StringEnd,Comma,
 LowerIdent,OpaqueName,OpColon,StringStart,StringPart,StringEnd,Comma,
 CloseCurly,
 EndOfFile,
@@ -628,8 +604,7 @@ EndOfFile,
 			(e-string-part (raw "kebab")))
 		(e-malformed (reason "expr_unexpected_token"))
 		(e-ident (raw "field"))
-		(e-malformed (reason "expr_unexpected_token"))
-		(s-type-anno (name "special")
+		(s-type-anno (name "$special")
 			(ty-malformed (tag "ty_anno_unexpected_token")))
 		(e-malformed (reason "expr_unexpected_token"))
 		(e-malformed (reason "expr_unexpected_token"))
@@ -656,7 +631,7 @@ EndOfFile,
 		"kebab"
 	
 	field
-		special : 
+	$special : 
 			
 	field
 			"at symbol"
@@ -705,9 +680,7 @@ EndOfFile,
 		(e-runtime-error (tag "expr_not_canonicalized")))
 	(s-expr
 		(e-runtime-error (tag "ident_not_in_scope")))
-	(s-expr
-		(e-runtime-error (tag "expr_not_canonicalized")))
-	(s-type-anno (name "special")
+	(s-type-anno (name "$special")
 		(ty-malformed))
 	(s-expr
 		(e-runtime-error (tag "expr_not_canonicalized")))

--- a/test/snapshots/type_var_underscore_conventions.md
+++ b/test/snapshots/type_var_underscore_conventions.md
@@ -1,6 +1,6 @@
 # META
 ~~~ini
-description=Comprehensive test of type variable underscore conventions
+description=Comprehensive test of type variable underscore and dollar sign conventions
 type=file
 ~~~
 # SOURCE
@@ -11,12 +11,12 @@ app [main] { pf: platform "../basic-cli/platform.roc" }
 single_use : List(elem) -> Str
 single_use = |x| "hello"
 
-# Test 2: TYPE VAR ENDING IN UNDERSCORE - variables should never end with underscore
-ending_underscore : List(elem_) -> elem_
-ending_underscore = |list| "default"
+# Test 2: TYPE VAR STARTING WITH DOLLAR - variables should never start with dollar sign (reusable markers)
+starting_dollar : List($elem) -> $elem
+starting_dollar = |list| "default"
 
-# Test 3: COMBINATION - single-use ending in underscore (both errors)
-combo_single : List(bad_) -> Str
+# Test 3: COMBINATION - single-use starting with dollar (both errors)
+combo_single : List($bad) -> Str
 combo_single = |x| "combo"
 
 # Test 4: VALID CASES - these should not generate warnings
@@ -30,11 +30,11 @@ main = |x| "done"
 ~~~
 # EXPECTED
 UNUSED VARIABLE - type_var_underscore_conventions.md:5:15:5:16
-UNUSED VARIABLE - type_var_underscore_conventions.md:9:22:9:26
+UNUSED VARIABLE - type_var_underscore_conventions.md:9:20:9:24
 UNUSED VARIABLE - type_var_underscore_conventions.md:13:17:13:18
 UNUSED VARIABLE - type_var_underscore_conventions.md:17:17:17:18
 UNUSED VARIABLE - type_var_underscore_conventions.md:22:9:22:10
-TYPE MISMATCH - type_var_underscore_conventions.md:9:28:9:37
+TYPE MISMATCH - type_var_underscore_conventions.md:9:26:9:35
 # PROBLEMS
 **UNUSED VARIABLE**
 Variable `x` is not used anywhere in your code.
@@ -53,11 +53,11 @@ Variable `list` is not used anywhere in your code.
 
 If you don't need this variable, prefix it with an underscore like `_list` to suppress this warning.
 The unused variable is declared here:
-**type_var_underscore_conventions.md:9:22:9:26:**
+**type_var_underscore_conventions.md:9:20:9:24:**
 ```roc
-ending_underscore = |list| "default"
+starting_dollar = |list| "default"
 ```
-                     ^^^^
+                   ^^^^
 
 
 **UNUSED VARIABLE**
@@ -98,17 +98,17 @@ main = |x| "done"
 
 **TYPE MISMATCH**
 This expression is used in an unexpected way:
-**type_var_underscore_conventions.md:9:28:9:37:**
+**type_var_underscore_conventions.md:9:26:9:35:**
 ```roc
-ending_underscore = |list| "default"
+starting_dollar = |list| "default"
 ```
-                           ^^^^^^^^^
+                         ^^^^^^^^^
 
 It has the type:
     _Str_
 
 But the type annotation says it should have the type:
-    _elem__
+    _$elem_
 
 # TOKENS
 ~~~zig
@@ -154,14 +154,14 @@ EndOfFile,
 					(p-ident (raw "x")))
 				(e-string
 					(e-string-part (raw "hello")))))
-		(s-type-anno (name "ending_underscore")
+		(s-type-anno (name "starting_dollar")
 			(ty-fn
 				(ty-apply
 					(ty (name "List"))
-					(ty-var (raw "elem_")))
-				(ty-var (raw "elem_"))))
+					(ty-var (raw "$elem")))
+				(ty-var (raw "$elem"))))
 		(s-decl
-			(p-ident (raw "ending_underscore"))
+			(p-ident (raw "starting_dollar"))
 			(e-lambda
 				(args
 					(p-ident (raw "list")))
@@ -171,7 +171,7 @@ EndOfFile,
 			(ty-fn
 				(ty-apply
 					(ty (name "List"))
-					(ty-var (raw "bad_")))
+					(ty-var (raw "$bad")))
 				(ty (name "Str"))))
 		(s-decl
 			(p-ident (raw "combo_single"))
@@ -234,7 +234,7 @@ NO CHANGE
 					(ty-rigid-var (name "elem")))
 				(ty-lookup (name "Str") (external-module "Str")))))
 	(d-let
-		(p-assign (ident "ending_underscore"))
+		(p-assign (ident "starting_dollar"))
 		(e-lambda
 			(args
 				(p-assign (ident "list")))
@@ -243,8 +243,8 @@ NO CHANGE
 		(annotation
 			(ty-fn (effectful false)
 				(ty-apply (name "List") (builtin)
-					(ty-rigid-var (name "elem_")))
-				(ty-rigid-var-lookup (ty-rigid-var (name "elem_"))))))
+					(ty-rigid-var (name "$elem")))
+				(ty-rigid-var-lookup (ty-rigid-var (name "$elem"))))))
 	(d-let
 		(p-assign (ident "combo_single"))
 		(e-lambda
@@ -255,7 +255,7 @@ NO CHANGE
 		(annotation
 			(ty-fn (effectful false)
 				(ty-apply (name "List") (builtin)
-					(ty-rigid-var (name "bad_")))
+					(ty-rigid-var (name "$bad")))
 				(ty-lookup (name "Str") (external-module "Str")))))
 	(d-let
 		(p-assign (ident "valid_single"))
@@ -296,15 +296,15 @@ NO CHANGE
 (inferred-types
 	(defs
 		(patt (type "List(elem) -> Str"))
-		(patt (type "List(elem_) -> Error"))
-		(patt (type "List(bad_) -> Str"))
+		(patt (type "List($elem) -> Error"))
+		(patt (type "List($bad) -> Str"))
 		(patt (type "List(_elem) -> Str"))
 		(patt (type "elem -> List(elem)"))
 		(patt (type "_arg -> Str")))
 	(expressions
 		(expr (type "List(elem) -> Str"))
-		(expr (type "List(elem_) -> Error"))
-		(expr (type "List(bad_) -> Str"))
+		(expr (type "List($elem) -> Error"))
+		(expr (type "List($bad) -> Str"))
 		(expr (type "List(_elem) -> Str"))
 		(expr (type "elem -> List(elem)"))
 		(expr (type "_arg -> Str"))))


### PR DESCRIPTION
Previously:

```ruby
var foo_ = []
foo_ = foo_.append(bar)
```

Now:

```ruby
var $foo_ = []
$foo = $foo.append(bar)
```