### PR TITLE
allow absolute paths as roc bundle CLI args

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -3632,6 +3632,65 @@ fn validateBundleWithCoordinator(
     }
 }
 
+/// Find the longest directory path that is an ancestor of every input in `abs_paths`.
+/// All inputs must be absolute paths (they may be paths to files or directories).
+/// Returns the common parent directory with no trailing path separator (except for
+/// a filesystem root such as "/"). Returns an empty slice if the inputs share no
+/// directory ancestor (e.g. two Windows paths on different drives).
+fn longestCommonParentDir(allocator: std.mem.Allocator, abs_paths: []const []const u8) ![]u8 {
+    std.debug.assert(abs_paths.len > 0);
+
+    const isSep = struct {
+        fn f(byte: u8) bool {
+            return byte == '/' or byte == '\\';
+        }
+    }.f;
+
+    // Start with the dirname of the first path.
+    var common = std.ArrayList(u8).empty;
+    errdefer common.deinit(allocator);
+    const first_dir = std.fs.path.dirname(abs_paths[0]) orelse abs_paths[0];
+    try common.appendSlice(allocator, first_dir);
+
+    for (abs_paths[1..]) |path| {
+        const dir = std.fs.path.dirname(path) orelse path;
+
+        // Find longest byte prefix shared between `common` and `dir`.
+        var i: usize = 0;
+        const max = @min(common.items.len, dir.len);
+        while (i < max and common.items[i] == dir[i]) : (i += 1) {}
+
+        // i is on a directory boundary if it is at the end of either path
+        // OR the next byte of either path is a separator.
+        const at_boundary = (i == common.items.len and (i == dir.len or isSep(dir[i]))) or
+            (i == dir.len and (i == common.items.len or isSep(common.items[i])));
+
+        if (!at_boundary) {
+            // Back up to the last separator within [0..i). Drop everything after it.
+            var j: usize = i;
+            while (j > 0) {
+                j -= 1;
+                if (isSep(common.items[j])) {
+                    // Keep the separator only when it's the root sep at index 0.
+                    i = if (j == 0) 1 else j;
+                    break;
+                }
+            } else {
+                i = 0;
+            }
+        }
+
+        common.items.len = @min(common.items.len, i);
+    }
+
+    // Strip trailing separators (preserve a single root separator).
+    while (common.items.len > 1 and isSep(common.items[common.items.len - 1])) {
+        common.items.len -= 1;
+    }
+
+    return common.toOwnedSlice(allocator);
+}
+
 /// Bundles a roc package and its dependencies into a compressed tar archive
 pub fn rocBundle(ctx: *CliContext, args: cli_args.BundleArgs) !void {
     const stdout = ctx.io.stdout();
@@ -3668,6 +3727,20 @@ pub fn rocBundle(ctx: *CliContext, args: cli_args.BundleArgs) !void {
 
     // Remember the first path from CLI args (before sorting)
     const first_cli_path = paths_to_use[0];
+
+    // Detect whether any input path is absolute. Absolute paths are not allowed
+    // inside the archive (the unbundle side rejects them, and a relative path
+    // is what the user actually wants extracted). If any input is absolute we
+    // rebase all paths against their longest common parent directory and pass
+    // that directory to the bundle library — so the archive itself only ever
+    // contains relative paths.
+    var any_absolute = false;
+    for (paths_to_use) |path| {
+        if (std.fs.path.isAbsolute(path)) {
+            any_absolute = true;
+            break;
+        }
+    }
 
     // Check that all files exist and collect their sizes
     for (paths_to_use) |path| {
@@ -3726,9 +3799,57 @@ pub fn rocBundle(ctx: *CliContext, args: cli_args.BundleArgs) !void {
         if (std.mem.endsWith(u8, path, ".roc")) break path;
     } else null;
 
-    // Use the Coordinator to discover all transitive module dependencies and validate
+    // Use the Coordinator to discover all transitive module dependencies and validate.
+    // We pass the original (possibly absolute) paths here because the coordinator
+    // resolves them via std.fs.cwd().realpathAlloc, which works for both absolute
+    // and cwd-relative paths.
     if (first_roc_file) |roc_file| {
         try validateBundleWithCoordinator(ctx, roc_file, file_paths.items, stderr);
+    }
+
+    // If any input was absolute, rebase all paths against their longest common
+    // parent directory so the archive only contains relative paths. The opened
+    // directory becomes the base_dir passed to the bundle library.
+    var rebased_base_dir: ?std.fs.Dir = null;
+    defer if (rebased_base_dir) |*d| d.close();
+    var archive_paths: []const []const u8 = file_paths.items;
+    if (any_absolute) {
+        const resolved = try ctx.arena.alloc([]u8, file_paths.items.len);
+        for (file_paths.items, 0..) |p, i| {
+            resolved[i] = cwd.realpathAlloc(ctx.arena, p) catch |err| {
+                try stderr.print("Error: Could not resolve path '{s}': {}\n", .{ p, err });
+                return err;
+            };
+        }
+
+        const common = try longestCommonParentDir(ctx.arena, resolved);
+        if (common.len == 0) {
+            try stderr.print("Error: Input file paths have no common parent directory.\n", .{});
+            return error.InvalidPath;
+        }
+
+        const opened_dir = std.fs.openDirAbsolute(common, .{}) catch |err| {
+            try stderr.print("Error: Could not open common parent directory '{s}': {}\n", .{ common, err });
+            return err;
+        };
+        rebased_base_dir = opened_dir;
+
+        // Build relative-to-common paths for the archive.
+        const rel_paths = try ctx.arena.alloc([]const u8, resolved.len);
+        for (resolved, 0..) |abs, i| {
+            // abs must start with `common`; everything after is the relative path.
+            // common has no trailing separator, so skip the leading separator byte
+            // that follows it within abs.
+            if (abs.len <= common.len or
+                !std.mem.eql(u8, abs[0..common.len], common) or
+                !(abs[common.len] == '/' or abs[common.len] == '\\'))
+            {
+                try stderr.print("Error: Path '{s}' is not under the common parent '{s}'.\n", .{ abs, common });
+                return error.InvalidPath;
+            }
+            rel_paths[i] = abs[common.len + 1 ..];
+        }
+        archive_paths = rel_paths;
     }
 
     // Create temporary output file
@@ -3753,19 +3874,20 @@ pub fn rocBundle(ctx: *CliContext, args: cli_args.BundleArgs) !void {
         }
     };
 
-    var iter = FilePathIterator{ .paths = file_paths.items };
+    var iter = FilePathIterator{ .paths = archive_paths };
 
     // Bundle the files
     var allocator_copy = ctx.arena;
     var error_ctx: bundle.ErrorContext = undefined;
     var temp_writer_buffer: [4096]u8 = undefined;
     var temp_writer = temp_file.writer(&temp_writer_buffer);
+    const bundle_base_dir = rebased_base_dir orelse cwd;
     const final_filename = bundle.bundleFiles(
         &iter,
         @intCast(args.compression_level),
         &allocator_copy,
         &temp_writer.interface,
-        cwd,
+        bundle_base_dir,
         null, // path_prefix parameter - null means no stripping
         &error_ctx,
     ) catch |err| {
@@ -7301,4 +7423,38 @@ test "classifyNativeRunTermination preserves signal termination" {
 
     try testing.expect(result == .signal);
     try testing.expectEqual(@as(u32, 11), result.signal);
+}
+
+test "longestCommonParentDir" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    const cases = [_]struct {
+        paths: []const []const u8,
+        expected: []const u8,
+    }{
+        // Single file: parent directory of that file.
+        .{ .paths = &.{"/tmp/pkg/main.roc"}, .expected = "/tmp/pkg" },
+        // Two files sharing a parent.
+        .{ .paths = &.{ "/tmp/pkg/main.roc", "/tmp/pkg/Mod.roc" }, .expected = "/tmp/pkg" },
+        // Files in sibling subdirectories: common parent.
+        .{ .paths = &.{ "/tmp/nested/a/main.roc", "/tmp/nested/b/Mod.roc" }, .expected = "/tmp/nested" },
+        // Names share a byte prefix but no directory boundary — must back up.
+        .{ .paths = &.{ "/tmp/abc/a.roc", "/tmp/abd/b.roc" }, .expected = "/tmp" },
+        // Only root in common.
+        .{ .paths = &.{ "/etc/foo.roc", "/var/bar.roc" }, .expected = "/" },
+        // Three files with same parent.
+        .{ .paths = &.{ "/a/b/c/x.roc", "/a/b/c/y.roc", "/a/b/c/z.roc" }, .expected = "/a/b/c" },
+        // Three files where the third narrows the common parent.
+        .{ .paths = &.{ "/a/b/c/x.roc", "/a/b/c/y.roc", "/a/b/d/z.roc" }, .expected = "/a/b" },
+    };
+
+    for (cases) |tc| {
+        const got = try longestCommonParentDir(allocator, tc.paths);
+        defer allocator.free(got);
+        testing.expectEqualStrings(tc.expected, got) catch |err| {
+            std.debug.print("Failed case: expected='{s}' got='{s}'\n", .{ tc.expected, got });
+            return err;
+        };
+    }
 }


### PR DESCRIPTION
Resolve absolute and cwd-relative input paths to their longest common parent directory and use that as the bundle base, so the archive itself only ever contains relative paths. The unbundle-side absolute-path rejection (the actual security boundary) is unchanged.

Fixes #9406