### PR TITLE
Fix segfault with recursive nominal types containing nested Box

### DIFF
--- a/test/snapshots/nominal/nominal_recursive_box_depth2.md
+++ b/test/snapshots/nominal/nominal_recursive_box_depth2.md
@@ -1,0 +1,164 @@
+# META
+~~~ini
+description=Recursive nominal with nested Box at depth 2+ (regression test for layout cache by nominal identity)
+type=snippet
+~~~
+# SOURCE
+~~~roc
+RichDoc := [PlainText(Str), Wrapped(Box(RichDoc))]
+
+depth0 : RichDoc
+depth0 = RichDoc.PlainText("hello")
+
+depth1 : RichDoc
+depth1 = RichDoc.Wrapped(Box.box(RichDoc.PlainText("one")))
+
+depth2 : RichDoc
+depth2 = RichDoc.Wrapped(Box.box(RichDoc.Wrapped(Box.box(RichDoc.PlainText("two")))))
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+UpperIdent,OpColonEqual,OpenSquare,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,Comma,UpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,CloseRound,CloseSquare,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,CloseRound,CloseRound,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,CloseRound,CloseRound,CloseRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "RichDoc")
+				(args))
+			(ty-tag-union
+				(tags
+					(ty-apply
+						(ty (name "PlainText"))
+						(ty (name "Str")))
+					(ty-apply
+						(ty (name "Wrapped"))
+						(ty-apply
+							(ty (name "Box"))
+							(ty (name "RichDoc")))))))
+		(s-type-anno (name "depth0")
+			(ty (name "RichDoc")))
+		(s-decl
+			(p-ident (raw "depth0"))
+			(e-apply
+				(e-tag (raw "RichDoc.PlainText"))
+				(e-string
+					(e-string-part (raw "hello")))))
+		(s-type-anno (name "depth1")
+			(ty (name "RichDoc")))
+		(s-decl
+			(p-ident (raw "depth1"))
+			(e-apply
+				(e-tag (raw "RichDoc.Wrapped"))
+				(e-apply
+					(e-ident (raw "Box.box"))
+					(e-apply
+						(e-tag (raw "RichDoc.PlainText"))
+						(e-string
+							(e-string-part (raw "one")))))))
+		(s-type-anno (name "depth2")
+			(ty (name "RichDoc")))
+		(s-decl
+			(p-ident (raw "depth2"))
+			(e-apply
+				(e-tag (raw "RichDoc.Wrapped"))
+				(e-apply
+					(e-ident (raw "Box.box"))
+					(e-apply
+						(e-tag (raw "RichDoc.Wrapped"))
+						(e-apply
+							(e-ident (raw "Box.box"))
+							(e-apply
+								(e-tag (raw "RichDoc.PlainText"))
+								(e-string
+									(e-string-part (raw "two")))))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "depth0"))
+		(e-nominal (nominal "RichDoc")
+			(e-tag (name "PlainText")
+				(args
+					(e-string
+						(e-literal (string "hello"))))))
+		(annotation
+			(ty-lookup (name "RichDoc") (local))))
+	(d-let
+		(p-assign (ident "depth1"))
+		(e-nominal (nominal "RichDoc")
+			(e-tag (name "Wrapped")
+				(args
+					(e-call
+						(e-lookup-external
+							(builtin))
+						(e-nominal (nominal "RichDoc")
+							(e-tag (name "PlainText")
+								(args
+									(e-string
+										(e-literal (string "one"))))))))))
+		(annotation
+			(ty-lookup (name "RichDoc") (local))))
+	(d-let
+		(p-assign (ident "depth2"))
+		(e-nominal (nominal "RichDoc")
+			(e-tag (name "Wrapped")
+				(args
+					(e-call
+						(e-lookup-external
+							(builtin))
+						(e-nominal (nominal "RichDoc")
+							(e-tag (name "Wrapped")
+								(args
+									(e-call
+										(e-lookup-external
+											(builtin))
+										(e-nominal (nominal "RichDoc")
+											(e-tag (name "PlainText")
+												(args
+													(e-string
+														(e-literal (string "two"))))))))))))))
+		(annotation
+			(ty-lookup (name "RichDoc") (local))))
+	(s-nominal-decl
+		(ty-header (name "RichDoc"))
+		(ty-tag-union
+			(ty-tag-name (name "PlainText")
+				(ty-lookup (name "Str") (builtin)))
+			(ty-tag-name (name "Wrapped")
+				(ty-apply (name "Box") (builtin)
+					(ty-lookup (name "RichDoc") (local)))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "RichDoc"))
+		(patt (type "RichDoc"))
+		(patt (type "RichDoc")))
+	(type_decls
+		(nominal (type "RichDoc")
+			(ty-header (name "RichDoc"))))
+	(expressions
+		(expr (type "RichDoc"))
+		(expr (type "RichDoc"))
+		(expr (type "RichDoc"))))
+~~~

--- a/test/snapshots/nominal/nominal_recursive_box_depth2_repl.md
+++ b/test/snapshots/nominal/nominal_recursive_box_depth2_repl.md
@@ -1,0 +1,20 @@
+# META
+~~~ini
+description=REPL test for recursive nominal with nested Box at depth 2+ (runtime execution test)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» RichDoc := [PlainText(Str), Wrapped(Box(RichDoc))]
+» depth0 = RichDoc.PlainText("hello")
+» depth1 = RichDoc.Wrapped(Box.box(depth0))
+» depth2 = RichDoc.Wrapped(Box.box(depth1))
+~~~
+# OUTPUT
+assigned `depth0`
+---
+assigned `depth1`
+---
+assigned `depth2`
+# PROBLEMS
+NIL


### PR DESCRIPTION
The layout cache (layouts_by_var) was keyed by type variable, not by nominal identity. When the same nominal type (e.g., RichDoc) was encountered through different type variables at runtime, the cache missed and layout computation started over. But by then, the temporary cycle-detection state (in_progress_nominals) had been cleared, so recursive references ended up with unresolved opaque_ptr placeholders instead of proper layouts, causing a segfault during refcount cleanup.

The fix adds a persistent cache (layouts_by_nominal) keyed by nominal identity (ident_idx + origin_module). This ensures that regardless of which type variable we encounter a nominal type through, we return the same layout index.

Parameterized builtin types (Box, List) are excluded from this cache since they need different layouts for different type arguments.

Fixes the crash in: RichDoc := [PlainText(Str), Wrapped(Box(RichDoc))] when creating values at depth 2+.