### PR TITLE
Make List.join_with concatenate lists; fix non-terminating static-dispatch `where` constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ src/snapshots/**/*.html
 
 # Local claude-code settings
 .claude/
+.claude
 
 *.bak
 kcov-output/

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -9878,15 +9878,39 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
         const deferred_constraint = env.deferred_static_dispatch_constraints.items.items[deferred_constraint_index];
 
         if (deferred_constraint_index >= max_deferred_dispatch_iterations) {
-            // Runaway: a non-terminating static-dispatch cycle keeps enqueueing
-            // fresh constrained receivers. Report an infinite type and stop,
-            // rather than hang. (See `max_deferred_dispatch_iterations`.)
-            const snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, deferred_constraint.var_);
-            _ = try self.problems.appendProblem(self.gpa, .{ .infinite_recursion = .{
-                .var_ = deferred_constraint.var_,
-                .snapshot = snapshot,
-                .def_name = null,
-            } });
+            // Runaway: a non-terminating static-dispatch cycle keeps re-deriving
+            // an unsatisfiable `where` constraint on the same type because the
+            // recursion never bottoms out (the element type's method has the
+            // wrong shape). Report the *unsatisfied method* precisely — naming the
+            // dispatcher type and method — rather than a generic infinite type,
+            // then stop. (See `max_deferred_dispatch_iterations`.)
+            const constraints = self.types.sliceStaticDispatchConstraints(deferred_constraint.constraints);
+            const resolved_content = self.types.resolveVar(deferred_constraint.var_).desc.content;
+            const dispatcher_type: ?problem.DispatcherDoesNotImplMethod.DispatcherType =
+                if (resolved_content == .structure and resolved_content.structure == .nominal_type)
+                    .nominal
+                else if (resolved_content == .rigid)
+                    .rigid
+                else
+                    null;
+            if (constraints.len > 0 and dispatcher_type != null) {
+                try self.reportConstraintError(
+                    deferred_constraint.var_,
+                    constraints[0],
+                    .{ .missing_method = dispatcher_type.? },
+                    env,
+                    is_numeric_default_pass,
+                );
+            } else {
+                // Fall back to a generic infinite-type error when we can't name a
+                // dispatcher type (e.g. the receiver is a flex/structural type).
+                const snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, deferred_constraint.var_);
+                _ = try self.problems.appendProblem(self.gpa, .{ .infinite_recursion = .{
+                    .var_ = deferred_constraint.var_,
+                    .snapshot = snapshot,
+                    .def_name = null,
+                } });
+            }
             try self.unifyWith(deferred_constraint.var_, .err, env);
             break;
         }

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -893,6 +893,21 @@ fn instantiateVarHelp(
     // Then, instantiate the variable with the provided context
     const instantiated_var = try instantiator.instantiateVar(var_to_instantiate);
 
+    if (instantiator.recursion_overflow) {
+        // Non-terminating instantiation — e.g. a self-referential static-dispatch
+        // `where` constraint used at a nesting depth the `var_map` memo cannot
+        // collapse. Report an infinite-type error and yield a fresh err var
+        // instead of using the partial (err-filled) result, rather than hang.
+        const overflow_region = self.regions.get(@enumFromInt(@intFromEnum(var_to_instantiate))).*;
+        const snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, var_to_instantiate);
+        _ = try self.problems.appendProblem(self.gpa, .{ .infinite_recursion = .{
+            .var_ = var_to_instantiate,
+            .snapshot = snapshot,
+            .def_name = null,
+        } });
+        return try self.freshFromContent(.err, env, overflow_region);
+    }
+
     // If we had to insert any new type variables, ensure that we have
     // corresponding regions for them. This is essential for error reporting.
     const root_instantiated_region = self.regions.get(@enumFromInt(@intFromEnum(var_to_instantiate))).*;
@@ -9840,6 +9855,15 @@ fn checkConstraints(self: *Self, env: *Env) std.mem.Allocator.Error!void {
 ///
 /// Initially, we only have to check constraint for `Test.to_str2`. But when we
 /// process that, we then have to check `Test.to_str`.
+/// Runaway guard for the deferred static-dispatch worklist below. The worklist
+/// legitimately grows while solving (resolving one constraint can reveal more),
+/// but a self-referential `where` constraint (e.g. `Vec(a) ... where
+/// [a.join : Vec(a), a -> a]` used nested) makes each iteration enqueue a fresh
+/// constrained receiver, so the list outruns the index forever. No real module
+/// reaches this many deferred dispatch constraints in one pass; hitting it means
+/// a non-terminating cycle, which we report as an infinite type instead of hanging.
+const max_deferred_dispatch_iterations: usize = 1 << 14;
+
 fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pass: bool) std.mem.Allocator.Error!void {
     const trace = tracy.trace(@src());
     defer trace.end();
@@ -9852,6 +9876,21 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
     var deferred_constraint_index: usize = 0;
     while (deferred_constraint_index < env.deferred_static_dispatch_constraints.items.items.len) : (deferred_constraint_index += 1) {
         const deferred_constraint = env.deferred_static_dispatch_constraints.items.items[deferred_constraint_index];
+
+        if (deferred_constraint_index >= max_deferred_dispatch_iterations) {
+            // Runaway: a non-terminating static-dispatch cycle keeps enqueueing
+            // fresh constrained receivers. Report an infinite type and stop,
+            // rather than hang. (See `max_deferred_dispatch_iterations`.)
+            const snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, deferred_constraint.var_);
+            _ = try self.problems.appendProblem(self.gpa, .{ .infinite_recursion = .{
+                .var_ = deferred_constraint.var_,
+                .snapshot = snapshot,
+                .def_name = null,
+            } });
+            try self.unifyWith(deferred_constraint.var_, .err, env);
+            break;
+        }
+
         const dispatcher_resolved = self.types.resolveVar(deferred_constraint.var_);
         const dispatcher_content = dispatcher_resolved.desc.content;
 

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -6364,17 +6364,15 @@ test "check type - tag union - ext hints 2" {
     );
 }
 
-// Userland reproduction of the `List.join_with` / `join_list_with` situation.
+// Userland reproduction of a recursive-constraint static-dispatch method that
+// cannot self-nest.
 //
-// `List.join_with : List(item), item -> item where [item.join_with : ...]` has a
-// recursive constraint. For a list-of-lists the element `List(_)` cannot satisfy
-// that constraint with the right shape, so the compiler reroutes to a *separately
-// named* builtin `join_list_with` via a hardcoded probe
-// (Check.zig:listJoinWithListItemsMethodDef, keyed on the `join_with`/`list`
-// idents). Static dispatch has no general overload resolution and the reroute is
-// hardcoded to those builtin idents, so a userland container cannot reproduce the
-// nesting: the base case (element implements the method) type-checks, but the
-// self-nested case has no second binding to resolve to.
+// A method like `join : Vec(a), a -> a where [a.join : Vec(a), a -> a]` has a
+// recursive constraint. For a nested `Vec(Vec(_))` the element `Vec(_)` cannot
+// satisfy that constraint with the right shape, and static dispatch has no
+// general overload resolution, so there is no second binding to resolve to: the
+// base case (element implements the method) type-checks, but the self-nested
+// case has no candidate and is a type error.
 test "static dispatch - userland recursive-constraint method cannot self-nest (no general overload)" {
     const source =
         \\Leaf := [L].{

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -6363,3 +6363,51 @@ test "check type - tag union - ext hints 2" {
         \\
     );
 }
+
+// Userland reproduction of the `List.join_with` / `join_list_with` situation.
+//
+// `List.join_with : List(item), item -> item where [item.join_with : ...]` has a
+// recursive constraint. For a list-of-lists the element `List(_)` cannot satisfy
+// that constraint with the right shape, so the compiler reroutes to a *separately
+// named* builtin `join_list_with` via a hardcoded probe
+// (Check.zig:listJoinWithListItemsMethodDef, keyed on the `join_with`/`list`
+// idents). Static dispatch has no general overload resolution and the reroute is
+// hardcoded to those builtin idents, so a userland container cannot reproduce the
+// nesting: the base case (element implements the method) type-checks, but the
+// self-nested case has no second binding to resolve to.
+test "static dispatch - userland recursive-constraint method cannot self-nest (no general overload)" {
+    const source =
+        \\Leaf := [L].{
+        \\  join : Vec(Leaf), Leaf -> Leaf
+        \\  join = |_v, sep| sep
+        \\}
+        \\
+        \\Vec(a) := [V(List(a))].{
+        \\  join : Vec(a), a -> a where [a.join : Vec(a), a -> a]
+        \\  join = |_v, sep| sep
+        \\}
+        \\
+        \\leaves : Vec(Leaf)
+        \\leaves = Vec.V([Leaf.L])
+        \\
+        \\ok : Leaf
+        \\ok = leaves.join(Leaf.L)
+        \\
+        \\nested : Vec(Vec(Leaf))
+        \\nested = Vec.V([leaves])
+        \\
+        \\bad : Vec(Leaf)
+        \\bad = nested.join(leaves)
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    // Base case: element type `Leaf` implements `join`, so regular static dispatch
+    // resolves it. (Tolerate the nested error elsewhere in the module.)
+    try test_env.assertDefTypeOptions("ok", "Leaf", .{ .allow_type_errors = true });
+
+    // Self-nested case: element type `Vec(Leaf)` would need a `join` of shape
+    // `Vec(Vec(Leaf)), Vec(Leaf) -> Vec(Leaf)`, but the only `Vec.join` has shape
+    // `Vec(a), a -> a`. No overload to select, no userland reroute -> a type error.
+    try testing.expect(test_env.checker.problems.problems.items.len >= 1);
+}

--- a/src/types/instantiate.zig
+++ b/src/types/instantiate.zig
@@ -27,6 +27,15 @@ const Tuple = types_mod.Tuple;
 const Rank = types_mod.Rank;
 const Ident = base.Ident;
 
+/// Hard ceiling on instantiation recursion depth. Finite types never approach
+/// this; a self-referential static-dispatch `where` constraint (e.g.
+/// `Vec(a) ... where [a.join : Vec(a), a -> a]` used nested) would otherwise
+/// recurse forever, minting fresh constrained vars at each level that the
+/// `var_map` memo cannot dedup. On hitting this ceiling the instantiator stops
+/// and flags `recursion_overflow`; the caller turns that into an infinite-type
+/// error rather than hanging.
+pub const max_instantiation_depth: u32 = 8192;
+
 /// Type to manage instantiation.
 ///
 /// Entry point is `instantiateVar`
@@ -42,6 +51,13 @@ pub const Instantiator = struct {
     current_rank: Rank,
     rigid_behavior: RigidBehavior,
     rank_behavior: RankBehavior = .respect_rank,
+
+    /// Live recursion depth, guarded against non-terminating instantiation.
+    depth: u32 = 0,
+    /// Set once `depth` exceeds `max_instantiation_depth`. The entry point
+    /// (`Check.instantiateVarHelp`) turns this into an infinite-type error
+    /// instead of using the (partial, err-filled) result.
+    recursion_overflow: bool = false,
 
     /// Controls whether to respect rank when deciding what to instantiate
     pub const RankBehavior = enum {
@@ -84,6 +100,16 @@ pub const Instantiator = struct {
     ) std.mem.Allocator.Error!Var {
         const resolved = self.store.resolveVar(initial_var);
         const resolved_var = resolved.var_;
+
+        // Guard against non-terminating instantiation (e.g. a self-referential
+        // static-dispatch `where` constraint). Stop recursing and flag overflow;
+        // the caller reports an infinite-type error.
+        self.depth += 1;
+        defer self.depth -= 1;
+        if (self.depth > max_instantiation_depth) {
+            self.recursion_overflow = true;
+            return try self.store.freshFromContentWithRank(.err, self.current_rank);
+        }
 
         // Non-generalized variables should _not_ be instantiated (unless configured to ignore rank)
         if (self.rank_behavior == .respect_rank and resolved.desc.rank != .generalized) {


### PR DESCRIPTION
## Summary

`List.join_with` was previously defined as a generic `where`-constrained method that forwarded to an `Item.join_with` interface, with a separate `join_list_with` providing the concrete list-of-lists implementation. Routing that forwarding required special-case "reroute" code in the type checker and the monotype lowering pass. Along the way, the `where`-constraint machinery could *hang* the type checker on a self-referential constraint.

This branch does two related things:

1. **Hardens the type checker** against non-terminating static-dispatch `where` constraints, converting a hang into a precise, reported error.
2. **Refactors `List.join_with`** into a plain list concatenation builtin, deleting the forwarding interface and the reroute hacks entirely.

## Changes

### `refactor(builtins): List.join_with concatenates lists, drop forwarding interface and reroute hacks`

- Redefines `List.join_with : List(List(item)), List(item) -> List(item)` so it concatenates a list of lists, inserting a separator list between consecutive elements (folding in the old `join_list_with` body). Example: `[[1, 2], [3], [4, 5]].join_with([0]) == [1, 2, 0, 3, 0, 4, 5]`.
- Drops the old `where [item.join_with : ...]` forwarding interface and the `Item.join_with` indirection.
- Removes the special-case routing that rerouted `List.join_with` to the helper: `listJoinWithListItemsMethodDef` in `Check.zig` and `listJoinWithListItemsTarget` in `postcheck/monotype/lower.zig`. With `join_with` a normal builtin, no bespoke dispatch routing is needed — in line with the repo's "no workarounds/heuristics outside parsing & error reporting" rule.
- Snapshots updated to the new semantics; the now-obsolete `eval/list_join_with_custom.md` snapshot is removed.

### `fix(check): terminate on self-referential static-dispatch where constraints`

A `where` constraint that recurses on a type parameter whose element method has the wrong shape made the type checker hang (the deferred static-dispatch worklist grew by one structurally-identical constraint per iteration and never drained). Adds two runaway guards that turn the hang into a reported infinite-type error:

- A hard iteration cap on the deferred static-dispatch worklist.
- A recursion-depth guard in the type instantiator.

Includes a regression test for the previously-hanging nested case.

### `fix(check): precise error for non-terminating static-dispatch where constraints`

When the worklist cap trips, emit the precise "dispatcher does not implement method" error (naming the dispatcher type and method) instead of a generic infinite-type message — the element type has the method, just not of the required shape.

### `chore: ignore .claude`

Adds a bare `.claude` entry to `.gitignore` (alongside the existing `.claude/`).

## Scope / follow-ups

The iteration cap and depth guard are deliberate safety backstops, not the root fix. Cheaper structural duplicate-detection and the real solution (overload resolution, so the nested case resolves rather than errors) are written up in the accompanying design notes and left for follow-up work.

## Testing

- `src/check` integration tests (including the new regression test)
- Snapshot suite regenerated and reviewed
