### PR TITLE
Evaluate custom from_numeral conversions at compile time and fix literal patterns on custom number types

### DIFF
--- a/design.md
+++ b/design.md
@@ -868,6 +868,27 @@ The method registry is an exact table keyed by `(MethodOwner, MethodNameId)`.
 It is not an owner-discovery mechanism. Post-check code may use it only after a
 concrete monomorphic dispatcher type has already determined the owner.
 
+### Compile-Time Numeral Conversions
+
+A numeric literal whose target type is a non-builtin nominal type converts
+through that type's `from_numeral` method. Every such conversion with a
+concrete target type is a compile-time root (`numeral_conversion`), no matter
+where the literal sits in the AST: checking finalization evaluates the raw
+dispatch call, stores its `Try` result through `ConstStore`, unwraps `Ok` into
+the literal's stored constant, and reports `Err(InvalidNumeral(msg))` as a
+checking problem carrying the implementation's message. Runtime lowering
+restores the stored constant instead of emitting a call. Conversions whose
+target type is still polymorphic (literals inside generalized functions) keep
+the dispatch call per monomorphic specialization.
+
+Literal patterns participate through the same machinery. A literal pattern on
+a non-builtin number type carries a synthesized checked conversion expression;
+match lowering binds the matched value and tests it against the converted
+constant, dispatching to the type's `is_eq` method when it has one and using
+structural equality otherwise — exactly mirroring `==`. Checking attaches an
+`is_eq` constraint to the pattern's type so this lowering is total. Literal
+patterns on builtin number types keep their direct literal-pattern encoding.
+
 ## Shared Post-Check Model
 
 Every post-check IR has a typed IR store:

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -6126,6 +6126,23 @@ fn canonicalizeSingleQuote(
         .bytes = @bitCast(@as(u128, @intCast(codepoint))),
         .kind = .u128,
     };
+
+    // Base-256 digits of the codepoint, so the literal carries the numeral
+    // facts a custom from_numeral target reads.
+    var digit_buf: [4]u8 = undefined;
+    var digit_len: usize = 0;
+    var remaining: u32 = codepoint;
+    while (true) {
+        digit_buf[digit_len] = @intCast(remaining & 0xff);
+        digit_len += 1;
+        remaining >>= 8;
+        if (remaining == 0) break;
+    }
+    var digits: [4]u8 = undefined;
+    for (0..digit_len) |i| {
+        digits[i] = digit_buf[digit_len - 1 - i];
+    }
+
     if (comptime Idx == Expr.Idx) {
         const expr_idx = try self.env.addExpr(CIR.Expr{
             .e_num = .{
@@ -6133,12 +6150,14 @@ fn canonicalizeSingleQuote(
                 .kind = .int_unbound,
             },
         }, region);
+        try self.env.recordNumeralLiteral(ModuleEnv.nodeIdxFrom(expr_idx), digits[0..digit_len], &.{}, 0, false, false, false);
         return expr_idx;
     } else if (comptime Idx == Pattern.Idx) {
         const pat_idx = try self.env.addPattern(Pattern{ .num_literal = .{
             .value = value_content,
             .kind = .int_unbound,
         } }, region);
+        try self.env.recordNumeralLiteral(ModuleEnv.nodeIdxFrom(pat_idx), digits[0..digit_len], &.{}, 0, false, false, false);
         return pat_idx;
     } else {
         @compileError("Unsupported Idx type");
@@ -6189,6 +6208,25 @@ fn recordNumeralLiteralForExpr(
 ) std.mem.Allocator.Error!void {
     try self.env.recordNumeralLiteral(
         ModuleEnv.nodeIdxFrom(expr_idx),
+        self.parse_ir.store.numericDigitsBefore(literal),
+        self.parse_ir.store.numericDigitsAfter(literal),
+        literal.after_decimal_digit_count,
+        literal.isNegative(),
+        literal.kind == .frac,
+        literal.flags.had_decimal_point,
+    );
+}
+
+/// Record the exact base-256 digits of a parsed numeric literal against the
+/// CIR pattern node we just emitted, so literal patterns can dispatch through
+/// `from_numeral` when matched against a non-builtin number type.
+fn recordNumeralLiteralForPattern(
+    self: *Self,
+    pattern_idx: Pattern.Idx,
+    literal: NumericLiteral.Stored,
+) std.mem.Allocator.Error!void {
+    try self.env.recordNumeralLiteral(
+        ModuleEnv.nodeIdxFrom(pattern_idx),
         self.parse_ir.store.numericDigitsBefore(literal),
         self.parse_ir.store.numericDigitsAfter(literal),
         literal.after_decimal_digit_count,
@@ -14338,10 +14376,14 @@ pub fn canonicalizePattern(
                     const region = self.parse_ir.tokenizedRegionToRegion(e.region);
                     const literal = self.parse_ir.store.getNumericLiteral(e.literal);
                     last_pattern = switch (literal.compact) {
-                        .int => |value| try self.env.addPattern(Pattern{ .num_literal = .{
-                            .value = cirIntValue(value),
-                            .kind = .num_unbound,
-                        } }, region),
+                        .int => |value| blk: {
+                            const pat_idx = try self.env.addPattern(Pattern{ .num_literal = .{
+                                .value = cirIntValue(value),
+                                .kind = .num_unbound,
+                            } }, region);
+                            try self.recordNumeralLiteralForPattern(pat_idx, literal);
+                            break :blk pat_idx;
+                        },
                         else => try self.env.pushMalformed(Pattern.Idx, Diagnostic{ .invalid_num_literal = .{ .region = region } }),
                     };
                 },
@@ -14349,14 +14391,22 @@ pub fn canonicalizePattern(
                     const region = self.parse_ir.tokenizedRegionToRegion(e.region);
                     const literal = self.parse_ir.store.getNumericLiteral(e.literal);
                     last_pattern = switch (literal.compact) {
-                        .small_dec => |value| try self.env.addPattern(Pattern{ .small_dec_literal = .{
-                            .value = cirSmallDec(value),
-                            .has_suffix = false,
-                        } }, region),
-                        .dec => |value| try self.env.addPattern(Pattern{ .dec_literal = .{
-                            .value = builtins.dec.RocDec{ .num = value },
-                            .has_suffix = false,
-                        } }, region),
+                        .small_dec => |value| blk: {
+                            const pat_idx = try self.env.addPattern(Pattern{ .small_dec_literal = .{
+                                .value = cirSmallDec(value),
+                                .has_suffix = false,
+                            } }, region);
+                            try self.recordNumeralLiteralForPattern(pat_idx, literal);
+                            break :blk pat_idx;
+                        },
+                        .dec => |value| blk: {
+                            const pat_idx = try self.env.addPattern(Pattern{ .dec_literal = .{
+                                .value = builtins.dec.RocDec{ .num = value },
+                                .has_suffix = false,
+                            } }, region);
+                            try self.recordNumeralLiteralForPattern(pat_idx, literal);
+                            break :blk pat_idx;
+                        },
                         else => try self.env.pushMalformed(Pattern.Idx, Diagnostic{ .invalid_num_literal = .{ .region = region } }),
                     };
                 },

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -4826,8 +4826,9 @@ fn checkPatternHelp(
                     };
 
                     // Create flex var with from_numeral constraint
-                    const flex_var = try self.mkFlexWithFromNumeralConstraint(null, num_literal_info, env);
+                    const flex_var = try self.mkFlexWithFromNumeralConstraint(ModuleEnv.nodeIdxFrom(pattern_idx), num_literal_info, env);
                     _ = try self.unify(pattern_var, flex_var, env);
+                    try self.mkPatternLiteralEqConstraint(pattern_var, env, pattern_region);
                 },
                 // Phase 5: For explicitly typed literals, use nominal types from Builtin
                 .u8 => try self.unifyWith(pattern_var, try self.mkNumberTypeContent(.u8, env), env),
@@ -4866,8 +4867,9 @@ fn checkPatternHelp(
                     pattern_region,
                 );
 
-                const flex_var = try self.mkFlexWithFromNumeralConstraint(null, num_literal_info, env);
+                const flex_var = try self.mkFlexWithFromNumeralConstraint(ModuleEnv.nodeIdxFrom(pattern_idx), num_literal_info, env);
                 _ = try self.unify(pattern_var, flex_var, env);
+                try self.mkPatternLiteralEqConstraint(pattern_var, env, pattern_region);
             }
         },
         .small_dec_literal => |dec| {
@@ -4884,8 +4886,9 @@ fn checkPatternHelp(
                     pattern_region,
                 );
 
-                const flex_var = try self.mkFlexWithFromNumeralConstraint(null, num_literal_info, env);
+                const flex_var = try self.mkFlexWithFromNumeralConstraint(ModuleEnv.nodeIdxFrom(pattern_idx), num_literal_info, env);
                 _ = try self.unify(pattern_var, flex_var, env);
+                try self.mkPatternLiteralEqConstraint(pattern_var, env, pattern_region);
             }
         },
         .runtime_error => {
@@ -8431,6 +8434,18 @@ fn getNominalOriginEnv(self: *Self, nominal_type: types_mod.NominalType) *const 
 
 /// Create a static dispatch fn like: `lhs, rhs -> ret` and assert the
 /// constraint to the lhs (receiver) var.
+/// Constrain a literal pattern's type to support equality, since matching the
+/// pattern compares the scrutinee against the literal's converted value.
+fn mkPatternLiteralEqConstraint(
+    self: *Self,
+    pattern_var: Var,
+    env: *Env,
+    region: Region,
+) Allocator.Error!void {
+    const ret_var = try self.freshBool(env, region);
+    try self.mkBinopConstraint(pattern_var, pattern_var, ret_var, self.cir.idents.is_eq, false, env, region, null);
+}
+
 fn mkBinopConstraint(
     self: *Self,
     lhs_var: Var,

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -3939,7 +3939,9 @@ fn appendStaticDispatchTypeRoots(
     }
 
     for (module.moduleEnvConst().numeral_dispatch_plans.items.items) |plan| {
-        if (!source_nodes.hasExpr(@enumFromInt(plan.node_idx))) continue;
+        const is_expr = source_nodes.hasExpr(@enumFromInt(plan.node_idx));
+        const is_pattern = source_nodes.hasPattern(@enumFromInt(plan.node_idx));
+        if (!is_expr and !is_pattern) continue;
         _ = try appendCheckedTypeRoot(allocator, module, names, imports, roots, payloads, active, @enumFromInt(plan.target_var));
         _ = try appendCheckedTypeRoot(allocator, module, names, imports, roots, payloads, active, @enumFromInt(plan.fn_var));
     }

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -698,7 +698,7 @@ pub const RootRequestTable = struct {
             try appendRoot(&requests, allocator, .{
                 .module_idx = root.module_idx,
                 .kind = switch (root.kind) {
-                    .constant => .compile_time_constant,
+                    .constant, .numeral_conversion => .compile_time_constant,
                     .callable_binding => .compile_time_callable,
                     .expect => .test_expect,
                 },
@@ -706,7 +706,7 @@ pub const RootRequestTable = struct {
                 .checked_type = entryWrapperForRoot(entry_wrappers, root.id).checked_fn_root,
                 .abi = switch (root.kind) {
                     .expect => .test_expect,
-                    .constant, .callable_binding => .compile_time,
+                    .constant, .callable_binding, .numeral_conversion => .compile_time,
                 },
                 .exposure = .private,
                 .procedure_template = templateForEntryWrapperRoot(entry_wrappers, root.id),
@@ -894,6 +894,7 @@ fn compileTimeRootKindMatchesRequest(
         .constant => request_kind == .compile_time_constant,
         .callable_binding => request_kind == .compile_time_callable,
         .expect => request_kind == .test_expect,
+        .numeral_conversion => request_kind == .compile_time_constant,
     };
 }
 
@@ -950,6 +951,7 @@ fn compileTimeRootDependsOnUnboundPlatformRequirement(
     return switch (root.kind) {
         .constant,
         .callable_binding,
+        .numeral_conversion,
         => exprDependsOnUnboundPlatformRequirement(
             checked_bodies,
             resolved_value_refs,
@@ -9281,7 +9283,7 @@ pub const CheckedProcedureTemplateTable = struct {
                 .nested_proc_sites = .{},
                 .target = switch (root.kind) {
                     .expect => .entry,
-                    .constant, .callable_binding => .comptime_only,
+                    .constant, .callable_binding, .numeral_conversion => .comptime_only,
                 },
             });
         }
@@ -12481,6 +12483,11 @@ pub const CompileTimeRootKind = enum {
     constant,
     callable_binding,
     expect,
+    /// A `from_numeral` conversion of a numeric literal whose target is a
+    /// non-builtin nominal type. The root body evaluates the dispatch call's
+    /// `Try` result; finalization unwraps `Ok` into the stored constant and
+    /// reports `Err(InvalidNumeral(..))` as a checking problem.
+    numeral_conversion,
 };
 
 /// Public `CompileTimeRootPayload` declaration.
@@ -12550,6 +12557,29 @@ pub const CompileTimeRootTable = struct {
             });
         }
 
+        for (module_env.numeral_dispatch_plans.items.items) |numeral_plan| {
+            const expr_idx: CIR.Expr.Idx = @enumFromInt(numeral_plan.node_idx);
+            const checked_expr = checked_bodies.exprIdForSource(expr_idx) orelse continue;
+            switch (checked_bodies.exprs[@intFromEnum(checked_expr)].data) {
+                .num_from_numeral, .typed_num_from_numeral => {},
+                else => continue,
+            }
+            const fn_ty = try checkedTypeIdForVar(allocator, module, checked_types, @enumFromInt(numeral_plan.fn_var));
+            const try_ty = switch (checked_types.store.payloads.items[@intFromEnum(fn_ty)]) {
+                .function => |function| function.ret,
+                else => checkedArtifactInvariant("from_numeral dispatch plan type was not a function", .{}),
+            };
+            try appendCompileTimeRoot(&roots, allocator, .{
+                .module_idx = module.moduleIndex(),
+                .kind = .numeral_conversion,
+                .source = .{ .expr = expr_idx },
+                .pattern = null,
+                .expr = checked_expr,
+                .checked_type = try_ty,
+                .payload = .pending,
+            });
+        }
+
         return .{ .roots = try roots.toOwnedSlice(allocator) };
     }
 
@@ -12563,6 +12593,13 @@ pub const CompileTimeRootTable = struct {
     pub fn lookupIdBySource(self: *const CompileTimeRootTable, source: RootSource) ?ComptimeRootId {
         for (self.roots) |entry| {
             if (rootSourceMatches(entry.source, source)) return entry.id;
+        }
+        return null;
+    }
+
+    pub fn lookupNumeralRootByExpr(self: *const CompileTimeRootTable, expr: CheckedExprId) ?CompileTimeRoot {
+        for (self.roots) |entry| {
+            if (entry.kind == .numeral_conversion and entry.expr == expr) return entry;
         }
         return null;
     }
@@ -12630,6 +12667,10 @@ fn verifyCompileTimeRootPayloadMatchesKind(kind: CompileTimeRootKind, payload: C
         },
         .expect => switch (payload) {
             .expect => true,
+            else => false,
+        },
+        .numeral_conversion => switch (payload) {
+            .const_node => true,
             else => false,
         },
     };
@@ -15268,7 +15309,7 @@ pub const CheckedModuleArtifact = struct {
             std.debug.assert(@intFromEnum(root.expr) < self.checked_bodies.exprs.len);
             if (root.pattern) |pattern| std.debug.assert(@intFromEnum(pattern) < self.checked_bodies.patterns.len);
             switch (root.kind) {
-                .constant, .callable_binding => switch (root.payload) {
+                .constant, .callable_binding, .numeral_conversion => switch (root.payload) {
                     .pending => {},
                     else => verifyCompileTimeRootPayloadMatchesKind(root.kind, root.payload),
                 },

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -5869,12 +5869,12 @@ pub const CheckedBodyStore = struct {
             const raw_node = @intFromEnum(entry.key_ptr.*);
             const checked_expr = self.source_node_map.exprAtRawNode(raw_node) orelse
                 self.numeralConversionExprAtRawNode(raw_node) orelse
-            {
-                checkedArtifactInvariant(
-                    "from_numeral plan {d} points at source node {d} with no checked expression",
-                    .{ @intFromEnum(entry.value_ptr.*), raw_node },
-                );
-            };
+                {
+                    checkedArtifactInvariant(
+                        "from_numeral plan {d} points at source node {d} with no checked expression",
+                        .{ @intFromEnum(entry.value_ptr.*), raw_node },
+                    );
+                };
             const data = &self.exprs[@intFromEnum(checked_expr)].data;
             switch (data.*) {
                 .num_from_numeral => data.* = .{ .num_from_numeral = entry.value_ptr.* },

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -4854,14 +4854,19 @@ pub const CheckedPatternData = union(enum) {
     num_literal: struct {
         value: CIR.IntValue,
         kind: CIR.NumKind,
+        /// Synthesized `.num_from_numeral` checked expression for matching this
+        /// literal against a non-builtin number type; null on the builtin fast path.
+        conversion: ?CheckedExprId = null,
     },
     small_dec_literal: struct {
         value: CIR.SmallDecValue,
         has_suffix: bool,
+        conversion: ?CheckedExprId = null,
     },
     dec_literal: struct {
         value: builtins.dec.RocDec,
         has_suffix: bool,
+        conversion: ?CheckedExprId = null,
     },
     frac_f32_literal: f32,
     frac_f64_literal: f64,
@@ -5532,6 +5537,15 @@ pub const CheckedBodyStore = struct {
     pattern_binders: []CheckedPatternBinder = &.{},
     pattern_binder_by_pattern: []?PatternBinderId = &.{},
     source_node_map: CheckedSourceNodeMap = .{},
+    /// Synthesized `from_numeral` conversion expressions for literal patterns,
+    /// keyed by the pattern's source node. Pattern nodes already occupy their
+    /// slot in `source_node_map`, so these live in a dedicated table.
+    numeral_conversion_exprs: []const NumeralConversionExpr = &.{},
+
+    pub const NumeralConversionExpr = struct {
+        raw_node: u32,
+        expr: CheckedExprId,
+    };
 
     pub fn fromModule(
         allocator: Allocator,
@@ -5609,10 +5623,6 @@ pub const CheckedBodyStore = struct {
             }
         }
 
-        const expr_diverges = try allocator.alloc(bool, exprs.items.len);
-        errdefer allocator.free(expr_diverges);
-        @memset(expr_diverges, false);
-
         const statement_diverges = try allocator.alloc(bool, statements.items.len);
         errdefer allocator.free(statement_diverges);
         @memset(statement_diverges, false);
@@ -5620,6 +5630,9 @@ pub const CheckedBodyStore = struct {
         const pattern_binder_by_pattern = try allocator.alloc(?PatternBinderId, patterns.items.len);
         errdefer allocator.free(pattern_binder_by_pattern);
         @memset(pattern_binder_by_pattern, null);
+
+        var numeral_conversion_exprs = std.ArrayList(NumeralConversionExpr).empty;
+        errdefer numeral_conversion_exprs.deinit(allocator);
 
         var copier = CheckedBodyPayloadCopier{
             .allocator = allocator,
@@ -5630,6 +5643,8 @@ pub const CheckedBodyStore = struct {
             .pattern_binders = &pattern_binders,
             .pattern_binder_by_pattern = pattern_binder_by_pattern,
             .checked_types = checked_types,
+            .exprs = &exprs,
+            .numeral_conversion_exprs = &numeral_conversion_exprs,
         };
 
         node_idx = 0;
@@ -5647,6 +5662,12 @@ pub const CheckedBodyStore = struct {
                 statements.items[@intFromEnum(id)].data = try copier.copyStatementData(@enumFromInt(node_idx));
             }
         }
+
+        // Allocated after the copy pass because copying literal patterns may
+        // append synthesized numeral-conversion expressions.
+        const expr_diverges = try allocator.alloc(bool, exprs.items.len);
+        errdefer allocator.free(expr_diverges);
+        @memset(expr_diverges, false);
 
         try publishCheckedBodyDivergence(allocator, exprs.items, statements.items, expr_diverges, statement_diverges);
 
@@ -5691,6 +5712,7 @@ pub const CheckedBodyStore = struct {
             .pattern_binders = pattern_binder_slice,
             .pattern_binder_by_pattern = pattern_binder_by_pattern,
             .source_node_map = source_node_map,
+            .numeral_conversion_exprs = try numeral_conversion_exprs.toOwnedSlice(allocator),
         };
     }
 
@@ -5738,6 +5760,13 @@ pub const CheckedBodyStore = struct {
 
     pub fn statementIdForSource(self: *const CheckedBodyStore, statement: CIR.Statement.Idx) ?CheckedStatementId {
         return self.source_node_map.statement(statement);
+    }
+
+    pub fn numeralConversionExprAtRawNode(self: *const CheckedBodyStore, raw_node: u32) ?CheckedExprId {
+        for (self.numeral_conversion_exprs) |entry| {
+            if (entry.raw_node == raw_node) return entry.expr;
+        }
+        return null;
     }
 
     pub fn patternBinderForCheckedPattern(self: *const CheckedBodyStore, pattern: CheckedPatternId) ?PatternBinderId {
@@ -5836,7 +5865,9 @@ pub const CheckedBodyStore = struct {
         var iter = plans.numeral_by_node.iterator();
         while (iter.next()) |entry| {
             const raw_node = @intFromEnum(entry.key_ptr.*);
-            const checked_expr = self.source_node_map.exprAtRawNode(raw_node) orelse {
+            const checked_expr = self.source_node_map.exprAtRawNode(raw_node) orelse
+                self.numeralConversionExprAtRawNode(raw_node) orelse
+            {
                 checkedArtifactInvariant(
                     "from_numeral plan {d} points at source node {d} with no checked expression",
                     .{ @intFromEnum(entry.value_ptr.*), raw_node },
@@ -5939,6 +5970,7 @@ pub const CheckedBodyStore = struct {
     }
 
     pub fn deinit(self: *CheckedBodyStore, allocator: Allocator) void {
+        allocator.free(self.numeral_conversion_exprs);
         self.source_node_map.deinit(allocator);
         allocator.free(self.pattern_binder_by_pattern);
         allocator.free(self.pattern_binders);
@@ -6379,11 +6411,13 @@ const CheckedBodyPayloadCopier = struct {
     allocator: Allocator,
     module: TypedCIR.Module,
     names: *canonical.CanonicalNameStore,
-    source_node_map: *const CheckedSourceNodeMap,
+    source_node_map: *CheckedSourceNodeMap,
     string_builder: *CheckedStringLiteralBuilder,
     pattern_binders: *std.ArrayList(CheckedPatternBinder),
     pattern_binder_by_pattern: []?PatternBinderId,
     checked_types: *const CheckedTypePublication,
+    exprs: *std.ArrayList(CheckedExpr),
+    numeral_conversion_exprs: *std.ArrayList(CheckedBodyStore.NumeralConversionExpr),
 
     fn copyExprData(self: *@This(), expr_idx: CIR.Expr.Idx) Allocator.Error!CheckedExprData {
         const expr = self.module.expr(expr_idx).data;
@@ -6679,6 +6713,36 @@ const CheckedBodyPayloadCopier = struct {
         return checkedBuiltinForLiteralTarget(self.checked_types.store.view(), checked_ty);
     }
 
+    fn checkedPatternTypeRoot(self: *@This(), pattern_idx: CIR.Pattern.Idx) CheckedTypeId {
+        return self.checked_types.rootForSourceVar(self.module, self.module.patternType(pattern_idx)) orelse {
+            checkedArtifactInvariant("checked numeric pattern type root was not published", .{});
+        };
+    }
+
+    /// Synthesize the `.num_from_numeral` checked expression a literal pattern
+    /// converts through when its type is a non-builtin number type. The
+    /// expression is registered at the pattern's source node so dispatch-plan
+    /// attachment and compile-time root creation find it the same way they
+    /// find literal expressions.
+    fn numeralConversionExprForPattern(self: *@This(), pattern_idx: CIR.Pattern.Idx) Allocator.Error!?CheckedExprId {
+        const node = ModuleEnv.nodeIdxFrom(pattern_idx);
+        if (self.module.moduleEnvConst().numeralDispatchPlanForNode(node) == null) return null;
+        const checked_ty = self.checkedPatternTypeRoot(pattern_idx);
+        if (checkedBuiltinForLiteralTarget(self.checked_types.store.view(), checked_ty) != null) return null;
+        const id: CheckedExprId = @enumFromInt(try checkedSourceNodeIdFromLen(self.exprs.items.len));
+        try self.exprs.append(self.allocator, .{
+            .id = id,
+            .ty = checked_ty,
+            .source_region = self.module.regionAt(node),
+            .data = .{ .num_from_numeral = null },
+        });
+        try self.numeral_conversion_exprs.append(self.allocator, .{
+            .raw_node = @intFromEnum(node),
+            .expr = id,
+        });
+        return id;
+    }
+
     fn floatLiteralForExpr(self: *@This(), comptime Float: type, expr_idx: CIR.Expr.Idx) Allocator.Error!Float {
         const literal = self.module.moduleEnvConst().numeralLiteralForNode(ModuleEnv.nodeIdxFrom(expr_idx)) orelse {
             checkedArtifactInvariant("checked typed float literal had no parser-owned numeral facts", .{});
@@ -6719,9 +6783,21 @@ const CheckedBodyPayloadCopier = struct {
                 } else null,
             } },
             .tuple => |tuple| .{ .tuple = try self.copyPatternSpan(tuple.patterns) },
-            .num_literal => |num| .{ .num_literal = .{ .value = num.value, .kind = num.kind } },
-            .small_dec_literal => |dec| .{ .small_dec_literal = .{ .value = dec.value, .has_suffix = dec.has_suffix } },
-            .dec_literal => |dec| .{ .dec_literal = .{ .value = dec.value, .has_suffix = dec.has_suffix } },
+            .num_literal => |num| .{ .num_literal = .{
+                .value = num.value,
+                .kind = num.kind,
+                .conversion = try self.numeralConversionExprForPattern(pattern_idx),
+            } },
+            .small_dec_literal => |dec| .{ .small_dec_literal = .{
+                .value = dec.value,
+                .has_suffix = dec.has_suffix,
+                .conversion = if (dec.has_suffix) null else try self.numeralConversionExprForPattern(pattern_idx),
+            } },
+            .dec_literal => |dec| .{ .dec_literal = .{
+                .value = dec.value,
+                .has_suffix = dec.has_suffix,
+                .conversion = if (dec.has_suffix) null else try self.numeralConversionExprForPattern(pattern_idx),
+            } },
             .frac_f32_literal => |frac| .{ .frac_f32_literal = frac.value },
             .frac_f64_literal => |frac| .{ .frac_f64_literal = frac.value },
             .str_literal => |str| .{ .str_literal = try self.string_builder.intern(str.literal) },
@@ -12559,7 +12635,9 @@ pub const CompileTimeRootTable = struct {
 
         for (module_env.numeral_dispatch_plans.items.items) |numeral_plan| {
             const expr_idx: CIR.Expr.Idx = @enumFromInt(numeral_plan.node_idx);
-            const checked_expr = checked_bodies.exprIdForSource(expr_idx) orelse continue;
+            const checked_expr = checked_bodies.exprIdForSource(expr_idx) orelse
+                checked_bodies.numeralConversionExprAtRawNode(numeral_plan.node_idx) orelse
+                continue;
             switch (checked_bodies.exprs[@intFromEnum(checked_expr)].data) {
                 .num_from_numeral, .typed_num_from_numeral => {},
                 else => continue,

--- a/src/check/problem.zig
+++ b/src/check/problem.zig
@@ -63,6 +63,7 @@ pub const EffectfulExpect = types.EffectfulExpect;
 
 // Comptime errors
 pub const ComptimeCrash = types.ComptimeCrash;
+pub const ComptimeInvalidNumeral = types.ComptimeInvalidNumeral;
 pub const ComptimeExpectFailed = types.ComptimeExpectFailed;
 pub const ComptimeEvalError = types.ComptimeEvalError;
 

--- a/src/check/problem/types.zig
+++ b/src/check/problem/types.zig
@@ -47,6 +47,7 @@ pub const Problem = union(enum) {
     platform_def_not_found: PlatformDefNotFound,
     platform_alias_not_found: PlatformAliasNotFound,
     comptime_crash: ComptimeCrash,
+    comptime_invalid_numeral: ComptimeInvalidNumeral,
     comptime_expect_failed: ComptimeExpectFailed,
     comptime_eval_error: ComptimeEvalError,
     invalid_numeric_literal: InvalidNumericLiteral,
@@ -96,6 +97,13 @@ pub const EffectfulExpect = struct {
 
 /// A crash that occurred during compile-time evaluation
 pub const ComptimeCrash = struct {
+    message: ExtraStringIdx,
+    region: base.Region,
+};
+
+/// A numeric literal that a custom `from_numeral` implementation rejected
+/// during compile-time evaluation
+pub const ComptimeInvalidNumeral = struct {
     message: ExtraStringIdx,
     region: base.Region,
 };

--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -72,6 +72,7 @@ const EffectfulExpect = problem_mod.EffectfulExpect;
 
 // Comptime errors
 const ComptimeCrash = problem_mod.ComptimeCrash;
+const ComptimeInvalidNumeral = problem_mod.ComptimeInvalidNumeral;
 const ComptimeExpectFailed = problem_mod.ComptimeExpectFailed;
 const ComptimeEvalError = problem_mod.ComptimeEvalError;
 
@@ -813,6 +814,7 @@ pub const ReportBuilder = struct {
                 return self.buildPlatformDefNotFound(data);
             },
             .comptime_crash => |data| return self.buildComptimeCrashReport(data),
+            .comptime_invalid_numeral => |data| return self.buildComptimeInvalidNumeralReport(data),
             .comptime_expect_failed => |data| return self.buildComptimeExpectFailedReport(data),
             .comptime_eval_error => |data| return self.buildComptimeEvalErrorReport(data),
             .invalid_numeric_literal => |data| return self.buildInvalidNumericLiteralReport(data),
@@ -3280,6 +3282,42 @@ pub const ReportBuilder = struct {
     }
 
     /// Build a report for compile-time crash
+    fn buildComptimeInvalidNumeralReport(self: *Self, data: ComptimeInvalidNumeral) Allocator.Error!Report {
+        var report = Report.init(self.gpa, "INVALID NUMBER", .runtime_error);
+        errdefer report.deinit();
+
+        const owned_message = try report.addOwnedString(
+            self.problems.getExtraString(data.message),
+        );
+
+        try D.renderSlice(&.{
+            D.bytes("The"),
+            D.bytes("from_numeral").withAnnotation(.inline_code),
+            D.bytes("implementation for this number literal's type rejected it:"),
+        }, self, &report);
+        try report.document.addLineBreak();
+
+        // Add source region highlighting
+        const region_info = self.module_env.calcRegionInfo(data.region);
+        try report.document.addSourceRegion(
+            region_info,
+            .error_highlight,
+            self.filename,
+            self.source,
+            self.module_env.getLineStarts(),
+        );
+        try report.document.addLineBreak();
+
+        try D.renderSlice(&.{
+            D.bytes("It returned this error message:"),
+        }, self, &report);
+        try report.document.addLineBreak();
+        try report.document.addLineBreak();
+        try report.document.addCodeBlock(owned_message);
+
+        return report;
+    }
+
     fn buildComptimeCrashReport(self: *Self, data: ComptimeCrash) Allocator.Error!Report {
         var report = Report.init(self.gpa, "COMPTIME CRASH", .runtime_error);
         errdefer report.deinit();

--- a/src/check/static_dispatch_registry.zig
+++ b/src/check/static_dispatch_registry.zig
@@ -601,7 +601,9 @@ pub const StaticDispatchPlanTable = struct {
         for (module_env.numeral_dispatch_plans.items.items) |numeral_plan| {
             const node: CIR.Node.Idx = @enumFromInt(numeral_plan.node_idx);
             const expr_idx: CIR.Expr.Idx = @enumFromInt(numeral_plan.node_idx);
-            const checked_expr = checked_bodies.exprIdForSource(expr_idx) orelse continue;
+            const checked_expr = checked_bodies.exprIdForSource(expr_idx) orelse
+                checked_bodies.numeralConversionExprAtRawNode(numeral_plan.node_idx) orelse
+                continue;
             switch (checked_bodies.exprs[@intFromEnum(checked_expr)].data) {
                 .num_from_numeral,
                 .typed_num_from_numeral,

--- a/src/eval/compile_time_finalization.zig
+++ b/src/eval/compile_time_finalization.zig
@@ -319,7 +319,7 @@ fn lowerEvalAndFinishRoots(
     for (lowered.lir_result.const_roots.items) |root| {
         const root_id = compileTimeRootForRequest(module, root.request);
         const compile_time_root = module.compile_time_roots.root(root_id);
-        const payload: checked.CompileTimeRootPayload = blk: {
+        var payload: checked.CompileTimeRootPayload = blk: {
             if (root.request.kind == .compile_time_constant and problem_store == null) {
                 const eval_result = interpreter.eval(.{
                     .proc_id = root.proc,
@@ -344,10 +344,84 @@ fn lowerEvalAndFinishRoots(
             break :blk try writer.storeRoot(root, eval_result.value);
         };
 
+        if (compile_time_root.kind == .numeral_conversion) {
+            payload = try finishNumeralConversionRoot(allocator, module, problem_store, compile_time_root, payload);
+        }
+
         module.compile_time_roots.fillPayload(root_id, payload);
         finishConstRoot(module, compile_time_root, payload);
         state.markDone(root_id);
     }
+}
+
+/// Unwrap the `Try` value a numeral-conversion root evaluated to. `Ok` payloads
+/// become the stored constant; `Err(InvalidNumeral(msg))` becomes a checking
+/// problem carrying the implementation's message.
+fn finishNumeralConversionRoot(
+    allocator: Allocator,
+    module: *checked.CheckedModuleArtifact,
+    problem_store: ?*check.problem.Store,
+    root: checked.CompileTimeRoot,
+    payload: checked.CompileTimeRootPayload,
+) anyerror!checked.CompileTimeRootPayload {
+    const try_node = switch (payload) {
+        .const_node => |node| node,
+        else => finalizationInvariant("numeral conversion root did not store a constant"),
+    };
+    switch (module.const_store.get(try_node)) {
+        // The from_numeral implementation itself crashed; that crash was
+        // already stored (and reported when a problem store exists).
+        .crash => return payload,
+        else => {},
+    }
+    const try_tag = constTagValue(module, try_node);
+    if (constTagNameIs(try_tag.tag_name, "Ok")) {
+        if (try_tag.payloads.len != 1) finalizationInvariant("numeral conversion Ok did not carry one payload");
+        return .{ .const_node = try_tag.payloads[0] };
+    }
+    if (!constTagNameIs(try_tag.tag_name, "Err")) {
+        finalizationInvariant("numeral conversion result was neither Ok nor Err");
+    }
+    if (try_tag.payloads.len != 1) finalizationInvariant("numeral conversion Err did not carry one payload");
+    const err_tag = constTagValue(module, try_tag.payloads[0]);
+    if (err_tag.payloads.len != 1) finalizationInvariant("numeral conversion error tag did not carry one payload");
+    const message_str = switch (module.const_store.get(err_tag.payloads[0])) {
+        .str => |str| str,
+        else => finalizationInvariant("numeral conversion error payload was not a string"),
+    };
+    const message = module.const_store.strBytes(message_str);
+    if (problem_store) |store| {
+        const message_idx = try store.putExtraString(message);
+        const region = module.checked_bodies.expr(root.expr).source_region;
+        _ = try store.appendProblem(allocator, .{ .comptime_invalid_numeral = .{
+            .message = message_idx,
+            .region = region,
+        } });
+        return error.CompileTimeProblem;
+    }
+    return .{ .const_node = try appendCrashConst(module, message) };
+}
+
+fn constTagValue(
+    module: *const checked.CheckedModuleArtifact,
+    node: checked.ConstNodeId,
+) @FieldType(checked.ConstValue, "tag") {
+    var current = node;
+    while (true) {
+        switch (module.const_store.get(current)) {
+            .nominal => |nominal| current = nominal.backing,
+            .tag => |tag| return tag,
+            else => finalizationInvariant("numeral conversion constant was not a tag value"),
+        }
+    }
+}
+
+fn constTagNameIs(name: []const u8, expected: []const u8) bool {
+    if (name.len != expected.len) return false;
+    for (name, expected) |actual, wanted| {
+        if (actual != wanted) return false;
+    }
+    return true;
 }
 
 fn appendCrashConst(
@@ -441,14 +515,13 @@ fn compileTimeRootForRequest(
     module: *const checked.CheckedModuleArtifact,
     request: checked.RootRequest,
 ) checked.ComptimeRootId {
-    const expected_kind: checked.CompileTimeRootKind = switch (request.kind) {
-        .compile_time_constant => .constant,
-        .compile_time_callable => .callable_binding,
-        else => finalizationInvariant("non compile-time request reached compile-time root lookup"),
-    };
-
     for (module.compile_time_roots.roots) |root| {
-        if (root.kind == expected_kind and rootSourceEql(root.source, request.source)) return root.id;
+        const kind_matches = switch (request.kind) {
+            .compile_time_constant => root.kind == .constant or root.kind == .numeral_conversion,
+            .compile_time_callable => root.kind == .callable_binding,
+            else => finalizationInvariant("non compile-time request reached compile-time root lookup"),
+        };
+        if (kind_matches and rootSourceEql(root.source, request.source)) return root.id;
     }
 
     finalizationInvariant("compile-time root request did not match a checked root");

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -540,13 +540,44 @@ const core_tests = [_]TestCase{
         \\
         \\describe : Tally -> Str
         \\describe = |tally| match tally {
-        \\    100 => "three digits"
+        \\    100 => "one byte"
         \\    _ => "other"
         \\}
         \\
         \\main = (describe(force(999)), describe(force(7)))
         ,
-        .expected = .{ .inspect_str = "(\"three digits\", \"other\")" },
+        // digits_before_pt holds base-256 digits: 999 is two bytes, while 100
+        // and 7 are one byte each — so 7 converts equal to the pattern literal
+        // and 999 does not, proving the pattern compares converted values.
+        .expected = .{ .inspect_str = "(\"other\", \"one byte\")" },
+    },
+    .{
+        .name = "inspect: custom from_numeral codepoint literals convert in exprs and patterns",
+        .source_kind = .module,
+        .source =
+        \\Code := [Code(List(U8))].{
+        \\    from_numeral : Numeral -> Try(Code, [InvalidNumeral(Str)])
+        \\    from_numeral = |numeral| match numeral {
+        \\        Literal(parts) => Ok(Code(parts.digits_before_pt))
+        \\    }
+        \\    is_eq : Code, Code -> Bool
+        \\    is_eq = |a, b| match (a, b) {
+        \\        (Code(x), Code(y)) => x == y
+        \\    }
+        \\}
+        \\
+        \\force : Code -> Code
+        \\force = |n| n
+        \\
+        \\describe : Code -> Str
+        \\describe = |code| match code {
+        \\    'a' => "letter a"
+        \\    _ => "other"
+        \\}
+        \\
+        \\main = (describe(force('a')), describe(force('b')))
+        ,
+        .expected = .{ .inspect_str = "(\"letter a\", \"other\")" },
     },
     .{
         .name = "custom from_numeral Err is a compile-time problem",

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -493,6 +493,94 @@ const core_tests = [_]TestCase{
         .expected = .{ .inspect_str = "(False, [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [1], 20)" },
     },
     .{
+        .name = "inspect: custom from_numeral literal pattern dispatches through is_eq",
+        .source_kind = .module,
+        .source =
+        \\Code := [Code(List(U8))].{
+        \\    from_numeral : Numeral -> Try(Code, [InvalidNumeral(Str)])
+        \\    from_numeral = |numeral| match numeral {
+        \\        Literal(parts) => Ok(Code(parts.digits_before_pt))
+        \\    }
+        \\    is_eq : Code, Code -> Bool
+        \\    is_eq = |a, b| match (a, b) {
+        \\        (Code(x), Code(y)) => x == y
+        \\    }
+        \\}
+        \\
+        \\force : Code -> Code
+        \\force = |n| n
+        \\
+        \\describe : Code -> Str
+        \\describe = |code| match code {
+        \\    42 => "yes"
+        \\    _ => "no"
+        \\}
+        \\
+        \\main = (describe(force(42)), describe(force(7)))
+        ,
+        .expected = .{ .inspect_str = "(\"yes\", \"no\")" },
+    },
+    .{
+        .name = "inspect: custom from_numeral literal pattern compares converted values not raw digits",
+        .source_kind = .module,
+        .source =
+        \\Tally := [Tally(U64)].{
+        \\    from_numeral : Numeral -> Try(Tally, [InvalidNumeral(Str)])
+        \\    from_numeral = |numeral| match numeral {
+        \\        Literal(parts) => Ok(Tally(parts.digits_before_pt.len()))
+        \\    }
+        \\    is_eq : Tally, Tally -> Bool
+        \\    is_eq = |a, b| match (a, b) {
+        \\        (Tally(x), Tally(y)) => x == y
+        \\    }
+        \\}
+        \\
+        \\force : Tally -> Tally
+        \\force = |n| n
+        \\
+        \\describe : Tally -> Str
+        \\describe = |tally| match tally {
+        \\    100 => "three digits"
+        \\    _ => "other"
+        \\}
+        \\
+        \\main = (describe(force(999)), describe(force(7)))
+        ,
+        .expected = .{ .inspect_str = "(\"three digits\", \"other\")" },
+    },
+    .{
+        .name = "custom from_numeral Err is a compile-time problem",
+        .source_kind = .module,
+        .source =
+        \\Picky := [Picky].{
+        \\    from_numeral : Numeral -> Try(Picky, [InvalidNumeral(Str)])
+        \\    from_numeral = |_numeral| Err(InvalidNumeral("Picky rejects every numeral"))
+        \\}
+        \\
+        \\force : Picky -> Picky
+        \\force = |n| n
+        \\
+        \\main = force(42)
+        ,
+        .expected = .problem,
+    },
+    .{
+        .name = "custom from_numeral Err in an uncalled function is a compile-time problem",
+        .source_kind = .module,
+        .source =
+        \\Picky := [Picky].{
+        \\    from_numeral : Numeral -> Try(Picky, [InvalidNumeral(Str)])
+        \\    from_numeral = |_numeral| Err(InvalidNumeral("Picky rejects every numeral"))
+        \\}
+        \\
+        \\unused : {} -> Picky
+        \\unused = |_| 42
+        \\
+        \\main = "ok"
+        ,
+        .expected = .problem,
+    },
+    .{
         .name = "inspect: unconstrained empty list specialization remains replaceable until constrained",
         .source_kind = .module,
         .source =

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -580,6 +580,40 @@ const core_tests = [_]TestCase{
         .expected = .{ .inspect_str = "(\"letter a\", \"other\")" },
     },
     .{
+        .name = "inspect: imported custom from_numeral converts literals in exprs and patterns",
+        .source_kind = .module,
+        .source =
+        \\import TallyMod
+        \\
+        \\force : TallyMod.Tally -> TallyMod.Tally
+        \\force = |n| n
+        \\
+        \\describe : TallyMod.Tally -> Str
+        \\describe = |tally| match tally {
+        \\    100 => "one byte"
+        \\    _ => "other"
+        \\}
+        \\
+        \\main = (describe(force(999)), describe(force(7)))
+        ,
+        .imports = &.{.{
+            .name = "TallyMod",
+            .source =
+            \\Tally := [Tally(U64)].{
+            \\    from_numeral : Numeral -> Try(Tally, [InvalidNumeral(Str)])
+            \\    from_numeral = |numeral| match numeral {
+            \\        Literal(parts) => Ok(Tally(parts.digits_before_pt.len()))
+            \\    }
+            \\    is_eq : Tally, Tally -> Bool
+            \\    is_eq = |a, b| match (a, b) {
+            \\        (Tally(x), Tally(y)) => x == y
+            \\    }
+            \\}
+            ,
+        }},
+        .expected = .{ .inspect_str = "(\"other\", \"one byte\")" },
+    },
+    .{
         .name = "custom from_numeral Err is a compile-time problem",
         .source_kind = .module,
         .source =

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -580,6 +580,34 @@ const core_tests = [_]TestCase{
         .expected = .{ .inspect_str = "(\"letter a\", \"other\")" },
     },
     .{
+        .name = "inspect: custom from_numeral fractional literal pattern dispatches through is_eq",
+        .source_kind = .module,
+        .source =
+        \\Scale := [Scale(U64)].{
+        \\    from_numeral : Numeral -> Try(Scale, [InvalidNumeral(Str)])
+        \\    from_numeral = |numeral| match numeral {
+        \\        Literal(parts) => Ok(Scale(parts.digits_after_pt_count))
+        \\    }
+        \\    is_eq : Scale, Scale -> Bool
+        \\    is_eq = |a, b| match (a, b) {
+        \\        (Scale(x), Scale(y)) => x == y
+        \\    }
+        \\}
+        \\
+        \\force : Scale -> Scale
+        \\force = |n| n
+        \\
+        \\describe : Scale -> Str
+        \\describe = |scale| match scale {
+        \\    2.5 => "one decimal"
+        \\    _ => "other"
+        \\}
+        \\
+        \\main = (describe(force(7.5)), describe(force(0.25)))
+        ,
+        .expected = .{ .inspect_str = "(\"one decimal\", \"other\")" },
+    },
+    .{
         .name = "inspect: imported custom from_numeral converts literals in exprs and patterns",
         .source_kind = .module,
         .source =

--- a/src/eval/test/parallel_runner.zig
+++ b/src/eval/test/parallel_runner.zig
@@ -1138,6 +1138,19 @@ fn runTestProblem(
             .backends = undefined,
         };
     }
+
+    // Checking found nothing; publish so compile-time evaluation can report
+    // problems (e.g. a custom from_numeral rejecting a literal).
+    const comptime_outcome = try helpers.publishProgramForComptimeProblems(allocator, source_kind, src, imports);
+    if (comptime_outcome == .comptime_problems) {
+        return .{
+            .status = .pass,
+            .timings = timings,
+            .has_backend_details = false,
+            .backends = undefined,
+        };
+    }
+
     return .{
         .status = .fail,
         .message = "expected problems but none found",

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -799,6 +799,7 @@ pub fn parseAndCanonicalizeProgramPublishedRoots(
     return parseAndCanonicalizeProgramWithRootMode(allocator, source_kind, source, imports, false, .published_roots_only, null);
 }
 
+/// Whether publishing a program for compile-time evaluation reported problems.
 pub const ComptimePublishOutcome = enum { no_problems, comptime_problems };
 
 /// Publish a program with compile-time evaluation problems routed into the

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -799,9 +799,45 @@ pub fn parseAndCanonicalizeProgramPublishedRoots(
     return parseAndCanonicalizeProgramWithRootMode(allocator, source_kind, source, imports, false, .published_roots_only, null);
 }
 
+pub const ComptimePublishOutcome = enum { no_problems, comptime_problems };
+
+/// Publish a program with compile-time evaluation problems routed into the
+/// checker's problem store, reporting whether any were found. The runtime eval
+/// pipeline intentionally publishes without a problem store so that crashes
+/// reachable from compile-time roots still compile and crash at runtime; this
+/// entry point exists for tests that assert on the compile-time diagnostics
+/// instead.
+pub fn publishProgramForComptimeProblems(
+    allocator: Allocator,
+    source_kind: SourceKind,
+    source: []const u8,
+    imports: []const ModuleSource,
+) anyerror!ComptimePublishOutcome {
+    const resources = parseAndCanonicalizeProgramWithRootModeReporting(
+        allocator,
+        source_kind,
+        source,
+        imports,
+        false,
+        .published_roots_only,
+        null,
+        .report_comptime_problems,
+    ) catch |err| switch (err) {
+        error.CompileTimeProblem => return .comptime_problems,
+        else => return err,
+    };
+    cleanupParseAndCanonical(allocator, resources);
+    return .no_problems;
+}
+
 const PublishedRootMode = union(enum) {
     eval_root: bool,
     published_roots_only,
+};
+
+const ComptimeProblemReporting = enum {
+    ignore_comptime_problems,
+    report_comptime_problems,
 };
 
 fn problemBlocksCheckedArtifact(problem: check.problem.Problem) bool {
@@ -826,6 +862,28 @@ fn parseAndCanonicalizeProgramWithRootMode(
     inspect_wrap: bool,
     root_mode: PublishedRootMode,
     pre_published_builtin: ?PrePublishedBuiltin,
+) anyerror!ParsedResources {
+    return parseAndCanonicalizeProgramWithRootModeReporting(
+        allocator,
+        source_kind,
+        source,
+        imports,
+        inspect_wrap,
+        root_mode,
+        pre_published_builtin,
+        .ignore_comptime_problems,
+    );
+}
+
+fn parseAndCanonicalizeProgramWithRootModeReporting(
+    allocator: Allocator,
+    source_kind: SourceKind,
+    source: []const u8,
+    imports: []const ModuleSource,
+    inspect_wrap: bool,
+    root_mode: PublishedRootMode,
+    pre_published_builtin: ?PrePublishedBuiltin,
+    problem_reporting: ComptimeProblemReporting,
 ) anyerror!ParsedResources {
     const builtin_indices: CIR.BuiltinIndices = if (pre_published_builtin) |ppb|
         ppb.indices
@@ -995,6 +1053,10 @@ fn parseAndCanonicalizeProgramWithRootMode(
             .imports = publish_imports,
             .explicit_roots = explicit_roots,
             .compile_time_finalizer = CompileTimeFinalization.finalizer(),
+            .problem_store = switch (problem_reporting) {
+                .ignore_comptime_problems => null,
+                .report_comptime_problems => &main_checked.checker.problems,
+            },
         },
     );
     errdefer checked_artifact.deinit(allocator);

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -2236,6 +2236,17 @@ const BodyContext = struct {
     string_literals: []?Ast.StringLiteralId,
     loop_contexts: std.ArrayList(LoopContext),
     type_cell_revision: u64,
+    /// Literal sub-patterns on non-builtin number types collected while
+    /// lowering a match branch's pattern; each becomes an equality condition
+    /// on the branch comparing the bound value against the literal's
+    /// `from_numeral`-converted constant.
+    pattern_literal_guards: std.ArrayList(PatternLiteralGuard),
+
+    const PatternLiteralGuard = struct {
+        local: Ast.LocalId,
+        conversion: checked.CheckedExprId,
+        ty: Type.TypeId,
+    };
 
     const MaterializedArg = struct {
         pattern: checked.CheckedPatternId,
@@ -2286,10 +2297,12 @@ const BodyContext = struct {
             .string_literals = string_literals,
             .loop_contexts = .empty,
             .type_cell_revision = 0,
+            .pattern_literal_guards = .empty,
         };
     }
 
     fn deinit(self: *BodyContext) void {
+        self.pattern_literal_guards.deinit(self.allocator);
         self.loop_contexts.deinit(self.allocator);
         self.allocator.free(self.string_literals);
         self.type_cells.deinit();
@@ -7426,7 +7439,10 @@ const BodyContext = struct {
 
                 var checks = std.ArrayList(CollectedListPattern).empty;
                 defer checks.deinit(branch_ctx.allocator);
+                const literal_guards_start = branch_ctx.pattern_literal_guards.items.len;
                 const pat = try branch_ctx.lowerPatternAtTypeCollectingLists(pattern.pattern, scrutinee_ty, &checks);
+                const literal_guards = try branch_ctx.drainPatternLiteralGuards(literal_guards_start);
+                defer branch_ctx.allocator.free(literal_guards);
 
                 try branch_ctx.applyAlternativeBinderRemaps(pattern.binder_remaps);
 
@@ -7435,6 +7451,8 @@ const BodyContext = struct {
                     const guard_cond = try branch_ctx.lowerExpr(guard_expr);
                     body_lowered = try branch_ctx.builder.ifExpr(guard_cond, body_lowered, fallback, output_ty);
                 }
+
+                body_lowered = try branch_ctx.applyPatternLiteralGuards(literal_guards, body_lowered, fallback, output_ty);
 
                 var i = checks.items.len;
                 while (i > 0) {
@@ -7494,17 +7512,27 @@ const BodyContext = struct {
             self.allocator.free(sub_checks_per_elem);
         }
         for (sub_checks_per_elem) |*sub| sub.* = std.ArrayList(CollectedListPattern).empty;
+        const literal_guards_per_elem = try self.allocator.alloc([]PatternLiteralGuard, list.patterns.len);
+        defer {
+            for (literal_guards_per_elem) |guards| self.allocator.free(guards);
+            self.allocator.free(literal_guards_per_elem);
+        }
+        for (literal_guards_per_elem) |*guards| guards.* = &.{};
 
         for (list.patterns, 0..) |pattern_id, index| {
             const item_index = try self.listPatternItemIndex(index, list.patterns.len, list.rest, len, u64_ty);
             values[index] = try self.builder.lowLevelExpr(.list_get_unsafe, &.{ scrutinee, item_index }, elem_ty);
+            const guards_start = self.pattern_literal_guards.items.len;
             patterns[index] = try self.lowerPatternAtTypeCollectingLists(pattern_id, elem_ty, &sub_checks_per_elem[index]);
+            literal_guards_per_elem[index] = try self.drainPatternLiteralGuards(guards_start);
         }
 
         var rest_pat: ?Ast.PatId = null;
         var rest_value: ?Ast.ExprId = null;
         var rest_sub_checks = std.ArrayList(CollectedListPattern).empty;
         defer rest_sub_checks.deinit(self.allocator);
+        var rest_literal_guards: []PatternLiteralGuard = &.{};
+        defer self.allocator.free(rest_literal_guards);
         if (list.rest) |rest| {
             if (rest.pattern) |rest_pattern| {
                 const list_len = len orelse try self.builder.lowLevelExpr(.list_len, &.{scrutinee}, u64_ty);
@@ -7513,7 +7541,9 @@ const BodyContext = struct {
                 const rest_start = try self.builder.intLiteralExpr(rest.index, u64_ty);
                 const range = try self.sublistRangeExpr(rest_start, rest_len, u64_ty);
                 rest_value = try self.builder.lowLevelExpr(.list_sublist, &.{ scrutinee, range }, scrutinee_ty);
+                const guards_start = self.pattern_literal_guards.items.len;
                 rest_pat = try self.lowerPatternAtTypeCollectingLists(rest_pattern, scrutinee_ty, &rest_sub_checks);
+                rest_literal_guards = try self.drainPatternLiteralGuards(guards_start);
             }
         }
 
@@ -7530,6 +7560,7 @@ const BodyContext = struct {
                 const sub_scrut = try self.builder.localExpr(sub.local, sub.ty);
                 elem_success = try self.applyListCheck(sub_scrut, sub.ty, sub, elem_success, fallback, output_ty);
             }
+            elem_success = try self.applyPatternLiteralGuards(literal_guards_per_elem[index], elem_success, fallback, output_ty);
             success = try self.wrapPatternMatch(values[index], elem_ty, patterns[index], elem_success, fallback, output_ty);
         }
 
@@ -7542,6 +7573,7 @@ const BodyContext = struct {
                 const sub_scrut = try self.builder.localExpr(sub.local, sub.ty);
                 rest_success = try self.applyListCheck(sub_scrut, sub.ty, sub, rest_success, fallback, output_ty);
             }
+            rest_success = try self.applyPatternLiteralGuards(rest_literal_guards, rest_success, fallback, output_ty);
             success = try self.wrapPatternMatch(
                 rest_value orelse Common.invariant("list rest pattern had no lowered rest value"),
                 scrutinee_ty,
@@ -7679,9 +7711,18 @@ const BodyContext = struct {
                 break :blk .{ .bind = local };
             },
             .tuple => |items| .{ .tuple = try self.lowerPatternSpanAtTypesCollectingLists(items, self.builder.tupleItemTypes(ty), checks_out) },
-            .num_literal => |num| self.lowerNumPattern(num.value, ty),
-            .small_dec_literal => Common.invariant("small decimal pattern reached Monotype after numeric finalization"),
-            .dec_literal => |dec| .{ .dec_lit = dec.value },
+            .num_literal => |num| if (num.conversion) |conversion|
+                try self.bindLiteralGuardPattern(conversion, ty)
+            else
+                self.lowerNumPattern(num.value, ty),
+            .small_dec_literal => |dec| if (dec.conversion) |conversion|
+                try self.bindLiteralGuardPattern(conversion, ty)
+            else
+                Common.invariant("small decimal pattern reached Monotype after numeric finalization"),
+            .dec_literal => |dec| if (dec.conversion) |conversion|
+                try self.bindLiteralGuardPattern(conversion, ty)
+            else
+                .{ .dec_lit = dec.value },
             .frac_f32_literal => |value| .{ .frac_f32_lit = value },
             .frac_f64_literal => |value| .{ .frac_f64_lit = value },
             .str_literal => |str| .{ .str_lit = try self.lowerStringLiteral(str) },
@@ -8056,7 +8097,8 @@ const BodyContext = struct {
 
                 const pat = try branch_ctx.lowerPatternAtType(pattern.pattern, scrutinee_ty);
                 try branch_ctx.applyAlternativeBinderRemaps(pattern.binder_remaps);
-                const guard = if (branch.guard) |guard_expr| try branch_ctx.lowerExpr(guard_expr) else null;
+                const user_guard = if (branch.guard) |guard_expr| try branch_ctx.lowerExpr(guard_expr) else null;
+                const guard = try branch_ctx.conjoinPatternLiteralGuards(user_guard);
                 const body = try branch_ctx.lowerMatchBranchBody(branch.value, output);
                 branches[index] = .{
                     .pat = pat,
@@ -9715,9 +9757,18 @@ const BodyContext = struct {
             .record_destructure => |destructs| try self.lowerRecordPattern(destructs, ty),
             .list => Common.invariant("list pattern must be lowered to explicit list operations before Monotype output"),
             .tuple => |items| .{ .tuple = try self.lowerTuplePattern(items, ty) },
-            .num_literal => |num| self.lowerNumPattern(num.value, ty),
-            .small_dec_literal => Common.invariant("small decimal pattern reached Monotype after numeric finalization"),
-            .dec_literal => |dec| .{ .dec_lit = dec.value },
+            .num_literal => |num| if (num.conversion) |conversion|
+                try self.bindLiteralGuardPattern(conversion, ty)
+            else
+                self.lowerNumPattern(num.value, ty),
+            .small_dec_literal => |dec| if (dec.conversion) |conversion|
+                try self.bindLiteralGuardPattern(conversion, ty)
+            else
+                Common.invariant("small decimal pattern reached Monotype after numeric finalization"),
+            .dec_literal => |dec| if (dec.conversion) |conversion|
+                try self.bindLiteralGuardPattern(conversion, ty)
+            else
+                .{ .dec_lit = dec.value },
             .frac_f32_literal => |value| .{ .frac_f32_lit = value },
             .frac_f64_literal => |value| .{ .frac_f64_lit = value },
             .str_literal => |str| .{ .str_lit = try self.lowerStringLiteral(str) },
@@ -9782,6 +9833,92 @@ const BodyContext = struct {
             .underscore => true,
             else => false,
         };
+    }
+
+    /// Lower a literal pattern on a non-builtin number type to a fresh bind,
+    /// recording an equality condition for the enclosing match branch.
+    fn bindLiteralGuardPattern(
+        self: *BodyContext,
+        conversion: checked.CheckedExprId,
+        ty: Type.TypeId,
+    ) Allocator.Error!Ast.PatData {
+        const local = try self.builder.program.addLocal(self.builder.symbols.fresh(), ty);
+        try self.pattern_literal_guards.append(self.allocator, .{
+            .local = local,
+            .conversion = conversion,
+            .ty = ty,
+        });
+        return .{ .bind = local };
+    }
+
+    /// Compare a bound match value against a literal's converted constant,
+    /// dispatching to the type's `is_eq` method when it has one and falling
+    /// back to structural equality otherwise, mirroring `==`.
+    fn lowerPatternLiteralEq(self: *BodyContext, entry: PatternLiteralGuard) Allocator.Error!Ast.ExprId {
+        const scrutinee = try self.builder.localExpr(entry.local, entry.ty);
+        const expected = try self.lowerExpr(entry.conversion);
+        if (methodOwnerFromType(&self.builder.program.types, entry.ty)) |owner| {
+            if (self.builder.lookupMethodTargetByName(owner, "is_eq")) |lookup| {
+                var target_ctx = try self.methodTargetContext(lookup);
+                defer target_ctx.deinit();
+                const target_fn = target_ctx.checkedFunctionType(lookup.target.callable_ty);
+                const bool_ty = try self.builder.lowerType(lookup.view, target_fn.ret);
+                const arg_tys = [_]Type.TypeId{ entry.ty, entry.ty };
+                const callable_mono_ty = try self.methodTargetMonoTypeFromArgs(lookup, &arg_tys, bool_ty);
+                const callee = try self.methodTargetCalleeWithMono(lookup, callable_mono_ty);
+                return try self.builder.program.addExpr(.{ .ty = bool_ty, .data = .{ .call_proc = .{
+                    .callee = .{ .template = callee },
+                    .args = try self.builder.program.addExprSpan(&.{ scrutinee, expected }),
+                } } });
+            }
+        }
+        return try self.lowerEqualityExpr(entry.ty, scrutinee, expected, "is_eq", try self.builder.primitiveType(.bool));
+    }
+
+    /// Take ownership of the literal-equality conditions collected since
+    /// `start`, restoring the collection to that length.
+    fn drainPatternLiteralGuards(self: *BodyContext, start: usize) Allocator.Error![]PatternLiteralGuard {
+        const drained = try self.allocator.dupe(PatternLiteralGuard, self.pattern_literal_guards.items[start..]);
+        self.pattern_literal_guards.shrinkRetainingCapacity(start);
+        return drained;
+    }
+
+    /// Wrap a match-branch body so it only runs when every collected literal
+    /// equality holds, falling through to the branch's fallback otherwise.
+    fn applyPatternLiteralGuards(
+        self: *BodyContext,
+        guards: []const PatternLiteralGuard,
+        body: Ast.ExprId,
+        fallback: Ast.ExprId,
+        output_ty: Type.TypeId,
+    ) Allocator.Error!Ast.ExprId {
+        var result = body;
+        var i = guards.len;
+        while (i > 0) {
+            i -= 1;
+            const eq = try self.lowerPatternLiteralEq(guards[i]);
+            result = try self.builder.ifExpr(eq, result, fallback, output_ty);
+        }
+        return result;
+    }
+
+    /// Conjoin the branch's collected literal-equality conditions with its
+    /// (optional) user guard, literal conditions first.
+    fn conjoinPatternLiteralGuards(self: *BodyContext, user_guard: ?Ast.ExprId) Allocator.Error!?Ast.ExprId {
+        if (self.pattern_literal_guards.items.len == 0) return user_guard;
+        const bool_ty = try self.builder.primitiveType(.bool);
+        var cond = user_guard;
+        var i = self.pattern_literal_guards.items.len;
+        while (i > 0) {
+            i -= 1;
+            const eq = try self.lowerPatternLiteralEq(self.pattern_literal_guards.items[i]);
+            cond = if (cond) |inner|
+                try self.builder.ifExpr(eq, inner, try self.boolLiteral(false, bool_ty), bool_ty)
+            else
+                eq;
+        }
+        self.pattern_literal_guards.clearRetainingCapacity();
+        return cond;
     }
 
     fn lowerNumPattern(self: *BodyContext, value: can.CIR.IntValue, ty: Type.TypeId) Ast.PatData {

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -4021,6 +4021,14 @@ const BodyContext = struct {
             },
             .entry_wrapper => |wrapper_id| {
                 const wrapper = self.view.entry_wrappers.get(wrapper_id);
+                const root = self.view.compile_time_roots.root(wrapper.root);
+                if (root.kind == .numeral_conversion) {
+                    return .{
+                        .args = .empty(),
+                        .body = try self.lowerNumeralRootBody(wrapper.body_expr, ret_ty),
+                        .ret = ret_ty,
+                    };
+                }
                 return .{
                     .args = .empty(),
                     .body = try self.lowerExprAtType(wrapper.body_expr, ret_ty),
@@ -4259,9 +4267,15 @@ const BodyContext = struct {
             .frac_f64 => |frac| .{ .frac_f64_lit = frac.value },
             .dec => |dec| .{ .dec_lit = dec.value },
             .dec_small => Common.invariant("small decimal literal reached Monotype after numeric finalization"),
-            .num_from_numeral => |plan| return try self.lowerNumeralCall(expr.ty, plan, ty),
+            .num_from_numeral => |plan| {
+                if (try self.restoredNumeralConst(expr_id, ty)) |restored| return restored;
+                return try self.lowerNumeralCall(expr.ty, plan, ty);
+            },
             .typed_frac => Common.invariant("typed fractional integer literal reached Monotype after numeric finalization"),
-            .typed_num_from_numeral => |plan| return try self.lowerNumeralCall(expr.ty, plan, ty),
+            .typed_num_from_numeral => |plan| {
+                if (try self.restoredNumeralConst(expr_id, ty)) |restored| return restored;
+                return try self.lowerNumeralCall(expr.ty, plan, ty);
+            },
             .str_segment => |str| .{ .str_lit = try self.lowerStringLiteral(str) },
             .bytes_literal => |str| .{ .str_lit = try self.lowerStringLiteral(str) },
             .empty_list => .{ .list = .empty() },
@@ -6290,6 +6304,21 @@ const BodyContext = struct {
         maybe_plan: ?static_dispatch.StaticDispatchPlanId,
         target_ty: Type.TypeId,
     ) Allocator.Error!Ast.ExprId {
+        const result = try self.lowerNumeralCallRaw(checked_ret_ty, maybe_plan, target_ty);
+        return try self.unwrapNumeralResult(result.call, result.try_ty, target_ty);
+    }
+
+    const NumeralCall = struct {
+        call: Ast.ExprId,
+        try_ty: Type.TypeId,
+    };
+
+    fn lowerNumeralCallRaw(
+        self: *BodyContext,
+        checked_ret_ty: checked.CheckedTypeId,
+        maybe_plan: ?static_dispatch.StaticDispatchPlanId,
+        target_ty: Type.TypeId,
+    ) Allocator.Error!NumeralCall {
         const plan_id = maybe_plan orelse Common.invariant("checked from_numeral expression reached Monotype without a dispatch plan");
         const plan = self.view.static_dispatch_plans.plans[@intFromEnum(plan_id)];
         if (plan.result_mode != .value) Common.invariant("checked from_numeral plan had a non-value result mode");
@@ -6320,7 +6349,40 @@ const BodyContext = struct {
             .ty = fn_data.ret,
             .data = try self.lowerResolvedDispatch(plan, resolved, target_mono_ty, self),
         });
-        return try self.unwrapNumeralResult(call_expr, fn_data.ret, target_ty);
+        return .{ .call = call_expr, .try_ty = fn_data.ret };
+    }
+
+    fn lowerNumeralRootBody(
+        self: *BodyContext,
+        expr_id: checked.CheckedExprId,
+        try_ty: Type.TypeId,
+    ) Allocator.Error!Ast.ExprId {
+        const expr = self.view.bodies.exprs[@intFromEnum(expr_id)];
+        const plan = switch (expr.data) {
+            .num_from_numeral, .typed_num_from_numeral => |plan| plan,
+            else => Common.invariant("numeral conversion root did not point at a from_numeral expression"),
+        };
+        const ok_tag = self.monoTagByText(try_ty, "Ok");
+        const ok_payloads = self.builder.program.types.span(ok_tag.payloads);
+        if (ok_payloads.len != 1) Common.invariant("numeral conversion root Try.Ok did not carry one payload");
+        const result = try self.lowerNumeralCallRaw(expr.ty, plan, ok_payloads[0]);
+        if (!self.sameType(result.try_ty, try_ty)) {
+            Common.invariant("numeral conversion root type differed from the from_numeral result type");
+        }
+        return result.call;
+    }
+
+    fn restoredNumeralConst(
+        self: *BodyContext,
+        expr_id: checked.CheckedExprId,
+        ty: Type.TypeId,
+    ) Allocator.Error!?Ast.ExprId {
+        const root = self.view.compile_time_roots.lookupNumeralRootByExpr(expr_id) orelse return null;
+        return switch (root.payload) {
+            .const_node => |node| try self.restoreConstNodeAtType(self.view, self.view, node, ty),
+            .pending => null,
+            else => Common.invariant("numeral conversion root stored a non-constant payload"),
+        };
     }
 
     fn lowerNumeralValue(

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -9884,7 +9884,7 @@ const BodyContext = struct {
     }
 
     /// Wrap a match-branch body so it only runs when every collected literal
-    /// equality holds, falling through to the branch's fallback otherwise.
+    /// equality holds, jumping to the branch's miss target otherwise.
     fn applyPatternLiteralGuards(
         self: *BodyContext,
         guards: []const PatternLiteralGuard,

--- a/test/snapshots/fuzz_crash/fuzz_crash_019.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_019.md
@@ -1905,7 +1905,7 @@ expect {
 				(s-expr
 					(e-not-implemented))
 				(s-expr
-					(e-call (constraint-fn-var 1343)
+					(e-call (constraint-fn-var 1403)
 						(e-lookup-local
 							(p-assign (ident "me")))
 						(e-not-implemented)))
@@ -1945,7 +1945,7 @@ expect {
 									(e-lookup-local
 										(p-assign (ident "er")))
 									(e-literal (string "")))))
-						(e-dispatch-call (method "plus") (constraint-fn-var 1528)
+						(e-dispatch-call (method "plus") (constraint-fn-var 1588)
 							(receiver
 								(e-runtime-error (tag "ident_not_in_scope")))
 							(args
@@ -2009,7 +2009,7 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 1911)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 1971)
 									(receiver
 										(e-match
 											(match
@@ -2043,18 +2043,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 2019)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 2079)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 1984)
+															(e-dispatch-call (method "plus") (constraint-fn-var 2044)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 2119)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 2179)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 2084)
+															(e-dispatch-call (method "minus") (constraint-fn-var 2144)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2069,7 +2069,7 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 2197)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 2257)
 										(receiver
 											(e-num (value "12")))
 										(args
@@ -2083,12 +2083,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "ned") (constraint-fn-var 2264)
+													(e-dispatch-call (method "ned") (constraint-fn-var 2324)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "od") (constraint-fn-var 2231)
+																		(e-dispatch-call (method "od") (constraint-fn-var 2291)
 																			(receiver
 																				(e-match
 																					(match

--- a/test/snapshots/fuzz_crash/fuzz_crash_020.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_020.md
@@ -1897,7 +1897,7 @@ expect {
 				(s-expr
 					(e-not-implemented))
 				(s-expr
-					(e-call (constraint-fn-var 1341)
+					(e-call (constraint-fn-var 1401)
 						(e-lookup-local
 							(p-assign (ident "me")))
 						(e-not-implemented)))
@@ -1937,7 +1937,7 @@ expect {
 									(e-lookup-local
 										(p-assign (ident "er")))
 									(e-literal (string "")))))
-						(e-dispatch-call (method "plus") (constraint-fn-var 1526)
+						(e-dispatch-call (method "plus") (constraint-fn-var 1586)
 							(receiver
 								(e-runtime-error (tag "ident_not_in_scope")))
 							(args
@@ -2001,7 +2001,7 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 1909)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 1969)
 									(receiver
 										(e-match
 											(match
@@ -2035,18 +2035,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 2017)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 2077)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 1982)
+															(e-dispatch-call (method "plus") (constraint-fn-var 2042)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 2117)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 2177)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 2082)
+															(e-dispatch-call (method "minus") (constraint-fn-var 2142)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2061,7 +2061,7 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 2195)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 2255)
 										(receiver
 											(e-num (value "12")))
 										(args
@@ -2075,12 +2075,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "ned") (constraint-fn-var 2262)
+													(e-dispatch-call (method "ned") (constraint-fn-var 2322)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "od") (constraint-fn-var 2229)
+																		(e-dispatch-call (method "od") (constraint-fn-var 2289)
 																			(receiver
 																				(e-match
 																					(match

--- a/test/snapshots/fuzz_crash/fuzz_crash_023.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_023.md
@@ -2386,7 +2386,7 @@ expect {
 				(s-expr
 					(e-not-implemented))
 				(s-expr
-					(e-call (constraint-fn-var 2289)
+					(e-call (constraint-fn-var 2399)
 						(e-lookup-local
 							(p-assign (ident "match_time")))
 						(e-not-implemented)))
@@ -2507,7 +2507,7 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 2924)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 3034)
 									(receiver
 										(e-match
 											(match
@@ -2532,7 +2532,7 @@ expect {
 														(value
 															(e-num (value "12"))))))))
 									(args
-										(e-dispatch-call (method "times") (constraint-fn-var 2919)
+										(e-dispatch-call (method "times") (constraint-fn-var 3029)
 											(receiver
 												(e-num (value "5")))
 											(args
@@ -2547,18 +2547,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 3032)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 3142)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 2997)
+															(e-dispatch-call (method "plus") (constraint-fn-var 3107)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 3132)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 3242)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 3097)
+															(e-dispatch-call (method "minus") (constraint-fn-var 3207)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2573,11 +2573,11 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 3242)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 3352)
 										(receiver
 											(e-num (value "12")))
 										(args
-											(e-dispatch-call (method "div_by") (constraint-fn-var 3237)
+											(e-dispatch-call (method "div_by") (constraint-fn-var 3347)
 												(receiver
 													(e-num (value "3")))
 												(args
@@ -2592,12 +2592,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 3308)
+													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 3418)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 3275)
+																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 3385)
 																			(receiver
 																				(e-match
 																					(match

--- a/test/snapshots/fuzz_crash/fuzz_crash_027.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_027.md
@@ -1855,7 +1855,7 @@ main! = |_| { # Yeah Ie
 				(s-expr
 					(e-not-implemented))
 				(s-expr
-					(e-call (constraint-fn-var 1761)
+					(e-call (constraint-fn-var 1861)
 						(e-lookup-local
 							(p-assign (ident "match_time")))
 						(e-not-implemented)))

--- a/test/snapshots/fuzz_crash/fuzz_crash_028.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_028.md
@@ -2688,7 +2688,7 @@ expect {
 				(s-expr
 					(e-not-implemented))
 				(s-expr
-					(e-call (constraint-fn-var 1865)
+					(e-call (constraint-fn-var 1965)
 						(e-lookup-local
 							(p-assign (ident "match_time")))
 						(e-not-implemented)))
@@ -2725,7 +2725,7 @@ expect {
 					(p-assign (ident "n"))
 					(e-runtime-error (tag "ident_not_in_scope"))
 					(e-block
-						(e-dispatch-call (method "plus") (constraint-fn-var 2042)
+						(e-dispatch-call (method "plus") (constraint-fn-var 2142)
 							(receiver
 								(e-call
 									(e-runtime-error (tag "ident_not_in_scope"))
@@ -2808,7 +2808,7 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 2462)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 2562)
 									(receiver
 										(e-match
 											(match
@@ -2833,7 +2833,7 @@ expect {
 														(value
 															(e-num (value "12"))))))))
 									(args
-										(e-dispatch-call (method "times") (constraint-fn-var 2457)
+										(e-dispatch-call (method "times") (constraint-fn-var 2557)
 											(receiver
 												(e-num (value "5")))
 											(args
@@ -2848,18 +2848,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 2570)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 2670)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 2535)
+															(e-dispatch-call (method "plus") (constraint-fn-var 2635)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 2670)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 2770)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 2635)
+															(e-dispatch-call (method "minus") (constraint-fn-var 2735)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2874,11 +2874,11 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 2780)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 2880)
 										(receiver
 											(e-num (value "12")))
 										(args
-											(e-dispatch-call (method "div_by") (constraint-fn-var 2775)
+											(e-dispatch-call (method "div_by") (constraint-fn-var 2875)
 												(receiver
 													(e-num (value "3")))
 												(args
@@ -2893,12 +2893,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "ned") (constraint-fn-var 2846)
+													(e-dispatch-call (method "ned") (constraint-fn-var 2946)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "od") (constraint-fn-var 2813)
+																		(e-dispatch-call (method "od") (constraint-fn-var 2913)
 																			(receiver
 																				(e-match
 																					(match

--- a/test/snapshots/is_eq/structural_alias_eq.md
+++ b/test/snapshots/is_eq/structural_alias_eq.md
@@ -299,7 +299,7 @@ is_match = from_flags(1) == { primary: Color2, secondary: Color4 }
 		(p-assign (ident "is_red"))
 		(e-structural-eq (negated "false")
 			(lhs
-				(e-call (constraint-fn-var 410)
+				(e-call (constraint-fn-var 448)
 					(e-lookup-local
 						(p-assign (ident "pick")))
 					(e-num (value "0"))))
@@ -311,7 +311,7 @@ is_match = from_flags(1) == { primary: Color2, secondary: Color4 }
 		(p-assign (ident "not_red"))
 		(e-structural-eq (negated "true")
 			(lhs
-				(e-call (constraint-fn-var 528)
+				(e-call (constraint-fn-var 566)
 					(e-lookup-local
 						(p-assign (ident "pick")))
 					(e-num (value "0"))))
@@ -385,7 +385,7 @@ is_match = from_flags(1) == { primary: Color2, secondary: Color4 }
 		(p-assign (ident "is_match"))
 		(e-structural-eq (negated "false")
 			(lhs
-				(e-call (constraint-fn-var 1232)
+				(e-call (constraint-fn-var 1289)
 					(e-lookup-local
 						(p-assign (ident "from_flags")))
 					(e-num (value "1"))))

--- a/test/snapshots/issue/try_match_type_bug.md
+++ b/test/snapshots/issue/try_match_type_bug.md
@@ -103,7 +103,7 @@ get_greeting = |{}| {
 												(e-match
 													(match
 														(cond
-															(e-call (constraint-fn-var 167)
+															(e-call (constraint-fn-var 172)
 																(e-lookup-external
 																	(builtin))
 																(e-list

--- a/test/snapshots/plume_package/Color.md
+++ b/test/snapshots/plume_package/Color.md
@@ -1026,7 +1026,7 @@ is_named_color = |str| {
 											(e-if
 												(if-branches
 													(if-branch
-														(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1099)
+														(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1118)
 															(receiver
 																(e-lookup-local
 																	(p-assign (ident "a"))))
@@ -1034,7 +1034,7 @@ is_named_color = |str| {
 														(e-if
 															(if-branches
 																(if-branch
-																	(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1105)
+																	(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1124)
 																		(receiver
 																			(e-lookup-local
 																				(p-assign (ident "b"))))
@@ -1042,7 +1042,7 @@ is_named_color = |str| {
 																	(e-if
 																		(if-branches
 																			(if-branch
-																				(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1111)
+																				(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1130)
 																					(receiver
 																						(e-lookup-local
 																							(p-assign (ident "c"))))
@@ -1050,7 +1050,7 @@ is_named_color = |str| {
 																				(e-if
 																					(if-branches
 																						(if-branch
-																							(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1117)
+																							(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1136)
 																								(receiver
 																									(e-lookup-local
 																										(p-assign (ident "d"))))
@@ -1058,12 +1058,12 @@ is_named_color = |str| {
 																							(e-if
 																								(if-branches
 																									(if-branch
-																										(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1123)
+																										(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1142)
 																											(receiver
 																												(e-lookup-local
 																													(p-assign (ident "e"))))
 																											(args))
-																										(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1129)
+																										(e-dispatch-call (method "is_char_in_hex_range") (constraint-fn-var 1148)
 																											(receiver
 																												(e-lookup-local
 																													(p-assign (ident "f"))))
@@ -1222,7 +1222,7 @@ is_named_color = |str| {
 			(e-if
 				(if-branches
 					(if-branch
-						(e-dispatch-call (method "is_named_color") (constraint-fn-var 1555)
+						(e-dispatch-call (method "is_named_color") (constraint-fn-var 1574)
 							(receiver
 								(e-lookup-local
 									(p-assign (ident "str"))))
@@ -1260,7 +1260,7 @@ is_named_color = |str| {
 			(e-block
 				(s-let
 					(p-assign (ident "colors"))
-					(e-call (constraint-fn-var 1661)
+					(e-call (constraint-fn-var 1680)
 						(e-lookup-external
 							(builtin))
 						(e-list
@@ -1271,7 +1271,7 @@ is_named_color = |str| {
 									(e-literal (string "AntiqueWhite")))
 								(e-string
 									(e-literal (string "Aqua")))))))
-				(e-dispatch-call (method "contains") (constraint-fn-var 1682)
+				(e-dispatch-call (method "contains") (constraint-fn-var 1701)
 					(receiver
 						(e-lookup-local
 							(p-assign (ident "colors"))))
@@ -1297,9 +1297,9 @@ is_named_color = |str| {
 	(s-expect
 		(e-method-eq (negated "false")
 			(lhs
-				(e-dispatch-call (method "to_str") (constraint-fn-var 2035)
+				(e-dispatch-call (method "to_str") (constraint-fn-var 2054)
 					(receiver
-						(e-call (constraint-fn-var 1824)
+						(e-call (constraint-fn-var 1843)
 							(e-lookup-local
 								(p-assign (ident "rgb")))
 							(e-num (value "124"))
@@ -1312,9 +1312,9 @@ is_named_color = |str| {
 	(s-expect
 		(e-method-eq (negated "false")
 			(lhs
-				(e-dispatch-call (method "to_str") (constraint-fn-var 2453)
+				(e-dispatch-call (method "to_str") (constraint-fn-var 2472)
 					(receiver
-						(e-call (constraint-fn-var 2172)
+						(e-call (constraint-fn-var 2191)
 							(e-lookup-local
 								(p-assign (ident "rgba")))
 							(e-num (value "124"))
@@ -1328,9 +1328,9 @@ is_named_color = |str| {
 	(s-expect
 		(e-method-eq (negated "false")
 			(lhs
-				(e-dispatch-call (method "map_ok") (constraint-fn-var 2477)
+				(e-dispatch-call (method "map_ok") (constraint-fn-var 2496)
 					(receiver
-						(e-call (constraint-fn-var 2476)
+						(e-call (constraint-fn-var 2495)
 							(e-lookup-local
 								(p-assign (ident "hex")))
 							(e-string

--- a/test/snapshots/syntax_grab_bag.md
+++ b/test/snapshots/syntax_grab_bag.md
@@ -2257,7 +2257,7 @@ expect {
 				(s-expr
 					(e-not-implemented))
 				(s-expr
-					(e-call (constraint-fn-var 2283)
+					(e-call (constraint-fn-var 2393)
 						(e-lookup-local
 							(p-assign (ident "match_time")))
 						(e-not-implemented)))
@@ -2384,7 +2384,7 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 2949)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 3059)
 									(receiver
 										(e-match
 											(match
@@ -2409,7 +2409,7 @@ expect {
 														(value
 															(e-num (value "12"))))))))
 									(args
-										(e-dispatch-call (method "times") (constraint-fn-var 2944)
+										(e-dispatch-call (method "times") (constraint-fn-var 3054)
 											(receiver
 												(e-num (value "5")))
 											(args
@@ -2424,18 +2424,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 3057)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 3167)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 3022)
+															(e-dispatch-call (method "plus") (constraint-fn-var 3132)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 3157)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 3267)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 3122)
+															(e-dispatch-call (method "minus") (constraint-fn-var 3232)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2450,11 +2450,11 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 3267)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 3377)
 										(receiver
 											(e-num (value "12")))
 										(args
-											(e-dispatch-call (method "div_by") (constraint-fn-var 3262)
+											(e-dispatch-call (method "div_by") (constraint-fn-var 3372)
 												(receiver
 													(e-num (value "3")))
 												(args
@@ -2469,12 +2469,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 3333)
+													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 3443)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 3300)
+																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 3410)
 																			(receiver
 																				(e-match
 																					(match


### PR DESCRIPTION
Numeric literals targeting a non-builtin nominal type previously lowered to a runtime `from_numeral` dispatch call whose `Err` branch crashed with a generic message, and matching a number literal pattern against such a type was broken outright: lowering stuffed the raw integer into a local of the scrutinee's layout and compared structurally, which panicked for types with owned payloads ("non-structural equality reached direct LIR structural equality lowering") and silently produced wrong match results otherwise.

Every `from_numeral` conversion with a concrete target type is now a compile-time root, no matter where the literal sits in the AST: checking finalization evaluates the raw dispatch call, stores the `Try` result in the `ConstStore`, unwraps `Ok` into the literal's stored constant, and reports `Err(InvalidNumeral(msg))` as an INVALID NUMBER diagnostic carrying the implementation's own message — including for literals in functions that are never called. Runtime lowering restores the stored constant instead of emitting a call; conversions whose target is still polymorphic (literals inside generalized functions) keep the dispatch call per specialization.

Literal patterns ride the same machinery: canonicalization now records exact digits for pattern nodes (and for codepoint literals, which previously had no numeral facts at all), the checked artifact synthesizes a conversion expression per custom-typed literal pattern, and match lowering binds the matched value and compares it against the converted constant through the type's `is_eq` method, with the same structural-equality permission as `==`. Checking attaches an `is_eq` constraint to literal pattern types so this lowering stays total. Literal patterns on builtin number types keep the direct literal-pattern encoding.