### PR TITLE
Fix use-after-free in List.append with tuples containing strings

### DIFF
--- a/src/eval/test/low_level_interp_test.zig
+++ b/src/eval/test/low_level_interp_test.zig
@@ -849,6 +849,19 @@ test "e_low_level_lambda - List.append for already refcounted elt" {
     try testing.expectEqual(@as(i128, 4), len_value);
 }
 
+test "e_low_level_lambda - List.append for list of tuples with strings (issue 8650)" {
+    // This test reproduces issue #8650 - use-after-free when appending tuples containing strings.
+    // The bug was that isRefcounted() returns false for tuples, so strings inside tuples
+    // weren't being increffed before the append, leading to use-after-free.
+    const src =
+        \\x = List.append([("a", "b")], ("hello", "world"))
+        \\len = List.len(x)
+    ;
+
+    const len_value = try evalModuleAndGetInt(src, 1);
+    try testing.expectEqual(@as(i128, 2), len_value);
+}
+
 test "e_low_level_lambda - List.drop_at on an empty list at index 0" {
     const src =
         \\x = List.drop_at([], 0)


### PR DESCRIPTION
## Summary
- Fixes #8650 - use-after-free when using List.append with tuples containing strings in a fold operation
- Added `layoutContainsRefcounted()` helper that checks if a layout transitively contains refcounted data (strings, lists, boxes, etc.)
- Fixed `list_append` to use this new function instead of `isRefcounted()`, which only checks if the layout itself is heap-allocated

## Test plan
- [x] Added regression test: `e_low_level_lambda - List.append for list of tuples with strings (issue 8650)`
- [x] All existing tests pass (`zig build test`)
- [x] `zig build minici` passes

## Notes
This fix applies to the **interpreter path** (used by the REPL, tests, and snapshot tooling). The compiled code path (LLVM via Rust) would need a similar fix in the code generator, but that is out of scope for this change since it requires modifying Rust code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)