### PR TITLE
Fix interpreter argument typing for static dispatch

### DIFF
--- a/test/fx/static_dispatch_fn_param.roc
+++ b/test/fx/static_dispatch_fn_param.roc
@@ -1,0 +1,19 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+# Test static dispatch on function parameters.
+# Previously, `args.get(0)` crashed when `args` was a function parameter
+# because the numeric literal wasn't getting the correct U64 type from
+# the method signature.
+process! = |args| {
+    match args.get(0) {
+        Ok(x) => Stdout.line!(x)
+        Err(_) => Stdout.line!("error")
+    }
+}
+
+main! = || {
+    args = ["hello", "world"]
+    process!(args)
+}


### PR DESCRIPTION
This commit improves how the interpreter handles argument typing for static dispatch (dot access) method calls.

Key changes:
- Correctly resolves the method's function signature from its closure header and environment.
- Unifies the method's receiver parameter with the actual receiver type to properly bind type variables (e.g., resolving 'a' in 'List a').
- Uses the resolved parameter types as the expected types for arguments. This fixes type inference for polymorphic literals (e.g., 'list.get(0)' where '0' needs to be inferred as 'U64').
- Adds a layout check to 'list_get_unsafe' to ensure the index argument is a scalar integer.

Includes a regression test in 'test/fx/static_dispatch_fn_param.roc'.