### PR TITLE
Add regression tests for issue #8521

### DIFF
--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -253,6 +253,16 @@ pub const io_spec_tests = [_]TestSpec{
         .io_spec = "1>Child is Text: hello",
         .description = "Regression test: dbg on recursive tag union preserves variant discriminant (issue #8804)",
     },
+    .{
+        .roc_file = "test/fx/issue8521_basic.roc",
+        .io_spec = "1>Testing issue 8521",
+        .description = "Regression test: app/platform return type unification (issue #8521)",
+    },
+    .{
+        .roc_file = "test/fx/issue8521_try_internal.roc",
+        .io_spec = "1>Testing issue 8521 with Try",
+        .description = "Regression test: Try return type used internally in app (issue #8521)",
+    },
 };
 
 /// Get the total number of IO spec tests

--- a/test/fx/issue8521_basic.roc
+++ b/test/fx/issue8521_basic.roc
@@ -1,0 +1,12 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+# Regression test for issue #8521: App/Platform return type not fully unified
+#
+# This test is a minimal example to verify that the return type of a lambda
+# is properly unified with the platform's expected type.
+
+main! = || {
+    Stdout.line!("Testing issue 8521")
+}

--- a/test/fx/issue8521_try_internal.roc
+++ b/test/fx/issue8521_try_internal.roc
@@ -1,0 +1,21 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+# Regression test for issue #8521: App/Platform return type not fully unified
+#
+# This test uses Try internally within the app and verifies
+# that type inference works correctly for tag union returns.
+
+get_greeting : {} -> Try(Str, [ListWasEmpty])
+get_greeting = |{}| {
+    first = List.first(["Testing issue 8521 with Try"])?
+    Ok(first)
+}
+
+main! = || {
+    match get_greeting({}) {
+        Ok(msg) => Stdout.line!(msg)
+        Err(ListWasEmpty) => Stdout.line!("Empty!")
+    }
+}


### PR DESCRIPTION
## Summary

Add regression test cases to verify that app/platform return type unification works correctly.

- `issue8521_basic.roc`: Simple test with basic platform that verifies lambda return types are properly unified with platform requirements
- `issue8521_try_internal.roc`: Test using Try type internally in app to verify tag union type inference

The core fix for issue #8521 was addressed in PR #8823 which added support for `..` open tag union syntax and fixed the handling of anonymous flex vars in `checkPlatformRequirements`.

Fixes #8521

Co-authored by Claude Opus 4.5