### PR TITLE
Fix NotNumeric crash with numeric operators in closures

### DIFF
--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -283,6 +283,11 @@ pub const io_spec_tests = [_]TestSpec{
         .io_spec = "1>SUCCESS: Builder.print_value! called via static dispatch!|1>  value: test|1>  count: 0",
         .description = "Regression test: Static dispatch on effect methods (issue #8928)",
     },
+    .{
+        .roc_file = "test/fx/issue9020.roc",
+        .io_spec = "1>Done",
+        .description = "Regression test: NotNumeric crash with multiple ? operators in fold closure (issue #9020)",
+    },
 };
 
 /// Get the total number of IO spec tests

--- a/test/fx/issue9020.roc
+++ b/test/fx/issue9020.roc
@@ -1,0 +1,30 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+# Reproduces issue 9020: compiler crashes with "Error evaluating: NotNumeric"
+# when using multiple ? operators with arithmetic inside a closure,
+# applied via fold to a dynamically created list.
+
+main! = || {
+    # Key ingredients for the bug:
+    # 1. Local closure f with multiple ? operators and arithmetic
+    # 2. Dynamically created list via .map()
+    # 3. fold with match on f's result
+    # 4. Piping result to another function
+    f = |digits| Ok(List.first(digits)? + List.first(digits)?)
+    vs = ["a"].map(|s| s.to_utf8().map(|c| c.to_u64()))
+    _result = vs.fold(
+        [],
+        |acc, v| {
+            match f(v) {
+                Ok(u) => acc.append(u)
+                Err(_) => acc
+            }
+        },
+    )->sum()
+    Stdout.line!("Done")
+}
+
+sum : List(U64) -> U64
+sum = |nums| nums.len()


### PR DESCRIPTION
## Summary

Fixes #9020 - the compiler was crashing with "Error evaluating: NotNumeric" when using multiple `?` operators with arithmetic inside a closure, applied via `fold` to a dynamically created list.

The root cause was in layout computation for flex/rigid type variables: when a variable had `desugared_binop` constraints (from arithmetic operators like `+`) but no `from_numeral` constraint (from numeric literals), it was getting `zst()` layout instead of a numeric layout.

- Extended `hasFromNumeralConstraint` to `hasNumericConstraint` which also recognizes `desugared_binop` and `desugared_unaryop` origins as indicators of numeric types
- Updated flex/rigid var layout computation to use this new check, so arithmetic operators properly result in Dec layout
- Added regression test in test/fx/issue9020.roc

Co-authored by Claude Opus 4.5