### PR TITLE
Fixes for Windows MIR re-write `zig build minici`

### DIFF
--- a/src/backend/dev/FrameBuilder.zig
+++ b/src/backend/dev/FrameBuilder.zig
@@ -409,15 +409,20 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
 
             // 1. Allocate frame and save FP/LR
             if (aligned_frame <= 504) {
-                // Small frame: stp pre-index (scaled offset fits in i7)
+                // Small frame: stp pre-index (scaled offset fits in i7).
+                // No probe needed — frame is smaller than one page.
                 const scaled_offset: i7 = @intCast(@divExact(-@as(i32, @intCast(aligned_frame)), 8));
                 try emit.stpPreIndex(.w64, .FP, .LR, .ZRSP, scaled_offset);
+            } else if (windowsNeedsStackProbe(aligned_frame)) {
+                // Windows: probe each guard page before committing.
+                try emitWindowsStackProbeAarch64(emit, aligned_frame);
+                try emit.stpSignedOffset(.w64, .FP, .LR, .ZRSP, 0);
             } else if (aligned_frame <= 4095) {
-                // Medium frame: sub sp with imm12, then store FP/LR at [sp]
+                // Medium frame (non-Windows, or Windows < one page is impossible here).
                 try emit.subRegRegImm12(.w64, .ZRSP, .ZRSP, @intCast(aligned_frame));
                 try emit.stpSignedOffset(.w64, .FP, .LR, .ZRSP, 0);
             } else {
-                // Large frame: load size into scratch register, sub from sp
+                // Large frame (non-Windows): load size into scratch register, sub from sp.
                 try emit.movRegImm64(.IP0, aligned_frame);
                 try emit.subRegRegReg(.w64, .ZRSP, .ZRSP, .IP0);
                 try emit.stpSignedOffset(.w64, .FP, .LR, .ZRSP, 0);
@@ -434,6 +439,50 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
             // Return initial stack offset (positive from FP for aarch64)
             // Locals start after FP/LR (16) + callee-saved area
             return 16 + @as(i32, @intCast(callee_saved_space));
+        }
+
+        /// Emit an inline stack-probe loop equivalent to MSVC's `__chkstk` for
+        /// AArch64. The x86_64 prologue grew the same logic in commit 8964805938
+        /// — without it, a direct `sub sp, N` for frames ≥ one page skips
+        /// guard pages and the program later faults with STATUS_ACCESS_VIOLATION
+        /// on the first access to an uncommitted page. On Windows ARM64 the
+        /// default stack commit is also 4 KB, so the same bug reproduces (CI:
+        /// test/fx/record_builder_cli_parser.roc [dev] on Windows 11 ARM).
+        ///
+        /// Counter in IP0 (x16), page-size constant in IP1 (x17). Both are
+        /// caller-saved scratch in every AArch64 ABI we target.
+        ///
+        ///   mov   x16, alloc_size       ; counter
+        ///   mov   x17, #0x1000          ; page size (movz, lsl #12 → single insn)
+        /// .loop:
+        ///   sub   sp, sp, x17           ; lower one page
+        ///   str   xzr, [sp]             ; touch the new top to commit it
+        ///   sub   x16, x16, x17
+        ///   cmp   x16, x17
+        ///   b.hi  .loop                 ; while remaining > one page
+        ///   sub   sp, sp, x16           ; allocate remainder (may be zero)
+        ///   str   xzr, [sp]             ; probe the final page
+        ///
+        /// The trailing `stp fp, lr, [sp]` from the caller overwrites the final
+        /// probe at [sp+0] — that's intentional; the probe was only there to
+        /// commit the page.
+        fn emitWindowsStackProbeAarch64(emit: *EmitType, alloc_size: u32) !void {
+            try emit.movRegImm64(.IP0, alloc_size);
+            try emit.movRegImm32(.w64, .IP1, 0x1000);
+
+            const loop_start = emit.buf.items.len;
+            try emit.subRegRegReg(.w64, .ZRSP, .ZRSP, .IP1);
+            try emit.strRegMemUoff(.w64, .ZRSP, .ZRSP, 0);
+            try emit.subRegRegReg(.w64, .IP0, .IP0, .IP1);
+            try emit.cmpRegReg(.w64, .IP0, .IP1);
+
+            // b.hi loop_start — branch if counter > page size (still ≥ one page left)
+            const bcond_pos: i64 = @intCast(emit.buf.items.len);
+            const target_pos: i64 = @intCast(loop_start);
+            try emit.bcond(.hi, @intCast(target_pos - bcond_pos));
+
+            try emit.subRegRegReg(.w64, .ZRSP, .ZRSP, .IP0);
+            try emit.strRegMemUoff(.w64, .ZRSP, .ZRSP, 0);
         }
 
         fn emitEpilogueAarch64(self: *Self, emit: *EmitType) !void {

--- a/src/backend/dev/FrameBuilder.zig
+++ b/src/backend/dev/FrameBuilder.zig
@@ -201,8 +201,8 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
             // mov rbp, rsp (3 bytes: 48 89 E5)
             size += 3;
 
-            // sub rsp, imm (7 bytes for 32-bit imm: 48 81 EC xx xx xx xx)
-            // Only if stack_alloc > 0
+            // Stack allocation. On Windows we must probe the stack page-by-page
+            // for any frame ≥ one page; see emitPrologueX86_64 for details.
             // Use full AREA_SIZE (not just actual callee-saved bytes) because
             // stack_offset is initialized to -CALLEE_SAVED_AREA_SIZE, so locals
             // are allocated after the full reserved area.
@@ -210,7 +210,12 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
             const total_needed = self.stack_size + callee_saved_space;
             const aligned_size = CC.alignStackSize(total_needed);
             if (aligned_size > 0) {
-                size += 7;
+                if (windowsNeedsStackProbe(aligned_size)) {
+                    size += windows_probe_loop_size;
+                } else {
+                    // sub rsp, imm (7 bytes for 32-bit imm: 48 81 EC xx xx xx xx)
+                    size += 7;
+                }
             }
 
             // mov [rbp-offset], reg for each callee-saved (4-8 bytes each)
@@ -227,6 +232,35 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
             }
 
             return size;
+        }
+
+        /// Exact byte count of the inline stack-probe loop emitted by
+        /// `emitWindowsStackProbe`. Must stay in sync with that emitter —
+        /// `calculatePrologueSize` reports it to deferred-prologue patching.
+        const windows_probe_loop_size: u32 =
+            // mov rax, imm32 (always REX.W + C7 + ModRM + imm32 = 7 bytes)
+            7 +
+            // sub rsp, 0x1000 (REX.W + 81 + ModRM + imm32 = 7 bytes)
+            7 +
+            // mov [rsp], eax (89 + ModRM disp32 + SIB + disp32 = 7 bytes)
+            7 +
+            // sub eax, 0x1000 (RAX short form: 2D + imm32 = 5 bytes)
+            5 +
+            // cmp eax, 0x1000 (RAX short form: 3D + imm32 = 5 bytes)
+            5 +
+            // ja rel32 (0F 87 + rel32 = 6 bytes)
+            6 +
+            // sub rsp, rax (REX.W + 29 + ModRM = 3 bytes)
+            3 +
+            // mov [rsp], eax (final probe, 7 bytes)
+            7;
+
+        /// True when this frame must probe the stack page-by-page on Windows.
+        /// Direct `sub rsp, N` with N ≥ one page skips guard pages with the
+        /// default stack commit, causing STATUS_ACCESS_VIOLATION on later
+        /// accesses to pages below the original commit boundary.
+        fn windowsNeedsStackProbe(aligned_size: u32) bool {
+            return is_windows and aligned_size >= 0x1000;
         }
 
         fn emitPrologueX86_64(self: *Self, emit: *EmitType) !i32 {
@@ -246,7 +280,11 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
             self.actual_stack_alloc = CC.alignStackSize(total_needed);
 
             if (self.actual_stack_alloc > 0) {
-                try emit.subRegImm32(.w64, .RSP, @intCast(self.actual_stack_alloc));
+                if (windowsNeedsStackProbe(self.actual_stack_alloc)) {
+                    try emitWindowsStackProbe(emit, self.actual_stack_alloc);
+                } else {
+                    try emit.subRegImm32(.w64, .RSP, @intCast(self.actual_stack_alloc));
+                }
             }
 
             // 4. Save callee-saved registers at fixed RBP offsets
@@ -255,6 +293,43 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
             // Return initial stack offset (0 for x86_64 since we use negative RBP offsets)
             // Callers use negative offsets from RBP for locals
             return 0;
+        }
+
+        /// Emit an inline stack-probe loop equivalent to calling MSVC's
+        /// `__chkstk`. Required on Windows for any frame ≥ one page so each
+        /// guard page is touched in order — a direct `sub rsp, N` skips
+        /// guard pages and yields a delayed STATUS_ACCESS_VIOLATION when the
+        /// uncommitted page is later accessed (test/fx record_builder_cli_parser
+        /// reproduced this on the default 4 KB stack commit).
+        ///
+        /// Layout (must remain byte-exact with `windows_probe_loop_size`):
+        ///   mov   rax, alloc_size       ; counter — caller-saved on Windows ABI
+        /// .loop:
+        ///   sub   rsp, 0x1000           ; lower one page
+        ///   mov   [rsp], eax            ; touch the new top to commit it
+        ///   sub   eax, 0x1000
+        ///   cmp   eax, 0x1000
+        ///   ja    .loop                 ; rel32 — sized in calculatePrologueSize
+        ///   sub   rsp, rax              ; allocate remaining bytes
+        ///   mov   [rsp], eax            ; probe the final page — MSVC's
+        ///                                ; __chkstk probes every page including
+        ///                                ; the partial one; without this probe
+        ///                                ; the remainder slips past the guard.
+        fn emitWindowsStackProbe(emit: *EmitType, alloc_size: u32) !void {
+            const buf_before_emit = emit.buf.items.len;
+            try emit.movRegImm32(.RAX, @intCast(alloc_size));
+            const loop_start = emit.buf.items.len;
+            try emit.subRegImm32(.w64, .RSP, 0x1000);
+            try emit.movMemReg(.w32, .RSP, 0, .RAX);
+            try emit.subRegImm32(.w32, .RAX, 0x1000);
+            try emit.cmpRegImm32(.w32, .RAX, 0x1000);
+            // ja loop_start: offset is from end-of-jcc to target.
+            const after_ja = emit.buf.items.len + 6; // jccRel32 emits 6 bytes
+            const rel: i32 = @intCast(@as(i64, @intCast(loop_start)) - @as(i64, @intCast(after_ja)));
+            try emit.jccRel32(.above, rel);
+            try emit.subRegReg(.w64, .RSP, .RAX);
+            try emit.movMemReg(.w32, .RSP, 0, .RAX);
+            std.debug.assert(emit.buf.items.len - buf_before_emit == windows_probe_loop_size);
         }
 
         fn emitEpilogueX86_64(self: *Self, emit: *EmitType) !void {

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -676,6 +676,14 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         /// and generateEarlyReturn.
         ret_ptr_slot: ?i32 = null,
 
+        /// Per-proc shared stack slot for debug-assertion crash messages.
+        /// Debug asserts each emit a unique msg, but only one fires at runtime
+        /// (the program crashes after the first). Sharing one slot across all
+        /// debug crash sites in a proc keeps the frame from growing linearly
+        /// with the number of debug asserts. Lazily allocated on first use.
+        proc_debug_msg_slot: ?i32 = null,
+        proc_debug_args_slot: ?i32 = null,
+
         /// Counter for unique temporary local IDs.
         /// Starts at 0x8000_0000 to avoid collision with real local variables.
         /// Used by allocTempGeneral() for temporaries that don't correspond to real locals.
@@ -1058,6 +1066,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         ) Allocator.Error!CodeResult {
             // Clear any leftover state from compileAllProcSpecs
             self.local_locations.clearRetainingCapacity();
+            self.proc_debug_msg_slot = null;
+            self.proc_debug_args_slot = null;
             self.codegen.callee_saved_used = 0;
 
             // Initialize stack_offset to reserve space for callee-saved area
@@ -4293,7 +4303,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 },
             );
             defer self.allocator.free(msg);
-            try self.emitRocCrash(msg);
+            try self.emitRocCrashShared(msg);
             try self.emitTrap();
 
             const done = self.codegen.currentOffset();
@@ -4403,7 +4413,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 },
             );
             defer self.allocator.free(msg);
-            try self.emitRocCrash(msg);
+            try self.emitRocCrashShared(msg);
             try self.emitTrap();
         }
 
@@ -9466,7 +9476,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     .{ hosted.dispatch_index, if (self.current_proc_name) |sym| sym.raw() else std.math.maxInt(u64) },
                 );
                 defer self.allocator.free(msg);
-                try self.emitRocCrash(msg);
+                try self.emitRocCrashShared(msg);
                 try self.emitTrap();
                 self.codegen.patchJump(count_ok_patch, self.codegen.currentOffset());
             }
@@ -11426,6 +11436,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const saved_current_proc_name = self.current_proc_name;
             const saved_current_proc_args = self.current_proc_args;
             const saved_current_stmt_id = self.current_stmt_id;
+            const saved_proc_debug_msg_slot = self.proc_debug_msg_slot;
+            const saved_proc_debug_args_slot = self.proc_debug_args_slot;
             var saved_local_locations = self.local_locations.clone() catch return error.OutOfMemory;
             defer saved_local_locations.deinit();
             var saved_join_points = self.join_points.clone() catch return error.OutOfMemory;
@@ -11446,6 +11458,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             // Clear state for procedure's scope
             self.local_locations.clearRetainingCapacity();
             self.clearFunctionControlFlowState();
+            self.proc_debug_msg_slot = null;
+            self.proc_debug_args_slot = null;
             self.codegen.callee_saved_used = 0;
             self.codegen.callee_saved_available = CodeGen.CALLEE_SAVED_GENERAL_MASK;
             self.codegen.free_general = CodeGen.INITIAL_FREE_GENERAL;
@@ -11522,6 +11536,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 self.current_proc_name = saved_current_proc_name;
                 self.current_proc_args = saved_current_proc_args;
                 self.current_stmt_id = saved_current_stmt_id;
+                self.proc_debug_msg_slot = saved_proc_debug_msg_slot;
+                self.proc_debug_args_slot = saved_proc_debug_args_slot;
                 self.local_locations.deinit();
                 self.local_locations = saved_local_locations.clone() catch unreachable;
                 self.join_points.deinit();
@@ -11712,6 +11728,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.current_proc_name = saved_current_proc_name;
             self.current_proc_args = saved_current_proc_args;
             self.current_stmt_id = saved_current_stmt_id;
+            self.proc_debug_msg_slot = saved_proc_debug_msg_slot;
+            self.proc_debug_args_slot = saved_proc_debug_args_slot;
             self.local_locations.deinit();
             self.local_locations = saved_local_locations.clone() catch return error.OutOfMemory;
             self.join_points.deinit();
@@ -13333,12 +13351,45 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             return .{ .stack_str = base_offset };
         }
 
+        /// Max size of any debug-assertion crash message (in bytes, aligned to 8).
+        /// Used to size the per-proc shared msg slot. Generous to cover any
+        /// future debug messages without re-tuning. Sharing this single slot
+        /// across all debug crashes in a proc keeps the proc's frame from
+        /// growing linearly with the number of debug asserts.
+        const debug_msg_slot_size: u32 = 256;
+
         fn emitRocStaticMessageCall(self: *Self, field_offset: i32, msg: []const u8) Allocator.Error!void {
+            return self.emitRocStaticMessageCallShared(field_offset, msg, false);
+        }
+
+        /// Like `emitRocStaticMessageCall`, but reuses a single per-proc stack
+        /// slot for the message and args. Safe because only one debug crash
+        /// can fire per program run — the program exits after the first.
+        fn emitRocStaticDebugMessageCall(self: *Self, field_offset: i32, msg: []const u8) Allocator.Error!void {
+            return self.emitRocStaticMessageCallShared(field_offset, msg, true);
+        }
+
+        fn emitRocStaticMessageCallShared(self: *Self, field_offset: i32, msg: []const u8, shared: bool) Allocator.Error!void {
             const roc_ops_reg = self.roc_ops_reg orelse unreachable;
 
             const msg_aligned_size: u32 = std.mem.alignForward(u32, @intCast(msg.len), 8);
-            const msg_slot = self.codegen.allocStackSlot(if (msg_aligned_size == 0) 8 else msg_aligned_size);
-            const args_slot = self.codegen.allocStackSlot(16);
+            const effective_size: u32 = if (msg_aligned_size == 0) 8 else msg_aligned_size;
+            // If the message is unexpectedly larger than the shared slot we
+            // fall back to a fresh per-call allocation. Keeps the safety
+            // invariant even if a future caller passes a long string.
+            const can_share = shared and effective_size <= debug_msg_slot_size;
+            const msg_slot = if (can_share) blk: {
+                if (self.proc_debug_msg_slot) |existing| break :blk existing;
+                const slot = self.codegen.allocStackSlot(debug_msg_slot_size);
+                self.proc_debug_msg_slot = slot;
+                break :blk slot;
+            } else self.codegen.allocStackSlot(effective_size);
+            const args_slot = if (can_share) blk: {
+                if (self.proc_debug_args_slot) |existing| break :blk existing;
+                const slot = self.codegen.allocStackSlot(16);
+                self.proc_debug_args_slot = slot;
+                break :blk slot;
+            } else self.codegen.allocStackSlot(16);
 
             const base_reg = frame_ptr;
             const tmp = try self.allocTempGeneral();
@@ -13399,6 +13450,13 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         /// Emit a roc_crashed call via RocOps with a static message.
         fn emitRocCrash(self: *Self, msg: []const u8) Allocator.Error!void {
             try self.emitRocStaticMessageCall(@offsetOf(RocOps, "roc_crashed"), msg);
+        }
+
+        /// Same as `emitRocCrash`, but reuses a per-proc shared msg/args slot.
+        /// Only safe from debug-assertion paths, where at most one fires per
+        /// run (the program exits immediately after).
+        fn emitRocCrashShared(self: *Self, msg: []const u8) Allocator.Error!void {
+            try self.emitRocStaticDebugMessageCall(@offsetOf(RocOps, "roc_crashed"), msg);
         }
 
         fn emitTrap(self: *Self) Allocator.Error!void {

--- a/src/backend/dev/ObjectFileCompiler.zig
+++ b/src/backend/dev/ObjectFileCompiler.zig
@@ -111,16 +111,36 @@ pub const ObjectFileCompiler = struct {
         );
         defer result.deinit();
 
-        // Write to file
-        std.fs.cwd().writeFile(.{
-            .sub_path = output_path,
-            .data = result.object_bytes,
-        }) catch |err| {
+        writeFileWindowsAvSafe(output_path, result.object_bytes) catch |err| {
             std.log.err("failed to write object file {s}: {}", .{ output_path, err });
             return CompilationError.ObjectGenerationFailed;
         };
     }
 };
+
+/// On Windows, filter drivers (Defender, EDR agents) can transiently hold a
+/// just-created file open and return AccessDenied on a follow-up write from a
+/// sibling process. Retry a few times with exponential backoff. Other OSes
+/// pass through to a single writeFile call.
+pub fn writeFileWindowsAvSafe(sub_path: []const u8, data: []const u8) !void {
+    if (comptime builtin.os.tag != .windows) {
+        return std.fs.cwd().writeFile(.{ .sub_path = sub_path, .data = data });
+    }
+    var attempt: u32 = 0;
+    const max_attempts: u32 = 6;
+    while (true) : (attempt += 1) {
+        std.fs.cwd().writeFile(.{ .sub_path = sub_path, .data = data }) catch |err| switch (err) {
+            error.AccessDenied => {
+                if (attempt + 1 >= max_attempts) return err;
+                const delay_ns: u64 = @as(u64, 10) * std.time.ns_per_ms * (@as(u64, 1) << @intCast(attempt));
+                std.Thread.sleep(delay_ns);
+                continue;
+            },
+            else => return err,
+        };
+        return;
+    }
+}
 
 /// Generic compilation function parameterized by code generator type.
 fn compileWithCodeGen(

--- a/src/backend/dev/mod.zig
+++ b/src/backend/dev/mod.zig
@@ -54,6 +54,7 @@ pub const StaticDataExport = @import("StaticDataExport.zig").StaticDataExport;
 pub const StaticDataRelocation = @import("StaticDataExport.zig").StaticDataRelocation;
 pub const procSymbolName = @import("StaticDataExport.zig").procSymbolName;
 pub const CompilationResult = if (builtin.os.tag == .freestanding) void else @import("ObjectFileCompiler.zig").CompilationResult;
+pub const writeFileWindowsAvSafe = @import("ObjectFileCompiler.zig").writeFileWindowsAvSafe;
 
 /// Generic development backend parameterized by architecture-specific types.
 ///

--- a/src/backend/mod.zig
+++ b/src/backend/mod.zig
@@ -34,6 +34,7 @@ pub const StaticDataRelocation = dev.StaticDataRelocation;
 pub const procSymbolName = dev.procSymbolName;
 pub const ObjectFileCompiler = dev.ObjectFileCompiler;
 pub const CompilationResult = dev.CompilationResult;
+pub const writeFileWindowsAvSafe = dev.writeFileWindowsAvSafe;
 pub const resolveBuiltinFunction = dev.resolveBuiltinFunction;
 
 test "backend tests" {

--- a/src/check/test/unify_test.zig
+++ b/src/check/test/unify_test.zig
@@ -1807,10 +1807,9 @@ test "unify - non-numeric flex with rigid keeps constraints deferred-only" {
 
     const resolved = env.module_env.types.resolveVar(rigid_var);
     try std.testing.expect(resolved.desc.content == .rigid);
-    try std.testing.expectEqual(
-        types_mod.StaticDispatchConstraint.SafeList.Range.empty(),
-        resolved.desc.content.rigid.constraints,
-    );
+    // Range.empty() leaves .start undefined; structural expectEqual would read it
+    // and fail under ReleaseFast. Check emptiness via count instead.
+    try std.testing.expectEqual(@as(u32, 0), resolved.desc.content.rigid.constraints.count);
     try std.testing.expectEqual(1, env.scratch.deferred_constraints.len());
     try std.testing.expectEqual(constraints, env.scratch.deferred_constraints.items.items[0].constraints);
 }

--- a/src/cli/linker.zig
+++ b/src/cli/linker.zig
@@ -115,6 +115,13 @@ pub const LinkConfig = struct {
     /// For example, if this is "/path/to/platform/targets", the linker will look for
     /// "/path/to/platform/targets/macos-sysroot" when linking for macOS.
     platform_files_dir: ?[]const u8 = null,
+
+    /// Per-build scratch directory for linker-generated intermediate object files
+    /// (e.g. the Windows stack_probe.obj). When multiple `roc build` processes
+    /// run in parallel against the same exe_dir they would otherwise collide on
+    /// a shared filename. When null, the linker falls back to the directory
+    /// containing the running `roc` executable.
+    scratch_dir: ?[]const u8 = null,
 };
 
 /// Errors that can occur during linking
@@ -420,15 +427,15 @@ fn buildLinkArgs(ctx: *CliContext, config: LinkConfig) LinkError!std.array_list.
             // the MinGW ABI, which requires ___chkstk_ms for functions with large stack frames.
             if (target_arch == .x86_64) {
                 const stack_probe_obj = stack_probe.generateStackProbeObject(ctx.arena) catch return LinkError.OutOfMemory;
-                // Write to a temp file and add to link line
+                // Prefer a per-build scratch dir so parallel `roc build` invocations
+                // don't race on a shared zig-out/bin/stack_probe.obj (truncated
+                // writes from one linker can corrupt what another linker is reading).
+                const probe_dir = config.scratch_dir orelse (std.fs.selfExeDirPathAlloc(ctx.arena) catch return LinkError.OutOfMemory);
                 const stack_probe_path = std.fs.path.join(ctx.arena, &.{
-                    std.fs.selfExeDirPathAlloc(ctx.arena) catch return LinkError.OutOfMemory,
+                    probe_dir,
                     "stack_probe.obj",
                 }) catch return LinkError.OutOfMemory;
-                std.fs.cwd().writeFile(.{
-                    .sub_path = stack_probe_path,
-                    .data = stack_probe_obj,
-                }) catch return LinkError.OutOfMemory;
+                @import("backend").writeFileWindowsAvSafe(stack_probe_path, stack_probe_obj) catch return LinkError.OutOfMemory;
                 try args.append(stack_probe_path);
             }
         },

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -3596,10 +3596,7 @@ fn rocBuildNative(ctx: *CliContext, args: cli_args.BuildArgs) !void {
     }
 
     const builtins_path = try std.fs.path.join(ctx.arena, &.{ build_cache_dir, BuiltinsObjects.filename(target) });
-    std.fs.cwd().writeFile(.{
-        .sub_path = builtins_path,
-        .data = BuiltinsObjects.forTarget(target),
-    }) catch |err| {
+    backend.writeFileWindowsAvSafe(builtins_path, BuiltinsObjects.forTarget(target)) catch |err| {
         std.log.err("Failed to write builtins object file: {}", .{err});
         return error.BuiltinsExtractionFailed;
     };

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -327,11 +327,9 @@ const legalDetailsFileContent = @embedFile("legal_details");
 /// memory fragmentation. With a 25KB source file, type checking can use ~2GB
 /// of shared memory due to this fragmentation.
 ///
-/// On 64-bit Linux/Windows, we reserve 2TB of virtual address space. This is possible
-/// without consuming physical memory:
-/// - On Linux: memfd_create with lazy page allocation means untouched pages cost nothing.
-/// - On Windows: SEC_RESERVE reserves virtual address space without page file backing,
-///   and VirtualAlloc(MEM_COMMIT) commits pages on-demand as they're accessed.
+/// On 64-bit Linux, we reserve 2TB of virtual address space. This is possible
+/// without consuming physical memory because memfd_create with lazy page
+/// allocation means untouched pages cost nothing.
 ///
 /// On macOS, shm_open + ftruncate creates a Mach VM object with higher per-object
 /// kernel overhead than Linux's memfd_create. Using 2TB causes kernel resource pressure
@@ -339,13 +337,22 @@ const legalDetailsFileContent = @embedFile("legal_details");
 /// in a loop), leading to SIGKILL from the jetsam memory pressure system.
 /// We use 8GB on macOS which provides ample headroom while keeping kernel overhead low.
 ///
+/// On Windows, SEC_RESERVE on CreateFileMapping reserves address space without
+/// page file backing, but MapViewOfFile still appears to charge against the
+/// system commit limit. Under parallel test load (`zig build test` with several
+/// workers each spawning `roc.exe`), four concurrent 2 TB reservations trip
+/// ERROR_COMMITMENT_LIMIT on CI runners (7 GB RAM + limited page file). 8 GB
+/// matches the macOS bound and leaves plenty of headroom for real programs.
+///
 /// On 32-bit targets, we use 256MB since larger sizes won't fit in the address space.
 const SHARED_MEMORY_SIZE: usize = if (@sizeOf(usize) < 8)
     256 * 1024 * 1024 // 256MB for 32-bit targets
 else if (builtin.os.tag == .macos)
     8 * 1024 * 1024 * 1024 // 8GB for macOS (shm_open has higher kernel overhead)
+else if (builtin.os.tag == .windows)
+    8 * 1024 * 1024 * 1024 // 8GB for Windows (MapViewOfFile commit accounting)
 else
-    2 * 1024 * 1024 * 1024 * 1024; // 2TB for 64-bit Linux/Windows
+    2 * 1024 * 1024 * 1024 * 1024; // 2TB for 64-bit Linux
 
 /// Create the shared-memory arena used for the parent-produced LIR runtime
 /// image. Allocation failure is reported directly; the compiler must not

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1223,6 +1223,7 @@ fn rocRun(ctx: *CliContext, args: cli_args.RunArgs) !void {
             .can_exit_early = false,
             .disable_output = false,
             .platform_files_dir = platform_files_dir,
+            .scratch_dir = temp_dir_path,
         };
 
         linker.link(ctx, link_config) catch |err| {
@@ -3619,6 +3620,7 @@ fn rocBuildNative(ctx: *CliContext, args: cli_args.BuildArgs) !void {
         .can_exit_early = false,
         .disable_output = false,
         .platform_files_dir = platform_files_dir,
+        .scratch_dir = build_cache_dir,
     };
 
     if (args.z_dump_linker) {
@@ -3959,6 +3961,7 @@ fn rocBuildEmbedded(ctx: *CliContext, args: cli_args.BuildArgs) !void {
         .wasm_initial_memory = args.wasm_memory orelse linker.DEFAULT_WASM_INITIAL_MEMORY,
         .wasm_stack_size = args.wasm_stack_size orelse linker.DEFAULT_WASM_STACK_SIZE,
         .platform_files_dir = platform_files_dir,
+        .scratch_dir = build_cache_dir,
     };
 
     if (args.z_dump_linker) {

--- a/test/snapshots/type_app_complex_nested.md
+++ b/test/snapshots/type_app_complex_nested.md
@@ -299,7 +299,7 @@ main! = |_| processComplex(Ok([Some(42), None]))
 		(e-lambda
 			(args
 				(p-underscore))
-			(e-call (constraint-fn-var 173)
+			(e-call (constraint-fn-var 207)
 				(e-lookup-local
 					(p-assign (ident "processComplex")))
 				(e-tag (name "Ok")

--- a/test/snapshots/type_app_multiple_args.md
+++ b/test/snapshots/type_app_multiple_args.md
@@ -95,12 +95,12 @@ NO CHANGE
 		(e-lambda
 			(args
 				(p-underscore))
-			(e-call
+			(e-call (constraint-fn-var 190)
 				(e-lookup-local
 					(p-assign (ident "processDict")))
-				(e-method-call (method "insert")
+				(e-dispatch-call (method "insert") (constraint-fn-var 126)
 					(receiver
-						(e-call
+						(e-call (constraint-fn-var 109)
 							(e-lookup-external
 								(builtin))))
 					(args


### PR DESCRIPTION
Fixes five issues for Windows; 

1. dev-backend debug-assert message slots inflated frames ~5 KB per str-returning callsite (now shared per-proc, frame shrunk 22 KB → 3 KB on `app_just_str.roc`)
2. the x86_64 prologue emitted an unconditional `sub rsp, N` that skipped Windows guard pages for frames ≥ 4 KB (now an inline page-probe loop mirroring MSVC `__chkstk`)
3. freshly-created `.obj` writes intermittently hit `error.AccessDenied` from AV/EDR filter drivers (new `writeFileWindowsAvSafe` retries with exponential backoff, applied to the per-app object and the builtins object)
4. `stack_probe.obj` was written to a single shared `zig-out/bin/` path by every linker invocation, so parallel workers corrupted each other's COFF and produced undefined symbol: `___chkstk_ms` (new `LinkConfig.scratch_dir` routes it into `build_cache_dir`/`temp_dir_path`)
5. two type-app snapshot fixtures were stale relative to current canonicalization output and have been regenerated.