### PR TITLE
Fix type alias lookup for platform requirements

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -2229,17 +2229,19 @@ pub fn setupSharedMemoryWithModuleEnv(ctx: *CliContext, roc_file_path: []const u
             const all_aliases = penv.for_clause_aliases.items.items;
             const type_aliases_slice = all_aliases[@intFromEnum(required_type.type_aliases.start)..][0..required_type.type_aliases.count];
             for (type_aliases_slice) |alias| {
-                // Add alias name (e.g., "Model") - must exist in app since it's required
+                // Add alias name (e.g., "Model") - insert it into app's ident store to ensure
+                // the mapping can be created even if canonicalization hasn't added it yet.
+                // The app will provide the actual type alias definition which will be checked later.
                 const alias_name_text = penv.getIdent(alias.alias_name);
-                if (app_env.common.findIdent(alias_name_text)) |app_ident| {
-                    try platform_to_app_idents.put(alias.alias_name, app_ident);
-                }
+                const alias_app_ident = try app_env.common.insertIdent(ctx.gpa, base.Ident.for_text(alias_name_text));
+                try platform_to_app_idents.put(alias.alias_name, alias_app_ident);
+
                 // Add rigid name (e.g., "model") - insert it into app's ident store since
                 // the rigid name is a platform concept that gets copied during type processing.
                 // Using insert (not find) ensures the app's ident store has this name for later lookups.
                 const rigid_name_text = penv.getIdent(alias.rigid_name);
-                const app_ident = try app_env.common.insertIdent(ctx.gpa, base.Ident.for_text(rigid_name_text));
-                try platform_to_app_idents.put(alias.rigid_name, app_ident);
+                const rigid_app_ident = try app_env.common.insertIdent(ctx.gpa, base.Ident.for_text(rigid_name_text));
+                try platform_to_app_idents.put(alias.rigid_name, rigid_app_ident);
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #8947 by adding for-clause type alias mappings to the platform-to-app ident translation map.

For-clause type aliases (e.g., `[Model : model] for main`) weren't being added to the translation map, causing false "MISSING PLATFORM REQUIRED TYPE" errors during `roc check`.

**Note:** The original issue also had a rank mismatch panic ("trying unifyWith unexpected ranks 1 & 0"), but that was fixed separately by #8945. This PR now only contains the type alias lookup fix.

## Changes

### Fixed type alias lookup in `src/compile/compile_build.zig` and `src/cli/main.zig`

Added for-clause type alias mappings to the platform-to-app ident translation map. This ensures both the alias name (e.g., "Model") and rigid name (e.g., "model") are properly mapped when checking platform requirements.

### Added regression test in `src/cli/test/roc_subcommands.zig`

Test verifies that `roc check test/int/app.roc` does not panic.

## Test Plan

- ✅ `roc check test/int/app.roc` - Reports "No errors found" (previously showed false errors)
- ✅ `roc test/int/app.roc` - Works correctly, reports "ALL TESTS PASSED"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>