### PR TITLE
Fix List.map crash on empty lists

### DIFF
--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -17175,13 +17175,15 @@ pub const Interpreter = struct {
                     return error.Crash;
                 };
 
-                // Get the list layout
-                if (list_value.layout.tag != .list) {
+                // Get the list layout - handle both regular lists and list_of_zst (empty lists)
+                if (list_value.layout.tag != .list and list_value.layout.tag != .list_of_zst) {
                     list_value.decref(&self.runtime_layout_store, roc_ops);
                     return error.TypeMismatch;
                 }
-                const elem_layout_idx = list_value.layout.data.list;
-                const elem_layout = self.runtime_layout_store.getLayout(elem_layout_idx);
+                const elem_layout = if (list_value.layout.tag == .list)
+                    self.runtime_layout_store.getLayout(list_value.layout.data.list)
+                else
+                    layout.Layout.zst(); // list_of_zst has zero-sized elements
                 const elem_size: usize = @intCast(self.runtime_layout_store.layoutSize(elem_layout));
 
                 // Get the RocList header

--- a/test/snapshots/list_map_empty.md
+++ b/test/snapshots/list_map_empty.md
@@ -1,0 +1,13 @@
+# META
+~~~ini
+description=List.map on empty list
+type=repl
+~~~
+# SOURCE
+~~~roc
+» List.map([], |_| 0)
+~~~
+# OUTPUT
+[]
+# PROBLEMS
+NIL


### PR DESCRIPTION
Fixes #8722

The interpreter's for_iterate continuation only accepted `.list` layout but not `.list_of_zst` layout. Empty lists (like `[]` in `List.map([], |_| 0)`) get the `.list_of_zst` layout, which caused a TypeMismatch error when iterating over them.

- Updated for_iterate to handle both `.list` and `.list_of_zst` layouts
- Added a snapshot test to verify the fix
- Consistent with other list-handling code in the interpreter that already handles both layout types

Co-authored by Claude Opus 4.5