### PR TITLE
Add sibling module discovery for local imports and roc build

### DIFF
--- a/test/fx/sibling_modules/Helper.roc
+++ b/test/fx/sibling_modules/Helper.roc
@@ -1,0 +1,4 @@
+module [greet]
+
+greet : Str -> Str
+greet = |name| "Hello, ${name}!"

--- a/test/fx/sibling_modules/app.roc
+++ b/test/fx/sibling_modules/app.roc
@@ -1,0 +1,8 @@
+app [main!] { pf: platform "../platform/main.roc" }
+
+import pf.Stdout
+import Helper
+
+main! = || {
+    Stdout.line!(Helper.greet("World"))
+}


### PR DESCRIPTION
## Summary
Enables importing sibling `.roc` modules in the same directory without explicit path configuration.

## Changes
- Discover sibling `.roc` files in same directory for local module imports
- Extend `roc build` command to support sibling module discovery
- Only considers files starting with uppercase letter (Roc module naming convention)

## Testing
- Added test files `test/fx/sibling_modules/` with `Helper.roc` and `app.roc`