### PR TITLE
Make Monotype function identities explicit

### DIFF
--- a/src/eval/test/eval_bughunt_repros.zig
+++ b/src/eval/test/eval_bughunt_repros.zig
@@ -638,7 +638,6 @@ pub const tests = [_]TestCase{
         \\main = (combine(Baz, Baz, |a, b| a + b) == Baz, combine(Bar(1), Bar(2), |a, b| a + b) == Bar(3))
         ,
         .expected = .{ .inspect_str = "(True, True)" },
-        .known_bug = true,
     },
     .{
         .name = "bughunt B102: recursive Monotype record lowering keeps field span stable",

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -20,6 +20,10 @@ pub const ExprId = enum(u32) { _ };
 pub const PatId = enum(u32) { _ };
 /// Identifier for a definition in Monotype IR.
 pub const DefId = enum(u32) { _ };
+/// Identifier for a nested definition in Monotype IR.
+pub const NestedDefId = enum(u32) { _ };
+/// Identifier for a function specialization in Monotype IR.
+pub const FnId = enum(u32) { _ };
 /// Identifier for a local binding in Monotype IR.
 pub const LocalId = enum(u32) { _ };
 /// Identifier assigned by Monotype lifting when this storage is consumed.
@@ -80,6 +84,11 @@ pub const FnTemplate = struct {
     source_fn_ty: checked.CheckedTypeId,
     source_fn_key: names.TypeDigest,
     mono_fn_ty: Type.TypeId,
+};
+
+/// Monotype function-specialization metadata.
+pub const Fn = struct {
+    source: FnTemplate,
 };
 
 /// Compare the fields that make two function templates identical for Monotype.
@@ -181,9 +190,9 @@ pub const TagExpr = struct {
 
 /// Lambda expression before lifting.
 pub const LambdaExpr = struct {
+    fn_id: FnId,
     args: Span(TypedLocal),
     body: ExprId,
-    source: FnTemplate,
 };
 
 /// Call through a function value before lambda solving.
@@ -194,7 +203,7 @@ pub const CallValue = struct {
 
 /// Direct call target before or after Monotype lifting.
 pub const ProcCallee = union(enum) {
-    template: FnTemplate,
+    func: FnId,
     lifted: LiftedFnId,
 };
 
@@ -267,7 +276,7 @@ pub const ExprData = union(enum) {
     },
     lambda: LambdaExpr,
     def_ref: DefId,
-    fn_def: FnTemplate,
+    fn_def: FnId,
     fn_ref: LiftedFnId,
     call_value: CallValue,
     call_proc: CallProc,
@@ -377,6 +386,7 @@ pub const Stmt = union(enum) {
 pub const Def = struct {
     symbol: Common.Symbol,
     fn_def: ?FnTemplate = null,
+    fn_id: ?FnId = null,
     args: Span(TypedLocal),
     body: FnBody,
     ret: Type.TypeId,
@@ -392,6 +402,7 @@ pub const FnBody = union(enum) {
 pub const NestedDef = struct {
     symbol: Common.Symbol,
     fn_def: FnTemplate,
+    fn_id: FnId,
     args: Span(TypedLocal),
     body: ExprId,
     ret: Type.TypeId,
@@ -425,6 +436,7 @@ pub const Program = struct {
     names: names.NameStore,
     next_symbol: u32,
     types: Type.Store,
+    fns: std.ArrayList(Fn),
     defs: std.ArrayList(Def),
     nested_defs: std.ArrayList(NestedDef),
     exprs: std.ArrayList(Expr),
@@ -465,6 +477,7 @@ pub const Program = struct {
             .names = names.NameStore.init(allocator),
             .next_symbol = 0,
             .types = Type.Store.init(allocator),
+            .fns = .empty,
             .defs = .empty,
             .nested_defs = .empty,
             .exprs = .empty,
@@ -521,8 +534,21 @@ pub const Program = struct {
         self.exprs.deinit(self.allocator);
         self.nested_defs.deinit(self.allocator);
         self.defs.deinit(self.allocator);
+        self.fns.deinit(self.allocator);
         self.types.deinit();
         self.names.deinit();
+    }
+
+    pub fn addFn(self: *Program, source: FnTemplate) std.mem.Allocator.Error!FnId {
+        const id: FnId = @enumFromInt(@as(u32, @intCast(self.fns.items.len)));
+        try self.fns.append(self.allocator, .{ .source = source });
+        return id;
+    }
+
+    pub fn fnSource(self: *const Program, id: FnId) FnTemplate {
+        const raw = @intFromEnum(id);
+        if (raw >= self.fns.items.len) Common.invariant("Monotype function id referenced a missing specialization");
+        return self.fns.items[raw].source;
     }
 
     pub fn addExpr(self: *Program, expr: Expr) std.mem.Allocator.Error!ExprId {
@@ -632,6 +658,15 @@ pub const Program = struct {
         return self.local_names.items[@intFromEnum(id)];
     }
 
+    pub fn setLocalType(self: *Program, id: LocalId, ty: Type.TypeId) void {
+        self.locals.items[@intFromEnum(id)].ty = ty;
+        for (self.typed_locals.items) |*typed_local| {
+            if (typed_local.local == id) {
+                typed_local.ty = ty;
+            }
+        }
+    }
+
     pub fn addExprSpan(self: *Program, ids: []const ExprId) std.mem.Allocator.Error!Span(ExprId) {
         const start: u32 = @intCast(self.expr_ids.items.len);
         try self.expr_ids.appendSlice(self.allocator, ids);
@@ -646,7 +681,11 @@ pub const Program = struct {
 
     pub fn addTypedLocalSpan(self: *Program, values: []const TypedLocal) std.mem.Allocator.Error!Span(TypedLocal) {
         const start: u32 = @intCast(self.typed_locals.items.len);
-        try self.typed_locals.appendSlice(self.allocator, values);
+        try self.typed_locals.ensureUnusedCapacity(self.allocator, values.len);
+        for (values) |value| {
+            const local_ty = self.locals.items[@intFromEnum(value.local)].ty;
+            self.typed_locals.appendAssumeCapacity(.{ .local = value.local, .ty = local_ty });
+        }
         return .{ .start = start, .len = @intCast(values.len) };
     }
 

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -220,18 +220,31 @@ const HostedSectionMap = struct {
 
 const BinderMap = std.AutoHashMap(checked.PatternBinderId, Ast.LocalId);
 
-/// A lowered procedure template specialization together with the Monotype
-/// function type its body was lowered at.
+const LoweredTemplateStatus = enum {
+    reserved,
+    lowering,
+    ready,
+};
+
+/// A procedure template specialization together with the Monotype function
+/// type its body is reserved or lowered at.
 const LoweredTemplate = struct {
     def: Ast.DefId,
     fn_ty: Type.TypeId,
+    status: LoweredTemplateStatus,
 };
 
 /// A lowered nested function specialization together with the Monotype
 /// function type its body was lowered at.
 const LoweredNestedFn = struct {
-    nested_id: u32,
+    nested_id: Ast.NestedDefId,
+    fn_id: Ast.FnId,
     fn_ty: Type.TypeId,
+};
+
+const ReservedTemplate = struct {
+    fn_id: Ast.FnId,
+    needs_lowering: bool,
 };
 
 /// A nested function body together with the instantiation context that
@@ -766,7 +779,7 @@ const Builder = struct {
         const body = try self.program.addExpr(.{
             .ty = fn_data.ret,
             .data = .{ .call_proc = .{
-                .callee = .{ .template = callee },
+                .callee = .{ .func = callee },
                 .args = try self.program.addExprSpan(arg_exprs),
             } },
         });
@@ -839,8 +852,11 @@ const Builder = struct {
                     view.types.rootKey(source_fn_ty),
                     mono_fn_ty,
                 );
-                const lowered_template = try self.lowerFnTemplateDef(view, fn_template);
-                break :blk try self.program.addExpr(.{ .ty = lowered_template.mono_fn_ty, .data = .{ .fn_def = lowered_template } });
+                const fn_id = try self.lowerFnTemplateDef(view, fn_template);
+                break :blk try self.program.addExpr(.{
+                    .ty = self.program.fnSource(fn_id).mono_fn_ty,
+                    .data = .{ .fn_def = fn_id },
+                });
             },
             .callable_eval_template => |template_id| try self.lowerCallableEvalBindingValue(view, template_id, mono_fn_ty),
         };
@@ -948,7 +964,9 @@ const Builder = struct {
         const family_entry = try self.lowered_templates.getOrPut(family);
         if (!family_entry.found_existing) family_entry.value_ptr.* = .empty;
         const fn_ty_digest = self.program.types.typeDigest(&self.program.names, fn_ty);
-        for (family_entry.value_ptr.items) |existing| {
+        var reserved_def: ?Ast.DefId = null;
+        var lower_fn_ty = fn_ty;
+        for (family_entry.value_ptr.items) |*existing| {
             if (existing.fn_ty != fn_ty) {
                 const existing_digest = self.program.types.typeDigest(&self.program.names, existing.fn_ty);
                 if (!std.mem.eql(u8, existing_digest.bytes[0..], fn_ty_digest.bytes[0..])) continue;
@@ -957,40 +975,81 @@ const Builder = struct {
                     try graph.drainDirty();
                 }
             }
-            return existing.def;
+            switch (existing.status) {
+                .ready,
+                .lowering,
+                => return existing.def,
+                .reserved => {
+                    reserved_def = existing.def;
+                    lower_fn_ty = existing.fn_ty;
+                    existing.status = .lowering;
+                    break;
+                },
+            }
         }
 
         const view = self.moduleForDigest(names.procTemplateModuleDigest(template_ref));
         const template = view.templates.get(template_ref.template);
-        const symbol = self.symbols.fresh();
-        const fn_template = self.fnDefForTemplate(view, template_ref, source_fn_ty, source_fn_key, fn_ty);
-        try self.registerProcDebugNameForTemplate(symbol, view, template_ref);
+        const fn_template = self.fnDefForTemplate(view, template_ref, source_fn_ty, source_fn_key, lower_fn_ty);
 
-        const reserved: Ast.DefId = @enumFromInt(@as(u32, @intCast(self.program.defs.items.len)));
-        // The definition fills once its body lowers; a recursive request that
-        // reuses this entry meanwhile reads the requested template, which is
-        // the same specialization by construction.
-        try self.program.defs.append(self.allocator, .{
-            .symbol = symbol,
-            .fn_def = fn_template,
-            .args = Ast.Span(Ast.TypedLocal).empty(),
-            .body = .hosted,
-            .ret = self.functionShape(fn_ty, "procedure template root type was not a function").ret,
-        });
-        try family_entry.value_ptr.append(self.allocator, .{ .def = reserved, .fn_ty = fn_ty });
+        const Reservation = struct {
+            def: Ast.DefId,
+            fn_id: Ast.FnId,
+            symbol: Common.Symbol,
+        };
+        const reservation: Reservation = if (reserved_def) |def_id| blk: {
+            const def = &self.program.defs.items[@intFromEnum(def_id)];
+            const fn_id = def.fn_id orelse
+                Common.invariant("reserved Monotype procedure template definition had no function id");
+            def.fn_def = fn_template;
+            self.program.fns.items[@intFromEnum(fn_id)].source = fn_template;
+            break :blk .{
+                .def = def_id,
+                .fn_id = fn_id,
+                .symbol = def.symbol,
+            };
+        } else blk: {
+            const symbol = self.symbols.fresh();
+            try self.registerProcDebugNameForTemplate(symbol, view, template_ref);
+            const fn_id = try self.program.addFn(fn_template);
+            const def_id: Ast.DefId = @enumFromInt(@as(u32, @intCast(self.program.defs.items.len)));
+            // The definition fills once its body lowers; a recursive request
+            // that reuses this entry meanwhile reads the requested template,
+            // which is the same specialization by construction.
+            try self.program.defs.append(self.allocator, .{
+                .symbol = symbol,
+                .fn_def = fn_template,
+                .fn_id = fn_id,
+                .args = Ast.Span(Ast.TypedLocal).empty(),
+                .body = .hosted,
+                .ret = self.functionShape(lower_fn_ty, "procedure template root type was not a function").ret,
+            });
+            try family_entry.value_ptr.append(self.allocator, .{
+                .def = def_id,
+                .fn_ty = lower_fn_ty,
+                .status = .lowering,
+            });
+            break :blk .{
+                .def = def_id,
+                .fn_id = fn_id,
+                .symbol = symbol,
+            };
+        };
 
         switch (template.target) {
             .hosted => {
-                const fn_data = self.functionShape(fn_ty, "hosted procedure template root type was not a function");
+                const fn_data = self.functionShape(lower_fn_ty, "hosted procedure template root type was not a function");
                 const args = try self.typedLocalsForArgs(self.program.types.span(fn_data.args));
-                self.program.defs.items[@intFromEnum(reserved)] = .{
-                    .symbol = symbol,
+                self.program.defs.items[@intFromEnum(reservation.def)] = .{
+                    .symbol = reservation.symbol,
                     .fn_def = fn_template,
+                    .fn_id = reservation.fn_id,
                     .args = args,
                     .body = .hosted,
                     .ret = fn_data.ret,
                 };
-                return reserved;
+                self.markTemplateReady(family, reservation.def, lower_fn_ty);
+                return reservation.def;
             },
             .roc,
             .intrinsic,
@@ -1010,9 +1069,9 @@ const Builder = struct {
         body_ctx.current_fn_key = root_fn_key;
         defer body_ctx.deinit();
         if (moduleBytesEqual(source_ty_view.key.bytes, view.key.bytes)) {
-            try body_ctx.constrainKnownType(source_fn_ty, fn_ty);
+            try body_ctx.constrainKnownType(source_fn_ty, lower_fn_ty);
         }
-        try body_ctx.constrainTypeToMono(template.checked_fn_root, fn_ty);
+        try body_ctx.constrainTypeToMono(template.checked_fn_root, lower_fn_ty);
 
         // The requested function type becomes a view of this specialization's
         // root: every later stage compares call-site and definition types for
@@ -1021,8 +1080,8 @@ const Builder = struct {
         // requester's id in place. Builder-global types stay snapshots; they
         // serve many specializations.
         const root_node = try body_ctx.instNode(template.checked_fn_root);
-        if (!self.unsolved_monos.contains(fn_ty)) {
-            try graph.addMonoView(root_node, fn_ty);
+        if (!self.unsolved_monos.contains(lower_fn_ty)) {
+            try graph.addMonoView(root_node, lower_fn_ty);
         }
         const live_fn_ty = try graph.monoFor(root_node);
         const lowered = try body_ctx.lowerTemplateBody(template_ref, template, live_fn_ty);
@@ -1033,6 +1092,7 @@ const Builder = struct {
         // adopt this recorded template directly.
         var def_template = fn_template;
         def_template.mono_fn_ty = live_fn_ty;
+        self.program.fns.items[@intFromEnum(reservation.fn_id)].source = def_template;
         // The body may have refined slots the request left unresolved (empty
         // tag unions). Flow the solved view back into the requester's Monotype
         // so call sites embedding the requested id digest identically to this
@@ -1044,15 +1104,81 @@ const Builder = struct {
             );
             try requester_graph.drainDirty();
         }
-        self.program.defs.items[@intFromEnum(reserved)] = .{
-            .symbol = symbol,
+        self.program.defs.items[@intFromEnum(reservation.def)] = .{
+            .symbol = reservation.symbol,
             .fn_def = def_template,
+            .fn_id = reservation.fn_id,
             .args = lowered.args,
             .body = .{ .roc = lowered.body },
             .ret = lowered.ret,
         };
+        self.markTemplateReady(family, reservation.def, live_fn_ty);
         try self.drainSpecRequests(graph);
-        return reserved;
+        return reservation.def;
+    }
+
+    fn reserveTemplateWithMonoFor(
+        self: *Builder,
+        template_ref: names.ProcTemplate,
+        source_fn_ty: checked.CheckedTypeId,
+        source_fn_key: names.TypeDigest,
+        fn_ty: Type.TypeId,
+        requester: *InstGraph,
+    ) Allocator.Error!ReservedTemplate {
+        const family = TemplateFamily.from(template_ref, source_fn_key);
+        const family_entry = try self.lowered_templates.getOrPut(family);
+        if (!family_entry.found_existing) family_entry.value_ptr.* = .empty;
+        const fn_ty_digest = self.program.types.typeDigest(&self.program.names, fn_ty);
+        for (family_entry.value_ptr.items) |existing| {
+            if (existing.fn_ty != fn_ty) {
+                const existing_digest = self.program.types.typeDigest(&self.program.names, existing.fn_ty);
+                if (!std.mem.eql(u8, existing_digest.bytes[0..], fn_ty_digest.bytes[0..])) continue;
+                try requester.unify(try requester.importMono(fn_ty), try requester.importMono(existing.fn_ty));
+                try requester.drainDirty();
+            }
+            const def = self.program.defs.items[@intFromEnum(existing.def)];
+            return .{
+                .fn_id = def.fn_id orelse
+                    Common.invariant("reserved Monotype procedure template definition had no function id"),
+                .needs_lowering = existing.status == .reserved,
+            };
+        }
+
+        const view = self.moduleForDigest(names.procTemplateModuleDigest(template_ref));
+        const fn_template = self.fnDefForTemplate(view, template_ref, source_fn_ty, source_fn_key, fn_ty);
+        const fn_id = try self.program.addFn(fn_template);
+        const def_id: Ast.DefId = @enumFromInt(@as(u32, @intCast(self.program.defs.items.len)));
+        const symbol = self.symbols.fresh();
+        try self.registerProcDebugNameForTemplate(symbol, view, template_ref);
+        try self.program.defs.append(self.allocator, .{
+            .symbol = symbol,
+            .fn_def = fn_template,
+            .fn_id = fn_id,
+            .args = Ast.Span(Ast.TypedLocal).empty(),
+            .body = .hosted,
+            .ret = self.functionShape(fn_ty, "procedure template root type was not a function").ret,
+        });
+        try family_entry.value_ptr.append(self.allocator, .{
+            .def = def_id,
+            .fn_ty = fn_ty,
+            .status = .reserved,
+        });
+        return .{
+            .fn_id = fn_id,
+            .needs_lowering = true,
+        };
+    }
+
+    fn markTemplateReady(self: *Builder, family: TemplateFamily, def: Ast.DefId, fn_ty: Type.TypeId) void {
+        const entries = self.lowered_templates.getPtr(family) orelse
+            Common.invariant("lowered procedure template family disappeared before completion");
+        for (entries.items) |*entry| {
+            if (entry.def != def) continue;
+            entry.fn_ty = fn_ty;
+            entry.status = .ready;
+            return;
+        }
+        Common.invariant("lowered procedure template definition disappeared before completion");
     }
 
     fn typedLocalsForArgs(self: *Builder, arg_tys: []const Type.TypeId) Allocator.Error!Ast.Span(Ast.TypedLocal) {
@@ -1601,7 +1727,7 @@ const Builder = struct {
         source_ty_view: ModuleView,
         proc: checked.ProcedureUseTemplate,
         source_fn_ty: checked.CheckedTypeId,
-    ) Allocator.Error!Ast.FnTemplate {
+    ) Allocator.Error!Ast.FnId {
         const mono_fn_ty = try self.lowerType(source_ty_view, source_fn_ty);
         const source_fn_key = proc.source_fn_ty_template;
         const fn_template = switch (proc.binding) {
@@ -1634,13 +1760,12 @@ const Builder = struct {
         return try self.lowerFnTemplateDef(source_ty_view, fn_template);
     }
 
-    /// Lower (or defer) a procedure template body and return the template the
-    /// call site should embed. Inside a specialization the request defers and
-    /// the requester's types agree with the body by construction. Outside one
-    /// (root and wrapper paths, whose types come from the builder-global cache
-    /// without body evidence), the body lowers now and the call site embeds
-    /// the definition's recorded template so both share the solved type.
-    fn lowerFnTemplateDef(self: *Builder, source_ty_view: ModuleView, fn_template: Ast.FnTemplate) Allocator.Error!Ast.FnTemplate {
+    /// Lower (or defer) a procedure template body and return the Monotype
+    /// function id the call site should embed. Inside a specialization the
+    /// request reserves an id and defers the body; outside one (root and
+    /// wrapper paths, whose types come from the builder-global cache without
+    /// body evidence), the body lowers now.
+    fn lowerFnTemplateDef(self: *Builder, source_ty_view: ModuleView, fn_template: Ast.FnTemplate) Allocator.Error!Ast.FnId {
         const template_ref = switch (fn_template.fn_def) {
             .local_template,
             .imported_template,
@@ -1649,7 +1774,7 @@ const Builder = struct {
             .local_hosted,
             .imported_hosted,
             => |hosted| hosted.template,
-            .nested => return fn_template,
+            .nested => Common.invariant("nested function specialization must be lowered through nested function lowering"),
         };
         // Deferral exists so a requester's solved types key the request; a
         // request typed by an unsolved builder-global Monotype gains nothing
@@ -1657,21 +1782,30 @@ const Builder = struct {
         // template instead.
         if (!self.unsolved_monos.contains(fn_template.mono_fn_ty)) {
             if (self.active_graph) |graph| {
-                try graph.deferred_templates.append(self.allocator, .{
-                    .template_ref = template_ref,
-                    .module = source_ty_view.key,
-                    .source_fn_ty = fn_template.source_fn_ty,
-                    .source_fn_key = fn_template.source_fn_key,
-                    .fn_ty = fn_template.mono_fn_ty,
-                });
-                return fn_template;
+                const reserved = try self.reserveTemplateWithMonoFor(
+                    template_ref,
+                    fn_template.source_fn_ty,
+                    fn_template.source_fn_key,
+                    fn_template.mono_fn_ty,
+                    graph,
+                );
+                if (reserved.needs_lowering) {
+                    try graph.deferred_templates.append(self.allocator, .{
+                        .template_ref = template_ref,
+                        .module = source_ty_view.key,
+                        .source_fn_ty = fn_template.source_fn_ty,
+                        .source_fn_key = fn_template.source_fn_key,
+                        .fn_ty = fn_template.mono_fn_ty,
+                    });
+                }
+                return reserved.fn_id;
             }
         }
         const def = try self.lowerTemplateWithMono(template_ref, source_ty_view, fn_template.source_fn_ty, fn_template.source_fn_key, fn_template.mono_fn_ty);
-        return self.program.defs.items[@intFromEnum(def)].fn_def orelse fn_template;
+        return self.defFnId(def);
     }
 
-    fn lowerRestoredConstFnTemplate(self: *Builder, type_view: ModuleView, fn_template: Ast.FnTemplate) Allocator.Error!Ast.FnTemplate {
+    fn lowerRestoredConstFnTemplate(self: *Builder, type_view: ModuleView, fn_template: Ast.FnTemplate) Allocator.Error!Ast.FnId {
         switch (fn_template.fn_def) {
             .nested => {
                 const fn_view = self.moduleForConstFnDef(fn_template.fn_def);
@@ -1682,37 +1816,47 @@ const Builder = struct {
                 defer self.active_graph = saved_graph;
                 var fn_ctx = try BodyContext.init(self.allocator, self, fn_view, ownerTemplateForConstFnDef(fn_template.fn_def), graph);
                 defer fn_ctx.deinit();
-                try self.lowerNestedFnFromContext(&fn_ctx, checkedLambdaExprIdForConstFn(fn_view, fn_template.fn_def), fn_template);
+                const fn_id = try self.lowerNestedFnFromContext(&fn_ctx, checkedLambdaExprIdForConstFn(fn_view, fn_template.fn_def), fn_template);
                 try self.drainSpecRequests(graph);
-                return fn_template;
+                return fn_id;
             },
             else => return try self.lowerFnTemplateDef(type_view, fn_template),
         }
     }
 
-    fn lowerFnTemplateDefFromContext(self: *Builder, source_ctx: *BodyContext, fn_template: Ast.FnTemplate) Allocator.Error!void {
-        switch (fn_template.fn_def) {
+    fn lowerFnTemplateDefFromContext(self: *Builder, source_ctx: *BodyContext, fn_template: Ast.FnTemplate) Allocator.Error!Ast.FnId {
+        const template_ref = switch (fn_template.fn_def) {
             .local_template,
             .imported_template,
             .checked_generated,
-            => |template| try source_ctx.graph.deferred_templates.append(self.allocator, .{
-                .template_ref = template,
-                .module = source_ctx.view.key,
-                .source_fn_ty = fn_template.source_fn_ty,
-                .source_fn_key = fn_template.source_fn_key,
-                .fn_ty = fn_template.mono_fn_ty,
-            }),
+            => |template| template,
             .local_hosted,
             .imported_hosted,
-            => |hosted| try source_ctx.graph.deferred_templates.append(self.allocator, .{
-                .template_ref = hosted.template,
+            => |hosted| hosted.template,
+            .nested => Common.invariant("nested function specialization must be lowered through nested function lowering"),
+        };
+        const reserved = try self.reserveTemplateWithMonoFor(
+            template_ref,
+            fn_template.source_fn_ty,
+            fn_template.source_fn_key,
+            fn_template.mono_fn_ty,
+            source_ctx.graph,
+        );
+        if (reserved.needs_lowering) {
+            try source_ctx.graph.deferred_templates.append(self.allocator, .{
+                .template_ref = template_ref,
                 .module = source_ctx.view.key,
                 .source_fn_ty = fn_template.source_fn_ty,
                 .source_fn_key = fn_template.source_fn_key,
                 .fn_ty = fn_template.mono_fn_ty,
-            }),
-            .nested => {},
+            });
         }
+        return reserved.fn_id;
+    }
+
+    fn defFnId(self: *Builder, def: Ast.DefId) Ast.FnId {
+        return self.program.defs.items[@intFromEnum(def)].fn_id orelse
+            Common.invariant("Monotype procedure template definition had no function id");
     }
 
     fn nestedFnForExpr(
@@ -1764,21 +1908,21 @@ const Builder = struct {
         source_ctx: *BodyContext,
         expr_id: checked.CheckedExprId,
         fn_template: Ast.FnTemplate,
-    ) Allocator.Error!void {
+    ) Allocator.Error!Ast.FnId {
         const nested_ctx = try self.allocator.create(BodyContext);
         errdefer self.allocator.destroy(nested_ctx);
         nested_ctx.* = try source_ctx.nestedInstantiationContext(Ast.fnTemplateDigest(fn_template, &self.program.types, &self.program.names));
         // Nested functions share the requester's graph, and an inferred local
         // procedure's body pins signature variables (its own evidence) that
         // the requester's remaining body relies on, so the body lowers now.
-        try self.lowerNestedFnRequest(.{
+        return try self.lowerNestedFnRequest(.{
             .ctx = nested_ctx,
             .expr_id = expr_id,
             .fn_template = fn_template,
         });
     }
 
-    fn lowerNestedFnRequest(self: *Builder, request: NestedFnRequest) Allocator.Error!void {
+    fn lowerNestedFnRequest(self: *Builder, request: NestedFnRequest) Allocator.Error!Ast.FnId {
         defer {
             request.ctx.deinit();
             self.allocator.destroy(request.ctx);
@@ -1802,24 +1946,47 @@ const Builder = struct {
                 );
                 try request.ctx.graph.drainDirty();
             }
-            return;
+            return existing.fn_id;
         }
 
-        const nested_id: u32 = @intCast(self.program.nested_defs.items.len);
+        const nested_id: Ast.NestedDefId = @enumFromInt(@as(u32, @intCast(self.program.nested_defs.items.len)));
+        const fn_id = try self.program.addFn(fn_template);
         try self.program.nested_defs.append(self.allocator, undefined);
-        try family_entry.value_ptr.append(self.allocator, .{ .nested_id = nested_id, .fn_ty = fn_template.mono_fn_ty });
+        try family_entry.value_ptr.append(self.allocator, .{
+            .nested_id = nested_id,
+            .fn_id = fn_id,
+            .fn_ty = fn_template.mono_fn_ty,
+        });
 
         try request.ctx.constrainTypeToMono(fn_template.source_fn_ty, fn_template.mono_fn_ty);
 
-        const live_fn_ty = try request.ctx.graph.monoFor(try request.ctx.instNode(fn_template.source_fn_ty));
+        const root_node = try request.ctx.instNode(fn_template.source_fn_ty);
+        if (!self.unsolved_monos.contains(fn_template.mono_fn_ty)) {
+            try request.ctx.graph.addMonoView(root_node, fn_template.mono_fn_ty);
+        }
+        const live_fn_ty = try request.ctx.graph.monoFor(root_node);
         const lowered = try request.ctx.lowerNestedFunction(request.expr_id, live_fn_ty);
-        self.program.nested_defs.items[nested_id] = .{
+        var def_template = fn_template;
+        def_template.mono_fn_ty = live_fn_ty;
+        self.program.fns.items[@intFromEnum(fn_id)].source = def_template;
+        self.program.nested_defs.items[@intFromEnum(nested_id)] = .{
             .symbol = self.symbols.fresh(),
-            .fn_def = fn_template,
+            .fn_def = def_template,
+            .fn_id = fn_id,
             .args = lowered.args,
             .body = lowered.body,
             .ret = lowered.ret,
         };
+        if (live_fn_ty != fn_template.mono_fn_ty) {
+            const entries = self.lowered_nested_fns.getPtr(family) orelse
+                Common.invariant("lowered nested function family disappeared before completion");
+            for (entries.items) |*entry| {
+                if (entry.nested_id != nested_id) continue;
+                entry.fn_ty = live_fn_ty;
+                break;
+            }
+        }
+        return fn_id;
     }
 
     /// Process the specialization body requests this specialization enqueued
@@ -1883,8 +2050,11 @@ const Builder = struct {
         const fn_value = store_view.const_store.fns.items[raw];
         const template = try self.constFnTemplateToMono(fn_value, ty);
         if (fn_value.captures.len == 0) {
-            const lowered_template = try self.lowerRestoredConstFnTemplate(type_view, template);
-            return try self.program.addExpr(.{ .ty = lowered_template.mono_fn_ty, .data = .{ .fn_def = lowered_template } });
+            const mono_fn_id = try self.lowerRestoredConstFnTemplate(type_view, template);
+            return try self.program.addExpr(.{
+                .ty = self.program.fnSource(mono_fn_id).mono_fn_ty,
+                .data = .{ .fn_def = mono_fn_id },
+            });
         }
 
         const fn_view = self.moduleForConstFnDef(fn_value.fn_def);
@@ -1955,7 +2125,7 @@ const Builder = struct {
         var expr = try self.program.addExpr(.{
             .ty = ty,
             .data = switch (lambda_expr.data) {
-                .lambda => |lambda| try fn_ctx.lowerLambdaExpr(lambda, template),
+                .lambda => try fn_ctx.lowerLambdaExpr(lambda_expr_id, template),
                 else => Common.invariant("stored capturing function did not reference a checked lambda"),
             },
         });
@@ -2250,7 +2420,7 @@ const Builder = struct {
         var target_ctx = try BodyContext.init(self.allocator, self, lookup.view, template, graph);
         defer target_ctx.deinit();
         const callable_mono_ty = try target_ctx.instantiateTargetCallTypeFromMonoArgs(lookup.target.callable_ty, &.{value_ty}, str_ty);
-        _ = try self.lowerTemplateWithMono(
+        const callee_def = try self.lowerTemplateWithMono(
             template,
             lookup.view,
             lookup.target.callable_ty,
@@ -2260,13 +2430,7 @@ const Builder = struct {
 
         const args = [_]Ast.ExprId{value};
         const call = try self.program.addExpr(.{ .ty = str_ty, .data = .{ .call_proc = .{
-            .callee = .{ .template = self.fnDefForTemplate(
-                lookup.view,
-                template,
-                lookup.target.callable_ty,
-                lookup.view.types.rootKey(lookup.target.callable_ty),
-                callable_mono_ty,
-            ) },
+            .callee = .{ .func = self.defFnId(callee_def) },
             .args = try self.program.addExprSpan(&args),
         } } });
         try self.drainSpecRequests(graph);
@@ -3120,6 +3284,10 @@ const BodyContext = struct {
             .index = 0,
             .body = checked_body,
         } }, ret_ty);
+        const body_loc = self.builder.program.exprLoc(body);
+        const saved_loc = self.builder.program.current_loc;
+        defer self.builder.program.current_loc = saved_loc;
+        self.builder.program.current_loc = body_loc;
         var remaining = arg_lets.items.len;
         while (remaining > 0) {
             remaining -= 1;
@@ -3264,9 +3432,9 @@ const BodyContext = struct {
             .zero_argument_tag => |tag| .{ .tag = .{ .name = try self.builder.tagName(self.view, tag.name), .payloads = .empty() } },
             .nominal => |nominal| .{ .nominal = try self.lowerExprAtType(nominal.backing_expr, self.builder.namedBackingType(ty) orelse ty) },
             .closure => |closure| try self.lowerClosure(expr_id, closure, ty),
-            .lambda => |lambda| blk: {
+            .lambda => blk: {
                 break :blk try self.lowerLambdaExpr(
-                    lambda,
+                    expr_id,
                     try self.builder.fnTemplateForNestedExprWithMono(self.view, self.owner_template, expr_id, expr.ty, self.view.types.rootKey(expr.ty), ty, self.current_fn_key),
                 );
             },
@@ -3406,7 +3574,7 @@ const BodyContext = struct {
             return .{
                 .ret_ty = fn_data.ret,
                 .data = .{ .call_proc = .{
-                    .callee = .{ .template = callee },
+                    .callee = .{ .func = callee },
                     .args = try self.lowerExprSpanAtTypes(call.args, self.builder.program.types.span(fn_data.args)),
                 } },
             };
@@ -3524,7 +3692,11 @@ const BodyContext = struct {
         const fn_node = try self.instNode(source_fn_ty);
         for (function.args, checked_args) |formal_ty, checked_arg| {
             const arg_ty = caller.view.bodies.exprs[@intFromEnum(checked_arg)].ty;
-            try self.graph.unify(try self.instNode(formal_ty), try caller.instNode(arg_ty));
+            const formal_node = try self.instNode(formal_ty);
+            try self.graph.unify(formal_node, try caller.instNode(arg_ty));
+            if (try caller.callArgumentMonoType(checked_arg, null)) |evidence_ty| {
+                try self.graph.unify(formal_node, try self.graph.importMono(evidence_ty));
+            }
         }
         try self.graph.unify(try self.instNode(function.ret), try caller.instNode(checked_ret_ty));
         if (expected_ret_ty) |expected| {
@@ -3742,7 +3914,7 @@ const BodyContext = struct {
         source_fn_ty: checked.CheckedTypeId,
         source_fn_key: names.TypeDigest,
         mono_fn_ty: Type.TypeId,
-    ) Allocator.Error!Ast.FnTemplate {
+    ) Allocator.Error!Ast.FnId {
         const raw = @intFromEnum(target);
         if (raw >= self.view.resolved_refs.records.len) {
             Common.invariant("checked direct call target is outside resolved value table");
@@ -3773,7 +3945,7 @@ const BodyContext = struct {
         source_fn_ty: checked.CheckedTypeId,
         source_fn_key: names.TypeDigest,
         mono_fn_ty: Type.TypeId,
-    ) Allocator.Error!Ast.FnTemplate {
+    ) Allocator.Error!Ast.FnId {
         const context_fn_key = self.local_proc_contexts.get(local.binder) orelse
             Common.invariant("local procedure use reached Monotype before its declaration context");
         const fn_template = try self.builder.fnTemplateForNestedExprWithMono(
@@ -3785,8 +3957,7 @@ const BodyContext = struct {
             mono_fn_ty,
             context_fn_key,
         );
-        try self.builder.lowerNestedFnFromContext(self, local.expr, fn_template);
-        return fn_template;
+        return try self.builder.lowerNestedFnFromContext(self, local.expr, fn_template);
     }
 
     fn fnDefForProcedureUseWithMono(
@@ -3795,7 +3966,7 @@ const BodyContext = struct {
         source_fn_ty: checked.CheckedTypeId,
         source_fn_key: names.TypeDigest,
         mono_fn_ty: Type.TypeId,
-    ) Allocator.Error!Ast.FnTemplate {
+    ) Allocator.Error!Ast.FnId {
         const fn_template = switch (proc.binding) {
             .top_level => |top_level| blk: {
                 const view = self.builder.moduleForId(checked.topLevelProcedureModuleId(top_level));
@@ -3829,8 +4000,7 @@ const BodyContext = struct {
                 break :blk self.builder.fnDefForProcedureBindingBody(app_view, binding.body, binding_source, app_view.types.rootKey(binding_source), mono_fn_ty);
             },
         };
-        try self.builder.lowerFnTemplateDefFromContext(self, fn_template);
-        return fn_template;
+        return try self.builder.lowerFnTemplateDefFromContext(self, fn_template);
     }
 
     fn currentLocalBindingForResolvedValue(self: *BodyContext, ref_id: checked.ResolvedValueId) ?CurrentLocal {
@@ -3868,16 +4038,19 @@ const BodyContext = struct {
         if (self.currentLocalBindingForResolvedValue(ref_id)) |binding| {
             const local_id = binding.local;
             const local_ty = self.builder.program.locals.items[@intFromEnum(local_id)].ty;
+            const binder_ty = checkedBinderType(self.view, binding.binder);
             // The local's Monotype identifies the binder's node in the
             // context that bound it; importing it unifies this context's
             // instantiation with that node before the use type is unified.
-            try self.constrainTypeToMono(checkedBinderType(self.view, binding.binder), local_ty);
-            try self.constrainTypeToMono(checkedBinderType(self.view, binding.binder), ty);
+            try self.constrainTypeToMono(binder_ty, local_ty);
+            try self.constrainTypeToMono(binder_ty, ty);
             try self.constrainTypeToMono(checked_ty, ty);
-            if (!self.sameType(ty, local_ty)) {
+            const live_ty = try self.lowerType(binder_ty);
+            if (live_ty != local_ty) self.builder.program.setLocalType(local_id, live_ty);
+            if (!self.sameType(ty, live_ty)) {
                 Common.invariant("checked local lookup type differed from its expected Monotype use type");
             }
-            return try self.builder.program.addExpr(.{ .ty = ty, .data = .{ .local = local_id } });
+            return try self.builder.program.addExpr(.{ .ty = live_ty, .data = .{ .local = local_id } });
         }
 
         switch (record.ref) {
@@ -3948,8 +4121,8 @@ const BodyContext = struct {
                     proc.source_fn_ty_template,
                     mono_fn_ty,
                 );
-                try self.builder.lowerFnTemplateDefFromContext(self, fn_template);
-                break :blk try self.builder.program.addExpr(.{ .ty = mono_fn_ty, .data = .{ .fn_def = fn_template } });
+                const fn_id = try self.builder.lowerFnTemplateDefFromContext(self, fn_template);
+                break :blk try self.builder.program.addExpr(.{ .ty = mono_fn_ty, .data = .{ .fn_def = fn_id } });
             },
             .platform_required => |required| blk: {
                 const view = self.builder.moduleForId(checked.requiredProcedureModuleId(required));
@@ -4018,7 +4191,12 @@ const BodyContext = struct {
         try body_ctx.constrainTypeToMono(entry_template.checked_fn_root, wrapper_fn_ty);
         try body_ctx.constrainTypeToMono(body.checked_type, ty);
 
-        const lowered = try body_ctx.lowerExprAtType(body.body_expr, ty);
+        const result_node = try body_ctx.instNode(body.checked_type);
+        if (!self.builder.unsolved_monos.contains(ty)) {
+            try graph.addMonoView(result_node, ty);
+        }
+        const live_ty = try graph.monoFor(result_node);
+        const lowered = try body_ctx.lowerExprAtType(body.body_expr, live_ty);
         try self.builder.drainSpecRequests(graph);
         return lowered;
     }
@@ -4292,6 +4470,9 @@ const BodyContext = struct {
         ty: Type.TypeId,
     ) Allocator.Error!Ast.ExprId {
         const expr = self.view.bodies.exprs[@intFromEnum(checked_expr)];
+        const saved_loc = self.builder.program.current_loc;
+        defer self.builder.program.current_loc = saved_loc;
+        self.builder.program.current_loc = try self.sourceLocFor(expr.source_region);
         switch (expr.data) {
             .call => |call| {
                 try self.constrainKnownType(expr.ty, ty);
@@ -4505,9 +4686,9 @@ const BodyContext = struct {
     fn lowerClosure(self: *BodyContext, expr_id: checked.CheckedExprId, closure: anytype, closure_ty: Type.TypeId) Allocator.Error!Ast.ExprData {
         const lambda = self.view.bodies.exprs[@intFromEnum(closure.lambda)];
         return switch (lambda.data) {
-            .lambda => |lambda_data| blk: {
+            .lambda => blk: {
                 const nested = try self.builder.fnTemplateForNestedExprWithMono(self.view, self.owner_template, expr_id, lambda.ty, self.view.types.rootKey(lambda.ty), closure_ty, self.current_fn_key);
-                break :blk try self.lowerLambdaExpr(lambda_data, nested);
+                break :blk try self.lowerLambdaExpr(expr_id, nested);
             },
             else => Common.invariant("checked closure did not point at a lambda expression"),
         };
@@ -4540,27 +4721,16 @@ const BodyContext = struct {
         } });
     }
 
-    fn lowerLambdaExpr(self: *BodyContext, lambda: anytype, nested: Ast.FnTemplate) Allocator.Error!Ast.ExprData {
-        var lambda_ctx = try self.nestedInstantiationContext(Ast.fnTemplateDigest(nested, &self.builder.program.types, &self.builder.program.names));
-        defer lambda_ctx.deinit();
-        try lambda_ctx.constrainTypeToMono(nested.source_fn_ty, nested.mono_fn_ty);
-
-        const fn_data = self.builder.functionShape(nested.mono_fn_ty, "nested lambda had a non-function type");
-        const arg_tys = try self.allocator.dupe(Type.TypeId, self.builder.program.types.span(fn_data.args));
-        defer self.allocator.free(arg_tys);
-        if (arg_tys.len != lambda.args.len) Common.invariant("nested lambda arity differs from concrete function type");
-
-        const lowered = try lambda_ctx.lowerLambdaArgsAndBody(lambda.args, arg_tys, lambda.body, fn_data.ret);
+    fn lowerLambdaExpr(
+        self: *BodyContext,
+        expr_id: checked.CheckedExprId,
+        nested: Ast.FnTemplate,
+    ) Allocator.Error!Ast.ExprData {
         switch (nested.fn_def) {
             .nested => {},
             else => Common.invariant("expression-position lambda was not assigned a nested function identity"),
         }
-
-        return .{ .lambda = .{
-            .args = lowered.args,
-            .body = lowered.body,
-            .source = nested,
-        } };
+        return .{ .fn_def = try self.builder.lowerNestedFnFromContext(self, expr_id, nested) };
     }
 
     fn lowerDispatchExpr(
@@ -5023,25 +5193,19 @@ const BodyContext = struct {
         self: *BodyContext,
         lookup: MethodLookup,
         callable_mono_ty: Type.TypeId,
-    ) Allocator.Error!Ast.FnTemplate {
+    ) Allocator.Error!Ast.FnId {
         const source_fn_ty = lookup.target.callable_ty;
         const source_fn_key = lookup.view.types.rootKey(source_fn_ty);
         return switch (lookup.target.kind) {
             .procedure => |procedure| blk: {
-                try self.graph.deferred_templates.append(self.builder.allocator, .{
-                    .template_ref = procedure.template,
-                    .module = lookup.view.key,
-                    .source_fn_ty = source_fn_ty,
-                    .source_fn_key = source_fn_key,
-                    .fn_ty = callable_mono_ty,
-                });
-                break :blk self.builder.fnDefForTemplate(
+                const fn_template = self.builder.fnDefForTemplate(
                     lookup.view,
                     procedure.template,
                     source_fn_ty,
                     source_fn_key,
                     callable_mono_ty,
                 );
+                break :blk try self.builder.lowerFnTemplateDefFromContext(self, fn_template);
             },
             .local_proc => |local| blk: {
                 self.requireLocalMethodTargetInCurrentView(lookup);
@@ -5066,7 +5230,7 @@ const BodyContext = struct {
         const fn_data = self.builder.functionShape(callable_mono_ty, "checked dispatch target had a non-function type");
         const args = try arg_ctx.lowerDispatchOperandsAtTypes(plan.args, self.builder.program.types.span(fn_data.args), pre_lowered);
         return .{ .call_proc = .{
-            .callee = .{ .template = try self.methodTargetCalleeWithMono(lookup, callable_mono_ty) },
+            .callee = .{ .func = try self.methodTargetCalleeWithMono(lookup, callable_mono_ty) },
             .args = args,
         } };
     }
@@ -5407,7 +5571,7 @@ const BodyContext = struct {
         const callable_mono_ty = try self.methodTargetMonoTypeFromArgs(lookup, &arg_tys, bool_ty);
         const args = [_]Ast.ExprId{ lhs, rhs };
         return try self.builder.program.addExpr(.{ .ty = bool_ty, .data = .{ .call_proc = .{
-            .callee = .{ .template = try self.methodTargetCalleeWithMono(lookup, callable_mono_ty) },
+            .callee = .{ .func = try self.methodTargetCalleeWithMono(lookup, callable_mono_ty) },
             .args = try self.builder.program.addExprSpan(&args),
         } } });
     }
@@ -7144,7 +7308,7 @@ const BodyContext = struct {
         return try self.builder.program.addExpr(.{
             .ty = fn_data.ret,
             .data = .{ .call_proc = .{
-                .callee = .{ .template = try self.methodTargetCalleeWithMono(lookup, target_mono_ty) },
+                .callee = .{ .func = try self.methodTargetCalleeWithMono(lookup, target_mono_ty) },
                 .args = try self.builder.program.addExprSpan(args),
             } },
         });
@@ -8069,7 +8233,7 @@ const BodyContext = struct {
                 const callable_mono_ty = try self.methodTargetMonoTypeFromArgs(lookup, &arg_tys, bool_ty);
                 const callee = try self.methodTargetCalleeWithMono(lookup, callable_mono_ty);
                 return try self.builder.program.addExpr(.{ .ty = bool_ty, .data = .{ .call_proc = .{
-                    .callee = .{ .template = callee },
+                    .callee = .{ .func = callee },
                     .args = try self.builder.program.addExprSpan(&.{ scrutinee, expected }),
                 } } });
             }

--- a/src/postcheck/monotype_lifted/ast.zig
+++ b/src/postcheck/monotype_lifted/ast.zig
@@ -97,7 +97,7 @@ pub const RuntimeSchemaRequest = Mono.RuntimeSchemaRequest;
 pub fn callProcCallee(call: Mono.CallProc) FnId {
     return switch (call.callee) {
         .lifted => |fn_id| fn_id,
-        .template => Common.invariant("Monotype Lifted direct call still referenced a Monotype function template"),
+        .func => Common.invariant("Monotype Lifted direct call still referenced a Monotype function id"),
     };
 }
 
@@ -391,7 +391,7 @@ pub const Program = struct {
         };
         const callee = switch (call.callee) {
             .lifted => |fn_id| fn_id,
-            .template => return null,
+            .func => return null,
         };
         const callee_body = switch (self.fns.items[@intFromEnum(callee)].body) {
             .roc => |body| body,

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -7,7 +7,6 @@ const Mono = @import("../monotype/ast.zig");
 const MonoType = @import("../monotype/type.zig");
 const Ast = @import("ast.zig");
 const checked = @import("check").CheckedModule;
-const names = @import("check").CheckedNames;
 
 const Allocator = std.mem.Allocator;
 
@@ -120,80 +119,11 @@ pub fn run(
     return program;
 }
 
-const FnTemplateMap = std.HashMap(Mono.FnTemplate, Ast.FnId, FnTemplateContext, std.hash_map.default_max_load_percentage);
-const FnFamilyMap = std.HashMap(Mono.FnTemplate, std.ArrayList(Ast.FnId), FnFamilyContext, std.hash_map.default_max_load_percentage);
-
-/// Template identity without the monomorphic type: the digest only
-/// disambiguates among multiple specializations of one checked template and
-/// scheme.
-const FnFamilyContext = struct {
-    pub fn hash(_: FnFamilyContext, template: Mono.FnTemplate) u64 {
-        var hasher = std.hash.Wyhash.init(0);
-        FnTemplateContext.hashFnDef(&hasher, template.fn_def);
-        hasher.update(&template.source_fn_key.bytes);
-        return hasher.final();
-    }
-
-    pub fn eql(_: FnFamilyContext, lhs: Mono.FnTemplate, rhs: Mono.FnTemplate) bool {
-        return std.meta.eql(lhs.fn_def, rhs.fn_def) and
-            std.mem.eql(u8, lhs.source_fn_key.bytes[0..], rhs.source_fn_key.bytes[0..]);
-    }
-};
 const FnActiveSet = std.AutoHashMap(Ast.FnId, void);
-
-const FnTemplateContext = struct {
-    types: *const MonoType.Store,
-    names: *const names.NameStore,
-
-    pub fn hash(self: FnTemplateContext, template: Mono.FnTemplate) u64 {
-        var hasher = std.hash.Wyhash.init(0);
-        hashFnDef(&hasher, template.fn_def);
-        hasher.update(&template.source_fn_key.bytes);
-        const mono_digest = self.types.typeDigest(self.names, template.mono_fn_ty);
-        hasher.update(&mono_digest.bytes);
-        return hasher.final();
-    }
-
-    pub fn eql(self: FnTemplateContext, lhs: Mono.FnTemplate, rhs: Mono.FnTemplate) bool {
-        const lhs_digest = self.types.typeDigest(self.names, lhs.mono_fn_ty);
-        const rhs_digest = self.types.typeDigest(self.names, rhs.mono_fn_ty);
-        return std.meta.eql(lhs.fn_def, rhs.fn_def) and
-            std.mem.eql(u8, lhs.source_fn_key.bytes[0..], rhs.source_fn_key.bytes[0..]) and
-            std.mem.eql(u8, lhs_digest.bytes[0..], rhs_digest.bytes[0..]);
-    }
-
-    pub fn hashFnDef(hasher: *std.hash.Wyhash, fn_def: Mono.FnDef) void {
-        std.hash.autoHash(hasher, std.meta.activeTag(fn_def));
-        switch (fn_def) {
-            .local_template,
-            .imported_template,
-            .checked_generated,
-            => |template| hashProcTemplate(hasher, template),
-            .local_hosted,
-            .imported_hosted,
-            => |hosted| {
-                hashProcTemplate(hasher, hosted.template);
-                std.hash.autoHash(hasher, @intFromEnum(hosted.external_symbol_name));
-                std.hash.autoHash(hasher, hosted.dispatch_index);
-            },
-            .nested => |nested| {
-                hashProcTemplate(hasher, nested.owner);
-                std.hash.autoHash(hasher, @intFromEnum(nested.site));
-                hasher.update(&nested.context_fn_key.bytes);
-            },
-        }
-    }
-
-    fn hashProcTemplate(hasher: *std.hash.Wyhash, template: names.ProcTemplate) void {
-        const module_digest = names.procTemplateModuleDigest(template);
-        hasher.update(&module_digest.bytes);
-        std.hash.autoHash(hasher, @intFromEnum(template.proc_base));
-        std.hash.autoHash(hasher, @intFromEnum(template.template));
-    }
-};
 
 const DefMap = []?Ast.FnId;
 const NestedDefMap = []?Ast.FnId;
+const FnMap = []?Ast.FnId;
 
 const MonoFnBody = struct {
     args: Mono.Span(Mono.TypedLocal),
@@ -208,8 +138,7 @@ const Lifter = struct {
     stmt_done: []bool,
     def_map: DefMap,
     nested_def_map: NestedDefMap,
-    fn_templates: FnTemplateMap,
-    fn_families: FnFamilyMap,
+    fn_map: FnMap,
     fn_bodies: std.ArrayList(?MonoFnBody),
     nested_fn_ids: std.AutoHashMap(Ast.FnId, void),
     initialized_fns: std.AutoHashMap(Ast.FnId, void),
@@ -232,11 +161,7 @@ const Lifter = struct {
             .stmt_done = stmt_done,
             .def_map = &.{},
             .nested_def_map = &.{},
-            .fn_templates = FnTemplateMap.initContext(allocator, .{
-                .types = &output.types,
-                .names = &output.names,
-            }),
-            .fn_families = FnFamilyMap.initContext(allocator, .{}),
+            .fn_map = &.{},
             .fn_bodies = .empty,
             .nested_fn_ids = std.AutoHashMap(Ast.FnId, void).init(allocator),
             .initialized_fns = std.AutoHashMap(Ast.FnId, void).init(allocator),
@@ -248,12 +173,7 @@ const Lifter = struct {
         self.initialized_fns.deinit();
         self.nested_fn_ids.deinit();
         self.fn_bodies.deinit(self.allocator);
-        var families = self.fn_families.valueIterator();
-        while (families.next()) |list| {
-            list.deinit(self.allocator);
-        }
-        self.fn_families.deinit();
-        self.fn_templates.deinit();
+        if (self.fn_map.len > 0) self.allocator.free(self.fn_map);
         if (self.nested_def_map.len > 0) self.allocator.free(self.nested_def_map);
         if (self.def_map.len > 0) self.allocator.free(self.def_map);
         self.allocator.free(self.stmt_done);
@@ -261,6 +181,9 @@ const Lifter = struct {
     }
 
     fn lowerDefsAndRoots(self: *Lifter) Allocator.Error!void {
+        self.fn_map = try self.allocator.alloc(?Ast.FnId, self.source.fns.items.len);
+        @memset(self.fn_map, null);
+
         self.def_map = try self.allocator.alloc(?Ast.FnId, self.source.defs.items.len);
         @memset(self.def_map, null);
 
@@ -269,7 +192,7 @@ const Lifter = struct {
             try self.output.fns.append(self.allocator, undefined);
             try self.fn_bodies.append(self.allocator, .{ .args = def.args, .body = def.body });
             self.def_map[index] = fn_id;
-            if (def.fn_def) |source| try self.registerFnTemplate(source, fn_id);
+            if (def.fn_id) |source_fn_id| self.registerFn(source_fn_id, fn_id);
         }
 
         self.nested_def_map = try self.allocator.alloc(?Ast.FnId, self.source.nested_defs.items.len);
@@ -280,7 +203,7 @@ const Lifter = struct {
             try self.fn_bodies.append(self.allocator, .{ .args = def.args, .body = .{ .roc = def.body } });
             self.nested_def_map[index] = fn_id;
             try self.nested_fn_ids.put(fn_id, {});
-            try self.registerFnTemplate(def.fn_def, fn_id);
+            self.registerFn(def.fn_id, fn_id);
         }
 
         for (self.source.defs.items, 0..) |def, index| {
@@ -345,7 +268,7 @@ const Lifter = struct {
         };
         self.output.fns.items[@intFromEnum(fn_id)] = .{
             .symbol = def.symbol,
-            .source = def.fn_def,
+            .source = if (def.fn_id) |source_fn_id| self.defSource(source_fn_id, def.fn_def) else null,
             .args = def.args,
             .captures = .empty(),
             .body = body,
@@ -368,7 +291,7 @@ const Lifter = struct {
         const capture_span = try self.output.addTypedLocalSpan(captures.items.items);
         self.output.fns.items[@intFromEnum(fn_id)] = .{
             .symbol = def.symbol,
-            .source = def.fn_def,
+            .source = self.nestedSource(def.fn_id, def.fn_def),
             .args = def.args,
             .captures = capture_span,
             .body = .{ .roc = def.body },
@@ -432,14 +355,14 @@ const Lifter = struct {
                 expr.data = .{ .fn_ref = self.def_map[raw] orelse
                     Common.invariant("Monotype definition reference reached lifting before its function was registered") };
             },
-            .fn_def => |fn_def| expr.data = .{ .fn_ref = self.fnIdForTemplate(fn_def) },
+            .fn_def => |fn_id| expr.data = .{ .fn_ref = self.liftedFn(fn_id) },
             .call_value => |call| {
                 try self.rewriteExpr(call.callee);
                 for (self.output.exprSpan(call.args)) |arg| try self.rewriteExpr(arg);
             },
             .call_proc => |call| {
                 const fn_id = switch (call.callee) {
-                    .template => |template| self.fnIdForTemplate(template),
+                    .func => |mono_fn_id| self.liftedFn(mono_fn_id),
                     .lifted => |fn_id| fn_id,
                 };
                 for (self.output.exprSpan(call.args)) |arg| try self.rewriteExpr(arg);
@@ -483,7 +406,7 @@ const Lifter = struct {
     }
 
     fn liftLambda(self: *Lifter, expr_id: Mono.ExprId, ty: @import("../monotype/type.zig").TypeId, lambda: Mono.LambdaExpr) Allocator.Error!void {
-        const fn_id = try self.reserveFnTemplate(lambda.source);
+        const fn_id = try self.reserveFn(lambda.fn_id);
         self.output.exprs.items[@intFromEnum(expr_id)].data = .{ .fn_ref = fn_id };
         if (self.nested_fn_ids.contains(fn_id)) return;
         if (self.initialized_fns.contains(fn_id)) return;
@@ -502,7 +425,7 @@ const Lifter = struct {
         const capture_span = try self.output.addTypedLocalSpan(captures.items.items);
         self.output.fns.items[@intFromEnum(fn_id)] = .{
             .symbol = self.symbols.fresh(),
-            .source = lambda.source,
+            .source = self.source.fnSource(lambda.fn_id),
             .args = lambda.args,
             .captures = capture_span,
             .body = .{ .roc = lambda.body },
@@ -511,13 +434,15 @@ const Lifter = struct {
         try self.initialized_fns.put(fn_id, {});
     }
 
-    fn reserveFnTemplate(self: *Lifter, template: Mono.FnTemplate) Allocator.Error!Ast.FnId {
-        if (self.fn_templates.get(template)) |existing| return existing;
+    fn reserveFn(self: *Lifter, mono_fn_id: Mono.FnId) Allocator.Error!Ast.FnId {
+        const raw = @intFromEnum(mono_fn_id);
+        if (raw >= self.fn_map.len) Common.invariant("Monotype lambda referenced a missing function specialization");
+        if (self.fn_map[raw]) |existing| return existing;
 
         const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(self.output.fns.items.len)));
         try self.output.fns.append(self.allocator, undefined);
         try self.fn_bodies.append(self.allocator, null);
-        try self.registerFnTemplate(template, fn_id);
+        self.fn_map[raw] = fn_id;
         return fn_id;
     }
 
@@ -531,30 +456,39 @@ const Lifter = struct {
         return FnActiveSet.init(self.allocator);
     }
 
-    fn registerFnTemplate(self: *Lifter, template: Mono.FnTemplate, fn_id: Ast.FnId) Allocator.Error!void {
-        const result = try self.fn_templates.getOrPut(template);
-        if (result.found_existing) {
-            if (result.value_ptr.* != fn_id) {
-                Common.invariant("Monotype function template was assigned two lifted function ids");
-            }
+    fn registerFn(self: *Lifter, mono_fn_id: Mono.FnId, fn_id: Ast.FnId) void {
+        const raw = @intFromEnum(mono_fn_id);
+        if (raw >= self.fn_map.len) Common.invariant("Monotype definition referenced a missing function specialization");
+        if (self.fn_map[raw]) |existing| {
+            if (existing != fn_id) Common.invariant("Monotype function specialization was assigned two lifted function ids");
             return;
         }
-        result.value_ptr.* = fn_id;
-        const family = try self.fn_families.getOrPut(template);
-        if (!family.found_existing) family.value_ptr.* = .empty;
-        try family.value_ptr.append(self.allocator, fn_id);
+        self.fn_map[raw] = fn_id;
     }
 
-    fn fnIdForTemplate(self: *Lifter, template: Mono.FnTemplate) Ast.FnId {
-        if (self.fn_templates.get(template)) |fn_id| return fn_id;
-        // The reference's monomorphic type may have been refined after the
-        // expression embedded it. The digest only disambiguates among
-        // multiple specializations of one template and scheme, so a family
-        // with exactly one specialization identifies the function on its own.
-        if (self.fn_families.get(template)) |family| {
-            if (family.items.len == 1) return family.items[0];
+    fn liftedFn(self: *Lifter, mono_fn_id: Mono.FnId) Ast.FnId {
+        const raw = @intFromEnum(mono_fn_id);
+        if (raw >= self.fn_map.len) Common.invariant("Monotype expression referenced a missing function specialization");
+        return self.fn_map[raw] orelse
+            Common.invariant("Monotype expression referenced a function specialization before lifting registered it");
+    }
+
+    fn defSource(self: *Lifter, mono_fn_id: Mono.FnId, expected: ?Mono.FnTemplate) ?Mono.FnTemplate {
+        const source = self.source.fnSource(mono_fn_id);
+        if (expected) |template| {
+            if (!std.meta.eql(source, template)) {
+                Common.invariant("Monotype definition source disagreed with its function specialization source");
+            }
         }
-        Common.invariant("Monotype function template reached lifting before its function was registered");
+        return source;
+    }
+
+    fn nestedSource(self: *Lifter, mono_fn_id: Mono.FnId, expected: Mono.FnTemplate) Mono.FnTemplate {
+        const source = self.source.fnSource(mono_fn_id);
+        if (!std.meta.eql(source, expected)) {
+            Common.invariant("Monotype nested definition source disagreed with its function specialization source");
+        }
+        return source;
     }
 };
 
@@ -654,10 +588,10 @@ const CaptureSet = struct {
             .dec_lit,
             .str_lit,
             .def_ref,
-            .fn_def,
             .fn_ref,
             .crash,
             => {},
+            .fn_def => |fn_id| try self.collectFnCaptures(self.lifter.liftedFn(fn_id), bound),
             .list,
             .tuple,
             => |items| for (input.exprSpan(items)) |child| try self.collectExpr(child, bound),
@@ -690,7 +624,7 @@ const CaptureSet = struct {
             },
             .call_proc => |call| {
                 switch (call.callee) {
-                    .template => |template| try self.collectTemplateCaptures(template, bound),
+                    .func => |mono_fn_id| try self.collectFnCaptures(self.lifter.liftedFn(mono_fn_id), bound),
                     .lifted => |fn_id| try self.collectFnCaptures(fn_id, bound),
                 }
                 for (input.exprSpan(call.args)) |arg| try self.collectExpr(arg, bound);
@@ -738,10 +672,6 @@ const CaptureSet = struct {
             .break_ => |maybe| if (maybe) |value| try self.collectExpr(value, bound),
             .continue_ => |continue_| for (input.exprSpan(continue_.values)) |value| try self.collectExpr(value, bound),
         }
-    }
-
-    fn collectTemplateCaptures(self: *CaptureSet, template: Mono.FnTemplate, caller_bound: *BoundSet) Allocator.Error!void {
-        try self.collectFnCaptures(self.lifter.fnIdForTemplate(template), caller_bound);
     }
 
     fn collectFnCaptures(self: *CaptureSet, fn_id: Ast.FnId, caller_bound: *BoundSet) Allocator.Error!void {

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -442,7 +442,7 @@ const Pass = struct {
                 spec.fn_id = fn_id;
                 try self.program.fns.append(self.allocator, .{
                     .symbol = symbol,
-                    .source = null,
+                    .source = source_fn.source,
                     .args = .empty(),
                     .captures = source_fn.captures,
                     .body = .hosted,
@@ -750,7 +750,7 @@ const Pass = struct {
         });
         try self.program.fns.append(self.allocator, .{
             .symbol = symbol,
-            .source = null,
+            .source = source_fn.source,
             .args = .empty(),
             .captures = source_fn.captures,
             .body = .hosted,
@@ -783,7 +783,7 @@ const Pass = struct {
 
         self.program.fns.items[@intFromEnum(spec_fn_id)] = .{
             .symbol = symbol,
-            .source = null,
+            .source = source_fn.source,
             .args = args,
             .captures = source_fn.captures,
             .body = body,
@@ -1305,6 +1305,10 @@ const Cloner = struct {
     }
 
     fn cloneExprValue(self: *Cloner, expr_id: Ast.ExprId) Common.LowerError!Value {
+        const saved_loc = self.pass.program.current_loc;
+        defer self.pass.program.current_loc = saved_loc;
+        self.pass.program.current_loc = self.pass.program.exprLoc(expr_id);
+
         const expr = self.pass.program.exprs.items[@intFromEnum(expr_id)];
         switch (expr.data) {
             .local => |local| {
@@ -1518,6 +1522,10 @@ const Cloner = struct {
     }
 
     fn cloneExprPlain(self: *Cloner, expr_id: Ast.ExprId) Common.LowerError!Ast.ExprId {
+        const saved_loc = self.pass.program.current_loc;
+        defer self.pass.program.current_loc = saved_loc;
+        self.pass.program.current_loc = self.pass.program.exprLoc(expr_id);
+
         const expr = self.pass.program.exprs.items[@intFromEnum(expr_id)];
         const data: Ast.ExprData = switch (expr.data) {
             .local => |local| .{ .local = local },
@@ -2575,6 +2583,10 @@ const Cloner = struct {
     }
 
     fn cloneStmt(self: *Cloner, stmt_id: Ast.StmtId) Common.LowerError!Ast.StmtId {
+        const saved_loc = self.pass.program.current_loc;
+        defer self.pass.program.current_loc = saved_loc;
+        self.pass.program.current_loc = self.pass.program.stmtLoc(stmt_id);
+
         const stmt = self.pass.program.stmts.items[@intFromEnum(stmt_id)];
         return try self.pass.program.addStmt(switch (stmt) {
             .let_ => |let_| blk: {

--- a/src/postcheck/structural_test.zig
+++ b/src/postcheck/structural_test.zig
@@ -124,7 +124,7 @@ test "Lifted functions own captures and consume Monotype expression storage" {
     try std.testing.expect(@hasField(Lifted.ExprData, "fn_ref"));
     try std.testing.expect(@hasField(Lifted.ExprData, "call_proc"));
     try std.testing.expect(@hasField(Lifted.ExprData, "call_value"));
-    try std.testing.expect(@hasField(Mono.ProcCallee, "template"));
+    try std.testing.expect(@hasField(Mono.ProcCallee, "func"));
     try std.testing.expect(@hasField(Mono.ProcCallee, "lifted"));
 
     try std.testing.expect(!@hasField(Lifted.ExprData, "dispatch_call"));
@@ -216,7 +216,7 @@ test "Monotype lifting mutates only callable expression nodes in place" {
     try expectContains(rewrite_expr, "expr.data = .{ .fn_ref");
     try expectContains(rewrite_expr, "expr.data = .{ .call_proc");
 
-    const lift_lambda = sourceSliceBetween(lifted_source, "fn liftLambda", "fn reserveFnTemplate");
+    const lift_lambda = sourceSliceBetween(lifted_source, "fn liftLambda", "fn reserveFn");
     try expectContains(lift_lambda, "self.output.exprs.items[@intFromEnum(expr_id)].data = .{ .fn_ref = fn_id };");
 
     const lambda_mono_source = @embedFile("lambda_mono/lower.zig");


### PR DESCRIPTION
Monotype now assigns explicit function specialization ids during lowering and threads them through function values and direct calls, so lifting can map ids directly instead of reconstructing identity from FnTemplate digests. Deferred top-level specializations reserve their function ids before their bodies are lowered, and nested/lambda specializations reuse the same Monotype-owned ids. This removes the lifter's template-family fallback and makes B101 an active regression test.\n\nFixes #9519.