### PR TITLE
Fix rank unification bug

### DIFF
--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -2490,6 +2490,7 @@ pub const Scratch = struct {
         self.only_in_a_static_dispatch_constraints.items.clearRetainingCapacity();
         self.only_in_b_static_dispatch_constraints.items.clearRetainingCapacity();
         self.in_both_static_dispatch_constraints.items.clearRetainingCapacity();
+        self.fresh_vars.items.clearRetainingCapacity();
         self.occurs_scratch.reset();
         self.err = null;
     }

--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -197,6 +197,13 @@ pub const io_spec_tests = [_]TestSpec{
         .io_spec = "1>Closed: TagB|1>With payload: Value(42)|1>Number: 123",
         .description = "Str.inspect on tag unions",
     },
+
+    // Bug regression tests
+    .{
+        .roc_file = "test/fx/unify_scratch_fresh_vars_rank_bug.roc",
+        .io_spec = "1>ok",
+        .description = "Regression test: unify scratch fresh_vars must be cleared between calls",
+    },
 };
 
 /// Get the total number of IO spec tests

--- a/test/fx/unify_scratch_fresh_vars_rank_bug.roc
+++ b/test/fx/unify_scratch_fresh_vars_rank_bug.roc
@@ -1,0 +1,35 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+# This is a minimal reproducer for a bug where the unify_scratch.fresh_vars
+# list was not being cleared between unify calls. This caused fresh vars
+# created at rank 2 (inside a lambda) during processing of f1 to persist
+# and then cause a panic when processing f2's annotation at rank 1.
+#
+# The key pattern is:
+# 1. main! has a lambda body (rank pushes to 2)
+# 2. Inside that lambda, we look up run! which triggers checkDef(run!)
+# 3. run! also has a lambda body (sub_env rank pushes to 2)
+# 4. Inside run!'s lambda, we look up f1 and f2 which both have Try(_, _)
+# 5. The underscore wildcard in Try annotations caused fresh vars at rank 2
+# 6. When processing f2, the fresh_vars from f1 were still in the list
+
+main! = || {
+    match run!() {
+        Ok(_) => Stdout.line!("ok")
+        Err(_) => {}
+    }
+}
+
+run! = || {
+    _x = f1(0)?
+    _y = f2(0)?
+    Ok({})
+}
+
+f1 : U64 -> Try(U64, _)
+f1 = |_| Ok(0)
+
+f2 : U64 -> Try(U64, _)
+f2 = |_| Ok(0)


### PR DESCRIPTION
This fixes a crash in @mpizenberg's Advent of Code day 2 solution.

There's a separate memory leak issue but that happens on the host side, not in the compiler!