### PR TITLE
Fix match result type using caller's expected type for open tag unions

### DIFF
--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -12582,8 +12582,22 @@ pub const Interpreter = struct {
                 // Get type info for scrutinee and result
                 const scrutinee_ct_var = can.ModuleEnv.varFrom(m.cond);
                 const scrutinee_rt_var = try self.translateTypeVar(self.env, scrutinee_ct_var);
-                const match_result_ct_var = can.ModuleEnv.varFrom(expr_idx);
-                const match_result_rt_var = try self.translateTypeVar(self.env, match_result_ct_var);
+
+                // Use expected_rt_var when available to preserve the caller's wider type.
+                // When a match expression is inside a polymorphic callee (e.g., Cmd.exec_exit_code!),
+                // the callee's compile-time type may have unresolved flex extension variables
+                // (the `..` in open tag unions). The caller's expected type has the full set of
+                // tags after unification, so using it ensures correct discriminant assignment
+                // for tag values created in match branches.
+                const match_result_rt_var = if (expected_rt_var) |expected| blk: {
+                    const expected_resolved = self.runtime_types.resolveVar(expected);
+                    if (expected_resolved.desc.content == .structure or
+                        expected_resolved.desc.content == .alias)
+                    {
+                        break :blk expected;
+                    }
+                    break :blk try self.translateTypeVar(self.env, can.ModuleEnv.varFrom(expr_idx));
+                } else try self.translateTypeVar(self.env, can.ModuleEnv.varFrom(expr_idx));
 
                 const branches = self.env.store.matchBranchSlice(m.branches);
 


### PR DESCRIPTION
In the e_match handler, the match result type was always computed from the callee's compile-time type. When a match expression is inside a polymorphic callee (e.g. Cmd.exec_exit_code!), the callee's type has unresolved flex extension variables (the `..` in open tag unions), so only the tags explicitly present in the callee are visible. Tags created in match branches were assigned discriminants based on this narrower view, causing mismatches when the caller's wider type was used.

For example, Err(FailedToGetExitCode({...})) in the [Cmd module](https://github.com/roc-lang/basic-cli/blob/main/platform/Cmd.roc) got discriminant 0 (only one tag visible), but the caller's type has [Exit(I32), FailedToGetExitCode({...})], where FailedToGetExitCode should be discriminant 1. The raw bytes were then misread by the caller's match as Exit(code) with a garbage code value.

Fix: use expected_rt_var (propagated from caller context) when it resolves to a concrete structure or alias type, instead of always translating from the callee's compile-time type. This preserves the caller's wider type through the match expression, ensuring correct discriminant assignment for tags created in match branches.