### PR TITLE
Fix formatter idempotence for chained zero-arg applications

### DIFF
--- a/test/snapshots/formatter_idempotence_issue_8851_comment1.md
+++ b/test/snapshots/formatter_idempotence_issue_8851_comment1.md
@@ -1,0 +1,69 @@
+# META
+~~~ini
+description=Formatter idempotence test for issue 8851 comment 1 - multiline dispatch with field access
+type=snippet
+~~~
+# SOURCE
+~~~roc
+a=0->b
+      .c()
+~~~
+# EXPECTED
+UNDEFINED VARIABLE - formatter_idempotence_issue_8851_comment1.md:1:6:1:7
+# PROBLEMS
+**UNDEFINED VARIABLE**
+Nothing is named `b` in this scope.
+Is there an `import` or `exposing` missing up-top?
+
+**formatter_idempotence_issue_8851_comment1.md:1:6:1:7:**
+```roc
+a=0->b
+```
+     ^
+
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,Int,OpArrow,LowerIdent,
+DotLowerIdent,NoSpaceOpenRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "a"))
+			(e-field-access
+				(e-local-dispatch
+					(e-int (raw "0"))
+					(e-ident (raw "b")))
+				(e-apply
+					(e-ident (raw ".c")))))))
+~~~
+# FORMATTED
+~~~roc
+a = 0->b
+	.c()
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "a"))
+		(e-dot-access (field "c")
+			(receiver
+				(e-call
+					(e-runtime-error (tag "ident_not_in_scope"))
+					(e-num (value "0"))))
+			(args))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Error")))
+	(expressions
+		(expr (type "Error"))))
+~~~

--- a/test/snapshots/formatter_idempotence_issue_8851_comment2.md
+++ b/test/snapshots/formatter_idempotence_issue_8851_comment2.md
@@ -1,0 +1,76 @@
+# META
+~~~ini
+description=Formatter idempotence test for issue 8851 comment 2 - chained empty parens with tuple dispatch
+type=snippet
+~~~
+# SOURCE
+~~~roc
+a=()->b()()()
+~~~
+# EXPECTED
+EMPTY TUPLE NOT ALLOWED - formatter_idempotence_issue_8851_comment2.md:1:3:1:5
+UNDEFINED VARIABLE - formatter_idempotence_issue_8851_comment2.md:1:7:1:8
+# PROBLEMS
+**EMPTY TUPLE NOT ALLOWED**
+I am part way through parsing this tuple, but it is empty:
+**formatter_idempotence_issue_8851_comment2.md:1:3:1:5:**
+```roc
+a=()->b()()()
+```
+  ^^
+
+If you want to represent nothing, try using an empty record: `{}`.
+
+**UNDEFINED VARIABLE**
+Nothing is named `b` in this scope.
+Is there an `import` or `exposing` missing up-top?
+
+**formatter_idempotence_issue_8851_comment2.md:1:7:1:8:**
+```roc
+a=()->b()()()
+```
+      ^
+
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,NoSpaceOpenRound,CloseRound,OpArrow,LowerIdent,NoSpaceOpenRound,CloseRound,NoSpaceOpenRound,CloseRound,NoSpaceOpenRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "a"))
+			(e-local-dispatch
+				(e-tuple)
+				(e-apply
+					(e-apply
+						(e-apply
+							(e-ident (raw "b")))))))))
+~~~
+# FORMATTED
+~~~roc
+a = ()->b()()()
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "a"))
+		(e-call
+			(e-call
+				(e-call
+					(e-runtime-error (tag "ident_not_in_scope"))))
+			(e-runtime-error (tag "empty_tuple")))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Error")))
+	(expressions
+		(expr (type "Error"))))
+~~~


### PR DESCRIPTION
## Summary

This fixes the remaining formatter idempotence issues from #8851. When the right side of a local dispatch (arrow syntax) is a chain of zero-arg applications like `()->b()()()`, the formatter was stripping only one layer of empty parens per pass, causing non-idempotent output.

- Fixed the formatter to only strip empty parens when the inner function is NOT itself a zero-arg apply
- Added snapshot tests for the two cases from the issue comments:
  - Multiline dispatch with field access: `0->b\n.c()`
  - Chained empty parens with tuple dispatch: `()->b()()()`

The fix ensures semantic preservation: `()->b()()` (call `b()`, then call result) is different from `()->b()` (call `b` with first arg), so the formatter now preserves the distinction.

Fixes #8851

Co-authored by Claude Opus 4.5