### PR TITLE
Massive speedup 🚀 

### DIFF
--- a/src/compile/compile_package.zig
+++ b/src/compile/compile_package.zig
@@ -195,7 +195,7 @@ const ModuleState = struct {
             if (semantic.checked_artifact == null) {
                 if (semantic.module_env) |e| {
                     // IMPORTANT: Use e.gpa, not the passed-in gpa, because source was allocated
-                    // with e.gpa (page_allocator in multi-threaded mode).
+                    // with e.gpa (smp_allocator in multi-threaded mode).
                     const env_alloc = e.gpa;
                     const source = e.common.source;
                     if (comptime trace_build) {

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -87,18 +87,35 @@ const is_freestanding = threading.is_freestanding;
 const threads_available = !is_freestanding;
 const Thread = threading.Thread;
 
+/// Thread-safe allocator used for worker-thread allocations and shared
+/// coordinator buffers (channels, per-package maps) when running multi-threaded.
+///
+/// On platforms with threads, `std.heap.smp_allocator` is used: it maintains
+/// per-thread freelists backed by a shared global pool, avoiding the per-call
+/// `mmap`/`munmap` serialization on the kernel VM lock that `page_allocator`
+/// incurs (the prior cause of the multi-threaded performance cliff).
+///
+/// On wasm/freestanding (no threads), `smp_allocator` is unreachable at
+/// runtime but the constant must still compile, so it resolves to
+/// `page_allocator` (which on wasm is backed by `WasmAllocator`).
+const thread_safe_allocator: Allocator = if (threads_available)
+    std.heap.smp_allocator
+else
+    std.heap.page_allocator;
+
 /// Allocators for a worker thread. Each worker has its own instance.
 /// This ensures thread-safe allocations without contention.
 ///
 /// Design rationale:
 /// - `gpa`: For long-lived data (ModuleEnv, source). In MT mode, this is
-///   page_allocator for thread safety. Data allocated here is stored in
-///   ModuleEnv.gpa and freed during module cleanup.
+///   smp_allocator (per-thread freelists backed by a shared global pool).
+///   Data allocated here is stored in ModuleEnv.gpa and freed during module
+///   cleanup.
 /// - `arena`: For temporary allocations within a task (reports, diagnostics).
 ///   Reset between tasks to reduce allocation pressure.
 pub const WorkerAllocators = struct {
     /// General purpose allocator for long-lived data (ModuleEnv, source).
-    /// In multi-threaded mode, this is page_allocator for thread safety.
+    /// In multi-threaded mode, this is smp_allocator for thread safety.
     gpa: Allocator,
 
     /// Arena for temporary allocations within a task.
@@ -291,7 +308,7 @@ pub const ModuleState = struct {
                 const env = semantic.module_env;
                 // IMPORTANT: env stores its own allocator (env.gpa) which was used to create it.
                 // We must use env.gpa for cleanup, not the passed-in gpa, because in multi-threaded
-                // mode, env.gpa is page_allocator while gpa is the coordinator's allocator.
+                // mode, env.gpa is smp_allocator while gpa is the coordinator's allocator.
                 const env_alloc = env.gpa;
                 const source = env.common.source;
                 if (comptime trace_build) {
@@ -347,10 +364,10 @@ pub const PackageState = struct {
             .name = name,
             .root_dir = root_dir,
             .modules = std.ArrayList(ModuleState).empty,
-            .module_names = std.StringHashMap(ModuleId).init(std.heap.page_allocator),
+            .module_names = std.StringHashMap(ModuleId).init(thread_safe_allocator),
             .remaining_modules = 0,
             .root_module_id = null,
-            .shorthands = std.StringHashMap([]const u8).init(std.heap.page_allocator),
+            .shorthands = std.StringHashMap([]const u8).init(thread_safe_allocator),
         };
     }
 
@@ -554,11 +571,12 @@ pub const Coordinator = struct {
     module_time_sum_ns: u64,
 
     /// Get allocator for worker thread operations.
-    /// In multi-threaded mode, returns page_allocator which is guaranteed thread-safe.
-    /// In single-threaded mode, returns gpa for better performance.
+    /// In multi-threaded mode, returns smp_allocator (per-thread freelists
+    /// backed by a shared global pool, designed for SMP workloads). In
+    /// single-threaded mode, returns gpa for better performance.
     pub fn getWorkerAllocator(self: *const Coordinator) Allocator {
         return if (threads_available and self.mode == .multi_threaded)
-            std.heap.page_allocator
+            thread_safe_allocator
         else
             self.gpa;
     }
@@ -581,10 +599,11 @@ pub const Coordinator = struct {
         compiler_version: []const u8,
         cache_manager: ?*CacheManager,
     ) !Coordinator {
-        // Both channels use page_allocator in multi-threaded mode because their
+        // Both channels use smp_allocator in multi-threaded mode because their
         // buffers may be grown (task_channel) or accessed from worker threads.
-        // page_allocator is guaranteed thread-safe (OS mmap/munmap).
-        const channel_allocator = if (threads_available) std.heap.page_allocator else gpa;
+        // smp_allocator is thread-safe and avoids the per-allocation mmap/munmap
+        // serialization on the kernel VM lock that page_allocator incurs.
+        const channel_allocator = if (threads_available) thread_safe_allocator else gpa;
         const initial_task_capacity = 256;
         return .{
             .gpa = gpa,
@@ -632,7 +651,7 @@ pub const Coordinator = struct {
 
         // Free packages
         // Note: ModuleEnv stores its own allocator (env.gpa), so deinit will use the correct
-        // allocator for each env. In multi-threaded mode, this is page_allocator.
+        // allocator for each env. In multi-threaded mode, this is smp_allocator.
         var pkg_it = self.packages.iterator();
         while (pkg_it.next()) |entry| {
             if (comptime trace_build) {
@@ -679,11 +698,11 @@ pub const Coordinator = struct {
     }
 
     /// Get the allocator to use for module data.
-    /// - In multi-threaded mode: page_allocator (guaranteed thread-safe)
+    /// - In multi-threaded mode: smp_allocator (per-thread freelists)
     /// - In single-threaded mode: gpa (better performance)
     pub fn getModuleAllocator(self: *Coordinator) std.mem.Allocator {
         return if (threads_available and self.mode == .multi_threaded)
-            std.heap.page_allocator
+            thread_safe_allocator
         else
             self.gpa;
     }
@@ -2770,9 +2789,9 @@ pub const Coordinator = struct {
     /// Worker thread main function
     fn workerThread(self: *Coordinator) void {
         // Each worker has its own allocators for thread safety.
-        // - gpa: page_allocator for long-lived data (ModuleEnv, source)
+        // - gpa: smp_allocator for long-lived data (ModuleEnv, source)
         // - arena: for temporary allocations, reset between tasks
-        const backing = if (threads_available) std.heap.page_allocator else self.gpa;
+        const backing = if (threads_available) thread_safe_allocator else self.gpa;
         var worker_allocs = WorkerAllocators.init(backing);
         defer worker_allocs.deinit();
 


### PR DESCRIPTION
The multi-threaded compile path used `std.heap.page_allocator` for worker gpa, channel buffers, and per-package StringHashMaps. On macOS each allocation goes to `mmap`/`munmap`, which serializes on a per-process VM lock — so adding worker threads made `roc check` slower than running single-threaded.

Swap to `std.heap.smp_allocator` (per-thread freelists backed by a shared global pool, only mmaps on freelist-empty or large allocations) via a new comptime `thread_safe_allocator` constant in `src/compile/coordinator.zig`. On wasm/freestanding the constant resolves to `page_allocator` so it still compiles (smp_allocator transitively requires mmap).

Touched call sites — all routed through the new constant:
- `getWorkerAllocator`
- `getModuleAllocator`
- `workerThread` backing
- `Channel(WorkerResult)` / `Channel(WorkerTask)` init
- `PackageState.module_names` / `shorthands` StringHashMap init

No lifetime changes: `smp_allocator` is a process-singleton with global storage, so allocations remain valid across thread boundaries — `env.gpa` keeping the worker-thread allocator across ownership transfer to the coordinator is still sound.

Wall-clock results on `roc check basic-cli/examples/command.roc --no-cache` (median of 3, ReleaseFast):

  --jobs=1:  45ms ->  48ms  (unchanged)
  default:  391ms ->  47ms  (8.3x)
  --jobs=2: 272ms ->  43ms  (6.3x)
  --jobs=4: 311ms ->  43ms  (7.2x)
  --jobs=8: 395ms ->  43ms  (9.2x)