### PR TITLE
Add Iter.step_by and Iter.rev combinators

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -771,6 +771,56 @@ Builtin :: [].{
 				Unknown =>
 					List.iter(List.drop_last(Iter.fold(iterator, [], |acc, item| acc.append(item)), n))
 				}
+
+		## Returns an iterator that yields the first item and then every `n`th item
+		## after it, skipping the `n - 1` items in between. A step of `0` yields an
+		## empty iterator.
+		## ```roc
+		## expect Iter.fold(Iter.step_by(List.iter([1, 2, 3, 4, 5]), 2), [], |acc, item| acc.append(item)) == [1, 3, 5]
+		##
+		## expect Iter.fold(Iter.step_by(List.iter([1, 2, 3]), 0), [], |acc, item| acc.append(item)) == []
+		## ```
+		step_by : Iter(item), U64 -> Iter(item)
+		step_by = |iterator, n|
+			if n == 0 {
+				range_done()
+			} else {
+				match iterator {
+					{ len_if_known, step } => {
+						len_if_known: match len_if_known {
+							Known(len) => Known(
+								if len == 0 {
+									0
+								} else {
+									(len - 1) / n + 1
+								},
+							)
+							Unknown => Unknown
+						},
+						step: ||
+							match step() {
+								Done => Done
+								Skip({ rest }) => Skip({ rest: Iter.step_by(rest, n) })
+								One({ item, rest }) => One({ item, rest: Iter.step_by(Iter.drop_first(rest, n - 1), n) })
+							},
+					}
+				}
+			}
+
+		## Returns an iterator that yields this iterator's items in reverse order.
+		##
+		## Because an [Iter] only moves forward, this materializes the source into a
+		## list to reverse it. The result always has a known length, so collecting it
+		## is efficient. Avoid calling this on iterators whose length is unknown and
+		## might be huge.
+		## ```roc
+		## expect Iter.fold(Iter.rev(List.iter([1, 2, 3])), [], |acc, item| acc.append(item)) == [3, 2, 1]
+		##
+		## expect Iter.fold(Iter.rev(List.iter([])), [], |acc, item| acc.append(item)) == []
+		## ```
+		rev : Iter(item) -> Iter(item)
+		rev = |iterator|
+			List.iter(List.rev(Iter.fold(iterator, [], |acc, item| acc.append(item))))
 	}
 
 	## An effectful iterator: identical to [Iter] except that its `step!` thunk is

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -3401,6 +3401,176 @@ const core_tests = [_]TestCase{
         ,
         .expected = .{ .inspect_str = "[0, 1, 1, 2, 3]" },
     },
+    .{
+        .name = "inspect: Iter.step_by yields first then every nth",
+        .source =
+        \\{
+        \\    iter = [1.I64, 2, 3, 4, 5].iter().step_by(2)
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[1, 3, 5]" },
+    },
+    .{
+        .name = "inspect: Iter.step_by even length stops within bounds",
+        .source =
+        \\{
+        \\    iter = [1.I64, 2, 3, 4, 5, 6].iter().step_by(2)
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[1, 3, 5]" },
+    },
+    .{
+        .name = "inspect: Iter.step_by of 1 is identity",
+        .source =
+        \\{
+        \\    iter = [1.I64, 2, 3].iter().step_by(1)
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[1, 2, 3]" },
+    },
+    .{
+        .name = "inspect: Iter.step_by of 0 is empty",
+        .source =
+        \\{
+        \\    iter = [1.I64, 2, 3].iter().step_by(0)
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[]" },
+    },
+    .{
+        .name = "inspect: Iter.step_by on empty source is empty",
+        .source =
+        \\{
+        \\    iter = [].iter().step_by(3)
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[]" },
+    },
+    .{
+        .name = "inspect: Iter.step_by larger than length yields first only",
+        .source =
+        \\{
+        \\    iter = [1.I64, 2, 3].iter().step_by(10)
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[1]" },
+    },
+    .{
+        .name = "inspect: Iter.step_by on a range",
+        .source =
+        \\{
+        \\    iter = (1.U64..=10).step_by(3)
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[1, 4, 7, 10]" },
+    },
+    .{
+        .name = "inspect: Iter.step_by counts values across skips from keep_if",
+        .source =
+        \\{
+        \\    evens = [1.I64, 2, 3, 4, 5, 6].iter().keep_if(|x| I64.rem_by(x, 2) == 0)
+        \\    Iter.fold(evens.step_by(2), [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[2, 6]" },
+    },
+    .{
+        .name = "inspect: Iter.step_by preserves known length as ceil",
+        .source = "Iter.size_hint([1.I64, 2, 3, 4, 5].iter().step_by(2))",
+        .expected = .{ .inspect_str = "Known(3)" },
+    },
+    .{
+        .name = "inspect: Iter.step_by known length on a range",
+        .source = "Iter.size_hint((1.U64..=10).step_by(3))",
+        .expected = .{ .inspect_str = "Known(4)" },
+    },
+    .{
+        .name = "inspect: Iter.step_by of 0 has known length zero",
+        .source = "Iter.size_hint([1.I64, 2, 3].iter().step_by(0))",
+        .expected = .{ .inspect_str = "Known(0)" },
+    },
+    .{
+        .name = "inspect: Iter.step_by reports unknown length for unknown source",
+        .source = "Iter.size_hint([1.I64, 2, 3, 4].iter().keep_if(|x| x > 1).step_by(2))",
+        .expected = .{ .inspect_str = "Unknown" },
+    },
+    .{
+        .name = "inspect: Iter.rev reverses items",
+        .source =
+        \\{
+        \\    iter = [1.I64, 2, 3].iter().rev()
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[3, 2, 1]" },
+    },
+    .{
+        .name = "inspect: Iter.rev on empty source is empty",
+        .source =
+        \\{
+        \\    iter = [].iter().rev()
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[]" },
+    },
+    .{
+        .name = "inspect: Iter.rev on a singleton",
+        .source =
+        \\{
+        \\    iter = [1.I64].iter().rev()
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[1]" },
+    },
+    .{
+        .name = "inspect: Iter.rev on a range",
+        .source =
+        \\{
+        \\    iter = (1.U64..=5).rev()
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[5, 4, 3, 2, 1]" },
+    },
+    .{
+        .name = "inspect: Iter.rev of unknown-length source upgrades to known",
+        .source =
+        \\{
+        \\    odds = [1.I64, 2, 3, 4, 5].iter().keep_if(|x| I64.rem_by(x, 2) == 1)
+        \\    Iter.fold(odds.rev(), [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[5, 3, 1]" },
+    },
+    .{
+        .name = "inspect: Iter.rev composed with step_by",
+        .source =
+        \\{
+        \\    iter = [1.I64, 2, 3, 4, 5].iter().step_by(2).rev()
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[5, 3, 1]" },
+    },
+    .{
+        .name = "inspect: Iter.rev reports known length",
+        .source = "Iter.size_hint([1.I64, 2, 3].iter().rev())",
+        .expected = .{ .inspect_str = "Known(3)" },
+    },
+    .{
+        .name = "inspect: Iter.rev upgrades unknown length to known",
+        .source = "Iter.size_hint([1.I64, 2, 3, 4, 5].iter().keep_if(|x| I64.rem_by(x, 2) == 1).rev())",
+        .expected = .{ .inspect_str = "Known(3)" },
+    },
     .{ .name = "inspect: List.any true on integers", .source = "List.any([1, 0, 1, 0, -1], |x| x > 0)", .expected = .{ .inspect_str = "True" } },
     .{ .name = "inspect: List.any false on positive integers with negative predicate", .source = "List.any([9, 8, 7, 6, 5], |x| x < 0)", .expected = .{ .inspect_str = "False" } },
     .{ .name = "inspect: List.any false on empty list", .source = "List.any([], |x| x < 0)", .expected = .{ .inspect_str = "False" } },


### PR DESCRIPTION
## Summary

Adds two new combinators to the `Iter(item)` builtin in `src/build/roc/Builtin.roc`:

- **`step_by : Iter(item), U64 -> Iter(item)`** — yields the first item, then every `n`th item after it (skipping the `n - 1` in between). A step of `0` yields an empty iterator. e.g. `[1, 2, 3, 4, 5].iter().step_by(2)` → `[1, 3, 5]`.
- **`rev : Iter(item) -> Iter(item)`** — yields the source's items in reverse order.

## Length preservation

Both combinators preserve `len_if_known` so that collecting stays efficient (pre-sized allocation + unchecked append):

- `step_by` maps a `Known(len)` source to `Known(ceil(len / n))`, computed as `(len - 1) / n + 1` to avoid overflow near `U64` max. It reuses `drop_first` internally, which decrements only on `One` and passes source `Skip`s through, so it counts *values* rather than skips. Unknown-length sources stay `Unknown`.
- `rev` materializes the source (the same approach `take_last`/`drop_last` already use, since `Iter` is forward-only), so the result always has a `Known` length — preserving a known length and upgrading an unknown one.

## Tests

Adds 20 eval cases in `src/eval/test/eval_tests.zig`, each checking yielded items and (where relevant) `Iter.size_hint`:

- `step_by`: odd/even length, step of 1 (identity), step of 0 (empty), empty source, step larger than length, on a range, and counting values across `Skip`s from `keep_if`; plus `size_hint` assertions (`Known(3)`, `Known(4)`, `Known(0)`, `Unknown`).
- `rev`: basic, empty, singleton, on a range, on an unknown-length source (length upgraded to `Known`), composed with `step_by`; plus `size_hint` assertions.

## Verification

- Full eval suite: **1355 passed, 0 failed**.
- `zig build run-check-builtin-format`: passes.
- No snapshot drift.