### PR TITLE
Fix Parser package lowering

### DIFF
--- a/design.md
+++ b/design.md
@@ -659,6 +659,12 @@ checked type relations provide concrete evidence. This is ordinary type solving
 inside one stage. Once Monotype IR is output, no open cell remains and no
 later stage may change a type.
 
+Monotype type cells are addressed by the owning checked module id and the exact
+checked type id. They are not addressed by `TypeDigest`. A digest can identify
+closed structural type content for specialization and comparison, but it cannot
+distinguish two different open checked variables with the same shape. Treating
+those variables as the same cell is a compiler bug.
+
 Generated helper code for an empty tag union, such as an inspector requested
 only because a container type mentions the empty tag union, has an unreachable
 body. Reaching that helper means a runtime value of an uninhabited type existed,
@@ -1063,12 +1069,14 @@ become ordinary value representations:
 const LambdaMonoType = union(enum) {
     primitive: Primitive,
     record: Span(Field),
+    capture_record: Span(CaptureField),
     tag_union: Span(Tag),
     tuple: Span(TypeId),
     list: TypeId,
     box: TypeId,
     named: NamedType,
-    erased,
+    callable: Span(FnVariant),
+    erased_fn: ErasedFn,
 };
 ```
 
@@ -1077,23 +1085,30 @@ gets one generated tag. If the member captures values, the tag payload is a
 generated record containing those captures. If it captures nothing, the tag is a
 zero-payload variant.
 
-The generated tag-union type carries the callable member identity needed by the
-LIR builder. The identity is part of the type node, not a separate
-representation table:
+The generated callable type carries the source member and the exact Lambda Mono
+function target. The target is part of the type node. The LIR builder never
+finds a function by scanning symbols or by rebuilding a specialization choice:
 
 ```zig
-const FnTag = struct {
-    variant: FnVariantId,
-    display_name: ?TagLabelId,
-    member: FnMember,
+const FnVariant = struct {
+    id: FnVariantId,
+    source: Symbol,
+    target: FnId,
     capture_record: ?TypeId,
 };
-
-const FnMember = struct {
-    lambda: Symbol,
-    source_fn_ty: TypeDigest,
-};
 ```
+
+`source` is the original lifted function symbol and is used only while lowering
+a `fn_ref` expression into the correct callable variant. `target` is the exact
+Lambda Mono function specialization to call for that variant. `capture_record`
+is the exact payload type for finite callable values and the exact capture
+argument type for erased callable entries.
+
+When Lambda Mono lowers a function reference, it reads the capture span from the
+Lambda Solved function value type at that expression site. It then builds a
+capture record with those exact slots and stores it in the callable value. It
+does not use the source function's own function type as a proxy for the
+expression-site callable type.
 
 ### Lambda Mono Expressions
 
@@ -1137,18 +1152,18 @@ turn that state into concrete jumps, blocks, or backend-friendly loop control.
 
 Lambda Mono IR has no `call_value` node. A call through a finite lambda set is
 lowered to a match over the generated callable tag union; each branch makes a
-`direct_call` to the specialized function for that member. A call through an
-erased callable becomes `indirect_erased_call`.
+`direct_call` to the variant's `target`. A call through an erased callable
+becomes `indirect_erased_call`.
 
-Generated callable variants are stage-local ids created by Lambda Mono. Any
-`display_name` exists only for dumps or diagnostics. The runtime discriminant
-and variant slot are chosen later by LIR layout commitment and then output
-explicitly in the LIR result.
+Generated callable variants are stage-local ids created by Lambda Mono. The
+runtime discriminant and variant slot are chosen later by LIR layout commitment
+and then output explicitly in the LIR result.
 
-Lambda Mono specialization identity includes the called function symbol, its solved
-function type, and the capture shape required by the callable representation.
-This is a normal stage-local specialization queue, driven only by explicit
-callable flow in Lambda Solved IR.
+Lambda Mono specialization is queued by exact function source id, solved
+function type, callable ABI, and capture shape. The queue is driven only by
+explicit callable flow in Lambda Solved IR. Each `FnVariant.target` names the
+queued result directly, so later stages consume a direct function id instead of
+looking up a symbol.
 
 For a finite callable member with captures, the specialized function receives
 the original Roc arguments followed by one compiler-created capture-record

--- a/src/base/signal_handler.zig
+++ b/src/base/signal_handler.zig
@@ -126,15 +126,11 @@ pub const StackBounds = struct {
         return addr >= guard_low and addr < guard_high;
     }
 
-    pub fn containsLowerBoundaryFault(self: StackBounds, fault_addr: usize, sp: usize) bool {
+    pub fn containsLowerBoundaryAddress(self: StackBounds, fault_addr: usize) bool {
         const boundary_low = self.low -| self.page_size;
         const boundary_high = self.low;
-        const lowest_stack_page_high = self.low +| self.page_size;
 
-        return fault_addr >= boundary_low and
-            fault_addr < boundary_high and
-            sp >= self.low and
-            sp <= lowest_stack_page_high;
+        return fault_addr >= boundary_low and fault_addr < boundary_high;
     }
 };
 
@@ -182,12 +178,12 @@ pub fn currentThreadStackBoundsForTest() ?StackBounds {
 
 /// Classify a fault from its address, interrupted stack pointer, and stack range.
 pub fn classifyFault(fault_addr: usize, interrupted_sp: ?usize, bounds: ?StackBounds) FaultKind {
-    const stack_bounds = bounds orelse return .access_violation;
-    const sp = interrupted_sp orelse return .access_violation;
+    _ = interrupted_sp;
 
-    if (sp < stack_bounds.low) return .stack_overflow;
+    const stack_bounds = bounds orelse return .access_violation;
+
     if (stack_bounds.containsGuardAddress(fault_addr)) return .stack_overflow;
-    if (stack_bounds.containsLowerBoundaryFault(fault_addr, sp)) return .stack_overflow;
+    if (stack_bounds.containsLowerBoundaryAddress(fault_addr)) return .stack_overflow;
     return .access_violation;
 }
 
@@ -452,9 +448,10 @@ test "classifyFault uses only exact stack data" {
 
     try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, 0x8000, bounds));
     try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, 0x9000, bounds));
+    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, 0x5ff0, bounds));
     try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6800, 0x8000, bounds));
-    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x5000, 0x5ff0, bounds));
-    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(0x6800, null, bounds));
+    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(0x5000, 0x5ff0, bounds));
+    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6800, null, bounds));
     try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, 0x8000, null));
 }
 
@@ -463,8 +460,9 @@ test "classifyFault treats a lower stack boundary fault as overflow" {
 
     try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6ff0, 0x7000, bounds));
     try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6000, 0x7000, bounds));
+    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6ff0, 0x8001, bounds));
+    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6ff0, null, bounds));
     try std.testing.expectEqual(FaultKind.access_violation, classifyFault(0x5ff0, 0x7000, bounds));
-    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(0x6ff0, 0x8001, bounds));
     try std.testing.expectEqual(FaultKind.access_violation, classifyFault(0x1000_1000, 0x7000, bounds));
 }
 

--- a/src/base/signal_handler.zig
+++ b/src/base/signal_handler.zig
@@ -176,10 +176,8 @@ pub fn currentThreadStackBoundsForTest() ?StackBounds {
     return thread_stack_bounds;
 }
 
-/// Classify a fault from its address, interrupted stack pointer, and stack range.
-pub fn classifyFault(fault_addr: usize, interrupted_sp: ?usize, bounds: ?StackBounds) FaultKind {
-    _ = interrupted_sp;
-
+/// Classify a fault from its address and stack range.
+pub fn classifyFault(fault_addr: usize, bounds: ?StackBounds) FaultKind {
     const stack_bounds = bounds orelse return .access_violation;
 
     if (stack_bounds.containsGuardAddress(fault_addr)) return .stack_overflow;
@@ -264,11 +262,10 @@ fn handleExceptionWindows(exception_info: *EXCEPTION_POINTERS) callconv(.winapi)
     ExitProcess(139);
 }
 
-fn handleSegvSignal(_: i32, info: *const posix.siginfo_t, context: ?*anyopaque) callconv(.c) void {
+fn handleSegvSignal(_: i32, info: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {
     const fault_addr = getFaultAddress(info);
-    const interrupted_sp = getInterruptedStackPointer(context);
 
-    switch (classifyFault(fault_addr, interrupted_sp, thread_stack_bounds)) {
+    switch (classifyFault(fault_addr, thread_stack_bounds)) {
         .stack_overflow => {
             if (stack_overflow_callback) |callback| callback();
             posix.exit(134);
@@ -302,54 +299,6 @@ fn getFaultAddress(info: *const posix.siginfo_t) usize {
     } else {
         return 0;
     }
-}
-
-fn getInterruptedStackPointer(context: ?*anyopaque) ?usize {
-    const context_ptr = context orelse return null;
-
-    if (comptime posix.ucontext_t == void) {
-        return null;
-    }
-
-    const unaligned: *align(1) posix.ucontext_t = @ptrCast(context_ptr);
-    var ctx = unaligned.*;
-
-    if (comptime builtin.os.tag == .macos or
-        builtin.os.tag == .ios or
-        builtin.os.tag == .tvos or
-        builtin.os.tag == .watchos or
-        builtin.os.tag == .visionos)
-    {
-        if (comptime builtin.cpu.arch == .aarch64) {
-            ctx.__mcontext_data = @as(*align(1) extern struct {
-                onstack: c_int,
-                sigmask: std.c.sigset_t,
-                stack: std.c.stack_t,
-                link: ?*std.c.ucontext_t,
-                mcsize: u64,
-                mcontext: *std.c.mcontext_t,
-                __mcontext_data: std.c.mcontext_t align(@sizeOf(usize)),
-            }, @ptrCast(unaligned)).__mcontext_data;
-        }
-        ctx.mcontext = &ctx.__mcontext_data;
-
-        return switch (builtin.cpu.arch) {
-            .aarch64 => @intCast(ctx.mcontext.ss.sp),
-            .x86_64 => @intCast(ctx.mcontext.ss.rsp),
-            else => null,
-        };
-    }
-
-    if (comptime builtin.os.tag == .linux) {
-        return switch (builtin.cpu.arch) {
-            .x86_64 => ctx.mcontext.gregs[std.os.linux.REG.RSP],
-            .x86 => ctx.mcontext.gregs[std.os.linux.REG.ESP],
-            .aarch64 => ctx.mcontext.sp,
-            else => null,
-        };
-    }
-
-    return null;
 }
 
 fn queryCurrentThreadStackBounds() ?StackBounds {
@@ -446,24 +395,24 @@ test "classifyFault uses only exact stack data" {
     const bounds = StackBounds.init(0x7000, 0x9000, 0x1000, 0x6000, 0x7000).?;
     const unrelated_addr: usize = 0x5000_0000;
 
-    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, 0x8000, bounds));
-    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, 0x9000, bounds));
-    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, 0x5ff0, bounds));
-    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6800, 0x8000, bounds));
-    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(0x5000, 0x5ff0, bounds));
-    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6800, null, bounds));
-    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, 0x8000, null));
+    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, bounds));
+    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, bounds));
+    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, bounds));
+    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6800, bounds));
+    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(0x5000, bounds));
+    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6800, bounds));
+    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(unrelated_addr, null));
 }
 
 test "classifyFault treats a lower stack boundary fault as overflow" {
     const bounds = StackBounds.init(0x7000, 0x9000, 0x1000, null, null).?;
 
-    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6ff0, 0x7000, bounds));
-    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6000, 0x7000, bounds));
-    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6ff0, 0x8001, bounds));
-    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6ff0, null, bounds));
-    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(0x5ff0, 0x7000, bounds));
-    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(0x1000_1000, 0x7000, bounds));
+    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6ff0, bounds));
+    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6000, bounds));
+    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6ff0, bounds));
+    try std.testing.expectEqual(FaultKind.stack_overflow, classifyFault(0x6ff0, bounds));
+    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(0x5ff0, bounds));
+    try std.testing.expectEqual(FaultKind.access_violation, classifyFault(0x1000_1000, bounds));
 }
 
 test "installForCurrentThread records current stack bounds" {

--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -763,6 +763,7 @@ pub fn deinitCachedModule(self: *Self) void {
     self.numeral_digit_bytes.deinit(self.gpa);
     self.numeral_literals.deinit(self.gpa);
     self.numeral_dispatch_plans.deinit(self.gpa);
+    self.numeric_suffix_types.deinit(self.gpa);
 
     // If enableRuntimeInserts was called on the interner, it allocated new memory
     // that needs to be freed. The interner.deinit checks supports_inserts internally
@@ -2791,10 +2792,10 @@ pub const Serialized = extern struct {
             .idents = self.idents,
             .import_mapping = types_mod.import_mapping.ImportMapping.init(gpa),
             .method_idents = self.method_idents.deserializeInto(base_addr),
-            .for_loop_dispatch_plans = try ForLoopDispatchPlan.SafeList.initCapacity(gpa, 4),
+            .for_loop_dispatch_plans = try self.for_loop_dispatch_plans.deserializeWithCopy(base_addr, gpa),
             .numeral_digit_bytes = try self.numeral_digit_bytes.deserializeWithCopy(base_addr, gpa),
             .numeral_literals = try self.numeral_literals.deserializeWithCopy(base_addr, gpa),
-            .numeral_dispatch_plans = try NumeralDispatchPlan.SafeList.initCapacity(gpa, 8),
+            .numeral_dispatch_plans = try self.numeral_dispatch_plans.deserializeWithCopy(base_addr, gpa),
             .numeric_suffix_types = try self.numeric_suffix_types.deserializeWithCopy(base_addr, gpa),
         };
 

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -15660,6 +15660,56 @@ pub fn loweringViewWithRelations(
     };
 }
 
+pub const CheckedModuleKeyInputs = struct {
+    imports: []const PublishImportArtifact = &.{},
+    platform_requirement_context: ?PlatformRequirementContextKey = null,
+    platform_app_relation: ?PlatformAppRelationKey = null,
+};
+
+pub fn checkedModuleKeyFromTypedModule(
+    allocator: Allocator,
+    modules: *const TypedCIR.Modules,
+    module_idx: u32,
+    inputs: CheckedModuleKeyInputs,
+) Allocator.Error!CheckedModuleArtifactKey {
+    const module = modules.module(module_idx);
+    const module_env = module.moduleEnvConst();
+    const idents = module.identStoreConst();
+
+    var canonical_names = canonical.CanonicalNameStore.init(allocator);
+    defer canonical_names.deinit();
+    const module_name = try canonical_names.internModuleName(module_env.module_name);
+    const display_module_name = try canonical_names.internModuleIdent(idents, module_env.display_module_name_idx);
+    const qualified_module_name = try canonical_names.internModuleIdent(idents, module_env.qualified_module_ident);
+    const module_identity = ModuleIdentity{
+        .stable_hash = computeStableModuleIdentityHash(module_env),
+        .module_idx = module_idx,
+        .module_name = module_name,
+        .display_module_name = display_module_name,
+        .qualified_module_name = qualified_module_name,
+        .kind = module_env.module_kind,
+    };
+
+    var checking_context_identity = try CheckingContextIdentity.fromModule(
+        allocator,
+        module,
+        inputs.imports,
+        inputs.platform_requirement_context,
+        inputs.platform_app_relation,
+    );
+    defer checking_context_identity.deinit(allocator);
+
+    const direct_import_artifact_keys = try directImportArtifactKeysFromModule(allocator, module, inputs.imports);
+    defer allocator.free(direct_import_artifact_keys);
+
+    return CheckedModuleArtifactKey.compute(
+        module_env.getSourceAll(),
+        module_identity,
+        checking_context_identity,
+        direct_import_artifact_keys,
+    );
+}
+
 /// Public `publishFromTypedModule` function.
 pub fn publishFromTypedModule(
     allocator: Allocator,

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -7087,7 +7087,7 @@ pub const ResolvedValueRefTable = struct {
                 }
                 unreachable;
             };
-            try attachUseTypePayload(allocator, artifact_key, &checked_types.store, &resolved_ref, checked_type_key, checked_ty);
+            try attachUseTypePayload(&resolved_ref, checked_type_key, checked_ty);
 
             const id: ResolvedValueRefId = @enumFromInt(@as(u32, @intCast(records.items.len)));
             try records.append(allocator, .{
@@ -7186,25 +7186,16 @@ fn categorizeValueRef(
 }
 
 fn attachUseTypePayload(
-    allocator: Allocator,
-    artifact_key: CheckedModuleArtifactKey,
-    checked_types: *const CheckedTypeStore,
     ref: *ResolvedValueRef,
     key: canonical.CanonicalTypeKey,
     checked_ty: CheckedTypeId,
 ) Allocator.Error!void {
     switch (ref.*) {
         .top_level_const => |*use| {
-            _ = allocator;
-            _ = artifact_key;
-            _ = checked_types;
             use.requested_source_ty_template = key;
             use.requested_source_ty_payload = checked_ty;
         },
         .imported_const => |*use| {
-            _ = allocator;
-            _ = artifact_key;
-            _ = checked_types;
             use.requested_source_ty_template = key;
             use.requested_source_ty_payload = checked_ty;
         },

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -645,7 +645,8 @@ pub const RootRequestTable = struct {
         }
 
         for (compile_time_roots.roots) |root| {
-            if (root.kind != .expect and !try checkedTypeIsConcreteCompileTimeRoot(allocator, &checked_types.store, root.checked_type)) {
+            const concrete = root.kind == .expect or try checkedTypeIsConcreteCompileTimeRoot(allocator, &checked_types.store, root.checked_type);
+            if (!concrete) {
                 continue;
             }
             if (compileTimeRootDependsOnUnboundPlatformRequirement(
@@ -752,16 +753,33 @@ fn checkedTypeIsConcreteCompileTimeRootInner(
     }
     return switch (checked_types.payloads[index]) {
         .pending => checkedArtifactInvariant("compile-time root checked type was pending", .{}),
-        .flex, .rigid => |variable| variable.row_default != null,
+        .flex,
+        .rigid,
+        => false,
         .empty_record,
         .empty_tag_union,
         => true,
-        .alias => |alias| checkedTypeIsConcreteCompileTimeRootInner(checked_types, alias.backing, active),
+        .alias => |alias| (try checkedTypeSpanIsConcreteCompileTimeRoot(checked_types, alias.args, active)) and
+            try checkedTypeIsConcreteCompileTimeRootInner(checked_types, alias.backing, active),
         .record => |record| (try checkedFieldTypesAreConcreteCompileTimeRoots(checked_types, record.fields, active)) and
             try checkedTypeIsConcreteCompileTimeRootInner(checked_types, record.ext, active),
         .record_unbound => |fields| checkedFieldTypesAreConcreteCompileTimeRoots(checked_types, fields, active),
         .tuple => |items| checkedTypeSpanIsConcreteCompileTimeRoot(checked_types, items, active),
-        .nominal => |nominal| checkedTypeSpanIsConcreteCompileTimeRoot(checked_types, nominal.args, active),
+        .nominal => |nominal| blk: {
+            if (!try checkedTypeSpanIsConcreteCompileTimeRoot(checked_types, nominal.args, active)) break :blk false;
+            switch (nominal.representation) {
+                .builtin => |builtin_type| switch (builtinRuntimeEncoding(builtin_type)) {
+                    .primitive,
+                    .list,
+                    .box,
+                    => break :blk true,
+                    .bool_tag_union => {},
+                },
+                .opaque_without_backing => break :blk true,
+                else => {},
+            }
+            break :blk try checkedTypeIsConcreteCompileTimeRootInner(checked_types, nominal.backing, active);
+        },
         .function => |function| !function.needs_instantiation and
             (try checkedTypeSpanIsConcreteCompileTimeRoot(checked_types, function.args, active)) and
             try checkedTypeIsConcreteCompileTimeRootInner(checked_types, function.ret, active),
@@ -7177,14 +7195,18 @@ fn attachUseTypePayload(
 ) Allocator.Error!void {
     switch (ref.*) {
         .top_level_const => |*use| {
-            const request = try constUseRequestPayload(allocator, artifact_key, checked_types, use.const_ref, key, checked_ty);
-            use.requested_source_ty_template = request.key;
-            use.requested_source_ty_payload = request.payload;
+            _ = allocator;
+            _ = artifact_key;
+            _ = checked_types;
+            use.requested_source_ty_template = key;
+            use.requested_source_ty_payload = checked_ty;
         },
         .imported_const => |*use| {
-            const request = try constUseRequestPayload(allocator, artifact_key, checked_types, use.const_ref, key, checked_ty);
-            use.requested_source_ty_template = request.key;
-            use.requested_source_ty_payload = request.payload;
+            _ = allocator;
+            _ = artifact_key;
+            _ = checked_types;
+            use.requested_source_ty_template = key;
+            use.requested_source_ty_payload = checked_ty;
         },
         .platform_required_const => |*required| {
             if (required.const_use.requested_source_ty_payload == null) {
@@ -7220,118 +7242,6 @@ fn attachUseTypePayload(
         .platform_required_declaration,
         => {},
     }
-}
-
-const ConstUseRequestPayload = struct {
-    key: canonical.CanonicalTypeKey,
-    payload: CheckedTypeId,
-};
-
-fn constUseRequestPayload(
-    allocator: Allocator,
-    artifact_key: CheckedModuleArtifactKey,
-    checked_types: *const CheckedTypeStore,
-    const_ref: ConstRef,
-    use_key: canonical.CanonicalTypeKey,
-    use_payload: CheckedTypeId,
-) Allocator.Error!ConstUseRequestPayload {
-    if (!std.meta.eql(const_ref.artifact.bytes, artifact_key.bytes)) {
-        return .{ .key = use_key, .payload = use_payload };
-    }
-
-    const scheme = checked_types.schemeForKey(const_ref.source_scheme) orelse {
-        checkedArtifactInvariant("local const use referenced a missing producer source scheme", .{});
-    };
-    const concrete_producer = try checkedTypeIsConcreteConstProducerScheme(allocator, checked_types, scheme.root);
-    if (!concrete_producer) {
-        return .{ .key = use_key, .payload = use_payload };
-    }
-
-    return .{
-        .key = checked_types.roots[@intFromEnum(scheme.root)].key,
-        .payload = scheme.root,
-    };
-}
-
-fn checkedTypeIsConcreteConstProducerScheme(
-    allocator: Allocator,
-    checked_types: *const CheckedTypeStore,
-    root: CheckedTypeId,
-) Allocator.Error!bool {
-    var active = std.AutoHashMap(CheckedTypeId, void).init(allocator);
-    defer active.deinit();
-    return try checkedTypeIsConcreteConstProducerSchemeInner(checked_types, root, &active);
-}
-
-fn checkedTypeIsConcreteConstProducerSchemeInner(
-    checked_types: *const CheckedTypeStore,
-    root: CheckedTypeId,
-    active: *std.AutoHashMap(CheckedTypeId, void),
-) Allocator.Error!bool {
-    if (active.contains(root)) return true;
-    try active.put(root, {});
-    defer _ = active.remove(root);
-
-    const index = @intFromEnum(root);
-    if (index >= checked_types.payloads.len) {
-        checkedArtifactInvariant("const producer checked type id is out of range", .{});
-    }
-    return switch (checked_types.payloads[index]) {
-        .pending => checkedArtifactInvariant("const producer checked type was pending", .{}),
-        .flex, .rigid => |variable| variable.row_default != null,
-        .empty_record,
-        .empty_tag_union,
-        => true,
-        .alias => |alias| (try checkedTypeIsConcreteConstProducerSchemeInner(checked_types, alias.backing, active)) and
-            try checkedTypeSpanIsConcreteConstProducerScheme(checked_types, alias.args, active),
-        .record => |record| (try checkedFieldTypesAreConcreteConstProducerScheme(checked_types, record.fields, active)) and
-            try checkedTypeIsConcreteConstProducerSchemeInner(checked_types, record.ext, active),
-        .record_unbound => |fields| checkedFieldTypesAreConcreteConstProducerScheme(checked_types, fields, active),
-        .tuple => |items| checkedTypeSpanIsConcreteConstProducerScheme(checked_types, items, active),
-        .nominal => |nominal| blk: {
-            if (!try checkedTypeSpanIsConcreteConstProducerScheme(checked_types, nominal.args, active)) break :blk false;
-            if (nominal.builtin != null) break :blk true;
-            break :blk try checkedTypeIsConcreteConstProducerSchemeInner(checked_types, nominal.backing, active);
-        },
-        .function => |function| !function.needs_instantiation and
-            (try checkedTypeSpanIsConcreteConstProducerScheme(checked_types, function.args, active)) and
-            try checkedTypeIsConcreteConstProducerSchemeInner(checked_types, function.ret, active),
-        .tag_union => |tag_union| (try checkedTagsAreConcreteConstProducerScheme(checked_types, tag_union.tags, active)) and
-            try checkedTypeIsConcreteConstProducerSchemeInner(checked_types, tag_union.ext, active),
-    };
-}
-
-fn checkedTypeSpanIsConcreteConstProducerScheme(
-    checked_types: *const CheckedTypeStore,
-    items: []const CheckedTypeId,
-    active: *std.AutoHashMap(CheckedTypeId, void),
-) Allocator.Error!bool {
-    for (items) |item| {
-        if (!try checkedTypeIsConcreteConstProducerSchemeInner(checked_types, item, active)) return false;
-    }
-    return true;
-}
-
-fn checkedFieldTypesAreConcreteConstProducerScheme(
-    checked_types: *const CheckedTypeStore,
-    fields: []const CheckedRecordField,
-    active: *std.AutoHashMap(CheckedTypeId, void),
-) Allocator.Error!bool {
-    for (fields) |field| {
-        if (!try checkedTypeIsConcreteConstProducerSchemeInner(checked_types, field.ty, active)) return false;
-    }
-    return true;
-}
-
-fn checkedTagsAreConcreteConstProducerScheme(
-    checked_types: *const CheckedTypeStore,
-    tags: []const CheckedTag,
-    active: *std.AutoHashMap(CheckedTypeId, void),
-) Allocator.Error!bool {
-    for (tags) |tag| {
-        if (!try checkedTypeSpanIsConcreteConstProducerScheme(checked_types, tag.args, active)) return false;
-    }
-    return true;
 }
 
 fn categorizeLocalValueRef(

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -15660,12 +15660,16 @@ pub fn loweringViewWithRelations(
     };
 }
 
+/// Inputs from imported modules and platform relation checking that participate
+/// in the checked module cache identity.
 pub const CheckedModuleKeyInputs = struct {
     imports: []const PublishImportArtifact = &.{},
     platform_requirement_context: ?PlatformRequirementContextKey = null,
     platform_app_relation: ?PlatformAppRelationKey = null,
 };
 
+/// Compute the checked module cache identity for a checked typed module and the
+/// checked data it depends on.
 pub fn checkedModuleKeyFromTypedModule(
     allocator: Allocator,
     modules: *const TypedCIR.Modules,

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -3400,9 +3400,6 @@ fn rocBuildNative(ctx: *CliContext, args: cli_args.BuildArgs) !void {
     if (!args.suppress_build_status) {
         const stdout = ctx.io.stdout();
         try stdout.print("Built {s} in {d:.1}ms", .{ final_output_path, elapsed_ms });
-        if (cache_stats.modules_total > 0 and cache_stats.cache_hits > 0) {
-            try stdout.print(" with {}% cache hit", .{cache_percent});
-        }
         try stdout.writeAll(" (checked-artifact native backend)\n");
 
         if (args.verbose) {
@@ -3741,9 +3738,6 @@ fn rocBuildEmbedded(ctx: *CliContext, args: cli_args.BuildArgs) !void {
     if (!args.suppress_build_status) {
         const stdout = ctx.io.stdout();
         try stdout.print("Built {s} in {d:.1}ms", .{ final_output_path, elapsed_ms });
-        if (cache_stats.modules_total > 0 and cache_stats.cache_hits > 0) {
-            try stdout.print(" with {}% cache hit", .{cache_percent});
-        }
         try stdout.writeAll(" (checked-artifact embedded interpreter)\n");
 
         if (args.verbose) {
@@ -5078,9 +5072,6 @@ fn rocCheck(ctx: *CliContext, args: cli_args.CheckArgs) !void {
     // Flush stderr to ensure all error output is visible
     ctx.io.flush();
 
-    // Compute cache hit percentage
-    const cache_percent = cacheHitPercent(check_result.cache_hits, check_result.cache_misses);
-
     if (check_result.error_count > 0 or check_result.warning_count > 0) {
         stderr.writeAll("\n") catch {};
         stderr.print("Found {} error(s) and {} warning(s) in ", .{
@@ -5088,10 +5079,6 @@ fn rocCheck(ctx: *CliContext, args: cli_args.CheckArgs) !void {
             check_result.warning_count,
         }) catch {};
         formatElapsedTimeMs(stderr, elapsed) catch {};
-        // Include inline cache stats summary
-        if (check_result.modules_total > 0 and check_result.cache_hits > 0) {
-            stderr.print(" with {}% cache hit", .{cache_percent}) catch {};
-        }
         stderr.print(" for {s}.\n", .{args.path}) catch {};
 
         // Print verbose stats if requested
@@ -5111,10 +5098,6 @@ fn rocCheck(ctx: *CliContext, args: cli_args.CheckArgs) !void {
     } else {
         stdout.print("No errors found in ", .{}) catch {};
         formatElapsedTimeMs(stdout, elapsed) catch {};
-        // Include inline cache stats summary
-        if (check_result.modules_total > 0 and check_result.cache_hits > 0) {
-            stdout.print(" with {}% cache hit", .{cache_percent}) catch {};
-        }
         stdout.print(" for {s}\n", .{args.path}) catch {};
 
         // Print verbose stats if requested

--- a/src/cli/test/roc_subcommands.zig
+++ b/src/cli/test/roc_subcommands.zig
@@ -1436,18 +1436,38 @@ test "roc test runs expects in Parser type module (interpreter)" {
     const has_passed = std.mem.indexOf(u8, result.stdout, "passed") != null;
     try testing.expect(has_passed);
 
-    // 3. Should have run 2 tests (extract count from "(N)" in output)
+    // 3. Should have run 5 tests (extract count from "(N)" in output)
     const count = blk: {
         const open = std.mem.indexOf(u8, result.stdout, "(") orelse break :blk @as(usize, 0);
         const close = std.mem.indexOfPos(u8, result.stdout, open, ")") orelse break :blk @as(usize, 0);
         break :blk std.fmt.parseInt(usize, result.stdout[open + 1 .. close], 10) catch 0;
     };
-    try testing.expect(count == 2);
+    try testing.expect(count == 5);
 }
 
 test "roc test runs expects in Parser type module (dev)" {
-    // TODO: dev backend compilation fails for test/package_simple_parser/Parser.roc
-    return error.SkipZigTest;
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    const result = try util.runRoc(gpa, &.{ "test", "--opt=dev", "--no-cache" }, "test/package_simple_parser/Parser.roc");
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    // Verify that:
+    // 1. Command succeeded (zero exit code)
+    try testing.expect(result.term == .Exited and result.term.Exited == 0);
+
+    // 2. Output indicates tests passed
+    const has_passed = std.mem.indexOf(u8, result.stdout, "passed") != null;
+    try testing.expect(has_passed);
+
+    // 3. Should have run 5 tests (extract count from "(N)" in output)
+    const count = blk: {
+        const open = std.mem.indexOf(u8, result.stdout, "(") orelse break :blk @as(usize, 0);
+        const close = std.mem.indexOfPos(u8, result.stdout, open, ")") orelse break :blk @as(usize, 0);
+        break :blk std.fmt.parseInt(usize, result.stdout[open + 1 .. close], 10) catch 0;
+    };
+    try testing.expect(count == 5);
 }
 
 test "roc test polymorphic list reverse with numeric literal does not overflow (interpreter)" {

--- a/src/compile/cache_manager.zig
+++ b/src/compile/cache_manager.zig
@@ -23,13 +23,6 @@ pub const CacheManager = struct {
 
     const Self = @This();
 
-    fn verboseLog(self: *Self, comptime fmt: []const u8, args: anytype) void {
-        if (!self.config.verbose) return;
-        var buf: [1024]u8 = undefined;
-        const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
-        self.io.writeStderr(msg) catch {};
-    }
-
     pub fn init(allocator: Allocator, config: CacheConfig, io: Io) Self {
         return .{
             .config = config,
@@ -73,8 +66,7 @@ pub const CacheManager = struct {
     pub fn storeRawBytes(self: *Self, cache_key: [32]u8, data: []const u8, entries_dir: []const u8) void {
         if (!self.config.enabled) return;
 
-        self.ensureCacheSubdirIn(cache_key, entries_dir) catch |err| {
-            self.verboseLog("Failed to create cache subdirectory: {}\n", .{err});
+        self.ensureCacheSubdirIn(cache_key, entries_dir) catch {
             self.stats.recordStoreFailure();
             return;
         };
@@ -91,14 +83,12 @@ pub const CacheManager = struct {
         };
         defer self.allocator.free(temp_path);
 
-        self.io.writeFile(temp_path, data) catch |err| {
-            self.verboseLog("Failed to write cache temp file {s}: {}\n", .{ temp_path, err });
+        self.io.writeFile(temp_path, data) catch {
             self.stats.recordStoreFailure();
             return;
         };
 
-        self.io.rename(temp_path, cache_path) catch |err| {
-            self.verboseLog("Failed to rename cache file {s} -> {s}: {}\n", .{ temp_path, cache_path, err });
+        self.io.rename(temp_path, cache_path) catch {
             self.stats.recordStoreFailure();
             return;
         };
@@ -120,8 +110,7 @@ pub const CacheManager = struct {
             return null;
         }
 
-        const data = self.io.readFile(cache_path, self.allocator) catch |err| {
-            self.verboseLog("Failed to read cache file {s}: {}\n", .{ cache_path, err });
+        const data = self.io.readFile(cache_path, self.allocator) catch {
             self.stats.recordMiss();
             return null;
         };

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -40,6 +40,7 @@ const parse = @import("parse");
 const reporting = @import("reporting");
 const eval = @import("eval");
 const base = @import("base");
+const collections = @import("collections");
 const build_options = @import("build_options");
 
 const CIR = can.CIR;
@@ -51,6 +52,8 @@ const compile_build = @import("compile_build.zig");
 const module_discovery = @import("module_discovery.zig");
 const cache_manager_mod = @import("cache_manager.zig");
 const CacheManager = cache_manager_mod.CacheManager;
+const CacheConfig = @import("cache_config.zig").CacheConfig;
+const CacheStats = @import("cache_config.zig").CacheStats;
 const app_header_mod = @import("app_header.zig");
 const roc_target = @import("roc_target");
 
@@ -59,9 +62,11 @@ const trace_build = if (@hasDecl(build_options, "trace_build")) build_options.tr
 
 const Allocator = std.mem.Allocator;
 const ModuleEnv = can.ModuleEnv;
+const CompactWriter = collections.CompactWriter;
 const Report = reporting.Report;
 const AST = parse.AST;
 const BuiltinModules = eval.BuiltinModules;
+const CheckedModules = check.TypedCIR.Modules;
 
 const WorkerTask = messages.WorkerTask;
 const WorkerResult = messages.WorkerResult;
@@ -102,6 +107,84 @@ const thread_safe_allocator: Allocator = if (threads_available)
     std.heap.smp_allocator
 else
     std.heap.page_allocator;
+
+const checked_module_cache_magic = "roc-mod-cache-v1";
+const checked_module_cache_format_version: u64 = 1;
+const checked_module_cache_header_len: usize = checked_module_cache_magic.len + 8 + 32 + 32;
+
+fn writeU64Little(buf: []u8, value: u64) void {
+    std.debug.assert(buf.len == 8);
+    buf[0] = @truncate(value);
+    buf[1] = @truncate(value >> 8);
+    buf[2] = @truncate(value >> 16);
+    buf[3] = @truncate(value >> 24);
+    buf[4] = @truncate(value >> 32);
+    buf[5] = @truncate(value >> 40);
+    buf[6] = @truncate(value >> 48);
+    buf[7] = @truncate(value >> 56);
+}
+
+fn readU64Little(buf: []const u8) u64 {
+    std.debug.assert(buf.len == 8);
+    return @as(u64, buf[0]) |
+        (@as(u64, buf[1]) << 8) |
+        (@as(u64, buf[2]) << 16) |
+        (@as(u64, buf[3]) << 24) |
+        (@as(u64, buf[4]) << 32) |
+        (@as(u64, buf[5]) << 40) |
+        (@as(u64, buf[6]) << 48) |
+        (@as(u64, buf[7]) << 56);
+}
+
+fn hashCacheBody(body: []const u8) [32]u8 {
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    hasher.update(body);
+    return hasher.finalResult();
+}
+
+fn encodeCheckedModuleCacheEntry(
+    allocator: Allocator,
+    key: check.CheckedArtifact.CheckedModuleArtifactKey,
+    body: []const u8,
+) Allocator.Error![]u8 {
+    const bytes = try allocator.alloc(u8, checked_module_cache_header_len + body.len);
+    errdefer allocator.free(bytes);
+
+    var offset: usize = 0;
+    @memcpy(bytes[offset..][0..checked_module_cache_magic.len], checked_module_cache_magic);
+    offset += checked_module_cache_magic.len;
+    writeU64Little(bytes[offset..][0..8], checked_module_cache_format_version);
+    offset += 8;
+    @memcpy(bytes[offset..][0..32], &key.bytes);
+    offset += 32;
+    const body_hash = hashCacheBody(body);
+    @memcpy(bytes[offset..][0..32], &body_hash);
+    offset += 32;
+    @memcpy(bytes[offset..], body);
+
+    return bytes;
+}
+
+fn decodeCheckedModuleCacheEntry(
+    key: check.CheckedArtifact.CheckedModuleArtifactKey,
+    bytes: []const u8,
+) ?[]const u8 {
+    if (bytes.len < checked_module_cache_header_len) return null;
+    var offset: usize = 0;
+    if (!std.mem.eql(u8, bytes[offset..][0..checked_module_cache_magic.len], checked_module_cache_magic)) return null;
+    offset += checked_module_cache_magic.len;
+    if (readU64Little(bytes[offset..][0..8]) != checked_module_cache_format_version) return null;
+    offset += 8;
+    if (!std.mem.eql(u8, bytes[offset..][0..32], &key.bytes)) return null;
+    offset += 32;
+    const stored_hash = bytes[offset..][0..32];
+    offset += 32;
+    const body = bytes[offset..];
+    const actual_hash = hashCacheBody(body);
+    if (!std.mem.eql(u8, stored_hash, &actual_hash)) return null;
+    if (body.len < @sizeOf(ModuleEnv.Serialized)) return null;
+    return body;
+}
 
 /// Allocators for a worker thread. Each worker has its own instance.
 /// This ensures thread-safe allocations without contention.
@@ -539,7 +622,7 @@ pub const Coordinator = struct {
     /// Compiler version for cache keys
     compiler_version: []const u8,
 
-    /// Optional cache manager for disk caching (not yet integrated)
+    /// Optional cache manager for transparent checked-module disk caching.
     cache_manager: ?*CacheManager,
 
     /// Cross-package dependents: when module (pkg, id) completes, notify these modules
@@ -1658,6 +1741,223 @@ pub const Coordinator = struct {
         return semantic;
     }
 
+    fn serializeModuleEnvForCache(self: *Coordinator, env: *const ModuleEnv) Allocator.Error![]u8 {
+        const allocator = self.cache_manager.?.allocator;
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        defer arena.deinit();
+        const arena_alloc = arena.allocator();
+
+        var writer = CompactWriter.init();
+        defer writer.deinit(arena_alloc);
+
+        const serialized = try writer.appendAlloc(arena_alloc, ModuleEnv.Serialized);
+        try serialized.serialize(env, arena_alloc, &writer);
+
+        const body = try allocator.alloc(u8, writer.total_bytes);
+        errdefer allocator.free(body);
+        _ = writer.writeToBuffer(body) catch unreachable;
+        return body;
+    }
+
+    fn checkedModuleCacheKey(
+        self: *Coordinator,
+        env: *ModuleEnv,
+        imported_envs: []const *ModuleEnv,
+        imported_artifacts: []const check.CheckedArtifact.PublishImportArtifact,
+    ) Allocator.Error!check.CheckedArtifact.CheckedModuleArtifactKey {
+        var imported_source_count: usize = 0;
+        for (imported_envs) |imported_env| {
+            if (std.mem.eql(u8, env.module_name, "Builtin") and
+                std.mem.eql(u8, imported_env.module_name, "Builtin")) continue;
+            imported_source_count += 1;
+        }
+
+        var source_modules = try self.gpa.alloc(CheckedModules.SourceModule, imported_source_count + 1);
+        defer self.gpa.free(source_modules);
+
+        var source_index: usize = 0;
+        for (imported_envs) |imported_env| {
+            if (std.mem.eql(u8, env.module_name, "Builtin") and
+                std.mem.eql(u8, imported_env.module_name, "Builtin")) continue;
+            source_modules[source_index] = .{ .precompiled = imported_env };
+            source_index += 1;
+        }
+
+        const module_idx: u32 = @intCast(imported_source_count);
+        source_modules[imported_source_count] = .{ .precompiled = env };
+
+        var typed_modules = try CheckedModules.init(self.gpa, source_modules);
+        defer typed_modules.deinit();
+
+        return check.CheckedArtifact.checkedModuleKeyFromTypedModule(
+            self.gpa,
+            &typed_modules,
+            module_idx,
+            .{ .imports = imported_artifacts },
+        );
+    }
+
+    fn storeCheckedModuleInCache(self: *Coordinator, artifact: *const check.CheckedArtifact.CheckedModuleArtifact) void {
+        const manager = self.cache_manager orelse return;
+        if (!manager.config.enabled) return;
+
+        const entries_dir = manager.config.getCheckedArtifactCacheDir(manager.allocator) catch {
+            manager.stats.recordStoreFailure();
+            return;
+        };
+        defer manager.allocator.free(entries_dir);
+
+        const body = self.serializeModuleEnvForCache(artifact.moduleEnvConst()) catch {
+            manager.stats.recordStoreFailure();
+            return;
+        };
+        defer manager.allocator.free(body);
+
+        const entry = encodeCheckedModuleCacheEntry(manager.allocator, artifact.key, body) catch {
+            manager.stats.recordStoreFailure();
+            return;
+        };
+        defer manager.allocator.free(entry);
+
+        manager.storeRawBytes(artifact.key.bytes, entry, entries_dir);
+    }
+
+    fn tryLoadCachedCheckedModule(
+        self: *Coordinator,
+        pkg: *PackageState,
+        mod: *ModuleState,
+        imported_envs: []const *ModuleEnv,
+        imported_artifacts: []const check.CheckedArtifact.PublishImportArtifact,
+        available_artifacts: []const check.CheckedArtifact.ImportedModuleView,
+    ) bool {
+        const manager = self.cache_manager orelse return false;
+        if (!manager.config.enabled) return false;
+
+        const current_env = mod.moduleEnv() orelse return false;
+        const cache_key = self.checkedModuleCacheKey(current_env, imported_envs, imported_artifacts) catch return false;
+
+        const entries_dir = manager.config.getCheckedArtifactCacheDir(manager.allocator) catch {
+            manager.stats.recordMiss();
+            return false;
+        };
+        defer manager.allocator.free(entries_dir);
+
+        const entry = manager.loadRawBytes(cache_key.bytes, entries_dir) orelse return false;
+        defer manager.allocator.free(entry);
+
+        const body = decodeCheckedModuleCacheEntry(cache_key, entry) orelse {
+            manager.stats.recordInvalidation();
+            return false;
+        };
+
+        const module_alloc = self.getModuleAllocator();
+        const buffer = module_alloc.alignedAlloc(u8, CompactWriter.SERIALIZATION_ALIGNMENT, body.len) catch {
+            manager.stats.recordInvalidation();
+            return false;
+        };
+        @memcpy(buffer, body);
+        var buffer_owned = true;
+        defer if (buffer_owned) module_alloc.free(buffer);
+
+        const source = module_alloc.dupe(u8, current_env.common.source) catch {
+            manager.stats.recordInvalidation();
+            return false;
+        };
+        var source_owned = true;
+        defer if (source_owned) module_alloc.free(source);
+
+        const serialized_ptr: *ModuleEnv.Serialized = @ptrCast(@alignCast(buffer.ptr));
+        const cached_env = serialized_ptr.deserializeWithMutableTypes(
+            @intFromPtr(buffer.ptr),
+            module_alloc,
+            source,
+            mod.name,
+        ) catch {
+            manager.stats.recordInvalidation();
+            return false;
+        };
+        var cached_env_owned = true;
+        defer if (cached_env_owned) {
+            cached_env.deinitCachedModule();
+            module_alloc.destroy(cached_env);
+        };
+
+        var artifact = compile_package.PackageEnv.publishCheckedArtifactFromCheckedModuleWithStorage(
+            module_alloc,
+            cached_env,
+            .{ .cached_buffer = .{
+                .env = cached_env,
+                .buffer = buffer,
+                .source = source,
+            } },
+            imported_envs,
+            imported_artifacts,
+            .{ .available_artifacts = available_artifacts },
+        ) catch {
+            manager.stats.recordInvalidation();
+            return false;
+        };
+        cached_env_owned = false;
+        buffer_owned = false;
+        source_owned = false;
+        var artifact_owned = true;
+        defer if (artifact_owned) artifact.deinit(artifact.canonical_names.allocator);
+
+        if (!std.mem.eql(u8, &artifact.key.bytes, &cache_key.bytes)) {
+            manager.stats.recordInvalidation();
+            return false;
+        }
+
+        const old_env = current_env;
+        const old_env_alloc = old_env.gpa;
+        const old_source = old_env.common.source;
+
+        if (mod.semantic) |*semantic| {
+            semantic.module_env = cached_env;
+            semantic.checked_artifact = artifact;
+        } else {
+            return false;
+        }
+
+        self.registerCheckedArtifact(pkg, mod) catch {
+            if (mod.semantic) |*semantic| {
+                semantic.module_env = old_env;
+                semantic.checked_artifact = null;
+            }
+            manager.stats.recordInvalidation();
+            return false;
+        };
+
+        old_env.deinit();
+        old_env_alloc.destroy(old_env);
+        if (old_source.len > 0) old_env_alloc.free(@constCast(old_source));
+
+        artifact_owned = false;
+        return true;
+    }
+
+    fn finishCachedModule(self: *Coordinator, pkg: *PackageState, mod: *ModuleState) !void {
+        const module_time = mod.compile_time_ns;
+        if (module_time < self.module_time_min_ns) self.module_time_min_ns = module_time;
+        if (module_time > self.module_time_max_ns) self.module_time_max_ns = module_time;
+        self.module_time_sum_ns += module_time;
+
+        mod.phase = .Done;
+        mod.visit_color = .black;
+
+        self.cache_hits += 1;
+
+        if (pkg.remaining_modules > 0) pkg.remaining_modules -= 1;
+        if (self.total_remaining > 0) self.total_remaining -= 1;
+
+        for (mod.dependents.items) |dep_id| {
+            try self.tryUnblock(pkg, dep_id);
+        }
+
+        const module_id = pkg.getModuleId(mod.name) orelse return;
+        try self.wakeCrossPackageDependents(pkg.name, module_id);
+    }
+
     /// Write a BUG diagnostic to stderr via the injected Io. No-op in release builds.
     fn bugReport(self: *Coordinator, comptime fmt: []const u8, args: anytype) void {
         if (comptime builtin.mode == .Debug) {
@@ -1854,6 +2154,24 @@ pub const Coordinator = struct {
         self.total_canonicalize_ns += result.canonicalize_ns;
         self.total_canonicalize_diag_ns += result.canonicalize_diagnostics_ns;
         mod.compile_time_ns += result.canonicalize_ns + result.canonicalize_diagnostics_ns;
+
+        const imported_envs = try self.buildTypecheckImportedEnvs(pkg, mod);
+        errdefer self.gpa.free(imported_envs);
+        const imported_artifacts = try self.buildTypecheckImportedArtifacts(pkg, mod);
+        errdefer self.gpa.free(imported_artifacts);
+        const available_artifacts = try self.collectAvailableArtifactViews(self.gpa);
+        errdefer self.gpa.free(available_artifacts);
+
+        if (mod.reports.items.len == 0 and
+            self.tryLoadCachedCheckedModule(pkg, mod, imported_envs, imported_artifacts, available_artifacts))
+        {
+            self.gpa.free(imported_envs);
+            self.gpa.free(imported_artifacts);
+            self.gpa.free(available_artifacts);
+            try self.finishCachedModule(pkg, mod);
+            return;
+        }
+
         mod.phase = .TypeCheck;
         mod.visit_color = .black;
         try self.enqueueTask(.{
@@ -1863,9 +2181,9 @@ pub const Coordinator = struct {
                 .module_name = mod.name,
                 .path = mod.path,
                 .module_env = mod.moduleEnv().?,
-                .imported_envs = try self.buildTypecheckImportedEnvs(pkg, mod),
-                .imported_artifacts = try self.buildTypecheckImportedArtifacts(pkg, mod),
-                .available_artifacts = try self.collectAvailableArtifactViews(self.gpa),
+                .imported_envs = imported_envs,
+                .imported_artifacts = imported_artifacts,
+                .available_artifacts = available_artifacts,
             },
         });
     }
@@ -1898,6 +2216,9 @@ pub const Coordinator = struct {
             self.unregisterCheckedArtifact(mod);
             mod.replaceCheckedArtifact(artifact);
             try self.registerCheckedArtifact(pkg, mod);
+            if (mod.checkedArtifact()) |cached_artifact| {
+                self.storeCheckedModuleInCache(cached_artifact);
+            }
         } else if (mod.semantic) |*semantic| {
             self.unregisterCheckedArtifact(mod);
             if (semantic.checked_artifact) |*existing| existing.deinit(existing.canonical_names.allocator);
@@ -2454,10 +2775,9 @@ pub const Coordinator = struct {
             };
         };
 
-        // Note: Cache checking now happens in enqueueParseTask (coordinator level)
-        // before tasks are dispatched. This works for both single and multi-threaded modes.
-
         // Parse, canonicalize, type-check
+        // Checked-module disk cache lookup happens after canonicalization,
+        // when the coordinator has the exact module identity and import keys.
 
         // Create ModuleEnv using the long-lived module allocator.
         const module_alloc = self.getModuleAllocator();
@@ -2814,6 +3134,110 @@ pub const Coordinator = struct {
         }
     }
 };
+
+const CheckedModuleCacheRunStats = struct {
+    build: compile_build.BuildEnv.BuildStats,
+    cache: CacheStats,
+};
+
+fn compileAppWithCheckedModuleCache(
+    allocator: Allocator,
+    cache_dir: []const u8,
+    app_path: []const u8,
+) !CheckedModuleCacheRunStats {
+    var cache_manager = CacheManager.init(allocator, .{
+        .enabled = true,
+        .cache_dir = cache_dir,
+    }, Io.default());
+
+    var builtin_modules = try eval.BuiltinModules.init(allocator);
+    defer builtin_modules.deinit();
+
+    var coord = try Coordinator.init(
+        allocator,
+        .single_threaded,
+        1,
+        roc_target.RocTarget.detectNative(),
+        &builtin_modules,
+        build_options.compiler_version,
+        &cache_manager,
+    );
+    defer coord.deinit();
+    coord.enable_hosted_transform = true;
+
+    var arena_impl = std.heap.ArenaAllocator.init(allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    try coord.start();
+    try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
+    try coord.coordinatorLoop();
+    try std.testing.expect(!coord.hasUserErrors());
+
+    return .{
+        .build = coord.getBuildStats(),
+        .cache = cache_manager.stats,
+    };
+}
+
+fn overwriteFilesUnderDir(allocator: Allocator, absolute_dir: []const u8, contents: []const u8) !usize {
+    var dir = try std.fs.cwd().openDir(absolute_dir, .{ .iterate = true });
+    defer dir.close();
+
+    var walker = try dir.walk(allocator);
+    defer walker.deinit();
+
+    var overwritten: usize = 0;
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        try dir.writeFile(.{ .sub_path = entry.path, .data = contents });
+        overwritten += 1;
+    }
+    return overwritten;
+}
+
+test "Coordinator checked module cache hits on second compile" {
+    const allocator = std.testing.allocator;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const cache_dir = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(cache_dir);
+
+    const first = try compileAppWithCheckedModuleCache(allocator, cache_dir, "test/str/app_message.roc");
+    try std.testing.expectEqual(@as(u32, 0), first.build.cache_hits);
+    try std.testing.expect(first.build.modules_compiled > 0);
+    try std.testing.expect(first.cache.stores > 0);
+    try std.testing.expectEqual(@as(u64, 0), first.cache.store_failures);
+
+    const second = try compileAppWithCheckedModuleCache(allocator, cache_dir, "test/str/app_message.roc");
+    try std.testing.expect(second.build.cache_hits > 0);
+    try std.testing.expect(second.build.modules_compiled < first.build.modules_compiled);
+    try std.testing.expect(second.cache.hits > 0);
+}
+
+test "Coordinator corrupt checked module cache entries compile from source" {
+    const allocator = std.testing.allocator;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    const cache_dir = try tmp_dir.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(cache_dir);
+
+    const first = try compileAppWithCheckedModuleCache(allocator, cache_dir, "test/str/app_message.roc");
+    try std.testing.expect(first.cache.stores > 0);
+
+    const config = CacheConfig{ .cache_dir = cache_dir };
+    const checked_module_cache_dir = try config.getCheckedArtifactCacheDir(allocator);
+    defer allocator.free(checked_module_cache_dir);
+    const overwritten = try overwriteFilesUnderDir(allocator, checked_module_cache_dir, "not a checked module cache entry");
+    try std.testing.expect(overwritten > 0);
+
+    const second = try compileAppWithCheckedModuleCache(allocator, cache_dir, "test/str/app_message.roc");
+    try std.testing.expectEqual(@as(u32, 0), second.build.cache_hits);
+    try std.testing.expect(second.build.modules_compiled > 0);
+    try std.testing.expect(second.cache.invalidations > 0);
+}
 
 test "Coordinator basic initialization" {
     const allocator = std.testing.allocator;

--- a/src/interpreter_shim/main.zig
+++ b/src/interpreter_shim/main.zig
@@ -31,7 +31,7 @@ var runtime_state: RuntimeState = undefined;
 var runtime_state_mutex: std.Thread.Mutex = .{};
 
 fn allocator() Allocator {
-    return std.heap.page_allocator;
+    return std.heap.smp_allocator;
 }
 
 fn openRuntimeState(gpa: Allocator) !RuntimeState {
@@ -41,7 +41,7 @@ fn openRuntimeState(gpa: Allocator) !RuntimeState {
 
     const header_offset = @sizeOf(SharedMemoryAllocator.Header);
     const header: *const lir.LirImage.Header = @ptrCast(@alignCast(shm.base_ptr + header_offset));
-    const view = try lir.LirImage.viewMappedImage(header, shm.base_ptr, shm.total_size);
+    const view = try lir.LirImage.viewMappedImageWithAllocator(header, shm.base_ptr, shm.total_size, gpa);
 
     return .{
         .shm = shm,
@@ -162,7 +162,7 @@ fn viewEmbeddedLirImage(image_base: *anyopaque, image_len: usize, ops: *RocOps) 
 
     const base_ptr: [*]align(1) u8 = @ptrCast(@alignCast(image_base));
     const header: *const lir.LirImage.Header = @ptrCast(@alignCast(base_ptr + @sizeOf(SharedMemoryAllocator.Header)));
-    return lir.LirImage.viewMappedImage(header, base_ptr, image_len) catch {
+    return lir.LirImage.viewMappedImageWithAllocator(header, base_ptr, image_len, allocator()) catch {
         ops.crash("Interpreter shim could not view the embedded LIR image");
         return error.LirImageUnavailable;
     };

--- a/src/lir/lir_image.zig
+++ b/src/lir/lir_image.zig
@@ -92,7 +92,7 @@ pub const LirStoreImage = extern struct {
         };
     }
 
-    fn view(self: LirStoreImage, base_ptr: [*]align(1) u8, image_size: usize) ImageError!LirStore {
+    fn view(self: LirStoreImage, base_ptr: [*]align(1) u8, image_size: usize, allocator: std.mem.Allocator) ImageError!LirStore {
         return .{
             .cf_stmts = try arrayListFromRef(LIR.CFStmt, base_ptr, image_size, self.cf_stmts),
             .cf_switch_branches = try arrayListFromRef(LIR.CFSwitchBranch, base_ptr, image_size, self.cf_switch_branches),
@@ -101,7 +101,7 @@ pub const LirStoreImage = extern struct {
             .local_ids = try arrayListFromRef(LIR.LocalId, base_ptr, image_size, self.local_ids),
             .proc_specs = try arrayListFromRef(LIR.LirProcSpec, base_ptr, image_size, self.proc_specs),
             .strings = try self.strings.view(base_ptr, image_size),
-            .allocator = std.heap.page_allocator,
+            .allocator = allocator,
             .next_synthetic_symbol = self.next_synthetic_symbol,
         };
     }
@@ -151,9 +151,10 @@ pub const LayoutStoreImage = extern struct {
         base_ptr: [*]align(1) u8,
         image_size: usize,
         target_usize: base.target.TargetUsize,
+        allocator: std.mem.Allocator,
     ) ImageError!layout_mod.Store {
         return .{
-            .allocator = std.heap.page_allocator,
+            .allocator = allocator,
             .layouts = try safeListFromRef(layout_mod.Layout, base_ptr, image_size, self.layouts),
             .resolved_list_layouts = try arrayListFromRef(?layout_mod.Idx, base_ptr, image_size, self.resolved_list_layouts),
             .tuple_elems = try safeListFromRef(layout_mod.Idx, base_ptr, image_size, self.tuple_elems),
@@ -161,7 +162,7 @@ pub const LayoutStoreImage = extern struct {
             .struct_data = try safeListFromRef(layout_mod.StructData, base_ptr, image_size, self.struct_data),
             .tag_union_variants = try safeMultiListFromRef(layout_mod.TagUnionVariant, base_ptr, image_size, self.tag_union_variants),
             .tag_union_data = try safeListFromRef(layout_mod.TagUnionData, base_ptr, image_size, self.tag_union_data),
-            .interned_layouts = std.StringHashMap(layout_mod.Idx).init(std.heap.page_allocator),
+            .interned_layouts = std.StringHashMap(layout_mod.Idx).init(allocator),
             .scratch_intern_key = .empty,
             .target_usize = target_usize,
         };
@@ -223,6 +224,17 @@ pub fn fillHeaderInSharedMemory(
 /// backed by `gpa.alignedAlloc` whose owning slice is `const`) pass it
 /// directly without a manual `@constCast`.
 pub fn viewMappedImage(header: *const Header, base_ptr: [*]align(1) const u8, mapped_size: usize) ImageError!ProgramView {
+    return viewMappedImageWithAllocator(header, base_ptr, mapped_size, std.heap.page_allocator);
+}
+
+/// View an ARC-inserted LIR program in place from a mapped buffer using the
+/// provided allocator for any scratch data owned by reconstructed stores.
+pub fn viewMappedImageWithAllocator(
+    header: *const Header,
+    base_ptr: [*]align(1) const u8,
+    mapped_size: usize,
+    allocator: std.mem.Allocator,
+) ImageError!ProgramView {
     if (mapped_size < @sizeOf(Header)) return error.InvalidLirImage;
 
     if (header.magic != MAGIC) return error.InvalidLirImage;
@@ -241,8 +253,8 @@ pub fn viewMappedImage(header: *const Header, base_ptr: [*]align(1) const u8, ma
     const mutable_base: [*]align(1) u8 = @constCast(base_ptr);
 
     return .{
-        .store = try header.store.view(mutable_base, @intCast(header.image_size)),
-        .layouts = try header.layouts.view(mutable_base, @intCast(header.image_size), target_usize),
+        .store = try header.store.view(mutable_base, @intCast(header.image_size), allocator),
+        .layouts = try header.layouts.view(mutable_base, @intCast(header.image_size), target_usize, allocator),
         .root_procs = try sliceFromRef(LIR.LirProcSpecId, mutable_base, @intCast(header.image_size), header.root_procs),
         .platform_entrypoints = try sliceFromRef(PlatformEntrypoint, mutable_base, @intCast(header.image_size), header.platform_entrypoints),
         .target_usize = target_usize,

--- a/src/postcheck/lambda_mono/ast.zig
+++ b/src/postcheck/lambda_mono/ast.zig
@@ -24,7 +24,7 @@ pub const PatId = enum(u32) { _ };
 /// Identifier for a statement in Lambda Mono IR.
 pub const StmtId = enum(u32) { _ };
 /// Identifier for a function body in Lambda Mono IR.
-pub const FnId = enum(u32) { _ };
+pub const FnId = Type.FnId;
 /// Identifier for a local binding in Lambda Mono IR.
 pub const LocalId = enum(u32) { _ };
 /// Owned string literal id shared with the lifted stage.

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -43,15 +43,67 @@ const CaptureBinding = struct {
     ty: Type.TypeId,
 };
 
-const FnCaptureParam = union(enum) {
-    none,
-    finite: CaptureRecord,
-    erased: ?CaptureRecord,
+const CaptureAbi = enum {
+    finite,
+    erased,
 };
 
-const CaptureRecord = struct {
-    ty: Type.TypeId,
-    captures: []const SolvedType.Capture,
+const CaptureSpanId = struct {
+    start: u32,
+    len: u32,
+
+    fn from(span: SolvedType.Span) CaptureSpanId {
+        return .{ .start = span.start, .len = span.len };
+    }
+};
+
+const FnSpec = struct {
+    source: Lifted.FnId,
+    solved_fn_ty: SolvedType.TypeVarId,
+    abi: CaptureAbi,
+    captures: CaptureSpanId,
+    capture_ty: ?Type.TypeId,
+};
+
+const FnSpecContext = struct {
+    pub fn hash(_: FnSpecContext, spec: FnSpec) u64 {
+        var hasher = std.hash.Wyhash.init(0);
+        std.hash.autoHash(&hasher, @intFromEnum(spec.source));
+        std.hash.autoHash(&hasher, @intFromEnum(spec.solved_fn_ty));
+        std.hash.autoHash(&hasher, spec.abi);
+        std.hash.autoHash(&hasher, spec.captures.start);
+        std.hash.autoHash(&hasher, spec.captures.len);
+        if (spec.capture_ty) |capture_ty| {
+            std.hash.autoHash(&hasher, @intFromEnum(capture_ty));
+        } else {
+            std.hash.autoHash(&hasher, @as(u32, std.math.maxInt(u32)));
+        }
+        return hasher.final();
+    }
+
+    pub fn eql(_: FnSpecContext, lhs: FnSpec, rhs: FnSpec) bool {
+        return lhs.source == rhs.source and
+            lhs.solved_fn_ty == rhs.solved_fn_ty and
+            lhs.abi == rhs.abi and
+            lhs.captures.start == rhs.captures.start and
+            lhs.captures.len == rhs.captures.len and
+            lhs.capture_ty == rhs.capture_ty;
+    }
+};
+
+const CaptureTypeMap = std.HashMap(CaptureSpanId, Type.TypeId, CaptureSpanContext, std.hash_map.default_max_load_percentage);
+
+const CaptureSpanContext = struct {
+    pub fn hash(_: CaptureSpanContext, span: CaptureSpanId) u64 {
+        var hasher = std.hash.Wyhash.init(0);
+        std.hash.autoHash(&hasher, span.start);
+        std.hash.autoHash(&hasher, span.len);
+        return hasher.final();
+    }
+
+    pub fn eql(_: CaptureSpanContext, lhs: CaptureSpanId, rhs: CaptureSpanId) bool {
+        return lhs.start == rhs.start and lhs.len == rhs.len;
+    }
 };
 
 const Lowerer = struct {
@@ -63,8 +115,11 @@ const Lowerer = struct {
     expr_map: []?Ast.ExprId,
     pat_map: []?Ast.PatId,
     stmt_map: []?Ast.StmtId,
-    fn_map: []Ast.FnId,
-    fn_written: []bool,
+    fn_specs: std.ArrayList(FnSpec),
+    fn_spec_map: std.HashMap(FnSpec, Ast.FnId, FnSpecContext, std.hash_map.default_max_load_percentage),
+    fn_written: std.ArrayList(bool),
+    source_symbols: std.AutoHashMap(Common.Symbol, Lifted.FnId),
+    capture_types: CaptureTypeMap,
     captures: std.AutoHashMap(Lifted.LocalId, CaptureBinding),
     symbols: Common.SymbolGen,
     erased_capture_ptr_ty: ?Type.TypeId = null,
@@ -86,13 +141,6 @@ const Lowerer = struct {
         errdefer allocator.free(stmt_map);
         @memset(stmt_map, null);
 
-        const fn_map = try allocator.alloc(Ast.FnId, solved.lifted.fns.items.len);
-        errdefer allocator.free(fn_map);
-
-        const fn_written = try allocator.alloc(bool, solved.lifted.fns.items.len);
-        errdefer allocator.free(fn_written);
-        @memset(fn_written, false);
-
         return .{
             .allocator = allocator,
             .solved = solved,
@@ -102,8 +150,11 @@ const Lowerer = struct {
             .expr_map = expr_map,
             .pat_map = pat_map,
             .stmt_map = stmt_map,
-            .fn_map = fn_map,
-            .fn_written = fn_written,
+            .fn_specs = .empty,
+            .fn_spec_map = std.HashMap(FnSpec, Ast.FnId, FnSpecContext, std.hash_map.default_max_load_percentage).initContext(allocator, .{}),
+            .fn_written = .empty,
+            .source_symbols = std.AutoHashMap(Common.Symbol, Lifted.FnId).init(allocator),
+            .capture_types = CaptureTypeMap.initContext(allocator, .{}),
             .captures = std.AutoHashMap(Lifted.LocalId, CaptureBinding).init(allocator),
             .symbols = .{ .next = solved.lifted.next_symbol },
         };
@@ -111,9 +162,12 @@ const Lowerer = struct {
 
     fn deinit(self: *Lowerer) void {
         self.captures.deinit();
+        self.capture_types.deinit();
+        self.source_symbols.deinit();
+        self.fn_written.deinit(self.allocator);
+        self.fn_spec_map.deinit();
+        self.fn_specs.deinit(self.allocator);
         self.type_map.deinit();
-        self.allocator.free(self.fn_written);
-        self.allocator.free(self.fn_map);
         self.allocator.free(self.stmt_map);
         self.allocator.free(self.pat_map);
         self.allocator.free(self.expr_map);
@@ -121,19 +175,12 @@ const Lowerer = struct {
     }
 
     fn lower(self: *Lowerer) Allocator.Error!void {
-        try self.reserveFns();
-        for (self.solved.lifted.fns.items, 0..) |fn_, index| {
-            const fn_id: Lifted.FnId = @enumFromInt(@as(u32, @intCast(index)));
-            try self.lowerFn(fn_id, fn_);
-        }
+        try self.indexSourceFns();
 
-        for (self.fn_written) |written| {
-            if (!written) Common.invariant("Lambda Mono function reservation was not filled");
-        }
-
+        try self.program.roots.ensureTotalCapacity(self.allocator, self.solved.lifted.roots.items.len);
         for (self.solved.lifted.roots.items) |root| {
             try self.program.roots.append(self.allocator, .{
-                .fn_id = self.fn_map[@intFromEnum(root.fn_id)],
+                .fn_id = try self.ensureOwnFnSpec(root.fn_id, .finite),
                 .request = root.request,
             });
         }
@@ -153,24 +200,38 @@ const Lowerer = struct {
                 .ty = try self.lowerType(request.ty),
             });
         }
+
+        try self.lowerQueuedFns();
     }
 
-    fn reserveFns(self: *Lowerer) Allocator.Error!void {
-        try self.program.fns.ensureTotalCapacity(self.allocator, self.solved.lifted.fns.items.len);
-        for (self.solved.lifted.fns.items, 0..) |_, index| {
-            const id: Ast.FnId = @enumFromInt(@as(u32, @intCast(self.program.fns.items.len)));
-            self.fn_map[index] = id;
-            try self.program.fns.append(self.allocator, undefined);
+    fn indexSourceFns(self: *Lowerer) Allocator.Error!void {
+        for (self.solved.lifted.fns.items, 0..) |fn_, index| {
+            const fn_id: Lifted.FnId = @enumFromInt(@as(u32, @intCast(index)));
+            const result = try self.source_symbols.getOrPut(fn_.symbol);
+            if (result.found_existing) Common.invariant("two lifted functions had the same symbol");
+            result.value_ptr.* = fn_id;
         }
     }
 
-    fn lowerFn(self: *Lowerer, fn_id: Lifted.FnId, fn_: Lifted.Fn) Allocator.Error!void {
+    fn lowerQueuedFns(self: *Lowerer) Allocator.Error!void {
+        var index: usize = 0;
+        while (index < self.fn_specs.items.len) : (index += 1) {
+            if (self.fn_written.items[index]) continue;
+            const out_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(index)));
+            try self.lowerFnSpec(out_id, self.fn_specs.items[index]);
+        }
+    }
+
+    fn lowerFnSpec(self: *Lowerer, out_id: Ast.FnId, spec: FnSpec) Allocator.Error!void {
+        const fn_id = spec.source;
+        const fn_ = self.solved.lifted.fns.items[@intFromEnum(fn_id)];
         self.captures.clearRetainingCapacity();
+        @memset(self.local_map, null);
         @memset(self.expr_map, null);
         @memset(self.pat_map, null);
         @memset(self.stmt_map, null);
 
-        const solved_fn_ty = self.solved.fn_tys.items[@intFromEnum(fn_id)];
+        const solved_fn_ty = spec.solved_fn_ty;
         const func = switch (self.solved.types.rootContent(solved_fn_ty)) {
             .func => |func| func,
             else => Common.invariant("Lambda Mono function table contains a non-function type"),
@@ -189,35 +250,36 @@ const Lowerer = struct {
             try args.append(self.allocator, .{ .local = local, .ty = arg_ty });
         }
 
-        switch (try self.captureParamForFn(fn_id)) {
-            .none => {},
-            .finite => |capture_record| {
-                const capture_local = try self.program.addLocal(self.symbols.fresh(), capture_record.ty);
-                const capture_expr = try self.program.addExpr(.{
-                    .ty = capture_record.ty,
-                    .data = .{ .local = capture_local },
-                });
-                try args.append(self.allocator, .{ .local = capture_local, .ty = capture_record.ty });
-                try self.bindCaptureRecord(capture_record, capture_expr);
+        switch (spec.abi) {
+            .finite => {
+                if (spec.capture_ty) |capture_ty| {
+                    const capture_local = try self.program.addLocal(self.symbols.fresh(), capture_ty);
+                    const capture_expr = try self.program.addExpr(.{
+                        .ty = capture_ty,
+                        .data = .{ .local = capture_local },
+                    });
+                    try args.append(self.allocator, .{ .local = capture_local, .ty = capture_ty });
+                    try self.bindCaptureRecord(spec.captures, capture_ty, capture_expr);
+                }
             },
-            .erased => |maybe_capture_record| {
+            .erased => {
                 const capture_ptr_ty = try self.erasedCapturePtrType();
                 const capture_ptr_local = try self.program.addLocal(self.symbols.fresh(), capture_ptr_ty);
-                const capture_ptr_expr = try self.program.addExpr(.{
+                const capture_expr = try self.program.addExpr(.{
                     .ty = capture_ptr_ty,
                     .data = .{ .local = capture_ptr_local },
                 });
                 try args.append(self.allocator, .{ .local = capture_ptr_local, .ty = capture_ptr_ty });
 
-                if (maybe_capture_record) |capture_record| {
-                    const capture_expr = try self.program.addExpr(.{
-                        .ty = capture_record.ty,
+                if (spec.capture_ty) |capture_ty| {
+                    const loaded = try self.program.addExpr(.{
+                        .ty = capture_ty,
                         .data = .{ .low_level = .{
                             .op = .erased_capture_load,
-                            .args = try self.program.addExprSpan(&.{capture_ptr_expr}),
+                            .args = try self.program.addExprSpan(&.{capture_expr}),
                         } },
                     });
-                    try self.bindCaptureRecord(capture_record, capture_expr);
+                    try self.bindCaptureRecord(spec.captures, capture_ty, loaded);
                 }
             },
         }
@@ -228,60 +290,119 @@ const Lowerer = struct {
         };
         const ret = try self.lowerType(func.ret);
 
-        const out_id = self.fn_map[@intFromEnum(fn_id)];
         self.program.fns.items[@intFromEnum(out_id)] = .{
-            .symbol = fn_.symbol,
+            .symbol = self.program.fns.items[@intFromEnum(out_id)].symbol,
             .source = fn_.source,
             .args = try self.program.addTypedLocalSpan(args.items),
             .body = body,
             .ret = ret,
         };
-        self.fn_written[@intFromEnum(fn_id)] = true;
+        self.fn_written.items[@intFromEnum(out_id)] = true;
     }
 
-    fn captureParamForFn(self: *Lowerer, fn_id: Lifted.FnId) Allocator.Error!FnCaptureParam {
+    fn ensureOwnFnSpec(self: *Lowerer, fn_id: Lifted.FnId, abi: CaptureAbi) Allocator.Error!Ast.FnId {
+        const fn_symbol = self.solved.lifted.fns.items[@intFromEnum(fn_id)].symbol;
+        const solved_fn_ty = self.solved.types.root(self.solved.fn_tys.items[@intFromEnum(fn_id)]);
+        const func = switch (self.solved.types.rootContent(solved_fn_ty)) {
+            .func => |func| func,
+            else => Common.invariant("Lambda Mono function table contains a non-function type"),
+        };
+
+        const callable = self.solved.types.rootContent(func.callable);
+        const members = switch (callable) {
+            .lambda_set => |members| members,
+            .erased => |erased| erased.members,
+            else => Common.invariant("function callable slot was unresolved before Lambda Mono"),
+        };
+
+        for (self.solved.types.memberSpan(members)) |member| {
+            if (member.lambda != fn_symbol) continue;
+            return try self.ensureFnSpec(fn_id, solved_fn_ty, abi, member.captures);
+        }
+
+        if (std.meta.activeTag(callable) == .erased) {
+            return try self.ensureFnSpec(fn_id, solved_fn_ty, abi, .empty());
+        }
+        Common.invariant("function callable slot did not contain its own lambda member");
+    }
+
+    fn ensureFnSpec(
+        self: *Lowerer,
+        source: Lifted.FnId,
+        solved_fn_ty: SolvedType.TypeVarId,
+        abi: CaptureAbi,
+        captures: SolvedType.Span,
+    ) Allocator.Error!Ast.FnId {
+        const capture_items = self.solved.types.captureSpan(captures);
+        const spec = FnSpec{
+            .source = source,
+            .solved_fn_ty = self.solved.types.root(solved_fn_ty),
+            .abi = abi,
+            .captures = CaptureSpanId.from(captures),
+            .capture_ty = if (capture_items.len == 0) null else try self.captureRecordType(captures),
+        };
+
+        const result = try self.fn_spec_map.getOrPut(spec);
+        if (result.found_existing) return result.value_ptr.*;
+
+        const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(self.program.fns.items.len)));
+        const source_fn = self.solved.lifted.fns.items[@intFromEnum(source)];
+        try self.program.fns.append(self.allocator, .{
+            .symbol = self.symbols.fresh(),
+            .source = source_fn.source,
+            .args = .empty(),
+            .body = .hosted,
+            .ret = try self.lowerType(switch (self.solved.types.rootContent(spec.solved_fn_ty)) {
+                .func => |func| func.ret,
+                else => Common.invariant("Lambda Mono function table contains a non-function type"),
+            }),
+        });
+        try self.fn_specs.append(self.allocator, spec);
+        try self.fn_written.append(self.allocator, false);
+        result.value_ptr.* = fn_id;
+        return fn_id;
+    }
+
+    fn sourceFnForSymbol(self: *Lowerer, symbol: Common.Symbol) Lifted.FnId {
+        return self.source_symbols.get(symbol) orelse
+            Common.invariant("Lambda Mono callable member referenced a missing lifted function symbol");
+    }
+
+    fn bindCaptureRecord(self: *Lowerer, captures_id: CaptureSpanId, capture_ty: Type.TypeId, capture_expr: Ast.ExprId) Allocator.Error!void {
+        const captures = self.solved.types.captureSpan(.{ .start = captures_id.start, .len = captures_id.len });
+        const fields = switch (self.program.types.get(capture_ty)) {
+            .capture_record => |fields| self.program.types.captureFieldSpan(fields),
+            else => Common.invariant("function capture argument was not a capture record"),
+        };
+        if (captures.len != fields.len) Common.invariant("function capture argument arity differed from capture slots");
+
+        for (captures, fields) |capture, field| {
+            if (capture.symbol != field.symbol or capture.binder != field.binder) {
+                Common.invariant("function capture argument fields differed from capture slots");
+            }
+            try self.captures.put(capture.local, .{
+                .record = capture_expr,
+                .symbol = capture.symbol,
+                .ty = field.ty,
+            });
+        }
+    }
+
+    fn capturesForFn(self: *Lowerer, fn_id: Lifted.FnId) SolvedType.Span {
         const fn_symbol = self.solved.lifted.fns.items[@intFromEnum(fn_id)].symbol;
         const func = switch (self.solved.types.rootContent(self.solved.fn_tys.items[@intFromEnum(fn_id)])) {
             .func => |func| func,
             else => Common.invariant("Lambda Mono function table contains a non-function type"),
         };
-        return switch (self.solved.types.rootContent(func.callable)) {
-            .lambda_set => |members| {
-                for (self.solved.types.memberSpan(members)) |member| {
-                    if (member.lambda != fn_symbol) continue;
-                    const captures = self.solved.types.captureSpan(member.captures);
-                    if (captures.len == 0) return .none;
-                    return .{ .finite = .{
-                        .ty = try self.captureRecordType(member.captures),
-                        .captures = captures,
-                    } };
-                }
-                Common.invariant("function callable slot did not contain its own lambda member");
-            },
-            .erased => |erased| {
-                for (self.solved.types.memberSpan(erased.members)) |member| {
-                    if (member.lambda != fn_symbol) continue;
-                    const captures = self.solved.types.captureSpan(member.captures);
-                    if (captures.len == 0) return .{ .erased = null };
-                    return .{ .erased = .{
-                        .ty = try self.captureRecordType(member.captures),
-                        .captures = captures,
-                    } };
-                }
-                return .{ .erased = null };
-            },
-            else => Common.invariant("function callable slot was unresolved before Lambda Mono"),
+        const callable = switch (self.solved.types.rootContent(func.callable)) {
+            .lambda_set => |members| members,
+            .erased => |erased| erased.members,
+            else => Common.invariant("callable value did not have a resolved callable slot"),
         };
-    }
-
-    fn bindCaptureRecord(self: *Lowerer, capture_record: CaptureRecord, capture_expr: Ast.ExprId) Allocator.Error!void {
-        for (capture_record.captures) |capture| {
-            try self.captures.put(capture.local, .{
-                .record = capture_expr,
-                .symbol = capture.symbol,
-                .ty = try self.lowerType(capture.ty),
-            });
+        for (self.solved.types.memberSpan(callable)) |member| {
+            if (member.lambda == fn_symbol) return member.captures;
         }
+        return .empty();
     }
 
     fn erasedCapturePtrType(self: *Lowerer) Allocator.Error!Type.TypeId {
@@ -318,10 +439,10 @@ const Lowerer = struct {
                 .value = try self.lowerExpr(let_.value),
                 .rest = try self.lowerExpr(let_.rest),
             } },
-            .fn_ref => |target| try self.lowerCallableValue(target, ty),
+            .fn_ref => |target| try self.lowerCallableValue(expr_id, target, ty),
             .call_value => |call| try self.lowerValueCall(ty, call),
             .call_proc => |call| .{ .direct_call = .{
-                .target = self.fn_map[@intFromEnum(call.callee)],
+                .target = try self.ensureOwnFnSpec(call.callee, .finite),
                 .args = try self.lowerDirectCallArgs(call.callee, call.args),
             } },
             .low_level => |call| .{ .low_level = .{
@@ -381,16 +502,17 @@ const Lowerer = struct {
         return .{ .local = try self.localFor(local, ty) };
     }
 
-    fn lowerCallableValue(self: *Lowerer, fn_id: Lifted.FnId, ty: Type.TypeId) Allocator.Error!Ast.ExprData {
+    fn lowerCallableValue(self: *Lowerer, expr_id: Lifted.ExprId, fn_id: Lifted.FnId, ty: Type.TypeId) Allocator.Error!Ast.ExprData {
+        const captures = self.memberCapturesForExpr(expr_id, fn_id);
         return switch (self.program.types.get(ty)) {
             .callable => |variants| blk: {
                 const fn_symbol = self.solved.lifted.fns.items[@intFromEnum(fn_id)].symbol;
                 for (self.program.types.fnVariantSpan(variants)) |variant| {
-                    if (variant.lambda != fn_symbol) continue;
+                    if (variant.source != fn_symbol) continue;
                     break :blk .{ .callable = .{
                         .ty = ty,
                         .variant = variant.id,
-                        .payload = if (variant.capture_ty) |capture_ty| try self.buildCaptureRecord(fn_id, capture_ty) else null,
+                        .payload = if (variant.capture_ty) |capture_ty| try self.buildCaptureRecord(captures, capture_ty) else null,
                     } };
                 }
                 Common.invariant("finite callable type did not contain referenced function");
@@ -398,10 +520,10 @@ const Lowerer = struct {
             .erased_fn => |erased| blk: {
                 const fn_symbol = self.solved.lifted.fns.items[@intFromEnum(fn_id)].symbol;
                 for (self.program.types.fnVariantSpan(erased.members)) |variant| {
-                    if (variant.lambda != fn_symbol) continue;
+                    if (variant.source != fn_symbol) continue;
                     break :blk .{ .packed_erased_fn = .{
-                        .target = self.fn_map[@intFromEnum(fn_id)],
-                        .capture = if (variant.capture_ty) |capture_ty| try self.buildCaptureRecord(fn_id, capture_ty) else null,
+                        .target = variant.target,
+                        .capture = if (variant.capture_ty) |capture_ty| try self.buildCaptureRecord(captures, capture_ty) else null,
                     } };
                 }
                 Common.invariant("erased callable type did not contain referenced function");
@@ -410,20 +532,37 @@ const Lowerer = struct {
         };
     }
 
+    fn memberCapturesForExpr(self: *Lowerer, expr_id: Lifted.ExprId, fn_id: Lifted.FnId) SolvedType.Span {
+        const fn_symbol = self.solved.lifted.fns.items[@intFromEnum(fn_id)].symbol;
+        const expr_ty = self.solved.expr_tys.items[@intFromEnum(expr_id)];
+        const callable = switch (self.solved.types.rootContent(expr_ty)) {
+            .func => |func| func.callable,
+            .lambda_set, .erased => expr_ty,
+            else => Common.invariant("function reference expression had no callable Lambda Solved type"),
+        };
+        const members = switch (self.solved.types.rootContent(callable)) {
+            .lambda_set => |members| members,
+            .erased => |erased| erased.members,
+            else => Common.invariant("function reference callable slot was unresolved before Lambda Mono"),
+        };
+        for (self.solved.types.memberSpan(members)) |member| {
+            if (member.lambda == fn_symbol) return member.captures;
+        }
+        Common.invariant("function reference callable slot did not contain referenced function");
+    }
+
     fn lowerDirectCallArgs(self: *Lowerer, fn_id: Lifted.FnId, args_span: Lifted.Span(Lifted.ExprId)) Allocator.Error!Ast.Span(Ast.ExprId) {
         const args = try self.lowerExprSlice(self.solved.lifted.exprSpan(args_span));
         defer self.allocator.free(args);
 
-        switch (try self.captureParamForFn(fn_id)) {
-            .none => {},
-            .finite => |capture_record| {
-                const call_args = try self.allocator.alloc(Ast.ExprId, args.len + 1);
-                defer self.allocator.free(call_args);
-                @memcpy(call_args[0..args.len], args);
-                call_args[args.len] = try self.buildCaptureRecord(fn_id, capture_record.ty);
-                return try self.program.addExprSpan(call_args);
-            },
-            .erased => Common.invariant("direct call targeted an erased-callable ABI function"),
+        const captures = self.capturesForFn(fn_id);
+        if (captures.len != 0) {
+            const capture_ty = try self.captureRecordType(captures);
+            const call_args = try self.allocator.alloc(Ast.ExprId, args.len + 1);
+            defer self.allocator.free(call_args);
+            @memcpy(call_args[0..args.len], args);
+            call_args[args.len] = try self.buildCaptureRecord(captures, capture_ty);
+            return try self.program.addExprSpan(call_args);
         }
 
         return try self.program.addExprSpan(args);
@@ -472,7 +611,7 @@ const Lowerer = struct {
                         .body = try self.program.addExpr(.{
                             .ty = ty,
                             .data = .{ .direct_call = .{
-                                .target = self.fnIdForSymbol(variant.lambda),
+                                .target = variant.target,
                                 .args = try self.program.addExprSpan(call_args),
                             } },
                         }),
@@ -492,36 +631,30 @@ const Lowerer = struct {
         };
     }
 
-    fn buildCaptureRecord(self: *Lowerer, fn_id: Lifted.FnId, capture_ty: Type.TypeId) Allocator.Error!Ast.ExprId {
-        const func = switch (self.solved.types.rootContent(self.solved.fn_tys.items[@intFromEnum(fn_id)])) {
-            .func => |func| func,
-            else => Common.invariant("Lambda Mono function table contains a non-function type"),
+    fn buildCaptureRecord(self: *Lowerer, capture_span: SolvedType.Span, capture_ty: Type.TypeId) Allocator.Error!Ast.ExprId {
+        const captures = self.solved.types.captureSpan(capture_span);
+        const fields = switch (self.program.types.get(capture_ty)) {
+            .capture_record => |fields| self.program.types.captureFieldSpan(fields),
+            else => Common.invariant("callable capture payload was not a capture record"),
         };
-        const callable = switch (self.solved.types.rootContent(func.callable)) {
-            .lambda_set => |members| members,
-            .erased => |erased| erased.members,
-            else => Common.invariant("callable value did not have a resolved callable slot"),
-        };
-        const fn_symbol = self.solved.lifted.fns.items[@intFromEnum(fn_id)].symbol;
-        for (self.solved.types.memberSpan(callable)) |member| {
-            if (member.lambda != fn_symbol) continue;
-            const captures = self.solved.types.captureSpan(member.captures);
-            const values = try self.allocator.alloc(Ast.ExprId, captures.len);
-            defer self.allocator.free(values);
-            for (captures, 0..) |capture, i| {
-                values[i] = try self.lowerCapturedValue(capture);
+        if (captures.len != fields.len) Common.invariant("callable capture payload arity differed from captured locals");
+
+        const values = try self.allocator.alloc(Ast.ExprId, captures.len);
+        defer self.allocator.free(values);
+        for (captures, fields, 0..) |capture, field, i| {
+            if (capture.symbol != field.symbol or capture.binder != field.binder) {
+                Common.invariant("callable capture payload fields differed from captured locals");
             }
-            return try self.program.addExpr(.{
-                .ty = capture_ty,
-                .data = .{ .capture_record = try self.program.addExprSpan(values) },
-            });
+            values[i] = try self.lowerCapturedValue(capture.local, field.ty);
         }
-        Common.invariant("finite callable slot did not contain referenced function");
+        return try self.program.addExpr(.{
+            .ty = capture_ty,
+            .data = .{ .capture_record = try self.program.addExprSpan(values) },
+        });
     }
 
-    fn lowerCapturedValue(self: *Lowerer, capture: SolvedType.Capture) Allocator.Error!Ast.ExprId {
-        const ty = try self.lowerType(capture.ty);
-        const data = try self.lowerLocalExpr(capture.local, ty);
+    fn lowerCapturedValue(self: *Lowerer, local: Lifted.LocalId, ty: Type.TypeId) Allocator.Error!Ast.ExprId {
+        const data = try self.lowerLocalExpr(local, ty);
         return try self.program.addExpr(.{ .ty = ty, .data = data });
     }
 
@@ -608,7 +741,7 @@ const Lowerer = struct {
             .zst => .zst,
             .erased => |erased| .{ .erased_fn = .{
                 .source_fn_ty = erased.source_fn_ty,
-                .members = try self.lowerFnMembers(erased.members),
+                .members = try self.lowerFnMembers(erased.members, .erased),
             } },
             .func => |func| return self.program.types.get(try self.lowerType(func.callable)),
             .list => |elem| .{ .list = try self.lowerType(elem) },
@@ -656,20 +789,28 @@ const Lowerer = struct {
                 } };
             },
             .lambda_set => |members| blk: {
-                break :blk .{ .callable = try self.lowerFnMembers(members) };
+                break :blk .{ .callable = try self.lowerFnMembers(members, .finite) };
             },
         };
     }
 
-    fn lowerFnMembers(self: *Lowerer, members: SolvedType.Span) Allocator.Error!Type.Span {
+    fn lowerFnMembers(self: *Lowerer, members: SolvedType.Span, abi: CaptureAbi) Allocator.Error!Type.Span {
         const solved_members = self.solved.types.memberSpan(members);
         const variants = try self.allocator.alloc(Type.FnVariant, solved_members.len);
         defer self.allocator.free(variants);
         for (solved_members, 0..) |member, i| {
             const captures = self.solved.types.captureSpan(member.captures);
+            const source = self.sourceFnForSymbol(member.lambda);
+            const target = try self.ensureFnSpec(
+                source,
+                self.solved.types.root(self.solved.fn_tys.items[@intFromEnum(source)]),
+                abi,
+                member.captures,
+            );
             variants[i] = .{
                 .id = undefined, // assigned by addFnVariants before the variant is stored
-                .lambda = member.lambda,
+                .source = member.lambda,
+                .target = target,
                 .capture_ty = if (captures.len == 0) null else try self.captureRecordType(member.captures),
             };
         }
@@ -677,6 +818,9 @@ const Lowerer = struct {
     }
 
     fn captureRecordType(self: *Lowerer, captures: SolvedType.Span) Allocator.Error!Type.TypeId {
+        const id = CaptureSpanId.from(captures);
+        if (self.capture_types.get(id)) |existing| return existing;
+
         const capture_items = self.solved.types.captureSpan(captures);
         const fields = try self.allocator.alloc(Type.CaptureField, capture_items.len);
         defer self.allocator.free(fields);
@@ -687,7 +831,9 @@ const Lowerer = struct {
                 .ty = try self.lowerType(capture.ty),
             };
         }
-        return try self.program.types.add(.{ .capture_record = try self.program.types.addCaptureFields(fields) });
+        const ty = try self.program.types.add(.{ .capture_record = try self.program.types.addCaptureFields(fields) });
+        try self.capture_types.put(id, ty);
+        return ty;
     }
 
     fn lowerTypeSpan(self: *Lowerer, items: []const SolvedType.TypeVarId) Allocator.Error![]Type.TypeId {
@@ -805,13 +951,6 @@ const Lowerer = struct {
             };
         }
         return try self.program.addIfBranchSpan(lowered);
-    }
-
-    fn fnIdForSymbol(self: *Lowerer, symbol: Common.Symbol) Ast.FnId {
-        for (self.solved.lifted.fns.items, 0..) |fn_, index| {
-            if (fn_.symbol == symbol) return self.fn_map[index];
-        }
-        Common.invariant("Lambda Mono callable variant referenced a missing function symbol");
     }
 };
 

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -353,15 +353,17 @@ const Lowerer = struct {
         try self.fn_written.append(self.allocator, false);
         result.value_ptr.* = fn_id;
 
+        const ret_ty = try self.lowerType(switch (self.solved.types.rootContent(spec.solved_fn_ty)) {
+            .func => |func| func.ret,
+            else => Common.invariant("Lambda Mono function table contains a non-function type"),
+        });
+
         self.program.fns.items[@intFromEnum(fn_id)] = .{
             .symbol = symbol,
             .source = source_fn.source,
             .args = .empty(),
             .body = .hosted,
-            .ret = try self.lowerType(switch (self.solved.types.rootContent(spec.solved_fn_ty)) {
-                .func => |func| func.ret,
-                else => Common.invariant("Lambda Mono function table contains a non-function type"),
-            }),
+            .ret = ret_ty,
         };
         return fn_id;
     }

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -290,10 +290,12 @@ const Lowerer = struct {
         };
         const ret = try self.lowerType(func.ret);
 
+        const args_span = try self.program.addTypedLocalSpan(args.items);
+        const symbol = self.program.fns.items[@intFromEnum(out_id)].symbol;
         self.program.fns.items[@intFromEnum(out_id)] = .{
-            .symbol = self.program.fns.items[@intFromEnum(out_id)].symbol,
+            .symbol = symbol,
             .source = fn_.source,
-            .args = try self.program.addTypedLocalSpan(args.items),
+            .args = args_span,
             .body = body,
             .ret = ret,
         };

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -347,8 +347,14 @@ const Lowerer = struct {
 
         const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(self.program.fns.items.len)));
         const source_fn = self.solved.lifted.fns.items[@intFromEnum(source)];
-        try self.program.fns.append(self.allocator, .{
-            .symbol = self.symbols.fresh(),
+        const symbol = self.symbols.fresh();
+        try self.program.fns.append(self.allocator, undefined);
+        try self.fn_specs.append(self.allocator, spec);
+        try self.fn_written.append(self.allocator, false);
+        result.value_ptr.* = fn_id;
+
+        self.program.fns.items[@intFromEnum(fn_id)] = .{
+            .symbol = symbol,
             .source = source_fn.source,
             .args = .empty(),
             .body = .hosted,
@@ -356,10 +362,7 @@ const Lowerer = struct {
                 .func => |func| func.ret,
                 else => Common.invariant("Lambda Mono function table contains a non-function type"),
             }),
-        });
-        try self.fn_specs.append(self.allocator, spec);
-        try self.fn_written.append(self.allocator, false);
-        result.value_ptr.* = fn_id;
+        };
         return fn_id;
     }
 

--- a/src/postcheck/lambda_mono/type.zig
+++ b/src/postcheck/lambda_mono/type.zig
@@ -16,6 +16,8 @@ const static_dispatch = check.StaticDispatchRegistry;
 
 /// Identifier for a Lambda Mono type in this store.
 pub const TypeId = enum(u32) { _ };
+/// Identifier for a Lambda Mono function body.
+pub const FnId = enum(u32) { _ };
 /// Identifier for a callable variant in this store.
 pub const FnVariantId = enum(u32) { _ };
 
@@ -52,7 +54,8 @@ pub const Tag = struct {
 /// Callable variant entry.
 pub const FnVariant = struct {
     id: FnVariantId,
-    lambda: Common.Symbol,
+    source: Common.Symbol,
+    target: FnId,
     capture_ty: ?TypeId,
 };
 
@@ -256,7 +259,8 @@ pub const Store = struct {
                 const variant_slice = self.fnVariantSpan(variants);
                 writeU32(hasher, @intCast(variant_slice.len));
                 for (variant_slice) |variant| {
-                    writeU32(hasher, @intFromEnum(variant.lambda));
+                    writeU32(hasher, @intFromEnum(variant.source));
+                    writeU32(hasher, @intFromEnum(variant.target));
                     if (variant.capture_ty) |capture_ty| {
                         writeBytes(hasher, "capture");
                         self.writeTypeDigest(name_store, hasher, capture_ty);
@@ -279,7 +283,8 @@ pub const Store = struct {
                 const variant_slice = self.fnVariantSpan(erased.members);
                 writeU32(hasher, @intCast(variant_slice.len));
                 for (variant_slice) |variant| {
-                    writeU32(hasher, @intFromEnum(variant.lambda));
+                    writeU32(hasher, @intFromEnum(variant.source));
+                    writeU32(hasher, @intFromEnum(variant.target));
                     if (variant.capture_ty) |capture_ty| {
                         writeBytes(hasher, "capture");
                         self.writeTypeDigest(name_store, hasher, capture_ty);
@@ -334,8 +339,8 @@ test "lambda mono callable variants receive store-local ids" {
 
     const capture_ty = try store.add(.zst);
     const variants = try store.addFnVariants(&.{
-        .{ .id = @enumFromInt(99), .lambda = @enumFromInt(7), .capture_ty = capture_ty },
-        .{ .id = @enumFromInt(99), .lambda = @enumFromInt(8), .capture_ty = null },
+        .{ .id = @enumFromInt(99), .source = @enumFromInt(7), .target = @enumFromInt(70), .capture_ty = capture_ty },
+        .{ .id = @enumFromInt(99), .source = @enumFromInt(8), .target = @enumFromInt(80), .capture_ty = null },
     });
     const callable = try store.add(.{ .callable = variants });
 
@@ -354,7 +359,7 @@ test "lambda mono empty spans use shared empty descriptor" {
     const nonempty_fields = try store.addFields(&.{.{ .name = @enumFromInt(1), .ty = unit }});
     const nonempty_capture_fields = try store.addCaptureFields(&.{.{ .symbol = @enumFromInt(2), .binder = null, .ty = unit }});
     const nonempty_tags = try store.addTags(&.{.{ .name = @enumFromInt(3), .checked_name = @enumFromInt(3), .payloads = nonempty_span }});
-    const nonempty_variants = try store.addFnVariants(&.{.{ .id = @enumFromInt(99), .lambda = @enumFromInt(4), .capture_ty = unit }});
+    const nonempty_variants = try store.addFnVariants(&.{.{ .id = @enumFromInt(99), .source = @enumFromInt(4), .target = @enumFromInt(40), .capture_ty = unit }});
     try std.testing.expect(nonempty_span.len == 1);
     try std.testing.expect(nonempty_fields.len == 1);
     try std.testing.expect(nonempty_capture_fields.len == 1);

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -622,14 +622,6 @@ const Solver = struct {
         return self.program.types.root(ty);
     }
 
-    fn patSlot(self: *Solver, pat_id: Lifted.PatId) Allocator.Error!Type.TypeVarId {
-        const index = @intFromEnum(pat_id);
-        if (self.pat_tys[index]) |ty| return ty;
-        const ty = try self.lowerTypeFresh(self.program.lifted.pats.items[index].ty);
-        self.pat_tys[index] = ty;
-        return ty;
-    }
-
     fn expectPat(self: *Solver, pat_id: Lifted.PatId, expected: Type.TypeVarId) Allocator.Error!Type.TypeVarId {
         const index = @intFromEnum(pat_id);
         if (self.pat_tys[index]) |ty| {
@@ -646,14 +638,6 @@ const Solver = struct {
         try self.unify(ty, expected);
         self.pat_tys[index] = ty;
         return self.program.types.root(ty);
-    }
-
-    fn inferExprSpan(self: *Solver, span: Lifted.Span(Lifted.ExprId)) Allocator.Error![]Type.TypeVarId {
-        const exprs = self.program.lifted.exprSpan(span);
-        const tys = try self.allocator.alloc(Type.TypeVarId, exprs.len);
-        errdefer self.allocator.free(tys);
-        for (exprs, 0..) |expr, i| tys[i] = try self.inferExpr(expr);
-        return tys;
     }
 
     fn functionShape(self: *Solver, ty: Type.TypeVarId) Allocator.Error!FunctionShape {

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -54,6 +54,12 @@ const Solver = struct {
     return_tys: std.ArrayList(Type.TypeVarId),
     active_unifications: std.AutoHashMap(UnifyPair, void),
 
+    const FunctionShape = struct {
+        args: Type.Span,
+        callable: Type.TypeVarId,
+        ret: Type.TypeVarId,
+    };
+
     fn init(allocator: Allocator, program: *Ast.Program) Allocator.Error!Solver {
         const local_tys = try allocator.alloc(?Type.TypeVarId, program.lifted.locals.items.len);
         errdefer allocator.free(local_tys);
@@ -179,8 +185,11 @@ const Solver = struct {
         const args = try self.allocator.alloc(Type.TypeVarId, arg_locals.len);
         defer self.allocator.free(args);
         for (arg_locals, 0..) |arg, i| {
-            args[i] = try self.lowerTypeFresh(arg.ty);
-            try self.unify(args[i], self.localTy(arg.local));
+            const local = self.program.lifted.locals.items[@intFromEnum(arg.local)];
+            if (@import("builtin").mode == .Debug and local.ty != arg.ty) {
+                Common.invariant("Lambda Solved function argument type differed from its local type");
+            }
+            args[i] = self.localTy(arg.local);
         }
 
         const capture_locals = self.program.lifted.typedLocalSpan(fn_.captures);
@@ -239,8 +248,7 @@ const Solver = struct {
 
         switch (fn_.body) {
             .roc => |body| {
-                const body_ty = try self.inferExpr(body);
-                try self.unify(body_ty, func.ret);
+                _ = try self.expectExpr(body, func.ret);
             },
             .hosted => {},
         }
@@ -372,7 +380,7 @@ const Solver = struct {
             .list => |items| {
                 const elem_ty = try self.listElem(expected);
                 for (self.program.lifted.exprSpan(items)) |child| {
-                    try self.unify(try self.inferExpr(child), elem_ty);
+                    _ = try self.expectExpr(child, elem_ty);
                 }
             },
             .tuple => |items| {
@@ -381,12 +389,12 @@ const Solver = struct {
                 if (item_tys.count() != children.len) Common.invariant("tuple expression arity differs from its checked type");
                 for (children, 0..) |child, i| {
                     const item_ty = self.program.types.spanItem(item_tys, i);
-                    try self.unify(try self.inferExpr(child), item_ty);
+                    _ = try self.expectExpr(child, item_ty);
                 }
             },
             .record => |fields| {
                 for (self.program.lifted.fieldExprSpan(fields)) |field| {
-                    try self.unify(try self.inferExpr(field.value), try self.recordField(expected, field.name));
+                    _ = try self.expectExpr(field.value, try self.recordField(expected, field.name));
                 }
             },
             .tag => |tag| {
@@ -395,13 +403,12 @@ const Solver = struct {
                 if (payload_tys.count() != payloads.len) Common.invariant("tag expression payload arity differs from its checked type");
                 for (payloads, 0..) |payload, i| {
                     const expected_payload_ty = self.program.types.spanItem(payload_tys, i);
-                    const payload_ty = try self.inferExpr(payload);
-                    try self.unify(payload_ty, expected_payload_ty);
+                    _ = try self.expectExpr(payload, expected_payload_ty);
                 }
             },
             .nominal => |backing| {
                 if (try self.namedBacking(expected)) |backing_ty| {
-                    try self.unify(try self.inferExpr(backing), backing_ty);
+                    _ = try self.expectExpr(backing, backing_ty);
                 } else {
                     _ = try self.inferExpr(backing);
                 }
@@ -409,30 +416,26 @@ const Solver = struct {
             .let_ => |let_| {
                 const value_ty = try self.inferExpr(let_.value);
                 try self.bindPattern(let_.bind, value_ty);
-                try self.unify(expected, try self.inferExpr(let_.rest));
+                _ = try self.expectExpr(let_.rest, expected);
             },
             .fn_ref => |fn_id| try self.unify(expected, self.program.fn_tys.items[@intFromEnum(fn_id)]),
             .call_value => |call| {
-                const args = try self.inferExprSpan(call.args);
-                defer self.allocator.free(args);
-                const callable = try self.program.types.add(.unbound);
-                const wanted = try self.program.types.add(.{ .func = .{
-                    .args = try self.program.types.addSpan(args),
-                    .callable = callable,
-                    .ret = expected,
-                } });
-                try self.unify(try self.inferExpr(call.callee), wanted);
+                const func = try self.functionShape(try self.inferExpr(call.callee));
+                const args = self.program.lifted.exprSpan(call.args);
+                if (func.args.count() != args.len) Common.invariant("value call arity differs from its checked type");
+                try self.unify(expected, func.ret);
+                for (args, 0..) |arg, i| {
+                    _ = try self.expectExpr(arg, self.program.types.spanItem(func.args, i));
+                }
             },
             .call_proc => |call| {
-                const args = try self.inferExprSpan(call.args);
-                defer self.allocator.free(args);
-                const callable = try self.program.types.add(.unbound);
-                const wanted = try self.program.types.add(.{ .func = .{
-                    .args = try self.program.types.addSpan(args),
-                    .callable = callable,
-                    .ret = expected,
-                } });
-                try self.unify(self.program.fn_tys.items[@intFromEnum(call.callee)], wanted);
+                const func = try self.functionShape(self.program.fn_tys.items[@intFromEnum(call.callee)]);
+                const args = self.program.lifted.exprSpan(call.args);
+                if (func.args.count() != args.len) Common.invariant("procedure call arity differs from its checked type");
+                try self.unify(expected, func.ret);
+                for (args, 0..) |arg, i| {
+                    _ = try self.expectExpr(arg, self.program.types.spanItem(func.args, i));
+                }
             },
             .low_level => |call| {
                 const args = self.program.lifted.exprSpan(call.args);
@@ -463,19 +466,19 @@ const Solver = struct {
                 for (self.program.lifted.branchSpan(match.branches)) |branch| {
                     try self.bindPattern(branch.pat, scrutinee_ty);
                     if (branch.guard) |guard| _ = try self.inferExpr(guard);
-                    try self.unify(expected, try self.inferExpr(branch.body));
+                    _ = try self.expectExpr(branch.body, expected);
                 }
             },
             .if_ => |if_| {
                 for (self.program.lifted.ifBranchSpan(if_.branches)) |branch| {
                     _ = try self.inferExpr(branch.cond);
-                    try self.unify(expected, try self.inferExpr(branch.body));
+                    _ = try self.expectExpr(branch.body, expected);
                 }
-                try self.unify(expected, try self.inferExpr(if_.final_else));
+                _ = try self.expectExpr(if_.final_else, expected);
             },
             .block => |block| {
                 for (self.program.lifted.stmtSpan(block.statements)) |stmt| try self.inferStmt(stmt);
-                try self.unify(expected, try self.inferExpr(block.final_expr));
+                _ = try self.expectExpr(block.final_expr, expected);
             },
             .loop_ => |loop| {
                 const params = self.program.lifted.typedLocalSpan(loop.params);
@@ -485,17 +488,17 @@ const Solver = struct {
                 defer self.allocator.free(param_tys);
                 for (params, 0..) |param, i| {
                     param_tys[i] = self.localTy(param.local);
-                    try self.unify(param_tys[i], try self.inferExpr(initials[i]));
+                    _ = try self.expectExpr(initials[i], param_tys[i]);
                 }
                 try self.loop_results.append(self.allocator, expected);
                 try self.loop_params.append(self.allocator, try self.program.types.addSpan(param_tys));
                 defer _ = self.loop_params.pop();
                 defer _ = self.loop_results.pop();
-                try self.unify(expected, try self.inferExpr(loop.body));
+                _ = try self.expectExpr(loop.body, expected);
             },
             .break_ => |maybe| {
                 if (maybe) |value| {
-                    try self.unify(self.currentLoopResult(), try self.inferExpr(value));
+                    _ = try self.expectExpr(value, self.currentLoopResult());
                 }
             },
             .continue_ => |continue_| {
@@ -504,10 +507,10 @@ const Solver = struct {
                 if (params.count() != values.len) Common.invariant("continue value count differs from loop parameter count");
                 for (values, 0..) |value, i| {
                     const param_ty = self.program.types.spanItem(params, i);
-                    try self.unify(param_ty, try self.inferExpr(value));
+                    _ = try self.expectExpr(value, param_ty);
                 }
             },
-            .return_ => |value| try self.unify(self.currentReturnTy(), try self.inferExpr(value)),
+            .return_ => |value| _ = try self.expectExpr(value, self.currentReturnTy()),
             .dbg,
             .expect,
             => |child| _ = try self.inferExpr(child),
@@ -525,15 +528,14 @@ const Solver = struct {
             .expect,
             .dbg,
             => |expr| _ = try self.inferExpr(expr),
-            .return_ => |expr| try self.unify(self.currentReturnTy(), try self.inferExpr(expr)),
+            .return_ => |expr| _ = try self.expectExpr(expr, self.currentReturnTy()),
             .crash => {},
         }
     }
 
     fn bindPattern(self: *Solver, pat_id: Lifted.PatId, value_ty: Type.TypeVarId) Allocator.Error!void {
         const pat = self.program.lifted.pats.items[@intFromEnum(pat_id)];
-        const pat_ty = try self.patSlot(pat_id);
-        try self.unify(value_ty, pat_ty);
+        const pat_ty = try self.expectPat(pat_id, value_ty);
         switch (pat.data) {
             .bind => |local| try self.unify(self.localTy(local), pat_ty),
             .wildcard,
@@ -580,17 +582,44 @@ const Solver = struct {
         }
     }
 
+    fn expectExpr(self: *Solver, expr_id: Lifted.ExprId, expected: Type.TypeVarId) Allocator.Error!Type.TypeVarId {
+        const slot = try self.expectExprSlot(expr_id, expected);
+        const inferred = try self.inferExpr(expr_id);
+        try self.unify(slot, inferred);
+        return self.program.types.root(slot);
+    }
+
     fn exprSlot(self: *Solver, expr_id: Lifted.ExprId) Allocator.Error!Type.TypeVarId {
         const index = @intFromEnum(expr_id);
         if (self.expr_tys[index]) |ty| return ty;
 
         const expr = self.program.lifted.exprs.items[index];
         const ty = switch (expr.data) {
+            .local => |local| self.localTy(local),
             .fn_ref => |fn_id| self.program.fn_tys.items[@intFromEnum(fn_id)],
+            .call_proc => |call| (try self.functionShape(self.program.fn_tys.items[@intFromEnum(call.callee)])).ret,
             else => try self.lowerTypeFresh(expr.ty),
         };
         self.expr_tys[index] = ty;
         return ty;
+    }
+
+    fn expectExprSlot(self: *Solver, expr_id: Lifted.ExprId, expected: Type.TypeVarId) Allocator.Error!Type.TypeVarId {
+        const index = @intFromEnum(expr_id);
+        if (self.expr_tys[index]) |ty| {
+            try self.unify(ty, expected);
+            return self.program.types.root(ty);
+        }
+
+        const expr = self.program.lifted.exprs.items[index];
+        const ty = switch (expr.data) {
+            .local => |local| self.localTy(local),
+            .fn_ref => |fn_id| self.program.fn_tys.items[@intFromEnum(fn_id)],
+            else => expected,
+        };
+        try self.unify(ty, expected);
+        self.expr_tys[index] = ty;
+        return self.program.types.root(ty);
     }
 
     fn patSlot(self: *Solver, pat_id: Lifted.PatId) Allocator.Error!Type.TypeVarId {
@@ -601,12 +630,37 @@ const Solver = struct {
         return ty;
     }
 
+    fn expectPat(self: *Solver, pat_id: Lifted.PatId, expected: Type.TypeVarId) Allocator.Error!Type.TypeVarId {
+        const index = @intFromEnum(pat_id);
+        if (self.pat_tys[index]) |ty| {
+            try self.unify(ty, expected);
+            return self.program.types.root(ty);
+        }
+
+        const pat = self.program.lifted.pats.items[index];
+        const ty = switch (pat.data) {
+            .bind => |local| self.localTy(local),
+            .as => |as| self.localTy(as.local),
+            else => expected,
+        };
+        try self.unify(ty, expected);
+        self.pat_tys[index] = ty;
+        return self.program.types.root(ty);
+    }
+
     fn inferExprSpan(self: *Solver, span: Lifted.Span(Lifted.ExprId)) Allocator.Error![]Type.TypeVarId {
         const exprs = self.program.lifted.exprSpan(span);
         const tys = try self.allocator.alloc(Type.TypeVarId, exprs.len);
         errdefer self.allocator.free(tys);
         for (exprs, 0..) |expr, i| tys[i] = try self.inferExpr(expr);
         return tys;
+    }
+
+    fn functionShape(self: *Solver, ty: Type.TypeVarId) Allocator.Error!FunctionShape {
+        return switch (try self.shapeContent(ty)) {
+            .func => |func| .{ .args = func.args, .callable = func.callable, .ret = func.ret },
+            else => Common.invariant("call expression had a non-function checked type"),
+        };
     }
 
     fn localTy(self: *Solver, local: Lifted.LocalId) Type.TypeVarId {
@@ -897,9 +951,7 @@ const Solver = struct {
                     }
                     self.program.types.set(b, .{ .link = a });
                 },
-                else => {
-                    Common.invariant("primitive type failed Lambda Solved unification");
-                },
+                else => Common.invariant("primitive type failed Lambda Solved unification"),
             },
             .zst => switch (right) {
                 .zst => self.program.types.set(b, .{ .link = a }),

--- a/src/postcheck/lir_lower.zig
+++ b/src/postcheck/lir_lower.zig
@@ -461,7 +461,7 @@ const Lowerer = struct {
                     try self.callablePayloadLayout(value_layout, type_variants.len, @intCast(index), capture_ty)
                 else
                     .zst,
-                .template = constFnTemplateFromMono(self.fnTemplateForSymbol(variant.lambda)),
+                .template = constFnTemplateFromMono(self.fnTemplateForFn(variant.target)),
                 .captures = captures,
             };
             captures_owned = false;
@@ -500,9 +500,9 @@ const Lowerer = struct {
             errdefer if (captures_owned) self.allocator.free(captures);
 
             entries[index] = .{
-                .entry = self.fnLirProcForSymbol(member.lambda),
+                .entry = self.fn_map[@intFromEnum(member.target)],
                 .capture_layout = if (member.capture_ty) |capture_ty| try self.layoutOfType(capture_ty) else .zst,
-                .template = constFnTemplateFromMono(self.fnTemplateForSymbol(member.lambda)),
+                .template = constFnTemplateFromMono(self.fnTemplateForFn(member.target)),
                 .captures = captures,
             };
             captures_owned = false;
@@ -558,20 +558,11 @@ const Lowerer = struct {
         return slots;
     }
 
-    fn fnTemplateForSymbol(self: *Lowerer, symbol: Common.Symbol) Mono.FnTemplate {
-        for (self.program.fns.items) |fn_| {
-            if (fn_.symbol != symbol) continue;
-            return fn_.source orelse Common.invariant("function result referenced a generated function without checked source identity");
-        }
-        Common.invariant("function result referenced a missing function symbol");
-    }
-
-    fn fnLirProcForSymbol(self: *Lowerer, symbol: Common.Symbol) LIR.LirProcSpecId {
-        for (self.program.fns.items, 0..) |fn_, index| {
-            if (fn_.symbol != symbol) continue;
-            return self.fn_map[index];
-        }
-        Common.invariant("erased function entry referenced a missing function symbol");
+    fn fnTemplateForFn(self: *Lowerer, fn_id: LambdaMono.FnId) Mono.FnTemplate {
+        const raw = @intFromEnum(fn_id);
+        if (raw >= self.program.fns.items.len) Common.invariant("function result referenced a missing function");
+        return self.program.fns.items[raw].source orelse
+            Common.invariant("function result referenced a generated function without checked source identity");
     }
 
     fn writeRuntimeSchemas(self: *Lowerer) Common.LowerError!void {

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -3175,7 +3175,10 @@ const BodyContext = struct {
             .tag_union => |tag_union| try self.fillTagUnionRowType(mono_ty, tag_union.tags, tag_union.ext),
             .alias => |alias| try self.fillAliasType(checked_ty, mono_ty, alias),
             .nominal => |nominal| try self.fillNominalType(checked_ty, mono_ty, nominal),
-            else => self.builder.program.types.types.items[@intFromEnum(mono_ty)] = try self.lowerTypePayload(checked_ty, payload),
+            else => {
+                const lowered = try self.lowerTypePayload(checked_ty, payload);
+                self.builder.program.types.types.items[@intFromEnum(mono_ty)] = lowered;
+            },
         }
 
         const binding = self.type_bindings.getPtr(address) orelse Common.invariant("checked type finished without a monotype binding");

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -1702,10 +1702,11 @@ const Builder = struct {
         const arg_expr = try self.localExpr(arg_local, value_ty);
         const body = try self.inspectBody(arg_expr, value_ty, value_ty, str_ty);
 
+        const args = try self.program.addTypedLocalSpan(&.{.{ .local = arg_local, .ty = value_ty }});
         self.program.defs.items[@intFromEnum(def_id)] = .{
             .symbol = self.symbols.fresh(),
             .fn_def = null,
-            .args = try self.program.addTypedLocalSpan(&.{.{ .local = arg_local, .ty = value_ty }}),
+            .args = args,
             .body = .{ .roc = body },
             .ret = str_ty,
         };
@@ -3196,8 +3197,9 @@ const BodyContext = struct {
         const args = try self.reserveTypeSlice(function.args);
         defer self.allocator.free(args);
         const ret = try self.reserveType(function.ret);
+        const args_span = try self.builder.program.types.addSpan(args);
         self.builder.program.types.types.items[@intFromEnum(mono_ty)] = .{ .func = .{
-            .args = try self.builder.program.types.addSpan(args),
+            .args = args_span,
             .ret = ret,
         } };
         try self.finishTypeSlice(function.args);
@@ -3211,8 +3213,9 @@ const BodyContext = struct {
     ) Allocator.Error!void {
         const reserved_items = try self.reserveTypeSlice(items);
         defer self.allocator.free(reserved_items);
+        const tuple_items = try self.builder.program.types.addSpan(reserved_items);
         self.builder.program.types.types.items[@intFromEnum(mono_ty)] = .{
-            .tuple = try self.builder.program.types.addSpan(reserved_items),
+            .tuple = tuple_items,
         };
         try self.finishTypeSlice(items);
     }
@@ -3228,8 +3231,9 @@ const BodyContext = struct {
         defer checked_fields.deinit(self.allocator);
         try self.appendReservedRecordFields(&lowered, &checked_fields, fields);
         std.mem.sort(Type.Field, lowered.items, self.builder, recordFieldLessThan);
+        const record_fields = try self.builder.program.types.addFields(lowered.items);
         self.builder.program.types.types.items[@intFromEnum(mono_ty)] = .{
-            .record = try self.builder.program.types.addFields(lowered.items),
+            .record = record_fields,
         };
         try self.finishTypeList(checked_fields.items);
     }
@@ -3276,8 +3280,9 @@ const BodyContext = struct {
 
         std.mem.sort(Type.Field, fields.items, self.builder, recordFieldLessThan);
         assertNoDuplicateRecordFields(self.builder, fields.items, "checked record row had duplicate fields at Monotype lowering");
+        const record_fields = try self.builder.program.types.addFields(fields.items);
         self.builder.program.types.types.items[@intFromEnum(mono_ty)] = .{
-            .record = try self.builder.program.types.addFields(fields.items),
+            .record = record_fields,
         };
         try self.finishTypeList(checked_fields.items);
     }
@@ -3335,8 +3340,9 @@ const BodyContext = struct {
 
         std.mem.sort(Type.Tag, tags.items, self.builder, tagLessThan);
         assertNoDuplicateTags(self.builder, tags.items, "checked tag-union row had duplicate tags at Monotype lowering");
+        const tag_span = try self.builder.program.types.addTags(tags.items);
         self.builder.program.types.types.items[@intFromEnum(mono_ty)] = .{
-            .tag_union = try self.builder.program.types.addTags(tags.items),
+            .tag_union = tag_span,
         };
         try self.finishTypeList(checked_payloads.items);
     }
@@ -3368,11 +3374,13 @@ const BodyContext = struct {
         const args = try self.reserveTypeSlice(alias.args);
         defer self.allocator.free(args);
         const backing = try self.reserveType(alias.backing);
+        const def = try self.builder.typeDef(self.view, alias.origin_module, alias.name);
+        const args_span = try self.builder.program.types.addSpan(args);
         self.builder.program.types.types.items[@intFromEnum(mono_ty)] = .{ .named = .{
             .named_type = .{ .module = self.builder.declaredModuleForAlias(self.view, alias), .ty = checked_ty },
-            .def = try self.builder.typeDef(self.view, alias.origin_module, alias.name),
+            .def = def,
             .kind = .alias,
-            .args = try self.builder.program.types.addSpan(args),
+            .args = args_span,
             .backing = .{
                 .ty = backing,
                 .use = .inspectable,
@@ -3424,12 +3432,14 @@ const BodyContext = struct {
                 .use = backing_use,
             },
         };
+        const def = try self.builder.typeDef(self.view, nominal.origin_module, nominal.name);
+        const args_span = try self.builder.program.types.addSpan(args);
         self.builder.program.types.types.items[@intFromEnum(mono_ty)] = .{ .named = .{
             .named_type = .{ .module = self.builder.declaredModuleForNominal(self.view, nominal), .ty = checked_ty },
-            .def = try self.builder.typeDef(self.view, nominal.origin_module, nominal.name),
+            .def = def,
             .kind = if (nominal.is_opaque) .@"opaque" else .nominal,
             .builtin_owner = builtinOwner(nominal.builtin),
-            .args = try self.builder.program.types.addSpan(args),
+            .args = args_span,
             .backing = backing,
         } };
         try self.finishTypeSlice(nominal.args);

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -139,6 +139,11 @@ const TypeBinding = struct {
     }
 };
 
+const CheckedMonoRelation = struct {
+    checked: CheckedTypeAddress,
+    mono: Type.TypeId,
+};
+
 const LambdaArgLet = struct {
     pat: Ast.PatId,
     value: Ast.ExprId,
@@ -2048,6 +2053,7 @@ const BodyContext = struct {
     owner_context_fn_key: names.TypeDigest,
     current_fn_key: names.TypeDigest,
     binders: BinderMap,
+    local_proc_contexts: std.AutoHashMap(checked.PatternBinderId, names.TypeDigest),
     type_bindings: std.AutoHashMap(CheckedTypeAddress, TypeBinding),
     string_literals: []?Ast.StringLiteralId,
     loop_contexts: std.ArrayList(LoopContext),
@@ -2070,6 +2076,7 @@ const BodyContext = struct {
             .owner_context_fn_key = .{},
             .current_fn_key = .{},
             .binders = BinderMap.init(allocator),
+            .local_proc_contexts = std.AutoHashMap(checked.PatternBinderId, names.TypeDigest).init(allocator),
             .type_bindings = std.AutoHashMap(CheckedTypeAddress, TypeBinding).init(allocator),
             .string_literals = string_literals,
             .loop_contexts = .empty,
@@ -2081,6 +2088,7 @@ const BodyContext = struct {
         self.loop_contexts.deinit(self.allocator);
         self.allocator.free(self.string_literals);
         self.type_bindings.deinit();
+        self.local_proc_contexts.deinit();
         self.binders.deinit();
     }
 
@@ -2093,6 +2101,11 @@ const BodyContext = struct {
         var binder_iter = self.binders.iterator();
         while (binder_iter.next()) |entry| {
             try child.binders.put(entry.key_ptr.*, entry.value_ptr.*);
+        }
+
+        var proc_iter = self.local_proc_contexts.iterator();
+        while (proc_iter.next()) |entry| {
+            try child.local_proc_contexts.put(entry.key_ptr.*, entry.value_ptr.*);
         }
 
         var type_iter = self.type_bindings.iterator();
@@ -2219,15 +2232,19 @@ const BodyContext = struct {
         const address = self.typeAddress(generic_ty);
         if (self.type_bindings.get(address)) |existing| {
             if (!self.sameType(existing.ty, mono_ty)) {
-                try self.bindTypeChildrenToMono(generic_ty, mono_ty, conflict_message);
-                if (self.sameType(existing.ty, mono_ty)) return;
+                if (existing.state == .defaulted and self.monoTypeIsEmptyTagUnion(mono_ty)) {
+                    return;
+                }
                 if (existing.state == .uninhabited or existing.state == .defaulted) {
                     self.builder.program.types.types.items[@intFromEnum(existing.ty)] = self.builder.program.types.get(mono_ty);
                     var entry = self.type_bindings.getPtr(address) orelse Common.invariant("checked type binding disappeared while completing replaceable type");
-                    entry.state = .lowered;
+                    entry.state = try self.bindingStateFor(generic_ty, existing.ty);
                     self.type_binding_revision += 1;
+                    try self.bindTypeChildrenToMono(generic_ty, existing.ty, conflict_message);
                     return;
                 }
+                try self.bindTypeChildrenToMono(generic_ty, mono_ty, conflict_message);
+                if (self.sameType(existing.ty, mono_ty)) return;
                 Common.invariant(conflict_message);
             }
             return;
@@ -2236,6 +2253,13 @@ const BodyContext = struct {
         self.type_binding_revision += 1;
 
         try self.bindTypeChildrenToMono(generic_ty, mono_ty, conflict_message);
+    }
+
+    fn monoTypeIsEmptyTagUnion(self: *BodyContext, ty: Type.TypeId) bool {
+        return switch (self.builder.shapeContent(ty)) {
+            .tag_union => |tags| self.builder.program.types.tagSpan(tags).len == 0,
+            else => false,
+        };
     }
 
     fn bindTypeChildrenToMono(
@@ -2502,21 +2526,52 @@ const BodyContext = struct {
         mono_ty: Type.TypeId,
         comptime conflict_message: []const u8,
     ) Allocator.Error!void {
+        switch (nominal.representation) {
+            .builtin => |builtin| switch (checked.builtinRuntimeEncoding(builtin)) {
+                .primitive => |primitive| {
+                    switch (self.builder.shapeContent(mono_ty)) {
+                        .primitive => |mono_primitive| {
+                            if (mono_primitive != primitive) Common.invariant(conflict_message);
+                            return;
+                        },
+                        else => Common.invariant("builtin primitive nominal was bound to a non-primitive monotype"),
+                    }
+                },
+                .bool_tag_union => {
+                    try self.bindTypeToMono(nominal.backing, self.builder.namedBackingType(mono_ty) orelse mono_ty, conflict_message);
+                    return;
+                },
+                .list => {
+                    if (nominal.args.len != 1) Common.invariant("template type substitution List arity mismatch");
+                    const elem_ty = switch (self.builder.shapeContent(mono_ty)) {
+                        .list => |elem| elem,
+                        else => Common.invariant("builtin List nominal was bound to a non-list monotype"),
+                    };
+                    try self.bindTypeToMono(nominal.args[0], elem_ty, conflict_message);
+                    return;
+                },
+                .box => {
+                    if (nominal.args.len != 1) Common.invariant("template type substitution Box arity mismatch");
+                    const elem_ty = switch (self.builder.shapeContent(mono_ty)) {
+                        .box => |elem| elem,
+                        else => Common.invariant("builtin Box nominal was bound to a non-box monotype"),
+                    };
+                    try self.bindTypeToMono(nominal.args[0], elem_ty, conflict_message);
+                    return;
+                },
+            },
+            else => {},
+        }
+
         switch (self.builder.program.types.get(mono_ty)) {
             .named => |named| try self.bindTypeSpanToMono(nominal.args, self.builder.program.types.span(named.args), conflict_message),
-            .list => |elem_ty| {
-                if (nominal.args.len != 1) Common.invariant("template type substitution List arity mismatch");
-                try self.bindTypeToMono(nominal.args[0], elem_ty, conflict_message);
-            },
-            .box => |elem_ty| {
-                if (nominal.args.len != 1) Common.invariant("template type substitution Box arity mismatch");
-                try self.bindTypeToMono(nominal.args[0], elem_ty, conflict_message);
-            },
             .primitive,
             .tag_union,
             .record,
             .tuple,
             .func,
+            .list,
+            .box,
             .erased,
             .zst,
             => {
@@ -2589,6 +2644,13 @@ const BodyContext = struct {
         };
     }
 
+    fn monoNamedArgs(types: *const Type.Store, mono_ty: Type.TypeId) ?[]const Type.TypeId {
+        return switch (types.get(mono_ty)) {
+            .named => |named| types.span(named.args),
+            else => null,
+        };
+    }
+
     fn bindKnownType(
         self: *BodyContext,
         checked_ty: checked.CheckedTypeId,
@@ -2599,21 +2661,297 @@ const BodyContext = struct {
 
     fn bindingStateFor(self: *BodyContext, checked_ty: checked.CheckedTypeId, mono_ty: Type.TypeId) Allocator.Error!TypeState {
         const payload = checkedPayload(self.view, checked_ty);
+        if (try self.checkedTypeUsesDefaultForMono(checked_ty, mono_ty)) return .defaulted;
         if (checkedTypePayloadIsOpenVariable(payload) and try self.monoTypeContainsUninhabited(mono_ty)) return .uninhabited;
-        if (checkedTypePayloadHasMonoDefault(payload) and try self.monoTypeContainsNumericDefault(mono_ty)) return .defaulted;
         return .lowered;
+    }
+
+    fn checkedTypeUsesDefaultForMono(self: *BodyContext, checked_ty: checked.CheckedTypeId, mono_ty: Type.TypeId) Allocator.Error!bool {
+        var active = std.AutoHashMap(CheckedMonoRelation, void).init(self.allocator);
+        defer active.deinit();
+        return try self.checkedTypeUsesDefaultForMonoInner(checked_ty, mono_ty, &active);
+    }
+
+    fn checkedTypeUsesDefaultForMonoInner(
+        self: *BodyContext,
+        checked_ty: checked.CheckedTypeId,
+        mono_ty: Type.TypeId,
+        active: *std.AutoHashMap(CheckedMonoRelation, void),
+    ) Allocator.Error!bool {
+        const relation = CheckedMonoRelation{
+            .checked = self.typeAddress(checked_ty),
+            .mono = mono_ty,
+        };
+        if (active.contains(relation)) return false;
+        try active.put(relation, {});
+        defer _ = active.remove(relation);
+
+        return switch (checkedPayload(self.view, checked_ty)) {
+            .pending => Common.invariant("pending checked type reached default-derived monotype detection"),
+            .flex, .rigid => |variable| self.checkedVariableUsesDefaultForMono(variable, mono_ty),
+            .empty_record,
+            .empty_tag_union,
+            => false,
+            .alias => |alias| (try self.checkedTypeSliceUsesDefaultForMono(alias.args, monoAliasArgs(&self.builder.program.types, mono_ty) orelse &.{}, active)) or
+                try self.checkedTypeUsesDefaultForMonoInner(alias.backing, monoAliasBacking(&self.builder.program.types, mono_ty) orelse mono_ty, active),
+            .record_unbound => |fields| try self.checkedRecordFieldsUseDefaultForMono(fields, mono_ty, active),
+            .record => |record| try self.checkedRecordRowUsesDefaultForMono(record.fields, record.ext, mono_ty, active),
+            .tuple => |items| try self.checkedTypeSliceUsesDefaultForMono(items, self.monoTupleItems(mono_ty), active),
+            .function => |function| blk: {
+                switch (self.builder.shapeContent(mono_ty)) {
+                    .func => |mono_fn| {
+                        if (try self.checkedTypeSliceUsesDefaultForMono(function.args, self.builder.program.types.span(mono_fn.args), active)) break :blk true;
+                        break :blk try self.checkedTypeUsesDefaultForMonoInner(function.ret, mono_fn.ret, active);
+                    },
+                    else => break :blk false,
+                }
+            },
+            .tag_union => |tag_union| try self.checkedTagRowUsesDefaultForMono(tag_union.tags, tag_union.ext, mono_ty, active),
+            .nominal => |nominal| try self.checkedNominalUsesDefaultForMono(nominal, mono_ty, active),
+        };
+    }
+
+    fn checkedVariableUsesDefaultForMono(self: *BodyContext, variable: checked.CheckedTypeVariable, mono_ty: Type.TypeId) bool {
+        if (variable.numeric_default_phase == .mono_specialization and self.builder.typeIsDec(mono_ty)) return true;
+        if (variable.row_default) |row_default| {
+            return switch (row_default) {
+                .empty_record => switch (self.builder.shapeContent(mono_ty)) {
+                    .record => |fields| self.builder.program.types.fieldSpan(fields).len == 0,
+                    else => false,
+                },
+                .empty_tag_union => switch (self.builder.shapeContent(mono_ty)) {
+                    .tag_union => |tags| self.builder.program.types.tagSpan(tags).len == 0,
+                    else => false,
+                },
+            };
+        }
+        return false;
+    }
+
+    fn checkedTypeSliceUsesDefaultForMono(
+        self: *BodyContext,
+        checked_tys: []const checked.CheckedTypeId,
+        mono_tys: []const Type.TypeId,
+        active: *std.AutoHashMap(CheckedMonoRelation, void),
+    ) Allocator.Error!bool {
+        if (checked_tys.len != mono_tys.len) return false;
+        for (checked_tys, mono_tys) |checked_ty, mono_ty| {
+            if (try self.checkedTypeUsesDefaultForMonoInner(checked_ty, mono_ty, active)) return true;
+        }
+        return false;
+    }
+
+    fn checkedRecordFieldsUseDefaultForMono(
+        self: *BodyContext,
+        checked_fields: []const checked.CheckedRecordField,
+        mono_ty: Type.TypeId,
+        active: *std.AutoHashMap(CheckedMonoRelation, void),
+    ) Allocator.Error!bool {
+        const mono_fields = switch (self.builder.shapeContent(mono_ty)) {
+            .record => |fields| self.builder.program.types.fieldSpan(fields),
+            else => return false,
+        };
+        for (checked_fields) |field| {
+            const mono_field = self.monoRecordFieldByCheckedName(mono_fields, field.name) orelse return false;
+            if (try self.checkedTypeUsesDefaultForMonoInner(field.ty, mono_field.ty, active)) return true;
+        }
+        return false;
+    }
+
+    fn checkedRecordRowUsesDefaultForMono(
+        self: *BodyContext,
+        head: []const checked.CheckedRecordField,
+        ext: checked.CheckedTypeId,
+        mono_ty: Type.TypeId,
+        active: *std.AutoHashMap(CheckedMonoRelation, void),
+    ) Allocator.Error!bool {
+        const mono_fields = switch (self.builder.shapeContent(mono_ty)) {
+            .record => |fields| self.builder.program.types.fieldSpan(fields),
+            else => return false,
+        };
+
+        var expected_count: usize = 0;
+        var defaulted_row = false;
+        var payload_default = false;
+
+        try self.recordFieldsDefaultState(head, mono_fields, &expected_count, &payload_default, active);
+
+        var seen = std.AutoHashMap(checked.CheckedTypeId, void).init(self.allocator);
+        defer seen.deinit();
+
+        var current = ext;
+        while (true) {
+            if (seen.contains(current)) break;
+            try seen.put(current, {});
+
+            switch (checkedPayload(self.view, current)) {
+                .alias => |alias| current = alias.backing,
+                .empty_record => break,
+                .flex, .rigid => |variable| {
+                    if (variable.row_default == .empty_record) {
+                        defaulted_row = true;
+                        break;
+                    }
+                    break;
+                },
+                .record_unbound => |tail_fields| {
+                    try self.recordFieldsDefaultState(tail_fields, mono_fields, &expected_count, &payload_default, active);
+                    break;
+                },
+                .record => |record| {
+                    try self.recordFieldsDefaultState(record.fields, mono_fields, &expected_count, &payload_default, active);
+                    current = record.ext;
+                },
+                else => break,
+            }
+        }
+
+        return payload_default or (defaulted_row and expected_count == mono_fields.len);
+    }
+
+    fn recordFieldsDefaultState(
+        self: *BodyContext,
+        checked_fields: []const checked.CheckedRecordField,
+        mono_fields: []const Type.Field,
+        expected_count: *usize,
+        payload_default: *bool,
+        active: *std.AutoHashMap(CheckedMonoRelation, void),
+    ) Allocator.Error!void {
+        for (checked_fields) |field| {
+            expected_count.* += 1;
+            const mono_field = self.monoRecordFieldByCheckedName(mono_fields, field.name) orelse continue;
+            if (try self.checkedTypeUsesDefaultForMonoInner(field.ty, mono_field.ty, active)) payload_default.* = true;
+        }
+    }
+
+    fn checkedTagRowUsesDefaultForMono(
+        self: *BodyContext,
+        head: []const checked.CheckedTag,
+        ext: checked.CheckedTypeId,
+        mono_ty: Type.TypeId,
+        active: *std.AutoHashMap(CheckedMonoRelation, void),
+    ) Allocator.Error!bool {
+        const mono_tags = switch (self.builder.shapeContent(mono_ty)) {
+            .tag_union => |tags| self.builder.program.types.tagSpan(tags),
+            else => return false,
+        };
+
+        var expected_count: usize = 0;
+        var defaulted_row = false;
+        var payload_default = false;
+
+        try self.tagsDefaultState(head, mono_tags, &expected_count, &payload_default, active);
+
+        var seen = std.AutoHashMap(checked.CheckedTypeId, void).init(self.allocator);
+        defer seen.deinit();
+
+        var current = ext;
+        while (true) {
+            if (seen.contains(current)) break;
+            try seen.put(current, {});
+
+            switch (checkedPayload(self.view, current)) {
+                .alias => |alias| current = alias.backing,
+                .empty_tag_union => break,
+                .flex, .rigid => |variable| {
+                    if (variable.row_default == .empty_tag_union) {
+                        defaulted_row = true;
+                        break;
+                    }
+                    break;
+                },
+                .tag_union => |tag_union| {
+                    try self.tagsDefaultState(tag_union.tags, mono_tags, &expected_count, &payload_default, active);
+                    current = tag_union.ext;
+                },
+                else => break,
+            }
+        }
+
+        return payload_default or (defaulted_row and expected_count == mono_tags.len);
+    }
+
+    fn tagsDefaultState(
+        self: *BodyContext,
+        checked_tags: []const checked.CheckedTag,
+        mono_tags: []const Type.Tag,
+        expected_count: *usize,
+        payload_default: *bool,
+        active: *std.AutoHashMap(CheckedMonoRelation, void),
+    ) Allocator.Error!void {
+        for (checked_tags) |tag| {
+            expected_count.* += 1;
+            const mono_tag = self.monoTagByCheckedName(mono_tags, tag.name) orelse continue;
+            const payload_tys = self.builder.program.types.span(mono_tag.payloads);
+            if (try self.checkedTypeSliceUsesDefaultForMono(tag.args, payload_tys, active)) payload_default.* = true;
+        }
+    }
+
+    fn checkedNominalUsesDefaultForMono(
+        self: *BodyContext,
+        nominal: checked.CheckedNominalType,
+        mono_ty: Type.TypeId,
+        active: *std.AutoHashMap(CheckedMonoRelation, void),
+    ) Allocator.Error!bool {
+        switch (nominal.representation) {
+            .builtin => |builtin| switch (checked.builtinRuntimeEncoding(builtin)) {
+                .primitive => return false,
+                .list => {
+                    const item = switch (self.builder.shapeContent(mono_ty)) {
+                        .list => |item| item,
+                        else => return false,
+                    };
+                    return nominal.args.len == 1 and try self.checkedTypeUsesDefaultForMonoInner(nominal.args[0], item, active);
+                },
+                .box => {
+                    const item = switch (self.builder.shapeContent(mono_ty)) {
+                        .box => |item| item,
+                        else => return false,
+                    };
+                    return nominal.args.len == 1 and try self.checkedTypeUsesDefaultForMonoInner(nominal.args[0], item, active);
+                },
+                .bool_tag_union => {},
+            },
+            else => {},
+        }
+
+        if (try self.checkedNamedArgsUseDefaultForMono(nominal.args, mono_ty, active)) return true;
+        return switch (nominal.representation) {
+            .opaque_without_backing => false,
+            else => try self.checkedTypeUsesDefaultForMonoInner(nominal.backing, self.builder.namedBackingType(mono_ty) orelse mono_ty, active),
+        };
+    }
+
+    fn checkedNamedArgsUseDefaultForMono(
+        self: *BodyContext,
+        checked_args: []const checked.CheckedTypeId,
+        mono_ty: Type.TypeId,
+        active: *std.AutoHashMap(CheckedMonoRelation, void),
+    ) Allocator.Error!bool {
+        const mono_args = monoNamedArgs(&self.builder.program.types, mono_ty) orelse return false;
+        return try self.checkedTypeSliceUsesDefaultForMono(checked_args, mono_args, active);
+    }
+
+    fn monoRecordFieldByCheckedName(self: *BodyContext, mono_fields: []const Type.Field, checked_name: names.RecordFieldNameId) ?Type.Field {
+        const wanted = self.view.names.recordFieldLabelText(checked_name);
+        for (mono_fields) |field| {
+            if (Ident.textEql(wanted, self.builder.program.names.recordFieldLabelText(field.name))) return field;
+        }
+        return null;
+    }
+
+    fn monoTagByCheckedName(self: *BodyContext, mono_tags: []const Type.Tag, checked_name: names.TagNameId) ?Type.Tag {
+        const wanted = self.view.names.tagLabelText(checked_name);
+        for (mono_tags) |tag| {
+            if (Ident.textEql(wanted, self.builder.program.names.tagLabelText(tag.name))) return tag;
+        }
+        return null;
     }
 
     fn monoTypeContainsUninhabited(self: *BodyContext, ty: Type.TypeId) Allocator.Error!bool {
         var active = std.AutoHashMap(Type.TypeId, void).init(self.allocator);
         defer active.deinit();
         return try self.monoTypeContainsUninhabitedInner(ty, &active);
-    }
-
-    fn monoTypeContainsNumericDefault(self: *BodyContext, ty: Type.TypeId) Allocator.Error!bool {
-        var active = std.AutoHashMap(Type.TypeId, void).init(self.allocator);
-        defer active.deinit();
-        return try self.monoTypeContainsNumericDefaultInner(ty, &active);
     }
 
     fn monoTypeContainsUninhabitedInner(
@@ -2659,47 +2997,6 @@ const BodyContext = struct {
         };
     }
 
-    fn monoTypeContainsNumericDefaultInner(
-        self: *BodyContext,
-        ty: Type.TypeId,
-        active: *std.AutoHashMap(Type.TypeId, void),
-    ) Allocator.Error!bool {
-        if (active.contains(ty)) return false;
-        try active.put(ty, {});
-        defer _ = active.remove(ty);
-
-        return switch (self.builder.program.types.get(ty)) {
-            .primitive => |primitive| primitive == .dec,
-            .named => |named| blk: {
-                if (try self.monoTypeSpanContainsNumericDefault(self.builder.program.types.span(named.args), active)) break :blk true;
-                if (named.backing) |backing| {
-                    if (try self.monoTypeContainsNumericDefaultInner(backing.ty, active)) break :blk true;
-                }
-                break :blk false;
-            },
-            .record => |fields| blk: {
-                for (self.builder.program.types.fieldSpan(fields)) |field| {
-                    if (try self.monoTypeContainsNumericDefaultInner(field.ty, active)) break :blk true;
-                }
-                break :blk false;
-            },
-            .tuple => |items| try self.monoTypeSpanContainsNumericDefault(self.builder.program.types.span(items), active),
-            .tag_union => |tags| blk: {
-                for (self.builder.program.types.tagSpan(tags)) |tag| {
-                    if (try self.monoTypeSpanContainsNumericDefault(self.builder.program.types.span(tag.payloads), active)) break :blk true;
-                }
-                break :blk false;
-            },
-            .list => |item| try self.monoTypeContainsNumericDefaultInner(item, active),
-            .box => |item| try self.monoTypeContainsNumericDefaultInner(item, active),
-            .func => |func| try self.monoTypeSpanContainsNumericDefault(self.builder.program.types.span(func.args), active) or
-                try self.monoTypeContainsNumericDefaultInner(func.ret, active),
-            .erased,
-            .zst,
-            => false,
-        };
-    }
-
     fn monoTypeSpanContainsUninhabited(
         self: *BodyContext,
         tys: []const Type.TypeId,
@@ -2707,17 +3004,6 @@ const BodyContext = struct {
     ) Allocator.Error!bool {
         for (tys) |ty| {
             if (try self.monoTypeContainsUninhabitedInner(ty, active)) return true;
-        }
-        return false;
-    }
-
-    fn monoTypeSpanContainsNumericDefault(
-        self: *BodyContext,
-        tys: []const Type.TypeId,
-        active: *std.AutoHashMap(Type.TypeId, void),
-    ) Allocator.Error!bool {
-        for (tys) |ty| {
-            if (try self.monoTypeContainsNumericDefaultInner(ty, active)) return true;
         }
         return false;
     }
@@ -4181,13 +4467,14 @@ const BodyContext = struct {
         expected_ret_ty: ?Type.TypeId,
         comptime conflict_message: []const u8,
     ) Allocator.Error!Type.TypeId {
-        try self.bindCheckedTypeRelations(target_ret, plan_ctx, plan_ret, conflict_message);
-
         if (expected_ret_ty) |ret_ty| {
             try self.bindTypeToMono(target_ret, ret_ty, conflict_message);
             try plan_ctx.bindTypeToMono(plan_ret, ret_ty, conflict_message);
+            try self.bindCheckedTypeRelations(target_ret, plan_ctx, plan_ret, conflict_message);
             return ret_ty;
         }
+
+        try self.bindCheckedTypeRelations(target_ret, plan_ctx, plan_ret, conflict_message);
 
         if (try self.checkedTypeHasFixedShape(target_ret)) {
             const target_mono_ty = try self.lowerType(target_ret);
@@ -4595,7 +4882,10 @@ const BodyContext = struct {
     }
 
     fn expectedMonoForFormal(self: *BodyContext, formal_ty: checked.CheckedTypeId) Allocator.Error!?Type.TypeId {
-        if (self.type_bindings.get(self.typeAddress(formal_ty))) |binding| return binding.ty;
+        if (self.type_bindings.get(self.typeAddress(formal_ty))) |binding| {
+            if (binding.hasFixedShape()) return binding.ty;
+            return null;
+        }
         if (try self.checkedTypeHasFixedShape(formal_ty)) return try self.lowerType(formal_ty);
         return null;
     }
@@ -4609,9 +4899,12 @@ const BodyContext = struct {
         const expr = self.view.bodies.exprs[@intFromEnum(checked_arg)];
         return switch (expr.data) {
             .call => |call| if (expected_ty != null) try self.callResultMonoType(expr.ty, call, expected_ty) else null,
-            .dispatch_call => |plan| if (expected_ty != null) try self.dispatchResultMonoType(expr.ty, plan, expected_ty) else null,
-            .type_dispatch_call => |plan| if (expected_ty != null) try self.dispatchResultMonoType(expr.ty, plan, expected_ty) else null,
-            .method_eq => |plan| if (expected_ty != null) try self.dispatchResultMonoType(expr.ty, plan, expected_ty) else null,
+            .dispatch_call => |plan| try self.dispatchResultMonoType(expr.ty, plan, expected_ty),
+            .type_dispatch_call => |plan| try self.dispatchResultMonoType(expr.ty, plan, expected_ty),
+            .method_eq => |plan| try self.dispatchResultMonoType(expr.ty, plan, expected_ty),
+            .lookup_local => |lookup| try self.lookupArgumentMonoType(expr.ty, lookup.resolved, expected_ty, allow_defaulted_type),
+            .lookup_external => |resolved| try self.lookupArgumentMonoType(expr.ty, resolved, expected_ty, allow_defaulted_type),
+            .lookup_required => |resolved| try self.lookupArgumentMonoType(expr.ty, resolved, expected_ty, allow_defaulted_type),
             .field_access => |field| try self.fieldAccessMonoType(field.receiver, field.field_name),
             else => if (expected_ty) |ty| blk: {
                 try self.bindTypeToMono(expr.ty, ty, "checked call argument expected type mapped one checked type to two monotype types");
@@ -4622,6 +4915,47 @@ const BodyContext = struct {
             else
                 null,
         };
+    }
+
+    fn boundExprMonoType(self: *BodyContext, checked_ty: checked.CheckedTypeId) ?Type.TypeId {
+        if (self.type_bindings.get(self.typeAddress(checked_ty))) |binding| {
+            if (binding.hasConcreteShape()) return binding.ty;
+        }
+        return null;
+    }
+
+    fn lookupArgumentMonoType(
+        self: *BodyContext,
+        checked_ty: checked.CheckedTypeId,
+        maybe_ref: ?checked.ResolvedValueId,
+        expected_ty: ?Type.TypeId,
+        allow_defaulted_type: bool,
+    ) Allocator.Error!?Type.TypeId {
+        if (maybe_ref) |ref_id| {
+            if (self.currentLocalForResolvedValue(ref_id)) |local_id| {
+                const local_ty = self.builder.program.locals.items[@intFromEnum(local_id)].ty;
+                if (expected_ty) |expected| {
+                    if (!self.sameType(expected, local_ty)) {
+                        Common.invariant("checked local lookup argument type differed from its expected monotype");
+                    }
+                }
+                try self.bindTypeToMono(checked_ty, local_ty, "checked local lookup type mapped one checked type to two monotype types");
+                return local_ty;
+            }
+        }
+
+        if (expected_ty) |ty| {
+            try self.bindTypeToMono(checked_ty, ty, "checked call argument expected type mapped one checked type to two monotype types");
+            return ty;
+        }
+
+        if (self.boundExprMonoType(checked_ty)) |bound_ty| return bound_ty;
+        if (try self.checkedTypeHasFixedShape(checked_ty) or
+            (allow_defaulted_type and try self.checkedTypeHasConcreteShape(checked_ty)))
+        {
+            return try self.lowerType(checked_ty);
+        }
+        return null;
     }
 
     fn fieldAccessMonoType(
@@ -4673,7 +5007,7 @@ const BodyContext = struct {
             Common.invariant("checked direct call target is outside resolved value table");
         }
         return switch (self.view.resolved_refs.records[raw].ref) {
-            .local_proc => |local| try self.fnTemplateForLocalProcWithMono(local.expr, source_fn_ty, source_fn_key, mono_fn_ty),
+            .local_proc => |local| try self.fnTemplateForLocalProcWithMono(local, source_fn_ty, source_fn_key, mono_fn_ty),
             .top_level_proc,
             .imported_proc,
             .hosted_proc,
@@ -4694,11 +5028,11 @@ const BodyContext = struct {
 
     fn fnTemplateForLocalProc(
         self: *BodyContext,
-        expr_id: checked.CheckedExprId,
+        local: checked.LocalProcedureBinding,
         source_fn_ty: checked.CheckedTypeId,
     ) Allocator.Error!Ast.FnTemplate {
         return try self.fnTemplateForLocalProcWithMono(
-            expr_id,
+            local,
             source_fn_ty,
             self.view.types.rootKey(source_fn_ty),
             try self.lowerType(source_fn_ty),
@@ -4707,21 +5041,23 @@ const BodyContext = struct {
 
     fn fnTemplateForLocalProcWithMono(
         self: *BodyContext,
-        expr_id: checked.CheckedExprId,
+        local: checked.LocalProcedureBinding,
         source_fn_ty: checked.CheckedTypeId,
         source_fn_key: names.TypeDigest,
         mono_fn_ty: Type.TypeId,
     ) Allocator.Error!Ast.FnTemplate {
+        const context_fn_key = self.local_proc_contexts.get(local.binder) orelse
+            Common.invariant("local procedure use reached Monotype before its declaration context");
         const fn_template = try self.builder.fnTemplateForNestedExprWithMono(
             self.view,
             self.owner_template,
-            expr_id,
+            local.expr,
             source_fn_ty,
             source_fn_key,
             mono_fn_ty,
-            self.current_fn_key,
+            context_fn_key,
         );
-        try self.builder.lowerNestedFnFromContext(self, expr_id, fn_template);
+        try self.builder.lowerNestedFnFromContext(self, local.expr, fn_template);
         return fn_template;
     }
 
@@ -4784,17 +5120,40 @@ const BodyContext = struct {
         return fn_template;
     }
 
+    fn currentLocalForResolvedValue(self: *BodyContext, ref_id: checked.ResolvedValueId) ?Ast.LocalId {
+        const raw = @intFromEnum(ref_id);
+        if (raw >= self.view.resolved_refs.records.len) {
+            Common.invariant("checked lookup resolved value id was outside resolved value table");
+        }
+        const record = self.view.resolved_refs.records[raw];
+        return switch (record.ref) {
+            .local_param,
+            .local_value,
+            .local_mutable_version,
+            .pattern_binder,
+            => |local| self.binders.get(local.binder) orelse
+                Common.invariant("local lookup referenced an unbound pattern binder"),
+            else => null,
+        };
+    }
+
     fn lowerLookupExpr(self: *BodyContext, checked_ty: checked.CheckedTypeId, maybe_ref: ?checked.ResolvedValueId) Allocator.Error!Ast.ExprId {
         const ref_id = maybe_ref orelse Common.invariant("checked lookup reached Monotype without resolved value ref");
         const record = self.view.resolved_refs.records[@intFromEnum(ref_id)];
+        if (self.currentLocalForResolvedValue(ref_id)) |local_id| {
+            const ty = self.builder.program.locals.items[@intFromEnum(local_id)].ty;
+            try self.bindTypeToMono(checked_ty, ty, "checked local lookup type mapped one checked type to two monotype types");
+            return try self.builder.program.addExpr(.{ .ty = ty, .data = .{ .local = local_id } });
+        }
+
         const ty = try self.lowerType(checked_ty);
         const data: Ast.ExprData = switch (record.ref) {
             .local_param,
             .local_value,
             .local_mutable_version,
             .pattern_binder,
-            => |local| .{ .local = self.binders.get(local.binder) orelse Common.invariant("local lookup referenced an unbound pattern binder") },
-            .local_proc => |local| .{ .fn_def = try self.fnTemplateForLocalProc(local.expr, checked_ty) },
+            => Common.invariant("local lookup reached Monotype without a current local binding"),
+            .local_proc => |local| .{ .fn_def = try self.fnTemplateForLocalProc(local, checked_ty) },
             .top_level_proc,
             .imported_proc,
             .hosted_proc,
@@ -5582,12 +5941,22 @@ const BodyContext = struct {
         defer self.allocator.free(plan_arg_tys);
         const plan_ret_ty = plan_fn_data.ret;
         const dispatcher_ty = try self.dispatcherMonoType(plan, plan_arg_tys);
-        const lookup = self.dispatchTarget(plan, dispatcher_ty);
-        if (lookup == null) {
-            try self.bindTypeToMono(checked_ret_ty, plan_ret_ty, "checked dispatch result type mapped one checked type to two monotype types");
-            return plan_ret_ty;
-        }
-        const resolved = lookup.?;
+
+        const owner = methodOwnerFromType(&self.builder.program.types, dispatcher_ty) orelse {
+            if (plan.result_mode == .equality and plan.result_mode.equality.structural_allowed) {
+                try self.bindTypeToMono(checked_ret_ty, plan_ret_ty, "checked dispatch result type mapped one checked type to two monotype types");
+                return plan_ret_ty;
+            }
+            return null;
+        };
+        const lookup = self.builder.lookupMethodTarget(owner, self.view, plan.method) orelse {
+            if (plan.result_mode == .equality and plan.result_mode.equality.structural_allowed) {
+                try self.bindTypeToMono(checked_ret_ty, plan_ret_ty, "checked dispatch result type mapped one checked type to two monotype types");
+                return plan_ret_ty;
+            }
+            Common.invariant("checked method registry is missing resolved dispatch target");
+        };
+        const resolved = lookup;
         const template = resolved.target.template orelse
             Common.invariant("checked dispatch target was not backed by a procedure template");
         var target_ctx = try BodyContext.init(self.allocator, self.builder, resolved.view, template);
@@ -6794,9 +7163,15 @@ const BodyContext = struct {
         const plan_id = for_.plan orelse Common.invariant("checked iterator for reached Monotype without an iterator dispatch plan");
         const plan = self.view.static_dispatch_plans.iterator_for_plans[@intFromEnum(plan_id)];
 
-        const initial_iterator = try self.lowerIteratorDispatch(plan.iter, null);
+        const step = self.iteratorStepShape(plan.step_ty);
+        const initial_iterator = try self.lowerIteratorDispatch(plan.iter, null, null);
         const iterator_ty = self.builder.program.exprs.items[@intFromEnum(initial_iterator)].ty;
         try self.bindTypeToMono(plan.iterator_ty, iterator_ty, "checked iterator type mapped one checked type to two monotype types");
+        try self.bindTypeToMono(step.one_rest.ty, iterator_ty, "checked iterator rest type mapped one checked type to two monotype types");
+        try self.bindTypeToMono(step.skip_rest.ty, iterator_ty, "checked iterator rest type mapped one checked type to two monotype types");
+        const item_ty = try self.lowerType(step.one_item.ty);
+        try self.bindTypeToMono(plan.item_ty, item_ty, "checked iterator item type mapped one checked type to two monotype types");
+        const step_expected_ty = try self.lowerType(plan.step_ty);
         const iterator_local = try self.builder.program.addLocal(self.builder.symbols.fresh(), iterator_ty);
         const iterator_param = Ast.TypedLocal{ .local = iterator_local, .ty = iterator_ty };
 
@@ -6811,9 +7186,8 @@ const BodyContext = struct {
         try self.pushLoopContext(result_ty, carries);
         defer self.popLoopContext();
 
-        const step_expr = try self.lowerIteratorDispatch(plan.next, iterator_param);
+        const step_expr = try self.lowerIteratorDispatch(plan.next, iterator_param, step_expected_ty);
         try self.bindTypeToMono(plan.step_ty, self.builder.program.exprs.items[@intFromEnum(step_expr)].ty, "checked iterator step type mapped one checked type to two monotype types");
-        const step = self.iteratorStepShape(plan.step_ty);
         const done_body = if (carries.len == 0)
             try self.builder.program.addExpr(.{ .ty = result_ty, .data = .{ .break_ = null } })
         else
@@ -6901,10 +7275,32 @@ const BodyContext = struct {
         self: *BodyContext,
         plan: static_dispatch.IteratorDispatchCall,
         loop_iterator: ?Ast.TypedLocal,
+        expected_ret_ty: ?Type.TypeId,
     ) Allocator.Error!Ast.ExprId {
         if (plan.dispatcher_arg_index >= plan.args.len) Common.invariant("iterator dispatch plan dispatcher argument index was outside the argument span");
-        const dispatcher_ty = (try self.iteratorOperandMonoType(plan.args[plan.dispatcher_arg_index], loop_iterator, null)) orelse
-            Common.invariant("iterator dispatch plan dispatcher operand was not concrete in the current specialization");
+
+        var call_ctx = try BodyContext.init(self.allocator, self.builder, self.view, self.owner_template);
+        defer call_ctx.deinit();
+        call_ctx.owner_context_fn_key = self.owner_context_fn_key;
+        call_ctx.current_fn_key = self.current_fn_key;
+
+        const callable_mono_ty = try call_ctx.instantiateIteratorPlanCallTypeFromCaller(plan.callable_ty, self, plan.args, loop_iterator, expected_ret_ty);
+        const plan_fn_data = self.builder.functionShape(callable_mono_ty, "checked iterator dispatch plan had a non-function type");
+        const plan_arg_tys = try self.allocator.dupe(Type.TypeId, self.builder.program.types.span(plan_fn_data.args));
+        defer self.allocator.free(plan_arg_tys);
+        if (expected_ret_ty) |expected| {
+            if (!self.sameType(plan_fn_data.ret, expected)) {
+                Common.invariant("checked iterator dispatch plan return type differed from iterator-for expected type");
+            }
+        }
+
+        const dispatcher_ty = plan_arg_tys[plan.dispatcher_arg_index];
+        try call_ctx.bindTypeToMono(plan.dispatcher_ty, dispatcher_ty, "checked iterator dispatch dispatcher type mapped one checked type to two monotype types");
+        const actual_dispatcher_ty = (try self.iteratorOperandMonoType(plan.args[plan.dispatcher_arg_index], loop_iterator, dispatcher_ty)) orelse
+            Common.invariant("iterator dispatch plan dispatcher operand did not match the checked dispatcher type");
+        if (!self.sameType(dispatcher_ty, actual_dispatcher_ty)) {
+            Common.invariant("iterator dispatch plan dispatcher operand differed from the checked dispatcher type");
+        }
         const owner = methodOwnerFromType(&self.builder.program.types, dispatcher_ty) orelse
             Common.invariant("iterator dispatch plan had no method owner");
         const lookup = self.builder.lookupMethodTarget(owner, self.view, plan.method) orelse
@@ -6914,11 +7310,19 @@ const BodyContext = struct {
 
         var target_ctx = try BodyContext.init(self.allocator, self.builder, lookup.view, template);
         defer target_ctx.deinit();
-        const callable_mono_ty = try target_ctx.instantiateIteratorTargetCallTypeFromCaller(lookup.target.callable_ty, self, plan.args, loop_iterator);
-        try self.bindTypeToMono(plan.callable_ty, callable_mono_ty, "checked iterator dispatch callable type mapped one checked type to two monotype types");
-        _ = try self.builder.lowerTemplateWithMono(template, lookup.view, lookup.target.callable_ty, lookup.view.types.rootKey(lookup.target.callable_ty), callable_mono_ty);
+        const target_mono_ty = try target_ctx.instantiateTargetFromPlan(lookup.target.callable_ty, &call_ctx, plan.callable_ty, expected_ret_ty);
+        try call_ctx.bindTypeToMono(plan.callable_ty, target_mono_ty, "checked iterator dispatch plan callable type differed from resolved target callable type");
+        if (!self.sameType(callable_mono_ty, target_mono_ty)) {
+            Common.invariant("checked iterator dispatch target callable type differed from dispatch plan callable type");
+        }
+        _ = try self.builder.lowerTemplateWithMono(template, lookup.view, lookup.target.callable_ty, lookup.view.types.rootKey(lookup.target.callable_ty), target_mono_ty);
 
-        const fn_data = self.builder.functionShape(callable_mono_ty, "checked iterator dispatch target had a non-function type");
+        const fn_data = self.builder.functionShape(target_mono_ty, "checked iterator dispatch target had a non-function type");
+        if (expected_ret_ty) |expected| {
+            if (!self.sameType(fn_data.ret, expected)) {
+                Common.invariant("checked iterator dispatch target return type differed from iterator-for expected type");
+            }
+        }
         const args = try self.allocator.alloc(Ast.ExprId, plan.args.len);
         defer self.allocator.free(args);
         const arg_tys = self.builder.program.types.span(fn_data.args);
@@ -6929,24 +7333,28 @@ const BodyContext = struct {
         return try self.builder.program.addExpr(.{
             .ty = fn_data.ret,
             .data = .{ .call_proc = .{
-                .callee = self.builder.fnDefForTemplate(lookup.view, template, lookup.target.callable_ty, lookup.view.types.rootKey(lookup.target.callable_ty), callable_mono_ty),
+                .callee = self.builder.fnDefForTemplate(lookup.view, template, lookup.target.callable_ty, lookup.view.types.rootKey(lookup.target.callable_ty), target_mono_ty),
                 .args = try self.builder.program.addExprSpan(args),
             } },
         });
     }
 
-    fn instantiateIteratorTargetCallTypeFromCaller(
+    fn instantiateIteratorPlanCallTypeFromCaller(
         self: *BodyContext,
         source_fn_ty: checked.CheckedTypeId,
         caller: *BodyContext,
         operands: []const static_dispatch.IteratorDispatchOperand,
         loop_iterator: ?Ast.TypedLocal,
+        expected_ret_ty: ?Type.TypeId,
     ) Allocator.Error!Type.TypeId {
         const function = self.checkedFunctionType(source_fn_ty);
         if (function.args.len != operands.len) {
             Common.invariant("checked iterator dispatch target arity differs from its function type");
         }
 
+        if (expected_ret_ty) |expected| {
+            try self.bindTypeToMono(function.ret, expected, "checked iterator dispatch plan return type mapped one checked type to two monotype types");
+        }
         try self.bindIteratorArgTypesFromCallerToFixedPoint(function.args, caller, operands, loop_iterator);
 
         const arg_tys = try self.allocator.alloc(Type.TypeId, function.args.len);
@@ -6958,10 +7366,12 @@ const BodyContext = struct {
             arg_tys[i] = try self.lowerType(arg_ty);
         }
 
-        if (!try self.checkedTypeCanLower(function.ret)) {
-            Common.invariant("checked iterator dispatch target return type was not concrete after call-site binding");
-        }
         const ret_ty = try self.lowerType(function.ret);
+        if (expected_ret_ty) |expected| {
+            if (!self.sameType(ret_ty, expected)) {
+                Common.invariant("checked iterator dispatch plan return type differed from the iterator-for result type");
+            }
+        }
 
         const mono_fn_ty = try self.builder.program.types.add(.{ .func = .{
             .args = try self.builder.program.types.addSpan(arg_tys),
@@ -7581,6 +7991,7 @@ const BodyContext = struct {
             => Common.invariant("non-runtime checked statement reached Monotype lowering"),
             .decl => |decl| blk: {
                 if (self.statementValueIsLocalProc(decl.expr)) {
+                    try self.registerLocalProc(decl.pattern);
                     const unit_ty = try self.unitType();
                     break :blk .{ .expr = try self.builder.program.addExpr(.{ .ty = unit_ty, .data = .unit }) };
                 }
@@ -7652,6 +8063,25 @@ const BodyContext = struct {
             .return_ => |ret| .{ .return_ = try self.lowerExpr(ret.expr) },
         };
         return try self.builder.program.addStmt(stmt);
+    }
+
+    fn registerLocalProc(self: *BodyContext, pattern_id: checked.CheckedPatternId) Allocator.Error!void {
+        const binder = self.localProcBinder(pattern_id);
+        if (self.local_proc_contexts.get(binder)) |existing| {
+            if (!std.mem.eql(u8, existing.bytes[0..], self.current_fn_key.bytes[0..])) {
+                Common.invariant("local procedure binder had two declaration contexts");
+            }
+            return;
+        }
+        try self.local_proc_contexts.put(binder, self.current_fn_key);
+    }
+
+    fn localProcBinder(self: *BodyContext, pattern_id: checked.CheckedPatternId) checked.PatternBinderId {
+        const pattern = self.view.bodies.patterns[@intFromEnum(pattern_id)];
+        return switch (pattern.data) {
+            .assign => |binder| binder,
+            else => Common.invariant("local procedure declaration pattern was not a binder"),
+        };
     }
 
     fn lowerExprStatement(self: *BodyContext, expr_id: checked.CheckedExprId) Allocator.Error!Ast.Stmt {
@@ -7947,14 +8377,6 @@ fn checkedTypePayloadIsOpenVariable(payload: checked.CheckedTypePayload) bool {
         .flex,
         .rigid,
         => true,
-        else => false,
-    };
-}
-
-fn checkedTypePayloadHasMonoDefault(payload: checked.CheckedTypePayload) bool {
-    return switch (payload) {
-        .flex => |variable| variable.numeric_default_phase == .mono_specialization,
-        .rigid => |variable| variable.numeric_default_phase == .mono_specialization,
         else => false,
     };
 }

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -786,10 +786,7 @@ const Builder = struct {
     }
 
     fn lowerType(self: *Builder, view: ModuleView, checked_ty: checked.CheckedTypeId) Allocator.Error!Type.TypeId {
-        const address = CheckedTypeAddress{
-            .module_bytes = view.key.bytes,
-            .ty = @intFromEnum(checked_ty),
-        };
+        const address = checkedTypeAddress(view, checked_ty);
         if (self.type_cache.get(address)) |cached| return cached;
 
         const raw = @intFromEnum(checked_ty);
@@ -2219,10 +2216,7 @@ const BodyContext = struct {
         mono_ty: Type.TypeId,
         comptime conflict_message: []const u8,
     ) Allocator.Error!void {
-        const address = CheckedTypeAddress{
-            .module_bytes = self.view.key.bytes,
-            .ty = @intFromEnum(generic_ty),
-        };
+        const address = self.typeAddress(generic_ty);
         if (self.type_bindings.get(address)) |existing| {
             if (!self.sameType(existing.ty, mono_ty)) {
                 try self.bindTypeChildrenToMono(generic_ty, mono_ty, conflict_message);
@@ -2258,7 +2252,12 @@ const BodyContext = struct {
             .empty_record,
             .empty_tag_union,
             => return,
-            .alias => |alias| try self.bindTypeToMono(alias.backing, monoAliasBacking(&self.builder.program.types, mono_ty) orelse mono_ty, conflict_message),
+            .alias => |alias| {
+                if (monoAliasArgs(&self.builder.program.types, mono_ty)) |args| {
+                    try self.bindTypeSpanToMono(alias.args, args, conflict_message);
+                }
+                try self.bindTypeToMono(alias.backing, monoAliasBacking(&self.builder.program.types, mono_ty) orelse mono_ty, conflict_message);
+            },
             .record_unbound => |fields| try self.bindRecordFieldsToMono(fields, mono_ty, conflict_message),
             .record => |record| try self.bindRecordFieldsToMono(record.fields, mono_ty, conflict_message),
             .tuple => |items| try self.bindTypeSpanToMono(items, self.monoTupleItems(mono_ty), conflict_message),
@@ -2583,6 +2582,13 @@ const BodyContext = struct {
         };
     }
 
+    fn monoAliasArgs(types: *const Type.Store, mono_ty: Type.TypeId) ?[]const Type.TypeId {
+        return switch (types.get(mono_ty)) {
+            .named => |named| if (named.kind == .alias) types.span(named.args) else null,
+            else => null,
+        };
+    }
+
     fn bindKnownType(
         self: *BodyContext,
         checked_ty: checked.CheckedTypeId,
@@ -2820,10 +2826,7 @@ const BodyContext = struct {
     }
 
     fn typeAddress(self: *BodyContext, checked_ty: checked.CheckedTypeId) CheckedTypeAddress {
-        return .{
-            .module_bytes = self.view.key.bytes,
-            .ty = @intFromEnum(checked_ty),
-        };
+        return checkedTypeAddress(self.view, checked_ty);
     }
 
     fn reserveType(self: *BodyContext, checked_ty: checked.CheckedTypeId) Allocator.Error!Type.TypeId {
@@ -3599,10 +3602,10 @@ const BodyContext = struct {
     fn lowerExprType(self: *BodyContext, expr_id: checked.CheckedExprId) Allocator.Error!Type.TypeId {
         const expr = self.view.bodies.exprs[@intFromEnum(expr_id)];
         return switch (expr.data) {
-            .call => |call| (try self.callResultMonoType(expr.ty, call)) orelse try self.lowerType(expr.ty),
-            .dispatch_call => |plan| (try self.dispatchResultMonoType(expr.ty, plan)) orelse try self.lowerType(expr.ty),
-            .type_dispatch_call => |plan| (try self.dispatchResultMonoType(expr.ty, plan)) orelse try self.lowerType(expr.ty),
-            .method_eq => |plan| (try self.dispatchResultMonoType(expr.ty, plan)) orelse try self.lowerType(expr.ty),
+            .call => |call| (try self.callResultMonoType(expr.ty, call, null)) orelse try self.lowerType(expr.ty),
+            .dispatch_call => |plan| (try self.dispatchResultMonoType(expr.ty, plan, null)) orelse try self.lowerType(expr.ty),
+            .type_dispatch_call => |plan| (try self.dispatchResultMonoType(expr.ty, plan, null)) orelse try self.lowerType(expr.ty),
+            .method_eq => |plan| (try self.dispatchResultMonoType(expr.ty, plan, null)) orelse try self.lowerType(expr.ty),
             .lambda => |lambda| try self.lambdaFunctionType(lambda),
             .closure => |closure| try self.closureFunctionType(closure),
             .field_access => |field| try self.fieldAccessMonoType(field.receiver, field.field_name),
@@ -3863,9 +3866,26 @@ const BodyContext = struct {
             Common.invariant("checked direct call arity differs from its function type");
         }
 
+        const return_available_before_args =
+            expected_ret_ty != null or
+            caller.type_bindings.contains(caller.typeAddress(checked_ret_ty)) or
+            try self.checkedTypeHasFixedShape(function.ret) or
+            try caller.checkedTypeHasFixedShape(checked_ret_ty);
+        const early_ret_ty = if (return_available_before_args)
+            try self.callReturnTypeFromCaller(
+                function.ret,
+                caller,
+                checked_ret_ty,
+                expected_ret_ty,
+                "checked direct call return type mapped one checked type to two monotype types",
+                "checked direct call result type mapped one checked type to two monotype types",
+            )
+        else
+            null;
+
         try self.bindCallArgTypesFromCallerToFixedPoint(function.args, caller, checked_args, "checked direct call argument type mapped one checked type to two monotype types");
 
-        const ret_ty = try self.callReturnTypeFromCaller(
+        const ret_ty = early_ret_ty orelse try self.callReturnTypeFromCaller(
             function.ret,
             caller,
             checked_ret_ty,
@@ -3906,19 +3926,29 @@ const BodyContext = struct {
             Common.invariant("checked dispatch plan arity differs from its function type");
         }
 
+        const return_available_before_args =
+            expected_ret_ty != null or
+            caller.type_bindings.contains(caller.typeAddress(checked_ret_ty)) or
+            try self.checkedTypeHasFixedShape(function.ret) or
+            try caller.checkedTypeHasFixedShape(checked_ret_ty);
+        const early_ret_ty = if (return_available_before_args)
+            try self.dispatchReturnTypeFromCaller(
+                function.ret,
+                caller,
+                checked_ret_ty,
+                expected_ret_ty,
+            )
+        else
+            null;
+
         try self.bindDispatchArgTypesFromCallerToFixedPoint(function.args, caller, operands, "checked dispatch plan argument type mapped one checked type to two monotype types");
 
-        const ret_ty = if (expected_ret_ty) |expected| ret: {
-            try self.bindTypeToMono(function.ret, expected, "checked dispatch plan return type mapped one checked type to two monotype types");
-            try caller.bindTypeToMono(checked_ret_ty, expected, "checked dispatch result type mapped one checked type to two monotype types");
-            break :ret expected;
-        } else if (try self.checkedTypeCanLower(function.ret)) ret: {
-            break :ret try self.lowerType(function.ret);
-        } else if (try caller.checkedTypeHasFixedShape(checked_ret_ty)) ret: {
-            const caller_ret_ty = try caller.lowerType(checked_ret_ty);
-            try self.bindTypeToMono(function.ret, caller_ret_ty, "checked dispatch plan return type mapped one checked type to two monotype types");
-            break :ret caller_ret_ty;
-        } else Common.invariant("checked dispatch plan return type was not concrete after call-site binding");
+        const ret_ty = early_ret_ty orelse try self.dispatchReturnTypeFromCaller(
+            function.ret,
+            caller,
+            checked_ret_ty,
+            expected_ret_ty,
+        );
 
         try self.bindDispatchArgTypesFromCallerToFixedPoint(function.args, caller, operands, "checked dispatch plan argument type mapped one checked type to two monotype types");
 
@@ -3987,6 +4017,8 @@ const BodyContext = struct {
         comptime return_conflict: []const u8,
         comptime result_conflict: []const u8,
     ) Allocator.Error!Type.TypeId {
+        try self.bindCheckedTypeRelations(function_ret, caller, checked_ret_ty, return_conflict);
+
         if (expected_ret_ty) |ret_ty| {
             try self.bindTypeToMono(function_ret, ret_ty, return_conflict);
             try caller.bindTypeToMono(checked_ret_ty, ret_ty, result_conflict);
@@ -4206,6 +4238,43 @@ const BodyContext = struct {
         Common.invariant("checked dispatch target return type was not concrete after plan binding");
     }
 
+    fn dispatchReturnTypeFromCaller(
+        self: *BodyContext,
+        function_ret: checked.CheckedTypeId,
+        caller: *BodyContext,
+        checked_ret_ty: checked.CheckedTypeId,
+        expected_ret_ty: ?Type.TypeId,
+    ) Allocator.Error!Type.TypeId {
+        if (expected_ret_ty) |expected| {
+            try self.bindTypeToMono(function_ret, expected, "checked dispatch plan return type mapped one checked type to two monotype types");
+            try caller.bindTypeToMono(checked_ret_ty, expected, "checked dispatch result type mapped one checked type to two monotype types");
+            return expected;
+        }
+
+        if (caller.type_bindings.get(caller.typeAddress(checked_ret_ty))) |caller_ret_binding| {
+            try self.bindTypeToMono(function_ret, caller_ret_binding.ty, "checked dispatch plan return type mapped one checked type to two monotype types");
+            return caller_ret_binding.ty;
+        }
+
+        if (try self.checkedTypeHasFixedShape(function_ret)) {
+            const ret_ty = try self.lowerType(function_ret);
+            try caller.bindTypeToMono(checked_ret_ty, ret_ty, "checked dispatch result type mapped one checked type to two monotype types");
+            return ret_ty;
+        }
+
+        if (try caller.checkedTypeHasFixedShape(checked_ret_ty)) {
+            const ret_ty = try caller.lowerType(checked_ret_ty);
+            try self.bindTypeToMono(function_ret, ret_ty, "checked dispatch plan return type mapped one checked type to two monotype types");
+            return ret_ty;
+        }
+
+        if (try self.checkedTypeCanLower(function_ret)) {
+            return try self.lowerType(function_ret);
+        }
+
+        Common.invariant("checked dispatch plan return type was not concrete after call-site binding");
+    }
+
     fn instantiateTargetCallTypeFromMonoArgs(
         self: *BodyContext,
         source_fn_ty: checked.CheckedTypeId,
@@ -4259,11 +4328,7 @@ const BodyContext = struct {
                 continue;
             }
 
-            if (checkedPayload(self.view, formal_ty) == .function) {
-                continue;
-            }
-
-            if (try caller.callArgumentMonoType(checked_arg)) |actual_mono_ty| {
+            if (try caller.callArgumentMonoType(checked_arg, try self.expectedMonoForFormal(formal_ty), numeric_literals)) |actual_mono_ty| {
                 try self.bindTypeToMono(
                     formal_ty,
                     actual_mono_ty,
@@ -4327,11 +4392,7 @@ const BodyContext = struct {
                         continue;
                     }
 
-                    if (checkedPayload(self.view, formal_ty) == .function) {
-                        continue;
-                    }
-
-                    if (try caller.callArgumentMonoType(checked_arg)) |actual_mono_ty| {
+                    if (try caller.callArgumentMonoType(checked_arg, try self.expectedMonoForFormal(formal_ty), numeric_literals)) |actual_mono_ty| {
                         try self.bindTypeToMono(
                             formal_ty,
                             actual_mono_ty,
@@ -4447,9 +4508,26 @@ const BodyContext = struct {
                 },
                 else => {},
             },
-            .record_unbound,
-            .record,
-            .tag_union,
+            .record_unbound => |left_fields| switch (right_payload) {
+                .record_unbound => |right_fields| try self.bindCheckedRecordRelations(right_ctx, left_fields, right_fields, conflict_message, active),
+                .record => |right_record| try self.bindCheckedRecordRelations(right_ctx, left_fields, right_record.fields, conflict_message, active),
+                else => {},
+            },
+            .record => |left_record| switch (right_payload) {
+                .record_unbound => |right_fields| try self.bindCheckedRecordRelations(right_ctx, left_record.fields, right_fields, conflict_message, active),
+                .record => |right_record| {
+                    try self.bindCheckedRecordRelations(right_ctx, left_record.fields, right_record.fields, conflict_message, active);
+                    try self.bindCheckedTypeRelationsInner(left_record.ext, right_ctx, right_record.ext, conflict_message, active);
+                },
+                else => {},
+            },
+            .tag_union => |left_union| switch (right_payload) {
+                .tag_union => |right_union| {
+                    try self.bindCheckedTagRelations(right_ctx, left_union.tags, right_union.tags, conflict_message, active);
+                    try self.bindCheckedTypeRelationsInner(left_union.ext, right_ctx, right_union.ext, conflict_message, active);
+                },
+                else => {},
+            },
             .flex,
             .rigid,
             .empty_record,
@@ -4459,15 +4537,87 @@ const BodyContext = struct {
         }
     }
 
-    fn callArgumentMonoType(self: *BodyContext, checked_arg: checked.CheckedExprId) Allocator.Error!?Type.TypeId {
+    fn bindCheckedRecordRelations(
+        self: *BodyContext,
+        right_ctx: *BodyContext,
+        left_fields: []const checked.CheckedRecordField,
+        right_fields: []const checked.CheckedRecordField,
+        comptime conflict_message: []const u8,
+        active: *std.AutoHashMap(CheckedTypeRelation, void),
+    ) Allocator.Error!void {
+        for (left_fields) |left_field| {
+            const right_field = self.findCheckedRecordField(right_ctx, right_fields, left_field.name) orelse return;
+            try self.bindCheckedTypeRelationsInner(left_field.ty, right_ctx, right_field.ty, conflict_message, active);
+        }
+    }
+
+    fn findCheckedRecordField(
+        self: *BodyContext,
+        right_ctx: *BodyContext,
+        right_fields: []const checked.CheckedRecordField,
+        left_name: names.RecordFieldNameId,
+    ) ?checked.CheckedRecordField {
+        const wanted = self.view.names.recordFieldLabelText(left_name);
+        for (right_fields) |right_field| {
+            if (Ident.textEql(wanted, right_ctx.view.names.recordFieldLabelText(right_field.name))) return right_field;
+        }
+        return null;
+    }
+
+    fn bindCheckedTagRelations(
+        self: *BodyContext,
+        right_ctx: *BodyContext,
+        left_tags: []const checked.CheckedTag,
+        right_tags: []const checked.CheckedTag,
+        comptime conflict_message: []const u8,
+        active: *std.AutoHashMap(CheckedTypeRelation, void),
+    ) Allocator.Error!void {
+        for (left_tags) |left_tag| {
+            const right_tag = self.findCheckedTag(right_ctx, right_tags, left_tag.name) orelse return;
+            if (left_tag.args.len != right_tag.args.len) return;
+            for (left_tag.args, right_tag.args) |left_arg, right_arg| {
+                try self.bindCheckedTypeRelationsInner(left_arg, right_ctx, right_arg, conflict_message, active);
+            }
+        }
+    }
+
+    fn findCheckedTag(
+        self: *BodyContext,
+        right_ctx: *BodyContext,
+        right_tags: []const checked.CheckedTag,
+        left_name: names.TagNameId,
+    ) ?checked.CheckedTag {
+        const wanted = self.view.names.tagLabelText(left_name);
+        for (right_tags) |right_tag| {
+            if (Ident.textEql(wanted, right_ctx.view.names.tagLabelText(right_tag.name))) return right_tag;
+        }
+        return null;
+    }
+
+    fn expectedMonoForFormal(self: *BodyContext, formal_ty: checked.CheckedTypeId) Allocator.Error!?Type.TypeId {
+        if (self.type_bindings.get(self.typeAddress(formal_ty))) |binding| return binding.ty;
+        if (try self.checkedTypeHasFixedShape(formal_ty)) return try self.lowerType(formal_ty);
+        return null;
+    }
+
+    fn callArgumentMonoType(
+        self: *BodyContext,
+        checked_arg: checked.CheckedExprId,
+        expected_ty: ?Type.TypeId,
+        allow_defaulted_type: bool,
+    ) Allocator.Error!?Type.TypeId {
         const expr = self.view.bodies.exprs[@intFromEnum(checked_arg)];
         return switch (expr.data) {
-            .call => |call| try self.callResultMonoType(expr.ty, call),
-            .dispatch_call => |plan| try self.dispatchResultMonoType(expr.ty, plan),
-            .type_dispatch_call => |plan| try self.dispatchResultMonoType(expr.ty, plan),
-            .method_eq => |plan| try self.dispatchResultMonoType(expr.ty, plan),
+            .call => |call| if (expected_ty != null) try self.callResultMonoType(expr.ty, call, expected_ty) else null,
+            .dispatch_call => |plan| if (expected_ty != null) try self.dispatchResultMonoType(expr.ty, plan, expected_ty) else null,
+            .type_dispatch_call => |plan| if (expected_ty != null) try self.dispatchResultMonoType(expr.ty, plan, expected_ty) else null,
+            .method_eq => |plan| if (expected_ty != null) try self.dispatchResultMonoType(expr.ty, plan, expected_ty) else null,
             .field_access => |field| try self.fieldAccessMonoType(field.receiver, field.field_name),
-            else => if (try self.checkedTypeHasConcreteShape(expr.ty))
+            else => if (expected_ty) |ty| blk: {
+                try self.bindTypeToMono(expr.ty, ty, "checked call argument expected type mapped one checked type to two monotype types");
+                break :blk ty;
+            } else if (try self.checkedTypeHasFixedShape(expr.ty) or
+                (allow_defaulted_type and try self.checkedTypeHasConcreteShape(expr.ty)))
                 try self.lowerType(expr.ty)
             else
                 null,
@@ -4486,8 +4636,17 @@ const BodyContext = struct {
         );
     }
 
-    fn callResultMonoType(self: *BodyContext, checked_ret_ty: checked.CheckedTypeId, call: anytype) Allocator.Error!?Type.TypeId {
+    fn callResultMonoType(
+        self: *BodyContext,
+        checked_ret_ty: checked.CheckedTypeId,
+        call: anytype,
+        expected_ret_ty: ?Type.TypeId,
+    ) Allocator.Error!?Type.TypeId {
         if (call.direct_target == null) {
+            if (expected_ret_ty) |ret_ty| {
+                try self.bindTypeToMono(checked_ret_ty, ret_ty, "checked indirect call result type mapped one checked type to two monotype types");
+                return ret_ty;
+            }
             if (!try self.checkedTypeCanLower(checked_ret_ty)) return null;
             return try self.lowerType(checked_ret_ty);
         }
@@ -4498,7 +4657,7 @@ const BodyContext = struct {
         call_ctx.current_fn_key = self.current_fn_key;
 
         const source_fn_ty = self.directCallInstantiationSourceFnType(call.direct_target.?, call.source_fn_ty_payload);
-        const mono_fn_ty = try call_ctx.instantiateCallTypeFromCaller(source_fn_ty, self, checked_ret_ty, call.args);
+        const mono_fn_ty = try call_ctx.instantiateCallTypeFromCallerAtType(source_fn_ty, self, checked_ret_ty, call.args, expected_ret_ty);
         return call_ctx.functionReturnType(mono_fn_ty);
     }
 
@@ -4560,7 +4719,7 @@ const BodyContext = struct {
             source_fn_ty,
             source_fn_key,
             mono_fn_ty,
-            self.owner_context_fn_key,
+            self.current_fn_key,
         );
         try self.builder.lowerNestedFnFromContext(self, expr_id, fn_template);
         return fn_template;
@@ -5407,6 +5566,7 @@ const BodyContext = struct {
         self: *BodyContext,
         checked_ret_ty: checked.CheckedTypeId,
         maybe_plan: ?static_dispatch.StaticDispatchPlanId,
+        expected_ret_ty: ?Type.TypeId,
     ) Allocator.Error!?Type.TypeId {
         const plan_id = maybe_plan orelse Common.invariant("checked dispatch expression reached Monotype without a dispatch plan");
         const plan = self.view.static_dispatch_plans.plans[@intFromEnum(plan_id)];
@@ -5416,7 +5576,7 @@ const BodyContext = struct {
         call_ctx.owner_context_fn_key = self.owner_context_fn_key;
         call_ctx.current_fn_key = self.current_fn_key;
 
-        const callable_mono_ty = try call_ctx.instantiateDispatchPlanCallTypeFromCaller(plan.callable_ty, self, checked_ret_ty, plan.args, null);
+        const callable_mono_ty = try call_ctx.instantiateDispatchPlanCallTypeFromCaller(plan.callable_ty, self, checked_ret_ty, plan.args, expected_ret_ty);
         const plan_fn_data = self.builder.functionShape(callable_mono_ty, "checked dispatch plan had a non-function type");
         const plan_arg_tys = try self.allocator.dupe(Type.TypeId, self.builder.program.types.span(plan_fn_data.args));
         defer self.allocator.free(plan_arg_tys);
@@ -6743,7 +6903,7 @@ const BodyContext = struct {
         loop_iterator: ?Ast.TypedLocal,
     ) Allocator.Error!Ast.ExprId {
         if (plan.dispatcher_arg_index >= plan.args.len) Common.invariant("iterator dispatch plan dispatcher argument index was outside the argument span");
-        const dispatcher_ty = (try self.iteratorOperandMonoType(plan.args[plan.dispatcher_arg_index], loop_iterator)) orelse
+        const dispatcher_ty = (try self.iteratorOperandMonoType(plan.args[plan.dispatcher_arg_index], loop_iterator, null)) orelse
             Common.invariant("iterator dispatch plan dispatcher operand was not concrete in the current specialization");
         const owner = methodOwnerFromType(&self.builder.program.types, dispatcher_ty) orelse
             Common.invariant("iterator dispatch plan had no method owner");
@@ -6835,7 +6995,7 @@ const BodyContext = struct {
                 ),
                 .loop_iterator_state => {},
             }
-            if (try caller.iteratorOperandMonoType(operand, loop_iterator)) |actual_mono_ty| {
+            if (try caller.iteratorOperandMonoType(operand, loop_iterator, try self.expectedMonoForFormal(formal_ty))) |actual_mono_ty| {
                 try self.bindTypeToMono(
                     formal_ty,
                     actual_mono_ty,
@@ -6873,9 +7033,10 @@ const BodyContext = struct {
         self: *BodyContext,
         operand: static_dispatch.IteratorDispatchOperand,
         loop_iterator: ?Ast.TypedLocal,
+        expected_ty: ?Type.TypeId,
     ) Allocator.Error!?Type.TypeId {
         return switch (operand) {
-            .checked_expr => |expr| try self.callArgumentMonoType(expr),
+            .checked_expr => |expr| try self.callArgumentMonoType(expr, expected_ty, false),
             .loop_iterator_state => if (loop_iterator) |iterator| iterator.ty else Common.invariant("iterator .next dispatch reached Monotype without a loop iterator local"),
         };
     }
@@ -7949,8 +8110,15 @@ fn moduleBytesEqual(a: [32]u8, b: [32]u8) bool {
 
 const CheckedTypeAddress = struct {
     module_bytes: [32]u8,
-    ty: u32,
+    type_id: u32,
 };
+
+fn checkedTypeAddress(view: ModuleView, checked_ty: checked.CheckedTypeId) CheckedTypeAddress {
+    return .{
+        .module_bytes = view.key.bytes,
+        .type_id = @intFromEnum(checked_ty),
+    };
+}
 
 const CheckedTypeRelation = struct {
     left: CheckedTypeAddress,

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -411,10 +411,11 @@ const Lifter = struct {
         defer self.popFunctionMaps(saved_maps);
         const body = try self.lowerExpr(lambda.body);
         const capture_span = try self.output.addTypedLocalSpan(captures.items.items);
+        const args = try self.copyTypedLocalSpan(lambda.args);
         self.output.fns.items[@intFromEnum(fn_id)] = .{
             .symbol = self.symbols.fresh(),
             .source = lambda.source,
-            .args = try self.copyTypedLocalSpan(lambda.args),
+            .args = args,
             .captures = capture_span,
             .body = .{ .roc = body },
             .ret = functionRet(&self.output.types, ty),

--- a/src/postcheck/structural_test.zig
+++ b/src/postcheck/structural_test.zig
@@ -189,7 +189,7 @@ test "stage-local expression maps are scoped to one function" {
     try expectContains(lift_lambda, "defer self.popFunctionMaps(saved_maps);");
 
     const lambda_mono_source = @embedFile("lambda_mono/lower.zig");
-    const lower_fn = sourceSliceBetween(lambda_mono_source, "fn lowerFn", "fn captureParamForFn");
+    const lower_fn = sourceSliceBetween(lambda_mono_source, "fn lowerFnSpec", "fn ensureOwnFnSpec");
     try expectContains(lower_fn, "self.captures.clearRetainingCapacity();");
     try expectContains(lower_fn, "@memset(self.expr_map, null);");
     try expectContains(lower_fn, "@memset(self.pat_map, null);");

--- a/test/package_simple_parser/Parser.roc
+++ b/test/package_simple_parser/Parser.roc
@@ -46,16 +46,14 @@ Parser(input, val) := { run : input -> [Ok(val, input), Err(Str)] }.{
     }
 
     ## Run first parser, keep its result, then run second parser and discard its result.
-    ## TODO: blocked by #9129
-    # skip : Parser(input, a), Parser(input, b) -> Parser(input, a)
-    # skip = |first, second|
-    #     map2(first, second, |a, _b| a)
+    skip : Parser(input, a), Parser(input, b) -> Parser(input, a)
+    skip = |first, second|
+        map2(first, second, |a, _b| a)
 
     ## Run first parser, discard its result, then run second parser and keep its result.
-    ## TODO: blocked by #9129
-    # keep : Parser(input, a), Parser(input, b) -> Parser(input, b)
-    # keep = |first, second|
-    #     map2(first, second, |_a, b| b)
+    keep : Parser(input, a), Parser(input, b) -> Parser(input, b)
+    keep = |first, second|
+        map2(first, second, |_a, b| b)
 }
 
 ## Tests for the Parser type module
@@ -66,6 +64,13 @@ expect Parser.parse(Parser.succeed("hi"), "hello") == Ok("hi", "hello")
 # Test basic fail
 expect Parser.parse(Parser.fail("oops"), "hello") == Err("oops")
 
-# Test map2 directly - currently has TypeMismatch error, investigating
-# combined = Parser.map2(Parser.succeed("a"), Parser.succeed("b"), |x, y| Str.concat(x, y))
-# expect Parser.parse(combined, "input") == Ok("ab", "input")
+# Test map2 directly
+combined = Parser.map2(Parser.succeed("a"), Parser.succeed("b"), |x, y| Str.concat(x, y))
+expect Parser.parse(combined, "input") == Ok("ab", "input")
+
+# Test skip and keep
+skip_second = Parser.skip(Parser.succeed("a"), Parser.succeed("b"))
+expect Parser.parse(skip_second, "input") == Ok("a", "input")
+
+keep_second = Parser.keep(Parser.succeed("a"), Parser.succeed("b"))
+expect Parser.parse(keep_second, "input") == Ok("b", "input")


### PR DESCRIPTION
## Summary
- fix parser package lowering after Iter-based loops
- preserve the checked use-site type when lowering parser combinator constants
- track local procedure declaration context during postcheck lowering
- tighten replaceable default monotype handling so defaults are only replaced by concrete use-site evidence
- wire checked-module disk cache storage and restore through the coordinator
- make checked-module cache failures transparent: missing, unreadable, corrupt, or mismatched entries compile from source without user-facing cache diagnostics
- preserve cached ModuleEnv dispatch data when restoring checked modules
- remove default CLI cache-hit chatter while keeping explicit verbose cache stats
- move interpreter shim/LIR image scratch allocations off page_allocator and onto smp_allocator

## Verification
- zig build minici --summary all
- zig build release --summary all
- zig build test-eval -Doptimize=ReleaseFast --summary all
- zig build test-compile --summary none
- zig build test-cli --summary none
- zig build test --summary none
