### PR TITLE
Add guard clause parsing for match branches

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -4847,6 +4847,8 @@ fn checkMatchExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, match: CIR.Exp
     const trace = tracy.trace(@src());
     defer trace.end();
 
+    const expr_region = self.cir.store.getNodeRegion(ModuleEnv.nodeIdxFrom(expr_idx));
+
     // Check the match's condition
     var does_fx = try self.checkExpr(match.cond, env, .no_expectation);
     const cond_var = ModuleEnv.varFrom(match.cond);
@@ -4906,6 +4908,14 @@ fn checkMatchExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, match: CIR.Exp
         if (!ptrn_result.isOk()) had_type_error = true;
     }
 
+    // Check guard if present
+    if (first_branch.guard) |guard_idx| {
+        does_fx = try self.checkExpr(guard_idx, env, .no_expectation) or does_fx;
+        const guard_var = ModuleEnv.varFrom(guard_idx);
+        const guard_bool_var = try self.freshBool(env, expr_region);
+        _ = try self.unifyInContext(guard_bool_var, guard_var, env, .if_condition);
+    }
+
     // Check the first branch's value, then use that at the branch_var
     does_fx = try self.checkExpr(first_branch.value, env, .no_expectation) or does_fx;
     const val_var = ModuleEnv.varFrom(first_branch.value);
@@ -4931,6 +4941,14 @@ fn checkMatchExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, match: CIR.Exp
                 .match_expr = expr_idx,
             } });
             if (!ptrn_result.isOk()) had_type_error = true;
+        }
+
+        // Check guard if present
+        if (branch.guard) |guard_idx| {
+            does_fx = try self.checkExpr(guard_idx, env, .no_expectation) or does_fx;
+            const guard_var = ModuleEnv.varFrom(guard_idx);
+            const branch_guard_bool_var = try self.freshBool(env, expr_region);
+            _ = try self.unifyInContext(branch_guard_bool_var, guard_var, env, .if_condition);
         }
 
         // Then, check the body

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -1419,6 +1419,10 @@ const Formatter = struct {
                     try fmt.ensureNewline();
                     try fmt.pushIndent();
                     const pattern_region = try fmt.formatPattern(branch.pattern);
+                    if (branch.guard) |guard| {
+                        try fmt.pushAll(" if ");
+                        _ = try fmt.formatExpr(guard);
+                    }
                     var flushed = try fmt.flushCommentsBefore(pattern_region.end);
                     if (flushed) {
                         fmt.curr_indent += 1;

--- a/src/lsp/handlers/selection_range.zig
+++ b/src/lsp/handlers/selection_range.zig
@@ -431,6 +431,9 @@ fn collectContainingRegionsFromExpr(
             const branches = ast.store.matchBranchSlice(m.branches);
             for (branches) |branch_idx| {
                 const branch = ast.store.getBranch(branch_idx);
+                if (branch.guard) |guard| {
+                    try collectContainingRegionsFromExpr(allocator, ast, guard, target_offset, regions);
+                }
                 try collectContainingRegionsFromExpr(allocator, ast, branch.body, target_offset, regions);
             }
         },

--- a/src/parse/AST.zig
+++ b/src/parse/AST.zig
@@ -3111,6 +3111,7 @@ pub const IfElse = struct {
 pub const MatchBranch = struct {
     pattern: Pattern.Idx,
     body: Expr.Idx,
+    guard: ?Expr.Idx,
     region: TokenizedRegion,
 
     pub const Idx = enum(u32) { _ };
@@ -3123,6 +3124,13 @@ pub const MatchBranch = struct {
         const attrs = tree.beginNode();
 
         try ast.store.getPattern(self.pattern).pushToSExprTree(gpa, env, ast, tree);
+        if (self.guard) |guard| {
+            const guard_begin = tree.beginNode();
+            try tree.pushStaticAtom("guard");
+            const guard_attrs = tree.beginNode();
+            try ast.store.getExpr(guard).pushToSExprTree(gpa, env, ast, tree);
+            try tree.endNode(guard_begin, guard_attrs);
+        }
         try ast.store.getExpr(self.body).pushToSExprTree(gpa, env, ast, tree);
 
         try tree.endNode(begin, attrs);

--- a/src/parse/Node.zig
+++ b/src/parse/Node.zig
@@ -476,8 +476,8 @@ pub const Tag = enum {
     /// * rhs - RHS DESCRIPTION
     ellipsis,
 
-    /// A branch is a when expression
-    /// Main token is ignored
+    /// A branch in a match expression
+    /// * main_token - Guard expression index (0 = no guard, raw value = @intFromEnum(guard) + 1)
     /// * lhs - Pattern index
     /// * rhs - Body index
     branch,

--- a/src/parse/NodeStore.zig
+++ b/src/parse/NodeStore.zig
@@ -873,7 +873,7 @@ pub fn addRecordField(store: *NodeStore, field: AST.RecordField) std.mem.Allocat
 pub fn addMatchBranch(store: *NodeStore, branch: AST.MatchBranch) std.mem.Allocator.Error!AST.MatchBranch.Idx {
     const node = Node{
         .tag = .branch,
-        .main_token = 0,
+        .main_token = if (branch.guard) |g| @intFromEnum(g) + 1 else 0,
         .data = .{
             .lhs = @intFromEnum(branch.pattern),
             .rhs = @intFromEnum(branch.body),
@@ -1879,6 +1879,7 @@ pub fn getBranch(store: *const NodeStore, branch_idx: AST.MatchBranch.Idx) AST.M
         .region = node.region,
         .pattern = @enumFromInt(node.data.lhs),
         .body = @enumFromInt(node.data.rhs),
+        .guard = if (node.main_token == 0) null else @enumFromInt(node.main_token - 1),
     };
 }
 

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -2857,6 +2857,13 @@ pub fn parseBranch(self: *Parser) Error!AST.MatchBranch.Idx {
 
     const start = self.pos;
     const p = try self.parsePattern(.alternatives_allowed);
+
+    // Parse optional guard: `if <expr>`
+    const guard: ?AST.Expr.Idx = if (self.peek() == .KwIf) blk: {
+        self.advance(); // consume `if`
+        break :blk try self.parseExpr();
+    } else null;
+
     if (self.peek() == .OpFatArrow) {
         self.advance();
     } else if (self.peek() == .OpArrow) {
@@ -2879,6 +2886,7 @@ pub fn parseBranch(self: *Parser) Error!AST.MatchBranch.Idx {
         .region = .{ .start = start, .end = self.pos },
         .pattern = p,
         .body = b,
+        .guard = guard,
     });
 }
 

--- a/test/snapshots/match_expr/guards_1.md
+++ b/test/snapshots/match_expr/guards_1.md
@@ -1,306 +1,155 @@
 # META
 ~~~ini
 description=Match expression with guard conditions using if clauses
-type=expr
+type=snippet
 ~~~
 # SOURCE
 ~~~roc
-match value {
-    x if x > 0 => "positive: ${Num.toStr x}"
-    x if x < 0 => "negative: ${Num.toStr x}"
+describe : I64 -> Str
+describe = |value| match value {
+    x if x > 0 => "positive: ${x.to_str()}"
+    x if x < 0 => "negative: ${x.to_str()}"
     _ => "other"
 }
 ~~~
 # EXPECTED
-PARSE ERROR - guards_1.md:2:7:2:7
-UNEXPECTED TOKEN IN EXPRESSION - guards_1.md:2:16:2:18
-PARSE ERROR - guards_1.md:2:19:2:20
-PARSE ERROR - guards_1.md:2:43:2:43
-UNEXPECTED TOKEN IN EXPRESSION - guards_1.md:2:43:2:44
-UNEXPECTED TOKEN IN PATTERN - guards_1.md:2:44:2:44
-PARSE ERROR - guards_1.md:2:44:2:44
-UNEXPECTED TOKEN IN EXPRESSION - guards_1.md:2:44:2:45
-PARSE ERROR - guards_1.md:3:7:3:7
-UNEXPECTED TOKEN IN EXPRESSION - guards_1.md:3:16:3:18
-PARSE ERROR - guards_1.md:3:19:3:20
-PARSE ERROR - guards_1.md:3:43:3:43
-UNEXPECTED TOKEN IN EXPRESSION - guards_1.md:3:43:3:44
-UNEXPECTED TOKEN IN PATTERN - guards_1.md:3:44:3:44
-PARSE ERROR - guards_1.md:3:44:3:44
-UNEXPECTED TOKEN IN EXPRESSION - guards_1.md:3:44:3:45
-UNDEFINED VARIABLE - guards_1.md:1:7:1:12
-INVALID IF BRANCH - :0:0:0:0
-INVALID PATTERN ARGUMENT - :0:0:0:0
-UNRECOGNIZED SYNTAX - guards_1.md:2:43:2:44
+NIL
 # PROBLEMS
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_1.md:2:7:2:7:**
-```roc
-    x if x > 0 => "positive: ${Num.toStr x}"
-```
-      ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **=>** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_1.md:2:16:2:18:**
-```roc
-    x if x > 0 => "positive: ${Num.toStr x}"
-```
-               ^^
-
-
-**PARSE ERROR**
-A parsing error occurred: `string_expected_close_interpolation`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_1.md:2:19:2:20:**
-```roc
-    x if x > 0 => "positive: ${Num.toStr x}"
-```
-                  ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_1.md:2:43:2:43:**
-```roc
-    x if x > 0 => "positive: ${Num.toStr x}"
-```
-                                          ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **}** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_1.md:2:43:2:44:**
-```roc
-    x if x > 0 => "positive: ${Num.toStr x}"
-```
-                                          ^
-
-
-**UNEXPECTED TOKEN IN PATTERN**
-The token  is not expected in a pattern.
-Patterns can contain identifiers, literals, lists, records, or tags.
-
-**guards_1.md:2:44:2:44:**
-```roc
-    x if x > 0 => "positive: ${Num.toStr x}"
-```
-                                           ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_1.md:2:44:2:44:**
-```roc
-    x if x > 0 => "positive: ${Num.toStr x}"
-```
-                                           ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **"** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_1.md:2:44:2:45:**
-```roc
-    x if x > 0 => "positive: ${Num.toStr x}"
-```
-                                           ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_1.md:3:7:3:7:**
-```roc
-    x if x < 0 => "negative: ${Num.toStr x}"
-```
-      ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **=>** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_1.md:3:16:3:18:**
-```roc
-    x if x < 0 => "negative: ${Num.toStr x}"
-```
-               ^^
-
-
-**PARSE ERROR**
-A parsing error occurred: `string_expected_close_interpolation`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_1.md:3:19:3:20:**
-```roc
-    x if x < 0 => "negative: ${Num.toStr x}"
-```
-                  ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_1.md:3:43:3:43:**
-```roc
-    x if x < 0 => "negative: ${Num.toStr x}"
-```
-                                          ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **}** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_1.md:3:43:3:44:**
-```roc
-    x if x < 0 => "negative: ${Num.toStr x}"
-```
-                                          ^
-
-
-**UNEXPECTED TOKEN IN PATTERN**
-The token  is not expected in a pattern.
-Patterns can contain identifiers, literals, lists, records, or tags.
-
-**guards_1.md:3:44:3:44:**
-```roc
-    x if x < 0 => "negative: ${Num.toStr x}"
-```
-                                           ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_1.md:3:44:3:44:**
-```roc
-    x if x < 0 => "negative: ${Num.toStr x}"
-```
-                                           ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **"** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_1.md:3:44:3:45:**
-```roc
-    x if x < 0 => "negative: ${Num.toStr x}"
-```
-                                           ^
-
-
-**UNDEFINED VARIABLE**
-Nothing is named `value` in this scope.
-Is there an `import` or `exposing` missing up-top?
-
-**guards_1.md:1:7:1:12:**
-```roc
-match value {
-```
-      ^^^^^
-
-
-**INVALID IF BRANCH**
-The branch in this `if` expression could not be processed.
-
-The branch must contain a valid expression. Check for syntax errors or missing values.
-
-**INVALID PATTERN ARGUMENT**
-Pattern arguments must be valid patterns like identifiers, literals, or destructuring patterns.
-
-**UNRECOGNIZED SYNTAX**
-I don't recognize this syntax.
-
-**guards_1.md:2:43:2:44:**
-```roc
-    x if x > 0 => "positive: ${Num.toStr x}"
-```
-                                          ^
-
-This might be a syntax error, an unsupported language feature, or a typo.
-
+NIL
 # TOKENS
 ~~~zig
-KwMatch,LowerIdent,OpenCurly,
-LowerIdent,KwIf,LowerIdent,OpGreaterThan,Int,OpFatArrow,StringStart,StringPart,OpenStringInterpolation,UpperIdent,NoSpaceDotLowerIdent,LowerIdent,CloseStringInterpolation,StringPart,StringEnd,
-LowerIdent,KwIf,LowerIdent,OpLessThan,Int,OpFatArrow,StringStart,StringPart,OpenStringInterpolation,UpperIdent,NoSpaceDotLowerIdent,LowerIdent,CloseStringInterpolation,StringPart,StringEnd,
+LowerIdent,OpColon,UpperIdent,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,KwMatch,LowerIdent,OpenCurly,
+LowerIdent,KwIf,LowerIdent,OpGreaterThan,Int,OpFatArrow,StringStart,StringPart,OpenStringInterpolation,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,CloseStringInterpolation,StringPart,StringEnd,
+LowerIdent,KwIf,LowerIdent,OpLessThan,Int,OpFatArrow,StringStart,StringPart,OpenStringInterpolation,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,CloseStringInterpolation,StringPart,StringEnd,
 Underscore,OpFatArrow,StringStart,StringPart,StringEnd,
 CloseCurly,
 EndOfFile,
 ~~~
 # PARSE
 ~~~clojure
-(e-match
-	(e-ident (raw "value"))
-	(branches
-		(branch
-			(p-ident (raw "x"))
-			(e-if-without-else
-				(e-binop (op ">")
-					(e-ident (raw "x"))
-					(e-int (raw "0")))
-				(e-malformed (reason "expr_unexpected_token"))))
-		(branch
-			(p-string (raw """))
-			(e-malformed (reason "expr_unexpected_token")))
-		(branch
-			(p-malformed (tag "pattern_unexpected_token"))
-			(e-malformed (reason "expr_unexpected_token")))
-		(branch
-			(p-ident (raw "x"))
-			(e-if-without-else
-				(e-binop (op "<")
-					(e-ident (raw "x"))
-					(e-int (raw "0")))
-				(e-malformed (reason "expr_unexpected_token"))))
-		(branch
-			(p-string (raw """))
-			(e-malformed (reason "expr_unexpected_token")))
-		(branch
-			(p-malformed (tag "pattern_unexpected_token"))
-			(e-malformed (reason "expr_unexpected_token")))
-		(branch
-			(p-underscore)
-			(e-string
-				(e-string-part (raw "other"))))))
+(file
+	(type-module)
+	(statements
+		(s-type-anno (name "describe")
+			(ty-fn
+				(ty (name "I64"))
+				(ty (name "Str"))))
+		(s-decl
+			(p-ident (raw "describe"))
+			(e-lambda
+				(args
+					(p-ident (raw "value")))
+				(e-match
+					(e-ident (raw "value"))
+					(branches
+						(branch
+							(p-ident (raw "x"))
+							(guard
+								(e-binop (op ">")
+									(e-ident (raw "x"))
+									(e-int (raw "0"))))
+							(e-string
+								(e-string-part (raw "positive: "))
+								(e-field-access
+									(e-ident (raw "x"))
+									(e-apply
+										(e-ident (raw "to_str"))))
+								(e-string-part (raw ""))))
+						(branch
+							(p-ident (raw "x"))
+							(guard
+								(e-binop (op "<")
+									(e-ident (raw "x"))
+									(e-int (raw "0"))))
+							(e-string
+								(e-string-part (raw "negative: "))
+								(e-field-access
+									(e-ident (raw "x"))
+									(e-apply
+										(e-ident (raw "to_str"))))
+								(e-string-part (raw ""))))
+						(branch
+							(p-underscore)
+							(e-string
+								(e-string-part (raw "other"))))))))))
 ~~~
 # FORMATTED
 ~~~roc
-match value {
-	x => if x > 0 
-	 => 
-	 => 
-	x => if x < 0 
-	 => 
-	 => 
+describe : I64 -> Str
+describe = |value| match value {
+	x if x > 0 => "positive: ${x.to_str()}"
+	x if x < 0 => "negative: ${x.to_str()}"
 	_ => "other"
 }
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-runtime-error (tag "expr_not_canonicalized"))
+(can-ir
+	(d-let
+		(p-assign (ident "describe"))
+		(e-lambda
+			(args
+				(p-assign (ident "value")))
+			(e-match
+				(match
+					(cond
+						(e-lookup-local
+							(p-assign (ident "value"))))
+					(branches
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-assign (ident "x"))))
+							(value
+								(e-string
+									(e-literal (string "positive: "))
+									(e-dot-access (field "to_str")
+										(receiver
+											(e-lookup-local
+												(p-assign (ident "x"))))
+										(args))
+									(e-literal (string ""))))
+							(guard
+								(e-binop (op "gt")
+									(e-lookup-local
+										(p-assign (ident "x")))
+									(e-num (value "0")))))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-assign (ident "x"))))
+							(value
+								(e-string
+									(e-literal (string "negative: "))
+									(e-dot-access (field "to_str")
+										(receiver
+											(e-lookup-local
+												(p-assign (ident "x"))))
+										(args))
+									(e-literal (string ""))))
+							(guard
+								(e-binop (op "lt")
+									(e-lookup-local
+										(p-assign (ident "x")))
+									(e-num (value "0")))))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-underscore)))
+							(value
+								(e-string
+									(e-literal (string "other")))))))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-lookup (name "I64") (builtin))
+				(ty-lookup (name "Str") (builtin))))))
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Error"))
+(inferred-types
+	(defs
+		(patt (type "I64 -> Str")))
+	(expressions
+		(expr (type "I64 -> Str"))))
 ~~~

--- a/test/snapshots/match_expr/guards_2.md
+++ b/test/snapshots/match_expr/guards_2.md
@@ -1,325 +1,175 @@
 # META
 ~~~ini
-description=Match expression with guard conditions using if clauses
-type=expr
+description=Match expression with guard conditions on list patterns
+type=snippet
 ~~~
 # SOURCE
 ~~~roc
-match value {
-    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${Num.toStr first}"
-    [x, y] if x == y => "pair of equal values: ${Num.toStr x}"
+describe : List(I64) -> Str
+describe = |value| match value {
+    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${first.to_str()}"
+    [x, y] if x == y => "pair of equal values: ${x.to_str()}"
     _ => "other"
 }
 ~~~
 # EXPECTED
-PARSE ERROR - guards_2.md:2:25:2:25
-UNEXPECTED TOKEN IN EXPRESSION - guards_2.md:2:47:2:49
-PARSE ERROR - guards_2.md:2:50:2:51
-PARSE ERROR - guards_2.md:2:92:2:92
-UNEXPECTED TOKEN IN EXPRESSION - guards_2.md:2:92:2:93
-UNEXPECTED TOKEN IN PATTERN - guards_2.md:2:93:2:93
-PARSE ERROR - guards_2.md:2:93:2:93
-UNEXPECTED TOKEN IN EXPRESSION - guards_2.md:2:93:2:94
-PARSE ERROR - guards_2.md:3:12:3:12
-UNEXPECTED TOKEN IN EXPRESSION - guards_2.md:3:22:3:24
-PARSE ERROR - guards_2.md:3:25:3:26
-PARSE ERROR - guards_2.md:3:61:3:61
-UNEXPECTED TOKEN IN EXPRESSION - guards_2.md:3:61:3:62
-UNEXPECTED TOKEN IN PATTERN - guards_2.md:3:62:3:62
-PARSE ERROR - guards_2.md:3:62:3:62
-UNEXPECTED TOKEN IN EXPRESSION - guards_2.md:3:62:3:63
-UNDEFINED VARIABLE - guards_2.md:1:7:1:12
-INVALID IF BRANCH - :0:0:0:0
-UNUSED VARIABLE - guards_2.md:2:6:2:11
-INVALID PATTERN ARGUMENT - :0:0:0:0
-UNRECOGNIZED SYNTAX - guards_2.md:2:92:2:93
+NIL
 # PROBLEMS
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_2.md:2:25:2:25:**
-```roc
-    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${Num.toStr first}"
-```
-                        ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **=>** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_2.md:2:47:2:49:**
-```roc
-    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${Num.toStr first}"
-```
-                                              ^^
-
-
-**PARSE ERROR**
-A parsing error occurred: `string_expected_close_interpolation`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_2.md:2:50:2:51:**
-```roc
-    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${Num.toStr first}"
-```
-                                                 ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_2.md:2:92:2:92:**
-```roc
-    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${Num.toStr first}"
-```
-                                                                                           ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **}** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_2.md:2:92:2:93:**
-```roc
-    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${Num.toStr first}"
-```
-                                                                                           ^
-
-
-**UNEXPECTED TOKEN IN PATTERN**
-The token  is not expected in a pattern.
-Patterns can contain identifiers, literals, lists, records, or tags.
-
-**guards_2.md:2:93:2:93:**
-```roc
-    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${Num.toStr first}"
-```
-                                                                                            ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_2.md:2:93:2:93:**
-```roc
-    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${Num.toStr first}"
-```
-                                                                                            ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **"** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_2.md:2:93:2:94:**
-```roc
-    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${Num.toStr first}"
-```
-                                                                                            ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_2.md:3:12:3:12:**
-```roc
-    [x, y] if x == y => "pair of equal values: ${Num.toStr x}"
-```
-           ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **=>** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_2.md:3:22:3:24:**
-```roc
-    [x, y] if x == y => "pair of equal values: ${Num.toStr x}"
-```
-                     ^^
-
-
-**PARSE ERROR**
-A parsing error occurred: `string_expected_close_interpolation`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_2.md:3:25:3:26:**
-```roc
-    [x, y] if x == y => "pair of equal values: ${Num.toStr x}"
-```
-                        ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_2.md:3:61:3:61:**
-```roc
-    [x, y] if x == y => "pair of equal values: ${Num.toStr x}"
-```
-                                                            ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **}** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_2.md:3:61:3:62:**
-```roc
-    [x, y] if x == y => "pair of equal values: ${Num.toStr x}"
-```
-                                                            ^
-
-
-**UNEXPECTED TOKEN IN PATTERN**
-The token  is not expected in a pattern.
-Patterns can contain identifiers, literals, lists, records, or tags.
-
-**guards_2.md:3:62:3:62:**
-```roc
-    [x, y] if x == y => "pair of equal values: ${Num.toStr x}"
-```
-                                                             ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `match_branch_missing_arrow`
-This is an unexpected parsing error. Please check your syntax.
-
-**guards_2.md:3:62:3:62:**
-```roc
-    [x, y] if x == y => "pair of equal values: ${Num.toStr x}"
-```
-                                                             ^
-
-
-**UNEXPECTED TOKEN IN EXPRESSION**
-The token **"** is not expected in an expression.
-Expressions can be identifiers, literals, function calls, or operators.
-
-**guards_2.md:3:62:3:63:**
-```roc
-    [x, y] if x == y => "pair of equal values: ${Num.toStr x}"
-```
-                                                             ^
-
-
-**UNDEFINED VARIABLE**
-Nothing is named `value` in this scope.
-Is there an `import` or `exposing` missing up-top?
-
-**guards_2.md:1:7:1:12:**
-```roc
-match value {
-```
-      ^^^^^
-
-
-**INVALID IF BRANCH**
-The branch in this `if` expression could not be processed.
-
-The branch must contain a valid expression. Check for syntax errors or missing values.
-
-**UNUSED VARIABLE**
-Variable `first` is not used anywhere in your code.
-
-If you don't need this variable, prefix it with an underscore like `_first` to suppress this warning.
-The unused variable is declared here:
-**guards_2.md:2:6:2:11:**
-```roc
-    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${Num.toStr first}"
-```
-     ^^^^^
-
-
-**INVALID PATTERN ARGUMENT**
-Pattern arguments must be valid patterns like identifiers, literals, or destructuring patterns.
-
-**UNRECOGNIZED SYNTAX**
-I don't recognize this syntax.
-
-**guards_2.md:2:92:2:93:**
-```roc
-    [first, .. as rest] if List.len(rest) > 5 => "long list starting with ${Num.toStr first}"
-```
-                                                                                           ^
-
-This might be a syntax error, an unsupported language feature, or a typo.
-
+NIL
 # TOKENS
 ~~~zig
-KwMatch,LowerIdent,OpenCurly,
-OpenSquare,LowerIdent,Comma,DoubleDot,KwAs,LowerIdent,CloseSquare,KwIf,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpGreaterThan,Int,OpFatArrow,StringStart,StringPart,OpenStringInterpolation,UpperIdent,NoSpaceDotLowerIdent,LowerIdent,CloseStringInterpolation,StringPart,StringEnd,
-OpenSquare,LowerIdent,Comma,LowerIdent,CloseSquare,KwIf,LowerIdent,OpEquals,LowerIdent,OpFatArrow,StringStart,StringPart,OpenStringInterpolation,UpperIdent,NoSpaceDotLowerIdent,LowerIdent,CloseStringInterpolation,StringPart,StringEnd,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,KwMatch,LowerIdent,OpenCurly,
+OpenSquare,LowerIdent,Comma,DoubleDot,KwAs,LowerIdent,CloseSquare,KwIf,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpGreaterThan,Int,OpFatArrow,StringStart,StringPart,OpenStringInterpolation,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,CloseStringInterpolation,StringPart,StringEnd,
+OpenSquare,LowerIdent,Comma,LowerIdent,CloseSquare,KwIf,LowerIdent,OpEquals,LowerIdent,OpFatArrow,StringStart,StringPart,OpenStringInterpolation,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,CloseStringInterpolation,StringPart,StringEnd,
 Underscore,OpFatArrow,StringStart,StringPart,StringEnd,
 CloseCurly,
 EndOfFile,
 ~~~
 # PARSE
 ~~~clojure
-(e-match
-	(e-ident (raw "value"))
-	(branches
-		(branch
-			(p-list
-				(p-ident (raw "first"))
-				(p-list-rest (name "rest")))
-			(e-if-without-else
-				(e-binop (op ">")
-					(e-apply
-						(e-ident (raw "List.len"))
-						(e-ident (raw "rest")))
-					(e-int (raw "5")))
-				(e-malformed (reason "expr_unexpected_token"))))
-		(branch
-			(p-string (raw """))
-			(e-malformed (reason "expr_unexpected_token")))
-		(branch
-			(p-malformed (tag "pattern_unexpected_token"))
-			(e-malformed (reason "expr_unexpected_token")))
-		(branch
-			(p-list
-				(p-ident (raw "x"))
-				(p-ident (raw "y")))
-			(e-if-without-else
-				(e-binop (op "==")
-					(e-ident (raw "x"))
-					(e-ident (raw "y")))
-				(e-malformed (reason "expr_unexpected_token"))))
-		(branch
-			(p-string (raw """))
-			(e-malformed (reason "expr_unexpected_token")))
-		(branch
-			(p-malformed (tag "pattern_unexpected_token"))
-			(e-malformed (reason "expr_unexpected_token")))
-		(branch
-			(p-underscore)
-			(e-string
-				(e-string-part (raw "other"))))))
+(file
+	(type-module)
+	(statements
+		(s-type-anno (name "describe")
+			(ty-fn
+				(ty-apply
+					(ty (name "List"))
+					(ty (name "I64")))
+				(ty (name "Str"))))
+		(s-decl
+			(p-ident (raw "describe"))
+			(e-lambda
+				(args
+					(p-ident (raw "value")))
+				(e-match
+					(e-ident (raw "value"))
+					(branches
+						(branch
+							(p-list
+								(p-ident (raw "first"))
+								(p-list-rest (name "rest")))
+							(guard
+								(e-binop (op ">")
+									(e-apply
+										(e-ident (raw "List.len"))
+										(e-ident (raw "rest")))
+									(e-int (raw "5"))))
+							(e-string
+								(e-string-part (raw "long list starting with "))
+								(e-field-access
+									(e-ident (raw "first"))
+									(e-apply
+										(e-ident (raw "to_str"))))
+								(e-string-part (raw ""))))
+						(branch
+							(p-list
+								(p-ident (raw "x"))
+								(p-ident (raw "y")))
+							(guard
+								(e-binop (op "==")
+									(e-ident (raw "x"))
+									(e-ident (raw "y"))))
+							(e-string
+								(e-string-part (raw "pair of equal values: "))
+								(e-field-access
+									(e-ident (raw "x"))
+									(e-apply
+										(e-ident (raw "to_str"))))
+								(e-string-part (raw ""))))
+						(branch
+							(p-underscore)
+							(e-string
+								(e-string-part (raw "other"))))))))))
 ~~~
 # FORMATTED
 ~~~roc
-match value {
-	[first, .. as rest] => if List.len(rest) > 5 
-	 => 
-	 => 
-	[x, y] => if x == y 
-	 => 
-	 => 
+describe : List(I64) -> Str
+describe = |value| match value {
+	[first, .. as rest] if List.len(rest) > 5 => "long list starting with ${first.to_str()}"
+	[x, y] if x == y => "pair of equal values: ${x.to_str()}"
 	_ => "other"
 }
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-runtime-error (tag "expr_not_canonicalized"))
+(can-ir
+	(d-let
+		(p-assign (ident "describe"))
+		(e-lambda
+			(args
+				(p-assign (ident "value")))
+			(e-match
+				(match
+					(cond
+						(e-lookup-local
+							(p-assign (ident "value"))))
+					(branches
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-list
+										(patterns
+											(p-assign (ident "first")))
+										(rest-at (index 1)
+											(p-assign (ident "rest"))))))
+							(value
+								(e-string
+									(e-literal (string "long list starting with "))
+									(e-dot-access (field "to_str")
+										(receiver
+											(e-lookup-local
+												(p-assign (ident "first"))))
+										(args))
+									(e-literal (string ""))))
+							(guard
+								(e-binop (op "gt")
+									(e-call
+										(e-lookup-external
+											(builtin))
+										(e-lookup-local
+											(p-assign (ident "rest"))))
+									(e-num (value "5")))))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-list
+										(patterns
+											(p-assign (ident "x"))
+											(p-assign (ident "y"))))))
+							(value
+								(e-string
+									(e-literal (string "pair of equal values: "))
+									(e-dot-access (field "to_str")
+										(receiver
+											(e-lookup-local
+												(p-assign (ident "x"))))
+										(args))
+									(e-literal (string ""))))
+							(guard
+								(e-binop (op "eq")
+									(e-lookup-local
+										(p-assign (ident "x")))
+									(e-lookup-local
+										(p-assign (ident "y"))))))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-underscore)))
+							(value
+								(e-string
+									(e-literal (string "other")))))))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-apply (name "List") (builtin)
+					(ty-lookup (name "I64") (builtin)))
+				(ty-lookup (name "Str") (builtin))))))
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Error"))
+(inferred-types
+	(defs
+		(patt (type "List(I64) -> Str")))
+	(expressions
+		(expr (type "List(I64) -> Str"))))
 ~~~


### PR DESCRIPTION
## Summary

- Parses `pattern if guard_expr => body` syntax in match expressions
- Threads the guard through AST, NodeStore, canonicalization, type checking, formatter, and LSP
- The CIR and all downstream passes (exhaustiveness, monomorphization, closure transform, mono IR, RC insertion) already handled guards — they just always received `null` from canonicalization because the parser never produced guards

## Files changed

- **Parser.zig** — parse `if <expr>` between pattern and `=>`
- **AST.zig / Node.zig / NodeStore.zig** — store and retrieve the guard field
- **Can.zig** — canonicalize guard expression with proper free-var filtering
- **Check.zig** — constrain guard to `Bool` (same pattern as `if` conditions)
- **fmt.zig** — format guard as ` if <guard>` between pattern and `=>`
- **selection_range.zig** — handle guard in LSP selection ranges
- **Snapshot tests** — updated to reflect guards now parsing correctly

## Test plan

- [x] `zig build test-parse` passes
- [x] `zig build test-can` passes
- [x] `zig build test-check` passes
- [x] `zig build test` — all 2803 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)