### PR TITLE
Support extra default app build targets

### DIFF
--- a/src/backend/llvm/Builder.zig
+++ b/src/backend/llvm/Builder.zig
@@ -6111,7 +6111,7 @@ pub const WipFunction = struct {
         args: []const Value,
         name: []const u8,
     ) Allocator.Error!Value {
-        return self.callInner(kind, call_conv, function_attributes, ty, callee, args, name, false);
+        return self.callInner(kind, call_conv, function_attributes, ty, callee, args, name, false, false);
     }
 
     fn callInner(
@@ -6124,6 +6124,7 @@ pub const WipFunction = struct {
         args: []const Value,
         name: []const u8,
         has_op_bundle_cold: bool,
+        force_debug_location: bool,
     ) Allocator.Error!Value {
         const ret_ty = ty.functionReturn(self.builder);
         assert(ty.isFunction(self.builder));
@@ -6132,31 +6133,35 @@ pub const WipFunction = struct {
         for (params, args[0..params.len]) |param, arg_val| assert(param == arg_val.typeOfWip(self));
 
         try self.ensureUnusedExtraCapacity(1, Instruction.Call, args.len);
-        const instruction = try self.addInst(switch (ret_ty) {
-            .void => null,
-            else => name,
-        }, .{
-            .tag = switch (kind) {
-                .normal => .call,
-                .fast => .@"call fast",
-                .musttail => .@"musttail call",
-                .musttail_fast => .@"musttail call fast",
-                .notail => .@"notail call",
-                .notail_fast => .@"notail call fast",
-                .tail => .@"tail call",
-                .tail_fast => .@"tail call fast",
+        const instruction = try self.addInstInner(
+            switch (ret_ty) {
+                .void => null,
+                else => name,
             },
-            .data = self.addExtraAssumeCapacity(Instruction.Call{
-                .info = .{
-                    .call_conv = call_conv,
-                    .has_op_bundle_cold = has_op_bundle_cold,
+            .{
+                .tag = switch (kind) {
+                    .normal => .call,
+                    .fast => .@"call fast",
+                    .musttail => .@"musttail call",
+                    .musttail_fast => .@"musttail call fast",
+                    .notail => .@"notail call",
+                    .notail_fast => .@"notail call fast",
+                    .tail => .@"tail call",
+                    .tail_fast => .@"tail call fast",
                 },
-                .attributes = function_attributes,
-                .ty = ty,
-                .callee = callee,
-                .args_len = @intCast(args.len),
-            }),
-        });
+                .data = self.addExtraAssumeCapacity(Instruction.Call{
+                    .info = .{
+                        .call_conv = call_conv,
+                        .has_op_bundle_cold = has_op_bundle_cold,
+                    },
+                    .attributes = function_attributes,
+                    .ty = ty,
+                    .callee = callee,
+                    .args_len = @intCast(args.len),
+                }),
+            },
+            force_debug_location,
+        );
         self.extra.appendSliceAssumeCapacity(@ptrCast(args));
         return instruction.toValue();
     }
@@ -6185,7 +6190,7 @@ pub const WipFunction = struct {
         name: []const u8,
     ) Allocator.Error!Value {
         const intrinsic = try self.builder.getIntrinsic(id, overload);
-        return self.call(
+        return self.callInner(
             fast.toCallKind(),
             CallConv.default,
             function_attributes,
@@ -6193,6 +6198,11 @@ pub const WipFunction = struct {
             intrinsic.toValue(self.builder),
             args,
             name,
+            false,
+            switch (id) {
+                .@"dbg.declare", .@"dbg.value" => self.debug_location != .no_location,
+                else => false,
+            },
         );
     }
 
@@ -6207,6 +6217,7 @@ pub const WipFunction = struct {
             &.{try self.builder.intValue(.i1, 1)},
             "",
             true,
+            false,
         );
     }
 
@@ -6991,6 +7002,15 @@ pub const WipFunction = struct {
         name: ?[]const u8,
         instruction: Instruction,
     ) Allocator.Error!Instruction.Index {
+        return self.addInstInner(name, instruction, false);
+    }
+
+    fn addInstInner(
+        self: *WipFunction,
+        name: ?[]const u8,
+        instruction: Instruction,
+        force_debug_location: bool,
+    ) Allocator.Error!Instruction.Index {
         const block_instructions = &self.cursor.block.ptr(self).instructions;
         try self.instructions.ensureUnusedCapacity(self.builder.gpa, 1);
         if (!self.strip) {
@@ -7007,7 +7027,8 @@ pub const WipFunction = struct {
         self.instructions.appendAssumeCapacity(instruction);
         if (!self.strip) {
             self.names.appendAssumeCapacity(final_name);
-            if (block_instructions.items.len == 0 or
+            if (force_debug_location or
+                block_instructions.items.len == 0 or
                 !std.meta.eql(self.debug_location, self.prev_debug_location))
             {
                 self.debug_locations.putAssumeCapacity(index, self.debug_location);

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -171,6 +171,8 @@ pub const MonoLlvmCodeGen = struct {
     /// one subprogram per proc, and per-statement line locations from the
     /// LIR store's source-location tables.
     emit_debug_info: bool = false,
+    /// Emit local variable declarations for source-level debugger inspection.
+    emit_local_debug_info: bool = false,
     /// Build-only default-platform Linux executables link a small runtime
     /// object that owns process startup diagnostics and signal handling.
     enable_default_platform_runtime: bool = false,
@@ -998,8 +1000,8 @@ pub const MonoLlvmCodeGen = struct {
         const empty_expr = builder.debugExpression(&.{}) catch return error.OutOfMemory;
         const previous_debug_location = wip.debug_location;
         wip.debug_location = .{ .location = .{
-            .line = if (self.enable_default_platform_diagnostics) proc_line else 0,
-            .column = if (self.enable_default_platform_diagnostics and proc_line != 0) 1 else 0,
+            .line = proc_line,
+            .column = if (proc_line == 0) 0 else 1,
             .scope = scope.toOptional(),
             .inlined_at = .none,
         } };
@@ -1187,7 +1189,9 @@ pub const MonoLlvmCodeGen = struct {
         defer self.allocator.free(self.local_slots);
         try self.allocLocalSlots();
         try self.unpackProcArgs(proc);
-        if (!builder.strip) try self.declareFrameLocals(proc, self.store.procLoc(proc_id).line);
+        if (!builder.strip and self.emit_local_debug_info) {
+            try self.declareFrameLocals(proc, self.store.procLoc(proc_id).line);
+        }
 
         if (proc.hosted) |hosted| {
             try self.emitHostedProcBody(hosted, proc);

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -997,14 +997,12 @@ pub const MonoLlvmCodeGen = struct {
         const file = try self.debugFileFor(builder, self.current_debug_file);
         const empty_expr = builder.debugExpression(&.{}) catch return error.OutOfMemory;
         const previous_debug_location = wip.debug_location;
-        if (self.enable_default_platform_diagnostics) {
-            wip.debug_location = .{ .location = .{
-                .line = proc_line,
-                .column = if (proc_line == 0) 0 else 1,
-                .scope = scope.toOptional(),
-                .inlined_at = .none,
-            } };
-        }
+        wip.debug_location = .{ .location = .{
+            .line = if (self.enable_default_platform_diagnostics) proc_line else 0,
+            .column = if (self.enable_default_platform_diagnostics and proc_line != 0) 1 else 0,
+            .scope = scope.toOptional(),
+            .inlined_at = .none,
+        } };
         defer wip.debug_location = previous_debug_location;
 
         for (self.store.getLocalSpan(proc.frame_locals)) |local_id| {

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -1388,7 +1388,7 @@ pub const MonoLlvmCodeGen = struct {
         arg_layouts: []const layout.Idx,
         ret_layout: layout.Idx,
     ) Error!void {
-        if (self.enable_default_platform_runtime and
+        if (self.enable_default_platform_hosted_calls and
             self.host_call_mode == .extern_symbols and
             self.target.os.tag == .linux and
             std.mem.eql(u8, symbol_name, "_start"))
@@ -4855,10 +4855,7 @@ pub const MonoLlvmCodeGen = struct {
 
     fn emitDefaultPlatformWriteStdout(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, len: LlvmBuilder.Value) Error!void {
         switch (self.target.os.tag) {
-            .linux => switch (self.target.abi) {
-                .gnu, .gnueabi, .gnueabihf, .gnux32 => try self.emitCWriteStdout(ptr, len),
-                else => try self.emitLinuxWriteStdout(ptr, len),
-            },
+            .linux => try self.emitLinuxWriteStdout(ptr, len),
             .macos, .windows => try self.emitCWriteStdout(ptr, len),
             else => return error.CompilationFailed,
         }

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -4855,7 +4855,10 @@ pub const MonoLlvmCodeGen = struct {
 
     fn emitDefaultPlatformWriteStdout(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, len: LlvmBuilder.Value) Error!void {
         switch (self.target.os.tag) {
-            .linux => try self.emitLinuxWriteStdout(ptr, len),
+            .linux => switch (self.target.abi) {
+                .gnu, .gnueabi, .gnueabihf, .gnux32 => try self.emitCWriteStdout(ptr, len),
+                else => try self.emitLinuxWriteStdout(ptr, len),
+            },
             .macos, .windows => try self.emitCWriteStdout(ptr, len),
             else => return error.CompilationFailed,
         }

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -3646,7 +3646,7 @@ fn defaultBuildPlatformSource(args: cli_args.BuildArgs) []const u8 {
     if (args.target) |target_str| {
         if (RocTarget.fromString(target_str)) |target| {
             return switch (target) {
-                .x64glibc, .arm64glibc, .x64mac, .arm64mac, .x64win, .arm64win => echo_platform.build_c_platform_main_source,
+                .x64mac, .arm64mac, .x64win, .arm64win => echo_platform.build_c_platform_main_source,
                 .wasm32 => echo_platform.build_wasm_archive_platform_main_source,
                 else => echo_platform.build_platform_main_source,
             };

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -4569,6 +4569,7 @@ fn compileLlvmAppObject(
     );
     codegen.layout_store = &lowered.lir_result.layouts;
     codegen.emit_debug_info = true;
+    codegen.emit_local_debug_info = args.debug;
     codegen.enable_default_platform_runtime = enable_default_platform_runtime;
     codegen.enable_default_platform_hosted_calls = enable_default_platform_hosted_calls;
     codegen.enable_default_platform_diagnostics = enable_default_platform_hosted_calls and args.debug;

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -3887,6 +3887,13 @@ fn linkerOutputKind(output: roc_target.OutputKind) linker.OutputKind {
     };
 }
 
+fn llvmBuildLinkAbi(target: RocTarget, synthetic_default_platform: bool) linker.TargetAbi {
+    if (synthetic_default_platform and target.toOsTag() == .linux) {
+        return .musl;
+    }
+    return linker.TargetAbi.fromRocTarget(target);
+}
+
 /// Write an Archive output: a static archive of the platform's pre inputs,
 /// the compiled objects, and the post inputs, with input archives flattened.
 fn writeArchiveOutput(
@@ -5086,7 +5093,7 @@ fn rocBuildLlvm(ctx: *CliCtx, args: cli_args.BuildArgs) anyerror!void {
 
             const link_config = linker.LinkConfig{
                 .target_format = linker.TargetFormat.detectFromOs(target_os),
-                .target_abi = linker.TargetAbi.fromRocTarget(target),
+                .target_abi = llvmBuildLinkAbi(target, args.synthetic_default_platform),
                 .target_os = target_os,
                 .target_arch = target_arch,
                 .output_path = final_output_path,

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -3643,19 +3643,22 @@ fn rocBuildDefaultApp(ctx: *CliCtx, args: cli_args.BuildArgs, original_source: [
 }
 
 fn defaultBuildPlatformSource(args: cli_args.BuildArgs) []const u8 {
-    const target = if (args.target) |target_str|
-        RocTarget.fromString(target_str)
-    else
-        RocTarget.detectNative();
+    if (args.target) |target_str| {
+        if (RocTarget.fromString(target_str)) |target| {
+            return switch (target) {
+                .x64glibc, .arm64glibc, .x64mac, .arm64mac, .x64win, .arm64win => echo_platform.build_c_platform_main_source,
+                .wasm32 => echo_platform.build_wasm_archive_platform_main_source,
+                else => echo_platform.build_platform_main_source,
+            };
+        }
 
-    if (target) |roc_build_target| {
-        return switch (roc_build_target.toOsTag()) {
-            .macos, .windows => echo_platform.build_c_platform_main_source,
-            else => echo_platform.build_platform_main_source,
-        };
+        return echo_platform.build_platform_main_source;
     }
 
-    return echo_platform.build_platform_main_source;
+    return switch (RocTarget.detectNative().toOsTag()) {
+        .macos, .windows => echo_platform.build_c_platform_main_source,
+        else => echo_platform.build_platform_main_source,
+    };
 }
 
 /// Build using the dev backend to generate native machine code.
@@ -5022,7 +5025,10 @@ fn rocBuildLlvm(ctx: *CliCtx, args: cli_args.BuildArgs) anyerror!void {
         );
     } else {
         const hosted_symbols = try hostedSymbolsFromLir(ctx.arena, &lowered.lir_result.store);
-        const enable_default_platform_runtime = target_os == .linux and args.synthetic_default_platform;
+        const enable_default_platform_runtime = args.synthetic_default_platform and switch (target) {
+            .x64musl, .arm64musl => true,
+            else => false,
+        };
 
         const app_object = try compileLlvmAppObject(
             ctx,

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -172,6 +172,9 @@ const CustomCase = enum {
     generated_graph_200_5,
     list_builtin_inlined,
     default_platform_linux_disassembly,
+    default_platform_build_x64glibc,
+    default_platform_build_arm64glibc,
+    default_platform_build_wasm32,
     default_platform_crash_x64musl,
     default_platform_crash_arm64musl,
     default_platform_crash_x64mac,
@@ -528,6 +531,9 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "roc check generated module graph handles many imported files", .body = .{ .custom = .generated_graph_200_5 } },
     .{ .id = 0, .suite = .subcommands, .name = "list builtins inline in native --opt=speed build", .body = .{ .custom = .list_builtin_inlined } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build default platform x64musl matches direct write assembly", .skip = .{ .always = "TODO: direct-write default-platform codegen" }, .body = .{ .custom = .default_platform_linux_disassembly } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc build default platform x64glibc succeeds", .body = .{ .custom = .default_platform_build_x64glibc } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc build default platform arm64glibc succeeds", .body = .{ .custom = .default_platform_build_arm64glibc } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc build default platform wasm32 archive succeeds", .body = .{ .custom = .default_platform_build_wasm32 } },
     .{ .id = 0, .suite = .subcommands, .name = "default platform crash prints debug backtrace on x64musl", .body = .{ .custom = .default_platform_crash_x64musl } },
     .{ .id = 0, .suite = .subcommands, .name = "default platform crash prints debug backtrace on arm64musl", .body = .{ .custom = .default_platform_crash_arm64musl } },
     .{ .id = 0, .suite = .subcommands, .name = "default platform crash prints debug backtrace on x64mac", .body = .{ .custom = .default_platform_crash_x64mac } },
@@ -1397,6 +1403,9 @@ fn runCustomCase(
         .generated_graph_200_5 => customGeneratedModuleGraph(io, allocator, &env, &timer, timeout_ms, .{ .roc_file_count = 200, .symbols_per_file = 5 }),
         .list_builtin_inlined => customListBuiltinInlined(io, allocator, &env, &timer, timeout_ms),
         .default_platform_linux_disassembly => customDefaultPlatformLinuxDisassembly(io, allocator, &env, &timer, timeout_ms),
+        .default_platform_build_x64glibc => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .x64glibc),
+        .default_platform_build_arm64glibc => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .arm64glibc),
+        .default_platform_build_wasm32 => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .wasm32),
         .default_platform_crash_x64musl => customDefaultPlatformDebugBacktrace(io, allocator, &env, &timer, timeout_ms, .x64musl, .crash),
         .default_platform_crash_arm64musl => customDefaultPlatformDebugBacktrace(io, allocator, &env, &timer, timeout_ms, .arm64musl, .crash),
         .default_platform_crash_x64mac => customDefaultPlatformDebugBacktrace(io, allocator, &env, &timer, timeout_ms, .x64mac, .crash),
@@ -1719,20 +1728,30 @@ fn isHexDigit(byte: u8) bool {
 const DefaultPlatformTarget = enum {
     x64musl,
     arm64musl,
+    x64glibc,
+    arm64glibc,
     x64mac,
     arm64mac,
     x64win,
     arm64win,
+    wasm32,
 
     fn cliName(self: DefaultPlatformTarget) []const u8 {
         return @tagName(self);
     }
 
+    fn canBuildOnHost(self: DefaultPlatformTarget) bool {
+        return switch (self) {
+            .x64glibc, .arm64glibc => builtin.os.tag == .linux,
+            else => true,
+        };
+    }
+
     fn canRunOnHost(self: DefaultPlatformTarget) bool {
         return switch (builtin.os.tag) {
             .linux => switch (builtin.cpu.arch) {
-                .x86_64 => self == .x64musl,
-                .aarch64 => self == .arm64musl,
+                .x86_64 => self == .x64musl or self == .x64glibc,
+                .aarch64 => self == .arm64musl or self == .arm64glibc,
                 else => false,
             },
             .macos => switch (builtin.cpu.arch) {
@@ -1745,6 +1764,7 @@ const DefaultPlatformTarget = enum {
                 .aarch64 => self == .arm64win,
                 else => false,
             },
+            .freestanding => false,
             else => false,
         };
     }
@@ -1798,6 +1818,78 @@ const default_platform_stack_overflow_debug_app =
     \\}
     \\
 ;
+
+const default_platform_echo_app =
+    \\main! = |_| {
+    \\    echo!("Hello, World!")
+    \\    Ok({})
+    \\}
+    \\
+;
+
+fn customDefaultPlatformBuild(
+    io: std.Io,
+    allocator: Allocator,
+    env: *const CaseEnv,
+    timer: *harness.Timer,
+    timeout_ms: u64,
+    target: DefaultPlatformTarget,
+) ?TestResult {
+    if (!target.canBuildOnHost()) {
+        const message = std.fmt.allocPrint(
+            allocator,
+            "{s} default-platform build requires Linux host support",
+            .{target.cliName()},
+        ) catch "default-platform build requires Linux host support";
+        return .{ .status = .skip, .phase = .setup, .duration_ns = timer.read(), .message = message };
+    }
+
+    const app_filename = std.fmt.allocPrint(allocator, "default_platform_build_{s}.roc", .{target.cliName()}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate default platform app filename: {}", .{err});
+    const app_path = std.fs.path.join(allocator, &.{ env.dirs.work_dir, app_filename }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate default platform app path: {}", .{err});
+    const output_path = std.fs.path.join(allocator, &.{ env.dirs.work_dir, "default_platform_build" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate default platform output path: {}", .{err});
+    const target_arg = std.fmt.allocPrint(allocator, "--target={s}", .{target.cliName()}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate target arg: {}", .{err});
+    const out_arg = outputArg(allocator, output_path) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate output arg: {}", .{err});
+
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = app_path, .data = default_platform_echo_app }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write default platform app: {}", .{err});
+
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "build", "--opt=speed", "--no-cache", target_arg, out_arg },
+        .roc_file = app_path,
+        .contains = &.{.{ .stream = .stdout, .text = "Built " }},
+    })) |failure| return failure;
+
+    if (target == .wasm32) {
+        var file = std.Io.Dir.cwd().openFile(io, output_path, .{ .mode = .read_only }) catch |err|
+            return customInfraFailure(allocator, timer, "failed to open built wasm archive: {}", .{err});
+        defer file.close(io);
+
+        var magic: [8]u8 = undefined;
+        const bytes_read = file.readPositionalAll(io, &magic, 0) catch |err|
+            return customInfraFailure(allocator, timer, "failed to read built wasm archive: {}", .{err});
+        if (bytes_read != magic.len or !std.mem.eql(u8, magic[0..], "!<arch>\n")) {
+            return customFailure(allocator, timer, "wasm32 default platform output was not an archive", .{});
+        }
+    }
+
+    if (target.canRunOnHost()) {
+        const executable_path = runnableOutputPath(io, allocator, output_path) catch |err|
+            return customInfraFailure(allocator, timer, "failed to find built executable: {}", .{err});
+
+        if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{executable_path}, env.dirs.work_dir, .{
+            .args = &.{},
+            .stdout_exact = "Hello, World!\n",
+            .stderr_exact = "",
+        })) |failure| return failure;
+    }
+
+    return null;
+}
 
 fn customDefaultPlatformDebugBacktrace(
     io: std.Io,

--- a/src/echo_platform/mod.zig
+++ b/src/echo_platform/mod.zig
@@ -32,6 +32,8 @@ pub const build_platform_main_source =
     \\        inputs: "targets/",
     \\        x64musl: { inputs: [app] },
     \\        arm64musl: { inputs: [app] },
+    \\        x64glibc: { inputs: [app] },
+    \\        arm64glibc: { inputs: [app] },
     \\    }
     \\
     \\import Echo
@@ -58,8 +60,6 @@ pub const build_c_platform_main_source =
     \\    hosted { "roc_default_echo_line": Echo.line! }
     \\    targets: {
     \\        inputs: "targets/",
-    \\        x64glibc: { inputs: [app] },
-    \\        arm64glibc: { inputs: [app] },
     \\        x64mac: { inputs: [app] },
     \\        arm64mac: { inputs: [app] },
     \\        x64win: { inputs: [app] },

--- a/src/echo_platform/mod.zig
+++ b/src/echo_platform/mod.zig
@@ -58,10 +58,39 @@ pub const build_c_platform_main_source =
     \\    hosted { "roc_default_echo_line": Echo.line! }
     \\    targets: {
     \\        inputs: "targets/",
+    \\        x64glibc: { inputs: [app] },
+    \\        arm64glibc: { inputs: [app] },
     \\        x64mac: { inputs: [app] },
     \\        arm64mac: { inputs: [app] },
     \\        x64win: { inputs: [app] },
     \\        arm64win: { inputs: [app] },
+    \\    }
+    \\
+    \\import Echo
+    \\
+    \\main_for_host! : {} => I32
+    \\main_for_host! = |_args|
+    \\    match main!([]) {
+    \\        Ok({}) => 0
+    \\        Err(Exit(code)) => I8.to_i32(code)
+    \\        Err(_) => 1
+    \\    }
+    \\
+;
+
+/// Build-only default platform for hostless wasm output. Without a platform
+/// host object there is no process entrypoint or stdout, so wasm default apps
+/// compile to an archive that a host can link and satisfy.
+pub const build_wasm_archive_platform_main_source =
+    \\platform ""
+    \\    requires {} { main! : List(Str) => Try({}, [Exit(I8), ..]) }
+    \\    exposes [Echo]
+    \\    packages {}
+    \\    provides { "main": main_for_host! }
+    \\    hosted { "roc_default_echo_line": Echo.line! }
+    \\    targets: {
+    \\        inputs: "targets/",
+    \\        wasm32: { inputs: [app], output: Archive },
     \\    }
     \\
     \\import Echo

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -3082,6 +3082,10 @@ const BodyContext = struct {
         ret_ty: Type.TypeId,
     ) Allocator.Error!LoweredLambdaArgs {
         if (arg_tys.len != checked_args.len) Common.invariant("lambda arity differs from concrete function type");
+        const saved_loc = self.builder.program.current_loc;
+        defer self.builder.program.current_loc = saved_loc;
+        const body_expr = self.view.bodies.exprs[@intFromEnum(checked_body)];
+        self.builder.program.current_loc = try self.sourceLocFor(body_expr.source_region);
 
         const args = try self.allocator.alloc(Ast.TypedLocal, checked_args.len);
         defer self.allocator.free(args);

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -205,6 +205,7 @@
 
 const std = @import("std");
 
+const SourceLoc = @import("base").SourceLoc;
 const Common = @import("../common.zig");
 const Ast = @import("ast.zig");
 const Mono = @import("../monotype/ast.zig");
@@ -1176,6 +1177,7 @@ const Cloner = struct {
     loop_stack: std.ArrayList(LoopPattern),
     inline_direct_calls: bool,
     inline_direct_requires_known_arg: bool,
+    current_loc: SourceLoc,
 
     fn init(pass: *Pass, source_fn: Ast.FnId, pattern: CallPattern) Cloner {
         return .{
@@ -1190,6 +1192,7 @@ const Cloner = struct {
             .loop_stack = .empty,
             .inline_direct_calls = true,
             .inline_direct_requires_known_arg = true,
+            .current_loc = SourceLoc.none,
         };
     }
 
@@ -1206,6 +1209,7 @@ const Cloner = struct {
             .loop_stack = .empty,
             .inline_direct_calls = true,
             .inline_direct_requires_known_arg = false,
+            .current_loc = SourceLoc.none,
         };
     }
 
@@ -1222,6 +1226,12 @@ const Cloner = struct {
         const source_fn = self.pass.program.fns.items[@intFromEnum(self.source_fn)];
         const source_args = self.pass.program.typedLocalSpan(source_fn.args);
         if (source_args.len != self.pattern.args.len) Common.invariant("call-pattern argument count differed from source function arity");
+        const saved_loc = self.current_loc;
+        defer self.current_loc = saved_loc;
+        self.current_loc = switch (source_fn.body) {
+            .roc => |body| self.pass.program.exprLoc(body),
+            .hosted => SourceLoc.none,
+        };
 
         var args = std.ArrayList(Ast.TypedLocal).empty;
         defer args.deinit(self.pass.allocator);
@@ -1239,7 +1249,7 @@ const Cloner = struct {
             .any => |ty| {
                 const local = try self.pass.program.addLocal(self.pass.symbols.fresh(), ty);
                 try args.append(self.pass.allocator, .{ .local = local, .ty = ty });
-                return .{ .expr = try self.pass.program.addExpr(.{
+                return .{ .expr = try self.addExpr(.{
                     .ty = ty,
                     .data = .{ .local = local },
                 }) };
@@ -1301,10 +1311,17 @@ const Cloner = struct {
     }
 
     fn cloneExpr(self: *Cloner, expr_id: Ast.ExprId) Common.LowerError!Ast.ExprId {
+        const saved_loc = self.current_loc;
+        defer self.current_loc = saved_loc;
+        self.current_loc = self.pass.program.exprLoc(expr_id);
         return try self.materialize(try self.cloneExprValue(expr_id));
     }
 
     fn cloneExprValue(self: *Cloner, expr_id: Ast.ExprId) Common.LowerError!Value {
+        const saved_loc = self.current_loc;
+        defer self.current_loc = saved_loc;
+        self.current_loc = self.pass.program.exprLoc(expr_id);
+
         const expr = self.pass.program.exprs.items[@intFromEnum(expr_id)];
         switch (expr.data) {
             .local => |local| {
@@ -1518,6 +1535,10 @@ const Cloner = struct {
     }
 
     fn cloneExprPlain(self: *Cloner, expr_id: Ast.ExprId) Common.LowerError!Ast.ExprId {
+        const saved_loc = self.current_loc;
+        defer self.current_loc = saved_loc;
+        self.current_loc = self.pass.program.exprLoc(expr_id);
+
         const expr = self.pass.program.exprs.items[@intFromEnum(expr_id)];
         const data: Ast.ExprData = switch (expr.data) {
             .local => |local| .{ .local = local },
@@ -2575,8 +2596,12 @@ const Cloner = struct {
     }
 
     fn cloneStmt(self: *Cloner, stmt_id: Ast.StmtId) Common.LowerError!Ast.StmtId {
+        const saved_loc = self.current_loc;
+        defer self.current_loc = saved_loc;
+        self.current_loc = self.pass.program.stmtLoc(stmt_id);
+
         const stmt = self.pass.program.stmts.items[@intFromEnum(stmt_id)];
-        return try self.pass.program.addStmt(switch (stmt) {
+        return try self.addStmt(switch (stmt) {
             .let_ => |let_| blk: {
                 const value = try self.cloneExprValue(let_.value);
                 const value_expr = try self.materialize(value);
@@ -2835,14 +2860,14 @@ const Cloner = struct {
         defer self.restore(change_start);
 
         for (source_captures, captures) |source_capture, capture| {
-            const local_expr = try self.pass.program.addExpr(.{
+            const local_expr = try self.addExpr(.{
                 .ty = capture.ty,
                 .data = .{ .local = capture.local },
             });
             try self.putSubst(source_capture.local, .{ .expr = local_expr });
         }
         for (source_args, args) |source_arg, arg| {
-            const arg_expr = try self.pass.program.addExpr(.{
+            const arg_expr = try self.addExpr(.{
                 .ty = arg.ty,
                 .data = .{ .local = arg.local },
             });
@@ -2960,7 +2985,17 @@ const Cloner = struct {
     }
 
     fn addExpr(self: *Cloner, expr: Ast.Expr) Allocator.Error!Ast.ExprId {
+        const saved_loc = self.pass.program.current_loc;
+        defer self.pass.program.current_loc = saved_loc;
+        self.pass.program.current_loc = self.current_loc;
         return try self.pass.program.addExpr(expr);
+    }
+
+    fn addStmt(self: *Cloner, stmt: Ast.Stmt) Allocator.Error!Ast.StmtId {
+        const saved_loc = self.pass.program.current_loc;
+        defer self.pass.program.current_loc = saved_loc;
+        self.pass.program.current_loc = self.current_loc;
+        return try self.pass.program.addStmt(stmt);
     }
 };
 


### PR DESCRIPTION
This extends the synthetic default platform used by headerless roc build apps to cover Linux glibc targets through the same no-libc _start lowering as musl, with synthetic Linux default apps linked statically so they do not load libc or a platform dynamic linker. It also covers wasm32 through a hostless archive target. The diagnostics runtime object remains limited to the musl _start targets, and LLVM debug local declarations now get a generated location so optimized default-app builds do not emit invalid debug info.