### PR TITLE
Reuse LSP build envs for unchanged documents

### DIFF
--- a/src/build/minici.zig
+++ b/src/build/minici.zig
@@ -57,7 +57,7 @@ const jobs = [_]Job{
     .{ .name = "run-test-zig-module-bundle" },
     .{ .name = "run-test-zig-module-unbundle" },
     .{ .name = "run-test-zig-module-base58" },
-    .{ .name = "run-test-zig-module-lsp", .skip_reason = "Skipped until #9514 is resolved" },
+    .{ .name = "run-test-zig-module-lsp" },
     .{ .name = "run-test-zig-module-backend" },
     .{ .name = "run-test-zig-module-lir_core" },
     .{ .name = "run-test-zig-module-postcheck" },
@@ -131,9 +131,8 @@ fn printRerunHint(result: CommandResult) void {
     std.debug.print("  Log: `{s}`\n", .{result.log_path});
 }
 
-fn heartbeatIntervalMs() u64 {
-    const raw_z = std.c.getenv(heartbeat_env) orelse return default_heartbeat_interval_ms;
-    const raw = std.mem.span(raw_z);
+fn heartbeatIntervalMs(env: *const std.process.Environ.Map) u64 {
+    const raw = env.get(heartbeat_env) orelse return default_heartbeat_interval_ms;
     if (raw.len == 0) return default_heartbeat_interval_ms;
     return std.fmt.parseInt(u64, raw, 10) catch |err| {
         std.debug.print("invalid {s}='{s}': {s}; using default {d}ms\n", .{ heartbeat_env, raw, @errorName(err), default_heartbeat_interval_ms });
@@ -218,13 +217,14 @@ fn runCommand(
     io: std.Io,
     argv: []const []const u8,
     log_path: []const u8,
+    heartbeat_interval_ms: u64,
 ) !CommandResult {
     const started = nowNs(io);
     var heartbeat = Heartbeat{
         .io = io,
         .argv = argv,
         .started = started,
-        .interval_ms = heartbeatIntervalMs(),
+        .interval_ms = heartbeat_interval_ms,
         .done = std.atomic.Value(bool).init(false),
         .printed = std.atomic.Value(bool).init(false),
     };
@@ -656,6 +656,7 @@ pub fn main(init: std.process.Init) !void {
     const raw_args = try init.minimal.args.toSlice(allocator);
     const args: []const []const u8 = @ptrCast(raw_args);
     const zig_exe = if (args.len >= 2) args[1] else "zig";
+    const heartbeat_interval_ms = heartbeatIntervalMs(init.environ_map);
 
     std.Io.Dir.cwd().deleteTree(io, out_dir) catch {};
     try std.Io.Dir.cwd().createDirPath(io, raw_dir);
@@ -666,7 +667,7 @@ pub fn main(init: std.process.Init) !void {
     const build_argv = try buildCommand(allocator, zig_exe, "build-ci", null);
     const build_log = logs_dir ++ "/build-ci.txt";
     std.debug.print("Building CI steps ... ", .{});
-    const build_result = try runCommand(allocator, io, build_argv, build_log);
+    const build_result = try runCommand(allocator, io, build_argv, build_log, heartbeat_interval_ms);
     if (build_result.heartbeat_printed) std.debug.print("Building CI steps ... ", .{});
     std.debug.print("{s} in {d:.3}s\n", .{ buildStatusText(build_result), seconds(build_result.duration_ns) });
 
@@ -691,7 +692,7 @@ pub fn main(init: std.process.Init) !void {
         var result = if (job.skip_reason) |reason|
             try skipCommand(io, argv, log_path, reason)
         else
-            try runCommand(allocator, io, argv, log_path);
+            try runCommand(allocator, io, argv, log_path, heartbeat_interval_ms);
         result.stats_path = if (job.skip_reason == null) stats_path else null;
         try results.append(allocator, result);
         if (result.heartbeat_printed) std.debug.print("Running `{s}` ... ", .{job.name});

--- a/src/lsp/build_env_handle.zig
+++ b/src/lsp/build_env_handle.zig
@@ -17,6 +17,9 @@ pub const BuildEnvHandle = struct {
     ref_count: usize = 0,
     debug: bool = false,
     owners: std.StringHashMapUnmanaged(usize) = .{},
+    document_path: ?[]const u8 = null,
+    document_hash: ?[32]u8 = null,
+    document_has_reports: bool = true,
 
     /// Create a new handle with a single owner.
     pub fn create(allocator: Allocator, env: BuildEnv, owner: []const u8, debug: bool) !*BuildEnvHandle {
@@ -37,6 +40,27 @@ pub const BuildEnvHandle = struct {
     /// Get a stable pointer to the underlying BuildEnv.
     pub fn envPtr(self: *BuildEnvHandle) *BuildEnv {
         return &self.env;
+    }
+
+    /// Record the source document used for this build environment.
+    pub fn setDocumentContent(self: *BuildEnvHandle, path: []const u8, hash: [32]u8, has_reports: bool) !void {
+        const owned_path = try self.allocator.dupe(u8, path);
+        if (self.document_path) |old_path| {
+            self.allocator.free(old_path);
+        }
+        self.document_path = owned_path;
+        self.document_hash = hash;
+        self.document_has_reports = has_reports;
+    }
+
+    pub fn matchesDocumentContent(self: *const BuildEnvHandle, path: []const u8, hash: [32]u8) bool {
+        const stored_path = self.document_path orelse return false;
+        const stored_hash = self.document_hash orelse return false;
+        return std.mem.eql(u8, stored_path, path) and std.mem.eql(u8, &stored_hash, &hash);
+    }
+
+    pub fn hasDocumentReports(self: *const BuildEnvHandle) bool {
+        return self.document_has_reports;
     }
 
     /// Retain the handle for an additional owner.
@@ -62,6 +86,9 @@ pub const BuildEnvHandle = struct {
             if (self.debug) {
                 // In debug mode, all owner counts should be fully released.
                 std.debug.assert(self.owners.count() == 0);
+            }
+            if (self.document_path) |path| {
+                self.allocator.free(path);
             }
             self.owners.deinit(self.allocator);
             self.env.deinit();

--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -64,6 +64,42 @@ pub const SyntaxChecker = struct {
     const owner_previous = "previous_build_env";
     const owner_snapshot = "snapshot";
 
+    const DocumentIdentity = struct {
+        absolute_path: [:0]u8,
+        content_hash: [32]u8,
+
+        fn deinit(self: *DocumentIdentity, allocator: Allocator) void {
+            allocator.free(self.absolute_path);
+        }
+    };
+
+    const DocumentBuild = struct {
+        checker: *SyntaxChecker,
+        identity: ?DocumentIdentity,
+        session: ?BuildSession,
+        env: *BuildEnv,
+        absolute_path: []const u8,
+        build_succeeded: bool,
+        has_reports: bool,
+        reused: bool,
+
+        fn deinit(self: *DocumentBuild) void {
+            if (self.session) |*session| {
+                session.deinit();
+            }
+            if (self.identity) |*identity| {
+                identity.deinit(self.checker.allocator);
+            }
+        }
+
+        fn getModuleEnv(self: *DocumentBuild) ?*ModuleEnv {
+            if (self.reused) {
+                return self.checker.getModuleEnvByPathInEnv(self.env, self.absolute_path);
+            }
+            return self.session.?.getModuleEnv();
+        }
+    };
+
     pub fn init(allocator: std.mem.Allocator, std_io: std.Io, debug: DebugFlags, log_file: ?std.Io.File) SyntaxChecker {
         return .{
             .allocator = allocator,
@@ -93,6 +129,100 @@ pub const SyntaxChecker = struct {
         self.snapshot_envs.deinit(self.allocator);
 
         self.dependency_graph.deinit();
+    }
+
+    fn documentIdentityFromText(self: *SyntaxChecker, uri: []const u8, text: []const u8) !DocumentIdentity {
+        const path = try uri_util.uriToPath(self.allocator, uri);
+        defer self.allocator.free(path);
+
+        const absolute_path: [:0]u8 = std.Io.Dir.cwd().realPathFileAlloc(self.std_io, path, self.allocator) catch
+            try self.allocator.dupeZ(u8, path);
+
+        return .{
+            .absolute_path = absolute_path,
+            .content_hash = DependencyGraph.computeContentHash(text),
+        };
+    }
+
+    fn matchingBuildEnvHandle(self: *SyntaxChecker, absolute_path: []const u8, content_hash: [32]u8) ?*BuildEnvHandle {
+        if (self.build_env) |handle| {
+            if (handle.matchesDocumentContent(absolute_path, content_hash)) {
+                return handle;
+            }
+        }
+
+        if (self.snapshot_envs.get(absolute_path)) |handle| {
+            if (handle.matchesDocumentContent(absolute_path, content_hash)) {
+                return handle;
+            }
+        }
+
+        if (self.previous_build_env) |handle| {
+            if (handle.matchesDocumentContent(absolute_path, content_hash)) {
+                return handle;
+            }
+        }
+
+        return null;
+    }
+
+    fn documentHasReports(_: *SyntaxChecker, absolute_path: []const u8, drained_reports: ?[]BuildEnv.DrainedModuleReports) bool {
+        const drained = drained_reports orelse return true;
+        for (drained) |entry| {
+            if (std.mem.eql(u8, entry.abs_path, absolute_path) and entry.reports.len > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fn prepareDocumentBuild(self: *SyntaxChecker, uri: []const u8, override_text: ?[]const u8) !DocumentBuild {
+        var identity: ?DocumentIdentity = if (override_text) |text|
+            try self.documentIdentityFromText(uri, text)
+        else
+            null;
+        errdefer if (identity) |*document| document.deinit(self.allocator);
+
+        if (identity) |document| {
+            if (self.matchingBuildEnvHandle(document.absolute_path, document.content_hash)) |handle| {
+                const env = handle.envPtr();
+                return .{
+                    .checker = self,
+                    .identity = identity,
+                    .session = null,
+                    .env = env,
+                    .absolute_path = document.absolute_path,
+                    .build_succeeded = self.getModuleEnvByPathInEnv(env, document.absolute_path) != null,
+                    .has_reports = handle.hasDocumentReports(),
+                    .reused = true,
+                };
+            }
+        }
+
+        const env_handle = try self.createFreshBuildEnv();
+        const env = env_handle.envPtr();
+
+        var session = try BuildSession.init(self.allocator, self.std_io, env, uri, override_text);
+        errdefer session.deinit();
+
+        const has_reports = self.documentHasReports(session.absolute_path, session.drained_reports);
+
+        if (identity) |document| {
+            env_handle.setDocumentContent(document.absolute_path, document.content_hash, has_reports) catch |err| {
+                self.logDebug(.build, "Failed to record document content: {s}", .{@errorName(err)});
+            };
+        }
+
+        return .{
+            .checker = self,
+            .identity = identity,
+            .session = session,
+            .env = env,
+            .absolute_path = session.absolute_path,
+            .build_succeeded = session.build_succeeded,
+            .has_reports = has_reports,
+            .reused = false,
+        };
     }
 
     /// Check the file referenced by the URI and return diagnostics grouped by URI.
@@ -151,6 +281,12 @@ pub const SyntaxChecker = struct {
         defer session.deinit();
 
         const absolute_path = session.absolute_path;
+
+        if (override_text) |text| {
+            env_handle.setDocumentContent(absolute_path, DependencyGraph.computeContentHash(text), self.documentHasReports(absolute_path, session.drained_reports)) catch |err| {
+                self.logDebug(.build, "Failed to record document content: {s}", .{@errorName(err)});
+            };
+        }
 
         // Update dependency graph from successful build
         self.updateDependencyGraph(env);
@@ -422,28 +558,6 @@ pub const SyntaxChecker = struct {
         return try imported_envs.toOwnedSlice(self.allocator);
     }
 
-    /// Free drained reports. If `free_reports` is true, also deinit each report.
-    /// The `check` function processes reports itself, so uses free_reports=false.
-    /// Other functions like `getDefinitionAtPosition` don't process reports, so use free_reports=true.
-    fn freeDrainedEx(self: *SyntaxChecker, drained: []BuildEnv.DrainedModuleReports, free_reports: bool) void {
-        for (drained) |*entry| {
-            self.allocator.free(entry.abs_path);
-            if (free_reports) {
-                // Free the reports themselves - each Report has owned allocations
-                for (entry.reports) |*report| {
-                    @constCast(report).deinit();
-                }
-                self.allocator.free(entry.reports);
-            }
-        }
-        self.allocator.free(drained);
-    }
-
-    fn freeDrainedWithReports(self: *SyntaxChecker, drained: []BuildEnv.DrainedModuleReports) void {
-        // Free reports too (for functions that don't process reports)
-        self.freeDrainedEx(drained, true);
-    }
-
     /// Update the dependency graph from a successful build.
     fn updateDependencyGraph(self: *SyntaxChecker, env: *BuildEnv) void {
         self.logDebug(.build, "[DEPS] Updating dependency graph...", .{});
@@ -685,21 +799,20 @@ pub const SyntaxChecker = struct {
         self.mutex.lockUncancelable(self.std_io);
         defer self.mutex.unlock(self.std_io);
 
-        const env_handle = try self.createFreshBuildEnv();
-        const env = env_handle.envPtr();
+        var build = try self.prepareDocumentBuild(uri, override_text);
+        defer build.deinit();
 
-        var session = try BuildSession.init(self.allocator, self.std_io, env, uri, override_text);
-        defer session.deinit();
+        const env = build.env;
 
-        self.logDebug(.build, "hover: building {s}", .{session.absolute_path});
+        self.logDebug(.build, "hover: document {s} reused={}", .{ build.absolute_path, build.reused });
 
-        if (!session.build_succeeded) {
-            self.logDebug(.build, "hover: build failed for {s}", .{session.absolute_path});
+        if (!build.build_succeeded) {
+            self.logDebug(.build, "hover: build unavailable for {s}", .{build.absolute_path});
             return null;
         }
 
         // Get module environment
-        const module_env = session.getModuleEnv() orelse return null;
+        const module_env = build.getModuleEnv() orelse return null;
 
         // Convert LSP position (0-based line/col) to byte offset
         // LSP uses 0-based line and UTF-16 code units for character
@@ -1199,21 +1312,18 @@ pub const SyntaxChecker = struct {
         self.mutex.lockUncancelable(self.std_io);
         defer self.mutex.unlock(self.std_io);
 
-        const env_handle = try self.createFreshBuildEnv();
-        const env = env_handle.envPtr();
+        var build = try self.prepareDocumentBuild(uri, override_text);
+        defer build.deinit();
 
-        var session = try BuildSession.init(self.allocator, self.std_io, env, uri, override_text);
-        defer session.deinit();
+        self.logDebug(.build, "definition: document {s} reused={}", .{ build.absolute_path, build.reused });
 
-        self.logDebug(.build, "definition: building {s}", .{session.absolute_path});
-
-        if (!session.build_succeeded) {
-            self.logDebug(.build, "definition: build failed for {s}", .{session.absolute_path});
+        if (!build.build_succeeded) {
+            self.logDebug(.build, "definition: build unavailable for {s}", .{build.absolute_path});
             return null;
         }
 
         // Get module environment
-        const module_env = session.getModuleEnv() orelse return null;
+        const module_env = build.getModuleEnv() orelse return null;
 
         // Convert LSP position to byte offset
         const target_offset = pos.positionToOffset(module_env, line, character) orelse return null;
@@ -1792,21 +1902,18 @@ pub const SyntaxChecker = struct {
         self.mutex.lockUncancelable(self.std_io);
         defer self.mutex.unlock(self.std_io);
 
-        const env_handle = try self.createFreshBuildEnv();
-        const env = env_handle.envPtr();
+        var build = try self.prepareDocumentBuild(uri, override_text);
+        defer build.deinit();
 
-        var session = try BuildSession.init(self.allocator, self.std_io, env, uri, override_text);
-        defer session.deinit();
+        self.logDebug(.build, "highlights: document {s} reused={}", .{ build.absolute_path, build.reused });
 
-        self.logDebug(.build, "highlights: building {s}", .{session.absolute_path});
-
-        if (!session.build_succeeded) {
-            self.logDebug(.build, "highlights: build failed for {s}", .{session.absolute_path});
+        if (!build.build_succeeded) {
+            self.logDebug(.build, "highlights: build unavailable for {s}", .{build.absolute_path});
             return null;
         }
 
         // Get module environment
-        const module_env = session.getModuleEnv() orelse return null;
+        const module_env = build.getModuleEnv() orelse return null;
 
         // Convert LSP position to byte offset
         const target_offset = pos.positionToOffset(module_env, line, character) orelse return null;
@@ -1848,55 +1955,17 @@ pub const SyntaxChecker = struct {
         self.mutex.lockUncancelable(self.std_io);
         defer self.mutex.unlock(self.std_io);
 
-        const env_handle = try self.createFreshBuildEnv();
-        const env = env_handle.envPtr();
+        var build = try self.prepareDocumentBuild(uri, source);
+        defer build.deinit();
 
-        // Convert URI to absolute path to match against module paths
-        const path = uri_util.uriToPath(allocator, uri) catch return &[_]SymbolInformation{};
-        defer allocator.free(path);
+        self.logDebug(.build, "symbols: document {s} reused={}", .{ build.absolute_path, build.reused });
 
-        const absolute_path: [:0]u8 = std.Io.Dir.cwd().realPathFileAlloc(self.std_io, path, allocator) catch
-            allocator.dupeZ(u8, path) catch return &[_]SymbolInformation{};
-        defer allocator.free(absolute_path);
-
-        // Override readFile for the current file so in-memory source is used.
-        var override = CoreCtx.ReadFileOverride{ .path = absolute_path, .content = source, .base = env.filesystem };
-        const saved_io = env.filesystem;
-        env.filesystem = override.io();
-        defer env.filesystem = saved_io;
-
-        self.logDebug(.build, "symbols: building {s}", .{absolute_path});
-        env.build(absolute_path) catch |err| {
-            self.logDebug(.build, "symbols: build failed for {s}: {s}", .{ absolute_path, @errorName(err) });
+        if (!build.build_succeeded) {
+            self.logDebug(.build, "symbols: build unavailable for {s}", .{build.absolute_path});
             return &[_]SymbolInformation{};
-        };
+        }
 
-        // Drain reports but ignore them for symbols (must still free to avoid leaks)
-        const drained = env.drainReports() catch return &[_]SymbolInformation{};
-        defer self.freeDrainedWithReports(drained);
-
-        // Get the module env from the scheduler
-        const module_env = blk: {
-            // Try "app" scheduler first
-            if (env.schedulers.get("app")) |sched| {
-                if (sched.getRootModule()) |rm| {
-                    if (rm.moduleEnv()) |e| {
-                        break :blk e;
-                    }
-                }
-            }
-            // Fallback: try any scheduler with a root module
-            var sched_it = env.schedulers.iterator();
-            while (sched_it.next()) |entry| {
-                const sched = entry.value_ptr.*;
-                if (sched.getRootModule()) |rm| {
-                    if (rm.moduleEnv()) |e| {
-                        break :blk e;
-                    }
-                }
-            }
-            return &[_]SymbolInformation{};
-        };
+        const module_env = build.getModuleEnv() orelse return &[_]SymbolInformation{};
 
         // Build line offset table
         const line_offsets = pos.buildLineOffsets(allocator, source) catch return &[_]SymbolInformation{};
@@ -2188,26 +2257,15 @@ pub const SyntaxChecker = struct {
         self.mutex.lockUncancelable(self.std_io);
         defer self.mutex.unlock(self.std_io);
 
-        const env_handle = try self.createFreshBuildEnv();
-        const env = env_handle.envPtr();
+        var build = try self.prepareDocumentBuild(uri, override_text);
+        defer build.deinit();
 
-        var session = try BuildSession.init(self.allocator, self.std_io, env, uri, override_text);
-        defer session.deinit();
+        const env = build.env;
 
-        self.logDebug(.completion, "completion: building {s}", .{session.absolute_path});
-        self.logDebug(.completion, "completion: build_succeeded={}", .{session.build_succeeded});
+        self.logDebug(.completion, "completion: document {s} reused={}", .{ build.absolute_path, build.reused });
+        self.logDebug(.completion, "completion: build_succeeded={}", .{build.build_succeeded});
 
-        var build_has_reports = false;
-
-        // Check if we have reports for this file
-        if (session.drained_reports) |drained| {
-            for (drained) |entry| {
-                if (std.mem.eql(u8, entry.abs_path, session.absolute_path) and entry.reports.len > 0) {
-                    build_has_reports = true;
-                    break;
-                }
-            }
-        }
+        const build_has_reports = build.has_reports;
 
         // Detect completion context from source
         const source = override_text orelse "";
@@ -2236,8 +2294,14 @@ pub const SyntaxChecker = struct {
         // lookups stay consistent with snapshot/previous envs.
         var module_lookup_env: *BuildEnv = env;
         const module_env_opt: ?*ModuleEnv = blk: {
-            if (self.snapshot_envs.get(session.absolute_path)) |snapshot_handle| {
-                const snapshot_module_env = self.getModuleEnvByPathInEnv(snapshot_handle.envPtr(), session.absolute_path);
+            if (!build_has_reports) {
+                if (build.getModuleEnv()) |module_env| {
+                    break :blk module_env;
+                }
+            }
+
+            if (self.snapshot_envs.get(build.absolute_path)) |snapshot_handle| {
+                const snapshot_module_env = self.getModuleEnvByPathInEnv(snapshot_handle.envPtr(), build.absolute_path);
                 if (snapshot_module_env) |module_env| {
                     used_snapshot = true;
                     module_lookup_env = snapshot_handle.envPtr();
@@ -2247,7 +2311,7 @@ pub const SyntaxChecker = struct {
 
             // Fall back to previous build env if snapshot not available
             if (self.previous_build_env) |previous_handle| {
-                const prev_module_env = self.getModuleEnvByPathInEnv(previous_handle.envPtr(), session.absolute_path);
+                const prev_module_env = self.getModuleEnvByPathInEnv(previous_handle.envPtr(), build.absolute_path);
                 if (prev_module_env) |module_env| {
                     used_snapshot = true;
                     module_lookup_env = previous_handle.envPtr();
@@ -2256,20 +2320,20 @@ pub const SyntaxChecker = struct {
             }
 
             // Fall back to current build only if no snapshot available and build succeeded
-            if (session.build_succeeded and !build_has_reports) {
-                if (self.getModuleEnvByPath(session.absolute_path)) |module_env| {
+            if (build.build_succeeded and !build_has_reports) {
+                if (self.getModuleEnvByPath(build.absolute_path)) |module_env| {
                     module_lookup_env = env;
                     break :blk module_env;
                 }
 
                 module_lookup_env = env;
-                break :blk session.getModuleEnv();
+                break :blk build.getModuleEnv();
             }
 
             break :blk null;
         };
 
-        self.logDebug(.completion, "completion: context={any}, module_env_opt={any}, build_succeeded={}, used_snapshot={}", .{ context, module_env_opt != null, session.build_succeeded, used_snapshot });
+        self.logDebug(.completion, "completion: context={any}, module_env_opt={any}, build_succeeded={}, used_snapshot={}", .{ context, module_env_opt != null, build.build_succeeded, used_snapshot });
 
         // Initialize CompletionBuilder for deduplication and organized completion item building
         // Provide the builtin module env so completion can resolve builtin method data.


### PR DESCRIPTION
Fixes #9514

## Summary

The LSP tests were slow because every document interaction rebuilt the whole build environment from scratch, even when the document's content hadn't changed.

This caches the `BuildEnv` on its handle keyed by the source document's path and content hash. When a request comes in for a document whose content matches what was last built, the existing build environment is reused instead of being rebuilt:

- `BuildEnvHandle` now records the document path, a 32-byte content hash, and whether the last build produced reports (`setDocumentContent` / `matchesDocumentContent` / `hasDocumentReports`).
- `syntax.zig` checks for a content match before kicking off a fresh build and reuses the cached env on a hit, falling back to a rebuild on a miss.

## Test plan

- `zig build minici` — all `run-check-*` and `run-test-*` steps pass or skip (no failures), with the LSP test step noticeably faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
