### PR TITLE
Fix stack overflow in tag union layout computation (#8750)

### DIFF
--- a/src/layout/store.zig
+++ b/src/layout/store.zig
@@ -946,6 +946,97 @@ pub const Store = struct {
         return Layout.tuple(std.mem.Alignment.fromByteUnits(max_alignment), tuple_idx);
     }
 
+    /// Finalizes a tag union layout after all variant payload layouts have been computed.
+    ///
+    /// This is called once all variants in `pending_tag_union_variants` have been processed
+    /// and their layouts stored in `resolved_tag_union_variants`. It:
+    /// 1. Collects all resolved variant layouts
+    /// 2. Calculates the max payload size and alignment across all variants
+    /// 3. Computes the discriminant offset (where the tag ID is stored in memory)
+    /// 4. Stores the final TagUnionData with size, discriminant info, and variant layouts
+    /// 5. Returns the complete tag union layout
+    fn finishTagUnion(
+        self: *Self,
+        pending: work.Work.PendingTagUnion,
+    ) (LayoutError || std.mem.Allocator.Error)!Layout {
+        const resolved_end = self.work.resolved_tag_union_variants.len;
+
+        // Collect resolved variants and sort by index
+        var variant_layouts = try self.env.gpa.alloc(Idx, pending.num_variants);
+        defer self.env.gpa.free(variant_layouts);
+
+        // Initialize all to ZST (for variants that were never processed because they have no payload)
+        const zst_idx = try self.ensureZstLayout();
+        for (variant_layouts) |*slot| {
+            slot.* = zst_idx;
+        }
+
+        // Fill in resolved variants
+        const indices = self.work.resolved_tag_union_variants.items(.index);
+        const layout_idxs = self.work.resolved_tag_union_variants.items(.layout_idx);
+        for (pending.resolved_variants_start..resolved_end) |i| {
+            variant_layouts[indices[i]] = layout_idxs[i];
+        }
+
+        // Calculate max payload size and alignment
+        var max_payload_size: u32 = 0;
+        var max_payload_alignment: std.mem.Alignment = std.mem.Alignment.@"1";
+
+        // Record variants_start BEFORE appending (this was the issue before - recursive calls would interleave)
+        const variants_start: u32 = @intCast(self.tag_union_variants.len());
+
+        for (variant_layouts) |variant_layout_idx| {
+            const variant_layout = self.getLayout(variant_layout_idx);
+            const variant_size = self.layoutSize(variant_layout);
+            const variant_alignment = variant_layout.alignment(self.targetUsize());
+            if (variant_size > max_payload_size) {
+                max_payload_size = variant_size;
+            }
+            max_payload_alignment = max_payload_alignment.max(variant_alignment);
+
+            // Store variant layout for runtime refcounting
+            _ = try self.tag_union_variants.append(self.env.gpa, .{
+                .payload_layout = variant_layout_idx,
+            });
+        }
+
+        // Calculate discriminant info from the stored discriminant layout
+        const discriminant_layout = self.getLayout(pending.discriminant_layout);
+        const discriminant_size: u8 = @intCast(self.layoutSize(discriminant_layout));
+        const discriminant_alignment: std.mem.Alignment = switch (discriminant_size) {
+            1 => .@"1",
+            2 => .@"2",
+            4 => .@"4",
+            else => .@"1",
+        };
+
+        // Calculate total size: payload at offset 0, discriminant at aligned offset after payload
+        const payload_end = max_payload_size;
+        const discriminant_offset: u16 = @intCast(std.mem.alignForward(u32, payload_end, @intCast(discriminant_alignment.toByteUnits())));
+        const total_size_unaligned = discriminant_offset + discriminant_size;
+
+        // Align total size to the tag union's alignment
+        const tag_union_alignment = max_payload_alignment.max(discriminant_alignment);
+        const total_size = std.mem.alignForward(u32, total_size_unaligned, @intCast(tag_union_alignment.toByteUnits()));
+
+        // Store TagUnionData
+        const tag_union_data_idx: u32 = @intCast(self.tag_union_data.len());
+        _ = try self.tag_union_data.append(self.env.gpa, .{
+            .size = total_size,
+            .discriminant_offset = discriminant_offset,
+            .discriminant_size = discriminant_size,
+            .variants = .{
+                .start = variants_start,
+                .count = @intCast(pending.num_variants),
+            },
+        });
+
+        // Clear resolved variants for this tag union
+        self.work.resolved_tag_union_variants.shrinkRetainingCapacity(pending.resolved_variants_start);
+
+        return Layout.tagUnion(tag_union_alignment, .{ .int_idx = @intCast(tag_union_data_idx) });
+    }
+
     /// Note: the caller must verify ahead of time that the given variable does not
     /// resolve to a flex var or rigid var, unless that flex var or rigid var is
     /// wrapped in a Box or a Num (e.g. `Num a` or `Int a`).
@@ -1291,14 +1382,27 @@ pub const Store = struct {
                             continue;
                         },
                         .tag_union => |tag_union| {
-                            // Handle tag unions by computing the layout based on:
-                            // 1. Discriminant size (based on number of tags)
-                            // 2. Maximum payload size and alignment
+                            // Tag Union Layout Computation (Iterative)
+                            //
+                            // We compute tag union layouts ITERATIVELY using a work queue to avoid
+                            // stack overflow on deeply nested types like `Ok((Name("str"), 5))`.
+                            //
+                            // The approach:
+                            // 1. Push all variants with payloads to `pending_tag_union_variants`
+                            // 2. Push a `PendingTagUnion` container to track progress
+                            // 3. Process each variant's payload type iteratively (not recursively)
+                            // 4. When a payload layout completes, move it to `resolved_tag_union_variants`
+                            // 5. When all variants are resolved, call `finishTagUnion` to assemble
+                            //    the final layout with discriminant, max payload size, etc.
+                            //
+                            // For multi-arg variants like `Point(1, 2)`, we push a `PendingTuple`
+                            // container on top of the tag union. The tuple processes its fields
+                            // iteratively, and its resulting layout becomes the variant's payload.
 
                             const pending_tags_top = self.work.pending_tags.len;
                             defer self.work.pending_tags.shrinkRetainingCapacity(pending_tags_top);
 
-                            // Recursively get all tags by checking the tag extension
+                            // Get all tags by checking the tag extension
                             const num_tags = try self.gatherTags(tag_union);
                             const tags_slice = self.work.pending_tags.slice();
                             const tags_args = tags_slice.items(.args)[pending_tags_top..];
@@ -1307,16 +1411,15 @@ pub const Store = struct {
                             // First, determine discriminant size based on number of tags
                             if (num_tags == 0) {
                                 // Empty tag union - represents a zero-sized type
-                                // Break to fall through to pending container processing
                                 break :flat_type Layout.zst();
                             }
 
-                            const discriminant_layout = if (num_tags <= 256)
-                                Layout.int(.u8)
+                            const discriminant_layout_idx: Idx = if (num_tags <= 256)
+                                Idx.u8
                             else if (num_tags <= 65536)
-                                Layout.int(.u16)
+                                Idx.u16
                             else
-                                Layout.int(.u32);
+                                Idx.u32;
 
                             // If all tags have no payload, we just need the discriminant
                             var has_payload = false;
@@ -1330,21 +1433,10 @@ pub const Store = struct {
 
                             if (!has_payload) {
                                 // Simple tag union with no payloads - just use discriminant
-                                // Break to fall through to pending container processing
-                                break :flat_type discriminant_layout;
+                                break :flat_type self.getLayout(discriminant_layout_idx);
                             }
 
-                            // Complex tag union with payloads
-                            // Create a proper tag_union layout that preserves all variant layouts
-                            // for correct reference counting at runtime.
-                            var max_payload_size: u32 = 0;
-                            var max_payload_alignment: std.mem.Alignment = std.mem.Alignment.@"1";
-
-                            // Sort tags alphabetically by name to ensure consistent discriminant values.
-                            // This is necessary because gatherTags may combine tags from multiple
-                            // unions when following extensions, and the combined list may not be sorted.
-                            // Note: appendUnionTags in the interpreter no longer sorts because
-                            // translateTypeVar already stores flattened, sorted tags in runtime_types.
+                            // Complex tag union with payloads - process iteratively
                             const tags_names = tags_slice.items(.name)[pending_tags_top..];
                             const tags_args_slice = tags_slice.items(.args)[pending_tags_top..];
 
@@ -1358,90 +1450,88 @@ pub const Store = struct {
                             // Sort alphabetically by tag name
                             std.mem.sort(types.Tag, sorted_tags, self.env.getIdentStore(), types.Tag.sortByNameAsc);
 
-                            // Phase 1: Compute all variant layouts first.
-                            // This must happen BEFORE we record variants_start, because computing layouts
-                            // for nested tag unions will recursively append to tag_union_variants.
-                            var variant_layout_indices = try self.env.gpa.alloc(Idx, num_tags);
-                            defer self.env.gpa.free(variant_layout_indices);
+                            // Push variants onto pending_tag_union_variants (in reverse order for pop)
+                            // For multi-arg variants, we create a synthetic tuple type var.
+                            var variants_with_payloads: u32 = 0;
 
-                            for (sorted_tags, 0..) |tag, variant_i| {
-                                const tag_args = tag.args;
-                                const args_slice = self.types_store.sliceVars(tag_args);
-                                variant_layout_indices[variant_i] = if (args_slice.len == 0)
-                                    // No payload - use ZST
-                                    try self.ensureZstLayout()
-                                else if (args_slice.len == 1)
-                                    // Single arg - use its layout
-                                    // Use type_scope to look up rigid var mappings
-                                    try self.addTypeVar(args_slice[0], type_scope)
-                                else blk: {
-                                    // Multiple args - build tuple layout
-                                    var elem_layouts = try self.env.gpa.alloc(Layout, args_slice.len);
-                                    defer self.env.gpa.free(elem_layouts);
-                                    for (args_slice, 0..) |v, i| {
-                                        // Use type_scope to look up rigid var mappings
-                                        const elem_idx = try self.addTypeVar(v, type_scope);
-                                        elem_layouts[i] = self.getLayout(elem_idx);
-                                    }
-                                    break :blk try self.putTuple(elem_layouts);
-                                };
-                            }
+                            // First pass: record where resolved variants will start
+                            const resolved_variants_start = self.work.resolved_tag_union_variants.len;
 
-                            // Phase 2: Now that all nested layouts are created, record variants_start
-                            // and append our variant layouts. This ensures our variants are contiguous.
-                            const variants_start: u32 = @intCast(self.tag_union_variants.len());
+                            for (0..num_tags) |i| {
+                                const variant_i = num_tags - 1 - i; // Reverse order for pop
+                                const tag = sorted_tags[variant_i];
+                                const args_slice = self.types_store.sliceVars(tag.args);
 
-                            for (variant_layout_indices) |variant_layout_idx| {
-                                const variant_layout = self.getLayout(variant_layout_idx);
-                                const variant_size = self.layoutSize(variant_layout);
-                                const variant_alignment = variant_layout.alignment(self.targetUsize());
-                                if (variant_size > max_payload_size) {
-                                    max_payload_size = variant_size;
+                                if (args_slice.len == 0) {
+                                    // No payload - resolve immediately as ZST
+                                    try self.work.resolved_tag_union_variants.append(self.env.gpa, .{
+                                        .index = @intCast(variant_i),
+                                        .layout_idx = try self.ensureZstLayout(),
+                                    });
+                                } else {
+                                    // One or more args - push to pending variants for processing
+                                    try self.work.pending_tag_union_variants.append(self.env.gpa, .{
+                                        .index = @intCast(variant_i),
+                                        .args = tag.args,
+                                    });
+                                    variants_with_payloads += 1;
                                 }
-                                max_payload_alignment = max_payload_alignment.max(variant_alignment);
-
-                                // Store variant layout for runtime refcounting
-                                _ = try self.tag_union_variants.append(self.env.gpa, .{
-                                    .payload_layout = variant_layout_idx,
-                                });
                             }
 
-                            // Calculate discriminant info
-                            const discriminant_size: u8 = if (num_tags <= 256) 1 else if (num_tags <= 65536) 2 else 4;
-                            const discriminant_alignment: std.mem.Alignment = switch (discriminant_size) {
-                                1 => .@"1",
-                                2 => .@"2",
-                                4 => .@"4",
-                                else => unreachable,
-                            };
-
-                            // Calculate total size: payload at offset 0, discriminant at aligned offset after payload
-                            const payload_end = max_payload_size;
-                            const discriminant_offset: u16 = @intCast(std.mem.alignForward(u32, payload_end, @intCast(discriminant_alignment.toByteUnits())));
-                            const total_size_unaligned = discriminant_offset + discriminant_size;
-
-                            // Align total size to the tag union's alignment
-                            const tag_union_alignment = max_payload_alignment.max(discriminant_alignment);
-                            const total_size = std.mem.alignForward(u32, total_size_unaligned, @intCast(tag_union_alignment.toByteUnits()));
-
-                            // Store TagUnionData
-                            const tag_union_data_idx: u32 = @intCast(self.tag_union_data.len());
-                            _ = try self.tag_union_data.append(self.env.gpa, .{
-                                .size = total_size,
-                                .discriminant_offset = discriminant_offset,
-                                .discriminant_size = discriminant_size,
-                                .variants = .{
-                                    .start = variants_start,
-                                    .count = @intCast(num_tags),
+                            // Push the tag union container
+                            try self.work.pending_containers.append(self.env.gpa, .{
+                                .var_ = current.var_,
+                                .container = .{
+                                    .tag_union = .{
+                                        .num_variants = @intCast(num_tags),
+                                        .pending_variants = variants_with_payloads,
+                                        .resolved_variants_start = @intCast(resolved_variants_start),
+                                        .discriminant_layout = discriminant_layout_idx,
+                                    },
                                 },
                             });
 
-                            // Create and store tag_union layout
-                            const tag_union_layout = Layout.tagUnion(tag_union_alignment, .{ .int_idx = @intCast(tag_union_data_idx) });
-                            const tag_union_idx = try self.insertLayout(tag_union_layout);
+                            if (variants_with_payloads == 0) {
+                                // All variants have no payload - finalize immediately
+                                // This shouldn't happen because we already handled has_payload == false above
+                                break :flat_type self.getLayout(discriminant_layout_idx);
+                            }
 
-                            // Break to fall through to pending container processing instead of returning directly
-                            break :flat_type self.getLayout(tag_union_idx);
+                            // Start processing the first variant with a payload
+                            // Find the last pending variant (we process in reverse)
+                            const last_variant = self.work.pending_tag_union_variants.get(
+                                self.work.pending_tag_union_variants.len - 1,
+                            );
+                            const args_slice = self.types_store.sliceVars(last_variant.args);
+                            if (args_slice.len == 1) {
+                                // Single arg variant - process directly
+                                current = self.types_store.resolveVar(args_slice[0]);
+                                continue :outer;
+                            } else {
+                                // Multi-arg variant - set up tuple processing
+                                for (args_slice, 0..) |var_, index| {
+                                    try self.work.pending_tuple_fields.append(self.env.gpa, .{
+                                        .index = @intCast(index),
+                                        .var_ = var_,
+                                    });
+                                }
+                                try self.work.pending_containers.append(self.env.gpa, .{
+                                    .var_ = current.var_, // This var will be overwritten anyway
+                                    .container = .{
+                                        .tuple = .{
+                                            .num_fields = @intCast(args_slice.len),
+                                            .resolved_fields_start = @intCast(self.work.resolved_tuple_fields.len),
+                                            .pending_fields = @intCast(args_slice.len),
+                                        },
+                                    },
+                                });
+                                // Process first tuple field
+                                const first_field = self.work.pending_tuple_fields.get(
+                                    self.work.pending_tuple_fields.len - 1,
+                                );
+                                current = self.types_store.resolveVar(first_field.var_);
+                                continue :outer;
+                            }
                         },
                         .record_unbound => |fields| {
                             // For record_unbound, we need to gather fields directly since it has no Record struct
@@ -1736,6 +1826,62 @@ pub const Store = struct {
                             continue :outer;
                         }
                     },
+                    .tag_union => |*pending_tag_union| {
+                        // Pop the variant we just processed
+                        const pending_variant = self.work.pending_tag_union_variants.pop() orelse unreachable;
+
+                        // Add to resolved variants
+                        try self.work.resolved_tag_union_variants.append(self.env.gpa, .{
+                            .index = pending_variant.index,
+                            .layout_idx = layout_idx,
+                        });
+
+                        // Check if there are more variants with payloads to process
+                        if (pending_tag_union.pending_variants > 0) {
+                            pending_tag_union.pending_variants -= 1;
+                        }
+
+                        if (pending_tag_union.pending_variants == 0) {
+                            // All variants processed - finalize
+                            layout = try self.finishTagUnion(pending_tag_union.*);
+                        } else {
+                            // More variants to process - continue with the next one
+                            const next_variant = self.work.pending_tag_union_variants.get(
+                                self.work.pending_tag_union_variants.len - 1,
+                            );
+                            const next_args_slice = self.types_store.sliceVars(next_variant.args);
+                            if (next_args_slice.len == 1) {
+                                // Single arg variant - process directly
+                                current = self.types_store.resolveVar(next_args_slice[0]);
+                                continue :outer;
+                            } else {
+                                // Multi-arg variant - set up tuple processing
+                                for (next_args_slice, 0..) |var_, index| {
+                                    try self.work.pending_tuple_fields.append(self.env.gpa, .{
+                                        .index = @intCast(index),
+                                        .var_ = var_,
+                                    });
+                                }
+                                // Push tuple container on top of the tag union
+                                try self.work.pending_containers.append(self.env.gpa, .{
+                                    .var_ = undefined, // synthetic tuple, var not meaningful
+                                    .container = .{
+                                        .tuple = .{
+                                            .num_fields = @intCast(next_args_slice.len),
+                                            .resolved_fields_start = @intCast(self.work.resolved_tuple_fields.len),
+                                            .pending_fields = @intCast(next_args_slice.len),
+                                        },
+                                    },
+                                });
+                                // Process first tuple field
+                                const first_field = self.work.pending_tuple_fields.get(
+                                    self.work.pending_tuple_fields.len - 1,
+                                );
+                                current = self.types_store.resolveVar(first_field.var_);
+                                continue :outer;
+                            }
+                        }
+                    },
                 }
 
                 // We're done with this container, so remove it from pending_containers
@@ -1772,12 +1918,12 @@ pub const Store = struct {
             // Since there are no pending containers remaining, there shouldn't be any pending record or tuple fields either.
             std.debug.assert(self.work.pending_record_fields.len == 0);
             std.debug.assert(self.work.pending_tuple_fields.len == 0);
+            std.debug.assert(self.work.pending_tag_union_variants.len == 0);
 
             // No more pending containers; we're done!
-            // Note: Work fields (in_progress_vars, in_progress_nominals, pending_record_fields, etc.)
-            // are not cleared here because addTypeVar may be called recursively (e.g., from tag union
-            // variant processing). Individual entries are removed via swapRemove/pop when types
-            // finish processing, so these should be empty when the top-level call returns.
+            // Note: Work fields (in_progress_vars, in_progress_nominals, etc.) are not cleared
+            // here because individual entries are removed via swapRemove/pop when types finish
+            // processing, so these should be empty when the top-level call returns.
             return layout_idx;
         }
     }


### PR DESCRIPTION
## Summary
- Fixes stack overflow when processing deeply nested tag unions like `Ok((Name("String"), 3))`
- Converts tag union layout computation from recursive to iterative approach
- Uses the existing work queue pattern already used for records and tuples

## Test plan
- [x] Added test case `test/fx/issue8750.roc` that reproduces the original issue
- [x] All 2078 tests pass
- [x] Full minici suite passes

Closes #8750

🤖 Generated with [Claude Code](https://claude.com/claude-code)