### PR TITLE
Improve platform requirements error messages

### DIFF
--- a/src/check/problem.zig
+++ b/src/check/problem.zig
@@ -2700,29 +2700,35 @@ pub const ReportBuilder = struct {
     }
 
     fn buildPlatformAliasNotFound(self: *Self, data: PlatformAliasNotFound) !Report {
-        var report = Report.init(self.gpa, "PLATFORM EXPECTED ALIAS: ", .runtime_error);
+        var report = Report.init(self.gpa, "MISSING PLATFORM REQUIRED TYPE", .runtime_error);
         errdefer report.deinit();
 
         const owned_name = try report.addOwnedString(self.can_ir.getIdentText(data.expected_alias_ident));
 
-        try report.document.addReflowingText("The platform expected your ");
+        try report.document.addReflowingText("The platform expects your ");
         try report.document.addAnnotated("app", .inline_code);
-        try report.document.addReflowingText(" module to have a type alias named:");
-        try report.document.addLineBreak();
-        try report.document.addCodeBlock(owned_name);
-        try report.document.addLineBreak();
-        try report.document.addLineBreak();
-        try report.document.addReflowingText("But I could not find it.");
+        try report.document.addReflowingText(" module to define a type alias named ");
+        try report.document.addAnnotated(owned_name, .type_variable);
+        try report.document.addReflowingText(", but I couldn't find one.");
 
         switch (data.ctx) {
-            .not_found => {},
+            .not_found => {
+                try report.document.addLineBreak();
+                try report.document.addLineBreak();
+                try report.document.addAnnotated("Hint:", .emphasized);
+                try report.document.addReflowingText(" Add a type alias definition for ");
+                try report.document.addAnnotated(owned_name, .type_variable);
+                try report.document.addReflowingText(" to your app module. Check your platform's documentation for the expected type.");
+            },
             .found_but_not_alias => {
                 try report.document.addLineBreak();
                 try report.document.addLineBreak();
                 try report.document.addAnnotated("Hint:", .emphasized);
-                try report.document.addReflowingText(" You have a type with the name ");
+                try report.document.addReflowingText(" You have a definition named ");
                 try report.document.addAnnotated(owned_name, .type_variable);
-                try report.document.addReflowingText(", but it's not an alias.");
+                try report.document.addReflowingText(", but it's not a type alias. The platform requires a type alias (defined with ");
+                try report.document.addAnnotated(":", .inline_code);
+                try report.document.addReflowingText("), not a value definition.");
             },
         }
 
@@ -2730,30 +2736,35 @@ pub const ReportBuilder = struct {
     }
 
     fn buildPlatformDefNotFound(self: *Self, data: PlatformDefNotFound) !Report {
-        var report = Report.init(self.gpa, "PLATFORM EXPECTED DEFINITION: ", .runtime_error);
+        var report = Report.init(self.gpa, "MISSING PLATFORM REQUIRED DEFINITION", .runtime_error);
         errdefer report.deinit();
 
         const owned_name = try report.addOwnedString(self.can_ir.getIdentText(data.expected_def_ident));
 
-        try report.document.addReflowingText("The platform expected your ");
+        try report.document.addReflowingText("The platform expects your ");
         try report.document.addAnnotated("app", .inline_code);
-        try report.document.addReflowingText(" module to have a exported definition named:");
-        try report.document.addLineBreak();
-        try report.document.addLineBreak();
-        try report.document.addCodeBlock(owned_name);
-        try report.document.addLineBreak();
-        try report.document.addLineBreak();
-        try report.document.addReflowingText("But I could not find it.");
+        try report.document.addReflowingText(" module to export a definition named ");
+        try report.document.addAnnotated(owned_name, .inline_code);
+        try report.document.addReflowingText(", but I couldn't find one.");
 
         switch (data.ctx) {
-            .not_found => {},
+            .not_found => {
+                try report.document.addLineBreak();
+                try report.document.addLineBreak();
+                try report.document.addAnnotated("Hint:", .emphasized);
+                try report.document.addReflowingText(" Define and export ");
+                try report.document.addAnnotated(owned_name, .inline_code);
+                try report.document.addReflowingText(" in your app module. Check your platform's documentation for the expected type signature.");
+            },
             .found_but_not_exported => {
                 try report.document.addLineBreak();
                 try report.document.addLineBreak();
                 try report.document.addAnnotated("Hint:", .emphasized);
-                try report.document.addReflowingText(" You have a definition with the name ");
-                try report.document.addAnnotated(owned_name, .type_variable);
-                try report.document.addReflowingText(", but it's not exported. Maybe add it to the export list?");
+                try report.document.addReflowingText(" You have a definition named ");
+                try report.document.addAnnotated(owned_name, .inline_code);
+                try report.document.addReflowingText(", but it's not exported. Add it to your module's ");
+                try report.document.addAnnotated("exposes", .inline_code);
+                try report.document.addReflowingText(" list in the module header.");
             },
         }
 


### PR DESCRIPTION
## Summary

- Clearer error titles: "MISSING PLATFORM REQUIRED TYPE" and "MISSING PLATFORM REQUIRED DEFINITION"
- Added helpful hints for all error cases (previously only some cases had hints):
  - For missing type aliases: suggests checking platform docs
  - For found-but-not-alias: explains the type alias requirement
  - For missing definitions: directs to platform documentation
  - For found-but-not-exported: suggests adding to exposes list
- Fixed grammar issues in the messages

## Test plan

- [x] `zig build minici` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)