### PR TITLE
Fix latent memory-safety bugs and correctness issues in Check.zig

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -5156,11 +5156,13 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                             .tuple = .{ .elems = elem_vars },
                         } }, env, expr_region);
 
+                        // A non-tuple structure can never satisfy a tuple access,
+                        // so this unify reports the mismatch. Poison the result to
+                        // `.err` (like the out-of-bounds branch above) rather than
+                        // leaving it a fresh flex var, so conflicting downstream
+                        // uses of the result don't produce cascading errors.
                         _ = try self.unify(tuple_var, expected_tuple_var, env);
-
-                        // The result type is the element at the index
-                        const result_var = self.types.sliceVars(elem_vars)[tuple_access.elem_index];
-                        _ = try self.unify(expr_var, result_var, env);
+                        try self.unifyWith(expr_var, .err, env);
                     },
                 },
                 .flex => {

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -8558,7 +8558,10 @@ fn resolveNumericLiteralsFromContext(self: *Self, env: *Env) std.mem.Allocator.E
             const fn_content = self.types.resolveVar(c.fn_var).desc.content;
             const func = fn_content.unwrapFunc() orelse continue;
             var found_peer = false;
-            for (self.types.sliceVars(func.args)) |arg| {
+            // Use iterVars, not sliceVars: unify below appends fresh vars and
+            // can reallocate the backing array, which would dangle a slice.
+            var peer_args = self.types.iterVars(func.args);
+            while (peer_args.next()) |arg| {
                 const resolved_arg = self.types.resolveVar(arg);
                 if (resolved_arg.var_ == resolved.var_) continue; // skip self
                 if (resolved_arg.desc.content.unwrapNominalType() == null) continue;
@@ -8581,7 +8584,10 @@ fn resolveNumericLiteralsFromContext(self: *Self, env: *Env) std.mem.Allocator.E
             if (resolved_ret.desc.content.unwrapNominalType() == null) continue;
             _ = try self.unify(resolved.var_, resolved_ret.var_, env);
 
-            for (self.types.sliceVars(func.args)) |arg| {
+            // Use iterVars, not sliceVars: each unify can reallocate the
+            // backing array, so a held slice would dangle on the next iteration.
+            var ret_args = self.types.iterVars(func.args);
+            while (ret_args.next()) |arg| {
                 const resolved_arg = self.types.resolveVar(arg);
                 if (resolved_arg.var_ == resolved.var_) continue;
                 _ = try self.unify(resolved_ret.var_, resolved_arg.var_, env);

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -2773,6 +2773,13 @@ pub fn checkExprReplWithDefs(self: *Self, expr_idx: CIR.Expr.Idx) std.mem.Alloca
         try self.checkForInfiniteType(CIR.Def.Idx, def_idx);
     }
 
+    // Check the result expression itself, matching checkExprRepl: its type may
+    // have incompatible constraints (e.g. !3) or be infinite/anonymously
+    // recursive, neither of which is covered by the per-def checks above.
+    const expr_var = ModuleEnv.varFrom(expr_idx);
+    try self.checkFlexVarConstraintCompatibility(expr_var, &env, true);
+    try self.checkForInfiniteType(CIR.Expr.Idx, expr_idx);
+
     try self.reportPolymorphicConstrainedExpr(expr_idx);
     try self.poisonErroneousValueUses();
 }

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -9786,7 +9786,11 @@ fn validateUnsignedFromNumeralLiteral(
     num_literal: types_mod.NumeralInfo,
 ) ?BuiltinFromNumeralLiteralProblem {
     if (num_literal.is_fractional) return .fractional_integer;
-    if (num_literal.is_negative) return .negative_unsigned;
+    // `is_negative` is a syntactic flag (a leading `-`); guard on the actual
+    // magnitude so `-0` (a valid unsigned value) is not rejected. Real
+    // negatives have a nonzero magnitude, and a large negative whose i128
+    // representation overflowed is still nonzero, so this stays correct.
+    if (num_literal.is_negative and num_literal.toI128() != 0) return .negative_unsigned;
 
     const value = if (num_literal.is_u128) blk: {
         break :blk num_literal.toU128();

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -1875,9 +1875,17 @@ fn checkFileInternal(self: *Self, skip_numeric_defaults: bool) std.mem.Allocator
 /// (local/nested lambdas included). A static-dispatch receiver that resolves into
 /// this set can be pinned by a caller at some level, so it is not ambiguous.
 fn collectPinnableVars(self: *Self, pinnable: *std.AutoHashMap(Var, void)) std.mem.Allocator.Error!void {
+    // Shared across all defs in this one-shot, end-of-check pass (not per
+    // expression), so it bounds memory by the largest type spine walked rather
+    // than growing as more of the program is checked. Guards the function-ret /
+    // alias spine in collectArgPositionVars against unbounded recursion; arg
+    // structure is already deduped via `pinnable` inside collectReachableVars.
+    var spine_visited = std.AutoHashMap(Var, void).init(self.gpa);
+    defer spine_visited.deinit();
+
     for (0..self.cir.all_defs.span.len) |def_offset| {
         const def_idx = self.cir.store.defAt(self.cir.all_defs, def_offset);
-        try self.collectArgPositionVars(ModuleEnv.varFrom(def_idx), pinnable);
+        try self.collectArgPositionVars(ModuleEnv.varFrom(def_idx), pinnable, &spine_visited);
     }
 
     var raw_node_idx: u32 = 0;
@@ -2168,10 +2176,21 @@ fn reportAmbiguousStaticDispatch(
 /// tuples, tag payloads, nested function args AND rets). Return positions of the
 /// outer function are NOT collected (a return-only var is not parameter-pinnable),
 /// but once inside an argument every nested position counts.
-fn collectArgPositionVars(self: *Self, var_: Var, out: *std.AutoHashMap(Var, void)) std.mem.Allocator.Error!void {
+fn collectArgPositionVars(
+    self: *Self,
+    var_: Var,
+    out: *std.AutoHashMap(Var, void),
+    spine_visited: *std.AutoHashMap(Var, void),
+) std.mem.Allocator.Error!void {
     const resolved = self.types.resolveVar(var_);
+    // Guard the function-ret / alias spine against cycles. Cyclic spines are
+    // currently pre-broken (infinite types are poisoned to .err before this
+    // pass, recursive aliases are rejected during generation), but the guard
+    // keeps this robust if that ever changes.
+    if (spine_visited.contains(resolved.var_)) return;
+    try spine_visited.put(resolved.var_, {});
     switch (resolved.desc.content) {
-        .alias => |alias| try self.collectArgPositionVars(self.types.getAliasBackingVar(alias), out),
+        .alias => |alias| try self.collectArgPositionVars(self.types.getAliasBackingVar(alias), out, spine_visited),
         .structure => |flat| switch (flat) {
             .fn_pure, .fn_effectful, .fn_unbound => |func| {
                 for (self.types.sliceVars(func.args)) |arg| {
@@ -2179,7 +2198,7 @@ fn collectArgPositionVars(self: *Self, var_: Var, out: *std.AutoHashMap(Var, voi
                 }
                 // Recurse into the return type: a curried function returns more
                 // functions whose own arguments are still parameter-pinnable.
-                try self.collectArgPositionVars(func.ret, out);
+                try self.collectArgPositionVars(func.ret, out, spine_visited);
             },
             else => {},
         },

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -10063,8 +10063,11 @@ fn checkAllFromNumeralFlexConstraintCompatibility(
 /// This handles cases like `Error -> Error` where the root is a function but the
 /// argument/return types are errors.
 /// Check if a branch body type is compatible with the expected return type.
-/// This performs a non-destructive unification probe using a type-store snapshot.
-/// Must be called BEFORE pairwise unification poisons branch vars.
+/// This unifies against a type-store snapshot that is rolled back afterward, so
+/// it leaves the type store unchanged. It is NOT fully side-effect-free,
+/// however: a mismatch is recorded as a diagnostic in the real problem store
+/// (see the note at the unify call below). Must be called BEFORE pairwise
+/// unification poisons branch vars.
 fn isCompatibleWithExpected(self: *Self, body_var: Var, expected_var: Var, ctx: problem.Context) bool {
     const body = self.types.resolveVar(body_var);
     const expected = self.types.resolveVar(expected_var);
@@ -10087,6 +10090,15 @@ fn isCompatibleWithExpected(self: *Self, body_var: Var, expected_var: Var, ctx: 
         store_snapshot.deinit(self.cir.gpa);
     }
 
+    // NOTE: this passes the real `self.problems`/`self.snapshots` stores, not
+    // throwaway ones, so a mismatch here is RECORDED as a diagnostic and is NOT
+    // rolled back by the defer above (which only rolls back the type store).
+    // This is intentional and load-bearing: callers respond to a `false` return
+    // by marking the branch erroneous WITHOUT emitting their own diagnostic, so
+    // for some branch mismatches (e.g. a match branch whose body conflicts with
+    // a rigid annotated return type) the problem recorded here is the only
+    // diagnostic the user ever sees. Do not switch this to a throwaway problem
+    // store without making the callers emit the diagnostic themselves.
     const probe_result = unifier.unifyInContext(
         self.cir.gpa,
         self.cir.getIdentStoreConst(),

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -9000,9 +9000,6 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
                 const rigid = dispatcher_content.rigid;
                 const rigid_constraints = self.types.sliceStaticDispatchConstraints(rigid.constraints);
 
-                // Get the deferred constraints to validate against
-                const deferred_constraints = self.types.sliceStaticDispatchConstraints(deferred_constraint.constraints);
-
                 // Build a map of constraints the rigid has
                 self.ident_to_var_map.clearRetainingCapacity();
                 try self.ident_to_var_map.ensureUnusedCapacity(@intCast(rigid_constraints.len));
@@ -9010,8 +9007,11 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
                     self.ident_to_var_map.putAssumeCapacity(rigid_constraint.fn_name, rigid_constraint.fn_var);
                 }
 
-                // Iterate over the constraints
-                for (deferred_constraints) |constraint| {
+                // Iterate over the deferred constraints to validate against.
+                // iterRange re-fetches each item through the SafeList, so it stays valid
+                // even if the unify below appends and reallocates the backing array.
+                var constraints_iter = self.types.static_dispatch_constraints.iterRange(deferred_constraint.constraints);
+                while (constraints_iter.next()) |constraint| {
                     if (constraint.origin == .from_numeral) {
                         if (self.builtinNumKindFromTypeName(rigid.name)) |num_kind| {
                             if (skipDefaultedDecIntegerLiteralValidation(is_numeric_default_pass, num_kind, constraint)) {
@@ -9474,8 +9474,10 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
             {
                 // Anonymous structural types (records, tuples, tag unions) have implicit is_eq
                 // only if all their components also support is_eq
-                const constraints = self.types.sliceStaticDispatchConstraints(deferred_constraint.constraints);
-                for (constraints) |constraint| {
+                // iterRange re-fetches each item through the SafeList, so it stays valid even if
+                // satisfyImplicitEqualityConstraint appends and reallocates the backing array.
+                var constraints_iter = self.types.static_dispatch_constraints.iterRange(deferred_constraint.constraints);
+                while (constraints_iter.next()) |constraint| {
                     // Check if this is a call to is_eq (anonymous types have implicit structural equality)
                     if (constraint.fn_name.eql(self.cir.idents.is_eq)) {
                         // Check if all components of this anonymous type support is_eq

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -9926,8 +9926,12 @@ fn satisfyImplicitEqualityConstraint(
         );
     }
 
-    _ = try self.unify(dispatcher_var, args[0], env);
-    _ = try self.unify(dispatcher_var, args[1], env);
+    // Read both arg vars before unifying: the first unify can append fresh
+    // vars and reallocate the backing array, dangling the `args` slice.
+    const arg0 = args[0];
+    const arg1 = args[1];
+    _ = try self.unify(dispatcher_var, arg0, env);
+    _ = try self.unify(dispatcher_var, arg1, env);
     _ = try self.unify(try self.freshBool(env, region), resolved_func.ret, env);
     self.rewriteImplicitEqMethodCallAsStructuralEq(constraint);
 }

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -7190,8 +7190,9 @@ fn checkMatchExpr(
     const first_branch = self.cir.store.getMatchBranch(first_branch_idx);
     const first_branch_ptrn_idxs = self.cir.store.sliceMatchBranchPatterns(first_branch.patterns);
 
-    // Skip pattern checking if we already know the condition isn't a Try type
-    // This prevents confusing cascading errors about pattern incompatibility
+    // Check each of the first branch's patterns and unify it with the
+    // condition type. (A failed unify poisons cond_var to .err, so subsequent
+    // pattern unifications short-circuit rather than cascading.)
     for (first_branch_ptrn_idxs, 0..) |branch_ptrn_idx, cur_ptrn_index| {
         const branch_ptrn = self.cir.store.getMatchBranchPattern(branch_ptrn_idx);
         try self.checkPattern(branch_ptrn.pattern, .match_branch, env);
@@ -7480,7 +7481,7 @@ fn checkUnaryMinusExpr(self: *Self, expr_idx: CIR.Expr.Idx, expr_region: Region,
     // This function attaches the dispatch fn to the not_arg
     try self.mkUnaryOp(not_arg_var, not_ret_var, not_method_name, env, expr_region, expr_idx);
 
-    // Redirect the result to the boolean type
+    // The result type is the operand type (the desugaring is `a -> a`).
     _ = try self.unify(expr_var, not_ret_var, env);
 
     return does_fx;
@@ -7509,7 +7510,7 @@ fn checkUnaryNotExpr(self: *Self, expr_idx: CIR.Expr.Idx, expr_region: Region, e
     // This function attaches the dispatch fn to the not_arg
     try self.mkUnaryOp(not_arg_var, not_ret_var, not_method_name, env, expr_region, expr_idx);
 
-    // Redirect the result to the boolean type
+    // The result type is the operand type (the desugaring is `a -> a`).
     _ = try self.unify(expr_var, not_ret_var, env);
 
     return does_fx;
@@ -7606,7 +7607,6 @@ fn checkBinopExpr(
                     .gt => .{ self.cir.idents.is_gt, try self.freshBool(env, expr_region) },
                     .le => .{ self.cir.idents.is_lte, try self.freshBool(env, expr_region) },
                     .ge => .{ self.cir.idents.is_gte, try self.freshBool(env, expr_region) },
-                    .eq => .{ self.cir.idents.is_eq, try self.freshBool(env, expr_region) },
                     else => unreachable,
                 };
 
@@ -8711,6 +8711,13 @@ fn builtinNumericCandidateSatisfiesStaticDispatchConstraints(
     return true;
 }
 
+/// PRECONDITION: the caller MUST have an active type-store snapshot in scope.
+/// This speculatively mutates the real stores (copyVar/instantiateVar append
+/// vars and regions, probeUnifyWithoutRecordingProblems unifies) and does NOT
+/// roll them back itself — it relies on the caller's snapshot rollback. The only
+/// caller, builtinNumericCandidateSatisfiesStaticDispatchConstraints, wraps its
+/// loop in such a snapshot. A new caller without one would leak speculative vars
+/// into the live store and corrupt subsequent solving.
 fn staticDispatchConstraintAcceptsCandidate(
     self: *Self,
     constraint: StaticDispatchConstraint,

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -1463,7 +1463,12 @@ fn base256DecimalText(allocator: Allocator, bytes_be: []const u8, min_digits: us
                 quotient_len += 1;
             }
         }
-        try digits_rev.append(allocator, '0' + @as(u8, @intCast(remainder)));
+        // Free the freshly-allocated quotient if recording the digit fails,
+        // since it has not yet been adopted into current_buf.
+        digits_rev.append(allocator, '0' + @as(u8, @intCast(remainder))) catch |err| {
+            allocator.free(quotient);
+            return err;
+        };
         allocator.free(current_buf);
         current_buf = quotient;
         current_len = quotient_len;

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -3646,6 +3646,13 @@ fn generateAnnoTypeInPlace(self: *Self, anno_idx: CIR.TypeAnno.Idx, env: *Env, c
                 }
             }.less);
 
+            // Materialize the tags into the types store before processing the
+            // ext. `tags_slice` points into the scratch_tags buffer, and
+            // generating the ext recurses and may append to scratch_tags,
+            // reallocating that buffer and dangling the slice. Copying into a
+            // stable range here mirrors the record case below.
+            const tags_range = try self.types.appendTags(tags_slice);
+
             // Process the ext if it exists. Absence means it's a closed union
             const ext_var = inner_blk: {
                 if (tag_union.ext) |ext_anno_idx| {
@@ -3657,7 +3664,14 @@ fn generateAnnoTypeInPlace(self: *Self, anno_idx: CIR.TypeAnno.Idx, env: *Env, c
             };
 
             // Set the anno's type
-            try self.unifyWith(anno_var, try self.types.mkTagUnion(tags_slice, ext_var), env);
+            try self.unifyWith(
+                anno_var,
+                .{ .structure = types_mod.FlatType{ .tag_union = .{
+                    .tags = tags_range,
+                    .ext = ext_var,
+                } } },
+                env,
+            );
         },
         .tag => {
             // Tags should only exist as direct children of tag_unions in type annotations.

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -9621,60 +9621,83 @@ fn nominalIsBoxType(self: *Self, nominal_type: types_mod.NominalType) bool {
 }
 
 fn varContainsUnboxedFunctionInHostedSignature(self: *Self, var_: Var) bool {
-    return self.varContainsUnboxedFunctionInHostedSignatureInternal(var_, true);
+    self.var_set.clearRetainingCapacity();
+    return self.varContainsUnboxedFunctionInHostedSignatureInternal(var_, true, &self.var_set) catch false;
 }
 
-fn varContainsUnboxedFunctionInHostedSignatureInternal(self: *Self, var_: Var, allow_top_fn: bool) bool {
+fn varContainsUnboxedFunctionInHostedSignatureInternal(
+    self: *Self,
+    var_: Var,
+    allow_top_fn: bool,
+    visited: *std.AutoHashMap(Var, void),
+) std.mem.Allocator.Error!bool {
     const resolved = self.types.resolveVar(var_);
+    // Cycle guard: recursive nominal/structural types would otherwise recurse
+    // forever through their backing vars. A var already on the stack
+    // contributes no new unboxed function we haven't already considered.
+    if (visited.contains(resolved.var_)) return false;
+    try visited.put(resolved.var_, {});
     return switch (resolved.desc.content) {
         .structure => |s| switch (s) {
             .fn_pure, .fn_effectful, .fn_unbound => |func| blk: {
                 if (!allow_top_fn) break :blk true;
                 const args = self.types.sliceVars(func.args);
                 for (args) |arg_var| {
-                    if (self.varContainsUnboxedFunctionInternal(arg_var, false)) break :blk true;
+                    if (try self.varContainsUnboxedFunctionInternal(arg_var, false, visited)) break :blk true;
                 }
-                if (self.varContainsUnboxedFunctionInternal(func.ret, false)) break :blk true;
+                if (try self.varContainsUnboxedFunctionInternal(func.ret, false, visited)) break :blk true;
                 break :blk false;
             },
-            else => self.flatTypeContainsUnboxedFunction(s, false),
+            else => try self.flatTypeContainsUnboxedFunction(s, false, visited),
         },
-        .alias => |alias| self.varContainsUnboxedFunctionInHostedSignatureInternal(self.types.getAliasBackingVar(alias), allow_top_fn),
+        .alias => |alias| try self.varContainsUnboxedFunctionInHostedSignatureInternal(self.types.getAliasBackingVar(alias), allow_top_fn, visited),
         .flex, .rigid, .err => false,
     };
 }
 
-fn varContainsUnboxedFunctionInternal(self: *Self, var_: Var, boxed_allowed: bool) bool {
+fn varContainsUnboxedFunctionInternal(
+    self: *Self,
+    var_: Var,
+    boxed_allowed: bool,
+    visited: *std.AutoHashMap(Var, void),
+) std.mem.Allocator.Error!bool {
     const resolved = self.types.resolveVar(var_);
+    if (visited.contains(resolved.var_)) return false;
+    try visited.put(resolved.var_, {});
     return switch (resolved.desc.content) {
-        .structure => |s| self.flatTypeContainsUnboxedFunction(s, boxed_allowed),
-        .alias => |alias| self.varContainsUnboxedFunctionInternal(self.types.getAliasBackingVar(alias), boxed_allowed),
+        .structure => |s| try self.flatTypeContainsUnboxedFunction(s, boxed_allowed, visited),
+        .alias => |alias| try self.varContainsUnboxedFunctionInternal(self.types.getAliasBackingVar(alias), boxed_allowed, visited),
         .flex, .rigid, .err => false,
     };
 }
 
-fn flatTypeContainsUnboxedFunction(self: *Self, flat_type: types_mod.FlatType, boxed_allowed: bool) bool {
+fn flatTypeContainsUnboxedFunction(
+    self: *Self,
+    flat_type: types_mod.FlatType,
+    boxed_allowed: bool,
+    visited: *std.AutoHashMap(Var, void),
+) std.mem.Allocator.Error!bool {
     return switch (flat_type) {
         .fn_pure, .fn_effectful, .fn_unbound => !boxed_allowed,
         .empty_record, .empty_tag_union => false,
         .record => |record| blk: {
             const fields_slice = self.types.getRecordFieldsSlice(record.fields);
             for (fields_slice.items(.var_)) |field_var| {
-                if (self.varContainsUnboxedFunctionInternal(field_var, boxed_allowed)) break :blk true;
+                if (try self.varContainsUnboxedFunctionInternal(field_var, boxed_allowed, visited)) break :blk true;
             }
             break :blk false;
         },
         .record_unbound => |fields| blk: {
             const fields_slice = self.types.getRecordFieldsSlice(fields);
             for (fields_slice.items(.var_)) |field_var| {
-                if (self.varContainsUnboxedFunctionInternal(field_var, boxed_allowed)) break :blk true;
+                if (try self.varContainsUnboxedFunctionInternal(field_var, boxed_allowed, visited)) break :blk true;
             }
             break :blk false;
         },
         .tuple => |tuple| blk: {
             const elems = self.types.sliceVars(tuple.elems);
             for (elems) |elem_var| {
-                if (self.varContainsUnboxedFunctionInternal(elem_var, boxed_allowed)) break :blk true;
+                if (try self.varContainsUnboxedFunctionInternal(elem_var, boxed_allowed, visited)) break :blk true;
             }
             break :blk false;
         },
@@ -9683,7 +9706,7 @@ fn flatTypeContainsUnboxedFunction(self: *Self, flat_type: types_mod.FlatType, b
             for (tags_slice.items(.args)) |tag_args| {
                 const args = self.types.sliceVars(tag_args);
                 for (args) |arg_var| {
-                    if (self.varContainsUnboxedFunctionInternal(arg_var, boxed_allowed)) break :blk true;
+                    if (try self.varContainsUnboxedFunctionInternal(arg_var, boxed_allowed, visited)) break :blk true;
                 }
             }
             break :blk false;
@@ -9691,7 +9714,7 @@ fn flatTypeContainsUnboxedFunction(self: *Self, flat_type: types_mod.FlatType, b
         .nominal_type => |nominal| blk: {
             if (self.nominalIsBoxType(nominal)) break :blk false;
             const backing_var = self.types.getNominalBackingVar(nominal);
-            break :blk self.varContainsUnboxedFunctionInternal(backing_var, boxed_allowed);
+            break :blk try self.varContainsUnboxedFunctionInternal(backing_var, boxed_allowed, visited);
         },
     };
 }

--- a/src/check/occurs.zig
+++ b/src/check/occurs.zig
@@ -51,16 +51,11 @@ pub fn occurs(types_store: *Store, scratch: *Scratch, var_: Var) std.mem.Allocat
 
     var result: Result = .not_recursive;
 
-    // Check if we're starting from a nominal type
-    const root = types_store.resolveVar(var_);
-    const initial_context = if (root.desc.content == .structure and root.desc.content.structure == .nominal_type)
-        Context.init().markNominal()
-    else
-        Context.init();
-
-    // Check for recursion
+    // Check for recursion. The root has no incoming edge, so it starts with the
+    // empty edge. Whether the recursion is nominal/anonymous/infinite is decided
+    // from the edges *within* the detected cycle, not from the root downward.
     var check_occurs = CheckOccurs.init(types_store, scratch);
-    check_occurs.occurs(var_, initial_context) catch |err| switch (err) {
+    check_occurs.occurs(var_, Edge.none) catch |err| switch (err) {
         error.AllocatorError => {
             return error.OutOfMemory;
         },
@@ -112,79 +107,69 @@ const CheckOccurs = struct {
     ///
     /// This method appends intermediate error chain information to the `scratch`,
     /// which can be queried after the run.
-    fn occurs(self: *Self, var_: Var, ctx: Context) Error!void {
+    fn occurs(self: *Self, var_: Var, edge: Edge) Error!void {
         const root = self.types_store.resolveVar(var_);
         const root_var = root.var_;
 
         if (self.scratch.hasVisited(root.desc_idx)) {
             // If we've already visited this var and not errored, then it's not recursive
             return;
-        } else if (self.scratch.hasSeenVar(root_var)) {
+        } else if (self.scratch.hasSeenVar(root_var)) |match_idx| {
             // Recursion point! We've already seen this var during traversal.
-            if (ctx.recursion_allowed and ctx.seen_nominal) {
-                // If recursion is allowed (we've passed through a Box, List or
-                // Tag Union) AND at somepoint in the chain we've seen a nominal
-                // type, then this recursion is okay
-                return error.RecursiveNominal;
-            } else if (ctx.recursion_allowed and !ctx.seen_nominal) {
-                // If recursion is allowed (we've passed through a Box, List or
-                // Tag Union) BUT we haven't seen any nominal types, then this
-                // recursion is anonymous and not okay
-                return error.RecursiveAnonymous;
-            } else {
-                // Otherwise, this is an infinite type
-                return error.InfiniteType;
-            }
+            // `edge` is the edge that closes the cycle (from the current parent
+            // back to `root_var`); `match_idx` is where `root_var` sits on the
+            // seen stack. Classify using only the edges inside that cycle.
+            return self.classifyCycle(match_idx, edge);
         } else {
-            self.scratch.appendSeen(root_var) catch return Error.AllocatorError;
+            self.scratch.pushSeen(root_var, edge) catch return Error.AllocatorError;
             switch (root.desc.content) {
                 .structure => |flat_type| {
                     switch (flat_type) {
                         .tuple => |tuple| {
                             const elems = self.types_store.sliceVars(tuple.elems);
-                            try self.occursSubVars(root, elems, ctx);
+                            try self.occursSubVars(root, elems, Edge.none);
                         },
                         .nominal_type => |nominal_type| {
-                            // Check all argument vars using iterator
+                            // Arguments are ordinary positions; only the backing
+                            // var is "through" the nominal.
                             var arg_iter = self.types_store.iterNominalArgs(nominal_type);
                             while (arg_iter.next()) |arg_var| {
-                                try self.occursSubVar(root, arg_var, ctx);
+                                try self.occursSubVar(root, arg_var, Edge.none);
                             }
-                            // Check backing var using helper method
                             const backing_var = self.types_store.getNominalBackingVar(nominal_type);
-                            try self.occursSubVar(root, backing_var, ctx.markNominal());
+                            try self.occursSubVar(root, backing_var, Edge.nominal);
                         },
                         .fn_pure => |func| {
                             const args = self.types_store.sliceVars(func.args);
-                            try self.occursSubVars(root, args, ctx);
-                            try self.occursSubVar(root, func.ret, ctx);
+                            try self.occursSubVars(root, args, Edge.none);
+                            try self.occursSubVar(root, func.ret, Edge.none);
                         },
                         .fn_effectful => |func| {
                             const args = self.types_store.sliceVars(func.args);
-                            try self.occursSubVars(root, args, ctx);
-                            try self.occursSubVar(root, func.ret, ctx);
+                            try self.occursSubVars(root, args, Edge.none);
+                            try self.occursSubVar(root, func.ret, Edge.none);
                         },
                         .fn_unbound => |func| {
                             const args = self.types_store.sliceVars(func.args);
-                            try self.occursSubVars(root, args, ctx);
-                            try self.occursSubVar(root, func.ret, ctx);
+                            try self.occursSubVars(root, args, Edge.none);
+                            try self.occursSubVar(root, func.ret, Edge.none);
                         },
                         .record => |record| {
                             const fields = self.types_store.getRecordFieldsSlice(record.fields);
-                            try self.occursSubVars(root, fields.items(.var_), ctx.allowRecursion());
-                            try self.occursSubVar(root, record.ext, ctx);
+                            try self.occursSubVars(root, fields.items(.var_), Edge.recursion);
+                            try self.occursSubVar(root, record.ext, Edge.none);
                         },
                         .record_unbound => |fields| {
                             const fields_slice = self.types_store.getRecordFieldsSlice(fields);
-                            try self.occursSubVars(root, fields_slice.items(.var_), ctx.allowRecursion());
+                            try self.occursSubVars(root, fields_slice.items(.var_), Edge.recursion);
                         },
                         .tag_union => |tag_union| {
                             const tags = self.types_store.getTagsSlice(tag_union.tags);
                             for (tags.items(.args)) |tag_args| {
                                 const args = self.types_store.sliceVars(tag_args);
-                                try self.occursSubVars(root, args, ctx.allowRecursion());
+                                try self.occursSubVars(root, args, Edge.recursion);
                             }
-                            try self.occursSubVar(root, tag_union.ext, ctx);
+                            try self.occursSubVar(root, tag_union.ext, Edge.none);
                         },
                         .empty_record => {},
                         .empty_tag_union => {},
@@ -194,10 +179,10 @@ const CheckOccurs = struct {
                     // Check all argument vars using iterator
                     var arg_iter = self.types_store.iterAliasArgs(alias);
                     while (arg_iter.next()) |arg_var| {
-                        try self.occursSubVar(root, arg_var, ctx);
+                        try self.occursSubVar(root, arg_var, Edge.none);
                     }
                     const backing_var = self.types_store.getAliasBackingVar(alias);
-                    try self.occursSubVar(root, backing_var, ctx);
+                    try self.occursSubVar(root, backing_var, Edge.none);
                 },
                 .flex => {
                     // Flex variables are not checked for cycles - they are allowed to have
@@ -212,10 +197,42 @@ const CheckOccurs = struct {
         }
     }
 
+    /// Classify a detected cycle using only the edges that lie *within* it.
+    ///
+    /// The cycle consists of the seen-stack frames `match_idx+1 ..= top` (each
+    /// carrying the edge that pushed it) plus the `closing` edge from the current
+    /// parent back to the cycle head at `match_idx`. Edges above the cycle (the
+    /// head's own incoming edge and anything before it) are intentionally ignored
+    /// so an enclosing nominal/container can't reclassify an unrelated cycle.
+    fn classifyCycle(self: *Self, match_idx: usize, closing: Edge) Error!void {
+        var recursion_allowed = closing.recursion_allowed;
+        var nominal = closing.nominal_backing;
+
+        const entries = self.scratch.seen.items.items;
+        var k = match_idx + 1;
+        while (k < entries.len) : (k += 1) {
+            recursion_allowed = recursion_allowed or entries[k].edge.recursion_allowed;
+            nominal = nominal or entries[k].edge.nominal_backing;
+        }
+
+        if (recursion_allowed and nominal) {
+            // The cycle passes through a recursion-allowed position (record, tag
+            // union) AND a nominal's backing: valid recursion through a nominal.
+            return error.RecursiveNominal;
+        } else if (recursion_allowed) {
+            // Through a recursion-allowed position but no nominal: anonymous
+            // recursion, which Roc rejects.
+            return error.RecursiveAnonymous;
+        } else {
+            // No recursion-allowed position in the cycle: structurally infinite.
+            return error.InfiniteType;
+        }
+    }
+
     /// Check if a sub var is recursive
     /// In the event of an error, append the root var to the chain
-    fn occursSubVar(self: *Self, root: ResolvedVarDesc, sub_var: Var, ctx: Context) Error!void {
-        self.occurs(sub_var, ctx) catch |err| {
+    fn occursSubVar(self: *Self, root: ResolvedVarDesc, sub_var: Var, edge: Edge) Error!void {
+        self.occurs(sub_var, edge) catch |err| {
             self.scratch.appendErrChain(root.var_) catch return Error.AllocatorError;
             if (root.desc.content.unwrapNominalType() != null) {
                 self.scratch.appendErrChainNominalVar(root.var_) catch return Error.AllocatorError;
@@ -226,41 +243,41 @@ const CheckOccurs = struct {
 
     /// Check if a slice of sub vars are recursive
     /// In the event of an error, append the root var to the chain
-    fn occursSubVars(self: *Self, root_var: ResolvedVarDesc, sub_vars: []Var, ctx: Context) Error!void {
+    fn occursSubVars(self: *Self, root_var: ResolvedVarDesc, sub_vars: []Var, edge: Edge) Error!void {
         for (sub_vars) |sub_var| {
-            try self.occursSubVar(root_var, sub_var, ctx);
+            try self.occursSubVar(root_var, sub_var, edge);
         }
     }
 };
 
-/// This type represents the context of a recursive branch in the occurs check
+/// A single parent→child edge in the type graph traversal.
 ///
-/// This types is passed down through the occurs check and is modified to keep
-/// track of whatever we've seen so far in this branch.
-const Context = struct {
+/// An `Edge` describes exactly one step and never carries state down from above:
+/// at most one flag is set per edge. Each `seen`-stack frame stores the edge that
+/// pushed it (see `SeenEntry`), and a detected cycle is classified from the edges
+/// inside the cycle only. This is what keeps an enclosing nominal/container from
+/// reclassifying a cycle it isn't actually part of.
+const Edge = struct {
+    /// The child sits in a record field or tag-union argument: a position that
+    /// makes recursion through it well-formed (vs. structurally infinite).
     recursion_allowed: bool,
-    seen_nominal: bool,
+    /// The child is a nominal type's backing var (recursion "through" a nominal).
+    nominal_backing: bool,
 
-    fn init() Context {
-        return .{ .recursion_allowed = false, .seen_nominal = false };
-    }
+    /// No flag set: tuple elems, fn args/ret, nominal args, alias args/backing,
+    /// record/tag-union ext.
+    const none: Edge = .{ .recursion_allowed = false, .nominal_backing = false };
+    /// Edge into a record field or tag-union argument.
+    const recursion: Edge = .{ .recursion_allowed = true, .nominal_backing = false };
+    /// Edge into a nominal type's backing var.
+    const nominal: Edge = .{ .recursion_allowed = false, .nominal_backing = true };
+};
 
-    /// Mark that recursion is allowed
-    /// ie the chain passes through a Box, List or Tag Union
-    fn allowRecursion(self: Context) Context {
-        return .{
-            .recursion_allowed = true,
-            .seen_nominal = self.seen_nominal,
-        };
-    }
-
-    /// Mark that we have seen a nominal type
-    fn markNominal(self: Context) Context {
-        return .{
-            .recursion_allowed = self.recursion_allowed,
-            .seen_nominal = true,
-        };
-    }
+/// A frame on the `seen` traversal stack: a resolved var plus the edge that
+/// pushed it onto the stack.
+const SeenEntry = struct {
+    var_: Var,
+    edge: Edge,
 };
 
 /// Struct to hold intermediate values used during occurs check
@@ -269,7 +286,7 @@ pub const Scratch = struct {
 
     gpa: std.mem.Allocator,
 
-    seen: Var.SafeList,
+    seen: MkSafeList(SeenEntry),
     err_chain: Var.SafeList,
     err_chain_nominal_vars: Var.SafeList,
     visited: MkSafeList(DescStoreIdx),
@@ -283,7 +300,7 @@ pub const Scratch = struct {
         // Future optimization: profile real codebases to tune these values.
         return .{
             .gpa = gpa,
-            .seen = try Var.SafeList.initCapacity(gpa, 32),
+            .seen = try MkSafeList(SeenEntry).initCapacity(gpa, 32),
             .err_chain = try Var.SafeList.initCapacity(gpa, 32),
             .err_chain_nominal_vars = try Var.SafeList.initCapacity(gpa, 8),
             .visited = try MkSafeList(DescStoreIdx).initCapacity(gpa, 64),
@@ -304,11 +321,13 @@ pub const Scratch = struct {
         self.visited.items.clearRetainingCapacity();
     }
 
-    fn hasSeenVar(self: *const Self, var_: Var) bool {
-        for (self.seen.items.items) |seen_var| {
-            if (seen_var == var_) return true;
+    /// Returns the index of `var_` on the seen stack if it's currently being
+    /// traversed (i.e. a cycle), else null. The index marks the cycle head.
+    fn hasSeenVar(self: *const Self, var_: Var) ?usize {
+        for (self.seen.items.items, 0..) |entry, i| {
+            if (entry.var_ == var_) return i;
         }
-        return false;
+        return null;
     }
 
     fn hasVisited(self: *const Self, desc_idx: DescStoreIdx) bool {
@@ -318,8 +337,8 @@ pub const Scratch = struct {
         return false;
     }
 
-    fn appendSeen(self: *Self, var_: Var) std.mem.Allocator.Error!void {
-        _ = try self.seen.append(self.gpa, var_);
+    fn pushSeen(self: *Self, var_: Var, edge: Edge) std.mem.Allocator.Error!void {
+        _ = try self.seen.append(self.gpa, .{ .var_ = var_, .edge = edge });
     }
 
     fn popSeen(self: *Self) void {
@@ -694,4 +713,111 @@ test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB 
     try std.testing.expectEqual(2, err_chain_nominal3.len);
     try std.testing.expectEqual(type_b_nominal, err_chain_nominal3[0]);
     try std.testing.expectEqual(type_a_nominal, err_chain_nominal3[1]);
+}
+
+test "occurs: anonymous recursion in a nominal's type argument is not recursive_nominal (regression)" {
+    // Wrapper(Inner) := {}   where   Inner = [ Cons(Inner), Nil ]
+    //
+    // The recursion cycle is `Inner -> Cons -> Inner`. It lives entirely inside
+    // the *type argument* of `Wrapper` and never passes through the nominal
+    // `Wrapper` itself, so this is anonymous recursion (which Roc rejects), NOT
+    // legal recursion-through-a-nominal.
+    const gpa = std.testing.allocator;
+    var types_store = try Store.init(gpa);
+    defer types_store.deinit();
+
+    var scratch = try Scratch.init(gpa);
+    defer scratch.deinit();
+
+    // Inner = [ Cons(Inner), Nil ]  -- an anonymous, self-recursive tag union
+    const inner = try types_store.fresh();
+    const ext = try types_store.fresh();
+    const cons_tag_args = try types_store.appendVars(&[_]Var{inner});
+    const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty() };
+    try types_store.setRootVarContent(inner, try types_store.mkTagUnion(&.{ cons_tag, nil_tag }, ext));
+
+    // Wrapper(Inner) := {}  -- nominal with `inner` as its only type argument
+    const wrapper_backing = try types_store.freshFromContent(.{ .structure = .empty_record });
+    const wrapper = try types_store.fresh();
+    try types_store.setVarContent(wrapper, try types_store.mkNominal(
+        undefined,
+        wrapper_backing,
+        &.{inner},
+        Ident.Idx{ .attributes = .{ .effectful = false, .ignored = false, .reassignable = false }, .idx = 0 },
+        false,
+    ));
+
+    const result = occurs(&types_store, &scratch, wrapper);
+    try std.testing.expectEqual(.recursive_anonymous, result);
+}
+
+test "occurs: anonymous recursion below a buried nominal is not recursive_nominal (regression)" {
+    // Root = ( N, )   where   N := Inner   and   Inner = [ Cons(Inner), Nil ]
+    //
+    // `Root` is a tuple, so no nominal edge is crossed at the root. The only
+    // nominal is `N`, buried one level down. The cycle is `Inner -> Cons ->
+    // Inner`, which does NOT pass through `N`. A buggy occurs check that lets the
+    // nominal marking from N's backing leak downward would wrongly classify this
+    // as recursive_nominal. Correct answer: recursive_anonymous.
+    const gpa = std.testing.allocator;
+    var types_store = try Store.init(gpa);
+    defer types_store.deinit();
+
+    var scratch = try Scratch.init(gpa);
+    defer scratch.deinit();
+
+    // Inner = [ Cons(Inner), Nil ]
+    const inner = try types_store.fresh();
+    const ext = try types_store.fresh();
+    const cons_tag_args = try types_store.appendVars(&[_]Var{inner});
+    const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty() };
+    try types_store.setRootVarContent(inner, try types_store.mkTagUnion(&.{ cons_tag, nil_tag }, ext));
+
+    // N := Inner  -- nominal whose backing is the anonymous recursive tag union
+    const n = try types_store.fresh();
+    try types_store.setVarContent(n, try types_store.mkNominal(
+        undefined,
+        inner,
+        &.{},
+        Ident.Idx{ .attributes = .{ .effectful = false, .ignored = false, .reassignable = false }, .idx = 0 },
+        false,
+    ));
+
+    // Root = ( N, )  -- a tuple so the root is NOT a nominal type
+    const elems_range = try types_store.appendVars(&[_]Var{n});
+    const root = try types_store.freshFromContent(.{ .structure = .{ .tuple = .{ .elems = elems_range } } });
+
+    const result = occurs(&types_store, &scratch, root);
+    try std.testing.expectEqual(.recursive_anonymous, result);
+}
+
+test "occurs: tuple self-cycle below a tag union stays infinite (regression)" {
+    // Outer = [ Wrap(Inner) ]   where   Inner = ( Inner, )
+    //
+    // The cycle is the tuple `Inner = (Inner,)`, which has no recursion-allowed
+    // constructor in it, so it is an infinite type. But `recursion_allowed`, set
+    // when descending into the outer tag union, leaks down into the tuple cycle
+    // and downgrades the result to recursive_anonymous. Correct answer: infinite.
+    const gpa = std.testing.allocator;
+    var types_store = try Store.init(gpa);
+    defer types_store.deinit();
+
+    var scratch = try Scratch.init(gpa);
+    defer scratch.deinit();
+
+    // Inner = ( Inner, )  -- a tuple that directly contains itself
+    const inner = try types_store.fresh();
+    const tuple_elems = try types_store.appendVars(&[_]Var{inner});
+    try types_store.setRootVarContent(inner, .{ .structure = .{ .tuple = .{ .elems = tuple_elems } } });
+
+    // Outer = [ Wrap(Inner) ]  -- a tag union wrapping the tuple
+    const ext = try types_store.fresh();
+    const wrap_args = try types_store.appendVars(&[_]Var{inner});
+    const wrap_tag = types.Tag{ .name = undefined, .args = wrap_args };
+    const outer = try types_store.freshFromContent(try types_store.mkTagUnion(&.{wrap_tag}, ext));
+
+    const result = occurs(&types_store, &scratch, outer);
+    try std.testing.expectEqual(.infinite, result);
 }

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -708,6 +708,30 @@ test "check type - tag - ext - typo" {
     );
 }
 
+test "check type - large open tag union annotation preserves all tags" {
+    // Regression guard for the tag-union arm of generateAnnoTypeInPlace, which
+    // builds the tag union from the scratch_tags buffer. Uses enough tags to
+    // grow scratch_tags past its initial capacity (64) so the buffer
+    // reallocates while building the annotation, ensuring tags are materialized
+    // into the types store rather than read from a stale scratch slice.
+    const lo = "abcdefghijklmnopqrstuvwxyz";
+    const source = comptime blk: {
+        var s: []const u8 = "foo : [";
+        var i: usize = 0;
+        while (i < 80) : (i += 1) {
+            s = s ++ "T" ++ &[_]u8{ lo[i / 26], lo[i % 26] };
+            if (i < 79) s = s ++ ", ";
+        }
+        s = s ++ ", ..ext]\nfoo = Taa";
+        break :blk s;
+    };
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+    // The first and last tags must both survive intact in the inferred type.
+    try test_env.assertLastDefTypeContains("Taa");
+    try test_env.assertLastDefTypeContains("Tdb");
+}
+
 // blocks //
 
 test "check type - block - return expr" {

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -1723,6 +1723,35 @@ test "check type - if else - different branch types 3" {
     try checkTypesModule(source, .fail, "TYPE MISMATCH");
 }
 
+test "check type - if else - annotated branch mismatch reports error" {
+    // Exercises the expected-return-type path in checkIfElseExpr (the
+    // isCompatibleWithExpected probe). The else branch (a number) does not
+    // match the annotated Str return type, which must be reported.
+    const source =
+        \\f : Bool -> Str
+        \\f = |b| if b "yes" else 42
+    ;
+    try checkTypesModule(source, .fail, "TYPE MISMATCH");
+}
+
+test "check type - match branch conflicting with rigid return type reports error" {
+    // Load-bearing case for isCompatibleWithExpected: the `Ok(_) => ""` branch
+    // body (Str) conflicts with the function's rigid annotated return type `e`.
+    // The caller's incompatible path (markErroneousBranchWithExpected) emits no
+    // diagnostic of its own, so the mismatch recorded by the
+    // isCompatibleWithExpected probe is the ONLY error reported. If that probe
+    // were switched to a throwaway problem store, this error would silently
+    // disappear.
+    const source =
+        \\get_err : [Ok(a), Err(e)] -> e
+        \\get_err = |result| match result {
+        \\    Ok(_) => ""
+        \\    Err(e) => e
+        \\}
+    ;
+    try checkTypesModule(source, .fail, "TYPE MISMATCH");
+}
+
 // match
 
 test "check type - match" {

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -1723,6 +1723,16 @@ test "check type - if else - different branch types 3" {
     try checkTypesModule(source, .fail, "TYPE MISMATCH");
 }
 
+test "check type - negative zero is valid for unsigned type" {
+    // `-0` carries the syntactic is_negative flag but has magnitude zero, which
+    // is a valid unsigned value and must not be rejected as a negative.
+    const source =
+        \\x : U8
+        \\x = -0
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "U8");
+}
+
 test "check type - tuple access on non-tuple does not cascade" {
     // Accessing `.0` on a record is a tuple access against a non-tuple
     // structure: a single mismatch. The result expression must be poisoned to

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -1723,6 +1723,25 @@ test "check type - if else - different branch types 3" {
     try checkTypesModule(source, .fail, "TYPE MISMATCH");
 }
 
+test "check type - tuple access on non-tuple does not cascade" {
+    // Accessing `.0` on a record is a tuple access against a non-tuple
+    // structure: a single mismatch. The result expression must be poisoned to
+    // `.err` so that conflicting downstream uses do not produce additional,
+    // cascading errors. Without poisoning, the result is a fresh flex var that
+    // unifies with the first use (Str) and then conflicts with the second
+    // (U64), yielding a spurious second TYPE MISMATCH.
+    const source =
+        \\r : { a : Str }
+        \\r = { a: "hello" }
+        \\x = r.0
+        \\y : Str
+        \\y = x
+        \\z : U64
+        \\z = x
+    ;
+    try checkTypesModule(source, .fail, "TYPE MISMATCH");
+}
+
 test "check type - if else - annotated branch mismatch reports error" {
     // Exercises the expected-return-type path in checkIfElseExpr (the
     // isCompatibleWithExpected probe). The else branch (a number) does not

--- a/test/snapshots/expr/module_dot_tuple.md
+++ b/test/snapshots/expr/module_dot_tuple.md
@@ -48,5 +48,5 @@ NO CHANGE
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "_a"))
+(expr (type "Error"))
 ~~~


### PR DESCRIPTION
## Summary

An audit of `src/check/Check.zig` surfaced several latent memory-safety bugs and a few correctness/robustness issues. This PR fixes them as small, independently-reviewable commits, each verified against the test suite. 

The dominant bug class is **holding a raw slice/pointer into a growable backing buffer (`Scratch`, `types.vars`, `static_dispatch_constraints`) across a call that can reallocate it.** The codebase is mostly disciplined about this (it uses `iterVars`/index-based re-fetch and documents the hazard); these were the spots that slipped through.


## Memory safety

- **Tag-union annotation UAF** — `generateAnnoTypeInPlace` held a `scratch_tags` slice across the recursive ext generation that can append to (and reallocate) `scratch_tags`. Now materializes tags into the type store first, mirroring the record case. *(Latent: the parser can't currently place a tag union in ext position, so unreachable today — fixed defensively.)*
- **`resolveNumericLiteralsFromContext` UAF** — two loops iterated `sliceVars(func.args)` while calling `unify`; switched to the realloc-safe `iterVars`.
- **`satisfyImplicitEqualityConstraint` UAF** — `args[1]` was read after `unify(dispatcher, args[0])` could reallocate; capture both before unifying.
- **Unboxed-function predicate stack overflow** — `varContainsUnboxedFunctionInternal`/`flatTypeContainsUnboxedFunction` recursed into nominal backing vars with no cycle guard, unlike their sibling predicates. Added a visited set. *(Latent: only reachable via the fixed-signature `echo!` hosted lambda today — fixed defensively.)*
- **Constraint-slice re-fetch** — the rigid and structural dispatch branches of `checkStaticDispatchConstraints` held a `static_dispatch_constraints` slice across `unify`/`satisfyImplicitEqualityConstraint`, which can append to that array; switched to the index-based re-fetch the nominal/alias branches already use.

## Correctness

- **Tuple access on a non-tuple structure** now poisons the result to `.err` (like the out-of-bounds branch) instead of a fresh flex var, preventing a cascading second TYPE MISMATCH at downstream use sites. Includes a regression test.
- **`checkExprReplWithDefs`** now runs the infinite-type and flex-constraint-compatibility checks on the result expression, matching `checkExprRepl`.
- **`isCompatibleWithExpected`** — its diagnostic recording turned out to be load-bearing (some branch mismatches rely on it as their only error); corrected the misleading "non-destructive" doc and added an inline note plus two regression tests (an annotated if/else branch mismatch, and a match branch whose body conflicts with a rigid annotated return type) rather than changing behavior.
- **Fixed nested anonymous recursion**: If a nominal type contained within in anonymous recursion that was completely contained in within but did not pass through the nominal, the `occurs.zig` check would not report it. This was incorrect.

## Testing

`zig build test` — all tests pass. New regression tests cover the tuple-access cascade, the `-0` unsigned case, the annotated if/else and match branch-mismatch paths, and a large open tag-union annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)