### PR TITLE
Fix wasm dev list mutation and short string concat

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3455,6 +3455,17 @@ pub fn build(b: *std.Build) void {
         build_wasm_list_builtin_app.step.dependOn(build_test_hosts_step);
         build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_list_builtin_app.step);
 
+        const build_wasm_single_variant_hosted_app = b.addRunArtifact(roc_exe);
+        build_wasm_single_variant_hosted_app.addArgs(&.{
+            "build",
+            "test/wasm/single_variant_hosted_static_lib_app.roc",
+            "--opt=speed",
+            "--target=wasm32",
+            "--output=test/wasm/single_variant_hosted_static_lib_app.wasm",
+        });
+        build_wasm_single_variant_hosted_app.step.dependOn(build_test_hosts_step);
+        build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_single_variant_hosted_app.step);
+
         const build_wasm_str_concat_join_app = b.addRunArtifact(roc_exe);
         build_wasm_str_concat_join_app.addArgs(&.{
             "build",
@@ -3540,6 +3551,16 @@ pub fn build(b: *std.Build) void {
             });
             run_wasm_list_builtin_test.step.dependOn(build_test_wasm_static_lib_runner_step);
             run_test_wasm_static_lib_step.dependOn(&run_wasm_list_builtin_test.step);
+
+            const run_wasm_single_variant_hosted_test = b.addRunArtifact(wasm_test_exe);
+            run_wasm_single_variant_hosted_test.addArgs(&.{
+                "--wasm-path",
+                "test/wasm/single_variant_hosted_static_lib_app.wasm",
+                "--expected",
+                "ok",
+            });
+            run_wasm_single_variant_hosted_test.step.dependOn(build_test_wasm_static_lib_runner_step);
+            run_test_wasm_static_lib_step.dependOn(&run_wasm_single_variant_hosted_test.step);
 
             const run_wasm_str_concat_join_test = b.addRunArtifact(wasm_test_exe);
             run_wasm_str_concat_join_test.addArgs(&.{

--- a/build.zig
+++ b/build.zig
@@ -3455,6 +3455,17 @@ pub fn build(b: *std.Build) void {
         build_wasm_list_builtin_app.step.dependOn(build_test_hosts_step);
         build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_list_builtin_app.step);
 
+        const build_wasm_str_concat_join_app = b.addRunArtifact(roc_exe);
+        build_wasm_str_concat_join_app.addArgs(&.{
+            "build",
+            "test/wasm/str_concat_join_static_lib_app.roc",
+            "--opt=dev",
+            "--target=wasm32",
+            "--output=test/wasm/str_concat_join_static_lib_app.wasm",
+        });
+        build_wasm_str_concat_join_app.step.dependOn(build_test_hosts_step);
+        build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_str_concat_join_app.step);
+
         const build_wasm_rc_cleanup_app = b.addRunArtifact(roc_exe);
         build_wasm_rc_cleanup_app.addArgs(&.{
             "build",
@@ -3529,6 +3540,18 @@ pub fn build(b: *std.Build) void {
             });
             run_wasm_list_builtin_test.step.dependOn(build_test_wasm_static_lib_runner_step);
             run_test_wasm_static_lib_step.dependOn(&run_wasm_list_builtin_test.step);
+
+            const run_wasm_str_concat_join_test = b.addRunArtifact(wasm_test_exe);
+            run_wasm_str_concat_join_test.addArgs(&.{
+                "--wasm-path",
+                "test/wasm/str_concat_join_static_lib_app.wasm",
+                "--expected",
+                "X:1Y:2",
+                "--max-allocs",
+                "0",
+            });
+            run_wasm_str_concat_join_test.step.dependOn(build_test_wasm_static_lib_runner_step);
+            run_test_wasm_static_lib_step.dependOn(&run_wasm_str_concat_join_test.step);
 
             const run_wasm_rc_cleanup_test = b.addRunArtifact(wasm_test_exe);
             run_wasm_rc_cleanup_test.addArgs(&.{

--- a/build.zig
+++ b/build.zig
@@ -3445,6 +3445,16 @@ pub fn build(b: *std.Build) void {
         build_wasm_app.step.dependOn(build_test_hosts_step);
         build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_app.step);
 
+        const build_wasm_list_builtin_app = b.addRunArtifact(roc_exe);
+        build_wasm_list_builtin_app.addArgs(&.{
+            "build",
+            "test/wasm/list_builtin_static_lib_app.roc",
+            "--target=wasm32",
+            "--output=test/wasm/list_builtin_static_lib_app.wasm",
+        });
+        build_wasm_list_builtin_app.step.dependOn(build_test_hosts_step);
+        build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_list_builtin_app.step);
+
         const build_wasm_rc_cleanup_app = b.addRunArtifact(roc_exe);
         build_wasm_rc_cleanup_app.addArgs(&.{
             "build",
@@ -3510,6 +3520,16 @@ pub fn build(b: *std.Build) void {
         if (run_args.len != 0) {
             run_wasm_test.addArgs(run_args);
         } else {
+            const run_wasm_list_builtin_test = b.addRunArtifact(wasm_test_exe);
+            run_wasm_list_builtin_test.addArgs(&.{
+                "--wasm-path",
+                "test/wasm/list_builtin_static_lib_app.wasm",
+                "--expected",
+                "ok",
+            });
+            run_wasm_list_builtin_test.step.dependOn(build_test_wasm_static_lib_runner_step);
+            run_test_wasm_static_lib_step.dependOn(&run_wasm_list_builtin_test.step);
+
             const run_wasm_rc_cleanup_test = b.addRunArtifact(wasm_test_exe);
             run_wasm_rc_cleanup_test.addArgs(&.{
                 "--wasm-path",

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -3182,11 +3182,22 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     const list_abi = builtinInternalListAbi(ls, "dev.list_set.builtin_list_abi", ll.ret_layout);
 
                     const list_off = try self.ensureOnStack(list_loc, roc_list_size);
+                    const result_offset = self.codegen.allocStackSlot(roc_list_size);
+                    if (list_abi.elem_size_align.size == 0) {
+                        const tmp = try self.allocTempGeneral();
+                        defer self.codegen.freeGeneral(tmp);
+                        var off: i32 = 0;
+                        while (off < roc_list_size) : (off += 8) {
+                            try self.emitLoad(.w64, tmp, frame_ptr, list_off + off);
+                            try self.emitStore(.w64, frame_ptr, result_offset + off, tmp);
+                        }
+                        return .{ .list_stack = .{ .struct_offset = result_offset, .data_offset = 0, .num_elements = 0 } };
+                    }
+
                     const index_off = try self.ensureOnStack(index_loc, 8);
                     const elem_off = try self.ensureOnStack(elem_loc, list_abi.elem_size_align.size);
-                    const result_offset = self.codegen.allocStackSlot(roc_str_size);
                     // We need a scratch slot for the old element (out_element param)
-                    const old_elem_slot = self.codegen.allocStackSlot(@intCast(if (list_abi.elem_size_align.size > 0) list_abi.elem_size_align.size else 8));
+                    const old_elem_slot = self.codegen.allocStackSlot(@intCast(list_abi.elem_size_align.size));
                     const fn_addr: usize = @intFromPtr(&dev_wrappers.roc_builtins_list_replace);
                     const elem_incref_reg = if (list_abi.elem_layout_idx) |idx| try self.emitBuiltinInternalOptionalRcHelperAddress(.incref, idx) else null;
                     defer if (elem_incref_reg) |reg| self.codegen.freeGeneral(reg);

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -4981,19 +4981,31 @@ pub const MonoLlvmCodeGen = struct {
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
         const abi = self.layouts().builtinListAbi(self.localLayout(args[0]));
-        // listReplace copies the displaced element into out_element before
-        // overwriting it, dereferencing the pointer unconditionally. list_set
-        // discards that value, but the builtin still needs a real slot to write.
-        const out_element_len = builder.intValue(.i32, @max(abi.elem_size, 1)) catch return error.OutOfMemory;
-        const out_element = wip.alloca(.normal, .i8, out_element_len, LlvmBuilder.Alignment.fromByteUnits(@max(abi.elem_alignment, 1)), .default, "list_set_old") catch return error.OutOfMemory;
+        if (abi.elem_size == 0) {
+            try self.copyBytes(self.slot(target).ptr, self.slot(args[0]).ptr, self.slot(target).size, self.slot(target).alignment);
+            return;
+        }
+
         var call_args = try self.rocListArgs1(args[0]);
         defer call_args.deinit(self.allocator);
+        // listReplace copies the displaced element into out_element before
+        // overwriting it. list_set discards that value, but the builtin still
+        // needs a real slot to write.
+        const old_elem_ptr = wip.alloca(
+            .normal,
+            .i8,
+            builder.intValue(.i32, abi.elem_size) catch return error.OutOfMemory,
+            LlvmBuilder.Alignment.fromByteUnits(@max(abi.elem_alignment, 1)),
+            .default,
+            "list_set_old_elem",
+        ) catch return error.OutOfMemory;
+
         try call_args.prepend(self.allocator, try self.ptrType(), self.slot(target).ptr);
         try call_args.append(self.allocator, .i32, builder.intValue(.i32, abi.elem_alignment) catch return error.OutOfMemory);
         try call_args.append(self.allocator, .i64, try self.coerceScalar(try self.loadScalar(self.slot(args[1]).ptr, self.localLayout(args[1])), .i64, false));
         try call_args.append(self.allocator, try self.ptrType(), self.slot(args[2]).ptr);
         try call_args.append(self.allocator, self.ptrSizedIntType(), builder.intValue(self.ptrSizedIntType(), abi.elem_size) catch return error.OutOfMemory);
-        try call_args.append(self.allocator, try self.ptrType(), out_element);
+        try call_args.append(self.allocator, try self.ptrType(), old_elem_ptr);
         try self.appendListElementRcArgs(&call_args, abi, true, true);
         try self.appendUpdateModeArg(&call_args, unique_args);
         try call_args.append(self.allocator, try self.ptrType(), self.rocOps());

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -817,7 +817,7 @@ fn compileBuiltinInternalIncrefCallback(self: *Self, helper_key: RcHelperKey) Al
     // the op and makes no thread-confinement claim, so they always use the
     // atomic helper family.
     const helper_func_idx = try self.compileBuiltinInternalRcHelper(helper_key, .atomic);
-    const type_idx = try self.internFuncType(&.{ .i32, .i64, .i32 }, &.{});
+    const type_idx = try self.internFuncType(&.{ .i32, .i32, .i32 }, &.{});
     const defined = self.module.addDefinedFunction(type_idx) catch return error.OutOfMemory;
     const func_idx = defined.function.raw();
     _ = try self.addOwnedLocalFunctionSymbol(defined, "roc_rc_incref_callback", rcHelperCacheKey(helper_key, .atomic));
@@ -837,12 +837,11 @@ fn compileBuiltinInternalIncrefCallback(self: *Self, helper_key: RcHelperKey) Al
     self.current_proc_id = null;
 
     const value_ptr_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-    const count_local = self.storage.allocAnonymousLocal(.i64) catch return error.OutOfMemory;
+    const count_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
     self.roc_ops_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
 
     try self.emitLocalGet(value_ptr_local);
     try self.emitLocalGet(count_local);
-    self.currentCode().append(self.allocator, Op.i32_wrap_i64) catch return error.OutOfMemory;
     try self.emitLocalGet(self.roc_ops_local);
     try self.emitCall(helper_func_idx);
 
@@ -10223,23 +10222,59 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
             try self.emitLocalSet(total);
 
-            // Allocate buffer
-            try self.emitHeapAllocWithRefcount(total, 1, false);
-            const buf = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-            try self.emitLocalSet(buf);
+            const result_offset = try self.allocStackMemory(12, 4);
+            const result_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+            try self.emitFpOffset(result_offset);
+            try self.emitLocalSet(result_ptr);
 
-            // Copy a bytes at offset 0
             const zero = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-            self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-            WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+            try self.emitI32Const(0);
             try self.emitLocalSet(zero);
-            try self.emitMemCopyLoop(buf, zero, a_ptr, a_len);
 
-            // Copy b bytes at offset a_len
-            try self.emitMemCopyLoop(buf, a_len, b_ptr, b_len);
+            try self.emitLocalGet(total);
+            try self.emitI32Const(12);
+            self.currentCode().append(self.allocator, Op.i32_lt_u) catch return error.OutOfMemory;
+            self.currentCode().append(self.allocator, Op.@"if") catch return error.OutOfMemory;
+            self.currentCode().append(self.allocator, @intFromEnum(BlockType.void)) catch return error.OutOfMemory;
+            {
+                try self.emitZeroInit(result_ptr, 12);
+                try self.emitMemCopyLoop(result_ptr, zero, a_ptr, a_len);
+                try self.emitMemCopyLoop(result_ptr, a_len, b_ptr, b_len);
 
-            // Build heap RocStr
-            try self.buildHeapRocStr(buf, total);
+                try self.emitLocalGet(result_ptr);
+                try self.emitLocalGet(total);
+                try self.emitI32Const(0x80);
+                self.currentCode().append(self.allocator, Op.i32_or) catch return error.OutOfMemory;
+                self.currentCode().append(self.allocator, Op.i32_store8) catch return error.OutOfMemory;
+                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 11) catch return error.OutOfMemory;
+            }
+            self.currentCode().append(self.allocator, Op.@"else") catch return error.OutOfMemory;
+            {
+                try self.emitHeapAllocWithRefcount(total, 1, false);
+                const buf = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                try self.emitLocalSet(buf);
+
+                try self.emitMemCopyLoop(buf, zero, a_ptr, a_len);
+                try self.emitMemCopyLoop(buf, a_len, b_ptr, b_len);
+
+                try self.emitLocalGet(result_ptr);
+                try self.emitLocalGet(buf);
+                try self.emitStoreOp(.i32, 0);
+
+                try self.emitLocalGet(result_ptr);
+                try self.emitLocalGet(total);
+                try self.emitI32Const(1);
+                self.currentCode().append(self.allocator, Op.i32_shl) catch return error.OutOfMemory;
+                try self.emitStoreOp(.i32, 4);
+
+                try self.emitLocalGet(result_ptr);
+                try self.emitLocalGet(total);
+                try self.emitStoreOp(.i32, 8);
+            }
+            self.currentCode().append(self.allocator, Op.end) catch return error.OutOfMemory;
+
+            try self.emitLocalGet(result_ptr);
         },
         .str_contains => {
             // Check if string a contains substring b

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -635,6 +635,55 @@ fn emitRocStrFields(self: *Self, fields: RocStrFields) Allocator.Error!void {
     try self.emitLocalGet(fields.cap);
 }
 
+fn emitAddressOffsetToLocal(self: *Self, base_local: u32, offset: u32) Allocator.Error!u32 {
+    const result = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitLocalGet(base_local);
+    if (offset > 0) {
+        try self.emitI32Const(@intCast(offset));
+        self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+    }
+    try self.emitLocalSet(result);
+    return result;
+}
+
+fn emitStrEqCall(self: *Self, lhs_str_ptr: u32, rhs_str_ptr: u32) Allocator.Error!void {
+    if (self.externalCallsUseRelocs()) {
+        const lhs = try self.loadRocStrFields(lhs_str_ptr);
+        const rhs = try self.loadRocStrFields(rhs_str_ptr);
+        try self.emitRocStrFields(lhs);
+        try self.emitRocStrFields(rhs);
+        try self.emitBuiltinCall(.str_equal, self.str_eq_import);
+    } else {
+        try self.emitLocalGet(lhs_str_ptr);
+        try self.emitLocalGet(rhs_str_ptr);
+        try self.emitBuiltinCall(.str_equal, self.str_eq_import);
+    }
+}
+
+fn emitListEqCall(
+    self: *Self,
+    lhs_list_ptr: u32,
+    rhs_list_ptr: u32,
+    kind: BuiltinKind,
+    host_import: ?u32,
+    elem_size: ?u32,
+) Allocator.Error!void {
+    if (self.externalCallsUseRelocs()) {
+        const lhs = try self.loadRocListFields(lhs_list_ptr);
+        const rhs = try self.loadRocListFields(rhs_list_ptr);
+        try self.emitRocListFields(lhs);
+        try self.emitRocListFields(rhs);
+    } else {
+        try self.emitLocalGet(lhs_list_ptr);
+        try self.emitLocalGet(rhs_list_ptr);
+    }
+
+    if (elem_size) |size| {
+        try self.emitI32Const(@intCast(size));
+    }
+    try self.emitBuiltinCall(kind, host_import);
+}
+
 fn hasherDomain(op: lir.LowLevel) u8 {
     return @intFromEnum(switch (op) {
         .hasher_write_bool => builtins.hash.HasherDomain.bool,
@@ -3765,21 +3814,9 @@ fn expandField(
     field_layout_idx: layout.Idx,
 ) Allocator.Error!void {
     if (field_layout_idx == .str) {
-        // String: call roc_str_eq(lhs_ptr + offset, rhs_ptr + offset)
-        const import_idx = self.str_eq_import orelse unreachable;
-        try self.emitLocalGet(lhs_local);
-        if (field_offset > 0) {
-            self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-            WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-            self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-        }
-        try self.emitLocalGet(rhs_local);
-        if (field_offset > 0) {
-            self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-            WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-            self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-        }
-        try self.emitCall(import_idx);
+        const lhs_field_local = try self.emitAddressOffsetToLocal(lhs_local, field_offset);
+        const rhs_field_local = try self.emitAddressOffsetToLocal(rhs_local, field_offset);
+        try self.emitStrEqCall(lhs_field_local, rhs_field_local);
         return;
     }
 
@@ -3788,66 +3825,20 @@ fn expandField(
     const field_layout = ls.getLayout(field_layout_idx);
     switch (field_layout.tag) {
         .list => {
-            // List: call roc_list_eq or roc_list_str_eq
             const elem_layout = field_layout.getIdx();
+            const lhs_list_local = try self.emitAddressOffsetToLocal(lhs_local, field_offset);
+            const rhs_list_local = try self.emitAddressOffsetToLocal(rhs_local, field_offset);
+
             if (elem_layout == .str) {
-                const import_idx = self.list_str_eq_import orelse unreachable;
-                try self.emitLocalGet(lhs_local);
-                if (field_offset > 0) {
-                    self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                }
-                try self.emitLocalGet(rhs_local);
-                if (field_offset > 0) {
-                    self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                }
-                try self.emitCall(import_idx);
+                try self.emitListEqCall(lhs_list_local, rhs_list_local, .list_str_eq, self.list_str_eq_import, null);
             } else if (ls.getLayout(elem_layout).tag == .list) {
-                // List of lists - use specialized host function with inner element size
                 const inner_elem_layout = ls.getLayout(elem_layout).getIdx();
                 const inner_elem_size = try self.layoutByteSize(inner_elem_layout);
-                const import_idx = self.list_list_eq_import orelse unreachable;
-                try self.emitLocalGet(lhs_local);
-                if (field_offset > 0) {
-                    self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                }
-                try self.emitLocalGet(rhs_local);
-                if (field_offset > 0) {
-                    self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                }
-                self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(inner_elem_size)) catch return error.OutOfMemory;
-                try self.emitCall(import_idx);
+                try self.emitListEqCall(lhs_list_local, rhs_list_local, .list_list_eq, self.list_list_eq_import, inner_elem_size);
             } else if (builtinInternalLayoutContainsRefcounted(ls, "wasm.compareFieldByLayout.builtin_elem_rc", elem_layout)) {
                 // Composite elements (records/tuples/tag-unions with refcounted fields):
                 // inline element-by-element structural comparison loop.
                 const elem_size = try self.layoutByteSize(elem_layout);
-                const lhs_list_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                const rhs_list_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-
-                try self.emitLocalGet(lhs_local);
-                if (field_offset > 0) {
-                    self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                }
-                try self.emitLocalSet(lhs_list_local);
-
-                try self.emitLocalGet(rhs_local);
-                if (field_offset > 0) {
-                    self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                }
-                try self.emitLocalSet(rhs_list_local);
-
                 try work.append(wa, .{ .list_loop = .{
                     .lhs = lhs_list_local,
                     .rhs = rhs_list_local,
@@ -3855,46 +3846,14 @@ fn expandField(
                     .elem_size = elem_size,
                 } });
             } else {
-                // Simple scalar elements: bytewise comparison via host function
-                const import_idx = self.list_eq_import orelse unreachable;
                 const elem_size = try self.layoutByteSize(elem_layout);
-                try self.emitLocalGet(lhs_local);
-                if (field_offset > 0) {
-                    self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                }
-                try self.emitLocalGet(rhs_local);
-                if (field_offset > 0) {
-                    self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                }
-                self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(elem_size)) catch return error.OutOfMemory;
-                try self.emitCall(import_idx);
+                try self.emitListEqCall(lhs_list_local, rhs_list_local, .list_eq, self.list_eq_import, elem_size);
             }
         },
         .struct_, .tag_union => {
             // Nested composite: create offset locals and recurse
-            const lhs_field_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-            const rhs_field_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-
-            try self.emitLocalGet(lhs_local);
-            if (field_offset > 0) {
-                self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-                self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-            }
-            try self.emitLocalSet(lhs_field_local);
-
-            try self.emitLocalGet(rhs_local);
-            if (field_offset > 0) {
-                self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(field_offset)) catch return error.OutOfMemory;
-                self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-            }
-            try self.emitLocalSet(rhs_field_local);
+            const lhs_field_local = try self.emitAddressOffsetToLocal(lhs_local, field_offset);
+            const rhs_field_local = try self.emitAddressOffsetToLocal(rhs_local, field_offset);
 
             if (field_layout.tag == .tag_union) {
                 const tu_info = ls.getTagUnionInfo(field_layout);
@@ -10185,18 +10144,13 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
         },
 
         .str_is_eq => {
-            // String equality via host function (handles both SSO and heap strings)
-            const import_idx = self.str_eq_import orelse unreachable;
             try self.emitProcLocal(args[0]);
             const a = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
             try self.emitLocalSet(a);
             try self.emitProcLocal(args[1]);
             const b = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
             try self.emitLocalSet(b);
-            // Push both pointers and call host function
-            try self.emitLocalGet(a);
-            try self.emitLocalGet(b);
-            try self.emitCall(import_idx);
+            try self.emitStrEqCall(a, b);
         },
         .str_concat => {
             // LowLevel str_concat: concatenate 2 strings
@@ -12849,11 +12803,9 @@ fn emitNumericLowLevel(self: *Self, op: anytype, args: []const ProcLocalId, ret_
     }
 }
 
-/// Generate string equality comparison using roc_str_eq host function.
+/// Generate string equality comparison.
 /// Both lhs and rhs should produce i32 pointers to 12-byte RocStr values.
 fn emitStrEq(self: *Self, lhs: ProcLocalId, rhs: ProcLocalId, negate: bool) Allocator.Error!void {
-    const import_idx = self.str_eq_import orelse unreachable;
-
     // Generate both string expressions, store to locals
     try self.emitProcLocal(lhs);
     const lhs_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
@@ -12863,10 +12815,7 @@ fn emitStrEq(self: *Self, lhs: ProcLocalId, rhs: ProcLocalId, negate: bool) Allo
     const rhs_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
     try self.emitLocalSet(rhs_local);
 
-    // Call roc_str_eq(lhs_ptr, rhs_ptr) -> i32
-    try self.emitLocalGet(lhs_local);
-    try self.emitLocalGet(rhs_local);
-    try self.emitCall(import_idx);
+    try self.emitStrEqCall(lhs_local, rhs_local);
 
     // If negate, flip the result
     if (negate) {
@@ -12898,37 +12847,21 @@ fn emitListEqWithElemLayout(self: *Self, lhs: ProcLocalId, rhs: ProcLocalId, ele
 
     // Determine which comparison to use based on element type
     if (elem_layout == .str) {
-        // List of strings - use specialized host function
-        const import_idx = self.list_str_eq_import orelse unreachable;
-        try self.emitLocalGet(lhs_local);
-        try self.emitLocalGet(rhs_local);
-        try self.emitCall(import_idx);
+        try self.emitListEqCall(lhs_local, rhs_local, .list_str_eq, self.list_str_eq_import, null);
     } else {
         const ls = self.getLayoutStore();
         const elem_l = ls.getLayout(elem_layout);
         if (elem_l.tag == .list) {
-            // List of lists - use specialized host function with inner element size
             const inner_elem_layout = elem_l.getIdx();
             const inner_elem_size = try self.layoutByteSize(inner_elem_layout);
-            const import_idx = self.list_list_eq_import orelse unreachable;
-            try self.emitLocalGet(lhs_local);
-            try self.emitLocalGet(rhs_local);
-            self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-            WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(inner_elem_size)) catch return error.OutOfMemory;
-            try self.emitCall(import_idx);
+            try self.emitListEqCall(lhs_local, rhs_local, .list_list_eq, self.list_list_eq_import, inner_elem_size);
         } else if (builtinInternalLayoutContainsRefcounted(ls, "wasm.emitListEqWithElemLayout.builtin_elem_rc", elem_layout)) {
             // Composite elements with refcounted fields: inline structural loop
             const elem_size = try self.layoutByteSize(elem_layout);
             try self.emitListEqLoop(lhs_local, rhs_local, elem_layout, elem_size);
         } else {
-            // Simple scalar elements - byte-wise comparison
-            const import_idx = self.list_eq_import orelse unreachable;
             const elem_size = try self.layoutByteSize(elem_layout);
-            try self.emitLocalGet(lhs_local);
-            try self.emitLocalGet(rhs_local);
-            self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-            WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(elem_size)) catch return error.OutOfMemory;
-            try self.emitCall(import_idx);
+            try self.emitListEqCall(lhs_local, rhs_local, .list_eq, self.list_eq_import, elem_size);
         }
     }
 

--- a/src/builtins/dev_wrappers.zig
+++ b/src/builtins/dev_wrappers.zig
@@ -115,7 +115,7 @@ const listWithCapacity = list.listWithCapacity;
 const listAppendUnsafe = list.listAppendUnsafe;
 const listDecref = list.listDecref;
 const RcDropFn = *const fn (?[*]u8, *RocOps) callconv(.c) void;
-const RcIncFn = *const fn (?[*]u8, u64, *RocOps) callconv(.c) void;
+const RcIncFn = *const fn (?[*]u8, isize, *RocOps) callconv(.c) void;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // String Wrappers

--- a/src/layout/abi/call.zig
+++ b/src/layout/abi/call.zig
@@ -321,3 +321,19 @@ test "lower win64: 16-byte struct is indirect, Plant is one register" {
     const c2 = try lower(arena, &store, .x86_64_windows, &.{two_words}, .i32, false);
     try testing.expectEqual(Placement.indirect, c2.args[0]);
 }
+
+test "lower wasm32: single-variant tag union returns payload register" {
+    var store = try Store.init(testing.allocator, .u32);
+    defer store.deinit();
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const box_idx = try store.insertLayout(layout.Layout.box(.u64));
+    const wrapped_u64 = try store.putTagUnion(&.{.u64});
+    const call = try lower(arena, &store, .wasm32, &.{ box_idx, box_idx }, wrapped_u64, false);
+
+    try expectRegisters(&.{.{ .class = .integer, .offset = 0, .size = 8 }}, call.ret);
+    try expectRegisters(&.{.{ .class = .integer, .offset = 0, .size = 4 }}, call.args[0]);
+    try expectRegisters(&.{.{ .class = .integer, .offset = 0, .size = 4 }}, call.args[1]);
+}

--- a/src/layout/abi/wasm.zig
+++ b/src/layout/abi/wasm.zig
@@ -53,9 +53,16 @@ pub fn classifyType(store: *const Store, idx: Idx) Class {
             return classifyType(store, store.getStructFieldLayout(struct_idx, 0));
         },
         .tag_union => {
-            // A no-payload tag union is an enum — a single integer, passed directly. Any tag
-            // union carrying a payload is a multi-field aggregate and is passed indirectly.
             const info = store.getTagUnionInfo(lay);
+            if (info.variants.len == 1) {
+                // Single-variant tag unions have an implicit discriminant, so their C ABI
+                // is exactly the payload's C ABI.
+                return classifyType(store, info.variants.get(0).payload_layout);
+            }
+
+            // A no-payload tag union is an enum — a single integer, passed directly. Any
+            // multi-variant tag union carrying a payload is a multi-field aggregate and is
+            // passed indirectly.
             var v: usize = 0;
             while (v < info.variants.len) : (v += 1) {
                 if (store.getLayout(info.variants.get(v).payload_layout).tag != .zst) {
@@ -113,6 +120,11 @@ test "wasm classify: aggregates are indirect, single-field structs unwrap" {
     const wrapped = try testStruct(&store, &.{.i64});
     try testing.expectEqual(Class{ .direct = .i64 }, classifyType(&store, wrapped));
 
+    // A single-variant tag union has an implicit discriminant and follows the
+    // payload's ABI.
+    const single_tag_u64 = try store.putTagUnion(&.{.u64});
+    try testing.expectEqual(Class{ .direct = .u64 }, classifyType(&store, single_tag_u64));
+
     // A struct whose only field is unnamed padding is not a real newtype, so it is
     // passed indirectly rather than unwrapped to the padding's borrowed type.
     const padding_only = try store.putNominalStructFields(&.{
@@ -127,4 +139,15 @@ test "wasm classify: enums are direct, Bool included" {
 
     // Bool is a no-payload tag union -> a direct integer.
     try testing.expectEqual(Class{ .direct = .bool }, classifyType(&store, .bool));
+}
+
+test "wasm classify: single-variant tag union with aggregate payload follows payload ABI" {
+    var store = try Store.init(testing.allocator, .u32);
+    defer store.deinit();
+
+    const wrapped_str = try store.putTagUnion(&.{.str});
+    try testing.expectEqual(Class.indirect, classifyType(&store, wrapped_str));
+
+    const wrapped_struct = try store.putTagUnion(&.{try testStruct(&store, &.{ .i32, .u32 })});
+    try testing.expectEqual(Class.indirect, classifyType(&store, wrapped_struct));
 }

--- a/test/cli/RcListSet.roc
+++ b/test/cli/RcListSet.roc
@@ -1,10 +1,30 @@
 expect {
     elem = ["a"]
     list = [["b"]]
-    match List.set(list, 0, elem) {
+    nested_ok = match List.set(list, 0, elem) {
         Ok(result) => result == [["a"]]
         Err(_) => Bool.False
     }
+
+    tuple_list : List((Str, U32, U32))
+    tuple_list = [("left", 1, 10), ("middle", 2, 20)]
+    tuple_ok = match List.set(tuple_list, 1, ("new", 9, 90)) {
+        Ok(result) =>
+            match List.get(result, 1) {
+                Ok((label, pitch, duration)) => label == "new" and pitch == 9 and duration == 90
+                Err(_) => Bool.False
+            }
+        Err(_) => Bool.False
+    }
+
+    zst_list : List({})
+    zst_list = [{}, {}, {}]
+    zst_ok = match List.set(zst_list, 1, {}) {
+        Ok(result) => List.len(result) == 3
+        Err(_) => Bool.False
+    }
+
+    nested_ok and tuple_ok and zst_ok
 }
 
 main! = |_| {

--- a/test/wasm/list_builtin_static_lib_app.roc
+++ b/test/wasm/list_builtin_static_lib_app.roc
@@ -14,6 +14,35 @@ str_byte_count_at = |list, index, expected|
         Err(_) => False
     }
 
+sound_at : List((Str, U32, U32)), U64, Str, U32, U32 -> Bool
+sound_at = |list, index, expected_label, expected_pitch, expected_duration|
+    match List.get(list, index) {
+        Ok((label, pitch, duration)) =>
+            label == expected_label and pitch == expected_pitch and duration == expected_duration
+        Err(_) => False
+    }
+
+set_str_or_empty : List(Str), U64, Str -> List(Str)
+set_str_or_empty = |list, index, replacement|
+    match List.set(list, index, replacement) {
+        Ok(result) => result
+        Err(_) => []
+    }
+
+set_sound_or_empty : List((Str, U32, U32)), U64, (Str, U32, U32) -> List((Str, U32, U32))
+set_sound_or_empty = |list, index, replacement|
+    match List.set(list, index, replacement) {
+        Ok(result) => result
+        Err(_) => []
+    }
+
+set_zst_or_empty : List({}), U64, {} -> List({})
+set_zst_or_empty = |list, index, replacement|
+    match List.set(list, index, replacement) {
+        Ok(result) => result
+        Err(_) => []
+    }
+
 flat_list_ops_ok : Bool
 flat_list_ops_ok = {
     appended = List.append([1.U8, 2.U8, 3.U8], 4.U8)
@@ -39,8 +68,38 @@ refcounted_list_ops_ok = {
         and str_byte_count_at(dropped, 1, 3)
 }
 
+refcounted_list_set_ok : Bool
+refcounted_list_set_ok = {
+    source = ["left", "middle", "right"]
+    updated = set_str_or_empty(source, 1, "new")
+
+    List.len(source) == 3
+        and str_byte_count_at(source, 1, 6)
+        and List.len(updated) == 3
+        and str_byte_count_at(updated, 1, 3)
+}
+
+refcounted_tuple_list_set_ok : Bool
+refcounted_tuple_list_set_ok = {
+    source : List((Str, U32, U32))
+    source = [("left", 1, 10), ("middle", 2, 20), ("right", 3, 30)]
+    updated = set_sound_or_empty(source, 1, ("new", 9, 90))
+
+    sound_at(source, 1, "middle", 2, 20)
+        and sound_at(updated, 1, "new", 9, 90)
+}
+
+zero_sized_list_set_ok : Bool
+zero_sized_list_set_ok = {
+    source : List({})
+    source = [{}, {}, {}]
+    updated = set_zst_or_empty(source, 1, {})
+
+    List.len(updated) == 3
+}
+
 main! = |_seed| {
-    if flat_list_ops_ok and refcounted_list_ops_ok {
+    if flat_list_ops_ok and refcounted_list_ops_ok and refcounted_list_set_ok and refcounted_tuple_list_set_ok and zero_sized_list_set_ok {
         "ok"
     } else {
         "bad"

--- a/test/wasm/main.zig
+++ b/test/wasm/main.zig
@@ -42,6 +42,7 @@ const TestResult = struct {
 const TestOptions = struct {
     assert_alloc_balanced: bool = false,
     min_allocs: usize = 0,
+    max_allocs: ?usize = null,
 };
 
 /// Host import implementations for the WASM module.
@@ -144,15 +145,16 @@ fn setupWasm(gpa: std.mem.Allocator, arena: std.mem.Allocator, io: std.Io, wasm_
     // Now that memory is available, update host context
     global_host_context.memory = module_instance.store.getMemory(0);
 
-    const reset_alloc_counts_handle: ?bytebox.FunctionHandle = if (options.assert_alloc_balanced)
+    const count_allocs = options.assert_alloc_balanced or options.max_allocs != null;
+    const reset_alloc_counts_handle: ?bytebox.FunctionHandle = if (count_allocs)
         try module_instance.getFunctionHandle("wasm_reset_alloc_counts")
     else
         null;
-    const alloc_count_handle: ?bytebox.FunctionHandle = if (options.assert_alloc_balanced)
+    const alloc_count_handle: ?bytebox.FunctionHandle = if (count_allocs)
         try module_instance.getFunctionHandle("wasm_alloc_count")
     else
         null;
-    const dealloc_count_handle: ?bytebox.FunctionHandle = if (options.assert_alloc_balanced)
+    const dealloc_count_handle: ?bytebox.FunctionHandle = if (count_allocs)
         try module_instance.getFunctionHandle("wasm_dealloc_count")
     else
         null;
@@ -237,7 +239,8 @@ fn runTest(gpa: std.mem.Allocator, arena: std.mem.Allocator, io: std.Io, wasm_pa
     };
     defer wasm.deinit();
 
-    if (options.assert_alloc_balanced) {
+    const count_allocs = options.assert_alloc_balanced or options.max_allocs != null;
+    if (count_allocs) {
         callWasmNoArgVoid(&wasm, wasm.wasm_reset_alloc_counts_handle.?, "wasm_reset_alloc_counts") catch |err| {
             return .{
                 .name = wasm_path,
@@ -263,7 +266,7 @@ fn runTest(gpa: std.mem.Allocator, arena: std.mem.Allocator, io: std.Io, wasm_pa
         };
     }
 
-    if (options.assert_alloc_balanced) {
+    if (count_allocs) {
         const alloc_count = callWasmNoArgUsize(&wasm, wasm.wasm_alloc_count_handle.?, "wasm_alloc_count") catch |err| {
             return .{
                 .name = wasm_path,
@@ -286,7 +289,16 @@ fn runTest(gpa: std.mem.Allocator, arena: std.mem.Allocator, io: std.Io, wasm_pa
                 .message = std.fmt.allocPrint(arena, "Expected at least {d} allocations, got {d}", .{ options.min_allocs, alloc_count }) catch "Too few allocations",
             };
         }
-        if (alloc_count != dealloc_count) {
+        if (options.max_allocs) |max_allocs| {
+            if (alloc_count > max_allocs) {
+                return .{
+                    .name = wasm_path,
+                    .passed = false,
+                    .message = std.fmt.allocPrint(arena, "Expected at most {d} allocations, got {d}", .{ max_allocs, alloc_count }) catch "Too many allocations",
+                };
+            }
+        }
+        if (options.assert_alloc_balanced and alloc_count != dealloc_count) {
             return .{
                 .name = wasm_path,
                 .passed = false,
@@ -325,7 +337,8 @@ pub fn main(init: std.process.Init) anyerror!void {
             std.debug.print("  --wasm-path PATH     Path to the WASM file (default: test/wasm/app.wasm)\n", .{});
             std.debug.print("  --expected OUTPUT    Expected output string\n", .{});
             std.debug.print("  --assert-alloc-balanced  Assert canonical roc_alloc and roc_dealloc counts match\n", .{});
-            std.debug.print("  --min-allocs N       Minimum canonical roc_alloc count when asserting balance\n", .{});
+            std.debug.print("  --min-allocs N       Minimum canonical roc_alloc count when counting allocations\n", .{});
+            std.debug.print("  --max-allocs N       Maximum canonical roc_alloc count when counting allocations\n", .{});
             std.debug.print("  --help               Display this help message\n", .{});
             return;
         } else if (std.mem.eql(u8, arg, "--wasm-path")) {
@@ -347,6 +360,15 @@ pub fn main(init: std.process.Init) anyerror!void {
             };
             options.min_allocs = std.fmt.parseInt(usize, min_allocs_arg, 10) catch |err| {
                 std.debug.print("Error: invalid --min-allocs value '{s}': {}\n", .{ min_allocs_arg, err });
+                return;
+            };
+        } else if (std.mem.eql(u8, arg, "--max-allocs")) {
+            const max_allocs_arg = arg_iter.next() orelse {
+                std.debug.print("Error: --max-allocs requires an argument\n", .{});
+                return;
+            };
+            options.max_allocs = std.fmt.parseInt(usize, max_allocs_arg, 10) catch |err| {
+                std.debug.print("Error: invalid --max-allocs value '{s}': {}\n", .{ max_allocs_arg, err });
                 return;
             };
         }

--- a/test/wasm/platform/host.zig
+++ b/test/wasm/platform/host.zig
@@ -190,6 +190,10 @@ export fn roc_runtime_seed() callconv(.c) u64 {
     return 0;
 }
 
+export fn roc_host_wrap_token(value: u64) callconv(.c) u64 {
+    return value + 1;
+}
+
 export fn roc_dbg(bytes: [*]const u8, len: usize) callconv(.c) void {
     env_imports.roc_dbg(bytes, len);
 }

--- a/test/wasm/single_variant_hosted_static_lib_app.roc
+++ b/test/wasm/single_variant_hosted_static_lib_app.roc
@@ -1,0 +1,13 @@
+app [main!] { pf: platform "./static-lib-platform/main.roc" }
+
+import pf.HostWrap
+
+main! = |_seed| {
+    token = HostWrap.wrap!(41)
+
+    if HostWrap.unwrap(token) == 42 {
+        "ok"
+    } else {
+        "bad"
+    }
+}

--- a/test/wasm/static-lib-platform/HostWrap.roc
+++ b/test/wasm/static-lib-platform/HostWrap.roc
@@ -1,0 +1,6 @@
+HostWrap := [HostWrap(U64)].{
+    wrap! : U64 => HostWrap
+
+    unwrap : HostWrap -> U64
+    unwrap = |HostWrap(value)| value
+}

--- a/test/wasm/static-lib-platform/main.roc
+++ b/test/wasm/static-lib-platform/main.roc
@@ -1,9 +1,10 @@
 platform ""
     requires {} { main! : U64 => Str }
-    exposes [Runtime]
+    exposes [Runtime, HostWrap]
     packages {}
     provides { "roc_main": main_for_host! }
     hosted {
+        "roc_host_wrap_token": HostWrap.wrap!,
         "roc_runtime_seed": Runtime.seed!,
     }
     targets: {
@@ -12,6 +13,7 @@ platform ""
     }
 
 import Runtime
+import HostWrap
 
 main_for_host! : () => Str
 main_for_host! = || main!(Runtime.seed!())

--- a/test/wasm/str_concat_join_static_lib_app.roc
+++ b/test/wasm/str_concat_join_static_lib_app.roc
@@ -1,0 +1,25 @@
+app [main!] { pf: platform "./static-lib-platform/main.roc" }
+
+choose : Bool, Str, Str -> Str
+choose = |flag, yes, no|
+    if flag {
+        yes
+    } else {
+        no
+    }
+
+left_label : Bool -> Str
+left_label = |flag| choose(flag, "X", "Y")
+
+right_label : Bool -> Str
+right_label = |flag| choose(flag, "1", "2")
+
+short_line : Bool -> Str
+short_line = |flag| {
+    left = left_label(flag)
+    right = right_label(flag)
+
+    Str.concat(Str.concat(left, ":"), right)
+}
+
+main! = || Str.concat(short_line(True), short_line(False))

--- a/test/wasm/str_concat_join_static_lib_app.roc
+++ b/test/wasm/str_concat_join_static_lib_app.roc
@@ -22,4 +22,4 @@ short_line = |flag| {
     Str.concat(Str.concat(left, ":"), right)
 }
 
-main! = || Str.concat(short_line(True), short_line(False))
+main! = |_seed| Str.concat(short_line(True), short_line(False))


### PR DESCRIPTION
## Summary
- rebase the wasm dev backend fixes onto current `origin/main`
- keep the wasm32 list element incref callback ABI pointer-sized, so builtin callback calls pass an `i32` count on wasm32
- lower short wasm dev `Str.concat` results as inline small `RocStr` values instead of heap strings
- route wasm32 symbol-ABI `Str` and list equality through explicit builtin reloc calls instead of old host-import equality symbols
- classify single-variant tag unions by their payload in the wasm C ABI, so LLVM hosted-call imports match direct host exports
- add wasm static-lib coverage for list mutation paths, zero-allocation short concat, and hosted returns of single-variant nominal wrappers

Closes #9744.
Closes #9745.

## Validation
- `zig build run-test-zig-module-layout --summary failures`
- `zig build roc --summary failures`
- `zig build build-test-hosts -Dplatform=wasm --summary failures`
- `./zig-out/bin/roc build --opt=dev --target=wasm32 --no-cache --output=/private/tmp/roc-wasm-eq-repro/str_eq_pr9666.wasm /private/tmp/roc-wasm-eq-repro/str_eq_pr9666.roc`
- `./zig-out/bin/roc build --opt=speed --target=wasm32 --no-cache --output=test/wasm/single_variant_hosted_static_lib_app.wasm test/wasm/single_variant_hosted_static_lib_app.roc`
- `zig build run-test-wasm-static-lib --summary failures`
- `git diff --check`

## roc-wasm4 validation
- `/home/lbw/Documents/Github/roc/zig-out/bin/roc build examples/sound.roc --opt=dev --output=/tmp/sound-dev-9667-fixed.wasm`
- `/home/lbw/Documents/Github/roc/zig-out/bin/roc build examples/basic.roc --opt=dev --output=/tmp/basic-dev-9667-fixed.wasm`
- `timeout 8s w4 run-native /tmp/basic-dev-9667-fixed.wasm`

`basic.roc` reached the timeout with no trap output, which matches the expected non-OOM behavior for the previous immediate WASM-4 reproduction.
