### PR TITLE
Forbid HTTP package URLs except localhost

### DIFF
--- a/src/base/mod.zig
+++ b/src/base/mod.zig
@@ -21,6 +21,7 @@ pub const SmallCollections = @import("PackedDataSpan.zig").SmallCollections;
 
 pub const CommonEnv = @import("CommonEnv.zig");
 pub const source_utils = @import("source_utils.zig");
+pub const url = @import("url.zig");
 
 test {
     _ = @import("Ident.zig");
@@ -164,4 +165,5 @@ test "base tests" {
     std.testing.refAllDecls(@import("stack_overflow.zig"));
     std.testing.refAllDecls(@import("StringLiteral.zig"));
     std.testing.refAllDecls(@import("target.zig"));
+    std.testing.refAllDecls(@import("url.zig"));
 }

--- a/src/base/url.zig
+++ b/src/base/url.zig
@@ -1,0 +1,44 @@
+//! Validation of URLs for security purposes.
+
+const std = @import("std");
+
+/// Checks if a URL is safe. Used for platform specification.
+///
+/// Allows:
+/// - HTTPS URLs (any host)
+/// - HTTP URLs to localhost variants: localhost, 127.0.0.1, [::1]
+///
+/// Rejects all other HTTP URLs for security.
+pub fn isSafeUrl(url: []const u8) bool {
+    return std.mem.startsWith(u8, url, "https://") or
+        std.mem.startsWith(u8, url, "http://localhost:") or
+        std.mem.startsWith(u8, url, "http://localhost/") or
+        std.mem.startsWith(u8, url, "http://127.0.0.1:") or
+        std.mem.startsWith(u8, url, "http://127.0.0.1/") or
+        std.mem.startsWith(u8, url, "http://[::1]:") or
+        std.mem.startsWith(u8, url, "http://[::1]/");
+}
+
+test "isSafeUrl" {
+    const testing = std.testing;
+
+    // Should return true for HTTPS URLs
+    try testing.expect(isSafeUrl("https://example.com/path"));
+
+    // Should return true for localhost HTTP URLs
+    try testing.expect(isSafeUrl("http://localhost:8080/path"));
+    try testing.expect(isSafeUrl("http://localhost/path"));
+    try testing.expect(isSafeUrl("http://127.0.0.1:8080/path"));
+    try testing.expect(isSafeUrl("http://127.0.0.1/path"));
+    try testing.expect(isSafeUrl("http://[::1]:8080/path"));
+    try testing.expect(isSafeUrl("http://[::1]/path"));
+
+    // Should return false for non-localhost HTTP URLs
+    try testing.expect(!isSafeUrl("http://example.com/path"));
+    try testing.expect(!isSafeUrl("http://192.168.1.100/platform.tar.zst"));
+
+    // Should return false for non-URLs
+    try testing.expect(!isSafeUrl("./relative/path"));
+    try testing.expect(!isSafeUrl("/absolute/path"));
+    try testing.expect(!isSafeUrl("platform.roc"));
+}

--- a/src/bundle/download.zig
+++ b/src/bundle/download.zig
@@ -2,6 +2,7 @@
 //! (or http if the URL host is `localhost`, `127.0.0.1`, or `::1`)
 
 const std = @import("std");
+const base = @import("base");
 const builtin = @import("builtin");
 const bundle = @import("bundle.zig");
 
@@ -26,16 +27,7 @@ pub const DownloadError = error{
 /// Parse URL and validate it meets our security requirements.
 /// Returns the hash from the URL if valid.
 pub fn validateUrl(url: []const u8) DownloadError![]const u8 {
-    // Check for https:// prefix
-    if (std.mem.startsWith(u8, url, "https://")) {
-        // This is fine, extract hash from last segment
-    } else if (std.mem.startsWith(u8, url, "http://127.0.0.1:") or std.mem.startsWith(u8, url, "http://127.0.0.1/")) {
-        // This is allowed for local testing (IPv4 loopback)
-    } else if (std.mem.startsWith(u8, url, "http://[::1]:") or std.mem.startsWith(u8, url, "http://[::1]/")) {
-        // This is allowed for local testing (IPv6 loopback)
-    } else if (std.mem.startsWith(u8, url, "http://localhost:") or std.mem.startsWith(u8, url, "http://localhost/")) {
-        // This is allowed but will require verification that localhost resolves to loopback
-    } else {
+    if (!base.url.isSafeUrl(url)) {
         return error.InvalidUrl;
     }
 

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1616,7 +1616,7 @@ pub fn setupSharedMemoryWithModuleEnv(ctx: *CliContext, roc_file_path: []const u
     // Note: All paths use arena allocator so no manual freeing is needed.
     const platform_main_path: ?[]const u8 = if (std.mem.startsWith(u8, platform_spec, "./") or std.mem.startsWith(u8, platform_spec, "../"))
         try std.fs.path.join(ctx.arena, &[_][]const u8{ app_dir, platform_spec })
-    else if (std.mem.startsWith(u8, platform_spec, "http://") or std.mem.startsWith(u8, platform_spec, "https://")) blk: {
+    else if (base.url.isSafeUrl(platform_spec)) blk: {
         // URL platform - resolve to cached package path
         const platform_paths = resolveUrlPlatform(ctx, platform_spec) catch |err| switch (err) {
             error.CliError => break :blk null,
@@ -3019,7 +3019,7 @@ fn compileAndSerializeModulesForEmbedding(
     // Resolve platform path
     const platform_main_path: ?[]const u8 = if (std.mem.startsWith(u8, platform_spec, "./") or std.mem.startsWith(u8, platform_spec, "../"))
         try std.fs.path.join(ctx.gpa, &[_][]const u8{ app_dir, platform_spec })
-    else if (std.mem.startsWith(u8, platform_spec, "http://") or std.mem.startsWith(u8, platform_spec, "https://")) blk: {
+    else if (base.url.isSafeUrl(platform_spec)) blk: {
         const platform_paths = resolveUrlPlatform(ctx, platform_spec) catch |err| switch (err) {
             error.CliError => break :blk null,
             error.OutOfMemory => return error.OutOfMemory,
@@ -4238,9 +4238,9 @@ fn rocBuildEmbedded(ctx: *CliContext, args: cli_args.BuildArgs) !void {
     std.log.debug("Platform spec: {s}", .{platform_spec});
 
     // Resolve platform path - errors are recorded in context and propagate up
-    const platform_paths: ?PlatformPaths = if (std.mem.startsWith(u8, platform_spec, "./") or std.mem.startsWith(u8, platform_spec, "../"))
-        try resolvePlatformSpecToPaths(ctx, platform_spec, app_dir)
-    else if (std.mem.startsWith(u8, platform_spec, "http://") or std.mem.startsWith(u8, platform_spec, "https://"))
+    const platform_paths: ?PlatformPaths = if (std.mem.startsWith(u8, platform_spec, "./") or
+        std.mem.startsWith(u8, platform_spec, "../") or
+        base.url.isSafeUrl(platform_spec))
         try resolvePlatformSpecToPaths(ctx, platform_spec, app_dir)
     else
         null;

--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -1024,7 +1024,7 @@ pub const BuildEnv = struct {
                 defer self.gpa.free(plat_rel);
 
                 // Check if this is a URL - if so, resolve it to a cached local path
-                const plat_path = if (isUrl(plat_rel)) blk: {
+                const plat_path = if (base.url.isSafeUrl(plat_rel)) blk: {
                     const cached_path = try self.resolveUrlPackage(plat_rel);
                     break :blk cached_path;
                 } else blk: {
@@ -1043,7 +1043,7 @@ pub const BuildEnv = struct {
 
                 // For URL-resolved packages, add the cache directory to workspace roots
                 // so that imports within the cached package can be resolved
-                if (isUrl(plat_rel)) {
+                if (base.url.isSafeUrl(plat_rel)) {
                     if (std.fs.path.dirname(plat_path)) |cache_pkg_dir| {
                         try self.workspace_roots.append(try self.gpa.dupe(u8, cache_pkg_dir));
                     }
@@ -1063,7 +1063,7 @@ pub const BuildEnv = struct {
                     defer self.gpa.free(relp);
 
                     // Check if this is a URL - if so, resolve it to a cached local path
-                    const v = if (isUrl(relp)) blk: {
+                    const v = if (base.url.isSafeUrl(relp)) blk: {
                         const cached_path = try self.resolveUrlPackage(relp);
                         // Add cache directory to workspace roots for URL packages
                         if (std.fs.path.dirname(cached_path)) |cache_pkg_dir| {
@@ -1098,7 +1098,7 @@ pub const BuildEnv = struct {
                     defer self.gpa.free(relp);
 
                     // Check if this is a URL - if so, resolve it to a cached local path
-                    const v = if (isUrl(relp)) blk: {
+                    const v = if (base.url.isSafeUrl(relp)) blk: {
                         const cached_path = try self.resolveUrlPackage(relp);
                         // Add cache directory to workspace roots for URL packages
                         if (std.fs.path.dirname(cached_path)) |cache_pkg_dir| {
@@ -1139,7 +1139,7 @@ pub const BuildEnv = struct {
                     defer self.gpa.free(relp);
 
                     // Check if this is a URL - if so, resolve it to a cached local path
-                    const v = if (isUrl(relp)) blk: {
+                    const v = if (base.url.isSafeUrl(relp)) blk: {
                         const cached_path = try self.resolveUrlPackage(relp);
                         // Add cache directory to workspace roots for URL packages
                         if (std.fs.path.dirname(cached_path)) |cache_pkg_dir| {
@@ -1257,11 +1257,6 @@ pub const BuildEnv = struct {
         // This reallocates to the correct size if normalization occurs, ensuring
         // proper memory management when the buffer is freed later.
         return base.source_utils.normalizeLineEndingsRealloc(self.gpa, data);
-    }
-
-    /// Check if a path is a URL (http:// or https://)
-    fn isUrl(path: []const u8) bool {
-        return std.mem.startsWith(u8, path, "http://") or std.mem.startsWith(u8, path, "https://");
     }
 
     /// Cross-platform environment variable lookup.
@@ -1516,7 +1511,7 @@ pub const BuildEnv = struct {
 
             const p_path = info.platform_path.?;
 
-            const abs = if (isUrl(p_path))
+            const abs = if (base.url.isSafeUrl(p_path))
                 try self.resolveUrlPackage(p_path)
             else
                 try self.makeAbsolute(p_path);
@@ -1600,7 +1595,7 @@ pub const BuildEnv = struct {
             const alias = e.key_ptr.*;
             const path = e.value_ptr.*;
 
-            const abs = if (isUrl(path))
+            const abs = if (base.url.isSafeUrl(path))
                 try self.resolveUrlPackage(path)
             else
                 try self.makeAbsolute(path);


### PR DESCRIPTION
Resolves https://github.com/roc-lang/roc/issues/8605

HTTP (except for localhost) is already forbidden in `download.validateUrl`. This PR:

- applies that stricter check in `src/cli/main.zig` and `src/compile/compile_build.zig`.
- moves the URL checking logic into a new module `base.url` to avoid duplication.