### PR TITLE
Fix opaque type pattern matching in same module

### DIFF
--- a/src/compile/compile_package.zig
+++ b/src/compile/compile_package.zig
@@ -885,7 +885,7 @@ pub const PackageEnv = struct {
 
         // Type check using the SAME module_envs_map
         const module_builtin_ctx: Check.BuiltinContext = .{
-            .module_name = try env.insertIdent(base.Ident.for_text("test")),
+            .module_name = env.module_name_idx,
             .bool_stmt = builtin_indices.bool_type,
             .try_stmt = builtin_indices.try_type,
             .str_stmt = builtin_indices.str_type,
@@ -1034,7 +1034,7 @@ pub const PackageEnv = struct {
         const builtin_indices = try builtin_loading.deserializeBuiltinIndices(gpa, compiled_builtins.builtin_indices_bin);
 
         const module_builtin_ctx: Check.BuiltinContext = .{
-            .module_name = try env.insertIdent(base.Ident.for_text("test")),
+            .module_name = env.module_name_idx,
             .bool_stmt = builtin_indices.bool_type,
             .try_stmt = builtin_indices.try_type,
             .str_stmt = builtin_indices.str_type,


### PR DESCRIPTION
- Fixed `canLiftInner` check failing for opaque types because `module_builtin_ctx.module_name` was hardcoded to `"test"` instead of using the actual module name
- This caused INCOMPATIBLE MATCH PATTERNS errors when pattern matching opaque types (like `Numeral`) within their defining module
- Also adds unit tests for opaque type unification with tag unions
