### PR TITLE
Fix roc check not detecting app vs platform type mismatch

### DIFF
--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -1166,3 +1166,44 @@ test "external platform memory alignment regression" {
 
     try checkSuccess(run_result);
 }
+
+test "fx platform issue8826 app vs platform type mismatch" {
+    // Regression test for https://github.com/roc-lang/roc/issues/8826
+    // The bug was that `roc check` reported "No errors found" when the app's main!
+    // signature didn't match the platform's requires. This happened because
+    // getRootEnv() was returning the wrong module (the first one added rather
+    // than the actual root module set in buildRoot).
+    const allocator = testing.allocator;
+
+    const run_result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &[_][]const u8{
+            roc_binary_path,
+            "check",
+            "test/fx/issue8826_minimal.roc",
+        },
+    });
+    defer allocator.free(run_result.stdout);
+    defer allocator.free(run_result.stderr);
+
+    // This file is expected to fail with a TYPE MISMATCH error because:
+    // - App has: main! : List(Str) => Try({}, [Exit(I32)])
+    // - Platform requires: main! : () => {}
+    switch (run_result.term) {
+        .Exited => |code| {
+            if (code != 0) {
+                // Expected to fail - check for type mismatch error message
+                try testing.expect(std.mem.indexOf(u8, run_result.stderr, "TYPE MISMATCH") != null);
+            } else {
+                std.debug.print("Expected type mismatch error but roc check succeeded\n", .{});
+                std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+                return error.UnexpectedSuccess;
+            }
+        },
+        else => {
+            std.debug.print("Run terminated abnormally: {}\n", .{run_result.term});
+            std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+            return error.RunTerminatedAbnormally;
+        },
+    }
+}

--- a/test/fx/issue8826_minimal.roc
+++ b/test/fx/issue8826_minimal.roc
@@ -1,0 +1,13 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+main! : List(Str) => Try({}, [Exit(I32)])
+main! = |args| {
+    match args {
+        _ => {
+            Stdout.line!("Invalid arguments")
+            Err(Exit(1))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #8826

When the app's `main!` type signature didn't match what the platform requires, `roc check` was reporting "No errors found" instead of a TYPE MISMATCH error.

The root cause was twofold:
- `PackageEnv.getRootEnv()` assumed the root module was at index 0 in the modules list. However, when external imports (like "pf.Stdout") are scheduled before `buildRoot()` is called, they get added to the module list first, so the actual root module ends up at a later index.
- For package-qualified imports (like "pf.Stdout"), the canonicalizer was using the module's internal name ("Stdout") instead of the qualified import name ("pf.Stdout") when creating auto-imports.

The fix:
- Added `root_module_id` field to `PackageEnv` to explicitly track which module is the root
- Updated `getRootEnv()` and `getRootModule()` to use this tracked ID
- Fixed `Can.zig` to use qualified names for package-qualified imports when creating auto-imports

Co-authored by Claude Opus 4.5