### PR TITLE
Skip kcov coverage on Linux x86_64

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2645,8 +2645,11 @@ pub fn build(b: *std.Build) void {
     check_fmt_step.dependOn(&check_fmt.step);
 
     // Parser code coverage with kcov
-    // Only supported on Linux and macOS (kcov doesn't work on Windows)
-    const is_coverage_supported = target.result.os.tag == .linux or target.result.os.tag == .macos;
+    // Only supported on Linux ARM64 and macOS (kcov doesn't work on Windows)
+    // Linux x86_64 is NOT supported due to Zig 0.15.2 generating invalid DWARF .debug_line
+    // sections that cause kcov to fail (see CoverageSummaryStep comments for details)
+    const is_linux_x86_64 = target.result.os.tag == .linux and target.result.cpu.arch == .x86_64;
+    const is_coverage_supported = (target.result.os.tag == .linux or target.result.os.tag == .macos) and !is_linux_x86_64;
     if (is_coverage_supported and isNativeishOrMusl(target)) {
         // Get the kcov dependency and build it from source
         // lazyDependency returns null on first pass; Zig re-runs build() after fetching


### PR DESCRIPTION
Skip kcov coverage on Linux x86_64 due to Zig 0.15.2 DWARF bug

Fixes #8960
