### PR TITLE
check: literal-defaulting cleanup follow-ups (post #9605)

### DIFF
--- a/src/canonicalize/NodeStore.zig
+++ b/src/canonicalize/NodeStore.zig
@@ -514,8 +514,18 @@ fn addMethodCallData(store: *NodeStore, args: CIR.Expr.Span, method_name_region:
 // Binop ops are offset past the three unit tags so every `Binop.Op` value has
 // a distinct slot.
 const surface_origin_binop_offset: u32 = 3;
+comptime {
+    // The binop range starts after the unit (payload-less) tags; keep the offset
+    // in sync so a new unit variant can't collide with a `Binop.Op` slot.
+    var unit_count: u32 = 0;
+    for (@typeInfo(CIR.Expr.SurfaceOrigin).@"union".fields) |field| {
+        if (field.type == void) unit_count += 1;
+    }
+    std.debug.assert(surface_origin_binop_offset == unit_count);
+}
 
-fn encodeSurfaceOrigin(origin: CIR.Expr.SurfaceOrigin) u32 {
+/// Encode surface origin
+pub fn encodeSurfaceOrigin(origin: CIR.Expr.SurfaceOrigin) u32 {
     return switch (origin) {
         .method_call => 0,
         .unary_minus => 1,
@@ -524,7 +534,8 @@ fn encodeSurfaceOrigin(origin: CIR.Expr.SurfaceOrigin) u32 {
     };
 }
 
-fn decodeSurfaceOrigin(encoded: u32) CIR.Expr.SurfaceOrigin {
+/// Decode surface origin
+pub fn decodeSurfaceOrigin(encoded: u32) CIR.Expr.SurfaceOrigin {
     return switch (encoded) {
         0 => .method_call,
         1 => .unary_minus,

--- a/src/canonicalize/RocEmitter.zig
+++ b/src/canonicalize/RocEmitter.zig
@@ -11,6 +11,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const base = @import("base");
 const builtins = @import("builtins");
+const parse = @import("parse");
 
 const i128h = builtins.compiler_rt_128;
 
@@ -768,31 +769,43 @@ fn emitStatementFrame(
     }
 }
 
-/// Binding power of the lhs and rhs of a binary operator (higher binds
-/// tighter). Left < right is left-associative; left >= right makes the
-/// operator bind into its own kind on the right (right-associative).
-const BinopBp = struct { left: u8, right: u8 };
-
-/// Binding powers for each binary operator. These must mirror the parser's
-/// `bin_op_bp_table` (src/parse/Parser.zig) exactly: re-emitted operator
-/// expressions only omit parentheses where the parser's binding powers
-/// reproduce the same tree.
-fn binopBp(op: Expr.Binop.Op) BinopBp {
+fn binopOpToToken(op: Expr.Binop.Op) parse.tokenize.Token.Tag {
     return switch (op) {
-        .mul => .{ .left = 30, .right = 31 },
-        .div => .{ .left = 28, .right = 29 },
-        .div_trunc => .{ .left = 26, .right = 27 },
-        .rem => .{ .left = 24, .right = 25 },
-        .add, .sub => .{ .left = 20, .right = 21 },
-        .eq => .{ .left = 15, .right = 15 },
-        .ne => .{ .left = 13, .right = 13 },
-        .lt => .{ .left = 11, .right = 11 },
-        .gt => .{ .left = 9, .right = 9 },
-        .le => .{ .left = 7, .right = 7 },
-        .ge => .{ .left = 5, .right = 5 },
-        .@"and" => .{ .left = 4, .right = 3 },
-        .@"or" => .{ .left = 2, .right = 1 },
+        .add => .OpPlus,
+        .sub => .OpBinaryMinus,
+        .mul => .OpStar,
+        .div => .OpSlash,
+        .rem => .OpPercent,
+        .lt => .OpLessThan,
+        .gt => .OpGreaterThan,
+        .le => .OpLessThanOrEq,
+        .ge => .OpGreaterThanOrEq,
+        .eq => .OpEquals,
+        .ne => .OpNotEquals,
+        .div_trunc => .OpDoubleSlash,
+        .@"and" => .OpAnd,
+        .@"or" => .OpOr,
     };
+}
+
+/// Binding powers for re-emission parenthesization come straight from the
+/// parser's single binding-power table, so a re-emitted operator expression
+/// always reparses to the same tree. (Every `Binop.Op` maps to an in-range
+/// operator token with non-zero binding power, so the lookup never returns null.)
+fn binopBp(op: Expr.Binop.Op) parse.Parser.BinOpBp {
+    return parse.Parser.getTokenBP(binopOpToToken(op)).?;
+}
+
+comptime {
+    // Enforce the invariant `binopBp`'s doc comment states: every `Binop.Op` maps
+    // to an operator token with a defined binding power, so the `.?` above can
+    // never panic. A future `binopOpToToken` mapping onto a non-operator (or
+    // zero-binding-power) token becomes a compile error here instead of a runtime
+    // crash during re-emission.
+    for (@typeInfo(Expr.Binop.Op).@"enum".fields) |field| {
+        const op: Expr.Binop.Op = @enumFromInt(field.value);
+        std.debug.assert(parse.Parser.getTokenBP(binopOpToToken(op)) != null);
+    }
 }
 
 const EmitError = std.mem.Allocator.Error || std.fmt.BufPrintError;

--- a/src/canonicalize/RocEmitter.zig
+++ b/src/canonicalize/RocEmitter.zig
@@ -239,7 +239,7 @@ fn unaryReceiverNeedsParens(self: *Self, receiver_idx: Expr.Idx) bool {
         .e_frac_f64 => |frac| std.math.signbit(frac.value),
         .e_dec => |dec| dec.value.num < 0,
         .e_dec_small => |small| small.value.numerator < 0,
-        .e_num_from_numeral => blk: {
+        .e_num_from_numeral, .e_typed_num_from_numeral => blk: {
             const literal = self.module_env.numeralLiteralForNode(ModuleEnv.nodeIdxFrom(receiver_idx)) orelse {
                 std.debug.panic("missing recorded numeral for expression {}", .{@intFromEnum(receiver_idx)});
             };

--- a/src/canonicalize/test/node_store_test.zig
+++ b/src/canonicalize/test/node_store_test.zig
@@ -1436,3 +1436,24 @@ test "NodeStore round trip - Pattern" {
         return error.IncompletePatternTestCoverage;
     }
 }
+
+test "SurfaceOrigin encode/decode round-trips" {
+    const SurfaceOrigin = CIR.Expr.SurfaceOrigin;
+    // Every unit form.
+    const unit_origins = [_]SurfaceOrigin{ .method_call, .unary_minus, .unary_not };
+    for (unit_origins) |origin| {
+        try testing.expectEqual(
+            origin,
+            NodeStore.decodeSurfaceOrigin(NodeStore.encodeSurfaceOrigin(origin)),
+        );
+    }
+    // Every binop form.
+    inline for (@typeInfo(CIR.Expr.Binop.Op).@"enum".fields) |field| {
+        const op: CIR.Expr.Binop.Op = @enumFromInt(field.value);
+        const origin = SurfaceOrigin{ .binop = op };
+        try testing.expectEqual(
+            origin,
+            NodeStore.decodeSurfaceOrigin(NodeStore.encodeSurfaceOrigin(origin)),
+        );
+    }
+}

--- a/src/canonicalize/test/roc_emitter_test.zig
+++ b/src/canonicalize/test/roc_emitter_test.zig
@@ -228,3 +228,36 @@ test "emit function application" {
     try emitter.emitExpr(call_idx);
     try testing.expectEqualStrings("f(42)", emitter.getOutput());
 }
+
+test "emit unary minus over negative typed numeral parenthesizes receiver" {
+    // A negative `e_typed_num_from_numeral` emits as one unit `-5.U8`; under a
+    // unary minus the receiver must be parenthesized so the leading `-` does not
+    // fuse into `--`. The whole receiver (type suffix included) stays inside the
+    // parens, so it reparses to the same single typed-numeral node: `-(-5.U8)`.
+    const module_env = try createTestEnv(test_allocator, "-(-5.U8)");
+    defer destroyTestEnv(test_allocator, module_env);
+
+    const u8_ident = try module_env.insertIdent(base.Ident.for_text("U8"));
+    const typed_idx = try module_env.store.addExpr(.{
+        .e_typed_num_from_numeral = .{ .type_name = u8_ident },
+    }, base.Region.zero());
+
+    try module_env.recordNumeralLiteral(
+        ModuleEnv.nodeIdxFrom(typed_idx),
+        &[_]u8{5}, // before-decimal base-256 digits
+        &[_]u8{}, // after-decimal digits
+        0, // after_decimal_digit_count
+        true, // is_negative
+        false, // is_fractional
+        false, // had_decimal_point
+    );
+
+    const unary_idx = try module_env.store.addExpr(.{
+        .e_unary_minus = CIR.Expr.UnaryMinus.init(typed_idx),
+    }, base.Region.zero());
+
+    var emitter = Emitter.init(test_allocator, module_env);
+    defer emitter.deinit();
+    try emitter.emitExpr(unary_idx);
+    try testing.expectEqualStrings("-(-5.U8)", emitter.getOutput());
+}

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -8557,7 +8557,8 @@ fn validateRecordRow(
     region: Region,
     visited: *std.AutoHashMap(Var, void),
 ) Allocator.Error!bool {
-    var names = std.AutoHashMap(Ident.Idx, void).init(self.gpa);
+    var names_sfa = std.heap.stackFallback(32 * @sizeOf(Ident.Idx), self.gpa);
+    var names = std.AutoHashMap(Ident.Idx, void).init(names_sfa.get());
     defer names.deinit();
 
     const field_slice = self.types.getRecordFieldsSlice(fields);
@@ -8638,7 +8639,8 @@ fn validateTagUnionRow(
     region: Region,
     visited: *std.AutoHashMap(Var, void),
 ) Allocator.Error!bool {
-    var names = std.AutoHashMap(Ident.Idx, void).init(self.gpa);
+    var names_sfa = std.heap.stackFallback(32 * @sizeOf(Ident.Idx), self.gpa);
+    var names = std.AutoHashMap(Ident.Idx, void).init(names_sfa.get());
     defer names.deinit();
 
     const tag_slice = self.types.getTagsSlice(tags);

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -15537,7 +15537,6 @@ fn varLiteralKind(self: *Self, var_: Var) ?StaticDispatchConstraint.LiteralKind 
     return if (has_quote) .quote else if (has_interpolation) .interpolation else null;
 }
 
-/// Whether this flex var carries any interpolation literal-origin constraint.
 // --- Per-kind literal facts, each an exhaustive `switch (LiteralKind)` ---------
 //
 // Adding a `LiteralKind` variant turns each switch below into a compile error

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -15517,30 +15517,16 @@ fn literalSourceRegion(self: *Self, var_: Var) ?Region {
 /// never type-check, but the kind reported here picks which head default is
 /// attempted (Dec vs Str) and hence which literal-kind diagnostic fires — so it
 /// must not depend on constraint storage order (which unify side each literal
-/// arrived on), or mirror-image programs would get different diagnostics. We scan
-/// all literal-origin constraints and prefer `.numeral` over `.quote`, agreeing
-/// with the two other sites that encode this choice:
-/// `numericDefaultPhaseForConstraints` in src/check/checked_artifact.zig (any
-/// numeral selects the Dec mono phase before quote is considered) and
-/// `flexLiteralDefaultKind` in src/check/canonical_type_keys.zig (numeral if any,
-/// else quote).
+/// arrived on), or mirror-image programs would get different diagnostics.
+/// Delegates to `StaticDispatchConstraint.dominantLiteralKind`, the single
+/// source of truth for the numeral > quote > interpolation tie-break shared
+/// with `flexLiteralDefaultKind` (canonical_type_keys.zig) and
+/// `numericDefaultPhaseForConstraints` (checked_artifact.zig).
 fn varLiteralKind(self: *Self, var_: Var) ?StaticDispatchConstraint.LiteralKind {
     const resolved = self.types.resolveVar(var_);
     if (resolved.desc.content != .flex) return null;
     const constraints = self.types.sliceStaticDispatchConstraints(resolved.desc.content.flex.constraints);
-    var has_quote = false;
-    var has_interpolation = false;
-    for (constraints) |constraint| {
-        switch (constraint.origin) {
-            .from_literal => |lit| switch (lit) {
-                .numeral => return .numeral,
-                .quote => has_quote = true,
-                .interpolation => has_interpolation = true,
-            },
-            else => {},
-        }
-    }
-    return if (has_quote) .quote else if (has_interpolation) .interpolation else null;
+    return StaticDispatchConstraint.dominantLiteralKind(constraints);
 }
 
 // --- Per-kind literal facts, each an exhaustive `switch (LiteralKind)` ---------

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -14964,14 +14964,7 @@ fn runLiteralDefaultingRounds(self: *Self, env: *Env, universe: LiteralDefaultUn
             try is_driver.append(self.gpa, drives);
             if (!drives) continue;
 
-            // collectReachableVars only reads the store, so holding the
-            // constraint slice across it is safe (same fence as
-            // `boundaryDefaultLeaksIntoSignature`). It stores RESOLVED roots.
-            footprint.clearRetainingCapacity();
-            for (self.types.sliceStaticDispatchConstraints(constraint_range)) |constraint| {
-                if (constraint.origin == .from_literal) continue;
-                try self.collectReachableVars(constraint.fn_var, &footprint);
-            }
+            try self.collectConstraintSignatureReachable(constraint_range, &footprint);
             var fp_iter = footprint.keyIterator();
             while (fp_iter.next()) |fp_var| {
                 // Only still-flex roots interfere; everything else is immune to
@@ -15281,18 +15274,30 @@ fn commitLiteralGroupDefault(self: *Self, drivers: []const Var, env: *Env) Alloc
 ///
 /// Must run while `literal_var` is still flex (before the default unify) and after
 /// `boundary_reachable_vars` is populated for the current boundary.
+/// Clear `out`, then collect every var reachable from the var's non-`from_literal`
+/// dispatch constraints into it. Single source of truth for the "signature
+/// footprint" used by both interference partitioning (runLiteralDefaultingRounds)
+/// and boundary-leak detection (boundaryDefaultLeaksIntoSignature) — they MUST
+/// agree, or a literal could be partitioned non-interfering yet warned.
+/// collectReachableVars only reads the store, so holding the constraint slice
+/// across it is safe.
+fn collectConstraintSignatureReachable(
+    self: *Self,
+    constraint_range: StaticDispatchConstraint.SafeList.Range,
+    out: *std.AutoHashMap(Var, void),
+) std.mem.Allocator.Error!void {
+    out.clearRetainingCapacity();
+    for (self.types.sliceStaticDispatchConstraints(constraint_range)) |constraint| {
+        if (constraint.origin == .from_literal) continue;
+        try self.collectReachableVars(constraint.fn_var, out);
+    }
+}
+
 fn boundaryDefaultLeaksIntoSignature(self: *Self, literal_var: Var) std.mem.Allocator.Error!bool {
     const resolved = self.types.resolveVar(literal_var);
     if (resolved.desc.content != .flex) return false;
 
-    // collectReachableVars only reads the store and inserts into the map (no
-    // unify/instantiate), so holding the constraint slice across it is safe.
-    self.boundary_leak_vars.clearRetainingCapacity();
-    const constraints = self.types.sliceStaticDispatchConstraints(resolved.desc.content.flex.constraints);
-    for (constraints) |constraint| {
-        if (constraint.origin == .from_literal) continue;
-        try self.collectReachableVars(constraint.fn_var, &self.boundary_leak_vars);
-    }
+    try self.collectConstraintSignatureReachable(resolved.desc.content.flex.constraints, &self.boundary_leak_vars);
 
     var leak_iter = self.boundary_leak_vars.keyIterator();
     while (leak_iter.next()) |leak_var| {

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -15009,34 +15009,7 @@ fn runLiteralDefaultingRounds(self: *Self, env: *Env, universe: LiteralDefaultUn
                 const kind = self.varLiteralKind(driver_root) orelse unreachable;
                 try self.commitGatheredLiteral(driver_root, kind, universe, env);
             } else {
-                // Several drivers, possibly of mixed literal kinds: quote drivers
-                // take their single candidate (Str) on every attempt while the
-                // numeral candidate scan iterates its list.
-                //
-                // BOUNDARY WARNING SEMANTICS FOR GROUPS: the leak check is per
-                // literal (it walks one literal's constraint signatures), so it
-                // runs for EVERY group member pre-commit — while all drivers are
-                // still flex — and each leaking member gets its own LITERAL
-                // DEFAULTED warning post-commit, exactly as if it had committed
-                // alone. Non-leaking members default silently (def-local), and the
-                // component's passives are never committed here, matching the
-                // single-commit paths: a passive carries only literal-conversion
-                // constraints, so its leak set is empty and it could never warn.
-                group_warnings.clearRetainingCapacity();
-                if (universe == .boundary) {
-                    for (group_drivers.items) |driver| {
-                        try group_warnings.append(self.gpa, try self.boundaryWarningBeforeCommit(driver));
-                    }
-                }
-                try self.commitLiteralGroupDefault(group_drivers.items, env);
-                if (universe == .boundary) {
-                    // The group commit unified each driver with its committed var,
-                    // so the driver root itself renders the committed type for the
-                    // snapshot.
-                    for (group_drivers.items, group_warnings.items) |driver, pending| {
-                        try self.emitBoundaryWarningAfterCommit(pending, driver, driver);
-                    }
-                }
+                try self.commitGatheredGroup(group_drivers.items, &group_warnings, universe, env);
             }
         }
 
@@ -15065,6 +15038,41 @@ fn commitGatheredLiteral(
             const pending = try self.boundaryWarningBeforeCommit(root);
             const default_var = try self.commitLiteralDefault(root, kind, env);
             try self.emitBoundaryWarningAfterCommit(pending, root, default_var);
+        },
+    }
+}
+
+/// Commit a multi-driver literal component via the shared group probe — plus, at
+/// a generalization boundary, a per-driver LITERAL DEFAULTED leak warning
+/// bracketing the commit, exactly as `commitGatheredLiteral` does for the single
+/// case. `warnings_scratch` is a caller-owned reused buffer (cleared here).
+///
+/// BOUNDARY WARNING SEMANTICS FOR GROUPS: the leak check is per literal (it walks
+/// one literal's constraint signatures), so it runs for EVERY group member
+/// pre-commit — while all drivers are still flex — and each leaking member gets
+/// its own LITERAL DEFAULTED warning post-commit, exactly as if it had committed
+/// alone. Non-leaking members default silently (def-local), and the component's
+/// passives are never committed here, matching the single-commit paths.
+fn commitGatheredGroup(
+    self: *Self,
+    drivers: []const Var,
+    warnings_scratch: *std.ArrayListUnmanaged(PendingBoundaryWarning),
+    universe: LiteralDefaultUniverse,
+    env: *Env,
+) std.mem.Allocator.Error!void {
+    switch (universe) {
+        .finalize => try self.commitLiteralGroupDefault(drivers, env),
+        .boundary => {
+            warnings_scratch.clearRetainingCapacity();
+            for (drivers) |driver| {
+                try warnings_scratch.append(self.gpa, try self.boundaryWarningBeforeCommit(driver));
+            }
+            try self.commitLiteralGroupDefault(drivers, env);
+            // The group commit unified each driver with its committed var, so the
+            // driver root itself renders the committed type for the snapshot.
+            for (drivers, warnings_scratch.items) |driver, pending| {
+                try self.emitBoundaryWarningAfterCommit(pending, driver, driver);
+            }
         },
     }
 }

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -359,6 +359,21 @@ boundary_leak_vars: std.AutoHashMap(Var, void),
 /// re-scanning the whole constraint list each round. Front-loaded; cleared and
 /// refilled per call.
 boundary_eql_edges: std.ArrayListUnmanaged(@FieldType(Constraint, "eql")),
+// Literal-defaulting scratch (front-loaded; cleared per round/use). Reused across
+// the per-def/finalize defaulting passes — see runLiteralDefaultingRounds. Safe as
+// shared fields despite that function's cascade reentrancy: every buffer is cleared
+// at the start of its step and never read across the step-4 cascade.
+literal_defaulting_open_roots: std.ArrayListUnmanaged(Var),
+literal_defaulting_seen_roots: std.AutoHashMap(Var, void),
+literal_defaulting_component_parent: std.ArrayListUnmanaged(usize),
+literal_defaulting_is_driver: std.ArrayListUnmanaged(bool),
+literal_defaulting_footprint_owner: std.AutoHashMap(Var, usize),
+literal_defaulting_footprint: std.AutoHashMap(Var, void),
+literal_defaulting_group_drivers: std.ArrayListUnmanaged(Var),
+literal_defaulting_group_warnings: std.ArrayListUnmanaged(PendingBoundaryWarning),
+literal_defaulting_constraint_ranges: std.ArrayListUnmanaged(StaticDispatchConstraint.SafeList.Range),
+literal_defaulting_kinds: std.ArrayListUnmanaged(StaticDispatchConstraint.LiteralKind),
+literal_defaulting_candidate_vars: std.ArrayListUnmanaged(Var),
 /// Debug-only literal-defaulting probe instrumentation, asserted by the
 /// refuted-count guard test. Only written under `comptime std.debug.runtime_safety`,
 /// so release builds compile the bookkeeping out entirely (no global state, no
@@ -1160,6 +1175,17 @@ fn initAssumePrepared(
         .boundary_reachable_vars = std.AutoHashMap(Var, void).init(gpa),
         .boundary_leak_vars = std.AutoHashMap(Var, void).init(gpa),
         .boundary_eql_edges = .empty,
+        .literal_defaulting_open_roots = .empty,
+        .literal_defaulting_seen_roots = std.AutoHashMap(Var, void).init(gpa),
+        .literal_defaulting_component_parent = .empty,
+        .literal_defaulting_is_driver = .empty,
+        .literal_defaulting_footprint_owner = std.AutoHashMap(Var, usize).init(gpa),
+        .literal_defaulting_footprint = std.AutoHashMap(Var, void).init(gpa),
+        .literal_defaulting_group_drivers = .empty,
+        .literal_defaulting_group_warnings = .empty,
+        .literal_defaulting_constraint_ranges = .empty,
+        .literal_defaulting_kinds = .empty,
+        .literal_defaulting_candidate_vars = .empty,
         .checked_lambda_params = .empty,
         .probe_var_pool_lens = .empty,
     };
@@ -1284,6 +1310,17 @@ pub fn deinit(self: *Self) void {
     self.boundary_reachable_vars.deinit();
     self.boundary_leak_vars.deinit();
     self.boundary_eql_edges.deinit(self.gpa);
+    self.literal_defaulting_open_roots.deinit(self.gpa);
+    self.literal_defaulting_seen_roots.deinit();
+    self.literal_defaulting_component_parent.deinit(self.gpa);
+    self.literal_defaulting_is_driver.deinit(self.gpa);
+    self.literal_defaulting_footprint_owner.deinit();
+    self.literal_defaulting_footprint.deinit();
+    self.literal_defaulting_group_drivers.deinit(self.gpa);
+    self.literal_defaulting_group_warnings.deinit(self.gpa);
+    self.literal_defaulting_constraint_ranges.deinit(self.gpa);
+    self.literal_defaulting_kinds.deinit(self.gpa);
+    self.literal_defaulting_candidate_vars.deinit(self.gpa);
     self.checked_lambda_params.deinit(self.gpa);
     self.probe_var_pool_lens.deinit(self.gpa);
 }
@@ -14861,29 +14898,14 @@ const LiteralDefaultUniverse = union(enum) {
 /// `anyDeferredDispatchReceiverResolved`), with runaway recursion capped by
 /// `max_deferred_dispatch_iterations`.
 fn runLiteralDefaultingRounds(self: *Self, env: *Env, universe: LiteralDefaultUniverse) std.mem.Allocator.Error!void {
-    // Round-scoped scratch. Components are tiny in practice (most literals are
-    // lone passives or single drivers), so plain local containers suffice.
-    var open_roots: std.ArrayListUnmanaged(Var) = .empty;
-    defer open_roots.deinit(self.gpa);
-    var seen_roots = std.AutoHashMap(Var, void).init(self.gpa);
-    defer seen_roots.deinit();
-    var component_parent: std.ArrayListUnmanaged(usize) = .empty;
-    defer component_parent.deinit(self.gpa);
-    var is_driver: std.ArrayListUnmanaged(bool) = .empty;
-    defer is_driver.deinit(self.gpa);
-    var footprint_owner = std.AutoHashMap(Var, usize).init(self.gpa);
-    defer footprint_owner.deinit();
-    var footprint = std.AutoHashMap(Var, void).init(self.gpa);
-    defer footprint.deinit();
-    var group_drivers: std.ArrayListUnmanaged(Var) = .empty;
-    defer group_drivers.deinit(self.gpa);
-    var group_warnings: std.ArrayListUnmanaged(PendingBoundaryWarning) = .empty;
-    defer group_warnings.deinit(self.gpa);
+    // Round-scoped scratch. Front-loaded as Check fields; cleared at the start
+    // of each step. Safe despite cascade reentrancy: every buffer is cleared
+    // before use and never read across the step-4 cascade.
 
     while (true) {
         // --- 1. Gather the still-open literal roots (deduped). ---
-        open_roots.clearRetainingCapacity();
-        seen_roots.clearRetainingCapacity();
+        self.literal_defaulting_open_roots.clearRetainingCapacity();
+        self.literal_defaulting_seen_roots.clearRetainingCapacity();
         switch (universe) {
             .finalize => |finalize| {
                 for (self.open_literal_vars.items[0..finalize.literal_count]) |literal_var| {
@@ -14891,9 +14913,9 @@ fn runLiteralDefaultingRounds(self: *Self, env: *Env, universe: LiteralDefaultUn
                     if (resolved.desc.content != .flex) continue;
                     if (resolved.desc.rank == .generalized) continue;
                     if (self.varLiteralKind(resolved.var_) == null) continue;
-                    const gop = try seen_roots.getOrPut(resolved.var_);
+                    const gop = try self.literal_defaulting_seen_roots.getOrPut(resolved.var_);
                     if (gop.found_existing) continue;
-                    try open_roots.append(self.gpa, resolved.var_);
+                    try self.literal_defaulting_open_roots.append(self.gpa, resolved.var_);
                 }
             },
             .boundary => |boundary| {
@@ -14914,13 +14936,13 @@ fn runLiteralDefaultingRounds(self: *Self, env: *Env, universe: LiteralDefaultUn
                     // thunk simply generalizes as a polymorphic function (see
                     // `reportPolymorphicTopLevelValues`).
                     if (self.boundary_reachable_vars.contains(resolved.var_)) continue;
-                    const gop = try seen_roots.getOrPut(resolved.var_);
+                    const gop = try self.literal_defaulting_seen_roots.getOrPut(resolved.var_);
                     if (gop.found_existing) continue;
-                    try open_roots.append(self.gpa, resolved.var_);
+                    try self.literal_defaulting_open_roots.append(self.gpa, resolved.var_);
                 }
             },
         }
-        if (open_roots.items.len == 0) return;
+        if (self.literal_defaulting_open_roots.items.len == 0) return;
 
         // --- 1b. Default unambiguous quote literals before ambiguous numerals. ---
         // A quote literal has exactly one possible type (Str), so committing it is
@@ -14943,7 +14965,7 @@ fn runLiteralDefaultingRounds(self: *Self, env: *Env, universe: LiteralDefaultUn
         // quote if any is open, else a numeral).
         {
             var any_quote = false;
-            for (open_roots.items) |root| {
+            for (self.literal_defaulting_open_roots.items) |root| {
                 if (self.varLiteralKind(root) == .quote) {
                     any_quote = true;
                     break;
@@ -14951,42 +14973,42 @@ fn runLiteralDefaultingRounds(self: *Self, env: *Env, universe: LiteralDefaultUn
             }
             if (any_quote) {
                 var write_idx: usize = 0;
-                for (open_roots.items) |root| {
+                for (self.literal_defaulting_open_roots.items) |root| {
                     if (self.varLiteralKind(root) != .quote) continue;
-                    open_roots.items[write_idx] = root;
+                    self.literal_defaulting_open_roots.items[write_idx] = root;
                     write_idx += 1;
                 }
-                open_roots.shrinkRetainingCapacity(write_idx);
+                self.literal_defaulting_open_roots.shrinkRetainingCapacity(write_idx);
             }
         }
 
         // --- 2. Partition into interference components. ---
-        component_parent.clearRetainingCapacity();
-        is_driver.clearRetainingCapacity();
-        footprint_owner.clearRetainingCapacity();
-        for (open_roots.items, 0..) |root, idx| {
-            try component_parent.append(self.gpa, idx);
+        self.literal_defaulting_component_parent.clearRetainingCapacity();
+        self.literal_defaulting_is_driver.clearRetainingCapacity();
+        self.literal_defaulting_footprint_owner.clearRetainingCapacity();
+        for (self.literal_defaulting_open_roots.items, 0..) |root, idx| {
+            try self.literal_defaulting_component_parent.append(self.gpa, idx);
             // Seed each literal's own root so any driver whose footprint reaches
             // it is merged into its component. Roots are deduped, so no collision
             // is possible here.
-            try footprint_owner.putNoClobber(root, idx);
+            try self.literal_defaulting_footprint_owner.putNoClobber(root, idx);
         }
-        for (open_roots.items, 0..) |root, idx| {
+        for (self.literal_defaulting_open_roots.items, 0..) |root, idx| {
             const constraint_range = self.types.resolveVar(root).desc.content.flex.constraints;
             const drives = self.rangeHasNonLiteralConstraint(constraint_range);
-            try is_driver.append(self.gpa, drives);
+            try self.literal_defaulting_is_driver.append(self.gpa, drives);
             if (!drives) continue;
 
-            try self.collectConstraintSignatureReachable(constraint_range, &footprint);
-            var fp_iter = footprint.keyIterator();
+            try self.collectConstraintSignatureReachable(constraint_range, &self.literal_defaulting_footprint);
+            var fp_iter = self.literal_defaulting_footprint.keyIterator();
             while (fp_iter.next()) |fp_var| {
                 // Only still-flex roots interfere; everything else is immune to
                 // pinning. (Union order is irrelevant: unions commute, so the
                 // partition is independent of hash-map iteration order.)
                 if (self.types.resolveVar(fp_var.*).desc.content != .flex) continue;
-                const gop = try footprint_owner.getOrPut(fp_var.*);
+                const gop = try self.literal_defaulting_footprint_owner.getOrPut(fp_var.*);
                 if (gop.found_existing) {
-                    componentUnion(component_parent.items, idx, gop.value_ptr.*);
+                    componentUnion(self.literal_defaulting_component_parent.items, idx, gop.value_ptr.*);
                 } else {
                     gop.value_ptr.* = idx;
                 }
@@ -14994,15 +15016,15 @@ fn runLiteralDefaultingRounds(self: *Self, env: *Env, universe: LiteralDefaultUn
         }
 
         // --- 3. Commit every component (disjoint, so order is unobservable). ---
-        for (0..open_roots.items.len) |leader| {
-            if (componentFind(component_parent.items, leader) != leader) continue;
-            group_drivers.clearRetainingCapacity();
+        for (0..self.literal_defaulting_open_roots.items.len) |leader| {
+            if (componentFind(self.literal_defaulting_component_parent.items, leader) != leader) continue;
+            self.literal_defaulting_group_drivers.clearRetainingCapacity();
             var member_count: usize = 0;
-            for (open_roots.items, 0..) |member_root, member_idx| {
-                if (componentFind(component_parent.items, member_idx) != leader) continue;
+            for (self.literal_defaulting_open_roots.items, 0..) |member_root, member_idx| {
+                if (componentFind(self.literal_defaulting_component_parent.items, member_idx) != leader) continue;
                 member_count += 1;
-                if (is_driver.items[member_idx]) {
-                    try group_drivers.append(self.gpa, member_root);
+                if (self.literal_defaulting_is_driver.items[member_idx]) {
+                    try self.literal_defaulting_group_drivers.append(self.gpa, member_root);
                 }
             }
             // Within a round, every gathered root is still flex with its
@@ -15010,19 +15032,19 @@ fn runLiteralDefaultingRounds(self: *Self, env: *Env, universe: LiteralDefaultUn
             // of OTHER components only touch their own (disjoint) footprints, and
             // this component commits exactly once. So the kind lookups below
             // cannot fail — gather guaranteed them non-null.
-            if (group_drivers.items.len == 0) {
+            if (self.literal_defaulting_group_drivers.items.len == 0) {
                 // A component without drivers is a lone passive (a passive's
                 // footprint is just itself, so only a driver can merge it).
                 std.debug.assert(member_count == 1);
-                const passive_root = open_roots.items[leader];
+                const passive_root = self.literal_defaulting_open_roots.items[leader];
                 const kind = self.varLiteralKind(passive_root) orelse unreachable;
                 try self.commitGatheredLiteral(passive_root, kind, universe, env);
-            } else if (group_drivers.items.len == 1) {
-                const driver_root = group_drivers.items[0];
+            } else if (self.literal_defaulting_group_drivers.items.len == 1) {
+                const driver_root = self.literal_defaulting_group_drivers.items[0];
                 const kind = self.varLiteralKind(driver_root) orelse unreachable;
                 try self.commitGatheredLiteral(driver_root, kind, universe, env);
             } else {
-                try self.commitGatheredGroup(group_drivers.items, &group_warnings, universe, env);
+                try self.commitGatheredGroup(self.literal_defaulting_group_drivers.items, &self.literal_defaulting_group_warnings, universe, env);
             }
         }
 
@@ -15161,22 +15183,17 @@ fn commitLiteralGroupDefault(self: *Self, drivers: []const Var, env: *Env) Alloc
     // Constraint ranges and literal kinds captured while the drivers are still
     // flex; the ranges index the constraint store, whose entries outlive the
     // unifications below.
-    var constraint_ranges: std.ArrayListUnmanaged(StaticDispatchConstraint.SafeList.Range) = .empty;
-    defer constraint_ranges.deinit(self.gpa);
-    var kinds: std.ArrayListUnmanaged(StaticDispatchConstraint.LiteralKind) = .empty;
-    defer kinds.deinit(self.gpa);
+    self.literal_defaulting_constraint_ranges.clearRetainingCapacity();
+    self.literal_defaulting_kinds.clearRetainingCapacity();
     var has_numeral_driver = false;
     for (drivers) |driver| {
-        try constraint_ranges.append(self.gpa, self.types.resolveVar(driver).desc.content.flex.constraints);
+        try self.literal_defaulting_constraint_ranges.append(self.gpa, self.types.resolveVar(driver).desc.content.flex.constraints);
         // Every group driver is an open literal (the component gather keyed
         // on `varLiteralKind`), so the kind always exists.
         const kind = self.varLiteralKind(driver).?;
-        try kinds.append(self.gpa, kind);
+        try self.literal_defaulting_kinds.append(self.gpa, kind);
         if (kind == .numeral) has_numeral_driver = true;
     }
-
-    var candidate_vars: std.ArrayListUnmanaged(Var) = .empty;
-    defer candidate_vars.deinit(self.gpa);
 
     // Quote drivers have exactly one candidate (Str) and are assigned it on
     // every attempt; only numeral drivers consume the candidate scan, so an
@@ -15191,7 +15208,7 @@ fn commitLiteralGroupDefault(self: *Self, drivers: []const Var, env: *Env) Alloc
         // arithmetic on the constraint payloads, before any speculation. Quote
         // drivers are assigned Str, which their own literal-conversion provenance
         // accepts by definition, so they have nothing to precheck.
-        for (constraint_ranges.items, kinds.items) |range, kind| {
+        for (self.literal_defaulting_constraint_ranges.items, self.literal_defaulting_kinds.items) |range, kind| {
             if (kind != .numeral) continue;
             if (!self.rangeNumeralDigitsFit(range, candidate_kind)) continue :candidate;
         }
@@ -15206,8 +15223,8 @@ fn commitLiteralGroupDefault(self: *Self, drivers: []const Var, env: *Env) Alloc
         // distinct and still flex, so these unifications are independent of each
         // other; flex-vs-concrete cannot mismatch (the drivers' dispatch
         // constraints defer onto the candidate as usual).
-        candidate_vars.clearRetainingCapacity();
-        for (drivers, kinds.items) |driver, kind| {
+        self.literal_defaulting_candidate_vars.clearRetainingCapacity();
+        for (drivers, self.literal_defaulting_kinds.items) |driver, kind| {
             const candidate_var = switch (kind) {
                 .numeral => try self.freshFromContent(
                     try self.mkBuiltinNumberTypeContentFromKind(candidate_kind, env),
@@ -15216,7 +15233,7 @@ fn commitLiteralGroupDefault(self: *Self, drivers: []const Var, env: *Env) Alloc
                 ),
                 .quote, .interpolation => try self.freshStr(env, self.getRegionAt(driver)),
             };
-            try candidate_vars.append(self.gpa, candidate_var);
+            try self.literal_defaulting_candidate_vars.append(self.gpa, candidate_var);
             const unify_result = try self.unify(driver, candidate_var, env);
             if (!unify_result.isOk()) continue :candidate;
         }
@@ -15225,8 +15242,8 @@ fn commitLiteralGroupDefault(self: *Self, drivers: []const Var, env: *Env) Alloc
         for (0..drivers.len) |driver_idx| {
             if (!try self.candidateSatisfiesRangeConstraints(
                 &commit_probe,
-                constraint_ranges.items[driver_idx],
-                candidate_vars.items[driver_idx],
+                self.literal_defaulting_constraint_ranges.items[driver_idx],
+                self.literal_defaulting_candidate_vars.items[driver_idx],
                 env,
             )) continue :candidate;
         }
@@ -15240,7 +15257,7 @@ fn commitLiteralGroupDefault(self: *Self, drivers: []const Var, env: *Env) Alloc
     // default (Dec for numerals, Str for quotes) so the dispatch pass reports the
     // conflicts. (All drivers are flex again — every failed probe rolled back —
     // but re-check defensively.)
-    for (drivers, kinds.items) |driver, kind| {
+    for (drivers, self.literal_defaulting_kinds.items) |driver, kind| {
         if (self.types.resolveVar(driver).desc.content != .flex) continue;
         switch (kind) {
             .numeral => _ = try self.commitLiteralDefaultHead(driver, env),

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -354,6 +354,11 @@ boundary_reachable_vars: std.AutoHashMap(Var, void),
 /// literal's constraint signatures, intersected with
 /// `boundary_reachable_vars` to detect interface leaks.
 boundary_leak_vars: std.AutoHashMap(Var, void),
+/// Reusable per-call buffer of the module's `.eql` constraint edges, so the
+/// generalization-boundary fixpoint iterates just the edges instead of
+/// re-scanning the whole constraint list each round. Front-loaded; cleared and
+/// refilled per call.
+boundary_eql_edges: std.ArrayListUnmanaged(@FieldType(Constraint, "eql")),
 /// Debug-only literal-defaulting probe instrumentation, asserted by the
 /// refuted-count guard test. Only written under `comptime std.debug.runtime_safety`,
 /// so release builds compile the bookkeeping out entirely (no global state, no
@@ -1154,6 +1159,7 @@ fn initAssumePrepared(
         .pinnable_spine_visited = std.AutoHashMap(Var, void).init(gpa),
         .boundary_reachable_vars = std.AutoHashMap(Var, void).init(gpa),
         .boundary_leak_vars = std.AutoHashMap(Var, void).init(gpa),
+        .boundary_eql_edges = .empty,
         .checked_lambda_params = .empty,
         .probe_var_pool_lens = .empty,
     };
@@ -1277,6 +1283,7 @@ pub fn deinit(self: *Self) void {
     self.pinnable_spine_visited.deinit();
     self.boundary_reachable_vars.deinit();
     self.boundary_leak_vars.deinit();
+    self.boundary_eql_edges.deinit(self.gpa);
     self.checked_lambda_params.deinit(self.gpa);
     self.probe_var_pool_lens.deinit(self.gpa);
 }
@@ -15376,6 +15383,20 @@ fn defaultLiteralsAtGeneralizationBoundary(self: *Self, def_root_var: Var, env: 
     }
     if (!has_candidate) return;
 
+    // Collect the module's `.eql` edges once so the recursive-def pass and the
+    // fixpoint below iterate just the edges, not the whole constraint list.
+    // Safe to snapshot here: nothing between this point and the fixpoint adds an
+    // `.eql` constraint (the passes only collect reachable vars).
+    self.boundary_eql_edges.clearRetainingCapacity();
+    {
+        var edge_iter = self.constraints.iterIndices();
+        while (edge_iter.next()) |constraint_idx| {
+            switch (self.constraints.get(constraint_idx).*) {
+                .eql => |eql| try self.boundary_eql_edges.append(self.gpa, eql),
+            }
+        }
+    }
+
     // The def root's reachable closure (recursing into `where`-constraint
     // signatures). A cycle root generalizes its whole group at once, so also seed
     // from every deferred cycle participant's def vars; at a non-cycle boundary
@@ -15414,36 +15435,31 @@ fn defaultLiteralsAtGeneralizationBoundary(self: *Self, def_root_var: Var, env: 
     // carries a `Str`, not an open numeral, so seeding its var changes no defaulting
     // and the real clash still surfaces. Purely conservative throughout: only ever
     // keeps more literals open, defaults none.
-    {
-        var rec_iter = self.constraints.iterIndices();
-        while (rec_iter.next()) |constraint_idx| {
-            switch (self.constraints.get(constraint_idx).*) {
-                .eql => |eql| switch (eql.ctx) {
-                    .recursive_def => {
-                        const ref_resolved = self.types.resolveVar(eql.actual);
-                        const ref_func = ref_resolved.desc.content.unwrapFunc() orelse continue;
-                        try self.collectReachableVars(ref_func.ret, &self.boundary_reachable_vars);
+    for (self.boundary_eql_edges.items) |eql| {
+        switch (eql.ctx) {
+            .recursive_def => {
+                const ref_resolved = self.types.resolveVar(eql.actual);
+                const ref_func = ref_resolved.desc.content.unwrapFunc() orelse continue;
+                try self.collectReachableVars(ref_func.ret, &self.boundary_reachable_vars);
 
-                        // The referenced def's annotated body var supplies the
-                        // parameter types: `expected` (a self-reference's pattern
-                        // var) is not yet unified with the annotation here, but the
-                        // body var has carried it since the body was checked.
-                        const annotated_fn_var = eql.recursive_annotated_fn_var orelse continue;
-                        const annotated_func = self.types.resolveVar(annotated_fn_var).desc.content.unwrapFunc() orelse continue;
-                        const call_args = self.types.sliceVars(ref_func.args);
-                        const param_vars = self.types.sliceVars(annotated_func.args);
-                        const arg_count = @min(call_args.len, param_vars.len);
-                        for (call_args[0..arg_count], param_vars[0..arg_count]) |call_arg, param_var| {
-                            const param_content = self.types.resolveVar(param_var).desc.content;
-                            switch (param_content) {
-                                .flex, .rigid => {},
-                                .structure, .alias, .err => try self.collectReachableVars(call_arg, &self.boundary_reachable_vars),
-                            }
-                        }
-                    },
-                    else => {},
-                },
-            }
+                // The referenced def's annotated body var supplies the
+                // parameter types: `expected` (a self-reference's pattern
+                // var) is not yet unified with the annotation here, but the
+                // body var has carried it since the body was checked.
+                const annotated_fn_var = eql.recursive_annotated_fn_var orelse continue;
+                const annotated_func = self.types.resolveVar(annotated_fn_var).desc.content.unwrapFunc() orelse continue;
+                const call_args = self.types.sliceVars(ref_func.args);
+                const param_vars = self.types.sliceVars(annotated_func.args);
+                const arg_count = @min(call_args.len, param_vars.len);
+                for (call_args[0..arg_count], param_vars[0..arg_count]) |call_arg, param_var| {
+                    const param_content = self.types.resolveVar(param_var).desc.content;
+                    switch (param_content) {
+                        .flex, .rigid => {},
+                        .structure, .alias, .err => try self.collectReachableVars(call_arg, &self.boundary_reachable_vars),
+                    }
+                }
+            },
+            else => {},
         }
     }
 
@@ -15455,18 +15471,13 @@ fn defaultLiteralsAtGeneralizationBoundary(self: *Self, def_root_var: Var, env: 
     var changed = true;
     while (changed) {
         changed = false;
-        var constraint_iter = self.constraints.iterIndices();
-        while (constraint_iter.next()) |constraint_idx| {
-            switch (self.constraints.get(constraint_idx).*) {
-                .eql => |eql| {
-                    const expected_in = self.boundary_reachable_vars.contains(self.types.resolveVar(eql.expected).var_);
-                    const actual_in = self.boundary_reachable_vars.contains(self.types.resolveVar(eql.actual).var_);
-                    if (expected_in == actual_in) continue;
-                    try self.collectReachableVars(eql.expected, &self.boundary_reachable_vars);
-                    try self.collectReachableVars(eql.actual, &self.boundary_reachable_vars);
-                    changed = true;
-                },
-            }
+        for (self.boundary_eql_edges.items) |eql| {
+            const expected_in = self.boundary_reachable_vars.contains(self.types.resolveVar(eql.expected).var_);
+            const actual_in = self.boundary_reachable_vars.contains(self.types.resolveVar(eql.actual).var_);
+            if (expected_in == actual_in) continue;
+            try self.collectReachableVars(eql.expected, &self.boundary_reachable_vars);
+            try self.collectReachableVars(eql.actual, &self.boundary_reachable_vars);
+            changed = true;
         }
     }
 

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -346,6 +346,9 @@ reported_dispatch_vars: std.AutoHashMap(Var, void),
 /// Scratch for `collectArgPositionVars`: guards its function-ret / alias
 /// spine walk against unbounded recursion.
 pinnable_spine_visited: std.AutoHashMap(Var, void),
+/// Scratch for the ambiguity sweep: vars an outside caller can pin through a
+/// top-level def's argument positions (computed once per `checkFile`).
+external_pinnable: std.AutoHashMap(Var, void),
 /// Scratch for `defaultLiteralsAtGeneralizationBoundary`: reachable-var
 /// closure of the def root(s) being generalized (constraint-signature edges
 /// included).
@@ -1181,6 +1184,7 @@ fn initAssumePrepared(
         .pinnable_vars = std.AutoHashMap(Var, void).init(gpa),
         .reported_dispatch_vars = std.AutoHashMap(Var, void).init(gpa),
         .pinnable_spine_visited = std.AutoHashMap(Var, void).init(gpa),
+        .external_pinnable = std.AutoHashMap(Var, void).init(gpa),
         .boundary_reachable_vars = std.AutoHashMap(Var, void).init(gpa),
         .boundary_leak_vars = std.AutoHashMap(Var, void).init(gpa),
         .boundary_eql_edges = .empty,
@@ -1323,6 +1327,7 @@ pub fn deinit(self: *Self) void {
     self.pinnable_vars.deinit();
     self.reported_dispatch_vars.deinit();
     self.pinnable_spine_visited.deinit();
+    self.external_pinnable.deinit();
     self.boundary_reachable_vars.deinit();
     self.boundary_leak_vars.deinit();
     self.boundary_eql_edges.deinit(self.gpa);
@@ -4747,9 +4752,8 @@ fn checkFileInternal(self: *Self, skip_numeric_defaults: bool) std.mem.Allocator
     // ARGUMENT position of a top-level def, including argument positions of
     // function values returned by that def. These are the vars an outside caller
     // can still pin after this module is checked.
-    var external_pinnable = std.AutoHashMap(Var, void).init(self.gpa);
-    defer external_pinnable.deinit();
-    try self.collectExternalPinnableVars(&external_pinnable);
+    self.external_pinnable.clearRetainingCapacity();
+    try self.collectExternalPinnableVars(&self.external_pinnable);
 
     // The full pinnable set additionally includes direct lambda parameters. That
     // remains correct for direct dispatch expressions on uncalled function values:
@@ -4757,9 +4761,9 @@ fn checkFileInternal(self: *Self, skip_numeric_defaults: bool) std.mem.Allocator
     // use only `external_pinnable`, because the call that instantiated the
     // contract must satisfy it now.
     self.pinnable_vars.clearRetainingCapacity();
-    try self.collectPinnableVars(&self.pinnable_vars, &external_pinnable);
+    try self.collectPinnableVars(&self.pinnable_vars, &self.external_pinnable);
 
-    try self.reportAmbiguousStaticDispatchPerInstantiation(&self.reported_dispatch_vars, &self.pinnable_vars, &external_pinnable);
+    try self.reportAmbiguousStaticDispatchPerInstantiation(&self.reported_dispatch_vars, &self.pinnable_vars, &self.external_pinnable);
     try self.reportAmbiguousStaticDispatch(&self.reported_dispatch_vars, &self.pinnable_vars);
 
     try self.reportNonExhaustiveLambdaParams(&env);

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -374,6 +374,15 @@ literal_defaulting_group_warnings: std.ArrayListUnmanaged(PendingBoundaryWarning
 literal_defaulting_constraint_ranges: std.ArrayListUnmanaged(StaticDispatchConstraint.SafeList.Range),
 literal_defaulting_kinds: std.ArrayListUnmanaged(StaticDispatchConstraint.LiteralKind),
 literal_defaulting_candidate_vars: std.ArrayListUnmanaged(Var),
+// Match alternative-pattern binding scratch (front-loaded; cleared per call/branch).
+alt_pattern_baseline: std.AutoHashMap(u32, MatchAltBaselineEntry),
+alt_pattern_bindings: std.ArrayList(PatternBinding),
+alt_pattern_current: std.AutoHashMap(u32, CIR.Pattern.Idx),
+// Payload-emptiness scratch (front-loaded; cleared at each use).
+collected_constructed_tags: std.ArrayList(Ident.Idx),
+payload_vars_to_close: std.ArrayList(Var),
+known_empty_payload_vars_destructure: std.ArrayList(Var),
+known_empty_payload_vars_match: std.ArrayList(Var),
 /// Debug-only literal-defaulting probe instrumentation, asserted by the
 /// refuted-count guard test. Only written under `comptime std.debug.runtime_safety`,
 /// so release builds compile the bookkeeping out entirely (no global state, no
@@ -1186,6 +1195,13 @@ fn initAssumePrepared(
         .literal_defaulting_constraint_ranges = .empty,
         .literal_defaulting_kinds = .empty,
         .literal_defaulting_candidate_vars = .empty,
+        .alt_pattern_baseline = std.AutoHashMap(u32, MatchAltBaselineEntry).init(gpa),
+        .alt_pattern_bindings = .empty,
+        .alt_pattern_current = std.AutoHashMap(u32, CIR.Pattern.Idx).init(gpa),
+        .collected_constructed_tags = .empty,
+        .payload_vars_to_close = .empty,
+        .known_empty_payload_vars_destructure = .empty,
+        .known_empty_payload_vars_match = .empty,
         .checked_lambda_params = .empty,
         .probe_var_pool_lens = .empty,
     };
@@ -1321,6 +1337,13 @@ pub fn deinit(self: *Self) void {
     self.literal_defaulting_constraint_ranges.deinit(self.gpa);
     self.literal_defaulting_kinds.deinit(self.gpa);
     self.literal_defaulting_candidate_vars.deinit(self.gpa);
+    self.alt_pattern_baseline.deinit();
+    self.alt_pattern_bindings.deinit(self.gpa);
+    self.alt_pattern_current.deinit();
+    self.collected_constructed_tags.deinit(self.gpa);
+    self.payload_vars_to_close.deinit(self.gpa);
+    self.known_empty_payload_vars_destructure.deinit(self.gpa);
+    self.known_empty_payload_vars_match.deinit(self.gpa);
     self.checked_lambda_params.deinit(self.gpa);
     self.probe_var_pool_lens.deinit(self.gpa);
 }
@@ -9326,6 +9349,8 @@ const PatternBinding = struct {
     pattern_idx: CIR.Pattern.Idx,
 };
 
+const MatchAltBaselineEntry = struct { pattern_idx: CIR.Pattern.Idx, pattern_index: u32 };
+
 fn reportMatchAltBinderProblem(
     self: *Self,
     expected_pattern_idx: CIR.Pattern.Idx,
@@ -9437,20 +9462,14 @@ fn unifyMatchAltPatternBindings(
 ) std.mem.Allocator.Error!bool {
     if (branch_ptrn_idxs.len <= 1) return false;
 
-    var baseline = std.AutoHashMap(u32, struct {
-        pattern_idx: CIR.Pattern.Idx,
-        pattern_index: u32,
-    }).init(self.gpa);
-    defer baseline.deinit();
-
-    var bindings: std.ArrayList(PatternBinding) = .empty;
-    defer bindings.deinit(self.gpa);
+    self.alt_pattern_baseline.clearRetainingCapacity();
+    self.alt_pattern_bindings.clearRetainingCapacity();
 
     {
         const first_branch_pattern = self.cir.store.getMatchBranchPattern(branch_ptrn_idxs[0]);
-        try self.collectPatternBindings(first_branch_pattern.pattern, &bindings);
-        for (bindings.items) |binding| {
-            try baseline.put(@as(u32, @bitCast(binding.ident)), .{
+        try self.collectPatternBindings(first_branch_pattern.pattern, &self.alt_pattern_bindings);
+        for (self.alt_pattern_bindings.items) |binding| {
+            try self.alt_pattern_baseline.put(@as(u32, @bitCast(binding.ident)), .{
                 .pattern_idx = binding.pattern_idx,
                 .pattern_index = 0,
             });
@@ -9460,17 +9479,16 @@ fn unifyMatchAltPatternBindings(
     var had_type_error = false;
 
     for (branch_ptrn_idxs[1..], 1..) |branch_ptrn_idx, pattern_index| {
-        bindings.clearRetainingCapacity();
+        self.alt_pattern_bindings.clearRetainingCapacity();
         const branch_pattern = self.cir.store.getMatchBranchPattern(branch_ptrn_idx);
-        try self.collectPatternBindings(branch_pattern.pattern, &bindings);
+        try self.collectPatternBindings(branch_pattern.pattern, &self.alt_pattern_bindings);
 
-        var current = std.AutoHashMap(u32, CIR.Pattern.Idx).init(self.gpa);
-        defer current.deinit();
+        self.alt_pattern_current.clearRetainingCapacity();
 
-        for (bindings.items) |binding| {
+        for (self.alt_pattern_bindings.items) |binding| {
             const key: u32 = @bitCast(binding.ident);
-            try current.put(key, binding.pattern_idx);
-            const first = baseline.get(key) orelse {
+            try self.alt_pattern_current.put(key, binding.pattern_idx);
+            const first = self.alt_pattern_baseline.get(key) orelse {
                 const first_branch_pattern = self.cir.store.getMatchBranchPattern(branch_ptrn_idxs[0]);
                 try self.reportMatchAltBinderProblem(
                     first_branch_pattern.pattern,
@@ -9503,9 +9521,9 @@ fn unifyMatchAltPatternBindings(
             if (!result.isOk()) had_type_error = true;
         }
 
-        var baseline_iter = baseline.iterator();
+        var baseline_iter = self.alt_pattern_baseline.iterator();
         while (baseline_iter.next()) |entry| {
-            if (current.contains(entry.key_ptr.*)) continue;
+            if (self.alt_pattern_current.contains(entry.key_ptr.*)) continue;
 
             const ident: Ident.Idx = @bitCast(entry.key_ptr.*);
             try self.reportMatchAltBinderProblem(
@@ -12085,14 +12103,13 @@ fn collectKnownEmptyPayloadVarsForExpr(
     target_var: Var,
     out: *std.ArrayList(Var),
 ) Allocator.Error!bool {
-    var constructed_tags: std.ArrayList(Ident.Idx) = .empty;
-    defer constructed_tags.deinit(self.gpa);
+    self.collected_constructed_tags.clearRetainingCapacity();
 
-    const known = try self.collectConstructedTagsForExpr(expr_idx, &constructed_tags);
+    const known = try self.collectConstructedTagsForExpr(expr_idx, &self.collected_constructed_tags);
     if (!known) return false;
-    if (constructed_tags.items.len == 0) return true;
+    if (self.collected_constructed_tags.items.len == 0) return true;
 
-    try self.collectAbsentCtorPayloadBlockers(target_var, constructed_tags.items, out);
+    try self.collectAbsentCtorPayloadBlockers(target_var, self.collected_constructed_tags.items, out);
     return true;
 }
 
@@ -12101,12 +12118,11 @@ fn closeAbsentConstructedPayloadVars(
     expr_idx: CIR.Expr.Idx,
     target_var: Var,
 ) Allocator.Error!void {
-    var payload_vars_to_close: std.ArrayList(Var) = .empty;
-    defer payload_vars_to_close.deinit(self.gpa);
+    self.payload_vars_to_close.clearRetainingCapacity();
 
-    _ = try self.collectKnownEmptyPayloadVarsForExpr(expr_idx, target_var, &payload_vars_to_close);
+    _ = try self.collectKnownEmptyPayloadVarsForExpr(expr_idx, target_var, &self.payload_vars_to_close);
 
-    for (payload_vars_to_close.items) |payload_var| {
+    for (self.payload_vars_to_close.items) |payload_var| {
         try self.closePayloadVarToEmpty(payload_var);
     }
 }
@@ -12125,9 +12141,8 @@ fn checkDestructureExhaustiveness(
 ) std.mem.Allocator.Error!void {
     if (!self.patternNeedsExhaustiveness(pattern_idx)) return;
 
-    var known_empty_payload_vars: std.ArrayList(Var) = .empty;
-    defer known_empty_payload_vars.deinit(self.gpa);
-    const value_constructors_known = try self.collectKnownEmptyPayloadVarsForExpr(value_expr_idx, value_var, &known_empty_payload_vars);
+    self.known_empty_payload_vars_destructure.clearRetainingCapacity();
+    const value_constructors_known = try self.collectKnownEmptyPayloadVarsForExpr(value_expr_idx, value_var, &self.known_empty_payload_vars_destructure);
 
     const result = exhaustive.checkDestructure(
         self.cir.gpa,
@@ -12136,7 +12151,7 @@ fn checkDestructureExhaustiveness(
         self.exhaustiveBuiltinIdents(),
         pattern_idx,
         value_var,
-        known_empty_payload_vars.items,
+        self.known_empty_payload_vars_destructure.items,
         value_constructors_known,
     ) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
@@ -13282,9 +13297,8 @@ fn checkMatchExpr(
     if (!match.skip_exhaustiveness and !had_type_error and !cond_is_error and !has_invalid_try and !cond_always_crashes) {
         const match_region = self.getRegionAt(@enumFromInt(@intFromEnum(expr_idx)));
 
-        var known_empty_payload_vars: std.ArrayList(Var) = .empty;
-        defer known_empty_payload_vars.deinit(self.gpa);
-        const cond_constructors_known = try self.collectKnownEmptyPayloadVarsForExpr(match.cond, cond_var, &known_empty_payload_vars);
+        self.known_empty_payload_vars_match.clearRetainingCapacity();
+        const cond_constructors_known = try self.collectKnownEmptyPayloadVarsForExpr(match.cond, cond_var, &self.known_empty_payload_vars_match);
 
         const result = exhaustive.checkMatch(
             self.cir.gpa,
@@ -13294,7 +13308,7 @@ fn checkMatchExpr(
             match.branches,
             cond_var,
             match_region,
-            known_empty_payload_vars.items,
+            self.known_empty_payload_vars_match.items,
             cond_constructors_known,
         ) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -15172,14 +15172,7 @@ fn commitLiteralGroupDefault(self: *Self, drivers: []const Var, env: *Env) Alloc
         // accepts by definition, so they have nothing to precheck.
         for (constraint_ranges.items, kinds.items) |range, kind| {
             if (kind != .numeral) continue;
-            for (self.types.sliceStaticDispatchConstraints(range)) |constraint| {
-                switch (constraint.origin) {
-                    .from_literal => |lit| {
-                        if (!literalInfoAcceptsBuiltinNumKind(lit, candidate_kind)) continue :candidate;
-                    },
-                    else => {},
-                }
-            }
+            if (!self.rangeNumeralDigitsFit(range, candidate_kind)) continue :candidate;
         }
 
         var commit_probe = try self.beginCommitProbe(env);
@@ -15208,26 +15201,13 @@ fn commitLiteralGroupDefault(self: *Self, drivers: []const Var, env: *Env) Alloc
         }
 
         // Phase 2: verify every driver's every non-literal constraint.
-        // Store-backed iterator, not a held slice: the verification appends to
-        // the constraint store, which can reallocate and dangle a slice.
-        for (drivers, 0..) |_, driver_idx| {
-            var constraints_iter = self.types.iterStaticDispatchConstraints(constraint_ranges.items[driver_idx]);
-            while (constraints_iter.next()) |constraint| {
-                switch (constraint.origin) {
-                    // Validated digit-fit above, before the probe began.
-                    .from_literal => {},
-                    else => {
-                        if (!try self.staticDispatchConstraintAcceptsCandidate(
-                            &commit_probe,
-                            constraint,
-                            candidate_vars.items[driver_idx],
-                            env,
-                        )) {
-                            continue :candidate;
-                        }
-                    },
-                }
-            }
+        for (0..drivers.len) |driver_idx| {
+            if (!try self.candidateSatisfiesRangeConstraints(
+                &commit_probe,
+                constraint_ranges.items[driver_idx],
+                candidate_vars.items[driver_idx],
+                env,
+            )) continue :candidate;
         }
 
         committed = true;
@@ -15796,14 +15776,7 @@ fn tryCommitNumeralCandidate(
     // numerals: the digits fit `candidate_kind`). Pure arithmetic on the
     // constraint payloads, checked before any store mutation so refuting a
     // candidate on digits alone costs no speculation at all.
-    for (self.types.sliceStaticDispatchConstraints(constraint_range)) |constraint| {
-        switch (constraint.origin) {
-            .from_literal => |lit| {
-                if (!literalInfoAcceptsBuiltinNumKind(lit, candidate_kind)) return null;
-            },
-            else => {},
-        }
-    }
+    if (!self.rangeNumeralDigitsFit(constraint_range, candidate_kind)) return null;
 
     var commit_probe = try self.beginCommitProbe(env);
     var committed = false;
@@ -15826,20 +15799,7 @@ fn tryCommitNumeralCandidate(
     const unify_result = try self.unify(literal_var, candidate_var, env);
     if (!unify_result.isOk()) return null;
 
-    // Store-backed iterator, not a held slice: the probe below appends to the
-    // constraint store, which can reallocate and dangle a slice.
-    var constraints_iter = self.types.iterStaticDispatchConstraints(constraint_range);
-    while (constraints_iter.next()) |constraint| {
-        switch (constraint.origin) {
-            // Validated digit-fit above, before the probe began.
-            .from_literal => {},
-            else => {
-                if (!try self.staticDispatchConstraintAcceptsCandidate(&commit_probe, constraint, candidate_var, env)) {
-                    return null;
-                }
-            },
-        }
-    }
+    if (!try self.candidateSatisfiesRangeConstraints(&commit_probe, constraint_range, candidate_var, env)) return null;
 
     committed = true;
     commit_probe.commit();
@@ -15904,6 +15864,52 @@ fn staticDispatchConstraintAcceptsCandidate(
     // commit-probe rollback rewinds.
     const result = try self.unify(method_var, constraint.fn_var, env);
     return result.isOk();
+}
+
+/// Whether the builtin numeric candidate `candidate_kind` can represent every
+/// `from_literal` numeral payload in `range` (digit fit). Pure arithmetic on the
+/// constraint payloads — no speculation. Shared digit-fit precheck for the
+/// single-literal and group numeral probes.
+fn rangeNumeralDigitsFit(
+    self: *Self,
+    range: StaticDispatchConstraint.SafeList.Range,
+    candidate_kind: CIR.NumKind,
+) bool {
+    for (self.types.sliceStaticDispatchConstraints(range)) |constraint| {
+        switch (constraint.origin) {
+            .from_literal => |lit| {
+                if (!literalInfoAcceptsBuiltinNumKind(lit, candidate_kind)) return false;
+            },
+            else => {},
+        }
+    }
+    return true;
+}
+
+/// Whether `candidate_var` satisfies every non-`from_literal` dispatch constraint
+/// in `range`, under the open `probe` scope. Uses the store-backed iterator (not a
+/// held slice) because verification appends to the constraint store, which can
+/// reallocate. Shared phase-2 verify for the single-literal and group numeral
+/// probes.
+fn candidateSatisfiesRangeConstraints(
+    self: *Self,
+    probe: *CommitProbe,
+    range: StaticDispatchConstraint.SafeList.Range,
+    candidate_var: Var,
+    env: *Env,
+) Allocator.Error!bool {
+    var constraints_iter = self.types.iterStaticDispatchConstraints(range);
+    while (constraints_iter.next()) |constraint| {
+        switch (constraint.origin) {
+            .from_literal => {},
+            else => {
+                if (!try self.staticDispatchConstraintAcceptsCandidate(probe, constraint, candidate_var, env)) {
+                    return false;
+                }
+            },
+        }
+    }
+    return true;
 }
 
 fn isBuiltinNumericNominal(self: *Self, var_: Var) bool {

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -354,6 +354,12 @@ boundary_reachable_vars: std.AutoHashMap(Var, void),
 /// literal's constraint signatures, intersected with
 /// `boundary_reachable_vars` to detect interface leaks.
 boundary_leak_vars: std.AutoHashMap(Var, void),
+/// Debug-only literal-defaulting probe instrumentation, asserted by the
+/// refuted-count guard test. Only written under `comptime std.debug.runtime_safety`,
+/// so release builds compile the bookkeeping out entirely (no global state, no
+/// hot-path cost). Per-instance, so no cross-test synchronization concern.
+bench_probe_attempts: usize = 0,
+bench_probe_refuted: usize = 0,
 /// Param-pattern spans of every checked `e_lambda` / `e_hosted_lambda`; the
 /// pinnable collection consumes this instead of re-walking the NodeStore.
 /// Union-find roots resolve at consumption time (eager roots would go stale).
@@ -15543,17 +15549,6 @@ fn varLiteralKind(self: *Self, var_: Var) ?StaticDispatchConstraint.LiteralKind 
 // until the new kind is handled: the exhaustiveness *is* the checklist for the
 // next literal kind (e.g. strings).
 
-// Literal-defaulting probe test-support counters (PERMANENT):
-// `bench_probe_attempts` and `bench_probe_refuted` are reset and asserted by the
-// refuted-count guard test in src/check/test/type_checking_integration.zig, which
-// detects `numeralCandidateStructurallyRefuted` silently going dead (refuting
-// nothing). Zig's default test runner executes a binary's tests sequentially
-// in-process, so the reset-check-assert pattern needs no synchronization.
-/// Number of default-candidate probes attempted by literal-defaulting tests.
-pub var bench_probe_attempts: usize = 0;
-/// Number of default-candidate probes skipped by structural refutation tests.
-pub var bench_probe_refuted: usize = 0;
-
 /// Default a still-open literal var and COMMIT the result, returning the var the
 /// literal was resolved against (for the boundary warning's snapshot).
 /// Haskell-style: commit the FIRST candidate in the kind's canonical order that
@@ -15591,15 +15586,17 @@ fn commitLiteralDefault(self: *Self, literal_var: Var, kind: StaticDispatchConst
                         // counted as such below via `bench_probe_refuted`), so
                         // counting the safety-only re-probe as an attempt would make
                         // the refuted-count guard test's attempt/refuted bookkeeping
-                        // diverge between safety and release builds.
+                        // diverge between safety and release builds. Both counters are
+                        // per-instance debug-only fields, compiled out entirely in
+                        // release builds (no global state, no hot-path cost).
                         if (comptime std.debug.runtime_safety) {
                             const witness = try self.tryCommitNumeralCandidate(literal_var, candidate_kind, constraint_range, env);
                             std.debug.assert(witness == null);
+                            self.bench_probe_refuted += 1;
                         }
-                        bench_probe_refuted += 1;
                         continue;
                     }
-                    bench_probe_attempts += 1;
+                    if (comptime std.debug.runtime_safety) self.bench_probe_attempts += 1;
                     if (try self.tryCommitNumeralCandidate(literal_var, candidate_kind, constraint_range, env)) |committed_var| {
                         return committed_var;
                     }

--- a/src/check/canonical_type_keys.zig
+++ b/src/check/canonical_type_keys.zig
@@ -236,34 +236,24 @@ const Builder = struct {
     /// A mixed-kind set (both numeral and quote literal-origin constraints,
     /// reachable only via a flex/flex merge the checker reports as a type
     /// error, so it never survives to key generation) deterministically picks
-    /// `numeral`. This MUST agree with the mono layer's scan in
-    /// checked_artifact.zig `numericDefaultPhaseForConstraints`, where any
-    /// numeral constraint wins (-> Dec) before quote is considered (-> Str);
-    /// if the two sites disagreed, the key would silently name a different
-    /// nominal than mono specializes the variable to.
+    /// `numeral`. The precedence is enforced by
+    /// `StaticDispatchConstraint.dominantLiteralKind`, the single source of
+    /// truth shared with `varLiteralKind` (Check.zig) and
+    /// `numericDefaultPhaseForConstraints` (checked_artifact.zig).
     fn flexLiteralDefaultKind(self: *Builder, flex: types.Flex) ?LiteralKind {
         const constraints = self.store.sliceStaticDispatchConstraints(flex.constraints);
-        var has_numeral = false;
-        var has_quote = false;
-        var has_interpolation = false;
+        const kind = types.StaticDispatchConstraint.dominantLiteralKind(constraints);
         var has_other = false;
         for (constraints) |constraint| {
             switch (constraint.origin) {
-                .from_literal => |lit| switch (lit) {
-                    .numeral => has_numeral = true,
-                    .quote => has_quote = true,
-                    .interpolation => has_interpolation = true,
-                },
+                .from_literal => {},
                 else => has_other = true,
             }
         }
-        if ((has_numeral or has_quote or has_interpolation) and has_other) {
+        if (kind != null and has_other) {
             invariantViolation("concrete canonical type key requested for an open literal with non-literal constraints (defaulting was skipped)");
         }
-        if (has_numeral) return .numeral;
-        if (has_quote) return .quote;
-        if (has_interpolation) return .interpolation;
-        return null;
+        return kind;
     }
 
     fn writeLiteralDefault(self: *Builder, kind: LiteralKind) void {

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -18578,9 +18578,10 @@ const PlatformAppRelationTypeDigestBuilder = struct {
             self.writeBytes(self.names.methodNameText(constraint.fn_name));
             try self.writeSourceType(constraint.fn_ty);
             self.writeTag(@tagName(constraint.origin));
-            self.writeBool(constraint.binop_negated);
-            self.writeBool(constraint.num_literal != null);
-            if (constraint.num_literal) |num_literal| {
+            self.writeBool(constraint.origin.binopNegated());
+            const maybe_num_literal = constraint.numeralInfo();
+            self.writeBool(maybe_num_literal != null);
+            if (maybe_num_literal) |num_literal| {
                 self.hasher.update(&num_literal.bytes);
                 self.writeBool(num_literal.is_u128);
                 self.writeBool(num_literal.is_negative);
@@ -28005,8 +28006,8 @@ test "SERIALIZED_VERSION_HASH golden value" {
     // change, bump `serialized_layout_version` and replace the golden bytes below with
     // the ones this assertion prints.
     const golden: [32]u8 = .{
-        0x7A, 0xD7, 0xF9, 0x6A, 0x8A, 0xCF, 0x2D, 0xB1, 0x38, 0xC7, 0xEE, 0x84, 0xE8, 0xFC, 0x73, 0x30,
-        0x87, 0xA4, 0x32, 0x84, 0x02, 0xD8, 0x9B, 0x50, 0x3E, 0x88, 0xA0, 0x03, 0xCA, 0x7A, 0x96, 0x46,
+        0x55, 0x6A, 0xBA, 0x07, 0x35, 0x96, 0x79, 0xDE, 0x7A, 0xD3, 0xFB, 0xDD, 0x99, 0xAA, 0xBD, 0x15,
+        0x96, 0x0A, 0x0A, 0x31, 0x68, 0x83, 0x94, 0xDF, 0x8C, 0x50, 0x91, 0x14, 0x7F, 0x86, 0x88, 0xD5,
     };
     try std.testing.expectEqualSlices(u8, &golden, &CheckedModuleArtifact.SERIALIZED_VERSION_HASH);
 }

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -5855,18 +5855,16 @@ fn numericDefaultPhaseForConstraints(
     constraints_range: types.StaticDispatchConstraint.SafeList.Range,
 ) ?NumericDefaultPhase {
     const constraints = module.typeStoreConst().sliceStaticDispatchConstraints(constraints_range);
-    var has_str_defaultable_literal = false;
+    const kind = types.StaticDispatchConstraint.dominantLiteralKind(constraints);
+    var has_arith = false;
     for (constraints) |constraint| {
-        switch (constraint.origin) {
-            .from_literal => |lit| switch (lit) {
-                .numeral => return .mono_specialization,
-                .quote, .interpolation => has_str_defaultable_literal = true,
-            },
-            else => {},
+        if (isDefaultableArithmeticConstraint(module, constraint)) {
+            has_arith = true;
+            break;
         }
-        if (isDefaultableArithmeticConstraint(module, constraint)) return .mono_specialization;
     }
-    if (has_str_defaultable_literal) return .mono_specialization_str;
+    if (kind == .numeral or has_arith) return .mono_specialization;
+    if (kind == .quote or kind == .interpolation) return .mono_specialization_str;
     return null;
 }
 

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -2114,8 +2114,14 @@ pub const CheckedStaticDispatchConstraint = struct {
     fn_name: canonical.MethodNameId,
     fn_ty: CheckedTypeId,
     origin: types.StaticDispatchConstraint.Origin,
-    binop_negated: bool = false,
-    num_literal: ?types.NumeralInfo = null,
+
+    pub fn binopNegated(self: @This()) bool {
+        return self.origin.binopNegated();
+    }
+
+    pub fn numeralInfo(self: @This()) ?types.NumeralInfo {
+        return self.origin.numeralInfo();
+    }
 };
 
 /// Public `NumericDefaultPhase` declaration.
@@ -3833,8 +3839,6 @@ pub const CheckedTypeStore = struct {
                 .fn_name = constraint.fn_name,
                 .fn_ty = try self.cloneCheckedTypeRootSubstituting(allocator, names, constraint.fn_ty, formals, actuals, active),
                 .origin = constraint.origin,
-                .binop_negated = constraint.origin.binopNegated(),
-                .num_literal = constraint.origin.numeralInfo(),
             };
         }
         return out;
@@ -5526,9 +5530,10 @@ const SubstitutedCheckedTypeKeyBuilder = struct {
             self.writeBytes(self.names.methodNameText(constraint.fn_name));
             try self.writeType(constraint.fn_ty);
             self.writeTag(@tagName(constraint.origin));
-            self.writeBool(constraint.binop_negated);
-            self.writeBool(constraint.num_literal != null);
-            if (constraint.num_literal) |num_literal| {
+            self.writeBool(constraint.binopNegated());
+            const maybe_num_literal = constraint.numeralInfo();
+            self.writeBool(maybe_num_literal != null);
+            if (maybe_num_literal) |num_literal| {
                 self.hasher.update(&num_literal.bytes);
                 self.writeBool(num_literal.is_u128);
                 self.writeBool(num_literal.is_negative);
@@ -6045,8 +6050,6 @@ fn copyCheckedStaticDispatchConstraints(
             .fn_name = try names.internMethodIdent(module.identStoreConst(), constraint.fn_name),
             .fn_ty = try appendCheckedTypeRoot(allocator, module, names, imports, store, active, constraint.fn_var),
             .origin = constraint.origin,
-            .binop_negated = constraint.origin.binopNegated(),
-            .num_literal = constraint.origin.numeralInfo(),
         };
     }
     return out;
@@ -25221,8 +25224,6 @@ pub const CheckedTypeProjector = struct {
                 .fn_name = try self.remapViewMethodName(source_names, constraint.fn_name),
                 .fn_ty = try self.projectCheckedTypeViewRootInner(source, source_names, constraint.fn_ty, active),
                 .origin = constraint.origin,
-                .binop_negated = constraint.origin.binopNegated(),
-                .num_literal = constraint.origin.numeralInfo(),
             };
         }
         return out;
@@ -25473,8 +25474,6 @@ pub const CheckedTypeProjector = struct {
                 .fn_name = try self.remapMethodName(imported, constraint.fn_name),
                 .fn_ty = try self.projectImportedCheckedType(imported, constraint.fn_ty),
                 .origin = constraint.origin,
-                .binop_negated = constraint.origin.binopNegated(),
-                .num_literal = constraint.origin.numeralInfo(),
             };
         }
         return out;
@@ -25780,8 +25779,6 @@ const CheckedTypeStoreImportProjector = struct {
                 .fn_name = try self.remapMethodName(constraint.fn_name),
                 .fn_ty = try self.project(constraint.fn_ty),
                 .origin = constraint.origin,
-                .binop_negated = constraint.origin.binopNegated(),
-                .num_literal = constraint.origin.numeralInfo(),
             };
         }
         return out;

--- a/src/check/problem/types.zig
+++ b/src/check/problem/types.zig
@@ -382,9 +382,9 @@ pub const DispatcherDoesNotImplMethod = struct {
     fn_var: Var,
     method_name: Ident.Idx,
     origin: types_mod.StaticDispatchConstraint.Origin,
-    /// Optional numeric literal info for from_numeral constraints
+    /// Optional numeric literal info for `from_literal` constraints of kind `numeral`
     num_literal: ?types_mod.NumeralInfo = null,
-    /// Source region of the string literal for from_quote constraints
+    /// Source region of the string literal for `from_literal` constraints of kind `quote`
     quote_region: ?base.Region = null,
     /// True when the dispatcher was a numeric literal that was defaulted to Dec
     /// because no type annotation was given. Used to add explanatory text in errors.

--- a/src/check/test/TestEnv.zig
+++ b/src/check/test/TestEnv.zig
@@ -602,11 +602,11 @@ pub fn assertLastDefTypeWithWarnings(
     try testing.expectEqualStrings(expected, self.type_writer.get());
 }
 
-/// Assert that every type problem is warning-severity and that the rendered
-/// titles match `expected_titles` exactly, in order. Any error-severity
-/// problem (or a count/title mismatch) fails the assertion.
-fn assertOnlyTypeWarnings(self: *TestEnv, expected_titles: []const []const u8) TestEnvError!void {
-    var report_builder = try report_mod.ReportBuilder.init(
+/// Construct a ReportBuilder wired to this TestEnv's allocator, module env,
+/// checker snapshots, problems, and regions. All test call sites are
+/// identical, so this single helper avoids repeating the nine arguments.
+fn initReportBuilder(self: *TestEnv) Allocator.Error!report_mod.ReportBuilder {
+    return report_mod.ReportBuilder.init(
         self.gpa,
         self.module_env,
         self.module_env,
@@ -617,6 +617,13 @@ fn assertOnlyTypeWarnings(self: *TestEnv, expected_titles: []const []const u8) T
         &self.checker.import_mapping,
         &self.checker.regions,
     );
+}
+
+/// Assert that every type problem is warning-severity and that the rendered
+/// titles match `expected_titles` exactly, in order. Any error-severity
+/// problem (or a count/title mismatch) fails the assertion.
+fn assertOnlyTypeWarnings(self: *TestEnv, expected_titles: []const []const u8) TestEnvError!void {
+    var report_builder = try self.initReportBuilder();
     defer report_builder.deinit();
 
     try testing.expectEqual(expected_titles.len, self.checker.problems.problems.items.len);
@@ -679,17 +686,7 @@ pub fn assertOneTypeError(self: *TestEnv, expected: []const u8) TestEnvError!voi
     const problem = self.checker.problems.problems.items[0];
 
     // Assert the rendered problem matches the expected problem
-    var report_builder = try report_mod.ReportBuilder.init(
-        self.gpa,
-        self.module_env,
-        self.module_env,
-        &self.checker.snapshots,
-        &self.checker.problems,
-        "test",
-        &.{},
-        &self.checker.import_mapping,
-        &self.checker.regions,
-    );
+    var report_builder = try self.initReportBuilder();
     defer report_builder.deinit();
 
     var report = try report_builder.build(problem);
@@ -709,17 +706,7 @@ pub fn assertOneTypeErrorMsg(self: *TestEnv, expected: []const u8) TestEnvError!
     const problem = self.checker.problems.problems.items[0];
 
     // Assert the rendered problem matches the expected problem
-    var report_builder = try report_mod.ReportBuilder.init(
-        self.gpa,
-        self.module_env,
-        self.module_env,
-        &self.checker.snapshots,
-        &self.checker.problems,
-        "test",
-        &.{},
-        &self.checker.import_mapping,
-        &self.checker.regions,
-    );
+    var report_builder = try self.initReportBuilder();
     defer report_builder.deinit();
 
     var report = try report_builder.build(problem);
@@ -740,20 +727,10 @@ pub fn assertTypeErrorMsgs(self: *TestEnv, expected: []const []const u8) TestEnv
 
     try testing.expectEqual(expected.len, self.checker.problems.problems.items.len);
 
-    for (expected, self.checker.problems.problems.items) |expected_msg, problem| {
-        var report_builder = try report_mod.ReportBuilder.init(
-            self.gpa,
-            self.module_env,
-            self.module_env,
-            &self.checker.snapshots,
-            &self.checker.problems,
-            "test",
-            &.{},
-            &self.checker.import_mapping,
-            &self.checker.regions,
-        );
-        defer report_builder.deinit();
+    var report_builder = try self.initReportBuilder();
+    defer report_builder.deinit();
 
+    for (expected, self.checker.problems.problems.items) |expected_msg, problem| {
         var report = try report_builder.build(problem);
         defer report.deinit();
 
@@ -807,17 +784,7 @@ pub fn assertFirstTypeError(self: *TestEnv, expected: []const u8) TestEnvError!v
     const problem = self.checker.problems.problems.items[0];
 
     // Assert the rendered problem matches the expected problem
-    var report_builder = try report_mod.ReportBuilder.init(
-        self.gpa,
-        self.module_env,
-        self.module_env,
-        &self.checker.snapshots,
-        &self.checker.problems,
-        "test",
-        &.{},
-        &self.checker.import_mapping,
-        &self.checker.regions,
-    );
+    var report_builder = try self.initReportBuilder();
     defer report_builder.deinit();
 
     var report = try report_builder.build(problem);
@@ -886,7 +853,7 @@ fn assertNoCanProblems(self: *TestEnv) TestEnvError!void {
 }
 
 fn assertNoTypeProblems(self: *TestEnv) TestEnvError!void {
-    var report_builder = try report_mod.ReportBuilder.init(self.gpa, self.module_env, self.module_env, &self.checker.snapshots, &self.checker.problems, "test", &.{}, &self.checker.import_mapping, &self.checker.regions);
+    var report_builder = try self.initReportBuilder();
     defer report_builder.deinit();
 
     var report_buf = try std.array_list.Managed(u8).initCapacity(self.gpa, 256);

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -348,14 +348,10 @@ test "check type - numeral defaulting survivor matrix - every candidate as first
 // candidates before `u8` in `numeral_default_candidates` (src/check/Check.zig:
 // dec, i64, u64, i128, u128, i32, u32, i16, u16, i8 — then u8). Editing that
 // list must update this count to u8's new index.
-// `bench_probe_attempts`/`bench_probe_refuted` are permanent test-support
-// counters in Check.zig; zig's default test runner runs this binary's tests
-// sequentially in-process, so resetting them here cannot race.
+// `bench_probe_attempts`/`bench_probe_refuted` are per-instance debug-only fields
+// on the Check struct, compiled out entirely in release builds. A fresh Check
+// instance starts at 0, so no reset is needed.
 test "check type - numeral defaulting pre-filter refutes provably-failing candidates" {
-    const Check = @import("../Check.zig");
-    Check.bench_probe_attempts = 0;
-    Check.bench_probe_refuted = 0;
-
     const source =
         \\my_u8 : U8
         \\my_u8 = 7
@@ -369,8 +365,10 @@ test "check type - numeral defaulting pre-filter refutes provably-failing candid
     // canonical default).
     try test_env.assertDefType("h", "U8");
 
-    try testing.expectEqual(@as(usize, 1), Check.bench_probe_attempts);
-    try testing.expectEqual(@as(usize, 10), Check.bench_probe_refuted);
+    if (comptime std.debug.runtime_safety) {
+        try testing.expectEqual(@as(usize, 1), test_env.checker.bench_probe_attempts);
+        try testing.expectEqual(@as(usize, 10), test_env.checker.bench_probe_refuted);
+    }
 }
 
 // CANDIDATE-ORDER PIN for `numeral_default_candidates` (src/check/Check.zig):

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -6390,7 +6390,7 @@ fn finishRecordExpr(
 }
 
 /// Binding power of the lhs and rhs of a particular operator.
-const BinOpBp = struct { left: u8, right: u8 };
+pub const BinOpBp = struct { left: u8, right: u8 };
 
 inline fn isInBinOpTokenRange(tok: Token.Tag) bool {
     const tok_int = @intFromEnum(tok);
@@ -6440,7 +6440,7 @@ inline fn getTokenBPInRange(tok: Token.Tag) BinOpBp {
 }
 
 /// Get the binding power for a Token if it's a operator token, else return null.
-fn getTokenBP(tok: Token.Tag) ?BinOpBp {
+pub fn getTokenBP(tok: Token.Tag) ?BinOpBp {
     if (!isInBinOpTokenRange(tok)) return null;
     const bp = getTokenBPInRange(tok);
     return if (bp.left == 0) null else bp;

--- a/src/types/types.zig
+++ b/src/types/types.zig
@@ -1016,6 +1016,28 @@ pub const StaticDispatchConstraint = struct {
         const b_text = store.getText(b.fn_name);
         return std.mem.order(u8, a_text, b_text);
     }
+
+    /// The literal kind a flex var defaults to when it carries `from_literal`
+    /// constraints, by fixed precedence: numeral > quote > interpolation. Single
+    /// source of truth for the tie-break used by the checker (`varLiteralKind`),
+    /// the canonical-key builder (`flexLiteralDefaultKind`), and the mono
+    /// default-phase scan (`numericDefaultPhaseForConstraints`) — they MUST agree,
+    /// or mirror-image programs get different keys/diagnostics.
+    pub fn dominantLiteralKind(constraints: []const StaticDispatchConstraint) ?LiteralKind {
+        var has_quote = false;
+        var has_interpolation = false;
+        for (constraints) |constraint| {
+            switch (constraint.origin) {
+                .from_literal => |lit| switch (lit) {
+                    .numeral => return .numeral,
+                    .quote => has_quote = true,
+                    .interpolation => has_interpolation = true,
+                },
+                else => {},
+            }
+        }
+        return if (has_quote) .quote else if (has_interpolation) .interpolation else null;
+    }
 };
 
 /// Two record fields


### PR DESCRIPTION
Follow-up cleanup to #9605 ("check: lots of literal things"), driven by a multi-pass review (correctness, duplication, and a local-optimum/architecture audit). Sixteen well-scoped commits, each behavior-preserving except the first (a latent bug fix). No snapshots were harmed in the making of this PR

### Correctness
- **fix(emit): parenthesize negative typed numerals under unary operators** — `unaryReceiverNeedsParens` only guarded `e_num_from_numeral`, so a unary op over a negative `e_typed_num_from_numeral` re-emitted as `--5.U8` (re-tokenizes as binary minus). Merged the two from-numeral arms; added a round-trip unit test.

### Duplication squashes (Check.zig)
- **extract `collectConstraintSignatureReachable`** — the signature-footprint walk was copy-pasted in `boundaryDefaultLeaksIntoSignature` and `runLiteralDefaultingRounds`; these must agree or a literal could be partitioned non-interfering yet warned.
- **share numeral-probe digit-fit and verify loops** — `tryCommitNumeralCandidate` and `commitLiteralGroupDefault` now call shared `rangeNumeralDigitsFit` / `candidateSatisfiesRangeConstraints` instead of hand-synced copies.
- **centralize boundary-leak warning bracketing** — new `commitGatheredGroup`, symmetric to `commitGatheredLiteral`, collapses the inlined before/commit/after warning dance.

### Consolidation
- **derive `CheckedStaticDispatchConstraint` flat fields via accessors** — drop the redundant `binop_negated`/`num_literal` (re-derived from `origin` at 5 sites) in favor of `binopNegated()`/`numeralInfo()`, finishing the consolidation the PR began on the type-store side.

### Architecture audit findings
- **single source of truth for binding powers** — RocEmitter kept a hand-synced parallel copy of the parser's binding-power table (its comment falsely claimed it "mirrored exactly"; the numbers were actually off-by-2). A parser precedence change could have silently made re-emitted operator expressions reparse to a different tree. The emitter now maps `Binop.Op → Token.Tag` and looks up the parser's one table, and a `comptime` assertion enforces that every `Binop.Op` resolves to a token with a defined binding power (so the lookup's `.?` can never panic — a bad future mapping becomes a compile error).
- **centralize the literal-kind tie-break** — `numeral > quote > interpolation` was replicated at three sites synced only by a doc comment; now one `StaticDispatchConstraint.dominantLiteralKind` kernel.
- **buffer `.eql` edges in the generalization-boundary scan** — `defaultLiteralsAtGeneralizationBoundary` re-scanned the whole module constraint list each fixpoint round; now collects the `.eql` edges into a front-loaded reusable buffer once per call.

### Tidy-ups
- **probe bench counters → per-instance + debug-only** — moved off process-global `pub var`s onto `Check` fields, gated every increment behind `comptime std.debug.runtime_safety` so release builds compile them out to a true no-op.
- `SurfaceOrigin` encode/decode comptime guard + round-trip test; `TestEnv.initReportBuilder` helper (collapsing 6 sites, hoisting one out of a loop); stale doc-comment fixes.
- Lifts all inline allocations to the root struct in `Check` for predictable memory use

### Verification
Every commit was implemented and independently reviewed (spec + code-quality) per task, then a final holistic review of the whole stack. Each behavior-preserving change asserts **zero `test/snapshots` drift** after regeneration. Full stack: **2608 Zig unit tests pass**, **multi-backend eval passes**, **zero snapshot drift**. (The binding-power `comptime` guard is compile-time-checked and adds no runtime behavior.)

> Note: local `zig build minici` fails only in `build-coverage-tools` (the vendored `kcov` tool can't find system libs `z`/`curl` in this environment) — unrelated to these changes and identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
