### PR TITLE
Fix recursive nominal types with nested Box

### DIFF
--- a/src/layout/store.zig
+++ b/src/layout/store.zig
@@ -66,6 +66,11 @@ pub const Store = struct {
     // Cache to avoid duplicate work
     layouts_by_var: collections.ArrayListMap(Var, Idx),
 
+    // Persistent cache for nominal types by identity (ident + origin_module).
+    // This is needed because the same nominal type may be encountered through
+    // different type variables, and we need to return the same layout index.
+    layouts_by_nominal: std.AutoArrayHashMap(work.NominalKey, Idx),
+
     // Reusable work stack for addTypeVar (so it can be stack-safe instead of recursing)
     work: work.Work,
 
@@ -179,6 +184,7 @@ pub const Store = struct {
             .tag_union_variants = try TagUnionVariant.SafeMultiList.initCapacity(env.gpa, 64),
             .tag_union_data = try collections.SafeList(TagUnionData).initCapacity(env.gpa, 64),
             .layouts_by_var = layouts_by_var,
+            .layouts_by_nominal = std.AutoArrayHashMap(work.NominalKey, Idx).init(env.gpa),
             .work = try Work.initCapacity(env.gpa, 32),
             .builtin_str_ident = builtin_str_ident,
             .builtin_str_plain_ident = env.idents.str,
@@ -210,6 +216,7 @@ pub const Store = struct {
         self.tag_union_variants.deinit(self.env.gpa);
         self.tag_union_data.deinit(self.env.gpa);
         self.layouts_by_var.deinit(self.env.gpa);
+        self.layouts_by_nominal.deinit();
         self.work.deinit(self.env.gpa);
     }
 
@@ -1124,6 +1131,11 @@ pub const Store = struct {
         // recursively (e.g., when processing tag union variant payloads), and nested
         // calls must not destroy the work state from outer calls.
 
+        // Track the initial container depth so we only process containers pushed by THIS call.
+        // This prevents nested calls (e.g., for tag union variant payloads) from accidentally
+        // finalizing containers that belong to outer calls.
+        const initial_container_depth = self.work.pending_containers.len;
+
         var layout_idx: Idx = undefined;
 
         // Debug-only: track vars visited via TypeScope lookup to detect cycles.
@@ -1160,16 +1172,37 @@ pub const Store = struct {
                     return LayoutError.TypeContainedMismatch;
                 }
             } else if (current.desc.content == .structure) blk: {
-                // Early cycle detection for nominal types from other modules.
-                // These have different vars but same identity (ident + origin_module).
+                // Check persistent nominal cache first - this handles the case where
+                // the same nominal type is encountered through different type variables.
                 const flat_type = current.desc.content.structure;
                 if (flat_type != .nominal_type) break :blk;
                 const nominal_type = flat_type.nominal_type;
+
+                // Skip cache for parameterized builtin types (Box, List) - they need
+                // different layouts for different type arguments (e.g., Box(Str) vs Box(I64)).
+                // These are handled specially below with their type arguments.
+                const is_parameterized_builtin = nominal_type.origin_module == self.env.idents.builtin_module and
+                    ((self.box_ident != null and nominal_type.ident.ident_idx == self.box_ident.?) or
+                        (self.list_ident != null and nominal_type.ident.ident_idx == self.list_ident.?));
+
+                if (is_parameterized_builtin) break :blk;
+
                 const nominal_key = work.NominalKey{
                     .ident_idx = nominal_type.ident.ident_idx,
                     .origin_module = nominal_type.origin_module,
                 };
 
+                // Check persistent cache - if we've already computed a layout for this
+                // nominal type, reuse it regardless of which type variable we're coming from.
+                if (self.layouts_by_nominal.get(nominal_key)) |cached_idx| {
+                    layout_idx = cached_idx;
+                    // Also cache by this var for faster future lookups
+                    try self.layouts_by_var.put(self.env.gpa, current.var_, cached_idx);
+                    skip_layout_computation = true;
+                    break :blk;
+                }
+
+                // Cycle detection for in-progress nominals (within the same addTypeVar call tree)
                 if (self.work.in_progress_nominals.get(nominal_key)) |progress| {
                     // This nominal type is already being processed - we have a cycle.
                     // Use the cached placeholder index for the nominal.
@@ -1369,6 +1402,8 @@ pub const Store = struct {
                             // 3. It can be updated with updateLayout() once the real layout is known
                             const reserved_idx = try self.insertLayout(Layout.box(.opaque_ptr));
                             try self.layouts_by_var.put(self.env.gpa, current.var_, reserved_idx);
+                            // Also cache by nominal key so other vars for the same nominal find it
+                            try self.layouts_by_nominal.put(nominal_key, reserved_idx);
 
                             // Mark this nominal type as in-progress.
                             // Store both the nominal var (for cache lookup) and backing var (to know when to update).
@@ -1762,7 +1797,8 @@ pub const Store = struct {
             } // end if (!skip_layout_computation)
 
             // If this was part of a pending container that we're working on, update that container.
-            while (self.work.pending_containers.len > 0) {
+            // Only process containers pushed by THIS call (not containers from outer recursive calls).
+            while (self.work.pending_containers.len > initial_container_depth) {
                 // Get a pointer to the last pending container, so we can mutate it in-place.
                 switch (self.work.pending_containers.slice().items(.container)[self.work.pending_containers.len - 1]) {
                     .box => {
@@ -1921,10 +1957,9 @@ pub const Store = struct {
                 }
             }
 
-            // Since there are no pending containers remaining, there shouldn't be any pending record or tuple fields either.
-            std.debug.assert(self.work.pending_record_fields.len == 0);
-            std.debug.assert(self.work.pending_tuple_fields.len == 0);
-            std.debug.assert(self.work.pending_tag_union_variants.len == 0);
+            // Since there are no pending containers remaining FOR THIS CALL, we're done.
+            // Note: There may still be pending containers from outer calls, which is fine.
+            std.debug.assert(self.work.pending_containers.len == initial_container_depth);
 
             // No more pending containers; we're done!
             // Note: Work fields (in_progress_vars, in_progress_nominals, etc.) are not cleared

--- a/test/snapshots/nominal/nominal_recursive_box_depth2.md
+++ b/test/snapshots/nominal/nominal_recursive_box_depth2.md
@@ -1,0 +1,164 @@
+# META
+~~~ini
+description=Recursive nominal with nested Box at depth 2+ (regression test for layout cache by nominal identity)
+type=snippet
+~~~
+# SOURCE
+~~~roc
+RichDoc := [PlainText(Str), Wrapped(Box(RichDoc))]
+
+depth0 : RichDoc
+depth0 = RichDoc.PlainText("hello")
+
+depth1 : RichDoc
+depth1 = RichDoc.Wrapped(Box.box(RichDoc.PlainText("one")))
+
+depth2 : RichDoc
+depth2 = RichDoc.Wrapped(Box.box(RichDoc.Wrapped(Box.box(RichDoc.PlainText("two")))))
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+UpperIdent,OpColonEqual,OpenSquare,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,Comma,UpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,CloseRound,CloseSquare,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,CloseRound,CloseRound,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,CloseRound,CloseRound,CloseRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "RichDoc")
+				(args))
+			(ty-tag-union
+				(tags
+					(ty-apply
+						(ty (name "PlainText"))
+						(ty (name "Str")))
+					(ty-apply
+						(ty (name "Wrapped"))
+						(ty-apply
+							(ty (name "Box"))
+							(ty (name "RichDoc")))))))
+		(s-type-anno (name "depth0")
+			(ty (name "RichDoc")))
+		(s-decl
+			(p-ident (raw "depth0"))
+			(e-apply
+				(e-tag (raw "RichDoc.PlainText"))
+				(e-string
+					(e-string-part (raw "hello")))))
+		(s-type-anno (name "depth1")
+			(ty (name "RichDoc")))
+		(s-decl
+			(p-ident (raw "depth1"))
+			(e-apply
+				(e-tag (raw "RichDoc.Wrapped"))
+				(e-apply
+					(e-ident (raw "Box.box"))
+					(e-apply
+						(e-tag (raw "RichDoc.PlainText"))
+						(e-string
+							(e-string-part (raw "one")))))))
+		(s-type-anno (name "depth2")
+			(ty (name "RichDoc")))
+		(s-decl
+			(p-ident (raw "depth2"))
+			(e-apply
+				(e-tag (raw "RichDoc.Wrapped"))
+				(e-apply
+					(e-ident (raw "Box.box"))
+					(e-apply
+						(e-tag (raw "RichDoc.Wrapped"))
+						(e-apply
+							(e-ident (raw "Box.box"))
+							(e-apply
+								(e-tag (raw "RichDoc.PlainText"))
+								(e-string
+									(e-string-part (raw "two")))))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "depth0"))
+		(e-nominal (nominal "RichDoc")
+			(e-tag (name "PlainText")
+				(args
+					(e-string
+						(e-literal (string "hello"))))))
+		(annotation
+			(ty-lookup (name "RichDoc") (local))))
+	(d-let
+		(p-assign (ident "depth1"))
+		(e-nominal (nominal "RichDoc")
+			(e-tag (name "Wrapped")
+				(args
+					(e-call
+						(e-lookup-external
+							(builtin))
+						(e-nominal (nominal "RichDoc")
+							(e-tag (name "PlainText")
+								(args
+									(e-string
+										(e-literal (string "one"))))))))))
+		(annotation
+			(ty-lookup (name "RichDoc") (local))))
+	(d-let
+		(p-assign (ident "depth2"))
+		(e-nominal (nominal "RichDoc")
+			(e-tag (name "Wrapped")
+				(args
+					(e-call
+						(e-lookup-external
+							(builtin))
+						(e-nominal (nominal "RichDoc")
+							(e-tag (name "Wrapped")
+								(args
+									(e-call
+										(e-lookup-external
+											(builtin))
+										(e-nominal (nominal "RichDoc")
+											(e-tag (name "PlainText")
+												(args
+													(e-string
+														(e-literal (string "two"))))))))))))))
+		(annotation
+			(ty-lookup (name "RichDoc") (local))))
+	(s-nominal-decl
+		(ty-header (name "RichDoc"))
+		(ty-tag-union
+			(ty-tag-name (name "PlainText")
+				(ty-lookup (name "Str") (builtin)))
+			(ty-tag-name (name "Wrapped")
+				(ty-apply (name "Box") (builtin)
+					(ty-lookup (name "RichDoc") (local)))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "RichDoc"))
+		(patt (type "RichDoc"))
+		(patt (type "RichDoc")))
+	(type_decls
+		(nominal (type "RichDoc")
+			(ty-header (name "RichDoc"))))
+	(expressions
+		(expr (type "RichDoc"))
+		(expr (type "RichDoc"))
+		(expr (type "RichDoc"))))
+~~~

--- a/test/snapshots/nominal/nominal_recursive_box_depth2_repl.md
+++ b/test/snapshots/nominal/nominal_recursive_box_depth2_repl.md
@@ -1,0 +1,20 @@
+# META
+~~~ini
+description=REPL test for recursive nominal with nested Box at depth 2+ (runtime execution test)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» RichDoc := [PlainText(Str), Wrapped(Box(RichDoc))]
+» depth0 = RichDoc.PlainText("hello")
+» depth1 = RichDoc.Wrapped(Box.box(depth0))
+» depth2 = RichDoc.Wrapped(Box.box(depth1))
+~~~
+# OUTPUT
+assigned `depth0`
+---
+assigned `depth1`
+---
+assigned `depth2`
+# PROBLEMS
+NIL


### PR DESCRIPTION
## Summary
Fixes segfaults with recursive nominal types by improving layout caching.

## Changes
- Add persistent `layouts_by_nominal` cache to handle the same nominal type encountered through different type variables
- Fix container depth tracking for nested recursive calls in layout computation
- Skip cache for parameterized builtin types (Box, List) that need different layouts for different type arguments

## Note
The cross-platform serialization fix was removed as upstream PR #8784 removed the RecursionInfo code entirely.

## Testing
- Added snapshot tests:
  - `test/snapshots/nominal/nominal_recursive_box_depth2.md`
  - `test/snapshots/nominal/nominal_recursive_box_depth2_repl.md`