### PR TITLE
fix false UNDECLARED TYPE for anno-only declarations in type modules

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -2010,7 +2010,23 @@ pub fn canonicalizeFile(
         }
     }
 
-    // Phase 1.5.5: Process anno-only top-level type annotations EARLY
+    // Phase 1.5.5: Introduce type names for types WITHOUT associated blocks
+    // This allows associated blocks (processed in Phase 1.6) to reference sibling types
+    // that are declared without associated blocks (e.g., Positive's negate -> Negative,
+    // or a type alias like NodeKind used in an associated item's type annotation).
+    // Also needed before Phase 1.5.6 so anno-only annotations can resolve type aliases.
+    // We only introduce the name here; full processing happens in Phase 1.7.
+    for (self.parse_ir.store.statementSlice(file.statements)) |stmt_id| {
+        const stmt = self.parse_ir.store.getStatement(stmt_id);
+        if (stmt == .type_decl) {
+            const type_decl = stmt.type_decl;
+            if (type_decl.associated == null) {
+                try self.introduceTypeNameOnly(type_decl);
+            }
+        }
+    }
+
+    // Phase 1.5.6: Process anno-only top-level type annotations EARLY
     // For type-modules, anno-only top-level type annotations (like list_get_unsafe) need to be
     // processed before associated blocks so they can be referenced inside those blocks
     // IMPORTANT: Only process anno-only (no matching decl), and only for type-modules
@@ -2085,21 +2101,6 @@ pub fn canonicalizeFile(
             }
         },
         else => {},
-    }
-
-    // Phase 1.5.8: Introduce type names for types WITHOUT associated blocks
-    // This allows associated blocks (processed in Phase 1.6) to reference sibling types
-    // that are declared without associated blocks (e.g., Positive's negate -> Negative,
-    // or a type alias like NodeKind used in an associated item's type annotation).
-    // We only introduce the name here; full processing happens in Phase 1.7.
-    for (self.parse_ir.store.statementSlice(file.statements)) |stmt_id| {
-        const stmt = self.parse_ir.store.getStatement(stmt_id);
-        if (stmt == .type_decl) {
-            const type_decl = stmt.type_decl;
-            if (type_decl.associated == null) {
-                try self.introduceTypeNameOnly(type_decl);
-            }
-        }
     }
 
     // Phase 1.6: Now process all deferred type declaration associated blocks

--- a/test/snapshots/type_alias_anno_only.md
+++ b/test/snapshots/type_alias_anno_only.md
@@ -1,0 +1,60 @@
+# META
+~~~ini
+description=Type alias used in annotation-only declaration should resolve correctly
+type=snippet
+~~~
+# SOURCE
+~~~roc
+MyType : Str
+
+hey : MyType
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+UpperIdent,OpColon,UpperIdent,
+LowerIdent,OpColon,UpperIdent,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "MyType")
+				(args))
+			(ty (name "Str")))
+		(s-type-anno (name "hey")
+			(ty (name "MyType")))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "hey"))
+		(e-anno-only)
+		(annotation
+			(ty-lookup (name "MyType") (local))))
+	(s-alias-decl
+		(ty-header (name "MyType"))
+		(ty-lookup (name "Str") (builtin))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "MyType")))
+	(type_decls
+		(alias (type "MyType")
+			(ty-header (name "MyType"))))
+	(expressions
+		(expr (type "MyType"))))
+~~~


### PR DESCRIPTION
Type aliases (e.g. `MyType : Str`) were not yet in scope when anno-only annotations (e.g. `hey : MyType` without a definition) were canonicalized, because type name introduction ran after anno-only annotation processing. Swap the two phases so type names are available when anno-only annotations resolve them.

Closes #9216