### PR TITLE
Fix builtin docs gen type mismatch

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -1338,6 +1338,21 @@ fn checkFileInternal(self: *Self, skip_numeric_defaults: bool) std.mem.Allocator
 
     std.debug.assert(env.rank() == .generalized);
 
+    // When checking the Builtin module directly (e.g., `roc check Builtin.roc`),
+    // the normal pipeline assigns a package-qualified module name like "module.Builtin".
+    // But the pre-compiled Builtin binary uses the unqualified "Builtin" as origin_module
+    // for all its types. This causes type mismatches when locally-defined types (using
+    // "module.Builtin") are unified with types from the pre-compiled module (using "Builtin").
+    // Fix: use the unqualified "Builtin" to match the pre-compiled module's convention.
+    if (self.builtin_ctx.builtin_module != null and
+        self.cir.display_module_name_idx.eql(self.cir.idents.builtin_module))
+    {
+        self.builtin_ctx.module_name = self.cir.idents.builtin_module;
+        // Also update qualified_module_ident so that opaque type checks
+        // (canLiftInner) allow pattern matching on types defined in this module.
+        self.cir.qualified_module_ident = self.cir.idents.builtin_module;
+    }
+
     // Copy builtin types (Bool, Try) into this module's type store
     // Note that bool_var and try_var will have generalized rank
     try self.copyBuiltinTypes();

--- a/src/cli/test/roc_subcommands.zig
+++ b/src/cli/test/roc_subcommands.zig
@@ -1544,3 +1544,17 @@ test "echo platform: roc test all_syntax_test.roc passes" {
     const has_passed = std.mem.indexOf(u8, result.stdout, "passed") != null;
     try std.testing.expect(has_passed);
 }
+
+test "roc docs Builtin.roc succeeds" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    const result = try util.runRoc(gpa, &.{ "docs", "--no-cache" }, "src/build/roc/Builtin.roc");
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try util.checkSuccess(result);
+
+    const has_generated = std.mem.indexOf(u8, result.stdout, "Generated docs for") != null;
+    try testing.expect(has_generated);
+}


### PR DESCRIPTION
When running `roc check Builtin.roc` or `roc docs Builtin.roc`, the normal pipeline assigns a package-qualified name "module.Builtin" to the module, but the pre-compiled Builtin binary uses the unqualified "Builtin" as origin_module. This mismatch caused unifyNominalType and canLiftInner to fail, producing confusing errors like "Bool != Bool".

Fix by detecting when the Builtin module is checked directly and overriding the module identity to match the pre-compiled convention.