### PR TITLE
delete incorrect ExternalSpecializationRequest.eql

### DIFF
--- a/src/canonicalize/Monomorphizer.zig
+++ b/src/canonicalize/Monomorphizer.zig
@@ -148,12 +148,6 @@ pub const ExternalSpecializationRequest = struct {
     concrete_type: types.Var,
     /// The call site in this module (for error reporting)
     call_site: ?Expr.Idx,
-
-    pub fn eql(a: ExternalSpecializationRequest, b: ExternalSpecializationRequest) bool {
-        return a.source_module == b.source_module and
-            a.original_ident == b.original_ident;
-        // Note: concrete_type comparison would require type equality check
-    }
 };
 
 /// Result of requesting an external specialization.


### PR DESCRIPTION
## Summary
- Delete `ExternalSpecializationRequest.eql` which ignored `concrete_type`, making two requests for the same function but different concrete types compare as equal
- The function was unused, so deleting it prevents future misuse

## Test plan
- [x] `zig build minici` passes (the only failure is a pre-existing unrelated untracked file `test/fx/issue9018.roc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)