### PR TITLE
Fix panic when doing field access on numeric literals

### DIFF
--- a/test/snapshots/scientific_notation_field_access.md
+++ b/test/snapshots/scientific_notation_field_access.md
@@ -1,0 +1,61 @@
+# META
+~~~ini
+description=Field access on scientific notation should produce an error, not crash
+type=snippet
+~~~
+# SOURCE
+~~~roc
+y = 1E10.e
+~~~
+# EXPECTED
+MISSING METHOD - scientific_notation_field_access.md:1:5:1:9
+# PROBLEMS
+**MISSING METHOD**
+This **from_numeral** method is being called on a value whose type doesn't have that method:
+**scientific_notation_field_access.md:1:5:1:9:**
+```roc
+y = 1E10.e
+```
+    ^^^^
+
+The value's type, which does not have a method named **from_numeral**, is:
+
+    { e: _field }
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,Float,NoSpaceDotLowerIdent,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "y"))
+			(e-field-access
+				(e-frac (raw "1E10"))
+				(e-ident (raw "e"))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "y"))
+		(e-dot-access (field "e")
+			(receiver
+				(e-frac-dec (value "10000000000"))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "_a")))
+	(expressions
+		(expr (type "_a"))))
+~~~


### PR DESCRIPTION
## Summary

When code like `1E10.e` is type-checked, the type system infers that the number literal must have type `{ e: _ }` (a record with field `e`). At runtime, the numeric literal evaluation functions would use this inferred record layout, but the record has size 0 (since the field is an unresolved flex var), resulting in a null pointer. When field access was then attempted on this "record", the code crashed with an assertion failure.

- Added layout compatibility checks to `evalDec`, `evalFracF64`, and `evalFracF32` similar to what `evalNum` and `evalDecSmall` already have
- When the inferred layout is not compatible with the literal type, we fall back to the appropriate numeric layout (Dec, F64, or F32)
- This allows the type checker to report a proper error message instead of the interpreter crashing
- Added a snapshot test to verify the fix

Fixes #9000

Co-authored by Claude Opus 4.5