### PR TITLE
Fix nominal no-payload tag union layout getting stale Box placeholder

### DIFF
--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -16150,6 +16150,61 @@ pub const Interpreter = struct {
                                     .rt_var = values[0].rt_var,
                                 };
                                 try inner_value.copyToPtr(&self.runtime_layout_store, payload_ptr, roc_ops);
+                            } else if (values[0].layout.tag == .tag_union and expected_payload_layout.tag == .tag_union) {
+                                // Tag union widening: the actual value is a narrower tag union
+                                // (e.g., [StdoutContainsInvalidUtf8({...})]) being placed into a wider
+                                // tag union (e.g., [FailedToGetExitCode, NonZeroExitCode, StdoutContainsInvalidUtf8]).
+                                // Copy the narrow value's raw bytes first (preserving refcounts),
+                                // then translate the discriminant in-place.
+                                const narrow_size = self.runtime_layout_store.layoutSize(values[0].layout);
+                                const wide_size = self.runtime_layout_store.layoutSize(expected_payload_layout);
+                                if (narrow_size < wide_size) {
+                                    // Tag union widening: determine the correct discriminant mapping
+                                    const narrow_tu_data = self.runtime_layout_store.getTagUnionData(values[0].layout.data.tag_union.idx);
+                                    const narrow_disc = narrow_tu_data.readDiscriminant(@as([*]const u8, @ptrCast(values[0].ptr.?)));
+
+                                    // Get tag names from the narrow type
+                                    var narrow_tag_list = std.array_list.AlignedManaged(types.Tag, null).init(self.allocator);
+                                    defer narrow_tag_list.deinit();
+                                    try self.appendUnionTags(values[0].rt_var, &narrow_tag_list);
+
+                                    // Get tag names from the wide type
+                                    const wide_rt_var = if (tc.arg_rt_vars.len > 0) tc.arg_rt_vars[0] else values[0].rt_var;
+                                    var wide_tag_list = std.array_list.AlignedManaged(types.Tag, null).init(self.allocator);
+                                    defer wide_tag_list.deinit();
+                                    try self.appendUnionTags(wide_rt_var, &wide_tag_list);
+
+                                    // Find the wide discriminant by matching tag names
+                                    var wide_disc: ?u32 = null;
+                                    if (narrow_disc < narrow_tag_list.items.len and wide_tag_list.items.len > narrow_tag_list.items.len) {
+                                        const narrow_tag_name = narrow_tag_list.items[narrow_disc].name;
+                                        for (wide_tag_list.items, 0..) |wide_tag, wi| {
+                                            if (wide_tag.name == narrow_tag_name) {
+                                                wide_disc = @intCast(wi);
+                                                break;
+                                            }
+                                        }
+                                    }
+
+                                    if (wide_disc) |wd| {
+                                        // Zero-fill the wide area, then copy narrow payload data
+                                        @memset(base_ptr[0..wide_size], 0);
+                                        try values[0].copyToPtr(&self.runtime_layout_store, payload_ptr, roc_ops);
+
+                                        // Clear the narrow discriminant and write the wide one
+                                        const narrow_disc_offset = self.runtime_layout_store.getTagUnionDiscriminantOffset(values[0].layout.data.tag_union.idx);
+                                        base_ptr[narrow_disc_offset] = 0;
+
+                                        const wide_tu_data = self.runtime_layout_store.getTagUnionData(expected_payload_layout.data.tag_union.idx);
+                                        const wide_disc_offset_val = self.runtime_layout_store.getTagUnionDiscriminantOffset(expected_payload_layout.data.tag_union.idx);
+                                        wide_tu_data.writeDiscriminantToPtr(base_ptr + wide_disc_offset_val, wd);
+                                    } else {
+                                        // No widening needed (same disc mapping or unknown tag)
+                                        try values[0].copyToPtr(&self.runtime_layout_store, payload_ptr, roc_ops);
+                                    }
+                                } else {
+                                    try values[0].copyToPtr(&self.runtime_layout_store, payload_ptr, roc_ops);
+                                }
                             } else {
                                 try values[0].copyToPtr(&self.runtime_layout_store, payload_ptr, roc_ops);
                             }

--- a/src/layout/store.zig
+++ b/src/layout/store.zig
@@ -2622,13 +2622,15 @@ pub const Store = struct {
                     // Check if this nominal's backing type just finished.
                     // The backing_var should match the var we just cached.
                     if (progress.backing_var == current.var_) {
-                        // Skip container types - they should be handled in the container finish path.
-                        // This prevents incorrect matching when a recursion_var resolves to the same
-                        // var as the backing type, but we haven't actually finished processing the container.
-                        if (current.desc.content == .structure) {
-                            const flat_type = current.desc.content.structure;
-                            if (flat_type == .tag_union or flat_type == .record or flat_type == .tuple) {
-                                // Container type - will be handled in container path below
+                        // Skip container types that actually pushed a pending container - they
+                        // will be handled in the container finish path below.
+                        // IMPORTANT: Only skip if the computed layout is a container type.
+                        // No-payload tag unions (enums) resolve to scalar discriminant layout
+                        // without pushing a container, so they must be handled here.
+                        {
+                            const computed = self.getLayout(layout_idx);
+                            if (computed.tag == .tag_union or computed.tag == .record or computed.tag == .tuple) {
+                                // Container layout - will be handled in container path below
                                 continue;
                             }
                         }

--- a/src/layout/store_test.zig
+++ b/src/layout/store_test.zig
@@ -926,3 +926,104 @@ test "fromTypeVar - recursive nominal with Box has no double-boxing (issue #8916
     const box_elem_layout = lt.layout_store.getLayout(box_elem_idx);
     try testing.expect(box_elem_layout.tag == .tag_union);
 }
+
+test "fromTypeVar - no-payload nominal tag union gets scalar layout, not box" {
+    // Regression test: nominal types backed by no-payload tag unions (enums) should
+    // get scalar discriminant layouts, not stale Box(opaque_ptr) placeholders.
+    //
+    // The bug was in the nominal update check (~line 2634): it checked the type content
+    // (.tag_union) to decide whether to skip the nominal placeholder update (deferring
+    // to the container finish path). But no-payload tag unions resolve to scalar layouts
+    // without pushing a container, so the container finish path never handled them.
+    // The stale Box placeholder remained cached.
+    //
+    // Example Roc code that triggered the bug:
+    //   Utf8ByteProblem := [InvalidStartByte, UnexpectedEndOfSequence, ...]
+    //   result = Str.from_utf8(bytes)  # Returns Try({ byte_problem: Utf8ByteProblem, index: U64 }, ...)
+
+    var lt: LayoutTest = undefined;
+    lt.gpa = testing.allocator;
+    lt.module_env = try ModuleEnv.init(lt.gpa, "");
+    lt.type_store = try types_store.Store.init(lt.gpa);
+
+    // Setup identifiers
+    const my_enum_ident_idx = try lt.module_env.insertIdent(Ident.for_text("MyEnum"));
+    _ = try lt.module_env.insertIdent(Ident.for_text("Box"));
+    const builtin_module_idx = try lt.module_env.insertIdent(Ident.for_text("Builtin"));
+    lt.module_env.idents.builtin_module = builtin_module_idx;
+
+    lt.module_env_ptr[0] = &lt.module_env;
+    lt.layout_store = try Store.init(&lt.module_env_ptr, null, lt.gpa, base.target.TargetUsize.native);
+    lt.layout_store.setOverrideTypesStore(&lt.type_store);
+    lt.type_scope = TypeScope.init(lt.gpa);
+    defer lt.deinit();
+
+    // Step 1: Create MyEnum := [A, B, C] (no-payload nominal tag union / enum)
+    const a_tag = types.Tag{
+        .name = try lt.module_env.insertIdent(Ident.for_text("A")),
+        .args = try lt.type_store.appendVars(&[_]types.Var{}),
+    };
+    const b_tag = types.Tag{
+        .name = try lt.module_env.insertIdent(Ident.for_text("B")),
+        .args = try lt.type_store.appendVars(&[_]types.Var{}),
+    };
+    const c_tag = types.Tag{
+        .name = try lt.module_env.insertIdent(Ident.for_text("C")),
+        .args = try lt.type_store.appendVars(&[_]types.Var{}),
+    };
+    const enum_tags = try lt.type_store.appendTags(&[_]types.Tag{ a_tag, b_tag, c_tag });
+    const enum_tag_union = types.TagUnion{
+        .tags = enum_tags,
+        .ext = try lt.type_store.freshFromContent(.{ .structure = .empty_tag_union }),
+    };
+    const enum_backing_var = try lt.type_store.freshFromContent(.{ .structure = .{ .tag_union = enum_tag_union } });
+
+    const my_enum_content = try lt.type_store.mkNominal(
+        .{ .ident_idx = my_enum_ident_idx },
+        enum_backing_var,
+        &[_]types.Var{},
+        builtin_module_idx,
+        false,
+    );
+    const my_enum_var = try lt.type_store.freshFromContent(my_enum_content);
+
+    // Step 2: Create a record { index: {} (simplified U64), value: MyEnum }
+    const index_var = try lt.type_store.freshFromContent(.{ .structure = .empty_record });
+    const record_fields = try lt.type_store.record_fields.appendSlice(lt.gpa, &[_]types.RecordField{
+        .{ .name = try lt.module_env.insertIdent(Ident.for_text("index")), .var_ = index_var },
+        .{ .name = try lt.module_env.insertIdent(Ident.for_text("value")), .var_ = my_enum_var },
+    });
+    const record_var = try lt.type_store.freshFromContent(.{
+        .structure = .{ .record = .{
+            .fields = record_fields,
+            .ext = try lt.type_store.freshFromContent(.{ .structure = .empty_record }),
+        } },
+    });
+
+    // Step 3: Create a tag union [Foo(record), Bar] to nest the record in a variant
+    const foo_tag = types.Tag{
+        .name = try lt.module_env.insertIdent(Ident.for_text("Foo")),
+        .args = try lt.type_store.appendVars(&[_]types.Var{record_var}),
+    };
+    const bar_tag = types.Tag{
+        .name = try lt.module_env.insertIdent(Ident.for_text("Bar")),
+        .args = try lt.type_store.appendVars(&[_]types.Var{}),
+    };
+    const outer_tags = try lt.type_store.appendTags(&[_]types.Tag{ foo_tag, bar_tag });
+    const outer_tag_union = types.TagUnion{
+        .tags = outer_tags,
+        .ext = try lt.type_store.freshFromContent(.{ .structure = .empty_tag_union }),
+    };
+    const outer_tag_union_var = try lt.type_store.freshFromContent(.{ .structure = .{ .tag_union = outer_tag_union } });
+
+    // Compute the outer tag union layout (this triggers the nested nominal computation)
+    const result_idx = try lt.layout_store.fromTypeVar(0, outer_tag_union_var, &lt.type_scope, null);
+    const result_layout = lt.layout_store.getLayout(result_idx);
+    try testing.expect(result_layout.tag == .tag_union);
+
+    // Step 4: Verify MyEnum's cached layout is scalar, not box.
+    // Before the fix, fromTypeVar would return the stale Box(opaque_ptr) placeholder.
+    const enum_layout_idx = try lt.layout_store.fromTypeVar(0, my_enum_var, &lt.type_scope, null);
+    const enum_layout = lt.layout_store.getLayout(enum_layout_idx);
+    try testing.expect(enum_layout.tag == .scalar);
+}


### PR DESCRIPTION
When a nominal type's backing type was a no-payload tag union (enum), the layout compiler skipped updating the nominal's placeholder because it checked the type content (.tag_union) rather than the computed layout. No-payload tag unions resolve to scalar discriminant layouts without pushing a container, so the container finish path never handled them, leaving a stale Box(opaque_ptr) placeholder in the cache.

Fix: check the computed layout tag instead of the type variable content to determine whether a container was actually pushed. Also add tag union widening support in the interpreter for early returns that widen narrow tag unions into wider ones (translating discriminants by tag name).