### PR TITLE
Fix #9491 self-recursion mismatch; make local lets sequentially scoped

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -142,6 +142,12 @@ scratch_bound_vars: base.Scratch(Pattern.Idx),
 /// Local function declaration patterns that are visible as direct local
 /// procedures in the current canonicalization context.
 scratch_local_function_patterns: base.Scratch(Pattern.Idx),
+/// Names declared in the current (and enclosing) block bodies, recorded by a
+/// pre-scan so a lookup miss can tell "used before its local definition" apart
+/// from a genuinely unknown identifier. Each entry also carries the
+/// forward-reference markers used to classify use-before-definition vs mutual
+/// recursion at block end. Snapshot/rollback per block.
+scratch_block_local_defs: base.Scratch(BlockLocalDef),
 /// Local type declarations found inside function bodies.
 /// Collected during canonicalization, then added to all_statements at the end.
 scratch_local_type_decls: std.ArrayList(CIR.Statement.Idx),
@@ -175,6 +181,17 @@ defining_patterns_start: ?u32 = null,
 /// was created in a first pass, or for simple ident patterns).
 /// Used to detect self-referential definitions like `a = a`.
 defining_pattern: ?Pattern.Idx = null,
+/// The identifier of the block-local definition whose body is currently being
+/// canonicalized, if any. Saved/restored around each local decl body so that
+/// references can be attributed to the def that made them (for sequential
+/// local-let scoping: detecting forward references and mutual recursion).
+current_local_def_ident: ?Ident.Idx = null,
+/// Index into `scratch_block_local_defs` of the def whose body is currently
+/// being canonicalized (paired with `current_local_def_ident`). Lets the
+/// lookup-hit path mark `refs_back` on that entry in O(1) when the def
+/// references its forward-referencer back. null when not in a local def body
+/// or the def has no resolvable name.
+current_local_def_index: ?usize = null,
 /// Whether the current declaration-pattern canonicalization should reuse
 /// existing mutable binders when it encounters `$name` patterns.
 allow_pattern_var_reuse: bool = false,
@@ -193,6 +210,28 @@ source_dir: ?[]const u8 = null,
 roc_ctx: CoreCtx,
 const Ident = base.Ident;
 const Region = base.Region;
+
+/// A name declared in a block body (for sequential local-let scoping). Recorded
+/// by a per-block pre-scan; used to recognize "used before its local definition".
+const BlockLocalDef = struct {
+    ident: Ident.Idx,
+    region: Region,
+    /// Whether the definition's body is a function (lambda). Only function
+    /// definitions can be "mutually recursive"; a cycle through a non-function
+    /// value is reported as a plain use-before-definition instead.
+    is_fn: bool,
+    /// Set when an earlier sibling references this def before it is defined (a
+    /// forward reference). Holds the use-site region for the diagnostic, which
+    /// is deferred to block end. First writer wins, so repeated forward uses of
+    /// the same name produce a single diagnostic.
+    fwd_ref_region: ?Region = null,
+    /// The sibling that made the first forward reference to this def. Together
+    /// with `refs_back` this identifies a mutual-recursion pair.
+    fwd_ref_from: ?Ident.Idx = null,
+    /// Set while canonicalizing THIS def's body if it references its
+    /// forward-referencer back — completing a 2-cycle (mutual recursion).
+    refs_back: bool = false,
+};
 // ModuleEnv is already imported at the top
 const CalledVia = base.CalledVia;
 
@@ -298,6 +337,7 @@ pub fn deinit(
     self.scratch_captures.deinit();
     self.scratch_bound_vars.deinit();
     self.scratch_local_function_patterns.deinit();
+    self.scratch_block_local_defs.deinit();
     self.scratch_local_type_decls.deinit(gpa);
     self.scratch_global_value_defs.deinit(gpa);
 }
@@ -354,6 +394,7 @@ fn initInternal(
         .scratch_captures = try base.Scratch(Pattern.Idx).init(gpa),
         .scratch_bound_vars = try base.Scratch(Pattern.Idx).init(gpa),
         .scratch_local_function_patterns = try base.Scratch(Pattern.Idx).init(gpa),
+        .scratch_block_local_defs = try base.Scratch(BlockLocalDef).init(gpa),
         .scratch_local_type_decls = try std.ArrayList(CIR.Statement.Idx).initCapacity(gpa, 0),
         .scratch_global_value_defs = try std.ArrayList(CIR.Def.Idx).initCapacity(gpa, 0),
     };
@@ -6254,6 +6295,18 @@ pub fn canonicalizeExpr(
                         // Check if this is a used underscore variable
                         try self.checkUsedUnderscoreVariable(ident, region);
 
+                        // Mutual-recursion detection (sequential local-let scoping):
+                        // if the def whose body we're in was itself forward-referenced
+                        // by an earlier sibling, and it now references that sibling
+                        // back, the two form a 2-cycle. Gated on the current def having
+                        // been forward-referenced, so the common case does no work.
+                        if (self.current_local_def_index) |idx| {
+                            const entry = &self.scratch_block_local_defs.items.items[idx];
+                            if (entry.fwd_ref_from) |fwd_from| {
+                                if (fwd_from.eql(ident)) entry.refs_back = true;
+                            }
+                        }
+
                         // We found the ident in scope, create a lookup to reference the pattern
                         // Note: Rank tracking for let-polymorphism is handled by the type checker (Check.zig)
                         const expr_idx = try self.env.addExpr(CIR.Expr{ .e_lookup_local = .{
@@ -6318,6 +6371,35 @@ pub fn canonicalizeExpr(
                                     };
                                 }
                                 // Module doesn't exist, fall through to ident_not_in_scope error below
+                            }
+                        }
+
+                        // Sequential local-let scoping: if this name is declared
+                        // later in the current (or an enclosing) block body, it's
+                        // being used before its definition. This takes precedence
+                        // over the associated-block forward-reference allowance
+                        // below, so local block defs are always sequential even
+                        // inside associated method bodies. The diagnostic is
+                        // deferred to block end, where it is classified as a plain
+                        // use-before-definition or as mutual recursion.
+                        if (self.current_local_def_ident) |from_ident| {
+                            if (self.blockLocalDefIndex(ident)) |idx| {
+                                // Record the forward reference on the target's entry
+                                // (first writer wins, so repeated uses of the same
+                                // name yield a single diagnostic). Classified at block
+                                // end as use-before-definition or mutual recursion.
+                                const entry = &self.scratch_block_local_defs.items.items[idx];
+                                if (entry.fwd_ref_region == null) {
+                                    entry.fwd_ref_region = region;
+                                    entry.fwd_ref_from = from_ident;
+                                }
+                                return CanonicalizedExpr{
+                                    .idx = try self.env.pushRuntimeErrorExpr(Expr.Idx, Diagnostic{ .local_reference_before_definition = .{
+                                        .ident = ident,
+                                        .region = region,
+                                    } }),
+                                    .free_vars = DataSpan.empty(),
+                                };
                             }
                         }
 
@@ -12013,37 +12095,43 @@ fn canonicalizeBlock(self: *Self, e: AST.Block) std.mem.Allocator.Error!Canonica
     const local_functions_top = self.scratch_local_function_patterns.top();
     defer self.scratch_local_function_patterns.clearFrom(local_functions_top);
 
+    // Sequential local-let scoping bookkeeping. We record this block's declared
+    // names (without making them resolvable) so a lookup miss can distinguish
+    // "used before its local definition" from a genuinely unknown identifier.
+    // Forward-reference markers are written onto these same entries while the
+    // def bodies are canonicalized, then classified at block end. The list is
+    // snapshot/rollback per block, which also scopes the markers per block.
+    const block_defs_top = self.scratch_block_local_defs.top();
+    defer self.scratch_block_local_defs.clearFrom(block_defs_top);
+
     const free_vars_top = self.scratch_free_vars.top();
 
     // Canonicalize all statements in the block
     const ast_stmt_idxs = self.parse_ir.store.statementSlice(e.statements);
 
-    // Pre-pass: Create forward references for lambda declaration patterns.
-    // This enables mutual recursion between closures in the same block by
-    // making all lambda-bound names visible before any bodies are canonicalized.
+    // Pre-scan: record the names declared in this block. Unlike the previous
+    // forward-declaration pre-pass, this does NOT introduce the names into
+    // scope, so local definitions are sequential: a definition is in scope only
+    // after itself (self-reference) and earlier siblings (backward reference).
+    // Forward references and mutual recursion are reported at block end.
     for (ast_stmt_idxs) |ast_stmt_idx| {
         const ast_stmt = self.parse_ir.store.getStatement(ast_stmt_idx);
-        if (ast_stmt != .decl) continue;
-        const d = ast_stmt.decl;
-        const ast_body_expr = self.parse_ir.store.getExpr(d.body);
-        if (ast_body_expr != .lambda) continue;
-        const ast_pattern = self.parse_ir.store.getPattern(d.pattern);
-        if (ast_pattern != .ident) continue;
-        const ident_idx = self.parse_ir.tokens.resolveIdentifier(ast_pattern.ident.ident_tok) orelse continue;
-        // Skip if already in scope (from outer scope or duplicate)
-        if (self.scopeLookup(.ident, ident_idx) == .found) continue;
-        const region = self.parse_ir.tokenizedRegionToRegion(ast_pattern.ident.region);
-        const pattern_idx = try self.env.addPattern(Pattern{ .assign = .{
-            .ident = ident_idx,
-        } }, region);
-        const current_scope = &self.scopes.items[self.scopes.items.len - 1];
-        try current_scope.forward_references.put(self.env.gpa, ident_idx, .{
-            .pattern_idx = pattern_idx,
-            .reference_regions = .empty,
-        });
-        try current_scope.idents.put(self.env.gpa, ident_idx, pattern_idx);
-        try self.scratch_local_function_patterns.append(pattern_idx);
-        try self.scratch_bound_vars.append(pattern_idx);
+        switch (ast_stmt) {
+            .decl => |d| {
+                const ast_pattern = self.parse_ir.store.getPattern(d.pattern);
+                if (ast_pattern != .ident) continue;
+                const ident_idx = self.parse_ir.tokens.resolveIdentifier(ast_pattern.ident.ident_tok) orelse continue;
+                const region = self.parse_ir.tokenizedRegionToRegion(ast_pattern.ident.region);
+                const is_fn = self.parse_ir.store.getExpr(d.body) == .lambda;
+                try self.scratch_block_local_defs.append(.{ .ident = ident_idx, .region = region, .is_fn = is_fn });
+            },
+            .@"var" => |v| {
+                const ident_idx = self.parse_ir.tokens.resolveIdentifier(v.name) orelse continue;
+                const region = self.parse_ir.tokenizedRegionToRegion(v.region);
+                try self.scratch_block_local_defs.append(.{ .ident = ident_idx, .region = region, .is_fn = false });
+            },
+            else => continue,
+        }
     }
 
     var last_expr: ?CanonicalizedExpr = null;
@@ -12172,6 +12260,14 @@ fn canonicalizeBlock(self: *Self, e: AST.Block) std.mem.Allocator.Error!Canonica
         }
     }
 
+    // Sequential local-let scoping: classify the forward references discovered
+    // while canonicalizing this block's definition bodies. A forward reference
+    // that is part of a reference cycle is mutual recursion (unsupported for
+    // local defs); otherwise it is a plain use-before-definition. This is done
+    // at block end because mutual recursion depends on a later sibling's
+    // references, which are only known once the whole block is canonicalized.
+    try self.classifyBlockLocalForwardRefs(block_defs_top);
+
     // Determine the final expression
     const final_expr = if (last_expr) |can_expr| can_expr else blk: {
         // Empty block - create empty record
@@ -12213,6 +12309,60 @@ fn canonicalizeBlock(self: *Self, e: AST.Block) std.mem.Allocator.Error!Canonica
     const block_idx = try self.env.addExpr(block_expr, block_region);
 
     return CanonicalizedExpr{ .idx = block_idx, .free_vars = block_free_vars };
+}
+
+/// Classify and report the forward references targeting this block's
+/// definitions (the names from `block_defs_top` onward). A forward-referenced
+/// function definition that references its forward-referencer back is mutual
+/// recursion between local definitions; otherwise it is a plain
+/// use-before-definition. The forward-reference markers live on the per-block
+/// `scratch_block_local_defs` entries (snapshot/rollback per block), so no
+/// separate edge state or cross-block bookkeeping is needed: a cross-block
+/// forward reference (an inner def naming an outer-later def) lands on the outer
+/// entry and is classified — never as mutual, since the inner def isn't visible
+/// to the outer one — when the outer block runs this pass.
+fn classifyBlockLocalForwardRefs(self: *Self, block_defs_top: u32) std.mem.Allocator.Error!void {
+    const this_defs = self.scratch_block_local_defs.slice(block_defs_top, self.scratch_block_local_defs.top());
+    for (this_defs) |d| {
+        const region = d.fwd_ref_region orelse continue;
+        // Mutual recursion only applies between function definitions; a cycle
+        // through a non-function value is reported as use-before-definition.
+        if (d.is_fn and d.refs_back and blockLocalIsFn(this_defs, d.fwd_ref_from.?)) {
+            try self.env.pushDiagnostic(Diagnostic{ .mutually_recursive_local_definitions = .{
+                .ident1 = d.fwd_ref_from.?,
+                .ident2 = d.ident,
+                .region = region,
+            } });
+        } else {
+            try self.env.pushDiagnostic(Diagnostic{ .local_reference_before_definition = .{
+                .ident = d.ident,
+                .region = region,
+            } });
+        }
+    }
+}
+
+fn blockLocalIsFn(defs: []const BlockLocalDef, target: Ident.Idx) bool {
+    for (defs) |d| {
+        if (d.ident.eql(target)) return d.is_fn;
+    }
+    return false;
+}
+
+/// The index in `scratch_block_local_defs` of the definition named `ident` in
+/// the current or an enclosing block body (recorded by the per-block pre-scan),
+/// or null if there is none. A lookup miss on such a name means it is used
+/// before its (sequential) definition. Scans from the end so a name shadowed
+/// across nested blocks resolves to the nearest (innermost) declaration, since
+/// the pre-scan appends outer entries before inner ones.
+fn blockLocalDefIndex(self: *const Self, ident: Ident.Idx) ?usize {
+    const defs = self.scratch_block_local_defs.items.items;
+    var i: usize = defs.len;
+    while (i > 0) {
+        i -= 1;
+        if (defs[i].ident.eql(ident)) return i;
+    }
+    return null;
 }
 
 const StatementResult = struct {
@@ -13154,6 +13304,38 @@ pub fn canonicalizeBlockDecl(self: *Self, d: AST.Statement.Decl, mb_last_anno: ?
     const ast_body_expr = self.parse_ir.store.getExpr(d.body);
     const is_lambda = ast_body_expr == .lambda;
 
+    // A local function definition must be recognized as a direct local
+    // procedure (excluded from closure captures) during its OWN body so that a
+    // recursive self-reference is looked up directly rather than captured. The
+    // previous block pre-pass registered all block lambdas up front; with
+    // sequential scoping we register each one just before its body instead.
+    if (is_lambda) {
+        try self.scratch_local_function_patterns.append(pattern_idx);
+    }
+
+    // Track which block-local definition's body we're canonicalizing, so that
+    // references it makes can be attributed to it for sequential local-let
+    // scoping (forward-reference / mutual-recursion detection).
+    const saved_current_local_def_ident = self.current_local_def_ident;
+    const saved_current_local_def_index = self.current_local_def_index;
+    const ast_decl_pattern = self.parse_ir.store.getPattern(d.pattern);
+    if (ast_decl_pattern == .ident) {
+        const decl_ident = self.parse_ir.tokens.resolveIdentifier(ast_decl_pattern.ident.ident_tok);
+        self.current_local_def_ident = decl_ident;
+        self.current_local_def_index = if (decl_ident) |di| self.blockLocalDefIndex(di) else null;
+        // If this definition's name was already forward-referenced earlier in
+        // the block (an error we report at block end), mark it used so it does
+        // not also produce a misleading "unused variable" warning.
+        if (self.current_local_def_index) |idx| {
+            if (self.scratch_block_local_defs.items.items[idx].fwd_ref_region != null) {
+                try self.used_patterns.put(self.env.gpa, pattern_idx, {});
+            }
+        }
+    } else {
+        self.current_local_def_ident = null;
+        self.current_local_def_index = null;
+    }
+
     // Save and set self-reference tracking for issues #8831, #9043:
     // - defining_pattern: the main pattern (handles `a = a`)
     // - defining_patterns_start: node index for new patterns (handles tuple cases)
@@ -13170,6 +13352,8 @@ pub fn canonicalizeBlockDecl(self: *Self, d: AST.Statement.Decl, mb_last_anno: ?
     // Restore self-reference tracking
     self.defining_patterns_start = saved_defining_patterns_start;
     self.defining_pattern = saved_defining_pattern;
+    self.current_local_def_ident = saved_current_local_def_ident;
+    self.current_local_def_index = saved_current_local_def_index;
 
     const stmt_idx = if (pattern_reused_existing_var)
         try self.env.addStatement(Statement{ .s_reassign = .{

--- a/src/canonicalize/Diagnostic.zig
+++ b/src/canonicalize/Diagnostic.zig
@@ -52,6 +52,21 @@ pub const Diagnostic = union(enum) {
         ident: Ident.Idx,
         region: Region,
     },
+    /// A local (block) definition references a name that is defined LATER in the
+    /// same block. Local definitions are sequential: they may reference
+    /// themselves or earlier definitions, but not later ones.
+    local_reference_before_definition: struct {
+        ident: Ident.Idx,
+        region: Region,
+    },
+    /// Two local (block) definitions are mutually recursive, which is not
+    /// supported for local definitions (only top-level definitions may be
+    /// mutually recursive).
+    mutually_recursive_local_definitions: struct {
+        ident1: Ident.Idx,
+        ident2: Ident.Idx,
+        region: Region,
+    },
     /// This use-site was rewritten to crash because the referenced top-level
     /// non-function value failed type checking earlier in the pipeline.
     erroneous_value_use: struct {
@@ -351,6 +366,8 @@ pub const Diagnostic = union(enum) {
             .ident_not_in_scope => |d| d.region,
             .self_referential_definition => |d| d.region,
             .circular_value_definition => |d| d.region,
+            .local_reference_before_definition => |d| d.region,
+            .mutually_recursive_local_definitions => |d| d.region,
             .erroneous_value_use => |d| d.region,
             .erroneous_value_expr => |d| d.region,
             .qualified_ident_does_not_exist => |d| d.region,

--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -798,6 +798,20 @@ pub fn pushMalformed(self: *Self, comptime RetIdx: type, reason: CIR.Diagnostic)
     return castIdx(Node.Idx, RetIdx, malformed_idx);
 }
 
+/// Like `pushMalformed`, but does NOT register `reason` in the reported
+/// diagnostics list. The malformed node still references the diagnostic (for
+/// runtime crash text), but the diagnostic that is actually reported for this
+/// site is pushed separately and later — used when forward-reference vs
+/// mutual-recursion classification of a local definition is deferred to the end
+/// of the enclosing block.
+pub fn pushRuntimeErrorExpr(self: *Self, comptime RetIdx: type, reason: CIR.Diagnostic) std.mem.Allocator.Error!RetIdx {
+    comptime if (!isCastable(RetIdx)) @compileError("Idx type " ++ @typeName(RetIdx) ++ " is not castable");
+    const diag_idx = try self.store.addDiagnosticUnregistered(reason);
+    const region = getDiagnosticRegion(reason);
+    const malformed_idx = try self.addMalformed(diag_idx, region);
+    return castIdx(Node.Idx, RetIdx, malformed_idx);
+}
+
 /// Extract the region from any diagnostic variant
 fn getDiagnosticRegion(diagnostic: CIR.Diagnostic) Region {
     return switch (diagnostic) {
@@ -962,6 +976,62 @@ pub fn diagnosticToReport(self: *Self, diagnostic: CIR.Diagnostic, allocator: st
             try report.document.addLineBreak();
             try report.document.addLineBreak();
             try report.document.addReflowingText("Only functions can be recursive. Non-function top-level values must be fully computable without depending on themselves through other values.");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            const owned_filename = try report.addOwnedString(filename);
+            try report.document.addSourceRegion(
+                region_info,
+                .error_highlight,
+                owned_filename,
+                self.getSourceAll(),
+                self.getLineStartsAll(),
+            );
+
+            break :blk report;
+        },
+        .local_reference_before_definition => |data| blk: {
+            const region_info = self.calcRegionInfo(data.region);
+            const ident_name = self.getIdent(data.ident);
+
+            var report = Report.init(allocator, "USED BEFORE DEFINITION", .runtime_error);
+            const owned_ident = try report.addOwnedString(ident_name);
+            try report.document.addReflowingText("The name ");
+            try report.document.addUnqualifiedSymbol(owned_ident);
+            try report.document.addReflowingText(" is used before it is defined.");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            try report.document.addReflowingText("Local definitions are evaluated in order: a definition can refer to itself or to definitions written before it, but not to definitions written later in the same block. Move ");
+            try report.document.addUnqualifiedSymbol(owned_ident);
+            try report.document.addReflowingText(" above this use, or move both to the top level.");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            const owned_filename = try report.addOwnedString(filename);
+            try report.document.addSourceRegion(
+                region_info,
+                .error_highlight,
+                owned_filename,
+                self.getSourceAll(),
+                self.getLineStartsAll(),
+            );
+
+            break :blk report;
+        },
+        .mutually_recursive_local_definitions => |data| blk: {
+            const region_info = self.calcRegionInfo(data.region);
+            const ident1_name = self.getIdent(data.ident1);
+            const ident2_name = self.getIdent(data.ident2);
+
+            var report = Report.init(allocator, "MUTUALLY RECURSIVE LOCAL DEFINITIONS", .runtime_error);
+            const owned_ident1 = try report.addOwnedString(ident1_name);
+            const owned_ident2 = try report.addOwnedString(ident2_name);
+            try report.document.addReflowingText("The local definitions ");
+            try report.document.addUnqualifiedSymbol(owned_ident1);
+            try report.document.addReflowingText(" and ");
+            try report.document.addUnqualifiedSymbol(owned_ident2);
+            try report.document.addReflowingText(" are mutually recursive, which isn't supported for local definitions.");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            try report.document.addReflowingText("Local definitions are evaluated in order and can only refer to themselves or to earlier definitions. Move these mutually recursive definitions to the top level, where mutual recursion is supported.");
             try report.document.addLineBreak();
             try report.document.addLineBreak();
             const owned_filename = try report.addOwnedString(filename);

--- a/src/canonicalize/Node.zig
+++ b/src/canonicalize/Node.zig
@@ -188,6 +188,8 @@ pub const Tag = enum {
     diag_ident_not_in_scope,
     diag_self_referential_definition,
     diag_circular_value_definition,
+    diag_local_reference_before_definition,
+    diag_mutually_recursive_local_definitions,
     diag_erroneous_value_use,
     diag_erroneous_value_expr,
     diag_qualified_ident_does_not_exist,

--- a/src/canonicalize/NodeStore.zig
+++ b/src/canonicalize/NodeStore.zig
@@ -303,7 +303,7 @@ pub fn relocate(store: *NodeStore, offset: isize) void {
 /// when adding/removing variants from ModuleEnv unions. Update these when modifying the unions.
 ///
 /// Count of the diagnostic nodes in the ModuleEnv
-pub const MODULEENV_DIAGNOSTIC_NODE_COUNT = 75;
+pub const MODULEENV_DIAGNOSTIC_NODE_COUNT = 77;
 /// Count of the expression nodes in the ModuleEnv
 pub const MODULEENV_EXPR_NODE_COUNT = 51;
 /// Count of the statement nodes in the ModuleEnv
@@ -3496,6 +3496,17 @@ pub fn sliceRecordDestructs(store: *const NodeStore, span: CIR.Pattern.RecordDes
 /// IMPORTANT: You should not use this function directly! Instead, use it's
 /// corresponding function in `ModuleEnv`.
 pub fn addDiagnostic(store: *NodeStore, reason: CIR.Diagnostic) Allocator.Error!CIR.Diagnostic.Idx {
+    const diag_idx = try store.addDiagnosticUnregistered(reason);
+    // append to our scratch so we can get a span later of all our diagnostics
+    try store.addScratch("diagnostics", diag_idx);
+    return diag_idx;
+}
+
+/// Create a diagnostic node WITHOUT registering it in the reported-diagnostics
+/// scratch list. Used when a malformed/runtime-error node needs a diagnostic to
+/// reference, but the diagnostic that should actually be reported is decided and
+/// pushed later (e.g. deferred forward-ref vs mutual-recursion classification).
+pub fn addDiagnosticUnregistered(store: *NodeStore, reason: CIR.Diagnostic) Allocator.Error!CIR.Diagnostic.Idx {
     var node = Node.init(undefined);
     var region = base.Region.zero();
 
@@ -3547,6 +3558,16 @@ pub fn addDiagnostic(store: *NodeStore, reason: CIR.Diagnostic) Allocator.Error!
             node.tag = .diag_circular_value_definition;
             region = r.region;
             node.setPayload(.{ .diag_single_ident = .{ .ident = @bitCast(r.ident) } });
+        },
+        .local_reference_before_definition => |r| {
+            node.tag = .diag_local_reference_before_definition;
+            region = r.region;
+            node.setPayload(.{ .diag_single_ident = .{ .ident = @bitCast(r.ident) } });
+        },
+        .mutually_recursive_local_definitions => |r| {
+            node.tag = .diag_mutually_recursive_local_definitions;
+            region = r.region;
+            node.setPayload(.{ .diag_two_idents = .{ .ident1 = @bitCast(r.ident1), .ident2 = @bitCast(r.ident2) } });
         },
         .erroneous_value_use => |r| {
             node.tag = .diag_erroneous_value_use;
@@ -3876,9 +3897,6 @@ pub fn addDiagnostic(store: *NodeStore, reason: CIR.Diagnostic) Allocator.Error!
     const nid = @intFromEnum(try store.nodes.append(store.gpa, node));
     _ = try store.regions.append(store.gpa, region);
 
-    // append to our scratch so we can get a span later of all our diagnostics
-    try store.addScratch("diagnostics", @as(CIR.Diagnostic.Idx, @enumFromInt(nid)));
-
     return @enumFromInt(nid);
 }
 
@@ -3958,6 +3976,15 @@ pub fn getDiagnostic(store: *const NodeStore, diagnostic: CIR.Diagnostic.Idx) CI
         } },
         .diag_circular_value_definition => return CIR.Diagnostic{ .circular_value_definition = .{
             .ident = @bitCast(payload.diag_single_ident.ident),
+            .region = store.getRegionAt(node_idx),
+        } },
+        .diag_local_reference_before_definition => return CIR.Diagnostic{ .local_reference_before_definition = .{
+            .ident = @bitCast(payload.diag_single_ident.ident),
+            .region = store.getRegionAt(node_idx),
+        } },
+        .diag_mutually_recursive_local_definitions => return CIR.Diagnostic{ .mutually_recursive_local_definitions = .{
+            .ident1 = @bitCast(payload.diag_two_idents.ident1),
+            .ident2 = @bitCast(payload.diag_two_idents.ident2),
             .region = store.getRegionAt(node_idx),
         } },
         .diag_erroneous_value_use => return CIR.Diagnostic{ .erroneous_value_use = .{

--- a/src/canonicalize/mod.zig
+++ b/src/canonicalize/mod.zig
@@ -110,6 +110,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/scope_test.zig"));
     std.testing.refAllDecls(@import("test/record_test.zig"));
     std.testing.refAllDecls(@import("test/type_decl_stmt_test.zig"));
+    std.testing.refAllDecls(@import("test/local_let_scoping_test.zig"));
 
     // Backend tests (Roc emitter)
     std.testing.refAllDecls(@import("RocEmitter.zig"));

--- a/src/canonicalize/test/local_let_scoping_test.zig
+++ b/src/canonicalize/test/local_let_scoping_test.zig
@@ -1,0 +1,97 @@
+//! Tests for sequential scoping of local `let` definitions inside a block.
+//!
+//! Local definitions are evaluated in order: a definition is in scope only
+//! after itself (self-reference) and after earlier definitions (backward
+//! reference). Forward references and mutual recursion between local
+//! definitions are NOT allowed and are reported with dedicated diagnostics.
+
+const std = @import("std");
+const TestEnv = @import("TestEnv.zig").TestEnv;
+
+const testing = std.testing;
+
+const Counts = struct {
+    forward_ref: usize = 0,
+    mutual: usize = 0,
+};
+
+fn scopingDiagnosticCounts(source: []const u8) !Counts {
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    _ = try test_env.canonicalizeExpr();
+
+    const diagnostics = try test_env.getDiagnostics();
+    defer testing.allocator.free(diagnostics);
+
+    var counts = Counts{};
+    for (diagnostics) |diag| {
+        switch (diag) {
+            .local_reference_before_definition => counts.forward_ref += 1,
+            .mutually_recursive_local_definitions => counts.mutual += 1,
+            else => {},
+        }
+    }
+    return counts;
+}
+
+test "local self-recursion is allowed" {
+    const counts = try scopingDiagnosticCounts(
+        \\|n| {
+        \\    fac = |x| if (x <= 1) 1 else x * fac(x - 1)
+        \\    fac(n)
+        \\}
+    );
+    try testing.expectEqual(@as(usize, 0), counts.forward_ref);
+    try testing.expectEqual(@as(usize, 0), counts.mutual);
+}
+
+test "backward reference to an earlier local def is allowed" {
+    const counts = try scopingDiagnosticCounts(
+        \\|_| {
+        \\    f = |x| x + 1
+        \\    g = |x| f(x)
+        \\    g(1)
+        \\}
+    );
+    try testing.expectEqual(@as(usize, 0), counts.forward_ref);
+    try testing.expectEqual(@as(usize, 0), counts.mutual);
+}
+
+test "nested self-recursion is allowed" {
+    const counts = try scopingDiagnosticCounts(
+        \\|_| {
+        \\    outer = |o| {
+        \\        inner = |x| if (x <= 1) 1 else inner(x - 1)
+        \\        inner(o)
+        \\    }
+        \\    outer(5)
+        \\}
+    );
+    try testing.expectEqual(@as(usize, 0), counts.forward_ref);
+    try testing.expectEqual(@as(usize, 0), counts.mutual);
+}
+
+test "forward reference to a later local def is use-before-definition" {
+    const counts = try scopingDiagnosticCounts(
+        \\|_| {
+        \\    g = |x| f(x)
+        \\    f = |x| x + 1
+        \\    g(1)
+        \\}
+    );
+    try testing.expectEqual(@as(usize, 1), counts.forward_ref);
+    try testing.expectEqual(@as(usize, 0), counts.mutual);
+}
+
+test "mutual recursion between local defs is reported" {
+    const counts = try scopingDiagnosticCounts(
+        \\|_| {
+        \\    is_even = |n| if (n == 0) True else is_odd(n - 1)
+        \\    is_odd = |n| if (n == 0) False else is_even(n - 1)
+        \\    is_even(4)
+        \\}
+    );
+    try testing.expectEqual(@as(usize, 0), counts.forward_ref);
+    try testing.expectEqual(@as(usize, 1), counts.mutual);
+}

--- a/src/canonicalize/test/node_store_test.zig
+++ b/src/canonicalize/test/node_store_test.zig
@@ -569,6 +569,21 @@ test "NodeStore round trip - Diagnostics" {
     });
 
     try diagnostics.append(gpa, CIR.Diagnostic{
+        .local_reference_before_definition = .{
+            .ident = rand_ident_idx(),
+            .region = rand_region(),
+        },
+    });
+
+    try diagnostics.append(gpa, CIR.Diagnostic{
+        .mutually_recursive_local_definitions = .{
+            .ident1 = rand_ident_idx(),
+            .ident2 = rand_ident_idx(),
+            .region = rand_region(),
+        },
+    });
+
+    try diagnostics.append(gpa, CIR.Diagnostic{
         .erroneous_value_use = .{
             .ident = rand_ident_idx(),
             .region = rand_region(),

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -117,6 +117,29 @@ expect_region_by_constraint_fn_var: std.AutoHashMap(Var, Region),
 current_expect_region: ?Region,
 /// Map representation all top level patterns, and if we've processed them yet
 top_level_ptrns: std.AutoHashMap(CIR.Pattern.Idx, DefProcessed),
+/// Local block-statement (`s_decl`) function patterns whose body is currently
+/// being type-checked. Used to detect self-recursion (and references to an
+/// enclosing in-flight def) of LOCAL function defs so their recursive references
+/// defer unification (fresh flex + a pending `local_recursive_refs` entry)
+/// instead of lowering the pattern var's rank, which would prevent
+/// generalization of the def's rigid type variables. Analogous to
+/// `top_level_ptrns` but for block-local defs.
+///
+/// Presence == "currently being checked" (defer); absence == normal
+/// lookup/instantiate. A reference can only resolve to the current def or an
+/// enclosing in-flight one: forward references to a *later* sibling, and local
+/// mutual recursion, are rejected during canonicalization (local defs are
+/// sequentially scoped), so this is always a single self/enclosing chain.
+local_processing_ptrns: std.AutoHashMapUnmanaged(CIR.Pattern.Idx, LocalDefProcessed) = .{},
+/// Recursive references recorded while checking a LOCAL block def's body (a
+/// self-reference, or a reference to an enclosing in-flight local def), pending
+/// validation once the def's lambda has generalized. Kept in a dedicated stack
+/// rather than the shared `constraints` list because sequential scoping
+/// guarantees local recursion is a single self/enclosing chain — never a mutual
+/// group — so these need no cycle machinery, no per-use instantiation, and no
+/// entanglement with the other constraint kinds (notably early-return / `?`
+/// constraints, which `processReturnConstraints` compacts mid-body).
+local_recursive_refs: std.ArrayListUnmanaged(LocalRecursiveRef) = .empty,
 /// The name of the enclosing function, if known.
 /// Used to provide better error messages when type checking lambda arguments.
 enclosing_func_name: ?Ident.Idx,
@@ -197,6 +220,23 @@ const InstantiationDispatcher = struct {
 
 /// Indicates if something has been processed or not
 const HasProcessed = enum { processed, processing, not_processed };
+
+/// A local block-statement (`s_decl`) function def whose body is currently being
+/// checked. Block defs are `s_decl` statements (not `CIR.Def`), so there is no
+/// `Def.Idx` — only the name (for error context) and pattern are tracked.
+const LocalDefProcessed = struct {
+    def_name: ?Ident.Idx,
+    pattern_idx: CIR.Pattern.Idx,
+};
+
+/// A recursive reference made inside a LOCAL block def's body, pending
+/// validation once the def's lambda has generalized. `pat_var` is the def's
+/// (eventually generalized) pattern var; `expr_var` is the reference's flex var.
+const LocalRecursiveRef = struct {
+    pat_var: Var,
+    expr_var: Var,
+    def_name: ?Ident.Idx,
+};
 
 /// A deferred def-level unification (def_var = ptrn_var = expr_var).
 const DeferredDefUnification = struct {
@@ -477,6 +517,8 @@ pub fn deinit(self: *Self) void {
     self.constraint_expr_by_fn_var.deinit();
     self.expect_region_by_constraint_fn_var.deinit();
     self.top_level_ptrns.deinit();
+    self.local_processing_ptrns.deinit(self.gpa);
+    self.local_recursive_refs.deinit(self.gpa);
     self.type_writer.deinit();
     self.deferred_def_unifications.deinit(self.gpa);
     self.instantiation_dispatchers.deinit(self.gpa);
@@ -5352,6 +5394,37 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                 }
             }
 
+            // Local block-def recursion. If this lookup targets a local `s_decl`
+            // function whose body is currently being checked, it's a recursive
+            // reference (to the def itself, or to an enclosing in-flight def).
+            // Defer unification — fresh flex now + a pending `local_recursive_refs`
+            // entry validated after the def generalizes — so we don't unify with
+            // the not-yet-generalized pattern var, which would lower its rank and
+            // prevent generalization of the def's rigid type parameters.
+            //
+            // A reference to an already-finished sibling local def is NOT in this
+            // map (removed after it generalizes), so it falls through to the tail
+            // below and instantiates normally.
+            if (self.local_processing_ptrns.get(lookup.pattern_idx)) |local_def| {
+                // The pattern is mid-check, so it must not be generalized yet.
+                std.debug.assert(self.types.resolveVar(pat_var).desc.rank != .generalized);
+
+                // Set the expr to be a flex
+                try self.unifyWith(expr_var, .{ .flex = Flex.init() }, env);
+
+                // Record for validation once the def's lambda has generalized.
+                // A dedicated stack, not the shared constraints list (sequential
+                // scoping makes this a single self/enclosing chain — see the
+                // `local_recursive_refs` field doc).
+                try self.local_recursive_refs.append(self.gpa, .{
+                    .pat_var = pat_var,
+                    .expr_var = expr_var,
+                    .def_name = local_def.def_name,
+                });
+
+                break :blk;
+            }
+
             // Instantiate if generalized, otherwise just use the pattern var
             const resolved_pat = self.types.resolveVar(pat_var);
             if (resolved_pat.desc.rank == Rank.generalized) {
@@ -6549,6 +6622,22 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                     }
                 };
 
+                // Register function defs as "currently processing" so recursive
+                // references in their own body defer unification (see the local
+                // recursion branch in `e_lookup_local`). Only function defs can
+                // legitimately be self-recursive; value defs (`x = x`) keep their
+                // existing diagnostics. Snapshot the pending-recursive-ref stack
+                // so we only validate the references recorded while checking THIS
+                // def's body.
+                const decl_is_fn = isFunctionDef(&self.cir.store, self.cir.store.getExpr(decl_stmt.expr));
+                const local_recursive_refs_top = self.local_recursive_refs.items.len;
+                if (decl_is_fn) {
+                    try self.local_processing_ptrns.put(self.gpa, decl_stmt.pattern, .{
+                        .def_name = self.getPatternIdent(decl_stmt.pattern),
+                        .pattern_idx = decl_stmt.pattern,
+                    });
+                }
+
                 does_fx = try self.checkExpr(decl_stmt.expr, env, expectation) or does_fx;
                 if (decl_stmt.anno == null and self.erroneous_value_exprs.contains(decl_stmt.expr)) {
                     try self.erroneous_value_patterns.put(self.gpa, decl_stmt.pattern, {});
@@ -6556,6 +6645,14 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
 
                 _ = try self.unify(decl_pattern_var, decl_expr_var, env);
                 _ = try self.unify(stmt_var, decl_pattern_var, env);
+
+                if (decl_is_fn) {
+                    // The def's lambda has generalized (inside checkExpr) and the
+                    // pattern var now carries the generalized function type, so it
+                    // is safe to validate the recursive references it recorded.
+                    try self.validateLocalRecursiveRefs(env, local_recursive_refs_top);
+                    _ = self.local_processing_ptrns.remove(decl_stmt.pattern);
+                }
             },
             .s_var => |var_stmt| {
                 // Check the pattern
@@ -8705,6 +8802,24 @@ fn processReturnConstraints(self: *Self, env: *Env) std.mem.Allocator.Error!void
     }
     std.debug.assert(self.constraints.items.items.len == original_len);
     self.constraints.items.shrinkRetainingCapacity(write_idx);
+}
+
+/// Validate the recursive references recorded while checking a LOCAL block def's
+/// body (those at index >= `from`), now that the def's lambda has generalized
+/// and its pattern var carries the generalized type. Sequential scoping forbids
+/// local mutual recursion, so every such reference is a self/enclosing one and a
+/// plain unification suffices (no per-use instantiation). The validated refs are
+/// then popped.
+fn validateLocalRecursiveRefs(self: *Self, env: *Env, from: usize) std.mem.Allocator.Error!void {
+    // Capture the end up front: validation only unifies, it never records new
+    // local recursive refs, so the range is stable.
+    const end = self.local_recursive_refs.items.len;
+    var i = from;
+    while (i < end) : (i += 1) {
+        const ref = self.local_recursive_refs.items[i];
+        _ = try self.unifyInContext(ref.pat_var, ref.expr_var, env, .{ .recursive_def = .{ .def_name = ref.def_name } });
+    }
+    self.local_recursive_refs.shrinkRetainingCapacity(from);
 }
 
 /// Check any accumulated constraints

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -261,7 +261,19 @@ const ScratchStaticDispatchConstraint = struct {
 /// In most cases, we don't defer constraint checking and unify things
 /// immediately. However, there are some cases where it's necessary.
 const Constraint = union(enum) {
-    eql: struct { expected: Var, actual: Var, ctx: problem.Context },
+    eql: struct {
+        expected: Var,
+        actual: Var,
+        ctx: problem.Context,
+        /// True when this is a `recursive_def` cross-reference to a *different*,
+        /// annotated member of a recursive group (mutual recursion). Such a
+        /// reference is instantiated per use-site at validation time so each
+        /// member keeps its own rigid type parameters; a self-reference (or an
+        /// unannotated target) stays monomorphic. Drives resolution, not the
+        /// error message — kept here rather than in `ctx` (which is purely
+        /// diagnostic) so it doesn't have to ride inside the problem context.
+        is_cross_reference: bool = false,
+    },
 
     pub const SafeList = MkSafeList(@This());
 };
@@ -5333,14 +5345,34 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                             // Cycle detected: store env for merge at cycle root.
                             _ = try self.deferred_cycle_envs.append(self.gpa, sub_env);
 
-                            // Use the def's closure/expr var directly. After
-                            // checkDef, e_closure rank elevation has already run,
-                            // so the closure var is at rank 2 — safe for
-                            // unification without pulling body vars below the
-                            // generalization rank.
                             const def = self.cir.store.getDef(processing_def.def_idx);
                             const def_expr_var = ModuleEnv.varFrom(def.expr);
-                            _ = try self.unify(expr_var, def_expr_var, env);
+                            if (def.annotation != null) {
+                                // Forward reference to an ANNOTATED member of the
+                                // recursive group (mutual recursion). Decouple the
+                                // reference with a flex var and defer a
+                                // cross-reference constraint to the cycle root,
+                                // where the target is generalized and instantiated
+                                // per use-site. Unifying directly with the target's
+                                // (not-yet-generalized) type would force the two
+                                // members' rigid type parameters to coincide,
+                                // producing a spurious `T(k)` != `T(k)`.
+                                try self.unifyWith(expr_var, .{ .flex = Flex.init() }, env);
+                                _ = try self.constraints.append(self.gpa, Constraint{ .eql = .{
+                                    .expected = def_expr_var,
+                                    .actual = expr_var,
+                                    .ctx = .{ .recursive_def = .{ .def_name = processing_def.def_name } },
+                                    .is_cross_reference = true,
+                                } });
+                            } else {
+                                // Unannotated member: the group is inferred together
+                                // and shares type variables, so link monomorphically.
+                                // After checkDef, e_closure rank elevation has run,
+                                // so the closure var is at rank 2 — safe to unify
+                                // without pulling body vars below the generalization
+                                // rank.
+                                _ = try self.unify(expr_var, def_expr_var, env);
+                            }
 
                             break :blk;
                         } else {
@@ -5364,11 +5396,36 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                         // Set the expr to be a flex
                         try self.unifyWith(expr_var, .{ .flex = Flex.init() }, env);
 
+                        // A reference to a *different*, ANNOTATED def in the cycle
+                        // (mutual recursion) is instantiated per use-site at
+                        // validation time, so the members' rigid type parameters
+                        // don't clash. A self-reference, or a reference to an
+                        // unannotated member, stays monomorphic: unannotated
+                        // mutually-recursive functions are inferred as a group and
+                        // must share their (not-yet-generalized) type variables.
+                        const is_cross_reference = (referenced_def.annotation != null) and
+                            if (self.current_processing_def) |current_def|
+                                current_def != processing_def.def_idx
+                            else
+                                false;
+
+                        // For a cross-reference, target the callee's expr var
+                        // rather than its pattern var: at the cycle root the
+                        // root's pattern var is not yet linked to its generalized
+                        // type (that def-level unification happens after the body
+                        // is checked), but every participant's expr var has been
+                        // generalized by then — so instantiation can find it.
+                        const constraint_expected = if (is_cross_reference)
+                            ModuleEnv.varFrom(referenced_def.expr)
+                        else
+                            pat_var;
+
                         // Write down this constraint for later validation
                         _ = try self.constraints.append(self.gpa, Constraint{ .eql = .{
-                            .expected = pat_var,
+                            .expected = constraint_expected,
                             .actual = expr_var,
                             .ctx = .{ .recursive_def = .{ .def_name = processing_def.def_name } },
+                            .is_cross_reference = is_cross_reference,
                         } });
 
                         // Detect mutual recursion through local lookups. If the
@@ -8822,6 +8879,21 @@ fn validateLocalRecursiveRefs(self: *Self, env: *Env, from: usize) std.mem.Alloc
     self.local_recursive_refs.shrinkRetainingCapacity(from);
 }
 
+/// Resolve one `eql` constraint. For a `recursive_def` cross-reference (mutual
+/// recursion) whose target has been generalized, instantiate the target so the
+/// reference gets fresh type parameters — otherwise the two members' rigid type
+/// variables would be forced to unify, producing a spurious `T(k)` != `T(k)`
+/// mismatch. Self-references (and any not-yet-generalized target) keep the
+/// monomorphic direct unification.
+fn resolveEqlConstraint(self: *Self, eql: anytype, env: *Env) std.mem.Allocator.Error!void {
+    if (eql.is_cross_reference and self.types.resolveVar(eql.expected).desc.rank == .generalized) {
+        const instantiated = try self.instantiateVar(eql.expected, env, .use_last_var);
+        _ = try self.unifyInContext(instantiated, eql.actual, env, eql.ctx);
+        return;
+    }
+    _ = try self.unifyInContext(eql.expected, eql.actual, env, eql.ctx);
+}
+
 /// Check any accumulated constraints
 fn checkConstraints(self: *Self, env: *Env) std.mem.Allocator.Error!void {
     const trace = tracy.trace(@src());
@@ -8832,7 +8904,7 @@ fn checkConstraints(self: *Self, env: *Env) std.mem.Allocator.Error!void {
         const constraint = self.constraints.get(idx);
         switch (constraint.*) {
             .eql => |eql| {
-                _ = try self.unifyInContext(eql.expected, eql.actual, env, eql.ctx);
+                try self.resolveEqlConstraint(eql, env);
             },
         }
     }

--- a/src/check/test/repros_test.zig
+++ b/src/check/test/repros_test.zig
@@ -474,3 +474,207 @@ test "check - repro - issue 9500 - equality on record alias of tag-union aliases
     defer test_env.deinit();
     try test_env.assertNoErrors();
 }
+
+test "check - repro - issue 9491 - local recursive def generalizes rigid type param" {
+    // A local, self-recursive annotated function on a parametric recursive
+    // nominal type, called through a separate annotated local helper, used to
+    // produce a spurious `RBTree(k)` != `RBTree(k)` mismatch because the
+    // recursive function's rigid type parameter was never generalized.
+    const src =
+        \\main! = |_args| {}
+        \\
+        \\RBTree(k) := [
+        \\    Empty,
+        \\    Node(RBTree(k)),
+        \\].{
+        \\    delete = |tree| {
+        \\        delRBTree : RBTree(k) -> RBTree(k)
+        \\        delRBTree = |inner| {
+        \\            match inner {
+        \\                RBTree.Node(Empty) => Empty
+        \\                RBTree.Node(RBTree.Node(x)) => RBTree.Node(x)->delRBTree()
+        \\                Empty => Empty
+        \\            }
+        \\        }
+        \\        delCurr : RBTree(k) -> RBTree(k)
+        \\        delCurr = |t| {
+        \\            match t {
+        \\                RBTree.Node(inner) => inner->delRBTree()
+        \\                _ => t
+        \\            }
+        \\        }
+        \\        tree->delCurr()
+        \\    }
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("Test", src);
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+}
+
+test "check - repro - issue 9491 - distinct type param names still unify" {
+    // Same as above, but the helper uses a differently-named type parameter.
+    // Before the fix this surfaced as `RBTree(j)` != `RBTree(k)`, proving the
+    // two sides were distinct ungeneralized rigids.
+    const src =
+        \\main! = |_args| {}
+        \\
+        \\RBTree(k) := [
+        \\    Empty,
+        \\    Node(RBTree(k)),
+        \\].{
+        \\    delete = |tree| {
+        \\        delRBTree : RBTree(k) -> RBTree(k)
+        \\        delRBTree = |inner| {
+        \\            match inner {
+        \\                RBTree.Node(Empty) => Empty
+        \\                RBTree.Node(RBTree.Node(x)) => RBTree.Node(x)->delRBTree()
+        \\                Empty => Empty
+        \\            }
+        \\        }
+        \\        delCurr : RBTree(j) -> RBTree(j)
+        \\        delCurr = |t| {
+        \\            match t {
+        \\                RBTree.Node(inner) => inner->delRBTree()
+        \\                _ => t
+        \\            }
+        \\        }
+        \\        tree->delCurr()
+        \\    }
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("Test", src);
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+}
+
+test "check - repro - issue 9491 - self-recursive local fn generalizes (no nominal)" {
+    // A self-recursive local annotated function with a rigid type parameter,
+    // called by a separate annotated local helper, must generalize so each call
+    // site instantiates a fresh type parameter.
+    const src =
+        \\main! = |_args| {
+        \\    loop : a -> a
+        \\    loop = |z| loop(z)
+        \\    caller : b -> b
+        \\    caller = |w| loop(w)
+        \\    _ = caller
+        \\    {}
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("Test", src);
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+}
+
+test "check - repro - issue 9491 - nested self-recursive local fns generalize" {
+    // The self-recursion generalization fix must work for local defs nested
+    // arbitrarily deep inside other function bodies, not just one level down.
+    const src =
+        \\main! = |_args| {}
+        \\
+        \\RBTree(k) := [
+        \\    Empty,
+        \\    Node(RBTree(k)),
+        \\].{
+        \\    delete = |tree| {
+        \\        outer = |o| {
+        \\            delRBTree : RBTree(k) -> RBTree(k)
+        \\            delRBTree = |inner| {
+        \\                match inner {
+        \\                    RBTree.Node(Empty) => Empty
+        \\                    RBTree.Node(RBTree.Node(x)) => RBTree.Node(x)->delRBTree()
+        \\                    Empty => Empty
+        \\                }
+        \\            }
+        \\            delCurr : RBTree(k) -> RBTree(k)
+        \\            delCurr = |t| {
+        \\                match t {
+        \\                    RBTree.Node(i2) => i2->delRBTree()
+        \\                    _ => t
+        \\                }
+        \\            }
+        \\            o->delCurr()
+        \\        }
+        \\        tree->outer()
+        \\    }
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("Test", src);
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+}
+
+test "check - repro - self-recursive local fn after early return in enclosing body" {
+    // An early `return` in the enclosing function body records an early-return
+    // constraint that `processReturnConstraints` later compacts out of the
+    // shared constraint list while checking the local def's lambda. The local
+    // def's recursive reference is tracked in a dedicated stack (NOT that shared
+    // list), so the compaction cannot affect its validation. Well-typed: no
+    // spurious errors.
+    const src =
+        \\main! = |_args| {
+        \\    f : U64 -> U64
+        \\    f = |n| {
+        \\        if n == 0 {
+        \\            return 0
+        \\        }
+        \\        loop : a -> a
+        \\        loop = |z| loop(z)
+        \\        _ = loop
+        \\        n
+        \\    }
+        \\    _ = f
+        \\    {}
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("Test", src);
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+}
+
+test "check - repro - self-recursive local fn recursive use still type-checked after early return" {
+    // Companion to the well-typed case above: the self-recursive local def's
+    // recursive reference must STILL be validated after the early-return
+    // compaction, so an ill-typed recursive use is caught. Here the recursive
+    // call result is forced to `Str`, contradicting the rigid `a` in
+    // `loop : a -> a`. If the reference were dropped, no error would be reported.
+    const src =
+        \\use_str : Str -> Str
+        \\use_str = |s| s
+        \\
+        \\main! = |_args| {
+        \\    f : U64 -> U64
+        \\    f = |n| {
+        \\        if n == 0 {
+        \\            return 0
+        \\        }
+        \\        loop : a -> a
+        \\        loop = |z| {
+        \\            r = loop(z)
+        \\            _ = use_str(r)
+        \\            z
+        \\        }
+        \\        _ = loop
+        \\        n
+        \\    }
+        \\    _ = f
+        \\    {}
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("Test", src);
+    defer test_env.deinit();
+
+    try test_env.assertOneTypeError("TYPE MISMATCH");
+}

--- a/src/check/test/repros_test.zig
+++ b/src/check/test/repros_test.zig
@@ -678,3 +678,32 @@ test "check - repro - self-recursive local fn recursive use still type-checked a
 
     try test_env.assertOneTypeError("TYPE MISMATCH");
 }
+
+test "check - repro - issue 9491 follow-up - top-level mutually recursive parametric fns" {
+    // Mutually recursive functions over a parametric recursive nominal type must
+    // type-check: each cross-call instantiates the callee, so the two members'
+    // rigid type parameters don't clash into a spurious `T(k)` != `T(k)`.
+    const src =
+        \\RBMut(k) := [
+        \\    Empty,
+        \\    Node(RBMut(k)),
+        \\]
+        \\
+        \\delA : RBMut(k) -> RBMut(k)
+        \\delA = |inner| match inner {
+        \\    RBMut.Node(x) => x->delB()
+        \\    Empty => Empty
+        \\}
+        \\
+        \\delB : RBMut(k) -> RBMut(k)
+        \\delB = |t| match t {
+        \\    RBMut.Node(inner) => inner->delA()
+        \\    _ => t
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("Test", src);
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+}

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -1245,7 +1245,10 @@ const core_tests = [_]TestCase{
         .expected = .{ .inspect_str = "120.0" },
     },
     .{
-        .name = "inspect: mutual recursion in local lambdas",
+        // Mutual recursion between local definitions is not supported: local
+        // definitions are sequential (self-reference and backward references
+        // only). This must be reported as an error rather than evaluated.
+        .name = "problem: mutual recursion in local lambdas",
         .source =
         \\{
         \\    is_even = |n| if (n == 0.I64) True else is_odd(n - 1.I64)
@@ -1253,16 +1256,39 @@ const core_tests = [_]TestCase{
         \\    is_even(6.I64)
         \\}
         ,
-        .expected = .{ .inspect_str = "True" },
+        .expected = .{ .problem = {} },
     },
     .{
-        .name = "inspect: mutual recursion in untyped closures",
+        .name = "problem: mutual recursion in untyped closures",
         .source =
         \\{
         \\    is_even = |n| if (n == 0) True else is_odd(n - 1)
         \\    is_odd = |n| if (n == 0) False else is_even(n - 1)
         \\    if (is_even(4)) 1 else 0
         \\}
+        ,
+        .expected = .{ .problem = {} },
+    },
+    .{
+        // Coverage migrated from the (now-disallowed) local mutual-recursion
+        // cases above: mutual recursion is supported at the top level and must
+        // still evaluate to the same results.
+        .name = "inspect: mutual recursion at top level (typed)",
+        .source_kind = .module,
+        .source =
+        \\is_even = |n| if (n == 0.I64) True else is_odd(n - 1.I64)
+        \\is_odd = |n| if (n == 0.I64) False else is_even(n - 1.I64)
+        \\main = is_even(6.I64)
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "inspect: mutual recursion at top level (untyped)",
+        .source_kind = .module,
+        .source =
+        \\is_even = |n| if (n == 0) True else is_odd(n - 1)
+        \\is_odd = |n| if (n == 0) False else is_even(n - 1)
+        \\main = if (is_even(4)) 1 else 0
         ,
         .expected = .{ .inspect_str = "1.0" },
     },

--- a/test/snapshots/eval/issue8783_fold_recursive_opaque.md
+++ b/test/snapshots/eval/issue8783_fold_recursive_opaque.md
@@ -170,7 +170,7 @@ NO CHANGE
 				(e-lookup-local
 					(p-assign (ident "acc")))
 				(e-literal (string " "))
-				(e-call (constraint-fn-var 226)
+				(e-call (constraint-fn-var 228)
 					(e-lookup-local
 						(p-assign (ident "process")))
 					(e-lookup-local
@@ -239,7 +239,7 @@ NO CHANGE
 			(ty-lookup (name "Elem") (local))))
 	(d-let
 		(p-assign (ident "result"))
-		(e-call (constraint-fn-var 288)
+		(e-call (constraint-fn-var 290)
 			(e-lookup-local
 				(p-assign (ident "process")))
 			(e-lookup-local

--- a/test/snapshots/eval/list_fold.md
+++ b/test/snapshots/eval/list_fold.md
@@ -143,7 +143,7 @@ expect sumResult == 10
 					(e-block
 						(s-reassign
 							(p-assign (ident "$state"))
-							(e-call (constraint-fn-var 224)
+							(e-call (constraint-fn-var 222)
 								(e-lookup-local
 									(p-assign (ident "step")))
 								(e-lookup-local
@@ -166,7 +166,7 @@ expect sumResult == 10
 				(ty-rigid-var-lookup (ty-rigid-var (name "state"))))))
 	(d-let
 		(p-assign (ident "sumResult"))
-		(e-call (constraint-fn-var 395)
+		(e-call (constraint-fn-var 393)
 			(e-lookup-local
 				(p-assign (ident "fold")))
 			(e-list
@@ -180,7 +180,7 @@ expect sumResult == 10
 				(args
 					(p-assign (ident "acc"))
 					(p-assign (ident "x")))
-				(e-dispatch-call (method "plus") (constraint-fn-var 393)
+				(e-dispatch-call (method "plus") (constraint-fn-var 391)
 					(receiver
 						(e-lookup-local
 							(p-assign (ident "acc"))))

--- a/test/snapshots/expr/ann_effectful_fn.md
+++ b/test/snapshots/expr/ann_effectful_fn.md
@@ -115,7 +115,7 @@ EndOfFile,
 				(p-record-destructure
 					(destructs)))
 			(e-runtime-error (tag "not_implemented"))))
-	(e-call (constraint-fn-var 57)
+	(e-call (constraint-fn-var 56)
 		(e-lookup-local
 			(p-assign (ident "launchTheNukes")))
 		(e-empty_record)))

--- a/test/snapshots/fuzz_crash/fuzz_crash_023.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_023.md
@@ -2517,7 +2517,7 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 3018)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 3016)
 									(receiver
 										(e-match
 											(match
@@ -2542,7 +2542,7 @@ expect {
 														(value
 															(e-num (value "12"))))))))
 									(args
-										(e-dispatch-call (method "times") (constraint-fn-var 3013)
+										(e-dispatch-call (method "times") (constraint-fn-var 3011)
 											(receiver
 												(e-num (value "5")))
 											(args
@@ -2557,18 +2557,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 3126)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 3124)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 3091)
+															(e-dispatch-call (method "plus") (constraint-fn-var 3089)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 3226)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 3224)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 3191)
+															(e-dispatch-call (method "minus") (constraint-fn-var 3189)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2583,11 +2583,11 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 3336)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 3334)
 										(receiver
 											(e-num (value "12")))
 										(args
-											(e-dispatch-call (method "div_by") (constraint-fn-var 3331)
+											(e-dispatch-call (method "div_by") (constraint-fn-var 3329)
 												(receiver
 													(e-num (value "3")))
 												(args
@@ -2602,12 +2602,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 3402)
+													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 3400)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 3369)
+																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 3367)
 																			(receiver
 																				(e-match
 																					(match

--- a/test/snapshots/fuzz_crash/fuzz_crash_027.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_027.md
@@ -2259,7 +2259,7 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 2725)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 2723)
 									(receiver
 										(e-match
 											(match
@@ -2284,7 +2284,7 @@ expect {
 														(value
 															(e-num (value "12"))))))))
 									(args
-										(e-dispatch-call (method "times") (constraint-fn-var 2720)
+										(e-dispatch-call (method "times") (constraint-fn-var 2718)
 											(receiver
 												(e-num (value "5")))
 											(args
@@ -2299,18 +2299,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 2833)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 2831)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 2798)
+															(e-dispatch-call (method "plus") (constraint-fn-var 2796)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 2933)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 2931)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 2898)
+															(e-dispatch-call (method "minus") (constraint-fn-var 2896)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2325,11 +2325,11 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 3043)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 3041)
 										(receiver
 											(e-num (value "12")))
 										(args
-											(e-dispatch-call (method "div_by") (constraint-fn-var 3038)
+											(e-dispatch-call (method "div_by") (constraint-fn-var 3036)
 												(receiver
 													(e-num (value "3")))
 												(args
@@ -2344,12 +2344,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "ned") (constraint-fn-var 3109)
+													(e-dispatch-call (method "ned") (constraint-fn-var 3107)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "statod") (constraint-fn-var 3076)
+																		(e-dispatch-call (method "statod") (constraint-fn-var 3074)
 																			(receiver
 																				(e-match
 																					(match

--- a/test/snapshots/local_let_forward_reference.md
+++ b/test/snapshots/local_let_forward_reference.md
@@ -1,0 +1,108 @@
+# META
+~~~ini
+description=A local definition used before it is defined (sequential scoping)
+type=expr
+canonicalize_diagnostics=true
+~~~
+# SOURCE
+~~~roc
+|_| {
+    g = |x| f(x)
+    f = |x| x + 1
+    g(1)
+}
+~~~
+# EXPECTED
+USED BEFORE DEFINITION - local_let_forward_reference.md:2:13:2:14
+# PROBLEMS
+**USED BEFORE DEFINITION**
+The name `f` is used before it is defined.
+
+Local definitions are evaluated in order: a definition can refer to itself or to definitions written before it, but not to definitions written later in the same block. Move `f` above this use, or move both to the top level.
+
+**local_let_forward_reference.md:2:13:2:14:**
+```roc
+    g = |x| f(x)
+```
+            ^
+
+
+# TOKENS
+~~~zig
+OpBar,Underscore,OpBar,OpenCurly,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,OpPlus,Int,
+LowerIdent,NoSpaceOpenRound,Int,CloseRound,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-lambda
+	(args
+		(p-underscore))
+	(e-block
+		(statements
+			(s-decl
+				(p-ident (raw "g"))
+				(e-lambda
+					(args
+						(p-ident (raw "x")))
+					(e-apply
+						(e-ident (raw "f"))
+						(e-ident (raw "x")))))
+			(s-decl
+				(p-ident (raw "f"))
+				(e-lambda
+					(args
+						(p-ident (raw "x")))
+					(e-binop (op "+")
+						(e-ident (raw "x"))
+						(e-int (raw "1")))))
+			(e-apply
+				(e-ident (raw "g"))
+				(e-int (raw "1"))))))
+~~~
+# FORMATTED
+~~~roc
+|_| {
+	g = |x| f(x)
+	f = |x| x + 1
+	g(1)
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(e-lambda
+	(args
+		(p-underscore))
+	(e-block
+		(s-let
+			(p-assign (ident "g"))
+			(e-lambda
+				(args
+					(p-assign (ident "x")))
+				(e-call
+					(e-runtime-error (tag "local_reference_before_definition"))
+					(e-lookup-local
+						(p-assign (ident "x"))))))
+		(s-let
+			(p-assign (ident "f"))
+			(e-lambda
+				(args
+					(p-assign (ident "x")))
+				(e-dispatch-call (method "plus") (constraint-fn-var 58)
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "x"))))
+					(args
+						(e-num (value "1"))))))
+		(e-call (constraint-fn-var 93)
+			(e-lookup-local
+				(p-assign (ident "g")))
+			(e-num (value "1")))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "_arg -> Error"))
+~~~

--- a/test/snapshots/local_let_mutual_recursion.md
+++ b/test/snapshots/local_let_mutual_recursion.md
@@ -1,0 +1,157 @@
+# META
+~~~ini
+description=Mutual recursion between local definitions is not allowed (sequential scoping)
+type=expr
+canonicalize_diagnostics=true
+~~~
+# SOURCE
+~~~roc
+|_| {
+    is_even = |n| if (n == 0) Bool.True else is_odd(n - 1)
+    is_odd = |n| if (n == 0) Bool.False else is_even(n - 1)
+    is_even(4)
+}
+~~~
+# EXPECTED
+MUTUALLY RECURSIVE LOCAL DEFINITIONS - local_let_mutual_recursion.md:2:46:2:52
+# PROBLEMS
+**MUTUALLY RECURSIVE LOCAL DEFINITIONS**
+The local definitions `is_even` and `is_odd` are mutually recursive, which isn't supported for local definitions.
+
+Local definitions are evaluated in order and can only refer to themselves or to earlier definitions. Move these mutually recursive definitions to the top level, where mutual recursion is supported.
+
+**local_let_mutual_recursion.md:2:46:2:52:**
+```roc
+    is_even = |n| if (n == 0) Bool.True else is_odd(n - 1)
+```
+                                             ^^^^^^
+
+
+# TOKENS
+~~~zig
+OpBar,Underscore,OpBar,OpenCurly,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,KwIf,OpenRound,LowerIdent,OpEquals,Int,CloseRound,UpperIdent,NoSpaceDotUpperIdent,KwElse,LowerIdent,NoSpaceOpenRound,LowerIdent,OpBinaryMinus,Int,CloseRound,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,KwIf,OpenRound,LowerIdent,OpEquals,Int,CloseRound,UpperIdent,NoSpaceDotUpperIdent,KwElse,LowerIdent,NoSpaceOpenRound,LowerIdent,OpBinaryMinus,Int,CloseRound,
+LowerIdent,NoSpaceOpenRound,Int,CloseRound,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-lambda
+	(args
+		(p-underscore))
+	(e-block
+		(statements
+			(s-decl
+				(p-ident (raw "is_even"))
+				(e-lambda
+					(args
+						(p-ident (raw "n")))
+					(e-if-then-else
+						(e-tuple
+							(e-binop (op "==")
+								(e-ident (raw "n"))
+								(e-int (raw "0"))))
+						(e-tag (raw "Bool.True"))
+						(e-apply
+							(e-ident (raw "is_odd"))
+							(e-binop (op "-")
+								(e-ident (raw "n"))
+								(e-int (raw "1")))))))
+			(s-decl
+				(p-ident (raw "is_odd"))
+				(e-lambda
+					(args
+						(p-ident (raw "n")))
+					(e-if-then-else
+						(e-tuple
+							(e-binop (op "==")
+								(e-ident (raw "n"))
+								(e-int (raw "0"))))
+						(e-tag (raw "Bool.False"))
+						(e-apply
+							(e-ident (raw "is_even"))
+							(e-binop (op "-")
+								(e-ident (raw "n"))
+								(e-int (raw "1")))))))
+			(e-apply
+				(e-ident (raw "is_even"))
+				(e-int (raw "4"))))))
+~~~
+# FORMATTED
+~~~roc
+|_| {
+	is_even = |n| if (n == 0) Bool.True else is_odd(n - 1)
+	is_odd = |n| if (n == 0) Bool.False else is_even(n - 1)
+	is_even(4)
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(e-lambda
+	(args
+		(p-underscore))
+	(e-block
+		(s-let
+			(p-assign (ident "is_even"))
+			(e-lambda
+				(args
+					(p-assign (ident "n")))
+				(e-if
+					(if-branches
+						(if-branch
+							(e-method-eq (negated "false")
+								(lhs
+									(e-lookup-local
+										(p-assign (ident "n"))))
+								(rhs
+									(e-num (value "0"))))
+							(e-nominal-external
+								(builtin)
+								(e-tag (name "True")))))
+					(if-else
+						(e-call
+							(e-runtime-error (tag "local_reference_before_definition"))
+							(e-dispatch-call (method "minus") (constraint-fn-var 122)
+								(receiver
+									(e-lookup-local
+										(p-assign (ident "n"))))
+								(args
+									(e-num (value "1")))))))))
+		(s-let
+			(p-assign (ident "is_odd"))
+			(e-lambda
+				(args
+					(p-assign (ident "n")))
+				(e-if
+					(if-branches
+						(if-branch
+							(e-method-eq (negated "false")
+								(lhs
+									(e-lookup-local
+										(p-assign (ident "n"))))
+								(rhs
+									(e-num (value "0"))))
+							(e-nominal-external
+								(builtin)
+								(e-tag (name "False")))))
+					(if-else
+						(e-call (constraint-fn-var 207)
+							(e-lookup-local
+								(p-assign (ident "is_even")))
+							(e-dispatch-call (method "minus") (constraint-fn-var 205)
+								(receiver
+									(e-lookup-local
+										(p-assign (ident "n"))))
+								(args
+									(e-num (value "1")))))))))
+		(e-call (constraint-fn-var 246)
+			(e-lookup-local
+				(p-assign (ident "is_even")))
+			(e-num (value "4")))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "_arg -> Error"))
+~~~

--- a/test/snapshots/local_let_self_recursion.md
+++ b/test/snapshots/local_let_self_recursion.md
@@ -1,0 +1,128 @@
+# META
+~~~ini
+description=Local self-recursion and backward references are allowed (sequential scoping)
+type=expr
+canonicalize_diagnostics=true
+~~~
+# SOURCE
+~~~roc
+|n| {
+    fac = |x| if (x <= 1) 1 else x * fac(x - 1)
+    helper = |y| fac(y)
+    helper(n)
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+OpBar,LowerIdent,OpBar,OpenCurly,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,KwIf,OpenRound,LowerIdent,OpLessThanOrEq,Int,CloseRound,Int,KwElse,LowerIdent,OpStar,LowerIdent,NoSpaceOpenRound,LowerIdent,OpBinaryMinus,Int,CloseRound,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+LowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-lambda
+	(args
+		(p-ident (raw "n")))
+	(e-block
+		(statements
+			(s-decl
+				(p-ident (raw "fac"))
+				(e-lambda
+					(args
+						(p-ident (raw "x")))
+					(e-if-then-else
+						(e-tuple
+							(e-binop (op "<=")
+								(e-ident (raw "x"))
+								(e-int (raw "1"))))
+						(e-int (raw "1"))
+						(e-binop (op "*")
+							(e-ident (raw "x"))
+							(e-apply
+								(e-ident (raw "fac"))
+								(e-binop (op "-")
+									(e-ident (raw "x"))
+									(e-int (raw "1"))))))))
+			(s-decl
+				(p-ident (raw "helper"))
+				(e-lambda
+					(args
+						(p-ident (raw "y")))
+					(e-apply
+						(e-ident (raw "fac"))
+						(e-ident (raw "y")))))
+			(e-apply
+				(e-ident (raw "helper"))
+				(e-ident (raw "n"))))))
+~~~
+# FORMATTED
+~~~roc
+|n| {
+	fac = |x| if (x <= 1) 1 else x * fac(x - 1)
+	helper = |y| fac(y)
+	helper(n)
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(e-lambda
+	(args
+		(p-assign (ident "n")))
+	(e-block
+		(s-let
+			(p-assign (ident "fac"))
+			(e-lambda
+				(args
+					(p-assign (ident "x")))
+				(e-if
+					(if-branches
+						(if-branch
+							(e-dispatch-call (method "is_lte") (constraint-fn-var 69)
+								(receiver
+									(e-lookup-local
+										(p-assign (ident "x"))))
+								(args
+									(e-num (value "1"))))
+							(e-num (value "1"))))
+					(if-else
+						(e-dispatch-call (method "times") (constraint-fn-var 139)
+							(receiver
+								(e-lookup-local
+									(p-assign (ident "x"))))
+							(args
+								(e-call (constraint-fn-var 138)
+									(e-lookup-local
+										(p-assign (ident "fac")))
+									(e-dispatch-call (method "minus") (constraint-fn-var 134)
+										(receiver
+											(e-lookup-local
+												(p-assign (ident "x"))))
+										(args
+											(e-num (value "1")))))))))))
+		(s-let
+			(p-assign (ident "helper"))
+			(e-lambda
+				(args
+					(p-assign (ident "y")))
+				(e-call (constraint-fn-var 149)
+					(e-lookup-local
+						(p-assign (ident "fac")))
+					(e-lookup-local
+						(p-assign (ident "y"))))))
+		(e-call (constraint-fn-var 158)
+			(e-lookup-local
+				(p-assign (ident "helper")))
+			(e-lookup-local
+				(p-assign (ident "n"))))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "a -> a where [a.from_numeral : Numeral -> Try(a, [InvalidNumeral(Str)]), a.is_lte : a, a -> Bool, a.minus : a, a -> a, a.times : a, a -> a]"))
+~~~

--- a/test/snapshots/nominal/mutual_recursion_parametric.md
+++ b/test/snapshots/nominal/mutual_recursion_parametric.md
@@ -1,0 +1,218 @@
+# META
+~~~ini
+description=Mutually recursive parametric functions (associated items) should type-check (issue #9491 follow-up)
+type=file:RBMut.roc
+~~~
+# SOURCE
+~~~roc
+RBMut(k) := [
+	Empty,
+	Node(RBMut(k)),
+].{
+	delA : RBMut(k) -> RBMut(k)
+	delA = |inner| match inner {
+		RBMut.Node(x) => x->delB()
+		Empty => Empty
+	}
+	delB : RBMut(k) -> RBMut(k)
+	delB = |t| match t {
+		RBMut.Node(inner) => inner->delA()
+		_ => t
+	}
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpColonEqual,OpenSquare,
+UpperIdent,Comma,
+UpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,CloseRound,Comma,
+CloseSquare,Dot,OpenCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpArrow,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,KwMatch,LowerIdent,OpenCurly,
+UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpFatArrow,LowerIdent,OpArrow,LowerIdent,NoSpaceOpenRound,CloseRound,
+UpperIdent,OpFatArrow,UpperIdent,
+CloseCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpArrow,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,KwMatch,LowerIdent,OpenCurly,
+UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpFatArrow,LowerIdent,OpArrow,LowerIdent,NoSpaceOpenRound,CloseRound,
+Underscore,OpFatArrow,LowerIdent,
+CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "RBMut")
+				(args
+					(ty-var (raw "k"))))
+			(ty-tag-union
+				(tags
+					(ty (name "Empty"))
+					(ty-apply
+						(ty (name "Node"))
+						(ty-apply
+							(ty (name "RBMut"))
+							(ty-var (raw "k"))))))
+			(associated
+				(s-type-anno (name "delA")
+					(ty-fn
+						(ty-apply
+							(ty (name "RBMut"))
+							(ty-var (raw "k")))
+						(ty-apply
+							(ty (name "RBMut"))
+							(ty-var (raw "k")))))
+				(s-decl
+					(p-ident (raw "delA"))
+					(e-lambda
+						(args
+							(p-ident (raw "inner")))
+						(e-match
+							(e-ident (raw "inner"))
+							(branches
+								(branch
+									(p-tag (raw ".Node")
+										(p-ident (raw "x")))
+									(e-arrow-call
+										(e-ident (raw "x"))
+										(e-apply
+											(e-ident (raw "delB")))))
+								(branch
+									(p-tag (raw "Empty"))
+									(e-tag (raw "Empty")))))))
+				(s-type-anno (name "delB")
+					(ty-fn
+						(ty-apply
+							(ty (name "RBMut"))
+							(ty-var (raw "k")))
+						(ty-apply
+							(ty (name "RBMut"))
+							(ty-var (raw "k")))))
+				(s-decl
+					(p-ident (raw "delB"))
+					(e-lambda
+						(args
+							(p-ident (raw "t")))
+						(e-match
+							(e-ident (raw "t"))
+							(branches
+								(branch
+									(p-tag (raw ".Node")
+										(p-ident (raw "inner")))
+									(e-arrow-call
+										(e-ident (raw "inner"))
+										(e-apply
+											(e-ident (raw "delA")))))
+								(branch
+									(p-underscore)
+									(e-ident (raw "t")))))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "RBMut.delA"))
+		(e-lambda
+			(args
+				(p-assign (ident "inner")))
+			(e-match
+				(match
+					(cond
+						(e-lookup-local
+							(p-assign (ident "inner"))))
+					(branches
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-nominal
+										(p-applied-tag))))
+							(value
+								(e-call (constraint-fn-var 127)
+									(e-lookup-local
+										(p-assign (ident "RBMut.delB")))
+									(e-lookup-local
+										(p-assign (ident "x"))))))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-applied-tag)))
+							(value
+								(e-tag (name "Empty"))))))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-apply (name "RBMut") (local)
+					(ty-rigid-var (name "k")))
+				(ty-apply (name "RBMut") (local)
+					(ty-rigid-var-lookup (ty-rigid-var (name "k")))))))
+	(d-let
+		(p-assign (ident "RBMut.delB"))
+		(e-lambda
+			(args
+				(p-assign (ident "t")))
+			(e-match
+				(match
+					(cond
+						(e-lookup-local
+							(p-assign (ident "t"))))
+					(branches
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-nominal
+										(p-applied-tag))))
+							(value
+								(e-call (constraint-fn-var 124)
+									(e-lookup-local
+										(p-assign (ident "RBMut.delA")))
+									(e-lookup-local
+										(p-assign (ident "inner"))))))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-underscore)))
+							(value
+								(e-lookup-local
+									(p-assign (ident "t")))))))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-apply (name "RBMut") (local)
+					(ty-rigid-var (name "k")))
+				(ty-apply (name "RBMut") (local)
+					(ty-rigid-var-lookup (ty-rigid-var (name "k")))))))
+	(s-nominal-decl
+		(ty-header (name "RBMut")
+			(ty-args
+				(ty-rigid-var (name "k"))))
+		(ty-tag-union
+			(ty-tag-name (name "Empty"))
+			(ty-tag-name (name "Node")
+				(ty-apply (name "RBMut") (local)
+					(ty-rigid-var-lookup (ty-rigid-var (name "k"))))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "RBMut(k) -> RBMut(k)"))
+		(patt (type "RBMut(k) -> RBMut(k)")))
+	(type_decls
+		(nominal (type "RBMut(k)")
+			(ty-header (name "RBMut")
+				(ty-args
+					(ty-rigid-var (name "k"))))))
+	(expressions
+		(expr (type "RBMut(k) -> RBMut(k)"))
+		(expr (type "RBMut(k) -> RBMut(k)"))))
+~~~

--- a/test/snapshots/nominal/nominal_recursive_local_def_generalization.md
+++ b/test/snapshots/nominal/nominal_recursive_local_def_generalization.md
@@ -1,0 +1,265 @@
+# META
+~~~ini
+description=Parametric recursive nominal type with local recursive function defs generalizes correctly (issue #9491)
+type=file:RBTree.roc
+~~~
+# SOURCE
+~~~roc
+RBTree(k) := [
+	Empty,
+	Node(RBTree(k)),
+].{
+	delete = |tree| {
+		delRBTree : RBTree(k) -> RBTree(k)
+		delRBTree = |inner| {
+			match inner {
+				RBTree.Node(Empty) => Empty
+				RBTree.Node(RBTree.Node(x)) => RBTree.Node(x)->delRBTree()
+				Empty => Empty
+			}
+		}
+		delCurr : RBTree(k) -> RBTree(k)
+		delCurr = |t| {
+			match t {
+				RBTree.Node(inner) => inner->delRBTree()
+				_ => t
+			}
+		}
+		tree->delCurr()
+	}
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpColonEqual,OpenSquare,
+UpperIdent,Comma,
+UpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,CloseRound,Comma,
+CloseSquare,Dot,OpenCurly,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpArrow,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+KwMatch,LowerIdent,OpenCurly,
+UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,OpFatArrow,UpperIdent,
+UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,CloseRound,OpFatArrow,UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpArrow,LowerIdent,NoSpaceOpenRound,CloseRound,
+UpperIdent,OpFatArrow,UpperIdent,
+CloseCurly,
+CloseCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpArrow,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+KwMatch,LowerIdent,OpenCurly,
+UpperIdent,NoSpaceDotUpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpFatArrow,LowerIdent,OpArrow,LowerIdent,NoSpaceOpenRound,CloseRound,
+Underscore,OpFatArrow,LowerIdent,
+CloseCurly,
+CloseCurly,
+LowerIdent,OpArrow,LowerIdent,NoSpaceOpenRound,CloseRound,
+CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "RBTree")
+				(args
+					(ty-var (raw "k"))))
+			(ty-tag-union
+				(tags
+					(ty (name "Empty"))
+					(ty-apply
+						(ty (name "Node"))
+						(ty-apply
+							(ty (name "RBTree"))
+							(ty-var (raw "k"))))))
+			(associated
+				(s-decl
+					(p-ident (raw "delete"))
+					(e-lambda
+						(args
+							(p-ident (raw "tree")))
+						(e-block
+							(statements
+								(s-type-anno (name "delRBTree")
+									(ty-fn
+										(ty-apply
+											(ty (name "RBTree"))
+											(ty-var (raw "k")))
+										(ty-apply
+											(ty (name "RBTree"))
+											(ty-var (raw "k")))))
+								(s-decl
+									(p-ident (raw "delRBTree"))
+									(e-lambda
+										(args
+											(p-ident (raw "inner")))
+										(e-block
+											(statements
+												(e-match
+													(e-ident (raw "inner"))
+													(branches
+														(branch
+															(p-tag (raw ".Node")
+																(p-tag (raw "Empty")))
+															(e-tag (raw "Empty")))
+														(branch
+															(p-tag (raw ".Node")
+																(p-tag (raw ".Node")
+																	(p-ident (raw "x"))))
+															(e-arrow-call
+																(e-apply
+																	(e-tag (raw "RBTree.Node"))
+																	(e-ident (raw "x")))
+																(e-apply
+																	(e-ident (raw "delRBTree")))))
+														(branch
+															(p-tag (raw "Empty"))
+															(e-tag (raw "Empty")))))))))
+								(s-type-anno (name "delCurr")
+									(ty-fn
+										(ty-apply
+											(ty (name "RBTree"))
+											(ty-var (raw "k")))
+										(ty-apply
+											(ty (name "RBTree"))
+											(ty-var (raw "k")))))
+								(s-decl
+									(p-ident (raw "delCurr"))
+									(e-lambda
+										(args
+											(p-ident (raw "t")))
+										(e-block
+											(statements
+												(e-match
+													(e-ident (raw "t"))
+													(branches
+														(branch
+															(p-tag (raw ".Node")
+																(p-ident (raw "inner")))
+															(e-arrow-call
+																(e-ident (raw "inner"))
+																(e-apply
+																	(e-ident (raw "delRBTree")))))
+														(branch
+															(p-underscore)
+															(e-ident (raw "t")))))))))
+								(e-arrow-call
+									(e-ident (raw "tree"))
+									(e-apply
+										(e-ident (raw "delCurr"))))))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "RBTree.delete"))
+		(e-lambda
+			(args
+				(p-assign (ident "tree")))
+			(e-block
+				(s-let
+					(p-assign (ident "delRBTree"))
+					(e-lambda
+						(args
+							(p-assign (ident "inner")))
+						(e-block
+							(e-match
+								(match
+									(cond
+										(e-lookup-local
+											(p-assign (ident "inner"))))
+									(branches
+										(branch
+											(patterns
+												(pattern (degenerate false)
+													(p-nominal
+														(p-applied-tag))))
+											(value
+												(e-tag (name "Empty"))))
+										(branch
+											(patterns
+												(pattern (degenerate false)
+													(p-nominal
+														(p-applied-tag))))
+											(value
+												(e-call (constraint-fn-var 141)
+													(e-lookup-local
+														(p-assign (ident "delRBTree")))
+													(e-nominal (nominal "RBTree")
+														(e-tag (name "Node")
+															(args
+																(e-lookup-local
+																	(p-assign (ident "x")))))))))
+										(branch
+											(patterns
+												(pattern (degenerate false)
+													(p-applied-tag)))
+											(value
+												(e-tag (name "Empty"))))))))))
+				(s-let
+					(p-assign (ident "delCurr"))
+					(e-lambda
+						(args
+							(p-assign (ident "t")))
+						(e-block
+							(e-match
+								(match
+									(cond
+										(e-lookup-local
+											(p-assign (ident "t"))))
+									(branches
+										(branch
+											(patterns
+												(pattern (degenerate false)
+													(p-nominal
+														(p-applied-tag))))
+											(value
+												(e-call (constraint-fn-var 181)
+													(e-lookup-local
+														(p-assign (ident "delRBTree")))
+													(e-lookup-local
+														(p-assign (ident "inner"))))))
+										(branch
+											(patterns
+												(pattern (degenerate false)
+													(p-underscore)))
+											(value
+												(e-lookup-local
+													(p-assign (ident "t")))))))))))
+				(e-call (constraint-fn-var 187)
+					(e-lookup-local
+						(p-assign (ident "delCurr")))
+					(e-lookup-local
+						(p-assign (ident "tree")))))))
+	(s-nominal-decl
+		(ty-header (name "RBTree")
+			(ty-args
+				(ty-rigid-var (name "k"))))
+		(ty-tag-union
+			(ty-tag-name (name "Empty"))
+			(ty-tag-name (name "Node")
+				(ty-apply (name "RBTree") (local)
+					(ty-rigid-var-lookup (ty-rigid-var (name "k"))))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "RBTree(k) -> RBTree(k)")))
+	(type_decls
+		(nominal (type "RBTree(k)")
+			(ty-header (name "RBTree")
+				(ty-args
+					(ty-rigid-var (name "k"))))))
+	(expressions
+		(expr (type "RBTree(k) -> RBTree(k)"))))
+~~~

--- a/test/snapshots/statement/for_loop_complex_mutation.md
+++ b/test/snapshots/statement/for_loop_complex_mutation.md
@@ -140,7 +140,7 @@ NO CHANGE
 							(if-branch
 								(e-method-eq (negated "false")
 									(lhs
-										(e-dispatch-call (method "rem_by") (constraint-fn-var 612)
+										(e-dispatch-call (method "rem_by") (constraint-fn-var 610)
 											(receiver
 												(e-lookup-local
 													(p-assign (ident "n"))))
@@ -151,7 +151,7 @@ NO CHANGE
 								(e-block
 									(s-reassign
 										(p-assign (ident "count_"))
-										(e-dispatch-call (method "plus") (constraint-fn-var 682)
+										(e-dispatch-call (method "plus") (constraint-fn-var 680)
 											(receiver
 												(e-lookup-local
 													(p-assign (ident "count_"))))
@@ -159,7 +159,7 @@ NO CHANGE
 												(e-num (value "1")))))
 									(s-reassign
 										(p-assign (ident "sum_"))
-										(e-dispatch-call (method "plus") (constraint-fn-var 684)
+										(e-dispatch-call (method "plus") (constraint-fn-var 682)
 											(receiver
 												(e-lookup-local
 													(p-assign (ident "sum_"))))
@@ -170,7 +170,7 @@ NO CHANGE
 						(if-else
 							(e-block
 								(e-empty_record))))))
-			(e-dispatch-call (method "times") (constraint-fn-var 694)
+			(e-dispatch-call (method "times") (constraint-fn-var 692)
 				(receiver
 					(e-lookup-local
 						(p-assign (ident "count_"))))

--- a/test/snapshots/statement/for_loop_list_str.md
+++ b/test/snapshots/statement/for_loop_list_str.md
@@ -94,7 +94,7 @@ NO CHANGE
 				(e-block
 					(s-reassign
 						(p-assign (ident "counter_"))
-						(e-dispatch-call (method "plus") (constraint-fn-var 277)
+						(e-dispatch-call (method "plus") (constraint-fn-var 275)
 							(receiver
 								(e-lookup-local
 									(p-assign (ident "counter_"))))

--- a/test/snapshots/statement/for_loop_list_u64.md
+++ b/test/snapshots/statement/for_loop_list_u64.md
@@ -92,7 +92,7 @@ NO CHANGE
 				(e-block
 					(s-reassign
 						(p-assign (ident "total_"))
-						(e-dispatch-call (method "plus") (constraint-fn-var 378)
+						(e-dispatch-call (method "plus") (constraint-fn-var 376)
 							(receiver
 								(e-lookup-local
 									(p-assign (ident "total_"))))

--- a/test/snapshots/statement/for_loop_nested.md
+++ b/test/snapshots/statement/for_loop_nested.md
@@ -109,12 +109,12 @@ NO CHANGE
 						(e-block
 							(s-reassign
 								(p-assign (ident "result_"))
-								(e-dispatch-call (method "plus") (constraint-fn-var 542)
+								(e-dispatch-call (method "plus") (constraint-fn-var 538)
 									(receiver
 										(e-lookup-local
 											(p-assign (ident "result_"))))
 									(args
-										(e-dispatch-call (method "times") (constraint-fn-var 540)
+										(e-dispatch-call (method "times") (constraint-fn-var 536)
 											(receiver
 												(e-lookup-local
 													(p-assign (ident "i"))))

--- a/test/snapshots/statement/for_loop_var_conditional_persist.md
+++ b/test/snapshots/statement/for_loop_var_conditional_persist.md
@@ -134,7 +134,7 @@ NO CHANGE
 							(if-branch
 								(e-method-eq (negated "false")
 									(lhs
-										(e-dispatch-call (method "rem_by") (constraint-fn-var 548)
+										(e-dispatch-call (method "rem_by") (constraint-fn-var 546)
 											(receiver
 												(e-lookup-local
 													(p-assign (ident "n"))))
@@ -149,7 +149,7 @@ NO CHANGE
 											(p-assign (ident "n"))))
 									(s-reassign
 										(p-assign (ident "evenCount_"))
-										(e-dispatch-call (method "plus") (constraint-fn-var 618)
+										(e-dispatch-call (method "plus") (constraint-fn-var 616)
 											(receiver
 												(e-lookup-local
 													(p-assign (ident "evenCount_"))))
@@ -159,7 +159,7 @@ NO CHANGE
 						(if-else
 							(e-block
 								(e-empty_record))))))
-			(e-dispatch-call (method "times") (constraint-fn-var 628)
+			(e-dispatch-call (method "times") (constraint-fn-var 626)
 				(receiver
 					(e-lookup-local
 						(p-assign (ident "lastEven_"))))

--- a/test/snapshots/statement/for_loop_var_every_iteration.md
+++ b/test/snapshots/statement/for_loop_var_every_iteration.md
@@ -106,7 +106,7 @@ NO CHANGE
 				(e-block
 					(s-reassign
 						(p-assign (ident "count_"))
-						(e-dispatch-call (method "plus") (constraint-fn-var 445)
+						(e-dispatch-call (method "plus") (constraint-fn-var 443)
 							(receiver
 								(e-lookup-local
 									(p-assign (ident "count_"))))
@@ -117,7 +117,7 @@ NO CHANGE
 						(e-lookup-local
 							(p-assign (ident "n"))))
 					(e-empty_record)))
-			(e-dispatch-call (method "plus") (constraint-fn-var 455)
+			(e-dispatch-call (method "plus") (constraint-fn-var 453)
 				(receiver
 					(e-lookup-local
 						(p-assign (ident "prev_"))))

--- a/test/snapshots/statement/for_loop_var_reassign_tracking.md
+++ b/test/snapshots/statement/for_loop_var_reassign_tracking.md
@@ -123,7 +123,7 @@ NO CHANGE
 				(e-block
 					(s-reassign
 						(p-assign (ident "sum_"))
-						(e-dispatch-call (method "plus") (constraint-fn-var 423)
+						(e-dispatch-call (method "plus") (constraint-fn-var 421)
 							(receiver
 								(e-lookup-local
 									(p-assign (ident "sum_"))))
@@ -133,7 +133,7 @@ NO CHANGE
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 428)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 426)
 									(receiver
 										(e-lookup-local
 											(p-assign (ident "n"))))
@@ -149,7 +149,7 @@ NO CHANGE
 						(if-else
 							(e-block
 								(e-empty_record))))))
-			(e-dispatch-call (method "plus") (constraint-fn-var 441)
+			(e-dispatch-call (method "plus") (constraint-fn-var 439)
 				(receiver
 					(e-lookup-local
 						(p-assign (ident "sum_"))))

--- a/test/snapshots/statement/for_stmt.md
+++ b/test/snapshots/statement/for_stmt.md
@@ -88,7 +88,7 @@ foo = {
 				(e-block
 					(s-reassign
 						(p-assign (ident "result"))
-						(e-dispatch-call (method "plus") (constraint-fn-var 312)
+						(e-dispatch-call (method "plus") (constraint-fn-var 310)
 							(receiver
 								(e-lookup-local
 									(p-assign (ident "result"))))

--- a/test/snapshots/syntax_grab_bag.md
+++ b/test/snapshots/syntax_grab_bag.md
@@ -2394,7 +2394,7 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 3043)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 3041)
 									(receiver
 										(e-match
 											(match
@@ -2419,7 +2419,7 @@ expect {
 														(value
 															(e-num (value "12"))))))))
 									(args
-										(e-dispatch-call (method "times") (constraint-fn-var 3038)
+										(e-dispatch-call (method "times") (constraint-fn-var 3036)
 											(receiver
 												(e-num (value "5")))
 											(args
@@ -2434,18 +2434,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 3151)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 3149)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 3116)
+															(e-dispatch-call (method "plus") (constraint-fn-var 3114)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 3251)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 3249)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 3216)
+															(e-dispatch-call (method "minus") (constraint-fn-var 3214)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2460,11 +2460,11 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 3361)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 3359)
 										(receiver
 											(e-num (value "12")))
 										(args
-											(e-dispatch-call (method "div_by") (constraint-fn-var 3356)
+											(e-dispatch-call (method "div_by") (constraint-fn-var 3354)
 												(receiver
 													(e-num (value "3")))
 												(args
@@ -2479,12 +2479,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 3427)
+													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 3425)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 3394)
+																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 3392)
 																			(receiver
 																				(e-match
 																					(match


### PR DESCRIPTION
## Summary

Fixes a family of spurious `TYPE MISMATCH` errors on recursive parametric types, where both sides of the mismatch print identically (distinct rigid type variables that render the same), and tightens local-definition scoping. **Three commits:**

### 1. Make local `let` definitions sequentially scoped

Local definitions inside a block are now **sequential**: in scope only after themselves (self-reference) and after earlier definitions (backward reference). **Forward references and mutual recursion between local definitions are no longer allowed** (mutual recursion remains available at the top level). Removed the block pre-pass that forward-declared all local lambdas; local function patterns are registered incrementally so self-recursion still works. Two new, separately-classified diagnostics:

- **`USED BEFORE DEFINITION`** (`local_reference_before_definition`) — a plain use-before-definition.
- **`MUTUALLY RECURSIVE LOCAL DEFINITIONS`** (`mutually_recursive_local_definitions`) — two local functions reference each other; suggests moving them to the top level.

Detection is folded into the per-block name pre-scan rather than a separate graph: each pre-scan entry carries a forward-reference marker, the cycle-completing back-reference is caught synchronously, and classification happens at block end. **No intermediate allocation**. Direct (two-definition) cycles are reported as mutual recursion; longer cycles report use-before-definition (with the same "move to the top level" guidance). The previously-passing local `is_even`/`is_odd` eval coverage is migrated to top-level (module-form) eval tests so we still exercise mutual recursion evaluating correctly.

This establishes a guarantee the next commit relies on: a *local* recursive reference can only ever be a single self/enclosing chain — never a mutual group.

### 2. Fix spurious `TYPE MISMATCH` on self-recursive local parametric functions (#9491)

A self-recursive function defined *inside another function's body* failed to generalize its rigid type parameter: its recursive reference unified directly with the not-yet-generalized pattern var, lowering the function type's rank below its generalization rank. A later (backward) call then saw the un-generalized function and reported `T(k)` ≠ `T(k)`.

Fix: when a local def's body references itself (or an enclosing in-flight def), give the reference a fresh flex var and record it in a **dedicated pending-reference stack**, validated with a plain unification once the def's lambda has generalized. Because commit 1 makes local recursion a single self/enclosing chain (no mutual groups), a dedicated stack is sufficient — no cycle machinery, no per-use instantiation, and crucially no entanglement with the shared constraint list (where early-return / `?` constraints are compacted mid-body). Works for arbitrarily nested local defs.

### 3. Fix spurious `TYPE MISMATCH` on parametric mutual recursion (method-level / top-level)

Two mutually-recursive functions over a parametric type (top-level or associated items in `.{}`) reported the same spurious `T(k)` ≠ `T(k)`. In a recursive group the cycle machinery linked members **monomorphically**, forcing each annotated member's own rigid `k` to coincide. Now a cross-reference to an **annotated** group member is deferred and **instantiated per use-site** at the cycle root (via a centralised `resolveEqlConstraint` helper), so each member keeps its own type parameters. Self-references — and references to **unannotated** members — keep monomorphic linking (unannotated mutually-recursive groups are inferred together and must share type variables).

## Behavior change for reviewers

Code relying on **local** mutual recursion or forward references now errors (intentional). Top-level / associated-item mutual recursion — including the **parametric** case, which previously errored — now type-checks.

## Test plan

- `zig build test` — all green (2395 unit tests), plus eval and host-effects suites.
- New regression coverage: `repros_test.zig` (issue 9491 self-rec variants + nested; self-recursive local def after an early `return`, well-typed and ill-typed; top-level parametric mutual recursion), `local_let_scoping_test.zig` (passing + failing local-scoping cases), `node_store_test.zig` round-trips for the new diagnostics, and snapshots `test/snapshots/local_let_*` and `test/snapshots/nominal/{nominal_recursive_local_def_generalization,mutual_recursion_parametric}.md`.
- Migrated the local `is_even`/`is_odd` eval tests to top-level module form (same assertions) and added `.problem` cases for the now-disallowed local mutual recursion.

Fixes #9491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)