### PR TITLE
Warn on private nominal types in public type surfaces

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -984,10 +984,15 @@ fn processTypeDeclFirstPass(
 
     // Process type parameters and annotation in a separate scope
     const anno_idx = blk: {
+        var associated_type_scope_entered = false;
+        defer if (associated_type_scope_entered) {
+            self.scopeExit(self.env.gpa) catch unreachable;
+        };
+
         if (type_decl.associated) |assoc| {
             try self.predeclareAssociatedTypePlaceholders(qualified_name_idx, relative_name_idx, assoc.statements);
             try self.scopeEnter(self.env.gpa, false);
-            defer self.scopeExit(self.env.gpa) catch unreachable;
+            associated_type_scope_entered = true;
             try self.introduceImmediateAssociatedTypeAliases(qualified_name_idx, relative_name_idx, assoc.statements);
         }
 
@@ -1104,10 +1109,15 @@ fn processTypeDeclFirstPassWithExisting(
 
     // Process type parameters and annotation in a separate scope
     const anno_idx = blk: {
+        var associated_type_scope_entered = false;
+        defer if (associated_type_scope_entered) {
+            self.scopeExit(self.env.gpa) catch unreachable;
+        };
+
         if (type_decl.associated) |assoc| {
             try self.predeclareAssociatedTypePlaceholders(qualified_name_idx, relative_name_idx, assoc.statements);
             try self.scopeEnter(self.env.gpa, false);
-            defer self.scopeExit(self.env.gpa) catch unreachable;
+            associated_type_scope_entered = true;
             try self.introduceImmediateAssociatedTypeAliases(qualified_name_idx, relative_name_idx, assoc.statements);
         }
 

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -3254,6 +3254,7 @@ pub fn canonicalizeFile(
 
     // Check for exposed but not implemented items
     try self.checkExposedButNotImplemented();
+    try self.checkExposedTypeSurfaces();
 
     // Add local type declarations to all_statements
     for (self.scratch_local_type_decls.items) |stmt_idx| {
@@ -4173,6 +4174,368 @@ fn checkExposedButNotImplemented(self: *Self) std.mem.Allocator.Error!void {
             .ident = ident_idx,
             .region = region,
         } });
+    }
+}
+
+const TypeSurfaceFrame = struct {
+    anno: TypeAnno.Idx,
+    field_name: ?Ident.Idx,
+    surface_region: ?Region,
+};
+
+const TypeSurfaceAliasUse = struct {
+    decl_idx: Statement.Idx,
+    surface_start: u32,
+    surface_end: u32,
+};
+
+const PublicTypeRoot = struct {
+    stmt_idx: Statement.Idx,
+    relative_name: Ident.Idx,
+};
+
+fn checkExposedTypeSurfaces(self: *Self) std.mem.Allocator.Error!void {
+    const gpa = self.env.gpa;
+
+    var public_type_decls: std.AutoHashMapUnmanaged(Statement.Idx, void) = .{};
+    defer public_type_decls.deinit(gpa);
+
+    var public_roots = std.ArrayList(PublicTypeRoot){};
+    defer public_roots.deinit(gpa);
+
+    var exposed_type_iter = self.exposed_types.iterator();
+    while (exposed_type_iter.next()) |entry| {
+        try self.addPublicTypeRoot(entry.key_ptr.*, &public_roots, &public_type_decls);
+    }
+
+    switch (self.env.module_kind) {
+        .type_module => |main_type| try self.addPublicTypeRoot(main_type, &public_roots, &public_type_decls),
+        else => {},
+    }
+
+    if (public_roots.items.len == 0) return;
+
+    var exposed_iter = self.env.common.exposed_items.iterator();
+    while (exposed_iter.next()) |entry| {
+        const stmt_idx = self.exposedTypeDeclStatementIdx(entry.node_idx) orelse continue;
+        const header = self.typeDeclHeader(stmt_idx) orelse continue;
+        if (!self.typeIsAtOrUnderPublicRoot(header.relative_name, public_roots.items)) continue;
+
+        try public_type_decls.put(gpa, stmt_idx, {});
+    }
+
+    var checked_public_nominals: std.AutoHashMapUnmanaged(Statement.Idx, void) = .{};
+    defer checked_public_nominals.deinit(gpa);
+
+    exposed_iter = self.env.common.exposed_items.iterator();
+    while (exposed_iter.next()) |entry| {
+        const stmt_idx = self.exposedTypeDeclStatementIdx(entry.node_idx) orelse continue;
+        if (!public_type_decls.contains(stmt_idx)) continue;
+
+        try self.checkPublicNominalStatementSurface(
+            stmt_idx,
+            &public_type_decls,
+            &checked_public_nominals,
+        );
+    }
+
+    for (public_roots.items) |root| {
+        try self.checkPublicNominalStatementSurface(
+            root.stmt_idx,
+            &public_type_decls,
+            &checked_public_nominals,
+        );
+    }
+}
+
+fn addPublicTypeRoot(
+    self: *Self,
+    type_name: Ident.Idx,
+    public_roots: *std.ArrayList(PublicTypeRoot),
+    public_type_decls: *std.AutoHashMapUnmanaged(Statement.Idx, void),
+) std.mem.Allocator.Error!void {
+    const stmt_idx = blk: {
+        if (self.env.getExposedNodeIndexById(type_name)) |node_idx| {
+            if (self.exposedTypeDeclStatementIdx(node_idx)) |stmt_idx| break :blk stmt_idx;
+        }
+        break :blk self.scopeLookupTypeDecl(type_name) orelse return;
+    };
+
+    const header = self.typeDeclHeader(stmt_idx) orelse return;
+    if (public_type_decls.contains(stmt_idx)) return;
+
+    try public_type_decls.put(self.env.gpa, stmt_idx, {});
+    try public_roots.append(self.env.gpa, .{
+        .stmt_idx = stmt_idx,
+        .relative_name = header.relative_name,
+    });
+}
+
+fn exposedTypeDeclStatementIdx(self: *Self, node_idx_u32: u32) ?Statement.Idx {
+    if (node_idx_u32 == 0 or node_idx_u32 >= self.env.store.nodes.len()) return null;
+
+    const node_idx: Node.Idx = @enumFromInt(node_idx_u32);
+    return switch (self.env.store.nodes.get(node_idx).tag) {
+        .statement_alias_decl, .statement_nominal_decl => @enumFromInt(node_idx_u32),
+        else => null,
+    };
+}
+
+fn typeDeclHeader(self: *Self, stmt_idx: Statement.Idx) ?CIR.TypeHeader {
+    return switch (self.env.store.getStatement(stmt_idx)) {
+        .s_alias_decl => |alias| self.env.store.getTypeHeader(alias.header),
+        .s_nominal_decl => |nominal| self.env.store.getTypeHeader(nominal.header),
+        else => null,
+    };
+}
+
+fn typeIsAtOrUnderPublicRoot(
+    self: *Self,
+    relative_name: Ident.Idx,
+    public_roots: []const PublicTypeRoot,
+) bool {
+    const relative_text = self.env.getIdent(relative_name);
+
+    for (public_roots) |root| {
+        if (relative_name.eql(root.relative_name)) return true;
+
+        const root_text = self.env.getIdent(root.relative_name);
+        if (relative_text.len > root_text.len and
+            relative_text[root_text.len] == '.' and
+            std.mem.startsWith(u8, relative_text, root_text))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+fn checkPublicNominalStatementSurface(
+    self: *Self,
+    stmt_idx: Statement.Idx,
+    public_type_decls: *const std.AutoHashMapUnmanaged(Statement.Idx, void),
+    checked_public_nominals: *std.AutoHashMapUnmanaged(Statement.Idx, void),
+) std.mem.Allocator.Error!void {
+    if (checked_public_nominals.contains(stmt_idx)) return;
+    try checked_public_nominals.put(self.env.gpa, stmt_idx, {});
+
+    const nominal = switch (self.env.store.getStatement(stmt_idx)) {
+        .s_nominal_decl => |decl| decl,
+        else => return,
+    };
+    if (nominal.is_opaque) return;
+
+    const header = self.env.store.getTypeHeader(nominal.header);
+    try self.checkPublicNominalTypeSurface(header.name, nominal.anno, public_type_decls);
+}
+
+fn checkPublicNominalTypeSurface(
+    self: *Self,
+    exposed_type: Ident.Idx,
+    root_anno: TypeAnno.Idx,
+    exposed_type_decls: *const std.AutoHashMapUnmanaged(Statement.Idx, void),
+) std.mem.Allocator.Error!void {
+    const gpa = self.env.gpa;
+
+    var stack = std.ArrayList(TypeSurfaceFrame){};
+    defer stack.deinit(gpa);
+    try stack.append(gpa, .{
+        .anno = root_anno,
+        .field_name = null,
+        .surface_region = null,
+    });
+
+    var visited_alias_uses: std.AutoHashMapUnmanaged(TypeSurfaceAliasUse, void) = .{};
+    defer visited_alias_uses.deinit(gpa);
+
+    while (stack.pop()) |frame| {
+        switch (self.env.store.getTypeAnno(frame.anno)) {
+            .lookup => |lookup| {
+                const lookup_region = self.env.store.getTypeAnnoRegion(frame.anno);
+                try self.checkPublicTypeSurfaceBase(
+                    exposed_type,
+                    lookup.base,
+                    frame.field_name,
+                    frame.surface_region,
+                    lookup_region,
+                    exposed_type_decls,
+                    &visited_alias_uses,
+                    &stack,
+                );
+            },
+            .apply => |apply| {
+                const lookup_region = self.env.store.getTypeAnnoRegion(frame.anno);
+                const args = self.env.store.sliceTypeAnnos(apply.args);
+                var i = args.len;
+                while (i > 0) {
+                    i -= 1;
+                    try stack.append(gpa, .{
+                        .anno = args[i],
+                        .field_name = frame.field_name,
+                        .surface_region = frame.surface_region,
+                    });
+                }
+                try self.checkPublicTypeSurfaceBase(
+                    exposed_type,
+                    apply.base,
+                    frame.field_name,
+                    frame.surface_region,
+                    lookup_region,
+                    exposed_type_decls,
+                    &visited_alias_uses,
+                    &stack,
+                );
+            },
+            .record => |record| {
+                if (record.ext) |ext| {
+                    try stack.append(gpa, .{
+                        .anno = ext,
+                        .field_name = frame.field_name,
+                        .surface_region = frame.surface_region,
+                    });
+                }
+
+                const fields = self.env.store.sliceAnnoRecordFields(record.fields);
+                var i = fields.len;
+                while (i > 0) {
+                    i -= 1;
+                    const field = self.env.store.getAnnoRecordField(fields[i]);
+                    try stack.append(gpa, .{
+                        .anno = field.ty,
+                        .field_name = field.name,
+                        .surface_region = frame.surface_region,
+                    });
+                }
+            },
+            .tag_union => |tag_union| {
+                if (tag_union.ext) |ext| {
+                    try stack.append(gpa, .{
+                        .anno = ext,
+                        .field_name = frame.field_name,
+                        .surface_region = frame.surface_region,
+                    });
+                }
+
+                const tags = self.env.store.sliceTypeAnnos(tag_union.tags);
+                var i = tags.len;
+                while (i > 0) {
+                    i -= 1;
+                    try stack.append(gpa, .{
+                        .anno = tags[i],
+                        .field_name = frame.field_name,
+                        .surface_region = frame.surface_region,
+                    });
+                }
+            },
+            .tag => |tag| {
+                const args = self.env.store.sliceTypeAnnos(tag.args);
+                var i = args.len;
+                while (i > 0) {
+                    i -= 1;
+                    try stack.append(gpa, .{
+                        .anno = args[i],
+                        .field_name = frame.field_name,
+                        .surface_region = frame.surface_region,
+                    });
+                }
+            },
+            .tuple => |tuple| {
+                const elems = self.env.store.sliceTypeAnnos(tuple.elems);
+                var i = elems.len;
+                while (i > 0) {
+                    i -= 1;
+                    try stack.append(gpa, .{
+                        .anno = elems[i],
+                        .field_name = frame.field_name,
+                        .surface_region = frame.surface_region,
+                    });
+                }
+            },
+            .@"fn" => |func| {
+                try stack.append(gpa, .{
+                    .anno = func.ret,
+                    .field_name = frame.field_name,
+                    .surface_region = frame.surface_region,
+                });
+
+                const args = self.env.store.sliceTypeAnnos(func.args);
+                var i = args.len;
+                while (i > 0) {
+                    i -= 1;
+                    try stack.append(gpa, .{
+                        .anno = args[i],
+                        .field_name = frame.field_name,
+                        .surface_region = frame.surface_region,
+                    });
+                }
+            },
+            .parens => |parens| {
+                try stack.append(gpa, .{
+                    .anno = parens.anno,
+                    .field_name = frame.field_name,
+                    .surface_region = frame.surface_region,
+                });
+            },
+            .rigid_var, .rigid_var_lookup, .underscore, .malformed => {},
+        }
+    }
+}
+
+fn checkPublicTypeSurfaceBase(
+    self: *Self,
+    exposed_type: Ident.Idx,
+    type_base: TypeAnno.LocalOrExternal,
+    field_name: ?Ident.Idx,
+    surface_region: ?Region,
+    lookup_region: Region,
+    exposed_type_decls: *const std.AutoHashMapUnmanaged(Statement.Idx, void),
+    visited_alias_uses: *std.AutoHashMapUnmanaged(TypeSurfaceAliasUse, void),
+    stack: *std.ArrayList(TypeSurfaceFrame),
+) std.mem.Allocator.Error!void {
+    const local = switch (type_base) {
+        .local => |local| local,
+        .builtin, .external, .pending => return,
+    };
+
+    const stmt = self.env.store.getStatement(local.decl_idx);
+    switch (stmt) {
+        .s_nominal_decl => |nominal| {
+            if (exposed_type_decls.contains(local.decl_idx)) return;
+
+            const private_header = self.env.store.getTypeHeader(nominal.header);
+            const diagnostic_region = surface_region orelse lookup_region;
+            if (field_name) |field| {
+                try self.env.pushDiagnostic(.{ .private_type_in_exposed_field = .{
+                    .exposed_type = exposed_type,
+                    .field_name = field,
+                    .private_type = private_header.name,
+                    .region = diagnostic_region,
+                } });
+            } else {
+                try self.env.pushDiagnostic(.{ .private_type_in_exposed_type = .{
+                    .exposed_type = exposed_type,
+                    .private_type = private_header.name,
+                    .region = diagnostic_region,
+                } });
+            }
+        },
+        .s_alias_decl => |alias| {
+            const alias_surface_region = surface_region orelse lookup_region;
+            const alias_use = TypeSurfaceAliasUse{
+                .decl_idx = local.decl_idx,
+                .surface_start = alias_surface_region.start.offset,
+                .surface_end = alias_surface_region.end.offset,
+            };
+            if (visited_alias_uses.contains(alias_use)) return;
+            try visited_alias_uses.put(self.env.gpa, alias_use, {});
+            try stack.append(self.env.gpa, .{
+                .anno = alias.anno,
+                .field_name = field_name,
+                .surface_region = alias_surface_region,
+            });
+        },
+        else => {},
     }
 }
 

--- a/src/canonicalize/Diagnostic.zig
+++ b/src/canonicalize/Diagnostic.zig
@@ -154,6 +154,17 @@ pub const Diagnostic = union(enum) {
         type_name: Ident.Idx,
         region: Region,
     },
+    private_type_in_exposed_type: struct {
+        exposed_type: Ident.Idx,
+        private_type: Ident.Idx,
+        region: Region,
+    },
+    private_type_in_exposed_field: struct {
+        exposed_type: Ident.Idx,
+        field_name: Ident.Idx,
+        private_type: Ident.Idx,
+        region: Region,
+    },
     type_from_missing_module: struct {
         module_name: Ident.Idx,
         type_name: Ident.Idx,
@@ -367,6 +378,8 @@ pub const Diagnostic = union(enum) {
             .module_not_found => |d| d.region,
             .value_not_exposed => |d| d.region,
             .type_not_exposed => |d| d.region,
+            .private_type_in_exposed_type => |d| d.region,
+            .private_type_in_exposed_field => |d| d.region,
             .type_from_missing_module => |d| d.region,
             .module_not_imported => |d| d.region,
             .nested_type_not_found => |d| d.region,

--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -1725,6 +1725,103 @@ pub fn diagnosticToReport(self: *Self, diagnostic: CIR.Diagnostic, allocator: st
 
             break :blk report;
         },
+        .private_type_in_exposed_type => |data| blk: {
+            const region_info = self.calcRegionInfo(data.region);
+
+            var report = Report.init(allocator, "PRIVATE TYPE IN EXPOSED TYPE", .warning);
+            const exposed_type = try report.addOwnedString(self.getIdent(data.exposed_type));
+            const private_type = try report.addOwnedString(self.getIdent(data.private_type));
+
+            try report.document.addReflowingText("The exposed type ");
+            try report.document.addType(exposed_type);
+            try report.document.addReflowingText(" refers to ");
+            try report.document.addType(private_type);
+            try report.document.addReflowingText(", but ");
+            try report.document.addType(private_type);
+            try report.document.addReflowingText(" is private to this module.");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+
+            try report.document.addReflowingText("Other modules can see ");
+            try report.document.addType(exposed_type);
+            try report.document.addReflowingText("'s public shape, but they cannot name this private type.");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+
+            try report.document.addReflowingText("It's referenced here:");
+            try report.document.addLineBreak();
+            const owned_filename = try report.addOwnedString(filename);
+            try report.document.addSourceRegion(
+                region_info,
+                .warning_highlight,
+                owned_filename,
+                self.getSourceAll(),
+                self.getLineStartsAll(),
+            );
+
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            try report.document.addAnnotated("Hint:", .emphasized);
+            try report.document.addReflowingText(" Expose the referenced type, make ");
+            try report.document.addType(exposed_type);
+            try report.document.addReflowingText(" opaque with ");
+            try report.document.addInlineCode("::");
+            try report.document.addReflowingText(", or move the type into ");
+            try report.document.addType(exposed_type);
+            try report.document.addReflowingText("'s associated block.");
+
+            break :blk report;
+        },
+        .private_type_in_exposed_field => |data| blk: {
+            const region_info = self.calcRegionInfo(data.region);
+
+            var report = Report.init(allocator, "PRIVATE TYPE IN EXPOSED FIELD", .warning);
+            const exposed_type = try report.addOwnedString(self.getIdent(data.exposed_type));
+            const field_name = try report.addOwnedString(self.getIdent(data.field_name));
+            const private_type = try report.addOwnedString(self.getIdent(data.private_type));
+
+            try report.document.addReflowingText("The ");
+            try report.document.addUnqualifiedSymbol(field_name);
+            try report.document.addReflowingText(" field of ");
+            try report.document.addType(exposed_type);
+            try report.document.addReflowingText(" refers to ");
+            try report.document.addType(private_type);
+            try report.document.addReflowingText(", but ");
+            try report.document.addType(private_type);
+            try report.document.addReflowingText(" is private to this module.");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+
+            try report.document.addReflowingText("Other modules can see this field because ");
+            try report.document.addType(exposed_type);
+            try report.document.addReflowingText(" is exposed and not opaque, but they cannot name this private type.");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+
+            try report.document.addReflowingText("It's referenced here:");
+            try report.document.addLineBreak();
+            const owned_filename = try report.addOwnedString(filename);
+            try report.document.addSourceRegion(
+                region_info,
+                .warning_highlight,
+                owned_filename,
+                self.getSourceAll(),
+                self.getLineStartsAll(),
+            );
+
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            try report.document.addAnnotated("Hint:", .emphasized);
+            try report.document.addReflowingText(" Expose the referenced type, make ");
+            try report.document.addType(exposed_type);
+            try report.document.addReflowingText(" opaque with ");
+            try report.document.addInlineCode("::");
+            try report.document.addReflowingText(", or move the type into ");
+            try report.document.addType(exposed_type);
+            try report.document.addReflowingText("'s associated block.");
+
+            break :blk report;
+        },
         .type_from_missing_module => |data| blk: {
             const region_info = self.calcRegionInfo(data.region);
 

--- a/src/canonicalize/Node.zig
+++ b/src/canonicalize/Node.zig
@@ -229,6 +229,8 @@ pub const Tag = enum {
     diag_module_not_found,
     diag_value_not_exposed,
     diag_type_not_exposed,
+    diag_private_type_in_exposed_type,
+    diag_private_type_in_exposed_field,
     diag_type_from_missing_module,
     diag_module_not_imported,
     diag_nested_type_not_found,
@@ -371,6 +373,7 @@ pub const Payload = extern union {
     diag_single_ident: DiagSingleIdent,
     diag_single_value: DiagSingleValue,
     diag_two_idents: DiagTwoIdents,
+    diag_three_idents: DiagThreeIdents,
     diag_ident_with_region: DiagIdentWithRegion,
     diag_two_idents_extra: DiagTwoIdentsExtra,
     diag_single_ident_extra: DiagSingleIdentExtra,
@@ -999,6 +1002,14 @@ pub const Payload = extern union {
         ident1: u32, // @bitCast(Ident.Idx)
         ident2: u32, // @bitCast(Ident.Idx)
         _padding: [4]u8 = .{ 0, 0, 0, 0 },
+    };
+
+    /// Diagnostics with three identifiers.
+    /// Used by: diag_private_type_in_exposed_field
+    pub const DiagThreeIdents = extern struct {
+        ident1: u32, // @bitCast(Ident.Idx)
+        ident2: u32, // @bitCast(Ident.Idx)
+        ident3: u32, // @bitCast(Ident.Idx)
     };
 
     /// Diagnostics with an identifier and inline region offsets.

--- a/src/canonicalize/NodeStore.zig
+++ b/src/canonicalize/NodeStore.zig
@@ -303,7 +303,7 @@ pub fn relocate(store: *NodeStore, offset: isize) void {
 /// when adding/removing variants from ModuleEnv unions. Update these when modifying the unions.
 ///
 /// Count of the diagnostic nodes in the ModuleEnv
-pub const MODULEENV_DIAGNOSTIC_NODE_COUNT = 73;
+pub const MODULEENV_DIAGNOSTIC_NODE_COUNT = 75;
 /// Count of the expression nodes in the ModuleEnv
 pub const MODULEENV_EXPR_NODE_COUNT = 51;
 /// Count of the statement nodes in the ModuleEnv
@@ -3739,6 +3739,16 @@ pub fn addDiagnostic(store: *NodeStore, reason: CIR.Diagnostic) Allocator.Error!
             region = r.region;
             node.setPayload(.{ .diag_two_idents = .{ .ident1 = @bitCast(r.module_name), .ident2 = @bitCast(r.type_name) } });
         },
+        .private_type_in_exposed_type => |r| {
+            node.tag = .diag_private_type_in_exposed_type;
+            region = r.region;
+            node.setPayload(.{ .diag_two_idents = .{ .ident1 = @bitCast(r.exposed_type), .ident2 = @bitCast(r.private_type) } });
+        },
+        .private_type_in_exposed_field => |r| {
+            node.tag = .diag_private_type_in_exposed_field;
+            region = r.region;
+            node.setPayload(.{ .diag_three_idents = .{ .ident1 = @bitCast(r.exposed_type), .ident2 = @bitCast(r.field_name), .ident3 = @bitCast(r.private_type) } });
+        },
         .type_from_missing_module => |r| {
             node.tag = .diag_type_from_missing_module;
             region = r.region;
@@ -4060,6 +4070,23 @@ pub fn getDiagnostic(store: *const NodeStore, diagnostic: CIR.Diagnostic.Idx) CI
             return CIR.Diagnostic{ .type_not_exposed = .{
                 .module_name = @as(base.Ident.Idx, @bitCast(p.ident1)),
                 .type_name = @as(base.Ident.Idx, @bitCast(p.ident2)),
+                .region = store.getRegionAt(node_idx),
+            } };
+        },
+        .diag_private_type_in_exposed_type => {
+            const p = payload.diag_two_idents;
+            return CIR.Diagnostic{ .private_type_in_exposed_type = .{
+                .exposed_type = @as(base.Ident.Idx, @bitCast(p.ident1)),
+                .private_type = @as(base.Ident.Idx, @bitCast(p.ident2)),
+                .region = store.getRegionAt(node_idx),
+            } };
+        },
+        .diag_private_type_in_exposed_field => {
+            const p = payload.diag_three_idents;
+            return CIR.Diagnostic{ .private_type_in_exposed_field = .{
+                .exposed_type = @as(base.Ident.Idx, @bitCast(p.ident1)),
+                .field_name = @as(base.Ident.Idx, @bitCast(p.ident2)),
+                .private_type = @as(base.Ident.Idx, @bitCast(p.ident3)),
                 .region = store.getRegionAt(node_idx),
             } };
         },

--- a/src/canonicalize/test/node_store_test.zig
+++ b/src/canonicalize/test/node_store_test.zig
@@ -937,6 +937,23 @@ test "NodeStore round trip - Diagnostics" {
     });
 
     try diagnostics.append(gpa, CIR.Diagnostic{
+        .private_type_in_exposed_type = .{
+            .exposed_type = rand_ident_idx(),
+            .private_type = rand_ident_idx(),
+            .region = rand_region(),
+        },
+    });
+
+    try diagnostics.append(gpa, CIR.Diagnostic{
+        .private_type_in_exposed_field = .{
+            .exposed_type = rand_ident_idx(),
+            .field_name = rand_ident_idx(),
+            .private_type = rand_ident_idx(),
+            .region = rand_region(),
+        },
+    });
+
+    try diagnostics.append(gpa, CIR.Diagnostic{
         .module_not_imported = .{
             .module_name = rand_ident_idx(),
             .region = rand_region(),

--- a/test/snapshots/nominal/type_module_nominal_field_depends_on_later_private_toplevel_type.md
+++ b/test/snapshots/nominal/type_module_nominal_field_depends_on_later_private_toplevel_type.md
@@ -1,0 +1,91 @@
+# META
+~~~ini
+description=Nominal (non-opaque) type module whose field depends on a private top-level nominal type declared later in the same file. This covers issue #9486's top-level arrangement: it compiles, but warns because the private nominal appears in ModuleType's public surface.
+type=file:ModuleType.roc
+~~~
+# SOURCE
+~~~roc
+ModuleType := {
+    field : InternalType,
+}
+
+InternalType := [Some, Other]
+~~~
+# EXPECTED
+PRIVATE TYPE IN EXPOSED FIELD - type_module_nominal_field_depends_on_later_private_toplevel_type.md:2:13:2:25
+# PROBLEMS
+**PRIVATE TYPE IN EXPOSED FIELD**
+The `field` field of _ModuleType_ refers to _InternalType_, but _InternalType_ is private to this module.
+
+Other modules can see this field because _ModuleType_ is exposed and not opaque, but they cannot name this private type.
+
+It's referenced here:
+**type_module_nominal_field_depends_on_later_private_toplevel_type.md:2:13:2:25:**
+```roc
+    field : InternalType,
+```
+            ^^^^^^^^^^^^
+
+
+**Hint:** Expose the referenced type, make _ModuleType_ opaque with `::`, or move the type into _ModuleType_'s associated block.
+
+# TOKENS
+~~~zig
+UpperIdent,OpColonEqual,OpenCurly,
+LowerIdent,OpColon,UpperIdent,Comma,
+CloseCurly,
+UpperIdent,OpColonEqual,OpenSquare,UpperIdent,Comma,UpperIdent,CloseSquare,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "ModuleType")
+				(args))
+			(ty-record
+				(anno-record-field (name "field")
+					(ty (name "InternalType")))))
+		(s-type-decl
+			(header (name "InternalType")
+				(args))
+			(ty-tag-union
+				(tags
+					(ty (name "Some"))
+					(ty (name "Other")))))))
+~~~
+# FORMATTED
+~~~roc
+ModuleType := {
+	field : InternalType,
+}
+
+InternalType := [Some, Other]
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(s-nominal-decl
+		(ty-header (name "InternalType"))
+		(ty-tag-union
+			(ty-tag-name (name "Some"))
+			(ty-tag-name (name "Other"))))
+	(s-nominal-decl
+		(ty-header (name "ModuleType"))
+		(ty-record
+			(field (field "field")
+				(ty-lookup (name "InternalType") (local))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(type_decls
+		(nominal (type "InternalType")
+			(ty-header (name "InternalType")))
+		(nominal (type "ModuleType")
+			(ty-header (name "ModuleType"))))
+	(expressions))
+~~~

--- a/test/snapshots/nominal/type_module_nominal_field_depends_on_nested_type.md
+++ b/test/snapshots/nominal/type_module_nominal_field_depends_on_nested_type.md
@@ -1,0 +1,89 @@
+# META
+~~~ini
+description=Nominal type module whose field depends on a nested associated type (qualified ModuleType.InternalType). This should compile, since the nested type is exposed as ModuleType.InternalType. It currently reproduces a MISSING NESTED TYPE error because the associated type is not yet in scope while the enclosing type's own annotation is canonicalized.
+type=file:ModuleType.roc
+~~~
+# SOURCE
+~~~roc
+ModuleType := {
+    field : ModuleType.InternalType,
+}.{
+    InternalType := [Some, Other]
+}
+~~~
+# EXPECTED
+MISSING NESTED TYPE - type_module_nominal_field_depends_on_nested_type.md:2:13:2:36
+# PROBLEMS
+**MISSING NESTED TYPE**
+`ModuleType` is in scope, but it doesn't have a nested type named `InternalType`.
+
+It's referenced here:
+**type_module_nominal_field_depends_on_nested_type.md:2:13:2:36:**
+```roc
+    field : ModuleType.InternalType,
+```
+            ^^^^^^^^^^^^^^^^^^^^^^^
+
+
+# TOKENS
+~~~zig
+UpperIdent,OpColonEqual,OpenCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceDotUpperIdent,Comma,
+CloseCurly,Dot,OpenCurly,
+UpperIdent,OpColonEqual,OpenSquare,UpperIdent,Comma,UpperIdent,CloseSquare,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "ModuleType")
+				(args))
+			(ty-record
+				(anno-record-field (name "field")
+					(ty (name "ModuleType.InternalType"))))
+			(associated
+				(s-type-decl
+					(header (name "InternalType")
+						(args))
+					(ty-tag-union
+						(tags
+							(ty (name "Some"))
+							(ty (name "Other")))))))))
+~~~
+# FORMATTED
+~~~roc
+ModuleType := {
+	field : ModuleType.InternalType,
+}.{
+	InternalType := [Some, Other]
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(s-nominal-decl
+		(ty-header (name "ModuleType"))
+		(ty-record
+			(field (field "field")
+				(ty-malformed))))
+	(s-nominal-decl
+		(ty-header (name "ModuleType.InternalType"))
+		(ty-tag-union
+			(ty-tag-name (name "Some"))
+			(ty-tag-name (name "Other")))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(type_decls
+		(nominal (type "ModuleType")
+			(ty-header (name "ModuleType")))
+		(nominal (type "ModuleType.InternalType")
+			(ty-header (name "ModuleType.InternalType"))))
+	(expressions))
+~~~

--- a/test/snapshots/nominal/type_module_nominal_field_depends_on_nested_type.md
+++ b/test/snapshots/nominal/type_module_nominal_field_depends_on_nested_type.md
@@ -1,6 +1,6 @@
 # META
 ~~~ini
-description=Nominal type module whose field depends on a nested associated type (qualified ModuleType.InternalType). This should compile, since the nested type is exposed as ModuleType.InternalType. It currently reproduces a MISSING NESTED TYPE error because the associated type is not yet in scope while the enclosing type's own annotation is canonicalized.
+description=Nominal type module whose field depends on a nested associated type (qualified ModuleType.InternalType). This compiles because the nested type is exposed as ModuleType.InternalType.
 type=file:ModuleType.roc
 ~~~
 # SOURCE

--- a/test/snapshots/nominal/type_module_nominal_field_depends_on_nested_type.md
+++ b/test/snapshots/nominal/type_module_nominal_field_depends_on_nested_type.md
@@ -12,19 +12,9 @@ ModuleType := {
 }
 ~~~
 # EXPECTED
-MISSING NESTED TYPE - type_module_nominal_field_depends_on_nested_type.md:2:13:2:36
+NIL
 # PROBLEMS
-**MISSING NESTED TYPE**
-`ModuleType` is in scope, but it doesn't have a nested type named `InternalType`.
-
-It's referenced here:
-**type_module_nominal_field_depends_on_nested_type.md:2:13:2:36:**
-```roc
-    field : ModuleType.InternalType,
-```
-            ^^^^^^^^^^^^^^^^^^^^^^^
-
-
+NIL
 # TOKENS
 ~~~zig
 UpperIdent,OpColonEqual,OpenCurly,
@@ -69,7 +59,7 @@ ModuleType := {
 		(ty-header (name "ModuleType"))
 		(ty-record
 			(field (field "field")
-				(ty-malformed))))
+				(ty-lookup (name "ModuleType.InternalType") (local)))))
 	(s-nominal-decl
 		(ty-header (name "ModuleType.InternalType"))
 		(ty-tag-union

--- a/test/snapshots/nominal/type_module_nominal_field_depends_on_private_toplevel_type.md
+++ b/test/snapshots/nominal/type_module_nominal_field_depends_on_private_toplevel_type.md
@@ -1,0 +1,91 @@
+# META
+~~~ini
+description=Nominal (non-opaque) type module whose field depends on a PRIVATE top-level nominal type. Because ModuleType is declared with := its fields are public, but InternalType is not exposed to other modules, so this should warn. Marked skip=true until that warning is implemented; remove skip=true to activate the test.
+type=file:ModuleType.roc
+skip=true
+# TODO: expected "PRIVATE TYPE IN EXPOSED FIELD" warning is not implemented yet
+~~~
+# SOURCE
+~~~roc
+InternalType := [Some, Other]
+
+ModuleType := {
+    field : InternalType,
+}
+~~~
+# EXPECTED
+PRIVATE TYPE IN EXPOSED FIELD - type_module_nominal_field_depends_on_private_toplevel_type.md:4:13:4:25
+# PROBLEMS
+**PRIVATE TYPE IN EXPOSED FIELD**
+The `field` field of `ModuleType` refers to `InternalType`, but `InternalType` is private to this module, so other modules that use `ModuleType` cannot name this type.
+
+It's referenced here:
+**type_module_nominal_field_depends_on_private_toplevel_type.md:4:13:4:25:**
+```roc
+    field : InternalType,
+```
+            ^^^^^^^^^^^^
+
+Because `ModuleType` is a nominal type (declared with `:=`), its fields are visible to other modules. To keep `InternalType` private, either make `ModuleType` opaque (declare it with `::`), or move `InternalType` into `ModuleType`'s associated block so it can be referenced as `ModuleType.InternalType`.
+
+
+# TOKENS
+~~~zig
+UpperIdent,OpColonEqual,OpenSquare,UpperIdent,Comma,UpperIdent,CloseSquare,
+UpperIdent,OpColonEqual,OpenCurly,
+LowerIdent,OpColon,UpperIdent,Comma,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "InternalType")
+				(args))
+			(ty-tag-union
+				(tags
+					(ty (name "Some"))
+					(ty (name "Other")))))
+		(s-type-decl
+			(header (name "ModuleType")
+				(args))
+			(ty-record
+				(anno-record-field (name "field")
+					(ty (name "InternalType")))))))
+~~~
+# FORMATTED
+~~~roc
+InternalType := [Some, Other]
+
+ModuleType := {
+	field : InternalType,
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(s-nominal-decl
+		(ty-header (name "InternalType"))
+		(ty-tag-union
+			(ty-tag-name (name "Some"))
+			(ty-tag-name (name "Other"))))
+	(s-nominal-decl
+		(ty-header (name "ModuleType"))
+		(ty-record
+			(field (field "field")
+				(ty-lookup (name "InternalType") (local))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(type_decls
+		(nominal (type "InternalType")
+			(ty-header (name "InternalType")))
+		(nominal (type "ModuleType")
+			(ty-header (name "ModuleType"))))
+	(expressions))
+~~~

--- a/test/snapshots/nominal/type_module_nominal_field_depends_on_private_toplevel_type.md
+++ b/test/snapshots/nominal/type_module_nominal_field_depends_on_private_toplevel_type.md
@@ -1,9 +1,7 @@
 # META
 ~~~ini
-description=Nominal (non-opaque) type module whose field depends on a PRIVATE top-level nominal type. Because ModuleType is declared with := its fields are public, but InternalType is not exposed to other modules, so this should warn. Marked skip=true until that warning is implemented; remove skip=true to activate the test.
+description=Nominal (non-opaque) type module whose field depends on a PRIVATE top-level nominal type. Because ModuleType is declared with := its fields are public, but InternalType is not exposed to other modules, so this warns.
 type=file:ModuleType.roc
-skip=true
-# TODO: expected "PRIVATE TYPE IN EXPOSED FIELD" warning is not implemented yet
 ~~~
 # SOURCE
 ~~~roc
@@ -17,7 +15,9 @@ ModuleType := {
 PRIVATE TYPE IN EXPOSED FIELD - type_module_nominal_field_depends_on_private_toplevel_type.md:4:13:4:25
 # PROBLEMS
 **PRIVATE TYPE IN EXPOSED FIELD**
-The `field` field of `ModuleType` refers to `InternalType`, but `InternalType` is private to this module, so other modules that use `ModuleType` cannot name this type.
+The `field` field of _ModuleType_ refers to _InternalType_, but _InternalType_ is private to this module.
+
+Other modules can see this field because _ModuleType_ is exposed and not opaque, but they cannot name this private type.
 
 It's referenced here:
 **type_module_nominal_field_depends_on_private_toplevel_type.md:4:13:4:25:**
@@ -26,8 +26,8 @@ It's referenced here:
 ```
             ^^^^^^^^^^^^
 
-Because `ModuleType` is a nominal type (declared with `:=`), its fields are visible to other modules. To keep `InternalType` private, either make `ModuleType` opaque (declare it with `::`), or move `InternalType` into `ModuleType`'s associated block so it can be referenced as `ModuleType.InternalType`.
 
+**Hint:** Expose the referenced type, make _ModuleType_ opaque with `::`, or move the type into _ModuleType_'s associated block.
 
 # TOKENS
 ~~~zig

--- a/test/snapshots/nominal/type_module_nominal_field_depends_on_toplevel_alias.md
+++ b/test/snapshots/nominal/type_module_nominal_field_depends_on_toplevel_alias.md
@@ -1,0 +1,77 @@
+# META
+~~~ini
+description=Nominal type module whose field depends on a top-level type ALIAS. No warning expected: aliases are structurally transparent, so other modules can still see the field's structure.
+type=file:ModuleType.roc
+~~~
+# SOURCE
+~~~roc
+InternalType : [Some, Other]
+
+ModuleType := {
+    field : InternalType,
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+UpperIdent,OpColon,OpenSquare,UpperIdent,Comma,UpperIdent,CloseSquare,
+UpperIdent,OpColonEqual,OpenCurly,
+LowerIdent,OpColon,UpperIdent,Comma,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "InternalType")
+				(args))
+			(ty-tag-union
+				(tags
+					(ty (name "Some"))
+					(ty (name "Other")))))
+		(s-type-decl
+			(header (name "ModuleType")
+				(args))
+			(ty-record
+				(anno-record-field (name "field")
+					(ty (name "InternalType")))))))
+~~~
+# FORMATTED
+~~~roc
+InternalType : [Some, Other]
+
+ModuleType := {
+	field : InternalType,
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(s-alias-decl
+		(ty-header (name "InternalType"))
+		(ty-tag-union
+			(ty-tag-name (name "Some"))
+			(ty-tag-name (name "Other"))))
+	(s-nominal-decl
+		(ty-header (name "ModuleType"))
+		(ty-record
+			(field (field "field")
+				(ty-lookup (name "InternalType") (local))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(type_decls
+		(alias (type "InternalType")
+			(ty-header (name "InternalType")))
+		(nominal (type "ModuleType")
+			(ty-header (name "ModuleType"))))
+	(expressions))
+~~~

--- a/test/snapshots/nominal/type_module_nominal_field_depends_on_unqualified_nested_type.md
+++ b/test/snapshots/nominal/type_module_nominal_field_depends_on_unqualified_nested_type.md
@@ -1,12 +1,12 @@
 # META
 ~~~ini
-description=Opaque type module whose field depends on a nested associated type (qualified ModuleType.InternalType). This compiles because the nested type is exposed as ModuleType.InternalType.
+description=Nominal type module whose field depends on an unqualified nested associated type declared in the same type module. This covers issue #9486's associated-definition arrangement.
 type=file:ModuleType.roc
 ~~~
 # SOURCE
 ~~~roc
-ModuleType :: {
-    field : ModuleType.InternalType,
+ModuleType := {
+    field : InternalType,
 }.{
     InternalType := [Some, Other]
 }
@@ -17,8 +17,8 @@ NIL
 NIL
 # TOKENS
 ~~~zig
-UpperIdent,OpDoubleColon,OpenCurly,
-LowerIdent,OpColon,UpperIdent,NoSpaceDotUpperIdent,Comma,
+UpperIdent,OpColonEqual,OpenCurly,
+LowerIdent,OpColon,UpperIdent,Comma,
 CloseCurly,Dot,OpenCurly,
 UpperIdent,OpColonEqual,OpenSquare,UpperIdent,Comma,UpperIdent,CloseSquare,
 CloseCurly,
@@ -34,7 +34,7 @@ EndOfFile,
 				(args))
 			(ty-record
 				(anno-record-field (name "field")
-					(ty (name "ModuleType.InternalType"))))
+					(ty (name "InternalType"))))
 			(associated
 				(s-type-decl
 					(header (name "InternalType")
@@ -46,8 +46,8 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-ModuleType :: {
-	field : ModuleType.InternalType,
+ModuleType := {
+	field : InternalType,
 }.{
 	InternalType := [Some, Other]
 }
@@ -59,7 +59,7 @@ ModuleType :: {
 		(ty-header (name "ModuleType"))
 		(ty-record
 			(field (field "field")
-				(ty-lookup (name "ModuleType.InternalType") (local)))))
+				(ty-lookup (name "InternalType") (local)))))
 	(s-nominal-decl
 		(ty-header (name "ModuleType.InternalType"))
 		(ty-tag-union

--- a/test/snapshots/nominal/type_module_opaque_field_depends_on_nested_type.md
+++ b/test/snapshots/nominal/type_module_opaque_field_depends_on_nested_type.md
@@ -12,19 +12,9 @@ ModuleType :: {
 }
 ~~~
 # EXPECTED
-MISSING NESTED TYPE - type_module_opaque_field_depends_on_nested_type.md:2:13:2:36
+NIL
 # PROBLEMS
-**MISSING NESTED TYPE**
-`ModuleType` is in scope, but it doesn't have a nested type named `InternalType`.
-
-It's referenced here:
-**type_module_opaque_field_depends_on_nested_type.md:2:13:2:36:**
-```roc
-    field : ModuleType.InternalType,
-```
-            ^^^^^^^^^^^^^^^^^^^^^^^
-
-
+NIL
 # TOKENS
 ~~~zig
 UpperIdent,OpDoubleColon,OpenCurly,
@@ -69,7 +59,7 @@ ModuleType :: {
 		(ty-header (name "ModuleType"))
 		(ty-record
 			(field (field "field")
-				(ty-malformed))))
+				(ty-lookup (name "ModuleType.InternalType") (local)))))
 	(s-nominal-decl
 		(ty-header (name "ModuleType.InternalType"))
 		(ty-tag-union

--- a/test/snapshots/nominal/type_module_opaque_field_depends_on_nested_type.md
+++ b/test/snapshots/nominal/type_module_opaque_field_depends_on_nested_type.md
@@ -1,0 +1,89 @@
+# META
+~~~ini
+description=Opaque type module whose field depends on a nested associated type (qualified ModuleType.InternalType). This should just work. It currently reproduces a MISSING NESTED TYPE error because the associated type is not yet in scope while the enclosing type's own annotation is canonicalized.
+type=file:ModuleType.roc
+~~~
+# SOURCE
+~~~roc
+ModuleType :: {
+    field : ModuleType.InternalType,
+}.{
+    InternalType := [Some, Other]
+}
+~~~
+# EXPECTED
+MISSING NESTED TYPE - type_module_opaque_field_depends_on_nested_type.md:2:13:2:36
+# PROBLEMS
+**MISSING NESTED TYPE**
+`ModuleType` is in scope, but it doesn't have a nested type named `InternalType`.
+
+It's referenced here:
+**type_module_opaque_field_depends_on_nested_type.md:2:13:2:36:**
+```roc
+    field : ModuleType.InternalType,
+```
+            ^^^^^^^^^^^^^^^^^^^^^^^
+
+
+# TOKENS
+~~~zig
+UpperIdent,OpDoubleColon,OpenCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceDotUpperIdent,Comma,
+CloseCurly,Dot,OpenCurly,
+UpperIdent,OpColonEqual,OpenSquare,UpperIdent,Comma,UpperIdent,CloseSquare,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "ModuleType")
+				(args))
+			(ty-record
+				(anno-record-field (name "field")
+					(ty (name "ModuleType.InternalType"))))
+			(associated
+				(s-type-decl
+					(header (name "InternalType")
+						(args))
+					(ty-tag-union
+						(tags
+							(ty (name "Some"))
+							(ty (name "Other")))))))))
+~~~
+# FORMATTED
+~~~roc
+ModuleType :: {
+	field : ModuleType.InternalType,
+}.{
+	InternalType := [Some, Other]
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(s-nominal-decl
+		(ty-header (name "ModuleType"))
+		(ty-record
+			(field (field "field")
+				(ty-malformed))))
+	(s-nominal-decl
+		(ty-header (name "ModuleType.InternalType"))
+		(ty-tag-union
+			(ty-tag-name (name "Some"))
+			(ty-tag-name (name "Other")))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(type_decls
+		(nominal (type "ModuleType")
+			(ty-header (name "ModuleType")))
+		(nominal (type "ModuleType.InternalType")
+			(ty-header (name "ModuleType.InternalType"))))
+	(expressions))
+~~~

--- a/test/snapshots/nominal/type_module_opaque_field_depends_on_private_toplevel_type.md
+++ b/test/snapshots/nominal/type_module_opaque_field_depends_on_private_toplevel_type.md
@@ -1,0 +1,77 @@
+# META
+~~~ini
+description=Opaque type module whose field depends on a private top-level nominal type. No warning expected: because ModuleType is opaque, its field is hidden from other modules, so referencing a private type there is fine.
+type=file:ModuleType.roc
+~~~
+# SOURCE
+~~~roc
+InternalType := [Some, Other]
+
+ModuleType :: {
+    field : InternalType,
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+UpperIdent,OpColonEqual,OpenSquare,UpperIdent,Comma,UpperIdent,CloseSquare,
+UpperIdent,OpDoubleColon,OpenCurly,
+LowerIdent,OpColon,UpperIdent,Comma,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "InternalType")
+				(args))
+			(ty-tag-union
+				(tags
+					(ty (name "Some"))
+					(ty (name "Other")))))
+		(s-type-decl
+			(header (name "ModuleType")
+				(args))
+			(ty-record
+				(anno-record-field (name "field")
+					(ty (name "InternalType")))))))
+~~~
+# FORMATTED
+~~~roc
+InternalType := [Some, Other]
+
+ModuleType :: {
+	field : InternalType,
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(s-nominal-decl
+		(ty-header (name "InternalType"))
+		(ty-tag-union
+			(ty-tag-name (name "Some"))
+			(ty-tag-name (name "Other"))))
+	(s-nominal-decl
+		(ty-header (name "ModuleType"))
+		(ty-record
+			(field (field "field")
+				(ty-lookup (name "InternalType") (local))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(type_decls
+		(nominal (type "InternalType")
+			(ty-header (name "InternalType")))
+		(nominal (type "ModuleType")
+			(ty-header (name "ModuleType"))))
+	(expressions))
+~~~


### PR DESCRIPTION
## Summary
- add snapshot coverage for type-module field dependencies
- handle both exact arrangements from #9486: unqualified associated nested type dependencies and later top-level nominal dependencies
- warn when an exposed non-opaque nominal type's public surface references a private local nominal type
- keep aliases transparent and public associated types nameable in the surface check

Closes #9486

## Tests
- zig build test
- zig build minici
- zig build test -- --test-filter "snapshot validation"
- zig build test -- --test-filter "check type - nested same-module mutually recursive nominal types"