### PR TITLE
enable question postfix in all_syntax

### DIFF
--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -260,6 +260,7 @@ test "fx platform all_syntax_test.roc prints expected output" {
         "Line 3\n" ++
         "Unicode escape sequence: \u{00A0}\n" ++
         "This is an effectful function!\n" ++
+        "Try.Ok(1)\n" ++
         "15.0\n" ++
         "False\n" ++
         "10.0\n" ++

--- a/test/fx/all_syntax_test.roc
+++ b/test/fx/all_syntax_test.roc
@@ -99,15 +99,14 @@ effect_demo! : Str => {}
 effect_demo! = |msg|
 	Stdout.line!(msg)
 
-# TODO issue #9170
-# question_postfix : List(Str) -> Try(I64, _)
-# question_postfix = |strings| {
-#     # `?` to immediately return the error if there is one
-#     first_str = strings.first()?
-#     first_num = I64.from_str(first_str)?
+question_postfix : List(Str) -> Try(I64, _)
+question_postfix = |strings| {
+    # `?` to immediately return the error if there is one
+    first_str = strings.first()?
+    first_num = I64.from_str(first_str)?
 
-#     Ok(first_num + 1)
-# }
+    Ok(first_num)
+}
 
 # three dots for things you want to fill in later, will crash if implement_me_later(arg) is called
 implement_me_later = |_str| ...
@@ -338,7 +337,7 @@ main! = || {
 
 	effect_demo!("This is an effectful function!")
 
-	#Stdout.line!(Str.inspect(question_postfix(["1", "not a number", "100"])))
+	print!(question_postfix(["1", "not a number", "100"]))
 
 	sum = for_loop([1, 2, 3, 4, 5])
 	print!(sum)


### PR DESCRIPTION
Removing the `+ 1` avoids #9170