### PR TITLE
Fix static dispatch allowing methods with unconstrained generic first param

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -5628,6 +5628,83 @@ fn checkDeferredStaticDispatchConstraints(self: *Self, env: *Env) std.mem.Alloca
                     continue;
                 }
 
+                // For explicit method calls via static dispatch syntax (e.g., `lst.repeat(3)`),
+                // the method's ORIGINAL first parameter must be compatible with the nominal type.
+                // We check the ORIGINAL type (before instantiation) because instantiation converts
+                // rigids to flexes, which would mask explicitly generic annotations.
+                //
+                // This check only applies to .method_call origins - other origins like
+                // .from_numeral, .where_clause, .desugared_binop have different semantics.
+                //
+                // Valid cases for method_call:
+                // 1. First param is the nominal type itself (e.g., `len : List(_) -> U64`)
+                // 2. First param is an alias to the nominal type
+                // 3. First param is a constrained type variable (e.g., `a where [a.method : ...]`)
+                //
+                // Invalid case: first param is an UNCONSTRAINED rigid type variable.
+                // A method like `repeat : a, U64 -> List(a)` should NOT be callable via
+                // `lst.repeat(3)` where lst : List(b), because the first parameter `a`
+                // is explicitly generic and doesn't specifically accept List values.
+                // Only check builtins for now - cross-module ident comparison is complex
+                const is_builtin = original_module_ident == self.cir.idents.builtin_module;
+                if (constraint.origin == .method_call and real_args.len > 0 and is_builtin) {
+                    // Check the ORIGINAL type before instantiation to detect explicitly generic params
+                    const original_types = &original_env.types;
+                    const original_def_resolved = original_types.resolveVar(def_var);
+                    const original_func_opt = original_def_resolved.desc.content.unwrapFunc();
+
+                    const first_param_is_compatible = if (original_func_opt) |original_func| blk: {
+                        const original_args = original_types.sliceVars(original_func.args);
+                        if (original_args.len == 0) break :blk true; // No first param to check
+
+                        const first_param_var = original_args[0];
+                        const first_param_resolved = original_types.resolveVar(first_param_var);
+                        const first_param_content = first_param_resolved.desc.content;
+
+                        break :blk switch (first_param_content) {
+                            // A flex (inferred) type variable is OK - it will unify with the actual receiver type.
+                            .flex => true,
+                            // A rigid (from annotation) type variable is OK only if it has constraints.
+                            // An unconstrained rigid means the annotation explicitly declared the function
+                            // as generic, which shouldn't be callable via static dispatch on a specific type.
+                            .rigid => |rigid| rigid.constraints.len() > 0,
+                            // Check if the first param is the same nominal type.
+                            // Compare both origin_module and ident_idx since both come from original_env.
+                            .structure => |flat| switch (flat) {
+                                .nominal_type => |first_nominal| first_nominal.origin_module == nominal_type.origin_module and
+                                    first_nominal.ident.ident_idx == nominal_type.ident.ident_idx,
+                                else => false,
+                            },
+                            // An alias needs to be checked against its backing type
+                            .alias => |alias| inner: {
+                                const backing_var = original_types.getAliasBackingVar(alias);
+                                const backing_resolved = original_types.resolveVar(backing_var);
+                                if (backing_resolved.desc.content == .structure) {
+                                    if (backing_resolved.desc.content.structure == .nominal_type) {
+                                        const backing_nominal = backing_resolved.desc.content.structure.nominal_type;
+                                        break :inner backing_nominal.origin_module == nominal_type.origin_module and
+                                            backing_nominal.ident.ident_idx == nominal_type.ident.ident_idx;
+                                    }
+                                }
+                                break :inner false;
+                            },
+                            .err => true, // Don't add more errors if already errored
+                        };
+                    } else true; // If not a function, let later checks handle it
+
+                    if (!first_param_is_compatible) {
+                        // The method exists but its first parameter doesn't match the nominal type,
+                        // so it can't be used for static dispatch on this type
+                        try self.reportConstraintError(
+                            deferred_constraint.var_,
+                            constraint,
+                            .{ .missing_method = .nominal },
+                            env,
+                        );
+                        continue;
+                    }
+                }
+
                 // Unify each argument pair
                 var any_arg_failed = false;
                 for (constraint_args, real_args) |constraint_arg, real_arg| {

--- a/test/snapshots/issue/method_call_inspect_defined.md
+++ b/test/snapshots/issue/method_call_inspect_defined.md
@@ -10,6 +10,7 @@ type=expr
 # EXPECTED
 UNEXPECTED TOKEN IN EXPRESSION - method_call_inspect_defined.md:1:14:1:15
 UNRECOGNIZED SYNTAX - method_call_inspect_defined.md:1:14:1:15
+MISSING METHOD - method_call_inspect_defined.md:1:18:1:25
 # PROBLEMS
 **UNEXPECTED TOKEN IN EXPRESSION**
 The token **;** is not expected in an expression.
@@ -32,6 +33,20 @@ I don't recognize this syntax.
              ^
 
 This might be a syntax error, an unsupported language feature, or a typo.
+
+**MISSING METHOD**
+This **inspect** method is being called on a value whose type doesn't have that method:
+**method_call_inspect_defined.md:1:18:1:25:**
+```roc
+{ x = "hello"; x.inspect() }
+```
+                 ^^^^^^^
+
+The value's type, which does not have a method named **inspect**, is:
+
+    Str
+
+**Hint:** For this to work, the type would need to have a method named **inspect** associated with it in the type's declaration.
 
 # TOKENS
 ~~~zig
@@ -76,5 +91,5 @@ EndOfFile,
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Str"))
+(expr (type "Error"))
 ~~~

--- a/test/snapshots/static_dispatch_type_mismatch.md
+++ b/test/snapshots/static_dispatch_type_mismatch.md
@@ -1,0 +1,87 @@
+# META
+~~~ini
+description=Static dispatch type mismatch - calling .repeat on List should error since List has no repeat method
+type=snippet
+~~~
+# SOURCE
+~~~roc
+# Calling .repeat(3) on a List should fail to compile, since List has no repeat method.
+# Only Str has a repeat method.
+lst = [1, 2, 3]
+result = lst.repeat(3)
+~~~
+# EXPECTED
+MISSING METHOD - static_dispatch_type_mismatch.md:4:14:4:20
+# PROBLEMS
+**MISSING METHOD**
+This **repeat** method is being called on a value whose type doesn't have that method:
+**static_dispatch_type_mismatch.md:4:14:4:20:**
+```roc
+result = lst.repeat(3)
+```
+             ^^^^^^
+
+The value's type, which does not have a method named **repeat**, is:
+
+    List(b) where [b.from_numeral : Numeral -> Try(b, [InvalidNumeral(Str)])]
+
+**Hint:** For this to work, the type would need to have a method named **repeat** associated with it in the type's declaration.
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpenSquare,Int,Comma,Int,Comma,Int,CloseSquare,
+LowerIdent,OpAssign,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,Int,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "lst"))
+			(e-list
+				(e-int (raw "1"))
+				(e-int (raw "2"))
+				(e-int (raw "3"))))
+		(s-decl
+			(p-ident (raw "result"))
+			(e-field-access
+				(e-ident (raw "lst"))
+				(e-apply
+					(e-ident (raw "repeat"))
+					(e-int (raw "3")))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "lst"))
+		(e-list
+			(elems
+				(e-num (value "1"))
+				(e-num (value "2"))
+				(e-num (value "3")))))
+	(d-let
+		(p-assign (ident "result"))
+		(e-dot-access (field "repeat")
+			(receiver
+				(e-lookup-local
+					(p-assign (ident "lst"))))
+			(args
+				(e-num (value "3"))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "List(b) where [b.from_numeral : Numeral -> Try(b, [InvalidNumeral(Str)])]"))
+		(patt (type "Error")))
+	(expressions
+		(expr (type "List(b) where [b.from_numeral : Numeral -> Try(b, [InvalidNumeral(Str)])]"))
+		(expr (type "Error"))))
+~~~


### PR DESCRIPTION
## Summary

This PR fixes a bug where static dispatch syntax (e.g., `lst.repeat(3)`) allowed calling methods whose first parameter type doesn't match the receiver type. Specifically, `List.repeat : a, U64 -> List(a)` could be called on a List even though its first parameter is a generic `a` that doesn't specifically accept List values.

- Added validation during deferred static dispatch constraint resolution to check the method's original first parameter type before instantiation
- For builtin methods, if the first parameter is an unconstrained rigid type variable (from an explicit annotation), the call is now rejected with a MISSING METHOD error
- Valid cases still work: first param is the nominal type, first param has constraints, or first param is inferred (flex)
- Added snapshot test for the bug reproduction case
- Updated existing snapshot test that now correctly reports additional MISSING METHOD error

Fixes #9019

Co-authored by Claude Opus 4.5