### PR TITLE
fix SIGSEGV on missing method dispatch (issue 9389)

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -5489,6 +5489,15 @@ fn rocTest(ctx: *CliContext, args: cli_args.TestArgs) !void {
         }
     }
 
+    // Compilation errors leave the CIR in a state the downstream passes
+    // (monomorphization, dispatch resolution) don't handle gracefully — they
+    // panic in debug and become UB (SIGSEGV) in release. Bail here with the
+    // diagnostics already rendered, matching `roc check` behavior.
+    if (has_compilation_errors) {
+        try stderr.print("\nCompilation errors prevent tests from running.\n", .{});
+        return error.TestsFailed;
+    }
+
     // Collect all module environments for the interpreter
     // This includes all modules from all packages (imports from other modules)
     var other_modules_list = std.array_list.Managed(*const ModuleEnv).init(ctx.gpa);

--- a/src/cli/test/roc_subcommands.zig
+++ b/src/cli/test/roc_subcommands.zig
@@ -1000,6 +1000,43 @@ test "roc test with nested list chunks does not panic on layout upgrade (dev)" {
     return error.SkipZigTest;
 }
 
+fn testRocTestDoesNotPanicOnMissingMethod(opt: []const u8) !void {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    // Regression test for issue #9389: calling a non-existent method
+    // (here, `list.reverse()` on a `List(U8)`) used to SIGSEGV in release
+    // and panic in debug because `roc test` ignored the type-checker's
+    // "MISSING METHOD" diagnostic and proceeded into monomorphization.
+    const result = try util.runRoc(gpa, &.{ "test", "--no-cache", opt }, "test/cli/MissingMethodDoesNotPanic.roc");
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    // 1. Command exited cleanly with code 1 (compile error), not a crash signal.
+    try testing.expect(result.term == .Exited and result.term.Exited == 1);
+
+    // 2. Stderr surfaces the type-checker's diagnostic.
+    const has_missing_method = std.mem.indexOf(u8, result.stderr, "MISSING METHOD") != null;
+    try testing.expect(has_missing_method);
+
+    // 3. Stderr surfaces the bail-out message that prevents monomorphization
+    //    from running on broken input.
+    const has_bailout = std.mem.indexOf(u8, result.stderr, "Compilation errors prevent tests from running") != null;
+    try testing.expect(has_bailout);
+
+    // 4. Stderr must not contain "panic" — that would mean the compiler crashed.
+    const has_panic = std.mem.indexOf(u8, result.stderr, "panic") != null;
+    try testing.expect(!has_panic);
+}
+
+test "roc test does not panic on missing method (interpreter)" {
+    try testRocTestDoesNotPanicOnMissingMethod("--opt=interpreter");
+}
+
+test "roc test does not panic on missing method (dev)" {
+    try testRocTestDoesNotPanicOnMissingMethod("--opt=dev");
+}
+
 fn testFailureOutputContainsSourceSnippet(opt: []const u8) !void {
     const testing = std.testing;
     const gpa = testing.allocator;

--- a/test/cli/MissingMethodDoesNotPanic.roc
+++ b/test/cli/MissingMethodDoesNotPanic.roc
@@ -1,0 +1,6 @@
+MissingMethodDoesNotPanic :: [].{
+	foo : List(U8) -> List(U8)
+	foo = |list| list.reverse()
+}
+
+expect foo([1, 2, 3]) == [3, 2, 1]

--- a/test/cli/issue8699.roc
+++ b/test/cli/issue8699.roc
@@ -1,3 +1,5 @@
+main! = |_| {}
+
 chunks = |arr, n| {
 	var $res = []
 	var $chunk = []


### PR DESCRIPTION
Fix for issue #9389.

`roc test` rendered compilation diagnostics and then proceeded into monomorphization regardless. When the type-checker reported MISSING METHOD or UNDEFINED VARIABLE, the dispatch resolver hit an `unreachable` in release (SIGSEGV) or `std.debug.panic` in debug. The `has_compilation_errors` flag was being computed but only consulted at the end for cache outcome.

Bail in `rocTest` after rendering reports if any are fatal/runtime_error, matching `roc check`'s behavior.

Also fix `test/cli/issue8699.roc`, which was missing `main!` and had been relying on the prior overlenient behavior to run tests despite the compile error. Added `main! = |_| {}` so the fixture compiles cleanly; the test's intent (verify nested-list operations don't panic) is unchanged.

Add CLI integration test `roc test does not panic on missing method` plus fixture `test/cli/MissingMethodDoesNotPanic.roc` to prevent regression.