### PR TITLE
Fix formatter dropping var keyword from type annotations

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -549,6 +549,9 @@ const Formatter = struct {
                 }
             },
             .type_anno => |t| {
+                if (t.is_var) {
+                    try fmt.pushAll("var ");
+                }
                 try fmt.pushTokenText(t.name);
                 if (multiline and try fmt.flushCommentsAfter(t.name)) {
                     fmt.curr_indent += 1;

--- a/src/parse/AST.zig
+++ b/src/parse/AST.zig
@@ -935,6 +935,7 @@ pub const Statement = union(enum) {
         name: Token.Idx,
         anno: TypeAnno.Idx,
         where: ?Collection.Idx,
+        is_var: bool,
         region: TokenizedRegion,
     },
     malformed: struct {

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -1505,6 +1505,7 @@ fn parseStmtByType(self: *Parser, statementType: StatementType) Error!AST.Statem
                     .anno = anno,
                     .name = name,
                     .where = try self.parseWhereConstraint(),
+                    .is_var = true,
                     .region = .{ .start = start, .end = self.pos },
                 } });
                 return statement_idx;
@@ -1557,6 +1558,7 @@ fn parseStmtByType(self: *Parser, statementType: StatementType) Error!AST.Statem
                     .anno = anno,
                     .name = start,
                     .where = try self.parseWhereConstraint(),
+                    .is_var = false,
                     .region = .{ .start = start, .end = self.pos },
                 } });
                 return statement_idx;
@@ -1588,6 +1590,7 @@ fn parseStmtByType(self: *Parser, statementType: StatementType) Error!AST.Statem
                     .anno = anno,
                     .name = start,
                     .where = try self.parseWhereConstraint(),
+                    .is_var = false,
                     .region = .{ .start = start, .end = self.pos },
                 } });
                 return statement_idx;

--- a/src/parse/test/ast_node_store_test.zig
+++ b/src/parse/test/ast_node_store_test.zig
@@ -230,6 +230,7 @@ test "NodeStore round trip - Statement" {
             .name = rand_token_idx(),
             .anno = rand_idx(AST.TypeAnno.Idx),
             .where = rand_idx(AST.Collection.Idx),
+            .is_var = false,
             .region = rand_region(),
         },
     });

--- a/test/snapshots/fmt_var_in_record_field.md
+++ b/test/snapshots/fmt_var_in_record_field.md
@@ -1,0 +1,78 @@
+# META
+~~~ini
+description=Formatter preserves var keyword in record field annotations
+type=snippet
+~~~
+# SOURCE
+~~~roc
+f=||{var c:[]}
+~~~
+# EXPECTED
+UNUSED VARIABLE - fmt_var_in_record_field.md:1:6:1:14
+# PROBLEMS
+**UNUSED VARIABLE**
+Variable `c` is not used anywhere in your code.
+
+If you don't need this variable, prefix it with an underscore like `_c` to suppress this warning.
+The unused variable is declared here:
+**fmt_var_in_record_field.md:1:6:1:14:**
+```roc
+f=||{var c:[]}
+```
+     ^^^^^^^^
+
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,OpBar,OpenCurly,KwVar,LowerIdent,OpColon,OpenSquare,CloseSquare,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "f"))
+			(e-lambda
+				(args)
+				(e-block
+					(statements
+						(s-type-anno (name "c")
+							(ty-tag-union
+								(tags)))))))))
+~~~
+# FORMATTED
+~~~roc
+f = || {
+	var c : []
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "c"))
+		(e-anno-only)
+		(annotation
+			(ty-tag-union)))
+	(d-let
+		(p-assign (ident "f"))
+		(e-lambda
+			(args)
+			(e-block
+				(s-let
+					(p-assign (ident "c"))
+					(e-anno-only))
+				(e-empty_record)))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "[Error]"))
+		(patt (type "({}) -> {}")))
+	(expressions
+		(expr (type "[Error]"))
+		(expr (type "({}) -> {}"))))
+~~~


### PR DESCRIPTION
Fixes #8824

When parsing `var c : Type` inside a block, the parser was creating a type_anno statement that lost the var keyword. The formatter then produced `c : Type` instead of `var c : Type`.

- Added an is_var field to the type_anno statement struct to track whether the annotation was declared with the var keyword
- Updated the parser to set is_var = true when parsing `var name : Type` and is_var = false for regular type annotations
- Updated the formatter to output the var prefix when is_var is true
- Updated the node storage to encode is_var as a bit flag in the main_token field
- Added a snapshot test that verifies the formatter preserves the var keyword

Co-authored by Claude Opus 4.5