### PR TITLE
Do not use setVarRedirect and revert generalization effective rank

### DIFF
--- a/src/check/copy_import.zig
+++ b/src/check/copy_import.zig
@@ -58,7 +58,7 @@ pub fn copyVar(
     const dest_content = try copyContent(source_store, dest_store, resolved.desc.content, var_mapping, source_idents, dest_idents, allocator);
 
     // Update the placeholder with the actual content
-    try dest_store.setVarDesc(placeholder_var, .{
+    try dest_store.dangerousSetVarDesc(placeholder_var, .{
         .content = dest_content,
         .rank = types_mod.Rank.generalized,
         .mark = types_mod.Mark.none,

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -649,8 +649,10 @@ const Unifier = struct {
                 // Next, we create a fresh alias (which internally points to `backing_var`),
                 // then we redirect both a & b to the new alias.
                 const fresh_alias_var = self.fresh(vars, .{ .alias = a_alias }) catch return Error.AllocatorError;
-                self.types_store.setVarRedirect(vars.a.var_, fresh_alias_var) catch return Error.AllocatorError;
-                self.types_store.setVarRedirect(vars.b.var_, fresh_alias_var) catch return Error.AllocatorError;
+
+                // TODO: Is it possible to loose rank information here? I suspect so...
+                self.types_store.dangerousSetVarRedirect(vars.a.var_, fresh_alias_var) catch return Error.AllocatorError;
+                self.types_store.dangerousSetVarRedirect(vars.b.var_, fresh_alias_var) catch return Error.AllocatorError;
             },
             .recursion_var => |_| {
                 // Unify alias backing var with recursion var
@@ -736,8 +738,10 @@ const Unifier = struct {
                 // Next, we create a fresh alias (which internally points to `backing_var`),
                 // then we redirect both a & b to the new alias.
                 const fresh_alias_var = self.fresh(vars, .{ .alias = b_alias }) catch return Error.AllocatorError;
-                self.types_store.setVarRedirect(vars.a.var_, fresh_alias_var) catch return Error.AllocatorError;
-                self.types_store.setVarRedirect(vars.b.var_, fresh_alias_var) catch return Error.AllocatorError;
+
+                // TODO: Is it possible to loose rank information here? I suspect so...
+                self.types_store.dangerousSetVarRedirect(vars.a.var_, fresh_alias_var) catch return Error.AllocatorError;
+                self.types_store.dangerousSetVarRedirect(vars.b.var_, fresh_alias_var) catch return Error.AllocatorError;
             },
             .structure => |b_flat_type| {
                 try self.unifyFlatType(vars, a_flat_type, b_flat_type);

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -8936,7 +8936,7 @@ pub const Interpreter = struct {
         // Redirect the placeholder to the final var so any code that grabbed the placeholder
         // during recursion will now resolve to the correct type
         if (@intFromEnum(placeholder) != @intFromEnum(final_var)) {
-            try self.runtime_types.setVarRedirect(placeholder, final_var);
+            try self.runtime_types.dangerousSetVarRedirect(placeholder, final_var);
         }
 
         return final_var;

--- a/src/types/generalize.zig
+++ b/src/types/generalize.zig
@@ -171,13 +171,7 @@ pub const Generalizer = struct {
         // Copy all variables at this rank into the temporary pool, resolving redirects
         for (vars_to_generalize) |var_| {
             const resolved = self.store.resolveVar(var_);
-            // Cap the rank at rank_to_generalize. If the resolved variable has a higher
-            // rank than what we're generalizing, this can happen when a variable is
-            // redirected (via setVarRedirect) to a higher-rank variable after being
-            // added to the var_pool. We handle this by treating it as if it's at the
-            // current rank - it will be properly handled during rank adjustment.
-            const effective_rank = resolved.desc.rank.min(rank_to_generalize);
-            try self.tmp_var_pool.addVarToRank(resolved.var_, effective_rank);
+            try self.tmp_var_pool.addVarToRank(resolved.var_, resolved.desc.rank);
             try self.vars_to_generalized.put(resolved.var_, {});
         }
 

--- a/src/types/instantiate.zig
+++ b/src/types/instantiate.zig
@@ -131,7 +131,7 @@ pub const Instantiator = struct {
                 };
 
                 // Update the placeholder fresh var with the real content
-                try self.store.setVarDesc(
+                try self.store.dangerousSetVarDesc(
                     fresh_var,
                     .{
                         .content = fresh_content,
@@ -152,7 +152,7 @@ pub const Instantiator = struct {
                 const fresh_content = try self.instantiateContent(resolved.desc.content);
 
                 // Update the placeholder fresh var with the real content
-                try self.store.setVarDesc(
+                try self.store.dangerousSetVarDesc(
                     fresh_var,
                     .{
                         .content = fresh_content,

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -191,7 +191,12 @@ pub const Store = struct {
     // setting variables //
 
     /// Set a type variable to the provided content
-    pub fn setVarDesc(self: *Self, target_var: Var, desc: Desc) Allocator.Error!void {
+    ///
+    /// IMPORTANT: When using this function during type checking, it's possible
+    /// to loose `rank` information! You should prefer to use regular `unify`
+    /// over this function, which correctly propagates rank, unless you already
+    /// know the two vars are of  the same rank.
+    pub fn dangerousSetVarDesc(self: *Self, target_var: Var, desc: Desc) Allocator.Error!void {
         std.debug.assert(@intFromEnum(target_var) < self.len());
         const resolved = self.resolveVar(target_var);
         self.descs.set(resolved.desc_idx, desc);
@@ -206,8 +211,14 @@ pub const Store = struct {
         self.descs.set(resolved.desc_idx, desc);
     }
 
-    /// Set a type variable to redirect to the provided redirect
-    pub fn setVarRedirect(self: *Self, target_var: Var, redirect_to: Var) Allocator.Error!void {
+    /// Set a type variable to redirect to the provided variables.
+    /// During type-checking, you probably don't want to use this function.
+    ///
+    /// IMPORTANT: When using this function during type checking, it's possible
+    /// to loose `rank` information! You should prefer to use regular `unify`
+    /// over this function, which correctly propagates rank, unless you already
+    /// know the two vars are of the same rank.
+    pub fn dangerousSetVarRedirect(self: *Self, target_var: Var, redirect_to: Var) Allocator.Error!void {
         std.debug.assert(@intFromEnum(target_var) < self.len());
         std.debug.assert(@intFromEnum(redirect_to) < self.len());
         // Self-redirects cause infinite loops in resolveVar


### PR DESCRIPTION
This PR address the same bug in https://github.com/roc-lang/roc/issues/8656 (originally resolved in https://github.com/roc-lang/roc/pull/8658), but fixes it in a different way.

During type checking implementation, I learned that the function `setVarRedirect` has a footgun in it, as it make it really easy to loose variable `rank` information. Problem is, I never documented that anywhere so subsequent type checking method where implemented using that function, causing the rank panic in the original issue.

This PR:
* Renames `setVarRedirect` to `dangerousSetVarRedirect` and adds a doc comment explaining the footgun in there
* Replaces calls to `dangerousSetVarRedirect` with calls to `unify` in `Check`
* Reverts generalization to how it was pre https://github.com/roc-lang/roc/pull/8658

The `effective_rank` solution in https://github.com/roc-lang/roc/pull/8658 may be totally fine (and indeed, there were no test regressions!), but rank tracking and generalization is one of the trickiest + most confusing parts of type checking overall. IMO the closer we can keep this to Elm (which is what this part of the codebase is ported from), the better. Hence this PR.