### PR TITLE
Fix #9344

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -7418,6 +7418,147 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             }
         }
 
+        /// Emit runtime checks for a pattern used in a match arm. Literal patterns
+        /// (int/str) produce compare-and-jump sequences whose fail-jump patch location
+        /// is appended to `fail_patches`. Struct and as-patterns recurse into their
+        /// contents. Bind and wildcard patterns emit nothing because they always match.
+        ///
+        /// The top-level match switch in generateMatch / generateMatchStmt handles
+        /// literal / tag / list / wildcard / bind patterns directly at the scrutinee
+        /// root. This helper is used when a pattern is nested inside a struct_ (e.g.,
+        /// a tuple pattern like `(1, 2)` whose fields are int_literal patterns) and
+        /// the scrutinee value must be compared field-by-field. Callers must pass a
+        /// `value_loc` that is stable across the emitted comparisons (for example,
+        /// a stack-backed location obtained via `ensureOnStack`).
+        fn emitPatternChecks(
+            self: *Self,
+            pattern_id: LirPatternId,
+            value_loc: ValueLocation,
+            value_layout_idx: layout.Idx,
+            fail_patches: *std.ArrayList(usize),
+        ) Allocator.Error!void {
+            const ls = self.layout_store;
+            const pattern = self.store.getPattern(pattern_id);
+
+            switch (pattern) {
+                .bind, .wildcard => {},
+
+                .int_literal => |int_lit| {
+                    try self.emitIntPatternCheck(int_lit.value, value_loc);
+                    const patch = try self.emitJumpIfNotEqual();
+                    try fail_patches.append(self.allocator, patch);
+                },
+
+                .str_literal => |str_lit_idx| {
+                    try self.emitStringPatternCheck(str_lit_idx, value_loc);
+                    const patch = try self.emitJumpIfEqual();
+                    try fail_patches.append(self.allocator, patch);
+                },
+
+                .struct_ => |struct_pat| {
+                    const struct_layout_val = ls.getLayout(struct_pat.struct_layout);
+                    if (struct_layout_val.tag != .struct_) return;
+
+                    const field_patterns = self.store.getPatternSpan(struct_pat.fields);
+                    if (field_patterns.len == 0) return;
+
+                    const base_offset: i32 = switch (value_loc) {
+                        .stack => |s| s.offset,
+                        .stack_i128, .stack_str => |off| off,
+                        .list_stack => |info| info.struct_offset,
+                        else => {
+                            if (builtin.mode == .Debug) {
+                                std.debug.panic(
+                                    "LIR/codegen invariant violated: emitPatternChecks struct expected stack value location, got {s}",
+                                    .{@tagName(value_loc)},
+                                );
+                            }
+                            unreachable;
+                        },
+                    };
+
+                    for (field_patterns, 0..) |field_pattern_id, field_idx| {
+                        const field_offset = ls.getStructFieldOffset(
+                            struct_layout_val.data.struct_.idx,
+                            @intCast(field_idx),
+                        );
+                        const field_layout_idx = ls.getStructFieldLayout(
+                            struct_layout_val.data.struct_.idx,
+                            @intCast(field_idx),
+                        );
+                        const field_loc = self.stackLocationForLayout(
+                            field_layout_idx,
+                            base_offset + @as(i32, @intCast(field_offset)),
+                        );
+
+                        try self.emitPatternChecks(
+                            field_pattern_id,
+                            field_loc,
+                            field_layout_idx,
+                            fail_patches,
+                        );
+                    }
+                },
+
+                .tag => |tag_pat| {
+                    const value_layout_val = ls.getLayout(value_layout_idx);
+                    if (value_layout_val.tag != .tag_union) return;
+
+                    const tu_data = ls.getTagUnionData(value_layout_val.data.tag_union.idx);
+                    const tu_disc_offset: i32 = @intCast(tu_data.discriminant_offset);
+                    const tu_disc_size: u8 = tu_data.discriminant_size;
+                    const tu_total_size: u32 = tu_data.size;
+                    const disc_use_w32 = (tu_disc_offset + 8 > @as(i32, @intCast(tu_total_size)));
+
+                    const disc_reg = try self.loadAndMaskDiscriminant(
+                        value_loc,
+                        disc_use_w32,
+                        tu_disc_offset,
+                        tu_disc_size,
+                    );
+                    try self.emitCmpImm(disc_reg, @intCast(tag_pat.discriminant));
+                    self.codegen.freeGeneral(disc_reg);
+                    const patch = try self.emitJumpIfNotEqual();
+                    try fail_patches.append(self.allocator, patch);
+
+                    try self.emitInnerTagArgDiscriminantChecks(
+                        tag_pat,
+                        value_loc,
+                        value_layout_idx,
+                        value_layout_val,
+                        fail_patches,
+                    );
+                },
+
+                .list => |list_pat| {
+                    try self.emitListLengthCheck(list_pat, value_loc);
+                    const is_exact_match = list_pat.rest.isNone();
+                    const patch = if (is_exact_match)
+                        try self.emitJumpIfNotEqual()
+                    else
+                        try self.emitJumpIfLessThan();
+                    try fail_patches.append(self.allocator, patch);
+
+                    try self.emitListLiteralChecks(list_pat, value_loc, fail_patches);
+                },
+
+                .as_pattern => |as_pat| {
+                    try self.emitPatternChecks(
+                        as_pat.inner,
+                        value_loc,
+                        value_layout_idx,
+                        fail_patches,
+                    );
+                },
+
+                .float_literal => {
+                    // Float literal comparisons inside struct fields are not yet
+                    // emitted by the dev backend. Leave as always-match to preserve
+                    // existing behaviour until a float compare helper exists.
+                },
+            }
+        }
+
         /// Bind tag payload fields to symbols after a tag pattern match.
         /// Computes the payload location for each arg and delegates to bindPattern,
         /// which handles all pattern types (bind, wildcard, tag, struct, list, as_pattern, etc.).
@@ -8286,26 +8427,53 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         }
                     },
                     .struct_ => {
-                        // Struct destructuring always matches - bind fields and generate body
-                        // Ensure the value is on the stack for field access
+                        // Ensure the value is on the stack so both the field-level
+                        // checks and the field bindings address the same memory.
                         const value_size = ls.layoutSizeAlign(value_layout_val).size;
                         const stack_off = try self.ensureOnStack(value_loc, value_size);
-                        try self.bindPattern(branch.pattern, .{ .stack = .{ .offset = stack_off } });
+                        const stable_loc: ValueLocation = .{ .stack = .{ .offset = stack_off } };
+
+                        const is_last_branch = (i == branches.len - 1);
+
+                        // A struct_ pattern only "always matches" when every field is a
+                        // bind/wildcard. Tuple patterns like `(1, 2)` lower to a struct_
+                        // whose fields are int_literal patterns, and those require
+                        // runtime comparisons. Collect any fail-jump patches here so
+                        // they all target the start of the next branch.
+                        var field_fail_patches = std.ArrayList(usize).empty;
+                        defer field_fail_patches.deinit(self.allocator);
+                        if (!is_last_branch) {
+                            try self.emitPatternChecks(
+                                branch.pattern,
+                                stable_loc,
+                                when_expr.value_layout,
+                                &field_fail_patches,
+                            );
+                        }
+
+                        try self.bindPattern(branch.pattern, stable_loc);
 
                         const guard_patch = try self.emitGuardCheck(branch.guard);
-                        if (guard_patch) |gp| {
-                            const body_loc = try self.generateExpr(branch.body);
-                            try self.storeMatchResult(body_loc, &use_stack_result, &result_slot, &result_reg, &result_size);
-                            if (i < branches.len - 1) {
-                                const end_patch = try self.codegen.emitJump();
-                                try end_patches.append(self.allocator, end_patch);
+
+                        const body_loc = try self.generateExpr(branch.body);
+                        try self.storeMatchResult(body_loc, &use_stack_result, &result_slot, &result_reg, &result_size);
+
+                        const unconditional = field_fail_patches.items.len == 0 and guard_patch == null;
+
+                        if (!is_last_branch and !unconditional) {
+                            const end_patch = try self.codegen.emitJump();
+                            try end_patches.append(self.allocator, end_patch);
+
+                            const next_branch_offset = self.codegen.currentOffset();
+                            for (field_fail_patches.items) |patch| {
+                                self.codegen.patchJump(patch, next_branch_offset);
                             }
-                            self.codegen.patchJump(gp, self.codegen.currentOffset());
-                        } else {
-                            const body_loc = try self.generateExpr(branch.body);
-                            try self.storeMatchResult(body_loc, &use_stack_result, &result_slot, &result_reg, &result_size);
-                            break;
                         }
+                        if (guard_patch) |patch| {
+                            self.codegen.patchJump(patch, self.codegen.currentOffset());
+                        }
+
+                        if (unconditional) break;
                     },
                     .as_pattern => |as_pat| {
                         // As-pattern: bind the whole value to the symbol, then match the inner pattern
@@ -15321,22 +15489,45 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         }
                     },
                     .struct_ => {
+                        // Ensure the value is on the stack so both the field-level
+                        // checks and the field bindings address the same memory.
                         const value_size = ls.layoutSizeAlign(value_layout_val).size;
                         const stack_off = try self.ensureOnStack(value_loc, value_size);
-                        try self.bindPattern(branch.pattern, .{ .stack = .{ .offset = stack_off } });
+                        const stable_loc: ValueLocation = .{ .stack = .{ .offset = stack_off } };
+
+                        var field_fail_patches = std.ArrayList(usize).empty;
+                        defer field_fail_patches.deinit(self.allocator);
+                        if (!is_last_branch) {
+                            try self.emitPatternChecks(
+                                branch.pattern,
+                                stable_loc,
+                                ms.value_layout,
+                                &field_fail_patches,
+                            );
+                        }
+
+                        try self.bindPattern(branch.pattern, stable_loc);
 
                         const guard_patch = try self.emitGuardCheck(branch.guard);
-                        if (guard_patch) |gp| {
-                            try self.generateStmt(branch.body);
-                            if (!is_last_branch) {
-                                const end_patch = try self.codegen.emitJump();
-                                try end_patches.append(self.allocator, end_patch);
+
+                        try self.generateStmt(branch.body);
+
+                        const unconditional = field_fail_patches.items.len == 0 and guard_patch == null;
+
+                        if (!is_last_branch and !unconditional) {
+                            const end_patch = try self.codegen.emitJump();
+                            try end_patches.append(self.allocator, end_patch);
+
+                            const next_branch_offset = self.codegen.currentOffset();
+                            for (field_fail_patches.items) |patch| {
+                                self.codegen.patchJump(patch, next_branch_offset);
                             }
-                            self.codegen.patchJump(gp, self.codegen.currentOffset());
-                        } else {
-                            try self.generateStmt(branch.body);
-                            break;
                         }
+                        if (guard_patch) |patch| {
+                            self.codegen.patchJump(patch, self.codegen.currentOffset());
+                        }
+
+                        if (unconditional) break;
                     },
                     .as_pattern => |as_pat| {
                         const symbol_key: u64 = @bitCast(as_pat.symbol);

--- a/src/eval/test/eval_test.zig
+++ b/src/eval/test/eval_test.zig
@@ -4224,6 +4224,54 @@ test "dev: Str.inspect through polymorphic wrapper" {
     , "\"42\"");
 }
 
+test "dev: tuple match - first branch matches" {
+    try runDevOnlyExpectStr(
+        \\match (1, 2) {
+        \\    (1, 2) => "1, 2 (correct)"
+        \\    _ => "any (incorrect)"
+        \\}
+    , "\"1, 2 (correct)\"");
+}
+
+test "dev: tuple match - wildcard branch matches when first does not" {
+    try runDevOnlyExpectStr(
+        \\match (1, 2) {
+        \\    (3, 4) => "3, 4 (incorrect)"
+        \\    _ => "any (correct)"
+        \\}
+    , "\"any (correct)\"");
+}
+
+test "dev: tuple match - wildcard branch matches when two tuple branches do not" {
+    try runDevOnlyExpectStr(
+        \\match (1, 2) {
+        \\    (5, 6) => "5, 6 (incorrect)"
+        \\    (3, 4) => "3, 4 (incorrect)"
+        \\    _ => "any (correct)"
+        \\}
+    , "\"any (correct)\"");
+}
+
+test "dev: tuple match - second tuple branch matches" {
+    try runDevOnlyExpectStr(
+        \\match (1, 2) {
+        \\    (5, 6) => "5, 6 (incorrect)"
+        \\    (1, 2) => "1, 2 (correct)"
+        \\    (3, 4) => "3, 4 (incorrect)"
+        \\    _ => "any (incorrect)"
+        \\}
+    , "\"1, 2 (correct)\"");
+}
+
+test "dev: str match - wildcard branch matches when literal does not" {
+    try runDevOnlyExpectStr(
+        \\match "foo" {
+        \\    "bar" => "bar (incorrect)"
+        \\    _ => "any (correct)"
+        \\}
+    , "\"any (correct)\"");
+}
+
 test "focused: polymorphic additional specialization via List.append (non-eq)" {
     try runExpectI64(
         \\{

--- a/src/lir/MirToLir.zig
+++ b/src/lir/MirToLir.zig
@@ -5693,10 +5693,23 @@ fn lowerPatternInternal(
                 .args = lir_args,
             } }, region);
         },
-        .int_literal => |i| self.lir_store.addPattern(.{ .int_literal = .{
-            .value = i.value.toI128(),
-            .layout_idx = runtime_layout,
-        } }, region),
+        .int_literal => |i| blk: {
+            // A raw integer literal in pattern position must match the scrutinee's
+            // runtime encoding. For Dec, values are stored scaled by 10^18, so the
+            // literal must be scaled the same way the matching expression-side
+            // lowering does (see `lowerInt`). Without this, a pattern like `(1, 2)`
+            // against a Dec tuple fails to match because the scrutinee is 10^18
+            // while the raw literal is 1.
+            var val = i.value.toI128();
+            if (runtime_layout == .dec) {
+                const one_point_zero: i128 = 1_000_000_000_000_000_000;
+                val *= one_point_zero;
+            }
+            break :blk self.lir_store.addPattern(.{ .int_literal = .{
+                .value = val,
+                .layout_idx = runtime_layout,
+            } }, region);
+        },
         .str_literal => |s| blk: {
             const lir_str_idx = try self.copyStringToLir(s);
             break :blk self.lir_store.addPattern(.{ .str_literal = lir_str_idx }, region);


### PR DESCRIPTION
Tuple patterns like `(1, 2)` lower to a struct_ LIR pattern whose fields
are literal patterns, but the dev backend was treating any struct_ pattern
as an unconditional match — so later branches were never consulted when
earlier tuple literals should not have matched. Add an emitPatternChecks
helper that recursively emits compare+jump sequences for literal, tag,
list, and as-patterns inside struct_ patterns, and route field-mismatch
jumps to the next branch.

Also fix a latent bug in MirToLir pattern lowering: int_literal pattern
values for `.dec` layout were not scaled by 10^18, so they failed to match
the Dec-encoded scrutinee. This was previously hidden because struct_
pattern checks were never actually emitted.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>