### PR TITLE
default to tracy_callstack off

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1286,7 +1286,7 @@ pub fn build(b: *std.Build) void {
 
     // tracy profiler configuration
     const flag_enable_tracy = b.option([]const u8, "tracy", "Enable Tracy integration. Supply path to Tracy source");
-    const flag_tracy_callstack = b.option(bool, "tracy-callstack", "Include callstack information with Tracy data. Does nothing if -Dtracy is not provided") orelse (flag_enable_tracy != null);
+    const flag_tracy_callstack = b.option(bool, "tracy-callstack", "Include callstack information with Tracy data. Does nothing if -Dtracy is not provided") orelse false;
     const flag_tracy_allocation = b.option(bool, "tracy-allocation", "Include allocation information with Tracy data. Does nothing if -Dtracy is not provided") orelse (flag_enable_tracy != null);
     const flag_tracy_callstack_depth: u32 = b.option(u32, "tracy-callstack-depth", "Declare callstack depth for Tracy data. Does nothing if -Dtracy_callstack is not provided") orelse 10;
     if (flag_tracy_callstack) {


### PR DESCRIPTION
It is just super slow and expensive to have all the time when tracy is enabled. The right default is off.