### PR TITLE
Remove unused region tracking from ClosureTransformer

### DIFF
--- a/src/canonicalize/ClosureTransformer.zig
+++ b/src/canonicalize/ClosureTransformer.zig
@@ -166,11 +166,6 @@ pub const UnspecializedClosure = struct {
     /// The expression that references the static dispatch method.
     /// Used to locate this in the IR for resolution.
     member_expr: Expr.Idx,
-
-    /// Region number for ordering during resolution.
-    /// When resolving nested static-dispatch-dependent closures, we process
-    /// innermost first (higher region numbers first).
-    region: u8,
 };
 
 /// Internal validation error for lambda set resolution failures.
@@ -715,11 +710,6 @@ pattern_lambda_return_sets: std.AutoHashMap(CIR.Pattern.Idx, LambdaSet),
 /// Set of top-level pattern indices (these don't need to be captured since they're always in scope)
 top_level_patterns: std.AutoHashMap(CIR.Pattern.Idx, void),
 
-/// Current region number for ordering unspecialized closures.
-/// Incremented when entering nested lambda scopes.
-/// Higher region = more deeply nested = should be resolved first.
-current_region: u8,
-
 /// Tracks unspecialized entries by the type variable they depend on.
 /// This enables efficient lookup during monomorphization when a type variable
 /// becomes concrete - we can quickly find all entries that need resolution.
@@ -745,25 +735,9 @@ pub fn initWithInference(allocator: std.mem.Allocator, module_env: *ModuleEnv, i
         .lambda_return_sets = std.AutoHashMap(Expr.Idx, LambdaSet).init(allocator),
         .pattern_lambda_return_sets = std.AutoHashMap(CIR.Pattern.Idx, LambdaSet).init(allocator),
         .top_level_patterns = std.AutoHashMap(CIR.Pattern.Idx, void).init(allocator),
-        .current_region = 0,
         .unspec_by_type_var = UnspecializedByTypeVar.init(allocator),
         .inference = inference,
     };
-}
-
-/// Enter a new nested scope (e.g., lambda body), incrementing the region counter.
-/// Returns the previous region value for restoration.
-pub fn enterRegion(self: *Self) u8 {
-    const prev = self.current_region;
-    if (self.current_region < 255) {
-        self.current_region += 1;
-    }
-    return prev;
-}
-
-/// Exit a nested scope, restoring the previous region value.
-pub fn exitRegion(self: *Self, prev_region: u8) void {
-    self.current_region = prev_region;
 }
 
 /// Info extracted from a static dispatch reference expression.
@@ -808,7 +782,6 @@ pub fn createUnspecializedClosure(
         .type_var = type_var,
         .member = member_info.method_name,
         .member_expr = expr_idx,
-        .region = self.current_region,
     };
 }
 
@@ -2647,39 +2620,6 @@ test "ClosureTransformer: generateClosureTagName without hint" {
     try testing.expectEqualStrings("#1", tag_str);
 }
 
-test "ClosureTransformer: region tracking" {
-    const allocator = testing.allocator;
-
-    const module_env = try allocator.create(ModuleEnv);
-    module_env.* = try ModuleEnv.init(allocator, "test");
-    defer {
-        module_env.deinit();
-        allocator.destroy(module_env);
-    }
-
-    var transformer = Self.init(allocator, module_env);
-    defer transformer.deinit();
-
-    // Initial region should be 0
-    try testing.expectEqual(@as(u8, 0), transformer.current_region);
-
-    // Enter nested scopes
-    const region0 = transformer.enterRegion();
-    try testing.expectEqual(@as(u8, 0), region0);
-    try testing.expectEqual(@as(u8, 1), transformer.current_region);
-
-    const region1 = transformer.enterRegion();
-    try testing.expectEqual(@as(u8, 1), region1);
-    try testing.expectEqual(@as(u8, 2), transformer.current_region);
-
-    // Exit scopes
-    transformer.exitRegion(region1);
-    try testing.expectEqual(@as(u8, 1), transformer.current_region);
-
-    transformer.exitRegion(region0);
-    try testing.expectEqual(@as(u8, 0), transformer.current_region);
-}
-
 test "LambdaSet: unspecialized closures" {
     const allocator = testing.allocator;
 
@@ -2698,7 +2638,6 @@ test "LambdaSet: unspecialized closures" {
             .idx = 42,
         },
         .member_expr = @enumFromInt(1),
-        .region = 1,
     };
     try lambda_set.addUnspecialized(allocator, unspec);
 
@@ -2725,7 +2664,6 @@ test "LambdaSet: merge with unspecialized" {
             .idx = 10,
         },
         .member_expr = @enumFromInt(1),
-        .region = 0,
     };
     try set1.addUnspecialized(allocator, unspec1);
 
@@ -2737,7 +2675,6 @@ test "LambdaSet: merge with unspecialized" {
             .idx = 20,
         },
         .member_expr = @enumFromInt(2),
-        .region = 1,
     };
     try set2.addUnspecialized(allocator, unspec2);
 
@@ -2766,7 +2703,6 @@ test "LambdaSet: isEmpty" {
             .idx = 1,
         },
         .member_expr = @enumFromInt(1),
-        .region = 0,
     };
     try lambda_set.addUnspecialized(allocator, unspec);
 
@@ -2983,7 +2919,6 @@ test "ClosureTransformer: validateAllResolved detects unresolved" {
             .idx = 42,
         },
         .member_expr = @enumFromInt(1),
-        .region = 0,
     };
     try lambda_set.addUnspecialized(allocator, unspec);
 

--- a/src/canonicalize/Monomorphizer.zig
+++ b/src/canonicalize/Monomorphizer.zig
@@ -658,9 +658,6 @@ pub fn resolveEntriesForTypeVar(
         }
     }
 
-    // Sort by region DESCENDING (innermost first - higher region numbers first)
-    std.mem.sort(ClosureTransformer.UnspecializedEntryRef, all_entries.items, {}, compareByRegionDesc);
-
     var resolved_count: usize = 0;
 
     // Step 3: Process each entry in region order
@@ -697,24 +694,6 @@ pub fn resolveEntriesForTypeVar(
     tracker.removeVar(type_var);
 
     return resolved_count;
-}
-
-/// Comparison function for sorting UnspecializedEntryRef by region descending.
-fn compareByRegionDesc(
-    _: void,
-    a: ClosureTransformer.UnspecializedEntryRef,
-    b: ClosureTransformer.UnspecializedEntryRef,
-) bool {
-    // Handle potential out-of-bounds indices gracefully
-    const a_region = if (a.index < a.lambda_set.unspecialized.items.len)
-        a.lambda_set.unspecialized.items[a.index].region
-    else
-        0;
-    const b_region = if (b.index < b.lambda_set.unspecialized.items.len)
-        b.lambda_set.unspecialized.items[b.index].region
-    else
-        0;
-    return a_region > b_region; // Descending order
 }
 
 /// Unify ambient function types when resolving an unspecialized entry.
@@ -785,17 +764,9 @@ pub fn resolveEntriesForTypeVarWithUnification(
 
     if (entry_refs.len == 0) return 0;
 
-    // Copy to slice for sorting
-    const entries = try self.allocator.alloc(ClosureTransformer.UnspecializedEntryRef, entry_refs.len);
-    defer self.allocator.free(entries);
-    @memcpy(entries, entry_refs);
-
-    // Sort by region DESCENDING (innermost first)
-    std.mem.sort(ClosureTransformer.UnspecializedEntryRef, entries, {}, compareByRegionDesc);
-
     var resolved_count: usize = 0;
 
-    for (entries) |entry_ref| {
+    for (entry_refs) |entry_ref| {
         if (entry_ref.index >= entry_ref.lambda_set.unspecialized.items.len) {
             continue;
         }

--- a/src/check/test/cross_module_mono_test.zig
+++ b/src/check/test/cross_module_mono_test.zig
@@ -408,7 +408,7 @@ test "cross-module mono: closure transformer tracks unspecialized closures" {
     defer transformer.deinit();
 
     // The transformer should be initialized and ready
-    try testing.expectEqual(@as(u8, 0), transformer.current_region);
+    _ = &transformer;
 }
 
 test "cross-module mono: monomorphizer tracks external requests" {


### PR DESCRIPTION
## Summary
- Remove the unused `region` field from `UnspecializedClosure` and `current_region` from `ClosureTransformer`
- `enterRegion`/`exitRegion` had zero call sites outside their own test, so `current_region` was always 0
- Remove the now-no-op `compareByRegionDesc` sort in the Monomorphizer and an unnecessary alloc+copy

## Test plan
- [x] `zig build test-can` passes
- [x] `zig build test-check` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)