### PR TITLE
Generalize bindings that alias a polymorphic function

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -5114,7 +5114,17 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
     // Direct call-argument lambdas are consumed immediately, so they must not
     // generalize independently. Doing so lets their generalized vars escape
     // into the enclosing value via unification.
-    const should_generalize = isFunctionDef(&self.cir.store, expr) and expr != .e_closure and !is_call_arg;
+    //
+    // We also generalize a binding whose RHS is a bare reference to an already-
+    // generalized scheme (e.g. `shorthand = FooBar.myfunc`). Such a reference is
+    // non-expansive: it performs no work and can hide no `dbg`/`expect`, so it
+    // raises none of the duplicate-work or duplicate-effect concerns that motivate
+    // restricting generalization to syntactic functions. In practice the only
+    // generalized schemes are functions (numeric literals use the separate
+    // defaulting path), so this never re-generalizes numbers or tag unions.
+    const is_value_alias = !is_call_arg and
+        (expr == .e_lookup_local or expr == .e_lookup_external);
+    const should_generalize = (isFunctionDef(&self.cir.store, expr) and expr != .e_closure and !is_call_arg) or is_value_alias;
 
     // Push/pop ranks based on if we should generalize
     if (should_generalize) try env.var_pool.pushRank();

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -170,6 +170,13 @@ defer_generalize: bool = false,
 /// This prevents rank pollution where inner lambda generalization pulls outer
 /// scope vars to rank 0 via Rank.min in merge.
 checking_call_arg: bool = false,
+/// True when checking the right-hand side of an immutable binding (a top-level
+/// def or a block-local `s_decl`). Used to generalize a binding whose RHS is a
+/// bare reference to an already-generalized scheme (e.g. `shorthand = Foo.bar`).
+/// Such a reference is non-expansive, so generalizing it is the value-restriction
+/// treatment of a variable binding. Deliberately NOT set for mutable `var`
+/// bindings, which must never generalize.
+checking_binding_rhs: bool = false,
 /// Deferred def-level unifications (def_var = ptrn_var = expr_var).
 /// These must happen AFTER generalization to avoid lowering expr_var's rank
 /// before generalization can process it, but BEFORE eql constraint resolution
@@ -3153,6 +3160,7 @@ fn checkDef(self: *Self, def_idx: CIR.Def.Idx, env: *Env) std.mem.Allocator.Erro
     };
 
     // Infer types for the body, checking against the instantiated annotation
+    self.checking_binding_rhs = true;
     const def_does_fx = try self.checkExpr(def.expr, env, expectation);
     if (def_does_fx) {
         _ = try self.problems.appendProblem(self.gpa, .{ .effectful_top_level = .{
@@ -5109,6 +5117,11 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
     const is_call_arg = self.checking_call_arg;
     self.checking_call_arg = false;
 
+    // Consume the binding-RHS flag: it applies only to this immediate checkExpr
+    // call and must not propagate into subexpressions.
+    const is_binding_rhs = self.checking_binding_rhs;
+    self.checking_binding_rhs = false;
+
     // Value restriction: only generalize at the inner lambda level, not the
     // outer e_closure wrapper (which delegates to e_lambda's own checkExpr).
     // Direct call-argument lambdas are consumed immediately, so they must not
@@ -5121,8 +5134,11 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
     // raises none of the duplicate-work or duplicate-effect concerns that motivate
     // restricting generalization to syntactic functions. In practice the only
     // generalized schemes are functions (numeric literals use the separate
-    // defaulting path), so this never re-generalizes numbers or tag unions.
-    const is_value_alias = !is_call_arg and
+    // defaulting path), so this never re-generalizes numbers or tag unions. We
+    // restrict this to binding-RHS position so that bare lookups appearing as
+    // arbitrary subexpressions don't pay generalization cost or get generalized
+    // out from under their surrounding context.
+    const is_value_alias = is_binding_rhs and
         (expr == .e_lookup_local or expr == .e_lookup_external);
     const should_generalize = (isFunctionDef(&self.cir.store, expr) and expr != .e_closure and !is_call_arg) or is_value_alias;
 
@@ -7272,6 +7288,7 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                     });
                 }
 
+                self.checking_binding_rhs = true;
                 does_fx = try self.checkExpr(decl_stmt.expr, env, expectation) or does_fx;
                 if (decl_stmt.anno == null and self.erroneous_value_exprs.contains(decl_stmt.expr)) {
                     try self.erroneous_value_patterns.put(self.gpa, decl_stmt.pattern, {});

--- a/test/snapshots/generalize_alias_assoc_fn_record.md
+++ b/test/snapshots/generalize_alias_assoc_fn_record.md
@@ -1,0 +1,163 @@
+# META
+~~~ini
+description=A record field holding a reference to a polymorphic associated function carrying a static-dispatch constraint
+type=snippet
+~~~
+# SOURCE
+~~~roc
+FooBar := {}.{
+    myfunc : List(a) -> U64
+    myfunc = |list| list.len()
+}
+
+bag = { run: FooBar.myfunc }
+
+main = (bag.run([1, 2, 3]), bag.run(["a", "b"]))
+~~~
+# EXPECTED
+MISSING METHOD - generalize_alias_assoc_fn_record.md:8:13:8:16
+MISSING METHOD - generalize_alias_assoc_fn_record.md:8:33:8:36
+# PROBLEMS
+**MISSING METHOD**
+This **run** method is being called on a value whose type doesn't have that method:
+**generalize_alias_assoc_fn_record.md:8:13:8:16:**
+```roc
+main = (bag.run([1, 2, 3]), bag.run(["a", "b"]))
+```
+            ^^^
+
+The value's type, which does not have a method named **run**, is:
+
+    { run: List(a) -> U64 }
+
+**MISSING METHOD**
+This **run** method is being called on a value whose type doesn't have that method:
+**generalize_alias_assoc_fn_record.md:8:33:8:36:**
+```roc
+main = (bag.run([1, 2, 3]), bag.run(["a", "b"]))
+```
+                                ^^^
+
+The value's type, which does not have a method named **run**, is:
+
+    { run: List(a) -> U64 }
+
+# TOKENS
+~~~zig
+UpperIdent,OpColonEqual,OpenCurly,CloseCurly,Dot,OpenCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,
+CloseCurly,
+LowerIdent,OpAssign,OpenCurly,LowerIdent,OpColon,UpperIdent,NoSpaceDotLowerIdent,CloseCurly,
+LowerIdent,OpAssign,OpenRound,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpenSquare,Int,Comma,Int,Comma,Int,CloseSquare,CloseRound,Comma,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpenSquare,StringStart,StringPart,StringEnd,Comma,StringStart,StringPart,StringEnd,CloseSquare,CloseRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "FooBar")
+				(args))
+			(ty-record)
+			(associated
+				(s-type-anno (name "myfunc")
+					(ty-fn
+						(ty-apply
+							(ty (name "List"))
+							(ty-var (raw "a")))
+						(ty (name "U64"))))
+				(s-decl
+					(p-ident (raw "myfunc"))
+					(e-lambda
+						(args
+							(p-ident (raw "list")))
+						(e-method-call (method ".len")
+							(receiver
+								(e-ident (raw "list")))
+							(args))))))
+		(s-decl
+			(p-ident (raw "bag"))
+			(e-record
+				(field (field "run")
+					(e-ident (raw "FooBar.myfunc")))))
+		(s-decl
+			(p-ident (raw "main"))
+			(e-tuple
+				(e-method-call (method ".run")
+					(receiver
+						(e-ident (raw "bag")))
+					(args
+						(e-list
+							(e-int (raw "1"))
+							(e-int (raw "2"))
+							(e-int (raw "3")))))
+				(e-method-call (method ".run")
+					(receiver
+						(e-ident (raw "bag")))
+					(args
+						(e-list
+							(e-string
+								(e-string-part (raw "a")))
+							(e-string
+								(e-string-part (raw "b"))))))))))
+~~~
+# FORMATTED
+~~~roc
+FooBar := {}.{
+	myfunc : List(a) -> U64
+	myfunc = |list| list.len()
+}
+
+bag = { run: FooBar.myfunc }
+
+main = (bag.run([1, 2, 3]), bag.run(["a", "b"]))
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "generalize_alias_assoc_fn_record.FooBar.myfunc"))
+		(e-lambda
+			(args
+				(p-assign (ident "list")))
+			(e-dispatch-call (method "len") (constraint-fn-var 56)
+				(receiver
+					(e-lookup-local
+						(p-assign (ident "list"))))
+				(args)))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-apply (name "List") (builtin)
+					(ty-rigid-var (name "a")))
+				(ty-lookup (name "U64") (builtin)))))
+	(d-let
+		(p-assign (ident "bag"))
+		(e-record
+			(fields
+				(field (name "run")
+					(e-lookup-local
+						(p-assign (ident "generalize_alias_assoc_fn_record.FooBar.myfunc")))))))
+	(d-let
+		(p-assign (ident "main"))
+		(e-runtime-error (tag "erroneous_value_expr")))
+	(s-nominal-decl
+		(ty-header (name "FooBar"))
+		(ty-record)))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "List(a) -> U64"))
+		(patt (type "{ run: List(a) -> U64 }"))
+		(patt (type "(Error, Error)")))
+	(type_decls
+		(nominal (type "FooBar")
+			(ty-header (name "FooBar"))))
+	(expressions
+		(expr (type "List(a) -> U64"))
+		(expr (type "{ run: List(a) -> U64 }"))
+		(expr (type "(Error, Error)"))))
+~~~

--- a/test/snapshots/generalize_alias_chain.md
+++ b/test/snapshots/generalize_alias_chain.md
@@ -1,0 +1,110 @@
+# META
+~~~ini
+description=A chain of bindings that each alias a polymorphic function should stay polymorphic
+type=snippet
+~~~
+# SOURCE
+~~~roc
+id = |x| x
+
+alias1 = id
+alias2 = alias1
+
+main = (alias2(1), alias2("a"))
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpAssign,OpenRound,LowerIdent,NoSpaceOpenRound,Int,CloseRound,Comma,LowerIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "id"))
+			(e-lambda
+				(args
+					(p-ident (raw "x")))
+				(e-ident (raw "x"))))
+		(s-decl
+			(p-ident (raw "alias1"))
+			(e-ident (raw "id")))
+		(s-decl
+			(p-ident (raw "alias2"))
+			(e-ident (raw "alias1")))
+		(s-decl
+			(p-ident (raw "main"))
+			(e-tuple
+				(e-apply
+					(e-ident (raw "alias2"))
+					(e-int (raw "1")))
+				(e-apply
+					(e-ident (raw "alias2"))
+					(e-string
+						(e-string-part (raw "a"))))))))
+~~~
+# FORMATTED
+~~~roc
+id = |x| x
+
+alias1 = id
+
+alias2 = alias1
+
+main = (alias2(1), alias2("a"))
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "id"))
+		(e-lambda
+			(args
+				(p-assign (ident "x")))
+			(e-lookup-local
+				(p-assign (ident "x")))))
+	(d-let
+		(p-assign (ident "alias1"))
+		(e-lookup-local
+			(p-assign (ident "id"))))
+	(d-let
+		(p-assign (ident "alias2"))
+		(e-lookup-local
+			(p-assign (ident "alias1"))))
+	(d-let
+		(p-assign (ident "main"))
+		(e-tuple
+			(elems
+				(e-call (constraint-fn-var 63)
+					(e-lookup-local
+						(p-assign (ident "alias2")))
+					(e-num (value "1")))
+				(e-call (constraint-fn-var 72)
+					(e-lookup-local
+						(p-assign (ident "alias2")))
+					(e-string
+						(e-literal (string "a"))))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> a"))
+		(patt (type "a -> a"))
+		(patt (type "a -> a"))
+		(patt (type "(Dec, Str)")))
+	(expressions
+		(expr (type "a -> a"))
+		(expr (type "a -> a"))
+		(expr (type "a -> a"))
+		(expr (type "(Dec, Str)"))))
+~~~

--- a/test/snapshots/generalize_alias_exposed.md
+++ b/test/snapshots/generalize_alias_exposed.md
@@ -1,0 +1,124 @@
+# META
+~~~ini
+description=A module that exposes a binding aliasing a polymorphic function
+type=file
+~~~
+# SOURCE
+~~~roc
+module [shorthand]
+
+FooBar := {}.{
+    myfunc : List(a) -> U64
+    myfunc = |list| list.len()
+}
+
+shorthand = FooBar.myfunc
+~~~
+# EXPECTED
+MODULE HEADER DEPRECATED - generalize_alias_exposed.md:1:1:1:19
+# PROBLEMS
+**MODULE HEADER DEPRECATED**
+The `module` header is deprecated.
+
+Type modules (headerless files with a top-level type matching the filename) are now the preferred way to define modules.
+
+Remove the `module` header and ensure your file defines a type that matches the filename.
+**generalize_alias_exposed.md:1:1:1:19:**
+```roc
+module [shorthand]
+```
+^^^^^^^^^^^^^^^^^^
+
+
+# TOKENS
+~~~zig
+KwModule,OpenSquare,LowerIdent,CloseSquare,
+UpperIdent,OpColonEqual,OpenCurly,CloseCurly,Dot,OpenCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,
+CloseCurly,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotLowerIdent,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(module
+		(exposes
+			(exposed-lower-ident
+				(text "shorthand"))))
+	(statements
+		(s-type-decl
+			(header (name "FooBar")
+				(args))
+			(ty-record)
+			(associated
+				(s-type-anno (name "myfunc")
+					(ty-fn
+						(ty-apply
+							(ty (name "List"))
+							(ty-var (raw "a")))
+						(ty (name "U64"))))
+				(s-decl
+					(p-ident (raw "myfunc"))
+					(e-lambda
+						(args
+							(p-ident (raw "list")))
+						(e-method-call (method ".len")
+							(receiver
+								(e-ident (raw "list")))
+							(args))))))
+		(s-decl
+			(p-ident (raw "shorthand"))
+			(e-ident (raw "FooBar.myfunc")))))
+~~~
+# FORMATTED
+~~~roc
+module [shorthand]
+
+FooBar := {}.{
+	myfunc : List(a) -> U64
+	myfunc = |list| list.len()
+}
+
+shorthand = FooBar.myfunc
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "generalize_alias_exposed.FooBar.myfunc"))
+		(e-lambda
+			(args
+				(p-assign (ident "list")))
+			(e-dispatch-call (method "len") (constraint-fn-var 39)
+				(receiver
+					(e-lookup-local
+						(p-assign (ident "list"))))
+				(args)))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-apply (name "List") (builtin)
+					(ty-rigid-var (name "a")))
+				(ty-lookup (name "U64") (builtin)))))
+	(d-let
+		(p-assign (ident "shorthand"))
+		(e-lookup-local
+			(p-assign (ident "generalize_alias_exposed.FooBar.myfunc"))))
+	(s-nominal-decl
+		(ty-header (name "FooBar"))
+		(ty-record)))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "List(a) -> U64"))
+		(patt (type "List(a) -> U64")))
+	(type_decls
+		(nominal (type "FooBar")
+			(ty-header (name "FooBar"))))
+	(expressions
+		(expr (type "List(a) -> U64"))
+		(expr (type "List(a) -> U64"))))
+~~~

--- a/test/snapshots/generalize_alias_if_branches.md
+++ b/test/snapshots/generalize_alias_if_branches.md
@@ -1,0 +1,123 @@
+# META
+~~~ini
+description=A binding whose RHS is an if-expression choosing between two polymorphic functions (expansive, not a bare reference)
+type=snippet
+~~~
+# SOURCE
+~~~roc
+id = |x| x
+
+picked = if Bool.True id else id
+
+main = (picked(1), picked("a"))
+~~~
+# EXPECTED
+TYPE MISMATCH - generalize_alias_if_branches.md:5:16:5:17
+# PROBLEMS
+**TYPE MISMATCH**
+This number is being used where a non-number type is needed:
+**generalize_alias_if_branches.md:5:16:5:17:**
+```roc
+main = (picked(1), picked("a"))
+```
+               ^
+
+The type was determined to be non-numeric here:
+**generalize_alias_if_branches.md:5:27:5:30:**
+```roc
+main = (picked(1), picked("a"))
+```
+                          ^^^
+
+Other code expects this to have the type:
+
+    Str
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,
+LowerIdent,OpAssign,KwIf,UpperIdent,NoSpaceDotUpperIdent,LowerIdent,KwElse,LowerIdent,
+LowerIdent,OpAssign,OpenRound,LowerIdent,NoSpaceOpenRound,Int,CloseRound,Comma,LowerIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "id"))
+			(e-lambda
+				(args
+					(p-ident (raw "x")))
+				(e-ident (raw "x"))))
+		(s-decl
+			(p-ident (raw "picked"))
+			(e-if-then-else
+				(e-tag (raw "Bool.True"))
+				(e-ident (raw "id"))
+				(e-ident (raw "id"))))
+		(s-decl
+			(p-ident (raw "main"))
+			(e-tuple
+				(e-apply
+					(e-ident (raw "picked"))
+					(e-int (raw "1")))
+				(e-apply
+					(e-ident (raw "picked"))
+					(e-string
+						(e-string-part (raw "a"))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "id"))
+		(e-lambda
+			(args
+				(p-assign (ident "x")))
+			(e-lookup-local
+				(p-assign (ident "x")))))
+	(d-let
+		(p-assign (ident "picked"))
+		(e-if
+			(if-branches
+				(if-branch
+					(e-nominal-external
+						(builtin)
+						(e-tag (name "True")))
+					(e-lookup-local
+						(p-assign (ident "id")))))
+			(if-else
+				(e-lookup-local
+					(p-assign (ident "id"))))))
+	(d-let
+		(p-assign (ident "main"))
+		(e-tuple
+			(elems
+				(e-call (constraint-fn-var 74)
+					(e-lookup-local
+						(p-assign (ident "picked")))
+					(e-num (value "1")))
+				(e-call (constraint-fn-var 81)
+					(e-lookup-local
+						(p-assign (ident "picked")))
+					(e-string
+						(e-literal (string "a"))))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> a"))
+		(patt (type "Str -> Str"))
+		(patt (type "(Str, Str)")))
+	(expressions
+		(expr (type "a -> a"))
+		(expr (type "Str -> Str"))
+		(expr (type "(Str, Str)"))))
+~~~

--- a/test/snapshots/generalize_alias_in_record.md
+++ b/test/snapshots/generalize_alias_in_record.md
@@ -1,0 +1,116 @@
+# META
+~~~ini
+description=A record field holding a reference to a polymorphic function, used at two types
+type=snippet
+~~~
+# SOURCE
+~~~roc
+id = |x| x
+
+r = { f: id }
+
+main = (r.f(1), r.f("a"))
+~~~
+# EXPECTED
+MISSING METHOD - generalize_alias_in_record.md:5:11:5:12
+MISSING METHOD - generalize_alias_in_record.md:5:19:5:20
+# PROBLEMS
+**MISSING METHOD**
+This **f** method is being called on a value whose type doesn't have that method:
+**generalize_alias_in_record.md:5:11:5:12:**
+```roc
+main = (r.f(1), r.f("a"))
+```
+          ^
+
+The value's type, which does not have a method named **f**, is:
+
+    { f: a -> a }
+
+**MISSING METHOD**
+This **f** method is being called on a value whose type doesn't have that method:
+**generalize_alias_in_record.md:5:19:5:20:**
+```roc
+main = (r.f(1), r.f("a"))
+```
+                  ^
+
+The value's type, which does not have a method named **f**, is:
+
+    { f: a -> a }
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,
+LowerIdent,OpAssign,OpenCurly,LowerIdent,OpColon,LowerIdent,CloseCurly,
+LowerIdent,OpAssign,OpenRound,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,Int,CloseRound,Comma,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "id"))
+			(e-lambda
+				(args
+					(p-ident (raw "x")))
+				(e-ident (raw "x"))))
+		(s-decl
+			(p-ident (raw "r"))
+			(e-record
+				(field (field "f")
+					(e-ident (raw "id")))))
+		(s-decl
+			(p-ident (raw "main"))
+			(e-tuple
+				(e-method-call (method ".f")
+					(receiver
+						(e-ident (raw "r")))
+					(args
+						(e-int (raw "1"))))
+				(e-method-call (method ".f")
+					(receiver
+						(e-ident (raw "r")))
+					(args
+						(e-string
+							(e-string-part (raw "a")))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "id"))
+		(e-lambda
+			(args
+				(p-assign (ident "x")))
+			(e-lookup-local
+				(p-assign (ident "x")))))
+	(d-let
+		(p-assign (ident "r"))
+		(e-record
+			(fields
+				(field (name "f")
+					(e-lookup-local
+						(p-assign (ident "id")))))))
+	(d-let
+		(p-assign (ident "main"))
+		(e-runtime-error (tag "erroneous_value_expr"))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> a"))
+		(patt (type "{ f: a -> a }"))
+		(patt (type "(Error, Error)")))
+	(expressions
+		(expr (type "a -> a"))
+		(expr (type "{ f: a -> a }"))
+		(expr (type "(Error, Error)"))))
+~~~

--- a/test/snapshots/generalize_alias_in_tuple.md
+++ b/test/snapshots/generalize_alias_in_tuple.md
@@ -1,0 +1,152 @@
+# META
+~~~ini
+description=A tuple holding references to a polymorphic function, destructured; one element is then used at two types
+type=snippet
+~~~
+# SOURCE
+~~~roc
+id = |x| x
+
+t = (id, id)
+
+main = {
+    (a, b) = t
+    (a(1), a("x"), b(2))
+}
+~~~
+# EXPECTED
+TYPE MISMATCH - generalize_alias_in_tuple.md:7:8:7:9
+# PROBLEMS
+**TYPE MISMATCH**
+This number is being used where a non-number type is needed:
+**generalize_alias_in_tuple.md:7:8:7:9:**
+```roc
+    (a(1), a("x"), b(2))
+```
+       ^
+
+The type was determined to be non-numeric here:
+**generalize_alias_in_tuple.md:7:14:7:17:**
+```roc
+    (a(1), a("x"), b(2))
+```
+             ^^^
+
+Other code expects this to have the type:
+
+    Str
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,
+LowerIdent,OpAssign,OpenRound,LowerIdent,Comma,LowerIdent,CloseRound,
+LowerIdent,OpAssign,OpenCurly,
+OpenRound,LowerIdent,Comma,LowerIdent,CloseRound,OpAssign,LowerIdent,
+OpenRound,LowerIdent,NoSpaceOpenRound,Int,CloseRound,Comma,LowerIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,Comma,LowerIdent,NoSpaceOpenRound,Int,CloseRound,CloseRound,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "id"))
+			(e-lambda
+				(args
+					(p-ident (raw "x")))
+				(e-ident (raw "x"))))
+		(s-decl
+			(p-ident (raw "t"))
+			(e-tuple
+				(e-ident (raw "id"))
+				(e-ident (raw "id"))))
+		(s-decl
+			(p-ident (raw "main"))
+			(e-block
+				(statements
+					(s-decl
+						(p-tuple
+							(p-ident (raw "a"))
+							(p-ident (raw "b")))
+						(e-ident (raw "t")))
+					(e-tuple
+						(e-apply
+							(e-ident (raw "a"))
+							(e-int (raw "1")))
+						(e-apply
+							(e-ident (raw "a"))
+							(e-string
+								(e-string-part (raw "x"))))
+						(e-apply
+							(e-ident (raw "b"))
+							(e-int (raw "2")))))))))
+~~~
+# FORMATTED
+~~~roc
+id = |x| x
+
+t = (id, id)
+
+main = {
+	(a, b) = t
+	(a(1), a("x"), b(2))
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "id"))
+		(e-lambda
+			(args
+				(p-assign (ident "x")))
+			(e-lookup-local
+				(p-assign (ident "x")))))
+	(d-let
+		(p-assign (ident "t"))
+		(e-tuple
+			(elems
+				(e-lookup-local
+					(p-assign (ident "id")))
+				(e-lookup-local
+					(p-assign (ident "id"))))))
+	(d-let
+		(p-assign (ident "main"))
+		(e-block
+			(s-let
+				(p-tuple
+					(patterns
+						(p-assign (ident "a"))
+						(p-assign (ident "b"))))
+				(e-lookup-local
+					(p-assign (ident "t"))))
+			(e-tuple
+				(elems
+					(e-call (constraint-fn-var 69)
+						(e-lookup-local
+							(p-assign (ident "a")))
+						(e-num (value "1")))
+					(e-call (constraint-fn-var 76)
+						(e-lookup-local
+							(p-assign (ident "a")))
+						(e-string
+							(e-literal (string "x"))))
+					(e-call (constraint-fn-var 108)
+						(e-lookup-local
+							(p-assign (ident "b")))
+						(e-num (value "2"))))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "c -> c"))
+		(patt (type "(Str -> Str, Dec -> Dec)"))
+		(patt (type "(Str, Str, Dec)")))
+	(expressions
+		(expr (type "c -> c"))
+		(expr (type "(Str -> Str, Dec -> Dec)"))
+		(expr (type "(Str, Str, Dec)"))))
+~~~

--- a/test/snapshots/generalize_alias_local_in_lambda.md
+++ b/test/snapshots/generalize_alias_local_in_lambda.md
@@ -1,0 +1,108 @@
+# META
+~~~ini
+description=A block-local alias of a polymorphic function inside a lambda body should stay polymorphic
+type=snippet
+~~~
+# SOURCE
+~~~roc
+id = |x| x
+
+main = |_y| {
+    alias = id
+    (alias(1), alias("a"))
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,
+LowerIdent,OpAssign,OpBar,NamedUnderscore,OpBar,OpenCurly,
+LowerIdent,OpAssign,LowerIdent,
+OpenRound,LowerIdent,NoSpaceOpenRound,Int,CloseRound,Comma,LowerIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,CloseRound,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "id"))
+			(e-lambda
+				(args
+					(p-ident (raw "x")))
+				(e-ident (raw "x"))))
+		(s-decl
+			(p-ident (raw "main"))
+			(e-lambda
+				(args
+					(p-ident (raw "_y")))
+				(e-block
+					(statements
+						(s-decl
+							(p-ident (raw "alias"))
+							(e-ident (raw "id")))
+						(e-tuple
+							(e-apply
+								(e-ident (raw "alias"))
+								(e-int (raw "1")))
+							(e-apply
+								(e-ident (raw "alias"))
+								(e-string
+									(e-string-part (raw "a")))))))))))
+~~~
+# FORMATTED
+~~~roc
+id = |x| x
+
+main = |_y| {
+	alias = id
+	(alias(1), alias("a"))
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "id"))
+		(e-lambda
+			(args
+				(p-assign (ident "x")))
+			(e-lookup-local
+				(p-assign (ident "x")))))
+	(d-let
+		(p-assign (ident "main"))
+		(e-lambda
+			(args
+				(p-assign (ident "_y")))
+			(e-block
+				(s-let
+					(p-assign (ident "alias"))
+					(e-lookup-local
+						(p-assign (ident "id"))))
+				(e-tuple
+					(elems
+						(e-call (constraint-fn-var 61)
+							(e-lookup-local
+								(p-assign (ident "alias")))
+							(e-num (value "1")))
+						(e-call (constraint-fn-var 70)
+							(e-lookup-local
+								(p-assign (ident "alias")))
+							(e-string
+								(e-literal (string "a"))))))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> a"))
+		(patt (type "_arg -> (a, Str) where [a.from_numeral : Numeral -> Try(a, [InvalidNumeral(Str)])]")))
+	(expressions
+		(expr (type "a -> a"))
+		(expr (type "_arg -> (a, Str) where [a.from_numeral : Numeral -> Try(a, [InvalidNumeral(Str)])]"))))
+~~~

--- a/test/snapshots/generalize_alias_self_reference.md
+++ b/test/snapshots/generalize_alias_self_reference.md
@@ -1,0 +1,69 @@
+# META
+~~~ini
+description=A self-referential value binding (x = x) should be a diagnostic, not a crash
+type=snippet
+~~~
+# SOURCE
+~~~roc
+x = x
+
+main = x
+~~~
+# EXPECTED
+INVALID ASSIGNMENT TO ITSELF - generalize_alias_self_reference.md:1:5:1:6
+# PROBLEMS
+**INVALID ASSIGNMENT TO ITSELF**
+The value `x` is assigned to itself, which would cause an infinite loop at runtime.
+
+Only functions can reference themselves (for recursion). For non-function values, the right-hand side must be fully computable without referring to the value being assigned.
+
+**generalize_alias_self_reference.md:1:5:1:6:**
+```roc
+x = x
+```
+    ^
+
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpAssign,LowerIdent,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "x"))
+			(e-ident (raw "x")))
+		(s-decl
+			(p-ident (raw "main"))
+			(e-ident (raw "x")))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "x"))
+		(e-runtime-error (tag "self_referential_definition")))
+	(d-let
+		(p-assign (ident "main"))
+		(e-lookup-local
+			(p-assign (ident "x")))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Error"))
+		(patt (type "Error")))
+	(expressions
+		(expr (type "Error"))
+		(expr (type "Error"))))
+~~~

--- a/test/snapshots/shorthand_polymorphic_method.md
+++ b/test/snapshots/shorthand_polymorphic_method.md
@@ -1,0 +1,201 @@
+# META
+~~~ini
+description=issue 9574 - a binding whose RHS is a bare reference to a polymorphic function is non-expansive, so it stays polymorphic (value restriction)
+type=file
+~~~
+# SOURCE
+~~~roc
+module [main]
+
+FooBar := {}.{
+    myfunc : List(a) -> U64
+    myfunc = |list| list.len()
+}
+
+shorthand = FooBar.myfunc
+
+main = {
+    int_list = shorthand([1, 2, 3])
+    string_list = shorthand(["a", "b", "c"])
+    (int_list, string_list)
+}
+~~~
+# EXPECTED
+MODULE HEADER DEPRECATED - shorthand_polymorphic_method.md:1:1:1:14
+# PROBLEMS
+**MODULE HEADER DEPRECATED**
+The `module` header is deprecated.
+
+Type modules (headerless files with a top-level type matching the filename) are now the preferred way to define modules.
+
+Remove the `module` header and ensure your file defines a type that matches the filename.
+**shorthand_polymorphic_method.md:1:1:1:14:**
+```roc
+module [main]
+```
+^^^^^^^^^^^^^
+
+
+# TOKENS
+~~~zig
+KwModule,OpenSquare,LowerIdent,CloseSquare,
+UpperIdent,OpColonEqual,OpenCurly,CloseCurly,Dot,OpenCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,
+CloseCurly,
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotLowerIdent,
+LowerIdent,OpAssign,OpenCurly,
+LowerIdent,OpAssign,LowerIdent,NoSpaceOpenRound,OpenSquare,Int,Comma,Int,Comma,Int,CloseSquare,CloseRound,
+LowerIdent,OpAssign,LowerIdent,NoSpaceOpenRound,OpenSquare,StringStart,StringPart,StringEnd,Comma,StringStart,StringPart,StringEnd,Comma,StringStart,StringPart,StringEnd,CloseSquare,CloseRound,
+OpenRound,LowerIdent,Comma,LowerIdent,CloseRound,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(module
+		(exposes
+			(exposed-lower-ident
+				(text "main"))))
+	(statements
+		(s-type-decl
+			(header (name "FooBar")
+				(args))
+			(ty-record)
+			(associated
+				(s-type-anno (name "myfunc")
+					(ty-fn
+						(ty-apply
+							(ty (name "List"))
+							(ty-var (raw "a")))
+						(ty (name "U64"))))
+				(s-decl
+					(p-ident (raw "myfunc"))
+					(e-lambda
+						(args
+							(p-ident (raw "list")))
+						(e-method-call (method ".len")
+							(receiver
+								(e-ident (raw "list")))
+							(args))))))
+		(s-decl
+			(p-ident (raw "shorthand"))
+			(e-ident (raw "FooBar.myfunc")))
+		(s-decl
+			(p-ident (raw "main"))
+			(e-block
+				(statements
+					(s-decl
+						(p-ident (raw "int_list"))
+						(e-apply
+							(e-ident (raw "shorthand"))
+							(e-list
+								(e-int (raw "1"))
+								(e-int (raw "2"))
+								(e-int (raw "3")))))
+					(s-decl
+						(p-ident (raw "string_list"))
+						(e-apply
+							(e-ident (raw "shorthand"))
+							(e-list
+								(e-string
+									(e-string-part (raw "a")))
+								(e-string
+									(e-string-part (raw "b")))
+								(e-string
+									(e-string-part (raw "c"))))))
+					(e-tuple
+						(e-ident (raw "int_list"))
+						(e-ident (raw "string_list"))))))))
+~~~
+# FORMATTED
+~~~roc
+module [main]
+
+FooBar := {}.{
+	myfunc : List(a) -> U64
+	myfunc = |list| list.len()
+}
+
+shorthand = FooBar.myfunc
+
+main = {
+	int_list = shorthand([1, 2, 3])
+	string_list = shorthand(["a", "b", "c"])
+	(int_list, string_list)
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "shorthand_polymorphic_method.FooBar.myfunc"))
+		(e-lambda
+			(args
+				(p-assign (ident "list")))
+			(e-dispatch-call (method "len") (constraint-fn-var 64)
+				(receiver
+					(e-lookup-local
+						(p-assign (ident "list"))))
+				(args)))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-apply (name "List") (builtin)
+					(ty-rigid-var (name "a")))
+				(ty-lookup (name "U64") (builtin)))))
+	(d-let
+		(p-assign (ident "shorthand"))
+		(e-lookup-local
+			(p-assign (ident "shorthand_polymorphic_method.FooBar.myfunc"))))
+	(d-let
+		(p-assign (ident "main"))
+		(e-block
+			(s-let
+				(p-assign (ident "int_list"))
+				(e-call (constraint-fn-var 180)
+					(e-lookup-local
+						(p-assign (ident "shorthand")))
+					(e-list
+						(elems
+							(e-num (value "1"))
+							(e-num (value "2"))
+							(e-num (value "3"))))))
+			(s-let
+				(p-assign (ident "string_list"))
+				(e-call (constraint-fn-var 204)
+					(e-lookup-local
+						(p-assign (ident "shorthand")))
+					(e-list
+						(elems
+							(e-string
+								(e-literal (string "a")))
+							(e-string
+								(e-literal (string "b")))
+							(e-string
+								(e-literal (string "c")))))))
+			(e-tuple
+				(elems
+					(e-lookup-local
+						(p-assign (ident "int_list")))
+					(e-lookup-local
+						(p-assign (ident "string_list")))))))
+	(s-nominal-decl
+		(ty-header (name "FooBar"))
+		(ty-record)))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "List(a) -> U64"))
+		(patt (type "List(a) -> U64"))
+		(patt (type "(U64, U64)")))
+	(type_decls
+		(nominal (type "FooBar")
+			(ty-header (name "FooBar"))))
+	(expressions
+		(expr (type "List(a) -> U64"))
+		(expr (type "List(a) -> U64"))
+		(expr (type "(U64, U64)"))))
+~~~


### PR DESCRIPTION
Fixes #9574. Aliasing a polymorphic function to a new binding, e.g. `shorthand = FooBar.myfunc` where `myfunc : List(a) -> U64`, left `shorthand` monomorphic (`List(Str) -> U64`) rather than polymorphic. The first call site pinned the binding's type variables, so a second call at a different type produced a confusing "this number is being used where a non-number type is needed" error pointing at the list literals rather than at the real culprit. Calling `FooBar.myfunc` directly worked fine because each call site instantiates the generalized scheme.

The root cause is that let-generalization was triggered only for *syntactically* functions (`isFunctionDef`), so a binding whose right-hand side is a bare reference to an already-generalized scheme was never re-generalized; its freshly instantiated type variables stayed at the binding's rank and were shared across all uses. A bare reference is non-expansive: it performs no work and can hide no `dbg`/`expect`, so it raises none of the duplicate-work or duplicate-effect concerns that motivate the syntactic-function restriction, and in practice the only generalized schemes are functions (numeric literals use the separate defaulting path), so this never re-generalizes numbers or tag unions. This is the value-restriction treatment of a variable binding.

Generalization is gated to genuine immutable binding right-hand sides (top-level defs and block-local `s_decl`s) via a `checking_binding_rhs` flag, rather than firing for every bare lookup subexpression — this avoids per-lookup generalization cost and keeps generalization out of expansive positions like `if`-branches and tuple/record-literal elements, which stay weak as the design intends. Mutable `var` bindings are deliberately excluded. The fix only takes effect when the referenced binding is itself a generalized scheme, so e.g. `(a, b) = some_tuple_literal` keeps `a`/`b` weak.

Opening as a draft because this is a deliberate loosening of let-generalization (from "syntactic functions only" toward generalizing non-expansive function references), so the policy is worth a look before merge. The added snapshots also stress adjacent scenarios (alias chains, references inside records/tuples, block-local aliases, self-reference, exposing an aliased function, and an `if` choosing between functions) to confirm the compiler infers reasonable types and never crashes. Note the linked issue's repro used an `app`/platform; the main snapshot reduces it to a `module` to keep the test focused on type checking.
