### PR TITLE
Fix Panic: Seal hosted procedure return types via concrete refs

### DIFF
--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -1329,6 +1329,14 @@ pub const Coordinator = struct {
 
             if (made_progress) {
                 iterations_without_progress = 0;
+            } else if (self.inflight.load(.acquire) > 0) {
+                // A worker is still processing a task or has one queued.
+                // `inflight` is incremented in enqueueTask before the task is
+                // sent to the channel, so it covers both "queued" and
+                // "executing". The wall-clock stuck check below would
+                // false-positive on overloaded CI when a worker is merely
+                // slow, so don't advance the counter while inflight > 0.
+                iterations_without_progress = 0;
             } else {
                 iterations_without_progress += 1;
                 if (iterations_without_progress > 1000) {

--- a/src/mir/mono/specialize.zig
+++ b/src/mir/mono/specialize.zig
@@ -6428,7 +6428,7 @@ const BodyLowerer = struct {
                     else => invariantViolation("mono body lowering expected checked closure to reference a lambda body"),
                 }
             },
-            .hosted_lambda => |hosted| try self.lowerHostedDef(reserved, fn_ty, hosted.symbol_name, hosted.args),
+            .hosted_lambda => |hosted| try self.lowerHostedDef(reserved, hosted.symbol_name, hosted.args),
             .anno_only => invariantViolation("mono body lowering reached annotation-only procedure body without checked backing expression"),
             else => invariantViolation("mono body lowering expected a checked procedure body to be a lambda-like expression"),
         };
@@ -6437,11 +6437,11 @@ const BodyLowerer = struct {
     fn lowerHostedDef(
         self: *BodyLowerer,
         reserved: ReservedMonoProc,
-        fn_ty: Type.TypeId,
         symbol_name: canonical.ExternalSymbolNameId,
         arg_patterns: []const checked_artifact.CheckedPatternId,
     ) Allocator.Error!Ast.DefId {
         const args = try self.lowerParamSpanFromFunction(arg_patterns, reserved.requested_fn_ty);
+        const ret_info = try self.returnTypeFromConcreteFunction(reserved.requested_fn_ty);
         const hosted = try self.hostedProcForReserved(reserved.proc.proc, symbol_name);
         return try self.program.ast.addDef(.{
             .proc = mirProcedureRefFromReserved(reserved),
@@ -6449,17 +6449,10 @@ const BodyLowerer = struct {
             .value = .{ .hosted_fn = .{
                 .proc = reserved.proc.proc,
                 .args = args,
-                .ret_ty = self.functionReturnType(fn_ty),
+                .ret_ty = ret_info.ty,
                 .hosted = hosted,
             } },
         });
-    }
-
-    fn functionReturnType(self: *const BodyLowerer, fn_ty: Type.TypeId) Type.TypeId {
-        return switch (self.program.types.getTypePreservingNominal(fn_ty)) {
-            .func => |func| func.ret,
-            else => invariantViolation("mono body lowering expected hosted procedure type to be a function"),
-        };
     }
 
     fn hostedProcForReserved(


### PR DESCRIPTION
Route hosted procedure return types through returnTypeFromConcreteFunction, matching the lambda/entry-wrapper paths. This materializes and seals the ret_ty's concrete payload (populating by_key) so lambda_solved can resolve each nominal's source_ty when importing the hosted def's return type.

Previously, lowerHostedDef used the template-derived fn_ty directly, which left artifact-published nominal source_ty keys unsealed. When such a key later reached concreteNominalBacking with use_concrete_source_payloads=true, the lookup panicked.

Original panic:
```
❯ ./zig-out/bin/roc /Users/username/gitrepos/basic-cli2/basic-cli/examples/command-line-args.roc --no-cache          
thread 219540 panic: lambda-solved nominal source type key has no concrete source type payload
/Users/username/gitrepos/roc13/roc/src/mir/lambda_solved/solve.zig:15782:59: 0x107d1387f in lambdaInvariant__anon_469461 (roc)
    if (@import("builtin").mode == .Debug) std.debug.panic(message, .{});
                                                          ^
/Users/username/gitrepos/roc13/roc/src/mir/lambda_solved/solve.zig:10866:28: 0x1078d2f73 in concreteNominalBacking__anon_407939 (roc)
            lambdaInvariant("lambda-solved nominal source type key has no concrete source type payload");
                           ^
/Users/username/gitrepos/roc13/roc/src/mir/lambda_solved/solve.zig:10809:56: 0x10733a5d7 in importTypeWithConcretePayloadMode (roc)
                        try self.concreteNominalBacking(nominal)
                                                       ^
/Users/username/gitrepos/roc13/roc/src/mir/lambda_solved/solve.zig:10754:58: 0x10707a543 in importType (roc)
        return try self.importTypeWithConcretePayloadMode(source, self.use_concrete_source_payloads);
                                                         ^
/Users/username/gitrepos/roc13/roc/src/mir/lambda_solved/solve.zig:11374:69: 0x106d6cb87 in lowerDef (roc)
                    const ret_ty = try self.type_importer.importType(hosted.ret_ty);
                                                                    ^
/Users/username/gitrepos/roc13/roc/src/mir/lambda_solved/solve.zig:946:41: 0x106b249cb in buildInstance (roc)
        const body = try solver.lowerDef(input_proc.body);
                                        ^
/Users/username/gitrepos/roc13/roc/src/mir/lambda_solved/solve.zig:732:35: 0x1068ead37 in buildPending (roc)
            try self.buildInstance(self.pending.items[index]);
                                  ^
/Users/username/gitrepos/roc13/roc/src/mir/lambda_solved/solve.zig:1756:30: 0x1066b36cb in run (roc)
    try registry.buildPending();
                             ^
/Users/username/gitrepos/roc13/roc/src/lir/checked_pipeline.zig:698:42: 0x1064d6adb in lowerArtifactsToLambdaSolved (roc)
    return try mir.LambdaSolved.Solve.run(allocator, lifted, .{
                                         ^
/Users/username/gitrepos/roc13/roc/src/lir/checked_pipeline.zig:623:50: 0x106669c73 in summarizeCompileTimeDependencies (roc)
    var solved = try lowerArtifactsToLambdaSolved(
                                                 ^
/Users/username/gitrepos/roc13/roc/src/eval/compile_time_finalization.zig:183:96: 0x10666a4bb in finalizeRuntimeDependencySummaries (roc)
    var runtime_dependency_summaries = try lir.CheckedPipeline.summarizeCompileTimeDependencies(
                                                                                               ^
/Users/username/gitrepos/roc13/roc/src/eval/compile_time_finalization.zig:82:47: 0x1064a175f in finalize (roc)
        try finalizeRuntimeDependencySummaries(allocator, artifact, dependency_views, lowering_imports, relation_artifacts, &runtime_env);
                                              ^
/Users/username/gitrepos/roc13/roc/src/check/checked_artifact.zig:357:26: 0x1064ba967 in run (roc)
        try self.finalize(self.context, allocator, artifact, imports, available_artifacts, relation_artifacts);
                         ^
/Users/username/gitrepos/roc13/roc/src/check/checked_artifact.zig:19516:42: 0x10635c733 in publishFromTypedModule (roc)
    try inputs.compile_time_finalizer.run(
                                         ^
/Users/username/gitrepos/roc13/roc/src/compile/compile_package.zig:1498:58: 0x106375dab in publishCheckedArtifactFromCheckedModuleWithStorage (roc)
        return try CheckedArtifact.publishFromTypedModule(
                                                         ^
/Users/username/gitrepos/roc13/roc/src/compile/coordinator.zig:1083:105: 0x106376627 in republishCheckedArtifact (roc)
        var artifact = try compile_package.PackageEnv.publishCheckedArtifactFromCheckedModuleWithStorage(
                                                                                                        ^
/Users/username/gitrepos/roc13/roc/src/compile/coordinator.zig:911:42: 0x106378c7b in finalizeExecutableArtifacts (roc)
        try self.republishCheckedArtifact(platform_root.pkg, platform_root.mod, .{
                                         ^
/Users/username/gitrepos/roc13/roc/src/cli/main.zig:2079:42: 0x10637e087 in buildLirRuntimeImageWithCoordinator (roc)
    try coord.finalizeExecutableArtifacts();
                                         ^
/Users/username/gitrepos/roc13/roc/src/cli/main.zig:1087:63: 0x1063ad977 in rocRun (roc)
    const shm_result = try buildLirRuntimeImageWithCoordinator(ctx, args.path, null);
                                                              ^
/Users/username/gitrepos/roc13/roc/src/cli/main.zig:729:19: 0x10648b9eb in mainArgs (roc)
            rocRun(&ctx, run_args) catch |err| switch (err) {
                  ^
/Users/username/gitrepos/roc13/roc/src/cli/main.zig:627:13: 0x10648dd17 in main (roc)
    mainArgs(&allocs, args) catch |err| {
            ^
/opt/homebrew/Cellar/zig/0.15.2/lib/zig/std/start.zig:627:37: 0x10648e277 in main (roc)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x18f8ddd53 in ??? (???)
???:?:?: 0x0 in ??? (???)
zsh: abort      ./zig-out/bin/roc  --no-cache
```