### PR TITLE
fix "Record field not found in layout" panic with map_err

### DIFF
--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -9771,6 +9771,22 @@ pub const Interpreter = struct {
                                 for (0..num_mappings) |i| {
                                     try self.translate_rigid_subst.put(rigids.items[i], ct_args[i]);
                                 }
+
+                                // Remove translate_cache entries for the backing var and its
+                                // rigid vars. The backing var is shared across all instantiations
+                                // of this nominal type, and the rigid vars are cached with their
+                                // substituted types from a previous instantiation. We must clear
+                                // them so the backing is re-translated with the current
+                                // translate_rigid_subst mappings. We only clear the backing and
+                                // rigids (not all sub-types) because concrete types like Str
+                                // don't depend on substitutions and should keep their cached
+                                // runtime vars for consistency.
+                                const backing_resolved = module.types.resolveVar(ct_backing);
+                                _ = self.translate_cache.remove(.{ .module = module, .var_ = backing_resolved.var_ });
+                                for (rigids.items) |rigid_var| {
+                                    const rigid_resolved = module.types.resolveVar(rigid_var);
+                                    _ = self.translate_cache.remove(.{ .module = module, .var_ = rigid_resolved.var_ });
+                                }
                             }
 
                             // Translate backing (rigids will be substituted via translate_rigid_subst)
@@ -12370,6 +12386,41 @@ pub const Interpreter = struct {
                         if (expected_resolved.desc.content == .structure or
                             expected_resolved.desc.content == .alias)
                         {
+                            // Verify the expected type actually contains the tag we're constructing.
+                            // When a polymorphic function's param and return types share the same
+                            // type variable (e.g. map_err where the type checker unified the error
+                            // type variables), prepareCallWithFuncVar's unification can corrupt the
+                            // expected_rt_var to reflect the INPUT type rather than the OUTPUT type.
+                            // In that case, the expected type won't contain our tag, and we should
+                            // fall through to CT translation for the correct type.
+                            var check_resolved = expected_resolved;
+                            // Unwrap nominal types to get to the tag union
+                            if (check_resolved.desc.content == .structure and check_resolved.desc.content.structure == .nominal_type) {
+                                const nom_backing = self.runtime_types.getNominalBackingVar(check_resolved.desc.content.structure.nominal_type);
+                                check_resolved = self.runtime_types.resolveVar(nom_backing);
+                            }
+                            if (check_resolved.desc.content == .alias) {
+                                const alias_backing = self.runtime_types.getAliasBackingVar(check_resolved.desc.content.alias);
+                                check_resolved = self.runtime_types.resolveVar(alias_backing);
+                            }
+                            if (check_resolved.desc.content == .structure and check_resolved.desc.content.structure == .tag_union) {
+                                const tag_name_str = self.env.getIdent(tag.name);
+                                const rt_tag_ident = try self.runtime_layout_store.getMutableEnv().?.insertIdent(base_pkg.Ident.for_text(tag_name_str));
+                                const check_tu = check_resolved.desc.content.structure.tag_union;
+                                const check_tags = self.runtime_types.getTagsSlice(check_tu.tags);
+                                var tag_found = false;
+                                for (check_tags.items(.name)) |tn| {
+                                    if (tn == rt_tag_ident) {
+                                        tag_found = true;
+                                        break;
+                                    }
+                                }
+                                if (!tag_found) {
+                                    // Tag not found in expected type - fall through to CT translation
+                                    const ct_var = can.ModuleEnv.varFrom(expr_idx);
+                                    break :blk try self.translateTypeVar(self.env, ct_var);
+                                }
+                            }
                             break :blk expected;
                         }
                     }
@@ -13008,6 +13059,7 @@ pub const Interpreter = struct {
                         entry.return_var,
                         .none,
                     );
+
                     // Use the function's return type - it has properly instantiated type args
                     break :blk entry.return_var;
                 } else call_ret_rt_var;
@@ -17004,18 +17056,26 @@ pub const Interpreter = struct {
                     const cleanup_saved_rigid_subst = saved_rigid_subst;
                     saved_rigid_subst = null;
 
-                    try work_stack.push(.{ .apply_continuation = .{ .call_cleanup = .{
-                        .saved_env = saved_env,
-                        .saved_bindings_len = saved_bindings_len,
-                        .param_count = params.len,
-                        .has_active_closure = true,
-                        .did_instantiate = ci.did_instantiate,
-                        .call_ret_rt_var = ci.call_ret_rt_var,
-                        .saved_rigid_subst = cleanup_saved_rigid_subst,
-                        .saved_flex_type_context = saved_flex_type_context,
-                        .arg_rt_vars_to_free = ci.arg_rt_vars_to_free,
-                        .saved_stack_ptr = self.stack_memory.next(),
-                    } } });
+                    try work_stack.push(.{
+                        .apply_continuation = .{
+                            .call_cleanup = .{
+                                .saved_env = saved_env,
+                                .saved_bindings_len = saved_bindings_len,
+                                .param_count = params.len,
+                                .has_active_closure = true,
+                                .did_instantiate = ci.did_instantiate,
+                                // Don't pass call_ret_rt_var for regular (non-method) calls.
+                                // The rt_var override is only needed for dot_access method calls
+                                // where the method body's module may have unified type variables
+                                // that don't reflect the call site's concrete types.
+                                .call_ret_rt_var = null,
+                                .saved_rigid_subst = cleanup_saved_rigid_subst,
+                                .saved_flex_type_context = saved_flex_type_context,
+                                .arg_rt_vars_to_free = ci.arg_rt_vars_to_free,
+                                .saved_stack_ptr = self.stack_memory.next(),
+                            },
+                        },
+                    });
                     try work_stack.push(.{ .eval_expr = .{
                         .expr_idx = header.body_idx,
                         .expected_rt_var = ci.call_ret_rt_var,
@@ -17210,7 +17270,19 @@ pub const Interpreter = struct {
                     self.stack_memory.restore(cleanup.saved_stack_ptr);
                 }
 
-                // rt_var is already set by the function's return value creation
+                // Override rt_var with call_ret_rt_var if available and concrete.
+                // This corrects the return type for polymorphic method calls where the
+                // function body's type (from the method's module, e.g. Builtin) may have
+                // unified type variables that don't reflect the actual concrete types from
+                // the call site (the user module). For example, map_err's body produces a
+                // value typed as Try(ok, a) where a=b in the Builtin module's type store,
+                // but the user module knows the correct type is Try(ok, [Wrapped(...)]).
+                if (cleanup.call_ret_rt_var) |ret_var| {
+                    const ret_resolved = self.runtime_types.resolveVar(ret_var);
+                    if (ret_resolved.desc.content == .structure or ret_resolved.desc.content == .alias) {
+                        result.rt_var = ret_var;
+                    }
+                }
                 try value_stack.push(result);
                 return true;
             },
@@ -19028,13 +19100,29 @@ pub const Interpreter = struct {
                     arg.decref(&self.runtime_layout_store, roc_ops);
                 }
 
+                // Translate the call expression's return type from the CALLER'S module
+                // (saved_env, which is the user module) to get the correct concrete type
+                // for the method call result. This is critical for polymorphic methods like
+                // map_err where the method body's module (Builtin) has unified type variables
+                // that don't distinguish between input and output types.
+                const dot_access_ret_rt_var: ?types.Var = blk: {
+                    const ret_ct_var = can.ModuleEnv.varFrom(dac.expr_idx);
+                    const ret_rt_var = try self.translateTypeVar(@constCast(saved_env), ret_ct_var);
+                    const ret_resolved = self.runtime_types.resolveVar(ret_rt_var);
+                    // Only use if it's a concrete type (not flex/rigid/err)
+                    break :blk if (ret_resolved.desc.content == .structure or ret_resolved.desc.content == .alias)
+                        ret_rt_var
+                    else
+                        null;
+                };
+
                 try work_stack.push(.{ .apply_continuation = .{ .call_cleanup = .{
                     .saved_env = saved_env,
                     .saved_bindings_len = saved_bindings_len,
                     .param_count = expected_params,
                     .has_active_closure = true,
                     .did_instantiate = did_instantiate,
-                    .call_ret_rt_var = null,
+                    .call_ret_rt_var = dot_access_ret_rt_var,
                     .saved_rigid_subst = saved_rigid_subst,
                     .saved_flex_type_context = saved_flex_type_context,
                     .arg_rt_vars_to_free = null,

--- a/src/eval/test/eval_test.zig
+++ b/src/eval/test/eval_test.zig
@@ -3615,3 +3615,45 @@ test "Str.join_with" {
 // Note: Str.from_utf8 returns a Result which requires match support in all evaluators.
 // It is tested indirectly via the encode/decode tests. The wasm codegen for it is implemented
 // but we don't add a standalone test here to avoid DevEvaluator limitations with Result matching.
+
+test "map_err on Try with record error payload does not panic" {
+    // Regression test: calling .map_err on a Try(Str, [BadUtf8({ problem, index })])
+    // caused a "Record field not found in layout" panic because the Builtin module's
+    // type checker unified map_err's error type variables (a and b in
+    // Try(ok, a), (a -> b) -> Try(ok, b)), causing prepareCallWithFuncVar to corrupt
+    // the return type so the function body used the input error type instead of output.
+    //
+    // Uses the interpreter directly because the DevEvaluator doesn't support
+    // match on Try types (see note above about Str.from_utf8).
+    const src =
+        \\{
+        \\    result : Try(Str, [BadUtf8({ problem : U8, index : U64 })])
+        \\    result = Err(BadUtf8({ problem: 0u8, index: 0u64 }))
+        \\    mapped = result.map_err(|err| Wrapped({ msg: "hello", err }))
+        \\    match mapped {
+        \\        Ok(s) => s
+        \\        Err(Wrapped(r)) => r.msg
+        \\        Err(_) => "other error"
+        \\    }
+        \\}
+    ;
+    const resources = try helpers.parseAndCanonicalizeExpr(test_allocator, src);
+    defer helpers.cleanupParseAndCanonical(test_allocator, resources);
+
+    var test_env_instance = TestEnv.init(helpers.interpreter_allocator);
+    defer test_env_instance.deinit();
+
+    const builtin_types = BuiltinTypes.init(resources.builtin_indices, resources.builtin_module.env, resources.builtin_module.env, resources.builtin_module.env);
+    const imported_envs = [_]*const can.ModuleEnv{ resources.module_env, resources.builtin_module.env };
+    var interpreter = try Interpreter.init(helpers.interpreter_allocator, resources.module_env, builtin_types, resources.builtin_module.env, &imported_envs, &resources.checker.import_mapping, null, null, roc_target.RocTarget.detectNative());
+    defer interpreter.deinit();
+
+    const ops = test_env_instance.get_ops();
+    const result = try interpreter.eval(resources.expr_idx, ops);
+
+    try testing.expect(result.layout.tag == .scalar);
+    try testing.expect(result.layout.data.scalar.tag == .str);
+
+    const roc_str: *const builtins.str.RocStr = @ptrCast(@alignCast(result.ptr.?));
+    try testing.expectEqualStrings("hello", roc_str.asSlice());
+}


### PR DESCRIPTION
When map_err is called on a Try containing a record error (e.g. BadUtf8), the interpreter panicked because the Builtin module's type checker unifies
the error type variables `a` and `b` in `map_err : Try(ok, a), (a -> b) ->
Try(ok, b)`. This caused prepareCallWithFuncVar's unification to corrupt the return type, making the function body use the input error type instead of the output error type.

The fix has five parts:
- Clear translate_cache entries for nominal type backing and rigid vars before re-translating with new rigid substitutions, preventing stale cache reuse
- Validate that expected_rt_var contains the tag being constructed in e_tag, falling through to CT translation when the expected type is corrupted
- Translate the method call return type from the caller's module in dot_access_collect_args, providing the correct concrete type
- Override result rt_var with the caller's type in call_cleanup for dot_access method calls where the method body's unified type vars are wrong
- Set call_ret_rt_var to null for regular (non-method) calls in call_invoke_closure to prevent incorrect rt_var overrides