### PR TITLE
Comment out debug print

### DIFF
--- a/src/layout/store_test.zig
+++ b/src/layout/store_test.zig
@@ -762,7 +762,7 @@ test "zst combinatorics matrix for nested singleton ordinary-data wrappers" {
     try lt.initLayoutStore();
 
     for (cases) |case| {
-        std.debug.print("running zst combinatorics case: {s}\n", .{case.name});
+        // std.debug.print("running zst combinatorics case: {s}\n", .{case.name});
 
         const type_var = try buildWrappedZstCase(&lt, builtin_module_idx, case.leaf, case.wrappers);
         try expectTypeAndMonotypeResolversAgree(testing.allocator, &lt, type_var);


### PR DESCRIPTION
This adds noise to the test output, I don't think this was left in intentionally.