### PR TITLE
add dbg output explanation

### DIFF
--- a/src/eval/test/low_level_interp_test.zig
+++ b/src/eval/test/low_level_interp_test.zig
@@ -2911,6 +2911,8 @@ test "e_low_level_lambda - I64.mod_by with zero result" {
 // variable in polymorphic contexts, leading to the wrong layout being used
 // for the return value (should be empty record {}).
 test "issue 8750: dbg in polymorphic debug function with List.len" {
+    std.debug.print("Ignore the dbg prints to stderr below, they are expected.\n", .{});
+
     const src =
         \\debug = |v| {
         \\    dbg v


### PR DESCRIPTION
So people now the stderr dbgs (visible when running `zig build test`) are not there by accident, I also tried to make it print to stdout but that lead to the tests getting stuck.