### PR TITLE
fix `Try.is_ok` and `Try.is_err` 

### DIFF
--- a/test/snapshots/repl/try_is_ok_assigned.md
+++ b/test/snapshots/repl/try_is_ok_assigned.md
@@ -1,0 +1,16 @@
+# META
+~~~ini
+description=Try.is_ok with assigned variable
+type=repl
+~~~
+# SOURCE
+~~~roc
+» ok_val = Ok(42)
+» Try.is_ok(ok_val)
+~~~
+# OUTPUT
+assigned `ok_val`
+---
+True
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/try_is_ok_direct.md
+++ b/test/snapshots/repl/try_is_ok_direct.md
@@ -1,0 +1,13 @@
+# META
+~~~ini
+description=Try.is_ok direct call without assignment
+type=repl
+~~~
+# SOURCE
+~~~roc
+» Try.is_ok(Ok(42))
+~~~
+# OUTPUT
+True
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/try_is_ok_is_err.md
+++ b/test/snapshots/repl/try_is_ok_is_err.md
@@ -1,0 +1,13 @@
+# META
+~~~ini
+description=Try.is_ok and Try.is_err should return correct values
+type=repl
+~~~
+# SOURCE
+~~~roc
+» Try.is_ok(Ok(42))
+~~~
+# OUTPUT
+True
+# PROBLEMS
+NIL


### PR DESCRIPTION
`Try.is_ok` and `Try.is_err` returned inverted/incorrect values when the tag value was created via a let-binding 

