### PR TITLE
Make docs type traversal stack safe

### DIFF
--- a/src/docs/DocModel.zig
+++ b/src/docs/DocModel.zig
@@ -411,78 +411,134 @@ pub const DocType = union(enum) {
     }
 
     pub fn deinit(self: *const DocType, gpa: Allocator) void {
-        switch (self.*) {
-            .type_ref => |ref| {
-                gpa.free(ref.module_path);
-                gpa.free(ref.type_name);
-            },
-            .type_var => |name| {
-                gpa.free(name);
-            },
-            .function => |func| {
-                for (func.args) |arg| {
-                    arg.deinit(gpa);
-                    gpa.destroy(arg);
+        const Frame = struct {
+            node: *const DocType,
+            children_done: bool,
+        };
+
+        const Stack = struct {
+            fn append(stack: *std.ArrayList(Frame), allocator: Allocator, frame: Frame) void {
+                stack.append(allocator, frame) catch @panic("out of memory while deinitializing DocType");
+            }
+        };
+
+        var stack = std.ArrayList(Frame).empty;
+        defer stack.deinit(gpa);
+
+        Stack.append(&stack, gpa, .{ .node = self, .children_done = false });
+        while (stack.pop()) |frame| {
+            const node = frame.node;
+            if (!frame.children_done) {
+                Stack.append(&stack, gpa, .{ .node = node, .children_done = true });
+                switch (node.*) {
+                    .function => |func| {
+                        Stack.append(&stack, gpa, .{ .node = func.ret, .children_done = false });
+                        for (func.args) |arg| {
+                            Stack.append(&stack, gpa, .{ .node = arg, .children_done = false });
+                        }
+                    },
+                    .record => |rec| {
+                        if (rec.ext) |ext| {
+                            Stack.append(&stack, gpa, .{ .node = ext, .children_done = false });
+                        }
+                        for (rec.fields) |field| {
+                            Stack.append(&stack, gpa, .{ .node = field.type, .children_done = false });
+                        }
+                    },
+                    .tag_union => |tu| {
+                        if (tu.ext) |ext| {
+                            Stack.append(&stack, gpa, .{ .node = ext, .children_done = false });
+                        }
+                        for (tu.tags) |tag| {
+                            for (tag.args) |arg| {
+                                Stack.append(&stack, gpa, .{ .node = arg, .children_done = false });
+                            }
+                        }
+                    },
+                    .tuple => |tup| {
+                        for (tup.elems) |elem| {
+                            Stack.append(&stack, gpa, .{ .node = elem, .children_done = false });
+                        }
+                    },
+                    .apply => |app| {
+                        Stack.append(&stack, gpa, .{ .node = app.constructor, .children_done = false });
+                        for (app.args) |arg| {
+                            Stack.append(&stack, gpa, .{ .node = arg, .children_done = false });
+                        }
+                    },
+                    .where_clause => |wc| {
+                        Stack.append(&stack, gpa, .{ .node = wc.type, .children_done = false });
+                        for (wc.constraints) |constraint| {
+                            Stack.append(&stack, gpa, .{ .node = constraint.signature, .children_done = false });
+                        }
+                    },
+                    .type_ref, .type_var, .wildcard, .@"error" => {},
                 }
-                gpa.free(func.args);
-                func.ret.deinit(gpa);
-                gpa.destroy(func.ret);
-            },
-            .record => |rec| {
-                if (rec.ext) |ext| {
-                    ext.deinit(gpa);
-                    gpa.destroy(ext);
-                }
-                for (rec.fields) |field| {
-                    gpa.free(field.name);
-                    field.type.deinit(gpa);
-                    gpa.destroy(field.type);
-                }
-                gpa.free(rec.fields);
-            },
-            .tag_union => |tu| {
-                for (tu.tags) |tag| {
-                    gpa.free(tag.name);
-                    for (tag.args) |arg| {
-                        arg.deinit(gpa);
+                continue;
+            }
+
+            switch (node.*) {
+                .type_ref => |ref| {
+                    gpa.free(ref.module_path);
+                    gpa.free(ref.type_name);
+                },
+                .type_var => |name| {
+                    gpa.free(name);
+                },
+                .function => |func| {
+                    for (func.args) |arg| {
                         gpa.destroy(arg);
                     }
-                    gpa.free(tag.args);
-                }
-                gpa.free(tu.tags);
-                if (tu.ext) |ext| {
-                    ext.deinit(gpa);
-                    gpa.destroy(ext);
-                }
-            },
-            .tuple => |tup| {
-                for (tup.elems) |elem| {
-                    elem.deinit(gpa);
-                    gpa.destroy(elem);
-                }
-                gpa.free(tup.elems);
-            },
-            .apply => |app| {
-                app.constructor.deinit(gpa);
-                gpa.destroy(app.constructor);
-                for (app.args) |arg| {
-                    arg.deinit(gpa);
-                    gpa.destroy(arg);
-                }
-                gpa.free(app.args);
-            },
-            .where_clause => |wc| {
-                wc.type.deinit(gpa);
-                gpa.destroy(wc.type);
-                for (wc.constraints) |constraint| {
-                    gpa.free(constraint.type_var);
-                    gpa.free(constraint.method_name);
-                    constraint.signature.deinit(gpa);
-                    gpa.destroy(constraint.signature);
-                }
-                gpa.free(wc.constraints);
-            },
-            .wildcard, .@"error" => {},
+                    gpa.free(func.args);
+                    gpa.destroy(func.ret);
+                },
+                .record => |rec| {
+                    if (rec.ext) |ext| {
+                        gpa.destroy(ext);
+                    }
+                    for (rec.fields) |field| {
+                        gpa.free(field.name);
+                        gpa.destroy(field.type);
+                    }
+                    gpa.free(rec.fields);
+                },
+                .tag_union => |tu| {
+                    for (tu.tags) |tag| {
+                        gpa.free(tag.name);
+                        for (tag.args) |arg| {
+                            gpa.destroy(arg);
+                        }
+                        gpa.free(tag.args);
+                    }
+                    gpa.free(tu.tags);
+                    if (tu.ext) |ext| {
+                        gpa.destroy(ext);
+                    }
+                },
+                .tuple => |tup| {
+                    for (tup.elems) |elem| {
+                        gpa.destroy(elem);
+                    }
+                    gpa.free(tup.elems);
+                },
+                .apply => |app| {
+                    gpa.destroy(app.constructor);
+                    for (app.args) |arg| {
+                        gpa.destroy(arg);
+                    }
+                    gpa.free(app.args);
+                },
+                .where_clause => |wc| {
+                    gpa.destroy(wc.type);
+                    for (wc.constraints) |constraint| {
+                        gpa.free(constraint.type_var);
+                        gpa.free(constraint.method_name);
+                        gpa.destroy(constraint.signature);
+                    }
+                    gpa.free(wc.constraints);
+                },
+                .wildcard, .@"error" => {},
+            }
         }
     }
 };

--- a/src/docs/extract.zig
+++ b/src/docs/extract.zig
@@ -696,8 +696,16 @@ fn extractDefEntry(
             const doc_extract = try extractDocComment(gpa, source, offset);
             errdefer if (doc_extract) |d| gpa.free(d.text);
 
-            // Extract structured type from inferred type
+            // For annotated definitions, render the checked source annotation.
+            // That is the signature the user wrote, and it avoids re-walking
+            // recursive inferred type graphs when explicit documentation data
+            // is already available in CIR.
             const type_sig: ?*const DocType = blk: {
+                if (def.annotation) |anno_idx| {
+                    const annotation = module_env.store.getAnnotation(anno_idx);
+                    break :blk try extractAnnotationAsDocType(gpa, module_env, annotation);
+                }
+
                 const def_var = ModuleEnv.varFrom(def_idx);
                 if (@intFromEnum(def_var) >= module_env.types.len()) break :blk null;
                 break :blk extractDocType(
@@ -855,6 +863,152 @@ fn extractDeclTypeSig(
     return try extractTypeAnnoAsDocType(gpa, module_env, anno_idx);
 }
 
+fn extractAnnotationAsDocType(
+    gpa: Allocator,
+    module_env: *const ModuleEnv,
+    annotation: CIR.Annotation,
+) !?*const DocType {
+    const base_type = try extractTypeAnnoAsDocType(gpa, module_env, annotation.anno) orelse return null;
+    var base_type_moved = false;
+    errdefer if (!base_type_moved) {
+        base_type.deinit(gpa);
+        gpa.destroy(base_type);
+    };
+
+    const where_span = annotation.where orelse return base_type;
+    var constraints = std.ArrayList(DocType.Constraint).empty;
+    defer {
+        for (constraints.items) |*constraint| {
+            constraint.signature.deinit(gpa);
+            gpa.destroy(constraint.signature);
+            gpa.free(constraint.type_var);
+            gpa.free(constraint.method_name);
+        }
+        constraints.deinit(gpa);
+    }
+
+    for (module_env.store.sliceWhereClauses(where_span)) |where_idx| {
+        const where_clause = module_env.store.getWhereClause(where_idx);
+        switch (where_clause) {
+            .w_method => |method| {
+                const constraint = try extractWhereMethodConstraint(gpa, module_env, method);
+                errdefer {
+                    constraint.signature.deinit(gpa);
+                    gpa.destroy(constraint.signature);
+                    gpa.free(constraint.type_var);
+                    gpa.free(constraint.method_name);
+                }
+                try constraints.append(gpa, constraint);
+            },
+            .w_alias, .w_malformed => {},
+        }
+    }
+
+    if (constraints.items.len == 0) return base_type;
+
+    const owned_constraints = try gpa.alloc(DocType.Constraint, constraints.items.len);
+    var constraints_moved = false;
+    errdefer if (!constraints_moved) {
+        for (owned_constraints) |*constraint| {
+            constraint.signature.deinit(gpa);
+            gpa.destroy(constraint.signature);
+            gpa.free(constraint.type_var);
+            gpa.free(constraint.method_name);
+        }
+        gpa.free(owned_constraints);
+    };
+    @memcpy(owned_constraints, constraints.items);
+    constraints.clearRetainingCapacity();
+
+    const wrapped = try allocDocType(gpa, .{ .where_clause = .{
+        .type = base_type,
+        .constraints = owned_constraints,
+    } });
+    base_type_moved = true;
+    constraints_moved = true;
+    return wrapped;
+}
+
+fn extractWhereMethodConstraint(
+    gpa: Allocator,
+    module_env: *const ModuleEnv,
+    method: @TypeOf(@as(CIR.WhereClause, undefined).w_method),
+) !DocType.Constraint {
+    const type_var = try extractWhereTypeVarName(gpa, module_env, method.var_);
+    errdefer gpa.free(type_var);
+
+    const method_name = try gpa.dupe(u8, module_env.getIdentText(method.method_name));
+    errdefer gpa.free(method_name);
+
+    const signature = try extractWhereMethodSignature(gpa, module_env, method);
+    errdefer {
+        signature.deinit(gpa);
+        gpa.destroy(signature);
+    }
+
+    return .{
+        .type_var = type_var,
+        .method_name = method_name,
+        .signature = signature,
+    };
+}
+
+fn extractWhereMethodSignature(
+    gpa: Allocator,
+    module_env: *const ModuleEnv,
+    method: @TypeOf(@as(CIR.WhereClause, undefined).w_method),
+) !*const DocType {
+    const args_slice = module_env.store.sliceTypeAnnos(method.args);
+    const args = try gpa.alloc(*const DocType, args_slice.len);
+    var args_len: usize = 0;
+    var args_moved = false;
+    errdefer if (!args_moved) {
+        for (args[0..args_len]) |arg| {
+            arg.deinit(gpa);
+            gpa.destroy(arg);
+        }
+        gpa.free(args);
+    };
+
+    for (args_slice) |arg_idx| {
+        args[args_len] = try extractTypeAnnoAsDocType(gpa, module_env, arg_idx) orelse
+            try allocDocType(gpa, .@"error");
+        args_len += 1;
+    }
+
+    const ret = try extractTypeAnnoAsDocType(gpa, module_env, method.ret) orelse
+        try allocDocType(gpa, .@"error");
+    var ret_moved = false;
+    errdefer if (!ret_moved) {
+        ret.deinit(gpa);
+        gpa.destroy(ret);
+    };
+
+    const signature = try allocDocType(gpa, .{ .function = .{
+        .args = args,
+        .ret = ret,
+        .effectful = false,
+    } });
+    args_moved = true;
+    ret_moved = true;
+    return signature;
+}
+
+fn extractWhereTypeVarName(
+    gpa: Allocator,
+    module_env: *const ModuleEnv,
+    var_idx: CIR.TypeAnno.Idx,
+) ![]const u8 {
+    var current = var_idx;
+    while (true) {
+        switch (module_env.store.getTypeAnno(current)) {
+            .rigid_var => |rv| return try gpa.dupe(u8, module_env.getIdentText(rv.name)),
+            .rigid_var_lookup => |rv_lookup| current = rv_lookup.ref,
+            else => return try gpa.dupe(u8, "?"),
+        }
+    }
+}
+
 /// Resolve the module path from a CIR TypeAnno's LocalOrExternal base.
 fn resolveModulePathFromBase(
     module_env: *const ModuleEnv,
@@ -862,7 +1016,10 @@ fn resolveModulePathFromBase(
 ) []const u8 {
     return switch (local_or_ext) {
         .builtin => "", // Don't expose "Builtin" module as it's an implementation detail
-        .local => module_env.module_name,
+        .local => if (!module_env.qualified_module_ident.isNone())
+            module_env.getIdentText(module_env.qualified_module_ident)
+        else
+            module_env.module_name,
         .external => |ext| blk: {
             const idx = @intFromEnum(ext.module_idx);
             if (idx >= module_env.imports.imports.items.items.len) break :blk "";
@@ -894,184 +1051,458 @@ fn extractTypeAnnoAsDocType(
     module_env: *const ModuleEnv,
     type_anno_idx: CIR.TypeAnno.Idx,
 ) !?*const DocType {
-    const anno = module_env.store.getTypeAnno(type_anno_idx);
-    switch (anno) {
-        .apply => |a| {
-            const name = module_env.getIdentText(a.name);
-            const args_slice = module_env.store.sliceTypeAnnos(a.args);
+    const BuildFrame = union(enum) {
+        visit: CIR.TypeAnno.Idx,
+        malformed_tag,
+        finish_apply: struct {
+            name: []const u8,
+            module_path: []const u8,
+            arg_count: usize,
+        },
+        finish_tag: struct {
+            name: []const u8,
+            arg_count: usize,
+        },
+        finish_tag_union: struct {
+            tag_count: usize,
+            has_ext: bool,
+            is_open: bool,
+        },
+        finish_tuple: usize,
+        finish_record: struct {
+            fields: []CIR.TypeAnno.RecordField.Idx,
+            has_ext: bool,
+            is_open: bool,
+        },
+        finish_fn: struct {
+            arg_count: usize,
+            effectful: bool,
+        },
+    };
 
-            const module_path = resolveModulePathFromBase(module_env, a.base);
+    const Builder = struct {
+        fn pushResult(results: *std.ArrayList(*const DocType), allocator: Allocator, value: *const DocType) ExtractError!void {
+            errdefer {
+                value.deinit(allocator);
+                allocator.destroy(value);
+            }
+            try results.append(allocator, value);
+        }
 
-            if (args_slice.len > 0) {
-                // Type application: List(Str), Result(ok, err)
-                const constructor = try allocDocType(gpa, .{ .type_ref = .{
-                    .module_path = try gpa.dupe(u8, module_path),
-                    .type_name = try gpa.dupe(u8, name),
+        fn cleanupDocTypes(allocator: Allocator, values: []const *const DocType) void {
+            for (values) |value| {
+                value.deinit(allocator);
+                allocator.destroy(value);
+            }
+        }
+
+        fn cleanupTag(allocator: Allocator, tag: DocType.Tag) void {
+            allocator.free(tag.name);
+            cleanupDocTypes(allocator, tag.args);
+            allocator.free(tag.args);
+        }
+
+        fn cleanupFields(allocator: Allocator, fields: []const DocType.Field) void {
+            for (fields) |field| {
+                allocator.free(field.name);
+                field.type.deinit(allocator);
+                allocator.destroy(field.type);
+            }
+        }
+
+        fn pushVisitsReversed(
+            frames: *std.ArrayList(BuildFrame),
+            allocator: Allocator,
+            children: []const CIR.TypeAnno.Idx,
+        ) ExtractError!void {
+            var i = children.len;
+            while (i > 0) {
+                i -= 1;
+                try frames.append(allocator, .{ .visit = children[i] });
+            }
+        }
+    };
+
+    var frames = std.ArrayList(BuildFrame).empty;
+    defer frames.deinit(gpa);
+
+    var results = std.ArrayList(*const DocType).empty;
+    defer results.deinit(gpa);
+    errdefer Builder.cleanupDocTypes(gpa, results.items);
+
+    try frames.append(gpa, .{ .visit = type_anno_idx });
+    while (frames.pop()) |frame| {
+        switch (frame) {
+            .visit => |idx| {
+                const anno = module_env.store.getTypeAnno(idx);
+                switch (anno) {
+                    .apply => |a| {
+                        const args_slice = module_env.store.sliceTypeAnnos(a.args);
+                        const name = module_env.getIdentText(a.name);
+                        const module_path = resolveModulePathFromBase(module_env, a.base);
+                        if (args_slice.len == 0) {
+                            try Builder.pushResult(&results, gpa, try allocDocType(gpa, .{ .type_ref = .{
+                                .module_path = try gpa.dupe(u8, module_path),
+                                .type_name = try gpa.dupe(u8, name),
+                            } }));
+                        } else {
+                            try frames.append(gpa, .{ .finish_apply = .{
+                                .name = name,
+                                .module_path = module_path,
+                                .arg_count = args_slice.len,
+                            } });
+                            try Builder.pushVisitsReversed(&frames, gpa, args_slice);
+                        }
+                    },
+                    .rigid_var => |tv| {
+                        try Builder.pushResult(&results, gpa, try allocDocType(gpa, .{
+                            .type_var = try gpa.dupe(u8, module_env.getIdentText(tv.name)),
+                        }));
+                    },
+                    .rigid_var_lookup => |rv| {
+                        try frames.append(gpa, .{ .visit = rv.ref });
+                    },
+                    .underscore => {
+                        try Builder.pushResult(&results, gpa, try allocDocType(gpa, .wildcard));
+                    },
+                    .lookup => |t| {
+                        const name = module_env.getIdentText(t.name);
+                        const module_path = resolveModulePathFromBase(module_env, t.base);
+                        try Builder.pushResult(&results, gpa, try allocDocType(gpa, .{ .type_ref = .{
+                            .module_path = try gpa.dupe(u8, module_path),
+                            .type_name = try gpa.dupe(u8, name),
+                        } }));
+                    },
+                    .tag_union => |tu| {
+                        const tags_slice = module_env.store.sliceTypeAnnos(tu.tags);
+                        const has_ext = if (tu.ext) |ext_idx| !isAnonymousOpenExt(module_env, ext_idx) else false;
+                        try frames.append(gpa, .{ .finish_tag_union = .{
+                            .tag_count = tags_slice.len,
+                            .has_ext = has_ext,
+                            .is_open = tu.ext != null,
+                        } });
+                        if (has_ext) {
+                            try frames.append(gpa, .{ .visit = tu.ext.? });
+                        }
+                        var i = tags_slice.len;
+                        while (i > 0) {
+                            i -= 1;
+                            const tag_anno = module_env.store.getTypeAnno(tags_slice[i]);
+                            switch (tag_anno) {
+                                .tag => |t| {
+                                    const tag_args_slice = module_env.store.sliceTypeAnnos(t.args);
+                                    try frames.append(gpa, .{ .finish_tag = .{
+                                        .name = module_env.getIdentText(t.name),
+                                        .arg_count = tag_args_slice.len,
+                                    } });
+                                    try Builder.pushVisitsReversed(&frames, gpa, tag_args_slice);
+                                },
+                                else => {
+                                    try frames.append(gpa, .malformed_tag);
+                                },
+                            }
+                        }
+                    },
+                    .tag => |t| {
+                        const tag_args_slice = module_env.store.sliceTypeAnnos(t.args);
+                        try frames.append(gpa, .{ .finish_tag = .{
+                            .name = module_env.getIdentText(t.name),
+                            .arg_count = tag_args_slice.len,
+                        } });
+                        try Builder.pushVisitsReversed(&frames, gpa, tag_args_slice);
+                    },
+                    .tuple => |t| {
+                        const elems_slice = module_env.store.sliceTypeAnnos(t.elems);
+                        try frames.append(gpa, .{ .finish_tuple = elems_slice.len });
+                        try Builder.pushVisitsReversed(&frames, gpa, elems_slice);
+                    },
+                    .record => |r| {
+                        const fields_slice = module_env.store.sliceAnnoRecordFields(r.fields);
+                        const has_ext = if (r.ext) |ext_idx| !isAnonymousOpenExt(module_env, ext_idx) else false;
+                        try frames.append(gpa, .{ .finish_record = .{
+                            .fields = fields_slice,
+                            .has_ext = has_ext,
+                            .is_open = r.ext != null,
+                        } });
+                        if (has_ext) {
+                            try frames.append(gpa, .{ .visit = r.ext.? });
+                        }
+                        var i = fields_slice.len;
+                        while (i > 0) {
+                            i -= 1;
+                            const field = module_env.store.getAnnoRecordField(fields_slice[i]);
+                            try frames.append(gpa, .{ .visit = field.ty });
+                        }
+                    },
+                    .@"fn" => |f| {
+                        const args_slice = module_env.store.sliceTypeAnnos(f.args);
+                        try frames.append(gpa, .{ .finish_fn = .{
+                            .arg_count = args_slice.len,
+                            .effectful = f.effectful,
+                        } });
+                        try frames.append(gpa, .{ .visit = f.ret });
+                        try Builder.pushVisitsReversed(&frames, gpa, args_slice);
+                    },
+                    .parens => |p| {
+                        try frames.append(gpa, .{ .visit = p.anno });
+                    },
+                    .malformed => {
+                        try Builder.pushResult(&results, gpa, try allocDocType(gpa, .@"error"));
+                    },
+                }
+            },
+            .malformed_tag => {
+                const tag_args = try gpa.alloc(*const DocType, 0);
+                var tag_args_moved = false;
+                errdefer if (!tag_args_moved) gpa.free(tag_args);
+
+                var tags = try gpa.alloc(DocType.Tag, 1);
+                var tags_len: usize = 0;
+                var tags_moved = false;
+                errdefer if (!tags_moved) {
+                    for (tags[0..tags_len]) |tag| {
+                        Builder.cleanupTag(gpa, tag);
+                    }
+                    gpa.free(tags);
+                };
+
+                tags[0] = .{
+                    .name = try gpa.dupe(u8, "?"),
+                    .args = tag_args,
+                };
+                tags_len = 1;
+                tag_args_moved = true;
+
+                const single_tag = try allocDocType(gpa, .{ .tag_union = .{
+                    .tags = tags,
+                    .ext = null,
+                    .is_open = false,
                 } });
-                errdefer {
+                tags_moved = true;
+                try Builder.pushResult(&results, gpa, single_tag);
+            },
+            .finish_apply => |finish| {
+                std.debug.assert(results.items.len >= finish.arg_count);
+                const start = results.items.len - finish.arg_count;
+                const args = try gpa.alloc(*const DocType, finish.arg_count);
+                var args_moved = false;
+                errdefer if (!args_moved) {
+                    Builder.cleanupDocTypes(gpa, args);
+                    gpa.free(args);
+                };
+                @memcpy(args, results.items[start..]);
+                results.shrinkRetainingCapacity(start);
+
+                const constructor = try allocDocType(gpa, .{ .type_ref = .{
+                    .module_path = try gpa.dupe(u8, finish.module_path),
+                    .type_name = try gpa.dupe(u8, finish.name),
+                } });
+                var constructor_moved = false;
+                errdefer if (!constructor_moved) {
                     constructor.deinit(gpa);
                     gpa.destroy(constructor);
-                }
+                };
 
-                var args = try gpa.alloc(*const DocType, args_slice.len);
-                errdefer {
-                    for (args) |arg| {
-                        arg.deinit(gpa);
-                        gpa.destroy(arg);
-                    }
-                    gpa.free(args);
-                }
-
-                for (args_slice, 0..) |arg_idx, i| {
-                    args[i] = try extractTypeAnnoAsDocType(gpa, module_env, arg_idx) orelse
-                        try allocDocType(gpa, .@"error");
-                }
-
-                return try allocDocType(gpa, .{ .apply = .{
+                const app = try allocDocType(gpa, .{ .apply = .{
                     .constructor = constructor,
                     .args = args,
                 } });
-            } else {
-                // Simple type reference: Str, U64, etc.
-                return try allocDocType(gpa, .{ .type_ref = .{
-                    .module_path = try gpa.dupe(u8, module_path),
-                    .type_name = try gpa.dupe(u8, name),
-                } });
-            }
-        },
-        .rigid_var => |tv| {
-            return try allocDocType(gpa, .{ .type_var = try gpa.dupe(u8, module_env.getIdentText(tv.name)) });
-        },
-        .rigid_var_lookup => |rv| {
-            return try extractTypeAnnoAsDocType(gpa, module_env, rv.ref);
-        },
-        .underscore => {
-            return try allocDocType(gpa, .wildcard);
-        },
-        .lookup => |t| {
-            const name = module_env.getIdentText(t.name);
-            const module_path = resolveModulePathFromBase(module_env, t.base);
-            return try allocDocType(gpa, .{ .type_ref = .{
-                .module_path = try gpa.dupe(u8, module_path),
-                .type_name = try gpa.dupe(u8, name),
-            } });
-        },
-        .tag_union => |tu| {
-            const tags_slice = module_env.store.sliceTypeAnnos(tu.tags);
-            var tags = try gpa.alloc(DocType.Tag, tags_slice.len);
-            errdefer gpa.free(tags);
-
-            for (tags_slice, 0..) |tag_idx, i| {
-                const tag_anno = module_env.store.getTypeAnno(tag_idx);
-                switch (tag_anno) {
-                    .tag => |t| {
-                        const tag_name = try gpa.dupe(u8, module_env.getIdentText(t.name));
-                        const tag_args_slice = module_env.store.sliceTypeAnnos(t.args);
-                        var tag_args = try gpa.alloc(*const DocType, tag_args_slice.len);
-                        for (tag_args_slice, 0..) |arg_idx, j| {
-                            tag_args[j] = try extractTypeAnnoAsDocType(gpa, module_env, arg_idx) orelse
-                                try allocDocType(gpa, .@"error");
-                        }
-                        tags[i] = .{ .name = tag_name, .args = tag_args };
-                    },
-                    else => {
-                        tags[i] = .{ .name = try gpa.dupe(u8, "?"), .args = try gpa.alloc(*const DocType, 0) };
-                    },
-                }
-            }
-
-            var ext: ?*const DocType = null;
-            var is_open = false;
-            if (tu.ext) |ext_idx| {
-                is_open = true;
-                if (!isAnonymousOpenExt(module_env, ext_idx)) {
-                    ext = try extractTypeAnnoAsDocType(gpa, module_env, ext_idx);
-                }
-            }
-
-            return try allocDocType(gpa, .{ .tag_union = .{
-                .tags = tags,
-                .ext = ext,
-                .is_open = is_open,
-            } });
-        },
-        .tag => |t| {
-            // A bare tag (shouldn't normally appear at top level, but handle it)
-            const tag_name = try gpa.dupe(u8, module_env.getIdentText(t.name));
-            const tag_args_slice = module_env.store.sliceTypeAnnos(t.args);
-            var tag_args = try gpa.alloc(*const DocType, tag_args_slice.len);
-            for (tag_args_slice, 0..) |arg_idx, i| {
-                tag_args[i] = try extractTypeAnnoAsDocType(gpa, module_env, arg_idx) orelse
-                    try allocDocType(gpa, .@"error");
-            }
-
-            var tags = try gpa.alloc(DocType.Tag, 1);
-            tags[0] = .{ .name = tag_name, .args = tag_args };
-            return try allocDocType(gpa, .{ .tag_union = .{
-                .tags = tags,
-                .ext = null,
-                .is_open = false,
-            } });
-        },
-        .tuple => |t| {
-            const elems_slice = module_env.store.sliceTypeAnnos(t.elems);
-            var elems = try gpa.alloc(*const DocType, elems_slice.len);
-            for (elems_slice, 0..) |elem_idx, i| {
-                elems[i] = try extractTypeAnnoAsDocType(gpa, module_env, elem_idx) orelse
-                    try allocDocType(gpa, .@"error");
-            }
-            return try allocDocType(gpa, .{ .tuple = .{ .elems = elems } });
-        },
-        .record => |r| {
-            const fields_slice = module_env.store.sliceAnnoRecordFields(r.fields);
-            var fields = try gpa.alloc(DocType.Field, fields_slice.len);
-            for (fields_slice, 0..) |field_idx, i| {
-                const field = module_env.store.getAnnoRecordField(field_idx);
-                fields[i] = .{
-                    .name = try gpa.dupe(u8, module_env.getIdentText(field.name)),
-                    .type = try extractTypeAnnoAsDocType(gpa, module_env, field.ty) orelse
-                        try allocDocType(gpa, .@"error"),
+                args_moved = true;
+                constructor_moved = true;
+                try Builder.pushResult(&results, gpa, app);
+            },
+            .finish_tag => |finish| {
+                std.debug.assert(results.items.len >= finish.arg_count);
+                const start = results.items.len - finish.arg_count;
+                const tag_args = try gpa.alloc(*const DocType, finish.arg_count);
+                var tag_args_moved = false;
+                errdefer if (!tag_args_moved) {
+                    Builder.cleanupDocTypes(gpa, tag_args);
+                    gpa.free(tag_args);
                 };
-            }
+                @memcpy(tag_args, results.items[start..]);
+                results.shrinkRetainingCapacity(start);
 
-            var ext: ?*const DocType = null;
-            var is_open = false;
-            if (r.ext) |ext_idx| {
-                is_open = true;
-                if (!isAnonymousOpenExt(module_env, ext_idx)) {
-                    ext = try extractTypeAnnoAsDocType(gpa, module_env, ext_idx);
+                var tags = try gpa.alloc(DocType.Tag, 1);
+                var tags_len: usize = 0;
+                var tags_moved = false;
+                errdefer if (!tags_moved) {
+                    for (tags[0..tags_len]) |tag| {
+                        Builder.cleanupTag(gpa, tag);
+                    }
+                    gpa.free(tags);
+                };
+                tags[0] = .{
+                    .name = try gpa.dupe(u8, finish.name),
+                    .args = tag_args,
+                };
+                tags_len = 1;
+                tag_args_moved = true;
+
+                const single_tag = try allocDocType(gpa, .{ .tag_union = .{
+                    .tags = tags,
+                    .ext = null,
+                    .is_open = false,
+                } });
+                tags_moved = true;
+                try Builder.pushResult(&results, gpa, single_tag);
+            },
+            .finish_tag_union => |finish| {
+                var ext: ?*const DocType = null;
+                var ext_moved = false;
+                errdefer if (!ext_moved) {
+                    if (ext) |ext_type| {
+                        ext_type.deinit(gpa);
+                        gpa.destroy(ext_type);
+                    }
+                };
+                if (finish.has_ext) {
+                    ext = results.pop().?;
                 }
-            }
 
-            return try allocDocType(gpa, .{ .record = .{
-                .fields = fields,
-                .ext = ext,
-                .is_open = is_open,
-            } });
-        },
-        .@"fn" => |f| {
-            const args_slice = module_env.store.sliceTypeAnnos(f.args);
-            var args = try gpa.alloc(*const DocType, args_slice.len);
-            for (args_slice, 0..) |arg_idx, i| {
-                args[i] = try extractTypeAnnoAsDocType(gpa, module_env, arg_idx) orelse
-                    try allocDocType(gpa, .@"error");
-            }
-            const ret = try extractTypeAnnoAsDocType(gpa, module_env, f.ret) orelse
-                try allocDocType(gpa, .@"error");
+                std.debug.assert(results.items.len >= finish.tag_count);
+                const start = results.items.len - finish.tag_count;
+                var tags = try gpa.alloc(DocType.Tag, finish.tag_count);
+                var tags_len: usize = 0;
+                var tags_moved = false;
+                errdefer if (!tags_moved) {
+                    for (tags[0..tags_len]) |tag| {
+                        Builder.cleanupTag(gpa, tag);
+                    }
+                    gpa.free(tags);
+                };
 
-            return try allocDocType(gpa, .{ .function = .{
-                .args = args,
-                .ret = ret,
-                .effectful = f.effectful,
-            } });
-        },
-        .parens => |p| {
-            return try extractTypeAnnoAsDocType(gpa, module_env, p.anno);
-        },
-        .malformed => {
-            return try allocDocType(gpa, .@"error");
-        },
+                for (results.items[start..], 0..) |single_tag, i| {
+                    switch (single_tag.*) {
+                        .tag_union => |tu| {
+                            std.debug.assert(tu.tags.len == 1);
+                            std.debug.assert(tu.ext == null);
+                            tags[i] = tu.tags[0];
+                            tags_len += 1;
+                            gpa.free(tu.tags);
+                        },
+                        else => unreachable,
+                    }
+                    gpa.destroy(single_tag);
+                }
+                results.shrinkRetainingCapacity(start);
+
+                const tag_union = try allocDocType(gpa, .{ .tag_union = .{
+                    .tags = tags,
+                    .ext = ext,
+                    .is_open = finish.is_open,
+                } });
+                tags_moved = true;
+                ext_moved = true;
+                try Builder.pushResult(&results, gpa, tag_union);
+            },
+            .finish_tuple => |elem_count| {
+                std.debug.assert(results.items.len >= elem_count);
+                const start = results.items.len - elem_count;
+                const elems = try gpa.alloc(*const DocType, elem_count);
+                var elems_moved = false;
+                errdefer if (!elems_moved) {
+                    Builder.cleanupDocTypes(gpa, elems);
+                    gpa.free(elems);
+                };
+                @memcpy(elems, results.items[start..]);
+                results.shrinkRetainingCapacity(start);
+
+                const tuple = try allocDocType(gpa, .{ .tuple = .{ .elems = elems } });
+                elems_moved = true;
+                try Builder.pushResult(&results, gpa, tuple);
+            },
+            .finish_record => |finish| {
+                var ext: ?*const DocType = null;
+                var ext_moved = false;
+                errdefer if (!ext_moved) {
+                    if (ext) |ext_type| {
+                        ext_type.deinit(gpa);
+                        gpa.destroy(ext_type);
+                    }
+                };
+                if (finish.has_ext) {
+                    ext = results.pop().?;
+                }
+
+                std.debug.assert(results.items.len >= finish.fields.len);
+                const start = results.items.len - finish.fields.len;
+                var field_names = try gpa.alloc([]const u8, finish.fields.len);
+                defer gpa.free(field_names);
+                var field_names_len: usize = 0;
+                var field_names_moved = false;
+                errdefer if (!field_names_moved) {
+                    for (field_names[0..field_names_len]) |name| {
+                        gpa.free(name);
+                    }
+                };
+                for (finish.fields) |field_idx| {
+                    const field = module_env.store.getAnnoRecordField(field_idx);
+                    field_names[field_names_len] = try gpa.dupe(u8, module_env.getIdentText(field.name));
+                    field_names_len += 1;
+                }
+
+                var fields = try gpa.alloc(DocType.Field, finish.fields.len);
+                var fields_len: usize = 0;
+                var fields_moved = false;
+                errdefer if (!fields_moved) {
+                    Builder.cleanupFields(gpa, fields[0..fields_len]);
+                    gpa.free(fields);
+                };
+
+                for (field_names, 0..) |field_name, i| {
+                    fields[i] = .{
+                        .name = field_name,
+                        .type = results.items[start + i],
+                    };
+                    fields_len += 1;
+                }
+                field_names_moved = true;
+                results.shrinkRetainingCapacity(start);
+
+                const record = try allocDocType(gpa, .{ .record = .{
+                    .fields = fields,
+                    .ext = ext,
+                    .is_open = finish.is_open,
+                } });
+                fields_moved = true;
+                ext_moved = true;
+                try Builder.pushResult(&results, gpa, record);
+            },
+            .finish_fn => |finish| {
+                const needed = finish.arg_count + 1;
+                std.debug.assert(results.items.len >= needed);
+                const ret = results.pop().?;
+                var ret_moved = false;
+                errdefer if (!ret_moved) {
+                    ret.deinit(gpa);
+                    gpa.destroy(ret);
+                };
+
+                const start = results.items.len - finish.arg_count;
+                const args = try gpa.alloc(*const DocType, finish.arg_count);
+                var args_moved = false;
+                errdefer if (!args_moved) {
+                    Builder.cleanupDocTypes(gpa, args);
+                    gpa.free(args);
+                };
+                @memcpy(args, results.items[start..]);
+                results.shrinkRetainingCapacity(start);
+
+                const func = try allocDocType(gpa, .{ .function = .{
+                    .args = args,
+                    .ret = ret,
+                    .effectful = finish.effectful,
+                } });
+                args_moved = true;
+                ret_moved = true;
+                try Builder.pushResult(&results, gpa, func);
+            },
+        }
     }
+
+    std.debug.assert(results.items.len == 1);
+    return results.pop().?;
 }
 
 // --- Type extraction from inferred types ---

--- a/src/docs/render_html.zig
+++ b/src/docs/render_html.zig
@@ -516,7 +516,7 @@ fn writeModulePageToDir(ctx: *const RenderContext, gpa: Allocator, dir: std.fs.D
             if (entry.type_signature) |sig| {
                 try w.writeAll("        <code class=\"entry-type-def\">");
                 try w.writeAll(":= ");
-                try renderDocTypeHtml(w, ctx, sig, false);
+                try renderDocTypeHtml(w, ctx, gpa, sig, false);
                 try w.writeAll("</code>\n");
             }
         }
@@ -536,7 +536,7 @@ fn writeModulePageToDir(ctx: *const RenderContext, gpa: Allocator, dir: std.fs.D
     }
 
     // Render entries
-    try renderEntryTree(w, ctx, entry_tree.root, 0);
+    try renderEntryTree(w, ctx, gpa, entry_tree.root, 0);
 
     try writeFooter(w);
     try w.writeAll("    </main>\n");
@@ -810,13 +810,14 @@ fn writeIndent(w: Writer, level: usize) !void {
 fn renderEntryTree(
     w: Writer,
     ctx: *const RenderContext,
+    gpa: Allocator,
     node: *const SidebarNode,
     depth: usize,
 ) !void {
     // Skip the root node (empty name), process its children
     if (depth == 0) {
         for (node.children.items) |child| {
-            try renderEntryTree(w, ctx, child, depth + 1);
+            try renderEntryTree(w, ctx, gpa, child, depth + 1);
         }
         return;
     }
@@ -865,7 +866,7 @@ fn renderEntryTree(
                         try writeIndent(w, base + 1);
                         try w.writeAll("<code class=\"entry-type-def\">");
                         try w.writeAll(":= ");
-                        try renderDocTypeHtml(w, ctx, sig, false);
+                        try renderDocTypeHtml(w, ctx, gpa, sig, false);
                         try w.writeAll("</code>\n");
                     }
                 }
@@ -883,7 +884,7 @@ fn renderEntryTree(
                 try w.writeAll("</a>\n");
                 try writeIndent(w, base + 2);
                 try w.writeAll("<code class=\"entry-signature-code\">");
-                try renderEntrySignature(w, ctx, entry, anchor_id);
+                try renderEntrySignature(w, ctx, gpa, entry, anchor_id);
                 try w.writeAll("</code>\n");
                 try writeIndent(w, base + 1);
                 try w.writeAll("</div>\n");
@@ -903,7 +904,7 @@ fn renderEntryTree(
                 try writeIndent(w, base + 1);
                 try w.writeAll("<div class=\"entry-children-container\">\n");
                 for (node.children.items) |child| {
-                    try renderEntryTree(w, ctx, child, depth + 1);
+                    try renderEntryTree(w, ctx, gpa, child, depth + 1);
                 }
                 try writeIndent(w, base + 1);
                 try w.writeAll("</div>\n");
@@ -924,7 +925,7 @@ fn renderEntryTree(
         try writeHtmlEscaped(w, node.name);
         try w.print("</h{d}>\n", .{heading_level});
         for (node.children.items) |child| {
-            try renderEntryTree(w, ctx, child, depth + 1);
+            try renderEntryTree(w, ctx, gpa, child, depth + 1);
         }
         try writeIndent(w, base);
         try w.writeAll("</section>\n");
@@ -1123,7 +1124,7 @@ fn renderSearchEntries(w: Writer, ctx: *const RenderContext, gpa: Allocator, bas
     for (ctx.package_docs.modules) |mod| {
         const entry_tree = try buildEntryTree(gpa, mod.entries, mod.name);
         defer entry_tree.deinit(gpa);
-        try renderSearchTree(w, ctx, mod.name, entry_tree.root, base);
+        try renderSearchTree(w, ctx, gpa, mod.name, entry_tree.root, base);
     }
 }
 
@@ -1132,6 +1133,7 @@ fn renderSearchEntries(w: Writer, ctx: *const RenderContext, gpa: Allocator, bas
 fn renderSearchTree(
     w: Writer,
     ctx: *const RenderContext,
+    gpa: Allocator,
     module_name: []const u8,
     node: *const SidebarNode,
     base: []const u8,
@@ -1194,11 +1196,11 @@ fn renderSearchTree(
             switch (entry.kind) {
                 .value, .alias => {
                     try w.writeAll(": ");
-                    try renderDocTypeHtml(w, sig_ctx, sig, false);
+                    try renderDocTypeHtml(w, sig_ctx, gpa, sig, false);
                 },
                 .nominal => {
                     try w.writeAll(":= ");
-                    try renderDocTypeHtml(w, sig_ctx, sig, false);
+                    try renderDocTypeHtml(w, sig_ctx, gpa, sig, false);
                 },
                 .@"opaque" => {},
             }
@@ -1208,11 +1210,11 @@ fn renderSearchTree(
     }
 
     for (node.children.items) |child| {
-        try renderSearchTree(w, ctx, module_name, child, base);
+        try renderSearchTree(w, ctx, gpa, module_name, child, base);
     }
 }
 
-fn renderEntrySignature(w: Writer, ctx: *const RenderContext, entry: *const DocModel.DocEntry, anchor_id: []const u8) !void {
+fn renderEntrySignature(w: Writer, ctx: *const RenderContext, gpa: Allocator, entry: *const DocModel.DocEntry, anchor_id: []const u8) !void {
     // Display only the identifier (last component) of the entry name
     // For "Builtin.Str.Utf8Problem.is_eq", display as "is_eq"
     const display_name = if (std.mem.lastIndexOfScalar(u8, entry.name, '.')) |idx|
@@ -1230,15 +1232,15 @@ fn renderEntrySignature(w: Writer, ctx: *const RenderContext, entry: *const DocM
         switch (entry.kind) {
             .value => {
                 try w.writeAll(" : ");
-                try renderDocTypeHtml(w, ctx, sig, false);
+                try renderDocTypeHtml(w, ctx, gpa, sig, false);
             },
             .alias => {
                 try w.writeAll(" : ");
-                try renderDocTypeHtml(w, ctx, sig, false);
+                try renderDocTypeHtml(w, ctx, gpa, sig, false);
             },
             .nominal => {
                 try w.writeAll(" := ");
-                try renderDocTypeHtml(w, ctx, sig, false);
+                try renderDocTypeHtml(w, ctx, gpa, sig, false);
             },
             .@"opaque" => {
                 try w.writeAll(" :: <span class=\"type\">&lt;hidden&gt;</span>");
@@ -1617,130 +1619,171 @@ fn validateAnchor(
     ctx.reportBrokenLink(label, anchor, bracket_offset);
 }
 
-fn renderDocTypeHtml(w: Writer, ctx: *const RenderContext, doc_type: *const DocType, needs_parens: bool) !void {
-    switch (doc_type.*) {
-        .type_ref => |ref| {
-            if (!ctx.suppress_type_links and resolveTypeLink(ctx, ref.module_path)) {
-                try w.writeAll("<a href=\"");
-                try writeTypeLink(w, ctx, ref.module_path, ref.type_name);
-                try w.writeAll("\">");
-                try w.writeAll("<span class=\"type\">");
-                // Display only the last component of the type name
+fn renderDocTypeHtml(
+    w: Writer,
+    ctx: *const RenderContext,
+    gpa: Allocator,
+    doc_type: *const DocType,
+    needs_parens: bool,
+) !void {
+    const RenderFrame = union(enum) {
+        doc_type: struct {
+            value: *const DocType,
+            needs_parens: bool,
+        },
+        html: []const u8,
+        escaped: []const u8,
+        type_ref: DocType.TypeRef,
+    };
+
+    var frames = std.ArrayList(RenderFrame).empty;
+    defer frames.deinit(gpa);
+
+    try frames.append(gpa, .{ .doc_type = .{ .value = doc_type, .needs_parens = needs_parens } });
+    while (frames.pop()) |frame| {
+        switch (frame) {
+            .html => |html| try w.writeAll(html),
+            .escaped => |text| try writeHtmlEscaped(w, text),
+            .type_ref => |ref| {
                 const display_name = if (std.mem.lastIndexOfScalar(u8, ref.type_name, '.')) |idx|
                     ref.type_name[idx + 1 ..]
                 else
                     ref.type_name;
-                try writeHtmlEscaped(w, display_name);
-                try w.writeAll("</span></a>");
-            } else {
-                try w.writeAll("<span class=\"type\">");
-                // Display only the last component of the type name
-                const display_name = if (std.mem.lastIndexOfScalar(u8, ref.type_name, '.')) |idx|
-                    ref.type_name[idx + 1 ..]
-                else
-                    ref.type_name;
-                try writeHtmlEscaped(w, display_name);
-                try w.writeAll("</span>");
-            }
-        },
-        .type_var => |name| {
-            try w.writeAll("<span class=\"type-var\">");
-            try writeHtmlEscaped(w, name);
-            try w.writeAll("</span>");
-        },
-        .function => |func| {
-            if (needs_parens) try w.writeAll("(");
-            for (func.args, 0..) |arg, i| {
-                if (i > 0) try w.writeAll(", ");
-                try renderDocTypeHtml(w, ctx, arg, true);
-            }
-            if (func.effectful) {
-                try w.writeAll("<span class=\"sig-arrow\"> =&gt; </span>");
-            } else {
-                try w.writeAll("<span class=\"sig-arrow\"> -&gt; </span>");
-            }
-            try renderDocTypeHtml(w, ctx, func.ret, false);
-            if (needs_parens) try w.writeAll(")");
-        },
-        .record => |rec| {
-            try w.writeAll("{ ");
-            if (rec.is_open) {
-                try w.writeAll("..");
-                if (rec.ext) |ext| {
-                    try renderDocTypeHtml(w, ctx, ext, false);
+
+                if (!ctx.suppress_type_links and resolveTypeLink(ctx, ref.module_path)) {
+                    try w.writeAll("<a href=\"");
+                    try writeTypeLink(w, ctx, ref.module_path, ref.type_name);
+                    try w.writeAll("\"><span class=\"type\">");
+                    try writeHtmlEscaped(w, display_name);
+                    try w.writeAll("</span></a>");
+                } else {
+                    try w.writeAll("<span class=\"type\">");
+                    try writeHtmlEscaped(w, display_name);
+                    try w.writeAll("</span>");
                 }
-                if (rec.fields.len > 0) try w.writeAll(", ");
-            }
-            for (rec.fields, 0..) |field, i| {
-                if (i > 0) try w.writeAll(", ");
-                try writeHtmlEscaped(w, field.name);
-                try w.writeAll(" : ");
-                try renderDocTypeHtml(w, ctx, field.type, false);
-            }
-            try w.writeAll(" }");
-        },
-        .tag_union => |tu| {
-            try w.writeAll("[");
-            for (tu.tags, 0..) |tag, i| {
-                if (i > 0) try w.writeAll(", ");
-                try w.writeAll("<span class=\"type\">");
-                try writeHtmlEscaped(w, tag.name);
-                try w.writeAll("</span>");
-                if (tag.args.len > 0) {
-                    try w.writeAll("(");
-                    for (tag.args, 0..) |arg, j| {
-                        if (j > 0) try w.writeAll(", ");
-                        try renderDocTypeHtml(w, ctx, arg, false);
-                    }
-                    try w.writeAll(")");
+            },
+            .doc_type => |item| {
+                switch (item.value.*) {
+                    .type_ref => |ref| {
+                        try frames.append(gpa, .{ .type_ref = ref });
+                    },
+                    .type_var => |name| {
+                        try frames.append(gpa, .{ .html = "</span>" });
+                        try frames.append(gpa, .{ .escaped = name });
+                        try frames.append(gpa, .{ .html = "<span class=\"type-var\">" });
+                    },
+                    .function => |func| {
+                        if (item.needs_parens) try frames.append(gpa, .{ .html = ")" });
+                        try frames.append(gpa, .{ .doc_type = .{ .value = func.ret, .needs_parens = false } });
+                        try frames.append(gpa, .{ .html = if (func.effectful)
+                            "<span class=\"sig-arrow\"> =&gt; </span>"
+                        else
+                            "<span class=\"sig-arrow\"> -&gt; </span>" });
+                        var i = func.args.len;
+                        while (i > 0) {
+                            i -= 1;
+                            try frames.append(gpa, .{ .doc_type = .{ .value = func.args[i], .needs_parens = true } });
+                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                        }
+                        if (item.needs_parens) try frames.append(gpa, .{ .html = "(" });
+                    },
+                    .record => |rec| {
+                        try frames.append(gpa, .{ .html = " }" });
+                        var i = rec.fields.len;
+                        while (i > 0) {
+                            i -= 1;
+                            const field = rec.fields[i];
+                            try frames.append(gpa, .{ .doc_type = .{ .value = field.type, .needs_parens = false } });
+                            try frames.append(gpa, .{ .html = " : " });
+                            try frames.append(gpa, .{ .escaped = field.name });
+                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                        }
+                        if (rec.is_open) {
+                            if (rec.fields.len > 0) try frames.append(gpa, .{ .html = ", " });
+                            if (rec.ext) |ext| {
+                                try frames.append(gpa, .{ .doc_type = .{ .value = ext, .needs_parens = false } });
+                            }
+                            try frames.append(gpa, .{ .html = ".." });
+                        }
+                        try frames.append(gpa, .{ .html = "{ " });
+                    },
+                    .tag_union => |tu| {
+                        try frames.append(gpa, .{ .html = "]" });
+                        if (tu.is_open) {
+                            if (tu.ext) |ext| {
+                                try frames.append(gpa, .{ .doc_type = .{ .value = ext, .needs_parens = false } });
+                            }
+                            try frames.append(gpa, .{ .html = ".." });
+                            if (tu.tags.len > 0) try frames.append(gpa, .{ .html = ", " });
+                        }
+                        var i = tu.tags.len;
+                        while (i > 0) {
+                            i -= 1;
+                            const tag = tu.tags[i];
+                            if (tag.args.len > 0) {
+                                try frames.append(gpa, .{ .html = ")" });
+                                var j = tag.args.len;
+                                while (j > 0) {
+                                    j -= 1;
+                                    try frames.append(gpa, .{ .doc_type = .{ .value = tag.args[j], .needs_parens = false } });
+                                    if (j > 0) try frames.append(gpa, .{ .html = ", " });
+                                }
+                                try frames.append(gpa, .{ .html = "(" });
+                            }
+                            try frames.append(gpa, .{ .html = "</span>" });
+                            try frames.append(gpa, .{ .escaped = tag.name });
+                            try frames.append(gpa, .{ .html = "<span class=\"type\">" });
+                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                        }
+                        try frames.append(gpa, .{ .html = "[" });
+                    },
+                    .tuple => |tup| {
+                        try frames.append(gpa, .{ .html = ")" });
+                        var i = tup.elems.len;
+                        while (i > 0) {
+                            i -= 1;
+                            try frames.append(gpa, .{ .doc_type = .{ .value = tup.elems[i], .needs_parens = false } });
+                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                        }
+                        try frames.append(gpa, .{ .html = "(" });
+                    },
+                    .apply => |app| {
+                        try frames.append(gpa, .{ .html = ")" });
+                        var i = app.args.len;
+                        while (i > 0) {
+                            i -= 1;
+                            try frames.append(gpa, .{ .doc_type = .{ .value = app.args[i], .needs_parens = false } });
+                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                        }
+                        try frames.append(gpa, .{ .html = "(" });
+                        try frames.append(gpa, .{ .doc_type = .{ .value = app.constructor, .needs_parens = false } });
+                    },
+                    .where_clause => |wc| {
+                        try frames.append(gpa, .{ .html = " }" });
+                        var i = wc.constraints.len;
+                        while (i > 0) {
+                            i -= 1;
+                            const constraint = wc.constraints[i];
+                            try frames.append(gpa, .{ .doc_type = .{ .value = constraint.signature, .needs_parens = false } });
+                            try frames.append(gpa, .{ .html = " : " });
+                            try frames.append(gpa, .{ .escaped = constraint.method_name });
+                            try frames.append(gpa, .{ .html = "</span>." });
+                            try frames.append(gpa, .{ .escaped = constraint.type_var });
+                            try frames.append(gpa, .{ .html = "<span class=\"type-var\">" });
+                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                        }
+                        try frames.append(gpa, .{ .html = " <span class=\"kw\">where</span> { " });
+                        try frames.append(gpa, .{ .doc_type = .{ .value = wc.type, .needs_parens = item.needs_parens } });
+                    },
+                    .wildcard => {
+                        try frames.append(gpa, .{ .html = "_" });
+                    },
+                    .@"error" => {
+                        try frames.append(gpa, .{ .html = "?" });
+                    },
                 }
-            }
-            if (tu.is_open) {
-                if (tu.tags.len > 0) try w.writeAll(", ");
-                try w.writeAll("..");
-                if (tu.ext) |ext| {
-                    try renderDocTypeHtml(w, ctx, ext, false);
-                }
-            }
-            try w.writeAll("]");
-        },
-        .tuple => |tup| {
-            try w.writeAll("(");
-            for (tup.elems, 0..) |elem, i| {
-                if (i > 0) try w.writeAll(", ");
-                try renderDocTypeHtml(w, ctx, elem, false);
-            }
-            try w.writeAll(")");
-        },
-        .apply => |app| {
-            try renderDocTypeHtml(w, ctx, app.constructor, false);
-            try w.writeAll("(");
-            for (app.args, 0..) |arg, i| {
-                if (i > 0) try w.writeAll(", ");
-                try renderDocTypeHtml(w, ctx, arg, false);
-            }
-            try w.writeAll(")");
-        },
-        .where_clause => |wc| {
-            try renderDocTypeHtml(w, ctx, wc.type, needs_parens);
-            try w.writeAll(" <span class=\"kw\">where</span> { ");
-            for (wc.constraints, 0..) |constraint, i| {
-                if (i > 0) try w.writeAll(", ");
-                try w.writeAll("<span class=\"type-var\">");
-                try writeHtmlEscaped(w, constraint.type_var);
-                try w.writeAll("</span>.");
-                try writeHtmlEscaped(w, constraint.method_name);
-                try w.writeAll(" : ");
-                try renderDocTypeHtml(w, ctx, constraint.signature, false);
-            }
-            try w.writeAll(" }");
-        },
-        .wildcard => {
-            try w.writeAll("_");
-        },
-        .@"error" => {
-            try w.writeAll("?");
-        },
+            },
+        }
     }
 }
 
@@ -1839,6 +1882,51 @@ fn writeHtmlEscaped(w: Writer, text: []const u8) !void {
             else => try w.writeAll(&[_]u8{c}),
         }
     }
+}
+
+test "renderDocTypeHtml handles deeply nested types without call stack recursion" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    const leaf = try gpa.create(DocType);
+    leaf.* = .{ .type_var = try gpa.dupe(u8, "a") };
+
+    var root: *const DocType = leaf;
+    for (0..20_000) |_| {
+        const constructor = try gpa.create(DocType);
+        constructor.* = .{ .type_ref = .{
+            .module_path = try gpa.dupe(u8, ""),
+            .type_name = try gpa.dupe(u8, "Wrap"),
+        } };
+
+        const args = try gpa.alloc(*const DocType, 1);
+        args[0] = root;
+
+        const app = try gpa.create(DocType);
+        app.* = .{ .apply = .{
+            .constructor = constructor,
+            .args = args,
+        } };
+        root = app;
+    }
+    defer {
+        root.deinit(gpa);
+        gpa.destroy(root);
+    }
+
+    const package_docs = DocModel.PackageDocs{
+        .name = "Test",
+        .modules = &[_]DocModel.ModuleDocs{},
+    };
+    var ctx = try RenderContext.init(&package_docs, gpa);
+    defer ctx.deinit(gpa);
+    ctx.suppress_type_links = true;
+
+    var output: std.Io.Writer.Allocating = .init(gpa);
+    defer output.deinit();
+
+    try renderDocTypeHtml(&output.writer, &ctx, gpa, root, false);
+    try testing.expect(std.mem.startsWith(u8, output.written(), "<span class=\"type\">Wrap</span>("));
 }
 
 test "writeDocRefHref reports broken shorthand refs" {


### PR DESCRIPTION
## Summary
- prefer checked source annotations for documented value signatures when available
- build DocType trees from source annotations with an explicit work stack
- render and deinitialize DocType trees with heap-backed worklists instead of recursive calls
- add a deep DocType rendering regression test

## Verification
- zig build test-docs
- zig build snapshot -- --check-expected
- zig build test-subcommands -- --test-filter "roc docs Builtin.roc succeeds"
- zig build minici