### PR TITLE
Add a dev shim for roc run using `--backend=dev`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3406,6 +3406,34 @@ fn addMainExe(
     // Add tracy support (required by parse/can/check modules)
     add_tracy(b, roc_modules.build_options, shim_lib, b.graph.host, false, flag_enable_tracy);
 
+    // Create dev shim static library - uses DevEvaluator for JIT compilation
+    // instead of the interpreter. Only supports x86_64/aarch64 (no wasm32).
+    const dev_shim_lib = b.addLibrary(.{
+        .name = "roc_dev_shim",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/dev_shim/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .strip = strip,
+            .omit_frame_pointer = omit_frame_pointer,
+            .pic = true,
+        }),
+        .linkage = .static,
+    });
+    configureBackend(dev_shim_lib, target);
+    roc_modules.addAll(dev_shim_lib);
+    dev_shim_lib.root_module.addImport("compiled_builtins", compiled_builtins_module);
+    dev_shim_lib.step.dependOn(&write_compiled_builtins.step);
+    dev_shim_lib.addObjectFile(builtins_obj.getEmittedBin());
+    dev_shim_lib.bundle_compiler_rt = true;
+    const install_dev_shim = b.addInstallArtifact(dev_shim_lib, .{});
+    b.getInstallStep().dependOn(&install_dev_shim.step);
+    const copy_dev_shim = b.addUpdateSourceFiles();
+    const dev_shim_filename = if (target.result.os.tag == .windows) "roc_dev_shim.lib" else "libroc_dev_shim.a";
+    copy_dev_shim.addCopyFileToSource(dev_shim_lib.getEmittedBin(), b.pathJoin(&.{ "src/cli", dev_shim_filename }));
+    exe.step.dependOn(&copy_dev_shim.step);
+    add_tracy(b, roc_modules.build_options, dev_shim_lib, b.graph.host, false, flag_enable_tracy);
+
     // Cross-compile interpreter shim for all supported targets
     // This allows `roc build --target=X` to work for cross-compilation
     const cross_compile_shim_targets = [_]struct { name: []const u8, query: std.Target.Query }{
@@ -3506,6 +3534,38 @@ fn addMainExe(
             b.pathJoin(&.{ "src/cli/targets", cross_target.name, builtins_ext }),
         );
         exe.step.dependOn(&copy_cross_builtins.step);
+
+        // Build dev shim for this cross target (skip wasm32 - dev backend is x86_64/aarch64 only)
+        if (cross_target.query.cpu_arch != .wasm32) {
+            const cross_dev_shim_lib = b.addLibrary(.{
+                .name = b.fmt("roc_dev_shim_{s}", .{cross_target.name}),
+                .root_module = b.createModule(.{
+                    .root_source_file = b.path("src/dev_shim/main.zig"),
+                    .target = cross_resolved_target,
+                    .optimize = optimize,
+                    .strip = strip,
+                    .omit_frame_pointer = omit_frame_pointer,
+                    .pic = true,
+                }),
+                .linkage = .static,
+            });
+            configureBackend(cross_dev_shim_lib, cross_resolved_target);
+            roc_modules.addAll(cross_dev_shim_lib);
+            cross_dev_shim_lib.root_module.addImport("compiled_builtins", compiled_builtins_module);
+            cross_dev_shim_lib.step.dependOn(&write_compiled_builtins.step);
+            cross_dev_shim_lib.addObjectFile(cross_builtins_obj.getEmittedBin());
+            cross_dev_shim_lib.bundle_compiler_rt = true;
+
+            const dev_shim_ext = if (cross_target.query.os_tag == .windows) "roc_dev_shim.lib" else "libroc_dev_shim.a";
+            const copy_cross_dev_shim = b.addUpdateSourceFiles();
+            copy_cross_dev_shim.addCopyFileToSource(
+                cross_dev_shim_lib.getEmittedBin(),
+                b.pathJoin(&.{ "src/cli/targets", cross_target.name, dev_shim_ext }),
+            );
+            exe.step.dependOn(&copy_cross_dev_shim.step);
+
+            add_tracy(b, roc_modules.build_options, cross_dev_shim_lib, b.graph.host, false, flag_enable_tracy);
+        }
     }
 
     const config = b.addOptions();

--- a/src/backend/dev/ExecutableMemory.zig
+++ b/src/backend/dev/ExecutableMemory.zig
@@ -99,6 +99,13 @@ pub const ExecutableMemory = struct {
         const func: *const fn (*anyopaque, *anyopaque) callconv(.c) void = @ptrCast(@alignCast(self.entryPtr()));
         func(result_ptr, roc_ops);
     }
+
+    /// Call using the RocCall ABI: fn(roc_ops, ret_ptr, args_ptr) callconv(.c) void
+    pub fn callRocABI(self: *const Self, roc_ops: *anyopaque, ret_ptr: *anyopaque, args_ptr: ?*anyopaque) void {
+        const func: *const fn (*anyopaque, *anyopaque, ?*anyopaque) callconv(.c) void =
+            @ptrCast(@alignCast(self.entryPtr()));
+        func(roc_ops, ret_ptr, args_ptr);
+    }
 };
 
 /// Allocate memory that can be made executable

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -143,6 +143,53 @@ const ShimLibraries = struct {
     }
 };
 
+/// Embedded dev shim libraries for different targets.
+/// The dev shim JIT-compiles CIR to native code using DevEvaluator
+/// instead of interpreting. Only supports x86_64/aarch64 (no wasm32).
+const DevShimLibraries = struct {
+    /// Native shim (for host platform builds and roc run)
+    const native = if (builtin.is_test)
+        &[_]u8{}
+    else if (builtin.target.os.tag == .windows)
+        @embedFile("roc_dev_shim.lib")
+    else
+        @embedFile("libroc_dev_shim.a");
+
+    /// Cross-compilation target shims (Linux musl targets)
+    const x64musl = if (builtin.is_test) &[_]u8{} else @embedFile("targets/x64musl/libroc_dev_shim.a");
+    const arm64musl = if (builtin.is_test) &[_]u8{} else @embedFile("targets/arm64musl/libroc_dev_shim.a");
+
+    /// Cross-compilation target shims (Linux glibc targets)
+    const x64glibc = if (builtin.is_test) &[_]u8{} else @embedFile("targets/x64glibc/libroc_dev_shim.a");
+    const arm64glibc = if (builtin.is_test) &[_]u8{} else @embedFile("targets/arm64glibc/libroc_dev_shim.a");
+
+    /// Cross-compilation target shims (Windows targets)
+    const x64win = if (builtin.is_test) &[_]u8{} else @embedFile("targets/x64win/roc_dev_shim.lib");
+    const arm64win = if (builtin.is_test) &[_]u8{} else @embedFile("targets/arm64win/roc_dev_shim.lib");
+
+    /// Cross-compilation target shims (macOS targets)
+    const x64mac = if (builtin.is_test) &[_]u8{} else @embedFile("targets/x64mac/libroc_dev_shim.a");
+    const arm64mac = if (builtin.is_test) &[_]u8{} else @embedFile("targets/arm64mac/libroc_dev_shim.a");
+
+    /// Get the appropriate dev shim library bytes for the given target
+    pub fn forTarget(t: roc_target.RocTarget) []const u8 {
+        return switch (t) {
+            .x64musl => x64musl,
+            .arm64musl => arm64musl,
+            .x64glibc => x64glibc,
+            .arm64glibc => arm64glibc,
+            .x64win => x64win,
+            .arm64win => arm64win,
+            .x64mac => x64mac,
+            .arm64mac => arm64mac,
+            // wasm32 not supported by dev backend
+            .wasm32 => native,
+            // Fallback for other targets
+            else => native,
+        };
+    }
+};
+
 /// Embedded pre-compiled builtins object files for each target.
 /// These contain the wrapper functions needed by the dev backend for string/list operations.
 /// Used by `roc build --backend=dev` to link the app object with builtins.
@@ -905,7 +952,7 @@ fn rocRun(ctx: *CliContext, args: cli_args.RunArgs) !void {
     defer trace.end();
 
     switch (args.backend) {
-        .dev => return rocRunDev(ctx, args),
+        .dev => return rocRunDevShim(ctx, args),
         .interpreter => {},
     }
 
@@ -1277,188 +1324,365 @@ fn rocRun(ctx: *CliContext, args: cli_args.RunArgs) !void {
     }
 }
 
-/// Run using the dev backend: build to a temp directory, then execute the result.
-fn rocRunDev(ctx: *CliContext, args: cli_args.RunArgs) !void {
-    // Build to a temp path
+/// Run using the dev shim: pre-link a shim with the host once, then pass CIR via
+/// shared memory for JIT compilation. Skips LLD linking on subsequent runs.
+fn rocRunDevShim(ctx: *CliContext, args: cli_args.RunArgs) !void {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
+    // Initialize cache
+    const cache_config = CacheConfig{
+        .enabled = !args.no_cache,
+        .verbose = false,
+    };
+    var cache_manager = CacheManager.init(ctx.gpa, cache_config, Filesystem.default());
+
+    const exe_cache_dir = cache_manager.config.getExeCacheDir(ctx.arena) catch |err| {
+        return ctx.fail(.{ .cache_dir_unavailable = .{ .reason = @errorName(err) } });
+    };
+
+    std.fs.cwd().makePath(exe_cache_dir) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => {
+            return ctx.fail(.{ .directory_create_failed = .{ .path = exe_cache_dir, .err = err } });
+        },
+    };
+
+    const exe_display_name = std.fs.path.basename(args.path);
+
+    const exe_display_name_with_ext = if (builtin.target.os.tag == .windows)
+        std.fmt.allocPrint(ctx.arena, "{s}.exe", .{exe_display_name}) catch |err| {
+            return ctx.fail(.{ .cache_dir_unavailable = .{ .reason = @errorName(err) } });
+        }
+    else
+        ctx.arena.dupe(u8, exe_display_name) catch |err| {
+            return ctx.fail(.{ .cache_dir_unavailable = .{ .reason = @errorName(err) } });
+        };
+
+    // Parse the app file to get the platform reference (needed for cache key)
+    const platform_spec = try extractPlatformSpecFromApp(ctx, args.path);
+
+    const app_dir = std.fs.path.dirname(args.path) orelse ".";
+    const platform_paths = try resolvePlatformSpecToPaths(ctx, platform_spec, app_dir);
+
     const temp_dir_path = createUniqueTempDir(ctx) catch |err| {
         return ctx.fail(.{ .temp_dir_failed = .{ .err = err } });
     };
-    // Clean up the temp directory on any error return. Success paths and std.process.exit
-    // paths handle cleanup explicitly before exiting.
-    errdefer compile.CacheCleanup.deleteTempDir(ctx.arena, temp_dir_path);
 
-    const exe_name = std.fs.path.stem(std.fs.path.basename(args.path));
-    const output_path = std.fs.path.join(ctx.arena, &.{ temp_dir_path, exe_name }) catch {
+    const exe_path = std.fs.path.join(ctx.arena, &.{ temp_dir_path, exe_display_name_with_ext }) catch |err| {
+        return ctx.fail(.{ .cache_dir_unavailable = .{ .reason = @errorName(err) } });
+    };
+
+    // Validate platform header and get link spec
+    var link_spec: ?roc_target.TargetLinkSpec = null;
+    var targets_config: ?roc_target.TargetsConfig = null;
+    if (platform_paths.platform_source_path) |platform_source| {
+        if (platform_validation.validatePlatformHeader(ctx.arena, platform_source)) |validation| {
+            targets_config = validation.config;
+
+            if (validation.config.exe.len == 0 and validation.config.static_lib.len > 0) {
+                ctx.io.stderr().print("Error: This platform only produces static libraries.\n\n", .{}) catch {};
+                ctx.io.stderr().print("Use 'roc build' instead to produce the library artifact.\n", .{}) catch {};
+                return error.UnsupportedTarget;
+            }
+
+            if (args.target) |target_str| {
+                const parsed_target = roc_target.RocTarget.fromString(target_str) orelse {
+                    const result = platform_validation.targets_validator.ValidationResult{
+                        .invalid_target = .{ .target_str = target_str },
+                    };
+                    _ = platform_validation.renderValidationError(ctx.gpa, result, ctx.io.stderr());
+                    return error.InvalidTarget;
+                };
+
+                if (validation.config.getLinkSpec(parsed_target, .exe)) |spec| {
+                    link_spec = spec;
+                } else {
+                    const result = platform_validation.createUnsupportedTargetResult(
+                        platform_source,
+                        parsed_target,
+                        .exe,
+                        validation.config,
+                    );
+                    _ = platform_validation.renderValidationError(ctx.gpa, result, ctx.io.stderr());
+                    return error.UnsupportedTarget;
+                }
+            } else {
+                if (validation.config.getDefaultTarget(.exe)) |compatible_target| {
+                    link_spec = validation.config.getLinkSpec(compatible_target, .exe);
+                } else {
+                    const native_target = builder.RocTarget.detectNative();
+                    const result = platform_validation.createUnsupportedTargetResult(
+                        platform_source,
+                        native_target,
+                        .exe,
+                        validation.config,
+                    );
+                    _ = platform_validation.renderValidationError(ctx.gpa, result, ctx.io.stderr());
+                    return error.UnsupportedTarget;
+                }
+            }
+        } else |err| {
+            switch (err) {
+                error.MissingTargetsSection => {
+                    ctx.io.stderr().print("Error: Platform is missing a targets section.\n\n", .{}) catch {};
+                    return error.PlatformNotSupported;
+                },
+                else => {
+                    std.log.debug("Could not validate platform header: {}", .{err});
+                },
+            }
+        }
+    }
+
+    const validated_link_spec = link_spec orelse {
+        ctx.io.stderr().print("Error: Platform does not support any target compatible with this system.\n", .{}) catch {};
+        return error.PlatformNotSupported;
+    };
+
+    // Extract entrypoints from platform source file
+    var entrypoints = std.array_list.Managed([]const u8).initCapacity(ctx.arena, 32) catch {
         return error.OutOfMemory;
     };
 
-    var warning_count: usize = 0;
-    const build_args = cli_args.BuildArgs{
-        .path = args.path,
-        .opt = args.opt,
-        .backend = .dev,
-        .target = args.target,
-        .output = output_path,
-        .no_cache = args.no_cache,
-        .allow_errors = args.allow_errors,
-        .exit_on_warnings = false,
-        .warning_count_out = &warning_count,
-        .require_executable_output = true,
-        .suppress_build_status = true,
+    if (platform_paths.platform_source_path) |platform_source| {
+        extractEntrypointsFromPlatform(ctx, platform_source, &entrypoints) catch |err| {
+            return ctx.fail(.{ .entrypoint_extraction_failed = .{
+                .path = platform_source,
+                .reason = @errorName(err),
+            } });
+        };
+    } else {
+        return ctx.fail(.{ .entrypoint_extraction_failed = .{
+            .path = platform_paths.platform_source_path orelse "<unknown>",
+            .reason = "No platform source file found for entrypoint extraction",
+        } });
+    }
+
+    // Build the cache key from all inputs that affect the linked executable:
+    // app path, target, platform source mtime, and mtimes of all linked host files.
+    const platform_dir = if (platform_paths.platform_source_path) |p|
+        std.fs.path.dirname(p) orelse "."
+    else
+        ".";
+    const files_dir = if (targets_config) |cfg| cfg.files_dir orelse "targets" else "targets";
+    const target_name = @tagName(validated_link_spec.target);
+
+    var cache_hasher = std.hash.crc.Crc32.init();
+    cache_hasher.update(args.path);
+    cache_hasher.update(target_name);
+
+    // Hash platform source mtime (captures entrypoint and targets section changes)
+    if (platform_paths.platform_source_path) |p| {
+        cache_hasher.update(p);
+        if (std.fs.cwd().statFile(p)) |stat| {
+            const mtime_bytes: [@sizeOf(i128)]u8 = @bitCast(stat.mtime);
+            cache_hasher.update(&mtime_bytes);
+        } else |_| {}
+    }
+
+    // Hash mtimes of all platform host files from the link spec
+    for (validated_link_spec.items) |item| {
+        switch (item) {
+            .file_path => |file_name| {
+                const host_file_path = std.fs.path.join(ctx.arena, &.{
+                    platform_dir, files_dir, target_name, file_name,
+                }) catch continue;
+                cache_hasher.update(host_file_path);
+                if (std.fs.cwd().statFile(host_file_path)) |stat| {
+                    const mtime_bytes: [@sizeOf(i128)]u8 = @bitCast(stat.mtime);
+                    cache_hasher.update(&mtime_bytes);
+                } else |_| {}
+            },
+            .app, .win_gui => {},
+        }
+    }
+
+    const exe_cache_name = std.fmt.allocPrint(ctx.arena, "roc_dev_{x}", .{cache_hasher.final()}) catch |err| {
+        return ctx.fail(.{ .cache_dir_unavailable = .{ .reason = @errorName(err) } });
     };
 
-    try rocBuildNative(ctx, build_args);
+    const exe_cache_name_with_ext = if (builtin.target.os.tag == .windows)
+        std.fmt.allocPrint(ctx.arena, "{s}.exe", .{exe_cache_name}) catch |err| {
+            return ctx.fail(.{ .cache_dir_unavailable = .{ .reason = @errorName(err) } });
+        }
+    else
+        ctx.arena.dupe(u8, exe_cache_name) catch |err| {
+            return ctx.fail(.{ .cache_dir_unavailable = .{ .reason = @errorName(err) } });
+        };
 
-    // Flush I/O buffers before spawning the child process so the "Built..." message
-    // appears before the app's output and doesn't interfere with the child's stdout.
-    ctx.io.flush();
+    const exe_cache_path = std.fs.path.join(ctx.arena, &.{ exe_cache_dir, exe_cache_name_with_ext }) catch |err| {
+        return ctx.fail(.{ .cache_dir_unavailable = .{ .reason = @errorName(err) } });
+    };
 
-    if (is_windows) {
-        // On Windows, use CreateProcessW directly to preserve the full DWORD exit code.
-        // std.process.Child.wait() truncates GetExitCodeProcess() into .Exited(u8),
-        // which loses NTSTATUS crash codes like 0xC0000005 (access violation).
-        try runDevChildWindows(ctx, output_path, args.app_args, warning_count, temp_dir_path);
+    // Check if the dev shim executable already exists in cache
+    const cache_exists = if (args.no_cache) false else blk: {
+        std.fs.accessAbsolute(exe_cache_path, .{}) catch {
+            break :blk false;
+        };
+        break :blk true;
+    };
+
+    if (cache_exists) {
+        std.log.debug("Using cached dev shim executable: {s}", .{exe_cache_path});
+        createHardlink(ctx, exe_cache_path, exe_path) catch |err| {
+            std.log.debug("Hardlink from cache failed, copying: {}", .{err});
+            std.fs.cwd().copyFile(exe_cache_path, std.fs.cwd(), exe_path, .{}) catch |copy_err| {
+                return ctx.fail(.{ .file_write_failed = .{
+                    .path = exe_path,
+                    .err = copy_err,
+                } });
+            };
+        };
     } else {
-        // Run the built executable
-        var child_args = std.array_list.Managed([]const u8).initCapacity(ctx.arena, 1 + args.app_args.len) catch {
+        // Extract dev shim library to temp dir
+        const shim_filename = if (builtin.target.os.tag == .windows) "roc_dev_shim.lib" else "libroc_dev_shim.a";
+        const shim_path = std.fs.path.join(ctx.arena, &.{ temp_dir_path, shim_filename }) catch {
             return error.OutOfMemory;
         };
-        child_args.append(output_path) catch return error.OutOfMemory;
-        for (args.app_args) |app_arg| {
-            child_args.append(app_arg) catch return error.OutOfMemory;
+
+        const selected_target = validated_link_spec.target;
+        extractDevShimLibrary(shim_path, selected_target) catch |err| {
+            return ctx.fail(.{ .shim_generation_failed = .{ .err = err } });
+        };
+
+        // Generate platform host shim
+        const platform_shim_path = try generatePlatformHostShim(ctx, temp_dir_path, entrypoints.items, selected_target, null, builtin.mode == .Debug);
+
+        // Link the host with our dev shim
+        var extra_args = std.array_list.Managed([]const u8).initCapacity(ctx.arena, 32) catch {
+            return error.OutOfMemory;
+        };
+
+        if (builtin.target.os.tag == .macos) {
+            extra_args.append("-lSystem") catch {
+                return error.OutOfMemory;
+            };
         }
 
-        var child = std.process.Child.init(child_args.items, ctx.arena);
-        child.stdin_behavior = .Inherit;
-        child.stdout_behavior = .Inherit;
-        child.stderr_behavior = .Inherit;
-        const term = child.spawnAndWait() catch |err| {
-            return ctx.fail(.{ .child_process_spawn_failed = .{
-                .command = output_path,
+        var object_files = std.array_list.Managed([]const u8).initCapacity(ctx.arena, 16) catch {
+            return error.OutOfMemory;
+        };
+
+        for (validated_link_spec.items) |item| {
+            switch (item) {
+                .file_path => |file_name| {
+                    const full_path = std.fs.path.join(ctx.arena, &.{
+                        platform_dir, files_dir, target_name, file_name,
+                    }) catch {
+                        return error.OutOfMemory;
+                    };
+                    object_files.append(full_path) catch {
+                        return error.OutOfMemory;
+                    };
+                },
+                .app => {
+                    object_files.append(shim_path) catch {
+                        return error.OutOfMemory;
+                    };
+                    if (platform_shim_path) |path| {
+                        object_files.append(path) catch {
+                            return error.OutOfMemory;
+                        };
+                    }
+                },
+                .win_gui => {},
+            }
+        }
+
+        const target_abi: linker.TargetAbi = if (validated_link_spec.target.isStatic()) .musl else .gnu;
+
+        const empty_files: []const []const u8 = &.{};
+
+        const platform_files_dir = std.fs.path.join(ctx.arena, &.{ platform_dir, files_dir }) catch {
+            return error.OutOfMemory;
+        };
+
+        const link_config = linker.LinkConfig{
+            .target_abi = target_abi,
+            .output_path = exe_path,
+            .object_files = object_files.items,
+            .platform_files_pre = empty_files,
+            .platform_files_post = empty_files,
+            .extra_args = extra_args.items,
+            .can_exit_early = false,
+            .disable_output = false,
+            .platform_files_dir = platform_files_dir,
+        };
+
+        linker.link(ctx, link_config) catch |err| {
+            return ctx.fail(.{ .linker_failed = .{
                 .err = err,
+                .target = @tagName(validated_link_spec.target),
             } });
         };
 
-        // Clean up the temp directory now that the child has exited.
-        compile.CacheCleanup.deleteTempDir(ctx.arena, temp_dir_path);
+        // Cache the linked executable
+        std.log.debug("Caching dev shim executable to: {s}", .{exe_cache_path});
+        std.fs.cwd().deleteFile(exe_cache_path) catch |err| switch (err) {
+            error.FileNotFound => {},
+            else => std.log.debug("Could not delete existing cache file: {}", .{err}),
+        };
+        createHardlink(ctx, exe_path, exe_cache_path) catch |err| {
+            std.log.debug("Hardlink to cache failed, copying: {}", .{err});
+            std.fs.cwd().copyFile(exe_path, std.fs.cwd(), exe_cache_path, .{}) catch |copy_err| {
+                std.log.debug("Failed to copy to cache: {}", .{copy_err});
+            };
+        };
+    }
 
-        try handleNativeRunTermination(ctx, output_path, term, warning_count);
+    // Set up shared memory with ModuleEnv using the Coordinator
+    const shm_result = try setupSharedMemoryWithCoordinator(ctx, args.path, args.allow_errors);
+
+    if (shm_result.error_count > 0 and !args.allow_errors) {
+        return error.TypeCheckingFailed;
+    }
+
+    const shm_handle = shm_result.handle;
+
+    defer {
+        if (comptime is_windows) {
+            _ = ipc.platform.windows.UnmapViewOfFile(shm_handle.ptr);
+            _ = ipc.platform.windows.CloseHandle(@ptrCast(shm_handle.fd));
+        } else {
+            _ = posix.munmap(shm_handle.ptr, shm_handle.mapped_size);
+            _ = c.close(shm_handle.fd);
+        }
+    }
+
+    std.log.debug("Launching dev shim executable: {s}", .{exe_path});
+    if (comptime is_windows) {
+        std.log.debug("Using Windows handle inheritance approach", .{});
+        try runWithWindowsHandleInheritance(ctx, exe_path, shm_handle, args.app_args);
+    } else {
+        std.log.debug("Using POSIX file descriptor inheritance approach", .{});
+        try runWithPosixFdInheritance(ctx, exe_path, shm_handle, args.app_args);
+    }
+    std.log.debug("Dev shim execution completed", .{});
+
+    if (shm_result.warning_count > 0) {
+        ctx.io.flush();
+        std.process.exit(2);
     }
 }
 
-/// Windows-specific child process execution that preserves full DWORD exit codes.
-/// This mirrors the interpreter's runWithWindowsHandleInheritance but without IPC setup.
-fn runDevChildWindows(ctx: *CliContext, exe_path: []const u8, app_args: []const []const u8, warning_count: usize, temp_dir_path: []const u8) !void {
-    // Convert exe path to wide string
-    const exe_path_w = std.unicode.utf8ToUtf16LeAllocZ(ctx.arena, exe_path) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        error.InvalidUtf8 => return ctx.fail(.{ .child_process_spawn_failed = .{
-            .command = exe_path,
-            .err = err,
-        } }),
-    };
-
-    const cwd = std.fs.cwd().realpathAlloc(ctx.arena, ".") catch {
-        return ctx.fail(.{ .directory_not_found = .{
-            .path = ".",
-        } });
-    };
-    const cwd_w = std.unicode.utf8ToUtf16LeAllocZ(ctx.arena, cwd) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        error.InvalidUtf8 => return ctx.fail(.{ .directory_not_found = .{
-            .path = cwd,
-        } }),
-    };
-
-    // Build command line with proper quoting
-    var cmd_builder = std.array_list.Managed(u8).initCapacity(ctx.gpa, 256) catch {
-        return error.OutOfMemory;
-    };
-    defer cmd_builder.deinit();
-    try appendWindowsQuotedArg(&cmd_builder, exe_path);
-    for (app_args) |arg| {
-        try cmd_builder.append(' ');
-        try appendWindowsQuotedArg(&cmd_builder, arg);
-    }
-    try cmd_builder.append(0);
-
-    const cmd_line = cmd_builder.items[0 .. cmd_builder.items.len - 1 :0];
-    const cmd_line_w = std.unicode.utf8ToUtf16LeAllocZ(ctx.arena, cmd_line) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        error.InvalidUtf8 => return ctx.fail(.{ .child_process_spawn_failed = .{
-            .command = exe_path,
-            .err = err,
-        } }),
-    };
-
-    var startup_info = std.mem.zeroes(windows.STARTUPINFOW);
-    startup_info.cb = @sizeOf(windows.STARTUPINFOW);
-    var process_info = std.mem.zeroes(windows.PROCESS_INFORMATION);
-
-    const success = windows.CreateProcessW(
-        exe_path_w.ptr,
-        cmd_line_w.ptr,
-        null,
-        null,
-        1, // bInheritHandles = TRUE (inherit parent's stdio for redirection/pipes)
-        0,
-        null,
-        cwd_w.ptr,
-        &startup_info,
-        &process_info,
-    );
-
-    if (success == 0) {
-        return ctx.fail(.{ .child_process_spawn_failed = .{
-            .command = exe_path,
-            .err = error.ProcessCreationFailed,
-        } });
+/// Extract the dev shim library to the given output path.
+fn extractDevShimLibrary(output_path: []const u8, target: ?roc_target.RocTarget) !void {
+    if (builtin.is_test) {
+        const shim_file = try std.fs.cwd().createFile(output_path, .{});
+        defer shim_file.close();
+        return;
     }
 
-    // Wait for child to complete
-    const wait_result = windows.WaitForSingleObject(process_info.hProcess, windows.INFINITE);
-    if (wait_result != 0) {
-        _ = ipc.platform.windows.CloseHandle(process_info.hProcess);
-        _ = ipc.platform.windows.CloseHandle(process_info.hThread);
-        return ctx.fail(.{ .child_process_wait_failed = .{
-            .command = exe_path,
-            .err = error.ProcessWaitFailed,
-        } });
-    }
+    const shim_data = if (target) |t|
+        DevShimLibraries.forTarget(t)
+    else
+        DevShimLibraries.native;
 
-    // Get the full exit code (not truncated to u8)
-    var exit_code: windows.DWORD = undefined;
-    if (windows.GetExitCodeProcess(process_info.hProcess, &exit_code) == 0) {
-        _ = ipc.platform.windows.CloseHandle(process_info.hProcess);
-        _ = ipc.platform.windows.CloseHandle(process_info.hThread);
-        return ctx.fail(.{ .child_process_wait_failed = .{
-            .command = exe_path,
-            .err = error.ProcessExitCodeFailed,
-        } });
-    }
+    const shim_file = try std.fs.cwd().createFile(output_path, .{});
+    defer shim_file.close();
 
-    _ = ipc.platform.windows.CloseHandle(process_info.hProcess);
-    _ = ipc.platform.windows.CloseHandle(process_info.hThread);
-
-    // Clean up the temp directory now that the child has exited.
-    compile.CacheCleanup.deleteTempDir(ctx.arena, temp_dir_path);
-
-    if (exit_code != 0) {
-        if (exit_code == 0xC0000005) {
-            const result = platform_validation.targets_validator.ValidationResult{
-                .process_crashed = .{ .exit_code = exit_code, .is_access_violation = true },
-            };
-            _ = platform_validation.renderValidationError(ctx.gpa, result, ctx.io.stderr());
-        } else if (exit_code >= 0xC0000000) {
-            const result = platform_validation.targets_validator.ValidationResult{
-                .process_crashed = .{ .exit_code = exit_code, .is_access_violation = false },
-            };
-            _ = platform_validation.renderValidationError(ctx.gpa, result, ctx.io.stderr());
-        }
-        std.process.exit(@truncate(exit_code));
-    } else if (warning_count > 0) {
-        std.process.exit(2);
-    }
+    try shim_file.writeAll(shim_data);
 }
 
 const NativeRunTermination = union(enum) {
@@ -5416,6 +5640,7 @@ fn rocTest(ctx: *CliContext, args: cli_args.TestArgs) !void {
                             @constCast(mod_env),
                             stmt.s_expect.body,
                             envs,
+                            null,
                         ) catch {
                             failed += 1;
                             results_list.append(.{

--- a/src/dev_shim/main.zig
+++ b/src/dev_shim/main.zig
@@ -1,0 +1,757 @@
+//! A shim to read the ModuleEnv from shared memory and JIT-compile
+//! Roc code using the dev backend (CIR → MIR → LIR → native machine code).
+//!
+//! Adapted from the interpreter shim. Instead of interpreting CIR directly,
+//! this shim compiles to native code via DevEvaluator and executes via
+//! ExecutableMemory (mmap/mprotect).
+//!
+//! No wasm32 support — the dev backend targets x86_64/aarch64 only.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const build_options = @import("build_options");
+const builtins = @import("builtins");
+const base = @import("base");
+const can = @import("can");
+const types = @import("types");
+const collections = @import("collections");
+const import_mapping_mod = types.import_mapping;
+const eval = @import("eval");
+const layout = @import("layout");
+const tracy = @import("tracy");
+const roc_target = @import("roc_target");
+const backend = @import("backend");
+
+// Module tracing flag - enabled via `zig build -Dtrace-modules`
+const trace_modules = if (@hasDecl(build_options, "trace_modules")) build_options.trace_modules else false;
+
+fn traceDbg(comptime fmt: []const u8, args: anytype) void {
+    if (comptime trace_modules) {
+        std.debug.print("[TRACE-MODULES] " ++ fmt ++ "\n", args);
+    }
+}
+
+const ipc = @import("ipc");
+
+// Debug allocator for native platforms - provides leak detection in Debug/ReleaseSafe builds
+var debug_allocator: std.heap.DebugAllocator(.{}) = .{ .backing_allocator = std.heap.c_allocator };
+
+fn getBaseAllocator() std.mem.Allocator {
+    return switch (builtin.mode) {
+        .Debug, .ReleaseSafe => debug_allocator.allocator(),
+        .ReleaseFast, .ReleaseSmall => std.heap.c_allocator,
+    };
+}
+
+// TracyAllocator wrapping for allocation profiling
+var tracy_allocator: tracy.TracyAllocator(null) = undefined;
+var wrapped_allocator: std.mem.Allocator = undefined;
+var allocator_initialized: bool = false;
+
+// Static empty import mapping for shim (no type name resolution needed)
+var shim_import_mapping: ?import_mapping_mod.ImportMapping = null;
+
+fn getShimImportMapping() *import_mapping_mod.ImportMapping {
+    if (shim_import_mapping == null) {
+        shim_import_mapping = import_mapping_mod.ImportMapping.init(wrapped_allocator);
+    }
+    return &shim_import_mapping.?;
+}
+
+const SharedMemoryAllocator = ipc.SharedMemoryAllocator;
+
+/// Thread-safe initialization flag with atomic ordering.
+const InitializationFlag = struct {
+    inner: std.atomic.Value(bool),
+
+    const Self = @This();
+
+    pub fn init() Self {
+        return .{ .inner = std.atomic.Value(bool).init(false) };
+    }
+
+    pub fn isSet(self: *const Self) bool {
+        return self.inner.load(.acquire);
+    }
+
+    pub fn set(self: *Self) void {
+        self.inner.store(true, .release);
+    }
+};
+
+/// Mutex for thread-safe initialization.
+const PlatformMutex = struct {
+    inner: std.Thread.Mutex,
+
+    const Self = @This();
+
+    pub fn init() Self {
+        return .{ .inner = .{} };
+    }
+
+    pub fn lock(self: *Self) void {
+        self.inner.lock();
+    }
+
+    pub fn unlock(self: *Self) void {
+        self.inner.unlock();
+    }
+};
+
+// Global base pointer for the serialized header + env.
+// Is a weak extern that can be overwritten by `roc build` when embedding module data.
+// If null at runtime, we're in IPC mode (roc run) and read from shared memory.
+// If non-null, we're in embedded mode (roc build) and data is compiled into the binary.
+extern var roc__serialized_base_ptr: ?[*]align(1) u8;
+extern var roc__serialized_size: usize;
+
+// Global state for shared memory - initialized once per process
+var shared_memory_initialized = InitializationFlag.init();
+var global_shm: ?SharedMemoryAllocator = null;
+var global_env_ptr: ?*ModuleEnv = null; // Primary env for entry point lookups (platform or app)
+var global_app_env_ptr: ?*ModuleEnv = null; // App env for e_lookup_required resolution
+var global_builtin_modules: ?eval.BuiltinModules = null;
+var global_imported_envs: ?[]*const ModuleEnv = null;
+var global_full_imported_envs: ?[]*const ModuleEnv = null; // Full slice with builtin prepended (for import resolution)
+var global_full_mutable_envs: ?[]*ModuleEnv = null; // All module envs used for MIR lowering/codegen
+var global_dev_evaluator: ?eval.DevEvaluator = null; // Dev evaluator instance
+var shm_mutex = PlatformMutex.init();
+
+// Cached header info (set during initialization, used for evaluation)
+var global_entry_count: u32 = 0;
+var global_def_indices_offset: u64 = 0;
+var global_is_serialized_format: bool = false;
+const CIR = can.CIR;
+const ModuleEnv = can.ModuleEnv;
+const RocOps = builtins.host_abi.RocOps;
+const safe_memory = base.safe_memory;
+
+// Constants for shared memory layout
+const FIRST_ALLOC_OFFSET = 504; // 0x1f8 - First allocation starts at this offset
+
+// Header structure that matches the one in main.zig (multi-module format)
+const Header = struct {
+    parent_base_addr: u64,
+    module_count: u32,
+    entry_count: u32,
+    def_indices_offset: u64,
+    module_envs_offset: u64,
+    platform_main_env_offset: u64,
+    app_env_offset: u64,
+};
+
+fn appendModuleEnvIfMissing(
+    allocator: std.mem.Allocator,
+    module_envs: *std.ArrayList(*ModuleEnv),
+    module_env: *ModuleEnv,
+) std.mem.Allocator.Error!void {
+    for (module_envs.items) |existing_env| {
+        if (existing_env == module_env) return;
+    }
+
+    try module_envs.append(allocator, module_env);
+}
+
+const SERIALIZED_FORMAT_MAGIC = collections.SERIALIZED_FORMAT_MAGIC;
+
+/// Comprehensive error handling for the shim
+const ShimError = error{
+    SharedMemoryError,
+    DevEvaluatorSetupFailed,
+    EvaluationFailed,
+    MemoryLayoutInvalid,
+    ModuleEnvSetupFailed,
+    UnexpectedClosureStructure,
+    StackOverflow,
+    OutOfMemory,
+    ZeroSizedType,
+    TypeContainedMismatch,
+    InvalidRecordExtension,
+    BugUnboxedFlexVar,
+    BugUnboxedRigidVar,
+    UnsupportedResultType,
+    InvalidEntryIndex,
+    CodeGenFailed,
+    ExecutionFailed,
+    Crash,
+} || safe_memory.MemoryError;
+
+/// Exported symbol that reads ModuleEnv from shared memory, compiles to native code, and executes.
+export fn roc_entrypoint(entry_idx: u32, ops: *builtins.host_abi.RocOps, ret_ptr: *anyopaque, arg_ptr: ?*anyopaque) callconv(.c) void {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
+    evaluateFromSharedMemory(entry_idx, ops, ret_ptr, arg_ptr) catch |err| switch (err) {
+        error.Crash, error.StackOverflow => {},
+        else => {
+            var buf: [256]u8 = undefined;
+            const msg2 = std.fmt.bufPrint(&buf, "Dev shim error: {s}", .{@errorName(err)}) catch "Dev shim evaluation error";
+            ops.crash(msg2);
+        },
+    };
+}
+
+/// Initialize shared memory and ModuleEnv once per process
+fn initializeOnce(roc_ops: *RocOps) ShimError!void {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
+    // Fast path: if already initialized, return immediately
+    if (shared_memory_initialized.isSet()) return;
+
+    // Slow path: acquire mutex and check again (double-checked locking)
+    shm_mutex.lock();
+    defer shm_mutex.unlock();
+
+    // Check again in case another thread initialized while we were waiting
+    if (shared_memory_initialized.isSet()) return;
+
+    // Set up allocator with optional TracyAllocator wrapping before any allocations
+    if (!allocator_initialized) {
+        const base_allocator = getBaseAllocator();
+        if (tracy.enable_allocation) {
+            tracy_allocator = tracy.tracyAllocator(base_allocator);
+            wrapped_allocator = tracy_allocator.allocator();
+        } else {
+            wrapped_allocator = base_allocator;
+        }
+        allocator_initialized = true;
+    }
+
+    const allocator = wrapped_allocator;
+    var buf: [256]u8 = undefined;
+
+    // IPC path: read from shared memory
+    if (roc__serialized_base_ptr == null) {
+        const page_size = SharedMemoryAllocator.getSystemPageSize() catch 4096;
+
+        var shm = SharedMemoryAllocator.fromCoordination(allocator, page_size) catch |err| {
+            const msg2 = std.fmt.bufPrint(&buf, "Failed to create shared memory allocator: {s}", .{@errorName(err)}) catch "Failed to create shared memory allocator";
+            roc_ops.crash(msg2);
+            return error.SharedMemoryError;
+        };
+
+        const min_required_size = FIRST_ALLOC_OFFSET + @sizeOf(Header);
+        if (shm.total_size < min_required_size) {
+            const msg = std.fmt.bufPrint(&buf, "Invalid memory layout: size {} is too small (minimum required: {})", .{ shm.total_size, min_required_size }) catch "Invalid memory layout";
+            roc_ops.crash(msg);
+            return error.MemoryLayoutInvalid;
+        }
+
+        roc__serialized_base_ptr = shm.getBasePtr();
+        roc__serialized_size = shm.total_size;
+    }
+
+    // Set up ModuleEnv from serialized data (embedded or shared memory)
+    const setup_result = try setupModuleEnv(roc_ops);
+
+    // Load builtin modules from compiled binary
+    const builtin_modules = eval.BuiltinModules.init(allocator) catch |err| {
+        const msg2 = std.fmt.bufPrint(&buf, "Failed to load builtin modules: {s}", .{@errorName(err)}) catch "Failed to load builtin modules";
+        roc_ops.crash(msg2);
+        return error.ModuleEnvSetupFailed;
+    };
+
+    // Store globals
+    global_env_ptr = setup_result.primary_env;
+    global_app_env_ptr = setup_result.app_env;
+    global_builtin_modules = builtin_modules;
+
+    // Build the full imported_envs slice (builtin + platform modules)
+    const builtin_module_env = builtin_modules.builtin_module.env;
+    var all_imported_envs = std.ArrayList(*const can.ModuleEnv).empty;
+
+    all_imported_envs.append(allocator, builtin_module_env) catch {
+        roc_ops.crash("Failed to build imported envs list");
+        return error.OutOfMemory;
+    };
+
+    if (global_imported_envs) |platform_envs| {
+        for (platform_envs) |penv| {
+            all_imported_envs.append(allocator, penv) catch {
+                roc_ops.crash("Failed to build imported envs list");
+                return error.OutOfMemory;
+            };
+        }
+    }
+
+    const full_imported_envs = all_imported_envs.toOwnedSlice(allocator) catch {
+        roc_ops.crash("Failed to get owned slice");
+        return error.OutOfMemory;
+    };
+    global_full_imported_envs = full_imported_envs;
+
+    // Build the codegen slice in import-resolution order, then append the
+    // primary and app envs if they are not already present.
+    var all_codegen_envs = std.ArrayList(*ModuleEnv).empty;
+    defer all_codegen_envs.deinit(allocator);
+
+    for (full_imported_envs) |env| {
+        all_codegen_envs.append(allocator, @constCast(env)) catch {
+            roc_ops.crash("Failed to build codegen envs list");
+            return error.OutOfMemory;
+        };
+    }
+
+    appendModuleEnvIfMissing(allocator, &all_codegen_envs, setup_result.primary_env) catch {
+        roc_ops.crash("Failed to add primary env to codegen envs");
+        return error.OutOfMemory;
+    };
+    appendModuleEnvIfMissing(allocator, &all_codegen_envs, setup_result.app_env) catch {
+        roc_ops.crash("Failed to add app env to codegen envs");
+        return error.OutOfMemory;
+    };
+
+    const mutable_envs = all_codegen_envs.toOwnedSlice(allocator) catch {
+        roc_ops.crash("Failed to allocate mutable envs");
+        return error.OutOfMemory;
+    };
+    global_full_mutable_envs = mutable_envs;
+
+    // Resolve imports for all modules
+    const env_ptr = setup_result.primary_env;
+    const app_env = setup_result.app_env;
+
+    traceDbg("Resolving imports for primary env \"{s}\"", .{env_ptr.module_name});
+    env_ptr.imports.resolveImports(env_ptr, full_imported_envs);
+
+    if (app_env != env_ptr) {
+        traceDbg("Resolving imports for app env \"{s}\"", .{app_env.module_name});
+        app_env.imports.resolveImports(app_env, full_imported_envs);
+    }
+
+    traceDbg("Re-resolving imports for all imported modules", .{});
+    for (full_imported_envs) |imp_env| {
+        traceDbg("  Re-resolving for \"{s}\"", .{imp_env.module_name});
+        @constCast(imp_env).imports.resolveImports(imp_env, full_imported_envs);
+    }
+
+    // Enable runtime inserts on all deserialized module environments
+    env_ptr.common.idents.interner.enableRuntimeInserts(allocator) catch {
+        roc_ops.crash("DEV SHIM: Failed to enable runtime inserts on platform env");
+        return error.DevEvaluatorSetupFailed;
+    };
+    if (app_env != env_ptr) {
+        @constCast(app_env).common.idents.interner.enableRuntimeInserts(allocator) catch {
+            roc_ops.crash("DEV SHIM: Failed to enable runtime inserts on app env");
+            return error.DevEvaluatorSetupFailed;
+        };
+    }
+    for (full_imported_envs) |imp_env| {
+        @constCast(imp_env).common.idents.interner.enableRuntimeInserts(allocator) catch {
+            roc_ops.crash("DEV SHIM: Failed to enable runtime inserts on imported env");
+            return error.DevEvaluatorSetupFailed;
+        };
+    }
+
+    // Fix up display_module_name_idx for deserialized modules
+    if (env_ptr.display_module_name_idx.isNone() and env_ptr.module_name.len > 0) {
+        env_ptr.display_module_name_idx = env_ptr.insertIdent(base.Ident.for_text(env_ptr.module_name)) catch {
+            roc_ops.crash("DEV SHIM: Failed to insert module name for platform env");
+            return error.DevEvaluatorSetupFailed;
+        };
+    }
+    if (env_ptr.qualified_module_ident.isNone() and !env_ptr.display_module_name_idx.isNone()) {
+        env_ptr.qualified_module_ident = env_ptr.display_module_name_idx;
+    }
+    if (app_env != env_ptr) {
+        if (app_env.display_module_name_idx.isNone() and app_env.module_name.len > 0) {
+            @constCast(app_env).display_module_name_idx = @constCast(app_env).insertIdent(base.Ident.for_text(app_env.module_name)) catch {
+                roc_ops.crash("DEV SHIM: Failed to insert module name for app env");
+                return error.DevEvaluatorSetupFailed;
+            };
+        }
+        if (app_env.qualified_module_ident.isNone() and !app_env.display_module_name_idx.isNone()) {
+            @constCast(app_env).qualified_module_ident = app_env.display_module_name_idx;
+        }
+    }
+    for (full_imported_envs) |imp_env| {
+        if (imp_env.display_module_name_idx.isNone() and imp_env.module_name.len > 0) {
+            @constCast(imp_env).display_module_name_idx = @constCast(imp_env).insertIdent(base.Ident.for_text(imp_env.module_name)) catch {
+                roc_ops.crash("DEV SHIM: Failed to insert module name for imported env");
+                return error.DevEvaluatorSetupFailed;
+            };
+        }
+        if (imp_env.qualified_module_ident.isNone() and !imp_env.display_module_name_idx.isNone()) {
+            @constCast(imp_env).qualified_module_ident = imp_env.display_module_name_idx;
+        }
+    }
+
+    // Initialize the DevEvaluator once per process
+    global_dev_evaluator = eval.DevEvaluator.init(allocator) catch |err| {
+        const msg2 = std.fmt.bufPrint(&buf, "Failed to initialize DevEvaluator: {s}", .{@errorName(err)}) catch "Failed to initialize DevEvaluator";
+        roc_ops.crash(msg2);
+        return error.DevEvaluatorSetupFailed;
+    };
+
+    // Mark as initialized (release semantics ensure all writes above are visible)
+    shared_memory_initialized.set();
+}
+
+/// Compile CIR to native code and execute it
+fn evaluateFromSharedMemory(entry_idx: u32, host_roc_ops: *RocOps, ret_ptr: *anyopaque, arg_ptr: ?*anyopaque) ShimError!void {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
+    // Initialize shared memory once per process
+    try initializeOnce(host_roc_ops);
+
+    const env_ptr = global_env_ptr.?;
+    const allocator = wrapped_allocator;
+
+    // Get expression info using entry_idx
+    const base_ptr = roc__serialized_base_ptr.?;
+    var buf: [256]u8 = undefined;
+
+    if (entry_idx >= global_entry_count) {
+        const err_msg = std.fmt.bufPrint(&buf, "Invalid entry_idx {} >= entry_count {}", .{ entry_idx, global_entry_count }) catch "Invalid entry_idx";
+        host_roc_ops.crash(err_msg);
+        return error.InvalidEntryIndex;
+    }
+
+    const def_offset = global_def_indices_offset + entry_idx * @sizeOf(u32);
+    const def_idx_raw: u32 = if (global_is_serialized_format) blk: {
+        const byte_offset: usize = @intCast(def_offset);
+        if (byte_offset + 4 > roc__serialized_size) {
+            const err_msg = std.fmt.bufPrint(&buf, "def_idx out of bounds: offset={}, size={}", .{ byte_offset, roc__serialized_size }) catch "def_idx out of bounds";
+            host_roc_ops.crash(err_msg);
+            return error.MemoryLayoutInvalid;
+        }
+        const ptr: *const [4]u8 = @ptrCast(base_ptr + byte_offset);
+        const val = std.mem.readInt(u32, ptr, .little);
+        break :blk val;
+    } else blk: {
+        break :blk safe_memory.safeRead(u32, base_ptr, @intCast(def_offset), roc__serialized_size) catch |err| {
+            const read_err = std.fmt.bufPrint(&buf, "Failed to read def_idx: {}", .{err}) catch "Failed to read def_idx";
+            host_roc_ops.crash(read_err);
+            return error.MemoryLayoutInvalid;
+        };
+    };
+    const def_idx: CIR.Def.Idx = @enumFromInt(def_idx_raw);
+
+    // Get the definition and extract its expression
+    const def = env_ptr.store.getDef(def_idx);
+    const expr_idx = def.expr;
+
+    traceDbg("Evaluating entry_idx={d}, def_idx={d}, expr_idx={d}", .{ entry_idx, def_idx_raw, @intFromEnum(expr_idx) });
+
+    // Get all module envs for code generation (needs mutable pointers)
+    const all_module_envs = global_full_mutable_envs.?;
+    const app_env = global_app_env_ptr.?;
+
+    // Get the global DevEvaluator
+    var dev_eval = &global_dev_evaluator.?;
+
+    // Resolve arg/ret layouts from the CIR function type
+    const layouts = resolveEntrypointLayouts(env_ptr, expr_idx, dev_eval, all_module_envs, allocator) catch |err| {
+        const err_msg = std.fmt.bufPrint(&buf, "Layout resolution failed: {s}", .{@errorName(err)}) catch "Layout resolution failed";
+        host_roc_ops.crash(err_msg);
+        return error.CodeGenFailed;
+    };
+
+    // Compile CIR → native code using entrypoint wrapper (RocCall ABI)
+    var code_result = dev_eval.generateEntrypointCode(env_ptr, expr_idx, all_module_envs, app_env, layouts.arg_layouts, layouts.ret_layout) catch |err| {
+        const err_msg = std.fmt.bufPrint(&buf, "Code generation failed: {s}", .{@errorName(err)}) catch "Code generation failed";
+        host_roc_ops.crash(err_msg);
+        return error.CodeGenFailed;
+    };
+    defer code_result.deinit();
+
+    // Check for crash during code generation
+    if (code_result.crash_message) |crash_msg| {
+        host_roc_ops.crash(crash_msg);
+        return error.Crash;
+    }
+
+    if (code_result.code.len == 0) {
+        host_roc_ops.crash("Dev shim: code generation produced empty code");
+        return error.CodeGenFailed;
+    }
+
+    // Create executable memory from generated code
+    var executable = backend.ExecutableMemory.initWithEntryOffset(code_result.code, code_result.entry_offset) catch {
+        host_roc_ops.crash("Dev shim: failed to create executable memory");
+        return error.ExecutionFailed;
+    };
+    defer executable.deinit();
+
+    // Execute using RocCall ABI — pass host's RocOps directly so generated code
+    // uses the host's allocator, hosted functions, and crash handlers.
+    executable.callRocABI(@ptrCast(host_roc_ops), ret_ptr, arg_ptr);
+}
+
+/// Resolve arg_layouts and ret_layout from the CIR function type of an entrypoint expression.
+fn resolveEntrypointLayouts(
+    env_ptr: *ModuleEnv,
+    expr_idx: CIR.Expr.Idx,
+    dev_eval: *eval.DevEvaluator,
+    all_module_envs: []const *ModuleEnv,
+    allocator: std.mem.Allocator,
+) !struct { arg_layouts: []const layout.Idx, ret_layout: layout.Idx } {
+    const layout_store_ptr = try dev_eval.ensureGlobalLayoutStore(all_module_envs);
+
+    // Find the module index for this module
+    const module_idx: u32 = for (all_module_envs, 0..) |env, i| {
+        if (env == env_ptr) break @intCast(i);
+    } else return error.ModuleEnvNotFound;
+
+    // Get the expression's type variable and resolve it
+    const expr_type_var = can.ModuleEnv.varFrom(expr_idx);
+    const resolved = env_ptr.types.resolveVar(expr_type_var);
+    const maybe_func = resolved.desc.content.unwrapFunc();
+
+    if (maybe_func) |func| {
+        const arg_vars = env_ptr.types.sliceVars(func.args);
+        var arg_layouts = try allocator.alloc(layout.Idx, arg_vars.len);
+        var type_scope = types.TypeScope.init(allocator);
+        defer type_scope.deinit();
+        for (arg_vars, 0..) |arg_var, i| {
+            arg_layouts[i] = try layout_store_ptr.fromTypeVar(module_idx, arg_var, &type_scope, null);
+        }
+        const ret_layout = try layout_store_ptr.fromTypeVar(module_idx, func.ret, &type_scope, null);
+        return .{ .arg_layouts = arg_layouts, .ret_layout = ret_layout };
+    }
+
+    // Non-function entrypoint (zero args) — the expression's type is the return type
+    var type_scope = types.TypeScope.init(allocator);
+    defer type_scope.deinit();
+    const ret_layout = try layout_store_ptr.fromTypeVar(module_idx, expr_type_var, &type_scope, null);
+    return .{ .arg_layouts = &.{}, .ret_layout = ret_layout };
+}
+
+/// Result of setting up module environments
+const SetupResult = struct {
+    primary_env: *ModuleEnv,
+    app_env: *ModuleEnv,
+};
+
+/// Set up ModuleEnv from serialized data with proper relocation (multi-module format)
+fn setupModuleEnv(roc_ops: *RocOps) ShimError!SetupResult {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
+    var buf: [256]u8 = undefined;
+    const base_ptr = roc__serialized_base_ptr.?;
+    const allocator = wrapped_allocator;
+
+    // Check for portable serialized format
+    const magic = std.mem.readInt(u32, base_ptr[0..4], .little);
+    if (magic == SERIALIZED_FORMAT_MAGIC) {
+        return setupModuleEnvFromSerialized(roc_ops, base_ptr, allocator);
+    }
+
+    // Legacy format
+    const header_addr = @intFromPtr(base_ptr) + FIRST_ALLOC_OFFSET;
+    const header_ptr: *const Header = @ptrFromInt(header_addr);
+    const parent_base_addr = header_ptr.parent_base_addr;
+    const module_count = header_ptr.module_count;
+
+    global_entry_count = header_ptr.entry_count;
+    global_def_indices_offset = header_ptr.def_indices_offset;
+    global_is_serialized_format = false;
+
+    const child_base_addr = @intFromPtr(base_ptr);
+    const offset: i64 = @as(i64, @intCast(child_base_addr)) - @as(i64, @intCast(parent_base_addr));
+
+    if (comptime builtin.mode == .Debug) {
+        const REQUIRED_ALIGNMENT: u64 = collections.SERIALIZATION_ALIGNMENT.toByteUnits();
+        const abs_offset: u64 = @abs(offset);
+        if (abs_offset % REQUIRED_ALIGNMENT != 0) {
+            const err_msg = std.fmt.bufPrint(&buf, "Relocation offset 0x{x} not {}-byte aligned! parent=0x{x} child=0x{x}", .{
+                abs_offset,
+                REQUIRED_ALIGNMENT,
+                parent_base_addr,
+                child_base_addr,
+            }) catch "Relocation offset misaligned";
+            std.debug.print("[MAIN] {s}\n", .{err_msg});
+            roc_ops.crash(err_msg);
+            return error.MemoryLayoutInvalid;
+        }
+    }
+
+    if (@abs(offset) > std.math.maxInt(isize) / 2) {
+        const err_msg = std.fmt.bufPrint(&buf, "Relocation offset too large: {}", .{offset}) catch "Relocation offset too large";
+        roc_ops.crash(err_msg);
+        return error.ModuleEnvSetupFailed;
+    }
+
+    const module_envs_base_addr = @intFromPtr(base_ptr) + @as(usize, @intCast(header_ptr.module_envs_offset));
+
+    if (comptime builtin.mode == .Debug) {
+        if (module_envs_base_addr % @alignOf(u64) != 0) {
+            const err_msg = std.fmt.bufPrint(&buf, "module_envs_base_addr misaligned: addr=0x{x}, base=0x{x}, offset=0x{x}", .{
+                module_envs_base_addr,
+                @intFromPtr(base_ptr),
+                header_ptr.module_envs_offset,
+            }) catch "module_envs_base_addr misaligned";
+            roc_ops.crash(err_msg);
+            return error.MemoryLayoutInvalid;
+        }
+    }
+
+    const module_env_offsets: [*]const u64 = @ptrFromInt(module_envs_base_addr);
+
+    var imported_envs = allocator.alloc(*const ModuleEnv, module_count - 1) catch {
+        roc_ops.crash("Failed to allocate imported envs array");
+        return error.OutOfMemory;
+    };
+
+    for (0..module_count - 1) |i| {
+        const module_env_offset = module_env_offsets[i];
+        const module_env_addr = @intFromPtr(base_ptr) + @as(usize, @intCast(module_env_offset));
+
+        if (comptime builtin.mode == .Debug) {
+            if (module_env_addr % @alignOf(ModuleEnv) != 0) {
+                const err_msg = std.fmt.bufPrint(&buf, "module_env_addr[{}] misaligned: addr=0x{x}, offset=0x{x}", .{
+                    i,
+                    module_env_addr,
+                    module_env_offset,
+                }) catch "module_env_addr misaligned";
+                roc_ops.crash(err_msg);
+                return error.MemoryLayoutInvalid;
+            }
+        }
+
+        const module_env_ptr: *ModuleEnv = @ptrFromInt(module_env_addr);
+        module_env_ptr.relocate(@intCast(offset));
+        module_env_ptr.gpa = allocator;
+        imported_envs[i] = module_env_ptr;
+    }
+
+    global_imported_envs = imported_envs;
+
+    const app_env_addr = @intFromPtr(base_ptr) + @as(usize, @intCast(header_ptr.app_env_offset));
+
+    if (comptime builtin.mode == .Debug) {
+        if (app_env_addr % @alignOf(ModuleEnv) != 0) {
+            const err_msg = std.fmt.bufPrint(&buf, "app_env_addr misaligned: addr=0x{x}, offset=0x{x}", .{
+                app_env_addr,
+                header_ptr.app_env_offset,
+            }) catch "app_env_addr misaligned";
+            roc_ops.crash(err_msg);
+            return error.MemoryLayoutInvalid;
+        }
+    }
+
+    const app_env_ptr: *ModuleEnv = @ptrFromInt(app_env_addr);
+    app_env_ptr.relocate(@intCast(offset));
+    app_env_ptr.gpa = allocator;
+
+    const primary_env: *ModuleEnv = if (header_ptr.platform_main_env_offset != 0) blk: {
+        const platform_env_addr = @intFromPtr(base_ptr) + @as(usize, @intCast(header_ptr.platform_main_env_offset));
+
+        if (comptime builtin.mode == .Debug) {
+            if (platform_env_addr % @alignOf(ModuleEnv) != 0) {
+                const err_msg = std.fmt.bufPrint(&buf, "platform_env_addr misaligned: addr=0x{x}, offset=0x{x}", .{
+                    platform_env_addr,
+                    header_ptr.platform_main_env_offset,
+                }) catch "platform_env_addr misaligned";
+                roc_ops.crash(err_msg);
+                return error.MemoryLayoutInvalid;
+            }
+        }
+
+        const platform_env_ptr: *ModuleEnv = @ptrFromInt(platform_env_addr);
+        platform_env_ptr.relocate(@intCast(offset));
+        platform_env_ptr.gpa = allocator;
+        break :blk platform_env_ptr;
+    } else app_env_ptr;
+
+    return SetupResult{
+        .primary_env = primary_env,
+        .app_env = app_env_ptr,
+    };
+}
+
+/// Set up ModuleEnv from portable serialized format (cross-architecture builds)
+fn setupModuleEnvFromSerialized(roc_ops: *RocOps, base_ptr: [*]align(1) u8, allocator: std.mem.Allocator) ShimError!SetupResult {
+    const trace = tracy.trace(@src());
+    defer trace.end();
+
+    var buf: [256]u8 = undefined;
+
+    const header_magic = std.mem.readInt(u32, base_ptr[0..4], .little);
+    if (header_magic != SERIALIZED_FORMAT_MAGIC) {
+        const err_msg = std.fmt.bufPrint(&buf, "Invalid magic number: 0x{x}", .{header_magic}) catch "Invalid magic number";
+        roc_ops.crash(err_msg);
+        return error.MemoryLayoutInvalid;
+    }
+
+    const format_version = std.mem.readInt(u32, base_ptr[4..8], .little);
+    if (format_version != 1) {
+        const err_msg = std.fmt.bufPrint(&buf, "Unsupported serialized format version: {}", .{format_version}) catch "Unsupported format version";
+        roc_ops.crash(err_msg);
+        return error.MemoryLayoutInvalid;
+    }
+
+    const module_count = std.mem.readInt(u32, base_ptr[8..12], .little);
+    const entry_count = std.mem.readInt(u32, base_ptr[12..16], .little);
+    const primary_env_index = std.mem.readInt(u32, base_ptr[16..20], .little);
+    const app_env_index = std.mem.readInt(u32, base_ptr[20..24], .little);
+    const def_indices_offset = std.mem.readInt(u64, base_ptr[24..32], .little);
+    const module_infos_offset = std.mem.readInt(u64, base_ptr[32..40], .little);
+
+    global_entry_count = entry_count;
+    global_def_indices_offset = def_indices_offset;
+    global_is_serialized_format = true;
+
+    const module_infos_addr = @intFromPtr(base_ptr) + @as(usize, @intCast(module_infos_offset));
+    const module_infos_bytes: [*]const u8 = @ptrFromInt(module_infos_addr);
+
+    var env_ptrs = allocator.alloc(*ModuleEnv, module_count) catch {
+        roc_ops.crash("Failed to allocate ModuleEnv pointer array");
+        return error.OutOfMemory;
+    };
+
+    const MODULE_INFO_SIZE: usize = 40;
+
+    for (0..module_count) |i| {
+        const info_base = module_infos_bytes + (i * MODULE_INFO_SIZE);
+
+        const source_offset = std.mem.readInt(u64, info_base[0..8], .little);
+        const source_len = std.mem.readInt(u64, info_base[8..16], .little);
+        const module_name_offset = std.mem.readInt(u64, info_base[16..24], .little);
+        const module_name_len = std.mem.readInt(u64, info_base[24..32], .little);
+        const env_serialized_offset = std.mem.readInt(u64, info_base[32..40], .little);
+
+        const source_ptr = base_ptr + @as(usize, @intCast(source_offset));
+        const source = source_ptr[0..@as(usize, @intCast(source_len))];
+
+        const name_ptr = base_ptr + @as(usize, @intCast(module_name_offset));
+        const module_name = name_ptr[0..@as(usize, @intCast(module_name_len))];
+
+        const env_serialized_addr = @intFromPtr(base_ptr) + @as(usize, @intCast(env_serialized_offset));
+        const env_serialized: *ModuleEnv.Serialized = @ptrFromInt(env_serialized_addr);
+
+        env_ptrs[i] = env_serialized.deserializeInto(
+            @intFromPtr(base_ptr),
+            allocator,
+            source,
+            module_name,
+        ) catch |err| {
+            const err_msg = std.fmt.bufPrint(&buf, "Failed to deserialize module {}: {s}", .{ i, @errorName(err) }) catch "Failed to deserialize module";
+            roc_ops.crash(err_msg);
+            return error.ModuleEnvSetupFailed;
+        };
+    }
+
+    if (module_count > 1) {
+        var imported_envs = allocator.alloc(*const ModuleEnv, module_count - 1) catch {
+            roc_ops.crash("Failed to allocate imported envs array");
+            return error.OutOfMemory;
+        };
+        var j: usize = 0;
+        for (0..module_count) |i| {
+            if (i != app_env_index) {
+                imported_envs[j] = env_ptrs[i];
+                j += 1;
+            }
+        }
+        global_imported_envs = imported_envs;
+    }
+
+    return SetupResult{
+        .primary_env = env_ptrs[primary_env_index],
+        .app_env = env_ptrs[app_env_index],
+    };
+}

--- a/src/eval/dev_evaluator.zig
+++ b/src/eval/dev_evaluator.zig
@@ -476,6 +476,7 @@ pub const DevEvaluator = struct {
         CanonicalizeError,
         TypeError,
         ExecutionError,
+        ModuleEnvNotFound,
     };
 
     /// Initialize the evaluator with builtin modules
@@ -540,7 +541,7 @@ pub const DevEvaluator = struct {
 
     /// Get or create the global layout store.
     /// The global layout store uses all module type stores for cross-module layout computation.
-    fn ensureGlobalLayoutStore(self: *DevEvaluator, all_module_envs: []const *ModuleEnv) Error!*layout.Store {
+    pub fn ensureGlobalLayoutStore(self: *DevEvaluator, all_module_envs: []const *ModuleEnv) Error!*layout.Store {
         // If we already have a global layout store, return it
         if (self.global_layout_store) |ls| return ls;
 
@@ -669,6 +670,7 @@ pub const DevEvaluator = struct {
         module_env: *ModuleEnv,
         expr_idx: CIR.Expr.Idx,
         all_module_envs: []const *ModuleEnv,
+        app_module_env: ?*ModuleEnv,
     ) Error!CodeResult {
         // Reset the static bump allocator so each evaluation starts fresh
         DevRocEnv.StaticAlloc.reset();
@@ -687,13 +689,11 @@ pub const DevEvaluator = struct {
         module_env.imports.resolveImports(module_env, all_module_envs);
 
         // Find the module index for this module
-        var module_idx: u32 = 0;
-        for (all_module_envs, 0..) |env, i| {
-            if (env == module_env) {
-                module_idx = @intCast(i);
-                break;
-            }
-        }
+        const module_idx = findModuleEnvIdx(all_module_envs, module_env) orelse return error.ModuleEnvNotFound;
+        const app_module_idx = if (app_module_env) |env|
+            findModuleEnvIdx(all_module_envs, env) orelse return error.ModuleEnvNotFound
+        else
+            null;
 
         // Get or create the global layout store for resolving layouts of composite types
         // This is a single store shared across all modules for cross-module correctness
@@ -715,7 +715,7 @@ pub const DevEvaluator = struct {
             all_module_envs,
             &module_env.types,
             module_idx,
-            null, // app_module_idx - not used for JIT evaluation
+            app_module_idx,
         ) catch return error.OutOfMemory;
         defer mir_lower.deinit();
 
@@ -791,6 +791,147 @@ pub const DevEvaluator = struct {
             .tuple_len = tuple_len,
             .entry_offset = gen_result.entry_offset,
         };
+    }
+
+    /// Generate code for an entrypoint using the RocCall ABI: fn(roc_ops, ret_ptr, args_ptr).
+    ///
+    /// Uses `generateEntrypointWrapper` which handles argument unpacking from args_ptr,
+    /// lambda/lookup/nominal resolution, and proper ABI slot sizing.
+    /// This is for `roc run` where the host passes its own RocOps.
+    pub fn generateEntrypointCode(
+        self: *DevEvaluator,
+        module_env: *ModuleEnv,
+        expr_idx: CIR.Expr.Idx,
+        all_module_envs: []const *ModuleEnv,
+        app_module_env: ?*ModuleEnv,
+        arg_layouts: []const layout.Idx,
+        ret_layout: layout.Idx,
+    ) Error!CodeResult {
+        // Reset the static bump allocator so each evaluation starts fresh
+        DevRocEnv.StaticAlloc.reset();
+
+        // Enable runtime inserts for all participating modules
+        for (all_module_envs) |env| {
+            env.common.idents.interner.enableRuntimeInserts(env.gpa) catch return error.OutOfMemory;
+        }
+
+        // Refresh imports for this module ordering
+        module_env.imports.resolveImports(module_env, all_module_envs);
+
+        // Find the module index for this module
+        const module_idx = findModuleEnvIdx(all_module_envs, module_env) orelse return error.ModuleEnvNotFound;
+        const app_module_idx = if (app_module_env) |env|
+            findModuleEnvIdx(all_module_envs, env) orelse return error.ModuleEnvNotFound
+        else
+            null;
+
+        // Get or create the global layout store
+        const layout_store_ptr = try self.ensureGlobalLayoutStore(all_module_envs);
+        layout_store_ptr.resetModuleCache(all_module_envs);
+
+        // Lower CIR → MIR
+        var mir_store = MIR.Store.init(self.allocator) catch return error.OutOfMemory;
+        defer mir_store.deinit(self.allocator);
+
+        var mir_lower = mir.Lower.init(
+            self.allocator,
+            &mir_store,
+            all_module_envs,
+            &module_env.types,
+            module_idx,
+            app_module_idx,
+        ) catch return error.OutOfMemory;
+        defer mir_lower.deinit();
+
+        var mir_expr_id = mir_lower.lowerExpr(expr_idx) catch {
+            return error.RuntimeError;
+        };
+
+        // Zero-arg function entrypoints like `main! : () => {}` must be lowered
+        // as calls, not as first-class function values.
+        if (arg_layouts.len == 0) {
+            const func_mono_idx = mir_store.typeOf(mir_expr_id);
+            const func_mono = mir_store.monotype_store.getMonotype(func_mono_idx);
+            if (func_mono == .func) {
+                mir_expr_id = mir_store.addExpr(self.allocator, .{ .call = .{
+                    .func = mir_expr_id,
+                    .args = MIR.ExprSpan.empty(),
+                } }, func_mono.func.ret, base.Region.zero()) catch return error.OutOfMemory;
+            }
+        }
+
+        // Run lambda set inference
+        const mir_mod = @import("mir");
+        var lambda_set_store = mir_mod.LambdaSet.infer(self.allocator, &mir_store, all_module_envs) catch return error.OutOfMemory;
+        defer lambda_set_store.deinit(self.allocator);
+
+        // Lower MIR to LIR
+        var lir_store = LirExprStore.init(self.allocator);
+        defer lir_store.deinit();
+
+        var mir_to_lir = lir.MirToLir.init(self.allocator, &mir_store, &lir_store, layout_store_ptr, &lambda_set_store, module_env.idents.true_tag);
+        defer mir_to_lir.deinit();
+
+        const lir_expr_id = mir_to_lir.lower(mir_expr_id) catch {
+            return error.RuntimeError;
+        };
+
+        // Run RC insertion pass
+        var rc_pass = lir.RcInsert.RcInsertPass.init(self.allocator, &lir_store, layout_store_ptr) catch return error.OutOfMemory;
+        defer rc_pass.deinit();
+        const final_expr_id = rc_pass.insertRcOps(lir_expr_id) catch lir_expr_id;
+
+        lir.RcInsert.insertRcOpsIntoSymbolDefsBestEffort(self.allocator, &lir_store, layout_store_ptr);
+
+        // Create codegen
+        var codegen = backend.HostLirCodeGen.init(
+            self.allocator,
+            &lir_store,
+            layout_store_ptr,
+            &self.static_interner,
+        ) catch return error.OutOfMemory;
+        defer codegen.deinit();
+
+        // Compile all procedures first
+        const procs = lir_store.getProcs();
+        if (procs.len > 0) {
+            codegen.compileAllProcs(procs) catch {
+                return error.RuntimeError;
+            };
+        }
+
+        // Generate entrypoint wrapper using RocCall ABI
+        const exported = codegen.generateEntrypointWrapper("", final_expr_id, arg_layouts, ret_layout) catch {
+            return error.RuntimeError;
+        };
+
+        // Patch cross-proc call sites
+        codegen.patchPendingCalls() catch {
+            return error.RuntimeError;
+        };
+
+        // Get the generated code
+        const all_code = codegen.getGeneratedCode();
+        const code_copy = self.allocator.dupe(u8, all_code) catch return error.OutOfMemory;
+
+        return CodeResult{
+            .code = code_copy,
+            .allocator = self.allocator,
+            .result_layout = ret_layout,
+            .layout_store = layout_store_ptr,
+            .tuple_len = 1,
+            .entry_offset = exported.offset,
+        };
+    }
+
+    fn findModuleEnvIdx(all_module_envs: []const *ModuleEnv, module_env: *ModuleEnv) ?u32 {
+        for (all_module_envs, 0..) |env, i| {
+            if (env == module_env) {
+                return @intCast(i);
+            }
+        }
+
+        return null;
     }
 
     /// Generate native code from source code string (full pipeline)

--- a/src/eval/test/helpers.zig
+++ b/src/eval/test/helpers.zig
@@ -247,7 +247,7 @@ fn devEvaluatorStr(allocator: std.mem.Allocator, module_env: *ModuleEnv, expr_id
     const all_module_envs = [_]*ModuleEnv{ @constCast(builtin_module_env), module_env };
 
     // Generate code using Mono IR pipeline
-    var code_result = dev_eval.generateCode(module_env, expr_idx, &all_module_envs) catch {
+    var code_result = dev_eval.generateCode(module_env, expr_idx, &all_module_envs, null) catch {
         return error.GenerateCodeFailed;
     };
     defer code_result.deinit();

--- a/src/repl/eval.zig
+++ b/src/repl/eval.zig
@@ -756,7 +756,7 @@ pub const Repl = struct {
             if (self.backend == .dev) {
                 if (self.dev_evaluator) |*dev_eval| {
                     const all_module_envs: []const *ModuleEnv = &.{ self.builtin_module.env, module_env };
-                    var code_result = dev_eval.generateCode(module_env, inspect_expr, all_module_envs) catch |err| {
+                    var code_result = dev_eval.generateCode(module_env, inspect_expr, all_module_envs, null) catch |err| {
                         return .{ .eval_error = try std.fmt.allocPrint(self.allocator, "Dev backend codegen error: {s}", .{@errorName(err)}) };
                     };
                     defer code_result.deinit();


### PR DESCRIPTION
## Summary

Replaces the old `roc --backend=dev path/to/app.roc` flow (full build → link → execute every time) with a shim-based architecture that mirrors the interpreter shim. The dev shim pre-links with the host platform once, then receives CIR via shared memory and JIT-compiles to native code on each run — skipping LLD on subsequent invocations.

### What changed

**New dev shim binary** (`src/dev_shim/main.zig`)
- Standalone shim that reads ModuleEnv from shared memory (IPC) or embedded data (`roc build`)
- Deserializes module environments, resolves imports, then compiles CIR → MIR → LIR → native machine code via `DevEvaluator`
- Exports `roc_entrypoint(entry_idx, roc_ops, ret_ptr, arg_ptr)` — the host calls this to run each entrypoint
- Supports both legacy pointer-relocation and portable serialized formats
- Thread-safe initialization with double-checked locking

**New entrypoint codegen path** (`src/eval/dev_evaluator.zig`)
- `generateEntrypointCode()` compiles a CIR expression using the RocCall ABI (`fn(roc_ops, ret_ptr, args_ptr)`)
- Resolves arg/ret layouts from CIR type variables via `resolveEntrypointLayouts()`
- Handles zero-arg function entrypoints (e.g. `main! : () => {}`) by lowering them as calls rather than first-class values
- Uses `generateEntrypointWrapper` for argument unpacking, lambda/lookup resolution, and ABI slot sizing
- `generateCode()` now accepts an `app_module_env` parameter for cross-module lookup resolution

**CLI changes** (`src/cli/main.zig`)
- `rocRunDevShim()` replaces `rocRunDev()`: parses platform spec, extracts entrypoints, links the shim with host objects once, then launches via shared memory IPC
- Cache key hashes: target name, platform source mtime, and mtimes of all linked host files — invalidates when any platform file changes
- `DevShimLibraries` embeds pre-compiled dev shim archives for all cross-compilation targets (x64/arm64 × musl/glibc/mac/win)
- Removes `rocRunDev()`, `runDevChildWindows()`, and `handleNativeRunTermination()` dead code

**Build system** (`build.zig`)
- Builds `roc_dev_shim` as a static library alongside the interpreter shim
- Cross-compiles for all targets except wasm32 (dev backend is x86_64/aarch64 only)

**ExecutableMemory** (`src/backend/dev/ExecutableMemory.zig`)
- `callRocABI()`: new entry point for the RocCall convention (`fn(roc_ops, ret_ptr, args_ptr)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)