### PR TITLE
increase parallel test runner timeout

### DIFF
--- a/src/build/test_harness.zig
+++ b/src/build/test_harness.zig
@@ -248,7 +248,7 @@ pub fn printSlowestN(
 pub const StandardArgs = struct {
     filters: []const []const u8 = &.{},
     max_threads: ?usize = null,
-    timeout_ms: u64 = 60_000,
+    timeout_ms: u64 = 120_000,
     timeout_provided: bool = false,
     verbose: bool = false,
     help_requested: bool = false,
@@ -295,7 +295,7 @@ fn parseStandardArgsFromSlice(raw_args: []const []const u8, allocator: Allocator
             i += 1;
             if (i < raw_args.len) {
                 args.timeout_provided = true;
-                args.timeout_ms = std.fmt.parseInt(u64, raw_args[i], 10) catch 60_000;
+                args.timeout_ms = std.fmt.parseInt(u64, raw_args[i], 10) catch 120_000;
             }
         } else if (std.mem.eql(u8, arg, "--worker")) {
             i += 1;

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -10,7 +10,7 @@
 //! Options:
 //!   --filter <pattern>   Run only tests whose name contains <pattern> (repeatable)
 //!   --threads <N>        Max concurrent child processes (default: CPU count)
-//!   --timeout <ms>       Per-test timeout in ms (default: 60000)
+//!   --timeout <ms>       Per-test timeout in ms (default: 120000)
 //!   --verbose            Print PASS results and timing details
 
 const std = @import("std");
@@ -598,7 +598,7 @@ fn printUsage() void {
         \\Options:
         \\  --filter <pattern>   Run tests matching pattern (repeatable)
         \\  --threads <N>        Max concurrent workers (default: CPU count)
-        \\  --timeout <ms>       Per-test timeout in ms (default: 60000)
+        \\  --timeout <ms>       Per-test timeout in ms (default: 120000)
         \\  --verbose            Show PASS results with timing
         \\
     , .{});


### PR DESCRIPTION
Some CI machines need >60 seconds