### PR TITLE
Fix LSP crash: type store and regions out of sync in checkPlatformRequirements

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -1193,6 +1193,11 @@ pub fn checkPlatformRequirements(
     const trace = tracy.trace(@src());
     defer trace.end();
 
+    // Ensure the type store is filled to match the number of regions.
+    // This is necessary because checkPlatformRequirements may be called with a
+    // fresh Check instance that hasn't had checkFile() called on it.
+    try ensureTypeStoreIsFilled(self);
+
     // Create a solver env for type operations
     var env = try self.env_pool.acquire(.generalized);
     defer self.env_pool.release(env);


### PR DESCRIPTION
## Summary

When checkPlatformRequirements is called, it creates a new Check instance that may not have its type store filled to match the number of regions. This caused the assertion "Arrays out of sync: type_nodes=17 region_nodes=38" to fail when processing platform requirements in the LSP.

Fixes #8995

- Added ensureTypeStoreIsFilled call at the start of checkPlatformRequirements
- This matches the pattern used in checkFile and checkExprRepl which also ensure the type store is properly initialized before operating on it

Co-authored by Claude Opus 4