### PR TITLE
Fix memory corruption in error messages when using ? on non-Try types

### DIFF
--- a/src/check/problem.zig
+++ b/src/check/problem.zig
@@ -3512,11 +3512,15 @@ pub const Store = struct {
     }
 
     pub fn deinit(self: *Self, gpa: Allocator) void {
-        // Free the indices slice in non_exhaustive_match problems
-        // (the actual strings are managed by the SnapshotStore)
+        // Free allocated memory in problem data
         for (self.problems.items) |prob| {
             switch (prob) {
                 .non_exhaustive_match => |nem| gpa.free(nem.missing_patterns),
+                // Free comptime evaluation messages - these are allocated by ComptimeEvaluator
+                // and ownership is transferred to ProblemStore
+                .comptime_crash => |cc| gpa.free(cc.message),
+                .comptime_expect_failed => |cef| gpa.free(cef.message),
+                .comptime_eval_error => |cee| gpa.free(cee.error_name),
                 else => {},
             }
         }

--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -1257,3 +1257,83 @@ test "fx platform issue8826 large file type checking" {
         return error.ExpectedTypeErrors;
     }
 }
+
+test "fx platform issue8943 error message memory corruption" {
+    // Regression test for https://github.com/roc-lang/roc/issues/8943
+    // The bug was that error messages would display corrupted/garbled text
+    // for both the filename and crash message when using the ? operator on
+    // a non-Try type.
+    //
+    // The root cause was:
+    // 1. ComptimeEvaluator.deinit() freed crash messages before reports were built
+    // 2. addSourceCodeWithUnderlines didn't dupe the filename from SourceCodeDisplayRegion
+    const allocator = testing.allocator;
+
+    const run_result = try runRoc(allocator, "test/fx/issue8943.roc", .{
+        .extra_args = &[_][]const u8{"check"},
+    });
+    defer allocator.free(run_result.stdout);
+    defer allocator.free(run_result.stderr);
+
+    // This file is expected to fail with EXPECTED TRY TYPE and COMPTIME CRASH errors
+    try checkFailure(run_result);
+
+    // Check that the EXPECTED TRY TYPE error is present
+    const has_try_type_error = std.mem.indexOf(u8, run_result.stderr, "EXPECTED TRY TYPE") != null;
+    if (!has_try_type_error) {
+        std.debug.print("Expected 'EXPECTED TRY TYPE' error but got:\n", .{});
+        std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+        return error.ExpectedTryTypeError;
+    }
+
+    // Check that the COMPTIME CRASH error is present
+    const has_comptime_crash = std.mem.indexOf(u8, run_result.stderr, "COMPTIME CRASH") != null;
+    if (!has_comptime_crash) {
+        std.debug.print("Expected 'COMPTIME CRASH' error but got:\n", .{});
+        std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+        return error.ExpectedComptimeCrash;
+    }
+
+    // The key check: verify no memory corruption in error messages
+    // Count how many times the filename appears - it should appear at least twice
+    // (once in each error's source region). The bug causes the first one to be garbled.
+    var filename_count: usize = 0;
+    var search_start: usize = 0;
+    while (std.mem.indexOfPos(u8, run_result.stderr, search_start, "issue8943.roc")) |pos| {
+        filename_count += 1;
+        search_start = pos + 1;
+    }
+
+    // We expect at least 2 occurrences: one in EXPECTED TRY TYPE and one in COMPTIME CRASH
+    // Plus one more at the end in "Found X error(s)..."
+    if (filename_count < 3) {
+        std.debug.print("Error output appears corrupted - filename 'issue8943.roc' found only {d} times (expected at least 3):\n", .{filename_count});
+        std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+        return error.CorruptedErrorOutput;
+    }
+
+    // Check for garbled/non-printable characters that indicate memory corruption
+    // The replacement character (U+FFFD = 0xEF 0xBF 0xBD in UTF-8) or high bytes often appear in corruption
+    for (run_result.stderr) |byte| {
+        // Check for bytes that shouldn't appear in normal error output
+        // Valid output should be ASCII printable characters, newlines, tabs, or ANSI escape sequences
+        if (byte >= 0x80) {
+            // This could be valid UTF-8 or ANSI escapes, skip for now
+            continue;
+        }
+        if (byte < 0x20 and byte != '\n' and byte != '\r' and byte != '\t' and byte != 0x1B) {
+            std.debug.print("Error output contains corrupted byte 0x{x:0>2} at position in stderr:\n", .{byte});
+            std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+            return error.CorruptedErrorOutput;
+        }
+    }
+
+    // Also check that the crash message contains readable text, not garbled bytes
+    // A valid crash message should contain "Try" since that's what the error is about
+    const has_readable_crash_msg = std.mem.indexOf(u8, run_result.stderr, "Try") != null;
+    if (!has_readable_crash_msg) {
+        std.debug.print("Crash message appears corrupted - expected 'Try' not found:\n", .{});
+        std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+        return error.CorruptedCrashMessage;
+    }
+}

--- a/src/eval/comptime_evaluator.zig
+++ b/src/eval/comptime_evaluator.zig
@@ -207,22 +207,12 @@ pub const ComptimeEvaluator = struct {
     }
 
     pub fn deinit(self: *ComptimeEvaluator) void {
-        // Free all crash messages we allocated
-        for (self.crash_messages.items) |msg| {
-            self.allocator.free(msg);
-        }
+        // Note: crash_messages, expect_messages, and error_names are NOT freed here.
+        // Ownership of these strings is transferred to ProblemStore when problems are
+        // appended. ProblemStore.deinit() is responsible for freeing them.
+        // We only deinit the tracking arrays themselves.
         self.crash_messages.deinit();
-
-        // Free all expect failure messages we allocated
-        for (self.expect_messages.items) |msg| {
-            self.allocator.free(msg);
-        }
         self.expect_messages.deinit();
-
-        // Free all error names we allocated
-        for (self.error_names.items) |name| {
-            self.allocator.free(name);
-        }
         self.error_names.deinit();
         self.failed_literal_exprs.deinit();
 

--- a/test/fx/issue8943.roc
+++ b/test/fx/issue8943.roc
@@ -1,0 +1,7 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+# This tests that error messages display correctly without memory corruption
+# when using the ? operator on a non-Try type
+_a = A?
+
+main! = || {}


### PR DESCRIPTION
## Summary

Fixes #8943

This PR fixes an issue where error messages would display corrupted/garbled text for both filenames and crash messages when using the `?` operator on a non-Try type.

## Changes

- **document.zig**: `addSourceCodeWithUnderlines` now dupes the filename from `SourceCodeDisplayRegion` to ensure lifetime safety, and `Document.deinit` now frees this field
- **comptime_evaluator.zig**: `deinit` no longer frees crash/expect/error message strings since ownership is transferred to `ProblemStore`
- **problem.zig**: `Store.deinit` now frees the message strings from `comptime_crash`, `comptime_expect_failed`, and `comptime_eval_error` problems
- **test/fx/issue8943.roc**: Regression test that verifies error messages are not corrupted

## Root Cause

Two memory bugs were causing the corruption:

1. `addSourceCodeWithUnderlines` in document.zig was not duping the filename field of `SourceCodeDisplayRegion`, leading to use-after-free when the original string was deallocated
2. `ComptimeEvaluator.deinit()` was freeing crash_messages, expect_messages, and error_names before the `ProblemStore` had built reports from those messages

Co-authored by Claude Opus 4.5