### PR TITLE
Fix FX runtime coverage and builtin embedding

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1686,12 +1686,18 @@ const TidyStep = struct {
     }
 };
 
+const BuiltinCompilerRun = struct {
+    run: *Step.Run,
+    builtin_bin: std.Build.LazyPath,
+    builtin_indices_bin: std.Build.LazyPath,
+};
+
 fn createAndRunBuiltinCompiler(
     b: *std.Build,
     roc_modules: modules.RocModules,
     flag_enable_tracy: ?[]const u8,
     roc_files: []const []const u8,
-) *Step.Run {
+) BuiltinCompilerRun {
     // Build and run the compiler
     const builtin_compiler_exe = b.addExecutable(.{
         .name = "builtin_compiler",
@@ -1725,7 +1731,14 @@ fn createAndRunBuiltinCompiler(
         run_builtin_compiler.addFileArg(b.path(roc_path));
     }
 
-    return run_builtin_compiler;
+    const builtin_bin = run_builtin_compiler.addOutputFileArg("Builtin.bin");
+    const builtin_indices_bin = run_builtin_compiler.addOutputFileArg("builtin_indices.bin");
+
+    return .{
+        .run = run_builtin_compiler,
+        .builtin_bin = builtin_bin,
+        .builtin_indices_bin = builtin_indices_bin,
+    };
 }
 
 fn createTestPlatformHostLib(
@@ -2238,12 +2251,12 @@ pub fn build(b: *std.Build) void {
     const write_compiled_builtins = b.addWriteFiles();
 
     // Always regenerate .bin files to ensure they match the current compiler
-    const run_builtin_compiler = createAndRunBuiltinCompiler(b, roc_modules, flag_enable_tracy, &.{builtin_roc_path});
-    write_compiled_builtins.step.dependOn(&run_builtin_compiler.step);
+    const builtin_compiler = createAndRunBuiltinCompiler(b, roc_modules, flag_enable_tracy, &.{builtin_roc_path});
+    write_compiled_builtins.step.dependOn(&builtin_compiler.run.step);
 
-    // Copy Builtin.bin from zig-out/builtins/
+    // Copy tracked outputs from the builtin compiler run step.
     _ = write_compiled_builtins.addCopyFile(
-        .{ .cwd_relative = "zig-out/builtins/Builtin.bin" },
+        builtin_compiler.builtin_bin,
         "Builtin.bin",
     );
 
@@ -2255,7 +2268,7 @@ pub fn build(b: *std.Build) void {
 
     // Copy builtin_indices.bin
     _ = write_compiled_builtins.addCopyFile(
-        .{ .cwd_relative = "zig-out/builtins/builtin_indices.bin" },
+        builtin_compiler.builtin_indices_bin,
         "builtin_indices.bin",
     );
 
@@ -2459,9 +2472,9 @@ pub fn build(b: *std.Build) void {
     };
 
     const run_builtin_compiler_force = createAndRunBuiltinCompiler(b, roc_modules, flag_enable_tracy, roc_files_force);
-    run_builtin_compiler_force.step.dependOn(&clean_out_step.step);
-    run_builtin_compiler_force.step.dependOn(clear_roc_cache_step);
-    rebuild_builtins_step.dependOn(&run_builtin_compiler_force.step);
+    run_builtin_compiler_force.run.step.dependOn(&clean_out_step.step);
+    run_builtin_compiler_force.run.step.dependOn(clear_roc_cache_step);
+    rebuild_builtins_step.dependOn(&run_builtin_compiler_force.run.step);
 
     // Add the compiled builtins module to roc exe and make it depend on the builtins being ready
     roc_exe.root_module.addImport("compiled_builtins", compiled_builtins_module);

--- a/src/build/builtin_compiler/main.zig
+++ b/src/build/builtin_compiler/main.zig
@@ -3,7 +3,7 @@
 //! This executable runs during `zig build` on the host machine to:
 //! 1. Parse and type-check the Builtin.roc module (which contains nested Bool, Try, Str, Dict, Set types)
 //! 2. Serialize the resulting ModuleEnv to a binary file
-//! 3. Output Builtin.bin to zig-out/builtins/ (which gets embedded in the roc binary)
+//! 3. Output Builtin.bin and builtin_indices.bin to paths provided by the build system
 
 const std = @import("std");
 const base = @import("base");
@@ -1265,8 +1265,12 @@ fn readFileAllocPath(gpa: Allocator, path: []const u8) ![]u8 {
 /// This runs during `zig build` on the host machine to generate .bin files
 /// that get embedded into the final roc executable.
 ///
-/// The build system passes the absolute path to Builtin.roc as the first argument for cache tracking;
-/// we honor that when present so the compiler works regardless of the current working directory.
+/// The build system passes:
+/// 1. the absolute path to Builtin.roc for cache tracking
+/// 2. the output path for Builtin.bin
+/// 3. the output path for builtin_indices.bin
+///
+/// We also keep project-relative defaults so manual runs still succeed.
 pub fn main() !void {
     var gpa_impl = std.heap.GeneralPurposeAllocator(.{}){};
     defer {
@@ -1280,9 +1284,11 @@ pub fn main() !void {
     const args = try std.process.argsAlloc(gpa);
     defer std.process.argsFree(gpa, args);
 
-    // Prefer the absolute path provided by the build system, but fall back to the
-    // project-relative path so manual runs (e.g. `zig build run`) still succeed.
+    // Prefer the explicit paths provided by the build system, but fall back to the
+    // project-relative defaults so manual runs still succeed.
     const builtin_src_path = if (args.len >= 2) args[1] else "src/build/roc/Builtin.roc";
+    const builtin_bin_path = if (args.len >= 3) args[2] else "zig-out/builtins/Builtin.bin";
+    const builtin_indices_path = if (args.len >= 4) args[3] else "zig-out/builtins/builtin_indices.bin";
 
     // Read the Builtin.roc source file at runtime
     // NOTE: We must free this source manually; CommonEnv.deinit() does not free the source.
@@ -1388,11 +1394,16 @@ pub fn main() !void {
     try builtin_env.common.setNodeIndexById(gpa, f64_ident, @intCast(@intFromEnum(f64_type_idx)));
     try builtin_env.common.setNodeIndexById(gpa, numeral_ident, @intCast(@intFromEnum(numeral_type_idx)));
 
-    // Create output directory
-    try std.fs.cwd().makePath("zig-out/builtins");
+    // Create output directories when needed.
+    if (std.fs.path.dirname(builtin_bin_path)) |dir| {
+        try std.fs.cwd().makePath(dir);
+    }
+    if (std.fs.path.dirname(builtin_indices_path)) |dir| {
+        try std.fs.cwd().makePath(dir);
+    }
 
     // Serialize the single Builtin module
-    try serializeModuleEnv(gpa, builtin_env, "zig-out/builtins/Builtin.bin");
+    try serializeModuleEnv(gpa, builtin_env, builtin_bin_path);
 
     // Create and serialize builtin indices
     const builtin_indices = BuiltinIndices{
@@ -1449,7 +1460,7 @@ pub fn main() !void {
     // This ensures BuiltinIndices stays in sync with the actual Builtin module content
     try validateBuiltinIndicesCompleteness(builtin_env, builtin_indices);
 
-    try serializeBuiltinIndices(builtin_indices, "zig-out/builtins/builtin_indices.bin");
+    try serializeBuiltinIndices(builtin_indices, builtin_indices_path);
 }
 
 /// Validates that BuiltinIndices contains all nominal type declarations in the Builtin module.

--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -49,6 +49,196 @@ fn runRoc(allocator: std.mem.Allocator, roc_file: []const u8, options: RunOption
     });
 }
 
+fn runDevBackendHostSelfTest(
+    allocator: std.mem.Allocator,
+    roc_file: []const u8,
+    self_test_flag: []const u8,
+) !std.process.Child.RunResult {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const tmp_path = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(tmp_path);
+
+    const output_path = try std.fs.path.join(allocator, &.{ tmp_path, "fx_dev_host_test" });
+    defer allocator.free(output_path);
+
+    const cache_path = try std.fs.path.join(allocator, &.{ tmp_path, "roc-cache" });
+    defer allocator.free(cache_path);
+    try tmp_dir.dir.makePath("roc-cache");
+
+    const output_arg = try std.fmt.allocPrint(allocator, "--output={s}", .{output_path});
+    defer allocator.free(output_arg);
+
+    var env_map = try std.process.getEnvMap(allocator);
+    defer env_map.deinit();
+    try env_map.put("ROC_CACHE_DIR", cache_path);
+
+    const build_result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &[_][]const u8{
+            roc_binary_path,
+            "build",
+            "--backend=dev",
+            "--no-cache",
+            output_arg,
+            roc_file,
+        },
+        .env_map = &env_map,
+        .max_output_bytes = 10 * 1024 * 1024,
+    });
+    defer allocator.free(build_result.stdout);
+    defer allocator.free(build_result.stderr);
+
+    switch (build_result.term) {
+        .Exited => |code| {
+            if (code != 0) {
+                std.debug.print("roc build --backend=dev failed with exit code {}\n", .{code});
+                std.debug.print("STDOUT: {s}\n", .{build_result.stdout});
+                std.debug.print("STDERR: {s}\n", .{build_result.stderr});
+                return error.DevBackendBuildFailed;
+            }
+        },
+        else => {
+            std.debug.print("roc build --backend=dev terminated abnormally: {}\n", .{build_result.term});
+            std.debug.print("STDOUT: {s}\n", .{build_result.stdout});
+            std.debug.print("STDERR: {s}\n", .{build_result.stderr});
+            return error.DevBackendBuildFailed;
+        },
+    }
+
+    return try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &[_][]const u8{
+            output_path,
+            self_test_flag,
+        },
+        .max_output_bytes = 10 * 1024 * 1024,
+    });
+}
+
+fn expectInterpreterRuntimeStackOverflow() !void {
+    const allocator = testing.allocator;
+
+    const run_result = try runRoc(allocator, "test/fx/stack_overflow_runtime.roc", .{});
+    defer allocator.free(run_result.stdout);
+    defer allocator.free(run_result.stderr);
+
+    switch (run_result.term) {
+        .Exited => |code| {
+            if (code != 1) {
+                std.debug.print("Unexpected interpreter exit code: {}\n", .{code});
+                std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+                return error.UnexpectedExitCode;
+            }
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "Roc crashed:") != null);
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "This Roc program overflowed its stack memory") != null);
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "divided by zero") == null);
+        },
+        else => {
+            std.debug.print("Unexpected interpreter termination: {}\n", .{run_result.term});
+            std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+            return error.UnexpectedTermination;
+        },
+    }
+}
+
+fn expectDevRuntimeStackOverflow() !void {
+    const allocator = testing.allocator;
+
+    const run_result = try runDevBackendHostSelfTest(
+        allocator,
+        "test/fx/hello_world.roc",
+        "--host-test-stack-overflow",
+    );
+    defer allocator.free(run_result.stdout);
+    defer allocator.free(run_result.stderr);
+
+    switch (run_result.term) {
+        .Exited => |code| {
+            if (code != 134) {
+                std.debug.print("Unexpected dev exit code: {}\n", .{code});
+                std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+                return error.UnexpectedExitCode;
+            }
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "This Roc application overflowed its stack memory and crashed.") != null);
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "divided by zero") == null);
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "Roc crashed:") == null);
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "panic:") == null);
+        },
+        .Signal => |sig| {
+            std.debug.print("Host self-test crashed with signal {}\n", .{sig});
+            std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+            return error.StackOverflowNotHandled;
+        },
+        else => {
+            std.debug.print("Unexpected dev termination: {}\n", .{run_result.term});
+            return error.UnexpectedTermination;
+        },
+    }
+}
+
+fn expectInterpreterRuntimeDivisionByZero() !void {
+    const allocator = testing.allocator;
+
+    const run_result = try runRoc(allocator, "test/fx/division_by_zero.roc", .{});
+    defer allocator.free(run_result.stdout);
+    defer allocator.free(run_result.stderr);
+
+    switch (run_result.term) {
+        .Exited => |code| {
+            if (code != 1) {
+                std.debug.print("Unexpected interpreter exit code: {}\n", .{code});
+                std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+                return error.UnexpectedExitCode;
+            }
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "Roc crashed:") != null);
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "DivisionByZero") != null);
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "overflowed its stack memory") == null);
+        },
+        else => {
+            std.debug.print("Unexpected interpreter termination: {}\n", .{run_result.term});
+            std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+            return error.UnexpectedTermination;
+        },
+    }
+}
+
+fn expectDevRuntimeDivisionByZero() !void {
+    const allocator = testing.allocator;
+
+    const run_result = try runDevBackendHostSelfTest(
+        allocator,
+        "test/fx/hello_world.roc",
+        "--host-test-division-by-zero",
+    );
+    defer allocator.free(run_result.stdout);
+    defer allocator.free(run_result.stderr);
+
+    switch (run_result.term) {
+        .Exited => |code| {
+            if (code != 136) {
+                std.debug.print("Unexpected dev exit code: {}\n", .{code});
+                std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+                return error.UnexpectedExitCode;
+            }
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "This Roc application divided by zero and crashed.") != null);
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "overflowed its stack memory") == null);
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "Roc crashed:") == null);
+            try testing.expect(std.mem.indexOf(u8, run_result.stderr, "panic:") == null);
+        },
+        .Signal => |sig| {
+            std.debug.print("Host self-test crashed with signal {}\n", .{sig});
+            std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+            return error.DivisionByZeroNotHandled;
+        },
+        else => {
+            std.debug.print("Unexpected dev termination: {}\n", .{run_result.term});
+            return error.UnexpectedTermination;
+        },
+    }
+}
+
 /// Helper to check if a run result indicates success (exit code 0)
 fn checkSuccess(result: std.process.Child.RunResult) !void {
     // Check for GPA (General Purpose Allocator) errors in stderr
@@ -984,101 +1174,19 @@ test "fx platform repeating pattern segfault" {
 }
 
 test "fx platform runtime stack overflow" {
-    // Tests that stack overflow in a running Roc program is caught and reported
-    // with a helpful error message instead of crashing with a raw signal.
-    //
-    // The Roc program contains an infinitely recursive function that will
-    // overflow the stack at runtime. Once proper stack overflow handling is
-    // implemented in the host/platform, this test will pass.
-    const allocator = testing.allocator;
-
-    const run_result = try runRoc(allocator, "test/fx/stack_overflow_runtime.roc", .{});
-    defer allocator.free(run_result.stdout);
-    defer allocator.free(run_result.stderr);
-
-    // Stack overflow can be caught by either:
-    // 1. The Roc interpreter (exit code 1, "overflowed its stack memory" message) - most common
-    // 2. The SIGABRT signal handler (exit code 134) - if native stack overflow handling is used
-    switch (run_result.term) {
-        .Exited => |code| {
-            if (code == 134) {
-                // Stack overflow was caught by native signal handler
-                // Verify the helpful error message was printed
-                try testing.expect(std.mem.indexOf(u8, run_result.stderr, "overflowed its stack memory") != null);
-            } else if (code == 1) {
-                // Stack overflow was caught by the interpreter - this is the expected case
-                // The interpreter detects excessive work stack depth and reports the error
-                try testing.expect(std.mem.indexOf(u8, run_result.stderr, "overflowed its stack memory") != null);
-            } else if (code == 139) {
-                // Exit code 139 = 128 + 11 (SIGSEGV) - stack overflow was NOT handled
-                // The Roc program crashed with a segfault that wasn't caught
-                std.debug.print("\n", .{});
-                std.debug.print("Stack overflow handling NOT YET IMPLEMENTED for Roc programs.\n", .{});
-                std.debug.print("Process crashed with SIGSEGV (exit code 139).\n", .{});
-                std.debug.print("Expected: exit code 1 or 134 with stack overflow message\n", .{});
-                return error.StackOverflowNotHandled;
-            } else {
-                std.debug.print("Unexpected exit code: {}\n", .{code});
-                std.debug.print("STDERR: {s}\n", .{run_result.stderr});
-                return error.UnexpectedExitCode;
-            }
-        },
-        .Signal => |sig| {
-            // Process was killed directly by a signal (likely SIGSEGV = 11).
-            std.debug.print("\n", .{});
-            std.debug.print("Stack overflow handling NOT YET IMPLEMENTED for Roc programs.\n", .{});
-            std.debug.print("Process was killed by signal: {}\n", .{sig});
-            std.debug.print("Expected: exit code 1 or 134 with stack overflow message\n", .{});
-            return error.StackOverflowNotHandled;
-        },
-        else => {
-            std.debug.print("Unexpected termination: {}\n", .{run_result.term});
-            return error.UnexpectedTermination;
-        },
-    }
+    // Keep coverage for both paths:
+    // 1. The normal interpreter path on the real runtime sample.
+    // 2. The compiled dev-backend host path via the FX host self-test hook.
+    try expectInterpreterRuntimeStackOverflow();
+    try expectDevRuntimeStackOverflow();
 }
 
 test "fx platform runtime division by zero" {
-    // Tests that division by zero in a running Roc program is caught and reported
-    // with a helpful error message instead of crashing with a raw signal.
-    //
-    // The error can be caught by either:
-    // 1. The Roc interpreter (exit code 1, "DivisionByZero" message) - most common
-    // 2. The SIGFPE signal handler (exit code 136, "divided by zero" message) - native code
-    const allocator = testing.allocator;
-
-    // The Roc program uses a var to prevent compile-time constant folding
-    const run_result = try runRoc(allocator, "test/fx/division_by_zero.roc", .{});
-    defer allocator.free(run_result.stdout);
-    defer allocator.free(run_result.stderr);
-
-    switch (run_result.term) {
-        .Exited => |code| {
-            if (code == 136) {
-                // Division by zero was caught by the SIGFPE handler (native code)
-                try testing.expect(std.mem.indexOf(u8, run_result.stderr, "divided by zero") != null);
-            } else if (code == 1) {
-                // Division by zero was caught by the interpreter - this is the expected case
-                // The interpreter catches it and reports "DivisionByZero"
-                try testing.expect(std.mem.indexOf(u8, run_result.stderr, "DivisionByZero") != null);
-            } else {
-                std.debug.print("Unexpected exit code: {}\n", .{code});
-                std.debug.print("STDERR: {s}\n", .{run_result.stderr});
-                return error.UnexpectedExitCode;
-            }
-        },
-        .Signal => |sig| {
-            // Process was killed directly by a signal without being caught
-            std.debug.print("\n", .{});
-            std.debug.print("Division by zero was not caught!\n", .{});
-            std.debug.print("Process was killed by signal: {}\n", .{sig});
-            return error.DivisionByZeroNotHandled;
-        },
-        else => {
-            std.debug.print("Unexpected termination: {}\n", .{run_result.term});
-            return error.UnexpectedTermination;
-        },
-    }
+    // Some architectures do not trap on integer divide by zero in generated code,
+    // so the dev-backend half uses the host self-test hook to exercise the host's
+    // arithmetic handler directly while still keeping the real interpreter sample.
+    try expectInterpreterRuntimeDivisionByZero();
+    try expectDevRuntimeDivisionByZero();
 }
 
 test "fx platform inline expect fails as expected" {

--- a/src/eval/builtin_loading.zig
+++ b/src/eval/builtin_loading.zig
@@ -30,6 +30,10 @@ pub const LoadedModule = struct {
 
 /// Deserialize BuiltinIndices from the binary data generated at build time
 pub fn deserializeBuiltinIndices(gpa: std.mem.Allocator, bin_data: []const u8) !can.CIR.BuiltinIndices {
+    if (bin_data.len < @sizeOf(can.CIR.BuiltinIndices)) {
+        return error.Internal;
+    }
+
     // Copy to properly aligned memory
     const aligned_buffer = try gpa.alignedAlloc(u8, @enumFromInt(@alignOf(can.CIR.BuiltinIndices)), bin_data.len);
     defer gpa.free(aligned_buffer);
@@ -41,6 +45,10 @@ pub fn deserializeBuiltinIndices(gpa: std.mem.Allocator, bin_data: []const u8) !
 
 /// Load a compiled ModuleEnv from embedded binary data
 pub fn loadCompiledModule(gpa: std.mem.Allocator, bin_data: []const u8, module_name: []const u8, source: []const u8) !LoadedModule {
+    if (bin_data.len < @sizeOf(ModuleEnv.Serialized)) {
+        return error.Internal;
+    }
+
     // Copy the embedded data to properly aligned memory
     // CompactWriter requires specific alignment for serialization
     const CompactWriter = collections.CompactWriter;
@@ -60,4 +68,11 @@ pub fn loadCompiledModule(gpa: std.mem.Allocator, bin_data: []const u8, module_n
         .buffer = buffer,
         .gpa = gpa,
     };
+}
+
+test "loadCompiledModule rejects empty data" {
+    try std.testing.expectError(
+        error.Internal,
+        loadCompiledModule(std.testing.allocator, "", "Builtin", ""),
+    );
 }

--- a/test/fx/platform/host.zig
+++ b/test/fx/platform/host.zig
@@ -148,6 +148,58 @@ fn handleRocArithmeticError() noreturn {
     }
 }
 
+const HostSelfTest = enum {
+    none,
+    stack_overflow,
+    division_by_zero,
+};
+
+fn installRuntimeSignalHandlers() void {
+    _ = builtins.handlers.install(handleRocStackOverflow, handleRocAccessViolation, handleRocArithmeticError);
+}
+
+fn triggerSelfTest(mode: HostSelfTest) noreturn {
+    installRuntimeSignalHandlers();
+
+    switch (mode) {
+        .stack_overflow => triggerSelfTestStackOverflow(),
+        .division_by_zero => triggerSelfTestDivisionByZero(),
+        .none => unreachable,
+    }
+}
+
+fn triggerSelfTestStackOverflow() noreturn {
+    _ = selfTestStackOverflow(0);
+    unreachable;
+}
+
+fn selfTestStackOverflow(depth: usize) usize {
+    var padding: [4096]u8 = undefined;
+    @memset(&padding, @as(u8, @truncate(depth)));
+    std.mem.doNotOptimizeAway(&padding);
+
+    return selfTestStackOverflow(depth +% 1) + padding[0];
+}
+
+fn triggerSelfTestDivisionByZero() noreturn {
+    if (comptime builtin.os.tag == .windows) {
+        const DWORD = u32;
+        const ULONG_PTR = usize;
+        const EXCEPTION_INT_DIVIDE_BY_ZERO: DWORD = 0xC0000094;
+
+        const kernel32 = struct {
+            extern "kernel32" fn RaiseException(dwExceptionCode: DWORD, dwExceptionFlags: DWORD, nNumberOfArguments: DWORD, lpArguments: ?[*]const ULONG_PTR) callconv(.winapi) noreturn;
+        };
+
+        kernel32.RaiseException(EXCEPTION_INT_DIVIDE_BY_ZERO, 0, 0, null);
+    } else if (comptime builtin.os.tag != .wasi) {
+        posix.raise(posix.SIG.FPE) catch {};
+        posix.exit(136);
+    } else {
+        std.process.exit(136);
+    }
+}
+
 /// Type of IO operation in test spec
 const EffectType = enum(u8) {
     stdin_input, // 0<
@@ -556,6 +608,7 @@ fn main(argc: c_int, argv: [*][*:0]u8) callconv(.c) c_int {
     // Parse --test or --test-verbose argument
     var test_spec: ?[]const u8 = null;
     var test_verbose: bool = false;
+    var self_test: HostSelfTest = .none;
     var i: usize = 1;
     const arg_count: usize = @intCast(argc);
     const stderr_file: std.fs.File = .stderr();
@@ -578,13 +631,21 @@ fn main(argc: c_int, argv: [*][*:0]u8) callconv(.c) c_int {
                 stderr_file.writeAll("Error: --test requires a spec argument\n") catch {};
                 return 1;
             }
+        } else if (std.mem.eql(u8, arg, "--host-test-stack-overflow")) {
+            self_test = .stack_overflow;
+        } else if (std.mem.eql(u8, arg, "--host-test-division-by-zero")) {
+            self_test = .division_by_zero;
         } else if (arg.len >= 2 and arg[0] == '-' and arg[1] == '-') {
             stderr_file.writeAll("Error: unknown flag '") catch {};
             stderr_file.writeAll(arg) catch {};
             stderr_file.writeAll("'\n") catch {};
-            stderr_file.writeAll("Usage: <app> [--test <spec>] [--test-verbose <spec>]\n") catch {};
+            stderr_file.writeAll("Usage: <app> [--test <spec>] [--test-verbose <spec>] [--host-test-stack-overflow] [--host-test-division-by-zero]\n") catch {};
             return 1;
         }
+    }
+
+    if (self_test != .none) {
+        triggerSelfTest(self_test);
     }
 
     const exit_code = platform_main(test_spec, test_verbose) catch |err| {
@@ -906,7 +967,7 @@ const hosted_function_ptrs = [_]builtins.host_abi.HostedFn{
 fn platform_main(test_spec: ?[]const u8, test_verbose: bool) !c_int {
     // Install signal handlers for stack overflow, access violations, and division by zero
     // This allows us to display helpful error messages instead of crashing
-    _ = builtins.handlers.install(handleRocStackOverflow, handleRocAccessViolation, handleRocArithmeticError);
+    installRuntimeSignalHandlers();
 
     var host_env = HostEnv{
         .gpa = std.heap.GeneralPurposeAllocator(.{ .safety = true }){},


### PR DESCRIPTION
## Summary
- make the FX runtime tests cover both the interpreter path and the dev-host signal-handler path for stack overflow and division by zero
- teach the FX test host to install and exercise distinct runtime handlers for stack overflow vs integer division by zero
- fix builtin compiler output tracking so embedded builtins are not read from stale zero-byte cache artifacts, and fail gracefully if builtin data is empty

## Testing
- zig build roc
- ./zig-out/bin/roc test/fx/hello_world.roc
- ./zig-out/bin/roc test/fx/stack_overflow_runtime.roc
- ./zig-out/bin/roc test/fx/division_by_zero.roc
- ./zig-out/bin/roc --backend=dev --no-cache test/fx/hello_world.roc
- zig build test -- --test-filter "fx platform runtime"
- zig build test -- --test-filter "loadCompiledModule rejects empty data"

Closes #9260