### PR TITLE
Add post-check wrapper inlining

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3378,6 +3378,51 @@ pub fn build(b: *std.Build) void {
         run_builtin_doc_test_step.dependOn(&run_builtin_doc_test.step);
     }
 
+    const lir_inline_test = b.addTest(.{
+        .name = "lir_inline_test",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/eval/test/lir_inline_test.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+        .filters = test_filters,
+    });
+    roc_modules.addAll(lir_inline_test);
+    lir_inline_test.root_module.addImport("compiled_builtins", compiled_builtins_module);
+    lir_inline_test.step.dependOn(&write_compiled_builtins.step);
+    try addLlvmSupportToStep(
+        b,
+        lir_inline_test,
+        target,
+        use_system_llvm,
+        user_llvm_path,
+        roc_modules,
+        llvm_codegen_module,
+        llvm_embedded_module,
+        zstd,
+    );
+    if (lir_inline_test.root_module.resolved_target.?.result.os.tag != .windows or
+        lir_inline_test.root_module.resolved_target.?.result.abi != .msvc)
+    {
+        lir_inline_test.root_module.link_libcpp = true;
+    }
+    add_tracy(b, roc_modules.build_options, lir_inline_test, target, true, flag_enable_tracy);
+    build_test_zig_step.dependOn(&lir_inline_test.step);
+
+    const run_lir_inline_test = b.addRunArtifact(lir_inline_test);
+    if (run_args.len != 0) {
+        run_lir_inline_test.addArgs(run_args);
+    }
+
+    tests_summary.addRun(&run_lir_inline_test.step);
+
+    const run_lir_inline_test_step = b.step(
+        "run-test-zig-lir-inline",
+        "Run LIR inline Zig tests",
+    );
+    run_lir_inline_test_step.dependOn(&run_lir_inline_test.step);
+
     // Add CLI test
     const enable_cli_tests = b.option(bool, "cli-tests", "Enable cli tests") orelse true;
     if (enable_cli_tests) {

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -3570,6 +3570,7 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) anyerror!void {
         .{ .requests = root_artifact.root_requests.runtime_requests },
         .{
             .target_usize = target_usize,
+            .inline_mode = postCheckInlineModeForOpt(args.opt),
         },
     );
     defer lowered.deinit();
@@ -4453,6 +4454,13 @@ fn cliTestExecutionMode(opt: cli_args.OptLevel) CliTestExecutionMode {
     };
 }
 
+fn postCheckInlineModeForOpt(opt: cli_args.OptLevel) lir.CheckedPipeline.InlineMode {
+    return switch (opt) {
+        .size, .speed => .direct_call_wrappers,
+        .dev, .interpreter => .none,
+    };
+}
+
 const CliTestRootRun = struct {
     root: check.CheckedArtifact.RootRequest,
     root_proc: lir.LirProcSpecId,
@@ -4762,6 +4770,7 @@ fn runCheckedArtifactTests(
         .{ .requests = test_roots },
         .{
             .target_usize = base.target.TargetUsize.native,
+            .inline_mode = postCheckInlineModeForOpt(opt),
         },
     );
     defer lowered.deinit();

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -1,0 +1,297 @@
+const std = @import("std");
+const base = @import("base");
+const check = @import("check");
+const eval = @import("eval");
+const lir = @import("lir");
+const helpers = eval.test_helpers;
+
+const Allocator = std.mem.Allocator;
+const LIR = lir.LIR;
+
+const LoweredSource = struct {
+    resources: helpers.ParsedResources,
+    lowered: lir.CheckedPipeline.LoweredProgram,
+
+    fn deinit(self: *LoweredSource, allocator: Allocator) void {
+        self.lowered.deinit();
+        helpers.cleanupParseAndCanonical(allocator, self.resources);
+    }
+};
+
+fn lowerModule(
+    allocator: Allocator,
+    source: []const u8,
+    inline_mode: lir.CheckedPipeline.InlineMode,
+) !LoweredSource {
+    var resources = try helpers.parseAndCanonicalizeProgram(allocator, .module, source, &.{});
+    errdefer helpers.cleanupParseAndCanonical(allocator, resources);
+
+    const import_count = resources.import_artifacts.len + if (resources.borrowed_builtin_artifact == null) @as(usize, 0) else 1;
+    const import_views = try allocator.alloc(check.CheckedArtifact.ImportedModuleView, import_count);
+    defer allocator.free(import_views);
+
+    var view_index: usize = 0;
+    if (resources.borrowed_builtin_artifact) |builtin_artifact| {
+        import_views[view_index] = check.CheckedArtifact.importedView(builtin_artifact);
+        view_index += 1;
+    }
+    for (resources.import_artifacts) |*artifact| {
+        import_views[view_index] = check.CheckedArtifact.importedView(artifact);
+        view_index += 1;
+    }
+
+    var lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
+        allocator,
+        .{
+            .root = check.CheckedArtifact.loweringView(&resources.checked_artifact),
+            .imports = import_views,
+        },
+        .{ .requests = resources.checked_artifact.root_requests.runtime_requests },
+        .{
+            .target_usize = base.target.TargetUsize.native,
+            .inline_mode = inline_mode,
+        },
+    );
+    errdefer lowered.deinit();
+
+    return .{
+        .resources = resources,
+        .lowered = lowered,
+    };
+}
+
+fn rootProc(lowered: *const lir.CheckedPipeline.LoweredProgram) !LIR.LirProcSpecId {
+    try std.testing.expectEqual(@as(usize, 1), lowered.lir_result.root_procs.items.len);
+    return lowered.lir_result.root_procs.items[0];
+}
+
+fn collectAssignCallProcs(
+    allocator: Allocator,
+    lowered: *const lir.CheckedPipeline.LoweredProgram,
+    proc_id: LIR.LirProcSpecId,
+) ![]LIR.LirProcSpecId {
+    const proc = lowered.lir_result.store.getProcSpec(proc_id);
+    const body = proc.body orelse return allocator.alloc(LIR.LirProcSpecId, 0);
+
+    var calls = std.ArrayList(LIR.LirProcSpecId).empty;
+    errdefer calls.deinit(allocator);
+
+    var work = std.ArrayList(LIR.CFStmtId).empty;
+    defer work.deinit(allocator);
+    try work.append(allocator, body);
+
+    var visited = std.AutoHashMap(LIR.CFStmtId, void).init(allocator);
+    defer visited.deinit();
+
+    while (work.pop()) |stmt_id| {
+        const visited_entry = try visited.getOrPut(stmt_id);
+        if (visited_entry.found_existing) continue;
+
+        switch (lowered.lir_result.store.getCFStmt(stmt_id)) {
+            .assign_ref => |stmt| try work.append(allocator, stmt.next),
+            .assign_literal => |stmt| try work.append(allocator, stmt.next),
+            .assign_call => |stmt| {
+                try calls.append(allocator, stmt.proc);
+                try work.append(allocator, stmt.next);
+            },
+            .assign_call_erased => |stmt| try work.append(allocator, stmt.next),
+            .assign_packed_erased_fn => |stmt| try work.append(allocator, stmt.next),
+            .assign_low_level => |stmt| try work.append(allocator, stmt.next),
+            .assign_list => |stmt| try work.append(allocator, stmt.next),
+            .assign_struct => |stmt| try work.append(allocator, stmt.next),
+            .assign_tag => |stmt| try work.append(allocator, stmt.next),
+            .set_local => |stmt| try work.append(allocator, stmt.next),
+            .debug => |stmt| try work.append(allocator, stmt.next),
+            .expect => |stmt| try work.append(allocator, stmt.next),
+            .incref => |stmt| try work.append(allocator, stmt.next),
+            .decref => |stmt| try work.append(allocator, stmt.next),
+            .free => |stmt| try work.append(allocator, stmt.next),
+            .switch_stmt => |stmt| {
+                if (stmt.continuation) |continuation| try work.append(allocator, continuation);
+                try work.append(allocator, stmt.default_branch);
+                for (lowered.lir_result.store.getCFSwitchBranches(stmt.branches)) |branch| {
+                    try work.append(allocator, branch.body);
+                }
+            },
+            .join => |stmt| {
+                try work.append(allocator, stmt.body);
+                try work.append(allocator, stmt.remainder);
+            },
+            .runtime_error,
+            .loop_continue,
+            .loop_break,
+            .jump,
+            .ret,
+            .crash,
+            => {},
+        }
+    }
+
+    return try calls.toOwnedSlice(allocator);
+}
+
+fn rootDirectCallTarget(
+    allocator: Allocator,
+    lowered: *const lir.CheckedPipeline.LoweredProgram,
+) !LIR.LirProcSpecId {
+    const root = try rootProc(lowered);
+    const root_calls = try collectAssignCallProcs(allocator, lowered, root);
+    defer allocator.free(root_calls);
+
+    try std.testing.expectEqual(@as(usize, 1), root_calls.len);
+    return root_calls[0];
+}
+
+fn expectRootTargetCallCount(
+    source: []const u8,
+    inline_mode: lir.CheckedPipeline.InlineMode,
+    expected: usize,
+) !void {
+    const allocator = std.testing.allocator;
+    var lowered_source = try lowerModule(allocator, source, inline_mode);
+    defer lowered_source.deinit(allocator);
+
+    const target = try rootDirectCallTarget(allocator, &lowered_source.lowered);
+    const target_calls = try collectAssignCallProcs(allocator, &lowered_source.lowered, target);
+    defer allocator.free(target_calls);
+
+    try std.testing.expectEqual(expected, target_calls.len);
+}
+
+fn expectRootTargetHasCalls(
+    source: []const u8,
+    inline_mode: lir.CheckedPipeline.InlineMode,
+) !void {
+    const allocator = std.testing.allocator;
+    var lowered_source = try lowerModule(allocator, source, inline_mode);
+    defer lowered_source.deinit(allocator);
+
+    const target = try rootDirectCallTarget(allocator, &lowered_source.lowered);
+    const target_calls = try collectAssignCallProcs(allocator, &lowered_source.lowered, target);
+    defer allocator.free(target_calls);
+
+    try std.testing.expect(target_calls.len > 0);
+}
+
+test "direct call wrapper is inlined when inline mode is enabled" {
+    try expectRootTargetCallCount(
+        \\module [main]
+        \\
+        \\callee : U64 -> U64
+        \\callee = |x| x + 1
+        \\
+        \\wrapper : U64 -> U64
+        \\wrapper = |x| callee(x)
+        \\
+        \\main : U64
+        \\main = wrapper(41)
+    , .direct_call_wrappers, 0);
+}
+
+test "direct call wrapper is not inlined when inline mode is none" {
+    try expectRootTargetHasCalls(
+        \\module [main]
+        \\
+        \\callee : U64 -> U64
+        \\callee = |x| x + 1
+        \\
+        \\wrapper : U64 -> U64
+        \\wrapper = |x| callee(x)
+        \\
+        \\main : U64
+        \\main = wrapper(41)
+    , .none);
+}
+
+test "zero statement block wrapper is inlined" {
+    try expectRootTargetCallCount(
+        \\module [main]
+        \\
+        \\callee : U64 -> U64
+        \\callee = |x| x + 1
+        \\
+        \\wrapper : U64 -> U64
+        \\wrapper = |x| {
+        \\    callee(x)
+        \\}
+        \\
+        \\main : U64
+        \\main = wrapper(41)
+    , .direct_call_wrappers, 0);
+}
+
+test "block wrapper with statements is not inlined" {
+    try expectRootTargetHasCalls(
+        \\module [main]
+        \\
+        \\callee : U64 -> U64
+        \\callee = |x| x + 1
+        \\
+        \\wrapper : U64 -> U64
+        \\wrapper = |x| {
+        \\    y = x
+        \\    callee(y)
+        \\}
+        \\
+        \\main : U64
+        \\main = wrapper(41)
+    , .direct_call_wrappers);
+}
+
+test "call value wrapper is not inlined" {
+    try expectRootTargetHasCalls(
+        \\module [main]
+        \\
+        \\callee : U64 -> U64
+        \\callee = |x| x + 1
+        \\
+        \\apply : (U64 -> U64), U64 -> U64
+        \\apply = |fn, x| fn(x)
+        \\
+        \\main : U64
+        \\main = apply(callee, 41)
+    , .direct_call_wrappers);
+}
+
+test "self-recursive direct wrapper is not inlined" {
+    try expectRootTargetHasCalls(
+        \\module [main]
+        \\
+        \\wrapper : U64 -> U64
+        \\wrapper = |x| wrapper(x)
+        \\
+        \\main : U64
+        \\main = wrapper(1)
+    , .direct_call_wrappers);
+}
+
+test "mutually recursive direct wrappers are not inlined" {
+    try expectRootTargetHasCalls(
+        \\module [main]
+        \\
+        \\a : U64 -> U64
+        \\a = |x| b(x)
+        \\
+        \\b : U64 -> U64
+        \\b = |x| a(x)
+        \\
+        \\main : U64
+        \\main = a(1)
+    , .direct_call_wrappers);
+}
+
+test "capturing direct wrapper is not inlined" {
+    try expectRootTargetHasCalls(
+        \\module [main]
+        \\
+        \\callee : U64 -> U64
+        \\callee = |x| x + 1
+        \\
+        \\main : U64
+        \\main = {
+        \\    offset = 1
+        \\    wrapper = |x| callee(x + offset)
+        \\    wrapper(41)
+        \\}
+    , .direct_call_wrappers);
+}

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -1,3 +1,5 @@
+//! Structural LIR tests for post-check wrapper inlining.
+
 const std = @import("std");
 const base = @import("base");
 const check = @import("check");
@@ -22,7 +24,7 @@ fn lowerModule(
     allocator: Allocator,
     source: []const u8,
     inline_mode: lir.CheckedPipeline.InlineMode,
-) !LoweredSource {
+) anyerror!LoweredSource {
     var resources = try helpers.parseAndCanonicalizeProgram(allocator, .module, source, &.{});
     errdefer helpers.cleanupParseAndCanonical(allocator, resources);
 
@@ -60,7 +62,7 @@ fn lowerModule(
     };
 }
 
-fn rootProc(lowered: *const lir.CheckedPipeline.LoweredProgram) !LIR.LirProcSpecId {
+fn rootProc(lowered: *const lir.CheckedPipeline.LoweredProgram) anyerror!LIR.LirProcSpecId {
     try std.testing.expectEqual(@as(usize, 1), lowered.lir_result.root_procs.items.len);
     return lowered.lir_result.root_procs.items[0];
 }
@@ -69,7 +71,7 @@ fn collectAssignCallProcs(
     allocator: Allocator,
     lowered: *const lir.CheckedPipeline.LoweredProgram,
     proc_id: LIR.LirProcSpecId,
-) ![]LIR.LirProcSpecId {
+) anyerror![]LIR.LirProcSpecId {
     const proc = lowered.lir_result.store.getProcSpec(proc_id);
     const body = proc.body orelse return allocator.alloc(LIR.LirProcSpecId, 0);
 
@@ -133,7 +135,7 @@ fn collectAssignCallProcs(
 fn rootDirectCallTarget(
     allocator: Allocator,
     lowered: *const lir.CheckedPipeline.LoweredProgram,
-) !LIR.LirProcSpecId {
+) anyerror!LIR.LirProcSpecId {
     const root = try rootProc(lowered);
     const root_calls = try collectAssignCallProcs(allocator, lowered, root);
     defer allocator.free(root_calls);
@@ -146,7 +148,7 @@ fn expectRootTargetCallCount(
     source: []const u8,
     inline_mode: lir.CheckedPipeline.InlineMode,
     expected: usize,
-) !void {
+) anyerror!void {
     const allocator = std.testing.allocator;
     var lowered_source = try lowerModule(allocator, source, inline_mode);
     defer lowered_source.deinit(allocator);
@@ -161,7 +163,7 @@ fn expectRootTargetCallCount(
 fn expectRootTargetHasCalls(
     source: []const u8,
     inline_mode: lir.CheckedPipeline.InlineMode,
-) !void {
+) anyerror!void {
     const allocator = std.testing.allocator;
     var lowered_source = try lowerModule(allocator, source, inline_mode);
     defer lowered_source.deinit(allocator);

--- a/src/lir/checked_pipeline.zig
+++ b/src/lir/checked_pipeline.zig
@@ -51,7 +51,7 @@ pub const RuntimeRecordFieldSchema = postcheck.SolvedLirLower.RuntimeRecordField
 pub const RuntimeRecordSchema = postcheck.SolvedLirLower.RuntimeRecordSchema;
 pub const RuntimeTagSchema = postcheck.SolvedLirLower.RuntimeTagSchema;
 pub const RuntimeTagUnionSchema = postcheck.SolvedLirLower.RuntimeTagUnionSchema;
-pub const InlineMode = postcheck.SolvedLirLower.InlineMode;
+pub const InlineMode = postcheck.SolvedInline.Mode;
 
 /// Runtime record and tag-union schemas needed by dev tooling.
 pub const RuntimeValueSchemaStore = struct {
@@ -203,8 +203,11 @@ pub fn lowerCheckedModulesToLir(
     var solved_owned = true;
     errdefer if (solved_owned) solved.deinit();
 
+    var inline_plan = try postcheck.SolvedInline.analyze(allocator, target.inline_mode, &solved);
+    defer inline_plan.deinit();
+
     var lowered = try postcheck.SolvedLirLower.run(allocator, target.target_usize, solved, .{
-        .inline_mode = target.inline_mode,
+        .inline_plan = inline_plan.view(),
     });
     solved_owned = false;
     solved = undefined;

--- a/src/lir/checked_pipeline.zig
+++ b/src/lir/checked_pipeline.zig
@@ -38,6 +38,7 @@ pub const RootRequestSet = struct {
 pub const TargetConfig = struct {
     target_usize: base.target.TargetUsize = base.target.TargetUsize.native,
     checked_module_state: CheckedModuleState = .complete,
+    inline_mode: InlineMode = .none,
 };
 
 /// Whether the root checked module is complete or inside checking finalization.
@@ -50,6 +51,7 @@ pub const RuntimeRecordFieldSchema = postcheck.SolvedLirLower.RuntimeRecordField
 pub const RuntimeRecordSchema = postcheck.SolvedLirLower.RuntimeRecordSchema;
 pub const RuntimeTagSchema = postcheck.SolvedLirLower.RuntimeTagSchema;
 pub const RuntimeTagUnionSchema = postcheck.SolvedLirLower.RuntimeTagUnionSchema;
+pub const InlineMode = postcheck.SolvedLirLower.InlineMode;
 
 /// Runtime record and tag-union schemas needed by dev tooling.
 pub const RuntimeValueSchemaStore = struct {
@@ -201,7 +203,9 @@ pub fn lowerCheckedModulesToLir(
     var solved_owned = true;
     errdefer if (solved_owned) solved.deinit();
 
-    var lowered = try postcheck.SolvedLirLower.run(allocator, target.target_usize, solved);
+    var lowered = try postcheck.SolvedLirLower.run(allocator, target.target_usize, solved, .{
+        .inline_mode = target.inline_mode,
+    });
     solved_owned = false;
     solved = undefined;
     errdefer lowered.deinit();

--- a/src/postcheck/mod.zig
+++ b/src/postcheck/mod.zig
@@ -30,6 +30,7 @@ pub const LambdaMono = struct {
     pub const Specialize = @import("lambda_mono/specialize.zig");
 };
 pub const LirLower = @import("lir_lower.zig");
+pub const SolvedInline = @import("solved_inline.zig");
 pub const SolvedLirLower = @import("solved_lir_lower.zig");
 pub const StructuralTest = @import("structural_test.zig");
 

--- a/src/postcheck/solved_inline.zig
+++ b/src/postcheck/solved_inline.zig
@@ -7,11 +7,13 @@ const Lifted = @import("monotype_lifted/ast.zig");
 const Solved = @import("lambda_solved/ast.zig");
 const SolvedType = @import("lambda_solved/type.zig");
 
+/// Post-check inline analysis mode.
 pub const Mode = enum {
     none,
     direct_call_wrappers,
 };
 
+/// Immutable inline eligibility table consumed by later lowering stages.
 pub const Plan = struct {
     inline_bodies: []const ?Lifted.ExprId = &.{},
 
@@ -26,6 +28,7 @@ pub const Plan = struct {
     }
 };
 
+/// Allocator-owned storage for a post-check inline plan.
 pub const OwnedPlan = struct {
     allocator: std.mem.Allocator,
     inline_bodies: []?Lifted.ExprId,
@@ -44,6 +47,7 @@ pub const OwnedPlan = struct {
     }
 };
 
+/// Analyze a Lambda Solved program and produce explicit inline decisions.
 pub fn analyze(
     allocator: std.mem.Allocator,
     mode: Mode,

--- a/src/postcheck/solved_inline.zig
+++ b/src/postcheck/solved_inline.zig
@@ -1,0 +1,221 @@
+//! Explicit inline eligibility analysis over Lambda Solved IR.
+
+const std = @import("std");
+
+const Common = @import("common.zig");
+const Lifted = @import("monotype_lifted/ast.zig");
+const Solved = @import("lambda_solved/ast.zig");
+const SolvedType = @import("lambda_solved/type.zig");
+
+pub const Mode = enum {
+    none,
+    direct_call_wrappers,
+};
+
+pub const Plan = struct {
+    inline_bodies: []const ?Lifted.ExprId = &.{},
+
+    pub fn bodyForFn(self: Plan, fn_id: Lifted.FnId) ?Lifted.ExprId {
+        if (self.inline_bodies.len == 0) return null;
+
+        const index = @intFromEnum(fn_id);
+        if (index >= self.inline_bodies.len) {
+            Common.invariant("inline plan did not contain a lifted function");
+        }
+        return self.inline_bodies[index];
+    }
+};
+
+pub const OwnedPlan = struct {
+    allocator: std.mem.Allocator,
+    inline_bodies: []?Lifted.ExprId,
+
+    pub fn empty(allocator: std.mem.Allocator) OwnedPlan {
+        return .{ .allocator = allocator, .inline_bodies = &.{} };
+    }
+
+    pub fn deinit(self: *OwnedPlan) void {
+        if (self.inline_bodies.len != 0) self.allocator.free(self.inline_bodies);
+        self.* = empty(self.allocator);
+    }
+
+    pub fn view(self: *const OwnedPlan) Plan {
+        return .{ .inline_bodies = self.inline_bodies };
+    }
+};
+
+pub fn analyze(
+    allocator: std.mem.Allocator,
+    mode: Mode,
+    solved: *const Solved.Program,
+) std.mem.Allocator.Error!OwnedPlan {
+    return switch (mode) {
+        .none => OwnedPlan.empty(allocator),
+        .direct_call_wrappers => try DirectCallWrapperAnalyzer.run(allocator, solved),
+    };
+}
+
+const Decision = union(enum) {
+    unknown,
+    visiting,
+    never,
+    inline_direct_call: Lifted.ExprId,
+};
+
+const Candidate = struct {
+    body: Lifted.ExprId,
+    callee: Lifted.FnId,
+};
+
+const DirectCallWrapperAnalyzer = struct {
+    allocator: std.mem.Allocator,
+    solved: *const Solved.Program,
+    decisions: []Decision,
+    stack: std.ArrayList(Lifted.FnId),
+
+    fn run(
+        allocator: std.mem.Allocator,
+        solved: *const Solved.Program,
+    ) std.mem.Allocator.Error!OwnedPlan {
+        const decisions = try allocator.alloc(Decision, solved.lifted.fns.items.len);
+        errdefer allocator.free(decisions);
+        @memset(decisions, .unknown);
+
+        var analyzer = DirectCallWrapperAnalyzer{
+            .allocator = allocator,
+            .solved = solved,
+            .decisions = decisions,
+            .stack = .empty,
+        };
+        defer analyzer.stack.deinit(allocator);
+
+        for (solved.lifted.fns.items, 0..) |_, index| {
+            const fn_id: Lifted.FnId = @enumFromInt(@as(u32, @intCast(index)));
+            _ = try analyzer.inlineBody(fn_id);
+        }
+
+        const inline_bodies = try allocator.alloc(?Lifted.ExprId, decisions.len);
+        errdefer allocator.free(inline_bodies);
+        for (decisions, 0..) |decision, index| {
+            inline_bodies[index] = switch (decision) {
+                .inline_direct_call => |body| body,
+                .unknown,
+                .visiting,
+                .never,
+                => null,
+            };
+        }
+
+        allocator.free(decisions);
+        analyzer.decisions = &.{};
+
+        return .{
+            .allocator = allocator,
+            .inline_bodies = inline_bodies,
+        };
+    }
+
+    fn inlineBody(self: *DirectCallWrapperAnalyzer, fn_id: Lifted.FnId) std.mem.Allocator.Error!?Lifted.ExprId {
+        const index = @intFromEnum(fn_id);
+        switch (self.decisions[index]) {
+            .unknown => {},
+            .visiting => {
+                self.markCycle(fn_id);
+                return null;
+            },
+            .never => return null,
+            .inline_direct_call => |body| return body,
+        }
+
+        self.decisions[index] = .visiting;
+        try self.stack.append(self.allocator, fn_id);
+        defer {
+            const popped = self.stack.pop() orelse Common.invariant("inline analysis stack underflow");
+            if (popped != fn_id) Common.invariant("inline analysis stack was corrupted");
+        }
+
+        const wrapper = self.wrapperCandidate(fn_id) orelse {
+            self.decisions[index] = .never;
+            return null;
+        };
+
+        _ = try self.inlineBody(wrapper.callee);
+
+        switch (self.decisions[index]) {
+            .never => return null,
+            .visiting => {},
+            .unknown,
+            .inline_direct_call,
+            => Common.invariant("inline analysis decision changed unexpectedly while visiting a candidate"),
+        }
+
+        self.decisions[index] = .{ .inline_direct_call = wrapper.body };
+        return wrapper.body;
+    }
+
+    fn wrapperCandidate(self: *const DirectCallWrapperAnalyzer, fn_id: Lifted.FnId) ?Candidate {
+        const source_fn = self.solved.lifted.fns.items[@intFromEnum(fn_id)];
+        if (self.solved.lifted.typedLocalSpan(source_fn.captures).len != 0) return null;
+        if (self.solvedCaptureCount(fn_id) != 0) return null;
+
+        const body = switch (source_fn.body) {
+            .roc => |body_expr| body_expr,
+            .hosted => return null,
+        };
+
+        const callee = self.directCallCalleeFromBody(body) orelse return null;
+        return .{ .body = body, .callee = callee };
+    }
+
+    fn solvedCaptureCount(self: *const DirectCallWrapperAnalyzer, fn_id: Lifted.FnId) usize {
+        const captures = self.solvedCapturesForFn(fn_id);
+        return self.solved.types.captureSpan(captures).len;
+    }
+
+    fn solvedCapturesForFn(self: *const DirectCallWrapperAnalyzer, fn_id: Lifted.FnId) SolvedType.Span {
+        const fn_symbol = self.solved.lifted.fns.items[@intFromEnum(fn_id)].symbol;
+        const func = switch (self.solved.types.rootContent(self.solved.fn_tys.items[@intFromEnum(fn_id)])) {
+            .func => |func| func,
+            else => Common.invariant("direct Lambda Mono function table contains a non-function type"),
+        };
+        const callable = switch (self.solved.types.rootContent(func.callable)) {
+            .lambda_set => |members| members,
+            .erased => |erased| erased.members,
+            else => Common.invariant("callable value did not have a resolved callable slot"),
+        };
+        for (self.solved.types.memberSpan(callable)) |member| {
+            if (member.lambda == fn_symbol) return member.captures;
+        }
+        return .empty();
+    }
+
+    fn directCallCalleeFromBody(self: *const DirectCallWrapperAnalyzer, expr_id: Lifted.ExprId) ?Lifted.FnId {
+        const expr = self.solved.lifted.exprs.items[@intFromEnum(expr_id)];
+        return switch (expr.data) {
+            .call_proc => |call| Lifted.callProcCallee(call),
+            .block => |block| blk: {
+                if (self.solved.lifted.stmtSpan(block.statements).len != 0) return null;
+                const final_expr = self.solved.lifted.exprs.items[@intFromEnum(block.final_expr)];
+                break :blk switch (final_expr.data) {
+                    .call_proc => |call| Lifted.callProcCallee(call),
+                    else => null,
+                };
+            },
+            else => null,
+        };
+    }
+
+    fn markCycle(self: *DirectCallWrapperAnalyzer, repeated: Lifted.FnId) void {
+        var cycle_start: ?usize = null;
+        for (self.stack.items, 0..) |fn_id, index| {
+            if (fn_id == repeated) {
+                cycle_start = index;
+                break;
+            }
+        }
+        const start = cycle_start orelse Common.invariant("inline cycle did not refer to a visiting function");
+        for (self.stack.items[start..]) |fn_id| {
+            self.decisions[@intFromEnum(fn_id)] = .never;
+        }
+    }
+};

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -103,16 +103,28 @@ pub const Output = struct {
     }
 };
 
+/// Optional post-check inlining performed while lowering solved monomorphic
+/// functions to LIR.
+pub const InlineMode = enum {
+    none,
+    direct_call_wrappers,
+};
+
+pub const Options = struct {
+    inline_mode: InlineMode = .none,
+};
+
 /// Lower Lambda Solved directly into LIR.
 pub fn run(
     allocator: std.mem.Allocator,
     target_usize: base.target.TargetUsize,
     solved: Solved.Program,
+    options: Options,
 ) Common.LowerError!Output {
     var owned = solved;
     errdefer owned.deinit();
 
-    var lowerer = try Lowerer.init(allocator, target_usize, &owned);
+    var lowerer = try Lowerer.init(allocator, target_usize, &owned, options);
     errdefer lowerer.deinit();
 
     try lowerer.lower();
@@ -197,6 +209,18 @@ const FnEntry = struct {
     proc: ?LIR.LirProcSpecId,
 };
 
+const InlineDecision = union(enum) {
+    unknown,
+    visiting,
+    never,
+    inline_direct_call: Lifted.ExprId,
+};
+
+const InlineCandidate = struct {
+    body: Lifted.ExprId,
+    call: Mono.CallProc,
+};
+
 const RootEntry = struct {
     fn_id: Type.FnId,
     request: check.CheckedModule.RootRequest,
@@ -235,6 +259,9 @@ const Lowerer = struct {
     fn_entries: std.ArrayList(FnEntry),
     fn_spec_map: std.HashMap(FnSpec, Type.FnId, FnSpecContext, std.hash_map.default_max_load_percentage),
     fn_written: std.ArrayList(bool),
+    inline_mode: InlineMode,
+    inline_decisions: std.ArrayList(InlineDecision),
+    inline_stack: std.ArrayList(Type.FnId),
     source_symbols: std.AutoHashMap(Common.Symbol, Lifted.FnId),
     capture_types: CaptureTypeMap,
     captures: std.AutoHashMap(Lifted.LocalId, CaptureBinding),
@@ -265,6 +292,7 @@ const Lowerer = struct {
         allocator: std.mem.Allocator,
         target_usize: base.target.TargetUsize,
         solved: *const Solved.Program,
+        options: Options,
     ) Common.LowerError!Lowerer {
         const local_map = try allocator.alloc(?LIR.LocalId, solved.lifted.locals.items.len);
         errdefer allocator.free(local_map);
@@ -281,6 +309,9 @@ const Lowerer = struct {
             .fn_entries = .empty,
             .fn_spec_map = std.HashMap(FnSpec, Type.FnId, FnSpecContext, std.hash_map.default_max_load_percentage).initContext(allocator, .{}),
             .fn_written = .empty,
+            .inline_mode = options.inline_mode,
+            .inline_decisions = .empty,
+            .inline_stack = .empty,
             .source_symbols = std.AutoHashMap(Common.Symbol, Lifted.FnId).init(allocator),
             .capture_types = CaptureTypeMap.initContext(allocator, .{}),
             .captures = std.AutoHashMap(Lifted.LocalId, CaptureBinding).init(allocator),
@@ -306,6 +337,8 @@ const Lowerer = struct {
         self.captures.deinit();
         self.capture_types.deinit();
         self.source_symbols.deinit();
+        self.inline_stack.deinit(self.allocator);
+        self.inline_decisions.deinit(self.allocator);
         self.fn_written.deinit(self.allocator);
         self.fn_spec_map.deinit();
         self.fn_entries.deinit(self.allocator);
@@ -331,6 +364,8 @@ const Lowerer = struct {
         self.captures.deinit();
         self.capture_types.deinit();
         self.source_symbols.deinit();
+        self.inline_stack.deinit(self.allocator);
+        self.inline_decisions.deinit(self.allocator);
         self.fn_written.deinit(self.allocator);
         self.fn_spec_map.deinit();
         self.fn_entries.deinit(self.allocator);
@@ -341,6 +376,8 @@ const Lowerer = struct {
         self.runtime_schemas = RuntimeSchemaStore.init(self.allocator);
         self.local_map = &.{};
         self.loop_stack = .empty;
+        self.inline_decisions = .empty;
+        self.inline_stack = .empty;
         return output;
     }
 
@@ -534,6 +571,9 @@ const Lowerer = struct {
         try self.fn_specs.append(self.allocator, spec);
         try self.fn_written.append(self.allocator, false);
         try self.fn_entries.append(self.allocator, undefined);
+        if (self.inline_mode != .none) {
+            try self.inline_decisions.append(self.allocator, .unknown);
+        }
 
         const source_fn = self.solved.lifted.fns.items[@intFromEnum(source)];
         const symbol = self.symbols.fresh();
@@ -1919,6 +1959,15 @@ const Lowerer = struct {
     ) Common.LowerError!LIR.CFStmtId {
         const lowered = try self.lowerExprsToTemps(args);
         defer self.allocator.free(lowered.ids);
+
+        if (capture_arg == null) {
+            if (try self.inlineBodyForKnownCall(callee)) |body_expr| {
+                var current = try self.lowerInlineKnownCallInto(target, callee, lowered.ids, body_expr, next);
+                current = try self.prependExprs(lowered, current);
+                return current;
+            }
+        }
+
         const call_args = if (capture_arg) |capture_local| blk: {
             const values = try self.allocator.alloc(LIR.LocalId, lowered.ids.len + 1);
             errdefer self.allocator.free(values);
@@ -1935,6 +1984,138 @@ const Lowerer = struct {
         } });
         current = try self.prependExprs(lowered, current);
         return current;
+    }
+
+    fn inlineBodyForKnownCall(self: *Lowerer, callee: Type.FnId) Common.LowerError!?Lifted.ExprId {
+        return switch (self.inline_mode) {
+            .none => null,
+            .direct_call_wrappers => try self.directCallWrapperInlineBody(callee),
+        };
+    }
+
+    fn directCallWrapperInlineBody(self: *Lowerer, fn_id: Type.FnId) Common.LowerError!?Lifted.ExprId {
+        const index = @intFromEnum(fn_id);
+        if (index >= self.inline_decisions.items.len) {
+            Common.invariant("inline decision table was not initialized for a function spec");
+        }
+
+        switch (self.inline_decisions.items[index]) {
+            .unknown => {},
+            .visiting => {
+                self.markInlineCycle(fn_id);
+                return null;
+            },
+            .never => return null,
+            .inline_direct_call => |body| return body,
+        }
+
+        self.inline_decisions.items[index] = .visiting;
+        try self.inline_stack.append(self.allocator, fn_id);
+        defer {
+            const popped = self.inline_stack.pop() orelse Common.invariant("inline decision stack underflow");
+            if (popped != fn_id) Common.invariant("inline decision stack was corrupted");
+        }
+
+        const candidate = self.directCallWrapperCandidate(fn_id) orelse {
+            self.inline_decisions.items[index] = .never;
+            return null;
+        };
+
+        const callee_source = Lifted.callProcCallee(candidate.call);
+        const callee_fn = try self.ensureOwnFnSpec(callee_source, .finite);
+        _ = try self.directCallWrapperInlineBody(callee_fn);
+
+        switch (self.inline_decisions.items[index]) {
+            .never => return null,
+            .visiting => {},
+            .unknown, .inline_direct_call => Common.invariant("inline decision changed unexpectedly while visiting a candidate"),
+        }
+
+        self.inline_decisions.items[index] = .{ .inline_direct_call = candidate.body };
+        return candidate.body;
+    }
+
+    fn directCallWrapperCandidate(self: *Lowerer, fn_id: Type.FnId) ?InlineCandidate {
+        const spec = self.fn_specs.items[@intFromEnum(fn_id)];
+        if (spec.abi != .finite) return null;
+        if (spec.capture_ty != null) return null;
+
+        const source_fn = self.solved.lifted.fns.items[@intFromEnum(spec.source)];
+        const body_expr = switch (source_fn.body) {
+            .roc => |body| body,
+            .hosted => return null,
+        };
+        const call = self.directCallFromInlineBody(body_expr) orelse return null;
+        return .{ .body = body_expr, .call = call };
+    }
+
+    fn directCallFromInlineBody(self: *Lowerer, expr_id: Lifted.ExprId) ?Mono.CallProc {
+        const expr = self.solved.lifted.exprs.items[@intFromEnum(expr_id)];
+        return switch (expr.data) {
+            .call_proc => |call| call,
+            .block => |block| blk: {
+                if (self.solved.lifted.stmtSpan(block.statements).len != 0) return null;
+                const final_expr = self.solved.lifted.exprs.items[@intFromEnum(block.final_expr)];
+                break :blk switch (final_expr.data) {
+                    .call_proc => |call| call,
+                    else => null,
+                };
+            },
+            else => null,
+        };
+    }
+
+    fn markInlineCycle(self: *Lowerer, repeated: Type.FnId) void {
+        var cycle_start: ?usize = null;
+        for (self.inline_stack.items, 0..) |fn_id, index| {
+            if (fn_id == repeated) {
+                cycle_start = index;
+                break;
+            }
+        }
+        const start = cycle_start orelse Common.invariant("inline cycle did not refer to a visiting function");
+        for (self.inline_stack.items[start..]) |fn_id| {
+            self.inline_decisions.items[@intFromEnum(fn_id)] = .never;
+        }
+    }
+
+    fn lowerInlineKnownCallInto(
+        self: *Lowerer,
+        target: LIR.LocalId,
+        callee: Type.FnId,
+        arg_locals: []const LIR.LocalId,
+        body_expr: Lifted.ExprId,
+        next: LIR.CFStmtId,
+    ) Common.LowerError!LIR.CFStmtId {
+        const spec = self.fn_specs.items[@intFromEnum(callee)];
+        if (spec.abi != .finite) Common.invariant("attempted to inline a non-finite function spec");
+        if (spec.capture_ty != null) Common.invariant("attempted to inline a capturing function spec");
+
+        const source_fn = self.solved.lifted.fns.items[@intFromEnum(spec.source)];
+        const func = switch (self.solved.types.rootContent(spec.solved_fn_ty)) {
+            .func => |func| func,
+            else => Common.invariant("direct Lambda Mono function table contains a non-function type"),
+        };
+        const solved_args = self.solved.types.span(func.args);
+        const lifted_args = self.solved.lifted.typedLocalSpan(source_fn.args);
+        if (solved_args.len != lifted_args.len) Common.invariant("direct Lambda Mono function arity changed after Lambda Solved");
+        if (arg_locals.len != lifted_args.len) Common.invariant("inline call argument count differed from function arity");
+
+        const saved = try self.allocator.alloc(?LIR.LocalId, lifted_args.len);
+        defer self.allocator.free(saved);
+        for (lifted_args, 0..) |arg, i| {
+            saved[i] = self.local_map[@intFromEnum(arg.local)];
+        }
+        for (lifted_args, 0..) |arg, i| {
+            self.local_map[@intFromEnum(arg.local)] = arg_locals[i];
+        }
+        defer {
+            for (lifted_args, 0..) |arg, i| {
+                self.local_map[@intFromEnum(arg.local)] = saved[i];
+            }
+        }
+
+        return try self.lowerExprInto(target, body_expr, next);
     }
 
     fn lowerValueCallInto(

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -14,6 +14,7 @@ const layout = @import("layout");
 const Common = @import("common.zig");
 const Mono = @import("monotype/ast.zig");
 const Lifted = @import("monotype_lifted/ast.zig");
+const SolvedInline = @import("solved_inline.zig");
 const Solved = @import("lambda_solved/ast.zig");
 const SolvedType = @import("lambda_solved/type.zig");
 const LambdaMono = @import("lambda_mono/ast.zig");
@@ -103,15 +104,8 @@ pub const Output = struct {
     }
 };
 
-/// Optional post-check inlining performed while lowering solved monomorphic
-/// functions to LIR.
-pub const InlineMode = enum {
-    none,
-    direct_call_wrappers,
-};
-
 pub const Options = struct {
-    inline_mode: InlineMode = .none,
+    inline_plan: SolvedInline.Plan = .{},
 };
 
 /// Lower Lambda Solved directly into LIR.
@@ -209,18 +203,6 @@ const FnEntry = struct {
     proc: ?LIR.LirProcSpecId,
 };
 
-const InlineDecision = union(enum) {
-    unknown,
-    visiting,
-    never,
-    inline_direct_call: Lifted.ExprId,
-};
-
-const InlineCandidate = struct {
-    body: Lifted.ExprId,
-    call: Mono.CallProc,
-};
-
 const RootEntry = struct {
     fn_id: Type.FnId,
     request: check.CheckedModule.RootRequest,
@@ -259,9 +241,7 @@ const Lowerer = struct {
     fn_entries: std.ArrayList(FnEntry),
     fn_spec_map: std.HashMap(FnSpec, Type.FnId, FnSpecContext, std.hash_map.default_max_load_percentage),
     fn_written: std.ArrayList(bool),
-    inline_mode: InlineMode,
-    inline_decisions: std.ArrayList(InlineDecision),
-    inline_stack: std.ArrayList(Type.FnId),
+    inline_plan: SolvedInline.Plan,
     source_symbols: std.AutoHashMap(Common.Symbol, Lifted.FnId),
     capture_types: CaptureTypeMap,
     captures: std.AutoHashMap(Lifted.LocalId, CaptureBinding),
@@ -309,9 +289,7 @@ const Lowerer = struct {
             .fn_entries = .empty,
             .fn_spec_map = std.HashMap(FnSpec, Type.FnId, FnSpecContext, std.hash_map.default_max_load_percentage).initContext(allocator, .{}),
             .fn_written = .empty,
-            .inline_mode = options.inline_mode,
-            .inline_decisions = .empty,
-            .inline_stack = .empty,
+            .inline_plan = options.inline_plan,
             .source_symbols = std.AutoHashMap(Common.Symbol, Lifted.FnId).init(allocator),
             .capture_types = CaptureTypeMap.initContext(allocator, .{}),
             .captures = std.AutoHashMap(Lifted.LocalId, CaptureBinding).init(allocator),
@@ -337,8 +315,6 @@ const Lowerer = struct {
         self.captures.deinit();
         self.capture_types.deinit();
         self.source_symbols.deinit();
-        self.inline_stack.deinit(self.allocator);
-        self.inline_decisions.deinit(self.allocator);
         self.fn_written.deinit(self.allocator);
         self.fn_spec_map.deinit();
         self.fn_entries.deinit(self.allocator);
@@ -364,8 +340,6 @@ const Lowerer = struct {
         self.captures.deinit();
         self.capture_types.deinit();
         self.source_symbols.deinit();
-        self.inline_stack.deinit(self.allocator);
-        self.inline_decisions.deinit(self.allocator);
         self.fn_written.deinit(self.allocator);
         self.fn_spec_map.deinit();
         self.fn_entries.deinit(self.allocator);
@@ -376,8 +350,6 @@ const Lowerer = struct {
         self.runtime_schemas = RuntimeSchemaStore.init(self.allocator);
         self.local_map = &.{};
         self.loop_stack = .empty;
-        self.inline_decisions = .empty;
-        self.inline_stack = .empty;
         return output;
     }
 
@@ -571,10 +543,6 @@ const Lowerer = struct {
         try self.fn_specs.append(self.allocator, spec);
         try self.fn_written.append(self.allocator, false);
         try self.fn_entries.append(self.allocator, undefined);
-        if (self.inline_mode != .none) {
-            try self.inline_decisions.append(self.allocator, .unknown);
-        }
-
         const source_fn = self.solved.lifted.fns.items[@intFromEnum(source)];
         const symbol = self.symbols.fresh();
         const func = switch (self.solved.types.rootContent(spec.solved_fn_ty)) {
@@ -1987,96 +1955,13 @@ const Lowerer = struct {
     }
 
     fn inlineBodyForKnownCall(self: *Lowerer, callee: Type.FnId) Common.LowerError!?Lifted.ExprId {
-        return switch (self.inline_mode) {
-            .none => null,
-            .direct_call_wrappers => try self.directCallWrapperInlineBody(callee),
-        };
-    }
+        const spec = self.fn_specs.items[@intFromEnum(callee)];
+        const body_expr = self.inline_plan.bodyForFn(spec.source) orelse return null;
 
-    fn directCallWrapperInlineBody(self: *Lowerer, fn_id: Type.FnId) Common.LowerError!?Lifted.ExprId {
-        const index = @intFromEnum(fn_id);
-        if (index >= self.inline_decisions.items.len) {
-            Common.invariant("inline decision table was not initialized for a function spec");
-        }
+        if (spec.abi != .finite) Common.invariant("inline plan selected a non-finite function spec");
+        if (spec.capture_ty != null) Common.invariant("inline plan selected a capturing function spec");
 
-        switch (self.inline_decisions.items[index]) {
-            .unknown => {},
-            .visiting => {
-                self.markInlineCycle(fn_id);
-                return null;
-            },
-            .never => return null,
-            .inline_direct_call => |body| return body,
-        }
-
-        self.inline_decisions.items[index] = .visiting;
-        try self.inline_stack.append(self.allocator, fn_id);
-        defer {
-            const popped = self.inline_stack.pop() orelse Common.invariant("inline decision stack underflow");
-            if (popped != fn_id) Common.invariant("inline decision stack was corrupted");
-        }
-
-        const candidate = self.directCallWrapperCandidate(fn_id) orelse {
-            self.inline_decisions.items[index] = .never;
-            return null;
-        };
-
-        const callee_source = Lifted.callProcCallee(candidate.call);
-        const callee_fn = try self.ensureOwnFnSpec(callee_source, .finite);
-        _ = try self.directCallWrapperInlineBody(callee_fn);
-
-        switch (self.inline_decisions.items[index]) {
-            .never => return null,
-            .visiting => {},
-            .unknown, .inline_direct_call => Common.invariant("inline decision changed unexpectedly while visiting a candidate"),
-        }
-
-        self.inline_decisions.items[index] = .{ .inline_direct_call = candidate.body };
-        return candidate.body;
-    }
-
-    fn directCallWrapperCandidate(self: *Lowerer, fn_id: Type.FnId) ?InlineCandidate {
-        const spec = self.fn_specs.items[@intFromEnum(fn_id)];
-        if (spec.abi != .finite) return null;
-        if (spec.capture_ty != null) return null;
-
-        const source_fn = self.solved.lifted.fns.items[@intFromEnum(spec.source)];
-        const body_expr = switch (source_fn.body) {
-            .roc => |body| body,
-            .hosted => return null,
-        };
-        const call = self.directCallFromInlineBody(body_expr) orelse return null;
-        return .{ .body = body_expr, .call = call };
-    }
-
-    fn directCallFromInlineBody(self: *Lowerer, expr_id: Lifted.ExprId) ?Mono.CallProc {
-        const expr = self.solved.lifted.exprs.items[@intFromEnum(expr_id)];
-        return switch (expr.data) {
-            .call_proc => |call| call,
-            .block => |block| blk: {
-                if (self.solved.lifted.stmtSpan(block.statements).len != 0) return null;
-                const final_expr = self.solved.lifted.exprs.items[@intFromEnum(block.final_expr)];
-                break :blk switch (final_expr.data) {
-                    .call_proc => |call| call,
-                    else => null,
-                };
-            },
-            else => null,
-        };
-    }
-
-    fn markInlineCycle(self: *Lowerer, repeated: Type.FnId) void {
-        var cycle_start: ?usize = null;
-        for (self.inline_stack.items, 0..) |fn_id, index| {
-            if (fn_id == repeated) {
-                cycle_start = index;
-                break;
-            }
-        }
-        const start = cycle_start orelse Common.invariant("inline cycle did not refer to a visiting function");
-        for (self.inline_stack.items[start..]) |fn_id| {
-            self.inline_decisions.items[@intFromEnum(fn_id)] = .never;
-        }
+        return body_expr;
     }
 
     fn lowerInlineKnownCallInto(

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -104,6 +104,7 @@ pub const Output = struct {
     }
 };
 
+/// Options used by solved-to-LIR lowering.
 pub const Options = struct {
     inline_plan: SolvedInline.Plan = .{},
 };


### PR DESCRIPTION
This adds an opt-in post-check inline mode for zero-capture direct-call wrappers and enables it for the size and speed optimized native/LLVM paths. The pass runs inside solved-to-LIR lowering, inlines only direct call-proc bodies or zero-statement block wrappers, and marks self-recursive or mutually recursive wrapper cycles as non-inlineable so lowering terminates without broadening eligibility.

The PR also adds focused LIR structural tests covering direct wrappers, zero-statement blocks, statement blocks, call-value wrappers, captures, and recursive cycles.