### PR TITLE
Fix HashMap pointer invalidation in populatePackageShorthands

### DIFF
--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -1534,6 +1534,9 @@ pub const BuildEnv = struct {
             const dep_name = try self.gpa.dupe(u8, alias);
             try self.ensurePackage(dep_name, .platform, abs);
 
+            // Re-fetch pack pointer since ensurePackage may have caused HashMap reallocation
+            pack = self.packages.getPtr(pkg_name).?;
+
             // If key already exists, free the old value before overwriting
             if (pack.shorthands.fetchRemove(dep_key)) |old_entry| {
                 freeConstSlice(self.gpa, old_entry.key);
@@ -1564,6 +1567,9 @@ pub const BuildEnv = struct {
                 if (!self.packages.contains(module_name)) {
                     try self.ensurePackage(module_name, .module, module_path);
                 }
+
+                // Re-fetch pack pointer since ensurePackage may have caused HashMap reallocation
+                pack = self.packages.getPtr(pkg_name).?;
 
                 // Also add to app's shorthands so imports resolve correctly
                 const mod_key = try self.gpa.dupe(u8, module_name);
@@ -1626,6 +1632,9 @@ pub const BuildEnv = struct {
             const dep_name = try self.gpa.dupe(u8, alias);
 
             try self.ensurePackage(dep_name, child_info.kind, abs);
+
+            // Re-fetch pack pointer since ensurePackage may have caused HashMap reallocation
+            pack = self.packages.getPtr(pkg_name).?;
 
             // If key already exists, free the old value before overwriting
             if (pack.shorthands.fetchRemove(dep_key)) |old_entry| {


### PR DESCRIPTION
Fixes a crash where roc check panics with "incorrect alignment" when using remote platform URLs served over HTTP.

The bug was a use-after-free caused by HashMap reallocation:
1. Get pointer to package entry in HashMap
2. Call ensurePackage() which adds entries, potentially reallocating
3. Use the now-invalid pointer, causing alignment panic

The fix re-fetches the package pointer after each ensurePackage() call to ensure it remains valid after potential HashMap growth.

This manifested primarily with remote/HTTP platforms because they trigger more complex package graph building, increasing the likelihood of HashMap reallocation during package registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)