### PR TITLE
Fix transparent alias structure unification

### DIFF
--- a/design.md
+++ b/design.md
@@ -171,6 +171,43 @@ The word `obligation` is banned in new post-check docs and code. Use the exact
 owner instead: checked dispatch plan, erased callable requirement,
 specialization queue entry, or debug assertion.
 
+## Type Alias Invariant
+
+Source type aliases are transparent views of their backing type. An alias root
+in the checked type store records source spelling and alias arguments. It is not
+a nominal type identity, and it is not the authoritative solved representative
+for a concrete structure.
+
+When unification relates an alias to a concrete structure, the checker must
+unify the concrete structure with the alias backing variable directly. It must
+not allocate a replacement alias, redirect the concrete structure to an alias
+root, redirect the alias backing through the alias root, or otherwise make alias
+preservation depend on union-find representative shape. The alias root may
+remain as a transparent checked view whose backing variable carries the solved
+structure.
+
+This invariant also covers the degenerate case where the concrete structure
+variable is already the alias backing variable. That unification is a no-op
+after resolving the backing. Creating a fresh alias representative in that case
+would make the alias backing resolve back to the alias itself, which is an
+invalid self-referential type-store graph.
+
+Any stage that needs alias spelling, source identity, or user-facing checked
+type presentation must consume explicit checked data produced by checking. It
+must not infer that presentation from a union-find representative chosen during
+structural unification. This keeps the producer responsible for checked
+presentation, keeps consumers simple, and keeps release builds fast: no
+alias-content cloning, no substitution-map reconstruction, and no cycle-repair
+walks are part of normal unification.
+
+For an expression or definition with an explicit type annotation, checking first
+proves that the body is compatible with the annotation. After that succeeds,
+the checked root for the expression or definition is the annotation root. The
+body may have constrained the annotation backing type, underscore variables, or
+alias arguments, but references to the annotated value consume the annotation
+root. This is how alias spelling from annotations is preserved without making
+alias roots union-find representatives for concrete structures.
+
 ## Cache Boundary
 
 The checked module cache is the only checked cache boundary in this design.

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -5653,8 +5653,10 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
             // raw expr var against the annotation
             _ = try self.unify(expr_var_raw, anno_vars.anno_var_backup, env);
         } else {
-            // Otherwise, unify the raw var with the intermediate var
-            _ = try self.unify(expr_var_raw, expr_var, env);
+            // Otherwise, make the explicit annotation the checked root for
+            // this expression. The body has already constrained the
+            // annotation's backing and any underscore variables above.
+            _ = try self.unify(expr_var_raw, anno_vars.anno_var, env);
         }
     }
 

--- a/src/check/test/unify_test.zig
+++ b/src/check/test/unify_test.zig
@@ -373,19 +373,21 @@ test "unify - alias with concrete" {
 
     try std.testing.expectEqual(.ok, result);
 
-    // Assert that the alias was preserved
-    const resolved = env.module_env.types.resolveVar(a);
-    try std.testing.expect(resolved.desc.content == .alias);
+    // The alias remains a transparent checked view; the concrete structure
+    // constrains its backing var instead of redirecting to the alias root.
+    const resolved_alias = env.module_env.types.resolveVar(a);
+    try std.testing.expect(resolved_alias.desc.content == .alias);
 
-    // Assert that the alias backing var was preserved
     const resolved_backing = env.module_env.types.resolveVar(
-        env.module_env.types.getAliasBackingVar(resolved.desc.content.alias),
+        env.module_env.types.getAliasBackingVar(resolved_alias.desc.content.alias),
     );
+    const resolved_concrete = env.module_env.types.resolveVar(b);
     try std.testing.expectEqual(Content{ .structure = .empty_record }, resolved_backing.desc.content);
+    try std.testing.expectEqual(resolved_concrete.var_, resolved_backing.var_);
+    try std.testing.expect(resolved_alias.var_ != resolved_backing.var_);
 
-    // Assert that a & b redirect to the alias
-    try std.testing.expectEqual(Slot{ .redirect = resolved.var_ }, env.module_env.types.getSlot(a));
-    try std.testing.expectEqual(Slot{ .redirect = resolved.var_ }, env.module_env.types.getSlot(b));
+    const occurs_result = try occurs.occurs(&env.module_env.types, &env.occurs_scratch, a);
+    try std.testing.expectEqual(.not_recursive, occurs_result);
 }
 
 test "unify - alias with concrete other way" {
@@ -403,19 +405,75 @@ test "unify - alias with concrete other way" {
 
     try std.testing.expectEqual(.ok, result);
 
-    // Assert that the alias was preserved
-    const resolved = env.module_env.types.resolveVar(a);
-    try std.testing.expect(resolved.desc.content == .alias);
+    // The concrete root and alias backing unify; the alias root remains the
+    // source-level checked view.
+    const resolved_alias = env.module_env.types.resolveVar(b);
+    try std.testing.expect(resolved_alias.desc.content == .alias);
 
-    // Assert that the alias backing var was preserved
     const resolved_backing = env.module_env.types.resolveVar(
-        env.module_env.types.getAliasBackingVar(resolved.desc.content.alias),
+        env.module_env.types.getAliasBackingVar(resolved_alias.desc.content.alias),
+    );
+    const resolved_concrete = env.module_env.types.resolveVar(a);
+    try std.testing.expectEqual(Content{ .structure = .empty_record }, resolved_backing.desc.content);
+    try std.testing.expectEqual(resolved_concrete.var_, resolved_backing.var_);
+    try std.testing.expect(resolved_alias.var_ != resolved_backing.var_);
+
+    const occurs_result = try occurs.occurs(&env.module_env.types, &env.occurs_scratch, b);
+    try std.testing.expectEqual(.not_recursive, occurs_result);
+}
+
+test "unify - alias with own backing structure" {
+    const gpa = std.testing.allocator;
+    var env = try TestEnv.init(gpa);
+    defer env.deinit();
+
+    const backing_var = try env.module_env.types.freshFromContent(Content{ .structure = .empty_record });
+    const alias_content = try env.mkAlias("Alias", backing_var, &[_]Var{});
+    const alias_var = try env.module_env.types.freshFromContent(alias_content);
+
+    const result = try env.unify(alias_var, backing_var);
+
+    try std.testing.expectEqual(.ok, result);
+
+    const resolved_alias = env.module_env.types.resolveVar(alias_var);
+    try std.testing.expect(resolved_alias.desc.content == .alias);
+
+    const resolved_backing = env.module_env.types.resolveVar(
+        env.module_env.types.getAliasBackingVar(resolved_alias.desc.content.alias),
     );
     try std.testing.expectEqual(Content{ .structure = .empty_record }, resolved_backing.desc.content);
+    try std.testing.expectEqual(env.module_env.types.resolveVar(backing_var).var_, resolved_backing.var_);
+    try std.testing.expect(resolved_alias.var_ != resolved_backing.var_);
 
-    // Assert that a & b redirect to the alias
-    try std.testing.expectEqual(Slot{ .redirect = resolved.var_ }, env.module_env.types.getSlot(a));
-    try std.testing.expectEqual(Slot{ .redirect = resolved.var_ }, env.module_env.types.getSlot(b));
+    const occurs_result = try occurs.occurs(&env.module_env.types, &env.occurs_scratch, alias_var);
+    try std.testing.expectEqual(.not_recursive, occurs_result);
+}
+
+test "unify - own backing structure with alias" {
+    const gpa = std.testing.allocator;
+    var env = try TestEnv.init(gpa);
+    defer env.deinit();
+
+    const backing_var = try env.module_env.types.freshFromContent(Content{ .structure = .empty_record });
+    const alias_content = try env.mkAlias("Alias", backing_var, &[_]Var{});
+    const alias_var = try env.module_env.types.freshFromContent(alias_content);
+
+    const result = try env.unify(backing_var, alias_var);
+
+    try std.testing.expectEqual(.ok, result);
+
+    const resolved_alias = env.module_env.types.resolveVar(alias_var);
+    try std.testing.expect(resolved_alias.desc.content == .alias);
+
+    const resolved_backing = env.module_env.types.resolveVar(
+        env.module_env.types.getAliasBackingVar(resolved_alias.desc.content.alias),
+    );
+    try std.testing.expectEqual(Content{ .structure = .empty_record }, resolved_backing.desc.content);
+    try std.testing.expectEqual(env.module_env.types.resolveVar(backing_var).var_, resolved_backing.var_);
+    try std.testing.expect(resolved_alias.var_ != resolved_backing.var_);
+
+    const occurs_result = try occurs.occurs(&env.module_env.types, &env.occurs_scratch, alias_var);
+    try std.testing.expectEqual(.not_recursive, occurs_result);
 }
 
 // unification - structure/flex_vars //

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -537,25 +537,10 @@ const Unifier = struct {
                 }
             },
             .structure => {
-                // When unifying an alias with a concrete structure, we
-                // want to preserve the alias for display while ensuring the
-                // types are compatible.
-
-                // First, we unify the concrete var with the alias backing var
-                // IMPORTANT: The arg order here is important! Unifying
-                // updates the second var to hold the type, and the first
-                // var to redirect to the second
+                // Structural aliases are transparent. The concrete structure
+                // constrains the alias backing; alias spelling is checked
+                // presentation data, not union-find representative shape.
                 try self.unifyGuarded(vars.b.var_, backing_var);
-
-                // Next, we create a fresh alias (which internally points to `backing_var`),
-                // then we redirect both a & b to the new alias.
-                const fresh_alias_var = try self.fresh(vars, .{ .alias = a_alias });
-
-                // These redirects are safe because fresh_alias_var is created at min(a_rank, b_rank).
-                // Because of this, we do not loose any rank information.
-                // This is essentially a custom `self.merge` strategy
-                try self.types_store.dangerousSetVarRedirect(vars.a.var_, fresh_alias_var);
-                try self.types_store.dangerousSetVarRedirect(vars.b.var_, fresh_alias_var);
             },
             .err => self.merge(vars, .err),
         }
@@ -634,27 +619,11 @@ const Unifier = struct {
             },
             .rigid => return error.TypeMismatch,
             .alias => |b_alias| {
-                // When unifying an alias with a concrete structure, we
-                // want to preserve the alias for display while ensuring the
-                // types are compatible.
-
                 const backing_var = self.types_store.getAliasBackingVar(b_alias);
-
-                // First, we unify the concrete var with the alias backing var
-                // IMPORTANT: The arg order here is important! Unifying
-                // updates the second var to hold the type, and the first
-                // var to redirect to the second
+                // Structural aliases are transparent. The concrete structure
+                // constrains the alias backing; alias spelling is checked
+                // presentation data, not union-find representative shape.
                 try self.unifyGuarded(vars.a.var_, backing_var);
-
-                // Next, we create a fresh alias (which internally points to `backing_var`),
-                // then we redirect both a & b to the new alias.
-                const fresh_alias_var = try self.fresh(vars, .{ .alias = b_alias });
-
-                // These redirects are safe because fresh_alias_var is created at min(a_rank, b_rank).
-                // Because of this, we do not loose any rank information.
-                // This is essentially a custom `self.merge` strategy
-                try self.types_store.dangerousSetVarRedirect(vars.a.var_, fresh_alias_var);
-                try self.types_store.dangerousSetVarRedirect(vars.b.var_, fresh_alias_var);
             },
             .structure => |b_flat_type| {
                 try self.unifyFlatType(vars, a_flat_type, b_flat_type);

--- a/src/cli/test/roc_subcommands.zig
+++ b/src/cli/test/roc_subcommands.zig
@@ -1716,6 +1716,32 @@ test "roc check does not panic on invalid package shorthand import (issue 9084)"
     try testing.expect(result.stderr.len > 0);
 }
 
+test "roc check does not hang on tag union type alias inside List (issue 9481)" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    // A type alias for a tag union (`Rle(a)`), used as the element type of a `List`,
+    // and then compared with `==` against a list literal, caused the type checker to
+    // build a self-referential alias: the alias backing var redirected back to the
+    // alias var.
+    const result = try util.runRoc(gpa, &.{ "check", "--no-cache" }, "test/cli/tag_union_alias_hang.roc");
+    defer gpa.free(result.stdout);
+    defer gpa.free(result.stderr);
+
+    // The command must not abort/panic (exit code 134 / a signal indicates SIGABRT).
+    const did_panic = result.term == .Signal or (result.term == .Exited and result.term.Exited == 134);
+    try testing.expect(!did_panic);
+
+    // Neither the infinite-loop guard nor the coordinator watchdog should have fired.
+    const has_panic_text = std.mem.indexOf(u8, result.stderr, "panic") != null or
+        std.mem.indexOf(u8, result.stderr, "Coordinator stuck") != null or
+        std.mem.indexOf(u8, result.stderr, "Infinite loop") != null or
+        std.mem.indexOf(u8, result.stderr, "INFINITE TYPE") != null;
+    try testing.expect(!has_panic_text);
+
+    try testing.expect(result.term == .Exited and result.term.Exited == 0);
+}
+
 test "roc check succeeds on Parser type module" {
     const testing = std.testing;
     const gpa = testing.allocator;

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -850,9 +850,9 @@ pub const Store = struct {
     /// * redirect a -> b
     ///
     /// The merge direction (a -> b) is load-bearing and must not be changed.
-    /// Multiple parts of the unification algorithm depend on this specific order:
-    /// - When unifying aliases with structures, we rely on this order to ensure
-    ///   that we don't lose alias context
+    /// Multiple parts of the unification algorithm depend on this specific order.
+    /// Alias spelling is not preserved by choosing an alias representative; source
+    /// alias views stay separate from the concrete solved backing variable.
     ///
     // NOTE: The elm & the roc compiler do this step differently
     // * The elm compiler sets b to redirect to a

--- a/test/cli/tag_union_alias_hang.roc
+++ b/test/cli/tag_union_alias_hang.roc
@@ -1,0 +1,8 @@
+Rle(a) : [One(a), Many(U64, a)]
+
+x : List(Rle(Str))
+x = [One("x")]
+
+test = x == [One("a")]
+
+main! = |_| test

--- a/test/snapshots/eval/record_i64_field_addition.md
+++ b/test/snapshots/eval/record_i64_field_addition.md
@@ -13,21 +13,9 @@ advance = |robot| { ..robot, y: robot.y + 1 }
 expect advance({ x: 7, y: 3 }) == { x: 7, y: 4 }
 ~~~
 # EXPECTED
-INFINITE TYPE - record_i64_field_addition.md:4:1:4:46
+NIL
 # PROBLEMS
-**INFINITE TYPE**
-I am inferring a weird self-referential type:
-**record_i64_field_addition.md:4:1:4:46:**
-```roc
-advance = |robot| { ..robot, y: robot.y + 1 }
-```
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Here is my best effort at writing down the type. You will see `<RecursiveType>` for parts of the type that repeat infinitely.
-
-    Robot
-
-
+NIL
 # TOKENS
 ~~~zig
 UpperIdent,OpColon,OpenCurly,LowerIdent,OpColon,UpperIdent,Comma,LowerIdent,OpColon,UpperIdent,CloseCurly,
@@ -100,7 +88,7 @@ NO CHANGE
 						(p-assign (ident "robot"))))
 				(fields
 					(field (name "y")
-						(e-dispatch-call (method "plus") (constraint-fn-var 125)
+						(e-dispatch-call (method "plus") (constraint-fn-var 124)
 							(receiver
 								(e-field-access (field "y")
 									(receiver
@@ -122,8 +110,9 @@ NO CHANGE
 	(s-expect
 		(e-structural-eq (negated "false")
 			(lhs
-				(e-call (constraint-fn-var 271)
-					(e-runtime-error (tag "erroneous_value_use"))
+				(e-call (constraint-fn-var 268)
+					(e-lookup-local
+						(p-assign (ident "advance")))
 					(e-record
 						(fields
 							(field (name "x")
@@ -142,10 +131,10 @@ NO CHANGE
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "Error")))
+		(patt (type "Robot -> Robot")))
 	(type_decls
 		(alias (type "Robot")
 			(ty-header (name "Robot"))))
 	(expressions
-		(expr (type "Error"))))
+		(expr (type "Robot -> Robot"))))
 ~~~

--- a/test/snapshots/eval/record_i64_field_update.md
+++ b/test/snapshots/eval/record_i64_field_update.md
@@ -18,35 +18,9 @@ expect retreat({ x: 7, y: 3 }) == { x: 7, y: 2 }
 expect advance(retreat({ x: 0, y: 0 })) == { x: 0, y: 0 }
 ~~~
 # EXPECTED
-INFINITE TYPE - record_i64_field_update.md:4:1:4:46
-INFINITE TYPE - record_i64_field_update.md:7:1:7:46
+NIL
 # PROBLEMS
-**INFINITE TYPE**
-I am inferring a weird self-referential type:
-**record_i64_field_update.md:4:1:4:46:**
-```roc
-advance = |robot| { ..robot, y: robot.y + 1 }
-```
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Here is my best effort at writing down the type. You will see `<RecursiveType>` for parts of the type that repeat infinitely.
-
-    Robot
-
-
-**INFINITE TYPE**
-I am inferring a weird self-referential type:
-**record_i64_field_update.md:7:1:7:46:**
-```roc
-retreat = |robot| { ..robot, y: robot.y - 1 }
-```
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Here is my best effort at writing down the type. You will see `<RecursiveType>` for parts of the type that repeat infinitely.
-
-    Robot
-
-
+NIL
 # TOKENS
 ~~~zig
 UpperIdent,OpColon,OpenCurly,LowerIdent,OpColon,UpperIdent,Comma,LowerIdent,OpColon,UpperIdent,CloseCurly,
@@ -171,7 +145,7 @@ NO CHANGE
 						(p-assign (ident "robot"))))
 				(fields
 					(field (name "y")
-						(e-dispatch-call (method "plus") (constraint-fn-var 170)
+						(e-dispatch-call (method "plus") (constraint-fn-var 169)
 							(receiver
 								(e-field-access (field "y")
 									(receiver
@@ -194,7 +168,7 @@ NO CHANGE
 						(p-assign (ident "robot"))))
 				(fields
 					(field (name "y")
-						(e-dispatch-call (method "minus") (constraint-fn-var 327)
+						(e-dispatch-call (method "minus") (constraint-fn-var 324)
 							(receiver
 								(e-field-access (field "y")
 									(receiver
@@ -216,8 +190,9 @@ NO CHANGE
 	(s-expect
 		(e-structural-eq (negated "false")
 			(lhs
-				(e-call (constraint-fn-var 473)
-					(e-runtime-error (tag "erroneous_value_use"))
+				(e-call (constraint-fn-var 468)
+					(e-lookup-local
+						(p-assign (ident "advance")))
 					(e-record
 						(fields
 							(field (name "x")
@@ -234,8 +209,9 @@ NO CHANGE
 	(s-expect
 		(e-structural-eq (negated "false")
 			(lhs
-				(e-call (constraint-fn-var 890)
-					(e-runtime-error (tag "erroneous_value_use"))
+				(e-call (constraint-fn-var 882)
+					(e-lookup-local
+						(p-assign (ident "retreat")))
 					(e-record
 						(fields
 							(field (name "x")
@@ -250,12 +226,14 @@ NO CHANGE
 						(field (name "y")
 							(e-num (value "2"))))))))
 	(s-expect
-		(e-method-eq (negated "false")
+		(e-structural-eq (negated "false")
 			(lhs
-				(e-call (constraint-fn-var 1308)
-					(e-runtime-error (tag "erroneous_value_use"))
-					(e-call (constraint-fn-var 1307)
-						(e-runtime-error (tag "erroneous_value_use"))
+				(e-call (constraint-fn-var 1437)
+					(e-lookup-local
+						(p-assign (ident "advance")))
+					(e-call (constraint-fn-var 1296)
+						(e-lookup-local
+							(p-assign (ident "retreat")))
 						(e-record
 							(fields
 								(field (name "x")
@@ -274,12 +252,12 @@ NO CHANGE
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "Error"))
-		(patt (type "Error")))
+		(patt (type "Robot -> Robot"))
+		(patt (type "Robot -> Robot")))
 	(type_decls
 		(alias (type "Robot")
 			(ty-header (name "Robot"))))
 	(expressions
-		(expr (type "Error"))
-		(expr (type "Error"))))
+		(expr (type "Robot -> Robot"))
+		(expr (type "Robot -> Robot"))))
 ~~~

--- a/test/snapshots/eval/robot_simulator_i64.md
+++ b/test/snapshots/eval/robot_simulator_i64.md
@@ -26,63 +26,9 @@ expect retreat_x({ x: 0, y: 0 }) == { x: -1, y: 0 }
 expect advance_y(retreat_y({ x: 5, y: 5 })) == { x: 5, y: 5 }
 ~~~
 # EXPECTED
-INFINITE TYPE - robot_simulator_i64.md:4:1:4:48
-INFINITE TYPE - robot_simulator_i64.md:7:1:7:48
-INFINITE TYPE - robot_simulator_i64.md:10:1:10:48
-INFINITE TYPE - robot_simulator_i64.md:13:1:13:48
+NIL
 # PROBLEMS
-**INFINITE TYPE**
-I am inferring a weird self-referential type:
-**robot_simulator_i64.md:4:1:4:48:**
-```roc
-advance_y = |robot| { ..robot, y: robot.y + 1 }
-```
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Here is my best effort at writing down the type. You will see `<RecursiveType>` for parts of the type that repeat infinitely.
-
-    Robot
-
-
-**INFINITE TYPE**
-I am inferring a weird self-referential type:
-**robot_simulator_i64.md:7:1:7:48:**
-```roc
-retreat_y = |robot| { ..robot, y: robot.y - 1 }
-```
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Here is my best effort at writing down the type. You will see `<RecursiveType>` for parts of the type that repeat infinitely.
-
-    Robot
-
-
-**INFINITE TYPE**
-I am inferring a weird self-referential type:
-**robot_simulator_i64.md:10:1:10:48:**
-```roc
-advance_x = |robot| { ..robot, x: robot.x + 1 }
-```
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Here is my best effort at writing down the type. You will see `<RecursiveType>` for parts of the type that repeat infinitely.
-
-    Robot
-
-
-**INFINITE TYPE**
-I am inferring a weird self-referential type:
-**robot_simulator_i64.md:13:1:13:48:**
-```roc
-retreat_x = |robot| { ..robot, x: robot.x - 1 }
-```
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Here is my best effort at writing down the type. You will see `<RecursiveType>` for parts of the type that repeat infinitely.
-
-    Robot
-
-
+NIL
 # TOKENS
 ~~~zig
 UpperIdent,OpColon,OpenCurly,LowerIdent,OpColon,UpperIdent,Comma,LowerIdent,OpColon,UpperIdent,CloseCurly,
@@ -277,7 +223,7 @@ NO CHANGE
 						(p-assign (ident "robot"))))
 				(fields
 					(field (name "y")
-						(e-dispatch-call (method "plus") (constraint-fn-var 228)
+						(e-dispatch-call (method "plus") (constraint-fn-var 227)
 							(receiver
 								(e-field-access (field "y")
 									(receiver
@@ -300,7 +246,7 @@ NO CHANGE
 						(p-assign (ident "robot"))))
 				(fields
 					(field (name "y")
-						(e-dispatch-call (method "minus") (constraint-fn-var 385)
+						(e-dispatch-call (method "minus") (constraint-fn-var 382)
 							(receiver
 								(e-field-access (field "y")
 									(receiver
@@ -323,7 +269,7 @@ NO CHANGE
 						(p-assign (ident "robot"))))
 				(fields
 					(field (name "x")
-						(e-dispatch-call (method "plus") (constraint-fn-var 542)
+						(e-dispatch-call (method "plus") (constraint-fn-var 537)
 							(receiver
 								(e-field-access (field "x")
 									(receiver
@@ -346,7 +292,7 @@ NO CHANGE
 						(p-assign (ident "robot"))))
 				(fields
 					(field (name "x")
-						(e-dispatch-call (method "minus") (constraint-fn-var 699)
+						(e-dispatch-call (method "minus") (constraint-fn-var 692)
 							(receiver
 								(e-field-access (field "x")
 									(receiver
@@ -368,8 +314,9 @@ NO CHANGE
 	(s-expect
 		(e-structural-eq (negated "false")
 			(lhs
-				(e-call (constraint-fn-var 845)
-					(e-runtime-error (tag "erroneous_value_use"))
+				(e-call (constraint-fn-var 836)
+					(e-lookup-local
+						(p-assign (ident "advance_y")))
 					(e-record
 						(fields
 							(field (name "x")
@@ -386,8 +333,9 @@ NO CHANGE
 	(s-expect
 		(e-structural-eq (negated "false")
 			(lhs
-				(e-call (constraint-fn-var 1262)
-					(e-runtime-error (tag "erroneous_value_use"))
+				(e-call (constraint-fn-var 1250)
+					(e-lookup-local
+						(p-assign (ident "retreat_y")))
 					(e-record
 						(fields
 							(field (name "x")
@@ -404,8 +352,9 @@ NO CHANGE
 	(s-expect
 		(e-structural-eq (negated "false")
 			(lhs
-				(e-call (constraint-fn-var 1679)
-					(e-runtime-error (tag "erroneous_value_use"))
+				(e-call (constraint-fn-var 1664)
+					(e-lookup-local
+						(p-assign (ident "advance_x")))
 					(e-record
 						(fields
 							(field (name "x")
@@ -422,8 +371,9 @@ NO CHANGE
 	(s-expect
 		(e-structural-eq (negated "false")
 			(lhs
-				(e-call (constraint-fn-var 2096)
-					(e-runtime-error (tag "erroneous_value_use"))
+				(e-call (constraint-fn-var 2078)
+					(e-lookup-local
+						(p-assign (ident "retreat_x")))
 					(e-record
 						(fields
 							(field (name "x")
@@ -438,12 +388,14 @@ NO CHANGE
 						(field (name "y")
 							(e-num (value "0"))))))))
 	(s-expect
-		(e-method-eq (negated "false")
+		(e-structural-eq (negated "false")
 			(lhs
-				(e-call (constraint-fn-var 2514)
-					(e-runtime-error (tag "erroneous_value_use"))
-					(e-call (constraint-fn-var 2513)
-						(e-runtime-error (tag "erroneous_value_use"))
+				(e-call (constraint-fn-var 2633)
+					(e-lookup-local
+						(p-assign (ident "advance_y")))
+					(e-call (constraint-fn-var 2492)
+						(e-lookup-local
+							(p-assign (ident "retreat_y")))
 						(e-record
 							(fields
 								(field (name "x")
@@ -462,16 +414,16 @@ NO CHANGE
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "Error"))
-		(patt (type "Error"))
-		(patt (type "Error"))
-		(patt (type "Error")))
+		(patt (type "Robot -> Robot"))
+		(patt (type "Robot -> Robot"))
+		(patt (type "Robot -> Robot"))
+		(patt (type "Robot -> Robot")))
 	(type_decls
 		(alias (type "Robot")
 			(ty-header (name "Robot"))))
 	(expressions
-		(expr (type "Error"))
-		(expr (type "Error"))
-		(expr (type "Error"))
-		(expr (type "Error"))))
+		(expr (type "Robot -> Robot"))
+		(expr (type "Robot -> Robot"))
+		(expr (type "Robot -> Robot"))
+		(expr (type "Robot -> Robot"))))
 ~~~

--- a/test/snapshots/test_exact_pattern_crash.md
+++ b/test/snapshots/test_exact_pattern_crash.md
@@ -249,12 +249,12 @@ main = {
 				(p-assign (ident "g")))
 			(e-tuple
 				(elems
-					(e-call (constraint-fn-var 124)
+					(e-call (constraint-fn-var 121)
 						(e-lookup-local
 							(p-assign (ident "f")))
 						(e-lookup-local
 							(p-assign (ident "x"))))
-					(e-call (constraint-fn-var 125)
+					(e-call (constraint-fn-var 122)
 						(e-lookup-local
 							(p-assign (ident "g")))
 						(e-lookup-local
@@ -280,7 +280,7 @@ main = {
 		(e-block
 			(s-let
 				(p-assign (ident "p1"))
-				(e-call (constraint-fn-var 195)
+				(e-call (constraint-fn-var 190)
 					(e-lookup-local
 						(p-assign (ident "swap_pair")))
 					(e-tuple
@@ -289,7 +289,7 @@ main = {
 							(e-num (value "2"))))))
 			(s-let
 				(p-assign (ident "p2"))
-				(e-call (constraint-fn-var 333)
+				(e-call (constraint-fn-var 328)
 					(e-lookup-local
 						(p-assign (ident "map_pair")))
 					(e-num (value "3"))
@@ -297,7 +297,7 @@ main = {
 					(e-lambda
 						(args
 							(p-assign (ident "x")))
-						(e-dispatch-call (method "plus") (constraint-fn-var 297)
+						(e-dispatch-call (method "plus") (constraint-fn-var 292)
 							(receiver
 								(e-lookup-local
 									(p-assign (ident "x"))))
@@ -306,7 +306,7 @@ main = {
 					(e-lambda
 						(args
 							(p-assign (ident "y")))
-						(e-dispatch-call (method "times") (constraint-fn-var 329)
+						(e-dispatch-call (method "times") (constraint-fn-var 324)
 							(receiver
 								(e-lookup-local
 									(p-assign (ident "y"))))

--- a/test/snapshots/type_alias_decl.md
+++ b/test/snapshots/type_alias_decl.md
@@ -373,7 +373,7 @@ main! = |_| {
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "_arg -> U64")))
+		(patt (type "_arg -> UserId")))
 	(type_decls
 		(alias (type "UserId")
 			(ty-header (name "UserId")))
@@ -402,5 +402,5 @@ main! = |_| {
 				(ty-args
 					(ty-rigid-var (name "item"))))))
 	(expressions
-		(expr (type "_arg -> U64"))))
+		(expr (type "_arg -> UserId"))))
 ~~~

--- a/test/snapshots/type_alias_parameterized.md
+++ b/test/snapshots/type_alias_parameterized.md
@@ -125,7 +125,7 @@ NO CHANGE
 		(e-lambda
 			(args
 				(p-underscore))
-			(e-call (constraint-fn-var 123)
+			(e-call (constraint-fn-var 121)
 				(e-lookup-local
 					(p-assign (ident "swapPair")))
 				(e-num (value "1"))

--- a/test/snapshots/type_multiple_aliases.md
+++ b/test/snapshots/type_multiple_aliases.md
@@ -184,14 +184,14 @@ NO CHANGE
 			(e-block
 				(s-let
 					(p-assign (ident "user"))
-					(e-call (constraint-fn-var 270)
+					(e-call (constraint-fn-var 267)
 						(e-lookup-local
 							(p-assign (ident "create_user")))
 						(e-num (value "123"))
 						(e-string
 							(e-literal (string "Alice")))
 						(e-num (value "25"))))
-				(e-call (constraint-fn-var 411)
+				(e-call (constraint-fn-var 408)
 					(e-lookup-local
 						(p-assign (ident "get_user_name")))
 					(e-lookup-local


### PR DESCRIPTION
## Summary
- Make alias-vs-structure unification constrain the alias backing directly instead of creating a fresh alias representative.
- Preserve explicit annotation alias spelling by using the annotation root after compatibility is proven.
- Add the tag-union alias/List equality regression and update snapshots that no longer report false infinite types.

## Tests
- zig build minici

Closes #9841