### PR TITLE
Add call-pattern specialization

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -472,6 +472,9 @@ Builtin :: [].{
 				One({ item, rest }) => Iter.fold(rest, step(acc, item), step)
 			}
 
+		collect : Iter(item) -> List(item)
+		collect = |iterator| List.from_iter(iterator)
+
 		## Returns an iterator that yields at most the first `n` items of this iterator.
 		## If the source has fewer than `n` items, all of them are yielded.
 		## ```roc
@@ -624,6 +627,34 @@ Builtin :: [].{
 			}
 
 			make(0)
+		}
+
+		from_iter : Iter(item) -> List(item)
+		from_iter = |iterator| {
+			cap = match iterator.len_if_known {
+				Known(n) => n
+				Unknown => 0
+			}
+
+			var $list = List.with_capacity(cap)
+			var $rest = iterator
+
+			while Bool.True {
+				match Iter.next($rest) {
+					Done => {
+						break
+					}
+					Skip({ rest }) => {
+						$rest = rest
+					}
+					One({ item, rest }) => {
+						$list = list_append_unsafe($list, item)
+						$rest = rest
+					}
+				}
+			}
+
+			$list
 		}
 
 		## Put two lists together.

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -10,6 +10,7 @@ const helpers = eval.test_helpers;
 
 const Allocator = std.mem.Allocator;
 const LIR = lir.LIR;
+const LayoutIdx = @import("layout").Idx;
 
 const LoweredSource = struct {
     resources: helpers.ParsedResources,
@@ -71,6 +72,73 @@ fn lowerModule(
         .resources = resources,
         .lowered = lowered,
     };
+}
+
+fn mainProcArgLayouts(
+    allocator: Allocator,
+    lowered: *const lir.CheckedPipeline.LoweredProgram,
+) anyerror![]LayoutIdx {
+    const proc = lowered.lir_result.store.getProcSpec(try rootProc(lowered));
+    const arg_locals = lowered.lir_result.store.getLocalSpan(proc.args);
+    const arg_layouts = try allocator.alloc(LayoutIdx, arg_locals.len);
+    errdefer allocator.free(arg_layouts);
+
+    for (arg_locals, 0..) |local_id, index| {
+        arg_layouts[index] = lowered.lir_result.store.getLocal(local_id).layout_idx;
+    }
+
+    return arg_layouts;
+}
+
+fn runLoweredWithHostEvents(
+    allocator: Allocator,
+    lowered: *const lir.CheckedPipeline.LoweredProgram,
+) anyerror!eval.RuntimeHostEnv.RecordedRun {
+    var runtime_env = eval.RuntimeHostEnv.init(allocator);
+    defer runtime_env.deinit();
+
+    var interpreter = try eval.Interpreter.init(
+        allocator,
+        &lowered.lir_result.store,
+        &lowered.lir_result.layouts,
+        runtime_env.get_ops(),
+    );
+    defer interpreter.deinit();
+
+    const arg_layouts = try mainProcArgLayouts(allocator, lowered);
+    defer allocator.free(arg_layouts);
+
+    const result = interpreter.eval(.{
+        .proc_id = try rootProc(lowered),
+        .arg_layouts = arg_layouts,
+    }) catch |err| switch (err) {
+        error.Crash => return runtime_env.snapshot(allocator),
+        else => return err,
+    };
+    switch (result) {
+        .value => {},
+    }
+
+    return runtime_env.snapshot(allocator);
+}
+
+fn expectOptimizedDbgEvents(source: []const u8, expected: []const []const u8) anyerror!void {
+    const allocator = std.testing.allocator;
+
+    var optimized = try lowerModule(allocator, source, .direct_call_wrappers);
+    defer optimized.deinit(allocator);
+
+    var run = try runLoweredWithHostEvents(allocator, &optimized.lowered);
+    defer run.deinit(allocator);
+
+    try std.testing.expectEqual(eval.RuntimeHostEnv.Termination.returned, run.termination);
+    try std.testing.expectEqual(expected.len, run.events.len);
+    for (expected, run.events) |expected_event, actual_event| {
+        switch (actual_event) {
+            .dbg => |msg| try std.testing.expectEqualStrings(expected_event, msg),
+            else => return error.TestUnexpectedResult,
+        }
+    }
 }
 
 fn liftModuleAfterSpecConstr(
@@ -846,6 +914,186 @@ test "spec constr does not duplicate opaque known-match payloads" {
 
     try std.testing.expect(try reachableProcShape(allocator, &optimized.lowered, opaqueLetCallWorkerDoesNotDuplicateCall));
     try std.testing.expect(!try reachableProcShape(allocator, &optimized.lowered, opaqueLetCallWorkerDuplicatesCall));
+}
+
+test "spec constr preserves direct call argument effect order" {
+    try expectOptimizedDbgEvents(
+        \\module [main]
+        \\
+        \\State : { n : I64 }
+        \\
+        \\tap : I64 -> I64
+        \\tap = |n| {
+        \\    dbg "arg"
+        \\    n
+        \\}
+        \\
+        \\use_after : State, I64 -> I64
+        \\use_after = |state, x| {
+        \\    dbg "callee-before"
+        \\    state.n + x
+        \\}
+        \\
+        \\outer : State -> I64
+        \\outer = |state|
+        \\    use_after({ n: state.n }, tap(state.n))
+        \\
+        \\main : I64
+        \\main = outer({ n: 1 })
+    , &.{ "\"arg\"", "\"callee-before\"" });
+}
+
+test "spec constr preserves left-to-right order for multiple unsafe call args" {
+    try expectOptimizedDbgEvents(
+        \\module [main]
+        \\
+        \\State : { n : I64 }
+        \\
+        \\tap_one : I64 -> I64
+        \\tap_one = |n| {
+        \\    dbg "arg-one"
+        \\    n
+        \\}
+        \\
+        \\tap_two : I64 -> I64
+        \\tap_two = |n| {
+        \\    dbg "arg-two"
+        \\    n + 1
+        \\}
+        \\
+        \\combine_after : State, I64, I64 -> I64
+        \\combine_after = |state, x, y| {
+        \\    dbg "callee-before"
+        \\    state.n + x + y
+        \\}
+        \\
+        \\outer : State -> I64
+        \\outer = |state|
+        \\    combine_after({ n: state.n }, tap_one(state.n), tap_two(state.n))
+        \\
+        \\main : I64
+        \\main = outer({ n: 1 })
+    , &.{ "\"arg-one\"", "\"arg-two\"", "\"callee-before\"" });
+}
+
+test "spec constr preserves substituted capture order before direct call args" {
+    try expectOptimizedDbgEvents(
+        \\module [main]
+        \\
+        \\State : { n : I64 }
+        \\
+        \\tap_capture : I64 -> I64
+        \\tap_capture = |n| {
+        \\    dbg "capture"
+        \\    n
+        \\}
+        \\
+        \\tap_arg : I64 -> I64
+        \\tap_arg = |n| {
+        \\    dbg "arg"
+        \\    n
+        \\}
+        \\
+        \\outer : State, I64 -> I64
+        \\outer = |state, seed| {
+        \\    inner = |next, arg| {
+        \\        dbg "callee-before"
+        \\        seed + next.n + arg
+        \\    }
+        \\    inner({ n: seed }, tap_arg(state.n))
+        \\}
+        \\
+        \\main : I64
+        \\main = outer({ n: 1 }, tap_capture(2))
+    , &.{ "\"capture\"", "\"arg\"", "\"callee-before\"" });
+}
+
+test "spec constr preserves callable argument effect order" {
+    try expectOptimizedDbgEvents(
+        \\module [main]
+        \\
+        \\State : { n : I64 }
+        \\
+        \\tap : I64 -> I64
+        \\tap = |n| {
+        \\    dbg "arg"
+        \\    n
+        \\}
+        \\
+        \\call_it : State, (I64 -> I64) -> I64
+        \\call_it = |state, f|
+        \\    f(tap(state.n))
+        \\
+        \\outer : State -> I64
+        \\outer = |state| {
+        \\    f = |x| {
+        \\        dbg "fn-before"
+        \\        x
+        \\    }
+        \\    call_it({ n: state.n }, f)
+        \\}
+        \\
+        \\main : I64
+        \\main = outer({ n: 1 })
+    , &.{ "\"arg\"", "\"fn-before\"" });
+}
+
+test "spec constr preserves known-match single-use payload effect order" {
+    try expectOptimizedDbgEvents(
+        \\module [main]
+        \\
+        \\State : { n : I64 }
+        \\Step : [One(I64)]
+        \\
+        \\tap : I64 -> I64
+        \\tap = |n| {
+        \\    dbg "payload"
+        \\    n
+        \\}
+        \\
+        \\outer : State -> I64
+        \\outer = |state|
+        \\    match One(tap(state.n)) {
+        \\        One(x) => {
+        \\            dbg "branch-before"
+        \\            x
+        \\        }
+        \\    }
+        \\
+        \\main : I64
+        \\main = outer({ n: 1 })
+    , &.{ "\"payload\"", "\"branch-before\"" });
+}
+
+test "spec constr preserves nested known-match payload effect order" {
+    try expectOptimizedDbgEvents(
+        \\module [main]
+        \\
+        \\State : { n : I64 }
+        \\Step : [One({ item : I64 })]
+        \\
+        \\tap : I64 -> I64
+        \\tap = |n| {
+        \\    dbg "payload"
+        \\    n
+        \\}
+        \\
+        \\consume : State, Step -> I64
+        \\consume = |state, step|
+        \\    match step {
+        \\        One({ item }) => {
+        \\            dbg "branch-before"
+        \\            state.n + item
+        \\        }
+        \\    }
+        \\
+        \\outer : State -> I64
+        \\outer = |state|
+        \\    consume({ n: state.n }, One({ item: tap(state.n) }))
+        \\
+        \\main : I64
+        \\main = outer({ n: 1 })
+    , &.{ "\"payload\"", "\"branch-before\"" });
 }
 
 test "spec constr writes dynamically discovered workers once" {

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -5,6 +5,7 @@ const base = @import("base");
 const check = @import("check");
 const eval = @import("eval");
 const lir = @import("lir");
+const postcheck = @import("postcheck");
 const helpers = eval.test_helpers;
 
 const Allocator = std.mem.Allocator;
@@ -16,6 +17,16 @@ const LoweredSource = struct {
 
     fn deinit(self: *LoweredSource, allocator: Allocator) void {
         self.lowered.deinit();
+        helpers.cleanupParseAndCanonical(allocator, self.resources);
+    }
+};
+
+const LiftedSource = struct {
+    resources: helpers.ParsedResources,
+    lifted: postcheck.MonotypeLifted.Ast.Program,
+
+    fn deinit(self: *LiftedSource, allocator: Allocator) void {
+        self.lifted.deinit();
         helpers.cleanupParseAndCanonical(allocator, self.resources);
     }
 };
@@ -59,6 +70,51 @@ fn lowerModule(
     return .{
         .resources = resources,
         .lowered = lowered,
+    };
+}
+
+fn liftModuleAfterSpecConstr(
+    allocator: Allocator,
+    source: []const u8,
+) anyerror!LiftedSource {
+    var resources = try helpers.parseAndCanonicalizeProgram(allocator, .module, source, &.{});
+    errdefer helpers.cleanupParseAndCanonical(allocator, resources);
+
+    const import_count = resources.import_artifacts.len + if (resources.borrowed_builtin_artifact == null) @as(usize, 0) else 1;
+    const import_views = try allocator.alloc(check.CheckedArtifact.ImportedModuleView, import_count);
+    defer allocator.free(import_views);
+
+    var view_index: usize = 0;
+    if (resources.borrowed_builtin_artifact) |builtin_artifact| {
+        import_views[view_index] = check.CheckedArtifact.importedView(builtin_artifact);
+        view_index += 1;
+    }
+    for (resources.import_artifacts) |*artifact| {
+        import_views[view_index] = check.CheckedArtifact.importedView(artifact);
+        view_index += 1;
+    }
+
+    var mono = try postcheck.Monotype.Lower.run(
+        allocator,
+        .{
+            .root = check.CheckedArtifact.loweringView(&resources.checked_artifact),
+            .imports = import_views,
+        },
+        .{ .requests = resources.checked_artifact.root_requests.runtime_requests },
+    );
+    var mono_owned = true;
+    errdefer if (mono_owned) mono.deinit();
+
+    var lifted = try postcheck.MonotypeLifted.Lift.run(allocator, mono);
+    mono_owned = false;
+    mono = undefined;
+    errdefer lifted.deinit();
+
+    try postcheck.MonotypeLifted.SpecConstr.run(allocator, &lifted);
+
+    return .{
+        .resources = resources,
+        .lifted = lifted,
     };
 }
 
@@ -239,7 +295,7 @@ fn procShapeMatchesIterCollect(shape: ProcShape, wanted: IterCollectShape) bool 
         .specialized => shape.arg_count == 3 and
             shape.direct_call_count >= 10 and
             shape.switch_count >= 10 and
-            shape.join_count >= 20 and
+            shape.join_count >= 16 and
             shape.jump_count >= 20,
         .generic => shape.arg_count == 1 and
             shape.direct_call_count == 3 and
@@ -309,6 +365,123 @@ fn reachableProcShape(
     comptime matches: fn (ProcShape) bool,
 ) anyerror!bool {
     return (try reachableProcShapeCount(allocator, lowered, matches)) > 0;
+}
+
+fn markReachableLiftedExpr(
+    program: *const postcheck.MonotypeLifted.Ast.Program,
+    expr_id: postcheck.MonotypeLifted.Ast.ExprId,
+    reachable: []bool,
+) void {
+    const index = @intFromEnum(expr_id);
+    if (reachable[index]) return;
+    reachable[index] = true;
+
+    switch (program.exprs.items[index].data) {
+        .local,
+        .unit,
+        .int_lit,
+        .frac_f32_lit,
+        .frac_f64_lit,
+        .dec_lit,
+        .str_lit,
+        .fn_ref,
+        .crash,
+        => {},
+        .list,
+        .tuple,
+        => |items| for (program.exprSpan(items)) |child| markReachableLiftedExpr(program, child, reachable),
+        .record => |fields| for (program.fieldExprSpan(fields)) |field| markReachableLiftedExpr(program, field.value, reachable),
+        .tag => |tag| for (program.exprSpan(tag.payloads)) |payload| markReachableLiftedExpr(program, payload, reachable),
+        .nominal,
+        .return_,
+        .dbg,
+        .expect,
+        => |child| markReachableLiftedExpr(program, child, reachable),
+        .let_ => |let_| {
+            markReachableLiftedExpr(program, let_.value, reachable);
+            markReachableLiftedExpr(program, let_.rest, reachable);
+        },
+        .lambda,
+        .def_ref,
+        .fn_def,
+        => {},
+        .call_value => |call| {
+            markReachableLiftedExpr(program, call.callee, reachable);
+            for (program.exprSpan(call.args)) |arg| markReachableLiftedExpr(program, arg, reachable);
+        },
+        .call_proc => |call| {
+            for (program.exprSpan(call.args)) |arg| markReachableLiftedExpr(program, arg, reachable);
+        },
+        .low_level => |call| for (program.exprSpan(call.args)) |arg| markReachableLiftedExpr(program, arg, reachable),
+        .field_access => |field| markReachableLiftedExpr(program, field.receiver, reachable),
+        .tuple_access => |access| markReachableLiftedExpr(program, access.tuple, reachable),
+        .structural_eq => |eq| {
+            markReachableLiftedExpr(program, eq.lhs, reachable);
+            markReachableLiftedExpr(program, eq.rhs, reachable);
+        },
+        .match_ => |match| {
+            markReachableLiftedExpr(program, match.scrutinee, reachable);
+            for (program.branchSpan(match.branches)) |branch| {
+                if (branch.guard) |guard| markReachableLiftedExpr(program, guard, reachable);
+                markReachableLiftedExpr(program, branch.body, reachable);
+            }
+        },
+        .if_ => |if_| {
+            for (program.ifBranchSpan(if_.branches)) |branch| {
+                markReachableLiftedExpr(program, branch.cond, reachable);
+                markReachableLiftedExpr(program, branch.body, reachable);
+            }
+            markReachableLiftedExpr(program, if_.final_else, reachable);
+        },
+        .block => |block| {
+            for (program.stmtSpan(block.statements)) |stmt| markReachableLiftedStmt(program, stmt, reachable);
+            markReachableLiftedExpr(program, block.final_expr, reachable);
+        },
+        .loop_ => |loop| {
+            for (program.exprSpan(loop.initial_values)) |initial| markReachableLiftedExpr(program, initial, reachable);
+            markReachableLiftedExpr(program, loop.body, reachable);
+        },
+        .break_ => |maybe| if (maybe) |value| markReachableLiftedExpr(program, value, reachable),
+        .continue_ => |continue_| for (program.exprSpan(continue_.values)) |value| markReachableLiftedExpr(program, value, reachable),
+    }
+}
+
+fn markReachableLiftedStmt(
+    program: *const postcheck.MonotypeLifted.Ast.Program,
+    stmt_id: postcheck.MonotypeLifted.Ast.StmtId,
+    reachable: []bool,
+) void {
+    switch (program.stmts.items[@intFromEnum(stmt_id)]) {
+        .let_ => |let_| markReachableLiftedExpr(program, let_.value, reachable),
+        .expr,
+        .expect,
+        .dbg,
+        .return_,
+        => |expr| markReachableLiftedExpr(program, expr, reachable),
+        .crash => {},
+    }
+}
+
+fn countUnreachableLiftedDirectCalls(
+    allocator: Allocator,
+    program: *const postcheck.MonotypeLifted.Ast.Program,
+) anyerror!usize {
+    const reachable = try allocator.alloc(bool, program.exprs.items.len);
+    defer allocator.free(reachable);
+    @memset(reachable, false);
+
+    for (program.fns.items) |fn_| {
+        switch (fn_.body) {
+            .roc => |body| markReachableLiftedExpr(program, body, reachable),
+            .hosted => {},
+        }
+    }
+
+    var count: usize = 0;
+    for (program.exprs.items, reachable) |expr, is_reachable| {
+        if (!is_reachable and expr.data == .call_proc) count += 1;
+    }
+    return count;
 }
 
 fn directRecordWorkerIsSpecialized(shape: ProcShape) bool {
@@ -386,6 +559,18 @@ fn multiTupleWorkerIsGeneric(shape: ProcShape) bool {
     return shape.arg_count == 3 and
         shape.self_call_count == 2 and
         shape.struct_assign_count >= 2;
+}
+
+fn opaqueLetCallWorkerDoesNotDuplicateCall(shape: ProcShape) bool {
+    return shape.arg_count == 1 and
+        shape.direct_call_count == 2 and
+        shape.struct_assign_count == 0;
+}
+
+fn opaqueLetCallWorkerDuplicatesCall(shape: ProcShape) bool {
+    return shape.arg_count == 1 and
+        shape.direct_call_count > 2 and
+        shape.struct_assign_count == 0;
 }
 
 fn expectIterCollectWorkerSpecialized(source: []const u8) anyerror!void {
@@ -606,6 +791,63 @@ test "direct iter collect worker specializes constructor recursive call" {
         \\        Iter.map(0.I64.to(15), |i| random_plant(i * 12)),
         \\    )
     );
+}
+
+test "spec constr does not duplicate opaque let-bound direct calls" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\module [main]
+        \\
+        \\State : { n : I64 }
+        \\
+        \\tick : I64 -> I64
+        \\tick = |n| n + 1
+        \\
+        \\read_twice : State -> I64
+        \\read_twice = |state| {
+        \\    x = tick(state.n)
+        \\    x + x
+        \\}
+        \\
+        \\main : I64
+        \\main = read_twice({ n: 1 })
+    ;
+
+    var optimized = try lowerModule(allocator, source, .direct_call_wrappers);
+    defer optimized.deinit(allocator);
+
+    try std.testing.expect(try reachableProcShape(allocator, &optimized.lowered, opaqueLetCallWorkerDoesNotDuplicateCall));
+    try std.testing.expect(!try reachableProcShape(allocator, &optimized.lowered, opaqueLetCallWorkerDuplicatesCall));
+}
+
+test "spec constr writes dynamically discovered workers once" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\module [main]
+        \\
+        \\Step : [Start(I64), Loop(I64)]
+        \\
+        \\go : Step -> I64
+        \\go = |step|
+        \\    match step {
+        \\        Start(n) => {
+        \\            next = Loop(n)
+        \\            go(next)
+        \\        }
+        \\        Loop(n) => tick(n)
+        \\    }
+        \\
+        \\tick : I64 -> I64
+        \\tick = |n| n + 1
+        \\
+        \\main : I64
+        \\main = go(Start(1))
+    ;
+
+    var lifted = try liftModuleAfterSpecConstr(allocator, source);
+    defer lifted.deinit(allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), try countUnreachableLiftedDirectCalls(allocator, &lifted.lifted));
 }
 
 test "spec constr specializes recursive record state" {

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -139,6 +139,7 @@ const ProcShape = struct {
     self_call_count: usize = 0,
     switch_count: usize = 0,
     join_count: usize = 0,
+    max_join_param_count: usize = 0,
     jump_count: usize = 0,
     struct_assign_count: usize = 0,
     tag_assign_count: usize = 0,
@@ -206,6 +207,10 @@ fn collectProcShape(
             },
             .join => |stmt| {
                 shape.join_count += 1;
+                shape.max_join_param_count = @max(
+                    shape.max_join_param_count,
+                    lowered.lir_result.store.getLocalSpan(stmt.params).len,
+                );
                 try work.append(allocator, stmt.body);
                 try work.append(allocator, stmt.remainder);
             },
@@ -322,16 +327,16 @@ fn whileRecordStateWorkerIsSpecialized(shape: ProcShape) bool {
     return shape.arg_count == 1 and
         shape.self_call_count == 0 and
         shape.join_count >= 1 and
-        shape.jump_count >= 2 and
-        shape.struct_assign_count == 0;
+        shape.max_join_param_count == 2 and
+        shape.jump_count >= 2;
 }
 
 fn whileRecordStateWorkerIsGeneric(shape: ProcShape) bool {
     return shape.arg_count == 1 and
         shape.self_call_count == 0 and
         shape.join_count >= 1 and
-        shape.jump_count >= 2 and
-        shape.struct_assign_count >= 1;
+        shape.max_join_param_count == 1 and
+        shape.jump_count >= 2;
 }
 
 fn directTupleWorkerIsSpecialized(shape: ProcShape) bool {

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -820,6 +820,34 @@ test "spec constr does not duplicate opaque let-bound direct calls" {
     try std.testing.expect(!try reachableProcShape(allocator, &optimized.lowered, opaqueLetCallWorkerDuplicatesCall));
 }
 
+test "spec constr does not duplicate opaque known-match payloads" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\module [main]
+        \\
+        \\State : { n : I64 }
+        \\Step : [One(I64)]
+        \\
+        \\tick : I64 -> I64
+        \\tick = |n| n + 1
+        \\
+        \\read_twice : State -> I64
+        \\read_twice = |state|
+        \\    match One(tick(state.n)) {
+        \\        One(x) => x + x
+        \\    }
+        \\
+        \\main : I64
+        \\main = read_twice({ n: 1 })
+    ;
+
+    var optimized = try lowerModule(allocator, source, .direct_call_wrappers);
+    defer optimized.deinit(allocator);
+
+    try std.testing.expect(try reachableProcShape(allocator, &optimized.lowered, opaqueLetCallWorkerDoesNotDuplicateCall));
+    try std.testing.expect(!try reachableProcShape(allocator, &optimized.lowered, opaqueLetCallWorkerDuplicatesCall));
+}
+
 test "spec constr writes dynamically discovered workers once" {
     const allocator = std.testing.allocator;
     const source =

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -132,6 +132,273 @@ fn collectAssignCallProcs(
     return try calls.toOwnedSlice(allocator);
 }
 
+const ProcShape = struct {
+    arg_count: usize,
+    direct_call_count: usize = 0,
+    erased_call_count: usize = 0,
+    self_call_count: usize = 0,
+    switch_count: usize = 0,
+    join_count: usize = 0,
+    jump_count: usize = 0,
+    struct_assign_count: usize = 0,
+    tag_assign_count: usize = 0,
+};
+
+fn collectProcShape(
+    allocator: Allocator,
+    lowered: *const lir.CheckedPipeline.LoweredProgram,
+    proc_id: LIR.LirProcSpecId,
+) anyerror!ProcShape {
+    const proc = lowered.lir_result.store.getProcSpec(proc_id);
+    var shape = ProcShape{
+        .arg_count = lowered.lir_result.store.getLocalSpan(proc.args).len,
+    };
+
+    const body = proc.body orelse return shape;
+
+    var work = std.ArrayList(LIR.CFStmtId).empty;
+    defer work.deinit(allocator);
+    try work.append(allocator, body);
+
+    var visited = std.AutoHashMap(LIR.CFStmtId, void).init(allocator);
+    defer visited.deinit();
+
+    while (work.pop()) |stmt_id| {
+        const visited_entry = try visited.getOrPut(stmt_id);
+        if (visited_entry.found_existing) continue;
+
+        switch (lowered.lir_result.store.getCFStmt(stmt_id)) {
+            .assign_ref => |stmt| try work.append(allocator, stmt.next),
+            .assign_literal => |stmt| try work.append(allocator, stmt.next),
+            .assign_call => |stmt| {
+                shape.direct_call_count += 1;
+                if (stmt.proc == proc_id) shape.self_call_count += 1;
+                try work.append(allocator, stmt.next);
+            },
+            .assign_call_erased => |stmt| {
+                shape.erased_call_count += 1;
+                try work.append(allocator, stmt.next);
+            },
+            .assign_packed_erased_fn => |stmt| try work.append(allocator, stmt.next),
+            .assign_low_level => |stmt| try work.append(allocator, stmt.next),
+            .assign_list => |stmt| try work.append(allocator, stmt.next),
+            .assign_struct => |stmt| {
+                shape.struct_assign_count += 1;
+                try work.append(allocator, stmt.next);
+            },
+            .assign_tag => |stmt| {
+                shape.tag_assign_count += 1;
+                try work.append(allocator, stmt.next);
+            },
+            .set_local => |stmt| try work.append(allocator, stmt.next),
+            .debug => |stmt| try work.append(allocator, stmt.next),
+            .expect => |stmt| try work.append(allocator, stmt.next),
+            .incref => |stmt| try work.append(allocator, stmt.next),
+            .decref => |stmt| try work.append(allocator, stmt.next),
+            .free => |stmt| try work.append(allocator, stmt.next),
+            .switch_stmt => |stmt| {
+                shape.switch_count += 1;
+                if (stmt.continuation) |continuation| try work.append(allocator, continuation);
+                try work.append(allocator, stmt.default_branch);
+                for (lowered.lir_result.store.getCFSwitchBranches(stmt.branches)) |branch| {
+                    try work.append(allocator, branch.body);
+                }
+            },
+            .join => |stmt| {
+                shape.join_count += 1;
+                try work.append(allocator, stmt.body);
+                try work.append(allocator, stmt.remainder);
+            },
+            .jump => {
+                shape.jump_count += 1;
+            },
+            .runtime_error,
+            .loop_continue,
+            .loop_break,
+            .ret,
+            .crash,
+            => {},
+        }
+    }
+
+    return shape;
+}
+
+const IterCollectShape = enum {
+    specialized,
+    generic,
+};
+
+fn procShapeMatchesIterCollect(shape: ProcShape, wanted: IterCollectShape) bool {
+    return switch (wanted) {
+        .specialized => shape.arg_count == 3 and
+            shape.direct_call_count >= 10 and
+            shape.switch_count >= 10 and
+            shape.join_count >= 20 and
+            shape.jump_count >= 20,
+        .generic => shape.arg_count == 1 and
+            shape.direct_call_count == 3 and
+            shape.switch_count == 6 and
+            shape.join_count == 9 and
+            shape.jump_count == 11 and
+            shape.struct_assign_count >= 10,
+    };
+}
+
+fn reachableIterCollectShape(
+    allocator: Allocator,
+    lowered: *const lir.CheckedPipeline.LoweredProgram,
+    wanted: IterCollectShape,
+) anyerror!bool {
+    var work = std.ArrayList(LIR.LirProcSpecId).empty;
+    defer work.deinit(allocator);
+    try work.append(allocator, try rootProc(lowered));
+
+    var visited = std.AutoHashMap(LIR.LirProcSpecId, void).init(allocator);
+    defer visited.deinit();
+
+    while (work.pop()) |proc_id| {
+        const visited_entry = try visited.getOrPut(proc_id);
+        if (visited_entry.found_existing) continue;
+
+        const shape = try collectProcShape(allocator, lowered, proc_id);
+        if (procShapeMatchesIterCollect(shape, wanted)) return true;
+
+        const calls = try collectAssignCallProcs(allocator, lowered, proc_id);
+        defer allocator.free(calls);
+        for (calls) |call| try work.append(allocator, call);
+    }
+    return false;
+}
+
+fn reachableProcShapeCount(
+    allocator: Allocator,
+    lowered: *const lir.CheckedPipeline.LoweredProgram,
+    comptime matches: fn (ProcShape) bool,
+) anyerror!usize {
+    var work = std.ArrayList(LIR.LirProcSpecId).empty;
+    defer work.deinit(allocator);
+    try work.append(allocator, try rootProc(lowered));
+
+    var visited = std.AutoHashMap(LIR.LirProcSpecId, void).init(allocator);
+    defer visited.deinit();
+
+    var count: usize = 0;
+    while (work.pop()) |proc_id| {
+        const visited_entry = try visited.getOrPut(proc_id);
+        if (visited_entry.found_existing) continue;
+
+        const shape = try collectProcShape(allocator, lowered, proc_id);
+        if (matches(shape)) count += 1;
+
+        const calls = try collectAssignCallProcs(allocator, lowered, proc_id);
+        defer allocator.free(calls);
+        for (calls) |call| try work.append(allocator, call);
+    }
+    return count;
+}
+
+fn reachableProcShape(
+    allocator: Allocator,
+    lowered: *const lir.CheckedPipeline.LoweredProgram,
+    comptime matches: fn (ProcShape) bool,
+) anyerror!bool {
+    return (try reachableProcShapeCount(allocator, lowered, matches)) > 0;
+}
+
+fn directRecordWorkerIsSpecialized(shape: ProcShape) bool {
+    return shape.arg_count == 2 and
+        shape.self_call_count == 1 and
+        shape.struct_assign_count == 0;
+}
+
+fn directRecordWorkerIsGeneric(shape: ProcShape) bool {
+    return shape.arg_count == 1 and
+        shape.self_call_count == 1 and
+        shape.struct_assign_count >= 1;
+}
+
+fn whileRecordStateWorkerIsSpecialized(shape: ProcShape) bool {
+    return shape.arg_count == 1 and
+        shape.self_call_count == 0 and
+        shape.join_count >= 1 and
+        shape.jump_count >= 2 and
+        shape.struct_assign_count == 0;
+}
+
+fn whileRecordStateWorkerIsGeneric(shape: ProcShape) bool {
+    return shape.arg_count == 1 and
+        shape.self_call_count == 0 and
+        shape.join_count >= 1 and
+        shape.jump_count >= 2 and
+        shape.struct_assign_count >= 1;
+}
+
+fn directTupleWorkerIsSpecialized(shape: ProcShape) bool {
+    return shape.arg_count == 2 and
+        shape.self_call_count == 1 and
+        shape.struct_assign_count == 0;
+}
+
+fn directTupleWorkerIsGeneric(shape: ProcShape) bool {
+    return shape.arg_count == 1 and
+        shape.self_call_count == 1 and
+        shape.struct_assign_count >= 1;
+}
+
+fn unusedStateWorkerIsSpecialized(shape: ProcShape) bool {
+    return shape.arg_count == 2 and
+        shape.self_call_count == 1 and
+        shape.struct_assign_count == 0;
+}
+
+fn unusedStateWorkerIsGeneric(shape: ProcShape) bool {
+    return shape.arg_count == 2 and
+        shape.self_call_count == 1 and
+        shape.struct_assign_count >= 1;
+}
+
+fn taggedStepWorkerIsSpecialized(shape: ProcShape) bool {
+    return shape.arg_count == 2 and
+        shape.self_call_count == 1 and
+        shape.direct_call_count >= 2 and
+        shape.tag_assign_count == 0;
+}
+
+fn taggedStepWorkerIsGeneric(shape: ProcShape) bool {
+    return shape.arg_count == 2 and
+        shape.self_call_count >= 1 and
+        shape.tag_assign_count >= 1;
+}
+
+fn multiTupleWorkerIsFullySpecialized(shape: ProcShape) bool {
+    return shape.arg_count == 5 and
+        shape.self_call_count == 2 and
+        shape.struct_assign_count == 0;
+}
+
+fn multiTupleWorkerIsGeneric(shape: ProcShape) bool {
+    return shape.arg_count == 3 and
+        shape.self_call_count == 2 and
+        shape.struct_assign_count >= 2;
+}
+
+fn expectIterCollectWorkerSpecialized(source: []const u8) anyerror!void {
+    const allocator = std.testing.allocator;
+
+    var optimized = try lowerModule(allocator, source, .direct_call_wrappers);
+    defer optimized.deinit(allocator);
+
+    var unoptimized = try lowerModule(allocator, source, .none);
+    defer unoptimized.deinit(allocator);
+
+    try std.testing.expect(try reachableIterCollectShape(allocator, &optimized.lowered, .specialized));
+    try std.testing.expect(!try reachableIterCollectShape(allocator, &optimized.lowered, .generic));
+
+    try std.testing.expect(!try reachableIterCollectShape(allocator, &unoptimized.lowered, .specialized));
+    try std.testing.expect(try reachableIterCollectShape(allocator, &unoptimized.lowered, .generic));
+}
+
 fn rootDirectCallTarget(
     allocator: Allocator,
     lowered: *const lir.CheckedPipeline.LoweredProgram,
@@ -296,4 +563,246 @@ test "capturing direct wrapper is not inlined" {
         \\    wrapper(41)
         \\}
     , .direct_call_wrappers);
+}
+
+test "plant iter pipeline specializes collect worker after inlining" {
+    try expectIterCollectWorkerSpecialized(
+        \\module [main]
+        \\
+        \\Plant : { seed : I64 }
+        \\
+        \\random_plant : I64 -> Plant
+        \\random_plant = |seed| { seed: seed }
+        \\
+        \\starting_plants : () -> List(Plant)
+        \\starting_plants = || {
+        \\    0.I64.to(15)
+        \\        .map(|i| random_plant(i * 12))
+        \\        .collect()
+        \\}
+        \\
+        \\main : List(Plant)
+        \\main = starting_plants()
+    );
+}
+
+test "direct iter collect worker specializes constructor recursive call" {
+    try expectIterCollectWorkerSpecialized(
+        \\module [main]
+        \\
+        \\Plant : { seed : I64 }
+        \\
+        \\random_plant : I64 -> Plant
+        \\random_plant = |seed| { seed: seed }
+        \\
+        \\main : List(Plant)
+        \\main =
+        \\    Iter.collect(
+        \\        Iter.map(0.I64.to(15), |i| random_plant(i * 12)),
+        \\    )
+    );
+}
+
+test "spec constr specializes recursive record state" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\module [main]
+        \\
+        \\State : { n : I64, acc : I64 }
+        \\
+        \\sum_record : State -> I64
+        \\sum_record = |state|
+        \\    if state.n == 0 {
+        \\        state.acc
+        \\    } else {
+        \\        sum_record({ n: state.n - 1, acc: state.acc + state.n })
+        \\    }
+        \\
+        \\main : I64
+        \\main = sum_record({ n: 4, acc: 0 })
+    ;
+
+    var optimized = try lowerModule(allocator, source, .direct_call_wrappers);
+    defer optimized.deinit(allocator);
+
+    var unoptimized = try lowerModule(allocator, source, .none);
+    defer unoptimized.deinit(allocator);
+
+    // Adapted from the GHC code base's SpecConstr examples for inspected loop state.
+    try std.testing.expect(try reachableProcShape(allocator, &optimized.lowered, directRecordWorkerIsSpecialized));
+    try std.testing.expect(!try reachableProcShape(allocator, &optimized.lowered, directRecordWorkerIsGeneric));
+
+    try std.testing.expect(!try reachableProcShape(allocator, &unoptimized.lowered, directRecordWorkerIsSpecialized));
+    try std.testing.expect(try reachableProcShape(allocator, &unoptimized.lowered, directRecordWorkerIsGeneric));
+}
+
+test "spec constr specializes record state carried by while loop" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\module [main]
+        \\
+        \\Start : { n : I64 }
+        \\State : { n : I64, acc : I64 }
+        \\
+        \\sum_from : Start -> I64
+        \\sum_from = |start| {
+        \\    var $state = { n: start.n, acc: 0 }
+        \\
+        \\    while $state.n != 0 {
+        \\        $state = { n: $state.n - 1, acc: $state.acc + $state.n }
+        \\    }
+        \\
+        \\    $state.acc
+        \\}
+        \\
+        \\main : I64
+        \\main = sum_from({ n: 4 })
+    ;
+
+    var optimized = try lowerModule(allocator, source, .direct_call_wrappers);
+    defer optimized.deinit(allocator);
+
+    var unoptimized = try lowerModule(allocator, source, .none);
+    defer unoptimized.deinit(allocator);
+
+    try std.testing.expect(try reachableProcShape(allocator, &optimized.lowered, whileRecordStateWorkerIsSpecialized));
+    try std.testing.expect(!try reachableProcShape(allocator, &optimized.lowered, whileRecordStateWorkerIsGeneric));
+
+    try std.testing.expect(!try reachableProcShape(allocator, &unoptimized.lowered, whileRecordStateWorkerIsSpecialized));
+    try std.testing.expect(try reachableProcShape(allocator, &unoptimized.lowered, whileRecordStateWorkerIsGeneric));
+}
+
+test "spec constr specializes recursive tuple state" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\module [main]
+        \\
+        \\sum_tuple : (I64, I64) -> I64
+        \\sum_tuple = |state|
+        \\    match state {
+        \\        (n, acc) =>
+        \\            if n == 0 {
+        \\                acc
+        \\            } else {
+        \\                sum_tuple((n - 1, acc + n))
+        \\            }
+        \\    }
+        \\
+        \\main : I64
+        \\main = sum_tuple((4, 0))
+    ;
+
+    var optimized = try lowerModule(allocator, source, .direct_call_wrappers);
+    defer optimized.deinit(allocator);
+
+    var unoptimized = try lowerModule(allocator, source, .none);
+    defer unoptimized.deinit(allocator);
+
+    // Adapted from the GHC code base's SpecConstr strict-tuple examples.
+    try std.testing.expect(try reachableProcShape(allocator, &optimized.lowered, directTupleWorkerIsSpecialized));
+    try std.testing.expect(!try reachableProcShape(allocator, &optimized.lowered, directTupleWorkerIsGeneric));
+
+    try std.testing.expect(!try reachableProcShape(allocator, &unoptimized.lowered, directTupleWorkerIsSpecialized));
+    try std.testing.expect(try reachableProcShape(allocator, &unoptimized.lowered, directTupleWorkerIsGeneric));
+}
+
+test "spec constr leaves uninspected constructor arguments generic" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\module [main]
+        \\
+        \\unused_state : { n : I64 }, I64 -> I64
+        \\unused_state = |state, n|
+        \\    if n == 0 {
+        \\        0
+        \\    } else {
+        \\        unused_state({ n: n }, n - 1)
+        \\    }
+        \\
+        \\main : I64
+        \\main = unused_state({ n: 0 }, 3)
+    ;
+
+    var optimized = try lowerModule(allocator, source, .direct_call_wrappers);
+    defer optimized.deinit(allocator);
+
+    var unoptimized = try lowerModule(allocator, source, .none);
+    defer unoptimized.deinit(allocator);
+
+    // Adapted from the GHC code base's Note [Good arguments].
+    try std.testing.expect(!try reachableProcShape(allocator, &optimized.lowered, unusedStateWorkerIsSpecialized));
+    try std.testing.expect(try reachableProcShape(allocator, &optimized.lowered, unusedStateWorkerIsGeneric));
+
+    try std.testing.expect(!try reachableProcShape(allocator, &unoptimized.lowered, unusedStateWorkerIsSpecialized));
+    try std.testing.expect(try reachableProcShape(allocator, &unoptimized.lowered, unusedStateWorkerIsGeneric));
+}
+
+test "spec constr specializes tagged recursive state" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\module [main]
+        \\
+        \\Step : [Done, More(I64)]
+        \\
+        \\count_down : Step, I64 -> I64
+        \\count_down = |step, acc|
+        \\    match step {
+        \\        Done => acc
+        \\        More(n) =>
+        \\            if n == 0 {
+        \\                count_down(Done, acc)
+        \\            } else {
+        \\                count_down(More(n - 1), acc + n)
+        \\            }
+        \\    }
+        \\
+        \\main : I64
+        \\main = count_down(More(4), 0)
+    ;
+
+    var optimized = try lowerModule(allocator, source, .direct_call_wrappers);
+    defer optimized.deinit(allocator);
+
+    var unoptimized = try lowerModule(allocator, source, .none);
+    defer unoptimized.deinit(allocator);
+
+    // Adapted from the GHC code base's SpecConstr constructor-call examples.
+    try std.testing.expect(try reachableProcShape(allocator, &optimized.lowered, taggedStepWorkerIsSpecialized));
+    try std.testing.expect(!try reachableProcShape(allocator, &optimized.lowered, taggedStepWorkerIsGeneric));
+
+    try std.testing.expect(!try reachableProcShape(allocator, &unoptimized.lowered, taggedStepWorkerIsSpecialized));
+    try std.testing.expect(try reachableProcShape(allocator, &unoptimized.lowered, taggedStepWorkerIsGeneric));
+}
+
+test "spec constr uses fully known entry shape for multiple tuple states" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\module [main]
+        \\
+        \\roman : I64, (I64, I64), (I64, I64) -> I64
+        \\roman = |n, p, q|
+        \\    if n == 0 {
+        \\        p.0 + q.0
+        \\    } else if n > 2 {
+        \\        roman(n - 1, (p.1, p.0), q)
+        \\    } else {
+        \\        roman(n - 1, p, (q.1, q.0))
+        \\    }
+        \\
+        \\main : I64
+        \\main = roman(4, (1, 2), (3, 4))
+    ;
+
+    var optimized = try lowerModule(allocator, source, .direct_call_wrappers);
+    defer optimized.deinit(allocator);
+
+    var unoptimized = try lowerModule(allocator, source, .none);
+    defer unoptimized.deinit(allocator);
+
+    // Adapted from the GHC code base's testsuite/tests/eyeball/spec-constr1.hs.
+    try std.testing.expect(try reachableProcShape(allocator, &optimized.lowered, multiTupleWorkerIsFullySpecialized));
+    try std.testing.expect(!try reachableProcShape(allocator, &optimized.lowered, multiTupleWorkerIsGeneric));
+
+    try std.testing.expect(!try reachableProcShape(allocator, &unoptimized.lowered, multiTupleWorkerIsFullySpecialized));
+    try std.testing.expect(try reachableProcShape(allocator, &unoptimized.lowered, multiTupleWorkerIsGeneric));
 }

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -168,7 +168,7 @@ fn liftModuleAfterSpecConstr(
             .root = check.CheckedArtifact.loweringView(&resources.checked_artifact),
             .imports = import_views,
         },
-        .{ .requests = resources.checked_artifact.root_requests.runtime_requests },
+        .{ .requests = resources.checked_artifact.root_requests.requests },
     );
     var mono_owned = true;
     errdefer if (mono_owned) mono.deinit();

--- a/src/lir/checked_pipeline.zig
+++ b/src/lir/checked_pipeline.zig
@@ -197,6 +197,10 @@ pub fn lowerCheckedModulesToLir(
     var lifted_owned = true;
     errdefer if (lifted_owned) lifted.deinit();
 
+    if (target.inline_mode != .none) {
+        try postcheck.MonotypeLifted.SpecConstr.run(allocator, &lifted);
+    }
+
     var solved = try postcheck.LambdaSolved.Solve.run(allocator, lifted);
     lifted_owned = false;
     lifted = undefined;

--- a/src/postcheck/mod.zig
+++ b/src/postcheck/mod.zig
@@ -15,6 +15,7 @@ pub const Monotype = struct {
 pub const MonotypeLifted = struct {
     pub const Ast = @import("monotype_lifted/ast.zig");
     pub const Lift = @import("monotype_lifted/lift.zig");
+    pub const SpecConstr = @import("monotype_lifted/spec_constr.zig");
 };
 /// Lifted IR with lambda-set relationships solved in the type store.
 pub const LambdaSolved = struct {

--- a/src/postcheck/monotype_lifted/ast.zig
+++ b/src/postcheck/monotype_lifted/ast.zig
@@ -194,9 +194,84 @@ pub const Program = struct {
         return id;
     }
 
+    pub fn addExpr(self: *Program, expr: Expr) std.mem.Allocator.Error!ExprId {
+        const id: ExprId = @enumFromInt(@as(u32, @intCast(self.exprs.items.len)));
+        try self.exprs.append(self.allocator, expr);
+        return id;
+    }
+
+    pub fn addPat(self: *Program, pat_: Pat) std.mem.Allocator.Error!PatId {
+        const id: PatId = @enumFromInt(@as(u32, @intCast(self.pats.items.len)));
+        try self.pats.append(self.allocator, pat_);
+        return id;
+    }
+
+    pub fn addStmt(self: *Program, stmt_: Stmt) std.mem.Allocator.Error!StmtId {
+        const id: StmtId = @enumFromInt(@as(u32, @intCast(self.stmts.items.len)));
+        try self.stmts.append(self.allocator, stmt_);
+        return id;
+    }
+
+    pub fn addLocal(self: *Program, symbol: Common.Symbol, ty: Type.TypeId) std.mem.Allocator.Error!LocalId {
+        return try self.addLocalWithBinder(symbol, ty, null);
+    }
+
+    pub fn addLocalWithBinder(
+        self: *Program,
+        symbol: Common.Symbol,
+        ty: Type.TypeId,
+        binder: ?check.CheckedModule.PatternBinderId,
+    ) std.mem.Allocator.Error!LocalId {
+        const id: LocalId = @enumFromInt(@as(u32, @intCast(self.locals.items.len)));
+        try self.locals.append(self.allocator, .{ .id = id, .symbol = symbol, .ty = ty, .binder = binder });
+        return id;
+    }
+
     pub fn addTypedLocalSpan(self: *Program, values: []const TypedLocal) std.mem.Allocator.Error!Span(TypedLocal) {
         const start: u32 = @intCast(self.typed_locals.items.len);
         try self.typed_locals.appendSlice(self.allocator, values);
+        return .{ .start = start, .len = @intCast(values.len) };
+    }
+
+    pub fn addExprSpan(self: *Program, ids: []const ExprId) std.mem.Allocator.Error!Span(ExprId) {
+        const start: u32 = @intCast(self.expr_ids.items.len);
+        try self.expr_ids.appendSlice(self.allocator, ids);
+        return .{ .start = start, .len = @intCast(ids.len) };
+    }
+
+    pub fn addPatSpan(self: *Program, ids: []const PatId) std.mem.Allocator.Error!Span(PatId) {
+        const start: u32 = @intCast(self.pat_ids.items.len);
+        try self.pat_ids.appendSlice(self.allocator, ids);
+        return .{ .start = start, .len = @intCast(ids.len) };
+    }
+
+    pub fn addStmtSpan(self: *Program, ids: []const StmtId) std.mem.Allocator.Error!Span(StmtId) {
+        const start: u32 = @intCast(self.stmt_ids.items.len);
+        try self.stmt_ids.appendSlice(self.allocator, ids);
+        return .{ .start = start, .len = @intCast(ids.len) };
+    }
+
+    pub fn addFieldExprSpan(self: *Program, values: []const FieldExpr) std.mem.Allocator.Error!Span(FieldExpr) {
+        const start: u32 = @intCast(self.field_exprs.items.len);
+        try self.field_exprs.appendSlice(self.allocator, values);
+        return .{ .start = start, .len = @intCast(values.len) };
+    }
+
+    pub fn addRecordDestructSpan(self: *Program, values: []const RecordDestruct) std.mem.Allocator.Error!Span(RecordDestruct) {
+        const start: u32 = @intCast(self.record_destructs.items.len);
+        try self.record_destructs.appendSlice(self.allocator, values);
+        return .{ .start = start, .len = @intCast(values.len) };
+    }
+
+    pub fn addBranchSpan(self: *Program, values: []const Branch) std.mem.Allocator.Error!Span(Branch) {
+        const start: u32 = @intCast(self.branches.items.len);
+        try self.branches.appendSlice(self.allocator, values);
+        return .{ .start = start, .len = @intCast(values.len) };
+    }
+
+    pub fn addIfBranchSpan(self: *Program, values: []const IfBranch) std.mem.Allocator.Error!Span(IfBranch) {
+        const start: u32 = @intCast(self.if_branches.items.len);
+        try self.if_branches.appendSlice(self.allocator, values);
         return .{ .start = start, .len = @intCast(values.len) };
     }
 

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -56,10 +56,6 @@
 //! - the loop uses `n` and `acc` directly instead of reading record fields;
 //! - later compiler stages have simple values to keep in registers.
 //!
-//! This pass does not turn tail-recursive helpers into loops. If an earlier pass
-//! has already produced this kind of `while` loop, the loop-state part of this
-//! rewrite applies to it too.
-//!
 //! This is Roc's version of the optimization described in
 //! "Call-pattern Specialisation for Haskell Programs" by Simon Peyton Jones:
 //!

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -1168,7 +1168,7 @@ const Cloner = struct {
     fn initForRewrite(pass: *Pass) Cloner {
         return .{
             .pass = pass,
-            .source_fn = @enumFromInt(0),
+            .source_fn = undefined, // initForRewrite never calls buildArgs, which is the only reader.
             .pattern = .{ .args = &.{} },
             .subst = std.AutoHashMap(Ast.LocalId, Value).init(pass.allocator),
             .binder_subst = std.AutoHashMap(check.CheckedModule.PatternBinderId, Value).init(pass.allocator),

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -2228,16 +2228,6 @@ const Cloner = struct {
         return try self.pass.program.addPatSpan(values);
     }
 
-    fn cloneStmtSpan(self: *Cloner, span: Ast.Span(Ast.StmtId)) Common.LowerError!Ast.Span(Ast.StmtId) {
-        const source = try self.pass.allocator.dupe(Ast.StmtId, self.pass.program.stmtSpan(span));
-        defer self.pass.allocator.free(source);
-
-        const values = try self.pass.allocator.alloc(Ast.StmtId, source.len);
-        defer self.pass.allocator.free(values);
-        for (source, 0..) |stmt, index| values[index] = try self.cloneStmt(stmt);
-        return try self.pass.program.addStmtSpan(values);
-    }
-
     fn cloneFieldExprSpan(self: *Cloner, span: Ast.Span(Ast.FieldExpr)) Common.LowerError!Ast.Span(Ast.FieldExpr) {
         const source = try self.pass.allocator.dupe(Ast.FieldExpr, self.pass.program.fieldExprSpan(span));
         defer self.pass.allocator.free(source);

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -310,6 +310,7 @@ const CallPattern = struct {
 const Spec = struct {
     pattern: CallPattern,
     fn_id: ?Ast.FnId = null,
+    written: bool = false,
 };
 
 const FnPlan = struct {
@@ -439,11 +440,19 @@ const Pass = struct {
     }
 
     fn createSpecializations(self: *Pass, original_fn_count: usize) Common.LowerError!void {
-        for (0..original_fn_count) |index| {
-            const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(index)));
-            var spec_index: usize = 0;
-            while (spec_index < self.plans[index].specs.items.len) : (spec_index += 1) {
-                try self.writeSpecialization(fn_id, spec_index);
+        var wrote_spec = true;
+        while (wrote_spec) {
+            wrote_spec = false;
+            for (0..original_fn_count) |index| {
+                const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(index)));
+                var spec_index: usize = 0;
+                while (spec_index < self.plans[index].specs.items.len) : (spec_index += 1) {
+                    if (self.plans[index].specs.items[spec_index].written) continue;
+
+                    self.plans[index].specs.items[spec_index].written = true;
+                    try self.writeSpecialization(fn_id, spec_index);
+                    wrote_spec = true;
+                }
             }
         }
     }
@@ -682,7 +691,7 @@ const Pass = struct {
 
         const pattern: CallPattern = .{ .args = shapes };
         for (self.plans[raw].specs.items) |spec| {
-            if (patternEql(spec.pattern, pattern)) return;
+            if (patternEql(self.program, spec.pattern, pattern)) return;
         }
 
         try self.plans[raw].specs.append(self.allocator, .{
@@ -713,7 +722,7 @@ const Pass = struct {
 
         const pattern: CallPattern = .{ .args = shapes };
         for (self.plans[raw].specs.items) |spec| {
-            if (patternEql(spec.pattern, pattern)) return;
+            if (patternEql(self.program, spec.pattern, pattern)) return;
         }
 
         const source_fn = self.program.fns.items[raw];
@@ -730,7 +739,6 @@ const Pass = struct {
             .body = .hosted,
             .ret = source_fn.ret,
         });
-        try self.writeSpecialization(fn_id, self.plans[raw].specs.items.len - 1);
     }
 
     fn writeSpecialization(self: *Pass, source_fn_id: Ast.FnId, spec_index: usize) Common.LowerError!void {
@@ -1420,6 +1428,58 @@ const Cloner = struct {
         };
     }
 
+    fn valueCanSubstitute(self: *Cloner, value: Value) bool {
+        return switch (value) {
+            .expr => |expr| self.exprCanSubstitute(expr),
+            .tag => |tag| blk: {
+                for (tag.payloads) |payload| {
+                    if (!self.valueCanSubstitute(payload)) break :blk false;
+                }
+                break :blk true;
+            },
+            .record => |record| blk: {
+                for (record.fields) |field| {
+                    if (!self.valueCanSubstitute(field.value)) break :blk false;
+                }
+                break :blk true;
+            },
+            .tuple => |tuple| blk: {
+                for (tuple.items) |item| {
+                    if (!self.valueCanSubstitute(item)) break :blk false;
+                }
+                break :blk true;
+            },
+            .nominal => |nominal| self.valueCanSubstitute(nominal.backing.*),
+            .callable => |callable| blk: {
+                for (callable.captures) |capture| {
+                    if (!self.valueCanSubstitute(capture)) break :blk false;
+                }
+                break :blk true;
+            },
+        };
+    }
+
+    fn exprCanSubstitute(self: *Cloner, expr_id: Ast.ExprId) bool {
+        return switch (self.pass.program.exprs.items[@intFromEnum(expr_id)].data) {
+            .local,
+            .unit,
+            .int_lit,
+            .frac_f32_lit,
+            .frac_f64_lit,
+            .dec_lit,
+            .str_lit,
+            .fn_ref,
+            => true,
+            .field_access => |field| self.exprCanSubstitute(field.receiver),
+            .tuple_access => |access| self.exprCanSubstitute(access.tuple),
+            else => false,
+        };
+    }
+
+    fn canInlineSubst(self: *Cloner, local: Ast.LocalId, value: Value, body: Ast.ExprId) bool {
+        return self.valueCanSubstitute(value) or localUseCountInExpr(self.pass.program, local, body) == 1;
+    }
+
     fn callableValue(self: *Cloner, ty: Type.TypeId, fn_id: Ast.FnId) Common.LowerError!Value {
         const fn_ = self.pass.program.fns.items[@intFromEnum(fn_id)];
         const source_captures = self.pass.program.typedLocalSpan(fn_.captures);
@@ -1502,7 +1562,7 @@ const Cloner = struct {
         const value = try self.cloneExprValue(let_.value);
         const value_expr = try self.materialize(value);
         const change_start = self.changes.items.len;
-        const bound = try self.bindPatToValue(let_.bind, value);
+        const bound = try self.bindPatToReusableValue(let_.bind, value);
         if (bound) {
             const rest = try self.cloneExprValue(let_.rest);
             self.restore(change_start);
@@ -1520,7 +1580,7 @@ const Cloner = struct {
         const value = try self.cloneExprValue(let_.value);
         const value_expr = try self.materialize(value);
         const change_start = self.changes.items.len;
-        const bound = try self.bindPatToValue(let_.bind, value);
+        const bound = try self.bindPatToReusableValue(let_.bind, value);
         const rest = if (bound) blk: {
             const cloned = try self.cloneExpr(let_.rest);
             self.restore(change_start);
@@ -1582,7 +1642,7 @@ const Cloner = struct {
 
                 const final_value = try self.cloneExprValue(block.final_expr);
                 const rest_ty = self.pass.program.exprs.items[@intFromEnum(let_.rest)].ty;
-                if (!try self.bindPatToValue(let_.bind, final_value)) {
+                if (!try self.bindPatToReusableValue(let_.bind, final_value)) {
                     if (try self.cloneDivergentAtType(block.final_expr, rest_ty)) |divergent| {
                         self.restore(change_start);
                         return try self.addExpr(.{ .ty = rest_ty, .data = .{ .block = .{
@@ -1605,7 +1665,7 @@ const Cloner = struct {
             else => {
                 const branch_value = try self.cloneExprValue(branch_body);
                 const change_start = self.changes.items.len;
-                if (!try self.bindPatToValue(let_.bind, branch_value)) {
+                if (!try self.bindPatToReusableValue(let_.bind, branch_value)) {
                     self.restore(change_start);
                     return null;
                 }
@@ -2033,10 +2093,33 @@ const Cloner = struct {
         defer self.pass.allocator.free(args);
         if (source_args.len != args.len) Common.invariant("callable call arity differed from lifted function arity");
 
+        const arg_values = try self.pass.allocator.alloc(Value, args.len);
+        defer self.pass.allocator.free(arg_values);
+        for (args, 0..) |arg_expr, index| {
+            arg_values[index] = try self.cloneExprValue(arg_expr);
+        }
+
         const source_captures = try self.pass.allocator.dupe(Ast.TypedLocal, self.pass.program.typedLocalSpan(source_fn.captures));
         defer self.pass.allocator.free(source_captures);
         if (source_captures.len != callable.captures.len) {
             Common.invariant("callable value capture count differed from lifted function capture count");
+        }
+
+        for (source_captures, callable.captures) |source_capture, capture_value| {
+            if (!self.canInlineSubst(source_capture.local, capture_value, body)) {
+                return .{ .expr = try self.addExpr(.{ .ty = ty, .data = .{ .call_value = .{
+                    .callee = try self.materialize(.{ .callable = callable }),
+                    .args = try self.valuesToExprSpan(arg_values),
+                } } }) };
+            }
+        }
+        for (source_args, arg_values) |source_arg, arg_value| {
+            if (!self.canInlineSubst(source_arg.local, arg_value, body)) {
+                return .{ .expr = try self.addExpr(.{ .ty = ty, .data = .{ .call_value = .{
+                    .callee = try self.materialize(.{ .callable = callable }),
+                    .args = try self.valuesToExprSpan(arg_values),
+                } } }) };
+            }
         }
 
         try self.inline_stack.append(self.pass.allocator, callable.fn_id);
@@ -2051,8 +2134,8 @@ const Cloner = struct {
         for (source_captures, callable.captures) |source_capture, capture_value| {
             try self.putSubst(source_capture.local, capture_value);
         }
-        for (source_args, args) |source_arg, arg_expr| {
-            try self.putSubst(source_arg.local, try self.cloneExprValue(arg_expr));
+        for (source_args, arg_values) |source_arg, arg_value| {
+            try self.putSubst(source_arg.local, arg_value);
         }
 
         return try self.cloneExprValue(body);
@@ -2079,6 +2162,21 @@ const Cloner = struct {
         defer self.pass.allocator.free(args);
         if (source_args.len != args.len) Common.invariant("direct call arity differed from lifted function arity");
 
+        const arg_values = try self.pass.allocator.alloc(Value, args.len);
+        defer self.pass.allocator.free(arg_values);
+        for (args, 0..) |arg_expr, index| {
+            arg_values[index] = try self.cloneExprValue(arg_expr);
+        }
+
+        for (source_args, arg_values) |source_arg, arg_value| {
+            if (!self.canInlineSubst(source_arg.local, arg_value, body)) {
+                return .{ .expr = try self.addExpr(.{ .ty = self.pass.program.exprs.items[@intFromEnum(original_expr)].ty, .data = .{ .call_proc = .{
+                    .callee = .{ .lifted = callee },
+                    .args = try self.valuesToExprSpan(arg_values),
+                } } }) };
+            }
+        }
+
         try self.inline_stack.append(self.pass.allocator, callee);
         defer {
             const popped = self.inline_stack.pop() orelse Common.invariant("call-pattern inline stack underflow");
@@ -2092,11 +2190,17 @@ const Cloner = struct {
         defer self.pass.allocator.free(captures);
         for (captures) |capture| {
             if (self.subst.get(capture.local)) |value| {
+                if (!self.canInlineSubst(capture.local, value, body)) {
+                    return .{ .expr = try self.addExpr(.{ .ty = self.pass.program.exprs.items[@intFromEnum(original_expr)].ty, .data = .{ .call_proc = .{
+                        .callee = .{ .lifted = callee },
+                        .args = try self.valuesToExprSpan(arg_values),
+                    } } }) };
+                }
                 try self.putSubst(capture.local, value);
             }
         }
-        for (source_args, args) |source_arg, arg_expr| {
-            try self.putSubst(source_arg.local, try self.cloneExprValue(arg_expr));
+        for (source_args, arg_values) |source_arg, arg_value| {
+            try self.putSubst(source_arg.local, arg_value);
         }
 
         return try self.cloneExprValue(body);
@@ -2159,6 +2263,11 @@ const Cloner = struct {
         }
     }
 
+    fn bindPatToReusableValue(self: *Cloner, pat_id: Ast.PatId, value: Value) Common.LowerError!bool {
+        if (!self.valueCanSubstitute(value)) return false;
+        return try self.bindPatToValue(pat_id, value);
+    }
+
     fn clonePat(self: *Cloner, pat_id: Ast.PatId) Allocator.Error!Ast.PatId {
         const pat = self.pass.program.pats.items[@intFromEnum(pat_id)];
         const data: Ast.PatData = switch (pat.data) {
@@ -2190,7 +2299,7 @@ const Cloner = struct {
             .let_ => |let_| blk: {
                 const value = try self.cloneExprValue(let_.value);
                 const value_expr = try self.materialize(value);
-                _ = try self.bindPatToValue(let_.pat, value);
+                _ = try self.bindPatToReusableValue(let_.pat, value);
                 break :blk .{ .let_ = .{
                     .pat = try self.clonePat(let_.pat),
                     .value = value_expr,
@@ -2580,6 +2689,90 @@ fn localExpr(program: *const Ast.Program, expr_id: Ast.ExprId) ?Ast.LocalId {
     };
 }
 
+fn localUseCountInExpr(program: *const Ast.Program, local: Ast.LocalId, expr_id: Ast.ExprId) usize {
+    return switch (program.exprs.items[@intFromEnum(expr_id)].data) {
+        .local => |seen| if (seen == local) 1 else 0,
+        .unit,
+        .int_lit,
+        .frac_f32_lit,
+        .frac_f64_lit,
+        .dec_lit,
+        .str_lit,
+        .fn_ref,
+        .crash,
+        => 0,
+        .list,
+        .tuple,
+        => |items| localUseCountInExprSpan(program, local, items),
+        .record => |fields| blk: {
+            var count: usize = 0;
+            for (program.fieldExprSpan(fields)) |field| count += localUseCountInExpr(program, local, field.value);
+            break :blk count;
+        },
+        .tag => |tag| localUseCountInExprSpan(program, local, tag.payloads),
+        .nominal,
+        .return_,
+        .dbg,
+        .expect,
+        => |child| localUseCountInExpr(program, local, child),
+        .let_ => |let_| localUseCountInExpr(program, local, let_.value) + localUseCountInExpr(program, local, let_.rest),
+        .lambda,
+        .def_ref,
+        .fn_def,
+        => 0,
+        .call_value => |call| localUseCountInExpr(program, local, call.callee) + localUseCountInExprSpan(program, local, call.args),
+        .call_proc => |call| localUseCountInExprSpan(program, local, call.args),
+        .low_level => |call| localUseCountInExprSpan(program, local, call.args),
+        .field_access => |field| localUseCountInExpr(program, local, field.receiver),
+        .tuple_access => |access| localUseCountInExpr(program, local, access.tuple),
+        .structural_eq => |eq| localUseCountInExpr(program, local, eq.lhs) + localUseCountInExpr(program, local, eq.rhs),
+        .match_ => |match| blk: {
+            var count = localUseCountInExpr(program, local, match.scrutinee);
+            for (program.branchSpan(match.branches)) |branch| {
+                if (branch.guard) |guard| count += localUseCountInExpr(program, local, guard);
+                count += localUseCountInExpr(program, local, branch.body);
+            }
+            break :blk count;
+        },
+        .if_ => |if_| blk: {
+            var count: usize = 0;
+            for (program.ifBranchSpan(if_.branches)) |branch| {
+                count += localUseCountInExpr(program, local, branch.cond);
+                count += localUseCountInExpr(program, local, branch.body);
+            }
+            count += localUseCountInExpr(program, local, if_.final_else);
+            break :blk count;
+        },
+        .block => |block| blk: {
+            var count: usize = 0;
+            for (program.stmtSpan(block.statements)) |stmt| count += localUseCountInStmt(program, local, stmt);
+            count += localUseCountInExpr(program, local, block.final_expr);
+            break :blk count;
+        },
+        .loop_ => |loop| localUseCountInExprSpan(program, local, loop.initial_values) + localUseCountInExpr(program, local, loop.body),
+        .break_ => |maybe| if (maybe) |value| localUseCountInExpr(program, local, value) else 0,
+        .continue_ => |continue_| localUseCountInExprSpan(program, local, continue_.values),
+    };
+}
+
+fn localUseCountInExprSpan(program: *const Ast.Program, local: Ast.LocalId, span: Ast.Span(Ast.ExprId)) usize {
+    var count: usize = 0;
+    for (program.exprSpan(span)) |expr| count += localUseCountInExpr(program, local, expr);
+    return count;
+}
+
+fn localUseCountInStmt(program: *const Ast.Program, local: Ast.LocalId, stmt_id: Ast.StmtId) usize {
+    return switch (program.stmts.items[@intFromEnum(stmt_id)]) {
+        .let_ => |let_| localUseCountInExpr(program, local, let_.value),
+        .expr,
+        .expect,
+        .dbg,
+        .return_,
+        => |expr| localUseCountInExpr(program, local, expr),
+        .crash => 0,
+    };
+}
+
 fn canReadFieldsFromExpr(program: *const Ast.Program, expr_id: Ast.ExprId) bool {
     return switch (program.exprs.items[@intFromEnum(expr_id)].data) {
         .local,
@@ -2612,15 +2805,15 @@ fn valueType(program: *const Ast.Program, value: Value) Type.TypeId {
     };
 }
 
-fn patternEql(lhs: CallPattern, rhs: CallPattern) bool {
+fn patternEql(program: *const Ast.Program, lhs: CallPattern, rhs: CallPattern) bool {
     if (lhs.args.len != rhs.args.len) return false;
     for (lhs.args, rhs.args) |lhs_arg, rhs_arg| {
-        if (!shapeEql(lhs_arg, rhs_arg)) return false;
+        if (!shapeEql(program, lhs_arg, rhs_arg)) return false;
     }
     return true;
 }
 
-fn shapeEql(lhs: Shape, rhs: Shape) bool {
+fn shapeEql(program: *const Ast.Program, lhs: Shape, rhs: Shape) bool {
     if (std.meta.activeTag(lhs) != std.meta.activeTag(rhs)) return false;
     return switch (lhs) {
         .any => |lhs_ty| lhs_ty == rhs.any,
@@ -2628,7 +2821,7 @@ fn shapeEql(lhs: Shape, rhs: Shape) bool {
             const rhs_tag = rhs.tag;
             if (lhs_tag.ty != rhs_tag.ty or lhs_tag.name != rhs_tag.name or lhs_tag.payloads.len != rhs_tag.payloads.len) break :blk false;
             for (lhs_tag.payloads, rhs_tag.payloads) |lhs_payload, rhs_payload| {
-                if (!shapeEql(lhs_payload, rhs_payload)) break :blk false;
+                if (!shapeEql(program, lhs_payload, rhs_payload)) break :blk false;
             }
             break :blk true;
         },
@@ -2636,7 +2829,7 @@ fn shapeEql(lhs: Shape, rhs: Shape) bool {
             const rhs_record = rhs.record;
             if (lhs_record.ty != rhs_record.ty or lhs_record.fields.len != rhs_record.fields.len) break :blk false;
             for (lhs_record.fields, rhs_record.fields) |lhs_field, rhs_field| {
-                if (lhs_field.name != rhs_field.name or !shapeEql(lhs_field.shape, rhs_field.shape)) break :blk false;
+                if (lhs_field.name != rhs_field.name or !shapeEql(program, lhs_field.shape, rhs_field.shape)) break :blk false;
             }
             break :blk true;
         },
@@ -2644,24 +2837,24 @@ fn shapeEql(lhs: Shape, rhs: Shape) bool {
             const rhs_tuple = rhs.tuple;
             if (lhs_tuple.ty != rhs_tuple.ty or lhs_tuple.items.len != rhs_tuple.items.len) break :blk false;
             for (lhs_tuple.items, rhs_tuple.items) |lhs_item, rhs_item| {
-                if (!shapeEql(lhs_item, rhs_item)) break :blk false;
+                if (!shapeEql(program, lhs_item, rhs_item)) break :blk false;
             }
             break :blk true;
         },
         .nominal => |lhs_nominal| {
             const rhs_nominal = rhs.nominal;
-            return lhs_nominal.ty == rhs_nominal.ty and shapeEql(lhs_nominal.backing.*, rhs_nominal.backing.*);
+            return lhs_nominal.ty == rhs_nominal.ty and shapeEql(program, lhs_nominal.backing.*, rhs_nominal.backing.*);
         },
         .callable => |lhs_callable| blk: {
             const rhs_callable = rhs.callable;
             if (lhs_callable.ty != rhs_callable.ty or
-                lhs_callable.fn_id != rhs_callable.fn_id or
+                !callableTargetMatches(program, lhs_callable.fn_id, rhs_callable.fn_id) or
                 lhs_callable.captures.len != rhs_callable.captures.len)
             {
                 break :blk false;
             }
             for (lhs_callable.captures, rhs_callable.captures) |lhs_capture, rhs_capture| {
-                if (!shapeEql(lhs_capture, rhs_capture)) break :blk false;
+                if (!shapeEql(program, lhs_capture, rhs_capture)) break :blk false;
             }
             break :blk true;
         },

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -322,13 +322,13 @@ const FnPlan = struct {
     }
 };
 
-const BindingKey = union(enum) {
+const BindingTarget = union(enum) {
     local: Ast.LocalId,
     binder: check.CheckedModule.PatternBinderId,
 };
 
 const BindingChange = struct {
-    key: BindingKey,
+    key: BindingTarget,
     previous: ?Value,
 };
 
@@ -1375,7 +1375,6 @@ const Cloner = struct {
                     return .{ .expr = try self.cloneExprPlain(expr_id) };
                 }
                 return try self.inlineDirectCallValue(
-                    expr.ty,
                     Ast.callProcCallee(call),
                     call.args,
                     expr_id,
@@ -2061,7 +2060,6 @@ const Cloner = struct {
 
     fn inlineDirectCallValue(
         self: *Cloner,
-        ty: Type.TypeId,
         callee: Ast.FnId,
         args_span: Ast.Span(Ast.ExprId),
         original_expr: Ast.ExprId,
@@ -2101,7 +2099,6 @@ const Cloner = struct {
             try self.putSubst(source_arg.local, try self.cloneExprValue(arg_expr));
         }
 
-        _ = ty;
         return try self.cloneExprValue(body);
     }
 

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -1482,10 +1482,6 @@ const Cloner = struct {
         };
     }
 
-    fn canInlineSubst(self: *Cloner, local: Ast.LocalId, value: Value, body: Ast.ExprId) bool {
-        return self.valueCanSubstitute(value) or localUseCountInExpr(self.pass.program, local, body) == 1;
-    }
-
     fn callableValue(self: *Cloner, ty: Type.TypeId, fn_id: Ast.FnId) Common.LowerError!Value {
         const fn_ = self.pass.program.fns.items[@intFromEnum(fn_id)];
         const source_captures = self.pass.program.typedLocalSpan(fn_.captures);
@@ -2025,7 +2021,8 @@ const Cloner = struct {
             defer pending_lets.deinit(self.pass.allocator);
 
             const change_start = self.changes.items.len;
-            if (try self.bindPatToMatchValue(branch.pat, scrutinee, branch.body, &pending_lets) == null) {
+            const unsafe_count = self.unsafeLeafCount(scrutinee);
+            if (try self.bindPatToMatchValue(branch.pat, scrutinee, branch.body, unsafe_count, &pending_lets) == null) {
                 Common.invariant("known constructor match changed after reusable payload binding");
             }
             const body = try self.cloneExprValue(branch.body);
@@ -2040,23 +2037,25 @@ const Cloner = struct {
         pat_id: Ast.PatId,
         value: Value,
         body: Ast.ExprId,
+        unsafe_count: usize,
         pending_lets: *std.ArrayList(PendingLet),
     ) Common.LowerError!?Value {
         const pat = self.pass.program.pats.items[@intFromEnum(pat_id)];
         switch (pat.data) {
             .bind => |local| {
-                const prepared = try self.valueForMatchLocal(local, value, body, pending_lets);
+                const prepared = try self.valueForMatchLocal(local, value, body, unsafe_count, pending_lets);
                 try self.putSubst(local, prepared);
                 return prepared;
             },
             .wildcard => return try self.makeReusableForMatch(value, pending_lets),
             .as => |as| {
                 const as_uses = localUseCountInExpr(self.pass.program, as.local, body);
-                const base = if (self.valueCanSubstitute(value) or as_uses == 1)
+                const base = if (self.valueCanSubstitute(value) or
+                    (unsafe_count == 1 and as_uses == 1 and localUseBeforeEffect(self.pass.program, as.local, body)))
                     value
                 else
                     try self.makeReusableForMatch(value, pending_lets);
-                const prepared = (try self.bindPatToMatchValue(as.pattern, base, body, pending_lets)) orelse return null;
+                const prepared = (try self.bindPatToMatchValue(as.pattern, base, body, unsafe_count, pending_lets)) orelse return null;
                 try self.putSubst(as.local, prepared);
                 return prepared;
             },
@@ -2066,7 +2065,7 @@ const Cloner = struct {
                 const prepared_fields = try self.pass.arena.allocator().alloc(FieldValue, record.fields.len);
                 for (record.fields, 0..) |field, index| {
                     if (recordPatField(fields, field.name)) |field_pat| {
-                        const prepared = (try self.bindPatToMatchValue(field_pat, field.value, body, pending_lets)) orelse return null;
+                        const prepared = (try self.bindPatToMatchValue(field_pat, field.value, body, unsafe_count, pending_lets)) orelse return null;
                         prepared_fields[index] = .{
                             .name = field.name,
                             .value = prepared,
@@ -2089,7 +2088,7 @@ const Cloner = struct {
                 if (pats.len != tuple.items.len) return null;
                 const items = try self.pass.arena.allocator().alloc(Value, tuple.items.len);
                 for (pats, tuple.items, 0..) |child_pat, child_value, index| {
-                    items[index] = (try self.bindPatToMatchValue(child_pat, child_value, body, pending_lets)) orelse return null;
+                    items[index] = (try self.bindPatToMatchValue(child_pat, child_value, body, unsafe_count, pending_lets)) orelse return null;
                 }
                 return Value{ .tuple = .{
                     .ty = tuple.ty,
@@ -2103,7 +2102,7 @@ const Cloner = struct {
                 if (pats.len != tag.payloads.len) return null;
                 const payloads = try self.pass.arena.allocator().alloc(Value, tag.payloads.len);
                 for (pats, tag.payloads, 0..) |child_pat, child_value, index| {
-                    payloads[index] = (try self.bindPatToMatchValue(child_pat, child_value, body, pending_lets)) orelse return null;
+                    payloads[index] = (try self.bindPatToMatchValue(child_pat, child_value, body, unsafe_count, pending_lets)) orelse return null;
                 }
                 return Value{ .tag = .{
                     .ty = tag.ty,
@@ -2117,7 +2116,7 @@ const Cloner = struct {
                     else => return null,
                 };
                 const backing = try self.pass.arena.allocator().create(Value);
-                backing.* = (try self.bindPatToMatchValue(backing_pat, nominal.backing.*, body, pending_lets)) orelse return null;
+                backing.* = (try self.bindPatToMatchValue(backing_pat, nominal.backing.*, body, unsafe_count, pending_lets)) orelse return null;
                 return Value{ .nominal = .{
                     .ty = nominal.ty,
                     .backing = backing,
@@ -2137,11 +2136,60 @@ const Cloner = struct {
         local: Ast.LocalId,
         value: Value,
         body: Ast.ExprId,
+        unsafe_count: usize,
         pending_lets: *std.ArrayList(PendingLet),
     ) Common.LowerError!Value {
         const uses = localUseCountInExpr(self.pass.program, local, body);
-        if (self.valueCanSubstitute(value) or uses == 1) return value;
+        if (self.valueCanSubstitute(value) or
+            (unsafe_count == 1 and uses == 1 and localUseBeforeEffect(self.pass.program, local, body)))
+        {
+            return value;
+        }
         return try self.makeReusableForMatch(value, pending_lets);
+    }
+
+    fn valueForInlineLocal(
+        self: *Cloner,
+        local: Ast.LocalId,
+        value: Value,
+        body: Ast.ExprId,
+        unsafe_count: usize,
+        pending_lets: *std.ArrayList(PendingLet),
+    ) Common.LowerError!Value {
+        const uses = localUseCountInExpr(self.pass.program, local, body);
+        if (self.valueCanSubstitute(value) or
+            (unsafe_count == 1 and uses == 1 and localUseBeforeEffect(self.pass.program, local, body)))
+        {
+            return value;
+        }
+        return try self.makeReusableForMatch(value, pending_lets);
+    }
+
+    fn unsafeLeafCount(self: *Cloner, value: Value) usize {
+        return switch (value) {
+            .expr => |expr| if (self.exprCanSubstitute(expr)) 0 else 1,
+            .tag => |tag| blk: {
+                var count: usize = 0;
+                for (tag.payloads) |payload| count += self.unsafeLeafCount(payload);
+                break :blk count;
+            },
+            .record => |record| blk: {
+                var count: usize = 0;
+                for (record.fields) |field| count += self.unsafeLeafCount(field.value);
+                break :blk count;
+            },
+            .tuple => |tuple| blk: {
+                var count: usize = 0;
+                for (tuple.items) |item| count += self.unsafeLeafCount(item);
+                break :blk count;
+            },
+            .nominal => |nominal| self.unsafeLeafCount(nominal.backing.*),
+            .callable => |callable| blk: {
+                var count: usize = 0;
+                for (callable.captures) |capture| count += self.unsafeLeafCount(capture);
+                break :blk count;
+            },
+        };
     }
 
     fn makeReusableForMatch(self: *Cloner, value: Value, pending_lets: *std.ArrayList(PendingLet)) Common.LowerError!Value {
@@ -2307,33 +2355,39 @@ const Cloner = struct {
         defer self.pass.allocator.free(args);
         if (source_args.len != args.len) Common.invariant("callable call arity differed from lifted function arity");
 
-        const arg_values = try self.pass.allocator.alloc(Value, args.len);
-        defer self.pass.allocator.free(arg_values);
-        for (args, 0..) |arg_expr, index| {
-            arg_values[index] = try self.cloneExprValue(arg_expr);
-        }
-
         const source_captures = try self.pass.allocator.dupe(Ast.TypedLocal, self.pass.program.typedLocalSpan(source_fn.captures));
         defer self.pass.allocator.free(source_captures);
         if (source_captures.len != callable.captures.len) {
             Common.invariant("callable value capture count differed from lifted function capture count");
         }
 
-        for (source_captures, callable.captures) |source_capture, capture_value| {
-            if (!self.canInlineSubst(source_capture.local, capture_value, body)) {
-                return .{ .expr = try self.addExpr(.{ .ty = ty, .data = .{ .call_value = .{
-                    .callee = try self.materialize(.{ .callable = callable }),
-                    .args = try self.valuesToExprSpan(arg_values),
-                } } }) };
-            }
+        var pending_lets = std.ArrayList(PendingLet).empty;
+        defer pending_lets.deinit(self.pass.allocator);
+
+        const change_start = self.changes.items.len;
+        defer self.restore(change_start);
+
+        const prepared_captures = try self.pass.allocator.alloc(Value, callable.captures.len);
+        defer self.pass.allocator.free(prepared_captures);
+        for (source_captures, callable.captures, 0..) |source_capture, capture_value, index| {
+            prepared_captures[index] = try self.makeReusableForMatch(capture_value, &pending_lets);
+            try self.putSubst(source_capture.local, prepared_captures[index]);
         }
-        for (source_args, arg_values) |source_arg, arg_value| {
-            if (!self.canInlineSubst(source_arg.local, arg_value, body)) {
-                return .{ .expr = try self.addExpr(.{ .ty = ty, .data = .{ .call_value = .{
-                    .callee = try self.materialize(.{ .callable = callable }),
-                    .args = try self.valuesToExprSpan(arg_values),
-                } } }) };
-            }
+
+        const arg_values = try self.pass.allocator.alloc(Value, args.len);
+        defer self.pass.allocator.free(arg_values);
+        for (args, 0..) |arg_expr, index| {
+            arg_values[index] = try self.cloneExprValue(arg_expr);
+        }
+
+        var unsafe_count: usize = 0;
+        for (prepared_captures) |capture_value| unsafe_count += self.unsafeLeafCount(capture_value);
+        for (arg_values) |arg_value| unsafe_count += self.unsafeLeafCount(arg_value);
+
+        const prepared_args = try self.pass.allocator.alloc(Value, arg_values.len);
+        defer self.pass.allocator.free(prepared_args);
+        for (source_args, arg_values, 0..) |source_arg, arg_value, index| {
+            prepared_args[index] = try self.valueForInlineLocal(source_arg.local, arg_value, body, unsafe_count, &pending_lets);
         }
 
         try self.inline_stack.append(self.pass.allocator, callable.fn_id);
@@ -2342,17 +2396,11 @@ const Cloner = struct {
             if (popped != callable.fn_id) Common.invariant("call-pattern inline stack was corrupted");
         }
 
-        const change_start = self.changes.items.len;
-        defer self.restore(change_start);
-
-        for (source_captures, callable.captures) |source_capture, capture_value| {
-            try self.putSubst(source_capture.local, capture_value);
-        }
-        for (source_args, arg_values) |source_arg, arg_value| {
+        for (source_args, prepared_args) |source_arg, arg_value| {
             try self.putSubst(source_arg.local, arg_value);
         }
 
-        return try self.cloneExprValue(body);
+        return try self.wrapPendingLets(try self.cloneExprValue(body), pending_lets.items);
     }
 
     fn inlineDirectCallValue(
@@ -2376,26 +2424,8 @@ const Cloner = struct {
         defer self.pass.allocator.free(args);
         if (source_args.len != args.len) Common.invariant("direct call arity differed from lifted function arity");
 
-        const arg_values = try self.pass.allocator.alloc(Value, args.len);
-        defer self.pass.allocator.free(arg_values);
-        for (args, 0..) |arg_expr, index| {
-            arg_values[index] = try self.cloneExprValue(arg_expr);
-        }
-
-        for (source_args, arg_values) |source_arg, arg_value| {
-            if (!self.canInlineSubst(source_arg.local, arg_value, body)) {
-                return .{ .expr = try self.addExpr(.{ .ty = self.pass.program.exprs.items[@intFromEnum(original_expr)].ty, .data = .{ .call_proc = .{
-                    .callee = .{ .lifted = callee },
-                    .args = try self.valuesToExprSpan(arg_values),
-                } } }) };
-            }
-        }
-
-        try self.inline_stack.append(self.pass.allocator, callee);
-        defer {
-            const popped = self.inline_stack.pop() orelse Common.invariant("call-pattern inline stack underflow");
-            if (popped != callee) Common.invariant("call-pattern inline stack was corrupted");
-        }
+        var pending_lets = std.ArrayList(PendingLet).empty;
+        defer pending_lets.deinit(self.pass.allocator);
 
         const change_start = self.changes.items.len;
         defer self.restore(change_start);
@@ -2404,20 +2434,39 @@ const Cloner = struct {
         defer self.pass.allocator.free(captures);
         for (captures) |capture| {
             if (self.subst.get(capture.local)) |value| {
-                if (!self.canInlineSubst(capture.local, value, body)) {
-                    return .{ .expr = try self.addExpr(.{ .ty = self.pass.program.exprs.items[@intFromEnum(original_expr)].ty, .data = .{ .call_proc = .{
-                        .callee = .{ .lifted = callee },
-                        .args = try self.valuesToExprSpan(arg_values),
-                    } } }) };
-                }
-                try self.putSubst(capture.local, value);
+                try self.putSubst(capture.local, try self.makeReusableForMatch(value, &pending_lets));
             }
         }
-        for (source_args, arg_values) |source_arg, arg_value| {
+
+        const arg_values = try self.pass.allocator.alloc(Value, args.len);
+        defer self.pass.allocator.free(arg_values);
+        for (args, 0..) |arg_expr, index| {
+            arg_values[index] = try self.cloneExprValue(arg_expr);
+        }
+
+        var unsafe_count: usize = 0;
+        for (arg_values) |arg_value| unsafe_count += self.unsafeLeafCount(arg_value);
+        for (captures) |capture| {
+            if (self.subst.get(capture.local)) |value| unsafe_count += self.unsafeLeafCount(value);
+        }
+
+        const prepared_args = try self.pass.allocator.alloc(Value, arg_values.len);
+        defer self.pass.allocator.free(prepared_args);
+        for (source_args, arg_values, 0..) |source_arg, arg_value, index| {
+            prepared_args[index] = try self.valueForInlineLocal(source_arg.local, arg_value, body, unsafe_count, &pending_lets);
+        }
+
+        try self.inline_stack.append(self.pass.allocator, callee);
+        defer {
+            const popped = self.inline_stack.pop() orelse Common.invariant("call-pattern inline stack underflow");
+            if (popped != callee) Common.invariant("call-pattern inline stack was corrupted");
+        }
+
+        for (source_args, prepared_args) |source_arg, arg_value| {
             try self.putSubst(source_arg.local, arg_value);
         }
 
-        return try self.cloneExprValue(body);
+        return try self.wrapPendingLets(try self.cloneExprValue(body), pending_lets.items);
     }
 
     fn bindPatToValue(self: *Cloner, pat_id: Ast.PatId, value: Value) Common.LowerError!bool {
@@ -2985,6 +3034,153 @@ fn localUseCountInStmt(program: *const Ast.Program, local: Ast.LocalId, stmt_id:
         => |expr| localUseCountInExpr(program, local, expr),
         .crash => 0,
     };
+}
+
+const LocalUseScan = struct {
+    seen_effect: bool = false,
+    found_before_effect: bool = false,
+    found_after_effect: bool = false,
+};
+
+fn localUseBeforeEffect(program: *const Ast.Program, local: Ast.LocalId, expr_id: Ast.ExprId) bool {
+    var scan: LocalUseScan = .{};
+    scanLocalUseInExpr(program, local, expr_id, &scan);
+    return scan.found_before_effect and !scan.found_after_effect;
+}
+
+fn scanLocalUseInExpr(program: *const Ast.Program, local: Ast.LocalId, expr_id: Ast.ExprId, scan: *LocalUseScan) void {
+    const expr = program.exprs.items[@intFromEnum(expr_id)];
+    switch (expr.data) {
+        .local => |seen| {
+            if (seen == local) {
+                if (scan.seen_effect) {
+                    scan.found_after_effect = true;
+                } else {
+                    scan.found_before_effect = true;
+                }
+            }
+        },
+        .unit,
+        .int_lit,
+        .frac_f32_lit,
+        .frac_f64_lit,
+        .dec_lit,
+        .str_lit,
+        .fn_ref,
+        => {},
+        .crash => scan.seen_effect = true,
+        .list,
+        .tuple,
+        => |items| scanLocalUseInExprSpan(program, local, items, scan),
+        .record => |fields| {
+            for (program.fieldExprSpan(fields)) |field| scanLocalUseInExpr(program, local, field.value, scan);
+        },
+        .tag => |tag| scanLocalUseInExprSpan(program, local, tag.payloads, scan),
+        .nominal => |child| scanLocalUseInExpr(program, local, child, scan),
+        .return_ => |child| {
+            scanLocalUseInExpr(program, local, child, scan);
+            scan.seen_effect = true;
+        },
+        .dbg,
+        .expect,
+        => |child| {
+            scanLocalUseInExpr(program, local, child, scan);
+            scan.seen_effect = true;
+        },
+        .let_ => |let_| {
+            scanLocalUseInExpr(program, local, let_.value, scan);
+            scanLocalUseInExpr(program, local, let_.rest, scan);
+        },
+        .lambda,
+        .def_ref,
+        .fn_def,
+        => {},
+        .call_value => |call| {
+            scanLocalUseInExpr(program, local, call.callee, scan);
+            scanLocalUseInExprSpan(program, local, call.args, scan);
+            scan.seen_effect = true;
+        },
+        .call_proc => |call| {
+            scanLocalUseInExprSpan(program, local, call.args, scan);
+            scan.seen_effect = true;
+        },
+        .low_level => |call| {
+            scanLocalUseInExprSpan(program, local, call.args, scan);
+            scan.seen_effect = true;
+        },
+        .field_access => |field| scanLocalUseInExpr(program, local, field.receiver, scan),
+        .tuple_access => |access| scanLocalUseInExpr(program, local, access.tuple, scan),
+        .structural_eq => |eq| {
+            scanLocalUseInExpr(program, local, eq.lhs, scan);
+            scanLocalUseInExpr(program, local, eq.rhs, scan);
+            scan.seen_effect = true;
+        },
+        .match_ => |match| {
+            scanLocalUseInExpr(program, local, match.scrutinee, scan);
+            for (program.branchSpan(match.branches)) |branch| {
+                var branch_scan = scan.*;
+                if (branch.guard) |guard| scanLocalUseInExpr(program, local, guard, &branch_scan);
+                scanLocalUseInExpr(program, local, branch.body, &branch_scan);
+                scan.found_before_effect = scan.found_before_effect or branch_scan.found_before_effect;
+                scan.found_after_effect = scan.found_after_effect or branch_scan.found_after_effect;
+                scan.seen_effect = scan.seen_effect or branch_scan.seen_effect;
+            }
+        },
+        .if_ => |if_| {
+            for (program.ifBranchSpan(if_.branches)) |branch| {
+                scanLocalUseInExpr(program, local, branch.cond, scan);
+                var branch_scan = scan.*;
+                scanLocalUseInExpr(program, local, branch.body, &branch_scan);
+                scan.found_before_effect = scan.found_before_effect or branch_scan.found_before_effect;
+                scan.found_after_effect = scan.found_after_effect or branch_scan.found_after_effect;
+                scan.seen_effect = scan.seen_effect or branch_scan.seen_effect;
+            }
+            scanLocalUseInExpr(program, local, if_.final_else, scan);
+        },
+        .block => |block| {
+            for (program.stmtSpan(block.statements)) |stmt| scanLocalUseInStmt(program, local, stmt, scan);
+            scanLocalUseInExpr(program, local, block.final_expr, scan);
+        },
+        .loop_ => |loop| {
+            scanLocalUseInExprSpan(program, local, loop.initial_values, scan);
+            scanLocalUseInExpr(program, local, loop.body, scan);
+        },
+        .break_ => |maybe| {
+            if (maybe) |value| scanLocalUseInExpr(program, local, value, scan);
+            scan.seen_effect = true;
+        },
+        .continue_ => |continue_| {
+            scanLocalUseInExprSpan(program, local, continue_.values, scan);
+            scan.seen_effect = true;
+        },
+    }
+}
+
+fn scanLocalUseInExprSpan(
+    program: *const Ast.Program,
+    local: Ast.LocalId,
+    span: Ast.Span(Ast.ExprId),
+    scan: *LocalUseScan,
+) void {
+    for (program.exprSpan(span)) |expr| scanLocalUseInExpr(program, local, expr, scan);
+}
+
+fn scanLocalUseInStmt(program: *const Ast.Program, local: Ast.LocalId, stmt_id: Ast.StmtId, scan: *LocalUseScan) void {
+    switch (program.stmts.items[@intFromEnum(stmt_id)]) {
+        .let_ => |let_| scanLocalUseInExpr(program, local, let_.value, scan),
+        .expr => |expr| scanLocalUseInExpr(program, local, expr, scan),
+        .expect,
+        .dbg,
+        => |expr| {
+            scanLocalUseInExpr(program, local, expr, scan);
+            scan.seen_effect = true;
+        },
+        .return_ => |expr| {
+            scanLocalUseInExpr(program, local, expr, scan);
+            scan.seen_effect = true;
+        },
+        .crash => scan.seen_effect = true,
+    }
 }
 
 fn canReadFieldsFromExpr(program: *const Ast.Program, expr_id: Ast.ExprId) bool {

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -333,6 +333,12 @@ const BindingChange = struct {
     previous: ?Value,
 };
 
+const PendingLet = struct {
+    local: Ast.LocalId,
+    ty: Type.TypeId,
+    value: Ast.ExprId,
+};
+
 const LoopPattern = struct {
     values: []const Shape,
 };
@@ -2009,19 +2015,227 @@ const Cloner = struct {
     fn simplifyKnownMatchValue(self: *Cloner, scrutinee: Value, branches_span: Ast.Span(Ast.Branch)) Common.LowerError!?Value {
         if (scrutinee == .expr) return null;
         for (self.pass.program.branchSpan(branches_span)) |branch| {
+            const match_change_start = self.changes.items.len;
+            const matches = try self.bindPatToValue(branch.pat, scrutinee);
+            self.restore(match_change_start);
+            if (!matches) continue;
+            if (branch.guard != null) return null;
+
+            var pending_lets = std.ArrayList(PendingLet).empty;
+            defer pending_lets.deinit(self.pass.allocator);
+
             const change_start = self.changes.items.len;
-            if (try self.bindPatToValue(branch.pat, scrutinee)) {
-                if (branch.guard != null) {
-                    self.restore(change_start);
-                    return null;
-                }
-                const body = try self.cloneExprValue(branch.body);
-                self.restore(change_start);
-                return body;
+            if (try self.bindPatToMatchValue(branch.pat, scrutinee, branch.body, &pending_lets) == null) {
+                Common.invariant("known constructor match changed after reusable payload binding");
             }
+            const body = try self.cloneExprValue(branch.body);
             self.restore(change_start);
+            return try self.wrapPendingLets(body, pending_lets.items);
         }
         Common.invariant("known constructor match had no matching branch");
+    }
+
+    fn bindPatToMatchValue(
+        self: *Cloner,
+        pat_id: Ast.PatId,
+        value: Value,
+        body: Ast.ExprId,
+        pending_lets: *std.ArrayList(PendingLet),
+    ) Common.LowerError!?Value {
+        const pat = self.pass.program.pats.items[@intFromEnum(pat_id)];
+        switch (pat.data) {
+            .bind => |local| {
+                const prepared = try self.valueForMatchLocal(local, value, body, pending_lets);
+                try self.putSubst(local, prepared);
+                return prepared;
+            },
+            .wildcard => return try self.makeReusableForMatch(value, pending_lets),
+            .as => |as| {
+                const as_uses = localUseCountInExpr(self.pass.program, as.local, body);
+                const base = if (self.valueCanSubstitute(value) or as_uses == 1)
+                    value
+                else
+                    try self.makeReusableForMatch(value, pending_lets);
+                const prepared = (try self.bindPatToMatchValue(as.pattern, base, body, pending_lets)) orelse return null;
+                try self.putSubst(as.local, prepared);
+                return prepared;
+            },
+            .record => |fields_span| {
+                const record = recordFromValue(value) orelse return null;
+                const fields = self.pass.program.recordDestructSpan(fields_span);
+                const prepared_fields = try self.pass.arena.allocator().alloc(FieldValue, record.fields.len);
+                for (record.fields, 0..) |field, index| {
+                    if (recordPatField(fields, field.name)) |field_pat| {
+                        const prepared = (try self.bindPatToMatchValue(field_pat, field.value, body, pending_lets)) orelse return null;
+                        prepared_fields[index] = .{
+                            .name = field.name,
+                            .value = prepared,
+                        };
+                    } else {
+                        prepared_fields[index] = .{
+                            .name = field.name,
+                            .value = try self.makeReusableForMatch(field.value, pending_lets),
+                        };
+                    }
+                }
+                return Value{ .record = .{
+                    .ty = record.ty,
+                    .fields = prepared_fields,
+                } };
+            },
+            .tuple => |items_span| {
+                const tuple = tupleFromValue(value) orelse return null;
+                const pats = self.pass.program.patSpan(items_span);
+                if (pats.len != tuple.items.len) return null;
+                const items = try self.pass.arena.allocator().alloc(Value, tuple.items.len);
+                for (pats, tuple.items, 0..) |child_pat, child_value, index| {
+                    items[index] = (try self.bindPatToMatchValue(child_pat, child_value, body, pending_lets)) orelse return null;
+                }
+                return Value{ .tuple = .{
+                    .ty = tuple.ty,
+                    .items = items,
+                } };
+            },
+            .tag => |tag_pat| {
+                const tag = tagFromValue(value) orelse return null;
+                if (tag.name != tag_pat.name) return null;
+                const pats = self.pass.program.patSpan(tag_pat.payloads);
+                if (pats.len != tag.payloads.len) return null;
+                const payloads = try self.pass.arena.allocator().alloc(Value, tag.payloads.len);
+                for (pats, tag.payloads, 0..) |child_pat, child_value, index| {
+                    payloads[index] = (try self.bindPatToMatchValue(child_pat, child_value, body, pending_lets)) orelse return null;
+                }
+                return Value{ .tag = .{
+                    .ty = tag.ty,
+                    .name = tag.name,
+                    .payloads = payloads,
+                } };
+            },
+            .nominal => |backing_pat| {
+                const nominal = switch (value) {
+                    .nominal => |nominal| nominal,
+                    else => return null,
+                };
+                const backing = try self.pass.arena.allocator().create(Value);
+                backing.* = (try self.bindPatToMatchValue(backing_pat, nominal.backing.*, body, pending_lets)) orelse return null;
+                return Value{ .nominal = .{
+                    .ty = nominal.ty,
+                    .backing = backing,
+                } };
+            },
+            .int_lit,
+            .dec_lit,
+            .frac_f32_lit,
+            .frac_f64_lit,
+            .str_lit,
+            => return null,
+        }
+    }
+
+    fn valueForMatchLocal(
+        self: *Cloner,
+        local: Ast.LocalId,
+        value: Value,
+        body: Ast.ExprId,
+        pending_lets: *std.ArrayList(PendingLet),
+    ) Common.LowerError!Value {
+        const uses = localUseCountInExpr(self.pass.program, local, body);
+        if (self.valueCanSubstitute(value) or uses == 1) return value;
+        return try self.makeReusableForMatch(value, pending_lets);
+    }
+
+    fn makeReusableForMatch(self: *Cloner, value: Value, pending_lets: *std.ArrayList(PendingLet)) Common.LowerError!Value {
+        if (self.valueCanSubstitute(value)) return value;
+        return switch (value) {
+            .expr => |expr| blk: {
+                const ty = self.pass.program.exprs.items[@intFromEnum(expr)].ty;
+                const local = try self.pass.program.addLocal(self.pass.symbols.fresh(), ty);
+                try pending_lets.append(self.pass.allocator, .{
+                    .local = local,
+                    .ty = ty,
+                    .value = expr,
+                });
+                break :blk Value{ .expr = try self.addExpr(.{
+                    .ty = ty,
+                    .data = .{ .local = local },
+                }) };
+            },
+            .tag => |tag| blk: {
+                const payloads = try self.pass.arena.allocator().alloc(Value, tag.payloads.len);
+                for (tag.payloads, 0..) |payload, index| {
+                    payloads[index] = try self.makeReusableForMatch(payload, pending_lets);
+                }
+                break :blk Value{ .tag = .{
+                    .ty = tag.ty,
+                    .name = tag.name,
+                    .payloads = payloads,
+                } };
+            },
+            .record => |record| blk: {
+                const fields = try self.pass.arena.allocator().alloc(FieldValue, record.fields.len);
+                for (record.fields, 0..) |field, index| {
+                    fields[index] = .{
+                        .name = field.name,
+                        .value = try self.makeReusableForMatch(field.value, pending_lets),
+                    };
+                }
+                break :blk Value{ .record = .{
+                    .ty = record.ty,
+                    .fields = fields,
+                } };
+            },
+            .tuple => |tuple| blk: {
+                const items = try self.pass.arena.allocator().alloc(Value, tuple.items.len);
+                for (tuple.items, 0..) |item, index| {
+                    items[index] = try self.makeReusableForMatch(item, pending_lets);
+                }
+                break :blk Value{ .tuple = .{
+                    .ty = tuple.ty,
+                    .items = items,
+                } };
+            },
+            .nominal => |nominal| blk: {
+                const backing = try self.pass.arena.allocator().create(Value);
+                backing.* = try self.makeReusableForMatch(nominal.backing.*, pending_lets);
+                break :blk Value{ .nominal = .{
+                    .ty = nominal.ty,
+                    .backing = backing,
+                } };
+            },
+            .callable => |callable| blk: {
+                const captures = try self.pass.arena.allocator().alloc(Value, callable.captures.len);
+                for (callable.captures, 0..) |capture, index| {
+                    captures[index] = try self.makeReusableForMatch(capture, pending_lets);
+                }
+                break :blk Value{ .callable = .{
+                    .ty = callable.ty,
+                    .fn_id = callable.fn_id,
+                    .captures = captures,
+                } };
+            },
+        };
+    }
+
+    fn wrapPendingLets(self: *Cloner, body: Value, pending_lets: []const PendingLet) Common.LowerError!Value {
+        if (pending_lets.len == 0) return body;
+
+        const ty = valueType(self.pass.program, body);
+        var result = try self.materialize(body);
+        var index = pending_lets.len;
+        while (index > 0) {
+            index -= 1;
+            const pending = pending_lets[index];
+            const pat = try self.pass.program.addPat(.{
+                .ty = pending.ty,
+                .data = .{ .bind = pending.local },
+            });
+            result = try self.addExpr(.{ .ty = ty, .data = .{ .let_ = .{
+                .bind = pat,
+                .value = pending.value,
+                .rest = result,
+            } } });
+        }
+        return .{ .expr = result };
     }
 
     fn cloneCaseOfCaseValue(
@@ -2938,6 +3152,13 @@ fn fieldFromValue(value: Value, name: names.RecordFieldNameId) ?Value {
 fn fieldFromRecord(record: RecordValue, name: names.RecordFieldNameId) ?Value {
     for (record.fields) |field| {
         if (field.name == name) return field.value;
+    }
+    return null;
+}
+
+fn recordPatField(fields: []const Ast.RecordDestruct, name: names.RecordFieldNameId) ?Ast.PatId {
+    for (fields) |field| {
+        if (field.name == name) return field.pattern;
     }
     return null;
 }

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -1,0 +1,2801 @@
+//! Make calls cheaper when they pass known-shaped values to code that
+//! immediately takes those values apart.
+//!
+//! The most obvious case is a freshly created tag union value that immediately
+//! gets pattern-matched. The same idea also applies to records and tuples whose
+//! fields are read right away, and to `Stream` values that carry a known step
+//! function after inlining. This shows up in recursive helpers, `Iter`/`Stream`
+//! pipelines, and loops that appear after inlining. This pass turns those calls
+//! into calls to workers that take the useful pieces directly.
+//!
+//! Here is the smallest version of the idea:
+//!
+//! ```roc
+//! Start : { n : I64 }
+//! SumState : { n : I64, acc : I64 }
+//!
+//! sum : Start -> I64
+//! sum = |start| {
+//!     var $state = { n: start.n, acc: 0 }
+//!
+//!     while $state.n != 0 {
+//!         $state = { n: $state.n - 1, acc: $state.acc + $state.n }
+//!     }
+//!
+//!     $state.acc
+//! }
+//!
+//! main = sum({ n: 4 })
+//! ```
+//!
+//! The call to `sum` passes a known `Start` record, and the loop state is always
+//! a `SumState`. The function reads `start.n`, then the loop immediately reads
+//! `$state.n` and `$state.acc`. This pass rewrites the call and loop so they
+//! carry the useful fields directly:
+//!
+//! ```roc
+//! sum_worker : I64 -> I64
+//! sum_worker = |start_n| {
+//!     var $n = start_n
+//!     var $acc = 0
+//!
+//!     while $n != 0 {
+//!         $acc = $acc + $n
+//!         $n = $n - 1
+//!     }
+//!
+//!     $acc
+//! }
+//!
+//! main = sum_worker(4)
+//! ```
+//!
+//! That is faster for plain, practical reasons:
+//!
+//! - each loop iteration carries two `I64`s directly;
+//! - the loop uses `n` and `acc` directly instead of reading record fields;
+//! - later compiler stages have simple values to keep in registers.
+//!
+//! This pass does not turn tail-recursive helpers into loops. If an earlier pass
+//! has already produced this kind of `while` loop, the loop-state part of this
+//! rewrite applies to it too.
+//!
+//! This is Roc's version of the optimization described in
+//! "Call-pattern Specialisation for Haskell Programs" by Simon Peyton Jones:
+//!
+//! https://www.microsoft.com/en-us/research/wp-content/uploads/2016/07/spec-constr.pdf
+//!
+//! The important Roc case is collection from `Iter` and `Stream`. Source code is
+//! compact:
+//!
+//! ```roc
+//! Plant : { seed : I64 }
+//!
+//! random_plant! : I64 => Plant
+//! random_plant! = |seed| { seed }
+//!
+//! starting_plants! : () => List(Plant)
+//! starting_plants! = || {
+//!     0.I64.to(15)
+//!         .stream()
+//!         .map(|i| random_plant!(i * 12))
+//!         .collect!()
+//! }
+//! ```
+//!
+//! After wrapper inlining exposes the `Stream` operations, the lifted program has
+//! the same shape as this Roc code. The range is wrapped in a stream record; map
+//! wraps that stream in another stream record; collect loops over that mapped
+//! stream by calling the carried step thunk:
+//!
+//! ```roc
+//! starting_plants! = || {
+//!     range_iter = 0.I64.to(15)
+//!
+//!     source_stream = {
+//!         len_if_known: Known(16),
+//!         step!: ||
+//!             match Iter.next(range_iter) {
+//!                 Done => Done
+//!                 Skip({ rest }) =>
+//!                     Skip({ rest: Stream.from_iter(rest) })
+//!                 One({ item, rest }) =>
+//!                     One({ item, rest: Stream.from_iter(rest) })
+//!             },
+//!     }
+//!
+//!     mapped_stream = {
+//!         len_if_known: source_stream.len_if_known,
+//!         step!: ||
+//!             match source_stream.step!() {
+//!                 Done => Done
+//!                 Skip({ rest }) =>
+//!                     Skip({ rest: Stream.map(rest, |i| random_plant!(i * 12)) })
+//!                 One({ item, rest }) =>
+//!                     One({
+//!                         item: random_plant!(item * 12),
+//!                         rest: Stream.map(rest, |i| random_plant!(i * 12)),
+//!                     })
+//!             },
+//!     }
+//!
+//!     cap = match mapped_stream.len_if_known {
+//!         Known(n) => n
+//!         Unknown => 0
+//!     }
+//!
+//!     var $list = List.with_capacity(cap)
+//!     var $rest = mapped_stream
+//!
+//!     while Bool.True {
+//!         match $rest.step!() {
+//!             Done => break
+//!             Skip({ rest }) => {
+//!                 $rest = rest
+//!             }
+//!             One({ item, rest }) => {
+//!                 $list = list_append_unsafe($list, item)
+//!                 $rest = rest
+//!             }
+//!         }
+//!     }
+//!
+//!     $list
+//! }
+//! ```
+//!
+//! In that inlined form, the loop state `$rest` has a known constructor shape:
+//! it is a `Stream` record whose `step!` field is the lifted function created by
+//! `Stream.map`, with captures for the source step thunk and the mapping
+//! function. Each `One` or `Skip` branch constructs the same mapped stream shape
+//! for the next iteration. Without this pass, the compiler lowers that as a loop
+//! over a single stream value, repacking stream fields and rebuilding the step
+//! closure before immediately reading them again.
+//!
+//! This pass specializes the collect worker for the known stream shape. Written
+//! in pure Roc terms, the optimized shape is:
+//!
+//! ```roc
+//! starting_plants! = || {
+//!     var $list = List.with_capacity(16)
+//!     var $current = 0.I64
+//!     var $last = 15.I64
+//!
+//!     while Bool.True {
+//!         if $current > $last {
+//!             break
+//!         }
+//!
+//!         item = random_plant!($current * 12)
+//!         $list = list_append_unsafe($list, item)
+//!         $current = $current + 1
+//!     }
+//!
+//!     $list
+//! }
+//! ```
+//!
+//! The real lifted IR is more explicit than that source sketch: lambdas have
+//! function ids, captures are separate locals, and branches still have explicit
+//! tags until later lowering. The essential change is that the reachable collect
+//! worker no longer receives one `Stream(Plant)` argument. It receives the
+//! stream's known fields and callable captures directly, and recursive loop
+//! updates pass those fields forward instead of re-forming a stream value.
+//!
+//! The implementation has five parts:
+//!
+//! 1. Scan original lifted functions and mark argument positions read by
+//!    `match`, field access, or tuple access. Direct calls propagate those marks
+//!    to the caller's corresponding arguments.
+//! 2. Record call patterns at direct calls. If a marked argument is an explicit
+//!    `tag`, `record`, `tuple`, `nominal`, or lifted callable value, that
+//!    constructor shape becomes part of the pattern.
+//! 3. Reserve worker ids for the recorded patterns, then clone each source
+//!    function into its workers. Constructor-shaped arguments are split into
+//!    their leaves; ordinary arguments stay as normal worker arguments.
+//! 4. Clone with a value environment. Known records simplify field reads, known
+//!    tuples simplify tuple reads, known tags simplify matches, known callable
+//!    values inline direct calls, and calls matching a recorded pattern are
+//!    redirected to the worker.
+//! 5. Specialize loop state in the cloned body. If a loop starts with a
+//!    constructor-shaped state value, its loop parameters are split the same way
+//!    function arguments are split, and `continue` values must pass the same
+//!    shape's leaves.
+//!
+//! Callable identity is part of a call pattern. A lifted callable matches only
+//! the same function id, or a specialized clone whose stored source function
+//! template is the same. That keeps dispatch static while allowing this pass's
+//! own callable workers to match the patterns that created them.
+
+const std = @import("std");
+
+const Common = @import("../common.zig");
+const Ast = @import("ast.zig");
+const Mono = @import("../monotype/ast.zig");
+const Type = @import("../monotype/type.zig");
+const check = @import("check");
+const names = @import("check").CheckedNames;
+
+const Allocator = std.mem.Allocator;
+
+/// Specialize recursive direct calls whose arguments are known constructor shapes.
+pub fn run(allocator: Allocator, program: *Ast.Program) Common.LowerError!void {
+    var pass = try Pass.init(allocator, program);
+    defer pass.deinit();
+    try pass.run();
+}
+
+const Shape = union(enum) {
+    any: Type.TypeId,
+    tag: TagShape,
+    record: RecordShape,
+    tuple: TupleShape,
+    nominal: NominalShape,
+    callable: CallableShape,
+};
+
+const TagShape = struct {
+    ty: Type.TypeId,
+    name: names.TagNameId,
+    payloads: []const Shape,
+};
+
+const FieldShape = struct {
+    name: names.RecordFieldNameId,
+    shape: Shape,
+};
+
+const RecordShape = struct {
+    ty: Type.TypeId,
+    fields: []const FieldShape,
+};
+
+const TupleShape = struct {
+    ty: Type.TypeId,
+    items: []const Shape,
+};
+
+const NominalShape = struct {
+    ty: Type.TypeId,
+    backing: *const Shape,
+};
+
+const CallableShape = struct {
+    ty: Type.TypeId,
+    fn_id: Ast.FnId,
+    captures: []const Shape,
+};
+
+const Value = union(enum) {
+    expr: Ast.ExprId,
+    tag: TagValue,
+    record: RecordValue,
+    tuple: TupleValue,
+    nominal: NominalValue,
+    callable: CallableValue,
+};
+
+const TagValue = struct {
+    ty: Type.TypeId,
+    name: names.TagNameId,
+    payloads: []const Value,
+};
+
+const FieldValue = struct {
+    name: names.RecordFieldNameId,
+    value: Value,
+};
+
+const RecordValue = struct {
+    ty: Type.TypeId,
+    fields: []const FieldValue,
+};
+
+const TupleValue = struct {
+    ty: Type.TypeId,
+    items: []const Value,
+};
+
+const NominalValue = struct {
+    ty: Type.TypeId,
+    backing: *const Value,
+};
+
+const CallableValue = struct {
+    ty: Type.TypeId,
+    fn_id: Ast.FnId,
+    captures: []const Value,
+};
+
+const CallPattern = struct {
+    args: []const Shape,
+};
+
+const Spec = struct {
+    pattern: CallPattern,
+    fn_id: ?Ast.FnId = null,
+};
+
+const FnPlan = struct {
+    used_args: []bool,
+    specs: std.ArrayList(Spec),
+
+    fn deinit(self: *FnPlan, allocator: Allocator) void {
+        allocator.free(self.used_args);
+        self.specs.deinit(allocator);
+    }
+};
+
+const BindingKey = union(enum) {
+    local: Ast.LocalId,
+    binder: check.CheckedModule.PatternBinderId,
+};
+
+const BindingChange = struct {
+    key: BindingKey,
+    previous: ?Value,
+};
+
+const LoopPattern = struct {
+    values: []const Shape,
+};
+
+const ActiveCallable = struct {
+    source: Ast.FnId,
+    specialized: Ast.FnId,
+};
+
+const Pass = struct {
+    allocator: Allocator,
+    arena: std.heap.ArenaAllocator,
+    program: *Ast.Program,
+    plans: []FnPlan,
+    symbols: Common.SymbolGen,
+
+    fn init(allocator: Allocator, program: *Ast.Program) Allocator.Error!Pass {
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+
+        const plans = try allocator.alloc(FnPlan, program.fns.items.len);
+        errdefer allocator.free(plans);
+
+        for (plans, 0..) |*plan, index| {
+            const fn_ = program.fns.items[index];
+            const args = program.typedLocalSpan(fn_.args);
+            const used_args = try allocator.alloc(bool, args.len);
+            errdefer allocator.free(used_args);
+            @memset(used_args, false);
+            plan.* = .{
+                .used_args = used_args,
+                .specs = .empty,
+            };
+        }
+
+        return .{
+            .allocator = allocator,
+            .arena = arena,
+            .program = program,
+            .plans = plans,
+            .symbols = .{ .next = program.next_symbol },
+        };
+    }
+
+    fn deinit(self: *Pass) void {
+        for (self.plans) |*plan| plan.deinit(self.allocator);
+        self.allocator.free(self.plans);
+        self.arena.deinit();
+    }
+
+    fn run(self: *Pass) Common.LowerError!void {
+        const original_fn_count = self.plans.len;
+
+        try self.collectArgUses(original_fn_count);
+        try self.collectCallPatterns(original_fn_count);
+        try self.reserveSpecIds();
+        try self.createSpecializations(original_fn_count);
+        try self.rewriteExistingCalls();
+
+        self.program.next_symbol = self.symbols.next;
+    }
+
+    fn collectArgUses(self: *Pass, original_fn_count: usize) Allocator.Error!void {
+        var changed = true;
+        while (changed) {
+            changed = false;
+            for (self.program.fns.items[0..original_fn_count], 0..) |fn_, index| {
+                const body = switch (fn_.body) {
+                    .roc => |body| body,
+                    .hosted => continue,
+                };
+                const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(index)));
+                try self.markArgUsesInExpr(fn_id, body, &changed);
+            }
+        }
+    }
+
+    fn collectCallPatterns(self: *Pass, original_fn_count: usize) Allocator.Error!void {
+        for (self.program.fns.items[0..original_fn_count], 0..) |fn_, index| {
+            const body = switch (fn_.body) {
+                .roc => |body| body,
+                .hosted => continue,
+            };
+            const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(index)));
+            try self.collectCallPatternsInExpr(fn_id, body);
+        }
+    }
+
+    fn reserveSpecIds(self: *Pass) Allocator.Error!void {
+        for (self.plans, 0..) |*plan, source_index| {
+            const source_fn = self.program.fns.items[source_index];
+            for (plan.specs.items) |*spec| {
+                const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(self.program.fns.items.len)));
+                spec.fn_id = fn_id;
+                try self.program.fns.append(self.allocator, .{
+                    .symbol = self.symbols.fresh(),
+                    .source = null,
+                    .args = .empty(),
+                    .captures = source_fn.captures,
+                    .body = .hosted,
+                    .ret = source_fn.ret,
+                });
+            }
+        }
+    }
+
+    fn createSpecializations(self: *Pass, original_fn_count: usize) Common.LowerError!void {
+        for (0..original_fn_count) |index| {
+            const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(index)));
+            var spec_index: usize = 0;
+            while (spec_index < self.plans[index].specs.items.len) : (spec_index += 1) {
+                try self.writeSpecialization(fn_id, spec_index);
+            }
+        }
+    }
+
+    fn markArgUsesInExpr(self: *Pass, fn_id: Ast.FnId, expr_id: Ast.ExprId, changed: *bool) Allocator.Error!void {
+        const expr = self.program.exprs.items[@intFromEnum(expr_id)];
+        switch (expr.data) {
+            .local,
+            .unit,
+            .int_lit,
+            .frac_f32_lit,
+            .frac_f64_lit,
+            .dec_lit,
+            .str_lit,
+            .fn_ref,
+            .crash,
+            => {},
+            .list,
+            .tuple,
+            => |items| for (self.program.exprSpan(items)) |child| try self.markArgUsesInExpr(fn_id, child, changed),
+            .record => |fields| for (self.program.fieldExprSpan(fields)) |field| try self.markArgUsesInExpr(fn_id, field.value, changed),
+            .tag => |tag| for (self.program.exprSpan(tag.payloads)) |payload| try self.markArgUsesInExpr(fn_id, payload, changed),
+            .nominal,
+            .return_,
+            .dbg,
+            .expect,
+            => |child| try self.markArgUsesInExpr(fn_id, child, changed),
+            .let_ => |let_| {
+                try self.markArgUsesInExpr(fn_id, let_.value, changed);
+                try self.markArgUsesInExpr(fn_id, let_.rest, changed);
+            },
+            .lambda,
+            .def_ref,
+            .fn_def,
+            => Common.invariant("pre-lift function expression reached call-pattern specialization"),
+            .call_value => |call| {
+                try self.markArgUsesInExpr(fn_id, call.callee, changed);
+                for (self.program.exprSpan(call.args)) |arg| try self.markArgUsesInExpr(fn_id, arg, changed);
+            },
+            .call_proc => |call| {
+                const args = self.program.exprSpan(call.args);
+                for (args) |arg| try self.markArgUsesInExpr(fn_id, arg, changed);
+                const callee = Ast.callProcCallee(call);
+                const callee_raw = @intFromEnum(callee);
+                if (callee_raw < self.plans.len) {
+                    const callee_uses = self.plans[callee_raw].used_args;
+                    if (args.len != callee_uses.len) Common.invariant("direct call arity differed from lifted function arity while propagating argument uses");
+                    for (args, callee_uses) |arg, callee_uses_arg| {
+                        if (callee_uses_arg) self.markArgUseIfLocal(fn_id, arg, changed);
+                    }
+                }
+            },
+            .low_level => |call| {
+                for (self.program.exprSpan(call.args)) |arg| try self.markArgUsesInExpr(fn_id, arg, changed);
+            },
+            .field_access => |field| {
+                self.markArgUseIfLocal(fn_id, field.receiver, changed);
+                try self.markArgUsesInExpr(fn_id, field.receiver, changed);
+            },
+            .tuple_access => |access| {
+                self.markArgUseIfLocal(fn_id, access.tuple, changed);
+                try self.markArgUsesInExpr(fn_id, access.tuple, changed);
+            },
+            .structural_eq => |eq| {
+                try self.markArgUsesInExpr(fn_id, eq.lhs, changed);
+                try self.markArgUsesInExpr(fn_id, eq.rhs, changed);
+            },
+            .match_ => |match| {
+                self.markArgUseIfLocal(fn_id, match.scrutinee, changed);
+                try self.markArgUsesInExpr(fn_id, match.scrutinee, changed);
+                for (self.program.branchSpan(match.branches)) |branch| {
+                    if (branch.guard) |guard| try self.markArgUsesInExpr(fn_id, guard, changed);
+                    try self.markArgUsesInExpr(fn_id, branch.body, changed);
+                }
+            },
+            .if_ => |if_| {
+                for (self.program.ifBranchSpan(if_.branches)) |branch| {
+                    try self.markArgUsesInExpr(fn_id, branch.cond, changed);
+                    try self.markArgUsesInExpr(fn_id, branch.body, changed);
+                }
+                try self.markArgUsesInExpr(fn_id, if_.final_else, changed);
+            },
+            .block => |block| {
+                for (self.program.stmtSpan(block.statements)) |stmt| try self.markArgUsesInStmt(fn_id, stmt, changed);
+                try self.markArgUsesInExpr(fn_id, block.final_expr, changed);
+            },
+            .loop_ => |loop| {
+                for (self.program.exprSpan(loop.initial_values)) |initial| try self.markArgUsesInExpr(fn_id, initial, changed);
+                try self.markArgUsesInExpr(fn_id, loop.body, changed);
+            },
+            .break_ => |maybe| if (maybe) |value| try self.markArgUsesInExpr(fn_id, value, changed),
+            .continue_ => |continue_| for (self.program.exprSpan(continue_.values)) |value| try self.markArgUsesInExpr(fn_id, value, changed),
+        }
+    }
+
+    fn markArgUsesInStmt(self: *Pass, fn_id: Ast.FnId, stmt_id: Ast.StmtId, changed: *bool) Allocator.Error!void {
+        switch (self.program.stmts.items[@intFromEnum(stmt_id)]) {
+            .let_ => |let_| try self.markArgUsesInExpr(fn_id, let_.value, changed),
+            .expr,
+            .expect,
+            .dbg,
+            .return_,
+            => |expr| try self.markArgUsesInExpr(fn_id, expr, changed),
+            .crash => {},
+        }
+    }
+
+    fn markArgUseIfLocal(self: *Pass, fn_id: Ast.FnId, expr_id: Ast.ExprId, changed: *bool) void {
+        const local = localExpr(self.program, expr_id) orelse return;
+        const args = self.program.typedLocalSpan(self.program.fns.items[@intFromEnum(fn_id)].args);
+        for (args, 0..) |arg, index| {
+            if (arg.local == local) {
+                const used = &self.plans[@intFromEnum(fn_id)].used_args[index];
+                if (!used.*) {
+                    used.* = true;
+                    changed.* = true;
+                }
+                return;
+            }
+        }
+    }
+
+    fn collectCallPatternsInExpr(self: *Pass, owner: Ast.FnId, expr_id: Ast.ExprId) Allocator.Error!void {
+        const expr = self.program.exprs.items[@intFromEnum(expr_id)];
+        switch (expr.data) {
+            .local,
+            .unit,
+            .int_lit,
+            .frac_f32_lit,
+            .frac_f64_lit,
+            .dec_lit,
+            .str_lit,
+            .fn_ref,
+            .crash,
+            => {},
+            .list,
+            .tuple,
+            => |items| for (self.program.exprSpan(items)) |child| try self.collectCallPatternsInExpr(owner, child),
+            .record => |fields| for (self.program.fieldExprSpan(fields)) |field| try self.collectCallPatternsInExpr(owner, field.value),
+            .tag => |tag| for (self.program.exprSpan(tag.payloads)) |payload| try self.collectCallPatternsInExpr(owner, payload),
+            .nominal,
+            .return_,
+            .dbg,
+            .expect,
+            => |child| try self.collectCallPatternsInExpr(owner, child),
+            .let_ => |let_| {
+                try self.collectCallPatternsInExpr(owner, let_.value);
+                try self.collectCallPatternsInExpr(owner, let_.rest);
+            },
+            .lambda,
+            .def_ref,
+            .fn_def,
+            => Common.invariant("pre-lift function expression reached call-pattern specialization"),
+            .call_value => |call| {
+                try self.collectCallPatternsInExpr(owner, call.callee);
+                for (self.program.exprSpan(call.args)) |arg| try self.collectCallPatternsInExpr(owner, arg);
+            },
+            .call_proc => |call| {
+                for (self.program.exprSpan(call.args)) |arg| try self.collectCallPatternsInExpr(owner, arg);
+                const callee = Ast.callProcCallee(call);
+                if (@intFromEnum(callee) < self.plans.len) try self.recordCallPattern(callee, call.args);
+            },
+            .low_level => |call| {
+                for (self.program.exprSpan(call.args)) |arg| try self.collectCallPatternsInExpr(owner, arg);
+            },
+            .field_access => |field| try self.collectCallPatternsInExpr(owner, field.receiver),
+            .tuple_access => |access| try self.collectCallPatternsInExpr(owner, access.tuple),
+            .structural_eq => |eq| {
+                try self.collectCallPatternsInExpr(owner, eq.lhs);
+                try self.collectCallPatternsInExpr(owner, eq.rhs);
+            },
+            .match_ => |match| {
+                try self.collectCallPatternsInExpr(owner, match.scrutinee);
+                for (self.program.branchSpan(match.branches)) |branch| {
+                    if (branch.guard) |guard| try self.collectCallPatternsInExpr(owner, guard);
+                    try self.collectCallPatternsInExpr(owner, branch.body);
+                }
+            },
+            .if_ => |if_| {
+                for (self.program.ifBranchSpan(if_.branches)) |branch| {
+                    try self.collectCallPatternsInExpr(owner, branch.cond);
+                    try self.collectCallPatternsInExpr(owner, branch.body);
+                }
+                try self.collectCallPatternsInExpr(owner, if_.final_else);
+            },
+            .block => |block| {
+                for (self.program.stmtSpan(block.statements)) |stmt| try self.collectCallPatternsInStmt(owner, stmt);
+                try self.collectCallPatternsInExpr(owner, block.final_expr);
+            },
+            .loop_ => |loop| {
+                for (self.program.exprSpan(loop.initial_values)) |initial| try self.collectCallPatternsInExpr(owner, initial);
+                try self.collectCallPatternsInExpr(owner, loop.body);
+            },
+            .break_ => |maybe| if (maybe) |value| try self.collectCallPatternsInExpr(owner, value),
+            .continue_ => |continue_| for (self.program.exprSpan(continue_.values)) |value| try self.collectCallPatternsInExpr(owner, value),
+        }
+    }
+
+    fn collectCallPatternsInStmt(self: *Pass, owner: Ast.FnId, stmt_id: Ast.StmtId) Allocator.Error!void {
+        switch (self.program.stmts.items[@intFromEnum(stmt_id)]) {
+            .let_ => |let_| try self.collectCallPatternsInExpr(owner, let_.value),
+            .expr,
+            .expect,
+            .dbg,
+            .return_,
+            => |expr| try self.collectCallPatternsInExpr(owner, expr),
+            .crash => {},
+        }
+    }
+
+    fn recordCallPattern(self: *Pass, fn_id: Ast.FnId, args_span: Ast.Span(Ast.ExprId)) Allocator.Error!void {
+        const raw = @intFromEnum(fn_id);
+        const args = try self.allocator.dupe(Ast.ExprId, self.program.exprSpan(args_span));
+        defer self.allocator.free(args);
+        const fn_args = self.program.typedLocalSpan(self.program.fns.items[raw].args);
+        if (args.len != fn_args.len) Common.invariant("direct call arity differed from lifted function arity");
+
+        const shapes = try self.arena.allocator().alloc(Shape, args.len);
+        var has_constructor = false;
+
+        for (args, 0..) |arg, index| {
+            if (self.plans[raw].used_args[index]) {
+                var cloner = Cloner.initForRewrite(self);
+                defer cloner.deinit();
+                const value = try cloner.cloneExprValue(arg);
+                if (try self.shapeFromValue(value)) |shape| {
+                    shapes[index] = shape;
+                    has_constructor = true;
+                    continue;
+                }
+            }
+            shapes[index] = .{ .any = self.program.exprs.items[@intFromEnum(arg)].ty };
+        }
+
+        if (!has_constructor) return;
+
+        const pattern: CallPattern = .{ .args = shapes };
+        for (self.plans[raw].specs.items) |spec| {
+            if (patternEql(spec.pattern, pattern)) return;
+        }
+
+        try self.plans[raw].specs.append(self.allocator, .{
+            .pattern = pattern,
+        });
+    }
+
+    fn ensureCallPatternForValues(self: *Pass, fn_id: Ast.FnId, values: []const Value) Common.LowerError!void {
+        const raw = @intFromEnum(fn_id);
+        if (raw >= self.plans.len) return;
+
+        const fn_args = self.program.typedLocalSpan(self.program.fns.items[raw].args);
+        if (values.len != fn_args.len) Common.invariant("direct call arity differed from lifted function arity");
+
+        const shapes = try self.arena.allocator().alloc(Shape, values.len);
+        var has_constructor = false;
+        for (values, 0..) |value, index| {
+            if (self.plans[raw].used_args[index]) {
+                if (try self.shapeFromValue(value)) |shape| {
+                    shapes[index] = shape;
+                    has_constructor = true;
+                    continue;
+                }
+            }
+            shapes[index] = .{ .any = valueType(self.program, value) };
+        }
+        if (!has_constructor) return;
+
+        const pattern: CallPattern = .{ .args = shapes };
+        for (self.plans[raw].specs.items) |spec| {
+            if (patternEql(spec.pattern, pattern)) return;
+        }
+
+        const source_fn = self.program.fns.items[raw];
+        const fn_id_reserved: Ast.FnId = @enumFromInt(@as(u32, @intCast(self.program.fns.items.len)));
+        try self.plans[raw].specs.append(self.allocator, .{
+            .pattern = pattern,
+            .fn_id = fn_id_reserved,
+        });
+        try self.program.fns.append(self.allocator, .{
+            .symbol = self.symbols.fresh(),
+            .source = null,
+            .args = .empty(),
+            .captures = source_fn.captures,
+            .body = .hosted,
+            .ret = source_fn.ret,
+        });
+        try self.writeSpecialization(fn_id, self.plans[raw].specs.items.len - 1);
+    }
+
+    fn writeSpecialization(self: *Pass, source_fn_id: Ast.FnId, spec_index: usize) Common.LowerError!void {
+        const source_fn = self.program.fns.items[@intFromEnum(source_fn_id)];
+        const spec = &self.plans[@intFromEnum(source_fn_id)].specs.items[spec_index];
+
+        const spec_fn_id = spec.fn_id orelse Common.invariant("call-pattern specialization id was not assigned before cloning");
+        const symbol = self.program.fns.items[@intFromEnum(spec_fn_id)].symbol;
+
+        var cloner = Cloner.init(self, source_fn_id, spec.pattern);
+        defer cloner.deinit();
+
+        try cloner.inline_stack.append(self.allocator, source_fn_id);
+        defer {
+            const popped = cloner.inline_stack.pop() orelse Common.invariant("call-pattern inline stack underflow while writing specialization");
+            if (popped != source_fn_id) Common.invariant("call-pattern inline stack was corrupted while writing specialization");
+        }
+
+        const args = try cloner.buildArgs();
+        const body: Ast.FnBody = switch (source_fn.body) {
+            .roc => |body_expr| .{ .roc = try cloner.cloneExpr(body_expr) },
+            .hosted => Common.invariant("hosted function had a call-pattern specialization"),
+        };
+
+        self.program.fns.items[@intFromEnum(spec_fn_id)] = .{
+            .symbol = symbol,
+            .source = null,
+            .args = args,
+            .captures = source_fn.captures,
+            .body = body,
+            .ret = source_fn.ret,
+        };
+    }
+
+    fn rewriteExistingCalls(self: *Pass) Allocator.Error!void {
+        const done = try self.allocator.alloc(bool, self.program.exprs.items.len);
+        defer self.allocator.free(done);
+        @memset(done, false);
+
+        const fn_count = self.program.fns.items.len;
+        for (self.program.fns.items[0..fn_count]) |fn_| {
+            const body = switch (fn_.body) {
+                .roc => |body| body,
+                .hosted => continue,
+            };
+            try self.rewriteCallsInExpr(body, done);
+        }
+    }
+
+    fn rewriteCallsInExpr(self: *Pass, expr_id: Ast.ExprId, done: []bool) Allocator.Error!void {
+        const index = @intFromEnum(expr_id);
+        if (done[index]) return;
+        done[index] = true;
+
+        const expr = self.program.exprs.items[index];
+        switch (expr.data) {
+            .local,
+            .unit,
+            .int_lit,
+            .frac_f32_lit,
+            .frac_f64_lit,
+            .dec_lit,
+            .str_lit,
+            .fn_ref,
+            .crash,
+            => {},
+            .list,
+            .tuple,
+            => |items| try self.rewriteCallsInExprSpan(items, done),
+            .record => |fields| try self.rewriteCallsInFieldExprSpan(fields, done),
+            .tag => |tag| try self.rewriteCallsInExprSpan(tag.payloads, done),
+            .nominal,
+            .return_,
+            .dbg,
+            .expect,
+            => |child| try self.rewriteCallsInExpr(child, done),
+            .let_ => |let_| {
+                try self.rewriteCallsInExpr(let_.value, done);
+                try self.rewriteCallsInExpr(let_.rest, done);
+            },
+            .lambda,
+            .def_ref,
+            .fn_def,
+            => Common.invariant("pre-lift function expression reached call-pattern specialization"),
+            .call_value => |call| {
+                try self.rewriteCallsInExpr(call.callee, done);
+                try self.rewriteCallsInExprSpan(call.args, done);
+            },
+            .call_proc => |call| {
+                try self.rewriteCallsInExprSpan(call.args, done);
+                try self.rewriteCallProc(expr_id, call);
+            },
+            .low_level => |call| try self.rewriteCallsInExprSpan(call.args, done),
+            .field_access => |field| try self.rewriteCallsInExpr(field.receiver, done),
+            .tuple_access => |access| try self.rewriteCallsInExpr(access.tuple, done),
+            .structural_eq => |eq| {
+                try self.rewriteCallsInExpr(eq.lhs, done);
+                try self.rewriteCallsInExpr(eq.rhs, done);
+            },
+            .match_ => |match| {
+                try self.rewriteCallsInExpr(match.scrutinee, done);
+                try self.rewriteCallsInBranchSpan(match.branches, done);
+            },
+            .if_ => |if_| {
+                try self.rewriteCallsInIfBranchSpan(if_.branches, done);
+                try self.rewriteCallsInExpr(if_.final_else, done);
+            },
+            .block => |block| {
+                try self.rewriteCallsInStmtSpan(block.statements, done);
+                try self.rewriteCallsInExpr(block.final_expr, done);
+            },
+            .loop_ => |loop| {
+                try self.rewriteCallsInExprSpan(loop.initial_values, done);
+                try self.rewriteCallsInExpr(loop.body, done);
+            },
+            .break_ => |maybe| if (maybe) |value| try self.rewriteCallsInExpr(value, done),
+            .continue_ => |continue_| try self.rewriteCallsInExprSpan(continue_.values, done),
+        }
+    }
+
+    fn rewriteCallsInExprSpan(self: *Pass, span: Ast.Span(Ast.ExprId), done: []bool) Allocator.Error!void {
+        const source = try self.allocator.dupe(Ast.ExprId, self.program.exprSpan(span));
+        defer self.allocator.free(source);
+        for (source) |expr| try self.rewriteCallsInExpr(expr, done);
+    }
+
+    fn rewriteCallsInFieldExprSpan(self: *Pass, span: Ast.Span(Ast.FieldExpr), done: []bool) Allocator.Error!void {
+        const source = try self.allocator.dupe(Ast.FieldExpr, self.program.fieldExprSpan(span));
+        defer self.allocator.free(source);
+        for (source) |field| try self.rewriteCallsInExpr(field.value, done);
+    }
+
+    fn rewriteCallsInBranchSpan(self: *Pass, span: Ast.Span(Ast.Branch), done: []bool) Allocator.Error!void {
+        const source = try self.allocator.dupe(Ast.Branch, self.program.branchSpan(span));
+        defer self.allocator.free(source);
+        for (source) |branch| {
+            if (branch.guard) |guard| try self.rewriteCallsInExpr(guard, done);
+            try self.rewriteCallsInExpr(branch.body, done);
+        }
+    }
+
+    fn rewriteCallsInIfBranchSpan(self: *Pass, span: Ast.Span(Ast.IfBranch), done: []bool) Allocator.Error!void {
+        const source = try self.allocator.dupe(Ast.IfBranch, self.program.ifBranchSpan(span));
+        defer self.allocator.free(source);
+        for (source) |branch| {
+            try self.rewriteCallsInExpr(branch.cond, done);
+            try self.rewriteCallsInExpr(branch.body, done);
+        }
+    }
+
+    fn rewriteCallsInStmtSpan(self: *Pass, span: Ast.Span(Ast.StmtId), done: []bool) Allocator.Error!void {
+        const source = try self.allocator.dupe(Ast.StmtId, self.program.stmtSpan(span));
+        defer self.allocator.free(source);
+        for (source) |stmt| try self.rewriteCallsInStmt(stmt, done);
+    }
+
+    fn rewriteCallsInStmt(self: *Pass, stmt_id: Ast.StmtId, done: []bool) Allocator.Error!void {
+        switch (self.program.stmts.items[@intFromEnum(stmt_id)]) {
+            .let_ => |let_| try self.rewriteCallsInExpr(let_.value, done),
+            .expr,
+            .expect,
+            .dbg,
+            .return_,
+            => |expr| try self.rewriteCallsInExpr(expr, done),
+            .crash => {},
+        }
+    }
+
+    fn rewriteCallProc(self: *Pass, expr_id: Ast.ExprId, call: @import("../monotype/ast.zig").CallProc) Allocator.Error!void {
+        const callee = Ast.callProcCallee(call);
+        const raw = @intFromEnum(callee);
+        if (raw >= self.plans.len) return;
+        if (self.plans[raw].specs.items.len == 0) return;
+
+        const args = try self.allocator.dupe(Ast.ExprId, self.program.exprSpan(call.args));
+        defer self.allocator.free(args);
+        for (self.plans[raw].specs.items) |spec| {
+            var rewritten_args = std.ArrayList(Ast.ExprId).empty;
+            defer rewritten_args.deinit(self.allocator);
+
+            if (try self.appendExistingCallArgs(spec.pattern, args, &rewritten_args)) {
+                self.program.exprs.items[@intFromEnum(expr_id)].data = .{ .call_proc = .{
+                    .callee = .{ .lifted = spec.fn_id orelse Common.invariant("call-pattern specialization id was not assigned before rewriting") },
+                    .args = try self.program.addExprSpan(rewritten_args.items),
+                } };
+                return;
+            }
+        }
+    }
+
+    fn appendExistingCallArgs(
+        self: *Pass,
+        pattern: CallPattern,
+        args: []const Ast.ExprId,
+        out: *std.ArrayList(Ast.ExprId),
+    ) Allocator.Error!bool {
+        if (pattern.args.len != args.len) Common.invariant("call-pattern arity differed from direct call arity");
+        var cloner = Cloner.initForRewrite(self);
+        defer cloner.deinit();
+
+        for (pattern.args, args) |shape, arg| {
+            const value = try cloner.cloneExprValue(arg);
+            if (!shapeMatchesValue(self.program, shape, value)) return false;
+            try cloner.appendExprsFromValue(shape, value, out);
+        }
+        return true;
+    }
+
+    fn appendExistingExprsForShape(
+        self: *Pass,
+        shape: Shape,
+        expr_id: Ast.ExprId,
+        out: *std.ArrayList(Ast.ExprId),
+    ) Allocator.Error!bool {
+        switch (shape) {
+            .any => {
+                try out.append(self.allocator, expr_id);
+                return true;
+            },
+            .tag => |tag| {
+                const expr = self.program.exprs.items[@intFromEnum(expr_id)];
+                const expr_tag = switch (expr.data) {
+                    .tag => |expr_tag| expr_tag,
+                    else => return false,
+                };
+                if (expr.ty != tag.ty or expr_tag.name != tag.name) return false;
+                const payloads = self.program.exprSpan(expr_tag.payloads);
+                if (payloads.len != tag.payloads.len) Common.invariant("tag call pattern arity differed from tag expression arity");
+                for (tag.payloads, payloads) |payload_shape, payload| {
+                    if (!try self.appendExistingExprsForShape(payload_shape, payload, out)) return false;
+                }
+                return true;
+            },
+            .record => |record| {
+                const expr = self.program.exprs.items[@intFromEnum(expr_id)];
+                const fields = switch (expr.data) {
+                    .record => |fields| self.program.fieldExprSpan(fields),
+                    else => return false,
+                };
+                if (expr.ty != record.ty or fields.len != record.fields.len) return false;
+                for (record.fields, fields) |field_shape, field| {
+                    if (field_shape.name != field.name) return false;
+                    if (!try self.appendExistingExprsForShape(field_shape.shape, field.value, out)) return false;
+                }
+                return true;
+            },
+            .tuple => |tuple| {
+                const expr = self.program.exprs.items[@intFromEnum(expr_id)];
+                const items = switch (expr.data) {
+                    .tuple => |items| self.program.exprSpan(items),
+                    else => return false,
+                };
+                if (expr.ty != tuple.ty or items.len != tuple.items.len) return false;
+                for (tuple.items, items) |item_shape, item| {
+                    if (!try self.appendExistingExprsForShape(item_shape, item, out)) return false;
+                }
+                return true;
+            },
+            .nominal => |nominal| {
+                const expr = self.program.exprs.items[@intFromEnum(expr_id)];
+                const backing = switch (expr.data) {
+                    .nominal => |backing| backing,
+                    else => return false,
+                };
+                if (expr.ty != nominal.ty) return false;
+                return try self.appendExistingExprsForShape(nominal.backing.*, backing, out);
+            },
+            .callable => return false,
+        }
+    }
+
+    fn constructorShape(self: *Pass, expr_id: Ast.ExprId) Allocator.Error!?Shape {
+        const expr = self.program.exprs.items[@intFromEnum(expr_id)];
+        return switch (expr.data) {
+            .tag => |tag| blk: {
+                const payloads = self.program.exprSpan(tag.payloads);
+                const shapes = try self.arena.allocator().alloc(Shape, payloads.len);
+                for (payloads, 0..) |payload, index| {
+                    shapes[index] = (try self.constructorShape(payload)) orelse
+                        .{ .any = self.program.exprs.items[@intFromEnum(payload)].ty };
+                }
+                break :blk Shape{ .tag = .{
+                    .ty = expr.ty,
+                    .name = tag.name,
+                    .payloads = shapes,
+                } };
+            },
+            .record => |fields_span| blk: {
+                const fields = self.program.fieldExprSpan(fields_span);
+                const shapes = try self.arena.allocator().alloc(FieldShape, fields.len);
+                for (fields, 0..) |field, index| {
+                    shapes[index] = .{
+                        .name = field.name,
+                        .shape = (try self.constructorShape(field.value)) orelse
+                            .{ .any = self.program.exprs.items[@intFromEnum(field.value)].ty },
+                    };
+                }
+                break :blk Shape{ .record = .{
+                    .ty = expr.ty,
+                    .fields = shapes,
+                } };
+            },
+            .tuple => |items_span| blk: {
+                const items = self.program.exprSpan(items_span);
+                const shapes = try self.arena.allocator().alloc(Shape, items.len);
+                for (items, 0..) |item, index| {
+                    shapes[index] = (try self.constructorShape(item)) orelse
+                        .{ .any = self.program.exprs.items[@intFromEnum(item)].ty };
+                }
+                break :blk Shape{ .tuple = .{
+                    .ty = expr.ty,
+                    .items = shapes,
+                } };
+            },
+            .nominal => |backing| blk: {
+                const backing_shape = (try self.constructorShape(backing)) orelse break :blk null;
+                const stored = try self.arena.allocator().create(Shape);
+                stored.* = backing_shape;
+                break :blk Shape{ .nominal = .{
+                    .ty = expr.ty,
+                    .backing = stored,
+                } };
+            },
+            .fn_ref => |fn_id| blk: {
+                const fn_ = self.program.fns.items[@intFromEnum(fn_id)];
+                const captures = self.program.typedLocalSpan(fn_.captures);
+                const capture_shapes = try self.arena.allocator().alloc(Shape, captures.len);
+                for (captures, 0..) |capture, index| {
+                    capture_shapes[index] = .{ .any = capture.ty };
+                }
+                break :blk Shape{ .callable = .{
+                    .ty = expr.ty,
+                    .fn_id = fn_id,
+                    .captures = capture_shapes,
+                } };
+            },
+            else => null,
+        };
+    }
+
+    fn shapeFromValue(self: *Pass, value: Value) Allocator.Error!?Shape {
+        return switch (value) {
+            .expr => |expr| try self.constructorShape(expr),
+            .tag => |tag| blk: {
+                const payloads = try self.arena.allocator().alloc(Shape, tag.payloads.len);
+                for (tag.payloads, 0..) |payload, index| {
+                    payloads[index] = (try self.shapeFromValue(payload)) orelse
+                        .{ .any = valueType(self.program, payload) };
+                }
+                break :blk Shape{ .tag = .{
+                    .ty = tag.ty,
+                    .name = tag.name,
+                    .payloads = payloads,
+                } };
+            },
+            .record => |record| blk: {
+                const fields = try self.arena.allocator().alloc(FieldShape, record.fields.len);
+                for (record.fields, 0..) |field, index| {
+                    fields[index] = .{
+                        .name = field.name,
+                        .shape = (try self.shapeFromValue(field.value)) orelse
+                            .{ .any = valueType(self.program, field.value) },
+                    };
+                }
+                break :blk Shape{ .record = .{
+                    .ty = record.ty,
+                    .fields = fields,
+                } };
+            },
+            .tuple => |tuple| blk: {
+                const items = try self.arena.allocator().alloc(Shape, tuple.items.len);
+                for (tuple.items, 0..) |item, index| {
+                    items[index] = (try self.shapeFromValue(item)) orelse
+                        .{ .any = valueType(self.program, item) };
+                }
+                break :blk Shape{ .tuple = .{
+                    .ty = tuple.ty,
+                    .items = items,
+                } };
+            },
+            .nominal => |nominal| blk: {
+                const backing_shape = (try self.shapeFromValue(nominal.backing.*)) orelse break :blk null;
+                const stored = try self.arena.allocator().create(Shape);
+                stored.* = backing_shape;
+                break :blk Shape{ .nominal = .{
+                    .ty = nominal.ty,
+                    .backing = stored,
+                } };
+            },
+            .callable => |callable| blk: {
+                const captures = try self.arena.allocator().alloc(Shape, callable.captures.len);
+                for (callable.captures, 0..) |capture, index| {
+                    captures[index] = (try self.shapeFromValue(capture)) orelse
+                        .{ .any = valueType(self.program, capture) };
+                }
+                break :blk Shape{ .callable = .{
+                    .ty = callable.ty,
+                    .fn_id = callable.fn_id,
+                    .captures = captures,
+                } };
+            },
+        };
+    }
+};
+
+const Cloner = struct {
+    pass: *Pass,
+    source_fn: Ast.FnId,
+    pattern: CallPattern,
+    subst: std.AutoHashMap(Ast.LocalId, Value),
+    binder_subst: std.AutoHashMap(check.CheckedModule.PatternBinderId, Value),
+    changes: std.ArrayList(BindingChange),
+    inline_stack: std.ArrayList(Ast.FnId),
+    callable_stack: std.ArrayList(ActiveCallable),
+    loop_stack: std.ArrayList(LoopPattern),
+    inline_direct_calls: bool,
+    inline_direct_requires_known_arg: bool,
+
+    fn init(pass: *Pass, source_fn: Ast.FnId, pattern: CallPattern) Cloner {
+        return .{
+            .pass = pass,
+            .source_fn = source_fn,
+            .pattern = pattern,
+            .subst = std.AutoHashMap(Ast.LocalId, Value).init(pass.allocator),
+            .binder_subst = std.AutoHashMap(check.CheckedModule.PatternBinderId, Value).init(pass.allocator),
+            .changes = .empty,
+            .inline_stack = .empty,
+            .callable_stack = .empty,
+            .loop_stack = .empty,
+            .inline_direct_calls = true,
+            .inline_direct_requires_known_arg = true,
+        };
+    }
+
+    fn initForRewrite(pass: *Pass) Cloner {
+        return .{
+            .pass = pass,
+            .source_fn = @enumFromInt(0),
+            .pattern = .{ .args = &.{} },
+            .subst = std.AutoHashMap(Ast.LocalId, Value).init(pass.allocator),
+            .binder_subst = std.AutoHashMap(check.CheckedModule.PatternBinderId, Value).init(pass.allocator),
+            .changes = .empty,
+            .inline_stack = .empty,
+            .callable_stack = .empty,
+            .loop_stack = .empty,
+            .inline_direct_calls = true,
+            .inline_direct_requires_known_arg = false,
+        };
+    }
+
+    fn deinit(self: *Cloner) void {
+        self.inline_stack.deinit(self.pass.allocator);
+        self.callable_stack.deinit(self.pass.allocator);
+        self.loop_stack.deinit(self.pass.allocator);
+        self.changes.deinit(self.pass.allocator);
+        self.binder_subst.deinit();
+        self.subst.deinit();
+    }
+
+    fn buildArgs(self: *Cloner) Allocator.Error!Ast.Span(Ast.TypedLocal) {
+        const source_fn = self.pass.program.fns.items[@intFromEnum(self.source_fn)];
+        const source_args = self.pass.program.typedLocalSpan(source_fn.args);
+        if (source_args.len != self.pattern.args.len) Common.invariant("call-pattern argument count differed from source function arity");
+
+        var args = std.ArrayList(Ast.TypedLocal).empty;
+        defer args.deinit(self.pass.allocator);
+
+        for (source_args, self.pattern.args) |source_arg, shape| {
+            const value = try self.valueFromShapeArgs(shape, &args);
+            try self.putSubst(source_arg.local, value);
+        }
+
+        return try self.pass.program.addTypedLocalSpan(args.items);
+    }
+
+    fn valueFromShapeArgs(self: *Cloner, shape: Shape, args: *std.ArrayList(Ast.TypedLocal)) Allocator.Error!Value {
+        switch (shape) {
+            .any => |ty| {
+                const local = try self.pass.program.addLocal(self.pass.symbols.fresh(), ty);
+                try args.append(self.pass.allocator, .{ .local = local, .ty = ty });
+                return .{ .expr = try self.pass.program.addExpr(.{
+                    .ty = ty,
+                    .data = .{ .local = local },
+                }) };
+            },
+            .tag => |tag| {
+                const payloads = try self.pass.arena.allocator().alloc(Value, tag.payloads.len);
+                for (tag.payloads, 0..) |payload, index| {
+                    payloads[index] = try self.valueFromShapeArgs(payload, args);
+                }
+                return .{ .tag = .{
+                    .ty = tag.ty,
+                    .name = tag.name,
+                    .payloads = payloads,
+                } };
+            },
+            .record => |record| {
+                const fields = try self.pass.arena.allocator().alloc(FieldValue, record.fields.len);
+                for (record.fields, 0..) |field, index| {
+                    fields[index] = .{
+                        .name = field.name,
+                        .value = try self.valueFromShapeArgs(field.shape, args),
+                    };
+                }
+                return .{ .record = .{
+                    .ty = record.ty,
+                    .fields = fields,
+                } };
+            },
+            .tuple => |tuple| {
+                const items = try self.pass.arena.allocator().alloc(Value, tuple.items.len);
+                for (tuple.items, 0..) |item, index| {
+                    items[index] = try self.valueFromShapeArgs(item, args);
+                }
+                return .{ .tuple = .{
+                    .ty = tuple.ty,
+                    .items = items,
+                } };
+            },
+            .nominal => |nominal| {
+                const backing = try self.pass.arena.allocator().create(Value);
+                backing.* = try self.valueFromShapeArgs(nominal.backing.*, args);
+                return .{ .nominal = .{
+                    .ty = nominal.ty,
+                    .backing = backing,
+                } };
+            },
+            .callable => |callable| {
+                const captures = try self.pass.arena.allocator().alloc(Value, callable.captures.len);
+                for (callable.captures, 0..) |capture, index| {
+                    captures[index] = try self.valueFromShapeArgs(capture, args);
+                }
+                return .{ .callable = .{
+                    .ty = callable.ty,
+                    .fn_id = callable.fn_id,
+                    .captures = captures,
+                } };
+            },
+        }
+    }
+
+    fn cloneExpr(self: *Cloner, expr_id: Ast.ExprId) Common.LowerError!Ast.ExprId {
+        return try self.materialize(try self.cloneExprValue(expr_id));
+    }
+
+    fn cloneExprValue(self: *Cloner, expr_id: Ast.ExprId) Common.LowerError!Value {
+        const expr = self.pass.program.exprs.items[@intFromEnum(expr_id)];
+        switch (expr.data) {
+            .local => |local| {
+                if (self.subst.get(local)) |value| return value;
+                if (self.pass.program.locals.items[@intFromEnum(local)].binder) |binder| {
+                    if (self.binder_subst.get(binder)) |value| return value;
+                }
+                return .{ .expr = try self.addExpr(.{ .ty = expr.ty, .data = .{ .local = local } }) };
+            },
+            .fn_ref => |fn_id| return try self.callableValue(expr.ty, fn_id),
+            .tag => |tag| {
+                const payload_exprs = self.pass.program.exprSpan(tag.payloads);
+                const payloads = try self.pass.arena.allocator().alloc(Value, payload_exprs.len);
+                for (payload_exprs, 0..) |payload, index| {
+                    payloads[index] = try self.cloneExprValue(payload);
+                }
+                return .{ .tag = .{
+                    .ty = expr.ty,
+                    .name = tag.name,
+                    .payloads = payloads,
+                } };
+            },
+            .record => |fields_span| {
+                const source_fields = self.pass.program.fieldExprSpan(fields_span);
+                const fields = try self.pass.arena.allocator().alloc(FieldValue, source_fields.len);
+                for (source_fields, 0..) |field, index| {
+                    fields[index] = .{
+                        .name = field.name,
+                        .value = try self.cloneExprValue(field.value),
+                    };
+                }
+                return .{ .record = .{
+                    .ty = expr.ty,
+                    .fields = fields,
+                } };
+            },
+            .tuple => |items_span| {
+                const source_items = self.pass.program.exprSpan(items_span);
+                const items = try self.pass.arena.allocator().alloc(Value, source_items.len);
+                for (source_items, 0..) |item, index| {
+                    items[index] = try self.cloneExprValue(item);
+                }
+                return .{ .tuple = .{
+                    .ty = expr.ty,
+                    .items = items,
+                } };
+            },
+            .nominal => |backing| {
+                const backing_value = try self.cloneExprValue(backing);
+                return .{ .nominal = .{
+                    .ty = expr.ty,
+                    .backing = try self.copyValue(backing_value),
+                } };
+            },
+            .let_ => |let_| return try self.cloneLetValue(let_),
+            .field_access => |field| {
+                const receiver = try self.cloneExprValue(field.receiver);
+                if (fieldFromValue(receiver, field.field)) |value| return value;
+                return .{ .expr = try self.addExpr(.{ .ty = expr.ty, .data = .{ .field_access = .{
+                    .receiver = try self.materialize(receiver),
+                    .field = field.field,
+                } } }) };
+            },
+            .tuple_access => |access| {
+                const receiver = try self.cloneExprValue(access.tuple);
+                if (itemFromValue(receiver, access.elem_index)) |value| return value;
+                return .{ .expr = try self.addExpr(.{ .ty = expr.ty, .data = .{ .tuple_access = .{
+                    .tuple = try self.materialize(receiver),
+                    .elem_index = access.elem_index,
+                } } }) };
+            },
+            .match_ => |match| {
+                const scrutinee = try self.cloneExprValue(match.scrutinee);
+                if (try self.simplifyKnownMatchValue(scrutinee, match.branches)) |value| return value;
+                const scrutinee_expr = try self.materialize(scrutinee);
+                if (try self.cloneCaseOfCaseValue(expr.ty, scrutinee_expr, match.branches)) |value| return value;
+                return .{ .expr = try self.addExpr(.{ .ty = expr.ty, .data = .{ .match_ = .{
+                    .scrutinee = scrutinee_expr,
+                    .branches = try self.cloneBranchSpan(match.branches),
+                } } }) };
+            },
+            .call_value => |call| {
+                const callee = try self.cloneExprValue(call.callee);
+                if (callee == .callable) {
+                    return try self.inlineCallableCallValue(expr.ty, callee.callable, call.args);
+                }
+                return .{ .expr = try self.addExpr(.{ .ty = expr.ty, .data = .{ .call_value = .{
+                    .callee = try self.materialize(callee),
+                    .args = try self.cloneExprSpan(call.args),
+                } } }) };
+            },
+            .call_proc => |call| {
+                if (!self.inline_direct_calls) return .{ .expr = try self.cloneExprPlain(expr_id) };
+                const has_known_shape_arg = try self.directCallHasKnownShapeArg(call.args);
+                if (self.inline_direct_requires_known_arg and !has_known_shape_arg) {
+                    return .{ .expr = try self.cloneExprPlain(expr_id) };
+                }
+                return try self.inlineDirectCallValue(
+                    expr.ty,
+                    Ast.callProcCallee(call),
+                    call.args,
+                    expr_id,
+                );
+            },
+            else => return .{ .expr = try self.cloneExprPlain(expr_id) },
+        }
+    }
+
+    fn directCallHasKnownShapeArg(self: *Cloner, args_span: Ast.Span(Ast.ExprId)) Allocator.Error!bool {
+        for (self.pass.program.exprSpan(args_span)) |arg| {
+            if (try self.exprHasKnownShape(arg)) return true;
+        }
+        return false;
+    }
+
+    fn exprHasKnownShape(self: *Cloner, expr_id: Ast.ExprId) Allocator.Error!bool {
+        const expr = self.pass.program.exprs.items[@intFromEnum(expr_id)];
+        return switch (expr.data) {
+            .local => |local| if (self.subst.get(local)) |value|
+                (try self.pass.shapeFromValue(value)) != null
+            else
+                false,
+            .tag,
+            .record,
+            .tuple,
+            .nominal,
+            .fn_ref,
+            => (try self.pass.constructorShape(expr_id)) != null,
+            .field_access => |field| blk: {
+                const receiver_local = localExpr(self.pass.program, field.receiver) orelse break :blk false;
+                const receiver = self.subst.get(receiver_local) orelse break :blk false;
+                const value = fieldFromValue(receiver, field.field) orelse break :blk false;
+                break :blk (try self.pass.shapeFromValue(value)) != null;
+            },
+            .tuple_access => |access| blk: {
+                const tuple_local = localExpr(self.pass.program, access.tuple) orelse break :blk false;
+                const tuple = self.subst.get(tuple_local) orelse break :blk false;
+                const value = itemFromValue(tuple, access.elem_index) orelse break :blk false;
+                break :blk (try self.pass.shapeFromValue(value)) != null;
+            },
+            else => false,
+        };
+    }
+
+    fn callableValue(self: *Cloner, ty: Type.TypeId, fn_id: Ast.FnId) Common.LowerError!Value {
+        const fn_ = self.pass.program.fns.items[@intFromEnum(fn_id)];
+        const source_captures = self.pass.program.typedLocalSpan(fn_.captures);
+        const captures = try self.pass.arena.allocator().alloc(Value, source_captures.len);
+        for (source_captures, 0..) |capture, index| {
+            if (self.subst.get(capture.local)) |value| {
+                captures[index] = value;
+            } else {
+                captures[index] = .{ .expr = try self.addExpr(.{
+                    .ty = capture.ty,
+                    .data = .{ .local = capture.local },
+                }) };
+            }
+        }
+        return .{ .callable = .{
+            .ty = ty,
+            .fn_id = fn_id,
+            .captures = captures,
+        } };
+    }
+
+    fn cloneExprPlain(self: *Cloner, expr_id: Ast.ExprId) Common.LowerError!Ast.ExprId {
+        const expr = self.pass.program.exprs.items[@intFromEnum(expr_id)];
+        const data: Ast.ExprData = switch (expr.data) {
+            .local => |local| .{ .local = local },
+            .unit => .unit,
+            .int_lit => |value| .{ .int_lit = value },
+            .frac_f32_lit => |value| .{ .frac_f32_lit = value },
+            .frac_f64_lit => |value| .{ .frac_f64_lit = value },
+            .dec_lit => |value| .{ .dec_lit = value },
+            .str_lit => |value| .{ .str_lit = value },
+            .list => |items| .{ .list = try self.cloneExprSpan(items) },
+            .tuple => |items| .{ .tuple = try self.cloneExprSpan(items) },
+            .record => |fields| .{ .record = try self.cloneFieldExprSpan(fields) },
+            .tag => |tag| .{ .tag = .{
+                .name = tag.name,
+                .payloads = try self.cloneExprSpan(tag.payloads),
+            } },
+            .nominal => |backing| .{ .nominal = try self.cloneExpr(backing) },
+            .let_ => |let_| try self.cloneLet(let_),
+            .lambda,
+            .def_ref,
+            .fn_def,
+            => Common.invariant("pre-lift function expression reached call-pattern specialization"),
+            .fn_ref => |target| .{ .fn_ref = target },
+            .call_value => |call| .{ .call_value = .{
+                .callee = try self.cloneExpr(call.callee),
+                .args = try self.cloneExprSpan(call.args),
+            } },
+            .call_proc => |call| try self.cloneCallProc(call),
+            .low_level => |call| .{ .low_level = .{
+                .op = call.op,
+                .args = try self.cloneExprSpan(call.args),
+            } },
+            .field_access => |field| return try self.cloneFieldAccess(expr.ty, field),
+            .tuple_access => |access| return try self.cloneTupleAccess(expr.ty, access),
+            .structural_eq => |eq| .{ .structural_eq = .{
+                .lhs = try self.cloneExpr(eq.lhs),
+                .rhs = try self.cloneExpr(eq.rhs),
+                .negated = eq.negated,
+            } },
+            .match_ => |match| return try self.cloneMatch(expr.ty, match),
+            .if_ => |if_| .{ .if_ = .{
+                .branches = try self.cloneIfBranchSpan(if_.branches),
+                .final_else = try self.cloneExpr(if_.final_else),
+            } },
+            .block => |block| return try self.cloneBlock(expr.ty, block),
+            .loop_ => |loop| return try self.cloneLoop(expr.ty, loop),
+            .break_ => |maybe| .{ .break_ = if (maybe) |value| try self.cloneExpr(value) else null },
+            .continue_ => |continue_| try self.cloneContinue(continue_),
+            .return_ => |value| .{ .return_ = try self.cloneExpr(value) },
+            .crash => |msg| .{ .crash = msg },
+            .dbg => |child| .{ .dbg = try self.cloneExpr(child) },
+            .expect => |child| .{ .expect = try self.cloneExpr(child) },
+        };
+        return try self.addExpr(.{ .ty = expr.ty, .data = data });
+    }
+
+    fn cloneLetValue(self: *Cloner, let_: anytype) Common.LowerError!Value {
+        const value = try self.cloneExprValue(let_.value);
+        const value_expr = try self.materialize(value);
+        const change_start = self.changes.items.len;
+        const bound = try self.bindPatToValue(let_.bind, value);
+        if (bound) {
+            const rest = try self.cloneExprValue(let_.rest);
+            self.restore(change_start);
+            return rest;
+        }
+        self.restore(change_start);
+        return .{ .expr = try self.addExpr(.{ .ty = self.pass.program.exprs.items[@intFromEnum(let_.rest)].ty, .data = .{ .let_ = .{
+            .bind = try self.clonePat(let_.bind),
+            .value = value_expr,
+            .rest = try self.cloneExpr(let_.rest),
+        } } }) };
+    }
+
+    fn cloneLet(self: *Cloner, let_: anytype) Common.LowerError!Ast.ExprData {
+        const value = try self.cloneExprValue(let_.value);
+        const value_expr = try self.materialize(value);
+        const change_start = self.changes.items.len;
+        const bound = try self.bindPatToValue(let_.bind, value);
+        const rest = if (bound) blk: {
+            const cloned = try self.cloneExpr(let_.rest);
+            self.restore(change_start);
+            break :blk cloned;
+        } else blk: {
+            self.restore(change_start);
+            if (try self.cloneLetOfCase(let_, value_expr)) |data| return data;
+            break :blk try self.cloneExpr(let_.rest);
+        };
+        return .{ .let_ = .{
+            .bind = try self.clonePat(let_.bind),
+            .value = value_expr,
+            .rest = rest,
+        } };
+    }
+
+    fn cloneLetOfCase(self: *Cloner, let_: anytype, value_expr: Ast.ExprId) Common.LowerError!?Ast.ExprData {
+        const value_data = self.pass.program.exprs.items[@intFromEnum(value_expr)].data;
+        const match = switch (value_data) {
+            .match_ => |match| match,
+            else => return null,
+        };
+
+        const branches = try self.pass.allocator.dupe(Ast.Branch, self.pass.program.branchSpan(match.branches));
+        defer self.pass.allocator.free(branches);
+
+        var rewritten = try self.pass.allocator.alloc(Ast.Branch, branches.len);
+        defer self.pass.allocator.free(rewritten);
+
+        for (branches, 0..) |branch, index| {
+            const body = (try self.cloneLetCaseBranchBody(let_, branch.body)) orelse return null;
+            rewritten[index] = .{
+                .pat = branch.pat,
+                .guard = branch.guard,
+                .body = body,
+            };
+        }
+
+        return .{ .match_ = .{
+            .scrutinee = match.scrutinee,
+            .branches = try self.pass.program.addBranchSpan(rewritten),
+        } };
+    }
+
+    fn cloneLetCaseBranchBody(self: *Cloner, let_: anytype, branch_body: Ast.ExprId) Common.LowerError!?Ast.ExprId {
+        const branch_expr = self.pass.program.exprs.items[@intFromEnum(branch_body)];
+        switch (branch_expr.data) {
+            .block => |block| {
+                const change_start = self.changes.items.len;
+
+                const source = try self.pass.allocator.dupe(Ast.StmtId, self.pass.program.stmtSpan(block.statements));
+                defer self.pass.allocator.free(source);
+
+                const statements = try self.pass.allocator.alloc(Ast.StmtId, source.len);
+                defer self.pass.allocator.free(statements);
+                for (source, 0..) |stmt, index| {
+                    statements[index] = try self.cloneStmt(stmt);
+                }
+
+                const final_value = try self.cloneExprValue(block.final_expr);
+                const rest_ty = self.pass.program.exprs.items[@intFromEnum(let_.rest)].ty;
+                if (!try self.bindPatToValue(let_.bind, final_value)) {
+                    if (try self.cloneDivergentAtType(block.final_expr, rest_ty)) |divergent| {
+                        self.restore(change_start);
+                        return try self.addExpr(.{ .ty = rest_ty, .data = .{ .block = .{
+                            .statements = try self.pass.program.addStmtSpan(statements),
+                            .final_expr = divergent,
+                        } } });
+                    }
+                    self.restore(change_start);
+                    return null;
+                }
+
+                const rest = try self.cloneExpr(let_.rest);
+                self.restore(change_start);
+
+                return try self.addExpr(.{ .ty = rest_ty, .data = .{ .block = .{
+                    .statements = try self.pass.program.addStmtSpan(statements),
+                    .final_expr = rest,
+                } } });
+            },
+            else => {
+                const branch_value = try self.cloneExprValue(branch_body);
+                const change_start = self.changes.items.len;
+                if (!try self.bindPatToValue(let_.bind, branch_value)) {
+                    self.restore(change_start);
+                    return null;
+                }
+                const rest = try self.cloneExpr(let_.rest);
+                self.restore(change_start);
+                return rest;
+            },
+        }
+    }
+
+    fn cloneDivergentAtType(self: *Cloner, expr_id: Ast.ExprId, ty: Type.TypeId) Common.LowerError!?Ast.ExprId {
+        const expr = self.pass.program.exprs.items[@intFromEnum(expr_id)];
+        return switch (expr.data) {
+            .crash => |msg| try self.addExpr(.{ .ty = ty, .data = .{ .crash = msg } }),
+            .return_ => |value| try self.addExpr(.{ .ty = ty, .data = .{ .return_ = try self.cloneExpr(value) } }),
+            else => null,
+        };
+    }
+
+    fn cloneLoop(self: *Cloner, ty: Type.TypeId, loop: anytype) Common.LowerError!Ast.ExprId {
+        const params = self.pass.program.typedLocalSpan(loop.params);
+        const initial_values = self.pass.program.exprSpan(loop.initial_values);
+        if (params.len != initial_values.len) Common.invariant("loop parameter count differed from initial value count");
+
+        const values = try self.pass.allocator.alloc(Value, initial_values.len);
+        defer self.pass.allocator.free(values);
+        const shapes = try self.pass.arena.allocator().alloc(Shape, initial_values.len);
+        var has_constructor = false;
+        for (initial_values, 0..) |initial, index| {
+            values[index] = try self.cloneExprValue(initial);
+            if (try self.pass.shapeFromValue(values[index])) |shape| {
+                shapes[index] = shape;
+                has_constructor = true;
+            } else {
+                shapes[index] = .{ .any = valueType(self.pass.program, values[index]) };
+            }
+        }
+
+        if (!has_constructor) {
+            const initial_span = try self.valuesToExprSpan(values);
+            return try self.addExpr(.{ .ty = ty, .data = .{ .loop_ = .{
+                .params = loop.params,
+                .initial_values = initial_span,
+                .body = try self.cloneExpr(loop.body),
+            } } });
+        }
+
+        const change_start = self.changes.items.len;
+        defer self.restore(change_start);
+
+        var new_params = std.ArrayList(Ast.TypedLocal).empty;
+        defer new_params.deinit(self.pass.allocator);
+
+        var new_initials = std.ArrayList(Ast.ExprId).empty;
+        defer new_initials.deinit(self.pass.allocator);
+
+        for (params, shapes, values) |param, shape, value| {
+            const param_value = try self.valueFromShapeArgs(shape, &new_params);
+            try self.putSubst(param.local, param_value);
+            try self.appendExprsFromValue(shape, value, &new_initials);
+        }
+
+        try self.loop_stack.append(self.pass.allocator, .{ .values = shapes });
+        defer _ = self.loop_stack.pop();
+
+        return try self.addExpr(.{ .ty = ty, .data = .{ .loop_ = .{
+            .params = try self.pass.program.addTypedLocalSpan(new_params.items),
+            .initial_values = try self.pass.program.addExprSpan(new_initials.items),
+            .body = try self.cloneExpr(loop.body),
+        } } });
+    }
+
+    fn cloneBlock(self: *Cloner, ty: Type.TypeId, block: anytype) Common.LowerError!Ast.ExprId {
+        const change_start = self.changes.items.len;
+        defer self.restore(change_start);
+
+        const source = try self.pass.allocator.dupe(Ast.StmtId, self.pass.program.stmtSpan(block.statements));
+        defer self.pass.allocator.free(source);
+
+        const statements = try self.pass.allocator.alloc(Ast.StmtId, source.len);
+        defer self.pass.allocator.free(statements);
+        for (source, 0..) |stmt, index| {
+            statements[index] = try self.cloneStmt(stmt);
+        }
+
+        return try self.addExpr(.{ .ty = ty, .data = .{ .block = .{
+            .statements = try self.pass.program.addStmtSpan(statements),
+            .final_expr = try self.cloneExpr(block.final_expr),
+        } } });
+    }
+
+    fn cloneContinue(self: *Cloner, continue_: anytype) Common.LowerError!Ast.ExprData {
+        const loop = self.loop_stack.getLastOrNull() orelse return .{ .continue_ = .{
+            .values = try self.cloneExprSpan(continue_.values),
+        } };
+        const values = self.pass.program.exprSpan(continue_.values);
+        if (values.len != loop.values.len) Common.invariant("continue value count differed from specialized loop pattern");
+
+        var new_values = std.ArrayList(Ast.ExprId).empty;
+        defer new_values.deinit(self.pass.allocator);
+
+        for (loop.values, values) |shape, value_expr| {
+            const value = try self.cloneExprValue(value_expr);
+            if (!shapeMatchesValue(self.pass.program, shape, value)) {
+                if (!try self.appendFieldReadExprsFromValue(shape, value, &new_values)) {
+                    Common.invariant("continue value did not match specialized loop state");
+                }
+                continue;
+            }
+            try self.appendExprsFromValue(shape, value, &new_values);
+        }
+
+        return .{ .continue_ = .{
+            .values = try self.pass.program.addExprSpan(new_values.items),
+        } };
+    }
+
+    fn valuesToExprSpan(self: *Cloner, values: []const Value) Common.LowerError!Ast.Span(Ast.ExprId) {
+        const exprs = try self.pass.allocator.alloc(Ast.ExprId, values.len);
+        defer self.pass.allocator.free(exprs);
+        for (values, 0..) |value, index| {
+            exprs[index] = try self.materialize(value);
+        }
+        return try self.pass.program.addExprSpan(exprs);
+    }
+
+    fn cloneCallProc(self: *Cloner, call: @import("../monotype/ast.zig").CallProc) Common.LowerError!Ast.ExprData {
+        const callee = Ast.callProcCallee(call);
+        const raw = @intFromEnum(callee);
+        if (raw < self.pass.plans.len) {
+            const source_args = self.pass.program.exprSpan(call.args);
+            const args = try self.pass.allocator.dupe(Ast.ExprId, source_args);
+            defer self.pass.allocator.free(args);
+
+            const values = try self.pass.allocator.alloc(Value, args.len);
+            defer self.pass.allocator.free(values);
+            for (args, 0..) |arg, index| {
+                values[index] = try self.cloneExprValue(arg);
+            }
+            try self.pass.ensureCallPatternForValues(callee, values);
+
+            for (self.pass.plans[raw].specs.items) |spec| {
+                var rewritten_args = std.ArrayList(Ast.ExprId).empty;
+                defer rewritten_args.deinit(self.pass.allocator);
+
+                if (try self.appendClonedCallArgs(spec.pattern, args, &rewritten_args)) {
+                    return .{ .call_proc = .{
+                        .callee = .{ .lifted = spec.fn_id orelse Common.invariant("call-pattern specialization id was not assigned before cloning calls") },
+                        .args = try self.pass.program.addExprSpan(rewritten_args.items),
+                    } };
+                }
+            }
+        }
+        return .{ .call_proc = .{
+            .callee = call.callee,
+            .args = try self.cloneExprSpan(call.args),
+        } };
+    }
+
+    fn appendClonedCallArgs(
+        self: *Cloner,
+        pattern: CallPattern,
+        args: []const Ast.ExprId,
+        out: *std.ArrayList(Ast.ExprId),
+    ) Common.LowerError!bool {
+        if (pattern.args.len != args.len) Common.invariant("call-pattern arity differed from direct call arity");
+        for (pattern.args, args) |shape, arg| {
+            if (!try self.appendClonedExprsForShape(shape, arg, out)) return false;
+        }
+        return true;
+    }
+
+    fn appendClonedExprsForShape(
+        self: *Cloner,
+        shape: Shape,
+        expr_id: Ast.ExprId,
+        out: *std.ArrayList(Ast.ExprId),
+    ) Common.LowerError!bool {
+        switch (shape) {
+            .any => {
+                try out.append(self.pass.allocator, try self.cloneExpr(expr_id));
+                return true;
+            },
+            else => {
+                const value = try self.valueForCallArg(expr_id);
+                if (!shapeMatchesValue(self.pass.program, shape, value)) return false;
+                try self.appendExprsFromValue(shape, value, out);
+                return true;
+            },
+        }
+    }
+
+    fn valueForCallArg(self: *Cloner, expr_id: Ast.ExprId) Common.LowerError!Value {
+        return try self.cloneExprValue(expr_id);
+    }
+
+    fn appendExprsFromValue(
+        self: *Cloner,
+        shape: Shape,
+        value: Value,
+        out: *std.ArrayList(Ast.ExprId),
+    ) Common.LowerError!void {
+        switch (shape) {
+            .any => try out.append(self.pass.allocator, try self.materialize(value)),
+            .tag => |tag| {
+                const tag_value = switch (value) {
+                    .tag => |tag_value| tag_value,
+                    else => Common.invariant("tag call pattern matched a non-tag value"),
+                };
+                for (tag.payloads, tag_value.payloads) |payload_shape, payload| {
+                    try self.appendExprsFromValue(payload_shape, payload, out);
+                }
+            },
+            .record => |record| {
+                const record_value = switch (value) {
+                    .record => |record_value| record_value,
+                    else => Common.invariant("record call pattern matched a non-record value"),
+                };
+                for (record.fields, record_value.fields) |field_shape, field| {
+                    if (field_shape.name != field.name) Common.invariant("record call-pattern field order changed after matching");
+                    try self.appendExprsFromValue(field_shape.shape, field.value, out);
+                }
+            },
+            .tuple => |tuple| {
+                const tuple_value = switch (value) {
+                    .tuple => |tuple_value| tuple_value,
+                    else => Common.invariant("tuple call pattern matched a non-tuple value"),
+                };
+                for (tuple.items, tuple_value.items) |item_shape, item| {
+                    try self.appendExprsFromValue(item_shape, item, out);
+                }
+            },
+            .nominal => |nominal| {
+                const nominal_value = switch (value) {
+                    .nominal => |nominal_value| nominal_value,
+                    else => Common.invariant("nominal call pattern matched a non-nominal value"),
+                };
+                try self.appendExprsFromValue(nominal.backing.*, nominal_value.backing.*, out);
+            },
+            .callable => |callable| {
+                const callable_value = switch (value) {
+                    .callable => |callable_value| callable_value,
+                    else => Common.invariant("callable call pattern matched a non-callable value"),
+                };
+                for (callable.captures, callable_value.captures) |capture_shape, capture_value| {
+                    try self.appendExprsFromValue(capture_shape, capture_value, out);
+                }
+            },
+        }
+    }
+
+    fn appendFieldReadExprsFromValue(
+        self: *Cloner,
+        shape: Shape,
+        value: Value,
+        out: *std.ArrayList(Ast.ExprId),
+    ) Common.LowerError!bool {
+        if (shapeMatchesValue(self.pass.program, shape, value)) {
+            try self.appendExprsFromValue(shape, value, out);
+            return true;
+        }
+
+        switch (shape) {
+            .any => {
+                try out.append(self.pass.allocator, try self.materialize(value));
+                return true;
+            },
+            .record => |record| {
+                const receiver = switch (value) {
+                    .expr => |expr| expr,
+                    else => return false,
+                };
+                if (!canReadFieldsFromExpr(self.pass.program, receiver)) return false;
+                for (record.fields) |field| {
+                    const field_expr = try self.addExpr(.{ .ty = shapeType(field.shape), .data = .{ .field_access = .{
+                        .receiver = receiver,
+                        .field = field.name,
+                    } } });
+                    if (!try self.appendFieldReadExprsFromValue(field.shape, .{ .expr = field_expr }, out)) return false;
+                }
+                return true;
+            },
+            .tuple => |tuple| {
+                const receiver = switch (value) {
+                    .expr => |expr| expr,
+                    else => return false,
+                };
+                if (!canReadFieldsFromExpr(self.pass.program, receiver)) return false;
+                for (tuple.items, 0..) |item, index| {
+                    const item_expr = try self.addExpr(.{ .ty = shapeType(item), .data = .{ .tuple_access = .{
+                        .tuple = receiver,
+                        .elem_index = @as(u32, @intCast(index)),
+                    } } });
+                    if (!try self.appendFieldReadExprsFromValue(item, .{ .expr = item_expr }, out)) return false;
+                }
+                return true;
+            },
+            .tag,
+            .nominal,
+            .callable,
+            => return false,
+        }
+    }
+
+    fn cloneFieldAccess(self: *Cloner, ty: Type.TypeId, field: anytype) Common.LowerError!Ast.ExprId {
+        const receiver = try self.cloneExprValue(field.receiver);
+        if (fieldFromValue(receiver, field.field)) |value| return try self.materialize(value);
+        return try self.addExpr(.{ .ty = ty, .data = .{ .field_access = .{
+            .receiver = try self.materialize(receiver),
+            .field = field.field,
+        } } });
+    }
+
+    fn cloneTupleAccess(self: *Cloner, ty: Type.TypeId, access: anytype) Common.LowerError!Ast.ExprId {
+        const receiver = try self.cloneExprValue(access.tuple);
+        if (itemFromValue(receiver, access.elem_index)) |value| return try self.materialize(value);
+        return try self.addExpr(.{ .ty = ty, .data = .{ .tuple_access = .{
+            .tuple = try self.materialize(receiver),
+            .elem_index = access.elem_index,
+        } } });
+    }
+
+    fn cloneMatch(self: *Cloner, ty: Type.TypeId, match: @import("../monotype/ast.zig").MatchExpr) Common.LowerError!Ast.ExprId {
+        const scrutinee = try self.cloneExprValue(match.scrutinee);
+        if (try self.simplifyKnownMatch(scrutinee, match.branches)) |body| return body;
+
+        const scrutinee_expr = try self.materialize(scrutinee);
+        return try self.addExpr(.{ .ty = ty, .data = .{ .match_ = .{
+            .scrutinee = scrutinee_expr,
+            .branches = try self.cloneBranchSpan(match.branches),
+        } } });
+    }
+
+    fn simplifyKnownMatch(self: *Cloner, scrutinee: Value, branches_span: Ast.Span(Ast.Branch)) Common.LowerError!?Ast.ExprId {
+        if (try self.simplifyKnownMatchValue(scrutinee, branches_span)) |value| {
+            return try self.materialize(value);
+        }
+        return null;
+    }
+
+    fn simplifyKnownMatchValue(self: *Cloner, scrutinee: Value, branches_span: Ast.Span(Ast.Branch)) Common.LowerError!?Value {
+        if (scrutinee == .expr) return null;
+        for (self.pass.program.branchSpan(branches_span)) |branch| {
+            const change_start = self.changes.items.len;
+            if (try self.bindPatToValue(branch.pat, scrutinee)) {
+                if (branch.guard != null) {
+                    self.restore(change_start);
+                    return null;
+                }
+                const body = try self.cloneExprValue(branch.body);
+                self.restore(change_start);
+                return body;
+            }
+            self.restore(change_start);
+        }
+        Common.invariant("known constructor match had no matching branch");
+    }
+
+    fn cloneCaseOfCaseValue(
+        self: *Cloner,
+        ty: Type.TypeId,
+        scrutinee_expr: Ast.ExprId,
+        outer_branches_span: Ast.Span(Ast.Branch),
+    ) Common.LowerError!?Value {
+        const scrutinee_data = self.pass.program.exprs.items[@intFromEnum(scrutinee_expr)].data;
+        const inner_match = switch (scrutinee_data) {
+            .match_ => |match| match,
+            else => return null,
+        };
+
+        const outer_branches = self.pass.program.branchSpan(outer_branches_span);
+        for (outer_branches) |branch| {
+            if (branch.guard != null) return null;
+        }
+
+        const inner_branches = try self.pass.allocator.dupe(Ast.Branch, self.pass.program.branchSpan(inner_match.branches));
+        defer self.pass.allocator.free(inner_branches);
+
+        var rewritten = try self.pass.allocator.alloc(Ast.Branch, inner_branches.len);
+        defer self.pass.allocator.free(rewritten);
+
+        for (inner_branches, 0..) |inner_branch, index| {
+            const inner_value = try self.cloneExprValue(inner_branch.body);
+            const outer_value = (try self.simplifyKnownMatchValue(inner_value, outer_branches_span)) orelse return null;
+            rewritten[index] = .{
+                .pat = inner_branch.pat,
+                .guard = inner_branch.guard,
+                .body = try self.materialize(outer_value),
+            };
+        }
+
+        return .{ .expr = try self.addExpr(.{ .ty = ty, .data = .{ .match_ = .{
+            .scrutinee = inner_match.scrutinee,
+            .branches = try self.pass.program.addBranchSpan(rewritten),
+        } } }) };
+    }
+
+    fn inlineCallableCallValue(
+        self: *Cloner,
+        ty: Type.TypeId,
+        callable: CallableValue,
+        args_span: Ast.Span(Ast.ExprId),
+    ) Common.LowerError!Value {
+        for (self.inline_stack.items) |active| {
+            if (active == callable.fn_id) {
+                return .{ .expr = try self.addExpr(.{ .ty = ty, .data = .{ .call_value = .{
+                    .callee = try self.materialize(.{ .callable = callable }),
+                    .args = try self.cloneExprSpan(args_span),
+                } } }) };
+            }
+        }
+
+        const source_fn = self.pass.program.fns.items[@intFromEnum(callable.fn_id)];
+        const body = switch (source_fn.body) {
+            .roc => |body| body,
+            .hosted => return .{ .expr = try self.addExpr(.{ .ty = ty, .data = .{ .call_value = .{
+                .callee = try self.materialize(.{ .callable = callable }),
+                .args = try self.cloneExprSpan(args_span),
+            } } }) },
+        };
+
+        const source_args = try self.pass.allocator.dupe(Ast.TypedLocal, self.pass.program.typedLocalSpan(source_fn.args));
+        defer self.pass.allocator.free(source_args);
+        const args = try self.pass.allocator.dupe(Ast.ExprId, self.pass.program.exprSpan(args_span));
+        defer self.pass.allocator.free(args);
+        if (source_args.len != args.len) Common.invariant("callable call arity differed from lifted function arity");
+
+        const source_captures = try self.pass.allocator.dupe(Ast.TypedLocal, self.pass.program.typedLocalSpan(source_fn.captures));
+        defer self.pass.allocator.free(source_captures);
+        if (source_captures.len != callable.captures.len) {
+            Common.invariant("callable value capture count differed from lifted function capture count");
+        }
+
+        try self.inline_stack.append(self.pass.allocator, callable.fn_id);
+        defer {
+            const popped = self.inline_stack.pop() orelse Common.invariant("call-pattern inline stack underflow");
+            if (popped != callable.fn_id) Common.invariant("call-pattern inline stack was corrupted");
+        }
+
+        const change_start = self.changes.items.len;
+        defer self.restore(change_start);
+
+        for (source_captures, callable.captures) |source_capture, capture_value| {
+            try self.putSubst(source_capture.local, capture_value);
+        }
+        for (source_args, args) |source_arg, arg_expr| {
+            try self.putSubst(source_arg.local, try self.cloneExprValue(arg_expr));
+        }
+
+        return try self.cloneExprValue(body);
+    }
+
+    fn inlineDirectCallValue(
+        self: *Cloner,
+        ty: Type.TypeId,
+        callee: Ast.FnId,
+        args_span: Ast.Span(Ast.ExprId),
+        original_expr: Ast.ExprId,
+    ) Common.LowerError!Value {
+        for (self.inline_stack.items) |active| {
+            if (active == callee) return .{ .expr = try self.cloneExprPlain(original_expr) };
+        }
+
+        const source_fn = self.pass.program.fns.items[@intFromEnum(callee)];
+        const body = switch (source_fn.body) {
+            .roc => |body| body,
+            .hosted => return .{ .expr = try self.cloneExprPlain(original_expr) },
+        };
+        const source_args = try self.pass.allocator.dupe(Ast.TypedLocal, self.pass.program.typedLocalSpan(source_fn.args));
+        defer self.pass.allocator.free(source_args);
+        const args = try self.pass.allocator.dupe(Ast.ExprId, self.pass.program.exprSpan(args_span));
+        defer self.pass.allocator.free(args);
+        if (source_args.len != args.len) Common.invariant("direct call arity differed from lifted function arity");
+
+        try self.inline_stack.append(self.pass.allocator, callee);
+        defer {
+            const popped = self.inline_stack.pop() orelse Common.invariant("call-pattern inline stack underflow");
+            if (popped != callee) Common.invariant("call-pattern inline stack was corrupted");
+        }
+
+        const change_start = self.changes.items.len;
+        defer self.restore(change_start);
+
+        const captures = try self.pass.allocator.dupe(Ast.TypedLocal, self.pass.program.typedLocalSpan(source_fn.captures));
+        defer self.pass.allocator.free(captures);
+        for (captures) |capture| {
+            if (self.subst.get(capture.local)) |value| {
+                try self.putSubst(capture.local, value);
+            }
+        }
+        for (source_args, args) |source_arg, arg_expr| {
+            try self.putSubst(source_arg.local, try self.cloneExprValue(arg_expr));
+        }
+
+        _ = ty;
+        return try self.cloneExprValue(body);
+    }
+
+    fn bindPatToValue(self: *Cloner, pat_id: Ast.PatId, value: Value) Common.LowerError!bool {
+        const pat = self.pass.program.pats.items[@intFromEnum(pat_id)];
+        switch (pat.data) {
+            .bind => |local| {
+                try self.putSubst(local, value);
+                return true;
+            },
+            .wildcard => return true,
+            .as => |as| {
+                if (!try self.bindPatToValue(as.pattern, value)) return false;
+                try self.putSubst(as.local, value);
+                return true;
+            },
+            .record => |fields_span| {
+                const record = recordFromValue(value) orelse return false;
+                const fields = self.pass.program.recordDestructSpan(fields_span);
+                for (fields) |field| {
+                    const field_value = fieldFromRecord(record, field.name) orelse return false;
+                    if (!try self.bindPatToValue(field.pattern, field_value)) return false;
+                }
+                return true;
+            },
+            .tuple => |items_span| {
+                const tuple = tupleFromValue(value) orelse return false;
+                const pats = self.pass.program.patSpan(items_span);
+                if (pats.len != tuple.items.len) return false;
+                for (pats, tuple.items) |child_pat, child_value| {
+                    if (!try self.bindPatToValue(child_pat, child_value)) return false;
+                }
+                return true;
+            },
+            .tag => |tag_pat| {
+                const tag = tagFromValue(value) orelse return false;
+                if (tag.name != tag_pat.name) return false;
+                const pats = self.pass.program.patSpan(tag_pat.payloads);
+                if (pats.len != tag.payloads.len) return false;
+                for (pats, tag.payloads) |child_pat, child_value| {
+                    if (!try self.bindPatToValue(child_pat, child_value)) return false;
+                }
+                return true;
+            },
+            .nominal => |backing_pat| {
+                const nominal = switch (value) {
+                    .nominal => |nominal| nominal,
+                    else => return false,
+                };
+                return try self.bindPatToValue(backing_pat, nominal.backing.*);
+            },
+            .int_lit,
+            .dec_lit,
+            .frac_f32_lit,
+            .frac_f64_lit,
+            .str_lit,
+            => return false,
+        }
+    }
+
+    fn clonePat(self: *Cloner, pat_id: Ast.PatId) Allocator.Error!Ast.PatId {
+        const pat = self.pass.program.pats.items[@intFromEnum(pat_id)];
+        const data: Ast.PatData = switch (pat.data) {
+            .bind => |local| .{ .bind = local },
+            .wildcard => .wildcard,
+            .as => |as| .{ .as = .{
+                .pattern = try self.clonePat(as.pattern),
+                .local = as.local,
+            } },
+            .record => |fields| .{ .record = try self.cloneRecordDestructSpan(fields) },
+            .tuple => |items| .{ .tuple = try self.clonePatSpan(items) },
+            .tag => |tag| .{ .tag = .{
+                .name = tag.name,
+                .payloads = try self.clonePatSpan(tag.payloads),
+            } },
+            .nominal => |backing| .{ .nominal = try self.clonePat(backing) },
+            .int_lit => |value| .{ .int_lit = value },
+            .dec_lit => |value| .{ .dec_lit = value },
+            .frac_f32_lit => |value| .{ .frac_f32_lit = value },
+            .frac_f64_lit => |value| .{ .frac_f64_lit = value },
+            .str_lit => |value| .{ .str_lit = value },
+        };
+        return try self.pass.program.addPat(.{ .ty = pat.ty, .data = data });
+    }
+
+    fn cloneStmt(self: *Cloner, stmt_id: Ast.StmtId) Common.LowerError!Ast.StmtId {
+        const stmt = self.pass.program.stmts.items[@intFromEnum(stmt_id)];
+        return try self.pass.program.addStmt(switch (stmt) {
+            .let_ => |let_| blk: {
+                const value = try self.cloneExprValue(let_.value);
+                const value_expr = try self.materialize(value);
+                _ = try self.bindPatToValue(let_.pat, value);
+                break :blk .{ .let_ = .{
+                    .pat = try self.clonePat(let_.pat),
+                    .value = value_expr,
+                    .recursive = let_.recursive,
+                } };
+            },
+            .expr => |expr| .{ .expr = try self.cloneExpr(expr) },
+            .expect => |expr| .{ .expect = try self.cloneExpr(expr) },
+            .dbg => |expr| .{ .dbg = try self.cloneExpr(expr) },
+            .return_ => |expr| .{ .return_ = try self.cloneExpr(expr) },
+            .crash => |msg| .{ .crash = msg },
+        });
+    }
+
+    fn cloneExprSpan(self: *Cloner, span: Ast.Span(Ast.ExprId)) Common.LowerError!Ast.Span(Ast.ExprId) {
+        const source = try self.pass.allocator.dupe(Ast.ExprId, self.pass.program.exprSpan(span));
+        defer self.pass.allocator.free(source);
+
+        const values = try self.pass.allocator.alloc(Ast.ExprId, source.len);
+        defer self.pass.allocator.free(values);
+        for (source, 0..) |expr, index| values[index] = try self.cloneExpr(expr);
+        return try self.pass.program.addExprSpan(values);
+    }
+
+    fn clonePatSpan(self: *Cloner, span: Ast.Span(Ast.PatId)) Allocator.Error!Ast.Span(Ast.PatId) {
+        const source = try self.pass.allocator.dupe(Ast.PatId, self.pass.program.patSpan(span));
+        defer self.pass.allocator.free(source);
+
+        const values = try self.pass.allocator.alloc(Ast.PatId, source.len);
+        defer self.pass.allocator.free(values);
+        for (source, 0..) |pat, index| values[index] = try self.clonePat(pat);
+        return try self.pass.program.addPatSpan(values);
+    }
+
+    fn cloneStmtSpan(self: *Cloner, span: Ast.Span(Ast.StmtId)) Common.LowerError!Ast.Span(Ast.StmtId) {
+        const source = try self.pass.allocator.dupe(Ast.StmtId, self.pass.program.stmtSpan(span));
+        defer self.pass.allocator.free(source);
+
+        const values = try self.pass.allocator.alloc(Ast.StmtId, source.len);
+        defer self.pass.allocator.free(values);
+        for (source, 0..) |stmt, index| values[index] = try self.cloneStmt(stmt);
+        return try self.pass.program.addStmtSpan(values);
+    }
+
+    fn cloneFieldExprSpan(self: *Cloner, span: Ast.Span(Ast.FieldExpr)) Common.LowerError!Ast.Span(Ast.FieldExpr) {
+        const source = try self.pass.allocator.dupe(Ast.FieldExpr, self.pass.program.fieldExprSpan(span));
+        defer self.pass.allocator.free(source);
+
+        const values = try self.pass.allocator.alloc(Ast.FieldExpr, source.len);
+        defer self.pass.allocator.free(values);
+        for (source, 0..) |field, index| {
+            values[index] = .{
+                .name = field.name,
+                .value = try self.cloneExpr(field.value),
+            };
+        }
+        return try self.pass.program.addFieldExprSpan(values);
+    }
+
+    fn cloneRecordDestructSpan(self: *Cloner, span: Ast.Span(Ast.RecordDestruct)) Allocator.Error!Ast.Span(Ast.RecordDestruct) {
+        const source = try self.pass.allocator.dupe(Ast.RecordDestruct, self.pass.program.recordDestructSpan(span));
+        defer self.pass.allocator.free(source);
+
+        const values = try self.pass.allocator.alloc(Ast.RecordDestruct, source.len);
+        defer self.pass.allocator.free(values);
+        for (source, 0..) |field, index| {
+            values[index] = .{
+                .name = field.name,
+                .pattern = try self.clonePat(field.pattern),
+            };
+        }
+        return try self.pass.program.addRecordDestructSpan(values);
+    }
+
+    fn cloneBranchSpan(self: *Cloner, span: Ast.Span(Ast.Branch)) Common.LowerError!Ast.Span(Ast.Branch) {
+        const source = try self.pass.allocator.dupe(Ast.Branch, self.pass.program.branchSpan(span));
+        defer self.pass.allocator.free(source);
+
+        const values = try self.pass.allocator.alloc(Ast.Branch, source.len);
+        defer self.pass.allocator.free(values);
+        for (source, 0..) |branch, index| {
+            values[index] = .{
+                .pat = try self.clonePat(branch.pat),
+                .guard = if (branch.guard) |guard| try self.cloneExpr(guard) else null,
+                .body = try self.cloneExpr(branch.body),
+            };
+        }
+        return try self.pass.program.addBranchSpan(values);
+    }
+
+    fn cloneIfBranchSpan(self: *Cloner, span: Ast.Span(Ast.IfBranch)) Common.LowerError!Ast.Span(Ast.IfBranch) {
+        const source = try self.pass.allocator.dupe(Ast.IfBranch, self.pass.program.ifBranchSpan(span));
+        defer self.pass.allocator.free(source);
+
+        const values = try self.pass.allocator.alloc(Ast.IfBranch, source.len);
+        defer self.pass.allocator.free(values);
+        for (source, 0..) |branch, index| {
+            values[index] = .{
+                .cond = try self.cloneExpr(branch.cond),
+                .body = try self.cloneExpr(branch.body),
+            };
+        }
+        return try self.pass.program.addIfBranchSpan(values);
+    }
+
+    fn materialize(self: *Cloner, value: Value) Common.LowerError!Ast.ExprId {
+        switch (value) {
+            .expr => |expr| return expr,
+            .tag => |tag| {
+                const payloads = try self.pass.allocator.alloc(Ast.ExprId, tag.payloads.len);
+                defer self.pass.allocator.free(payloads);
+                for (tag.payloads, 0..) |payload, index| {
+                    payloads[index] = try self.materialize(payload);
+                }
+                return try self.addExpr(.{ .ty = tag.ty, .data = .{ .tag = .{
+                    .name = tag.name,
+                    .payloads = try self.pass.program.addExprSpan(payloads),
+                } } });
+            },
+            .record => |record| {
+                const fields = try self.pass.allocator.alloc(Ast.FieldExpr, record.fields.len);
+                defer self.pass.allocator.free(fields);
+                for (record.fields, 0..) |field, index| {
+                    fields[index] = .{
+                        .name = field.name,
+                        .value = try self.materialize(field.value),
+                    };
+                }
+                return try self.addExpr(.{ .ty = record.ty, .data = .{
+                    .record = try self.pass.program.addFieldExprSpan(fields),
+                } });
+            },
+            .tuple => |tuple| {
+                const items = try self.pass.allocator.alloc(Ast.ExprId, tuple.items.len);
+                defer self.pass.allocator.free(items);
+                for (tuple.items, 0..) |item, index| {
+                    items[index] = try self.materialize(item);
+                }
+                return try self.addExpr(.{ .ty = tuple.ty, .data = .{
+                    .tuple = try self.pass.program.addExprSpan(items),
+                } });
+            },
+            .nominal => |nominal| return try self.addExpr(.{ .ty = nominal.ty, .data = .{
+                .nominal = try self.materialize(nominal.backing.*),
+            } }),
+            .callable => |callable| return try self.materializeCallable(callable),
+        }
+    }
+
+    fn materializeCallable(self: *Cloner, callable: CallableValue) Common.LowerError!Ast.ExprId {
+        const fn_ = self.pass.program.fns.items[@intFromEnum(callable.fn_id)];
+        const captures = self.pass.program.typedLocalSpan(fn_.captures);
+        if (captures.len != callable.captures.len) {
+            Common.invariant("callable value capture count differed from lifted function capture count");
+        }
+
+        var all_original = true;
+        for (captures, callable.captures) |capture, value| {
+            const expr = switch (value) {
+                .expr => |expr| expr,
+                else => {
+                    all_original = false;
+                    break;
+                },
+            };
+            const local = localExpr(self.pass.program, expr) orelse {
+                all_original = false;
+                break;
+            };
+            if (local != capture.local) {
+                all_original = false;
+                break;
+            }
+        }
+
+        if (!all_original) {
+            var active_index = self.callable_stack.items.len;
+            while (active_index > 0) {
+                active_index -= 1;
+                const active = self.callable_stack.items[active_index];
+                if (active.source == callable.fn_id) {
+                    const active_fn = self.pass.program.fns.items[@intFromEnum(active.specialized)];
+                    return try self.materializeCallableWithCaptures(
+                        callable.ty,
+                        active.specialized,
+                        active_fn.captures,
+                        callable.captures,
+                    );
+                }
+            }
+            return try self.specializedCallableRef(callable);
+        }
+
+        return try self.addExpr(.{ .ty = callable.ty, .data = .{ .fn_ref = callable.fn_id } });
+    }
+
+    fn specializedCallableRef(self: *Cloner, callable: CallableValue) Common.LowerError!Ast.ExprId {
+        const source_fn = self.pass.program.fns.items[@intFromEnum(callable.fn_id)];
+        const source_body = switch (source_fn.body) {
+            .roc => |body| body,
+            .hosted => Common.invariant("hosted callable value needed capture substitution"),
+        };
+
+        const source_captures = try self.pass.allocator.dupe(Ast.TypedLocal, self.pass.program.typedLocalSpan(source_fn.captures));
+        defer self.pass.allocator.free(source_captures);
+        if (source_captures.len != callable.captures.len) {
+            Common.invariant("callable value capture count differed from lifted function capture count");
+        }
+
+        const captures = try self.pass.allocator.alloc(Ast.TypedLocal, callable.captures.len);
+        defer self.pass.allocator.free(captures);
+        for (source_captures, 0..) |source_capture, index| {
+            const local = try self.pass.program.addLocal(self.pass.symbols.fresh(), source_capture.ty);
+            captures[index] = .{
+                .local = local,
+                .ty = source_capture.ty,
+            };
+        }
+        const captures_span = try self.pass.program.addTypedLocalSpan(captures);
+
+        const source_args = try self.pass.allocator.dupe(Ast.TypedLocal, self.pass.program.typedLocalSpan(source_fn.args));
+        defer self.pass.allocator.free(source_args);
+        const args = try self.pass.allocator.alloc(Ast.TypedLocal, source_args.len);
+        defer self.pass.allocator.free(args);
+        for (source_args, 0..) |source_arg, index| {
+            const local = try self.pass.program.addLocal(self.pass.symbols.fresh(), source_arg.ty);
+            args[index] = .{ .local = local, .ty = source_arg.ty };
+        }
+        const args_span = try self.pass.program.addTypedLocalSpan(args);
+
+        const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(self.pass.program.fns.items.len)));
+        const symbol = self.pass.symbols.fresh();
+        try self.pass.program.fns.append(self.pass.allocator, .{
+            .symbol = symbol,
+            .source = source_fn.source,
+            .args = args_span,
+            .captures = captures_span,
+            .body = .hosted,
+            .ret = source_fn.ret,
+        });
+
+        try self.callable_stack.append(self.pass.allocator, .{
+            .source = callable.fn_id,
+            .specialized = fn_id,
+        });
+        defer {
+            const popped = self.callable_stack.pop() orelse Common.invariant("callable specialization stack underflow");
+            if (popped.source != callable.fn_id or popped.specialized != fn_id) {
+                Common.invariant("callable specialization stack was corrupted");
+            }
+        }
+
+        const result = try self.materializeCallableWithCaptures(
+            callable.ty,
+            fn_id,
+            captures_span,
+            callable.captures,
+        );
+
+        const change_start = self.changes.items.len;
+        defer self.restore(change_start);
+
+        for (source_captures, captures) |source_capture, capture| {
+            const local_expr = try self.pass.program.addExpr(.{
+                .ty = capture.ty,
+                .data = .{ .local = capture.local },
+            });
+            try self.putSubst(source_capture.local, .{ .expr = local_expr });
+        }
+        for (source_args, args) |source_arg, arg| {
+            const arg_expr = try self.pass.program.addExpr(.{
+                .ty = arg.ty,
+                .data = .{ .local = arg.local },
+            });
+            try self.putSubst(source_arg.local, .{ .expr = arg_expr });
+        }
+
+        self.pass.program.fns.items[@intFromEnum(fn_id)] = .{
+            .symbol = symbol,
+            .source = source_fn.source,
+            .args = args_span,
+            .captures = captures_span,
+            .body = .{ .roc = try self.cloneExpr(source_body) },
+            .ret = source_fn.ret,
+        };
+
+        return result;
+    }
+
+    fn materializeCallableWithCaptures(
+        self: *Cloner,
+        ty: Type.TypeId,
+        fn_id: Ast.FnId,
+        captures_span: Ast.Span(Ast.TypedLocal),
+        values: []const Value,
+    ) Common.LowerError!Ast.ExprId {
+        const captures = try self.pass.allocator.dupe(Ast.TypedLocal, self.pass.program.typedLocalSpan(captures_span));
+        defer self.pass.allocator.free(captures);
+        if (captures.len != values.len) {
+            Common.invariant("callable value capture count differed from specialized function capture count");
+        }
+
+        const value_exprs = try self.pass.allocator.alloc(?Ast.ExprId, values.len);
+        defer self.pass.allocator.free(value_exprs);
+        for (captures, values, 0..) |capture, value, index| {
+            const value_expr = try self.materialize(value);
+            const value_local = localExpr(self.pass.program, value_expr);
+            value_exprs[index] = if (value_local != null and value_local.? == capture.local) null else value_expr;
+        }
+
+        var result = try self.addExpr(.{ .ty = ty, .data = .{ .fn_ref = fn_id } });
+        var index = value_exprs.len;
+        while (index > 0) {
+            index -= 1;
+            const value_expr = value_exprs[index] orelse continue;
+            const pat = try self.pass.program.addPat(.{
+                .ty = captures[index].ty,
+                .data = .{ .bind = captures[index].local },
+            });
+            result = try self.addExpr(.{ .ty = ty, .data = .{ .let_ = .{
+                .bind = pat,
+                .value = value_expr,
+                .rest = result,
+            } } });
+        }
+        return result;
+    }
+
+    fn copyValue(self: *Cloner, value: Value) Allocator.Error!*const Value {
+        const out = try self.pass.arena.allocator().create(Value);
+        out.* = value;
+        return out;
+    }
+
+    fn putSubst(self: *Cloner, local: Ast.LocalId, value: Value) Allocator.Error!void {
+        const previous = self.subst.get(local);
+        try self.changes.append(self.pass.allocator, .{
+            .key = .{ .local = local },
+            .previous = previous,
+        });
+        try self.subst.put(local, value);
+
+        const subst_binder = switch (value) {
+            .tag,
+            .record,
+            .tuple,
+            .nominal,
+            => true,
+            .expr,
+            .callable,
+            => false,
+        };
+        if (subst_binder) if (self.pass.program.locals.items[@intFromEnum(local)].binder) |binder| {
+            const previous_binder = self.binder_subst.get(binder);
+            try self.changes.append(self.pass.allocator, .{
+                .key = .{ .binder = binder },
+                .previous = previous_binder,
+            });
+            try self.binder_subst.put(binder, value);
+        };
+    }
+
+    fn restore(self: *Cloner, start: usize) void {
+        var index = self.changes.items.len;
+        while (index > start) {
+            index -= 1;
+            const change = self.changes.items[index];
+            switch (change.key) {
+                .local => |local| {
+                    if (change.previous) |previous| {
+                        self.subst.putAssumeCapacity(local, previous);
+                    } else {
+                        _ = self.subst.remove(local);
+                    }
+                },
+                .binder => |binder| {
+                    if (change.previous) |previous| {
+                        self.binder_subst.putAssumeCapacity(binder, previous);
+                    } else {
+                        _ = self.binder_subst.remove(binder);
+                    }
+                },
+            }
+        }
+        self.changes.shrinkRetainingCapacity(start);
+    }
+
+    fn addExpr(self: *Cloner, expr: Ast.Expr) Allocator.Error!Ast.ExprId {
+        return try self.pass.program.addExpr(expr);
+    }
+};
+
+fn localExpr(program: *const Ast.Program, expr_id: Ast.ExprId) ?Ast.LocalId {
+    return switch (program.exprs.items[@intFromEnum(expr_id)].data) {
+        .local => |local| local,
+        else => null,
+    };
+}
+
+fn canReadFieldsFromExpr(program: *const Ast.Program, expr_id: Ast.ExprId) bool {
+    return switch (program.exprs.items[@intFromEnum(expr_id)].data) {
+        .local,
+        .field_access,
+        .tuple_access,
+        => true,
+        else => false,
+    };
+}
+
+fn shapeType(shape: Shape) Type.TypeId {
+    return switch (shape) {
+        .any => |ty| ty,
+        .tag => |tag| tag.ty,
+        .record => |record| record.ty,
+        .tuple => |tuple| tuple.ty,
+        .nominal => |nominal| nominal.ty,
+        .callable => |callable| callable.ty,
+    };
+}
+
+fn valueType(program: *const Ast.Program, value: Value) Type.TypeId {
+    return switch (value) {
+        .expr => |expr| program.exprs.items[@intFromEnum(expr)].ty,
+        .tag => |tag| tag.ty,
+        .record => |record| record.ty,
+        .tuple => |tuple| tuple.ty,
+        .nominal => |nominal| nominal.ty,
+        .callable => |callable| callable.ty,
+    };
+}
+
+fn patternEql(lhs: CallPattern, rhs: CallPattern) bool {
+    if (lhs.args.len != rhs.args.len) return false;
+    for (lhs.args, rhs.args) |lhs_arg, rhs_arg| {
+        if (!shapeEql(lhs_arg, rhs_arg)) return false;
+    }
+    return true;
+}
+
+fn shapeEql(lhs: Shape, rhs: Shape) bool {
+    if (std.meta.activeTag(lhs) != std.meta.activeTag(rhs)) return false;
+    return switch (lhs) {
+        .any => |lhs_ty| lhs_ty == rhs.any,
+        .tag => |lhs_tag| blk: {
+            const rhs_tag = rhs.tag;
+            if (lhs_tag.ty != rhs_tag.ty or lhs_tag.name != rhs_tag.name or lhs_tag.payloads.len != rhs_tag.payloads.len) break :blk false;
+            for (lhs_tag.payloads, rhs_tag.payloads) |lhs_payload, rhs_payload| {
+                if (!shapeEql(lhs_payload, rhs_payload)) break :blk false;
+            }
+            break :blk true;
+        },
+        .record => |lhs_record| blk: {
+            const rhs_record = rhs.record;
+            if (lhs_record.ty != rhs_record.ty or lhs_record.fields.len != rhs_record.fields.len) break :blk false;
+            for (lhs_record.fields, rhs_record.fields) |lhs_field, rhs_field| {
+                if (lhs_field.name != rhs_field.name or !shapeEql(lhs_field.shape, rhs_field.shape)) break :blk false;
+            }
+            break :blk true;
+        },
+        .tuple => |lhs_tuple| blk: {
+            const rhs_tuple = rhs.tuple;
+            if (lhs_tuple.ty != rhs_tuple.ty or lhs_tuple.items.len != rhs_tuple.items.len) break :blk false;
+            for (lhs_tuple.items, rhs_tuple.items) |lhs_item, rhs_item| {
+                if (!shapeEql(lhs_item, rhs_item)) break :blk false;
+            }
+            break :blk true;
+        },
+        .nominal => |lhs_nominal| {
+            const rhs_nominal = rhs.nominal;
+            return lhs_nominal.ty == rhs_nominal.ty and shapeEql(lhs_nominal.backing.*, rhs_nominal.backing.*);
+        },
+        .callable => |lhs_callable| blk: {
+            const rhs_callable = rhs.callable;
+            if (lhs_callable.ty != rhs_callable.ty or
+                lhs_callable.fn_id != rhs_callable.fn_id or
+                lhs_callable.captures.len != rhs_callable.captures.len)
+            {
+                break :blk false;
+            }
+            for (lhs_callable.captures, rhs_callable.captures) |lhs_capture, rhs_capture| {
+                if (!shapeEql(lhs_capture, rhs_capture)) break :blk false;
+            }
+            break :blk true;
+        },
+    };
+}
+
+fn shapeMatchesValue(program: *const Ast.Program, shape: Shape, value: Value) bool {
+    return switch (shape) {
+        .any => true,
+        .tag => |tag| blk: {
+            const value_tag = switch (value) {
+                .tag => |value_tag| value_tag,
+                else => break :blk false,
+            };
+            if (tag.ty != value_tag.ty or tag.name != value_tag.name or tag.payloads.len != value_tag.payloads.len) break :blk false;
+            for (tag.payloads, value_tag.payloads) |payload_shape, payload_value| {
+                if (!shapeMatchesValue(program, payload_shape, payload_value)) break :blk false;
+            }
+            break :blk true;
+        },
+        .record => |record| blk: {
+            const value_record = switch (value) {
+                .record => |value_record| value_record,
+                else => break :blk false,
+            };
+            if (record.ty != value_record.ty or record.fields.len != value_record.fields.len) break :blk false;
+            for (record.fields, value_record.fields) |field_shape, field_value| {
+                if (field_shape.name != field_value.name or !shapeMatchesValue(program, field_shape.shape, field_value.value)) break :blk false;
+            }
+            break :blk true;
+        },
+        .tuple => |tuple| blk: {
+            const value_tuple = switch (value) {
+                .tuple => |value_tuple| value_tuple,
+                else => break :blk false,
+            };
+            if (tuple.ty != value_tuple.ty or tuple.items.len != value_tuple.items.len) break :blk false;
+            for (tuple.items, value_tuple.items) |item_shape, item_value| {
+                if (!shapeMatchesValue(program, item_shape, item_value)) break :blk false;
+            }
+            break :blk true;
+        },
+        .nominal => |nominal| blk: {
+            const value_nominal = switch (value) {
+                .nominal => |value_nominal| value_nominal,
+                else => break :blk false,
+            };
+            break :blk nominal.ty == value_nominal.ty and shapeMatchesValue(program, nominal.backing.*, value_nominal.backing.*);
+        },
+        .callable => |callable| blk: {
+            const value_callable = switch (value) {
+                .callable => |value_callable| value_callable,
+                else => break :blk false,
+            };
+            if (callable.ty != value_callable.ty or
+                !callableTargetMatches(program, callable.fn_id, value_callable.fn_id) or
+                callable.captures.len != value_callable.captures.len)
+            {
+                break :blk false;
+            }
+            for (callable.captures, value_callable.captures) |capture_shape, capture_value| {
+                if (!shapeMatchesValue(program, capture_shape, capture_value)) break :blk false;
+            }
+            break :blk true;
+        },
+    };
+}
+
+fn callableTargetMatches(program: *const Ast.Program, expected: Ast.FnId, actual: Ast.FnId) bool {
+    if (expected == actual) return true;
+    const expected_source = program.fns.items[@intFromEnum(expected)].source orelse return false;
+    const actual_source = program.fns.items[@intFromEnum(actual)].source orelse return false;
+    return Mono.fnTemplateIdentityEql(expected_source, actual_source);
+}
+
+fn fieldFromValue(value: Value, name: names.RecordFieldNameId) ?Value {
+    const record = recordFromValue(value) orelse return null;
+    return fieldFromRecord(record, name);
+}
+
+fn fieldFromRecord(record: RecordValue, name: names.RecordFieldNameId) ?Value {
+    for (record.fields) |field| {
+        if (field.name == name) return field.value;
+    }
+    return null;
+}
+
+fn itemFromValue(value: Value, index: u32) ?Value {
+    const tuple = tupleFromValue(value) orelse return null;
+    if (index >= tuple.items.len) return null;
+    return tuple.items[index];
+}
+
+fn tagFromValue(value: Value) ?TagValue {
+    return switch (value) {
+        .tag => |tag| tag,
+        .nominal => |nominal| tagFromValue(nominal.backing.*),
+        else => null,
+    };
+}
+
+fn recordFromValue(value: Value) ?RecordValue {
+    return switch (value) {
+        .record => |record| record,
+        .nominal => |nominal| recordFromValue(nominal.backing.*),
+        else => null,
+    };
+}
+
+fn tupleFromValue(value: Value) ?TupleValue {
+    return switch (value) {
+        .tuple => |tuple| tuple,
+        .nominal => |nominal| tupleFromValue(nominal.backing.*),
+        else => null,
+    };
+}
+
+test "call-pattern specialization declarations are referenced" {
+    std.testing.refAllDecls(@This());
+}


### PR DESCRIPTION
This adds a post-check call-pattern specialization pass for known-shaped direct calls and loop state exposed after inlining. The motivating case is Iter and Stream collection: after wrapper inlining, collect workers can carry iterator fields and callable captures directly instead of rebuilding wrapper values before opening them again.

The pass runs in optimized post-check lowering, keeps direct calls static, and adds LIR shape regressions for real Iter.collect plus GHC-inspired constructor-shape cases.