### PR TITLE
Auto-pass benchmarks whose output is byte-identical

### DIFF
--- a/ci/benchmarks_zig/run_fx_benchmarks.sh
+++ b/ci/benchmarks_zig/run_fx_benchmarks.sh
@@ -228,6 +228,69 @@ preflight_benchmark() {
     return 2
 }
 
+# Determine whether `roc build <file>` produces a byte-identical executable for
+# the two binaries. A confirmed build slowdown whose output executable is
+# byte-identical is definitionally a false positive: the compiler produced the
+# same program, so the timing difference is measurement or binary-layout noise
+# (e.g. a larger compiler binary with slightly different code locality) rather
+# than real work.
+#
+# roc embeds nothing version-specific into the linked executable (the compiler
+# version only reaches the DWARF producer string in the intermediate bitcode,
+# which is stripped before linking), and its linker is deterministic, so two
+# compiler builds that do the same work emit byte-identical executables.
+#
+# Each binary builds in an isolated working directory and cache so their outputs
+# cannot clobber each other; --no-cache bypasses cache reads but still emits the
+# executable. Returns 0 only when both executables are present and byte-identical;
+# any uncertainty (a build failure or a missing executable) returns 1 so we fail
+# safe toward the normal slowdown failure.
+build_executable_output_identical() {
+    local main_roc="$1"
+    local pr_roc="$2"
+    local fx_file="$3"
+    local roc_extra_args="$4"
+
+    # roc resolves a platform's relative path against the source file's location
+    # and writes the executable into the current directory, so we pass an
+    # absolute source path and build from a scratch directory per binary.
+    local abs_fx
+    abs_fx="$(cd "$(dirname "$fx_file")" && pwd)/$(basename "$fx_file")" || return 1
+
+    local work
+    work=$(mktemp -d) || return 1
+    local main_dir="$work/main" pr_dir="$work/pr"
+    mkdir -p "$main_dir" "$pr_dir"
+
+    local -a extra_arg_array=()
+    if [ -n "$roc_extra_args" ]; then
+        read -r -a extra_arg_array <<< "$roc_extra_args"
+    fi
+    # Guard the array expansion so an empty extra-args list does not trip
+    # `set -u` on older bash (e.g. macOS's bash 3.2).
+    if ! ( cd "$main_dir" && XDG_CACHE_HOME="$main_dir/.cache" "$main_roc" build "$abs_fx" --no-cache "${extra_arg_array[@]+"${extra_arg_array[@]}"}" >/dev/null 2>&1 ); then
+        rm -rf "$work"
+        return 1
+    fi
+    if ! ( cd "$pr_dir" && XDG_CACHE_HOME="$pr_dir/.cache" "$pr_roc" build "$abs_fx" --no-cache "${extra_arg_array[@]+"${extra_arg_array[@]}"}" >/dev/null 2>&1 ); then
+        rm -rf "$work"
+        return 1
+    fi
+
+    local main_exe pr_exe
+    main_exe=$(find "$main_dir" -maxdepth 1 -type f -perm -u+x | head -1)
+    pr_exe=$(find "$pr_dir" -maxdepth 1 -type f -perm -u+x | head -1)
+    if [ -z "$main_exe" ] || [ -z "$pr_exe" ]; then
+        rm -rf "$work"
+        return 1
+    fi
+
+    local identical=1
+    cmp -s "$main_exe" "$pr_exe" || identical=0
+    rm -rf "$work"
+    [ "$identical" -eq 1 ]
+}
+
 # Run hyperfine benchmark and return percentage change via global variable
 # Returns 0 on success, 1 on failure
 # Sets BENCH_PCT_CHANGE on success
@@ -428,6 +491,16 @@ benchmark_file() {
         local confirm_is_slower
         confirm_is_slower=$(awk "BEGIN {print ($confirm_pct_change > 4 && $confirm_abs_delta_ms > 5) ? 1 : 0}")
         if [ "$confirm_is_slower" = "1" ]; then
+            # A build slowdown whose output executable is byte-identical is a
+            # definitional false positive (the same program cannot have cost
+            # more to produce), so pass it without a human override.
+            if [ "$roc_subcommand" = "build" ] && \
+               build_executable_output_identical "$MAIN_ROC" "$PR_ROC" "$fx_file" "$roc_extra_args"; then
+                echo "  IDENTICAL OUTPUT: $display_name produces a byte-identical executable on both binaries; treating the timing difference as a false positive (measurement or binary-layout noise), not a regression."
+                echo ""
+                return 0
+            fi
+
             echo "  SLOWER EXECUTION CONFIRMED in $display_name (${pct_change}% / ${abs_delta_ms} ms then ${confirm_pct_change}% / ${confirm_abs_delta_ms} ms)"
             SLOWER_DETECTED=1
             SLOWER_FILES+=("$display_name")


### PR DESCRIPTION
The FX build benchmarks compare a PR compiler against the base compiler by timing `roc build` on a handful of files. A confirmed slowdown can be a false positive: if the two compilers emit a byte-for-byte identical executable, they produced the same program, so the timing difference is measurement or binary-layout noise (for example, adding code to the compiler makes its own binary larger, and slightly worse code locality shows up across a second-long build while leaving the compiled output unchanged). Today these require a maintainer to override the benchmark gate by hand.

When a build benchmark's slowdown is confirmed, this builds the file with each compiler into an isolated working directory and cache and compares the resulting executables. If they are byte-identical, the benchmark passes with a note instead of failing. The comparison is exact rather than version-tolerant: roc embeds nothing version-specific into the linked executable (the compiler version only reaches the intermediate bitcode's DWARF producer string, which is stripped before linking) and its linker is deterministic, so equal work yields byte-identical executables — verified across two real compiler commits, including under `--debug`. Any uncertainty (a build failure or a missing executable) falls through to the normal slowdown failure, so a genuine codegen change is never masked.