### PR TITLE
Improve asClosure() and add box lifecycle helpers to StackValue

### DIFF
--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -718,7 +718,7 @@ pub const Interpreter = struct {
                 return error.Crash;
             }
 
-            const header: *const layout.Closure = @ptrCast(@alignCast(func_val.ptr.?));
+            const header = func_val.asClosure().?;
 
             // Switch to the closure's source module for correct expression evaluation.
             // This is critical because pattern indices and expression indices in the closure
@@ -1129,7 +1129,7 @@ pub const Interpreter = struct {
         saved_rigid_subst = null; // Ownership transferred to continuation
 
         // Invoke comparison function with (elem_at_outer, elem_at_inner)
-        const cmp_header: *const layout.Closure = @ptrCast(@alignCast(compare_fn.ptr.?));
+        const cmp_header = compare_fn.asClosure().?;
         const cmp_saved_env = self.env;
         self.env = @constCast(cmp_header.source_env);
 
@@ -2241,7 +2241,7 @@ pub const Interpreter = struct {
                         return out;
                     }
 
-                    const closure_header: *const layout.Closure = @ptrCast(@alignCast(method_func.ptr.?));
+                    const closure_header = method_func.asClosure().?;
                     const lambda_expr = closure_header.source_env.store.getExpr(closure_header.lambda_expr_idx);
 
                     if (lambda_expr == .e_low_level_lambda) {
@@ -6594,7 +6594,7 @@ pub const Interpreter = struct {
             return error.TypeMismatch;
         }
 
-        const closure_header: *const layout.Closure = @ptrCast(@alignCast(method_func.ptr.?));
+        const closure_header = method_func.asClosure().?;
         const lambda_expr = closure_header.source_env.store.getExpr(closure_header.lambda_expr_idx);
 
         if (lambda_expr == .e_low_level_lambda) {
@@ -7123,8 +7123,7 @@ pub const Interpreter = struct {
                 };
 
                 // Get pointer to heap data from the box
-                const box_ptr: *const usize = @ptrCast(@alignCast(value.ptr.?));
-                const data_ptr: *anyopaque = @ptrFromInt(box_ptr.*);
+                const data_ptr: *anyopaque = @ptrCast(value.getBoxedData().?);
 
                 // Create an unboxed value and recursively extract tag
                 const unboxed = StackValue{
@@ -7148,9 +7147,8 @@ pub const Interpreter = struct {
         switch (result_layout.tag) {
             .box_of_zst => {
                 traceDbg(roc_ops, "makeBoxValueFromLayout: handling box_of_zst", .{});
-                if (out.ptr) |ptr| {
-                    const slot: *usize = @ptrCast(@alignCast(ptr));
-                    slot.* = 0;
+                if (out.ptr != null) {
+                    out.initBoxSlot(null);
                 }
                 return out;
             },
@@ -7189,9 +7187,8 @@ pub const Interpreter = struct {
                     traceDbg(roc_ops, "makeBoxValueFromLayout: copy complete", .{});
                 }
 
-                if (out.ptr) |ptr| {
-                    const slot: *usize = @ptrCast(@alignCast(ptr));
-                    slot.* = @intFromPtr(data_ptr);
+                if (out.ptr != null) {
+                    out.initBoxSlot(data_ptr);
                 }
                 traceDbg(roc_ops, "makeBoxValueFromLayout: returning boxed value", .{});
                 return out;
@@ -7259,8 +7256,7 @@ pub const Interpreter = struct {
             const elem_size = self.runtime_layout_store.layoutSize(elem_layout);
 
             // Get pointer to heap data from the box
-            const box_ptr: *usize = @ptrCast(@alignCast(boxed_value.ptr.?));
-            const data_ptr: [*]u8 = @ptrFromInt(box_ptr.*);
+            const data_ptr = boxed_value.getBoxedData().?;
 
             // Allocate stack space and copy the value
             var result = try self.pushRaw(elem_layout, 0, elem_rt_var);
@@ -7347,7 +7343,7 @@ pub const Interpreter = struct {
         // Found to_inspect - call it synchronously
         if (method_func.layout.tag != .closure) return null;
 
-        const closure_header: *const layout.Closure = @ptrCast(@alignCast(method_func.ptr.?));
+        const closure_header = method_func.asClosure().?;
         // Use closure's source_env for pattern lookup, not self.env
         const params = closure_header.source_env.store.slicePatterns(closure_header.params);
         if (params.len != 1) return null;
@@ -11172,7 +11168,7 @@ pub const Interpreter = struct {
 
                 if (arg_exprs.len == 0) {
                     // No arguments - invoke method directly
-                    const closure_header: *const layout.Closure = @ptrCast(@alignCast(method_func.ptr.?));
+                    const closure_header = method_func.asClosure().?;
 
                     const saved_env = self.env;
                     const saved_bindings_len = self.bindings.items.len;
@@ -13634,7 +13630,7 @@ pub const Interpreter = struct {
                     closure_idx -= 1;
                     const cls_val = self.active_closures.items[closure_idx];
                     if (cls_val.layout.tag == .closure and cls_val.ptr != null) {
-                        const header: *const layout.Closure = @ptrCast(@alignCast(cls_val.ptr.?));
+                        const header = cls_val.asClosure().?;
                         const lambda_expr = header.source_env.store.getExpr(header.lambda_expr_idx);
                         const has_real_captures = (lambda_expr == .e_closure);
                         if (has_real_captures) {
@@ -15300,8 +15296,7 @@ pub const Interpreter = struct {
                                 // but wrapped in a tag union (like Try) whose type says unboxed.
                                 // Dereference the box and copy the inner data.
                                 const inner_layout = self.runtime_layout_store.getLayout(values[0].layout.data.box);
-                                const box_ptr: *const usize = @ptrCast(@alignCast(values[0].ptr.?));
-                                const data_ptr: *anyopaque = @ptrFromInt(box_ptr.*);
+                                const data_ptr: *anyopaque = @ptrCast(values[0].getBoxedData().?);
                                 const inner_value = StackValue{
                                     .layout = inner_layout,
                                     .ptr = data_ptr,
@@ -15767,7 +15762,7 @@ pub const Interpreter = struct {
 
                 // Handle closure invocation
                 if (func_val.layout.tag == .closure) {
-                    const header: *const layout.Closure = @ptrCast(@alignCast(func_val.ptr.?));
+                    const header = func_val.asClosure().?;
                     traceDbg(roc_ops, "invoking closure, body_idx={d}, source_env=\"{s}\"", .{ @intFromEnum(header.body_idx), header.source_env.module_name });
 
                     // Switch to the closure's source module
@@ -16251,7 +16246,7 @@ pub const Interpreter = struct {
                     return error.TypeMismatch;
                 }
 
-                const closure_header: *const layout.Closure = @ptrCast(@alignCast(method_func.ptr.?));
+                const closure_header = method_func.asClosure().?;
 
                 // Switch to the closure's source module
                 const saved_env = self.env;
@@ -16641,7 +16636,7 @@ pub const Interpreter = struct {
                     return error.TypeMismatch;
                 }
 
-                const closure_header: *const layout.Closure = @ptrCast(@alignCast(method_func.ptr.?));
+                const closure_header = method_func.asClosure().?;
 
                 // Switch to the closure's source module
                 const saved_env = self.env;
@@ -17013,7 +17008,7 @@ pub const Interpreter = struct {
 
                                         if (arg_exprs.len == 0) {
                                             // No args - invoke directly
-                                            const closure_header: *const layout.Closure = @ptrCast(@alignCast(copied_field.ptr.?));
+                                            const closure_header = copied_field.asClosure().?;
                                             const saved_env = self.env;
                                             const saved_bindings_len = self.bindings.items.len;
                                             self.env = @constCast(closure_header.source_env);
@@ -17332,7 +17327,7 @@ pub const Interpreter = struct {
                         self.triggerCrash("Hosted lambda closure has null pointer", false, roc_ops);
                         return error.Crash;
                     }
-                    const closure_header: *const layout.Closure = @ptrCast(@alignCast(method_func.ptr.?));
+                    const closure_header = method_func.asClosure().?;
 
                     const saved_env = self.env;
                     const saved_bindings_len = self.bindings.items.len;
@@ -17482,7 +17477,7 @@ pub const Interpreter = struct {
                 // This is critical for type inference of polymorphic literals like numeric 0 in list.get(0).
                 // We get the parameter types from the method signature and use them as expected types,
                 // but only when they are concrete types (not flex/rigid type variables).
-                const closure_header: *const layout.Closure = @ptrCast(@alignCast(method_func.ptr.?));
+                const closure_header = method_func.asClosure().?;
                 const method_lambda_ct_var = can.ModuleEnv.varFrom(closure_header.lambda_expr_idx);
                 const method_source_env = closure_header.source_env;
                 const method_lambda_rt_var = try self.translateTypeVar(@constCast(method_source_env), method_lambda_ct_var);
@@ -17633,7 +17628,7 @@ pub const Interpreter = struct {
                 const method_func = value_stack.pop() orelse return error.Crash;
                 const receiver_value = value_stack.pop() orelse return error.Crash;
 
-                const closure_header: *const layout.Closure = @ptrCast(@alignCast(method_func.ptr.?));
+                const closure_header = method_func.asClosure().?;
 
                 const saved_env = self.env;
                 const saved_bindings_len = self.bindings.items.len;
@@ -17974,7 +17969,7 @@ pub const Interpreter = struct {
                     return error.TypeMismatch;
                 }
 
-                const closure_header: *const layout.Closure = @ptrCast(@alignCast(method_func.ptr.?));
+                const closure_header = method_func.asClosure().?;
 
                 const saved_env = self.env;
                 const saved_bindings_len = self.bindings.items.len;
@@ -18704,7 +18699,7 @@ pub const Interpreter = struct {
                         saved_rigid_subst = null;
 
                         // Invoke comparison function
-                        const cmp_header: *const layout.Closure = @ptrCast(@alignCast(sc.compare_fn.ptr.?));
+                        const cmp_header = sc.compare_fn.asClosure().?;
                         const cmp_saved_env = self.env;
                         self.env = @constCast(cmp_header.source_env);
 
@@ -18824,7 +18819,7 @@ pub const Interpreter = struct {
                     saved_rigid_subst = null;
 
                     // Invoke comparison function
-                    const cmp_header: *const layout.Closure = @ptrCast(@alignCast(sc.compare_fn.ptr.?));
+                    const cmp_header = sc.compare_fn.asClosure().?;
                     const cmp_saved_env = self.env;
                     self.env = @constCast(cmp_header.source_env);
 

--- a/src/eval/render_helpers.zig
+++ b/src/eval/render_helpers.zig
@@ -167,7 +167,7 @@ pub fn renderValueRocWithType(ctx: *RenderCtx, value: StackValue, rt_var: types.
                         switch (value.layout.tag) {
                             .box => {
                                 const elem_layout = ctx.layout_store.getLayout(value.layout.data.box);
-                                const data_ptr_opt = value.boxDataPointer() orelse return error.TypeMismatch;
+                                const data_ptr_opt = value.getBoxedData() orelse return error.TypeMismatch;
                                 if (!elem_layout.eql(payload_layout)) {
                                     return error.TypeMismatch;
                                 }
@@ -827,7 +827,7 @@ pub fn renderValueRoc(ctx: *RenderCtx, value: StackValue) ![]u8 {
         const elem_size = ctx.layout_store.layoutSize(elem_layout);
 
         if (elem_size > 0) {
-            if (value.boxDataPointer()) |data_ptr| {
+            if (value.getBoxedData()) |data_ptr| {
                 const elem_val = StackValue{
                     .layout = elem_layout,
                     .ptr = @ptrCast(data_ptr),


### PR DESCRIPTION
## Summary

- Update `asClosure()` to return `?*const Closure` for consistency with `asRocStr`/`asRocList` pattern
- Add four box lifecycle methods with clear semantic intent:
  - `asBoxSlot()`: returns `?*usize` for low-level slot access
  - `getBoxedData()`: reads slot and returns `?[*]u8` data pointer
  - `initBoxSlot()`: writes data pointer to slot during creation
  - `clearBoxSlot()`: zeros slot during destruction
- Remove unused `boxDataPointer()` (replaced by `getBoxedData()`)

## Changes

- Update 17 closure read patterns in interpreter.zig
- Update box patterns in interpreter.zig and render_helpers.zig
- Update internal StackValue.zig usages in `copyTo`, `incref`, `decref`

## Context

This follows the pattern established by #8954 (asRocStr) and #8955 (asRocList).

The closure changes are intentionally minimal (simple accessor only) because the interpreter uses continuation-passing style where RAII-style helpers would not work well - body evaluation is deferred via the work stack.

Box lifecycle helpers encapsulate the two-level access pattern (slot → data pointer) with semantic methods that clarify intent at each call site.

## Test plan

- [x] All 2280 tests pass
- [x] `hello_world.roc` runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)