### PR TITLE
Precompute layout contains-refcounted bit so the query is O(1) and infallible

### DIFF
--- a/src/interpreter_layout/layout.zig
+++ b/src/interpreter_layout/layout.zig
@@ -220,6 +220,11 @@ pub const StructData = struct {
     size: u32,
     /// Range of fields in the struct_fields list
     fields: collections.NonEmptyRange,
+    /// Whether this struct transitively contains refcounted data. Precomputed
+    /// when the struct is committed so `Store.layoutContainsRefcounted` is an
+    /// O(1), infallible lookup. Defaults to `false` for the few literals that
+    /// don't set it (e.g. empty structs, which never contain refcounted data).
+    contains_refcounted: bool = false,
 
     pub fn getFields(self: StructData) StructField.SafeMultiList.Range {
         // Handle empty structs specially - NonEmptyRange.toRange() asserts count > 0
@@ -265,6 +270,9 @@ pub const TagUnionData = struct {
     discriminant_size: u8,
     /// Range of variants in the tag_union_variants list
     variants: collections.NonEmptyRange,
+    /// Whether this tag union transitively contains refcounted data. Precomputed
+    /// at commit time so `Store.layoutContainsRefcounted` is an O(1) lookup.
+    contains_refcounted: bool = false,
 
     pub fn getVariants(self: TagUnionData) TagUnionVariant.SafeMultiList.Range {
         return self.variants.toRange(TagUnionVariant.SafeMultiList.Idx);

--- a/src/interpreter_layout/store.zig
+++ b/src/interpreter_layout/store.zig
@@ -83,7 +83,6 @@ const StructInfo = layout_mod.StructInfo;
 const TagUnionInfo = layout_mod.TagUnionInfo;
 const ScalarInfo = layout_mod.ScalarInfo;
 const Work = work.Work;
-const RefcountedVisitState = enum(u2) { active, no, yes };
 
 /// Errors that can occur during layout computation
 /// Stores Layout instances by Idx.
@@ -468,6 +467,7 @@ pub const Store = struct {
             .fields = fields_range,
         });
         assertAppendIdx(expected_idx, struct_data_idx);
+        self.struct_data.get(struct_data_idx).contains_refcounted = self.structContainsRefcounted(struct_idx);
 
         return try self.insertLayout(Layout.struct_(std.mem.Alignment.fromByteUnits(max_alignment), struct_idx));
     }
@@ -536,6 +536,7 @@ pub const Store = struct {
         const expected_struct_idx = self.struct_data.items.items.len;
         const struct_data_idx = try self.struct_data.append(self.allocator, StructData{ .size = total_size, .fields = fields_range });
         assertAppendIdx(expected_struct_idx, struct_data_idx);
+        self.struct_data.get(struct_data_idx).contains_refcounted = self.structContainsRefcounted(struct_idx);
         return try self.insertLayout(Layout.struct_(std.mem.Alignment.fromByteUnits(max_alignment), struct_idx));
     }
 
@@ -591,6 +592,7 @@ pub const Store = struct {
             },
         });
         assertAppendIdx(expected_tag_union_idx, tag_union_data_list_idx);
+        self.tag_union_data.get(tag_union_data_list_idx).contains_refcounted = self.tagUnionContainsRefcounted(.{ .int_idx = @intCast(tag_union_data_idx) });
 
         const tu_layout = Layout.tagUnion(tag_union_alignment, .{ .int_idx = @intCast(tag_union_data_idx) });
         return try self.insertLayout(tu_layout);
@@ -628,6 +630,7 @@ pub const Store = struct {
         const expected_struct_idx = self.struct_data.items.items.len;
         const struct_data_idx = try self.struct_data.append(self.allocator, StructData{ .size = total_size, .fields = fields_range });
         assertAppendIdx(expected_struct_idx, struct_data_idx);
+        self.struct_data.get(struct_data_idx).contains_refcounted = self.structContainsRefcounted(struct_idx);
         const capture_layout = Layout.struct_(std.mem.Alignment.fromByteUnits(max_alignment), struct_idx);
         return try self.insertLayout(capture_layout);
     }
@@ -668,6 +671,7 @@ pub const Store = struct {
         const expected_struct_idx = self.struct_data.items.items.len;
         const struct_data_idx = try self.struct_data.append(self.allocator, StructData{ .size = total_size, .fields = fields_range });
         assertAppendIdx(expected_struct_idx, struct_data_idx);
+        self.struct_data.get(struct_data_idx).contains_refcounted = self.structContainsRefcounted(struct_idx);
         const union_layout = Layout.struct_(std.mem.Alignment.fromByteUnits(max_alignment), struct_idx);
         return try self.insertLayout(union_layout);
     }
@@ -837,6 +841,7 @@ pub const Store = struct {
             },
         });
         assertAppendIdx(expected_tag_union_idx, tag_union_data_list_idx);
+        self.tag_union_data.get(tag_union_data_list_idx).contains_refcounted = self.tagUnionContainsRefcounted(.{ .int_idx = @intCast(tag_union_data_idx) });
 
         return Layout.tagUnion(tag_union_alignment, .{ .int_idx = @intCast(tag_union_data_idx) });
     }
@@ -1157,69 +1162,45 @@ pub const Store = struct {
     /// This is more comprehensive than Layout.isRefcounted() which only checks if
     /// the layout itself is heap-allocated. This function also returns true for
     /// tuples/records that contain strings, lists, or boxes.
+    ///
+    /// For struct/tag-union layouts the answer is read from a bit precomputed when
+    /// the layout was committed (`StructData.contains_refcounted`), so this is O(1)
+    /// and never allocates. Recursive nominals are materialized as box layouts
+    /// (placeholders are boxes too), which short-circuit to `true` here, so the
+    /// committed struct/tag graph is acyclic and a layout's bit only ever depends
+    /// on already-committed child bits.
     pub fn layoutContainsRefcounted(self: *const Self, l: Layout) bool {
-        var visit_states = std.AutoHashMap(u32, RefcountedVisitState).init(self.allocator);
-        defer visit_states.deinit();
-
-        return self.layoutContainsRefcountedInner(l, &visit_states) catch
-            @panic("layoutContainsRefcounted ran out of memory");
+        return switch (l.tag) {
+            .scalar => l.getScalar().tag == .str,
+            .list, .list_of_zst => true,
+            .box, .box_of_zst => true,
+            .zst => false,
+            .struct_ => self.getStructData(l.getStruct().idx).contains_refcounted,
+            .tag_union => self.getTagUnionData(l.getTagUnion().idx).contains_refcounted,
+            .closure => self.layoutContainsRefcounted(self.getLayout(l.getClosure().captures_layout_idx)),
+        };
     }
 
-    fn layoutContainsRefcountedInner(
-        self: *const Self,
-        l: Layout,
-        visit_states: *std.AutoHashMap(u32, RefcountedVisitState),
-    ) std.mem.Allocator.Error!bool {
-        const key: u32 = @bitCast(l);
-        if (visit_states.get(key)) |state| {
-            return switch (state) {
-                .active, .yes => true,
-                .no => false,
-            };
+    /// Compute a just-committed struct's `contains_refcounted` from its (already
+    /// committed) field layouts. Used to populate `StructData.contains_refcounted`.
+    fn structContainsRefcounted(self: *const Self, struct_idx: StructIdx) bool {
+        const sd = self.getStructData(struct_idx);
+        const fields = self.struct_fields.sliceRange(sd.getFields());
+        for (0..fields.len) |i| {
+            if (self.layoutContainsRefcounted(self.getLayout(fields.get(i).layout))) return true;
         }
+        return false;
+    }
 
-        switch (l.tag) {
-            .scalar => return l.getScalar().tag == .str,
-            .list, .list_of_zst => return true,
-            .box, .box_of_zst => return true,
-            .zst => return false,
-            .struct_, .tag_union, .closure => {},
+    /// Compute a just-committed tag union's `contains_refcounted` from its (already
+    /// committed) variant payload layouts.
+    fn tagUnionContainsRefcounted(self: *const Self, tag_union_idx: TagUnionIdx) bool {
+        const tu_data = self.getTagUnionData(tag_union_idx);
+        const variants = self.getTagUnionVariants(tu_data);
+        for (0..variants.len) |i| {
+            if (self.layoutContainsRefcounted(self.getLayout(variants.get(i).payload_layout))) return true;
         }
-
-        try visit_states.put(key, .active);
-
-        const contains_refcounted = switch (l.tag) {
-            .struct_ => blk: {
-                const sd = self.getStructData(l.getStruct().idx);
-                const fields = self.struct_fields.sliceRange(sd.getFields());
-                for (0..fields.len) |i| {
-                    const field_layout = self.getLayout(fields.get(i).layout);
-                    if (try self.layoutContainsRefcountedInner(field_layout, visit_states)) {
-                        break :blk true;
-                    }
-                }
-                break :blk false;
-            },
-            .tag_union => blk: {
-                const tu_data = self.getTagUnionData(l.getTagUnion().idx);
-                const variants = self.getTagUnionVariants(tu_data);
-                for (0..variants.len) |i| {
-                    const variant_layout = self.getLayout(variants.get(i).payload_layout);
-                    if (try self.layoutContainsRefcountedInner(variant_layout, visit_states)) {
-                        break :blk true;
-                    }
-                }
-                break :blk false;
-            },
-            .closure => blk: {
-                const captures_layout = self.getLayout(l.getClosure().captures_layout_idx);
-                break :blk try self.layoutContainsRefcountedInner(captures_layout, visit_states);
-            },
-            .scalar, .list, .list_of_zst, .box, .box_of_zst, .zst => unreachable,
-        };
-
-        try visit_states.put(key, if (contains_refcounted) .yes else .no);
-        return contains_refcounted;
+        return false;
     }
 
     /// Add the tag union's tags to self.pending_tags,
@@ -1449,6 +1430,7 @@ pub const Store = struct {
             .fields = fields_range,
         });
         assertAppendIdx(expected_struct_idx, struct_data_idx);
+        self.struct_data.get(struct_data_idx).contains_refcounted = self.structContainsRefcounted(struct_idx);
 
         self.work.resolved_record_fields.shrinkRetainingCapacity(updated_record.resolved_fields_start);
 
@@ -1532,6 +1514,7 @@ pub const Store = struct {
             .fields = fields_range,
         });
         assertAppendIdx(expected_struct_idx, struct_data_idx);
+        self.struct_data.get(struct_data_idx).contains_refcounted = self.structContainsRefcounted(struct_idx);
 
         self.work.resolved_tuple_fields.shrinkRetainingCapacity(updated_tuple.resolved_fields_start);
 
@@ -1621,6 +1604,7 @@ pub const Store = struct {
             },
         });
         assertAppendIdx(expected_tag_union_idx, tag_union_data_list_idx);
+        self.tag_union_data.get(tag_union_data_list_idx).contains_refcounted = self.tagUnionContainsRefcounted(.{ .int_idx = @intCast(tag_union_data_idx) });
 
         // Clear resolved variants for this tag union
         self.work.resolved_tag_union_variants.shrinkRetainingCapacity(pending.resolved_variants_start);

--- a/src/layout/layout.zig
+++ b/src/layout/layout.zig
@@ -210,6 +210,10 @@ pub const StructData = struct {
     size: u32,
     /// Range of fields in the struct_fields list
     fields: collections.NonEmptyRange,
+    /// Whether this struct transitively contains refcounted data. Precomputed
+    /// when the struct is committed (its field layouts are already committed by
+    /// then) so `Store.layoutContainsRefcounted` is an O(1), infallible lookup.
+    contains_refcounted: bool = false,
 
     pub fn getFields(self: StructData) StructField.SafeMultiList.Range {
         // Handle empty structs specially - NonEmptyRange.toRange() asserts count > 0
@@ -257,6 +261,9 @@ pub const TagUnionData = struct {
     discriminant_size: u8,
     /// Range of variants in the tag_union_variants list
     variants: collections.NonEmptyRange,
+    /// Whether this tag union transitively contains refcounted data. Precomputed
+    /// at commit time so `Store.layoutContainsRefcounted` is an O(1) lookup.
+    contains_refcounted: bool = false,
 
     pub fn getVariants(self: TagUnionData) TagUnionVariant.SafeMultiList.Range {
         return self.variants.toRange(TagUnionVariant.SafeMultiList.Idx);

--- a/src/layout/store.zig
+++ b/src/layout/store.zig
@@ -32,7 +32,6 @@ const ScalarInfo = layout_mod.ScalarInfo;
 const LayoutGraph = graph_mod.Graph;
 const GraphNodeId = graph_mod.NodeId;
 const GraphRef = graph_mod.Ref;
-const RefcountedVisitState = enum(u2) { active, no, yes };
 const Var = types.Var;
 const TypeScope = types.TypeScope;
 pub const ModuleVarKey = work_mod.ModuleVarKey;
@@ -136,6 +135,9 @@ pub const Store = struct {
                     .start = 0,
                     .count = 2,
                 },
+                // Both variants are zero-sized (no payload), so this builtin
+                // two-nullary enum contains no refcounted data.
+                .contains_refcounted = false,
             });
             assertAppendIdx(expected_idx, idx);
         }
@@ -420,6 +422,7 @@ pub const Store = struct {
             assertAppendIdx(expected_idx, idx);
         }
 
+        const contains_refcounted = self.computeStructContainsRefcounted(fields);
         const struct_idx = StructIdx{ .int_idx = @intCast(self.struct_data.len()) };
         const expected_idx = self.struct_data.items.items.len;
         const struct_data_idx = try self.struct_data.append(self.allocator, .{
@@ -428,6 +431,7 @@ pub const Store = struct {
                 .start = @intCast(fields_start),
                 .count = @intCast(fields.len),
             },
+            .contains_refcounted = contains_refcounted,
         });
         assertAppendIdx(expected_idx, struct_data_idx);
 
@@ -462,6 +466,7 @@ pub const Store = struct {
             assertAppendIdx(expected_idx, idx);
         }
 
+        const contains_refcounted = self.computeTagUnionContainsRefcounted(variant_layouts);
         const tag_union_data_idx: u32 = @intCast(self.tag_union_data.len());
         {
             const expected_idx = self.tag_union_data.items.items.len;
@@ -473,6 +478,7 @@ pub const Store = struct {
                     .start = variants_start,
                     .count = @intCast(variant_layouts.len),
                 },
+                .contains_refcounted = contains_refcounted,
             });
             assertAppendIdx(expected_idx, idx);
         }
@@ -676,6 +682,7 @@ pub const Store = struct {
             assertAppendIdx(expected_idx, idx);
         }
 
+        const contains_refcounted = self.computeStructContainsRefcounted(temp_fields.items);
         const struct_idx = StructIdx{ .int_idx = @intCast(self.struct_data.len()) };
         const expected_idx = self.struct_data.items.items.len;
         const struct_data_idx = try self.struct_data.append(self.allocator, .{
@@ -684,6 +691,7 @@ pub const Store = struct {
                 .start = @intCast(fields_start),
                 .count = @intCast(temp_fields.items.len),
             },
+            .contains_refcounted = contains_refcounted,
         });
         assertAppendIdx(expected_idx, struct_data_idx);
 
@@ -728,6 +736,7 @@ pub const Store = struct {
             assertAppendIdx(expected_idx, idx);
         }
 
+        const contains_refcounted = self.computeTagUnionContainsRefcounted(variant_layouts);
         const tag_union_data_idx: u32 = @intCast(self.tag_union_data.len());
         {
             const expected_idx = self.tag_union_data.items.items.len;
@@ -739,6 +748,7 @@ pub const Store = struct {
                     .start = variants_start,
                     .count = @intCast(variant_layouts.len),
                 },
+                .contains_refcounted = contains_refcounted,
             });
             assertAppendIdx(expected_idx, idx);
         }
@@ -1896,12 +1906,39 @@ pub const Store = struct {
     /// This is more comprehensive than Layout.isRefcounted() which only checks if
     /// the layout itself is heap-allocated. This function also returns true for
     /// tuples/records that contain strings, lists, or boxes.
+    ///
+    /// For struct/tag-union layouts the answer is read from a bit precomputed when
+    /// the layout was committed (`StructData.contains_refcounted`), so this is O(1)
+    /// and never allocates. Closures defer to their captures layout (a bounded
+    /// chain). Recursion is not a concern: recursive back-edges are materialized as
+    /// box layouts, which short-circuit to `true` here.
     pub fn layoutContainsRefcounted(self: *const Self, l: Layout) bool {
-        var visit_states = std.AutoHashMap(u32, RefcountedVisitState).init(self.allocator);
-        defer visit_states.deinit();
+        return switch (l.tag) {
+            .scalar => l.getScalar().tag == .str,
+            .list, .list_of_zst, .box, .box_of_zst, .erased_callable => true,
+            .zst => false,
+            .struct_ => self.getStructData(l.getStruct().idx).contains_refcounted,
+            .tag_union => self.getTagUnionData(l.getTagUnion().idx).contains_refcounted,
+            .closure => self.layoutContainsRefcounted(self.getLayout(l.getClosure().captures_layout_idx)),
+        };
+    }
 
-        return self.layoutContainsRefcountedInner(l, &visit_states) catch
-            @panic("layoutContainsRefcounted ran out of memory");
+    /// Compute whether a struct contains refcounted data from its already-committed
+    /// field layouts. Used to populate `StructData.contains_refcounted` at commit time.
+    fn computeStructContainsRefcounted(self: *const Self, fields: []const StructField) bool {
+        for (fields) |field| {
+            if (self.layoutContainsRefcounted(self.getLayout(field.layout))) return true;
+        }
+        return false;
+    }
+
+    /// Compute whether a tag union contains refcounted data from its already-committed
+    /// variant payload layouts. Used to populate `TagUnionData.contains_refcounted`.
+    fn computeTagUnionContainsRefcounted(self: *const Self, variant_layouts: []const Idx) bool {
+        for (variant_layouts) |variant_layout_idx| {
+            if (self.layoutContainsRefcounted(self.getLayout(variant_layout_idx))) return true;
+        }
+        return false;
     }
 
     pub fn rcHelperPlan(self: *const Self, helper_key: @import("./rc_helper.zig").HelperKey) @import("./rc_helper.zig").Plan {
@@ -1934,66 +1971,6 @@ pub const Store = struct {
 
     pub fn rcHelperTagUnionVariantPlan(self: *const Self, tag_plan: @import("./rc_helper.zig").TagUnionPlan, variant_index: u32) ?@import("./rc_helper.zig").HelperKey {
         return rc_helper.Resolver.init(self).tagUnionVariantPlan(tag_plan, variant_index);
-    }
-
-    fn layoutContainsRefcountedInner(
-        self: *const Self,
-        l: Layout,
-        visit_states: *std.AutoHashMap(u32, RefcountedVisitState),
-    ) std.mem.Allocator.Error!bool {
-        const key: u32 = @bitCast(l);
-        if (visit_states.get(key)) |state| {
-            return switch (state) {
-                // Recursive layout back-edges are materialized through placeholder
-                // indirections, so re-entering an active node implies refcounted data.
-                .active, .yes => true,
-                .no => false,
-            };
-        }
-
-        switch (l.tag) {
-            .scalar => return l.getScalar().tag == .str,
-            .list, .list_of_zst => return true,
-            .box, .box_of_zst => return true,
-            .erased_callable => return true,
-            .zst => return false,
-            .struct_, .tag_union, .closure => {},
-        }
-
-        try visit_states.put(key, .active);
-
-        const contains_refcounted = switch (l.tag) {
-            .struct_ => blk: {
-                const sd = self.getStructData(l.getStruct().idx);
-                const fields = self.struct_fields.sliceRange(sd.getFields());
-                for (0..fields.len) |i| {
-                    const field_layout = self.getLayout(fields.get(i).layout);
-                    if (try self.layoutContainsRefcountedInner(field_layout, visit_states)) {
-                        break :blk true;
-                    }
-                }
-                break :blk false;
-            },
-            .tag_union => blk: {
-                const tu_data = self.getTagUnionData(l.getTagUnion().idx);
-                const variants = self.getTagUnionVariants(tu_data);
-                for (0..variants.len) |i| {
-                    const variant_layout = self.getLayout(variants.get(i).payload_layout);
-                    if (try self.layoutContainsRefcountedInner(variant_layout, visit_states)) {
-                        break :blk true;
-                    }
-                }
-                break :blk false;
-            },
-            .closure => blk: {
-                const captures_layout = self.getLayout(l.getClosure().captures_layout_idx);
-                break :blk try self.layoutContainsRefcountedInner(captures_layout, visit_states);
-            },
-            .scalar, .list, .list_of_zst, .box, .box_of_zst, .erased_callable, .zst => unreachable,
-        };
-
-        try visit_states.put(key, if (contains_refcounted) .yes else .no);
-        return contains_refcounted;
     }
 
     fn tagUnionDiscriminantSize(variant_count: usize) u8 {


### PR DESCRIPTION
`Store.layoutContainsRefcounted` is called per-op during refcount insertion and codegen, and each call re-walked the struct / tag-union / closure layout graph, allocating an `AutoHashMap` to detect cycles and `@panic`-ing if that allocation failed. The answer for a given layout never changes, so this computes it once when the layout is committed and stores it on `StructData` / `TagUnionData`; the query then reduces to a tag switch plus a field read — no allocation, no panic, and O(1) instead of O(n).

The precompute is safe because by the time a struct or tag union is committed, every field/variant layout it references is already committed: containers are only built once their non-box children are ready, and recursive nominals are materialized as box layouts (boxes, including the placeholder boxes used while a recursive type is still resolving, short-circuit to "refcounted" without recursing). So computing a layout's bit only ever reads already-known child bits, and the committed struct/tag graph is acyclic.

This applies to both layout stores: the main store (`src/layout`, used by the dev/LLVM/wasm backends and the LIR refcount pass) and the separate interpreter store (`src/interpreter_layout`). They each have their own `StructData`/`TagUnionData`, so the bit is added to both; it carries a `false` default so the few literals that don't set it (empty structs, which never contain refcounted data) are correct. In the main store the new `StructData.contains_refcounted` is serialized automatically with the rest of the layout store in the LIR image.

Both old walks and their visit-state enums are removed. Validated by the full test suite (the eval/interpreter tests exercise refcounting on recursive nominals, records, tag unions, lists, and boxes — a wrong bit would surface as a crash or leak): 1265 + 80 tests pass, 0 failed/crashed/leaked, plus tidy and check-fmt clean.

Draft pending review of the commit-ordering argument above.