### PR TITLE
Add host-boundary DCE coverage

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1747,6 +1747,9 @@ fn buildAndCopyWasmHostObject(
     configureBackend(obj, target);
     obj.root_module.addImport("builtins", roc_modules.builtins);
     obj.root_module.addImport("build_options", roc_modules.build_options);
+    // Per-function/data sections so wasm final-link DCE can strip unused host code.
+    obj.link_function_sections = true;
+    obj.link_data_sections = true;
 
     const dest_path = "test/wasm/platform/targets/wasm32/host.wasm";
     const copy_step = b.addUpdateSourceFiles();
@@ -3313,6 +3316,31 @@ pub fn build(b: *std.Build) void {
         const install = b.addInstallArtifact(wasm_test_exe, .{});
         build_test_wasm_static_lib_runner_step.dependOn(&install.step);
 
+        const wasm_dce_check_exe = b.addExecutable(.{
+            .name = "wasm_dce_check",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("test/archive/archive_check.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
+        });
+        configureBackend(wasm_dce_check_exe, target);
+        const run_wasm_dce_check = b.addRunArtifact(wasm_dce_check_exe);
+        run_wasm_dce_check.addArgs(&.{
+            "test/wasm/app.wasm",
+            "--absent",
+            "roc_unused_host_canary_7f3a9c",
+            "--absent",
+            "roc_dead_private_helper_canary_41d2cb",
+            "--absent",
+            "ROC_DCE_WASM_DEAD_HOSTED_BLOB_0ac91d",
+            "--absent",
+            "ROC_DCE_WASM_DEAD_HELPER_BLOB_f25a77",
+            "ROC_DCE_WASM_SHARED_BLOB_31e82f",
+        });
+        run_wasm_dce_check.step.dependOn(&build_wasm_app.step);
+        run_test_wasm_static_lib_step.dependOn(&run_wasm_dce_check.step);
+
         const run_wasm_test = b.addRunArtifact(wasm_test_exe);
         if (run_args.len != 0) {
             run_wasm_test.addArgs(run_args);
@@ -3397,7 +3425,15 @@ pub fn build(b: *std.Build) void {
         });
         configureBackend(dylib_dce_check_exe, target);
         const run_dylib_dce_check = b.addRunArtifact(dylib_dce_check_exe);
-        run_dylib_dce_check.addArgs(&.{ dylib_output, "--absent", "ROC_DCE_CANARY_BLOB_7f3a9c", "roc_host_double" });
+        run_dylib_dce_check.addArgs(&.{
+            dylib_output,
+            "--absent",
+            "ROC_DCE_CANARY_BLOB_7f3a9c",
+            "--absent",
+            "ROC_DCE_DEAD_HELPER_BLOB_28d0aa",
+            "ROC_DCE_SHARED_BLOB_93e2c1",
+            "roc_host_double",
+        });
         run_dylib_dce_check.step.dependOn(&build_dylib_app.step);
         run_test_dylib_step.dependOn(&run_dylib_dce_check.step);
     }
@@ -3454,6 +3490,18 @@ pub fn build(b: *std.Build) void {
             }),
         });
         configureBackend(archive_check_exe, target);
+
+        const run_native_archive_dce_check = b.addRunArtifact(archive_check_exe);
+        run_native_archive_dce_check.addFileArg(archive_consumer_exe.getEmittedBin());
+        run_native_archive_dce_check.addArgs(&.{
+            "--absent",
+            "ROC_DCE_CANARY_BLOB_7f3a9c",
+            "--absent",
+            "ROC_DCE_DEAD_HELPER_BLOB_28d0aa",
+            "ROC_DCE_SHARED_BLOB_93e2c1",
+        });
+        run_native_archive_dce_check.step.dependOn(&archive_consumer_exe.step);
+        run_test_archive_step.dependOn(&run_native_archive_dce_check.step);
 
         const run_wasm_archive_check = b.addRunArtifact(archive_check_exe);
         run_wasm_archive_check.addArgs(&.{ "--archive", "test/archive/app-wasm32.a", "roc_builtins" });

--- a/src/backend/wasm/WasmModule.zig
+++ b/src/backend/wasm/WasmModule.zig
@@ -2137,6 +2137,8 @@ pub fn eliminateDeadCode(self: *Self, called_fns: []const bool) Allocator.Error!
         }
     }
 
+    try self.eliminateDeadData(live_flags, fn_index_min, fn_count);
+
     // --- 3. Replace dead defined-function bodies with dummies ---
     var buffer: std.ArrayList(u8) = .empty;
     defer buffer.deinit(gpa);
@@ -2180,6 +2182,80 @@ pub fn eliminateDeadCode(self: *Self, called_fns: []const bool) Allocator.Error!
 
     // Update import_fn_count to reflect removals.
     self.import_fn_count -= eliminated_import_count;
+}
+
+fn eliminateDeadData(self: *Self, live_flags: []const bool, fn_index_min: u32, fn_count: u32) Allocator.Error!void {
+    const gpa = self.allocator;
+    if (self.data_segments.items.len == 0) return;
+
+    const live_segments = try gpa.alloc(bool, self.data_segments.items.len);
+    defer gpa.free(live_segments);
+    @memset(live_segments, false);
+
+    // Seed data liveness from relocations inside live function bodies.
+    for (live_flags, 0..) |is_live, fi| {
+        if (!is_live) continue;
+        if (fi < fn_index_min or fi >= fn_count) continue;
+
+        const offset_index = fi - fn_index_min;
+        const code_start = self.function_offsets.items[offset_index];
+        const code_end: u32 = if (offset_index + 1 < self.function_offsets.items.len)
+            self.function_offsets.items[offset_index + 1]
+        else
+            @intCast(self.code_bytes.items.len);
+
+        for (self.reloc_code.entries.items) |entry| {
+            if (!relocationOffsetInRange(entry, code_start, code_end)) continue;
+            _ = self.markRelocationDataTarget(live_segments, entry);
+        }
+    }
+
+    // Follow data-to-data references until all transitively live segments are marked.
+    var changed = true;
+    while (changed) {
+        changed = false;
+        for (self.reloc_data.entries.items) |entry| {
+            const source_segment = relocationDataSegment(entry);
+            std.debug.assert(source_segment < live_segments.len);
+            if (!live_segments[source_segment]) continue;
+
+            if (self.markRelocationDataTarget(live_segments, entry)) changed = true;
+        }
+    }
+
+    var write_idx: usize = 0;
+    for (self.data_segments.items, 0..) |segment, i| {
+        if (live_segments[i]) {
+            self.data_segments.items[write_idx] = segment;
+            write_idx += 1;
+        } else {
+            gpa.free(segment.data);
+        }
+    }
+    self.data_segments.items.len = write_idx;
+}
+
+fn relocationOffsetInRange(entry: WasmLinking.RelocationEntry, code_start: u32, code_end: u32) bool {
+    const offset = entry.getOffset();
+    return offset > code_start and offset < code_end;
+}
+
+fn relocationDataSegment(entry: WasmLinking.RelocationEntry) u32 {
+    return switch (entry) {
+        .index => |idx| idx.data_segment_index,
+        .offset => |off| off.data_segment_index,
+    };
+}
+
+fn markRelocationDataTarget(self: *const Self, live_segments: []bool, entry: WasmLinking.RelocationEntry) bool {
+    const symbol_index = entry.getSymbolIndex();
+    std.debug.assert(symbol_index < self.linking.symbol_table.items.len);
+    const sym = self.linking.symbol_table.items[symbol_index];
+    if (sym.kind != .data or sym.isUndefined()) return false;
+    std.debug.assert(sym.index < live_segments.len);
+    const was_live = live_segments[sym.index];
+    live_segments[sym.index] = true;
+    return !was_live;
 }
 
 /// Trace the call graph starting from called functions, exports, init funcs,

--- a/test/archive/platform/Host.roc
+++ b/test/archive/platform/Host.roc
@@ -2,4 +2,7 @@
 Host := [].{
     ## Double a number in the host.
     double! : I64 => I64
+
+    ## Hosted function that the platform exposes but this app never calls.
+    unused_niche_feature! : I64 => I64
 }

--- a/test/archive/platform/host.zig
+++ b/test/archive/platform/host.zig
@@ -96,31 +96,42 @@ comptime {
 /// refcounted values, so under the hosted C ABI it takes no parameters
 /// beyond its arguments.
 fn hostedHostDouble(n: i64) callconv(.c) i64 {
-    return n * 2;
+    return @call(.never_inline, sharedPrivateHelper, .{n}) * 2;
 }
 
 // --- Dead-code-elimination canaries
-// A large constant and a function that uses it, exported (hidden) but never
-// referenced by the app. Symbol-ABI links must strip both from the final
-// artifact; tests scan the output for the distinctive byte pattern.
-const dce_canary_blob: [4096]u8 = blk: {
+// The dead hosted function owns one private constant, calls one dead-only
+// private helper with its own constant, and also calls a shared private helper
+// used by live Host.double!. Final-link section GC must drop the dead-only
+// data while keeping the shared helper/data alive.
+fn canaryBlob(comptime marker: []const u8) [4096]u8 {
     @setEvalBranchQuota(20000);
     var blob: [4096]u8 = undefined;
-    const marker = "ROC_DCE_CANARY_BLOB_7f3a9c";
     var i: usize = 0;
     while (i < blob.len) : (i += 1) {
         blob[i] = marker[i % marker.len];
     }
-    break :blk blob;
-};
+    return blob;
+}
+
+const dead_hosted_canary_blob = canaryBlob("ROC_DCE_CANARY_BLOB_7f3a9c");
+const dead_helper_canary_blob = canaryBlob("ROC_DCE_DEAD_HELPER_BLOB_28d0aa");
+const shared_canary_blob = canaryBlob("ROC_DCE_SHARED_BLOB_93e2c1");
+
+fn sharedPrivateHelper(n: i64) i64 {
+    std.mem.doNotOptimizeAway(&shared_canary_blob);
+    return n;
+}
+
+fn deadOnlyPrivateHelper(n: i64) i64 {
+    std.mem.doNotOptimizeAway(&dead_helper_canary_blob);
+    return n + 1;
+}
 
 fn hostUnusedNicheFeature(n: i64) callconv(.c) i64 {
-    // Touch every byte so the blob cannot be dropped independently.
-    var acc: i64 = n;
-    for (dce_canary_blob) |byte| {
-        acc +%= byte;
-    }
-    return acc;
+    std.mem.doNotOptimizeAway(&dead_hosted_canary_blob);
+    const dead_value = @call(.never_inline, deadOnlyPrivateHelper, .{n});
+    return @call(.never_inline, sharedPrivateHelper, .{dead_value});
 }
 
 comptime {

--- a/test/archive/platform/main.roc
+++ b/test/archive/platform/main.roc
@@ -5,7 +5,10 @@ platform ""
     exposes [Host]
     packages {}
     provides { "roc_main": main_for_host! }
-    hosted { "roc_host_double": Host.double! }
+    hosted {
+        "roc_host_double": Host.double!,
+        "roc_host_unused_niche_feature": Host.unused_niche_feature!,
+    }
     targets: {
         inputs: "targets/",
         x64mac: { inputs: ["libhost.a", app], output: Archive },

--- a/test/dylib/platform/Host.roc
+++ b/test/dylib/platform/Host.roc
@@ -2,4 +2,7 @@
 Host := [].{
     ## Double a number in the host.
     double! : I64 => I64
+
+    ## Hosted function that the platform exposes but this app never calls.
+    unused_niche_feature! : I64 => I64
 }

--- a/test/dylib/platform/host.zig
+++ b/test/dylib/platform/host.zig
@@ -96,31 +96,42 @@ comptime {
 /// refcounted values, so under the hosted C ABI it takes no parameters
 /// beyond its arguments.
 fn hostedHostDouble(n: i64) callconv(.c) i64 {
-    return n * 2;
+    return @call(.never_inline, sharedPrivateHelper, .{n}) * 2;
 }
 
 // --- Dead-code-elimination canaries
-// A large constant and a function that uses it, exported (hidden) but never
-// referenced by the app. Symbol-ABI links must strip both from the final
-// artifact; tests scan the output for the distinctive byte pattern.
-const dce_canary_blob: [4096]u8 = blk: {
+// The dead hosted function owns one private constant, calls one dead-only
+// private helper with its own constant, and also calls a shared private helper
+// used by live Host.double!. Final-link section GC must drop the dead-only
+// data while keeping the shared helper/data alive.
+fn canaryBlob(comptime marker: []const u8) [4096]u8 {
     @setEvalBranchQuota(20000);
     var blob: [4096]u8 = undefined;
-    const marker = "ROC_DCE_CANARY_BLOB_7f3a9c";
     var i: usize = 0;
     while (i < blob.len) : (i += 1) {
         blob[i] = marker[i % marker.len];
     }
-    break :blk blob;
-};
+    return blob;
+}
+
+const dead_hosted_canary_blob = canaryBlob("ROC_DCE_CANARY_BLOB_7f3a9c");
+const dead_helper_canary_blob = canaryBlob("ROC_DCE_DEAD_HELPER_BLOB_28d0aa");
+const shared_canary_blob = canaryBlob("ROC_DCE_SHARED_BLOB_93e2c1");
+
+fn sharedPrivateHelper(n: i64) i64 {
+    std.mem.doNotOptimizeAway(&shared_canary_blob);
+    return n;
+}
+
+fn deadOnlyPrivateHelper(n: i64) i64 {
+    std.mem.doNotOptimizeAway(&dead_helper_canary_blob);
+    return n + 1;
+}
 
 fn hostUnusedNicheFeature(n: i64) callconv(.c) i64 {
-    // Touch every byte so the blob cannot be dropped independently.
-    var acc: i64 = n;
-    for (dce_canary_blob) |byte| {
-        acc +%= byte;
-    }
-    return acc;
+    std.mem.doNotOptimizeAway(&dead_hosted_canary_blob);
+    const dead_value = @call(.never_inline, deadOnlyPrivateHelper, .{n});
+    return @call(.never_inline, sharedPrivateHelper, .{dead_value});
 }
 
 comptime {

--- a/test/dylib/platform/main.roc
+++ b/test/dylib/platform/main.roc
@@ -5,7 +5,10 @@ platform ""
     exposes [Host]
     packages {}
     provides { "roc_main": main_for_host! }
-    hosted { "roc_host_double": Host.double! }
+    hosted {
+        "roc_host_double": Host.double!,
+        "roc_host_unused_niche_feature": Host.unused_niche_feature!,
+    }
     targets: {
         inputs: "targets/",
         x64mac: { inputs: ["libhost.a", app], output: Shared },

--- a/test/wasm/platform/Stdout.roc
+++ b/test/wasm/platform/Stdout.roc
@@ -1,3 +1,4 @@
 Stdout := [].{
     line! : Str => {}
+    unused_niche_feature! : I64 => I64
 }

--- a/test/wasm/platform/host.zig
+++ b/test/wasm/platform/host.zig
@@ -27,6 +27,8 @@ const env_imports = struct {
     extern "env" fn roc_dbg(ptr: [*]const u8, len: usize) void;
     extern "env" fn roc_expect_failed(ptr: [*]const u8, len: usize) void;
     extern "env" fn echo(ptr: [*]const u8, len: usize) void;
+    extern "env" fn roc_unused_host_canary_7f3a9c(value: i64) void;
+    extern "env" fn roc_dead_private_helper_canary_41d2cb(value: i64) void;
 };
 
 // Use Zig's standard WASM allocator for proper memory management
@@ -201,8 +203,45 @@ export fn roc_crashed(bytes: [*]const u8, len: usize) callconv(.c) void {
 // transfers here, and the bytes are echoed before it is freed at module
 // teardown (this host never frees individual strings).
 export fn roc_stdout_line(str: RocStr) callconv(.c) void {
+    @call(.never_inline, sharedPrivateHelper, .{});
     const s = str.asSlice();
     env_imports.echo(s.ptr, s.len);
+}
+
+fn canaryBlob(comptime marker: []const u8) [4096]u8 {
+    @setEvalBranchQuota(20000);
+    var blob: [4096]u8 = undefined;
+    var i: usize = 0;
+    while (i < blob.len) : (i += 1) {
+        blob[i] = marker[i % marker.len];
+    }
+    return blob;
+}
+
+const wasm_dead_hosted_canary_blob = canaryBlob("ROC_DCE_WASM_DEAD_HOSTED_BLOB_0ac91d");
+const wasm_dead_helper_canary_blob = canaryBlob("ROC_DCE_WASM_DEAD_HELPER_BLOB_f25a77");
+const wasm_shared_canary_blob = canaryBlob("ROC_DCE_WASM_SHARED_BLOB_31e82f");
+
+fn sharedPrivateHelper() void {
+    std.mem.doNotOptimizeAway(&wasm_shared_canary_blob);
+}
+
+fn deadOnlyPrivateHelper(n: i64) i64 {
+    std.mem.doNotOptimizeAway(&wasm_dead_helper_canary_blob);
+    env_imports.roc_dead_private_helper_canary_41d2cb(n);
+    return n + 1;
+}
+
+fn hostedUnusedNicheFeature(n: i64) callconv(.c) i64 {
+    std.mem.doNotOptimizeAway(&wasm_dead_hosted_canary_blob);
+    env_imports.roc_unused_host_canary_7f3a9c(n);
+    const dead_value = @call(.never_inline, deadOnlyPrivateHelper, .{n});
+    @call(.never_inline, sharedPrivateHelper, .{});
+    return dead_value + 1;
+}
+
+comptime {
+    @export(&hostedUnusedNicheFeature, .{ .name = "roc_stdout_unused_niche_feature", .visibility = .hidden });
 }
 
 // The app's entrypoint, exported under its provides symbol with its natural

--- a/test/wasm/platform/main.roc
+++ b/test/wasm/platform/main.roc
@@ -3,7 +3,10 @@ platform ""
     exposes [Stdout]
     packages {}
     provides { "roc_main": main_for_host! }
-    hosted { "roc_stdout_line": Stdout.line! }
+    hosted {
+        "roc_stdout_line": Stdout.line!,
+        "roc_stdout_unused_niche_feature": Stdout.unused_niche_feature!,
+    }
     targets: {
         inputs: "targets/",
         wasm32: { inputs: ["host.wasm", app] },


### PR DESCRIPTION
This adds build-level coverage that platform-declared hosted functions which are exposed to an app but never called are removed from the final linked artifact, including their private transitive helper/data dependencies. The archive, dylib, and wasm fixtures now distinguish dead-only canaries from a shared canary used by both live and dead hosted paths, so the tests verify dead-only code/data disappears while shared dependencies remain. The wasm final-link DCE now also prunes data segments using explicit relocation reachability from live functions and live data.