### PR TITLE
Fix canonicalization of top level recursive function

### DIFF
--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -1231,3 +1231,16 @@ test "fx platform runtime division by zero" {
         },
     }
 }
+
+test "fx platform recursive top-level function regression" {
+    // Regression test: Recursive functions defined at top-level were incorrectly
+    // capturing themselves as free variables, causing a segfault when the closure
+    // tried to resolve the capture value before the function was fully bound.
+    const allocator = testing.allocator;
+
+    const run_result = try runRoc(allocator, "test/fx/recursive_top_level.roc", .{});
+    defer allocator.free(run_result.stdout);
+    defer allocator.free(run_result.stderr);
+
+    try checkSuccess(run_result);
+}

--- a/src/eval/test/eval_test.zig
+++ b/src/eval/test/eval_test.zig
@@ -1387,3 +1387,12 @@ test "if block with local bindings - regression" {
         \\else 99
     , 0, .no_trace);
 }
+
+test "recursive function - regression" {
+    // Regression test for recursive function
+    // Bug report: `main! = || { countdown = |n| if True { 0 } else { countdown(n - 1) }\n _ignore = countdown(1) }`
+    try runExpectInt(
+        \\{ countdown = |n| if True { 0 } else { countdown(n - 1) }
+        \\countdown(1) }
+    , 0, .no_trace);
+}

--- a/test/fx/recursive_top_level.roc
+++ b/test/fx/recursive_top_level.roc
@@ -1,0 +1,7 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+countdown = |n| if True { 0 } else { countdown(n - 1) }
+
+main! = || {
+    _result = countdown(1)
+}


### PR DESCRIPTION
Defining a recursive function as a top-level constant caused a segmentation fault:

```roc
countdown = |n| if True { 0 } else { countdown(n - 1) }
```

**Root Cause**: When canonicalizing the lambda, the closure incorrectly captured `countdown` as a free variable. At runtime, when `evalClosure` tried to resolve this capture, `countdown` hadn't been bound yet (it was still being defined), causing a null pointer dereference and segfault.

## Solution

Added a `current_def_pattern` field to the canonicalizer to track which pattern is currently being defined. When collecting lambda captures, we now filter out self-references:

**Changes in `src/canonicalize/Can.zig`:**

1. Added field to track current definition (line 71):
```zig
current_def_pattern: ?Pattern.Idx = null,
```

2. Filter self-references in lambda capture collection (line 4854-4858):
```zig
const is_self_reference = if (self.current_def_pattern) |def_pat| fv == def_pat else false;
if (!is_self_reference and !self.scratch_captures.contains(fv) and !bound_vars.contains(fv)) {
    try self.scratch_captures.append(fv);
}
```

3. Set `current_def_pattern` in block declarations (line 9481-9484)

4. Set `current_def_pattern` in top-level declarations (line 3671-3674)
