### PR TITLE
Fix stack overflow when passing builtin fallible function to List.map

### DIFF
--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -16776,7 +16776,9 @@ pub const Interpreter = struct {
                                 },
                                 .flex => |flex| flex.constraints.count > 0,
                                 .rigid => |rigid| rigid.constraints.count > 0,
-                                else => true,
+                                // Error types are not concrete - fall back to lambda's return type
+                                .err => false,
+                                .alias => true,
                             };
 
                             if (is_concrete) {


### PR DESCRIPTION
When a builtin function returning a Result type (e.g. U64.from_str) was passed directly to List.map, the call site's return type variable resolved to Content.err. The catch-all `else => true` in the is_concrete check incorrectly treated .err as concrete, causing the interpreter to use the erroneous type instead of falling back to the lambda's correct return type. In release builds this led to a stack overflow.

Replace the catch-all with explicit handling: .err => false (not concrete) and .alias => true (concrete).

Closes #9149