### PR TITLE
Fix segfault when ? operator used on non-Try type

### DIFF
--- a/test/fx/for_var_in_type_method.roc
+++ b/test/fx/for_var_in_type_method.roc
@@ -1,0 +1,21 @@
+# Bug #9118: segfault when ? operator is used on tuple in type method
+# Minimal reproduction
+
+Value := [VAtom(Str), ..].{
+    parse : Str -> Try(Value, Str)
+    parse = |s| {
+        (token, _) = make_value(s)?
+        Ok(token)
+    }
+}
+
+make_value : Str -> (Value, [Ok, Err(Str)])
+make_value = |s| (VAtom(s), Ok)
+
+expect {
+    result = Value.parse("hello")
+    match result {
+        Ok(VAtom("hello")) => Bool.True
+        _ => Bool.False
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #9118

The interpreter crashed with a segfault when the `?` operator was used on a tuple instead of a Try type. This happened because:

1. The `?` operator desugars to a match with `Ok`/`Err` patterns
2. When given a tuple like `(Value, [Ok, Err(Str)])` instead of a Try type `[Ok(Value), Err(Str)]`, neither pattern matches
3. The interpreter hit `unreachable` instead of reporting an error

## Changes

- Replace `unreachable` with `triggerCrash` in the match continuation handlers (`match_branches` and `match_guard`)
- Provide context-aware error messages:
  - For `?` operator: "The ? operator was used on a value that is not a Try type..."
  - For regular matches: "Match expression was not exhaustive..."
- Add regression test that verifies the type error is reported without crashing

## Test plan

- [x] `zig build minici` passes
- [x] `roc test test/fx/for_var_in_type_method.roc` reports TYPE MISMATCH error without segfaulting
- [x] New regression test in `fx_platform_test.zig` verifies the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)