### PR TITLE
Fix hosted effects on opaque types with data in interpreter

### DIFF
--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -304,6 +304,11 @@ pub const io_spec_tests = [_]TestSpec{
         .io_spec = "1>Direct: False|1>Via pure/run: False",
         .description = "Regression test: Bool.False inspected via opaque type extraction shows correct value (issue #9049)",
     },
+    .{
+        .roc_file = "test/fx/hosted_effect_opaque_with_data.roc",
+        .io_spec = "1>Hello, World!",
+        .description = "Regression test: Hosted effects on opaque types with data (not just [])",
+    },
 };
 
 /// Get the total number of IO spec tests

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -18359,6 +18359,35 @@ pub const Interpreter = struct {
                     return true;
                 }
 
+                // Check if hosted lambda (platform-provided function)
+                if (lambda_expr == .e_hosted_lambda) {
+                    const hosted = lambda_expr.e_hosted_lambda;
+
+                    // Build args array: receiver + explicit args
+                    var all_args = try self.allocator.alloc(StackValue, 1 + total_args);
+                    defer self.allocator.free(all_args);
+                    all_args[0] = receiver_value;
+                    for (arg_values, 0..) |arg, idx| {
+                        all_args[1 + idx] = arg;
+                    }
+
+                    // Get the return type from the call site
+                    const return_ct_var = can.ModuleEnv.varFrom(dac.expr_idx);
+                    const return_rt_var = try self.translateTypeVar(saved_env, return_ct_var);
+
+                    const result = try self.callHostedFunction(hosted.index, all_args, roc_ops, return_rt_var);
+
+                    // Decref all arguments (hosted functions borrow their arguments)
+                    for (all_args) |arg| {
+                        arg.decref(&self.runtime_layout_store, roc_ops);
+                    }
+
+                    method_func.decref(&self.runtime_layout_store, roc_ops);
+                    self.env = saved_env;
+                    try value_stack.push(result);
+                    return true;
+                }
+
                 // Regular closure invocation
                 const params = self.env.store.slicePatterns(closure_header.params);
                 const expected_params = 1 + total_args;

--- a/test/fx/hosted_effect_opaque_with_data.roc
+++ b/test/fx/hosted_effect_opaque_with_data.roc
@@ -1,0 +1,19 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+import pf.Host
+
+## Test that hosted effects work on opaque types with data.
+## This is a regression test for a bug where hosted effects on opaque types
+## with actual data (not just []) would crash with:
+## "Roc crashed: Hosted functions cannot be called in the interpreter"
+main! = || {
+    # Create a Host with data using the factory function
+    host = Host.new("World")
+
+    # Call the hosted effect method on the opaque type with data
+    greeting = host.get_greeting!()
+
+    # Print the result
+    Stdout.line!(greeting)
+}

--- a/test/fx/platform/Host.roc
+++ b/test/fx/platform/Host.roc
@@ -1,0 +1,15 @@
+## Host module with an opaque nominal type containing data and hosted effects.
+Host :: {
+    name : Str,
+}.{
+    ## Create a new Host with the given name
+    new : Str -> Host
+    new = |n| { name: n }
+
+    ## Get the host's name (pure method for testing)
+    get_name : Host -> Str
+    get_name = |host| host.name
+
+    ## Get a greeting - this is a hosted effect that takes Host as first argument
+    get_greeting! : Host => Str
+}

--- a/test/fx/platform/main.roc
+++ b/test/fx/platform/main.roc
@@ -2,7 +2,7 @@ platform ""
     requires {
         main! : () => {}
     }
-    exposes [Stdout, Stderr, Stdin, Builder]
+    exposes [Stdout, Stderr, Stdin, Builder, Host]
     packages {}
     provides { main_for_host!: "main" }
     targets: {
@@ -21,6 +21,7 @@ import Stdout
 import Stderr
 import Stdin
 import Builder
+import Host
 
 main_for_host! : () => {}
 main_for_host! = main!


### PR DESCRIPTION
## Summary

- Fixes a bug where hosted effect methods on opaque types with actual data (not just `[]`) would crash with "Hosted functions cannot be called in the interpreter"
- The bug was in the `dot_access_collect_args` continuation in the interpreter - it checked for `e_low_level_lambda` but not for `e_hosted_lambda`
- Adds regression test with a `Host` opaque type containing data and a `get_greeting!` hosted effect method

🤖 Generated with [Claude Code](https://claude.com/claude-code)