### PR TITLE
Fix O(N^2) memory growth in lambda-solved boundary stores

### DIFF
--- a/src/cli/test/echo_tests.zig
+++ b/src/cli/test/echo_tests.zig
@@ -89,6 +89,13 @@ test "echo platform: list concat with refcounted elements issue 9316 (dev backen
     try runEchoExpectOutput(&.{"--opt=dev"}, "test/echo/issue_9316.roc", "[\"BAZ\", \"DUCK\", \"XYZ\", \"ABC\"]\n");
 }
 
+test "echo platform: cmd-test OOM repro compiles and runs (interpreter)" {
+    try runEchoExpectOutput(&.{}, "test/echo/repro_oom_cmd_test.roc", "");
+}
+test "echo platform: cmd-test OOM repro compiles and runs (dev backend)" {
+    try runEchoExpectOutput(&.{"--opt=dev"}, "test/echo/repro_oom_cmd_test.roc", "");
+}
+
 test "echo platform: no main is not a default app (interpreter)" {
     try runEchoExpectFailure(&.{"--opt=interpreter"}, "test/echo/no_main.roc");
 }

--- a/src/mir/lambda_solved/representation.zig
+++ b/src/mir/lambda_solved/representation.zig
@@ -1801,8 +1801,8 @@ pub const RepresentationStore = struct {
     erased_fn_abis: ErasedFnAbiStore = .{},
     box_payload_plans: []BoxPayloadRepresentationPlan = &.{},
     box_boundaries: []BoxBoundary = &.{},
-    capture_boundaries: []CaptureBoundaryInfo = &.{},
-    value_transform_boundaries: []const ValueTransformBoundary = &.{},
+    capture_boundaries: std.ArrayList(CaptureBoundaryInfo) = .empty,
+    value_transform_boundaries: std.ArrayList(ValueTransformBoundary) = .empty,
     consumer_use_plans: std.ArrayList(ConsumerUsePlan) = .empty,
     transform_endpoint_scopes: std.ArrayList(TransformEndpointScope) = .empty,
     transform_endpoint_paths: std.ArrayList(Span(TransformEndpointPathStep)) = .empty,
@@ -1880,8 +1880,8 @@ pub const RepresentationStore = struct {
         if (self.box_payload_plans.len > 0) self.allocator.free(self.box_payload_plans);
         for (self.box_boundaries) |*boundary| deinitBoxPayloadRepresentationPlan(self.allocator, boundary.payload_plan);
         if (self.box_boundaries.len > 0) self.allocator.free(self.box_boundaries);
-        if (self.capture_boundaries.len > 0) self.allocator.free(self.capture_boundaries);
-        if (self.value_transform_boundaries.len > 0) self.allocator.free(self.value_transform_boundaries);
+        self.capture_boundaries.deinit(self.allocator);
+        self.value_transform_boundaries.deinit(self.allocator);
         if (self.root_groups.len > 0) self.allocator.free(self.root_groups);
         if (self.callable_group_emissions.len > 0) self.allocator.free(self.callable_group_emissions);
         for (self.group_erasure_provenance) |provenance| {
@@ -2356,13 +2356,8 @@ pub const RepresentationStore = struct {
         self: *RepresentationStore,
         boundary: ValueTransformBoundary,
     ) std.mem.Allocator.Error!ValueTransformBoundaryId {
-        const id: ValueTransformBoundaryId = @enumFromInt(@as(u32, @intCast(self.value_transform_boundaries.len)));
-        const old = self.value_transform_boundaries;
-        const next = try self.allocator.alloc(ValueTransformBoundary, old.len + 1);
-        @memcpy(next[0..old.len], old);
-        next[old.len] = boundary;
-        if (old.len > 0) self.allocator.free(old);
-        self.value_transform_boundaries = next;
+        const id: ValueTransformBoundaryId = @enumFromInt(@as(u32, @intCast(self.value_transform_boundaries.items.len)));
+        try self.value_transform_boundaries.append(self.allocator, boundary);
         return id;
     }
 
@@ -2370,13 +2365,8 @@ pub const RepresentationStore = struct {
         self: *RepresentationStore,
         info: CaptureBoundaryInfo,
     ) std.mem.Allocator.Error!CaptureBoundaryId {
-        const id: CaptureBoundaryId = @enumFromInt(@as(u32, @intCast(self.capture_boundaries.len)));
-        const old = self.capture_boundaries;
-        const next = try self.allocator.alloc(CaptureBoundaryInfo, old.len + 1);
-        @memcpy(next[0..old.len], old);
-        next[old.len] = info;
-        if (old.len > 0) self.allocator.free(old);
-        self.capture_boundaries = next;
+        const id: CaptureBoundaryId = @enumFromInt(@as(u32, @intCast(self.capture_boundaries.items.len)));
+        try self.capture_boundaries.append(self.allocator, info);
         return id;
     }
 
@@ -2386,18 +2376,18 @@ pub const RepresentationStore = struct {
         boundary: ValueTransformBoundaryId,
     ) void {
         const index = @intFromEnum(id);
-        if (index >= self.capture_boundaries.len) {
+        if (index >= self.capture_boundaries.items.len) {
             debug.invariant(false, "lambda-solved invariant violated: capture boundary id out of range");
             unreachable;
         }
-        self.capture_boundaries[index].boundary = boundary;
+        self.capture_boundaries.items[index].boundary = boundary;
     }
 
     pub fn captureBoundary(
         self: *const RepresentationStore,
         id: CaptureBoundaryId,
     ) CaptureBoundaryInfo {
-        return self.capture_boundaries[@intFromEnum(id)];
+        return self.capture_boundaries.items[@intFromEnum(id)];
     }
 
     pub fn appendSessionExecutableValueTransform(
@@ -2580,7 +2570,7 @@ pub const RepresentationStore = struct {
         self: *const RepresentationStore,
         id: ValueTransformBoundaryId,
     ) ValueTransformBoundary {
-        return self.value_transform_boundaries[@intFromEnum(id)];
+        return self.value_transform_boundaries.items[@intFromEnum(id)];
     }
 
     pub fn appendConsumerUsePlan(
@@ -2712,12 +2702,12 @@ pub const RepresentationStore = struct {
                 else => {},
             }
         }
-        for (self.capture_boundaries, 0..) |capture, raw_id| {
+        for (self.capture_boundaries.items, 0..) |capture, raw_id| {
             const boundary_index = @intFromEnum(capture.boundary);
-            if (boundary_index >= self.value_transform_boundaries.len) {
+            if (boundary_index >= self.value_transform_boundaries.items.len) {
                 debug.invariant(false, "lambda-solved invariant violated: capture boundary did not point at a value transform boundary");
             }
-            const boundary = self.value_transform_boundaries[boundary_index];
+            const boundary = self.value_transform_boundaries.items[boundary_index];
             const capture_id: CaptureBoundaryId = @enumFromInt(@as(u32, @intCast(raw_id)));
             switch (boundary.kind) {
                 .capture_value => |id| {

--- a/test/echo/repro_oom_cmd_test.roc
+++ b/test/echo/repro_oom_cmd_test.roc
@@ -1,0 +1,100 @@
+# Reproduces the OOM:
+#
+#   The Roc compiler ran out of memory trying to preallocate virtual
+#   address space for compiling and running this program. Try using
+#   `roc build` to build the executable separately, then run it
+#   manually.
+#
+# Mirrors the structure of basic-cli2's cmd-test.roc: an opaque nominal
+# `MyCmd` type with several static-dispatch methods that each return
+# `Try` with a different open tag-union error type, and a polymorphic
+# `expect_err` helper that calls `Str.inspect(err)` on the result.
+
+IOErr := [
+    AlreadyExists,
+    BrokenPipe,
+    Interrupted,
+    NotFound,
+    Other(Str),
+    OutOfMemory,
+    PermissionDenied,
+    Unsupported,
+]
+
+MyCmd :: {
+    program : Str,
+    args : List(Str),
+}.{
+    new : Str -> MyCmd
+    new = |program| { program, args: [] }
+
+    arg : MyCmd, Str -> MyCmd
+    arg = |cmd, a| { ..cmd, args: cmd.args.append(a) }
+
+    args : MyCmd, List(Str) -> MyCmd
+    args = |cmd, more| { ..cmd, args: cmd.args.concat(more) }
+
+    exec! : Str, List(Str) => Try({}, [ExecFailed({ command : Str, exit_code : I32 }), FailedToGetExitCode({ command : Str, err : IOErr }), ..])
+    exec! = |program, _arguments| Err(FailedToGetExitCode({ command: program, err: IOErr.NotFound }))
+
+    exec_cmd! : MyCmd => Try({}, [ExecCmdFailed({ command : Str, exit_code : I32 }), FailedToGetExitCode({ command : Str, err : IOErr }), ..])
+    exec_cmd! = |cmd| Err(FailedToGetExitCode({ command: cmd.program, err: IOErr.NotFound }))
+
+    exec_output! : MyCmd => Try(
+        { stdout_utf8 : Str, stderr_utf8_lossy : Str },
+        [
+            StdoutContainsInvalidUtf8({ cmd_str : Str, err : [BadUtf8({ problem : _, index : U64 })] }),
+            NonZeroExitCode({ command : Str, exit_code : I32, stdout_utf8_lossy : Str, stderr_utf8_lossy : Str }),
+            FailedToGetExitCode({ command : Str, err : IOErr }),
+            ..
+        ]
+    )
+    exec_output! = |cmd| Err(FailedToGetExitCode({ command: cmd.program, err: IOErr.NotFound }))
+
+    exec_output_bytes! : MyCmd => Try(
+        { stderr_bytes : List(U8), stdout_bytes : List(U8) },
+        [
+            NonZeroExitCodeB({ exit_code : I32, stdout_bytes : List(U8), stderr_bytes : List(U8) }),
+            FailedToGetExitCodeB(IOErr),
+            ..
+        ]
+    )
+    exec_output_bytes! = |_cmd| Err(FailedToGetExitCodeB(IOErr.NotFound))
+
+    exec_exit_code! : MyCmd => Try(I32, [FailedToGetExitCode({ command : Str, err : IOErr }), ..])
+    exec_exit_code! = |cmd| Err(FailedToGetExitCode({ command: cmd.program, err: IOErr.NotFound }))
+}
+
+main! = |_args| {
+    match run!() {
+        Ok(_) => Ok({})
+        Err(_) => Ok({})
+    }
+}
+
+run! = || {
+    expect_err(MyCmd.exec!("blablaXYZ", []), "x")?
+    expect_err(MyCmd.exec!("cat", ["a"]), "x")?
+    expect_err(MyCmd.new("blablaXYZ").exec_cmd!(), "x")?
+    expect_err(MyCmd.new("cat").arg("a").exec_cmd!(), "x")?
+    expect_err(MyCmd.new("blablaXYZ").exec_output!(), "x")?
+    expect_err(MyCmd.new("cat").arg("a").exec_output!(), "x")?
+    expect_err(MyCmd.new("printf").args(["x"]).exec_output!(), "x")?
+    expect_err(MyCmd.new("blablaXYZ").exec_output_bytes!(), "x")?
+    expect_err(MyCmd.new("cat").arg("a").exec_output_bytes!(), "x")?
+    expect_err(MyCmd.new("blablaXYZ").exec_exit_code!(), "x")?
+    expect_err(MyCmd.new("cat").arg("a").exec_exit_code!(), "x")?
+    expect_err(MyCmd.exec!("rm", ["x"]), "x")?
+
+    echo!("done")
+
+    Ok({})
+}
+
+expect_err = |err, expected_str| {
+    if Str.inspect(err) == expected_str {
+        Ok({})
+    } else {
+        Err(FailedExpectation(Str.inspect(err)))
+    }
+}


### PR DESCRIPTION
`appendValueTransformBoundary` and `reserveCaptureBoundary` grew their backing slices one element at a time via `alloc(T, old.len + 1)` + memcpy + free. Because the runtime image is built into a bump-style SharedMemoryAllocator that can't reclaim freed memory, each append costs O(N) and the total cost is O(N^2). On a program with many proc-instance value aliases (repro: test/echo/repro_oom_cmd_test.roc), ~10k appends across multiple stores accumulated ~12.8 GB of dead allocations, blowing past the 8 GB macOS arena.

Convert both fields to `std.ArrayList(T)` (matching the convention already used by `consumer_use_plans`, `transform_endpoint_scopes`, etc. in the same struct) so growth is geometric. Peak RSS on the repro drops from 8.6 GB to ~650 MB.