### PR TITLE
Reuse builtin state in builtin-doc tests

### DIFF
--- a/src/build/minici.zig
+++ b/src/build/minici.zig
@@ -67,7 +67,7 @@ const jobs = [_]Job{
     .{ .name = "run-test-zig-module-echo_platform" },
     .{ .name = "run-test-zig-module-docs" },
     .{ .name = "run-test-zig-snapshot-tool" },
-    .{ .name = "run-test-zig-builtin-doc", .skip_reason = "Skipped until #9515 is resolved" },
+    .{ .name = "run-test-zig-builtin-doc" },
     .{ .name = "run-test-zig-cli-main", .skip_reason = "Skipped until #9516 is resolved" },
     .{ .name = "run-test-zig-watch-cli" },
     .{ .name = "run-test-zig-fx-platform", .skip_reason = "Skipped until #9517 is resolved" },

--- a/src/eval/test/builtin_doc_tests.zig
+++ b/src/eval/test/builtin_doc_tests.zig
@@ -28,6 +28,25 @@ const CoreCtx = @import("ctx").CoreCtx;
 
 const Allocator = std.mem.Allocator;
 
+/// Builtin module loaded and published once in the parent test process and
+/// reused (read-only) by every block: directly for the in-parent check phase,
+/// and — via fork copy-on-write — by the child eval phase. Reusing it avoids
+/// re-deserializing and re-publishing the Builtin module ~700 times. File-scope
+/// because the C-ABI child work fns dispatched through `runInChild` cannot
+/// capture it, and because it must already be in the parent's address space
+/// when `fork()` copies it into each child.
+var shared_builtins: ?*eval_mod.BuiltinModules = null;
+
+/// Borrow the shared Builtin as a `PrePublishedBuiltin`, or null before setup.
+fn prePublishedBuiltin() ?test_helpers.PrePublishedBuiltin {
+    const bm = shared_builtins orelse return null;
+    return .{
+        .env = bm.builtin_module.env,
+        .indices = bm.builtin_indices,
+        .artifact = &bm.checked_artifact,
+    };
+}
+
 /// Path to the Builtin.roc file, relative to the project root (the directory
 /// where `zig build run-test-zig` is invoked from).
 const builtin_roc_path = "src/build/roc/Builtin.roc";
@@ -458,12 +477,11 @@ fn runCheck(
     source_kind: test_helpers.SourceKind,
     source: []const u8,
 ) !?[]u8 {
-    var resources = test_helpers.parseAndCheckProgramForProblems(
-        allocator,
-        source_kind,
-        source,
-        &.{},
-    ) catch |err| return try dupeErr(allocator, "parseAndCheckProgramForProblems: {s}", .{@errorName(err)});
+    var resources = (if (prePublishedBuiltin()) |ppb|
+        test_helpers.parseAndCheckProgramForProblemsWithBuiltin(allocator, source_kind, source, &.{}, ppb)
+    else
+        test_helpers.parseAndCheckProgramForProblems(allocator, source_kind, source, &.{})) catch |err|
+        return try dupeErr(allocator, "parseAndCheckProgramForProblems: {s}", .{@errorName(err)});
     defer resources.deinit(allocator);
 
     if (!checkPassed(&resources)) {
@@ -486,7 +504,7 @@ fn runExpects(allocator: Allocator, source: []const u8) !?[]u8 {
         return try dupeErr(allocator, "expect-only block had no expect statements", .{});
     }
 
-    var compiled = test_helpers.compileInspectedProgram(allocator, std.testing.io, .module, wrapped, &.{}) catch |err|
+    var compiled = compileNative(allocator, .module, wrapped) catch |err|
         return try dupeErr(allocator, "compileInspectedProgram: {s}", .{@errorName(err)});
     defer compiled.deinit(allocator);
 
@@ -565,19 +583,44 @@ fn runEval(
     source_kind: test_helpers.SourceKind,
     source: []const u8,
 ) !?[]u8 {
-    var compiled = test_helpers.compileInspectedProgram(
-        allocator,
-        std.testing.io,
-        source_kind,
-        source,
-        &.{},
-    ) catch |err| return try dupeErr(allocator, "compileInspectedProgram: {s}", .{@errorName(err)});
+    var compiled = compileNative(allocator, source_kind, source) catch |err|
+        return try dupeErr(allocator, "compileInspectedProgram: {s}", .{@errorName(err)});
     defer compiled.deinit(allocator);
 
     const inspected = test_helpers.lirInterpreterInspectedStr(allocator, &compiled.lowered) catch |err|
         return try dupeErr(allocator, "lirInterpreterInspectedStr: {s}", .{@errorName(err)});
     allocator.free(inspected);
     return null;
+}
+
+/// Compile a block for the native target only, reusing the shared Builtin when
+/// it is available. The harness only evaluates `compiled.lowered` through the
+/// native LIR interpreter, so lowering wasm (as the generic
+/// `compileInspectedProgram` does) is pure waste here.
+fn compileNative(
+    allocator: Allocator,
+    source_kind: test_helpers.SourceKind,
+    source: []const u8,
+) !test_helpers.CompiledTargetProgram {
+    if (prePublishedBuiltin()) |ppb| {
+        return test_helpers.compileInspectedProgramForTargetWithBuiltin(
+            allocator,
+            std.testing.io,
+            source_kind,
+            source,
+            &.{},
+            .native,
+            ppb,
+        );
+    }
+    return test_helpers.compileInspectedProgramForTarget(
+        allocator,
+        std.testing.io,
+        source_kind,
+        source,
+        &.{},
+        .native,
+    );
 }
 
 /// Result of processing a block.
@@ -790,6 +833,14 @@ test "Builtin.roc doc code blocks check and evaluate" {
     }
 
     try testing.expect(blocks.len > 0);
+
+    // Load and publish the Builtin module once. Every block's check phase (in
+    // this parent process) and eval phase (in a forked child, via copy-on-write)
+    // borrows it read-only instead of re-deserializing and re-publishing it.
+    var builtins_instance = try eval_mod.BuiltinModules.init(allocator);
+    defer builtins_instance.deinit();
+    shared_builtins = &builtins_instance;
+    defer shared_builtins = null;
 
     var failures = std.ArrayList(Failure).empty;
     defer {

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -212,14 +212,17 @@ pub const CheckedModule = struct {
 /// Public `ProblemResources` declaration.
 pub const ProblemResources = struct {
     main: CheckedModule,
-    builtin_module: builtin_loading.LoadedModule,
+    /// Locally-loaded Builtin; null when the caller supplied a pre-published
+    /// Builtin via `parseAndCheckProgramForProblemsWithBuiltin` and retains
+    /// ownership of the borrowed env.
+    builtin_module: ?builtin_loading.LoadedModule,
     extra_modules: []CheckedModule,
 
     pub fn deinit(self: *ProblemResources, allocator: Allocator) void {
         cleanupCheckedModule(allocator, self.main);
         for (self.extra_modules) |module| cleanupCheckedModule(allocator, module);
         allocator.free(self.extra_modules);
-        self.builtin_module.deinit();
+        if (self.builtin_module) |*lm| lm.deinit();
     }
 };
 
@@ -437,14 +440,49 @@ pub fn parseAndCheckProgramForProblems(
     source: []const u8,
     imports: []const ModuleSource,
 ) !ProblemResources {
-    const builtin_indices = try builtin_loading.deserializeBuiltinIndices(allocator, compiled_builtins.builtin_indices_bin);
-    var builtin_module = try builtin_loading.loadCompiledModule(
-        allocator,
-        compiled_builtins.builtin_bin,
-        "Builtin",
-        compiled_builtins.builtin_source,
-    );
-    errdefer builtin_module.deinit();
+    return parseAndCheckProgramForProblemsImpl(allocator, source_kind, source, imports, null);
+}
+
+/// Same as `parseAndCheckProgramForProblems` but reuses a Builtin module the
+/// caller has already loaded. The returned `ProblemResources` borrows the
+/// builtin env (its `builtin_module` is null) and never deinits it.
+pub fn parseAndCheckProgramForProblemsWithBuiltin(
+    allocator: Allocator,
+    source_kind: SourceKind,
+    source: []const u8,
+    imports: []const ModuleSource,
+    pre_published_builtin: PrePublishedBuiltin,
+) !ProblemResources {
+    return parseAndCheckProgramForProblemsImpl(allocator, source_kind, source, imports, pre_published_builtin);
+}
+
+fn parseAndCheckProgramForProblemsImpl(
+    allocator: Allocator,
+    source_kind: SourceKind,
+    source: []const u8,
+    imports: []const ModuleSource,
+    pre_published_builtin: ?PrePublishedBuiltin,
+) !ProblemResources {
+    const builtin_indices: CIR.BuiltinIndices = if (pre_published_builtin) |ppb|
+        ppb.indices
+    else
+        try builtin_loading.deserializeBuiltinIndices(allocator, compiled_builtins.builtin_indices_bin);
+
+    var loaded_builtin: ?builtin_loading.LoadedModule = if (pre_published_builtin == null)
+        try builtin_loading.loadCompiledModule(
+            allocator,
+            compiled_builtins.builtin_bin,
+            "Builtin",
+            compiled_builtins.builtin_source,
+        )
+    else
+        null;
+    errdefer if (loaded_builtin) |*lm| lm.deinit();
+
+    const builtin_env: *const ModuleEnv = if (pre_published_builtin) |ppb|
+        ppb.env
+    else
+        loaded_builtin.?.env;
 
     var extra_modules = std.ArrayList(CheckedModule).empty;
     errdefer {
@@ -472,7 +510,7 @@ pub fn parseAndCheckProgramForProblems(
             true,
             .checked_artifact,
             &.{},
-            builtin_module.env,
+            builtin_env,
             builtin_indices,
             available_imports,
         );
@@ -498,7 +536,7 @@ pub fn parseAndCheckProgramForProblems(
         false,
         .checked_artifact,
         &.{},
-        builtin_module.env,
+        builtin_env,
         builtin_indices,
         main_imports,
     );
@@ -507,7 +545,7 @@ pub fn parseAndCheckProgramForProblems(
     var all_module_envs = try allocator.alloc(*ModuleEnv, extra_modules.items.len + 2);
     defer allocator.free(all_module_envs);
     all_module_envs[0] = main_checked.module_env;
-    all_module_envs[1] = builtin_module.env;
+    all_module_envs[1] = @constCast(builtin_env);
     for (extra_modules.items, 0..) |extra, i| {
         all_module_envs[i + 2] = extra.module_env;
     }
@@ -515,7 +553,7 @@ pub fn parseAndCheckProgramForProblems(
 
     return .{
         .main = main_checked,
-        .builtin_module = builtin_module,
+        .builtin_module = loaded_builtin,
         .extra_modules = try extra_modules.toOwnedSlice(allocator),
     };
 }


### PR DESCRIPTION
Fixes #9515

## Summary

`run-test-zig-builtin-doc` was a very slow MiniCI leaf (~370s) because the harness re-ran full compiler setup for each of ~700 `Builtin.roc` doc blocks:

- it re-deserialized and re-published the Builtin module on **every** check **and** **every** eval, and
- `compileInspectedProgram` lowered **both** native and wasm LIR even though the harness only interprets the native lowering.

This loads and publishes the Builtin module **once** in the parent test process and borrows it read-only for every block — directly for the in-parent check phase, and via `fork()` copy-on-write for the child eval phase. Evaluation now lowers the native target only.

**Measured: ~370s → ~11s** (both tests still pass; full `run-test-eval` suite stays green).

## Changes

- **`src/eval/test_helpers.zig`** — add `parseAndCheckProgramForProblemsWithBuiltin`, which borrows a caller-owned `PrePublishedBuiltin` (env + indices) instead of reloading. `ProblemResources.builtin_module` is now optional (`null` when borrowed) so `deinit` never frees a borrowed builtin. Mirrors the existing canonicalize-with-builtin path.
- **`src/eval/test/builtin_doc_tests.zig`** — publish the Builtin once via `eval.BuiltinModules.init` (stored file-scope so both the parent check and the fork-COW child eval reuse it read-only); evaluate via `compileInspectedProgramForTarget(.native)` WithBuiltin, skipping wasm lowering. Crash isolation and the binary-reproduction failure path are unchanged.
- **`src/build/minici.zig`** — re-enable `run-test-zig-builtin-doc` (drop the "skipped until #9515" marker).

## Test plan

- `zig build run-test-zig-builtin-doc` — passes in ~11s (was ~370s).
- `zig build run-test-eval` — passes (covers `parallel_runner.zig`, the other consumer of the changed check helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
