### PR TITLE
Increase Rank size from u4 to u8 to support deeper nesting

### DIFF
--- a/src/types/types.zig
+++ b/src/types/types.zig
@@ -100,9 +100,7 @@ pub const Descriptor = struct { content: Content, rank: Rank, mark: Mark };
 ///
 /// Keeping track of ranks makes type inference faster.
 ///
-/// TODO: We probably need to increase the size of this enum, as 15 is fairly
-/// shallow
-pub const Rank = enum(u4) {
+pub const Rank = enum(u8) {
     /// When the corresponding type is generic, like in `List.len`.
     generalized = 0,
     top_level = 1,


### PR DESCRIPTION
## Summary
- Increased the `Rank` enum in `src/types/types.zig` from `u4` to `u8`
- This changes the maximum nesting depth from 15 levels to 255 levels
- The memory impact is negligible compared to other type data

## Test plan
- [x] All tests pass with `zig build minici`

🤖 Generated with [Claude Code](https://claude.com/claude-code)