### PR TITLE
Improve StackValue RocStr methods for idiomatic Zig

### DIFF
--- a/src/eval/StackValue.zig
+++ b/src/eval/StackValue.zig
@@ -1273,16 +1273,33 @@ pub const RecordAccessor = struct {
     }
 };
 
-/// Get this value as a mutable string pointer.
-///
-/// Panics in debug builds if:
-/// - The layout is not a scalar string type
-/// - The pointer is null (via ptr.?)
-///
-/// Callers do NOT need to check ptr != null before calling this method.
-pub fn asRocStr(self: StackValue) *RocStr {
+/// Get this value as a string pointer, or null if the pointer is null.
+pub fn asRocStr(self: StackValue) ?*RocStr {
     std.debug.assert(self.layout.tag == .scalar and self.layout.data.scalar.tag == .str);
-    return @ptrCast(@alignCast(self.ptr.?));
+    if (self.ptr) |ptr| {
+        return @ptrCast(@alignCast(ptr));
+    }
+    return null;
+}
+
+/// Set this value's contents to a RocStr.
+/// Panics if ptr is null or layout is not a string type.
+pub fn setRocStr(self: StackValue, value: RocStr) void {
+    std.debug.assert(self.layout.tag == .scalar and self.layout.data.scalar.tag == .str);
+    const str_ptr: *RocStr = @ptrCast(@alignCast(self.ptr.?));
+    str_ptr.* = value;
+}
+
+/// Zero-initialize this value's memory based on its layout size.
+/// Used for union payloads that need clearing before writing a smaller variant.
+/// No-op if ptr is null.
+pub fn clearBytes(self: StackValue, layout_cache: *LayoutStore) void {
+    if (self.ptr) |ptr| {
+        const size = layout_cache.layoutSize(self.layout);
+        if (size > 0) {
+            @memset(@as([*]u8, @ptrCast(ptr))[0..size], 0);
+        }
+    }
 }
 
 /// Get this value as a closure pointer
@@ -1434,7 +1451,7 @@ pub fn incref(self: StackValue, layout_cache: *LayoutStore, roc_ops: *RocOps) vo
     }
 
     if (self.layout.tag == .scalar and self.layout.data.scalar.tag == .str) {
-        const roc_str = self.asRocStr();
+        const roc_str = self.asRocStr().?;
         if (comptime trace_refcount) {
             // Small strings have no allocation - skip refcount tracing for them
             if (roc_str.isSmallStr()) {
@@ -1574,7 +1591,7 @@ pub fn decref(self: StackValue, layout_cache: *LayoutStore, ops: *RocOps) void {
     switch (self.layout.tag) {
         .scalar => switch (self.layout.data.scalar.tag) {
             .str => {
-                const roc_str = self.asRocStr();
+                const roc_str = self.asRocStr().?;
                 if (comptime trace_refcount) {
                     // Small strings have no allocation - skip refcount tracing for them
                     if (roc_str.isSmallStr()) {

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -947,10 +947,7 @@ pub const Interpreter = struct {
         roc_ops: *RocOps,
     ) !RocStr {
         if (value.layout.tag == .scalar and value.layout.data.scalar.tag == .str) {
-            if (value.ptr) |ptr| {
-                // Cannot use asRocStr() here - we need to handle null gracefully by returning
-                // empty string, rather than panicking. The unwrapped ptr is a raw pointer.
-                const existing: *const RocStr = @ptrCast(@alignCast(ptr));
+            if (value.asRocStr()) |existing| {
                 var copy = existing.*;
                 copy.incref(1, roc_ops);
                 return copy;
@@ -1304,7 +1301,7 @@ pub const Interpreter = struct {
                 std.debug.assert(args.len == 1); // low-level .str_is_empty expects 1 argument
 
                 const str_arg = args[0];
-                const roc_str = str_arg.asRocStr();
+                const roc_str = str_arg.asRocStr().?;
 
                 return try self.makeBoolValue(builtins.str.isEmpty(roc_str.*));
             },
@@ -1314,8 +1311,8 @@ pub const Interpreter = struct {
 
                 const str_a = args[0];
                 const str_b = args[1];
-                const roc_str_a = str_a.asRocStr();
-                const roc_str_b = str_b.asRocStr();
+                const roc_str_a = str_a.asRocStr().?;
+                const roc_str_b = str_b.asRocStr().?;
 
                 return try self.makeBoolValue(roc_str_a.eql(roc_str_b.*));
             },
@@ -1326,8 +1323,8 @@ pub const Interpreter = struct {
                 const str_a_arg = args[0];
                 const str_b_arg = args[1];
 
-                const str_a = str_a_arg.asRocStr();
-                const str_b = str_b_arg.asRocStr();
+                const str_a = str_a_arg.asRocStr().?;
+                const str_b = str_b_arg.asRocStr().?;
 
                 // Call strConcat to concatenate the strings
                 const result_str = builtins.str.strConcat(str_a.*, str_b.*, roc_ops);
@@ -1338,7 +1335,7 @@ pub const Interpreter = struct {
                 out.is_initialized = false;
 
                 // Copy the result string structure to the output
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1351,8 +1348,8 @@ pub const Interpreter = struct {
                 const haystack_arg = args[0];
                 const needle_arg = args[1];
 
-                const haystack = haystack_arg.asRocStr();
-                const needle = needle_arg.asRocStr();
+                const haystack = haystack_arg.asRocStr().?;
+                const needle = needle_arg.asRocStr().?;
 
                 const result = builtins.str.strContains(haystack.*, needle.*);
 
@@ -1363,7 +1360,7 @@ pub const Interpreter = struct {
                 std.debug.assert(args.len == 1);
 
                 const str_arg = args[0];
-                const roc_str_arg = str_arg.asRocStr();
+                const roc_str_arg = str_arg.asRocStr().?;
 
                 const result_str = builtins.str.strTrim(roc_str_arg.*, roc_ops);
 
@@ -1373,7 +1370,7 @@ pub const Interpreter = struct {
                 out.is_initialized = false;
 
                 // Copy the result string structure to the output
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1384,7 +1381,7 @@ pub const Interpreter = struct {
                 std.debug.assert(args.len == 1);
 
                 const str_arg = args[0];
-                const roc_str_arg = str_arg.asRocStr();
+                const roc_str_arg = str_arg.asRocStr().?;
 
                 const result_str = builtins.str.strTrimStart(roc_str_arg.*, roc_ops);
 
@@ -1394,7 +1391,7 @@ pub const Interpreter = struct {
                 out.is_initialized = false;
 
                 // Copy the result string structure to the output
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1405,7 +1402,7 @@ pub const Interpreter = struct {
                 std.debug.assert(args.len == 1);
 
                 const str_arg = args[0];
-                const roc_str_arg = str_arg.asRocStr();
+                const roc_str_arg = str_arg.asRocStr().?;
 
                 const result_str = builtins.str.strTrimEnd(roc_str_arg.*, roc_ops);
 
@@ -1415,7 +1412,7 @@ pub const Interpreter = struct {
                 out.is_initialized = false;
 
                 // Copy the result string structure to the output
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1428,8 +1425,8 @@ pub const Interpreter = struct {
                 const str_a_arg = args[0];
                 const str_b_arg = args[1];
 
-                const str_a = str_a_arg.asRocStr();
-                const str_b = str_b_arg.asRocStr();
+                const str_a = str_a_arg.asRocStr().?;
+                const str_b = str_b_arg.asRocStr().?;
 
                 // Call strConcat to concatenate the strings
                 const result = builtins.str.strCaselessAsciiEquals(str_a.*, str_b.*);
@@ -1441,7 +1438,7 @@ pub const Interpreter = struct {
                 std.debug.assert(args.len == 1);
 
                 const str_arg = args[0];
-                const roc_str_arg = str_arg.asRocStr();
+                const roc_str_arg = str_arg.asRocStr().?;
 
                 const result_str = builtins.str.strWithAsciiLowercased(roc_str_arg.*, roc_ops);
 
@@ -1451,7 +1448,7 @@ pub const Interpreter = struct {
                 out.is_initialized = false;
 
                 // Copy the result string structure to the output
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1462,7 +1459,7 @@ pub const Interpreter = struct {
                 std.debug.assert(args.len == 1);
 
                 const str_arg = args[0];
-                const roc_str_arg = str_arg.asRocStr();
+                const roc_str_arg = str_arg.asRocStr().?;
 
                 const result_str = builtins.str.strWithAsciiUppercased(roc_str_arg.*, roc_ops);
 
@@ -1472,7 +1469,7 @@ pub const Interpreter = struct {
                 out.is_initialized = false;
 
                 // Copy the result string structure to the output
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1485,8 +1482,8 @@ pub const Interpreter = struct {
                 const string_arg = args[0];
                 const prefix_arg = args[1];
 
-                const string = string_arg.asRocStr();
-                const prefix = prefix_arg.asRocStr();
+                const string = string_arg.asRocStr().?;
+                const prefix = prefix_arg.asRocStr().?;
 
                 return try self.makeBoolValue(builtins.str.startsWith(string.*, prefix.*));
             },
@@ -1497,8 +1494,8 @@ pub const Interpreter = struct {
                 const string_arg = args[0];
                 const suffix_arg = args[1];
 
-                const string = string_arg.asRocStr();
-                const suffix = suffix_arg.asRocStr();
+                const string = string_arg.asRocStr().?;
+                const suffix = suffix_arg.asRocStr().?;
 
                 return try self.makeBoolValue(builtins.str.endsWith(string.*, suffix.*));
             },
@@ -1509,7 +1506,7 @@ pub const Interpreter = struct {
                 const string_arg = args[0];
                 const count_arg = args[1];
 
-                const string = string_arg.asRocStr();
+                const string = string_arg.asRocStr().?;
                 const count_value = try self.extractNumericValue(count_arg);
                 const count: u64 = switch (count_value) {
                     .int => |v| @intCast(v),
@@ -1527,7 +1524,7 @@ pub const Interpreter = struct {
                 out.is_initialized = false;
 
                 // Copy the result string structure to the output
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1540,8 +1537,8 @@ pub const Interpreter = struct {
                 const string_arg = args[0];
                 const prefix_arg = args[1];
 
-                const string = string_arg.asRocStr();
-                const prefix = prefix_arg.asRocStr();
+                const string = string_arg.asRocStr().?;
+                const prefix = prefix_arg.asRocStr().?;
 
                 // with_prefix is just concat with args swapped: prefix ++ string
                 const result_str = builtins.str.strConcat(prefix.*, string.*, roc_ops);
@@ -1552,7 +1549,7 @@ pub const Interpreter = struct {
                 out.is_initialized = false;
 
                 // Copy the result string structure to the output
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1565,8 +1562,8 @@ pub const Interpreter = struct {
                 const string_arg = args[0];
                 const prefix_arg = args[1];
 
-                const string = string_arg.asRocStr();
-                const prefix = prefix_arg.asRocStr();
+                const string = string_arg.asRocStr().?;
+                const prefix = prefix_arg.asRocStr().?;
 
                 const result_str = builtins.str.strDropPrefix(string.*, prefix.*, roc_ops);
 
@@ -1576,7 +1573,7 @@ pub const Interpreter = struct {
                 out.is_initialized = false;
 
                 // Copy the result string structure to the output
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1589,8 +1586,8 @@ pub const Interpreter = struct {
                 const string_arg = args[0];
                 const suffix_arg = args[1];
 
-                const string = string_arg.asRocStr();
-                const suffix = suffix_arg.asRocStr();
+                const string = string_arg.asRocStr().?;
+                const suffix = suffix_arg.asRocStr().?;
 
                 const result_str = builtins.str.strDropSuffix(string.*, suffix.*, roc_ops);
 
@@ -1600,7 +1597,7 @@ pub const Interpreter = struct {
                 out.is_initialized = false;
 
                 // Copy the result string structure to the output
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1611,7 +1608,7 @@ pub const Interpreter = struct {
                 std.debug.assert(args.len == 1);
 
                 const string_arg = args[0];
-                const string = string_arg.asRocStr();
+                const string = string_arg.asRocStr().?;
                 const byte_count = builtins.str.countUtf8Bytes(string.*);
 
                 const result_rt_var = return_rt_var orelse debugUnreachable(roc_ops, "return type required for str_count_utf8_bytes", @src());
@@ -1637,7 +1634,7 @@ pub const Interpreter = struct {
                 var out = try self.pushRaw(result_layout, 0, result_rt_var);
                 out.is_initialized = false;
 
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1650,7 +1647,7 @@ pub const Interpreter = struct {
                 const string_arg = args[0];
                 const spare_arg = args[1];
 
-                const string = string_arg.asRocStr();
+                const string = string_arg.asRocStr().?;
                 const spare_value = try self.extractNumericValue(spare_arg);
                 const spare: u64 = @intCast(spare_value.int);
 
@@ -1660,7 +1657,7 @@ pub const Interpreter = struct {
                 var out = try self.pushRaw(result_layout, 0, string_arg.rt_var);
                 out.is_initialized = false;
 
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1671,14 +1668,14 @@ pub const Interpreter = struct {
                 std.debug.assert(args.len == 1);
 
                 const string_arg = args[0];
-                const string = string_arg.asRocStr();
+                const string = string_arg.asRocStr().?;
                 const result_str = builtins.str.strReleaseExcessCapacity(roc_ops, string.*);
 
                 const result_layout = string_arg.layout;
                 var out = try self.pushRaw(result_layout, 0, string_arg.rt_var);
                 out.is_initialized = false;
 
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1689,7 +1686,7 @@ pub const Interpreter = struct {
                 std.debug.assert(args.len == 1);
 
                 const string_arg = args[0];
-                const string = string_arg.asRocStr();
+                const string = string_arg.asRocStr().?;
                 const result_list = builtins.str.strToUtf8C(string.*, roc_ops);
 
                 // Get the result layout - should be List(U8).
@@ -1751,7 +1748,7 @@ pub const Interpreter = struct {
                 var out = try self.pushRaw(result_layout, 0, result_rt_var);
                 out.is_initialized = false;
 
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -1813,16 +1810,9 @@ pub const Interpreter = struct {
 
                         // Element 0 is the payload - clear it first since it's a union
                         const payload_field = try acc.getElement(0, str_rt_var);
-                        if (payload_field.ptr) |payload_ptr| {
-                            const payload_bytes_len = self.runtime_layout_store.layoutSize(payload_field.layout);
-                            if (payload_bytes_len > 0) {
-                                const bytes = @as([*]u8, @ptrCast(payload_ptr))[0..payload_bytes_len];
-                                @memset(bytes, 0);
-                            }
-                            // Cannot use asRocStr() here - payload_ptr is a raw computed pointer
-                            // from tuple element access, not a StackValue. Also need raw ptr for memset above.
-                            const str_ptr: *RocStr = @ptrCast(@alignCast(payload_ptr));
-                            str_ptr.* = result.string;
+                        if (payload_field.ptr != null) {
+                            payload_field.clearBytes(&self.runtime_layout_store);
+                            payload_field.setRocStr(result.string);
                         }
 
                         // Element 1 is the tag discriminant
@@ -1863,16 +1853,9 @@ pub const Interpreter = struct {
 
                         // Clear payload area first since it's a union
                         const payload_field = try acc.getFieldByIndex(payload_field_idx, str_rt_var);
-                        if (payload_field.ptr) |payload_ptr| {
-                            const payload_bytes_len = self.runtime_layout_store.layoutSize(payload_field.layout);
-                            if (payload_bytes_len > 0) {
-                                const bytes = @as([*]u8, @ptrCast(payload_ptr))[0..payload_bytes_len];
-                                @memset(bytes, 0);
-                            }
-                            // Cannot use asRocStr() here - payload_ptr is a raw computed pointer
-                            // from record field access, not a StackValue. Also need raw ptr for memset above.
-                            const str_ptr: *RocStr = @ptrCast(@alignCast(payload_ptr));
-                            str_ptr.* = result.string;
+                        if (payload_field.ptr != null) {
+                            payload_field.clearBytes(&self.runtime_layout_store);
+                            payload_field.setRocStr(result.string);
                         }
 
                         dest.is_initialized = true;
@@ -1884,19 +1867,13 @@ pub const Interpreter = struct {
                         const tu_data = self.runtime_layout_store.getTagUnionData(tu_idx);
                         const disc_offset = self.runtime_layout_store.getTagUnionDiscriminantOffset(tu_idx);
 
+                        // Clear the entire payload area first
+                        dest.clearBytes(&self.runtime_layout_store);
                         if (dest.ptr) |base_ptr| {
                             const ptr_u8 = @as([*]u8, @ptrCast(base_ptr));
-
-                            // Clear the entire payload area first
-                            const total_size = self.runtime_layout_store.layoutSize(result_layout);
-                            if (total_size > 0) {
-                                @memset(ptr_u8[0..total_size], 0);
-                            }
-
                             tu_data.writeDiscriminantToPtr(ptr_u8 + disc_offset, @intCast(ok_index orelse 0));
-
-                            // Cannot use asRocStr() here - base_ptr is a raw computed pointer
-                            // from tag union base, not a StackValue. Also need raw ptr for memset above.
+                            // Cannot use setRocStr() - dest.layout is tag_union, not str.
+                            // String data is written at base_ptr (offset 0).
                             const str_ptr: *RocStr = @ptrCast(@alignCast(base_ptr));
                             str_ptr.* = result.string;
                         }
@@ -2167,8 +2144,8 @@ pub const Interpreter = struct {
                 const string_arg = args[0];
                 const delimiter_arg = args[1];
 
-                const string = string_arg.asRocStr();
-                const delimiter = delimiter_arg.asRocStr();
+                const string = string_arg.asRocStr().?;
+                const delimiter = delimiter_arg.asRocStr().?;
 
                 const result_list = builtins.str.strSplitOn(string.*, delimiter.*, roc_ops);
 
@@ -2211,7 +2188,7 @@ pub const Interpreter = struct {
                 const separator_arg = args[1];
 
                 const roc_list: *const builtins.list.RocList = @ptrCast(@alignCast(list_arg.ptr.?));
-                const separator = separator_arg.asRocStr();
+                const separator = separator_arg.asRocStr().?;
 
                 const result_str = builtins.str.strJoinWithC(roc_list.*, separator.*, roc_ops);
 
@@ -2220,7 +2197,7 @@ pub const Interpreter = struct {
                 var out = try self.pushRaw(result_layout, 0, str_rt_var);
                 out.is_initialized = false;
 
-                const result_ptr = out.asRocStr();
+                const result_ptr = out.asRocStr().?;
                 result_ptr.* = result_str;
 
                 out.is_initialized = true;
@@ -2262,7 +2239,7 @@ pub const Interpreter = struct {
 
                         const str_rt_var = try self.getCanonicalStrRuntimeVar();
                         const out = try self.pushStr(str_rt_var);
-                        const roc_str_ptr = out.asRocStr();
+                        const roc_str_ptr = out.asRocStr().?;
                         roc_str_ptr.* = RocStr.fromSlice(rendered, roc_ops);
                         return out;
                     }
@@ -2297,7 +2274,7 @@ pub const Interpreter = struct {
 
                         const str_rt_var = try self.getCanonicalStrRuntimeVar();
                         const out = try self.pushStr(str_rt_var);
-                        const roc_str_ptr = out.asRocStr();
+                        const roc_str_ptr = out.asRocStr().?;
                         roc_str_ptr.* = RocStr.fromSlice(rendered, roc_ops);
                         return out;
                     }
@@ -2343,7 +2320,7 @@ pub const Interpreter = struct {
 
                     const str_rt_var = try self.getCanonicalStrRuntimeVar();
                     const out = try self.pushStr(str_rt_var);
-                    const roc_str_ptr = out.asRocStr();
+                    const roc_str_ptr = out.asRocStr().?;
                     roc_str_ptr.* = RocStr.fromSlice(rendered, roc_ops);
                     return out;
                 }
@@ -2385,7 +2362,7 @@ pub const Interpreter = struct {
 
                 const str_rt_var = try self.getCanonicalStrRuntimeVar();
                 const out = try self.pushStr(str_rt_var);
-                const roc_str_ptr = out.asRocStr();
+                const roc_str_ptr = out.asRocStr().?;
                 roc_str_ptr.* = RocStr.fromSlice(rendered, roc_ops);
                 return out;
             },
@@ -4441,11 +4418,8 @@ pub const Interpreter = struct {
                                     if (err_acc.findFieldIndex(layout_env.idents.payload)) |inner_payload_idx| {
                                         const inner_payload_rt = try self.runtime_types.fresh();
                                         const inner_payload_field = try err_acc.getFieldByIndex(inner_payload_idx, inner_payload_rt);
-                                        if (inner_payload_field.ptr) |str_ptr| {
-                                            // Cannot use asRocStr() - str_ptr is an unwrapped optional
-                                            // pointer from record field access, not a StackValue.
-                                            const str_dest: *RocStr = @ptrCast(@alignCast(str_ptr));
-                                            str_dest.* = roc_str;
+                                        if (inner_payload_field.ptr != null) {
+                                            inner_payload_field.setRocStr(roc_str);
                                         }
                                     }
                                 } else if (err_payload_layout.tag == .scalar and err_payload_layout.data.scalar.tag == .str) {
@@ -4740,7 +4714,7 @@ pub const Interpreter = struct {
                 // Dispatch to type-specific parsing using comptime generics
                 std.debug.assert(args.len == 1);
                 const str_arg = args[0];
-                const roc_str = str_arg.asRocStr();
+                const roc_str = str_arg.asRocStr().?;
 
                 const result_rt_var = return_rt_var orelse debugUnreachable(roc_ops, "return type required for num_from_str", @src());
                 const ok_payload_var = try self.getTryOkPayloadVar(result_rt_var);
@@ -4782,7 +4756,7 @@ pub const Interpreter = struct {
 
                 const str_rt_var = try self.getCanonicalStrRuntimeVar();
                 const value = try self.pushStr(str_rt_var);
-                const roc_str_ptr = value.asRocStr();
+                const roc_str_ptr = value.asRocStr().?;
                 roc_str_ptr.* = result_str;
                 return value;
             },
@@ -5100,7 +5074,7 @@ pub const Interpreter = struct {
 
         const str_rt_var = try self.getCanonicalStrRuntimeVar();
         const value = try self.pushStr(str_rt_var);
-        const roc_str_ptr = value.asRocStr();
+        const roc_str_ptr = value.asRocStr().?;
         roc_str_ptr.* = RocStr.init(&buf, result.len, roc_ops);
         return value;
     }
@@ -5118,7 +5092,7 @@ pub const Interpreter = struct {
 
         const str_rt_var = try self.getCanonicalStrRuntimeVar();
         const value = try self.pushStr(str_rt_var);
-        const roc_str_ptr = value.asRocStr();
+        const roc_str_ptr = value.asRocStr().?;
         roc_str_ptr.* = RocStr.init(&buf, result.len, roc_ops);
         return value;
     }
@@ -6368,8 +6342,8 @@ pub const Interpreter = struct {
                 },
                 .str => {
                     if (lhs.ptr == null or rhs.ptr == null) return error.TypeMismatch;
-                    const lhs_str = lhs.asRocStr();
-                    const rhs_str = rhs.asRocStr();
+                    const lhs_str = lhs.asRocStr().?;
+                    const rhs_str = rhs.asRocStr().?;
                     return lhs_str.eql(rhs_str.*);
                 },
                 else => {
@@ -6592,8 +6566,8 @@ pub const Interpreter = struct {
                 },
                 .str => blk: {
                     if (lhs.ptr == null or rhs.ptr == null) return error.TypeMismatch;
-                    const lhs_str = lhs.asRocStr();
-                    const rhs_str = rhs.asRocStr();
+                    const lhs_str = lhs.asRocStr().?;
+                    const rhs_str = rhs.asRocStr().?;
                     break :blk lhs_str.eql(rhs_str.*);
                 },
                 .opaque_ptr => blk: {
@@ -7652,7 +7626,7 @@ pub const Interpreter = struct {
             .str_literal => |sl| {
                 if (!(value.layout.tag == .scalar and value.layout.data.scalar.tag == .str)) return false;
                 const lit = self.env.getString(sl.literal);
-                const rs = value.asRocStr();
+                const rs = value.asRocStr().?;
                 return rs.eqlSlice(lit);
             },
             .nominal => |n| {
@@ -10940,7 +10914,7 @@ pub const Interpreter = struct {
                     traceDbg(roc_ops, "e_str: empty string", .{});
                     const str_rt_var = try self.getCanonicalStrRuntimeVar();
                     const value = try self.pushStr(str_rt_var);
-                    const roc_str = value.asRocStr();
+                    const roc_str = value.asRocStr().?;
                     roc_str.* = RocStr.empty();
                     try value_stack.push(value);
                 } else {
@@ -12978,7 +12952,7 @@ pub const Interpreter = struct {
         const content = self.env.getString(seg.literal);
         const str_rt_var = try self.getCanonicalStrRuntimeVar();
         const value = try self.pushStr(str_rt_var);
-        const roc_str = value.asRocStr();
+        const roc_str = value.asRocStr().?;
         // Use arena allocator for string literals - freed wholesale at interpreter deinit
         roc_str.* = try self.createConstantStr(content);
         return value;
@@ -15633,7 +15607,7 @@ pub const Interpreter = struct {
                     // Push as string value
                     const str_rt_var = try self.getCanonicalStrRuntimeVar();
                     const str_value = try self.pushStr(str_rt_var);
-                    const roc_str_ptr = str_value.asRocStr();
+                    const roc_str_ptr = str_value.asRocStr().?;
                     roc_str_ptr.* = segment_str;
                     try value_stack.push(str_value);
                     collected_count += 1;
@@ -15669,10 +15643,7 @@ pub const Interpreter = struct {
                     var i: usize = 0;
                     while (i < sc.total_count) : (i += 1) {
                         const str_val = value_stack.pop() orelse return error.Crash;
-                        if (str_val.ptr) |ptr| {
-                            // Cannot use asRocStr() - we need to handle null gracefully by appending
-                            // empty string. The unwrapped ptr is a raw pointer.
-                            const roc_str: *RocStr = @ptrCast(@alignCast(ptr));
+                        if (str_val.asRocStr()) |roc_str| {
                             try segment_strings.append(roc_str.*);
                         } else {
                             try segment_strings.append(RocStr.empty());
@@ -15705,7 +15676,7 @@ pub const Interpreter = struct {
 
                     const str_rt_var = try self.getCanonicalStrRuntimeVar();
                     const result = try self.pushStr(str_rt_var);
-                    const roc_str_ptr = result.asRocStr();
+                    const roc_str_ptr = result.asRocStr().?;
                     roc_str_ptr.* = result_str;
                     try value_stack.push(result);
                     return true;
@@ -15722,7 +15693,7 @@ pub const Interpreter = struct {
                     const seg_str = try self.createConstantStr(content);
                     const str_rt_var = try self.getCanonicalStrRuntimeVar();
                     const seg_value = try self.pushStr(str_rt_var);
-                    const roc_str_ptr = seg_value.asRocStr();
+                    const roc_str_ptr = seg_value.asRocStr().?;
                     roc_str_ptr.* = seg_str;
                     try value_stack.push(seg_value);
 


### PR DESCRIPTION
## Summary

- Change `asRocStr()` to return `?*RocStr` (optional) instead of panicking on null - more idiomatic Zig
- Add `setRocStr()` method for safe string assignment with layout assertion
- Add `clearBytes()` method for zeroing union payloads before writing smaller variants
- Update all ~67 call sites to use `.?` for unwrapping
- Refactor edge cases to use new helper methods where possible

## Motivation

This reduces error-prone manual pointer casting (`@ptrCast(@alignCast(...))`) throughout the interpreter by providing type-safe helper methods on `StackValue`. The optional return type for `asRocStr()` is more idiomatic Zig - callers explicitly handle the null case or use `.?` when confident the pointer is non-null.

## Test plan

- [x] `zig build` succeeds
- [x] All 2280 tests pass (`zig build test`)
- [x] String interpolation test passes
- [x] Various fx tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)