### PR TITLE
Make comptime errors use problem.extra_strings

### DIFF
--- a/src/eval/comptime_evaluator.zig
+++ b/src/eval/comptime_evaluator.zig
@@ -159,12 +159,6 @@ pub const ComptimeEvaluator = struct {
     expect: CrashContext, // Reuse CrashContext for expect failures
     roc_ops: ?RocOps,
     problems: *ProblemStore,
-    /// Track crash messages we've allocated so we can free them
-    crash_messages: std.array_list.Managed([]const u8),
-    /// Track expect failure messages we've allocated so we can free them
-    expect_messages: std.array_list.Managed([]const u8),
-    /// Track error names we've allocated so we can free them
-    error_names: std.array_list.Managed([]const u8),
     /// Track expressions that failed numeric literal validation (to skip evaluation)
     failed_literal_exprs: std.AutoHashMap(CIR.Expr.Idx, void),
     /// Flag to indicate if evaluation has been halted due to a crash
@@ -195,9 +189,6 @@ pub const ComptimeEvaluator = struct {
             .expect = CrashContext.init(allocator),
             .roc_ops = null,
             .problems = problems,
-            .crash_messages = std.array_list.Managed([]const u8).init(allocator),
-            .expect_messages = std.array_list.Managed([]const u8).init(allocator),
-            .error_names = std.array_list.Managed([]const u8).init(allocator),
             .failed_literal_exprs = std.AutoHashMap(CIR.Expr.Idx, void).init(allocator),
             .halted = false,
             .current_expr_region = null,
@@ -207,13 +198,6 @@ pub const ComptimeEvaluator = struct {
     }
 
     pub fn deinit(self: *ComptimeEvaluator) void {
-        // Note: crash_messages, expect_messages, and error_names are NOT freed here.
-        // Ownership of these strings is transferred to ProblemStore when problems are
-        // appended. ProblemStore.deinit() is responsible for freeing them.
-        // We only deinit the tracking arrays themselves.
-        self.crash_messages.deinit();
-        self.expect_messages.deinit();
-        self.error_names.deinit();
         self.failed_literal_exprs.deinit();
 
         // Free all Roc runtime allocations at once
@@ -1233,12 +1217,10 @@ pub const ComptimeEvaluator = struct {
         region: base.Region,
         problem_type: enum { crash, expect_failed, error_eval },
     ) !void {
-        // Allocate and track the message
-        const owned_message = try self.allocator.dupe(u8, message);
-
+        // Put error str into problems store
+        const owned_message = try self.problems.putExtraString(message);
         switch (problem_type) {
             .crash => {
-                try self.crash_messages.append(owned_message);
                 const problem = Problem{
                     .comptime_crash = .{
                         .message = owned_message,
@@ -1248,7 +1230,6 @@ pub const ComptimeEvaluator = struct {
                 _ = try self.problems.appendProblem(self.allocator, problem);
             },
             .expect_failed => {
-                try self.expect_messages.append(owned_message);
                 const problem = Problem{
                     .comptime_expect_failed = .{
                         .message = owned_message,
@@ -1258,7 +1239,6 @@ pub const ComptimeEvaluator = struct {
                 _ = try self.problems.appendProblem(self.allocator, problem);
             },
             .error_eval => {
-                try self.error_names.append(owned_message);
                 const problem = Problem{
                     .comptime_eval_error = .{
                         .error_name = owned_message,
@@ -1315,12 +1295,9 @@ pub const ComptimeEvaluator = struct {
                     else => {
                         // Non-nominal types (e.g., records, tuples, functions) don't have from_numeral
                         // This is a type error - numeric literal can't be used as this type
-                        const error_msg = try std.fmt.allocPrint(
-                            self.allocator,
+                        const error_msg = try self.problems.putExtraString(
                             "Numeric literal cannot be used as this type (type doesn't support from_numeral)",
-                            .{},
                         );
-                        try self.error_names.append(error_msg);
                         const problem = Problem{
                             .comptime_eval_error = .{
                                 .error_name = error_msg,
@@ -1338,12 +1315,9 @@ pub const ComptimeEvaluator = struct {
                     // If still flex, type checking didn't fully resolve it - this is OK, may resolve later
                     // If rigid/alias, it doesn't support from_numeral
                     if (content != .flex) {
-                        const error_msg = try std.fmt.allocPrint(
-                            self.allocator,
+                        const error_msg = try self.problems.putExtraString(
                             "Numeric literal cannot be used as this type (type doesn't support from_numeral)",
-                            .{},
                         );
-                        try self.error_names.append(error_msg);
                         const problem = Problem{
                             .comptime_eval_error = .{
                                 .error_name = error_msg,
@@ -1394,12 +1368,10 @@ pub const ComptimeEvaluator = struct {
                     self.env.common.getIdentStore(),
                     nominal_type.ident.ident_idx,
                 );
-                const error_msg = try std.fmt.allocPrint(
-                    self.allocator,
+                const error_msg = try self.problems.putFmtExtraString(
                     "Type {s} does not have a from_numeral method",
                     .{short_type_name},
                 );
-                try self.error_names.append(error_msg);
                 const problem = Problem{
                     .comptime_eval_error = .{
                         .error_name = error_msg,
@@ -1419,12 +1391,10 @@ pub const ComptimeEvaluator = struct {
                     self.env.common.getIdentStore(),
                     nominal_type.ident.ident_idx,
                 );
-                const error_msg = try std.fmt.allocPrint(
-                    self.allocator,
+                const error_msg = try self.problems.putFmtExtraString(
                     "Type {s} does not have an accessible from_numeral method",
                     .{short_type_name},
                 );
-                try self.error_names.append(error_msg);
                 const problem = Problem{
                     .comptime_eval_error = .{
                         .error_name = error_msg,
@@ -1651,12 +1621,10 @@ pub const ComptimeEvaluator = struct {
 
         // Evaluate the from_numeral function to get a closure
         const func_value = self.interpreter.eval(target_def.expr, roc_ops) catch |err| {
-            const error_msg = try std.fmt.allocPrint(
-                self.allocator,
+            const error_msg = try self.problems.putFmtExtraString(
                 "Failed to evaluate from_numeral function: {s}",
                 .{@errorName(err)},
             );
-            try self.error_names.append(error_msg);
             const problem = Problem{
                 .comptime_eval_error = .{
                     .error_name = error_msg,
@@ -1670,12 +1638,10 @@ pub const ComptimeEvaluator = struct {
 
         // Check if func_value is a closure
         if (func_value.layout.tag != .closure) {
-            const error_msg = try std.fmt.allocPrint(
-                self.allocator,
+            const error_msg = try self.problems.putFmtExtraString(
                 "from_numeral is not a function",
                 .{},
             );
-            try self.error_names.append(error_msg);
             const problem = Problem{
                 .comptime_eval_error = .{
                     .error_name = error_msg,
@@ -1691,12 +1657,10 @@ pub const ComptimeEvaluator = struct {
         // Get the parameters
         const params = origin_env.store.slicePatterns(closure_header.params);
         if (params.len != 1) {
-            const error_msg = try std.fmt.allocPrint(
-                self.allocator,
+            const error_msg = try self.problems.putFmtExtraString(
                 "from_numeral has wrong number of parameters (expected 1, got {d})",
                 .{params.len},
             );
-            try self.error_names.append(error_msg);
             const problem = Problem{
                 .comptime_eval_error = .{
                     .error_name = error_msg,
@@ -1747,12 +1711,10 @@ pub const ComptimeEvaluator = struct {
             result = self.interpreter.callLowLevelBuiltinWithTargetType(low_level.op, &args, roc_ops, return_rt_var, target_rt_var) catch |err| {
                 // Include crash message if available for better debugging
                 const crash_msg = self.crash.crashMessage() orelse "no crash message";
-                const error_msg = try std.fmt.allocPrint(
-                    self.allocator,
+                const error_msg = try self.problems.putFmtExtraString(
                     "from_numeral builtin failed: {s} ({s})",
                     .{ @errorName(err), crash_msg },
                 );
-                try self.error_names.append(error_msg);
                 const problem = Problem{
                     .comptime_eval_error = .{
                         .error_name = error_msg,
@@ -1778,12 +1740,10 @@ pub const ComptimeEvaluator = struct {
 
             // Call the function body
             result = self.interpreter.eval(closure_header.body_idx, roc_ops) catch |err| {
-                const error_msg = try std.fmt.allocPrint(
-                    self.allocator,
+                const error_msg = try self.problems.putFmtExtraString(
                     "from_numeral evaluation failed: {s}",
                     .{@errorName(err)},
                 );
-                try self.error_names.append(error_msg);
                 const problem = Problem{
                     .comptime_eval_error = .{
                         .error_name = error_msg,
@@ -1907,10 +1867,9 @@ pub const ComptimeEvaluator = struct {
         // (happens when payload area is too small for RocStr)
         if (self.interpreter.last_error_message) |msg| {
             // Copy the message to our allocator
-            const error_msg = try self.allocator.dupe(u8, msg);
+            const error_msg = try self.problems.putExtraString(msg);
             // Free the original message from the interpreter's allocator
             self.interpreter.allocator.free(msg);
-            try self.error_names.append(error_msg);
             const problem = Problem{
                 .comptime_eval_error = .{
                     .error_name = error_msg,
@@ -1930,12 +1889,10 @@ pub const ComptimeEvaluator = struct {
                 // "Err" < "Ok" alphabetically, so Err = 0, Ok = 1
                 if (tag_value == 0) {
                     // Err with no payload - generic error
-                    const error_msg = try std.fmt.allocPrint(
-                        self.allocator,
+                    const error_msg = try self.problems.putFmtExtraString(
                         "Numeric literal validation failed",
                         .{},
                     );
-                    try self.error_names.append(error_msg);
                     const problem = Problem{
                         .comptime_eval_error = .{
                             .error_name = error_msg,
@@ -1960,8 +1917,7 @@ pub const ComptimeEvaluator = struct {
                 const tag_value = tag_field.asI128();
                 if (tag_value == 0) {
                     // This is an Err - try to extract InvalidNumeral(Str) message
-                    const error_msg = try self.extractInvalidNumeralMessage(accessor, region);
-                    try self.error_names.append(error_msg);
+                    const error_msg = try self.problems.putExtraString(try self.extractInvalidNumeralMessage(accessor, region));
                     const problem = Problem{
                         .comptime_eval_error = .{
                             .error_name = error_msg,
@@ -1993,12 +1949,10 @@ pub const ComptimeEvaluator = struct {
                 if (tag_value == 0) {
                     // This is an Err - the detailed message should have been in last_error_message
                     // If we get here, something went wrong but we know it's an error
-                    const error_msg = try std.fmt.allocPrint(
-                        self.allocator,
+                    const error_msg = try self.problems.putFmtExtraString(
                         "Numeric literal validation failed",
                         .{},
                     );
-                    try self.error_names.append(error_msg);
                     const problem = Problem{
                         .comptime_eval_error = .{
                             .error_name = error_msg,

--- a/src/eval/test/comptime_eval_test.zig
+++ b/src/eval/test/comptime_eval_test.zig
@@ -1148,20 +1148,15 @@ test "comptime eval - I8: -129 does not fit" {
 
 // Comprehensive numeric literal validation tests with error message verification
 
-/// Helper to extract error message from first comptime_eval_error problem
-fn getFirstComptimeEvalErrorMessage(problems: *check.problem.Store) ?[]const u8 {
-    for (problems.problems.items) |problem| {
-        if (problem == .comptime_eval_error) {
-            return problem.comptime_eval_error.error_name;
-        }
-    }
-    return null;
-}
-
 /// Helper to check if error message contains expected substring
 fn errorContains(problems: *check.problem.Store, expected: []const u8) bool {
-    if (getFirstComptimeEvalErrorMessage(problems)) |msg| {
-        return std.mem.indexOf(u8, msg, expected) != null;
+    for (problems.problems.items) |problem| {
+        switch (problem) {
+            .comptime_eval_error => |comptime_eval_error| {
+                return std.mem.indexOf(u8, problems.getExtraString(comptime_eval_error.error_name), expected) != null;
+            },
+            else => {},
+        }
     }
     return false;
 }
@@ -1183,7 +1178,7 @@ test "comptime eval - U8 valid max value" {
         for (result.problems.problems.items) |problem| {
             std.debug.print("  - {s}", .{@tagName(problem)});
             if (problem == .comptime_eval_error) {
-                std.debug.print(": {s}", .{problem.comptime_eval_error.error_name});
+                std.debug.print(": {s}", .{result.problems.getExtraString(problem.comptime_eval_error.error_name)});
             }
             std.debug.print("\n", .{});
         }
@@ -1684,7 +1679,7 @@ test "comptime eval - F32 valid" {
         for (result.problems.problems.items) |problem| {
             std.debug.print("  - {s}", .{@tagName(problem)});
             if (problem == .comptime_eval_error) {
-                std.debug.print(": {s}", .{problem.comptime_eval_error.error_name});
+                std.debug.print(": {s}", .{result.problems.getExtraString(problem.comptime_eval_error.error_name)});
             }
             std.debug.print("\n", .{});
         }


### PR DESCRIPTION
Move compile time error messages into `problem`s store for:
* Faster deallocation
* Easier memory management