### PR TITLE
Fix formatter idempotence for chained empty parens after static dispatch

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -1004,7 +1004,59 @@ const Formatter = struct {
                 try fmt.pushTokenText(i.token);
             },
             .field_access => |fa| {
-                _ = try fmt.formatExpr(fa.left);
+                // Special case: when left side is a local_dispatch with zero-arg apply,
+                // we must preserve ONE set of parens to prevent the output from being
+                // re-parsed with a different structure. E.g., `0->b().c()` should NOT
+                // become `0->b.c()` because the parser would interpret `b.c` as a
+                // qualified identifier instead of a field access chain. (See issue #8851)
+                //
+                // For nested applies like `0->b()().c()`, we strip all but one layer,
+                // outputting `0->b().c()` which is then stable on subsequent passes.
+                const left_expr = fmt.ast.store.getExpr(fa.left);
+                if (left_expr == .local_dispatch) {
+                    const ld = left_expr.local_dispatch;
+                    const ld_right_initial = fmt.ast.store.getExpr(ld.right);
+                    if (ld_right_initial == .apply) {
+                        const apply_initial = ld_right_initial.apply;
+                        if (fmt.ast.store.exprSlice(apply_initial.args).len == 0) {
+                            // Strip nested zero-arg applies to find the innermost function
+                            var innermost_fn = apply_initial.@"fn";
+                            var inner_expr = fmt.ast.store.getExpr(innermost_fn);
+                            while (inner_expr == .apply) {
+                                const inner_apply = inner_expr.apply;
+                                if (fmt.ast.store.exprSlice(inner_apply.args).len == 0) {
+                                    innermost_fn = inner_apply.@"fn";
+                                    inner_expr = fmt.ast.store.getExpr(innermost_fn);
+                                } else {
+                                    break;
+                                }
+                            }
+
+                            // Format the local_dispatch preserving one set of parens
+                            const ld_multiline = fmt.nodeWillBeMultiline(AST.Expr.Idx, fa.left);
+                            _ = try fmt.formatExpr(ld.left);
+                            if (ld_multiline and try fmt.flushCommentsBefore(ld.operator)) {
+                                fmt.curr_indent += 1;
+                                try fmt.pushIndent();
+                            }
+                            try fmt.pushAll("->");
+                            if (ld_multiline and try fmt.flushCommentsAfter(ld.operator)) {
+                                try fmt.pushIndent();
+                            }
+                            // Output the innermost function followed by () to preserve one
+                            // set of parens (prevents `b` from being parsed with following `.`
+                            // as a qualified identifier)
+                            _ = try fmt.formatExprInner(innermost_fn, .no_indent_on_access);
+                            try fmt.pushAll("()");
+                        } else {
+                            _ = try fmt.formatExpr(fa.left);
+                        }
+                    } else {
+                        _ = try fmt.formatExpr(fa.left);
+                    }
+                } else {
+                    _ = try fmt.formatExpr(fa.left);
+                }
                 const right_region = fmt.nodeRegion(@intFromEnum(fa.right));
                 if (multiline and try fmt.flushCommentsBefore(right_region.start)) {
                     fmt.curr_indent += 1;

--- a/test/snapshots/formatter_idempotence_issue_8851.md
+++ b/test/snapshots/formatter_idempotence_issue_8851.md
@@ -1,0 +1,67 @@
+# META
+~~~ini
+description=Formatter idempotence test for issue 8851 - chained empty parens with static dispatch
+type=snippet
+~~~
+# SOURCE
+~~~roc
+a = 0->b().c()
+~~~
+# EXPECTED
+UNDEFINED VARIABLE - formatter_idempotence_issue_8851.md:1:8:1:9
+# PROBLEMS
+**UNDEFINED VARIABLE**
+Nothing is named `b` in this scope.
+Is there an `import` or `exposing` missing up-top?
+
+**formatter_idempotence_issue_8851.md:1:8:1:9:**
+```roc
+a = 0->b().c()
+```
+       ^
+
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,Int,OpArrow,LowerIdent,NoSpaceOpenRound,CloseRound,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "a"))
+			(e-field-access
+				(e-local-dispatch
+					(e-int (raw "0"))
+					(e-apply
+						(e-ident (raw "b"))))
+				(e-apply
+					(e-ident (raw "c")))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "a"))
+		(e-dot-access (field "c")
+			(receiver
+				(e-call
+					(e-runtime-error (tag "ident_not_in_scope"))
+					(e-num (value "0"))))
+			(args))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Error")))
+	(expressions
+		(expr (type "Error"))))
+~~~


### PR DESCRIPTION
## Summary

Fixes the formatter instability when handling expressions like `0->b()().c()`. Previously, the formatter would strip empty parentheses one at a time across multiple passes:

- Pass 1: `0->b()().c()` -> `0->b().c()`
- Pass 2: `0->b().c()` -> `0->b.c()`
- Pass 3: `0->b.c()` -> `0->b.c`

The root cause was that stripping empty parens from `0->b().c()` produced `0->b.c()`, which the parser interprets as `0->(b.c)()` (calling qualified function `b.c`) rather than `(0->b()).c()` (field access on result).

- Added special case handling in field_access formatting for when the left side is a local_dispatch with zero-arg apply
- When this case is detected, we preserve one set of parens to maintain correct parse structure
- For nested applies like `b()()`, we strip all but one layer
- This ensures formatter idempotence without needing context-passing hacks

Fixes #8851

Co-authored by Claude Opus 4.5