### PR TITLE
Fix typo: static_dispach -> static_dispatch

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -5738,7 +5738,7 @@ fn reportConstraintError(
 ) !void {
     const snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, dispatcher_var);
     const constraint_problem = switch (kind) {
-        .missing_method => |dispatcher_type| problem.Problem{ .static_dispach = .{
+        .missing_method => |dispatcher_type| problem.Problem{ .static_dispatch = .{
             .dispatcher_does_not_impl_method = .{
                 .dispatcher_var = dispatcher_var,
                 .dispatcher_snapshot = snapshot,
@@ -5748,7 +5748,7 @@ fn reportConstraintError(
                 .origin = constraint.origin,
             },
         } },
-        .not_nominal => problem.Problem{ .static_dispach = .{
+        .not_nominal => problem.Problem{ .static_dispatch = .{
             .dispatcher_not_nominal = .{
                 .dispatcher_var = dispatcher_var,
                 .dispatcher_snapshot = snapshot,
@@ -5770,7 +5770,7 @@ fn reportEqualityError(
     env: *Env,
 ) !void {
     const snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, dispatcher_var);
-    const equality_problem = problem.Problem{ .static_dispach = .{
+    const equality_problem = problem.Problem{ .static_dispatch = .{
         .type_does_not_support_equality = .{
             .dispatcher_var = dispatcher_var,
             .dispatcher_snapshot = snapshot,

--- a/src/check/problem.zig
+++ b/src/check/problem.zig
@@ -43,7 +43,7 @@ pub const Problem = union(enum) {
     type_mismatch: TypeMismatch,
     fn_call_arity_mismatch: FnCallArityMismatch,
     type_apply_mismatch_arities: TypeApplyArityMismatch,
-    static_dispach: StaticDispatch,
+    static_dispatch: StaticDispatch,
     cannot_access_opaque_nominal: CannotAccessOpaqueNominal,
     nominal_type_resolution_failed: NominalTypeResolutionFailed,
     number_does_not_fit: NumberDoesNotFit,
@@ -485,7 +485,7 @@ pub const ReportBuilder = struct {
             .nominal_type_resolution_failed => |data| {
                 return self.buildNominalTypeResolutionFailed(data);
             },
-            .static_dispach => |detail| {
+            .static_dispatch => |detail| {
                 switch (detail) {
                     .dispatcher_not_nominal => |data| return self.buildStaticDispatchDispatcherNotNominal(data),
                     .dispatcher_does_not_impl_method => |data| return self.buildStaticDispatchDispatcherDoesNotImplMethod(data),


### PR DESCRIPTION
## Summary
- Fixes a typo in the `Problem` union variant name: `static_dispach` → `static_dispatch`
- Updates all 5 occurrences across `src/check/problem.zig` and `src/check/Check.zig`

This cleanup was noted as part of reviewing the static dispatch error message code, which already provides helpful, user-friendly error messages (contrary to what was documented in cleanups.md).

## Test plan
- [x] `zig build minici` passes
- [x] All 2067 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)