### PR TITLE
Stop swallowing out-of-memory errors across src/

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -12118,22 +12118,18 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 self.current_stmt_id = saved_current_stmt_id;
                 self.proc_debug_msg_slot = saved_proc_debug_msg_slot;
                 self.proc_debug_args_slot = saved_proc_debug_args_slot;
-                self.local_locations.deinit();
-                self.local_locations = saved_local_locations.clone() catch unreachable;
-                self.join_points.deinit();
-                self.join_points = saved_join_points.clone() catch unreachable;
-                self.stmt_locations.deinit();
-                self.stmt_locations = saved_stmt_locations.clone() catch unreachable;
-                self.deinitJoinPointJumpsMap(&self.join_point_jumps);
-                self.join_point_jumps = self.cloneJoinPointJumpsMap(&saved_join_point_jumps) catch unreachable;
-                self.join_point_params.deinit();
-                self.join_point_params = saved_join_point_params.clone() catch unreachable;
-                self.loop_continue_targets.deinit(self.allocator);
-                self.loop_continue_targets = saved_loop_continue_targets.clone(self.allocator) catch unreachable;
-                self.loop_break_patch_starts.deinit(self.allocator);
-                self.loop_break_patch_starts = saved_loop_break_patch_starts.clone(self.allocator) catch unreachable;
-                self.loop_break_patches.deinit(self.allocator);
-                self.loop_break_patches = saved_loop_break_patches.clone(self.allocator) catch unreachable;
+                // Restore the saved maps by swapping them back into place. This
+                // cannot allocate (so it is safe in an errdefer that cannot
+                // propagate errors): the mutated maps end up in the saved_*
+                // locals, which their own defers deinit.
+                std.mem.swap(@TypeOf(self.local_locations), &self.local_locations, &saved_local_locations);
+                std.mem.swap(@TypeOf(self.join_points), &self.join_points, &saved_join_points);
+                std.mem.swap(@TypeOf(self.stmt_locations), &self.stmt_locations, &saved_stmt_locations);
+                std.mem.swap(@TypeOf(self.join_point_jumps), &self.join_point_jumps, &saved_join_point_jumps);
+                std.mem.swap(@TypeOf(self.join_point_params), &self.join_point_params, &saved_join_point_params);
+                std.mem.swap(@TypeOf(self.loop_continue_targets), &self.loop_continue_targets, &saved_loop_continue_targets);
+                std.mem.swap(@TypeOf(self.loop_break_patch_starts), &self.loop_break_patch_starts, &saved_loop_break_patch_starts);
+                std.mem.swap(@TypeOf(self.loop_break_patches), &self.loop_break_patches, &saved_loop_break_patches);
                 self.early_return_ret_layout = saved_early_return_ret_layout;
                 self.early_return_patches.shrinkRetainingCapacity(saved_early_return_patches_len);
             }

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -363,7 +363,7 @@ pub const MonoLlvmCodeGen = struct {
             const body = proc.body orelse return error.CompilationFailed;
             try self.compileStmt(body);
             if (!self.currentBlockHasTerminator()) {
-                _ = wip.retVoid() catch return error.CompilationFailed;
+                _ = wip.retVoid() catch return error.OutOfMemory;
             }
         }
 
@@ -407,7 +407,7 @@ pub const MonoLlvmCodeGen = struct {
         const args_buf = try self.allocArgBuffer(arg_layouts, true);
         try self.copyEntrypointArgsToInternalBuffer(args_ptr, args_buf, arg_layouts);
         _ = try self.callFunctionIndex(proc_fn, &.{ roc_ops, ret_ptr, args_buf });
-        _ = wip.retVoid() catch return error.CompilationFailed;
+        _ = wip.retVoid() catch return error.OutOfMemory;
         try self.finishCurrentWipFunction();
     }
 
@@ -462,7 +462,7 @@ pub const MonoLlvmCodeGen = struct {
             builder.print(&ir_text.writer) catch return error.CompilationFailed;
             CoreCtx.writeFileCwd(std.Options.debug_io, keep_path, ir_text.written()) catch return error.CompilationFailed;
         } else |_| {}
-        return builder.toBitcode(self.allocator, producer) catch return error.CompilationFailed;
+        return builder.toBitcode(self.allocator, producer) catch return error.OutOfMemory;
     }
 
     fn procArgLayouts(self: *MonoLlvmCodeGen, proc: LirProcSpec, exclude_erased_capture: bool) Error![]layout.Idx {
@@ -481,7 +481,7 @@ pub const MonoLlvmCodeGen = struct {
         for (self.store.locals.items, self.local_slots) |local, *local_slot| {
             const sa = self.sizeAlignOf(local.layout_idx);
             const len = builder.intValue(.i32, @max(sa.size, 1)) catch return error.OutOfMemory;
-            const ptr = wip.alloca(.normal, .i8, len, self.llvmAlignment(sa.alignment), .default, "local") catch return error.CompilationFailed;
+            const ptr = wip.alloca(.normal, .i8, len, self.llvmAlignment(sa.alignment), .default, "local") catch return error.OutOfMemory;
             local_slot.* = .{
                 .ptr = ptr,
                 .layout_idx = local.layout_idx,
@@ -524,7 +524,7 @@ pub const MonoLlvmCodeGen = struct {
         const ret_ptr = self.ret_ptr_arg orelse return error.CompilationFailed;
         try self.callHostedFunction(hosted.dispatch_index, ret_ptr, args_buf);
         const wip = self.wip orelse return error.CompilationFailed;
-        _ = wip.retVoid() catch return error.CompilationFailed;
+        _ = wip.retVoid() catch return error.OutOfMemory;
     }
 
     fn compileStmt(self: *MonoLlvmCodeGen, stmt_id: CFStmtId) Error!void {
@@ -711,7 +711,7 @@ pub const MonoLlvmCodeGen = struct {
         else
             self.slot(target).ptr;
         const fn_ty = builder.fnType(.void, &.{ ptr_ty, ptr_ty, ptr_ty, ptr_ty }, .normal) catch return error.OutOfMemory;
-        _ = wip.call(.normal, .ccc, .none, fn_ty, fn_ptr, &.{ self.rocOps(), ret_ptr, args_buf, capture_ptr }, "") catch return error.CompilationFailed;
+        _ = wip.call(.normal, .ccc, .none, fn_ty, fn_ptr, &.{ self.rocOps(), ret_ptr, args_buf, capture_ptr }, "") catch return error.OutOfMemory;
     }
 
     fn emitPackedErasedFn(
@@ -865,7 +865,7 @@ pub const MonoLlvmCodeGen = struct {
         switch (op) {
             .bool_not => {
                 const value = try self.loadBool(self.slot(arg_locals[0]).ptr);
-                const not_value = (self.wip orelse return error.CompilationFailed).not(value, "") catch return error.CompilationFailed;
+                const not_value = (self.wip orelse return error.CompilationFailed).not(value, "") catch return error.OutOfMemory;
                 try self.storeBool(self.slot(target).ptr, not_value);
             },
             .num_is_eq => try self.storeBool(self.slot(target).ptr, try self.emitValueEqual(self.slot(arg_locals[0]).ptr, self.slot(arg_locals[1]).ptr, self.localLayout(arg_locals[0]))),
@@ -949,7 +949,7 @@ pub const MonoLlvmCodeGen = struct {
                 .num_is_lte => .ole,
                 else => unreachable,
             };
-            break :blk wip.fcmp(.normal, cmp_cond, lhs, rhs, "") catch return error.CompilationFailed;
+            break :blk wip.fcmp(.normal, cmp_cond, lhs, rhs, "") catch return error.OutOfMemory;
         } else blk: {
             const signed = layout_idx.isSigned();
             const cmp_cond: LlvmBuilder.IntegerCondition = switch (op) {
@@ -959,7 +959,7 @@ pub const MonoLlvmCodeGen = struct {
                 .num_is_lte => if (signed) .sle else .ule,
                 else => unreachable,
             };
-            break :blk wip.icmp(cmp_cond, lhs, rhs, "") catch return error.CompilationFailed;
+            break :blk wip.icmp(cmp_cond, lhs, rhs, "") catch return error.OutOfMemory;
         };
         try self.storeBool(self.slot(target).ptr, cond);
     }
@@ -987,7 +987,7 @@ pub const MonoLlvmCodeGen = struct {
                 .num_rem_by, .num_mod_by => .frem,
                 else => return error.UnsupportedLowLevel,
             };
-            break :blk wip.bin(tag, lhs, rhs, "") catch return error.CompilationFailed;
+            break :blk wip.bin(tag, lhs, rhs, "") catch return error.OutOfMemory;
         } else blk: {
             if (op == .num_shift_left_by or op == .num_shift_right_by or op == .num_shift_right_zf_by) {
                 const result = try self.emitIntegerShift(op, lhs, rhs, target_layout);
@@ -1007,17 +1007,17 @@ pub const MonoLlvmCodeGen = struct {
                 .num_bitwise_xor => .xor,
                 else => return error.UnsupportedLowLevel,
             };
-            const raw = wip.bin(tag, lhs, rhs, "") catch return error.CompilationFailed;
+            const raw = wip.bin(tag, lhs, rhs, "") catch return error.OutOfMemory;
             if (op != .num_mod_by or !signed) break :blk raw;
 
             const zero = builder.zeroInitValue(result_ty) catch return error.OutOfMemory;
-            const rem_is_zero = wip.icmp(.eq, raw, zero, "") catch return error.CompilationFailed;
-            const rem_negative = wip.icmp(.slt, raw, zero, "") catch return error.CompilationFailed;
-            const rhs_negative = wip.icmp(.slt, rhs, zero, "") catch return error.CompilationFailed;
-            const sign_differs = wip.bin(.xor, rem_negative, rhs_negative, "") catch return error.CompilationFailed;
-            const adjusted = wip.bin(.add, raw, rhs, "") catch return error.CompilationFailed;
-            const adjusted_or_raw = wip.select(.normal, sign_differs, adjusted, raw, "") catch return error.CompilationFailed;
-            break :blk wip.select(.normal, rem_is_zero, zero, adjusted_or_raw, "") catch return error.CompilationFailed;
+            const rem_is_zero = wip.icmp(.eq, raw, zero, "") catch return error.OutOfMemory;
+            const rem_negative = wip.icmp(.slt, raw, zero, "") catch return error.OutOfMemory;
+            const rhs_negative = wip.icmp(.slt, rhs, zero, "") catch return error.OutOfMemory;
+            const sign_differs = wip.bin(.xor, rem_negative, rhs_negative, "") catch return error.OutOfMemory;
+            const adjusted = wip.bin(.add, raw, rhs, "") catch return error.OutOfMemory;
+            const adjusted_or_raw = wip.select(.normal, sign_differs, adjusted, raw, "") catch return error.OutOfMemory;
+            break :blk wip.select(.normal, rem_is_zero, zero, adjusted_or_raw, "") catch return error.OutOfMemory;
         };
         try self.storeScalar(self.slot(target).ptr, target_layout, result);
     }
@@ -1028,19 +1028,19 @@ pub const MonoLlvmCodeGen = struct {
         const result_ty = self.scalarType(target_layout);
         const shift_bits = builder.intValue(.i8, self.intBits(target_layout)) catch return error.OutOfMemory;
         const rhs_u8 = try self.coerceScalar(rhs, .i8, false);
-        const too_large = wip.icmp(.uge, rhs_u8, shift_bits, "") catch return error.CompilationFailed;
+        const too_large = wip.icmp(.uge, rhs_u8, shift_bits, "") catch return error.OutOfMemory;
         const zero_amount = builder.zeroInitValue(result_ty) catch return error.OutOfMemory;
         const amount = try self.coerceScalar(rhs_u8, result_ty, false);
-        const safe_amount = wip.select(.normal, too_large, zero_amount, amount, "") catch return error.CompilationFailed;
+        const safe_amount = wip.select(.normal, too_large, zero_amount, amount, "") catch return error.OutOfMemory;
         const tag: LlvmBuilder.Function.Instruction.Tag = switch (op) {
             .num_shift_left_by => .shl,
             .num_shift_right_by => if (target_layout.isSigned()) .ashr else .lshr,
             .num_shift_right_zf_by => .lshr,
             else => unreachable,
         };
-        const shifted = wip.bin(tag, lhs, safe_amount, "") catch return error.CompilationFailed;
+        const shifted = wip.bin(tag, lhs, safe_amount, "") catch return error.OutOfMemory;
         const zero_result = builder.zeroInitValue(result_ty) catch return error.OutOfMemory;
-        return wip.select(.normal, too_large, zero_result, shifted, "") catch return error.CompilationFailed;
+        return wip.select(.normal, too_large, zero_result, shifted, "") catch return error.OutOfMemory;
     }
 
     fn emitDecBinary(self: *MonoLlvmCodeGen, target: LocalId, op: lir.LowLevel, args: []const LocalId) Error!void {
@@ -1049,25 +1049,25 @@ pub const MonoLlvmCodeGen = struct {
         const lhs = try self.loadScalar(self.slot(args[0]).ptr, .dec);
         const rhs = try self.loadScalar(self.slot(args[1]).ptr, .dec);
         const result = switch (op) {
-            .num_plus => wip.bin(.add, lhs, rhs, "") catch return error.CompilationFailed,
-            .num_minus => wip.bin(.sub, lhs, rhs, "") catch return error.CompilationFailed,
+            .num_plus => wip.bin(.add, lhs, rhs, "") catch return error.OutOfMemory,
+            .num_minus => wip.bin(.sub, lhs, rhs, "") catch return error.OutOfMemory,
             .num_times => try self.callDecBinaryBuiltin("roc_builtins_dec_mul_saturated", lhs, rhs, false),
             .num_div_by => try self.callDecBinaryBuiltin("roc_builtins_dec_div", lhs, rhs, true),
             .num_div_trunc_by => try self.callDecBinaryBuiltin("roc_builtins_dec_div_trunc", lhs, rhs, true),
             .num_rem_by, .num_mod_by => blk: {
                 const quotient = try self.callDecBinaryBuiltin("roc_builtins_dec_div_trunc", lhs, rhs, true);
                 const product = try self.callDecBinaryBuiltin("roc_builtins_dec_mul_saturated", quotient, rhs, false);
-                const remainder = wip.bin(.sub, lhs, product, "") catch return error.CompilationFailed;
+                const remainder = wip.bin(.sub, lhs, product, "") catch return error.OutOfMemory;
                 if (op == .num_rem_by) break :blk remainder;
 
                 const zero = builder.intValue(.i128, 0) catch return error.OutOfMemory;
-                const rem_is_zero = wip.icmp(.eq, remainder, zero, "") catch return error.CompilationFailed;
-                const rem_positive = wip.icmp(.sgt, remainder, zero, "") catch return error.CompilationFailed;
-                const rhs_positive = wip.icmp(.sgt, rhs, zero, "") catch return error.CompilationFailed;
-                const sign_differs = wip.bin(.xor, rem_positive, rhs_positive, "") catch return error.CompilationFailed;
-                const adjusted = wip.bin(.add, remainder, rhs, "") catch return error.CompilationFailed;
-                const nonzero_mod = wip.select(.normal, sign_differs, adjusted, remainder, "") catch return error.CompilationFailed;
-                break :blk wip.select(.normal, rem_is_zero, zero, nonzero_mod, "") catch return error.CompilationFailed;
+                const rem_is_zero = wip.icmp(.eq, remainder, zero, "") catch return error.OutOfMemory;
+                const rem_positive = wip.icmp(.sgt, remainder, zero, "") catch return error.OutOfMemory;
+                const rhs_positive = wip.icmp(.sgt, rhs, zero, "") catch return error.OutOfMemory;
+                const sign_differs = wip.bin(.xor, rem_positive, rhs_positive, "") catch return error.OutOfMemory;
+                const adjusted = wip.bin(.add, remainder, rhs, "") catch return error.OutOfMemory;
+                const nonzero_mod = wip.select(.normal, sign_differs, adjusted, remainder, "") catch return error.OutOfMemory;
+                break :blk wip.select(.normal, rem_is_zero, zero, nonzero_mod, "") catch return error.OutOfMemory;
             },
             else => return error.UnsupportedLowLevel,
         };
@@ -1076,8 +1076,8 @@ pub const MonoLlvmCodeGen = struct {
 
     fn callDecBinaryBuiltin(self: *MonoLlvmCodeGen, name: []const u8, lhs: LlvmBuilder.Value, rhs: LlvmBuilder.Value, pass_roc_ops: bool) Error!LlvmBuilder.Value {
         const wip = self.wip orelse return error.CompilationFailed;
-        const out_low = wip.alloca(.normal, .i64, .@"1", LlvmBuilder.Alignment.fromByteUnits(8), .default, "dec_low") catch return error.CompilationFailed;
-        const out_high = wip.alloca(.normal, .i64, .@"1", LlvmBuilder.Alignment.fromByteUnits(8), .default, "dec_high") catch return error.CompilationFailed;
+        const out_low = wip.alloca(.normal, .i64, .@"1", LlvmBuilder.Alignment.fromByteUnits(8), .default, "dec_low") catch return error.OutOfMemory;
+        const out_high = wip.alloca(.normal, .i64, .@"1", LlvmBuilder.Alignment.fromByteUnits(8), .default, "dec_high") catch return error.OutOfMemory;
         const lhs_parts = try self.splitI128Value(lhs);
         const rhs_parts = try self.splitI128Value(rhs);
         if (pass_roc_ops) {
@@ -1094,8 +1094,8 @@ pub const MonoLlvmCodeGen = struct {
             );
         }
 
-        const low = wip.load(.normal, .i64, out_low, LlvmBuilder.Alignment.fromByteUnits(8), "") catch return error.CompilationFailed;
-        const high = wip.load(.normal, .i64, out_high, LlvmBuilder.Alignment.fromByteUnits(8), "") catch return error.CompilationFailed;
+        const low = wip.load(.normal, .i64, out_low, LlvmBuilder.Alignment.fromByteUnits(8), "") catch return error.OutOfMemory;
+        const high = wip.load(.normal, .i64, out_high, LlvmBuilder.Alignment.fromByteUnits(8), "") catch return error.OutOfMemory;
         return self.combineI128Parts(low, high);
     }
 
@@ -1107,7 +1107,7 @@ pub const MonoLlvmCodeGen = struct {
     fn splitI128Value(self: *MonoLlvmCodeGen, value: LlvmBuilder.Value) Error!I128Parts {
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
-        const high = wip.bin(.lshr, value, builder.intValue(.i128, 64) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
+        const high = wip.bin(.lshr, value, builder.intValue(.i128, 64) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
         return .{
             .low = try self.coerceScalar(value, .i64, false),
             .high = try self.coerceScalar(high, .i64, false),
@@ -1119,8 +1119,8 @@ pub const MonoLlvmCodeGen = struct {
         const wip = self.wip orelse return error.CompilationFailed;
         const low128 = try self.coerceScalar(low, .i128, false);
         const high128 = try self.coerceScalar(high, .i128, false);
-        const shifted_high = wip.bin(.shl, high128, builder.intValue(.i128, 64) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
-        return wip.bin(.@"or", shifted_high, low128, "") catch return error.CompilationFailed;
+        const shifted_high = wip.bin(.shl, high128, builder.intValue(.i128, 64) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+        return wip.bin(.@"or", shifted_high, low128, "") catch return error.OutOfMemory;
     }
 
     fn emitNumericNegate(self: *MonoLlvmCodeGen, target: LocalId, arg: LocalId) Error!void {
@@ -1128,9 +1128,9 @@ pub const MonoLlvmCodeGen = struct {
         const target_layout = self.localLayout(target);
         const value = try self.loadScalar(self.slot(arg).ptr, self.localLayout(arg));
         const result = if (isFloatLayout(target_layout))
-            wip.un(.fneg, value, "") catch return error.CompilationFailed
+            wip.un(.fneg, value, "") catch return error.OutOfMemory
         else
-            wip.neg(value, "") catch return error.CompilationFailed;
+            wip.neg(value, "") catch return error.OutOfMemory;
         try self.storeScalar(self.slot(target).ptr, target_layout, result);
     }
 
@@ -1138,7 +1138,7 @@ pub const MonoLlvmCodeGen = struct {
         const wip = self.wip orelse return error.CompilationFailed;
         const target_layout = self.localLayout(target);
         const value = try self.loadScalar(self.slot(arg).ptr, self.localLayout(arg));
-        const result = wip.not(value, "") catch return error.CompilationFailed;
+        const result = wip.not(value, "") catch return error.OutOfMemory;
         try self.storeScalar(self.slot(target).ptr, target_layout, result);
     }
 
@@ -1153,14 +1153,14 @@ pub const MonoLlvmCodeGen = struct {
         }
         const zero = builder.zeroInitValue(value.typeOfWip(wip)) catch return error.OutOfMemory;
         const is_neg = if (isFloatLayout(target_layout))
-            wip.fcmp(.normal, .olt, value, zero, "") catch return error.CompilationFailed
+            wip.fcmp(.normal, .olt, value, zero, "") catch return error.OutOfMemory
         else
-            wip.icmp(.slt, value, zero, "") catch return error.CompilationFailed;
+            wip.icmp(.slt, value, zero, "") catch return error.OutOfMemory;
         const neg = if (isFloatLayout(target_layout))
-            wip.un(.fneg, value, "") catch return error.CompilationFailed
+            wip.un(.fneg, value, "") catch return error.OutOfMemory
         else
-            wip.neg(value, "") catch return error.CompilationFailed;
-        const result = wip.select(.normal, is_neg, neg, value, "") catch return error.CompilationFailed;
+            wip.neg(value, "") catch return error.OutOfMemory;
+        const result = wip.select(.normal, is_neg, neg, value, "") catch return error.OutOfMemory;
         try self.storeScalar(self.slot(target).ptr, target_layout, result);
     }
 
@@ -1174,15 +1174,15 @@ pub const MonoLlvmCodeGen = struct {
         const zero = builder.intValue(.i128, 0) catch return error.OutOfMemory;
 
         const result = if (lhs_layout.isSigned() or rhs_layout.isSigned()) blk: {
-            const diff = wip.bin(.sub, lhs, rhs, "") catch return error.CompilationFailed;
-            const is_neg = wip.icmp(.slt, diff, zero, "") catch return error.CompilationFailed;
-            const neg = wip.bin(.sub, zero, diff, "") catch return error.CompilationFailed;
-            break :blk wip.select(.normal, is_neg, neg, diff, "") catch return error.CompilationFailed;
+            const diff = wip.bin(.sub, lhs, rhs, "") catch return error.OutOfMemory;
+            const is_neg = wip.icmp(.slt, diff, zero, "") catch return error.OutOfMemory;
+            const neg = wip.bin(.sub, zero, diff, "") catch return error.OutOfMemory;
+            break :blk wip.select(.normal, is_neg, neg, diff, "") catch return error.OutOfMemory;
         } else blk: {
-            const lhs_ge_rhs = wip.icmp(.uge, lhs, rhs, "") catch return error.CompilationFailed;
-            const lhs_minus_rhs = wip.bin(.sub, lhs, rhs, "") catch return error.CompilationFailed;
-            const rhs_minus_lhs = wip.bin(.sub, rhs, lhs, "") catch return error.CompilationFailed;
-            break :blk wip.select(.normal, lhs_ge_rhs, lhs_minus_rhs, rhs_minus_lhs, "") catch return error.CompilationFailed;
+            const lhs_ge_rhs = wip.icmp(.uge, lhs, rhs, "") catch return error.OutOfMemory;
+            const lhs_minus_rhs = wip.bin(.sub, lhs, rhs, "") catch return error.OutOfMemory;
+            const rhs_minus_lhs = wip.bin(.sub, rhs, lhs, "") catch return error.OutOfMemory;
+            break :blk wip.select(.normal, lhs_ge_rhs, lhs_minus_rhs, rhs_minus_lhs, "") catch return error.OutOfMemory;
         };
 
         const target_layout = self.localLayout(target);
@@ -1217,12 +1217,12 @@ pub const MonoLlvmCodeGen = struct {
         const arg_layout = self.localLayout(arg);
         const value = try self.loadScalar(self.slot(arg).ptr, arg_layout);
         const value64 = try self.coerceScalar(value, .i64, arg_layout.isSigned());
-        const low_ptr = wip.alloca(.normal, .i64, .@"1", LlvmBuilder.Alignment.fromByteUnits(8), .default, "dec_low") catch return error.CompilationFailed;
-        const high_ptr = wip.alloca(.normal, .i64, .@"1", LlvmBuilder.Alignment.fromByteUnits(8), .default, "dec_high") catch return error.CompilationFailed;
+        const low_ptr = wip.alloca(.normal, .i64, .@"1", LlvmBuilder.Alignment.fromByteUnits(8), .default, "dec_low") catch return error.OutOfMemory;
+        const high_ptr = wip.alloca(.normal, .i64, .@"1", LlvmBuilder.Alignment.fromByteUnits(8), .default, "dec_high") catch return error.OutOfMemory;
         const fn_name = if (arg_layout.isSigned()) "roc_builtins_i64_to_dec" else "roc_builtins_u64_to_dec";
         try self.callBuiltinVoid(fn_name, &.{ try self.ptrType(), try self.ptrType(), .i64 }, &.{ low_ptr, high_ptr, value64 });
-        const low = wip.load(.normal, .i64, low_ptr, LlvmBuilder.Alignment.fromByteUnits(8), "") catch return error.CompilationFailed;
-        const high = wip.load(.normal, .i64, high_ptr, LlvmBuilder.Alignment.fromByteUnits(8), "") catch return error.CompilationFailed;
+        const low = wip.load(.normal, .i64, low_ptr, LlvmBuilder.Alignment.fromByteUnits(8), "") catch return error.OutOfMemory;
+        const high = wip.load(.normal, .i64, high_ptr, LlvmBuilder.Alignment.fromByteUnits(8), "") catch return error.OutOfMemory;
         try self.storeScalar(self.slot(target).ptr, .dec, try self.combineI128Parts(low, high));
     }
 
@@ -1261,9 +1261,9 @@ pub const MonoLlvmCodeGen = struct {
         defer self.allocator.free(branch_blocks);
         for (branch_blocks) |*block| block.* = wip.block(0, "switch_case") catch return error.OutOfMemory;
         const cond = try self.readSwitchValue(self.slot(sw.cond).ptr, self.localLayout(sw.cond));
-        var switch_inst = wip.@"switch"(cond, default_block, @intCast(branches.len), .none) catch return error.CompilationFailed;
+        var switch_inst = wip.@"switch"(cond, default_block, @intCast(branches.len), .none) catch return error.OutOfMemory;
         for (branches, branch_blocks) |branch, block| {
-            switch_inst.addCase(builder.intConst(cond.typeOfWip(wip), branch.value) catch return error.OutOfMemory, block, wip) catch return error.CompilationFailed;
+            switch_inst.addCase(builder.intConst(cond.typeOfWip(wip), branch.value) catch return error.OutOfMemory, block, wip) catch return error.OutOfMemory;
         }
         switch_inst.finish(wip);
         for (branches, branch_blocks) |branch, block| {
@@ -1282,13 +1282,13 @@ pub const MonoLlvmCodeGen = struct {
         try self.join_points.put(key, .{ .block = join_block, .params = join_stmt.params, .body = join_stmt.body });
 
         try self.compileStmt(join_stmt.remainder);
-        if (!self.currentBlockHasTerminator()) _ = wip.br(after_block) catch return error.CompilationFailed;
+        if (!self.currentBlockHasTerminator()) _ = wip.br(after_block) catch return error.OutOfMemory;
 
         if (!self.compiled_joins.contains(key)) {
             try self.compiled_joins.put(key, {});
             wip.cursor = .{ .block = join_block };
             try self.compileStmt(join_stmt.body);
-            if (!self.currentBlockHasTerminator()) _ = wip.br(after_block) catch return error.CompilationFailed;
+            if (!self.currentBlockHasTerminator()) _ = wip.br(after_block) catch return error.OutOfMemory;
         }
 
         wip.cursor = .{ .block = after_block };
@@ -1297,19 +1297,19 @@ pub const MonoLlvmCodeGen = struct {
     fn emitJump(self: *MonoLlvmCodeGen, jump_stmt: anytype) Error!void {
         const wip = self.wip orelse return error.CompilationFailed;
         const info = self.join_points.get(@intFromEnum(jump_stmt.target)) orelse return error.CompilationFailed;
-        _ = wip.br(info.block) catch return error.CompilationFailed;
+        _ = wip.br(info.block) catch return error.OutOfMemory;
     }
 
     fn emitLoopContinue(self: *MonoLlvmCodeGen) Error!void {
         const wip = self.wip orelse return error.CompilationFailed;
         const dest = self.loop_continue_blocks.items[self.loop_continue_blocks.items.len - 1];
-        _ = wip.br(dest) catch return error.CompilationFailed;
+        _ = wip.br(dest) catch return error.OutOfMemory;
     }
 
     fn emitLoopBreak(self: *MonoLlvmCodeGen) Error!void {
         const wip = self.wip orelse return error.CompilationFailed;
         const dest = self.loop_break_blocks.items[self.loop_break_blocks.items.len - 1];
-        _ = wip.br(dest) catch return error.CompilationFailed;
+        _ = wip.br(dest) catch return error.OutOfMemory;
     }
 
     fn emitReturn(self: *MonoLlvmCodeGen, value: LocalId) Error!void {
@@ -1319,7 +1319,7 @@ pub const MonoLlvmCodeGen = struct {
             try self.copyBytes(ret_ptr, self.slot(value).ptr, size, self.alignmentForLayout(self.current_ret_layout));
         }
         const wip = self.wip orelse return error.CompilationFailed;
-        _ = wip.retVoid() catch return error.CompilationFailed;
+        _ = wip.retVoid() catch return error.OutOfMemory;
     }
 
     fn emitExpect(self: *MonoLlvmCodeGen, condition: LocalId) Error!void {
@@ -1327,10 +1327,10 @@ pub const MonoLlvmCodeGen = struct {
         const ok_block = wip.block(0, "expect_ok") catch return error.OutOfMemory;
         const fail_block = wip.block(0, "expect_fail") catch return error.OutOfMemory;
         const cond = try self.loadBool(self.slot(condition).ptr);
-        _ = wip.brCond(cond, ok_block, fail_block, .then_likely) catch return error.CompilationFailed;
+        _ = wip.brCond(cond, ok_block, fail_block, .then_likely) catch return error.OutOfMemory;
         wip.cursor = .{ .block = fail_block };
         try self.emitStaticRocOpsMessageCall(@offsetOf(builtins.host_abi.RocOps, "roc_expect_failed"), "expect failed");
-        _ = wip.br(ok_block) catch return error.CompilationFailed;
+        _ = wip.br(ok_block) catch return error.OutOfMemory;
         wip.cursor = .{ .block = ok_block };
     }
 
@@ -1340,9 +1340,9 @@ pub const MonoLlvmCodeGen = struct {
         // Linux AArch64 eval tests handle crashes by returning to the Zig host.
         // Longjmping through LLVM-generated frames is not reliable on that target.
         if (self.target.cpu.arch == .aarch64 and self.target.os.tag == .linux) {
-            _ = wip.retVoid() catch return error.CompilationFailed;
+            _ = wip.retVoid() catch return error.OutOfMemory;
         } else {
-            _ = wip.@"unreachable"() catch return error.CompilationFailed;
+            _ = wip.@"unreachable"() catch return error.OutOfMemory;
         }
     }
 
@@ -1378,7 +1378,7 @@ pub const MonoLlvmCodeGen = struct {
             LlvmBuilder.Alignment.fromByteUnits(@alignOf(builtins.host_abi.RocCrashed)),
             .default,
             "roc_ops_msg",
-        ) catch return error.CompilationFailed;
+        ) catch return error.OutOfMemory;
 
         try self.storePointer(args_ptr, try self.staticBytes(msg));
         try self.storeUsize(
@@ -1390,7 +1390,7 @@ pub const MonoLlvmCodeGen = struct {
         const callback_ptr_ptr = try self.offsetPtr(self.rocOps(), @intCast(callback_offset));
         const callback_ptr = try self.loadPointer(callback_ptr_ptr);
         const fn_ty = builder.fnType(.void, &.{ ptr_ty, ptr_ty }, .normal) catch return error.OutOfMemory;
-        _ = wip.call(.normal, .ccc, .none, fn_ty, callback_ptr, &.{ args_ptr, env_ptr }, "") catch return error.CompilationFailed;
+        _ = wip.call(.normal, .ccc, .none, fn_ty, callback_ptr, &.{ args_ptr, env_ptr }, "") catch return error.OutOfMemory;
     }
 
     fn copyLocal(self: *MonoLlvmCodeGen, target: LocalId, source: LocalId) Error!void {
@@ -1526,7 +1526,7 @@ pub const MonoLlvmCodeGen = struct {
             LlvmBuilder.Alignment.fromByteUnits(@alignOf(builtins.dev_wrappers.StrFromUtf8Layout)),
             .default,
             "str_from_utf8_layout",
-        ) catch return error.CompilationFailed;
+        ) catch return error.OutOfMemory;
 
         try self.storeRawInt(layout_ptr, 0, .i64, info.ok_tag, 8);
         try self.storeRawInt(layout_ptr, 8, .i64, info.err_tag, 8);
@@ -1588,7 +1588,7 @@ pub const MonoLlvmCodeGen = struct {
         const bits = self.intBits(arg_layout);
         const value = try self.coerceScalar(try self.loadScalar(self.slot(arg).ptr, arg_layout), .i128, arg_layout.isSigned());
         const lo = try self.coerceScalar(value, .i64, false);
-        const hi = (self.wip orelse return error.CompilationFailed).bin(.lshr, value, builder.intValue(.i128, 64) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
+        const hi = (self.wip orelse return error.CompilationFailed).bin(.lshr, value, builder.intValue(.i128, 64) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
         const hi64 = try self.coerceScalar(hi, .i64, false);
         const byte_width: u8 = @intCast(bits / 8);
         try self.callBuiltinVoid("roc_builtins_int_to_str", &.{ try self.ptrType(), .i64, .i64, .i8, .i1, try self.ptrType() }, &.{
@@ -1607,9 +1607,9 @@ pub const MonoLlvmCodeGen = struct {
         const arg_layout = self.localLayout(arg);
         const value = try self.loadScalar(self.slot(arg).ptr, arg_layout);
         const bits = if (arg_layout == .f32)
-            try self.coerceScalar(wip.cast(.bitcast, value, .i32, "") catch return error.CompilationFailed, .i64, false)
+            try self.coerceScalar(wip.cast(.bitcast, value, .i32, "") catch return error.OutOfMemory, .i64, false)
         else
-            wip.cast(.bitcast, value, .i64, "") catch return error.CompilationFailed;
+            wip.cast(.bitcast, value, .i64, "") catch return error.OutOfMemory;
         try self.callBuiltinVoid("roc_builtins_float_to_str", &.{ try self.ptrType(), .i64, .i1, try self.ptrType() }, &.{
             self.slot(target).ptr,
             bits,
@@ -1622,7 +1622,7 @@ pub const MonoLlvmCodeGen = struct {
         const builder = self.builder orelse return error.CompilationFailed;
         const value = try self.loadScalar(self.slot(arg).ptr, .dec);
         const lo = try self.coerceScalar(value, .i64, false);
-        const hi = (self.wip orelse return error.CompilationFailed).bin(.lshr, value, builder.intValue(.i128, 64) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
+        const hi = (self.wip orelse return error.CompilationFailed).bin(.lshr, value, builder.intValue(.i128, 64) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
         const hi64 = try self.coerceScalar(hi, .i64, false);
         try self.callBuiltinVoid("roc_builtins_dec_to_str", &.{ try self.ptrType(), .i64, .i64, try self.ptrType() }, &.{ self.slot(target).ptr, lo, hi64, self.rocOps() });
     }
@@ -1741,8 +1741,8 @@ pub const MonoLlvmCodeGen = struct {
         const idx = try self.coerceScalar(try self.loadScalar(self.slot(args[1]).ptr, self.localLayout(args[1])), self.ptrSizedIntType(), false);
         const wip = self.wip orelse return error.CompilationFailed;
         const builder = self.builder orelse return error.CompilationFailed;
-        const offset = wip.bin(.mul, idx, builder.intValue(self.ptrSizedIntType(), abi.elem_size) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
-        const src = wip.gep(.inbounds, .i8, bytes, &.{offset}, "") catch return error.CompilationFailed;
+        const offset = wip.bin(.mul, idx, builder.intValue(self.ptrSizedIntType(), abi.elem_size) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+        const src = wip.gep(.inbounds, .i8, bytes, &.{offset}, "") catch return error.OutOfMemory;
         try self.copyBytes(self.slot(target).ptr, src, self.slot(target).size, self.slot(target).alignment);
     }
 
@@ -1777,14 +1777,14 @@ pub const MonoLlvmCodeGen = struct {
         if (abi.elem_size == 0) {
             const lhs_len = try self.loadUsize(try self.offsetPtr(self.slot(args[0]).ptr, @sizeOf(usize)));
             const rhs_len = try self.loadUsize(try self.offsetPtr(self.slot(args[1]).ptr, @sizeOf(usize)));
-            const total_len = (self.wip orelse return error.CompilationFailed).bin(.add, lhs_len, rhs_len, "") catch return error.CompilationFailed;
+            const total_len = (self.wip orelse return error.CompilationFailed).bin(.add, lhs_len, rhs_len, "") catch return error.OutOfMemory;
             const null_ptr = builder.nullValue(try self.ptrType()) catch return error.OutOfMemory;
             try self.storePointer(self.slot(target).ptr, null_ptr);
             try self.storeScalar(try self.offsetPtr(self.slot(target).ptr, @sizeOf(usize)), .u64, total_len);
             try self.storeScalar(
                 try self.offsetPtr(self.slot(target).ptr, 2 * @sizeOf(usize)),
                 .u64,
-                (self.wip orelse return error.CompilationFailed).bin(.shl, total_len, builder.intValue(self.ptrSizedIntType(), 1) catch return error.OutOfMemory, "") catch return error.CompilationFailed,
+                (self.wip orelse return error.CompilationFailed).bin(.shl, total_len, builder.intValue(self.ptrSizedIntType(), 1) catch return error.OutOfMemory, "") catch return error.OutOfMemory,
             );
             return;
         }
@@ -1829,17 +1829,17 @@ pub const MonoLlvmCodeGen = struct {
         const slice = switch (op) {
             .list_drop_first => ListSlice{ .start = one, .len = max_count },
             .list_drop_last => blk: {
-                const len_is_zero = (self.wip orelse return error.CompilationFailed).icmp(.eq, len, zero, "") catch return error.CompilationFailed;
-                const decremented = (self.wip orelse return error.CompilationFailed).bin(.sub, len, one, "") catch return error.CompilationFailed;
-                const safe_len = (self.wip orelse return error.CompilationFailed).select(.normal, len_is_zero, zero, decremented, "") catch return error.CompilationFailed;
+                const len_is_zero = (self.wip orelse return error.CompilationFailed).icmp(.eq, len, zero, "") catch return error.OutOfMemory;
+                const decremented = (self.wip orelse return error.CompilationFailed).bin(.sub, len, one, "") catch return error.OutOfMemory;
+                const safe_len = (self.wip orelse return error.CompilationFailed).select(.normal, len_is_zero, zero, decremented, "") catch return error.OutOfMemory;
                 break :blk ListSlice{ .start = zero, .len = safe_len };
             },
             .list_take_first => ListSlice{ .start = zero, .len = try self.loadIntegerLocalAsUsize(args[1]) },
             .list_take_last => blk: {
                 const count = try self.loadIntegerLocalAsUsize(args[1]);
-                const takes_all = (self.wip orelse return error.CompilationFailed).icmp(.uge, count, len, "") catch return error.CompilationFailed;
-                const suffix_start = (self.wip orelse return error.CompilationFailed).bin(.sub, len, count, "") catch return error.CompilationFailed;
-                const safe_start = (self.wip orelse return error.CompilationFailed).select(.normal, takes_all, zero, suffix_start, "") catch return error.CompilationFailed;
+                const takes_all = (self.wip orelse return error.CompilationFailed).icmp(.uge, count, len, "") catch return error.OutOfMemory;
+                const suffix_start = (self.wip orelse return error.CompilationFailed).bin(.sub, len, count, "") catch return error.OutOfMemory;
+                const safe_start = (self.wip orelse return error.CompilationFailed).select(.normal, takes_all, zero, suffix_start, "") catch return error.OutOfMemory;
                 break :blk ListSlice{ .start = safe_start, .len = count };
             },
             .list_sublist => try self.loadSublistStartLen(args[1]),
@@ -1959,27 +1959,27 @@ pub const MonoLlvmCodeGen = struct {
         const wip = self.wip orelse return error.CompilationFailed;
         const list_ptr = self.slot(args[0]).ptr;
         const len = try self.loadUsize(try self.offsetPtr(list_ptr, @sizeOf(usize)));
-        const non_empty = wip.icmp(.ne, len, builder.intValue(self.ptrSizedIntType(), 0) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
+        const non_empty = wip.icmp(.ne, len, builder.intValue(self.ptrSizedIntType(), 0) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
         const empty_block = wip.block(0, "list_empty") catch return error.OutOfMemory;
         const full_block = wip.block(0, "list_full") catch return error.OutOfMemory;
         const after = wip.block(0, "list_first_after") catch return error.OutOfMemory;
-        _ = wip.brCond(non_empty, full_block, empty_block, .then_likely) catch return error.CompilationFailed;
+        _ = wip.brCond(non_empty, full_block, empty_block, .then_likely) catch return error.OutOfMemory;
         wip.cursor = .{ .block = empty_block };
         try self.emitTagLiteral(target, 0, null);
-        _ = wip.br(after) catch return error.CompilationFailed;
+        _ = wip.br(after) catch return error.OutOfMemory;
         wip.cursor = .{ .block = full_block };
         const abi = self.layouts().builtinListAbi(self.localLayout(args[0]));
         const bytes = try self.loadPointer(list_ptr);
         const idx = if (op == .list_first)
             builder.intValue(self.ptrSizedIntType(), 0) catch return error.OutOfMemory
         else
-            wip.bin(.sub, len, builder.intValue(self.ptrSizedIntType(), 1) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
-        const offset = wip.bin(.mul, idx, builder.intValue(self.ptrSizedIntType(), abi.elem_size) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
-        const elem_src = wip.gep(.inbounds, .i8, bytes, &.{offset}, "") catch return error.CompilationFailed;
+            wip.bin(.sub, len, builder.intValue(self.ptrSizedIntType(), 1) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+        const offset = wip.bin(.mul, idx, builder.intValue(self.ptrSizedIntType(), abi.elem_size) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+        const elem_src = wip.gep(.inbounds, .i8, bytes, &.{offset}, "") catch return error.OutOfMemory;
         const payload_layout = self.tagPayloadLayout(self.localLayout(target), 1);
         try self.emitTagLiteral(target, 1, null);
         try self.copyBytes(self.slot(target).ptr, elem_src, self.layoutByteSize(payload_layout), self.alignmentForLayout(payload_layout));
-        _ = wip.br(after) catch return error.CompilationFailed;
+        _ = wip.br(after) catch return error.OutOfMemory;
         wip.cursor = .{ .block = after };
     }
 
@@ -2014,15 +2014,15 @@ pub const MonoLlvmCodeGen = struct {
                     const lhs = try self.loadScalar(lhs_ptr, layout_idx);
                     const rhs = try self.loadScalar(rhs_ptr, layout_idx);
                     return if (isFloatLayout(layout_idx))
-                        wip.fcmp(.normal, .oeq, lhs, rhs, "") catch return error.CompilationFailed
+                        wip.fcmp(.normal, .oeq, lhs, rhs, "") catch return error.OutOfMemory
                     else
-                        wip.icmp(.eq, lhs, rhs, "") catch return error.CompilationFailed;
+                        wip.icmp(.eq, lhs, rhs, "") catch return error.OutOfMemory;
                 },
             },
             .box, .erased_callable => {
                 const lhs = try self.loadPointer(lhs_ptr);
                 const rhs = try self.loadPointer(rhs_ptr);
-                return wip.icmp(.eq, lhs, rhs, "") catch return error.CompilationFailed;
+                return wip.icmp(.eq, lhs, rhs, "") catch return error.OutOfMemory;
             },
             .list, .list_of_zst => return self.emitListEqual(lhs_ptr, rhs_ptr, layout_idx),
             .struct_ => {
@@ -2032,7 +2032,7 @@ pub const MonoLlvmCodeGen = struct {
                     const field = info.fields.get(@intCast(i));
                     const offset = self.layouts().getStructFieldOffset(layout_val.getStruct().idx, @intCast(i));
                     const field_eq = try self.emitValueEqual(try self.offsetPtr(lhs_ptr, offset), try self.offsetPtr(rhs_ptr, offset), field.layout);
-                    result = wip.bin(.@"and", result, field_eq, "") catch return error.CompilationFailed;
+                    result = wip.bin(.@"and", result, field_eq, "") catch return error.OutOfMemory;
                 }
                 return result;
             },
@@ -2047,10 +2047,10 @@ pub const MonoLlvmCodeGen = struct {
         var result = builder.intValue(.i1, 1) catch return error.OutOfMemory;
         var offset: u32 = 0;
         while (offset < size) : (offset += 1) {
-            const lhs = wip.load(.normal, .i8, try self.offsetPtr(lhs_ptr, offset), LlvmBuilder.Alignment.fromByteUnits(1), "") catch return error.CompilationFailed;
-            const rhs = wip.load(.normal, .i8, try self.offsetPtr(rhs_ptr, offset), LlvmBuilder.Alignment.fromByteUnits(1), "") catch return error.CompilationFailed;
-            const eq = wip.icmp(.eq, lhs, rhs, "") catch return error.CompilationFailed;
-            result = wip.bin(.@"and", result, eq, "") catch return error.CompilationFailed;
+            const lhs = wip.load(.normal, .i8, try self.offsetPtr(lhs_ptr, offset), LlvmBuilder.Alignment.fromByteUnits(1), "") catch return error.OutOfMemory;
+            const rhs = wip.load(.normal, .i8, try self.offsetPtr(rhs_ptr, offset), LlvmBuilder.Alignment.fromByteUnits(1), "") catch return error.OutOfMemory;
+            const eq = wip.icmp(.eq, lhs, rhs, "") catch return error.OutOfMemory;
+            result = wip.bin(.@"and", result, eq, "") catch return error.OutOfMemory;
         }
         return result;
     }
@@ -2061,37 +2061,37 @@ pub const MonoLlvmCodeGen = struct {
         const abi = self.layouts().builtinListAbi(list_layout);
         const lhs_len = try self.loadUsize(try self.offsetPtr(lhs_ptr, @sizeOf(usize)));
         const rhs_len = try self.loadUsize(try self.offsetPtr(rhs_ptr, @sizeOf(usize)));
-        const len_eq = wip.icmp(.eq, lhs_len, rhs_len, "") catch return error.CompilationFailed;
+        const len_eq = wip.icmp(.eq, lhs_len, rhs_len, "") catch return error.OutOfMemory;
         if (abi.elem_size == 0) return len_eq;
 
-        const result_ptr = wip.alloca(.normal, .i8, .@"1", LlvmBuilder.Alignment.fromByteUnits(1), .default, "list_eq") catch return error.CompilationFailed;
+        const result_ptr = wip.alloca(.normal, .i8, .@"1", LlvmBuilder.Alignment.fromByteUnits(1), .default, "list_eq") catch return error.OutOfMemory;
         try self.storeBool(result_ptr, len_eq);
         const header = wip.block(0, "list_eq_header") catch return error.OutOfMemory;
         const body = wip.block(0, "list_eq_body") catch return error.OutOfMemory;
         const after = wip.block(0, "list_eq_after") catch return error.OutOfMemory;
-        const idx_ptr = wip.alloca(.normal, .i64, .@"1", LlvmBuilder.Alignment.fromByteUnits(8), .default, "list_eq_idx") catch return error.CompilationFailed;
-        _ = wip.store(.normal, builder.intValue(.i64, 0) catch return error.OutOfMemory, idx_ptr, LlvmBuilder.Alignment.fromByteUnits(8)) catch return error.CompilationFailed;
-        _ = wip.br(header) catch return error.CompilationFailed;
+        const idx_ptr = wip.alloca(.normal, .i64, .@"1", LlvmBuilder.Alignment.fromByteUnits(8), .default, "list_eq_idx") catch return error.OutOfMemory;
+        _ = wip.store(.normal, builder.intValue(.i64, 0) catch return error.OutOfMemory, idx_ptr, LlvmBuilder.Alignment.fromByteUnits(8)) catch return error.OutOfMemory;
+        _ = wip.br(header) catch return error.OutOfMemory;
         wip.cursor = .{ .block = header };
         const so_far = try self.loadBool(result_ptr);
-        const idx = wip.load(.normal, .i64, idx_ptr, LlvmBuilder.Alignment.fromByteUnits(8), "") catch return error.CompilationFailed;
+        const idx = wip.load(.normal, .i64, idx_ptr, LlvmBuilder.Alignment.fromByteUnits(8), "") catch return error.OutOfMemory;
         const idx_usize = try self.coerceScalar(idx, self.ptrSizedIntType(), false);
-        const in_range = wip.icmp(.ult, idx_usize, lhs_len, "") catch return error.CompilationFailed;
-        const continue_loop = wip.bin(.@"and", so_far, in_range, "") catch return error.CompilationFailed;
-        _ = wip.brCond(continue_loop, body, after, .none) catch return error.CompilationFailed;
+        const in_range = wip.icmp(.ult, idx_usize, lhs_len, "") catch return error.OutOfMemory;
+        const continue_loop = wip.bin(.@"and", so_far, in_range, "") catch return error.OutOfMemory;
+        _ = wip.brCond(continue_loop, body, after, .none) catch return error.OutOfMemory;
         wip.cursor = .{ .block = body };
         const lhs_bytes = try self.loadPointer(lhs_ptr);
         const rhs_bytes = try self.loadPointer(rhs_ptr);
-        const offset = wip.bin(.mul, idx_usize, builder.intValue(self.ptrSizedIntType(), abi.elem_size) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
+        const offset = wip.bin(.mul, idx_usize, builder.intValue(self.ptrSizedIntType(), abi.elem_size) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
         const elem_eq = try self.emitValueEqual(
-            wip.gep(.inbounds, .i8, lhs_bytes, &.{offset}, "") catch return error.CompilationFailed,
-            wip.gep(.inbounds, .i8, rhs_bytes, &.{offset}, "") catch return error.CompilationFailed,
+            wip.gep(.inbounds, .i8, lhs_bytes, &.{offset}, "") catch return error.OutOfMemory,
+            wip.gep(.inbounds, .i8, rhs_bytes, &.{offset}, "") catch return error.OutOfMemory,
             abi.elem_layout_idx orelse .zst,
         );
         try self.storeBool(result_ptr, elem_eq);
-        const next = wip.bin(.add, idx, builder.intValue(.i64, 1) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
-        _ = wip.store(.normal, next, idx_ptr, LlvmBuilder.Alignment.fromByteUnits(8)) catch return error.CompilationFailed;
-        _ = wip.br(header) catch return error.CompilationFailed;
+        const next = wip.bin(.add, idx, builder.intValue(.i64, 1) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+        _ = wip.store(.normal, next, idx_ptr, LlvmBuilder.Alignment.fromByteUnits(8)) catch return error.OutOfMemory;
+        _ = wip.br(header) catch return error.OutOfMemory;
         wip.cursor = .{ .block = after };
         return self.loadBool(result_ptr);
     }
@@ -2101,33 +2101,33 @@ pub const MonoLlvmCodeGen = struct {
         const wip = self.wip orelse return error.CompilationFailed;
         const lhs_disc = try self.readTagDiscriminant(lhs_ptr, tag_layout);
         const rhs_disc = try self.readTagDiscriminant(rhs_ptr, tag_layout);
-        const disc_eq = wip.icmp(.eq, lhs_disc, rhs_disc, "") catch return error.CompilationFailed;
+        const disc_eq = wip.icmp(.eq, lhs_disc, rhs_disc, "") catch return error.OutOfMemory;
         const data = self.layouts().getTagUnionData(self.layoutValue(tag_layout).getTagUnion().idx);
         const variants = self.layouts().getTagUnionVariants(data);
-        const result_ptr = wip.alloca(.normal, .i8, .@"1", LlvmBuilder.Alignment.fromByteUnits(1), .default, "tag_eq") catch return error.CompilationFailed;
+        const result_ptr = wip.alloca(.normal, .i8, .@"1", LlvmBuilder.Alignment.fromByteUnits(1), .default, "tag_eq") catch return error.OutOfMemory;
         try self.storeBool(result_ptr, disc_eq);
         const after = wip.block(0, "tag_eq_after") catch return error.OutOfMemory;
         const mismatch = wip.block(0, "tag_eq_mismatch") catch return error.OutOfMemory;
         const case_blocks = try self.allocator.alloc(LlvmBuilder.Function.Block.Index, variants.len);
         defer self.allocator.free(case_blocks);
         for (case_blocks) |*block| block.* = wip.block(0, "tag_eq_case") catch return error.OutOfMemory;
-        _ = wip.brCond(disc_eq, case_blocks[0], mismatch, .then_likely) catch return error.CompilationFailed;
+        _ = wip.brCond(disc_eq, case_blocks[0], mismatch, .then_likely) catch return error.OutOfMemory;
         wip.cursor = .{ .block = mismatch };
         try self.storeBool(result_ptr, builder.intValue(.i1, 0) catch return error.OutOfMemory);
-        _ = wip.br(after) catch return error.CompilationFailed;
+        _ = wip.br(after) catch return error.OutOfMemory;
         for (case_blocks, 0..) |block, i| {
             wip.cursor = .{ .block = block };
             if (i + 1 < case_blocks.len) {
-                const is_case = wip.icmp(.eq, lhs_disc, builder.intValue(lhs_disc.typeOfWip(wip), i) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
+                const is_case = wip.icmp(.eq, lhs_disc, builder.intValue(lhs_disc.typeOfWip(wip), i) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
                 const next_case = case_blocks[i + 1];
                 const do_case = wip.block(0, "tag_eq_do_case") catch return error.OutOfMemory;
-                _ = wip.brCond(is_case, do_case, next_case, .none) catch return error.CompilationFailed;
+                _ = wip.brCond(is_case, do_case, next_case, .none) catch return error.OutOfMemory;
                 wip.cursor = .{ .block = do_case };
             }
             const payload_layout = variants.get(@intCast(i)).payload_layout;
             const eq = try self.emitValueEqual(lhs_ptr, rhs_ptr, payload_layout);
             try self.storeBool(result_ptr, eq);
-            _ = wip.br(after) catch return error.CompilationFailed;
+            _ = wip.br(after) catch return error.OutOfMemory;
         }
         wip.cursor = .{ .block = after };
         return self.loadBool(result_ptr);
@@ -2253,17 +2253,17 @@ pub const MonoLlvmCodeGen = struct {
             .decref, .free => wip.arg(1),
         };
 
-        const is_null = wip.icmp(.eq, value_ptr, builder.nullValue(try self.ptrType()) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
-        _ = wip.brCond(is_null, done, body, .else_likely) catch return error.CompilationFailed;
+        const is_null = wip.icmp(.eq, value_ptr, builder.nullValue(try self.ptrType()) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+        _ = wip.brCond(is_null, done, body, .else_likely) catch return error.OutOfMemory;
 
         wip.cursor = .{ .block = body };
         try self.emitRcHelperBody(helper_key, value_ptr, count_value);
         if (!self.currentBlockHasTerminator()) {
-            _ = wip.br(done) catch return error.CompilationFailed;
+            _ = wip.br(done) catch return error.OutOfMemory;
         }
 
         wip.cursor = .{ .block = done };
-        _ = wip.retVoid() catch return error.CompilationFailed;
+        _ = wip.retVoid() catch return error.OutOfMemory;
         try self.finishCurrentWipFunction();
     }
 
@@ -2305,30 +2305,30 @@ pub const MonoLlvmCodeGen = struct {
         const bytes = try self.loadPointer(value_ptr);
         const cap_or_alloc = try self.loadUsize(try self.offsetPtr(value_ptr, @sizeOf(usize)));
         const ptr_int_ty = self.ptrSizedIntType();
-        const bytes_int = wip.cast(.ptrtoint, bytes, ptr_int_ty, "") catch return error.CompilationFailed;
-        const slice_tag = wip.bin(.@"and", cap_or_alloc, builder.intValue(ptr_int_ty, 1) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
-        const slice_mask = wip.bin(.sub, builder.intValue(ptr_int_ty, 0) catch return error.OutOfMemory, slice_tag, "") catch return error.CompilationFailed;
-        const owned_mask = wip.not(slice_mask, "") catch return error.CompilationFailed;
-        const owned_ptr = wip.bin(.@"and", bytes_int, owned_mask, "") catch return error.CompilationFailed;
-        const slice_alloc = wip.bin(.@"and", cap_or_alloc, builder.intValue(ptr_int_ty, -2) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
-        const slice_ptr = wip.bin(.@"and", slice_alloc, slice_mask, "") catch return error.CompilationFailed;
-        const data_ptr = wip.bin(.@"or", owned_ptr, slice_ptr, "") catch return error.CompilationFailed;
-        return wip.cast(.inttoptr, data_ptr, try self.ptrType(), "") catch return error.CompilationFailed;
+        const bytes_int = wip.cast(.ptrtoint, bytes, ptr_int_ty, "") catch return error.OutOfMemory;
+        const slice_tag = wip.bin(.@"and", cap_or_alloc, builder.intValue(ptr_int_ty, 1) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+        const slice_mask = wip.bin(.sub, builder.intValue(ptr_int_ty, 0) catch return error.OutOfMemory, slice_tag, "") catch return error.OutOfMemory;
+        const owned_mask = wip.not(slice_mask, "") catch return error.OutOfMemory;
+        const owned_ptr = wip.bin(.@"and", bytes_int, owned_mask, "") catch return error.OutOfMemory;
+        const slice_alloc = wip.bin(.@"and", cap_or_alloc, builder.intValue(ptr_int_ty, -2) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+        const slice_ptr = wip.bin(.@"and", slice_alloc, slice_mask, "") catch return error.OutOfMemory;
+        const data_ptr = wip.bin(.@"or", owned_ptr, slice_ptr, "") catch return error.OutOfMemory;
+        return wip.cast(.inttoptr, data_ptr, try self.ptrType(), "") catch return error.OutOfMemory;
     }
 
     fn emitRcHelperStrIncref(self: *MonoLlvmCodeGen, value_ptr: LlvmBuilder.Value, count_value: LlvmBuilder.Value) Error!void {
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
         const len = try self.loadUsize(try self.offsetPtr(value_ptr, 2 * @sizeOf(usize)));
-        const is_small = wip.icmp(.slt, len, builder.intValue(self.ptrSizedIntType(), 0) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
+        const is_small = wip.icmp(.slt, len, builder.intValue(self.ptrSizedIntType(), 0) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
         const heap_str = wip.block(0, "str_heap") catch return error.OutOfMemory;
         const after = wip.block(0, "str_after") catch return error.OutOfMemory;
-        _ = wip.brCond(is_small, after, heap_str, .else_likely) catch return error.CompilationFailed;
+        _ = wip.brCond(is_small, after, heap_str, .else_likely) catch return error.OutOfMemory;
 
         wip.cursor = .{ .block = heap_str };
         const data_ptr = try self.loadStrDataPtrForRc(value_ptr);
         try self.callBuiltinVoid("roc_builtins_incref_data_ptr", &.{ try self.ptrType(), .i64, try self.ptrType() }, &.{ data_ptr, count_value, self.rocOps() });
-        _ = wip.br(after) catch return error.CompilationFailed;
+        _ = wip.br(after) catch return error.OutOfMemory;
 
         wip.cursor = .{ .block = after };
     }
@@ -2337,10 +2337,10 @@ pub const MonoLlvmCodeGen = struct {
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
         const len = try self.loadUsize(try self.offsetPtr(value_ptr, 2 * @sizeOf(usize)));
-        const is_small = wip.icmp(.slt, len, builder.intValue(self.ptrSizedIntType(), 0) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
+        const is_small = wip.icmp(.slt, len, builder.intValue(self.ptrSizedIntType(), 0) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
         const heap_str = wip.block(0, "str_heap") catch return error.OutOfMemory;
         const after = wip.block(0, "str_after") catch return error.OutOfMemory;
-        _ = wip.brCond(is_small, after, heap_str, .else_likely) catch return error.CompilationFailed;
+        _ = wip.brCond(is_small, after, heap_str, .else_likely) catch return error.OutOfMemory;
 
         wip.cursor = .{ .block = heap_str };
         const data_ptr = try self.loadStrDataPtrForRc(value_ptr);
@@ -2354,7 +2354,7 @@ pub const MonoLlvmCodeGen = struct {
                 self.rocOps(),
             },
         );
-        _ = wip.br(after) catch return error.CompilationFailed;
+        _ = wip.br(after) catch return error.OutOfMemory;
 
         wip.cursor = .{ .block = after };
     }
@@ -2471,7 +2471,7 @@ pub const MonoLlvmCodeGen = struct {
         if (disc_size == 0) return;
         const disc_offset = self.layouts().rcHelperTagUnionDiscriminantOffset(tag_plan);
         const disc_ptr = try self.offsetPtr(value_ptr, disc_offset);
-        const disc_raw = wip.load(.normal, intTypeForBytes(disc_size), disc_ptr, LlvmBuilder.Alignment.fromByteUnits(@max(disc_size, 1)), "") catch return error.CompilationFailed;
+        const disc_raw = wip.load(.normal, intTypeForBytes(disc_size), disc_ptr, LlvmBuilder.Alignment.fromByteUnits(@max(disc_size, 1)), "") catch return error.OutOfMemory;
         const disc = try self.coerceScalar(disc_raw, .i64, false);
         const after = wip.block(0, "rc_tag_after") catch return error.OutOfMemory;
 
@@ -2480,17 +2480,17 @@ pub const MonoLlvmCodeGen = struct {
             const child_key = self.layouts().rcHelperTagUnionVariantPlan(tag_plan, variant_i) orelse continue;
             const do_case = wip.block(0, "rc_tag_case") catch return error.OutOfMemory;
             const next_case = wip.block(0, "rc_tag_next") catch return error.OutOfMemory;
-            const is_case = wip.icmp(.eq, disc, builder.intValue(.i64, variant_i) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
-            _ = wip.brCond(is_case, do_case, next_case, .none) catch return error.CompilationFailed;
+            const is_case = wip.icmp(.eq, disc, builder.intValue(.i64, variant_i) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+            _ = wip.brCond(is_case, do_case, next_case, .none) catch return error.OutOfMemory;
 
             wip.cursor = .{ .block = do_case };
             try self.emitRcHelperCall(child_key, value_ptr, if (child_key.op == .incref) count_value else null);
-            _ = wip.br(after) catch return error.CompilationFailed;
+            _ = wip.br(after) catch return error.OutOfMemory;
 
             wip.cursor = .{ .block = next_case };
         }
 
-        _ = wip.br(after) catch return error.CompilationFailed;
+        _ = wip.br(after) catch return error.OutOfMemory;
         wip.cursor = .{ .block = after };
     }
 
@@ -2547,31 +2547,31 @@ pub const MonoLlvmCodeGen = struct {
         if (offset == 0) return ptr;
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
-        return wip.gep(.inbounds, .i8, ptr, &.{builder.intValue(.i32, offset) catch return error.OutOfMemory}, "") catch return error.CompilationFailed;
+        return wip.gep(.inbounds, .i8, ptr, &.{builder.intValue(.i32, offset) catch return error.OutOfMemory}, "") catch return error.OutOfMemory;
     }
 
     fn copyBytes(self: *MonoLlvmCodeGen, dst: LlvmBuilder.Value, src: LlvmBuilder.Value, size: u32, alignment: LlvmBuilder.Alignment) Error!void {
         if (size == 0) return;
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
-        _ = wip.callMemCpy(dst, alignment, src, alignment, builder.intValue(self.ptrSizedIntType(), size) catch return error.OutOfMemory, .normal, false) catch return error.CompilationFailed;
+        _ = wip.callMemCpy(dst, alignment, src, alignment, builder.intValue(self.ptrSizedIntType(), size) catch return error.OutOfMemory, .normal, false) catch return error.OutOfMemory;
     }
 
     fn zeroBytes(self: *MonoLlvmCodeGen, dst: LlvmBuilder.Value, size: u32) Error!void {
         if (size == 0) return;
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
-        _ = wip.callMemSet(dst, LlvmBuilder.Alignment.fromByteUnits(1), builder.intValue(.i8, 0) catch return error.OutOfMemory, builder.intValue(self.ptrSizedIntType(), size) catch return error.OutOfMemory, .normal, false) catch return error.CompilationFailed;
+        _ = wip.callMemSet(dst, LlvmBuilder.Alignment.fromByteUnits(1), builder.intValue(.i8, 0) catch return error.OutOfMemory, builder.intValue(self.ptrSizedIntType(), size) catch return error.OutOfMemory, .normal, false) catch return error.OutOfMemory;
     }
 
     fn storePointer(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, value: LlvmBuilder.Value) Error!void {
         const wip = self.wip orelse return error.CompilationFailed;
-        _ = wip.store(.normal, value, ptr, LlvmBuilder.Alignment.fromByteUnits(@sizeOf(usize))) catch return error.CompilationFailed;
+        _ = wip.store(.normal, value, ptr, LlvmBuilder.Alignment.fromByteUnits(@sizeOf(usize))) catch return error.OutOfMemory;
     }
 
     fn storeUsize(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, value: LlvmBuilder.Value) Error!void {
         const wip = self.wip orelse return error.CompilationFailed;
-        _ = wip.store(.normal, value, ptr, LlvmBuilder.Alignment.fromByteUnits(@sizeOf(usize))) catch return error.CompilationFailed;
+        _ = wip.store(.normal, value, ptr, LlvmBuilder.Alignment.fromByteUnits(@sizeOf(usize))) catch return error.OutOfMemory;
     }
 
     fn storeRawInt(self: *MonoLlvmCodeGen, base: LlvmBuilder.Value, offset: u32, ty: LlvmBuilder.Type, value: u64, alignment: u32) Error!void {
@@ -2583,17 +2583,17 @@ pub const MonoLlvmCodeGen = struct {
             builder.intValue(ty, @as(i64, @intCast(value))) catch return error.OutOfMemory,
             ptr,
             LlvmBuilder.Alignment.fromByteUnits(alignment),
-        ) catch return error.CompilationFailed;
+        ) catch return error.OutOfMemory;
     }
 
     fn loadPointer(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value) Error!LlvmBuilder.Value {
         const wip = self.wip orelse return error.CompilationFailed;
-        return wip.load(.normal, try self.ptrType(), ptr, LlvmBuilder.Alignment.fromByteUnits(@sizeOf(usize)), "") catch return error.CompilationFailed;
+        return wip.load(.normal, try self.ptrType(), ptr, LlvmBuilder.Alignment.fromByteUnits(@sizeOf(usize)), "") catch return error.OutOfMemory;
     }
 
     fn loadUsize(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value) Error!LlvmBuilder.Value {
         const wip = self.wip orelse return error.CompilationFailed;
-        return wip.load(.normal, self.ptrSizedIntType(), ptr, LlvmBuilder.Alignment.fromByteUnits(@sizeOf(usize)), "") catch return error.CompilationFailed;
+        return wip.load(.normal, self.ptrSizedIntType(), ptr, LlvmBuilder.Alignment.fromByteUnits(@sizeOf(usize)), "") catch return error.OutOfMemory;
     }
 
     fn scalarType(self: *MonoLlvmCodeGen, layout_idx: layout.Idx) LlvmBuilder.Type {
@@ -2612,13 +2612,13 @@ pub const MonoLlvmCodeGen = struct {
 
     fn loadScalar(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, layout_idx: layout.Idx) Error!LlvmBuilder.Value {
         const wip = self.wip orelse return error.CompilationFailed;
-        return wip.load(.normal, self.scalarType(layout_idx), ptr, self.alignmentForLayout(layout_idx), "") catch return error.CompilationFailed;
+        return wip.load(.normal, self.scalarType(layout_idx), ptr, self.alignmentForLayout(layout_idx), "") catch return error.OutOfMemory;
     }
 
     fn storeScalar(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, layout_idx: layout.Idx, value: LlvmBuilder.Value) Error!void {
         const wip = self.wip orelse return error.CompilationFailed;
         const store_value = try self.coerceScalar(value, self.scalarType(layout_idx), layout_idx.isSigned());
-        _ = wip.store(.normal, store_value, ptr, self.alignmentForLayout(layout_idx)) catch return error.CompilationFailed;
+        _ = wip.store(.normal, store_value, ptr, self.alignmentForLayout(layout_idx)) catch return error.OutOfMemory;
     }
 
     fn storeIntToLayout(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, value: LlvmBuilder.Value, layout_idx: layout.Idx) Error!void {
@@ -2648,20 +2648,20 @@ pub const MonoLlvmCodeGen = struct {
         const wip = self.wip orelse return error.CompilationFailed;
         const value_ty = value.typeOfWip(wip);
         if (value_ty == target_ty) return value;
-        return wip.conv(if (signed) .signed else .unsigned, value, target_ty, "") catch return error.CompilationFailed;
+        return wip.conv(if (signed) .signed else .unsigned, value, target_ty, "") catch return error.OutOfMemory;
     }
 
     fn loadBool(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value) Error!LlvmBuilder.Value {
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
-        const byte = wip.load(.normal, .i8, ptr, LlvmBuilder.Alignment.fromByteUnits(1), "") catch return error.CompilationFailed;
-        return wip.icmp(.ne, byte, builder.intValue(.i8, 0) catch return error.OutOfMemory, "") catch return error.CompilationFailed;
+        const byte = wip.load(.normal, .i8, ptr, LlvmBuilder.Alignment.fromByteUnits(1), "") catch return error.OutOfMemory;
+        return wip.icmp(.ne, byte, builder.intValue(.i8, 0) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
     }
 
     fn storeBool(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, cond: LlvmBuilder.Value) Error!void {
         const wip = self.wip orelse return error.CompilationFailed;
         const byte = try self.coerceScalar(cond, .i8, false);
-        _ = wip.store(.normal, byte, ptr, LlvmBuilder.Alignment.fromByteUnits(1)) catch return error.CompilationFailed;
+        _ = wip.store(.normal, byte, ptr, LlvmBuilder.Alignment.fromByteUnits(1)) catch return error.OutOfMemory;
     }
 
     fn readSwitchValue(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, layout_idx: layout.Idx) Error!LlvmBuilder.Value {
@@ -2685,7 +2685,7 @@ pub const MonoLlvmCodeGen = struct {
         if (data.discriminant_size == 0) return builder.intValue(.i64, 0) catch return error.OutOfMemory;
         const disc_ptr = try self.offsetPtr(ptr, data.discriminant_offset);
         const ty = intTypeForBytes(data.discriminant_size);
-        const raw = wip.load(.normal, ty, disc_ptr, LlvmBuilder.Alignment.fromByteUnits(@max(data.discriminant_size, 1)), "") catch return error.CompilationFailed;
+        const raw = wip.load(.normal, ty, disc_ptr, LlvmBuilder.Alignment.fromByteUnits(@max(data.discriminant_size, 1)), "") catch return error.OutOfMemory;
         return self.coerceScalar(raw, .i64, false);
     }
 
@@ -2705,7 +2705,7 @@ pub const MonoLlvmCodeGen = struct {
         if (data.discriminant_size == 0) return;
         const disc_ptr = try self.offsetPtr(ptr, data.discriminant_offset);
         const ty = intTypeForBytes(data.discriminant_size);
-        _ = wip.store(.normal, builder.intValue(ty, discriminant) catch return error.OutOfMemory, disc_ptr, LlvmBuilder.Alignment.fromByteUnits(@max(data.discriminant_size, 1))) catch return error.CompilationFailed;
+        _ = wip.store(.normal, builder.intValue(ty, discriminant) catch return error.OutOfMemory, disc_ptr, LlvmBuilder.Alignment.fromByteUnits(@max(data.discriminant_size, 1))) catch return error.OutOfMemory;
     }
 
     fn tagPayloadLayout(self: *MonoLlvmCodeGen, layout_idx: layout.Idx, discriminant: u16) layout.Idx {
@@ -2933,7 +2933,7 @@ pub const MonoLlvmCodeGen = struct {
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
         const size = try self.argBufferSize(arg_layouts, rounded_slots);
-        const ptr = wip.alloca(.normal, .i8, builder.intValue(.i32, size) catch return error.OutOfMemory, LlvmBuilder.Alignment.fromByteUnits(16), .default, "args") catch return error.CompilationFailed;
+        const ptr = wip.alloca(.normal, .i8, builder.intValue(.i32, size) catch return error.OutOfMemory, LlvmBuilder.Alignment.fromByteUnits(16), .default, "args") catch return error.OutOfMemory;
         try self.zeroBytes(ptr, size);
         return ptr;
     }
@@ -2948,7 +2948,7 @@ pub const MonoLlvmCodeGen = struct {
             total += sa.size;
         }
         total = @max(total, 8);
-        const ptr = wip.alloca(.normal, .i8, builder.intValue(.i32, total) catch return error.OutOfMemory, LlvmBuilder.Alignment.fromByteUnits(16), .default, "host_args") catch return error.CompilationFailed;
+        const ptr = wip.alloca(.normal, .i8, builder.intValue(.i32, total) catch return error.OutOfMemory, LlvmBuilder.Alignment.fromByteUnits(16), .default, "host_args") catch return error.OutOfMemory;
         try self.zeroBytes(ptr, total);
         return ptr;
     }
@@ -2996,7 +2996,7 @@ pub const MonoLlvmCodeGen = struct {
         const fn_ptr_ptr = try self.offsetPtr(table_ptr, dispatch_index * @as(u32, @intCast(@sizeOf(builtins.host_abi.HostedFn))));
         const fn_ptr = try self.loadPointer(fn_ptr_ptr);
         const fn_ty = builder.fnType(.void, &.{ ptr_ty, ptr_ty, ptr_ty }, .normal) catch return error.OutOfMemory;
-        _ = wip.call(.normal, .ccc, .none, fn_ty, fn_ptr, &.{ self.rocOps(), ret_ptr, args_ptr }, "") catch return error.CompilationFailed;
+        _ = wip.call(.normal, .ccc, .none, fn_ty, fn_ptr, &.{ self.rocOps(), ret_ptr, args_ptr }, "") catch return error.OutOfMemory;
     }
 
     fn callBuiltin(
@@ -3009,7 +3009,7 @@ pub const MonoLlvmCodeGen = struct {
         const wip = self.wip orelse return error.CompilationFailed;
         const builder = self.builder orelse return error.CompilationFailed;
         const func = try self.declareBuiltin(name, ret_type, param_types);
-        return wip.call(.normal, .ccc, .none, func.typeOf(builder), func.toValue(builder), args, "") catch return error.CompilationFailed;
+        return wip.call(.normal, .ccc, .none, func.typeOf(builder), func.toValue(builder), args, "") catch return error.OutOfMemory;
     }
 
     fn callBuiltinVoid(self: *MonoLlvmCodeGen, name: []const u8, param_types: []const LlvmBuilder.Type, args: []const LlvmBuilder.Value) Error!void {
@@ -3032,7 +3032,7 @@ pub const MonoLlvmCodeGen = struct {
     fn callFunctionIndex(self: *MonoLlvmCodeGen, func: LlvmBuilder.Function.Index, args: []const LlvmBuilder.Value) Error!LlvmBuilder.Value {
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
-        return wip.call(.normal, .ccc, .none, func.typeOf(builder), func.toValue(builder), args, "") catch return error.CompilationFailed;
+        return wip.call(.normal, .ccc, .none, func.typeOf(builder), func.toValue(builder), args, "") catch return error.OutOfMemory;
     }
 
     fn currentBlockHasTerminator(self: *const MonoLlvmCodeGen) bool {
@@ -3048,7 +3048,7 @@ pub const MonoLlvmCodeGen = struct {
         for (wip.blocks.items, 0..) |*block, block_idx| {
             if (block.instructions.items.len == 0 or !block.instructions.items[block.instructions.items.len - 1].isTerminatorWip(wip)) {
                 wip.cursor = .{ .block = @enumFromInt(block_idx) };
-                _ = wip.@"unreachable"() catch return error.CompilationFailed;
+                _ = wip.@"unreachable"() catch return error.OutOfMemory;
             }
         }
 
@@ -3062,7 +3062,7 @@ pub const MonoLlvmCodeGen = struct {
             block.incoming = block.branches;
         }
 
-        wip.finish() catch return error.CompilationFailed;
+        wip.finish() catch return error.OutOfMemory;
     }
 
     fn intBits(_: *MonoLlvmCodeGen, layout_idx: layout.Idx) u32 {

--- a/src/backend/wasm/WasmModule.zig
+++ b/src/backend/wasm/WasmModule.zig
@@ -5381,21 +5381,21 @@ test "preload + merge + encode roundtrip with real builtins" {
     app_module.enableMemory(2);
     app_module.enableStackPointer(131072);
     app_module.enableTable();
-    app_module.addExport("memory", .memory, 0) catch unreachable;
+    try app_module.addExport("memory", .memory, 0);
 
     // Add RocCall function: (i32, i32, i32) -> void
     const roc_call_type_idx = try app_module.addFuncType(&.{ .i32, .i32, .i32 }, &.{});
     const roc_call_fn_idx = try app_module.addFunction(roc_call_type_idx);
     const roc_call_body = [_]u8{ 0x00, Op.end };
     try app_module.setFunctionBody(roc_call_fn_idx, &roc_call_body);
-    app_module.addExport("roc__main_for_host_1_exposed", .func, roc_call_fn_idx) catch unreachable;
+    try app_module.addExport("roc__main_for_host_1_exposed", .func, roc_call_fn_idx);
 
     // Add eval wrapper: (i32) -> i32
     const eval_type_idx = try app_module.addFuncType(&.{.i32}, &.{.i32});
     const eval_fn_idx = try app_module.addFunction(eval_type_idx);
     const eval_body = [_]u8{ 0x00, Op.i32_const, 42, Op.end };
     try app_module.setFunctionBody(eval_fn_idx, &eval_body);
-    app_module.addExport("main", .func, eval_fn_idx) catch unreachable;
+    try app_module.addExport("main", .func, eval_fn_idx);
 
     // Encode the module
     const encoded = try app_module.encode(allocator);

--- a/src/backend/wasm/WasmModule.zig
+++ b/src/backend/wasm/WasmModule.zig
@@ -1477,7 +1477,7 @@ pub fn resolveCodeRelocations(self: *Self) void {
 }
 
 /// Resolve all data relocations in place.
-pub fn resolveDataRelocations(self: *Self) void {
+pub fn resolveDataRelocations(self: *Self) Allocator.Error!void {
     // First pass: ensure functions referenced by table_index_* relocations
     // are present in the element section. This is needed because data segments
     // can store function pointers (e.g. hosted_function_ptrs) which need valid
@@ -1491,7 +1491,7 @@ pub fn resolveDataRelocations(self: *Self) void {
                 {
                     const sym = self.linking.symbol_table.items[idx.symbol_index];
                     if (sym.isFunction()) {
-                        _ = self.ensureTableElement(sym.index) catch continue;
+                        _ = try self.ensureTableElement(sym.index);
                     }
                 }
             },
@@ -1514,9 +1514,9 @@ pub fn resolveDataRelocations(self: *Self) void {
 }
 
 /// Resolve both code and data relocations in place.
-pub fn resolveRelocations(self: *Self) void {
+pub fn resolveRelocations(self: *Self) Allocator.Error!void {
     self.resolveCodeRelocations();
-    self.resolveDataRelocations();
+    try self.resolveDataRelocations();
 }
 
 /// Transfer function bodies added via setFunctionBody into the code_bytes
@@ -1866,7 +1866,7 @@ fn traceLiveFunctions(
 /// symbols with `binding=global vis=default`, but no Export section exists.
 /// This must be called after preload so that the surgical linker pipeline can
 /// see and preserve these exports.
-pub fn exportGlobalSymbols(self: *Self) void {
+pub fn exportGlobalSymbols(self: *Self) Allocator.Error!void {
     for (self.linking.symbol_table.items) |sym| {
         if (sym.kind != .function or sym.isUndefined() or sym.isLocal()) continue;
         if ((sym.flags & WasmLinking.SymFlag.VISIBILITY_HIDDEN) != 0) continue;
@@ -1882,7 +1882,7 @@ pub fn exportGlobalSymbols(self: *Self) void {
             }
         }
         if (!already_exported) {
-            self.addExport(name, .func, sym.index) catch {};
+            try self.addExport(name, .func, sym.index);
         }
     }
 }
@@ -4453,7 +4453,7 @@ test "mergeModule + resolveDataRelocations — patches merged data segment bytes
     try std.testing.expectEqual(@as(usize, 3), host.data_segments.items.len);
     try std.testing.expectEqual(@as(usize, 1), host.reloc_data.entries.items.len);
 
-    host.resolveDataRelocations();
+    try host.resolveDataRelocations();
 
     const patch_segment = host.data_segments.items[1];
     const target_segment = host.data_segments.items[2];
@@ -5374,7 +5374,7 @@ test "preload + merge + encode roundtrip with real builtins" {
     _ = try BuiltinSymbols.populate(&app_module);
 
     // Resolve relocations and materialize function bodies
-    app_module.resolveRelocations();
+    try app_module.resolveRelocations();
     try app_module.materializeFuncBodies();
 
     // Enable memory + stack pointer + table (as generateModule does)

--- a/src/bundle/download.zig
+++ b/src/bundle/download.zig
@@ -90,7 +90,10 @@ pub fn download(
     var request = client.request(.GET, uri, .{
         .redirect_behavior = .unhandled,
         .extra_headers = extra_headers,
-    }) catch return error.HttpError;
+    }) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.HttpError,
+    };
     defer request.deinit();
 
     // Send just the request head (no body)
@@ -98,7 +101,10 @@ pub fn download(
 
     // Receive headers into a temporary buffer
     var head_buffer: [SERVER_HEADER_BUFFER_SIZE]u8 = undefined;
-    var response = request.receiveHead(&head_buffer) catch return error.HttpError;
+    var response = request.receiveHead(&head_buffer) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.HttpError,
+    };
 
     // Check response status
     if (response.head.status != .ok) {

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -10917,8 +10917,9 @@ const EnvPool = struct {
 
         var releasable_env = env;
         releasable_env.reset(.generalized) catch {
-            // If we can't add to the pool, just deinit this env
+            // If we can't reset the env, deinit it and don't return it to the pool
             releasable_env.deinit(self.gpa);
+            return;
         };
         self.available.append(self.gpa, releasable_env) catch {
             // If we can't add to the pool, just deinit this env

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -15274,7 +15274,7 @@ pub const CheckedModuleArtifact = struct {
         }
     }
 
-    pub fn verifyComplete(self: *const CheckedModuleArtifact) void {
+    pub fn verifyComplete(self: *const CheckedModuleArtifact) Allocator.Error!void {
         if (builtin.mode != .Debug) return;
 
         std.debug.assert(self.module_identity.module_idx != std.math.maxInt(u32));
@@ -15675,7 +15675,7 @@ pub const CheckedModuleArtifact = struct {
         }
 
         self.const_templates.verifySealed();
-        self.const_store.verifyComplete();
+        try self.const_store.verifyComplete();
         self.interface_capabilities.verifyComplete();
         for (self.resolved_value_refs.records) |record| {
             std.debug.assert(@intFromEnum(record.expr) < self.checked_bodies.exprs.len);
@@ -17423,7 +17423,7 @@ pub fn publishFromTypedModule(
         inputs.relation_artifacts,
         inputs.problem_store,
     );
-    artifact.verifyComplete();
+    try artifact.verifyComplete();
     return artifact;
 }
 

--- a/src/check/const_store.zig
+++ b/src/check/const_store.zig
@@ -172,7 +172,7 @@ pub const ConstStore = struct {
         return backing[offset..][0..len];
     }
 
-    pub fn verifyComplete(self: *const ConstStore) void {
+    pub fn verifyComplete(self: *const ConstStore) Allocator.Error!void {
         if (@import("builtin").mode != .Debug) return;
         for (self.values.items) |value| {
             switch (value) {
@@ -180,15 +180,11 @@ pub const ConstStore = struct {
                 else => {},
             }
         }
-        const value_state = self.allocator.alloc(VisitState, self.values.items.len) catch |err| switch (err) {
-            error.OutOfMemory => @panic("OOM"),
-        };
+        const value_state = try self.allocator.alloc(VisitState, self.values.items.len);
         defer self.allocator.free(value_state);
         @memset(value_state, .unseen);
 
-        const fn_state = self.allocator.alloc(VisitState, self.fns.items.len) catch |err| switch (err) {
-            error.OutOfMemory => @panic("OOM"),
-        };
+        const fn_state = try self.allocator.alloc(VisitState, self.fns.items.len);
         defer self.allocator.free(fn_state);
         @memset(fn_state, .unseen);
 

--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -471,7 +471,7 @@ pub const ReportBuilder = struct {
         }
 
         // Generate and print type comparison hints
-        const diff_hints = diff.compareTypes(
+        const diff_hints = try diff.compareTypes(
             self.snapshots,
             self.module_env.getIdentStoreConst(),
             expected_snapshot,

--- a/src/check/snapshot/diff.zig
+++ b/src/check/snapshot/diff.zig
@@ -239,7 +239,7 @@ pub fn compareTypes(
     gpa: Allocator,
     fields: *SnapshotRecordFieldSafeList,
     tags: *SnapshotTagSafeList,
-) HintList {
+) Allocator.Error!HintList {
     const trace = tracy.trace(@src());
     defer trace.end();
 
@@ -253,21 +253,21 @@ pub fn compareTypes(
     switch (expected) {
         .structure => |exp_flat| switch (actual) {
             .structure => |act_flat| {
-                compareStructures(snap_store, ident_store, exp_flat, act_flat, &hints, gpa, fields, tags);
+                try compareStructures(snap_store, ident_store, exp_flat, act_flat, &hints, gpa, fields, tags);
             },
             else => {},
         },
         .alias => |exp_alias| switch (actual) {
             .alias => |act_alias| {
                 // Compare the backing types of aliases
-                compareTypesInternal(snap_store, ident_store, exp_alias.backing, act_alias.backing, &hints, gpa, fields, tags);
+                try compareTypesInternal(snap_store, ident_store, exp_alias.backing, act_alias.backing, &hints, gpa, fields, tags);
             },
             .structure => |act_flat| {
                 // Compare alias backing with structure
                 const exp_backing = snap_store.getContent(exp_alias.backing);
                 switch (exp_backing) {
                     .structure => |exp_flat| {
-                        compareStructures(snap_store, ident_store, exp_flat, act_flat, &hints, gpa, fields, tags);
+                        try compareStructures(snap_store, ident_store, exp_flat, act_flat, &hints, gpa, fields, tags);
                     },
                     else => {},
                 }
@@ -290,26 +290,26 @@ fn compareTypesInternal(
     gpa: Allocator,
     fields: *SnapshotRecordFieldSafeList,
     tags: *SnapshotTagSafeList,
-) void {
+) Allocator.Error!void {
     const expected = snap_store.getContent(expected_idx);
     const actual = snap_store.getContent(actual_idx);
 
     switch (expected) {
         .structure => |exp_flat| switch (actual) {
             .structure => |act_flat| {
-                compareStructures(snap_store, ident_store, exp_flat, act_flat, hints, gpa, fields, tags);
+                try compareStructures(snap_store, ident_store, exp_flat, act_flat, hints, gpa, fields, tags);
             },
             else => {},
         },
         .alias => |exp_alias| switch (actual) {
             .alias => |act_alias| {
-                compareTypesInternal(snap_store, ident_store, exp_alias.backing, act_alias.backing, hints, gpa, fields, tags);
+                try compareTypesInternal(snap_store, ident_store, exp_alias.backing, act_alias.backing, hints, gpa, fields, tags);
             },
             .structure => |act_flat| {
                 const exp_backing = snap_store.getContent(exp_alias.backing);
                 switch (exp_backing) {
                     .structure => |exp_flat| {
-                        compareStructures(snap_store, ident_store, exp_flat, act_flat, hints, gpa, fields, tags);
+                        try compareStructures(snap_store, ident_store, exp_flat, act_flat, hints, gpa, fields, tags);
                     },
                     else => {},
                 }
@@ -329,7 +329,7 @@ fn compareStructures(
     gpa: Allocator,
     fields: *SnapshotRecordFieldSafeList,
     tags: *SnapshotTagSafeList,
-) void {
+) Allocator.Error!void {
     switch (expected) {
         .fn_pure => |exp_func| {
             switch (actual) {
@@ -374,20 +374,20 @@ fn compareStructures(
         .record => |exp_record| {
             switch (actual) {
                 .record => |act_record| {
-                    compareRecords(snap_store, ident_store, exp_record, act_record, hints, gpa, fields);
+                    try compareRecords(snap_store, ident_store, exp_record, act_record, hints, gpa, fields);
                 },
                 .record_unbound => |act_fields_range| {
                     // Gather expected fields (with extensions), actual is just immediate fields
-                    const exp_range = gatherFieldsFromRecord(snap_store, exp_record, gpa, fields);
+                    const exp_range = try gatherFieldsFromRecord(snap_store, exp_record, gpa, fields);
                     const exp_names = fields.sliceRange(exp_range).items(.name);
                     const act_names = snap_store.sliceRecordFields(act_fields_range).items(.name);
-                    compareFieldNames(ident_store, exp_names, act_names, hints, gpa, fields);
+                    try compareFieldNames(ident_store, exp_names, act_names, hints, gpa, fields);
                 },
                 .empty_record => {
                     // Actual is empty but expected has fields - gather all missing
-                    const exp_range = gatherFieldsFromRecord(snap_store, exp_record, gpa, fields);
+                    const exp_range = try gatherFieldsFromRecord(snap_store, exp_record, gpa, fields);
                     const exp_names = fields.sliceRange(exp_range).items(.name);
-                    addMissingFields(exp_names, hints, gpa, fields);
+                    try addMissingFields(exp_names, hints, gpa, fields);
                 },
                 else => {},
             }
@@ -397,19 +397,19 @@ fn compareStructures(
                 .record => |act_record| {
                     // Expected is just immediate fields, gather actual (with extensions)
                     const exp_names = snap_store.sliceRecordFields(exp_fields_range).items(.name);
-                    const act_range = gatherFieldsFromRecord(snap_store, act_record, gpa, fields);
+                    const act_range = try gatherFieldsFromRecord(snap_store, act_record, gpa, fields);
                     const act_names = fields.sliceRange(act_range).items(.name);
-                    compareFieldNames(ident_store, exp_names, act_names, hints, gpa, fields);
+                    try compareFieldNames(ident_store, exp_names, act_names, hints, gpa, fields);
                 },
                 .record_unbound => |act_fields_range| {
                     // Both are just immediate fields, no extensions
                     const exp_names = snap_store.sliceRecordFields(exp_fields_range).items(.name);
                     const act_names = snap_store.sliceRecordFields(act_fields_range).items(.name);
-                    compareFieldNames(ident_store, exp_names, act_names, hints, gpa, fields);
+                    try compareFieldNames(ident_store, exp_names, act_names, hints, gpa, fields);
                 },
                 .empty_record => {
                     const exp_names = snap_store.sliceRecordFields(exp_fields_range).items(.name);
-                    addMissingFields(exp_names, hints, gpa, fields);
+                    try addMissingFields(exp_names, hints, gpa, fields);
                 },
                 else => {},
             }
@@ -417,7 +417,7 @@ fn compareStructures(
         .tag_union => |exp_union| {
             switch (actual) {
                 .tag_union => |act_union| {
-                    compareTagUnions(snap_store, ident_store, exp_union, act_union, hints, gpa, tags);
+                    try compareTagUnions(snap_store, ident_store, exp_union, act_union, hints, gpa, tags);
                 },
                 else => {},
             }
@@ -450,16 +450,16 @@ fn compareRecords(
     hints: *HintList,
     gpa: Allocator,
     fields: *SnapshotRecordFieldSafeList,
-) void {
+) Allocator.Error!void {
     // Gather ALL fields from expected (including extensions)
-    const exp_range = gatherFieldsFromRecord(snap_store, exp_record, gpa, fields);
+    const exp_range = try gatherFieldsFromRecord(snap_store, exp_record, gpa, fields);
     const exp_names = fields.sliceRange(exp_range).items(.name);
 
     // Gather ALL fields from actual (including extensions)
-    const act_range = gatherFieldsFromRecord(snap_store, act_record, gpa, fields);
+    const act_range = try gatherFieldsFromRecord(snap_store, act_record, gpa, fields);
     const act_names = fields.sliceRange(act_range).items(.name);
 
-    compareFieldNames(ident_store, exp_names, act_names, hints, gpa, fields);
+    try compareFieldNames(ident_store, exp_names, act_names, hints, gpa, fields);
 }
 
 /// Gather all fields from a record, following extension chain.
@@ -469,12 +469,12 @@ pub fn gatherFieldsFromRecord(
     record: snapshot.SnapshotRecord,
     gpa: Allocator,
     fields: *SnapshotRecordFieldSafeList,
-) SnapshotRecordFieldSafeList.Range {
+) Allocator.Error!SnapshotRecordFieldSafeList.Range {
     const trace = tracy.trace(@src());
     defer trace.end();
 
     const start: u32 = fields.len();
-    snap_store.gatherRecordFieldsHelp(record, gpa, fields) catch {};
+    try snap_store.gatherRecordFieldsHelp(record, gpa, fields);
     return fields.rangeToEnd(start);
 }
 
@@ -486,7 +486,7 @@ fn compareFieldNames(
     hints: *HintList,
     gpa: Allocator,
     fields: *SnapshotRecordFieldSafeList,
-) void {
+) Allocator.Error!void {
     // Track where missing fields start in buffer
     const start_idx: u32 = fields.len();
 
@@ -509,7 +509,7 @@ fn compareFieldNames(
                 } });
             } else {
                 // No typo found, add to missing fields (with placeholder content)
-                _ = fields.append(gpa, .{ .name = exp_name_idx, .content = .first }) catch {};
+                _ = try fields.append(gpa, .{ .name = exp_name_idx, .content = .first });
             }
         }
     }
@@ -529,12 +529,12 @@ fn addMissingFields(
     hints: *HintList,
     gpa: Allocator,
     fields: *SnapshotRecordFieldSafeList,
-) void {
+) Allocator.Error!void {
     if (exp_names.len == 0) return;
 
     const start_idx: u32 = fields.len();
     for (exp_names) |name| {
-        _ = fields.append(gpa, .{ .name = name, .content = .first }) catch {};
+        _ = try fields.append(gpa, .{ .name = name, .content = .first });
     }
 
     hints.append(.{ .fields_missing = .{
@@ -550,14 +550,14 @@ fn compareTagUnions(
     hints: *HintList,
     gpa: Allocator,
     tags: *SnapshotTagSafeList,
-) void {
+) Allocator.Error!void {
     // Gather ALL tags from expected (including extensions)
-    const exp_gathered = gatherTagsFromUnion(snap_store, exp_union, gpa, tags);
+    const exp_gathered = try gatherTagsFromUnion(snap_store, exp_union, gpa, tags);
     const exp_range = exp_gathered.fields;
     const exp_tag_names = tags.sliceRange(exp_range).items(.name);
 
     // Gather ALL tags from actual (including extensions)
-    const act_gathered = gatherTagsFromUnion(snap_store, act_union, gpa, tags);
+    const act_gathered = try gatherTagsFromUnion(snap_store, act_union, gpa, tags);
     const act_range = act_gathered.fields;
     const act_tag_names = tags.sliceRange(act_range).items(.name);
 
@@ -626,13 +626,13 @@ fn gatherTagsFromUnion(
     union_: snapshot.SnapshotTagUnion,
     gpa: Allocator,
     tags: *SnapshotTagSafeList,
-) struct { fields: SnapshotTagSafeList.Range, ext: TagExt } {
+) Allocator.Error!struct { fields: SnapshotTagSafeList.Range, ext: TagExt } {
     const start: u32 = tags.len();
 
     // Add immediate tags
     const union_tags = snap_store.sliceTags(union_.tags);
     for (union_tags.items(.name), union_tags.items(.args), union_tags.items(.formatted)) |name, args, formatted| {
-        _ = tags.append(gpa, .{ .name = name, .args = args, .formatted = formatted }) catch {};
+        _ = try tags.append(gpa, .{ .name = name, .args = args, .formatted = formatted });
     }
 
     var ext: TagExt = .other;
@@ -646,7 +646,7 @@ fn gatherTagsFromUnion(
                 .tag_union => |ext_union| {
                     const ext_tags = snap_store.sliceTags(ext_union.tags);
                     for (ext_tags.items(.name), ext_tags.items(.args), ext_tags.items(.formatted)) |name, args, formatted| {
-                        _ = tags.append(gpa, .{ .name = name, .args = args, .formatted = formatted }) catch {};
+                        _ = try tags.append(gpa, .{ .name = name, .args = args, .formatted = formatted });
                     }
                     ext_idx = ext_union.ext;
                 },

--- a/src/cli/builder.zig
+++ b/src/cli/builder.zig
@@ -175,7 +175,7 @@ pub fn initializeLLVM() void {
 /// Compile LLVM bitcode file to object file
 pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileConfig) !bool {
     if (comptime !llvm_available) {
-        renderLLVMNotAvailableError(gpa);
+        try renderLLVMNotAvailableError(gpa);
         return error.LLVMNotAvailable;
     }
 
@@ -189,7 +189,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
 
     // Verify input file exists
     std.Io.Dir.cwd().access(std_io, config.input_path, .{}) catch |err| {
-        renderFileNotAccessibleError(gpa, config.input_path, err);
+        try renderFileNotAccessibleError(gpa, config.input_path, err);
         return false;
     };
 
@@ -207,7 +207,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
     defer gpa.free(bitcode_path_z);
 
     if (externs.LLVMCreateMemoryBufferWithContentsOfFile(bitcode_path_z.ptr, &mem_buf, &error_message) != 0) {
-        renderLLVMError(gpa, "BITCODE LOAD ERROR", "Failed to load bitcode file", std.mem.span(error_message));
+        try renderLLVMError(gpa, "BITCODE LOAD ERROR", "Failed to load bitcode file", std.mem.span(error_message));
         externs.LLVMDisposeMessage(error_message);
         return false;
     }
@@ -218,7 +218,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
     std.log.debug("Parsing bitcode into LLVM module...", .{});
     var module: ?*anyopaque = null;
     if (externs.LLVMParseBitcode(mem_buf, &module, &error_message) != 0) {
-        renderLLVMError(gpa, "BITCODE PARSE ERROR", "Failed to parse bitcode", std.mem.span(error_message));
+        try renderLLVMError(gpa, "BITCODE PARSE ERROR", "Failed to parse bitcode", std.mem.span(error_message));
         externs.LLVMDisposeMessage(error_message);
         return false;
     }
@@ -238,7 +238,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
     std.log.debug("Getting LLVM target for triple: {s}", .{target_triple});
     var llvm_target: ?*anyopaque = null;
     if (externs.LLVMGetTargetFromTriple(target_triple_z.ptr, &llvm_target, &error_message) != 0) {
-        renderTargetError(gpa, target_triple, std.mem.span(error_message));
+        try renderTargetError(gpa, target_triple, std.mem.span(error_message));
         externs.LLVMDisposeMessage(error_message);
         return false;
     }
@@ -266,7 +266,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
         false, // emulated_tls
     );
     if (target_machine == null) {
-        renderTargetMachineError(gpa, target_triple, config.cpu, config.features);
+        try renderTargetMachineError(gpa, target_triple, config.cpu, config.features);
         return false;
     }
     defer externs.LLVMDisposeTargetMachine(target_machine);
@@ -308,7 +308,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
     );
 
     if (emit_result) {
-        renderEmitError(gpa, config.output_path, std.mem.span(emit_error_message));
+        try renderEmitError(gpa, config.output_path, std.mem.span(emit_error_message));
         externs.LLVMDisposeMessage(emit_error_message);
         return false;
     }
@@ -324,17 +324,17 @@ pub fn isLLVMAvailable() bool {
 
 // --- Error Reporting Helpers ---
 
-fn renderLLVMNotAvailableError(allocator: Allocator) void {
+fn renderLLVMNotAvailableError(allocator: Allocator) Allocator.Error!void {
     var report = reporting.Report.init(allocator, "LLVM NOT AVAILABLE", .fatal);
     defer report.deinit();
 
-    report.document.addText("LLVM is not available at compile time.") catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("This binary was built without LLVM support.") catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("To use this feature, rebuild roc with LLVM enabled.") catch return;
-    report.document.addLineBreak() catch return;
+    try report.document.addText("LLVM is not available at compile time.");
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("This binary was built without LLVM support.");
+    try report.document.addLineBreak();
+    try report.document.addText("To use this feature, rebuild roc with LLVM enabled.");
+    try report.document.addLineBreak();
 
     reporting.renderReportToTerminal(
         &report,
@@ -344,20 +344,20 @@ fn renderLLVMNotAvailableError(allocator: Allocator) void {
     ) catch {};
 }
 
-fn renderFileNotAccessibleError(allocator: Allocator, path: []const u8, err: anyerror) void {
+fn renderFileNotAccessibleError(allocator: Allocator, path: []const u8, err: anyerror) Allocator.Error!void {
     var report = reporting.Report.init(allocator, "FILE NOT ACCESSIBLE", .fatal);
     defer report.deinit();
 
-    report.document.addText("Input bitcode file does not exist or is not accessible:") catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("    ") catch return;
-    report.document.addAnnotated(path, .path) catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("Error: ") catch return;
-    report.document.addAnnotated(@errorName(err), .error_highlight) catch return;
-    report.document.addLineBreak() catch return;
+    try report.document.addText("Input bitcode file does not exist or is not accessible:");
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("    ");
+    try report.document.addAnnotated(path, .path);
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("Error: ");
+    try report.document.addAnnotated(@errorName(err), .error_highlight);
+    try report.document.addLineBreak();
 
     reporting.renderReportToTerminal(
         &report,
@@ -367,16 +367,16 @@ fn renderFileNotAccessibleError(allocator: Allocator, path: []const u8, err: any
     ) catch {};
 }
 
-fn renderLLVMError(allocator: Allocator, title: []const u8, message: []const u8, llvm_message: []const u8) void {
+fn renderLLVMError(allocator: Allocator, title: []const u8, message: []const u8, llvm_message: []const u8) Allocator.Error!void {
     var report = reporting.Report.init(allocator, title, .fatal);
     defer report.deinit();
 
-    report.document.addText(message) catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("LLVM error: ") catch return;
-    report.document.addAnnotated(llvm_message, .error_highlight) catch return;
-    report.document.addLineBreak() catch return;
+    try report.document.addText(message);
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("LLVM error: ");
+    try report.document.addAnnotated(llvm_message, .error_highlight);
+    try report.document.addLineBreak();
 
     reporting.renderReportToTerminal(
         &report,
@@ -386,20 +386,20 @@ fn renderLLVMError(allocator: Allocator, title: []const u8, message: []const u8,
     ) catch {};
 }
 
-fn renderTargetError(allocator: Allocator, triple: []const u8, llvm_message: []const u8) void {
+fn renderTargetError(allocator: Allocator, triple: []const u8, llvm_message: []const u8) Allocator.Error!void {
     var report = reporting.Report.init(allocator, "INVALID TARGET", .fatal);
     defer report.deinit();
 
-    report.document.addText("Failed to get LLVM target for triple:") catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("    ") catch return;
-    report.document.addAnnotated(triple, .emphasized) catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("LLVM error: ") catch return;
-    report.document.addAnnotated(llvm_message, .error_highlight) catch return;
-    report.document.addLineBreak() catch return;
+    try report.document.addText("Failed to get LLVM target for triple:");
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("    ");
+    try report.document.addAnnotated(triple, .emphasized);
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("LLVM error: ");
+    try report.document.addAnnotated(llvm_message, .error_highlight);
+    try report.document.addLineBreak();
 
     reporting.renderReportToTerminal(
         &report,
@@ -409,33 +409,33 @@ fn renderTargetError(allocator: Allocator, triple: []const u8, llvm_message: []c
     ) catch {};
 }
 
-fn renderTargetMachineError(allocator: Allocator, triple: []const u8, cpu: []const u8, features: []const u8) void {
+fn renderTargetMachineError(allocator: Allocator, triple: []const u8, cpu: []const u8, features: []const u8) Allocator.Error!void {
     var report = reporting.Report.init(allocator, "TARGET MACHINE ERROR", .fatal);
     defer report.deinit();
 
-    report.document.addText("Failed to create LLVM target machine with configuration:") catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("    Triple:   ") catch return;
-    report.document.addAnnotated(triple, .emphasized) catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("    CPU:      ") catch return;
+    try report.document.addText("Failed to create LLVM target machine with configuration:");
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("    Triple:   ");
+    try report.document.addAnnotated(triple, .emphasized);
+    try report.document.addLineBreak();
+    try report.document.addText("    CPU:      ");
     if (cpu.len > 0) {
-        report.document.addAnnotated(cpu, .emphasized) catch return;
+        try report.document.addAnnotated(cpu, .emphasized);
     } else {
-        report.document.addText("(default)") catch return;
+        try report.document.addText("(default)");
     }
-    report.document.addLineBreak() catch return;
-    report.document.addText("    Features: ") catch return;
+    try report.document.addLineBreak();
+    try report.document.addText("    Features: ");
     if (features.len > 0) {
-        report.document.addAnnotated(features, .emphasized) catch return;
+        try report.document.addAnnotated(features, .emphasized);
     } else {
-        report.document.addText("(default)") catch return;
+        try report.document.addText("(default)");
     }
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("This may indicate an unsupported target configuration.") catch return;
-    report.document.addLineBreak() catch return;
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("This may indicate an unsupported target configuration.");
+    try report.document.addLineBreak();
 
     reporting.renderReportToTerminal(
         &report,
@@ -445,20 +445,20 @@ fn renderTargetMachineError(allocator: Allocator, triple: []const u8, cpu: []con
     ) catch {};
 }
 
-fn renderEmitError(allocator: Allocator, output_path: []const u8, llvm_message: []const u8) void {
+fn renderEmitError(allocator: Allocator, output_path: []const u8, llvm_message: []const u8) Allocator.Error!void {
     var report = reporting.Report.init(allocator, "OBJECT FILE EMIT ERROR", .fatal);
     defer report.deinit();
 
-    report.document.addText("Failed to emit object file:") catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("    Output: ") catch return;
-    report.document.addAnnotated(output_path, .path) catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("LLVM error: ") catch return;
-    report.document.addAnnotated(llvm_message, .error_highlight) catch return;
-    report.document.addLineBreak() catch return;
+    try report.document.addText("Failed to emit object file:");
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("    Output: ");
+    try report.document.addAnnotated(output_path, .path);
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("LLVM error: ");
+    try report.document.addAnnotated(llvm_message, .error_highlight);
+    try report.document.addLineBreak();
 
     reporting.renderReportToTerminal(
         &report,

--- a/src/cli/linker.zig
+++ b/src/cli/linker.zig
@@ -170,15 +170,20 @@ fn findDarwinSysroot(allocator: std.mem.Allocator, std_io: std.Io) ![]const u8 {
 /// Looks for 'macos-sysroot' directory in the platform's files directory.
 /// For example, if platform_files_dir is "/path/to/platform/targets",
 /// this looks for "/path/to/platform/targets/macos-sysroot/".
-fn findPlatformSysroot(allocator: std.mem.Allocator, std_io: std.Io, platform_files_dir: ?[]const u8) ?[]const u8 {
+fn findPlatformSysroot(allocator: std.mem.Allocator, std_io: std.Io, platform_files_dir: ?[]const u8) std.mem.Allocator.Error!?[]const u8 {
     const files_dir = platform_files_dir orelse return null;
 
     // Look for macos-sysroot in the platform files directory
-    const sysroot_path = std.fs.path.join(allocator, &.{ files_dir, "macos-sysroot" }) catch return null;
+    const sysroot_path = try std.fs.path.join(allocator, &.{ files_dir, "macos-sysroot" });
+    errdefer allocator.free(sysroot_path);
 
     // Verify it exists and has the expected structure (usr/lib/libSystem.tbd)
-    const lib_path = std.fs.path.join(allocator, &.{ sysroot_path, "usr", "lib", "libSystem.tbd" }) catch return null;
-    std.Io.Dir.cwd().access(std_io, lib_path, .{}) catch return null;
+    const lib_path = try std.fs.path.join(allocator, &.{ sysroot_path, "usr", "lib", "libSystem.tbd" });
+    defer allocator.free(lib_path);
+    std.Io.Dir.cwd().access(std_io, lib_path, .{}) catch {
+        allocator.free(sysroot_path);
+        return null;
+    };
 
     std.log.info("Using platform-provided macOS sysroot: {s}", .{sysroot_path});
     return sysroot_path;
@@ -291,7 +296,7 @@ fn buildLinkArgs(ctx: *CliCtx, config: LinkConfig) LinkError!std.array_list.Mana
             // Try to find a platform-provided sysroot first (for cross-compilation with bundled frameworks)
             // Falls back to Roc's bundled darwin sysroot (minimal, only has libSystem.tbd)
             try args.append("-syslibroot");
-            if (findPlatformSysroot(ctx.arena, ctx.io.std_io, config.platform_files_dir)) |platform_sysroot| {
+            if (try findPlatformSysroot(ctx.arena, ctx.io.std_io, config.platform_files_dir)) |platform_sysroot| {
                 try args.append(platform_sysroot);
 
                 // Add framework search path to help linker resolve framework dependencies

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1025,7 +1025,7 @@ fn rocRun(ctx: *CliCtx, args: cli_args.RunArgs) !void {
 
     // Check if this is a default_app (headerless file with main!) before
     // linking the platform host shim.
-    if (readDefaultAppSource(ctx, args.path)) |source| {
+    if (try readDefaultAppSource(ctx, args.path)) |source| {
         return rocRunDefaultApp(ctx, args, source);
     }
 
@@ -1396,26 +1396,36 @@ fn classifyNativeRunTermination(term: std.process.Child.Term, warning_count: usi
 /// Check if a file is a default_app (headerless file with a main! function).
 /// On success, returns the file source (caller owns the allocation).
 /// Returns null if the file is not a default_app.
-fn readDefaultAppSource(ctx: *CliCtx, file_path: []const u8) ?[]const u8 {
+fn readDefaultAppSource(ctx: *CliCtx, file_path: []const u8) std.mem.Allocator.Error!?[]const u8 {
     const max_source_size = 256 * 1024 * 1024; // 256 MB
     const source = std.Io.Dir.cwd().readFileAlloc(ctx.io.std_io, file_path, ctx.gpa, .limited(max_source_size)) catch return null;
 
-    const module_name = base.module_path.getModuleNameAlloc(ctx.arena, file_path) catch {
-        ctx.gpa.free(source);
-        return null;
+    const module_name = base.module_path.getModuleNameAlloc(ctx.arena, file_path) catch |err| switch (err) {
+        error.OutOfMemory => {
+            ctx.gpa.free(source);
+            return error.OutOfMemory;
+        },
     };
 
-    var env = ModuleEnv.init(ctx.gpa, source) catch {
-        ctx.gpa.free(source);
-        return null;
+    var env = ModuleEnv.init(ctx.gpa, source) catch |err| switch (err) {
+        error.OutOfMemory => {
+            ctx.gpa.free(source);
+            return error.OutOfMemory;
+        },
     };
     defer env.deinit();
     env.common.source = source;
     env.module_name = module_name;
 
-    const ast = parse.parse(ctx.gpa, &env.common) catch {
-        ctx.gpa.free(source);
-        return null;
+    const ast = parse.parse(ctx.gpa, &env.common) catch |err| switch (err) {
+        error.OutOfMemory => {
+            ctx.gpa.free(source);
+            return error.OutOfMemory;
+        },
+        error.TooNested => {
+            ctx.gpa.free(source);
+            return null;
+        },
     };
     defer ast.deinit();
 
@@ -2334,21 +2344,21 @@ fn resolvePlatformSpecToPaths(ctx: *CliCtx, platform_spec: []const u8, base_dir:
 /// - Windows: %LOCALAPPDATA%\roc\packages\
 fn getRocCacheDir(allocator: std.mem.Allocator) ![]const u8 {
     // Check XDG_CACHE_HOME first (Linux/macOS)
-    if (getEnvVar(allocator, "XDG_CACHE_HOME")) |xdg_cache| {
+    if (try getEnvVar(allocator, "XDG_CACHE_HOME")) |xdg_cache| {
         defer allocator.free(xdg_cache);
         return std.fs.path.join(allocator, &.{ xdg_cache, "roc", "packages" });
     }
 
     // Fall back to %LOCALAPPDATA%\roc\packages (Windows)
     if (comptime builtin.os.tag == .windows) {
-        if (getEnvVar(allocator, "LOCALAPPDATA")) |local_app_data| {
+        if (try getEnvVar(allocator, "LOCALAPPDATA")) |local_app_data| {
             defer allocator.free(local_app_data);
             return std.fs.path.join(allocator, &.{ local_app_data, "roc", "packages" });
         }
     }
 
     // Fall back to ~/.cache/roc/packages (Unix)
-    if (getEnvVar(allocator, "HOME")) |home| {
+    if (try getEnvVar(allocator, "HOME")) |home| {
         defer allocator.free(home);
         return std.fs.path.join(allocator, &.{ home, ".cache", "roc", "packages" });
     }
@@ -2358,12 +2368,12 @@ fn getRocCacheDir(allocator: std.mem.Allocator) ![]const u8 {
 
 /// Cross-platform helper to get environment variable.
 /// Returns null if the variable is not set. Caller must free the returned slice.
-fn getEnvVar(allocator: std.mem.Allocator, key: []const u8) ?[]const u8 {
-    const key_z = allocator.dupeZ(u8, key) catch return null;
+fn getEnvVar(allocator: std.mem.Allocator, key: []const u8) std.mem.Allocator.Error!?[]const u8 {
+    const key_z = try allocator.dupeZ(u8, key);
     defer allocator.free(key_z);
     const value = std.c.getenv(key_z) orelse return null;
     const len = std.mem.len(value);
-    return allocator.dupe(u8, value[0..len]) catch null;
+    return try allocator.dupe(u8, value[0..len]);
 }
 
 /// Resolve a URL bundle (platform or package) by downloading and caching it.
@@ -3043,7 +3053,7 @@ fn rocBuild(ctx: *CliCtx, args: cli_args.BuildArgs) !void {
     }
 
     // Headerless apps use a simple builtin platform and cannot be compiled
-    if (readDefaultAppSource(ctx, args.path)) |source| {
+    if (try readDefaultAppSource(ctx, args.path)) |source| {
         ctx.gpa.free(source);
         renderProblem(ctx.gpa, ctx.io.stderr(), .{
             .build_not_supported_for_headerless = .{ .app_path = args.path },
@@ -4902,13 +4912,13 @@ fn replReportingConfig(ctx: *CliCtx, repl_args: cli_args.ReplArgs, mode: ReplMod
 }
 
 fn envVarNonEmpty(allocator: Allocator, name: []const u8) !bool {
-    const value = getEnvVar(allocator, name) orelse return false;
+    const value = try getEnvVar(allocator, name) orelse return false;
     defer allocator.free(value);
     return value.len > 0;
 }
 
 fn envVarEquals(allocator: Allocator, name: []const u8, expected: []const u8) !bool {
-    const value = getEnvVar(allocator, name) orelse return false;
+    const value = try getEnvVar(allocator, name) orelse return false;
     defer allocator.free(value);
     return std.mem.eql(u8, value, expected);
 }
@@ -5863,7 +5873,7 @@ fn generateDocs(
             try ctx.gpa.dupe(u8, basename);
     };
 
-    const modules_slice = module_docs_list.toOwnedSlice(ctx.gpa) catch return;
+    const modules_slice = try module_docs_list.toOwnedSlice(ctx.gpa);
 
     var package_docs = DocModel.PackageDocs{
         .name = pkg_name,

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -1499,7 +1499,7 @@ fn rocRunDefaultApp(ctx: *CliCtx, args: cli_args.RunArgs, original_source: []con
     var hosted_fn_array = [_]echo_platform.host_abi.HostedFn{echo_platform.host_abi.hostedFn(&echo_platform.echoHostedFn)};
     var echo_env = echo_platform.EchoEnv{ .std_io = ctx.io.std_io };
     var roc_ops = echo_platform.makeDefaultRocOps(&echo_env, &hosted_fn_array);
-    var cli_args_list = echo_platform.buildCliArgs(args.app_args, &roc_ops);
+    var cli_args_list = try echo_platform.buildCliArgs(args.app_args, &roc_ops);
 
     var result_buf: [16]u8 align(16) = undefined;
     try evaluateLirImageEntrypoint(
@@ -3278,7 +3278,7 @@ fn rocBuildWasmSurgical(
         }
     }
 
-    wasm_module.exportGlobalSymbols();
+    try wasm_module.exportGlobalSymbols();
     wasm_module.removeMemoryAndTableImports();
 
     const builtins_bytes = BuiltinsObjects.forTarget(.wasm32);
@@ -3328,7 +3328,7 @@ fn rocBuildWasmSurgical(
     const stack_bytes = args.wasm_stack_size orelse linker.DEFAULT_WASM_STACK_SIZE;
     try codegen.module.finalizeMemoryAndTable(@intCast(stack_bytes));
     codegen.module.ensureMemoryMinBytes(args.wasm_memory orelse linker.DEFAULT_WASM_INITIAL_MEMORY);
-    codegen.module.resolveRelocations();
+    try codegen.module.resolveRelocations();
 
     const called_fns = try ctx.gpa.alloc(bool, codegen.module.liveFunctionCount());
     defer ctx.gpa.free(called_fns);
@@ -5215,7 +5215,10 @@ fn checkFileWithBuildEnvPreserved(
                 const phase = package_env.modules.items[0].phase;
                 if (phase == .Done) break;
 
-                package_env.processModuleByName(module_name) catch break;
+                package_env.processModuleByName(module_name) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => break,
+                };
             }
         }
     }

--- a/src/cli/platform_validation.zig
+++ b/src/cli/platform_validation.zig
@@ -72,7 +72,7 @@ pub fn validatePlatformHeader(
 ) ValidationError!PlatformValidation {
     // Read platform source
     var source = std.Io.Dir.cwd().readFileAlloc(std_io, platform_source_path, allocator, .unlimited) catch {
-        renderFileReadError(allocator, platform_source_path);
+        try renderFileReadError(allocator, platform_source_path);
         return error.FileReadError;
     };
     source = base.source_utils.normalizeLineEndingsRealloc(allocator, source) catch {
@@ -87,7 +87,7 @@ pub fn validatePlatformHeader(
     };
 
     const ast = parse.parse(allocator, &env) catch {
-        renderParseError(allocator, platform_source_path);
+        try renderParseError(allocator, platform_source_path);
         return error.ParseError;
     };
     defer ast.deinit();
@@ -96,7 +96,7 @@ pub fn validatePlatformHeader(
     const config = TargetsConfig.fromAST(allocator, ast) catch {
         return error.ParseError;
     } orelse {
-        renderMissingTargetsError(allocator, platform_source_path);
+        try renderMissingTargetsError(allocator, platform_source_path);
         return error.MissingTargetsSection;
     };
 
@@ -107,19 +107,19 @@ pub fn validatePlatformHeader(
 }
 
 /// Render a file read error report to stderr.
-fn renderFileReadError(allocator: std.mem.Allocator, path: []const u8) void {
+fn renderFileReadError(allocator: std.mem.Allocator, path: []const u8) std.mem.Allocator.Error!void {
     var report = reporting.Report.init(allocator, "FILE READ ERROR", .fatal);
     defer report.deinit();
 
-    report.document.addText("Failed to read platform source file:") catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("    ") catch return;
-    report.document.addAnnotated(path, .path) catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("Check that the file exists and you have read permissions.") catch return;
-    report.document.addLineBreak() catch return;
+    try report.document.addText("Failed to read platform source file:");
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("    ");
+    try report.document.addAnnotated(path, .path);
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("Check that the file exists and you have read permissions.");
+    try report.document.addLineBreak();
 
     reporting.renderReportToTerminal(
         &report,
@@ -130,19 +130,19 @@ fn renderFileReadError(allocator: std.mem.Allocator, path: []const u8) void {
 }
 
 /// Render a parse error report to stderr.
-fn renderParseError(allocator: std.mem.Allocator, path: []const u8) void {
+fn renderParseError(allocator: std.mem.Allocator, path: []const u8) std.mem.Allocator.Error!void {
     var report = reporting.Report.init(allocator, "PARSE ERROR", .fatal);
     defer report.deinit();
 
-    report.document.addText("Failed to parse platform header:") catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("    ") catch return;
-    report.document.addAnnotated(path, .path) catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("Check that the file contains valid Roc syntax.") catch return;
-    report.document.addLineBreak() catch return;
+    try report.document.addText("Failed to parse platform header:");
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("    ");
+    try report.document.addAnnotated(path, .path);
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("Check that the file contains valid Roc syntax.");
+    try report.document.addLineBreak();
 
     reporting.renderReportToTerminal(
         &report,
@@ -153,19 +153,19 @@ fn renderParseError(allocator: std.mem.Allocator, path: []const u8) void {
 }
 
 /// Render a missing targets section error report to stderr.
-fn renderMissingTargetsError(allocator: std.mem.Allocator, path: []const u8) void {
+fn renderMissingTargetsError(allocator: std.mem.Allocator, path: []const u8) std.mem.Allocator.Error!void {
     var report = reporting.Report.init(allocator, "MISSING TARGETS SECTION", .fatal);
     defer report.deinit();
 
-    report.document.addText("Platform at ") catch return;
-    report.document.addAnnotated(path, .path) catch return;
-    report.document.addText(" does not have a 'targets:' section.") catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addText("Platform headers must declare supported targets. Example:") catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addLineBreak() catch return;
-    report.document.addCodeBlock(
+    try report.document.addText("Platform at ");
+    try report.document.addAnnotated(path, .path);
+    try report.document.addText(" does not have a 'targets:' section.");
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addText("Platform headers must declare supported targets. Example:");
+    try report.document.addLineBreak();
+    try report.document.addLineBreak();
+    try report.document.addCodeBlock(
         \\    targets: {
         \\        files: "targets/",
         \\        exe: {
@@ -173,8 +173,8 @@ fn renderMissingTargetsError(allocator: std.mem.Allocator, path: []const u8) voi
         \\            arm64linux: ["host.o", app],
         \\        }
         \\    }
-    ) catch return;
-    report.document.addLineBreak() catch return;
+    );
+    try report.document.addLineBreak();
 
     reporting.renderReportToTerminal(
         &report,

--- a/src/compile/cache_config.zig
+++ b/src/compile/cache_config.zig
@@ -50,20 +50,28 @@ pub const CacheConfig = struct {
         // Useful for test isolation and CI on any OS.
         if (self.roc_ctx.getEnvVar("ROC_CACHE_DIR", allocator)) |roc_dir| {
             return roc_dir;
-        } else |_| {}
+        } else |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.EnvironmentVariableMissing => {},
+        }
         // Respect XDG_CACHE_HOME if set
         if (self.roc_ctx.getEnvVar("XDG_CACHE_HOME", allocator)) |xdg_cache| {
             defer allocator.free(xdg_cache);
             return std.fs.path.join(allocator, &[_][]const u8{ xdg_cache, getCacheDirName() });
-        } else |_| {
+        } else |err| {
+            switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.EnvironmentVariableMissing => {},
+            }
             // Fall back to platform defaults
             const home_env = switch (builtin.target.os.tag) {
                 .windows => "APPDATA",
                 else => "HOME",
             };
 
-            const home_dir = self.roc_ctx.getEnvVar(home_env, allocator) catch {
-                return error.NoHomeDirectory;
+            const home_dir = self.roc_ctx.getEnvVar(home_env, allocator) catch |home_err| switch (home_err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.EnvironmentVariableMissing => return error.NoHomeDirectory,
             };
             defer allocator.free(home_dir);
 

--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -1274,7 +1274,7 @@ pub const BuildEnv = struct {
                 }
 
                 // Extract targets config from the platform AST
-                info.targets_config = targets_config_mod.TargetsConfig.fromAST(self.gpa, ast) catch null;
+                info.targets_config = try targets_config_mod.TargetsConfig.fromAST(self.gpa, ast);
             },
             .module => {
                 info.kind = .module;

--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -1349,8 +1349,11 @@ pub const BuildEnv = struct {
     /// Cross-platform environment variable lookup.
     /// Uses the filesystem vtable which works on both POSIX, Windows, and wasm
     /// (unlike std.posix.getenv which only works on POSIX systems).
-    fn getEnvVar(self: *BuildEnv, allocator: Allocator, key: []const u8) ?[]const u8 {
-        return self.filesystem.getEnvVar(key, allocator) catch null;
+    fn getEnvVar(self: *BuildEnv, allocator: Allocator, key: []const u8) Allocator.Error!?[]const u8 {
+        return self.filesystem.getEnvVar(key, allocator) catch |err| switch (err) {
+            error.OutOfMemory => error.OutOfMemory,
+            error.EnvironmentVariableMissing => null,
+        };
     }
 
     /// Get the roc cache directory for downloaded packages.
@@ -1359,21 +1362,21 @@ pub const BuildEnv = struct {
     /// - Windows: %LOCALAPPDATA%\roc\packages\
     fn getRocCacheDir(self: *BuildEnv, allocator: Allocator) ![]const u8 {
         // Check XDG_CACHE_HOME first (Linux/macOS)
-        if (self.getEnvVar(allocator, "XDG_CACHE_HOME")) |xdg_cache| {
+        if (try self.getEnvVar(allocator, "XDG_CACHE_HOME")) |xdg_cache| {
             defer allocator.free(xdg_cache);
             return std.fs.path.join(allocator, &.{ xdg_cache, "roc", "packages" });
         }
 
         // Fall back to %LOCALAPPDATA%\roc\packages (Windows)
         if (comptime builtin.os.tag == .windows) {
-            if (self.getEnvVar(allocator, "LOCALAPPDATA")) |local_app_data| {
+            if (try self.getEnvVar(allocator, "LOCALAPPDATA")) |local_app_data| {
                 defer allocator.free(local_app_data);
                 return std.fs.path.join(allocator, &.{ local_app_data, "roc", "packages" });
             }
         }
 
         // Fall back to ~/.cache/roc/packages (Unix)
-        if (self.getEnvVar(allocator, "HOME")) |home| {
+        if (try self.getEnvVar(allocator, "HOME")) |home| {
             defer allocator.free(home);
             return std.fs.path.join(allocator, &.{ home, ".cache", "roc", "packages" });
         }
@@ -1389,19 +1392,25 @@ pub const BuildEnv = struct {
         const download = unbundle.download;
 
         // Validate URL and extract hash
-        const base58_hash = download.validateUrl(url) catch |err| {
-            if (comptime !is_freestanding) {
-                std.log.err("Invalid package URL: {s} ({})", .{ url, err });
-            }
-            return error.InvalidUrl;
+        const base58_hash = download.validateUrl(url) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => {
+                if (comptime !is_freestanding) {
+                    std.log.err("Invalid package URL: {s} ({})", .{ url, err });
+                }
+                return error.InvalidUrl;
+            },
         };
 
         // Get cache directory
-        const cache_dir_path = self.getRocCacheDir(self.gpa) catch {
-            if (comptime !is_freestanding) {
-                std.log.err("Could not determine cache directory", .{});
-            }
-            return error.NoCacheDir;
+        const cache_dir_path = self.getRocCacheDir(self.gpa) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => {
+                if (comptime !is_freestanding) {
+                    std.log.err("Could not determine cache directory", .{});
+                }
+                return error.NoCacheDir;
+            },
         };
         defer self.gpa.free(cache_dir_path);
 
@@ -1418,14 +1427,18 @@ pub const BuildEnv = struct {
             }
 
             // Create cache directory structure
-            self.filesystem.makePath(cache_dir_path) catch |make_err| {
-                std.log.err("Failed to create cache directory: {}", .{make_err});
-                return error.FileError;
+            self.filesystem.makePath(cache_dir_path) catch |make_err| switch (make_err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => {
+                    std.log.err("Failed to create cache directory: {}", .{make_err});
+                    return error.FileError;
+                },
             };
 
             // Create package directory
             self.filesystem.createDir(package_dir_path) catch |make_err| switch (make_err) {
                 error.IoError => {}, // May be PathAlreadyExists from race condition
+                error.OutOfMemory => return error.OutOfMemory,
                 else => {
                     if (comptime !is_freestanding) {
                         std.log.err("Failed to create package directory: {}", .{make_err});
@@ -1437,8 +1450,13 @@ pub const BuildEnv = struct {
             // Download and extract via io vtable (path-based, no Dir handle needed)
             self.filesystem.fetchUrl(self.gpa, url, package_dir_path) catch |fetch_err| {
                 self.filesystem.deleteTree(package_dir_path) catch {};
-                std.log.err("Failed to download package: {} (url: {s})", .{ fetch_err, url });
-                return error.DownloadFailed;
+                switch (fetch_err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => {
+                        std.log.err("Failed to download package: {} (url: {s})", .{ fetch_err, url });
+                        return error.DownloadFailed;
+                    },
+                }
             };
 
             if (comptime !is_freestanding) {

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -2751,6 +2751,7 @@ pub const Coordinator = struct {
             .parse_failed => |*r| try self.handleParseFailed(r),
             .compile_failed => |*r| try self.handleCompileFailed(r),
             .cycle_detected => |*r| try self.handleCycleDetected(r),
+            .worker_oom => return error.OutOfMemory,
         }
     }
 
@@ -3578,21 +3579,26 @@ pub const Coordinator = struct {
 
     /// Execute a parse task (pure function)
     fn executeParse(self: *Coordinator, task: ParseTask, allocators: WorkerTaskAllocators) WorkerResult {
-        return self.executeParseFallible(task, allocators) catch |err| {
-            const title = switch (err) {
-                error.FileNotFound => "FILE NOT FOUND",
-                else => "PARSING FAILED",
-            };
-            return .{
-                .parse_failed = .{
+        return self.executeParseFallible(task, allocators) catch |err| switch (err) {
+            error.OutOfMemory => WorkerResult{ .worker_oom = .{
+                .package_name = task.package_name,
+                .module_id = task.module_id,
+                .module_name = task.module_name,
+            } },
+            else => |e| blk: {
+                const title = switch (e) {
+                    error.FileNotFound => "FILE NOT FOUND",
+                    else => "PARSING FAILED",
+                };
+                break :blk WorkerResult{ .parse_failed = .{
                     .package_name = task.package_name,
                     .module_id = task.module_id,
                     .module_name = task.module_name,
                     .path = task.path,
-                    .reports = self.workerFailureReports(allocators.result, title, task.path, err),
+                    .reports = self.workerFailureReports(allocators.result, title, task.path, e),
                     .partial_env = null,
-                },
-            };
+                } };
+            },
         };
     }
 
@@ -3709,17 +3715,12 @@ pub const Coordinator = struct {
 
     /// Execute a canonicalize task (pure function)
     fn executeCanonicalize(self: *Coordinator, task: CanonicalizeTask, allocators: WorkerTaskAllocators) WorkerResult {
-        return self.executeCanonicalizeFallible(task, allocators) catch |err| {
-            return .{
-                .compile_failed = .{
-                    .package_name = task.package_name,
-                    .module_id = task.module_id,
-                    .module_name = task.module_name,
-                    .path = task.path,
-                    .reports = self.workerFailureReports(allocators.result, "CANONICALIZATION FAILED", task.path, err),
-                    .partial_env = task.module_env,
-                },
-            };
+        return self.executeCanonicalizeFallible(task, allocators) catch |err| switch (err) {
+            error.OutOfMemory => WorkerResult{ .worker_oom = .{
+                .package_name = task.package_name,
+                .module_id = task.module_id,
+                .module_name = task.module_name,
+            } },
         };
     }
 
@@ -3793,17 +3794,20 @@ pub const Coordinator = struct {
 
     /// Execute a type-check task (pure function)
     fn executeTypeCheck(self: *Coordinator, task: TypeCheckTask, allocators: WorkerTaskAllocators) WorkerResult {
-        return self.executeTypeCheckFallible(task, allocators) catch |err| {
-            return .{
-                .compile_failed = .{
-                    .package_name = task.package_name,
-                    .module_id = task.module_id,
-                    .module_name = task.module_name,
-                    .path = task.path,
-                    .reports = self.workerFailureReports(allocators.result, "TYPE CHECKING FAILED", task.path, err),
-                    .partial_env = task.module_env,
-                },
-            };
+        return self.executeTypeCheckFallible(task, allocators) catch |err| switch (err) {
+            error.OutOfMemory => WorkerResult{ .worker_oom = .{
+                .package_name = task.package_name,
+                .module_id = task.module_id,
+                .module_name = task.module_name,
+            } },
+            else => |e| WorkerResult{ .compile_failed = .{
+                .package_name = task.package_name,
+                .module_id = task.module_id,
+                .module_name = task.module_name,
+                .path = task.path,
+                .reports = self.workerFailureReports(allocators.result, "TYPE CHECKING FAILED", task.path, e),
+                .partial_env = task.module_env,
+            } },
         };
     }
 

--- a/src/compile/messages.zig
+++ b/src/compile/messages.zig
@@ -273,6 +273,19 @@ pub const CycleDetected = struct {
     module_env: *ModuleEnv,
 };
 
+/// Result when a worker stage ran out of memory. Carries just enough identity
+/// to report which module was being processed; the coordinator turns this into
+/// `error.OutOfMemory` and aborts the whole compilation rather than letting the
+/// failure masquerade as an ordinary stage failure.
+pub const WorkerOom = struct {
+    /// Package this module belongs to
+    package_name: []const u8,
+    /// Module identifier
+    module_id: ModuleId,
+    /// Module name
+    module_name: []const u8,
+};
+
 /// Result sent from workers - contains ALL outputs from the operation
 pub const WorkerResult = union(enum) {
     /// Module was successfully parsed
@@ -287,6 +300,8 @@ pub const WorkerResult = union(enum) {
     compile_failed: CompileFailure,
     /// Import cycle was detected
     cycle_detected: CycleDetected,
+    /// A worker stage ran out of memory
+    worker_oom: WorkerOom,
 
     pub fn getPackageName(self: WorkerResult) []const u8 {
         return switch (self) {
@@ -296,6 +311,7 @@ pub const WorkerResult = union(enum) {
             .parse_failed => |r| r.package_name,
             .compile_failed => |r| r.package_name,
             .cycle_detected => |r| r.package_name,
+            .worker_oom => |r| r.package_name,
         };
     }
 
@@ -307,6 +323,7 @@ pub const WorkerResult = union(enum) {
             .parse_failed => |r| r.module_id,
             .compile_failed => |r| r.module_id,
             .cycle_detected => |r| r.module_id,
+            .worker_oom => |r| r.module_id,
         };
     }
 
@@ -318,6 +335,7 @@ pub const WorkerResult = union(enum) {
             .parse_failed => |r| r.module_name,
             .compile_failed => |r| r.module_name,
             .cycle_detected => |r| r.module_name,
+            .worker_oom => |r| r.module_name,
         };
     }
 
@@ -369,6 +387,7 @@ pub const WorkerResult = union(enum) {
                 for (r.reports.items) |*rep| rep.deinit();
                 r.reports.deinit(gpa);
             },
+            .worker_oom => {},
         }
     }
 };

--- a/src/ctx/CoreCtx.zig
+++ b/src/ctx/CoreCtx.zig
@@ -575,7 +575,9 @@ fn osListDir(_: ?*anyopaque, std_io: std.Io, path: []const u8, allocator: Alloca
     };
     defer dir.close(std_io);
 
-    var walker = dir.walk(allocator) catch return error.IoError;
+    var walker = dir.walk(allocator) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+    };
     defer walker.deinit();
 
     var entries: std.ArrayList(FileEntry) = .empty;
@@ -585,7 +587,10 @@ fn osListDir(_: ?*anyopaque, std_io: std.Io, path: []const u8, allocator: Alloca
     }
 
     while (true) {
-        const next = walker.next(std_io) catch return error.IoError;
+        const next = walker.next(std_io) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.IoError,
+        };
         const entry = next orelse break;
         const kind: FileKind = switch (entry.kind) {
             .file => .file,

--- a/src/docs/DocModel.zig
+++ b/src/docs/DocModel.zig
@@ -412,135 +412,79 @@ pub const DocType = union(enum) {
         }
     }
 
+    /// Frees a child `DocType` that was individually heap-allocated: first
+    /// recursively frees its contents, then destroys the node itself.
+    fn deinitChild(child: *const DocType, gpa: Allocator) void {
+        child.deinit(gpa);
+        gpa.destroy(child);
+    }
+
+    /// Recursively frees everything owned by this `DocType`, but not the node
+    /// itself (the caller owns that storage). Recursion depth is bounded by the
+    /// depth of the type structure, so no growable allocation is needed and this
+    /// destructor cannot fail.
     pub fn deinit(self: *const DocType, gpa: Allocator) void {
-        const Frame = struct {
-            node: *const DocType,
-            children_done: bool,
-        };
-
-        const Stack = struct {
-            fn append(stack: *std.ArrayList(Frame), allocator: Allocator, frame: Frame) void {
-                stack.append(allocator, frame) catch @panic("out of memory while deinitializing DocType");
-            }
-        };
-
-        var stack = std.ArrayList(Frame).empty;
-        defer stack.deinit(gpa);
-
-        Stack.append(&stack, gpa, .{ .node = self, .children_done = false });
-        while (stack.pop()) |frame| {
-            const node = frame.node;
-            if (!frame.children_done) {
-                Stack.append(&stack, gpa, .{ .node = node, .children_done = true });
-                switch (node.*) {
-                    .function => |func| {
-                        Stack.append(&stack, gpa, .{ .node = func.ret, .children_done = false });
-                        for (func.args) |arg| {
-                            Stack.append(&stack, gpa, .{ .node = arg, .children_done = false });
-                        }
-                    },
-                    .record => |rec| {
-                        if (rec.ext) |ext| {
-                            Stack.append(&stack, gpa, .{ .node = ext, .children_done = false });
-                        }
-                        for (rec.fields) |field| {
-                            Stack.append(&stack, gpa, .{ .node = field.type, .children_done = false });
-                        }
-                    },
-                    .tag_union => |tu| {
-                        if (tu.ext) |ext| {
-                            Stack.append(&stack, gpa, .{ .node = ext, .children_done = false });
-                        }
-                        for (tu.tags) |tag| {
-                            for (tag.args) |arg| {
-                                Stack.append(&stack, gpa, .{ .node = arg, .children_done = false });
-                            }
-                        }
-                    },
-                    .tuple => |tup| {
-                        for (tup.elems) |elem| {
-                            Stack.append(&stack, gpa, .{ .node = elem, .children_done = false });
-                        }
-                    },
-                    .apply => |app| {
-                        Stack.append(&stack, gpa, .{ .node = app.constructor, .children_done = false });
-                        for (app.args) |arg| {
-                            Stack.append(&stack, gpa, .{ .node = arg, .children_done = false });
-                        }
-                    },
-                    .where_clause => |wc| {
-                        Stack.append(&stack, gpa, .{ .node = wc.type, .children_done = false });
-                        for (wc.constraints) |constraint| {
-                            Stack.append(&stack, gpa, .{ .node = constraint.signature, .children_done = false });
-                        }
-                    },
-                    .type_ref, .type_var, .wildcard, .@"error" => {},
+        switch (self.*) {
+            .type_ref => |ref| {
+                gpa.free(ref.module_path);
+                gpa.free(ref.type_name);
+            },
+            .type_var => |name| {
+                gpa.free(name);
+            },
+            .function => |func| {
+                for (func.args) |arg| {
+                    deinitChild(arg, gpa);
                 }
-                continue;
-            }
-
-            switch (node.*) {
-                .type_ref => |ref| {
-                    gpa.free(ref.module_path);
-                    gpa.free(ref.type_name);
-                },
-                .type_var => |name| {
-                    gpa.free(name);
-                },
-                .function => |func| {
-                    for (func.args) |arg| {
-                        gpa.destroy(arg);
+                gpa.free(func.args);
+                deinitChild(func.ret, gpa);
+            },
+            .record => |rec| {
+                if (rec.ext) |ext| {
+                    deinitChild(ext, gpa);
+                }
+                for (rec.fields) |field| {
+                    gpa.free(field.name);
+                    deinitChild(field.type, gpa);
+                }
+                gpa.free(rec.fields);
+            },
+            .tag_union => |tu| {
+                for (tu.tags) |tag| {
+                    gpa.free(tag.name);
+                    for (tag.args) |arg| {
+                        deinitChild(arg, gpa);
                     }
-                    gpa.free(func.args);
-                    gpa.destroy(func.ret);
-                },
-                .record => |rec| {
-                    if (rec.ext) |ext| {
-                        gpa.destroy(ext);
-                    }
-                    for (rec.fields) |field| {
-                        gpa.free(field.name);
-                        gpa.destroy(field.type);
-                    }
-                    gpa.free(rec.fields);
-                },
-                .tag_union => |tu| {
-                    for (tu.tags) |tag| {
-                        gpa.free(tag.name);
-                        for (tag.args) |arg| {
-                            gpa.destroy(arg);
-                        }
-                        gpa.free(tag.args);
-                    }
-                    gpa.free(tu.tags);
-                    if (tu.ext) |ext| {
-                        gpa.destroy(ext);
-                    }
-                },
-                .tuple => |tup| {
-                    for (tup.elems) |elem| {
-                        gpa.destroy(elem);
-                    }
-                    gpa.free(tup.elems);
-                },
-                .apply => |app| {
-                    gpa.destroy(app.constructor);
-                    for (app.args) |arg| {
-                        gpa.destroy(arg);
-                    }
-                    gpa.free(app.args);
-                },
-                .where_clause => |wc| {
-                    gpa.destroy(wc.type);
-                    for (wc.constraints) |constraint| {
-                        gpa.free(constraint.type_var);
-                        gpa.free(constraint.method_name);
-                        gpa.destroy(constraint.signature);
-                    }
-                    gpa.free(wc.constraints);
-                },
-                .wildcard, .@"error" => {},
-            }
+                    gpa.free(tag.args);
+                }
+                gpa.free(tu.tags);
+                if (tu.ext) |ext| {
+                    deinitChild(ext, gpa);
+                }
+            },
+            .tuple => |tup| {
+                for (tup.elems) |elem| {
+                    deinitChild(elem, gpa);
+                }
+                gpa.free(tup.elems);
+            },
+            .apply => |app| {
+                deinitChild(app.constructor, gpa);
+                for (app.args) |arg| {
+                    deinitChild(arg, gpa);
+                }
+                gpa.free(app.args);
+            },
+            .where_clause => |wc| {
+                deinitChild(wc.type, gpa);
+                for (wc.constraints) |constraint| {
+                    gpa.free(constraint.type_var);
+                    gpa.free(constraint.method_name);
+                    deinitChild(constraint.signature, gpa);
+                }
+                gpa.free(wc.constraints);
+            },
+            .wildcard, .@"error" => {},
         }
     }
 };

--- a/src/docs/DocModel.zig
+++ b/src/docs/DocModel.zig
@@ -412,79 +412,135 @@ pub const DocType = union(enum) {
         }
     }
 
-    /// Frees a child `DocType` that was individually heap-allocated: first
-    /// recursively frees its contents, then destroys the node itself.
-    fn deinitChild(child: *const DocType, gpa: Allocator) void {
-        child.deinit(gpa);
-        gpa.destroy(child);
-    }
-
-    /// Recursively frees everything owned by this `DocType`, but not the node
-    /// itself (the caller owns that storage). Recursion depth is bounded by the
-    /// depth of the type structure, so no growable allocation is needed and this
-    /// destructor cannot fail.
     pub fn deinit(self: *const DocType, gpa: Allocator) void {
-        switch (self.*) {
-            .type_ref => |ref| {
-                gpa.free(ref.module_path);
-                gpa.free(ref.type_name);
-            },
-            .type_var => |name| {
-                gpa.free(name);
-            },
-            .function => |func| {
-                for (func.args) |arg| {
-                    deinitChild(arg, gpa);
+        const Frame = struct {
+            node: *const DocType,
+            children_done: bool,
+        };
+
+        const Stack = struct {
+            fn append(stack: *std.ArrayList(Frame), allocator: Allocator, frame: Frame) void {
+                stack.append(allocator, frame) catch @panic("out of memory while deinitializing DocType");
+            }
+        };
+
+        var stack = std.ArrayList(Frame).empty;
+        defer stack.deinit(gpa);
+
+        Stack.append(&stack, gpa, .{ .node = self, .children_done = false });
+        while (stack.pop()) |frame| {
+            const node = frame.node;
+            if (!frame.children_done) {
+                Stack.append(&stack, gpa, .{ .node = node, .children_done = true });
+                switch (node.*) {
+                    .function => |func| {
+                        Stack.append(&stack, gpa, .{ .node = func.ret, .children_done = false });
+                        for (func.args) |arg| {
+                            Stack.append(&stack, gpa, .{ .node = arg, .children_done = false });
+                        }
+                    },
+                    .record => |rec| {
+                        if (rec.ext) |ext| {
+                            Stack.append(&stack, gpa, .{ .node = ext, .children_done = false });
+                        }
+                        for (rec.fields) |field| {
+                            Stack.append(&stack, gpa, .{ .node = field.type, .children_done = false });
+                        }
+                    },
+                    .tag_union => |tu| {
+                        if (tu.ext) |ext| {
+                            Stack.append(&stack, gpa, .{ .node = ext, .children_done = false });
+                        }
+                        for (tu.tags) |tag| {
+                            for (tag.args) |arg| {
+                                Stack.append(&stack, gpa, .{ .node = arg, .children_done = false });
+                            }
+                        }
+                    },
+                    .tuple => |tup| {
+                        for (tup.elems) |elem| {
+                            Stack.append(&stack, gpa, .{ .node = elem, .children_done = false });
+                        }
+                    },
+                    .apply => |app| {
+                        Stack.append(&stack, gpa, .{ .node = app.constructor, .children_done = false });
+                        for (app.args) |arg| {
+                            Stack.append(&stack, gpa, .{ .node = arg, .children_done = false });
+                        }
+                    },
+                    .where_clause => |wc| {
+                        Stack.append(&stack, gpa, .{ .node = wc.type, .children_done = false });
+                        for (wc.constraints) |constraint| {
+                            Stack.append(&stack, gpa, .{ .node = constraint.signature, .children_done = false });
+                        }
+                    },
+                    .type_ref, .type_var, .wildcard, .@"error" => {},
                 }
-                gpa.free(func.args);
-                deinitChild(func.ret, gpa);
-            },
-            .record => |rec| {
-                if (rec.ext) |ext| {
-                    deinitChild(ext, gpa);
-                }
-                for (rec.fields) |field| {
-                    gpa.free(field.name);
-                    deinitChild(field.type, gpa);
-                }
-                gpa.free(rec.fields);
-            },
-            .tag_union => |tu| {
-                for (tu.tags) |tag| {
-                    gpa.free(tag.name);
-                    for (tag.args) |arg| {
-                        deinitChild(arg, gpa);
+                continue;
+            }
+
+            switch (node.*) {
+                .type_ref => |ref| {
+                    gpa.free(ref.module_path);
+                    gpa.free(ref.type_name);
+                },
+                .type_var => |name| {
+                    gpa.free(name);
+                },
+                .function => |func| {
+                    for (func.args) |arg| {
+                        gpa.destroy(arg);
                     }
-                    gpa.free(tag.args);
-                }
-                gpa.free(tu.tags);
-                if (tu.ext) |ext| {
-                    deinitChild(ext, gpa);
-                }
-            },
-            .tuple => |tup| {
-                for (tup.elems) |elem| {
-                    deinitChild(elem, gpa);
-                }
-                gpa.free(tup.elems);
-            },
-            .apply => |app| {
-                deinitChild(app.constructor, gpa);
-                for (app.args) |arg| {
-                    deinitChild(arg, gpa);
-                }
-                gpa.free(app.args);
-            },
-            .where_clause => |wc| {
-                deinitChild(wc.type, gpa);
-                for (wc.constraints) |constraint| {
-                    gpa.free(constraint.type_var);
-                    gpa.free(constraint.method_name);
-                    deinitChild(constraint.signature, gpa);
-                }
-                gpa.free(wc.constraints);
-            },
-            .wildcard, .@"error" => {},
+                    gpa.free(func.args);
+                    gpa.destroy(func.ret);
+                },
+                .record => |rec| {
+                    if (rec.ext) |ext| {
+                        gpa.destroy(ext);
+                    }
+                    for (rec.fields) |field| {
+                        gpa.free(field.name);
+                        gpa.destroy(field.type);
+                    }
+                    gpa.free(rec.fields);
+                },
+                .tag_union => |tu| {
+                    for (tu.tags) |tag| {
+                        gpa.free(tag.name);
+                        for (tag.args) |arg| {
+                            gpa.destroy(arg);
+                        }
+                        gpa.free(tag.args);
+                    }
+                    gpa.free(tu.tags);
+                    if (tu.ext) |ext| {
+                        gpa.destroy(ext);
+                    }
+                },
+                .tuple => |tup| {
+                    for (tup.elems) |elem| {
+                        gpa.destroy(elem);
+                    }
+                    gpa.free(tup.elems);
+                },
+                .apply => |app| {
+                    gpa.destroy(app.constructor);
+                    for (app.args) |arg| {
+                        gpa.destroy(arg);
+                    }
+                    gpa.free(app.args);
+                },
+                .where_clause => |wc| {
+                    gpa.destroy(wc.type);
+                    for (wc.constraints) |constraint| {
+                        gpa.free(constraint.type_var);
+                        gpa.free(constraint.method_name);
+                        gpa.destroy(constraint.signature);
+                    }
+                    gpa.free(wc.constraints);
+                },
+                .wildcard, .@"error" => {},
+            }
         }
     }
 };

--- a/src/docs/extract.zig
+++ b/src/docs/extract.zig
@@ -674,12 +674,12 @@ fn extractDefEntry(
 
                 const def_var = ModuleEnv.varFrom(def_idx);
                 if (@intFromEnum(def_var) >= module_env.types.len()) break :blk null;
-                break :blk extractDocType(
+                break :blk try extractDocType(
                     gpa,
                     &module_env.types,
                     module_env.getIdentStoreConst(),
                     def_var,
-                ) catch break :blk null;
+                );
             };
             errdefer if (type_sig) |s| {
                 s.deinit(gpa);

--- a/src/docs/render_html.zig
+++ b/src/docs/render_html.zig
@@ -188,7 +188,7 @@ const RenderContext = struct {
         label: []const u8,
         resolved_anchor: []const u8,
         bracket_offset: usize,
-    ) void {
+    ) Allocator.Error!void {
         const list = self.broken_links orelse return;
         const gpa = self.broken_links_gpa orelse return;
         const source_module = self.current_module orelse "";
@@ -205,21 +205,17 @@ const RenderContext = struct {
             break :blk active.start_line + newlines;
         };
 
-        const label_dup = gpa.dupe(u8, label) catch return;
-        const anchor_dup = gpa.dupe(u8, resolved_anchor) catch {
-            gpa.free(label_dup);
-            return;
-        };
-        list.append(gpa, .{
+        const label_dup = try gpa.dupe(u8, label);
+        errdefer gpa.free(label_dup);
+        const anchor_dup = try gpa.dupe(u8, resolved_anchor);
+        errdefer gpa.free(anchor_dup);
+        try list.append(gpa, .{
             .source_module = source_module,
             .source_path = self.current_source_path.*,
             .source_line = source_line,
             .label = label_dup,
             .resolved_anchor = anchor_dup,
-        }) catch {
-            gpa.free(label_dup);
-            gpa.free(anchor_dup);
-        };
+        });
     }
 
     /// Replace `current_module` and `current_module_entries`, then rebuild the
@@ -1561,7 +1557,7 @@ fn writeDocRefHref(w: Writer, ctx: *const RenderContext, label: []const u8, brac
                 try writeHtmlEscaped(w, label[d..]);
                 append(&anchor_buf, &anchor_len, &anchor_overflow, label[d..]);
             }
-            validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
+            try validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
             return;
         }
 
@@ -1575,7 +1571,7 @@ fn writeDocRefHref(w: Writer, ctx: *const RenderContext, label: []const u8, brac
             try w.writeAll("#");
             try writeHtmlEscaped(w, label);
             append(&anchor_buf, &anchor_len, &anchor_overflow, label);
-            validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
+            try validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
         }
         // No fragment — the link points at the module's index page, which is
         // guaranteed to exist by the `known_modules.contains` check above.
@@ -1600,7 +1596,7 @@ fn writeDocRefHref(w: Writer, ctx: *const RenderContext, label: []const u8, brac
         try writeHtmlEscaped(w, label[d..]);
         append(&anchor_buf, &anchor_len, &anchor_overflow, label[d..]);
     }
-    validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
+    try validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
 }
 
 /// Report `label` as broken when its resolved anchor isn't in `all_anchors`.
@@ -1613,11 +1609,11 @@ fn validateAnchor(
     anchor: []const u8,
     overflow: bool,
     bracket_offset: usize,
-) void {
+) Allocator.Error!void {
     if (overflow) return;
     if (anchor.len == 0) return;
     if (ctx.all_anchors.contains(anchor)) return;
-    ctx.reportBrokenLink(label, anchor, bracket_offset);
+    try ctx.reportBrokenLink(label, anchor, bracket_offset);
 }
 
 fn renderDocTypeHtml(

--- a/src/echo_platform/mod.zig
+++ b/src/echo_platform/mod.zig
@@ -184,15 +184,15 @@ pub fn makeDefaultRocOps(env: *EchoEnv, hosted_fns: []host_abi.HostedFn) host_ab
 
 /// Build a RocList of RocStr from CLI argument slices.
 /// Each argument is sanitized to valid UTF-8.
-pub fn buildCliArgs(app_args: []const []const u8, roc_ops: *host_abi.RocOps) RocList {
+pub fn buildCliArgs(app_args: []const []const u8, roc_ops: *host_abi.RocOps) std.mem.Allocator.Error!RocList {
     if (comptime is_wasm) return RocList.empty();
     if (app_args.len == 0) return RocList.empty();
 
     const allocator = std.heap.page_allocator;
-    const roc_strs = allocator.alloc(RocStr, app_args.len) catch return RocList.empty();
+    const roc_strs = try allocator.alloc(RocStr, app_args.len);
 
     for (app_args, 0..) |arg, i| {
-        const sanitized = sanitizeUtf8(arg, allocator);
+        const sanitized = try sanitizeUtf8(arg, allocator);
         roc_strs[i] = RocStr.fromSlice(sanitized, roc_ops);
     }
 
@@ -201,11 +201,11 @@ pub fn buildCliArgs(app_args: []const []const u8, roc_ops: *host_abi.RocOps) Roc
 
 /// Sanitize a byte slice to valid UTF-8, replacing invalid bytes with U+FFFD.
 /// Returns the input slice unchanged if it's already valid UTF-8.
-fn sanitizeUtf8(input: []const u8, allocator: std.mem.Allocator) []const u8 {
+fn sanitizeUtf8(input: []const u8, allocator: std.mem.Allocator) std.mem.Allocator.Error![]const u8 {
     if (std.unicode.utf8ValidateSlice(input)) return input;
 
     // Worst case: each invalid byte becomes 3-byte replacement char
-    const buf = allocator.alloc(u8, input.len * 3) catch return input;
+    const buf = try allocator.alloc(u8, input.len * 3);
     var out_i: usize = 0;
     var in_i: usize = 0;
     while (in_i < input.len) {
@@ -254,7 +254,7 @@ const test_allocator = std.heap.page_allocator;
 
 test "sanitizeUtf8: valid ASCII passes through unchanged" {
     const input = "hello world";
-    const result = sanitizeUtf8(input, test_allocator);
+    const result = try sanitizeUtf8(input, test_allocator);
     try testing.expectEqualStrings("hello world", result);
     // Should return the original slice (no allocation)
     try testing.expectEqual(input.ptr, result.ptr);
@@ -262,42 +262,42 @@ test "sanitizeUtf8: valid ASCII passes through unchanged" {
 
 test "sanitizeUtf8: valid multibyte UTF-8 passes through unchanged" {
     const input = "na\xc3\xafve \xe2\x9c\x93"; // "naïve ✓"
-    const result = sanitizeUtf8(input, test_allocator);
+    const result = try sanitizeUtf8(input, test_allocator);
     try testing.expectEqualStrings(input, result);
     try testing.expectEqual(input.ptr, result.ptr);
 }
 
 test "sanitizeUtf8: single invalid byte becomes replacement char" {
-    const result = sanitizeUtf8("\xff", test_allocator);
+    const result = try sanitizeUtf8("\xff", test_allocator);
     try testing.expectEqualStrings("\xef\xbf\xbd", result); // U+FFFD
 }
 
 test "sanitizeUtf8: invalid byte surrounded by valid ASCII" {
-    const result = sanitizeUtf8("a\xffb", test_allocator);
+    const result = try sanitizeUtf8("a\xffb", test_allocator);
     try testing.expectEqualStrings("a\xef\xbf\xbdb", result);
 }
 
 test "sanitizeUtf8: truncated 2-byte sequence" {
     // 0xC3 starts a 2-byte sequence but there's no continuation byte
-    const result = sanitizeUtf8("a\xc3", test_allocator);
+    const result = try sanitizeUtf8("a\xc3", test_allocator);
     try testing.expectEqualStrings("a\xef\xbf\xbd", result);
 }
 
 test "sanitizeUtf8: truncated 3-byte sequence" {
     // 0xE2 starts a 3-byte sequence but only one continuation follows
-    const result = sanitizeUtf8("\xe2\x9c", test_allocator);
+    const result = try sanitizeUtf8("\xe2\x9c", test_allocator);
     // Each byte of the truncated sequence is replaced individually
     try testing.expectEqualStrings("\xef\xbf\xbd\xef\xbf\xbd", result);
 }
 
 test "sanitizeUtf8: multiple consecutive invalid bytes" {
-    const result = sanitizeUtf8("\xff\xfe\xfd", test_allocator);
+    const result = try sanitizeUtf8("\xff\xfe\xfd", test_allocator);
     // Each invalid byte gets its own replacement char
     try testing.expectEqualStrings("\xef\xbf\xbd\xef\xbf\xbd\xef\xbf\xbd", result);
 }
 
 test "sanitizeUtf8: empty input" {
     const input: []const u8 = "";
-    const result = sanitizeUtf8(input, test_allocator);
+    const result = try sanitizeUtf8(input, test_allocator);
     try testing.expectEqual(@as(usize, 0), result.len);
 }

--- a/src/echo_platform/runner.zig
+++ b/src/echo_platform/runner.zig
@@ -151,12 +151,12 @@ pub fn runEcho(opts: RunOptions) !u8 {
     build_env.filesystem = echo_ctx.io();
 
     build_env.discoverDependencies(opts.paths.app_abs) catch |err| {
-        _ = emitDiagnostics(&build_env, diag, allocator);
+        _ = try emitDiagnostics(&build_env, diag, allocator);
         diag.step("discoverDependencies", err);
         return err;
     };
     build_env.compileDiscovered() catch |err| {
-        _ = emitDiagnostics(&build_env, diag, allocator);
+        _ = try emitDiagnostics(&build_env, diag, allocator);
         diag.step("compileDiscovered", err);
         return err;
     };
@@ -166,7 +166,7 @@ pub fn runEcho(opts: RunOptions) !u8 {
     // The CIR contains runtime_error placeholder nodes in that state, and
     // mono lowering asserts they don't appear as runtime values — proceeding
     // would trap. The reports themselves are the user-facing output.
-    if (emitDiagnostics(&build_env, diag, allocator)) {
+    if (try emitDiagnostics(&build_env, diag, allocator)) {
         return error.CompilationFailed;
     }
 
@@ -262,7 +262,7 @@ fn runEchoView(
     var hosted_fn_array = [_]HostedFn{echo_platform.host_abi.hostedFn(&echo_platform.echoHostedFn)};
     var echo_env: echo_platform.EchoEnv = .{ .std_io = std_io };
     var roc_ops = echo_platform.makeDefaultRocOps(&echo_env, &hosted_fn_array);
-    var cli_args_list = echo_platform.buildCliArgs(&.{}, &roc_ops);
+    var cli_args_list = try echo_platform.buildCliArgs(&.{}, &roc_ops);
     var result_buf: [16]u8 align(16) = undefined;
 
     var interpreter = eval.LirInterpreter.init(
@@ -302,8 +302,8 @@ fn runEchoView(
 
 /// Drain BuildEnv reports through `diag` and return true if any
 /// had `runtime_error` or `fatal` severity (i.e. compile-blocking).
-fn emitDiagnostics(build_env: *BuildEnv, diag: Diagnostics, gpa: Allocator) bool {
-    const drained = build_env.drainReports() catch return false;
+fn emitDiagnostics(build_env: *BuildEnv, diag: Diagnostics, gpa: Allocator) Allocator.Error!bool {
+    const drained = try build_env.drainReports();
     defer build_env.freeDrainedReports(drained);
 
     var has_blocking_error = false;

--- a/src/eval/builtin_loading.zig
+++ b/src/eval/builtin_loading.zig
@@ -53,6 +53,7 @@ pub fn loadCompiledModule(gpa: std.mem.Allocator, bin_data: []const u8, module_n
     // CompactWriter requires specific alignment for serialization
     const CompactWriter = collections.CompactWriter;
     const buffer = try gpa.alignedAlloc(u8, CompactWriter.SERIALIZATION_ALIGNMENT, bin_data.len);
+    errdefer gpa.free(buffer);
     @memcpy(buffer, bin_data);
 
     // Cast to the serialized structure and deserialize

--- a/src/eval/compile_time_finalization.zig
+++ b/src/eval/compile_time_finalization.zig
@@ -68,7 +68,7 @@ fn finalize(
         }
     }
 
-    module.const_store.verifyComplete();
+    try module.const_store.verifyComplete();
 }
 
 const RootStatus = enum {

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -176,7 +176,7 @@ pub fn formatFilePath(gpa: std.mem.Allocator, base_dir: std.Io.Dir, path: []cons
 
     // If there are any parsing problems, print them to stderr
     if (parse_ast.parse_diagnostics.items.len > 0) {
-        parse_ast.toSExprStr(gpa, &module_env.common, stderr) catch @panic("Failed to print SExpr");
+        try parse_ast.toSExprStr(gpa, &module_env.common, stderr);
         try printParseErrors(gpa, module_env.common.source, parse_ast.*, stderr);
         return error.ParsingFailed;
     }
@@ -225,7 +225,7 @@ pub fn formatStdin(gpa: std.mem.Allocator, io: std.Io, stdin: std.Io.File, stdou
 
     // If there are any parsing problems, print them to stderr
     if (parse_ast.parse_diagnostics.items.len > 0) {
-        parse_ast.toSExprStr(gpa, &module_env.common, stderr) catch @panic("Failed to print SExpr");
+        try parse_ast.toSExprStr(gpa, &module_env.common, stderr);
         try printParseErrors(gpa, module_env.common.source, parse_ast.*, stderr);
         return error.ParsingFailed;
     }

--- a/src/glue/glue.zig
+++ b/src/glue/glue.zig
@@ -369,7 +369,7 @@ fn rocGlueInner(gpa: Allocator, stderr: *std.Io.Writer, stdout: *std.Io.Writer, 
         return error.CompilationFailed;
     };
 
-    const glue_result = extractGlueResult(gpa, &glue_writer, result_buf.ptr, proc.ret_layout);
+    const glue_result = try extractGlueResult(gpa, &glue_writer, result_buf.ptr, proc.ret_layout);
     defer glue_result.deinit();
     if (glue_result.err_msg) |err_msg| {
         stderr.print("Glue spec error: {s}\n", .{err_msg}) catch {};
@@ -1949,8 +1949,8 @@ const GlueResultFiles = struct {
     }
 };
 
-fn copyRocStrSlice(allocator: Allocator, str: RocStr) []const u8 {
-    return allocator.dupe(u8, str.asSlice()) catch glueInvariant("could not copy glue result string", .{});
+fn copyRocStrSlice(allocator: Allocator, str: RocStr) Allocator.Error![]const u8 {
+    return try allocator.dupe(u8, str.asSlice());
 }
 
 fn extractGlueResult(
@@ -1958,7 +1958,7 @@ fn extractGlueResult(
     writer: *const GlueRocValueWriter,
     result_base: [*]const u8,
     result_layout: layout.Idx,
-) GlueResultFiles {
+) Allocator.Error!GlueResultFiles {
     const ok_index = writer.tagIndex("Builtin.Try", "Ok");
     const err_index = writer.tagIndex("Builtin.Try", "Err");
     const discriminant = writer.readTagDiscriminant(result_base, result_layout);
@@ -1972,9 +1972,7 @@ fn extractGlueResult(
 
         const file_layout = writer.listElementLayout(files_list_layout);
         const file_size = writer.sizeOf(file_layout);
-        const out = allocator.alloc(GlueResultFile, files.len()) catch {
-            glueInvariant("could not allocate glue result file slice", .{});
-        };
+        const out = try allocator.alloc(GlueResultFile, files.len());
         const file_bytes = files.bytes.?;
         for (out, 0..) |*file, index| {
             const file_base = file_bytes + index * file_size;
@@ -1983,8 +1981,8 @@ fn extractGlueResult(
             const name = writer.readValue(name_slot.ptr, RocStr);
             const content = writer.readValue(content_slot.ptr, RocStr);
             file.* = .{
-                .name = copyRocStrSlice(allocator, name),
-                .content = copyRocStrSlice(allocator, content),
+                .name = try copyRocStrSlice(allocator, name),
+                .content = try copyRocStrSlice(allocator, content),
             };
         }
         return .{ .allocator = allocator, .files = out, .err_msg = null };
@@ -1993,7 +1991,7 @@ fn extractGlueResult(
     if (discriminant == err_index) {
         _ = writer.variantPayloadLayout(result_layout, err_index);
         const err = writer.readValue(result_base, RocStr);
-        return .{ .allocator = allocator, .files = &.{}, .err_msg = copyRocStrSlice(allocator, err) };
+        return .{ .allocator = allocator, .files = &.{}, .err_msg = try copyRocStrSlice(allocator, err) };
     }
 
     glueInvariant("glue result Try discriminant {d} was neither Ok nor Err", .{discriminant});

--- a/src/glue/glue.zig
+++ b/src/glue/glue.zig
@@ -212,8 +212,10 @@ fn rocGlueInner(gpa: Allocator, stderr: *std.Io.Writer, stdout: *std.Io.Writer, 
         if (mod.is_platform_sibling or mod.is_platform_main) {
             const artifact = mod.semantic.checked_artifact orelse continue;
             type_table.clearVarMap();
-            if (collectModuleTypeInfo(gpa, artifact, mod.name, hosted_indices, &type_table)) |mod_info| {
-                collected_modules.append(gpa, mod_info) catch {};
+            if (try collectModuleTypeInfo(gpa, artifact, mod.name, hosted_indices, &type_table)) |mod_info| {
+                var owned_mod_info = mod_info;
+                errdefer owned_mod_info.deinit(gpa);
+                try collected_modules.append(gpa, owned_mod_info);
             }
         }
     }
@@ -709,13 +711,13 @@ fn parsePlatformHeader(gpa: Allocator, platform_path: []const u8, std_io: std.Io
                     var type_buf = std.ArrayList(u8).empty;
                     defer type_buf.deinit(gpa);
 
-                    printTypeAnnoToBuf(gpa, &env, parse_ast, entry.type_anno, &type_buf);
+                    try printTypeAnnoToBuf(gpa, &env, parse_ast, entry.type_anno, &type_buf);
 
                     // Generate stub expression from type annotation
                     var stub_buf = std.ArrayList(u8).empty;
                     defer stub_buf.deinit(gpa);
 
-                    generateStubExprFromTypeAnno(gpa, &env, parse_ast, entry.type_anno, &stub_buf);
+                    try generateStubExprFromTypeAnno(gpa, &env, parse_ast, entry.type_anno, &stub_buf);
 
                     try requires_entries.append(gpa, .{
                         .name = try gpa.dupe(u8, name),
@@ -2090,15 +2092,13 @@ fn typeStringAlloc(
     gpa: std.mem.Allocator,
     artifact: *const CheckedArtifact.CheckedModuleArtifact,
     checked_type: CheckedArtifact.CheckedTypeId,
-) []const u8 {
+) Allocator.Error![]const u8 {
     var buf = std.ArrayList(u8).empty;
+    errdefer buf.deinit(gpa);
     var active = std.AutoHashMap(CheckedArtifact.CheckedTypeId, void).init(gpa);
     defer active.deinit();
-    writeTypeString(gpa, artifact, checked_type, &buf, &active) catch {
-        buf.deinit(gpa);
-        return gpa.dupe(u8, "") catch "";
-    };
-    return buf.toOwnedSlice(gpa) catch "";
+    try writeTypeString(gpa, artifact, checked_type, &buf, &active);
+    return buf.toOwnedSlice(gpa);
 }
 
 fn writeTypeString(
@@ -2273,16 +2273,14 @@ fn extractRecordFields(
     gpa: std.mem.Allocator,
     artifact: *const CheckedArtifact.CheckedModuleArtifact,
     checked_type: CheckedArtifact.CheckedTypeId,
-) []const CollectedModuleTypeInfo.CollectedRecordFieldInfo {
+) Allocator.Error![]const CollectedModuleTypeInfo.CollectedRecordFieldInfo {
     var fields = std.ArrayList(CheckedArtifact.CheckedRecordField).empty;
     defer fields.deinit(gpa);
-    if (!(collectRecordFieldsForRoot(gpa, artifact, checked_type, &fields) catch {
-        return &[_]CollectedModuleTypeInfo.CollectedRecordFieldInfo{};
-    })) {
+    if (!(try collectRecordFieldsForRoot(gpa, artifact, checked_type, &fields))) {
         return &[_]CollectedModuleTypeInfo.CollectedRecordFieldInfo{};
     }
 
-    var indices = gpa.alloc(usize, fields.items.len) catch return &[_]CollectedModuleTypeInfo.CollectedRecordFieldInfo{};
+    var indices = try gpa.alloc(usize, fields.items.len);
     defer gpa.free(indices);
     for (0..fields.items.len) |i| indices[i] = i;
 
@@ -2301,14 +2299,25 @@ fn extractRecordFields(
     std.mem.sort(usize, indices, SortCtx{ .fields = fields.items, .names = &artifact.canonical_names }, SortCtx.lessThan);
 
     var result_list = std.ArrayList(CollectedModuleTypeInfo.CollectedRecordFieldInfo).empty;
+    errdefer {
+        for (result_list.items) |item| {
+            gpa.free(item.name);
+            gpa.free(item.type_str);
+        }
+        result_list.deinit(gpa);
+    }
     for (indices) |idx| {
         const field = fields.items[idx];
-        result_list.append(gpa, .{
-            .name = gpa.dupe(u8, artifact.canonical_names.recordFieldLabelText(field.name)) catch continue,
-            .type_str = typeStringAlloc(gpa, artifact, field.ty),
-        }) catch continue;
+        const name = try gpa.dupe(u8, artifact.canonical_names.recordFieldLabelText(field.name));
+        errdefer gpa.free(name);
+        const type_str = try typeStringAlloc(gpa, artifact, field.ty);
+        errdefer gpa.free(type_str);
+        try result_list.append(gpa, .{
+            .name = name,
+            .type_str = type_str,
+        });
     }
-    return result_list.toOwnedSlice(gpa) catch &[_]CollectedModuleTypeInfo.CollectedRecordFieldInfo{};
+    return result_list.toOwnedSlice(gpa);
 }
 
 fn collectRecordFieldsForRoot(
@@ -2340,22 +2349,48 @@ fn collectModuleTypeInfo(
     module_name: []const u8,
     hosted_indices: []const HostedProcGlobalIndex,
     type_table: *TypeTable,
-) ?CollectedModuleTypeInfo {
-    var main_type_str: []const u8 = gpa.dupe(u8, "") catch "";
+) Allocator.Error!?CollectedModuleTypeInfo {
+    var main_type_str: []const u8 = try gpa.dupe(u8, "");
+    errdefer gpa.free(main_type_str);
     for (artifact.checked_types.nominal_declarations) |declaration| {
         const type_name = TypeTable.getTypeDisplayName(artifact.canonical_names.typeNameText(declaration.nominal.type_name));
         if (std.mem.eql(u8, type_name, module_name)) {
-            if (main_type_str.len > 0) gpa.free(main_type_str);
-            main_type_str = typeStringAlloc(gpa, artifact, declaration.declaration_root);
+            gpa.free(main_type_str);
+            main_type_str = try typeStringAlloc(gpa, artifact, declaration.declaration_root);
             break;
         }
     }
 
     // Collect functions
     var functions = std.ArrayList(CollectedModuleTypeInfo.CollectedFunctionInfo).empty;
+    errdefer {
+        for (functions.items) |f| {
+            gpa.free(f.name);
+            gpa.free(f.type_str);
+        }
+        functions.deinit(gpa);
+    }
     var hosted_functions = std.ArrayList(CollectedModuleTypeInfo.CollectedHostedFunctionInfo).empty;
+    errdefer {
+        for (hosted_functions.items) |h| {
+            gpa.free(h.name);
+            gpa.free(h.type_str);
+            for (h.arg_fields) |field| {
+                gpa.free(field.name);
+                gpa.free(field.type_str);
+            }
+            gpa.free(h.arg_fields);
+            for (h.ret_fields) |field| {
+                gpa.free(field.name);
+                gpa.free(field.type_str);
+            }
+            gpa.free(h.ret_fields);
+            if (h.arg_type_ids.len > 0) gpa.free(h.arg_type_ids);
+        }
+        hosted_functions.deinit(gpa);
+    }
 
-    const module_prefix = std.fmt.allocPrint(gpa, "{s}.", .{module_name}) catch return null;
+    const module_prefix = try std.fmt.allocPrint(gpa, "{s}.", .{module_name});
     defer gpa.free(module_prefix);
 
     for (artifact.top_level_values.entries) |entry| {
@@ -2371,23 +2406,39 @@ fn collectModuleTypeInfo(
             continue;
 
         const checked_type = checkedTypeRootForScheme(artifact, entry.source_scheme);
-        const type_str = typeStringAlloc(gpa, artifact, checked_type);
+        const type_str = try typeStringAlloc(gpa, artifact, checked_type);
+        errdefer gpa.free(type_str);
 
         if (hostedProcForDef(&artifact.hosted_procs, def_idx)) |_| {
             // Extract record fields from function arg and return types.
             var arg_fields: []const CollectedModuleTypeInfo.CollectedRecordFieldInfo = &.{};
+            errdefer {
+                for (arg_fields) |field| {
+                    gpa.free(field.name);
+                    gpa.free(field.type_str);
+                }
+                gpa.free(arg_fields);
+            }
             var ret_fields: []const CollectedModuleTypeInfo.CollectedRecordFieldInfo = &.{};
+            errdefer {
+                for (ret_fields) |field| {
+                    gpa.free(field.name);
+                    gpa.free(field.type_str);
+                }
+                gpa.free(ret_fields);
+            }
             var arg_type_ids: []const u64 = &.{};
+            errdefer if (arg_type_ids.len > 0) gpa.free(arg_type_ids);
             var ret_type_id: u64 = 0;
 
             if (functionPayloadForRoot(artifact, checked_type)) |func| {
-                ret_fields = extractRecordFields(gpa, artifact, func.ret);
+                ret_fields = try extractRecordFields(gpa, artifact, func.ret);
                 if (func.args.len == 1) {
-                    arg_fields = extractRecordFields(gpa, artifact, func.args[0]);
+                    arg_fields = try extractRecordFields(gpa, artifact, func.args[0]);
                 }
                 ret_type_id = type_table.getOrInsert(artifact, func.ret);
                 if (func.args.len > 0) {
-                    const ids = gpa.alloc(u64, func.args.len) catch continue;
+                    const ids = try gpa.alloc(u64, func.args.len);
                     for (func.args, 0..) |arg, i| {
                         ids[i] = type_table.getOrInsert(artifact, arg);
                     }
@@ -2397,34 +2448,32 @@ fn collectModuleTypeInfo(
                 ret_type_id = type_table.insertUnit();
             }
 
-            hosted_functions.append(gpa, .{
+            const name = try gpa.dupe(u8, local_name);
+            errdefer gpa.free(name);
+            try hosted_functions.append(gpa, .{
                 .index = hostedGlobalIndexForDef(hosted_indices, artifact.key, def_idx),
-                .name = gpa.dupe(u8, local_name) catch continue,
+                .name = name,
                 .type_str = type_str,
                 .arg_fields = arg_fields,
                 .ret_fields = ret_fields,
                 .arg_type_ids = arg_type_ids,
                 .ret_type_id = ret_type_id,
-            }) catch {
-                gpa.free(type_str);
-                continue;
-            };
+            });
         } else switch (entry.value) {
             .procedure_binding => {
-                functions.append(gpa, .{
-                    .name = gpa.dupe(u8, local_name) catch continue,
+                const name = try gpa.dupe(u8, local_name);
+                errdefer gpa.free(name);
+                try functions.append(gpa, .{
+                    .name = name,
                     .type_str = type_str,
-                }) catch {
-                    gpa.free(type_str);
-                    continue;
-                };
+                });
             },
             .const_ref => gpa.free(type_str),
         }
     }
 
     return CollectedModuleTypeInfo{
-        .name = gpa.dupe(u8, module_name) catch return null,
+        .name = try gpa.dupe(u8, module_name),
         .main_type = main_type_str,
         .functions = functions,
         .hosted_functions = hosted_functions,
@@ -2432,7 +2481,7 @@ fn collectModuleTypeInfo(
 }
 
 /// Print a type annotation to a buffer (for requires entries which use AST types)
-fn printTypeAnnoToBuf(gpa: std.mem.Allocator, env: *ModuleEnv, ast: *const parse.AST, type_anno_idx: parse.AST.TypeAnno.Idx, buf: *std.ArrayList(u8)) void {
+fn printTypeAnnoToBuf(gpa: std.mem.Allocator, env: *ModuleEnv, ast: *const parse.AST, type_anno_idx: parse.AST.TypeAnno.Idx, buf: *std.ArrayList(u8)) Allocator.Error!void {
     const type_anno = ast.store.getTypeAnno(type_anno_idx);
 
     switch (type_anno) {
@@ -2440,17 +2489,17 @@ fn printTypeAnnoToBuf(gpa: std.mem.Allocator, env: *ModuleEnv, ast: *const parse
             const arrow = if (f.effectful) "=>" else "->";
             const args = ast.store.typeAnnoSlice(f.args);
             if (args.len == 0) {
-                buf.appendSlice(gpa, "()") catch {};
+                try buf.appendSlice(gpa, "()");
             } else {
                 for (args, 0..) |arg_idx, i| {
-                    if (i > 0) buf.appendSlice(gpa, ", ") catch {};
-                    printTypeAnnoToBuf(gpa, env, ast, arg_idx, buf);
+                    if (i > 0) try buf.appendSlice(gpa, ", ");
+                    try printTypeAnnoToBuf(gpa, env, ast, arg_idx, buf);
                 }
             }
-            buf.appendSlice(gpa, " ") catch {};
-            buf.appendSlice(gpa, arrow) catch {};
-            buf.appendSlice(gpa, " ") catch {};
-            printTypeAnnoToBuf(gpa, env, ast, f.ret, buf);
+            try buf.appendSlice(gpa, " ");
+            try buf.appendSlice(gpa, arrow);
+            try buf.appendSlice(gpa, " ");
+            try printTypeAnnoToBuf(gpa, env, ast, f.ret, buf);
         },
         .ty => |t| {
             // Print qualified type name
@@ -2458,93 +2507,93 @@ fn printTypeAnnoToBuf(gpa: std.mem.Allocator, env: *ModuleEnv, ast: *const parse
             for (qualifiers) |qual_tok_idx| {
                 const qual_tok: parse.tokenize.Token.Idx = @intCast(qual_tok_idx);
                 if (ast.tokens.resolveIdentifier(qual_tok)) |ident_idx| {
-                    buf.appendSlice(gpa, env.common.getIdent(ident_idx)) catch {};
-                    buf.append(gpa, '.') catch {};
+                    try buf.appendSlice(gpa, env.common.getIdent(ident_idx));
+                    try buf.append(gpa, '.');
                 }
             }
             if (ast.tokens.resolveIdentifier(t.token)) |ident_idx| {
-                buf.appendSlice(gpa, env.common.getIdent(ident_idx)) catch {};
+                try buf.appendSlice(gpa, env.common.getIdent(ident_idx));
             }
         },
         .ty_var => |tv| {
             if (ast.tokens.resolveIdentifier(tv.tok)) |ident_idx| {
-                buf.appendSlice(gpa, env.common.getIdent(ident_idx)) catch {};
+                try buf.appendSlice(gpa, env.common.getIdent(ident_idx));
             }
         },
         .record => |r| {
-            buf.appendSlice(gpa, "{ ") catch {};
+            try buf.appendSlice(gpa, "{ ");
             const fields = ast.store.annoRecordFieldSlice(r.fields);
             for (fields, 0..) |field_idx, i| {
-                if (i > 0) buf.appendSlice(gpa, ", ") catch {};
+                if (i > 0) try buf.appendSlice(gpa, ", ");
                 const field = ast.store.getAnnoRecordField(field_idx) catch continue;
                 if (ast.tokens.resolveIdentifier(field.name)) |ident_idx| {
-                    buf.appendSlice(gpa, env.common.getIdent(ident_idx)) catch {};
-                    buf.appendSlice(gpa, " : ") catch {};
+                    try buf.appendSlice(gpa, env.common.getIdent(ident_idx));
+                    try buf.appendSlice(gpa, " : ");
                 }
-                printTypeAnnoToBuf(gpa, env, ast, field.ty, buf);
+                try printTypeAnnoToBuf(gpa, env, ast, field.ty, buf);
             }
             switch (r.ext) {
                 .closed => {},
-                .open => buf.appendSlice(gpa, ", ..") catch {},
+                .open => try buf.appendSlice(gpa, ", .."),
                 .named => |named| {
-                    buf.appendSlice(gpa, ", ..") catch {};
-                    printTypeAnnoToBuf(gpa, env, ast, named.anno, buf);
+                    try buf.appendSlice(gpa, ", ..");
+                    try printTypeAnnoToBuf(gpa, env, ast, named.anno, buf);
                 },
             }
-            buf.appendSlice(gpa, " }") catch {};
+            try buf.appendSlice(gpa, " }");
         },
         .tag_union => |tu| {
-            buf.append(gpa, '[') catch {};
+            try buf.append(gpa, '[');
             const tags = ast.store.typeAnnoSlice(tu.tags);
             for (tags, 0..) |tag_idx, i| {
-                if (i > 0) buf.appendSlice(gpa, ", ") catch {};
-                printTypeAnnoToBuf(gpa, env, ast, tag_idx, buf);
+                if (i > 0) try buf.appendSlice(gpa, ", ");
+                try printTypeAnnoToBuf(gpa, env, ast, tag_idx, buf);
             }
             switch (tu.ext) {
                 .closed => {},
-                .open => buf.appendSlice(gpa, ", ..") catch {},
+                .open => try buf.appendSlice(gpa, ", .."),
                 .named => |named| {
-                    buf.appendSlice(gpa, ", ..") catch {};
-                    printTypeAnnoToBuf(gpa, env, ast, named.anno, buf);
+                    try buf.appendSlice(gpa, ", ..");
+                    try printTypeAnnoToBuf(gpa, env, ast, named.anno, buf);
                 },
             }
-            buf.append(gpa, ']') catch {};
+            try buf.append(gpa, ']');
         },
         .tuple => |t| {
-            buf.append(gpa, '(') catch {};
+            try buf.append(gpa, '(');
             const annos = ast.store.typeAnnoSlice(t.annos);
             for (annos, 0..) |anno_idx, i| {
-                if (i > 0) buf.appendSlice(gpa, ", ") catch {};
-                printTypeAnnoToBuf(gpa, env, ast, anno_idx, buf);
+                if (i > 0) try buf.appendSlice(gpa, ", ");
+                try printTypeAnnoToBuf(gpa, env, ast, anno_idx, buf);
             }
-            buf.append(gpa, ')') catch {};
+            try buf.append(gpa, ')');
         },
         .apply => |a| {
             const args = ast.store.typeAnnoSlice(a.args);
             if (args.len > 0) {
-                printTypeAnnoToBuf(gpa, env, ast, args[0], buf);
+                try printTypeAnnoToBuf(gpa, env, ast, args[0], buf);
                 if (args.len > 1) {
-                    buf.append(gpa, ' ') catch {};
+                    try buf.append(gpa, ' ');
                     for (args[1..], 0..) |arg_idx, i| {
-                        if (i > 0) buf.append(gpa, ' ') catch {};
-                        printTypeAnnoToBuf(gpa, env, ast, arg_idx, buf);
+                        if (i > 0) try buf.append(gpa, ' ');
+                        try printTypeAnnoToBuf(gpa, env, ast, arg_idx, buf);
                     }
                 }
             }
         },
         .parens => |p| {
-            buf.append(gpa, '(') catch {};
-            printTypeAnnoToBuf(gpa, env, ast, p.anno, buf);
-            buf.append(gpa, ')') catch {};
+            try buf.append(gpa, '(');
+            try printTypeAnnoToBuf(gpa, env, ast, p.anno, buf);
+            try buf.append(gpa, ')');
         },
         .underscore => {
-            buf.append(gpa, '_') catch {};
+            try buf.append(gpa, '_');
         },
         .underscore_type_var => {
-            buf.append(gpa, '_') catch {};
+            try buf.append(gpa, '_');
         },
         .malformed => {
-            buf.appendSlice(gpa, "<malformed>") catch {};
+            try buf.appendSlice(gpa, "<malformed>");
         },
     }
 }
@@ -2552,7 +2601,7 @@ fn printTypeAnnoToBuf(gpa: std.mem.Allocator, env: *ModuleEnv, ast: *const parse
 /// Generate a stub expression from a type annotation.
 /// This produces valid Roc expressions that will crash at runtime rather than compile-time.
 /// Uses `...` inside lambdas to defer the crash to runtime.
-fn generateStubExprFromTypeAnno(gpa: std.mem.Allocator, env: *ModuleEnv, ast: *const parse.AST, type_anno_idx: parse.AST.TypeAnno.Idx, buf: *std.ArrayList(u8)) void {
+fn generateStubExprFromTypeAnno(gpa: std.mem.Allocator, env: *ModuleEnv, ast: *const parse.AST, type_anno_idx: parse.AST.TypeAnno.Idx, buf: *std.ArrayList(u8)) Allocator.Error!void {
     const type_anno = ast.store.getTypeAnno(type_anno_idx);
 
     switch (type_anno) {
@@ -2561,15 +2610,15 @@ fn generateStubExprFromTypeAnno(gpa: std.mem.Allocator, env: *ModuleEnv, ast: *c
             const args = ast.store.typeAnnoSlice(f.args);
             if (args.len == 0) {
                 // No args: || body
-                buf.appendSlice(gpa, "|| ") catch {};
+                try buf.appendSlice(gpa, "|| ");
             } else {
                 // Has args: |_, _, ...| body
-                buf.append(gpa, '|') catch {};
+                try buf.append(gpa, '|');
                 for (0..args.len) |i| {
-                    if (i > 0) buf.appendSlice(gpa, ", ") catch {};
-                    buf.append(gpa, '_') catch {};
+                    if (i > 0) try buf.appendSlice(gpa, ", ");
+                    try buf.append(gpa, '_');
                 }
-                buf.appendSlice(gpa, "| ") catch {};
+                try buf.appendSlice(gpa, "| ");
             }
 
             // Check if return type is unit {}
@@ -2579,32 +2628,32 @@ fn generateStubExprFromTypeAnno(gpa: std.mem.Allocator, env: *ModuleEnv, ast: *c
                 const fields = ast.store.annoRecordFieldSlice(record.fields);
                 if (fields.len == 0 and record.ext == .closed) {
                     // Return type is {} (unit) - return empty record
-                    buf.appendSlice(gpa, "{}") catch {};
+                    try buf.appendSlice(gpa, "{}");
                     return;
                 }
             }
 
             // Non-unit return type - use { ... } to crash at runtime (not compile-time)
             // The block syntax is required for single-line lambdas
-            buf.appendSlice(gpa, "{ ... }") catch {};
+            try buf.appendSlice(gpa, "{ ... }");
         },
         .record => |r| {
-            buf.appendSlice(gpa, "{ ") catch {};
+            try buf.appendSlice(gpa, "{ ");
             const fields = ast.store.annoRecordFieldSlice(r.fields);
             for (fields, 0..) |field_idx, i| {
-                if (i > 0) buf.appendSlice(gpa, ", ") catch {};
+                if (i > 0) try buf.appendSlice(gpa, ", ");
                 const field = ast.store.getAnnoRecordField(field_idx) catch continue;
                 if (ast.tokens.resolveIdentifier(field.name)) |ident_idx| {
-                    buf.appendSlice(gpa, env.common.getIdent(ident_idx)) catch {};
-                    buf.appendSlice(gpa, ": ") catch {};
+                    try buf.appendSlice(gpa, env.common.getIdent(ident_idx));
+                    try buf.appendSlice(gpa, ": ");
                 }
-                generateStubExprFromTypeAnno(gpa, env, ast, field.ty, buf);
+                try generateStubExprFromTypeAnno(gpa, env, ast, field.ty, buf);
             }
-            buf.appendSlice(gpa, " }") catch {};
+            try buf.appendSlice(gpa, " }");
         },
         else => {
             // For all other types, use { ... } to crash at runtime
-            buf.appendSlice(gpa, "{ ... }") catch {};
+            try buf.appendSlice(gpa, "{ ... }");
         },
     }
 }

--- a/src/glue/platform/host.zig
+++ b/src/glue/platform/host.zig
@@ -156,6 +156,15 @@ const HostEnv = struct {
     dealloc_count: usize = 0,
 };
 
+/// Report an out-of-memory failure from a Roc host allocation callback and
+/// abort. These callbacks use the C ABI and cannot return a Zig error, so a
+/// reported `exit(1)` is the graceful failure path.
+fn hostAllocFailed(host: *HostEnv) noreturn {
+    const stderr: std.Io.File = .stderr();
+    stderr.writeStreamingAll(host.std_io, "\x1b[31mHost error:\x1b[0m out of memory\n") catch {};
+    std.process.exit(1);
+}
+
 /// Roc allocation function with size-tracking metadata
 fn rocAllocFn(roc_alloc: *builtins.host_abi.RocAlloc, env: *anyopaque) callconv(.c) void {
     const roc_alloc_addr = @intFromPtr(roc_alloc);
@@ -179,16 +188,7 @@ fn rocAllocFn(roc_alloc: *builtins.host_abi.RocAlloc, env: *anyopaque) callconv(
 
     const result = allocator.rawAlloc(total_size, align_enum, @returnAddress());
 
-    const base_ptr = result orelse {
-        const stderr: std.Io.File = .stderr();
-        var buf: [256]u8 = undefined;
-        const msg = std.fmt.bufPrint(&buf, "\x1b[31mHost error:\x1b[0m allocation failed for size={d} align={d}\n", .{
-            total_size,
-            roc_alloc.alignment,
-        }) catch "\x1b[31mHost error:\x1b[0m allocation failed, out of memory\n";
-        stderr.writeStreamingAll(host.std_io, msg) catch {};
-        std.process.exit(1);
-    };
+    const base_ptr = result orelse hostAllocFailed(host);
 
     const base_addr = @intFromPtr(base_ptr);
     if (base_addr % min_alignment != 0) {
@@ -209,7 +209,7 @@ fn rocAllocFn(roc_alloc: *builtins.host_abi.RocAlloc, env: *anyopaque) callconv(
         .ptr = base_ptr,
         .total_size = total_size,
         .alignment = align_enum,
-    }) catch {};
+    }) catch hostAllocFailed(host);
     host.alloc_count += 1;
 
     if (trace_refcount or (builtin.mode == .Debug and builtin.os.tag != .freestanding)) {
@@ -279,11 +279,7 @@ fn rocReallocFn(roc_realloc: *builtins.host_abi.RocRealloc, env: *anyopaque) cal
 
     const old_slice = @as([*]u8, @ptrCast(old_base_ptr))[0..old_total_size];
 
-    const new_ptr = allocator.rawAlloc(new_total_size, align_enum, @returnAddress()) orelse {
-        const stderr: std.Io.File = .stderr();
-        stderr.writeStreamingAll(host.std_io, "\x1b[31mHost error:\x1b[0m reallocation failed, out of memory\n") catch {};
-        std.process.exit(1);
-    };
+    const new_ptr = allocator.rawAlloc(new_total_size, align_enum, @returnAddress()) orelse hostAllocFailed(host);
 
     const copy_size = @min(old_total_size, new_total_size);
     @memcpy(new_ptr[0..copy_size], old_slice[0..copy_size]);
@@ -298,7 +294,7 @@ fn rocReallocFn(roc_realloc: *builtins.host_abi.RocRealloc, env: *anyopaque) cal
         .ptr = new_ptr,
         .total_size = new_total_size,
         .alignment = align_enum,
-    }) catch {};
+    }) catch hostAllocFailed(host);
 
     allocator.rawFree(old_slice, align_enum, @returnAddress());
 

--- a/src/ipc/coordination.zig
+++ b/src/ipc/coordination.zig
@@ -95,9 +95,12 @@ fn readFdInfoFromCommandLine(allocator: std.mem.Allocator) CoordinationError!FdI
 /// POSIX: Read fd and size from temporary file
 fn readFdInfoFromFile(allocator: std.mem.Allocator, io: std.Io) CoordinationError!FdInfo {
     // Get our own executable path
-    const exe_path = std.process.executablePathAlloc(io, allocator) catch {
-        std.log.err("Failed to get executable path", .{});
-        return error.FdInfoReadFailed;
+    const exe_path = std.process.executablePathAlloc(io, allocator) catch |err| switch (err) {
+        error.OutOfMemory => return error.AllocationFailed,
+        else => {
+            std.log.err("Failed to get executable path", .{});
+            return error.FdInfoReadFailed;
+        },
     };
     defer allocator.free(exe_path);
 
@@ -137,9 +140,12 @@ fn readFdInfoFromFile(allocator: std.mem.Allocator, io: std.Io) CoordinationErro
     defer allocator.free(fd_file_path);
 
     // Read the file
-    const content = std.Io.Dir.cwd().readFileAlloc(io, fd_file_path, allocator, .limited(128)) catch {
-        std.log.err("Failed to read fd file at '{s}'", .{fd_file_path});
-        return error.FileReadFailed;
+    const content = std.Io.Dir.cwd().readFileAlloc(io, fd_file_path, allocator, .limited(128)) catch |err| switch (err) {
+        error.OutOfMemory => return error.AllocationFailed,
+        else => {
+            std.log.err("Failed to read fd file at '{s}'", .{fd_file_path});
+            return error.FileReadFailed;
+        },
     };
     defer allocator.free(content);
 

--- a/src/lir/checked_pipeline.zig
+++ b/src/lir/checked_pipeline.zig
@@ -171,7 +171,7 @@ pub fn lowerCheckedModulesToLir(
     roots: RootRequestSet,
     target: TargetConfig,
 ) LowerResourceError!LoweredProgram {
-    verifyCheckedBoundary(modules, target);
+    try verifyCheckedBoundary(modules, target);
 
     const layout_requests = try collectLayoutRequests(allocator, modules.root.module, roots.layout_requests);
     defer allocator.free(layout_requests);
@@ -237,10 +237,10 @@ pub fn lowerCheckedModulesToLir(
     };
 }
 
-fn verifyCheckedBoundary(modules: CheckedModuleSet, target: TargetConfig) void {
+fn verifyCheckedBoundary(modules: CheckedModuleSet, target: TargetConfig) Allocator.Error!void {
     if (builtin.mode != .Debug) return;
     switch (target.checked_module_state) {
-        .complete => modules.root.module.verifyComplete(),
+        .complete => try modules.root.module.verifyComplete(),
         .checking_finalization => modules.root.module.verifyReadyForCompileTimeLowering(),
     }
 }

--- a/src/lsp/build_session.zig
+++ b/src/lsp/build_session.zig
@@ -82,7 +82,7 @@ pub const BuildSession = struct {
 
         // Drain reports regardless of build success to capture parse errors
         // Parse errors are emitted to the sink even when build fails
-        const drained_reports = env.drainReports() catch null;
+        const drained_reports = try env.drainReports();
 
         return BuildSession{
             .allocator = allocator,

--- a/src/lsp/cir_queries.zig
+++ b/src/lsp/cir_queries.zig
@@ -261,6 +261,11 @@ const CollectReferencesContext = struct {
     allocator: std.mem.Allocator,
     results: *std.ArrayList(LspRange),
 
+    /// Records an OOM that occurred inside a visit callback. The CirVisitor
+    /// callback signature returns `VisitAction` (no error channel), so OOM is
+    /// stashed here and re-raised by the lsp-level entry point after the walk.
+    oom: ?std.mem.Allocator.Error = null,
+
     /// Pre-visit callback for expressions.
     fn visitExprPre(ctx: *CollectReferencesContext, expr_idx: CIR.Expr.Idx, expr: CIR.Expr) VisitAction {
         switch (expr) {
@@ -268,7 +273,10 @@ const CollectReferencesContext = struct {
                 if (@intFromEnum(lookup.pattern_idx) == @intFromEnum(ctx.target_pattern)) {
                     const region = ctx.store.getExprRegion(expr_idx);
                     if (regionToRange(ctx.module_env, region)) |range| {
-                        ctx.results.append(ctx.allocator, range) catch {};
+                        ctx.results.append(ctx.allocator, range) catch |err| {
+                            ctx.oom = err;
+                            return .stop;
+                        };
                     }
                 }
             },
@@ -473,8 +481,9 @@ pub fn collectLookupReferences(
     module_env: *ModuleEnv,
     target_pattern: CIR.Pattern.Idx,
     allocator: std.mem.Allocator,
-) std.ArrayList(LspRange) {
+) std.mem.Allocator.Error!std.ArrayList(LspRange) {
     var results: std.ArrayList(LspRange) = .empty;
+    errdefer results.deinit(allocator);
 
     var ctx = CollectReferencesContext{
         .store = &module_env.store,
@@ -500,6 +509,9 @@ pub fn collectLookupReferences(
     if (!visitor.stopped) {
         visitor.walkModule(&module_env.store, module_env.all_statements);
     }
+
+    // Re-raise any OOM that was stashed by a visit callback.
+    if (ctx.oom) |err| return err;
 
     return results;
 }

--- a/src/lsp/completion/builder.zig
+++ b/src/lsp/completion/builder.zig
@@ -84,7 +84,7 @@ pub const CompletionBuilder = struct {
 
     /// Get or build the scope map for the given module env.
     /// Reuses a previously built scope if the module's qualified ident idx matches.
-    fn getOrBuildScope(self: *CompletionBuilder, module_env: *ModuleEnv) *scope_map.ScopeMap {
+    fn getOrBuildScope(self: *CompletionBuilder, module_env: *ModuleEnv) Allocator.Error!*scope_map.ScopeMap {
         const module_ident = module_env.qualified_module_ident;
         if (self.cached_scope != null and
             !self.cached_scope_module_ident.isNone() and
@@ -96,7 +96,8 @@ pub const CompletionBuilder = struct {
         if (self.cached_scope) |*old| old.deinit();
 
         var scope = scope_map.ScopeMap.init(self.allocator);
-        scope.build(module_env) catch {};
+        errdefer scope.deinit();
+        try scope.build(module_env);
         self.cached_scope = scope;
         self.cached_scope_module_ident = module_ident;
         return &self.cached_scope.?;
@@ -272,7 +273,7 @@ pub const CompletionBuilder = struct {
         module_env: *ModuleEnv,
         module_name: []const u8,
     ) !void {
-        var type_writer = module_env.initTypeWriter() catch null;
+        var type_writer: ?types.TypeWriter = try module_env.initTypeWriter();
         defer if (type_writer) |*tw| tw.deinit();
 
         const exposed = &module_env.common.exposed_items;
@@ -315,19 +316,22 @@ pub const CompletionBuilder = struct {
                         const def = module_env.store.getDef(def_idx);
                         const type_var = ModuleEnv.varFrom(def.pattern);
                         // Type formatting is best-effort; missing type info is acceptable
-                        tw.write(type_var, .one_line) catch {};
+                        tw.write(type_var, .one_line) catch |err| switch (err) {
+                            error.OutOfMemory => return error.OutOfMemory,
+                            error.WriteFailed => {},
+                        };
                         const type_str = tw.get();
                         if (type_str.len > 0) {
-                            detail = self.allocator.dupe(u8, type_str) catch null;
+                            detail = try self.allocator.dupe(u8, type_str);
                         }
                         tw.reset();
 
-                        documentation = doc_comments.extractDocForDef(
+                        documentation = try doc_comments.extractDocForDef(
                             self.allocator,
                             module_env.common.source,
                             &module_env.store,
                             def,
-                        ) catch null;
+                        );
                     }
                 }
             }
@@ -433,13 +437,13 @@ pub const CompletionBuilder = struct {
                     const name = module_env.getIdentText(header.name);
                     if (name.len == 0) continue;
 
-                    const documentation = doc_comments.extractDocForStatement(
+                    const documentation = try doc_comments.extractDocForStatement(
                         self.allocator,
                         module_env.common.source,
                         &module_env.store,
                         stmt,
                         stmt_idx,
-                    ) catch null;
+                    );
 
                     _ = try self.addItem(.{
                         .label = name,
@@ -458,10 +462,10 @@ pub const CompletionBuilder = struct {
     /// Add local definition completions (variables, functions in scope).
     pub fn addLocalCompletions(self: *CompletionBuilder, module_env: *ModuleEnv, cursor_offset: u32) !void {
         // Initialize type writer for formatting types
-        var type_writer = module_env.initTypeWriter() catch null;
+        var type_writer: ?types.TypeWriter = try module_env.initTypeWriter();
         defer if (type_writer) |*tw| tw.deinit();
 
-        const scope = self.getOrBuildScope(module_env);
+        const scope = try self.getOrBuildScope(module_env);
 
         // Add local variables in scope at cursor position
         for (scope.bindings.items) |binding| {
@@ -481,19 +485,22 @@ pub const CompletionBuilder = struct {
             if (type_writer) |*tw| {
                 const type_var = ModuleEnv.varFrom(binding.pattern_idx);
                 // Type formatting is best-effort; missing type info is acceptable
-                tw.write(type_var, .one_line) catch {};
+                tw.write(type_var, .one_line) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    error.WriteFailed => {},
+                };
                 const type_str = tw.get();
                 if (type_str.len > 0) {
-                    detail = self.allocator.dupe(u8, type_str) catch null;
+                    detail = try self.allocator.dupe(u8, type_str);
                 }
                 tw.reset();
             }
 
-            const documentation = doc_comments.extractDocCommentBefore(
+            const documentation = try doc_comments.extractDocCommentBefore(
                 self.allocator,
                 module_env.common.source,
                 module_env.store.getPatternRegion(binding.pattern_idx).start.offset,
-            ) catch null;
+            );
 
             _ = try self.addItem(.{
                 .label = label,
@@ -531,20 +538,23 @@ pub const CompletionBuilder = struct {
             if (type_writer) |*tw| {
                 const type_var = ModuleEnv.varFrom(def.pattern);
                 // Type formatting is best-effort; missing type info is acceptable
-                tw.write(type_var, .one_line) catch {};
+                tw.write(type_var, .one_line) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    error.WriteFailed => {},
+                };
                 const type_str = tw.get();
                 if (type_str.len > 0) {
-                    detail = self.allocator.dupe(u8, type_str) catch null;
+                    detail = try self.allocator.dupe(u8, type_str);
                 }
                 tw.reset();
             }
 
-            const documentation = doc_comments.extractDocForDef(
+            const documentation = try doc_comments.extractDocForDef(
                 self.allocator,
                 module_env.common.source,
                 &module_env.store,
                 def,
-            ) catch null;
+            );
 
             _ = try self.addItem(.{
                 .label = name,
@@ -588,21 +598,24 @@ pub const CompletionBuilder = struct {
                 if (type_writer) |*tw| {
                     const type_var = ModuleEnv.varFrom(pattern_idx);
                     // Type formatting is best-effort; missing type info is acceptable
-                    tw.write(type_var, .one_line) catch {};
+                    tw.write(type_var, .one_line) catch |err| switch (err) {
+                        error.OutOfMemory => return error.OutOfMemory,
+                        error.WriteFailed => {},
+                    };
                     const type_str = tw.get();
                     if (type_str.len > 0) {
-                        detail = self.allocator.dupe(u8, type_str) catch null;
+                        detail = try self.allocator.dupe(u8, type_str);
                     }
                     tw.reset();
                 }
 
-                const documentation = doc_comments.extractDocForStatement(
+                const documentation = try doc_comments.extractDocForStatement(
                     self.allocator,
                     module_env.common.source,
                     &module_env.store,
                     stmt,
                     stmt_idx,
-                ) catch null;
+                );
 
                 _ = try self.addItem(.{
                     .label = name,
@@ -750,17 +763,20 @@ pub const CompletionBuilder = struct {
                         .tuple => |tuple| {
                             const elem_vars = type_store.sliceVars(tuple.elems);
 
-                            var type_writer = module_env.initTypeWriter() catch null;
+                            var type_writer: ?types.TypeWriter = try module_env.initTypeWriter();
                             defer if (type_writer) |*tw| tw.deinit();
 
                             for (elem_vars, 0..) |elem_var, i| {
                                 var detail: ?[]const u8 = null;
                                 if (type_writer) |*tw| {
                                     // Type formatting is best-effort; missing type info is acceptable
-                                    tw.write(elem_var, .one_line) catch {};
+                                    tw.write(elem_var, .one_line) catch |err| switch (err) {
+                                        error.OutOfMemory => return error.OutOfMemory,
+                                        error.WriteFailed => {},
+                                    };
                                     const type_str = tw.get();
                                     if (type_str.len > 0) {
-                                        detail = self.allocator.dupe(u8, type_str) catch null;
+                                        detail = try self.allocator.dupe(u8, type_str);
                                     }
                                     tw.reset();
                                 }
@@ -908,7 +924,7 @@ pub const CompletionBuilder = struct {
         self.logDebug("addFieldsFromRecord: record.fields={}, fields_slice.len={}, field_names.len={d}", .{ record.fields, fields_slice.len, field_names.len });
 
         // Initialize type writer for formatting field types
-        var type_writer = module_env.initTypeWriter() catch null;
+        var type_writer: ?types.TypeWriter = try module_env.initTypeWriter();
         defer if (type_writer) |*tw| tw.deinit();
 
         // Iterate over record fields
@@ -921,10 +937,13 @@ pub const CompletionBuilder = struct {
             var detail: ?[]const u8 = null;
             if (type_writer) |*tw| {
                 // Type formatting is best-effort; missing type info is acceptable
-                tw.write(field_var, .one_line) catch {};
+                tw.write(field_var, .one_line) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    error.WriteFailed => {},
+                };
                 const type_str = tw.get();
                 if (type_str.len > 0) {
-                    detail = self.allocator.dupe(u8, type_str) catch null;
+                    detail = try self.allocator.dupe(u8, type_str);
                 }
                 tw.reset();
             }
@@ -966,7 +985,7 @@ pub const CompletionBuilder = struct {
     ) !void {
         self.logDebug("addMethodCompletions: looking for '{s}' at offset {d}", .{ variable_name, variable_start });
 
-        const scope = self.getOrBuildScope(module_env);
+        const scope = try self.getOrBuildScope(module_env);
         self.logDebug("addMethodCompletions: scope has {d} bindings", .{scope.bindings.items.len});
 
         // Find the binding with matching name that's visible at the variable position
@@ -1142,15 +1161,18 @@ pub const CompletionBuilder = struct {
 
             // Try to get detail from the constraint's function type
             var detail: ?[]const u8 = null;
-            var type_writer = module_env.initTypeWriter() catch null;
+            var type_writer: ?types.TypeWriter = try module_env.initTypeWriter();
             defer if (type_writer) |*tw| tw.deinit();
 
             if (type_writer) |*tw| {
                 // Type formatting is best-effort; missing type info is acceptable
-                tw.write(constraint.fn_var, .one_line) catch {};
+                tw.write(constraint.fn_var, .one_line) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    error.WriteFailed => {},
+                };
                 const type_str = tw.get();
                 if (type_str.len > 0) {
-                    detail = self.allocator.dupe(u8, type_str) catch null;
+                    detail = try self.allocator.dupe(u8, type_str);
                 }
                 tw.reset();
             }
@@ -1196,7 +1218,7 @@ pub const CompletionBuilder = struct {
     /// Add methods for a specific source declaration owner by searching method_idents.
     fn addMethodsForOwnerInEnv(self: *CompletionBuilder, module_env: *ModuleEnv, method_owner: MethodOwnerLookup) !void {
         // Initialize type writer for formatting method signatures
-        var type_writer = module_env.initTypeWriter() catch null;
+        var type_writer: ?types.TypeWriter = try module_env.initTypeWriter();
         defer if (type_writer) |*tw| tw.deinit();
 
         // Get the type name for display purposes
@@ -1221,10 +1243,13 @@ pub const CompletionBuilder = struct {
                 if (self.findMethodType(module_env, qualified_ident)) |method_type_var| {
                     if (type_writer) |*tw| {
                         // Type formatting is best-effort; missing type info is acceptable
-                        tw.write(method_type_var, .one_line) catch {};
+                        tw.write(method_type_var, .one_line) catch |err| switch (err) {
+                            error.OutOfMemory => return error.OutOfMemory,
+                            error.WriteFailed => {},
+                        };
                         const type_str = tw.get();
                         if (type_str.len > 0) {
-                            detail = self.allocator.dupe(u8, type_str) catch null;
+                            detail = try self.allocator.dupe(u8, type_str);
                         }
                         tw.reset();
                     }
@@ -1232,11 +1257,11 @@ pub const CompletionBuilder = struct {
 
                 // If we couldn't get the type signature, at least show which type it's from
                 if (detail == null and type_name.len > 0 and qualified_name.len > 0) {
-                    detail = std.fmt.allocPrint(self.allocator, "method on {s}", .{type_name}) catch null;
+                    detail = try std.fmt.allocPrint(self.allocator, "method on {s}", .{type_name});
                 }
 
                 // Extract documentation for the method definition.
-                const documentation = self.findMethodDocumentation(module_env, qualified_ident);
+                const documentation = try self.findMethodDocumentation(module_env, qualified_ident);
 
                 const added = try self.addItem(.{
                     .label = method_name,
@@ -1253,7 +1278,7 @@ pub const CompletionBuilder = struct {
     ///
     /// Searches top-level definitions and statements for a def/decl whose
     /// pattern ident matches `qualified_ident`, then extracts the doc comment.
-    fn findMethodDocumentation(self: *CompletionBuilder, module_env: *ModuleEnv, qualified_ident: base.Ident.Idx) ?[]const u8 {
+    fn findMethodDocumentation(self: *CompletionBuilder, module_env: *ModuleEnv, qualified_ident: base.Ident.Idx) Allocator.Error!?[]const u8 {
         // Search all_defs for a matching definition.
         const defs_slice = module_env.store.sliceDefs(module_env.all_defs);
         for (defs_slice) |def_idx| {
@@ -1267,12 +1292,12 @@ pub const CompletionBuilder = struct {
             };
 
             if (ident_idx.eql(qualified_ident)) {
-                return doc_comments.extractDocForDef(
+                return try doc_comments.extractDocForDef(
                     self.allocator,
                     module_env.common.source,
                     &module_env.store,
                     def,
-                ) catch null;
+                );
             }
         }
 
@@ -1294,13 +1319,13 @@ pub const CompletionBuilder = struct {
             };
 
             if (ident_idx.eql(qualified_ident)) {
-                return doc_comments.extractDocForStatement(
+                return try doc_comments.extractDocForStatement(
                     self.allocator,
                     module_env.common.source,
                     &module_env.store,
                     stmt,
                     stmt_idx,
-                ) catch null;
+                );
             }
         }
 
@@ -1408,7 +1433,7 @@ pub const CompletionBuilder = struct {
                             if (tag_name.len == 0) continue;
 
                             // Show the tag signature (e.g. "SubVal(Str)") as detail
-                            const detail = self.formatTagSignature(module_env, tag_name, t.args);
+                            const detail = try self.formatTagSignature(module_env, tag_name, t.args);
 
                             const added = try self.addItem(.{
                                 .label = tag_name,
@@ -1428,11 +1453,11 @@ pub const CompletionBuilder = struct {
 
     /// Format a tag signature like "SubVal(Str)" or "Cons(a, List(a))".
     /// Returns null for tags with no arguments.
-    fn formatTagSignature(self: *CompletionBuilder, module_env: *ModuleEnv, tag_name: []const u8, args: CIR.TypeAnno.Span) ?[]const u8 {
+    fn formatTagSignature(self: *CompletionBuilder, module_env: *ModuleEnv, tag_name: []const u8, args: CIR.TypeAnno.Span) Allocator.Error!?[]const u8 {
         const args_slice = module_env.store.sliceTypeAnnos(args);
         if (args_slice.len == 0) return null;
 
-        return self.formatTagSignatureInner(module_env, tag_name, args_slice) catch null;
+        return try self.formatTagSignatureInner(module_env, tag_name, args_slice);
     }
 
     fn formatTagSignatureInner(self: *CompletionBuilder, module_env: *ModuleEnv, tag_name: []const u8, args_slice: []const CIR.TypeAnno.Idx) ![]const u8 {
@@ -1443,106 +1468,106 @@ pub const CompletionBuilder = struct {
         for (args_slice, 0..) |arg_idx, i| {
             if (i > 0) try buf.appendSlice(self.allocator, ", ");
             const arg_anno = module_env.store.getTypeAnno(arg_idx);
-            self.writeTypeAnno(&buf, module_env, arg_anno);
+            try self.writeTypeAnno(&buf, module_env, arg_anno);
         }
         try buf.append(self.allocator, ')');
         return try buf.toOwnedSlice(self.allocator);
     }
 
     /// Write a human-readable representation of a TypeAnno to a buffer.
-    fn writeTypeAnno(self: *CompletionBuilder, buf: *std.ArrayList(u8), module_env: *ModuleEnv, anno: CIR.TypeAnno) void {
+    fn writeTypeAnno(self: *CompletionBuilder, buf: *std.ArrayList(u8), module_env: *ModuleEnv, anno: CIR.TypeAnno) Allocator.Error!void {
         const alloc = self.allocator;
         switch (anno) {
             .lookup => |t| {
                 const name = module_env.getIdentText(t.name);
-                buf.appendSlice(alloc, stripBuiltinPrefix(name)) catch return;
+                try buf.appendSlice(alloc, stripBuiltinPrefix(name));
             },
             .rigid_var => |t| {
-                buf.appendSlice(alloc, module_env.getIdentText(t.name)) catch return;
+                try buf.appendSlice(alloc, module_env.getIdentText(t.name));
             },
             .rigid_var_lookup => |t| {
                 const ref_anno = module_env.store.getTypeAnno(t.ref);
-                self.writeTypeAnno(buf, module_env, ref_anno);
+                try self.writeTypeAnno(buf, module_env, ref_anno);
             },
             .apply => |a| {
                 const name = module_env.getIdentText(a.name);
-                buf.appendSlice(alloc, stripBuiltinPrefix(name)) catch return;
+                try buf.appendSlice(alloc, stripBuiltinPrefix(name));
                 const apply_args = module_env.store.sliceTypeAnnos(a.args);
                 if (apply_args.len > 0) {
-                    buf.append(alloc, '(') catch return;
+                    try buf.append(alloc, '(');
                     for (apply_args, 0..) |arg_idx, i| {
-                        if (i > 0) buf.appendSlice(alloc, ", ") catch return;
+                        if (i > 0) try buf.appendSlice(alloc, ", ");
                         const arg_anno = module_env.store.getTypeAnno(arg_idx);
-                        self.writeTypeAnno(buf, module_env, arg_anno);
+                        try self.writeTypeAnno(buf, module_env, arg_anno);
                     }
-                    buf.append(alloc, ')') catch return;
+                    try buf.append(alloc, ')');
                 }
             },
             .tag_union => |tu| {
-                buf.append(alloc, '[') catch return;
+                try buf.append(alloc, '[');
                 const tags = module_env.store.sliceTypeAnnos(tu.tags);
                 for (tags, 0..) |tag_idx, i| {
-                    if (i > 0) buf.appendSlice(alloc, ", ") catch return;
+                    if (i > 0) try buf.appendSlice(alloc, ", ");
                     const tag_anno = module_env.store.getTypeAnno(tag_idx);
-                    self.writeTypeAnno(buf, module_env, tag_anno);
+                    try self.writeTypeAnno(buf, module_env, tag_anno);
                 }
-                buf.append(alloc, ']') catch return;
+                try buf.append(alloc, ']');
             },
             .tag => |t| {
-                buf.appendSlice(alloc, module_env.getIdentText(t.name)) catch return;
+                try buf.appendSlice(alloc, module_env.getIdentText(t.name));
                 const tag_args = module_env.store.sliceTypeAnnos(t.args);
                 if (tag_args.len > 0) {
-                    buf.append(alloc, '(') catch return;
+                    try buf.append(alloc, '(');
                     for (tag_args, 0..) |arg_idx, i| {
-                        if (i > 0) buf.appendSlice(alloc, ", ") catch return;
+                        if (i > 0) try buf.appendSlice(alloc, ", ");
                         const arg_anno = module_env.store.getTypeAnno(arg_idx);
-                        self.writeTypeAnno(buf, module_env, arg_anno);
+                        try self.writeTypeAnno(buf, module_env, arg_anno);
                     }
-                    buf.append(alloc, ')') catch return;
+                    try buf.append(alloc, ')');
                 }
             },
             .tuple => |t| {
-                buf.append(alloc, '(') catch return;
+                try buf.append(alloc, '(');
                 const elems = module_env.store.sliceTypeAnnos(t.elems);
                 for (elems, 0..) |elem_idx, i| {
-                    if (i > 0) buf.appendSlice(alloc, ", ") catch return;
+                    if (i > 0) try buf.appendSlice(alloc, ", ");
                     const elem_anno = module_env.store.getTypeAnno(elem_idx);
-                    self.writeTypeAnno(buf, module_env, elem_anno);
+                    try self.writeTypeAnno(buf, module_env, elem_anno);
                 }
-                buf.append(alloc, ')') catch return;
+                try buf.append(alloc, ')');
             },
             .record => |r| {
-                buf.append(alloc, '{') catch return;
+                try buf.append(alloc, '{');
                 const fields = module_env.store.sliceAnnoRecordFields(r.fields);
                 for (fields, 0..) |field_idx, i| {
-                    if (i > 0) buf.appendSlice(alloc, ", ") catch return;
+                    if (i > 0) try buf.appendSlice(alloc, ", ");
                     const field = module_env.store.getAnnoRecordField(field_idx);
-                    buf.appendSlice(alloc, module_env.getIdentText(field.name)) catch return;
-                    buf.appendSlice(alloc, ": ") catch return;
+                    try buf.appendSlice(alloc, module_env.getIdentText(field.name));
+                    try buf.appendSlice(alloc, ": ");
                     const field_anno = module_env.store.getTypeAnno(field.ty);
-                    self.writeTypeAnno(buf, module_env, field_anno);
+                    try self.writeTypeAnno(buf, module_env, field_anno);
                 }
-                buf.append(alloc, '}') catch return;
+                try buf.append(alloc, '}');
             },
             .@"fn" => |f| {
                 const fn_args = module_env.store.sliceTypeAnnos(f.args);
                 for (fn_args, 0..) |arg_idx, i| {
-                    if (i > 0) buf.appendSlice(alloc, ", ") catch return;
+                    if (i > 0) try buf.appendSlice(alloc, ", ");
                     const arg_anno = module_env.store.getTypeAnno(arg_idx);
-                    self.writeTypeAnno(buf, module_env, arg_anno);
+                    try self.writeTypeAnno(buf, module_env, arg_anno);
                 }
-                buf.appendSlice(alloc, if (f.effectful) " => " else " -> ") catch return;
+                try buf.appendSlice(alloc, if (f.effectful) " => " else " -> ");
                 const ret_anno = module_env.store.getTypeAnno(f.ret);
-                self.writeTypeAnno(buf, module_env, ret_anno);
+                try self.writeTypeAnno(buf, module_env, ret_anno);
             },
             .parens => |p| {
-                buf.append(alloc, '(') catch return;
+                try buf.append(alloc, '(');
                 const inner = module_env.store.getTypeAnno(p.anno);
-                self.writeTypeAnno(buf, module_env, inner);
-                buf.append(alloc, ')') catch return;
+                try self.writeTypeAnno(buf, module_env, inner);
+                try buf.append(alloc, ')');
             },
-            .underscore => buf.append(alloc, '_') catch return,
-            .malformed => buf.appendSlice(alloc, "?") catch return,
+            .underscore => try buf.append(alloc, '_'),
+            .malformed => try buf.appendSlice(alloc, "?"),
         }
     }
 

--- a/src/lsp/handlers/completion.zig
+++ b/src/lsp/handlers/completion.zig
@@ -123,15 +123,18 @@ pub fn handler(comptime ServerType: type) type {
                 text,
                 line,
                 character,
-            ) catch |err| {
-                std.log.err("completion failed: {s}", .{@errorName(err)});
-                // Return empty completion list on error
-                const CompletionResponse = struct {
-                    isIncomplete: bool = false,
-                    items: []const CompletionItem = &.{},
-                };
-                try self.sendResponse(id, CompletionResponse{});
-                return;
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => {
+                    std.log.err("completion failed: {s}", .{@errorName(err)});
+                    // Return empty completion list on error
+                    const CompletionResponse = struct {
+                        isIncomplete: bool = false,
+                        items: []const CompletionItem = &.{},
+                    };
+                    try self.sendResponse(id, CompletionResponse{});
+                    return;
+                },
             };
 
             if (completion_result) |result| {

--- a/src/lsp/handlers/definition.zig
+++ b/src/lsp/handlers/definition.zig
@@ -93,10 +93,13 @@ pub fn handler(comptime ServerType: type) type {
                 text,
                 line,
                 character,
-            ) catch |err| {
-                std.log.err("definition failed: {s}", .{@errorName(err)});
-                try self.sendNullResponse(id);
-                return;
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => {
+                    std.log.err("definition failed: {s}", .{@errorName(err)});
+                    try self.sendNullResponse(id);
+                    return;
+                },
             };
 
             if (def_result) |result| {

--- a/src/lsp/handlers/did_change.zig
+++ b/src/lsp/handlers/did_change.zig
@@ -79,12 +79,11 @@ pub fn handler(comptime ServerType: type) type {
                     std.log.err("received invalid mix of full and incremental changes for {s}", .{uri});
                     return;
                 }
-                self.doc_store.upsert(uri, version, parsed_changes.items[0].text) catch |err| {
-                    std.log.err("failed to apply full change for {s}: {s}", .{ uri, @errorName(err) });
-                };
+                try self.doc_store.upsert(uri, version, parsed_changes.items[0].text);
             } else {
-                self.doc_store.applyContentChanges(uri, version, parsed_changes.items) catch |err| {
-                    std.log.err("failed to apply incremental change for {s}: {s}", .{ uri, @errorName(err) });
+                self.doc_store.applyContentChanges(uri, version, parsed_changes.items) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => std.log.err("failed to apply incremental change for {s}: {s}", .{ uri, @errorName(err) }),
                 };
             }
 

--- a/src/lsp/handlers/did_open.zig
+++ b/src/lsp/handlers/did_open.zig
@@ -37,9 +37,7 @@ pub fn handler(comptime ServerType: type) type {
                 else => 0,
             };
 
-            self.doc_store.upsert(uri, version, text) catch |err| {
-                std.log.err("failed to open {s}: {s}", .{ uri, @errorName(err) });
-            };
+            try self.doc_store.upsert(uri, version, text);
 
             self.onDocumentChanged(uri);
         }

--- a/src/lsp/handlers/document_highlight.zig
+++ b/src/lsp/handlers/document_highlight.zig
@@ -87,7 +87,11 @@ pub fn handler(comptime ServerType: type) type {
             };
 
             // Try CIR-based highlighting first (scope-aware)
-            if (self.syntax_checker.getHighlightsAtPosition(uri, text, line, character) catch null) |result| {
+            const cir_highlights = self.syntax_checker.getHighlightsAtPosition(uri, text, line, character) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => null,
+            };
+            if (cir_highlights) |result| {
                 defer result.deinit(self.allocator);
 
                 // Convert to DocumentHighlight array
@@ -109,11 +113,7 @@ pub fn handler(comptime ServerType: type) type {
             }
 
             // Fall back to token-based highlighting
-            const highlights = findHighlightsByToken(self.allocator, text, line, character) catch |err| {
-                std.log.err("document highlight failed: {s}", .{@errorName(err)});
-                try self.sendResponse(id, &[_]DocumentHighlight{});
-                return;
-            };
+            const highlights = try findHighlightsByToken(self.allocator, text, line, character);
             defer self.allocator.free(highlights);
 
             try self.sendResponse(id, highlights);
@@ -155,13 +155,12 @@ fn findHighlightsByToken(allocator: std.mem.Allocator, source: []const u8, line:
     };
 
     // Parse to get tokens
-    var module_env = can.ModuleEnv.init(allocator, source) catch {
-        return &[_]DocumentHighlight{};
-    };
+    var module_env = try can.ModuleEnv.init(allocator, source);
     defer module_env.deinit();
 
-    const ast = parse.parse(allocator, &module_env.common) catch {
-        return &[_]DocumentHighlight{};
+    const ast = parse.parse(allocator, &module_env.common) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.TooNested => return &[_]DocumentHighlight{},
     };
     defer ast.deinit();
 

--- a/src/lsp/handlers/document_symbol.zig
+++ b/src/lsp/handlers/document_symbol.zig
@@ -54,9 +54,12 @@ pub fn handler(comptime ServerType: type) type {
             };
 
             // Use the syntax checker to get the canonicalized module
-            const symbols = self.syntax_checker.getDocumentSymbols(self.allocator, uri, source) catch {
-                try self.sendResponse(id, &[_]SymbolInformation{});
-                return;
+            const symbols = self.syntax_checker.getDocumentSymbols(self.allocator, uri, source) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => {
+                    try self.sendResponse(id, &[_]SymbolInformation{});
+                    return;
+                },
             };
             defer {
                 for (symbols) |*sym| {

--- a/src/lsp/handlers/folding_range.zig
+++ b/src/lsp/handlers/folding_range.zig
@@ -57,11 +57,7 @@ pub fn handler(comptime ServerType: type) type {
             };
 
             // Extract folding ranges from the document
-            const ranges = extractFoldingRanges(self.allocator, text) catch |err| {
-                std.log.err("folding range extraction failed: {s}", .{@errorName(err)});
-                try self.sendResponse(id, &[_]FoldingRange{});
-                return;
-            };
+            const ranges = try extractFoldingRanges(self.allocator, text);
             defer self.allocator.free(ranges);
 
             try self.sendResponse(id, ranges);
@@ -89,13 +85,12 @@ fn extractFoldingRanges(allocator: std.mem.Allocator, source: []const u8) ![]Fol
     defer bracket_stack.deinit(allocator);
 
     // Parse to get tokens
-    var module_env = can.ModuleEnv.init(allocator, source) catch {
-        return &[_]FoldingRange{};
-    };
+    var module_env = try can.ModuleEnv.init(allocator, source);
     defer module_env.deinit();
 
-    const ast = parse.parse(allocator, &module_env.common) catch {
-        return &[_]FoldingRange{};
+    const ast = parse.parse(allocator, &module_env.common) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.TooNested => return &[_]FoldingRange{},
     };
     defer ast.deinit();
 

--- a/src/lsp/handlers/formatting.zig
+++ b/src/lsp/handlers/formatting.zig
@@ -56,10 +56,13 @@ pub fn handler(comptime ServerType: type) type {
             };
 
             // Format the document
-            const formatted = formatSource(self.allocator, text) catch |err| {
-                std.log.err("formatting failed: {s}", .{@errorName(err)});
-                try self.sendNullResponse(id);
-                return;
+            const formatted = formatSource(self.allocator, text) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => {
+                    std.log.err("formatting failed: {s}", .{@errorName(err)});
+                    try self.sendNullResponse(id);
+                    return;
+                },
             };
             defer self.allocator.free(formatted);
 

--- a/src/lsp/handlers/hover.zig
+++ b/src/lsp/handlers/hover.zig
@@ -93,10 +93,13 @@ pub fn handler(comptime ServerType: type) type {
                 text,
                 line,
                 character,
-            ) catch |err| {
-                std.log.err("hover failed: {s}", .{@errorName(err)});
-                try self.sendNullResponse(id);
-                return;
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => {
+                    std.log.err("hover failed: {s}", .{@errorName(err)});
+                    try self.sendNullResponse(id);
+                    return;
+                },
             };
 
             if (hover_result) |result| {

--- a/src/lsp/handlers/selection_range.zig
+++ b/src/lsp/handlers/selection_range.zig
@@ -107,7 +107,10 @@ pub fn handler(comptime ServerType: type) type {
                     };
                 };
 
-                const selection_range = computeSelectionRange(self.allocator, text, line, character) catch null;
+                const selection_range = computeSelectionRange(self.allocator, text, line, character) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => null,
+                };
                 try results.append(self.allocator, selection_range);
             }
 
@@ -150,13 +153,12 @@ fn computeSelectionRange(allocator: std.mem.Allocator, source: []const u8, line:
     const target_offset = positionToOffset(line, character, &line_offsets) orelse return error.InvalidPosition;
 
     // Parse to get AST
-    var module_env = can.ModuleEnv.init(allocator, source) catch {
-        return error.ParseFailed;
-    };
+    var module_env = try can.ModuleEnv.init(allocator, source);
     defer module_env.deinit();
 
-    const ast = parse.parse(allocator, &module_env.common) catch {
-        return error.ParseFailed;
+    const ast = parse.parse(allocator, &module_env.common) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.TooNested => return error.ParseFailed,
     };
     defer ast.deinit();
 

--- a/src/lsp/handlers/semantic_tokens.zig
+++ b/src/lsp/handlers/semantic_tokens.zig
@@ -23,8 +23,9 @@ pub fn handler(comptime ServerType: type) type {
                 return try ServerType.sendError(self, id, .invalid_params, "semanticTokens requires params");
             };
 
-            var params = protocol.SemanticTokensParams.fromJson(self.allocator, params_value) catch {
-                return try ServerType.sendError(self, id, .invalid_params, "invalid semanticTokens params");
+            var params = protocol.SemanticTokensParams.fromJson(self.allocator, params_value) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return try ServerType.sendError(self, id, .invalid_params, "invalid semanticTokens params"),
             };
             defer params.deinit(self.allocator);
 
@@ -34,9 +35,7 @@ pub fn handler(comptime ServerType: type) type {
             };
 
             // Build line info for position conversion
-            var info = line_info.LineInfo.init(self.allocator, doc.text) catch {
-                return try ServerType.sendError(self, id, .internal_error, "failed to build line info");
-            };
+            var info = try line_info.LineInfo.init(self.allocator, doc.text);
             defer info.deinit();
 
             // Try to get imported ModuleEnvs for cross-module semantic tokens
@@ -44,33 +43,33 @@ pub fn handler(comptime ServerType: type) type {
             defer if (imported_envs) |envs| self.allocator.free(envs);
 
             // Convert URI to path and get imports
-            if (uri_util.uriToPath(self.allocator, params.textDocument.uri)) |path| {
+            {
+                const path = try uri_util.uriToPath(self.allocator, params.textDocument.uri);
                 defer self.allocator.free(path);
-                // Get absolute path
-                if (std.Io.Dir.cwd().realPathFileAlloc(self.std_io, path, self.allocator)) |abs_path| {
-                    defer self.allocator.free(abs_path);
+                // Get absolute path. A missing on-disk file is fine; we just skip
+                // cross-module enrichment, but a genuine OOM must surface.
+                const abs_path: ?[:0]u8 = std.Io.Dir.cwd().realPathFileAlloc(self.std_io, path, self.allocator) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => null,
+                };
+                if (abs_path) |ap| {
+                    defer self.allocator.free(ap);
                     // Get imported modules from the syntax checker's cached build
-                    if (self.syntax_checker.getImportedModuleEnvs(abs_path)) |maybe_envs| {
-                        imported_envs = maybe_envs;
-                    } else |_| {}
-                } else |_| {}
-            } else |_| {}
+                    imported_envs = try self.syntax_checker.getImportedModuleEnvs(ap);
+                }
+            }
 
             // Extract semantic tokens using CIR with cross-module context
-            const tokens = semantic_tokens.extractSemanticTokensWithImports(
+            const tokens = try semantic_tokens.extractSemanticTokensWithImports(
                 self.allocator,
                 doc.text,
                 &info,
                 imported_envs,
-            ) catch {
-                return try ServerType.sendError(self, id, .internal_error, "failed to extract tokens");
-            };
+            );
             defer self.allocator.free(tokens);
 
             // Delta-encode the tokens
-            const data = semantic_tokens.deltaEncode(self.allocator, tokens) catch {
-                return try ServerType.sendError(self, id, .internal_error, "failed to encode tokens");
-            };
+            const data = try semantic_tokens.deltaEncode(self.allocator, tokens);
             defer if (data.len > 0) self.allocator.free(data);
 
             // Send the response

--- a/src/lsp/semantic_tokens.zig
+++ b/src/lsp/semantic_tokens.zig
@@ -330,7 +330,7 @@ pub fn extractSemanticTokensWithImports(
 
     if (imported_envs) |envs| {
         for (envs) |imp_env| {
-            import_context.addModuleExports(imp_env) catch {};
+            try import_context.addModuleExports(imp_env);
         }
     }
 
@@ -385,7 +385,7 @@ const ImportContext = struct {
     }
 
     /// Add exports from a module to the context.
-    fn addModuleExports(self: *ImportContext, module_env: *ModuleEnv) !void {
+    fn addModuleExports(self: *ImportContext, module_env: *ModuleEnv) std.mem.Allocator.Error!void {
         const module_name = module_env.module_name;
         if (module_name.len == 0) return;
 

--- a/src/lsp/semantic_tokens.zig
+++ b/src/lsp/semantic_tokens.zig
@@ -281,29 +281,27 @@ pub fn extractSemanticTokensWithImports(
     imported_envs: ?[]*ModuleEnv,
 ) ![]SemanticToken {
     // Create ModuleEnv with source
-    var module_env = ModuleEnv.init(allocator, source) catch {
-        // Fall back to token-only extraction on error
-        return extractSemanticTokens(allocator, source, info);
-    };
+    var module_env = ModuleEnv.init(allocator, source) catch return error.OutOfMemory;
     defer module_env.deinit();
 
     // Parse the source
-    const parse_ast = parse.parse(allocator, &module_env.common) catch {
+    const parse_ast = parse.parse(allocator, &module_env.common) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
         // Fall back to token-only extraction on parse error
-        return extractSemanticTokens(allocator, source, info);
+        else => return extractSemanticTokens(allocator, source, info),
     };
     defer parse_ast.deinit();
 
     // Initialize CIR fields
-    module_env.initCIRFields("semantic-tokens") catch {
-        return extractSemanticTokens(allocator, source, info);
-    };
+    module_env.initCIRFields("semantic-tokens") catch return error.OutOfMemory;
 
-    const builtin_indices = builtin_loading.deserializeBuiltinIndices(allocator, compiled_builtins.builtin_indices_bin) catch {
-        return extractSemanticTokens(allocator, source, info);
+    const builtin_indices = builtin_loading.deserializeBuiltinIndices(allocator, compiled_builtins.builtin_indices_bin) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return extractSemanticTokens(allocator, source, info),
     };
-    var builtin_module = builtin_loading.loadCompiledModule(allocator, compiled_builtins.builtin_bin, "Builtin", compiled_builtins.builtin_source) catch {
-        return extractSemanticTokens(allocator, source, info);
+    var builtin_module = builtin_loading.loadCompiledModule(allocator, compiled_builtins.builtin_bin, "Builtin", compiled_builtins.builtin_source) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return extractSemanticTokens(allocator, source, info),
     };
     defer builtin_module.deinit();
 
@@ -314,15 +312,10 @@ pub fn extractSemanticTokensWithImports(
             .builtin_module_env = builtin_module.env,
             .builtin_indices = builtin_indices,
         },
-    }) catch {
-        return extractSemanticTokens(allocator, source, info);
-    };
+    }) catch return error.OutOfMemory;
     defer canonicalizer.deinit();
 
-    canonicalizer.canonicalizeFile() catch {
-        // Fall back to token-only on canonicalization error
-        return extractSemanticTokens(allocator, source, info);
-    };
+    canonicalizer.canonicalizeFile() catch return error.OutOfMemory;
 
     // Build import context for cross-module lookups
     var import_context = ImportContext.init(allocator);
@@ -346,11 +339,7 @@ pub fn extractSemanticTokensWithImports(
     errdefer collector.tokens.deinit(allocator);
 
     // Walk CIR statements for semantic information
-    collector.walkStatements() catch {
-        // Fall back on error
-        collector.tokens.deinit(allocator);
-        return extractSemanticTokens(allocator, source, info);
-    };
+    collector.walkStatements() catch return error.OutOfMemory;
 
     // Also extract tokens from the tokenizer that weren't covered by CIR
     // (keywords, operators, and identifiers as fallback)

--- a/src/lsp/server.zig
+++ b/src/lsp/server.zig
@@ -259,10 +259,10 @@ pub fn Server(comptime ReaderType: type, comptime WriterType: type) type {
 
         fn runSyntaxCheck(self: *Self, uri: []const u8) !void {
             const doc = self.doc_store.get(uri);
-            const root_path = if (self.client.root_uri) |root_uri| blk: {
-                const path = uri_util.uriToPath(self.allocator, root_uri) catch null;
-                break :blk path;
-            } else null;
+            const root_path = if (self.client.root_uri) |root_uri|
+                try uri_util.uriToPath(self.allocator, root_uri)
+            else
+                null;
             const publish_sets = try self.syntax_checker.check(uri, if (doc) |d| d.text else null, root_path);
             if (root_path) |p| self.allocator.free(p);
             defer {

--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -111,13 +111,13 @@ pub const SyntaxChecker = struct {
         // Check if content has changed using hash comparison BEFORE building.
         // This avoids unnecessary rebuilds on focus/blur events.
         if (override_text) |text| {
-            const path = uri_util.uriToPath(self.allocator, uri) catch null;
-            defer if (path) |p| self.allocator.free(p);
+            const path = try uri_util.uriToPath(self.allocator, uri);
+            defer self.allocator.free(path);
 
-            const abs_path: ?[:0]u8 = if (path) |p|
-                std.Io.Dir.cwd().realPathFileAlloc(self.std_io, p, self.allocator) catch null
-            else
-                null;
+            const abs_path: ?[:0]u8 = std.Io.Dir.cwd().realPathFileAlloc(self.std_io, path, self.allocator) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => null,
+            };
             defer if (abs_path) |a| self.allocator.free(a);
 
             if (abs_path) |ap| {
@@ -144,9 +144,7 @@ pub const SyntaxChecker = struct {
                     });
                 }
 
-                self.dependency_graph.setContentHash(ap, new_hash) catch |err| {
-                    self.logDebug(.build, "Failed to set content hash: {s}", .{@errorName(err)});
-                };
+                try self.dependency_graph.setContentHash(ap, new_hash);
             }
         }
 
@@ -159,7 +157,7 @@ pub const SyntaxChecker = struct {
         const absolute_path = session.absolute_path;
 
         // Update dependency graph from successful build
-        self.updateDependencyGraph(env);
+        try self.updateDependencyGraph(env);
 
         var publish_list: std.ArrayList(Diagnostics.PublishDiagnostics) = .empty;
         errdefer {
@@ -472,7 +470,7 @@ pub const SyntaxChecker = struct {
     }
 
     /// Update the dependency graph from a successful build.
-    fn updateDependencyGraph(self: *SyntaxChecker, env: *BuildEnv) void {
+    fn updateDependencyGraph(self: *SyntaxChecker, env: *BuildEnv) Allocator.Error!void {
         self.logDebug(.build, "[DEPS] Updating dependency graph...", .{});
 
         // Clear only relationships, preserving content/exports hashes for incremental detection
@@ -489,20 +487,14 @@ pub const SyntaxChecker = struct {
 
             self.logDebug(.build, "[DEPS] Processing package '{s}' with {d} modules", .{ pkg_name, sched.modules.items.len });
 
-            self.dependency_graph.buildFromPackageEnv(sched) catch |err| {
-                self.logDebug(.build, "[DEPS] Failed to build dependency graph for '{s}': {s}", .{ pkg_name, @errorName(err) });
-                continue;
-            };
+            try self.dependency_graph.buildFromPackageEnv(sched);
 
             // Compute and store exports hash for each module with a valid ModuleEnv
             for (sched.modules.items) |*module_state| {
                 total_modules += 1;
 
                 if (module_state.moduleEnv()) |module_env| {
-                    const new_exports_hash = DependencyGraph.computeExportsHash(self.allocator, module_env) catch |err| {
-                        self.logDebug(.build, "[DEPS] Failed to compute exports hash for {s}: {s}", .{ module_state.path, @errorName(err) });
-                        continue;
-                    };
+                    const new_exports_hash = try DependencyGraph.computeExportsHash(self.allocator, module_env);
 
                     // Check if exports changed (for future smart invalidation)
                     const old_exports_hash = self.dependency_graph.getExportsHash(module_state.path);
@@ -789,7 +781,7 @@ pub const SyntaxChecker = struct {
         // When we already have a lookup expression, resolve directly to avoid
         // region/offset ambiguity around delimiters.
         var documentation = if (lookup_expr_idx_opt) |lookup_expr_idx|
-            self.resolveDocForLookup(env, module_env, lookup_expr_idx)
+            try self.resolveDocForLookup(env, module_env, lookup_expr_idx)
         else
             try self.findDocumentationForRegion(env, module_env, result.region, target_offset);
 
@@ -797,16 +789,19 @@ pub const SyntaxChecker = struct {
         // call sites where direct lookup queries can miss the identifier region.
         // This keeps hover aligned with go-to-definition behavior.
         if (documentation == null) {
-            if (self.findDefinitionAtOffset(module_env, target_offset, uri)) |def_loc| {
+            var def_oom: ?Allocator.Error = null;
+            const def_loc_opt = self.findDefinitionAtOffset(module_env, target_offset, uri, &def_oom);
+            if (def_oom) |e| return e;
+            if (def_loc_opt) |def_loc| {
                 if (std.mem.eql(u8, def_loc.uri, uri)) {
                     if (pos.positionToOffset(module_env, def_loc.range.start_line, def_loc.range.start_col)) |def_offset| {
                         if (cir_queries.findPatternAtOffset(module_env, def_offset)) |pattern_idx| {
                             hover_type_var = ModuleEnv.varFrom(pattern_idx);
-                            documentation = doc_comments.extractDocCommentBefore(
+                            documentation = try doc_comments.extractDocCommentBefore(
                                 self.allocator,
                                 module_env.common.source,
                                 module_env.store.getPatternRegion(pattern_idx).start.offset,
-                            ) catch null;
+                            );
                         }
                     }
                 }
@@ -830,34 +825,34 @@ pub const SyntaxChecker = struct {
                         hover_type_text_opt = module_env.getSource(anno_region);
                     }
 
-                    const extracted = doc_comments.extractDocForDef(
+                    const extracted = try doc_comments.extractDocForDef(
                         self.allocator,
                         module_env.common.source,
                         &module_env.store,
                         def,
-                    ) catch documentation;
+                    );
                     if (extracted != null) {
                         if (documentation) |doc| self.allocator.free(doc);
                         documentation = extracted;
                     }
                 } else if (module_lookup.findStatementOwningPattern(module_env, def_info.pattern_idx)) |stmt_owner| {
-                    const extracted = doc_comments.extractDocForStatement(
+                    const extracted = try doc_comments.extractDocForStatement(
                         self.allocator,
                         module_env.common.source,
                         &module_env.store,
                         stmt_owner.stmt,
                         stmt_owner.idx,
-                    ) catch documentation;
+                    );
                     if (extracted != null) {
                         if (documentation) |doc| self.allocator.free(doc);
                         documentation = extracted;
                     }
                 } else {
-                    const extracted = doc_comments.extractDocCommentBefore(
+                    const extracted = try doc_comments.extractDocCommentBefore(
                         self.allocator,
                         module_env.common.source,
                         module_env.store.getPatternRegion(def_info.pattern_idx).start.offset,
-                    ) catch documentation;
+                    );
                     if (extracted != null) {
                         if (documentation) |doc| self.allocator.free(doc);
                         documentation = extracted;
@@ -893,7 +888,7 @@ pub const SyntaxChecker = struct {
         // First, check if this is a lookup expression (e.g., a function call)
         // If so, resolve it to the definition and extract docs from there
         if (cir_queries.findLookupAtOffset(module_env, target_offset)) |expr_idx| {
-            if (self.resolveDocForLookup(env, module_env, expr_idx)) |doc| return doc;
+            if (try self.resolveDocForLookup(env, module_env, expr_idx)) |doc| return doc;
         }
 
         // Hover positions can land on delimiters around the symbol (e.g. `(` in
@@ -902,7 +897,7 @@ pub const SyntaxChecker = struct {
         // documentation resolution.
         if (region.start.offset != target_offset) {
             if (cir_queries.findLookupAtOffset(module_env, region.start.offset)) |expr_idx| {
-                if (self.resolveDocForLookup(env, module_env, expr_idx)) |doc| return doc;
+                if (try self.resolveDocForLookup(env, module_env, expr_idx)) |doc| return doc;
             }
         }
 
@@ -917,13 +912,13 @@ pub const SyntaxChecker = struct {
             if (cir_queries.regionContainsOffset(pattern_region, region.start.offset) or
                 pattern_region.start.offset == region.start.offset)
             {
-                return doc_comments.extractDocForDef(self.allocator, source, store, def) catch null;
+                return try doc_comments.extractDocForDef(self.allocator, source, store, def);
             }
 
             // Also check if the expression region matches (for hovering over expressions)
             const expr_region = store.getExprRegion(def.expr);
             if (cir_queries.regionContainsOffset(expr_region, region.start.offset)) {
-                return doc_comments.extractDocForDef(self.allocator, source, store, def) catch null;
+                return try doc_comments.extractDocForDef(self.allocator, source, store, def);
             }
         }
 
@@ -934,7 +929,7 @@ pub const SyntaxChecker = struct {
             const stmt_region = store.getStatementRegion(stmt_idx);
 
             if (cir_queries.regionContainsOffset(stmt_region, region.start.offset)) {
-                return doc_comments.extractDocForStatement(self.allocator, source, store, stmt, stmt_idx) catch null;
+                return try doc_comments.extractDocForStatement(self.allocator, source, store, stmt, stmt_idx);
             }
         }
 
@@ -942,7 +937,7 @@ pub const SyntaxChecker = struct {
     }
 
     /// Resolve documentation for a lookup expression (local, external, or dot access).
-    fn resolveDocForLookup(self: *SyntaxChecker, env: *BuildEnv, module_env: *ModuleEnv, expr_idx: CIR.Expr.Idx) ?[]const u8 {
+    fn resolveDocForLookup(self: *SyntaxChecker, env: *BuildEnv, module_env: *ModuleEnv, expr_idx: CIR.Expr.Idx) Allocator.Error!?[]const u8 {
         const source = module_env.common.source;
         const store = &module_env.store;
         const expr = store.getExpr(expr_idx);
@@ -951,20 +946,20 @@ pub const SyntaxChecker = struct {
             .e_lookup_local => |lookup| {
                 // Local lookup - resolve to the owning def or statement
                 if (module_lookup.findDefOwningPattern(module_env, lookup.pattern_idx)) |def| {
-                    return doc_comments.extractDocForDef(self.allocator, source, store, def) catch null;
+                    return try doc_comments.extractDocForDef(self.allocator, source, store, def);
                 }
                 if (module_lookup.findStatementOwningPattern(module_env, lookup.pattern_idx)) |result| {
-                    return doc_comments.extractDocForStatement(self.allocator, source, store, result.stmt, result.idx) catch null;
+                    return try doc_comments.extractDocForStatement(self.allocator, source, store, result.stmt, result.idx);
                 }
 
                 // Some local bindings are nested inside expressions (e.g. block
                 // locals) and are not owned by top-level defs/statements. Fall
                 // back to doc extraction directly from the bound pattern region.
-                return doc_comments.extractDocCommentBefore(
+                return try doc_comments.extractDocCommentBefore(
                     self.allocator,
                     source,
                     store.getPatternRegion(lookup.pattern_idx).start.offset,
-                ) catch null;
+                );
             },
             .e_lookup_external => |lookup| {
                 // External lookup - parse "Module.function" and find docs in that module
@@ -974,7 +969,7 @@ pub const SyntaxChecker = struct {
                     const function_name = region_text[dot_pos + 1 ..];
 
                     if (findExternalModuleEnv(env, module_name)) |external_env| {
-                        return findDocInModule(self.allocator, external_env, function_name);
+                        return try findDocInModule(self.allocator, external_env, function_name);
                     }
                 }
             },
@@ -986,19 +981,19 @@ pub const SyntaxChecker = struct {
                     // Prefer local method docs first (e.g. static-dispatch methods
                     // defined in the current module), then fall back to external
                     // module lookup for builtin/qualified providers.
-                    if (findMethodDocForOwnerAndName(self.allocator, module_env, method_owner.owner, field_name)) |local_doc| {
+                    if (try findMethodDocForOwnerAndName(self.allocator, module_env, method_owner.owner, field_name)) |local_doc| {
                         return local_doc;
                     }
 
                     const type_name = module_env.getIdentText(method_owner.type_ident);
                     if (findExternalModuleEnvForMethodOwner(env, method_owner, type_name)) |external_env| {
-                        const qualified_name = std.fmt.allocPrint(
+                        const qualified_name = try std.fmt.allocPrint(
                             self.allocator,
                             "{s}.{s}",
                             .{ type_name, field_name },
-                        ) catch return null;
+                        );
                         defer self.allocator.free(qualified_name);
-                        return findDocInModule(self.allocator, external_env, qualified_name);
+                        return try findDocInModule(self.allocator, external_env, qualified_name);
                     }
                 }
             },
@@ -1006,19 +1001,19 @@ pub const SyntaxChecker = struct {
                 const method_name = module_env.getIdentText(method_call.method_name);
                 const receiver_type_var = ModuleEnv.varFrom(method_call.receiver);
                 if (resolveMethodOwnerForLookup(module_env, receiver_type_var)) |method_owner| {
-                    if (findMethodDocForOwnerAndName(self.allocator, module_env, method_owner.owner, method_name)) |local_doc| {
+                    if (try findMethodDocForOwnerAndName(self.allocator, module_env, method_owner.owner, method_name)) |local_doc| {
                         return local_doc;
                     }
 
                     const type_name = module_env.getIdentText(method_owner.type_ident);
                     if (findExternalModuleEnvForMethodOwner(env, method_owner, type_name)) |external_env| {
-                        const qualified_name = std.fmt.allocPrint(
+                        const qualified_name = try std.fmt.allocPrint(
                             self.allocator,
                             "{s}.{s}",
                             .{ type_name, method_name },
-                        ) catch return null;
+                        );
                         defer self.allocator.free(qualified_name);
-                        return findDocInModule(self.allocator, external_env, qualified_name);
+                        return try findDocInModule(self.allocator, external_env, qualified_name);
                     }
                 }
             },
@@ -1116,7 +1111,7 @@ pub const SyntaxChecker = struct {
         module_env: *ModuleEnv,
         owner: CIR.Statement.Idx,
         method_name: []const u8,
-    ) ?[]const u8 {
+    ) Allocator.Error!?[]const u8 {
         const entries = module_env.method_idents.entries.items;
         for (entries) |entry| {
             if (entry.key.owner != owner) continue;
@@ -1124,7 +1119,7 @@ pub const SyntaxChecker = struct {
             const entry_method_name = module_env.getIdentText(entry.key.methodIdent());
             if (!std.mem.eql(u8, entry_method_name, method_name)) continue;
 
-            return findDocForQualifiedIdent(allocator, module_env, entry.value);
+            return try findDocForQualifiedIdent(allocator, module_env, entry.value);
         }
 
         return null;
@@ -1167,7 +1162,7 @@ pub const SyntaxChecker = struct {
 
     /// Find documentation for a definition by name in a module.
     /// Uses module_lookup infrastructure for the search, with qualified-name fallback.
-    fn findDocInModule(allocator: Allocator, module_env: *ModuleEnv, name: []const u8) ?[]const u8 {
+    fn findDocInModule(allocator: Allocator, module_env: *ModuleEnv, name: []const u8) Allocator.Error!?[]const u8 {
         const source = module_env.common.source;
         const store = &module_env.store;
 
@@ -1175,24 +1170,24 @@ pub const SyntaxChecker = struct {
         if (module_lookup.findDefinitionByUnqualifiedName(module_env, name)) |def_info| {
             // Try to find the full Def for annotation-aware offset
             if (module_lookup.findDefOwningPattern(module_env, def_info.pattern_idx)) |def| {
-                return doc_comments.extractDocForDef(allocator, source, store, def) catch null;
+                return try doc_comments.extractDocForDef(allocator, source, store, def);
             }
             // Fall back to statement-based extraction
             if (module_lookup.findStatementOwningPattern(module_env, def_info.pattern_idx)) |result| {
-                return doc_comments.extractDocForStatement(allocator, source, store, result.stmt, result.idx) catch null;
+                return try doc_comments.extractDocForStatement(allocator, source, store, result.stmt, result.idx);
             }
             // Last resort: use pattern region directly
-            return doc_comments.extractDocCommentBefore(
+            return try doc_comments.extractDocCommentBefore(
                 allocator,
                 source,
                 store.getPatternRegion(def_info.pattern_idx).start.offset,
-            ) catch null;
+            );
         }
         return null;
     }
 
     /// Find documentation for a specific qualified identifier in a module.
-    fn findDocForQualifiedIdent(allocator: Allocator, module_env: *ModuleEnv, qualified_ident: base.Ident.Idx) ?[]const u8 {
+    fn findDocForQualifiedIdent(allocator: Allocator, module_env: *ModuleEnv, qualified_ident: base.Ident.Idx) Allocator.Error!?[]const u8 {
         const source = module_env.common.source;
         const store = &module_env.store;
 
@@ -1209,7 +1204,7 @@ pub const SyntaxChecker = struct {
             };
 
             if (ident_idx.eql(qualified_ident)) {
-                return doc_comments.extractDocForDef(allocator, source, store, def) catch null;
+                return try doc_comments.extractDocForDef(allocator, source, store, def);
             }
         }
 
@@ -1230,7 +1225,7 @@ pub const SyntaxChecker = struct {
             };
 
             if (ident_idx.eql(qualified_ident)) {
-                return doc_comments.extractDocForStatement(allocator, source, store, stmt, stmt_idx) catch null;
+                return try doc_comments.extractDocForStatement(allocator, source, store, stmt, stmt_idx);
             }
         }
 
@@ -1269,7 +1264,11 @@ pub const SyntaxChecker = struct {
         const target_offset = pos.positionToOffset(module_env, line, character) orelse return null;
 
         // Find the definition at this position
-        const result = self.findDefinitionAtOffset(module_env, target_offset, uri) orelse return null;
+        var oom: ?Allocator.Error = null;
+        const result = self.findDefinitionAtOffset(module_env, target_offset, uri, &oom) orelse {
+            if (oom) |e| return e;
+            return null;
+        };
 
         return result;
     }
@@ -1280,7 +1279,7 @@ pub const SyntaxChecker = struct {
 
     /// Find the definition location for the expression at the given byte offset.
     /// Looks for lookups (e_lookup_local, e_lookup_external) and returns the definition location.
-    fn findDefinitionAtOffset(self: *SyntaxChecker, module_env: *ModuleEnv, target_offset: u32, current_uri: []const u8) ?DefinitionResult {
+    fn findDefinitionAtOffset(self: *SyntaxChecker, module_env: *ModuleEnv, target_offset: u32, current_uri: []const u8, oom: *?Allocator.Error) ?DefinitionResult {
         var best_expr: ?CIR.Expr.Idx = null;
         var best_size: u32 = std.math.maxInt(u32);
 
@@ -1292,7 +1291,7 @@ pub const SyntaxChecker = struct {
             // Check type annotation on this definition
             if (def.annotation) |anno_idx| {
                 const annotation = module_env.store.getAnnotation(anno_idx);
-                if (self.findTypeAnnoAtOffset(module_env, annotation.anno, target_offset)) |result| {
+                if (self.findTypeAnnoAtOffset(module_env, annotation.anno, target_offset, oom)) |result| {
                     // If URI is empty, it's a local type - use current file
                     if (result.uri.len == 0) {
                         return DefinitionResult{
@@ -1310,7 +1309,7 @@ pub const SyntaxChecker = struct {
 
             if (cir_queries.regionContainsOffset(expr_region, target_offset)) {
                 // First check for type annotations in nested blocks
-                if (self.findTypeAnnoInExpr(module_env, expr_idx, target_offset, current_uri)) |result| {
+                if (self.findTypeAnnoInExpr(module_env, expr_idx, target_offset, current_uri, oom)) |result| {
                     return result;
                 }
                 // Then search for lookup expressions
@@ -1336,7 +1335,7 @@ pub const SyntaxChecker = struct {
                     const module_name = module_env.common.idents.getText(import_stmt.module_name_tok);
 
                     // Try to find the module in the schedulers
-                    if (self.findModuleByName(module_name)) |result| {
+                    if (self.findModuleByName(module_name, oom)) |result| {
                         return result;
                     }
                 }
@@ -1353,7 +1352,7 @@ pub const SyntaxChecker = struct {
             };
 
             if (maybe_type_anno) |type_anno_idx| {
-                if (self.findTypeAnnoAtOffset(module_env, type_anno_idx, target_offset)) |result| {
+                if (self.findTypeAnnoAtOffset(module_env, type_anno_idx, target_offset, oom)) |result| {
                     // If URI is empty, it's a local type - use current file
                     if (result.uri.len == 0) {
                         return DefinitionResult{
@@ -1414,7 +1413,7 @@ pub const SyntaxChecker = struct {
                     if (std.mem.find(u8, region_text, ".")) |dot_pos| {
                         const module_name = region_text[0..dot_pos];
                         self.logDebug(.build, "[DEF] e_lookup_external: extracted module='{s}' from '{s}'", .{ module_name, region_text });
-                        return self.findModuleByName(module_name);
+                        return self.findModuleByName(module_name, oom);
                     }
                     self.logDebug(.build, "[DEF] e_lookup_external: could not extract module name from '{s}'", .{region_text});
                     return null;
@@ -1425,13 +1424,20 @@ pub const SyntaxChecker = struct {
                     const receiver_type_var = ModuleEnv.varFrom(dot.receiver);
                     var type_writer = module_env.initTypeWriter() catch |err| {
                         self.logDebug(.build, "[DEF] initTypeWriter failed: {s}", .{@errorName(err)});
+                        oom.* = err;
                         return null;
                     };
                     defer type_writer.deinit();
 
-                    type_writer.write(receiver_type_var, .one_line) catch |err| {
-                        self.logDebug(.build, "[DEF] type_writer.write failed: {s}", .{@errorName(err)});
-                        return null;
+                    type_writer.write(receiver_type_var, .one_line) catch |err| switch (err) {
+                        error.OutOfMemory => {
+                            oom.* = error.OutOfMemory;
+                            return null;
+                        },
+                        error.WriteFailed => {
+                            self.logDebug(.build, "[DEF] type_writer.write failed: {s}", .{@errorName(err)});
+                            return null;
+                        },
                     };
                     const type_str = type_writer.get();
 
@@ -1439,7 +1445,7 @@ pub const SyntaxChecker = struct {
 
                     self.logDebug(.build, "[DEF] e_dot_access type_str='{s}', base_type='{s}'", .{ type_str, base_type });
 
-                    return self.findModuleByName(base_type);
+                    return self.findModuleByName(base_type, oom);
                 },
                 .e_dispatch_call => |method_call| {
                     // Attached method call - navigate to the provider module for the receiver type
@@ -1447,13 +1453,20 @@ pub const SyntaxChecker = struct {
                     const receiver_type_var = ModuleEnv.varFrom(method_call.receiver);
                     var type_writer = module_env.initTypeWriter() catch |err| {
                         self.logDebug(.build, "[DEF] initTypeWriter failed: {s}", .{@errorName(err)});
+                        oom.* = err;
                         return null;
                     };
                     defer type_writer.deinit();
 
-                    type_writer.write(receiver_type_var, .one_line) catch |err| {
-                        self.logDebug(.build, "[DEF] type_writer.write failed: {s}", .{@errorName(err)});
-                        return null;
+                    type_writer.write(receiver_type_var, .one_line) catch |err| switch (err) {
+                        error.OutOfMemory => {
+                            oom.* = error.OutOfMemory;
+                            return null;
+                        },
+                        error.WriteFailed => {
+                            self.logDebug(.build, "[DEF] type_writer.write failed: {s}", .{@errorName(err)});
+                            return null;
+                        },
                     };
                     const type_str = type_writer.get();
 
@@ -1464,7 +1477,7 @@ pub const SyntaxChecker = struct {
 
                     // Find the module for this type
                     // TODO: Also navigate to the specific method definition within the module
-                    const result = self.findModuleByName(base_type);
+                    const result = self.findModuleByName(base_type, oom);
                     if (result == null) {
                         self.logDebug(.build, "[DEF] findModuleByName returned null for '{s}'", .{base_type});
                     }
@@ -1480,7 +1493,7 @@ pub const SyntaxChecker = struct {
     // isBuiltinType moved to completion/builtins.zig module
 
     /// Helper function to find a module by name and return a DefinitionResult pointing to it
-    fn findModuleByName(self: *SyntaxChecker, module_name: []const u8) ?DefinitionResult {
+    fn findModuleByName(self: *SyntaxChecker, module_name: []const u8, oom: *?Allocator.Error) ?DefinitionResult {
         const env = self.getModuleLookupEnv() orelse return null;
 
         // Extract the base module name (e.g., "Stdout" from "pf.Stdout")
@@ -1494,9 +1507,16 @@ pub const SyntaxChecker = struct {
             self.logDebug(.build, "[DEF] '{s}' is a builtin type", .{base_name});
 
             // Write embedded builtin source to roc cache
-            const cache_dir = self.cache_config.getModuleCacheDir(self.allocator) catch return null;
-            const builtin_cache_path = std.fs.path.join(self.allocator, &.{ cache_dir, "Builtin.roc" }) catch {
+            const cache_dir = self.cache_config.getModuleCacheDir(self.allocator) catch |err| switch (err) {
+                error.OutOfMemory => {
+                    oom.* = error.OutOfMemory;
+                    return null;
+                },
+                else => return null,
+            };
+            const builtin_cache_path = std.fs.path.join(self.allocator, &.{ cache_dir, "Builtin.roc" }) catch |err| {
                 self.allocator.free(cache_dir);
+                oom.* = err;
                 return null;
             };
             self.allocator.free(cache_dir);
@@ -1520,8 +1540,9 @@ pub const SyntaxChecker = struct {
                 };
             }
 
-            const module_uri = uri_util.pathToUri(self.allocator, builtin_cache_path) catch {
+            const module_uri = uri_util.pathToUri(self.allocator, builtin_cache_path) catch |err| {
                 self.allocator.free(builtin_cache_path);
+                oom.* = err;
                 return null;
             };
             self.allocator.free(builtin_cache_path);
@@ -1537,7 +1558,10 @@ pub const SyntaxChecker = struct {
         while (sched_it.next()) |entry| {
             const sched = entry.value_ptr.*;
             if (sched.getModuleState(base_name)) |mod_state| {
-                const module_uri = uri_util.pathToUri(self.allocator, mod_state.path) catch return null;
+                const module_uri = uri_util.pathToUri(self.allocator, mod_state.path) catch |err| {
+                    oom.* = err;
+                    return null;
+                };
                 return DefinitionResult{
                     .uri = module_uri,
                     .range = .{
@@ -1580,6 +1604,7 @@ pub const SyntaxChecker = struct {
         module_env: *ModuleEnv,
         type_anno_idx: CIR.TypeAnno.Idx,
         target_offset: u32,
+        oom: *?Allocator.Error,
     ) ?DefinitionResult {
         const region = module_env.store.getTypeAnnoRegion(type_anno_idx);
         if (!cir_queries.regionContainsOffset(region, target_offset)) return null;
@@ -1608,7 +1633,7 @@ pub const SyntaxChecker = struct {
                     },
                     .builtin, .external, .pending => {
                         // Builtin, external, or pending type - find the module
-                        return self.findModuleByName(type_name);
+                        return self.findModuleByName(type_name, oom);
                     },
                 }
             },
@@ -1616,7 +1641,7 @@ pub const SyntaxChecker = struct {
                 // Type with args like `List(Str)` - check args first, then the base type
                 const args_slice = module_env.store.sliceTypeAnnos(apply.args);
                 for (args_slice) |arg_idx| {
-                    if (self.findTypeAnnoAtOffset(module_env, arg_idx, target_offset)) |result| {
+                    if (self.findTypeAnnoAtOffset(module_env, arg_idx, target_offset, oom)) |result| {
                         return result;
                     }
                 }
@@ -1639,7 +1664,7 @@ pub const SyntaxChecker = struct {
                     },
                     .builtin, .external, .pending => {
                         // Builtin, external, or pending type - find the module
-                        return self.findModuleByName(type_name);
+                        return self.findModuleByName(type_name, oom);
                     },
                 }
             },
@@ -1648,7 +1673,7 @@ pub const SyntaxChecker = struct {
                 const fields_slice = module_env.store.sliceAnnoRecordFields(rec.fields);
                 for (fields_slice) |field_idx| {
                     const field = module_env.store.getAnnoRecordField(field_idx);
-                    if (self.findTypeAnnoAtOffset(module_env, field.ty, target_offset)) |result| {
+                    if (self.findTypeAnnoAtOffset(module_env, field.ty, target_offset, oom)) |result| {
                         return result;
                     }
                 }
@@ -1658,12 +1683,12 @@ pub const SyntaxChecker = struct {
                 // Check tag types
                 const tags_slice = module_env.store.sliceTypeAnnos(tu.tags);
                 for (tags_slice) |tag_idx| {
-                    if (self.findTypeAnnoAtOffset(module_env, tag_idx, target_offset)) |result| {
+                    if (self.findTypeAnnoAtOffset(module_env, tag_idx, target_offset, oom)) |result| {
                         return result;
                     }
                 }
                 if (tu.ext) |ext_idx| {
-                    if (self.findTypeAnnoAtOffset(module_env, ext_idx, target_offset)) |result| {
+                    if (self.findTypeAnnoAtOffset(module_env, ext_idx, target_offset, oom)) |result| {
                         return result;
                     }
                 }
@@ -1673,7 +1698,7 @@ pub const SyntaxChecker = struct {
                 // Check tag argument types
                 const args_slice = module_env.store.sliceTypeAnnos(t.args);
                 for (args_slice) |arg_idx| {
-                    if (self.findTypeAnnoAtOffset(module_env, arg_idx, target_offset)) |result| {
+                    if (self.findTypeAnnoAtOffset(module_env, arg_idx, target_offset, oom)) |result| {
                         return result;
                     }
                 }
@@ -1683,11 +1708,11 @@ pub const SyntaxChecker = struct {
                 // Check function argument and return types
                 const args_slice = module_env.store.sliceTypeAnnos(f.args);
                 for (args_slice) |arg_idx| {
-                    if (self.findTypeAnnoAtOffset(module_env, arg_idx, target_offset)) |result| {
+                    if (self.findTypeAnnoAtOffset(module_env, arg_idx, target_offset, oom)) |result| {
                         return result;
                     }
                 }
-                if (self.findTypeAnnoAtOffset(module_env, f.ret, target_offset)) |result| {
+                if (self.findTypeAnnoAtOffset(module_env, f.ret, target_offset, oom)) |result| {
                     return result;
                 }
                 return null;
@@ -1696,7 +1721,7 @@ pub const SyntaxChecker = struct {
                 // Check tuple element types
                 const elems_slice = module_env.store.sliceTypeAnnos(t.elems);
                 for (elems_slice) |elem_idx| {
-                    if (self.findTypeAnnoAtOffset(module_env, elem_idx, target_offset)) |result| {
+                    if (self.findTypeAnnoAtOffset(module_env, elem_idx, target_offset, oom)) |result| {
                         return result;
                     }
                 }
@@ -1704,7 +1729,7 @@ pub const SyntaxChecker = struct {
             },
             .parens => |p| {
                 // Unwrap and recurse
-                return self.findTypeAnnoAtOffset(module_env, p.anno, target_offset);
+                return self.findTypeAnnoAtOffset(module_env, p.anno, target_offset, oom);
             },
             .rigid_var, .rigid_var_lookup, .underscore, .malformed => {
                 // These don't have type definitions to navigate to
@@ -1720,6 +1745,7 @@ pub const SyntaxChecker = struct {
         expr_idx: CIR.Expr.Idx,
         target_offset: u32,
         current_uri: []const u8,
+        oom: *?Allocator.Error,
     ) ?DefinitionResult {
         const expr = module_env.store.getExpr(expr_idx);
 
@@ -1741,7 +1767,7 @@ pub const SyntaxChecker = struct {
                     };
 
                     if (maybe_type_anno) |type_anno_idx| {
-                        if (self.findTypeAnnoAtOffset(module_env, type_anno_idx, target_offset)) |result| {
+                        if (self.findTypeAnnoAtOffset(module_env, type_anno_idx, target_offset, oom)) |result| {
                             if (result.uri.len == 0) {
                                 return DefinitionResult{
                                     .uri = current_uri,
@@ -1755,50 +1781,50 @@ pub const SyntaxChecker = struct {
                     // Recurse into expressions within the statement
                     const stmt_parts = module_lookup.getStatementParts(stmt);
                     if (stmt_parts.expr) |stmt_expr| {
-                        if (self.findTypeAnnoInExpr(module_env, stmt_expr, target_offset, current_uri)) |result| {
+                        if (self.findTypeAnnoInExpr(module_env, stmt_expr, target_offset, current_uri, oom)) |result| {
                             return result;
                         }
                     }
                     if (stmt_parts.expr2) |stmt_expr| {
-                        if (self.findTypeAnnoInExpr(module_env, stmt_expr, target_offset, current_uri)) |result| {
+                        if (self.findTypeAnnoInExpr(module_env, stmt_expr, target_offset, current_uri, oom)) |result| {
                             return result;
                         }
                     }
                 }
                 // Also check final expression
-                return self.findTypeAnnoInExpr(module_env, block.final_expr, target_offset, current_uri);
+                return self.findTypeAnnoInExpr(module_env, block.final_expr, target_offset, current_uri, oom);
             },
             .e_lambda => |lambda| {
-                return self.findTypeAnnoInExpr(module_env, lambda.body, target_offset, current_uri);
+                return self.findTypeAnnoInExpr(module_env, lambda.body, target_offset, current_uri, oom);
             },
             .e_closure => |closure| {
-                return self.findTypeAnnoInExpr(module_env, closure.lambda_idx, target_offset, current_uri);
+                return self.findTypeAnnoInExpr(module_env, closure.lambda_idx, target_offset, current_uri, oom);
             },
             .e_if => |if_expr| {
                 const branch_indices = module_env.store.sliceIfBranches(if_expr.branches);
                 for (branch_indices) |branch_idx| {
                     const branch = module_env.store.getIfBranch(branch_idx);
-                    if (self.findTypeAnnoInExpr(module_env, branch.cond, target_offset, current_uri)) |result| {
+                    if (self.findTypeAnnoInExpr(module_env, branch.cond, target_offset, current_uri, oom)) |result| {
                         return result;
                     }
-                    if (self.findTypeAnnoInExpr(module_env, branch.body, target_offset, current_uri)) |result| {
+                    if (self.findTypeAnnoInExpr(module_env, branch.body, target_offset, current_uri, oom)) |result| {
                         return result;
                     }
                 }
-                return self.findTypeAnnoInExpr(module_env, if_expr.final_else, target_offset, current_uri);
+                return self.findTypeAnnoInExpr(module_env, if_expr.final_else, target_offset, current_uri, oom);
             },
             .e_match => |match_expr| {
-                if (self.findTypeAnnoInExpr(module_env, match_expr.cond, target_offset, current_uri)) |result| {
+                if (self.findTypeAnnoInExpr(module_env, match_expr.cond, target_offset, current_uri, oom)) |result| {
                     return result;
                 }
                 const branch_indices = module_env.store.sliceMatchBranches(match_expr.branches);
                 for (branch_indices) |branch_idx| {
                     const branch = module_env.store.getMatchBranch(branch_idx);
-                    if (self.findTypeAnnoInExpr(module_env, branch.value, target_offset, current_uri)) |result| {
+                    if (self.findTypeAnnoInExpr(module_env, branch.value, target_offset, current_uri, oom)) |result| {
                         return result;
                     }
                     if (branch.guard) |guard| {
-                        if (self.findTypeAnnoInExpr(module_env, guard, target_offset, current_uri)) |result| {
+                        if (self.findTypeAnnoInExpr(module_env, guard, target_offset, current_uri, oom)) |result| {
                             return result;
                         }
                     }
@@ -1806,12 +1832,12 @@ pub const SyntaxChecker = struct {
                 return null;
             },
             .e_call => |call| {
-                if (self.findTypeAnnoInExpr(module_env, call.func, target_offset, current_uri)) |result| {
+                if (self.findTypeAnnoInExpr(module_env, call.func, target_offset, current_uri, oom)) |result| {
                     return result;
                 }
                 const args = module_env.store.sliceExpr(call.args);
                 for (args) |arg| {
-                    if (self.findTypeAnnoInExpr(module_env, arg, target_offset, current_uri)) |result| {
+                    if (self.findTypeAnnoInExpr(module_env, arg, target_offset, current_uri, oom)) |result| {
                         return result;
                     }
                 }
@@ -1902,11 +1928,13 @@ pub const SyntaxChecker = struct {
         const env = env_handle.envPtr();
 
         // Convert URI to absolute path to match against module paths
-        const path = uri_util.uriToPath(allocator, uri) catch return &[_]SymbolInformation{};
+        const path = try uri_util.uriToPath(allocator, uri);
         defer allocator.free(path);
 
-        const absolute_path: [:0]u8 = std.Io.Dir.cwd().realPathFileAlloc(self.std_io, path, allocator) catch
-            allocator.dupeZ(u8, path) catch return &[_]SymbolInformation{};
+        const absolute_path: [:0]u8 = std.Io.Dir.cwd().realPathFileAlloc(self.std_io, path, allocator) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => try allocator.dupeZ(u8, path),
+        };
         defer allocator.free(absolute_path);
 
         // Override readFile for the current file so in-memory source is used.
@@ -1949,7 +1977,7 @@ pub const SyntaxChecker = struct {
         };
 
         // Build line offset table
-        const line_offsets = pos.buildLineOffsets(allocator, source) catch return &[_]SymbolInformation{};
+        const line_offsets = try pos.buildLineOffsets(allocator, source);
         defer line_offsets.deinit();
 
         var symbols: std.ArrayList(SymbolInformation) = .empty;
@@ -2037,10 +2065,13 @@ pub const SyntaxChecker = struct {
     }
 
     /// Resolve a local binding's type var for chained access completion.
-    fn resolveLocalBindingTypeVar(self: *SyntaxChecker, module_env: *ModuleEnv, name: []const u8, name_start: u32) ?types.Var {
+    fn resolveLocalBindingTypeVar(self: *SyntaxChecker, module_env: *ModuleEnv, name: []const u8, name_start: u32, oom: *?Allocator.Error) ?types.Var {
         var scope = scope_map.ScopeMap.init(self.allocator);
         defer scope.deinit();
-        scope.build(module_env) catch return null;
+        scope.build(module_env) catch |err| {
+            oom.* = err;
+            return null;
+        };
 
         for (scope.bindings.items) |binding| {
             const binding_name = module_env.getIdentText(binding.ident);
@@ -2083,6 +2114,7 @@ pub const SyntaxChecker = struct {
         env: *BuildEnv,
         access_chain: []const u8,
         chain_start: u32,
+        oom: *?Allocator.Error,
     ) ?struct { module_env: *ModuleEnv, type_var: types.Var } {
         var idx: usize = 0;
         const first = nextChainSegment(access_chain, idx) orelse return null;
@@ -2104,37 +2136,60 @@ pub const SyntaxChecker = struct {
                 resolved_env,
                 first.segment,
                 member.segment,
+                oom,
             ) orelse return null;
             var type_var = ModuleEnv.varFrom(def_info.pattern_idx);
             var namespace_prefix = std.ArrayList(u8).empty;
             defer namespace_prefix.deinit(self.allocator);
-            namespace_prefix.appendSlice(self.allocator, first.segment) catch return null;
-            namespace_prefix.append(self.allocator, '.') catch return null;
-            namespace_prefix.appendSlice(self.allocator, member.segment) catch return null;
+            namespace_prefix.appendSlice(self.allocator, first.segment) catch |err| {
+                oom.* = err;
+                return null;
+            };
+            namespace_prefix.append(self.allocator, '.') catch |err| {
+                oom.* = err;
+                return null;
+            };
+            namespace_prefix.appendSlice(self.allocator, member.segment) catch |err| {
+                oom.* = err;
+                return null;
+            };
 
             while (nextChainSegment(access_chain, idx)) |segment| {
                 idx = segment.next;
 
                 // Prefer namespace/member traversal for uppercase segments before
                 // falling back to structural field traversal.
-                if (findDefinitionByQualifiedPrefix(self.allocator, resolved_env, namespace_prefix.items, segment.segment)) |next_def| {
+                if (findDefinitionByQualifiedPrefix(self.allocator, resolved_env, namespace_prefix.items, segment.segment, oom)) |next_def| {
                     type_var = ModuleEnv.varFrom(next_def.pattern_idx);
-                    namespace_prefix.append(self.allocator, '.') catch return null;
-                    namespace_prefix.appendSlice(self.allocator, segment.segment) catch return null;
+                    namespace_prefix.append(self.allocator, '.') catch |err| {
+                        oom.* = err;
+                        return null;
+                    };
+                    namespace_prefix.appendSlice(self.allocator, segment.segment) catch |err| {
+                        oom.* = err;
+                        return null;
+                    };
                     continue;
                 }
+                if (oom.* != null) return null;
 
                 const next_var = builder.getFieldTypeVarFromTypeVar(resolved_env, type_var, segment.segment) orelse return null;
                 type_var = next_var;
 
-                namespace_prefix.append(self.allocator, '.') catch return null;
-                namespace_prefix.appendSlice(self.allocator, segment.segment) catch return null;
+                namespace_prefix.append(self.allocator, '.') catch |err| {
+                    oom.* = err;
+                    return null;
+                };
+                namespace_prefix.appendSlice(self.allocator, segment.segment) catch |err| {
+                    oom.* = err;
+                    return null;
+                };
             }
 
             return .{ .module_env = resolved_env, .type_var = type_var };
         }
 
-        var type_var = self.resolveLocalBindingTypeVar(module_env, first.segment, chain_start) orelse return null;
+        var type_var = self.resolveLocalBindingTypeVar(module_env, first.segment, chain_start, oom) orelse return null;
         while (nextChainSegment(access_chain, idx)) |segment| {
             idx = segment.next;
             const next_var = builder.getFieldTypeVarFromTypeVar(module_env, type_var, segment.segment) orelse return null;
@@ -2154,14 +2209,16 @@ pub const SyntaxChecker = struct {
         module_env: *ModuleEnv,
         namespace_prefix: []const u8,
         member_name: []const u8,
+        oom: *?Allocator.Error,
     ) ?module_lookup.DefinitionInfo {
         if (module_lookup.findDefinitionByName(module_env, member_name)) |def_info| {
             return def_info;
         }
 
-        if (findDefinitionByQualifiedPrefix(allocator, module_env, namespace_prefix, member_name)) |def_info| {
+        if (findDefinitionByQualifiedPrefix(allocator, module_env, namespace_prefix, member_name, oom)) |def_info| {
             return def_info;
         }
+        if (oom.* != null) return null;
 
         return module_lookup.findDefinitionByUnqualifiedName(module_env, member_name);
     }
@@ -2172,8 +2229,12 @@ pub const SyntaxChecker = struct {
         module_env: *ModuleEnv,
         prefix: []const u8,
         member_name: []const u8,
+        oom: *?Allocator.Error,
     ) ?module_lookup.DefinitionInfo {
-        const qualified = std.fmt.allocPrint(allocator, "{s}.{s}", .{ prefix, member_name }) catch return null;
+        const qualified = std.fmt.allocPrint(allocator, "{s}.{s}", .{ prefix, member_name }) catch |err| {
+            oom.* = err;
+            return null;
+        };
         defer allocator.free(qualified);
         return module_lookup.findDefinitionByName(module_env, qualified);
     }
@@ -2347,12 +2408,14 @@ pub const SyntaxChecker = struct {
                 self.logDebug(.completion, "completion: after_record_dot for '{s}' at offset {d}", .{ record_access.access_chain, record_access.member_start });
                 if (module_env_opt) |module_env| {
                     var chain_resolved = false;
-                    if (resolveAccessChainTypeVar(self, &builder, module_env, module_lookup_env, env, record_access.access_chain, record_access.chain_start)) |resolved| {
+                    var chain_oom: ?Allocator.Error = null;
+                    if (resolveAccessChainTypeVar(self, &builder, module_env, module_lookup_env, env, record_access.access_chain, record_access.chain_start, &chain_oom)) |resolved| {
                         chain_resolved = true;
                         try builder.addFieldsFromTypeVar(resolved.module_env, resolved.type_var);
                         try builder.addTupleIndexCompletions(resolved.module_env, resolved.type_var);
                         try builder.addMethodsFromTypeVar(resolved.module_env, resolved.type_var);
                     }
+                    if (chain_oom) |err| return err;
 
                     // When the chain starts with an uppercase identifier and
                     // type-based traversal fails, try namespace-style member
@@ -2421,12 +2484,14 @@ pub const SyntaxChecker = struct {
                         // Fall back to resolving the call chain textually.
                         if (info.call_chain) |call_chain| {
                             self.logDebug(.completion, "completion: after_receiver_dot fallback using call_chain='{s}'", .{call_chain});
-                            if (resolveAccessChainTypeVar(self, &builder, module_env, module_lookup_env, env, call_chain, info.chain_start)) |resolved| {
+                            var chain_oom: ?Allocator.Error = null;
+                            if (resolveAccessChainTypeVar(self, &builder, module_env, module_lookup_env, env, call_chain, info.chain_start, &chain_oom)) |resolved| {
                                 const ret_type = extractReturnType(resolved.module_env, resolved.type_var);
                                 try builder.addFieldsFromTypeVar(resolved.module_env, ret_type);
                                 try builder.addTupleIndexCompletions(resolved.module_env, ret_type);
                                 try builder.addMethodsFromTypeVar(resolved.module_env, ret_type);
                             }
+                            if (chain_oom) |err| return err;
                         } else if (resolved_type_var) |type_var| {
                             try builder.addFieldsFromTypeVar(module_env, type_var);
                             try builder.addTupleIndexCompletions(module_env, type_var);

--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -169,7 +169,7 @@ pub const SyntaxChecker = struct {
         if (session.drained_reports) |drained_reports| {
             // if the build succeeded, consider snapshotting the BuildEnv for completions
             if (self.shouldSnapshotBuild(env, session.absolute_path, drained_reports)) {
-                self.storeSnapshotEnv(env_handle, session.absolute_path);
+                try self.storeSnapshotEnv(env_handle, session.absolute_path);
             }
             for (drained_reports) |entry| {
                 const mapped_path = if (entry.abs_path.len == 0) session.absolute_path else entry.abs_path;
@@ -289,7 +289,7 @@ pub const SyntaxChecker = struct {
         return true;
     }
 
-    fn storeSnapshotEnv(self: *SyntaxChecker, env_handle: *BuildEnvHandle, absolute_path: []const u8) void {
+    fn storeSnapshotEnv(self: *SyntaxChecker, env_handle: *BuildEnvHandle, absolute_path: []const u8) std.mem.Allocator.Error!void {
         self.logDebug(.completion, "storeSnapshotEnv: path={s}", .{absolute_path});
         if (self.snapshot_envs.fetchRemove(absolute_path)) |removed| {
             self.logDebug(.completion, "storeSnapshotEnv: replacing existing snapshot", .{});
@@ -297,10 +297,10 @@ pub const SyntaxChecker = struct {
             self.allocator.free(removed.key);
         }
 
-        const owned_path = self.allocator.dupe(u8, absolute_path) catch return;
-        self.snapshot_envs.put(self.allocator, owned_path, env_handle) catch {
+        const owned_path = try self.allocator.dupe(u8, absolute_path);
+        self.snapshot_envs.put(self.allocator, owned_path, env_handle) catch |err| {
             self.allocator.free(owned_path);
-            return;
+            return err;
         };
         env_handle.retain(owner_snapshot);
         self.logDebug(.completion, "storeSnapshotEnv: stored snapshot count={d}", .{self.snapshot_envs.count()});
@@ -309,15 +309,36 @@ pub const SyntaxChecker = struct {
     fn clearSnapshots(self: *SyntaxChecker) void {
         // Collect all handles and keys before clearing the map so we can
         // release snapshot ownership without mutating the map mid-iteration.
+        const count = self.snapshot_envs.count();
         var envs: std.ArrayListUnmanaged(*BuildEnvHandle) = .empty;
         defer envs.deinit(self.allocator);
         var keys: std.ArrayListUnmanaged([]const u8) = .empty;
         defer keys.deinit(self.allocator);
 
+        // Pre-reserve so the appends below cannot fail. If reserving fails we
+        // fall back to releasing each entry as we iterate; this still avoids
+        // leaking the handle refcount and key on OOM.
+        const reserved = blk: {
+            envs.ensureTotalCapacity(self.allocator, count) catch break :blk false;
+            keys.ensureTotalCapacity(self.allocator, count) catch break :blk false;
+            break :blk true;
+        };
+
+        if (!reserved) {
+            // OOM path: release/free directly while iterating, then clear.
+            var it = self.snapshot_envs.iterator();
+            while (it.next()) |entry| {
+                entry.value_ptr.*.release(owner_snapshot);
+                self.allocator.free(entry.key_ptr.*);
+            }
+            self.snapshot_envs.clearRetainingCapacity();
+            return;
+        }
+
         var it = self.snapshot_envs.iterator();
         while (it.next()) |entry| {
-            envs.append(self.allocator, entry.value_ptr.*) catch {};
-            keys.append(self.allocator, entry.key_ptr.*) catch {};
+            envs.appendAssumeCapacity(entry.value_ptr.*);
+            keys.appendAssumeCapacity(entry.key_ptr.*);
         }
 
         // Clear the map FIRST so snapshot ownership is only represented by handles.
@@ -1855,7 +1876,7 @@ pub const SyntaxChecker = struct {
         }
 
         // Find all lookups that reference this pattern
-        var lookup_regions = cir_queries.collectLookupReferences(module_env, target_pattern, self.allocator);
+        var lookup_regions = try cir_queries.collectLookupReferences(module_env, target_pattern, self.allocator);
         defer lookup_regions.deinit(self.allocator);
         try regions.appendSlice(self.allocator, lookup_regions.items);
 
@@ -1901,7 +1922,7 @@ pub const SyntaxChecker = struct {
         };
 
         // Drain reports but ignore them for symbols (must still free to avoid leaks)
-        const drained = env.drainReports() catch return &[_]SymbolInformation{};
+        const drained = try env.drainReports();
         defer self.freeDrainedWithReports(drained);
 
         // Get the module env from the scheduler

--- a/src/parse/tokenize.zig
+++ b/src/parse/tokenize.zig
@@ -1704,7 +1704,7 @@ fn testTokenization(gpa: std.mem.Allocator, input: []const u8, expected: []const
 
 /// Assert the invariants of the tokenizer are held.
 pub fn checkTokenizerInvariants(gpa: std.mem.Allocator, input: []const u8, debug: bool) std.mem.Allocator.Error!void {
-    var env = try CommonEnv.init(gpa, gpa.dupe(u8, "") catch unreachable);
+    var env = try CommonEnv.init(gpa, try gpa.dupe(u8, ""));
     defer env.deinit(gpa);
 
     // Initial tokenization.

--- a/src/playground_wasm/main.zig
+++ b/src/playground_wasm/main.zig
@@ -1303,7 +1303,7 @@ fn compileSource(source: []const u8, module_name: []const u8) !CompilerStageData
             // This prevents crashes on malformed diagnostics or empty input
             continue;
         };
-        result.tokenize_reports.append(report) catch continue;
+        try result.tokenize_reports.append(report);
     }
 
     // Collect parse diagnostics with additional error handling
@@ -1313,7 +1313,7 @@ fn compileSource(source: []const u8, module_name: []const u8) !CompilerStageData
             // This prevents crashes on malformed diagnostics or empty input
             continue;
         };
-        result.parse_reports.append(report) catch continue;
+        try result.parse_reports.append(report);
     }
 
     // Stage 2: Canonicalization (always run, even with parse errors)
@@ -1391,7 +1391,7 @@ fn compileSource(source: []const u8, module_name: []const u8) !CompilerStageData
             // This prevents crashes on malformed diagnostics or empty input
             continue;
         };
-        result.can_reports.append(report) catch continue;
+        try result.can_reports.append(report);
     }
 
     // Stage 3: Type checking (always run if we have CIR, even with canonicalization errors)

--- a/src/playground_wasm/main.zig
+++ b/src/playground_wasm/main.zig
@@ -473,6 +473,7 @@ pub const WasmError = enum(u8) {
 const ResponseWriteError = error{
     OutOfBufferSpace,
     WriteFailed,
+    OutOfMemory,
 };
 
 fn cleanupReplState() void {
@@ -587,7 +588,7 @@ export fn processMessage(message_ptr: [*]const u8, message_len: usize, response_
 
     return if (result) |_| @intFromEnum(WasmError.success) else |err| switch (err) {
         error.OutOfBufferSpace => @intFromEnum(WasmError.response_buffer_too_small),
-        error.WriteFailed => @intFromEnum(WasmError.internal_error),
+        error.WriteFailed, error.OutOfMemory => @intFromEnum(WasmError.internal_error),
     };
 }
 
@@ -1761,16 +1762,19 @@ fn writeCanCirResponse(response_buffer: []u8, data: CompilerStageData) ResponseW
 
     if (defs_count == 0 and stmts_count == 0) {
         const debug_begin = tree.beginNode();
-        tree.pushStaticAtom("empty-cir-debug") catch {};
-        tree.pushStaticAtom("no-defs-or-statements") catch {};
+        try tree.pushStaticAtom("empty-cir-debug");
+        try tree.pushStaticAtom("no-defs-or-statements");
         const debug_attrs = tree.beginNode();
-        tree.endNode(debug_begin, debug_attrs) catch {};
+        try tree.endNode(debug_begin, debug_attrs);
     }
 
     const mutable_cir = @constCast(cir);
-    ModuleEnv.pushToSExprTree(mutable_cir, null, &tree) catch {};
-    tree.toHtml(&sexpr_writer_allocating.writer, .include_linecol) catch {};
-    sexpr_writer_allocating.writer.flush() catch {};
+    try ModuleEnv.pushToSExprTree(mutable_cir, null, &tree);
+    tree.toHtml(&sexpr_writer_allocating.writer, .include_linecol) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.WriteFailed,
+    };
+    try sexpr_writer_allocating.writer.flush();
 
     try writeJsonString(w, sexpr_writer_allocating.written());
     try w.writeAll("\"}");
@@ -2119,8 +2123,11 @@ fn writeTypesResponse(response_buffer: []u8, data: CompilerStageData) ResponseWr
         try writeErrorResponse(response_buffer, .ERROR, error_msg);
         return;
     };
-    tree.toHtml(&sexpr_writer_allocating.writer, .include_linecol) catch {};
-    sexpr_writer_allocating.writer.flush() catch {};
+    tree.toHtml(&sexpr_writer_allocating.writer, .include_linecol) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.WriteFailed,
+    };
+    try sexpr_writer_allocating.writer.flush();
 
     try w.writeAll("{\"status\":\"SUCCESS\",\"data\":\"");
     try writeJsonString(w, sexpr_writer_allocating.written());

--- a/src/playground_wasm/main.zig
+++ b/src/playground_wasm/main.zig
@@ -2001,9 +2001,12 @@ fn writeHoverInfoResponse(response_buffer: []u8, data: CompilerStageData, messag
         return;
     }
 
-    var maybe_hover_info = findHoverInfoAtPosition(data, byte_offset, ident_str) catch {
-        try writeErrorResponse(response_buffer, .ERROR, "Failed to find hover information");
-        return;
+    var maybe_hover_info = findHoverInfoAtPosition(data, byte_offset, ident_str) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => {
+            try writeErrorResponse(response_buffer, .ERROR, "Failed to find hover information");
+            return;
+        },
     };
 
     try w.writeAll("{\"status\":\"SUCCESS\",\"hover_info\":");

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -1585,7 +1585,9 @@ const Builder = struct {
             while (initialized > 0) {
                 initialized -= 1;
                 if (captures[initialized].previous) |previous| {
-                    fn_ctx.binders.put(captures[initialized].binder, previous) catch {};
+                    fn_ctx.binders.put(captures[initialized].binder, previous) catch |err| switch (err) {
+                        error.OutOfMemory => Common.invariant("restoring a previously inserted binder cannot reallocate"),
+                    };
                 } else {
                     _ = fn_ctx.binders.remove(captures[initialized].binder);
                 }
@@ -1615,7 +1617,9 @@ const Builder = struct {
             while (index > 0) {
                 index -= 1;
                 if (captures[index].previous) |previous| {
-                    fn_ctx.binders.put(captures[index].binder, previous) catch {};
+                    fn_ctx.binders.put(captures[index].binder, previous) catch |err| switch (err) {
+                        error.OutOfMemory => Common.invariant("restoring a previously inserted binder cannot reallocate"),
+                    };
                 } else {
                     _ = fn_ctx.binders.remove(captures[index].binder);
                 }
@@ -7725,7 +7729,9 @@ const BodyContext = struct {
         while (index > 0) {
             index -= 1;
             if (saved[index].previous) |previous| {
-                self.binders.put(saved[index].binder, previous) catch {};
+                self.binders.put(saved[index].binder, previous) catch |err| switch (err) {
+                    error.OutOfMemory => Common.invariant("restoring a previously inserted binder cannot reallocate"),
+                };
             } else {
                 _ = self.binders.remove(saved[index].binder);
             }

--- a/src/reporting/report.zig
+++ b/src/reporting/report.zig
@@ -108,7 +108,7 @@ pub const Report = struct {
     }
 
     /// Add a suggestion with proper formatting and UTF-8 validation.
-    pub fn addSuggestion(self: *Report, suggestion: []const u8) !void {
+    pub fn addSuggestion(self: *Report, suggestion: []const u8) Allocator.Error!void {
         validateUtf8(suggestion) catch |err| switch (err) {
             error.InvalidUtf8 => {
                 try self.document.addError("[Invalid UTF-8 in suggestion]");
@@ -118,7 +118,13 @@ pub const Report = struct {
         };
 
         const truncated_suggestion = if (suggestion.len > DEFAULT_MAX_MESSAGE_BYTES) blk: {
-            const truncated = truncateUtf8(self.allocator, suggestion, DEFAULT_MAX_MESSAGE_BYTES) catch suggestion;
+            // `suggestion` is already validated as UTF-8 above, and the limit is
+            // large enough that a truncation point always exists, so the only
+            // failure `truncateUtf8` can produce here is running out of memory.
+            const truncated = truncateUtf8(self.allocator, suggestion, DEFAULT_MAX_MESSAGE_BYTES) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.InvalidUtf8, error.CannotTruncate => unreachable,
+            };
             if (truncated.ptr != suggestion.ptr) {
                 try self.owned_strings.append(truncated);
             }

--- a/src/snapshot_tool/main.zig
+++ b/src/snapshot_tool/main.zig
@@ -3656,10 +3656,12 @@ fn processDocsSnapshot(
             std.log.err("Failed to extract docs from module {s}: {}", .{ mod.name, err });
             continue;
         };
+        errdefer mod_docs.deinit(allocator);
         // Override the module name with the clean name from CompiledModuleInfo
+        const clean_name = try allocator.dupe(u8, mod.name);
         allocator.free(mod_docs.name);
-        mod_docs.name = allocator.dupe(u8, mod.name) catch continue;
-        module_docs_list.append(allocator, mod_docs) catch continue;
+        mod_docs.name = clean_name;
+        try module_docs_list.append(allocator, mod_docs);
     }
 
     // Build PackageDocs

--- a/src/unbundle/download.zig
+++ b/src/unbundle/download.zig
@@ -34,7 +34,7 @@ fn getTempDir(allocator: std.mem.Allocator, io: std.Io) !std.Io.Dir {
             const path = std.process.getEnvVarOwned(alloc, name) catch |err| switch (err) {
                 error.EnvironmentVariableNotFound => return null,
                 error.InvalidWtf8 => return null,
-                error.OutOfMemory => return error.FileError,
+                error.OutOfMemory => return error.OutOfMemory,
             };
             defer alloc.free(path);
             return std.Io.Dir.cwd().openDir(io_inner, path, .{}) catch return error.FileError;

--- a/src/unbundle/test_unbundle.zig
+++ b/src/unbundle/test_unbundle.zig
@@ -143,7 +143,7 @@ test "BufferExtractWriter - basic functionality" {
     // Create a file
     const file_writer = try writer.extractWriter().createFile("test.txt");
     try file_writer.writeAll("Hello, World!");
-    writer.extractWriter().finishFile();
+    try writer.extractWriter().finishFile();
 
     // Create a directory (should be no-op for buffer writer)
     try writer.extractWriter().makeDir("test_dir");
@@ -151,7 +151,7 @@ test "BufferExtractWriter - basic functionality" {
     // Create another file in a subdirectory
     const file_writer2 = try writer.extractWriter().createFile("subdir/test2.txt");
     try file_writer2.writeAll("Second file");
-    writer.extractWriter().finishFile();
+    try writer.extractWriter().finishFile();
 
     // Verify files were stored
     try testing.expectEqual(@as(usize, 2), writer.files.count());
@@ -187,7 +187,7 @@ test "DirExtractWriter - basic functionality" {
     // Create a file
     const file_writer = try writer.extractWriter().createFile("test.txt");
     try file_writer.writeAll("Test content");
-    writer.extractWriter().finishFile();
+    try writer.extractWriter().finishFile();
 
     // Verify file was created
     const content = try tmp.dir.readFileAlloc(io, "test.txt", testing.allocator, .limited(1024));
@@ -197,7 +197,7 @@ test "DirExtractWriter - basic functionality" {
     // Create a file in a subdirectory (should create parent dirs)
     const file_writer2 = try writer.extractWriter().createFile("deep/nested/file.txt");
     try file_writer2.writeAll("Nested content");
-    writer.extractWriter().finishFile();
+    try writer.extractWriter().finishFile();
 
     // Verify nested file was created
     const nested_content = try tmp.dir.readFileAlloc(io, "deep/nested/file.txt", testing.allocator, .limited(1024));
@@ -307,12 +307,12 @@ test "BufferExtractWriter - overwrite existing file" {
     // Create a file with initial content
     const file_writer1 = try writer.extractWriter().createFile("test.txt");
     try file_writer1.writeAll("Initial content");
-    writer.extractWriter().finishFile();
+    try writer.extractWriter().finishFile();
 
     // Overwrite the same file
     const file_writer2 = try writer.extractWriter().createFile("test.txt");
     try file_writer2.writeAll("New content");
-    writer.extractWriter().finishFile();
+    try writer.extractWriter().finishFile();
 
     // Verify it was overwritten
     const file = writer.files.get("test.txt");
@@ -332,7 +332,7 @@ test "DirExtractWriter - nested directory creation" {
     // Create a file in a deeply nested path
     const file_writer = try writer.extractWriter().createFile("a/b/c/d/e/file.txt");
     try file_writer.writeAll("Nested content");
-    writer.extractWriter().finishFile();
+    try writer.extractWriter().finishFile();
 
     // Verify the file was created
     const content = try tmp.dir.readFileAlloc(io, "a/b/c/d/e/file.txt", testing.allocator, .limited(1024));

--- a/src/unbundle/unbundle.zig
+++ b/src/unbundle/unbundle.zig
@@ -65,7 +65,7 @@ pub const ExtractWriter = struct {
 
     pub const VTable = struct {
         createFile: *const fn (ptr: *anyopaque, path: []const u8) CreateFileError!*std.Io.Writer,
-        finishFile: *const fn (ptr: *anyopaque) void,
+        finishFile: *const fn (ptr: *anyopaque) std.mem.Allocator.Error!void,
         makeDir: *const fn (ptr: *anyopaque, path: []const u8) MakeDirError!void,
     };
 
@@ -82,7 +82,7 @@ pub const ExtractWriter = struct {
         return self.vtable.createFile(self.ptr, path);
     }
 
-    pub fn finishFile(self: ExtractWriter) void {
+    pub fn finishFile(self: ExtractWriter) std.mem.Allocator.Error!void {
         return self.vtable.finishFile(self.ptr);
     }
 
@@ -164,7 +164,7 @@ pub const DirExtractWriter = struct {
         return &entry.writer.interface;
     }
 
-    fn finishFile(ptr: *anyopaque) void {
+    fn finishFile(ptr: *anyopaque) std.mem.Allocator.Error!void {
         const self: *DirExtractWriter = @ptrCast(@alignCast(ptr));
         // Close and remove the last file
         if (self.open_files.items.len > 0) {
@@ -237,19 +237,21 @@ pub const BufferExtractWriter = struct {
         return &self.current_file_writer.?.writer;
     }
 
-    fn finishFile(ptr: *anyopaque) void {
+    fn finishFile(ptr: *anyopaque) std.mem.Allocator.Error!void {
         const self: *BufferExtractWriter = @ptrCast(@alignCast(ptr));
         if (self.current_file_writer) |*writer| {
             if (self.current_file_path) |path| {
                 // Convert writer contents to Managed ArrayList
                 const unmanaged_list = writer.toArrayList();
                 var managed_list = std.array_list.Managed(u8).fromOwnedSlice(self.allocator, unmanaged_list.items);
-                self.files.put(path, managed_list) catch {
-                    // If put fails, clean up
+                self.current_file_path = null;
+                self.current_file_writer = null;
+                self.files.put(path, managed_list) catch |err| {
                     managed_list.deinit();
                     self.allocator.free(path);
+                    return err;
                 };
-                self.current_file_path = null;
+                return;
             } else {
                 writer.deinit();
             }
@@ -592,10 +594,15 @@ pub fn unbundleStream(
             },
             .file => {
                 const file_writer = try extract_writer.createFile(file_path);
-                defer extract_writer.finishFile();
+                // On the error path, finish the file to release the open-file
+                // resource; a secondary OOM here cannot be propagated from the
+                // unwind, so it is dropped. The success path commits explicitly
+                // below and propagates OOM.
+                errdefer extract_writer.finishFile() catch {};
 
                 try tar_iterator.streamRemaining(entry, file_writer);
                 try file_writer.flush();
+                try extract_writer.finishFile();
 
                 data_extracted = true;
             },

--- a/src/unbundle/unbundle.zig
+++ b/src/unbundle/unbundle.zig
@@ -76,6 +76,7 @@ pub const ExtractWriter = struct {
 
     pub const MakeDirError = error{
         DirectoryCreateFailed,
+        OutOfMemory,
     };
 
     pub fn createFile(self: ExtractWriter, path: []const u8) CreateFileError!*std.Io.Writer {
@@ -261,10 +262,12 @@ pub const BufferExtractWriter = struct {
 
     fn makeDir(ptr: *anyopaque, path: []const u8) ExtractWriter.MakeDirError!void {
         const self: *BufferExtractWriter = @ptrCast(@alignCast(ptr));
-        const dir_copy = self.allocator.dupe(u8, path) catch return error.DirectoryCreateFailed;
-        self.directories.append(dir_copy) catch {
-            self.allocator.free(dir_copy);
-            return error.DirectoryCreateFailed;
+        const dir_copy = self.allocator.dupe(u8, path) catch return error.OutOfMemory;
+        self.directories.append(dir_copy) catch |err| switch (err) {
+            error.OutOfMemory => {
+                self.allocator.free(dir_copy);
+                return error.OutOfMemory;
+            },
         };
     }
 };
@@ -330,26 +333,16 @@ pub fn pathHasUnbundleErr(path: []const u8) ?PathValidationError {
             };
         }
 
-        // Use stack buffer for small components to avoid allocation
-        var upper_buf: [256]u8 = undefined;
-        const upper_component = if (component.len <= upper_buf.len) blk: {
-            for (component, 0..) |c, i| {
-                upper_buf[i] = std.ascii.toUpper(c);
-            }
-            break :blk upper_buf[0..component.len];
-        } else blk: {
-            break :blk std.ascii.allocUpperString(std.heap.page_allocator, component) catch component;
-        };
-        defer if (component.len > upper_buf.len and upper_component.ptr != component.ptr)
-            std.heap.page_allocator.free(upper_component);
-
-        const base_name = if (std.mem.findScalar(u8, upper_component, '.')) |dot_pos|
-            upper_component[0..dot_pos]
+        // The Windows reserved-name check is case-insensitive on the base name
+        // (the part before the first '.'). Compare without allocating so this
+        // validator cannot fail on OOM.
+        const base_name = if (std.mem.findScalar(u8, component, '.')) |dot_pos|
+            component[0..dot_pos]
         else
-            upper_component;
+            component;
 
         for (WINDOWS_RESERVED_NAMES) |reserved| {
-            if (std.mem.eql(u8, base_name, reserved)) {
+            if (std.ascii.eqlIgnoreCase(base_name, reserved)) {
                 return PathValidationError{
                     .path = path,
                     .reason = .windows_reserved_name,

--- a/src/watch/watch.zig
+++ b/src/watch/watch.zig
@@ -680,7 +680,12 @@ pub const Watcher = struct {
                 if (std.mem.endsWith(u8, name, ".roc")) {
                     for (self.impl.watch_descriptors.items) |wd| {
                         if (wd.wd == event.wd) {
-                            const full_path = std.fs.path.join(self.allocator, &.{ wd.path, name }) catch break;
+                            const full_path = std.fs.path.join(self.allocator, &.{ wd.path, name }) catch |err| switch (err) {
+                                error.OutOfMemory => {
+                                    std.log.err("Out of memory building path for changed file: {s}", .{name});
+                                    break;
+                                },
+                            };
                             defer self.allocator.free(full_path);
                             self.callback(.{ .path = full_path });
                             break;
@@ -691,7 +696,12 @@ pub const Watcher = struct {
                 if (event.mask & std.os.linux.IN.CREATE != 0 and event.mask & std.os.linux.IN.ISDIR != 0) {
                     for (self.impl.watch_descriptors.items) |wd| {
                         if (wd.wd == event.wd) {
-                            const new_dir = std.fs.path.join(self.allocator, &.{ wd.path, name }) catch break;
+                            const new_dir = std.fs.path.join(self.allocator, &.{ wd.path, name }) catch |err| switch (err) {
+                                error.OutOfMemory => {
+                                    std.log.err("Out of memory building path for new directory: {s}", .{name});
+                                    break;
+                                },
+                            };
                             defer self.allocator.free(new_dir);
                             self.addWatchRecursiveLinux(new_dir) catch |err| {
                                 std.log.err("Failed to watch new directory: {}", .{err});
@@ -704,7 +714,12 @@ pub const Watcher = struct {
                             var it = dir.iterate();
                             while (it.next(self.std_io) catch null) |entry| {
                                 if (entry.kind == .file and std.mem.endsWith(u8, entry.name, ".roc")) {
-                                    const full_path = std.fs.path.join(self.allocator, &.{ new_dir, entry.name }) catch continue;
+                                    const full_path = std.fs.path.join(self.allocator, &.{ new_dir, entry.name }) catch |err| switch (err) {
+                                        error.OutOfMemory => {
+                                            std.log.err("Out of memory building path for file in new directory: {s}", .{entry.name});
+                                            continue;
+                                        },
+                                    };
                                     defer self.allocator.free(full_path);
                                     self.callback(.{ .path = full_path });
                                 }
@@ -1029,11 +1044,14 @@ pub const Watcher = struct {
             // Check if it's a .roc file
             if (std.mem.endsWith(u8, filename_utf8, ".roc")) {
                 // Create full path
-                const full_path = std.fs.path.join(self.allocator, &.{ base_path, filename_utf8 }) catch {
-                    // Skip this file if we can't create the path
-                    if (info.NextEntryOffset == 0) break;
-                    offset += info.NextEntryOffset;
-                    continue;
+                const full_path = std.fs.path.join(self.allocator, &.{ base_path, filename_utf8 }) catch |err| switch (err) {
+                    error.OutOfMemory => {
+                        std.log.err("Out of memory building path for changed file: {s}", .{filename_utf8});
+                        // Skip this file if we can't create the path
+                        if (info.NextEntryOffset == 0) break;
+                        offset += info.NextEntryOffset;
+                        continue;
+                    },
                 };
                 defer self.allocator.free(full_path);
 


### PR DESCRIPTION
A full audit of `error.OutOfMemory` handling across `src/` surfaced a set of places that silently swallowed allocation failure, panicked where graceful propagation was feasible, mislabeled OOM as an unrelated error, or hit undefined behavior on OOM. This propagates OOM with explicit error sets (`Allocator.Error!T`) and routes the `callconv(.c)` FFI-boundary cases through a graceful host crash instead of a success-shaped default.

The standout correctness/safety fixes: the wasm backend no longer emits a silently-corrupt module or drops a global export when a relocation/export allocation fails (`resolveDataRelocations`/`resolveRelocations`/`exportGlobalSymbols` now propagate); `EnvPool.release` no longer appends a deinit'd env back into the pool after a failed `reset` (a use-after-free that was reachable only on OOM); the glue result extractor propagates OOM rather than calling `glueInvariant`, which is `unreachable` (UB) in release builds; and the unbundle `BufferExtractWriter` no longer silently drops an extracted file when its hashmap insert fails — the `finishFile` vtable callback now returns an error and the extract loop commits explicitly with error-path cleanup.

The compile coordinator gains a `worker_oom` `WorkerResult` variant so an allocation failure during parse/canonicalize/type-check aborts the build with the real `error.OutOfMemory` instead of masquerading as a "PARSING/CANONICALIZATION/TYPE CHECKING FAILED" report. The URL-package and cache-dir resolution paths add explicit `error.OutOfMemory` arms instead of folding OOM into `InvalidUrl`/`NoCacheDir`/`DownloadFailed`/`NoHomeDirectory`. `MonoLlvmCodeGen` relabels its OOM-only LLVM builder calls from `CompilationFailed` to `OutOfMemory` (the genuine `CompilationFailed` and the two debug-IR-dump writer/file sites are left as-is). `LirCodeGen` restores its saved per-proc maps with allocation-free `std.mem.swap` in the `errdefer` instead of `clone() catch unreachable` (a `try` would be illegal in a defer). The glue platform host reports OOM and exits rather than leaking its allocation-tracking entry.

The remaining tooling paths propagate OOM as well: echo_platform (`emitDiagnostics`/`buildCliArgs`/`sanitizeUtf8`), docs (doc-type extraction and broken-link recording), the playground CIR/types debug views (with `OutOfMemory` added to `ResponseWriteError`), the linker sysroot lookup (which also had pre-existing leaks of the joined paths), the `roc check` loop, and the const-store debug verifier; `builtin_loading` gains a missing `errdefer`.

One audit finding was intentionally left: `backend/llvm/Builder.zig`'s `bigint.toStringAlloc(...) catch return error.WriteFailed` is vendored Zig-compiler code implementing the std `format` interface whose error set cannot carry `OutOfMemory`, so `WriteFailed` is the only legal mapping and the OOM still propagates and aborts the print.