### PR TITLE
Use typed exposed item targets

### DIFF
--- a/src/base/CommonEnv.zig
+++ b/src/base/CommonEnv.zig
@@ -197,14 +197,29 @@ pub fn addExposedById(self: *CommonEnv, gpa: std.mem.Allocator, ident_idx: Ident
     return try self.exposed_items.addExposedById(gpa, @bitCast(ident_idx));
 }
 
-/// Retrieves the node index associated with an exposed identifier.
-pub fn getNodeIndexById(self: *const CommonEnv, allocator: std.mem.Allocator, ident_idx: Ident.Idx) ?u32 {
-    return self.exposed_items.getNodeIndexById(allocator, @bitCast(ident_idx));
+/// Retrieves the explicit target associated with an exposed identifier.
+pub fn getExposedTargetById(self: *const CommonEnv, allocator: std.mem.Allocator, ident_idx: Ident.Idx) ?collections.ExposedItemTarget {
+    return self.exposed_items.getTargetById(allocator, @bitCast(ident_idx));
 }
 
-/// Associates a node index with an exposed identifier.
-pub fn setNodeIndexById(self: *CommonEnv, gpa: std.mem.Allocator, ident_idx: Ident.Idx, node_idx: u32) Allocator.Error!void {
-    return try self.exposed_items.setNodeIndexById(gpa, @bitCast(ident_idx), node_idx);
+/// Retrieves the value definition node associated with an exposed identifier.
+pub fn getValueNodeIndexById(self: *const CommonEnv, allocator: std.mem.Allocator, ident_idx: Ident.Idx) ?u32 {
+    return self.exposed_items.getValueNodeIndexById(allocator, @bitCast(ident_idx));
+}
+
+/// Retrieves the type declaration node associated with an exposed identifier.
+pub fn getTypeNodeIndexById(self: *const CommonEnv, allocator: std.mem.Allocator, ident_idx: Ident.Idx) ?u32 {
+    return self.exposed_items.getTypeNodeIndexById(allocator, @bitCast(ident_idx));
+}
+
+/// Associates a value definition node index with an exposed identifier.
+pub fn setValueNodeIndexById(self: *CommonEnv, gpa: std.mem.Allocator, ident_idx: Ident.Idx, node_idx: u32) Allocator.Error!void {
+    return try self.exposed_items.setValueNodeIndexById(gpa, @bitCast(ident_idx), node_idx);
+}
+
+/// Associates a type declaration node index with an exposed identifier.
+pub fn setTypeNodeIndexById(self: *CommonEnv, gpa: std.mem.Allocator, ident_idx: Ident.Idx, node_idx: u32) Allocator.Error!void {
+    return try self.exposed_items.setTypeNodeIndexById(gpa, @bitCast(ident_idx), node_idx);
 }
 
 /// Get region info for a given region

--- a/src/build/builtin_compiler/main.zig
+++ b/src/build/builtin_compiler/main.zig
@@ -215,31 +215,31 @@ fn expectBuiltinIdent(env: *const ModuleEnv, text: []const u8) base.Ident.Idx {
 }
 
 fn installBuiltinNodeIndices(gpa: Allocator, env: *ModuleEnv, indices: BuiltinIndices) !void {
-    try env.common.setNodeIndexById(gpa, indices.bool_ident, @intCast(@intFromEnum(indices.bool_type)));
-    try env.common.setNodeIndexById(gpa, indices.try_ident, @intCast(@intFromEnum(indices.try_type)));
-    try env.common.setNodeIndexById(gpa, indices.dict_ident, @intCast(@intFromEnum(indices.dict_type)));
-    try env.common.setNodeIndexById(gpa, indices.set_ident, @intCast(@intFromEnum(indices.set_type)));
-    try env.common.setNodeIndexById(gpa, indices.str_ident, @intCast(@intFromEnum(indices.str_type)));
-    try env.common.setNodeIndexById(gpa, indices.hasher_ident, @intCast(@intFromEnum(indices.hasher_type)));
-    try env.common.setNodeIndexById(gpa, indices.iter_ident, @intCast(@intFromEnum(indices.iter_type)));
-    try env.common.setNodeIndexById(gpa, indices.stream_ident, @intCast(@intFromEnum(indices.stream_type)));
-    try env.common.setNodeIndexById(gpa, indices.list_ident, @intCast(@intFromEnum(indices.list_type)));
-    try env.common.setNodeIndexById(gpa, indices.box_ident, @intCast(@intFromEnum(indices.box_type)));
-    try env.common.setNodeIndexById(gpa, indices.utf8_problem_ident, @intCast(@intFromEnum(indices.utf8_problem_type)));
-    try env.common.setNodeIndexById(gpa, indices.u8_ident, @intCast(@intFromEnum(indices.u8_type)));
-    try env.common.setNodeIndexById(gpa, indices.i8_ident, @intCast(@intFromEnum(indices.i8_type)));
-    try env.common.setNodeIndexById(gpa, indices.u16_ident, @intCast(@intFromEnum(indices.u16_type)));
-    try env.common.setNodeIndexById(gpa, indices.i16_ident, @intCast(@intFromEnum(indices.i16_type)));
-    try env.common.setNodeIndexById(gpa, indices.u32_ident, @intCast(@intFromEnum(indices.u32_type)));
-    try env.common.setNodeIndexById(gpa, indices.i32_ident, @intCast(@intFromEnum(indices.i32_type)));
-    try env.common.setNodeIndexById(gpa, indices.u64_ident, @intCast(@intFromEnum(indices.u64_type)));
-    try env.common.setNodeIndexById(gpa, indices.i64_ident, @intCast(@intFromEnum(indices.i64_type)));
-    try env.common.setNodeIndexById(gpa, indices.u128_ident, @intCast(@intFromEnum(indices.u128_type)));
-    try env.common.setNodeIndexById(gpa, indices.i128_ident, @intCast(@intFromEnum(indices.i128_type)));
-    try env.common.setNodeIndexById(gpa, indices.dec_ident, @intCast(@intFromEnum(indices.dec_type)));
-    try env.common.setNodeIndexById(gpa, indices.f32_ident, @intCast(@intFromEnum(indices.f32_type)));
-    try env.common.setNodeIndexById(gpa, indices.f64_ident, @intCast(@intFromEnum(indices.f64_type)));
-    try env.common.setNodeIndexById(gpa, indices.numeral_ident, @intCast(@intFromEnum(indices.numeral_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.bool_ident, @intCast(@intFromEnum(indices.bool_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.try_ident, @intCast(@intFromEnum(indices.try_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.dict_ident, @intCast(@intFromEnum(indices.dict_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.set_ident, @intCast(@intFromEnum(indices.set_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.str_ident, @intCast(@intFromEnum(indices.str_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.hasher_ident, @intCast(@intFromEnum(indices.hasher_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.iter_ident, @intCast(@intFromEnum(indices.iter_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.stream_ident, @intCast(@intFromEnum(indices.stream_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.list_ident, @intCast(@intFromEnum(indices.list_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.box_ident, @intCast(@intFromEnum(indices.box_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.utf8_problem_ident, @intCast(@intFromEnum(indices.utf8_problem_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.u8_ident, @intCast(@intFromEnum(indices.u8_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.i8_ident, @intCast(@intFromEnum(indices.i8_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.u16_ident, @intCast(@intFromEnum(indices.u16_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.i16_ident, @intCast(@intFromEnum(indices.i16_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.u32_ident, @intCast(@intFromEnum(indices.u32_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.i32_ident, @intCast(@intFromEnum(indices.i32_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.u64_ident, @intCast(@intFromEnum(indices.u64_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.i64_ident, @intCast(@intFromEnum(indices.i64_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.u128_ident, @intCast(@intFromEnum(indices.u128_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.i128_ident, @intCast(@intFromEnum(indices.i128_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.dec_ident, @intCast(@intFromEnum(indices.dec_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.f32_ident, @intCast(@intFromEnum(indices.f32_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.f64_ident, @intCast(@intFromEnum(indices.f64_type)));
+    try env.common.setTypeNodeIndexById(gpa, indices.numeral_ident, @intCast(@intFromEnum(indices.numeral_type)));
 }
 
 /// Validates that BuiltinIndices contains all nominal type declarations in the Builtin module.

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -8,6 +8,7 @@ const Allocator = std.mem.Allocator;
 const builtin = @import("builtin");
 const testing = std.testing;
 const base = @import("base");
+const collections = @import("collections");
 const parse = @import("parse");
 const NumericLiteral = parse.NumericLiteral;
 const types = @import("types");
@@ -1980,7 +1981,7 @@ fn registerTypeDecl(
     // Exposed type names must resolve to the canonical type-decl statement idx
     // so importing modules consume an explicit exported-binding fact.
     if (self.exposed_types.contains(type_header.name)) {
-        try self.env.setExposedNodeIndexById(type_header.name, node_idx_u32);
+        try self.env.setExposedTypeNodeIndexById(type_header.name, node_idx_u32);
     }
 
     // For type modules, associate the node index with the exposed type.
@@ -1989,7 +1990,7 @@ fn registerTypeDecl(
     if (self.env.module_kind == .type_module) {
         if (qualified_name_idx.eql(self.env.display_module_name_idx)) {
             // This is the main type of the type module - set its node index
-            try self.env.setExposedNodeIndexById(qualified_name_idx, node_idx_u32);
+            try self.env.setExposedTypeNodeIndexById(qualified_name_idx, node_idx_u32);
         }
     }
 
@@ -2892,7 +2893,7 @@ fn finishAssociatedDeclBody(
 
     const def_idx_u32: u32 = @intFromEnum(associated_def.def_idx);
     if (state.owner_is_module_visible) {
-        try self.env.setExposedNodeIndexById(work.qualified_ident, def_idx_u32);
+        try self.env.setExposedValueNodeIndexById(work.qualified_ident, def_idx_u32);
     }
     try self.registerAssociatedMethodIdent(state.work.owner_stmt_idx, work.decl_ident, work.qualified_ident, method_binding);
 
@@ -2963,7 +2964,7 @@ fn registerNestedTypeDecl(
     );
 
     const node_idx_u32: u32 = @intFromEnum(nested_type_decl_idx);
-    try self.env.setExposedNodeIndexById(nested_qualified_idx, node_idx_u32);
+    try self.env.setExposedTypeNodeIndexById(nested_qualified_idx, node_idx_u32);
 
     const current_scope = &self.scopes.items[self.scopes.items.len - 1];
     try current_scope.introduceTypeAlias(self.env.gpa, nested_type_ident, nested_type_decl_idx);
@@ -3373,7 +3374,7 @@ fn canonicalizeAssociatedItems(
                         try self.createAnnoOnlyDef(qualified_idx, type_anno_idx, where_clauses, region);
 
                     if (owner_is_module_visible) {
-                        try self.env.setExposedNodeIndexById(qualified_idx, @intFromEnum(def_idx));
+                        try self.env.setExposedValueNodeIndexById(qualified_idx, @intFromEnum(def_idx));
                     }
                     const method_binding = try self.recordAssociatedValue(
                         AssociatedValueDef{ .def_idx = def_idx, .free_vars = DataSpan.empty() },
@@ -3395,7 +3396,7 @@ fn canonicalizeAssociatedItems(
                         qualified_idx
                     else blk_atq: {
                         // Re-fetch the ident texts here — earlier calls
-                        // (createAnnoOnlyDef, setExposedNodeIndexById, …) may
+                        // (createAnnoOnlyDef, setExposedValueNodeIndexById, …) may
                         // have grown the interner and invalidated the slices
                         // captured before this point.
                         const type_text_now = self.env.getIdent(type_name);
@@ -3855,7 +3856,7 @@ pub fn canonicalizeFile(
                                 const ident_text = self.env.getIdent(name_ident);
                                 if (self.exposed_ident_texts.contains(ident_text)) {
                                     const def_idx_u32: u32 = @intFromEnum(def_idx);
-                                    try self.env.setExposedNodeIndexById(name_ident, def_idx_u32);
+                                    try self.env.setExposedValueNodeIndexById(name_ident, def_idx_u32);
                                 }
                             }
                         },
@@ -3870,7 +3871,7 @@ pub fn canonicalizeFile(
                             const ident_text = self.env.getIdent(name_ident);
                             if (self.exposed_ident_texts.contains(ident_text)) {
                                 const def_idx_u32: u32 = @intFromEnum(def_idx);
-                                try self.env.setExposedNodeIndexById(name_ident, def_idx_u32);
+                                try self.env.setExposedValueNodeIndexById(name_ident, def_idx_u32);
                             }
                         },
                     }
@@ -3888,7 +3889,7 @@ pub fn canonicalizeFile(
                     const ident_text = self.env.getIdent(name_ident);
                     if (self.exposed_ident_texts.contains(ident_text)) {
                         const def_idx_u32: u32 = @intFromEnum(def_idx);
-                        try self.env.setExposedNodeIndexById(name_ident, def_idx_u32);
+                        try self.env.setExposedValueNodeIndexById(name_ident, def_idx_u32);
                     }
                 }
             },
@@ -4316,7 +4317,7 @@ fn canonicalizeStmtDecl(
         if (self.exposed_ident_texts.contains(ident_text) or is_associated_item) {
             // Store the def index as u16 in exposed_items
             const def_idx_u32: u32 = @intFromEnum(def_idx);
-            try self.env.setExposedNodeIndexById(idx, def_idx_u32);
+            try self.env.setExposedValueNodeIndexById(idx, def_idx_u32);
         }
 
         _ = self.exposed_ident_texts.remove(ident_text);
@@ -5018,7 +5019,8 @@ fn checkExposedTypeSurfaces(self: *Self) std.mem.Allocator.Error!void {
 
     var exposed_iter = self.env.common.exposed_items.iterator();
     while (exposed_iter.next()) |entry| {
-        const stmt_idx = self.exposedTypeDeclStatementIdx(entry.node_idx) orelse continue;
+        const node_idx = entry.target.typeDeclNode() orelse continue;
+        const stmt_idx = self.exposedTypeDeclStatementIdx(node_idx) orelse continue;
         const header = self.typeDeclHeader(stmt_idx) orelse continue;
         if (!self.typeIsAtOrUnderPublicRoot(header.relative_name, public_roots.items)) continue;
 
@@ -5030,7 +5032,8 @@ fn checkExposedTypeSurfaces(self: *Self) std.mem.Allocator.Error!void {
 
     exposed_iter = self.env.common.exposed_items.iterator();
     while (exposed_iter.next()) |entry| {
-        const stmt_idx = self.exposedTypeDeclStatementIdx(entry.node_idx) orelse continue;
+        const node_idx = entry.target.typeDeclNode() orelse continue;
+        const stmt_idx = self.exposedTypeDeclStatementIdx(node_idx) orelse continue;
         if (!public_type_decls.contains(stmt_idx)) continue;
 
         try self.checkPublicNominalStatementSurface(
@@ -5069,7 +5072,7 @@ fn addPublicTypeRoot(
     public_type_decls: *std.AutoHashMapUnmanaged(Statement.Idx, void),
 ) std.mem.Allocator.Error!void {
     const stmt_idx = blk: {
-        if (self.env.getExposedNodeIndexById(type_name)) |node_idx| {
+        if (self.env.getExposedTypeNodeIndexById(type_name)) |node_idx| {
             if (self.exposedTypeDeclStatementIdx(node_idx)) |stmt_idx| break :blk stmt_idx;
         }
         break :blk (try self.scopeLookupTypeDecl(type_name)) orelse return;
@@ -5086,7 +5089,7 @@ fn addPublicTypeRoot(
 }
 
 fn exposedTypeDeclStatementIdx(self: *Self, node_idx_u32: u32) ?Statement.Idx {
-    if (node_idx_u32 == 0 or node_idx_u32 >= self.env.store.nodes.len()) return null;
+    if (node_idx_u32 >= self.env.store.nodes.len()) return null;
 
     const node_idx: Node.Idx = @enumFromInt(node_idx_u32);
     return switch (self.env.store.nodes.get(node_idx).tag) {
@@ -5831,14 +5834,8 @@ fn introduceItemsAliased(
                 if (module_env.containsExposedById(main_type_ident)) {
                     const original_type_name = module_env.getIdent(main_type_ident);
                     const original_ident = try self.env.insertIdent(base.Ident.for_text(original_type_name));
-                    const item_info = Scope.ExposedItemInfo{
-                        .module_name = module_name,
-                        .original_name = original_ident,
-                    };
-                    try self.scopeIntroduceExposedItem(module_alias, item_info, import_region);
 
-                    // Get the correct target_node_idx using statement_idx from module_envs
-                    const target_node_idx = blk: {
+                    const maybe_target_node_idx = blk: {
                         // Use the already-captured envs_map from the outer scope
                         if (envs_map.get(module_name)) |auto_imported| {
                             if (auto_imported.statement_idx) |stmt_idx| {
@@ -5848,20 +5845,29 @@ fn introduceItemsAliased(
                             }
                         }
                         // If we can't find it via statement_idx, look it up by ident.
-                        break :blk module_env.getExposedNodeIndexById(main_type_ident);
+                        break :blk module_env.getExposedTypeNodeIndexById(main_type_ident);
                     };
 
-                    try self.setExternalTypeBinding(
-                        current_scope,
-                        module_alias,
-                        module_name,
-                        original_ident,
-                        original_type_name,
-                        target_node_idx,
-                        module_import_idx,
-                        import_region,
-                        .module_was_found,
-                    );
+                    if (maybe_target_node_idx) |target_node_idx| {
+                        const item_info = Scope.ExposedItemInfo{
+                            .module_name = module_name,
+                            .original_name = original_ident,
+                            .target = collections.ExposedItemTarget.typeDecl(target_node_idx),
+                        };
+                        try self.scopeIntroduceExposedItem(module_alias, item_info, import_region);
+
+                        try self.setExternalTypeBinding(
+                            current_scope,
+                            module_alias,
+                            module_name,
+                            original_ident,
+                            original_type_name,
+                            target_node_idx,
+                            module_import_idx,
+                            import_region,
+                            .module_was_found,
+                        );
+                    }
                 }
             },
             else => {},
@@ -5871,33 +5877,47 @@ fn introduceItemsAliased(
         for (exposed_items_slice) |exposed_item_idx| {
             const exposed_item = self.env.store.getExposedItem(exposed_item_idx);
             const item_name_text = self.env.getIdent(exposed_item.name);
+            const is_type_name = item_name_text.len > 0 and item_name_text[0] >= 'A' and item_name_text[0] <= 'Z';
 
             // Check if the item is exposed by the module. The identifiers are
             // from different modules, so look up by string. A type module's
             // associated items are exposed under `<MainType>.<item>`, which
-            // lookupImportedExposedNode resolves in addition to the bare name.
-            const is_exposed = (try self.lookupImportedExposedNode(module_env, item_name_text)) != null;
-
-            if (!is_exposed) {
-                // Determine if it's a type or value based on capitalization
-                const first_char = item_name_text[0];
-
-                if (first_char >= 'A' and first_char <= 'Z') {
-                    // Type not exposed
+            // lookupImportedExposedTarget resolves in addition to the bare name.
+            const target = (try self.lookupImportedExposedTarget(module_env, item_name_text)) orelse {
+                if (is_type_name) {
                     try self.env.pushDiagnostic(Diagnostic{ .type_not_exposed = .{
                         .module_name = module_name,
                         .type_name = exposed_item.name,
                         .region = import_region,
                     } });
                 } else {
-                    // Value not exposed
                     try self.env.pushDiagnostic(Diagnostic{ .value_not_exposed = .{
                         .module_name = module_name,
                         .value_name = exposed_item.name,
                         .region = import_region,
                     } });
                 }
-                continue; // Skip introducing this item to scope
+                continue;
+            };
+
+            if (is_type_name) {
+                if (target.typeDeclNode() == null) {
+                    try self.env.pushDiagnostic(Diagnostic{ .type_not_exposed = .{
+                        .module_name = module_name,
+                        .type_name = exposed_item.name,
+                        .region = import_region,
+                    } });
+                    continue;
+                }
+            } else {
+                if (target.valueDefNode() == null) {
+                    try self.env.pushDiagnostic(Diagnostic{ .value_not_exposed = .{
+                        .module_name = module_name,
+                        .value_name = exposed_item.name,
+                        .region = import_region,
+                    } });
+                    continue;
+                }
             }
 
             // Item is valid, introduce it to scope
@@ -5905,6 +5925,7 @@ fn introduceItemsAliased(
             const item_info = Scope.ExposedItemInfo{
                 .module_name = module_name,
                 .original_name = exposed_item.name,
+                .target = target,
             };
             try self.scopeIntroduceExposedItem(item_name, item_info, import_region);
         }
@@ -5916,6 +5937,7 @@ fn introduceItemsAliased(
             const item_info = Scope.ExposedItemInfo{
                 .module_name = module_name,
                 .original_name = exposed_item.name,
+                .target = null,
             };
             try self.scopeIntroduceExposedItem(item_name, item_info, import_region);
         }
@@ -5974,12 +5996,35 @@ fn introduceItemsUnaliased(
             const is_type_name = local_name_text.len > 0 and local_name_text[0] >= 'A' and local_name_text[0] <= 'Z';
 
             // A type module's associated items are exposed under
-            // `<MainType>.<item>`; lookupImportedExposedNode resolves both that
+            // `<MainType>.<item>`; lookupImportedExposedTarget resolves both that
             // qualified form and the bare module-style name.
-            if (try self.lookupImportedExposedNode(module_env, item_name_text)) |target_node_idx| {
+            if (try self.lookupImportedExposedTarget(module_env, item_name_text)) |target| {
+                const target_node_idx = if (is_type_name)
+                    target.typeDeclNode()
+                else
+                    target.valueDefNode();
+
+                if (target_node_idx == null) {
+                    if (is_type_name) {
+                        try self.env.pushDiagnostic(Diagnostic{ .type_not_exposed = .{
+                            .module_name = module_name,
+                            .type_name = exposed_item.name,
+                            .region = import_region,
+                        } });
+                    } else {
+                        try self.env.pushDiagnostic(Diagnostic{ .value_not_exposed = .{
+                            .module_name = module_name,
+                            .value_name = exposed_item.name,
+                            .region = import_region,
+                        } });
+                    }
+                    continue;
+                }
+
                 const item_info = Scope.ExposedItemInfo{
                     .module_name = module_name,
                     .original_name = exposed_item.name,
+                    .target = target,
                 };
                 try self.scopeIntroduceExposedItem(local_ident, item_info, import_region);
 
@@ -5993,7 +6038,7 @@ fn introduceItemsUnaliased(
                         module_name,
                         exposed_item.name,
                         original_type_name,
-                        target_node_idx,
+                        target_node_idx.?,
                         module_import_idx,
                         import_region,
                         .module_was_found,
@@ -6021,6 +6066,7 @@ fn introduceItemsUnaliased(
             const item_info = Scope.ExposedItemInfo{
                 .module_name = module_name,
                 .original_name = exposed_item.name,
+                .target = null,
             };
             try self.scopeIntroduceExposedItem(local_ident, item_info, import_region);
 
@@ -6571,7 +6617,7 @@ fn canonicalizeTypeAssociatedLookup(
             const qualified_text = self.env.getIdent(fully_qualified_idx);
 
             if (module_env.common.findIdent(qualified_text)) |qname_ident| {
-                if (module_env.getExposedNodeIndexById(qname_ident)) |target_node_idx| {
+                if (module_env.getExposedValueNodeIndexById(qname_ident)) |target_node_idx| {
                     const import_idx = if (autoImportedTypeUsesCompilerBuiltinImport(auto_imported_type_env))
                         try self.getOrCreateCompilerBuiltinAutoImport()
                     else blk_import: {
@@ -6663,7 +6709,7 @@ fn canonicalizeModuleQualifiedIdent(
         };
 
         const qname_ident = module_env.common.findIdent(lookup_name) orelse break :blk null;
-        break :blk module_env.getExposedNodeIndexById(qname_ident);
+        break :blk module_env.getExposedValueNodeIndexById(qname_ident);
     } else null;
 
     const target_node_idx = target_node_idx_opt orelse {
@@ -6724,10 +6770,12 @@ fn canonicalizeUnqualifiedIdentExpr(
         .not_found => {
             if (self.scopeLookupExposedItem(ident)) |exposed_info| {
                 const import_idx = self.scopeLookupImportedModule(exposed_info.module_name) orelse unreachable;
-                const field_text = self.env.getIdent(exposed_info.original_name);
-                const target_node_idx_opt: ?u32 = blk: {
+                const target_node_idx_opt: ?u32 = if (exposed_info.target) |target|
+                    target.valueDefNode()
+                else blk: {
+                    const field_text = self.env.getIdent(exposed_info.original_name);
                     if (self.lookupAvailableModuleEnv(exposed_info.module_name)) |auto_imported_type| {
-                        break :blk try self.lookupImportedExposedNode(auto_imported_type.env, field_text);
+                        break :blk try self.lookupImportedExposedValueNode(auto_imported_type.env, field_text);
                     }
                     break :blk null;
                 };
@@ -11509,7 +11557,7 @@ fn resolveRecordBuilderExternalMap2(
         const qualified_map2_name = try self.insertQualifiedIdent(qualified_type_text, map2_text);
         const qualified_map2_text = self.env.getIdent(qualified_map2_name);
         const imported_ident = imported_type.env.common.findIdent(qualified_map2_text) orelse return null;
-        const target_node_idx = imported_type.env.getExposedNodeIndexById(imported_ident) orelse return null;
+        const target_node_idx = imported_type.env.getExposedValueNodeIndexById(imported_ident) orelse return null;
 
         return RecordBuilderMap2{ .external = .{
             .module_idx = import_idx,
@@ -11518,7 +11566,7 @@ fn resolveRecordBuilderExternalMap2(
         } };
     }
 
-    const target_node_idx = (try self.lookupImportedExposedNode(imported_type.env, map2_text)) orelse return null;
+    const target_node_idx = (try self.lookupImportedExposedValueNode(imported_type.env, map2_text)) orelse return null;
     return RecordBuilderMap2{ .external = .{
         .module_idx = import_idx,
         .target_node_idx = target_node_idx,
@@ -11847,36 +11895,53 @@ fn validateImportedNominalTagTarget(
     }
 }
 
-/// Resolve the exposed-node index for an item exposed by `imported_env`,
+/// Resolve the explicit target for an item exposed by `imported_env`,
 /// handling both module-style exposure (the item is exposed under its bare
 /// name) and type-module associated items (exposed under `<MainType>.<item>`,
-/// since the module's main type name equals its module name). Used for both
-/// exposed types and exposed values.
-fn lookupImportedExposedNode(
+/// since the module's main type name equals its module name).
+fn lookupImportedExposedTarget(
     self: *Self,
     imported_env: *const ModuleEnv,
     item_text: []const u8,
-) std.mem.Allocator.Error!?u32 {
+) std.mem.Allocator.Error!?collections.ExposedItemTarget {
     const module_name_text = imported_env.module_name;
     const scratch_top = self.scratchBytesTop();
     defer self.clearScratchBytesFrom(scratch_top);
     const module_qualified_text = try self.scratchQualifiedText(module_name_text, item_text);
-    const module_qualified_node_idx = lookupExposedNodeByText(imported_env, module_qualified_text);
+    const module_qualified_target = lookupExposedTargetByText(imported_env, module_qualified_text);
 
-    if (module_qualified_node_idx) |target_node_idx| {
-        return target_node_idx;
+    if (module_qualified_target) |target| {
+        return target;
     }
 
-    return lookupExposedNodeByText(imported_env, item_text);
+    return lookupExposedTargetByText(imported_env, item_text);
 }
 
-fn lookupExposedNodeByText(
+fn lookupImportedExposedValueNode(
+    self: *Self,
+    imported_env: *const ModuleEnv,
+    item_text: []const u8,
+) std.mem.Allocator.Error!?u32 {
+    const target = (try self.lookupImportedExposedTarget(imported_env, item_text)) orelse return null;
+    return target.valueDefNode();
+}
+
+fn lookupImportedExposedTypeNode(
+    self: *Self,
+    imported_env: *const ModuleEnv,
+    item_text: []const u8,
+) std.mem.Allocator.Error!?u32 {
+    const target = (try self.lookupImportedExposedTarget(imported_env, item_text)) orelse return null;
+    return target.typeDeclNode();
+}
+
+fn lookupExposedTargetByText(
     imported_env: *const ModuleEnv,
     type_text: []const u8,
-) ?u32 {
+) ?collections.ExposedItemTarget {
     if (imported_env.common.findIdent(type_text)) |qualified_ident| {
-        if (imported_env.getExposedNodeIndexById(qualified_ident)) |target_node_idx| {
-            return target_node_idx;
+        if (imported_env.getExposedTargetById(qualified_ident)) |target| {
+            return target;
         }
     }
 
@@ -12025,15 +12090,17 @@ fn finishTagExprWithArgs(
                 } }), .free_vars = DataSpan.empty() };
             };
             const target_node_idx = blk: {
-                const original_name_text = self.env.getIdent(exposed_info.original_name);
-                break :blk (try self.lookupImportedExposedNode(imported_type.env, original_name_text)) orelse {
-                    // Type is not exposed by the imported module
-                    return CanonicalizedExpr{ .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_not_exposed = .{
-                        .module_name = module_name,
-                        .type_name = type_tok_ident,
-                        .region = type_tok_region,
-                    } }), .free_vars = DataSpan.empty() };
-                };
+                if (exposed_info.target) |target| {
+                    if (target.typeDeclNode()) |node_idx| break :blk node_idx;
+                } else {
+                    const original_name_text = self.env.getIdent(exposed_info.original_name);
+                    if (try self.lookupImportedExposedTypeNode(imported_type.env, original_name_text)) |node_idx| break :blk node_idx;
+                }
+                return CanonicalizedExpr{ .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_not_exposed = .{
+                    .module_name = module_name,
+                    .type_name = type_tok_ident,
+                    .region = type_tok_region,
+                } }), .free_vars = DataSpan.empty() };
             };
 
             if (try self.validateImportedNominalTagTarget(Expr.Idx, imported_type.env, target_node_idx, module_name, type_tok_ident, type_tok_region)) |malformed_idx| {
@@ -12085,7 +12152,7 @@ fn finishTagExprWithArgs(
             };
 
             const tag_text = self.env.getIdent(tag_name);
-            const target_node_idx = (try self.lookupImportedExposedNode(imported_type.env, tag_text)) orelse {
+            const target_node_idx = (try self.lookupImportedExposedTypeNode(imported_type.env, tag_text)) orelse {
                 return CanonicalizedExpr{ .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_not_exposed = .{
                     .module_name = module_name,
                     .type_name = tag_name,
@@ -12236,7 +12303,7 @@ fn finishTagExprWithArgs(
 
         // Look up the target node index in the imported file's exposed_nodes
         const target_node_idx = blk: {
-            const other_module_node_id = (try self.lookupImportedExposedNode(imported_type.env, type_name)) orelse {
+            const other_module_node_id = (try self.lookupImportedExposedTypeNode(imported_type.env, type_name)) orelse {
                 // Type is not exposed by the imported file
                 return CanonicalizedExpr{ .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_not_exposed = .{
                     .module_name = module_name,
@@ -12679,7 +12746,7 @@ fn finishTagPattern(
                 } });
             };
 
-            const other_module_node_id = (try self.lookupImportedExposedNode(auto_imported_type.env, type_name)) orelse {
+            const other_module_node_id = (try self.lookupImportedExposedTypeNode(auto_imported_type.env, type_name)) orelse {
                 return try self.env.pushMalformed(Pattern.Idx, CIR.Diagnostic{ .type_not_exposed = .{
                     .module_name = module_name,
                     .type_name = type_name_ident,
@@ -16166,9 +16233,13 @@ fn canonicalizeTypeAnnoBasicType(
                     // Get the node index from the imported module
                     if (self.lookupAvailableModuleEnv(exposed_info.module_name)) |auto_imported_type| {
                         // Convert identifier from current module to target module's interner
-                        const original_name_text = self.env.getIdent(exposed_info.original_name);
-                        const target_node_idx = (try self.lookupImportedExposedNode(auto_imported_type.env, original_name_text)) orelse {
-                            // Type is not exposed by the imported module
+                        const target_node_idx = blk: {
+                            if (exposed_info.target) |target| {
+                                if (target.typeDeclNode()) |node_idx| break :blk node_idx;
+                            } else {
+                                const original_name_text = self.env.getIdent(exposed_info.original_name);
+                                if (try self.lookupImportedExposedTypeNode(auto_imported_type.env, original_name_text)) |node_idx| break :blk node_idx;
+                            }
                             return try self.env.pushMalformed(TypeAnno.Idx, CIR.Diagnostic{ .type_not_exposed = .{
                                 .module_name = exposed_info.module_name,
                                 .type_name = type_name_ident,
@@ -16256,7 +16327,7 @@ fn canonicalizeTypeAnnoBasicType(
                 } });
             };
 
-            const target_node_idx = (try self.lookupImportedExposedNode(imported_type.env, type_path_text)) orelse {
+            const target_node_idx = (try self.lookupImportedExposedTypeNode(imported_type.env, type_path_text)) orelse {
                 return try self.env.pushMalformed(TypeAnno.Idx, CIR.Diagnostic{ .type_not_exposed = .{
                     .module_name = module_name,
                     .type_name = type_path_ident,
@@ -16322,7 +16393,7 @@ fn canonicalizeTypeAnnoBasicType(
                 } });
             };
 
-            const other_module_node_id = (try self.lookupImportedExposedNode(auto_imported_type.env, type_name_text)) orelse {
+            const other_module_node_id = (try self.lookupImportedExposedTypeNode(auto_imported_type.env, type_name_text)) orelse {
                 // Type is not exposed by the module
                 return try self.env.pushMalformed(TypeAnno.Idx, CIR.Diagnostic{ .type_not_exposed = .{
                     .module_name = module_name,
@@ -17881,7 +17952,7 @@ fn prepareModuleQualifiedLookup(self: *Self, field_access: AST.BinOp) std.mem.Al
                 const qualified_text = self.env.getIdent(qualified_method_name);
 
                 if (module_env.common.findIdent(qualified_text)) |method_ident_idx| {
-                    if (module_env.getExposedNodeIndexById(method_ident_idx)) |method_node_idx| {
+                    if (module_env.getExposedValueNodeIndexById(method_ident_idx)) |method_node_idx| {
                         const func_expr_idx = try self.env.addExpr(CIR.Expr{ .e_lookup_external = .{
                             .module_idx = auto_import_idx,
                             .target_node_idx = method_node_idx,
@@ -17907,7 +17978,7 @@ fn prepareModuleQualifiedLookup(self: *Self, field_access: AST.BinOp) std.mem.Al
         const field_text = self.env.getIdent(method_name);
         const target_node_idx_opt: ?u32 = blk: {
             if (self.lookupAvailableModuleEnv(module_name)) |auto_imported_type| {
-                break :blk try self.lookupImportedExposedNode(auto_imported_type.env, field_text);
+                break :blk try self.lookupImportedExposedValueNode(auto_imported_type.env, field_text);
             }
             break :blk null;
         };
@@ -17981,7 +18052,7 @@ fn prepareModuleQualifiedLookup(self: *Self, field_access: AST.BinOp) std.mem.Al
     const field_text = self.env.getIdent(field_name);
     const target_node_idx_opt: ?u32 = blk: {
         if (self.lookupAvailableModuleEnv(module_name)) |auto_imported_type| {
-            break :blk try self.lookupImportedExposedNode(auto_imported_type.env, field_text);
+            break :blk try self.lookupImportedExposedValueNode(auto_imported_type.env, field_text);
         }
         break :blk null;
     };
@@ -18287,7 +18358,7 @@ fn exposeTopLevelTypesForExplicitRoots(self: *Self) std.mem.Allocator.Error!void
             unreachable;
         };
 
-        try self.env.setExposedNodeIndexById(type_ident, @intFromEnum(stmt_idx));
+        try self.env.setExposedTypeNodeIndexById(type_ident, @intFromEnum(stmt_idx));
     }
 }
 

--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -3548,14 +3548,29 @@ pub fn addExposedById(self: *Self, ident_idx: Ident.Idx) Allocator.Error!void {
     return try self.common.exposed_items.addExposedById(self.gpa, @bitCast(ident_idx));
 }
 
-/// Associates a node index with an exposed identifier.
-pub fn setExposedNodeIndexById(self: *Self, ident_idx: Ident.Idx, node_idx: u32) Allocator.Error!void {
-    return try self.common.exposed_items.setNodeIndexById(self.gpa, @bitCast(ident_idx), node_idx);
+/// Associates a value definition node index with an exposed identifier.
+pub fn setExposedValueNodeIndexById(self: *Self, ident_idx: Ident.Idx, node_idx: u32) Allocator.Error!void {
+    return try self.common.setValueNodeIndexById(self.gpa, ident_idx, node_idx);
 }
 
-/// Retrieves the node index associated with an exposed identifier, if any.
-pub fn getExposedNodeIndexById(self: *const Self, ident_idx: Ident.Idx) ?u32 {
-    return self.common.getNodeIndexById(self.gpa, ident_idx);
+/// Associates a type declaration node index with an exposed identifier.
+pub fn setExposedTypeNodeIndexById(self: *Self, ident_idx: Ident.Idx, node_idx: u32) Allocator.Error!void {
+    return try self.common.setTypeNodeIndexById(self.gpa, ident_idx, node_idx);
+}
+
+/// Retrieves the value definition node index associated with an exposed identifier, if any.
+pub fn getExposedValueNodeIndexById(self: *const Self, ident_idx: Ident.Idx) ?u32 {
+    return self.common.getValueNodeIndexById(self.gpa, ident_idx);
+}
+
+/// Retrieves the type declaration node index associated with an exposed identifier, if any.
+pub fn getExposedTypeNodeIndexById(self: *const Self, ident_idx: Ident.Idx) ?u32 {
+    return self.common.getTypeNodeIndexById(self.gpa, ident_idx);
+}
+
+/// Retrieves the explicit exposure target associated with an exposed identifier, if any.
+pub fn getExposedTargetById(self: *const Self, ident_idx: Ident.Idx) ?collections.ExposedItemTarget {
+    return self.common.getExposedTargetById(self.gpa, ident_idx);
 }
 
 /// Get the exposed node index for a type given its statement index.

--- a/src/canonicalize/Scope.zig
+++ b/src/canonicalize/Scope.zig
@@ -3,6 +3,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const base = @import("base");
+const collections = @import("collections");
 
 const CIR = @import("CIR.zig");
 
@@ -170,6 +171,7 @@ pub const ModuleAliasLookupResult = union(enum) {
 pub const ExposedItemInfo = struct {
     module_name: Ident.Idx,
     original_name: Ident.Idx,
+    target: ?collections.ExposedItemTarget = null,
 };
 
 /// Result of looking up an exposed item

--- a/src/canonicalize/test/import_validation_test.zig
+++ b/src/canonicalize/test/import_validation_test.zig
@@ -8,6 +8,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const base = @import("base");
+const collections = @import("collections");
 const parse = @import("parse");
 
 const Can = @import("../Can.zig");
@@ -18,6 +19,22 @@ const BuiltinTestContext = @import("./BuiltinTestContext.zig").BuiltinTestContex
 const CoreCtx = @import("ctx").CoreCtx;
 const testing = std.testing;
 const expectEqual = testing.expectEqual;
+
+fn expectNoZeroTargetExternalLookup(env: *const ModuleEnv) error{TestUnexpectedResult}!void {
+    var raw_node_idx: u32 = 0;
+    while (raw_node_idx < env.store.nodes.len()) : (raw_node_idx += 1) {
+        const node_idx: CIR.Node.Idx = @enumFromInt(raw_node_idx);
+        if (env.store.nodes.get(node_idx).tag != .expr_external_lookup) continue;
+
+        const expr_idx: CIR.Expr.Idx = @enumFromInt(raw_node_idx);
+        switch (env.store.getExpr(expr_idx)) {
+            .e_lookup_external => |external| {
+                try testing.expect(external.target_node_idx != 0);
+            },
+            else => unreachable,
+        }
+    }
+}
 
 // Helper function to parse and canonicalize source code
 fn parseAndCanonicalizeSource(
@@ -78,13 +95,13 @@ test "import validation - mix of MODULE NOT FOUND, TYPE NOT EXPOSED, VALUE NOT E
     // Add exposed items to Json module
     const Ident = base.Ident;
     const decode_idx = try json_env.common.idents.insert(allocator, Ident.for_text("decode"));
-    try json_env.addExposedById(decode_idx);
+    try json_env.setExposedValueNodeIndexById(decode_idx, 1);
     const encode_idx = try json_env.common.idents.insert(allocator, Ident.for_text("encode"));
-    try json_env.addExposedById(encode_idx);
+    try json_env.setExposedValueNodeIndexById(encode_idx, 2);
     const json_error_idx = try json_env.common.idents.insert(allocator, Ident.for_text("JsonError"));
-    try json_env.addExposedById(json_error_idx);
+    try json_env.setExposedTypeNodeIndexById(json_error_idx, 3);
     const decode_problem_idx = try json_env.common.idents.insert(allocator, Ident.for_text("DecodeProblem"));
-    try json_env.addExposedById(decode_problem_idx);
+    try json_env.setExposedTypeNodeIndexById(decode_problem_idx, 4);
 
     // Create module environment for "Utils" module
     const utils_env = try allocator.create(ModuleEnv);
@@ -95,11 +112,11 @@ test "import validation - mix of MODULE NOT FOUND, TYPE NOT EXPOSED, VALUE NOT E
     }
     // Add exposed items to Utils module
     const map_idx = try utils_env.common.idents.insert(allocator, Ident.for_text("map"));
-    try utils_env.addExposedById(map_idx);
+    try utils_env.setExposedValueNodeIndexById(map_idx, 1);
     const filter_idx = try utils_env.common.idents.insert(allocator, Ident.for_text("filter"));
-    try utils_env.addExposedById(filter_idx);
+    try utils_env.setExposedValueNodeIndexById(filter_idx, 2);
     const result_idx = try utils_env.common.idents.insert(allocator, Ident.for_text("Try"));
-    try utils_env.addExposedById(result_idx);
+    try utils_env.setExposedTypeNodeIndexById(result_idx, 3);
     // Parse source code with various import statements
     const source =
         \\module [main]
@@ -297,6 +314,109 @@ test "import validation - type module associated values are importable via expos
             else => {},
         }
     }
+}
+
+test "unresolved exposed value is not imported as external lookup target zero" {
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
+    defer std.debug.assert(gpa_state.deinit() == .ok);
+    const allocator = gpa_state.allocator();
+    const Ident = base.Ident;
+
+    var builtin_ctx = try BuiltinTestContext.init(allocator);
+    defer builtin_ctx.deinit();
+    const roc_ctx = CoreCtx.testing(allocator, allocator);
+
+    const a_source =
+        \\module [f]
+        \\
+        \\T := [].{
+        \\    f = |x| x
+        \\}
+    ;
+
+    var a_env = try ModuleEnv.init(allocator, a_source);
+    defer a_env.deinit();
+    try a_env.initCIRFields("A");
+
+    const a_ast = try parse.file(allocator, &a_env.common);
+    defer a_ast.deinit();
+
+    var a_can = try Can.initModule(roc_ctx, &a_env, a_ast, builtin_ctx.canInitContext());
+    defer a_can.deinit();
+    try a_can.canonicalizeFile();
+
+    const exposed_f = a_env.common.findIdent("f") orelse return error.MissingExposedIdent;
+    const f_target = a_env.getExposedTargetById(exposed_f) orelse return error.MissingExposedTarget;
+    try expectEqual(collections.ExposedItemTarget.Kind.unresolved, f_target.tag());
+    try expectEqual(@as(?u32, null), a_env.getExposedValueNodeIndexById(exposed_f));
+
+    var found_unimplemented_f = false;
+    const a_diagnostics = try a_env.getDiagnostics();
+    defer allocator.free(a_diagnostics);
+    for (a_diagnostics) |diagnostic| {
+        switch (diagnostic) {
+            .exposed_but_not_implemented => |d| {
+                if (std.mem.eql(u8, a_env.getIdent(d.ident), "f")) {
+                    found_unimplemented_f = true;
+                }
+            },
+            else => {},
+        }
+    }
+    try testing.expect(found_unimplemented_f);
+
+    const importer_source =
+        \\module [main]
+        \\
+        \\import A
+        \\
+        \\main = A.f({})
+    ;
+
+    var importer_env = try ModuleEnv.init(allocator, importer_source);
+    defer importer_env.deinit();
+    try importer_env.initCIRFields("Importer");
+
+    var module_envs = std.AutoHashMap(base.Ident.Idx, Can.AutoImportedType).init(allocator);
+    defer module_envs.deinit();
+
+    const a_import_ident = try importer_env.insertIdent(Ident.for_text("A"));
+    const a_qualified_ident = try a_env.insertIdent(Ident.for_text("A"));
+    try module_envs.put(a_import_ident, .{
+        .env = &a_env,
+        .qualified_type_ident = a_qualified_ident,
+    });
+
+    const importer_ast = try parse.file(allocator, &importer_env.common);
+    defer importer_ast.deinit();
+
+    var importer_can = try Can.initModule(roc_ctx, &importer_env, importer_ast, .{
+        .builtin_types = .{
+            .builtin_module_env = builtin_ctx.builtin_module.env,
+            .builtin_indices = builtin_ctx.builtin_indices,
+        },
+        .imported_modules = &module_envs,
+    });
+    defer importer_can.deinit();
+    try importer_can.canonicalizeFile();
+
+    var found_missing_f = false;
+    const importer_diagnostics = try importer_env.getDiagnostics();
+    defer allocator.free(importer_diagnostics);
+    for (importer_diagnostics) |diagnostic| {
+        switch (diagnostic) {
+            .nested_value_not_found => |d| {
+                if (std.mem.eql(u8, importer_env.getIdent(d.parent_name), "A") and
+                    std.mem.eql(u8, importer_env.getIdent(d.nested_name), "f"))
+                {
+                    found_missing_f = true;
+                }
+            },
+            else => {},
+        }
+    }
+    try testing.expect(found_missing_f);
+    try expectNoZeroTargetExternalLookup(&importer_env);
 }
 
 test "import validation - no module_envs provided" {
@@ -618,11 +738,11 @@ test "exposed_items - tracking CIR node indices for exposed items" {
     // Add exposed items
     const Ident = base.Ident;
     const add_idx = try math_env.common.idents.insert(allocator, Ident.for_text("add"));
-    try math_env.addExposedById(add_idx);
+    try math_env.setExposedValueNodeIndexById(add_idx, 1);
     const multiply_idx = try math_env.common.idents.insert(allocator, Ident.for_text("multiply"));
-    try math_env.addExposedById(multiply_idx);
+    try math_env.setExposedValueNodeIndexById(multiply_idx, 2);
     const pi_idx = try math_env.common.idents.insert(allocator, Ident.for_text("PI"));
-    try math_env.addExposedById(pi_idx);
+    try math_env.setExposedTypeNodeIndexById(pi_idx, 3);
 
     const math_utils_ident = try temp_idents.insert(allocator, Ident.for_text("MathUtils"));
     const math_utils_qualified_ident = try math_env.common.insertIdent(math_env.gpa, Ident.for_text("MathUtils"));

--- a/src/canonicalize/test/type_decl_stmt_test.zig
+++ b/src/canonicalize/test/type_decl_stmt_test.zig
@@ -568,7 +568,7 @@ test "malformed associated type header does not suppress later associated value"
     try canonicalizeModuleAndCheck(source, struct {
         fn check(env: *ModuleEnv, diagnostics: []const CIR.Diagnostic) anyerror!void {
             const qualified_outer_ok = env.common.findIdent("Test.Outer.ok") orelse return error.MissingQualifiedOuterOkIdent;
-            try testing.expect(env.getExposedNodeIndexById(qualified_outer_ok) != null);
+            try testing.expect(env.getExposedValueNodeIndexById(qualified_outer_ok) != null);
             try testing.expectEqual(@as(usize, 0), countAssociatedLookupDiagnostics(env, diagnostics, "Outer.ok"));
         }
     }.check);
@@ -593,10 +593,10 @@ test "block-local associated value does not leak after owner scope exits" {
             try testing.expectEqual(@as(usize, 1), countValueLookupDiagnostics(env, diagnostics, "T", "marker"));
 
             if (env.common.findIdent("T.marker")) |ident| {
-                try testing.expect(env.getExposedNodeIndexById(ident) == null);
+                try testing.expect(env.getExposedValueNodeIndexById(ident) == null);
             }
             if (env.common.findIdent("Test.T.marker")) |ident| {
-                try testing.expect(env.getExposedNodeIndexById(ident) == null);
+                try testing.expect(env.getExposedValueNodeIndexById(ident) == null);
             }
         }
     }.check);

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -501,7 +501,7 @@ pub const ProvidedExportTable = struct {
         errdefer exports.deinit(allocator);
 
         for (source, published_provides) |provides_entry, published| {
-            const def_node_idx = module_env.getExposedNodeIndexById(provides_entry.ident) orelse {
+            const def_node_idx = module_env.getExposedValueNodeIndexById(provides_entry.ident) orelse {
                 if (builtin.mode == .Debug) {
                     std.debug.panic(
                         "checked artifact invariant violated: provided entry {s} has no top-level definition",
@@ -1156,7 +1156,7 @@ fn appendPublishedEntrypointRoots(
     switch (module_env.module_kind) {
         .default_app => {
             const main_ident = module_env.idents.main_bang;
-            const main_node_idx = module_env.getExposedNodeIndexById(main_ident) orelse {
+            const main_node_idx = module_env.getExposedValueNodeIndexById(main_ident) orelse {
                 if (builtin.mode == .Debug) {
                     std.debug.panic(
                         "checked artifact invariant violated: default app main! has no published root definition",
@@ -8615,9 +8615,7 @@ fn collectPublishedExportDefs(
 
     var exposed_iter = module_env.common.exposed_items.iterator();
     while (exposed_iter.next()) |entry| {
-        if (entry.node_idx == 0) continue;
-
-        const raw_node_idx: u32 = entry.node_idx;
+        const raw_node_idx: u32 = entry.target.valueDefNode() orelse continue;
         if (raw_node_idx >= node_count) {
             if (builtin.mode == .Debug) {
                 std.debug.panic(
@@ -13602,8 +13600,7 @@ fn appendExposedTypeDeclarationPublicApiDependencies(
     const module_env = module.moduleEnvConst();
     var exposed_iter = module_env.common.exposed_items.iterator();
     while (exposed_iter.next()) |entry| {
-        if (entry.node_idx == 0) continue;
-        const raw_node_idx: u32 = entry.node_idx;
+        const raw_node_idx: u32 = entry.target.typeDeclNode() orelse continue;
         if (raw_node_idx >= module.nodeCount()) {
             checkedArtifactInvariant("exposed type item points at out-of-range node", .{});
         }

--- a/src/check/test/TestEnv.zig
+++ b/src/check/test/TestEnv.zig
@@ -188,7 +188,7 @@ pub fn initWithImport(module_name: []const u8, source: []const u8, other_module_
             // Type modules expose their main type under the module name
             const type_ident = other_test_env.module_env.common.findIdent(other_module_name);
             if (type_ident) |ident| {
-                if (other_test_env.module_env.getExposedNodeIndexById(ident)) |node_idx| {
+                if (other_test_env.module_env.getExposedTypeNodeIndexById(ident)) |node_idx| {
                     // The node index IS the statement index for type declarations
                     break :blk @as(CIR.Statement.Idx, @enumFromInt(node_idx));
                 }

--- a/src/check/test/cross_module_mono_test.zig
+++ b/src/check/test/cross_module_mono_test.zig
@@ -253,7 +253,7 @@ const MonoTestEnv = struct {
             if (other_env.module_env.module_kind == .type_module) {
                 const type_ident = other_env.module_env.common.findIdent(other_module_name);
                 if (type_ident) |ident| {
-                    if (other_env.module_env.getExposedNodeIndexById(ident)) |node_idx| {
+                    if (other_env.module_env.getExposedTypeNodeIndexById(ident)) |node_idx| {
                         break :blk @as(CIR.Statement.Idx, @enumFromInt(node_idx));
                     }
                 }
@@ -370,7 +370,7 @@ const MonoTestEnv = struct {
                 if (imp.env.module_env.module_kind == .type_module) {
                     const type_ident = imp.env.module_env.common.findIdent(imp.name);
                     if (type_ident) |ident| {
-                        if (imp.env.module_env.getExposedNodeIndexById(ident)) |node_idx| {
+                        if (imp.env.module_env.getExposedTypeNodeIndexById(ident)) |node_idx| {
                             break :blk @as(CIR.Statement.Idx, @enumFromInt(node_idx));
                         }
                     }

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -1861,15 +1861,13 @@ fn customDefaultPlatformDebugBacktrace(
         .crash => &.{
             .{ .stream = .stderr, .text = "Roc application crashed with this message:\n\n\tdefault platform crash contract\n\n" },
             .{ .stream = .stderr, .text = "Backtrace:" },
-            .{ .stream = .stderr, .text = "\x1b[94mtrigger!\x1b[0m " },
-            .{ .stream = .stderr, .text = "\x1b[94mmain!\x1b[0m " },
-            .{ .stream = .stderr, .text = " main:" },
+            .{ .stream = .stderr, .text = "\x1b[94mtrigger!\x1b[0m" },
+            .{ .stream = .stderr, .text = "\x1b[94mmain!\x1b[0m" },
         },
         .stack_overflow => &.{
             .{ .stream = .stderr, .text = "Roc application overflowed its stack memory\n\n" },
             .{ .stream = .stderr, .text = "Backtrace:" },
-            .{ .stream = .stderr, .text = "\x1b[94mrecurse\x1b[0m " },
-            .{ .stream = .stderr, .text = " main:" },
+            .{ .stream = .stderr, .text = "\x1b[94mrecurse\x1b[0m" },
         },
     };
 

--- a/src/collections/ExposedItems.zig
+++ b/src/collections/ExposedItems.zig
@@ -2,10 +2,7 @@
 //!
 //! This combines the functionality of exposed_by_str and exposed_nodes into a single
 //! SortedArrayBuilder to save memory and simplify the API. It uses interned identifier
-//! indices (u32 matching Ident.Idx) as keys and u32 values (the node indices).
-//!
-//! A value of 0 means "exposed but not yet defined", while non-zero values
-//! are actual node indices.
+//! indices (u32 matching Ident.Idx) as keys and explicit export targets as values.
 //!
 //! Note: This module only provides ID-based methods. String-to-ID conversion must be
 //! handled by the caller who has access to the Ident.Store.
@@ -20,16 +17,65 @@ const CompactWriter = @import("CompactWriter.zig");
 // This is critical because foo, foo!, and _foo are different identifiers
 const IdentIdx = u32;
 
-/// A collection that tracks exposed items by their names and associated CIR node indices
+/// The resolved target for an exposed item.
+pub const ExposedItemTarget = extern struct {
+    kind: u32,
+    node_idx: u32,
+
+    pub const Kind = enum(u32) {
+        unresolved,
+        value_def,
+        type_decl,
+    };
+
+    pub fn unresolved() ExposedItemTarget {
+        return .{
+            .kind = @intFromEnum(Kind.unresolved),
+            .node_idx = 0,
+        };
+    }
+
+    pub fn valueDef(node_idx: u32) ExposedItemTarget {
+        return .{
+            .kind = @intFromEnum(Kind.value_def),
+            .node_idx = node_idx,
+        };
+    }
+
+    pub fn typeDecl(node_idx: u32) ExposedItemTarget {
+        return .{
+            .kind = @intFromEnum(Kind.type_decl),
+            .node_idx = node_idx,
+        };
+    }
+
+    pub fn tag(self: ExposedItemTarget) Kind {
+        return @enumFromInt(self.kind);
+    }
+
+    pub fn isResolved(self: ExposedItemTarget) bool {
+        return self.tag() != .unresolved;
+    }
+
+    pub fn valueDefNode(self: ExposedItemTarget) ?u32 {
+        return if (self.tag() == .value_def) self.node_idx else null;
+    }
+
+    pub fn typeDeclNode(self: ExposedItemTarget) ?u32 {
+        return if (self.tag() == .type_decl) self.node_idx else null;
+    }
+};
+
+/// A collection that tracks exposed items by their names and explicit targets.
 pub const ExposedItems = struct {
-    /// Maps item name (as interned ID) -> CIR node index (0 means exposed but not defined)
-    items: SortedArrayBuilder(IdentIdx, u32),
+    /// Maps item name (as interned ID) -> resolved or unresolved exposure target.
+    items: SortedArrayBuilder(IdentIdx, ExposedItemTarget),
 
     const Self = @This();
 
     pub fn init() Self {
         return .{
-            .items = SortedArrayBuilder(IdentIdx, u32).init(),
+            .items = SortedArrayBuilder(IdentIdx, ExposedItemTarget).init(),
         };
     }
 
@@ -43,35 +89,18 @@ pub const ExposedItems = struct {
         };
     }
 
-    /// Add an exposed item by its interned ID (pass @bitCast(base.Ident.Idx) to u32)
-    pub fn addExposedById(self: *Self, allocator: Allocator, ident_idx: IdentIdx) Allocator.Error!void {
-        // Add with value 0 to indicate "exposed but not yet defined"
-        // The SortedArrayBuilder will handle duplicates by keeping the last value,
-        // but we don't want to overwrite an existing node index with 0
-        if (self.items.sorted) {
-            // If already sorted, check if it exists first
-            if (self.items.get(allocator, ident_idx) == null) {
-                try self.items.put(allocator, ident_idx, 0);
-            }
-        } else {
-            // If not sorted yet, just add it - duplicates will be handled later
-            try self.items.put(allocator, ident_idx, 0);
-        }
-    }
-
-    /// Set the node index for an exposed item by its interned ID (pass @bitCast(base.Ident.Idx) to u32)
-    pub fn setNodeIndexById(self: *Self, allocator: Allocator, ident_idx: IdentIdx, node_idx: u32) Allocator.Error!void {
+    fn findIndex(self: *Self, allocator: Allocator, ident_idx: IdentIdx) struct { index: usize, found: bool } {
         self.items.ensureSorted(allocator);
 
         const entries = self.items.entries.items;
         var left: usize = 0;
         var right: usize = entries.len;
+
         while (left < right) {
             const mid = left + (right - left) / 2;
             const mid_key = entries[mid].key;
             if (mid_key == ident_idx) {
-                entries[mid].value = node_idx;
-                return;
+                return .{ .index = mid, .found = true };
             } else if (mid_key < ident_idx) {
                 left = mid + 1;
             } else {
@@ -79,7 +108,41 @@ pub const ExposedItems = struct {
             }
         }
 
-        try self.items.put(allocator, ident_idx, node_idx);
+        return .{ .index = left, .found = false };
+    }
+
+    /// Add an exposed item by its interned ID (pass @bitCast(base.Ident.Idx) to u32)
+    pub fn addExposedById(self: *Self, allocator: Allocator, ident_idx: IdentIdx) Allocator.Error!void {
+        const found = self.findIndex(allocator, ident_idx);
+        if (found.found) return;
+
+        try self.items.entries.insert(allocator, found.index, .{
+            .key = ident_idx,
+            .value = ExposedItemTarget.unresolved(),
+        });
+    }
+
+    fn setTargetById(self: *Self, allocator: Allocator, ident_idx: IdentIdx, target: ExposedItemTarget) Allocator.Error!void {
+        const found = self.findIndex(allocator, ident_idx);
+        if (found.found) {
+            self.items.entries.items[found.index].value = target;
+            return;
+        }
+
+        try self.items.entries.insert(allocator, found.index, .{
+            .key = ident_idx,
+            .value = target,
+        });
+    }
+
+    /// Set the value definition target for an exposed item by its interned ID.
+    pub fn setValueNodeIndexById(self: *Self, allocator: Allocator, ident_idx: IdentIdx, node_idx: u32) Allocator.Error!void {
+        try self.setTargetById(allocator, ident_idx, ExposedItemTarget.valueDef(node_idx));
+    }
+
+    /// Set the type declaration target for an exposed item by its interned ID.
+    pub fn setTypeNodeIndexById(self: *Self, allocator: Allocator, ident_idx: IdentIdx, node_idx: u32) Allocator.Error!void {
+        try self.setTargetById(allocator, ident_idx, ExposedItemTarget.typeDecl(node_idx));
     }
 
     /// Check if an item is exposed by its interned ID (pass @bitCast(base.Ident.Idx) to u32)
@@ -88,10 +151,22 @@ pub const ExposedItems = struct {
         return mutable_self.items.get(allocator, ident_idx) != null;
     }
 
-    /// Get the node index for an exposed item by its interned ID (pass @bitCast(base.Ident.Idx) to u32)
-    pub fn getNodeIndexById(self: *const Self, allocator: Allocator, ident_idx: IdentIdx) ?u32 {
+    /// Get the explicit target for an exposed item by its interned ID.
+    pub fn getTargetById(self: *const Self, allocator: Allocator, ident_idx: IdentIdx) ?ExposedItemTarget {
         var mutable_self = @constCast(self);
         return mutable_self.items.get(allocator, ident_idx);
+    }
+
+    /// Get the value definition node for an exposed item by its interned ID.
+    pub fn getValueNodeIndexById(self: *const Self, allocator: Allocator, ident_idx: IdentIdx) ?u32 {
+        const target = self.getTargetById(allocator, ident_idx) orelse return null;
+        return target.valueDefNode();
+    }
+
+    /// Get the type declaration node for an exposed item by its interned ID.
+    pub fn getTypeNodeIndexById(self: *const Self, allocator: Allocator, ident_idx: IdentIdx) ?u32 {
+        const target = self.getTargetById(allocator, ident_idx) orelse return null;
+        return target.typeDeclNode();
     }
 
     /// Get the number of exposed items
@@ -119,7 +194,7 @@ pub const ExposedItems = struct {
     /// Serialized representation of ExposedItems
     /// Uses extern struct to guarantee consistent field layout across optimization levels.
     pub const Serialized = extern struct {
-        items: SortedArrayBuilder(IdentIdx, u32).Serialized,
+        items: SortedArrayBuilder(IdentIdx, ExposedItemTarget).Serialized,
 
         /// Serialize an ExposedItems into this Serialized struct, appending data to the writer
         pub fn serialize(
@@ -180,14 +255,14 @@ pub const ExposedItems = struct {
 
     /// Iterator for all exposed items
     pub const Iterator = struct {
-        items: []const SortedArrayBuilder(IdentIdx, u32).Entry,
+        items: []const SortedArrayBuilder(IdentIdx, ExposedItemTarget).Entry,
         index: usize,
 
-        pub fn next(self: *Iterator) ?struct { ident_idx: IdentIdx, node_idx: u32 } {
+        pub fn next(self: *Iterator) ?struct { ident_idx: IdentIdx, target: ExposedItemTarget } {
             if (self.index < self.items.len) {
                 const entry = self.items[self.index];
                 self.index += 1;
-                return .{ .ident_idx = entry.key, .node_idx = entry.value };
+                return .{ .ident_idx = entry.key, .target = entry.value };
             }
             return null;
         }
@@ -225,18 +300,22 @@ test "ExposedItems basic operations" {
     try testing.expect(exposed.containsById(allocator, my_type_id));
     try testing.expect(!exposed.containsById(allocator, 999)); // missing
 
-    // Test getNodeIndexById before setting (should be 0)
-    try testing.expectEqual(@as(?u32, 0), exposed.getNodeIndexById(allocator, foo_id));
+    // Test unresolved exposure requests before setting.
+    try testing.expectEqual(@as(?u32, null), exposed.getValueNodeIndexById(allocator, foo_id));
+    try testing.expectEqual(@as(?u32, null), exposed.getTypeNodeIndexById(allocator, foo_id));
+    try testing.expectEqual(ExposedItemTarget.Kind.unresolved, exposed.getTargetById(allocator, foo_id).?.tag());
 
     // Set node indices
-    try exposed.setNodeIndexById(allocator, foo_id, 42);
-    try exposed.setNodeIndexById(allocator, bar_id, 84);
+    try exposed.setValueNodeIndexById(allocator, foo_id, 42);
+    try exposed.setTypeNodeIndexById(allocator, bar_id, 84);
 
-    // Test getNodeIndexById after setting
-    try testing.expectEqual(@as(?u32, 42), exposed.getNodeIndexById(allocator, foo_id));
-    try testing.expectEqual(@as(?u32, 84), exposed.getNodeIndexById(allocator, bar_id));
-    try testing.expectEqual(@as(?u32, 0), exposed.getNodeIndexById(allocator, my_type_id)); // Not set
-    try testing.expectEqual(@as(?u32, null), exposed.getNodeIndexById(allocator, 999)); // Not exposed
+    // Test typed lookups after setting
+    try testing.expectEqual(@as(?u32, 42), exposed.getValueNodeIndexById(allocator, foo_id));
+    try testing.expectEqual(@as(?u32, 84), exposed.getTypeNodeIndexById(allocator, bar_id));
+    try testing.expectEqual(@as(?u32, null), exposed.getTypeNodeIndexById(allocator, foo_id));
+    try testing.expectEqual(@as(?u32, null), exposed.getValueNodeIndexById(allocator, bar_id));
+    try testing.expectEqual(@as(?u32, null), exposed.getValueNodeIndexById(allocator, my_type_id)); // Not set
+    try testing.expectEqual(@as(?u32, null), exposed.getValueNodeIndexById(allocator, 999)); // Not exposed
 }
 
 test "ExposedItems empty CompactWriter roundtrip" {
@@ -297,9 +376,9 @@ test "ExposedItems basic CompactWriter roundtrip" {
     try original.addExposedById(allocator, id3);
 
     // Set node indices
-    try original.setNodeIndexById(allocator, id1, 42);
-    try original.setNodeIndexById(allocator, id2, 84);
-    // id3 left as 0 (exposed but not defined)
+    try original.setValueNodeIndexById(allocator, id1, 42);
+    try original.setTypeNodeIndexById(allocator, id2, 84);
+    // id3 left unresolved
 
     // Ensure sorted before serialization
     original.ensureSorted(allocator);
@@ -335,9 +414,12 @@ test "ExposedItems basic CompactWriter roundtrip" {
 
     // Verify the items are accessible
     try testing.expectEqual(@as(usize, 3), deserialized.count());
-    try testing.expectEqual(@as(?u32, 42), deserialized.getNodeIndexById(allocator, id1));
-    try testing.expectEqual(@as(?u32, 84), deserialized.getNodeIndexById(allocator, id2));
-    try testing.expectEqual(@as(?u32, 0), deserialized.getNodeIndexById(allocator, id3));
+    try testing.expectEqual(@as(?u32, 42), deserialized.getValueNodeIndexById(allocator, id1));
+    try testing.expectEqual(@as(?u32, 84), deserialized.getTypeNodeIndexById(allocator, id2));
+    try testing.expectEqual(@as(?u32, null), deserialized.getValueNodeIndexById(allocator, id3));
+    try testing.expectEqual(ExposedItemTarget.Kind.value_def, deserialized.getTargetById(allocator, id1).?.tag());
+    try testing.expectEqual(ExposedItemTarget.Kind.type_decl, deserialized.getTargetById(allocator, id2).?.tag());
+    try testing.expectEqual(ExposedItemTarget.Kind.unresolved, deserialized.getTargetById(allocator, id3).?.tag());
 }
 
 test "ExposedItems with duplicates CompactWriter roundtrip" {
@@ -352,10 +434,10 @@ test "ExposedItems with duplicates CompactWriter roundtrip" {
     const id2: IdentIdx = 200;
 
     try original.addExposedById(allocator, id1);
-    try original.setNodeIndexById(allocator, id1, 42);
+    try original.setValueNodeIndexById(allocator, id1, 42);
     try original.addExposedById(allocator, id2);
     try original.addExposedById(allocator, id1); // duplicate
-    try original.setNodeIndexById(allocator, id2, 84);
+    try original.setValueNodeIndexById(allocator, id2, 84);
     try original.addExposedById(allocator, id2); // duplicate
 
     // Ensure sorted before serialization (this will also deduplicate)
@@ -392,8 +474,8 @@ test "ExposedItems with duplicates CompactWriter roundtrip" {
 
     // After deduplication, should have only 2 items
     try testing.expectEqual(@as(usize, 2), deserialized.count());
-    try testing.expectEqual(@as(?u32, 42), deserialized.getNodeIndexById(allocator, id1));
-    try testing.expectEqual(@as(?u32, 84), deserialized.getNodeIndexById(allocator, id2));
+    try testing.expectEqual(@as(?u32, 42), deserialized.getValueNodeIndexById(allocator, id1));
+    try testing.expectEqual(@as(?u32, 84), deserialized.getValueNodeIndexById(allocator, id2));
 }
 
 test "ExposedItems comprehensive CompactWriter roundtrip" {
@@ -404,23 +486,23 @@ test "ExposedItems comprehensive CompactWriter roundtrip" {
     defer original.deinit(allocator);
 
     // Test with many items including edge cases
-    const test_items = [_]struct { id: IdentIdx, node_idx: u32 }{
-        .{ .id = 0, .node_idx = 0 }, // minimum ID
+    const test_items = [_]struct { id: IdentIdx, node_idx: ?u32 }{
+        .{ .id = 0, .node_idx = null }, // minimum ID, unresolved
         .{ .id = 1, .node_idx = 100 },
         .{ .id = 42, .node_idx = 200 },
         .{ .id = 100, .node_idx = 300 },
         .{ .id = 1000, .node_idx = 400 },
         .{ .id = 10000, .node_idx = 500 },
         .{ .id = 65535, .node_idx = 600 },
-        .{ .id = 100000, .node_idx = 0 }, // exposed but not defined
+        .{ .id = 100000, .node_idx = null }, // exposed but not defined
         .{ .id = std.math.maxInt(u32) - 1, .node_idx = 999 }, // near max ID
     };
 
     // Add all items
     for (test_items) |item| {
         try original.addExposedById(allocator, item.id);
-        if (item.node_idx > 0) {
-            try original.setNodeIndexById(allocator, item.id, item.node_idx);
+        if (item.node_idx) |node_idx| {
+            try original.setValueNodeIndexById(allocator, item.id, node_idx);
         }
     }
 
@@ -459,8 +541,8 @@ test "ExposedItems comprehensive CompactWriter roundtrip" {
     // Verify all items
     try testing.expectEqual(@as(usize, test_items.len), deserialized.count());
     for (test_items) |item| {
-        const actual = deserialized.getNodeIndexById(allocator, item.id);
-        try testing.expectEqual(@as(?u32, item.node_idx), actual);
+        const actual = deserialized.getValueNodeIndexById(allocator, item.id);
+        try testing.expectEqual(item.node_idx, actual);
     }
 }
 
@@ -497,7 +579,7 @@ test "ExposedItems edge cases CompactWriter roundtrip" {
         defer exposed.deinit(allocator);
 
         try exposed.addExposedById(allocator, 100);
-        try exposed.setNodeIndexById(allocator, 100, 42);
+        try exposed.setValueNodeIndexById(allocator, 100, 42);
         exposed.ensureSorted(allocator);
 
         // Create a temp file
@@ -526,6 +608,6 @@ test "ExposedItems edge cases CompactWriter roundtrip" {
         const deserialized = serialized_ptr.deserializeInto(@intFromPtr(buffer.ptr));
 
         try testing.expectEqual(@as(usize, 1), deserialized.count());
-        try testing.expectEqual(@as(?u32, 42), deserialized.getNodeIndexById(allocator, 100));
+        try testing.expectEqual(@as(?u32, 42), deserialized.getValueNodeIndexById(allocator, 100));
     }
 }

--- a/src/collections/mod.zig
+++ b/src/collections/mod.zig
@@ -34,6 +34,7 @@ pub const SafeStringHashMap = @import("safe_hash_map.zig").SafeStringHashMap;
 
 pub const SortedArrayBuilder = @import("SortedArrayBuilder.zig").SortedArrayBuilder;
 pub const ExposedItems = @import("ExposedItems.zig").ExposedItems;
+pub const ExposedItemTarget = @import("ExposedItems.zig").ExposedItemTarget;
 pub const CompactWriter = @import("CompactWriter.zig");
 
 /// Single-threaded arena allocator; the non-atomic counterpart to

--- a/src/compile/compile_package.zig
+++ b/src/compile/compile_package.zig
@@ -1484,7 +1484,7 @@ pub const PackageEnv = struct {
             else => return null,
         }
         const type_ident_in_module = sibling_env.common.findIdent(sibling_name) orelse return null;
-        const type_node_idx = sibling_env.getExposedNodeIndexById(type_ident_in_module) orelse return null;
+        const type_node_idx = sibling_env.getExposedTypeNodeIndexById(type_ident_in_module) orelse return null;
         return @enumFromInt(type_node_idx);
     }
 
@@ -1605,7 +1605,7 @@ pub const PackageEnv = struct {
             const statement_idx: ?can.CIR.Statement.Idx = stmt_blk: {
                 // Look up the type in the module's exposed_items to get the actual node index
                 const type_ident_in_module = actual_env.common.findIdent(base_module_name) orelse break :stmt_blk null;
-                const type_node_idx = actual_env.getExposedNodeIndexById(type_ident_in_module) orelse break :stmt_blk null;
+                const type_node_idx = actual_env.getExposedTypeNodeIndexById(type_ident_in_module) orelse break :stmt_blk null;
                 break :stmt_blk @enumFromInt(type_node_idx);
             };
 

--- a/src/compile/test/module_env_test.zig
+++ b/src/compile/test/module_env_test.zig
@@ -27,7 +27,7 @@ test "ModuleEnv.Serialized roundtrip" {
     _ = try original.insertString("test string");
 
     try original.addExposedById(hello_idx);
-    try original.setExposedNodeIndexById(hello_idx, 42);
+    try original.setExposedValueNodeIndexById(hello_idx, 42);
     original.ensureExposedSorted(gpa);
 
     try original.common.calcLineStarts(gpa);
@@ -76,7 +76,7 @@ test "ModuleEnv.Serialized roundtrip" {
     try std.testing.expectEqualStrings("world", env.getIdent(world_idx));
 
     try std.testing.expectEqual(@as(usize, 1), env.common.exposed_items.count());
-    try std.testing.expectEqual(@as(?u32, 42), env.common.exposed_items.getNodeIndexById(gpa, @as(u32, @bitCast(hello_idx))));
+    try std.testing.expectEqual(@as(?u32, 42), env.common.exposed_items.getValueNodeIndexById(gpa, @as(u32, @bitCast(hello_idx))));
 
     try std.testing.expectEqual(original.common.line_starts.len(), env.common.line_starts.len());
     for (original.common.line_starts.items.items, env.common.line_starts.items.items) |expected, actual| {
@@ -123,7 +123,7 @@ test "ModuleEnv.Serialized roundtrip" {
     try testing.expectEqual(@as(u32, 91), env.common.idents.interner.entry_count);
 
     try testing.expectEqual(@as(usize, 1), env.common.exposed_items.count());
-    try testing.expectEqual(@as(?u32, 42), env.common.exposed_items.getNodeIndexById(gpa, @as(u32, @bitCast(hello_idx))));
+    try testing.expectEqual(@as(?u32, 42), env.common.exposed_items.getValueNodeIndexById(gpa, @as(u32, @bitCast(hello_idx))));
 
     try testing.expectEqual(@as(usize, 3), env.common.line_starts.len());
     try testing.expectEqual(@as(u32, 0), env.common.line_starts.items.items[0]);

--- a/src/lsp/completion/builder.zig
+++ b/src/lsp/completion/builder.zig
@@ -310,8 +310,8 @@ pub const CompletionBuilder = struct {
             var detail: ?[]const u8 = null;
             var documentation: ?[]const u8 = null;
             if (type_writer) |*tw| {
-                if (module_env.common.getNodeIndexById(self.allocator, ident_idx)) |node_idx| {
-                    if (node_idx != 0 and module_env.store.isDefNode(node_idx)) {
+                if (module_env.common.getValueNodeIndexById(self.allocator, ident_idx)) |node_idx| {
+                    if (module_env.store.isDefNode(node_idx)) {
                         const def_idx: CIR.Def.Idx = @enumFromInt(node_idx);
                         const def = module_env.store.getDef(def_idx);
                         const type_var = ModuleEnv.varFrom(def.pattern);


### PR DESCRIPTION
Fixes #9638 by replacing ExposedItems' numeric node-index payload and unresolved 0 sentinel with explicit unresolved, value definition, and type declaration targets. Import resolution and downstream consumers now ask for the target kind they actually need, so an unresolved exposed value cannot be mistaken for a valid external definition node; the regression covers a module exposing bare f while only defining T.f.