### PR TITLE
Fix panic when tuple access is applied to non-tuple value

### DIFF
--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -14997,6 +14997,11 @@ pub const Interpreter = struct {
                 const tuple_val = value_stack.pop() orelse return error.Crash;
                 defer tuple_val.decref(&self.runtime_layout_store, roc_ops);
 
+                // Verify the value is actually a tuple
+                if (tuple_val.layout.tag != .tuple) {
+                    return error.TypeMismatch;
+                }
+
                 // Get tuple accessor
                 var accessor = try tuple_val.asTuple(&self.runtime_layout_store);
 


### PR DESCRIPTION
## Summary

- Fix assertion failure / panic when the interpreter tries to apply tuple access (`.0`, `.1`, etc.) to a non-tuple value
- Now returns `TypeMismatch` error instead of crashing, allowing proper error reporting

## Reproduction

```bash
zig build repro-canonicalize -- -b eD0wLjAuMA== -v
```

The input `x=0.0.0` (base64: `eD0wLjAuMA==`) was being parsed as `x = (0.0).0` - accessing tuple element 0 on a float literal. The interpreter assumed the value was a tuple and crashed on the assertion in `asTuple()`.

## Test plan

- [x] Verified the reproduction case no longer panics
- [x] All 2612 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)