### PR TITLE
Add regression tests for issue 8894 and fix broken check test

### DIFF
--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -1641,8 +1641,9 @@ test "check type - for" {
 
 test "check type - for mismatch" {
     const source =
+        \\main : I64
         \\main = {
-        \\  var result = 0
+        \\  var result = 0.I64
         \\  for x in ["a", "b", "c"] {
         \\    result = result + x
         \\  }
@@ -1652,7 +1653,7 @@ test "check type - for mismatch" {
     try checkTypesModule(
         source,
         .fail_first,
-        "MISSING METHOD",
+        "TYPE MISMATCH",
     );
 }
 

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -2687,3 +2687,17 @@ test "issue 8851: chained field access after local dispatch is idempotent" {
     defer std.testing.allocator.free(result);
     try std.testing.expectEqualStrings("a = 0->b().c.d()\n", result);
 }
+
+test "issue 8894: typed integer literal formats correctly" {
+    // Typed integer literals like 0.F or 123.U64 should format without panicking
+    const result = try moduleFmtsStable(std.testing.allocator, "x = 0.F", false);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("x = 0.F\n", result);
+}
+
+test "issue 8894: typed frac literal formats correctly" {
+    // Typed frac literals like 3.14.F64 should format without panicking
+    const result = try moduleFmtsStable(std.testing.allocator, "x = 3.14.F64", false);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("x = 3.14.F64\n", result);
+}


### PR DESCRIPTION
This PR adds regression tests for issue 8894 (formatter panic on typed numeric literals) and fixes a broken test that was introduced in PR #8884.

Fixes #8894

- Added regression tests for typed integer (`0.F`) and typed frac (`3.14.F64`) literal formatting to prevent future regressions. The underlying bug was already fixed in PR #8884 which added formatter support for typed_int and typed_frac expressions.
- Fixed the "check type - for mismatch" test that was broken in PR #8884: updated to use the new typed numeric suffix syntax (`0.I64` instead of `0u8`) and corrected the expected error type from `MISSING METHOD` to `TYPE MISMATCH`.

Co-authored by Claude Opus 4.5