### PR TITLE
Fix panic codegen invariant

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -12889,8 +12889,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
         /// Convert callable values stored on stack to a concrete stack ValueLocation
         /// based on the expected return layout.
-        fn normalizeResultLocForLayout(_: *Self, loc: ValueLocation, _: layout.Idx) ValueLocation {
-            return loc;
+        fn normalizeResultLocForLayout(self: *Self, loc: ValueLocation, ret_layout: layout.Idx) ValueLocation {
+            return self.coerceImmediateToLayout(loc, ret_layout);
         }
 
         /// Normalize immediate literal representation to match the target layout.

--- a/src/eval/test/eval_test.zig
+++ b/src/eval/test/eval_test.zig
@@ -4916,3 +4916,18 @@ test "issue 9342: passing lambda to function ignoring its parameter should not p
         \\}
     , 42, .no_trace);
 }
+
+test "dev: function returning U64 max value should not panic codegen" {
+    // Regression test: returning the maximum U64 value (18446744073709551615)
+    // from a function caused a LIR/codegen panic:
+    // "moveOneRegToReturn does not support loc=immediate_i128"
+    // The literal needs i128 to represent it, but the function return type
+    // is U64, and the codegen path didn't handle this case.
+    try runDevOnlyExpectStr(
+        \\{
+        \\    highest : () -> U64
+        \\    highest = || 18446744073709551615
+        \\    highest().to_str()
+        \\}
+    , "\"18446744073709551615\"");
+}


### PR DESCRIPTION
Fix immediate_i128 panic when returning narrower int type.

normalizeResultLocForLayout now delegates to coerceImmediateToLayout,
truncating immediate_i128 carriers to immediate_i64 when the return
layout is u64 or smaller. Without this, returning a literal like
18446744073709551615 from a U64 function panicked in moveOneRegToReturn.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>