### PR TITLE
Fix wildcard match on open tag unions returning wrong values

### DIFF
--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -298,6 +298,22 @@ test "fx platform match with wildcard" {
     try checkTestSuccess(result);
 }
 
+test "fx platform wildcard match on open union" {
+    // Tests that wildcard patterns on open tag unions work correctly.
+    // Bug: When error propagates through open tag unions [Exit(I64), ..],
+    // Err(_) wildcard match was returning 0 instead of the expected value 42.
+    const allocator = testing.allocator;
+
+    const run_result = try runRoc(allocator, "test/fx/wildcard_match_open_union_bug.roc", .{});
+    defer allocator.free(run_result.stdout);
+    defer allocator.free(run_result.stderr);
+
+    try checkSuccess(run_result);
+
+    // Verify that the wildcard match worked correctly
+    try testing.expect(std.mem.indexOf(u8, run_result.stdout, "PASS: Wildcard match worked correctly") != null);
+}
+
 test "fx platform dbg missing return value" {
     const allocator = testing.allocator;
 

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -7257,24 +7257,37 @@ pub const Interpreter = struct {
                 // (there's only one possible tag), so we can safely use index 0.
                 // For multi-variant unions with out-of-range discriminants, return an error.
                 if (tag_index >= layout_variants.len) {
-                    if (layout_variants.len == 1) {
-                        // Single-variant union: discriminant is irrelevant, use index 0
-                        // This handles the case where the value was created with a narrower
-                        // type that has only one variant, even if the discriminant memory
-                        // contains uninitialized/garbage data.
+                    // The discriminant is out of range for this layout's variant count.
+                    // This typically means the value was created with a wider type (more variants)
+                    // than the current expected type. Return the actual discriminant so the caller
+                    // (pattern matching) can correctly determine this value doesn't match.
+                    //
+                    // For example: if the value is NotFound (discriminant 1) and the expected
+                    // type only has Exit (1 variant with index 0), returning the actual
+                    // discriminant 1 allows pattern matching to correctly fail when trying
+                    // to match Exit against NotFound.
+                    //
+                    // We use variant 0's layout as a placeholder for memory shape, but preserve
+                    // original_tu_layout_idx so that refcounting uses the correct original layout
+                    // to properly incref/decref the actual payload.
+                    if (layout_variants.len >= 1) {
                         const payload_layout = acc.getVariantLayout(0);
+                        // Preserve original tag union layout: use existing original if present,
+                        // otherwise capture current layout's tag union index
+                        const orig_tu_idx = value.original_tu_layout_idx orelse value.layout.data.tag_union.idx;
                         if (payload_layout.tag != .zst) {
                             return .{
-                                .index = 0,
+                                .index = tag_index, // Return actual discriminant, not 0
                                 .payload = StackValue{
                                     .layout = payload_layout,
                                     .ptr = value.ptr,
                                     .is_initialized = true,
                                     .rt_var = value.rt_var,
+                                    .original_tu_layout_idx = orig_tu_idx,
                                 },
                             };
                         } else {
-                            return .{ .index = 0, .payload = null };
+                            return .{ .index = tag_index, .payload = null }; // Return actual discriminant
                         }
                     }
                     return error.TypeMismatch;
@@ -7302,6 +7315,7 @@ pub const Interpreter = struct {
                             .ptr = value.ptr,
                             .is_initialized = true,
                             .rt_var = value.rt_var,
+                            .original_tu_layout_idx = value.original_tu_layout_idx,
                         };
                     } else {
                         payload_value = null;
@@ -7317,6 +7331,7 @@ pub const Interpreter = struct {
                         .ptr = value.ptr,
                         .is_initialized = true,
                         .rt_var = arg_var,
+                        .original_tu_layout_idx = value.original_tu_layout_idx,
                     };
                 } else {
                     // Multiple args: the payload is a tuple at offset 0
@@ -7328,6 +7343,7 @@ pub const Interpreter = struct {
                         .ptr = value.ptr,
                         .is_initialized = true,
                         .rt_var = value.rt_var,
+                        .original_tu_layout_idx = value.original_tu_layout_idx,
                     };
                 }
 
@@ -7360,11 +7376,13 @@ pub const Interpreter = struct {
                 const data_ptr: *anyopaque = @ptrCast(value.getBoxedData().?);
 
                 // Create an unboxed value and recursively extract tag
+                // Propagate original_tu_layout_idx through box unwrapping
                 const unboxed = StackValue{
                     .layout = elem_layout,
                     .ptr = data_ptr,
                     .is_initialized = true,
                     .rt_var = elem_rt_var,
+                    .original_tu_layout_idx = value.original_tu_layout_idx,
                 };
 
                 return self.extractTagValue(unboxed, elem_rt_var);

--- a/test/fx/wildcard_match_open_union_bug.roc
+++ b/test/fx/wildcard_match_open_union_bug.roc
@@ -1,0 +1,53 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+## Test wildcard match on open tag union errors
+## Bug: When error propagates through open tag unions,
+## Err(_) wildcard match produces zero instead of the expected value
+
+# Simulates a hosted effect that returns Try with open error type
+read_something! : {} => Try(Str, [NotFound, ..])
+read_something! = |{}| Err(NotFound)
+
+# Simulates an init function with its own error types plus open extension
+# This is like: init! : Host => Try(Model, [Exit(I64), ..])
+# When read_something! fails with NotFound, it propagates through the ".."
+do_init! : {} => Try(Str, [Exit(I64), ..])
+do_init! = |{}| {
+    # This should propagate NotFound through the ".." in our error type
+    result = read_something!({})?
+    Ok(result)
+}
+
+# Platform converts open error to fixed type - this is where the bug appears
+# When error is Exit(code), extract code; otherwise use wildcard for any other error
+wrap_init! : {} => Try(Str, I64)
+wrap_init! = |{}| {
+    match do_init!({}) {
+        Ok(s) => Ok(s)
+        Err(Exit(code)) => Err(code)
+        Err(_) => Err(42)  # BUG: This should return 42 but may return 0
+    }
+}
+
+main! = || {
+    # This will cause NotFound to propagate through ".." and hit the Err(_) branch
+    result = wrap_init!({})
+
+    code = match result {
+        Ok(_) => 999
+        Err(c) => c
+    }
+
+    # Should print 42 (the wildcard match result), but bug causes 0
+    Stdout.line!("Error code: ${Str.inspect(code)}")
+
+    if code == 42 {
+        Stdout.line!("PASS: Wildcard match worked correctly")
+    } else if code == 0 {
+        Stdout.line!("FAIL: Bug reproduced - got 0 instead of 42")
+    } else {
+        Stdout.line!("UNEXPECTED: Got ${Str.inspect(code)}")
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes a bug where wildcard pattern matching on open tag unions (`[Exit(I64), ..]`) returned incorrect values
- When an error propagates through an open union extension (`..`) and hits a wildcard match (`Err(_)`), the interpreter was incorrectly matching against the wrong variant

## Problem

When a tag union value crosses the platform-app boundary with an open union type, the discriminant may be out of range for the narrowed layout. The old code used "variant 0 as fallback" for refcounting, which could cause:
- Incorrect pattern matching (returning 0 instead of the expected value like 42)
- Memory leaks if actual payload has refcounted fields the fallback layout doesn't know about
- Memory corruption if actual payload is interpreted with wrong layout

## Solution

Added an `original_tu_layout_idx` field to `StackValue` that preserves the original tag union layout index when a value is accessed through a narrower type. Refcounting functions use this original layout when the discriminant is out of range for the current layout.

Key changes:
- `src/eval/StackValue.zig`: Added `original_tu_layout_idx` field and updated `increfLayoutPtr`, `decrefLayoutPtr`, `copyToPtr`, `incref`, and `decref` to use the original layout when discriminant is out of range
- `src/eval/interpreter.zig`: Updated `extractTagValue` to preserve/propagate the original tag union layout index

## Test plan

- [x] Added `test/fx/wildcard_match_open_union_bug.roc` test case
- [x] `zig build minici` passes
- [x] Verified fix with roc-ray `read_env.roc` example (returns exit code 42 instead of 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)