### PR TITLE
Publish public API dependencies for transitive imports

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -50,6 +50,10 @@ cir: *ModuleEnv,
 regions: Region.List,
 /// List of directly imported  module. Import indexes in CIR refer to this list
 imported_modules: []const *const ModuleEnv,
+/// Module envs whose public APIs are semantically visible through direct imports.
+/// These are not lexically importable, and CIR import indexes never refer to
+/// this set. It exists only for owner lookups on copied imported types.
+owner_module_envs: std.StringHashMap(*const ModuleEnv),
 /// Map of auto-imported type names (like "Str", "List", "Bool") to their defining modules.
 /// This is used to resolve type names that are automatically available without explicit imports.
 auto_imported_types: ?*const std.AutoHashMap(Ident.Idx, can.Can.AutoImportedType),
@@ -236,6 +240,33 @@ pub fn init(
         types,
         mutable_cir,
         imported_modules,
+        imported_modules,
+        auto_imported_types,
+        regions,
+        builtin_ctx,
+    );
+}
+
+/// Init type solver with an explicit semantic owner set for imported public APIs.
+/// `imported_modules` remains the direct-import list used by CIR import indexes.
+pub fn initWithOwnerModules(
+    gpa: std.mem.Allocator,
+    types: *types_mod.Store,
+    cir: *const ModuleEnv,
+    imported_modules: []const *const ModuleEnv,
+    owner_modules: []const *const ModuleEnv,
+    auto_imported_types: ?*const std.AutoHashMap(Ident.Idx, can.Can.AutoImportedType),
+    regions: *const Region.List,
+    builtin_ctx: BuiltinContext,
+) std.mem.Allocator.Error!Self {
+    const mutable_cir = @constCast(cir);
+    try preflightForTypeChecking(mutable_cir);
+    return initAssumePrepared(
+        gpa,
+        types,
+        mutable_cir,
+        imported_modules,
+        owner_modules,
         auto_imported_types,
         regions,
         builtin_ctx,
@@ -267,10 +298,14 @@ fn initAssumePrepared(
     types: *types_mod.Store,
     cir: *ModuleEnv,
     imported_modules: []const *const ModuleEnv,
+    owner_modules: []const *const ModuleEnv,
     auto_imported_types: ?*const std.AutoHashMap(Ident.Idx, can.Can.AutoImportedType),
     regions: *const Region.List,
     builtin_ctx: BuiltinContext,
 ) std.mem.Allocator.Error!Self {
+    var owner_module_envs = try buildOwnerModuleEnvMap(gpa, imported_modules, owner_modules, builtin_ctx);
+    errdefer owner_module_envs.deinit();
+
     var import_mapping = try createImportMapping(
         gpa,
         cir.getIdentStore(),
@@ -285,6 +320,7 @@ fn initAssumePrepared(
         .types = types,
         .cir = cir,
         .imported_modules = imported_modules,
+        .owner_module_envs = owner_module_envs,
         .auto_imported_types = auto_imported_types,
         .regions = blk: {
             var owned = Region.List{};
@@ -332,6 +368,44 @@ fn initAssumePrepared(
     return self;
 }
 
+fn buildOwnerModuleEnvMap(
+    gpa: std.mem.Allocator,
+    imported_modules: []const *const ModuleEnv,
+    owner_modules: []const *const ModuleEnv,
+    builtin_ctx: BuiltinContext,
+) std.mem.Allocator.Error!std.StringHashMap(*const ModuleEnv) {
+    var map = std.StringHashMap(*const ModuleEnv).init(gpa);
+    errdefer map.deinit();
+
+    if (builtin_ctx.builtin_module) |builtin_env| {
+        try putOwnerModuleEnvNames(&map, builtin_env);
+    }
+
+    for (imported_modules) |imported_env| {
+        try putOwnerModuleEnvNames(&map, imported_env);
+    }
+    for (owner_modules) |owner_env| {
+        try putOwnerModuleEnvNames(&map, owner_env);
+    }
+
+    return map;
+}
+
+fn putOwnerModuleEnvNames(
+    map: *std.StringHashMap(*const ModuleEnv),
+    module_env: *const ModuleEnv,
+) std.mem.Allocator.Error!void {
+    if (!module_env.qualified_module_ident.isNone()) {
+        try map.put(module_env.getIdent(module_env.qualified_module_ident), module_env);
+    }
+    if (!module_env.display_module_name_idx.isNone()) {
+        try map.put(module_env.getIdent(module_env.display_module_name_idx), module_env);
+    }
+    if (module_env.module_name.len > 0) {
+        try map.put(module_env.module_name, module_env);
+    }
+}
+
 /// Call this after Check has been stored at its final location to set up the import_mapping pointer.
 /// This is needed because returning Check by value invalidates the pointer set during init.
 pub fn fixupTypeWriter(self: *Self) void {
@@ -344,6 +418,7 @@ pub fn deinit(self: *Self) void {
     self.problems.deinit(self.gpa);
     self.snapshots.deinit();
     self.import_mapping.deinit();
+    self.owner_module_envs.deinit();
     self.unify_scratch.deinit();
     self.occurs_scratch.deinit();
     self.seen_annos.deinit();
@@ -4985,21 +5060,23 @@ fn toInspectMethodVarForAlias(
 }
 
 fn methodOwnerEnv(self: *Self, origin_module: Ident.Idx) Allocator.Error!struct { *const ModuleEnv, bool } {
+    return self.ownerEnvForOriginModule(origin_module, "to_inspect");
+}
+
+fn ownerEnvForOriginModule(self: *Self, origin_module: Ident.Idx, context: []const u8) struct { *const ModuleEnv, bool } {
     if (origin_module.eql(self.builtin_ctx.module_name)) return .{ self.cir, true };
     if (origin_module.eql(self.cir.idents.builtin_module)) {
         return .{ self.builtin_ctx.builtin_module orelse self.cir, self.builtin_ctx.builtin_module == null };
     }
-    for (self.imported_modules) |imported_env| {
-        const imported_name = if (!imported_env.qualified_module_ident.isNone())
-            imported_env.getIdent(imported_env.qualified_module_ident)
-        else
-            imported_env.module_name;
-        const imported_module_ident = try @constCast(self.cir).insertIdent(base.Ident.for_text(imported_name));
-        if (imported_module_ident.eql(origin_module)) return .{ imported_env, false };
+    if (self.owner_module_envs.get(self.cir.getIdent(origin_module))) |owner_env| {
+        return .{ owner_env, false };
     }
 
     if (builtin.mode == .Debug) {
-        std.debug.panic("type checker invariant violated: unable to find module environment for to_inspect owner {s}", .{self.cir.getIdent(origin_module)});
+        std.debug.panic(
+            "type checker invariant violated: unable to find module environment for {s} owner from module {s}",
+            .{ context, self.cir.getIdent(origin_module) },
+        );
     }
     unreachable;
 }
@@ -6118,34 +6195,8 @@ fn reportMissingNominalMethodForBinopConstraint(
 }
 
 fn getNominalOriginEnv(self: *Self, nominal_type: types_mod.NominalType) *const ModuleEnv {
-    const original_module_ident = nominal_type.origin_module;
-
-    if (original_module_ident.eql(self.builtin_ctx.module_name)) return self.cir;
-
-    if (original_module_ident.eql(self.cir.idents.builtin_module)) {
-        if (self.builtin_ctx.builtin_module) |builtin_env| {
-            return builtin_env;
-        }
-        return self.cir;
-    }
-
-    for (self.imported_modules) |imported_env| {
-        const imported_name = if (!imported_env.qualified_module_ident.isNone())
-            imported_env.getIdent(imported_env.qualified_module_ident)
-        else
-            imported_env.module_name;
-        const imported_module_ident = @constCast(self.cir).insertIdent(base.Ident.for_text(imported_name)) catch {
-            std.debug.panic("Unable to intern module name {s} for static dispatch lookup", .{imported_name});
-        };
-        if (imported_module_ident.eql(original_module_ident)) {
-            return imported_env;
-        }
-    }
-
-    std.debug.panic(
-        "Unable to find module environment for type {s} from module {s}",
-        .{ self.cir.getIdent(nominal_type.ident.ident_idx), self.cir.getIdent(original_module_ident) },
-    );
+    const original_env, _ = self.ownerEnvForOriginModule(nominal_type.origin_module, "nominal type");
+    return original_env;
 }
 
 // binop + unary op exprs //
@@ -7040,40 +7091,7 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
                 const original_module_ident = nominal_type.origin_module;
 
                 // Check if the nominal type in question is defined in this module
-                const is_this_module = original_module_ident.eql(self.builtin_ctx.module_name);
-
-                // Get the list of exposed items to check
-                const original_env: *const ModuleEnv = blk: {
-                    if (is_this_module) {
-                        break :blk self.cir;
-                    } else if (original_module_ident.eql(self.cir.idents.builtin_module)) {
-                        // For builtin types, use the builtin module environment directly
-                        if (self.builtin_ctx.builtin_module) |builtin_env| {
-                            break :blk builtin_env;
-                        } else {
-                            // This happens when compiling the Builtin module itself
-                            break :blk self.cir;
-                        }
-                    } else {
-                        // For types from other modules (not this module, not builtin), find the
-                        // module environment from imported_modules by matching the qualified module name.
-                        // We use qualified_module_ident (package-qualified) for comparison since origin_module
-                        // is also package-qualified (e.g., "pf.Builder" rather than just "Builder").
-                        for (self.imported_modules) |imported_env| {
-                            const imported_name = if (!imported_env.qualified_module_ident.isNone())
-                                imported_env.getIdent(imported_env.qualified_module_ident)
-                            else
-                                imported_env.module_name;
-                            const imported_module_ident = try @constCast(self.cir).insertIdent(base.Ident.for_text(imported_name));
-                            if (imported_module_ident.eql(original_module_ident)) {
-                                break :blk imported_env;
-                            }
-                        }
-
-                        // Could not find the module environment. This is an internal compiler error.
-                        std.debug.panic("Unable to find module environment for type {s} from module {s}", .{ self.cir.getIdent(nominal_type.ident.ident_idx), self.cir.getIdent(original_module_ident) });
-                    }
-                };
+                const original_env, const is_this_module = self.ownerEnvForOriginModule(original_module_ident, "static dispatch nominal");
 
                 // Get some data about the nominal type
                 const region = self.getRegionAt(deferred_constraint.var_);
@@ -7268,35 +7286,7 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
 
                 // Get the module ident that this alias type was defined in
                 const original_module_ident = alias.origin_module;
-                const is_this_module = original_module_ident.eql(self.builtin_ctx.module_name);
-
-                const original_env: *const ModuleEnv = blk: {
-                    if (is_this_module) {
-                        break :blk self.cir;
-                    } else if (original_module_ident.eql(self.cir.idents.builtin_module)) {
-                        if (self.builtin_ctx.builtin_module) |builtin_env| {
-                            break :blk builtin_env;
-                        } else {
-                            break :blk self.cir;
-                        }
-                    } else {
-                        for (self.imported_modules) |imported_env| {
-                            const imported_name = if (!imported_env.qualified_module_ident.isNone())
-                                imported_env.getIdent(imported_env.qualified_module_ident)
-                            else
-                                imported_env.module_name;
-                            const imported_module_ident = try @constCast(self.cir).insertIdent(base.Ident.for_text(imported_name));
-                            if (imported_module_ident.eql(original_module_ident)) {
-                                break :blk imported_env;
-                            }
-                        }
-
-                        std.debug.panic(
-                            "Unable to find module environment for type {s} from module {s}",
-                            .{ self.cir.getIdent(alias.ident.ident_idx), self.cir.getIdent(original_module_ident) },
-                        );
-                    }
-                };
+                const original_env, const is_this_module = self.ownerEnvForOriginModule(original_module_ident, "static dispatch alias");
 
                 const region = self.getRegionAt(deferred_constraint.var_);
                 const constraints_range = deferred_constraint.constraints;

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -311,6 +311,17 @@ pub const PublishImportArtifact = struct {
     view: ImportedModuleView,
 };
 
+/// Checked artifacts that must be available to consume this module's public API.
+/// This is semantic visibility, not lexical import visibility.
+pub const PublicApiDependencies = struct {
+    artifacts: []const CheckedModuleArtifactKey = &.{},
+
+    pub fn deinit(self: *PublicApiDependencies, allocator: Allocator) void {
+        allocator.free(self.artifacts);
+        self.* = .{};
+    }
+};
+
 /// Public `PublishInputs` declaration.
 pub const PublishInputs = struct {
     module_env_storage: ModuleEnvStorage,
@@ -14127,6 +14138,364 @@ fn appendClosureArtifactKey(
     try keys.append(allocator, key);
 }
 
+fn collectPublicApiDependencies(
+    allocator: Allocator,
+    module: TypedCIR.Module,
+    names: *const canonical.CanonicalNameStore,
+    module_identity: ModuleIdentity,
+    artifact_key: CheckedModuleArtifactKey,
+    exported_defs: []const CIR.Def.Idx,
+    checked_type_publication: *const CheckedTypePublication,
+    checked_types: *const CheckedTypeStore,
+    imports: []const PublishImportArtifact,
+    available_artifacts: []const ImportedModuleView,
+    exported_procedure_templates: *const ExportedProcedureTemplateTable,
+    exported_procedure_bindings: *const ExportedProcedureBindingTable,
+    exported_const_templates: *const ExportedConstTemplateTable,
+) Allocator.Error!PublicApiDependencies {
+    var keys = std.ArrayList(CheckedModuleArtifactKey).empty;
+    errdefer keys.deinit(allocator);
+
+    var active_types = std.AutoHashMap(CheckedTypeId, void).init(allocator);
+    defer active_types.deinit();
+
+    for (exported_defs) |def_idx| {
+        const root = checked_type_publication.rootForSourceVar(module, module.defType(def_idx)) orelse {
+            checkedArtifactInvariant("exported def type root was not published", .{});
+        };
+        try appendPublicApiTypeDependencies(
+            allocator,
+            names,
+            module_identity,
+            artifact_key,
+            checked_types,
+            root,
+            &active_types,
+            imports,
+            available_artifacts,
+            &keys,
+        );
+    }
+
+    try appendExposedTypeDeclarationPublicApiDependencies(
+        allocator,
+        module,
+        names,
+        module_identity,
+        artifact_key,
+        checked_type_publication,
+        checked_types,
+        imports,
+        available_artifacts,
+        &active_types,
+        &keys,
+    );
+
+    try appendExportedClosurePublicApiDependencies(allocator, artifact_key, imports, available_artifacts, &keys, exported_procedure_templates.*);
+    for (exported_procedure_bindings.bindings) |binding| {
+        try appendTemplateClosurePublicApiDependencies(allocator, artifact_key, imports, available_artifacts, &keys, binding.template_closure);
+    }
+    for (exported_const_templates.templates) |template| {
+        try appendTemplateClosurePublicApiDependencies(allocator, artifact_key, imports, available_artifacts, &keys, template.template_closure);
+    }
+
+    return .{ .artifacts = try keys.toOwnedSlice(allocator) };
+}
+
+fn appendExposedTypeDeclarationPublicApiDependencies(
+    allocator: Allocator,
+    module: TypedCIR.Module,
+    names: *const canonical.CanonicalNameStore,
+    module_identity: ModuleIdentity,
+    artifact_key: CheckedModuleArtifactKey,
+    checked_type_publication: *const CheckedTypePublication,
+    checked_types: *const CheckedTypeStore,
+    imports: []const PublishImportArtifact,
+    available_artifacts: []const ImportedModuleView,
+    active_types: *std.AutoHashMap(CheckedTypeId, void),
+    keys: *std.ArrayList(CheckedModuleArtifactKey),
+) Allocator.Error!void {
+    const module_env = module.moduleEnvConst();
+    var exposed_iter = module_env.common.exposed_items.iterator();
+    while (exposed_iter.next()) |entry| {
+        if (entry.node_idx == 0) continue;
+        const raw_node_idx: u32 = entry.node_idx;
+        if (raw_node_idx >= module.nodeCount()) {
+            checkedArtifactInvariant("exposed type item points at out-of-range node", .{});
+        }
+
+        const node_idx: CIR.Node.Idx = @enumFromInt(raw_node_idx);
+        if (!isStatementNodeTag(module.nodeTag(node_idx))) continue;
+
+        const statement_idx: CIR.Statement.Idx = @enumFromInt(raw_node_idx);
+        switch (module.getStatement(statement_idx)) {
+            .s_alias_decl, .s_nominal_decl => {
+                const root = checked_type_publication.rootForSourceVar(module, ModuleEnv.varFrom(statement_idx)) orelse {
+                    checkedArtifactInvariant("exposed type declaration root was not published", .{});
+                };
+                try appendPublicApiTypeDependencies(
+                    allocator,
+                    names,
+                    module_identity,
+                    artifact_key,
+                    checked_types,
+                    root,
+                    active_types,
+                    imports,
+                    available_artifacts,
+                    keys,
+                );
+            },
+            else => {},
+        }
+    }
+}
+
+fn appendPublicApiTypeDependencies(
+    allocator: Allocator,
+    names: *const canonical.CanonicalNameStore,
+    module_identity: ModuleIdentity,
+    artifact_key: CheckedModuleArtifactKey,
+    checked_types: *const CheckedTypeStore,
+    root: CheckedTypeId,
+    active: *std.AutoHashMap(CheckedTypeId, void),
+    imports: []const PublishImportArtifact,
+    available_artifacts: []const ImportedModuleView,
+    keys: *std.ArrayList(CheckedModuleArtifactKey),
+) Allocator.Error!void {
+    const index: usize = @intFromEnum(root);
+    if (index >= checked_types.payloads.len) {
+        checkedArtifactInvariant("public API dependency scan referenced a missing checked type payload", .{});
+    }
+    if (active.contains(root)) return;
+    try active.put(root, {});
+    defer _ = active.remove(root);
+
+    switch (checked_types.payloads[index]) {
+        .pending => checkedArtifactInvariant("public API dependency scan reached pending checked type payload", .{}),
+        .empty_record, .empty_tag_union => {},
+        .flex => |flex| try appendPublicApiConstraintDependencies(
+            allocator,
+            names,
+            module_identity,
+            artifact_key,
+            checked_types,
+            flex.constraints,
+            active,
+            imports,
+            available_artifacts,
+            keys,
+        ),
+        .rigid => |rigid| try appendPublicApiConstraintDependencies(
+            allocator,
+            names,
+            module_identity,
+            artifact_key,
+            checked_types,
+            rigid.constraints,
+            active,
+            imports,
+            available_artifacts,
+            keys,
+        ),
+        .alias => |alias| {
+            try appendPublicApiModuleDependency(
+                allocator,
+                names,
+                module_identity,
+                artifact_key,
+                alias.origin_module,
+                imports,
+                available_artifacts,
+                keys,
+            );
+            try appendPublicApiTypeDependencies(allocator, names, module_identity, artifact_key, checked_types, alias.backing, active, imports, available_artifacts, keys);
+            try appendPublicApiTypeDependencyRange(allocator, names, module_identity, artifact_key, checked_types, alias.args, active, imports, available_artifacts, keys);
+        },
+        .nominal => |nominal| {
+            try appendPublicApiModuleDependency(
+                allocator,
+                names,
+                module_identity,
+                artifact_key,
+                nominal.origin_module,
+                imports,
+                available_artifacts,
+                keys,
+            );
+            try appendPublicApiTypeDependencies(allocator, names, module_identity, artifact_key, checked_types, nominal.backing, active, imports, available_artifacts, keys);
+            try appendPublicApiTypeDependencyRange(allocator, names, module_identity, artifact_key, checked_types, nominal.args, active, imports, available_artifacts, keys);
+        },
+        .record => |record| {
+            for (record.fields) |field| {
+                try appendPublicApiTypeDependencies(allocator, names, module_identity, artifact_key, checked_types, field.ty, active, imports, available_artifacts, keys);
+            }
+            try appendPublicApiTypeDependencies(allocator, names, module_identity, artifact_key, checked_types, record.ext, active, imports, available_artifacts, keys);
+        },
+        .record_unbound => |fields| {
+            for (fields) |field| {
+                try appendPublicApiTypeDependencies(allocator, names, module_identity, artifact_key, checked_types, field.ty, active, imports, available_artifacts, keys);
+            }
+        },
+        .tuple => |items| try appendPublicApiTypeDependencyRange(allocator, names, module_identity, artifact_key, checked_types, items, active, imports, available_artifacts, keys),
+        .function => |function| {
+            try appendPublicApiTypeDependencyRange(allocator, names, module_identity, artifact_key, checked_types, function.args, active, imports, available_artifacts, keys);
+            try appendPublicApiTypeDependencies(allocator, names, module_identity, artifact_key, checked_types, function.ret, active, imports, available_artifacts, keys);
+        },
+        .tag_union => |tag_union| {
+            for (tag_union.tags) |tag| {
+                try appendPublicApiTypeDependencyRange(allocator, names, module_identity, artifact_key, checked_types, tag.args, active, imports, available_artifacts, keys);
+            }
+            try appendPublicApiTypeDependencies(allocator, names, module_identity, artifact_key, checked_types, tag_union.ext, active, imports, available_artifacts, keys);
+        },
+    }
+}
+
+fn appendPublicApiConstraintDependencies(
+    allocator: Allocator,
+    names: *const canonical.CanonicalNameStore,
+    module_identity: ModuleIdentity,
+    artifact_key: CheckedModuleArtifactKey,
+    checked_types: *const CheckedTypeStore,
+    constraints: []const CheckedStaticDispatchConstraint,
+    active: *std.AutoHashMap(CheckedTypeId, void),
+    imports: []const PublishImportArtifact,
+    available_artifacts: []const ImportedModuleView,
+    keys: *std.ArrayList(CheckedModuleArtifactKey),
+) Allocator.Error!void {
+    for (constraints) |constraint| {
+        try appendPublicApiTypeDependencies(allocator, names, module_identity, artifact_key, checked_types, constraint.fn_ty, active, imports, available_artifacts, keys);
+    }
+}
+
+fn appendPublicApiTypeDependencyRange(
+    allocator: Allocator,
+    names: *const canonical.CanonicalNameStore,
+    module_identity: ModuleIdentity,
+    artifact_key: CheckedModuleArtifactKey,
+    checked_types: *const CheckedTypeStore,
+    roots: []const CheckedTypeId,
+    active: *std.AutoHashMap(CheckedTypeId, void),
+    imports: []const PublishImportArtifact,
+    available_artifacts: []const ImportedModuleView,
+    keys: *std.ArrayList(CheckedModuleArtifactKey),
+) Allocator.Error!void {
+    for (roots) |child| {
+        try appendPublicApiTypeDependencies(allocator, names, module_identity, artifact_key, checked_types, child, active, imports, available_artifacts, keys);
+    }
+}
+
+fn appendPublicApiModuleDependency(
+    allocator: Allocator,
+    names: *const canonical.CanonicalNameStore,
+    module_identity: ModuleIdentity,
+    artifact_key: CheckedModuleArtifactKey,
+    origin_module: canonical.ModuleNameId,
+    imports: []const PublishImportArtifact,
+    available_artifacts: []const ImportedModuleView,
+    keys: *std.ArrayList(CheckedModuleArtifactKey),
+) Allocator.Error!void {
+    const origin_name = names.moduleNameText(origin_module);
+    if (isSelfPublicApiModuleName(names, module_identity, origin_name)) return;
+    if (Ident.textEql(origin_name, "Builtin")) return;
+
+    const view = publicApiDependencyViewByModuleName(origin_name, imports, available_artifacts) orelse {
+        checkedArtifactInvariant("public API dependency scan could not find checked artifact for module {s}", .{origin_name});
+    };
+    try appendPublicApiDependencyView(allocator, artifact_key, keys, view);
+}
+
+fn isSelfPublicApiModuleName(
+    names: *const canonical.CanonicalNameStore,
+    module_identity: ModuleIdentity,
+    origin_name: []const u8,
+) bool {
+    return Ident.textEql(origin_name, names.moduleNameText(module_identity.module_name)) or
+        Ident.textEql(origin_name, names.moduleNameText(module_identity.display_module_name)) or
+        Ident.textEql(origin_name, names.moduleNameText(module_identity.qualified_module_name));
+}
+
+fn publicApiDependencyViewByModuleName(
+    module_name: []const u8,
+    imports: []const PublishImportArtifact,
+    available_artifacts: []const ImportedModuleView,
+) ?ImportedModuleView {
+    for (imports) |import_artifact| {
+        if (importedViewModuleNameMatches(import_artifact.view, module_name)) return import_artifact.view;
+    }
+    for (available_artifacts) |view| {
+        if (importedViewModuleNameMatches(view, module_name)) return view;
+    }
+    return null;
+}
+
+fn importedViewModuleNameMatches(view: ImportedModuleView, module_name: []const u8) bool {
+    return Ident.textEql(module_name, view.canonical_names.moduleNameText(view.module_identity.module_name)) or
+        Ident.textEql(module_name, view.canonical_names.moduleNameText(view.module_identity.display_module_name)) or
+        Ident.textEql(module_name, view.canonical_names.moduleNameText(view.module_identity.qualified_module_name));
+}
+
+fn appendPublicApiDependencyView(
+    allocator: Allocator,
+    artifact_key: CheckedModuleArtifactKey,
+    keys: *std.ArrayList(CheckedModuleArtifactKey),
+    view: ImportedModuleView,
+) Allocator.Error!void {
+    if (checkedArtifactKeyEql(view.key, artifact_key)) return;
+    try appendClosureArtifactKey(allocator, keys, view.key);
+    for (view.public_api_dependencies.artifacts) |dependency| {
+        if (checkedArtifactKeyEql(dependency, artifact_key)) continue;
+        try appendClosureArtifactKey(allocator, keys, dependency);
+    }
+}
+
+fn appendExportedClosurePublicApiDependencies(
+    allocator: Allocator,
+    artifact_key: CheckedModuleArtifactKey,
+    imports: []const PublishImportArtifact,
+    available_artifacts: []const ImportedModuleView,
+    keys: *std.ArrayList(CheckedModuleArtifactKey),
+    exported_procedure_templates: ExportedProcedureTemplateTable,
+) Allocator.Error!void {
+    for (exported_procedure_templates.templates) |template| {
+        try appendTemplateClosurePublicApiDependencies(allocator, artifact_key, imports, available_artifacts, keys, template.template_closure);
+    }
+}
+
+fn appendTemplateClosurePublicApiDependencies(
+    allocator: Allocator,
+    artifact_key: CheckedModuleArtifactKey,
+    imports: []const PublishImportArtifact,
+    available_artifacts: []const ImportedModuleView,
+    keys: *std.ArrayList(CheckedModuleArtifactKey),
+    closure: ImportedTemplateClosureView,
+) Allocator.Error!void {
+    var closure_keys = std.ArrayList(CheckedModuleArtifactKey).empty;
+    defer closure_keys.deinit(allocator);
+    try appendImportedTemplateClosureArtifactKeys(allocator, &closure_keys, closure);
+    for (closure_keys.items) |key| {
+        if (checkedArtifactKeyEql(key, artifact_key)) continue;
+        const view = publicApiDependencyViewByKey(key, imports, available_artifacts) orelse {
+            checkedArtifactInvariant("public API closure dependency scan could not find checked artifact for referenced key", .{});
+        };
+        try appendPublicApiDependencyView(allocator, artifact_key, keys, view);
+    }
+}
+
+fn publicApiDependencyViewByKey(
+    key: CheckedModuleArtifactKey,
+    imports: []const PublishImportArtifact,
+    available_artifacts: []const ImportedModuleView,
+) ?ImportedModuleView {
+    for (imports) |import_artifact| {
+        if (checkedArtifactKeyEql(import_artifact.key, key)) return import_artifact.view;
+    }
+    for (available_artifacts) |view| {
+        if (checkedArtifactKeyEql(view.key, key)) return view;
+    }
+    return null;
+}
+
 /// Public `ExportedProcedureTemplate` declaration.
 pub const ExportedProcedureTemplate = struct {
     export_name: ?canonical.ExportNameId,
@@ -16685,6 +17054,7 @@ pub const CheckedModuleArtifact = struct {
     module_identity: ModuleIdentity,
     checking_context_identity: CheckingContextIdentity,
     direct_import_artifact_keys: []CheckedModuleArtifactKey = &.{},
+    public_api_dependencies: PublicApiDependencies = .{},
     module_env: ModuleEnvStorage,
     exports: ExportTable,
     checked_types: CheckedTypeStore = .{},
@@ -16921,6 +17291,7 @@ pub const CheckedModuleArtifact = struct {
         self.checked_bodies.deinit(allocator);
         self.checked_types.deinit(allocator);
         self.exports.deinit(allocator);
+        self.public_api_dependencies.deinit(allocator);
         allocator.free(self.direct_import_artifact_keys);
         self.checking_context_identity.deinit(allocator);
         self.canonical_names.deinit();
@@ -17506,6 +17877,7 @@ pub const ImportedModuleView = struct {
     canonical_names: *const canonical.CanonicalNameStore,
     module_identity: ModuleIdentity,
     direct_import_artifact_keys: []const CheckedModuleArtifactKey = &.{},
+    public_api_dependencies: PublicApiDependencies = .{},
     exports: ExportTableView,
     checked_types: CheckedTypeStoreView,
     checked_bodies: CheckedBodyStoreView,
@@ -17556,6 +17928,7 @@ pub fn importedView(artifact: *const CheckedModuleArtifact) ImportedModuleView {
         .canonical_names = &artifact.canonical_names,
         .module_identity = artifact.module_identity,
         .direct_import_artifact_keys = artifact.direct_import_artifact_keys,
+        .public_api_dependencies = artifact.public_api_dependencies,
         .exports = artifact.exports.view(),
         .checked_types = artifact.checked_types.view(),
         .checked_bodies = artifact.checked_bodies.view(),
@@ -19075,12 +19448,30 @@ pub fn publishFromTypedModule(
     );
     errdefer interface_capabilities.deinit(allocator);
 
+    var public_api_dependencies = try collectPublicApiDependencies(
+        allocator,
+        module,
+        &canonical_names,
+        module_identity,
+        artifact_key,
+        exports,
+        &checked_type_publication,
+        checked_types,
+        inputs.imports,
+        inputs.available_artifacts,
+        &exported_procedure_templates,
+        &exported_procedure_bindings,
+        &exported_const_templates,
+    );
+    errdefer public_api_dependencies.deinit(allocator);
+
     var artifact = CheckedModuleArtifact{
         .key = artifact_key,
         .canonical_names = canonical_names,
         .module_identity = module_identity,
         .checking_context_identity = checking_context_identity,
         .direct_import_artifact_keys = direct_import_artifact_keys,
+        .public_api_dependencies = public_api_dependencies,
         .module_env = inputs.module_env_storage,
         .exports = .{ .defs = exports },
         .checked_types = checked_types.*,

--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -492,6 +492,11 @@ pub const io_spec_tests = [_]TestSpec{
         .description = "Cross-module recursive nominal types with pattern matching",
     },
     .{
+        .roc_file = "test/fx/transitive_import_nominal_equality/main.roc",
+        .io_spec = "1>True",
+        .description = "Regression test: transitive imports preserve nominal method owner environments for equality",
+    },
+    .{
         .roc_file = "test/fx/test_no_dbg.roc",
         .io_spec = "1>Text",
         .description = "Recursive nominal type with List and pattern matching",

--- a/src/compile/compile_package.zig
+++ b/src/compile/compile_package.zig
@@ -337,6 +337,77 @@ fn importedArtifactsCoverImportedEnvs(
     return true;
 }
 
+fn buildCheckOwnerEnvs(
+    allocator: Allocator,
+    imported_envs: []const *ModuleEnv,
+    imported_artifacts: []const CheckedArtifact.PublishImportArtifact,
+    available_artifacts: []const CheckedArtifact.ImportedModuleView,
+) Allocator.Error![]const *const ModuleEnv {
+    var owner_envs = std.ArrayList(*const ModuleEnv).empty;
+    errdefer owner_envs.deinit(allocator);
+
+    for (imported_envs) |env| {
+        try appendCheckOwnerEnvIfMissing(allocator, &owner_envs, env);
+    }
+
+    for (imported_artifacts) |imported_artifact| {
+        for (imported_artifact.view.public_api_dependencies.artifacts) |dependency_key| {
+            const dependency = availableArtifactByKey(available_artifacts, dependency_key) orelse {
+                std.debug.panic("compile.typeCheckModule missing public API dependency artifact for imported module", .{});
+            };
+            try appendCheckOwnerEnvIfMissing(allocator, &owner_envs, dependency.module_env);
+        }
+    }
+
+    return try owner_envs.toOwnedSlice(allocator);
+}
+
+fn appendCheckOwnerEnvIfMissing(
+    allocator: Allocator,
+    owner_envs: *std.ArrayList(*const ModuleEnv),
+    module_env: *const ModuleEnv,
+) Allocator.Error!void {
+    for (owner_envs.items) |existing| {
+        if (moduleEnvNamesMatch(existing, module_env)) return;
+    }
+    try owner_envs.append(allocator, module_env);
+}
+
+fn moduleEnvNamesMatch(a: *const ModuleEnv, b: *const ModuleEnv) bool {
+    if (@intFromPtr(a) == @intFromPtr(b)) return true;
+    if (!a.qualified_module_ident.isNone() and !b.qualified_module_ident.isNone()) {
+        return std.mem.eql(u8, a.getIdent(a.qualified_module_ident), b.getIdent(b.qualified_module_ident));
+    }
+    if (!a.display_module_name_idx.isNone() and !b.display_module_name_idx.isNone()) {
+        return std.mem.eql(u8, a.getIdent(a.display_module_name_idx), b.getIdent(b.display_module_name_idx));
+    }
+    if (a.qualified_module_ident.isNone() or b.qualified_module_ident.isNone()) {
+        if (std.mem.eql(u8, a.module_name, b.module_name)) return true;
+    }
+    return false;
+}
+
+fn availableArtifactByKey(
+    available_artifacts: []const CheckedArtifact.ImportedModuleView,
+    key: CheckedArtifact.CheckedModuleArtifactKey,
+) ?CheckedArtifact.ImportedModuleView {
+    for (available_artifacts) |artifact| {
+        if (std.mem.eql(u8, &artifact.key.bytes, &key.bytes)) return artifact;
+    }
+    return null;
+}
+
+fn appendAvailableArtifactViewIfMissing(
+    allocator: Allocator,
+    views: *std.ArrayList(CheckedArtifact.ImportedModuleView),
+    view: CheckedArtifact.ImportedModuleView,
+) Allocator.Error!void {
+    for (views.items) |existing| {
+        if (std.mem.eql(u8, &existing.key.bytes, &view.key.bytes)) return;
+    }
+    try views.append(allocator, view);
+}
+
 /// Per-package module build orchestrator
 pub const PackageEnv = struct {
     gpa: Allocator,
@@ -1326,11 +1397,15 @@ pub const PackageEnv = struct {
         var module_envs_map = std.AutoHashMap(base.Ident.Idx, Can.AutoImportedType).init(gpa);
         errdefer module_envs_map.deinit();
 
-        var checker = try Check.init(
+        const owner_envs = try buildCheckOwnerEnvs(gpa, imported_envs, imported_artifacts, available_artifacts);
+        defer gpa.free(owner_envs);
+
+        var checker = try Check.initWithOwnerModules(
             gpa,
             &env.types,
             env,
             imported_envs,
+            owner_envs,
             &module_envs_map,
             &env.store.regions,
             module_builtin_ctx,
@@ -1502,11 +1577,23 @@ pub const PackageEnv = struct {
             }
         }
 
-        const available_artifacts = try self.gpa.alloc(CheckedArtifact.ImportedModuleView, imported_artifacts.items.len);
-        defer self.gpa.free(available_artifacts);
-        for (imported_artifacts.items, 0..) |imported, i| {
-            available_artifacts[i] = imported.view;
+        var available_artifact_views = std.ArrayList(CheckedArtifact.ImportedModuleView).empty;
+        errdefer available_artifact_views.deinit(self.gpa);
+        try appendAvailableArtifactViewIfMissing(
+            self.gpa,
+            &available_artifact_views,
+            CheckedArtifact.importedView(&self.builtin_modules.checked_artifact),
+        );
+        for (self.modules.items) |*module_state| {
+            if (module_state.checkedArtifact()) |artifact| {
+                try appendAvailableArtifactViewIfMissing(self.gpa, &available_artifact_views, CheckedArtifact.importedView(artifact));
+            }
         }
+        for (imported_artifacts.items) |imported| {
+            try appendAvailableArtifactViewIfMissing(self.gpa, &available_artifact_views, imported.view);
+        }
+        const available_artifacts = try available_artifact_views.toOwnedSlice(self.gpa);
+        defer self.gpa.free(available_artifacts);
 
         const check_start = if (!threading.is_freestanding) std.time.nanoTimestamp() else 0;
         var typecheck_output = try typeCheckModule(

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -734,14 +734,11 @@ pub const Coordinator = struct {
 
         try appendImportedArtifactViewIfMissing(&views, allocator, root_artifact.key, &self.builtin_modules.checked_artifact);
 
-        var pkg_iter = self.packages.iterator();
-        while (pkg_iter.next()) |entry| {
-            const pkg = entry.value_ptr.*;
-            for (pkg.modules.items) |*mod| {
-                const artifact = mod.checkedArtifact() orelse continue;
-                if (rootRelationContainsArtifact(root_artifact, artifact.key)) continue;
-                try appendImportedArtifactViewIfMissing(&views, allocator, root_artifact.key, artifact);
-            }
+        for (root_artifact.direct_import_artifact_keys) |key| {
+            try self.appendPublicApiDependencyViewByKey(&views, allocator, root_artifact, key);
+        }
+        for (root_artifact.public_api_dependencies.artifacts) |key| {
+            try self.appendPublicApiDependencyViewByKey(&views, allocator, root_artifact, key);
         }
         try self.appendRelationClosureDependencyViews(&views, allocator, root_artifact);
 
@@ -821,14 +818,40 @@ pub const Coordinator = struct {
         for (keys.items) |key| {
             if (std.mem.eql(u8, &key.bytes, &root_artifact.key.bytes)) continue;
             if (rootRelationContainsArtifact(root_artifact, key)) continue;
-            const artifact = self.checkedArtifactByKey(key) orelse {
-                if (builtin.mode == .Debug) {
-                    std.debug.panic("compile.coordinator invariant violated: platform relation closure references unavailable checked artifact", .{});
-                }
-                unreachable;
-            };
-            try appendImportedArtifactViewIfMissing(views, allocator, root_artifact.key, artifact);
+            try self.appendPublicApiDependencyViewByKey(views, allocator, root_artifact, key);
         }
+    }
+
+    fn appendPublicApiDependencyViewByKey(
+        self: *Coordinator,
+        views: *std.ArrayList(check.CheckedArtifact.ImportedModuleView),
+        allocator: Allocator,
+        root_artifact: *const check.CheckedArtifact.CheckedModuleArtifact,
+        key: check.CheckedArtifact.CheckedModuleArtifactKey,
+    ) Allocator.Error!void {
+        if (std.mem.eql(u8, &key.bytes, &root_artifact.key.bytes)) return;
+        if (rootRelationContainsArtifact(root_artifact, key)) return;
+        if (importedArtifactViewExists(views.items, key)) return;
+        const artifact = self.checkedArtifactByKey(key) orelse {
+            if (builtin.mode == .Debug) {
+                std.debug.panic("compile.coordinator invariant violated: public API dependency references unavailable checked artifact", .{});
+            }
+            unreachable;
+        };
+        try appendImportedArtifactViewIfMissing(views, allocator, root_artifact.key, artifact);
+        for (artifact.public_api_dependencies.artifacts) |dependency_key| {
+            try self.appendPublicApiDependencyViewByKey(views, allocator, root_artifact, dependency_key);
+        }
+    }
+
+    fn importedArtifactViewExists(
+        views: []const check.CheckedArtifact.ImportedModuleView,
+        key: check.CheckedArtifact.CheckedModuleArtifactKey,
+    ) bool {
+        for (views) |view| {
+            if (std.mem.eql(u8, &view.key.bytes, &key.bytes)) return true;
+        }
+        return false;
     }
 
     pub fn finalizeExecutableArtifacts(self: *Coordinator) !void {
@@ -1888,34 +1911,6 @@ pub const Coordinator = struct {
                 const resolved_module_idx: u32 = @intCast(imported_envs.items.len);
                 try imported_envs.append(self.gpa, ext_env);
                 mod.moduleEnv().?.imports.setResolvedModule(import_idx, resolved_module_idx);
-            }
-        }
-
-        var seen_modules = std.StringHashMap(void).init(self.gpa);
-        defer seen_modules.deinit();
-
-        for (imported_envs.items) |env| {
-            try seen_modules.put(env.module_name, {});
-        }
-
-        for (mod.external_imports.items) |ext_name| {
-            const ext_env = self.getExternalEnv(pkg.name, ext_name) orelse continue;
-            if (!seen_modules.contains(ext_env.module_name)) {
-                try imported_envs.append(self.gpa, ext_env);
-                try seen_modules.put(ext_env.module_name, {});
-            }
-
-            const qualified = base.module_path.parseQualifiedImport(ext_name) orelse continue;
-            const target_pkg_name = pkg.shorthands.get(qualified.qualifier) orelse continue;
-            const target_pkg = self.packages.get(target_pkg_name) orelse continue;
-
-            for (ext_env.imports.imports.items.items) |trans_str_idx| {
-                const trans_name = ext_env.getString(trans_str_idx);
-                if (seen_modules.contains(trans_name)) continue;
-                if (target_pkg.getSemanticDataIfDone(trans_name)) |semantic| {
-                    try imported_envs.append(self.gpa, semantic.env);
-                    try seen_modules.put(trans_name, {});
-                }
             }
         }
 

--- a/test/fx/transitive_import_nominal_equality/A.roc
+++ b/test/fx/transitive_import_nominal_equality/A.roc
@@ -1,0 +1,9 @@
+import B
+
+A :: [].{
+    a : B.Thing
+    a = B.a
+
+    b : B.Thing
+    b = B.b
+}

--- a/test/fx/transitive_import_nominal_equality/B.roc
+++ b/test/fx/transitive_import_nominal_equality/B.roc
@@ -1,0 +1,12 @@
+B :: [].{
+    Thing := [Thing(I64)].{
+        is_eq : Thing, Thing -> Bool
+        is_eq = |_, _| Bool.True
+    }
+
+    a : Thing
+    a = Thing(1)
+
+    b : Thing
+    b = Thing(2)
+}

--- a/test/fx/transitive_import_nominal_equality/main.roc
+++ b/test/fx/transitive_import_nominal_equality/main.roc
@@ -1,0 +1,8 @@
+app [main!] { pf: platform "../platform/main.roc" }
+
+import pf.Stdout
+import A
+
+main! = || {
+    Stdout.line!(Str.inspect(A.a == A.b))
+}


### PR DESCRIPTION
## Summary
- add a CLI regression for nominal equality through a transitive import
- publish explicit public API dependencies on checked artifacts
- use those dependencies for checker owner lookup and post-check import views without widening direct import scope

## Tests
- zig build test-cli -- --test-filter "test/fx/transitive_import_nominal_equality/main.roc [dev]"
- zig build test-cli