### PR TITLE
Improve error message for `?` mismatch

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -4705,27 +4705,19 @@ fn checkMatchExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, match: CIR.Exp
         if (!result.is_exhaustive) {
             const condition_snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, cond_var);
 
-            // If this is a try-desugared match (from the ? operator), provide a more helpful error
-            if (match.is_try_suffix) {
-                _ = try self.problems.appendProblem(self.cir.gpa, .{ .try_operator_on_non_try = .{
-                    .match_expr = expr_idx,
-                    .condition_snapshot = condition_snapshot,
-                } });
-            } else {
-                // Format missing patterns and store in snapshot store for lifecycle management
-                var missing_indices: std.ArrayList(ExtraStringIdx) = .empty;
-                for (result.missing_patterns) |pattern| {
-                    const formatted = try exhaustive.formatPattern(self.cir.gpa, &self.cir.common.idents, &self.cir.common.strings, pattern);
-                    const idx = try self.snapshots.storeExtraString(formatted);
-                    try missing_indices.append(self.cir.gpa, idx);
-                }
-
-                _ = try self.problems.appendProblem(self.cir.gpa, .{ .non_exhaustive_match = .{
-                    .match_expr = expr_idx,
-                    .condition_snapshot = condition_snapshot,
-                    .missing_patterns = try missing_indices.toOwnedSlice(self.cir.gpa),
-                } });
+            // Format missing patterns and store in snapshot store for lifecycle management
+            var missing_indices: std.ArrayList(ExtraStringIdx) = .empty;
+            for (result.missing_patterns) |pattern| {
+                const formatted = try exhaustive.formatPattern(self.cir.gpa, &self.cir.common.idents, &self.cir.common.strings, pattern);
+                const idx = try self.snapshots.storeExtraString(formatted);
+                try missing_indices.append(self.cir.gpa, idx);
             }
+
+            _ = try self.problems.appendProblem(self.cir.gpa, .{ .non_exhaustive_match = .{
+                .match_expr = expr_idx,
+                .condition_snapshot = condition_snapshot,
+                .missing_patterns = try missing_indices.toOwnedSlice(self.cir.gpa),
+            } });
         }
 
         // Report redundant patterns

--- a/test/snapshots/try_undefined_tag.md
+++ b/test/snapshots/try_undefined_tag.md
@@ -8,20 +8,22 @@ type=expr
 A?
 ~~~
 # EXPECTED
-TYPE MISMATCH - try_undefined_tag.md:1:1:1:3
+EXPECTED TRY TYPE - try_undefined_tag.md:1:1:1:1
 # PROBLEMS
-**TYPE MISMATCH**
-The `?` operator expects a _Try_ value (`Ok(...)` or `Err(...)`), but this expression has a different type:
-**try_undefined_tag.md:1:1:1:3:**
+**EXPECTED TRY TYPE**
+The `?` operator expects a _Try_ type (a tag union containing ONLY _Ok_ and _Err_ tags),
+but I found:
+**try_undefined_tag.md:1:1:**
 ```roc
 A?
 ```
-^^
+^
 
-The expression has type:
-        _[A, Ok(_a), Err(_b), .._others]_
+This expression has type:
 
-**Hint:** The `?` operator unwraps `Ok` values and returns early on `Err`. Make sure your expression evaluates to a _Try_ type.
+_[A, Ok(_a), Err(_b), .._others]_
+
+Tip: Maybe wrap a value using _Ok(value)_ or _Err(value)_.
 
 # TOKENS
 ~~~zig


### PR DESCRIPTION
## Summary

Fixes #8832

The try operator (A?) was not reporting a proper error when used on a non-Try type. Previously, it would panic with "reached unreachable code" instead of giving a proper compile-time error.

This PR fixes exhaustiveness checking for arity-0 tags: The original issue was that arity-0 constructors (tags with no payload like `A`) were never detected as missing by the exhaustiveness checker. When the try operator desugars `A?` to a match on Ok/Err patterns, the exhaustiveness check would fail to detect that `A` is missing, leading to the runtime panic.

The fix checks for empty specialized matrix with arity=0 while excluding the synthetic `#Open` tag from consideration.

The error message now correctly shows:
```
EXPECTED TRY TYPE
The `?` operator expects a Try type (a tag union containing ONLY Ok and Err tags),
but I found:
A?
^

This expression has type:

[A, Ok(_a), Err(_b), .._others]

Tip: Maybe wrap a value using Ok(value) or Err(value).
```

Changes:
- Fixed exhaustiveness checking for arity-0 constructors
- Skip the synthetic `#Open` tag when checking for missing arity-0 constructors
- Added snapshot test that verifies the error is properly shown

Co-authored by Claude Opus 4.5