### PR TITLE
Fix roc check to resolve platform-exposed module types in annotations

### DIFF
--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -76,6 +76,11 @@ pub const io_spec_tests = [_]TestSpec{
         .io_spec = "1>My favourite color is Red",
         .description = "Opaque type with attached method",
     },
+    .{
+        .roc_file = "test/fx/test_issue9034.roc",
+        .io_spec = "1>test",
+        .description = "Platform-exposed opaque types in type annotations (issue #9034)",
+    },
 
     // Language feature tests
     .{

--- a/test/fx/test_issue9034.roc
+++ b/test/fx/test_issue9034.roc
@@ -1,0 +1,13 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Builder
+import pf.Stdout
+
+# Test that platform-exposed opaque types can be used in type annotations
+# This is a regression test for issue #9034
+my_builder : Builder
+my_builder = Builder.new("test")
+
+main! = || {
+    Stdout.line!(Builder.get_value(my_builder))
+}


### PR DESCRIPTION
## Summary

- Fixes `roc check` failing with "UNDECLARED TYPE" error when using platform-exposed types in type annotations
- Adds both qualified and unqualified module names to `module_envs_map` for proper lookup
- Adds regression test for issue #9034

## Test plan

- [x] New test file `test/fx/test_issue9034.roc` that uses `Builder` type from platform in a type annotation
- [x] `roc check test/fx/test_issue9034.roc` now passes (previously failed with UNDECLARED TYPE)
- [x] `roc run test/fx/test_issue9034.roc` still works (was already working)
- [x] All existing fx platform tests continue to pass
- [x] `zig build test-can`, `zig build test-compile`, `zig build test-check` pass

Fixes #9034

🤖 Generated with [Claude Code](https://claude.com/claude-code)