### PR TITLE
Reuse unique list allocations in List.map

### DIFF
--- a/design.md
+++ b/design.md
@@ -2495,15 +2495,21 @@ layouts are not interchangeable (or the optimization is off), so the
 runtime check never runs for a pair it could corrupt.
 
 The in-place branch itself is dropped before it reaches LIR whenever the
-input and output element monotypes differ or the optimization is disabled
+element layouts are not interchangeable or the optimization is disabled
 (`TargetConfig.list_in_place_map`, on for `--opt=size`/`--opt=speed`, off
-for dev, interpreter, and compile-time evaluation). That fold is decided on
-the lifted program from monotype digests rather than layouts, because the
-debug Lambda Mono materializer must reach the same answer without a layout
-store: both consult one function, so the verifier sees the same set of
-demanded functions. Element monotypes that differ but share a layout
-therefore take the copy path; identical monotypes keep both branches and
-let the runtime count decide.
+for dev, interpreter, and compile-time evaluation), so ineligible map
+specializations never carry dead in-place machinery and dev builds lower
+exactly the copy loop. The fold uses the same layout-eligibility decision
+as the primitive, so every interchangeable pair — including different
+types that share one layout — keeps the branch. The debug Lambda Mono
+materializer runs before layout selection and cannot recompute that
+decision; instead, direct lowering records each statically resolved match
+site as explicit data and the verifier replays the record, so the two
+derivations demand the same set of functions without the materializer ever
+consulting layouts. A wrong record can only misplace dead code, never a
+runtime check — the primitive's own lowering independently gates the
+runtime path — and a fold regression surfaces as a Debug stride assertion
+in the backends rather than as silent dead code.
 
 Inside the in-place loop, `list_map_extract_unsafe` moves one element's
 ownership out of the buffer and `list_map_write_unsafe` moves the

--- a/design.md
+++ b/design.md
@@ -2474,7 +2474,49 @@ choosing between a borrow and an owned move, the choice that keeps a
 mutation check-free becomes visible to the solver rather than a lucky
 outcome of emission order.
 
-### Adoption Stages
+### In-Place List.map
+
+`List.map` may overwrite a uniquely owned input list's buffer instead of
+allocating an output list when the input and output element layouts are
+interchangeable in one allocation: same stride, same allocation alignment
+class, and the same refcounted-elements header shape. The hidden header in
+front of a list's data and the alignment handed to the allocator both
+derive from the element layout, so reusing an allocation across layouts
+that disagree on either would make a later free reconstruct the wrong
+allocation pointer.
+
+The decision has a compile-time half and a runtime half. `List.map`'s body
+in Builtin.roc matches on the `list_map_can_reuse` primitive, whose runtime
+meaning is "uniquely owned and not a seamless slice" — a slice's buffer
+points into the middle of an allocation whose header bookkeeping covers the
+whole allocation, so a unique slice still copies. At direct LIR lowering,
+where layouts exist, the primitive lowers to a constant 0 whenever the
+layouts are not interchangeable (or the optimization is off), so the
+runtime check never runs for a pair it could corrupt.
+
+The in-place branch itself is dropped before it reaches LIR whenever the
+input and output element monotypes differ or the optimization is disabled
+(`TargetConfig.list_in_place_map`, on for `--opt=size`/`--opt=speed`, off
+for dev, interpreter, and compile-time evaluation). That fold is decided on
+the lifted program from monotype digests rather than layouts, because the
+debug Lambda Mono materializer must reach the same answer without a layout
+store: both consult one function, so the verifier sees the same set of
+demanded functions. Element monotypes that differ but share a layout
+therefore take the copy path; identical monotypes keep both branches and
+let the runtime count decide.
+
+Inside the in-place loop, `list_map_extract_unsafe` moves one element's
+ownership out of the buffer and `list_map_write_unsafe` moves the
+transform's result into the vacated slot. Neither performs RC work: the
+extracted element is an ordinary owned local, so ARC places its release
+according to the transform's solved convention, and the certifier checks
+the loop like any other code. Between the two ops the slot holds stale
+bytes and the buffer is typed by the output element while later slots still
+hold input elements; this window is unobservable because no cleanup path
+walks live values — `crash` is fatal and leaks by design — and the loop
+itself is the only holder of the buffer (the runtime count of 1 proved
+there were no other counted handles, and a live borrow of the list would
+have forced the copy path through an owned capture's incref).
 
 Each stage fully replaces the previous behavior when it lands; there are no
 parallel insertion paths at any point:

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -204,6 +204,7 @@ pub const BuiltinFn = enum {
     list_drop_at,
     list_replace,
     list_swap,
+    list_map_can_reuse,
     list_reserve,
     list_release_excess_capacity,
     list_decref_str,
@@ -307,6 +308,7 @@ pub const BuiltinFn = enum {
             .list_drop_at => "roc_builtins_list_drop_at",
             .list_replace => "roc_builtins_list_replace",
             .list_swap => "roc_builtins_list_swap",
+            .list_map_can_reuse => "roc_builtins_list_map_can_reuse",
             .list_reserve => "roc_builtins_list_reserve",
             .list_release_excess_capacity => "roc_builtins_list_release_excess_capacity",
             .list_decref_str => "roc_builtins_list_decref_str",
@@ -1717,6 +1719,181 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
                     result_loc = try self.stabilize(result_loc);
                     return result_loc;
+                },
+                .list_map_can_reuse => {
+                    // list_map_can_reuse(list, transform) -> U8; only the list is inspected.
+                    std.debug.assert(args.len == 2);
+                    const roc_ops_reg = self.roc_ops_reg orelse unreachable;
+                    const list_loc = try self.emitValueLocal(args[0]);
+                    const list_off = try self.ensureOnStack(list_loc, roc_list_size);
+
+                    // roc_builtins_list_map_can_reuse(bytes, len, cap, roc_ops) -> u8
+                    var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
+                    try builder.addMemArg(frame_ptr, list_off);
+                    try builder.addMemArg(frame_ptr, list_off + 8);
+                    try builder.addMemArg(frame_ptr, list_off + 16);
+                    try builder.addRegArg(roc_ops_reg);
+                    try self.callBuiltin(&builder, @intFromPtr(&dev_wrappers.roc_builtins_list_map_can_reuse), .list_map_can_reuse);
+
+                    const result_reg = try self.allocTempGeneral();
+                    if (comptime target.toCpuArch() == .aarch64) {
+                        try self.codegen.emit.movRegReg(.w64, result_reg, .X0);
+                    } else {
+                        try self.codegen.emit.movRegReg(.w64, result_reg, .RAX);
+                        // x86_64 ABI: only the low byte is guaranteed valid for
+                        // bool-like returns; mask so 64-bit compares work.
+                        try self.codegen.emit.andRegImm8(result_reg, 1);
+                    }
+                    return .{ .general_reg = result_reg };
+                },
+                .list_map_cast_unsafe => {
+                    // Same bits, new element type: copy the list struct through.
+                    std.debug.assert(args.len == 1);
+                    const list_loc = try self.emitValueLocal(args[0]);
+                    const list_off = try self.ensureOnStack(list_loc, roc_list_size);
+                    const result_offset = self.codegen.allocStackSlot(roc_str_size);
+                    const tmp = try self.allocTempGeneral();
+                    var off: i32 = 0;
+                    while (off < roc_list_size) : (off += 8) {
+                        try self.emitLoad(.w64, tmp, frame_ptr, list_off + off);
+                        try self.emitStore(.w64, frame_ptr, result_offset + off, tmp);
+                    }
+                    self.codegen.freeGeneral(tmp);
+                    return .{ .list_stack = .{ .struct_offset = result_offset, .data_offset = 0, .num_elements = 0 } };
+                },
+                .list_map_extract_unsafe => {
+                    // list_map_extract_unsafe(list, index) -> element of the input
+                    // type. The list local already carries the output element type;
+                    // lowering only emits this op when both element layouts share
+                    // one stride, so the result layout supplies both the copy size
+                    // and the stride.
+                    std.debug.assert(args.len == 2);
+                    const list_loc = try self.emitValueLocal(args[0]);
+                    const index_loc = try self.emitValueLocal(args[1]);
+
+                    const list_base: i32 = switch (list_loc) {
+                        .stack => |s| s.offset,
+                        .list_stack => |ls_info| ls_info.struct_offset,
+                        else => unreachable,
+                    };
+
+                    const ls = self.layout_store;
+                    const ret_layout_val = ls.getLayout(ll.ret_layout);
+                    const elem_size: u32 = ls.layoutSizeAlign(ret_layout_val).size;
+                    if (elem_size == 0) {
+                        return .{ .immediate_i64 = 0 };
+                    }
+                    if (builtin.mode == .Debug) {
+                        const list_layout_val = ls.getLayout(self.valueLayout(args[0]));
+                        if (list_layout_val.tag != .list or ls.layoutSizeAlign(ls.getLayout(list_layout_val.getIdx())).size != elem_size) {
+                            std.debug.panic("LIR/codegen invariant violated: list_map_extract_unsafe stride mismatch", .{});
+                        }
+                    }
+
+                    const index_reg = try self.ensureInGeneralReg(index_loc);
+                    const ptr_reg = try self.allocTempGeneral();
+                    try self.codegen.emitLoadStack(.w64, ptr_reg, list_base);
+
+                    const addr_reg = try self.allocTempGeneral();
+                    try self.codegen.emit.movRegReg(.w64, addr_reg, index_reg);
+                    self.codegen.freeGeneral(index_reg);
+                    if (elem_size != 1) {
+                        const size_reg = try self.allocTempGeneral();
+                        try self.codegen.emitLoadImm(size_reg, elem_size);
+                        try self.emitMulRegs(.w64, addr_reg, addr_reg, size_reg);
+                        self.codegen.freeGeneral(size_reg);
+                    }
+                    try self.emitAddRegs(.w64, addr_reg, addr_reg, ptr_reg);
+                    self.codegen.freeGeneral(ptr_reg);
+
+                    const elem_slot = self.codegen.allocStackSlot(@intCast(elem_size));
+                    const temp_reg = try self.allocTempGeneral();
+                    if (elem_size <= 8) {
+                        const vs = ValueSize.fromByteCount(@intCast(elem_size));
+                        try self.emitSizedLoadMem(temp_reg, addr_reg, 0, vs);
+                        try self.emitSizedStoreMem(frame_ptr, elem_slot, temp_reg, vs);
+                    } else {
+                        try self.copyChunked(temp_reg, addr_reg, 0, frame_ptr, elem_slot, elem_size);
+                    }
+                    self.codegen.freeGeneral(temp_reg);
+                    self.codegen.freeGeneral(addr_reg);
+
+                    var result_loc: ValueLocation = if (ll.ret_layout == .i128 or ll.ret_layout == .u128 or ll.ret_layout == .dec)
+                        .{ .stack_i128 = elem_slot }
+                    else if (ll.ret_layout == .str)
+                        .{ .stack_str = elem_slot }
+                    else if (ret_layout_val.tag == .list or ret_layout_val.tag == .list_of_zst)
+                        .{ .list_stack = .{
+                            .struct_offset = elem_slot,
+                            .data_offset = 0,
+                            .num_elements = 0,
+                        } }
+                    else
+                        .{ .stack = .{ .offset = elem_slot } };
+
+                    result_loc = try self.stabilize(result_loc);
+                    return result_loc;
+                },
+                .list_map_write_unsafe => {
+                    // list_map_write_unsafe(list, index, element) -> the same list,
+                    // with the owned element's bytes stored into the vacated slot.
+                    std.debug.assert(args.len == 3);
+                    const list_loc = try self.emitValueLocal(args[0]);
+                    const index_loc = try self.emitValueLocal(args[1]);
+                    const elem_loc = try self.emitValueLocal(args[2]);
+
+                    const ls = self.layout_store;
+                    const elem_size: u32 = ls.layoutSizeAlign(ls.getLayout(self.valueLayout(args[2]))).size;
+
+                    const list_off = try self.ensureOnStack(list_loc, roc_list_size);
+                    if (elem_size == 0) {
+                        const zst_result_offset = self.codegen.allocStackSlot(roc_str_size);
+                        const zst_tmp = try self.allocTempGeneral();
+                        var zst_off: i32 = 0;
+                        while (zst_off < roc_list_size) : (zst_off += 8) {
+                            try self.emitLoad(.w64, zst_tmp, frame_ptr, list_off + zst_off);
+                            try self.emitStore(.w64, frame_ptr, zst_result_offset + zst_off, zst_tmp);
+                        }
+                        self.codegen.freeGeneral(zst_tmp);
+                        return .{ .list_stack = .{ .struct_offset = zst_result_offset, .data_offset = 0, .num_elements = 0 } };
+                    }
+                    const elem_off = try self.ensureOnStack(elem_loc, elem_size);
+
+                    const index_reg = try self.ensureInGeneralReg(index_loc);
+                    const addr_reg = try self.allocTempGeneral();
+                    try self.codegen.emit.movRegReg(.w64, addr_reg, index_reg);
+                    self.codegen.freeGeneral(index_reg);
+                    if (elem_size != 1) {
+                        const size_reg = try self.allocTempGeneral();
+                        try self.codegen.emitLoadImm(size_reg, elem_size);
+                        try self.emitMulRegs(.w64, addr_reg, addr_reg, size_reg);
+                        self.codegen.freeGeneral(size_reg);
+                    }
+                    const ptr_reg = try self.allocTempGeneral();
+                    try self.codegen.emitLoadStack(.w64, ptr_reg, list_off);
+                    try self.emitAddRegs(.w64, addr_reg, addr_reg, ptr_reg);
+                    self.codegen.freeGeneral(ptr_reg);
+
+                    const temp_reg = try self.allocTempGeneral();
+                    if (elem_size <= 8) {
+                        const vs = ValueSize.fromByteCount(@intCast(elem_size));
+                        try self.emitSizedLoadMem(temp_reg, frame_ptr, elem_off, vs);
+                        try self.emitSizedStoreMem(addr_reg, 0, temp_reg, vs);
+                    } else {
+                        try self.copyChunked(temp_reg, frame_ptr, elem_off, addr_reg, 0, elem_size);
+                    }
+                    self.codegen.freeGeneral(temp_reg);
+                    self.codegen.freeGeneral(addr_reg);
+
+                    const result_offset = self.codegen.allocStackSlot(roc_str_size);
+                    const tmp = try self.allocTempGeneral();
+                    var off: i32 = 0;
+                    while (off < roc_list_size) : (off += 8) {
+                        try self.emitLoad(.w64, tmp, frame_ptr, list_off + off);
+                        try self.emitStore(.w64, frame_ptr, result_offset + off, tmp);
+                    }
+                    self.codegen.freeGeneral(tmp);
+                    return .{ .list_stack = .{ .struct_offset = result_offset, .data_offset = 0, .num_elements = 0 } };
                 },
                 .list_concat => {
                     // list_concat(list_a, list_b) -> List

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -1062,6 +1062,10 @@ pub const MonoLlvmCodeGen = struct {
             .list_sublist, .list_drop_first, .list_drop_last, .list_take_first, .list_take_last => try self.emitListSublist(target, op, arg_locals, unique_args),
             .list_drop_at => try self.emitListDropAt(target, arg_locals, unique_args),
             .list_set => try self.emitListSet(target, arg_locals, unique_args),
+            .list_map_can_reuse => try self.emitListMapCanReuse(target, arg_locals),
+            .list_map_cast_unsafe => try self.copyBytes(self.slot(target).ptr, self.slot(arg_locals[0]).ptr, self.slot(target).size, self.slot(target).alignment),
+            .list_map_extract_unsafe => try self.emitListMapExtractUnsafe(target, arg_locals),
+            .list_map_write_unsafe => try self.emitListMapWriteUnsafe(target, arg_locals),
             .list_reserve => try self.emitListReserve(target, arg_locals, unique_args),
             .list_release_excess_capacity => try self.emitListReleaseExcess(target, arg_locals, unique_args),
             .list_first, .list_last => try self.emitListFirstLast(target, op, arg_locals),
@@ -1957,6 +1961,44 @@ pub const MonoLlvmCodeGen = struct {
         const offset = wip.bin(.mul, idx, builder.intValue(self.ptrSizedIntType(), abi.elem_size) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
         const src = wip.gep(.inbounds, .i8, bytes, &.{offset}, "") catch return error.OutOfMemory;
         try self.copyBytes(self.slot(target).ptr, src, self.slot(target).size, self.slot(target).alignment);
+    }
+
+    fn emitListMapCanReuse(self: *MonoLlvmCodeGen, target: LocalId, args: []const LocalId) Error!void {
+        var call_args = try self.rocListArgs1(args[0]);
+        defer call_args.deinit(self.allocator);
+        try call_args.append(self.allocator, try self.ptrType(), self.rocOps());
+        const result = try self.callBuiltin("roc_builtins_list_map_can_reuse", .i8, call_args.types.items, call_args.values.items);
+        try self.storeIntToLayout(self.slot(target).ptr, result, self.localLayout(target));
+    }
+
+    fn emitListMapExtractUnsafe(self: *MonoLlvmCodeGen, target: LocalId, args: []const LocalId) Error!void {
+        // Reads the element of the input type out of a buffer already typed
+        // as the output element type; lowering guarantees both share one
+        // stride, so the result layout supplies the stride and the copy size.
+        const elem_size = self.slot(target).size;
+        if (elem_size == 0) return;
+        const bytes = try self.loadPointer(self.slot(args[0]).ptr);
+        const idx = try self.coerceScalar(try self.loadScalar(self.slot(args[1]).ptr, self.localLayout(args[1])), self.ptrSizedIntType(), false);
+        const wip = self.wip orelse return error.CompilationFailed;
+        const builder = self.builder orelse return error.CompilationFailed;
+        const offset = wip.bin(.mul, idx, builder.intValue(self.ptrSizedIntType(), elem_size) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+        const src = wip.gep(.inbounds, .i8, bytes, &.{offset}, "") catch return error.OutOfMemory;
+        try self.copyBytes(self.slot(target).ptr, src, elem_size, self.slot(target).alignment);
+    }
+
+    fn emitListMapWriteUnsafe(self: *MonoLlvmCodeGen, target: LocalId, args: []const LocalId) Error!void {
+        const elem_size = self.slot(args[2]).size;
+        if (elem_size != 0) {
+            const bytes = try self.loadPointer(self.slot(args[0]).ptr);
+            const idx = try self.coerceScalar(try self.loadScalar(self.slot(args[1]).ptr, self.localLayout(args[1])), self.ptrSizedIntType(), false);
+            const wip = self.wip orelse return error.CompilationFailed;
+            const builder = self.builder orelse return error.CompilationFailed;
+            const offset = wip.bin(.mul, idx, builder.intValue(self.ptrSizedIntType(), elem_size) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+            const dst = wip.gep(.inbounds, .i8, bytes, &.{offset}, "") catch return error.OutOfMemory;
+            try self.copyBytes(dst, self.slot(args[2]).ptr, elem_size, self.slot(args[2]).alignment);
+        }
+        // The result is the same list value.
+        try self.copyBytes(self.slot(target).ptr, self.slot(args[0]).ptr, self.slot(target).size, self.slot(target).alignment);
     }
 
     fn emitListWithCapacity(self: *MonoLlvmCodeGen, target: LocalId, args: []const LocalId) Error!void {

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -8677,6 +8677,169 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             }
         },
 
+        .list_map_can_reuse => {
+            // list_map_can_reuse(list, transform) -> U8: the list uniquely owns
+            // its allocation and is not a seamless slice. Wasm is
+            // single-threaded, so a plain refcount load suffices.
+            try self.emitProcLocal(args[0]);
+            const list_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+            try self.emitLocalSet(list_local);
+
+            const cap_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+            try self.emitLocalGet(list_local);
+            try self.emitLoadOp(.i32, 8);
+            try self.emitLocalSet(cap_local);
+
+            // Seamless slices tag the low bit of the capacity field.
+            try self.emitLocalGet(cap_local);
+            try self.emitI32Const(1);
+            self.currentCode().append(self.allocator, Op.i32_and) catch return error.OutOfMemory;
+            self.currentCode().append(self.allocator, Op.@"if") catch return error.OutOfMemory;
+            self.currentCode().append(self.allocator, @intFromEnum(ValType.i32)) catch return error.OutOfMemory;
+            try self.emitI32Const(0);
+            self.currentCode().append(self.allocator, Op.@"else") catch return error.OutOfMemory;
+            // Zero capacity has no heap refcount and counts as unique.
+            try self.emitLocalGet(cap_local);
+            try self.emitI32Const(1);
+            self.currentCode().append(self.allocator, Op.i32_shr_u) catch return error.OutOfMemory;
+            self.currentCode().append(self.allocator, Op.i32_eqz) catch return error.OutOfMemory;
+            self.currentCode().append(self.allocator, Op.@"if") catch return error.OutOfMemory;
+            self.currentCode().append(self.allocator, @intFromEnum(ValType.i32)) catch return error.OutOfMemory;
+            try self.emitI32Const(1);
+            self.currentCode().append(self.allocator, Op.@"else") catch return error.OutOfMemory;
+            // The refcount lives one usize before the data pointer.
+            try self.emitLocalGet(list_local);
+            try self.emitLoadOp(.i32, 0);
+            try self.emitI32Const(4);
+            self.currentCode().append(self.allocator, Op.i32_sub) catch return error.OutOfMemory;
+            try self.emitLoadOp(.i32, 0);
+            try self.emitI32Const(1);
+            self.currentCode().append(self.allocator, Op.i32_eq) catch return error.OutOfMemory;
+            self.currentCode().append(self.allocator, Op.end) catch return error.OutOfMemory;
+            self.currentCode().append(self.allocator, Op.end) catch return error.OutOfMemory;
+        },
+
+        .list_map_cast_unsafe => {
+            // Same bits, new element type: copy the 12-byte list struct.
+            try self.emitProcLocal(args[0]);
+            const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+            try self.emitLocalSet(src_local);
+            const dst_offset = try self.allocStackMemory(12, 4);
+            const dst_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+            try self.emitFpOffset(dst_offset);
+            try self.emitLocalSet(dst_local);
+            try self.emitMemCopy(dst_local, 0, src_local, 12);
+            try self.emitLocalGet(dst_local);
+        },
+
+        .list_map_extract_unsafe => {
+            // Like list_get_unsafe, but the element layout comes from the
+            // result (input element type) while the buffer is typed with the
+            // output element type; lowering guarantees the strides match.
+            const ls = self.getLayoutStore();
+            const elem_layout_idx = ll.ret_layout;
+            const elem_size: u32 = try self.layoutStorageByteSize(elem_layout_idx);
+            const elem_is_composite = try self.isCompositeLayout(elem_layout_idx);
+            if (elem_size == 0) {
+                // ZST element: no data to read.
+                try self.emitI32Const(0);
+                return;
+            }
+
+            try self.emitProcLocal(args[0]);
+            const list_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+            try self.emitLocalSet(list_local);
+
+            const index_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+            try self.emitProcLocal(args[1]);
+            if (try self.procLocalValType(args[1]) == .i64) {
+                self.currentCode().append(self.allocator, Op.i32_wrap_i64) catch return error.OutOfMemory;
+            }
+            try self.emitLocalSet(index_local);
+
+            try self.emitLocalGet(list_local);
+            try self.emitLoadOp(.i32, 0);
+            try self.emitLocalGet(index_local);
+            try self.emitI32Const(@intCast(elem_size));
+            self.currentCode().append(self.allocator, Op.i32_mul) catch return error.OutOfMemory;
+            self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+
+            if (elem_is_composite) {
+                const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                try self.emitLocalSet(src_local);
+
+                const elem_align: u32 = @intCast(@max(ls.layoutSizeAlign(ls.getLayout(elem_layout_idx)).alignment.toByteUnits(), 1));
+                const dst_offset = try self.allocStackMemory(elem_size, elem_align);
+                const dst_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                try self.emitFpOffset(dst_offset);
+                try self.emitLocalSet(dst_local);
+
+                try self.emitMemCopy(dst_local, 0, src_local, elem_size);
+                try self.emitLocalGet(dst_local);
+            } else {
+                try self.emitLoadOpForLayout(elem_layout_idx, 0);
+            }
+        },
+
+        .list_map_write_unsafe => {
+            // list_map_write_unsafe(list, index, element) -> the same list,
+            // with the owned element's bytes stored into the vacated slot.
+            const elem_layout_idx = self.procLocalLayoutIdx(args[2]);
+            const elem_size: u32 = try self.layoutStorageByteSize(elem_layout_idx);
+            const elem_is_composite = try self.isCompositeLayout(elem_layout_idx);
+
+            try self.emitProcLocal(args[0]);
+            const list_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+            try self.emitLocalSet(list_local);
+
+            if (elem_size == 0) {
+                // ZST element: nothing to store; pass the list through.
+                const zst_result_offset = try self.allocStackMemory(12, 4);
+                const zst_result_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                try self.emitFpOffset(zst_result_offset);
+                try self.emitLocalSet(zst_result_local);
+                try self.emitMemCopy(zst_result_local, 0, list_local, 12);
+                try self.emitLocalGet(zst_result_local);
+                return;
+            }
+
+            const index_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+            try self.emitProcLocal(args[1]);
+            if (try self.procLocalValType(args[1]) == .i64) {
+                self.currentCode().append(self.allocator, Op.i32_wrap_i64) catch return error.OutOfMemory;
+            }
+            try self.emitLocalSet(index_local);
+
+            const dst_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+            try self.emitLocalGet(list_local);
+            try self.emitLoadOp(.i32, 0);
+            try self.emitLocalGet(index_local);
+            try self.emitI32Const(@intCast(elem_size));
+            self.currentCode().append(self.allocator, Op.i32_mul) catch return error.OutOfMemory;
+            self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+            try self.emitLocalSet(dst_local);
+
+            if (elem_is_composite) {
+                try self.emitProcLocal(args[2]);
+                const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                try self.emitLocalSet(src_local);
+                try self.emitMemCopy(dst_local, 0, src_local, elem_size);
+            } else {
+                const elem_vt = try self.resolveValType(elem_layout_idx);
+                try self.emitLocalGet(dst_local);
+                try self.emitProcLocal(args[2]);
+                try self.emitConversion(try self.procLocalValType(args[2]), elem_vt);
+                try self.emitStoreOpSized(elem_vt, elem_size, 0);
+            }
+
+            const result_offset = try self.allocStackMemory(12, 4);
+            const result_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+            try self.emitFpOffset(result_offset);
+            try self.emitLocalSet(result_local);
+            try self.emitMemCopy(result_local, 0, list_local, 12);
+            try self.emitLocalGet(result_local);
+        },
+
         // String operations
         // Bitwise operations
         .num_pow, .num_log => unreachable, // Resolved by earlier lowering

--- a/src/base/LowLevel.zig
+++ b/src/base/LowLevel.zig
@@ -70,6 +70,10 @@ pub const LowLevel = enum {
     list_release_excess_capacity,
     list_split_first,
     list_split_last,
+    list_map_can_reuse,
+    list_map_cast_unsafe,
+    list_map_extract_unsafe,
+    list_map_write_unsafe,
 
     // Bool operations
     bool_not,
@@ -598,6 +602,23 @@ pub const LowLevel = enum {
             => RcEffect.runtimeUniqueness(argMask(&.{0})),
 
             .list_append_unsafe => RcEffect.consumesArgsReturningConsumedArgsRetainingArgs(argMask(&.{0}), argMask(&.{1})),
+
+            // Reads the list's refcount (and slice bit) without changing it.
+            .list_map_can_reuse => RcEffect.none(),
+
+            // Retypes a unique non-slice list to the output element type,
+            // keeping the same allocation. Only reachable behind a true
+            // `list_map_can_reuse`, so the result's count is 1 on return.
+            .list_map_cast_unsafe => RcEffect.consumesArgsReturningConsumedArgsRetainingArgs(argMask(&.{0}), 0),
+
+            // Moves one element's ownership out of a unique list's buffer.
+            // The buffer slot keeps stale bytes until `list_map_write_unsafe`
+            // stores the replacement; the op itself performs no RC work.
+            .list_map_extract_unsafe => RcEffect.none(),
+
+            // Stores an owned element into the slot vacated by
+            // `list_map_extract_unsafe`, mirroring `list_append_unsafe`.
+            .list_map_write_unsafe => RcEffect.consumesArgsReturningConsumedArgsRetainingArgs(argMask(&.{0}), argMask(&.{2})),
 
             .list_set,
             .list_replace_unsafe,

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -887,12 +887,26 @@ Builtin :: [].{
 		## ```
 		map : List(a), (a -> b) -> List(b)
 		map = |list, transform| {
-			# TODO: Optimize with in-place update when list is unique and element sizes match
-			var $new_list = List.with_capacity(list.len())
-			for item in list {
-				$new_list = list_append_unsafe($new_list, transform(item))
+			match list_map_can_reuse(list, transform) {
+				1 => {
+					len = list.len()
+					var $out = list_map_cast_unsafe(list)
+					var $index = 0
+					while $index < len {
+						item = list_map_extract_unsafe($out, $index)
+						$out = list_map_write_unsafe($out, $index, transform(item))
+						$index = $index + 1
+					}
+					$out
+				}
+				_ => {
+					var $new_list = List.with_capacity(list.len())
+					for item in list {
+						$new_list = list_append_unsafe($new_list, transform(item))
+					}
+					$new_list
+				}
 			}
-			$new_list
 		}
 
 		## This works like [List.map], except it also passes the index
@@ -9521,6 +9535,29 @@ list_replace_unsafe : List(item), U64, item -> { list : List(item), prev : item 
 
 # Implemented by the compiler, does not perform bounds checks
 list_swap_unsafe : List(item), U64, U64 -> List(item)
+
+# Implemented by the compiler. Returns 1 (otherwise 0) when List.map may reuse
+# the input list's allocation for its output: the input and output element
+# layouts are interchangeable, and at runtime the list is uniquely owned and
+# not a seamless slice. Lowered to a constant 0 when the layouts are not
+# interchangeable, which lets lowering drop the in-place branch entirely.
+# Note: success is U8 (0 = false, 1 = true) since Bool is not available at top level
+list_map_can_reuse : List(input), (input -> output) -> U8
+
+# Implemented by the compiler. Retypes a unique, non-slice list in place so
+# List.map can overwrite its elements without allocating a new list. Must only
+# be called on a list for which list_map_can_reuse returned 1.
+list_map_cast_unsafe : List(input) -> List(output)
+
+# Implemented by the compiler. Moves ownership of the element at the given
+# index out of the list's buffer; the slot keeps stale bytes until
+# list_map_write_unsafe stores its replacement. No bounds checks.
+list_map_extract_unsafe : List(output), U64 -> input
+
+# Implemented by the compiler. Stores an owned element into the slot at the
+# given index, which must have been vacated by list_map_extract_unsafe.
+# No bounds checks.
+list_map_write_unsafe : List(output), U64, output -> List(output)
 
 # Implemented by the compiler, ensures at least spare additional elements of capacity
 list_reserve : List(item), U64 -> List(item)

--- a/src/builtins/dev_wrappers.zig
+++ b/src/builtins/dev_wrappers.zig
@@ -450,6 +450,12 @@ pub fn roc_builtins_list_append_unsafe(out: *RocList, list_bytes: ?[*]u8, list_l
     out.* = listAppendUnsafe(l, @constCast(element), element_width, @ptrCast(&copy_fallback));
 }
 
+/// Wrapper: listMapCanReuse
+pub fn roc_builtins_list_map_can_reuse(list_bytes: ?[*]u8, list_len: usize, list_cap: usize, roc_ops: *RocOps) callconv(.c) u8 {
+    const l = RocList{ .bytes = list_bytes, .length = list_len, .capacity_or_alloc_ptr = list_cap };
+    return @intFromBool(list.listMapCanReuse(l, roc_ops));
+}
+
 /// Wrapper: listConcat(RocList, RocList, alignment, element_width, ..., *RocOps) -> RocList.
 /// `update_modes` carries one bit per list argument (bit 0 = a, bit 1 = b); a
 /// set bit selects `.InPlace` for that argument's uniqueness check, skipping

--- a/src/builtins/list.zig
+++ b/src/builtins/list.zig
@@ -1519,6 +1519,17 @@ pub fn listIsUnique(
     return list.isEmpty() or list.isUnique(roc_ops);
 }
 
+/// Whether List.map may overwrite this list's elements in place: the list
+/// must uniquely own its allocation and must not be a seamless slice into a
+/// larger allocation (a slice's buffer start and header bookkeeping cover
+/// the whole underlying allocation, not just the slice window).
+pub fn listMapCanReuse(
+    list: RocList,
+    roc_ops: *RocOps,
+) callconv(.c) bool {
+    return !list.isSeamlessSlice() and list.isUnique(roc_ops);
+}
+
 /// Create independent copy for safe mutation when list is shared.
 pub fn listClone(
     list: RocList,

--- a/src/builtins/static_lib.zig
+++ b/src/builtins/static_lib.zig
@@ -71,6 +71,7 @@ comptime {
     @export(&dw.roc_builtins_str_from_literal, .{ .name = "roc_builtins_str_from_literal" });
     @export(&dw.roc_builtins_list_with_capacity, .{ .name = "roc_builtins_list_with_capacity" });
     @export(&dw.roc_builtins_list_append_unsafe, .{ .name = "roc_builtins_list_append_unsafe" });
+    @export(&dw.roc_builtins_list_map_can_reuse, .{ .name = "roc_builtins_list_map_can_reuse" });
     @export(&dw.roc_builtins_list_concat, .{ .name = "roc_builtins_list_concat" });
     @export(&dw.roc_builtins_list_prepend, .{ .name = "roc_builtins_list_prepend" });
     @export(&dw.roc_builtins_list_sublist, .{ .name = "roc_builtins_list_sublist" });

--- a/src/canonicalize/BuiltinLowLevel.zig
+++ b/src/canonicalize/BuiltinLowLevel.zig
@@ -242,6 +242,18 @@ fn replaceProvidedByCompilerLowLevels(env: *ModuleEnv) (Allocator.Error || error
     if (env.common.findIdent("list_swap_unsafe")) |list_swap_unsafe_ident| {
         try low_level_map.put(list_swap_unsafe_ident, .list_swap);
     }
+    if (env.common.findIdent("list_map_can_reuse")) |list_map_can_reuse_ident| {
+        try low_level_map.put(list_map_can_reuse_ident, .list_map_can_reuse);
+    }
+    if (env.common.findIdent("list_map_cast_unsafe")) |list_map_cast_unsafe_ident| {
+        try low_level_map.put(list_map_cast_unsafe_ident, .list_map_cast_unsafe);
+    }
+    if (env.common.findIdent("list_map_extract_unsafe")) |list_map_extract_unsafe_ident| {
+        try low_level_map.put(list_map_extract_unsafe_ident, .list_map_extract_unsafe);
+    }
+    if (env.common.findIdent("list_map_write_unsafe")) |list_map_write_unsafe_ident| {
+        try low_level_map.put(list_map_write_unsafe_ident, .list_map_write_unsafe);
+    }
     const numeric_types = [_][]const u8{ "U8", "I8", "U16", "I16", "U32", "I32", "U64", "I64", "U128", "I128", "Dec", "F32", "F64" };
     const signed_types = [_][]const u8{ "I8", "I16", "I32", "I64", "I128", "Dec", "F32", "F64" };
     // Numeric equality operations.

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -4573,6 +4573,7 @@ fn rocBuildLlvm(ctx: *CliCtx, args: cli_args.BuildArgs) anyerror!void {
         .{ .requests = root_artifact.root_requests.runtime_requests },
         .{
             .target_usize = target_usize,
+            .list_in_place_map = listInPlaceMapForOpt(args.opt),
         },
     );
     defer lowered.deinit();
@@ -4859,6 +4860,7 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) anyerror!void {
         .{
             .target_usize = target_usize,
             .inline_mode = postCheckInlineModeForOpt(args.opt),
+            .list_in_place_map = listInPlaceMapForOpt(args.opt),
         },
     );
     defer lowered.deinit();
@@ -5697,6 +5699,13 @@ fn postCheckInlineModeForOpt(opt: cli_args.OptLevel) lir.CheckedPipeline.InlineM
     };
 }
 
+fn listInPlaceMapForOpt(opt: cli_args.OptLevel) bool {
+    return switch (opt) {
+        .size, .speed => true,
+        .dev, .interpreter => false,
+    };
+}
+
 const CliTestRootRun = struct {
     root: check.CheckedArtifact.RootRequest,
     root_proc: lir.LirProcSpecId,
@@ -6007,6 +6016,7 @@ fn runCheckedArtifactTests(
         .{
             .target_usize = base.target.TargetUsize.native,
             .inline_mode = postCheckInlineModeForOpt(opt),
+            .list_in_place_map = listInPlaceMapForOpt(opt),
         },
     );
     defer lowered.deinit();

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -4246,6 +4246,38 @@ pub const Interpreter = struct {
                 );
                 break :blk self.rocListToValue(result, ll.ret_layout);
             },
+            .list_map_can_reuse => blk: {
+                const rl = self.valueToRocListForLayout(args[0], arg_layout);
+                const val = try self.alloc(ll.ret_layout);
+                val.write(u8, if (builtins.list.listMapCanReuse(rl, &self.roc_ops)) 1 else 0);
+                break :blk val;
+            },
+            .list_map_cast_unsafe => blk: {
+                const rl = self.valueToRocListForLayout(args[0], arg_layout);
+                break :blk self.rocListToValue(rl, ll.ret_layout);
+            },
+            .list_map_extract_unsafe => blk: {
+                // Same data movement as list_get_unsafe; ownership of the
+                // element transfers out of the buffer, which is RC metadata
+                // rather than runtime behavior.
+                const rl = self.valueToRocListForLayout(args[0], arg_layout);
+                const idx = args[1].read(u64);
+                const info = self.listElemInfo(arg_layout);
+                if (info.width == 0) break :blk try self.alloc(ll.ret_layout);
+                const elem_ptr = rl.bytes.? + @as(usize, @intCast(idx)) * info.width;
+                const val = try self.alloc(ll.ret_layout);
+                @memcpy(val.ptr[0..info.width], elem_ptr[0..info.width]);
+                break :blk val;
+            },
+            .list_map_write_unsafe => blk: {
+                const rl = self.valueToRocListForLayout(args[0], arg_layout);
+                const idx = args[1].read(u64);
+                const info = self.listElemInfo(arg_layout);
+                if (info.width == 0) break :blk self.rocListToValue(rl, ll.ret_layout);
+                const elem_ptr = rl.bytes.? + @as(usize, @intCast(idx)) * info.width;
+                @memcpy(elem_ptr[0..info.width], args[2].ptr[0..info.width]);
+                break :blk self.rocListToValue(rl, ll.ret_layout);
+            },
             .list_sublist => blk: {
                 if (args.len != 2 or ll.arg_layouts.len != 2) {
                     return self.runtimeError("list_sublist expected 2 arguments");

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -134,6 +134,38 @@ const core_tests = [_]TestCase{
         .expected = .{ .inspect_str = "[10.0, 20.0, 30.0, 40.0]" },
     },
 
+    // Cross-type reuse: a tuple and a record with the same field layouts are
+    // different types but interchangeable in one allocation, so a unique
+    // list still maps in place.
+    .{
+        .name = "allocation - List.map reuses unique list across tuple-to-record types",
+        .source =
+        \\{
+        \\    base = List.concat([(1, 2)], [(3, 4)])
+        \\    swapped = List.map(base, |(a, b)| { x: b, y: a })
+        \\    if swapped == List.concat([{ x: 2, y: 1 }], [{ x: 4, y: 3 }]) {
+        \\        "ok"
+        \\    } else {
+        \\        "bad"
+        \\    }
+        \\}
+        ,
+        // Four list literals plus two concats; the map itself contributes
+        // zero. The copy path would allocate one more and fail this ceiling.
+        .expected = .{ .allocations_at_most = .{
+            .output = "ok",
+            .max_allocations = 6,
+        } },
+    },
+
+    // Cross-type reuse with refcounted elements: ownership of each string
+    // moves out of the slot and back in inside the new record.
+    .{
+        .name = "inspect: List.map in place across tuple-to-record with strings",
+        .source = "List.map(List.concat([(\"a\", 1)], [(\"b\", 2)]), |(s, n)| { label: s, n: n })",
+        .expected = .{ .inspect_str = "[{ label: \"a\", n: 1.0 }, { label: \"b\", n: 2.0 }]" },
+    },
+
     // The list is shared (used again after the map), so map must take the
     // copy path and leave the original untouched.
     .{

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -105,6 +105,141 @@ const core_tests = [_]TestCase{
         } },
     },
 
+    // In-place List.map: same element type, unique list -> the output reuses
+    // the input allocation, so map itself must not allocate.
+    .{
+        .name = "allocation - List.map reuses unique same-type list in place",
+        .source =
+        \\{
+        \\    base = List.concat([1, 2], [3, 4])
+        \\    doubled = List.map(base, |x| x * 2)
+        \\    if doubled == List.concat([2, 4], [6, 8]) {
+        \\        "ok"
+        \\    } else {
+        \\        "bad"
+        \\    }
+        \\}
+        ,
+        // Four list literals plus two concats; the map itself contributes
+        // zero. The copy path would allocate one more and fail this ceiling.
+        .expected = .{ .allocations_at_most = .{
+            .output = "ok",
+            .max_allocations = 6,
+        } },
+    },
+
+    .{
+        .name = "inspect: List.map in place over unique same-type list",
+        .source = "List.map(List.concat([1, 2], [3, 4]), |x| x * 10)",
+        .expected = .{ .inspect_str = "[10.0, 20.0, 30.0, 40.0]" },
+    },
+
+    // The list is shared (used again after the map), so map must take the
+    // copy path and leave the original untouched.
+    .{
+        .name = "inspect: List.map leaves shared list unchanged",
+        .source =
+        \\{
+        \\    a = List.concat([1], [2])
+        \\    b = List.map(a, |x| x + 1)
+        \\    (a, b)
+        \\}
+        ,
+        .expected = .{ .inspect_str = "([1.0, 2.0], [2.0, 3.0])" },
+    },
+
+    // The transform captures the list it is mapping, which holds the
+    // refcount above 1; in-place mutation here would make later elements
+    // observe already-written outputs through the capture.
+    .{
+        .name = "inspect: List.map transform capturing the mapped list",
+        .source =
+        \\{
+        \\    a = List.concat([5], [7])
+        \\    List.map(a, |x| x + (match a.get(0) {
+        \\        Ok(v) => v
+        \\        Err(_) => 0
+        \\    }))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[10.0, 12.0]" },
+    },
+
+    // A seamless slice can be uniquely owned yet must never be mutated in
+    // place, because its buffer points into the middle of an allocation.
+    .{
+        .name = "inspect: List.map over unique seamless slice",
+        .source =
+        \\{
+        \\    s = List.sublist(List.concat([1, 2], [3, 4]), { start: 1, len: 2 })
+        \\    List.map(s, |x| x * 2)
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[4.0, 6.0]" },
+    },
+
+    // A unique list emptied at runtime still goes through the in-place
+    // branch; the loop must tolerate len == 0.
+    .{
+        .name = "inspect: List.map in place over emptied unique list",
+        .source = "List.map(List.drop_first(List.concat([1], [2]), 2), |x| x + 1)",
+        .expected = .{ .inspect_str = "[]" },
+    },
+
+    // Zero-sized elements have no allocation to reuse; the runtime check
+    // lowers to a constant 0 and the copy path handles them.
+    .{
+        .name = "inspect: List.map over zero-sized elements",
+        .source = "List.map(List.concat([{}], [{}]), |x| x)",
+        .expected = .{ .inspect_str = "[{}, {}]" },
+    },
+
+    // Str -> Str maps are in-place eligible and the elements are refcounted:
+    // the identity transform exercises element ownership moving out of and
+    // back into the buffer without double-frees or leaks.
+    .{
+        .name = "inspect: List.map identity over unique list of strings",
+        .source = "List.map(List.concat([\"hello\"], [\"world\"]), |s| s)",
+        .expected = .{ .inspect_str = "[\"hello\", \"world\"]" },
+    },
+
+    // Heap-allocated strings: each transform result replaces a heap-owning
+    // element, so the old element must be released exactly once.
+    .{
+        .name = "inspect: List.map concat over unique list of heap strings",
+        .source = "List.map(List.concat([Str.repeat(\"x\", 30)], [Str.repeat(\"y\", 30)]), |s| Str.concat(s, \"!\"))",
+        .expected = .{ .inspect_str = "[\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx!\", \"yyyyyyyyyyyyyyyyyyyyyyyyyyyyyy!\"]" },
+    },
+
+    // Shared list of refcounted elements: copy path, original intact.
+    .{
+        .name = "inspect: List.map leaves shared string list unchanged",
+        .source =
+        \\{
+        \\    a = List.concat(["x"], ["y"])
+        \\    b = List.map(a, |s| Str.concat(s, "!"))
+        \\    (a, b)
+        \\}
+        ,
+        .expected = .{ .inspect_str = "([\"x\", \"y\"], [\"x!\", \"y!\"])" },
+    },
+
+    // The transform crashes partway through an in-place map; crash is fatal,
+    // so the half-rewritten buffer must never be observed by cleanup.
+    .{
+        .name = "inspect: List.map transform crashes mid-list",
+        .source =
+        \\List.map(List.concat(["a"], ["b", "c"]), |s| {
+        \\    if Str.starts_with(s, "b") {
+        \\        crash "boom"
+        \\    } else {
+        \\        s
+        \\    }
+        \\})
+        ,
+        .expected = .{ .crash = {} },
+    },
+
     // Basic expressions and control flow
     .{ .name = "inspect: integer literal", .source = "42", .expected = .{ .inspect_str = "42.0" } },
     .{ .name = "inspect: negative integer literal", .source = "-1234", .expected = .{ .inspect_str = "-1234.0" } },

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -1214,6 +1214,10 @@ fn lowerCheckedRootWithViews(
         .{ .requests = root_module.root_requests.runtime_requests },
         .{
             .target_usize = target_usize,
+            // Match optimized builds so every backend exercises the in-place
+            // List.map path; the copy path is still covered by shared-list,
+            // slice, and layout-mismatch cases.
+            .list_in_place_map = true,
         },
     );
 

--- a/src/lir/checked_pipeline.zig
+++ b/src/lir/checked_pipeline.zig
@@ -40,6 +40,11 @@ pub const TargetConfig = struct {
     target_usize: base.target.TargetUsize = base.target.TargetUsize.native,
     checked_module_state: CheckedModuleState = .complete,
     inline_mode: InlineMode = .none,
+    /// Allow `List.map` to reuse a unique input list's allocation when the
+    /// input and output element layouts are interchangeable. Optimized builds
+    /// enable this; dev builds and compile-time evaluation leave it off so
+    /// the in-place branch is dropped during lowering.
+    list_in_place_map: bool = false,
 };
 
 /// Whether the root checked module is complete or inside checking finalization.
@@ -213,6 +218,7 @@ pub fn lowerCheckedModulesToLir(
 
     var lowered = try postcheck.SolvedLirLower.run(allocator, target.target_usize, solved, .{
         .inline_plan = inline_plan.view(),
+        .list_in_place_map = target.list_in_place_map,
     });
     solved_owned = false;
     solved = undefined;

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -15,7 +15,9 @@ const Allocator = std.mem.Allocator;
 pub fn run(
     allocator: Allocator,
     solved: Solved.Program,
-    list_in_place_map: bool,
+    /// Match sites the direct lowerer statically resolved; replayed here so
+    /// both derivations demand the same set of functions.
+    folded_matches: []const Lifted.Program.FoldedMatch,
 ) Common.LowerError!Ast.Program {
     var owned = solved;
     errdefer owned.deinit();
@@ -30,7 +32,10 @@ pub fn run(
     errdefer program.deinit();
 
     var lowerer = try Lowerer.init(allocator, &owned, &program);
-    lowerer.list_in_place_map = list_in_place_map;
+    defer lowerer.folded_matches.deinit(allocator);
+    for (folded_matches) |folded| {
+        try lowerer.folded_matches.put(allocator, folded.scrutinee, folded.body);
+    }
     defer lowerer.deinit();
     try lowerer.lower();
     program.next_symbol = lowerer.symbols.next;
@@ -125,9 +130,10 @@ const Lowerer = struct {
     captures: std.AutoHashMap(Lifted.LocalId, CaptureBinding),
     symbols: Common.SymbolGen,
     erased_capture_ptr_ty: ?Type.TypeId = null,
-    /// Mirrors direct LIR lowering's in-place `List.map` branch fold so the
-    /// debug verifier sees the same set of demanded functions.
-    list_in_place_map: bool = false,
+    /// Replays the match resolutions direct LIR lowering recorded, so the
+    /// debug verifier sees the same set of demanded functions. Keyed by the
+    /// match's scrutinee expression.
+    folded_matches: std.AutoHashMapUnmanaged(Lifted.ExprId, Lifted.ExprId) = .empty,
 
     fn init(allocator: Allocator, solved: *const Solved.Program, program: *Ast.Program) Allocator.Error!Lowerer {
         const local_map = try allocator.alloc(?Ast.LocalId, solved.lifted.locals.items.len);
@@ -482,12 +488,7 @@ const Lowerer = struct {
                 .negated = eq.negated,
             } },
             .match_ => |match| blk: {
-                if (self.solved.lifted.listMapCanReuseFoldedBranchBody(
-                    &self.program.names,
-                    match.scrutinee,
-                    match.branches,
-                    self.list_in_place_map,
-                )) |folded_body| {
+                if (self.folded_matches.get(match.scrutinee)) |folded_body| {
                     break :blk .{ .block = .{
                         .statements = .empty(),
                         .final_expr = try self.lowerExpr(folded_body),

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -15,6 +15,7 @@ const Allocator = std.mem.Allocator;
 pub fn run(
     allocator: Allocator,
     solved: Solved.Program,
+    list_in_place_map: bool,
 ) Common.LowerError!Ast.Program {
     var owned = solved;
     errdefer owned.deinit();
@@ -29,6 +30,7 @@ pub fn run(
     errdefer program.deinit();
 
     var lowerer = try Lowerer.init(allocator, &owned, &program);
+    lowerer.list_in_place_map = list_in_place_map;
     defer lowerer.deinit();
     try lowerer.lower();
     program.next_symbol = lowerer.symbols.next;
@@ -123,6 +125,9 @@ const Lowerer = struct {
     captures: std.AutoHashMap(Lifted.LocalId, CaptureBinding),
     symbols: Common.SymbolGen,
     erased_capture_ptr_ty: ?Type.TypeId = null,
+    /// Mirrors direct LIR lowering's in-place `List.map` branch fold so the
+    /// debug verifier sees the same set of demanded functions.
+    list_in_place_map: bool = false,
 
     fn init(allocator: Allocator, solved: *const Solved.Program, program: *Ast.Program) Allocator.Error!Lowerer {
         const local_map = try allocator.alloc(?Ast.LocalId, solved.lifted.locals.items.len);
@@ -476,10 +481,23 @@ const Lowerer = struct {
                 .rhs = try self.lowerExpr(eq.rhs),
                 .negated = eq.negated,
             } },
-            .match_ => |match| .{ .match_ = .{
-                .scrutinee = try self.lowerExpr(match.scrutinee),
-                .branches = try self.lowerBranchSpan(match.branches),
-            } },
+            .match_ => |match| blk: {
+                if (self.solved.lifted.listMapCanReuseFoldedBranchBody(
+                    &self.program.names,
+                    match.scrutinee,
+                    match.branches,
+                    self.list_in_place_map,
+                )) |folded_body| {
+                    break :blk .{ .block = .{
+                        .statements = .empty(),
+                        .final_expr = try self.lowerExpr(folded_body),
+                    } };
+                }
+                break :blk .{ .match_ = .{
+                    .scrutinee = try self.lowerExpr(match.scrutinee),
+                    .branches = try self.lowerBranchSpan(match.branches),
+                } };
+            },
             .if_ => |if_| .{ .if_ = .{
                 .branches = try self.lowerIfBranchSpan(if_.branches),
                 .final_else = try self.lowerExpr(if_.final_else),

--- a/src/postcheck/monotype_lifted/ast.zig
+++ b/src/postcheck/monotype_lifted/ast.zig
@@ -303,24 +303,25 @@ pub const Program = struct {
         return self.branches.items[span_.start..][0..span_.len];
     }
 
-    /// When a match scrutinizes the Builtin `list_map_can_reuse` wrapper and
-    /// the in-place `List.map` branch is statically impossible — the
-    /// optimization is disabled, or the input and output element monotypes
-    /// differ — returns the body of the branch a constant-0 scrutinee
-    /// selects. Direct LIR lowering and the debug Lambda Mono materializer
-    /// both consult this, so they agree on which functions exist and the
-    /// in-place branch (with the wrapper specializations it references)
-    /// never reaches LIR in that case. Returns null when the match is not
-    /// that shape or the runtime uniqueness check must decide.
-    pub fn listMapCanReuseFoldedBranchBody(
+    /// The two pieces direct LIR lowering needs to consider folding away the
+    /// in-place `List.map` branch: the `list_map_can_reuse` call's arguments
+    /// (to compute layout eligibility) and the body a constant-0 scrutinee
+    /// selects.
+    pub const ListMapCanReuseMatch = struct {
+        call_args: Span(ExprId),
+        zero_branch_body: ExprId,
+    };
+
+    /// Recognizes the `List.map` reuse match: a match whose scrutinee calls
+    /// the Builtin `list_map_can_reuse` wrapper, with guard-free
+    /// integer-literal and wildcard branches. Returns null for any other
+    /// shape. Whether to fold is the caller's layout-aware decision; this
+    /// only identifies the site and the branch a constant 0 reaches.
+    pub fn listMapCanReuseMatch(
         self: *const Program,
-        // Taken explicitly because the Lambda Mono materializer moves the
-        // name store out of the lifted program before lowering.
-        name_store: *const names.NameStore,
         scrutinee: ExprId,
         branches_span: Span(Branch),
-        list_in_place_map: bool,
-    ) ?ExprId {
+    ) ?ListMapCanReuseMatch {
         const call = switch (self.exprs.items[@intFromEnum(scrutinee)].data) {
             .call_proc => |call| call,
             else => return null,
@@ -335,39 +336,27 @@ pub const Program = struct {
         };
         if (!self.exprIsListMapCanReuseOp(callee_body)) return null;
 
-        fold: {
-            if (!list_in_place_map) break :fold;
-            const args = self.exprSpan(call.args);
-            if (args.len != 2) return null;
-            const in_elem = switch (self.types.get(self.unwrapNamedBacking(self.exprs.items[@intFromEnum(args[0])].ty))) {
-                .list => |elem| elem,
-                else => return null,
-            };
-            const out_elem = switch (self.types.get(self.unwrapNamedBacking(self.exprs.items[@intFromEnum(args[1])].ty))) {
-                .func => |func| func.ret,
-                else => return null,
-            };
-            const in_digest = self.types.typeDigest(name_store, in_elem);
-            const out_digest = self.types.typeDigest(name_store, out_elem);
-            // Identical element monotypes share one layout, so reuse is the
-            // runtime uniqueness check's call; keep both branches.
-            if (std.mem.eql(u8, &in_digest.bytes, &out_digest.bytes)) return null;
-            break :fold;
-        }
-
-        // The scrutinee is a constant 0: select the branch it reaches. Only
-        // guard-free integer-literal and wildcard patterns participate; any
-        // other shape keeps the full match.
         for (self.branchSpan(branches_span)) |branch| {
             if (branch.guard != null) return null;
             switch (self.pats.items[@intFromEnum(branch.pat)].data) {
-                .wildcard => return branch.body,
-                .int_lit => |value| if (value.toI128() == 0) return branch.body,
+                .wildcard => return .{ .call_args = call.args, .zero_branch_body = branch.body },
+                .int_lit => |value| if (value.toI128() == 0) {
+                    return .{ .call_args = call.args, .zero_branch_body = branch.body };
+                },
                 else => return null,
             }
         }
         return null;
     }
+
+    /// One match statically resolved by direct LIR lowering, recorded so the
+    /// debug Lambda Mono materializer replays the identical resolution and
+    /// the two derivations demand the same set of functions. Keyed by the
+    /// match's scrutinee expression, which belongs to exactly one match.
+    pub const FoldedMatch = struct {
+        scrutinee: ExprId,
+        body: ExprId,
+    };
 
     fn exprIsListMapCanReuseOp(self: *const Program, expr_id: ExprId) bool {
         return switch (self.exprs.items[@intFromEnum(expr_id)].data) {
@@ -375,19 +364,6 @@ pub const Program = struct {
             .block => |block| block.statements.len == 0 and self.exprIsListMapCanReuseOp(block.final_expr),
             else => false,
         };
-    }
-
-    fn unwrapNamedBacking(self: *const Program, ty: Type.TypeId) Type.TypeId {
-        var current = ty;
-        while (true) {
-            switch (self.types.get(current)) {
-                .named => |named| {
-                    const backing = named.backing orelse return current;
-                    current = backing.ty;
-                },
-                else => return current,
-            }
-        }
     }
 
     pub fn ifBranchSpan(self: *const Program, span_: Span(IfBranch)) []const IfBranch {

--- a/src/postcheck/monotype_lifted/ast.zig
+++ b/src/postcheck/monotype_lifted/ast.zig
@@ -303,6 +303,93 @@ pub const Program = struct {
         return self.branches.items[span_.start..][0..span_.len];
     }
 
+    /// When a match scrutinizes the Builtin `list_map_can_reuse` wrapper and
+    /// the in-place `List.map` branch is statically impossible — the
+    /// optimization is disabled, or the input and output element monotypes
+    /// differ — returns the body of the branch a constant-0 scrutinee
+    /// selects. Direct LIR lowering and the debug Lambda Mono materializer
+    /// both consult this, so they agree on which functions exist and the
+    /// in-place branch (with the wrapper specializations it references)
+    /// never reaches LIR in that case. Returns null when the match is not
+    /// that shape or the runtime uniqueness check must decide.
+    pub fn listMapCanReuseFoldedBranchBody(
+        self: *const Program,
+        // Taken explicitly because the Lambda Mono materializer moves the
+        // name store out of the lifted program before lowering.
+        name_store: *const names.NameStore,
+        scrutinee: ExprId,
+        branches_span: Span(Branch),
+        list_in_place_map: bool,
+    ) ?ExprId {
+        const call = switch (self.exprs.items[@intFromEnum(scrutinee)].data) {
+            .call_proc => |call| call,
+            else => return null,
+        };
+        const callee = switch (call.callee) {
+            .lifted => |fn_id| fn_id,
+            .template => return null,
+        };
+        const callee_body = switch (self.fns.items[@intFromEnum(callee)].body) {
+            .roc => |body| body,
+            .hosted => return null,
+        };
+        if (!self.exprIsListMapCanReuseOp(callee_body)) return null;
+
+        fold: {
+            if (!list_in_place_map) break :fold;
+            const args = self.exprSpan(call.args);
+            if (args.len != 2) return null;
+            const in_elem = switch (self.types.get(self.unwrapNamedBacking(self.exprs.items[@intFromEnum(args[0])].ty))) {
+                .list => |elem| elem,
+                else => return null,
+            };
+            const out_elem = switch (self.types.get(self.unwrapNamedBacking(self.exprs.items[@intFromEnum(args[1])].ty))) {
+                .func => |func| func.ret,
+                else => return null,
+            };
+            const in_digest = self.types.typeDigest(name_store, in_elem);
+            const out_digest = self.types.typeDigest(name_store, out_elem);
+            // Identical element monotypes share one layout, so reuse is the
+            // runtime uniqueness check's call; keep both branches.
+            if (std.mem.eql(u8, &in_digest.bytes, &out_digest.bytes)) return null;
+            break :fold;
+        }
+
+        // The scrutinee is a constant 0: select the branch it reaches. Only
+        // guard-free integer-literal and wildcard patterns participate; any
+        // other shape keeps the full match.
+        for (self.branchSpan(branches_span)) |branch| {
+            if (branch.guard != null) return null;
+            switch (self.pats.items[@intFromEnum(branch.pat)].data) {
+                .wildcard => return branch.body,
+                .int_lit => |value| if (value.toI128() == 0) return branch.body,
+                else => return null,
+            }
+        }
+        return null;
+    }
+
+    fn exprIsListMapCanReuseOp(self: *const Program, expr_id: ExprId) bool {
+        return switch (self.exprs.items[@intFromEnum(expr_id)].data) {
+            .low_level => |ll| ll.op == .list_map_can_reuse,
+            .block => |block| block.statements.len == 0 and self.exprIsListMapCanReuseOp(block.final_expr),
+            else => false,
+        };
+    }
+
+    fn unwrapNamedBacking(self: *const Program, ty: Type.TypeId) Type.TypeId {
+        var current = ty;
+        while (true) {
+            switch (self.types.get(current)) {
+                .named => |named| {
+                    const backing = named.backing orelse return current;
+                    current = backing.ty;
+                },
+                else => return current,
+            }
+        }
+    }
+
     pub fn ifBranchSpan(self: *const Program, span_: Span(IfBranch)) []const IfBranch {
         return self.if_branches.items[span_.start..][0..span_.len];
     }

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -107,6 +107,11 @@ pub const Output = struct {
 /// Options used by solved-to-LIR lowering.
 pub const Options = struct {
     inline_plan: SolvedInline.Plan = .{},
+    /// Allow `List.map` to reuse a unique input list's allocation for its
+    /// output when the input and output element layouts are interchangeable.
+    /// When disabled, `list_map_can_reuse` lowers to a constant 0 and the
+    /// in-place branch of `List.map` is dropped before it reaches LIR.
+    list_in_place_map: bool = false,
 };
 
 /// Lower Lambda Solved directly into LIR.
@@ -243,6 +248,7 @@ const Lowerer = struct {
     fn_spec_map: std.HashMap(FnSpec, Type.FnId, FnSpecContext, std.hash_map.default_max_load_percentage),
     fn_written: std.ArrayList(bool),
     inline_plan: SolvedInline.Plan,
+    list_in_place_map: bool,
     source_symbols: std.AutoHashMap(Common.Symbol, Lifted.FnId),
     capture_types: CaptureTypeMap,
     captures: std.AutoHashMap(Lifted.LocalId, CaptureBinding),
@@ -291,6 +297,7 @@ const Lowerer = struct {
             .fn_spec_map = std.HashMap(FnSpec, Type.FnId, FnSpecContext, std.hash_map.default_max_load_percentage).initContext(allocator, .{}),
             .fn_written = .empty,
             .inline_plan = options.inline_plan,
+            .list_in_place_map = options.list_in_place_map,
             .source_symbols = std.AutoHashMap(Common.Symbol, Lifted.FnId).init(allocator),
             .capture_types = CaptureTypeMap.initContext(allocator, .{}),
             .captures = std.AutoHashMap(Lifted.LocalId, CaptureBinding).init(allocator),
@@ -1246,7 +1253,7 @@ const Lowerer = struct {
         var clone_owned = true;
         errdefer if (clone_owned) solved_clone.deinit();
 
-        var materialized = try LambdaMonoLower.run(self.allocator, solved_clone);
+        var materialized = try LambdaMonoLower.run(self.allocator, solved_clone, self.list_in_place_map);
         clone_owned = false;
         defer materialized.deinit();
 
@@ -2101,6 +2108,19 @@ const Lowerer = struct {
             .box_box,
             .box_unbox,
             => return try self.lowerBoxBoundaryLowLevelInto(target, op, args, next),
+            .list_map_can_reuse => if (!try self.listMapLayoutsInterchangeable(args)) {
+                // Reuse is statically impossible (or disabled), so the
+                // runtime uniqueness check never needs to run. The op's
+                // arguments are pure local reads, so dropping them is safe.
+                return try self.result.store.addCFStmt(.{ .assign_literal = .{
+                    .target = target,
+                    .value = .{ .i64_literal = .{
+                        .value = 0,
+                        .layout_idx = self.result.store.getLocal(target).layout_idx,
+                    } },
+                    .next = next,
+                } });
+            },
             else => {},
         }
         if (lowLevelNeedsIntegerZeroDenominatorCheck(op)) {
@@ -2118,6 +2138,52 @@ const Lowerer = struct {
         } });
         current = try self.prependExprs(lowered, current);
         return current;
+    }
+
+    /// Compile-time half of the `list_map_can_reuse` decision. Returns true
+    /// when the input and output element layouts of a `List.map` call are
+    /// interchangeable in one allocation, meaning the same element stride,
+    /// the same allocation alignment class, and the same refcounted-elements
+    /// header shape — in that case the runtime uniqueness check decides.
+    /// Returns false when reuse is statically impossible or disabled, in
+    /// which case the op lowers to a constant 0.
+    fn listMapLayoutsInterchangeable(self: *Lowerer, args: []const Lifted.ExprId) Common.LowerError!bool {
+        if (args.len != 2) Common.invariant("list_map_can_reuse reached LIR lowering with the wrong arity");
+        if (!self.list_in_place_map) return false;
+
+        const list_layout_idx = try self.layoutOfType(try self.lowerExprTy(args[0]));
+        const list_layout = self.result.layouts.getLayout(list_layout_idx);
+        // A list of zero-sized elements has no allocation to reuse.
+        if (list_layout.tag != .list) return false;
+        const in_abi = self.result.layouts.builtinListAbi(list_layout_idx);
+        if (in_abi.elem_size == 0) return false;
+
+        const transform_ty = self.solved.expr_tys.items[@intFromEnum(args[1])];
+        const transform_root = self.solved.types.root(transform_ty);
+        const out_ret = switch (self.solved.types.get(transform_root)) {
+            .func => |func| func.ret,
+            else => Common.invariant("list_map_can_reuse transform argument is not a function"),
+        };
+        const out_elem_idx = self.result.layouts.runtimeRepresentationLayoutIdx(
+            try self.layoutOfType(try self.lowerType(out_ret)),
+        );
+        const out_elem = self.result.layouts.getLayout(out_elem_idx);
+
+        if (self.result.layouts.layoutSize(out_elem) != in_abi.elem_size) return false;
+
+        // The allocation's hidden header and the alignment passed to the
+        // allocator both derive from max(ptr_width, element alignment) and
+        // from whether elements are refcounted (which reserves an extra
+        // element-count slot for seamless slices). Both must agree or a
+        // later free would reconstruct the wrong allocation pointer.
+        const target_usize = self.result.layouts.targetUsize();
+        const ptr_width = target_usize.size();
+        const out_alignment: u32 = @intCast(out_elem.alignment(target_usize).toByteUnits());
+        if (@max(ptr_width, in_abi.elem_alignment) != @max(ptr_width, out_alignment)) return false;
+
+        if (in_abi.contains_refcounted != self.result.layouts.layoutContainsRefcounted(out_elem)) return false;
+
+        return true;
     }
 
     fn lowLevelNeedsIntegerZeroDenominatorCheck(op: LIR.LowLevel) bool {
@@ -2276,6 +2342,7 @@ const Lowerer = struct {
         branches_span: Lifted.Span(Lifted.Branch),
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
+        if (try self.foldListMapCanReuseMatch(target, scrutinee, branches_span, next)) |folded| return folded;
         const scrutinee_local = try self.addTemp(try self.lowerExprTy(scrutinee));
         const branches = self.solved.lifted.branchSpan(branches_span);
         const done = self.freshJoinPointId();
@@ -2287,6 +2354,27 @@ const Lowerer = struct {
             .body = next,
             .remainder = remainder,
         } });
+    }
+
+    /// When the in-place `List.map` branch is statically impossible, lower
+    /// only the branch a constant-0 `list_map_can_reuse` selects, so the
+    /// in-place machinery never reaches LIR. The decision lives on the lifted
+    /// program because the debug Lambda Mono materializer applies the same
+    /// fold and the two must agree on which functions exist.
+    fn foldListMapCanReuseMatch(
+        self: *Lowerer,
+        target: LIR.LocalId,
+        scrutinee: Lifted.ExprId,
+        branches_span: Lifted.Span(Lifted.Branch),
+        next: LIR.CFStmtId,
+    ) Common.LowerError!?LIR.CFStmtId {
+        const body = self.solved.lifted.listMapCanReuseFoldedBranchBody(
+            &self.solved.lifted.names,
+            scrutinee,
+            branches_span,
+            self.list_in_place_map,
+        ) orelse return null;
+        return try self.lowerExprInto(target, body, next);
     }
 
     fn lowerIfInto(self: *Lowerer, target: LIR.LocalId, branches_span: Lifted.Span(Lifted.IfBranch), final_else: Lifted.ExprId, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -249,6 +249,9 @@ const Lowerer = struct {
     fn_written: std.ArrayList(bool),
     inline_plan: SolvedInline.Plan,
     list_in_place_map: bool,
+    /// Match sites statically resolved by `foldListMapCanReuseMatch`,
+    /// recorded (Debug only) so the Lambda Mono verifier replays them.
+    folded_map_matches: std.ArrayList(Lifted.Program.FoldedMatch),
     source_symbols: std.AutoHashMap(Common.Symbol, Lifted.FnId),
     capture_types: CaptureTypeMap,
     captures: std.AutoHashMap(Lifted.LocalId, CaptureBinding),
@@ -298,6 +301,7 @@ const Lowerer = struct {
             .fn_written = .empty,
             .inline_plan = options.inline_plan,
             .list_in_place_map = options.list_in_place_map,
+            .folded_map_matches = .empty,
             .source_symbols = std.AutoHashMap(Common.Symbol, Lifted.FnId).init(allocator),
             .capture_types = CaptureTypeMap.initContext(allocator, .{}),
             .captures = std.AutoHashMap(Lifted.LocalId, CaptureBinding).init(allocator),
@@ -313,6 +317,7 @@ const Lowerer = struct {
     }
 
     fn deinit(self: *Lowerer) void {
+        self.folded_map_matches.deinit(self.allocator);
         self.loop_stack.deinit(self.allocator);
         self.allocator.free(self.local_map);
         self.const_plan_map.deinit();
@@ -338,6 +343,7 @@ const Lowerer = struct {
             .lir_result = self.result,
             .runtime_schemas = self.runtime_schemas,
         };
+        self.folded_map_matches.deinit(self.allocator);
         self.loop_stack.deinit(self.allocator);
         self.allocator.free(self.local_map);
         self.const_plan_map.deinit();
@@ -358,6 +364,7 @@ const Lowerer = struct {
         self.runtime_schemas = RuntimeSchemaStore.init(self.allocator);
         self.local_map = &.{};
         self.loop_stack = .empty;
+        self.folded_map_matches = .empty;
         return output;
     }
 
@@ -1253,7 +1260,7 @@ const Lowerer = struct {
         var clone_owned = true;
         errdefer if (clone_owned) solved_clone.deinit();
 
-        var materialized = try LambdaMonoLower.run(self.allocator, solved_clone, self.list_in_place_map);
+        var materialized = try LambdaMonoLower.run(self.allocator, solved_clone, self.folded_map_matches.items);
         clone_owned = false;
         defer materialized.deinit();
 
@@ -2175,7 +2182,7 @@ const Lowerer = struct {
         // allocator both derive from max(ptr_width, element alignment) and
         // from whether elements are refcounted (which reserves an extra
         // element-count slot for seamless slices). Both must agree or a
-        // later free would reconstruct the wrong allocation pointer.
+        // later free would compute the wrong allocation pointer.
         const target_usize = self.result.layouts.targetUsize();
         const ptr_width = target_usize.size();
         const out_alignment: u32 = @intCast(out_elem.alignment(target_usize).toByteUnits());
@@ -2356,11 +2363,14 @@ const Lowerer = struct {
         } });
     }
 
-    /// When the in-place `List.map` branch is statically impossible, lower
-    /// only the branch a constant-0 `list_map_can_reuse` selects, so the
-    /// in-place machinery never reaches LIR. The decision lives on the lifted
-    /// program because the debug Lambda Mono materializer applies the same
-    /// fold and the two must agree on which functions exist.
+    /// When the in-place `List.map` branch is statically impossible — the
+    /// optimization is disabled or the element layouts are not
+    /// interchangeable — lower only the branch a constant-0
+    /// `list_map_can_reuse` selects, so the in-place machinery never reaches
+    /// LIR. Each fold is recorded as explicit data; the debug Lambda Mono
+    /// materializer replays the recorded resolutions instead of recomputing
+    /// them (it runs before layout selection and has no layout store), so
+    /// the two derivations demand the same set of functions.
     fn foldListMapCanReuseMatch(
         self: *Lowerer,
         target: LIR.LocalId,
@@ -2368,13 +2378,19 @@ const Lowerer = struct {
         branches_span: Lifted.Span(Lifted.Branch),
         next: LIR.CFStmtId,
     ) Common.LowerError!?LIR.CFStmtId {
-        const body = self.solved.lifted.listMapCanReuseFoldedBranchBody(
-            &self.solved.lifted.names,
-            scrutinee,
-            branches_span,
-            self.list_in_place_map,
-        ) orelse return null;
-        return try self.lowerExprInto(target, body, next);
+        const match = self.solved.lifted.listMapCanReuseMatch(scrutinee, branches_span) orelse return null;
+        const args = self.solved.lifted.exprSpan(match.call_args);
+        if (self.list_in_place_map and try self.listMapLayoutsInterchangeable(args)) {
+            // Reuse is possible; the runtime uniqueness check decides.
+            return null;
+        }
+        if (builtin.mode == .Debug) {
+            try self.folded_map_matches.append(self.allocator, .{
+                .scrutinee = scrutinee,
+                .body = match.zero_branch_body,
+            });
+        }
+        return try self.lowerExprInto(target, match.zero_branch_body, next);
     }
 
     fn lowerIfInto(self: *Lowerer, target: LIR.LocalId, branches_span: Lifted.Span(Lifted.IfBranch), final_else: Lifted.ExprId, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {


### PR DESCRIPTION
When `List.map`'s input list uniquely owns its allocation, is not a seamless slice, and the input and output element layouts are interchangeable in one allocation (same stride, same allocation alignment class, same refcounted-elements header shape), map now overwrites the input buffer element by element instead of allocating an output list. This applies to same-type maps and to different element types that share a layout (e.g. tuples mapped to same-shaped records), and is enabled for `--opt=size` and `--opt=speed`; dev, interpreter, and compile-time evaluation are unaffected.

`List.map`'s body matches on a new `list_map_can_reuse` primitive whose runtime meaning is the uniqueness/slice check; lowering pins it to a constant 0 whenever the layouts are not interchangeable, so the runtime check can never pass for a pair whose reuse would corrupt the allocation header (the header in front of a list's data and the alignment handed to the allocator both derive from the element layout). Inside the in-place loop, `list_map_extract_unsafe` moves element ownership out of the buffer and `list_map_write_unsafe` moves the transform's result into the vacated slot; neither performs RC work, so ARC places the old element's release per the transform's solved convention and the borrow certifier checks the loop like ordinary code.

The in-place branch is dropped before it reaches LIR whenever reuse is statically impossible or the optimization is off, so ineligible specializations carry no dead code and dev builds lower exactly the previous copy loop. The fold decision is made once, with layouts, in direct lowering; each statically resolved match site is recorded as explicit data and the debug Lambda Mono materializer replays the record, since it runs before layout selection and cannot recompute the decision. A wrong record can only misplace dead code, never a runtime check, and a fold regression surfaces as a Debug stride assertion in the backends.