### PR TITLE
Lower LIR from explicit roots

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -2699,13 +2699,16 @@ pub fn buildLirImageWithCoordinator(
     const relation_artifacts = try coord.collectRelationArtifactViews(ctx.gpa, root_artifact);
     defer ctx.gpa.free(relation_artifacts);
 
+    const lir_roots = try lir.CheckedPipeline.selectPlatformEntrypointRoots(ctx.gpa, root_artifact.root_requests.runtime_requests);
+    defer ctx.gpa.free(lir_roots);
+
     const lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
         shm_allocator,
         .{
             .root = check.CheckedArtifact.loweringViewWithRelations(root_artifact, relation_artifacts),
             .imports = imported_artifacts,
         },
-        .{ .requests = root_artifact.root_requests.runtime_requests },
+        .{ .requests = lir_roots },
         .{
             .target_usize = base.target.TargetUsize.native,
             .debug_effects = debug_effects,
@@ -5148,13 +5151,16 @@ fn rocBuildLlvm(ctx: *CliCtx, args: cli_args.BuildArgs) anyerror!void {
         },
     };
 
+    const build_roots = try lir.CheckedPipeline.selectPlatformExportRoots(ctx.gpa, root_artifact.root_requests.runtime_requests);
+    defer ctx.gpa.free(build_roots);
+
     var lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
         ctx.gpa,
         .{
             .root = check.CheckedArtifact.loweringViewWithRelations(root_artifact, relation_artifacts),
             .imports = imported_artifacts,
         },
-        .{ .requests = root_artifact.root_requests.runtime_requests },
+        .{ .requests = build_roots, .include_static_data_exports = true },
         .{
             .target_usize = target_usize,
             .debug_effects = debugEffectsForOpt(args.opt),
@@ -5466,13 +5472,16 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) anyerror!void {
         },
     };
 
+    const build_roots = try lir.CheckedPipeline.selectPlatformExportRoots(ctx.gpa, root_artifact.root_requests.runtime_requests);
+    defer ctx.gpa.free(build_roots);
+
     var lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
         ctx.gpa,
         .{
             .root = check.CheckedArtifact.loweringViewWithRelations(root_artifact, relation_artifacts),
             .imports = imported_artifacts,
         },
-        .{ .requests = root_artifact.root_requests.runtime_requests },
+        .{ .requests = build_roots, .include_static_data_exports = true },
         .{
             .target_usize = target_usize,
             .inline_mode = postCheckInlineModeForOpt(args.opt),
@@ -5789,13 +5798,16 @@ fn rocBuildEmbedded(ctx: *CliCtx, args: cli_args.BuildArgs) anyerror!void {
     const shm_allocator = shm.allocator();
     const image_header = try shm_allocator.create(lir.LirImage.Header);
 
+    const lir_roots = try lir.CheckedPipeline.selectPlatformEntrypointRoots(ctx.gpa, root_artifact.root_requests.runtime_requests);
+    defer ctx.gpa.free(lir_roots);
+
     const lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
         shm_allocator,
         .{
             .root = check.CheckedArtifact.loweringViewWithRelations(root_artifact, relation_artifacts),
             .imports = imported_artifacts,
         },
-        .{ .requests = root_artifact.root_requests.runtime_requests },
+        .{ .requests = lir_roots },
         .{
             .target_usize = base.target.TargetUsize.native,
         },

--- a/src/compile/README.md
+++ b/src/compile/README.md
@@ -67,6 +67,7 @@ if (coord.hasUserErrors()) return error.CompilationFailed;
 const root = coord.executableRootCheckedArtifact();
 const imports = try coord.collectImportedArtifactViews(arena, root);
 const relations = try coord.collectRelationArtifactViews(arena, root);
+const lir_roots = try lir.CheckedPipeline.selectPlatformEntrypointRoots(arena, root.root_requests.runtime_requests);
 
 const lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
     runtime_alloc,
@@ -74,7 +75,7 @@ const lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
         .root = check.CheckedArtifact.loweringViewWithRelations(root, relations),
         .imports = imports,
     },
-    .{ .requests = root.root_requests.runtime_requests },
+    .{ .requests = lir_roots },
     .{ .target_usize = base.target.TargetUsize.native },
 );
 

--- a/src/compile/test/embedding_smoke.zig
+++ b/src/compile/test/embedding_smoke.zig
@@ -108,13 +108,15 @@ test "embedding API: full canonical sequence on simple_success app" {
     const imports = try coord.collectImportedArtifactViews(arena, root);
     const relations = try coord.collectRelationArtifactViews(arena, root);
 
+    const lir_roots = try lir.CheckedPipeline.selectPlatformEntrypointRoots(arena, root.root_requests.runtime_requests);
+
     const lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
         runtime_alloc,
         .{
             .root = check.CheckedArtifact.loweringViewWithRelations(root, relations),
             .imports = imports,
         },
-        .{ .requests = root.root_requests.runtime_requests },
+        .{ .requests = lir_roots },
         .{ .target_usize = base.target.TargetUsize.native },
     );
 

--- a/src/compile/test/issue_9614_test.zig
+++ b/src/compile/test/issue_9614_test.zig
@@ -125,13 +125,16 @@ test "issue 9614: default app list fold_until result tag narrowing lowers to LIR
     const imports = try coord.collectImportedArtifactViews(arena, root);
     const relations = try coord.collectRelationArtifactViews(arena, root);
 
+    const lir_roots = try lir.CheckedPipeline.selectPlatformEntrypointRoots(gpa, root.root_requests.runtime_requests);
+    defer gpa.free(lir_roots);
+
     var lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
         gpa,
         .{
             .root = check.CheckedArtifact.loweringViewWithRelations(root, relations),
             .imports = imports,
         },
-        .{ .requests = root.root_requests.runtime_requests },
+        .{ .requests = lir_roots },
         .{ .target_usize = base.target.TargetUsize.native },
     );
     defer lowered.deinit();

--- a/src/echo_platform/runner.zig
+++ b/src/echo_platform/runner.zig
@@ -193,13 +193,19 @@ pub fn runEcho(opts: RunOptions) anyerror!u8 {
     };
     defer allocator.free(relation_views);
 
+    const lir_roots = lir.CheckedPipeline.selectPlatformEntrypointRoots(allocator, root_artifact.root_requests.runtime_requests) catch |err| {
+        diag.step("selectPlatformEntrypointRoots", err);
+        return err;
+    };
+    defer allocator.free(lir_roots);
+
     var lowered = lir.CheckedPipeline.lowerCheckedModulesToLir(
         allocator,
         .{
             .root = check.CheckedArtifact.loweringViewWithRelations(root_artifact, relation_views),
             .imports = import_views,
         },
-        .{ .requests = root_artifact.root_requests.runtime_requests },
+        .{ .requests = lir_roots },
         .{ .target_usize = opts.target_usize },
     ) catch |err| {
         diag.step("lowerCheckedModulesToLir", err);

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -1600,6 +1600,34 @@ test "LIR statements and procs carry resolved source locations" {
     try std.testing.expect(found_mul3);
 }
 
+test "referenced but uncalled function does not materialize a proc" {
+    const allocator = std.testing.allocator;
+
+    const source =
+        \\module [main]
+        \\
+        \\unused : U64 -> U64
+        \\unused = |n| n + 1
+        \\
+        \\main : U64
+        \\main = {
+        \\    _fn = unused
+        \\    0
+        \\}
+    ;
+
+    var lowered_source = try lowerModuleWithProcDebugNames(allocator, source, .none, true);
+    defer lowered_source.deinit(allocator);
+
+    const store = &lowered_source.lowered.lir_result.store;
+    var found_unused = false;
+    for (0..store.proc_specs.items.len) |i| {
+        const name = store.procDebugName(@enumFromInt(i)) orelse continue;
+        if (std.mem.eql(u8, name, "unused")) found_unused = true;
+    }
+    try std.testing.expect(!found_unused);
+}
+
 test "LIR statements carry source locations under optimizing inline mode" {
     const allocator = std.testing.allocator;
 

--- a/src/glue/glue.zig
+++ b/src/glue/glue.zig
@@ -303,13 +303,18 @@ fn rocGlueInner(gpa: Allocator, stderr: *std.Io.Writer, stdout: *std.Io.Writer, 
     };
     defer gpa.free(relation_artifacts);
 
+    const lir_roots = lir.CheckedPipeline.selectPlatformEntrypointRoots(gpa, root_artifact.root_requests.runtime_requests) catch {
+        return error.OutOfMemory;
+    };
+    defer gpa.free(lir_roots);
+
     var lowered = lir.CheckedPipeline.lowerCheckedModulesToLir(
         gpa,
         .{
             .root = CheckedArtifact.loweringViewWithRelations(root_artifact, relation_artifacts),
             .imports = imported_artifacts,
         },
-        .{ .requests = root_artifact.root_requests.runtime_requests },
+        .{ .requests = lir_roots },
         .{
             .target_usize = target_usize,
         },

--- a/src/lir/checked_pipeline.zig
+++ b/src/lir/checked_pipeline.zig
@@ -34,6 +34,7 @@ pub const CheckedModuleSet = struct {
 pub const RootRequestSet = struct {
     requests: []const checked.RootRequest = &.{},
     layout_requests: []const checked.CheckedTypeId = &.{},
+    include_static_data_exports: bool = false,
 };
 
 /// Target settings and checked module state for the checked-to-LIR pipeline.
@@ -186,10 +187,13 @@ pub fn lowerCheckedModulesToLir(
 ) LowerResourceError!LoweredProgram {
     try verifyCheckedBoundary(modules, target);
 
-    const layout_requests = try collectLayoutRequests(allocator, modules.root.module, roots.layout_requests);
+    const layout_requests = try collectLayoutRequests(allocator, modules.root.module, roots.layout_requests, roots.include_static_data_exports);
     defer allocator.free(layout_requests);
     const static_data_requests = switch (target.checked_module_state) {
-        .complete => try collectStaticDataRequests(allocator, modules.root.module),
+        .complete => if (roots.include_static_data_exports)
+            try collectStaticDataRequests(allocator, modules.root.module)
+        else
+            try allocator.alloc(postcheck.Common.StaticDataRequest, 0),
         .checking_finalization => try allocator.alloc(postcheck.Common.StaticDataRequest, 0),
     };
     defer allocator.free(static_data_requests);
@@ -297,11 +301,14 @@ fn collectLayoutRequests(
     allocator: Allocator,
     root: *const checked.Module,
     explicit: []const checked.CheckedTypeId,
+    include_static_data_exports: bool,
 ) Allocator.Error![]checked.CheckedTypeId {
     var requests = std.ArrayList(checked.CheckedTypeId).empty;
     errdefer requests.deinit(allocator);
 
     try requests.appendSlice(allocator, explicit);
+    if (!include_static_data_exports) return try requests.toOwnedSlice(allocator);
+
     const types = root.checked_types.view();
     for (root.provided_exports.exports) |provided| {
         switch (provided) {
@@ -314,6 +321,42 @@ fn collectLayoutRequests(
         }
     }
     return try requests.toOwnedSlice(allocator);
+}
+
+/// Select ABI roots for native object/archive/shared-library outputs.
+pub fn selectPlatformExportRoots(
+    allocator: Allocator,
+    requests: []const checked.RootRequest,
+) Allocator.Error![]checked.RootRequest {
+    var selected = std.ArrayList(checked.RootRequest).empty;
+    errdefer selected.deinit(allocator);
+
+    for (requests) |request| {
+        if (request.kind != .provided_export) continue;
+        try selected.append(allocator, request);
+    }
+
+    return try selected.toOwnedSlice(allocator);
+}
+
+/// Select platform roots for LIR images consumed by host shims/interpreters.
+pub fn selectPlatformEntrypointRoots(
+    allocator: Allocator,
+    requests: []const checked.RootRequest,
+) Allocator.Error![]checked.RootRequest {
+    var selected = std.ArrayList(checked.RootRequest).empty;
+    errdefer selected.deinit(allocator);
+
+    for (requests) |request| {
+        switch (request.kind) {
+            .provided_export,
+            .platform_required_binding,
+            => try selected.append(allocator, request),
+            else => {},
+        }
+    }
+
+    return try selected.toOwnedSlice(allocator);
 }
 
 fn collectStaticDataRequests(

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -142,6 +142,7 @@ pub fn run(
     try lowerer.result.store.setSourceFiles(owned.lifted.source_files.items);
     try lowerer.lower();
     try lowerer.bindRoots();
+    try lowerer.lowerReachableFns();
     try lowerer.writeRuntimeSchemas();
     if (builtin.mode == .Debug) {
         try lowerer.verifyMaterializedDecisions();
@@ -260,6 +261,8 @@ const Lowerer = struct {
     fn_entries: std.ArrayList(FnEntry),
     fn_spec_map: std.HashMap(FnSpec, Type.FnId, FnSpecContext, std.hash_map.default_max_load_percentage),
     fn_written: std.ArrayList(bool),
+    fn_reachable: std.ArrayList(bool),
+    fn_reach_queue: std.ArrayList(Type.FnId),
     inline_plan: SolvedInline.Plan,
     debug_effects: DebugEffectMode,
     list_in_place_map: bool,
@@ -320,6 +323,8 @@ const Lowerer = struct {
             .fn_entries = .empty,
             .fn_spec_map = std.HashMap(FnSpec, Type.FnId, FnSpecContext, std.hash_map.default_max_load_percentage).initContext(allocator, .{}),
             .fn_written = .empty,
+            .fn_reachable = .empty,
+            .fn_reach_queue = .empty,
             .inline_plan = options.inline_plan,
             .debug_effects = options.debug_effects,
             .list_in_place_map = options.list_in_place_map,
@@ -353,6 +358,8 @@ const Lowerer = struct {
         self.captures.deinit();
         self.capture_types.deinit();
         self.source_symbols.deinit();
+        self.fn_reach_queue.deinit(self.allocator);
+        self.fn_reachable.deinit(self.allocator);
         self.fn_written.deinit(self.allocator);
         self.fn_spec_map.deinit();
         self.fn_entries.deinit(self.allocator);
@@ -380,6 +387,8 @@ const Lowerer = struct {
         self.captures.deinit();
         self.capture_types.deinit();
         self.source_symbols.deinit();
+        self.fn_reach_queue.deinit(self.allocator);
+        self.fn_reachable.deinit(self.allocator);
         self.fn_written.deinit(self.allocator);
         self.fn_spec_map.deinit();
         self.fn_entries.deinit(self.allocator);
@@ -400,10 +409,12 @@ const Lowerer = struct {
 
         try self.roots.ensureTotalCapacity(self.allocator, self.solved.lifted.roots.items.len);
         for (self.solved.lifted.roots.items) |root| {
+            const fn_id = try self.ensureOwnFnSpec(root.fn_id, .finite);
             try self.roots.append(self.allocator, .{
-                .fn_id = try self.ensureOwnFnSpec(root.fn_id, .finite),
+                .fn_id = fn_id,
                 .request = root.request,
             });
+            _ = try self.markReachableFn(fn_id);
         }
 
         try self.layout_requests.ensureTotalCapacity(self.allocator, self.solved.layout_requests.items.len);
@@ -422,7 +433,7 @@ const Lowerer = struct {
             });
         }
 
-        try self.lowerQueuedFns();
+        try self.lowerReachableFns();
     }
 
     fn indexSourceFns(self: *Lowerer) Common.LowerError!void {
@@ -434,17 +445,18 @@ const Lowerer = struct {
         }
     }
 
-    fn lowerQueuedFns(self: *Lowerer) Common.LowerError!void {
+    fn lowerReachableFns(self: *Lowerer) Common.LowerError!void {
         var index: usize = 0;
-        while (index < self.fn_specs.items.len) : (index += 1) {
-            if (self.fn_written.items[index]) continue;
-            const fn_id: Type.FnId = @enumFromInt(@as(u32, @intCast(index)));
-            try self.lowerFnSpec(fn_id, self.fn_specs.items[index]);
+        while (index < self.fn_reach_queue.items.len) : (index += 1) {
+            const fn_id = self.fn_reach_queue.items[index];
+            const fn_index = @intFromEnum(fn_id);
+            if (self.fn_written.items[fn_index]) continue;
+            try self.lowerFnSpec(fn_id, self.fn_specs.items[fn_index]);
         }
     }
 
     fn lowerFnSpec(self: *Lowerer, fn_id: Type.FnId, spec: FnSpec) Common.LowerError!void {
-        const proc_id = try self.fnProc(fn_id);
+        const proc_id = try self.procPlaceholder(fn_id);
         const entry = self.fn_entries.items[@intFromEnum(fn_id)];
         const source_fn = self.solved.lifted.fns.items[@intFromEnum(spec.source)];
 
@@ -589,6 +601,7 @@ const Lowerer = struct {
         result.value_ptr.* = fn_id;
         try self.fn_specs.append(self.allocator, spec);
         try self.fn_written.append(self.allocator, false);
+        try self.fn_reachable.append(self.allocator, false);
         try self.fn_entries.append(self.allocator, undefined);
         const source_fn = self.solved.lifted.fns.items[@intFromEnum(source)];
         const symbol = self.symbols.fresh();
@@ -608,7 +621,18 @@ const Lowerer = struct {
         return fn_id;
     }
 
-    fn fnProc(self: *Lowerer, fn_id: Type.FnId) Common.LowerError!LIR.LirProcSpecId {
+    fn markReachableFn(self: *Lowerer, fn_id: Type.FnId) Common.LowerError!LIR.LirProcSpecId {
+        const index = @intFromEnum(fn_id);
+        if (index >= self.fn_entries.items.len) Common.invariant("direct LIR reachability referenced a missing function spec");
+        const proc = try self.procPlaceholder(fn_id);
+        if (!self.fn_reachable.items[index]) {
+            self.fn_reachable.items[index] = true;
+            try self.fn_reach_queue.append(self.allocator, fn_id);
+        }
+        return proc;
+    }
+
+    fn procPlaceholder(self: *Lowerer, fn_id: Type.FnId) Common.LowerError!LIR.LirProcSpecId {
         const index = @intFromEnum(fn_id);
         if (self.fn_entries.items[index].proc) |existing| return existing;
         return try self.finalizeFnProc(fn_id);
@@ -968,7 +992,7 @@ const Lowerer = struct {
     fn bindRoots(self: *Lowerer) Common.LowerError!void {
         for (self.roots.items) |root| {
             const entry = self.fn_entries.items[@intFromEnum(root.fn_id)];
-            const proc = try self.fnProc(root.fn_id);
+            const proc = try self.markReachableFn(root.fn_id);
             try self.result.root_procs.append(self.allocator, proc);
             try self.result.root_metadata.append(self.allocator, RootMetadata.fromCheckedRoot(root.request));
             if (root.request.abi == .compile_time) {
@@ -1158,7 +1182,7 @@ const Lowerer = struct {
             errdefer if (captures_owned) self.allocator.free(captures);
 
             entries[index] = .{
-                .entry = try self.fnProc(member.target),
+                .entry = try self.markReachableFn(member.target),
                 .capture_layout = if (member.capture_ty) |capture_ty| try self.layoutOfType(capture_ty) else .zst,
                 .template = constFnTemplateFromMono(self.fnTemplateForFn(member.target)),
                 .captures = captures,
@@ -1336,8 +1360,8 @@ const Lowerer = struct {
     }
 
     fn verifyFnEntriesMatch(self: *Lowerer, materialized: *const LambdaMono.Program) Common.LowerError!void {
-        if (self.fn_entries.items.len != materialized.fns.items.len) {
-            Common.invariant("debug Lambda Mono verifier saw a function count mismatch");
+        if (self.fn_entries.items.len > materialized.fns.items.len) {
+            Common.invariant("debug Lambda Mono verifier saw too many direct function specs");
         }
         const used = try self.allocator.alloc(bool, materialized.fns.items.len);
         defer self.allocator.free(used);
@@ -1404,7 +1428,11 @@ const Lowerer = struct {
             Common.invariant("debug Lambda Mono verifier saw a root count mismatch");
         }
         for (self.roots.items, materialized.roots.items) |direct, expected| {
-            if (direct.fn_id != expected.fn_id or !std.meta.eql(direct.request, expected.request)) {
+            if (!std.meta.eql(direct.request, expected.request)) {
+                Common.invariant("debug Lambda Mono verifier saw a root mismatch");
+            }
+            const expected_fn = materialized.fns.items[@intFromEnum(expected.fn_id)];
+            if (!try self.fnEntryMatchesMaterialized(self.fn_entries.items[@intFromEnum(direct.fn_id)], expected_fn, materialized)) {
                 Common.invariant("debug Lambda Mono verifier saw a root mismatch");
             }
         }
@@ -1989,7 +2017,7 @@ const Lowerer = struct {
 
         const assign = try self.result.store.addCFStmt(.{ .assign_packed_erased_fn = .{
             .target = target,
-            .proc = try self.fnProc(fn_id),
+            .proc = try self.markReachableFn(fn_id),
             .capture = capture,
             .capture_layout = capture_layout,
             .on_drop = on_drop,
@@ -2046,7 +2074,7 @@ const Lowerer = struct {
         defer if (capture_arg != null) self.allocator.free(call_args);
         var current = try self.result.store.addCFStmt(.{ .assign_call = .{
             .target = target,
-            .proc = try self.fnProc(callee),
+            .proc = try self.markReachableFn(callee),
             .args = try self.result.store.addLocalSpan(call_args),
             .next = next,
         } });

--- a/src/snapshot_tool/main.zig
+++ b/src/snapshot_tool/main.zig
@@ -4117,13 +4117,16 @@ fn processDevObjectSnapshot(
                     break :target_snapshot;
                 },
             };
+            const build_roots = try lir.CheckedPipeline.selectPlatformExportRoots(allocator, root_artifact.root_requests.runtime_requests);
+            defer allocator.free(build_roots);
+
             var lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
                 allocator,
                 .{
                     .root = check.CheckedArtifact.loweringViewWithRelations(root_artifact, relation_artifacts),
                     .imports = imported_artifacts,
                 },
-                .{ .requests = root_artifact.root_requests.runtime_requests },
+                .{ .requests = build_roots, .include_static_data_exports = true },
                 .{
                     .target_usize = target_usize,
                 },

--- a/test/fuzzing/fuzz-build.zig
+++ b/test/fuzzing/fuzz-build.zig
@@ -115,13 +115,18 @@ pub fn zig_fuzz_test_inner(buf: [*]u8, len: isize, debug: bool) void {
     };
     defer gpa.free(relations);
 
+    const lir_roots = lir.CheckedPipeline.selectPlatformEntrypointRoots(gpa, root_checked.root_requests.runtime_requests) catch |err| switch (err) {
+        error.OutOfMemory => @panic("OOM while selecting LIR roots"),
+    };
+    defer gpa.free(lir_roots);
+
     var lowered = lir.CheckedPipeline.lowerCheckedModulesToLir(
         gpa,
         .{
             .root = check.CheckedArtifact.loweringViewWithRelations(root_checked, relations),
             .imports = imported,
         },
-        .{ .requests = root_checked.root_requests.runtime_requests },
+        .{ .requests = lir_roots },
         .{
             .target_usize = base.target.TargetUsize.native,
             .inline_mode = .none,


### PR DESCRIPTION
This changes checked-to-LIR lowering to start from explicit ABI roots and lower procedures by reachability fanout instead of materializing every function spec. Platform build paths now select export roots up front, LIR image paths select platform entrypoints, and static data export layout/static-data requests are opt-in so object generation still has the data layouts it needs without forcing unrelated application entrypoints into LIR.\n\nThe direct lowerer now keeps function metadata separate from proc reachability; direct calls, erased callable packing, and erased static callable entries enqueue reachable callees as they are encountered, so referenced-but-uncalled functions can remain metadata-only. Closes #9659.