### PR TITLE
Implement comptime exhaustiveness checking

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -5428,7 +5428,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         try locals.put(localKey(expect_stmt.condition), expect_stmt.condition);
                         try stack.append(sa, expect_stmt.next);
                     },
-                    .runtime_error => {},
+                    .comptime_branch_taken => |marker| try stack.append(sa, marker.next),
+                    .runtime_error, .comptime_exhaustiveness_failed => {},
                     .incref => |inc| {
                         try locals.put(localKey(inc.value), inc.value);
                         try stack.append(sa, inc.next);
@@ -5549,7 +5550,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         try locals.put(localKey(expect_stmt.condition), expect_stmt.condition);
                         try stack.append(sa, expect_stmt.next);
                     },
-                    .runtime_error => {},
+                    .comptime_branch_taken => |marker| try stack.append(sa, marker.next),
+                    .runtime_error, .comptime_exhaustiveness_failed => {},
                     .incref => |inc| {
                         try locals.put(localKey(inc.value), inc.value);
                         try stack.append(sa, inc.next);
@@ -14046,6 +14048,15 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         .runtime_error => {
                             try self.emitRocCrash("hit a runtime error");
                             try self.emitTrap();
+                        },
+
+                        .comptime_exhaustiveness_failed => {
+                            try self.emitRocCrash("compile-time exhaustiveness failure reached runtime code");
+                            try self.emitTrap();
+                        },
+
+                        .comptime_branch_taken => |marker| {
+                            try work.append(wa, .{ .node = marker.next });
                         },
 
                         .join => |j| {

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -1800,6 +1800,12 @@ pub const MonoLlvmCodeGen = struct {
             .runtime_error => {
                 try self.emitCrashBytes("hit a runtime error");
             },
+            .comptime_exhaustiveness_failed => {
+                try self.emitCrashBytes("compile-time exhaustiveness failure reached runtime code");
+            },
+            .comptime_branch_taken => |marker| {
+                try work.append(wa, .{ .node = marker.next });
+            },
             .incref => |inc| {
                 try self.emitRcForLocal(.incref, inc.value, inc.count, inc.atomicity);
                 try work.append(wa, .{ .node = inc.next });

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -3123,7 +3123,8 @@ fn collectProcLocals(
                 try recordProcLocal(locals, expect_stmt.condition);
                 try work.append(wa, expect_stmt.next);
             },
-            .runtime_error => {},
+            .comptime_branch_taken => |marker| try work.append(wa, marker.next),
+            .runtime_error, .comptime_exhaustiveness_failed => {},
             .switch_stmt => |switch_stmt| {
                 try recordProcLocal(locals, switch_stmt.cond);
                 for (self.store.getCFSwitchBranches(switch_stmt.branches)) |branch| {
@@ -7283,6 +7284,13 @@ fn generateCFStmtNode(self: *Self, work: *std.ArrayList(StmtWork), wa: Allocator
             ) catch "runtime_error";
             try self.emitRocStaticStringCall(wasm_roc_ops_crashed_offset, msg);
             self.currentCode().append(self.allocator, Op.@"unreachable") catch return error.OutOfMemory;
+        },
+        .comptime_exhaustiveness_failed => {
+            try self.emitRocStaticStringCall(wasm_roc_ops_crashed_offset, "compile-time exhaustiveness failure reached runtime code");
+            self.currentCode().append(self.allocator, Op.@"unreachable") catch return error.OutOfMemory;
+        },
+        .comptime_branch_taken => |marker| {
+            try work.append(wa, .{ .node = .{ .stmt_id = marker.next, .stop = stop } });
         },
         .crash => |crash| {
             const msg_bytes = self.store.getString(crash.msg);

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -10081,6 +10081,7 @@ fn runExprKernel(
                 const if_expr_idx = try self.env.addExpr(Expr{ .e_if = .{
                     .branches = branches_span,
                     .final_else = final_else,
+                    .warn_unused_branches = false,
                 } }, state.region);
 
                 const if_free_vars = self.scratch_free_vars.spanFrom(state.free_vars_start);
@@ -10754,6 +10755,7 @@ fn runExprKernel(
                 .e_if = .{
                     .branches = branches_span,
                     .final_else = can_else.idx,
+                    .warn_unused_branches = true,
                 },
             }, state.region);
 
@@ -10820,6 +10822,7 @@ fn runExprKernel(
                 .e_if = .{
                     .branches = branches_span,
                     .final_else = empty_record_idx,
+                    .warn_unused_branches = true,
                 },
             }, state.region);
 

--- a/src/canonicalize/Expression.zig
+++ b/src/canonicalize/Expression.zig
@@ -201,6 +201,7 @@ pub const Expr = union(enum) {
     e_if: struct {
         branches: IfBranch.Span,
         final_else: Expr.Idx,
+        warn_unused_branches: bool,
     },
     /// This is *only* for calling functions, not for tag application.
     /// The Tag variant contains any applied values inside it.

--- a/src/canonicalize/Node.zig
+++ b/src/canonicalize/Node.zig
@@ -573,7 +573,7 @@ pub const Payload = extern union {
     };
 
     pub const ExprIfThenElse = extern struct {
-        branches_else_idx: u32, // Index into span_with_node_data: (branches.start, branches.len, final_else)
+        branches_else_idx: u32, // Index into if_data
         _padding: [8]u8 = .{ 0, 0, 0, 0, 0, 0, 0, 0 },
     };
 

--- a/src/canonicalize/NodeStore.zig
+++ b/src/canonicalize/NodeStore.zig
@@ -28,6 +28,7 @@ span2_data: collections.SafeList(Span2), // Typed storage for (start, len) span 
 span_with_node_data: collections.SafeList(SpanWithNode), // Typed storage for (start, len, node) triples
 method_call_data: collections.SafeList(MethodCallData), // Typed storage for method args plus method-token source region
 match_data: collections.SafeList(MatchData), // Typed storage for match expression data
+if_data: collections.SafeList(IfData), // Typed storage for if expression data
 match_branch_data: collections.SafeList(MatchBranchData), // Typed storage for match branch data
 closure_data: collections.SafeList(ClosureData), // Typed storage for closure expressions
 zero_arg_tag_data: collections.SafeList(ZeroArgTagData), // Typed storage for zero-argument tags
@@ -71,6 +72,15 @@ pub const MatchData = extern struct {
     exhaustive: u32,
     is_try_suffix: u32,
     skip_exhaustiveness: u32,
+};
+
+/// If expression data.
+/// Stores branches span, final else, and whether to warn for untaken compile-time branches.
+pub const IfData = extern struct {
+    branches_start: u32,
+    branches_len: u32,
+    final_else: u32,
+    warn_unused_branches: u32,
 };
 
 /// Match branch data.
@@ -257,6 +267,8 @@ pub fn initCapacity(gpa: Allocator, capacity: usize) Allocator.Error!NodeStore {
     errdefer method_call_data.deinit(gpa);
     var match_data = try collections.SafeList(MatchData).initCapacity(gpa, capacity / 8);
     errdefer match_data.deinit(gpa);
+    var if_data = try collections.SafeList(IfData).initCapacity(gpa, capacity / 8);
+    errdefer if_data.deinit(gpa);
     var match_branch_data = try collections.SafeList(MatchBranchData).initCapacity(gpa, capacity / 8);
     errdefer match_branch_data.deinit(gpa);
     var closure_data = try collections.SafeList(ClosureData).initCapacity(gpa, capacity / 16);
@@ -285,6 +297,7 @@ pub fn initCapacity(gpa: Allocator, capacity: usize) Allocator.Error!NodeStore {
         .span_with_node_data = span_with_node_data,
         .method_call_data = method_call_data,
         .match_data = match_data,
+        .if_data = if_data,
         .match_branch_data = match_branch_data,
         .closure_data = closure_data,
         .zero_arg_tag_data = zero_arg_tag_data,
@@ -308,6 +321,7 @@ pub fn clone(self: *const NodeStore, gpa: Allocator) Allocator.Error!NodeStore {
         .span_with_node_data = try self.span_with_node_data.clone(gpa),
         .method_call_data = try self.method_call_data.clone(gpa),
         .match_data = try self.match_data.clone(gpa),
+        .if_data = try self.if_data.clone(gpa),
         .match_branch_data = try self.match_branch_data.clone(gpa),
         .closure_data = try self.closure_data.clone(gpa),
         .zero_arg_tag_data = try self.zero_arg_tag_data.clone(gpa),
@@ -331,6 +345,7 @@ pub fn deinit(store: *NodeStore) void {
     store.span_with_node_data.deinit(store.gpa);
     store.method_call_data.deinit(store.gpa);
     store.match_data.deinit(store.gpa);
+    store.if_data.deinit(store.gpa);
     store.match_branch_data.deinit(store.gpa);
     store.closure_data.deinit(store.gpa);
     store.zero_arg_tag_data.deinit(store.gpa);
@@ -354,6 +369,7 @@ pub fn relocate(store: *NodeStore, offset: isize) void {
     store.span_with_node_data.relocate(offset);
     store.method_call_data.relocate(offset);
     store.match_data.relocate(offset);
+    store.if_data.relocate(offset);
     store.match_branch_data.relocate(offset);
     store.closure_data.relocate(offset);
     store.zero_arg_tag_data.relocate(offset);
@@ -1034,12 +1050,12 @@ pub fn getExpr(store: *const NodeStore, expr: CIR.Expr.Idx) CIR.Expr {
         },
         .expr_if_then_else => {
             const p = payload.expr_if_then_else;
-            // Retrieve branches span and final_else from span_with_node_data
-            const branches_else = store.span_with_node_data.items.items[p.branches_else_idx];
+            const if_data = store.if_data.items.items[p.branches_else_idx];
 
             return CIR.Expr{ .e_if = .{
-                .branches = .{ .span = .{ .start = branches_else.start, .len = branches_else.len } },
-                .final_else = @enumFromInt(branches_else.node),
+                .branches = .{ .span = .{ .start = if_data.branches_start, .len = if_data.branches_len } },
+                .final_else = @enumFromInt(if_data.final_else),
+                .warn_unused_branches = if_data.warn_unused_branches != 0,
             } };
         },
         .expr_field_access => {
@@ -2378,15 +2394,16 @@ pub fn addExpr(store: *NodeStore, expr: CIR.Expr, region: base.Region) Allocator
         },
         .e_if => |e| {
             node.tag = .expr_if_then_else;
-            const branches_else_idx: u32 = @intCast(store.span_with_node_data.len());
-            _ = try store.span_with_node_data.append(store.gpa, .{
-                .start = e.branches.span.start,
-                .len = e.branches.span.len,
-                .node = @intFromEnum(e.final_else),
+            const if_data_idx: u32 = @intCast(store.if_data.len());
+            _ = try store.if_data.append(store.gpa, .{
+                .branches_start = e.branches.span.start,
+                .branches_len = e.branches.span.len,
+                .final_else = @intFromEnum(e.final_else),
+                .warn_unused_branches = @intFromBool(e.warn_unused_branches),
             });
 
             node.setPayload(.{ .expr_if_then_else = .{
-                .branches_else_idx = branches_else_idx,
+                .branches_else_idx = if_data_idx,
             } });
         },
         .e_call => |e| {
@@ -4527,6 +4544,7 @@ pub const Serialized = extern struct {
     span_with_node_data: collections.SafeList(SpanWithNode).Serialized,
     method_call_data: collections.SafeList(MethodCallData).Serialized,
     match_data: collections.SafeList(MatchData).Serialized,
+    if_data: collections.SafeList(IfData).Serialized,
     match_branch_data: collections.SafeList(MatchBranchData).Serialized,
     closure_data: collections.SafeList(ClosureData).Serialized,
     zero_arg_tag_data: collections.SafeList(ZeroArgTagData).Serialized,
@@ -4558,6 +4576,8 @@ pub const Serialized = extern struct {
         try self.method_call_data.serialize(&store.method_call_data, allocator, writer);
         // Serialize match_data
         try self.match_data.serialize(&store.match_data, allocator, writer);
+        // Serialize if_data
+        try self.if_data.serialize(&store.if_data, allocator, writer);
         // Serialize match_branch_data
         try self.match_branch_data.serialize(&store.match_branch_data, allocator, writer);
         // Serialize closure_data
@@ -4590,6 +4610,7 @@ pub const Serialized = extern struct {
             .span_with_node_data = self.span_with_node_data.deserializeInto(base_addr),
             .method_call_data = self.method_call_data.deserializeInto(base_addr),
             .match_data = self.match_data.deserializeInto(base_addr),
+            .if_data = self.if_data.deserializeInto(base_addr),
             .match_branch_data = self.match_branch_data.deserializeInto(base_addr),
             .closure_data = self.closure_data.deserializeInto(base_addr),
             .zero_arg_tag_data = self.zero_arg_tag_data.deserializeInto(base_addr),
@@ -4615,6 +4636,7 @@ pub const Serialized = extern struct {
             .span_with_node_data = self.span_with_node_data.deserializeInto(base_addr),
             .method_call_data = self.method_call_data.deserializeInto(base_addr),
             .match_data = self.match_data.deserializeInto(base_addr),
+            .if_data = self.if_data.deserializeInto(base_addr),
             .match_branch_data = self.match_branch_data.deserializeInto(base_addr),
             .closure_data = self.closure_data.deserializeInto(base_addr),
             .zero_arg_tag_data = self.zero_arg_tag_data.deserializeInto(base_addr),

--- a/src/canonicalize/test/node_store_test.zig
+++ b/src/canonicalize/test/node_store_test.zig
@@ -305,6 +305,7 @@ test "NodeStore round trip - Expressions" {
         .e_if = .{
             .branches = CIR.Expr.IfBranch.Span{ .span = rand_span() },
             .final_else = rand_idx(CIR.Expr.Idx),
+            .warn_unused_branches = true,
         },
     });
     try expressions.append(gpa, CIR.Expr{

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -181,6 +181,11 @@ checking_call_arg: bool = false,
 /// treatment of a variable binding. Deliberately NOT set for mutable `var`
 /// bindings, which must never generalize.
 checking_binding_rhs: bool = false,
+/// Nonzero while checking source that constructs a compile-time value. Static
+/// exhaustiveness diagnostics under this depth are empirical candidates: the
+/// compile-time finalizer either observes them executing, reports their generated
+/// miss path, or discards them if the source was not reached.
+empirical_exhaustiveness_depth: u32 = 0,
 /// Deferred def-level unifications (def_var = ptrn_var = expr_var).
 /// These must happen AFTER generalization to avoid lowering expr_var's rank
 /// before generalization can process it, but BEFORE eql constraint resolution
@@ -3401,6 +3406,9 @@ fn checkDef(self: *Self, def_idx: CIR.Def.Idx, env: *Env) std.mem.Allocator.Erro
         }
     };
 
+    self.empirical_exhaustiveness_depth += 1;
+    defer self.empirical_exhaustiveness_depth -= 1;
+
     // Infer types for the body, checking against the instantiated annotation
     self.checking_binding_rhs = true;
     const def_does_fx = try self.checkExpr(def.expr, env, expectation);
@@ -6396,6 +6404,10 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
 
             // Check the the body of the expr
             // If we have an expected function, use that as the expr's expected type
+            const saved_empirical_exhaustiveness_depth = self.empirical_exhaustiveness_depth;
+            self.empirical_exhaustiveness_depth = 0;
+            defer self.empirical_exhaustiveness_depth = saved_empirical_exhaustiveness_depth;
+
             const body_does_fx = if (mb_anno_func) |expected_func| blk: {
                 const lambda_body_does_fx = try self.checkExpr(lambda.body, env, Expected.none().withBranchResult(expected_func.ret));
                 try self.closeAbsentConstructedPayloadVars(lambda.body, body_var);
@@ -7717,6 +7729,10 @@ fn closeAbsentConstructedPayloadVars(
     }
 }
 
+fn pendingExhaustivenessMode(self: *const Self) ProblemStore.PendingStaticExhaustivenessMode {
+    return if (self.empirical_exhaustiveness_depth == 0) .static else .empirical;
+}
+
 fn checkDestructureExhaustiveness(
     self: *Self,
     pattern_idx: CIR.Pattern.Idx,
@@ -7767,7 +7783,7 @@ fn checkDestructureExhaustiveness(
             .count = self.problems.missing_patterns_backing.items.len - missing_patterns_start,
         };
 
-        _ = try self.problems.appendProblem(self.gpa, .{ .non_exhaustive_destructure = .{
+        try self.problems.appendPendingStaticExhaustiveness(self.gpa, .destructure, self.pendingExhaustivenessMode(), region, .{ .non_exhaustive_destructure = .{
             .pattern = pattern_idx,
             .value_snapshot = value_snapshot,
             .missing_patterns = missing_patterns_range,
@@ -8525,7 +8541,7 @@ fn checkMatchExpr(
                 .count = self.problems.missing_patterns_backing.items.len - missing_patterns_start,
             };
 
-            _ = try self.problems.appendProblem(self.gpa, .{ .non_exhaustive_match = .{
+            try self.problems.appendPendingStaticExhaustiveness(self.gpa, .match, self.pendingExhaustivenessMode(), match_region, .{ .non_exhaustive_match = .{
                 .match_expr = expr_idx,
                 .condition_snapshot = condition_snapshot,
                 .missing_patterns = missing_patterns_range,

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -4962,6 +4962,7 @@ pub const CheckedExprData = union(enum) {
     if_: struct {
         branches: []const CheckedIfBranch,
         final_else: CheckedExprId,
+        warn_unused_branches: bool,
     },
     call: struct {
         func: CheckedExprId,
@@ -6543,6 +6544,7 @@ const CheckedBodyPayloadCopier = struct {
             .e_if => |if_| .{ .if_ = .{
                 .branches = try self.copyIfBranches(if_.branches),
                 .final_else = self.checkedExpr(if_.final_else),
+                .warn_unused_branches = if_.warn_unused_branches,
             } },
             .e_call => |call| .{ .call = .{
                 .func = self.checkedExpr(call.func),

--- a/src/check/problem.zig
+++ b/src/check/problem.zig
@@ -44,6 +44,7 @@ pub const NonExhaustiveMatch = types.NonExhaustiveMatch;
 pub const NonExhaustiveDestructure = types.NonExhaustiveDestructure;
 pub const RedundantPattern = types.RedundantPattern;
 pub const UnmatchablePattern = types.UnmatchablePattern;
+pub const ComptimeUnusedBranch = types.ComptimeUnusedBranch;
 
 // Type declaration errors
 pub const TypeApplyArityMismatch = types.TypeApplyArityMismatch;

--- a/src/check/problem/store.zig
+++ b/src/check/problem/store.zig
@@ -4,6 +4,7 @@
 //! storage for extra data like formatted strings and missing patterns.
 
 const std = @import("std");
+const base = @import("base");
 
 const types = @import("types.zig");
 
@@ -24,7 +25,25 @@ pub const Store = struct {
     const Self = @This();
     const ALIGNMENT = std.mem.Alignment.@"16";
 
+    pub const EmpiricalSiteKind = enum {
+        match,
+        destructure,
+    };
+
+    pub const PendingStaticExhaustivenessMode = enum {
+        static,
+        empirical,
+    };
+
+    pub const PendingStaticExhaustiveness = struct {
+        kind: EmpiricalSiteKind,
+        mode: PendingStaticExhaustivenessMode,
+        region: base.Region,
+        problem: Problem,
+    };
+
     problems: std.ArrayListAligned(Problem, ALIGNMENT) = .empty,
+    pending_static_exhaustiveness: std.ArrayList(PendingStaticExhaustiveness) = .empty,
 
     /// Backing storage for formatted pattern strings
     extra_strings_backing: ByteList,
@@ -34,6 +53,7 @@ pub const Store = struct {
     pub fn init(gpa: Allocator) std.mem.Allocator.Error!Self {
         return .{
             .problems = try std.ArrayListAligned(Problem, ALIGNMENT).initCapacity(gpa, 16),
+            .pending_static_exhaustiveness = .empty,
             .extra_strings_backing = try ByteList.initCapacity(gpa, 512),
             .missing_patterns_backing = try std.array_list.Managed(ExtraStringIdx).initCapacity(gpa, 64),
         };
@@ -42,6 +62,7 @@ pub const Store = struct {
     pub fn initCapacity(gpa: Allocator, capacity: usize) std.mem.Allocator.Error!Self {
         return .{
             .problems = try std.ArrayListAligned(Problem, ALIGNMENT).initCapacity(gpa, capacity),
+            .pending_static_exhaustiveness = .empty,
             .extra_strings_backing = try ByteList.initCapacity(gpa, 512),
             .missing_patterns_backing = try std.array_list.Managed(ExtraStringIdx).initCapacity(gpa, 64),
         };
@@ -50,6 +71,7 @@ pub const Store = struct {
     pub fn deinit(self: *Self, gpa: Allocator) void {
         self.extra_strings_backing.deinit();
         self.missing_patterns_backing.deinit();
+        self.pending_static_exhaustiveness.deinit(gpa);
         self.problems.deinit(gpa);
     }
 
@@ -86,6 +108,80 @@ pub const Store = struct {
         return idx;
     }
 
+    pub fn appendPendingStaticExhaustiveness(
+        self: *Self,
+        gpa: Allocator,
+        kind: EmpiricalSiteKind,
+        mode: PendingStaticExhaustivenessMode,
+        region: base.Region,
+        pending_problem: Problem,
+    ) std.mem.Allocator.Error!void {
+        try self.pending_static_exhaustiveness.append(gpa, .{
+            .kind = kind,
+            .mode = mode,
+            .region = region,
+            .problem = pending_problem,
+        });
+    }
+
+    pub fn resolvePendingStaticExhaustiveness(self: *Self, kind: EmpiricalSiteKind, region: base.Region) void {
+        var write: usize = 0;
+        for (self.pending_static_exhaustiveness.items) |pending| {
+            if (pending.mode == .empirical and pending.kind == kind and regionsEqual(pending.region, region)) continue;
+            self.pending_static_exhaustiveness.items[write] = pending;
+            write += 1;
+        }
+        self.pending_static_exhaustiveness.shrinkRetainingCapacity(write);
+    }
+
+    pub fn appendEmpiricalExhaustivenessFailure(
+        self: *Self,
+        gpa: Allocator,
+        kind: EmpiricalSiteKind,
+        region: base.Region,
+    ) std.mem.Allocator.Error!bool {
+        var index: usize = 0;
+        while (index < self.pending_static_exhaustiveness.items.len) {
+            const pending = self.pending_static_exhaustiveness.items[index];
+            if (pending.kind != kind or !regionsEqual(pending.region, region)) {
+                index += 1;
+                continue;
+            }
+            var problem = pending.problem;
+            if (pending.mode == .empirical) {
+                switch (problem) {
+                    .non_exhaustive_match => |*match| match.empirical = true,
+                    .non_exhaustive_destructure => |*destructure| destructure.empirical = true,
+                    else => unreachable,
+                }
+            }
+            _ = try self.appendProblem(gpa, problem);
+            _ = self.pending_static_exhaustiveness.swapRemove(index);
+            return true;
+        }
+        return false;
+    }
+
+    pub fn flushPendingStaticExhaustiveness(self: *Self, gpa: Allocator) std.mem.Allocator.Error!usize {
+        var count: usize = 0;
+        for (self.pending_static_exhaustiveness.items) |pending| {
+            if (pending.mode != .static) continue;
+            _ = try self.appendProblem(gpa, pending.problem);
+            count += 1;
+        }
+        self.pending_static_exhaustiveness.clearRetainingCapacity();
+        return count;
+    }
+
+    pub fn flushAllPendingStaticExhaustiveness(self: *Self, gpa: Allocator) std.mem.Allocator.Error!usize {
+        const count = self.pending_static_exhaustiveness.items.len;
+        for (self.pending_static_exhaustiveness.items) |pending| {
+            _ = try self.appendProblem(gpa, pending.problem);
+        }
+        self.pending_static_exhaustiveness.clearRetainingCapacity();
+        return count;
+    }
+
     pub fn get(self: *Self, idx: Problem.Idx) Problem {
         return self.problems.items[@intFromEnum(idx)];
     }
@@ -94,3 +190,7 @@ pub const Store = struct {
         return self.problems.items.len;
     }
 };
+
+fn regionsEqual(a: base.Region, b: base.Region) bool {
+    return a.start.offset == b.start.offset and a.end.offset == b.end.offset;
+}

--- a/src/check/problem/types.zig
+++ b/src/check/problem/types.zig
@@ -57,6 +57,7 @@ pub const Problem = union(enum) {
     non_exhaustive_destructure: NonExhaustiveDestructure,
     redundant_pattern: RedundantPattern,
     unmatchable_pattern: UnmatchablePattern,
+    comptime_unused_branch: ComptimeUnusedBranch,
 
     pub const Idx = enum(u32) { _ };
     pub const Tag = std.meta.Tag(@This());
@@ -231,6 +232,8 @@ pub const NonExhaustiveMatch = struct {
     condition_snapshot: SnapshotContentIdx,
     /// Range into the problems store's missing_patterns_backing for pattern indices
     missing_patterns: MissingPatternsRange,
+    /// This was discovered by compile-time evaluation taking the generated miss branch.
+    empirical: bool = false,
 };
 
 /// Problem data for a non-exhaustive destructuring pattern
@@ -240,6 +243,18 @@ pub const NonExhaustiveDestructure = struct {
     value_snapshot: SnapshotContentIdx,
     /// Range into the problems store's missing_patterns_backing for pattern indices
     missing_patterns: MissingPatternsRange,
+    /// This was discovered by compile-time evaluation taking the generated miss branch.
+    empirical: bool = false,
+};
+
+/// A compile-time-only branch or match alternative was not taken by compile-time evaluation.
+pub const ComptimeUnusedBranch = struct {
+    kind: enum {
+        match,
+        if_,
+    },
+    site_region: base.Region,
+    branch_region: base.Region,
 };
 
 /// Problem data for a redundant pattern in a match

--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -53,6 +53,7 @@ const NonExhaustiveMatch = problem_mod.NonExhaustiveMatch;
 const NonExhaustiveDestructure = problem_mod.NonExhaustiveDestructure;
 const RedundantPattern = problem_mod.RedundantPattern;
 const UnmatchablePattern = problem_mod.UnmatchablePattern;
+const ComptimeUnusedBranch = problem_mod.ComptimeUnusedBranch;
 
 // Type declaration errors
 const TypeApplyArityMismatch = problem_mod.TypeApplyArityMismatch;
@@ -829,6 +830,7 @@ pub const ReportBuilder = struct {
             .non_exhaustive_destructure => |data| return self.buildNonExhaustiveDestructureReport(data),
             .redundant_pattern => |data| return self.buildRedundantPatternReport(data),
             .unmatchable_pattern => |data| return self.buildUnmatchablePatternReport(data),
+            .comptime_unused_branch => |data| return self.buildComptimeUnusedBranchReport(data),
         }
     }
 
@@ -3628,6 +3630,13 @@ pub const ReportBuilder = struct {
             D.bytes("_").withAnnotation(.keyword),
             D.bytes("to match anything."),
         }, self, &report);
+        if (data.empirical) {
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            try D.renderSlice(&.{
+                D.bytes("Note: This non-exhaustive match was discovered empirically during compile-time evaluation."),
+            }, self, &report);
+        }
 
         return report;
     }
@@ -3666,6 +3675,13 @@ pub const ReportBuilder = struct {
             try report.document.addText("    ");
             try report.document.addCodeBlock(owned_pattern);
             try report.document.addLineBreak();
+        }
+
+        if (data.empirical) {
+            try report.document.addLineBreak();
+            try D.renderSlice(&.{
+                D.bytes("Note: This non-exhaustive destructure was discovered empirically during compile-time evaluation."),
+            }, self, &report);
         }
 
         return report;
@@ -3714,6 +3730,38 @@ pub const ReportBuilder = struct {
 
         try D.renderSlice(&.{
             D.bytes("This pattern matches a type that has no possible values (an uninhabited type), so no value can ever match it."),
+        }, self, &report);
+
+        return report;
+    }
+
+    fn buildComptimeUnusedBranchReport(self: *Self, data: ComptimeUnusedBranch) Allocator.Error!Report {
+        var report = Report.init(self.gpa, "UNUSED BRANCH", .warning);
+        errdefer report.deinit();
+
+        const noun = switch (data.kind) {
+            .match => "match alternative",
+            .if_ => "if branch",
+        };
+        try D.renderSlice(&.{
+            D.bytes("This"),
+            D.bytes(noun),
+            D.bytes("was not taken during compile-time evaluation:"),
+        }, self, &report);
+        try report.document.addLineBreak();
+
+        const region_info = self.module_env.calcRegionInfo(data.branch_region);
+        try report.document.addSourceRegion(
+            region_info,
+            .warning_highlight,
+            self.filename,
+            self.source,
+            self.module_env.getLineStarts(),
+        );
+        try report.document.addLineBreak();
+
+        try D.renderSlice(&.{
+            D.bytes("Note: This warning is empirical; it only describes the compile-time evaluation that ran for this definition."),
         }, self, &report);
 
         return report;

--- a/src/check/test/TestEnv.zig
+++ b/src/check/test/TestEnv.zig
@@ -278,6 +278,7 @@ pub fn initWithImport(module_name: []const u8, source: []const u8, other_module_
     errdefer checker.deinit();
 
     try checker.checkFile();
+    _ = try checker.problems.flushAllPendingStaticExhaustiveness(gpa);
 
     var type_writer = try module_env.initTypeWriter();
     errdefer type_writer.deinit();
@@ -388,6 +389,7 @@ pub fn init(module_name: []const u8, source: []const u8) Allocator.Error!TestEnv
     errdefer checker.deinit();
 
     try checker.checkFile();
+    _ = try checker.problems.flushAllPendingStaticExhaustiveness(gpa);
 
     var type_writer = try module_env.initTypeWriter();
     errdefer type_writer.deinit();

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -2482,6 +2482,7 @@ fn reportCliInterpreterError(ops: *echo_platform.host_abi.RocOps, interpreter: *
         error.OutOfMemory => "Roc interpreter ran out of memory",
         error.RuntimeError => interpreter.getRuntimeErrorMessage() orelse "Roc runtime error",
         error.DivisionByZero => interpreter.getRuntimeErrorMessage() orelse "Division by zero",
+        error.ComptimeExhaustiveness => "compile-time exhaustiveness failure reached runtime code",
         error.Crash => return,
         // expect_err statements only occur in top-level expect test roots,
         // never in program entrypoints.
@@ -6237,6 +6238,7 @@ fn interpreterTestFailureMessage(
         error.OutOfMemory => return error.OutOfMemory,
         error.RuntimeError => interpreter.getRuntimeErrorMessage() orelse "Roc runtime error",
         error.DivisionByZero => interpreter.getRuntimeErrorMessage() orelse "Division by zero",
+        error.ComptimeExhaustiveness => "compile-time exhaustiveness failure reached runtime code",
         error.Crash => interpreter.getCrashMessage() orelse "Test crashed",
         error.ExpectErr => interpreter.getExpectErrMessage() orelse
             "The `?` operator evaluated an `Err` inside an `expect`",

--- a/src/compile/compile_package.zig
+++ b/src/compile/compile_package.zig
@@ -329,7 +329,7 @@ pub const ArtifactPublicationInputs = struct {
 
 fn problemBlocksCheckedArtifact(problem: check.problem.Problem) bool {
     return switch (problem) {
-        .redundant_pattern, .unmatchable_pattern => false,
+        .redundant_pattern, .unmatchable_pattern, .comptime_unused_branch => false,
         else => true,
     };
 }
@@ -1468,6 +1468,8 @@ pub const PackageEnv = struct {
 
         try checker.checkFile();
 
+        _ = try checker.problems.flushAllPendingStaticExhaustiveness(gpa);
+
         return checker;
     }
 
@@ -1702,6 +1704,7 @@ pub const PackageEnv = struct {
             checkerHasArtifactBlockingProblems(&checker) or
             !importedArtifactsCoverImportedEnvs(imported_envs, imported_artifacts))
         {
+            _ = try checker.problems.flushPendingStaticExhaustiveness(check_alloc);
             return .{
                 .checker = checker,
                 .checked_artifact = null,
@@ -1721,9 +1724,12 @@ pub const PackageEnv = struct {
                 .problem_store = &checker.problems,
             },
         ) catch |err| switch (err) {
-            error.CompileTimeProblem => return .{
-                .checker = checker,
-                .checked_artifact = null,
+            error.CompileTimeProblem => {
+                _ = try checker.problems.flushPendingStaticExhaustiveness(check_alloc);
+                return .{
+                    .checker = checker,
+                    .checked_artifact = null,
+                };
             },
             else => |other| return other,
         };

--- a/src/echo_platform/runner.zig
+++ b/src/echo_platform/runner.zig
@@ -287,6 +287,10 @@ fn runEchoView(
             diag.step("interpreter.runEntrypoint", err);
             return error.EvaluationFailed;
         },
+        error.ComptimeExhaustiveness => {
+            diag.step("interpreter.runEntrypoint", err);
+            return error.EvaluationFailed;
+        },
         error.OutOfMemory => {
             diag.step("interpreter.runEntrypoint", err);
             return error.OutOfMemory;

--- a/src/eval/compile_time_finalization.zig
+++ b/src/eval/compile_time_finalization.zig
@@ -16,6 +16,87 @@ const CompilerHost = @import("compiler_host.zig");
 const ConstStoreWriter = @import("const_store_writer.zig");
 const Interpreter = @import("interpreter.zig").Interpreter;
 
+const ComptimeCoverage = struct {
+    allocator: Allocator,
+    entries: std.ArrayList(Entry),
+
+    const Entry = struct {
+        kind: lir.LIR.ComptimeSiteKind,
+        region: base.Region,
+        branch_regions: []base.Region,
+        hits: []bool,
+    };
+
+    fn init(allocator: Allocator) ComptimeCoverage {
+        return .{
+            .allocator = allocator,
+            .entries = .empty,
+        };
+    }
+
+    fn deinit(self: *ComptimeCoverage) void {
+        for (self.entries.items) |entry| {
+            self.allocator.free(entry.branch_regions);
+            self.allocator.free(entry.hits);
+        }
+        self.entries.deinit(self.allocator);
+    }
+
+    fn record(self: *ComptimeCoverage, site: lir.LIR.ComptimeSite, branch_index: u32) Allocator.Error!void {
+        if (site.kind != .match and site.kind != .if_) return;
+        if (site.branch_regions.len == 0) return;
+        if (branch_index >= site.branch_regions.len) {
+            finalizationInvariant("compile-time branch hit referenced a branch outside its site");
+        }
+
+        const entry = try self.entryFor(site);
+        entry.hits[branch_index] = true;
+    }
+
+    fn entryFor(self: *ComptimeCoverage, site: lir.LIR.ComptimeSite) Allocator.Error!*Entry {
+        for (self.entries.items) |*entry| {
+            if (entry.kind == site.kind and regionsEqual(entry.region, site.region)) {
+                if (entry.branch_regions.len != site.branch_regions.len) {
+                    finalizationInvariant("compile-time site branch count changed for one source region");
+                }
+                return entry;
+            }
+        }
+
+        const branch_regions = try self.allocator.dupe(base.Region, site.branch_regions);
+        errdefer self.allocator.free(branch_regions);
+        const hits = try self.allocator.alloc(bool, site.branch_regions.len);
+        errdefer self.allocator.free(hits);
+        @memset(hits, false);
+
+        try self.entries.append(self.allocator, .{
+            .kind = site.kind,
+            .region = site.region,
+            .branch_regions = branch_regions,
+            .hits = hits,
+        });
+        return &self.entries.items[self.entries.items.len - 1];
+    }
+
+    fn reportUnusedBranches(self: *const ComptimeCoverage, allocator: Allocator, problem_store: ?*check.problem.Store) Allocator.Error!void {
+        const store = problem_store orelse return;
+        for (self.entries.items) |entry| {
+            for (entry.hits, 0..) |hit, index| {
+                if (hit) continue;
+                _ = try store.appendProblem(allocator, .{ .comptime_unused_branch = .{
+                    .kind = switch (entry.kind) {
+                        .match => .match,
+                        .if_ => .if_,
+                        .destructure => unreachable,
+                    },
+                    .site_region = entry.region,
+                    .branch_region = entry.branch_regions[index],
+                } });
+            }
+        }
+    }
+};
+
 /// Return the checking finalizer that evaluates compile-time roots.
 pub fn finalizer() checked.CompileTimeFinalizer {
     return .{ .finalize = finalize };
@@ -33,6 +114,9 @@ fn finalize(
     const requests = module.root_requests.compile_time_requests;
 
     if (requests.len != 0) {
+        var coverage = ComptimeCoverage.init(allocator);
+        defer coverage.deinit();
+
         const lowering_imports = try finalizationImports(allocator, checked.importedView(module), imports, available_modules);
         defer allocator.free(lowering_imports);
 
@@ -63,8 +147,17 @@ fn finalize(
                 ready.items,
                 &state,
                 problem_store,
+                &coverage,
             );
             pending -= ready.items.len;
+        }
+
+        try coverage.reportUnusedBranches(allocator, problem_store);
+    }
+
+    if (problem_store) |store| {
+        if (try store.flushPendingStaticExhaustiveness(allocator) != 0) {
+            return error.CompileTimeProblem;
         }
     }
 
@@ -287,6 +380,7 @@ fn lowerEvalAndFinishRoots(
     requests: []const checked.RootRequest,
     state: *RootCompletionState,
     problem_store: ?*check.problem.Store,
+    coverage: *ComptimeCoverage,
 ) anyerror!void {
     var lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
         allocator,
@@ -330,6 +424,9 @@ fn lowerEvalAndFinishRoots(
                         const message = interpreter.getRuntimeErrorMessage() orelse host.crash_message orelse "compile-time evaluation failed";
                         break :blk .{ .const_node = try appendCrashConst(module, message) };
                     },
+                    error.ComptimeExhaustiveness => {
+                        break :blk .{ .const_node = try appendCrashConst(module, "compile-time exhaustiveness failure") };
+                    },
                     error.Crash => {
                         const message = interpreter.getCrashMessage() orelse host.crash_message orelse "Roc crashed";
                         break :blk .{ .const_node = try appendCrashConst(module, message) };
@@ -342,7 +439,8 @@ fn lowerEvalAndFinishRoots(
                 break :blk try writer.storeRoot(root, eval_result.value);
             }
 
-            const eval_result = try evalCompileTimeRoot(allocator, &interpreter, problem_store, module, compile_time_root, root.proc, root.ret_layout);
+            const eval_result = try evalCompileTimeRoot(allocator, &interpreter, problem_store, module, compile_time_root, &lowered.lir_result, root.proc, root.ret_layout);
+            try recordComptimeSiteHits(problem_store, coverage, &lowered.lir_result, interpreter.getComptimeBranchHits(), root.proc);
             defer interpreter.dropValue(eval_result.value, root.ret_layout);
             break :blk try writer.storeRoot(root, eval_result.value);
         };
@@ -455,6 +553,7 @@ fn evalCompileTimeRoot(
     problem_store: ?*check.problem.Store,
     module: *const checked.CheckedModuleArtifact,
     root: checked.CompileTimeRoot,
+    lir_result: *const lir.Program.Result,
     proc: lir.LIR.LirProcSpecId,
     ret_layout: @import("layout").Idx,
 ) anyerror!Interpreter.EvalResult {
@@ -464,10 +563,56 @@ fn evalCompileTimeRoot(
     }) catch |err| switch (err) {
         error.OutOfMemory => error.OutOfMemory,
         error.RuntimeError => finalizationInvariant("compile-time root produced a runtime error"),
+        error.ComptimeExhaustiveness => try reportCompileTimeExhaustiveness(allocator, problem_store, lir_result, interpreter),
         error.DivisionByZero => try reportCompileTimeCrash(allocator, problem_store, module, root, interpreter.getRuntimeErrorMessage() orelse "Division by zero"),
         error.Crash => try reportCompileTimeCrash(allocator, problem_store, module, root, interpreter.getCrashMessage() orelse "Roc crashed"),
         error.ExpectErr => finalizationInvariant("compile-time root reached an expect_err statement"),
     };
+}
+
+fn recordComptimeSiteHits(
+    maybe_problem_store: ?*check.problem.Store,
+    coverage: *ComptimeCoverage,
+    lir_result: *const lir.Program.Result,
+    hits: []const Interpreter.ComptimeBranchHit,
+    root_proc: lir.LIR.LirProcSpecId,
+) Allocator.Error!void {
+    const problem_store = maybe_problem_store orelse return;
+    for (hits) |hit| {
+        const site = lir_result.comptime_sites.items[@intFromEnum(hit.site)];
+        switch (site.kind) {
+            .match => problem_store.resolvePendingStaticExhaustiveness(.match, site.region),
+            .destructure => problem_store.resolvePendingStaticExhaustiveness(.destructure, site.region),
+            .if_ => {},
+        }
+        if (site.proc == root_proc) {
+            try coverage.record(site, hit.branch_index);
+        }
+    }
+}
+
+fn reportCompileTimeExhaustiveness(
+    allocator: Allocator,
+    maybe_problem_store: ?*check.problem.Store,
+    lir_result: *const lir.Program.Result,
+    interpreter: *const Interpreter,
+) anyerror!Interpreter.EvalResult {
+    const problem_store = maybe_problem_store orelse {
+        finalizationInvariant("compile-time root reached an empirical exhaustiveness failure without a checking problem store");
+    };
+    const site_id = interpreter.getComptimeFailedSite() orelse {
+        finalizationInvariant("compile-time root reported empirical exhaustiveness failure without a site");
+    };
+    const site = lir_result.comptime_sites.items[@intFromEnum(site_id)];
+    const matched = switch (site.kind) {
+        .match => try problem_store.appendEmpiricalExhaustivenessFailure(allocator, .match, site.region),
+        .destructure => try problem_store.appendEmpiricalExhaustivenessFailure(allocator, .destructure, site.region),
+        .if_ => finalizationInvariant("if expression reached empirical exhaustiveness failure"),
+    };
+    if (!matched) {
+        finalizationInvariant("empirical exhaustiveness failure had no pending static diagnostic");
+    }
+    return error.CompileTimeProblem;
 }
 
 fn reportCompileTimeCrash(
@@ -523,6 +668,10 @@ fn appendUniqueImport(
 
 fn sameModuleIdentity(a: checked.ImportedModuleView, b: checked.ImportedModuleView) bool {
     return std.meta.eql(a.module_identity.stable_hash, b.module_identity.stable_hash);
+}
+
+fn regionsEqual(a: base.Region, b: base.Region) bool {
+    return a.start.offset == b.start.offset and a.end.offset == b.end.offset;
 }
 
 fn compileTimeRootForRequest(

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -281,6 +281,8 @@ pub const Interpreter = struct {
     call_stack: std.ArrayList(LirProcSpecId),
     /// Call stack captured at the first failed exit in the current evaluation.
     failed_call_stack: std.ArrayList(LirProcSpecId),
+    comptime_branch_hits: std.ArrayList(ComptimeBranchHit),
+    comptime_failed_site: ?LIR.ComptimeSiteId = null,
 
     const RcPresence = enum(u2) {
         unknown,
@@ -292,9 +294,15 @@ pub const Interpreter = struct {
     pub const Error = error{
         OutOfMemory,
         RuntimeError,
+        ComptimeExhaustiveness,
         DivisionByZero,
         Crash,
         ExpectErr,
+    };
+
+    pub const ComptimeBranchHit = struct {
+        site: LIR.ComptimeSiteId,
+        branch_index: u32,
     };
 
     const CrashBoundary = struct {
@@ -490,10 +498,12 @@ pub const Interpreter = struct {
             .tag_variant_plans = tag_variant_plans,
             .call_stack = .empty,
             .failed_call_stack = .empty,
+            .comptime_branch_hits = .empty,
         };
     }
 
     pub fn deinit(self: *LirInterpreter) void {
+        self.comptime_branch_hits.deinit(self.evalAllocator());
         self.failed_call_stack.deinit(self.evalAllocator());
         self.call_stack.deinit(self.evalAllocator());
         self.roc_env.deinit();
@@ -609,6 +619,14 @@ pub const Interpreter = struct {
         return self.failed_call_stack.items;
     }
 
+    pub fn getComptimeFailedSite(self: *const LirInterpreter) ?LIR.ComptimeSiteId {
+        return self.comptime_failed_site;
+    }
+
+    pub fn getComptimeBranchHits(self: *const LirInterpreter) []const ComptimeBranchHit {
+        return self.comptime_branch_hits.items;
+    }
+
     fn recordFailedCallStackIfUnset(self: *LirInterpreter) Allocator.Error!void {
         if (self.failed_call_stack.items.len != 0) return;
         try self.failed_call_stack.appendSlice(self.evalAllocator(), self.call_stack.items);
@@ -624,6 +642,11 @@ pub const Interpreter = struct {
     fn runtimeError(self: *LirInterpreter, message: []const u8) Error {
         self.roc_env.runtime_error_message = message;
         return error.RuntimeError;
+    }
+
+    fn comptimeExhaustivenessFailed(self: *LirInterpreter, site: LIR.ComptimeSiteId) Error {
+        self.comptime_failed_site = site;
+        return error.ComptimeExhaustiveness;
     }
 
     fn divisionByZeroMessageForLayout(self: *const LirInterpreter, layout_idx: layout_mod.Idx) []const u8 {
@@ -811,6 +834,8 @@ pub const Interpreter = struct {
         self.roc_env.resetForEval();
         self.call_stack.clearRetainingCapacity();
         self.failed_call_stack.clearRetainingCapacity();
+        self.comptime_branch_hits.clearRetainingCapacity();
+        self.comptime_failed_site = null;
 
         if (sljmp.supported) {
             var eval_jmp_buf: JmpBuf = undefined;
@@ -1394,12 +1419,14 @@ pub const Interpreter = struct {
                 .set_local => |assign| assign.next,
                 .debug => |stmt_next| stmt_next.next,
                 .expect => |stmt_next| stmt_next.next,
+                .comptime_branch_taken => |marker| marker.next,
                 .incref => |stmt_next| stmt_next.next,
                 .decref => |stmt_next| stmt_next.next,
                 .free => |stmt_next| stmt_next.next,
                 .join => |join_stmt| join_stmt.body,
                 .switch_stmt,
                 .runtime_error,
+                .comptime_exhaustiveness_failed,
                 .jump,
                 .ret,
                 .crash,
@@ -1774,6 +1801,16 @@ pub const Interpreter = struct {
                 .runtime_error => {
                     return self.runtimeError("RuntimeError");
                 },
+                .comptime_exhaustiveness_failed => |failed| {
+                    return self.comptimeExhaustivenessFailed(failed.site);
+                },
+                .comptime_branch_taken => |marker| {
+                    try self.comptime_branch_hits.append(self.evalAllocator(), .{
+                        .site = marker.site,
+                        .branch_index = marker.branch_index,
+                    });
+                    current = marker.next;
+                },
                 .incref => |inc| {
                     if (builtin.mode == .Debug and !frame.isAssigned(inc.value)) {
                         debugPrint(
@@ -2077,6 +2114,21 @@ pub const Interpreter = struct {
                 },
                 .runtime_error => {
                     debugPrint("    {d}: runtime_error\n", .{@intFromEnum(stmt_id)});
+                },
+                .comptime_exhaustiveness_failed => |failed| {
+                    debugPrint("    {d}: comptime_exhaustiveness_failed site={d}\n", .{
+                        @intFromEnum(stmt_id),
+                        @intFromEnum(failed.site),
+                    });
+                },
+                .comptime_branch_taken => |marker| {
+                    debugPrint("    {d}: comptime_branch_taken site={d} branch={d} next={d}\n", .{
+                        @intFromEnum(stmt_id),
+                        @intFromEnum(marker.site),
+                        marker.branch_index,
+                        @intFromEnum(marker.next),
+                    });
+                    stack.append(self.evalAllocator(), marker.next) catch return;
                 },
                 .incref => |inc| {
                     debugPrint("    {d}: incref value={d} next={d}\n", .{
@@ -2475,6 +2527,7 @@ pub const Interpreter = struct {
         context.interpreter.callInterpreterErasedCallable(context, ops, ret, args) catch |err| switch (err) {
             error.OutOfMemory => ops.crash("LIR/interpreter erased callable trampoline ran out of memory"),
             error.RuntimeError => ops.crash("LIR/interpreter erased callable trampoline hit runtime error"),
+            error.ComptimeExhaustiveness => ops.crash("LIR/interpreter erased callable trampoline hit compile-time exhaustiveness marker"),
             error.DivisionByZero => ops.crash("LIR/interpreter erased callable trampoline hit division by zero"),
             error.Crash => ops.crash("LIR/interpreter erased callable trampoline hit Roc crash"),
             // expect_err statements only occur in top-level expect test

--- a/src/eval/test/eval_comptime_finalization_tests.zig
+++ b/src/eval/test/eval_comptime_finalization_tests.zig
@@ -625,6 +625,62 @@ const tag_payload_single =
     \\main = lookup([MyTag.Foo({x: 42, y: 7})], 0)
 ;
 
+const comptime_exhaustive_match_ok =
+    \\x : Try(Str, Str)
+    \\x = Ok("blah")
+    \\
+    \\main = match x {
+    \\    Ok(foo) => foo
+    \\}
+;
+
+const comptime_exhaustive_destructure_email =
+    \\Email := [Email(Str)].{
+    \\    parse : Str -> Try(Email, Str)
+    \\    parse = |raw| if raw == "" { Err("empty") } else { Ok(Email(raw)) }
+    \\
+    \\    to_str : Email -> Str
+    \\    to_str = |Email(raw)| raw
+    \\}
+    \\
+    \\main = {
+    \\    Ok(email) = Email.parse("alice@example.com")
+    \\
+    \\    Email.to_str(email)
+    \\}
+;
+
+const comptime_non_exhaustive_match =
+    \\x : Try(Str, Str)
+    \\x = Err("bad")
+    \\
+    \\main = match x {
+    \\    Ok(foo) => foo
+    \\}
+;
+
+const comptime_non_exhaustive_destructure =
+    \\main = {
+    \\    x : Try(Str, Str)
+    \\    x = Err("bad")
+    \\
+    \\    Ok(foo) = x
+    \\
+    \\    foo
+    \\}
+;
+
+const comptime_unused_match_alternative =
+    \\main = match True {
+    \\    True => "yes"
+    \\    False => "no"
+    \\}
+;
+
+const comptime_unused_if_branch =
+    \\main = if True { 42 } else { 0 }
+;
+
 const opaque_function_field =
     \\W(a) := { f : {} -> [V(a)] }.{
     \\    run : W(a) -> [V(a)]
@@ -822,6 +878,12 @@ pub const tests = [_]TestCase{
     .{ .name = "issue 8979: while (False) should not crash", .source_kind = .module, .source = while_false, .expected = .{ .inspect_str = "42.0" } },
     .{ .name = "issue 8979: nested while - inner break does not save outer loop", .source = crash_now, .expected = .{ .crash = {} } },
     .{ .name = "tag union matching with payload inside function - single module", .source_kind = .module, .source = tag_payload_single, .expected = .{ .inspect_str = "42" } },
+    .{ .name = "comptime exhaustiveness - match succeeds empirically", .source_kind = .module, .source = comptime_exhaustive_match_ok, .expected = .{ .inspect_str = "\"blah\"" } },
+    .{ .name = "comptime exhaustiveness - Email.parse destructure succeeds empirically", .source_kind = .module, .source = comptime_exhaustive_destructure_email, .expected = .{ .inspect_str = "\"alice@example.com\"" } },
+    .{ .name = "comptime exhaustiveness - match failure is reported empirically", .source_kind = .module, .source = comptime_non_exhaustive_match, .expected = .{ .problem = {} } },
+    .{ .name = "comptime exhaustiveness - destructure failure is reported empirically", .source_kind = .module, .source = comptime_non_exhaustive_destructure, .expected = .{ .problem = {} } },
+    .{ .name = "comptime exhaustiveness - unused match alternative is reported", .source_kind = .module, .source = comptime_unused_match_alternative, .expected = .{ .problem = {} } },
+    .{ .name = "comptime exhaustiveness - unused if branch is reported", .source_kind = .module, .source = comptime_unused_if_branch, .expected = .{ .problem = {} } },
     .{
         .name = "tag union matching with payload inside function - cross module",
         .source_kind = .module,

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -240,6 +240,7 @@ fn collectAssignCallProcs(
             .set_local => |stmt| try work.append(allocator, stmt.next),
             .debug => |stmt| try work.append(allocator, stmt.next),
             .expect => |stmt| try work.append(allocator, stmt.next),
+            .comptime_branch_taken => |stmt| try work.append(allocator, stmt.next),
             .incref => |stmt| try work.append(allocator, stmt.next),
             .decref => |stmt| try work.append(allocator, stmt.next),
             .free => |stmt| try work.append(allocator, stmt.next),
@@ -255,6 +256,7 @@ fn collectAssignCallProcs(
                 try work.append(allocator, stmt.remainder);
             },
             .runtime_error,
+            .comptime_exhaustiveness_failed,
             .loop_continue,
             .loop_break,
             .jump,
@@ -330,6 +332,7 @@ fn collectProcShape(
             .set_local => |stmt| try work.append(allocator, stmt.next),
             .debug => |stmt| try work.append(allocator, stmt.next),
             .expect => |stmt| try work.append(allocator, stmt.next),
+            .comptime_branch_taken => |stmt| try work.append(allocator, stmt.next),
             .incref => |stmt| try work.append(allocator, stmt.next),
             .decref => |stmt| try work.append(allocator, stmt.next),
             .free => |stmt| try work.append(allocator, stmt.next),
@@ -354,6 +357,7 @@ fn collectProcShape(
                 shape.jump_count += 1;
             },
             .runtime_error,
+            .comptime_exhaustiveness_failed,
             .loop_continue,
             .loop_break,
             .ret,
@@ -467,6 +471,7 @@ fn markReachableLiftedExpr(
         .str_lit,
         .fn_ref,
         .crash,
+        .comptime_exhaustiveness_failed,
         => {},
         .list,
         .tuple,
@@ -479,6 +484,7 @@ fn markReachableLiftedExpr(
         .expect,
         => |child| markReachableLiftedExpr(program, child, reachable),
         .expect_err => |expect_err| markReachableLiftedExpr(program, expect_err.msg, reachable),
+        .comptime_branch_taken => |taken| markReachableLiftedExpr(program, taken.body, reachable),
         .let_ => |let_| {
             markReachableLiftedExpr(program, let_.value, reachable);
             markReachableLiftedExpr(program, let_.rest, reachable);

--- a/src/eval/test/trmc_lir_test.zig
+++ b/src/eval/test/trmc_lir_test.zig
@@ -392,8 +392,8 @@ fn hasSelfCall(allocator: Allocator, store: *const LirStore, proc_id: LIR.LirPro
                 try work.append(allocator, s.default_branch);
                 if (s.continuation) |continuation| try work.append(allocator, continuation);
             },
-            .jump, .ret, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
-            inline .assign_ref, .assign_literal, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| {
+            .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
+            inline .assign_ref, .assign_literal, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                 try work.append(allocator, s.next);
             },
         }

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -840,8 +840,12 @@ pub fn publishProgramForComptimeProblems(
         error.CompileTimeProblem => return .comptime_problems,
         else => return err,
     };
-    cleanupParseAndCanonical(allocator, resources);
-    return .no_problems;
+    defer cleanupParseAndCanonical(allocator, resources);
+
+    return if (resources.checker.problems.problems.items.len == 0)
+        .no_problems
+    else
+        .comptime_problems;
 }
 
 const PublishedRootMode = union(enum) {
@@ -856,7 +860,7 @@ const ComptimeProblemReporting = enum {
 
 fn problemBlocksCheckedArtifact(problem: check.problem.Problem) bool {
     return switch (problem) {
-        .redundant_pattern, .unmatchable_pattern => false,
+        .redundant_pattern, .unmatchable_pattern, .comptime_unused_branch => false,
         else => true,
     };
 }

--- a/src/interpreter_shim/main.zig
+++ b/src/interpreter_shim/main.zig
@@ -118,6 +118,7 @@ fn reportEvalError(ops: *RocOps, interpreter: *const eval.LirInterpreter, err: e
         error.OutOfMemory => "Roc interpreter ran out of memory",
         error.RuntimeError => interpreter.getRuntimeErrorMessage() orelse "Roc runtime error",
         error.DivisionByZero => interpreter.getRuntimeErrorMessage() orelse "Division by zero",
+        error.ComptimeExhaustiveness => "compile-time exhaustiveness failure reached runtime code",
         error.Crash => return,
         // expect_err statements only occur in top-level expect test roots,
         // never in platform entrypoints.

--- a/src/lir/LIR.zig
+++ b/src/lir/LIR.zig
@@ -63,6 +63,26 @@ pub const CFStmtId = enum(u32) {
     _,
 };
 
+/// Identifier of a compile-time-observed control-flow site.
+pub const ComptimeSiteId = enum(u32) {
+    _,
+};
+
+/// Source control-flow construct observed during compile-time finalization.
+pub const ComptimeSiteKind = enum {
+    match,
+    destructure,
+    if_,
+};
+
+/// Metadata for one compile-time-observed control-flow site.
+pub const ComptimeSite = struct {
+    kind: ComptimeSiteKind,
+    region: base.Region,
+    proc: LirProcSpecId,
+    branch_regions: []const base.Region = &.{},
+};
+
 /// Identifier of a join point targeted by `jump`.
 pub const JoinPointId = enum(u32) {
     _,
@@ -322,6 +342,17 @@ pub const CFStmt = union(enum) {
     },
     /// Compiler-generated impossible execution path. This is terminal.
     runtime_error: void,
+    /// Pattern coverage failed during compile-time evaluation. This is
+    /// terminal and becomes a checking diagnostic while finalizing.
+    comptime_exhaustiveness_failed: struct {
+        site: ComptimeSiteId,
+    },
+    /// One compile-time-observed branch or match alternative was taken.
+    comptime_branch_taken: struct {
+        site: ComptimeSiteId,
+        branch_index: u32,
+        next: CFStmtId,
+    },
     incref: struct {
         value: LocalId,
         rc: layout.RcHelper,

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -783,11 +783,15 @@ const Inserter = struct {
                     self.destroyRewritePath(path);
                     return;
                 },
-                .runtime_error => {
+                .runtime_error, .comptime_exhaustiveness_failed => {
                     const tail = try self.releaseAll(&path.owned, path.cursor);
                     path.result.* = try self.finishLinearRewrite(&path.frames, tail);
                     self.destroyRewritePath(path);
                     return;
+                },
+                .comptime_branch_taken => |marker| {
+                    try path.frames.append(self.store.allocator, .{ .stmt = path.cursor, .head = current_start });
+                    path.cursor = marker.next;
                 },
                 .loop_continue => {
                     const tail = if (path.options.loop_keep) |keep| try self.releaseDifference(&path.owned, keep, path.cursor) else path.cursor;
@@ -1012,6 +1016,13 @@ const Inserter = struct {
                     .next = next,
                 } });
             },
+            .comptime_branch_taken => |marker| {
+                cloned = try self.store.addCFStmt(.{ .comptime_branch_taken = .{
+                    .site = marker.site,
+                    .branch_index = marker.branch_index,
+                    .next = next,
+                } });
+            },
             .incref => |rc| {
                 cloned = try self.store.addCFStmt(.{ .incref = .{
                     .value = rc.value,
@@ -1038,6 +1049,7 @@ const Inserter = struct {
                 } });
             },
             .runtime_error,
+            .comptime_exhaustiveness_failed,
             .switch_stmt,
             .loop_continue,
             .loop_break,
@@ -1564,9 +1576,12 @@ const Inserter = struct {
                     self.destroyAnalysisPath(path);
                     return;
                 },
-                .runtime_error, .loop_continue, .loop_break, .jump, .ret, .crash, .expect_err => {
+                .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break, .jump, .ret, .crash, .expect_err => {
                     self.destroyAnalysisPath(path);
                     return;
+                },
+                .comptime_branch_taken => |marker| {
+                    path.cursor = marker.next;
                 },
             }
         }
@@ -2102,6 +2117,7 @@ const Inserter = struct {
                 .set_local => |assign| try stack.append(self.store.allocator, assign.next),
                 .debug => |debug_stmt| try stack.append(self.store.allocator, debug_stmt.next),
                 .expect => |expect_stmt| try stack.append(self.store.allocator, expect_stmt.next),
+                .comptime_branch_taken => |taken| try stack.append(self.store.allocator, taken.next),
                 .switch_stmt => |switch_stmt| {
                     if (switch_stmt.continuation) |continuation| {
                         try stack.append(self.store.allocator, continuation);
@@ -2123,6 +2139,7 @@ const Inserter = struct {
                 .jump,
                 .ret,
                 .runtime_error,
+                .comptime_exhaustiveness_failed,
                 .loop_continue,
                 .loop_break,
                 .crash,
@@ -2185,6 +2202,7 @@ const Inserter = struct {
                 .incref => |rc| try stack.append(self.store.allocator, rc.next),
                 .decref => |rc| try stack.append(self.store.allocator, rc.next),
                 .free => |rc| try stack.append(self.store.allocator, rc.next),
+                .comptime_branch_taken => |taken| try stack.append(self.store.allocator, taken.next),
                 .switch_stmt => |switch_stmt| {
                     if (switch_stmt.continuation) |continuation| {
                         try stack.append(self.store.allocator, continuation);
@@ -2211,6 +2229,7 @@ const Inserter = struct {
                 .jump,
                 .ret,
                 .runtime_error,
+                .comptime_exhaustiveness_failed,
                 .loop_continue,
                 .loop_break,
                 .crash,
@@ -2328,8 +2347,10 @@ const Inserter = struct {
                     if (keep.contains(needle)) return true;
                 },
                 .runtime_error,
+                .comptime_exhaustiveness_failed,
                 .crash,
                 => {},
+                .comptime_branch_taken => |marker| try stack.append(self.store.allocator, marker.next),
                 .incref => |rc| try stack.append(self.store.allocator, rc.next),
                 .decref => |rc| try stack.append(self.store.allocator, rc.next),
                 .free => |rc| try stack.append(self.store.allocator, rc.next),
@@ -2471,8 +2492,10 @@ const Inserter = struct {
                     }
                 },
                 .runtime_error,
+                .comptime_exhaustiveness_failed,
                 .crash,
                 => {},
+                .comptime_branch_taken => |marker| try stack.append(self.store.allocator, marker.next),
                 .incref => |rc| try stack.append(self.store.allocator, rc.next),
                 .decref => |rc| try stack.append(self.store.allocator, rc.next),
                 .free => |rc| try stack.append(self.store.allocator, rc.next),
@@ -3023,10 +3046,10 @@ const ArcTest = struct {
                     try stack.append(self.allocator, j.body);
                     try stack.append(self.allocator, j.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| {
+                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                     try stack.append(self.allocator, s.next);
                 },
-                .ret, .jump, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
+                .ret, .jump, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
             }
         }
         return mask;
@@ -3079,6 +3102,7 @@ const ArcTest = struct {
                 .set_local => |assign| cursor = assign.next,
                 .debug => |debug_stmt| cursor = debug_stmt.next,
                 .expect => |expect_stmt| cursor = expect_stmt.next,
+                .comptime_branch_taken => |marker| cursor = marker.next,
                 .ret => {
                     if (before == .ret) return error.ExpectedRcBeforeStop;
                     return;
@@ -3087,7 +3111,7 @@ const ArcTest = struct {
                     if (before == .crash) return error.ExpectedRcBeforeStop;
                     return;
                 },
-                .expect_err, .runtime_error, .switch_stmt, .loop_continue, .loop_break, .join, .jump => return error.NonLinearPath,
+                .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .switch_stmt, .loop_continue, .loop_break, .join, .jump => return error.NonLinearPath,
             }
         }
         return error.CyclicPath;

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -214,10 +214,10 @@ fn certifyUniqueArgs(
                     try stack.append(allocator, j.body);
                     try stack.append(allocator, j.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| {
+                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                     try stack.append(allocator, s.next);
                 },
-                .ret, .jump, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
+                .ret, .jump, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
             }
         }
     }
@@ -314,7 +314,8 @@ fn writeFailureContext(context: *FailureContext, store: *const LirStore, proc_id
             if (reachable.contains(current)) continue;
             reachable.put(current, {}) catch return;
             switch (store.getCFStmt(current)) {
-                .runtime_error, .loop_continue, .loop_break, .jump, .ret, .crash, .expect_err => {},
+                .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break, .jump, .ret, .crash, .expect_err => {},
+                .comptime_branch_taken => |s| walk.append(store.allocator, s.next) catch return,
                 .switch_stmt => |s| {
                     for (store.getCFSwitchBranches(s.branches)) |branch| {
                         walk.append(store.allocator, branch.body) catch return;
@@ -394,7 +395,7 @@ fn stmtMentionsLocal(store: *const LirStore, stmt: LIR.CFStmt, needle: LIR.Local
         .free => |rc| rc.value == needle,
         .switch_stmt => |s| s.cond == needle,
         .ret => |r| r.value == needle,
-        .join, .jump, .crash, .runtime_error, .loop_continue, .loop_break => false,
+        .join, .jump, .crash, .runtime_error, .comptime_exhaustiveness_failed, .comptime_branch_taken, .loop_continue, .loop_break => false,
     };
 }
 
@@ -1019,7 +1020,8 @@ const Certifier = struct {
                     try stack.append(self.allocator, join_stmt.remainder);
                 },
                 .ret => |ret_stmt| try self.noteProcLocal(ret_stmt.value),
-                .jump, .crash, .runtime_error, .loop_continue, .loop_break => {},
+                .jump, .crash, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
+                .comptime_branch_taken => |marker| try stack.append(self.allocator, marker.next),
             }
         }
     }
@@ -1131,7 +1133,8 @@ const Certifier = struct {
                 .ret => |ret_stmt| {
                     if (ret_stmt.value == needle) return true;
                 },
-                .runtime_error, .crash, .loop_continue, .loop_break => {},
+                .runtime_error, .comptime_exhaustiveness_failed, .crash, .loop_continue, .loop_break => {},
+                .comptime_branch_taken => |marker| try self.scan_stack.append(self.allocator, marker.next),
             }
         }
         return false;
@@ -1478,6 +1481,9 @@ const Certifier = struct {
                     _ = try self.requireLive(&state, expect_stmt.condition);
                     cursor = expect_stmt.next;
                 },
+                .comptime_branch_taken => |taken| {
+                    cursor = taken.next;
+                },
                 .incref => |rc| {
                     if (!self.isRc(rc.value)) {
                         return self.fail("incref of non-refcounted local {d}", .{@intFromEnum(rc.value)});
@@ -1569,7 +1575,7 @@ const Certifier = struct {
                     try self.checkLeaks(&state);
                     return;
                 },
-                .runtime_error => {
+                .runtime_error, .comptime_exhaustiveness_failed => {
                     try self.checkLeaks(&state);
                     return;
                 },

--- a/src/lir/arc_solve.zig
+++ b/src/lir/arc_solve.zig
@@ -586,10 +586,10 @@ fn retLenders(
                 try solver.stack.append(allocator, j.body);
                 try solver.stack.append(allocator, j.remainder);
             },
-            inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| {
+            inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                 try solver.stack.append(allocator, s.next);
             },
-            .jump, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
+            .jump, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
         }
     }
 
@@ -637,10 +637,10 @@ fn retAllUnique(
                 try solver.stack.append(allocator, j.body);
                 try solver.stack.append(allocator, j.remainder);
             },
-            inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| {
+            inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                 try solver.stack.append(allocator, s.next);
             },
-            .jump, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
+            .jump, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
         }
     }
 
@@ -852,6 +852,7 @@ fn collectStmt(
         // The failure report takes ownership of the message.
         .expect_err => |expect_err_stmt| noteDemand(solver, expect_err_stmt.message),
         .expect => |expect_stmt| try solver.stack.append(allocator, expect_stmt.next),
+        .comptime_branch_taken => |marker| try solver.stack.append(allocator, marker.next),
         .incref => |rc| try solver.stack.append(allocator, rc.next),
         .decref => |rc| try solver.stack.append(allocator, rc.next),
         .free => |rc| try solver.stack.append(allocator, rc.next),
@@ -874,7 +875,7 @@ fn collectStmt(
             try solver.stack.append(allocator, join_stmt.remainder);
         },
         .ret => {},
-        .jump, .crash, .runtime_error, .loop_continue, .loop_break => {},
+        .jump, .crash, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
     }
 }
 
@@ -1025,10 +1026,10 @@ pub fn computeVisibility(
                     try stack.append(allocator, stmt.body);
                     try stack.append(allocator, stmt.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |stmt| {
+                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |stmt| {
                     try stack.append(allocator, stmt.next);
                 },
-                .jump, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
+                .jump, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
             }
         }
     }
@@ -1539,8 +1540,9 @@ pub fn computeUniqueness(
             // The failure report is the message's consuming use.
             .expect_err => |expect_err_stmt| marks.consume(&consumed_once, &destroyed, expect_err_stmt.message),
             .expect => |expect_stmt| marks.noteUse(&borrow_used, expect_stmt.condition),
+            .comptime_branch_taken => {},
             .switch_stmt => |switch_stmt| marks.noteUse(&borrow_used, switch_stmt.cond),
-            .decref, .free, .jump, .crash, .runtime_error, .loop_continue, .loop_break => {},
+            .decref, .free, .jump, .crash, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
         }
     }
 
@@ -1636,10 +1638,10 @@ fn computeSccs(solver: *Solver) SolveError!void {
                     try solver.stack.append(allocator, j.body);
                     try solver.stack.append(allocator, j.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| {
+                inline .assign_ref, .assign_literal, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                     try solver.stack.append(allocator, s.next);
                 },
-                .jump, .ret, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
+                .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
             }
         }
     }

--- a/src/lir/debug_print.zig
+++ b/src/lir/debug_print.zig
@@ -159,6 +159,11 @@ const Printer = struct {
                     try writer.print("expect l{d}\n", .{@intFromEnum(s.condition)});
                     current = s.next;
                 },
+                .comptime_branch_taken => |s| {
+                    try writeIndent(indent, writer);
+                    try writer.print("comptime_branch_taken site={d} branch={d}\n", .{ @intFromEnum(s.site), s.branch_index });
+                    current = s.next;
+                },
                 .expect_err => |s| {
                     try writeIndent(indent, writer);
                     try writer.print("expect_err l{d}\n", .{@intFromEnum(s.message)});
@@ -228,6 +233,11 @@ const Printer = struct {
                 .runtime_error => {
                     try writeIndent(indent, writer);
                     try writer.writeAll("runtime_error\n");
+                    return;
+                },
+                .comptime_exhaustiveness_failed => |s| {
+                    try writeIndent(indent, writer);
+                    try writer.print("comptime_exhaustiveness_failed site={d}\n", .{@intFromEnum(s.site)});
                     return;
                 },
                 .loop_continue => {

--- a/src/lir/program.zig
+++ b/src/lir/program.zig
@@ -2,6 +2,7 @@
 //! interpreter consumers.
 
 const std = @import("std");
+const base = @import("base");
 const check = @import("check");
 const layout = @import("layout");
 
@@ -129,6 +130,7 @@ pub const Result = struct {
     erased_fns: std.ArrayList(ErasedFns),
     const_plans: std.ArrayList(ConstPlan),
     const_roots: std.ArrayList(ConstRootPlan),
+    comptime_sites: std.ArrayList(LIR.ComptimeSite),
 
     pub fn init(allocator: Allocator, target_usize: @import("base").target.TargetUsize) Allocator.Error!Result {
         return .{
@@ -141,11 +143,16 @@ pub const Result = struct {
             .erased_fns = .empty,
             .const_plans = .empty,
             .const_roots = .empty,
+            .comptime_sites = .empty,
         };
     }
 
     pub fn deinit(self: *Result) void {
         const allocator = self.store.allocator;
+        for (self.comptime_sites.items) |site| {
+            allocator.free(site.branch_regions);
+        }
+        self.comptime_sites.deinit(allocator);
         deinitConstPlans(allocator, self.const_plans.items);
         self.const_roots.deinit(allocator);
         self.const_plans.deinit(allocator);
@@ -165,6 +172,25 @@ pub const Result = struct {
             if (std.mem.eql(u8, entry.ty.bytes[0..], ty.bytes[0..])) return entry.layout_idx;
         }
         return null;
+    }
+
+    pub fn addComptimeSite(
+        self: *Result,
+        kind: LIR.ComptimeSiteKind,
+        region: base.Region,
+        proc: LIR.LirProcSpecId,
+        branch_regions: []const base.Region,
+    ) Allocator.Error!LIR.ComptimeSiteId {
+        const owned_branch_regions = try self.store.allocator.dupe(base.Region, branch_regions);
+        errdefer self.store.allocator.free(owned_branch_regions);
+        const id: LIR.ComptimeSiteId = @enumFromInt(@as(u32, @intCast(self.comptime_sites.items.len)));
+        try self.comptime_sites.append(self.store.allocator, .{
+            .kind = kind,
+            .region = region,
+            .proc = proc,
+            .branch_regions = owned_branch_regions,
+        });
+        return id;
     }
 };
 

--- a/src/lir/scalarize_joins.zig
+++ b/src/lir/scalarize_joins.zig
@@ -203,10 +203,10 @@ const Pass = struct {
                         try self.stack.append(self.allocator, continuation);
                     }
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| {
+                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                     try self.stack.append(self.allocator, s.next);
                 },
-                .jump, .ret, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
+                .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
             }
         }
 
@@ -404,11 +404,11 @@ const Pass = struct {
                     try self.stack.append(self.allocator, j.body);
                     try self.stack.append(self.allocator, j.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |*s| {
+                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |*s| {
                     s.next = self.resolveRemoved(s.next);
                     try self.stack.append(self.allocator, s.next);
                 },
-                .jump, .ret, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
+                .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
             }
         }
     }
@@ -451,10 +451,10 @@ const Pass = struct {
                     try self.stack.append(self.allocator, join_stmt.body);
                     try self.stack.append(self.allocator, join_stmt.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |a| {
+                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |a| {
                     try self.stack.append(self.allocator, a.next);
                 },
-                .jump, .ret, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
+                .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
             }
         }
 
@@ -544,6 +544,7 @@ const Pass = struct {
                     try self.noteUse(s.condition);
                     try self.stack.append(self.allocator, s.next);
                 },
+                .comptime_branch_taken => |s| try self.stack.append(self.allocator, s.next),
                 .switch_stmt => |s| {
                     try self.noteUse(s.cond);
                     for (self.store.getCFSwitchBranches(s.branches)) |branch| {
@@ -571,7 +572,7 @@ const Pass = struct {
                     try self.noteUse(rc.value);
                     try self.stack.append(self.allocator, rc.next);
                 },
-                .jump, .crash, .runtime_error, .loop_continue, .loop_break => {},
+                .jump, .crash, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
             }
         }
     }

--- a/src/lir/trmc.zig
+++ b/src/lir/trmc.zig
@@ -421,8 +421,8 @@ const Detection = struct {
                         try work.append(gpa, .{ .stmt = branches[i].body, .edge = .{ .switch_branch = .{ .stmt = item.stmt, .index = @intCast(i) } } });
                     }
                 },
-                .jump, .ret, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| {
+                .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
+                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                     try work.append(gpa, .{ .stmt = s.next, .edge = .{ .stmt_next = item.stmt } });
                 },
             }
@@ -475,8 +475,8 @@ const Detection = struct {
                     try self.appendSharedSuccessor(work, branch.body);
                 }
             },
-            .jump, .ret, .crash, .expect_err, .runtime_error, .loop_continue, .loop_break => {},
-            inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| {
+            .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
+            inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                 try self.appendSharedSuccessor(work, s.next);
             },
         }
@@ -682,7 +682,7 @@ const Detection = struct {
             .switch_stmt => |s| c.chainContains(s.cond),
             .ret => |s| c.chainContains(s.value),
             .expect_err => |s| c.chainContains(s.message),
-            .jump, .crash, .runtime_error, .loop_continue, .loop_break, .join => false,
+            .jump, .crash, .runtime_error, .comptime_exhaustiveness_failed, .comptime_branch_taken, .loop_continue, .loop_break, .join => false,
         };
     }
 

--- a/src/postcheck/lambda_mono/ast.zig
+++ b/src/postcheck/lambda_mono/ast.zig
@@ -30,6 +30,8 @@ pub const FnId = Type.FnId;
 pub const LocalId = enum(u32) { _ };
 /// Owned string literal id shared with the lifted stage.
 pub const StringLiteralId = Lifted.StringLiteralId;
+/// Identifier for a compile-time-observed control-flow site.
+pub const ComptimeSiteId = enum(u32) { _ };
 
 /// Slice descriptor over one of the program side arrays.
 pub fn Span(comptime _: type) type {
@@ -100,6 +102,23 @@ pub const CallableValue = struct {
     payload: ?ExprId,
 };
 
+/// Source control-flow construct observed during compile-time finalization.
+pub const ComptimeSiteKind = Lifted.ComptimeSiteKind;
+
+/// Metadata for one compile-time-observed control-flow site.
+pub const ComptimeSite = struct {
+    kind: ComptimeSiteKind,
+    region: base.Region,
+    branch_regions: []const base.Region = &.{},
+};
+
+/// Expression wrapper that records a branch hit before evaluating `body`.
+pub const ComptimeBranchTaken = struct {
+    site: ComptimeSiteId,
+    branch_index: u32,
+    body: ExprId,
+};
+
 /// Typed Lambda Mono expression.
 pub const Expr = struct {
     ty: Type.TypeId,
@@ -129,6 +148,7 @@ pub const ExprData = union(enum) {
         bind: PatId,
         value: ExprId,
         rest: ExprId,
+        comptime_site: ?ComptimeSiteId = null,
     },
     direct_call: DirectCall,
     indirect_erased_call: ErasedCall,
@@ -154,6 +174,7 @@ pub const ExprData = union(enum) {
     match_: struct {
         scrutinee: ExprId,
         branches: Span(Branch),
+        comptime_site: ?ComptimeSiteId = null,
     },
     if_: struct {
         branches: Span(IfBranch),
@@ -174,6 +195,8 @@ pub const ExprData = union(enum) {
     },
     return_: ExprId,
     crash: StringLiteralId,
+    comptime_branch_taken: ComptimeBranchTaken,
+    comptime_exhaustiveness_failed: ComptimeSiteId,
     dbg: ExprId,
     expect_err: ExpectErrExpr,
     expect: ExprId,
@@ -241,6 +264,7 @@ pub const Stmt = union(enum) {
         pat: PatId,
         value: ExprId,
         recursive: bool = false,
+        comptime_site: ?ComptimeSiteId = null,
     },
     expr: ExprId,
     expect: ExprId,
@@ -309,6 +333,7 @@ pub const Program = struct {
     roots: std.ArrayList(Root),
     layout_requests: std.ArrayList(LayoutRequest),
     runtime_schema_requests: std.ArrayList(RuntimeSchemaRequest),
+    comptime_sites: std.ArrayList(ComptimeSite),
     /// Source file table for `SourceLoc.file` indices (copied from the lifted
     /// program; owned by this program).
     source_files: std.ArrayList([]const u8),
@@ -351,6 +376,7 @@ pub const Program = struct {
             .roots = .empty,
             .layout_requests = .empty,
             .runtime_schema_requests = .empty,
+            .comptime_sites = .empty,
             .source_files = .empty,
             .expr_locs = .empty,
             .stmt_locs = .empty,
@@ -368,6 +394,10 @@ pub const Program = struct {
         self.expr_locs.deinit(self.allocator);
         for (self.source_files.items) |file| self.allocator.free(file);
         self.source_files.deinit(self.allocator);
+        for (self.comptime_sites.items) |site| {
+            self.allocator.free(site.branch_regions);
+        }
+        self.comptime_sites.deinit(self.allocator);
         self.runtime_schema_requests.deinit(self.allocator);
         self.layout_requests.deinit(self.allocator);
         self.roots.deinit(self.allocator);
@@ -433,6 +463,27 @@ pub const Program = struct {
         try self.stmts.append(self.allocator, stmt);
         try self.stmt_locs.append(self.allocator, self.current_loc);
         return id;
+    }
+
+    pub fn addComptimeSite(
+        self: *Program,
+        kind: ComptimeSiteKind,
+        region: base.Region,
+        branch_regions: []const base.Region,
+    ) std.mem.Allocator.Error!ComptimeSiteId {
+        const owned_branch_regions = try self.allocator.dupe(base.Region, branch_regions);
+        errdefer self.allocator.free(owned_branch_regions);
+        const id: ComptimeSiteId = @enumFromInt(@as(u32, @intCast(self.comptime_sites.items.len)));
+        try self.comptime_sites.append(self.allocator, .{
+            .kind = kind,
+            .region = region,
+            .branch_regions = owned_branch_regions,
+        });
+        return id;
+    }
+
+    pub fn comptimeSite(self: *const Program, id: ComptimeSiteId) ComptimeSite {
+        return self.comptime_sites.items[@intFromEnum(id)];
     }
 
     pub fn addLocal(self: *Program, symbol: Common.Symbol, ty: Type.TypeId) std.mem.Allocator.Error!LocalId {

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -124,6 +124,7 @@ const Lowerer = struct {
     expr_map: []?Ast.ExprId,
     pat_map: []?Ast.PatId,
     stmt_map: []?Ast.StmtId,
+    comptime_site_map: []?Ast.ComptimeSiteId,
     fn_specs: std.ArrayList(FnSpec),
     fn_spec_map: std.HashMap(FnSpec, Ast.FnId, FnSpecContext, std.hash_map.default_max_load_percentage),
     fn_written: std.ArrayList(bool),
@@ -154,6 +155,10 @@ const Lowerer = struct {
         errdefer allocator.free(stmt_map);
         @memset(stmt_map, null);
 
+        const comptime_site_map = try allocator.alloc(?Ast.ComptimeSiteId, solved.lifted.comptime_sites.items.len);
+        errdefer allocator.free(comptime_site_map);
+        @memset(comptime_site_map, null);
+
         return .{
             .allocator = allocator,
             .solved = solved,
@@ -163,6 +168,7 @@ const Lowerer = struct {
             .expr_map = expr_map,
             .pat_map = pat_map,
             .stmt_map = stmt_map,
+            .comptime_site_map = comptime_site_map,
             .fn_specs = .empty,
             .fn_spec_map = std.HashMap(FnSpec, Ast.FnId, FnSpecContext, std.hash_map.default_max_load_percentage).initContext(allocator, .{}),
             .fn_written = .empty,
@@ -182,6 +188,7 @@ const Lowerer = struct {
         self.fn_specs.deinit(self.allocator);
         self.type_map.deinit();
         self.allocator.free(self.stmt_map);
+        self.allocator.free(self.comptime_site_map);
         self.allocator.free(self.pat_map);
         self.allocator.free(self.expr_map);
         self.allocator.free(self.local_map);
@@ -464,6 +471,7 @@ const Lowerer = struct {
                 .bind = try self.lowerPat(let_.bind),
                 .value = try self.lowerExpr(let_.value),
                 .rest = try self.lowerExpr(let_.rest),
+                .comptime_site = if (let_.comptime_site) |site| try self.lowerComptimeSite(site) else null,
             } },
             .lambda,
             .def_ref,
@@ -505,6 +513,7 @@ const Lowerer = struct {
                 break :blk .{ .match_ = .{
                     .scrutinee = try self.lowerExpr(match.scrutinee),
                     .branches = try self.lowerBranchSpan(match.branches),
+                    .comptime_site = if (match.comptime_site) |site| try self.lowerComptimeSite(site) else null,
                 } };
             },
             .if_ => |if_| .{ .if_ = .{
@@ -524,6 +533,12 @@ const Lowerer = struct {
             .continue_ => |continue_| .{ .continue_ = .{ .values = try self.lowerExprSpan(continue_.values) } },
             .return_ => |value| .{ .return_ = try self.lowerExpr(value) },
             .crash => |msg| .{ .crash = msg },
+            .comptime_branch_taken => |taken| .{ .comptime_branch_taken = .{
+                .site = try self.lowerComptimeSite(taken.site),
+                .branch_index = taken.branch_index,
+                .body = try self.lowerExpr(taken.body),
+            } },
+            .comptime_exhaustiveness_failed => |site| .{ .comptime_exhaustiveness_failed = try self.lowerComptimeSite(site) },
             .dbg => |child| .{ .dbg = try self.lowerExpr(child) },
             .expect_err => |expect_err| .{ .expect_err = .{
                 .msg = try self.lowerExpr(expect_err.msg),
@@ -545,6 +560,16 @@ const Lowerer = struct {
             } };
         }
         return .{ .local = try self.localFor(local, ty) };
+    }
+
+    fn lowerComptimeSite(self: *Lowerer, site: Lifted.ComptimeSiteId) Allocator.Error!Ast.ComptimeSiteId {
+        const index = @intFromEnum(site);
+        if (self.comptime_site_map[index]) |existing| return existing;
+
+        const source = self.solved.lifted.comptimeSite(site);
+        const lowered = try self.program.addComptimeSite(source.kind, source.region, source.branch_regions);
+        self.comptime_site_map[index] = lowered;
+        return lowered;
     }
 
     fn lowerCallableValue(self: *Lowerer, expr_id: Lifted.ExprId, fn_id: Lifted.FnId, ty: Type.TypeId) Allocator.Error!Ast.ExprData {
@@ -666,6 +691,7 @@ const Lowerer = struct {
                 break :blk .{ .match_ = .{
                     .scrutinee = callee,
                     .branches = try self.program.addBranchSpan(branches),
+                    .comptime_site = null,
                 } };
             },
             .erased_fn => .{ .indirect_erased_call = .{
@@ -744,6 +770,7 @@ const Lowerer = struct {
                 .pat = try self.lowerPat(let_.pat),
                 .value = try self.lowerExpr(let_.value),
                 .recursive = let_.recursive,
+                .comptime_site = if (let_.comptime_site) |site| try self.lowerComptimeSite(site) else null,
             } },
             .expr => |expr| .{ .expr = try self.lowerExpr(expr) },
             .expect => |expr| .{ .expect = try self.lowerExpr(expr) },

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -376,6 +376,7 @@ const Solver = struct {
             .dec_lit,
             .str_lit,
             .crash,
+            .comptime_exhaustiveness_failed,
             => {},
             .list => |items| {
                 const elem_ty = try self.listElem(expected);
@@ -520,6 +521,7 @@ const Solver = struct {
             .expect,
             => |child| _ = try self.inferExpr(child),
             .expect_err => |expect_err| _ = try self.inferExpr(expect_err.msg),
+            .comptime_branch_taken => |taken| _ = try self.expectExpr(taken.body, expected),
         }
         return self.program.types.root(expected);
     }

--- a/src/postcheck/lir_lower.zig
+++ b/src/postcheck/lir_lower.zig
@@ -124,12 +124,14 @@ const Lowerer = struct {
     runtime_schemas: RuntimeSchemaStore,
     fn_map: []LIR.LirProcSpecId,
     local_map: []?LIR.LocalId,
+    comptime_site_map: []?LIR.ComptimeSiteId,
     type_layouts: []?layout.Idx,
     const_plan_map: []?LirProgram.ConstPlanId,
     next_join_point: u32 = 0,
     loop_stack: std.ArrayList(LoopContext),
     current_ret_ty: ?Type.TypeId = null,
     current_proc_locals: ?*ProcLocalSet = null,
+    current_proc: ?LIR.LirProcSpecId = null,
 
     const ProcLocalSet = std.AutoArrayHashMapUnmanaged(u32, void);
 
@@ -152,6 +154,10 @@ const Lowerer = struct {
         errdefer allocator.free(local_map);
         @memset(local_map, null);
 
+        const comptime_site_map = try allocator.alloc(?LIR.ComptimeSiteId, program.comptime_sites.items.len);
+        errdefer allocator.free(comptime_site_map);
+        @memset(comptime_site_map, null);
+
         const type_layouts = try allocator.alloc(?layout.Idx, program.types.types.items.len);
         errdefer allocator.free(type_layouts);
         @memset(type_layouts, null);
@@ -167,6 +173,7 @@ const Lowerer = struct {
             .runtime_schemas = RuntimeSchemaStore.init(allocator),
             .fn_map = fn_map,
             .local_map = local_map,
+            .comptime_site_map = comptime_site_map,
             .type_layouts = type_layouts,
             .const_plan_map = const_plan_map,
             .loop_stack = .empty,
@@ -177,6 +184,7 @@ const Lowerer = struct {
         self.loop_stack.deinit(self.allocator);
         self.allocator.free(self.const_plan_map);
         self.allocator.free(self.type_layouts);
+        self.allocator.free(self.comptime_site_map);
         self.allocator.free(self.local_map);
         self.allocator.free(self.fn_map);
         self.runtime_schemas.deinit();
@@ -269,6 +277,20 @@ const Lowerer = struct {
         }
     }
 
+    fn lowerComptimeSite(self: *Lowerer, site: LambdaMono.ComptimeSiteId) Common.LowerError!LIR.ComptimeSiteId {
+        const index = @intFromEnum(site);
+        if (self.comptime_site_map[index]) |existing| return existing;
+        const proc = self.current_proc orelse Common.invariant("compile-time site reached LIR lowering outside a proc");
+        const source = self.program.comptimeSite(site);
+        const lowered = try self.result.addComptimeSite(switch (source.kind) {
+            .match => .match,
+            .destructure => .destructure,
+            .if_ => .if_,
+        }, source.region, proc, source.branch_regions);
+        self.comptime_site_map[index] = lowered;
+        return lowered;
+    }
+
     fn writeFrameLocals(self: *Lowerer, locals: *ProcLocalSet) Common.LowerError!LIR.LocalSpan {
         const raw_ids = locals.keys();
         const sorted = try self.allocator.alloc(LIR.LocalId, raw_ids.len);
@@ -291,14 +313,17 @@ const Lowerer = struct {
                 .roc => |body_expr| {
                     const saved_ret_ty = self.current_ret_ty;
                     const saved_proc_locals = self.current_proc_locals;
+                    const saved_current_proc = self.current_proc;
                     var proc_locals: ProcLocalSet = .{};
                     defer proc_locals.deinit(self.allocator);
 
                     self.current_proc_locals = &proc_locals;
                     self.current_ret_ty = fn_.ret;
+                    self.current_proc = proc_id;
                     defer {
                         self.current_ret_ty = saved_ret_ty;
                         self.current_proc_locals = saved_proc_locals;
+                        self.current_proc = saved_current_proc;
                     }
 
                     try self.noteLocalSpan(self.result.store.getProcSpec(proc_id).args);
@@ -728,7 +753,7 @@ const Lowerer = struct {
             .capture_access => |slot| try self.lowerCaptureAccessInto(target, slot, next),
             .tuple_access => |access| try self.lowerTupleAccessInto(target, access.tuple, access.elem_index, next),
             .structural_eq => |eq| try self.lowerStructuralEqInto(target, eq.lhs, eq.rhs, eq.negated, next),
-            .match_ => |match_| try self.lowerMatchInto(target, match_.scrutinee, match_.branches, next),
+            .match_ => |match_| try self.lowerMatchInto(target, match_.scrutinee, match_.branches, match_.comptime_site, next),
             .if_ => |if_| try self.lowerIfInto(target, if_.branches, if_.final_else, next),
             .block => |block| try self.lowerBlockInto(target, block.statements, block.final_expr, next),
             .loop_ => |loop| try self.lowerLoopInto(target, loop, next),
@@ -737,6 +762,14 @@ const Lowerer = struct {
             .return_ => |value| try self.lowerReturn(value),
             .crash => |msg| try self.result.store.addCFStmt(.{ .crash = .{
                 .msg = try self.result.store.insertString(self.program.stringLiteralText(msg)),
+            } }),
+            .comptime_branch_taken => |taken| try self.result.store.addCFStmt(.{ .comptime_branch_taken = .{
+                .site = try self.lowerComptimeSite(taken.site),
+                .branch_index = taken.branch_index,
+                .next = try self.lowerExprInto(target, taken.body, next),
+            } }),
+            .comptime_exhaustiveness_failed => |site| try self.result.store.addCFStmt(.{ .comptime_exhaustiveness_failed = .{
+                .site = try self.lowerComptimeSite(site),
             } }),
             .dbg => |child| blk: {
                 const after_dbg = try self.assignZst(target, next);
@@ -1090,7 +1123,7 @@ const Lowerer = struct {
         const rest = try self.lowerExprInto(target, let_.rest, next);
         const value_expr = self.expr(let_.value);
         const value_local = try self.addTemp(value_expr.ty);
-        const bind = try self.bindPatternOrCrash(let_.bind, value_local, rest);
+        const bind = try self.bindPatternOrCrash(let_.bind, value_local, rest, let_.comptime_site);
         return try self.lowerExprInto(value_local, let_.value, bind);
     }
 
@@ -1340,12 +1373,13 @@ const Lowerer = struct {
         target: LIR.LocalId,
         scrutinee: LambdaMono.ExprId,
         branches_span: LambdaMono.Span(LambdaMono.Branch),
+        comptime_site: ?LambdaMono.ComptimeSiteId,
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
         const scrutinee_local = try self.addTemp(self.expr(scrutinee).ty);
         const branches = self.program.branchSpan(branches_span);
         const done = self.freshJoinPointId();
-        const branch_chain = try self.lowerBranchChain(scrutinee_local, branches, target, done);
+        const branch_chain = try self.lowerBranchChain(scrutinee_local, branches, target, done, comptime_site);
         const remainder = try self.lowerExprInto(scrutinee_local, scrutinee, branch_chain);
         return try self.result.store.addCFStmt(.{ .join = .{
             .id = done,
@@ -1393,7 +1427,7 @@ const Lowerer = struct {
         return switch (self.program.stmts.items[@intFromEnum(stmt_id)]) {
             .let_ => |let_| blk: {
                 const value = try self.addTemp(self.expr(let_.value).ty);
-                const bind = try self.bindPatternOrCrash(let_.pat, value, next);
+                const bind = try self.bindPatternOrCrash(let_.pat, value, next, let_.comptime_site);
                 break :blk try self.lowerExprInto(value, let_.value, bind);
             },
             .expr => |expr_id| blk: {
@@ -1495,8 +1529,18 @@ const Lowerer = struct {
         join_id: LIR.JoinPointId,
     };
 
-    fn lowerBranchChain(self: *Lowerer, scrutinee: LIR.LocalId, branches: []const LambdaMono.Branch, target: LIR.LocalId, done: LIR.JoinPointId) Common.LowerError!LIR.CFStmtId {
-        var current = try self.result.store.addCFStmt(.{ .runtime_error = {} });
+    fn lowerBranchChain(
+        self: *Lowerer,
+        scrutinee: LIR.LocalId,
+        branches: []const LambdaMono.Branch,
+        target: LIR.LocalId,
+        done: LIR.JoinPointId,
+        comptime_site: ?LambdaMono.ComptimeSiteId,
+    ) Common.LowerError!LIR.CFStmtId {
+        var current = if (comptime_site) |site|
+            try self.result.store.addCFStmt(.{ .comptime_exhaustiveness_failed = .{ .site = try self.lowerComptimeSite(site) } })
+        else
+            try self.result.store.addCFStmt(.{ .runtime_error = {} });
         var i = branches.len;
         while (i > 0) {
             i -= 1;
@@ -1773,12 +1817,29 @@ const Lowerer = struct {
         };
     }
 
-    fn bindPatternOrCrash(self: *Lowerer, pat_id: LambdaMono.PatId, source: LIR.LocalId, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
+    fn bindPatternOrCrash(
+        self: *Lowerer,
+        pat_id: LambdaMono.PatId,
+        source: LIR.LocalId,
+        next: LIR.CFStmtId,
+        comptime_site: ?LambdaMono.ComptimeSiteId,
+    ) Common.LowerError!LIR.CFStmtId {
         if (!self.patternCanMiss(pat_id)) return try self.bindPattern(pat_id, source, next);
 
         const miss = PatternMiss{ .join_id = self.freshJoinPointId() };
-        const crash = try self.result.store.addCFStmt(.{ .runtime_error = {} });
-        const matched = try self.lowerPatternThen(pat_id, source, next, miss, next);
+        const crash = if (comptime_site) |site|
+            try self.result.store.addCFStmt(.{ .comptime_exhaustiveness_failed = .{ .site = try self.lowerComptimeSite(site) } })
+        else
+            try self.result.store.addCFStmt(.{ .runtime_error = {} });
+        const on_match = if (comptime_site) |site|
+            try self.result.store.addCFStmt(.{ .comptime_branch_taken = .{
+                .site = try self.lowerComptimeSite(site),
+                .branch_index = 0,
+                .next = next,
+            } })
+        else
+            next;
+        const matched = try self.lowerPatternThen(pat_id, source, on_match, miss, on_match);
         return try self.result.store.addCFStmt(.{ .join = .{
             .id = miss.join_id,
             .params = LIR.LocalSpan.empty(),

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -26,6 +26,8 @@ pub const LocalId = enum(u32) { _ };
 pub const LiftedFnId = enum(u32) { _ };
 /// Identifier for an owned string literal.
 pub const StringLiteralId = enum(u32) { _ };
+/// Identifier for a compile-time-observed control-flow site.
+pub const ComptimeSiteId = enum(u32) { _ };
 
 /// Owned string bytes plus the exact slice used by this literal.
 pub const StringLiteral = struct {
@@ -214,6 +216,7 @@ pub const LowLevelCall = struct {
 pub const MatchExpr = struct {
     scrutinee: ExprId,
     branches: Span(Branch),
+    comptime_site: ?ComptimeSiteId = null,
 };
 
 /// If expression with one or more conditional branches.
@@ -240,6 +243,27 @@ pub const ContinueExpr = struct {
     values: Span(ExprId),
 };
 
+/// Source control-flow construct observed during compile-time finalization.
+pub const ComptimeSiteKind = enum {
+    match,
+    destructure,
+    if_,
+};
+
+/// Metadata for one compile-time-observed control-flow site.
+pub const ComptimeSite = struct {
+    kind: ComptimeSiteKind,
+    region: base.Region,
+    branch_regions: []const base.Region = &.{},
+};
+
+/// Expression wrapper that records a branch hit before evaluating `body`.
+pub const ComptimeBranchTaken = struct {
+    site: ComptimeSiteId,
+    branch_index: u32,
+    body: ExprId,
+};
+
 /// Typed Monotype expression.
 pub const Expr = struct {
     ty: Type.TypeId,
@@ -264,6 +288,7 @@ pub const ExprData = union(enum) {
         bind: PatId,
         value: ExprId,
         rest: ExprId,
+        comptime_site: ?ComptimeSiteId = null,
     },
     lambda: LambdaExpr,
     def_ref: DefId,
@@ -293,6 +318,8 @@ pub const ExprData = union(enum) {
     continue_: ContinueExpr,
     return_: ExprId,
     crash: StringLiteralId,
+    comptime_branch_taken: ComptimeBranchTaken,
+    comptime_exhaustiveness_failed: ComptimeSiteId,
     dbg: ExprId,
     expect_err: ExpectErrExpr,
     expect: ExprId,
@@ -365,6 +392,7 @@ pub const Stmt = union(enum) {
         pat: PatId,
         value: ExprId,
         recursive: bool = false,
+        comptime_site: ?ComptimeSiteId = null,
     },
     expr: ExprId,
     expect: ExprId,
@@ -444,6 +472,7 @@ pub const Program = struct {
     roots: std.ArrayList(Root),
     layout_requests: std.ArrayList(LayoutRequest),
     runtime_schema_requests: std.ArrayList(RuntimeSchemaRequest),
+    comptime_sites: std.ArrayList(ComptimeSite),
     /// Source file table for `SourceLoc.file` indices (module display names,
     /// owned by this program).
     source_files: std.ArrayList([]const u8),
@@ -484,6 +513,7 @@ pub const Program = struct {
             .roots = .empty,
             .layout_requests = .empty,
             .runtime_schema_requests = .empty,
+            .comptime_sites = .empty,
             .source_files = .empty,
             .expr_locs = .empty,
             .stmt_locs = .empty,
@@ -501,6 +531,10 @@ pub const Program = struct {
         self.expr_locs.deinit(self.allocator);
         for (self.source_files.items) |file| self.allocator.free(file);
         self.source_files.deinit(self.allocator);
+        for (self.comptime_sites.items) |site| {
+            self.allocator.free(site.branch_regions);
+        }
+        self.comptime_sites.deinit(self.allocator);
         self.runtime_schema_requests.deinit(self.allocator);
         self.layout_requests.deinit(self.allocator);
         self.roots.deinit(self.allocator);
@@ -571,6 +605,27 @@ pub const Program = struct {
         try self.stmts.append(self.allocator, stmt);
         try self.stmt_locs.append(self.allocator, self.current_loc);
         return id;
+    }
+
+    pub fn addComptimeSite(
+        self: *Program,
+        kind: ComptimeSiteKind,
+        region: base.Region,
+        branch_regions: []const base.Region,
+    ) std.mem.Allocator.Error!ComptimeSiteId {
+        const owned_branch_regions = try self.allocator.dupe(base.Region, branch_regions);
+        errdefer self.allocator.free(owned_branch_regions);
+        const id: ComptimeSiteId = @enumFromInt(@as(u32, @intCast(self.comptime_sites.items.len)));
+        try self.comptime_sites.append(self.allocator, .{
+            .kind = kind,
+            .region = region,
+            .branch_regions = owned_branch_regions,
+        });
+        return id;
+    }
+
+    pub fn comptimeSite(self: *const Program, id: ComptimeSiteId) ComptimeSite {
+        return self.comptime_sites.items[@intFromEnum(id)];
     }
 
     pub fn addStringLiteral(self: *Program, text: []const u8) std.mem.Allocator.Error!StringLiteralId {

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -902,7 +902,7 @@ const Builder = struct {
         try body_ctx.constrainTypeToMono(template.checked_fn_root, mono_fn_ty);
         try body_ctx.constrainKnownType(root.checked_type, mono_fn_ty);
 
-        const lowered = try body_ctx.lowerExprAtType(wrapper.body_expr, mono_fn_ty);
+        const lowered = try body_ctx.lowerComptimeRootExprAtType(wrapper.body_expr, mono_fn_ty);
         try self.drainSpecRequests(graph);
         return lowered;
     }
@@ -2560,6 +2560,7 @@ const BodyContext = struct {
     owner_template: names.ProcTemplate,
     owner_context_fn_key: names.TypeDigest,
     current_fn_key: names.TypeDigest,
+    comptime_exhaustiveness_depth: u32,
     binders: BinderMap,
     local_proc_contexts: std.AutoHashMap(checked.PatternBinderId, names.TypeDigest),
     /// This specialization's type solver, shared by every instantiation
@@ -2630,6 +2631,7 @@ const BodyContext = struct {
             .owner_template = owner_template,
             .owner_context_fn_key = .{},
             .current_fn_key = .{},
+            .comptime_exhaustiveness_depth = 0,
             .binders = BinderMap.init(allocator),
             .local_proc_contexts = std.AutoHashMap(checked.PatternBinderId, names.TypeDigest).init(allocator),
             .graph = graph,
@@ -2667,6 +2669,7 @@ const BodyContext = struct {
         errdefer child.deinit();
         child.owner_context_fn_key = self.owner_context_fn_key;
         child.current_fn_key = current_fn_key;
+        child.comptime_exhaustiveness_depth = self.comptime_exhaustiveness_depth;
 
         var binder_iter = self.binders.iterator();
         while (binder_iter.next()) |entry| {
@@ -3029,7 +3032,7 @@ const BodyContext = struct {
                 }
                 return .{
                     .args = .empty(),
-                    .body = try self.lowerExprAtType(wrapper.body_expr, ret_ty),
+                    .body = try self.lowerComptimeRootExprAtType(wrapper.body_expr, ret_ty),
                     .ret = ret_ty,
                 };
             },
@@ -3082,6 +3085,9 @@ const BodyContext = struct {
         ret_ty: Type.TypeId,
     ) Allocator.Error!LoweredLambdaArgs {
         if (arg_tys.len != checked_args.len) Common.invariant("lambda arity differs from concrete function type");
+
+        const saved_comptime_depth = self.resetComptimeExhaustivenessDepth();
+        defer self.restoreComptimeExhaustivenessDepth(saved_comptime_depth);
 
         const args = try self.allocator.alloc(Ast.TypedLocal, checked_args.len);
         defer self.allocator.free(args);
@@ -3208,6 +3214,30 @@ const BodyContext = struct {
         }
         const ty = try self.lowerExprType(expr_id);
         return try self.lowerExprWithType(expr_id, ty);
+    }
+
+    fn lowerComptimeRootExprAtType(
+        self: *BodyContext,
+        expr_id: checked.CheckedExprId,
+        ty: Type.TypeId,
+    ) Allocator.Error!Ast.ExprId {
+        self.comptime_exhaustiveness_depth += 1;
+        defer self.comptime_exhaustiveness_depth -= 1;
+        return try self.lowerExprAtType(expr_id, ty);
+    }
+
+    fn resetComptimeExhaustivenessDepth(self: *BodyContext) u32 {
+        const saved = self.comptime_exhaustiveness_depth;
+        self.comptime_exhaustiveness_depth = 0;
+        return saved;
+    }
+
+    fn restoreComptimeExhaustivenessDepth(self: *BodyContext, saved: u32) void {
+        self.comptime_exhaustiveness_depth = saved;
+    }
+
+    fn inComptimeExhaustivenessContext(self: *const BodyContext) bool {
+        return self.comptime_exhaustiveness_depth != 0;
     }
 
     fn lowerExprWithType(
@@ -4018,7 +4048,7 @@ const BodyContext = struct {
         try body_ctx.constrainTypeToMono(entry_template.checked_fn_root, wrapper_fn_ty);
         try body_ctx.constrainTypeToMono(body.checked_type, ty);
 
-        const lowered = try body_ctx.lowerExprAtType(body.body_expr, ty);
+        const lowered = try body_ctx.lowerComptimeRootExprAtType(body.body_expr, ty);
         try self.builder.drainSpecRequests(graph);
         return lowered;
     }
@@ -6427,6 +6457,7 @@ const BodyContext = struct {
     }
 
     fn matchComptimeSite(self: *BodyContext, expr_id: checked.CheckedExprId, match: anytype) Allocator.Error!?Ast.ComptimeSiteId {
+        if (!self.inComptimeExhaustivenessContext()) return null;
         if (match.skip_exhaustiveness) return null;
         const branch_regions = try self.matchBranchRegions(match.branches);
         defer self.allocator.free(branch_regions);
@@ -6447,6 +6478,7 @@ const BodyContext = struct {
     }
 
     fn ifComptimeSite(self: *BodyContext, expr_id: checked.CheckedExprId, if_: anytype) Allocator.Error!?Ast.ComptimeSiteId {
+        if (!self.inComptimeExhaustivenessContext()) return null;
         if (!if_.warn_unused_branches) return null;
         const branch_regions = try self.ifBranchRegions(if_);
         defer self.allocator.free(branch_regions);
@@ -6997,7 +7029,7 @@ const BodyContext = struct {
         } }));
 
         const source_expr = try self.builder.localExpr(source_local, value_ty);
-        const comptime_site = if (self.patternCanMiss(pattern))
+        const comptime_site = if (self.inComptimeExhaustivenessContext() and self.patternCanMiss(pattern))
             try self.addComptimeSite(.destructure, statement.source_region, &.{})
         else
             null;
@@ -8024,7 +8056,7 @@ const BodyContext = struct {
     ) Allocator.Error!Ast.Stmt {
         const value = try self.lowerExpr(expr);
         const value_ty = self.builder.program.exprs.items[@intFromEnum(value)].ty;
-        const comptime_site = if (self.patternCanMiss(pattern))
+        const comptime_site = if (self.inComptimeExhaustivenessContext() and self.patternCanMiss(pattern))
             try self.addComptimeSite(.destructure, source_region, &.{})
         else
             null;

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -5462,10 +5462,11 @@ const BodyContext = struct {
     }
 
     fn lowerMatchExpr(self: *BodyContext, expr_id: checked.CheckedExprId, match: anytype, result_ty: Type.TypeId) Allocator.Error!Ast.ExprId {
+        const comptime_site = try self.matchComptimeSite(expr_id, match);
         const merge_binders = try self.stateMergeBinders(expr_id);
         defer self.allocator.free(merge_binders);
         if (merge_binders.len == 0) {
-            return try self.lowerMatchExprWithOutput(match, .{ .value = result_ty });
+            return try self.lowerMatchExprWithOutput(match, .{ .value = result_ty }, comptime_site);
         }
 
         const state_ty = try self.stateResultType(merge_binders, result_ty);
@@ -5473,7 +5474,7 @@ const BodyContext = struct {
             .result_ty = result_ty,
             .state_ty = state_ty,
             .merge_binders = merge_binders,
-        } });
+        } }, comptime_site);
 
         const pattern_items = try self.allocator.alloc(Ast.PatId, merge_binders.len + 1);
         defer self.allocator.free(pattern_items);
@@ -5496,12 +5497,17 @@ const BodyContext = struct {
         } } });
     }
 
-    fn lowerMatchExprWithOutput(self: *BodyContext, match: anytype, output: MatchOutput) Allocator.Error!Ast.ExprId {
+    fn lowerMatchExprWithOutput(
+        self: *BodyContext,
+        match: anytype,
+        output: MatchOutput,
+        comptime_site: ?Ast.ComptimeSiteId,
+    ) Allocator.Error!Ast.ExprId {
         const output_ty = self.matchOutputType(output);
         if (!self.matchContainsListPattern(match)) {
             return try self.builder.program.addExpr(.{
                 .ty = output_ty,
-                .data = try self.lowerMatch(match, output),
+                .data = try self.lowerMatch(match, output, comptime_site),
             });
         }
 
@@ -5509,7 +5515,7 @@ const BodyContext = struct {
         const scrutinee_ty = self.builder.program.exprs.items[@intFromEnum(scrutinee)].ty;
         const scrutinee_local = try self.builder.program.addLocal(self.builder.symbols.fresh(), scrutinee_ty);
         const scrutinee_expr = try self.builder.localExpr(scrutinee_local, scrutinee_ty);
-        const rest = try self.lowerListPatternMatchAlternatives(scrutinee_expr, scrutinee_ty, match.branches, output);
+        const rest = try self.lowerListPatternMatchAlternatives(scrutinee_expr, scrutinee_ty, match.branches, output, comptime_site);
         return try self.builder.program.addExpr(.{ .ty = output_ty, .data = .{ .let_ = .{
             .bind = try self.builder.bindPat(scrutinee_local, scrutinee_ty),
             .value = scrutinee,
@@ -5578,6 +5584,44 @@ const BodyContext = struct {
         };
     }
 
+    fn patternCanMiss(self: *BodyContext, pattern_id: checked.CheckedPatternId) bool {
+        const pattern = self.view.bodies.patterns[@intFromEnum(pattern_id)];
+        return switch (pattern.data) {
+            .assign,
+            .underscore,
+            => false,
+            .as => |as| self.patternCanMiss(as.pattern),
+            .nominal => |nominal| self.patternCanMiss(nominal.backing_pattern),
+            .tuple => |items| blk: {
+                for (items) |child| {
+                    if (self.patternCanMiss(child)) break :blk true;
+                }
+                break :blk false;
+            },
+            .record_destructure => |destructs| blk: {
+                for (destructs) |destruct| {
+                    const child = switch (destruct.kind) {
+                        .required, .sub_pattern, .rest => |child_pattern| child_pattern,
+                    };
+                    if (self.patternCanMiss(child)) break :blk true;
+                }
+                break :blk false;
+            },
+            .applied_tag,
+            .list,
+            .num_literal,
+            .small_dec_literal,
+            .dec_literal,
+            .frac_f32_literal,
+            .frac_f64_literal,
+            .str_literal,
+            => true,
+            .pending,
+            .runtime_error,
+            => false,
+        };
+    }
+
     fn recordDestructsNeedExplicitRest(self: *BodyContext, destructs: []const checked.CheckedRecordDestruct) bool {
         for (destructs) |destruct| {
             switch (destruct.kind) {
@@ -5594,18 +5638,25 @@ const BodyContext = struct {
         scrutinee_ty: Type.TypeId,
         branches: []const checked.CheckedMatchBranch,
         output: MatchOutput,
+        comptime_site: ?Ast.ComptimeSiteId,
     ) Allocator.Error!Ast.ExprId {
         const output_ty = self.matchOutputType(output);
-        const msg = try self.builder.program.addStringLiteral("non-exhaustive checked match reached Monotype");
-        var fallback = try self.builder.program.addExpr(.{ .ty = output_ty, .data = .{ .crash = msg } });
+        var fallback = if (comptime_site) |site|
+            try self.comptimeExhaustivenessFailedExpr(output_ty, site)
+        else blk: {
+            const msg = try self.builder.program.addStringLiteral("non-exhaustive checked match reached Monotype");
+            break :blk try self.builder.program.addExpr(.{ .ty = output_ty, .data = .{ .crash = msg } });
+        };
 
         var branch_index = branches.len;
+        var alternative_index = branchCount(branches);
         while (branch_index > 0) {
             branch_index -= 1;
             const branch = branches[branch_index];
             var pattern_index = branch.patterns.len;
             while (pattern_index > 0) {
                 pattern_index -= 1;
+                alternative_index -= 1;
                 fallback = try self.lowerListPatternMatchAlternative(
                     scrutinee,
                     scrutinee_ty,
@@ -5614,6 +5665,8 @@ const BodyContext = struct {
                     branch.value,
                     fallback,
                     output,
+                    comptime_site,
+                    alternative_index,
                 );
             }
         }
@@ -5630,6 +5683,8 @@ const BodyContext = struct {
         body: checked.CheckedExprId,
         fallback: Ast.ExprId,
         output: MatchOutput,
+        comptime_site: ?Ast.ComptimeSiteId,
+        alternative_index: usize,
     ) Allocator.Error!Ast.ExprId {
         const output_ty = self.matchOutputType(output);
         const checked_pattern = self.view.bodies.patterns[@intFromEnum(pattern.pattern)];
@@ -5645,7 +5700,11 @@ const BodyContext = struct {
                 try branch_ctx.preRegisterPatternBinders(pattern.pattern, scrutinee_ty);
                 try branch_ctx.applyAlternativeBinderRemaps(pattern.binder_remaps);
 
-                var body_lowered = try branch_ctx.lowerMatchBranchBody(body, output);
+                var body_lowered = try branch_ctx.wrapComptimeBranch(
+                    comptime_site,
+                    alternative_index,
+                    try branch_ctx.lowerMatchBranchBody(body, output),
+                );
                 if (guard) |guard_expr| {
                     const guard_cond = try branch_ctx.lowerExpr(guard_expr);
                     body_lowered = try branch_ctx.builder.ifExpr(guard_cond, body_lowered, fallback, output_ty);
@@ -5661,7 +5720,11 @@ const BodyContext = struct {
                 try branch_ctx.saveMatchPatternBinders(pattern, &saved);
                 defer branch_ctx.restoreBinders(saved.items);
                 try branch_ctx.applyAlternativeBinderRemaps(pattern.binder_remaps);
-                const branch_body = try branch_ctx.lowerMatchBranchBody(body, output);
+                const branch_body = try branch_ctx.wrapComptimeBranch(
+                    comptime_site,
+                    alternative_index,
+                    try branch_ctx.lowerMatchBranchBody(body, output),
+                );
                 if (guard) |guard_expr| {
                     const guard_cond = try branch_ctx.lowerExpr(guard_expr);
                     return try branch_ctx.builder.ifExpr(guard_cond, branch_body, fallback, output_ty);
@@ -5687,7 +5750,11 @@ const BodyContext = struct {
 
                 try branch_ctx.applyAlternativeBinderRemaps(pattern.binder_remaps);
 
-                var body_lowered = try branch_ctx.lowerMatchBranchBody(body, output);
+                var body_lowered = try branch_ctx.wrapComptimeBranch(
+                    comptime_site,
+                    alternative_index,
+                    try branch_ctx.lowerMatchBranchBody(body, output),
+                );
                 if (guard) |guard_expr| {
                     const guard_cond = try branch_ctx.lowerExpr(guard_expr);
                     body_lowered = try branch_ctx.builder.ifExpr(guard_cond, body_lowered, fallback, output_ty);
@@ -6328,7 +6395,75 @@ const BodyContext = struct {
         });
     }
 
-    fn lowerMatch(self: *BodyContext, match: anytype, output: MatchOutput) Allocator.Error!Ast.ExprData {
+    fn comptimeExhaustivenessFailedExpr(self: *BodyContext, ty: Type.TypeId, site: Ast.ComptimeSiteId) Allocator.Error!Ast.ExprId {
+        return try self.builder.program.addExpr(.{
+            .ty = ty,
+            .data = .{ .comptime_exhaustiveness_failed = site },
+        });
+    }
+
+    fn addComptimeSite(
+        self: *BodyContext,
+        kind: Ast.ComptimeSiteKind,
+        region: base.Region,
+        branch_regions: []const base.Region,
+    ) Allocator.Error!Ast.ComptimeSiteId {
+        return try self.builder.program.addComptimeSite(kind, region, branch_regions);
+    }
+
+    fn wrapComptimeBranch(
+        self: *BodyContext,
+        site: ?Ast.ComptimeSiteId,
+        branch_index: usize,
+        body: Ast.ExprId,
+    ) Allocator.Error!Ast.ExprId {
+        const actual_site = site orelse return body;
+        const ty = self.builder.program.exprs.items[@intFromEnum(body)].ty;
+        return try self.builder.program.addExpr(.{ .ty = ty, .data = .{ .comptime_branch_taken = .{
+            .site = actual_site,
+            .branch_index = @intCast(branch_index),
+            .body = body,
+        } } });
+    }
+
+    fn matchComptimeSite(self: *BodyContext, expr_id: checked.CheckedExprId, match: anytype) Allocator.Error!?Ast.ComptimeSiteId {
+        if (match.skip_exhaustiveness) return null;
+        const branch_regions = try self.matchBranchRegions(match.branches);
+        defer self.allocator.free(branch_regions);
+        const expr = self.view.bodies.exprs[@intFromEnum(expr_id)];
+        return try self.addComptimeSite(.match, expr.source_region, branch_regions);
+    }
+
+    fn matchBranchRegions(self: *BodyContext, branches: []const checked.CheckedMatchBranch) Allocator.Error![]base.Region {
+        const regions = try self.allocator.alloc(base.Region, branchCount(branches));
+        var index: usize = 0;
+        for (branches) |branch| {
+            for (branch.patterns) |pattern| {
+                regions[index] = self.view.bodies.patterns[@intFromEnum(pattern.pattern)].source_region;
+                index += 1;
+            }
+        }
+        return regions;
+    }
+
+    fn ifComptimeSite(self: *BodyContext, expr_id: checked.CheckedExprId, if_: anytype) Allocator.Error!?Ast.ComptimeSiteId {
+        if (!if_.warn_unused_branches) return null;
+        const branch_regions = try self.ifBranchRegions(if_);
+        defer self.allocator.free(branch_regions);
+        const expr = self.view.bodies.exprs[@intFromEnum(expr_id)];
+        return try self.addComptimeSite(.if_, expr.source_region, branch_regions);
+    }
+
+    fn ifBranchRegions(self: *BodyContext, if_: anytype) Allocator.Error![]base.Region {
+        const regions = try self.allocator.alloc(base.Region, if_.branches.len + 1);
+        for (if_.branches, 0..) |branch, index| {
+            regions[index] = self.view.bodies.exprs[@intFromEnum(branch.cond)].source_region;
+        }
+        regions[if_.branches.len] = self.view.bodies.exprs[@intFromEnum(if_.final_else)].source_region;
+        return regions;
+    }
+
+    fn lowerMatch(self: *BodyContext, match: anytype, output: MatchOutput, comptime_site: ?Ast.ComptimeSiteId) Allocator.Error!Ast.ExprData {
         const scrutinee_ty = try self.matchScrutineeType(match);
         const scrutinee = try self.lowerExprAtType(match.cond, scrutinee_ty);
         const branches = try self.allocator.alloc(Ast.Branch, branchCount(match.branches));
@@ -6347,7 +6482,11 @@ const BodyContext = struct {
                 try branch_ctx.applyAlternativeBinderRemaps(pattern.binder_remaps);
                 const user_guard = if (branch.guard) |guard_expr| try branch_ctx.lowerExpr(guard_expr) else null;
                 const guard = try branch_ctx.conjoinPatternLiteralGuards(user_guard);
-                const body = try branch_ctx.lowerMatchBranchBody(branch.value, output);
+                const body = try branch_ctx.wrapComptimeBranch(
+                    comptime_site,
+                    index,
+                    try branch_ctx.lowerMatchBranchBody(branch.value, output),
+                );
                 branches[index] = .{
                     .pat = pat,
                     .guard = guard,
@@ -6359,6 +6498,7 @@ const BodyContext = struct {
         return .{ .match_ = .{
             .scrutinee = scrutinee,
             .branches = try self.builder.program.addBranchSpan(branches),
+            .comptime_site = comptime_site,
         } };
     }
 
@@ -6465,20 +6605,21 @@ const BodyContext = struct {
         if_: anytype,
         result_ty: Type.TypeId,
     ) Allocator.Error!Ast.ExprId {
+        const comptime_site = try self.ifComptimeSite(expr_id, if_);
         const merge_binders = try self.stateMergeBinders(expr_id);
         defer self.allocator.free(merge_binders);
 
         if (merge_binders.len == 0) {
             return try self.builder.program.addExpr(.{
                 .ty = result_ty,
-                .data = try self.lowerIf(if_, result_ty, result_ty, &.{}),
+                .data = try self.lowerIf(if_, result_ty, result_ty, &.{}, comptime_site),
             });
         }
 
         const state_ty = try self.stateResultType(merge_binders, result_ty);
         const state_expr = try self.builder.program.addExpr(.{
             .ty = state_ty,
-            .data = try self.lowerIf(if_, result_ty, state_ty, merge_binders),
+            .data = try self.lowerIf(if_, result_ty, state_ty, merge_binders, comptime_site),
         });
 
         const pattern_items = try self.allocator.alloc(Ast.PatId, merge_binders.len + 1);
@@ -6552,6 +6693,7 @@ const BodyContext = struct {
         result_ty: Type.TypeId,
         branch_ty: Type.TypeId,
         merge_binders: []const MergeBinder,
+        comptime_site: ?Ast.ComptimeSiteId,
     ) Allocator.Error!Ast.ExprData {
         const branches = try self.allocator.alloc(Ast.IfBranch, if_.branches.len);
         defer self.allocator.free(branches);
@@ -6561,14 +6703,22 @@ const BodyContext = struct {
             defer branch_ctx.deinit();
             branches[i] = .{
                 .cond = cond,
-                .body = try branch_ctx.lowerIfBranchBody(branch.body, result_ty, branch_ty, merge_binders),
+                .body = try branch_ctx.wrapComptimeBranch(
+                    comptime_site,
+                    i,
+                    try branch_ctx.lowerIfBranchBody(branch.body, result_ty, branch_ty, merge_binders),
+                ),
             };
         }
         var else_ctx = try self.childContext(self.current_fn_key);
         defer else_ctx.deinit();
         return .{ .if_ = .{
             .branches = try self.builder.program.addIfBranchSpan(branches),
-            .final_else = try else_ctx.lowerIfBranchBody(if_.final_else, result_ty, branch_ty, merge_binders),
+            .final_else = try else_ctx.wrapComptimeBranch(
+                comptime_site,
+                if_.branches.len,
+                try else_ctx.lowerIfBranchBody(if_.final_else, result_ty, branch_ty, merge_binders),
+            ),
         } };
     }
 
@@ -6589,6 +6739,7 @@ const BodyContext = struct {
         if_: anytype,
         state_ty: Type.TypeId,
         merge_binders: []const MergeBinder,
+        comptime_site: ?Ast.ComptimeSiteId,
     ) Allocator.Error!Ast.ExprData {
         const branches = try self.allocator.alloc(Ast.IfBranch, if_.branches.len);
         defer self.allocator.free(branches);
@@ -6598,14 +6749,22 @@ const BodyContext = struct {
             defer branch_ctx.deinit();
             branches[i] = .{
                 .cond = cond,
-                .body = try branch_ctx.lowerBodyThenStateOnly(branch.body, state_ty, merge_binders),
+                .body = try branch_ctx.wrapComptimeBranch(
+                    comptime_site,
+                    i,
+                    try branch_ctx.lowerBodyThenStateOnly(branch.body, state_ty, merge_binders),
+                ),
             };
         }
         var else_ctx = try self.childContext(self.current_fn_key);
         defer else_ctx.deinit();
         return .{ .if_ = .{
             .branches = try self.builder.program.addIfBranchSpan(branches),
-            .final_else = try else_ctx.lowerBodyThenStateOnly(if_.final_else, state_ty, merge_binders),
+            .final_else = try else_ctx.wrapComptimeBranch(
+                comptime_site,
+                if_.branches.len,
+                try else_ctx.lowerBodyThenStateOnly(if_.final_else, state_ty, merge_binders),
+            ),
         } };
     }
 
@@ -6838,7 +6997,11 @@ const BodyContext = struct {
         } }));
 
         const source_expr = try self.builder.localExpr(source_local, value_ty);
-        try self.appendRecordRestPatternStatements(source_expr, value_ty, destructs, lowered);
+        const comptime_site = if (self.patternCanMiss(pattern))
+            try self.addComptimeSite(.destructure, statement.source_region, &.{})
+        else
+            null;
+        try self.appendRecordRestPatternStatements(source_expr, value_ty, destructs, lowered, comptime_site);
         return true;
     }
 
@@ -6848,6 +7011,7 @@ const BodyContext = struct {
         value_ty: Type.TypeId,
         destructs: []const checked.CheckedRecordDestruct,
         lowered: *LoweredStatements,
+        comptime_site: ?Ast.ComptimeSiteId,
     ) Allocator.Error!void {
         for (destructs) |destruct| {
             switch (destruct.kind) {
@@ -6864,6 +7028,7 @@ const BodyContext = struct {
                     try lowered.append(self.allocator, try self.builder.program.addStmt(.{ .let_ = .{
                         .pat = try self.lowerPatternAtType(child, field_ty),
                         .value = field_value,
+                        .comptime_site = if (self.patternCanMiss(child)) comptime_site else null,
                     } }));
                 },
                 .rest => |child| {
@@ -6873,6 +7038,7 @@ const BodyContext = struct {
                     try lowered.append(self.allocator, try self.builder.program.addStmt(.{ .let_ = .{
                         .pat = try self.lowerPatternAtType(child, rest_ty),
                         .value = rest_value,
+                        .comptime_site = if (self.patternCanMiss(child)) comptime_site else null,
                     } }));
                 },
             }
@@ -7799,10 +7965,10 @@ const BodyContext = struct {
                     const unit_ty = try self.unitType();
                     break :blk .{ .expr = try self.builder.program.addExpr(.{ .ty = unit_ty, .data = .unit }) };
                 }
-                break :blk try self.lowerPatternStatement(decl.pattern, decl.expr);
+                break :blk try self.lowerPatternStatement(decl.pattern, decl.expr, statement.source_region);
             },
-            .var_ => |decl| try self.lowerPatternStatement(decl.pattern, decl.expr),
-            .reassign => |decl| try self.lowerPatternStatement(decl.pattern, decl.expr),
+            .var_ => |decl| try self.lowerPatternStatement(decl.pattern, decl.expr, statement.source_region),
+            .reassign => |decl| try self.lowerPatternStatement(decl.pattern, decl.expr, statement.source_region),
             .crash => |msg| .{ .crash = try self.lowerStringLiteral(msg) },
             .dbg => |child| .{ .dbg = try self.lowerDbgMessage(child) },
             .expr => |child| try self.lowerExprStatement(child),
@@ -7854,19 +8020,29 @@ const BodyContext = struct {
         self: *BodyContext,
         pattern: checked.CheckedPatternId,
         expr: checked.CheckedExprId,
+        source_region: base.Region,
     ) Allocator.Error!Ast.Stmt {
         const value = try self.lowerExpr(expr);
         const value_ty = self.builder.program.exprs.items[@intFromEnum(value)].ty;
+        const comptime_site = if (self.patternCanMiss(pattern))
+            try self.addComptimeSite(.destructure, source_region, &.{})
+        else
+            null;
         if (!self.patternNeedsExplicitBinding(pattern)) {
             return .{ .let_ = .{
                 .pat = try self.lowerPatternAtType(pattern, value_ty),
                 .value = value,
+                .comptime_site = comptime_site,
             } };
         }
 
         const unit_ty = try self.unitType();
-        const unit = try self.builder.program.addExpr(.{ .ty = unit_ty, .data = .unit });
-        const miss = try self.runtimeCrashExpr(unit_ty, "pattern match failed");
+        var unit = try self.builder.program.addExpr(.{ .ty = unit_ty, .data = .unit });
+        unit = try self.wrapComptimeBranch(comptime_site, 0, unit);
+        const miss = if (comptime_site) |site|
+            try self.comptimeExhaustivenessFailedExpr(unit_ty, site)
+        else
+            try self.runtimeCrashExpr(unit_ty, "pattern match failed");
         return .{ .expr = try self.lowerMaterializedPatternValueThen(
             pattern,
             value,
@@ -7906,12 +8082,12 @@ const BodyContext = struct {
         const state_expr = switch (checked_expr.data) {
             .if_ => |if_| try self.builder.program.addExpr(.{
                 .ty = state_ty,
-                .data = try self.lowerIfStateOnly(if_, state_ty, merge_binders),
+                .data = try self.lowerIfStateOnly(if_, state_ty, merge_binders, try self.ifComptimeSite(expr_id, if_)),
             }),
             .match_ => |match| try self.lowerMatchExprWithOutput(match, .{ .state_only = .{
                 .state_ty = state_ty,
                 .merge_binders = merge_binders,
-            } }),
+            } }, try self.matchComptimeSite(expr_id, match)),
             else => try self.lowerBodyThenStateOnly(expr_id, state_ty, merge_binders),
         };
         return .{ .let_ = .{

--- a/src/postcheck/monotype_lifted/ast.zig
+++ b/src/postcheck/monotype_lifted/ast.zig
@@ -32,6 +32,12 @@ pub const Local = Mono.Local;
 pub const TypedLocal = Mono.TypedLocal;
 /// Owned string literal id shared with Monotype IR.
 pub const StringLiteralId = Mono.StringLiteralId;
+/// Compile-time site id shared with Monotype IR.
+pub const ComptimeSiteId = Mono.ComptimeSiteId;
+/// Compile-time site kind shared with Monotype IR.
+pub const ComptimeSiteKind = Mono.ComptimeSiteKind;
+/// Compile-time site metadata shared with Monotype IR.
+pub const ComptimeSite = Mono.ComptimeSite;
 /// Record field expression entry.
 pub const FieldExpr = Mono.FieldExpr;
 /// Record destructuring field pattern.
@@ -125,6 +131,7 @@ pub const Program = struct {
     roots: std.ArrayList(Root),
     layout_requests: std.ArrayList(LayoutRequest),
     runtime_schema_requests: std.ArrayList(RuntimeSchemaRequest),
+    comptime_sites: std.ArrayList(ComptimeSite),
     /// Source file table for `SourceLoc.file` indices (moved from Monotype).
     source_files: std.ArrayList([]const u8),
     /// Source location per expression, parallel to `exprs`.
@@ -160,6 +167,7 @@ pub const Program = struct {
         expr_locs: std.ArrayList(base.SourceLoc),
         stmt_locs: std.ArrayList(base.SourceLoc),
         local_names: std.ArrayList([]const u8),
+        comptime_sites: std.ArrayList(ComptimeSite),
         next_symbol: u32,
     ) Program {
         return .{
@@ -185,6 +193,7 @@ pub const Program = struct {
             .roots = .empty,
             .layout_requests = .empty,
             .runtime_schema_requests = .empty,
+            .comptime_sites = comptime_sites,
             .source_files = source_files,
             .expr_locs = expr_locs,
             .stmt_locs = stmt_locs,
@@ -202,6 +211,10 @@ pub const Program = struct {
         self.expr_locs.deinit(self.allocator);
         for (self.source_files.items) |file| self.allocator.free(file);
         self.source_files.deinit(self.allocator);
+        for (self.comptime_sites.items) |site| {
+            self.allocator.free(site.branch_regions);
+        }
+        self.comptime_sites.deinit(self.allocator);
         self.runtime_schema_requests.deinit(self.allocator);
         self.layout_requests.deinit(self.allocator);
         self.roots.deinit(self.allocator);
@@ -267,6 +280,10 @@ pub const Program = struct {
         try self.stmts.append(self.allocator, stmt_);
         try self.stmt_locs.append(self.allocator, self.current_loc);
         return id;
+    }
+
+    pub fn comptimeSite(self: *const Program, id: ComptimeSiteId) ComptimeSite {
+        return self.comptime_sites.items[@intFromEnum(id)];
     }
 
     pub fn addLocal(self: *Program, symbol: Common.Symbol, ty: Type.TypeId) std.mem.Allocator.Error!LocalId {

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -53,6 +53,8 @@ pub fn run(
     owned.proc_debug_names = Mono.ProcDebugNameMap.init(allocator);
     var runtime_schema_requests = owned.runtime_schema_requests;
     owned.runtime_schema_requests = .empty;
+    var comptime_sites = owned.comptime_sites;
+    owned.comptime_sites = .empty;
     var source_files = owned.source_files;
     owned.source_files = .empty;
     var expr_locs = owned.expr_locs;
@@ -84,6 +86,7 @@ pub fn run(
         expr_locs,
         stmt_locs,
         local_names,
+        comptime_sites,
         owned.next_symbol,
     );
     name_store = undefined;
@@ -106,6 +109,7 @@ pub fn run(
     expr_locs = undefined;
     stmt_locs = undefined;
     local_names = undefined;
+    comptime_sites = undefined;
     program.runtime_schema_requests = runtime_schema_requests;
     runtime_schema_requests = undefined;
     errdefer program.deinit();
@@ -408,6 +412,7 @@ const Lifter = struct {
             .dec_lit,
             .str_lit,
             .crash,
+            .comptime_exhaustiveness_failed,
             .fn_ref,
             => {},
             .list,
@@ -421,6 +426,7 @@ const Lifter = struct {
             .expect,
             => |child| try self.rewriteExpr(child),
             .expect_err => |expect_err| try self.rewriteExpr(expect_err.msg),
+            .comptime_branch_taken => |taken| try self.rewriteExpr(taken.body),
             .let_ => |let_| {
                 try self.rewriteExpr(let_.value);
                 try self.rewriteExpr(let_.rest);
@@ -657,6 +663,7 @@ const CaptureSet = struct {
             .fn_def,
             .fn_ref,
             .crash,
+            .comptime_exhaustiveness_failed,
             => {},
             .list,
             .tuple,
@@ -669,6 +676,7 @@ const CaptureSet = struct {
             .expect,
             => |child| try self.collectExpr(child, bound),
             .expect_err => |expect_err| try self.collectExpr(expect_err.msg, bound),
+            .comptime_branch_taken => |taken| try self.collectExpr(taken.body, bound),
             .let_ => |let_| {
                 try self.collectExpr(let_.value, bound);
                 var added = std.ArrayList(Mono.LocalId).empty;

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -483,6 +483,7 @@ const Pass = struct {
             .str_lit,
             .fn_ref,
             .crash,
+            .comptime_exhaustiveness_failed,
             => {},
             .list,
             .tuple,
@@ -495,6 +496,7 @@ const Pass = struct {
             .expect,
             => |child| try self.markArgUsesInExpr(fn_id, child, changed),
             .expect_err => |expect_err| try self.markArgUsesInExpr(fn_id, expect_err.msg, changed),
+            .comptime_branch_taken => |taken| try self.markArgUsesInExpr(fn_id, taken.body, changed),
             .let_ => |let_| {
                 try self.markArgUsesInExpr(fn_id, let_.value, changed);
                 try self.markArgUsesInExpr(fn_id, let_.rest, changed);
@@ -602,6 +604,7 @@ const Pass = struct {
             .str_lit,
             .fn_ref,
             .crash,
+            .comptime_exhaustiveness_failed,
             => {},
             .list,
             .tuple,
@@ -614,6 +617,7 @@ const Pass = struct {
             .expect,
             => |child| try self.collectCallPatternsInExpr(owner, child),
             .expect_err => |expect_err| try self.collectCallPatternsInExpr(owner, expect_err.msg),
+            .comptime_branch_taken => |taken| try self.collectCallPatternsInExpr(owner, taken.body),
             .let_ => |let_| {
                 try self.collectCallPatternsInExpr(owner, let_.value);
                 try self.collectCallPatternsInExpr(owner, let_.rest);
@@ -823,6 +827,7 @@ const Pass = struct {
             .str_lit,
             .fn_ref,
             .crash,
+            .comptime_exhaustiveness_failed,
             => {},
             .list,
             .tuple,
@@ -835,6 +840,7 @@ const Pass = struct {
             .expect,
             => |child| try self.rewriteCallsInExpr(child, done),
             .expect_err => |expect_err| try self.rewriteCallsInExpr(expect_err.msg, done),
+            .comptime_branch_taken => |taken| try self.rewriteCallsInExpr(taken.body, done),
             .let_ => |let_| {
                 try self.rewriteCallsInExpr(let_.value, done);
                 try self.rewriteCallsInExpr(let_.rest, done);
@@ -1384,6 +1390,7 @@ const Cloner = struct {
                 return .{ .expr = try self.addExpr(.{ .ty = expr.ty, .data = .{ .match_ = .{
                     .scrutinee = scrutinee_expr,
                     .branches = try self.cloneBranchSpan(match.branches),
+                    .comptime_site = match.comptime_site,
                 } } }) };
             },
             .call_value => |call| {
@@ -1444,6 +1451,8 @@ const Cloner = struct {
                 const value = itemFromValue(tuple, access.elem_index) orelse break :blk false;
                 break :blk (try self.pass.shapeFromValue(value)) != null;
             },
+            .comptime_branch_taken => |taken| try self.exprHasKnownShape(taken.body),
+            .comptime_exhaustiveness_failed => false,
             else => false,
         };
     }
@@ -1568,6 +1577,12 @@ const Cloner = struct {
             .continue_ => |continue_| try self.cloneContinue(continue_),
             .return_ => |value| .{ .return_ = try self.cloneExpr(value) },
             .crash => |msg| .{ .crash = msg },
+            .comptime_branch_taken => |taken| .{ .comptime_branch_taken = .{
+                .site = taken.site,
+                .branch_index = taken.branch_index,
+                .body = try self.cloneExpr(taken.body),
+            } },
+            .comptime_exhaustiveness_failed => |site| .{ .comptime_exhaustiveness_failed = site },
             .dbg => |child| .{ .dbg = try self.cloneExpr(child) },
             .expect_err => |expect_err| .{ .expect_err = .{
                 .msg = try self.cloneExpr(expect_err.msg),
@@ -1593,6 +1608,7 @@ const Cloner = struct {
             .bind = try self.clonePat(let_.bind),
             .value = value_expr,
             .rest = try self.cloneExpr(let_.rest),
+            .comptime_site = let_.comptime_site,
         } } }) };
     }
 
@@ -1614,6 +1630,7 @@ const Cloner = struct {
             .bind = try self.clonePat(let_.bind),
             .value = value_expr,
             .rest = rest,
+            .comptime_site = let_.comptime_site,
         } };
     }
 
@@ -1642,6 +1659,7 @@ const Cloner = struct {
         return .{ .match_ = .{
             .scrutinee = match.scrutinee,
             .branches = try self.pass.program.addBranchSpan(rewritten),
+            .comptime_site = match.comptime_site,
         } };
     }
 
@@ -1700,6 +1718,7 @@ const Cloner = struct {
         const expr = self.pass.program.exprs.items[@intFromEnum(expr_id)];
         return switch (expr.data) {
             .crash => |msg| try self.addExpr(.{ .ty = ty, .data = .{ .crash = msg } }),
+            .comptime_exhaustiveness_failed => |site| try self.addExpr(.{ .ty = ty, .data = .{ .comptime_exhaustiveness_failed = site } }),
             .return_ => |value| try self.addExpr(.{ .ty = ty, .data = .{ .return_ = try self.cloneExpr(value) } }),
             else => null,
         };
@@ -2016,6 +2035,7 @@ const Cloner = struct {
         return try self.addExpr(.{ .ty = ty, .data = .{ .match_ = .{
             .scrutinee = scrutinee_expr,
             .branches = try self.cloneBranchSpan(match.branches),
+            .comptime_site = match.comptime_site,
         } } });
     }
 
@@ -2340,6 +2360,7 @@ const Cloner = struct {
         return .{ .expr = try self.addExpr(.{ .ty = ty, .data = .{ .match_ = .{
             .scrutinee = inner_match.scrutinee,
             .branches = try self.pass.program.addBranchSpan(rewritten),
+            .comptime_site = inner_match.comptime_site,
         } } }) };
     }
 
@@ -2585,6 +2606,7 @@ const Cloner = struct {
                     .pat = try self.clonePat(let_.pat),
                     .value = value_expr,
                     .recursive = let_.recursive,
+                    .comptime_site = let_.comptime_site,
                 } };
             },
             .expr => |expr| .{ .expr = try self.cloneExpr(expr) },
@@ -2982,6 +3004,7 @@ fn localUseCountInExpr(program: *const Ast.Program, local: Ast.LocalId, expr_id:
         .str_lit,
         .fn_ref,
         .crash,
+        .comptime_exhaustiveness_failed,
         => 0,
         .list,
         .tuple,
@@ -2998,6 +3021,7 @@ fn localUseCountInExpr(program: *const Ast.Program, local: Ast.LocalId, expr_id:
         .expect,
         => |child| localUseCountInExpr(program, local, child),
         .expect_err => |expect_err| localUseCountInExpr(program, local, expect_err.msg),
+        .comptime_branch_taken => |taken| localUseCountInExpr(program, local, taken.body),
         .let_ => |let_| localUseCountInExpr(program, local, let_.value) + localUseCountInExpr(program, local, let_.rest),
         .lambda,
         .def_ref,
@@ -3088,7 +3112,7 @@ fn scanLocalUseInExpr(program: *const Ast.Program, local: Ast.LocalId, expr_id: 
         .str_lit,
         .fn_ref,
         => {},
-        .crash => scan.seen_effect = true,
+        .crash, .comptime_exhaustiveness_failed => scan.seen_effect = true,
         .list,
         .tuple,
         => |items| scanLocalUseInExprSpan(program, local, items, scan),
@@ -3111,6 +3135,7 @@ fn scanLocalUseInExpr(program: *const Ast.Program, local: Ast.LocalId, expr_id: 
             scanLocalUseInExpr(program, local, expect_err.msg, scan);
             scan.seen_effect = true;
         },
+        .comptime_branch_taken => |taken| scanLocalUseInExpr(program, local, taken.body, scan),
         .let_ => |let_| {
             scanLocalUseInExpr(program, local, let_.value, scan);
             scanLocalUseInExpr(program, local, let_.rest, scan);

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -266,11 +266,13 @@ const Lowerer = struct {
     const_plan_map: std.AutoHashMap(Type.TypeId, LirProgram.ConstPlanId),
     symbols: Common.SymbolGen,
     local_map: []?LIR.LocalId,
+    comptime_site_map: []?LIR.ComptimeSiteId,
     next_join_point: u32 = 0,
     loop_stack: std.ArrayList(LoopContext),
     current_ret_ty: ?Type.TypeId = null,
     current_proc_locals: ?*ProcLocalSet = null,
     current_fn: ?Type.FnId = null,
+    current_proc: ?LIR.LirProcSpecId = null,
     erased_capture_ptr_ty: ?Type.TypeId = null,
 
     const ProcLocalSet = std.AutoArrayHashMapUnmanaged(u32, void);
@@ -291,6 +293,10 @@ const Lowerer = struct {
         const local_map = try allocator.alloc(?LIR.LocalId, solved.lifted.locals.items.len);
         errdefer allocator.free(local_map);
         @memset(local_map, null);
+
+        const comptime_site_map = try allocator.alloc(?LIR.ComptimeSiteId, solved.lifted.comptime_sites.items.len);
+        errdefer allocator.free(comptime_site_map);
+        @memset(comptime_site_map, null);
 
         return .{
             .allocator = allocator,
@@ -317,6 +323,7 @@ const Lowerer = struct {
             .const_plan_map = std.AutoHashMap(Type.TypeId, LirProgram.ConstPlanId).init(allocator),
             .symbols = .{ .next = solved.lifted.next_symbol },
             .local_map = local_map,
+            .comptime_site_map = comptime_site_map,
             .loop_stack = .empty,
         };
     }
@@ -324,6 +331,7 @@ const Lowerer = struct {
     fn deinit(self: *Lowerer) void {
         self.folded_map_matches.deinit(self.allocator);
         self.loop_stack.deinit(self.allocator);
+        self.allocator.free(self.comptime_site_map);
         self.allocator.free(self.local_map);
         self.const_plan_map.deinit();
         self.type_layouts.deinit();
@@ -350,6 +358,7 @@ const Lowerer = struct {
         };
         self.folded_map_matches.deinit(self.allocator);
         self.loop_stack.deinit(self.allocator);
+        self.allocator.free(self.comptime_site_map);
         self.allocator.free(self.local_map);
         self.const_plan_map.deinit();
         self.type_layouts.deinit();
@@ -368,6 +377,7 @@ const Lowerer = struct {
         self.result = undefined;
         self.runtime_schemas = RuntimeSchemaStore.init(self.allocator);
         self.local_map = &.{};
+        self.comptime_site_map = &.{};
         self.loop_stack = .empty;
         self.folded_map_matches = .empty;
         return output;
@@ -466,16 +476,19 @@ const Lowerer = struct {
                 const saved_ret_ty = self.current_ret_ty;
                 const saved_proc_locals = self.current_proc_locals;
                 const saved_current_fn = self.current_fn;
+                const saved_current_proc = self.current_proc;
                 var proc_locals: ProcLocalSet = .{};
                 defer proc_locals.deinit(self.allocator);
 
                 self.current_proc_locals = &proc_locals;
                 self.current_ret_ty = entry.ret;
                 self.current_fn = fn_id;
+                self.current_proc = proc_id;
                 defer {
                     self.current_ret_ty = saved_ret_ty;
                     self.current_proc_locals = saved_proc_locals;
                     self.current_fn = saved_current_fn;
+                    self.current_proc = saved_current_proc;
                 }
 
                 try self.noteLocalSpan(self.result.store.getProcSpec(proc_id).args);
@@ -909,6 +922,20 @@ const Lowerer = struct {
         for (self.result.store.getLocalSpan(span)) |local| {
             try self.noteLocal(local);
         }
+    }
+
+    fn lowerComptimeSite(self: *Lowerer, site: Lifted.ComptimeSiteId) Common.LowerError!LIR.ComptimeSiteId {
+        const index = @intFromEnum(site);
+        if (self.comptime_site_map[index]) |existing| return existing;
+        const proc = self.current_proc orelse Common.invariant("compile-time site reached direct LIR lowering outside a proc");
+        const source = self.solved.lifted.comptimeSite(site);
+        const lowered = try self.result.addComptimeSite(switch (source.kind) {
+            .match => .match,
+            .destructure => .destructure,
+            .if_ => .if_,
+        }, source.region, proc, source.branch_regions);
+        self.comptime_site_map[index] = lowered;
+        return lowered;
     }
 
     fn writeFrameLocals(self: *Lowerer, locals: *ProcLocalSet) Common.LowerError!LIR.LocalSpan {
@@ -1456,7 +1483,7 @@ const Lowerer = struct {
             .field_access => |field| try self.lowerFieldAccessInto(target, field.receiver, field.field, next),
             .tuple_access => |access| try self.lowerTupleAccessInto(target, access.tuple, access.elem_index, next),
             .structural_eq => |eq| try self.lowerStructuralEqInto(target, eq.lhs, eq.rhs, eq.negated, next),
-            .match_ => |match_| try self.lowerMatchInto(target, match_.scrutinee, match_.branches, next),
+            .match_ => |match_| try self.lowerMatchInto(target, match_.scrutinee, match_.branches, match_.comptime_site, next),
             .if_ => |if_| try self.lowerIfInto(target, if_.branches, if_.final_else, next),
             .block => |block| try self.lowerBlockInto(target, block.statements, block.final_expr, next),
             .loop_ => |loop| try self.lowerLoopInto(target, loop, next),
@@ -1465,6 +1492,14 @@ const Lowerer = struct {
             .return_ => |value| try self.lowerReturn(value),
             .crash => |msg| try self.result.store.addCFStmt(.{ .crash = .{
                 .msg = try self.result.store.insertString(self.stringLiteralText(msg)),
+            } }),
+            .comptime_branch_taken => |taken| try self.result.store.addCFStmt(.{ .comptime_branch_taken = .{
+                .site = try self.lowerComptimeSite(taken.site),
+                .branch_index = taken.branch_index,
+                .next = try self.lowerExprInto(target, taken.body, next),
+            } }),
+            .comptime_exhaustiveness_failed => |site| try self.result.store.addCFStmt(.{ .comptime_exhaustiveness_failed = .{
+                .site = try self.lowerComptimeSite(site),
             } }),
             .dbg => |child| blk: {
                 const after_dbg = try self.assignZst(target, next);
@@ -1844,7 +1879,7 @@ const Lowerer = struct {
     fn lowerLetInto(self: *Lowerer, target: LIR.LocalId, let_: anytype, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
         const rest = try self.lowerExprInto(target, let_.rest, next);
         const value_local = try self.addTemp(try self.lowerExprTy(let_.value));
-        const bind = try self.bindPatternOrCrash(let_.bind, value_local, rest);
+        const bind = try self.bindPatternOrCrash(let_.bind, value_local, rest, let_.comptime_site);
         return try self.lowerExprInto(value_local, let_.value, bind);
     }
 
@@ -2376,13 +2411,14 @@ const Lowerer = struct {
         target: LIR.LocalId,
         scrutinee: Lifted.ExprId,
         branches_span: Lifted.Span(Lifted.Branch),
+        comptime_site: ?Lifted.ComptimeSiteId,
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
         if (try self.foldListMapCanReuseMatch(target, scrutinee, branches_span, next)) |folded| return folded;
         const scrutinee_local = try self.addTemp(try self.lowerExprTy(scrutinee));
         const branches = self.solved.lifted.branchSpan(branches_span);
         const done = self.freshJoinPointId();
-        const branch_chain = try self.lowerBranchChain(scrutinee_local, branches, target, done);
+        const branch_chain = try self.lowerBranchChain(scrutinee_local, branches, target, done, comptime_site);
         const remainder = try self.lowerExprInto(scrutinee_local, scrutinee, branch_chain);
         return try self.result.store.addCFStmt(.{ .join = .{
             .id = done,
@@ -2460,7 +2496,7 @@ const Lowerer = struct {
         return switch (self.solved.lifted.stmts.items[@intFromEnum(stmt_id)]) {
             .let_ => |let_| blk: {
                 const value = try self.addTemp(try self.lowerExprTy(let_.value));
-                const bind = try self.bindPatternOrCrash(let_.pat, value, next);
+                const bind = try self.bindPatternOrCrash(let_.pat, value, next, let_.comptime_site);
                 break :blk try self.lowerExprInto(value, let_.value, bind);
             },
             .expr => |expr_id| blk: {
@@ -2562,8 +2598,18 @@ const Lowerer = struct {
         join_id: LIR.JoinPointId,
     };
 
-    fn lowerBranchChain(self: *Lowerer, scrutinee: LIR.LocalId, branches: []const Lifted.Branch, target: LIR.LocalId, done: LIR.JoinPointId) Common.LowerError!LIR.CFStmtId {
-        var current = try self.result.store.addCFStmt(.{ .runtime_error = {} });
+    fn lowerBranchChain(
+        self: *Lowerer,
+        scrutinee: LIR.LocalId,
+        branches: []const Lifted.Branch,
+        target: LIR.LocalId,
+        done: LIR.JoinPointId,
+        comptime_site: ?Lifted.ComptimeSiteId,
+    ) Common.LowerError!LIR.CFStmtId {
+        var current = if (comptime_site) |site|
+            try self.result.store.addCFStmt(.{ .comptime_exhaustiveness_failed = .{ .site = try self.lowerComptimeSite(site) } })
+        else
+            try self.result.store.addCFStmt(.{ .runtime_error = {} });
         var i = branches.len;
         while (i > 0) {
             i -= 1;
@@ -2793,12 +2839,29 @@ const Lowerer = struct {
         };
     }
 
-    fn bindPatternOrCrash(self: *Lowerer, pat_id: Lifted.PatId, source: LIR.LocalId, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
+    fn bindPatternOrCrash(
+        self: *Lowerer,
+        pat_id: Lifted.PatId,
+        source: LIR.LocalId,
+        next: LIR.CFStmtId,
+        comptime_site: ?Lifted.ComptimeSiteId,
+    ) Common.LowerError!LIR.CFStmtId {
         if (!self.patternCanMiss(pat_id)) return try self.bindPattern(pat_id, source, next);
 
         const miss = PatternMiss{ .join_id = self.freshJoinPointId() };
-        const crash = try self.result.store.addCFStmt(.{ .runtime_error = {} });
-        const matched = try self.lowerPatternThen(pat_id, source, next, miss, next);
+        const crash = if (comptime_site) |site|
+            try self.result.store.addCFStmt(.{ .comptime_exhaustiveness_failed = .{ .site = try self.lowerComptimeSite(site) } })
+        else
+            try self.result.store.addCFStmt(.{ .runtime_error = {} });
+        const on_match = if (comptime_site) |site|
+            try self.result.store.addCFStmt(.{ .comptime_branch_taken = .{
+                .site = try self.lowerComptimeSite(site),
+                .branch_index = 0,
+                .next = next,
+            } })
+        else
+            next;
+        const matched = try self.lowerPatternThen(pat_id, source, on_match, miss, on_match);
         return try self.result.store.addCFStmt(.{ .join = .{
             .id = miss.join_id,
             .params = LIR.LocalSpan.empty(),
@@ -3871,6 +3934,7 @@ fn cloneLiftedProgram(allocator: std.mem.Allocator, program: *const Lifted.Progr
         .roots = try cloneArrayList(Lifted.Root, allocator, &program.roots),
         .layout_requests = try cloneArrayList(Lifted.LayoutRequest, allocator, &program.layout_requests),
         .runtime_schema_requests = try cloneArrayList(Lifted.RuntimeSchemaRequest, allocator, &program.runtime_schema_requests),
+        .comptime_sites = try cloneComptimeSites(allocator, &program.comptime_sites),
         .source_files = source_files,
         .expr_locs = try cloneArrayList(base.SourceLoc, allocator, &program.expr_locs),
         .stmt_locs = try cloneArrayList(base.SourceLoc, allocator, &program.stmt_locs),
@@ -3890,6 +3954,23 @@ fn cloneLiftedProgram(allocator: std.mem.Allocator, program: *const Lifted.Progr
         },
         .current_loc = program.current_loc,
     };
+}
+
+fn cloneComptimeSites(allocator: std.mem.Allocator, source: *const std.ArrayList(Lifted.ComptimeSite)) std.mem.Allocator.Error!std.ArrayList(Lifted.ComptimeSite) {
+    var cloned: std.ArrayList(Lifted.ComptimeSite) = .empty;
+    errdefer {
+        for (cloned.items) |site| allocator.free(site.branch_regions);
+        cloned.deinit(allocator);
+    }
+    try cloned.ensureTotalCapacityPrecise(allocator, source.items.len);
+    for (source.items) |site| {
+        cloned.appendAssumeCapacity(.{
+            .kind = site.kind,
+            .region = site.region,
+            .branch_regions = try allocator.dupe(base.Region, site.branch_regions),
+        });
+    }
+    return cloned;
 }
 
 fn cloneProcDebugNameMap(allocator: std.mem.Allocator, source: *const Lifted.ProcDebugNameMap) std.mem.Allocator.Error!Lifted.ProcDebugNameMap {

--- a/src/snapshot_tool/main.zig
+++ b/src/snapshot_tool/main.zig
@@ -482,6 +482,8 @@ fn generateAllReports(
         try reports.append(report);
     }
 
+    _ = try solver.problems.flushPendingStaticExhaustiveness(allocator);
+
     // Generate type checking reports
     for (solver.problems.problems.items) |problem| {
         const empty_modules: []const *ModuleEnv = &.{};

--- a/test/serialization_size_check.zig
+++ b/test/serialization_size_check.zig
@@ -31,8 +31,8 @@ const expected_safelist_u8_size = 24;
 const expected_safelist_u32_size = 24;
 const expected_safemultilist_teststruct_size = 24;
 const expected_safemultilist_node_size = 24;
-const expected_moduleenv_size = 1712; // Platform-independent size
-const expected_nodestore_size = 384; // Platform-independent size
+const expected_moduleenv_size = 1736; // Platform-independent size
+const expected_nodestore_size = 408; // Platform-independent size
 
 // Compile-time assertions - build will fail if sizes don't match expected values
 comptime {

--- a/test/snapshots/file/underscore_type_decl.md
+++ b/test/snapshots/file/underscore_type_decl.md
@@ -12,67 +12,9 @@ Pair2(_, y) = Pair(0, 1)
 Pair3(_, _) = Pair(0, 1)
 ~~~
 # EXPECTED
-NON-EXHAUSTIVE DESTRUCTURE - underscore_type_decl.md:3:1:3:12
-NON-EXHAUSTIVE DESTRUCTURE - underscore_type_decl.md:4:1:4:12
-NON-EXHAUSTIVE DESTRUCTURE - underscore_type_decl.md:5:1:5:12
+NIL
 # PROBLEMS
-**NON-EXHAUSTIVE DESTRUCTURE**
-This destructuring pattern doesn't cover all possible cases:
-**underscore_type_decl.md:3:1:3:12:**
-```roc
-Pair1(x, _) = Pair(0, 1)
-```
-^^^^^^^^^^^
-
-The value being destructured has type:
-        _[Pair(a, b), Pair1([], []), ..]
-  where [
-    a.from_numeral : Numeral -> Try(a, [InvalidNumeral(Str)]),
-    b.from_numeral : Numeral -> Try(b, [InvalidNumeral(Str)]),
-  ]_
-
-Missing patterns:
-        _
-
-
-**NON-EXHAUSTIVE DESTRUCTURE**
-This destructuring pattern doesn't cover all possible cases:
-**underscore_type_decl.md:4:1:4:12:**
-```roc
-Pair2(_, y) = Pair(0, 1)
-```
-^^^^^^^^^^^
-
-The value being destructured has type:
-        _[Pair(a, b), Pair2([], []), ..]
-  where [
-    a.from_numeral : Numeral -> Try(a, [InvalidNumeral(Str)]),
-    b.from_numeral : Numeral -> Try(b, [InvalidNumeral(Str)]),
-  ]_
-
-Missing patterns:
-        _
-
-
-**NON-EXHAUSTIVE DESTRUCTURE**
-This destructuring pattern doesn't cover all possible cases:
-**underscore_type_decl.md:5:1:5:12:**
-```roc
-Pair3(_, _) = Pair(0, 1)
-```
-^^^^^^^^^^^
-
-The value being destructured has type:
-        _[Pair(a, b), Pair3([], []), ..]
-  where [
-    a.from_numeral : Numeral -> Try(a, [InvalidNumeral(Str)]),
-    b.from_numeral : Numeral -> Try(b, [InvalidNumeral(Str)]),
-  ]_
-
-Missing patterns:
-        _
-
-
+NIL
 # TOKENS
 ~~~zig
 KwImport,UpperIdent,KwExposing,OpenSquare,UpperIdent,CloseSquare,

--- a/test/static-data-host/app.roc
+++ b/test/static-data-host/app.roc
@@ -85,11 +85,8 @@ assembled_strings = {
 intermediate_final : Str
 intermediate_final = {
     intermediate = "INTERMEDIATE_ONLY_LEFT_SHOULD_NOT_BE_EMITTED".concat("_INTERMEDIATE_ONLY_RIGHT_SHOULD_NOT_BE_EMITTED")
-    if intermediate.count_utf8_bytes() > 0 {
-        "final readonly string after comptime branch"
-    } else {
-        "unreachable readonly string after comptime branch"
-    }
+    empty_suffix = intermediate.drop_prefix(intermediate)
+    "final readonly string after comptime branch".concat(empty_suffix)
 }
 
 static_slices : (Str, Str)


### PR DESCRIPTION
This adds empirical exhaustiveness handling for compile-time-evaluated matches and destructures. Compile-time-only sites defer the static diagnostic until finalization, report the normal non-exhaustive problem only if the generated miss path actually executes, and record branch coverage so untaken compile-time match alternatives and source if branches can be reported as unused.

The implementation carries explicit comptime site metadata through postcheck and LIR, teaches the interpreter and finalizer to report empirical failures and unused branches, and keeps runtime-reachable code on the normal static path. Synthetic short-circuit conditionals are marked explicitly so they do not produce dead-branch warnings.