### PR TITLE
fix allocator mismatch in deferred_numeric_literals append

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -3402,7 +3402,8 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
             _ = try self.unify(expr_var, flex_var, env);
 
             // Record for deferred validation during comptime eval
-            _ = try self.cir.deferred_numeric_literals.append(self.gpa, .{
+            // Use cir.gpa since deferred_numeric_literals belongs to the ModuleEnv
+            _ = try self.cir.deferred_numeric_literals.append(self.cir.gpa, .{
                 .expr_idx = expr_idx,
                 .type_var = flex_var,
                 .constraint = constraint,
@@ -3437,7 +3438,8 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
             _ = try self.unify(expr_var, flex_var, env);
 
             // Record for deferred validation during comptime eval
-            _ = try self.cir.deferred_numeric_literals.append(self.gpa, .{
+            // Use cir.gpa since deferred_numeric_literals belongs to the ModuleEnv
+            _ = try self.cir.deferred_numeric_literals.append(self.cir.gpa, .{
                 .expr_idx = expr_idx,
                 .type_var = flex_var,
                 .constraint = constraint,

--- a/test/fx/all_syntax_test.roc
+++ b/test/fx/all_syntax_test.roc
@@ -63,10 +63,7 @@ match_list_patterns = |lst| {
 		[2, .., 1] => 88
 		[1, .. as tail] => 77 + tail.len()
 		[_head, 5] => 55
-
-		# Not implemented yet:
-		# [ 99, x ] if x < 4 => 99 + x
-
+		[ 99, x ] if x < 4 => 99 + x
 		# Note: avoid overusing `_` in a match branch, in general you should
 		# try to match all cases explicitly.
 		_ => 100


### PR DESCRIPTION
The e_typed_int and e_typed_frac handlers used self.gpa (the checker's worker allocator) instead of self.cir.gpa (the ModuleEnv's allocator) when appending to deferred_numeric_literals. Since the list was initialized with the ModuleEnv allocator, using a different allocator to resize it caused an "Invalid free" panic from the debug allocator's canary check.

Also uncomment the guard pattern demo in all_syntax_test.roc which was previously disabled.