### PR TITLE
Fix links to .md files

### DIFF
--- a/docs/langref/modules.md
+++ b/docs/langref/modules.md
@@ -7,18 +7,18 @@ Every `.roc` file is a _module_. Modules have two purposes:
 
 Roc has several different categories of modules, and they each hide different things:
 
-- [Type modules](#type-modules) expose a single [type](types), including all its associated items (methods, nested types, etc.) and hide implementation details such as private helper functions called by that type's methods.
+- [Type modules](#type-modules) expose a single [type](types.md), including all its associated items (methods, nested types, etc.) and hide implementation details such as private helper functions called by that type's methods.
 - [Package modules](#package-modules) expose one or more [type modules](#type-modules) and hide private modules that are only used behind the scenes.
 - [Application modules](#app-modules) expose the entrypoints (e.g. `main`) required by the platform, and hide the implementation details which go into building those entrypoints.
-- [Platform modules](#platform-modules) expose the [type modules](#type-modules) that application authors can import from the platform, and hide the configuration it uses to communicate with its lower-level [host](platforms#host) implementation.
+- [Platform modules](#platform-modules) expose the [type modules](#type-modules) that application authors can import from the platform, and hide the configuration it uses to communicate with its lower-level [host](platforms.md#host) implementation.
 
 ## Type Modules
 
 Type modules are specified by a .roc file with a capitalized name, such as `Url.roc`.
 
-The file must contain a top-level [nominal type](types#nominal-types)
-(defined with `:=`, or optionally with `::` to make it [opaque](types#opaque-types)) whose name is
-the same as the filename without the `.roc` extension. Note that [type aliases](types#type-aliases)
+The file must contain a top-level [nominal type](types.md#nominal-types)
+(defined with `:=`, or optionally with `::` to make it [opaque](types.md#opaque-types)) whose name is
+the same as the filename without the `.roc` extension. Note that [type aliases](types.md#type-aliases)
 (defined with `:`) don't satisfy this requirement.
 
 So for example, if a type module has a filename of `Url.roc`, then it must have
@@ -91,9 +91,9 @@ private_helper_fn : …
 ```
 
 This is known as a _void module_ because it exposes an opaque _void type_ (namely, `[]`, which is
-the [empty tag union type](tag-unions#void); the empty tag union type is known as "void" for short).
+the [empty tag union type](tag-unions.md#void); the empty tag union type is known as "void" for short).
 
-`Util` is [opaque](types#opaque-types), which prevents other modules from instantiating it,
+`Util` is [opaque](types.md#opaque-types), which prevents other modules from instantiating it,
 and its backing type is `[]`, which means it can't even be instantiated inside `Util.roc`
 itself. Choosing `[]` over `{}` for the backing type makes it clear that the `Util` type's
 purpose is just to be a namespace, not to be a value that ever gets passed anywhere.
@@ -200,7 +200,7 @@ factor to Elm and Roc being generally being known for much faster build times th
 
 ## `import` Statements
 
-Roc's `import` statement brings a [type](types) into scope from a [type module](#type-modules):
+Roc's `import` statement brings a [type](types.md) into scope from a [type module](#type-modules):
 
 ```roc
 import Color
@@ -258,7 +258,7 @@ Foo := [BarVal(Bar), Nothing]
 Bar := [FooVal(Foo), Nothing]
 ```
 
-These [mutually recursive types](types#mutually-recursive) do not come up often, but when
+These [mutually recursive types](types.md#mutually-recursive) do not come up often, but when
 they do, there's a helpful technique you can use to make them easier to import.
 
 Since type modules expose a single type, you can't expose both `Foo` and `Bar` from the


### PR DESCRIPTION
Replaces links like [types](types) with [types](types.md)