### PR TITLE
Add infinite loop statement classification

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -7959,11 +7959,330 @@ fn canonicalizeStandaloneWhileStatement(
     }
     const free_vars = self.scratch_free_vars.spanFrom(free_vars_start);
 
-    const stmt_idx = try self.env.addStatement(Statement{ .s_while = .{
-        .cond = cond.idx,
-        .body = body.idx,
-    } }, region);
+    const stmt_idx = try self.addClassifiedWhileStatement(cond.idx, body.idx, region);
     return CanonicalizedStatement{ .idx = stmt_idx, .free_vars = free_vars };
+}
+
+const LoopExitFacts = struct {
+    has_loop_owned_break: bool = false,
+    has_exit: bool = false,
+};
+
+const LoopScanFrame = union(enum) {
+    expr: struct {
+        idx: Expr.Idx,
+        loop_depth: u32,
+    },
+    stmt: struct {
+        idx: Statement.Idx,
+        loop_depth: u32,
+    },
+};
+
+fn addClassifiedWhileStatement(
+    self: *Self,
+    cond: Expr.Idx,
+    body: Expr.Idx,
+    region: Region,
+) std.mem.Allocator.Error!Statement.Idx {
+    const stmt = try self.classifyWhileStatement(cond, body, region);
+    return try self.env.addStatement(stmt, region);
+}
+
+fn classifyWhileStatement(
+    self: *Self,
+    cond: Expr.Idx,
+    body: Expr.Idx,
+    region: Region,
+) std.mem.Allocator.Error!Statement {
+    if (!self.isInfiniteLoopCondition(cond)) {
+        return Statement{ .s_while = .{ .cond = cond, .body = body } };
+    }
+
+    const facts = try self.scanLoopExitFacts(body);
+    if (facts.has_loop_owned_break) {
+        return Statement{ .s_breakable_loop = .{ .cond = cond, .body = body } };
+    }
+
+    if (!facts.has_exit) {
+        try self.env.pushDiagnostic(.{ .infinite_loop_never_exits = .{ .region = region } });
+    }
+
+    return Statement{ .s_infinite_loop = .{ .cond = cond, .body = body } };
+}
+
+fn isInfiniteLoopCondition(self: *const Self, expr_idx: Expr.Idx) bool {
+    return switch (self.env.store.getExpr(expr_idx)) {
+        .e_block => |block| blk: {
+            if (self.env.store.sliceStatements(block.stmts).len != 0) break :blk false;
+            break :blk self.isInfiniteLoopCondition(block.final_expr);
+        },
+        .e_tag => self.exprIsBareTrueTag(expr_idx),
+        .e_nominal => |nominal| nominal.backing_type == .tag and
+            self.isBuiltinBoolLocalNominal(nominal.nominal_type_decl) and
+            self.exprIsBareTrueTag(nominal.backing_expr),
+        .e_nominal_external => |nominal| nominal.backing_type == .tag and
+            self.isBuiltinBoolExternalNominal(nominal.module_idx, nominal.target_node_idx) and
+            self.exprIsBareTrueTag(nominal.backing_expr),
+        else => false,
+    };
+}
+
+fn exprIsBareTrueTag(self: *const Self, expr_idx: Expr.Idx) bool {
+    return switch (self.env.store.getExpr(expr_idx)) {
+        .e_tag => |tag| tag.name.eql(self.env.idents.true_tag) and tag.args.span.len == 0,
+        else => false,
+    };
+}
+
+fn isBuiltinBoolLocalNominal(self: *const Self, nominal_type_decl: Statement.Idx) bool {
+    if (self.env.module_role != .builtin) return false;
+
+    return switch (self.env.store.getStatement(nominal_type_decl)) {
+        .s_nominal_decl => |decl| self.env.store.getTypeHeader(decl.header).name.eql(self.env.idents.bool),
+        else => false,
+    };
+}
+
+fn isBuiltinBoolExternalNominal(self: *const Self, module_idx: Import.Idx, target_node_idx: u32) bool {
+    const bool_info = self.builtin_auto_imported_types.get(self.env.idents.bool) orelse return false;
+    const bool_stmt_idx = bool_info.statement_idx orelse return false;
+    const bool_target_node_idx = bool_info.env.getExposedNodeIndexByStatementIdx(bool_stmt_idx) orelse return false;
+    if (target_node_idx != bool_target_node_idx) return false;
+
+    const module_idx_int = @intFromEnum(module_idx);
+    if (module_idx_int >= self.env.imports.imports.items.items.len) return false;
+
+    const string_lit_idx = self.env.imports.imports.items.items[module_idx_int];
+    const module_name = self.env.common.strings.get(string_lit_idx);
+    if (bool_info.env.module_role == .builtin) {
+        return std.mem.eql(u8, module_name, "Builtin") or CIR.Import.isCompilerBuiltinImportName(module_name);
+    }
+
+    return std.mem.eql(u8, module_name, bool_info.env.module_name);
+}
+
+fn scanLoopExitFacts(self: *Self, body: Expr.Idx) std.mem.Allocator.Error!LoopExitFacts {
+    var stack_allocator_state = std.heap.stackFallback(4096, self.env.gpa);
+    const stack_allocator = stack_allocator_state.get();
+    var pending: std.ArrayList(LoopScanFrame) = .empty;
+    defer pending.deinit(stack_allocator);
+
+    var facts = LoopExitFacts{};
+    try pending.append(stack_allocator, .{ .expr = .{ .idx = body, .loop_depth = 0 } });
+
+    while (pending.pop()) |frame| {
+        switch (frame) {
+            .expr => |expr_frame| {
+                const expr = self.env.store.getExpr(expr_frame.idx);
+                switch (expr) {
+                    .e_block => |block| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = block.final_expr, .loop_depth = expr_frame.loop_depth } });
+                        for (self.env.store.sliceStatements(block.stmts)) |stmt_idx| {
+                            try pending.append(stack_allocator, .{ .stmt = .{ .idx = stmt_idx, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_if => |if_expr| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = if_expr.final_else, .loop_depth = expr_frame.loop_depth } });
+                        for (self.env.store.sliceIfBranches(if_expr.branches)) |branch_idx| {
+                            const branch = self.env.store.getIfBranch(branch_idx);
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = branch.body, .loop_depth = expr_frame.loop_depth } });
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = branch.cond, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_match => |match_expr| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = match_expr.cond, .loop_depth = expr_frame.loop_depth } });
+                        for (self.env.store.sliceMatchBranches(match_expr.branches)) |branch_idx| {
+                            const branch = self.env.store.getMatchBranch(branch_idx);
+                            if (branch.guard) |guard| {
+                                try pending.append(stack_allocator, .{ .expr = .{ .idx = guard, .loop_depth = expr_frame.loop_depth } });
+                            }
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = branch.value, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_call => |call| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = call.func, .loop_depth = expr_frame.loop_depth } });
+                        for (self.env.store.sliceExpr(call.args)) |arg| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = arg, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_binop => |binop| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = binop.lhs, .loop_depth = expr_frame.loop_depth } });
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = binop.rhs, .loop_depth = expr_frame.loop_depth } });
+                    },
+                    .e_unary_minus => |unary| try pending.append(stack_allocator, .{ .expr = .{ .idx = unary.expr, .loop_depth = expr_frame.loop_depth } }),
+                    .e_unary_not => |unary| try pending.append(stack_allocator, .{ .expr = .{ .idx = unary.expr, .loop_depth = expr_frame.loop_depth } }),
+                    .e_field_access => |field| try pending.append(stack_allocator, .{ .expr = .{ .idx = field.receiver, .loop_depth = expr_frame.loop_depth } }),
+                    .e_method_call => |call| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = call.receiver, .loop_depth = expr_frame.loop_depth } });
+                        for (self.env.store.sliceExpr(call.args)) |arg| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = arg, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_dispatch_call => |call| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = call.receiver, .loop_depth = expr_frame.loop_depth } });
+                        for (self.env.store.sliceExpr(call.args)) |arg| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = arg, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_interpolation => |interpolation| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = interpolation.first, .loop_depth = expr_frame.loop_depth } });
+                        for (self.env.store.sliceExpr(interpolation.parts)) |part| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = part, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_structural_eq => |eq| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = eq.lhs, .loop_depth = expr_frame.loop_depth } });
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = eq.rhs, .loop_depth = expr_frame.loop_depth } });
+                    },
+                    .e_method_eq => |eq| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = eq.lhs, .loop_depth = expr_frame.loop_depth } });
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = eq.rhs, .loop_depth = expr_frame.loop_depth } });
+                    },
+                    .e_type_method_call => |call| {
+                        for (self.env.store.sliceExpr(call.args)) |arg| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = arg, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_type_dispatch_call => |call| {
+                        for (self.env.store.sliceExpr(call.args)) |arg| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = arg, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_tuple_access => |access| try pending.append(stack_allocator, .{ .expr = .{ .idx = access.tuple, .loop_depth = expr_frame.loop_depth } }),
+                    .e_list => |list| {
+                        for (self.env.store.sliceExpr(list.elems)) |elem| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = elem, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_tuple => |tuple| {
+                        for (self.env.store.sliceExpr(tuple.elems)) |elem| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = elem, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_record => |record| {
+                        if (record.ext) |ext| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = ext, .loop_depth = expr_frame.loop_depth } });
+                        }
+                        for (self.env.store.sliceRecordFields(record.fields)) |field_idx| {
+                            const field = self.env.store.getRecordField(field_idx);
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = field.value, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_str => |str| {
+                        for (self.env.store.sliceExpr(str.span)) |segment| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = segment, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_tag => |tag| {
+                        for (self.env.store.sliceExpr(tag.args)) |arg| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = arg, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_nominal => |nominal| try pending.append(stack_allocator, .{ .expr = .{ .idx = nominal.backing_expr, .loop_depth = expr_frame.loop_depth } }),
+                    .e_nominal_external => |nominal| try pending.append(stack_allocator, .{ .expr = .{ .idx = nominal.backing_expr, .loop_depth = expr_frame.loop_depth } }),
+                    .e_dbg => |dbg| try pending.append(stack_allocator, .{ .expr = .{ .idx = dbg.expr, .loop_depth = expr_frame.loop_depth } }),
+                    .e_expect => |expect| try pending.append(stack_allocator, .{ .expr = .{ .idx = expect.body, .loop_depth = expr_frame.loop_depth } }),
+                    .e_expect_err => |expect_err| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = expect_err.expr, .loop_depth = expr_frame.loop_depth } });
+                    },
+                    .e_return => |ret| {
+                        if (self.enclosing_lambda == null or ret.lambda == self.enclosing_lambda.?) {
+                            facts.has_exit = true;
+                        }
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = ret.expr, .loop_depth = expr_frame.loop_depth } });
+                    },
+                    .e_crash => {
+                        facts.has_exit = true;
+                    },
+                    .e_for => |for_expr| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = for_expr.expr, .loop_depth = expr_frame.loop_depth } });
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = for_expr.body, .loop_depth = expr_frame.loop_depth + 1 } });
+                    },
+                    .e_run_low_level => |run_low_level| {
+                        for (self.env.store.sliceExpr(run_low_level.args)) |arg| {
+                            try pending.append(stack_allocator, .{ .expr = .{ .idx = arg, .loop_depth = expr_frame.loop_depth } });
+                        }
+                    },
+                    .e_lambda,
+                    .e_closure,
+                    .e_hosted_lambda,
+                    .e_num,
+                    .e_frac_f32,
+                    .e_frac_f64,
+                    .e_dec,
+                    .e_dec_small,
+                    .e_num_from_numeral,
+                    .e_typed_int,
+                    .e_typed_frac,
+                    .e_typed_num_from_numeral,
+                    .e_str_segment,
+                    .e_bytes_literal,
+                    .e_lookup_local,
+                    .e_lookup_external,
+                    .e_lookup_required,
+                    .e_empty_list,
+                    .e_empty_record,
+                    .e_zero_argument_tag,
+                    .e_runtime_error,
+                    .e_ellipsis,
+                    .e_anno_only,
+                    => {},
+                }
+            },
+            .stmt => |stmt_frame| {
+                const stmt = self.env.store.getStatement(stmt_frame.idx);
+                switch (stmt) {
+                    .s_decl => |decl| try pending.append(stack_allocator, .{ .expr = .{ .idx = decl.expr, .loop_depth = stmt_frame.loop_depth } }),
+                    .s_var => |var_stmt| try pending.append(stack_allocator, .{ .expr = .{ .idx = var_stmt.expr, .loop_depth = stmt_frame.loop_depth } }),
+                    .s_reassign => |reassign| try pending.append(stack_allocator, .{ .expr = .{ .idx = reassign.expr, .loop_depth = stmt_frame.loop_depth } }),
+                    .s_dbg => |dbg| try pending.append(stack_allocator, .{ .expr = .{ .idx = dbg.expr, .loop_depth = stmt_frame.loop_depth } }),
+                    .s_expr => |expr_stmt| try pending.append(stack_allocator, .{ .expr = .{ .idx = expr_stmt.expr, .loop_depth = stmt_frame.loop_depth } }),
+                    .s_expect => |expect| try pending.append(stack_allocator, .{ .expr = .{ .idx = expect.body, .loop_depth = stmt_frame.loop_depth } }),
+                    .s_for => |for_stmt| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = for_stmt.expr, .loop_depth = stmt_frame.loop_depth } });
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = for_stmt.body, .loop_depth = stmt_frame.loop_depth + 1 } });
+                    },
+                    .s_while => |while_stmt| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = while_stmt.cond, .loop_depth = stmt_frame.loop_depth } });
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = while_stmt.body, .loop_depth = stmt_frame.loop_depth + 1 } });
+                    },
+                    .s_infinite_loop => |loop_stmt| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = loop_stmt.cond, .loop_depth = stmt_frame.loop_depth } });
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = loop_stmt.body, .loop_depth = stmt_frame.loop_depth + 1 } });
+                    },
+                    .s_breakable_loop => |loop_stmt| {
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = loop_stmt.cond, .loop_depth = stmt_frame.loop_depth } });
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = loop_stmt.body, .loop_depth = stmt_frame.loop_depth + 1 } });
+                    },
+                    .s_crash => {
+                        facts.has_exit = true;
+                    },
+                    .s_return => |ret| {
+                        if (self.enclosing_lambda == null or ret.lambda == self.enclosing_lambda.?) {
+                            facts.has_exit = true;
+                        }
+                        try pending.append(stack_allocator, .{ .expr = .{ .idx = ret.expr, .loop_depth = stmt_frame.loop_depth } });
+                    },
+                    .s_break => {
+                        if (stmt_frame.loop_depth == 0) {
+                            facts.has_loop_owned_break = true;
+                            return facts;
+                        }
+                    },
+                    .s_import,
+                    .s_alias_decl,
+                    .s_nominal_decl,
+                    .s_type_anno,
+                    .s_type_var_alias,
+                    .s_runtime_error,
+                    => {},
+                }
+            },
+        }
+    }
+
+    return facts;
 }
 
 fn canonicalizeStandaloneForStatement(
@@ -9721,12 +10040,7 @@ fn runExprKernel(
             }
             const free_vars = self.scratch_free_vars.spanFrom(free_vars_start);
 
-            const stmt_idx = try self.env.addStatement(Statement{
-                .s_while = .{
-                    .cond = state.cond.idx,
-                    .body = body.idx,
-                },
-            }, state.region);
+            const stmt_idx = try self.addClassifiedWhileStatement(state.cond.idx, body.idx, state.region);
             try self.addBlockStatement(blockContextFromState(state.block), CanonicalizedStatement{ .idx = stmt_idx, .free_vars = free_vars });
             child_slots.shrinkRetainingCapacity(state.block.result_start);
             try stacks.pushBlockNext(frame_allocator, .{ .block = state.block, .next = state.next });

--- a/src/canonicalize/DependencyGraph.zig
+++ b/src/canonicalize/DependencyGraph.zig
@@ -251,6 +251,14 @@ fn collectExprDependencies(
                             try pending.append(stack_allocator, while_stmt.body);
                             try pending.append(stack_allocator, while_stmt.cond);
                         },
+                        .s_infinite_loop => |loop_stmt| {
+                            try pending.append(stack_allocator, loop_stmt.body);
+                            try pending.append(stack_allocator, loop_stmt.cond);
+                        },
+                        .s_breakable_loop => |loop_stmt| {
+                            try pending.append(stack_allocator, loop_stmt.body);
+                            try pending.append(stack_allocator, loop_stmt.cond);
+                        },
                         .s_return => |ret| try pending.append(stack_allocator, ret.expr),
                         .s_import, .s_alias_decl, .s_nominal_decl, .s_type_anno, .s_type_var_alias, .s_crash, .s_runtime_error, .s_break => {},
                     }

--- a/src/canonicalize/Diagnostic.zig
+++ b/src/canonicalize/Diagnostic.zig
@@ -327,6 +327,9 @@ pub const Diagnostic = union(enum) {
     break_outside_loop: struct {
         region: Region,
     },
+    infinite_loop_never_exits: struct {
+        region: Region,
+    },
     return_outside_fn: struct {
         region: Region,
         context: ReturnContext,
@@ -434,6 +437,7 @@ pub const Diagnostic = union(enum) {
             .type_var_starting_with_dollar => |d| d.region,
             .underscore_in_type_declaration => |d| d.region,
             .break_outside_loop => |d| d.region,
+            .infinite_loop_never_exits => |d| d.region,
             .return_outside_fn => |d| d.region,
             .mutually_recursive_type_aliases => |d| d.region,
             .deprecated_number_suffix => |d| d.region,

--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -2842,6 +2842,32 @@ pub fn diagnosticToReport(self: *Self, diagnostic: CIR.Diagnostic, allocator: st
 
             break :blk report;
         },
+        .infinite_loop_never_exits => |data| blk: {
+            const region_info = self.calcRegionInfo(data.region);
+
+            var report = Report.init(allocator, "INFINITE LOOP NEVER EXITS", .warning);
+            try report.document.addReflowingText("This infinite loop has no ");
+            try report.document.addAnnotated("return", .inline_code);
+            try report.document.addReflowingText(", ");
+            try report.document.addAnnotated("?", .inline_code);
+            try report.document.addReflowingText(", ");
+            try report.document.addAnnotated("crash", .inline_code);
+            try report.document.addReflowingText(", or ");
+            try report.document.addAnnotated("break", .inline_code);
+            try report.document.addReflowingText(" that exits this loop, so it will run forever and hang the program.");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+
+            try report.document.addSourceRegion(
+                region_info,
+                .error_highlight,
+                filename,
+                self.getSourceAll(),
+                self.getLineStartsAll(),
+            );
+
+            break :blk report;
+        },
         .return_outside_fn => |data| blk: {
             const region_info = self.calcRegionInfo(data.region);
 

--- a/src/canonicalize/Node.zig
+++ b/src/canonicalize/Node.zig
@@ -46,6 +46,8 @@ pub const Tag = enum {
     statement_expect,
     statement_for,
     statement_while,
+    statement_infinite_loop,
+    statement_breakable_loop,
     statement_break,
     statement_return,
     statement_import,
@@ -261,6 +263,7 @@ pub const Tag = enum {
     diag_mutually_recursive_type_aliases,
     diag_deprecated_number_suffix,
     diag_range_op_chained,
+    diag_infinite_loop_never_exits,
 };
 
 /// Typed payload union for accessing node data in a type-safe manner.

--- a/src/canonicalize/NodeStore.zig
+++ b/src/canonicalize/NodeStore.zig
@@ -387,11 +387,11 @@ pub fn relocate(store: *NodeStore, offset: isize) void {
 /// when adding/removing variants from ModuleEnv unions. Update these when modifying the unions.
 ///
 /// Count of the diagnostic nodes in the ModuleEnv
-pub const MODULEENV_DIAGNOSTIC_NODE_COUNT = 78;
+pub const MODULEENV_DIAGNOSTIC_NODE_COUNT = 79;
 /// Count of the expression nodes in the ModuleEnv
 pub const MODULEENV_EXPR_NODE_COUNT = 53;
 /// Count of the statement nodes in the ModuleEnv
-pub const MODULEENV_STATEMENT_NODE_COUNT = 17;
+pub const MODULEENV_STATEMENT_NODE_COUNT = 19;
 /// Count of the type annotation nodes in the ModuleEnv
 pub const MODULEENV_TYPE_ANNO_NODE_COUNT = 12;
 /// Count of the pattern nodes in the ModuleEnv
@@ -602,6 +602,20 @@ pub fn getStatement(store: *const NodeStore, statement: CIR.Statement.Idx) CIR.S
         .statement_while => {
             const p = payload.statement_while;
             return CIR.Statement{ .s_while = .{
+                .cond = @enumFromInt(p.cond),
+                .body = @enumFromInt(p.body),
+            } };
+        },
+        .statement_infinite_loop => {
+            const p = payload.statement_while;
+            return CIR.Statement{ .s_infinite_loop = .{
+                .cond = @enumFromInt(p.cond),
+                .body = @enumFromInt(p.body),
+            } };
+        },
+        .statement_breakable_loop => {
+            const p = payload.statement_while;
+            return CIR.Statement{ .s_breakable_loop = .{
                 .cond = @enumFromInt(p.cond),
                 .body = @enumFromInt(p.body),
             } };
@@ -2064,6 +2078,20 @@ fn makeStatementNode(store: *NodeStore, statement: CIR.Statement) Allocator.Erro
         },
         .s_while => |s| {
             node.tag = .statement_while;
+            node.setPayload(.{ .statement_while = .{
+                .cond = @intFromEnum(s.cond),
+                .body = @intFromEnum(s.body),
+            } });
+        },
+        .s_infinite_loop => |s| {
+            node.tag = .statement_infinite_loop;
+            node.setPayload(.{ .statement_while = .{
+                .cond = @intFromEnum(s.cond),
+                .body = @intFromEnum(s.body),
+            } });
+        },
+        .s_breakable_loop => |s| {
+            node.tag = .statement_breakable_loop;
             node.setPayload(.{ .statement_while = .{
                 .cond = @intFromEnum(s.cond),
                 .body = @intFromEnum(s.body),
@@ -4082,6 +4110,10 @@ pub fn addDiagnosticUnregistered(store: *NodeStore, reason: CIR.Diagnostic) Allo
             node.tag = .diag_break_outside_loop;
             region = r.region;
         },
+        .infinite_loop_never_exits => |r| {
+            node.tag = .diag_infinite_loop_never_exits;
+            region = r.region;
+        },
         .return_outside_fn => |r| {
             node.tag = .diag_return_outside_fn;
             region = r.region;
@@ -4535,6 +4567,9 @@ pub fn getDiagnostic(store: *const NodeStore, diagnostic: CIR.Diagnostic.Idx) CI
             .region = store.getRegionAt(node_idx),
         } },
         .diag_break_outside_loop => return CIR.Diagnostic{ .break_outside_loop = .{
+            .region = store.getRegionAt(node_idx),
+        } },
+        .diag_infinite_loop_never_exits => return CIR.Diagnostic{ .infinite_loop_never_exits = .{
             .region = store.getRegionAt(node_idx),
         } },
         .diag_return_outside_fn => {

--- a/src/canonicalize/Statement.zig
+++ b/src/canonicalize/Statement.zig
@@ -121,6 +121,20 @@ pub const Statement = union(enum) {
         cond: Expr.Idx,
         body: Expr.Idx,
     },
+    /// A `while True`/`while Bool.True` loop that cannot break from this loop.
+    ///
+    /// Kept distinct from `s_while` so type checking can treat it as divergent.
+    s_infinite_loop: struct {
+        cond: Expr.Idx,
+        body: Expr.Idx,
+    },
+    /// A `while True`/`while Bool.True` loop with a break that exits this loop.
+    ///
+    /// This has the same type as an ordinary `while`, but stays distinct for tooling.
+    s_breakable_loop: struct {
+        cond: Expr.Idx,
+        body: Expr.Idx,
+    },
     /// A early break from the nearest enclosing loop.
     ///
     /// Not valid at the top level of a module
@@ -306,6 +320,30 @@ pub const Statement = union(enum) {
             .s_while => |s| {
                 const begin = tree.beginNode();
                 try tree.pushStaticAtom("s-while");
+                const region = env.store.getStatementRegion(stmt_idx);
+                try env.appendRegionInfoToSExprTreeFromRegion(tree, region);
+                const attrs = tree.beginNode();
+
+                try env.store.getExpr(s.cond).pushToSExprTree(env, tree, s.cond);
+                try env.store.getExpr(s.body).pushToSExprTree(env, tree, s.body);
+
+                try tree.endNode(begin, attrs);
+            },
+            .s_infinite_loop => |s| {
+                const begin = tree.beginNode();
+                try tree.pushStaticAtom("s-infinite-loop");
+                const region = env.store.getStatementRegion(stmt_idx);
+                try env.appendRegionInfoToSExprTreeFromRegion(tree, region);
+                const attrs = tree.beginNode();
+
+                try env.store.getExpr(s.cond).pushToSExprTree(env, tree, s.cond);
+                try env.store.getExpr(s.body).pushToSExprTree(env, tree, s.body);
+
+                try tree.endNode(begin, attrs);
+            },
+            .s_breakable_loop => |s| {
+                const begin = tree.beginNode();
+                try tree.pushStaticAtom("s-breakable-loop");
                 const region = env.store.getStatementRegion(stmt_idx);
                 try env.appendRegionInfoToSExprTreeFromRegion(tree, region);
                 const attrs = tree.beginNode();

--- a/src/canonicalize/mod.zig
+++ b/src/canonicalize/mod.zig
@@ -112,6 +112,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/record_test.zig"));
     std.testing.refAllDecls(@import("test/type_decl_stmt_test.zig"));
     std.testing.refAllDecls(@import("test/local_let_scoping_test.zig"));
+    std.testing.refAllDecls(@import("test/while_loop_test.zig"));
 
     // Backend tests (Roc emitter)
     std.testing.refAllDecls(@import("RocEmitter.zig"));

--- a/src/canonicalize/test/node_store_test.zig
+++ b/src/canonicalize/test/node_store_test.zig
@@ -125,6 +125,20 @@ test "NodeStore round trip - Statements" {
     });
 
     try statements.append(gpa, CIR.Statement{
+        .s_infinite_loop = .{
+            .cond = rand_idx(CIR.Expr.Idx),
+            .body = rand_idx(CIR.Expr.Idx),
+        },
+    });
+
+    try statements.append(gpa, CIR.Statement{
+        .s_breakable_loop = .{
+            .cond = rand_idx(CIR.Expr.Idx),
+            .body = rand_idx(CIR.Expr.Idx),
+        },
+    });
+
+    try statements.append(gpa, CIR.Statement{
         .s_return = .{
             .expr = rand_idx(CIR.Expr.Idx),
             .lambda = rand_idx(CIR.Expr.Idx),
@@ -1033,6 +1047,12 @@ test "NodeStore round trip - Diagnostics" {
 
     try diagnostics.append(gpa, CIR.Diagnostic{
         .break_outside_loop = .{
+            .region = rand_region(),
+        },
+    });
+
+    try diagnostics.append(gpa, CIR.Diagnostic{
+        .infinite_loop_never_exits = .{
             .region = rand_region(),
         },
     });

--- a/src/canonicalize/test/while_loop_test.zig
+++ b/src/canonicalize/test/while_loop_test.zig
@@ -1,0 +1,419 @@
+//! Tests for canonicalizing while loops.
+
+const std = @import("std");
+const testing = std.testing;
+
+const CIR = @import("../CIR.zig");
+const TestEnv = @import("TestEnv.zig").TestEnv;
+
+fn firstBlockStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) !CIR.Statement {
+    return try blockStatementAt(test_env, expr_idx, 0);
+}
+
+fn blockStatementAt(test_env: *TestEnv, expr_idx: CIR.Expr.Idx, index: usize) !CIR.Statement {
+    const expr = test_env.getCanonicalExpr(expr_idx);
+    try testing.expectEqual(.e_block, std.meta.activeTag(expr));
+
+    const statements = test_env.module_env.store.sliceStatements(expr.e_block.stmts);
+    try testing.expect(index < statements.len);
+
+    return test_env.module_env.store.getStatement(statements[index]);
+}
+
+fn firstLambdaBodyStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) !CIR.Statement {
+    const expr = test_env.getCanonicalExpr(expr_idx);
+    const lambda_idx = switch (expr) {
+        .e_lambda => expr_idx,
+        .e_closure => |closure| closure.lambda_idx,
+        else => return error.ExpectedLambda,
+    };
+
+    const lambda = test_env.getCanonicalExpr(lambda_idx);
+    try testing.expectEqual(.e_lambda, std.meta.activeTag(lambda));
+
+    return try firstBlockStatement(test_env, lambda.e_lambda.body);
+}
+
+fn expectDiagnosticTag(test_env: *TestEnv, expected: std.meta.Tag(CIR.Diagnostic)) !void {
+    const diagnostics = try test_env.getDiagnostics();
+    defer testing.allocator.free(diagnostics);
+
+    for (diagnostics) |diagnostic| {
+        if (std.meta.activeTag(diagnostic) == expected) return;
+    }
+
+    return error.ExpectedDiagnosticNotFound;
+}
+
+fn expectNoDiagnosticTag(test_env: *TestEnv, unexpected: std.meta.Tag(CIR.Diagnostic)) !void {
+    const diagnostics = try test_env.getDiagnostics();
+    defer testing.allocator.free(diagnostics);
+
+    for (diagnostics) |diagnostic| {
+        try testing.expect(std.meta.activeTag(diagnostic) != unexpected);
+    }
+}
+
+test "while True with an exit canonicalizes as infinite_loop" {
+    const source =
+        \\{
+        \\    while True {
+        \\        crash "done"
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+}
+
+test "while parenthesized True canonicalizes as infinite_loop" {
+    const source =
+        \\{
+        \\    while ((True)) {
+        \\        crash "done"
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+}
+
+test "while Bool.True canonicalizes as infinite_loop" {
+    const source =
+        \\{
+        \\    while Bool.True {
+        \\        crash "done"
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+}
+
+test "while False does not canonicalize as infinite_loop" {
+    const source =
+        \\{
+        \\    while False {
+        \\        crash "done"
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_while, std.meta.activeTag(stmt));
+}
+
+test "while Bool.False does not canonicalize as infinite_loop" {
+    const source =
+        \\{
+        \\    while Bool.False {
+        \\        crash "done"
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_while, std.meta.activeTag(stmt));
+}
+
+test "while block True condition with no statements canonicalizes as infinite_loop" {
+    const source =
+        \\{
+        \\    while { True } {
+        \\        crash "done"
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+}
+
+test "while block True condition with statements does not canonicalize as infinite_loop" {
+    const source =
+        \\{
+        \\    while {
+        \\        dbg "condition"
+        \\        True
+        \\    } {
+        \\        crash "done"
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_while, std.meta.activeTag(stmt));
+}
+
+test "non-builtin nominal True does not canonicalize as infinite_loop" {
+    const source =
+        \\{
+        \\    MyBool := [False, True]
+        \\    while MyBool.True {
+        \\        crash "done"
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try blockStatementAt(&test_env, canonical_expr.get_idx(), 1);
+
+    try testing.expectEqual(.s_while, std.meta.activeTag(stmt));
+}
+
+test "while True with loop-owned break canonicalizes as breakable_loop" {
+    const source =
+        \\{
+        \\    while True {
+        \\        break
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_breakable_loop, std.meta.activeTag(stmt));
+}
+
+test "break inside if makes while True breakable_loop" {
+    const source =
+        \\{
+        \\    while True {
+        \\        if Bool.True {
+        \\            break
+        \\        }
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_breakable_loop, std.meta.activeTag(stmt));
+}
+
+test "break inside nested loop does not make outer while True breakable" {
+    const source =
+        \\{
+        \\    while True {
+        \\        for item in [] {
+        \\            break
+        \\        }
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+    try expectDiagnosticTag(&test_env, .infinite_loop_never_exits);
+}
+
+test "break inside nested while does not make outer while True breakable" {
+    const source =
+        \\{
+        \\    while True {
+        \\        while Bool.False {
+        \\            break
+        \\        }
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+    try expectDiagnosticTag(&test_env, .infinite_loop_never_exits);
+}
+
+test "while True with no exits warns" {
+    const source =
+        \\{
+        \\    while True {
+        \\        dbg "still running"
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+    try expectDiagnosticTag(&test_env, .infinite_loop_never_exits);
+}
+
+test "return inside while True suppresses infinite loop warning" {
+    const source =
+        \\|_| {
+        \\    while True {
+        \\        return 1
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstLambdaBodyStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+    try expectNoDiagnosticTag(&test_env, .infinite_loop_never_exits);
+}
+
+test "try suffix inside while True suppresses infinite loop warning" {
+    const source =
+        \\|_| {
+        \\    while True {
+        \\        Try.Err("bad")?
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstLambdaBodyStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+    try expectNoDiagnosticTag(&test_env, .infinite_loop_never_exits);
+}
+
+test "crash inside while True suppresses infinite loop warning" {
+    const source =
+        \\{
+        \\    while True {
+        \\        crash "done"
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+    try expectNoDiagnosticTag(&test_env, .infinite_loop_never_exits);
+}
+
+test "expect inside while True does not suppress infinite loop warning" {
+    const source =
+        \\{
+        \\    while True {
+        \\        expect Bool.True
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+    try expectDiagnosticTag(&test_env, .infinite_loop_never_exits);
+}
+
+test "try suffix inside expect does not suppress infinite loop warning" {
+    const source =
+        \\{
+        \\    while True {
+        \\        expect Try.Err("bad")? == "ok"
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+    try expectDiagnosticTag(&test_env, .infinite_loop_never_exits);
+}
+
+test "return inside nested lambda does not count as infinite loop exit" {
+    const source =
+        \\{
+        \\    while True {
+        \\        f = |_| {
+        \\            return 1
+        \\        }
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+    try expectDiagnosticTag(&test_env, .infinite_loop_never_exits);
+}
+
+test "crash inside nested lambda does not count as infinite loop exit" {
+    const source =
+        \\{
+        \\    while True {
+        \\        f = |_| {
+        \\            crash "done"
+        \\        }
+        \\    }
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const stmt = try firstBlockStatement(&test_env, canonical_expr.get_idx());
+
+    try testing.expectEqual(.s_infinite_loop, std.meta.activeTag(stmt));
+    try expectDiagnosticTag(&test_env, .infinite_loop_never_exits);
+}

--- a/src/canonicalize/test/while_loop_test.zig
+++ b/src/canonicalize/test/while_loop_test.zig
@@ -6,11 +6,11 @@ const testing = std.testing;
 const CIR = @import("../CIR.zig");
 const TestEnv = @import("TestEnv.zig").TestEnv;
 
-fn firstBlockStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) !CIR.Statement {
+fn firstBlockStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) anyerror!CIR.Statement {
     return try blockStatementAt(test_env, expr_idx, 0);
 }
 
-fn blockStatementAt(test_env: *TestEnv, expr_idx: CIR.Expr.Idx, index: usize) !CIR.Statement {
+fn blockStatementAt(test_env: *TestEnv, expr_idx: CIR.Expr.Idx, index: usize) anyerror!CIR.Statement {
     const expr = test_env.getCanonicalExpr(expr_idx);
     try testing.expectEqual(.e_block, std.meta.activeTag(expr));
 
@@ -20,7 +20,7 @@ fn blockStatementAt(test_env: *TestEnv, expr_idx: CIR.Expr.Idx, index: usize) !C
     return test_env.module_env.store.getStatement(statements[index]);
 }
 
-fn firstLambdaBodyStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) !CIR.Statement {
+fn firstLambdaBodyStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) anyerror!CIR.Statement {
     const expr = test_env.getCanonicalExpr(expr_idx);
     const lambda_idx = switch (expr) {
         .e_lambda => expr_idx,
@@ -34,7 +34,7 @@ fn firstLambdaBodyStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) !CIR.Sta
     return try firstBlockStatement(test_env, lambda.e_lambda.body);
 }
 
-fn expectDiagnosticTag(test_env: *TestEnv, expected: std.meta.Tag(CIR.Diagnostic)) !void {
+fn expectDiagnosticTag(test_env: *TestEnv, expected: std.meta.Tag(CIR.Diagnostic)) anyerror!void {
     const diagnostics = try test_env.getDiagnostics();
     defer testing.allocator.free(diagnostics);
 
@@ -45,7 +45,7 @@ fn expectDiagnosticTag(test_env: *TestEnv, expected: std.meta.Tag(CIR.Diagnostic
     return error.ExpectedDiagnosticNotFound;
 }
 
-fn expectNoDiagnosticTag(test_env: *TestEnv, unexpected: std.meta.Tag(CIR.Diagnostic)) !void {
+fn expectNoDiagnosticTag(test_env: *TestEnv, unexpected: std.meta.Tag(CIR.Diagnostic)) anyerror!void {
     const diagnostics = try test_env.getDiagnostics();
     defer testing.allocator.free(diagnostics);
 

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -8401,6 +8401,30 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                 const empty_rec = try self.freshFromContent(.{ .structure = .empty_record }, env, cond_region);
                 _ = try self.unify(stmt_var, empty_rec, env);
             },
+            .s_breakable_loop => |while_stmt| {
+                does_fx = try self.checkExpr(while_stmt.cond, env, Expected.none()) or does_fx;
+                const cond_var: Var = ModuleEnv.varFrom(while_stmt.cond);
+                const cond_region = self.cir.store.getNodeRegion(ModuleEnv.nodeIdxFrom(while_stmt.cond));
+
+                const bool_var = try self.freshBool(env, cond_region);
+                _ = try self.unify(bool_var, cond_var, env);
+
+                does_fx = try self.checkExpr(while_stmt.body, env, Expected.none()) or does_fx;
+                const empty_rec = try self.freshFromContent(.{ .structure = .empty_record }, env, cond_region);
+                _ = try self.unify(stmt_var, empty_rec, env);
+            },
+            .s_infinite_loop => |while_stmt| {
+                does_fx = try self.checkExpr(while_stmt.cond, env, Expected.none()) or does_fx;
+                const cond_var: Var = ModuleEnv.varFrom(while_stmt.cond);
+                const cond_region = self.cir.store.getNodeRegion(ModuleEnv.nodeIdxFrom(while_stmt.cond));
+
+                const bool_var = try self.freshBool(env, cond_region);
+                _ = try self.unify(bool_var, cond_var, env);
+
+                does_fx = try self.checkExpr(while_stmt.body, env, Expected.none()) or does_fx;
+                try self.unifyWith(stmt_var, .{ .flex = Flex.init() }, env);
+                diverges = true;
+            },
             .s_expr => |expr| {
                 does_fx = try self.checkExpr(expr.expr, env, Expected.none()) or does_fx;
                 const expr_var: Var = ModuleEnv.varFrom(expr.expr);

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -1107,6 +1107,10 @@ fn statementDependsOnUnboundPlatformRequirement(
             exprDependsOnUnboundPlatformRequirement(checked_bodies, resolved_value_refs, for_.body, relation_blocked_exprs),
         .while_ => |while_| exprDependsOnUnboundPlatformRequirement(checked_bodies, resolved_value_refs, while_.cond, relation_blocked_exprs) or
             exprDependsOnUnboundPlatformRequirement(checked_bodies, resolved_value_refs, while_.body, relation_blocked_exprs),
+        .infinite_loop => |loop| exprDependsOnUnboundPlatformRequirement(checked_bodies, resolved_value_refs, loop.cond, relation_blocked_exprs) or
+            exprDependsOnUnboundPlatformRequirement(checked_bodies, resolved_value_refs, loop.body, relation_blocked_exprs),
+        .breakable_loop => |loop| exprDependsOnUnboundPlatformRequirement(checked_bodies, resolved_value_refs, loop.cond, relation_blocked_exprs) or
+            exprDependsOnUnboundPlatformRequirement(checked_bodies, resolved_value_refs, loop.body, relation_blocked_exprs),
         .return_ => |ret| exprDependsOnUnboundPlatformRequirement(checked_bodies, resolved_value_refs, ret.expr, relation_blocked_exprs),
         .pending,
         .crash,
@@ -4877,6 +4881,8 @@ pub const CheckedStatementData = union(enum) {
         plan: ?static_dispatch.IteratorForPlanId,
     },
     while_: struct { cond: CheckedExprId, body: CheckedExprId },
+    infinite_loop: struct { cond: CheckedExprId, body: CheckedExprId },
+    breakable_loop: struct { cond: CheckedExprId, body: CheckedExprId },
     break_,
     return_: struct { expr: CheckedExprId, lambda: CheckedExprId },
     import_,
@@ -5564,6 +5570,14 @@ const CheckedSourceNodes = struct {
             .s_while => |while_| {
                 try self.markExpr(while_.cond, work);
                 try self.markExpr(while_.body, work);
+            },
+            .s_infinite_loop => |loop| {
+                try self.markExpr(loop.cond, work);
+                try self.markExpr(loop.body, work);
+            },
+            .s_breakable_loop => |loop| {
+                try self.markExpr(loop.cond, work);
+                try self.markExpr(loop.body, work);
             },
             .s_return => |ret| {
                 try self.markExpr(ret.expr, work);
@@ -6325,6 +6339,8 @@ fn checkedStatementDataDiverges(
         => |expr| checkedExprDiverges(exprs, statements, expr_diverges, statement_diverges, expr, expr_states, statement_states),
         .for_ => |for_| checkedExprDiverges(exprs, statements, expr_diverges, statement_diverges, for_.expr, expr_states, statement_states),
         .while_ => |while_| checkedExprDiverges(exprs, statements, expr_diverges, statement_diverges, while_.cond, expr_states, statement_states),
+        .infinite_loop => true,
+        .breakable_loop => |loop| checkedExprDiverges(exprs, statements, expr_diverges, statement_diverges, loop.cond, expr_states, statement_states),
         .pending,
         .import_,
         .alias_decl,
@@ -7096,6 +7112,14 @@ const CheckedBodyPayloadCopier = struct {
             .s_while => |while_| .{ .while_ = .{
                 .cond = self.checkedExpr(while_.cond),
                 .body = self.checkedExpr(while_.body),
+            } },
+            .s_infinite_loop => |loop| .{ .infinite_loop = .{
+                .cond = self.checkedExpr(loop.cond),
+                .body = self.checkedExpr(loop.body),
+            } },
+            .s_breakable_loop => |loop| .{ .breakable_loop = .{
+                .cond = self.checkedExpr(loop.cond),
+                .body = self.checkedExpr(loop.body),
             } },
             .s_break => .break_,
             .s_return => |ret| .{ .return_ = .{
@@ -9366,6 +9390,14 @@ const CheckedTemplateRefCollector = struct {
                 try self.collectExpr(while_.cond);
                 try self.collectExpr(while_.body);
             },
+            .infinite_loop => |loop| {
+                try self.collectExpr(loop.cond);
+                try self.collectExpr(loop.body);
+            },
+            .breakable_loop => |loop| {
+                try self.collectExpr(loop.cond);
+                try self.collectExpr(loop.body);
+            },
             .pending,
             .crash,
             .break_,
@@ -10023,6 +10055,14 @@ const NestedProcSiteBuilder = struct {
             .while_ => |while_| {
                 try self.scanExpr(while_.cond, owner, false);
                 try self.scanExpr(while_.body, owner, false);
+            },
+            .infinite_loop => |loop| {
+                try self.scanExpr(loop.cond, owner, false);
+                try self.scanExpr(loop.body, owner, false);
+            },
+            .breakable_loop => |loop| {
+                try self.scanExpr(loop.cond, owner, false);
+                try self.scanExpr(loop.body, owner, false);
             },
             .pending,
             .crash,

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -4620,6 +4620,94 @@ test "check type - early return - pass" {
     try checkTypesExpr(source, .pass, "Bool -> List(_a)");
 }
 
+test "check type - final infinite loop can satisfy annotated return type" {
+    const source =
+        \\looping : Bool -> Str
+        \\looping = |bool| {
+        \\  while True {
+        \\    if bool {
+        \\      return "yes"
+        \\    }
+        \\    crash "no"
+        \\  }
+        \\}
+    ;
+    try checkTypesModule(source, .{ .pass = .{ .def = "looping" } }, "Bool -> Str");
+}
+
+test "check type - final Bool.True infinite loop can satisfy annotated return type" {
+    const source =
+        \\looping : Bool -> Str
+        \\looping = |bool| {
+        \\  while Bool.True {
+        \\    if bool {
+        \\      return "yes"
+        \\    }
+        \\    crash "no"
+        \\  }
+        \\}
+    ;
+    try checkTypesModule(source, .{ .pass = .{ .def = "looping" } }, "Bool -> Str");
+}
+
+test "check type - final block True infinite loop can satisfy annotated return type" {
+    const source =
+        \\looping : Bool -> Str
+        \\looping = |bool| {
+        \\  while { True } {
+        \\    if bool {
+        \\      return "yes"
+        \\    }
+        \\    crash "no"
+        \\  }
+        \\}
+    ;
+    try checkTypesModule(source, .{ .pass = .{ .def = "looping" } }, "Bool -> Str");
+}
+
+test "check type - final breakable loop remains empty record" {
+    const source =
+        \\looping : Bool -> Str
+        \\looping = |_| {
+        \\  while True {
+        \\    break
+        \\  }
+        \\}
+    ;
+    try checkTypesModule(source, .fail_first, "TYPE MISMATCH");
+}
+
+test "check type - final loop with break and return remains empty record" {
+    const source =
+        \\looping : Bool -> Str
+        \\looping = |bool| {
+        \\  while True {
+        \\    if bool {
+        \\      break
+        \\    }
+        \\    return "yes"
+        \\  }
+        \\}
+    ;
+    try checkTypesModule(source, .fail_first, "TYPE MISMATCH");
+}
+
+test "check type - infinite loop branch unifies with sibling branch" {
+    const source =
+        \\looping : Bool -> Str
+        \\looping = |bool| {
+        \\  if bool {
+        \\    while True {
+        \\      return "yes"
+        \\    }
+        \\  } else {
+        \\    "ok"
+        \\  }
+        \\}
+    ;
+    try checkTypesModule(source, .{ .pass = .{ .def = "looping" } }, "Bool -> Str");
+}
+
 test "check type - early return - fail" {
     const source =
         \\|bool| {

--- a/src/eval/test/host_effects_tests.zig
+++ b/src/eval/test/host_effects_tests.zig
@@ -1018,6 +1018,7 @@ pub const tests = [_]TestCase{
         \\            "boxed callable second item definitely long enough to allocate outside small-string storage",
         \\        ],
         \\    }
+        \\    boxed : Box((I64 -> I64))
         \\    boxed = Box.box(|x| x + List.len(record.items).to_i64_wrap())
         \\    f = Box.unbox(boxed)
         \\    expect f(40) == 42

--- a/src/lsp/cir_visitor.zig
+++ b/src/lsp/cir_visitor.zig
@@ -402,6 +402,16 @@ pub fn CirVisitor(comptime Context: type) type {
                     if (self.stopped) return;
                     self.walkExpr(store, w.body);
                 },
+                .s_infinite_loop => |w| {
+                    self.walkExpr(store, w.cond);
+                    if (self.stopped) return;
+                    self.walkExpr(store, w.body);
+                },
+                .s_breakable_loop => |w| {
+                    self.walkExpr(store, w.cond);
+                    if (self.stopped) return;
+                    self.walkExpr(store, w.body);
+                },
                 .s_expr => |e| {
                     self.walkExpr(store, e.expr);
                 },

--- a/src/lsp/completion/builder.zig
+++ b/src/lsp/completion/builder.zig
@@ -1693,6 +1693,8 @@ fn getStatementParts(stmt: CIR.Statement) StatementParts {
         .s_reassign => |reassign| .{ .pattern = null, .expr = reassign.expr, .expr2 = null },
         .s_for => |for_stmt| .{ .pattern = for_stmt.patt, .expr = for_stmt.expr, .expr2 = for_stmt.body },
         .s_while => |while_stmt| .{ .pattern = null, .expr = while_stmt.cond, .expr2 = while_stmt.body },
+        .s_infinite_loop => |while_stmt| .{ .pattern = null, .expr = while_stmt.cond, .expr2 = while_stmt.body },
+        .s_breakable_loop => |while_stmt| .{ .pattern = null, .expr = while_stmt.cond, .expr2 = while_stmt.body },
         .s_expr => |expr_stmt| .{ .pattern = null, .expr = expr_stmt.expr, .expr2 = null },
         .s_expect => |expect_stmt| .{ .pattern = null, .expr = expect_stmt.body, .expr2 = null },
         .s_dbg => |dbg_stmt| .{ .pattern = null, .expr = dbg_stmt.expr, .expr2 = null },

--- a/src/lsp/module_lookup.zig
+++ b/src/lsp/module_lookup.zig
@@ -336,6 +336,16 @@ pub fn getStatementParts(stmt: CIR.Statement) StatementParts {
             .expr = w.cond,
             .expr2 = w.body,
         },
+        .s_infinite_loop => |w| .{
+            .pattern = null,
+            .expr = w.cond,
+            .expr2 = w.body,
+        },
+        .s_breakable_loop => |w| .{
+            .pattern = null,
+            .expr = w.cond,
+            .expr2 = w.body,
+        },
         .s_dbg => |d| .{
             .pattern = null,
             .expr = d.expr,

--- a/src/lsp/scope_map.zig
+++ b/src/lsp/scope_map.zig
@@ -116,6 +116,14 @@ pub const ScopeMap = struct {
                 try self.traverseExpr(module_env, while_stmt.cond, scope_end, depth + 1);
                 try self.traverseExpr(module_env, while_stmt.body, scope_end, depth + 1);
             },
+            .s_infinite_loop => |while_stmt| {
+                try self.traverseExpr(module_env, while_stmt.cond, scope_end, depth + 1);
+                try self.traverseExpr(module_env, while_stmt.body, scope_end, depth + 1);
+            },
+            .s_breakable_loop => |while_stmt| {
+                try self.traverseExpr(module_env, while_stmt.cond, scope_end, depth + 1);
+                try self.traverseExpr(module_env, while_stmt.body, scope_end, depth + 1);
+            },
             .s_expr => |expr_stmt| {
                 try self.traverseExpr(module_env, expr_stmt.expr, scope_end, depth + 1);
             },

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -7752,6 +7752,8 @@ const BodyContext = struct {
             .expect,
             .for_,
             .while_,
+            .infinite_loop,
+            .breakable_loop,
             .break_,
             .return_,
             => true,
@@ -8525,6 +8527,14 @@ const BodyContext = struct {
                 try self.collectReassignedBindersInExpr(while_.cond, out);
                 try self.collectReassignedBindersInExpr(while_.body, out);
             },
+            .infinite_loop => |loop| {
+                try self.collectReassignedBindersInExpr(loop.cond, out);
+                try self.collectReassignedBindersInExpr(loop.body, out);
+            },
+            .breakable_loop => |loop| {
+                try self.collectReassignedBindersInExpr(loop.cond, out);
+                try self.collectReassignedBindersInExpr(loop.body, out);
+            },
             .return_ => |ret| try self.collectReassignedBindersInExpr(ret.expr, out),
             .pending,
             .crash,
@@ -8696,6 +8706,44 @@ const BodyContext = struct {
                 const unit_ty = try self.unitType();
                 const loop_ty = try self.loopStateType(unit_ty, carries);
                 const expr = try self.builder.program.addExpr(.{ .ty = loop_ty, .data = try self.lowerWhile(while_, loop_ty, carries) });
+                if (carries.len == 0) break :blk .{ .expr = expr };
+
+                break :blk .{ .let_ = .{
+                    .pat = try self.finalCarryPattern(carries, loop_ty),
+                    .value = expr,
+                } };
+            },
+            .infinite_loop => |loop| blk: {
+                var reassigned = std.ArrayList(checked.PatternBinderId).empty;
+                defer reassigned.deinit(self.allocator);
+                try self.collectReassignedBindersInExpr(loop.cond, &reassigned);
+                try self.collectReassignedBindersInExpr(loop.body, &reassigned);
+
+                const carries = try self.prepareLoopCarries(reassigned.items);
+                defer self.allocator.free(carries);
+
+                const unit_ty = try self.unitType();
+                const loop_ty = try self.loopStateType(unit_ty, carries);
+                const expr = try self.builder.program.addExpr(.{ .ty = loop_ty, .data = try self.lowerWhile(loop, loop_ty, carries) });
+                if (carries.len == 0) break :blk .{ .expr = expr };
+
+                break :blk .{ .let_ = .{
+                    .pat = try self.finalCarryPattern(carries, loop_ty),
+                    .value = expr,
+                } };
+            },
+            .breakable_loop => |loop| blk: {
+                var reassigned = std.ArrayList(checked.PatternBinderId).empty;
+                defer reassigned.deinit(self.allocator);
+                try self.collectReassignedBindersInExpr(loop.cond, &reassigned);
+                try self.collectReassignedBindersInExpr(loop.body, &reassigned);
+
+                const carries = try self.prepareLoopCarries(reassigned.items);
+                defer self.allocator.free(carries);
+
+                const unit_ty = try self.unitType();
+                const loop_ty = try self.loopStateType(unit_ty, carries);
+                const expr = try self.builder.program.addExpr(.{ .ty = loop_ty, .data = try self.lowerWhile(loop, loop_ty, carries) });
                 if (carries.len == 0) break :blk .{ .expr = expr };
 
                 break :blk .{ .let_ = .{

--- a/test/snapshots/statement/break_while_loop.md
+++ b/test/snapshots/statement/break_while_loop.md
@@ -86,7 +86,7 @@ expect result == True
 			(s-var
 				(p-assign (ident "$foo"))
 				(e-tag (name "True")))
-			(s-while
+			(s-breakable-loop
 				(e-tag (name "True"))
 				(e-block
 					(s-break)


### PR DESCRIPTION
Adds explicit `infinite_loop` and `breakable_loop` CIR/checked statement forms for literal `while True` and builtin `while Bool.True` loops. Infinite loops now type as divergent so they can satisfy any surrounding return type, while loops with a loop-owned `break` retain ordinary `{}` typing; canonicalization also warns when a literal infinite loop has no syntactic exit. The host-effects RC balance fixture now pins its boxed callable type so `minici` exercises the RC case without depending on ambiguous numeric dispatch inference.