### PR TITLE
fix: add hints for Num.to_str and Inspect.to_str errors

### DIFF
--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -825,6 +825,24 @@ pub fn diagnosticToReport(self: *Self, diagnostic: CIR.Diagnostic, allocator: st
                 self.getLineStartsAll(),
             );
 
+            if (std.mem.eql(u8, ident_name, "Num.to_str")) {
+                try report.document.addLineBreak();
+                try report.document.addLineBreak();
+                try report.document.addAnnotated("Hint:", .emphasized);
+                try report.document.addReflowingText(" Instead of ");
+                try report.document.addInlineCode("Num.to_str(value)");
+                try report.document.addReflowingText(", use method syntax: ");
+                try report.document.addInlineCode("value.to_str()");
+            } else if (std.mem.eql(u8, ident_name, "Inspect.to_str")) {
+                try report.document.addLineBreak();
+                try report.document.addLineBreak();
+                try report.document.addAnnotated("Hint:", .emphasized);
+                try report.document.addInlineCode(" Inspect.to_str");
+                try report.document.addReflowingText(" has been renamed to ");
+                try report.document.addInlineCode("Str.inspect");
+                try report.document.addReflowingText(".");
+            }
+
             break :blk report;
         },
         .exposed_but_not_implemented => |data| blk: {


### PR DESCRIPTION
Closes #9192
Closes #9191

When a user writes `Num.to_str(value)` or `Inspect.to_str(value)`, the current error just says the identifier doesn't exist. This adds a hint after the error pointing them to the right syntax:

**`Num.to_str`**: suggests method syntax `value.to_str()`

**`Inspect.to_str`**: suggests the renamed function `Str.inspect`

Follows the existing hint pattern used elsewhere in `ModuleEnv.zig` (e.g. `addAnnotated("Hint:", .emphasized)`).