### PR TITLE
WIP: Fix type generalization for polymorphic recursive nominal types (issue #9053)

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -535,6 +535,10 @@ fn instantiateVarWithSubs(
 
         .current_rank = env.rank(),
         .rigid_behavior = .{ .substitute_rigids = subs },
+        // When substituting rigids, we need to traverse all vars regardless of rank.
+        // Type declarations have vars at rank 0/1 (not generalized), but we still
+        // need to substitute rigids inside them to get proper type instantiation.
+        .rank_behavior = .ignore_rank,
     };
     return self.instantiateVarHelp(var_to_instantiate, &instantiate_ctx, env, region_behavior);
 }

--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -81,6 +81,11 @@ pub const io_spec_tests = [_]TestSpec{
         .io_spec = "1>test",
         .description = "Platform-exposed opaque types in type annotations (issue #9034)",
     },
+    .{
+        .roc_file = "test/fx/issue9053.roc",
+        .io_spec = "1>hello",
+        .description = "Polymorphic recursive opaque types with unannotated inner functions (issue #9053)",
+    },
 
     // Language feature tests
     .{

--- a/test/fx/issue9053.roc
+++ b/test/fx/issue9053.roc
@@ -1,0 +1,28 @@
+app [main!] { pf: platform "platform/main.roc" }
+
+import pf.Stdout
+
+Node(a) := [One(a), Many(List(Node(a)))]
+
+flatten : List(Node(a)) -> List(a)
+flatten = |input| {
+    # Unannotated inner function - this triggers the stack overflow in issue #9053
+    flatten_aux = |l, acc| {
+        match l {
+            [] => acc
+            [One(e), .. as rest] => flatten_aux(rest, List.append(acc, e))
+            [Many(e), .. as rest] => flatten_aux(rest, flatten_aux(e, acc))
+        }
+    }
+    flatten_aux(input, [])
+}
+
+main! = || {
+    Stdout.line!("hello")
+}
+
+expect {
+    input : List(Node(Str))
+    input = [One("a")]
+    flatten(input) == ["a"]
+}


### PR DESCRIPTION
## Summary
- Adds a test case reproducing issue #9053 (stack overflow with recursive nominal types)
- Partial fix: use `.ignore_rank` during rigid substitution instantiation

## Investigation Notes

The bug occurs when:
1. A function has a polymorphic type annotation with a recursive nominal type (e.g., `flatten : List(Node(a)) -> List(a)`)
2. The nominal type has a type parameter that appears in the backing type (e.g., `Node(a) := [One(a), Many(List(Node(a)))]`)
3. The function contains an unannotated inner function that uses the recursive type

### Root Cause Analysis

When processing the type annotation `List(Node(a)) -> List(a)`, we need to instantiate the `Node` type declaration with the annotation's type variable `a`. This is done via `instantiateVarWithSubs`.

The problem: the type declaration's vars are at rank 0/1 (outermost), while the annotation's vars should be at rank 2 (inside the lambda scope for generalization). During instantiation:

1. We substitute rigids (like `a`) with the annotation's vars at rank 2 ✓
2. We create fresh vars for structures at `current_rank` (should be rank 2) ✓
3. But something is causing vars to escape at rank 1 during generalization ✗

The `.ignore_rank` fix ensures we traverse all vars regardless of rank during substitution, which is necessary but not sufficient.

### Next Steps

The complete fix likely needs to ensure that:
1. All freshly created vars during instantiation have the correct rank (annotation's scope rank)
2. The recursive references within the nominal type's backing type are properly tied to the outer instantiation

This is a complex type system issue that may require deeper changes to the instantiation or generalization logic.

## Test plan
- [ ] `zig build test` passes
- [ ] The test file `test/fx/issue9053.roc` compiles without type errors
- [ ] `roc test test/fx/issue9053.roc` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)