### PR TITLE
Skip impossible tag payloads in exhaustiveness

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -7065,6 +7065,7 @@ fn finishSuffixSingleQuestionExpr(
         .branches = branches_span,
         .exhaustive = try self.env.types.fresh(),
         .is_try_suffix = true,
+        .skip_exhaustiveness = true,
     };
     const expr_idx = try self.env.addExpr(CIR.Expr{ .e_match = match_expr }, region);
 
@@ -10953,6 +10954,7 @@ fn runExprKernel(
                     .branches = branches_span,
                     .exhaustive = try self.env.types.fresh(),
                     .is_try_suffix = false,
+                    .skip_exhaustiveness = false,
                 };
                 const expr_idx = try self.env.addExpr(CIR.Expr{ .e_match = match_expr }, state.region);
                 const free_vars_span = self.scratch_free_vars.spanFrom(state.free_vars_start);
@@ -11449,6 +11451,7 @@ fn canonicalizeDoubleQuestionOp(
         .branches = branches_span,
         .exhaustive = try self.env.types.fresh(),
         .is_try_suffix = false,
+        .skip_exhaustiveness = true,
     };
     const expr_idx = try self.env.addExpr(CIR.Expr{ .e_match = match_expr }, region);
 

--- a/src/canonicalize/Expression.zig
+++ b/src/canonicalize/Expression.zig
@@ -1532,6 +1532,9 @@ pub const Expr = union(enum) {
         /// Whether this match was desugared from the `?` (try suffix) operator.
         /// When true, we need to verify the condition is actually a Try type.
         is_try_suffix: bool,
+        /// Whether to skip user-facing exhaustiveness/redundancy diagnostics for this match.
+        /// This is true for compiler-generated matches such as `?` and `??` desugarings.
+        skip_exhaustiveness: bool,
 
         pub const Idx = enum(u32) { _ };
         pub const Span = extern struct { span: base.DataSpan };

--- a/src/canonicalize/Node.zig
+++ b/src/canonicalize/Node.zig
@@ -578,7 +578,7 @@ pub const Payload = extern union {
     };
 
     pub const ExprMatch = extern struct {
-        match_data_idx: u32, // Index into match_data: (cond, branches_start, branches_len, exhaustive, is_try_suffix)
+        match_data_idx: u32, // Index into match_data: (cond, branches_start, branches_len, exhaustive, is_try_suffix, skip_exhaustiveness)
         _padding: [8]u8 = .{ 0, 0, 0, 0, 0, 0, 0, 0 },
     };
 

--- a/src/canonicalize/NodeStore.zig
+++ b/src/canonicalize/NodeStore.zig
@@ -63,13 +63,14 @@ pub const MethodCallData = extern struct {
 };
 
 /// Match expression data.
-/// Stores cond, branches span, exhaustive flag, and is_try_suffix flag.
+/// Stores cond, branches span, exhaustive flag, try-suffix flag, and exhaustiveness-reporting flag.
 pub const MatchData = extern struct {
     cond: u32,
     branches_start: u32,
     branches_len: u32,
     exhaustive: u32,
     is_try_suffix: u32,
+    skip_exhaustiveness: u32,
 };
 
 /// Match branch data.
@@ -921,6 +922,7 @@ pub fn getExpr(store: *const NodeStore, expr: CIR.Expr.Idx) CIR.Expr {
                     .branches = .{ .span = .{ .start = md.branches_start, .len = md.branches_len } },
                     .exhaustive = @enumFromInt(md.exhaustive),
                     .is_try_suffix = md.is_try_suffix != 0,
+                    .skip_exhaustiveness = md.skip_exhaustiveness != 0,
                 },
             };
         },
@@ -2367,6 +2369,7 @@ pub fn addExpr(store: *NodeStore, expr: CIR.Expr, region: base.Region) Allocator
                 .branches_len = e.branches.span.len,
                 .exhaustive = @intFromEnum(e.exhaustive),
                 .is_try_suffix = @intFromBool(e.is_try_suffix),
+                .skip_exhaustiveness = @intFromBool(e.skip_exhaustiveness),
             });
 
             node.setPayload(.{ .expr_match = .{

--- a/src/canonicalize/test/node_store_test.zig
+++ b/src/canonicalize/test/node_store_test.zig
@@ -298,6 +298,7 @@ test "NodeStore round trip - Expressions" {
             .branches = CIR.Expr.Match.Branch.Span{ .span = rand_span() },
             .exhaustive = rand_idx(TypeVar),
             .is_try_suffix = false,
+            .skip_exhaustiveness = false,
         },
     });
     try expressions.append(gpa, CIR.Expr{

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -7738,7 +7738,6 @@ fn checkDestructureExhaustiveness(
         self.exhaustiveBuiltinIdents(),
         pattern_idx,
         value_var,
-        region,
         known_empty_payload_vars.items,
         value_constructors_known,
     ) catch |err| switch (err) {

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -3382,8 +3382,10 @@ fn checkDef(self: *Self, def_idx: CIR.Def.Idx, env: *Env) std.mem.Allocator.Erro
     try self.setVarRank(def_var, env);
     try self.setVarRank(ptrn_var, env);
 
+    const def_pattern_ctx: PatternCtx = if (self.patternNeedsExhaustiveness(def.pattern)) .match_branch else .bound;
+
     // Check the pattern
-    try self.checkPattern(def.pattern, .bound, env);
+    try self.checkPattern(def.pattern, def_pattern_ctx, env);
 
     // Extract function name from the pattern (for better error messages)
     const saved_func_name = self.enclosing_func_name;
@@ -3414,6 +3416,7 @@ fn checkDef(self: *Self, def_idx: CIR.Def.Idx, env: *Env) std.mem.Allocator.Erro
     if (def.annotation == null and self.erroneous_value_exprs.contains(def.expr)) {
         try self.erroneous_value_patterns.put(self.gpa, def.pattern, {});
     }
+    try self.closeAbsentConstructedPayloadVars(def.expr, expr_var);
 
     if (self.defer_generalize) {
         // defer_generalize is only set when a cycle root has been identified.
@@ -3429,10 +3432,15 @@ fn checkDef(self: *Self, def_idx: CIR.Def.Idx, env: *Env) std.mem.Allocator.Erro
         });
     } else {
         // Unify the ptrn and the expr
-        _ = try self.unify(ptrn_var, expr_var, env);
+        const ptrn_result = try self.unify(ptrn_var, expr_var, env);
 
         // Unify the def and ptrn
         _ = try self.unify(def_var, ptrn_var, env);
+
+        if (ptrn_result.isOk()) {
+            const def_region = self.cir.store.getNodeRegion(ModuleEnv.nodeIdxFrom(def.pattern));
+            try self.checkDestructureExhaustiveness(def.pattern, def.expr, expr_var, env, def_region);
+        }
     }
 
     // Mark as processed
@@ -5152,6 +5160,43 @@ fn getPatternIdent(self: *const Self, ptrn_idx: CIR.Pattern.Idx) ?Ident.Idx {
     }
 }
 
+fn patternNeedsExhaustiveness(self: *const Self, pattern_idx: CIR.Pattern.Idx) bool {
+    const pattern = self.cir.store.getPattern(pattern_idx);
+    return switch (pattern) {
+        .assign, .underscore, .runtime_error => false,
+        .as => |as_pattern| self.patternNeedsExhaustiveness(as_pattern.pattern),
+        .applied_tag,
+        .list,
+        .num_literal,
+        .small_dec_literal,
+        .dec_literal,
+        .frac_f32_literal,
+        .frac_f64_literal,
+        .str_literal,
+        => true,
+        .tuple => |tuple| {
+            for (self.cir.store.slicePatterns(tuple.patterns)) |elem_pattern_idx| {
+                if (self.patternNeedsExhaustiveness(elem_pattern_idx)) return true;
+            }
+            return false;
+        },
+        .record_destructure => |destructure| {
+            for (self.cir.store.sliceRecordDestructs(destructure.destructs)) |destruct_idx| {
+                const destruct = self.cir.store.getRecordDestruct(destruct_idx);
+                const sub_pattern_idx = switch (destruct.kind) {
+                    .Required => |sub_pattern| sub_pattern,
+                    .SubPattern => |sub_pattern| sub_pattern,
+                    .Rest => |sub_pattern| sub_pattern,
+                };
+                if (self.patternNeedsExhaustiveness(sub_pattern_idx)) return true;
+            }
+            return false;
+        },
+        .nominal => |nominal| self.patternNeedsExhaustiveness(nominal.backing_pattern),
+        .nominal_external => |nominal| self.patternNeedsExhaustiveness(nominal.backing_pattern),
+    };
+}
+
 const PatternBinding = struct {
     ident: Ident.Idx,
     pattern_idx: CIR.Pattern.Idx,
@@ -6353,9 +6398,14 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
             // If we have an expected function, use that as the expr's expected type
             const body_does_fx = if (mb_anno_func) |expected_func| blk: {
                 const lambda_body_does_fx = try self.checkExpr(lambda.body, env, Expected.none().withBranchResult(expected_func.ret));
+                try self.closeAbsentConstructedPayloadVars(lambda.body, body_var);
                 _ = try self.unifyInContext(expected_func.ret, body_var, env, .type_annotation);
                 break :blk lambda_body_does_fx;
-            } else try self.checkExpr(lambda.body, env, Expected.none());
+            } else blk: {
+                const lambda_body_does_fx = try self.checkExpr(lambda.body, env, Expected.none());
+                try self.closeAbsentConstructedPayloadVars(lambda.body, body_var);
+                break :blk lambda_body_does_fx;
+            };
 
             // Process any pending return constraints (from early returns / ? operator) before
             // creating the function type. This must happen after the body is fully checked
@@ -7498,6 +7548,234 @@ fn exprAlwaysCrashes(self: *const Self, expr_idx: CIR.Expr.Idx) bool {
     };
 }
 
+fn exhaustiveBuiltinIdents(self: *const Self) exhaustive.BuiltinIdents {
+    return .{
+        .builtin_module = self.cir.idents.builtin_module,
+        .u8_type = self.cir.idents.u8_type,
+        .i8_type = self.cir.idents.i8_type,
+        .u16_type = self.cir.idents.u16_type,
+        .i16_type = self.cir.idents.i16_type,
+        .u32_type = self.cir.idents.u32_type,
+        .i32_type = self.cir.idents.i32_type,
+        .u64_type = self.cir.idents.u64_type,
+        .i64_type = self.cir.idents.i64_type,
+        .u128_type = self.cir.idents.u128_type,
+        .i128_type = self.cir.idents.i128_type,
+        .f32_type = self.cir.idents.f32_type,
+        .f64_type = self.cir.idents.f64_type,
+        .dec_type = self.cir.idents.dec_type,
+        .u8 = self.cir.idents.u8,
+        .i8 = self.cir.idents.i8,
+        .u16 = self.cir.idents.u16,
+        .i16 = self.cir.idents.i16,
+        .u32 = self.cir.idents.u32,
+        .i32 = self.cir.idents.i32,
+        .u64 = self.cir.idents.u64,
+        .i64 = self.cir.idents.i64,
+        .u128 = self.cir.idents.u128,
+        .i128 = self.cir.idents.i128,
+        .f32 = self.cir.idents.f32,
+        .f64 = self.cir.idents.f64,
+        .dec = self.cir.idents.dec,
+    };
+}
+
+fn closeExhaustiveVars(
+    self: *Self,
+    result: exhaustive.CheckResult,
+    env: *Env,
+    region: Region,
+) std.mem.Allocator.Error!void {
+    for (result.ext_vars_to_close) |ext_var| {
+        const empty_tu_var = try self.freshFromContent(.{ .structure = .empty_tag_union }, env, region);
+        _ = try self.unify(ext_var, empty_tu_var, env);
+    }
+
+    for (result.payload_vars_to_close) |payload_var| {
+        try self.closePayloadVarToEmpty(payload_var);
+    }
+}
+
+fn appendUniqueIdent(gpa: std.mem.Allocator, out: *std.ArrayList(Ident.Idx), ident: Ident.Idx) Allocator.Error!void {
+    for (out.items) |existing| {
+        if (existing.eql(ident)) return;
+    }
+    try out.append(gpa, ident);
+}
+
+fn collectConstructedTagsForExpr(
+    self: *Self,
+    expr_idx: CIR.Expr.Idx,
+    out: *std.ArrayList(Ident.Idx),
+) Allocator.Error!bool {
+    const expr = self.cir.store.getExpr(expr_idx);
+    switch (expr) {
+        .e_zero_argument_tag => |tag| {
+            try appendUniqueIdent(self.gpa, out, tag.name);
+            return true;
+        },
+        .e_tag => |tag| {
+            try appendUniqueIdent(self.gpa, out, tag.name);
+            return true;
+        },
+        .e_nominal => |nominal| {
+            return self.collectConstructedTagsForExpr(nominal.backing_expr, out);
+        },
+        .e_nominal_external => |nominal| {
+            return self.collectConstructedTagsForExpr(nominal.backing_expr, out);
+        },
+        .e_block => |block| {
+            return self.collectConstructedTagsForExpr(block.final_expr, out);
+        },
+        .e_if => |if_expr| {
+            const branches = self.cir.store.sliceIfBranches(if_expr.branches);
+            for (branches) |branch_idx| {
+                const branch = self.cir.store.getIfBranch(branch_idx);
+                if (!try self.collectConstructedTagsForExpr(branch.body, out)) return false;
+            }
+            return self.collectConstructedTagsForExpr(if_expr.final_else, out);
+        },
+        .e_match => |match_expr| {
+            const branches = self.cir.store.sliceMatchBranches(match_expr.branches);
+            for (branches) |branch_idx| {
+                const branch = self.cir.store.getMatchBranch(branch_idx);
+                if (!try self.collectConstructedTagsForExpr(branch.value, out)) return false;
+            }
+            return true;
+        },
+        else => return false,
+    }
+}
+
+fn collectAbsentCtorPayloadBlockers(
+    self: *Self,
+    target_var: Var,
+    constructed_tags: []const Ident.Idx,
+    out: *std.ArrayList(Var),
+) Allocator.Error!void {
+    var arena = std.heap.ArenaAllocator.init(self.gpa);
+    defer arena.deinit();
+
+    try exhaustive.collectAbsentCtorPayloadBlockersForConstructedTags(
+        arena.allocator(),
+        self.types,
+        self.exhaustiveBuiltinIdents(),
+        target_var,
+        constructed_tags,
+        out,
+    );
+}
+
+fn payloadVarCanResolveToEmpty(content: Content) bool {
+    return switch (content) {
+        .flex => |flex| flex.constraints.len() == 0 and if (flex.name) |name| name.attributes.ignored else true,
+        .rigid => |rigid| rigid.constraints.len() == 0 and rigid.name.attributes.ignored,
+        else => false,
+    };
+}
+
+fn closePayloadVarToEmpty(
+    self: *Self,
+    payload_var: Var,
+) Allocator.Error!void {
+    const empty_content = Content{ .structure = .empty_tag_union };
+    const resolved = self.types.resolveVar(payload_var);
+    if (payloadVarCanResolveToEmpty(resolved.desc.content)) {
+        try self.types.setVarContent(resolved.var_, empty_content);
+    }
+}
+
+fn collectKnownEmptyPayloadVarsForExpr(
+    self: *Self,
+    expr_idx: CIR.Expr.Idx,
+    target_var: Var,
+    out: *std.ArrayList(Var),
+) Allocator.Error!bool {
+    var constructed_tags: std.ArrayList(Ident.Idx) = .empty;
+    defer constructed_tags.deinit(self.gpa);
+
+    const known = try self.collectConstructedTagsForExpr(expr_idx, &constructed_tags);
+    if (!known) return false;
+    if (constructed_tags.items.len == 0) return true;
+
+    try self.collectAbsentCtorPayloadBlockers(target_var, constructed_tags.items, out);
+    return true;
+}
+
+fn closeAbsentConstructedPayloadVars(
+    self: *Self,
+    expr_idx: CIR.Expr.Idx,
+    target_var: Var,
+) Allocator.Error!void {
+    var payload_vars_to_close: std.ArrayList(Var) = .empty;
+    defer payload_vars_to_close.deinit(self.gpa);
+
+    _ = try self.collectKnownEmptyPayloadVarsForExpr(expr_idx, target_var, &payload_vars_to_close);
+
+    for (payload_vars_to_close.items) |payload_var| {
+        try self.closePayloadVarToEmpty(payload_var);
+    }
+}
+
+fn checkDestructureExhaustiveness(
+    self: *Self,
+    pattern_idx: CIR.Pattern.Idx,
+    value_expr_idx: CIR.Expr.Idx,
+    value_var: Var,
+    env: *Env,
+    region: Region,
+) std.mem.Allocator.Error!void {
+    if (!self.patternNeedsExhaustiveness(pattern_idx)) return;
+
+    var known_empty_payload_vars: std.ArrayList(Var) = .empty;
+    defer known_empty_payload_vars.deinit(self.gpa);
+    const value_constructors_known = try self.collectKnownEmptyPayloadVarsForExpr(value_expr_idx, value_var, &known_empty_payload_vars);
+
+    const result = exhaustive.checkDestructure(
+        self.cir.gpa,
+        self.types,
+        &self.cir.store,
+        self.exhaustiveBuiltinIdents(),
+        pattern_idx,
+        value_var,
+        region,
+        known_empty_payload_vars.items,
+        value_constructors_known,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.TypeError => return,
+    };
+    defer result.deinit(self.cir.gpa);
+
+    try self.closeExhaustiveVars(result, env, region);
+
+    if (!result.is_exhaustive) {
+        const value_snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, value_var);
+        const missing_patterns_start = self.problems.missing_patterns_backing.items.len;
+
+        for (result.missing_patterns) |pattern| {
+            const idx = try exhaustive.formatPattern(
+                &self.problems.extra_strings_backing,
+                &self.cir.common.idents,
+                &self.cir.common.strings,
+                pattern,
+            );
+            try self.problems.missing_patterns_backing.append(idx);
+        }
+
+        const missing_patterns_range = problem.MissingPatternsRange{
+            .start = missing_patterns_start,
+            .count = self.problems.missing_patterns_backing.items.len - missing_patterns_start,
+        };
+
+        _ = try self.problems.appendProblem(self.gpa, .{ .non_exhaustive_destructure = .{
+            .pattern = pattern_idx,
+            .value_snapshot = value_snapshot,
+            .missing_patterns = missing_patterns_range,
+        } });
+    }
+}
+
 // stmts //
 
 const BlockStatementsResult = struct {
@@ -7526,8 +7804,10 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                 const decl_expr_var: Var = ModuleEnv.varFrom(decl_stmt.expr);
                 const decl_pattern_var: Var = ModuleEnv.varFrom(decl_stmt.pattern);
 
+                const decl_pattern_ctx: PatternCtx = if (self.patternNeedsExhaustiveness(decl_stmt.pattern)) .match_branch else .bound;
+
                 // Check the pattern
-                try self.checkPattern(decl_stmt.pattern, .bound, env);
+                try self.checkPattern(decl_stmt.pattern, decl_pattern_ctx, env);
 
                 // Extract function name from the pattern (for better error messages)
                 const saved_func_name = self.enclosing_func_name;
@@ -7564,9 +7844,14 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                 if (decl_stmt.anno == null and self.erroneous_value_exprs.contains(decl_stmt.expr)) {
                     try self.erroneous_value_patterns.put(self.gpa, decl_stmt.pattern, {});
                 }
+                try self.closeAbsentConstructedPayloadVars(decl_stmt.expr, decl_expr_var);
 
-                _ = try self.unify(decl_pattern_var, decl_expr_var, env);
+                const decl_pattern_result = try self.unify(decl_pattern_var, decl_expr_var, env);
                 _ = try self.unify(stmt_var, decl_pattern_var, env);
+
+                if (decl_pattern_result.isOk()) {
+                    try self.checkDestructureExhaustiveness(decl_stmt.pattern, decl_stmt.expr, decl_expr_var, env, stmt_region);
+                }
 
                 if (decl_is_fn) {
                     // The def's lambda has generalized (inside checkExpr) and the
@@ -7577,8 +7862,10 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                 }
             },
             .s_var => |var_stmt| {
+                const var_pattern_ctx: PatternCtx = if (self.patternNeedsExhaustiveness(var_stmt.pattern_idx)) .match_branch else .bound;
+
                 // Check the pattern
-                try self.checkPattern(var_stmt.pattern_idx, .bound, env);
+                try self.checkPattern(var_stmt.pattern_idx, var_pattern_ctx, env);
                 const var_pattern_var: Var = ModuleEnv.varFrom(var_stmt.pattern_idx);
 
                 // Check the annotation, if it exists
@@ -7596,9 +7883,14 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                     try self.erroneous_value_patterns.put(self.gpa, var_stmt.pattern_idx, {});
                 }
                 const var_expr: Var = ModuleEnv.varFrom(var_stmt.expr);
+                try self.closeAbsentConstructedPayloadVars(var_stmt.expr, var_expr);
 
-                _ = try self.unify(var_pattern_var, var_expr, env);
+                const var_pattern_result = try self.unify(var_pattern_var, var_expr, env);
                 _ = try self.unify(stmt_var, var_expr, env);
+
+                if (var_pattern_result.isOk()) {
+                    try self.checkDestructureExhaustiveness(var_stmt.pattern_idx, var_stmt.expr, var_expr, env, stmt_region);
+                }
             },
             .s_reassign => |reassign| {
                 // Reassignment patterns can mix existing mutable binders with
@@ -7606,20 +7898,26 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                 // The pattern occurrence itself must therefore always be
                 // checked here so its structural type and any fresh binders are
                 // established explicitly before we unify it with the RHS.
-                try self.checkPattern(reassign.pattern_idx, .bound, env);
+                const reassign_pattern_ctx: PatternCtx = if (self.patternNeedsExhaustiveness(reassign.pattern_idx)) .match_branch else .bound;
+                try self.checkPattern(reassign.pattern_idx, reassign_pattern_ctx, env);
 
                 const reassign_pattern_var: Var = ModuleEnv.varFrom(reassign.pattern_idx);
 
                 does_fx = try self.checkExpr(reassign.expr, env, Expected.none()) or does_fx;
                 const reassign_expr_var: Var = ModuleEnv.varFrom(reassign.expr);
+                try self.closeAbsentConstructedPayloadVars(reassign.expr, reassign_expr_var);
 
                 // Unify the pattern with the expression
                 //
                 // TODO: if there's a mismatch here, the region of the error is
                 // the original assignment pattern, not the reassignment region
-                _ = try self.unify(reassign_pattern_var, reassign_expr_var, env);
+                const reassign_pattern_result = try self.unify(reassign_pattern_var, reassign_expr_var, env);
 
                 _ = try self.unify(stmt_var, reassign_expr_var, env);
+
+                if (reassign_pattern_result.isOk()) {
+                    try self.checkDestructureExhaustiveness(reassign.pattern_idx, reassign.expr, reassign_expr_var, env, stmt_region);
+                }
             },
             .s_for => |for_stmt| {
                 const for_region = self.cir.store.getStatementRegion(stmt_idx);
@@ -7974,6 +8272,9 @@ fn checkMatchExpr(
     var does_fx = try self.checkExpr(match.cond, env, Expected.none());
     const cond_var = ModuleEnv.varFrom(match.cond);
     const cond_always_crashes = self.exprAlwaysCrashes(match.cond);
+    if (!match.is_try_suffix) {
+        try self.closeAbsentConstructedPayloadVars(match.cond, cond_var);
+    }
 
     // Assert we have at least 1 branch
     std.debug.assert(match.branches.span.len > 0);
@@ -8177,46 +8478,23 @@ fn checkMatchExpr(
     const resolved_cond = self.types.resolveVar(cond_var);
     const cond_is_error = resolved_cond.desc.content == .err;
 
-    if (!had_type_error and !cond_is_error and !has_invalid_try and !cond_always_crashes) {
+    if (!match.is_try_suffix and !had_type_error and !cond_is_error and !has_invalid_try and !cond_always_crashes) {
         const match_region = self.getRegionAt(@enumFromInt(@intFromEnum(expr_idx)));
-        const builtin_idents = exhaustive.BuiltinIdents{
-            .builtin_module = self.cir.idents.builtin_module,
-            .u8_type = self.cir.idents.u8_type,
-            .i8_type = self.cir.idents.i8_type,
-            .u16_type = self.cir.idents.u16_type,
-            .i16_type = self.cir.idents.i16_type,
-            .u32_type = self.cir.idents.u32_type,
-            .i32_type = self.cir.idents.i32_type,
-            .u64_type = self.cir.idents.u64_type,
-            .i64_type = self.cir.idents.i64_type,
-            .u128_type = self.cir.idents.u128_type,
-            .i128_type = self.cir.idents.i128_type,
-            .f32_type = self.cir.idents.f32_type,
-            .f64_type = self.cir.idents.f64_type,
-            .dec_type = self.cir.idents.dec_type,
-            .u8 = self.cir.idents.u8,
-            .i8 = self.cir.idents.i8,
-            .u16 = self.cir.idents.u16,
-            .i16 = self.cir.idents.i16,
-            .u32 = self.cir.idents.u32,
-            .i32 = self.cir.idents.i32,
-            .u64 = self.cir.idents.u64,
-            .i64 = self.cir.idents.i64,
-            .u128 = self.cir.idents.u128,
-            .i128 = self.cir.idents.i128,
-            .f32 = self.cir.idents.f32,
-            .f64 = self.cir.idents.f64,
-            .dec = self.cir.idents.dec,
-        };
+
+        var known_empty_payload_vars: std.ArrayList(Var) = .empty;
+        defer known_empty_payload_vars.deinit(self.gpa);
+        const cond_constructors_known = try self.collectKnownEmptyPayloadVarsForExpr(match.cond, cond_var, &known_empty_payload_vars);
 
         const result = exhaustive.checkMatch(
             self.cir.gpa,
             self.types,
             &self.cir.store,
-            builtin_idents,
+            self.exhaustiveBuiltinIdents(),
             match.branches,
             cond_var,
             match_region,
+            known_empty_payload_vars.items,
+            cond_constructors_known,
         ) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             error.TypeError => {
@@ -8228,13 +8506,7 @@ fn checkMatchExpr(
         };
         defer result.deinit(self.cir.gpa);
 
-        // Close ext vars identified by exhaustiveness checker via proper unification.
-        // These are tag union positions where all constructors were exhaustively
-        // covered without wildcards (open unions that should become closed).
-        for (result.ext_vars_to_close) |ext_var| {
-            const empty_tu_var = try self.freshFromContent(.{ .structure = .empty_tag_union }, env, match_region);
-            _ = try self.unify(ext_var, empty_tu_var, env);
-        }
+        try self.closeExhaustiveVars(result, env, match_region);
 
         // Report non-exhaustive match if any patterns are missing
         if (!result.is_exhaustive) {

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -8477,7 +8477,7 @@ fn checkMatchExpr(
     const resolved_cond = self.types.resolveVar(cond_var);
     const cond_is_error = resolved_cond.desc.content == .err;
 
-    if (!match.is_try_suffix and !had_type_error and !cond_is_error and !has_invalid_try and !cond_always_crashes) {
+    if (!match.skip_exhaustiveness and !had_type_error and !cond_is_error and !has_invalid_try and !cond_always_crashes) {
         const match_region = self.getRegionAt(@enumFromInt(@intFromEnum(expr_idx)));
 
         var known_empty_payload_vars: std.ArrayList(Var) = .empty;

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -4957,6 +4957,7 @@ pub const CheckedExprData = union(enum) {
         cond: CheckedExprId,
         branches: []const CheckedMatchBranch,
         is_try_suffix: bool,
+        skip_exhaustiveness: bool,
     },
     if_: struct {
         branches: []const CheckedIfBranch,
@@ -6537,6 +6538,7 @@ const CheckedBodyPayloadCopier = struct {
                 .cond = self.checkedExpr(match.cond),
                 .branches = try self.copyMatchBranches(match.branches),
                 .is_try_suffix = match.is_try_suffix,
+                .skip_exhaustiveness = match.skip_exhaustiveness,
             } },
             .e_if => |if_| .{ .if_ = .{
                 .branches = try self.copyIfBranches(if_.branches),

--- a/src/check/exhaustive.zig
+++ b/src/check/exhaustive.zig
@@ -1319,6 +1319,7 @@ fn isCtorPayloadTagUnionInhabited(
     }
 }
 
+/// Collects unresolved unbound type variables that make a constructor payload uninhabited.
 pub fn collectCtorPayloadBlockers(
     type_store: *TypeStore,
     builtin_idents: BuiltinIdents,

--- a/src/check/exhaustive.zig
+++ b/src/check/exhaustive.zig
@@ -202,11 +202,20 @@ pub const Pattern = union(enum) {
     /// A pattern is uninhabited if it matches a type with no possible values,
     /// such as an empty tag union or a constructor with uninhabited arguments.
     pub fn isInhabited(self: Pattern, type_store: *TypeStore, builtin_idents: BuiltinIdents) error{OutOfMemory}!bool {
+        return self.isInhabitedWithKnownEmpty(type_store, builtin_idents, &.{});
+    }
+
+    pub fn isInhabitedWithKnownEmpty(
+        self: Pattern,
+        type_store: *TypeStore,
+        builtin_idents: BuiltinIdents,
+        known_empty_vars: []const Var,
+    ) error{OutOfMemory}!bool {
         return switch (self) {
             .anything => |maybe_type| {
                 if (maybe_type) |type_var| {
                     // Check if the type is inhabited using our comprehensive check
-                    return isTypeInhabited(type_store, builtin_idents, type_var);
+                    return isTypeInhabitedWithKnownEmpty(type_store, builtin_idents, type_var, known_empty_vars);
                 }
                 // Wildcards without type info should only occur in intermediate patterns
                 // during matrix specialization, which should never be checked for inhabitedness.
@@ -225,7 +234,7 @@ pub const Pattern = union(enum) {
 
                 // All arguments must be inhabited for the pattern to be inhabited
                 for (c.args) |arg| {
-                    if (!try arg.isInhabited(type_store, builtin_idents)) return false;
+                    if (!try arg.isInhabitedWithKnownEmpty(type_store, builtin_idents, known_empty_vars)) return false;
                 }
                 return true;
             },
@@ -233,7 +242,7 @@ pub const Pattern = union(enum) {
             .list => |l| {
                 // All elements must be inhabited
                 for (l.elements) |elem| {
-                    if (!try elem.isInhabited(type_store, builtin_idents)) return false;
+                    if (!try elem.isInhabitedWithKnownEmpty(type_store, builtin_idents, known_empty_vars)) return false;
                 }
                 return true;
             },
@@ -979,6 +988,24 @@ const WorkItem = union(enum) {
 /// This implementation uses a work-list algorithm to avoid stack overflow on
 /// deeply nested types. See docs/exhaustiveness/004_worklist_inhabitedness_algorithm.md
 fn isTypeInhabited(type_store: *TypeStore, builtin_idents: BuiltinIdents, type_var: Var) error{OutOfMemory}!bool {
+    return isTypeInhabitedWithKnownEmpty(type_store, builtin_idents, type_var, &.{});
+}
+
+fn varIsKnownEmpty(type_store: *TypeStore, known_empty_vars: []const Var, type_var: Var) bool {
+    const resolved_var = type_store.resolveVar(type_var).var_;
+    for (known_empty_vars) |known_empty_var| {
+        const resolved_known_empty = type_store.resolveVar(known_empty_var).var_;
+        if (@intFromEnum(resolved_var) == @intFromEnum(resolved_known_empty)) return true;
+    }
+    return false;
+}
+
+fn isTypeInhabitedWithKnownEmpty(
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    type_var: Var,
+    known_empty_vars: []const Var,
+) error{OutOfMemory}!bool {
     // Use a seen set to detect cycles in recursive types
     var seen: std.AutoHashMapUnmanaged(Var, void) = .empty;
     defer seen.deinit(type_store.gpa);
@@ -1002,6 +1029,11 @@ fn isTypeInhabited(type_store: *TypeStore, builtin_idents: BuiltinIdents, type_v
                 const resolved = type_store.resolveVar(var_to_check);
                 const resolved_var = resolved.var_;
                 const content = resolved.desc.content;
+
+                if (varIsKnownEmpty(type_store, known_empty_vars, resolved_var)) {
+                    try results.append(gpa, false);
+                    continue;
+                }
 
                 // Cycle detection: if we've seen this resolved variable before,
                 // treat it as inhabited. Cycles in recursive types are considered
@@ -1109,6 +1141,8 @@ fn isTypeInhabited(type_store: *TypeStore, builtin_idents: BuiltinIdents, type_v
                 if (current) {
                     // Already inhabited, no need to check extension
                     try results.append(gpa, true);
+                } else if (varIsKnownEmpty(type_store, known_empty_vars, ext_var)) {
+                    try results.append(gpa, false);
                 } else {
                     // Check if extension is open (flex/rigid)
                     const is_open = try isExtensionOpen(type_store, ext_var);
@@ -1120,6 +1154,595 @@ fn isTypeInhabited(type_store: *TypeStore, builtin_idents: BuiltinIdents, type_v
 
     // Final result should be on top of the results stack
     return if (results.items.len > 0) results.items[0] else true;
+}
+
+fn isUnresolvedUnboundFlex(flex: types.Flex) bool {
+    return flex.constraints.len() == 0;
+}
+
+fn isUnresolvedUnboundRigid(rigid: types.Rigid) bool {
+    return rigid.constraints.len() == 0 and rigid.name.attributes.ignored;
+}
+
+fn appendUniqueVar(gpa: std.mem.Allocator, out: *std.ArrayList(Var), var_: Var) Allocator.Error!void {
+    const resolved_var = var_;
+    for (out.items) |existing| {
+        if (@intFromEnum(existing) == @intFromEnum(resolved_var)) return;
+    }
+    try out.append(gpa, resolved_var);
+}
+
+/// Check constructor payload inhabitedness.
+///
+/// This differs from general type inhabitedness only for unresolved unbound
+/// variables: as a constructor payload, one means no value of that payload type
+/// has been constructed, so the constructor is not constructible unless a later
+/// constraint has already resolved it to a concrete type.
+pub fn isCtorPayloadTypeInhabited(
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    type_var: Var,
+) error{OutOfMemory}!bool {
+    var seen: std.AutoHashMapUnmanaged(Var, void) = .empty;
+    defer seen.deinit(type_store.gpa);
+    return isCtorPayloadTypeInhabitedHelp(type_store, builtin_idents, type_var, &seen);
+}
+
+fn isCtorPayloadTypeInhabitedHelp(
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    type_var: Var,
+    seen: *std.AutoHashMapUnmanaged(Var, void),
+) error{OutOfMemory}!bool {
+    const resolved = type_store.resolveVar(type_var);
+    const content = resolved.desc.content;
+
+    switch (content) {
+        .flex => |flex| return !isUnresolvedUnboundFlex(flex),
+        .rigid => |rigid| return !isUnresolvedUnboundRigid(rigid),
+        .err => return true,
+        else => {},
+    }
+
+    const gop = try seen.getOrPut(type_store.gpa, resolved.var_);
+    if (gop.found_existing) return true;
+
+    return switch (content) {
+        .flex, .rigid, .err => unreachable,
+        .alias => |alias| blk: {
+            if (builtin_idents.isBuiltinNumericIdent(alias.ident.ident_idx)) {
+                break :blk true;
+            }
+            break :blk try isCtorPayloadTypeInhabitedHelp(
+                type_store,
+                builtin_idents,
+                type_store.getAliasBackingVar(alias),
+                seen,
+            );
+        },
+        .structure => |flat_type| switch (flat_type) {
+            .empty_tag_union => false,
+            .empty_record => true,
+            .tag_union => |tag_union| try isCtorPayloadTagUnionInhabited(
+                type_store,
+                builtin_idents,
+                tag_union,
+                seen,
+            ),
+            .nominal_type => |nominal| blk: {
+                if (builtin_idents.isBuiltinNumericType(nominal)) {
+                    break :blk true;
+                }
+                break :blk try isCtorPayloadTypeInhabitedHelp(
+                    type_store,
+                    builtin_idents,
+                    type_store.getNominalBackingVar(nominal),
+                    seen,
+                );
+            },
+            .record => |record| blk: {
+                const fields_slice = type_store.getRecordFieldsSlice(record.fields);
+                for (fields_slice.items(.var_)) |field_var| {
+                    if (!try isCtorPayloadTypeInhabitedHelp(type_store, builtin_idents, field_var, seen)) {
+                        break :blk false;
+                    }
+                }
+                break :blk true;
+            },
+            .record_unbound => |fields| blk: {
+                const fields_slice = type_store.getRecordFieldsSlice(fields);
+                for (fields_slice.items(.var_)) |field_var| {
+                    if (!try isCtorPayloadTypeInhabitedHelp(type_store, builtin_idents, field_var, seen)) {
+                        break :blk false;
+                    }
+                }
+                break :blk true;
+            },
+            .tuple => |tuple| blk: {
+                for (type_store.sliceVars(tuple.elems)) |elem_var| {
+                    if (!try isCtorPayloadTypeInhabitedHelp(type_store, builtin_idents, elem_var, seen)) {
+                        break :blk false;
+                    }
+                }
+                break :blk true;
+            },
+            .fn_pure, .fn_effectful, .fn_unbound => true,
+        },
+    };
+}
+
+fn isCtorPayloadTagUnionInhabited(
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    initial_tag_union: types.TagUnion,
+    seen: *std.AutoHashMapUnmanaged(Var, void),
+) error{OutOfMemory}!bool {
+    var seen_exts: std.AutoHashMapUnmanaged(Var, void) = .empty;
+    defer seen_exts.deinit(type_store.gpa);
+
+    var current_tags = initial_tag_union.tags;
+    var current_ext = initial_tag_union.ext;
+
+    while (true) {
+        const tags_slice = type_store.getTagsSlice(current_tags);
+        for (tags_slice.items(.args)) |args_range| {
+            var all_args_inhabited = true;
+            for (type_store.sliceVars(args_range)) |arg_var| {
+                if (!try isCtorPayloadTypeInhabitedHelp(type_store, builtin_idents, arg_var, seen)) {
+                    all_args_inhabited = false;
+                    break;
+                }
+            }
+            if (all_args_inhabited) return true;
+        }
+
+        const ext_resolved = type_store.resolveVar(current_ext);
+        const gop = try seen_exts.getOrPut(type_store.gpa, ext_resolved.var_);
+        if (gop.found_existing) return false;
+
+        switch (ext_resolved.desc.content) {
+            .flex => |flex| return !isUnresolvedUnboundFlex(flex),
+            .rigid => |rigid| return !isUnresolvedUnboundRigid(rigid),
+            .structure => |flat_type| switch (flat_type) {
+                .tag_union => |ext_tag_union| {
+                    current_tags = ext_tag_union.tags;
+                    current_ext = ext_tag_union.ext;
+                },
+                .empty_tag_union => return false,
+                else => return false,
+            },
+            .alias => |alias| {
+                current_ext = type_store.getAliasBackingVar(alias);
+            },
+            else => return false,
+        }
+    }
+}
+
+pub fn collectCtorPayloadBlockers(
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    type_var: Var,
+    out: *std.ArrayList(Var),
+) error{OutOfMemory}!void {
+    var seen: std.AutoHashMapUnmanaged(Var, void) = .empty;
+    defer seen.deinit(type_store.gpa);
+    try collectCtorPayloadBlockersHelp(type_store, builtin_idents, type_var, out, &seen);
+}
+
+fn collectCtorPayloadBlockersHelp(
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    type_var: Var,
+    out: *std.ArrayList(Var),
+    seen: *std.AutoHashMapUnmanaged(Var, void),
+) error{OutOfMemory}!void {
+    const resolved = type_store.resolveVar(type_var);
+    const content = resolved.desc.content;
+
+    switch (content) {
+        .flex => |flex| {
+            if (isUnresolvedUnboundFlex(flex)) {
+                try appendUniqueVar(type_store.gpa, out, resolved.var_);
+            }
+            return;
+        },
+        .rigid => |rigid| {
+            if (isUnresolvedUnboundRigid(rigid)) {
+                try appendUniqueVar(type_store.gpa, out, resolved.var_);
+            }
+            return;
+        },
+        .err => return,
+        else => {},
+    }
+
+    const gop = try seen.getOrPut(type_store.gpa, resolved.var_);
+    if (gop.found_existing) return;
+
+    switch (content) {
+        .flex, .rigid, .err => unreachable,
+        .alias => |alias| {
+            if (builtin_idents.isBuiltinNumericIdent(alias.ident.ident_idx)) return;
+            try collectCtorPayloadBlockersHelp(
+                type_store,
+                builtin_idents,
+                type_store.getAliasBackingVar(alias),
+                out,
+                seen,
+            );
+        },
+        .structure => |flat_type| switch (flat_type) {
+            .empty_tag_union, .empty_record => {},
+            .tag_union => |tag_union| try collectCtorPayloadTagUnionBlockers(
+                type_store,
+                builtin_idents,
+                tag_union,
+                out,
+                seen,
+            ),
+            .nominal_type => |nominal| {
+                if (builtin_idents.isBuiltinNumericType(nominal)) return;
+                try collectCtorPayloadBlockersHelp(
+                    type_store,
+                    builtin_idents,
+                    type_store.getNominalBackingVar(nominal),
+                    out,
+                    seen,
+                );
+            },
+            .record => |record| {
+                const fields_slice = type_store.getRecordFieldsSlice(record.fields);
+                for (fields_slice.items(.var_)) |field_var| {
+                    if (!try isCtorPayloadTypeInhabited(type_store, builtin_idents, field_var)) {
+                        try collectCtorPayloadBlockersHelp(type_store, builtin_idents, field_var, out, seen);
+                    }
+                }
+            },
+            .record_unbound => |fields| {
+                const fields_slice = type_store.getRecordFieldsSlice(fields);
+                for (fields_slice.items(.var_)) |field_var| {
+                    if (!try isCtorPayloadTypeInhabited(type_store, builtin_idents, field_var)) {
+                        try collectCtorPayloadBlockersHelp(type_store, builtin_idents, field_var, out, seen);
+                    }
+                }
+            },
+            .tuple => |tuple| {
+                for (type_store.sliceVars(tuple.elems)) |elem_var| {
+                    if (!try isCtorPayloadTypeInhabited(type_store, builtin_idents, elem_var)) {
+                        try collectCtorPayloadBlockersHelp(type_store, builtin_idents, elem_var, out, seen);
+                    }
+                }
+            },
+            .fn_pure, .fn_effectful, .fn_unbound => {},
+        },
+    }
+}
+
+fn collectCtorPayloadTagUnionBlockers(
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    initial_tag_union: types.TagUnion,
+    out: *std.ArrayList(Var),
+    seen: *std.AutoHashMapUnmanaged(Var, void),
+) error{OutOfMemory}!void {
+    var seen_exts: std.AutoHashMapUnmanaged(Var, void) = .empty;
+    defer seen_exts.deinit(type_store.gpa);
+
+    var current_tags = initial_tag_union.tags;
+    var current_ext = initial_tag_union.ext;
+
+    while (true) {
+        const tags_slice = type_store.getTagsSlice(current_tags);
+        for (tags_slice.items(.args)) |args_range| {
+            const args = type_store.sliceVars(args_range);
+            var all_args_inhabited = true;
+            for (args) |arg_var| {
+                if (!try isCtorPayloadTypeInhabited(type_store, builtin_idents, arg_var)) {
+                    all_args_inhabited = false;
+                    break;
+                }
+            }
+            if (!all_args_inhabited) {
+                for (args) |arg_var| {
+                    if (!try isCtorPayloadTypeInhabited(type_store, builtin_idents, arg_var)) {
+                        try collectCtorPayloadBlockersHelp(type_store, builtin_idents, arg_var, out, seen);
+                    }
+                }
+            }
+        }
+
+        const ext_resolved = type_store.resolveVar(current_ext);
+        const gop = try seen_exts.getOrPut(type_store.gpa, ext_resolved.var_);
+        if (gop.found_existing) return;
+
+        switch (ext_resolved.desc.content) {
+            .flex => |flex| {
+                if (isUnresolvedUnboundFlex(flex)) {
+                    try appendUniqueVar(type_store.gpa, out, ext_resolved.var_);
+                }
+                return;
+            },
+            .rigid => |rigid| {
+                if (isUnresolvedUnboundRigid(rigid)) {
+                    try appendUniqueVar(type_store.gpa, out, ext_resolved.var_);
+                }
+                return;
+            },
+            .structure => |flat_type| switch (flat_type) {
+                .tag_union => |ext_tag_union| {
+                    current_tags = ext_tag_union.tags;
+                    current_ext = ext_tag_union.ext;
+                },
+                .empty_tag_union => return,
+                else => return,
+            },
+            .alias => |alias| {
+                current_ext = type_store.getAliasBackingVar(alias);
+            },
+            else => return,
+        }
+    }
+}
+
+fn isKnownAbsentCtorPayloadTypeInhabited(
+    allocator: Allocator,
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    type_var: Var,
+) error{OutOfMemory}!bool {
+    var seen: std.AutoHashMapUnmanaged(Var, void) = .empty;
+    defer seen.deinit(type_store.gpa);
+
+    return isKnownAbsentCtorPayloadTypeInhabitedHelp(allocator, type_store, builtin_idents, type_var, &seen);
+}
+
+fn isKnownAbsentCtorPayloadTypeInhabitedHelp(
+    allocator: Allocator,
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    type_var: Var,
+    seen: *std.AutoHashMapUnmanaged(Var, void),
+) error{OutOfMemory}!bool {
+    const resolved = type_store.resolveVar(type_var);
+    const content = resolved.desc.content;
+
+    switch (content) {
+        .flex => return false,
+        .rigid => |rigid| return !rigid.name.attributes.ignored,
+        .err => return true,
+        else => {},
+    }
+
+    const gop = try seen.getOrPut(type_store.gpa, resolved.var_);
+    if (gop.found_existing) return true;
+
+    return switch (content) {
+        .flex, .rigid, .err => unreachable,
+        .alias => |alias| blk: {
+            if (builtin_idents.isBuiltinNumericIdent(alias.ident.ident_idx)) break :blk true;
+            break :blk try isKnownAbsentCtorPayloadTypeInhabitedHelp(
+                allocator,
+                type_store,
+                builtin_idents,
+                type_store.getAliasBackingVar(alias),
+                seen,
+            );
+        },
+        .structure => |flat_type| switch (flat_type) {
+            .empty_tag_union => false,
+            .empty_record => true,
+            .tag_union, .nominal_type => blk: {
+                if (flat_type == .nominal_type and builtin_idents.isBuiltinNumericType(flat_type.nominal_type)) {
+                    break :blk true;
+                }
+
+                const union_result = try getUnionFromType(allocator, type_store, builtin_idents, type_var);
+                const union_info = switch (union_result) {
+                    .success => |union_info| union_info,
+                    .not_a_union => break :blk false,
+                };
+
+                for (union_info.alternatives) |alt| {
+                    const arg_types = try getCtorArgTypes(allocator, type_store, type_var, alt.tag_id);
+                    var all_args_inhabited = true;
+                    for (arg_types) |arg_var| {
+                        if (!try isKnownAbsentCtorPayloadTypeInhabitedHelp(
+                            allocator,
+                            type_store,
+                            builtin_idents,
+                            arg_var,
+                            seen,
+                        )) {
+                            all_args_inhabited = false;
+                            break;
+                        }
+                    }
+                    if (all_args_inhabited) break :blk true;
+                }
+
+                break :blk false;
+            },
+            .record => |record| blk: {
+                const fields_slice = type_store.getRecordFieldsSlice(record.fields);
+                for (fields_slice.items(.var_)) |field_var| {
+                    if (!try isKnownAbsentCtorPayloadTypeInhabitedHelp(
+                        allocator,
+                        type_store,
+                        builtin_idents,
+                        field_var,
+                        seen,
+                    )) {
+                        break :blk false;
+                    }
+                }
+                break :blk true;
+            },
+            .record_unbound => |fields| blk: {
+                const fields_slice = type_store.getRecordFieldsSlice(fields);
+                for (fields_slice.items(.var_)) |field_var| {
+                    if (!try isKnownAbsentCtorPayloadTypeInhabitedHelp(
+                        allocator,
+                        type_store,
+                        builtin_idents,
+                        field_var,
+                        seen,
+                    )) {
+                        break :blk false;
+                    }
+                }
+                break :blk true;
+            },
+            .tuple => |tuple| blk: {
+                for (type_store.sliceVars(tuple.elems)) |elem_var| {
+                    if (!try isKnownAbsentCtorPayloadTypeInhabitedHelp(
+                        allocator,
+                        type_store,
+                        builtin_idents,
+                        elem_var,
+                        seen,
+                    )) {
+                        break :blk false;
+                    }
+                }
+                break :blk true;
+            },
+            .fn_pure, .fn_effectful, .fn_unbound => true,
+        },
+    };
+}
+
+fn collectKnownAbsentCtorPayloadBlockers(
+    allocator: Allocator,
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    type_var: Var,
+    out: *std.ArrayList(Var),
+) error{OutOfMemory}!void {
+    var seen: std.AutoHashMapUnmanaged(Var, void) = .empty;
+    defer seen.deinit(type_store.gpa);
+
+    try collectKnownAbsentCtorPayloadBlockersHelp(allocator, type_store, builtin_idents, type_var, out, &seen);
+}
+
+fn collectKnownAbsentCtorPayloadBlockersHelp(
+    allocator: Allocator,
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    type_var: Var,
+    out: *std.ArrayList(Var),
+    seen: *std.AutoHashMapUnmanaged(Var, void),
+) error{OutOfMemory}!void {
+    const resolved = type_store.resolveVar(type_var);
+    const content = resolved.desc.content;
+
+    switch (content) {
+        .flex => {
+            try appendUniqueVar(type_store.gpa, out, resolved.var_);
+            return;
+        },
+        .rigid => |rigid| {
+            if (rigid.name.attributes.ignored) {
+                try appendUniqueVar(type_store.gpa, out, resolved.var_);
+            }
+            return;
+        },
+        .err => return,
+        else => {},
+    }
+
+    const gop = try seen.getOrPut(type_store.gpa, resolved.var_);
+    if (gop.found_existing) return;
+
+    switch (content) {
+        .flex, .rigid, .err => unreachable,
+        .alias => |alias| {
+            if (builtin_idents.isBuiltinNumericIdent(alias.ident.ident_idx)) return;
+            try collectKnownAbsentCtorPayloadBlockersHelp(
+                allocator,
+                type_store,
+                builtin_idents,
+                type_store.getAliasBackingVar(alias),
+                out,
+                seen,
+            );
+        },
+        .structure => |flat_type| switch (flat_type) {
+            .empty_tag_union, .empty_record => {},
+            .tag_union, .nominal_type => {
+                if (flat_type == .nominal_type and builtin_idents.isBuiltinNumericType(flat_type.nominal_type)) {
+                    return;
+                }
+
+                const union_result = try getUnionFromType(allocator, type_store, builtin_idents, type_var);
+                const union_info = switch (union_result) {
+                    .success => |union_info| union_info,
+                    .not_a_union => return,
+                };
+
+                for (union_info.alternatives) |alt| {
+                    const arg_types = try getCtorArgTypes(allocator, type_store, type_var, alt.tag_id);
+                    var all_args_inhabited = true;
+                    for (arg_types) |arg_var| {
+                        if (!try isKnownAbsentCtorPayloadTypeInhabitedHelp(
+                            allocator,
+                            type_store,
+                            builtin_idents,
+                            arg_var,
+                            seen,
+                        )) {
+                            all_args_inhabited = false;
+                            break;
+                        }
+                    }
+
+                    if (!all_args_inhabited) {
+                        for (arg_types) |arg_var| {
+                            if (!try isKnownAbsentCtorPayloadTypeInhabited(
+                                allocator,
+                                type_store,
+                                builtin_idents,
+                                arg_var,
+                            )) {
+                                try collectKnownAbsentCtorPayloadBlockersHelp(
+                                    allocator,
+                                    type_store,
+                                    builtin_idents,
+                                    arg_var,
+                                    out,
+                                    seen,
+                                );
+                            }
+                        }
+                    }
+                }
+            },
+            .record => |record| {
+                const fields_slice = type_store.getRecordFieldsSlice(record.fields);
+                for (fields_slice.items(.var_)) |field_var| {
+                    if (!try isKnownAbsentCtorPayloadTypeInhabited(allocator, type_store, builtin_idents, field_var)) {
+                        try collectKnownAbsentCtorPayloadBlockersHelp(allocator, type_store, builtin_idents, field_var, out, seen);
+                    }
+                }
+            },
+            .record_unbound => |fields| {
+                const fields_slice = type_store.getRecordFieldsSlice(fields);
+                for (fields_slice.items(.var_)) |field_var| {
+                    if (!try isKnownAbsentCtorPayloadTypeInhabited(allocator, type_store, builtin_idents, field_var)) {
+                        try collectKnownAbsentCtorPayloadBlockersHelp(allocator, type_store, builtin_idents, field_var, out, seen);
+                    }
+                }
+            },
+            .tuple => |tuple| {
+                for (type_store.sliceVars(tuple.elems)) |elem_var| {
+                    if (!try isKnownAbsentCtorPayloadTypeInhabited(allocator, type_store, builtin_idents, elem_var)) {
+                        try collectKnownAbsentCtorPayloadBlockersHelp(allocator, type_store, builtin_idents, elem_var, out, seen);
+                    }
+                }
+            },
+            .fn_pure, .fn_effectful, .fn_unbound => {},
+        },
+    }
 }
 
 /// Push work items for AND semantics: all types must be inhabited.
@@ -1282,12 +1905,47 @@ fn areAllTypesInhabited(
     builtin_idents: BuiltinIdents,
     type_vars: []const Var,
 ) error{OutOfMemory}!bool {
+    return areAllTypesInhabitedWithKnownEmpty(type_store, builtin_idents, type_vars, &.{});
+}
+
+fn areAllTypesInhabitedWithKnownEmpty(
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    type_vars: []const Var,
+    known_empty_vars: []const Var,
+) error{OutOfMemory}!bool {
     for (type_vars) |type_var| {
-        if (!try isTypeInhabited(type_store, builtin_idents, type_var)) {
+        if (!try isTypeInhabitedWithKnownEmpty(type_store, builtin_idents, type_var, known_empty_vars)) {
             return false;
         }
     }
     return true;
+}
+
+/// Check constructor payload argument types.
+///
+/// Unresolved payload variables are treated as uninhabited here, and any such
+/// variables that make the constructor impossible are recorded for the caller.
+/// The caller decides whether to use them only for this exhaustiveness query or
+/// to resolve them globally to `[]`.
+fn areAllCtorPayloadTypesInhabited(
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    type_vars: []const Var,
+    payload_vars_to_close: ?*std.ArrayList(Var),
+) error{OutOfMemory}!bool {
+    var all_inhabited = true;
+    for (type_vars) |type_var| {
+        if (!try isCtorPayloadTypeInhabited(type_store, builtin_idents, type_var)) {
+            all_inhabited = false;
+            if (payload_vars_to_close) |out| {
+                try collectCtorPayloadBlockers(type_store, builtin_idents, type_var, out);
+            } else {
+                return false;
+            }
+        }
+    }
+    return all_inhabited;
 }
 
 /// Check if an UnresolvedPattern (sketched pattern) is inhabited.
@@ -1302,6 +1960,7 @@ fn isSketchedPatternInhabited(
     builtin_idents: BuiltinIdents,
     patterns: []const UnresolvedPattern,
     column_types: ColumnTypes,
+    payload_vars_to_close: ?*std.ArrayList(Var),
 ) PatternResolveError!bool {
     if (patterns.len == 0) return true;
     if (column_types.types.len == 0) return true;
@@ -1323,8 +1982,9 @@ fn isSketchedPatternInhabited(
             const arg_types = try getCtorArgTypes(allocator, type_store, first_col_type, tag_id);
 
             // Check if any argument type is uninhabited
+            const known_empty_vars = if (payload_vars_to_close) |vars| vars.items else &.{};
             for (arg_types, 0..) |arg_type, i| {
-                if (!try isTypeInhabited(type_store, builtin_idents, arg_type)) {
+                if (!try isTypeInhabitedWithKnownEmpty(type_store, builtin_idents, arg_type, known_empty_vars)) {
                     return false; // Uninhabited argument = uninhabited pattern
                 }
                 // Also recursively check nested patterns
@@ -1337,7 +1997,7 @@ fn isSketchedPatternInhabited(
                         .types = arg_col_types,
                         .type_store = type_store,
                         .builtin_idents = builtin_idents,
-                    })) {
+                    }, payload_vars_to_close)) {
                         return false;
                     }
                 }
@@ -1349,7 +2009,8 @@ fn isSketchedPatternInhabited(
         .known_ctor => return true,
         .anything => {
             // Wildcard - check if the type itself is uninhabited
-            return isTypeInhabited(type_store, builtin_idents, first_col_type);
+            const known_empty_vars = if (payload_vars_to_close) |vars| vars.items else &.{};
+            return isTypeInhabitedWithKnownEmpty(type_store, builtin_idents, first_col_type, known_empty_vars);
         },
         .literal => return true, // Literals are always inhabited
         .list => |l| {
@@ -1360,7 +2021,8 @@ fn isSketchedPatternInhabited(
 
             // Check if element type is inhabited
             const elem_type = getListElemType(type_store, first_col_type) orelse return true;
-            return isTypeInhabited(type_store, builtin_idents, elem_type);
+            const known_empty_vars = if (payload_vars_to_close) |vars| vars.items else &.{};
+            return isTypeInhabitedWithKnownEmpty(type_store, builtin_idents, elem_type, known_empty_vars);
         },
     }
 }
@@ -1417,6 +2079,53 @@ fn findTagId(union_info: Union, tag_name: Ident.Idx) ?TagId {
         }
     }
     return null;
+}
+
+fn ctorNameIdent(ctor_name: CtorName) ?Ident.Idx {
+    return switch (ctor_name) {
+        .tag => |tag| if (tag.eql(Ident.Idx.NONE)) null else tag,
+        .opaque_type => |opaque_type| opaque_type,
+    };
+}
+
+fn identSetContains(idents: []const Ident.Idx, ident: Ident.Idx) bool {
+    for (idents) |existing| {
+        if (existing.eql(ident)) return true;
+    }
+    return false;
+}
+
+/// Collect uninhabited payload vars for constructors that are absent from a
+/// syntactically-known constructed tag set.
+///
+/// This intentionally resolves each constructor's payload through the concrete
+/// target type, not just the nominal backing type, so `Try(Str, e)` reports `e`
+/// as the blocker for `Err(e)` rather than the backing type parameter.
+pub fn collectAbsentCtorPayloadBlockersForConstructedTags(
+    allocator: std.mem.Allocator,
+    type_store: *TypeStore,
+    builtin_idents: BuiltinIdents,
+    target_var: Var,
+    constructed_tags: []const Ident.Idx,
+    out: *std.ArrayList(Var),
+) error{OutOfMemory}!void {
+    const union_result = try getUnionFromType(allocator, type_store, builtin_idents, target_var);
+    const union_info = switch (union_result) {
+        .success => |union_info| union_info,
+        .not_a_union => return,
+    };
+
+    for (union_info.alternatives) |alt| {
+        const name = ctorNameIdent(alt.name) orelse continue;
+        if (identSetContains(constructed_tags, name)) continue;
+
+        const arg_types = try getCtorArgTypes(allocator, type_store, target_var, alt.tag_id);
+        for (arg_types) |arg_type| {
+            if (!try isKnownAbsentCtorPayloadTypeInhabited(allocator, type_store, builtin_idents, arg_type)) {
+                try collectKnownAbsentCtorPayloadBlockers(allocator, type_store, builtin_idents, arg_type, out);
+            }
+        }
+    }
 }
 
 /// Collect unique type parameter variables from a backing type structure.
@@ -2383,6 +3092,7 @@ fn recurseIntoAllCtors(
     column_types: ColumnTypes,
     ext_vars_to_close: *std.ArrayList(Var),
     ext_vars_to_keep_open: *std.ArrayList(Var),
+    payload_vars_to_close: *std.ArrayList(Var),
     alternatives: []const CtorInfo,
     union_info: Union,
     first_col_type: Var,
@@ -2390,7 +3100,7 @@ fn recurseIntoAllCtors(
     for (alternatives) |alt| {
         // Skip uninhabited constructors
         const arg_types = try getCtorArgTypes(allocator, type_store, first_col_type, alt.tag_id);
-        if (!try areAllTypesInhabited(type_store, builtin_idents, arg_types)) {
+        if (!try areAllTypesInhabitedWithKnownEmpty(type_store, builtin_idents, arg_types, payload_vars_to_close.items)) {
             continue;
         }
 
@@ -2408,7 +3118,7 @@ fn recurseIntoAllCtors(
             .guard => try column_types.specializeByGuard(allocator),
             else => try column_types.specializeByConstructor(allocator, alt.tag_id, alt.arity),
         };
-        const missing = try checkExhaustiveSketched(allocator, type_store, builtin_idents, specialized, specialized_types, ext_vars_to_close, ext_vars_to_keep_open);
+        const missing = try checkExhaustiveSketched(allocator, type_store, builtin_idents, specialized, specialized_types, ext_vars_to_close, ext_vars_to_keep_open, payload_vars_to_close, false);
 
         if (missing.len > 0) {
             const args = try allocator.alloc(Pattern, alt.arity);
@@ -2427,7 +3137,7 @@ fn recurseIntoAllCtors(
                 .args = args,
             } };
 
-            if (try missing_pattern.isInhabited(column_types.type_store, column_types.builtin_idents)) {
+            if (try missing_pattern.isInhabitedWithKnownEmpty(column_types.type_store, column_types.builtin_idents, payload_vars_to_close.items)) {
                 const result = try allocator.alloc(Pattern, 1);
                 result[0] = missing_pattern;
                 return result;
@@ -2449,6 +3159,8 @@ pub fn checkExhaustiveSketched(
     column_types: ColumnTypes,
     ext_vars_to_close: *std.ArrayList(Var),
     ext_vars_to_keep_open: *std.ArrayList(Var),
+    payload_vars_to_close: *std.ArrayList(Var),
+    close_open_extension: bool,
 ) PatternResolveError![]const Pattern {
     const n = column_types.len();
 
@@ -2484,7 +3196,7 @@ pub fn checkExhaustiveSketched(
 
             const new_matrix = try specializeByAnythingSketched(allocator, matrix);
             const rest_types = column_types.dropFirst();
-            const rest = try checkExhaustiveSketched(allocator, type_store, builtin_idents, new_matrix, rest_types, ext_vars_to_close, ext_vars_to_keep_open);
+            const rest = try checkExhaustiveSketched(allocator, type_store, builtin_idents, new_matrix, rest_types, ext_vars_to_close, ext_vars_to_keep_open, payload_vars_to_close, false);
 
             if (rest.len == 0) return &[_]Pattern{};
 
@@ -2508,11 +3220,44 @@ pub fn checkExhaustiveSketched(
             // The only "missing" constructor is the synthetic #Open.
             // Record the ext var for closing and recurse into payloads.
             std.debug.assert(num_found <= num_alts);
-            if (ctor_info.union_info.has_flex_extension and
+            const has_open_synthetic = if (num_alts > 0) switch (ctor_info.union_info.alternatives[num_alts - 1].name) {
+                .tag => |tag| tag.isNone(),
+                .opaque_type => false,
+            } else false;
+            const real_alternatives = if (has_open_synthetic)
+                ctor_info.union_info.alternatives[0 .. num_alts - 1]
+            else
+                ctor_info.union_info.alternatives;
+            var all_inhabited_real_ctors_found = true;
+            if (ctor_info.union_info.has_flex_extension or close_open_extension) {
+                for (real_alternatives) |alt| {
+                    const arg_types = try getCtorArgTypes(allocator, type_store, first_col_type, alt.tag_id);
+                    if (!try areAllTypesInhabitedWithKnownEmpty(type_store, builtin_idents, arg_types, payload_vars_to_close.items)) {
+                        continue;
+                    }
+
+                    var found = false;
+                    for (ctor_info.found) |found_id| {
+                        if (@intFromEnum(alt.tag_id) == @intFromEnum(found_id)) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        all_inhabited_real_ctors_found = false;
+                        break;
+                    }
+                }
+            }
+
+            if ((ctor_info.union_info.has_flex_extension or close_open_extension) and
+                has_open_synthetic and
                 !ctor_info.has_wildcards and
-                num_found == num_alts - 1)
+                all_inhabited_real_ctors_found)
             {
-                try collectFlexExtVars(allocator, type_store, first_col_type, ext_vars_to_close);
+                if (ctor_info.union_info.has_flex_extension) {
+                    try collectFlexExtVars(allocator, type_store, first_col_type, ext_vars_to_close);
+                }
 
                 // Recurse into all real constructors' payloads (skip #Open synthetic).
                 return recurseIntoAllCtors(
@@ -2523,7 +3268,8 @@ pub fn checkExhaustiveSketched(
                     column_types,
                     ext_vars_to_close,
                     ext_vars_to_keep_open,
-                    ctor_info.union_info.alternatives[0 .. num_alts - 1],
+                    payload_vars_to_close,
+                    real_alternatives,
                     ctor_info.union_info,
                     first_col_type,
                 );
@@ -2543,7 +3289,7 @@ pub fn checkExhaustiveSketched(
                         // Skip uninhabited constructors - they don't need to be matched
                         // because no values of that constructor can exist.
                         const arg_types = try getCtorArgTypes(allocator, type_store, first_col_type, alt.tag_id);
-                        if (!try areAllTypesInhabited(type_store, builtin_idents, arg_types)) {
+                        if (!try areAllTypesInhabitedWithKnownEmpty(type_store, builtin_idents, arg_types, payload_vars_to_close.items)) {
                             continue;
                         }
 
@@ -2561,7 +3307,7 @@ pub fn checkExhaustiveSketched(
                             .guard => try column_types.specializeByGuard(allocator),
                             else => try column_types.specializeByConstructor(allocator, alt.tag_id, alt.arity),
                         };
-                        const inner_missing = try checkExhaustiveSketched(allocator, type_store, builtin_idents, specialized, specialized_types, ext_vars_to_close, ext_vars_to_keep_open);
+                        const inner_missing = try checkExhaustiveSketched(allocator, type_store, builtin_idents, specialized, specialized_types, ext_vars_to_close, ext_vars_to_keep_open, payload_vars_to_close, false);
 
                         // For arity-0 constructors with no matching rows, the specialized matrix
                         // is empty with 0 columns, which returns empty inner_missing. But we still
@@ -2571,7 +3317,7 @@ pub fn checkExhaustiveSketched(
                         // closed. For rigid extensions (from annotations), #Open represents real
                         // unknown tags and must be reported as missing.
                         const is_open_synthetic = alt.name.tag.isNone();
-                        const skip_open = is_open_synthetic and ctor_info.union_info.has_flex_extension;
+                        const skip_open = is_open_synthetic and (ctor_info.union_info.has_flex_extension or close_open_extension);
                         const is_missing = inner_missing.len > 0 or (alt.arity == 0 and specialized.isEmpty() and !skip_open);
                         if (is_missing) {
                             const missing_pattern = Pattern{ .ctor = .{
@@ -2579,7 +3325,7 @@ pub fn checkExhaustiveSketched(
                                 .tag_id = alt.tag_id,
                                 .args = inner_missing,
                             } };
-                            if (try missing_pattern.isInhabited(column_types.type_store, column_types.builtin_idents)) {
+                            if (try missing_pattern.isInhabitedWithKnownEmpty(column_types.type_store, column_types.builtin_idents, payload_vars_to_close.items)) {
                                 const result = try allocator.alloc(Pattern, 1);
                                 result[0] = missing_pattern;
                                 return result;
@@ -2599,6 +3345,7 @@ pub fn checkExhaustiveSketched(
                 column_types,
                 ext_vars_to_close,
                 ext_vars_to_keep_open,
+                payload_vars_to_close,
                 ctor_info.union_info.alternatives,
                 ctor_info.union_info,
                 first_col_type,
@@ -2614,7 +3361,7 @@ pub fn checkExhaustiveSketched(
             else
                 null;
             const elem_inhabited = if (elem_type) |et|
-                try isTypeInhabited(type_store, builtin_idents, et)
+                try isTypeInhabitedWithKnownEmpty(type_store, builtin_idents, et, payload_vars_to_close.items)
             else
                 true; // No type info, assume inhabited
 
@@ -2628,7 +3375,7 @@ pub fn checkExhaustiveSketched(
 
                 const specialized = try specializeByListAritySketched(allocator, matrix, list_arity);
                 const specialized_types = try column_types.specializeForList(allocator, min_len);
-                const missing = try checkExhaustiveSketched(allocator, type_store, builtin_idents, specialized, specialized_types, ext_vars_to_close, ext_vars_to_keep_open);
+                const missing = try checkExhaustiveSketched(allocator, type_store, builtin_idents, specialized, specialized_types, ext_vars_to_close, ext_vars_to_keep_open, payload_vars_to_close, false);
 
                 // For length-0 lists (empty list) with no matching rows, the specialized matrix
                 // is empty with 0 columns, which returns empty missing. But we still
@@ -2675,12 +3422,14 @@ pub fn isUsefulSketched(
     existing_matrix: SketchedMatrix,
     new_row: []const UnresolvedPattern,
     column_types: ColumnTypes,
+    payload_vars_to_close: *std.ArrayList(Var),
+    close_open_extension: bool,
 ) PatternResolveError!bool {
     // Empty matrix = new row is definitely useful, UNLESS the pattern is uninhabited
     if (existing_matrix.isEmpty()) {
         // Check if the pattern is on an uninhabited type
         // For ctor patterns, check if any argument type is uninhabited
-        return isSketchedPatternInhabited(allocator, type_store, builtin_idents, new_row, column_types);
+        return isSketchedPatternInhabited(allocator, type_store, builtin_idents, new_row, column_types, payload_vars_to_close);
     }
 
     // No more patterns to check = not useful (existing rows cover everything)
@@ -2716,7 +3465,7 @@ pub fn isUsefulSketched(
             @memcpy(extended_row[0..c.args.len], c.args);
             @memcpy(extended_row[c.args.len..], rest);
 
-            return isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended_row, specialized_types);
+            return isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended_row, specialized_types, payload_vars_to_close, false);
         },
 
         .known_ctor => |kc| {
@@ -2829,7 +3578,7 @@ pub fn isUsefulSketched(
                 },
             };
 
-            return isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended_row, specialized_types);
+            return isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended_row, specialized_types, payload_vars_to_close, false);
         },
 
         .anything => {
@@ -2840,13 +3589,13 @@ pub fn isUsefulSketched(
                 .non_exhaustive_wildcards => {
                     const specialized = try specializeByAnythingSketched(allocator, existing_matrix);
                     const rest_types = column_types.dropFirst();
-                    return isUsefulSketched(allocator, type_store, builtin_idents, specialized, rest, rest_types);
+                    return isUsefulSketched(allocator, type_store, builtin_idents, specialized, rest, rest_types, payload_vars_to_close, false);
                 },
 
                 .ctors => |ctor_info| {
                     // Optimization: For flex extensions, wildcards are always useful.
                     // See comment in isUseful for detailed explanation.
-                    if (ctor_info.union_info.has_flex_extension) {
+                    if (ctor_info.union_info.has_flex_extension and !close_open_extension) {
                         return true;
                     }
 
@@ -2865,11 +3614,19 @@ pub fn isUsefulSketched(
                                 }
                             }
                             if (!found) {
+                                if (close_open_extension) {
+                                    const is_open_synthetic = switch (alt.name) {
+                                        .tag => |tag| tag.isNone(),
+                                        .opaque_type => false,
+                                    };
+                                    if (is_open_synthetic) continue;
+                                }
+
                                 // This constructor is missing - check if it's inhabited
                                 const arg_types = try getCtorArgTypes(allocator, type_store, first_col_type, alt.tag_id);
                                 var ctor_uninhabited = false;
                                 for (arg_types) |arg_type| {
-                                    if (!try isTypeInhabited(type_store, builtin_idents, arg_type)) {
+                                    if (!try isTypeInhabitedWithKnownEmpty(type_store, builtin_idents, arg_type, payload_vars_to_close.items)) {
                                         ctor_uninhabited = true;
                                         break;
                                     }
@@ -2888,14 +3645,14 @@ pub fn isUsefulSketched(
 
                         const specialized = try specializeByAnythingSketched(allocator, existing_matrix);
                         const rest_types = column_types.dropFirst();
-                        return isUsefulSketched(allocator, type_store, builtin_idents, specialized, rest, rest_types);
+                        return isUsefulSketched(allocator, type_store, builtin_idents, specialized, rest, rest_types, payload_vars_to_close, false);
                     }
 
                     // All constructors covered - check each one
                     for (ctor_info.union_info.alternatives) |alt| {
                         // Skip uninhabited constructors
                         const arg_types = try getCtorArgTypes(allocator, type_store, first_col_type, alt.tag_id);
-                        if (!try areAllTypesInhabited(type_store, builtin_idents, arg_types)) {
+                        if (!try areAllTypesInhabitedWithKnownEmpty(type_store, builtin_idents, arg_types, payload_vars_to_close.items)) {
                             continue;
                         }
 
@@ -2920,7 +3677,7 @@ pub fn isUsefulSketched(
                         }
                         @memcpy(extended[alt.arity..], rest);
 
-                        if (try isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended, specialized_types)) {
+                        if (try isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended, specialized_types, payload_vars_to_close, false)) {
                             return true;
                         }
                     }
@@ -2936,7 +3693,7 @@ pub fn isUsefulSketched(
                     else
                         null;
                     const elem_inhabited = if (elem_type) |et|
-                        try isTypeInhabited(type_store, builtin_idents, et)
+                        try isTypeInhabitedWithKnownEmpty(type_store, builtin_idents, et, payload_vars_to_close.items)
                     else
                         true; // No type info, assume inhabited
 
@@ -2957,7 +3714,7 @@ pub fn isUsefulSketched(
                         }
                         @memcpy(extended[min_len..], rest);
 
-                        if (try isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended, specialized_types)) {
+                        if (try isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended, specialized_types, payload_vars_to_close, false)) {
                             return true;
                         }
                     }
@@ -2990,7 +3747,7 @@ pub fn isUsefulSketched(
 
             const filtered = SketchedMatrix.init(allocator, try matching_rows.toOwnedSlice(allocator));
             const rest_types = column_types.dropFirst();
-            return isUsefulSketched(allocator, type_store, builtin_idents, filtered, rest, rest_types);
+            return isUsefulSketched(allocator, type_store, builtin_idents, filtered, rest, rest_types, payload_vars_to_close, false);
         },
 
         .list => |l| {
@@ -3000,7 +3757,7 @@ pub fn isUsefulSketched(
             else
                 null;
             const elem_inhabited = if (elem_type) |et|
-                try isTypeInhabited(type_store, builtin_idents, et)
+                try isTypeInhabitedWithKnownEmpty(type_store, builtin_idents, et, payload_vars_to_close.items)
             else
                 true; // No type info, assume inhabited
 
@@ -3019,7 +3776,7 @@ pub fn isUsefulSketched(
                     @memcpy(extended_row[0..l.elements.len], l.elements);
                     @memcpy(extended_row[l.elements.len..], rest);
 
-                    return isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended_row, specialized_types);
+                    return isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended_row, specialized_types, payload_vars_to_close, false);
                 },
                 .slice => |s| {
                     // Slice patterns always match at least one non-empty list (prefix + suffix elements),
@@ -3058,7 +3815,7 @@ pub fn isUsefulSketched(
                         }
                         @memcpy(extended_row[len..], rest);
 
-                        if (try isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended_row, specialized_types)) {
+                        if (try isUsefulSketched(allocator, type_store, builtin_idents, specialized, extended_row, specialized_types, payload_vars_to_close, false)) {
                             return true;
                         }
                     }
@@ -3094,6 +3851,8 @@ pub fn checkRedundancySketched(
     builtin_idents: BuiltinIdents,
     rows: []const UnresolvedRow,
     column_types: ColumnTypes,
+    payload_vars_to_close: *std.ArrayList(Var),
+    close_open_extension: bool,
 ) PatternResolveError!RedundancyResultSketched {
     var non_redundant: std.ArrayList([]const UnresolvedPattern) = .empty;
     var redundant_indices: std.ArrayList(u32) = .empty;
@@ -3109,6 +3868,7 @@ pub fn checkRedundancySketched(
             builtin_idents,
             row.patterns,
             column_types,
+            payload_vars_to_close,
         );
 
         if (!is_inhabited) {
@@ -3122,7 +3882,7 @@ pub fn checkRedundancySketched(
         // Rows with guards are always considered useful (guard might fail at runtime)
         const matrix = SketchedMatrix.init(allocator, non_redundant.items);
         const is_useful = row.guard == .has_guard or
-            try isUsefulSketched(allocator, type_store, builtin_idents, matrix, row.patterns, column_types);
+            try isUsefulSketched(allocator, type_store, builtin_idents, matrix, row.patterns, column_types, payload_vars_to_close, close_open_extension);
 
         if (is_useful) {
             try non_redundant.append(allocator, row.patterns);
@@ -3163,6 +3923,10 @@ pub const CheckResult = struct {
     /// These are tag union positions where all constructors were exhaustively
     /// covered without wildcards.
     ext_vars_to_close: []const Var,
+    /// Unresolved constructor payload vars to close via unification with
+    /// empty_tag_union. Exhaustiveness relied on these payloads being
+    /// unconstructible.
+    payload_vars_to_close: []const Var,
 
     /// Free all allocated memory in the result
     pub fn deinit(self: CheckResult, allocator: std.mem.Allocator) void {
@@ -3175,6 +3939,7 @@ pub const CheckResult = struct {
         allocator.free(self.unmatchable_indices);
         allocator.free(self.unmatchable_regions);
         allocator.free(self.ext_vars_to_close);
+        allocator.free(self.payload_vars_to_close);
     }
 
     fn freePattern(allocator: std.mem.Allocator, pattern: Pattern) void {
@@ -3214,6 +3979,8 @@ pub fn checkMatch(
     branches_span: CIR.Expr.Match.Branch.Span,
     scrutinee_type: Var,
     overall_region: Region,
+    known_empty_payload_vars: []const Var,
+    scrutinee_constructors_known: bool,
 ) PatternResolveError!CheckResult {
     // Use an arena for all intermediate allocations to avoid leaks
     var arena = base.SingleThreadArena.init(allocator);
@@ -3239,12 +4006,19 @@ pub fn checkMatch(
 
     // Phase 2: Check redundancy with on-demand resolution
     // Patterns are resolved as needed when type information is required
+    var payload_vars_to_close: std.ArrayList(Var) = .empty;
+    for (known_empty_payload_vars) |payload_var| {
+        try appendUniqueVar(arena_alloc, &payload_vars_to_close, type_store.resolveVar(payload_var).var_);
+    }
+
     const redundancy = try checkRedundancySketched(
         arena_alloc,
         type_store,
         builtin_idents,
         sketched.rows,
         column_types,
+        &payload_vars_to_close,
+        scrutinee_constructors_known,
     );
 
     // Phase 3: Check exhaustiveness on non-redundant patterns
@@ -3259,6 +4033,8 @@ pub fn checkMatch(
         column_types,
         &ext_vars_to_close,
         &ext_vars_to_keep_open,
+        &payload_vars_to_close,
+        scrutinee_constructors_known,
     );
 
     // Filter: remove any ext vars that should be kept open.
@@ -3293,6 +4069,108 @@ pub fn checkMatch(
         .unmatchable_indices = try allocator.dupe(u32, redundancy.unmatchable_indices),
         .unmatchable_regions = try allocator.dupe(Region, redundancy.unmatchable_regions),
         .ext_vars_to_close = try allocator.dupe(Var, filtered_close.items),
+        .payload_vars_to_close = try allocator.dupe(Var, payload_vars_to_close.items),
+    };
+}
+
+/// Perform exhaustiveness checking for a single destructuring pattern.
+///
+/// This uses the same matrix algorithm as match expressions, with a single row
+/// corresponding to the destructure pattern.
+pub fn checkDestructure(
+    allocator: std.mem.Allocator,
+    type_store: *TypeStore,
+    node_store: *const NodeStore,
+    builtin_idents: BuiltinIdents,
+    pattern_idx: CirPattern.Idx,
+    scrutinee_type: Var,
+    overall_region: Region,
+    known_empty_payload_vars: []const Var,
+    scrutinee_constructors_known: bool,
+) PatternResolveError!CheckResult {
+    var arena = base.SingleThreadArena.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const converted = try convertPattern(arena_alloc, node_store, pattern_idx);
+    const pattern_slice = try arena_alloc.alloc(UnresolvedPattern, 1);
+    pattern_slice[0] = converted;
+
+    const rows = try arena_alloc.alloc(UnresolvedRow, 1);
+    rows[0] = .{
+        .patterns = pattern_slice,
+        .region = node_store.getPatternRegion(pattern_idx),
+        .guard = .no_guard,
+        .branch_index = 0,
+    };
+
+    const initial_types = try arena_alloc.alloc(Var, 1);
+    initial_types[0] = scrutinee_type;
+    const column_types = ColumnTypes{
+        .types = initial_types,
+        .type_store = type_store,
+        .builtin_idents = builtin_idents,
+    };
+
+    var payload_vars_to_close: std.ArrayList(Var) = .empty;
+    for (known_empty_payload_vars) |payload_var| {
+        try appendUniqueVar(arena_alloc, &payload_vars_to_close, type_store.resolveVar(payload_var).var_);
+    }
+
+    const redundancy = try checkRedundancySketched(
+        arena_alloc,
+        type_store,
+        builtin_idents,
+        rows,
+        column_types,
+        &payload_vars_to_close,
+        scrutinee_constructors_known,
+    );
+
+    const sketched_matrix = SketchedMatrix.init(arena_alloc, redundancy.non_redundant_rows);
+    var ext_vars_to_close: std.ArrayList(Var) = .empty;
+    var ext_vars_to_keep_open: std.ArrayList(Var) = .empty;
+    const missing = try checkExhaustiveSketched(
+        arena_alloc,
+        type_store,
+        builtin_idents,
+        sketched_matrix,
+        column_types,
+        &ext_vars_to_close,
+        &ext_vars_to_keep_open,
+        &payload_vars_to_close,
+        scrutinee_constructors_known,
+    );
+
+    var filtered_close: std.ArrayList(Var) = .empty;
+    for (ext_vars_to_close.items) |close_var| {
+        var dominated = false;
+        for (ext_vars_to_keep_open.items) |keep_var| {
+            if (@intFromEnum(close_var) == @intFromEnum(keep_var)) {
+                dominated = true;
+                break;
+            }
+        }
+        if (!dominated) {
+            try filtered_close.append(arena_alloc, close_var);
+        }
+    }
+
+    const result_patterns = try allocator.alloc(Pattern, missing.len);
+    for (missing, 0..) |pat, i| {
+        result_patterns[i] = try pat.dupe(allocator);
+    }
+
+    _ = overall_region;
+    return .{
+        .is_exhaustive = missing.len == 0,
+        .missing_patterns = result_patterns,
+        .redundant_indices = try allocator.dupe(u32, redundancy.redundant_indices),
+        .redundant_regions = try allocator.dupe(Region, redundancy.redundant_regions),
+        .unmatchable_indices = try allocator.dupe(u32, redundancy.unmatchable_indices),
+        .unmatchable_regions = try allocator.dupe(Region, redundancy.unmatchable_regions),
+        .ext_vars_to_close = try allocator.dupe(Var, filtered_close.items),
+        .payload_vars_to_close = try allocator.dupe(Var, payload_vars_to_close.items),
     };
 }
 

--- a/src/check/exhaustive.zig
+++ b/src/check/exhaustive.zig
@@ -941,10 +941,8 @@ const GatheredTag = struct {
 // require matching.
 //
 // Core API:
-// - `isTypeInhabited`: Check if a single type is inhabited (THE primary entry point)
-// - `areAllTypesInhabited`: Check if all types in a slice are inhabited (AND semantics)
-//
-// Pattern.isInhabited() delegates to isTypeInhabited for wildcard patterns.
+// - `isTypeInhabitedWithKnownEmpty`: Check if a single type is inhabited.
+// - `areAllTypesInhabitedWithKnownEmpty`: Check if all types in a slice are inhabited (AND semantics).
 //
 // Based on the algorithm from the Rust implementation in crates/compiler/types/src/subs.rs.
 
@@ -987,10 +985,6 @@ const WorkItem = union(enum) {
 ///
 /// This implementation uses a work-list algorithm to avoid stack overflow on
 /// deeply nested types. See docs/exhaustiveness/004_worklist_inhabitedness_algorithm.md
-fn isTypeInhabited(type_store: *TypeStore, builtin_idents: BuiltinIdents, type_var: Var) error{OutOfMemory}!bool {
-    return isTypeInhabitedWithKnownEmpty(type_store, builtin_idents, type_var, &.{});
-}
-
 fn varIsKnownEmpty(type_store: *TypeStore, known_empty_vars: []const Var, type_var: Var) bool {
     const resolved_var = type_store.resolveVar(type_var).var_;
     for (known_empty_vars) |known_empty_var| {
@@ -1899,16 +1893,6 @@ fn isExtensionOpen(type_store: *TypeStore, ext_var: Var) error{OutOfMemory}!bool
     }
 }
 
-/// Check if all types in a slice are inhabited.
-/// Returns false if ANY type is uninhabited (AND semantics).
-fn areAllTypesInhabited(
-    type_store: *TypeStore,
-    builtin_idents: BuiltinIdents,
-    type_vars: []const Var,
-) error{OutOfMemory}!bool {
-    return areAllTypesInhabitedWithKnownEmpty(type_store, builtin_idents, type_vars, &.{});
-}
-
 fn areAllTypesInhabitedWithKnownEmpty(
     type_store: *TypeStore,
     builtin_idents: BuiltinIdents,
@@ -1921,32 +1905,6 @@ fn areAllTypesInhabitedWithKnownEmpty(
         }
     }
     return true;
-}
-
-/// Check constructor payload argument types.
-///
-/// Unresolved payload variables are treated as uninhabited here, and any such
-/// variables that make the constructor impossible are recorded for the caller.
-/// The caller decides whether to use them only for this exhaustiveness query or
-/// to resolve them globally to `[]`.
-fn areAllCtorPayloadTypesInhabited(
-    type_store: *TypeStore,
-    builtin_idents: BuiltinIdents,
-    type_vars: []const Var,
-    payload_vars_to_close: ?*std.ArrayList(Var),
-) error{OutOfMemory}!bool {
-    var all_inhabited = true;
-    for (type_vars) |type_var| {
-        if (!try isCtorPayloadTypeInhabited(type_store, builtin_idents, type_var)) {
-            all_inhabited = false;
-            if (payload_vars_to_close) |out| {
-                try collectCtorPayloadBlockers(type_store, builtin_idents, type_var, out);
-            } else {
-                return false;
-            }
-        }
-    }
-    return all_inhabited;
 }
 
 /// Check if an UnresolvedPattern (sketched pattern) is inhabited.

--- a/src/check/exhaustive.zig
+++ b/src/check/exhaustive.zig
@@ -4043,7 +4043,6 @@ pub fn checkDestructure(
     builtin_idents: BuiltinIdents,
     pattern_idx: CirPattern.Idx,
     scrutinee_type: Var,
-    overall_region: Region,
     known_empty_payload_vars: []const Var,
     scrutinee_constructors_known: bool,
 ) PatternResolveError!CheckResult {
@@ -4120,7 +4119,6 @@ pub fn checkDestructure(
         result_patterns[i] = try pat.dupe(allocator);
     }
 
-    _ = overall_region;
     return .{
         .is_exhaustive = missing.len == 0,
         .missing_patterns = result_patterns,

--- a/src/check/problem.zig
+++ b/src/check/problem.zig
@@ -41,6 +41,7 @@ pub const UnusedValue = types.UnusedValue;
 
 // Match/exhaustiveness errors
 pub const NonExhaustiveMatch = types.NonExhaustiveMatch;
+pub const NonExhaustiveDestructure = types.NonExhaustiveDestructure;
 pub const RedundantPattern = types.RedundantPattern;
 pub const UnmatchablePattern = types.UnmatchablePattern;
 

--- a/src/check/problem/types.zig
+++ b/src/check/problem/types.zig
@@ -54,6 +54,7 @@ pub const Problem = union(enum) {
     comptime_eval_error: ComptimeEvalError,
     invalid_numeric_literal: InvalidNumericLiteral,
     non_exhaustive_match: NonExhaustiveMatch,
+    non_exhaustive_destructure: NonExhaustiveDestructure,
     redundant_pattern: RedundantPattern,
     unmatchable_pattern: UnmatchablePattern,
 
@@ -228,6 +229,15 @@ pub const NonExhaustiveMatch = struct {
     match_expr: CIR.Expr.Idx,
     /// Snapshot of the condition type for error messages
     condition_snapshot: SnapshotContentIdx,
+    /// Range into the problems store's missing_patterns_backing for pattern indices
+    missing_patterns: MissingPatternsRange,
+};
+
+/// Problem data for a non-exhaustive destructuring pattern
+pub const NonExhaustiveDestructure = struct {
+    pattern: CIR.Pattern.Idx,
+    /// Snapshot of the destructured value type for error messages
+    value_snapshot: SnapshotContentIdx,
     /// Range into the problems store's missing_patterns_backing for pattern indices
     missing_patterns: MissingPatternsRange,
 };

--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -50,6 +50,7 @@ const UnresolvedDispatcher = problem_mod.UnresolvedDispatcher;
 
 // Match/exhaustiveness errors
 const NonExhaustiveMatch = problem_mod.NonExhaustiveMatch;
+const NonExhaustiveDestructure = problem_mod.NonExhaustiveDestructure;
 const RedundantPattern = problem_mod.RedundantPattern;
 const UnmatchablePattern = problem_mod.UnmatchablePattern;
 
@@ -825,6 +826,7 @@ pub const ReportBuilder = struct {
             .comptime_eval_error => |data| return self.buildComptimeEvalErrorReport(data),
             .invalid_numeric_literal => |data| return self.buildInvalidNumericLiteralReport(data),
             .non_exhaustive_match => |data| return self.buildNonExhaustiveMatchReport(data),
+            .non_exhaustive_destructure => |data| return self.buildNonExhaustiveDestructureReport(data),
             .redundant_pattern => |data| return self.buildRedundantPatternReport(data),
             .unmatchable_pattern => |data| return self.buildUnmatchablePatternReport(data),
         }
@@ -3626,6 +3628,45 @@ pub const ReportBuilder = struct {
             D.bytes("_").withAnnotation(.keyword),
             D.bytes("to match anything."),
         }, self, &report);
+
+        return report;
+    }
+
+    fn buildNonExhaustiveDestructureReport(self: *Self, data: NonExhaustiveDestructure) Allocator.Error!Report {
+        var report = Report.init(self.gpa, "NON-EXHAUSTIVE DESTRUCTURE", .runtime_error);
+        errdefer report.deinit();
+
+        try D.renderSlice(&.{
+            D.bytes("This destructuring pattern doesn't cover all possible cases:"),
+        }, self, &report);
+        try report.document.addLineBreak();
+
+        try self.addSourceHighlight(&report, regionIdxFrom(data.pattern));
+        try report.document.addLineBreak();
+
+        const value_type = self.getFormattedString(data.value_snapshot);
+        try D.renderSlice(&.{
+            D.bytes("The value being destructured has type:"),
+        }, self, &report);
+        try report.document.addLineBreak();
+        try report.document.addText("        ");
+        try report.document.addAnnotated(value_type, .type_variable);
+        try report.document.addLineBreak();
+        try report.document.addLineBreak();
+
+        try D.renderSlice(&.{
+            D.bytes("Missing patterns:"),
+        }, self, &report);
+        try report.document.addLineBreak();
+
+        const missing_patterns = self.problems.getMissingPatterns(data.missing_patterns);
+        for (missing_patterns) |pattern_idx| {
+            const pattern = self.problems.getExtraString(pattern_idx);
+            const owned_pattern = try report.addOwnedString(pattern);
+            try report.document.addText("    ");
+            try report.document.addCodeBlock(owned_pattern);
+            try report.document.addLineBreak();
+        }
 
         return report;
     }

--- a/src/check/test/exhaustiveness_test.zig
+++ b/src/check/test/exhaustiveness_test.zig
@@ -504,6 +504,148 @@ test "unmatchable - Err pattern first on empty error type is unreachable" {
     try test_env.assertFirstTypeError("UNMATCHABLE PATTERN");
 }
 
+test "exhaustive - ignored error type means only Ok needed" {
+    const source =
+        \\x : Try(I64, _err)
+        \\x = Ok(42)
+        \\
+        \\result : I64
+        \\result = match x {
+        \\    Ok(n) => n
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertLastDefType("I64");
+}
+
+test "exhaustive - inferred wildcard error type means only Ok needed" {
+    const source =
+        \\x : Try(I64, _)
+        \\x = Ok(42)
+        \\
+        \\result : I64
+        \\result = match x {
+        \\    Ok(n) => n
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertLastDefType("I64");
+}
+
+test "exhaustive - direct Try.Ok match only needs Ok" {
+    const source =
+        \\result : Str
+        \\result = match Try.Ok("blah") {
+        \\    Ok(foo) => foo
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertLastDefType("Str");
+}
+
+test "unmatchable - Err pattern first on ignored error type is unreachable" {
+    const source =
+        \\x : Try(I64, _err)
+        \\x = Ok(42)
+        \\
+        \\result = match x {
+        \\    Err(_) => 0
+        \\    Ok(n) => n
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertFirstTypeError("UNMATCHABLE PATTERN");
+}
+
+test "exhaustive - structural tag with ignored payload is not required" {
+    const source =
+        \\x : [Something, Other(_payload)]
+        \\x = Something
+        \\
+        \\result : I64
+        \\result = match x {
+        \\    Something => 1
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertLastDefType("I64");
+}
+
+test "non-exhaustive - structural tag with ordinary payload is required" {
+    const source =
+        \\x : [Something, Other(payload)]
+        \\x = Something
+        \\
+        \\result = match x {
+        \\    Something => 1
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneTypeError("NON-EXHAUSTIVE MATCH");
+}
+
+test "destructure - Ok on ignored error type is exhaustive" {
+    const source =
+        \\result : Str
+        \\result = {
+        \\    x : Try(Str, _err)
+        \\    x = Ok("blah")
+        \\
+        \\    Ok(foo) = x
+        \\
+        \\    foo
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertLastDefType("Str");
+}
+
+test "destructure - direct Try.Ok is exhaustive" {
+    const source =
+        \\result : Str
+        \\result = {
+        \\    Ok(foo) = Try.Ok("blah")
+        \\
+        \\    foo
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertLastDefType("Str");
+}
+
+test "non-exhaustive destructure - Ok on concrete error type can miss Err" {
+    const source =
+        \\result = {
+        \\    x : Try(Str, Str)
+        \\    x = if True { Ok("blah") } else { Err("bad") }
+        \\
+        \\    Ok(foo) = x
+        \\
+        \\    foo
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertFirstTypeError("NON-EXHAUSTIVE DESTRUCTURE");
+}
+
 // Additional Inhabitedness Edge Cases
 // These tests verify correct handling of various uninhabited type scenarios.
 

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -197,6 +197,42 @@ fn looksLikeTypeDecl(self: *Parser) bool {
     };
 }
 
+fn looksLikeAppliedTagDestructure(self: *Parser) bool {
+    std.debug.assert(self.peek() == .UpperIdent);
+
+    var lookahead: u32 = 1;
+    while (self.peekN(lookahead) == .NoSpaceDotUpperIdent) {
+        lookahead += 1;
+    }
+
+    if (self.peekN(lookahead) != .NoSpaceOpenRound) {
+        return false;
+    }
+
+    lookahead += 1;
+    var depth: u32 = 1;
+    var closing_tok = Token.Tag.EndOfFile;
+    while (depth > 0) {
+        const tok = self.peekN(lookahead);
+        switch (tok) {
+            .OpenRound, .NoSpaceOpenRound, .OpenSquare, .OpenCurly => depth += 1,
+            .CloseRound, .CloseSquare, .CloseCurly => {
+                closing_tok = tok;
+                depth -= 1;
+            },
+            .EndOfFile => return false,
+            else => {},
+        }
+        lookahead += 1;
+    }
+
+    if (closing_tok != .CloseRound) {
+        return false;
+    }
+
+    return self.peekN(lookahead) == .OpAssign;
+}
+
 /// The error set that methods of the Parser return
 pub const Error = std.mem.Allocator.Error;
 
@@ -4969,6 +5005,16 @@ fn runExprStatementKernel(
                 }
                 if (tok == .UpperIdent) {
                     const start = self.pos;
+                    if (self.looksLikeAppliedTagDestructure()) {
+                        try open_syntax.pushPattern(open_allocator, .statement_destructure_pattern, Token.Idx, start);
+                        pattern_root_state = .{
+                            .outer_start = self.pos,
+                            .scratch_top = self.store.scratchPatternTop(),
+                            .alternatives = .alternatives_forbidden,
+                        };
+                        continue :expr_kernel .pattern_root_next;
+                    }
+
                     const is_type_decl_context = statement_type == .top_level or
                         statement_type == .in_associated_block or
                         (statement_type == .in_body and self.looksLikeTypeDecl());

--- a/test/snapshots/file/underscore_type_decl.md
+++ b/test/snapshots/file/underscore_type_decl.md
@@ -12,317 +12,65 @@ Pair2(_, y) = Pair(0, 1)
 Pair3(_, _) = Pair(0, 1)
 ~~~
 # EXPECTED
-PARSE ERROR - underscore_type_decl.md:3:13:3:14
-PARSE ERROR - underscore_type_decl.md:3:20:3:21
-PARSE ERROR - underscore_type_decl.md:3:23:3:24
-PARSE ERROR - underscore_type_decl.md:4:1:4:6
-PARSE ERROR - underscore_type_decl.md:4:6:4:7
-PARSE ERROR - underscore_type_decl.md:4:7:4:8
-PARSE ERROR - underscore_type_decl.md:4:8:4:9
-PARSE ERROR - underscore_type_decl.md:4:10:4:11
-PARSE ERROR - underscore_type_decl.md:4:11:4:12
-PARSE ERROR - underscore_type_decl.md:4:13:4:14
-PARSE ERROR - underscore_type_decl.md:4:20:4:21
-PARSE ERROR - underscore_type_decl.md:4:23:4:24
-PARSE ERROR - underscore_type_decl.md:5:1:5:6
-PARSE ERROR - underscore_type_decl.md:5:6:5:7
-PARSE ERROR - underscore_type_decl.md:5:7:5:8
-PARSE ERROR - underscore_type_decl.md:5:8:5:9
-PARSE ERROR - underscore_type_decl.md:5:10:5:11
-PARSE ERROR - underscore_type_decl.md:5:11:5:12
-PARSE ERROR - underscore_type_decl.md:5:13:5:14
-PARSE ERROR - underscore_type_decl.md:5:20:5:21
-PARSE ERROR - underscore_type_decl.md:5:23:5:24
-PARSE ERROR - underscore_type_decl.md:6:1:6:1
+NON-EXHAUSTIVE DESTRUCTURE - underscore_type_decl.md:3:1:3:12
+NON-EXHAUSTIVE DESTRUCTURE - underscore_type_decl.md:4:1:4:12
+NON-EXHAUSTIVE DESTRUCTURE - underscore_type_decl.md:5:1:5:12
 # PROBLEMS
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Try(a, Str)`
-    `Maybe(List(U64))`
-
-**underscore_type_decl.md:3:13:3:14:**
+**NON-EXHAUSTIVE DESTRUCTURE**
+This destructuring pattern doesn't cover all possible cases:
+**underscore_type_decl.md:3:1:3:12:**
 ```roc
 Pair1(x, _) = Pair(0, 1)
 ```
-            ^
+^^^^^^^^^^^
+
+The value being destructured has type:
+        _[Pair(a, b), Pair1([], []), ..]
+  where [
+    a.from_numeral : Numeral -> Try(a, [InvalidNumeral(Str)]),
+    b.from_numeral : Numeral -> Try(b, [InvalidNumeral(Str)]),
+  ]_
+
+Missing patterns:
+        _
 
 
-**PARSE ERROR**
-A parsing error occurred: `invalid_type_arg`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:3:20:3:21:**
-```roc
-Pair1(x, _) = Pair(0, 1)
-```
-                   ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `invalid_type_arg`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:3:23:3:24:**
-```roc
-Pair1(x, _) = Pair(0, 1)
-```
-                      ^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Try(a, Str)`
-    `Maybe(List(U64))`
-
-**underscore_type_decl.md:4:1:4:6:**
+**NON-EXHAUSTIVE DESTRUCTURE**
+This destructuring pattern doesn't cover all possible cases:
+**underscore_type_decl.md:4:1:4:12:**
 ```roc
 Pair2(_, y) = Pair(0, 1)
 ```
-^^^^^
+^^^^^^^^^^^
+
+The value being destructured has type:
+        _[Pair(a, b), Pair2([], []), ..]
+  where [
+    a.from_numeral : Numeral -> Try(a, [InvalidNumeral(Str)]),
+    b.from_numeral : Numeral -> Try(b, [InvalidNumeral(Str)]),
+  ]_
+
+Missing patterns:
+        _
 
 
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:4:6:4:7:**
-```roc
-Pair2(_, y) = Pair(0, 1)
-```
-     ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:4:7:4:8:**
-```roc
-Pair2(_, y) = Pair(0, 1)
-```
-      ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:4:8:4:9:**
-```roc
-Pair2(_, y) = Pair(0, 1)
-```
-       ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:4:10:4:11:**
-```roc
-Pair2(_, y) = Pair(0, 1)
-```
-         ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:4:11:4:12:**
-```roc
-Pair2(_, y) = Pair(0, 1)
-```
-          ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:4:13:4:14:**
-```roc
-Pair2(_, y) = Pair(0, 1)
-```
-            ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `invalid_type_arg`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:4:20:4:21:**
-```roc
-Pair2(_, y) = Pair(0, 1)
-```
-                   ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `invalid_type_arg`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:4:23:4:24:**
-```roc
-Pair2(_, y) = Pair(0, 1)
-```
-                      ^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Try(a, Str)`
-    `Maybe(List(U64))`
-
-**underscore_type_decl.md:5:1:5:6:**
+**NON-EXHAUSTIVE DESTRUCTURE**
+This destructuring pattern doesn't cover all possible cases:
+**underscore_type_decl.md:5:1:5:12:**
 ```roc
 Pair3(_, _) = Pair(0, 1)
 ```
-^^^^^
+^^^^^^^^^^^
 
+The value being destructured has type:
+        _[Pair(a, b), Pair3([], []), ..]
+  where [
+    a.from_numeral : Numeral -> Try(a, [InvalidNumeral(Str)]),
+    b.from_numeral : Numeral -> Try(b, [InvalidNumeral(Str)]),
+  ]_
 
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:5:6:5:7:**
-```roc
-Pair3(_, _) = Pair(0, 1)
-```
-     ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:5:7:5:8:**
-```roc
-Pair3(_, _) = Pair(0, 1)
-```
-      ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:5:8:5:9:**
-```roc
-Pair3(_, _) = Pair(0, 1)
-```
-       ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:5:10:5:11:**
-```roc
-Pair3(_, _) = Pair(0, 1)
-```
-         ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:5:11:5:12:**
-```roc
-Pair3(_, _) = Pair(0, 1)
-```
-          ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:5:13:5:14:**
-```roc
-Pair3(_, _) = Pair(0, 1)
-```
-            ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `invalid_type_arg`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:5:20:5:21:**
-```roc
-Pair3(_, _) = Pair(0, 1)
-```
-                   ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `invalid_type_arg`
-This is an unexpected parsing error. Please check your syntax.
-
-**underscore_type_decl.md:5:23:5:24:**
-```roc
-Pair3(_, _) = Pair(0, 1)
-```
-                      ^
-
-
-**PARSE ERROR**
-Type applications require parentheses around their type arguments.
-
-I found a type followed by what looks like a type argument, but they need to be connected with parentheses.
-
-Instead of:
-    **List U8**
-
-Use:
-    **List(U8)**
-
-Other valid examples:
-    `Dict(Str, Num)`
-    `Try(a, Str)`
-    `Maybe(List(U64))`
-
-**underscore_type_decl.md:6:1:6:1:**
-```roc
-
-```
-^
+Missing patterns:
+        _
 
 
 # TOKENS
@@ -341,33 +89,62 @@ EndOfFile,
 		(s-import (raw "Module")
 			(exposing
 				(exposed-upper-ident (text "Pair"))))
-		(s-malformed (tag "expected_colon_after_type_annotation"))
-		(s-malformed (tag "expected_colon_after_type_annotation"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "expected_colon_after_type_annotation"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "expected_colon_after_type_annotation"))))
+		(s-decl
+			(p-tag (raw "Pair1")
+				(p-ident (raw "x"))
+				(p-underscore))
+			(e-apply
+				(e-tag (raw "Pair"))
+				(e-int (raw "0"))
+				(e-int (raw "1"))))
+		(s-decl
+			(p-tag (raw "Pair2")
+				(p-underscore)
+				(p-ident (raw "y")))
+			(e-apply
+				(e-tag (raw "Pair"))
+				(e-int (raw "0"))
+				(e-int (raw "1"))))
+		(s-decl
+			(p-tag (raw "Pair3")
+				(p-underscore)
+				(p-underscore))
+			(e-apply
+				(e-tag (raw "Pair"))
+				(e-int (raw "0"))
+				(e-int (raw "1"))))))
 ~~~
 # FORMATTED
 ~~~roc
 import Module exposing [Pair]
 
+Pair1(x, _) = Pair(0, 1)
 
+Pair2(_, y) = Pair(0, 1)
 
+Pair3(_, _) = Pair(0, 1)
 ~~~
 # CANONICALIZE
 ~~~clojure
 (can-ir
+	(d-let
+		(p-applied-tag)
+		(e-tag (name "Pair")
+			(args
+				(e-num (value "0"))
+				(e-num (value "1")))))
+	(d-let
+		(p-applied-tag)
+		(e-tag (name "Pair")
+			(args
+				(e-num (value "0"))
+				(e-num (value "1")))))
+	(d-let
+		(p-applied-tag)
+		(e-tag (name "Pair")
+			(args
+				(e-num (value "0"))
+				(e-num (value "1")))))
 	(s-import (module "Module")
 		(exposes
 			(exposed (name "Pair") (wildcard false)))))
@@ -376,5 +153,8 @@ import Module exposing [Pair]
 ~~~clojure
 (inferred-types
 	(defs)
-	(expressions))
+	(expressions
+		(expr (type "[Pair(Dec, Dec), Pair1([], []), ..]"))
+		(expr (type "[Pair(Dec, Dec), Pair2([], []), ..]"))
+		(expr (type "[Pair(Dec, Dec), Pair3([], []), ..]"))))
 ~~~

--- a/test/snapshots/nominal/nominal_tag_payload.md
+++ b/test/snapshots/nominal/nominal_tag_payload.md
@@ -137,7 +137,7 @@ NO CHANGE
 (inferred-types
 	(defs
 		(patt (type "a -> Maybe(a)"))
-		(patt (type "Maybe(_a)"))
+		(patt (type "Maybe([])"))
 		(patt (type "a -> Maybe(a)"))
 		(patt (type "Maybe(a)")))
 	(type_decls
@@ -147,7 +147,7 @@ NO CHANGE
 					(ty-rigid-var (name "a"))))))
 	(expressions
 		(expr (type "a -> Maybe(a)"))
-		(expr (type "Maybe(_a)"))
+		(expr (type "Maybe([])"))
 		(expr (type "a -> Maybe(a)"))
 		(expr (type "Maybe(a)"))))
 ~~~


### PR DESCRIPTION
This changes exhaustiveness checking so constructors whose payload type is known to be uninhabited, including direct unconstructed payload variables inferred from expressions like Try.Ok(...), do not need to be matched. It also applies the same check to destructuring patterns, reports NON-EXHAUSTIVE DESTRUCTURE for refutable destructures, and teaches the parser to accept applied tag destructures like Ok(foo) = value.