### PR TITLE
Fix segfault when pattern matching on opaque types from lists

### DIFF
--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -309,6 +309,16 @@ pub const io_spec_tests = [_]TestSpec{
         .io_spec = "1>Hello, World!",
         .description = "Regression test: Hosted effects on opaque types with data (not just [])",
     },
+    .{
+        .roc_file = "test/fx/issue9113_simple.roc",
+        .io_spec = "1>Test: SimpleElement with Leaf in list|1>Container branch|1>  iterating child|1>Leaf branch|1>Done!",
+        .description = "Regression test: Recursive opaque types with list element layout mismatch (issue #9113)",
+    },
+    .{
+        .roc_file = "test/fx/list_opaque_pattern_match_bug.roc",
+        .io_spec = "1>Test 1: Text elements in list (should work)|1>Div branch|1>  iterating child|1>Text branch: Hello|1>  iterating child|1>Text branch: World|1>|1>Test 2: Label element with opaque payload in list|1>Div branch|1>  iterating child|1>Label branch|1>Done!",
+        .description = "Regression test: Nested opaque types in lists (issue #9113 related)",
+    },
 };
 
 /// Get the total number of IO spec tests

--- a/test/fx/issue9113_simple.roc
+++ b/test/fx/issue9113_simple.roc
@@ -1,0 +1,12 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+import pf.SimpleElement
+
+main! = || {
+    Stdout.line!("Test: SimpleElement with Leaf in list")
+    leaf_elem = SimpleElement.leaf("test")
+    container_elem = SimpleElement.container([leaf_elem])
+    SimpleElement.process!(container_elem)
+    Stdout.line!("Done!")
+}

--- a/test/fx/list_opaque_pattern_match_bug.roc
+++ b/test/fx/list_opaque_pattern_match_bug.roc
@@ -1,0 +1,26 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+import pf.NodeA
+import pf.NodeB
+import pf.Element
+
+main! = || {
+    Stdout.line!("Test 1: Text elements in list (should work)")
+    text_elem = Element.div([
+        Element.text("Hello"),
+        Element.text("World"),
+    ])
+    Element.process!(text_elem)
+
+    Stdout.line!("")
+    Stdout.line!("Test 2: Label element with opaque payload in list")
+    event = NodeA.source({})
+    signal = NodeB.fold("initial", event)
+    label_elem = Element.div([
+        Element.label(signal),
+    ])
+    Element.process!(label_elem)
+
+    Stdout.line!("Done!")
+}

--- a/test/fx/platform/Element.roc
+++ b/test/fx/platform/Element.roc
@@ -1,0 +1,36 @@
+import NodeB exposing [NodeB]
+import Stdout
+
+Element := [
+    Div(List(Element)),
+    Label(NodeB),
+    Text(Str),
+].{
+    div : List(Element) -> Element
+    div = |children| Div(children)
+
+    label : NodeB -> Element
+    label = |node| Label(node)
+
+    text : Str -> Element
+    text = |s| Text(s)
+
+    process! : Element => {}
+    process! = |elem| {
+        match elem {
+            Div(children) => {
+                Stdout.line!("Div branch")
+                List.for_each!(children, |child| {
+                    Stdout.line!("  iterating child")
+                    Element.process!(child)
+                })
+            }
+            Label(_node) => {
+                Stdout.line!("Label branch")
+            }
+            Text(s) => {
+                Stdout.line!("Text branch: ${s}")
+            }
+        }
+    }
+}

--- a/test/fx/platform/NodeA.roc
+++ b/test/fx/platform/NodeA.roc
@@ -1,0 +1,7 @@
+NodeA := [
+    SourceA,
+    MappedA({ source : NodeA }),
+].{
+    source : {} -> NodeA
+    source = |{}| SourceA
+}

--- a/test/fx/platform/NodeB.roc
+++ b/test/fx/platform/NodeB.roc
@@ -1,0 +1,12 @@
+import NodeA exposing [NodeA]
+
+NodeB := [
+    ConstB(Str),
+    FoldB({ initial : Str, event : NodeA }),
+].{
+    const : Str -> NodeB
+    const = |s| ConstB(s)
+
+    fold : Str, NodeA -> NodeB
+    fold = |initial, event| FoldB({ initial, event })
+}

--- a/test/fx/platform/SimpleElement.roc
+++ b/test/fx/platform/SimpleElement.roc
@@ -1,0 +1,35 @@
+import Stdout
+
+SimpleElement := [
+    Container(List(SimpleElement)),
+    Leaf({ value : Str }),
+    Text(Str),
+].{
+    container : List(SimpleElement) -> SimpleElement
+    container = |children| Container(children)
+
+    leaf : Str -> SimpleElement
+    leaf = |s| Leaf({ value: s })
+
+    text : Str -> SimpleElement
+    text = |s| Text(s)
+
+    process! : SimpleElement => {}
+    process! = |elem| {
+        match elem {
+            Container(children) => {
+                Stdout.line!("Container branch")
+                List.for_each!(children, |child| {
+                    Stdout.line!("  iterating child")
+                    SimpleElement.process!(child)
+                })
+            }
+            Leaf(_payload) => {
+                Stdout.line!("Leaf branch")
+            }
+            Text(s) => {
+                Stdout.line!("Text branch: ${s}")
+            }
+        }
+    }
+}

--- a/test/fx/platform/main.roc
+++ b/test/fx/platform/main.roc
@@ -2,7 +2,7 @@ platform ""
     requires {
         main! : () => {}
     }
-    exposes [Stdout, Stderr, Stdin, Builder, Host]
+    exposes [Stdout, Stderr, Stdin, Builder, Host, SimpleElement, NodeA, NodeB, Element]
     packages {}
     provides { main_for_host!: "main" }
     targets: {
@@ -22,6 +22,10 @@ import Stderr
 import Stdin
 import Builder
 import Host
+import SimpleElement
+import NodeA
+import NodeB
+import Element
 
 main_for_host! : () => {}
 main_for_host! = main!


### PR DESCRIPTION
## Summary
Fix segfault (issue #9113) when pattern matching on recursive opaque types extracted from lists. This PR addresses two related issues:

### 1. List element re-boxing (original fix)
When a recursive opaque type (like `Element`) is stored in a list, elements are auto-boxed for uniform size. When these elements are later used as tag union payloads, the code now correctly re-boxes them to match the expected layout.

### 2. Incorrect auto-boxing in record_collect (new fix)
The `record_collect` continuation was incorrectly auto-boxing fields based on whether the field's type is self-recursive. This caused layout mismatches when a separate recursive type (like `NodeA`) was used in a different type's record field (like `NodeB`'s `FoldB` payload).

The fix removes this incorrect auto-boxing. The type-based layout is the source of truth:
- When a type references itself (`Type := [Node({ child: Type })]`), the layout system correctly creates `Box(Type)` during layout computation.
- When a separate recursive type is used (`{ event: NodeA }`), it should NOT be boxed because `NodeA` is already a complete type.

## Changes
1. **List re-boxing in tag_collect**: When storing a list as a tag variant payload, if the expected element layout is `box` but the actual list has non-boxed elements, re-box each element
2. **Remove incorrect auto-boxing in record_collect**: Removed the logic that auto-boxed all self-recursive tag unions in record fields, which caused layout mismatches with the type-based layout
3. **Dynamic discriminant offset**: Use dynamic computation instead of stored value for recursive types

## Test plan
- [x] Added regression test `test/fx/issue9113_simple.roc` (tests list re-boxing)
- [x] Added regression test `test/fx/list_opaque_pattern_match_bug.roc` (tests nested opaque types)
- [x] All unit tests pass
- [x] `zig build minici` passes

Fixes #9113

🤖 Generated with [Claude Code](https://claude.com/claude-code)