### PR TITLE
Unify Improvements

### DIFF
--- a/src/check/copy_import.zig
+++ b/src/check/copy_import.zig
@@ -60,7 +60,6 @@ pub fn copyVar(
     try dest_store.dangerousSetVarDesc(placeholder_var, .{
         .content = dest_content,
         .rank = types_mod.Rank.generalized,
-        .mark = types_mod.Mark.none,
     });
 
     return placeholder_var;

--- a/src/check/occurs.zig
+++ b/src/check/occurs.zig
@@ -8,11 +8,8 @@
 //! The main entrypoint is `occurs()`. It analyzes the type graph rooted at a variable
 //! and reports whether the structure is recursive, and if so, what kind of recursion.
 //!
-//! The traversal uses a shared `Scratch` value to track visited nodes, recursion
-//! chains, and to temporarily mark variables during analysis. This is reset between runs.
-//!
-//! The check only mutates the `Mark` field of descriptors in `Store`, and all marks
-//! are reset before returning. Other descriptor state remains unchanged.
+//! The traversal uses a shared `Scratch` value to track visited nodes and recursion
+//! chains. This is reset between runs. The check does not mutate the `Store`.
 
 const std = @import("std");
 const base = @import("base");
@@ -25,7 +22,6 @@ const Store = types.Store;
 const DescStoreIdx = types.DescStoreIdx;
 const ResolvedVarDesc = types.ResolvedVarDesc;
 const Content = types.Content;
-const Mark = types.Mark;
 const Var = types.Var;
 const TagUnion = types.TagUnion;
 const Tag = types.Tag;
@@ -49,9 +45,7 @@ pub const Result = enum {
 /// If the result is `recursive_nominal`, you can use `scratch.err_chain_nominal_vars`
 /// to check what nominal vars were encountered
 ///
-/// This function accepts a mutable reference to `Store`, but guarantees that it
-/// _only_ modifies a variable's `Mark`. Before returning, all visited nodes'
-/// `Mark`s will be reset to `none`.
+/// This function does not modify the `Store`.
 pub fn occurs(types_store: *Store, scratch: *Scratch, var_: Var) std.mem.Allocator.Error!Result {
     scratch.reset();
 
@@ -85,11 +79,6 @@ pub fn occurs(types_store: *Store, scratch: *Scratch, var_: Var) std.mem.Allocat
         },
     };
 
-    // Reset the marks for all visited nodes
-    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
-        types_store.setDescMark(visited_desc_idx, Mark.none);
-    }
-
     return result;
 }
 
@@ -113,9 +102,6 @@ const CheckOccurs = struct {
     /// Init CheckOccurs
     ///
     /// Note that this struct does not own any of it's fields
-    ///
-    /// This function accepts a mutable reference to `Store`, and _must_ only
-    /// modify a var's `Mark`
     fn init(types_store: *Store, scratch: *Scratch) Self {
         return .{ .types_store = types_store, .scratch = scratch };
     }
@@ -130,7 +116,7 @@ const CheckOccurs = struct {
         const root = self.types_store.resolveVar(var_);
         const root_var = root.var_;
 
-        if (root.desc.mark == .visited) {
+        if (self.scratch.hasVisited(root.desc_idx)) {
             // If we've already visited this var and not errored, then it's not recursive
             return;
         } else if (self.scratch.hasSeenVar(root_var)) {
@@ -223,7 +209,6 @@ const CheckOccurs = struct {
             self.scratch.popSeen();
 
             self.scratch.appendVisited(root.desc_idx) catch return Error.AllocatorError;
-            self.types_store.setDescMark(root.desc_idx, Mark.visited);
         }
     }
 
@@ -322,6 +307,13 @@ pub const Scratch = struct {
     fn hasSeenVar(self: *const Self, var_: Var) bool {
         for (self.seen.items.items) |seen_var| {
             if (seen_var == var_) return true;
+        }
+        return false;
+    }
+
+    fn hasVisited(self: *const Self, desc_idx: DescStoreIdx) bool {
+        for (self.visited.items.items) |visited_idx| {
+            if (visited_idx == desc_idx) return true;
         }
         return false;
     }
@@ -518,10 +510,6 @@ test "occurs: recursive tag union (v = [ Cons(elem, v), Nil ]" {
     const err_chain = scratch.errChainSlice();
     try std.testing.expectEqual(1, err_chain.len);
     try std.testing.expectEqual(linked_list, err_chain[0]);
-
-    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
-        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
-    }
 }
 test "occurs: nested recursive tag union (v = [ Cons(elem, Box(v)) ] )" {
     const gpa = std.testing.allocator;
@@ -564,10 +552,6 @@ test "occurs: nested recursive tag union (v = [ Cons(elem, Box(v)) ] )" {
     try std.testing.expect(err_chain.len == 2);
     try std.testing.expectEqual(err_chain[0], boxed_linked_list);
     try std.testing.expectEqual(err_chain[1], linked_list);
-
-    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
-        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
-    }
 }
 
 test "occurs: recursive tag union (v = List: [ Cons(Elem, List), Nil ])" {
@@ -609,10 +593,6 @@ test "occurs: recursive tag union (v = List: [ Cons(Elem, List), Nil ])" {
     try std.testing.expectEqual(1, err_chain_nominal1.len);
     try std.testing.expectEqual(nominal_type, err_chain_nominal1[0]);
 
-    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
-        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
-    }
-
     // assert that starting from the the tag union, it works
 
     const result2 = occurs(&types_store, &scratch, backing_var);
@@ -626,10 +606,6 @@ test "occurs: recursive tag union (v = List: [ Cons(Elem, List), Nil ])" {
     const err_chain_nominal2 = scratch.errChainNominalVarsSlice();
     try std.testing.expectEqual(1, err_chain_nominal2.len);
     try std.testing.expectEqual(nominal_type, err_chain_nominal2[0]);
-
-    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
-        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
-    }
 }
 
 test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB := [ Cons(Elem, TypeA), Nil ])" {
@@ -685,10 +661,6 @@ test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB 
     try std.testing.expectEqual(type_b_nominal, err_chain_nominal1[0]);
     try std.testing.expectEqual(type_a_nominal, err_chain_nominal1[1]);
 
-    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
-        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
-    }
-
     // assert that starting from the `TypeB` nominal, it works
 
     const result2 = occurs(&types_store, &scratch, type_b_nominal);
@@ -705,10 +677,6 @@ test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB 
     try std.testing.expectEqual(type_a_nominal, err_chain_nominal2[0]);
     try std.testing.expectEqual(type_b_nominal, err_chain_nominal2[1]);
 
-    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
-        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
-    }
-
     // assert that starting from the the tag union, it works
 
     const result3 = occurs(&types_store, &scratch, type_b_backing);
@@ -724,8 +692,4 @@ test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB 
     try std.testing.expectEqual(2, err_chain_nominal3.len);
     try std.testing.expectEqual(type_b_nominal, err_chain_nominal3[0]);
     try std.testing.expectEqual(type_a_nominal, err_chain_nominal3[1]);
-
-    for (scratch.visited.items.items[0..]) |visited_desc_idx| {
-        try std.testing.expectEqual(Mark.none, types_store.getDesc(visited_desc_idx).mark);
-    }
 }

--- a/src/types/instantiate.zig
+++ b/src/types/instantiate.zig
@@ -25,7 +25,6 @@ const Tag = types_mod.Tag;
 const NominalType = types_mod.NominalType;
 const Tuple = types_mod.Tuple;
 const Rank = types_mod.Rank;
-const Mark = types_mod.Mark;
 const Ident = base.Ident;
 
 /// Type to manage instantiation.
@@ -148,7 +147,6 @@ pub const Instantiator = struct {
                     .{
                         .content = fresh_content,
                         .rank = self.current_rank,
-                        .mark = Mark.none,
                     },
                 );
 
@@ -170,7 +168,6 @@ pub const Instantiator = struct {
                     .{
                         .content = fresh_content,
                         .rank = self.current_rank,
-                        .mark = Mark.none,
                     },
                 );
 


### PR DESCRIPTION
I recommend reviewing by commit:

1. Remove snapshotting of types store before every unification pass
2. To fix polluting the types store caused by ^, refactor `unify` to never early merge
3. Remove unsound merging when backing nominal types where `.err`. Unify now propagates the error in this case, rather than promoting the non-err
4. Remove `Mark`s from type descriptors

Re: 1 & 2:
* Snapshotting is very expensive (have to snapshot eagerly)
* In Elm unification, there's no snapshotting
* In the Roc Rust unification, there's only snapshotting when unifying lambda-sets (which Zig compiler does not do)
* In the Zig compiler, it was only added because a "early merge" pattern was added to unification when the occurs check was extracted
* This caused polluting of types that failed unification part-way
* By implementing a  `visited_vars` list recursion check, we can get rid of the "early merge" pattern, making snapshotting unnecessary

Re: 4:
* I've wanted to get rid of Marks for a while
* **Rational**: Marks are not used after type checking. But if we store them on the type descriptor, then that memory has to sit, unused, then entire duration of the complication process after type checking. But, if we smartly allocation and de-allocate memory to do the jobs of mark during type-checking, after that phase is done, we can deinit that memory immediately.
* The traditional places they're used are: let-polymorphism, recursion guarding (occurs), and generating var names
* For each of theses, they were originally implemented without using `Mark` (occurs was refactored to use Marks, this PR reverts it backs)
* All tests pass and no snapshots changed, and we have save 4 bytes on every type descriptor!