### PR TITLE
Support var declarations without initializers

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -15674,6 +15674,10 @@ fn runRootU8(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR.L
 }
 
 test "dev lowering: init_uninitialized writes poison pattern" {
+    if (comptime builtin.cpu.arch != .x86_64 and builtin.cpu.arch != .aarch64) {
+        return error.SkipZigTest;
+    }
+
     const allocator = std.testing.allocator;
     var store = LirStore.init(allocator);
     defer store.deinit();

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -5355,6 +5355,29 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             try self.local_locations.put(key, stable_loc);
         }
 
+        fn stableLocationStackOffset(stable_loc: ValueLocation) i32 {
+            return switch (stable_loc) {
+                .stack => |stack_loc| stack_loc.offset,
+                .stack_i128 => |offset| offset,
+                .stack_str => |offset| offset,
+                .list_stack => |list_loc| list_loc.struct_offset,
+                else => std.debug.panic(
+                    "LirCodeGen invariant violated: uninitialized local used non-stack stable location {s}",
+                    .{@tagName(stable_loc)},
+                ),
+            };
+        }
+
+        fn poisonUninitializedLocal(self: *Self, local: LocalId) Allocator.Error!void {
+            const layout_idx = self.localLayout(local);
+            const size = self.getLayoutSize(layout_idx);
+            if (size == 0) return;
+
+            try self.ensureStableLocationForLocal(local);
+            const stable_loc = self.local_locations.get(localKey(local)) orelse unreachable;
+            try self.poisonStackArea(stableLocationStackOffset(stable_loc), size);
+        }
+
         fn collectStmtReadLocals(
             self: *Self,
             root_stmt_id: CFStmtId,
@@ -5377,6 +5400,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         try stack.append(sa, assign.next);
                     },
                     .assign_literal => |assign| try stack.append(sa, assign.next),
+                    .init_uninitialized => |uninit| try stack.append(sa, uninit.next),
                     .assign_call => |assign| {
                         for (self.store.getLocalSpan(assign.args)) |arg| {
                             try locals.put(localKey(arg), arg);
@@ -5493,6 +5517,10 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     .assign_literal => |assign| {
                         try locals.put(localKey(assign.target), assign.target);
                         try stack.append(sa, assign.next);
+                    },
+                    .init_uninitialized => |uninit| {
+                        try locals.put(localKey(uninit.target), uninit.target);
+                        try stack.append(sa, uninit.next);
                     },
                     .assign_call => |assign| {
                         try locals.put(localKey(assign.target), assign.target);
@@ -12135,6 +12163,33 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             }
         }
 
+        fn poisonStackArea(self: *Self, offset: i32, size: u32) Allocator.Error!void {
+            const reg = try self.allocTempGeneral();
+            defer self.codegen.freeGeneral(reg);
+            try self.codegen.emitLoadImm(reg, @as(i64, @bitCast(@as(u64, 0xAAAAAAAAAAAAAAAA))));
+
+            var remaining = size;
+            var current_offset = offset;
+            while (remaining >= 8) {
+                try self.codegen.emitStoreStack(.w64, current_offset, reg);
+                current_offset += 8;
+                remaining -= 8;
+            }
+            if (remaining >= 4) {
+                try self.codegen.emitStoreStack(.w32, current_offset, reg);
+                current_offset += 4;
+                remaining -= 4;
+            }
+            if (remaining >= 2) {
+                try self.emitStoreStackW16(current_offset, reg);
+                current_offset += 2;
+                remaining -= 2;
+            }
+            if (remaining >= 1) {
+                try self.emitStoreStackW8(current_offset, reg);
+            }
+        }
+
         /// Zero-fill `size` bytes through a base register (heap memory),
         /// mirroring zeroStackArea's chunking.
         fn zeroMemAt(self: *Self, base_reg: GeneralReg, size: u32) Allocator.Error!void {
@@ -13903,6 +13958,11 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                             try work.append(wa, .{ .node = assign.next });
                         },
 
+                        .init_uninitialized => |uninit| {
+                            try self.poisonUninitializedLocal(uninit.target);
+                            try work.append(wa, .{ .node = uninit.next });
+                        },
+
                         .assign_call => |assign| {
                             const value_loc = try self.generateCall(.{
                                 .proc = assign.proc,
@@ -15611,6 +15671,25 @@ fn runRootU8(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR.L
     const func: *const fn (*anyopaque, *anyopaque) callconv(.c) void = @ptrCast(@alignCast(executable.entryPtr()));
     func(@ptrCast(&out), @ptrCast(test_ops.getOps()));
     return out;
+}
+
+test "dev lowering: init_uninitialized writes poison pattern" {
+    const allocator = std.testing.allocator;
+    var store = LirStore.init(allocator);
+    defer store.deinit();
+
+    var test_state = try TestLayoutState.init(allocator);
+    defer test_state.deinit();
+
+    const value = try addLocal(&store, .u64);
+    const ret = try store.addCFStmt(.{ .ret = .{ .value = value } });
+    const init_stmt = try store.addCFStmt(.{ .init_uninitialized = .{
+        .target = value,
+        .next = ret,
+    } });
+    const root_proc = try addNoArgProc(&store, init_stmt, .u64);
+
+    try std.testing.expectEqual(@as(u64, 0xAAAAAAAAAAAAAAAA), try runRootU64(&store, &test_state.layout_store, root_proc, .u64));
 }
 
 fn stackOffsetOfTestLocation(loc: anytype) i32 {

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -1759,6 +1759,9 @@ pub const MonoLlvmCodeGen = struct {
                 try self.emitLiteral(assign.target, assign.value);
                 try work.append(wa, .{ .node = assign.next });
             },
+            .init_uninitialized => |uninit| {
+                try work.append(wa, .{ .node = uninit.next });
+            },
             .assign_call => |assign| {
                 try self.emitDirectCall(assign.target, assign.proc, assign.args);
                 try work.append(wa, .{ .node = assign.next });

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -3069,6 +3069,10 @@ fn collectProcLocals(
                 try recordProcLocal(locals, assign.target);
                 try work.append(wa, assign.next);
             },
+            .init_uninitialized => |uninit| {
+                try recordProcLocal(locals, uninit.target);
+                try work.append(wa, uninit.next);
+            },
             .assign_call => |assign| {
                 try recordProcLocal(locals, assign.target);
                 for (self.store.getLocalSpan(assign.args)) |arg| try recordProcLocal(locals, arg);
@@ -7160,6 +7164,9 @@ fn generateCFStmtNode(self: *Self, work: *std.ArrayList(StmtWork), wa: Allocator
             try self.generateLiteral(assign.value);
             try self.bindAssignedLocal(assign.target);
             try work.append(wa, .{ .node = .{ .stmt_id = assign.next, .stop = stop } });
+        },
+        .init_uninitialized => |uninit| {
+            try work.append(wa, .{ .node = .{ .stmt_id = uninit.next, .stop = stop } });
         },
         .assign_call => |assign| {
             try self.generateCall(.{

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -7219,6 +7219,11 @@ fn finishBlockState(
     const block_free_vars = self.scratch_free_vars.spanFrom(block_captures_start);
 
     const stmt_span = try self.env.store.statementSpanFrom(block.stmt_start);
+    if (self.blockHasUninitializedVar(stmt_span)) {
+        var analyzer = DefiniteInitAnalyzer.init(self, self.env.gpa);
+        try analyzer.analyzeRootBlock(stmt_span, final_expr.idx);
+    }
+
     const block_idx = try self.env.addExpr(CIR.Expr{
         .e_block = .{
             .stmts = stmt_span,
@@ -7228,6 +7233,517 @@ fn finishBlockState(
 
     return CanonicalizedExpr{ .idx = block_idx, .free_vars = block_free_vars };
 }
+
+fn blockHasUninitializedVar(self: *Self, stmts: Statement.Span) bool {
+    for (self.env.store.sliceStatements(stmts)) |stmt_idx| {
+        if (self.env.store.getStatement(stmt_idx) == .s_var_uninitialized) return true;
+    }
+    return false;
+}
+
+const DefiniteInitAnalyzer = struct {
+    can: *Self,
+    allocator: Allocator,
+
+    const VarState = struct {
+        pattern: Pattern.Idx,
+        initialized: bool,
+    };
+
+    const InitState = struct {
+        vars: std.ArrayList(VarState) = .empty,
+
+        fn deinit(self: *@This(), allocator: Allocator) void {
+            self.vars.deinit(allocator);
+        }
+
+        fn clone(self: *const @This(), allocator: Allocator) Allocator.Error!@This() {
+            var copy = @This(){};
+            errdefer copy.deinit(allocator);
+            try copy.vars.appendSlice(allocator, self.vars.items);
+            return copy;
+        }
+
+        fn indexOf(self: *const @This(), pattern: Pattern.Idx) ?usize {
+            for (self.vars.items, 0..) |entry, i| {
+                if (entry.pattern == pattern) return i;
+            }
+            return null;
+        }
+
+        fn isTrackedUninitialized(self: *const @This(), pattern: Pattern.Idx) bool {
+            const idx = self.indexOf(pattern) orelse return false;
+            return !self.vars.items[idx].initialized;
+        }
+
+        fn addUninitialized(self: *@This(), allocator: Allocator, pattern: Pattern.Idx) Allocator.Error!void {
+            if (self.indexOf(pattern) != null) return;
+            try self.vars.append(allocator, .{ .pattern = pattern, .initialized = false });
+        }
+
+        fn markInitialized(self: *@This(), pattern: Pattern.Idx) void {
+            if (self.indexOf(pattern)) |idx| {
+                self.vars.items[idx].initialized = true;
+            }
+        }
+
+        fn trimTo(self: *@This(), len: usize) void {
+            self.vars.items.len = len;
+        }
+    };
+
+    fn init(can: *Self, allocator: Allocator) @This() {
+        return .{ .can = can, .allocator = allocator };
+    }
+
+    fn analyzeRootBlock(self: *@This(), stmts: Statement.Span, final_expr: Expr.Idx) Allocator.Error!void {
+        var state = InitState{};
+        defer state.deinit(self.allocator);
+        var breaks = std.ArrayList(InitState).empty;
+        defer self.deinitStates(&breaks);
+        _ = try self.analyzeBlock(stmts, final_expr, &state, &breaks, true);
+    }
+
+    fn deinitStates(self: *@This(), states: *std.ArrayList(InitState)) void {
+        for (states.items) |*state| state.deinit(self.allocator);
+        states.deinit(self.allocator);
+    }
+
+    fn analyzeBlock(
+        self: *@This(),
+        stmts: Statement.Span,
+        final_expr: Expr.Idx,
+        state: *InitState,
+        breaks: *std.ArrayList(InitState),
+        track_new_vars: bool,
+    ) Allocator.Error!bool {
+        const local_start = state.vars.items.len;
+        defer state.trimTo(local_start);
+
+        const break_start = breaks.items.len;
+        errdefer self.trimBreakStates(breaks, break_start, local_start);
+
+        for (self.can.env.store.sliceStatements(stmts)) |stmt_idx| {
+            if (!try self.analyzeStatement(stmt_idx, state, breaks, track_new_vars)) {
+                self.trimBreakStates(breaks, break_start, local_start);
+                return false;
+            }
+        }
+
+        const continues = try self.analyzeExpr(final_expr, state, breaks);
+        self.trimBreakStates(breaks, break_start, local_start);
+        return continues;
+    }
+
+    fn trimBreakStates(self: *@This(), breaks: *std.ArrayList(InitState), start: usize, len: usize) void {
+        _ = self;
+        for (breaks.items[start..]) |*break_state| break_state.trimTo(len);
+    }
+
+    fn analyzeStatement(
+        self: *@This(),
+        stmt_idx: Statement.Idx,
+        state: *InitState,
+        breaks: *std.ArrayList(InitState),
+        track_new_vars: bool,
+    ) Allocator.Error!bool {
+        return switch (self.can.env.store.getStatement(stmt_idx)) {
+            .s_decl => |decl| try self.analyzeExpr(decl.expr, state, breaks),
+            .s_var => |var_| try self.analyzeExpr(var_.expr, state, breaks),
+            .s_var_uninitialized => |var_| blk: {
+                if (track_new_vars) try state.addUninitialized(self.allocator, var_.pattern_idx);
+                break :blk true;
+            },
+            .s_reassign => |reassign| blk: {
+                if (!try self.analyzeExpr(reassign.expr, state, breaks)) break :blk false;
+                try self.markAssignedPattern(state, reassign.pattern_idx);
+                break :blk true;
+            },
+            .s_dbg => |dbg| try self.analyzeExpr(dbg.expr, state, breaks),
+            .s_expr => |expr| try self.analyzeExpr(expr.expr, state, breaks),
+            .s_expect => |expect| try self.analyzeExpr(expect.body, state, breaks),
+            .s_for => |for_| try self.analyzeForLike(for_.expr, for_.body, state, breaks),
+            .s_while => |while_| try self.analyzeWhile(while_.cond, while_.body, state, breaks, .ordinary),
+            .s_infinite_loop => |loop| try self.analyzeWhile(loop.cond, loop.body, state, breaks, .infinite),
+            .s_breakable_loop => |loop| try self.analyzeWhile(loop.cond, loop.body, state, breaks, .breakable),
+            .s_return => |ret| blk: {
+                _ = try self.analyzeExpr(ret.expr, state, breaks);
+                break :blk false;
+            },
+            .s_break => blk: {
+                try breaks.append(self.allocator, try state.clone(self.allocator));
+                break :blk false;
+            },
+            .s_crash,
+            .s_runtime_error,
+            => false,
+            .s_import,
+            .s_alias_decl,
+            .s_nominal_decl,
+            .s_type_anno,
+            .s_type_var_alias,
+            => true,
+        };
+    }
+
+    const LoopKind = enum { ordinary, infinite, breakable };
+
+    fn analyzeWhile(
+        self: *@This(),
+        cond: Expr.Idx,
+        body: Expr.Idx,
+        state: *InitState,
+        breaks: *std.ArrayList(InitState),
+        kind: LoopKind,
+    ) Allocator.Error!bool {
+        const break_start = breaks.items.len;
+        if (!try self.analyzeExpr(cond, state, breaks)) {
+            self.consumeLoopBreaks(breaks, break_start);
+            return breaks.items.len > break_start;
+        }
+
+        var body_state = try state.clone(self.allocator);
+        defer body_state.deinit(self.allocator);
+        _ = try self.analyzeExpr(body, &body_state, breaks);
+
+        return switch (kind) {
+            .ordinary => blk: {
+                _ = try self.mergeLoopBreaksIntoState(state, breaks, break_start, true);
+                break :blk true;
+            },
+            .infinite => blk: {
+                self.consumeLoopBreaks(breaks, break_start);
+                break :blk false;
+            },
+            .breakable => blk: {
+                break :blk try self.mergeLoopBreaksIntoState(state, breaks, break_start, false);
+            },
+        };
+    }
+
+    fn analyzeForLike(
+        self: *@This(),
+        iter_expr: Expr.Idx,
+        body: Expr.Idx,
+        state: *InitState,
+        breaks: *std.ArrayList(InitState),
+    ) Allocator.Error!bool {
+        const break_start = breaks.items.len;
+        if (!try self.analyzeExpr(iter_expr, state, breaks)) {
+            self.consumeLoopBreaks(breaks, break_start);
+            return breaks.items.len > break_start;
+        }
+
+        var body_state = try state.clone(self.allocator);
+        defer body_state.deinit(self.allocator);
+        _ = try self.analyzeExpr(body, &body_state, breaks);
+        _ = try self.mergeLoopBreaksIntoState(state, breaks, break_start, true);
+        return true;
+    }
+
+    fn consumeLoopBreaks(self: *@This(), breaks: *std.ArrayList(InitState), start: usize) void {
+        for (breaks.items[start..]) |*break_state| break_state.deinit(self.allocator);
+        breaks.items.len = start;
+    }
+
+    fn mergeLoopBreaksIntoState(
+        self: *@This(),
+        state: *InitState,
+        breaks: *std.ArrayList(InitState),
+        start: usize,
+        include_current_state: bool,
+    ) Allocator.Error!bool {
+        var normal_states = std.ArrayList(InitState).empty;
+        defer self.deinitStates(&normal_states);
+
+        if (include_current_state) {
+            try normal_states.append(self.allocator, try state.clone(self.allocator));
+        }
+        for (breaks.items[start..]) |*break_state| {
+            try normal_states.append(self.allocator, try break_state.clone(self.allocator));
+        }
+        self.deinitBreakRange(breaks, start);
+
+        if (normal_states.items.len == 0) return false;
+        try self.mergeStatesInto(state, normal_states.items);
+        return true;
+    }
+
+    fn deinitBreakRange(self: *@This(), breaks: *std.ArrayList(InitState), start: usize) void {
+        for (breaks.items[start..]) |*break_state| break_state.deinit(self.allocator);
+        breaks.items.len = start;
+    }
+
+    fn analyzeExpr(
+        self: *@This(),
+        expr_idx: Expr.Idx,
+        state: *InitState,
+        breaks: *std.ArrayList(InitState),
+    ) Allocator.Error!bool {
+        return switch (self.can.env.store.getExpr(expr_idx)) {
+            .e_lookup_local => |lookup| blk: {
+                if (state.isTrackedUninitialized(lookup.pattern_idx)) {
+                    try self.reportUninitializedRead(expr_idx, lookup.pattern_idx);
+                }
+                break :blk true;
+            },
+            .e_lookup_external,
+            .e_lookup_required,
+            .e_num,
+            .e_frac_f32,
+            .e_frac_f64,
+            .e_dec,
+            .e_dec_small,
+            .e_num_from_numeral,
+            .e_typed_int,
+            .e_typed_frac,
+            .e_typed_num_from_numeral,
+            .e_str_segment,
+            .e_bytes_literal,
+            .e_empty_list,
+            .e_empty_record,
+            .e_zero_argument_tag,
+            .e_runtime_error,
+            .e_ellipsis,
+            .e_anno_only,
+            => true,
+            .e_str => |str| try self.analyzeExprSpan(str.span, state, breaks),
+            .e_list => |list| try self.analyzeExprSpan(list.elems, state, breaks),
+            .e_tuple => |tuple| try self.analyzeExprSpan(tuple.elems, state, breaks),
+            .e_tag => |tag| try self.analyzeExprSpan(tag.args, state, breaks),
+            .e_nominal => |nominal| try self.analyzeExpr(nominal.backing_expr, state, breaks),
+            .e_nominal_external => |nominal| try self.analyzeExpr(nominal.backing_expr, state, breaks),
+            .e_record => |record| blk: {
+                for (self.can.env.store.sliceRecordFields(record.fields)) |field_idx| {
+                    const field = self.can.env.store.getRecordField(field_idx);
+                    if (!try self.analyzeExpr(field.value, state, breaks)) break :blk false;
+                }
+                if (record.ext) |ext| {
+                    if (!try self.analyzeExpr(ext, state, breaks)) break :blk false;
+                }
+                break :blk true;
+            },
+            .e_call => |call| blk: {
+                if (!try self.analyzeExpr(call.func, state, breaks)) break :blk false;
+                break :blk try self.analyzeExprSpan(call.args, state, breaks);
+            },
+            .e_closure,
+            .e_lambda,
+            .e_hosted_lambda,
+            => true,
+            .e_binop => |binop| blk: {
+                if (binop.op == .@"and" or binop.op == .@"or") {
+                    if (!try self.analyzeExpr(binop.lhs, state, breaks)) break :blk false;
+                    var skipped_state = try state.clone(self.allocator);
+                    defer skipped_state.deinit(self.allocator);
+                    var rhs_state = try state.clone(self.allocator);
+                    defer rhs_state.deinit(self.allocator);
+                    const rhs_continues = try self.analyzeExpr(binop.rhs, &rhs_state, breaks);
+                    if (rhs_continues) {
+                        const states = [_]InitState{ skipped_state, rhs_state };
+                        try self.mergeStatesInto(state, &states);
+                    }
+                    break :blk true;
+                }
+                if (!try self.analyzeExpr(binop.lhs, state, breaks)) break :blk false;
+                break :blk try self.analyzeExpr(binop.rhs, state, breaks);
+            },
+            .e_unary_minus => |unary| try self.analyzeExpr(unary.expr, state, breaks),
+            .e_unary_not => |unary| try self.analyzeExpr(unary.expr, state, breaks),
+            .e_field_access => |field| try self.analyzeExpr(field.receiver, state, breaks),
+            .e_method_call => |call| blk: {
+                if (!try self.analyzeExpr(call.receiver, state, breaks)) break :blk false;
+                break :blk try self.analyzeExprSpan(call.args, state, breaks);
+            },
+            .e_dispatch_call => |call| blk: {
+                if (!try self.analyzeExpr(call.receiver, state, breaks)) break :blk false;
+                break :blk try self.analyzeExprSpan(call.args, state, breaks);
+            },
+            .e_interpolation => |interpolation| blk: {
+                if (!try self.analyzeExpr(interpolation.first, state, breaks)) break :blk false;
+                break :blk try self.analyzeExprSpan(interpolation.parts, state, breaks);
+            },
+            .e_structural_eq => |eq| blk: {
+                if (!try self.analyzeExpr(eq.lhs, state, breaks)) break :blk false;
+                break :blk try self.analyzeExpr(eq.rhs, state, breaks);
+            },
+            .e_method_eq => |eq| blk: {
+                if (!try self.analyzeExpr(eq.lhs, state, breaks)) break :blk false;
+                break :blk try self.analyzeExpr(eq.rhs, state, breaks);
+            },
+            .e_type_method_call => |call| try self.analyzeExprSpan(call.args, state, breaks),
+            .e_type_dispatch_call => |call| try self.analyzeExprSpan(call.args, state, breaks),
+            .e_tuple_access => |access| try self.analyzeExpr(access.tuple, state, breaks),
+            .e_block => |block| try self.analyzeBlock(block.stmts, block.final_expr, state, breaks, false),
+            .e_if => |if_| try self.analyzeIf(if_, state, breaks),
+            .e_match => |match| try self.analyzeMatch(match, state, breaks),
+            .e_crash => false,
+            .e_dbg => |dbg| try self.analyzeExpr(dbg.expr, state, breaks),
+            .e_expect_err => |expect_err| try self.analyzeExpr(expect_err.expr, state, breaks),
+            .e_expect => |expect| try self.analyzeExpr(expect.body, state, breaks),
+            .e_return => |ret| blk: {
+                _ = try self.analyzeExpr(ret.expr, state, breaks);
+                break :blk false;
+            },
+            .e_for => |for_| try self.analyzeForLike(for_.expr, for_.body, state, breaks),
+            .e_run_low_level => |run| try self.analyzeExprSpan(run.args, state, breaks),
+        };
+    }
+
+    fn analyzeExprSpan(self: *@This(), span: Expr.Span, state: *InitState, breaks: *std.ArrayList(InitState)) Allocator.Error!bool {
+        for (self.can.env.store.sliceExpr(span)) |child| {
+            if (!try self.analyzeExpr(child, state, breaks)) return false;
+        }
+        return true;
+    }
+
+    fn analyzeIf(
+        self: *@This(),
+        if_: std.meta.fieldInfo(Expr, .e_if).type,
+        state: *InitState,
+        breaks: *std.ArrayList(InitState),
+    ) Allocator.Error!bool {
+        var normal_states = std.ArrayList(InitState).empty;
+        defer self.deinitStates(&normal_states);
+
+        for (self.can.env.store.sliceIfBranches(if_.branches)) |branch_idx| {
+            const branch = self.can.env.store.getIfBranch(branch_idx);
+            var branch_state = try state.clone(self.allocator);
+            errdefer branch_state.deinit(self.allocator);
+            if (try self.analyzeExpr(branch.cond, &branch_state, breaks)) {
+                if (try self.analyzeExpr(branch.body, &branch_state, breaks)) {
+                    try normal_states.append(self.allocator, branch_state);
+                    continue;
+                }
+            }
+            branch_state.deinit(self.allocator);
+        }
+
+        var else_state = try state.clone(self.allocator);
+        errdefer else_state.deinit(self.allocator);
+        if (try self.analyzeExpr(if_.final_else, &else_state, breaks)) {
+            try normal_states.append(self.allocator, else_state);
+        } else {
+            else_state.deinit(self.allocator);
+        }
+
+        if (normal_states.items.len == 0) return false;
+        try self.mergeStatesInto(state, normal_states.items);
+        return true;
+    }
+
+    fn analyzeMatch(
+        self: *@This(),
+        match: Expr.Match,
+        state: *InitState,
+        breaks: *std.ArrayList(InitState),
+    ) Allocator.Error!bool {
+        if (!try self.analyzeExpr(match.cond, state, breaks)) return false;
+
+        var normal_states = std.ArrayList(InitState).empty;
+        defer self.deinitStates(&normal_states);
+
+        for (self.can.env.store.sliceMatchBranches(match.branches)) |branch_idx| {
+            const branch = self.can.env.store.getMatchBranch(branch_idx);
+            var branch_state = try state.clone(self.allocator);
+            errdefer branch_state.deinit(self.allocator);
+            if (branch.guard) |guard| {
+                if (!try self.analyzeExpr(guard, &branch_state, breaks)) {
+                    branch_state.deinit(self.allocator);
+                    continue;
+                }
+            }
+            if (try self.analyzeExpr(branch.value, &branch_state, breaks)) {
+                try normal_states.append(self.allocator, branch_state);
+            } else {
+                branch_state.deinit(self.allocator);
+            }
+        }
+
+        if (normal_states.items.len == 0) return false;
+        try self.mergeStatesInto(state, normal_states.items);
+        return true;
+    }
+
+    fn mergeStatesInto(self: *@This(), state: *InitState, states: []const InitState) Allocator.Error!void {
+        const merged = try self.mergeStateCopies(states);
+        state.deinit(self.allocator);
+        state.* = merged;
+    }
+
+    fn mergeStateCopies(self: *@This(), states: []const InitState) Allocator.Error!InitState {
+        std.debug.assert(states.len > 0);
+        var result = try states[0].clone(self.allocator);
+        errdefer result.deinit(self.allocator);
+
+        for (result.vars.items) |*entry| {
+            for (states[1..]) |*other| {
+                const other_idx = other.indexOf(entry.pattern) orelse {
+                    entry.initialized = false;
+                    continue;
+                };
+                entry.initialized = entry.initialized and other.vars.items[other_idx].initialized;
+            }
+        }
+
+        return result;
+    }
+
+    fn markAssignedPattern(self: *@This(), state: *InitState, pattern_idx: Pattern.Idx) Allocator.Error!void {
+        var stack_allocator_state = std.heap.stackFallback(1024, self.allocator);
+        const stack_allocator = stack_allocator_state.get();
+        var pending: std.ArrayList(Pattern.Idx) = .empty;
+        defer pending.deinit(stack_allocator);
+
+        try pending.append(stack_allocator, pattern_idx);
+        while (pending.pop()) |current_idx| {
+            const pattern = self.can.env.store.getPattern(current_idx);
+            switch (pattern) {
+                .assign => state.markInitialized(current_idx),
+                .as => |as| {
+                    state.markInitialized(current_idx);
+                    try pending.append(stack_allocator, as.pattern);
+                },
+                .applied_tag => |tag| {
+                    for (self.can.env.store.slicePatterns(tag.args)) |child| try pending.append(stack_allocator, child);
+                },
+                .nominal => |nominal| try pending.append(stack_allocator, nominal.backing_pattern),
+                .nominal_external => |nominal| try pending.append(stack_allocator, nominal.backing_pattern),
+                .record_destructure => |record| {
+                    for (self.can.env.store.sliceRecordDestructs(record.destructs)) |destruct_idx| {
+                        const destruct = self.can.env.store.getRecordDestruct(destruct_idx);
+                        try pending.append(stack_allocator, destruct.kind.toPatternIdx());
+                    }
+                },
+                .list => |list| {
+                    for (self.can.env.store.slicePatterns(list.patterns)) |child| try pending.append(stack_allocator, child);
+                    if (list.rest_info) |rest| if (rest.pattern) |child| try pending.append(stack_allocator, child);
+                },
+                .tuple => |tuple| {
+                    for (self.can.env.store.slicePatterns(tuple.patterns)) |child| try pending.append(stack_allocator, child);
+                },
+                .num_literal,
+                .small_dec_literal,
+                .dec_literal,
+                .frac_f32_literal,
+                .frac_f64_literal,
+                .str_literal,
+                .underscore,
+                .runtime_error,
+                => {},
+            }
+        }
+    }
+
+    fn reportUninitializedRead(self: *@This(), expr_idx: Expr.Idx, pattern_idx: Pattern.Idx) Allocator.Error!void {
+        const ident = self.can.boundPatternIdent(pattern_idx) orelse return;
+        const region = self.can.env.store.getExprRegion(expr_idx);
+        try self.can.env.replaceExprWithRuntimeError(expr_idx, Diagnostic{ .read_uninitialized_var = .{
+            .ident = ident,
+            .region = region,
+        } });
+    }
+};
 
 fn createBlockAnnoOnlyStatement(
     self: *Self,
@@ -7839,7 +8355,8 @@ fn canonicalizeStandaloneVarStatement(
         };
     };
 
-    const expr = try self.canonicalizeExprOrMalformed(var_stmt.body);
+    const body = var_stmt.body orelse return try self.createUninitializedVarStatement(var_name, annotation, region);
+    const expr = try self.canonicalizeExprOrMalformed(body);
     const pattern_idx = try self.env.addPattern(Pattern{ .assign = .{ .ident = var_name } }, region);
     _ = try self.scopeIntroduceVar(var_name, pattern_idx, region, true, Pattern.Idx);
     const stmt_idx = try self.env.addStatement(Statement{ .s_var = .{
@@ -7848,6 +8365,21 @@ fn canonicalizeStandaloneVarStatement(
         .anno = annotation,
     } }, region);
     return CanonicalizedStatement{ .idx = stmt_idx, .free_vars = expr.free_vars };
+}
+
+fn createUninitializedVarStatement(
+    self: *Self,
+    var_name: Ident.Idx,
+    annotation: ?Annotation.Idx,
+    region: Region,
+) std.mem.Allocator.Error!CanonicalizedStatement {
+    const pattern_idx = try self.env.addPattern(Pattern{ .assign = .{ .ident = var_name } }, region);
+    _ = try self.scopeIntroduceVar(var_name, pattern_idx, region, true, Pattern.Idx);
+    const stmt_idx = try self.env.addStatement(Statement{ .s_var_uninitialized = .{
+        .pattern_idx = pattern_idx,
+        .anno = annotation,
+    } }, region);
+    return CanonicalizedStatement{ .idx = stmt_idx, .free_vars = DataSpan.empty() };
 }
 
 fn canonicalizeStandaloneCrashStatement(
@@ -7921,6 +8453,14 @@ fn canonicalizeStandaloneTypeAnnoStatement(
         }
         break :inner_blk try self.env.store.whereClauseSpanFrom(where_start);
     } else null;
+
+    if (type_anno.is_var) {
+        const annotation_idx = try self.env.addAnnotation(CIR.Annotation{
+            .anno = type_anno_idx,
+            .where = where_clauses,
+        }, region);
+        return try self.createUninitializedVarStatement(name_ident, annotation_idx, region);
+    }
 
     return try self.createBlockAnnoOnlyStatement(name_ident, type_anno_idx, where_clauses, region);
 }
@@ -8235,6 +8775,7 @@ fn scanLoopExitFacts(self: *Self, body: Expr.Idx) std.mem.Allocator.Error!LoopEx
                 switch (stmt) {
                     .s_decl => |decl| try pending.append(stack_allocator, .{ .expr = .{ .idx = decl.expr, .loop_depth = stmt_frame.loop_depth } }),
                     .s_var => |var_stmt| try pending.append(stack_allocator, .{ .expr = .{ .idx = var_stmt.expr, .loop_depth = stmt_frame.loop_depth } }),
+                    .s_var_uninitialized => {},
                     .s_reassign => |reassign| try pending.append(stack_allocator, .{ .expr = .{ .idx = reassign.expr, .loop_depth = stmt_frame.loop_depth } }),
                     .s_dbg => |dbg| try pending.append(stack_allocator, .{ .expr = .{ .idx = dbg.expr, .loop_depth = stmt_frame.loop_depth } }),
                     .s_expr => |expr_stmt| try pending.append(stack_allocator, .{ .expr = .{ .idx = expr_stmt.expr, .loop_depth = stmt_frame.loop_depth } }),
@@ -9566,16 +10107,23 @@ fn runExprKernel(
                         break :blk;
                     };
 
+                    const ast_expr = v.body orelse {
+                        const stmt = try self.createUninitializedVarStatement(var_name, null, region);
+                        try self.addBlockStatement(blockContextFromState(work), stmt);
+                        try stacks.pushBlockNext(frame_allocator, .{ .block = work, .next = next });
+                        break :blk;
+                    };
+
                     try stacks.pushFinishBlockVarStmt(frame_allocator, .{
                         .block = work,
                         .next = next,
                         .region = region,
                         .var_name = var_name,
                         .annotation = null,
-                        .ast_expr = v.body,
+                        .ast_expr = ast_expr,
                         .type_var_scope = null,
                     });
-                    try stacks.pushParse(frame_allocator, .{ .idx = v.body, .target = .scratch });
+                    try stacks.pushParse(frame_allocator, .{ .idx = ast_expr, .target = .scratch });
                 },
                 .expr => |expr_stmt| {
                     try stacks.pushFinishBlockExprStmt(frame_allocator, .{
@@ -9734,16 +10282,23 @@ fn runExprKernel(
                                     }, region);
 
                                     keep_type_var_scope_for_body = true;
+                                    const ast_expr = var_stmt.body orelse {
+                                        defer self.scopeExitTypeVar(type_var_scope);
+                                        const stmt = try self.createUninitializedVarStatement(name_ident, annotation_idx, var_region);
+                                        try self.addBlockStatement(blockContextFromState(work), stmt);
+                                        try stacks.pushBlockNext(frame_allocator, .{ .block = work, .next = next_i + 1 });
+                                        break :type_anno_blk;
+                                    };
                                     try stacks.pushFinishBlockVarStmt(frame_allocator, .{
                                         .block = work,
                                         .next = next_i + 1,
                                         .region = var_region,
                                         .var_name = name_ident,
                                         .annotation = annotation_idx,
-                                        .ast_expr = var_stmt.body,
+                                        .ast_expr = ast_expr,
                                         .type_var_scope = type_var_scope,
                                     });
-                                    try stacks.pushParse(frame_allocator, .{ .idx = var_stmt.body, .target = .scratch });
+                                    try stacks.pushParse(frame_allocator, .{ .idx = ast_expr, .target = .scratch });
                                     break :type_anno_blk;
                                 }
                             },
@@ -9751,7 +10306,13 @@ fn runExprKernel(
                         }
                     }
 
-                    const stmt = try self.createBlockAnnoOnlyStatement(name_ident, type_anno_idx, where_clauses, region);
+                    const stmt = if (ta.is_var) blk: {
+                        const annotation_idx = try self.env.addAnnotation(CIR.Annotation{
+                            .anno = type_anno_idx,
+                            .where = where_clauses,
+                        }, region);
+                        break :blk try self.createUninitializedVarStatement(name_ident, annotation_idx, region);
+                    } else try self.createBlockAnnoOnlyStatement(name_ident, type_anno_idx, where_clauses, region);
                     try self.addBlockStatement(blockContextFromState(work), stmt);
                     try stacks.pushBlockNext(frame_allocator, .{ .block = work, .next = next });
                 },
@@ -17024,6 +17585,7 @@ fn addBlockStatement(
     switch (cir_stmt) {
         .s_decl => |decl| try self.collectBoundVarsToScratch(decl.pattern),
         .s_var => |var_stmt| try self.collectBoundVarsToScratch(var_stmt.pattern_idx),
+        .s_var_uninitialized => |var_stmt| try self.collectBoundVarsToScratch(var_stmt.pattern_idx),
         .s_reassign => |reassign| try self.collectReassignBoundVarsToScratch(reassign.pattern_idx),
         else => {},
     }

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -7321,22 +7321,21 @@ const DefiniteInitAnalyzer = struct {
         defer state.trimTo(local_start);
 
         const break_start = breaks.items.len;
-        errdefer self.trimBreakStates(breaks, break_start, local_start);
+        errdefer trimBreakStates(breaks, break_start, local_start);
 
         for (self.can.env.store.sliceStatements(stmts)) |stmt_idx| {
             if (!try self.analyzeStatement(stmt_idx, state, breaks, track_new_vars)) {
-                self.trimBreakStates(breaks, break_start, local_start);
+                trimBreakStates(breaks, break_start, local_start);
                 return false;
             }
         }
 
         const continues = try self.analyzeExpr(final_expr, state, breaks);
-        self.trimBreakStates(breaks, break_start, local_start);
+        trimBreakStates(breaks, break_start, local_start);
         return continues;
     }
 
-    fn trimBreakStates(self: *@This(), breaks: *std.ArrayList(InitState), start: usize, len: usize) void {
-        _ = self;
+    fn trimBreakStates(breaks: *std.ArrayList(InitState), start: usize, len: usize) void {
         for (breaks.items[start..]) |*break_state| break_state.trimTo(len);
     }
 

--- a/src/canonicalize/DependencyGraph.zig
+++ b/src/canonicalize/DependencyGraph.zig
@@ -242,6 +242,7 @@ fn collectExprDependencies(
                     switch (stmt) {
                         .s_decl => |decl| try pending.append(stack_allocator, decl.expr),
                         .s_var => |var_stmt| try pending.append(stack_allocator, var_stmt.expr),
+                        .s_var_uninitialized => {},
                         .s_reassign => |reassign| try pending.append(stack_allocator, reassign.expr),
                         .s_dbg => |dbg| try pending.append(stack_allocator, dbg.expr),
                         .s_expr => |expr_stmt| try pending.append(stack_allocator, expr_stmt.expr),

--- a/src/canonicalize/Diagnostic.zig
+++ b/src/canonicalize/Diagnostic.zig
@@ -40,6 +40,10 @@ pub const Diagnostic = union(enum) {
         ident: Ident.Idx,
         region: Region,
     },
+    read_uninitialized_var: struct {
+        ident: Ident.Idx,
+        region: Region,
+    },
     /// A non-function value is defined in terms of itself, which would cause an infinite loop.
     /// For example: `a = a` or `a = [a, b]`. Only functions can reference themselves (for recursion).
     self_referential_definition: struct {

--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -905,6 +905,13 @@ pub fn pushRuntimeErrorExpr(self: *Self, comptime RetIdx: type, reason: CIR.Diag
     return castIdx(Node.Idx, RetIdx, malformed_idx);
 }
 
+/// Replaces an existing expression with a runtime error and records the diagnostic.
+pub fn replaceExprWithRuntimeError(self: *Self, expr_idx: CIR.Expr.Idx, reason: CIR.Diagnostic) std.mem.Allocator.Error!void {
+    const diag_idx = try self.addDiagnostic(reason);
+    self.store.setExprRuntimeError(expr_idx, diag_idx);
+    self.debugAssertArraysInSync();
+}
+
 /// Extract the region from any diagnostic variant
 fn getDiagnosticRegion(diagnostic: CIR.Diagnostic) Region {
     return switch (diagnostic) {
@@ -1019,6 +1026,28 @@ pub fn diagnosticToReport(self: *Self, diagnostic: CIR.Diagnostic, allocator: st
             try report.document.addReflowingText(" or ");
             try report.document.addKeyword("exposing");
             try report.document.addReflowingText(" missing up-top?");
+            try report.document.addLineBreak();
+            try report.document.addLineBreak();
+            const owned_filename = try report.addOwnedString(filename);
+            try report.document.addSourceRegion(
+                region_info,
+                .error_highlight,
+                owned_filename,
+                self.getSourceAll(),
+                self.getLineStartsAll(),
+            );
+
+            break :blk report;
+        },
+        .read_uninitialized_var => |data| blk: {
+            const region_info = self.calcRegionInfo(data.region);
+            const ident_name = self.getIdent(data.ident);
+
+            var report = Report.init(allocator, "READING UNINITIALIZED VAR", .runtime_error);
+            const owned_ident = try report.addOwnedString(ident_name);
+            try report.document.addReflowingText("This reads ");
+            try report.document.addUnqualifiedSymbol(owned_ident);
+            try report.document.addReflowingText(" before every path has assigned it a value.");
             try report.document.addLineBreak();
             try report.document.addLineBreak();
             const owned_filename = try report.addOwnedString(filename);

--- a/src/canonicalize/Node.zig
+++ b/src/canonicalize/Node.zig
@@ -39,6 +39,7 @@ pub const Tag = enum {
     // Statements
     statement_decl,
     statement_var,
+    statement_var_uninitialized,
     statement_reassign,
     statement_crash,
     statement_dbg,
@@ -190,6 +191,7 @@ pub const Tag = enum {
     diag_empty_tuple,
     diag_ident_already_in_scope,
     diag_ident_not_in_scope,
+    diag_read_uninitialized_var,
     diag_self_referential_definition,
     diag_circular_value_definition,
     diag_local_reference_before_definition,
@@ -276,6 +278,7 @@ pub const Payload = extern union {
     // === Statement payloads ===
     statement_decl: StatementDecl,
     statement_var: StatementVar,
+    statement_var_uninitialized: StatementVarUninitialized,
     statement_reassign: StatementReassign,
     statement_crash: StatementCrash,
     statement_single_expr: StatementSingleExpr,
@@ -408,6 +411,13 @@ pub const Payload = extern union {
         pattern_idx: u32,
         expr: u32,
         anno_span2_idx: u32, // Index into span2_data: (has_anno, anno_idx_or_zero)
+    };
+
+    /// statement_var_uninitialized: pattern_idx + annotation info
+    pub const StatementVarUninitialized = extern struct {
+        pattern_idx: u32,
+        anno_span2_idx: u32, // Index into span2_data: (has_anno, anno_idx_or_zero)
+        _padding: [4]u8 = .{ 0, 0, 0, 0 },
     };
 
     /// statement_reassign: pattern_idx + expr

--- a/src/canonicalize/NodeStore.zig
+++ b/src/canonicalize/NodeStore.zig
@@ -387,11 +387,11 @@ pub fn relocate(store: *NodeStore, offset: isize) void {
 /// when adding/removing variants from ModuleEnv unions. Update these when modifying the unions.
 ///
 /// Count of the diagnostic nodes in the ModuleEnv
-pub const MODULEENV_DIAGNOSTIC_NODE_COUNT = 79;
+pub const MODULEENV_DIAGNOSTIC_NODE_COUNT = 80;
 /// Count of the expression nodes in the ModuleEnv
 pub const MODULEENV_EXPR_NODE_COUNT = 53;
 /// Count of the statement nodes in the ModuleEnv
-pub const MODULEENV_STATEMENT_NODE_COUNT = 19;
+pub const MODULEENV_STATEMENT_NODE_COUNT = 20;
 /// Count of the type annotation nodes in the ModuleEnv
 pub const MODULEENV_TYPE_ANNO_NODE_COUNT = 12;
 /// Count of the pattern nodes in the ModuleEnv
@@ -550,6 +550,20 @@ pub fn getStatement(store: *const NodeStore, statement: CIR.Statement.Idx) CIR.S
             return CIR.Statement{ .s_var = .{
                 .pattern_idx = @enumFromInt(p.pattern_idx),
                 .expr = @enumFromInt(p.expr),
+                .anno = blk: {
+                    const anno_data = store.span2_data.items.items[p.anno_span2_idx];
+                    if (anno_data.start != 0) {
+                        break :blk @enumFromInt(anno_data.len);
+                    } else {
+                        break :blk null;
+                    }
+                },
+            } };
+        },
+        .statement_var_uninitialized => {
+            const p = payload.statement_var_uninitialized;
+            return CIR.Statement{ .s_var_uninitialized = .{
+                .pattern_idx = @enumFromInt(p.pattern_idx),
                 .anno = blk: {
                     const anno_data = store.span2_data.items.items[p.anno_span2_idx];
                     if (anno_data.start != 0) {
@@ -1999,6 +2013,15 @@ pub fn setStatementNode(store: *NodeStore, stmt_idx: CIR.Statement.Idx, statemen
     store.nodes.set(@enumFromInt(@intFromEnum(stmt_idx)), node);
 }
 
+/// Replaces an existing expression node with a runtime error expression.
+pub fn setExprRuntimeError(store: *NodeStore, expr_idx: CIR.Expr.Idx, diagnostic_idx: CIR.Diagnostic.Idx) void {
+    var node = Node.init(.malformed);
+    node.setPayload(.{ .diag_single_value = .{
+        .value = @intFromEnum(diagnostic_idx),
+    } });
+    store.nodes.set(@enumFromInt(@intFromEnum(expr_idx)), node);
+}
+
 /// Creates a statement node, but does not append to the store.
 /// IMPORTANT: It *does* append to typed data lists (span2_data, import_data, etc.)
 ///
@@ -2034,6 +2057,20 @@ fn makeStatementNode(store: *NodeStore, statement: CIR.Statement) Allocator.Erro
             node.setPayload(.{ .statement_var = .{
                 .pattern_idx = @intFromEnum(s.pattern_idx),
                 .expr = @intFromEnum(s.expr),
+                .anno_span2_idx = anno_span2_idx,
+            } });
+        },
+        .s_var_uninitialized => |s| {
+            const anno_span2_idx: u32 = @intCast(store.span2_data.len());
+            const anno_data: Span2 = if (s.anno) |anno| .{
+                .start = 1,
+                .len = @intFromEnum(anno),
+            } else .{ .start = 0, .len = 0 };
+            _ = try store.span2_data.append(store.gpa, anno_data);
+
+            node.tag = .statement_var_uninitialized;
+            node.setPayload(.{ .statement_var_uninitialized = .{
+                .pattern_idx = @intFromEnum(s.pattern_idx),
                 .anno_span2_idx = anno_span2_idx,
             } });
         },
@@ -3787,6 +3824,11 @@ pub fn addDiagnosticUnregistered(store: *NodeStore, reason: CIR.Diagnostic) Allo
             region = r.region;
             node.setPayload(.{ .diag_single_ident = .{ .ident = @bitCast(r.ident) } });
         },
+        .read_uninitialized_var => |r| {
+            node.tag = .diag_read_uninitialized_var;
+            region = r.region;
+            node.setPayload(.{ .diag_single_ident = .{ .ident = @bitCast(r.ident) } });
+        },
         .self_referential_definition => |r| {
             node.tag = .diag_self_referential_definition;
             region = r.region;
@@ -4213,6 +4255,10 @@ pub fn getDiagnostic(store: *const NodeStore, diagnostic: CIR.Diagnostic.Idx) CI
             } };
         },
         .diag_ident_not_in_scope => return CIR.Diagnostic{ .ident_not_in_scope = .{
+            .ident = @bitCast(payload.diag_single_ident.ident),
+            .region = store.getRegionAt(node_idx),
+        } },
+        .diag_read_uninitialized_var => return CIR.Diagnostic{ .read_uninitialized_var = .{
             .ident = @bitCast(payload.diag_single_ident.ident),
             .region = store.getRegionAt(node_idx),
         } },

--- a/src/canonicalize/Statement.zig
+++ b/src/canonicalize/Statement.zig
@@ -49,6 +49,13 @@ pub const Statement = union(enum) {
         expr: Expr.Idx,
         anno: ?Annotation.Idx,
     },
+    /// A rebindable declaration using the "var" keyword, with no initializer.
+    ///
+    /// Reads are only valid after every control-flow path has assigned this var.
+    s_var_uninitialized: struct {
+        pattern_idx: Pattern.Idx,
+        anno: ?Annotation.Idx,
+    },
     /// Reassignment of a previously declared var
     ///
     /// Not valid at the top level of a module
@@ -247,6 +254,17 @@ pub const Statement = union(enum) {
 
                 try env.store.getPattern(v.pattern_idx).pushToSExprTree(env, tree, v.pattern_idx);
                 try env.store.getExpr(v.expr).pushToSExprTree(env, tree, v.expr);
+
+                try tree.endNode(begin, attrs);
+            },
+            .s_var_uninitialized => |v| {
+                const begin = tree.beginNode();
+                try tree.pushStaticAtom("s-var-uninitialized");
+                const region = env.store.getStatementRegion(stmt_idx);
+                try env.appendRegionInfoToSExprTreeFromRegion(tree, region);
+                const attrs = tree.beginNode();
+
+                try env.store.getPattern(v.pattern_idx).pushToSExprTree(env, tree, v.pattern_idx);
 
                 try tree.endNode(begin, attrs);
             },

--- a/src/canonicalize/mod.zig
+++ b/src/canonicalize/mod.zig
@@ -112,6 +112,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/record_test.zig"));
     std.testing.refAllDecls(@import("test/type_decl_stmt_test.zig"));
     std.testing.refAllDecls(@import("test/local_let_scoping_test.zig"));
+    std.testing.refAllDecls(@import("test/uninitialized_var_test.zig"));
     std.testing.refAllDecls(@import("test/while_loop_test.zig"));
 
     // Backend tests (Roc emitter)

--- a/src/canonicalize/test/node_store_test.zig
+++ b/src/canonicalize/test/node_store_test.zig
@@ -79,6 +79,13 @@ test "NodeStore round trip - Statements" {
     });
 
     try statements.append(gpa, CIR.Statement{
+        .s_var_uninitialized = .{
+            .pattern_idx = rand_idx(CIR.Pattern.Idx),
+            .anno = rand_idx(CIR.Annotation.Idx),
+        },
+    });
+
+    try statements.append(gpa, CIR.Statement{
         .s_reassign = .{
             .pattern_idx = rand_idx(CIR.Pattern.Idx),
             .expr = rand_idx(CIR.Expr.Idx),
@@ -581,6 +588,13 @@ test "NodeStore round trip - Diagnostics" {
 
     try diagnostics.append(gpa, CIR.Diagnostic{
         .ident_not_in_scope = .{
+            .ident = rand_ident_idx(),
+            .region = rand_region(),
+        },
+    });
+
+    try diagnostics.append(gpa, CIR.Diagnostic{
+        .read_uninitialized_var = .{
             .ident = rand_ident_idx(),
             .region = rand_region(),
         },

--- a/src/canonicalize/test/uninitialized_var_test.zig
+++ b/src/canonicalize/test/uninitialized_var_test.zig
@@ -1,0 +1,34 @@
+//! Tests for canonicalizing vars declared without an initial value.
+
+const std = @import("std");
+const testing = std.testing;
+
+const TestEnv = @import("TestEnv.zig").TestEnv;
+
+test "uninitialized var read becomes runtime error expression" {
+    const source =
+        \\{
+        \\    var $value
+        \\    $value
+        \\}
+    ;
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const block = test_env.module_env.store.getExpr(canonical_expr.get_idx());
+    try testing.expectEqual(.e_block, std.meta.activeTag(block));
+
+    const statements = test_env.module_env.store.sliceStatements(block.e_block.stmts);
+    try testing.expectEqual(@as(usize, 1), statements.len);
+
+    const var_stmt = test_env.module_env.store.getStatement(statements[0]);
+    try testing.expectEqual(.s_var_uninitialized, std.meta.activeTag(var_stmt));
+
+    const final_expr = test_env.module_env.store.getExpr(block.e_block.final_expr);
+    try testing.expectEqual(.e_runtime_error, std.meta.activeTag(final_expr));
+
+    const diag = test_env.module_env.store.getDiagnostic(final_expr.e_runtime_error.diagnostic);
+    try testing.expectEqual(.read_uninitialized_var, std.meta.activeTag(diag));
+    try testing.expectEqualStrings("$value", test_env.getIdent(diag.read_uninitialized_var.ident));
+}

--- a/src/canonicalize/test/while_loop_test.zig
+++ b/src/canonicalize/test/while_loop_test.zig
@@ -6,11 +6,11 @@ const testing = std.testing;
 const CIR = @import("../CIR.zig");
 const TestEnv = @import("TestEnv.zig").TestEnv;
 
-fn firstBlockStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) !CIR.Statement {
+fn firstBlockStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) anyerror!CIR.Statement {
     return try blockStatementAt(test_env, expr_idx, 0);
 }
 
-fn blockStatementAt(test_env: *TestEnv, expr_idx: CIR.Expr.Idx, index: usize) !CIR.Statement {
+fn blockStatementAt(test_env: *TestEnv, expr_idx: CIR.Expr.Idx, index: usize) anyerror!CIR.Statement {
     const expr = test_env.getCanonicalExpr(expr_idx);
     try testing.expectEqual(.e_block, std.meta.activeTag(expr));
 
@@ -20,7 +20,7 @@ fn blockStatementAt(test_env: *TestEnv, expr_idx: CIR.Expr.Idx, index: usize) !C
     return test_env.module_env.store.getStatement(statements[index]);
 }
 
-fn firstLambdaBodyStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) !CIR.Statement {
+fn firstLambdaBodyStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) anyerror!CIR.Statement {
     const expr = test_env.getCanonicalExpr(expr_idx);
     const lambda_idx = switch (expr) {
         .e_lambda => expr_idx,
@@ -34,7 +34,7 @@ fn firstLambdaBodyStatement(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) !CIR.Sta
     return try firstBlockStatement(test_env, lambda.e_lambda.body);
 }
 
-fn expectDiagnosticTag(test_env: *TestEnv, expected: std.meta.Tag(CIR.Diagnostic)) !void {
+fn expectDiagnosticTag(test_env: *TestEnv, expected: std.meta.Tag(CIR.Diagnostic)) anyerror!void {
     const diagnostics = try test_env.getDiagnostics();
     defer testing.allocator.free(diagnostics);
 
@@ -45,7 +45,7 @@ fn expectDiagnosticTag(test_env: *TestEnv, expected: std.meta.Tag(CIR.Diagnostic
     return error.ExpectedDiagnosticNotFound;
 }
 
-fn expectNoDiagnosticTag(test_env: *TestEnv, unexpected: std.meta.Tag(CIR.Diagnostic)) !void {
+fn expectNoDiagnosticTag(test_env: *TestEnv, unexpected: std.meta.Tag(CIR.Diagnostic)) anyerror!void {
     const diagnostics = try test_env.getDiagnostics();
     defer testing.allocator.free(diagnostics);
 

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -8340,6 +8340,20 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                     try self.checkDestructureExhaustiveness(var_stmt.pattern_idx, var_stmt.expr, var_expr, env, stmt_region);
                 }
             },
+            .s_var_uninitialized => |var_stmt| {
+                const var_pattern_ctx: PatternCtx = if (self.patternNeedsExhaustiveness(var_stmt.pattern_idx)) .match_branch else .bound;
+
+                try self.checkPattern(var_stmt.pattern_idx, var_pattern_ctx, env);
+                const var_pattern_var: Var = ModuleEnv.varFrom(var_stmt.pattern_idx);
+
+                if (var_stmt.anno) |annotation_idx| {
+                    try self.generateAnnotationType(annotation_idx, env);
+                    _ = try self.unifyInContext(ModuleEnv.varFrom(annotation_idx), var_pattern_var, env, .type_annotation);
+                }
+
+                const empty_rec = try self.freshFromContent(.{ .structure = .empty_record }, env, stmt_region);
+                _ = try self.unify(stmt_var, empty_rec, env);
+            },
             .s_reassign => |reassign| {
                 // Reassignment patterns can mix existing mutable binders with
                 // fresh local binders, e.g. `(word, $index) = pair`.

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -1098,6 +1098,7 @@ fn statementDependsOnUnboundPlatformRequirement(
     return switch (checked_bodies.statements[@intFromEnum(statement_id)].data) {
         .decl => |statement| exprDependsOnUnboundPlatformRequirement(checked_bodies, resolved_value_refs, statement.expr, relation_blocked_exprs),
         .var_ => |statement| exprDependsOnUnboundPlatformRequirement(checked_bodies, resolved_value_refs, statement.expr, relation_blocked_exprs),
+        .var_uninitialized => false,
         .reassign => |statement| exprDependsOnUnboundPlatformRequirement(checked_bodies, resolved_value_refs, statement.expr, relation_blocked_exprs),
         .dbg,
         .expr,
@@ -4869,6 +4870,7 @@ pub const CheckedStatementData = union(enum) {
     pending,
     decl: struct { pattern: CheckedPatternId, expr: CheckedExprId },
     var_: struct { pattern: CheckedPatternId, expr: CheckedExprId },
+    var_uninitialized: struct { pattern: CheckedPatternId },
     reassign: struct { pattern: CheckedPatternId, expr: CheckedExprId, reassigned_binders: []const PatternBinderId },
     crash: CheckedStringLiteralId,
     dbg: CheckedExprId,
@@ -5554,6 +5556,9 @@ const CheckedSourceNodes = struct {
             .s_var => |var_| {
                 try self.markPattern(var_.pattern_idx, work);
                 try self.markExpr(var_.expr, work);
+            },
+            .s_var_uninitialized => |var_| {
+                try self.markPattern(var_.pattern_idx, work);
             },
             .s_reassign => |reassign| {
                 try self.markPattern(reassign.pattern_idx, work);
@@ -6332,6 +6337,7 @@ fn checkedStatementDataDiverges(
         => true,
         .decl => |decl| checkedExprDiverges(exprs, statements, expr_diverges, statement_diverges, decl.expr, expr_states, statement_states),
         .var_ => |var_| checkedExprDiverges(exprs, statements, expr_diverges, statement_diverges, var_.expr, expr_states, statement_states),
+        .var_uninitialized => false,
         .reassign => |reassign| checkedExprDiverges(exprs, statements, expr_diverges, statement_diverges, reassign.expr, expr_states, statement_states),
         .dbg,
         .expr,
@@ -7093,6 +7099,10 @@ const CheckedBodyPayloadCopier = struct {
             .s_var => |var_| blk: {
                 try self.markSourcePatternBindersReassignable(var_.pattern_idx);
                 break :blk .{ .var_ = .{ .pattern = self.checkedPattern(var_.pattern_idx), .expr = self.checkedExpr(var_.expr) } };
+            },
+            .s_var_uninitialized => |var_| blk: {
+                try self.markSourcePatternBindersReassignable(var_.pattern_idx);
+                break :blk .{ .var_uninitialized = .{ .pattern = self.checkedPattern(var_.pattern_idx) } };
             },
             .s_reassign => |reassign| .{ .reassign = .{
                 .pattern = self.checkedPattern(reassign.pattern_idx),
@@ -8889,6 +8899,15 @@ const LocalPatternRoleIndex = struct {
                     };
                     putStatementRole(statement_roles, node_count, var_.pattern_idx, .mutable_version);
                 },
+                .statement_var_uninitialized => {
+                    const statement: CIR.Statement.Idx = @enumFromInt(node_idx);
+                    if (checked_bodies.source_node_map.statement(statement) == null) continue;
+                    const var_ = switch (module.getStatement(statement)) {
+                        .s_var_uninitialized => |var_| var_,
+                        else => unreachable,
+                    };
+                    putStatementRole(statement_roles, node_count, var_.pattern_idx, .mutable_version);
+                },
                 .expr_lambda => {
                     const expr_idx: CIR.Expr.Idx = @enumFromInt(node_idx);
                     if (checked_bodies.exprIdForSource(expr_idx) == null) continue;
@@ -9366,6 +9385,9 @@ const CheckedTemplateRefCollector = struct {
             .var_ => |var_| {
                 try self.collectPattern(var_.pattern);
                 try self.collectExpr(var_.expr);
+            },
+            .var_uninitialized => |var_| {
+                try self.collectPattern(var_.pattern);
             },
             .reassign => |reassign| {
                 try self.collectPattern(reassign.pattern);
@@ -10034,6 +10056,9 @@ const NestedProcSiteBuilder = struct {
             .var_ => |var_| {
                 try self.scanPattern(var_.pattern, owner);
                 try self.scanExpr(var_.expr, owner, false);
+            },
+            .var_uninitialized => |var_| {
+                try self.scanPattern(var_.pattern, owner);
             },
             .reassign => |reassign| {
                 try self.scanPattern(reassign.pattern, owner);

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -4224,7 +4224,7 @@ const DefExpectation = union(enum) {
     def: []const u8,
 };
 
-fn expectReadUninitializedVarDiagnostics(test_env: *TestEnv, expected_count: usize) !void {
+fn expectReadUninitializedVarDiagnostics(test_env: *TestEnv, expected_count: usize) anyerror!void {
     try testing.expect(!test_env.parse_ast.hasErrors());
 
     const diagnostics = try test_env.module_env.getDiagnostics();

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -2732,6 +2732,154 @@ test "check type - var reassignment" {
     );
 }
 
+test "check type - uninitialized var - all if branches assign before final read" {
+    const source =
+        \\main = |condition| {
+        \\  var $value : Dec
+        \\
+        \\  if condition {
+        \\    $value = 1
+        \\  } else {
+        \\    $value = 2
+        \\  }
+        \\
+        \\  $value
+        \\}
+    ;
+    try checkTypesModule(
+        source,
+        .{ .pass = .last_def },
+        "Bool -> Dec",
+    );
+}
+
+test "check can - uninitialized var - branch-local read before assignment" {
+    const source =
+        \\main = |condition| {
+        \\  var $value
+        \\
+        \\  if condition {
+        \\    $value = 1
+        \\  } else {
+        \\    $value
+        \\  }
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneCanError("READING UNINITIALIZED VAR");
+}
+
+test "check can - uninitialized var - missing branch assignment before final read" {
+    const source =
+        \\main = |condition| {
+        \\  var $value
+        \\
+        \\  if condition {
+        \\    $value = 1
+        \\  } else {
+        \\    {}
+        \\  }
+        \\
+        \\  $value
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneCanError("READING UNINITIALIZED VAR");
+}
+
+test "check type - uninitialized var - terminal branches do not need assignment" {
+    const source =
+        \\fallible : {} -> Try({}, Str)
+        \\fallible = |_| Try.Err("no value")
+        \\
+        \\main = |mode| {
+        \\  var $value : Dec
+        \\
+        \\  match mode {
+        \\    Return => {
+        \\      return Ok(0)
+        \\    }
+        \\    Crash => {
+        \\      crash "no value"
+        \\    }
+        \\    Try => {
+        \\      _ignored = fallible({})?
+        \\      $value = 1
+        \\    }
+        \\    Assign => {
+        \\      $value = 1
+        \\    }
+        \\  }
+        \\
+        \\  Ok($value)
+        \\}
+    ;
+    try checkTypesModule(
+        source,
+        .{ .pass = .{ .def = "main" } },
+        "[Assign, Crash, Return, Try] -> Try(Dec, Str)",
+    );
+}
+
+test "check type - uninitialized var - breakable loop assignment counts" {
+    const source =
+        \\main = {
+        \\  var $value : Dec
+        \\
+        \\  while True {
+        \\    $value = 1
+        \\    break
+        \\  }
+        \\
+        \\  $value
+        \\}
+    ;
+    try checkTypesModule(
+        source,
+        .{ .pass = .last_def },
+        "Dec",
+    );
+}
+
+test "check can - uninitialized var - ordinary loop assignment does not guarantee initialization" {
+    const source =
+        \\main = |condition| {
+        \\  var $value
+        \\
+        \\  while condition {
+        \\    $value = 1
+        \\    break
+        \\  }
+        \\
+        \\  $value
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertOneCanError("READING UNINITIALIZED VAR");
+}
+
+test "check can - uninitialized var - reports each bad read" {
+    const source =
+        \\main = {
+        \\  var $first
+        \\  var $second
+        \\
+        \\  _ = $first
+        \\  $second
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try expectReadUninitializedVarDiagnostics(&test_env, 2);
+}
+
 // expect //
 
 test "check type - expect" {
@@ -4075,6 +4223,27 @@ const DefExpectation = union(enum) {
     last_def,
     def: []const u8,
 };
+
+fn expectReadUninitializedVarDiagnostics(test_env: *TestEnv, expected_count: usize) !void {
+    try testing.expect(!test_env.parse_ast.hasErrors());
+
+    const diagnostics = try test_env.module_env.getDiagnostics();
+    defer test_env.gpa.free(diagnostics);
+
+    try testing.expectEqual(expected_count, diagnostics.len);
+
+    for (diagnostics) |diagnostic| {
+        switch (diagnostic) {
+            .read_uninitialized_var => {},
+            else => return error.TestUnexpectedResult,
+        }
+
+        var report = try test_env.module_env.diagnosticToReport(diagnostic, test_env.gpa, test_env.module_env.module_name);
+        defer report.deinit();
+
+        try testing.expectEqualStrings("READING UNINITIALIZED VAR", report.title);
+    }
+}
 
 /// A unified helper to run the full pipeline: parse, canonicalize, and type-check source code.
 ///

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -751,6 +751,14 @@ pub const Interpreter = struct {
         return slice;
     }
 
+    fn poisonUninitializedValue(self: *LirInterpreter, layout_idx: layout_mod.Idx) Error!Value {
+        const sa = self.helper.sizeAlignOf(layout_idx);
+        if (sa.size == 0) return Value.zst;
+        const slice = try self.allocAlignedByteSlice(sa.size, sa.alignment);
+        @memset(slice, 0xAA);
+        return Value.fromSlice(slice);
+    }
+
     fn maxRocAlignment(a: layout_mod.RocAlignment, b: layout_mod.RocAlignment) layout_mod.RocAlignment {
         return if (@intFromEnum(a) >= @intFromEnum(b)) a else b;
     }
@@ -1439,6 +1447,7 @@ pub const Interpreter = struct {
             current = switch (stmt) {
                 .assign_ref => |assign| assign.next,
                 .assign_literal => |assign| assign.next,
+                .init_uninitialized => |uninit| uninit.next,
                 .assign_call => |assign| assign.next,
                 .assign_call_erased => |assign| assign.next,
                 .assign_packed_erased_fn => |assign| assign.next,
@@ -1717,6 +1726,13 @@ pub const Interpreter = struct {
                 .assign_literal => |assign| {
                     self.setLocalChecked(frame, current, assign.target, try self.evalLiteral(assign.value));
                     current = assign.next;
+                },
+                .init_uninitialized => |uninit| {
+                    frame.setLocal(
+                        uninit.target,
+                        try self.poisonUninitializedValue(self.store.getLocal(uninit.target).layout_idx),
+                    );
+                    current = uninit.next;
                 },
                 .assign_call => |assign| {
                     const arg_locals = self.store.getLocalSpan(assign.args);
@@ -2047,6 +2063,14 @@ pub const Interpreter = struct {
                         @intFromEnum(assign.next),
                     });
                     stack.append(self.evalAllocator(), assign.next) catch return;
+                },
+                .init_uninitialized => |uninit| {
+                    debugPrint("    {d}: init_uninitialized target={d} next={d}\n", .{
+                        @intFromEnum(stmt_id),
+                        @intFromEnum(uninit.target),
+                        @intFromEnum(uninit.next),
+                    });
+                    stack.append(self.evalAllocator(), uninit.next) catch return;
                 },
                 .assign_call => |assign| {
                     debugPrint("    {d}: assign_call proc={d} target={d} args=", .{

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -297,6 +297,7 @@ fn collectAssignCallProcs(
         switch (lowered.lir_result.store.getCFStmt(stmt_id)) {
             .assign_ref => |stmt| try work.append(allocator, stmt.next),
             .assign_literal => |stmt| try work.append(allocator, stmt.next),
+            .init_uninitialized => |stmt| try work.append(allocator, stmt.next),
             .assign_call => |stmt| {
                 try calls.append(allocator, stmt.proc);
                 try work.append(allocator, stmt.next);
@@ -379,6 +380,7 @@ fn collectProcShape(
         switch (lowered.lir_result.store.getCFStmt(stmt_id)) {
             .assign_ref => |stmt| try work.append(allocator, stmt.next),
             .assign_literal => |stmt| try work.append(allocator, stmt.next),
+            .init_uninitialized => |stmt| try work.append(allocator, stmt.next),
             .assign_call => |stmt| {
                 shape.direct_call_count += 1;
                 if (stmt.proc == proc_id) shape.self_call_count += 1;
@@ -626,6 +628,7 @@ fn markReachableLiftedStmt(
         .return_,
         => |expr| markReachableLiftedExpr(program, expr, reachable),
         .crash => {},
+        .uninitialized => {},
     }
 }
 

--- a/src/eval/test/trmc_lir_test.zig
+++ b/src/eval/test/trmc_lir_test.zig
@@ -393,7 +393,7 @@ fn hasSelfCall(allocator: Allocator, store: *const LirStore, proc_id: LIR.LirPro
                 if (s.continuation) |continuation| try work.append(allocator, continuation);
             },
             .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
-            inline .assign_ref, .assign_literal, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
+            inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                 try work.append(allocator, s.next);
             },
         }

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -449,21 +449,23 @@ const Formatter = struct {
                     try fmt.push(' ');
                 }
                 try fmt.pushTokenText(v.name);
-                if (multiline and try fmt.flushCommentsAfter(v.name)) {
-                    fmt.curr_indent += 1;
-                    try fmt.pushIndent();
-                } else {
-                    try fmt.push(' ');
+                if (v.body) |body| {
+                    if (multiline and try fmt.flushCommentsAfter(v.name)) {
+                        fmt.curr_indent += 1;
+                        try fmt.pushIndent();
+                    } else {
+                        try fmt.push(' ');
+                    }
+                    try fmt.push('=');
+                    const body_region = fmt.nodeRegion(@intFromEnum(body));
+                    if (multiline and try fmt.flushCommentsBefore(body_region.start)) {
+                        fmt.curr_indent += 1;
+                        try fmt.pushIndent();
+                    } else {
+                        try fmt.push(' ');
+                    }
+                    try fmt.formatExprDiscard(body);
                 }
-                try fmt.push('=');
-                const body_region = fmt.nodeRegion(@intFromEnum(v.body));
-                if (multiline and try fmt.flushCommentsBefore(body_region.start)) {
-                    fmt.curr_indent += 1;
-                    try fmt.pushIndent();
-                } else {
-                    try fmt.push(' ');
-                }
-                try fmt.formatExprDiscard(v.body);
             },
             .expr => |e| {
                 try fmt.formatExprDiscard(e.expr);

--- a/src/lir/LIR.zig
+++ b/src/lir/LIR.zig
@@ -256,6 +256,10 @@ pub const TailTransform = enum(u8) {
 
 /// Single statement/control-flow language for all lowered code.
 pub const CFStmt = union(enum) {
+    init_uninitialized: struct {
+        target: LocalId,
+        next: CFStmtId,
+    },
     assign_ref: struct {
         target: LocalId,
         op: RefOp,

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -537,6 +537,11 @@ const Inserter = struct {
                     });
                     path.cursor = assign.next;
                 },
+                .init_uninitialized => |uninit| {
+                    current_start = try self.releaseOldTargetIfNeeded(uninit.target, &path.owned, current_start);
+                    try path.frames.append(self.store.allocator, .{ .stmt = path.cursor, .head = current_start });
+                    path.cursor = uninit.next;
+                },
                 .assign_call => |assign| {
                     const callee_sig = self.solution.sigOf(assign.proc);
                     // Unique demands clone variants, so they exist only when
@@ -916,6 +921,12 @@ const Inserter = struct {
                 cloned = try self.store.addCFStmt(.{ .assign_literal = .{
                     .target = assign.target,
                     .value = assign.value,
+                    .next = next,
+                } });
+            },
+            .init_uninitialized => |uninit| {
+                cloned = try self.store.addCFStmt(.{ .init_uninitialized = .{
+                    .target = uninit.target,
                     .next = next,
                 } });
             },
@@ -1430,6 +1441,10 @@ const Inserter = struct {
                     const singles = [_]LIR.LocalId{ refOpSource(assign.op), assign.target };
                     try self.postStmtDeaths(&path.owned, &singles, null, assign.next, path.loop_keep, null);
                     path.cursor = assign.next;
+                },
+                .init_uninitialized => |uninit| {
+                    path.owned.unset(uninit.target);
+                    path.cursor = uninit.next;
                 },
                 .assign_literal => |assign| {
                     self.addOwnedIfRc(&path.owned, assign.target);
@@ -2114,6 +2129,7 @@ const Inserter = struct {
             switch (stmt) {
                 .assign_ref => |assign| try stack.append(self.store.allocator, assign.next),
                 .assign_literal => |assign| try stack.append(self.store.allocator, assign.next),
+                .init_uninitialized => |uninit| try stack.append(self.store.allocator, uninit.next),
                 .assign_call => |assign| try stack.append(self.store.allocator, assign.next),
                 .assign_call_erased => |assign| try stack.append(self.store.allocator, assign.next),
                 .assign_packed_erased_fn => |assign| try stack.append(self.store.allocator, assign.next),
@@ -2196,6 +2212,7 @@ const Inserter = struct {
             switch (stmt) {
                 .assign_ref => |assign| try stack.append(self.store.allocator, assign.next),
                 .assign_literal => |assign| try stack.append(self.store.allocator, assign.next),
+                .init_uninitialized => |uninit| try stack.append(self.store.allocator, uninit.next),
                 .assign_call => |assign| try stack.append(self.store.allocator, assign.next),
                 .assign_call_erased => |assign| try stack.append(self.store.allocator, assign.next),
                 .assign_packed_erased_fn => |assign| try stack.append(self.store.allocator, assign.next),
@@ -2272,6 +2289,10 @@ const Inserter = struct {
                 .assign_literal => |assign| {
                     if (assign.target == needle) continue;
                     try stack.append(self.store.allocator, assign.next);
+                },
+                .init_uninitialized => |uninit| {
+                    if (uninit.target == needle) continue;
+                    try stack.append(self.store.allocator, uninit.next);
                 },
                 .assign_call => |assign| {
                     if (self.spanUsesLocal(assign.args, needle)) return true;
@@ -2425,6 +2446,9 @@ const Inserter = struct {
                 },
                 .assign_literal => |assign| {
                     try stack.append(self.store.allocator, assign.next);
+                },
+                .init_uninitialized => |uninit| {
+                    try stack.append(self.store.allocator, uninit.next);
                 },
                 .assign_call => |assign| {
                     if (self.spanUsesAny(assign.args, needles)) return true;
@@ -3053,7 +3077,7 @@ const ArcTest = struct {
                     try stack.append(self.allocator, j.body);
                     try stack.append(self.allocator, j.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
+                inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                     try stack.append(self.allocator, s.next);
                 },
                 .ret, .jump, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
@@ -3099,6 +3123,7 @@ const ArcTest = struct {
                 },
                 .assign_ref => |assign| cursor = assign.next,
                 .assign_literal => |assign| cursor = assign.next,
+                .init_uninitialized => |uninit| cursor = uninit.next,
                 .assign_call => |assign| cursor = assign.next,
                 .assign_call_erased => |assign| cursor = assign.next,
                 .assign_packed_erased_fn => |assign| cursor = assign.next,
@@ -4504,6 +4529,7 @@ fn expectDecrefBeforeStmt(f: *const ArcTest, start: LIR.CFStmtId, local: LIR.Loc
             .free => |rc| cursor = rc.next,
             .assign_ref => |a| cursor = a.next,
             .assign_literal => |a| cursor = a.next,
+            .init_uninitialized => |a| cursor = a.next,
             .assign_call => |a| cursor = a.next,
             .assign_call_erased => |a| cursor = a.next,
             .assign_packed_erased_fn => |a| cursor = a.next,

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -214,7 +214,7 @@ fn certifyUniqueArgs(
                     try stack.append(allocator, j.body);
                     try stack.append(allocator, j.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
+                inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                     try stack.append(allocator, s.next);
                 },
                 .ret, .jump, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
@@ -326,7 +326,7 @@ fn writeFailureContext(context: *FailureContext, store: *const LirStore, proc_id
                     walk.append(store.allocator, j.body) catch return;
                     walk.append(store.allocator, j.remainder) catch return;
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| {
+                inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| {
                     walk.append(store.allocator, s.next) catch return;
                 },
             }
@@ -360,6 +360,7 @@ fn writeFailureContext(context: *FailureContext, store: *const LirStore, proc_id
             .set_local => |a| context.append(" target={d} value={d} mode={s} next={d}", .{
                 @intFromEnum(a.target), @intFromEnum(a.value), @tagName(a.mode), @intFromEnum(a.next),
             }),
+            .init_uninitialized => |a| context.append(" target={d} next={d}", .{ @intFromEnum(a.target), @intFromEnum(a.next) }),
             .incref => |rc| context.append(" value={d} next={d}", .{ @intFromEnum(rc.value), @intFromEnum(rc.next) }),
             .decref => |rc| context.append(" value={d} next={d}", .{ @intFromEnum(rc.value), @intFromEnum(rc.next) }),
             .free => |rc| context.append(" value={d} next={d}", .{ @intFromEnum(rc.value), @intFromEnum(rc.next) }),
@@ -387,6 +388,7 @@ fn stmtMentionsLocal(store: *const LirStore, stmt: LIR.CFStmt, needle: LIR.Local
         .assign_struct => |a| a.target == needle or spanHasLocal(store, a.fields, needle),
         .assign_tag => |a| a.target == needle or (a.payload != null and a.payload.? == needle),
         .set_local => |a| a.target == needle or a.value == needle,
+        .init_uninitialized => |a| a.target == needle,
         .debug => |d| d.message == needle,
         .expect_err => |e| e.message == needle,
         .expect => |e| e.condition == needle,
@@ -941,6 +943,10 @@ const Certifier = struct {
                     try self.noteProcLocal(assign.target);
                     try stack.append(self.allocator, assign.next);
                 },
+                .init_uninitialized => |init| {
+                    try self.noteProcLocal(init.target);
+                    try stack.append(self.allocator, init.next);
+                },
                 .assign_call => |assign| {
                     try self.noteProcLocal(assign.target);
                     try self.noteProcLocalSpan(assign.args);
@@ -1047,6 +1053,10 @@ const Certifier = struct {
                 .assign_literal => |assign| {
                     if (assign.target == needle) continue;
                     try self.scan_stack.append(self.allocator, assign.next);
+                },
+                .init_uninitialized => |init| {
+                    if (init.target == needle) continue;
+                    try self.scan_stack.append(self.allocator, init.next);
                 },
                 .assign_call => |assign| {
                     if (self.spanReadsLocal(assign.args, needle)) return true;
@@ -1419,6 +1429,12 @@ const Certifier = struct {
                         _ = try self.bindFresh(&state, assign.target, 1, &.{});
                     }
                     cursor = assign.next;
+                },
+                .init_uninitialized => |init| {
+                    if (self.isRc(init.target)) {
+                        state.bindValue(init.target, no_value);
+                    }
+                    cursor = init.next;
                 },
                 .assign_call => |assign| {
                     try self.applyCall(&state, assign.target, self.sigs.get(assign.proc), assign.args);

--- a/src/lir/arc_solve.zig
+++ b/src/lir/arc_solve.zig
@@ -586,7 +586,7 @@ fn retLenders(
                 try solver.stack.append(allocator, j.body);
                 try solver.stack.append(allocator, j.remainder);
             },
-            inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
+            inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                 try solver.stack.append(allocator, s.next);
             },
             .jump, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
@@ -637,7 +637,7 @@ fn retAllUnique(
                 try solver.stack.append(allocator, j.body);
                 try solver.stack.append(allocator, j.remainder);
             },
-            inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
+            inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                 try solver.stack.append(allocator, s.next);
             },
             .jump, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
@@ -759,6 +759,9 @@ fn collectStmt(
         .assign_literal => |assign| {
             noteDef(solver.defs, assign.target, .fresh);
             try solver.stack.append(allocator, assign.next);
+        },
+        .init_uninitialized => |init| {
+            try solver.stack.append(allocator, init.next);
         },
         .assign_call => |assign| {
             const callee_sig = solver.sigs[@intFromEnum(assign.proc)];
@@ -1026,7 +1029,7 @@ pub fn computeVisibility(
                     try stack.append(allocator, stmt.body);
                     try stack.append(allocator, stmt.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |stmt| {
+                inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |stmt| {
                     try stack.append(allocator, stmt.next);
                 },
                 .jump, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
@@ -1540,6 +1543,7 @@ pub fn computeUniqueness(
             // The failure report is the message's consuming use.
             .expect_err => |expect_err_stmt| marks.consume(&consumed_once, &destroyed, expect_err_stmt.message),
             .expect => |expect_stmt| marks.noteUse(&borrow_used, expect_stmt.condition),
+            .init_uninitialized => {},
             .comptime_branch_taken => {},
             .switch_stmt => |switch_stmt| marks.noteUse(&borrow_used, switch_stmt.cond),
             .decref, .free, .jump, .crash, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
@@ -1638,7 +1642,7 @@ fn computeSccs(solver: *Solver) SolveError!void {
                     try solver.stack.append(allocator, j.body);
                     try solver.stack.append(allocator, j.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
+                inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                     try solver.stack.append(allocator, s.next);
                 },
                 .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},

--- a/src/lir/debug_print.zig
+++ b/src/lir/debug_print.zig
@@ -97,6 +97,11 @@ const Printer = struct {
                     try writer.writeAll("\n");
                     current = s.next;
                 },
+                .init_uninitialized => |s| {
+                    try writeIndent(indent, writer);
+                    try writer.print("init_uninitialized l{d}\n", .{@intFromEnum(s.target)});
+                    current = s.next;
+                },
                 .assign_call => |s| {
                     try self.writeTarget(s.target, indent, writer);
                     try writer.print("call p{d}(", .{@intFromEnum(s.proc)});

--- a/src/lir/scalarize_joins.zig
+++ b/src/lir/scalarize_joins.zig
@@ -203,7 +203,7 @@ const Pass = struct {
                         try self.stack.append(self.allocator, continuation);
                     }
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
+                inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                     try self.stack.append(self.allocator, s.next);
                 },
                 .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
@@ -404,7 +404,7 @@ const Pass = struct {
                     try self.stack.append(self.allocator, j.body);
                     try self.stack.append(self.allocator, j.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |*s| {
+                inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |*s| {
                     s.next = self.resolveRemoved(s.next);
                     try self.stack.append(self.allocator, s.next);
                 },
@@ -451,7 +451,7 @@ const Pass = struct {
                     try self.stack.append(self.allocator, join_stmt.body);
                     try self.stack.append(self.allocator, join_stmt.remainder);
                 },
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |a| {
+                inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |a| {
                     try self.stack.append(self.allocator, a.next);
                 },
                 .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
@@ -481,6 +481,10 @@ const Pass = struct {
                 .assign_literal => |assign| {
                     try self.noteWrite(assign.target);
                     try self.stack.append(self.allocator, assign.next);
+                },
+                .init_uninitialized => |init| {
+                    try self.noteWrite(init.target);
+                    try self.stack.append(self.allocator, init.next);
                 },
                 .assign_call => |assign| {
                     for (self.store.getLocalSpan(assign.args)) |arg| try self.noteUse(arg);

--- a/src/lir/trmc.zig
+++ b/src/lir/trmc.zig
@@ -422,7 +422,7 @@ const Detection = struct {
                     }
                 },
                 .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
-                inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
+                inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                     try work.append(gpa, .{ .stmt = s.next, .edge = .{ .stmt_next = item.stmt } });
                 },
             }
@@ -476,7 +476,7 @@ const Detection = struct {
                 }
             },
             .jump, .ret, .crash, .expect_err, .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
-            inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
+            inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .comptime_branch_taken, .incref, .decref, .free => |s| {
                 try self.appendSharedSuccessor(work, s.next);
             },
         }
@@ -665,6 +665,7 @@ const Detection = struct {
                 .nominal => |n| c.chainContains(n.backing_ref),
             },
             .assign_literal, .assign_packed_erased_fn => false,
+            .init_uninitialized => |s| c.chainContains(s.target),
             .assign_call => |s| self.spanTouchesChain(s.args, c),
             .assign_call_erased => |s| c.chainContains(s.closure) or self.spanTouchesChain(s.args, c),
             .assign_low_level => |s| self.spanTouchesChain(s.args, c),
@@ -1118,7 +1119,7 @@ const Transform = struct {
 
     fn nextOf(self: *const Transform, stmt_id: CFStmtId) CFStmtId {
         return switch (self.store.getCFStmt(stmt_id)) {
-            inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| s.next,
+            inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |s| s.next,
             else => unreachable,
         };
     }
@@ -1126,7 +1127,7 @@ const Transform = struct {
     fn setNext(self: *Transform, stmt_id: CFStmtId, next: CFStmtId) void {
         const ptr = self.store.getCFStmtPtr(stmt_id);
         switch (ptr.*) {
-            inline .assign_ref, .assign_literal, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |*s| s.next = next,
+            inline .assign_ref, .assign_literal, .init_uninitialized, .assign_call, .assign_call_erased, .assign_packed_erased_fn, .assign_low_level, .assign_list, .assign_struct, .assign_tag, .set_local, .debug, .expect, .incref, .decref, .free => |*s| s.next = next,
             else => unreachable,
         }
     }

--- a/src/lsp/cir_queries.zig
+++ b/src/lsp/cir_queries.zig
@@ -162,6 +162,7 @@ const FindTypeContext = struct {
         const anno_idx: ?CIR.Annotation.Idx = switch (stmt) {
             .s_decl => |d| d.anno,
             .s_var => |v| v.anno,
+            .s_var_uninitialized => |v| v.anno,
             else => null,
         };
 
@@ -173,6 +174,7 @@ const FindTypeContext = struct {
                 const pattern_idx: ?CIR.Pattern.Idx = switch (stmt) {
                     .s_decl => |d| d.pattern,
                     .s_var => |v| v.pattern_idx,
+                    .s_var_uninitialized => |v| v.pattern_idx,
                     else => null,
                 };
                 if (pattern_idx) |pat| {
@@ -189,6 +191,7 @@ const FindTypeContext = struct {
                 const pattern_idx: ?CIR.Pattern.Idx = switch (stmt) {
                     .s_decl => |d| d.pattern,
                     .s_var => |v| v.pattern_idx,
+                    .s_var_uninitialized => |v| v.pattern_idx,
                     else => null,
                 };
                 if (pattern_idx) |pat| {

--- a/src/lsp/cir_visitor.zig
+++ b/src/lsp/cir_visitor.zig
@@ -385,6 +385,11 @@ pub fn CirVisitor(comptime Context: type) type {
                     if (self.stopped) return;
                     if (v.anno) |a| self.walkAnnotation(store, a);
                 },
+                .s_var_uninitialized => |v| {
+                    self.walkPattern(store, v.pattern_idx);
+                    if (self.stopped) return;
+                    if (v.anno) |a| self.walkAnnotation(store, a);
+                },
                 .s_reassign => |r| {
                     self.walkPattern(store, r.pattern_idx);
                     if (self.stopped) return;

--- a/src/lsp/completion/builder.zig
+++ b/src/lsp/completion/builder.zig
@@ -678,6 +678,7 @@ pub const CompletionBuilder = struct {
             const pattern_idx = switch (stmt) {
                 .s_decl => |decl| decl.pattern,
                 .s_var => |var_stmt| var_stmt.pattern_idx,
+                .s_var_uninitialized => |var_stmt| var_stmt.pattern_idx,
                 else => continue,
             };
 
@@ -1035,6 +1036,7 @@ pub const CompletionBuilder = struct {
                 const pattern_idx = switch (stmt) {
                     .s_decl => |decl| decl.pattern,
                     .s_var => |var_stmt| var_stmt.pattern_idx,
+                    .s_var_uninitialized => |var_stmt| var_stmt.pattern_idx,
                     else => continue,
                 };
 
@@ -1308,6 +1310,7 @@ pub const CompletionBuilder = struct {
             const pattern_idx = switch (stmt) {
                 .s_decl => |decl| decl.pattern,
                 .s_var => |var_stmt| var_stmt.pattern_idx,
+                .s_var_uninitialized => |var_stmt| var_stmt.pattern_idx,
                 else => continue,
             };
 
@@ -1358,6 +1361,7 @@ pub const CompletionBuilder = struct {
             const pattern_idx = switch (stmt) {
                 .s_decl => |decl| decl.pattern,
                 .s_var => |var_stmt| var_stmt.pattern_idx,
+                .s_var_uninitialized => |var_stmt| var_stmt.pattern_idx,
                 else => continue,
             };
 
@@ -1690,6 +1694,7 @@ fn getStatementParts(stmt: CIR.Statement) StatementParts {
     return switch (stmt) {
         .s_decl => |decl| .{ .pattern = decl.pattern, .expr = decl.expr, .expr2 = null },
         .s_var => |var_stmt| .{ .pattern = var_stmt.pattern_idx, .expr = var_stmt.expr, .expr2 = null },
+        .s_var_uninitialized => |var_stmt| .{ .pattern = var_stmt.pattern_idx, .expr = null, .expr2 = null },
         .s_reassign => |reassign| .{ .pattern = null, .expr = reassign.expr, .expr2 = null },
         .s_for => |for_stmt| .{ .pattern = for_stmt.patt, .expr = for_stmt.expr, .expr2 = for_stmt.body },
         .s_while => |while_stmt| .{ .pattern = null, .expr = while_stmt.cond, .expr2 = while_stmt.body },

--- a/src/lsp/doc_comments.zig
+++ b/src/lsp/doc_comments.zig
@@ -183,6 +183,10 @@ pub fn docOffsetForStatement(store: *const NodeStore, stmt: CIR.Statement, stmt_
             store.getAnnotationRegion(a).start.offset
         else
             store.getPatternRegion(v.pattern_idx).start.offset,
+        .s_var_uninitialized => |v| if (v.anno) |a|
+            store.getAnnotationRegion(a).start.offset
+        else
+            store.getPatternRegion(v.pattern_idx).start.offset,
         else => store.getStatementRegion(stmt_idx).start.offset,
     };
 }

--- a/src/lsp/handlers/selection_range.zig
+++ b/src/lsp/handlers/selection_range.zig
@@ -286,7 +286,9 @@ fn collectContainingRegionsFromStatement(
             try collectContainingRegionsFromExpr(allocator, ast, d.body, target_offset, regions);
         },
         .@"var" => |v| {
-            try collectContainingRegionsFromExpr(allocator, ast, v.body, target_offset, regions);
+            if (v.body) |body| {
+                try collectContainingRegionsFromExpr(allocator, ast, body, target_offset, regions);
+            }
         },
         .expr => |e| {
             try collectContainingRegionsFromExpr(allocator, ast, e.expr, target_offset, regions);

--- a/src/lsp/module_lookup.zig
+++ b/src/lsp/module_lookup.zig
@@ -177,6 +177,7 @@ pub fn findStatementOwningPattern(module_env: *ModuleEnv, target_pattern: CIR.Pa
         const pattern_idx_opt: ?CIR.Pattern.Idx = switch (stmt) {
             .s_decl => |decl| decl.pattern,
             .s_var => |var_stmt| var_stmt.pattern_idx,
+            .s_var_uninitialized => |var_stmt| var_stmt.pattern_idx,
             else => null,
         };
         if (pattern_idx_opt) |pat_idx| {
@@ -314,6 +315,11 @@ pub fn getStatementParts(stmt: CIR.Statement) StatementParts {
         .s_var => |d| .{
             .pattern = d.pattern_idx,
             .expr = d.expr,
+            .expr2 = null,
+        },
+        .s_var_uninitialized => |d| .{
+            .pattern = d.pattern_idx,
+            .expr = null,
             .expr2 = null,
         },
         .s_reassign => |d| .{

--- a/src/lsp/scope_map.zig
+++ b/src/lsp/scope_map.zig
@@ -100,6 +100,9 @@ pub const ScopeMap = struct {
                 try self.extractBindingsFromPattern(module_env, var_decl.pattern_idx, stmt_region.start.offset, scope_end, false, depth + 1);
                 try self.traverseExpr(module_env, var_decl.expr, scope_end, depth + 1);
             },
+            .s_var_uninitialized => |var_decl| {
+                try self.extractBindingsFromPattern(module_env, var_decl.pattern_idx, stmt_region.start.offset, scope_end, false, depth + 1);
+            },
             .s_reassign => |reassign| {
                 // Reassignment doesn't introduce new bindings, but traverse the expr
                 try self.traverseExpr(module_env, reassign.expr, scope_end, depth + 1);

--- a/src/lsp/semantic_tokens.zig
+++ b/src/lsp/semantic_tokens.zig
@@ -435,6 +435,10 @@ const SemanticCollector = struct {
         switch (stmt) {
             .s_decl => |d| try self.visitDecl(d.pattern, d.expr),
             .s_var => |v| try self.visitDecl(v.pattern_idx, v.expr),
+            .s_var_uninitialized => |v| {
+                const pattern_region = self.module_env.store.getPatternRegion(v.pattern_idx);
+                try self.addToken(pattern_region, .variable);
+            },
             .s_expr => |e| try self.visitExpr(e.expr),
             // Type declarations and imports don't need special handling
             // since they're covered by the tokenizer

--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -1230,6 +1230,7 @@ pub const SyntaxChecker = struct {
             const pattern_idx = switch (stmt) {
                 .s_decl => |decl| decl.pattern,
                 .s_var => |var_stmt| var_stmt.pattern_idx,
+                .s_var_uninitialized => |var_stmt| var_stmt.pattern_idx,
                 else => continue,
             };
 
@@ -1485,6 +1486,7 @@ pub const SyntaxChecker = struct {
             const maybe_type_anno: ?CIR.TypeAnno.Idx = switch (stmt) {
                 .s_decl => |d| if (d.anno) |anno_idx| module_env.store.getAnnotation(anno_idx).anno else null,
                 .s_var => |d| if (d.anno) |anno_idx| module_env.store.getAnnotation(anno_idx).anno else null,
+                .s_var_uninitialized => |d| if (d.anno) |anno_idx| module_env.store.getAnnotation(anno_idx).anno else null,
                 .s_type_anno => |t| t.anno,
                 .s_alias_decl => |a| a.anno,
                 .s_nominal_decl => |n| n.anno,
@@ -1900,6 +1902,7 @@ pub const SyntaxChecker = struct {
                     const maybe_type_anno: ?CIR.TypeAnno.Idx = switch (stmt) {
                         .s_decl => |d| if (d.anno) |anno_idx| module_env.store.getAnnotation(anno_idx).anno else null,
                         .s_var => |d| if (d.anno) |anno_idx| module_env.store.getAnnotation(anno_idx).anno else null,
+                        .s_var_uninitialized => |d| if (d.anno) |anno_idx| module_env.store.getAnnotation(anno_idx).anno else null,
                         .s_type_anno => |t| t.anno,
                         .s_alias_decl => |a| a.anno,
                         .s_nominal_decl => |n| n.anno,

--- a/src/parse/AST.zig
+++ b/src/parse/AST.zig
@@ -967,7 +967,7 @@ pub const Statement = union(enum) {
     decl: Decl,
     @"var": struct {
         name: Token.Idx,
-        body: Expr.Idx,
+        body: ?Expr.Idx,
         region: TokenizedRegion,
     },
     expr: struct {
@@ -1082,7 +1082,9 @@ pub const Statement = union(enum) {
                 try tree.pushStringPair("name", name_str);
                 const attrs = tree.beginNode();
 
-                try ast.store.getExpr(v.body).pushToSExprTree(gpa, env, ast, tree);
+                if (v.body) |body| {
+                    try ast.store.getExpr(body).pushToSExprTree(gpa, env, ast, tree);
+                }
 
                 try tree.endNode(begin, attrs);
             },

--- a/src/parse/NodeStore.zig
+++ b/src/parse/NodeStore.zig
@@ -552,7 +552,7 @@ pub fn addStatement(store: *NodeStore, statement: AST.Statement) std.mem.Allocat
         .@"var" => |v| {
             node.tag = .@"var";
             node.main_token = v.name;
-            node.data.lhs = @intFromEnum(v.body);
+            node.data.lhs = try packOptionalIndex(v.body);
             node.region = v.region;
         },
         .expr => |expr| {
@@ -1528,7 +1528,7 @@ pub fn getStatement(store: *const NodeStore, statement_idx: AST.Statement.Idx) A
         .@"var" => {
             return .{ .@"var" = .{
                 .name = node.main_token,
-                .body = @enumFromInt(node.data.lhs),
+                .body = unpackOptionalIndex(AST.Expr.Idx, node.data.lhs),
                 .region = node.region,
             } };
         },

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -5134,10 +5134,15 @@ fn runExprStatementKernel(
                         type_args = .not_looking_for_args;
                         continue :expr_kernel .type_prefix;
                     }
-                    self.expect(.OpAssign) catch {
-                        last_statement = try self.pushMalformed(AST.Statement.Idx, .var_expected_equals, self.pos);
+                    if (self.peek() != .OpAssign) {
+                        last_statement = try self.addStatement(.{ .@"var" = .{
+                            .name = name,
+                            .body = null,
+                            .region = .{ .start = start, .end = self.pos },
+                        } });
                         continue :expr_kernel .statement_complete;
-                    };
+                    }
+                    self.advance();
                     try open_syntax.pushExpr(open_allocator, .statement_var_body, StatementVarBodyState, .{
                         .start = start,
                         .name = name,

--- a/src/postcheck/lambda_mono/ast.zig
+++ b/src/postcheck/lambda_mono/ast.zig
@@ -260,6 +260,7 @@ pub const IfBranch = struct {
 
 /// Lambda Mono statement forms.
 pub const Stmt = union(enum) {
+    uninitialized: PatId,
     let_: struct {
         pat: PatId,
         value: ExprId,

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -792,6 +792,7 @@ const Lowerer = struct {
         defer self.program.current_loc = saved_loc;
         self.program.current_loc = self.solved.lifted.stmtLoc(stmt_id);
         const lowered_stmt: Ast.Stmt = switch (self.solved.lifted.stmts.items[index]) {
+            .uninitialized => |pat| .{ .uninitialized = try self.lowerPat(pat) },
             .let_ => |let_| .{ .let_ = .{
                 .pat = try self.lowerPat(let_.pat),
                 .value = try self.lowerExpr(let_.value),

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -528,6 +528,10 @@ const Solver = struct {
 
     fn inferStmt(self: *Solver, stmt_id: Lifted.StmtId) Allocator.Error!void {
         switch (self.program.lifted.stmts.items[@intFromEnum(stmt_id)]) {
+            .uninitialized => |pat| {
+                const pat_ty = try self.lowerTypeFresh(self.program.lifted.pats.items[@intFromEnum(pat)].ty);
+                try self.bindPattern(pat, pat_ty);
+            },
             .let_ => |let_| {
                 const value_ty = try self.inferExpr(let_.value);
                 try self.bindPattern(let_.pat, value_ty);

--- a/src/postcheck/lir_lower.zig
+++ b/src/postcheck/lir_lower.zig
@@ -1425,6 +1425,7 @@ const Lowerer = struct {
         defer self.result.store.current_loc = saved_loc;
         self.result.store.current_loc = self.program.stmtLoc(stmt_id);
         return switch (self.program.stmts.items[@intFromEnum(stmt_id)]) {
+            .uninitialized => |pat_id| try self.initUninitializedPattern(pat_id, next),
             .let_ => |let_| blk: {
                 const value = try self.addTemp(self.expr(let_.value).ty);
                 const bind = try self.bindPatternOrCrash(let_.pat, value, next, let_.comptime_site);
@@ -1445,6 +1446,72 @@ const Lowerer = struct {
                 .msg = try self.result.store.insertString(self.program.stringLiteralText(msg)),
             } }),
         };
+    }
+
+    fn initUninitializedPattern(
+        self: *Lowerer,
+        pat_id: LambdaMono.PatId,
+        next: LIR.CFStmtId,
+    ) Common.LowerError!LIR.CFStmtId {
+        const pat_data = self.pat(pat_id);
+        return switch (pat_data.data) {
+            .bind => |local| try self.initUninitializedLocal(try self.localFor(local), next),
+            .wildcard,
+            .int_lit,
+            .dec_lit,
+            .frac_f32_lit,
+            .frac_f64_lit,
+            .str_lit,
+            => next,
+            .as => |as| blk: {
+                const inner = try self.initUninitializedPattern(as.pattern, next);
+                break :blk try self.initUninitializedLocal(try self.localFor(as.local), inner);
+            },
+            .record => |fields| blk: {
+                var current = next;
+                const destructs = self.program.recordDestructSpan(fields);
+                var i = destructs.len;
+                while (i > 0) {
+                    i -= 1;
+                    current = try self.initUninitializedPattern(destructs[i].pattern, current);
+                }
+                break :blk current;
+            },
+            .tuple => |items| blk: {
+                var current = next;
+                const pats = self.program.patSpan(items);
+                var i = pats.len;
+                while (i > 0) {
+                    i -= 1;
+                    current = try self.initUninitializedPattern(pats[i], current);
+                }
+                break :blk current;
+            },
+            .tag => |tag| blk: {
+                var current = next;
+                const payloads = self.program.patSpan(tag.payloads);
+                var i = payloads.len;
+                while (i > 0) {
+                    i -= 1;
+                    current = try self.initUninitializedPattern(payloads[i], current);
+                }
+                break :blk current;
+            },
+            .callable => |callable| if (callable.payload) |payload| try self.initUninitializedPattern(payload, next) else next,
+            .nominal => |inner| try self.initUninitializedPattern(inner, next),
+        };
+    }
+
+    fn initUninitializedLocal(
+        self: *Lowerer,
+        target: LIR.LocalId,
+        next: LIR.CFStmtId,
+    ) Common.LowerError!LIR.CFStmtId {
+        if (self.isZstLocal(target)) return next;
+        return try self.result.store.addCFStmt(.{ .init_uninitialized = .{
+            .target = target,
+            .next = next,
+        } });
     }
 
     fn lowerLoopInto(self: *Lowerer, target: LIR.LocalId, loop: anytype, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -397,6 +397,7 @@ pub const StmtId = enum(u32) { _ };
 
 /// Monotype statement forms.
 pub const Stmt = union(enum) {
+    uninitialized: PatId,
     let_: struct {
         pat: PatId,
         value: ExprId,

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -7745,6 +7745,7 @@ const BodyContext = struct {
         return switch (self.view.bodies.statements[raw].data) {
             .decl,
             .var_,
+            .var_uninitialized,
             .reassign,
             .crash,
             .dbg,
@@ -8511,6 +8512,7 @@ const BodyContext = struct {
         switch (statement.data) {
             .decl => |decl| try self.collectReassignedBindersInExpr(decl.expr, out),
             .var_ => |var_| try self.collectReassignedBindersInExpr(var_.expr, out),
+            .var_uninitialized => {},
             .reassign => |reassign| {
                 for (reassign.reassigned_binders) |binder| try self.appendUniqueBinder(out, binder);
                 try self.collectReassignedBindersInExpr(reassign.expr, out);
@@ -8671,6 +8673,7 @@ const BodyContext = struct {
                 break :blk try self.lowerPatternStatement(decl.pattern, decl.expr, statement.source_region);
             },
             .var_ => |decl| try self.lowerPatternStatement(decl.pattern, decl.expr, statement.source_region),
+            .var_uninitialized => |decl| .{ .uninitialized = try self.lowerUninitializedPatternStatement(decl.pattern) },
             .reassign => |decl| try self.lowerPatternStatement(decl.pattern, decl.expr, statement.source_region),
             .crash => |msg| .{ .crash = try self.lowerStringLiteral(msg) },
             .dbg => |child| .{ .dbg = try self.lowerDbgMessage(child) },
@@ -8755,6 +8758,14 @@ const BodyContext = struct {
             .return_ => |ret| .{ .return_ = try self.lowerExpr(ret.expr) },
         };
         return try self.builder.program.addStmt(stmt);
+    }
+
+    fn lowerUninitializedPatternStatement(
+        self: *BodyContext,
+        pattern: checked.CheckedPatternId,
+    ) Allocator.Error!Ast.PatId {
+        const checked_pattern = self.view.bodies.patterns[@intFromEnum(pattern)];
+        return try self.lowerPatternAtType(pattern, try self.lowerType(checked_pattern.ty));
     }
 
     fn lowerPatternStatement(

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -310,6 +310,7 @@ const Lifter = struct {
         self.stmt_done[index] = true;
 
         switch (self.output.stmts.items[index]) {
+            .uninitialized => {},
             .let_ => |let_| try self.rewriteExpr(let_.value),
             .expr,
             .expect,
@@ -708,6 +709,7 @@ const CaptureSet = struct {
 
     fn collectStmt(self: *CaptureSet, input: *const Ast.Program, stmt_id: Mono.StmtId, bound: *BoundSet, added: *std.ArrayList(Mono.LocalId)) Allocator.Error!void {
         switch (input.stmts.items[@intFromEnum(stmt_id)]) {
+            .uninitialized => |pat| try bindPat(self.allocator, input, pat, bound, added),
             .let_ => |let_| {
                 if (let_.recursive) {
                     try bindPat(self.allocator, input, let_.pat, bound, added);

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -574,7 +574,7 @@ const Pass = struct {
             .dbg,
             .return_,
             => |expr| try self.markArgUsesInExpr(fn_id, expr, changed),
-            .crash => {},
+            .uninitialized, .crash => {},
         }
     }
 
@@ -680,7 +680,7 @@ const Pass = struct {
             .dbg,
             .return_,
             => |expr| try self.collectCallPatternsInExpr(owner, expr),
-            .crash => {},
+            .uninitialized, .crash => {},
         }
     }
 
@@ -930,7 +930,7 @@ const Pass = struct {
             .dbg,
             .return_,
             => |expr| try self.rewriteCallsInExpr(expr, done),
-            .crash => {},
+            .uninitialized, .crash => {},
         }
     }
 
@@ -2623,6 +2623,7 @@ const Cloner = struct {
 
         const stmt = self.pass.program.stmts.items[@intFromEnum(stmt_id)];
         return try self.addStmt(switch (stmt) {
+            .uninitialized => |pat| .{ .uninitialized = try self.clonePat(pat) },
             .let_ => |let_| blk: {
                 const value = try self.cloneExprValue(let_.value);
                 const value_expr = try self.materialize(value);
@@ -3107,6 +3108,7 @@ fn localUseCountInExprSpan(program: *const Ast.Program, local: Ast.LocalId, span
 
 fn localUseCountInStmt(program: *const Ast.Program, local: Ast.LocalId, stmt_id: Ast.StmtId) usize {
     return switch (program.stmts.items[@intFromEnum(stmt_id)]) {
+        .uninitialized => 0,
         .let_ => |let_| localUseCountInExpr(program, local, let_.value),
         .expr,
         .expect,
@@ -3253,6 +3255,7 @@ fn scanLocalUseInExprSpan(
 
 fn scanLocalUseInStmt(program: *const Ast.Program, local: Ast.LocalId, stmt_id: Ast.StmtId, scan: *LocalUseScan) void {
     switch (program.stmts.items[@intFromEnum(stmt_id)]) {
+        .uninitialized => {},
         .let_ => |let_| scanLocalUseInExpr(program, local, let_.value, scan),
         .expr => |expr| scanLocalUseInExpr(program, local, expr, scan),
         .expect,

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -2543,6 +2543,7 @@ const Lowerer = struct {
         defer self.result.store.current_loc = saved_loc;
         self.result.store.current_loc = self.solved.lifted.stmtLoc(stmt_id);
         return switch (self.solved.lifted.stmts.items[@intFromEnum(stmt_id)]) {
+            .uninitialized => |pat_id| try self.initUninitializedPattern(pat_id, next),
             .let_ => |let_| blk: {
                 const value = try self.addTemp(try self.lowerExprTy(let_.value));
                 const bind = try self.bindPatternOrCrash(let_.pat, value, next, let_.comptime_site);
@@ -2564,6 +2565,72 @@ const Lowerer = struct {
                 .msg = try self.result.store.insertString(self.stringLiteralText(msg)),
             } }),
         };
+    }
+
+    fn initUninitializedPattern(
+        self: *Lowerer,
+        pat_id: Lifted.PatId,
+        next: LIR.CFStmtId,
+    ) Common.LowerError!LIR.CFStmtId {
+        const pat_data = self.pat(pat_id);
+        const pat_ty = try self.lowerPatTy(pat_id);
+        return switch (pat_data.data) {
+            .bind => |local| try self.initUninitializedLocal(try self.localForTyped(local, pat_ty), next),
+            .wildcard,
+            .int_lit,
+            .dec_lit,
+            .frac_f32_lit,
+            .frac_f64_lit,
+            .str_lit,
+            => next,
+            .as => |as| blk: {
+                const inner = try self.initUninitializedPattern(as.pattern, next);
+                break :blk try self.initUninitializedLocal(try self.localForTyped(as.local, pat_ty), inner);
+            },
+            .record => |fields| blk: {
+                var current = next;
+                const destructs = self.solved.lifted.recordDestructSpan(fields);
+                var i = destructs.len;
+                while (i > 0) {
+                    i -= 1;
+                    current = try self.initUninitializedPattern(destructs[i].pattern, current);
+                }
+                break :blk current;
+            },
+            .tuple => |items| blk: {
+                var current = next;
+                const pats = self.solved.lifted.patSpan(items);
+                var i = pats.len;
+                while (i > 0) {
+                    i -= 1;
+                    current = try self.initUninitializedPattern(pats[i], current);
+                }
+                break :blk current;
+            },
+            .tag => |tag| blk: {
+                var current = next;
+                const payloads = self.solved.lifted.patSpan(tag.payloads);
+                var i = payloads.len;
+                while (i > 0) {
+                    i -= 1;
+                    current = try self.initUninitializedPattern(payloads[i], current);
+                }
+                break :blk current;
+            },
+            .nominal => |inner| try self.initUninitializedPattern(inner, next),
+        };
+    }
+
+    fn initUninitializedLocal(
+        self: *Lowerer,
+        target: LIR.LocalId,
+        next: LIR.CFStmtId,
+    ) Common.LowerError!LIR.CFStmtId {
+        if (self.isZstLocal(target)) return next;
+        return try self.result.store.addCFStmt(.{ .init_uninitialized = .{
+            .target = target,
+            .next = next,
+        } });
     }
 
     fn lowerLoopInto(self: *Lowerer, target: LIR.LocalId, loop: anytype, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {

--- a/test/snapshots/fmt_var_in_record_field.md
+++ b/test/snapshots/fmt_var_in_record_field.md
@@ -9,8 +9,6 @@ f=||{var c:[]}
 ~~~
 # EXPECTED
 UNUSED VARIABLE - fmt_var_in_record_field.md:1:6:1:14
-DECLARATION HAS NO VALUE - fmt_var_in_record_field.md:1:6:1:14
-DECLARATION HAS NO VALUE - fmt_var_in_record_field.md:1:6:1:14
 # PROBLEMS
 **UNUSED VARIABLE**
 Variable `c` is not used anywhere in your code.

--- a/test/snapshots/fmt_var_in_record_field.md
+++ b/test/snapshots/fmt_var_in_record_field.md
@@ -24,28 +24,6 @@ f=||{var c:[]}
      ^^^^^^^^
 
 
-**DECLARATION HAS NO VALUE**
-This declaration has a type annotation but no implementation.
-**fmt_var_in_record_field.md:1:6:1:14:**
-```roc
-f=||{var c:[]}
-```
-     ^^^^^^^^
-
-
-Add a value body here, or put hosted functions in a platform type module so they are published through the host boundary.
-
-**DECLARATION HAS NO VALUE**
-This declaration has a type annotation but no implementation.
-**fmt_var_in_record_field.md:1:6:1:14:**
-```roc
-f=||{var c:[]}
-```
-     ^^^^^^^^
-
-
-Add a value body here, or put hosted functions in a platform type module so they are published through the host boundary.
-
 # TOKENS
 ~~~zig
 LowerIdent,OpAssign,OpBar,OpBar,OpenCurly,KwVar,LowerIdent,OpColon,OpenSquare,CloseSquare,CloseCurly,
@@ -76,27 +54,19 @@ f = || {
 ~~~clojure
 (can-ir
 	(d-let
-		(p-assign (ident "c"))
-		(e-anno-only)
-		(annotation
-			(ty-tag-union)))
-	(d-let
 		(p-assign (ident "f"))
 		(e-lambda
 			(args)
 			(e-block
-				(s-let
-					(p-assign (ident "c"))
-					(e-anno-only))
+				(s-var-uninitialized
+					(p-assign (ident "c")))
 				(e-empty_record)))))
 ~~~
 # TYPES
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "Error"))
 		(patt (type "({}) -> {}")))
 	(expressions
-		(expr (type "Error"))
 		(expr (type "({}) -> {}"))))
 ~~~

--- a/test/snapshots/statement/break_while_loop.md
+++ b/test/snapshots/statement/break_while_loop.md
@@ -86,7 +86,7 @@ expect result == True
 			(s-var
 				(p-assign (ident "$foo"))
 				(e-tag (name "True")))
-			(s-while
+			(s-breakable-loop
 				(e-tag (name "True"))
 				(e-block
 					(s-break)


### PR DESCRIPTION
This adds support for `var` declarations without an initializer and checks that every read is definitely preceded by an assignment on all reachable paths. The check runs only for blocks that contain an uninitialized `var`, reports `READING UNINITIALIZED VAR` at the read site, and replaces the bad read with a runtime-error expression so compilation can continue.

The new uninitialized statement is carried through check, postcheck, LIR, ARC, backends, eval, formatting, and LSP handling. Dev lowering/interpreter poison uninitialized storage with `0xAA`, while optimized LLVM/Wasm lowering emits no explicit initialization.