### PR TITLE
Embedding API for in-process Roc compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,7 +154,7 @@ kcov-output/
 src/snapshots/**/*.html
 
 # Local claude-code settings
-.claude/settings.local.json
+.claude/
 
 *.bak
 kcov-output/

--- a/build.zig
+++ b/build.zig
@@ -2414,6 +2414,7 @@ pub fn build(b: *std.Build) void {
     const eval_host_effects_step = b.step("test-eval-host-effects", "Run runtime host-effects eval tests across supported backends");
     const playground_step = b.step("playground", "Build the WASM playground");
     const playground_test_step = b.step("test-playground", "Build the integration test suite for the WASM playground");
+    const echo_wasm_step = b.step("build-echo-wasm", "Build the echo platform to zig-out/lib/echo.wasm");
     const serialization_size_step = b.step("test-serialization-sizes", "Verify Serialized types have platform-independent sizes");
     const wasm_static_lib_test_step = b.step("test-wasm-static-lib", "Test WASM static library builds with bytebox");
     const test_cli_step = b.step("test-cli", "Run all CLI integration tests (platforms + subcommands + glue)");
@@ -3059,11 +3060,13 @@ pub fn build(b: *std.Build) void {
             .dest_dir = .{ .override = .lib },
         });
         playground_step.dependOn(&echo_wasm_install.step);
+        echo_wasm_step.dependOn(&echo_wasm_install.step);
 
         // Copy the echo platform www files alongside echo.wasm
         inline for (.{ "index.html", "app.js" }) |filename| {
             const install_file = b.addInstallFile(b.path("src/echo_platform/www/" ++ filename), "lib/" ++ filename);
             playground_step.dependOn(&install_file.step);
+            echo_wasm_step.dependOn(&install_file.step);
         }
 
         // echo_native: native binary that drives the same runEcho pipeline as

--- a/build.zig
+++ b/build.zig
@@ -3065,6 +3065,59 @@ pub fn build(b: *std.Build) void {
             const install_file = b.addInstallFile(b.path("src/echo_platform/www/" ++ filename), "lib/" ++ filename);
             playground_step.dependOn(&install_file.step);
         }
+
+        // echo_native: native binary that drives the same runEcho pipeline as
+        // echo.wasm. Use it to debug compile/run failures with real stack
+        // traces. `zig build run-echo -- path/to/app.roc [--with-file Name=path] ...`
+        const echo_native_exe = b.addExecutable(.{
+            .name = "echo_native",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/echo_platform/echo_native.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
+        });
+        configureBackend(echo_native_exe, target);
+        echo_native_exe.root_module.addImport("compile", roc_modules.compile);
+        echo_native_exe.root_module.addImport("check", roc_modules.check);
+        echo_native_exe.root_module.addImport("eval", roc_modules.eval);
+        echo_native_exe.root_module.addImport("lir", roc_modules.lir);
+        echo_native_exe.root_module.addImport("layout", roc_modules.layout);
+        echo_native_exe.root_module.addImport("base", roc_modules.base);
+        echo_native_exe.root_module.addImport("can", roc_modules.can);
+        echo_native_exe.root_module.addImport("echo_platform", roc_modules.echo_platform);
+        echo_native_exe.root_module.addImport("reporting", roc_modules.reporting);
+        echo_native_exe.root_module.addImport("roc_target", roc_modules.roc_target);
+        echo_native_exe.root_module.addImport("compiled_builtins", compiled_builtins_module);
+        echo_native_exe.step.dependOn(&write_compiled_builtins.step);
+
+        const echo_native_install = b.addInstallArtifact(echo_native_exe, .{});
+
+        const run_echo_step = b.step("run-echo", "Run the native echo platform driver (debug helper for echo.wasm)");
+        const run_echo_cmd = b.addRunArtifact(echo_native_exe);
+        if (run_args.len != 0) run_echo_cmd.addArgs(run_args);
+        run_echo_cmd.step.dependOn(&echo_native_install.step);
+        run_echo_step.dependOn(&run_echo_cmd.step);
+
+        // test-echo-wasm: bytebox-driven integration test that loads
+        // zig-out/lib/echo.wasm, supplies in-process js_echo + js_stderr,
+        // and asserts the tutorial example produces the expected output.
+        const echo_wasm_test_exe = b.addExecutable(.{
+            .name = "echo_wasm_test",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("test/echo-wasm-test/main.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
+        });
+        configureBackend(echo_wasm_test_exe, target);
+        echo_wasm_test_exe.root_module.addImport("bytebox", bytebox.module("bytebox"));
+
+        const test_echo_wasm_step = b.step("test-echo-wasm", "Run echo.wasm tutorial example through bytebox");
+        const run_echo_wasm_test = b.addRunArtifact(echo_wasm_test_exe);
+        // Ensure the wasm is built before the test runs.
+        run_echo_wasm_test.step.dependOn(&echo_wasm_install.step);
+        test_echo_wasm_step.dependOn(&run_echo_wasm_test.step);
     }
 
     // Build playground integration tests - now enabled for all optimization modes

--- a/build.zig
+++ b/build.zig
@@ -4664,7 +4664,7 @@ fn getCompilerArtifactHash(b: *std.Build, compiler_version: []const u8) [32]u8 {
     hasher.update("roc-checked-artifact-v1");
     hasher.update(compiler_version);
 
-    const builtin_source = std.fs.cwd().readFileAlloc(
+    const builtin_source = b.build_root.handle.readFileAlloc(
         b.allocator,
         "src/build/roc/Builtin.roc",
         32 * 1024 * 1024,

--- a/ci/tidy.zig
+++ b/ci/tidy.zig
@@ -620,6 +620,7 @@ const DeadFilesDetector = struct {
             "llvm_evaluator.zig", // LLVM evaluator executable
             "darwin_compat.zig", // Compiled to .o by build.zig for macOS linking
             "echo.zig", // Echo platform WASM entry point
+            "echo_native.zig", // Echo platform native debug binary (zig build run-echo)
             "parallel_cli_runner.zig", // Parallel CLI test runner executable
             "test_harness.zig", // Shared test harness (added via b.addModule)
             "test_env_pkg.zig", // Typed CIR package root used via build root_source_file

--- a/src/builtins/host_abi.zig
+++ b/src/builtins/host_abi.zig
@@ -72,14 +72,12 @@ pub fn hostedFn(func: anytype) HostedFn {
 
 /// Array of hosted function pointers provided by the platform.
 ///
-/// The interpreter looks up hosted functions positionally as `fns[dispatch_index]`.
-/// The index is assigned deterministically: within each checked artifact,
-/// hosted functions are sorted alphabetically by their fully-qualified name
-/// `Module.fn_name` (with trailing `!` stripped, so `Echo.line!` sorts as
-/// `Echo.line`), tiebroken by definition order. The global catalog
-/// concatenates artifacts as root → imports[i] → relations[i]. For a
-/// single-module platform this collapses to plain alphabetical order.
-/// See `src/compile/README.md` ("Host functions") for full detail.
+/// Dispatch is positional: the interpreter calls `fns[i]`. For a
+/// typical platform — hosted functions in a single module — `i` is the
+/// function's alphabetical index by `Module.fn_name` (trailing `!`
+/// stripped). When hosted functions span multiple modules the ordering
+/// rule is more involved; see `src/compile/README.md` ("Host functions").
+/// Wrong order is silent: the wrong function gets called.
 pub const HostedFunctions = extern struct {
     count: u32,
     fns: [*]HostedFn,

--- a/src/builtins/host_abi.zig
+++ b/src/builtins/host_abi.zig
@@ -71,7 +71,15 @@ pub fn hostedFn(func: anytype) HostedFn {
 }
 
 /// Array of hosted function pointers provided by the platform.
-/// These are sorted alphabetically by function name during canonicalization.
+///
+/// The interpreter looks up hosted functions positionally as `fns[dispatch_index]`.
+/// The index is assigned deterministically: within each checked artifact,
+/// hosted functions are sorted alphabetically by their fully-qualified name
+/// `Module.fn_name` (with trailing `!` stripped, so `Echo.line!` sorts as
+/// `Echo.line`), tiebroken by definition order. The global catalog
+/// concatenates artifacts as root → imports[i] → relations[i]. For a
+/// single-module platform this collapses to plain alphabetical order.
+/// See `src/compile/README.md` ("Host functions") for full detail.
 pub const HostedFunctions = extern struct {
     count: u32,
     fns: [*]HostedFn,

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -17112,6 +17112,51 @@ pub const CheckedModuleArtifact = struct {
         );
     }
 
+    /// Look up the root request with the given metadata order.
+    /// Returns null if not found (callers that rely on an invariant can assert).
+    pub fn lookupRootRequestByOrder(self: *const CheckedModuleArtifact, order: u32) ?RootRequest {
+        for (self.root_requests.requests) |request| {
+            if (request.order == order) return request;
+        }
+        return null;
+    }
+
+    /// Name of a `provided_export` root's published FFI symbol, or null if absent.
+    pub fn providedEntrypointName(self: *const CheckedModuleArtifact, root: RootRequest) ?[]const u8 {
+        const def_idx = switch (root.source) {
+            .def => |def| def,
+            else => return null,
+        };
+        const top_level = self.top_level_values.lookupByDef(def_idx) orelse return null;
+        for (self.provides_requires.provides) |entry| {
+            if (entry.source_name == top_level.source_name) {
+                return self.canonical_names.externalSymbolNameText(entry.ffi_symbol);
+            }
+        }
+        return null;
+    }
+
+    /// Name of a `platform_required_binding` root's exported symbol, or null if absent.
+    pub fn requiredEntrypointName(self: *const CheckedModuleArtifact, root: RootRequest) ?[]const u8 {
+        const binding_id = switch (root.source) {
+            .required_binding => |id| id,
+            else => return null,
+        };
+        const binding = self.platform_required_bindings.lookupByBindingId(binding_id) orelse return null;
+        const declaration = self.platform_required_declarations.lookupByDeclarationId(binding.declaration) orelse return null;
+        return self.canonical_names.exportNameText(declaration.platform_name);
+    }
+
+    /// Dispatch to the right name lookup based on the root kind. Returns null
+    /// if the root kind isn't an entrypoint kind or the lookup fails.
+    pub fn entrypointNameForRoot(self: *const CheckedModuleArtifact, root: RootRequest) ?[]const u8 {
+        return switch (root.kind) {
+            .provided_export => self.providedEntrypointName(root),
+            .platform_required_binding => self.requiredEntrypointName(root),
+            else => null,
+        };
+    }
+
     pub fn appendPromotedCallableWrapper(
         self: *CheckedModuleArtifact,
         allocator: Allocator,

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1790,12 +1790,12 @@ fn renderCoordinatorReports(ctx: *CliContext, coord: *Coordinator, roc_file_path
         if (rep.severity == .fatal or rep.severity == .runtime_error) {
             counts.errors += 1;
             if (!builtin.is_test) {
-                reporting.renderReportToTerminal(@constCast(rep), ctx.io.stderr(), ColorPalette.ANSI, reporting.ReportingConfig.initColorTerminal()) catch {};
+                reporting.renderReportToTerminal(rep, ctx.io.stderr(), ColorPalette.ANSI, reporting.ReportingConfig.initColorTerminal()) catch {};
             }
         } else if (rep.severity == .warning) {
             counts.warnings += 1;
             if (!builtin.is_test) {
-                reporting.renderReportToTerminal(@constCast(rep), ctx.io.stderr(), ColorPalette.ANSI, reporting.ReportingConfig.initColorTerminal()) catch {};
+                reporting.renderReportToTerminal(rep, ctx.io.stderr(), ColorPalette.ANSI, reporting.ReportingConfig.initColorTerminal()) catch {};
             }
         }
     }

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1784,22 +1784,18 @@ const CoordinatorReportCounts = struct {
 fn renderCoordinatorReports(ctx: *CliContext, coord: *Coordinator, roc_file_path: []const u8) CoordinatorReportCounts {
     var counts = CoordinatorReportCounts{ .errors = 0, .warnings = 0 };
 
-    var pkg_it = coord.packages.iterator();
-    while (pkg_it.next()) |entry| {
-        const pkg = entry.value_ptr.*;
-        for (pkg.modules.items) |*mod| {
-            for (mod.reports.items) |*rep| {
-                if (rep.severity == .fatal or rep.severity == .runtime_error) {
-                    counts.errors += 1;
-                    if (!builtin.is_test) {
-                        reporting.renderReportToTerminal(rep, ctx.io.stderr(), ColorPalette.ANSI, reporting.ReportingConfig.initColorTerminal()) catch {};
-                    }
-                } else if (rep.severity == .warning) {
-                    counts.warnings += 1;
-                    if (!builtin.is_test) {
-                        reporting.renderReportToTerminal(rep, ctx.io.stderr(), ColorPalette.ANSI, reporting.ReportingConfig.initColorTerminal()) catch {};
-                    }
-                }
+    var it = coord.iterReports();
+    while (it.next()) |entry| {
+        const rep = entry.report;
+        if (rep.severity == .fatal or rep.severity == .runtime_error) {
+            counts.errors += 1;
+            if (!builtin.is_test) {
+                reporting.renderReportToTerminal(@constCast(rep), ctx.io.stderr(), ColorPalette.ANSI, reporting.ReportingConfig.initColorTerminal()) catch {};
+            }
+        } else if (rep.severity == .warning) {
+            counts.warnings += 1;
+            if (!builtin.is_test) {
+                reporting.renderReportToTerminal(@constCast(rep), ctx.io.stderr(), ColorPalette.ANSI, reporting.ReportingConfig.initColorTerminal()) catch {};
             }
         }
     }
@@ -1887,72 +1883,21 @@ fn evaluateRuntimeImageEntrypoint(
     ret_ptr: ?*anyopaque,
     arg_ptr: ?*anyopaque,
 ) !void {
-    var entrypoint: ?lir.RuntimeImage.PlatformEntrypoint = null;
-    for (view.platform_entrypoints) |candidate| {
-        if (candidate.ordinal == ordinal) {
-            entrypoint = candidate;
-            break;
-        }
-    }
-    const selected = entrypoint orelse {
-        if (builtin.mode == .Debug) {
-            std.debug.panic("CLI runtime image invariant violated: missing platform entrypoint ordinal {d}", .{ordinal});
-        }
-        unreachable;
-    };
-
-    const arg_layouts = try argLayoutsForProc(allocator, &view.store, selected.root_proc);
-    defer allocator.free(arg_layouts);
-
-    var interpreter = try eval.LirInterpreter.init(
-        allocator,
-        &view.store,
-        &view.layouts,
-        ops,
-    );
+    var interpreter = try eval.LirInterpreter.init(allocator, &view.store, &view.layouts, ops);
     defer interpreter.deinit();
 
-    const proc = view.store.getProcSpec(selected.root_proc);
-    _ = interpreter.eval(.{
-        .proc_id = selected.root_proc,
-        .arg_layouts = arg_layouts,
-        .ret_layout = proc.ret_layout,
-        .arg_ptr = arg_ptr,
-        .ret_ptr = ret_ptr,
-    }) catch |err| {
-        reportCliInterpreterError(ops, &interpreter, err);
-        return;
+    _ = interpreter.runEntrypoint(view, ordinal, arg_ptr, ret_ptr) catch |err| switch (err) {
+        error.EntrypointNotFound => {
+            if (builtin.mode == .Debug) {
+                std.debug.panic("CLI runtime image invariant violated: missing platform entrypoint ordinal {d}", .{ordinal});
+            }
+            unreachable;
+        },
+        else => |e| {
+            reportCliInterpreterError(ops, &interpreter, e);
+            return;
+        },
     };
-}
-
-fn buildPlatformEntrypoints(
-    allocator: Allocator,
-    lowered: *const lir.CheckedPipeline.LoweredProgram,
-) ![]lir.RuntimeImage.PlatformEntrypoint {
-    const root_procs = lowered.lir_result.root_procs.items;
-    const root_metadata = lowered.lir_result.root_metadata.items;
-    if (root_procs.len != root_metadata.len) {
-        if (builtin.mode == .Debug) {
-            std.debug.panic(
-                "checked pipeline invariant violated: root metadata mismatch roots={d} metadata={d}",
-                .{ root_procs.len, root_metadata.len },
-            );
-        }
-        unreachable;
-    }
-
-    var entrypoints = std.ArrayList(lir.RuntimeImage.PlatformEntrypoint).empty;
-    errdefer entrypoints.deinit(allocator);
-
-    for (root_procs, root_metadata) |root_proc, metadata| {
-        if (metadata.abi != .platform and metadata.exposure != .platform_required) continue;
-        try entrypoints.append(allocator, .{
-            .ordinal = @intCast(entrypoints.items.len),
-            .root_proc = root_proc,
-        });
-    }
-
-    return try entrypoints.toOwnedSlice(allocator);
 }
 
 /// Build shared memory containing a viewable ARC-inserted LIR runtime image.
@@ -1977,13 +1922,31 @@ pub fn buildLirRuntimeImageWithCoordinator(
     defer builtin_modules.deinit();
 
     const app_dir = std.fs.path.dirname(roc_file_path) orelse ".";
-    const platform_spec = try extractPlatformSpecFromApp(ctx, roc_file_path);
-    try validatePlatformSpec(ctx, platform_spec);
 
-    const platform_main_path: ?[]const u8 = if (std.mem.startsWith(u8, platform_spec, "./") or std.mem.startsWith(u8, platform_spec, "../"))
-        try std.fs.path.join(ctx.arena, &[_][]const u8{ app_dir, platform_spec })
-    else if (base.url.isSafeUrl(platform_spec)) blk: {
-        const platform_paths = resolveUrlPlatform(ctx, platform_spec) catch |err| switch (err) {
+    // Parse the app header
+    const header_info = compile.app_header.parseAppHeader(
+        FsIo.default(),
+        ctx.gpa,
+        ctx.arena,
+        roc_file_path,
+    ) catch |err| switch (err) {
+        error.NotAnAppHeader => return ctx.fail(.{ .expected_app_header = .{
+            .path = roc_file_path,
+            .found = "non-app header",
+        } }),
+        error.FileNotFound => return ctx.fail(.{ .file_not_found = .{
+            .path = roc_file_path,
+            .context = .source_file,
+        } }),
+        else => |e| return e,
+    };
+    try validatePlatformSpec(ctx, header_info.platform_spec);
+
+    // Resolve the platform spec to a local main.roc path (handles URL fetch).
+    const platform_main_path: ?[]const u8 = if (std.mem.startsWith(u8, header_info.platform_spec, "./") or std.mem.startsWith(u8, header_info.platform_spec, "../"))
+        try std.fs.path.join(ctx.arena, &[_][]const u8{ app_dir, header_info.platform_spec })
+    else if (base.url.isSafeUrl(header_info.platform_spec)) blk: {
+        const platform_paths = resolveUrlPlatform(ctx, header_info.platform_spec) catch |err| switch (err) {
             error.CliError => break :blk null,
             error.OutOfMemory => return error.OutOfMemory,
         };
@@ -2020,51 +1983,31 @@ pub fn buildLirRuntimeImageWithCoordinator(
     app_pkg.remaining_modules += 1;
     coord.total_remaining += 1;
 
-    const platform_qualifier = try extractPlatformQualifier(ctx, roc_file_path);
-
     if (platform_dir) |pf_dir| {
-        const pf_pkg = try coord.ensurePackage("pf", pf_dir);
-
-        if (platform_qualifier) |qual| {
+        if (platform_main_path) |pmp| {
+            try coord.registerPlatformPackage(app_pkg, pf_dir, pmp, header_info.platform_qualifier);
+        } else if (header_info.platform_qualifier) |qual| {
+            // URL platform that failed to resolve — keep the shorthand wired so
+            // downstream code reports a clean error rather than a missing-import.
             try app_pkg.shorthands.put(
                 try ctx.gpa.dupe(u8, qual),
                 try ctx.gpa.dupe(u8, "pf"),
             );
-        }
-
-        if (platform_main_path) |pmp| {
-            const pf_module_id = try pf_pkg.ensureModule(ctx.gpa, "main", pmp);
-            pf_pkg.root_module_id = pf_module_id;
-            pf_pkg.modules.items[pf_module_id].depth = 1;
-            pf_pkg.remaining_modules += 1;
-            coord.total_remaining += 1;
-            try coord.enqueueParseTask("pf", pf_module_id);
+            _ = try coord.ensurePackage("pf", pf_dir);
         }
     }
 
-    var non_platform_packages = try extractNonPlatformPackages(ctx, roc_file_path, platform_qualifier);
-    defer {
-        var iter = non_platform_packages.iterator();
-        while (iter.next()) |entry| {
-            ctx.gpa.free(entry.key_ptr.*);
-            ctx.gpa.free(entry.value_ptr.*);
-        }
-        non_platform_packages.deinit();
-    }
-
-    var pkg_iter = non_platform_packages.iterator();
-    while (pkg_iter.next()) |entry| {
-        const shorthand = entry.key_ptr.*;
-        const pkg_main_path = entry.value_ptr.*;
-        const pkg_dir = std.fs.path.dirname(pkg_main_path) orelse ".";
-        const pkg_name = try ctx.gpa.dupe(u8, shorthand);
-        defer ctx.gpa.free(pkg_name);
-
-        _ = try coord.ensurePackage(pkg_name, pkg_dir);
-        try app_pkg.shorthands.put(
-            try ctx.gpa.dupe(u8, shorthand),
-            try ctx.gpa.dupe(u8, pkg_name),
-        );
+    // Resolve and register non-platform packages (URL-aware path).
+    for (header_info.non_platform_packages) |entry| {
+        const pkg_abs_path = if (base.url.isSafeUrl(entry.spec)) blk: {
+            const cached = resolveUrlBundle(ctx, entry.spec) catch |err| switch (err) {
+                error.CliError => return error.CliError,
+                error.OutOfMemory => return error.OutOfMemory,
+            };
+            break :blk try ctx.arena.dupe(u8, cached);
+        } else try std.fs.path.join(ctx.arena, &.{ app_dir, entry.spec });
+        const pkg_dir = std.fs.path.dirname(pkg_abs_path) orelse ".";
+        _ = try coord.registerInlinePackage(entry.shorthand, pkg_dir, app_pkg, entry.shorthand);
     }
 
     try coord.enqueueParseTask("app", app_module_id);
@@ -2101,8 +2044,8 @@ pub fn buildLirRuntimeImageWithCoordinator(
         },
     );
 
-    const platform_entrypoints = try buildPlatformEntrypoints(shm_allocator, &lowered);
-    const entrypoint_names = try platformEntrypointNamesFromLowered(ctx, root_artifact, &lowered);
+    const platform_entrypoints = try lowered.platformEntrypoints(shm_allocator);
+    const entrypoint_names = try lowered.platformEntrypointNames(ctx.arena, root_artifact);
 
     try lir.RuntimeImage.fillHeaderInSharedMemory(
         runtime_header,
@@ -2115,128 +2058,6 @@ pub fn buildLirRuntimeImageWithCoordinator(
 
     shm.updateHeader();
     return sharedMemoryResult(&shm, finalized_counts, entrypoint_names);
-}
-
-/// Extract the platform qualifier from an app header (e.g., "rr" from { rr: platform "..." })
-fn extractPlatformQualifier(ctx: *CliContext, roc_file_path: []const u8) !?[]const u8 {
-    var source = std.fs.cwd().readFileAlloc(ctx.gpa, roc_file_path, std.math.maxInt(usize)) catch return null;
-    source = base.source_utils.normalizeLineEndingsRealloc(ctx.gpa, source) catch |err| {
-        ctx.gpa.free(source);
-        return err;
-    };
-    defer ctx.gpa.free(source);
-
-    var env = ModuleEnv.init(ctx.gpa, source) catch return null;
-    defer env.deinit();
-    env.common.source = source;
-
-    var allocators: Allocators = undefined;
-    allocators.initInPlace(ctx.gpa);
-    defer allocators.deinit();
-
-    const parse_ast = parse.parse(&allocators, &env.common) catch return null;
-    defer parse_ast.deinit();
-
-    const file_node = parse_ast.store.getFile();
-    const header = parse_ast.store.getHeader(file_node.header);
-
-    if (header == .app) {
-        const platform_field = parse_ast.store.getRecordField(header.app.platform_idx);
-        const key_region = parse_ast.tokens.resolve(platform_field.name);
-        const qualifier = source[key_region.start.offset..key_region.end.offset];
-        return try ctx.arena.dupe(u8, qualifier);
-    }
-
-    return null;
-}
-
-/// Extract non-platform package shorthands from app header.
-/// Returns a map of shorthand name -> absolute package path.
-/// e.g., for `{ fx: platform "./platform/main.roc", hlp: "./helper_pkg/main.roc" }`,
-/// this would return { "hlp" -> "/absolute/path/to/helper_pkg/main.roc" }.
-fn extractNonPlatformPackages(
-    ctx: *CliContext,
-    roc_file_path: []const u8,
-    platform_qualifier: ?[]const u8,
-) !std.StringHashMap([]const u8) {
-    var packages = std.StringHashMap([]const u8).init(ctx.gpa);
-    errdefer {
-        var iter = packages.iterator();
-        while (iter.next()) |entry| {
-            ctx.gpa.free(entry.key_ptr.*);
-            ctx.gpa.free(entry.value_ptr.*);
-        }
-        packages.deinit();
-    }
-
-    const app_dir = std.fs.path.dirname(roc_file_path) orelse ".";
-
-    var source = std.fs.cwd().readFileAlloc(ctx.gpa, roc_file_path, std.math.maxInt(usize)) catch return packages;
-    source = base.source_utils.normalizeLineEndingsRealloc(ctx.gpa, source) catch |err| {
-        ctx.gpa.free(source);
-        return err;
-    };
-    defer ctx.gpa.free(source);
-
-    var env = ModuleEnv.init(ctx.gpa, source) catch return packages;
-    defer env.deinit();
-    env.common.source = source;
-
-    var allocators: Allocators = undefined;
-    allocators.initInPlace(ctx.gpa);
-    defer allocators.deinit();
-
-    const parse_ast = parse.parse(&allocators, &env.common) catch return packages;
-    defer parse_ast.deinit();
-
-    const file_node = parse_ast.store.getFile();
-    const header = parse_ast.store.getHeader(file_node.header);
-
-    if (header == .app) {
-        const packages_coll = parse_ast.store.getCollection(header.app.packages);
-        const packages_fields = parse_ast.store.recordFieldSlice(.{ .span = packages_coll.span });
-        for (packages_fields) |field_idx| {
-            const field = parse_ast.store.getRecordField(field_idx);
-            const key_region = parse_ast.tokens.resolve(field.name);
-            const shorthand = source[key_region.start.offset..key_region.end.offset];
-
-            // Skip if this is the platform field
-            if (platform_qualifier) |qual| {
-                if (std.mem.eql(u8, shorthand, qual)) continue;
-            }
-
-            // Get the package path from the field value
-            if (field.value) |value_idx| {
-                const value_node = parse_ast.store.getExpr(value_idx);
-                switch (value_node) {
-                    .string => |str| {
-                        // Use the region to get the full string
-                        const str_region = parse_ast.tokenizedRegionToRegion(str.region);
-                        const raw_path = source[str_region.start.offset..str_region.end.offset];
-                        if (raw_path.len >= 2 and raw_path[0] == '"' and raw_path[raw_path.len - 1] == '"') {
-                            const pkg_spec = raw_path[1 .. raw_path.len - 1];
-                            // If this is a URL, download and resolve to the cached main.roc.
-                            // Otherwise, treat it as a relative file path under app_dir.
-                            const pkg_abs_path = if (base.url.isSafeUrl(pkg_spec)) blk: {
-                                // Dupe into the arena since `source` is freed when this
-                                // function returns but error reports may reference the URL.
-                                const url_owned = try ctx.arena.dupe(u8, pkg_spec);
-                                const cached = resolveUrlBundle(ctx, url_owned) catch |err| switch (err) {
-                                    error.CliError => return error.CliError,
-                                    error.OutOfMemory => return error.OutOfMemory,
-                                };
-                                break :blk try ctx.gpa.dupe(u8, cached);
-                            } else try std.fs.path.join(ctx.gpa, &.{ app_dir, pkg_spec });
-                            try packages.put(try ctx.gpa.dupe(u8, shorthand), pkg_abs_path);
-                        }
-                    },
-                    else => {},
-                }
-            }
-        }
-    }
-
-    return packages;
 }
 
 /// Platform resolution result containing the platform source path
@@ -3179,7 +3000,12 @@ fn nativeBuildEntrypoints(
 
     for (root_procs, root_metadata) |root_proc, metadata| {
         if (metadata.abi != .platform or metadata.exposure != .exported) continue;
-        const root = rootRequestByOrder(root_artifact, metadata.order);
+        const root = root_artifact.lookupRootRequestByOrder(metadata.order) orelse {
+            if (builtin.mode == .Debug) {
+                std.debug.panic("native build invariant violated: missing root request order {d}", .{metadata.order});
+            }
+            unreachable;
+        };
         if (root.kind != .provided_export) continue;
 
         const proc_spec = lowered.lir_result.store.getProcSpec(root_proc);
@@ -3200,133 +3026,20 @@ fn nativeBuildEntrypoints(
     return try entrypoints.toOwnedSlice(ctx.gpa);
 }
 
-fn rootRequestByOrder(
-    root_artifact: *const check.CheckedArtifact.CheckedModuleArtifact,
-    order: u32,
-) check.CheckedArtifact.RootRequest {
-    for (root_artifact.root_requests.requests) |request| {
-        if (request.order == order) return request;
-    }
-    if (builtin.mode == .Debug) {
-        std.debug.panic("native build invariant violated: missing root request order {d}", .{order});
-    }
-    unreachable;
-}
-
-fn platformProvidedEntrypointName(
-    _: *CliContext,
-    root_artifact: *const check.CheckedArtifact.CheckedModuleArtifact,
-    root: check.CheckedArtifact.RootRequest,
-) ![]const u8 {
-    const def_idx = switch (root.source) {
-        .def => |def| def,
-        else => {
-            if (builtin.mode == .Debug) {
-                std.debug.panic("native build invariant violated: exported platform root is not a definition", .{});
-            }
-            unreachable;
-        },
-    };
-    const top_level = root_artifact.top_level_values.lookupByDef(def_idx) orelse {
-        if (builtin.mode == .Debug) {
-            std.debug.panic("platform entrypoint invariant violated: exported platform root has no published top-level value", .{});
-        }
-        unreachable;
-    };
-
-    for (root_artifact.provides_requires.provides) |entry| {
-        if (entry.source_name == top_level.source_name) {
-            return root_artifact.canonical_names.externalSymbolNameText(entry.ffi_symbol);
-        }
-    }
-
-    if (builtin.mode == .Debug) {
-        std.debug.panic(
-            "platform entrypoint invariant violated: exported platform root has no published FFI symbol",
-            .{},
-        );
-    }
-    unreachable;
-}
-
-fn platformRequiredEntrypointName(
-    root_artifact: *const check.CheckedArtifact.CheckedModuleArtifact,
-    root: check.CheckedArtifact.RootRequest,
-) []const u8 {
-    const binding_id = switch (root.source) {
-        .required_binding => |id| id,
-        else => {
-            if (builtin.mode == .Debug) {
-                std.debug.panic("platform entrypoint invariant violated: platform-required root is not a required binding", .{});
-            }
-            unreachable;
-        },
-    };
-    const binding = root_artifact.platform_required_bindings.lookupByBindingId(binding_id) orelse {
-        if (builtin.mode == .Debug) {
-            std.debug.panic("platform entrypoint invariant violated: missing platform-required binding {d}", .{binding_id});
-        }
-        unreachable;
-    };
-    const declaration = root_artifact.platform_required_declarations.lookupByDeclarationId(binding.declaration) orelse {
-        if (builtin.mode == .Debug) {
-            std.debug.panic("platform entrypoint invariant violated: missing platform-required declaration", .{});
-        }
-        unreachable;
-    };
-    return root_artifact.canonical_names.exportNameText(declaration.platform_name);
-}
-
-fn platformEntrypointNameForRoot(
-    ctx: *CliContext,
-    root_artifact: *const check.CheckedArtifact.CheckedModuleArtifact,
-    root: check.CheckedArtifact.RootRequest,
-) ![]const u8 {
-    return switch (root.kind) {
-        .provided_export => try platformProvidedEntrypointName(ctx, root_artifact, root),
-        .platform_required_binding => platformRequiredEntrypointName(root_artifact, root),
-        else => {
-            if (builtin.mode == .Debug) {
-                std.debug.panic("platform entrypoint invariant violated: unexpected root kind {s}", .{@tagName(root.kind)});
-            }
-            unreachable;
-        },
-    };
-}
-
-fn platformEntrypointNamesFromLowered(
-    ctx: *CliContext,
-    root_artifact: *const check.CheckedArtifact.CheckedModuleArtifact,
-    lowered: *const lir.CheckedPipeline.LoweredProgram,
-) ![]const []const u8 {
-    const root_procs = lowered.lir_result.root_procs.items;
-    const root_metadata = lowered.lir_result.root_metadata.items;
-    if (root_procs.len != root_metadata.len) {
-        if (builtin.mode == .Debug) {
-            std.debug.panic(
-                "embedded build invariant violated: root metadata mismatch roots={d} metadata={d}",
-                .{ root_procs.len, root_metadata.len },
-            );
-        }
-        unreachable;
-    }
-
-    var names = std.array_list.Managed([]const u8).initCapacity(ctx.arena, root_metadata.len) catch return error.OutOfMemory;
-    for (root_metadata) |metadata| {
-        if (metadata.abi != .platform and metadata.exposure != .platform_required) continue;
-        const root = rootRequestByOrder(root_artifact, metadata.order);
-        const artifact_name = try platformEntrypointNameForRoot(ctx, root_artifact, root);
-        try names.append(try ctx.arena.dupe(u8, artifact_name));
-    }
-    return names.items;
-}
-
 fn nativeEntrypointSymbolName(
     ctx: *CliContext,
     root_artifact: *const check.CheckedArtifact.CheckedModuleArtifact,
     root: check.CheckedArtifact.RootRequest,
 ) ![]const u8 {
-    const entrypoint_name = try platformProvidedEntrypointName(ctx, root_artifact, root);
+    const entrypoint_name = root_artifact.providedEntrypointName(root) orelse {
+        if (builtin.mode == .Debug) {
+            std.debug.panic(
+                "platform entrypoint invariant violated: exported platform root has no published FFI symbol",
+                .{},
+            );
+        }
+        unreachable;
+    };
     return try std.fmt.allocPrint(ctx.arena, "roc__{s}", .{entrypoint_name});
 }
 
@@ -3881,7 +3594,7 @@ fn rocBuildEmbedded(ctx: *CliContext, args: cli_args.BuildArgs) !void {
         },
     );
 
-    const platform_entrypoints = try buildPlatformEntrypoints(shm_allocator, &lowered);
+    const platform_entrypoints = try lowered.platformEntrypoints(shm_allocator);
     try lir.RuntimeImage.fillHeaderInSharedMemory(
         runtime_header,
         shm.base_ptr,
@@ -3893,7 +3606,7 @@ fn rocBuildEmbedded(ctx: *CliContext, args: cli_args.BuildArgs) !void {
     shm.updateHeader();
 
     const runtime_image = try ctx.arena.dupe(u8, shm.base_ptr[0..shm.getUsedSize()]);
-    const entrypoint_names = try platformEntrypointNamesFromLowered(ctx, root_artifact, &lowered);
+    const entrypoint_names = try lowered.platformEntrypointNames(ctx.arena, root_artifact);
     if (entrypoint_names.len == 0) {
         if (builtin.mode == .Debug) {
             std.debug.panic("embedded build invariant violated: no platform entrypoints", .{});

--- a/src/compile/README.md
+++ b/src/compile/README.md
@@ -15,3 +15,108 @@ Key responsibilities include:
 - **Build Environment**: Managing build contexts and environments
 
 The compile module serves as the orchestrator that coordinates between the different compiler stages and manages the build process efficiently.
+
+## Embedding
+
+Roc can be embedded in another Zig program to compile and run `.roc` files in-process. The driver is [`Coordinator`](coordinator.zig); the in-process execution path uses [`lir.RuntimeImage`](../lir/runtime_image.zig) and [`eval.LirInterpreter`](../eval/interpreter.zig).
+
+The embedding API is stable in shape; implementation details may change between releases.
+
+### Canonical sequence
+
+```zig
+const compile = @import("compile");
+const lir = @import("lir");
+const eval = @import("eval");
+const check = @import("check");
+const base = @import("base");
+
+// 1. Builtins + Coordinator
+var builtins = try eval.BuiltinModules.init(gpa);
+defer builtins.deinit();
+
+var coord = try compile.coordinator.Coordinator.init(
+    gpa, .single_threaded, 1,
+    target, &builtins, version, null,
+);
+defer coord.deinit();
+coord.enable_hosted_transform = true;  // if you have host functions
+coord.setIo(my_io);                     // optional: virtualise the filesystem
+
+// 2. Discover + compile
+try coord.start();
+try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
+try coord.coordinatorLoop();
+
+// Render or collect diagnostics
+var it = coord.iterReports();
+while (it.next()) |entry| {
+    // entry.package_name, entry.module_name, entry.report
+}
+
+try coord.finalizeExecutableArtifacts();
+if (coord.hasUserErrors()) return error.CompilationFailed;
+
+// 3. Lower to LIR
+const root = coord.executableRootCheckedArtifact();
+const imports = try coord.collectImportedArtifactViews(arena, root);
+const relations = try coord.collectRelationArtifactViews(arena, root);
+
+const lowered = try lir.CheckedPipeline.lowerArtifactsToLir(
+    arena,
+    .{
+        .root = check.CheckedArtifact.loweringViewWithRelations(root, relations),
+        .imports = imports,
+    },
+    .{ .requests = root.root_requests.requests },
+    .{ .target_usize = base.target.TargetUsize.native },
+);
+
+// 4. Build the runtime image in an arena buffer (no shared memory required)
+const entrypoints = try lowered.platformEntrypoints(arena);
+const entrypoint_names = try lowered.platformEntrypointNames(arena, root);
+
+const runtime_header = try arena.create(lir.RuntimeImage.Header);
+try lir.RuntimeImage.fillHeaderInBuffer(
+    runtime_header,
+    base_ptr,            // start of the arena's backing buffer
+    used_size,           // bytes used so far
+    &lowered.lir_result,
+    lowered.target_usize,
+    entrypoints,
+);
+const view = try lir.RuntimeImage.viewMappedImage(
+    runtime_header,
+    @constCast(base_ptr),
+    used_size,
+);
+
+// 5. Execute via the interpreter
+var interp = try eval.LirInterpreter.init(gpa, &view.store, &view.layouts, &my_roc_ops);
+defer interp.deinit();
+_ = try interp.runEntrypoint(&view, 0, &args, &result_buf);
+```
+
+For type-check-only flows (LSP, fuzzing), skip steps 3-5.
+
+### Custom filesystem
+
+Implement the [`Io`](../io/Io.zig) vtable and pass it via `coord.setIo(...)`. The default `Io` reads from `std.fs.cwd()`.
+
+For embedders that don't have a filesystem at all (e.g. wasm), `Coordinator` doesn't require one as long as every path passed in is served through the configured `Io`. The cache manager (`cache_manager` parameter to `Coordinator.init`) can be left null.
+
+### Host functions
+
+Set `coord.enable_hosted_transform = true` before `coord.start()`. Hosted lambda bodies in platform modules are auto-converted during canonicalization.
+
+At execution time, populate `RocOps.hosted_fns` with function pointers. The interpreter matches against the platform's hosted function names; ordinals are determined by the order they appear in `lowered.lir_result.root_procs`.
+
+### URL-resolved packages
+
+`Coordinator.discoverAppFromPath` does not download URL-specified packages — it only supports relative paths. For URL support:
+
+1. Call `compile.app_header.parseAppHeader(io, gpa, arena, path)` to get the raw header.
+2. Resolve URLs to local paths using your own caching policy.
+3. Register packages with `coord.ensurePackage` / `coord.registerInlinePackage` instead of `discoverAppFromPath`.
+
+The Roc CLI follows exactly this pattern — see `buildLirRuntimeImageWithCoordinator` in `src/cli/main.zig` for a worked example.

--- a/src/compile/README.md
+++ b/src/compile/README.md
@@ -48,22 +48,28 @@ try coord.start();
 try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
 try coord.coordinatorLoop();
 
-// Render or collect diagnostics
+// 3. Render or collect diagnostics, then check for errors before finalizing.
 var it = coord.iterReports();
 while (it.next()) |entry| {
     // entry.package_name, entry.module_name, entry.report
 }
-
-try coord.finalizeExecutableArtifacts();
 if (coord.hasUserErrors()) return error.CompilationFailed;
 
-// 3. Lower to LIR
+// 4. Finalize — links the platform-app relation. Must come after the
+//    error check; calling this with outstanding user errors returns
+//    error.HasUserErrors.
+try coord.finalizeExecutableArtifacts();
+// finalize can surface new errors of its own — check once more.
+if (coord.hasUserErrors()) return error.CompilationFailed;
+
+// 5. Lower to LIR. The allocator must own a single contiguous buffer —
+//    see "Runtime arena" below.
 const root = coord.executableRootCheckedArtifact();
 const imports = try coord.collectImportedArtifactViews(arena, root);
 const relations = try coord.collectRelationArtifactViews(arena, root);
 
 const lowered = try lir.CheckedPipeline.lowerArtifactsToLir(
-    arena,
+    runtime_alloc,
     .{
         .root = check.CheckedArtifact.loweringViewWithRelations(root, relations),
         .imports = imports,
@@ -72,32 +78,83 @@ const lowered = try lir.CheckedPipeline.lowerArtifactsToLir(
     .{ .target_usize = base.target.TargetUsize.native },
 );
 
-// 4. Build the runtime image in an arena buffer (no shared memory required)
-const entrypoints = try lowered.platformEntrypoints(arena);
+// 6. Build the runtime image in the same contiguous buffer.
+const entrypoints = try lowered.platformEntrypoints(runtime_alloc);
 const entrypoint_names = try lowered.platformEntrypointNames(arena, root);
 
-const runtime_header = try arena.create(lir.RuntimeImage.Header);
+const runtime_header = try runtime_alloc.create(lir.RuntimeImage.Header);
 try lir.RuntimeImage.fillHeaderInBuffer(
     runtime_header,
-    base_ptr,            // start of the arena's backing buffer
-    used_size,           // bytes used so far
+    runtime_buffer.ptr,    // start of the contiguous backing buffer
+    runtime_fba.end_index, // bytes used so far
     &lowered.lir_result,
     lowered.target_usize,
     entrypoints,
 );
 const view = try lir.RuntimeImage.viewMappedImage(
     runtime_header,
-    @constCast(base_ptr),
-    used_size,
+    runtime_buffer.ptr,
+    runtime_fba.end_index,
 );
 
-// 5. Execute via the interpreter
+// 7. Execute via the interpreter.
 var interp = try eval.LirInterpreter.init(gpa, &view.store, &view.layouts, &my_roc_ops);
 defer interp.deinit();
 _ = try interp.runEntrypoint(&view, 0, &args, &result_buf);
 ```
 
-For type-check-only flows (LSP, fuzzing), skip steps 3-5.
+### Type-check-only flow
+
+For LSP, fuzzing, or any consumer that only needs diagnostics, stop after step 3:
+
+```zig
+try coord.start();
+try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
+try coord.coordinatorLoop();
+
+var it = coord.iterReports();
+while (it.next()) |entry| {
+    // render entry.report
+}
+const had_errors = coord.hasUserErrors();
+```
+
+Skip `finalizeExecutableArtifacts`, LIR lowering, and execution entirely.
+
+### Runtime arena
+
+`fillHeaderInBuffer` and `viewMappedImage` compute offsets via `ptr - base_ptr` arithmetic, so **the runtime allocator must own a single contiguous virtual region**. `std.heap.ArenaAllocator` grows by allocating new pages and **will not work** — the offsets it computes will be wrong, either silently producing a broken image or tripping `error.InvalidRuntimeImage`.
+
+Use a `std.heap.FixedBufferAllocator` over a heap-allocated contiguous buffer:
+
+```zig
+const RUNTIME_ARENA_SIZE = 128 * 1024 * 1024; // 128 MiB
+
+const runtime_buffer = try gpa.alignedAlloc(u8, 16, RUNTIME_ARENA_SIZE);
+defer gpa.free(runtime_buffer);
+
+var runtime_fba = std.heap.FixedBufferAllocator.init(runtime_buffer);
+const runtime_alloc = runtime_fba.allocator();
+```
+
+**Sizing:** budget at least 128 MiB for a typical app — even a "hello world" needs more than 16 MiB after lowering all reachable modules. Anonymous virtual memory overcommits on Linux/macOS, so a generously-sized buffer doesn't cost real RAM until actually touched. Pick a number that comfortably exceeds your largest expected program.
+
+### Memory ownership
+
+Refcounted values that Roc returns to the host (a `RocStr`, `RocList`, or `RocBox` written through `ret_ptr`; or any of those passed as arguments to your hosted functions) are **heap-owned by the host**. The interpreter does not auto-tear-down on `eval` return — that's intentional, since embedders frequently want to inspect the return value before freeing it.
+
+The host must explicitly `decref` returned refcounted values when done. Without this, host allocator leak-checking will report leaks tracing back to `rocAllocFn` in the interpreter:
+
+```zig
+// After interp.runEntrypoint(...) returns, if the entrypoint's return type
+// is a refcounted value (e.g. RocStr returned via ret_ptr), decref before
+// tearing down. `RocStr.decref` takes the value by copy and a *RocOps; it's
+// a no-op for small (stack) strings.
+const result_str: RocStr = @as(*const RocStr, @ptrCast(@alignCast(&result_buf))).*;
+defer result_str.decref(&my_roc_ops);
+```
+
+The same rule applies to hosted-fn arguments: the host owns each `*RocStr` (or other refcounted pointer) it receives for the call's duration. Read freely, but if you stow the value to use later, call the appropriate `incref` helper first.
 
 ### Custom filesystem
 
@@ -109,7 +166,14 @@ For embedders that don't have a filesystem at all (e.g. wasm), `Coordinator` doe
 
 Set `coord.enable_hosted_transform = true` before `coord.start()`. Hosted lambda bodies in platform modules are auto-converted during canonicalization.
 
-At execution time, populate `RocOps.hosted_fns` with function pointers. The interpreter matches against the platform's hosted function names; ordinals are determined by the order they appear in `lowered.lir_result.root_procs`.
+At execution time, `RocOps.hosted_fns.fns` is a **positional array** — the interpreter calls `fns[dispatch_index]`. The dispatch index is computed deterministically by:
+
+1. Within each checked artifact, hosted functions are sorted alphabetically by their fully-qualified name `Module.fn_name` (with trailing `!` stripped — so `Echo.line!` sorts as `Echo.line`), tiebroken by definition order.
+2. The global catalog concatenates artifacts in this order: the root (executable) artifact's hosted functions, then each imported artifact in import order, then each relation artifact in relation order.
+
+For a platform whose hosted functions all live in one module — the typical case — this collapses to **plain alphabetical order by `Module.fn_name`**. Build your `HostedFn` array to match.
+
+Wrong order is silent (wrong function called), not loud — be deliberate, especially when adding hosted functions across multiple modules.
 
 ### URL-resolved packages
 

--- a/src/compile/app_header.zig
+++ b/src/compile/app_header.zig
@@ -1,0 +1,160 @@
+//! Parse the header of an `app .roc` file.
+//!
+//! Returns the platform spec, platform qualifier, and the non-platform
+//! package entries declared in the header.
+//!
+//! This is a single-pass replacement for the three CLI helpers
+//! `extractPlatformSpecFromApp`, `extractPlatformQualifier`, and
+//! `extractNonPlatformPackages`. It performs no URL resolution — package
+//! specs are returned exactly as written in source so callers can apply
+//! their own resolution policy (caching, fetching, virtualised paths).
+//!
+//! Reads through the `Io` vtable, so it works against virtual filesystems
+//! (e.g. embedders, the wasm playground).
+
+const std = @import("std");
+const base = @import("base");
+const parse = @import("parse");
+const can = @import("can");
+
+const Allocator = std.mem.Allocator;
+const Io = @import("io").Io;
+const ModuleEnv = can.ModuleEnv;
+const Allocators = base.Allocators;
+
+/// One non-platform package reference from an `app` header.
+pub const PackageEntry = struct {
+    /// Shorthand name (the key — e.g. `hlp` in `{ hlp: "./helper_pkg/main.roc" }`).
+    /// Arena-owned.
+    shorthand: []const u8,
+    /// Raw package spec as written in source (relative path, absolute path, or URL).
+    /// Callers are responsible for resolution. Arena-owned.
+    spec: []const u8,
+};
+
+/// Information extracted from an `app` header. All slices are arena-owned
+/// by the `arena` allocator passed to `parseAppHeader`.
+pub const AppHeaderInfo = struct {
+    /// Raw platform spec (the string literal after `platform`). Empty if absent.
+    platform_spec: []const u8,
+    /// Platform qualifier (the key in `{ pf: platform "..." }`). Null if absent.
+    platform_qualifier: ?[]const u8,
+    /// Non-platform package entries from the `packages` collection.
+    non_platform_packages: []const PackageEntry,
+};
+
+/// Errors `parseAppHeader` can return — either a header-shape problem
+/// (`NotAnAppHeader`), an allocation failure, or an `Io.readFile` failure.
+pub const Error = error{
+    NotAnAppHeader,
+    OutOfMemory,
+} || Io.ReadError;
+
+/// Read and parse an `app .roc` file, returning the header's platform and
+/// package metadata.
+///
+/// - `io`: filesystem to read the source through.
+/// - `gpa`: used for transient parsing state (freed before this returns).
+/// - `arena`: holds the returned strings — kept alive as long as the caller
+///   needs `AppHeaderInfo`.
+pub fn parseAppHeader(
+    io: Io,
+    gpa: Allocator,
+    arena: Allocator,
+    app_path: []const u8,
+) Error!AppHeaderInfo {
+    var source = try io.readFile(app_path, gpa);
+    source = base.source_utils.normalizeLineEndingsRealloc(gpa, source) catch |err| {
+        gpa.free(source);
+        return err;
+    };
+    defer gpa.free(source);
+
+    var env = ModuleEnv.init(gpa, source) catch return error.OutOfMemory;
+    defer env.deinit();
+    env.common.source = source;
+
+    var allocators: Allocators = undefined;
+    allocators.initInPlace(gpa);
+    defer allocators.deinit();
+
+    const ast = parse.parse(&allocators, &env.common) catch return error.OutOfMemory;
+    defer ast.deinit();
+
+    const file_node = ast.store.getFile();
+    const header = ast.store.getHeader(file_node.header);
+
+    const app = switch (header) {
+        .app => |a| a,
+        else => return error.NotAnAppHeader,
+    };
+
+    const platform_field = ast.store.getRecordField(app.platform_idx);
+
+    const platform_spec: []const u8 = blk: {
+        const value_expr = platform_field.value orelse break :blk "";
+        const s = stringFromExpr(ast, value_expr) catch break :blk "";
+        break :blk try arena.dupe(u8, s);
+    };
+
+    const platform_qualifier: ?[]const u8 = blk: {
+        const key_region = ast.tokens.resolve(platform_field.name);
+        const q = source[key_region.start.offset..key_region.end.offset];
+        if (q.len == 0) break :blk null;
+        break :blk try arena.dupe(u8, q);
+    };
+
+    var entries: std.array_list.Managed(PackageEntry) = .init(arena);
+
+    const packages_coll = ast.store.getCollection(app.packages);
+    const fields = ast.store.recordFieldSlice(.{ .span = packages_coll.span });
+    for (fields) |field_idx| {
+        const field = ast.store.getRecordField(field_idx);
+        const key_region = ast.tokens.resolve(field.name);
+        const shorthand = source[key_region.start.offset..key_region.end.offset];
+
+        if (platform_qualifier) |qual| {
+            if (std.mem.eql(u8, shorthand, qual)) continue;
+        }
+
+        const value_idx = field.value orelse continue;
+        const value_node = ast.store.getExpr(value_idx);
+        const spec: []const u8 = switch (value_node) {
+            .string => |str| inner: {
+                const str_region = ast.tokenizedRegionToRegion(str.region);
+                const raw = source[str_region.start.offset..str_region.end.offset];
+                if (raw.len < 2 or raw[0] != '"' or raw[raw.len - 1] != '"') break :inner "";
+                break :inner raw[1 .. raw.len - 1];
+            },
+            else => "",
+        };
+        if (spec.len == 0) continue;
+
+        try entries.append(.{
+            .shorthand = try arena.dupe(u8, shorthand),
+            .spec = try arena.dupe(u8, spec),
+        });
+    }
+
+    return .{
+        .platform_spec = platform_spec,
+        .platform_qualifier = platform_qualifier,
+        .non_platform_packages = try entries.toOwnedSlice(),
+    };
+}
+
+fn stringFromExpr(ast: *parse.AST, expr_idx: parse.AST.Expr.Idx) ![]const u8 {
+    const e = ast.store.getExpr(expr_idx);
+    return switch (e) {
+        .string => |s| {
+            for (ast.store.exprSlice(s.parts)) |part_idx| {
+                const part = ast.store.getExpr(part_idx);
+                if (part == .string_part) {
+                    return ast.resolve(part.string_part.token);
+                }
+            }
+            return error.ExpectedString;
+        },
+        else => error.ExpectedString,
+    };
+}

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -563,6 +563,15 @@ pub const Coordinator = struct {
             self.gpa;
     }
 
+    /// Initialize a `Coordinator`.
+    ///
+    /// `compiler_version` is a cache-key discriminant — it is incorporated
+    /// into the keys used by `cache_manager` so that artifacts from
+    /// different compiler versions (or different consumer wrappers) stay
+    /// segregated. Embedders should pass a stable string that changes
+    /// whenever their consumer's compile semantics could change, e.g.
+    /// `"my-embedder@1.2.3+roc@" ++ build_options.compiler_version`.
+    /// Mismatching across runs causes cache misses, not corruption.
     pub fn init(
         gpa: Allocator,
         mode: Mode,
@@ -716,10 +725,14 @@ pub const Coordinator = struct {
     /// returns, the caller should call `start()` and `coordinatorLoop()`.
     ///
     /// Only relative paths (`./...`, `../...`) are supported for the platform
-    /// spec and non-platform packages. Callers that need URL pre-resolution
-    /// (downloading + caching) should call `compile.app_header.parseAppHeader`
-    /// themselves, resolve URLs to local paths, and register packages via
-    /// `ensurePackage` / `registerInlinePackage`.
+    /// spec and non-platform packages — URL specs return
+    /// `error.UnsupportedPlatformSpec` or `error.UnsupportedPackageSpec`.
+    /// Embedders that need URL pre-resolution (downloading + caching) should
+    /// call `compile.app_header.parseAppHeader` themselves, resolve URLs to
+    /// local paths through their own policy, and register packages via
+    /// `ensurePackage` / `registerInlinePackage`. See
+    /// `buildLirRuntimeImageWithCoordinator` in `src/cli/main.zig` for a
+    /// worked example of the URL-aware path.
     ///
     /// `arena` holds strings extracted from the header (qualifiers, specs).
     pub fn discoverAppFromPath(
@@ -980,13 +993,14 @@ pub const Coordinator = struct {
         return false;
     }
 
+    /// Finalize the build's executable artifacts (link app + platform, build
+    /// the platform-app relation, republish the root artifact).
+    ///
+    /// Must only be called after `coordinatorLoop` returns and after the
+    /// caller has confirmed `hasUserErrors() == false`. Returns
+    /// `error.HasUserErrors` if called while user-facing diagnostics exist.
     pub fn finalizeExecutableArtifacts(self: *Coordinator) !void {
-        if (self.hasUserErrors()) {
-            if (builtin.mode == .Debug) {
-                std.debug.panic("compile.coordinator.finalizeExecutableArtifacts called after user-facing errors", .{});
-            }
-            unreachable;
-        }
+        if (self.hasUserErrors()) return error.HasUserErrors;
 
         const app_root = self.findRootModule(.app) orelse self.findRootModule(.default_app) orelse return;
         const platform_root = self.findRootModule(.platform) orelse return;

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -2053,8 +2053,12 @@ pub const Coordinator = struct {
 
         for (mod.imports.items) |imp_id| {
             const imp = pkg.getModule(imp_id).?;
-            const env = imp.moduleEnv() orelse
-                std.debug.panic("compile.coordinator.buildCanonicalizeImports missing local env for {s}", .{imp.name});
+            // Skip imports whose module env is missing (e.g. the source file
+            // wasn't found during discovery). Canonicalize will emit a
+            // `module_not_found` diagnostic for the unresolved name — see
+            // src/canonicalize/can.zig where it checks `explicit_module_envs`.
+            // Mirrors the `orelse continue` handling for external_imports below.
+            const env = imp.moduleEnv() orelse continue;
             try imports.append(self.gpa, .{
                 .import_name = imp.name,
                 .module_env = env,

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -51,6 +51,7 @@ const compile_build = @import("compile_build.zig");
 const module_discovery = @import("module_discovery.zig");
 const cache_manager_mod = @import("cache_manager.zig");
 const CacheManager = cache_manager_mod.CacheManager;
+const app_header_mod = @import("app_header.zig");
 const roc_target = @import("roc_target");
 
 // Compile-time flag for build tracing - enabled via `zig build -Dtrace-build`
@@ -695,6 +696,131 @@ pub const Coordinator = struct {
         return self.packages.get(name);
     }
 
+    /// Options for `discoverAppFromPath`.
+    pub const AppDiscoveryOptions = struct {
+        /// Path to the app `.roc` file, accessible via the configured Io.
+        entry_path: []const u8,
+        /// Optional override for the app module's `source_dir_override`.
+        source_dir_override: ?[]const u8 = null,
+    };
+
+    pub const AppDiscoveryError = error{
+        InvalidPlatformPath,
+        AbsolutePlatformPath,
+        UnsupportedPlatformSpec,
+        UnsupportedPackageSpec,
+    } || app_header_mod.Error || Allocator.Error;
+
+    /// Read an app `.roc` file's header, register the app + platform +
+    /// non-platform packages, and enqueue the app's parse task. After this
+    /// returns, the caller should call `start()` and `coordinatorLoop()`.
+    ///
+    /// Only relative paths (`./...`, `../...`) are supported for the platform
+    /// spec and non-platform packages. Callers that need URL pre-resolution
+    /// (downloading + caching) should call `compile.app_header.parseAppHeader`
+    /// themselves, resolve URLs to local paths, and register packages via
+    /// `ensurePackage` / `registerInlinePackage`.
+    ///
+    /// `arena` holds strings extracted from the header (qualifiers, specs).
+    pub fn discoverAppFromPath(
+        self: *Coordinator,
+        arena: Allocator,
+        opts: AppDiscoveryOptions,
+    ) AppDiscoveryError!void {
+        const header_info = try app_header_mod.parseAppHeader(self.io, self.gpa, arena, opts.entry_path);
+
+        const app_dir = std.fs.path.dirname(opts.entry_path) orelse ".";
+
+        const app_pkg = try self.ensurePackage("app", app_dir);
+        const app_module_name = base.module_path.getModuleName(opts.entry_path);
+        const app_module_id = try app_pkg.ensureModule(self.gpa, app_module_name, opts.entry_path);
+        if (opts.source_dir_override) |source_dir| {
+            app_pkg.modules.items[app_module_id].source_dir_override = try self.gpa.dupe(u8, source_dir);
+        }
+        app_pkg.root_module_id = app_module_id;
+        app_pkg.modules.items[app_module_id].depth = 0;
+        app_pkg.remaining_modules += 1;
+        self.total_remaining += 1;
+
+        if (header_info.platform_spec.len > 0) {
+            if (std.fs.path.isAbsolute(header_info.platform_spec)) {
+                return error.AbsolutePlatformPath;
+            }
+            if (!isRelativeSpec(header_info.platform_spec)) {
+                return error.UnsupportedPlatformSpec;
+            }
+            const platform_main_path = try std.fs.path.join(arena, &.{ app_dir, header_info.platform_spec });
+            const platform_dir = std.fs.path.dirname(platform_main_path) orelse return error.InvalidPlatformPath;
+
+            try self.registerPlatformPackage(app_pkg, platform_dir, platform_main_path, header_info.platform_qualifier);
+        }
+
+        for (header_info.non_platform_packages) |entry| {
+            if (!isRelativeSpec(entry.spec)) {
+                return error.UnsupportedPackageSpec;
+            }
+            const pkg_main_path = try std.fs.path.join(arena, &.{ app_dir, entry.spec });
+            const pkg_dir = std.fs.path.dirname(pkg_main_path) orelse ".";
+            _ = try self.registerInlinePackage(entry.shorthand, pkg_dir, app_pkg, entry.shorthand);
+        }
+
+        try self.enqueueParseTask("app", app_module_id);
+    }
+
+    /// Register the platform package (named "pf"), wire the app's shorthand
+    /// for it, ensure the platform's main module, and enqueue its parse task.
+    pub fn registerPlatformPackage(
+        self: *Coordinator,
+        app_pkg: *PackageState,
+        platform_dir: []const u8,
+        platform_main_path: []const u8,
+        qualifier: ?[]const u8,
+    ) !void {
+        const pf_pkg = try self.ensurePackage("pf", platform_dir);
+
+        if (qualifier) |qual| {
+            try app_pkg.shorthands.put(
+                try self.gpa.dupe(u8, qual),
+                try self.gpa.dupe(u8, "pf"),
+            );
+        }
+
+        const pf_module_id = try pf_pkg.ensureModule(self.gpa, "main", platform_main_path);
+        pf_pkg.root_module_id = pf_module_id;
+        pf_pkg.modules.items[pf_module_id].depth = 1;
+        pf_pkg.remaining_modules += 1;
+        self.total_remaining += 1;
+        try self.enqueueParseTask("pf", pf_module_id);
+    }
+
+    /// Register a non-platform package and (optionally) wire a shorthand on
+    /// the app package that resolves to it. Useful for embedders that have
+    /// pre-resolved URL packages to local paths.
+    ///
+    /// Returns the new (or existing) package state.
+    pub fn registerInlinePackage(
+        self: *Coordinator,
+        package_name: []const u8,
+        package_root_dir: []const u8,
+        app_pkg: ?*PackageState,
+        shorthand_on_app: ?[]const u8,
+    ) !*PackageState {
+        const pkg = try self.ensurePackage(package_name, package_root_dir);
+        if (app_pkg) |a| {
+            if (shorthand_on_app) |sh| {
+                try a.shorthands.put(
+                    try self.gpa.dupe(u8, sh),
+                    try self.gpa.dupe(u8, package_name),
+                );
+            }
+        }
+        return pkg;
+    }
+
+    fn isRelativeSpec(spec: []const u8) bool {
+        return std.mem.startsWith(u8, spec, "./") or std.mem.startsWith(u8, spec, "../");
+    }
+
     /// Return the published checked artifact for a package root module.
     pub fn rootCheckedArtifact(self: *Coordinator, package_name: []const u8) *const check.CheckedArtifact.CheckedModuleArtifact {
         const pkg = self.packages.get(package_name) orelse {
@@ -1015,6 +1141,54 @@ pub const Coordinator = struct {
             }
         }
         return false;
+    }
+
+    /// One entry yielded by `ReportIter` — a single diagnostic with the package
+    /// and module it came from. Pointers borrow from the Coordinator's storage.
+    pub const ReportEntry = struct {
+        package_name: []const u8,
+        module_name: []const u8,
+        report: *const Report,
+    };
+
+    /// Iterator over every report from every module in every package.
+    /// Borrows from `Coordinator` storage — do not mutate while iterating.
+    pub const ReportIter = struct {
+        pkg_it: std.StringHashMap(*PackageState).Iterator,
+        cur_pkg: ?*PackageState = null,
+        module_idx: usize = 0,
+        report_idx: usize = 0,
+
+        pub fn next(self: *ReportIter) ?ReportEntry {
+            while (true) {
+                if (self.cur_pkg) |pkg| {
+                    if (self.module_idx < pkg.modules.items.len) {
+                        const mod = &pkg.modules.items[self.module_idx];
+                        if (self.report_idx < mod.reports.items.len) {
+                            const report = &mod.reports.items[self.report_idx];
+                            self.report_idx += 1;
+                            return .{
+                                .package_name = pkg.name,
+                                .module_name = mod.name,
+                                .report = report,
+                            };
+                        }
+                        self.module_idx += 1;
+                        self.report_idx = 0;
+                        continue;
+                    }
+                }
+                const entry = self.pkg_it.next() orelse return null;
+                self.cur_pkg = entry.value_ptr.*;
+                self.module_idx = 0;
+                self.report_idx = 0;
+            }
+        }
+    };
+
+    /// Iterate over every diagnostic produced during compilation.
+    pub fn iterReports(self: *const Coordinator) ReportIter {
+        return .{ .pkg_it = self.packages.iterator() };
     }
 
     pub fn executableRootCheckedArtifact(self: *Coordinator) *const check.CheckedArtifact.CheckedModuleArtifact {

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -99,4 +99,5 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/test_package_env.zig"));
     std.testing.refAllDecls(@import("test/module_env_test.zig"));
     std.testing.refAllDecls(@import("test/type_printing_bug_test.zig"));
+    std.testing.refAllDecls(@import("test/embedding_smoke.zig"));
 }

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -17,6 +17,7 @@ pub const static_data_exports = @import("static_data_exports.zig");
 pub const messages = @import("messages.zig");
 pub const channel = @import("channel.zig");
 pub const coordinator = @import("coordinator.zig");
+pub const app_header = @import("app_header.zig");
 
 pub const key = @import("cache_key.zig");
 pub const config = @import("cache_config.zig");
@@ -91,6 +92,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("messages.zig"));
     std.testing.refAllDecls(@import("channel.zig"));
     std.testing.refAllDecls(@import("coordinator.zig"));
+    std.testing.refAllDecls(@import("app_header.zig"));
 
     std.testing.refAllDecls(@import("test/cache_test.zig"));
     std.testing.refAllDecls(@import("test/test_build_env.zig"));

--- a/src/compile/test/embedding_smoke.zig
+++ b/src/compile/test/embedding_smoke.zig
@@ -1,0 +1,168 @@
+//! End-to-end smoke test for the public embedding API.
+//!
+//! Drives a minimal compile + execute through every method an embedder is
+//! expected to call (`Coordinator.discoverAppFromPath` → `coordinatorLoop`
+//! → `iterReports` → `finalizeExecutableArtifacts` → `lowerArtifactsToLir`
+//! → `LoweredProgram.platformEntrypoints` → `RuntimeImage.fillHeaderInBuffer`
+//! → `RuntimeImage.viewMappedImage` → `LirInterpreter.runEntrypoint`).
+//!
+//! If this test breaks, the public surface changed in a way that will break
+//! external embedders. The test itself is documentation: the canonical
+//! sequence shown in `src/compile/README.md` is the structure here.
+
+const std = @import("std");
+const build_options = @import("build_options");
+const lir = @import("lir");
+const eval = @import("eval");
+const check = @import("check");
+const base = @import("base");
+const host_abi = @import("builtins").host_abi;
+const roc_target = @import("roc_target");
+
+const Coordinator = @import("../coordinator.zig").Coordinator;
+
+// Allocator callbacks for the test's RocOps. The simple_success.roc app's
+// `main!` is empty, so these are unlikely to fire — but they must be valid
+// function pointers.
+fn testRocAlloc(args: *host_abi.RocAlloc, _: *anyopaque) callconv(.c) void {
+    const align_enum = std.mem.Alignment.fromByteUnits(@max(args.alignment, @alignOf(usize)));
+    const raw = std.heap.page_allocator.rawAlloc(args.length, align_enum, @returnAddress()) orelse {
+        std.debug.panic("embedding smoke test roc_alloc OOM", .{});
+    };
+    args.answer = @ptrCast(raw);
+}
+
+fn testRocDealloc(_: *host_abi.RocDealloc, _: *anyopaque) callconv(.c) void {
+    // No-op for the smoke test — page_allocator pages are reclaimed at exit.
+}
+
+fn testRocRealloc(_: *host_abi.RocRealloc, _: *anyopaque) callconv(.c) void {
+    std.debug.panic("embedding smoke test roc_realloc unexpected", .{});
+}
+
+fn testRocDbg(_: *const host_abi.RocDbg, _: *anyopaque) callconv(.c) void {}
+fn testRocExpectFailed(_: *const host_abi.RocExpectFailed, _: *anyopaque) callconv(.c) void {}
+fn testRocCrashed(_: *const host_abi.RocCrashed, _: *anyopaque) callconv(.c) void {
+    std.debug.panic("embedding smoke test received roc_crashed", .{});
+}
+
+test "embedding API: full canonical sequence on simple_success app" {
+    // Path is resolved relative to the cwd at test time, which is the repo
+    // root for `zig build test-compile`.
+    const app_path = "test/cli/simple_success.roc";
+
+    const gpa = std.testing.allocator;
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    // 1. Builtins + Coordinator.
+    var builtin_modules = try eval.BuiltinModules.init(gpa);
+    defer builtin_modules.deinit();
+
+    var coord = try Coordinator.init(
+        gpa,
+        .single_threaded,
+        1,
+        roc_target.RocTarget.detectNative(),
+        &builtin_modules,
+        build_options.compiler_version,
+        null,
+    );
+    defer coord.deinit();
+    coord.enable_hosted_transform = true;
+
+    try coord.start();
+
+    // 2. Discover + compile.
+    try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
+    try coord.coordinatorLoop();
+
+    // 3. iterReports must walk without crashing; we expect no errors for
+    //    simple_success.roc.
+    var report_iter = coord.iterReports();
+    while (report_iter.next()) |entry| {
+        try std.testing.expect(entry.report.severity != .fatal);
+        try std.testing.expect(entry.report.severity != .runtime_error);
+    }
+    try std.testing.expect(!coord.hasUserErrors());
+
+    // 4. Finalize must succeed (no HasUserErrors).
+    try coord.finalizeExecutableArtifacts();
+    try std.testing.expect(!coord.hasUserErrors());
+
+    // 5. Lower to LIR in a contiguous FixedBufferAllocator (the runtime
+    //    arena pattern documented in README "Runtime arena"). 128 MiB is
+    //    the recommended starting size for an embedder.
+    const RUNTIME_ARENA_SIZE: usize = 128 * 1024 * 1024;
+    const runtime_buffer = try gpa.alignedAlloc(u8, .@"16", RUNTIME_ARENA_SIZE);
+    defer gpa.free(runtime_buffer);
+
+    var runtime_fba = std.heap.FixedBufferAllocator.init(runtime_buffer);
+    const runtime_alloc = runtime_fba.allocator();
+
+    const root = coord.executableRootCheckedArtifact();
+    const imports = try coord.collectImportedArtifactViews(arena, root);
+    const relations = try coord.collectRelationArtifactViews(arena, root);
+
+    const lowered = try lir.CheckedPipeline.lowerArtifactsToLir(
+        runtime_alloc,
+        .{
+            .root = check.CheckedArtifact.loweringViewWithRelations(root, relations),
+            .imports = imports,
+        },
+        .{ .requests = root.root_requests.requests },
+        .{ .target_usize = base.target.TargetUsize.native },
+    );
+
+    // 6. Build entrypoint list. simple_success has a platform-provided main!
+    //    so at least one entrypoint must exist.
+    const entrypoints = try lowered.platformEntrypoints(runtime_alloc);
+    const entrypoint_names = try lowered.platformEntrypointNames(arena, root);
+    try std.testing.expect(entrypoints.len > 0);
+    try std.testing.expectEqual(entrypoints.len, entrypoint_names.len);
+
+    // 7. Fill the runtime image header in the contiguous buffer.
+    const runtime_header = try runtime_alloc.create(lir.RuntimeImage.Header);
+    try lir.RuntimeImage.fillHeaderInBuffer(
+        runtime_header,
+        runtime_buffer.ptr,
+        runtime_fba.end_index,
+        &lowered.lir_result,
+        lowered.target_usize,
+        entrypoints,
+    );
+
+    // 8. View the image. With the const-correctness fix from this branch,
+    //    viewMappedImage now accepts `[*]align(1) const u8` so no
+    //    @constCast is needed on the buffer pointer.
+    const view = try lir.RuntimeImage.viewMappedImage(
+        runtime_header,
+        runtime_buffer.ptr,
+        runtime_fba.end_index,
+    );
+
+    // 9. Wire RocOps with empty hosted_fns (simple_success has no hosted-fn
+    //    calls). For platforms with hosted functions, the dispatch index
+    //    rule applies — see README "Host functions".
+    var hosted_fns = host_abi.emptyHostedFunctions();
+    var roc_ops = host_abi.RocOps{
+        .env = @ptrFromInt(0xdeadbeef), // unused by simple_success
+        .roc_alloc = &testRocAlloc,
+        .roc_dealloc = &testRocDealloc,
+        .roc_realloc = &testRocRealloc,
+        .roc_dbg = &testRocDbg,
+        .roc_expect_failed = &testRocExpectFailed,
+        .roc_crashed = &testRocCrashed,
+        .hosted_fns = hosted_fns,
+    };
+    _ = &hosted_fns;
+
+    // 10. Initialize the interpreter and run the entrypoint.
+    var interp = try eval.LirInterpreter.init(gpa, &view.store, &view.layouts, &roc_ops);
+    defer interp.deinit();
+
+    // simple_success has main! : () => {} — no args, returns unit.
+    var ret_buf: [16]u8 align(16) = undefined;
+    _ = try interp.runEntrypoint(&view, 0, null, @ptrCast(&ret_buf));
+}

--- a/src/echo_platform/echo.zig
+++ b/src/echo_platform/echo.zig
@@ -5,32 +5,20 @@
 //! 2. Register module files (e.g. Greeting.roc)
 //! 3. Compile and execute a headerless Roc app through the full compiler pipeline
 //!
-//! Uses the same multi-module BuildEnv compilation as the CLI,
-//! with a unified EchoCtx (Io implementation) that intercepts reads for
-//! the echo platform's virtual files (main.roc, Echo.roc) and user-provided
-//! modules, while delegating everything else to WasmFilesystem.
+//! Delegates the compile-and-run pipeline to `runner.zig`, which is shared
+//! with the native CLI in `echo_native.zig`.
 
 const std = @import("std");
 const builtin = @import("builtin");
-const base = @import("base");
-const check = @import("check");
-const compile = @import("compile");
-const echo_platform = @import("echo_platform");
-const eval = @import("eval");
-const layout = @import("layout");
-const lir = @import("lir");
-const roc_target = @import("roc_target");
 const reporting = @import("reporting");
+const runner = @import("runner.zig");
 
 const WasmFilesystem = @import("WasmFilesystem.zig");
 
-const BuildEnv = compile.BuildEnv;
-const Io = compile.Io;
-const RocTarget = roc_target.RocTarget;
-const HostedFn = echo_platform.host_abi.HostedFn;
-const ReportingConfig = reporting.ReportingConfig;
-
 const Allocator = std.mem.Allocator;
+const Diagnostics = runner.Diagnostics;
+const ExtraFile = runner.ExtraFile;
+const ReportingConfig = reporting.ReportingConfig;
 
 /// Public API.
 pub const std_options: std.Options = .{
@@ -45,8 +33,12 @@ fn logFn(comptime level: std.log.Level, comptime scope: @TypeOf(.enum_literal), 
     std.log.defaultLog(level, scope, format, args);
 }
 
-// Fixed-size heap in WASM linear memory (64 MB).
-var wasm_heap_memory: [64 * 1024 * 1024]u8 = undefined;
+// Fixed-size heap in WASM linear memory (128 MiB — matches the runtime arena
+// size recommended in src/compile/README.md "Runtime arena"; smaller sizes
+// OOM during BuildEnv.init / lowering for non-trivial programs). align(16)
+// so the runtime image's base_ptr satisfies the alignment constraints
+// documented in the same section.
+var wasm_heap_memory: [128 * 1024 * 1024]u8 align(16) = undefined;
 var fba: std.heap.FixedBufferAllocator = undefined;
 var allocator: Allocator = undefined;
 
@@ -56,103 +48,29 @@ const js = struct {
     extern "env" fn js_stderr(ptr: [*]const u8, len: usize) void;
 };
 
-fn jsErr(msg: []const u8) void {
+// --- Diagnostics implementation: emits HTML reports + step labels via js_stderr ---
+
+fn jsWrite(_: ?*anyopaque, msg: []const u8) void {
     js.js_stderr(msg.ptr, msg.len);
 }
 
-fn emitDiagnostics(build_env: *BuildEnv) void {
-    const drained = build_env.drainReports() catch return;
-    defer build_env.freeDrainedReports(drained);
-
+fn jsEmitReport(_: ?*anyopaque, gpa: Allocator, report: *reporting.Report) void {
     const config = ReportingConfig.initHtml();
-
-    for (drained) |mod| {
-        for (mod.reports) |*report| {
-            var diag_writer: std.Io.Writer.Allocating = .init(allocator);
-            reporting.renderReportToHtml(report, &diag_writer.writer, config) catch continue;
-            const output = diag_writer.written();
-            if (output.len > 0) {
-                js.js_stderr(output.ptr, output.len);
-            }
-        }
+    var diag_writer: std.Io.Writer.Allocating = .init(gpa);
+    reporting.renderReportToHtml(report, &diag_writer.writer, config) catch return;
+    const output = diag_writer.written();
+    if (output.len > 0) {
+        js.js_stderr(output.ptr, output.len);
     }
 }
 
-fn platformRootProc(lowered: *const lir.CheckedPipeline.LoweredProgram) lir.LirProcSpecId {
-    const root_procs = lowered.lir_result.root_procs.items;
-    const root_metadata = lowered.lir_result.root_metadata.items;
-    if (root_procs.len != root_metadata.len) {
-        if (builtin.mode == .Debug) {
-            std.debug.panic(
-                "echo platform invariant violated: root metadata mismatch roots={d} metadata={d}",
-                .{ root_procs.len, root_metadata.len },
-            );
-        }
-        unreachable;
-    }
-    for (root_procs, root_metadata) |root_proc, metadata| {
-        if (metadata.abi == .platform or metadata.exposure == .platform_required) return root_proc;
-    }
-    if (builtin.mode == .Debug) {
-        std.debug.panic("echo platform invariant violated: checked artifact lowering produced no platform root", .{});
-    }
-    unreachable;
-}
+const js_diagnostics_vtable = Diagnostics.VTable{
+    .write = &jsWrite,
+    .emitReport = &jsEmitReport,
+};
 
-fn argLayoutsForProc(
-    alloc: Allocator,
-    store: *const lir.LirStore,
-    proc_id: lir.LirProcSpecId,
-) ![]layout.Idx {
-    const proc = store.getProcSpec(proc_id);
-    const arg_ids = store.getLocalSpan(proc.args);
-    const arg_layouts = try alloc.alloc(layout.Idx, arg_ids.len);
-    errdefer alloc.free(arg_layouts);
-
-    for (arg_ids, 0..) |local_id, i| {
-        arg_layouts[i] = store.locals.items[@intFromEnum(local_id)].layout_idx;
-    }
-
-    return arg_layouts;
-}
-
-fn runEchoLir(lowered: *const lir.CheckedPipeline.LoweredProgram) !u8 {
-    var hosted_fn_array = [_]HostedFn{echo_platform.host_abi.hostedFn(&echo_platform.echoHostedFn)};
-    var default_roc_ops_env: echo_platform.DefaultRocOpsEnv = .{};
-    var roc_ops = echo_platform.makeDefaultRocOps(&default_roc_ops_env, &hosted_fn_array);
-    var cli_args_list = echo_platform.buildCliArgs(&.{}, &roc_ops);
-    var result_buf: [16]u8 align(16) = undefined;
-
-    const root_proc = platformRootProc(lowered);
-    const arg_layouts = try argLayoutsForProc(allocator, &lowered.lir_result.store, root_proc);
-    defer allocator.free(arg_layouts);
-
-    var interpreter = try eval.LirInterpreter.init(
-        allocator,
-        &lowered.lir_result.store,
-        &lowered.lir_result.layouts,
-        &roc_ops,
-    );
-    defer interpreter.deinit();
-
-    const proc = lowered.lir_result.store.getProcSpec(root_proc);
-    _ = interpreter.eval(.{
-        .proc_id = root_proc,
-        .arg_layouts = arg_layouts,
-        .ret_layout = proc.ret_layout,
-        .arg_ptr = @ptrCast(&cli_args_list),
-        .ret_ptr = @ptrCast(&result_buf),
-    }) catch |err| switch (err) {
-        error.RuntimeError, error.DivisionByZero => {
-            if (interpreter.getRuntimeErrorMessage()) |msg| jsErr(msg);
-            return error.EvaluationFailed;
-        },
-        error.Crash => return error.EvaluationFailed,
-        error.OutOfMemory => return error.OutOfMemory,
-    };
-
-    if (default_roc_ops_env.inline_expect_failed) return 1;
-    return result_buf[0];
+fn jsDiagnostics() Diagnostics {
+    return .{ .ctx = null, .vtable = &js_diagnostics_vtable };
 }
 
 // --- Extra module file storage (static, survives FBA reset) ---
@@ -161,22 +79,22 @@ const MAX_FILES = 16;
 const MAX_NAME_LEN = 256;
 const MAX_CONTENT_LEN = 64 * 1024;
 
-const ExtraFile = struct {
+const ExtraFileSlot = struct {
     name_buf: [MAX_NAME_LEN]u8 = undefined,
     name_len: usize = 0,
     content_buf: [MAX_CONTENT_LEN]u8 = undefined,
     content_len: usize = 0,
 
-    fn name(self: *const ExtraFile) []const u8 {
+    fn name(self: *const ExtraFileSlot) []const u8 {
         return self.name_buf[0..self.name_len];
     }
 
-    fn content(self: *const ExtraFile) []const u8 {
+    fn content(self: *const ExtraFileSlot) []const u8 {
         return self.content_buf[0..self.content_len];
     }
 };
 
-var extra_files: [MAX_FILES]ExtraFile = [_]ExtraFile{.{}} ** MAX_FILES;
+var extra_files: [MAX_FILES]ExtraFileSlot = [_]ExtraFileSlot{.{}} ** MAX_FILES;
 var extra_file_count: usize = 0;
 
 // Static buffer for copying source before FBA reset (avoids 64KB stack allocation in WASM).
@@ -184,136 +102,6 @@ var source_copy_buf: [MAX_CONTENT_LEN]u8 = undefined;
 
 // WASM filesystem context — static so it survives FBA reset.
 var wasm_ctx: WasmFilesystem.WasmContext = .{};
-
-// --- Echo I/O context ---
-
-/// Unified I/O context for the echo platform.
-/// Intercepts readFile/fileExists for synthetic app source, embedded platform
-/// files, and user-provided module files. All other operations delegate to the
-/// WasmFilesystem implementation.
-const EchoCtx = struct {
-    app_abs_path: []const u8,
-    synthetic_app_source: []const u8,
-    platform_main_path: []const u8,
-    echo_module_path: []const u8,
-    fallback: Io,
-
-    fn io(self: *@This()) Io {
-        return .{ .ctx = @ptrCast(self), .vtable = echo_vtable };
-    }
-
-    /// Return the content for a synthetic/embedded path, or null if not synthetic.
-    fn getSyntheticContent(self: *const @This(), path: []const u8) ?[]const u8 {
-        if (std.mem.eql(u8, path, self.app_abs_path)) return self.synthetic_app_source;
-        if (std.mem.eql(u8, path, self.platform_main_path)) return echo_platform.platform_main_source;
-        if (std.mem.eql(u8, path, self.echo_module_path)) return echo_platform.echo_module_source;
-        for (extra_files[0..extra_file_count]) |*ef| {
-            var expected: [5 + MAX_NAME_LEN + 4]u8 = undefined;
-            const prefix = "/app/";
-            const suffix = ".roc";
-            const total = prefix.len + ef.name_len + suffix.len;
-            if (total <= expected.len) {
-                @memcpy(expected[0..prefix.len], prefix);
-                @memcpy(expected[prefix.len..][0..ef.name_len], ef.name());
-                @memcpy(expected[prefix.len + ef.name_len ..][0..suffix.len], suffix);
-                if (std.mem.eql(u8, path, expected[0..total])) return ef.content();
-            }
-        }
-        return null;
-    }
-
-    /// Check if `path` is one of the synthetic/embedded paths.
-    fn isSyntheticPath(self: *const @This(), path: []const u8) bool {
-        return self.getSyntheticContent(path) != null;
-    }
-};
-
-fn echoGetCtx(ctx_ptr: ?*anyopaque) *EchoCtx {
-    return @ptrCast(@alignCast(ctx_ptr.?));
-}
-
-fn echoReadFile(ctx_ptr: ?*anyopaque, path: []const u8, gpa: Allocator) Io.ReadError![]u8 {
-    const self = echoGetCtx(ctx_ptr);
-    if (self.getSyntheticContent(path)) |content|
-        return gpa.dupe(u8, content) catch return error.OutOfMemory;
-    return self.fallback.readFile(path, gpa);
-}
-
-fn echoFileExists(ctx_ptr: ?*anyopaque, path: []const u8) bool {
-    const self = echoGetCtx(ctx_ptr);
-    if (self.isSyntheticPath(path)) return true;
-    return self.fallback.fileExists(path);
-}
-
-fn echoReadFileInto(ctx_ptr: ?*anyopaque, path: []const u8, buf: []u8) Io.ReadError!usize {
-    return echoGetCtx(ctx_ptr).fallback.readFileInto(path, buf);
-}
-fn echoWriteFile(ctx_ptr: ?*anyopaque, path: []const u8, data: []const u8) Io.WriteError!void {
-    return echoGetCtx(ctx_ptr).fallback.writeFile(path, data);
-}
-fn echoStat(ctx_ptr: ?*anyopaque, path: []const u8) Io.StatError!Io.FileInfo {
-    return echoGetCtx(ctx_ptr).fallback.stat(path);
-}
-fn echoListDir(ctx_ptr: ?*anyopaque, path: []const u8, gpa: Allocator) Io.ListError![]Io.FileEntry {
-    return echoGetCtx(ctx_ptr).fallback.listDir(path, gpa);
-}
-fn echoDirName(ctx_ptr: ?*anyopaque, path: []const u8) ?[]const u8 {
-    return echoGetCtx(ctx_ptr).fallback.dirName(path);
-}
-fn echoBaseName(ctx_ptr: ?*anyopaque, path: []const u8) []const u8 {
-    return echoGetCtx(ctx_ptr).fallback.baseName(path);
-}
-fn echoJoinPath(ctx_ptr: ?*anyopaque, parts: []const []const u8, gpa: Allocator) Allocator.Error![]const u8 {
-    return echoGetCtx(ctx_ptr).fallback.joinPath(parts, gpa);
-}
-fn echoCanonicalize(ctx_ptr: ?*anyopaque, path: []const u8, gpa: Allocator) Io.CanonicalizeError![]const u8 {
-    return echoGetCtx(ctx_ptr).fallback.canonicalize(path, gpa);
-}
-fn echoMakePath(ctx_ptr: ?*anyopaque, path: []const u8) Io.MakePathError!void {
-    return echoGetCtx(ctx_ptr).fallback.makePath(path);
-}
-fn echoRename(ctx_ptr: ?*anyopaque, old: []const u8, new: []const u8) Io.RenameError!void {
-    return echoGetCtx(ctx_ptr).fallback.rename(old, new);
-}
-fn echoGetEnvVar(ctx_ptr: ?*anyopaque, key: []const u8, gpa: Allocator) Io.GetEnvVarError![]u8 {
-    return echoGetCtx(ctx_ptr).fallback.getEnvVar(key, gpa);
-}
-fn echoFetchUrl(ctx_ptr: ?*anyopaque, gpa: Allocator, url: []const u8, dest: []const u8) Io.FetchUrlError!void {
-    return echoGetCtx(ctx_ptr).fallback.fetchUrl(gpa, url, dest);
-}
-fn echoWriteStdout(ctx_ptr: ?*anyopaque, data: []const u8) Io.StdioError!void {
-    return echoGetCtx(ctx_ptr).fallback.writeStdout(data);
-}
-fn echoWriteStderr(ctx_ptr: ?*anyopaque, data: []const u8) Io.StdioError!void {
-    return echoGetCtx(ctx_ptr).fallback.writeStderr(data);
-}
-fn echoReadStdin(ctx_ptr: ?*anyopaque, buf: []u8) Io.StdioError!usize {
-    return echoGetCtx(ctx_ptr).fallback.readStdin(buf);
-}
-fn echoIsTty(ctx_ptr: ?*anyopaque) bool {
-    return echoGetCtx(ctx_ptr).fallback.isTty();
-}
-
-const echo_vtable = Io.VTable{
-    .readFile = &echoReadFile,
-    .readFileInto = &echoReadFileInto,
-    .writeFile = &echoWriteFile,
-    .fileExists = &echoFileExists,
-    .stat = &echoStat,
-    .listDir = &echoListDir,
-    .dirName = &echoDirName,
-    .baseName = &echoBaseName,
-    .joinPath = &echoJoinPath,
-    .canonicalize = &echoCanonicalize,
-    .makePath = &echoMakePath,
-    .rename = &echoRename,
-    .getEnvVar = &echoGetEnvVar,
-    .fetchUrl = &echoFetchUrl,
-    .writeStdout = &echoWriteStdout,
-    .writeStderr = &echoWriteStderr,
-    .readStdin = &echoReadStdin,
-    .isTty = &echoIsTty,
-};
 
 // --- Exported WASM API ---
 
@@ -342,15 +130,15 @@ export fn addFile(
     content_len: usize,
 ) u8 {
     if (extra_file_count >= MAX_FILES) {
-        jsErr("addFile: too many files (max 16)");
+        jsWrite(null, "addFile: too many files (max 16)\n");
         return 1;
     }
     if (name_len > MAX_NAME_LEN) {
-        jsErr("addFile: module name too long (max 256 bytes)");
+        jsWrite(null, "addFile: module name too long (max 256 bytes)\n");
         return 2;
     }
     if (content_len > MAX_CONTENT_LEN) {
-        jsErr("addFile: module content too long (max 64KB)");
+        jsWrite(null, "addFile: module content too long (max 64KB)\n");
         return 3;
     }
 
@@ -386,62 +174,25 @@ fn compileAndRunInner(source: []const u8) !u8 {
     fba.reset();
     allocator = fba.allocator();
 
-    const app_abs_path = "/app/main.roc";
-    const platform_main_path = "/app/.roc_echo_platform/main.roc";
-    const echo_module_path = "/app/.roc_echo_platform/Echo.roc";
+    // Build the extras slice in the FBA-backed allocator.
+    var extras = try allocator.alloc(ExtraFile, extra_file_count);
+    defer allocator.free(extras);
+    for (extra_files[0..extra_file_count], 0..) |*slot, i| {
+        extras[i] = .{ .name = slot.name(), .content = slot.content() };
+    }
 
-    const header =
-        "app [main!] { pf: platform \"./.roc_echo_platform/main.roc\" }\n\n" ++
-        "import pf.Echo\n\n";
-    const footer =
-        "\n\necho! = |msg| Echo.line!(msg)\n";
-    const synthetic_source = try std.mem.concat(allocator, u8, &.{ header, source, footer });
+    // Synthetic app source must be set on the WasmFilesystem so it shares
+    // the filename mapping; runner.runEcho generates it and passes it back
+    // through the Io vtable for any internal reads it triggers.
+    wasm_ctx.setFilename(allocator, "/app/main.roc");
+    // The runner writes the synthetic source itself via EchoCtx — the wasm
+    // fallback's setSource is only consulted for non-synthetic paths.
 
-    wasm_ctx.setFilename(allocator, app_abs_path);
-    wasm_ctx.setSource(allocator, synthetic_source);
-
-    var echo_ctx = EchoCtx{
-        .app_abs_path = app_abs_path,
-        .synthetic_app_source = synthetic_source,
-        .platform_main_path = platform_main_path,
-        .echo_module_path = echo_module_path,
-        .fallback = WasmFilesystem.wasm(&wasm_ctx),
-    };
-
-    var build_env = try BuildEnv.init(allocator, .single_threaded, 1, RocTarget.wasm32, "/app");
-    defer build_env.deinit();
-    build_env.filesystem = echo_ctx.io();
-
-    build_env.discoverDependencies(app_abs_path) catch |err| {
-        emitDiagnostics(&build_env);
-        return err;
-    };
-    build_env.compileDiscovered() catch |err| {
-        emitDiagnostics(&build_env);
-        return err;
-    };
-
-    emitDiagnostics(&build_env);
-
-    const root_artifact = build_env.executableRootCheckedArtifact();
-
-    const import_views = try build_env.collectImportedArtifactViews(allocator, root_artifact);
-    defer allocator.free(import_views);
-    const relation_views = try build_env.collectRelationArtifactViews(allocator, root_artifact);
-    defer allocator.free(relation_views);
-
-    var lowered = try lir.CheckedPipeline.lowerArtifactsToLir(
-        allocator,
-        .{
-            .root = check.CheckedArtifact.loweringViewWithRelations(root_artifact, relation_views),
-            .imports = import_views,
-        },
-        .{ .requests = root_artifact.root_requests.requests },
-        .{
-            .target_usize = base.target.TargetUsize.u32,
-        },
-    );
-    defer lowered.deinit();
-
-    return try runEchoLir(&lowered);
+    return runner.runEcho(.{
+        .runtime_fba = &fba,
+        .fallback_io = WasmFilesystem.wasm(&wasm_ctx),
+        .source = source,
+        .extras = extras,
+        .diagnostics = jsDiagnostics(),
+    });
 }

--- a/src/echo_platform/echo_native.zig
+++ b/src/echo_platform/echo_native.zig
@@ -1,0 +1,132 @@
+//! Native CLI for the echo platform — reproduces the WASM `compileAndRun`
+//! flow with real stack traces. Use this to debug pipeline failures that
+//! surface as silent exit-255s in the browser.
+//!
+//! Usage:
+//!   echo_native <path/to/app.roc> [--with-file Name=path/to/Module.roc] ...
+//!
+//! The file at `<path/to/app.roc>` is the headerless body; the runner wraps
+//! it in an `app [main!]` header that imports the embedded echo platform.
+
+const std = @import("std");
+const compile = @import("compile");
+const reporting = @import("reporting");
+const roc_target = @import("roc_target");
+const runner = @import("runner.zig");
+
+const Allocator = std.mem.Allocator;
+const Diagnostics = runner.Diagnostics;
+const ExtraFile = runner.ExtraFile;
+
+const Io = compile.Io;
+
+// --- Diagnostics: write to real stderr ---
+
+fn stderrWrite(_: ?*anyopaque, msg: []const u8) void {
+    std.fs.File.stderr().writeAll(msg) catch {};
+}
+
+fn stderrEmitReport(_: ?*anyopaque, gpa: Allocator, report: *reporting.Report) void {
+    var diag_writer: std.Io.Writer.Allocating = .init(gpa);
+    defer diag_writer.deinit();
+    reporting.renderReport(report, &diag_writer.writer, .color_terminal) catch return;
+    const output = diag_writer.written();
+    if (output.len > 0) {
+        std.fs.File.stderr().writeAll(output) catch {};
+    }
+}
+
+const stderr_diagnostics_vtable = Diagnostics.VTable{
+    .write = &stderrWrite,
+    .emitReport = &stderrEmitReport,
+};
+
+fn stderrDiagnostics() Diagnostics {
+    return .{ .ctx = null, .vtable = &stderr_diagnostics_vtable };
+}
+
+// --- CLI ---
+
+fn printUsageAndExit() noreturn {
+    const msg =
+        \\Usage: echo_native <path/to/app.roc> [--with-file Name=path/to/Module.roc]...
+        \\
+        \\Compiles & runs a headerless Roc app through the echo platform pipeline.
+        \\Each --with-file registers an extra module accessible as `import Name`.
+        \\
+    ;
+    std.fs.File.stderr().writeAll(msg) catch {};
+    std.process.exit(2);
+}
+
+pub fn main() !void {
+    var gpa_impl: std.heap.GeneralPurposeAllocator(.{}) = .init;
+    defer _ = gpa_impl.deinit();
+    const gpa = gpa_impl.allocator();
+
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const args = try std.process.argsAlloc(arena);
+    if (args.len < 2) printUsageAndExit();
+
+    const app_path = args[1];
+
+    var extras = std.ArrayList(ExtraFile).empty;
+    defer extras.deinit(arena);
+
+    var i: usize = 2;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+        if (!std.mem.eql(u8, arg, "--with-file")) {
+            std.fs.File.stderr().writeAll("unknown argument: ") catch {};
+            std.fs.File.stderr().writeAll(arg) catch {};
+            std.fs.File.stderr().writeAll("\n") catch {};
+            printUsageAndExit();
+        }
+        i += 1;
+        if (i >= args.len) printUsageAndExit();
+        const spec = args[i];
+        const eq = std.mem.indexOfScalar(u8, spec, '=') orelse {
+            std.fs.File.stderr().writeAll("--with-file value must be Name=path\n") catch {};
+            std.process.exit(2);
+        };
+        const name = spec[0..eq];
+        const path = spec[eq + 1 ..];
+        const content = try std.fs.cwd().readFileAlloc(arena, path, std.math.maxInt(usize));
+        try extras.append(arena, .{ .name = name, .content = content });
+    }
+
+    const source = try std.fs.cwd().readFileAlloc(arena, app_path, std.math.maxInt(usize));
+
+    // Use a 128 MiB FBA so the pipeline behaves like the wasm case (single
+    // contiguous heap) — this is also what the runtime-image migration in
+    // Phase 3 will require.
+    const RUNTIME_BUFFER_SIZE: usize = 128 * 1024 * 1024;
+    const runtime_buffer = try gpa.alignedAlloc(u8, .@"16", RUNTIME_BUFFER_SIZE);
+    defer gpa.free(runtime_buffer);
+    var runtime_fba = std.heap.FixedBufferAllocator.init(runtime_buffer);
+
+    // ECHO_NATIVE_TARGET env var: "native" (default), "wasm32" — cross-compile
+    // through the same target_usize=.u32 path the wasm uses, while still
+    // running the interpreter natively. Useful to isolate wasm-runtime bugs
+    // from wasm32-target compilation bugs.
+    const target_choice = std.posix.getenv("ECHO_NATIVE_TARGET") orelse "native";
+    const is_wasm_target = std.mem.eql(u8, target_choice, "wasm32");
+
+    const code = runner.runEcho(.{
+        .runtime_fba = &runtime_fba,
+        .fallback_io = Io.default(),
+        .source = source,
+        .extras = extras.items,
+        .diagnostics = stderrDiagnostics(),
+        .roc_target = if (is_wasm_target) .wasm32 else roc_target.RocTarget.detectNative(),
+        .target_usize = if (is_wasm_target) .u32 else .native,
+    }) catch |err| {
+        std.fs.File.stderr().writeAll("echo_native: pipeline returned error\n") catch {};
+        return err;
+    };
+
+    std.process.exit(code);
+}

--- a/src/echo_platform/echo_native.zig
+++ b/src/echo_platform/echo_native.zig
@@ -59,6 +59,9 @@ fn printUsageAndExit() noreturn {
     std.process.exit(2);
 }
 
+/// CLI entry point. Parses argv, reads the app source (and any
+/// `--with-file` modules), then drives `runner.runEcho` against a
+/// 128 MiB FixedBufferAllocator. Exits with the Roc program's exit code.
 pub fn main() !void {
     var gpa_impl: std.heap.GeneralPurposeAllocator(.{}) = .init;
     defer _ = gpa_impl.deinit();

--- a/src/echo_platform/runner.zig
+++ b/src/echo_platform/runner.zig
@@ -1,0 +1,408 @@
+//! Shared compile-and-run pipeline for the echo platform.
+//!
+//! Both the wasm export (`echo.zig`) and the native CLI (`echo_native.zig`)
+//! drive this function. Keeping the pipeline in one place means a native
+//! reproduction with a real stack trace exercises identical code to the
+//! browser path.
+
+const std = @import("std");
+const base = @import("base");
+const check = @import("check");
+const compile = @import("compile");
+const echo_platform = @import("echo_platform");
+const eval = @import("eval");
+const lir = @import("lir");
+const roc_target = @import("roc_target");
+const reporting = @import("reporting");
+
+const Allocator = std.mem.Allocator;
+const BuildEnv = compile.BuildEnv;
+const Io = compile.Io;
+const RocTarget = roc_target.RocTarget;
+const HostedFn = echo_platform.host_abi.HostedFn;
+
+/// Diagnostic-emission interface. The wasm host renders HTML to `js_stderr`;
+/// the native host renders plain text to its real stderr.
+pub const Diagnostics = struct {
+    ctx: ?*anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        /// Emit a free-form message (e.g. "echo: step 'X' failed: Y").
+        write: *const fn (ctx: ?*anyopaque, msg: []const u8) void,
+        /// Render & emit a single compiler Report.
+        emitReport: *const fn (ctx: ?*anyopaque, gpa: Allocator, report: *reporting.Report) void,
+    };
+
+    pub fn write(self: Diagnostics, msg: []const u8) void {
+        self.vtable.write(self.ctx, msg);
+    }
+
+    pub fn emitReport(self: Diagnostics, gpa: Allocator, report: *reporting.Report) void {
+        self.vtable.emitReport(self.ctx, gpa, report);
+    }
+
+    /// Format a labelled step-failure message and emit it.
+    pub fn step(self: Diagnostics, comptime label: []const u8, err: anyerror) void {
+        var buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "echo: step '" ++ label ++ "' failed: {s}\n", .{@errorName(err)}) catch {
+            self.write("echo: step '" ++ label ++ "' failed (and message formatting failed)\n");
+            return;
+        };
+        self.write(msg);
+    }
+};
+
+/// A user-supplied module file (e.g. `Greeting.roc`).
+pub const ExtraFile = struct {
+    name: []const u8,
+    content: []const u8,
+};
+
+/// Caller-controlled paths for the synthetic app & embedded platform files.
+/// Both the wasm and native flows generate a synthetic app whose `app [main!]`
+/// header references these paths.
+pub const Paths = struct {
+    app_abs: []const u8 = "/app/main.roc",
+    platform_main: []const u8 = "/app/.roc_echo_platform/main.roc",
+    echo_module: []const u8 = "/app/.roc_echo_platform/Echo.roc",
+    cwd: []const u8 = "/app",
+    /// Prefix prepended to extra-file paths so `addFile("Greeting", ...)`
+    /// resolves as `<extras_prefix>Greeting.roc`. Must end with `/`.
+    extras_prefix: []const u8 = "/app/",
+};
+
+pub const RunOptions = struct {
+    /// Single contiguous arena used for the entire pipeline (BuildEnv,
+    /// lowering, runtime image, interpreter). Must own a flat virtual
+    /// region — `std.heap.ArenaAllocator` will not work because the
+    /// runtime-image step computes offsets via `ptr - base_ptr` arithmetic
+    /// (see `src/compile/README.md` "Runtime arena").
+    runtime_fba: *std.heap.FixedBufferAllocator,
+    /// Fallback Io that handles everything not served by EchoCtx (i.e. paths
+    /// not in `Paths` and not in `extras`).
+    fallback_io: Io,
+    /// The headerless user source (the body of the synthetic app).
+    source: []const u8,
+    /// Extra user-supplied modules, available as `import <name>`.
+    extras: []const ExtraFile,
+    /// Where to send diagnostics.
+    diagnostics: Diagnostics,
+    /// Filesystem paths used by the synthetic app + embedded platform.
+    paths: Paths = .{},
+    /// Target word width. `.u32` for wasm32 builds.
+    target_usize: base.target.TargetUsize = .u32,
+    /// Roc compilation target.
+    roc_target: RocTarget = .wasm32,
+};
+
+/// Compile and execute a headerless Roc source through the echo platform.
+///
+/// Wraps the user `source` in a synthetic `app [main!]` header that imports
+/// the embedded echo platform, then walks the canonical embedding sequence
+/// (see `src/compile/README.md`): BuildEnv discovery → check → LIR lowering
+/// → `RuntimeImage.fillHeaderInBuffer` → `viewMappedImage` →
+/// `LirInterpreter.runEntrypoint`.
+///
+/// Returns the Roc program's exit code (or 1 if an inline `expect` failed
+/// while the program otherwise returned 0). On compilation/runtime error,
+/// emits a labelled diagnostic through `opts.diagnostics` and propagates
+/// the error so the caller can decide on an exit code.
+pub fn runEcho(opts: RunOptions) !u8 {
+    const allocator = opts.runtime_fba.allocator();
+    const diag = opts.diagnostics;
+
+    const header_str =
+        "app [main!] { pf: platform \"./.roc_echo_platform/main.roc\" }\n\n" ++
+        "import pf.Echo\n\n";
+    const footer_str =
+        "\n\necho! = |msg| Echo.line!(msg)\n";
+
+    const synthetic_source = std.mem.concat(allocator, u8, &.{ header_str, opts.source, footer_str }) catch |err| {
+        diag.step("std.mem.concat (synthetic source)", err);
+        return err;
+    };
+
+    var echo_ctx = EchoCtx{
+        .paths = opts.paths,
+        .synthetic_app_source = synthetic_source,
+        .extras = opts.extras,
+        .fallback = opts.fallback_io,
+    };
+
+    var build_env = BuildEnv.init(allocator, .single_threaded, 1, opts.roc_target, opts.paths.cwd) catch |err| {
+        diag.step("BuildEnv.init", err);
+        return err;
+    };
+    defer build_env.deinit();
+    build_env.filesystem = echo_ctx.io();
+
+    build_env.discoverDependencies(opts.paths.app_abs) catch |err| {
+        emitDiagnostics(&build_env, diag, allocator);
+        diag.step("discoverDependencies", err);
+        return err;
+    };
+    build_env.compileDiscovered() catch |err| {
+        emitDiagnostics(&build_env, diag, allocator);
+        diag.step("compileDiscovered", err);
+        return err;
+    };
+
+    emitDiagnostics(&build_env, diag, allocator);
+
+    const root_artifact = build_env.executableRootCheckedArtifact();
+
+    const import_views = build_env.collectImportedArtifactViews(allocator, root_artifact) catch |err| {
+        diag.step("collectImportedArtifactViews", err);
+        return err;
+    };
+    defer allocator.free(import_views);
+    const relation_views = build_env.collectRelationArtifactViews(allocator, root_artifact) catch |err| {
+        diag.step("collectRelationArtifactViews", err);
+        return err;
+    };
+    defer allocator.free(relation_views);
+
+    var lowered = lir.CheckedPipeline.lowerArtifactsToLir(
+        allocator,
+        .{
+            .root = check.CheckedArtifact.loweringViewWithRelations(root_artifact, relation_views),
+            .imports = import_views,
+        },
+        .{ .requests = root_artifact.root_requests.requests },
+        .{ .target_usize = opts.target_usize },
+    ) catch |err| {
+        diag.step("lowerArtifactsToLir", err);
+        return err;
+    };
+    defer lowered.deinit();
+
+    // Canonical embedding sequence: build entrypoints + runtime image, then
+    // view it and execute via runEntrypoint. The viewMappedImage step
+    // re-constructs the layout Store with the correct target_usize, which
+    // matters for cross-compile cases.
+    const entrypoints = lowered.platformEntrypoints(allocator) catch |err| {
+        diag.step("platformEntrypoints", err);
+        return err;
+    };
+
+    const runtime_header = allocator.create(lir.RuntimeImage.Header) catch |err| {
+        diag.step("create RuntimeImage.Header", err);
+        return err;
+    };
+    lir.RuntimeImage.fillHeaderInBuffer(
+        runtime_header,
+        opts.runtime_fba.buffer.ptr,
+        opts.runtime_fba.end_index,
+        &lowered.lir_result,
+        lowered.target_usize,
+        entrypoints,
+    ) catch |err| {
+        diag.step("RuntimeImage.fillHeaderInBuffer", err);
+        return err;
+    };
+
+    const view = lir.RuntimeImage.viewMappedImage(
+        runtime_header,
+        opts.runtime_fba.buffer.ptr,
+        opts.runtime_fba.end_index,
+    ) catch |err| {
+        diag.step("RuntimeImage.viewMappedImage", err);
+        return err;
+    };
+
+    return runEchoView(allocator, &view, diag) catch |err| {
+        diag.step("runEchoView", err);
+        return err;
+    };
+}
+
+fn runEchoView(
+    allocator: Allocator,
+    view: *const lir.RuntimeImage.ProgramView,
+    diag: Diagnostics,
+) !u8 {
+    // HostedFn array order matters: the interpreter calls
+    // `roc_ops.hosted_fns.fns[dispatch_index]`. Dispatch indices are sorted
+    // alphabetically by fully-qualified `Module.fn_name` (with trailing `!`
+    // stripped). The echo platform has only `Echo.line`, so order is
+    // trivially correct — but additions must respect alphabetical order or
+    // the wrong function will be called silently. See README "Host functions".
+    var hosted_fn_array = [_]HostedFn{echo_platform.host_abi.hostedFn(&echo_platform.echoHostedFn)};
+    var default_roc_ops_env: echo_platform.DefaultRocOpsEnv = .{};
+    var roc_ops = echo_platform.makeDefaultRocOps(&default_roc_ops_env, &hosted_fn_array);
+    var cli_args_list = echo_platform.buildCliArgs(&.{}, &roc_ops);
+    var result_buf: [16]u8 align(16) = undefined;
+
+    var interpreter = eval.LirInterpreter.init(
+        allocator,
+        &view.store,
+        &view.layouts,
+        &roc_ops,
+    ) catch |err| {
+        diag.step("LirInterpreter.init", err);
+        return err;
+    };
+    defer interpreter.deinit();
+
+    _ = interpreter.runEntrypoint(view, 0, @ptrCast(&cli_args_list), @ptrCast(&result_buf)) catch |err| switch (err) {
+        error.RuntimeError, error.DivisionByZero => {
+            if (interpreter.getRuntimeErrorMessage()) |msg| diag.write(msg);
+            diag.step("interpreter.runEntrypoint", err);
+            return error.EvaluationFailed;
+        },
+        error.Crash => {
+            diag.step("interpreter.runEntrypoint", err);
+            return error.EvaluationFailed;
+        },
+        error.OutOfMemory => {
+            diag.step("interpreter.runEntrypoint", err);
+            return error.OutOfMemory;
+        },
+        error.EntrypointNotFound => {
+            diag.step("interpreter.runEntrypoint", err);
+            return err;
+        },
+    };
+
+    if (default_roc_ops_env.inline_expect_failed) return 1;
+    return result_buf[0];
+}
+
+fn emitDiagnostics(build_env: *BuildEnv, diag: Diagnostics, gpa: Allocator) void {
+    const drained = build_env.drainReports() catch return;
+    defer build_env.freeDrainedReports(drained);
+
+    for (drained) |mod| {
+        for (mod.reports) |*report| {
+            diag.emitReport(gpa, report);
+        }
+    }
+}
+
+// --- Echo I/O context ---
+
+/// Unified I/O context for the echo platform. Intercepts readFile/fileExists
+/// for synthetic app source, embedded platform files, and extras; delegates
+/// everything else to `fallback`.
+pub const EchoCtx = struct {
+    paths: Paths,
+    synthetic_app_source: []const u8,
+    extras: []const ExtraFile,
+    fallback: Io,
+
+    pub fn io(self: *EchoCtx) Io {
+        return .{ .ctx = @ptrCast(self), .vtable = echo_vtable };
+    }
+
+    /// Return the content for a synthetic/embedded path, or null if not synthetic.
+    pub fn getSyntheticContent(self: *const EchoCtx, path: []const u8) ?[]const u8 {
+        if (std.mem.eql(u8, path, self.paths.app_abs)) return self.synthetic_app_source;
+        if (std.mem.eql(u8, path, self.paths.platform_main)) return echo_platform.platform_main_source;
+        if (std.mem.eql(u8, path, self.paths.echo_module)) return echo_platform.echo_module_source;
+        for (self.extras) |ef| {
+            if (matchesExtra(self.paths.extras_prefix, ef.name, path)) return ef.content;
+        }
+        return null;
+    }
+
+    /// Check if `path` is one of the synthetic/embedded paths.
+    pub fn isSyntheticPath(self: *const EchoCtx, path: []const u8) bool {
+        return self.getSyntheticContent(path) != null;
+    }
+};
+
+fn matchesExtra(prefix: []const u8, name: []const u8, path: []const u8) bool {
+    const suffix = ".roc";
+    if (path.len != prefix.len + name.len + suffix.len) return false;
+    if (!std.mem.startsWith(u8, path, prefix)) return false;
+    if (!std.mem.eql(u8, path[prefix.len..][0..name.len], name)) return false;
+    return std.mem.eql(u8, path[prefix.len + name.len ..][0..suffix.len], suffix);
+}
+
+fn echoGetCtx(ctx_ptr: ?*anyopaque) *EchoCtx {
+    return @ptrCast(@alignCast(ctx_ptr.?));
+}
+
+fn echoReadFile(ctx_ptr: ?*anyopaque, path: []const u8, gpa: Allocator) Io.ReadError![]u8 {
+    const self = echoGetCtx(ctx_ptr);
+    if (self.getSyntheticContent(path)) |content|
+        return gpa.dupe(u8, content) catch return error.OutOfMemory;
+    return self.fallback.readFile(path, gpa);
+}
+
+fn echoFileExists(ctx_ptr: ?*anyopaque, path: []const u8) bool {
+    const self = echoGetCtx(ctx_ptr);
+    if (self.isSyntheticPath(path)) return true;
+    return self.fallback.fileExists(path);
+}
+
+fn echoReadFileInto(ctx_ptr: ?*anyopaque, path: []const u8, buf: []u8) Io.ReadError!usize {
+    return echoGetCtx(ctx_ptr).fallback.readFileInto(path, buf);
+}
+fn echoWriteFile(ctx_ptr: ?*anyopaque, path: []const u8, data: []const u8) Io.WriteError!void {
+    return echoGetCtx(ctx_ptr).fallback.writeFile(path, data);
+}
+fn echoStat(ctx_ptr: ?*anyopaque, path: []const u8) Io.StatError!Io.FileInfo {
+    return echoGetCtx(ctx_ptr).fallback.stat(path);
+}
+fn echoListDir(ctx_ptr: ?*anyopaque, path: []const u8, gpa: Allocator) Io.ListError![]Io.FileEntry {
+    return echoGetCtx(ctx_ptr).fallback.listDir(path, gpa);
+}
+fn echoDirName(ctx_ptr: ?*anyopaque, path: []const u8) ?[]const u8 {
+    return echoGetCtx(ctx_ptr).fallback.dirName(path);
+}
+fn echoBaseName(ctx_ptr: ?*anyopaque, path: []const u8) []const u8 {
+    return echoGetCtx(ctx_ptr).fallback.baseName(path);
+}
+fn echoJoinPath(ctx_ptr: ?*anyopaque, parts: []const []const u8, gpa: Allocator) Allocator.Error![]const u8 {
+    return echoGetCtx(ctx_ptr).fallback.joinPath(parts, gpa);
+}
+fn echoCanonicalize(ctx_ptr: ?*anyopaque, path: []const u8, gpa: Allocator) Io.CanonicalizeError![]const u8 {
+    return echoGetCtx(ctx_ptr).fallback.canonicalize(path, gpa);
+}
+fn echoMakePath(ctx_ptr: ?*anyopaque, path: []const u8) Io.MakePathError!void {
+    return echoGetCtx(ctx_ptr).fallback.makePath(path);
+}
+fn echoRename(ctx_ptr: ?*anyopaque, old: []const u8, new: []const u8) Io.RenameError!void {
+    return echoGetCtx(ctx_ptr).fallback.rename(old, new);
+}
+fn echoGetEnvVar(ctx_ptr: ?*anyopaque, key: []const u8, gpa: Allocator) Io.GetEnvVarError![]u8 {
+    return echoGetCtx(ctx_ptr).fallback.getEnvVar(key, gpa);
+}
+fn echoFetchUrl(ctx_ptr: ?*anyopaque, gpa: Allocator, url: []const u8, dest: []const u8) Io.FetchUrlError!void {
+    return echoGetCtx(ctx_ptr).fallback.fetchUrl(gpa, url, dest);
+}
+fn echoWriteStdout(ctx_ptr: ?*anyopaque, data: []const u8) Io.StdioError!void {
+    return echoGetCtx(ctx_ptr).fallback.writeStdout(data);
+}
+fn echoWriteStderr(ctx_ptr: ?*anyopaque, data: []const u8) Io.StdioError!void {
+    return echoGetCtx(ctx_ptr).fallback.writeStderr(data);
+}
+fn echoReadStdin(ctx_ptr: ?*anyopaque, buf: []u8) Io.StdioError!usize {
+    return echoGetCtx(ctx_ptr).fallback.readStdin(buf);
+}
+fn echoIsTty(ctx_ptr: ?*anyopaque) bool {
+    return echoGetCtx(ctx_ptr).fallback.isTty();
+}
+
+const echo_vtable = Io.VTable{
+    .readFile = &echoReadFile,
+    .readFileInto = &echoReadFileInto,
+    .writeFile = &echoWriteFile,
+    .fileExists = &echoFileExists,
+    .stat = &echoStat,
+    .listDir = &echoListDir,
+    .dirName = &echoDirName,
+    .baseName = &echoBaseName,
+    .joinPath = &echoJoinPath,
+    .canonicalize = &echoCanonicalize,
+    .makePath = &echoMakePath,
+    .rename = &echoRename,
+    .getEnvVar = &echoGetEnvVar,
+    .fetchUrl = &echoFetchUrl,
+    .writeStdout = &echoWriteStdout,
+    .writeStderr = &echoWriteStderr,
+    .readStdin = &echoReadStdin,
+    .isTty = &echoIsTty,
+};

--- a/src/echo_platform/runner.zig
+++ b/src/echo_platform/runner.zig
@@ -72,6 +72,7 @@ pub const Paths = struct {
     extras_prefix: []const u8 = "/app/",
 };
 
+/// Inputs to `runEcho`. See field doc comments for the contract on each.
 pub const RunOptions = struct {
     /// Single contiguous arena used for the entire pipeline (BuildEnv,
     /// lowering, runtime image, interpreter). Must own a flat virtual

--- a/src/echo_platform/runner.zig
+++ b/src/echo_platform/runner.zig
@@ -139,19 +139,36 @@ pub fn runEcho(opts: RunOptions) !u8 {
     build_env.filesystem = echo_ctx.io();
 
     build_env.discoverDependencies(opts.paths.app_abs) catch |err| {
-        emitDiagnostics(&build_env, diag, allocator);
+        _ = emitDiagnostics(&build_env, diag, allocator);
         diag.step("discoverDependencies", err);
         return err;
     };
     build_env.compileDiscovered() catch |err| {
-        emitDiagnostics(&build_env, diag, allocator);
+        _ = emitDiagnostics(&build_env, diag, allocator);
         diag.step("compileDiscovered", err);
         return err;
     };
 
-    emitDiagnostics(&build_env, diag, allocator);
+    // Bail before lowering if canonicalization or type-checking produced
+    // blocking-severity reports (e.g. `module_not_found`, `undefined_variable`).
+    // The CIR contains runtime_error placeholder nodes in that state, and
+    // mono lowering asserts they don't appear as runtime values — proceeding
+    // would trap. The reports themselves are the user-facing output.
+    if (emitDiagnostics(&build_env, diag, allocator)) {
+        return error.CompilationFailed;
+    }
 
-    const root_artifact = build_env.executableRootCheckedArtifact();
+    // Defense in depth: even with no blocking reports, the artifact may be
+    // missing in some unexpected state. Bail cleanly instead of trapping in
+    // the asserting variant (compile_build.zig:executableRootCheckedArtifact).
+    const root_semantic = build_env.getExecutableRootSemanticData() orelse {
+        diag.step("executableRootCheckedArtifact", error.CompilationFailed);
+        return error.CompilationFailed;
+    };
+    const root_artifact = root_semantic.checked_artifact orelse {
+        diag.step("executableRootCheckedArtifact", error.CompilationFailed);
+        return error.CompilationFailed;
+    };
 
     const import_views = build_env.collectImportedArtifactViews(allocator, root_artifact) catch |err| {
         diag.step("collectImportedArtifactViews", err);
@@ -270,15 +287,23 @@ fn runEchoView(
     return result_buf[0];
 }
 
-fn emitDiagnostics(build_env: *BuildEnv, diag: Diagnostics, gpa: Allocator) void {
-    const drained = build_env.drainReports() catch return;
+/// Drain BuildEnv reports through `diag` and return true if any
+/// had `runtime_error` or `fatal` severity (i.e. compile-blocking).
+fn emitDiagnostics(build_env: *BuildEnv, diag: Diagnostics, gpa: Allocator) bool {
+    const drained = build_env.drainReports() catch return false;
     defer build_env.freeDrainedReports(drained);
 
+    var has_blocking_error = false;
     for (drained) |mod| {
         for (mod.reports) |*report| {
+            switch (report.severity) {
+                .runtime_error, .fatal => has_blocking_error = true,
+                .info, .warning => {},
+            }
             diag.emitReport(gpa, report);
         }
     }
+    return has_blocking_error;
 }
 
 // --- Echo I/O context ---

--- a/src/echo_platform/www/app.js
+++ b/src/echo_platform/www/app.js
@@ -1,8 +1,12 @@
 let wasm;
+const MAX_MODULES = 16;
 const decoder = new TextDecoder();
 const encoder = new TextEncoder();
 const outputEl = document.getElementById("output");
 const errorsEl = document.getElementById("errors");
+const modulesListEl = document.getElementById("modules-list");
+const addModuleBtn = document.getElementById("add-module");
+const moduleTemplate = document.getElementById("module-template");
 
 const importObject = {
   env: {
@@ -17,6 +21,27 @@ const importObject = {
   },
 };
 
+function appendTrapNotice(err) {
+  const div = document.createElement("div");
+  div.className = "report error";
+  const h = document.createElement("h1");
+  h.textContent = "Compiler crashed";
+  const p = document.createElement("pre");
+  p.textContent =
+    "The Roc compiler hit an unrecoverable error while compiling your code. " +
+    "This is a bug in Roc — please report it.\n\n" +
+    String(err);
+  div.appendChild(h);
+  div.appendChild(p);
+  errorsEl.appendChild(div);
+}
+
+async function reinstantiate() {
+  const instance = await WebAssembly.instantiate(wasm.module, importObject);
+  wasm = { module: wasm.module, instance };
+  wasm.instance.exports.init();
+}
+
 function wasmWrite(str) {
   const encoded = encoder.encode(str);
   const ptr = wasm.instance.exports.allocateBuffer(encoded.length);
@@ -25,19 +50,67 @@ function wasmWrite(str) {
   return { ptr, len: encoded.length };
 }
 
-function run() {
+function updateAddButton() {
+  addModuleBtn.disabled = modulesListEl.children.length >= MAX_MODULES;
+}
+
+function addModuleCard(name, content) {
+  if (modulesListEl.children.length >= MAX_MODULES) return null;
+  const card = moduleTemplate.content.firstElementChild.cloneNode(true);
+  card.querySelector(".module-name").value = name;
+  card.querySelector(".module-content").value = content;
+  card.querySelector(".remove").addEventListener("click", () => {
+    card.remove();
+    updateAddButton();
+  });
+  modulesListEl.appendChild(card);
+  updateAddButton();
+  return card;
+}
+
+function appendSkipNotice(msg) {
+  const div = document.createElement("div");
+  div.className = "skip-notice";
+  div.textContent = msg;
+  errorsEl.appendChild(div);
+}
+
+async function run() {
   outputEl.textContent = "";
   errorsEl.innerHTML = "";
-  wasm.instance.exports.init();
 
-  for (const ta of document.querySelectorAll("textarea[data-module]")) {
-    const n = wasmWrite(ta.dataset.module);
-    const c = wasmWrite(ta.value);
-    wasm.instance.exports.addFile(n.ptr, n.len, c.ptr, c.len);
+  let trapped = false;
+  let code = 255;
+  try {
+    wasm.instance.exports.init();
+
+    for (const card of modulesListEl.querySelectorAll(".module-card")) {
+      const name = card.querySelector(".module-name").value.trim();
+      const content = card.querySelector(".module-content").value;
+      if (!name) {
+        appendSkipNotice("Skipped a module with an empty name.");
+        continue;
+      }
+      const n = wasmWrite(name);
+      const c = wasmWrite(content);
+      wasm.instance.exports.addFile(n.ptr, n.len, c.ptr, c.len);
+    }
+
+    const s = wasmWrite(document.getElementById("source").value);
+    code = wasm.instance.exports.compileAndRun(s.ptr, s.len);
+  } catch (err) {
+    trapped = true;
+    appendTrapNotice(err);
   }
 
-  const s = wasmWrite(document.getElementById("source").value);
-  const code = wasm.instance.exports.compileAndRun(s.ptr, s.len);
+  if (trapped) {
+    try {
+      await reinstantiate();
+    } catch (err) {
+      appendTrapNotice(err);
+    }
+    return;
+  }
 
   if (code === 255 && !errorsEl.innerHTML) {
     errorsEl.textContent = "Compilation or execution failed";
@@ -45,6 +118,18 @@ function run() {
     outputEl.textContent += `Exit code: ${code}\n`;
   }
 }
+
+addModuleBtn.addEventListener("click", () => {
+  addModuleCard("", "");
+});
+
+addModuleCard(
+  "Greeting",
+  `Greeting := [].{
+    msg : Str
+    msg = "Hello from the Greeting module!"
+}`,
+);
 
 fetch("echo.wasm")
   .then((r) => WebAssembly.instantiateStreaming(r, importObject))

--- a/src/echo_platform/www/index.html
+++ b/src/echo_platform/www/index.html
@@ -1,48 +1,157 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Roc Echo Platform</title>
-  <style>
-    body { font-family: monospace; max-width: 720px; margin: 2em auto; }
-    .file { margin-bottom: 1em; }
-    .file label { display: block; font-weight: bold; margin-bottom: 0.25em; }
-    textarea { width: 100%; height: 8em; font-family: inherit; font-size: 14px; tab-size: 4; }
-    #output { background: #111; color: #0f0; padding: 1em; min-height: 2em; white-space: pre-wrap; }
-    #errors { padding: 0.5em 0; }
-    button { margin: 0.5em 0; padding: 0.4em 1.2em; font-size: 14px; }
-    .report { border-left: 3px solid #ccc; padding: 0.5em 1em; margin: 0.5em 0; font-size: 13px; }
-    .report.error { border-color: #e55; background: #fee; }
-    .report.warning { border-color: #ea0; background: #ffe; }
-    .report.info { border-color: #48f; background: #eef; }
-    .report h1 { font-size: 14px; margin: 0 0 0.25em; }
-    .report pre { margin: 0.25em 0; white-space: pre-wrap; }
-  </style>
-</head>
-<body>
-  <h1>Roc Echo Platform</h1>
+    <head>
+        <meta charset="UTF-8" />
+        <title>Roc Echo Platform</title>
+        <style>
+            body {
+                font-family: monospace;
+                max-width: 720px;
+                margin: 2em auto;
+                padding: 0 1em;
+            }
+            h1 {
+                margin: 0 0 1em;
+            }
+            h2 {
+                font-size: 1.1em;
+                margin: 1.5em 0 0.5em;
+            }
+            .card {
+                border: 1px solid #ddd;
+                border-radius: 4px;
+                padding: 0.75em;
+                margin-bottom: 0.75em;
+                background: #fafafa;
+            }
+            .card-header {
+                display: flex;
+                align-items: center;
+                gap: 0.5em;
+                margin-bottom: 0.4em;
+            }
+            .card-header label {
+                font-weight: bold;
+            }
+            .card-header input.module-name {
+                flex: 1;
+                font-family: inherit;
+                font-size: 14px;
+                padding: 0.2em 0.4em;
+            }
+            .card-header .remove {
+                padding: 0.2em 0.6em;
+                font-size: 12px;
+            }
+            textarea {
+                width: 100%;
+                height: 8em;
+                font-family: inherit;
+                font-size: 14px;
+                tab-size: 4;
+                box-sizing: border-box;
+            }
+            #source {
+                height: 10em;
+            }
+            #output {
+                background: #111;
+                color: #0f0;
+                padding: 1em;
+                min-height: 2em;
+                white-space: pre-wrap;
+            }
+            #errors {
+                padding: 0.5em 0;
+            }
+            button {
+                padding: 0.4em 1.2em;
+                font-size: 14px;
+            }
+            button:disabled {
+                opacity: 0.5;
+                cursor: not-allowed;
+            }
+            #run {
+                margin-top: 0.5em;
+            }
+            #add-module {
+                margin-bottom: 0.5em;
+            }
+            .report {
+                border-left: 3px solid #ccc;
+                padding: 0.5em 1em;
+                margin: 0.5em 0;
+                font-size: 13px;
+            }
+            .report.error {
+                border-color: #e55;
+                background: #fee;
+            }
+            .report.warning {
+                border-color: #ea0;
+                background: #ffe;
+            }
+            .report.info {
+                border-color: #48f;
+                background: #eef;
+            }
+            .report h1 {
+                font-size: 14px;
+                margin: 0 0 0.25em;
+            }
+            .report pre {
+                margin: 0.25em 0;
+                white-space: pre-wrap;
+            }
+            .skip-notice {
+                color: #a60;
+                font-size: 13px;
+                padding: 0.25em 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>Roc Echo Platform</h1>
 
-  <div class="file">
-    <label>Greeting.roc</label>
-    <textarea data-module="Greeting">Greeting := [].{
-    msg : Str
-    msg = "Hello from the Greeting module!"
-}</textarea>
-  </div>
-
-  <div class="file">
-    <label>main (headerless app)</label>
-    <textarea id="source">import Greeting
+        <section>
+            <h2>main (headerless app)</h2>
+            <textarea id="source">
+import Greeting
 
 main! = |_| {
     echo!(Greeting.msg)
     Ok({})
-}</textarea>
-  </div>
+}</textarea
+            >
+            <button id="run" disabled>Run</button>
+        </section>
 
-  <button id="run" disabled>Run</button>
-  <div id="errors"></div>
-  <pre id="output"></pre>
-  <script src="app.js"></script>
-</body>
+        <section>
+            <h2>Modules</h2>
+            <div id="modules-list"></div>
+            <button id="add-module">+ Add module</button>
+        </section>
+
+        <div id="errors"></div>
+        <pre id="output"></pre>
+
+        <template id="module-template">
+            <div class="card module-card">
+                <div class="card-header">
+                    <label>Name:</label>
+                    <input
+                        class="module-name"
+                        type="text"
+                        spellcheck="false"
+                        autocomplete="off"
+                    />
+                    <button class="remove" type="button">Remove</button>
+                </div>
+                <textarea class="module-content"></textarea>
+            </div>
+        </template>
+
+        <script src="app.js"></script>
+    </body>
 </html>

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -539,6 +539,44 @@ pub const Interpreter = struct {
         return args_buf;
     }
 
+    /// Look up the platform entrypoint by ordinal, build its argument layout
+    /// list from the proc spec, and run it with the RocOps bound at init.
+    ///
+    /// Returns `error.EntrypointNotFound` if no entrypoint matches `ordinal`.
+    /// Other errors come from `eval`.
+    pub fn runEntrypoint(
+        self: *LirInterpreter,
+        view: *const lir.RuntimeImage.ProgramView,
+        ordinal: u32,
+        arg_ptr: ?*anyopaque,
+        ret_ptr: ?*anyopaque,
+    ) (Error || error{EntrypointNotFound})!EvalResult {
+        var entrypoint: ?lir.RuntimeImage.PlatformEntrypoint = null;
+        for (view.platform_entrypoints) |candidate| {
+            if (candidate.ordinal == ordinal) {
+                entrypoint = candidate;
+                break;
+            }
+        }
+        const selected = entrypoint orelse return error.EntrypointNotFound;
+
+        const proc = view.store.getProcSpec(selected.root_proc);
+        const arg_ids = view.store.getLocalSpan(proc.args);
+        const arg_layouts = try self.allocator.alloc(layout_mod.Idx, arg_ids.len);
+        defer self.allocator.free(arg_layouts);
+        for (arg_ids, 0..) |local_id, i| {
+            arg_layouts[i] = view.store.locals.items[@intFromEnum(local_id)].layout_idx;
+        }
+
+        return self.eval(.{
+            .proc_id = selected.root_proc,
+            .arg_layouts = arg_layouts,
+            .ret_layout = proc.ret_layout,
+            .arg_ptr = arg_ptr,
+            .ret_ptr = ret_ptr,
+        });
+    }
+
     /// Evaluate a proc-root LIR program using the RocOps bound at initialization time.
     pub fn eval(self: *LirInterpreter, request: EvalRequest) Error!EvalResult {
         self.roc_env.resetForEval();

--- a/src/lir/checked_pipeline.zig
+++ b/src/lir/checked_pipeline.zig
@@ -14,6 +14,7 @@ const ir = @import("ir");
 const Arc = @import("arc.zig");
 const LowerIr = @import("lower_ir.zig");
 const LIR = @import("LIR.zig");
+const RuntimeImage = @import("runtime_image.zig");
 
 const Allocator = std.mem.Allocator;
 const checked_artifact = check.CheckedArtifact;
@@ -405,6 +406,86 @@ pub const LoweredProgram = struct {
         }
         self.runtime_value_schemas.deinit();
         self.lir_result.deinit();
+    }
+
+    /// Build the list of platform entrypoints in the order they appear in
+    /// `lir_result.root_procs`. An entrypoint is any root proc whose metadata
+    /// indicates `abi == .platform` or `exposure == .platform_required`.
+    /// Caller owns the returned slice.
+    pub fn platformEntrypoints(
+        self: *const LoweredProgram,
+        allocator: Allocator,
+    ) Allocator.Error![]RuntimeImage.PlatformEntrypoint {
+        const root_procs = self.lir_result.root_procs.items;
+        const root_metadata = self.lir_result.root_metadata.items;
+        if (root_procs.len != root_metadata.len) {
+            if (builtin.mode == .Debug) {
+                std.debug.panic(
+                    "checked pipeline invariant violated: root metadata mismatch roots={d} metadata={d}",
+                    .{ root_procs.len, root_metadata.len },
+                );
+            }
+            unreachable;
+        }
+
+        var entrypoints = std.ArrayList(RuntimeImage.PlatformEntrypoint).empty;
+        errdefer entrypoints.deinit(allocator);
+
+        for (root_procs, root_metadata) |root_proc, metadata| {
+            if (metadata.abi != .platform and metadata.exposure != .platform_required) continue;
+            try entrypoints.append(allocator, .{
+                .ordinal = @intCast(entrypoints.items.len),
+                .root_proc = root_proc,
+            });
+        }
+
+        return try entrypoints.toOwnedSlice(allocator);
+    }
+
+    /// Resolve the exported/required name for each platform entrypoint
+    /// produced by `platformEntrypoints`. Each returned string is duplicated
+    /// into `allocator` (caller owns).
+    pub fn platformEntrypointNames(
+        self: *const LoweredProgram,
+        allocator: Allocator,
+        root_artifact: *const checked_artifact.CheckedModuleArtifact,
+    ) Allocator.Error![]const []const u8 {
+        const root_procs = self.lir_result.root_procs.items;
+        const root_metadata = self.lir_result.root_metadata.items;
+        if (root_procs.len != root_metadata.len) {
+            if (builtin.mode == .Debug) {
+                std.debug.panic(
+                    "embedded build invariant violated: root metadata mismatch roots={d} metadata={d}",
+                    .{ root_procs.len, root_metadata.len },
+                );
+            }
+            unreachable;
+        }
+
+        var names = std.ArrayList([]const u8).empty;
+        errdefer {
+            for (names.items) |name| allocator.free(name);
+            names.deinit(allocator);
+        }
+
+        for (root_metadata) |metadata| {
+            if (metadata.abi != .platform and metadata.exposure != .platform_required) continue;
+            const root = root_artifact.lookupRootRequestByOrder(metadata.order) orelse {
+                if (builtin.mode == .Debug) {
+                    std.debug.panic("platform entrypoint invariant violated: missing root request order {d}", .{metadata.order});
+                }
+                unreachable;
+            };
+            const artifact_name = root_artifact.entrypointNameForRoot(root) orelse {
+                if (builtin.mode == .Debug) {
+                    std.debug.panic("platform entrypoint invariant violated: unresolved name for root kind {s}", .{@tagName(root.kind)});
+                }
+                unreachable;
+            };
+            try names.append(allocator, try allocator.dupe(u8, artifact_name));
+        }
+
+        return try names.toOwnedSlice(allocator);
     }
 };
 

--- a/src/lir/runtime_image.zig
+++ b/src/lir/runtime_image.zig
@@ -164,11 +164,16 @@ pub const LayoutStoreImage = extern struct {
     }
 };
 
-/// Fill the reserved runtime-image header in the existing shared-memory mapping.
+/// Fill the reserved runtime-image header in a contiguous buffer.
 ///
-/// `lowered` must already have been allocated with the shared-memory allocator
-/// associated with `base_ptr`; this function only installs offset metadata.
-pub fn fillHeaderInSharedMemory(
+/// `lowered` must already have been allocated from an allocator that owns
+/// the buffer at `base_ptr` (the buffer must contain every pointer reachable
+/// from `lowered`). This function only installs offset metadata — it does not
+/// copy data.
+///
+/// This is the IPC-agnostic variant. Use it for in-process embedders that
+/// place the runtime image in a plain arena instead of shared memory.
+pub fn fillHeaderInBuffer(
     header: *Header,
     base_ptr: [*]align(1) const u8,
     image_size: usize,
@@ -186,6 +191,23 @@ pub fn fillHeaderInSharedMemory(
         .store = try LirStoreImage.fromStore(base_ptr, image_size, &lowered.store),
         .layouts = try LayoutStoreImage.fromStore(base_ptr, image_size, &lowered.layouts),
     };
+}
+
+/// Fill the reserved runtime-image header in the existing shared-memory mapping.
+///
+/// `lowered` must already have been allocated with the shared-memory allocator
+/// associated with `base_ptr`; this function only installs offset metadata.
+///
+/// Thin wrapper over `fillHeaderInBuffer` — kept for naming clarity at IPC sites.
+pub fn fillHeaderInSharedMemory(
+    header: *Header,
+    base_ptr: [*]align(1) const u8,
+    image_size: usize,
+    lowered: *const LowerIr.Result,
+    target_usize: base.target.TargetUsize,
+    platform_entrypoints: []const PlatformEntrypoint,
+) ImageError!void {
+    return fillHeaderInBuffer(header, base_ptr, image_size, lowered, target_usize, platform_entrypoints);
 }
 
 /// View an ARC-inserted LIR program in place from mapped shared memory.

--- a/src/lir/runtime_image.zig
+++ b/src/lir/runtime_image.zig
@@ -210,8 +210,15 @@ pub fn fillHeaderInSharedMemory(
     return fillHeaderInBuffer(header, base_ptr, image_size, lowered, target_usize, platform_entrypoints);
 }
 
-/// View an ARC-inserted LIR program in place from mapped shared memory.
-pub fn viewMappedImage(header: *const Header, base_ptr: [*]align(1) u8, mapped_size: usize) ImageError!ProgramView {
+/// View an ARC-inserted LIR program in place from a mapped buffer.
+///
+/// The buffer is treated as read-only by the view — `LirStore` and
+/// `layout_mod.Store` are constructed with slices that the interpreter
+/// reads but never mutates. Accepting `const` here lets embedders that
+/// hold the buffer behind a `const` pointer (e.g. a `FixedBufferAllocator`
+/// backed by `gpa.alignedAlloc` whose owning slice is `const`) pass it
+/// directly without a manual `@constCast`.
+pub fn viewMappedImage(header: *const Header, base_ptr: [*]align(1) const u8, mapped_size: usize) ImageError!ProgramView {
     if (mapped_size < @sizeOf(Header)) return error.InvalidRuntimeImage;
 
     if (header.magic != MAGIC) return error.InvalidRuntimeImage;
@@ -224,11 +231,16 @@ pub fn viewMappedImage(header: *const Header, base_ptr: [*]align(1) u8, mapped_s
         else => return error.InvalidRuntimeImage,
     };
 
+    // The view path constructs mutable container types (LirStore, Store)
+    // whose slice fields are not const, even though the interpreter only
+    // reads them. Cast once at the boundary so callers don't have to.
+    const mutable_base: [*]align(1) u8 = @constCast(base_ptr);
+
     return .{
-        .store = try header.store.view(base_ptr, @intCast(header.image_size)),
-        .layouts = try header.layouts.view(base_ptr, @intCast(header.image_size), target_usize),
-        .root_procs = sliceFromRef(LIR.LirProcSpecId, base_ptr, @intCast(header.image_size), header.root_procs),
-        .platform_entrypoints = sliceFromRef(PlatformEntrypoint, base_ptr, @intCast(header.image_size), header.platform_entrypoints),
+        .store = try header.store.view(mutable_base, @intCast(header.image_size)),
+        .layouts = try header.layouts.view(mutable_base, @intCast(header.image_size), target_usize),
+        .root_procs = sliceFromRef(LIR.LirProcSpecId, mutable_base, @intCast(header.image_size), header.root_procs),
+        .platform_entrypoints = sliceFromRef(PlatformEntrypoint, mutable_base, @intCast(header.image_size), header.platform_entrypoints),
         .target_usize = target_usize,
     };
 }

--- a/test/echo-wasm-test/main.zig
+++ b/test/echo-wasm-test/main.zig
@@ -1,0 +1,195 @@
+//! Bytebox-driven integration test for echo.wasm.
+//!
+//! Loads zig-out/lib/echo.wasm via bytebox, supplies js_echo + js_stderr host
+//! functions that capture output into in-process buffers, and drives the
+//! exported API (init / allocateBuffer / addFile / compileAndRun) the same
+//! way `www/app.js` does. Validates that the tutorial example produces
+//! "Hello from the Greeting module!" as its single echo line.
+
+const std = @import("std");
+const bytebox = @import("bytebox");
+
+// Capture buffers shared with bytebox host functions via a CaptureCtx.
+const CaptureCtx = struct {
+    echoed: std.ArrayList(u8),
+    stderr: std.ArrayList(u8),
+    gpa: std.mem.Allocator,
+};
+
+var capture_ctx: CaptureCtx = undefined;
+var memory_instance: *bytebox.MemoryInstance = undefined;
+
+fn hostJsEcho(_: ?*anyopaque, _: *bytebox.ModuleInstance, params: [*]const bytebox.Val, _: [*]bytebox.Val) error{}!void {
+    const ptr: u32 = @intCast(params[0].I32);
+    const len: u32 = @intCast(params[1].I32);
+    const mem = memory_instance.buffer();
+    if (@as(usize, ptr) + @as(usize, len) > mem.len) return;
+    capture_ctx.echoed.appendSlice(capture_ctx.gpa, mem[ptr .. ptr + len]) catch return;
+    capture_ctx.echoed.append(capture_ctx.gpa, '\n') catch return;
+}
+
+fn hostJsStderr(_: ?*anyopaque, _: *bytebox.ModuleInstance, params: [*]const bytebox.Val, _: [*]bytebox.Val) error{}!void {
+    const ptr: u32 = @intCast(params[0].I32);
+    const len: u32 = @intCast(params[1].I32);
+    const mem = memory_instance.buffer();
+    if (@as(usize, ptr) + @as(usize, len) > mem.len) return;
+    capture_ctx.stderr.appendSlice(capture_ctx.gpa, mem[ptr .. ptr + len]) catch return;
+}
+
+fn invokeAlloc(instance: *bytebox.ModuleInstance, handle: bytebox.FunctionHandle, size: u32) !u32 {
+    var params = [_]bytebox.Val{.{ .I32 = @intCast(size) }};
+    var returns = [_]bytebox.Val{.{ .I32 = 0 }};
+    try instance.invoke(handle, &params, &returns, .{});
+    const result: u32 = @intCast(returns[0].I32);
+    if (result == 0) return error.WasmAllocReturnedNull;
+    return result;
+}
+
+fn writeBytesToWasm(instance: *bytebox.ModuleInstance, alloc_handle: bytebox.FunctionHandle, data: []const u8) !struct { ptr: u32, len: u32 } {
+    const ptr = try invokeAlloc(instance, alloc_handle, @intCast(data.len));
+    const mem = memory_instance.buffer();
+    if (@as(usize, ptr) + data.len > mem.len) return error.WasmBufferOutOfBounds;
+    @memcpy(mem[ptr .. ptr + data.len], data);
+    return .{ .ptr = ptr, .len = @intCast(data.len) };
+}
+
+pub fn main() !void {
+    var gpa_impl: std.heap.GeneralPurposeAllocator(.{}) = .init;
+    defer _ = gpa_impl.deinit();
+    const gpa = gpa_impl.allocator();
+
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    capture_ctx = .{
+        .echoed = std.ArrayList(u8).empty,
+        .stderr = std.ArrayList(u8).empty,
+        .gpa = gpa,
+    };
+    defer capture_ctx.echoed.deinit(gpa);
+    defer capture_ctx.stderr.deinit(gpa);
+
+    // Locate echo.wasm relative to repo root (cwd when run via `zig build`).
+    const wasm_path = "zig-out/lib/echo.wasm";
+    const wasm_bytes = std.fs.cwd().readFileAlloc(arena, wasm_path, std.math.maxInt(usize)) catch |err| {
+        std.debug.print("FAIL: could not read {s}: {s}\n", .{ wasm_path, @errorName(err) });
+        std.debug.print("(Did you run `zig build playground` first?)\n", .{});
+        std.process.exit(2);
+    };
+
+    var module_def = try bytebox.createModuleDefinition(arena, .{ .debug_name = "echo_wasm" });
+    defer module_def.destroy();
+    try module_def.decode(wasm_bytes);
+
+    var module_instance = try bytebox.createModuleInstance(.Stack, module_def, gpa);
+    defer module_instance.destroy();
+
+    // Wire env.js_echo + env.js_stderr.
+    var env_imports = try bytebox.ModuleImportPackage.init("env", null, null, gpa);
+    defer env_imports.deinit();
+    try env_imports.addHostFunction(
+        "js_echo",
+        &[_]bytebox.ValType{ .I32, .I32 },
+        &[_]bytebox.ValType{},
+        hostJsEcho,
+        null,
+    );
+    try env_imports.addHostFunction(
+        "js_stderr",
+        &[_]bytebox.ValType{ .I32, .I32 },
+        &[_]bytebox.ValType{},
+        hostJsStderr,
+        null,
+    );
+
+    const packages = [_]bytebox.ModuleImportPackage{env_imports};
+    try module_instance.instantiate(.{
+        .imports = &packages,
+        // 256 KiB — same as playground-integration. Larger values overflow
+        // bytebox's internal max_labels calc.
+        .stack_size = 1024 * 256,
+    });
+
+    memory_instance = module_instance.store.getMemory(0);
+
+    const init_handle = try module_instance.getFunctionHandle("init");
+    const alloc_handle = try module_instance.getFunctionHandle("allocateBuffer");
+    const addfile_handle = try module_instance.getFunctionHandle("addFile");
+    const run_handle = try module_instance.getFunctionHandle("compileAndRun");
+
+    // init()
+    {
+        var params = [_]bytebox.Val{};
+        var returns = [_]bytebox.Val{};
+        try module_instance.invoke(init_handle, &params, &returns, .{});
+    }
+
+    // addFile("Greeting", "<content>")
+    const greeting_name = try writeBytesToWasm(module_instance, alloc_handle, "Greeting");
+    const greeting_src =
+        \\Greeting := [].{
+        \\    msg : Str
+        \\    msg = "Hello from the Greeting module!"
+        \\}
+    ;
+    const greeting_content = try writeBytesToWasm(module_instance, alloc_handle, greeting_src);
+    {
+        var params = [_]bytebox.Val{
+            .{ .I32 = @intCast(greeting_name.ptr) },
+            .{ .I32 = @intCast(greeting_name.len) },
+            .{ .I32 = @intCast(greeting_content.ptr) },
+            .{ .I32 = @intCast(greeting_content.len) },
+        };
+        var returns = [_]bytebox.Val{.{ .I32 = 0 }};
+        try module_instance.invoke(addfile_handle, &params, &returns, .{});
+        const code: u32 = @intCast(returns[0].I32);
+        if (code != 0) {
+            std.debug.print("FAIL: addFile returned {d}\n", .{code});
+            std.process.exit(1);
+        }
+    }
+
+    // compileAndRun(<main source>)
+    const main_src =
+        \\import Greeting
+        \\
+        \\main! = |_| {
+        \\    echo!(Greeting.msg)
+        \\    Ok({})
+        \\}
+    ;
+    const main_buf = try writeBytesToWasm(module_instance, alloc_handle, main_src);
+    var run_params = [_]bytebox.Val{
+        .{ .I32 = @intCast(main_buf.ptr) },
+        .{ .I32 = @intCast(main_buf.len) },
+    };
+    var run_returns = [_]bytebox.Val{.{ .I32 = 0 }};
+    try module_instance.invoke(run_handle, &run_params, &run_returns, .{});
+
+    const exit_code: u32 = @intCast(run_returns[0].I32);
+
+    const expected_output = "Hello from the Greeting module!\n";
+    const got_output = capture_ctx.echoed.items;
+    const got_stderr = capture_ctx.stderr.items;
+
+    if (exit_code != 0) {
+        std.debug.print("FAIL: compileAndRun returned exit code {d}\n", .{exit_code});
+        if (got_stderr.len > 0) {
+            std.debug.print("stderr:\n{s}\n", .{got_stderr});
+        }
+        std.process.exit(1);
+    }
+
+    if (!std.mem.eql(u8, got_output, expected_output)) {
+        std.debug.print("FAIL: echo output mismatch.\n", .{});
+        std.debug.print("  expected: {s}", .{expected_output});
+        std.debug.print("  got:      {s}\n", .{got_output});
+        if (got_stderr.len > 0) {
+            std.debug.print("stderr:\n{s}\n", .{got_stderr});
+        }
+        std.process.exit(1);
+    }
+
+    std.debug.print("PASS: echo.wasm tutorial example produced expected output.\n", .{});
+}


### PR DESCRIPTION
## Summary

Promotes the in-process compile + execute pipeline (previously private helpers in `src/cli/main.zig`) into a public API that external embedders can consume, and migrates the `echo_platform` browser demo onto it so we have a working in-tree reference for the tutorial.

Commits, oldest first:

1. **Read Builtin.roc from package build root in `getCompilerArtifactHash`** — fixes a panic when `roc` is consumed as a Zig package dependency (`std.fs.cwd()` resolved to the consuming project's directory).
2. **Update .gitignore**.
3. **Add embedding API for in-process Roc compilation** — public surface: `app_header.parseAppHeader`, `Coordinator.discoverAppFromPath` / `registerPlatformPackage` / `registerInlinePackage` / `iterReports`, `CheckedModuleArtifact` entrypoint-name helpers, `LoweredProgram.platformEntrypoints` / `platformEntrypointNames`, `RuntimeImage.fillHeaderInBuffer` (IPC-agnostic), `LirInterpreter.runEntrypoint`. CLI now consumes the same surface internally — `buildLirRuntimeImageWithCoordinator` shrinks substantially and parses the app header once (down from three passes). `src/compile/README.md` gains an Embedding section.
4. **Address embedding-API feedback** — polishes the API based on feedback from porting an external embedder: `finalizeExecutableArtifacts` returns `error.HasUserErrors` instead of panicking, `viewMappedImage` accepts `*const u8` (no more `@constCast`), README gains \"Runtime arena\" / \"Memory ownership\" / \"Type-check only\" sections, \"Host functions\" rewritten with the precise alphabetical dispatch rule, and `src/compile/test/embedding_smoke.zig` end-to-end test walks the entire public API surface.
5. **Fix echo.wasm: migrate to canonical embedding API** — echo.wasm was returning silent exit-255 in the browser; root cause was `BuildEnv.init` OOMing the 64 MiB heap during builtin deserialization (bumped to 128 MiB per the README's sizing guidance). While debugging, migrated the pipeline to the canonical sequence, factored a shared `runner.zig` used by both the wasm export and a new native debug binary (`zig build run-echo`), and added a bytebox-driven integration test (`zig build test-echo-wasm`) that exercises echo.wasm end-to-end.

## Test plan

- [x] `zig build test-compile` — exercises `src/compile/test/embedding_smoke.zig`
- [x] `zig build test-echo-wasm` — bytebox loads `zig-out/lib/echo.wasm` and asserts the tutorial example produces \"Hello from the Greeting module!\"
- [x] `zig build run-echo -- path/to/app.roc [--with-file Name=path]` — native echo driver
- [x] `zig build playground` then host `zig-out/lib/` and exercise in a browser
- [x] `zig build minici` for the full check sweep

## Out of scope (filed separately)

While debugging echo.wasm I uncovered an unrelated `LirInterpreter` bug — `valueToRocList` / `valueToRocStr` use host `@sizeOf` instead of the target-aware size — that only manifests when interpreting LIR for a different target than the host. Real wasm is unaffected. Filed as #9436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)