### PR TITLE
Unify canonicalization API with *Allocators parameter

### DIFF
--- a/src/build/builtin_compiler/main.zig
+++ b/src/build/builtin_compiler/main.zig
@@ -1628,7 +1628,7 @@ fn compileModule(
     }
 
     // When compiling Builtin itself, pass null for module_envs so setupAutoImportedBuiltinTypes doesn't run
-    can_result.* = try Can.init(module_env, parse_ast, null);
+    can_result.* = try Can.init(&allocators, module_env, parse_ast, null);
 
     try can_result.canonicalizeFile();
     try can_result.validateForChecking();

--- a/src/canonicalize/mod.zig
+++ b/src/canonicalize/mod.zig
@@ -1,6 +1,12 @@
 //! This module contains the canonicalizer and the Canonical Intermediate Representation (CIR).
 
 const std = @import("std");
+const base = @import("base");
+const parse = @import("parse");
+
+const Allocators = base.Allocators;
+const Ident = base.Ident;
+const AST = parse.AST;
 
 /// The canonicalizer (the thing that canonicalizes the AST).
 pub const Can = @import("Can.zig");
@@ -20,6 +26,58 @@ pub const RocEmitter = @import("RocEmitter.zig");
 pub const Monomorphizer = @import("Monomorphizer.zig");
 /// Closure Transformer - transforms closures with captures into tagged values
 pub const ClosureTransformer = @import("ClosureTransformer.zig");
+
+/// Re-export AutoImportedType for callers
+pub const AutoImportedType = Can.AutoImportedType;
+
+/// Canonicalize a full module file.
+///
+/// This is the unified entry point for module canonicalization. It:
+/// 1. Initializes the canonicalizer
+/// 2. Canonicalizes the entire file
+/// 3. Validates the result for type checking
+/// 4. Cleans up canonicalizer resources
+///
+/// Results are stored in module_env (all_defs, all_statements, diagnostics, etc).
+///
+/// Memory ownership:
+/// - allocators: Caller provides and manages
+/// - module_env: Caller provides; results stored here
+/// - parse_ast: Caller provides and manages
+/// - module_envs: Optional map of imported module environments
+pub fn canonicalizeModule(
+    allocators: *Allocators,
+    module_env: *ModuleEnv,
+    parse_ast: *AST,
+    module_envs: ?*const std.AutoHashMap(Ident.Idx, AutoImportedType),
+) std.mem.Allocator.Error!void {
+    var czer = try Can.init(allocators, module_env, parse_ast, module_envs);
+    defer czer.deinit();
+    try czer.canonicalizeFile();
+    try czer.validateForChecking();
+}
+
+/// Canonicalize a single expression (for REPL).
+///
+/// Returns the canonical expression result, or null if canonicalization failed.
+/// Check module_env.getDiagnostics() for any errors.
+///
+/// Memory ownership:
+/// - allocators: Caller provides and manages
+/// - module_env: Caller provides; results stored here
+/// - parse_ast: Caller provides (root_node_idx should point to expression)
+/// - module_envs: Optional map of imported module environments
+pub fn canonicalizeExpr(
+    allocators: *Allocators,
+    module_env: *ModuleEnv,
+    parse_ast: *AST,
+    module_envs: ?*const std.AutoHashMap(Ident.Idx, AutoImportedType),
+) std.mem.Allocator.Error!?Can.CanonicalizedExpr {
+    var czer = try Can.init(allocators, module_env, parse_ast, module_envs);
+    defer czer.deinit();
+    const expr_idx: AST.Expr.Idx = @enumFromInt(parse_ast.root_node_idx);
+    return try czer.canonicalizeExpr(expr_idx);
+}
 
 test "compile tests" {
     std.testing.refAllDecls(@This());

--- a/src/canonicalize/test/TestEnv.zig
+++ b/src/canonicalize/test/TestEnv.zig
@@ -49,7 +49,7 @@ pub fn init(source: []const u8) !TestEnv {
 
     try module_env.initCIRFields("test");
 
-    can.* = try Can.init(module_env, parse_ast, null);
+    can.* = try Can.init(&allocators, module_env, parse_ast, null);
 
     return TestEnv{
         .gpa = gpa,

--- a/src/canonicalize/test/exposed_shadowing_test.zig
+++ b/src/canonicalize/test/exposed_shadowing_test.zig
@@ -34,7 +34,7 @@ test "exposed but not implemented - values" {
     const ast = try parse.parse(&allocators, &env.common);
     defer ast.deinit();
 
-    var czer = try Can.init(&env, ast, null);
+    var czer = try Can.init(&allocators, &env, ast, null);
     defer czer.deinit();
 
     try czer.canonicalizeFile();
@@ -77,7 +77,7 @@ test "exposed but not implemented - types" {
     const ast = try parse.parse(&allocators, &env.common);
     defer ast.deinit();
 
-    var czer = try Can.init(&env, ast, null);
+    var czer = try Can.init(&allocators, &env, ast, null);
     defer czer.deinit();
 
     try czer.canonicalizeFile();
@@ -119,7 +119,7 @@ test "redundant exposed entries" {
     const ast = try parse.parse(&allocators, &env.common);
     defer ast.deinit();
 
-    var czer = try Can.init(&env, ast, null);
+    var czer = try Can.init(&allocators, &env, ast, null);
     defer czer.deinit();
     try czer
         .canonicalizeFile();
@@ -166,7 +166,7 @@ test "shadowing with exposed items" {
     const ast = try parse.parse(&allocators, &env.common);
     defer ast.deinit();
 
-    var czer = try Can.init(&env, ast, null);
+    var czer = try Can.init(&allocators, &env, ast, null);
     defer czer.deinit();
     try czer
         .canonicalizeFile();
@@ -203,7 +203,7 @@ test "shadowing non-exposed items" {
     const ast = try parse.parse(&allocators, &env.common);
     defer ast.deinit();
 
-    var czer = try Can.init(&env, ast, null);
+    var czer = try Can.init(&allocators, &env, ast, null);
     defer czer.deinit();
     try czer
         .canonicalizeFile();
@@ -247,7 +247,7 @@ test "exposed items correctly tracked across shadowing" {
     const ast = try parse.parse(&allocators, &env.common);
     defer ast.deinit();
 
-    var czer = try Can.init(&env, ast, null);
+    var czer = try Can.init(&allocators, &env, ast, null);
     defer czer.deinit();
     try czer
         .canonicalizeFile();
@@ -307,7 +307,7 @@ test "complex case with redundant, shadowing, and not implemented" {
     const ast = try parse.parse(&allocators, &env.common);
     defer ast.deinit();
 
-    var czer = try Can.init(&env, ast, null);
+    var czer = try Can.init(&allocators, &env, ast, null);
     defer czer.deinit();
     try czer
         .canonicalizeFile();
@@ -363,7 +363,7 @@ test "exposed_items is populated correctly" {
     const ast = try parse.parse(&allocators, &env.common);
     defer ast.deinit();
 
-    var czer = try Can.init(&env, ast, null);
+    var czer = try Can.init(&allocators, &env, ast, null);
     defer czer.deinit();
     try czer
         .canonicalizeFile();
@@ -399,7 +399,7 @@ test "exposed_items persists after canonicalization" {
     const ast = try parse.parse(&allocators, &env.common);
     defer ast.deinit();
 
-    var czer = try Can.init(&env, ast, null);
+    var czer = try Can.init(&allocators, &env, ast, null);
     defer czer.deinit();
     try czer
         .canonicalizeFile();
@@ -433,7 +433,7 @@ test "exposed_items never has entries removed" {
     const ast = try parse.parse(&allocators, &env.common);
     defer ast.deinit();
 
-    var czer = try Can.init(&env, ast, null);
+    var czer = try Can.init(&allocators, &env, ast, null);
     defer czer.deinit();
     try czer
         .canonicalizeFile();
@@ -470,7 +470,7 @@ test "exposed_items handles identifiers with different attributes" {
     const ast = try parse.parse(&allocators, &env.common);
     defer ast.deinit();
 
-    var czer = try Can.init(&env, ast, null);
+    var czer = try Can.init(&allocators, &env, ast, null);
     defer czer.deinit();
     try czer
         .canonicalizeFile();

--- a/src/canonicalize/test/import_validation_test.zig
+++ b/src/canonicalize/test/import_validation_test.zig
@@ -42,7 +42,7 @@ fn parseAndCanonicalizeSource(
     try parse_env.initCIRFields("Test");
 
     const can = try allocator.create(Can);
-    can.* = try Can.init(parse_env, ast, module_envs);
+    can.* = try Can.init(&allocators, parse_env, ast, module_envs);
 
     return .{
         .parse_env = parse_env,
@@ -134,7 +134,7 @@ test "import validation - mix of MODULE NOT FOUND, TYPE NOT EXPOSED, VALUE NOT E
     try module_envs.put(utils_module_ident, .{ .env = utils_env, .qualified_type_ident = utils_qualified_ident });
 
     // Canonicalize with module validation
-    var can = try Can.init(parse_env, ast, &module_envs);
+    var can = try Can.init(&allocators, parse_env, ast, &module_envs);
     defer can.deinit();
     _ = try can.canonicalizeFile();
     // Collect all diagnostics
@@ -211,9 +211,8 @@ test "import validation - no module_envs provided" {
     defer ast.deinit();
     // Initialize CIR fields
     try parse_env.initCIRFields("Test");
-    // Create czer
-    //  with null module_envs
-    var can = try Can.init(parse_env, ast, null);
+    // Create czer with null module_envs
+    var can = try Can.init(&allocators, parse_env, ast, null);
     defer can.deinit();
     _ = try can.canonicalizeFile();
     const diagnostics = try parse_env.getDiagnostics();

--- a/src/canonicalize/test/int_test.zig
+++ b/src/canonicalize/test/int_test.zig
@@ -484,7 +484,7 @@ test "hexadecimal integer literals" {
         const ast = try parse.parseExpr(&allocators, &env.common);
         defer ast.deinit();
 
-        var czer = try Can.init(&env, ast, null);
+        var czer = try Can.init(&allocators, &env, ast, null);
         defer czer.deinit();
 
         const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
@@ -547,7 +547,7 @@ test "binary integer literals" {
         const ast = try parse.parseExpr(&allocators, &env.common);
         defer ast.deinit();
 
-        var czer = try Can.init(&env, ast, null);
+        var czer = try Can.init(&allocators, &env, ast, null);
         defer czer.deinit();
 
         const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
@@ -610,7 +610,7 @@ test "octal integer literals" {
         const ast = try parse.parseExpr(&allocators, &env.common);
         defer ast.deinit();
 
-        var czer = try Can.init(&env, ast, null);
+        var czer = try Can.init(&allocators, &env, ast, null);
         defer czer.deinit();
 
         const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
@@ -673,7 +673,7 @@ test "integer literals with uppercase base prefixes" {
         const ast = try parse.parseExpr(&allocators, &env.common);
         defer ast.deinit();
 
-        var czer = try Can.init(&env, ast, null);
+        var czer = try Can.init(&allocators, &env, ast, null);
         defer czer.deinit();
 
         const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);

--- a/src/canonicalize/test/record_test.zig
+++ b/src/canonicalize/test/record_test.zig
@@ -28,7 +28,7 @@ test "record literal uses record_unbound" {
         const ast = try parse.parseExpr(&allocators, &env.common);
         defer ast.deinit();
 
-        var can = try Can.init(&env, ast, null);
+        var can = try Can.init(&allocators, &env, ast, null);
         defer can.deinit();
 
         const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
@@ -63,7 +63,7 @@ test "record literal uses record_unbound" {
         const ast = try parse.parseExpr(&allocators, &env.common);
         defer ast.deinit();
 
-        var can = try Can.init(&env, ast, null);
+        var can = try Can.init(&allocators, &env, ast, null);
         defer can.deinit();
 
         const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
@@ -98,7 +98,7 @@ test "record literal uses record_unbound" {
         const ast = try parse.parseExpr(&allocators, &env.common);
         defer ast.deinit();
 
-        var can = try Can.init(&env, ast, null);
+        var can = try Can.init(&allocators, &env, ast, null);
         defer can.deinit();
 
         const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
@@ -143,7 +143,7 @@ test "record_unbound basic functionality" {
     const ast = try parse.parseExpr(&allocators, &env.common);
     defer ast.deinit();
 
-    var can = try Can.init(&env, ast, null);
+    var can = try Can.init(&allocators, &env, ast, null);
     defer can.deinit();
 
     const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
@@ -189,7 +189,7 @@ test "record_unbound with multiple fields" {
     const ast = try parse.parseExpr(&allocators, &env.common);
     defer ast.deinit();
 
-    var can = try Can.init(&env, ast, null);
+    var can = try Can.init(&allocators, &env, ast, null);
     defer can.deinit();
 
     const expr_idx: parse.AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
@@ -237,7 +237,7 @@ test "record pattern destructuring" {
     const ast = try parse.parseStatement(&allocators, &env.common);
     defer ast.deinit();
 
-    var can = try Can.init(&env, ast, null);
+    var can = try Can.init(&allocators, &env, ast, null);
     defer can.deinit();
 
     // Enter a function scope so we can have local bindings
@@ -314,7 +314,7 @@ test "record pattern with sub-patterns" {
     const ast = try parse.parseStatement(&allocators, &env.common);
     defer ast.deinit();
 
-    var can = try Can.init(&env, ast, null);
+    var can = try Can.init(&allocators, &env, ast, null);
     defer can.deinit();
 
     // Enter a function scope so we can have local bindings

--- a/src/canonicalize/test/scope_test.zig
+++ b/src/canonicalize/test/scope_test.zig
@@ -10,6 +10,7 @@ const Scope = @import("../Scope.zig");
 const Ident = base.Ident;
 const Pattern = CIR.Pattern;
 const TypeAnno = CIR.TypeAnno;
+const Allocators = base.Allocators;
 
 /// Context helper for Scope tests
 const ScopeTestContext = struct {
@@ -23,8 +24,12 @@ const ScopeTestContext = struct {
         module_env.* = try ModuleEnv.init(gpa, "");
         try module_env.initCIRFields("test");
 
+        var allocators: Allocators = undefined;
+        allocators.initInPlace(gpa);
+        defer allocators.deinit();
+
         return ScopeTestContext{
-            .self = try Can.init(module_env, undefined, null),
+            .self = try Can.init(&allocators, module_env, undefined, null),
             .module_env = module_env,
             .gpa = gpa,
         };

--- a/src/canonicalize/test/type_decl_stmt_test.zig
+++ b/src/canonicalize/test/type_decl_stmt_test.zig
@@ -280,7 +280,7 @@ test "scopeLookupTypeDecl API is accessible" {
     const ast = try parse.parseExpr(&allocators, &env.common);
     defer ast.deinit();
 
-    var can = try Can.init(&env, ast, null);
+    var can = try Can.init(&allocators, &env, ast, null);
     defer can.deinit();
 
     // Enter a scope
@@ -309,7 +309,7 @@ test "introduceType API is accessible" {
     const ast = try parse.parseExpr(&allocators, &env.common);
     defer ast.deinit();
 
-    var can = try Can.init(&env, ast, null);
+    var can = try Can.init(&allocators, &env, ast, null);
     defer can.deinit();
 
     // Enter a scope for local type declarations
@@ -358,7 +358,7 @@ test "local type scoping - not visible after exiting block" {
     const ast = try parse.parseExpr(&allocators, &env.common);
     defer ast.deinit();
 
-    var can = try Can.init(&env, ast, null);
+    var can = try Can.init(&allocators, &env, ast, null);
     defer can.deinit();
 
     // Enter outer scope

--- a/src/check/test/TestEnv.zig
+++ b/src/check/test/TestEnv.zig
@@ -206,7 +206,7 @@ pub fn initWithImport(module_name: []const u8, source: []const u8, other_module_
     // Canonicalize
     try module_env.initCIRFields(module_name);
 
-    can.* = try Can.init(module_env, parse_ast, &module_envs);
+    can.* = try Can.init(&allocators, module_env, parse_ast, &module_envs);
     errdefer can.deinit();
 
     try can.canonicalizeFile();
@@ -328,7 +328,7 @@ pub fn init(module_name: []const u8, source: []const u8) !TestEnv {
     // Canonicalize
     try module_env.initCIRFields(module_name);
 
-    can.* = try Can.init(module_env, parse_ast, &module_envs);
+    can.* = try Can.init(&allocators, module_env, parse_ast, &module_envs);
     errdefer can.deinit();
 
     try can.canonicalizeFile();

--- a/src/check/test/cross_module_mono_test.zig
+++ b/src/check/test/cross_module_mono_test.zig
@@ -141,7 +141,7 @@ const MonoTestEnv = struct {
 
         try module_env.initCIRFields(module_name);
 
-        can_instance.* = try Can.init(module_env, parse_ast, &module_envs);
+        can_instance.* = try Can.init(&allocators, module_env, parse_ast, &module_envs);
         errdefer can_instance.deinit();
 
         try can_instance.canonicalizeFile();
@@ -243,7 +243,7 @@ const MonoTestEnv = struct {
 
         try module_env.initCIRFields(module_name);
 
-        can_instance.* = try Can.init(module_env, parse_ast, &module_envs);
+        can_instance.* = try Can.init(&allocators, module_env, parse_ast, &module_envs);
         errdefer can_instance.deinit();
 
         try can_instance.canonicalizeFile();
@@ -661,7 +661,7 @@ test "type checker catches polymorphic recursion (infinite type)" {
 
     try module_env.initCIRFields("Test");
 
-    can_instance.* = try Can.init(module_env, parse_ast, &module_envs);
+    can_instance.* = try Can.init(&allocators, module_env, parse_ast, &module_envs);
     defer can_instance.deinit();
 
     try can_instance.canonicalizeFile();

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -2043,8 +2043,11 @@ pub const Coordinator = struct {
         // Canonicalize using the PackageEnv shared function with sibling awareness
         // This sets up placeholders for external imports that will be resolved during type-checking
         // Use worker allocator for thread safety in multi-threaded mode
+        var allocators: base.Allocators = undefined;
+        allocators.initInPlace(canon_alloc);
+        defer allocators.deinit();
         compile_package.PackageEnv.canonicalizeModuleWithSiblings(
-            canon_alloc,
+            &allocators,
             env,
             ast,
             self.builtin_modules.builtin_module.env,

--- a/src/compile/test/type_printing_bug_test.zig
+++ b/src/compile/test/type_printing_bug_test.zig
@@ -55,6 +55,7 @@ test "canonicalizeAndTypeCheckModule preserves Try types in type printing" {
 
     const imported_envs: []const *ModuleEnv = &[_]*ModuleEnv{builtin_env};
     var result = try compile_package.PackageEnv.canonicalizeAndTypeCheckModule(
+        &allocators,
         gpa,
         &env,
         parse_ast,

--- a/src/eval/dev_evaluator.zig
+++ b/src/eval/dev_evaluator.zig
@@ -1639,7 +1639,7 @@ pub const DevEvaluator = struct {
             self.builtin_indices,
         ) catch return error.OutOfMemory;
 
-        var czer = Can.init(&module_env, parse_ast, &module_envs_map) catch {
+        var czer = Can.init(&allocators, &module_env, parse_ast, &module_envs_map) catch {
             return error.CanonicalizeError;
         };
         defer czer.deinit();

--- a/src/eval/llvm_evaluator.zig
+++ b/src/eval/llvm_evaluator.zig
@@ -23,6 +23,7 @@ const eval_mod = @import("mod.zig");
 const LlvmBuilder = std.zig.llvm.Builder;
 
 const Allocator = std.mem.Allocator;
+const Allocators = base.Allocators;
 const ModuleEnv = can.ModuleEnv;
 const CIR = can.CIR;
 const Can = can.Can;
@@ -227,10 +228,14 @@ pub const LlvmEvaluator = struct {
         var module_env = ModuleEnv.init(self.allocator, source) catch return error.OutOfMemory;
         defer module_env.deinit();
 
-        var parse_ast = parse.parseExpr(&module_env.common, self.allocator) catch {
+        var allocators: Allocators = undefined;
+        allocators.initInPlace(self.allocator);
+        defer allocators.deinit();
+
+        const parse_ast = parse.parseExpr(&allocators, &module_env.common) catch {
             return error.ParseError;
         };
-        defer parse_ast.deinit(self.allocator);
+        defer parse_ast.deinit();
 
         if (parse_ast.hasErrors()) {
             return error.ParseError;
@@ -250,7 +255,7 @@ pub const LlvmEvaluator = struct {
             self.builtin_indices,
         ) catch return error.OutOfMemory;
 
-        var czer = Can.init(&module_env, &parse_ast, &module_envs_map) catch {
+        var czer = Can.init(&allocators, &module_env, parse_ast, &module_envs_map) catch {
             return error.CanonicalizeError;
         };
         defer czer.deinit();

--- a/src/eval/test/anno_only_interp_test.zig
+++ b/src/eval/test/anno_only_interp_test.zig
@@ -79,7 +79,7 @@ fn parseCheckAndEvalModule(src: []const u8) !struct {
         builtin_indices,
     );
 
-    var czer = try Can.init(module_env, parse_ast, &module_envs_map);
+    var czer = try Can.init(&allocators, module_env, parse_ast, &module_envs_map);
     defer czer.deinit();
 
     try czer.canonicalizeFile();

--- a/src/eval/test/comptime_eval_test.zig
+++ b/src/eval/test/comptime_eval_test.zig
@@ -72,7 +72,7 @@ fn parseCheckAndEvalModuleWithName(src: []const u8, module_name: []const u8) !Ev
     };
 
     // Create canonicalizer
-    var czer = try Can.init(module_env, parse_ast, null);
+    var czer = try Can.init(&allocators, module_env, parse_ast, null);
     defer czer.deinit();
 
     // Canonicalize the module
@@ -171,7 +171,7 @@ fn parseCheckAndEvalModuleWithImport(src: []const u8, import_name: []const u8, i
     try module_envs.put(import_ident, .{ .env = imported_module, .qualified_type_ident = import_qualified_ident });
 
     // Create canonicalizer with imports
-    var czer = try Can.init(module_env, parse_ast, &module_envs);
+    var czer = try Can.init(&allocators, module_env, parse_ast, &module_envs);
     defer czer.deinit();
 
     // Canonicalize the module

--- a/src/eval/test/eval_test.zig
+++ b/src/eval/test/eval_test.zig
@@ -751,7 +751,7 @@ test "ModuleEnv serialization and interpreter evaluation" {
     try module_envs_map.put(builtin_ident, .{ .env = builtin_module.env, .qualified_type_ident = builtin_qualified_ident });
 
     // Create canonicalizer with module_envs_map for qualified name resolution
-    var czer = try Can.init(&original_env, parse_ast, &module_envs_map);
+    var czer = try Can.init(&allocators, &original_env, parse_ast, &module_envs_map);
     defer czer.deinit();
 
     // Canonicalize the expression

--- a/src/eval/test/helpers.zig
+++ b/src/eval/test/helpers.zig
@@ -990,7 +990,7 @@ pub fn parseAndCanonicalizeExpr(allocator: std.mem.Allocator, source: []const u8
 
     // Create czer with module_envs_map for qualified name resolution (following REPL pattern)
     const czer = try allocator.create(Can);
-    czer.* = try Can.init(module_env, parse_ast, &module_envs_map);
+    czer.* = try Can.init(&allocators, module_env, parse_ast, &module_envs_map);
 
     // Canonicalize the expression (following REPL pattern)
     const expr_idx: parse.AST.Expr.Idx = @enumFromInt(parse_ast.root_node_idx);

--- a/src/eval/test/low_level_interp_test.zig
+++ b/src/eval/test/low_level_interp_test.zig
@@ -81,7 +81,7 @@ fn parseCheckAndEvalModule(src: []const u8) !struct {
         builtin_indices,
     );
 
-    var czer = try Can.init(module_env, parse_ast, &module_envs_map);
+    var czer = try Can.init(&allocators, module_env, parse_ast, &module_envs_map);
     defer czer.deinit();
 
     try czer.canonicalizeFile();

--- a/src/lsp/semantic_tokens.zig
+++ b/src/lsp/semantic_tokens.zig
@@ -301,7 +301,7 @@ pub fn extractSemanticTokensWithImports(
     };
 
     // Create canonicalizer and run
-    var canonicalizer = can.Can.init(&module_env, parse_ast, null) catch {
+    var canonicalizer = can.Can.init(&allocators, &module_env, parse_ast, null) catch {
         return extractSemanticTokens(allocator, source, info);
     };
     defer canonicalizer.deinit();

--- a/src/playground_wasm/main.zig
+++ b/src/playground_wasm/main.zig
@@ -1094,7 +1094,7 @@ fn compileSource(source: []const u8, module_name: []const u8) !CompilerStageData
     try Can.populateModuleEnvs(&module_envs_map, module_env, builtin_module.env, builtin_indices);
 
     logDebug("compileSource: Starting canonicalization\n", .{});
-    var czer = try Can.init(env, result.parse_ast.?, &module_envs_map);
+    var czer = try Can.init(&allocators, env, result.parse_ast.?, &module_envs_map);
     defer czer.deinit();
 
     czer.canonicalizeFile() catch |err| {

--- a/src/repl/eval.zig
+++ b/src/repl/eval.zig
@@ -587,7 +587,7 @@ pub const Repl = struct {
             self.builtin_indices,
         );
 
-        var czer = Can.init(cir, parse_ast, &module_envs_map) catch |err| {
+        var czer = Can.init(&allocators, cir, parse_ast, &module_envs_map) catch |err| {
             return .{ .canonicalize_error = try std.fmt.allocPrint(self.allocator, "Canonicalize init error: {}", .{err}) };
         };
         defer czer.deinit();

--- a/src/repl/repl_test.zig
+++ b/src/repl/repl_test.zig
@@ -333,7 +333,7 @@ test "Repl - minimal interpreter integration" {
     };
 
     // Step 4: Canonicalize
-    var can = try Canon.init(cir, parse_ast, null);
+    var can = try Canon.init(&allocators, cir, parse_ast, null);
     defer can.deinit();
 
     const expr_idx: parse.AST.Expr.Idx = @enumFromInt(parse_ast.root_node_idx);

--- a/src/snapshot_tool/main.zig
+++ b/src/snapshot_tool/main.zig
@@ -972,7 +972,7 @@ fn processSnapshotContent(
                 try Can.populateModuleEnvs(&module_envs, can_ir, builtin_env, config.builtin_indices);
             }
 
-            var czer = try Can.init(can_ir, parse_ast, &module_envs);
+            var czer = try Can.init(&allocators, can_ir, parse_ast, &module_envs);
             defer czer.deinit();
             try czer.canonicalizeFile();
         },
@@ -989,7 +989,7 @@ fn processSnapshotContent(
                 try Can.populateModuleEnvs(&module_envs, can_ir, builtin_env, config.builtin_indices);
             }
 
-            var czer = try Can.init(can_ir, parse_ast, &module_envs);
+            var czer = try Can.init(&allocators, can_ir, parse_ast, &module_envs);
             defer czer.deinit();
 
             switch (content.meta.node_type) {
@@ -1110,6 +1110,7 @@ fn processSnapshotContent(
             module_envs_for_file = std.AutoHashMap(base.Ident.Idx, Can.AutoImportedType).init(allocator);
 
             const checker = try compile.PackageEnv.canonicalizeAndTypeCheckModule(
+                &allocators,
                 allocator,
                 can_ir,
                 parse_ast,
@@ -2884,7 +2885,7 @@ fn validateMonoOutput(allocator: Allocator, mono_source: []const u8, source_path
     }
 
     // Canonicalize the parsed MONO output
-    var czer = Can.init(&validation_env, validation_ast, &module_envs) catch |err| {
+    var czer = Can.init(&allocators, &validation_env, validation_ast, &module_envs) catch |err| {
         std.log.err("MONO VALIDATION ERROR in {s}: Failed to initialize canonicalizer: {}", .{ source_path, err });
         return false;
     };


### PR DESCRIPTION
## Summary

- Thread `*Allocators` through canonicalization for API consistency with the parse module
- Add unified entry points: `can.canonicalizeModule()` and `can.canonicalizeExpr()`
- Add `compile_module.canonicalizeSingleModule()` for higher-level interface
- Remove redundant `gpa` parameter from `canonicalizeModuleWithSiblings`

## Design Notes

- `Can.init()` takes `*Allocators` but uses `env.gpa` for allocations since internal methods use `self.env.gpa` throughout
- `Allocators` is stored for future arena/scratch support
- Per-task `Allocators` lifetime is intentional - arena memory should be freed after each module's canonicalization

Follows #9141 (parse API unification).

## Test plan

- [x] All 2625 tests pass
- [x] Snapshot tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)