### PR TITLE
Fix nominal type layout for enum-like tag unions in tuples

### DIFF
--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -283,6 +283,16 @@ pub const io_spec_tests = [_]TestSpec{
         .io_spec = "1>SUCCESS: Builder.print_value! called via static dispatch!|1>  value: test|1>  count: 0",
         .description = "Regression test: Static dispatch on effect methods (issue #8928)",
     },
+    .{
+        .roc_file = "test/fx/issue9011.roc",
+        .io_spec = "1>parse_value! called|1>finished creating combination method 1 in parse_value!|1>parse_value! called|1>Returning early from parse_value!|1>finished calling parse_value!|1>parsed: Try.Ok((<tag_union variant=1>, <tag_union variant=0>, 4))",
+        .description = "Regression test: Nominal types wrapping enum-like tag unions in tuples (issue #9011)",
+    },
+    .{
+        .roc_file = "test/fx/issue9011_minimal.roc",
+        .io_spec = "1>value: Value.CombinedValue({ combination_method: C }), index: 1",
+        .description = "Regression test: Minimal reproduction of issue #9011",
+    },
 };
 
 /// Get the total number of IO spec tests

--- a/src/eval/test/eval_test.zig
+++ b/src/eval/test/eval_test.zig
@@ -2365,3 +2365,8 @@ test "issue 8978: incref alignment with recursive tag unions in tuples" {
         \\}
     , 42, .no_trace);
 }
+
+// Note: Issue #9011 (nominal type wrapping enum-like tag union in tuple) is tested in
+// test/fx/issue9011.roc and test/fx/issue9011_minimal.roc. The bug is specifically about
+// nominal types defined with the := syntax, which cannot be tested in the eval test
+// framework since it only accepts expressions, not full module definitions.

--- a/test/fx/issue9011.roc
+++ b/test/fx/issue9011.roc
@@ -1,0 +1,68 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+# Issue 9011: Panics with "cast causes pointer to be null" or "integer overflow"
+# when using recursive functions with mutable variables and tagged unions.
+
+TokenContents : [
+    EqualToken,
+    ModuloToken,
+    UIntDigitsToken(U64),
+    IdentToken(Str),
+    EndOfFileToken,
+]
+
+TokenizerResult : (
+    TokenContents,
+    U64,
+)
+
+get_next_token! : U64 => TokenizerResult
+get_next_token! = |index| {
+    tokens : List(TokenContents)
+    tokens = [IdentToken("i"), ModuloToken, UIntDigitsToken(15), EqualToken, UIntDigitsToken(0)]
+    match List.get(tokens, index) {
+        Ok(value) => (value, index+1)
+        Err(_) => (EndOfFileToken, index)
+    }
+}
+
+ValueCombinationMethod := [
+    BooleanAnd, BooleanOr, BooleanNot,
+    IsEqual, IsNotEqual, IsGreaterThan, IsLessThan, IsGreaterThanOrEqual, IsLessThanOrEqual,
+    Multiply, Divide, Modulo,
+    Add, Subtract,
+]
+
+Value := [
+    UInt(U64),
+    CombinedValue({
+        combination_method: ValueCombinationMethod,
+    }),
+]
+
+parse_value! : TokenizerResult => Try((TokenContents, Value, U64), Str)
+parse_value! = |(_, var $index)| {
+    Stdout.line!("parse_value! called")
+    (token2, $index) = get_next_token!($index)
+    combination_method1 : ValueCombinationMethod
+    combination_method1 = match token2 {
+        ModuloToken => Modulo
+        _ => {
+            Stdout.line!("Returning early from parse_value!")
+            return Ok((token2, UInt(3), $index))
+        }
+    }
+    Stdout.line!("finished creating combination method 1 in parse_value!")
+    (token3, _value2, $index) = parse_value!(get_next_token!($index))?
+    Stdout.line!("finished calling parse_value!")
+    value : Value
+    value = CombinedValue({combination_method: combination_method1})
+    Ok((token3, value, $index))
+}
+
+main! = || {
+    parsed = parse_value!(get_next_token!(0))
+    Stdout.line!("parsed: ${Str.inspect(parsed)}")
+}

--- a/test/fx/issue9011_minimal.roc
+++ b/test/fx/issue9011_minimal.roc
@@ -1,0 +1,38 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+# Minimal reproduction of issue 9011
+
+ValueCombinationMethod := [A, B, C, D, E, F, G, H, I, J, K, L, M, N]
+
+Value := [
+    UInt(U64),
+    CombinedValue({
+        combination_method: ValueCombinationMethod,
+    }),
+]
+
+other! : {} => Try((Value, U64), Str)
+other! = |{}| {
+    Ok((UInt(3), 1))
+}
+
+helper! : {} => Try((Value, U64), Str)
+helper! = |{}| {
+    combination_method1 : ValueCombinationMethod
+    combination_method1 = C
+
+    (_value, index) = other!({})?
+
+    value : Value
+    value = CombinedValue({combination_method: combination_method1})
+    Ok((value, index))
+}
+
+main! = || {
+    match helper!({}) {
+        Ok((value, index)) => Stdout.line!("value: ${Str.inspect(value)}, index: ${Str.inspect(index)}")
+        Err(_) => {}
+    }
+}


### PR DESCRIPTION
## Summary
When a nominal type wraps an enum-like tag union (one with no payloads), the layout computation would incorrectly skip the nominal update, causing crashes with "cast causes pointer to be null" or "integer overflow" errors.

- Added check for pending container before skipping nominal update in layout computation
- The fix ensures enum-like tag unions (which resolve directly to scalars without creating pending containers) properly update the nominal's placeholder layout
- Added regression tests for issue #9011

Fixes #9011

Co-authored by Claude Opus 4.5