### PR TITLE
Fix incomplete type substitution for tag union payloads

### DIFF
--- a/src/canonicalize/Monomorphizer.zig
+++ b/src/canonicalize/Monomorphizer.zig
@@ -1290,6 +1290,24 @@ fn buildFlatTypeSubstitutions(
                 else => return,
             };
 
+            // Compare tag payload types (tags are sorted by name, so positional match is correct)
+            const poly_tags = self.types_store.getTagsSlice(poly_union.tags);
+            const concrete_tags = self.types_store.getTagsSlice(concrete_union.tags);
+
+            const poly_args_slice = poly_tags.items(.args);
+            const concrete_args_slice = concrete_tags.items(.args);
+
+            const min_tags = @min(poly_args_slice.len, concrete_args_slice.len);
+            for (0..min_tags) |i| {
+                const poly_tag_args = self.types_store.sliceVars(poly_args_slice[i]);
+                const concrete_tag_args = self.types_store.sliceVars(concrete_args_slice[i]);
+
+                const min_args = @min(poly_tag_args.len, concrete_tag_args.len);
+                for (0..min_args) |j| {
+                    try self.buildTypeSubstitutions(poly_tag_args[j], concrete_tag_args[j], var_map);
+                }
+            }
+
             // Compare extension types
             try self.buildTypeSubstitutions(poly_union.ext, concrete_union.ext, var_map);
         },


### PR DESCRIPTION
## Summary
- `buildFlatTypeSubstitutions` in `Monomorphizer.zig` was only comparing extension variables for tag unions, never walking tag payload types. Type variables only appearing in tag payloads (e.g. `a` in `[Ok(a), Err(e)]`) were never discovered during monomorphization.
- Added iteration over tag payload arguments, matching positionally (tags are canonically sorted by name, same as records).
- Added 3 eval tests exercising polymorphic functions with type variables in tag union payloads.

## Test plan
- [x] `zig build test-eval` — all 1039 eval tests pass (including 3 new ones)
- [x] `zig build minici` — all 2758 tests pass, all checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)