### PR TITLE
Add List.sum method with default constraint

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -245,6 +245,13 @@ Builtin :: [].{
 			$list
 		}
 
+		sum : List(item) -> item
+			where [item.plus : item, item -> item, item.default : item]
+		sum = |list| {
+			Item : item
+			List.fold(list, Item.default(), |acc, elem| acc + elem)
+		}
+
 	}
 
 	Bool := [False, True].{
@@ -363,6 +370,9 @@ Builtin :: [].{
 		}
 
 		U8 :: [].{
+			default : () -> U8
+			default = || 0u8
+
 			to_str : U8 -> Str
 			is_zero : U8 -> Bool
 			is_eq : U8, U8 -> Bool
@@ -421,6 +431,9 @@ Builtin :: [].{
 		}
 
 		I8 :: [].{
+			default : () -> I8
+			default = || 0i8
+
 			to_str : I8 -> Str
 			is_zero : I8 -> Bool
 			is_negative : I8 -> Bool
@@ -475,6 +488,9 @@ Builtin :: [].{
 		}
 
 		U16 :: [].{
+			default : () -> U16
+			default = || 0u16
+
 			to_str : U16 -> Str
 			is_zero : U16 -> Bool
 			is_eq : U16, U16 -> Bool
@@ -523,6 +539,9 @@ Builtin :: [].{
 		}
 
 		I16 :: [].{
+			default : () -> I16
+			default = || 0i16
+
 			to_str : I16 -> Str
 			is_zero : I16 -> Bool
 			is_negative : I16 -> Bool
@@ -578,6 +597,9 @@ Builtin :: [].{
 		}
 
 		U32 :: [].{
+			default : () -> U32
+			default = || 0u32
+
 			to_str : U32 -> Str
 			is_zero : U32 -> Bool
 			is_eq : U32, U32 -> Bool
@@ -628,6 +650,9 @@ Builtin :: [].{
 		}
 
 		I32 :: [].{
+			default : () -> I32
+			default = || 0i32
+
 			to_str : I32 -> Str
 			is_zero : I32 -> Bool
 			is_negative : I32 -> Bool
@@ -684,6 +709,9 @@ Builtin :: [].{
 		}
 
 		U64 :: [].{
+			default : () -> U64
+			default = || 0u64
+
 			to_str : U64 -> Str
 			is_zero : U64 -> Bool
 			is_eq : U64, U64 -> Bool
@@ -736,6 +764,9 @@ Builtin :: [].{
 		}
 
 		I64 :: [].{
+			default : () -> I64
+			default = || 0i64
+
 			to_str : I64 -> Str
 			is_zero : I64 -> Bool
 			is_negative : I64 -> Bool
@@ -793,6 +824,9 @@ Builtin :: [].{
 		}
 
 		U128 :: [].{
+			default : () -> U128
+			default = || 0u128
+
 			to_str : U128 -> Str
 			is_zero : U128 -> Bool
 			is_eq : U128, U128 -> Bool
@@ -849,6 +883,9 @@ Builtin :: [].{
 		}
 
 		I128 :: [].{
+			default : () -> I128
+			default = || 0i128
+
 			to_str : I128 -> Str
 			is_zero : I128 -> Bool
 			is_negative : I128 -> Bool
@@ -909,6 +946,9 @@ Builtin :: [].{
 		}
 
 		Dec :: [].{
+			default : () -> Dec
+			default = || 0.0dec
+
 			to_str : Dec -> Str
 			is_zero : Dec -> Bool
 			is_negative : Dec -> Bool
@@ -965,6 +1005,9 @@ Builtin :: [].{
 		}
 
 		F32 :: [].{
+			default : () -> F32
+			default = || 0.0f32
+
 			to_str : F32 -> Str
 			is_zero : F32 -> Bool
 			is_negative : F32 -> Bool
@@ -1018,6 +1061,9 @@ Builtin :: [].{
 		}
 
 		F64 :: [].{
+			default : () -> F64
+			default = || 0.0f64
+
 			to_str : F64 -> Str
 			is_zero : F64 -> Bool
 			is_negative : F64 -> Bool

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -11146,6 +11146,37 @@ pub const Interpreter = struct {
                         },
                         else => null,
                     },
+                    .flex => |flex| blk: {
+                        // Check if this flex var has a from_numeral constraint,
+                        // indicating it's an unresolved numeric type that should default to Dec.
+                        if (!flex.constraints.isEmpty()) {
+                            for (self.runtime_types.sliceStaticDispatchConstraints(flex.constraints)) |constraint| {
+                                if (constraint.origin == .from_numeral) {
+                                    // Default to Dec
+                                    break :blk .{
+                                        .origin = self.root_env.idents.builtin_module,
+                                        .ident = self.root_env.idents.dec_type,
+                                    };
+                                }
+                            }
+                        }
+                        break :blk null;
+                    },
+                    .rigid => |rigid| blk: {
+                        // Same handling for rigid vars
+                        if (!rigid.constraints.isEmpty()) {
+                            for (self.runtime_types.sliceStaticDispatchConstraints(rigid.constraints)) |constraint| {
+                                if (constraint.origin == .from_numeral) {
+                                    // Default to Dec
+                                    break :blk .{
+                                        .origin = self.root_env.idents.builtin_module,
+                                        .ident = self.root_env.idents.dec_type,
+                                    };
+                                }
+                            }
+                        }
+                        break :blk null;
+                    },
                     else => null,
                 };
 

--- a/src/eval/test/eval_test.zig
+++ b/src/eval/test/eval_test.zig
@@ -24,6 +24,7 @@ const testing = std.testing;
 const test_allocator = testing.allocator;
 
 const runExpectI64 = helpers.runExpectI64;
+const runExpectIntDec = helpers.runExpectIntDec;
 const runExpectBool = helpers.runExpectBool;
 const runExpectError = helpers.runExpectError;
 const runExpectStr = helpers.runExpectStr;
@@ -1382,6 +1383,25 @@ test "List.with_capacity - append case" {
         &[_]i64{10},
         .trace,
     );
+}
+
+// Tests for List.sum
+
+test "List.sum - basic case" {
+    // Sum of a list of integers (untyped literals default to Dec)
+    try runExpectIntDec("List.sum([1, 2, 3, 4])", 10, .no_trace);
+}
+
+test "List.sum - single element" {
+    try runExpectIntDec("List.sum([42])", 42, .no_trace);
+}
+
+test "List.sum - negative numbers" {
+    try runExpectIntDec("List.sum([-1, -2, 3, 4])", 4, .no_trace);
+}
+
+test "List.sum - larger list" {
+    try runExpectIntDec("List.sum([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])", 55, .no_trace);
 }
 
 // Bug regression tests - interpreter crash issues

--- a/src/eval/test/helpers.zig
+++ b/src/eval/test/helpers.zig
@@ -218,6 +218,43 @@ pub fn runExpectF64(src: []const u8, expected_f64: f64, should_trace: enum { tra
     }
 }
 
+/// Dec scale factor: 10^18 (18 decimal places)
+const dec_scale: i128 = 1_000_000_000_000_000_000;
+
+/// Helper function to run an expression and expect a Dec result from an integer.
+/// Automatically scales the expected value by 10^18 for Dec's fixed-point representation.
+pub fn runExpectIntDec(src: []const u8, expected_int: i128, should_trace: enum { trace, no_trace }) !void {
+    const resources = try parseAndCanonicalizeExpr(test_allocator, src);
+    defer cleanupParseAndCanonical(test_allocator, resources);
+
+    var test_env_instance = TestEnv.init(test_allocator);
+    defer test_env_instance.deinit();
+
+    const builtin_types = BuiltinTypes.init(resources.builtin_indices, resources.builtin_module.env, resources.builtin_module.env, resources.builtin_module.env);
+    const imported_envs = [_]*const can.ModuleEnv{resources.builtin_module.env};
+    var interpreter = try Interpreter.init(test_allocator, resources.module_env, builtin_types, resources.builtin_module.env, &imported_envs, &resources.checker.import_mapping, null);
+    defer interpreter.deinit();
+
+    const enable_trace = should_trace == .trace;
+    if (enable_trace) {
+        interpreter.startTrace();
+    }
+    defer if (enable_trace) interpreter.endTrace();
+
+    const ops = test_env_instance.get_ops();
+    const result = try interpreter.eval(resources.expr_idx, ops);
+    const layout_cache = &interpreter.runtime_layout_store;
+    defer result.decref(layout_cache, ops);
+    defer interpreter.cleanupBindings(ops);
+
+    const actual_dec = result.asDec(ops);
+    const expected_dec = expected_int * dec_scale;
+    if (actual_dec.num != expected_dec) {
+        std.debug.print("Expected Dec({d}), got Dec({d})\n", .{ expected_dec, actual_dec.num });
+        return error.TestExpectedEqual;
+    }
+}
+
 /// Helper function to run an expression and expect a Dec result.
 /// Dec is a fixed-point decimal type stored as i128 with 18 decimal places.
 /// For testing, we compare the raw i128 values directly.


### PR DESCRIPTION
## Summary

- Adds `List.sum : List(item) -> item where [item.plus : item, item -> item, item.default : () -> item]` that sums all elements using fold with `default()` as the initial value
- Adds `default : () -> T` methods to all numeric types (U8, I8, U16, I16, U32, I32, U64, I64, U128, I128, Dec, F32, F64) returning 0
- Adds eval tests for List.sum

## Known issue

There's a type inference bug where `List.sum([1, 2, 3])` crashes with "type variable dispatch requires a nominal type" when list elements don't have explicit type annotations. `List.sum([1i64, 2i64, 3i64])` works fine.

Root cause: at `interpreter.zig:11141-11154`, the type variable for `item` hasn't been resolved to a nominal type (like I64) before ability dispatch runs. The `resolved.desc.content` is not a `structure.nominal_type`, so `nominal_info` is null.

## Test plan

- [x] `zig build minici` passes
- [x] `zig build test-eval -- --test-filter "List.sum"` passes (with explicit type annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)