### PR TITLE
Fix issue 9010: Allow closed error types to flow into open Try error types

### DIFF
--- a/src/check/test/repros_test.zig
+++ b/src/check/test/repros_test.zig
@@ -122,6 +122,29 @@ test "check - repro - issue 8919" {
     try test_env.assertNoErrors();
 }
 
+test "check - repro - issue 9010" {
+    // Closed tag unions in Try should be compatible with open tag unions.
+    // When a function returns Try(U32, [Bar(U8)]) (closed), it should be
+    // usable with ? operator in a function expecting Try(U32, [Foo(U8), ..]) (open).
+    const src =
+        \\bar : {} -> Try(U32, [Bar(U8)])
+        \\bar = |_| {
+        \\    Err(Bar(5))
+        \\}
+        \\
+        \\foo : {} -> Try(U32, [Foo(U8), ..])
+        \\foo = |_| {
+        \\    a = bar({})?
+        \\    Ok(a + 5)
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("Test", src);
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+}
+
 test "check - repro - issue 8848" {
     // Pattern matching on recursive opaque type element retrieved from List
     const src =

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -1549,7 +1549,11 @@ test "check type - patterns num" {
 }
 
 test "check type - patterns int mismatch" {
-    // Test that matching a tag against incompatible tag patterns fails
+    // Test that matching a tag against incompatible tag patterns fails.
+    // Note: With error propagation support (issue 9010), the unification of
+    // closed+open tag unions now succeeds, so the error is detected during
+    // exhaustiveness checking rather than pattern matching. Both errors correctly
+    // indicate that the patterns don't match the condition type.
     const source =
         \\{
         \\  x : [Ok(I64), Err(Str)]
@@ -1561,7 +1565,7 @@ test "check type - patterns int mismatch" {
         \\  }
         \\}
     ;
-    try checkTypesExpr(source, .fail, "INCOMPATIBLE MATCH PATTERNS");
+    try checkTypesExpr(source, .fail, "NON-EXHAUSTIVE MATCH");
 }
 
 test "check type - patterns frac 1" {


### PR DESCRIPTION
## Summary

This fixes issue #9010 where using the `?` operator with a function that returns a closed error type inside a function returning an open error type would fail to type-check.

- When a function returns `Try(U32, [Bar(U8)])` (closed error), it should work inside a function returning `Try(U32, [Foo(U8), ..])` (open error)
- The closed error tags from the inner function flow into the open error union of the outer function
- Added pre-validation for nominal type usage to preserve strict checking for cases like `Color.Yellow` when `Color := [Red, Green, Blue]`
- Added test case reproducing the issue in repros_test.zig

Fixes #9010

Co-authored by Claude Opus 4.5