### PR TITLE
Instantiate generalized call.func before unifying call args

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -4495,7 +4495,25 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                     // First, check the function being called
                     // It could be effectful, e.g. `(mk_fn!())(arg)`
                     does_fx = try self.checkExpr(call.func, env, .no_expectation) or does_fx;
-                    const func_var = ModuleEnv.varFrom(call.func);
+                    const call_func_expr_var = ModuleEnv.varFrom(call.func);
+
+                    // If the function was generalized (e.g. an immediately-invoked
+                    // lambda `(|x| ...)(arg)`), instantiate it so the call site gets
+                    // fresh type variables. Without this, the generalized vars would
+                    // be unified directly with concrete arg types, which can leak
+                    // generalization into the enclosing function's types.
+                    const func_var = blk_instantiate: {
+                        const resolved = self.types.resolveVar(call_func_expr_var);
+                        if (resolved.desc.rank == Rank.generalized) {
+                            break :blk_instantiate try self.instantiateVar(
+                                call_func_expr_var,
+                                env,
+                                .use_last_var,
+                            );
+                        } else {
+                            break :blk_instantiate call_func_expr_var;
+                        }
+                    };
 
                     // Resolve the func var
                     const resolved_func = self.types.resolveVar(func_var).desc.content;

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -1107,7 +1107,9 @@ test "check type - value restriction - out of order 2" {
 }
 
 test "check type - value restriction - curried 1" {
-    // Currently errors out in czer
+    // Each inline `process(1.U8)` call creates a fresh instantiation, so the
+    // two inner applications with differently-typed ignored arguments are
+    // independent and both type-check successfully (mirrors curried 2).
 
     const source =
         \\main! = |_| {}
@@ -1123,10 +1125,12 @@ test "check type - value restriction - curried 1" {
         \\
         \\x = 10
     ;
-    try checkTypesModule(
+    try checkTypesModuleDefs(
         source,
-        .fail,
-        "TYPE MISMATCH",
+        &.{
+            .{ .def = "x", .expected = "U8" },
+            .{ .def = "process", .expected = "U8 -> (_arg -> List(U8))" },
+        },
     );
 }
 test "check type - value restriction - curried 2" {


### PR DESCRIPTION
When an immediately-invoked lambda like `(|x| [x])(list)` is the target of a call, its type gets generalized during `checkExpr(call.func, ...)`. The call-site code then unwrapped the generalized Func directly and unified its arg/ret vars against concrete call arguments, leaking generalization into the enclosing function and corrupting bindings such as `list: List(a)`.

Mirror the instantiation `e_lookup_local` already performs: if the resolved `call.func` var is at `Rank.generalized`, instantiate it first so the call site unifies against fresh copies.

The existing `value restriction - curried 1` test was documenting this bug ("Currently errors out in czer"); update it to assert the now-correct behavior, matching the equivalent `curried 2` test.