### PR TITLE
Better test error outputs

### DIFF
--- a/src/cli/ansi_term.zig
+++ b/src/cli/ansi_term.zig
@@ -3,9 +3,11 @@ const std = @import("std");
 
 const CSI = "\x1B[";
 
-/// ANSI color escape sequences.
+/// ANSI escape sequence to set foreground color to green.
 pub const green = "\x1B[32m";
+/// ANSI escape sequence to set foreground color to red.
 pub const red = "\x1B[31m";
+/// ANSI escape sequence to reset all text attributes.
 pub const reset = "\x1B[0m";
 
 /// ASCII DEL character, used as backspace in terminals.

--- a/src/cli/ansi_term.zig
+++ b/src/cli/ansi_term.zig
@@ -3,6 +3,11 @@ const std = @import("std");
 
 const CSI = "\x1B[";
 
+/// ANSI color escape sequences.
+pub const green = "\x1B[32m";
+pub const red = "\x1B[31m";
+pub const reset = "\x1B[0m";
+
 /// ASCII DEL character, used as backspace in terminals.
 pub const BACKSPACE: u8 = 127;
 /// ANSI escape sequence identifier for the up arrow key.

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -5999,38 +5999,29 @@ fn rocTest(ctx: *CliContext, args: cli_args.TestArgs) !void {
                         .passed => try stdout.print("\x1b[32mPASS\x1b[0m: {s}:{}\n", .{ mr.path, region_info.start_line_idx + 1 }),
                         .skipped => try stdout.print("\x1b[33mSKIP\x1b[0m: {s}:{}\n", .{ mr.path, region_info.start_line_idx + 1 }),
                         .failed => {
+                            // get error code snippet from source
                             const src = mr.env.getSourceAll();
                             const error_src = src[result.region.start.offset..result.region.end.offset];
 
-                            var is_empty_line = true;
-                            var last_line_start: ?usize = null;
-                            var i = result.region.start.offset - 1;
-
-                            while (i > 0) : (i -= 1) {
-                                const ch = src[i];
-
-                                switch (ch) {
-                                    ' ', '\t' => {},
-                                    '\n' => {
-                                        if (!is_empty_line) {
-                                            break;
-                                        }
-                                        last_line_start = i;
-                                    },
-                                    else => {
-                                        is_empty_line = false;
-                                    },
+                            // check if the previous line is a doc comment
+                            const doc_comment: ?[]const u8 = blk: {
+                                const line_starts = mr.env.getLineStarts();
+                                const curr_line_start_idx = region_info.start_line_idx;
+                                const curr_line_start = line_starts[curr_line_start_idx];
+                                const prev_line_start = if (curr_line_start_idx > 0) line_starts[curr_line_start_idx - 1] else break :blk null;
+                                if (std.mem.startsWith(u8, src[prev_line_start..], "##")) {
+                                    break :blk std.mem.trim(u8, src[prev_line_start + 2 .. curr_line_start - 1], " ");
                                 }
-                            }
-
-                            const prev_line_start = i + 1;
-                            var doc_comment_start: ?usize = null;
-                            if (src[prev_line_start] == '#' and src[prev_line_start + 1] == '#') {
-                                doc_comment_start = prev_line_start + 2;
-                            }
+                                break :blk null;
+                            };
 
                             try stderr.print("\n\x1b[31mFAIL\x1b[0m: {s}", .{mr.path});
-                            try stderr.print("\x1b[91m\n𜸖\t", .{});
+                            if (doc_comment) |comment| {
+                                try stderr.print("\n\x1b[0m{s}", .{comment});
+                            }
+
+                            try stderr.print("\x1b[31m\n𜸖\t", .{});
+
                             for (error_src) |ch| {
                                 if (ch == '\n') {
                                     try stderr.print("\n\u{2502}\u{00A0}\u{00A0}\t", .{});
@@ -6038,17 +6029,14 @@ fn rocTest(ctx: *CliContext, args: cli_args.TestArgs) !void {
                                     try stderr.print("{c}", .{ch});
                                 }
                             }
-                            try stderr.print("\n\u{2514}\u{2500}> line {}:{}", .{ region_info.start_line_idx + 1, region_info.start_col_idx + 1 });
-                            if (doc_comment_start) |start| {
-                                try stderr.print("{s}\n", .{src[start..last_line_start.?]});
-                            } else {
-                                try stderr.print("\n", .{});
-                            }
+                            try stderr.print("\n\u{2514}\u{2500}> [line {}:{}]", .{ region_info.start_line_idx + 1, region_info.start_col_idx + 1 });
 
                             try stderr.print("\x1b[31m", .{});
+
                             if (result.error_msg) |msg| {
                                 try stderr.print(" - {s}", .{msg});
                             }
+
                             try stderr.print("\x1b[0m", .{});
                             try stderr.print("\n", .{});
                         },
@@ -6061,7 +6049,46 @@ fn rocTest(ctx: *CliContext, args: cli_args.TestArgs) !void {
                 for (mr.results) |result| {
                     if (result.result == .failed) {
                         const region_info = mr.env.calcRegionInfo(result.region);
-                        try stderr.print("\x1b[31mFAIL\x1b[0m: {s}:{}\n", .{ mr.path, region_info.start_line_idx + 1 });
+                        // get error code snippet from source
+                        const src = mr.env.getSourceAll();
+                        const error_src = src[result.region.start.offset..result.region.end.offset];
+
+                        // check if the previous line is a doc comment
+                        const doc_comment: ?[]const u8 = blk: {
+                            const line_starts = mr.env.getLineStarts();
+                            const curr_line_start_idx = region_info.start_line_idx;
+                            const curr_line_start = line_starts[curr_line_start_idx];
+                            const prev_line_start = if (curr_line_start_idx > 0) line_starts[curr_line_start_idx - 1] else break :blk null;
+                            if (std.mem.startsWith(u8, src[prev_line_start..], "##")) {
+                                break :blk std.mem.trim(u8, src[prev_line_start + 2 .. curr_line_start - 1], " ");
+                            }
+                            break :blk null;
+                        };
+
+                        try stderr.print("\n\x1b[31mFAIL\x1b[0m: {s}", .{mr.path});
+                        if (doc_comment) |comment| {
+                            try stderr.print("\n\x1b[0m{s}", .{comment});
+                        }
+
+                        try stderr.print("\x1b[31m\n𜸖\t", .{});
+
+                        for (error_src) |ch| {
+                            if (ch == '\n') {
+                                try stderr.print("\n\u{2502}\u{00A0}\u{00A0}\t", .{});
+                            } else {
+                                try stderr.print("{c}", .{ch});
+                            }
+                        }
+                        try stderr.print("\n\u{2514}\u{2500}> [line {}:{}]", .{ region_info.start_line_idx + 1, region_info.start_col_idx + 1 });
+
+                        try stderr.print("\x1b[31m", .{});
+
+                        if (result.error_msg) |msg| {
+                            try stderr.print(" - {s}", .{msg});
+                        }
+
+                        try stderr.print("\x1b[0m", .{});
+                        try stderr.print("\n", .{});
                     }
                 }
             }

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -5999,10 +5999,57 @@ fn rocTest(ctx: *CliContext, args: cli_args.TestArgs) !void {
                         .passed => try stdout.print("\x1b[32mPASS\x1b[0m: {s}:{}\n", .{ mr.path, region_info.start_line_idx + 1 }),
                         .skipped => try stdout.print("\x1b[33mSKIP\x1b[0m: {s}:{}\n", .{ mr.path, region_info.start_line_idx + 1 }),
                         .failed => {
-                            try stderr.print("\x1b[31mFAIL\x1b[0m: {s}:{}", .{ mr.path, region_info.start_line_idx + 1 });
+                            const src = mr.env.getSourceAll();
+                            const error_src = src[result.region.start.offset..result.region.end.offset];
+
+                            var is_empty_line = true;
+                            var last_line_start: ?usize = null;
+                            var i = result.region.start.offset - 1;
+
+                            while (i > 0) : (i -= 1) {
+                                const ch = src[i];
+
+                                switch (ch) {
+                                    ' ', '\t' => {},
+                                    '\n' => {
+                                        if (!is_empty_line) {
+                                            break;
+                                        }
+                                        last_line_start = i;
+                                    },
+                                    else => {
+                                        is_empty_line = false;
+                                    },
+                                }
+                            }
+
+                            const prev_line_start = i + 1;
+                            var doc_comment_start: ?usize = null;
+                            if (src[prev_line_start] == '#' and src[prev_line_start + 1] == '#') {
+                                doc_comment_start = prev_line_start + 2;
+                            }
+
+                            try stderr.print("\n\x1b[31mFAIL\x1b[0m: {s}", .{mr.path});
+                            try stderr.print("\x1b[91m\n𜸖\t", .{});
+                            for (error_src) |ch| {
+                                if (ch == '\n') {
+                                    try stderr.print("\n\u{2502}\u{00A0}\u{00A0}\t", .{});
+                                } else {
+                                    try stderr.print("{c}", .{ch});
+                                }
+                            }
+                            try stderr.print("\n\u{2514}\u{2500}> line {}:{}", .{ region_info.start_line_idx + 1, region_info.start_col_idx + 1 });
+                            if (doc_comment_start) |start| {
+                                try stderr.print("{s}\n", .{src[start..last_line_start.?]});
+                            } else {
+                                try stderr.print("\n", .{});
+                            }
+
+                            try stderr.print("\x1b[31m", .{});
                             if (result.error_msg) |msg| {
                                 try stderr.print(" - {s}", .{msg});
                             }
+                            try stderr.print("\x1b[0m", .{});
                             try stderr.print("\n", .{});
                         },
                     }

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -46,6 +46,7 @@ const eval = @import("eval");
 const echo_platform = @import("echo_platform");
 const lsp = @import("lsp");
 const cli_repl = @import("repl.zig");
+const ansi_term = @import("ansi_term.zig");
 
 const cli_args = @import("cli_args.zig");
 const roc_target = @import("target.zig");
@@ -5321,7 +5322,7 @@ fn replayTestCache(
     } else {
         const total_tests = passed + failed;
         if (total_tests > 0) {
-            try stderr.print("Ran {} test(s): {} passed, {} failed in {d:.1}ms (cached)\n", .{ total_tests, passed, failed, elapsed_ms });
+            try stderr.print("Ran {} tests in {d:.1}ms (cached):\n    " ++ ansi_term.green ++ "{}" ++ ansi_term.reset ++ " passed\n    " ++ ansi_term.red ++ "{}" ++ ansi_term.reset ++ " failed\n", .{ total_tests, elapsed_ms, passed, failed });
         }
 
         if (args.verbose) {
@@ -5985,9 +5986,9 @@ fn rocTest(ctx: *CliContext, args: cli_args.TestArgs) !void {
         const total_tests = total_passed + total_failed + total_skipped;
         if (total_tests > 0) {
             if (total_skipped > 0) {
-                try stderr.print("Ran {} test(s): {} passed, {} failed, {} skipped in {d:.1}ms\n", .{ total_tests, total_passed, total_failed, total_skipped, elapsed_ms });
+                try stderr.print("Ran {} tests in {d:.1}ms:\n    " ++ ansi_term.green ++ "{}" ++ ansi_term.reset ++ " passed\n    " ++ ansi_term.red ++ "{}" ++ ansi_term.reset ++ " failed\n    {} skipped\n", .{ total_tests, elapsed_ms, total_passed, total_failed, total_skipped });
             } else {
-                try stderr.print("Ran {} test(s): {} passed, {} failed in {d:.1}ms\n", .{ total_tests, total_passed, total_failed, elapsed_ms });
+                try stderr.print("Ran {} tests in {d:.1}ms:\n    " ++ ansi_term.green ++ "{}" ++ ansi_term.reset ++ " passed\n    " ++ ansi_term.red ++ "{}" ++ ansi_term.reset ++ " failed\n", .{ total_tests, elapsed_ms, total_passed, total_failed });
             }
         }
 
@@ -6039,29 +6040,39 @@ fn printTestFailure(
         const prev_line_start = if (curr_line_start_idx > 0) line_starts[curr_line_start_idx - 1] else break :blk null;
         const prev_line = std.mem.trimLeft(u8, src[prev_line_start..curr_line_start], " ");
         if (std.mem.startsWith(u8, prev_line, "##")) {
-            break :blk std.mem.trim(u8, prev_line[2..], " \r\n");
+            break :blk std.mem.trimRight(u8, prev_line, " \r\n");
         }
         break :blk null;
     };
 
     try stderr.print("\n\x1b[31mFAIL\x1b[0m: {s}", .{path});
-    if (doc_comment) |comment| {
-        try stderr.print("\n{s}", .{comment});
-    }
 
-    try stderr.print("\x1b[31m\n\u{250c}\t", .{});
+    try stderr.print("\x1b[31m", .{});
+
+    // Calculate the width needed to right-align line numbers
+    const last_line_num: usize = region_info.end_line_idx + 1;
+    const num_width: usize = blk: {
+        var digits: usize = 0;
+        var n = last_line_num;
+        while (n > 0) : (n /= 10) digits += 1;
+        break :blk if (digits == 0) 1 else digits;
+    };
+
+    var line_num: usize = region_info.start_line_idx + 1;
+
+    if (doc_comment) |comment| {
+        line_num -= 1;
+        try stderr.print("\n{d:[num_width]} \u{2502} ", .{ .d = line_num, .num_width = num_width });
+        try stderr.print("{s}", .{comment});
+        line_num += 1;
+    }
 
     var lines = std.mem.splitScalar(u8, error_src, '\n');
-    var first = true;
     while (lines.next()) |line| {
-        if (!first) {
-            try stderr.print("\n\u{2502}\u{00A0}\u{00A0}\t", .{});
-        }
-        first = false;
+        try stderr.print("\n{d:[num_width]} \u{2502} ", .{ .d = line_num, .num_width = num_width });
         try stderr.print("{s}", .{line});
+        line_num += 1;
     }
-
-    try stderr.print("\n\u{2514}\u{2500}> [line {}:{}]", .{ region_info.start_line_idx + 1, region_info.start_col_idx + 1 });
 
     if (error_msg) |msg| {
         try stderr.print("\x1b[31m - {s}", .{msg});

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -5998,97 +5998,17 @@ fn rocTest(ctx: *CliContext, args: cli_args.TestArgs) !void {
                     switch (result.result) {
                         .passed => try stdout.print("\x1b[32mPASS\x1b[0m: {s}:{}\n", .{ mr.path, region_info.start_line_idx + 1 }),
                         .skipped => try stdout.print("\x1b[33mSKIP\x1b[0m: {s}:{}\n", .{ mr.path, region_info.start_line_idx + 1 }),
-                        .failed => {
-                            // get error code snippet from source
-                            const src = mr.env.getSourceAll();
-                            const error_src = src[result.region.start.offset..result.region.end.offset];
-
-                            // check if the previous line is a doc comment
-                            const doc_comment: ?[]const u8 = blk: {
-                                const line_starts = mr.env.getLineStarts();
-                                const curr_line_start_idx = region_info.start_line_idx;
-                                const curr_line_start = line_starts[curr_line_start_idx];
-                                const prev_line_start = if (curr_line_start_idx > 0) line_starts[curr_line_start_idx - 1] else break :blk null;
-                                if (std.mem.startsWith(u8, src[prev_line_start..], "##")) {
-                                    break :blk std.mem.trim(u8, src[prev_line_start + 2 .. curr_line_start - 1], " ");
-                                }
-                                break :blk null;
-                            };
-
-                            try stderr.print("\n\x1b[31mFAIL\x1b[0m: {s}", .{mr.path});
-                            if (doc_comment) |comment| {
-                                try stderr.print("\n\x1b[0m{s}", .{comment});
-                            }
-
-                            try stderr.print("\x1b[31m\n𜸖\t", .{});
-
-                            for (error_src) |ch| {
-                                if (ch == '\n') {
-                                    try stderr.print("\n\u{2502}\u{00A0}\u{00A0}\t", .{});
-                                } else {
-                                    try stderr.print("{c}", .{ch});
-                                }
-                            }
-                            try stderr.print("\n\u{2514}\u{2500}> [line {}:{}]", .{ region_info.start_line_idx + 1, region_info.start_col_idx + 1 });
-
-                            try stderr.print("\x1b[31m", .{});
-
-                            if (result.error_msg) |msg| {
-                                try stderr.print(" - {s}", .{msg});
-                            }
-
-                            try stderr.print("\x1b[0m", .{});
-                            try stderr.print("\n", .{});
-                        },
+                        .failed => try printTestFailure(stderr, mr.path, mr.env, result.region, region_info, result.error_msg),
                     }
                 }
             }
         } else {
-            // Non-verbose mode: just show simple FAIL messages with line numbers
+            // Non-verbose mode: only show failures
             for (module_results.items) |mr| {
                 for (mr.results) |result| {
                     if (result.result == .failed) {
                         const region_info = mr.env.calcRegionInfo(result.region);
-                        // get error code snippet from source
-                        const src = mr.env.getSourceAll();
-                        const error_src = src[result.region.start.offset..result.region.end.offset];
-
-                        // check if the previous line is a doc comment
-                        const doc_comment: ?[]const u8 = blk: {
-                            const line_starts = mr.env.getLineStarts();
-                            const curr_line_start_idx = region_info.start_line_idx;
-                            const curr_line_start = line_starts[curr_line_start_idx];
-                            const prev_line_start = if (curr_line_start_idx > 0) line_starts[curr_line_start_idx - 1] else break :blk null;
-                            if (std.mem.startsWith(u8, src[prev_line_start..], "##")) {
-                                break :blk std.mem.trim(u8, src[prev_line_start + 2 .. curr_line_start - 1], " ");
-                            }
-                            break :blk null;
-                        };
-
-                        try stderr.print("\n\x1b[31mFAIL\x1b[0m: {s}", .{mr.path});
-                        if (doc_comment) |comment| {
-                            try stderr.print("\n\x1b[0m{s}", .{comment});
-                        }
-
-                        try stderr.print("\x1b[31m\n𜸖\t", .{});
-
-                        for (error_src) |ch| {
-                            if (ch == '\n') {
-                                try stderr.print("\n\u{2502}\u{00A0}\u{00A0}\t", .{});
-                            } else {
-                                try stderr.print("{c}", .{ch});
-                            }
-                        }
-                        try stderr.print("\n\u{2514}\u{2500}> [line {}:{}]", .{ region_info.start_line_idx + 1, region_info.start_col_idx + 1 });
-
-                        try stderr.print("\x1b[31m", .{});
-
-                        if (result.error_msg) |msg| {
-                            try stderr.print(" - {s}", .{msg});
-                        }
-
-                        try stderr.print("\x1b[0m", .{});
-                        try stderr.print("\n", .{});
+                        try printTestFailure(stderr, mr.path, mr.env, result.region, region_info, result.error_msg);
                     }
                 }
             }
@@ -6096,6 +6016,58 @@ fn rocTest(ctx: *CliContext, args: cli_args.TestArgs) !void {
 
         return error.TestsFailed;
     }
+}
+
+/// Prints a formatted test failure to stderr, including the source snippet,
+/// an optional doc comment from the preceding line, and an optional error message.
+fn printTestFailure(
+    stderr: *std.Io.Writer,
+    path: []const u8,
+    env: *const ModuleEnv,
+    region: base.Region,
+    region_info: base.RegionInfo,
+    error_msg: ?[]const u8,
+) !void {
+    const src = env.getSourceAll();
+    const error_src = src[region.start.offset..region.end.offset];
+
+    // Check if the previous line is a doc comment
+    const doc_comment: ?[]const u8 = blk: {
+        const line_starts = env.getLineStarts();
+        const curr_line_start_idx = region_info.start_line_idx;
+        const curr_line_start = line_starts[curr_line_start_idx];
+        const prev_line_start = if (curr_line_start_idx > 0) line_starts[curr_line_start_idx - 1] else break :blk null;
+        const prev_line = std.mem.trimLeft(u8, src[prev_line_start..curr_line_start], " ");
+        if (std.mem.startsWith(u8, prev_line, "##")) {
+            break :blk std.mem.trim(u8, prev_line[2..], " \r\n");
+        }
+        break :blk null;
+    };
+
+    try stderr.print("\n\x1b[31mFAIL\x1b[0m: {s}", .{path});
+    if (doc_comment) |comment| {
+        try stderr.print("\n{s}", .{comment});
+    }
+
+    try stderr.print("\x1b[31m\n\u{250c}\t", .{});
+
+    var lines = std.mem.splitScalar(u8, error_src, '\n');
+    var first = true;
+    while (lines.next()) |line| {
+        if (!first) {
+            try stderr.print("\n\u{2502}\u{00A0}\u{00A0}\t", .{});
+        }
+        first = false;
+        try stderr.print("{s}", .{line});
+    }
+
+    try stderr.print("\n\u{2514}\u{2500}> [line {}:{}]", .{ region_info.start_line_idx + 1, region_info.start_col_idx + 1 });
+
+    if (error_msg) |msg| {
+        try stderr.print("\x1b[31m - {s}", .{msg});
+    }
+
+    try stderr.print("\x1b[0m\n", .{});
 }
 
 fn rocRepl(ctx: *CliContext, repl_args: cli_args.ReplArgs) !void {

--- a/src/cli/test/roc_subcommands.zig
+++ b/src/cli/test/roc_subcommands.zig
@@ -1000,6 +1000,92 @@ test "roc test with nested list chunks does not panic on layout upgrade (dev)" {
     return error.SkipZigTest;
 }
 
+fn testFailureOutputContainsSourceSnippet(opt: []const u8) !void {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    const result = try util.runRoc(gpa, &.{ "test", opt }, "test/cli/SomeFailTests.roc");
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try testing.expect(result.term == .Exited and result.term.Exited == 1);
+
+    // Output should contain line-numbered source lines with │ prefix
+    try testing.expect(std.mem.indexOf(u8, result.stderr, "\u{2502}") != null); // │
+
+    // Output should contain the failing source expression
+    try testing.expect(std.mem.indexOf(u8, result.stderr, "add(1, 1) == 3") != null);
+}
+
+test "roc test failure output contains source snippet (interpreter)" {
+    try testFailureOutputContainsSourceSnippet("--opt=interpreter");
+}
+test "roc test failure output contains source snippet (dev)" {
+    // TODO: dev backend compilation fails for test/cli/SomeFailTests.roc
+    return error.SkipZigTest;
+}
+
+fn testFailureOutputContainsDocComment(opt: []const u8) !void {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    const result = try util.runRoc(gpa, &.{ "test", opt }, "test/cli/FailWithDocComment.roc");
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    try testing.expect(result.term == .Exited and result.term.Exited == 1);
+
+    // Output should contain the doc comment text
+    try testing.expect(std.mem.indexOf(u8, result.stderr, "## This test should fail") != null);
+
+    // Output should still contain the source snippet with line numbers
+    try testing.expect(std.mem.indexOf(u8, result.stderr, "add(1, 1) == 3") != null);
+    try testing.expect(std.mem.indexOf(u8, result.stderr, "\u{2502}") != null);
+}
+
+test "roc test failure output contains doc comment (interpreter)" {
+    try testFailureOutputContainsDocComment("--opt=interpreter");
+}
+test "roc test failure output contains doc comment (dev)" {
+    // TODO: dev backend compilation fails for test/cli/FailWithDocComment.roc
+    return error.SkipZigTest;
+}
+
+fn testVerboseAndNonVerboseFailureFormatMatch(opt: []const u8) !void {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    var env_map1 = try createPerTestCacheEnv(gpa);
+    defer env_map1.deinit();
+    var env_map2 = try createPerTestCacheEnv(gpa);
+    defer env_map2.deinit();
+
+    const non_verbose = try util.runRocWithEnv(gpa, &.{ "test", opt }, "test/cli/SomeFailTests.roc", &env_map1);
+    defer gpa.free(non_verbose.stdout);
+    defer gpa.free(non_verbose.stderr);
+
+    const verbose = try util.runRocWithEnv(gpa, &.{ "test", opt, "--verbose" }, "test/cli/SomeFailTests.roc", &env_map2);
+    defer gpa.free(verbose.stdout);
+    defer gpa.free(verbose.stderr);
+
+    try testing.expect(non_verbose.term == .Exited and non_verbose.term.Exited == 1);
+    try testing.expect(verbose.term == .Exited and verbose.term.Exited == 1);
+
+    // Both modes should contain the same formatting elements for failures
+    for ([_][]const u8{ "\u{2502}", "add(1, 1) == 3" }) |needle| {
+        try testing.expect(std.mem.indexOf(u8, non_verbose.stderr, needle) != null);
+        try testing.expect(std.mem.indexOf(u8, verbose.stderr, needle) != null);
+    }
+}
+
+test "roc test verbose and non-verbose failure format match (interpreter)" {
+    try testVerboseAndNonVerboseFailureFormatMatch("--opt=interpreter");
+}
+test "roc test verbose and non-verbose failure format match (dev)" {
+    // TODO: dev backend compilation fails for test/cli/SomeFailTests.roc
+    return error.SkipZigTest;
+}
+
 // Exit code tests for warnings
 
 test "roc check returns exit code 2 for warnings" {

--- a/test/cli/FailWithDocComment.roc
+++ b/test/cli/FailWithDocComment.roc
@@ -1,0 +1,12 @@
+FailWithDocComment := {}
+
+add = |a, b| a + b
+
+## This test should fail
+expect {
+    add(1, 1) == 3
+}
+
+expect {
+    add(2, 2) == 4
+}


### PR DESCRIPTION
Implementation for [#9320](https://github.com/roc-lang/roc/issues/9320).
<img width="914" height="332" alt="roc_pull_req_screenshot" src="https://github.com/user-attachments/assets/77d15721-f7fa-48d2-a37e-f4ca2404d5b2" />

- [x]  Show the source code (with line numbers) of the expect that failed
- [x] If the expect has a doc comment (starts with ## ) above it, show that too.  