### PR TITLE
Expand language reference and fix Numeral.digits_after_pt

### DIFF
--- a/docs/langref/if-else.md
+++ b/docs/langref/if-else.md
@@ -1,0 +1,56 @@
+# `if` / `else`
+
+Like most language, Roc has ways to run either one code pathway or another depending on a runtime value.
+
+## `if`
+
+Roc's `if` keyword is syntax sugar for [`match`](pattern-matching#match). This code:
+
+```roc
+if foo {
+    bar()
+} else {
+    baz()
+}
+```
+
+Does the exact same thing as this code:
+
+```roc
+match foo {
+    True => bar()
+    False => baz()
+}
+```
+
+## `else if`
+
+## `if` without `else`
+
+## `and` / `or`
+
+The keywords `and` and `or` perform [short-circuiting evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation) by desugaring to `if`:
+
+```roc
+a() or b()
+```
+
+...desugars to:
+
+```roc
+if a() True else b()
+```
+
+Similarly:
+
+```roc
+a() and b()
+```
+
+...desugars to:
+
+```roc
+if a() b() else False
+```
+
+The desugared versions compile to the same machine instructions as the operator versions, even in debug builds.


### PR DESCRIPTION
## Summary
- Add `builtin-numbers.md` and `custom-numbers.md` to the language reference with detailed docs on number types, custom number types, and numeral suffixes
- Fix type annotation bug in `Builtin.roc`: `digits_before_pt` → `digits_after_pt` on the `digits_after_pt` method
- Add Ratio custom number type test based on the langref example
- WIP fix for type generalization with polymorphic recursive nominal types (issue #9053)

## Test plan
- [ ] Verify `custom_num_type_test.zig` Ratio test passes
- [ ] Verify existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)