### PR TITLE
check: grow CheckedTypeStore with ArrayLists instead of per-append realloc

### DIFF
--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -800,10 +800,10 @@ fn checkedTypeIsConcreteCompileTimeRootInner(
     defer _ = active.remove(root);
 
     const index = @intFromEnum(root);
-    if (index >= checked_types.payloads.len) {
+    if (index >= checked_types.payloads.items.len) {
         checkedArtifactInvariant("compile-time root checked type id is out of range", .{});
     }
-    return switch (checked_types.payloads[index]) {
+    return switch (checked_types.payloads.items[index]) {
         .pending => checkedArtifactInvariant("compile-time root checked type was pending", .{}),
         .flex,
         .rigid,
@@ -1973,10 +1973,10 @@ const CheckedTypePublication = struct {
 
 /// Public `CheckedTypeStore` declaration.
 pub const CheckedTypeStore = struct {
-    roots: []CheckedTypeRoot = &.{},
-    schemes: []CheckedTypeScheme = &.{},
-    payloads: []CheckedTypePayload = &.{},
-    nominal_declarations: []CheckedNominalDeclaration = &.{},
+    roots: std.ArrayList(CheckedTypeRoot) = .empty,
+    schemes: std.ArrayList(CheckedTypeScheme) = .empty,
+    payloads: std.ArrayList(CheckedTypePayload) = .empty,
+    nominal_declarations: std.ArrayList(CheckedNominalDeclaration) = .empty,
 
     pub fn fromModule(
         allocator: Allocator,
@@ -2109,10 +2109,10 @@ pub const CheckedTypeStore = struct {
 
         return .{
             .store = .{
-                .roots = try roots.toOwnedSlice(allocator),
-                .schemes = try schemes.toOwnedSlice(allocator),
-                .payloads = try payloads.toOwnedSlice(allocator),
-                .nominal_declarations = try nominal_declarations.toOwnedSlice(allocator),
+                .roots = roots,
+                .schemes = schemes,
+                .payloads = payloads,
+                .nominal_declarations = nominal_declarations,
             },
             .source_type_roots = source_type_roots,
         };
@@ -2120,22 +2120,22 @@ pub const CheckedTypeStore = struct {
 
     pub fn view(self: *const CheckedTypeStore) CheckedTypeStoreView {
         return .{
-            .roots = self.roots,
-            .schemes = self.schemes,
-            .payloads = self.payloads,
-            .nominal_declarations = self.nominal_declarations,
+            .roots = self.roots.items,
+            .schemes = self.schemes.items,
+            .payloads = self.payloads.items,
+            .nominal_declarations = self.nominal_declarations.items,
         };
     }
 
     pub fn rootForKey(self: *const CheckedTypeStore, key: canonical.CanonicalTypeKey) ?CheckedTypeId {
-        for (self.roots) |root| {
+        for (self.roots.items) |root| {
             if (std.meta.eql(root.key.bytes, key.bytes)) return root.id;
         }
         return null;
     }
 
     pub fn schemeForKey(self: *const CheckedTypeStore, key: canonical.CanonicalTypeSchemeKey) ?CheckedTypeScheme {
-        for (self.schemes) |scheme| {
+        for (self.schemes.items) |scheme| {
             if (std.meta.eql(scheme.key.bytes, key.bytes)) return scheme;
         }
         return null;
@@ -2152,31 +2152,23 @@ pub const CheckedTypeStore = struct {
         const key = syntheticFunctionTypeKey(self, finalized_kind, args, ret);
         if (self.rootForKey(key)) |existing| return existing;
 
-        const id: CheckedTypeId = @enumFromInt(@as(u32, @intCast(self.roots.len)));
+        const id: CheckedTypeId = @enumFromInt(@as(u32, @intCast(self.roots.items.len)));
+        try self.roots.ensureUnusedCapacity(allocator, 1);
+        try self.payloads.ensureUnusedCapacity(allocator, 1);
         const owned_args = try allocator.dupe(CheckedTypeId, args);
-        errdefer allocator.free(owned_args);
 
-        const old_roots = self.roots;
-        const new_roots = try allocator.alloc(CheckedTypeRoot, old_roots.len + 1);
-        @memcpy(new_roots[0..old_roots.len], old_roots);
-        new_roots[old_roots.len] = .{ .id = id, .key = key };
-        errdefer allocator.free(new_roots);
-
-        const old_payloads = self.payloads;
-        const new_payloads = try allocator.alloc(CheckedTypePayload, old_payloads.len + 1);
-        @memcpy(new_payloads[0..old_payloads.len], old_payloads);
-        new_payloads[old_payloads.len] = .{ .function = .{
+        self.roots.appendAssumeCapacity(.{ .id = id, .key = key });
+        self.payloads.appendAssumeCapacity(.{ .function = .{
             .kind = finalized_kind,
             .args = owned_args,
             .ret = ret,
             .needs_instantiation = false,
-        } };
-        errdefer allocator.free(new_payloads);
-
-        allocator.free(old_roots);
-        allocator.free(old_payloads);
-        self.roots = new_roots;
-        self.payloads = new_payloads;
+        } });
+        errdefer {
+            var removed = self.payloads.pop().?;
+            deinitCheckedTypePayload(allocator, &removed);
+            _ = self.roots.pop();
+        }
 
         try self.ensureSyntheticSchemeForRoot(allocator, id, key);
         return id;
@@ -2192,35 +2184,25 @@ pub const CheckedTypeStore = struct {
         var payload_owned = true;
         errdefer if (payload_owned) deinitCheckedTypePayload(allocator, &owned_payload);
 
-        const key = try checkedTypePayloadKey(allocator, names, self.roots, self.payloads, owned_payload);
+        const key = try checkedTypePayloadKey(allocator, names, self.payloads.items, owned_payload);
         if (self.rootForKey(key)) |existing| {
             deinitCheckedTypePayload(allocator, &owned_payload);
             payload_owned = false;
             return existing;
         }
 
-        const id: CheckedTypeId = @enumFromInt(@as(u32, @intCast(self.roots.len)));
+        const id: CheckedTypeId = @enumFromInt(@as(u32, @intCast(self.roots.items.len)));
+        try self.roots.ensureUnusedCapacity(allocator, 1);
+        try self.payloads.ensureUnusedCapacity(allocator, 1);
 
-        const old_roots = self.roots;
-        const new_roots = try allocator.alloc(CheckedTypeRoot, old_roots.len + 1);
-        @memcpy(new_roots[0..old_roots.len], old_roots);
-        new_roots[old_roots.len] = .{ .id = id, .key = key };
-        errdefer allocator.free(new_roots);
-
-        const old_payloads = self.payloads;
-        const new_payloads = try allocator.alloc(CheckedTypePayload, old_payloads.len + 1);
-        @memcpy(new_payloads[0..old_payloads.len], old_payloads);
-        new_payloads[old_payloads.len] = owned_payload;
+        self.roots.appendAssumeCapacity(.{ .id = id, .key = key });
+        self.payloads.appendAssumeCapacity(owned_payload);
         payload_owned = false;
         errdefer {
-            deinitCheckedTypePayload(allocator, &new_payloads[old_payloads.len]);
-            allocator.free(new_payloads);
+            var removed = self.payloads.pop().?;
+            deinitCheckedTypePayload(allocator, &removed);
+            _ = self.roots.pop();
         }
-
-        allocator.free(old_roots);
-        allocator.free(old_payloads);
-        self.roots = new_roots;
-        self.payloads = new_payloads;
 
         try self.ensureSyntheticSchemeForRoot(allocator, id, key);
         return id;
@@ -2235,24 +2217,12 @@ pub const CheckedTypeStore = struct {
     ) Allocator.Error!CheckedTypeId {
         if (self.rootForKey(key)) |existing| return existing;
 
-        const id: CheckedTypeId = @enumFromInt(@as(u32, @intCast(self.roots.len)));
+        const id: CheckedTypeId = @enumFromInt(@as(u32, @intCast(self.roots.items.len)));
+        try self.roots.ensureUnusedCapacity(allocator, 1);
+        try self.payloads.ensureUnusedCapacity(allocator, 1);
 
-        const old_roots = self.roots;
-        const new_roots = try allocator.alloc(CheckedTypeRoot, old_roots.len + 1);
-        @memcpy(new_roots[0..old_roots.len], old_roots);
-        new_roots[old_roots.len] = .{ .id = id, .key = key };
-        errdefer allocator.free(new_roots);
-
-        const old_payloads = self.payloads;
-        const new_payloads = try allocator.alloc(CheckedTypePayload, old_payloads.len + 1);
-        @memcpy(new_payloads[0..old_payloads.len], old_payloads);
-        new_payloads[old_payloads.len] = .pending;
-        errdefer allocator.free(new_payloads);
-
-        allocator.free(old_roots);
-        allocator.free(old_payloads);
-        self.roots = new_roots;
-        self.payloads = new_payloads;
+        self.roots.appendAssumeCapacity(.{ .id = id, .key = key });
+        self.payloads.appendAssumeCapacity(.pending);
 
         return id;
     }
@@ -2265,27 +2235,27 @@ pub const CheckedTypeStore = struct {
         payload: CheckedTypePayload,
     ) Allocator.Error!void {
         const index: usize = @intFromEnum(root);
-        if (index >= self.payloads.len) {
+        if (index >= self.payloads.items.len) {
             checkedArtifactInvariant("synthetic checked type fill referenced a missing root", .{});
         }
-        switch (self.payloads[index]) {
+        switch (self.payloads.items[index]) {
             .pending => {},
             else => checkedArtifactInvariant("synthetic checked type fill referenced an already-filled root", .{}),
         }
 
-        self.payloads[index] = payload;
+        self.payloads.items[index] = payload;
         errdefer {
-            deinitCheckedTypePayload(allocator, &self.payloads[index]);
-            self.payloads[index] = .pending;
+            deinitCheckedTypePayload(allocator, &self.payloads.items[index]);
+            self.payloads.items[index] = .pending;
         }
-        try self.ensureSyntheticSchemeForRoot(allocator, root, self.roots[index].key);
+        try self.ensureSyntheticSchemeForRoot(allocator, root, self.roots.items[index].key);
     }
 
     pub fn nominalDeclaration(
         self: *const CheckedTypeStore,
         nominal: canonical.NominalTypeKey,
     ) ?CheckedNominalDeclaration {
-        for (self.nominal_declarations) |declaration| {
+        for (self.nominal_declarations.items) |declaration| {
             if (canonicalNominalTypeKeyEql(declaration.nominal, nominal)) return declaration;
         }
         return null;
@@ -2328,7 +2298,7 @@ pub const CheckedTypeStore = struct {
         allocator: Allocator,
         root: CheckedTypeId,
     ) Allocator.Error!canonical.CanonicalTypeSchemeKey {
-        const key = self.roots[@intFromEnum(root)].key;
+        const key = self.roots.items[@intFromEnum(root)].key;
         const scheme_key = syntheticSchemeKeyForType(key);
         try self.ensureSyntheticSchemeForRoot(allocator, root, key);
         return scheme_key;
@@ -2343,26 +2313,21 @@ pub const CheckedTypeStore = struct {
         const scheme_key = syntheticSchemeKeyForType(key);
         if (self.schemeForKey(scheme_key) != null) return;
 
-        const old = self.schemes;
-        const next = try allocator.alloc(CheckedTypeScheme, old.len + 1);
-        @memcpy(next[0..old.len], old);
-        next[old.len] = .{
-            .id = @enumFromInt(@as(u32, @intCast(old.len))),
+        try self.schemes.append(allocator, .{
+            .id = @enumFromInt(@as(u32, @intCast(self.schemes.items.len))),
             .key = scheme_key,
             .root = root,
             .generalized_vars = &.{},
-        };
-        allocator.free(old);
-        self.schemes = next;
+        });
     }
 
     pub fn deinit(self: *CheckedTypeStore, allocator: Allocator) void {
-        for (self.payloads) |*payload| deinitCheckedTypePayload(allocator, payload);
-        for (self.schemes) |scheme| allocator.free(scheme.generalized_vars);
-        allocator.free(self.nominal_declarations);
-        allocator.free(self.payloads);
-        allocator.free(self.schemes);
-        allocator.free(self.roots);
+        for (self.payloads.items) |*payload| deinitCheckedTypePayload(allocator, payload);
+        for (self.schemes.items) |scheme| allocator.free(scheme.generalized_vars);
+        self.nominal_declarations.deinit(allocator);
+        self.payloads.deinit(allocator);
+        self.schemes.deinit(allocator);
+        self.roots.deinit(allocator);
         self.* = .{};
     }
 
@@ -2381,11 +2346,11 @@ pub const CheckedTypeStore = struct {
         if (active.get(source)) |existing| return existing;
 
         const source_index: usize = @intFromEnum(source);
-        if (source_index >= self.payloads.len or source_index >= self.roots.len) {
+        if (source_index >= self.payloads.items.len or source_index >= self.roots.items.len) {
             checkedArtifactInvariant("checked type substitution referenced a missing source root {} with {} payloads and {} roots", .{
                 source_index,
-                self.payloads.len,
-                self.roots.len,
+                self.payloads.items.len,
+                self.roots.items.len,
             });
         }
 
@@ -2393,16 +2358,16 @@ pub const CheckedTypeStore = struct {
         if (self.rootForKey(key)) |existing| return existing;
 
         const target = try self.reserveSyntheticTypeRoot(allocator, key);
-        errdefer deinitCheckedTypePayload(allocator, &self.payloads[@intFromEnum(target)]);
+        errdefer deinitCheckedTypePayload(allocator, &self.payloads.items[@intFromEnum(target)]);
         try active.put(source, target);
         errdefer _ = active.remove(source);
 
-        const source_payload = self.payloads[source_index];
-        if (source_payload == .function and @intFromEnum(source_payload.function.ret) >= self.payloads.len) {
+        const source_payload = self.payloads.items[source_index];
+        if (source_payload == .function and @intFromEnum(source_payload.function.ret) >= self.payloads.items.len) {
             checkedArtifactInvariant("checked type substitution reached function root {} with missing ret {} and {} payloads", .{
                 source_index,
                 @intFromEnum(source_payload.function.ret),
-                self.payloads.len,
+                self.payloads.items.len,
             });
         }
         const payload = try self.cloneCheckedTypePayloadSubstituting(
@@ -2616,14 +2581,14 @@ pub const CheckedTypeStore = struct {
         active: *std.AutoHashMap(CheckedTypeId, void),
     ) Allocator.Error!bool {
         const index: usize = @intFromEnum(root);
-        if (index >= self.payloads.len) {
+        if (index >= self.payloads.items.len) {
             checkedArtifactInvariant("checked type identity scan referenced a missing payload", .{});
         }
         if (active.contains(root)) return false;
         try active.put(root, {});
         defer _ = active.remove(root);
 
-        return switch (self.payloads[index]) {
+        return switch (self.payloads.items[index]) {
             .pending,
             .flex,
             .rigid,
@@ -3281,7 +3246,7 @@ fn appendExplicitCheckedTypePayload(
     var payload_owned = true;
     errdefer if (payload_owned) deinitCheckedTypePayload(allocator, &owned_payload);
 
-    const key = try checkedTypePayloadKey(allocator, names, roots.items, payloads.items, owned_payload);
+    const key = try checkedTypePayloadKey(allocator, names, payloads.items, owned_payload);
     if (findCheckedTypeRoot(roots.items, key)) |existing| {
         deinitCheckedTypePayload(allocator, &owned_payload);
         payload_owned = false;
@@ -3312,7 +3277,7 @@ fn appendNominalDeclarationRootPayload(
         else => checkedArtifactInvariant("nominal declaration root payload was not nominal", .{}),
     };
 
-    const key = try checkedTypePayloadKey(allocator, names, roots.items, payloads.items, owned_payload);
+    const key = try checkedTypePayloadKey(allocator, names, payloads.items, owned_payload);
     if (findCheckedTypeRoot(roots.items, key)) |existing| {
         const index: usize = @intFromEnum(existing);
         if (index >= payloads.items.len) {
@@ -3355,17 +3320,10 @@ fn appendNominalDeclarationRootPayload(
 fn checkedTypePayloadKey(
     allocator: Allocator,
     names: *const canonical.CanonicalNameStore,
-    roots: []const CheckedTypeRoot,
     payloads: []const CheckedTypePayload,
     payload: CheckedTypePayload,
 ) Allocator.Error!canonical.CanonicalTypeKey {
-    const store = CheckedTypeStore{
-        .roots = @constCast(roots),
-        .payloads = @constCast(payloads),
-        .schemes = &.{},
-        .nominal_declarations = &.{},
-    };
-    var builder = SubstitutedCheckedTypeKeyBuilder.init(allocator, names, &store, &.{}, &.{});
+    var builder = SubstitutedCheckedTypeKeyBuilder.init(allocator, names, payloads, &.{}, &.{});
     defer builder.deinit();
     try builder.writePayload(payload);
     return .{ .bytes = builder.hasher.finalResult() };
@@ -3429,7 +3387,7 @@ fn substitutedCheckedTypeKey(
         checkedArtifactInvariant("checked type substitution key arity mismatch", .{});
     }
 
-    var builder = SubstitutedCheckedTypeKeyBuilder.init(allocator, names, store, formals, actuals);
+    var builder = SubstitutedCheckedTypeKeyBuilder.init(allocator, names, store.payloads.items, formals, actuals);
     defer builder.deinit();
     try builder.writeType(source);
     return .{ .bytes = builder.hasher.finalResult() };
@@ -3438,7 +3396,7 @@ fn substitutedCheckedTypeKey(
 const SubstitutedCheckedTypeKeyBuilder = struct {
     allocator: Allocator,
     names: *const canonical.CanonicalNameStore,
-    store: *const CheckedTypeStore,
+    payloads: []const CheckedTypePayload,
     formals: []const CheckedTypeId,
     actuals: []const CheckedTypeId,
     hasher: std.crypto.hash.sha2.Sha256,
@@ -3458,14 +3416,14 @@ const SubstitutedCheckedTypeKeyBuilder = struct {
     fn init(
         allocator: Allocator,
         names: *const canonical.CanonicalNameStore,
-        store: *const CheckedTypeStore,
+        payloads: []const CheckedTypePayload,
         formals: []const CheckedTypeId,
         actuals: []const CheckedTypeId,
     ) SubstitutedCheckedTypeKeyBuilder {
         return .{
             .allocator = allocator,
             .names = names,
-            .store = store,
+            .payloads = payloads,
             .formals = formals,
             .actuals = actuals,
             .hasher = std.crypto.hash.sha2.Sha256.init(.{}),
@@ -3489,11 +3447,11 @@ const SubstitutedCheckedTypeKeyBuilder = struct {
     fn writeType(self: *SubstitutedCheckedTypeKeyBuilder, source: CheckedTypeId) Allocator.Error!void {
         const id = self.substitutedRoot(source);
         const raw: usize = @intFromEnum(id);
-        if (raw >= self.store.payloads.len) {
+        if (raw >= self.payloads.len) {
             checkedArtifactInvariant("checked type substitution key referenced a missing payload", .{});
         }
 
-        switch (self.store.payloads[raw]) {
+        switch (self.payloads[raw]) {
             .flex => |flex| return try self.writeIdentityVariable(id, "flex", flex.name, flex.constraints),
             .rigid => |rigid| return try self.writeIdentityVariable(id, "rigid", rigid.name, rigid.constraints),
             else => {},
@@ -3507,7 +3465,7 @@ const SubstitutedCheckedTypeKeyBuilder = struct {
 
         const slot: u32 = @intCast(self.active.count());
         try self.active.put(id, slot);
-        try self.writePayload(self.store.payloads[raw]);
+        try self.writePayload(self.payloads[raw]);
         _ = self.active.remove(id);
     }
 
@@ -3612,10 +3570,10 @@ const SubstitutedCheckedTypeKeyBuilder = struct {
             if (seen.contains(tail_id)) break;
             try seen.put(tail_id, {});
             const raw: usize = @intFromEnum(tail_id);
-            if (raw >= self.store.payloads.len) {
+            if (raw >= self.payloads.len) {
                 checkedArtifactInvariant("checked type substitution key row normalization referenced missing record tail", .{});
             }
-            switch (self.store.payloads[raw]) {
+            switch (self.payloads[raw]) {
                 .empty_record => {
                     tail = null;
                     break;
@@ -3665,10 +3623,10 @@ const SubstitutedCheckedTypeKeyBuilder = struct {
             if (seen.contains(tail_id)) break;
             try seen.put(tail_id, {});
             const raw: usize = @intFromEnum(tail_id);
-            if (raw >= self.store.payloads.len) {
+            if (raw >= self.payloads.len) {
                 checkedArtifactInvariant("checked type substitution key row normalization referenced missing record tail", .{});
             }
-            switch (self.store.payloads[raw]) {
+            switch (self.payloads[raw]) {
                 .empty_record => {
                     tail = null;
                     break;
@@ -3737,10 +3695,10 @@ const SubstitutedCheckedTypeKeyBuilder = struct {
             if (seen.contains(tail_id)) break;
             try seen.put(tail_id, {});
             const raw: usize = @intFromEnum(tail_id);
-            if (raw >= self.store.payloads.len) {
+            if (raw >= self.payloads.len) {
                 checkedArtifactInvariant("checked type substitution key row normalization referenced missing tag tail", .{});
             }
-            switch (self.store.payloads[raw]) {
+            switch (self.payloads[raw]) {
                 .empty_tag_union => {
                     tail = null;
                     break;
@@ -3802,14 +3760,14 @@ const SubstitutedCheckedTypeKeyBuilder = struct {
     ) Allocator.Error!bool {
         const id = self.substitutedRoot(source);
         const raw: usize = @intFromEnum(id);
-        if (raw >= self.store.payloads.len) {
+        if (raw >= self.payloads.len) {
             checkedArtifactInvariant("checked type substitution key identity scan referenced missing payload", .{});
         }
         if (active.contains(id)) return false;
         try active.put(id, {});
         defer _ = active.remove(id);
 
-        return switch (self.store.payloads[raw]) {
+        return switch (self.payloads[raw]) {
             .pending,
             .flex,
             .rigid,
@@ -3997,9 +3955,9 @@ fn syntheticFunctionTypeKey(
     hashByteSlice(&hasher, @tagName(finalized_kind));
     hashU32(&hasher, @intCast(args.len));
     for (args) |arg| {
-        hasher.update(&store.roots[@intFromEnum(arg)].key.bytes);
+        hasher.update(&store.roots.items[@intFromEnum(arg)].key.bytes);
     }
-    hasher.update(&store.roots[@intFromEnum(ret)].key.bytes);
+    hasher.update(&store.roots.items[@intFromEnum(ret)].key.bytes);
     return .{ .bytes = hasher.finalResult() };
 }
 
@@ -9296,7 +9254,7 @@ pub const CheckedProcedureTemplateTable = struct {
                 &.{},
                 root.checked_type,
             );
-            const checked_fn_scheme = syntheticSchemeKeyForType(checked_types.roots[@intFromEnum(checked_fn_root)].key);
+            const checked_fn_scheme = syntheticSchemeKeyForType(checked_types.roots.items[@intFromEnum(checked_fn_root)].key);
             const proc_base = try names.internProcBase(.{
                 .module_name = module_name,
                 .export_name = null,
@@ -10127,7 +10085,7 @@ pub const PlatformRequirementRelationTable = struct {
                 input,
                 declaration,
             );
-            const payload_key = checked_types.store.roots[@intFromEnum(payload)].key;
+            const payload_key = checked_types.store.roots.items[@intFromEnum(payload)].key;
 
             rows[i] = .{
                 .id = input.id,
@@ -10894,8 +10852,8 @@ const PlatformRequirementTypeCompatibilityChecker = struct {
         if (expected_nominal.is_opaque) return true;
         if (try self.compatible(expected_nominal.backing, actual_nominal.backing)) return true;
         return canonicalTypeKeyEql(
-            self.store.roots[@intFromEnum(expected)].key,
-            self.store.roots[@intFromEnum(actual)].key,
+            self.store.roots.items[@intFromEnum(expected)].key,
+            self.store.roots.items[@intFromEnum(actual)].key,
         );
     }
 
@@ -11062,10 +11020,10 @@ const PlatformRequirementTypeCompatibilityChecker = struct {
 
     fn payload(self: *const PlatformRequirementTypeCompatibilityChecker, root: CheckedTypeId) CheckedTypePayload {
         const index: usize = @intFromEnum(root);
-        if (index >= self.store.payloads.len) {
+        if (index >= self.store.payloads.items.len) {
             checkedArtifactInvariant("platform requirement type compatibility referenced missing checked type payload", .{});
         }
-        return self.store.payloads[index];
+        return self.store.payloads.items[index];
     }
 };
 
@@ -11745,10 +11703,10 @@ const PlatformAppRelationTypeResolver = struct {
 
     fn payload(self: *const PlatformAppRelationTypeResolver, root: CheckedTypeId) CheckedTypePayload {
         const index: usize = @intFromEnum(root);
-        if (index >= self.store.payloads.len) {
+        if (index >= self.store.payloads.items.len) {
             checkedArtifactInvariant("platform/app relation referenced missing checked type payload", .{});
         }
-        return self.store.payloads[index];
+        return self.store.payloads.items[index];
     }
 };
 
@@ -11788,10 +11746,10 @@ fn writeCheckedType(
     defer _ = active.remove(root);
 
     const index: usize = @intFromEnum(root);
-    if (index >= artifact.checked_types.payloads.len) {
+    if (index >= artifact.checked_types.payloads.items.len) {
         checkedArtifactInvariant("checked type formatter referenced a missing payload", .{});
     }
-    switch (artifact.checked_types.payloads[index]) {
+    switch (artifact.checked_types.payloads.items[index]) {
         .pending => checkedArtifactInvariant("checked type formatter reached pending payload", .{}),
         .flex => |flex| try writeCheckedTypeVar(allocator, flex, buf),
         .rigid => |rigid| try writeCheckedTypeVar(allocator, rigid, buf),
@@ -11896,7 +11854,7 @@ fn writeCheckedTagUnionType(
             try buf.append(allocator, ')');
         }
     }
-    const has_ext = switch (artifact.checked_types.payloads[@intFromEnum(ext)]) {
+    const has_ext = switch (artifact.checked_types.payloads.items[@intFromEnum(ext)]) {
         .empty_tag_union => false,
         else => true,
     };
@@ -12165,10 +12123,10 @@ pub const ModuleInterfaceCapabilities = struct {
         var seen_nominals = std.AutoHashMap(NominalCapabilitySeenKey, void).init(allocator);
         defer seen_nominals.deinit();
 
-        const published_payload_count = checked_types.payloads.len;
+        const published_payload_count = checked_types.payloads.items.len;
         var i: usize = 0;
         while (i < published_payload_count) : (i += 1) {
-            const payload = checked_types.payloads[i];
+            const payload = checked_types.payloads.items[i];
             const nominal = switch (payload) {
                 .nominal => |nominal| nominal,
                 else => continue,
@@ -12176,7 +12134,7 @@ pub const ModuleInterfaceCapabilities = struct {
             if (nominal.builtin != null) continue;
             if (nominal.origin_module != current_module) continue;
 
-            const source_key = checked_types.roots[i].key;
+            const source_key = checked_types.roots.items[i].key;
             const nominal_key = canonical.NominalTypeKey{
                 .module_name = nominal.origin_module,
                 .type_name = nominal.name,
@@ -12206,7 +12164,7 @@ pub const ModuleInterfaceCapabilities = struct {
             try boxed_payload_templates.append(allocator, .{
                 .id = capability_id,
                 .nominal = nominal_key,
-                .source_ty_payload = checked_types.roots[i].id,
+                .source_ty_payload = checked_types.roots.items[i].id,
                 .source_ty = source_key,
                 .backing_ty = backing_ty,
                 .backing_ty_key = checkedTypeKeyForId(checked_types, backing_ty),
@@ -12226,7 +12184,7 @@ pub const ModuleInterfaceCapabilities = struct {
                 try opaque_atomic_proofs.append(allocator, .{
                     .id = id,
                     .nominal = nominal_key,
-                    .source_ty_payload = checked_types.roots[i].id,
+                    .source_ty_payload = checked_types.roots.items[i].id,
                     .source_ty = source_key,
                     .instantiated_args = owned_args,
                 });
@@ -12234,7 +12192,7 @@ pub const ModuleInterfaceCapabilities = struct {
                 break :blk id;
             };
 
-            const published_payload = &checked_types.payloads[i];
+            const published_payload = &checked_types.payloads.items[i];
             switch (published_payload.*) {
                 .nominal => |*published_nominal| {
                     published_nominal.representation = .{ .local_box_payload_capability = .{
@@ -12387,10 +12345,10 @@ fn checkedTypeKeyForId(
     id: CheckedTypeId,
 ) canonical.CanonicalTypeKey {
     const index: usize = @intFromEnum(id);
-    if (index >= checked_types.roots.len) {
+    if (index >= checked_types.roots.items.len) {
         checkedArtifactInvariant("checked type key lookup referenced a missing root", .{});
     }
-    return checked_types.roots[index].key;
+    return checked_types.roots.items[index].key;
 }
 
 fn checkedTypeKeysForIds(
@@ -12423,14 +12381,14 @@ fn checkedTypeHasNoReachableCallableSlotsInner(
     active: *std.AutoHashMap(CheckedTypeId, void),
 ) Allocator.Error!bool {
     const index: usize = @intFromEnum(root);
-    if (index >= checked_types.payloads.len) {
+    if (index >= checked_types.payloads.items.len) {
         checkedArtifactInvariant("callable-slot proof referenced a missing checked type", .{});
     }
     if (active.contains(root)) return true;
     try active.put(root, {});
     defer _ = active.remove(root);
 
-    return switch (checked_types.payloads[index]) {
+    return switch (checked_types.payloads.items[index]) {
         .pending => checkedArtifactInvariant("callable-slot proof reached pending checked type", .{}),
         .flex,
         .rigid,
@@ -13337,14 +13295,14 @@ fn appendPublicApiTypeDependencies(
     type_owner_keys: *ArtifactKeyAccumulator,
 ) Allocator.Error!void {
     const index: usize = @intFromEnum(root);
-    if (index >= checked_types.payloads.len) {
+    if (index >= checked_types.payloads.items.len) {
         checkedArtifactInvariant("public API dependency scan referenced a missing checked type payload", .{});
     }
     if (active.contains(root)) return;
     try active.put(root, {});
     defer _ = active.remove(root);
 
-    switch (checked_types.payloads[index]) {
+    switch (checked_types.payloads.items[index]) {
         .pending => checkedArtifactInvariant("public API dependency scan reached pending checked type payload", .{}),
         .empty_record, .empty_tag_union => {},
         .flex => |flex| try appendPublicApiConstraintDependencies(
@@ -15258,12 +15216,12 @@ pub const CheckedModuleArtifact = struct {
         if (builtin.mode != .Debug) return;
 
         std.debug.assert(self.module_identity.module_idx != std.math.maxInt(u32));
-        std.debug.assert(self.checked_types.roots.len == self.checked_types.payloads.len);
+        std.debug.assert(self.checked_types.roots.items.len == self.checked_types.payloads.items.len);
         std.debug.assert(self.checked_bodies.expr_diverges.len == self.checked_bodies.exprs.len);
         std.debug.assert(self.checked_bodies.statement_diverges.len == self.checked_bodies.statements.len);
         verifyRootRequestSubsets(self.root_requests);
 
-        for (self.checked_types.payloads, 0..) |payload, i| {
+        for (self.checked_types.payloads.items, 0..) |payload, i| {
             switch (payload) {
                 .pending => std.debug.panic("checked artifact invariant violated: checked type payload {d} was not filled before compile-time lowering", .{i}),
                 else => {},
@@ -15272,7 +15230,7 @@ pub const CheckedModuleArtifact = struct {
 
         for (self.checked_bodies.exprs, 0..) |expr, i| {
             std.debug.assert(@intFromEnum(expr.id) == i);
-            std.debug.assert(@intFromEnum(expr.ty) < self.checked_types.roots.len);
+            std.debug.assert(@intFromEnum(expr.ty) < self.checked_types.roots.items.len);
             verifyCheckedExprDataComplete(expr.data);
         }
 
@@ -15284,13 +15242,13 @@ pub const CheckedModuleArtifact = struct {
             std.debug.assert(root.expr == body.body_expr);
             std.debug.assert(root.checked_type == body.checked_type);
             std.debug.assert(@intFromEnum(body.body_expr) < self.checked_bodies.exprs.len);
-            std.debug.assert(@intFromEnum(body.checked_type) < self.checked_types.roots.len);
+            std.debug.assert(@intFromEnum(body.checked_type) < self.checked_types.roots.items.len);
         }
 
         for (self.root_requests.requests, 0..) |request, i| {
             std.debug.assert(request.order == i);
             std.debug.assert(request.module_idx == self.module_identity.module_idx);
-            std.debug.assert(@intFromEnum(request.checked_type) < self.checked_types.roots.len);
+            std.debug.assert(@intFromEnum(request.checked_type) < self.checked_types.roots.items.len);
             if (request.abi == .compile_time) {
                 const template_ref = request.procedure_template orelse {
                     std.debug.panic("checked artifact invariant violated: compile-time root has no private wrapper template", .{});
@@ -15333,7 +15291,7 @@ pub const CheckedModuleArtifact = struct {
         for (self.root_requests.requests, 0..) |request, i| {
             std.debug.assert(request.order == i);
             std.debug.assert(request.module_idx == self.module_identity.module_idx);
-            std.debug.assert(@intFromEnum(request.checked_type) < self.checked_types.roots.len);
+            std.debug.assert(@intFromEnum(request.checked_type) < self.checked_types.roots.items.len);
             if (request.kind == .test_expect or
                 request.kind == .compile_time_constant or
                 request.kind == .compile_time_callable)
@@ -15380,10 +15338,10 @@ pub const CheckedModuleArtifact = struct {
             std.debug.assert(proc.module_idx == self.module_identity.module_idx);
         }
 
-        for (self.checked_types.roots, 0..) |root, i| {
+        for (self.checked_types.roots.items, 0..) |root, i| {
             std.debug.assert(@intFromEnum(root.id) == i);
-            std.debug.assert(self.checked_types.payloads.len == self.checked_types.roots.len);
-            switch (self.checked_types.payloads[i]) {
+            std.debug.assert(self.checked_types.payloads.items.len == self.checked_types.roots.items.len);
+            switch (self.checked_types.payloads.items[i]) {
                 .pending => std.debug.panic("checked artifact invariant violated: checked type payload {d} was not filled", .{i}),
                 else => {},
             }
@@ -15391,13 +15349,13 @@ pub const CheckedModuleArtifact = struct {
 
         for (self.checked_bodies.exprs, 0..) |expr, i| {
             std.debug.assert(@intFromEnum(expr.id) == i);
-            std.debug.assert(@intFromEnum(expr.ty) < self.checked_types.roots.len);
+            std.debug.assert(@intFromEnum(expr.ty) < self.checked_types.roots.items.len);
             verifyCheckedExprDataComplete(expr.data);
         }
 
         for (self.checked_bodies.patterns, 0..) |pattern, i| {
             std.debug.assert(@intFromEnum(pattern.id) == i);
-            std.debug.assert(@intFromEnum(pattern.ty) < self.checked_types.roots.len);
+            std.debug.assert(@intFromEnum(pattern.ty) < self.checked_types.roots.items.len);
             verifyCheckedPatternDataComplete(pattern.data);
         }
 
@@ -15423,12 +15381,12 @@ pub const CheckedModuleArtifact = struct {
             std.debug.assert(root.expr == body.body_expr);
             std.debug.assert(root.checked_type == body.checked_type);
             std.debug.assert(@intFromEnum(body.body_expr) < self.checked_bodies.exprs.len);
-            std.debug.assert(@intFromEnum(body.checked_type) < self.checked_types.roots.len);
+            std.debug.assert(@intFromEnum(body.checked_type) < self.checked_types.roots.items.len);
         }
 
         for (self.checked_procedure_templates.templates, 0..) |template, i| {
             std.debug.assert(@intFromEnum(template.template_id) == i);
-            std.debug.assert(@intFromEnum(template.checked_fn_root) < self.checked_types.roots.len);
+            std.debug.assert(@intFromEnum(template.checked_fn_root) < self.checked_types.roots.items.len);
             _ = self.checked_types.schemeForKey(template.checked_fn_scheme) orelse {
                 std.debug.panic("checked artifact invariant violated: checked procedure template references missing type scheme", .{});
             };
@@ -15449,7 +15407,7 @@ pub const CheckedModuleArtifact = struct {
                 .entry_wrapper => |wrapper_id| {
                     const wrapper = self.entry_wrappers.get(wrapper_id);
                     std.debug.assert(@intFromEnum(wrapper.body_expr) < self.checked_bodies.exprs.len);
-                    std.debug.assert(@intFromEnum(wrapper.checked_fn_root) < self.checked_types.roots.len);
+                    std.debug.assert(@intFromEnum(wrapper.checked_fn_root) < self.checked_types.roots.items.len);
                     std.debug.assert(wrapper.checked_fn_root == template.checked_fn_root);
                     std.debug.assert(wrapper.template.template == template.template_id);
                     std.debug.assert(wrapper.template.proc_base == template.proc_base);
@@ -15490,12 +15448,12 @@ pub const CheckedModuleArtifact = struct {
             }
             for (exported.template_closure.checked_type_roots) |type_ref| {
                 if (closureArtifactRefIsLocal(self, type_ref.artifact)) {
-                    std.debug.assert(@intFromEnum(type_ref.ty) < self.checked_types.roots.len);
+                    std.debug.assert(@intFromEnum(type_ref.ty) < self.checked_types.roots.items.len);
                 }
             }
             for (exported.template_closure.checked_type_schemes) |scheme_ref| {
                 if (closureArtifactRefIsLocal(self, scheme_ref.artifact)) {
-                    std.debug.assert(@intFromEnum(scheme_ref.scheme) < self.checked_types.schemes.len);
+                    std.debug.assert(@intFromEnum(scheme_ref.scheme) < self.checked_types.schemes.items.len);
                 }
             }
         }
@@ -15547,12 +15505,12 @@ pub const CheckedModuleArtifact = struct {
             }
             for (exported.template_closure.checked_type_roots) |type_ref| {
                 if (closureArtifactRefIsLocal(self, type_ref.artifact)) {
-                    std.debug.assert(@intFromEnum(type_ref.ty) < self.checked_types.roots.len);
+                    std.debug.assert(@intFromEnum(type_ref.ty) < self.checked_types.roots.items.len);
                 }
             }
             for (exported.template_closure.checked_type_schemes) |scheme_ref| {
                 if (closureArtifactRefIsLocal(self, scheme_ref.artifact)) {
-                    std.debug.assert(@intFromEnum(scheme_ref.scheme) < self.checked_types.schemes.len);
+                    std.debug.assert(@intFromEnum(scheme_ref.scheme) < self.checked_types.schemes.items.len);
                 }
             }
             for (exported.template_closure.checked_const_bodies) |body_ref| {
@@ -15579,13 +15537,13 @@ pub const CheckedModuleArtifact = struct {
             };
             std.debug.assert(declaration.requires_idx == relation.requires_idx);
             const payload_index = @intFromEnum(relation.requested_source_ty_payload);
-            if (payload_index >= self.checked_types.roots.len) {
+            if (payload_index >= self.checked_types.roots.items.len) {
                 std.debug.panic(
                     "checked artifact invariant violated: platform requirement relation {d} requested payload is out of range",
                     .{i},
                 );
             }
-            if (!canonicalTypeKeyEql(self.checked_types.roots[payload_index].key, relation.requested_source_ty)) {
+            if (!canonicalTypeKeyEql(self.checked_types.roots.items[payload_index].key, relation.requested_source_ty)) {
                 std.debug.panic(
                     "checked artifact invariant violated: platform requirement relation {d} requested payload key disagrees with relation key",
                     .{i},
@@ -15630,7 +15588,7 @@ pub const CheckedModuleArtifact = struct {
             const root = self.compile_time_roots.root(template.root);
             std.debug.assert(root.kind == .callable_binding);
             std.debug.assert(root.pattern != null and root.pattern.? == template.pattern);
-            std.debug.assert(@intFromEnum(template.checked_fn_root) < self.checked_types.roots.len);
+            std.debug.assert(@intFromEnum(template.checked_fn_root) < self.checked_types.roots.items.len);
             _ = self.checked_types.schemeForKey(template.source_scheme) orelse {
                 std.debug.panic("checked artifact invariant violated: callable eval template references missing type scheme", .{});
             };
@@ -15692,7 +15650,7 @@ pub const CheckedModuleArtifact = struct {
                 .procedure => |procedure| {
                     std.debug.assert(procedure.source_name == metadata.source_name);
                     std.debug.assert(procedure.ffi_symbol == metadata.ffi_symbol);
-                    std.debug.assert(@intFromEnum(procedure.checked_type) < self.checked_types.roots.len);
+                    std.debug.assert(@intFromEnum(procedure.checked_type) < self.checked_types.roots.items.len);
                     const top_level = self.top_level_values.lookupByDef(procedure.def) orelse {
                         std.debug.panic("checked artifact invariant violated: provided procedure export references missing top-level value", .{});
                     };
@@ -15707,7 +15665,7 @@ pub const CheckedModuleArtifact = struct {
                 .data => |data| {
                     std.debug.assert(data.source_name == metadata.source_name);
                     std.debug.assert(data.ffi_symbol == metadata.ffi_symbol);
-                    std.debug.assert(@intFromEnum(data.checked_type) < self.checked_types.roots.len);
+                    std.debug.assert(@intFromEnum(data.checked_type) < self.checked_types.roots.items.len);
                     const top_level = self.top_level_values.lookupByDef(data.def) orelse {
                         std.debug.panic("checked artifact invariant violated: provided data export references missing top-level value", .{});
                     };

--- a/src/check/static_dispatch_registry.zig
+++ b/src/check/static_dispatch_registry.zig
@@ -884,13 +884,13 @@ fn sourceCallableHasEqualityShape(
 
 fn checkedTypeIsBuiltinBool(checked_types: anytype, ty: CheckedTypeId) bool {
     const raw = @intFromEnum(ty);
-    if (raw >= checked_types.store.payloads.len) {
+    if (raw >= checked_types.store.payloads.items.len) {
         if (@import("builtin").mode == .Debug) {
             std.debug.panic("checked static dispatch invariant violated: equality return type root was outside the checked type store", .{});
         }
         unreachable;
     }
-    return switch (checked_types.store.payloads[raw]) {
+    return switch (checked_types.store.payloads.items[raw]) {
         .nominal => |nominal| if (nominal.builtin) |builtin_owner| builtin_owner == .bool else false,
         else => false,
     };
@@ -915,13 +915,13 @@ fn checkedFunctionReturnTypeId(
     callable_ty: CheckedTypeId,
 ) CheckedTypeId {
     const raw = @intFromEnum(callable_ty);
-    if (raw >= checked_types.store.payloads.len) {
+    if (raw >= checked_types.store.payloads.items.len) {
         if (@import("builtin").mode == .Debug) {
             std.debug.panic("checked static dispatch invariant violated: callable type root was outside the checked type store", .{});
         }
         unreachable;
     }
-    return switch (checked_types.store.payloads[raw]) {
+    return switch (checked_types.store.payloads.items[raw]) {
         .function => |func| func.ret,
         else => if (@import("builtin").mode == .Debug) {
             std.debug.panic("checked static dispatch invariant violated: for-loop dispatch constraint was not a function", .{});

--- a/src/glue/glue.zig
+++ b/src/glue/glue.zig
@@ -1998,10 +1998,10 @@ fn checkedTypePayload(
     checked_type: CheckedArtifact.CheckedTypeId,
 ) CheckedArtifact.CheckedTypePayload {
     const idx = @intFromEnum(checked_type);
-    if (idx >= artifact.checked_types.payloads.len) {
+    if (idx >= artifact.checked_types.payloads.items.len) {
         glueInvariant("checked type id {d} out of bounds", .{idx});
     }
-    return artifact.checked_types.payloads[idx];
+    return artifact.checked_types.payloads.items[idx];
 }
 
 fn checkedTypeRootForScheme(
@@ -2346,7 +2346,7 @@ fn collectModuleTypeInfo(
 ) Allocator.Error!?CollectedModuleTypeInfo {
     var main_type_str: []const u8 = try gpa.dupe(u8, "");
     errdefer gpa.free(main_type_str);
-    for (artifact.checked_types.nominal_declarations) |declaration| {
+    for (artifact.checked_types.nominal_declarations.items) |declaration| {
         const type_name = TypeTable.getTypeDisplayName(artifact.canonical_names.typeNameText(declaration.nominal.type_name));
         if (std.mem.eql(u8, type_name, module_name)) {
             gpa.free(main_type_str);


### PR DESCRIPTION
Based on @lukewilliamboswell's write-up here: https://gist.github.com/lukewilliamboswell/be4fb69f8299419d7c52386611c7ce5e

The synthetic-root append paths (`appendSyntheticFunctionRoot`, `appendSyntheticPayloadRoot`, `reserveSyntheticTypeRoot`, `ensureSyntheticSchemeForRoot`) grew `CheckedTypeStore`'s parallel arrays by one element per call via `alloc(len+1)` + full memcpy + free — O(n²) byte traffic. In ReleaseSafe, where every alloc and free also poisons the whole buffer, this accounted for ~24% of all instructions in a profiled `roc build` (592M Ir of memset across 215 appends into ~690KB arrays), driven by the builtin republish path.

Changes:
- Store `roots`/`schemes`/`payloads`/`nominal_declarations` as `std.ArrayList` and append via `ensureUnusedCapacity` + `appendAssumeCapacity`, reserving both roots and payloads up front so the parallel arrays stay in lockstep on every error path (this also fixes a latent error-path bug where the old errdefers freed the freshly swapped-in arrays while the store still pointed at them).
- `SubstitutedCheckedTypeKeyBuilder` borrows the payload slice directly instead of wrapping borrowed slices in a temporary fake store.
- `CheckedTypeStoreView` and all view consumers are unchanged.

No behavior change: all Zig unit tests pass (2453) and the snapshot corpus is unchanged.


🤖 Generated with [Claude Code](https://claude.com/claude-code)