### PR TITLE
Add to and until methods to all integer types

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -463,6 +463,12 @@ Builtin :: [].{
 			from_numeral : Numeral -> Try(I8, [InvalidNumeral(Str), ..others])
 			from_str : Str -> Try(I8, [BadNumStr, ..others])
 
+			to : I8, I8 -> List(I8)
+			to = |start, end| range_to(start, end)
+
+			until : I8, I8 -> List(I8)
+			until = |start, end| range_until(start, end)
+
 			# Conversions to signed integers (all safe widening)
 			to_i16 : I8 -> I16
 			to_i32 : I8 -> I32
@@ -515,6 +521,12 @@ Builtin :: [].{
 			from_int_digits : List(U8) -> Try(U16, [OutOfRange, ..others])
 			from_numeral : Numeral -> Try(U16, [InvalidNumeral(Str), ..others])
 			from_str : Str -> Try(U16, [BadNumStr, ..others])
+
+			to : U16, U16 -> List(U16)
+			to = |start, end| range_to(start, end)
+
+			until : U16, U16 -> List(U16)
+			until = |start, end| range_until(start, end)
 
 			# Conversions to signed integers
 			to_i8_wrap : U16 -> I8
@@ -571,6 +583,12 @@ Builtin :: [].{
 			from_numeral : Numeral -> Try(I16, [InvalidNumeral(Str), ..others])
 			from_str : Str -> Try(I16, [BadNumStr, ..others])
 
+			to : I16, I16 -> List(I16)
+			to = |start, end| range_to(start, end)
+
+			until : I16, I16 -> List(I16)
+			until = |start, end| range_until(start, end)
+
 			# Conversions to signed integers
 			to_i8_wrap : I16 -> I8
 			to_i8_try : I16 -> Try(I8, [OutOfRange, ..others])
@@ -624,6 +642,12 @@ Builtin :: [].{
 			from_int_digits : List(U8) -> Try(U32, [OutOfRange, ..others])
 			from_numeral : Numeral -> Try(U32, [InvalidNumeral(Str), ..others])
 			from_str : Str -> Try(U32, [BadNumStr, ..others])
+
+			to : U32, U32 -> List(U32)
+			to = |start, end| range_to(start, end)
+
+			until : U32, U32 -> List(U32)
+			until = |start, end| range_until(start, end)
 
 			# Conversions to signed integers
 			to_i8_wrap : U32 -> I8
@@ -682,6 +706,12 @@ Builtin :: [].{
 			from_numeral : Numeral -> Try(I32, [InvalidNumeral(Str), ..others])
 			from_str : Str -> Try(I32, [BadNumStr, ..others])
 
+			to : I32, I32 -> List(I32)
+			to = |start, end| range_to(start, end)
+
+			until : I32, I32 -> List(I32)
+			until = |start, end| range_until(start, end)
+
 			# Conversions to signed integers
 			to_i8_wrap : I32 -> I8
 			to_i8_try : I32 -> Try(I8, [OutOfRange, ..others])
@@ -736,6 +766,12 @@ Builtin :: [].{
 			from_int_digits : List(U8) -> Try(U64, [OutOfRange, ..others])
 			from_numeral : Numeral -> Try(U64, [InvalidNumeral(Str), ..others])
 			from_str : Str -> Try(U64, [BadNumStr, ..others])
+
+			to : U64, U64 -> List(U64)
+			to = |start, end| range_to(start, end)
+
+			until : U64, U64 -> List(U64)
+			until = |start, end| range_until(start, end)
 
 			# Conversions to signed integers
 			to_i8_wrap : U64 -> I8
@@ -796,6 +832,12 @@ Builtin :: [].{
 			from_numeral : Numeral -> Try(I64, [InvalidNumeral(Str), ..others])
 			from_str : Str -> Try(I64, [BadNumStr, ..others])
 
+			to : I64, I64 -> List(I64)
+			to = |start, end| range_to(start, end)
+
+			until : I64, I64 -> List(I64)
+			until = |start, end| range_until(start, end)
+
 			# Conversions to signed integers
 			to_i8_wrap : I64 -> I8
 			to_i8_try : I64 -> Try(I8, [OutOfRange, ..others])
@@ -851,6 +893,12 @@ Builtin :: [].{
 			from_int_digits : List(U8) -> Try(U128, [OutOfRange, ..others])
 			from_numeral : Numeral -> Try(U128, [InvalidNumeral(Str), ..others])
 			from_str : Str -> Try(U128, [BadNumStr, ..others])
+
+			to : U128, U128 -> List(U128)
+			to = |start, end| range_to(start, end)
+
+			until : U128, U128 -> List(U128)
+			until = |start, end| range_until(start, end)
 
 			# Conversions to signed integers
 			to_i8_wrap : U128 -> I8
@@ -914,6 +962,12 @@ Builtin :: [].{
 			from_int_digits : List(U8) -> Try(I128, [OutOfRange, ..others])
 			from_numeral : Numeral -> Try(I128, [InvalidNumeral(Str), ..others])
 			from_str : Str -> Try(I128, [BadNumStr, ..others])
+
+			to : I128, I128 -> List(I128)
+			to = |start, end| range_to(start, end)
+
+			until : I128, I128 -> List(I128)
+			until = |start, end| range_until(start, end)
 
 			# Conversions to signed integers
 			to_i8_wrap : I128 -> I8

--- a/test/snapshots/repl/i128_range_to.md
+++ b/test/snapshots/repl/i128_range_to.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=I128.to - creates a list of integers from start to end (inclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 1i128.to(5i128)
+» 0i128.to(0i128)
+» 5i128.to(3i128)
+» -3i128.to(2i128)
+~~~
+# OUTPUT
+[1, 2, 3, 4, 5]
+---
+[0]
+---
+[]
+---
+[-3, -2, -1, 0, 1, 2]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/i128_range_until.md
+++ b/test/snapshots/repl/i128_range_until.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=I128.until - creates a list of integers from start to end (exclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 0i128.until(3i128)
+» 1i128.until(1i128)
+» 5i128.until(3i128)
+» -2i128.until(2i128)
+~~~
+# OUTPUT
+[0, 1, 2]
+---
+[]
+---
+[]
+---
+[-2, -1, 0, 1]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/i16_range_to.md
+++ b/test/snapshots/repl/i16_range_to.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=I16.to - creates a list of integers from start to end (inclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 1i16.to(5i16)
+» 0i16.to(0i16)
+» 5i16.to(3i16)
+» -3i16.to(2i16)
+~~~
+# OUTPUT
+[1, 2, 3, 4, 5]
+---
+[0]
+---
+[]
+---
+[-3, -2, -1, 0, 1, 2]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/i16_range_until.md
+++ b/test/snapshots/repl/i16_range_until.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=I16.until - creates a list of integers from start to end (exclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 0i16.until(3i16)
+» 1i16.until(1i16)
+» 5i16.until(3i16)
+» -2i16.until(2i16)
+~~~
+# OUTPUT
+[0, 1, 2]
+---
+[]
+---
+[]
+---
+[-2, -1, 0, 1]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/i32_range_to.md
+++ b/test/snapshots/repl/i32_range_to.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=I32.to - creates a list of integers from start to end (inclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 1i32.to(5i32)
+» 0i32.to(0i32)
+» 5i32.to(3i32)
+» -3i32.to(2i32)
+~~~
+# OUTPUT
+[1, 2, 3, 4, 5]
+---
+[0]
+---
+[]
+---
+[-3, -2, -1, 0, 1, 2]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/i32_range_until.md
+++ b/test/snapshots/repl/i32_range_until.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=I32.until - creates a list of integers from start to end (exclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 0i32.until(3i32)
+» 1i32.until(1i32)
+» 5i32.until(3i32)
+» -2i32.until(2i32)
+~~~
+# OUTPUT
+[0, 1, 2]
+---
+[]
+---
+[]
+---
+[-2, -1, 0, 1]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/i64_range_to.md
+++ b/test/snapshots/repl/i64_range_to.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=I64.to - creates a list of integers from start to end (inclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 1i64.to(5i64)
+» 0i64.to(0i64)
+» 5i64.to(3i64)
+» -3i64.to(2i64)
+~~~
+# OUTPUT
+[1, 2, 3, 4, 5]
+---
+[0]
+---
+[]
+---
+[-3, -2, -1, 0, 1, 2]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/i64_range_until.md
+++ b/test/snapshots/repl/i64_range_until.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=I64.until - creates a list of integers from start to end (exclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 0i64.until(3i64)
+» 1i64.until(1i64)
+» 5i64.until(3i64)
+» -2i64.until(2i64)
+~~~
+# OUTPUT
+[0, 1, 2]
+---
+[]
+---
+[]
+---
+[-2, -1, 0, 1]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/i8_range_to.md
+++ b/test/snapshots/repl/i8_range_to.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=I8.to - creates a list of integers from start to end (inclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 1i8.to(5i8)
+» 0i8.to(0i8)
+» 5i8.to(3i8)
+» -3i8.to(2i8)
+~~~
+# OUTPUT
+[1, 2, 3, 4, 5]
+---
+[0]
+---
+[]
+---
+[-3, -2, -1, 0, 1, 2]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/i8_range_until.md
+++ b/test/snapshots/repl/i8_range_until.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=I8.until - creates a list of integers from start to end (exclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 0i8.until(3i8)
+» 1i8.until(1i8)
+» 5i8.until(3i8)
+» -2i8.until(2i8)
+~~~
+# OUTPUT
+[0, 1, 2]
+---
+[]
+---
+[]
+---
+[-2, -1, 0, 1]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/u128_range_to.md
+++ b/test/snapshots/repl/u128_range_to.md
@@ -1,0 +1,19 @@
+# META
+~~~ini
+description=U128.to - creates a list of integers from start to end (inclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 1u128.to(5u128)
+» 0u128.to(0u128)
+» 5u128.to(3u128)
+~~~
+# OUTPUT
+[1, 2, 3, 4, 5]
+---
+[0]
+---
+[]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/u128_range_until.md
+++ b/test/snapshots/repl/u128_range_until.md
@@ -1,0 +1,19 @@
+# META
+~~~ini
+description=U128.until - creates a list of integers from start to end (exclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 0u128.until(3u128)
+» 1u128.until(1u128)
+» 5u128.until(3u128)
+~~~
+# OUTPUT
+[0, 1, 2]
+---
+[]
+---
+[]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/u16_range_to.md
+++ b/test/snapshots/repl/u16_range_to.md
@@ -1,0 +1,19 @@
+# META
+~~~ini
+description=U16.to - creates a list of integers from start to end (inclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 1u16.to(5u16)
+» 0u16.to(0u16)
+» 5u16.to(3u16)
+~~~
+# OUTPUT
+[1, 2, 3, 4, 5]
+---
+[0]
+---
+[]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/u16_range_until.md
+++ b/test/snapshots/repl/u16_range_until.md
@@ -1,0 +1,19 @@
+# META
+~~~ini
+description=U16.until - creates a list of integers from start to end (exclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 0u16.until(3u16)
+» 1u16.until(1u16)
+» 5u16.until(3u16)
+~~~
+# OUTPUT
+[0, 1, 2]
+---
+[]
+---
+[]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/u32_range_to.md
+++ b/test/snapshots/repl/u32_range_to.md
@@ -1,0 +1,19 @@
+# META
+~~~ini
+description=U32.to - creates a list of integers from start to end (inclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 1u32.to(5u32)
+» 0u32.to(0u32)
+» 5u32.to(3u32)
+~~~
+# OUTPUT
+[1, 2, 3, 4, 5]
+---
+[0]
+---
+[]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/u32_range_until.md
+++ b/test/snapshots/repl/u32_range_until.md
@@ -1,0 +1,19 @@
+# META
+~~~ini
+description=U32.until - creates a list of integers from start to end (exclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 0u32.until(3u32)
+» 1u32.until(1u32)
+» 5u32.until(3u32)
+~~~
+# OUTPUT
+[0, 1, 2]
+---
+[]
+---
+[]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/u64_range_to.md
+++ b/test/snapshots/repl/u64_range_to.md
@@ -1,0 +1,19 @@
+# META
+~~~ini
+description=U64.to - creates a list of integers from start to end (inclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 1u64.to(5u64)
+» 0u64.to(0u64)
+» 5u64.to(3u64)
+~~~
+# OUTPUT
+[1, 2, 3, 4, 5]
+---
+[0]
+---
+[]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/u64_range_until.md
+++ b/test/snapshots/repl/u64_range_until.md
@@ -1,0 +1,19 @@
+# META
+~~~ini
+description=U64.until - creates a list of integers from start to end (exclusive)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» 0u64.until(3u64)
+» 1u64.until(1u64)
+» 5u64.until(3u64)
+~~~
+# OUTPUT
+[0, 1, 2]
+---
+[]
+---
+[]
+# PROBLEMS
+NIL


### PR DESCRIPTION
## Summary
- Adds `to` and `until` range methods to all integer types (previously only U8 had them)
- Adds REPL snapshot tests for all the new methods
- Signed integer tests include negative number edge cases

## Test plan
- [x] `zig build test-repl` passes
- [x] `zig build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)