### PR TITLE
repl: render full diagnostics on type errors

### DIFF
--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -61,9 +61,16 @@ pub fn step(self: *ReplSession, input: []const u8) ![]u8 {
             var snapshot = try self.definitions.snapshot(self.allocator);
             errdefer snapshot.deinit(self.allocator);
             try self.addOrReplaceDefinition(line, name, input_info.definition_kind);
-            const valid = self.validateDefinitions() catch false;
-            if (!valid) {
+            const validation = self.validateDefinitions() catch DefinitionValidation{ .valid = false, .error_message = null };
+            if (!validation.valid) {
                 self.definitions.restore(self.allocator, &snapshot);
+                // Drop any pending annotation for this name. A `y : Str` typed before a
+                // failed `y = 5` would otherwise survive and poison every subsequent
+                // REPL turn with "DECLARATION HAS NO VALUE".
+                if (input_info.definition_kind == .value and !self.definitions.hasKind(name, .value)) {
+                    self.definitions.removeByNameAndKind(self.allocator, name, .annotation);
+                }
+                if (validation.error_message) |msg| return msg;
                 return self.allocator.dupe(u8, "Definition failed to compile");
             }
             const message = try std.fmt.allocPrint(self.allocator, "assigned `{s}`", .{name});
@@ -175,18 +182,32 @@ fn helpText(self: *ReplSession) ![]u8 {
     );
 }
 
-fn validateDefinitions(self: *ReplSession) !bool {
+const DefinitionValidation = struct {
+    valid: bool,
+    /// Rendered diagnostic reports when invalid; caller owns and must free.
+    error_message: ?[]u8,
+};
+
+fn validateDefinitions(self: *ReplSession) !DefinitionValidation {
     const definitions = try self.definitionsSource();
     defer self.allocator.free(definitions);
 
     const source = try std.fmt.allocPrint(self.allocator, "{s}\nmain = \"\"\n", .{definitions});
     defer self.allocator.free(source);
 
-    const parsed = eval.test_helpers.parseAndCanonicalizeProgramPublishedRoots(self.allocator, .module, source, &.{}) catch {
-        return false;
-    };
-    defer eval.test_helpers.cleanupParseAndCanonical(self.allocator, parsed);
-    return true;
+    if (eval.test_helpers.parseAndCanonicalizeProgramPublishedRoots(self.allocator, .module, source, &.{})) |parsed| {
+        eval.test_helpers.cleanupParseAndCanonical(self.allocator, parsed);
+        return .{ .valid = true, .error_message = null };
+    } else |err| switch (err) {
+        error.TypeCheckError => {
+            const msg = eval.test_helpers.renderProblems(self.allocator, .module, source) catch |render_err| switch (render_err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return .{ .valid = false, .error_message = null },
+            };
+            return .{ .valid = false, .error_message = msg };
+        },
+        else => return .{ .valid = false, .error_message = null },
+    }
 }
 
 fn evaluateExpression(self: *ReplSession, expr: []const u8) ![]u8 {
@@ -200,7 +221,10 @@ fn evaluateExpression(self: *ReplSession, expr: []const u8) ![]u8 {
         .interpreter, .dev, .llvm => .native,
         .wasm => .u32,
     };
-    var compiled = try eval.test_helpers.compileInspectedProgramForTarget(self.allocator, .module, source, &.{}, target_usize);
+    var compiled = eval.test_helpers.compileInspectedProgramForTarget(self.allocator, .module, source, &.{}, target_usize) catch |err| switch (err) {
+        error.TypeCheckError => return eval.test_helpers.renderProblems(self.allocator, .module, source),
+        else => return err,
+    };
     defer compiled.deinit(self.allocator);
 
     return switch (self.backend_kind) {
@@ -337,6 +361,26 @@ pub const DefinitionStore = struct {
 
     pub fn count(self: *const DefinitionStore) usize {
         return self.items.items.len;
+    }
+
+    pub fn hasKind(self: *const DefinitionStore, name: []const u8, kind: DefinitionKind) bool {
+        for (self.items.items) |definition| {
+            if (definition.kind == kind and std.mem.eql(u8, definition.name, name)) return true;
+        }
+        return false;
+    }
+
+    pub fn removeByNameAndKind(self: *DefinitionStore, allocator: Allocator, name: []const u8, kind: DefinitionKind) void {
+        var i: usize = 0;
+        while (i < self.items.items.len) {
+            const definition = &self.items.items[i];
+            if (definition.kind == kind and std.mem.eql(u8, definition.name, name)) {
+                var removed = self.items.orderedRemove(i);
+                removed.deinit(allocator);
+                return;
+            }
+            i += 1;
+        }
     }
 
     fn addOrReplace(self: *DefinitionStore, allocator: Allocator, source: []const u8, name: []const u8, kind: DefinitionKind) !void {

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -12,6 +12,7 @@ const backend = @import("backend");
 const collections = @import("collections");
 const compiled_builtins = @import("compiled_builtins");
 const lir = @import("lir");
+const reporting = @import("reporting");
 
 const builtin_loading = @import("builtin_loading.zig");
 const CompileTimeFinalization = @import("compile_time_finalization.zig");
@@ -1010,6 +1011,79 @@ fn publishImportKeys(
         };
     }
     return imports;
+}
+
+/// Render diagnostics (tokenize, parse, canonicalize, type-check) for a source as a
+/// terminal-formatted string. Use this on `error.TypeCheckError` to produce the same
+/// nice messages the file-based path prints.
+pub fn renderProblems(
+    allocator: Allocator,
+    source_kind: SourceKind,
+    source: []const u8,
+) ![]u8 {
+    var resources = try parseAndCheckProgramForProblems(allocator, source_kind, source, &.{});
+    defer resources.deinit(allocator);
+
+    return try renderCheckedModuleProblems(allocator, &resources.main, "repl");
+}
+
+fn renderCheckedModuleProblems(
+    allocator: Allocator,
+    main: *const CheckedModule,
+    filename: []const u8,
+) ![]u8 {
+    var reports = std.array_list.Managed(reporting.Report).init(allocator);
+    defer {
+        for (reports.items) |*r| r.deinit();
+        reports.deinit();
+    }
+
+    for (main.parse_ast.tokenize_diagnostics.items) |diagnostic| {
+        const report = try main.parse_ast.tokenizeDiagnosticToReport(diagnostic, allocator, filename);
+        try reports.append(report);
+    }
+
+    for (main.parse_ast.parse_diagnostics.items) |diagnostic| {
+        const report = try main.parse_ast.parseDiagnosticToReport(&main.module_env.common, diagnostic, allocator, filename);
+        try reports.append(report);
+    }
+
+    const diagnostics = try main.module_env.getDiagnostics();
+    defer allocator.free(diagnostics);
+    for (diagnostics) |diagnostic| {
+        const report = try main.module_env.diagnosticToReport(diagnostic, allocator, filename);
+        try reports.append(report);
+    }
+
+    for (main.checker.problems.problems.items) |problem| {
+        var report_builder = try check.ReportBuilder.init(
+            allocator,
+            main.module_env,
+            main.module_env,
+            &main.checker.snapshots,
+            &main.checker.problems,
+            filename,
+            &.{},
+            &main.checker.import_mapping,
+            &main.checker.regions,
+        );
+        defer report_builder.deinit();
+
+        const report = try report_builder.build(problem);
+        try reports.append(report);
+    }
+
+    var out: std.Io.Writer.Allocating = .init(allocator);
+    errdefer out.deinit();
+    for (reports.items) |report| {
+        try report.render(&out.writer, .color_terminal);
+    }
+    const raw = try out.toOwnedSlice();
+    const trimmed = std.mem.trimRight(u8, raw, "\r\n");
+    if (trimmed.len == raw.len) return raw;
+    const result = try allocator.dupe(u8, trimmed);
+    allocator.free(raw);
+    return result;
 }
 
 fn cleanupCheckedModule(allocator: Allocator, module: CheckedModule) void {


### PR DESCRIPTION
The REPL printed only "Error: TypeCheckError" when type checking failed, while the file-based path produced rich messages like "TOO FEW ARGS" with source highlights. Render the same reports in the REPL on both expression type errors and failed value definitions.