### PR TITLE
Improve MISSING METHOD formatting

### DIFF
--- a/src/check/problem.zig
+++ b/src/check/problem.zig
@@ -1669,10 +1669,8 @@ pub const ReportBuilder = struct {
         const region_info = self.module_env.calcRegionInfo(region.*);
 
         try report.document.addReflowingText("This ");
-        try report.document.addAnnotated(method_name_str, .inline_code);
-        try report.document.addReflowingText(" method is being called on the type ");
-        try report.document.addAnnotated(snapshot_str, .type_variable);
-        try report.document.addReflowingText(", which has no method with that name:");
+        try report.document.addAnnotated(method_name_str, .emphasized);
+        try report.document.addReflowingText(" method is being called on a value whose type doesn't have that method:");
         try report.document.addLineBreak();
 
         try report.document.addSourceRegion(
@@ -1682,6 +1680,15 @@ pub const ReportBuilder = struct {
             self.source,
             self.module_env.getLineStarts(),
         );
+        try report.document.addLineBreak();
+
+        try report.document.addReflowingText("The value's type, which does not have a method named ");
+        try report.document.addAnnotated(method_name_str, .emphasized);
+        try report.document.addReflowingText(", is:");
+        try report.document.addLineBreak();
+        try report.document.addLineBreak();
+        try report.document.addText("    ");
+        try report.document.addAnnotated(snapshot_str, .type_variable);
         try report.document.addLineBreak();
 
         return report;
@@ -1713,19 +1720,16 @@ pub const ReportBuilder = struct {
         if (is_plus_operator) {
             try report.document.addReflowingText("The value before this ");
             try report.document.addAnnotated("+", .emphasized);
-            try report.document.addReflowingText(" operator has the type ");
-            try report.document.addAnnotated(snapshot_str, .emphasized);
-            try report.document.addReflowingText(", which has no ");
+            try report.document.addReflowingText(" operator has a type that doesn't have a ");
             try report.document.addAnnotated(method_name_str, .emphasized);
             try report.document.addReflowingText(" method:");
+            try report.document.addLineBreak();
         } else {
             try report.document.addReflowingText("This ");
             try report.document.addAnnotated(method_name_str, .emphasized);
-            try report.document.addReflowingText(" method is being called on the type ");
-            try report.document.addAnnotated(snapshot_str, .emphasized);
-            try report.document.addReflowingText(", which has no method with that name:");
+            try report.document.addReflowingText(" method is being called on a value whose type doesn't have that method:");
+            try report.document.addLineBreak();
         }
-        try report.document.addLineBreak();
 
         try report.document.addSourceRegion(
             region_info,
@@ -1734,6 +1738,21 @@ pub const ReportBuilder = struct {
             self.source,
             self.module_env.getLineStarts(),
         );
+        try report.document.addLineBreak();
+
+        if (is_plus_operator) {
+            try report.document.addReflowingText("The value's type, which does not have a method named ");
+            try report.document.addAnnotated(method_name_str, .emphasized);
+            try report.document.addReflowingText(", is:");
+        } else {
+            try report.document.addReflowingText("The value's type, which does not have a method named ");
+            try report.document.addAnnotated(method_name_str, .emphasized);
+            try report.document.addReflowingText(", is:");
+        }
+        try report.document.addLineBreak();
+        try report.document.addLineBreak();
+        try report.document.addText("    ");
+        try report.document.addAnnotated(snapshot_str, .type_variable);
 
         // TODO: Find similar method names and show a more helpful error message
         // here

--- a/test/snapshots/annotations.md
+++ b/test/snapshots/annotations.md
@@ -50,13 +50,16 @@ But the type annotation says it should have the type:
     _Pair(Num.U8)_
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **annotations.md:16:33:16:34:**
 ```roc
 failPairDiffTypes = mkPair("1", 2)
 ```
                                 ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
@@ -75,13 +78,16 @@ But the type annotation says it should have the type:
     _Pair(Num.U64)_
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **annotations.md:19:32:19:33:**
 ```roc
 failPairDiffTypes2 = Pair.Pair(1, "str")
 ```
                                ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/binop_omnibus__single__no_spaces.md
+++ b/test/snapshots/binop_omnibus__single__no_spaces.md
@@ -29,13 +29,16 @@ This feature is not yet implemented: unsupported operator
 This error doesn't have a proper diagnostic report yet. Let us know if you want to help improve Roc's error messages!
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Bool**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **binop_omnibus__single__no_spaces.md:1:32:1:34:**
 ```roc
 Err(foo)??12>5*5 or 13+2<5 and 10-1>=16 or 12<=3/5
 ```
                                ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Bool_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/can_list_first_concrete.md
+++ b/test/snapshots/can_list_first_concrete.md
@@ -12,24 +12,30 @@ MISSING METHOD - can_list_first_concrete.md:1:2:1:4
 MISSING METHOD - can_list_first_concrete.md:1:15:1:19
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_list_first_concrete.md:1:2:1:4:**
 ```roc
 [42, "world", 3.14]
 ```
  ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_list_first_concrete.md:1:15:1:19:**
 ```roc
 [42, "world", 3.14]
 ```
               ^^^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/can_list_heterogeneous.md
+++ b/test/snapshots/can_list_heterogeneous.md
@@ -12,24 +12,30 @@ MISSING METHOD - can_list_heterogeneous.md:1:2:1:3
 MISSING METHOD - can_list_heterogeneous.md:1:14:1:18
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_list_heterogeneous.md:1:2:1:3:**
 ```roc
 [1, "hello", 3.14]
 ```
  ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_list_heterogeneous.md:1:14:1:18:**
 ```roc
 [1, "hello", 3.14]
 ```
              ^^^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/can_list_mismatch_then_nested_error.md
+++ b/test/snapshots/can_list_mismatch_then_nested_error.md
@@ -32,24 +32,30 @@ Note: You can wrap each element in a tag to make them compatible.
 To learn about tags, see <https://www.roc-lang.org/tutorial#tags>
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_list_mismatch_then_nested_error.md:1:2:1:3:**
 ```roc
 [1, "hello", [3, "world"]]
 ```
  ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_list_mismatch_then_nested_error.md:1:15:1:16:**
 ```roc
 [1, "hello", [3, "world"]]
 ```
               ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/can_list_multiline_mismatch.md
+++ b/test/snapshots/can_list_multiline_mismatch.md
@@ -16,24 +16,30 @@ MISSING METHOD - can_list_multiline_mismatch.md:2:5:2:7
 MISSING METHOD - can_list_multiline_mismatch.md:4:5:4:8
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_list_multiline_mismatch.md:2:5:2:7:**
 ```roc
     42,
 ```
     ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_list_multiline_mismatch.md:4:5:4:8:**
 ```roc
     100
 ```
     ^^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/can_list_nested_heterogeneous.md
+++ b/test/snapshots/can_list_nested_heterogeneous.md
@@ -11,13 +11,16 @@ type=expr
 MISSING METHOD - can_list_nested_heterogeneous.md:1:7:1:8
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_list_nested_heterogeneous.md:1:7:1:8:**
 ```roc
 [[], [1], ["hello"]]
 ```
       ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/can_list_triple_nested_heterogeneous.md
+++ b/test/snapshots/can_list_triple_nested_heterogeneous.md
@@ -11,13 +11,16 @@ type=expr
 MISSING METHOD - can_list_triple_nested_heterogeneous.md:1:12:1:13
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_list_triple_nested_heterogeneous.md:1:12:1:13:**
 ```roc
 [[], [[], [1]], [[], ["hello"]]]
 ```
            ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/can_list_two_elements.md
+++ b/test/snapshots/can_list_two_elements.md
@@ -11,13 +11,16 @@ type=expr
 MISSING METHOD - can_list_two_elements.md:1:2:1:3
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_list_two_elements.md:1:2:1:3:**
 ```roc
 [1, "hello"]
 ```
  ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/can_nested_heterogeneous_lists.md
+++ b/test/snapshots/can_nested_heterogeneous_lists.md
@@ -12,24 +12,30 @@ MISSING METHOD - can_nested_heterogeneous_lists.md:1:3:1:4
 MISSING METHOD - can_nested_heterogeneous_lists.md:1:20:1:21
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_nested_heterogeneous_lists.md:1:3:1:4:**
 ```roc
 [[1, "hello"], [2, 3]]
 ```
   ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **can_nested_heterogeneous_lists.md:1:20:1:21:**
 ```roc
 [[1, "hello"], [2, 3]]
 ```
                    ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/eval/call_float_literal.md
+++ b/test/snapshots/eval/call_float_literal.md
@@ -11,13 +11,16 @@ x = 12.34()
 MISSING METHOD - call_float_literal.md:1:5:1:10
 # PROBLEMS
 **MISSING METHOD**
-This `from_numeral` method is being called on the type _({}) -> _ret_, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **call_float_literal.md:1:5:1:10:**
 ```roc
 x = 12.34()
 ```
     ^^^^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _({}) -> _ret_
 
 
 # TOKENS

--- a/test/snapshots/expr/list_type_err.md
+++ b/test/snapshots/expr/list_type_err.md
@@ -11,13 +11,16 @@ type=expr
 MISSING METHOD - list_type_err.md:1:5:1:6
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **list_type_err.md:1:5:1:6:**
 ```roc
 [1, 2, "hello"]
 ```
     ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/expr/tag_applications_simple.md
+++ b/test/snapshots/expr/tag_applications_simple.md
@@ -22,13 +22,16 @@ type=expr
 MISSING METHOD - tag_applications_simple.md:2:10:2:12
 # PROBLEMS
 **MISSING METHOD**
-This `from_numeral` method is being called on the type _[Ok([Just(_a)]_others)]_others2 where [[Ok([Just(b)]c)]d.from_numeral : [Ok([Just(b)]c)]d]_, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **tag_applications_simple.md:2:10:2:12:**
 ```roc
     Some(42),
 ```
          ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _[Ok([Just(_a)]_others)]_others2 where [[Ok([Just(b)]c)]d.from_numeral : [Ok([Just(b)]c)]d]_
 
 
 # TOKENS

--- a/test/snapshots/expr/tuple_type.md
+++ b/test/snapshots/expr/tuple_type.md
@@ -17,24 +17,30 @@ MISSING METHOD - tuple_type.md:5:8:5:9
 MISSING METHOD - tuple_type.md:5:11:5:12
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **tuple_type.md:5:8:5:9:**
 ```roc
     f((1, 2))
 ```
        ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **tuple_type.md:5:11:5:12:**
 ```roc
     f((1, 2))
 ```
           ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/expr_if_missing_else.md
+++ b/test/snapshots/expr_if_missing_else.md
@@ -23,13 +23,16 @@ foo = if tru 0
 
 
 **MISSING METHOD**
-This `from_numeral` method is being called on the type _{}_, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **expr_if_missing_else.md:1:14:1:15:**
 ```roc
 foo = if tru 0
 ```
              ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _{}_
 
 
 # TOKENS

--- a/test/snapshots/if_then_else/if_then_else_9.md
+++ b/test/snapshots/if_then_else/if_then_else_9.md
@@ -31,34 +31,43 @@ if bool {
 
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Bool**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **if_then_else_9.md:3:11:3:13:**
 ```roc
 } else if 10 { # Comment after else open
 ```
           ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Bool_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This `from_numeral` method is being called on the type _[A]_others_, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **if_then_else_9.md:2:2:2:3:**
 ```roc
 	1
 ```
 	^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _[A]_others_
 
 
 **MISSING METHOD**
-This `from_numeral` method is being called on the type _[A]_others_, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **if_then_else_9.md:6:2:6:3:**
 ```roc
 	3
 ```
 	^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _[A]_others_
 
 
 # TOKENS

--- a/test/snapshots/if_then_else/if_then_else_simple_block_formatting.md
+++ b/test/snapshots/if_then_else/if_then_else_simple_block_formatting.md
@@ -25,13 +25,16 @@ if bool {
 
 
 **MISSING METHOD**
-This `from_numeral` method is being called on the type _[A]_others_, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **if_then_else_simple_block_formatting.md:3:8:3:9:**
 ```roc
 } else 2
 ```
        ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _[A]_others_
 
 
 # TOKENS

--- a/test/snapshots/if_then_else/if_then_else_simple_file.md
+++ b/test/snapshots/if_then_else/if_then_else_simple_file.md
@@ -39,13 +39,16 @@ Note: You can wrap branches in a tag to make them compatible.
 To learn about tags, see <https://www.roc-lang.org/tutorial#tags>
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Bool**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **if_then_else_simple_file.md:1:10:1:11:**
 ```roc
 foo = if 1 A
 ```
          ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Bool_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/issue/simple_underscore_error.md
+++ b/test/snapshots/issue/simple_underscore_error.md
@@ -26,13 +26,16 @@ BadType := _
 Underscores in type annotations mean "I don't care about this type", which doesn't make sense when declaring a type. If you need a placeholder type variable, use a named type variable like `a` instead.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **BadType**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **simple_underscore_error.md:4:7:4:9:**
 ```roc
 foo = 42
 ```
       ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _BadType_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/issue/underscore_error_type.md
+++ b/test/snapshots/issue/underscore_error_type.md
@@ -122,13 +122,16 @@ BadTuple := (_, U32)
 Underscores in type annotations mean "I don't care about this type", which doesn't make sense when declaring a type. If you need a placeholder type variable, use a named type variable like `a` instead.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **BadType**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **underscore_error_type.md:4:7:4:9:**
 ```roc
 foo = 42
 ```
       ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _BadType_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/issue/usage_test.md
+++ b/test/snapshots/issue/usage_test.md
@@ -40,13 +40,16 @@ UnusedType := _
 Underscores in type annotations mean "I don't care about this type", which doesn't make sense when declaring a type. If you need a placeholder type variable, use a named type variable like `a` instead.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **UsedType**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **usage_test.md:6:9:6:11:**
 ```roc
 value = 42
 ```
         ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _UsedType_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/lambda_annotation_mismatch_error.md
+++ b/test/snapshots/lambda_annotation_mismatch_error.md
@@ -18,13 +18,16 @@ MISSING METHOD - lambda_annotation_mismatch_error.md:3:23:3:29
 + - :0:0:0:0
 # PROBLEMS
 **MISSING METHOD**
-The value before this **+** operator has the type **Str**, which has no **plus** method:
+The value before this **+** operator has a type that doesn't have a **plus** method:
 **lambda_annotation_mismatch_error.md:3:23:3:29:**
 ```roc
 string_function = |x| x + 42
 ```
                       ^^^^^^
 
+The value's type, which does not have a method named **plus**, is:
+
+    _Str_
 
 **Hint: **The **+** operator calls a method named **plus** on the value preceding it, passing the value after the operator as the one argument.
 

--- a/test/snapshots/lambda_multi_arg_mismatch.md
+++ b/test/snapshots/lambda_multi_arg_mismatch.md
@@ -91,24 +91,30 @@ But the seventh argument has the type:
 `multi_arg_fn` needs these arguments to have compatible types.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **lambda_multi_arg_mismatch.md:9:5:9:7:**
 ```roc
     42,        # x1: U64 (type 'a')
 ```
     ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **lambda_multi_arg_mismatch.md:13:5:13:9:**
 ```roc
     3.14,      # x5: F64 (should be 'a' = U64) - MISMATCH
 ```
     ^^^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/let_polymorphism_error.md
+++ b/test/snapshots/let_polymorphism_error.md
@@ -11,13 +11,16 @@ type=expr
 MISSING METHOD - let_polymorphism_error.md:1:6:1:9
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **let_polymorphism_error.md:1:6:1:9:**
 ```roc
 [42, 4.2, "hello"]
 ```
      ^^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/let_polymorphism_records.md
+++ b/test/snapshots/let_polymorphism_records.md
@@ -54,13 +54,16 @@ UNUSED VALUE - let_polymorphism_records.md:38:2:38:17
 MISSING METHOD - let_polymorphism_records.md:38:2:38:3
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **let_polymorphism_records.md:26:47:26:49:**
 ```roc
 updated_mismatch = update_data(str_container, 99)
 ```
                                               ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
@@ -76,13 +79,16 @@ It has the type:
     _{ ..a, data: b }, b -> { ..a, data: b }_
 
 **MISSING METHOD**
-This `from_numeral` method is being called on the type _{ ..a, data: b }, b -> { ..a, data: b }_, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **let_polymorphism_records.md:38:2:38:3:**
 ```roc
 	1 + update_data
 ```
 	^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _{ ..a, data: b }, b -> { ..a, data: b }_
 
 
 # TOKENS

--- a/test/snapshots/match_expr/basic_tag_union.md
+++ b/test/snapshots/match_expr/basic_tag_union.md
@@ -27,13 +27,16 @@ match color {
 
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **basic_tag_union.md:3:10:3:11:**
 ```roc
 	Blue => 2
 ```
 	        ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/match_expr/literal_patterns.md
+++ b/test/snapshots/match_expr/literal_patterns.md
@@ -19,45 +19,57 @@ MISSING METHOD - literal_patterns.md:5:5:5:7
 MISSING METHOD - literal_patterns.md:5:11:5:12
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **literal_patterns.md:2:15:2:16:**
 ```roc
     Answer => 1
 ```
               ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **literal_patterns.md:4:17:4:18:**
 ```roc
     Greeting => 3
 ```
                 ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This `from_numeral` method is being called on the type _[Answer, Zero, Greeting]_others_, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **literal_patterns.md:5:5:5:7:**
 ```roc
     10 => 4
 ```
     ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _[Answer, Zero, Greeting]_others_
 
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **literal_patterns.md:5:11:5:12:**
 ```roc
     10 => 4
 ```
           ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/match_expr/pattern_alternatives_mixed.md
+++ b/test/snapshots/match_expr/pattern_alternatives_mixed.md
@@ -44,13 +44,16 @@ All patterns in an `match` must have compatible types.
 
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **pattern_alternatives_mixed.md:2:10:2:11:**
 ```roc
 	1 | 2 | 3 => "small numbers"
 ```
 	        ^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/multiline_string_complex.md
+++ b/test/snapshots/multiline_string_complex.md
@@ -72,13 +72,16 @@ But I expected it to be:
     _Bool_
 
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **multiline_string_complex.md:37:3:37:4:**
 ```roc
 		0 - \\
 ```
 		^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/plume_package/Color.md
+++ b/test/snapshots/plume_package/Color.md
@@ -210,24 +210,30 @@ It's referenced here:
 
 
 **MISSING METHOD**
-This **to_frac** method is being called on the type **Num.U8**, which has no method with that name:
+This **to_frac** method is being called on a value whose type doesn't have that method:
 **Color.md:22:15:22:26:**
 ```roc
     rounded = a.to_frac() / 255.0
 ```
               ^^^^^^^^^^^
 
+The value's type, which does not have a method named **to_frac**, is:
+
+    _Num.U8_
 
 **Hint: **For this to work, the type would need to have a method named **to_frac** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **to_utf8** method is being called on the type **Str**, which has no method with that name:
+This **to_utf8** method is being called on a value whose type doesn't have that method:
 **Color.md:29:13:29:26:**
 ```roc
     bytes = str.to_utf8()
 ```
             ^^^^^^^^^^^^^
 
+The value's type, which does not have a method named **to_utf8**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **to_utf8** associated with it in the type's declaration.
 
@@ -258,35 +264,44 @@ But the type annotation says it should have the type:
     _Try(Color, [InvalidHex(Str)])_
 
 **MISSING METHOD**
-This **is_named_color** method is being called on the type **Str**, which has no method with that name:
+This **is_named_color** method is being called on a value whose type doesn't have that method:
 **Color.md:62:8:62:28:**
 ```roc
     if str.is_named_color()
 ```
        ^^^^^^^^^^^^^^^^^^^^
 
+The value's type, which does not have a method named **is_named_color**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **is_named_color** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **to_str** method is being called on the type **Color**, which has no method with that name:
+This **to_str** method is being called on a value whose type doesn't have that method:
 **Color.md:56:8:56:34:**
 ```roc
 expect rgb(124, 56, 245).to_str() == "rgb(124, 56, 245)"
 ```
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+The value's type, which does not have a method named **to_str**, is:
+
+    _Color_
 
 **Hint: **For this to work, the type would need to have a method named **to_str** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **to_str** method is being called on the type **Color**, which has no method with that name:
+This **to_str** method is being called on a value whose type doesn't have that method:
 **Color.md:57:8:57:40:**
 ```roc
 expect rgba(124, 56, 245, 255).to_str() == "rgba(124, 56, 245, 1.0)"
 ```
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+The value's type, which does not have a method named **to_str**, is:
+
+    _Color_
 
 **Hint: **For this to work, the type would need to have a method named **to_str** associated with it in the type's declaration.
 

--- a/test/snapshots/records/polymorphism.md
+++ b/test/snapshots/records/polymorphism.md
@@ -17,13 +17,16 @@ type=expr
 MISSING METHOD - polymorphism.md:6:5:6:37
 # PROBLEMS
 **MISSING METHOD**
-This `to_str` method is being called on the type _{ first: a, first: Str, first: [True]b, pair1: { first: a, second: Str }, pair2: { first: Str, second: c }, pair3: { first: [True]b, second: [False]d }, second: Str, second: c, second: [False]d } where [{ first: a, first: Str, first: [True]b, pair1: { first: a, second: Str }, pair2: { first: Str, second: c }, pair3: { first: [True]b, second: [False]d }, second: Str, second: c, second: [False]d }.from_numeral : { first: a, first: Str, first: [True]b, pair1: { first: a, second: Str }, pair2: { first: Str, second: c }, pair3: { first: [True]b, second: [False]d }, second: Str, second: c, second: [False]d }, { first: a, first: Str, first: [True]b, pair1: { first: a, second: Str }, pair2: { first: Str, second: c }, pair3: { first: [True]b, second: [False]d }, second: Str, second: c, second: [False]d }.from_numeral : { first: a, first: Str, first: [True]b, pair1: { first: a, second: Str }, pair2: { first: Str, second: c }, pair3: { first: [True]b, second: [False]d }, second: Str, second: c, second: [False]d }]_, which has no method with that name:
+This **to_str** method is being called on a value whose type doesn't have that method:
 **polymorphism.md:6:5:6:37:**
 ```roc
     { pair1, pair2, pair3 }.to_str()
 ```
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+The value's type, which does not have a method named **to_str**, is:
+
+    _{ first: a, first: Str, first: [True]b, pair1: { first: a, second: Str }, pair2: { first: Str, second: c }, pair3: { first: [True]b, second: [False]d }, second: Str, second: c, second: [False]d } where [{ first: a, first: Str, first: [True]b, pair1: { first: a, second: Str }, pair2: { first: Str, second: c }, pair3: { first: [True]b, second: [False]d }, second: Str, second: c, second: [False]d }.from_numeral : { first: a, first: Str, first: [True]b, pair1: { first: a, second: Str }, pair2: { first: Str, second: c }, pair3: { first: [True]b, second: [False]d }, second: Str, second: c, second: [False]d }, { first: a, first: Str, first: [True]b, pair1: { first: a, second: Str }, pair2: { first: Str, second: c }, pair3: { first: [True]b, second: [False]d }, second: Str, second: c, second: [False]d }.from_numeral : { first: a, first: Str, first: [True]b, pair1: { first: a, second: Str }, pair2: { first: Str, second: c }, pair3: { first: [True]b, second: [False]d }, second: Str, second: c, second: [False]d }]_
 
 
 # TOKENS

--- a/test/snapshots/static_dispatch/Adv.md
+++ b/test/snapshots/static_dispatch/Adv.md
@@ -49,35 +49,44 @@ MISSING METHOD - Adv.md:23:13:23:33
 MISSING METHOD - Adv.md:28:13:28:32
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **Adv.md:17:28:17:31:**
 ```roc
 	next_val = val.update_str(100)
 ```
 	                          ^^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **update_strr** method is being called on the type **Adv**, which has no method with that name:
+This **update_strr** method is being called on a value whose type doesn't have that method:
 **Adv.md:23:13:23:33:**
 ```roc
 	next_val = val.update_strr(100)
 ```
 	           ^^^^^^^^^^^^^^^^^^^^
 
+The value's type, which does not have a method named **update_strr**, is:
+
+    _Adv_
 
 **Hint: **For this to work, the type would need to have a method named **update_strr** associated with it in the type's declaration.
 
 **MISSING METHOD**
-This **update** method is being called on the type **Str**, which has no method with that name:
+This **update** method is being called on a value whose type doesn't have that method:
 **Adv.md:28:13:28:32:**
 ```roc
 	next_val = "Hello".update(100)
 ```
 	           ^^^^^^^^^^^^^^^^^^^
 
+The value's type, which does not have a method named **update**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **update** associated with it in the type's declaration.
 

--- a/test/snapshots/static_dispatch/plus_operator_vs_method.md
+++ b/test/snapshots/static_dispatch/plus_operator_vs_method.md
@@ -27,24 +27,30 @@ MISSING METHOD - plus_operator_vs_method.md:11:11:11:16
 MISSING METHOD - plus_operator_vs_method.md:15:11:15:20
 # PROBLEMS
 **MISSING METHOD**
-The value before this **+** operator has the type **MyType**, which has no **plus** method:
+The value before this **+** operator has a type that doesn't have a **plus** method:
 **plus_operator_vs_method.md:11:11:11:16:**
 ```roc
 result1 = a + b
 ```
           ^^^^^
 
+The value's type, which does not have a method named **plus**, is:
+
+    _MyType_
 
 **Hint: **The **+** operator calls a method named **plus** on the value preceding it, passing the value after the operator as the one argument.
 
 **MISSING METHOD**
-This **plus** method is being called on the type **MyType**, which has no method with that name:
+This **plus** method is being called on a value whose type doesn't have that method:
 **plus_operator_vs_method.md:15:11:15:20:**
 ```roc
 result2 = a.plus(b)
 ```
           ^^^^^^^^^
 
+The value's type, which does not have a method named **plus**, is:
+
+    _MyType_
 
 **Hint: **For this to work, the type would need to have a method named **plus** associated with it in the type's declaration.
 

--- a/test/snapshots/test_instantiated_arg_mismatch.md
+++ b/test/snapshots/test_instantiated_arg_mismatch.md
@@ -16,13 +16,16 @@ type=expr
 MISSING METHOD - test_instantiated_arg_mismatch.md:5:10:5:12
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **Str**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **test_instantiated_arg_mismatch.md:5:10:5:12:**
 ```roc
     pair(42, "hello")
 ```
          ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _Str_
 
 **Hint: **For this to work, the type would need to have a method named **from_numeral** associated with it in the type's declaration.
 

--- a/test/snapshots/type_var_mismatch.md
+++ b/test/snapshots/type_var_mismatch.md
@@ -26,13 +26,16 @@ main! = |_| {}
 MISSING METHOD - type_var_mismatch.md:7:9:7:11
 # PROBLEMS
 **MISSING METHOD**
-This **from_numeral** method is being called on the type **item**, which has no method with that name:
+This **from_numeral** method is being called on a value whose type doesn't have that method:
 **type_var_mismatch.md:7:9:7:11:**
 ```roc
 	item = 42
 ```
 	       ^^
 
+The value's type, which does not have a method named **from_numeral**, is:
+
+    _item_
 
 **Hint: ** Did you forget to specify **from_numeral** in the type annotation?
 


### PR DESCRIPTION
I think this could be improved further, but this is better than what we have on `main` right now.