### PR TITLE
Fix f64 plus repl

### DIFF
--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -13250,22 +13250,45 @@ pub const Interpreter = struct {
             const ct_var = can.ModuleEnv.varFrom(expr_idx);
             break :blk try self.translateTypeVar(self.env, ct_var);
         };
-        const layout_val = try self.getRuntimeLayout(layout_rt_var);
+        var layout_val = try self.getRuntimeLayout(layout_rt_var);
 
         // Check if the resolved type is flex/rigid (unconstrained).
         // If so, give it a concrete Dec type for method dispatch to work.
         // REPL rendering will still strip .0 from whole-number Dec values regardless of type.
         const resolved_rt = self.runtime_types.resolveVar(layout_rt_var);
         const is_flex_or_rigid = resolved_rt.desc.content == .flex or resolved_rt.desc.content == .rigid;
-        const final_rt_var = if (is_flex_or_rigid) blk: {
+        var final_rt_var = layout_rt_var;
+        if (is_flex_or_rigid) {
             const dec_content = try self.mkNumberTypeContentRuntime("Dec");
-            break :blk try self.runtime_types.freshFromContent(dec_content);
-        } else layout_rt_var;
-
-        const value = try self.pushRaw(layout_val, 0, final_rt_var);
-        if (value.ptr) |ptr| {
-            builtins.utils.writeAs(RocDec, ptr, dec_lit.value, @src());
+            final_rt_var = try self.runtime_types.freshFromContent(dec_content);
+            layout_val = try self.getRuntimeLayout(final_rt_var);
         }
+
+        // The literal carries an exact Dec value, but the unified layout may be F32 or F64
+        // (e.g. when the surrounding context constrains the type to a float). Dispatch on
+        // the layout's precision so the slot size and stored bytes always agree.
+        var value = try self.pushRaw(layout_val, 0, final_rt_var);
+        value.is_initialized = false;
+        switch (layout_val.tag) {
+            .scalar => switch (layout_val.data.scalar.tag) {
+                .frac => switch (layout_val.data.scalar.data.frac) {
+                    .f32 => {
+                        const ptr = builtins.utils.alignedPtrCast(*f32, value.ptr.?, @src());
+                        ptr.* = @floatCast(dec_lit.value.toF64());
+                    },
+                    .f64 => {
+                        const ptr = builtins.utils.alignedPtrCast(*f64, value.ptr.?, @src());
+                        ptr.* = dec_lit.value.toF64();
+                    },
+                    .dec => {
+                        builtins.utils.writeAs(RocDec, value.ptr.?, dec_lit.value, @src());
+                    },
+                },
+                else => return error.TypeMismatch,
+            },
+            else => return error.TypeMismatch,
+        }
+        value.is_initialized = true;
         return value;
     }
 
@@ -13282,14 +13305,11 @@ pub const Interpreter = struct {
         };
         var layout_val = try self.getRuntimeLayout(layout_rt_var);
 
-        // Dec literals require Dec-compatible layout. If we reach here with a different layout
-        // (e.g., function type from calling a literal like 0.0()), the type is incompatible.
-        // Return an error instead of crashing - the type checker will report the actual error.
-        const is_dec_layout = layout_val.tag == .scalar and
-            layout_val.data.scalar.tag == .frac and
-            layout_val.data.scalar.data.frac == .dec;
-        if (!is_dec_layout) {
-            // Fall back to Dec layout for the literal itself
+        // If the layout isn't a numeric float type (e.g., function type from calling a
+        // literal like 0.0()), fall back to Dec - the type checker will surface the
+        // actual error.
+        const is_frac_layout = layout_val.tag == .scalar and layout_val.data.scalar.tag == .frac;
+        if (!is_frac_layout) {
             layout_val = layout.Layout.frac(types.Frac.Precision.dec);
         }
 
@@ -13298,18 +13318,41 @@ pub const Interpreter = struct {
         // REPL rendering will still strip .0 from whole-number Dec values regardless of type.
         const resolved_rt = self.runtime_types.resolveVar(layout_rt_var);
         const is_flex_or_rigid = resolved_rt.desc.content == .flex or resolved_rt.desc.content == .rigid;
-        const final_rt_var = if (is_flex_or_rigid) blk: {
+        var final_rt_var = layout_rt_var;
+        if (is_flex_or_rigid) {
             const dec_content = try self.mkNumberTypeContentRuntime("Dec");
-            break :blk try self.runtime_types.freshFromContent(dec_content);
-        } else layout_rt_var;
-
-        const value = try self.pushRaw(layout_val, 0, final_rt_var);
-        if (value.ptr) |ptr| {
-            const typed_ptr = builtins.utils.alignedPtrCast(*RocDec, ptr, @src());
-            const scale_factor = std.math.pow(i128, 10, RocDec.decimal_places - small.value.denominator_power_of_ten);
-            const scaled = @as(i128, small.value.numerator) * scale_factor;
-            typed_ptr.* = RocDec{ .num = scaled };
+            final_rt_var = try self.runtime_types.freshFromContent(dec_content);
+            layout_val = try self.getRuntimeLayout(final_rt_var);
         }
+
+        // The literal is rational (numerator / 10^denominator_power_of_ten), but the
+        // unified layout may be Dec, F32, or F64. Dispatch on the layout's precision
+        // so the slot size and stored bytes always agree.
+        var value = try self.pushRaw(layout_val, 0, final_rt_var);
+        value.is_initialized = false;
+        switch (layout_val.tag) {
+            .scalar => switch (layout_val.data.scalar.tag) {
+                .frac => switch (layout_val.data.scalar.data.frac) {
+                    .f32 => {
+                        const ptr = builtins.utils.alignedPtrCast(*f32, value.ptr.?, @src());
+                        ptr.* = @floatCast(small.value.toF64());
+                    },
+                    .f64 => {
+                        const ptr = builtins.utils.alignedPtrCast(*f64, value.ptr.?, @src());
+                        ptr.* = small.value.toF64();
+                    },
+                    .dec => {
+                        const ptr = builtins.utils.alignedPtrCast(*RocDec, value.ptr.?, @src());
+                        const scale_factor = std.math.pow(i128, 10, RocDec.decimal_places - small.value.denominator_power_of_ten);
+                        const scaled = @as(i128, small.value.numerator) * scale_factor;
+                        ptr.* = RocDec{ .num = scaled };
+                    },
+                },
+                else => return error.TypeMismatch,
+            },
+            else => return error.TypeMismatch,
+        }
+        value.is_initialized = true;
         return value;
     }
 

--- a/src/mir/Lower.zig
+++ b/src/mir/Lower.zig
@@ -2825,10 +2825,68 @@ fn lowerExprWithMonotypeOverride(
         .e_num => |num| try self.store.addExpr(self.allocator, .{ .int = .{ .value = num.value } }, monotype, region),
         .e_frac_f32 => |frac| try self.store.addExpr(self.allocator, .{ .frac_f32 = frac.value }, monotype, region),
         .e_frac_f64 => |frac| try self.store.addExpr(self.allocator, .{ .frac_f64 = frac.value }, monotype, region),
-        .e_dec => |dec| try self.store.addExpr(self.allocator, .{ .dec = dec.value }, monotype, region),
+        .e_dec => |dec| {
+            // The literal carries an exact Dec value, but the unified monotype may be
+            // F32 or F64 (e.g. when the surrounding context constrains the type to a
+            // float). Dispatch on the monotype's precision so the emitted MIR literal
+            // matches the resolved type.
+            const mono = self.store.monotype_store.getMonotype(monotype);
+            return switch (mono) {
+                .prim => |p| switch (p) {
+                    .f64 => try self.store.addExpr(self.allocator, .{ .frac_f64 = dec.value.toF64() }, monotype, region),
+                    .f32 => try self.store.addExpr(self.allocator, .{ .frac_f32 = @floatCast(dec.value.toF64()) }, monotype, region),
+                    .dec => try self.store.addExpr(self.allocator, .{ .dec = dec.value }, monotype, region),
+                    else => {
+                        if (std.debug.runtime_safety) {
+                            std.debug.panic(
+                                "lowerExpr(e_dec): unsupported prim monotype {s} (checker/lowering invariant broken)",
+                                .{@tagName(p)},
+                            );
+                        }
+                        unreachable;
+                    },
+                },
+                else => {
+                    if (std.debug.runtime_safety) {
+                        std.debug.panic(
+                            "lowerExpr(e_dec): non-prim monotype {s} (checker/lowering invariant broken)",
+                            .{@tagName(mono)},
+                        );
+                    }
+                    unreachable;
+                },
+            };
+        },
         .e_dec_small => |dec_small| {
-            const roc_dec = dec_small.value.toRocDec();
-            return try self.store.addExpr(self.allocator, .{ .dec = roc_dec }, monotype, region);
+            // Dispatch on the unified monotype: a small dec literal is rational
+            // (numerator / 10^denominator_power_of_ten), so we can produce an exact
+            // Dec or a converted F32/F64 depending on the resolved type.
+            const mono = self.store.monotype_store.getMonotype(monotype);
+            return switch (mono) {
+                .prim => |p| switch (p) {
+                    .f64 => try self.store.addExpr(self.allocator, .{ .frac_f64 = dec_small.value.toF64() }, monotype, region),
+                    .f32 => try self.store.addExpr(self.allocator, .{ .frac_f32 = @floatCast(dec_small.value.toF64()) }, monotype, region),
+                    .dec => try self.store.addExpr(self.allocator, .{ .dec = dec_small.value.toRocDec() }, monotype, region),
+                    else => {
+                        if (std.debug.runtime_safety) {
+                            std.debug.panic(
+                                "lowerExpr(e_dec_small): unsupported prim monotype {s} (checker/lowering invariant broken)",
+                                .{@tagName(p)},
+                            );
+                        }
+                        unreachable;
+                    },
+                },
+                else => {
+                    if (std.debug.runtime_safety) {
+                        std.debug.panic(
+                            "lowerExpr(e_dec_small): non-prim monotype {s} (checker/lowering invariant broken)",
+                            .{@tagName(mono)},
+                        );
+                    }
+                    unreachable;
+                },
+            };
         },
         .e_typed_int => |ti| try self.store.addExpr(self.allocator, .{ .int = .{ .value = ti.value } }, monotype, region),
         .e_typed_frac => |tf| {

--- a/src/repl/repl_test.zig
+++ b/src/repl/repl_test.zig
@@ -469,7 +469,7 @@ test "issue 9364: F64.plus with integer literals" {
 }
 
 test "issue 9364: F64.plus with float literals" {
-    try expectAllNative("F64.plus(1.0, 1.0)", "2.0");
+    try expectAllNative("F64.plus(1.0, 1.0)", "2");
 }
 
 test "issue 9364: F64.to_str integer-valued float literal" {

--- a/src/repl/repl_test.zig
+++ b/src/repl/repl_test.zig
@@ -463,3 +463,19 @@ test "Repl - 4-arg lambda call (dev)" {
     try expectStateful(.wasm, steps);
     try expectStateful(.llvm, steps);
 }
+
+test "issue 9364: F64.plus with integer literals" {
+    try expectAllNative("F64.plus(1, 1)", "2");
+}
+
+test "issue 9364: F64.plus with float literals" {
+    try expectAllNative("F64.plus(1.0, 1.0)", "2.0");
+}
+
+test "issue 9364: F64.to_str integer-valued float literal" {
+    try expectAllNative("F64.to_str(2.0)", "\"2\"");
+}
+
+test "issue 9364: F64.to_str non-integer float literal" {
+    try expectAllNative("F64.to_str(2.5)", "\"2.5\"");
+}


### PR DESCRIPTION
Fixes #9364

fix F64 literals losing precision when unified with float types (issue 9364)
    
Dec literals (e_dec, e_dec_small) were storing their i128 Dec representation
even when type inference unified them to F64/F32, so the float code paths
later read the Dec bytes as float bits. Dispatch on the resolved layout
in the interpreter and on the monotype in MIR lowering so the slot size
and stored bytes always match.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>