### PR TITLE
Fix wrong exhaustiveness error for match on tuple with list and wildcard

### DIFF
--- a/src/check/exhaustive.zig
+++ b/src/check/exhaustive.zig
@@ -2104,9 +2104,12 @@ fn collectCtorsSketched(
     }
 
     if (found_list) {
-        if (found_wildcard) {
-            return .non_exhaustive_wildcards;
-        }
+        // When we have both list patterns and wildcards, we still need to check
+        // all list arities. The wildcards will be expanded during specialization
+        // (specializeByListAritySketched handles wildcards by expanding them).
+        // Previously this returned .non_exhaustive_wildcards when wildcards were
+        // present, which caused false non-exhaustive errors because wildcards
+        // covering all list arities weren't being considered.
         var arities: std.ArrayList(ListArity) = .empty;
         for (first_col) |pat| {
             if (pat == .list) {

--- a/src/check/test/exhaustiveness_test.zig
+++ b/src/check/test/exhaustiveness_test.zig
@@ -839,23 +839,27 @@ test "exhaustive - record patterns with different field subsets" {
     try test_env.assertLastDefType("Str");
 }
 
-// Regression test for issue #8896: non-exhaustive tuple with list pattern
-// Previously caused "Invalid free" panic due to allocator mismatch when freeing
-// the missing_patterns slice in the NonExhaustiveMatch error.
+// Regression test for issue #8935: wrong exhaustiveness error for match on tuple
+// The patterns ([], _), (_, 0), ([_, ..], _) together cover all cases:
+// - [] with any U64 (first pattern)
+// - [_, ..] with any U64 (third pattern)
+// Together these cover all lists. The middle pattern (_, 0) is just an optimization.
 
-test "non-exhaustive - tuple with list pattern" {
+test "exhaustive - tuple with list and integer patterns" {
     const source =
-        \\f : (List(I64), I64) -> I64
-        \\f = |l, i| {
-        \\    match (l, i) {
-        \\        ([], _) => 0
-        \\        (_, 0) => 0
-        \\        ([_x, ..], _) => 0
-        \\    }
+        \\x : (List(I64), I64)
+        \\x = ([1, 2, 3], 42)
+        \\
+        \\result : I64
+        \\result = match x {
+        \\    ([], _) => 0
+        \\    (_, 0) => 1
+        \\    ([_head, ..], _) => 2
         \\}
     ;
     var test_env = try TestEnv.init("Test", source);
     defer test_env.deinit();
 
-    try test_env.assertFirstTypeError("NON-EXHAUSTIVE MATCH");
+    // This should be exhaustive - patterns 1 and 3 together cover all lists
+    try test_env.assertLastDefType("I64");
 }


### PR DESCRIPTION
When matching on tuples containing lists, if a wildcard pattern appeared in the list column alongside list patterns, the exhaustiveness checker would incorrectly return "non_exhaustive_wildcards" which caused only the wildcard rows to be considered. This led to false non-exhaustive match errors even when the patterns covered all cases.

The fix removes the early return when wildcards are found with list patterns, allowing the algorithm to properly check all list arities with wildcards expanded during specialization.

- Fixed `collectCtorsSketched` in exhaustive.zig to not early-return when wildcards are present alongside list patterns
- Added regression test for the exact bug case: matching `(List, I64)` with patterns `([], _)`, `(_, 0)`, `([_, ..], _)`

Fixes #8935

Co-authored by Claude Opus 4.5