### PR TITLE
Fix interpreter and glue generator for polymorphic types

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -4585,6 +4585,10 @@ pub fn canonicalizeExpr(
                         e.token,
                         &strip_tokens,
                     );
+                    if (comptime trace_modules) {
+                        const ident_text = self.env.getIdent(ident);
+                        std.debug.print("[TRACE-CAN] ident blk_qualified: qualified_name={s} ident={s} calling_module={s}\n", .{ qualified_name_text, ident_text, self.env.module_name });
+                    }
                     const qualified_ident = try self.env.insertIdent(base.Ident.for_text(qualified_name_text));
 
                     // Single-lookup approach: look up the qualified name exactly as written.
@@ -4652,6 +4656,18 @@ pub fn canonicalizeExpr(
                             }
                             break :blk null;
                         };
+                        if (comptime trace_modules) {
+                            const alias_text = self.env.getIdent(module_alias);
+                            if (module_info) |info| {
+                                const mn_text = self.env.getIdent(info.module_name);
+                                std.debug.print("[TRACE-CAN]   module_info found: alias={s} module_name={s} is_pkg_qual={}\n", .{ alias_text, mn_text, info.is_package_qualified });
+                            } else {
+                                std.debug.print("[TRACE-CAN]   module_info NOT found for alias={s}\n", .{alias_text});
+                                const is_type = self.scopeLookupTypeBinding(module_alias) != null;
+                                const in_envs = if (self.module_envs) |em| em.contains(module_alias) else false;
+                                std.debug.print("[TRACE-CAN]     is_type_in_scope={} is_in_module_envs={}\n", .{ is_type, in_envs });
+                            }
+                        }
                         const module_name = if (module_info) |info| info.module_name else {
                             // Not a module alias and not an auto-imported module
                             // Check if the qualifier is a type - if so, try to lookup associated items
@@ -4869,6 +4885,18 @@ pub fn canonicalizeExpr(
                                 break :blk module_env.getExposedNodeIndexById(qname_ident);
                             } else null;
 
+                            if (comptime trace_modules) {
+                                const ft = self.env.getIdent(ident);
+                                if (std.mem.eql(u8, ft, "pack")) {
+                                    const mn_text = self.env.getIdent(module_name);
+                                    std.debug.print("[TRACE-CAN]   pack lookup: module_name={s} lookup_module_name={s} import_idx={}\n", .{ mn_text, lookup_module_name, @intFromEnum(import_idx) });
+                                    if (auto_imported_type_info) |info| {
+                                        std.debug.print("[TRACE-CAN]   pack: env.module_name={s} is_placeholder={} statement_idx={}\n", .{ info.env.module_name, info.is_placeholder, info.statement_idx != null });
+                                        const qt = self.env.getIdent(info.qualified_type_ident);
+                                        std.debug.print("[TRACE-CAN]   pack: qualified_type_ident={s} target_node_idx_opt={?}\n", .{ qt, target_node_idx_opt });
+                                    }
+                                }
+                            }
                             // If target_node_idx_opt is null, we need to handle the error case
                             if (target_node_idx_opt == null) {
                                 // Check if the module is in module_envs - if not, the import failed (MODULE NOT FOUND)
@@ -13073,6 +13101,19 @@ fn tryModuleQualifiedLookup(self: *Self, field_access: AST.BinOp) std.mem.Alloca
         };
 
         // Check if this is a type module (like Stdout) - look up the qualified method name directly
+        if (comptime trace_modules) {
+            const mn_text = self.env.getIdent(module_name);
+            const met_text = self.env.getIdent(method_name);
+            const has_envs = self.module_envs != null;
+            std.debug.print("[TRACE-CAN] tryModuleQualifiedLookup: module={s} method={s} calling_module={s} has_envs={}\n", .{ mn_text, met_text, self.env.module_name, has_envs });
+            if (self.module_envs) |envs_map| {
+                if (envs_map.get(module_name)) |ait| {
+                    std.debug.print("[TRACE-CAN]   found in module_envs: env.module_name={s} statement_idx={} is_placeholder={}\n", .{ ait.env.module_name, ait.statement_idx != null, ait.is_placeholder });
+                } else {
+                    std.debug.print("[TRACE-CAN]   NOT found in module_envs\n", .{});
+                }
+            }
+        }
         if (self.module_envs) |envs_map| {
             if (envs_map.get(module_name)) |auto_imported_type| {
                 if (auto_imported_type.statement_idx != null) {

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -4585,10 +4585,6 @@ pub fn canonicalizeExpr(
                         e.token,
                         &strip_tokens,
                     );
-                    if (comptime trace_modules) {
-                        const ident_text = self.env.getIdent(ident);
-                        std.debug.print("[TRACE-CAN] ident blk_qualified: qualified_name={s} ident={s} calling_module={s}\n", .{ qualified_name_text, ident_text, self.env.module_name });
-                    }
                     const qualified_ident = try self.env.insertIdent(base.Ident.for_text(qualified_name_text));
 
                     // Single-lookup approach: look up the qualified name exactly as written.
@@ -4656,18 +4652,6 @@ pub fn canonicalizeExpr(
                             }
                             break :blk null;
                         };
-                        if (comptime trace_modules) {
-                            const alias_text = self.env.getIdent(module_alias);
-                            if (module_info) |info| {
-                                const mn_text = self.env.getIdent(info.module_name);
-                                std.debug.print("[TRACE-CAN]   module_info found: alias={s} module_name={s} is_pkg_qual={}\n", .{ alias_text, mn_text, info.is_package_qualified });
-                            } else {
-                                std.debug.print("[TRACE-CAN]   module_info NOT found for alias={s}\n", .{alias_text});
-                                const is_type = self.scopeLookupTypeBinding(module_alias) != null;
-                                const in_envs = if (self.module_envs) |em| em.contains(module_alias) else false;
-                                std.debug.print("[TRACE-CAN]     is_type_in_scope={} is_in_module_envs={}\n", .{ is_type, in_envs });
-                            }
-                        }
                         const module_name = if (module_info) |info| info.module_name else {
                             // Not a module alias and not an auto-imported module
                             // Check if the qualifier is a type - if so, try to lookup associated items
@@ -4885,18 +4869,6 @@ pub fn canonicalizeExpr(
                                 break :blk module_env.getExposedNodeIndexById(qname_ident);
                             } else null;
 
-                            if (comptime trace_modules) {
-                                const ft = self.env.getIdent(ident);
-                                if (std.mem.eql(u8, ft, "pack")) {
-                                    const mn_text = self.env.getIdent(module_name);
-                                    std.debug.print("[TRACE-CAN]   pack lookup: module_name={s} lookup_module_name={s} import_idx={}\n", .{ mn_text, lookup_module_name, @intFromEnum(import_idx) });
-                                    if (auto_imported_type_info) |info| {
-                                        std.debug.print("[TRACE-CAN]   pack: env.module_name={s} is_placeholder={} statement_idx={}\n", .{ info.env.module_name, info.is_placeholder, info.statement_idx != null });
-                                        const qt = self.env.getIdent(info.qualified_type_ident);
-                                        std.debug.print("[TRACE-CAN]   pack: qualified_type_ident={s} target_node_idx_opt={?}\n", .{ qt, target_node_idx_opt });
-                                    }
-                                }
-                            }
                             // If target_node_idx_opt is null, we need to handle the error case
                             if (target_node_idx_opt == null) {
                                 // Check if the module is in module_envs - if not, the import failed (MODULE NOT FOUND)
@@ -13101,19 +13073,6 @@ fn tryModuleQualifiedLookup(self: *Self, field_access: AST.BinOp) std.mem.Alloca
         };
 
         // Check if this is a type module (like Stdout) - look up the qualified method name directly
-        if (comptime trace_modules) {
-            const mn_text = self.env.getIdent(module_name);
-            const met_text = self.env.getIdent(method_name);
-            const has_envs = self.module_envs != null;
-            std.debug.print("[TRACE-CAN] tryModuleQualifiedLookup: module={s} method={s} calling_module={s} has_envs={}\n", .{ mn_text, met_text, self.env.module_name, has_envs });
-            if (self.module_envs) |envs_map| {
-                if (envs_map.get(module_name)) |ait| {
-                    std.debug.print("[TRACE-CAN]   found in module_envs: env.module_name={s} statement_idx={} is_placeholder={}\n", .{ ait.env.module_name, ait.statement_idx != null, ait.is_placeholder });
-                } else {
-                    std.debug.print("[TRACE-CAN]   NOT found in module_envs\n", .{});
-                }
-            }
-        }
         if (self.module_envs) |envs_map| {
             if (envs_map.get(module_name)) |auto_imported_type| {
                 if (auto_imported_type.statement_idx != null) {

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -7294,9 +7294,16 @@ pub const Interpreter = struct {
                     const arg_resolved = self.runtime_types.resolveVar(arg_var);
                     const effective_layout = blk: {
                         if (arg_resolved.desc.content == .rigid) {
-                            if (self.rigid_subst.get(arg_resolved.var_)) |subst_var| {
+                            // Check both rigid_subst (var-based) and rigid_name_subst
+                            // (name-based, from the platform's `for` clause). This must
+                            // mirror getRuntimeLayout's substitution logic — otherwise
+                            // payloads like Ok({}) in Try({}, I64) keep the inflated
+                            // shared-payload layout instead of resolving to ZST.
+                            const subst_var = self.rigid_subst.get(arg_resolved.var_) orelse
+                                self.rigid_name_subst.get(arg_resolved.desc.content.rigid.name.idx);
+                            if (subst_var) |sv| {
                                 // Use the substituted concrete type's layout
-                                break :blk self.getRuntimeLayout(subst_var) catch variant_layout;
+                                break :blk self.getRuntimeLayout(sv) catch variant_layout;
                             } else {
                                 // No substitution found. For polymorphic functions like List.get,
                                 // the rigid var wasn't properly substituted. As a workaround,
@@ -7338,12 +7345,13 @@ pub const Interpreter = struct {
                                 }
                             }
                         }
-                        // For concrete (structure/alias) types where variant_layout is ZST:
-                        // the tag union was compiled in a polymorphic context (e.g., List.get :
-                        // List(a) -> Result a b) where `a` was unknown, yielding a ZST payload.
+                        // For concrete (structure/alias) types where variant_layout is wrong:
+                        // the tag union was compiled in a polymorphic context where the payload
+                        // type was unknown, yielding either a ZST payload (e.g., List.get) or
+                        // a box_of_zst payload (e.g., render_for_host! where the return type
+                        // Try(Box(Model), I64) leaks Box into the Ok variant layout).
                         // At runtime, compute the correct layout from the concrete arg type.
-                        // Only apply when variant_layout is ZST to avoid disturbing correct layouts.
-                        if (variant_layout.tag == .zst and
+                        if ((variant_layout.tag == .zst or variant_layout.tag == .box_of_zst) and
                             (arg_resolved.desc.content == .structure or arg_resolved.desc.content == .alias))
                         {
                             if (self.getRuntimeLayout(arg_var)) |computed_layout| {
@@ -7485,6 +7493,23 @@ pub const Interpreter = struct {
         roc_ops: *RocOps,
     ) !StackValue {
         traceDbg(roc_ops, "evalBoxIntrinsic: entering with arg_value.layout.tag={s}", .{@tagName(arg_value.layout.tag)});
+
+        // If the payload is ZST, always use box_of_zst regardless of what the
+        // polymorphic return type variable resolves to.
+        // Also handle the case where the payload has box_of_zst layout due to type
+        // variable contamination (e.g., render_for_host! where the return type
+        // Try(Box(Model), I64) causes the Ok variant's Model type to be resolved as
+        // Box(Model) instead of Model). In that case, the payload is conceptually
+        // ZST but has 8-byte box_of_zst layout. Boxing it should produce box_of_zst,
+        // not allocate a new box wrapping the null pointer.
+        const payload_size = self.runtime_layout_store.layoutSize(arg_value.layout);
+        if (payload_size == 0 or arg_value.layout.tag == .box_of_zst) {
+            traceDbg(roc_ops, "evalBoxIntrinsic: payload is ZST (size=0) or box_of_zst, using box_of_zst", .{});
+            const return_ct_var = can.ModuleEnv.varFrom(return_expr_idx);
+            const return_rt_var = try self.translateTypeVar(self.env, return_ct_var);
+            return try self.makeBoxValueFromLayout(layout.Layout.boxOfZst(), arg_value, roc_ops, return_rt_var);
+        }
+
         const return_ct_var = can.ModuleEnv.varFrom(return_expr_idx);
         traceDbg(roc_ops, "evalBoxIntrinsic: return_ct_var obtained", .{});
         const return_rt_var = try self.translateTypeVar(self.env, return_ct_var);

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -7287,9 +7287,10 @@ pub const Interpreter = struct {
                     // even though the type says it's the recursive type directly.
                     const variant_layout = acc.getVariantLayout(tag_index);
 
-                    // For rigid type variables, the variant_layout may be incorrect (e.g., ZST)
-                    // because the layout was computed before type substitution. Check if we have
-                    // a substitution and use its layout instead.
+                    // The variant_layout may be incorrect (e.g., ZST) when the tag union was
+                    // compiled in a polymorphic context (e.g., List.get : List(a) -> Result a b)
+                    // where the payload type `a` was a rigid/flex var at layout-computation time.
+                    // When we have a concrete arg type at runtime, compute the correct layout.
                     const arg_resolved = self.runtime_types.resolveVar(arg_var);
                     const effective_layout = blk: {
                         if (arg_resolved.desc.content == .rigid) {
@@ -7336,6 +7337,18 @@ pub const Interpreter = struct {
                                     }
                                 }
                             }
+                        }
+                        // For concrete (structure/alias) types where variant_layout is ZST:
+                        // the tag union was compiled in a polymorphic context (e.g., List.get :
+                        // List(a) -> Result a b) where `a` was unknown, yielding a ZST payload.
+                        // At runtime, compute the correct layout from the concrete arg type.
+                        // Only apply when variant_layout is ZST to avoid disturbing correct layouts.
+                        if (variant_layout.tag == .zst and
+                            (arg_resolved.desc.content == .structure or arg_resolved.desc.content == .alias))
+                        {
+                            if (self.getRuntimeLayout(arg_var)) |computed_layout| {
+                                break :blk computed_layout;
+                            } else |_| {}
                         }
                         break :blk variant_layout;
                     };

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -12824,31 +12824,36 @@ pub const Interpreter = struct {
                         break :blk self.resolved_module_envs[resolved_idx];
                     };
                     if (other_env) |builtin_env| {
-                        const target_def_idx: can.CIR.Def.Idx = @enumFromInt(lookup.target_node_idx);
-                        const target_def = builtin_env.store.getDef(target_def_idx);
-                        const target_pattern = builtin_env.store.getPattern(target_def.pattern);
-                        if (target_pattern == .assign) {
-                            const method_ident = target_pattern.assign.ident;
-                            const is_box_method = method_ident == builtin_env.idents.builtin_box_box;
-                            const is_unbox_method = method_ident == builtin_env.idents.builtin_box_unbox;
-                            // Check if this is Box.box
-                            if (is_box_method and arg_indices.len == 1) {
-                                const arg_expr = arg_indices[0];
-                                const arg_value = try self.evalWithExpectedType(arg_expr, roc_ops, null);
-                                defer arg_value.decref(&self.runtime_layout_store, roc_ops);
+                        // Guard: only attempt Box intrinsic detection if the target node is actually a def.
+                        // External lookups can point to type declaration statement nodes (not defs) for
+                        // type modules, so we must check before calling getDef.
+                        if (builtin_env.store.isDefNode(@intCast(lookup.target_node_idx))) {
+                            const target_def_idx: can.CIR.Def.Idx = @enumFromInt(lookup.target_node_idx);
+                            const target_def = builtin_env.store.getDef(target_def_idx);
+                            const target_pattern = builtin_env.store.getPattern(target_def.pattern);
+                            if (target_pattern == .assign) {
+                                const method_ident = target_pattern.assign.ident;
+                                const is_box_method = method_ident == builtin_env.idents.builtin_box_box;
+                                const is_unbox_method = method_ident == builtin_env.idents.builtin_box_unbox;
+                                // Check if this is Box.box
+                                if (is_box_method and arg_indices.len == 1) {
+                                    const arg_expr = arg_indices[0];
+                                    const arg_value = try self.evalWithExpectedType(arg_expr, roc_ops, null);
+                                    defer arg_value.decref(&self.runtime_layout_store, roc_ops);
 
-                                const result = try self.evalBoxIntrinsic(arg_value, expr_idx, roc_ops);
-                                try value_stack.push(result);
-                                return;
-                            }
-                            // Check if this is Box.unbox
-                            if (is_unbox_method and arg_indices.len == 1) {
-                                const arg_expr = arg_indices[0];
-                                const boxed_value = try self.evalWithExpectedType(arg_expr, roc_ops, null);
-                                defer boxed_value.decref(&self.runtime_layout_store, roc_ops);
+                                    const result = try self.evalBoxIntrinsic(arg_value, expr_idx, roc_ops);
+                                    try value_stack.push(result);
+                                    return;
+                                }
+                                // Check if this is Box.unbox
+                                if (is_unbox_method and arg_indices.len == 1) {
+                                    const arg_expr = arg_indices[0];
+                                    const boxed_value = try self.evalWithExpectedType(arg_expr, roc_ops, null);
+                                    defer boxed_value.decref(&self.runtime_layout_store, roc_ops);
 
-                                try self.evalUnboxIntrinsic(boxed_value, value_stack, roc_ops);
-                                return;
+                                    try self.evalUnboxIntrinsic(boxed_value, value_stack, roc_ops);
+                                    return;
+                                }
                             }
                         }
                     }
@@ -14532,20 +14537,22 @@ pub const Interpreter = struct {
         // backwards compatibility with unit tests that don't call resolveImports.
         //
         const other_env = blk: {
-            // Only use import_envs if self.env is the primary module or app_env,
-            // since import_envs only contains mappings from those modules.
-            if (self.env == self.root_env or (self.app_env != null and self.env == @constCast(self.app_env.?))) {
-                if (self.import_envs.get(lookup.module_idx)) |env| {
-                    traceDbg(roc_ops, "evalLookupExternal: \"{s}\" import[{d}] -> \"{s}\"", .{ self.env.module_name, @intFromEnum(lookup.module_idx), env.module_name });
-                    break :blk env;
-                }
-            }
-            // Fall back to resolved module indices + resolved_module_envs
-            // Note: resolved_idx is an index into the other_envs array passed to resolveImports,
-            // which is stored in resolved_module_envs (NOT all_module_envs which has env at [0])
+            // Always prefer the module's own resolved import table. Each module has its own
+            // import index space, so env.imports.resolved_modules is the only correct source
+            // of truth for the module currently being executed.
             if (self.env.imports.getResolvedModule(lookup.module_idx)) |resolved_idx| {
                 std.debug.assert(resolved_idx < self.resolved_module_envs.len);
-                break :blk self.resolved_module_envs[resolved_idx];
+                const found_env = self.resolved_module_envs[resolved_idx];
+                traceDbg(roc_ops, "evalLookupExternal: \"{s}\" import[{d}] -> \"{s}\"", .{ self.env.module_name, @intFromEnum(lookup.module_idx), found_env.module_name });
+                break :blk found_env;
+            }
+            // Fall back to import_envs for backwards compatibility with unit tests
+            // that construct the interpreter without calling resolveImports.
+            if (self.env == self.root_env or (self.app_env != null and self.env == @constCast(self.app_env.?))) {
+                if (self.import_envs.get(lookup.module_idx)) |env| {
+                    traceDbg(roc_ops, "evalLookupExternal: \"{s}\" import[{d}] -> \"{s}\" (import_envs fallback)", .{ self.env.module_name, @intFromEnum(lookup.module_idx), env.module_name });
+                    break :blk env;
+                }
             }
             traceDbg(roc_ops, "evalLookupExternal: UNRESOLVED import[{d}] in \"{s}\"", .{ @intFromEnum(lookup.module_idx), self.env.module_name });
             self.triggerCrash("e_lookup_external: unresolved import", false, roc_ops);
@@ -14554,6 +14561,18 @@ pub const Interpreter = struct {
 
         // The target_node_idx is a Def.Idx in the other module
         const target_def_idx: can.CIR.Def.Idx = @enumFromInt(lookup.target_node_idx);
+
+        // Guard: the target node must be a def. Non-def nodes (e.g. statement_nominal_decl
+        // for type modules) indicate the canonicalizer stored the wrong node index.
+        if (!other_env.store.isDefNode(@intCast(lookup.target_node_idx))) {
+            const ident_text = self.env.getIdent(lookup.ident_idx);
+            var buf: [256]u8 = undefined;
+            const msg = std.fmt.bufPrint(&buf, "evalLookupExternal: target node is not a def (node_idx={d}, ident=\"{s}\", target_module=\"{s}\", calling_module=\"{s}\")", .{
+                lookup.target_node_idx, ident_text, other_env.module_name, self.env.module_name,
+            }) catch "evalLookupExternal: target node is not a def";
+            self.triggerCrash(msg, false, roc_ops);
+            return error.Crash;
+        }
 
         const target_def = other_env.store.getDef(target_def_idx);
 
@@ -19056,12 +19075,12 @@ pub const Interpreter = struct {
                         all_args[1 + idx] = arg;
                     }
 
-                    // For hosted functions, translate the return type from the CALLEE's module
-                    // (self.env), not the caller's module (saved_env). The caller's type store
-                    // may have .err content for cross-module opaque types because the union-find
-                    // chain was lost during serialization.
-                    const return_ct_var = can.ModuleEnv.varFrom(closure_header.lambda_expr_idx);
-                    const return_rt_var = try self.translateTypeVar(self.env, return_ct_var);
+                    // Use the call-site return type (dac.expr_idx) from the caller's env.
+                    // dac.expr_idx is the e_dot_access expression whose CT var is the return type.
+                    // Do NOT use closure_header.lambda_expr_idx here — that gives the function
+                    // type itself (fn(Host, Str) => Try(Str, ...)), not its return type.
+                    const return_ct_var = can.ModuleEnv.varFrom(dac.expr_idx);
+                    const return_rt_var = try self.translateTypeVar(saved_env, return_ct_var);
 
                     const result = try self.callHostedFunction(hosted.index, all_args, roc_ops, return_rt_var);
 

--- a/src/glue/glue.zig
+++ b/src/glue/glue.zig
@@ -1065,8 +1065,8 @@ const TypeTable = struct {
             const names = slice.items(.name);
             const vars = slice.items(.var_);
             for (names, vars) |n, v| {
-                all_names.append(self.gpa, n) catch {};
-                all_vars.append(self.gpa, v) catch {};
+                all_names.append(self.gpa, n) catch return self.oomUnknown("record");
+                all_vars.append(self.gpa, v) catch return self.oomUnknown("record");
             }
 
             // Follow the extension variable to the next record segment

--- a/src/glue/glue.zig
+++ b/src/glue/glue.zig
@@ -404,11 +404,49 @@ fn rocGlueInner(gpa: Allocator, stderr: *std.Io.Writer, stdout: *std.Io.Writer, 
         return error.CompilationFailed;
     };
 
+    // 5b. Compute per-target layouts
+    // Deduplicate by pointer width: compute once per unique width, share result
+    var per_target_layouts = gpa.alloc([]CollectedTypeLayout, platform_info.targets.len) catch {
+        return error.OutOfMemory;
+    };
+    defer {
+        // Free unique layouts only (avoid double-free for shared layouts)
+        var freed = std.AutoHashMap(usize, void).init(gpa);
+        defer freed.deinit();
+        for (per_target_layouts) |layouts| {
+            const ptr_val = @intFromPtr(layouts.ptr);
+            if (!freed.contains(ptr_val)) {
+                freed.put(ptr_val, {}) catch {};
+                freeComputedLayouts(gpa, layouts);
+            }
+        }
+        gpa.free(per_target_layouts);
+    }
+
+    // Track already-computed layouts by pointer width for dedup
+    var width_to_layouts = std.AutoHashMap(u16, []CollectedTypeLayout).init(gpa);
+    defer width_to_layouts.deinit();
+
+    for (platform_info.targets, 0..) |target_name, ti| {
+        const roc_tgt = roc_target.RocTarget.fromString(target_name) orelse RocTarget.detectNative();
+        const ptr_width = roc_tgt.ptrBitWidth();
+
+        if (width_to_layouts.get(ptr_width)) |existing| {
+            per_target_layouts[ti] = existing;
+        } else {
+            const layouts = computeLayoutsForTarget(gpa, type_table.entries.items, roc_tgt) catch {
+                return error.OutOfMemory;
+            };
+            per_target_layouts[ti] = layouts;
+            width_to_layouts.put(ptr_width, layouts) catch {};
+        }
+    }
+
     // 6. Construct List(Types) as C-ABI structs
     const hosted_function_ptrs = [_]builtins.host_abi.HostedFn{};
     var roc_ops = echo_platform.makeDefaultRocOps(@constCast(&hosted_function_ptrs));
 
-    var types_list = constructTypesRocList(collected_modules.items, &platform_info, cir_provides_entries.items, &type_table, &entrypoint_type_ids, &provides_type_ids, &roc_ops);
+    var types_list = constructTypesRocList(collected_modules.items, &platform_info, cir_provides_entries.items, &type_table, &entrypoint_type_ids, &provides_type_ids, per_target_layouts, &roc_ops);
 
     // 7. Run glue spec via interpreter
     var result_buf: ResultListFileStr = undefined;
@@ -475,6 +513,7 @@ fn rocGlueInner(gpa: Allocator, stderr: *std.Io.Writer, stdout: *std.Io.Writer, 
 pub const PlatformHeaderInfo = struct {
     requires_entries: []RequiresEntry,
     type_aliases: [][]const u8,
+    targets: [][]const u8,
 
     pub const RequiresEntry = struct {
         name: []const u8,
@@ -498,6 +537,10 @@ pub const PlatformHeaderInfo = struct {
             gpa.free(alias_name);
         }
         gpa.free(self.type_aliases);
+        for (self.targets) |target_name| {
+            gpa.free(target_name);
+        }
+        gpa.free(self.targets);
     }
 };
 
@@ -607,9 +650,59 @@ fn parsePlatformHeader(gpa: Allocator, platform_path: []const u8) !PlatformHeade
                 try type_aliases.append(gpa, key.*);
             }
 
+            // Extract target names from the targets section
+            var target_names = std.ArrayList([]const u8).empty;
+            errdefer {
+                for (target_names.items) |tn| gpa.free(tn);
+                target_names.deinit(gpa);
+            }
+            // Use a set to deduplicate target names across exe/static_lib
+            var target_dedup = std.StringHashMap(void).init(gpa);
+            defer target_dedup.deinit();
+
+            if (platform_header.targets) |targets_idx| {
+                const targets_section = parse_ast.store.getTargetsSection(targets_idx);
+
+                // Collect from exe targets
+                if (targets_section.exe) |exe_idx| {
+                    const exe_link = parse_ast.store.getTargetLinkType(exe_idx);
+                    const entries = parse_ast.store.targetEntrySlice(exe_link.entries);
+                    for (entries) |entry_idx| {
+                        const tentry = parse_ast.store.getTargetEntry(entry_idx);
+                        const tname = parse_ast.resolve(tentry.target);
+                        if (!target_dedup.contains(tname)) {
+                            const duped = try gpa.dupe(u8, tname);
+                            try target_dedup.put(duped, {});
+                            try target_names.append(gpa, duped);
+                        }
+                    }
+                }
+
+                // Collect from static_lib targets
+                if (targets_section.static_lib) |lib_idx| {
+                    const lib_link = parse_ast.store.getTargetLinkType(lib_idx);
+                    const entries = parse_ast.store.targetEntrySlice(lib_link.entries);
+                    for (entries) |entry_idx| {
+                        const tentry = parse_ast.store.getTargetEntry(entry_idx);
+                        const tname = parse_ast.resolve(tentry.target);
+                        if (!target_dedup.contains(tname)) {
+                            const duped = try gpa.dupe(u8, tname);
+                            try target_dedup.put(duped, {});
+                            try target_names.append(gpa, duped);
+                        }
+                    }
+                }
+            }
+
+            // Default to native target if no targets section
+            if (target_names.items.len == 0) {
+                try target_names.append(gpa, try gpa.dupe(u8, RocTarget.detectNative().toName()));
+            }
+
             return PlatformHeaderInfo{
                 .requires_entries = try requires_entries.toOwnedSlice(gpa),
                 .type_aliases = try type_aliases.toOwnedSlice(gpa),
+                .targets = try target_names.toOwnedSlice(gpa),
             };
         },
         else => return error.NotPlatformFile,
@@ -671,6 +764,9 @@ const CollectedModuleTypeInfo = struct {
 };
 
 /// Internal representation of a collected type for the type table.
+/// Contains only structural information (field names, type_ids, tag names).
+/// Layout information (sizes, alignments, field ordering) is computed separately
+/// per target via `computeLayoutsForTarget`.
 const CollectedTypeRepr = union(enum) {
     bool_,
     box: u64,
@@ -693,40 +789,40 @@ const CollectedTypeRepr = union(enum) {
     function: struct { arg_ids: []const u64, ret_id: u64 },
     record: struct {
         name: []const u8,
+        /// Fields stored in alphabetical order by name (canonical, target-independent).
         fields: []const CollectedRecordField,
-        size: u64,
-        alignment: u64,
-        /// Alt (other pointer-size) layout fields, populated only when field ordering differs.
-        alt_fields: []const CollectedRecordField = &.{},
-        alt_size: u64 = 0,
-        alt_alignment: u64 = 0,
     },
-    tag_union: struct { name: []const u8, tags: []const CollectedTagInfo, size: u64, alignment: u64 },
+    tag_union: struct { name: []const u8, tags: []const CollectedTagInfo },
     unknown: []const u8,
 };
 
 const CollectedRecordField = struct {
     name: []const u8,
     type_id: u64,
-    size: u64,
-    alignment: u64,
 };
 
 const CollectedTagInfo = struct {
     name: []const u8,
     payload_ids: []const u64,
-    payload_size: u64,
-    payload_alignment: u64,
+};
+
+/// Per-type layout information computed for a specific target.
+const CollectedTypeLayout = struct {
+    size: u64,
+    alignment: u64,
+    /// For records: permutation of field indices giving ABI ordering for this target.
+    /// Empty for non-records.
+    field_order: []const u64,
 };
 
 /// Builds a type table from compiler type vars, deduplicating entries.
+/// Contains only structural type information; layout is computed separately per target.
 const TypeTable = struct {
     entries: std.ArrayList(CollectedTypeRepr),
     var_map: std.AutoHashMap(@import("types").Var, u64),
     /// Maps structural record signatures to existing type table indices for dedup.
     record_dedup: std.StringHashMap(u64),
     gpa: std.mem.Allocator,
-    target: RocTarget,
 
     const types = @import("types");
 
@@ -736,7 +832,6 @@ const TypeTable = struct {
             .var_map = std.AutoHashMap(types.Var, u64).init(gpa),
             .record_dedup = std.StringHashMap(u64).init(gpa),
             .gpa = gpa,
-            .target = RocTarget.detectNative(),
         };
     }
 
@@ -761,10 +856,6 @@ const TypeTable = struct {
                     self.freeDuped(field.name);
                 }
                 self.gpa.free(rec.fields);
-                for (rec.alt_fields) |field| {
-                    self.freeDuped(field.name);
-                }
-                if (rec.alt_fields.len > 0) self.gpa.free(rec.alt_fields);
                 self.freeDuped(rec.name);
             },
             .tag_union => |tu| {
@@ -859,11 +950,6 @@ const TypeTable = struct {
                     self.entries.items[@intCast(idx)] = .{ .record = .{
                         .name = std.fmt.allocPrint(self.gpa, "__AnonStruct{d}", .{idx}) catch "",
                         .fields = rec.fields,
-                        .size = rec.size,
-                        .alignment = rec.alignment,
-                        .alt_fields = rec.alt_fields,
-                        .alt_size = rec.alt_size,
-                        .alt_alignment = rec.alt_alignment,
                     } };
                     return idx;
                 }
@@ -896,40 +982,6 @@ const TypeTable = struct {
         const idx: u64 = @intCast(self.entries.items.len);
         self.entries.append(self.gpa, .unit) catch return 0;
         return idx;
-    }
-
-    const SizeAlign = struct { size: u64, alignment: u64 };
-
-    /// Get the size and alignment for a type table entry by index.
-    fn getSizeAlign(self: *const TypeTable, type_id: u64) SizeAlign {
-        if (type_id >= self.entries.items.len) return .{ .size = 0, .alignment = 1 };
-        return getSizeAlignForRepr(self.entries.items[@intCast(type_id)], self.target);
-    }
-
-    /// Get the size and alignment for a CollectedTypeRepr.
-    fn getSizeAlignForRepr(repr: CollectedTypeRepr, target: RocTarget) SizeAlign {
-        const ptr_size: u64 = target.ptrBitWidth() / 8;
-        return switch (repr) {
-            .bool_ => .{ .size = 1, .alignment = 1 },
-            .box => .{ .size = ptr_size, .alignment = ptr_size },
-            .u8_, .i8_ => .{ .size = 1, .alignment = 1 },
-            .u16_, .i16_ => .{ .size = 2, .alignment = 2 },
-            .u32_, .i32_, .f32_ => .{ .size = 4, .alignment = 4 },
-            .u64_, .i64_, .f64_, .dec => .{ .size = 8, .alignment = 8 },
-            .u128_, .i128_ => .{ .size = 16, .alignment = 16 },
-            .str_ => .{ .size = ptr_size * 3, .alignment = ptr_size },
-            .list => .{ .size = ptr_size * 3, .alignment = ptr_size },
-            .unit => .{ .size = 0, .alignment = 0 },
-            .record => |rec| .{ .size = rec.size, .alignment = rec.alignment },
-            .function => .{ .size = 0, .alignment = 1 },
-            .tag_union => |tu| .{ .size = tu.size, .alignment = tu.alignment },
-            .unknown => .{ .size = 0, .alignment = 1 },
-        };
-    }
-
-    /// Get the canonical "other" pointer-size target for alt layout computation.
-    fn altTarget(target: RocTarget) RocTarget {
-        if (target.ptrBitWidth() == 64) return .wasm32 else return .x64linux;
     }
 
     fn convertContent(self: *TypeTable, env: *const ModuleEnv, content: types.Content) CollectedTypeRepr {
@@ -1009,11 +1061,6 @@ const TypeTable = struct {
                         return .{ .record = .{
                             .name = self.gpa.dupe(u8, display_name) catch "",
                             .fields = rec.fields,
-                            .size = rec.size,
-                            .alignment = rec.alignment,
-                            .alt_fields = rec.alt_fields,
-                            .alt_size = rec.alt_size,
-                            .alt_alignment = rec.alt_alignment,
                         } };
                     },
                     else => return record_repr,
@@ -1031,8 +1078,6 @@ const TypeTable = struct {
                         return .{ .tag_union = .{
                             .name = self.gpa.dupe(u8, display_name) catch "",
                             .tags = collected_tu.tags,
-                            .size = collected_tu.size,
-                            .alignment = collected_tu.alignment,
                         } };
                     },
                     else => return tu_repr,
@@ -1094,187 +1139,40 @@ const TypeTable = struct {
             field_type_ids[i] = self.getOrInsert(env, all_vars.items[i]);
         }
 
-        // Get size/alignment for each field
-        const field_sizes = self.gpa.alloc(SizeAlign, field_count) catch return self.oomUnknown("record");
-        defer self.gpa.free(field_sizes);
-        for (0..field_count) |i| {
-            field_sizes[i] = self.getSizeAlign(field_type_ids[i]);
-        }
-
-        // Build sortable array of field indices
+        // Build sortable array of field indices for alphabetical ordering
         var field_indices = self.gpa.alloc(usize, field_count) catch return self.oomUnknown("record");
         defer self.gpa.free(field_indices);
         for (0..field_count) |i| {
             field_indices[i] = i;
         }
 
-        // Sort by alignment descending, then name ascending (matching store.zig ABI)
+        // Sort alphabetically by name (canonical, target-independent order)
         const SortCtx = struct {
             names: []const base.Ident.Idx,
             idents: *const base.Ident.Store,
-            sizes: []const SizeAlign,
 
             pub fn lessThan(ctx: @This(), a: usize, b: usize) bool {
-                const a_align = ctx.sizes[a].alignment;
-                const b_align = ctx.sizes[b].alignment;
-                if (a_align != b_align) {
-                    return a_align > b_align; // descending alignment
-                }
                 const a_text = ctx.idents.getText(ctx.names[a]);
                 const b_text = ctx.idents.getText(ctx.names[b]);
                 return std.mem.order(u8, a_text, b_text) == .lt;
             }
         };
-        std.mem.sort(usize, field_indices, SortCtx{ .names = all_names.items, .idents = ident_store, .sizes = field_sizes }, SortCtx.lessThan);
+        std.mem.sort(usize, field_indices, SortCtx{ .names = all_names.items, .idents = ident_store }, SortCtx.lessThan);
 
-        // Build collected fields in sorted order and compute record size
+        // Build collected fields in alphabetical order
         const collected_fields = self.gpa.alloc(CollectedRecordField, field_count) catch return self.oomUnknown("record");
-        var max_alignment: u64 = 0;
-        var current_offset: u64 = 0;
         for (field_indices, 0..) |src_idx, dst_idx| {
             const name_text = ident_store.getText(all_names.items[src_idx]);
-            const f_size = field_sizes[src_idx].size;
-            const f_align = field_sizes[src_idx].alignment;
-
-            // Track max alignment for the record
-            if (f_align > max_alignment) max_alignment = f_align;
-
-            // Align current offset
-            if (f_align > 0) {
-                const rem = current_offset % f_align;
-                if (rem != 0) current_offset += f_align - rem;
-            }
-            current_offset += f_size;
-
             collected_fields[dst_idx] = .{
                 .name = self.gpa.dupe(u8, name_text) catch "",
                 .type_id = field_type_ids[src_idx],
-                .size = f_size,
-                .alignment = f_align,
             };
         }
-
-        // Round total size up to max alignment
-        var record_size = current_offset;
-        if (max_alignment > 0) {
-            const rem = record_size % max_alignment;
-            if (rem != 0) record_size += max_alignment - rem;
-        }
-
-        // Compute alt (other pointer-size) layout to detect divergence
-        const alt_layout = self.computeAltRecordLayout(
-            field_count,
-            field_type_ids,
-            all_names.items,
-            ident_store,
-            field_indices,
-        );
 
         return .{ .record = .{
             .name = "",
             .fields = collected_fields,
-            .size = record_size,
-            .alignment = max_alignment,
-            .alt_fields = alt_layout.fields,
-            .alt_size = alt_layout.size,
-            .alt_alignment = alt_layout.alignment,
         } };
-    }
-
-    const AltLayout = struct {
-        fields: []const CollectedRecordField,
-        size: u64,
-        alignment: u64,
-    };
-
-    /// Compute the alt-target record layout. Returns non-empty fields only when
-    /// the field ordering differs from the primary layout.
-    fn computeAltRecordLayout(
-        self: *TypeTable,
-        field_count: usize,
-        field_type_ids: []const u64,
-        names: anytype,
-        ident_store: *const base.Ident.Store,
-        primary_indices: []const usize,
-    ) AltLayout {
-        const alt_tgt = altTarget(self.target);
-
-        // Get alt-target size/alignment for each field
-        const alt_sizes = self.gpa.alloc(SizeAlign, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
-        defer self.gpa.free(alt_sizes);
-        for (0..field_count) |i| {
-            if (field_type_ids[i] < self.entries.items.len) {
-                alt_sizes[i] = getSizeAlignForRepr(self.entries.items[@intCast(field_type_ids[i])], alt_tgt);
-            } else {
-                alt_sizes[i] = .{ .size = 0, .alignment = 1 };
-            }
-        }
-
-        // Sort by alt alignment descending, then name ascending
-        var alt_indices = self.gpa.alloc(usize, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
-        defer self.gpa.free(alt_indices);
-        for (0..field_count) |i| {
-            alt_indices[i] = i;
-        }
-
-        const AltSortCtx = struct {
-            nm: @TypeOf(names),
-            ids: *const base.Ident.Store,
-            szs: []const SizeAlign,
-
-            pub fn lessThan(ctx: @This(), a: usize, b: usize) bool {
-                const a_align = ctx.szs[a].alignment;
-                const b_align = ctx.szs[b].alignment;
-                if (a_align != b_align) return a_align > b_align;
-                const a_text = ctx.ids.getText(ctx.nm[a]);
-                const b_text = ctx.ids.getText(ctx.nm[b]);
-                return std.mem.order(u8, a_text, b_text) == .lt;
-            }
-        };
-        std.mem.sort(usize, alt_indices, AltSortCtx{ .nm = names, .ids = ident_store, .szs = alt_sizes }, AltSortCtx.lessThan);
-
-        // Check if field order differs
-        var orders_differ = false;
-        for (0..field_count) |i| {
-            if (primary_indices[i] != alt_indices[i]) {
-                orders_differ = true;
-                break;
-            }
-        }
-
-        if (!orders_differ) return .{ .fields = &.{}, .size = 0, .alignment = 0 };
-
-        // Build alt collected fields
-        const alt_fields = self.gpa.alloc(CollectedRecordField, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
-        var alt_max_alignment: u64 = 0;
-        var alt_offset: u64 = 0;
-        for (alt_indices, 0..) |src_idx, dst_idx| {
-            const name_text = ident_store.getText(names[src_idx]);
-            const f_size = alt_sizes[src_idx].size;
-            const f_align = alt_sizes[src_idx].alignment;
-
-            if (f_align > alt_max_alignment) alt_max_alignment = f_align;
-            if (f_align > 0) {
-                const rem = alt_offset % f_align;
-                if (rem != 0) alt_offset += f_align - rem;
-            }
-            alt_offset += f_size;
-
-            alt_fields[dst_idx] = .{
-                .name = self.gpa.dupe(u8, name_text) catch "",
-                .type_id = field_type_ids[src_idx],
-                .size = f_size,
-                .alignment = f_align,
-            };
-        }
-
-        var alt_record_size = alt_offset;
-        if (alt_max_alignment > 0) {
-            const rem = alt_record_size % alt_max_alignment;
-            if (rem != 0) alt_record_size += alt_max_alignment - rem;
-        }
-
-        return .{ .fields = alt_fields, .size = alt_record_size, .alignment = alt_max_alignment };
     }
 
     fn oomUnknown(self: *TypeTable, name: []const u8) CollectedTypeRepr {
@@ -1292,168 +1190,19 @@ const TypeTable = struct {
             field_type_ids[i] = self.getOrInsert(env, ev);
         }
 
-        const field_sizes = self.gpa.alloc(SizeAlign, elem_vars.len) catch return self.oomUnknown("tuple");
-        defer self.gpa.free(field_sizes);
-        for (0..elem_vars.len) |i| {
-            field_sizes[i] = self.getSizeAlign(field_type_ids[i]);
-        }
-
-        // Generate positional field names (_0, _1, ...) before sorting
-        const field_names = self.gpa.alloc([]const u8, elem_vars.len) catch return self.oomUnknown("tuple");
-        defer self.gpa.free(field_names);
-        for (0..elem_vars.len) |i| {
-            field_names[i] = std.fmt.allocPrint(self.gpa, "_{d}", .{i}) catch "";
-        }
-
-        // Sort by alignment descending, then name ascending (matching Roc ABI)
-        var field_indices = self.gpa.alloc(usize, elem_vars.len) catch return self.oomUnknown("tuple");
-        defer self.gpa.free(field_indices);
-        for (0..elem_vars.len) |i| {
-            field_indices[i] = i;
-        }
-
-        const SortCtx = struct {
-            sizes: []const SizeAlign,
-            names: []const []const u8,
-
-            pub fn lessThan(ctx: @This(), a: usize, b: usize) bool {
-                const a_align = ctx.sizes[a].alignment;
-                const b_align = ctx.sizes[b].alignment;
-                if (a_align != b_align) {
-                    return a_align > b_align; // descending alignment
-                }
-                return std.mem.order(u8, ctx.names[a], ctx.names[b]) == .lt;
-            }
-        };
-        std.mem.sort(usize, field_indices, SortCtx{ .sizes = field_sizes, .names = field_names }, SortCtx.lessThan);
-
+        // Generate positional field names (_0, _1, ...) — already alphabetical
         const collected_fields = self.gpa.alloc(CollectedRecordField, elem_vars.len) catch return self.oomUnknown("tuple");
-        var max_alignment: u64 = 0;
-        var current_offset: u64 = 0;
-        for (field_indices, 0..) |src_idx, dst_idx| {
-            const f_size = field_sizes[src_idx].size;
-            const f_align = field_sizes[src_idx].alignment;
-
-            if (f_align > max_alignment) max_alignment = f_align;
-
-            if (f_align > 0) {
-                const rem = current_offset % f_align;
-                if (rem != 0) current_offset += f_align - rem;
-            }
-            current_offset += f_size;
-
-            collected_fields[dst_idx] = .{
-                .name = field_names[src_idx],
-                .type_id = field_type_ids[src_idx],
-                .size = f_size,
-                .alignment = f_align,
+        for (0..elem_vars.len) |i| {
+            collected_fields[i] = .{
+                .name = std.fmt.allocPrint(self.gpa, "_{d}", .{i}) catch "",
+                .type_id = field_type_ids[i],
             };
         }
-
-        var record_size = current_offset;
-        if (max_alignment > 0) {
-            const rem = record_size % max_alignment;
-            if (rem != 0) record_size += max_alignment - rem;
-        }
-
-        // Compute alt (other pointer-size) layout to detect divergence
-        const alt_layout = self.computeAltTupleLayout(
-            elem_vars.len,
-            field_type_ids,
-            field_names,
-            field_indices,
-        );
 
         return .{ .record = .{
             .name = "",
             .fields = collected_fields,
-            .size = record_size,
-            .alignment = max_alignment,
-            .alt_fields = alt_layout.fields,
-            .alt_size = alt_layout.size,
-            .alt_alignment = alt_layout.alignment,
         } };
-    }
-
-    /// Compute the alt-target tuple layout. Returns non-empty fields only when
-    /// the field ordering differs from the primary layout.
-    fn computeAltTupleLayout(
-        self: *TypeTable,
-        field_count: usize,
-        field_type_ids: []const u64,
-        field_names: []const []const u8,
-        primary_indices: []const usize,
-    ) AltLayout {
-        const alt_tgt = altTarget(self.target);
-
-        const alt_sizes = self.gpa.alloc(SizeAlign, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
-        defer self.gpa.free(alt_sizes);
-        for (0..field_count) |i| {
-            if (field_type_ids[i] < self.entries.items.len) {
-                alt_sizes[i] = getSizeAlignForRepr(self.entries.items[@intCast(field_type_ids[i])], alt_tgt);
-            } else {
-                alt_sizes[i] = .{ .size = 0, .alignment = 1 };
-            }
-        }
-
-        var alt_indices = self.gpa.alloc(usize, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
-        defer self.gpa.free(alt_indices);
-        for (0..field_count) |i| {
-            alt_indices[i] = i;
-        }
-
-        const TupleSortCtx = struct {
-            szs: []const SizeAlign,
-            nms: []const []const u8,
-
-            pub fn lessThan(ctx: @This(), a: usize, b: usize) bool {
-                const a_align = ctx.szs[a].alignment;
-                const b_align = ctx.szs[b].alignment;
-                if (a_align != b_align) return a_align > b_align;
-                return std.mem.order(u8, ctx.nms[a], ctx.nms[b]) == .lt;
-            }
-        };
-        std.mem.sort(usize, alt_indices, TupleSortCtx{ .szs = alt_sizes, .nms = field_names }, TupleSortCtx.lessThan);
-
-        var orders_differ = false;
-        for (0..field_count) |i| {
-            if (primary_indices[i] != alt_indices[i]) {
-                orders_differ = true;
-                break;
-            }
-        }
-
-        if (!orders_differ) return .{ .fields = &.{}, .size = 0, .alignment = 0 };
-
-        const alt_fields = self.gpa.alloc(CollectedRecordField, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
-        var alt_max_alignment: u64 = 0;
-        var alt_offset: u64 = 0;
-        for (alt_indices, 0..) |src_idx, dst_idx| {
-            const f_size = alt_sizes[src_idx].size;
-            const f_align = alt_sizes[src_idx].alignment;
-
-            if (f_align > alt_max_alignment) alt_max_alignment = f_align;
-            if (f_align > 0) {
-                const rem = alt_offset % f_align;
-                if (rem != 0) alt_offset += f_align - rem;
-            }
-            alt_offset += f_size;
-
-            alt_fields[dst_idx] = .{
-                .name = self.gpa.dupe(u8, field_names[src_idx]) catch "",
-                .type_id = field_type_ids[src_idx],
-                .size = f_size,
-                .alignment = f_align,
-            };
-        }
-
-        var alt_record_size = alt_offset;
-        if (alt_max_alignment > 0) {
-            const rem = alt_record_size % alt_max_alignment;
-            if (rem != 0) alt_record_size += alt_max_alignment - rem;
-        }
-
-        return .{ .fields = alt_fields, .size = alt_record_size, .alignment = alt_max_alignment };
     }
 
     fn convertTagUnion(self: *TypeTable, env: *const ModuleEnv, tag_union: types.TagUnion) CollectedTypeRepr {
@@ -1484,10 +1233,8 @@ const TypeTable = struct {
         };
         std.mem.sort(usize, tag_indices, SortCtx{ .names = tag_names, .idents = ident_store }, SortCtx.lessThan);
 
-        // Collect tags and compute per-variant payload layout
+        // Collect tags with just name and payload type ids (no layout)
         const collected_tags = self.gpa.alloc(CollectedTagInfo, tag_names.len) catch return self.oomUnknown("tag_union");
-        var max_payload_size: u64 = 0;
-        var max_payload_alignment: u64 = 0;
 
         // Also build auto-generated name from variant names joined with "Or"
         var name_len: usize = 0;
@@ -1510,33 +1257,9 @@ const TypeTable = struct {
                 payload_ids[i] = self.getOrInsert(env, av);
             }
 
-            // Compute payload as a tuple: sequential fields with alignment padding
-            var payload_size: u64 = 0;
-            var payload_alignment: u64 = 0;
-            for (payload_ids) |pid| {
-                const sa = self.getSizeAlign(pid);
-                if (sa.alignment > payload_alignment) payload_alignment = sa.alignment;
-                // Align current offset
-                if (sa.alignment > 0) {
-                    const rem = payload_size % sa.alignment;
-                    if (rem != 0) payload_size += sa.alignment - rem;
-                }
-                payload_size += sa.size;
-            }
-            // Round up to payload alignment
-            if (payload_alignment > 0) {
-                const rem = payload_size % payload_alignment;
-                if (rem != 0) payload_size += payload_alignment - rem;
-            }
-
-            if (payload_size > max_payload_size) max_payload_size = payload_size;
-            if (payload_alignment > max_payload_alignment) max_payload_alignment = payload_alignment;
-
             collected_tags[dst_idx] = .{
                 .name = self.gpa.dupe(u8, name_text) catch "",
                 .payload_ids = payload_ids,
-                .payload_size = payload_size,
-                .payload_alignment = payload_alignment,
             };
 
             // Build auto-name
@@ -1555,34 +1278,13 @@ const TypeTable = struct {
             }
         }
 
-        // Compute discriminant size/alignment from tag count.
-        // Single-variant tag unions have no discriminant (ZigGlue unwraps them to payload).
-        const disc_size: u64 = if (tag_names.len <= 1) 0 else layout.TagUnionData.discriminantSize(tag_names.len);
-        const disc_align: u64 = disc_size;
-
-        // Compute overall tag union layout: payload at offset 0, discriminant at end
-        // disc_offset = alignForward(max_payload_size, disc_align)
-        var disc_offset = max_payload_size;
-        if (disc_align > 0) {
-            const rem = disc_offset % disc_align;
-            if (rem != 0) disc_offset += disc_align - rem;
-        }
-
-        const total_align = @max(max_payload_alignment, disc_align);
-        // total_size = alignForward(disc_offset + disc_size, total_align)
-        var total_size = disc_offset + disc_size;
-        if (total_align > 0) {
-            const rem = total_size % total_align;
-            if (rem != 0) total_size += total_align - rem;
-        }
-
-        // Disambiguate tag unions that share variant names but have different
-        // payload types by appending _{size}_{alignment} to the auto-name
-        // (e.g. "ErrOrOk" becomes "ErrOrOk_16_8" vs "ErrOrOk_32_8").
+        // Use the type table index for disambiguation instead of size/alignment
+        // (we no longer have sizes at this point)
+        const idx: u64 = @intCast(self.entries.items.len);
         const auto_name: []const u8 = std.fmt.allocPrint(
             self.gpa,
-            "{s}_{d}_{d}",
-            .{ auto_name_buf[0..name_pos], total_size, total_align },
+            "{s}_{d}",
+            .{ auto_name_buf[0..name_pos], idx },
         ) catch auto_name_buf[0..name_pos];
         if (auto_name.ptr != auto_name_buf.ptr) {
             self.gpa.free(auto_name_buf);
@@ -1591,8 +1293,6 @@ const TypeTable = struct {
         return .{ .tag_union = .{
             .name = auto_name,
             .tags = collected_tags,
-            .size = total_size,
-            .alignment = total_align,
         } };
     }
 
@@ -1625,6 +1325,194 @@ const TypeTable = struct {
         return raw_name;
     }
 };
+
+/// Compute per-type layouts for a specific target.
+/// Returns one CollectedTypeLayout per type table entry (same index).
+///
+/// Uses recursive computation because the type table inserts parent placeholders
+/// before children (getOrInsert pattern), so a forward pass would read uncomputed
+/// child layouts. Each entry is computed at most once (tracked by `computed` flags).
+fn computeLayoutsForTarget(
+    gpa: std.mem.Allocator,
+    entries: []const CollectedTypeRepr,
+    target: RocTarget,
+) ![]CollectedTypeLayout {
+    const layouts = try gpa.alloc(CollectedTypeLayout, entries.len);
+    @memset(layouts, .{ .size = 0, .alignment = 0, .field_order = &.{} });
+    const computed = try gpa.alloc(bool, entries.len);
+    defer gpa.free(computed);
+    @memset(computed, false);
+    const ptr_size: u64 = target.ptrBitWidth() / 8;
+
+    for (0..entries.len) |i| {
+        try computeLayoutForEntry(gpa, entries, layouts, computed, i, ptr_size);
+    }
+
+    return layouts;
+}
+
+/// Recursively compute the layout for a single type table entry.
+/// Ensures all referenced child types are computed first.
+fn computeLayoutForEntry(
+    gpa: std.mem.Allocator,
+    entries: []const CollectedTypeRepr,
+    layouts: []CollectedTypeLayout,
+    computed: []bool,
+    i: usize,
+    ptr_size: u64,
+) !void {
+    if (computed[i]) return;
+    computed[i] = true;
+
+    layouts[i] = switch (entries[i]) {
+        .bool_ => .{ .size = 1, .alignment = 1, .field_order = &.{} },
+        .box => .{ .size = ptr_size, .alignment = ptr_size, .field_order = &.{} },
+        .u8_, .i8_ => .{ .size = 1, .alignment = 1, .field_order = &.{} },
+        .u16_, .i16_ => .{ .size = 2, .alignment = 2, .field_order = &.{} },
+        .u32_, .i32_, .f32_ => .{ .size = 4, .alignment = 4, .field_order = &.{} },
+        .u64_, .i64_, .f64_, .dec => .{ .size = 8, .alignment = 8, .field_order = &.{} },
+        .u128_, .i128_ => .{ .size = 16, .alignment = 16, .field_order = &.{} },
+        .str_ => .{ .size = ptr_size * 3, .alignment = ptr_size, .field_order = &.{} },
+        .list => .{ .size = ptr_size * 3, .alignment = ptr_size, .field_order = &.{} },
+        .unit => .{ .size = 0, .alignment = 0, .field_order = &.{} },
+        .function => .{ .size = 0, .alignment = 1, .field_order = &.{} },
+        .unknown => .{ .size = 0, .alignment = 1, .field_order = &.{} },
+        .record => |rec| blk: {
+            const field_count = rec.fields.len;
+            if (field_count == 0) break :blk .{ .size = 0, .alignment = 0, .field_order = &.{} };
+
+            // Recursively ensure all field types are computed first
+            for (rec.fields) |field| {
+                if (field.type_id < entries.len) {
+                    try computeLayoutForEntry(gpa, entries, layouts, computed, @intCast(field.type_id), ptr_size);
+                }
+            }
+
+            // Get size/alignment for each field from now-computed layouts
+            const field_sa = try gpa.alloc(SizeAlign, field_count);
+            defer gpa.free(field_sa);
+            for (rec.fields, 0..) |field, fi| {
+                if (field.type_id < entries.len) {
+                    field_sa[fi] = .{ .size = layouts[@intCast(field.type_id)].size, .alignment = layouts[@intCast(field.type_id)].alignment };
+                } else {
+                    field_sa[fi] = .{ .size = 0, .alignment = 1 };
+                }
+            }
+
+            // Build field indices and sort by alignment desc, then name asc (Roc ABI)
+            const field_indices = try gpa.alloc(usize, field_count);
+            defer gpa.free(field_indices);
+            for (0..field_count) |fi| {
+                field_indices[fi] = fi;
+            }
+
+            const RecordSortCtx = struct {
+                sa: []const SizeAlign,
+                flds: []const CollectedRecordField,
+
+                pub fn lessThan(ctx: @This(), a: usize, b: usize) bool {
+                    const a_align = ctx.sa[a].alignment;
+                    const b_align = ctx.sa[b].alignment;
+                    if (a_align != b_align) return a_align > b_align;
+                    return std.mem.order(u8, ctx.flds[a].name, ctx.flds[b].name) == .lt;
+                }
+            };
+            std.mem.sort(usize, field_indices, RecordSortCtx{ .sa = field_sa, .flds = rec.fields }, RecordSortCtx.lessThan);
+
+            // Compute padded offsets and total size
+            var max_alignment: u64 = 0;
+            var current_offset: u64 = 0;
+            for (field_indices) |src_idx| {
+                const f_align = field_sa[src_idx].alignment;
+                const f_size = field_sa[src_idx].size;
+                if (f_align > max_alignment) max_alignment = f_align;
+                if (f_align > 0) {
+                    const rem = current_offset % f_align;
+                    if (rem != 0) current_offset += f_align - rem;
+                }
+                current_offset += f_size;
+            }
+            if (max_alignment > 0) {
+                const rem = current_offset % max_alignment;
+                if (rem != 0) current_offset += max_alignment - rem;
+            }
+
+            // Store field_order as the ABI-sorted permutation
+            const field_order = try gpa.alloc(u64, field_count);
+            for (field_indices, 0..) |src_idx, dst_idx| {
+                field_order[dst_idx] = @intCast(src_idx);
+            }
+
+            break :blk .{ .size = current_offset, .alignment = max_alignment, .field_order = field_order };
+        },
+        .tag_union => |tu| blk: {
+            // Recursively ensure all payload types are computed first
+            for (tu.tags) |tag| {
+                for (tag.payload_ids) |pid| {
+                    if (pid < entries.len) {
+                        try computeLayoutForEntry(gpa, entries, layouts, computed, @intCast(pid), ptr_size);
+                    }
+                }
+            }
+
+            // Compute per-variant payload sizes from now-computed layouts
+            var max_payload_size: u64 = 0;
+            var max_payload_alignment: u64 = 0;
+
+            for (tu.tags) |tag| {
+                var payload_size: u64 = 0;
+                var payload_alignment: u64 = 0;
+                for (tag.payload_ids) |pid| {
+                    const sa: SizeAlign = if (pid < entries.len)
+                        .{ .size = layouts[@intCast(pid)].size, .alignment = layouts[@intCast(pid)].alignment }
+                    else
+                        .{ .size = 0, .alignment = 1 };
+                    if (sa.alignment > payload_alignment) payload_alignment = sa.alignment;
+                    if (sa.alignment > 0) {
+                        const rem = payload_size % sa.alignment;
+                        if (rem != 0) payload_size += sa.alignment - rem;
+                    }
+                    payload_size += sa.size;
+                }
+                if (payload_alignment > 0) {
+                    const rem = payload_size % payload_alignment;
+                    if (rem != 0) payload_size += payload_alignment - rem;
+                }
+                if (payload_size > max_payload_size) max_payload_size = payload_size;
+                if (payload_alignment > max_payload_alignment) max_payload_alignment = payload_alignment;
+            }
+
+            // Discriminant
+            const disc_size: u64 = if (tu.tags.len <= 1) 0 else layout.TagUnionData.discriminantSize(tu.tags.len);
+            const disc_align: u64 = disc_size;
+
+            var disc_offset = max_payload_size;
+            if (disc_align > 0) {
+                const rem = disc_offset % disc_align;
+                if (rem != 0) disc_offset += disc_align - rem;
+            }
+
+            const total_align = @max(max_payload_alignment, disc_align);
+            var total_size = disc_offset + disc_size;
+            if (total_align > 0) {
+                const rem = total_size % total_align;
+                if (rem != 0) total_size += total_align - rem;
+            }
+
+            break :blk .{ .size = total_size, .alignment = total_align, .field_order = &.{} };
+        },
+    };
+}
+
+const SizeAlign = struct { size: u64, alignment: u64 };
+
+/// Free computed layouts, including any allocated field_order slices.
+fn freeComputedLayouts(gpa: std.mem.Allocator, layouts: []CollectedTypeLayout) void {
+    for (layouts) |l| {
+        if (l.field_order.len > 0) gpa.free(l.field_order);
+    }
+    gpa.free(layouts);
+}
 
 // Roc C-ABI struct definitions for glue platform types.
 // Fields are ordered alphabetically to match Roc's C ABI layout.
@@ -1668,12 +1556,27 @@ const ProvidesEntryRoc = extern struct {
     type_id: u64,
 };
 
-/// Types := { entrypoints : List(EntryPoint), modules : List(ModuleTypeInfo), provides_entries : List(ProvidesEntry), type_table : List(TypeRepr) }
+/// TypeLayout := { alignment : U64, field_order : List(U64), size : U64 } — fields alphabetical
+const TypeLayoutRoc = extern struct {
+    alignment: u64,
+    field_order: RocList,
+    size: u64,
+};
+
+/// TargetLayout := { target : Str, type_layouts : List(TypeLayout) } — fields alphabetical
+const TargetLayoutRoc = extern struct {
+    target: RocStr,
+    type_layouts: RocList,
+};
+
+/// Types := { entrypoints : List(EntryPoint), layouts : List(TargetLayout), modules : List(ModuleTypeInfo), provides_entries : List(ProvidesEntry), target_names : List(Str), type_table : List(TypeRepr) }
 /// Fields ordered by alignment descending, then alphabetically
 const TypesInnerRoc = extern struct {
     entrypoints: RocList,
+    layouts: RocList,
     modules: RocList,
     provides_entries: RocList,
+    target_names: RocList,
     type_table: RocList,
 };
 
@@ -1732,22 +1635,15 @@ const FunctionPayload = extern struct {
     ret: u64,
 };
 
-/// RecordRepr := { alignment : U64, alt_alignment : U64, alt_fields : List(RecordField), alt_size : U64, fields : List(RecordField), name : Str, size : U64 } — fields alphabetical
+/// RecordRepr := { fields : List(RecordField), name : Str } — fields alphabetical
 const RecordPayload = extern struct {
-    alignment: u64,
-    alt_alignment: u64,
-    alt_fields: RocList,
-    alt_size: u64,
     fields: RocList,
     name: RocStr,
-    size: u64,
 };
 
-/// TagUnionRepr := { alignment : U64, name : Str, size : U64, tags : List(TagVariant) } — fields alphabetical
+/// TagUnionRepr := { name : Str, tags : List(TagVariant) } — fields alphabetical
 const TagUnionPayload = extern struct {
-    alignment: u64,
     name: RocStr,
-    size: u64,
     tags: RocList,
 };
 
@@ -1767,20 +1663,16 @@ const TypeReprRoc = extern struct {
     tag: TypeReprTag,
 };
 
-/// RecordField := { alignment : U64, name : Str, size : U64, type_id : U64 }
+/// RecordField := { name : Str, type_id : U64 } — fields alphabetical
 const RecordFieldTypeReprRoc = extern struct {
-    alignment: u64,
     name: RocStr,
-    size: u64,
     type_id: u64,
 };
 
-/// TagVariant := { name : Str, payload : List(U64), payload_alignment : U64, payload_size : U64 }
+/// TagVariant := { name : Str, payload : List(U64) } — fields alphabetical
 const TagVariantRoc = extern struct {
     name: RocStr,
     payload: RocList,
-    payload_alignment: u64,
-    payload_size: u64,
 };
 
 const SMALL_STRING_SIZE = @sizeOf(RocStr);
@@ -1917,9 +1809,7 @@ fn serializeTypeRepr(
                 const fptr: [*]RecordFieldTypeReprRoc = @ptrCast(@alignCast(fb));
                 for (rec.fields, 0..) |field, i| {
                     fptr[i] = .{
-                        .alignment = field.alignment,
                         .name = createBigRocStr(field.name, roc_ops),
-                        .size = field.size,
                         .type_id = field.type_id,
                     };
                 }
@@ -1930,39 +1820,9 @@ fn serializeTypeRepr(
                 };
             } else RocList.empty();
 
-            // Build alt_fields list (empty if no alt layout)
-            const alt_fields_list = if (rec.alt_fields.len > 0) afblk: {
-                const alt_data_size = rec.alt_fields.len * @sizeOf(RecordFieldTypeReprRoc);
-                const afb = builtins.utils.allocateWithRefcount(
-                    alt_data_size,
-                    @alignOf(RecordFieldTypeReprRoc),
-                    true,
-                    roc_ops,
-                );
-                const afptr: [*]RecordFieldTypeReprRoc = @ptrCast(@alignCast(afb));
-                for (rec.alt_fields, 0..) |field, i| {
-                    afptr[i] = .{
-                        .alignment = field.alignment,
-                        .name = createBigRocStr(field.name, roc_ops),
-                        .size = field.size,
-                        .type_id = field.type_id,
-                    };
-                }
-                break :afblk RocList{
-                    .bytes = afb,
-                    .length = rec.alt_fields.len,
-                    .capacity_or_alloc_ptr = rec.alt_fields.len,
-                };
-            } else RocList.empty();
-
             result.payload.record = .{
-                .alignment = rec.alignment,
-                .alt_alignment = rec.alt_alignment,
-                .alt_fields = alt_fields_list,
-                .alt_size = rec.alt_size,
                 .fields = fields_list,
                 .name = createBigRocStr(rec.name, roc_ops),
-                .size = rec.size,
             };
         },
         .tag_union => |tu| {
@@ -1981,8 +1841,6 @@ fn serializeTypeRepr(
                     tptr[i] = .{
                         .name = createBigRocStr(tag.name, roc_ops),
                         .payload = buildU64RocList(tag.payload_ids, roc_ops),
-                        .payload_alignment = tag.payload_alignment,
-                        .payload_size = tag.payload_size,
                     };
                 }
                 break :tblk RocList{
@@ -1993,9 +1851,7 @@ fn serializeTypeRepr(
             } else RocList.empty();
 
             result.payload.tag_union = .{
-                .alignment = tu.alignment,
                 .name = createBigRocStr(tu.name, roc_ops),
-                .size = tu.size,
                 .tags = tags_list,
             };
         },
@@ -2034,6 +1890,86 @@ fn buildTypeTableRocList(
     };
 }
 
+/// Build a RocList of RocStr from a string slice.
+fn buildStrRocList(
+    strings: []const []const u8,
+    roc_ops: *builtins.host_abi.RocOps,
+) RocList {
+    if (strings.len == 0) return RocList.empty();
+
+    const data_size = strings.len * @sizeOf(RocStr);
+    const bytes = builtins.utils.allocateWithRefcount(
+        data_size,
+        @alignOf(RocStr),
+        true,
+        roc_ops,
+    );
+    const ptr: [*]RocStr = @ptrCast(@alignCast(bytes));
+    for (strings, 0..) |s, i| {
+        ptr[i] = createBigRocStr(s, roc_ops);
+    }
+    return RocList{
+        .bytes = bytes,
+        .length = strings.len,
+        .capacity_or_alloc_ptr = strings.len,
+    };
+}
+
+/// Build a RocList of TargetLayoutRoc from per-target layout data.
+fn buildLayoutsRocList(
+    target_names: []const []const u8,
+    per_target_layouts: []const []CollectedTypeLayout,
+    roc_ops: *builtins.host_abi.RocOps,
+) RocList {
+    if (target_names.len == 0) return RocList.empty();
+
+    const data_size = target_names.len * @sizeOf(TargetLayoutRoc);
+    const bytes = builtins.utils.allocateWithRefcount(
+        data_size,
+        @alignOf(TargetLayoutRoc),
+        true,
+        roc_ops,
+    );
+    const ptr: [*]TargetLayoutRoc = @ptrCast(@alignCast(bytes));
+
+    for (target_names, per_target_layouts, 0..) |tname, layouts, i| {
+        // Build type_layouts list for this target
+        const tl_list = if (layouts.len > 0) tblk: {
+            const tl_data_size = layouts.len * @sizeOf(TypeLayoutRoc);
+            const tl_bytes = builtins.utils.allocateWithRefcount(
+                tl_data_size,
+                @alignOf(TypeLayoutRoc),
+                true,
+                roc_ops,
+            );
+            const tl_ptr: [*]TypeLayoutRoc = @ptrCast(@alignCast(tl_bytes));
+            for (layouts, 0..) |l, j| {
+                tl_ptr[j] = TypeLayoutRoc{
+                    .alignment = l.alignment,
+                    .field_order = buildU64RocList(l.field_order, roc_ops),
+                    .size = l.size,
+                };
+            }
+            break :tblk RocList{
+                .bytes = tl_bytes,
+                .length = layouts.len,
+                .capacity_or_alloc_ptr = layouts.len,
+            };
+        } else RocList.empty();
+
+        ptr[i] = TargetLayoutRoc{
+            .target = createBigRocStr(tname, roc_ops),
+            .type_layouts = tl_list,
+        };
+    }
+
+    return RocList{
+        .bytes = bytes,
+        .length = target_names.len,
+        .capacity_or_alloc_ptr = target_names.len,
+    };
+}
+
 /// Construct the List(Types) Roc value from collected module type info.
 fn constructTypesRocList(
     collected_modules: []const CollectedModuleTypeInfo,
@@ -2042,6 +1978,7 @@ fn constructTypesRocList(
     type_table: *const TypeTable,
     entrypoint_type_ids: *const std.StringHashMap(u64),
     provides_type_ids: *const std.StringHashMap(u64),
+    per_target_layouts: []const []CollectedTypeLayout,
     roc_ops: *builtins.host_abi.RocOps,
 ) RocList {
     // Build modules list
@@ -2193,8 +2130,10 @@ fn constructTypesRocList(
     const types_inner_ptr: *TypesInnerRoc = @ptrCast(@alignCast(types_inner_bytes));
     types_inner_ptr.* = TypesInnerRoc{
         .entrypoints = entrypoints_list,
+        .layouts = buildLayoutsRocList(platform_info.targets, per_target_layouts, roc_ops),
         .modules = modules_list,
         .provides_entries = provides_list,
+        .target_names = buildStrRocList(platform_info.targets, roc_ops),
         .type_table = buildTypeTableRocList(type_table, roc_ops),
     };
 

--- a/src/glue/glue.zig
+++ b/src/glue/glue.zig
@@ -691,7 +691,16 @@ const CollectedTypeRepr = union(enum) {
     unit,
     list: u64,
     function: struct { arg_ids: []const u64, ret_id: u64 },
-    record: struct { name: []const u8, fields: []const CollectedRecordField, size: u64, alignment: u64 },
+    record: struct {
+        name: []const u8,
+        fields: []const CollectedRecordField,
+        size: u64,
+        alignment: u64,
+        /// Alt (other pointer-size) layout fields, populated only when field ordering differs.
+        alt_fields: []const CollectedRecordField = &.{},
+        alt_size: u64 = 0,
+        alt_alignment: u64 = 0,
+    },
     tag_union: struct { name: []const u8, tags: []const CollectedTagInfo, size: u64, alignment: u64 },
     unknown: []const u8,
 };
@@ -714,7 +723,10 @@ const CollectedTagInfo = struct {
 const TypeTable = struct {
     entries: std.ArrayList(CollectedTypeRepr),
     var_map: std.AutoHashMap(@import("types").Var, u64),
+    /// Maps structural record signatures to existing type table indices for dedup.
+    record_dedup: std.StringHashMap(u64),
     gpa: std.mem.Allocator,
+    target: RocTarget,
 
     const types = @import("types");
 
@@ -722,7 +734,9 @@ const TypeTable = struct {
         return .{
             .entries = std.ArrayList(CollectedTypeRepr).empty,
             .var_map = std.AutoHashMap(types.Var, u64).init(gpa),
+            .record_dedup = std.StringHashMap(u64).init(gpa),
             .gpa = gpa,
+            .target = RocTarget.detectNative(),
         };
     }
 
@@ -732,6 +746,12 @@ const TypeTable = struct {
         }
         self.entries.deinit(self.gpa);
         self.var_map.deinit();
+        // Free dedup keys
+        var dedup_iter = self.record_dedup.keyIterator();
+        while (dedup_iter.next()) |key| {
+            self.gpa.free(key.*);
+        }
+        self.record_dedup.deinit();
     }
 
     fn freeEntry(self: *TypeTable, entry: CollectedTypeRepr) void {
@@ -741,6 +761,10 @@ const TypeTable = struct {
                     self.freeDuped(field.name);
                 }
                 self.gpa.free(rec.fields);
+                for (rec.alt_fields) |field| {
+                    self.freeDuped(field.name);
+                }
+                if (rec.alt_fields.len > 0) self.gpa.free(rec.alt_fields);
                 self.freeDuped(rec.name);
             },
             .tag_union => |tu| {
@@ -794,6 +818,7 @@ const TypeTable = struct {
     /// Get an existing type table index for a var, or insert a new entry.
     /// Pre-registers a placeholder before conversion to prevent infinite recursion
     /// on cyclic types (the placeholder is updated in-place after conversion).
+    /// Records are deduplicated by structural signature (field names + type_ids).
     fn getOrInsert(self: *TypeTable, env: *const ModuleEnv, type_var: types.Var) u64 {
         const resolved = env.types.resolveVar(type_var);
         const root_var = resolved.var_;
@@ -809,25 +834,61 @@ const TypeTable = struct {
 
         const repr = self.convertContent(env, resolved.desc.content);
 
-        // Update placeholder with actual representation
-        self.entries.items[@intCast(idx)] = repr;
-
-        // Assign synthetic names to anonymous records so glue generates struct defs
+        // For anonymous records, check for structural duplicates
         switch (repr) {
             .record => |rec| {
                 if (rec.name.len == 0) {
+                    // Build a dedup key from field names + type_ids
+                    if (self.buildRecordDedupKey(rec.fields)) |dedup_key| {
+                        if (self.record_dedup.get(dedup_key)) |existing_idx| {
+                            // Duplicate found — point this var at the existing entry
+                            // and discard the placeholder and the new repr
+                            self.var_map.put(root_var, existing_idx) catch {};
+                            self.freeEntry(repr);
+                            // Replace placeholder with unit (placeholder slot is wasted but harmless)
+                            self.entries.items[@intCast(idx)] = .unit;
+                            self.gpa.free(dedup_key);
+                            return existing_idx;
+                        }
+                        // New unique record — register it
+                        self.record_dedup.put(dedup_key, idx) catch {
+                            self.gpa.free(dedup_key);
+                        };
+                    }
+                    // Assign synthetic name
                     self.entries.items[@intCast(idx)] = .{ .record = .{
                         .name = std.fmt.allocPrint(self.gpa, "__AnonStruct{d}", .{idx}) catch "",
                         .fields = rec.fields,
                         .size = rec.size,
                         .alignment = rec.alignment,
+                        .alt_fields = rec.alt_fields,
+                        .alt_size = rec.alt_size,
+                        .alt_alignment = rec.alt_alignment,
                     } };
+                    return idx;
                 }
             },
             else => {},
         }
 
+        // Update placeholder with actual representation
+        self.entries.items[@intCast(idx)] = repr;
         return idx;
+    }
+
+    /// Build a dedup key for a record from its sorted fields (name + type_id pairs).
+    /// Returns null on allocation failure.
+    fn buildRecordDedupKey(self: *TypeTable, fields: []const CollectedRecordField) ?[]const u8 {
+        var buf = std.ArrayList(u8).empty;
+        for (fields) |field| {
+            buf.appendSlice(self.gpa, field.name) catch return null;
+            buf.append(self.gpa, ':') catch return null;
+            // Append type_id as fixed-width bytes for unambiguous separation
+            const id_bytes = std.mem.asBytes(&field.type_id);
+            buf.appendSlice(self.gpa, id_bytes) catch return null;
+            buf.append(self.gpa, ',') catch return null;
+        }
+        return buf.toOwnedSlice(self.gpa) catch null;
     }
 
     /// Insert a Unit type and return its index.
@@ -842,27 +903,33 @@ const TypeTable = struct {
     /// Get the size and alignment for a type table entry by index.
     fn getSizeAlign(self: *const TypeTable, type_id: u64) SizeAlign {
         if (type_id >= self.entries.items.len) return .{ .size = 0, .alignment = 1 };
-        return getSizeAlignForRepr(self.entries.items[@intCast(type_id)]);
+        return getSizeAlignForRepr(self.entries.items[@intCast(type_id)], self.target);
     }
 
     /// Get the size and alignment for a CollectedTypeRepr.
-    fn getSizeAlignForRepr(repr: CollectedTypeRepr) SizeAlign {
+    fn getSizeAlignForRepr(repr: CollectedTypeRepr, target: RocTarget) SizeAlign {
+        const ptr_size: u64 = target.ptrBitWidth() / 8;
         return switch (repr) {
             .bool_ => .{ .size = 1, .alignment = 1 },
-            .box => .{ .size = 8, .alignment = 8 },
+            .box => .{ .size = ptr_size, .alignment = ptr_size },
             .u8_, .i8_ => .{ .size = 1, .alignment = 1 },
             .u16_, .i16_ => .{ .size = 2, .alignment = 2 },
             .u32_, .i32_, .f32_ => .{ .size = 4, .alignment = 4 },
             .u64_, .i64_, .f64_, .dec => .{ .size = 8, .alignment = 8 },
             .u128_, .i128_ => .{ .size = 16, .alignment = 16 },
-            .str_ => .{ .size = 24, .alignment = 8 },
-            .list => .{ .size = 24, .alignment = 8 },
+            .str_ => .{ .size = ptr_size * 3, .alignment = ptr_size },
+            .list => .{ .size = ptr_size * 3, .alignment = ptr_size },
             .unit => .{ .size = 0, .alignment = 0 },
             .record => |rec| .{ .size = rec.size, .alignment = rec.alignment },
             .function => .{ .size = 0, .alignment = 1 },
             .tag_union => |tu| .{ .size = tu.size, .alignment = tu.alignment },
             .unknown => .{ .size = 0, .alignment = 1 },
         };
+    }
+
+    /// Get the canonical "other" pointer-size target for alt layout computation.
+    fn altTarget(target: RocTarget) RocTarget {
+        if (target.ptrBitWidth() == 64) return .wasm32 else return .x64linux;
     }
 
     fn convertContent(self: *TypeTable, env: *const ModuleEnv, content: types.Content) CollectedTypeRepr {
@@ -944,6 +1011,9 @@ const TypeTable = struct {
                             .fields = rec.fields,
                             .size = rec.size,
                             .alignment = rec.alignment,
+                            .alt_fields = rec.alt_fields,
+                            .alt_size = rec.alt_size,
+                            .alt_alignment = rec.alt_alignment,
                         } };
                     },
                     else => return record_repr,
@@ -978,30 +1048,63 @@ const TypeTable = struct {
 
     fn convertRecord(self: *TypeTable, env: *const ModuleEnv, record: types.Record) CollectedTypeRepr {
         const ident_store = env.getIdentStoreConst();
-        const fields_slice = env.types.getRecordFieldsSlice(record.fields);
-        const field_names = fields_slice.items(.name);
-        const field_vars = fields_slice.items(.var_);
 
-        if (field_names.len == 0) return .unit;
+        // Flatten record extension chain: a record type may be split across
+        // multiple linked records via the `ext` variable, e.g.:
+        //   { mouse_wheel: F32 | { frame_count: U64, keys: List(U8) | empty_record } }
+        // We must collect fields from all segments.
+        var all_names = std.ArrayList(base.Ident.Idx).empty;
+        defer all_names.deinit(self.gpa);
+        var all_vars = std.ArrayList(types.Var).empty;
+        defer all_vars.deinit(self.gpa);
+
+        var current = record;
+        var depth: usize = 0;
+        while (depth < 64) : (depth += 1) {
+            const slice = env.types.getRecordFieldsSlice(current.fields);
+            const names = slice.items(.name);
+            const vars = slice.items(.var_);
+            for (names, vars) |n, v| {
+                all_names.append(self.gpa, n) catch {};
+                all_vars.append(self.gpa, v) catch {};
+            }
+
+            // Follow the extension variable to the next record segment
+            const ext = env.types.resolveVar(current.ext);
+            switch (ext.desc.content) {
+                .structure => |ft| switch (ft) {
+                    .record => |r| {
+                        current = r;
+                        continue;
+                    },
+                    .empty_record => break,
+                    else => break,
+                },
+                else => break,
+            }
+        }
+
+        const field_count = all_names.items.len;
+        if (field_count == 0) return .unit;
 
         // First pass: getOrInsert all field type_ids so nested types are in the table
-        const field_type_ids = self.gpa.alloc(u64, field_names.len) catch return self.oomUnknown("record");
+        const field_type_ids = self.gpa.alloc(u64, field_count) catch return self.oomUnknown("record");
         defer self.gpa.free(field_type_ids);
-        for (0..field_names.len) |i| {
-            field_type_ids[i] = self.getOrInsert(env, field_vars[i]);
+        for (0..field_count) |i| {
+            field_type_ids[i] = self.getOrInsert(env, all_vars.items[i]);
         }
 
         // Get size/alignment for each field
-        const field_sizes = self.gpa.alloc(SizeAlign, field_names.len) catch return self.oomUnknown("record");
+        const field_sizes = self.gpa.alloc(SizeAlign, field_count) catch return self.oomUnknown("record");
         defer self.gpa.free(field_sizes);
-        for (0..field_names.len) |i| {
+        for (0..field_count) |i| {
             field_sizes[i] = self.getSizeAlign(field_type_ids[i]);
         }
 
         // Build sortable array of field indices
-        var field_indices = self.gpa.alloc(usize, field_names.len) catch return self.oomUnknown("record");
+        var field_indices = self.gpa.alloc(usize, field_count) catch return self.oomUnknown("record");
         defer self.gpa.free(field_indices);
-        for (0..field_names.len) |i| {
+        for (0..field_count) |i| {
             field_indices[i] = i;
         }
 
@@ -1022,14 +1125,14 @@ const TypeTable = struct {
                 return std.mem.order(u8, a_text, b_text) == .lt;
             }
         };
-        std.mem.sort(usize, field_indices, SortCtx{ .names = field_names, .idents = ident_store, .sizes = field_sizes }, SortCtx.lessThan);
+        std.mem.sort(usize, field_indices, SortCtx{ .names = all_names.items, .idents = ident_store, .sizes = field_sizes }, SortCtx.lessThan);
 
         // Build collected fields in sorted order and compute record size
-        const collected_fields = self.gpa.alloc(CollectedRecordField, field_names.len) catch return self.oomUnknown("record");
+        const collected_fields = self.gpa.alloc(CollectedRecordField, field_count) catch return self.oomUnknown("record");
         var max_alignment: u64 = 0;
         var current_offset: u64 = 0;
         for (field_indices, 0..) |src_idx, dst_idx| {
-            const name_text = ident_store.getText(field_names[src_idx]);
+            const name_text = ident_store.getText(all_names.items[src_idx]);
             const f_size = field_sizes[src_idx].size;
             const f_align = field_sizes[src_idx].alignment;
 
@@ -1058,12 +1161,120 @@ const TypeTable = struct {
             if (rem != 0) record_size += max_alignment - rem;
         }
 
+        // Compute alt (other pointer-size) layout to detect divergence
+        const alt_layout = self.computeAltRecordLayout(
+            field_count,
+            field_type_ids,
+            all_names.items,
+            ident_store,
+            field_indices,
+        );
+
         return .{ .record = .{
             .name = "",
             .fields = collected_fields,
             .size = record_size,
             .alignment = max_alignment,
+            .alt_fields = alt_layout.fields,
+            .alt_size = alt_layout.size,
+            .alt_alignment = alt_layout.alignment,
         } };
+    }
+
+    const AltLayout = struct {
+        fields: []const CollectedRecordField,
+        size: u64,
+        alignment: u64,
+    };
+
+    /// Compute the alt-target record layout. Returns non-empty fields only when
+    /// the field ordering differs from the primary layout.
+    fn computeAltRecordLayout(
+        self: *TypeTable,
+        field_count: usize,
+        field_type_ids: []const u64,
+        names: anytype,
+        ident_store: *const base.Ident.Store,
+        primary_indices: []const usize,
+    ) AltLayout {
+        const alt_tgt = altTarget(self.target);
+
+        // Get alt-target size/alignment for each field
+        const alt_sizes = self.gpa.alloc(SizeAlign, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
+        defer self.gpa.free(alt_sizes);
+        for (0..field_count) |i| {
+            if (field_type_ids[i] < self.entries.items.len) {
+                alt_sizes[i] = getSizeAlignForRepr(self.entries.items[@intCast(field_type_ids[i])], alt_tgt);
+            } else {
+                alt_sizes[i] = .{ .size = 0, .alignment = 1 };
+            }
+        }
+
+        // Sort by alt alignment descending, then name ascending
+        var alt_indices = self.gpa.alloc(usize, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
+        defer self.gpa.free(alt_indices);
+        for (0..field_count) |i| {
+            alt_indices[i] = i;
+        }
+
+        const AltSortCtx = struct {
+            nm: @TypeOf(names),
+            ids: *const base.Ident.Store,
+            szs: []const SizeAlign,
+
+            pub fn lessThan(ctx: @This(), a: usize, b: usize) bool {
+                const a_align = ctx.szs[a].alignment;
+                const b_align = ctx.szs[b].alignment;
+                if (a_align != b_align) return a_align > b_align;
+                const a_text = ctx.ids.getText(ctx.nm[a]);
+                const b_text = ctx.ids.getText(ctx.nm[b]);
+                return std.mem.order(u8, a_text, b_text) == .lt;
+            }
+        };
+        std.mem.sort(usize, alt_indices, AltSortCtx{ .nm = names, .ids = ident_store, .szs = alt_sizes }, AltSortCtx.lessThan);
+
+        // Check if field order differs
+        var orders_differ = false;
+        for (0..field_count) |i| {
+            if (primary_indices[i] != alt_indices[i]) {
+                orders_differ = true;
+                break;
+            }
+        }
+
+        if (!orders_differ) return .{ .fields = &.{}, .size = 0, .alignment = 0 };
+
+        // Build alt collected fields
+        const alt_fields = self.gpa.alloc(CollectedRecordField, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
+        var alt_max_alignment: u64 = 0;
+        var alt_offset: u64 = 0;
+        for (alt_indices, 0..) |src_idx, dst_idx| {
+            const name_text = ident_store.getText(names[src_idx]);
+            const f_size = alt_sizes[src_idx].size;
+            const f_align = alt_sizes[src_idx].alignment;
+
+            if (f_align > alt_max_alignment) alt_max_alignment = f_align;
+            if (f_align > 0) {
+                const rem = alt_offset % f_align;
+                if (rem != 0) alt_offset += f_align - rem;
+            }
+            alt_offset += f_size;
+
+            alt_fields[dst_idx] = .{
+                .name = self.gpa.dupe(u8, name_text) catch "",
+                .type_id = field_type_ids[src_idx],
+                .size = f_size,
+                .alignment = f_align,
+            };
+        }
+
+        var alt_record_size = alt_offset;
+        if (alt_max_alignment > 0) {
+            const rem = alt_record_size % alt_max_alignment;
+            if (rem != 0) alt_record_size += alt_max_alignment - rem;
+        }
+
+        return .{ .fields = alt_fields, .size = alt_record_size, .alignment = alt_max_alignment };
     }
 
     fn oomUnknown(self: *TypeTable, name: []const u8) CollectedTypeRepr {
@@ -1145,12 +1356,104 @@ const TypeTable = struct {
             if (rem != 0) record_size += max_alignment - rem;
         }
 
+        // Compute alt (other pointer-size) layout to detect divergence
+        const alt_layout = self.computeAltTupleLayout(
+            elem_vars.len,
+            field_type_ids,
+            field_names,
+            field_indices,
+        );
+
         return .{ .record = .{
             .name = "",
             .fields = collected_fields,
             .size = record_size,
             .alignment = max_alignment,
+            .alt_fields = alt_layout.fields,
+            .alt_size = alt_layout.size,
+            .alt_alignment = alt_layout.alignment,
         } };
+    }
+
+    /// Compute the alt-target tuple layout. Returns non-empty fields only when
+    /// the field ordering differs from the primary layout.
+    fn computeAltTupleLayout(
+        self: *TypeTable,
+        field_count: usize,
+        field_type_ids: []const u64,
+        field_names: []const []const u8,
+        primary_indices: []const usize,
+    ) AltLayout {
+        const alt_tgt = altTarget(self.target);
+
+        const alt_sizes = self.gpa.alloc(SizeAlign, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
+        defer self.gpa.free(alt_sizes);
+        for (0..field_count) |i| {
+            if (field_type_ids[i] < self.entries.items.len) {
+                alt_sizes[i] = getSizeAlignForRepr(self.entries.items[@intCast(field_type_ids[i])], alt_tgt);
+            } else {
+                alt_sizes[i] = .{ .size = 0, .alignment = 1 };
+            }
+        }
+
+        var alt_indices = self.gpa.alloc(usize, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
+        defer self.gpa.free(alt_indices);
+        for (0..field_count) |i| {
+            alt_indices[i] = i;
+        }
+
+        const TupleSortCtx = struct {
+            szs: []const SizeAlign,
+            nms: []const []const u8,
+
+            pub fn lessThan(ctx: @This(), a: usize, b: usize) bool {
+                const a_align = ctx.szs[a].alignment;
+                const b_align = ctx.szs[b].alignment;
+                if (a_align != b_align) return a_align > b_align;
+                return std.mem.order(u8, ctx.nms[a], ctx.nms[b]) == .lt;
+            }
+        };
+        std.mem.sort(usize, alt_indices, TupleSortCtx{ .szs = alt_sizes, .nms = field_names }, TupleSortCtx.lessThan);
+
+        var orders_differ = false;
+        for (0..field_count) |i| {
+            if (primary_indices[i] != alt_indices[i]) {
+                orders_differ = true;
+                break;
+            }
+        }
+
+        if (!orders_differ) return .{ .fields = &.{}, .size = 0, .alignment = 0 };
+
+        const alt_fields = self.gpa.alloc(CollectedRecordField, field_count) catch return .{ .fields = &.{}, .size = 0, .alignment = 0 };
+        var alt_max_alignment: u64 = 0;
+        var alt_offset: u64 = 0;
+        for (alt_indices, 0..) |src_idx, dst_idx| {
+            const f_size = alt_sizes[src_idx].size;
+            const f_align = alt_sizes[src_idx].alignment;
+
+            if (f_align > alt_max_alignment) alt_max_alignment = f_align;
+            if (f_align > 0) {
+                const rem = alt_offset % f_align;
+                if (rem != 0) alt_offset += f_align - rem;
+            }
+            alt_offset += f_size;
+
+            alt_fields[dst_idx] = .{
+                .name = self.gpa.dupe(u8, field_names[src_idx]) catch "",
+                .type_id = field_type_ids[src_idx],
+                .size = f_size,
+                .alignment = f_align,
+            };
+        }
+
+        var alt_record_size = alt_offset;
+        if (alt_max_alignment > 0) {
+            const rem = alt_record_size % alt_max_alignment;
+            if (rem != 0) alt_record_size += alt_max_alignment - rem;
+        }
+
+        return .{ .fields = alt_fields, .size = alt_record_size, .alignment = alt_max_alignment };
     }
 
     fn convertTagUnion(self: *TypeTable, env: *const ModuleEnv, tag_union: types.TagUnion) CollectedTypeRepr {
@@ -1273,7 +1576,17 @@ const TypeTable = struct {
             if (rem != 0) total_size += total_align - rem;
         }
 
-        const auto_name: []const u8 = auto_name_buf[0..name_pos];
+        // Disambiguate tag unions that share variant names but have different
+        // payload types by appending _{size}_{alignment} to the auto-name
+        // (e.g. "ErrOrOk" becomes "ErrOrOk_16_8" vs "ErrOrOk_32_8").
+        const auto_name: []const u8 = std.fmt.allocPrint(
+            self.gpa,
+            "{s}_{d}_{d}",
+            .{ auto_name_buf[0..name_pos], total_size, total_align },
+        ) catch auto_name_buf[0..name_pos];
+        if (auto_name.ptr != auto_name_buf.ptr) {
+            self.gpa.free(auto_name_buf);
+        }
 
         return .{ .tag_union = .{
             .name = auto_name,
@@ -1419,9 +1732,12 @@ const FunctionPayload = extern struct {
     ret: u64,
 };
 
-/// RecordRepr := { alignment : U64, fields : List(RecordField), name : Str, size : U64 } — fields alphabetical
+/// RecordRepr := { alignment : U64, alt_alignment : U64, alt_fields : List(RecordField), alt_size : U64, fields : List(RecordField), name : Str, size : U64 } — fields alphabetical
 const RecordPayload = extern struct {
     alignment: u64,
+    alt_alignment: u64,
+    alt_fields: RocList,
+    alt_size: u64,
     fields: RocList,
     name: RocStr,
     size: u64,
@@ -1614,8 +1930,36 @@ fn serializeTypeRepr(
                 };
             } else RocList.empty();
 
+            // Build alt_fields list (empty if no alt layout)
+            const alt_fields_list = if (rec.alt_fields.len > 0) afblk: {
+                const alt_data_size = rec.alt_fields.len * @sizeOf(RecordFieldTypeReprRoc);
+                const afb = builtins.utils.allocateWithRefcount(
+                    alt_data_size,
+                    @alignOf(RecordFieldTypeReprRoc),
+                    true,
+                    roc_ops,
+                );
+                const afptr: [*]RecordFieldTypeReprRoc = @ptrCast(@alignCast(afb));
+                for (rec.alt_fields, 0..) |field, i| {
+                    afptr[i] = .{
+                        .alignment = field.alignment,
+                        .name = createBigRocStr(field.name, roc_ops),
+                        .size = field.size,
+                        .type_id = field.type_id,
+                    };
+                }
+                break :afblk RocList{
+                    .bytes = afb,
+                    .length = rec.alt_fields.len,
+                    .capacity_or_alloc_ptr = rec.alt_fields.len,
+                };
+            } else RocList.empty();
+
             result.payload.record = .{
                 .alignment = rec.alignment,
+                .alt_alignment = rec.alt_alignment,
+                .alt_fields = alt_fields_list,
+                .alt_size = rec.alt_size,
                 .fields = fields_list,
                 .name = createBigRocStr(rec.name, roc_ops),
                 .size = rec.size,

--- a/src/glue/platform/RecordField.roc
+++ b/src/glue/platform/RecordField.roc
@@ -1,1 +1,1 @@
-RecordField := { alignment : U64, name : Str, size : U64, type_id : U64 }
+RecordField := { name : Str, type_id : U64 }

--- a/src/glue/platform/RecordRepr.roc
+++ b/src/glue/platform/RecordRepr.roc
@@ -1,3 +1,3 @@
 import RecordField exposing [RecordField]
 
-RecordRepr := { alignment : U64, fields : List(RecordField), name : Str, size : U64 }
+RecordRepr := { alignment : U64, alt_alignment : U64, alt_fields : List(RecordField), alt_size : U64, fields : List(RecordField), name : Str, size : U64 }

--- a/src/glue/platform/RecordRepr.roc
+++ b/src/glue/platform/RecordRepr.roc
@@ -1,3 +1,3 @@
 import RecordField exposing [RecordField]
 
-RecordRepr := { alignment : U64, alt_alignment : U64, alt_fields : List(RecordField), alt_size : U64, fields : List(RecordField), name : Str, size : U64 }
+RecordRepr := { fields : List(RecordField), name : Str }

--- a/src/glue/platform/TagUnionRepr.roc
+++ b/src/glue/platform/TagUnionRepr.roc
@@ -1,3 +1,3 @@
 import TagVariant exposing [TagVariant]
 
-TagUnionRepr := { alignment : U64, name : Str, size : U64, tags : List(TagVariant) }
+TagUnionRepr := { name : Str, tags : List(TagVariant) }

--- a/src/glue/platform/TagVariant.roc
+++ b/src/glue/platform/TagVariant.roc
@@ -1,1 +1,1 @@
-TagVariant := { name : Str, payload : List(U64), payload_alignment : U64, payload_size : U64 }
+TagVariant := { name : Str, payload : List(U64) }

--- a/src/glue/platform/TargetLayout.roc
+++ b/src/glue/platform/TargetLayout.roc
@@ -1,0 +1,3 @@
+import TypeLayout exposing [TypeLayout]
+
+TargetLayout := { target : Str, type_layouts : List(TypeLayout) }

--- a/src/glue/platform/TypeLayout.roc
+++ b/src/glue/platform/TypeLayout.roc
@@ -1,0 +1,1 @@
+TypeLayout := { alignment : U64, field_order : List(U64), size : U64 }

--- a/src/glue/platform/Types.roc
+++ b/src/glue/platform/Types.roc
@@ -5,12 +5,14 @@ import FunctionInfo exposing [FunctionInfo]
 import HostedFunctionInfo exposing [HostedFunctionInfo]
 import TypeRepr exposing [TypeRepr]
 import ProvidesEntry exposing [ProvidesEntry]
+import TargetLayout exposing [TargetLayout]
 
 ## Type information extracted from the platform module for glue generation
 Types := {
-    ## Entry points (aka platform requires)
     entrypoints : List(EntryPoint),
+    layouts : List(TargetLayout),
     modules : List(ModuleTypeInfo),
     provides_entries : List(ProvidesEntry),
+    target_names : List(Str),
     type_table : List(TypeRepr),
 }

--- a/src/glue/platform/main.roc
+++ b/src/glue/platform/main.roc
@@ -15,7 +15,9 @@ platform ""
         RecordRepr,
         TagUnionRepr,
         TagVariant,
+        TargetLayout,
         TypeId,
+        TypeLayout,
         TypeRepr,
         Types,
     ]
@@ -46,6 +48,8 @@ import RecordField exposing [RecordField]
 import RecordRepr exposing [RecordRepr]
 import TagUnionRepr exposing [TagUnionRepr]
 import TagVariant exposing [TagVariant]
+import TargetLayout exposing [TargetLayout]
+import TypeLayout exposing [TypeLayout]
 import TypeRepr exposing [TypeRepr]
 import ProvidesEntry exposing [ProvidesEntry]
 

--- a/src/glue/src/RustGlue.roc
+++ b/src/glue/src/RustGlue.roc
@@ -10,15 +10,19 @@ import pf.RecordRepr exposing [RecordRepr]
 import pf.TagUnionRepr exposing [TagUnionRepr]
 import pf.RecordField exposing [RecordField]
 import pf.TagVariant exposing [TagVariant]
+import pf.TargetLayout exposing [TargetLayout]
+import pf.TypeLayout exposing [TypeLayout]
 
 make_glue : List(Types) -> Try(List(File), Str)
 make_glue = |types_list| {
 	# Collect all hosted functions from all modules, with module name prefix
 	var $hosted_functions = []
 	var $type_table = []
+	var $layouts = []
 
 	for types in types_list {
 		$type_table = types.type_table
+		$layouts = types.layouts
 
 		for mod in types.modules {
 			for func in mod.hosted_functions {
@@ -42,7 +46,7 @@ make_glue = |types_list| {
 	# Sort by index so array entries are in the correct order
 	sorted = List.sort_with($hosted_functions, compare_by_index)
 
-	rust_content = generate_rust_file(sorted, $type_table)
+	rust_content = generate_rust_file(sorted, $type_table, $layouts)
 
 	Ok([{ name: "roc_platform_abi.rs", content: rust_content }])
 }
@@ -493,9 +497,9 @@ lookup_record_in_type_table = |type_table, type_id| {
 			match type_repr {
 				RocRecord(rec) =>
 					if List.len(rec.fields) > 0 {
-						{ found: Bool.True, fields: rec.fields, size: rec.size, alignment: rec.alignment }
+						{ found: Bool.True, fields: rec.fields }
 					} else {
-						{ found: Bool.False, fields: [], size: 0, alignment: 0 }
+						{ found: Bool.False, fields: [] }
 					}
 				RocTagUnion(tu) =>
 					# Follow single-variant tag unions to their payload
@@ -504,16 +508,16 @@ lookup_record_in_type_table = |type_table, type_id| {
 							Ok(tag) =>
 								match List.first(tag.payload) {
 									Ok(payload_id) => lookup_record_in_type_table(type_table, payload_id)
-									_ => { found: Bool.False, fields: [], size: 0, alignment: 0 }
+									_ => { found: Bool.False, fields: [] }
 								}
-							_ => { found: Bool.False, fields: [], size: 0, alignment: 0 }
+							_ => { found: Bool.False, fields: [] }
 						}
 					} else {
-						{ found: Bool.False, fields: [], size: 0, alignment: 0 }
+						{ found: Bool.False, fields: [] }
 					}
-				_ => { found: Bool.False, fields: [], size: 0, alignment: 0 }
+				_ => { found: Bool.False, fields: [] }
 			}
-		Err(_) => { found: Bool.False, fields: [], size: 0, alignment: 0 }
+		Err(_) => { found: Bool.False, fields: [] }
 	}
 }
 
@@ -522,7 +526,7 @@ lookup_record_in_type_table = |type_table, type_id| {
 # =============================================================================
 
 ## Generate the complete Rust source file
-generate_rust_file = |hosted_functions, type_table| {
+generate_rust_file = |hosted_functions, type_table, layouts| {
 	count = List.len(hosted_functions)
 
 	generate_rust_file_header
@@ -536,10 +540,10 @@ generate_rust_file = |hosted_functions, type_table| {
 		.concat("\n")
 		.concat(generate_index_constants_rust(hosted_functions, count))
 		.concat("\n")
-		.concat(generate_element_type_structs_rust(type_table))
+		.concat(generate_element_type_structs_rust(type_table, layouts))
 		.concat(generate_tag_union_structs_rust(type_table))
-		.concat(generate_all_record_structs_rust(hosted_functions, type_table))
-		.concat(generate_all_args_structs_rust(hosted_functions, type_table))
+		.concat(generate_all_record_structs_rust(hosted_functions, type_table, layouts))
+		.concat(generate_all_args_structs_rust(hosted_functions, type_table, layouts))
 		.concat(generate_platform_fns_struct_rust(hosted_functions, type_table))
 		.concat("\n")
 		.concat(generate_hosted_functions_helper_rust(hosted_functions))
@@ -982,42 +986,66 @@ generate_index_constants_rust = |hosted_functions, count| {
 	$constants
 }
 
+## Get the layout for a type_id from the first target's layouts.
+get_first_layout = |layouts, type_id| {
+	match List.first(layouts) {
+		Ok(target_layout) => {
+			match List.get(target_layout.type_layouts, type_id) {
+				Ok(tl) => tl
+				Err(_) => { alignment: 0, field_order: [], size: 0 }
+			}
+		}
+		Err(_) => { alignment: 0, field_order: [], size: 0 }
+	}
+}
+
+## Emit record fields in ABI order using layout's field_order permutation.
+emit_fields_in_order_rust = |fields, type_layout, type_table| {
+	var $field_strs = ""
+	if List.is_empty(type_layout.field_order) {
+		for field in fields {
+			rust_type = type_id_to_rust(type_table, field.type_id)
+			$field_strs = Str.concat($field_strs, "    pub ${field.name}: ${rust_type},\n")
+		}
+	} else {
+		for order_idx in type_layout.field_order {
+			match List.get(fields, order_idx) {
+				Ok(field) => {
+					rust_type = type_id_to_rust(type_table, field.type_id)
+					$field_strs = Str.concat($field_strs, "    pub ${field.name}: ${rust_type},\n")
+				}
+				Err(_) => {}
+			}
+		}
+	}
+	$field_strs
+}
+
 ## Generate #[repr(C)] structs for element types found in the type table.
-generate_element_type_structs_rust : List(TypeRepr) -> Str
-generate_element_type_structs_rust = |type_table| {
+generate_element_type_structs_rust = |type_table, layouts| {
 	var $structs = ""
 	var $seen_names = []
+	var $cur_idx = 0
 
 	for type_repr in type_table {
 		match type_repr {
-			RocRecord(rec) =>
+			RocRecord(rec) => {
 				if rec.name != "" and !(List.contains($seen_names, rec.name)) {
 					$seen_names = $seen_names.append(rec.name)
 
 					struct_name = name_to_struct_name(rec.name)
-					var $field_strs = ""
-					for field in rec.fields {
-						rust_type = type_id_to_rust(type_table, field.type_id)
-						$field_strs = Str.concat(
-							$field_strs,
-							"    pub ${field.name}: ${rust_type},\n",
-						)
-					}
-
-					# Size/alignment assertions (guarded by pointer width)
-					assertions = if rec.size > 0 {
-						"const _: () = assert!(core::mem::size_of::<${struct_name}>() == ${U64.to_str(rec.size)}, \"${struct_name} size mismatch\");\nconst _: () = assert!(core::mem::align_of::<${struct_name}>() == ${U64.to_str(rec.alignment)}, \"${struct_name} alignment mismatch\");\n\n"
-					} else {
-						""
-					}
+					type_layout = get_first_layout(layouts, $cur_idx)
+					field_strs = emit_fields_in_order_rust(rec.fields, type_layout, type_table)
 
 					$structs = Str.concat(
 						$structs,
-						"/// Element type for ${rec.name}\n#[repr(C)]\npub struct ${struct_name} {\n${$field_strs}}\n\n${assertions}",
+						"/// Element type for ${rec.name}\n#[repr(C)]\npub struct ${struct_name} {\n${field_strs}}\n\n",
 					)
 				}
+			}
 			_ => {}
 		}
+		$cur_idx = $cur_idx + 1
 	}
 
 	$structs
@@ -1107,45 +1135,25 @@ generate_single_tag_union_rust = |type_table, tu| {
 			}
 		}
 
-		# Size/alignment assertions
-		assertions = if tu.size > 0 {
-			"const _: () = assert!(core::mem::size_of::<${struct_name}>() == ${U64.to_str(tu.size)}, \"${struct_name} size mismatch\");\nconst _: () = assert!(core::mem::align_of::<${struct_name}>() == ${U64.to_str(tu.alignment)}, \"${struct_name} alignment mismatch\");\n\n"
-		} else {
-			""
-		}
-
-		"${$tuple_structs}/// Tag discriminant for ${tu.name}.\n#[repr(${disc_type})]\n#[derive(Debug, Clone, Copy, PartialEq, Eq)]\npub enum ${struct_name}Tag {\n${$enum_variants}}\n\n/// Tag union: ${tu.name}\n#[repr(C)]\npub struct ${struct_name} {\n    pub payload: ${struct_name}Payload,\n    pub tag: ${struct_name}Tag,\n}\n\n#[repr(C)]\npub union ${struct_name}Payload {\n${$union_fields}}\n\n${assertions}"
+		"${$tuple_structs}/// Tag discriminant for ${tu.name}.\n#[repr(${disc_type})]\n#[derive(Debug, Clone, Copy, PartialEq, Eq)]\npub enum ${struct_name}Tag {\n${$enum_variants}}\n\n/// Tag union: ${tu.name}\n#[repr(C)]\npub struct ${struct_name} {\n    pub payload: ${struct_name}Payload,\n    pub tag: ${struct_name}Tag,\n}\n\n#[repr(C)]\npub union ${struct_name}Payload {\n${$union_fields}}\n\n"
 	}
 }
 
 ## Generate #[repr(C)] structs for record return types using type table.
-generate_all_record_structs_rust = |hosted_functions, type_table| {
+generate_all_record_structs_rust = |hosted_functions, type_table, layouts| {
 	var $structs = ""
 	for func in hosted_functions {
 		type_table_result = lookup_record_in_type_table(type_table, func.ret_type_id)
 
 		if type_table_result.found {
 			struct_name = name_to_struct_name(func.name)
+			type_layout = get_first_layout(layouts, func.ret_type_id)
+			fields = emit_fields_in_order_rust(type_table_result.fields, type_layout, type_table)
 
-			var $fields = ""
-			for field in type_table_result.fields {
-				rust_type = type_id_to_rust(type_table, field.type_id)
-				$fields = Str.concat(
-					$fields,
-					"    pub ${field.name}: ${rust_type},\n",
-				)
-			}
-
-			assertions = if type_table_result.size > 0 {
-				"const _: () = assert!(core::mem::size_of::<${struct_name}RetRecord>() == ${U64.to_str(type_table_result.size)}, \"${struct_name}RetRecord size mismatch\");\nconst _: () = assert!(core::mem::align_of::<${struct_name}RetRecord>() == ${U64.to_str(type_table_result.alignment)}, \"${struct_name}RetRecord alignment mismatch\");\n\n"
-			} else {
-				""
-			}
-
-			doc = "/// Return type record for ${func.name}\n/// Fields ordered by alignment descending (Roc ABI)\n"
+			doc = "/// Return type record for ${func.name}\n/// Fields ordered per Roc ABI layout\n"
 			$structs = Str.concat(
 				$structs,
-				"${doc}#[repr(C)]\npub struct ${struct_name}RetRecord {\n${$fields}}\n\n${assertions}",
+				"${doc}#[repr(C)]\npub struct ${struct_name}RetRecord {\n${fields}}\n\n",
 			)
 		}
 	}
@@ -1153,16 +1161,16 @@ generate_all_record_structs_rust = |hosted_functions, type_table| {
 }
 
 ## Generate all argument #[repr(C)] structs
-generate_all_args_structs_rust = |hosted_functions, type_table| {
+generate_all_args_structs_rust = |hosted_functions, type_table, layouts| {
 	var $structs = ""
 	for func in hosted_functions {
-		$structs = Str.concat($structs, generate_args_struct_rust(func, type_table))
+		$structs = Str.concat($structs, generate_args_struct_rust(func, type_table, layouts))
 	}
 	$structs
 }
 
 ## Generate a single argument struct (empty string if no args).
-generate_args_struct_rust = |func, type_table| {
+generate_args_struct_rust = |func, type_table, layouts| {
 	parsed = parse_type_str(func.type_str)
 
 	if List.is_empty(parsed.args) {
@@ -1175,30 +1183,22 @@ generate_args_struct_rust = |func, type_table| {
 	type_table_result = if List.len(func.arg_type_ids) == 1 {
 		match List.first(func.arg_type_ids) {
 			Ok(arg_id) => lookup_record_in_type_table(type_table, arg_id)
-			Err(_) => { found: Bool.False, fields: [], size: 0, alignment: 0 }
+			Err(_) => { found: Bool.False, fields: [] }
 		}
 	} else {
-		{ found: Bool.False, fields: [], size: 0, alignment: 0 }
+		{ found: Bool.False, fields: [] }
 	}
 
 	if type_table_result.found {
-		var $fields = ""
-		for field in type_table_result.fields {
-			rust_type = type_id_to_rust(type_table, field.type_id)
-			$fields = Str.concat(
-				$fields,
-				"    pub ${field.name}: ${rust_type},\n",
-			)
+		arg_id = match List.first(func.arg_type_ids) {
+			Ok(id) => id
+			Err(_) => 0
 		}
-
-		assertions = if type_table_result.size > 0 {
-			"const _: () = assert!(core::mem::size_of::<${struct_name}Args>() == ${U64.to_str(type_table_result.size)}, \"${struct_name}Args size mismatch\");\nconst _: () = assert!(core::mem::align_of::<${struct_name}Args>() == ${U64.to_str(type_table_result.alignment)}, \"${struct_name}Args alignment mismatch\");\n\n"
-		} else {
-			""
-		}
+		type_layout = get_first_layout(layouts, arg_id)
+		fields = emit_fields_in_order_rust(type_table_result.fields, type_layout, type_table)
 
 		doc = "/// Arguments for ${func.name}\n/// Roc signature: ${func.type_str}\n"
-		return "${doc}#[repr(C)]\npub struct ${struct_name}Args {\n${$fields}}\n\n${assertions}"
+		return "${doc}#[repr(C)]\npub struct ${struct_name}Args {\n${fields}}\n\n"
 	}
 
 	# Multi-arg or primitive args: use positional fields from type table

--- a/src/glue/src/ZigGlue.roc
+++ b/src/glue/src/ZigGlue.roc
@@ -78,7 +78,7 @@ type_repr_to_zig : List(TypeRepr), TypeRepr -> Str
 type_repr_to_zig = |type_table, type_repr| {
 	match type_repr {
 		RocBool => "bool"
-		RocBox(inner_id) => "*${type_id_to_zig(type_table, inner_id)}"
+		RocBox(_) => "*anyopaque"
 		RocStr => "RocStr"
 		RocUnit => "void"
 		RocU8 => "u8"
@@ -150,10 +150,54 @@ is_repr_refcounted = |type_table, type_repr| {
 	}
 }
 
+## Check if a tag union is a Roc Try type: exactly [Err, Ok] with 0 or 1 payload each.
+is_try_type = |tu| {
+	if List.len(tu.tags) == 2 {
+		match List.get(tu.tags, 0) {
+			Ok(first) =>
+				match List.get(tu.tags, 1) {
+					Ok(second) =>
+						first.name == "Err" and second.name == "Ok"
+						and List.len(first.payload) <= 1
+						and List.len(second.payload) <= 1
+					_ => Bool.False
+				}
+			_ => Bool.False
+		}
+	} else {
+		Bool.False
+	}
+}
+
+## Get the Zig type for a Try variant's payload.
+## Returns "void" for empty/ZST payloads (the Try comptime function handles void -> [0]u8).
+try_variant_zig_type = |type_table, tag| {
+	if tag.payload_size == 0 {
+		"void"
+	} else {
+		match List.first(tag.payload) {
+			Ok(pid) => type_id_to_zig(type_table, pid)
+			Err(_) => "void"
+		}
+	}
+}
+
 ## Resolve a tag union to a Zig type. Single-variant unions are unwrapped to their payload.
-## Multi-variant unions with a name return a generated struct name.
+## Try types use the comptime Try(Ok, Err) constructor.
+## Other multi-variant unions with a name return a generated struct name.
 resolve_tag_union_type = |type_table, tu| {
-	if List.len(tu.tags) == 1 {
+	if is_try_type(tu) {
+		# Tags are sorted alphabetically: Err=index 0, Ok=index 1
+		err_type = match List.get(tu.tags, 0) {
+			Ok(err_tag) => try_variant_zig_type(type_table, err_tag)
+			_ => "void"
+		}
+		ok_type = match List.get(tu.tags, 1) {
+			Ok(ok_tag) => try_variant_zig_type(type_table, ok_tag)
+			_ => "void"
+		}
+		"Try(${ok_type}, ${err_type})"
+	} else if List.len(tu.tags) == 1 {
 		match List.first(tu.tags) {
 			Ok(tag) =>
 				match List.first(tag.payload) {
@@ -302,7 +346,7 @@ generate_element_type_structs = |type_table| {
 						zig_type = type_id_to_zig(type_table, field.type_id)
 						$field_strs = Str.concat(
 							$field_strs,
-							"    ${field.name}: ${zig_type},\n",
+							"    ${escape_zig_field_name(field.name)}: ${zig_type},\n",
 						)
 					}
 
@@ -356,7 +400,7 @@ generate_tag_union_structs = |type_table| {
 	for type_repr in type_table {
 		match type_repr {
 			RocTagUnion(tu) =>
-				if List.len(tu.tags) >= 2 and tu.name != "" and !(List.contains($seen_names, tu.name)) {
+				if List.len(tu.tags) >= 2 and tu.name != "" and !(List.contains($seen_names, tu.name)) and !(is_try_type(tu)) {
 					$seen_names = $seen_names.append(tu.name)
 					$structs = Str.concat($structs, generate_single_tag_union(type_table, tu))
 				}
@@ -486,6 +530,21 @@ str_replace_all = |s, from, to| {
 
 expect str_replace_all("a.b.c", ".", "_") == "a_b_c"
 expect str_replace_all("hello!", "!", "") == "hello"
+
+## Escape a Roc field name for use as a Zig identifier.
+## Roc field names can contain characters like `!` that are invalid in Zig identifiers.
+## Such names are wrapped with @"..." syntax.
+escape_zig_field_name : Str -> Str
+escape_zig_field_name = |name| {
+	bytes = Str.to_utf8(name)
+	needs_escape = List.any(bytes, |b|
+		!(b >= 'a' and b <= 'z')
+		and !(b >= 'A' and b <= 'Z')
+		and !(b >= '0' and b <= '9')
+		and b != '_'
+	)
+	if needs_escape { "@\"${name}\"" } else { name }
+}
 
 to_uppercase : U8 -> U8
 to_uppercase = |ch| ch - 32
@@ -646,24 +705,29 @@ expect lowercase_first("") == ""
 ## Look up a type_id in the type table and return record fields if it's a record.
 ## Follows single-variant tag unions (unwrapping to their payload).
 ## Type annotation ensures the interpreter uses the full TypeRepr layout.
-lookup_record_in_type_table : List(TypeRepr), U64 -> { found: Bool, fields: List(RecordField), size: U64, alignment: U64 }
+RecordLookup : { found: Bool, fields: List(RecordField), size: U64, alignment: U64, alt_fields: List(RecordField), alt_size: U64, alt_alignment: U64 }
+
+no_record : RecordLookup
+no_record = { found: Bool.False, fields: [], size: 0, alignment: 0, alt_fields: [], alt_size: 0, alt_alignment: 0 }
+
+lookup_record_in_type_table : List(TypeRepr), U64 -> RecordLookup
 lookup_record_in_type_table = |type_table, type_id| {
 	match List.get(type_table, type_id) {
 		Ok(type_repr) => lookup_record_from_repr(type_table, type_repr)
-		Err(_) => { found: Bool.False, fields: [], size: 0, alignment: 0 }
+		Err(_) => no_record
 	}
 }
 
 ## Match a TypeRepr and return record fields if it's a record.
 ## Type annotation ensures the interpreter uses the full 21-variant TypeRepr layout.
-lookup_record_from_repr : List(TypeRepr), TypeRepr -> { found: Bool, fields: List(RecordField), size: U64, alignment: U64 }
+lookup_record_from_repr : List(TypeRepr), TypeRepr -> RecordLookup
 lookup_record_from_repr = |type_table, type_repr| {
 	match type_repr {
 		RocRecord(rec) =>
 			if List.len(rec.fields) > 0 {
-				{ found: Bool.True, fields: rec.fields, size: rec.size, alignment: rec.alignment }
+				{ found: Bool.True, fields: rec.fields, size: rec.size, alignment: rec.alignment, alt_fields: rec.alt_fields, alt_size: rec.alt_size, alt_alignment: rec.alt_alignment }
 			} else {
-				{ found: Bool.False, fields: [], size: 0, alignment: 0 }
+				no_record
 			}
 		RocTagUnion(tu) =>
 			# Follow single-variant tag unions to their payload
@@ -672,33 +736,33 @@ lookup_record_from_repr = |type_table, type_repr| {
 					Ok(tag) =>
 						match List.first(tag.payload) {
 							Ok(payload_id) => lookup_record_in_type_table(type_table, payload_id)
-							_ => { found: Bool.False, fields: [], size: 0, alignment: 0 }
+							_ => no_record
 						}
-					_ => { found: Bool.False, fields: [], size: 0, alignment: 0 }
+					_ => no_record
 				}
 			} else {
-				{ found: Bool.False, fields: [], size: 0, alignment: 0 }
+				no_record
 			}
-		RocBox(_) => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocBool => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocDec => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocF32 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocF64 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocFunction(_) => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocI128 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocI16 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocI32 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocI64 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocI8 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocList(_) => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocStr => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocU128 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocU16 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocU32 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocU64 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocU8 => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocUnit => { found: Bool.False, fields: [], size: 0, alignment: 0 }
-		RocUnknown(_) => { found: Bool.False, fields: [], size: 0, alignment: 0 }
+		RocBox(_) => no_record
+		RocBool => no_record
+		RocDec => no_record
+		RocF32 => no_record
+		RocF64 => no_record
+		RocFunction(_) => no_record
+		RocI128 => no_record
+		RocI16 => no_record
+		RocI32 => no_record
+		RocI64 => no_record
+		RocI8 => no_record
+		RocList(_) => no_record
+		RocStr => no_record
+		RocU128 => no_record
+		RocU16 => no_record
+		RocU32 => no_record
+		RocU64 => no_record
+		RocU8 => no_record
+		RocUnit => no_record
+		RocUnknown(_) => no_record
 	}
 }
 
@@ -712,6 +776,8 @@ generate_zig_file = |hosted_functions, type_table, provides_list| {
 		.concat(generate_imports)
 		.concat("\n")
 		.concat(generate_host_abi_types)
+		.concat("\n")
+		.concat(generate_try_type)
 		.concat("\n")
 		.concat(generate_roc_str)
 		.concat("\n")
@@ -799,6 +865,32 @@ generate_host_abi_types =
 	\\}
 	\\
 
+## Generate the comptime Try(Ok, Err) type constructor.
+## Roc's Try(ok, err) is the tag union [Ok(ok), Err(err)].
+## Layout: payload extern union at offset 0, u8 discriminant after.
+generate_try_type : Str
+generate_try_type =
+	\\/// Comptime constructor for Roc's `Try(Ok, Err)` result type.
+	\\///
+	\\/// Roc's `Try(ok, err)` is the tag union `[Ok(ok), Err(err)]`.
+	\\/// Layout: payload extern union at offset 0, u8 discriminant after.
+	\\/// Discriminant values: Err = 0, Ok = 1 (alphabetical).
+	\\///
+	\\/// Example: `Try(*anyopaque, i32)` for `Try(Box(Model), I32)`.
+	\\pub fn Try(comptime Ok: type, comptime Err: type) type {
+	\\    const OkField = if (@sizeOf(Ok) == 0) [0]u8 else Ok;
+	\\    const ErrField = if (@sizeOf(Err) == 0) [0]u8 else Err;
+	\\    return extern struct {
+	\\        payload: extern union {
+	\\            err: ErrField,
+	\\            ok: OkField,
+	\\        },
+	\\        tag: TryTag,
+	\\        pub const TryTag = enum(u8) { Err = 0, Ok = 1 };
+	\\    };
+	\\}
+	\\
+
 ## Generate self-contained RocStr type definition
 generate_roc_str : Str
 generate_roc_str =
@@ -811,7 +903,6 @@ generate_roc_str =
 	\\
 	\\    const Self = @This();
 	\\    const small_string_size = @sizeOf(RocStr);
-	\\    const small_str_max_length = small_string_size - 1;
 	\\    const seamless_slice_bit: usize = @as(usize, @bitCast(@as(isize, std.math.minInt(isize))));
 	\\
 	\\    /// Return the string contents as a `[]const u8` slice.
@@ -941,26 +1032,11 @@ generate_all_record_structs = |hosted_functions, type_table| {
 
 		if type_table_result.found {
 			struct_name = name_to_struct_name(func.name)
+			full_name = "${struct_name}RetRecord"
 
-			var $fields = ""
-			for field in type_table_result.fields {
-				zig_type = type_id_to_zig(type_table, field.type_id)
-				$fields = Str.concat(
-					$fields,
-					"    ${field.name}: ${zig_type},\n",
-				)
-			}
-
-			assertions = if type_table_result.size > 0 {
-				"comptime {\n    if (@sizeOf(usize) == 8) {\n        if (@sizeOf(${struct_name}RetRecord) != ${U64.to_str(type_table_result.size)}) @compileError(\"${struct_name}RetRecord size mismatch\");\n        if (@alignOf(${struct_name}RetRecord) != ${U64.to_str(type_table_result.alignment)}) @compileError(\"${struct_name}RetRecord alignment mismatch\");\n    }\n}\n\n"
-			} else {
-				""
-			}
-
-			doc = "/// Return type record for ${func.name}\n/// Fields ordered by alignment descending (Roc ABI)\n"
 			$structs = Str.concat(
 				$structs,
-				"${doc}pub const ${struct_name}RetRecord = extern struct {\n${$fields}};\n\n${assertions}",
+				generate_record_struct_def(full_name, "Return type record for ${func.name}", type_table_result, type_table),
 			)
 		}
 		# else: return type is not a record (tag union, primitive, etc.) — skip RetRecord generation
@@ -990,30 +1066,15 @@ generate_args_struct = |func, type_table| {
 	type_table_result = if List.len(func.arg_type_ids) == 1 {
 		match List.first(func.arg_type_ids) {
 			Ok(arg_id) => lookup_record_in_type_table(type_table, arg_id)
-			Err(_) => { found: Bool.False, fields: [], size: 0, alignment: 0 }
+			Err(_) => no_record
 		}
 	} else {
-		{ found: Bool.False, fields: [], size: 0, alignment: 0 }
+		no_record
 	}
 
 	if type_table_result.found {
-		var $fields = ""
-		for field in type_table_result.fields {
-			zig_type = type_id_to_zig(type_table, field.type_id)
-			$fields = Str.concat(
-				$fields,
-				"    ${field.name}: ${zig_type},\n",
-			)
-		}
-
-		assertions = if type_table_result.size > 0 {
-			"comptime {\n    if (@sizeOf(usize) == 8) {\n        if (@sizeOf(${struct_name}Args) != ${U64.to_str(type_table_result.size)}) @compileError(\"${struct_name}Args size mismatch\");\n        if (@alignOf(${struct_name}Args) != ${U64.to_str(type_table_result.alignment)}) @compileError(\"${struct_name}Args alignment mismatch\");\n    }\n}\n\n"
-		} else {
-			""
-		}
-
-		doc = "/// Arguments for ${func.name}\n/// Roc signature: ${func.type_str}\n"
-		return "${doc}pub const ${struct_name}Args = extern struct {\n${$fields}};\n\n${assertions}"
+		full_name = "${struct_name}Args"
+		return generate_record_struct_def(full_name, "Arguments for ${func.name}\n/// Roc signature: ${func.type_str}", type_table_result, type_table)
 	}
 
 	# Multi-arg or primitive args: use positional fields from type table
@@ -1031,6 +1092,57 @@ generate_args_struct = |func, type_table| {
 	doc = "/// Arguments for ${func.name}\n/// Roc signature: ${func.type_str}\n"
 
 	"${doc}pub const ${struct_name}Args = extern struct {\n${$positional_fields}};\n\n"
+}
+
+## Generate a record struct definition, with comptime conditional if alt layout differs.
+generate_record_struct_def = |name, doc_text, record_info, type_table| {
+	var $fields = ""
+	for field in record_info.fields {
+		zig_type = type_id_to_zig(type_table, field.type_id)
+		$fields = Str.concat(
+			$fields,
+			"    ${escape_zig_field_name(field.name)}: ${zig_type},\n",
+		)
+	}
+
+	has_alt = List.len(record_info.alt_fields) > 0
+
+	if has_alt {
+		# Emit comptime conditional struct for divergent 64-bit/32-bit layouts
+		var $alt_field_strs = ""
+		for alt_field in record_info.alt_fields {
+			zig_type = type_id_to_zig(type_table, alt_field.type_id)
+			$alt_field_strs = Str.concat(
+				$alt_field_strs,
+				"    ${escape_zig_field_name(alt_field.name)}: ${zig_type},\n",
+			)
+		}
+
+		assertions_64 = if record_info.size > 0 {
+			"    if (@sizeOf(${name}) != ${U64.to_str(record_info.size)}) @compileError(\"${name} size mismatch\");\n    if (@alignOf(${name}) != ${U64.to_str(record_info.alignment)}) @compileError(\"${name} alignment mismatch\");\n"
+		} else {
+			""
+		}
+
+		assertions_32 = if record_info.alt_size > 0 {
+			"    if (@sizeOf(${name}) != ${U64.to_str(record_info.alt_size)}) @compileError(\"${name} size mismatch\");\n    if (@alignOf(${name}) != ${U64.to_str(record_info.alt_alignment)}) @compileError(\"${name} alignment mismatch\");\n"
+		} else {
+			""
+		}
+
+		doc = "/// ${doc_text}\n/// Fields ordered by alignment descending (Roc ABI)\n"
+		"${doc}pub const ${name} = if (@sizeOf(usize) == 8) extern struct {\n${$fields}} else extern struct {\n${$alt_field_strs}};\n\ncomptime {\n    if (@sizeOf(usize) == 8) {\n${assertions_64}    }\n    if (@sizeOf(usize) == 4) {\n${assertions_32}    }\n}\n\n"
+	} else {
+		# Single layout — same for both targets
+		assertions = if record_info.size > 0 {
+			"comptime {\n    if (@sizeOf(usize) == 8) {\n        if (@sizeOf(${name}) != ${U64.to_str(record_info.size)}) @compileError(\"${name} size mismatch\");\n        if (@alignOf(${name}) != ${U64.to_str(record_info.alignment)}) @compileError(\"${name} alignment mismatch\");\n    }\n}\n\n"
+		} else {
+			""
+		}
+
+		doc = "/// ${doc_text}\n/// Fields ordered by alignment descending (Roc ABI)\n"
+		"${doc}pub const ${name} = extern struct {\n${$fields}};\n\n${assertions}"
+	}
 }
 
 ## Generate the PlatformHostedFns struct type
@@ -1382,7 +1494,7 @@ generate_entrypoint_externs = |provides_list, type_table| {
 		return ""
 	}
 
-	var $result = "// =============================================================================\n// Entrypoint Declarations\n//\n// Extern declarations for Roc entrypoints. Call these from your platform host\n// to invoke Roc application functions.\n// =============================================================================\n\n"
+	var $result = "// Entrypoint Declarations\n//\n// Extern declarations for Roc entrypoints. Call these from your platform host\n// to invoke Roc application functions.\n\n"
 
 	$result = Str.concat($result, generate_entrypoint_arg_structs(provides_list, type_table))
 

--- a/src/glue/src/ZigGlue.roc
+++ b/src/glue/src/ZigGlue.roc
@@ -11,6 +11,8 @@ import pf.TagUnionRepr exposing [TagUnionRepr]
 import pf.RecordField exposing [RecordField]
 import pf.TagVariant exposing [TagVariant]
 import pf.ProvidesEntry exposing [ProvidesEntry]
+import pf.TargetLayout exposing [TargetLayout]
+import pf.TypeLayout exposing [TypeLayout]
 
 make_glue : List(Types) -> Try(List(File), Str)
 make_glue = |types_list| {
@@ -18,10 +20,14 @@ make_glue = |types_list| {
 	var $hosted_functions = []
 	var $type_table = []
 	var $provides_entries = []
+	var $tgts = []
+	var $layouts = []
 
 	for types in types_list {
 		$type_table = types.type_table
 		$provides_entries = types.provides_entries
+		$tgts = types.target_names
+		$layouts = types.layouts
 
 		for mod in types.modules {
 			for func in mod.hosted_functions {
@@ -45,7 +51,7 @@ make_glue = |types_list| {
 	# Sort by index so array entries are in the correct order
 	sorted = List.sort_with($hosted_functions, compare_by_index)
 
-	zig_content = generate_zig_file(sorted, $type_table, $provides_entries)
+	zig_content = generate_zig_file(sorted, $type_table, $provides_entries, $tgts, $layouts)
 
 	Ok([{ name: "roc_platform_abi.zig", content: zig_content }])
 }
@@ -170,9 +176,9 @@ is_try_type = |tu| {
 }
 
 ## Get the Zig type for a Try variant's payload.
-## Returns "void" for empty/ZST payloads (the Try comptime function handles void -> [0]u8).
+## Returns "void" for empty payloads (the Try comptime function handles void -> [0]u8).
 try_variant_zig_type = |type_table, tag| {
-	if tag.payload_size == 0 {
+	if List.is_empty(tag.payload) {
 		"void"
 	} else {
 		match List.first(tag.payload) {
@@ -326,41 +332,168 @@ generate_roc_list_generic =
 	\\}
 	\\
 
+## Look up the TypeLayout for a given type_id from a TargetLayout.
+get_type_layout : TargetLayout, U64 -> TypeLayout
+get_type_layout = |target_layout, type_id| {
+	match List.get(target_layout.type_layouts, type_id) {
+		Ok(tl) => tl
+		Err(_) => { alignment: 0, field_order: [], size: 0 }
+	}
+}
+
+## Check if any target is 32-bit (pointer width 4)
+has_32bit_target : List(Str) -> Bool
+has_32bit_target = |tgts| {
+	List.any(tgts, |t| t == "wasm32" or t == "arm32linux" or t == "arm32musl")
+}
+
+## Check if any target is 64-bit (pointer width 8)
+has_64bit_target : List(Str) -> Bool
+has_64bit_target = |tgts| {
+	List.any(tgts, |t| !(t == "wasm32" or t == "arm32linux" or t == "arm32musl"))
+}
+
+## Get the first 64-bit target layout index (or 0)
+first_64bit_layout_idx : List(Str) -> U64
+first_64bit_layout_idx = |tgts| {
+	var $idx = 0
+	var $found = 0
+	for t in tgts {
+		if !(t == "wasm32" or t == "arm32linux" or t == "arm32musl") {
+			$found = $idx
+		}
+		$idx = $idx + 1
+	}
+	$found
+}
+
+## Get the first 32-bit target layout index (or 0)
+first_32bit_layout_idx : List(Str) -> U64
+first_32bit_layout_idx = |tgts| {
+	var $idx = 0
+	var $found = 0
+	for t in tgts {
+		if t == "wasm32" or t == "arm32linux" or t == "arm32musl" {
+			$found = $idx
+		}
+		$idx = $idx + 1
+	}
+	$found
+}
+
+## Emit fields in ABI order for a given target, using the layout's field_order permutation.
+emit_fields_in_order : List(RecordField), TypeLayout, List(TypeRepr) -> Str
+emit_fields_in_order = |fields, type_layout, type_table| {
+	var $field_strs = ""
+	if List.is_empty(type_layout.field_order) {
+		# No field_order => emit in canonical (alphabetical) order
+		for field in fields {
+			zig_type = type_id_to_zig(type_table, field.type_id)
+			$field_strs = Str.concat($field_strs, "    ${escape_zig_field_name(field.name)}: ${zig_type},\n")
+		}
+	} else {
+		for order_idx in type_layout.field_order {
+			match List.get(fields, order_idx) {
+				Ok(field) => {
+					zig_type = type_id_to_zig(type_table, field.type_id)
+					$field_strs = Str.concat($field_strs, "    ${escape_zig_field_name(field.name)}: ${zig_type},\n")
+				}
+				Err(_) => {}
+			}
+		}
+	}
+	$field_strs
+}
+
+## Check if two field_order lists are the same permutation.
+same_field_order : List(U64), List(U64) -> Bool
+same_field_order = |a, b| {
+	if List.len(a) != List.len(b) {
+		Bool.False
+	} else if List.is_empty(a) and List.is_empty(b) {
+		Bool.True
+	} else {
+		var $same = Bool.True
+		var $i = 0
+		for ai in a {
+			match List.get(b, $i) {
+				Ok(bi) => { if ai != bi { $same = Bool.False } }
+				Err(_) => { $same = Bool.False }
+			}
+			$i = $i + 1
+		}
+		$same
+	}
+}
+
 ## Generate extern structs for element types found in the type table.
 ## Scans for Record types and generates Zig extern structs for them.
-## Fields arrive pre-sorted by alignment descending from the compiler.
-generate_element_type_structs : List(TypeRepr) -> Str
-generate_element_type_structs = |type_table| {
+## Fields are emitted in ABI order using the per-target layout's field_order.
+generate_element_type_structs : List(TypeRepr), List(Str), List(TargetLayout) -> Str
+generate_element_type_structs = |type_table, tgts, layouts| {
 	var $structs = ""
 	var $seen_names = []
+	var $type_idx = 0
 
 	for type_repr in type_table {
+		cur_idx = $type_idx
+		$type_idx = $type_idx + 1
 		match type_repr {
 			RocRecord(rec) =>
 				if rec.name != "" and !(List.contains($seen_names, rec.name)) {
 					$seen_names = $seen_names.append(rec.name)
-
 					struct_name = name_to_struct_name(rec.name)
-					var $field_strs = ""
-					for field in rec.fields {
-						zig_type = type_id_to_zig(type_table, field.type_id)
-						$field_strs = Str.concat(
-							$field_strs,
-							"    ${escape_zig_field_name(field.name)}: ${zig_type},\n",
+
+					# Get layouts for this type from each target
+					# Check if all tgts agree on field_order
+					first_layout = match List.first(layouts) {
+						Ok(tl) => get_type_layout(tl, cur_idx)
+						Err(_) => { alignment: 0, field_order: [], size: 0 }
+					}
+
+					all_same_order = List.all(layouts, |tl|
+						same_field_order(get_type_layout(tl, cur_idx).field_order, first_layout.field_order)
+					)
+
+					if all_same_order {
+						# Single layout — emit fields in ABI order from first target
+						field_strs = emit_fields_in_order(rec.fields, first_layout, type_table)
+
+						assertions = generate_size_assertions(struct_name, tgts, layouts, cur_idx)
+
+						$structs = Str.concat(
+							$structs,
+							"/// Element type for ${rec.name}\npub const ${struct_name} = extern struct {\n${field_strs}};\n\n${assertions}",
+						)
+					} else {
+						# Divergent field orders — emit comptime conditional
+						idx_64 = first_64bit_layout_idx(tgts)
+						idx_32 = first_32bit_layout_idx(tgts)
+						layout_64 = match List.get(layouts, idx_64) {
+							Ok(tl) => get_type_layout(tl, cur_idx)
+							Err(_) => first_layout
+						}
+						layout_32 = match List.get(layouts, idx_32) {
+							Ok(tl) => get_type_layout(tl, cur_idx)
+							Err(_) => first_layout
+						}
+
+						fields_64 = emit_fields_in_order(rec.fields, layout_64, type_table)
+						fields_32 = emit_fields_in_order(rec.fields, layout_32, type_table)
+
+						assertions_64 = if layout_64.size > 0 {
+							"    if (@sizeOf(${struct_name}) != ${U64.to_str(layout_64.size)}) @compileError(\"${struct_name} size mismatch\");\n    if (@alignOf(${struct_name}) != ${U64.to_str(layout_64.alignment)}) @compileError(\"${struct_name} alignment mismatch\");\n"
+						} else { "" }
+
+						assertions_32 = if layout_32.size > 0 {
+							"    if (@sizeOf(${struct_name}) != ${U64.to_str(layout_32.size)}) @compileError(\"${struct_name} size mismatch\");\n    if (@alignOf(${struct_name}) != ${U64.to_str(layout_32.alignment)}) @compileError(\"${struct_name} alignment mismatch\");\n"
+						} else { "" }
+
+						$structs = Str.concat(
+							$structs,
+							"/// Element type for ${rec.name}\n/// Fields ordered by alignment descending (Roc ABI)\npub const ${struct_name} = if (@sizeOf(usize) == 8) extern struct {\n${fields_64}} else extern struct {\n${fields_32}};\n\ncomptime {\n    if (@sizeOf(usize) == 8) {\n${assertions_64}    }\n    if (@sizeOf(usize) == 4) {\n${assertions_32}    }\n}\n\n",
 						)
 					}
-
-					# Comptime size/alignment assertions (guarded by pointer width)
-					assertions = if rec.size > 0 {
-						"comptime {\n    if (@sizeOf(usize) == 8) {\n        if (@sizeOf(${struct_name}) != ${U64.to_str(rec.size)}) @compileError(\"${struct_name} size mismatch\");\n        if (@alignOf(${struct_name}) != ${U64.to_str(rec.alignment)}) @compileError(\"${struct_name} alignment mismatch\");\n    }\n}\n\n"
-					} else {
-						""
-					}
-
-					$structs = Str.concat(
-						$structs,
-						"/// Element type for ${rec.name}\npub const ${struct_name} = extern struct {\n${$field_strs}};\n\n${assertions}",
-					)
 				}
 			RocBox(_) => {}
 			RocTagUnion(_) => {}
@@ -389,20 +522,53 @@ generate_element_type_structs = |type_table| {
 	$structs
 }
 
+## Generate comptime size/alignment assertions for all tgts.
+## Groups tgts by pointer width and emits guarded assertions.
+generate_size_assertions : Str, List(Str), List(TargetLayout), U64 -> Str
+generate_size_assertions = |struct_name, tgts, layouts, type_idx| {
+	has_64 = has_64bit_target(tgts)
+	has_32 = has_32bit_target(tgts)
+
+	idx_64 = first_64bit_layout_idx(tgts)
+	idx_32 = first_32bit_layout_idx(tgts)
+
+	layout_64 = match List.get(layouts, idx_64) {
+		Ok(tl) => get_type_layout(tl, type_idx)
+		Err(_) => { alignment: 0, field_order: [], size: 0 }
+	}
+	layout_32 = match List.get(layouts, idx_32) {
+		Ok(tl) => get_type_layout(tl, type_idx)
+		Err(_) => { alignment: 0, field_order: [], size: 0 }
+	}
+
+	if has_64 and has_32 and layout_64.size > 0 and layout_32.size > 0 {
+		"comptime {\n    if (@sizeOf(usize) == 8) {\n        if (@sizeOf(${struct_name}) != ${U64.to_str(layout_64.size)}) @compileError(\"${struct_name} size mismatch\");\n        if (@alignOf(${struct_name}) != ${U64.to_str(layout_64.alignment)}) @compileError(\"${struct_name} alignment mismatch\");\n    }\n    if (@sizeOf(usize) == 4) {\n        if (@sizeOf(${struct_name}) != ${U64.to_str(layout_32.size)}) @compileError(\"${struct_name} size mismatch\");\n        if (@alignOf(${struct_name}) != ${U64.to_str(layout_32.alignment)}) @compileError(\"${struct_name} alignment mismatch\");\n    }\n}\n\n"
+	} else if has_64 and layout_64.size > 0 {
+		"comptime {\n    if (@sizeOf(usize) == 8) {\n        if (@sizeOf(${struct_name}) != ${U64.to_str(layout_64.size)}) @compileError(\"${struct_name} size mismatch\");\n        if (@alignOf(${struct_name}) != ${U64.to_str(layout_64.alignment)}) @compileError(\"${struct_name} alignment mismatch\");\n    }\n}\n\n"
+	} else if has_32 and layout_32.size > 0 {
+		"comptime {\n    if (@sizeOf(usize) == 4) {\n        if (@sizeOf(${struct_name}) != ${U64.to_str(layout_32.size)}) @compileError(\"${struct_name} size mismatch\");\n        if (@alignOf(${struct_name}) != ${U64.to_str(layout_32.alignment)}) @compileError(\"${struct_name} alignment mismatch\");\n    }\n}\n\n"
+	} else {
+		""
+	}
+}
+
 ## Generate extern structs for tag union types found in the type table.
 ## Multi-variant tag unions get a tag enum, payload extern union, and wrapping extern struct.
 ## Pure enums (all variants have no payload) get just an enum.
-generate_tag_union_structs : List(TypeRepr) -> Str
-generate_tag_union_structs = |type_table| {
+generate_tag_union_structs : List(TypeRepr), List(Str), List(TargetLayout) -> Str
+generate_tag_union_structs = |type_table, tgts, layouts| {
 	var $structs = ""
 	var $seen_names = []
+	var $type_idx = 0
 
 	for type_repr in type_table {
+		cur_idx = $type_idx
+		$type_idx = $type_idx + 1
 		match type_repr {
 			RocTagUnion(tu) =>
 				if List.len(tu.tags) >= 2 and tu.name != "" and !(List.contains($seen_names, tu.name)) and !(is_try_type(tu)) {
 					$seen_names = $seen_names.append(tu.name)
-					$structs = Str.concat($structs, generate_single_tag_union(type_table, tu))
+					$structs = Str.concat($structs, generate_single_tag_union(type_table, tu, tgts, layouts, cur_idx))
 				}
 			RocBox(_) => {}
 			RocRecord(_) => {}
@@ -432,7 +598,7 @@ generate_tag_union_structs = |type_table| {
 }
 
 ## Generate Zig code for a single multi-variant tag union.
-generate_single_tag_union = |type_table, tu| {
+generate_single_tag_union = |type_table, tu, tgts, layouts, type_idx| {
 	struct_name = name_to_struct_name(tu.name)
 	tag_count = List.len(tu.tags)
 	disc_type = disc_type_for_count(tag_count)
@@ -495,12 +661,8 @@ generate_single_tag_union = |type_table, tu| {
 			}
 		}
 
-		# Comptime assertions
-		assertions = if tu.size > 0 {
-			"comptime {\n    if (@sizeOf(usize) == 8) {\n        if (@sizeOf(${struct_name}) != ${U64.to_str(tu.size)}) @compileError(\"${struct_name} size mismatch\");\n        if (@alignOf(${struct_name}) != ${U64.to_str(tu.alignment)}) @compileError(\"${struct_name} alignment mismatch\");\n    }\n}\n\n"
-		} else {
-			""
-		}
+		# Comptime assertions using per-target layouts
+		assertions = generate_size_assertions(struct_name, tgts, layouts, type_idx)
 
 		"${$tuple_structs}/// Tag discriminant for ${tu.name}.\npub const ${struct_name}Tag = enum(${disc_type}) {\n${$enum_variants}};\n\n/// Tag union: ${tu.name}\npub const ${struct_name} = extern struct {\n    payload: extern union {\n${$union_fields}    },\n    tag: ${struct_name}Tag,\n};\n\n${assertions}"
 	}
@@ -704,11 +866,10 @@ expect lowercase_first("") == ""
 
 ## Look up a type_id in the type table and return record fields if it's a record.
 ## Follows single-variant tag unions (unwrapping to their payload).
-## Type annotation ensures the interpreter uses the full TypeRepr layout.
-RecordLookup : { found: Bool, fields: List(RecordField), size: U64, alignment: U64, alt_fields: List(RecordField), alt_size: U64, alt_alignment: U64 }
+RecordLookup : { found: Bool, fields: List(RecordField) }
 
 no_record : RecordLookup
-no_record = { found: Bool.False, fields: [], size: 0, alignment: 0, alt_fields: [], alt_size: 0, alt_alignment: 0 }
+no_record = { found: Bool.False, fields: [] }
 
 lookup_record_in_type_table : List(TypeRepr), U64 -> RecordLookup
 lookup_record_in_type_table = |type_table, type_id| {
@@ -719,13 +880,12 @@ lookup_record_in_type_table = |type_table, type_id| {
 }
 
 ## Match a TypeRepr and return record fields if it's a record.
-## Type annotation ensures the interpreter uses the full 21-variant TypeRepr layout.
 lookup_record_from_repr : List(TypeRepr), TypeRepr -> RecordLookup
 lookup_record_from_repr = |type_table, type_repr| {
 	match type_repr {
 		RocRecord(rec) =>
 			if List.len(rec.fields) > 0 {
-				{ found: Bool.True, fields: rec.fields, size: rec.size, alignment: rec.alignment, alt_fields: rec.alt_fields, alt_size: rec.alt_size, alt_alignment: rec.alt_alignment }
+				{ found: Bool.True, fields: rec.fields }
 			} else {
 				no_record
 			}
@@ -771,7 +931,7 @@ lookup_record_from_repr = |type_table, type_repr| {
 # =============================================================================
 
 ## Generate the complete Zig source file
-generate_zig_file = |hosted_functions, type_table, provides_list| {
+generate_zig_file = |hosted_functions, type_table, provides_list, tgts, layouts| {
 	file_header
 		.concat(generate_imports)
 		.concat("\n")
@@ -783,10 +943,10 @@ generate_zig_file = |hosted_functions, type_table, provides_list| {
 		.concat("\n")
 		.concat(generate_roc_list_generic)
 		.concat("\n")
-		.concat(generate_element_type_structs(type_table))
-		.concat(generate_tag_union_structs(type_table))
-		.concat(generate_all_record_structs(hosted_functions, type_table))
-		.concat(generate_all_args_structs(hosted_functions, type_table))
+		.concat(generate_element_type_structs(type_table, tgts, layouts))
+		.concat(generate_tag_union_structs(type_table, tgts, layouts))
+		.concat(generate_all_record_structs(hosted_functions, type_table, tgts, layouts))
+		.concat(generate_all_args_structs(hosted_functions, type_table, tgts, layouts))
 		.concat(generate_platform_fns_struct(hosted_functions, type_table))
 		.concat("\n")
 		.concat(generate_hosted_functions_helper(hosted_functions))
@@ -1024,7 +1184,7 @@ generate_roc_str =
 ## Generate extern structs for record return types using type table (correctly sorted by alignment).
 ## Only generates RetRecord structs when ret_type_id resolves to a record in the type table.
 ## Tag union return types (e.g., Try(Record, Str)) are not yet supported and are skipped.
-generate_all_record_structs = |hosted_functions, type_table| {
+generate_all_record_structs = |hosted_functions, type_table, tgts, layouts| {
 	var $structs = ""
 	for func in hosted_functions {
 		# Only generate RetRecord if the return type is actually a record
@@ -1036,7 +1196,7 @@ generate_all_record_structs = |hosted_functions, type_table| {
 
 			$structs = Str.concat(
 				$structs,
-				generate_record_struct_def(full_name, "Return type record for ${func.name}", type_table_result, type_table),
+				generate_record_struct_def(full_name, "Return type record for ${func.name}", type_table_result, type_table, func.ret_type_id, tgts, layouts),
 			)
 		}
 		# else: return type is not a record (tag union, primitive, etc.) — skip RetRecord generation
@@ -1045,17 +1205,17 @@ generate_all_record_structs = |hosted_functions, type_table| {
 }
 
 ## Generate all argument extern structs
-generate_all_args_structs = |hosted_functions, type_table| {
+generate_all_args_structs = |hosted_functions, type_table, tgts, layouts| {
 	var $structs = ""
 	for func in hosted_functions {
-		$structs = Str.concat($structs, generate_args_struct(func, type_table))
+		$structs = Str.concat($structs, generate_args_struct(func, type_table, tgts, layouts))
 	}
 	$structs
 }
 
 ## Generate a single argument extern struct (empty string if no args).
 ## Uses type table for single-record args; positional for multi-arg or primitive args.
-generate_args_struct = |func, type_table| {
+generate_args_struct = |func, type_table, tgts, layouts| {
 	if !(has_meaningful_args(func, type_table)) {
 		return ""
 	}
@@ -1074,7 +1234,11 @@ generate_args_struct = |func, type_table| {
 
 	if type_table_result.found {
 		full_name = "${struct_name}Args"
-		return generate_record_struct_def(full_name, "Arguments for ${func.name}\n/// Roc signature: ${func.type_str}", type_table_result, type_table)
+		arg_id = match List.first(func.arg_type_ids) {
+			Ok(id) => id
+			Err(_) => 0
+		}
+		return generate_record_struct_def(full_name, "Arguments for ${func.name}\n/// Roc signature: ${func.type_str}", type_table_result, type_table, arg_id, tgts, layouts)
 	}
 
 	# Multi-arg or primitive args: use positional fields from type table
@@ -1094,54 +1258,63 @@ generate_args_struct = |func, type_table| {
 	"${doc}pub const ${struct_name}Args = extern struct {\n${$positional_fields}};\n\n"
 }
 
-## Generate a record struct definition, with comptime conditional if alt layout differs.
-generate_record_struct_def = |name, doc_text, record_info, type_table| {
-	var $fields = ""
-	for field in record_info.fields {
-		zig_type = type_id_to_zig(type_table, field.type_id)
-		$fields = Str.concat(
-			$fields,
-			"    ${escape_zig_field_name(field.name)}: ${zig_type},\n",
-		)
+## Generate a record struct definition, using per-target layouts for field ordering.
+## If tgts have divergent field orderings, emits a comptime conditional struct.
+generate_record_struct_def = |name, doc_text, record_info, type_table, type_id, tgts, layouts| {
+	# If no layouts provided, emit fields in canonical (alphabetical) order without assertions
+	if List.is_empty(layouts) {
+		var $fields = ""
+		for field in record_info.fields {
+			zig_type = type_id_to_zig(type_table, field.type_id)
+			$fields = Str.concat($fields, "    ${escape_zig_field_name(field.name)}: ${zig_type},\n")
+		}
+		doc = "/// ${doc_text}\n/// Fields ordered by alignment descending (Roc ABI)\n"
+		return "${doc}pub const ${name} = extern struct {\n${$fields}};\n\n"
 	}
 
-	has_alt = List.len(record_info.alt_fields) > 0
+	# Get layout from first target
+	first_layout = match List.first(layouts) {
+		Ok(tl) => get_type_layout(tl, type_id)
+		Err(_) => { alignment: 0, field_order: [], size: 0 }
+	}
 
-	if has_alt {
-		# Emit comptime conditional struct for divergent 64-bit/32-bit layouts
-		var $alt_field_strs = ""
-		for alt_field in record_info.alt_fields {
-			zig_type = type_id_to_zig(type_table, alt_field.type_id)
-			$alt_field_strs = Str.concat(
-				$alt_field_strs,
-				"    ${escape_zig_field_name(alt_field.name)}: ${zig_type},\n",
-			)
-		}
+	# Check if all tgts agree on field_order
+	all_same_order = List.all(layouts, |tl|
+		same_field_order(get_type_layout(tl, type_id).field_order, first_layout.field_order)
+	)
 
-		assertions_64 = if record_info.size > 0 {
-			"    if (@sizeOf(${name}) != ${U64.to_str(record_info.size)}) @compileError(\"${name} size mismatch\");\n    if (@alignOf(${name}) != ${U64.to_str(record_info.alignment)}) @compileError(\"${name} alignment mismatch\");\n"
-		} else {
-			""
-		}
-
-		assertions_32 = if record_info.alt_size > 0 {
-			"    if (@sizeOf(${name}) != ${U64.to_str(record_info.alt_size)}) @compileError(\"${name} size mismatch\");\n    if (@alignOf(${name}) != ${U64.to_str(record_info.alt_alignment)}) @compileError(\"${name} alignment mismatch\");\n"
-		} else {
-			""
-		}
-
+	if all_same_order {
+		# Single layout — emit fields in ABI order from first target
+		field_strs = emit_fields_in_order(record_info.fields, first_layout, type_table)
+		assertions = generate_size_assertions(name, tgts, layouts, type_id)
 		doc = "/// ${doc_text}\n/// Fields ordered by alignment descending (Roc ABI)\n"
-		"${doc}pub const ${name} = if (@sizeOf(usize) == 8) extern struct {\n${$fields}} else extern struct {\n${$alt_field_strs}};\n\ncomptime {\n    if (@sizeOf(usize) == 8) {\n${assertions_64}    }\n    if (@sizeOf(usize) == 4) {\n${assertions_32}    }\n}\n\n"
+		"${doc}pub const ${name} = extern struct {\n${field_strs}};\n\n${assertions}"
 	} else {
-		# Single layout — same for both targets
-		assertions = if record_info.size > 0 {
-			"comptime {\n    if (@sizeOf(usize) == 8) {\n        if (@sizeOf(${name}) != ${U64.to_str(record_info.size)}) @compileError(\"${name} size mismatch\");\n        if (@alignOf(${name}) != ${U64.to_str(record_info.alignment)}) @compileError(\"${name} alignment mismatch\");\n    }\n}\n\n"
-		} else {
-			""
+		# Divergent field orders — emit comptime conditional
+		idx_64 = first_64bit_layout_idx(tgts)
+		idx_32 = first_32bit_layout_idx(tgts)
+		layout_64 = match List.get(layouts, idx_64) {
+			Ok(tl) => get_type_layout(tl, type_id)
+			Err(_) => first_layout
+		}
+		layout_32 = match List.get(layouts, idx_32) {
+			Ok(tl) => get_type_layout(tl, type_id)
+			Err(_) => first_layout
 		}
 
+		fields_64 = emit_fields_in_order(record_info.fields, layout_64, type_table)
+		fields_32 = emit_fields_in_order(record_info.fields, layout_32, type_table)
+
+		assertions_64 = if layout_64.size > 0 {
+			"    if (@sizeOf(${name}) != ${U64.to_str(layout_64.size)}) @compileError(\"${name} size mismatch\");\n    if (@alignOf(${name}) != ${U64.to_str(layout_64.alignment)}) @compileError(\"${name} alignment mismatch\");\n"
+		} else { "" }
+
+		assertions_32 = if layout_32.size > 0 {
+			"    if (@sizeOf(${name}) != ${U64.to_str(layout_32.size)}) @compileError(\"${name} size mismatch\");\n    if (@alignOf(${name}) != ${U64.to_str(layout_32.alignment)}) @compileError(\"${name} alignment mismatch\");\n"
+		} else { "" }
+
 		doc = "/// ${doc_text}\n/// Fields ordered by alignment descending (Roc ABI)\n"
-		"${doc}pub const ${name} = extern struct {\n${$fields}};\n\n${assertions}"
+		"${doc}pub const ${name} = if (@sizeOf(usize) == 8) extern struct {\n${fields_64}} else extern struct {\n${fields_32}};\n\ncomptime {\n    if (@sizeOf(usize) == 8) {\n${assertions_64}    }\n    if (@sizeOf(usize) == 4) {\n${assertions_32}    }\n}\n\n"
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Interpreter**: Fix module resolution collisions between platform and app imports; use correct type var for hosted method return types
- **Interpreter**: Fix ZST variant layout for concrete types in polymorphic tag unions (e.g., `List.get : List(a) -> Result a b` where `a` was rigid at layout time)
- **Interpreter**: Fix rigid type substitution to also check `rigid_name_subst` (from platform `for` clause), extend variant layout correction to `box_of_zst`, and handle ZST/box_of_zst payloads in `evalBoxIntrinsic`
- **Interpreter**: Fix silent OOM in record extension chain flattening
- **Glue generator**: Separate per-target layout computation from type table — types are now stored without size/alignment, and layouts are computed per target via `computeLayoutsForTarget`
- **Glue generator**: Parse platform `targets` section to build target list, deduplicate by pointer width
- **Glue generator**: Pass per-target layouts to Roc glue specs (`ZigGlue.roc`, `RustGlue.roc`) for correct cross-platform struct field ordering and comptime assertions
- **Glue generator**: New platform types `TargetLayout` and `TypeLayout`; simplified `RecordField`, `RecordRepr`, `TagUnionRepr`, `TagVariant` (removed inline size/alignment fields)

## Test plan
- [x] `zig build minici` passes (all 3107 tests, CLI tests, lints, snapshots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)