### PR TITLE
Store big string literals as static data

### DIFF
--- a/src/base/StringLiteral.zig
+++ b/src/base/StringLiteral.zig
@@ -24,30 +24,183 @@ pub const Idx = enum(u32) {
 /// The deduplication uses a linear search through existing strings, which is acceptable
 /// because the number of unique string literals in pattern matching is typically small.
 pub const Store = struct {
-    /// An Idx points to the
-    /// first byte of the string. The previous
-    /// 4 bytes encode it's length.
-    ///          Idx of "well"
-    ///           |
-    ///           |
-    ///           |
-    /// |    3   |w|e|l|l|   5    |h|e|l|l|o|
-    /// |---u32--|--u8---|--u32---|--u8-----|
-    /// conceptually these are the sizes above.
+    /// An Idx points to the first byte of the string. The entry immediately
+    /// before it stores a static refcount word, and the entry header stores
+    /// the string length:
+    ///
+    /// | len: u32 | padding | static refcount: isize | bytes... |
+    ///
+    /// The byte pointer at Idx can therefore be used directly as big `RocStr`
+    /// static data. Runtime refcount operations read the word immediately
+    /// before the bytes and see `0`, the static-data refcount sentinel.
     ///
     /// Note:
     /// Later we could change from fixed u32-s to variable lengthed
     /// sizes, encoded in reverse where for example,
     /// the first 7 bit would signal the length, the last bit would signal that the length
     /// continues to the previous byte
-    buffer: collections.SafeList(u8) = .{},
+    buffer: Buffer = .{},
+
+    const len_size = @sizeOf(u32);
+    const static_refcount_size = @sizeOf(isize);
+    pub const static_refcount_alignment = @alignOf(isize);
+    const static_refcount_alignment_value = std.mem.Alignment.fromByteUnits(static_refcount_alignment);
+    const refcount_offset_from_entry_start = std.mem.alignForward(usize, len_size, static_refcount_alignment);
+    const entry_header_size = refcount_offset_from_entry_start + static_refcount_size;
+    // Must match builtins.utils.REFCOUNT_STATIC_DATA without making base depend on builtins.
+    const static_refcount_value: isize = 0;
+
+    pub const Buffer = struct {
+        items: std.array_list.Aligned(u8, static_refcount_alignment_value) = .empty,
+
+        const SerializedDataRef = struct {
+            offset: usize,
+            len: usize,
+            capacity: usize,
+        };
+
+        pub const Serialized = extern struct {
+            offset: i64,
+            len: u64,
+            capacity: u64,
+
+            pub fn serialize(
+                self: *@This(),
+                buffer: *const Buffer,
+                allocator: std.mem.Allocator,
+                writer: *CompactWriter,
+            ) std.mem.Allocator.Error!void {
+                const data_ref = try buffer.writeData(allocator, writer);
+
+                self.offset = @intCast(data_ref.offset);
+                self.len = @intCast(data_ref.len);
+                self.capacity = @intCast(data_ref.capacity);
+            }
+
+            pub fn deserializeInto(self: *const @This(), base: usize) Buffer {
+                if (self.capacity == 0) {
+                    return Buffer{};
+                }
+
+                const items_ptr: [*]align(static_refcount_alignment) u8 = @ptrFromInt(base +% @as(usize, @intCast(self.offset)));
+
+                return Buffer{
+                    .items = .{
+                        .items = items_ptr[0..@intCast(self.len)],
+                        .capacity = @intCast(self.capacity),
+                    },
+                };
+            }
+        };
+
+        pub fn initCapacity(gpa: std.mem.Allocator, bytes: usize) std.mem.Allocator.Error!Buffer {
+            return .{
+                .items = try std.array_list.Aligned(u8, static_refcount_alignment_value).initCapacity(gpa, bytes),
+            };
+        }
+
+        pub fn deinit(self: *Buffer, gpa: std.mem.Allocator) void {
+            self.items.deinit(gpa);
+        }
+
+        pub fn clone(self: *const Buffer, gpa: std.mem.Allocator) std.mem.Allocator.Error!Buffer {
+            return .{
+                .items = try self.items.clone(gpa),
+            };
+        }
+
+        pub fn len(self: *const Buffer) usize {
+            return self.items.items.len;
+        }
+
+        pub fn append(self: *Buffer, gpa: std.mem.Allocator, byte: u8) std.mem.Allocator.Error!usize {
+            const start = self.items.items.len;
+            try self.items.append(gpa, byte);
+            return start;
+        }
+
+        pub fn appendSlice(self: *Buffer, gpa: std.mem.Allocator, bytes: []const u8) std.mem.Allocator.Error!usize {
+            const start = self.items.items.len;
+            try self.items.appendSlice(gpa, bytes);
+            return start;
+        }
+
+        pub fn serialize(
+            self: *const Buffer,
+            allocator: std.mem.Allocator,
+            writer: *CompactWriter,
+        ) std.mem.Allocator.Error!*const Buffer {
+            const offset_self = try writer.appendAlloc(allocator, Buffer);
+            offset_self.* = try self.toOffsetBuffer(allocator, writer);
+            return @constCast(offset_self);
+        }
+
+        pub fn relocate(self: *Buffer, offset: isize) void {
+            if (self.items.capacity == 0) return;
+
+            const old_addr: isize = @intCast(@intFromPtr(self.items.items.ptr));
+            const new_addr = @as(usize, @intCast(old_addr + offset));
+            self.items.items.ptr = @ptrFromInt(new_addr);
+        }
+
+        pub fn fromMappedSlice(items: []align(static_refcount_alignment) u8, capacity: usize) Buffer {
+            return .{
+                .items = .{
+                    .items = items,
+                    .capacity = capacity,
+                },
+            };
+        }
+
+        fn toOffsetBuffer(
+            self: *const Buffer,
+            allocator: std.mem.Allocator,
+            writer: *CompactWriter,
+        ) std.mem.Allocator.Error!Buffer {
+            const data_ref = try self.writeData(allocator, writer);
+
+            if (data_ref.capacity == 0) {
+                return Buffer{};
+            }
+
+            const items_ptr: [*]align(static_refcount_alignment) u8 = @ptrFromInt(data_ref.offset);
+
+            return Buffer{
+                .items = .{
+                    .items = items_ptr[0..data_ref.len],
+                    .capacity = data_ref.capacity,
+                },
+            };
+        }
+
+        fn writeData(
+            self: *const Buffer,
+            allocator: std.mem.Allocator,
+            writer: *CompactWriter,
+        ) std.mem.Allocator.Error!SerializedDataRef {
+            if (self.items.items.len == 0) {
+                return .{ .offset = 0, .len = 0, .capacity = 0 };
+            }
+
+            try writer.padToAlignment(allocator, static_refcount_alignment);
+            const data_offset = writer.total_bytes;
+            const bytes: []const u8 = self.items.items;
+            _ = try writer.appendSlice(allocator, bytes);
+
+            return .{
+                .offset = data_offset,
+                .len = self.items.items.len,
+                .capacity = self.items.items.len,
+            };
+        }
+    };
 
     /// Intiizalizes a `Store` with capacity `bytes` of space.
     /// Note this specifically is the number of bytes for storing strings.
     /// The string `hello, world!` will use 14 bytes including the null terminator.
     pub fn initCapacityBytes(gpa: std.mem.Allocator, bytes: usize) std.mem.Allocator.Error!Store {
         return .{
-            .buffer = try collections.SafeList(u8).initCapacity(gpa, bytes),
+            .buffer = try Buffer.initCapacity(gpa, bytes),
         };
     }
 
@@ -76,19 +229,32 @@ pub const Store = struct {
         // String not found, insert it
         const str_len: u32 = @truncate(string.len);
 
+        try self.alignBufferForEntry(gpa);
+
         const str_len_bytes = std.mem.asBytes(&str_len);
         {
             const expected_start = self.buffer.items.items.len;
-            const range = try self.buffer.appendSlice(gpa, str_len_bytes);
-            assertAppendRange(expected_start, @intCast(str_len_bytes.len), range);
+            const start = try self.buffer.appendSlice(gpa, str_len_bytes);
+            assertAppendRange(expected_start, str_len_bytes.len, start, str_len_bytes.len);
+        }
+
+        while (self.buffer.items.items.len % static_refcount_alignment != 0) {
+            _ = try self.buffer.append(gpa, 0);
+        }
+
+        const static_refcount_bytes = std.mem.asBytes(&static_refcount_value);
+        {
+            const expected_start = self.buffer.items.items.len;
+            const start = try self.buffer.appendSlice(gpa, static_refcount_bytes);
+            assertAppendRange(expected_start, static_refcount_bytes.len, start, static_refcount_bytes.len);
         }
 
         const string_content_start = self.buffer.len();
 
         {
             const expected_start = self.buffer.items.items.len;
-            const range = try self.buffer.appendSlice(gpa, string);
-            assertAppendRange(expected_start, @intCast(string.len), range);
+            const start = try self.buffer.appendSlice(gpa, string);
+            assertAppendRange(expected_start, string.len, start, string.len);
         }
 
         return @enumFromInt(@as(u32, @intCast(string_content_start)));
@@ -99,10 +265,13 @@ pub const Store = struct {
         const buffer_items = self.buffer.items.items;
         var pos: usize = 0;
 
-        while (pos + 4 <= buffer_items.len) {
+        while (true) {
+            pos = std.mem.alignForward(usize, pos, static_refcount_alignment);
+            if (pos + entry_header_size > buffer_items.len) break;
+
             // Read the length (4 bytes)
-            const str_len = std.mem.bytesAsValue(u32, buffer_items[pos .. pos + 4]).*;
-            const content_start = pos + 4;
+            const str_len = std.mem.bytesAsValue(u32, buffer_items[pos .. pos + len_size]).*;
+            const content_start = pos + entry_header_size;
             const content_end = content_start + str_len;
 
             if (content_end > buffer_items.len) break;
@@ -123,8 +292,15 @@ pub const Store = struct {
     /// Get a string literal's text from this `Store`.
     pub fn get(self: *const Store, idx: Idx) []u8 {
         const idx_u32: u32 = @intCast(@intFromEnum(idx));
-        const str_len = std.mem.bytesAsValue(u32, self.buffer.items.items[idx_u32 - 4 .. idx_u32]).*;
+        const len_start = idx_u32 - entry_header_size;
+        const str_len = std.mem.bytesAsValue(u32, self.buffer.items.items[len_start .. len_start + len_size]).*;
         return self.buffer.items.items[idx_u32 .. idx_u32 + str_len];
+    }
+
+    fn alignBufferForEntry(self: *Store, gpa: std.mem.Allocator) std.mem.Allocator.Error!void {
+        while (self.buffer.items.items.len % static_refcount_alignment != 0) {
+            _ = try self.buffer.append(gpa, 0);
+        }
     }
 
     /// Serialize this Store to the given CompactWriter. The resulting Store
@@ -139,7 +315,7 @@ pub const Store = struct {
         // First, write the Store struct itself
         const offset_self = try writer.appendAlloc(allocator, Store);
 
-        // Then serialize the buffer SafeList and update the struct
+        // Then serialize the byte buffer and update the struct
         offset_self.* = .{
             .buffer = (try self.buffer.serialize(allocator, writer)).*,
         };
@@ -155,7 +331,7 @@ pub const Store = struct {
     /// Serialized representation of a Store
     /// Uses extern struct to guarantee consistent field layout across optimization levels.
     pub const Serialized = extern struct {
-        buffer: collections.SafeList(u8).Serialized,
+        buffer: Buffer.Serialized,
 
         /// Serialize a Store into this Serialized struct, appending data to the writer
         pub fn serialize(
@@ -164,7 +340,7 @@ pub const Store = struct {
             allocator: std.mem.Allocator,
             writer: *CompactWriter,
         ) std.mem.Allocator.Error!void {
-            // Serialize the buffer SafeList
+            // Serialize the byte buffer
             try self.buffer.serialize(&store.buffer, allocator, writer);
         }
 
@@ -178,13 +354,26 @@ pub const Store = struct {
     };
 };
 
-fn assertAppendRange(expected_start: usize, expected_len: u32, range: collections.SafeList(u8).Range) void {
+fn assertAppendRange(expected_start: usize, expected_len: usize, actual_start: usize, actual_len: usize) void {
     if (comptime builtin.mode == .Debug) {
-        std.debug.assert(@intFromEnum(range.start) == expected_start);
-        std.debug.assert(range.count == expected_len);
-    } else if (@intFromEnum(range.start) != expected_start or range.count != expected_len) {
+        std.debug.assert(actual_start == expected_start);
+        std.debug.assert(actual_len == expected_len);
+    } else if (actual_start != expected_start or actual_len != expected_len) {
         unreachable;
     }
+}
+
+fn expectedNextStringContentStart(previous_end: *usize, string_len: usize) u32 {
+    const entry_start = std.mem.alignForward(usize, previous_end.*, Store.static_refcount_alignment);
+    const content_start = entry_start + Store.entry_header_size;
+    previous_end.* = content_start + string_len;
+    return @intCast(content_start);
+}
+
+fn expectStaticRefcountBefore(bytes: []const u8) !void {
+    try testing.expectEqual(@as(usize, 0), @intFromPtr(bytes.ptr) % Store.static_refcount_alignment);
+    const refcount_ptr: *const isize = @ptrCast(@alignCast(bytes.ptr - @sizeOf(isize)));
+    try testing.expectEqual(Store.static_refcount_value, refcount_ptr.*);
 }
 
 test "insert" {
@@ -200,6 +389,19 @@ test "insert" {
 
     try std.testing.expectEqualStrings("abc", interner.get(idx_1));
     try std.testing.expectEqualStrings("defg", interner.get(idx_2));
+}
+
+test "insert stores static refcount immediately before bytes" {
+    const gpa = std.testing.allocator;
+
+    var interner = Store{};
+    defer interner.deinit(gpa);
+
+    const idx = try interner.insert(gpa, "aaaaaaaaaaaaaaaaaaaaaaaa");
+    const bytes = interner.get(idx);
+
+    try testing.expectEqualStrings("aaaaaaaaaaaaaaaaaaaaaaaa", bytes);
+    try expectStaticRefcountBefore(bytes);
 }
 
 test "Store empty CompactWriter roundtrip" {
@@ -452,7 +654,7 @@ test "Store.Serialized roundtrip" {
 
     // Read back
     const file_size = try tmp_file.getEndPos();
-    const buffer = try gpa.alloc(u8, @as(usize, @intCast(file_size)));
+    const buffer = try gpa.alignedAlloc(u8, std.mem.Alignment.@"16", @as(usize, @intCast(file_size)));
     defer gpa.free(buffer);
     const read_len = try tmp_file.pread(buffer, 0);
     try std.testing.expectEqual(buffer.len, read_len);
@@ -473,26 +675,22 @@ test "Store edge case indices CompactWriter roundtrip" {
     var original = Store{};
     defer original.deinit(gpa);
 
-    // The index returned points to the first byte of the string content,
-    // with the length stored in the previous 4 bytes.
+    // The index returned points to the first byte of the string content.
     // Test various scenarios that might stress the index calculation.
+    var previous_end: usize = 0;
 
-    // First string starts at index 4 (after its length)
     const idx1 = try original.insert(gpa, "first");
-    try std.testing.expectEqual(@as(u32, 4), @intFromEnum(idx1));
+    try std.testing.expectEqual(expectedNextStringContentStart(&previous_end, "first".len), @intFromEnum(idx1));
 
-    // Second string starts at 4 + 5 + 4 = 13
     const idx2 = try original.insert(gpa, "second");
-    try std.testing.expectEqual(@as(u32, 13), @intFromEnum(idx2));
+    try std.testing.expectEqual(expectedNextStringContentStart(&previous_end, "second".len), @intFromEnum(idx2));
 
-    // Empty string
     const idx3 = try original.insert(gpa, "");
-    try std.testing.expectEqual(@as(u32, 23), @intFromEnum(idx3));
+    try std.testing.expectEqual(expectedNextStringContentStart(&previous_end, "".len), @intFromEnum(idx3));
 
-    // Very long string
     const long_str = "x" ** 1000;
     const idx4 = try original.insert(gpa, long_str);
-    try std.testing.expectEqual(@as(u32, 27), @intFromEnum(idx4));
+    try std.testing.expectEqual(expectedNextStringContentStart(&previous_end, long_str.len), @intFromEnum(idx4));
 
     // Create a temp file
     var tmp_dir = std.testing.tmpDir(.{});

--- a/src/cli/test/roc_subcommands.zig
+++ b/src/cli/test/roc_subcommands.zig
@@ -544,6 +544,34 @@ test "roc test/str/app.roc runs successfully (dev)" {
     try testRocRunsSuccessfully("--opt=dev", "test/str/app.roc");
 }
 
+test "roc run test/str/app_static_24_byte_string.roc does not panic" {
+    if (@import("builtin").os.tag == .windows) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    // The minimized app makes the host fail its string assertion after codegen,
+    // but direct `roc file.roc` must not panic before the host runs.
+    const result = try util.runRoc(gpa, &.{"--no-cache"}, "test/str/app_static_24_byte_string.roc");
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    const did_panic = result.term == .Signal or
+        (result.term == .Exited and result.term.Exited == 134) or
+        std.mem.indexOf(u8, result.stderr, "panic") != null or
+        std.mem.indexOf(u8, result.stderr, "reached unreachable code") != null;
+
+    if (did_panic) {
+        std.debug.print("roc direct run panicked\nterm: {}\nstdout: {s}\nstderr: {s}\n", .{
+            result.term,
+            result.stdout,
+            result.stderr,
+        });
+    }
+
+    try testing.expect(!did_panic);
+}
+
 // roc build tests
 
 test "roc build creates executable from test/int/app.roc (interpreter)" {

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -2867,24 +2867,25 @@ pub const Interpreter = struct {
             return self.rocStrToValue(small, .str);
         }
 
-        const total_bytes = @sizeOf(usize) + bytes.len;
-        const storage = switch (@alignOf(usize)) {
-            1 => self.arena.allocator().alignedAlloc(u8, .@"1", total_bytes),
-            2 => self.arena.allocator().alignedAlloc(u8, .@"2", total_bytes),
-            4 => self.arena.allocator().alignedAlloc(u8, .@"4", total_bytes),
-            8 => self.arena.allocator().alignedAlloc(u8, .@"8", total_bytes),
-            16 => self.arena.allocator().alignedAlloc(u8, .@"16", total_bytes),
-            else => @compileError("unsupported usize alignment for static string literal allocation"),
-        } catch return error.OutOfMemory;
-
-        const refcount_ptr: *isize = @ptrCast(@alignCast(storage.ptr));
-        refcount_ptr.* = builtins.utils.REFCOUNT_STATIC_DATA;
-
-        const data_slice = storage[@sizeOf(usize)..];
-        @memcpy(data_slice[0..bytes.len], bytes);
+        if (builtin.mode == .Debug) {
+            const data_addr = @intFromPtr(bytes.ptr);
+            if (data_addr % @alignOf(isize) != 0) {
+                self.invariantFailed(
+                    "LIR/interpreter invariant violated: static string literal bytes are not refcount-aligned",
+                    .{},
+                );
+            }
+            const refcount_ptr: *const isize = @ptrCast(@alignCast(bytes.ptr - @sizeOf(isize)));
+            if (refcount_ptr.* != builtins.utils.REFCOUNT_STATIC_DATA) {
+                self.invariantFailed(
+                    "LIR/interpreter invariant violated: static string literal missing static refcount",
+                    .{},
+                );
+            }
+        }
 
         const rs = RocStr{
-            .bytes = @ptrCast(data_slice.ptr),
+            .bytes = @ptrCast(@constCast(bytes.ptr)),
             .length = bytes.len,
             .capacity_or_alloc_ptr = bytes.len,
         };

--- a/src/lir/runtime_image.zig
+++ b/src/lir/runtime_image.zig
@@ -115,7 +115,7 @@ pub const StringLiteralStoreImage = extern struct {
 
     fn view(self: StringLiteralStoreImage, base_ptr: [*]align(1) u8, image_size: usize) ImageError!base.StringLiteral.Store {
         return .{
-            .buffer = safeListFromRef(u8, base_ptr, image_size, self.buffer),
+            .buffer = stringLiteralBufferFromRef(base_ptr, image_size, self.buffer),
         };
     }
 };
@@ -275,6 +275,14 @@ fn safeListFromRef(comptime T: type, base_ptr: [*]align(1) u8, image_size: usize
             .capacity = @intCast(ref.capacity),
         },
     };
+}
+
+fn stringLiteralBufferFromRef(base_ptr: [*]align(1) u8, image_size: usize, ref: ArrayRef) base.StringLiteral.Store.Buffer {
+    if (ref.capacity == 0) return .{};
+    debugCheckByteRef(image_size, ref, @as(usize, @intCast(ref.len)));
+
+    const ptr: [*]align(base.StringLiteral.Store.static_refcount_alignment) u8 = @ptrCast(@alignCast(base_ptr + @as(usize, @intCast(ref.offset))));
+    return base.StringLiteral.Store.Buffer.fromMappedSlice(ptr[0..@intCast(ref.len)], @intCast(ref.capacity));
 }
 
 fn safeMultiListFromRef(comptime T: type, base_ptr: [*]align(1) u8, image_size: usize, ref: ArrayRef) collections.SafeMultiList(T) {

--- a/test/str/app_static_24_byte_string.roc
+++ b/test/str/app_static_24_byte_string.roc
@@ -1,0 +1,4 @@
+app [process_string] { pf: platform "./platform/main.roc" }
+
+process_string : Str -> Str
+process_string = |_input| "aaaaaaaaaaaaaaaaaaaaaaaa"


### PR DESCRIPTION
## Summary
- store string literal bytes with an aligned static refcount word immediately before big-string data
- construct big RocStr literals directly from runtime-image string bytes instead of copying into interpreter arena
- add a direct-run regression fixture for the 24-byte string literal panic

## Testing
- zig build roc
- zig build test -- --test-filter "StringLiteral"
- zig build test-subcommands -- --test-filter "static_24_byte"
- zig build test-eval -- --test-filter "large string literal"
- ./zig-out/bin/roc --no-cache test/str/app_static_24_byte_string.roc