### PR TITLE
Fix dev backend SIGABRT with --allow-errors on type-erroneous effectful calls

### DIFF
--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -917,6 +917,40 @@ test "run with --allow-errors attempts execution despite type errors" {
     // We just verify it didn't abort during type checking
 }
 
+test "run with --allow-errors handles type mismatch in function args" {
+    // Regression test for https://github.com/roc-lang/roc/issues/9263
+    // The dev backend crashed (SIGABRT) when --allow-errors was used on code
+    // where a type mismatch in a function argument caused the return type to
+    // become an error type variable nested inside a function type.
+    const allocator = testing.allocator;
+
+    const run_result = try util.runRocCommand(allocator, &.{
+        "--opt=dev",
+        "test/fx/allow_errors_type_mismatch.roc",
+        "--allow-errors",
+    });
+    defer allocator.free(run_result.stdout);
+    defer allocator.free(run_result.stderr);
+
+    // Should report the type mismatch
+    try testing.expect(std.mem.indexOf(u8, run_result.stderr, "TYPE MISMATCH") != null);
+
+    // Must not crash with SIGABRT — the process should exit cleanly (or with
+    // a runtime error exit code), not be killed by a signal.
+    switch (run_result.term) {
+        .Exited => {},
+        .Signal => |sig| {
+            std.debug.print("CRASH: process killed by signal {}\n", .{sig});
+            std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+            return error.TestUnexpectedResult;
+        },
+        else => |term| {
+            std.debug.print("Unexpected termination: {}\n", .{term});
+            return error.TestUnexpectedResult;
+        },
+    }
+}
+
 test "run allows warnings without blocking execution" {
     // Tests that warnings don't block execution (they never should)
     const allocator = testing.allocator;

--- a/src/mir/Monotype.zig
+++ b/src/mir/Monotype.zig
@@ -394,9 +394,12 @@ pub const Store = struct {
             .structure => |flat_type| {
                 return try self.fromFlatType(allocator, types_store, resolved.var_, flat_type, common_idents, specializations, nominal_cycle_breakers, scratches);
             },
-            // Error types are caught in lowerExpr before resolveMonotype;
-            // reaching here means a compiler bug in an earlier phase.
-            .err => unreachable,
+            // Error types can appear nested inside function types (as argument
+            // or return types) when --allow-errors is used. The guard in
+            // lowerExpr only catches top-level error types, so we need to handle
+            // them here too. Return unit as a safe placeholder so lowering can
+            // continue and the runtime-error path is hit at runtime.
+            .err => return self.unit_idx,
         };
     }
 

--- a/test/fx/allow_errors_type_mismatch.roc
+++ b/test/fx/allow_errors_type_mismatch.roc
@@ -1,0 +1,9 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+main! = || {
+    x : U8
+    x = 1
+    Stdout.line!(x)
+}


### PR DESCRIPTION
When using `--allow-errors` on code with a type mismatch in a function argument (e.g., passing `U8` to a function expecting `Str`), the dev backend crashed with SIGABRT. The interpreter handled the same code gracefully.

- The type checker marks poisoned return types with `.err` type variables when errors propagate through function types.
- The guard in `lowerExpr` only catches top-level `.err` types; it does not protect against `.err` appearing nested inside function types (argument or return types).
- `Monotype.fromTypeVar` hit `.err => unreachable` when processing the return type of the effectful function, causing the crash.
- Fix: handle `.err` in `fromTypeVar` by returning `unit_idx`, consistent with how unresolvable flex/rigid type variables are already handled. Without `--allow-errors`, the compiler aborts before lowering; with `--allow-errors`, this is a deliberate fallback.
- Added a regression test at `test/fx/allow_errors_type_mismatch.roc` and a corresponding fx platform test that verifies the process exits cleanly (not killed by a signal).

Fixes #9263

Co-authored by claude-sonnet-4-6