### PR TITLE
fix interpreter crash on Str.from_utf8 with chained ?

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -2592,7 +2592,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     return try self.callStr1RocOpsToResult(list_off, @intFromPtr(&wrapStrFromUtf8Lossy), .str_from_utf8_lossy, .str);
                 },
                 .str_from_utf8 => {
-                    // str_from_utf8(list) -> Result Str [BadUtf8 {problem: Utf8Problem, index: U64}]
+                    // str_from_utf8(list) -> Try(Str, [BadUtf8 {problem: Utf8Problem, index: U64}])
                     if (args.len != 1) unreachable;
                     const list_loc = try self.emitValueLocal(args[0]);
                     const list_off = try self.ensureOnStack(list_loc, roc_list_size);

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -3387,6 +3387,43 @@ pub const Interpreter = struct {
         return field.layout;
     }
 
+    /// Locate the BadUtf8 variant inside an err tag union that may have been extended via `?`
+    /// to include additional error tags. BadUtf8 is uniquely identified by its payload: a
+    /// struct with one u64-sized field (index) and one byte-sized field (problem enum). Other
+    /// stdlib error tags chained via `?` are zero-sized, so this match is unambiguous in
+    /// practice.
+    fn findBadUtf8Variant(
+        self: *LirInterpreter,
+        inner_tu: *const layout_mod.TagUnionData,
+    ) ?struct { disc: u16, struct_idx: layout_mod.StructIdx } {
+        const inner_v = self.layout_store.getTagUnionVariants(inner_tu);
+        for (0..inner_v.len) |i| {
+            const inner_payload = inner_v.get(@intCast(i)).payload_layout;
+            const unwrapped = self.unwrapSingleFieldPayloadLayout(inner_payload) orelse inner_payload;
+            const inner_layout = self.layout_store.getLayout(unwrapped);
+            if (inner_layout.tag != .struct_) continue;
+
+            const struct_idx = inner_layout.data.struct_.idx;
+            const struct_data = self.layout_store.getStructData(struct_idx);
+            const fields = self.layout_store.struct_fields.sliceRange(struct_data.getFields());
+            if (fields.len != 2) continue;
+
+            var has_u64_field = false;
+            var has_byte_field = false;
+            for (0..fields.len) |fi| {
+                const field = fields.get(fi);
+                const field_layout = self.layout_store.getLayout(field.layout);
+                const field_size = self.layout_store.layoutSize(field_layout);
+                if (field_size == 8) has_u64_field = true;
+                if (field_size == 1) has_byte_field = true;
+            }
+            if (has_u64_field and has_byte_field) {
+                return .{ .disc = @intCast(i), .struct_idx = struct_idx };
+            }
+        }
+        return null;
+    }
+
     const LowLevelEvalInput = struct {
         op: LIR.LowLevel,
         args: []const Value,
@@ -3467,10 +3504,13 @@ pub const Interpreter = struct {
                 break :blk self.rocListToValue(result, ll.ret_layout);
             },
             .str_from_utf8 => blk: {
-                // str_from_utf8(list) -> Result Str [BadUtf8 {index: U64, problem: Utf8Problem}]
-                // The C builtin returns FromUtf8Try (a flat struct).
-                // Convert to the Roc tag union layout using layout-resolved offsets,
-                // following the same pattern as the dev backend (LirCodeGen.zig).
+                // str_from_utf8(list) -> Try(Str, [BadUtf8 {index: U64, problem: Utf8Problem}, ..])
+                // The C builtin returns FromUtf8Try (a flat struct). We convert it to the Roc
+                // tag union layout using layout-resolved offsets. Note the err tag union has an
+                // open extension (`..`), so at the call site it may be unified with other error
+                // tags from `?` chaining. We must locate the BadUtf8 variant inside that
+                // (possibly multi-variant) inner tag union and write the inner discriminant
+                // when there is more than one inner variant.
                 var crash_boundary = self.enterCrashBoundary();
                 defer crash_boundary.deinit();
                 const sj = crash_boundary.set();
@@ -3488,6 +3528,8 @@ pub const Interpreter = struct {
                 var ok_disc: ?u16 = null;
                 var err_disc: ?u16 = null;
                 var err_record_idx: ?layout_mod.StructIdx = null;
+                var inner_tu_data_opt: ?*const layout_mod.TagUnionData = null;
+                var inner_bad_utf8_disc: u16 = 0;
                 for (0..variants.len) |i| {
                     const v_payload = variants.get(@intCast(i)).payload_layout;
                     const candidate = self.unwrapSingleFieldPayloadLayout(v_payload) orelse v_payload;
@@ -3496,20 +3538,19 @@ pub const Interpreter = struct {
                     } else {
                         err_disc = @intCast(i);
                         const err_layout = self.layout_store.getLayout(candidate);
-                        err_record_idx = switch (err_layout.tag) {
-                            .struct_ => err_layout.data.struct_.idx,
-                            .tag_union => inner: {
+                        switch (err_layout.tag) {
+                            .struct_ => err_record_idx = err_layout.data.struct_.idx,
+                            .tag_union => {
                                 const inner_tu = self.layout_store.getTagUnionData(err_layout.data.tag_union.idx);
-                                const inner_v = self.layout_store.getTagUnionVariants(inner_tu);
-                                if (inner_v.len == 0) break :inner null;
-                                const inner_payload = inner_v.get(0).payload_layout;
-                                const unwrapped = self.unwrapSingleFieldPayloadLayout(inner_payload) orelse inner_payload;
-                                const inner_layout = self.layout_store.getLayout(unwrapped);
-                                if (inner_layout.tag == .struct_) break :inner inner_layout.data.struct_.idx;
-                                break :inner null;
+                                inner_tu_data_opt = inner_tu;
+                                const found = self.findBadUtf8Variant(inner_tu);
+                                if (found) |info| {
+                                    err_record_idx = info.struct_idx;
+                                    inner_bad_utf8_disc = info.disc;
+                                }
                             },
-                            else => null,
-                        };
+                            else => {},
+                        }
                     }
                 }
 
@@ -3528,6 +3569,11 @@ pub const Interpreter = struct {
                     const problem_off = self.layout_store.getStructFieldOffsetByOriginalIndex(rec_idx, 1);
                     val.offset(index_off).write(u64, result.byte_index);
                     val.offset(problem_off).write(u8, @intFromEnum(result.problem_code));
+                    if (inner_tu_data_opt) |inner_tu| {
+                        // The inner tag union sits at offset 0 of the Err payload, which is at
+                        // offset 0 of the outer tag union. Write its discriminant in place.
+                        inner_tu.writeDiscriminant(val.ptr, inner_bad_utf8_disc);
+                    }
                     self.helper.writeTagDiscriminant(val, ll.ret_layout, resolved_err);
                 }
                 break :blk val;

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -2930,6 +2930,26 @@ const core_tests = [_]TestCase{
         ,
         .expected = .{ .inspect_str = "True" },
     },
+    .{
+        .name = "inspect: chained ? with Str.from_utf8 and I32.from_str (issue 9456)",
+        .source_kind = .module,
+        .source =
+        \\parse = |s| {
+        \\    chars = s.to_utf8()
+        \\    match chars {
+        \\        [] => Err(ParsingError)
+        \\        [_first, .. as rest] => {
+        \\            num_str = Str.from_utf8(rest)?
+        \\            _num = I32.from_str(num_str)?
+        \\            Ok({})
+        \\        }
+        \\    }
+        \\}
+        \\
+        \\main = parse("L12")
+        ,
+        .expected = .{ .inspect_str = "Ok({})" },
+    },
 };
 
 pub const tests = core_tests ++ comptime_finalization_tests.tests ++ closure_recursion_tests.tests ++ recursive_data_tests.tests ++ low_level_tests.tests ++ highest_lowest_tests.tests ++ polymorphism_tests.tests ++ issue_93xx_tests.tests ++ interpreter_style_tests.tests;


### PR DESCRIPTION
When ? chains Str.from_utf8 with other Try-returning calls, the err extension is unified to a multi-variant inner tag union, and the interpreter's str_from_utf8 handler picked the wrong inner variant and never wrote the inner discriminant, causing a compile-time finalization crash.

Closes #9456 