### PR TITLE
fix if else fmt without {}

### DIFF
--- a/test/snapshots/if_then_else/if_then_else_multiline_no_curlies.md
+++ b/test/snapshots/if_then_else/if_then_else_multiline_no_curlies.md
@@ -1,0 +1,55 @@
+# META
+~~~ini
+description=if else multiline without curly brackets
+type=expr
+~~~
+# SOURCE
+~~~roc
+if Bool.True
+	"true"
+else
+	"false"
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+KwIf,UpperIdent,NoSpaceDotUpperIdent,
+StringStart,StringPart,StringEnd,
+KwElse,
+StringStart,StringPart,StringEnd,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-if-then-else
+	(e-tag (raw "Bool.True"))
+	(e-string
+		(e-string-part (raw "true")))
+	(e-string
+		(e-string-part (raw "false"))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-if
+	(if-branches
+		(if-branch
+			(e-nominal-external
+				(builtin)
+				(e-tag (name "True")))
+			(e-string
+				(e-literal (string "true")))))
+	(if-else
+		(e-string
+			(e-literal (string "false")))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "Str"))
+~~~

--- a/test/snapshots/plume_package/Color.md
+++ b/test/snapshots/plume_package/Color.md
@@ -869,8 +869,8 @@ named : Str -> Try(Color, [UnknownColor(Str)])
 named = |str|
 	if str.is_named_color()
 		Ok(Color.Named(str))
-			else
-				Err(UnknownColor("Unknown color ${str}"))
+	else
+		Err(UnknownColor("Unknown color ${str}"))
 
 is_named_color = |str| {
 	colors = Set.from_list(["AliceBlue", "AntiqueWhite", "Aqua"])


### PR DESCRIPTION
We allow `if else` without curly brackets but `roc fmt` formatted these badly, this is now fixed.