### PR TITLE
Fix formatter bugs, add some regression tests

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -987,15 +987,12 @@ const Formatter = struct {
             fmt.curr_indent = record_indent;
         }
         try fmt.push('{');
-        if (fields.len == 0) {
-            // Just the extension, e.g. { .. } or { ..a }
-            try fmt.push(' ');
+        if (record_multiline) {
+            fmt.curr_indent += 1;
         } else {
-            if (record_multiline) {
-                fmt.curr_indent += 1;
-            } else {
-                try fmt.push(' ');
-            }
+            try fmt.push(' ');
+        }
+        if (fields.len > 0) {
             for (fields, 0..) |field_idx, i| {
                 const field_region = fmt.nodeRegion(@intFromEnum(field_idx));
                 if (record_multiline) {

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -496,11 +496,21 @@ const Formatter = struct {
                         } else {
                             try fmt.pushAll(" as");
                         }
-                        flushed = try fmt.flushCommentsBefore(a);
-                        if (!flushed) {
-                            try fmt.push(' ');
+                        // Only preserve newlines between `as` and the alias if there
+                        // is an actual comment there. A bare source newline like
+                        // `as\n    X1` should normalize to ` as X1`; otherwise we
+                        // strand the alias on its own line and (with auto-expose)
+                        // glue it directly to `exposing` (see issue #9373).
+                        if (fmt.hasCommentBefore(a)) {
+                            flushed = try fmt.flushCommentsBefore(a);
+                            if (!flushed) {
+                                try fmt.push(' ');
+                            } else {
+                                try fmt.pushIndent();
+                            }
                         } else {
-                            try fmt.pushIndent();
+                            try fmt.push(' ');
+                            flushed = false;
                         }
                     } else {
                         try fmt.pushAll(" as ");
@@ -2699,6 +2709,17 @@ const Formatter = struct {
 
     fn flushCommentsBefore(fmt: *Formatter, tokenIdx: Token.Idx) !bool {
         return fmt.flushCommentsBeforeMin(tokenIdx, 0);
+    }
+
+    /// True iff the source text between the previous token and `tokenIdx`
+    /// contains an actual `#` comment. Use this to decide whether to preserve
+    /// inter-token whitespace, since `flushCommentsBefore` always emits any
+    /// source newlines it finds (which is wrong for places where bare line
+    /// breaks should be normalized to a single space).
+    fn hasCommentBefore(fmt: *Formatter, tokenIdx: Token.Idx) bool {
+        const start = if (tokenIdx == 0) 0 else fmt.ast.tokens.resolve(tokenIdx - 1).end.offset;
+        const end = fmt.ast.tokens.resolve(tokenIdx).start.offset;
+        return std.mem.indexOfScalar(u8, fmt.ast.env.source[start..end], '#') != null;
     }
 
     /// Like `flushCommentsBefore`, but ensures at least `min_leading_newlines` newlines

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -1279,9 +1279,33 @@ const Formatter = struct {
                     // Plain identifier: add () after it
                     try fmt.formatExprInnerDiscard(ld.right, .no_indent_on_access);
                     try fmt.pushAll("()");
-                } else if (right_expr == .apply or right_expr == .tag) {
-                    // Already has parens (apply) or tag: format normally
+                } else if (right_expr == .tag) {
+                    // Tag: format normally
                     try fmt.formatExprInnerDiscard(ld.right, .no_indent_on_access);
+                } else if (right_expr == .apply) {
+                    // The arrow parser strips the outer parens around the fn part
+                    // of an `apply` (because `->(...)` consumes the parens directly
+                    // rather than producing a tuple), so e.g. `10->(|x| x + 1)()`
+                    // parses to apply{fn=lambda, args=()}. Re-add those parens when
+                    // the fn would otherwise be ambiguous (see issue #9372).
+                    const apply = right_expr.apply;
+                    const apply_fn_idx = apply.@"fn";
+                    const apply_fn = fmt.ast.store.getExpr(apply_fn_idx);
+                    const fn_needs_parens = switch (apply_fn) {
+                        .ident, .tag, .apply, .tuple, .field_access, .tuple_access, .method_call, .list, .record, .string, .multiline_string, .string_part, .int, .frac, .typed_int, .typed_frac, .single_quote => false,
+                        else => true,
+                    };
+                    if (fn_needs_parens) {
+                        try fmt.push('(');
+                        try fmt.formatExprInnerDiscard(apply_fn_idx, .no_indent_on_access);
+                        try fmt.push(')');
+                        const right_region = fmt.nodeRegion(@intFromEnum(ld.right));
+                        const fn_region = fmt.nodeRegion(@intFromEnum(apply_fn_idx));
+                        const args_region = AST.TokenizedRegion{ .start = fn_region.end, .end = right_region.end };
+                        try fmt.formatCollection(args_region, .round, AST.Expr.Idx, fmt.ast.store.exprSlice(apply.args), Formatter.formatExpr);
+                    } else {
+                        try fmt.formatExprInnerDiscard(ld.right, .no_indent_on_access);
+                    }
                 } else {
                     // Lambda or other expression: wrap in parens for round-trip safety
                     try fmt.push('(');

--- a/test/snapshots/fmt_arrow_dispatched_inline_lambda_call_issue_9372.md
+++ b/test/snapshots/fmt_arrow_dispatched_inline_lambda_call_issue_9372.md
@@ -1,0 +1,64 @@
+# META
+~~~ini
+description=Issue 9372 - Formatter must not drop parentheses around an arrow-dispatched, inline lambda that is then called
+type=snippet
+~~~
+# SOURCE
+~~~roc
+test1 = 10->(|x| x + 1)()
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,Int,OpArrow,NoSpaceOpenRound,OpBar,LowerIdent,OpBar,LowerIdent,OpPlus,Int,CloseRound,NoSpaceOpenRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "test1"))
+			(e-arrow-call
+				(e-int (raw "10"))
+				(e-apply
+					(e-lambda
+						(args
+							(p-ident (raw "x")))
+						(e-binop (op "+")
+							(e-ident (raw "x"))
+							(e-int (raw "1")))))))))
+~~~
+# FORMATTED
+~~~roc
+test1 = 10->|x| x + 1()
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "test1"))
+		(e-call (constraint-fn-var 77)
+			(e-lambda
+				(args
+					(p-assign (ident "x")))
+				(e-dispatch-call (method "plus") (constraint-fn-var 45)
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "x"))))
+					(args
+						(e-num (value "1")))))
+			(e-num (value "10")))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Dec")))
+	(expressions
+		(expr (type "Dec"))))
+~~~

--- a/test/snapshots/fmt_arrow_dispatched_inline_lambda_call_issue_9372.md
+++ b/test/snapshots/fmt_arrow_dispatched_inline_lambda_call_issue_9372.md
@@ -35,7 +35,7 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-test1 = 10->|x| x + 1()
+NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/fmt_empty_auto_expose_multiline_issue_9373.md
+++ b/test/snapshots/fmt_empty_auto_expose_multiline_issue_9373.md
@@ -7,7 +7,7 @@ type=snippet
 ~~~roc
 import A .B as
     X1
-import A .B .C as 
+import A .B .C as
     X2
 import A .B .C .D as
     X3
@@ -38,17 +38,14 @@ EndOfFile,
 # FORMATTED
 ~~~roc
 import A
-	.B as
-X1exposing []
+	.B as X1 exposing []
 import A
 	.B
-	.C as
-X2exposing []
+	.C as X2 exposing []
 import A
 	.B
 	.C
-	.D as
-X3exposing []
+	.D as X3 exposing []
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/fmt_empty_auto_expose_multiline_issue_9373.md
+++ b/test/snapshots/fmt_empty_auto_expose_multiline_issue_9373.md
@@ -1,0 +1,68 @@
+# META
+~~~ini
+description=Issue 9373 - Formatter must keep the imported alias on the same line as `as`, even with multiline qualifiers
+type=snippet
+~~~
+# SOURCE
+~~~roc
+import A .B as
+    X1
+import A .B .C as 
+    X2
+import A .B .C .D as
+    X3
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+KwImport,UpperIdent,DotUpperIdent,KwAs,
+UpperIdent,
+KwImport,UpperIdent,DotUpperIdent,DotUpperIdent,KwAs,
+UpperIdent,
+KwImport,UpperIdent,DotUpperIdent,DotUpperIdent,DotUpperIdent,KwAs,
+UpperIdent,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-import (raw "A .B") (alias "X1"))
+		(s-import (raw "A .B .C") (alias "X2"))
+		(s-import (raw "A .B .C .D") (alias "X3"))))
+~~~
+# FORMATTED
+~~~roc
+import A
+	.B as
+X1exposing []
+import A
+	.B
+	.C as
+X2exposing []
+import A
+	.B
+	.C
+	.D as
+X3exposing []
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(s-import (module "A")
+		(exposes))
+	(s-import (module "A")
+		(exposes))
+	(s-import (module "A")
+		(exposes)))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(expressions))
+~~~

--- a/test/snapshots/fmt_record_type_extension_trailing_comma_issue_9374.md
+++ b/test/snapshots/fmt_record_type_extension_trailing_comma_issue_9374.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=Issue 9374 - Formatter must not crash with integer underflow on a record type whose extension has a trailing comma
+type=snippet
+skip=true
+# TODO: Currently panics in fmt.zig formatRecordWithExtension with integer overflow on `curr_indent -= 1`
+#       because curr_indent was never incremented when fields.len == 0. Unskip once fixed.
+~~~
+# SOURCE
+~~~roc
+x : { ..a, }
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# FORMATTED
+~~~roc
+x : {
+	..a,
+}
+~~~

--- a/test/snapshots/fmt_record_type_extension_trailing_comma_issue_9374.md
+++ b/test/snapshots/fmt_record_type_extension_trailing_comma_issue_9374.md
@@ -2,21 +2,60 @@
 ~~~ini
 description=Issue 9374 - Formatter must not crash with integer underflow on a record type whose extension has a trailing comma
 type=snippet
-skip=true
-# TODO: Currently panics in fmt.zig formatRecordWithExtension with integer overflow on `curr_indent -= 1`
-#       because curr_indent was never incremented when fields.len == 0. Unskip once fixed.
 ~~~
 # SOURCE
 ~~~roc
 x : { ..a, }
 ~~~
 # EXPECTED
-NIL
+DECLARATION HAS NO VALUE - fmt_record_type_extension_trailing_comma_issue_9374.md:1:1:1:13
 # PROBLEMS
-NIL
+**DECLARATION HAS NO VALUE**
+This declaration has a type annotation but no implementation.
+**fmt_record_type_extension_trailing_comma_issue_9374.md:1:1:1:13:**
+```roc
+x : { ..a, }
+```
+^^^^^^^^^^^^
+
+
+Add a value body here, or put hosted functions in a platform type module so they are published through the host boundary.
+
+# TOKENS
+~~~zig
+LowerIdent,OpColon,OpenCurly,DoubleDot,LowerIdent,Comma,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-anno (name "x")
+			(ty-record
+				(ty-record-ext
+					(ty-var (raw "a")))))))
+~~~
 # FORMATTED
 ~~~roc
 x : {
 	..a,
 }
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "x"))
+		(e-anno-only)
+		(annotation
+			(ty-record))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "{ ..a }")))
+	(expressions
+		(expr (type "{ ..a }"))))
 ~~~

--- a/test/snapshots/repl/repl_static_dispatch_assigned_to_var_issue_9377.md
+++ b/test/snapshots/repl/repl_static_dispatch_assigned_to_var_issue_9377.md
@@ -1,0 +1,25 @@
+# META
+~~~ini
+description=Issue 9377 - REPL must not panic when a static-dispatch call is assigned to a var and then evaluated
+type=repl
+~~~
+# SOURCE
+~~~roc
+» [1,2,3].first()
+» numbers = [1,2,3]
+» numbers.first()
+» out = numbers.first()
+» out
+~~~
+# OUTPUT
+Ok(1.0)
+---
+assigned `numbers`
+---
+Ok(1.0)
+---
+assigned `out`
+---
+Ok(1.0)
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/repl_static_dispatch_on_undefined_issue_9375.md
+++ b/test/snapshots/repl/repl_static_dispatch_on_undefined_issue_9375.md
@@ -1,0 +1,21 @@
+# META
+~~~ini
+description=Issue 9375 - REPL must not panic when doing static dispatch on a non-existent variable
+type=repl
+~~~
+# SOURCE
+~~~roc
+» lst.map(|_| "zzz ").join_with(" ").trim()
+~~~
+# OUTPUT
+**UNDEFINED VARIABLE**
+Nothing is named `lst` in this scope.
+Is there an `import` or `exposing` missing up-top?
+
+**repl:1:1:1:4:**
+```roc
+lst.map(|_| "zzz ").join_with(" ").trim()
+```
+^^^
+# PROBLEMS
+NIL


### PR DESCRIPTION
Adds snapshot regression tests for five recent bug reports and fixes the three that still reproduced.

## Status of each issue

- **#9377** — already fixed on `main`; snapshot pins the correct REPL output for static dispatch on a `var`-bound list.
- **#9375** — already fixed on `main`; snapshot pins the correct REPL output for static dispatch on a non-existent variable (now an `UNDEFINED VARIABLE` error instead of a panic).
- **#9374** — formatter integer underflow on `x : { ..a, }`. Fixed by hoisting the multiline `curr_indent += 1` above the `fields.len == 0` check in `formatRecordWithExtension`, so the matching `-= 1` no longer underflows.
- **#9372** — `10->(|x| x + 1)()` was reformatting to `10->|x| x + 1()` and then failing to reparse. The arrow parser strips the outer parens around the fn part of an `apply` (because `->(...)` consumes the parens directly rather than producing a tuple), so the arrow_call formatter now re-adds those parens whenever the apply's fn is anything other than a syntactic form that's already self-delimited (ident, tag, tuple, apply, field/tuple/method access, literal, list, record).
- **#9373** — `import A .B as\n    X1` was producing the broken output below. `flushCommentsBefore` was preserving the source newline between `as` and the alias even when there was no actual comment, stranding the alias on a new line and (with auto-expose) gluing it directly to `exposing`:
  ```
  import A
  	.B as
  X1exposing []
  ```
  Added a `hasCommentBefore` helper and only flush when there is an actual `#` comment in the inter-token text. Bare newlines now normalize to a single space.

## Commits

1. Add snapshot tests for all five issues.
2. Fix #9374.
3. Fix #9372.
4. Fix #9373.

Closes #9372
Closes #9373
Closes #9374
Closes #9375
Closes #9377