### PR TITLE
add Str.trim builtin

### DIFF
--- a/src/build/builtin_compiler/main.zig
+++ b/src/build/builtin_compiler/main.zig
@@ -101,6 +101,9 @@ fn replaceStrIsEmptyWithLowLevel(env: *ModuleEnv) !std.ArrayList(CIR.Def.Idx) {
     if (env.common.findIdent("Builtin.Str.concat")) |str_concat_ident| {
         try low_level_map.put(str_concat_ident, .str_concat);
     }
+    if (env.common.findIdent("Builtin.Str.trim")) |str_trim_ident| {
+        try low_level_map.put(str_trim_ident, .str_trim);
+    }
     if (env.common.findIdent("Builtin.List.len")) |list_len_ident| {
         try low_level_map.put(list_len_ident, .list_len);
     }

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -2,6 +2,7 @@ Builtin :: [].{
 	Str :: [ProvidedByCompiler].{
 		is_empty : Str -> Bool
 		concat : Str, Str -> Str
+		trim : Str -> Str
 
 		contains : Str, Str -> Bool
 		contains = |_str, _other| True

--- a/src/canonicalize/Expression.zig
+++ b/src/canonicalize/Expression.zig
@@ -402,6 +402,7 @@ pub const Expr = union(enum) {
         // String operations
         str_is_empty,
         str_concat,
+        str_trim,
 
         // Numeric to_str operations
         u8_to_str,

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -2791,6 +2791,29 @@ pub const Interpreter = struct {
                 out.is_initialized = true;
                 return out;
             },
+            .str_trim => {
+                // Str.trim : Str -> Str
+                std.debug.assert(args.len == 1);
+
+                const str_arg = args[0];
+                std.debug.assert(str_arg.ptr != null);
+
+                const roc_str_arg: *const RocStr = @ptrCast(@alignCast(str_arg.ptr.?));
+
+                const result_str = builtins.str.strTrim(roc_str_arg.*, roc_ops);
+
+                // Allocate space for the result string
+                const result_layout = str_arg.layout; // Str layout
+                var out = try self.pushRaw(result_layout, 0);
+                out.is_initialized = false;
+
+                // Copy the result string structure to the output
+                const result_ptr: *RocStr = @ptrCast(@alignCast(out.ptr.?));
+                result_ptr.* = result_str;
+
+                out.is_initialized = true;
+                return out;
+            },
             .list_len => {
                 // List.len : List(a) -> U64
                 // Note: listLen returns usize, but List.len always returns U64.

--- a/src/eval/test/low_level_interp_test.zig
+++ b/src/eval/test/low_level_interp_test.zig
@@ -276,6 +276,33 @@ test "e_low_level_lambda - Str.concat with longer strings" {
     try testing.expectEqualStrings("\"This is a longer string that contains about one hundred characters for testing concatenation. This is the second string that also has many characters in it for testing longer string operations.\"", value);
 }
 
+test "e_low_level_lambda - Str.trim with an empty string" {
+    const src =
+        \\x = Str.trim("")
+    ;
+    const value = try evalModuleAndGetString(src, 0, test_allocator);
+    defer test_allocator.free(value);
+    try testing.expectEqualStrings("\"\"", value);
+}
+
+test "e_low_level_lambda - Str.trim with a whitespace string" {
+    const src =
+        \\x = Str.trim("   ")
+    ;
+    const value = try evalModuleAndGetString(src, 0, test_allocator);
+    defer test_allocator.free(value);
+    try testing.expectEqualStrings("\"\"", value);
+}
+
+test "e_low_level_lambda - Str.trim with a non-whitespace string" {
+    const src =
+        \\x = Str.trim("  hello  ")
+    ;
+    const value = try evalModuleAndGetString(src, 0, test_allocator);
+    defer test_allocator.free(value);
+    try testing.expectEqualStrings("\"hello\"", value);
+}
+
 test "e_low_level_lambda - List.concat with two non-empty lists" {
     const src =
         \\x = List.concat([1, 2], [3, 4])


### PR DESCRIPTION
This wires up `Str.trim` in the interpreter following the pattern of Anton's `Str.concat` PR.