### PR TITLE
Add Iter take/drop methods and Known lengths for int ranges

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -455,6 +455,110 @@ Builtin :: [].{
 				Skip({ rest, .. }) => Iter.fold(rest, acc, step)
 				One({ item, rest }) => Iter.fold(rest, step(acc, item), step)
 			}
+
+		## Returns an iterator that yields at most the first `n` items of this iterator.
+		## If the source has fewer than `n` items, all of them are yielded.
+		## ```roc
+		## expect Iter.fold(Iter.take_first(List.iter([1, 2, 3, 4, 5]), 3), [], |acc, item| acc.append(item)) == [1, 2, 3]
+		##
+		## expect Iter.fold(Iter.take_first(List.iter([1, 2]), 5), [], |acc, item| acc.append(item)) == [1, 2]
+		## ```
+		take_first : Iter(item), U64 -> Iter(item)
+		take_first = |iterator, n|
+			if n == 0 {
+				range_done()
+			} else {
+				match iterator {
+					{ len_if_known, step } => {
+						len_if_known: match len_if_known {
+							Known(len) => Known(if len < n { len } else { n })
+							Unknown => Unknown
+						},
+						step: ||
+							match step() {
+								Done => Done
+								Skip({ count, rest }) => Skip({ count, rest: Iter.take_first(rest, n) })
+								One({ item, rest }) => One({ item, rest: Iter.take_first(rest, n - 1) })
+							},
+					}
+				}
+			}
+
+		## Returns an iterator that skips the first `n` items of this iterator.
+		## If the source has `n` or fewer items, the result is empty.
+		## ```roc
+		## expect Iter.fold(Iter.drop_first(List.iter([1, 2, 3, 4, 5]), 2), [], |acc, item| acc.append(item)) == [3, 4, 5]
+		##
+		## expect Iter.fold(Iter.drop_first(List.iter([1, 2, 3]), 10), [], |acc, item| acc.append(item)) == []
+		## ```
+		drop_first : Iter(item), U64 -> Iter(item)
+		drop_first = |iterator, n|
+			if n == 0 {
+				iterator
+			} else {
+				match iterator {
+					{ len_if_known, step } => {
+						len_if_known: match len_if_known {
+							Known(len) => Known(if len < n { 0 } else { len - n })
+							Unknown => Unknown
+						},
+						step: ||
+							match step() {
+								Done => Done
+								Skip({ count, rest }) => Skip({ count, rest: Iter.drop_first(rest, n) })
+								One({ item: _, rest }) => Skip({ count: 1, rest: Iter.drop_first(rest, n - 1) })
+							},
+					}
+				}
+			}
+
+		## Returns an iterator that yields the last `n` items of this iterator.
+		## If the source has fewer than `n` items, all of them are yielded.
+		##
+		## When the source iterator's length is unknown, this materializes the
+		## source into a list to find where the last `n` items begin. Avoid
+		## calling this on iterators whose length is unknown and might be huge.
+		## ```roc
+		## expect Iter.fold(Iter.take_last(List.iter([1, 2, 3, 4, 5]), 3), [], |acc, item| acc.append(item)) == [3, 4, 5]
+		##
+		## expect Iter.fold(Iter.take_last(List.iter([1, 2]), 5), [], |acc, item| acc.append(item)) == [1, 2]
+		## ```
+		take_last : Iter(item), U64 -> Iter(item)
+		take_last = |iterator, n|
+			match iterator.len_if_known {
+				Known(len) =>
+					if len <= n {
+						iterator
+					} else {
+						Iter.drop_first(iterator, len - n)
+					}
+				Unknown =>
+					List.iter(List.take_last(Iter.fold(iterator, [], |acc, item| acc.append(item)), n))
+			}
+
+		## Returns an iterator that yields all items except the last `n`.
+		## If the source has `n` or fewer items, the result is empty.
+		##
+		## When the source iterator's length is unknown, this materializes the
+		## source into a list to find where the last `n` items begin. Avoid
+		## calling this on iterators whose length is unknown and might be huge.
+		## ```roc
+		## expect Iter.fold(Iter.drop_last(List.iter([1, 2, 3, 4, 5]), 2), [], |acc, item| acc.append(item)) == [1, 2, 3]
+		##
+		## expect Iter.fold(Iter.drop_last(List.iter([1, 2, 3]), 10), [], |acc, item| acc.append(item)) == []
+		## ```
+		drop_last : Iter(item), U64 -> Iter(item)
+		drop_last = |iterator, n|
+			match iterator.len_if_known {
+				Known(len) =>
+					if len <= n {
+						range_done()
+					} else {
+						Iter.take_first(iterator, len - n)
+					}
+				Unknown =>
+					List.iter(List.drop_last(Iter.fold(iterator, [], |acc, item| acc.append(item)), n))
+			}
 	}
 
 	List(_item) :: [ProvidedByCompiler].{
@@ -2106,7 +2210,7 @@ Builtin :: [].{
 			## ```
 			to : U8, U8 -> Iter(U8)
 			to = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start > end { Known(0) } else { Known(U8.to_u64(end) - U8.to_u64(start) + 1) },
 				step: ||
 					if start <= end {
 						One(
@@ -2139,7 +2243,7 @@ Builtin :: [].{
 			## ```
 			until : U8, U8 -> Iter(U8)
 			until = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start >= end { Known(0) } else { Known(U8.to_u64(end) - U8.to_u64(start)) },
 				step: ||
 					if start < end {
 						One(
@@ -2492,7 +2596,7 @@ Builtin :: [].{
 			## ```
 			to : I8, I8 -> Iter(I8)
 			to = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start > end { Known(0) } else { Known(I64.to_u64_wrap(I8.to_i64(end) - I8.to_i64(start) + 1)) },
 				step: ||
 					if start <= end {
 						One(
@@ -2525,7 +2629,7 @@ Builtin :: [].{
 			## ```
 			until : I8, I8 -> Iter(I8)
 			until = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start >= end { Known(0) } else { Known(I64.to_u64_wrap(I8.to_i64(end) - I8.to_i64(start))) },
 				step: ||
 					if start < end {
 						One(
@@ -2930,7 +3034,7 @@ Builtin :: [].{
 			## ```
 			to : U16, U16 -> Iter(U16)
 			to = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start > end { Known(0) } else { Known(U16.to_u64(end) - U16.to_u64(start) + 1) },
 				step: ||
 					if start <= end {
 						One(
@@ -2963,7 +3067,7 @@ Builtin :: [].{
 			## ```
 			until : U16, U16 -> Iter(U16)
 			until = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start >= end { Known(0) } else { Known(U16.to_u64(end) - U16.to_u64(start)) },
 				step: ||
 					if start < end {
 						One(
@@ -3376,7 +3480,7 @@ Builtin :: [].{
 			## ```
 			to : I16, I16 -> Iter(I16)
 			to = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start > end { Known(0) } else { Known(I64.to_u64_wrap(I16.to_i64(end) - I16.to_i64(start) + 1)) },
 				step: ||
 					if start <= end {
 						One(
@@ -3409,7 +3513,7 @@ Builtin :: [].{
 			## ```
 			until : I16, I16 -> Iter(I16)
 			until = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start >= end { Known(0) } else { Known(I64.to_u64_wrap(I16.to_i64(end) - I16.to_i64(start))) },
 				step: ||
 					if start < end {
 						One(
@@ -3831,7 +3935,7 @@ Builtin :: [].{
 			## ```
 			to : U32, U32 -> Iter(U32)
 			to = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start > end { Known(0) } else { Known(U32.to_u64(end) - U32.to_u64(start) + 1) },
 				step: ||
 					if start <= end {
 						One(
@@ -3864,7 +3968,7 @@ Builtin :: [].{
 			## ```
 			until : U32, U32 -> Iter(U32)
 			until = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start >= end { Known(0) } else { Known(U32.to_u64(end) - U32.to_u64(start)) },
 				step: ||
 					if start < end {
 						One(
@@ -4315,7 +4419,7 @@ Builtin :: [].{
 			## ```
 			to : I32, I32 -> Iter(I32)
 			to = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start > end { Known(0) } else { Known(I64.to_u64_wrap(I32.to_i64(end) - I32.to_i64(start) + 1)) },
 				step: ||
 					if start <= end {
 						One(
@@ -4348,7 +4452,7 @@ Builtin :: [].{
 			## ```
 			until : I32, I32 -> Iter(I32)
 			until = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start >= end { Known(0) } else { Known(I64.to_u64_wrap(I32.to_i64(end) - I32.to_i64(start))) },
 				step: ||
 					if start < end {
 						One(
@@ -4790,7 +4894,14 @@ Builtin :: [].{
 			## ```
 			to : U64, U64 -> Iter(U64)
 			to = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start > end {
+					Known(0)
+				} else {
+					match U64.add_checked(end - start, 1) {
+						Ok(len) => Known(len)
+						Err(Overflow) => Unknown
+					}
+				},
 				step: ||
 					if start <= end {
 						One(
@@ -4823,7 +4934,7 @@ Builtin :: [].{
 			## ```
 			until : U64, U64 -> Iter(U64)
 			until = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start >= end { Known(0) } else { Known(end - start) },
 				step: ||
 					if start < end {
 						One(
@@ -5316,7 +5427,17 @@ Builtin :: [].{
 			## ```
 			to : I64, I64 -> Iter(I64)
 			to = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start > end {
+					Known(0)
+				} else {
+					match I64.sub_checked(end, start) {
+						Ok(diff) => match I64.add_checked(diff, 1) {
+							Ok(d1) => Known(I64.to_u64_wrap(d1))
+							Err(Overflow) => Unknown
+						}
+						Err(Overflow) => Unknown
+					}
+				},
 				step: ||
 					if start <= end {
 						One(
@@ -5349,7 +5470,14 @@ Builtin :: [].{
 			## ```
 			until : I64, I64 -> Iter(I64)
 			until = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start >= end {
+					Known(0)
+				} else {
+					match I64.sub_checked(end, start) {
+						Ok(diff) => Known(I64.to_u64_wrap(diff))
+						Err(Overflow) => Unknown
+					}
+				},
 				step: ||
 					if start < end {
 						One(
@@ -5807,7 +5935,17 @@ Builtin :: [].{
 			## ```
 			to : U128, U128 -> Iter(U128)
 			to = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start > end {
+					Known(0)
+				} else {
+					match U128.to_u64_try(end - start) {
+						Ok(diff_u64) => match U64.add_checked(diff_u64, 1) {
+							Ok(len) => Known(len)
+							Err(Overflow) => Unknown
+						}
+						Err(OutOfRange) => Unknown
+					}
+				},
 				step: ||
 					if start <= end {
 						One(
@@ -5840,7 +5978,14 @@ Builtin :: [].{
 			## ```
 			until : U128, U128 -> Iter(U128)
 			until = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start >= end {
+					Known(0)
+				} else {
+					match U128.to_u64_try(end - start) {
+						Ok(len) => Known(len)
+						Err(OutOfRange) => Unknown
+					}
+				},
 				step: ||
 					if start < end {
 						One(
@@ -6373,7 +6518,20 @@ Builtin :: [].{
 			## ```
 			to : I128, I128 -> Iter(I128)
 			to = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start > end {
+					Known(0)
+				} else {
+					match I128.sub_checked(end, start) {
+						Ok(diff) => match I128.to_u64_try(diff) {
+							Ok(diff_u64) => match U64.add_checked(diff_u64, 1) {
+								Ok(len) => Known(len)
+								Err(Overflow) => Unknown
+							}
+							Err(OutOfRange) => Unknown
+						}
+						Err(Overflow) => Unknown
+					}
+				},
 				step: ||
 					if start <= end {
 						One(
@@ -6406,7 +6564,17 @@ Builtin :: [].{
 			## ```
 			until : I128, I128 -> Iter(I128)
 			until = |start, end| {
-				len_if_known: Unknown,
+				len_if_known: if start >= end {
+					Known(0)
+				} else {
+					match I128.sub_checked(end, start) {
+						Ok(diff) => match I128.to_u64_try(diff) {
+							Ok(len) => Known(len)
+							Err(OutOfRange) => Unknown
+						}
+						Err(Overflow) => Unknown
+					}
+				},
 				step: ||
 					if start < end {
 						One(

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -471,7 +471,13 @@ Builtin :: [].{
 				match iterator {
 					{ len_if_known, step } => {
 						len_if_known: match len_if_known {
-							Known(len) => Known(if len < n { len } else { n })
+							Known(len) => Known(
+								if len < n {
+									len
+								} else {
+									n
+								},
+							)
 							Unknown => Unknown
 						},
 						step: ||
@@ -499,7 +505,13 @@ Builtin :: [].{
 				match iterator {
 					{ len_if_known, step } => {
 						len_if_known: match len_if_known {
-							Known(len) => Known(if len < n { 0 } else { len - n })
+							Known(len) => Known(
+								if len < n {
+									0
+								} else {
+									len - n
+								},
+							)
 							Unknown => Unknown
 						},
 						step: ||
@@ -534,7 +546,7 @@ Builtin :: [].{
 					}
 				Unknown =>
 					List.iter(List.take_last(Iter.fold(iterator, [], |acc, item| acc.append(item)), n))
-			}
+				}
 
 		## Returns an iterator that yields all items except the last `n`.
 		## If the source has `n` or fewer items, the result is empty.
@@ -558,7 +570,7 @@ Builtin :: [].{
 					}
 				Unknown =>
 					List.iter(List.drop_last(Iter.fold(iterator, [], |acc, item| acc.append(item)), n))
-			}
+				}
 	}
 
 	List(_item) :: [ProvidedByCompiler].{
@@ -2210,7 +2222,11 @@ Builtin :: [].{
 			## ```
 			to : U8, U8 -> Iter(U8)
 			to = |start, end| {
-				len_if_known: if start > end { Known(0) } else { Known(U8.to_u64(end) - U8.to_u64(start) + 1) },
+				len_if_known: if start > end {
+					Known(0)
+				} else {
+					Known(U8.to_u64(end) - U8.to_u64(start) + 1)
+				},
 				step: ||
 					if start <= end {
 						One(
@@ -2243,7 +2259,11 @@ Builtin :: [].{
 			## ```
 			until : U8, U8 -> Iter(U8)
 			until = |start, end| {
-				len_if_known: if start >= end { Known(0) } else { Known(U8.to_u64(end) - U8.to_u64(start)) },
+				len_if_known: if start >= end {
+					Known(0)
+				} else {
+					Known(U8.to_u64(end) - U8.to_u64(start))
+				},
 				step: ||
 					if start < end {
 						One(
@@ -2596,7 +2616,11 @@ Builtin :: [].{
 			## ```
 			to : I8, I8 -> Iter(I8)
 			to = |start, end| {
-				len_if_known: if start > end { Known(0) } else { Known(I64.to_u64_wrap(I8.to_i64(end) - I8.to_i64(start) + 1)) },
+				len_if_known: if start > end {
+					Known(0)
+				} else {
+					Known(I64.to_u64_wrap(I8.to_i64(end) - I8.to_i64(start) + 1))
+				},
 				step: ||
 					if start <= end {
 						One(
@@ -2629,7 +2653,11 @@ Builtin :: [].{
 			## ```
 			until : I8, I8 -> Iter(I8)
 			until = |start, end| {
-				len_if_known: if start >= end { Known(0) } else { Known(I64.to_u64_wrap(I8.to_i64(end) - I8.to_i64(start))) },
+				len_if_known: if start >= end {
+					Known(0)
+				} else {
+					Known(I64.to_u64_wrap(I8.to_i64(end) - I8.to_i64(start)))
+				},
 				step: ||
 					if start < end {
 						One(
@@ -3034,7 +3062,11 @@ Builtin :: [].{
 			## ```
 			to : U16, U16 -> Iter(U16)
 			to = |start, end| {
-				len_if_known: if start > end { Known(0) } else { Known(U16.to_u64(end) - U16.to_u64(start) + 1) },
+				len_if_known: if start > end {
+					Known(0)
+				} else {
+					Known(U16.to_u64(end) - U16.to_u64(start) + 1)
+				},
 				step: ||
 					if start <= end {
 						One(
@@ -3067,7 +3099,11 @@ Builtin :: [].{
 			## ```
 			until : U16, U16 -> Iter(U16)
 			until = |start, end| {
-				len_if_known: if start >= end { Known(0) } else { Known(U16.to_u64(end) - U16.to_u64(start)) },
+				len_if_known: if start >= end {
+					Known(0)
+				} else {
+					Known(U16.to_u64(end) - U16.to_u64(start))
+				},
 				step: ||
 					if start < end {
 						One(
@@ -3480,7 +3516,11 @@ Builtin :: [].{
 			## ```
 			to : I16, I16 -> Iter(I16)
 			to = |start, end| {
-				len_if_known: if start > end { Known(0) } else { Known(I64.to_u64_wrap(I16.to_i64(end) - I16.to_i64(start) + 1)) },
+				len_if_known: if start > end {
+					Known(0)
+				} else {
+					Known(I64.to_u64_wrap(I16.to_i64(end) - I16.to_i64(start) + 1))
+				},
 				step: ||
 					if start <= end {
 						One(
@@ -3513,7 +3553,11 @@ Builtin :: [].{
 			## ```
 			until : I16, I16 -> Iter(I16)
 			until = |start, end| {
-				len_if_known: if start >= end { Known(0) } else { Known(I64.to_u64_wrap(I16.to_i64(end) - I16.to_i64(start))) },
+				len_if_known: if start >= end {
+					Known(0)
+				} else {
+					Known(I64.to_u64_wrap(I16.to_i64(end) - I16.to_i64(start)))
+				},
 				step: ||
 					if start < end {
 						One(
@@ -3935,7 +3979,11 @@ Builtin :: [].{
 			## ```
 			to : U32, U32 -> Iter(U32)
 			to = |start, end| {
-				len_if_known: if start > end { Known(0) } else { Known(U32.to_u64(end) - U32.to_u64(start) + 1) },
+				len_if_known: if start > end {
+					Known(0)
+				} else {
+					Known(U32.to_u64(end) - U32.to_u64(start) + 1)
+				},
 				step: ||
 					if start <= end {
 						One(
@@ -3968,7 +4016,11 @@ Builtin :: [].{
 			## ```
 			until : U32, U32 -> Iter(U32)
 			until = |start, end| {
-				len_if_known: if start >= end { Known(0) } else { Known(U32.to_u64(end) - U32.to_u64(start)) },
+				len_if_known: if start >= end {
+					Known(0)
+				} else {
+					Known(U32.to_u64(end) - U32.to_u64(start))
+				},
 				step: ||
 					if start < end {
 						One(
@@ -4419,7 +4471,11 @@ Builtin :: [].{
 			## ```
 			to : I32, I32 -> Iter(I32)
 			to = |start, end| {
-				len_if_known: if start > end { Known(0) } else { Known(I64.to_u64_wrap(I32.to_i64(end) - I32.to_i64(start) + 1)) },
+				len_if_known: if start > end {
+					Known(0)
+				} else {
+					Known(I64.to_u64_wrap(I32.to_i64(end) - I32.to_i64(start) + 1))
+				},
 				step: ||
 					if start <= end {
 						One(
@@ -4452,7 +4508,11 @@ Builtin :: [].{
 			## ```
 			until : I32, I32 -> Iter(I32)
 			until = |start, end| {
-				len_if_known: if start >= end { Known(0) } else { Known(I64.to_u64_wrap(I32.to_i64(end) - I32.to_i64(start))) },
+				len_if_known: if start >= end {
+					Known(0)
+				} else {
+					Known(I64.to_u64_wrap(I32.to_i64(end) - I32.to_i64(start)))
+				},
 				step: ||
 					if start < end {
 						One(
@@ -4934,7 +4994,11 @@ Builtin :: [].{
 			## ```
 			until : U64, U64 -> Iter(U64)
 			until = |start, end| {
-				len_if_known: if start >= end { Known(0) } else { Known(end - start) },
+				len_if_known: if start >= end {
+					Known(0)
+				} else {
+					Known(end - start)
+				},
 				step: ||
 					if start < end {
 						One(

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -1903,8 +1903,6 @@ fn processAssociatedItemsSecondPass(
                     // Register the method ident mapping for fast index-based lookup
                     try self.registerAssociatedMethodIdent(parent_name, relative_parent_name, type_name, name_ident, qualified_idx);
 
-                    // Pattern is now available in scope (was created in createAnnoOnlyDef)
-
                     try self.env.store.addScratchDef(def_idx);
                 }
             },
@@ -2287,6 +2285,20 @@ fn processAssociatedItemsFirstPass(
 
                     // Register progressively qualified names at each scope level per the plan
                     try self.registerUserFacingName(qualified_idx, placeholder_pattern_idx);
+
+                    // Also register the bare-type-qualified form (e.g., "U8.to_u64") so that
+                    // sibling methods in the same associated block can call this anno-only
+                    // method by that name during second-pass body canonicalization. The
+                    // decl-with-anno path already adds this alias from inside its second-pass
+                    // branch, but for anno-only methods the existing post-pass runs too late
+                    // (after sibling bodies have already been canonicalized).
+                    const parent_text_for_type = self.env.getIdent(parent_name);
+                    if (std.mem.lastIndexOfScalar(u8, parent_text_for_type, '.')) |last_dot| {
+                        const bare_type_text = parent_text_for_type[last_dot + 1 ..];
+                        const anno_text = self.env.getIdent(anno_ident);
+                        const type_qualified_idx = try self.env.insertQualifiedIdent(bare_type_text, anno_text);
+                        try current_scope.idents.put(self.env.gpa, type_qualified_idx, placeholder_pattern_idx);
+                    }
                 }
             },
             else => {


### PR DESCRIPTION
## Summary

- Adds four new methods to \`Iter\`: \`take_first\`, \`drop_first\`, \`take_last\`, \`drop_last\`.
  - \`take_first(n)\` / \`drop_first(n)\` are lazy with O(1) per step. \`drop_first\` turns each consumed item into a \`Skip\`, so callers don't pay deep recursion for large drops.
  - \`take_last(n)\` / \`drop_last(n)\` use the lazy versions when the source length is \`Known\`, and otherwise materialize through a list (documented in the doc comments).
  - \`len_if_known\` is tracked exactly when the source is \`Known\` and \`Unknown\` otherwise.

- Updates the \`to\` and \`until\` functions on every integer type (\`U8\`/\`I8\`/\`U16\`/\`I16\`/\`U32\`/\`I32\`/\`U64\`/\`I64\`/\`U128\`/\`I128\`) to compute \`len_if_known\` via arithmetic instead of always returning \`Unknown\`.
  - For widths under 64 bits the count always fits in U64 (computed via the existing \`to_u64\` / \`to_i64\` / \`to_u64_wrap\` widening intrinsics).
  - For \`U64\`/\`I64\`/\`U128\`/\`I128\` the implementation uses checked arithmetic and falls back to \`Unknown\` only when \`end - start + 1\` overflows U64 (i.e., the absolute-extreme cases that can't be represented in a U64 length).
  - \`Dec.to\` / \`Dec.until\` are intentionally left as \`Unknown\` — out of scope for this PR.

- One small canonicalizer change in \`Can.zig\` to make all of the above actually compile:
  - The conversion intrinsics (\`U8.to_u64\`, \`I64.to_u64_wrap\`, etc.) are declared as anno-only methods inside their type's associated block. Their \`BuiltinLowLevel.zig\` mappings were already in place, but the canonicalizer's existing alias post-pass for anno-only methods ran *after* sibling bodies were canonicalized, so a call like \`U8.to_u64(end)\` from inside \`U8.to\` couldn't resolve.
  - The first-pass placeholder code now also registers the bare-type-qualified form (e.g. \`U8.to_u64\`) in scope at placeholder-creation time, mirroring what the decl-with-anno path does in its own second-pass branch. The deliberately-omitted unqualified form (\`to_u64\`) would have collided with local bindings like \`len = List.len(list)\` in \`List.iter\`, so I only registered the type-qualified form — which is enough for the call sites in this PR.

## Test plan

- [x] \`zig build\` succeeds
- [x] \`zig build test\` — all 2239 tests pass
- [x] \`zig build test-can\` — passes
- [x] \`zig build snapshot\` — builds cleanly with no snapshot diffs
- [ ] Spot-check a few of the new doc-tests interactively (the \`## expect ...\` blocks on the new methods)