### PR TITLE
Fix MIR nominal monotypes for opaque type params

### DIFF
--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -1043,8 +1043,12 @@ const Unifier = struct {
             try self.unifyGuarded(a_arg, b_arg);
         }
 
-        // Merge after all checks pass
-        // Note that we *do not* unify backing variable
+        // Merge after all checks pass.
+        // We intentionally do not unify backing vars here: nominal identity is
+        // defined by origin/name/args, and forcing backing vars to coincide at
+        // unification time over-constrains row-polymorphic nominals like Try.
+        // MIR monotype lowering substitutes formal nominal params into backing
+        // types explicitly when it strips nominal wrappers.
         self.merge(vars, vars.b.desc.content);
     }
 

--- a/src/mir/Lower.zig
+++ b/src/mir/Lower.zig
@@ -198,6 +198,8 @@ pub fn init(
         .mono_scratches = blk: {
             var ms = try Monotype.Store.Scratches.init(allocator);
             ms.ident_store = all_module_envs[current_module_idx].getIdentStoreConst();
+            ms.module_env = all_module_envs[current_module_idx];
+            ms.all_module_envs = all_module_envs;
             break :blk ms;
         },
     };
@@ -4182,8 +4184,13 @@ fn monotypeFromTypeVarInStore(
     defer local_cycles.deinit();
 
     const saved_ident_store = self.mono_scratches.ident_store;
+    const saved_module_env = self.mono_scratches.module_env;
     self.mono_scratches.ident_store = self.all_module_envs[module_idx].getIdentStoreConst();
-    defer self.mono_scratches.ident_store = saved_ident_store;
+    self.mono_scratches.module_env = self.all_module_envs[module_idx];
+    defer {
+        self.mono_scratches.ident_store = saved_ident_store;
+        self.mono_scratches.module_env = saved_module_env;
+    }
 
     return self.store.monotype_store.fromTypeVar(
         self.allocator,
@@ -4464,11 +4471,13 @@ fn lowerExternalDefWithType(self: *Self, symbol: MIR.Symbol, cir_expr_idx: CIR.E
     const saved_type_var_seen = self.type_var_seen;
     const saved_nominal_cycle_breakers = self.nominal_cycle_breakers;
     const saved_ident_store = self.mono_scratches.ident_store;
+    const saved_module_env = self.mono_scratches.module_env;
     self.current_pattern_scope = symbol_key;
     if (switching_module) {
         self.current_module_idx = symbol_module_idx;
         self.types_store = &self.all_module_envs[symbol_module_idx].types;
         self.mono_scratches.ident_store = self.all_module_envs[symbol_module_idx].getIdentStoreConst();
+        self.mono_scratches.module_env = self.all_module_envs[symbol_module_idx];
     }
 
     // Always isolate type_var_seen per external definition lowering.
@@ -4501,6 +4510,7 @@ fn lowerExternalDefWithType(self: *Self, symbol: MIR.Symbol, cir_expr_idx: CIR.E
             self.types_store = saved_types_store;
             self.current_module_idx = saved_module_idx;
             self.mono_scratches.ident_store = saved_ident_store;
+            self.mono_scratches.module_env = saved_module_env;
         }
     }
 

--- a/src/mir/Monotype.zig
+++ b/src/mir/Monotype.zig
@@ -14,6 +14,7 @@ const types = @import("types");
 
 const Ident = base.Ident;
 const Allocator = std.mem.Allocator;
+const ModuleEnv = can.ModuleEnv;
 const CommonIdents = can.ModuleEnv.CommonIdents;
 const StaticDispatchConstraint = types.StaticDispatchConstraint;
 
@@ -183,6 +184,11 @@ pub const FieldSpan = extern struct {
     }
 };
 
+const NamedSpecialization = struct {
+    name_text: []const u8,
+    type_idx: Idx,
+};
+
 /// Flat storage for monomorphic types.
 pub const Store = struct {
     monotypes: std.ArrayListUnmanaged(Monotype),
@@ -204,15 +210,21 @@ pub const Store = struct {
         fields: base.Scratch(Field),
         tags: base.Scratch(Tag),
         idxs: base.Scratch(Idx),
+        named_specializations: base.Scratch(NamedSpecialization),
         /// Ident store for sorting tag names alphabetically.
         /// Updated when switching modules during cross-module lowering.
         ident_store: ?*const Ident.Store = null,
+        /// Module env owning the current `types_store` / `ident_store`.
+        module_env: ?*const ModuleEnv = null,
+        /// Shared module env slice used to resolve nominal definitions by origin module.
+        all_module_envs: ?[]const *ModuleEnv = null,
 
         pub fn init(allocator: Allocator) Allocator.Error!Scratches {
             return .{
                 .fields = try base.Scratch(Field).init(allocator),
                 .tags = try base.Scratch(Tag).init(allocator),
                 .idxs = try base.Scratch(Idx).init(allocator),
+                .named_specializations = try base.Scratch(NamedSpecialization).init(allocator),
             };
         }
 
@@ -220,6 +232,7 @@ pub const Store = struct {
             self.fields.deinit();
             self.tags.deinit();
             self.idxs.deinit();
+            self.named_specializations.deinit();
         }
     };
 
@@ -360,11 +373,15 @@ pub const Store = struct {
 
         return switch (resolved.desc.content) {
             .flex => |flex| {
+                if (flex.name) |name| {
+                    if (lookupNamedSpecialization(scratches, name)) |specialized| return specialized;
+                }
                 if (hasNumeralConstraint(types_store, flex.constraints))
                     return self.primIdx(.dec);
                 return self.unit_idx;
             },
             .rigid => |rigid| {
+                if (lookupNamedSpecialization(scratches, rigid.name)) |specialized| return specialized;
                 if (hasNumeralConstraint(types_store, rigid.constraints))
                     return self.primIdx(.dec);
                 return self.unit_idx;
@@ -472,6 +489,10 @@ pub const Store = struct {
                                 },
                             },
                             .flex => {
+                                if (findNamedRowExtensionMonotype(scratches, ext_var, types_store)) |specialized| {
+                                    try self.appendSpecializedRecordFields(specialized, scratch_top, scratches);
+                                    break :rows;
+                                }
                                 if (std.debug.runtime_safety) {
                                     std.debug.panic(
                                         "Monotype.fromTypeVar(record): unresolved flex row extension tail",
@@ -481,6 +502,10 @@ pub const Store = struct {
                                 unreachable;
                             },
                             .rigid => {
+                                if (findNamedRowExtensionMonotype(scratches, ext_var, types_store)) |specialized| {
+                                    try self.appendSpecializedRecordFields(specialized, scratch_top, scratches);
+                                    break :rows;
+                                }
                                 if (std.debug.runtime_safety) {
                                     std.debug.panic(
                                         "Monotype.fromTypeVar(record): unresolved rigid row extension tail",
@@ -592,8 +617,18 @@ pub const Store = struct {
                                     unreachable;
                                 },
                             },
-                            .flex => break :rows, // Open tag union — treat as closed with collected tags
-                            .rigid => break :rows, // Rigid tag union — treat as closed with collected tags
+                            .flex => {
+                                if (findNamedRowExtensionMonotype(scratches, ext_var, types_store)) |specialized| {
+                                    try self.appendSpecializedTagUnionTags(specialized, scratches);
+                                }
+                                break :rows; // Open tag union — treat as closed with collected tags
+                            },
+                            .rigid => {
+                                if (findNamedRowExtensionMonotype(scratches, ext_var, types_store)) |specialized| {
+                                    try self.appendSpecializedTagUnionTags(specialized, scratches);
+                                }
+                                break :rows; // Rigid tag union — treat as closed with collected tags
+                            },
                             .err => {
                                 if (std.debug.runtime_safety) {
                                     std.debug.panic(
@@ -722,6 +757,17 @@ pub const Store = struct {
         const placeholder_idx = try self.addMonotype(allocator, .recursive_placeholder);
         try nominal_cycle_breakers.put(nominal_var, placeholder_idx);
 
+        const named_specializations_top = try self.pushNominalArgSpecializations(
+            allocator,
+            types_store,
+            nominal,
+            common_idents,
+            specializations,
+            nominal_cycle_breakers,
+            scratches,
+        );
+        defer scratches.named_specializations.clearFrom(named_specializations_top);
+
         const backing_var = types_store.getNominalBackingVar(nominal);
         const backing_idx = try self.fromTypeVar(allocator, types_store, backing_var, common_idents, specializations, nominal_cycle_breakers, scratches);
 
@@ -734,5 +780,182 @@ pub const Store = struct {
             std.debug.assert(self.monotypes.items[@intFromEnum(placeholder_idx)] != .recursive_placeholder);
         }
         return placeholder_idx;
+    }
+
+    fn lookupNamedSpecialization(scratches: *const Scratches, name: Ident.Idx) ?Idx {
+        const ident_store = scratches.ident_store orelse return null;
+        const name_text = ident_store.getText(name);
+        const items = scratches.named_specializations.items.items;
+
+        var i = items.len;
+        while (i > 0) {
+            i -= 1;
+            if (std.mem.eql(u8, items[i].name_text, name_text)) {
+                return items[i].type_idx;
+            }
+        }
+        return null;
+    }
+
+    fn findNamedRowExtensionMonotype(scratches: *const Scratches, ext_var: types.Var, types_store: *const types.Store) ?Idx {
+        const resolved = types_store.resolveVar(ext_var);
+        return switch (resolved.desc.content) {
+            .flex => |flex| if (flex.name) |name| lookupNamedSpecialization(scratches, name) else null,
+            .rigid => |rigid| lookupNamedSpecialization(scratches, rigid.name),
+            else => null,
+        };
+    }
+
+    fn appendSpecializedRecordFields(
+        self: *Store,
+        specialized: Idx,
+        scratch_top: u32,
+        scratches: *Scratches,
+    ) Allocator.Error!void {
+        const mono = self.getMonotype(specialized);
+        switch (mono) {
+            .record => |record| {
+                for (self.getFields(record.fields)) |field| {
+                    var seen_name = false;
+                    for (scratches.fields.sliceFromStart(scratch_top)) |existing| {
+                        if (existing.name.eql(field.name)) {
+                            seen_name = true;
+                            break;
+                        }
+                    }
+                    if (seen_name) continue;
+                    try scratches.fields.append(field);
+                }
+            },
+            .unit => {},
+            else => {
+                if (std.debug.runtime_safety) {
+                    std.debug.panic(
+                        "Monotype.fromTypeVar(record): nominal row specialization must be record or unit, found '{s}'",
+                        .{@tagName(mono)},
+                    );
+                }
+                unreachable;
+            },
+        }
+    }
+
+    fn appendSpecializedTagUnionTags(
+        self: *Store,
+        specialized: Idx,
+        scratches: *Scratches,
+    ) Allocator.Error!void {
+        const mono = self.getMonotype(specialized);
+        switch (mono) {
+            .tag_union => |tag_union| {
+                for (self.getTags(tag_union.tags)) |tag| {
+                    try scratches.tags.append(tag);
+                }
+            },
+            else => {
+                if (std.debug.runtime_safety) {
+                    std.debug.panic(
+                        "Monotype.fromTypeVar(tag_union): nominal row specialization must be tag_union, found '{s}'",
+                        .{@tagName(mono)},
+                    );
+                }
+                unreachable;
+            },
+        }
+    }
+
+    fn pushNominalArgSpecializations(
+        self: *Store,
+        allocator: Allocator,
+        types_store: *const types.Store,
+        nominal: types.NominalType,
+        common_idents: CommonIdents,
+        specializations: *const std.AutoHashMap(types.Var, Idx),
+        nominal_cycle_breakers: *std.AutoHashMap(types.Var, Idx),
+        scratches: *Scratches,
+    ) Allocator.Error!u32 {
+        const top = scratches.named_specializations.top();
+
+        const source_env = scratches.module_env orelse return top;
+        const all_module_envs = scratches.all_module_envs orelse return top;
+        const definition_env = findNominalDefinitionEnv(source_env, all_module_envs, nominal.origin_module) orelse return top;
+        const type_name = source_env.getIdent(nominal.ident.ident_idx);
+        const definition_nominal = findDefinitionNominal(definition_env, type_name) orelse return top;
+
+        const formal_args = definition_env.types.sliceNominalArgs(definition_nominal);
+        const actual_args = types_store.sliceNominalArgs(nominal);
+        if (formal_args.len != actual_args.len) {
+            if (std.debug.runtime_safety) {
+                std.debug.panic(
+                    "Monotype.fromNominalType: arg arity mismatch for nominal '{s}' (formal={d}, actual={d})",
+                    .{ type_name, formal_args.len, actual_args.len },
+                );
+            }
+            unreachable;
+        }
+
+        for (formal_args, actual_args) |formal_arg, actual_arg| {
+            const formal_name_text = resolvedTypeVarNameText(&definition_env.types, definition_env, formal_arg) orelse continue;
+            const actual_mono = try self.fromTypeVar(
+                allocator,
+                types_store,
+                actual_arg,
+                common_idents,
+                specializations,
+                nominal_cycle_breakers,
+                scratches,
+            );
+            try scratches.named_specializations.append(.{
+                .name_text = formal_name_text,
+                .type_idx = actual_mono,
+            });
+        }
+
+        return top;
+    }
+
+    fn resolvedTypeVarNameText(
+        types_store: *const types.Store,
+        module_env: *const ModuleEnv,
+        var_: types.Var,
+    ) ?[]const u8 {
+        const resolved = types_store.resolveVar(var_);
+        return switch (resolved.desc.content) {
+            .rigid => |rigid| module_env.getIdent(rigid.name),
+            .flex => |flex| if (flex.name) |name| module_env.getIdent(name) else null,
+            else => null,
+        };
+    }
+
+    fn findNominalDefinitionEnv(
+        source_env: *const ModuleEnv,
+        all_module_envs: []const *ModuleEnv,
+        origin_module: Ident.Idx,
+    ) ?*const ModuleEnv {
+        const origin_name = source_env.getIdent(origin_module);
+        for (all_module_envs) |candidate_env| {
+            const candidate_name = candidate_env.getIdent(candidate_env.qualified_module_ident);
+            if (std.mem.eql(u8, origin_name, candidate_name)) return candidate_env;
+        }
+        return null;
+    }
+
+    fn findDefinitionNominal(definition_env: *const ModuleEnv, type_name: []const u8) ?types.NominalType {
+        for (definition_env.store.sliceStatements(definition_env.all_statements)) |stmt_idx| {
+            const stmt = definition_env.store.getStatement(stmt_idx);
+            switch (stmt) {
+                .s_nominal_decl => |nominal_decl| {
+                    const header = definition_env.store.getTypeHeader(nominal_decl.header);
+                    if (!std.mem.eql(u8, definition_env.getIdent(header.relative_name), type_name)) continue;
+
+                    const resolved = definition_env.types.resolveVar(ModuleEnv.varFrom(stmt_idx));
+                    if (resolved.desc.content == .structure and resolved.desc.content.structure == .nominal_type) {
+                        return resolved.desc.content.structure.nominal_type;
+                    }
+                },
+                else => {},
+            }
+        }
+        return null;
     }
 };

--- a/src/mir/test/lower_test.zig
+++ b/src/mir/test/lower_test.zig
@@ -1135,6 +1135,42 @@ test "fromTypeVar: recursive binary tree type completes without hanging" {
     try testing.expect(monotype == .tag_union);
 }
 
+test "fromTypeVar: polymorphic opaque with function field propagates nominal args into backing type" {
+    var env = try MirTestEnv.initModule("Test",
+        \\W(a) := { f : {} -> [V(a)] }.{
+        \\    mk : a -> W(a)
+        \\    mk = |val| { f: |_| V(val) }
+        \\}
+        \\
+        \\w : W(Str)
+        \\w = W.mk("x")
+    );
+    defer env.deinit();
+
+    const expr = try env.lowerNamedDef("w");
+    const monotype = env.mir_store.monotype_store.getMonotype(env.mir_store.typeOf(expr));
+
+    try testing.expect(monotype == .record);
+
+    const fields = env.mir_store.monotype_store.getFields(monotype.record.fields);
+    try testing.expectEqual(@as(usize, 1), fields.len);
+
+    const field_type = env.mir_store.monotype_store.getMonotype(fields[0].type_idx);
+    try testing.expect(field_type == .func);
+
+    const ret_type = env.mir_store.monotype_store.getMonotype(field_type.func.ret);
+    try testing.expect(ret_type == .tag_union);
+
+    const tags = env.mir_store.monotype_store.getTags(ret_type.tag_union.tags);
+    try testing.expectEqual(@as(usize, 1), tags.len);
+    try testing.expectEqual(@as(usize, 1), tags[0].payloads.len);
+
+    const payloads = env.mir_store.monotype_store.getIdxSpan(tags[0].payloads);
+    const payload_type = env.mir_store.monotype_store.getMonotype(payloads[0]);
+    try testing.expect(payload_type == .prim);
+    try testing.expectEqual(Monotype.Prim.str, payload_type.prim);
+}
+
 // --- Gap #26: lowerExternalDef recursion guard ---
 
 test "lowerExternalDef: recursion guard returns lookup placeholder" {


### PR DESCRIPTION
## Summary
Fixes #9256.

When MIR strips a nominal wrapper, it now substitutes the nominal definition's formal type params with the current nominal's actual type args before projecting the backing type. This keeps nested function/tag-union structure inside opaque types aligned with the concrete call-site monotype instead of defaulting disconnected vars to `unit`.

## Testing
- zig build test-mir
- zig build test-mir -- --test-filter "fromTypeVar"
- zig build test-mir -- --test-filter "cross-module: type module"