### PR TITLE
Generalize let-def has a polymorphic annotation

### DIFF
--- a/docs/langref/types.md
+++ b/docs/langref/types.md
@@ -32,7 +32,7 @@ cases:
   Annotating a value with a free type variable opts into a type scheme, so
   the binding is generalized to it (`empty : List(a)` is then reusable at any
   `a`). Note that we report an error for top-level values with free vars, so in
-  practice the only only applies to let-defs.
+  practice this only applies to let-defs.
 - **A value alias** — a binding whose right-hand side is a bare reference to an
   already-generalized binding (`shorthand = Foo.my_func`) — stays generalized,
   since copying a reference does no work and so is safe to reuse at many types.

--- a/docs/langref/types.md
+++ b/docs/langref/types.md
@@ -1,19 +1,137 @@
 # Types
 
+Roc is statically typed, and types are inferred — you rarely have to write them,
+but you can, and any annotation you write is checked.
+
 ## Roc's Type System
 
-- no hkp
-- rank-1
+Roc uses Hindley–Milner type inference with a few deliberate restrictions:
+
+- **Rank-1.** Quantification happens once per definition, at the outermost
+  level. A definition can be polymorphic (`identity : a -> a`), but a function
+  argument is used at a single type. I.E. you can't take an `(a -> a)` argument
+  and apply it at several element types within one call (that needs rank-2).
+- **No higher-kinded polymorphism.** Type variables range over types
+  (`Str`, `List(U64)`), never over type constructors — you can't abstract over
+  `List` itself, as in `f : m(a) -> m(b)`.
+- **No subtyping.** Types relate by unification, not a sub/supertype lattice.
+  The width flexibility of records and tag unions is expressed with extension
+  variables (see [Structural Types](#structural-types)), not subtyping.
+
+### Generalization
+
+A definition is *generalized* — made reusable at many types — only in these
+cases:
+
+- **Functions** are always generalized; each call site is checked at its own
+  types.
+- **Number literals** default rather than generalize: an unsuffixed literal
+  resolves to a concrete type, ultimately falling back to `Dec`. See
+  [numbers](numbers.md).
+- **An explicitly annotated value** is generalized to its annotated scheme.
+  Annotating a value with a free type variable opts into a type scheme, so
+  the binding is generalized to it (`empty : List(a)` is then reusable at any
+  `a`). Note that we report an error for top-level values with free vars, so in
+  practice the only only applies to let-defs.
+- **A value alias** — a binding whose right-hand side is a bare reference to an
+  already-generalized binding (`shorthand = Foo.my_func`) — stays generalized,
+  since copying a reference does no work and so is safe to reuse at many types.
+
+Every other value is monomorphic: one type, fixed by its definition and uses.
+This is what stops a value (or its `dbg`/`expect`) from being silently
+recomputed at each type it might otherwise take.
+
+A mutable variable (`var`) is never generalized, even with an annotation: it has
+a single type, fixed by its first use. This is the value restriction in its
+original, soundness role — a polymorphic mutable cell could be written at one
+type and read back at another, so a `var` is always monomorphic.
 
 ## Type Annotations
 
+Annotate a definition by writing `name : Type` above it. Lowercase names in a
+type are type variables; repeating a name means the same type.
+
+```roc
+greeting : Str
+greeting = "hello"
+
+identity : a -> a
+identity = |x| x
+```
+
+Capitalized declarations introduce *types* rather than values — see
+[Nominal Types](#nominal-types) (`:=`) and [Type Aliases](#type-aliases) (`:`).
+
 ### Where Clauses
+
+A `where` clause lists the [methods](static-dispatch.md) a type variable must
+provide. Each constraint has the form `var.method : signature`:
+
+```roc
+join : List(a) -> Str where [a.to_str : a -> Str]
+```
+
+A `where` clause can appear on any annotation, including a value's:
+
+```roc
+items : List(a) where [a.to_str : a -> Str]
+items = []
+```
 
 ## Structural Types
 
+Structural types are defined by their shape: two of them are the same type when
+their shapes match, with no declaration required.
+
+- **Records** — `{ name : Str, age : U64 }`. See [records](records.md).
+- **Tag unions** — `[Ok(a), Err(e)]`. See [tag unions](tag-unions.md).
+- **Tuples** — `(Str, U64)`. See [tuples](tuples.md).
+
+Records and tag unions are either **closed** (exactly the listed fields or tags)
+or **open**, ending in an extension variable that stands for "and possibly
+more":
+
+```roc
+{ name : Str, .. }     # any record with at least a `name : Str` field
+{ name : Str, ..r }    # the same, naming the rest `r`
+[Red, Green, ..]       # this union, or any wider one
+[Red, Green, ..u]      # the same, naming the rest `u`
+```
+
+An anonymous extension (`..`) is a fresh variable each time; a named one (`..r`)
+lets you refer to the same "rest" in more than one place.
+
 ## Nominal Types
 
+A nominal type is a distinct type with its own identity, declared with `:=`:
+
+```roc
+UserId := U64
+```
+
+`UserId` and `U64` share a representation but are different types — unification
+will not silently mix them. Nominal types may take parameters (`Tree(a) := …`)
+and define associated methods in a trailing `.{ }` block.
+
 ### Constructing Nominal Types
+
+You construct a nominal value by writing its backing value where the nominal
+type is expected; the annotation (or surrounding context) supplies the identity.
+
+```roc
+Color := [Red, Green, Blue]
+Point := { x : F64, y : F64 }
+UserId := U64
+
+c : Color
+c = Red               # or `Color.Red`; tags with payloads use `Color.Tag(payload)`
+
+p : Point
+p = { x: 1, y: 2 }    # a bare record literal becomes a Point here
+
+uid : UserId
+uid = 0               # a bare U64 becomes a UserId here
+```
 
 ### Destructuring Nominal Types
 
@@ -42,6 +160,17 @@ get_x = |{ x }| x
 ```
 
 ### Opaque Nominal Types
+
+Declaring with `::` instead of `:=` makes a nominal type *opaque*: outside its
+defining module the backing representation is hidden, so the type can only be
+created and inspected through the methods that module exposes.
+
+```roc
+Token :: Str         # other modules see `Token`, never the `Str` inside
+```
+
+Inside the defining module an opaque type is constructed and destructured just
+like any nominal type; the restriction applies only to other modules.
 
 ### Nested Nominal Types
 
@@ -73,3 +202,16 @@ rect = Geometry.Rectangle.{ top_left: Geometry.Point.origin, bottom_right: { x: 
 This is useful for grouping related types under a common namespace.
 
 ## Type Aliases
+
+A type alias names an existing type with `:` (not `:=`). Aliases are transparent
+— substituted away during compilation — so an alias and its definition are the
+*same* type and interchange freely:
+
+```roc
+Bytes : List(U8)
+Pair : (U64, U64)
+```
+
+Reach for an alias when you only want a shorter or clearer name; reach for a
+[nominal type](#nominal-types) when you want a genuinely distinct type the
+compiler keeps separate.

--- a/src/canonicalize/CIR.zig
+++ b/src/canonicalize/CIR.zig
@@ -328,6 +328,14 @@ pub const Annotation = struct {
 
     anno: TypeAnno.Idx,
     where: ?WhereClause.Span,
+    /// Whether `anno` mentions any type variable (a fresh `.rigid_var` or a
+    /// `.rigid_var_lookup` to an enclosing one). Derived from `anno` by
+    /// `addAnnotation` and populated on read by `getAnnotation`; the value passed
+    /// at construction is ignored.
+    mentions_type_var: bool = false,
+    /// Whether `anno` *introduces* a type variable (`.rigid_var`). Derived and
+    /// populated like `mentions_type_var`.
+    introduces_type_var: bool = false,
 
     pub fn pushToSExprTree(self: *const @This(), env: anytype, tree: *SExprTree, idx: Annotation.Idx) Allocator.Error!void {
         const annotation = self.*;

--- a/src/canonicalize/Node.zig
+++ b/src/canonicalize/Node.zig
@@ -1004,8 +1004,18 @@ pub const Payload = extern union {
 
     pub const Annotation = extern struct {
         anno: u32,
-        has_where: u32,
-        where_span2_idx: u32, // Index into span2_data: (where_start, where_len) when has_where == 1
+        /// Index into span2_data: (where_start, where_len); meaningful only when
+        /// `has_where`.
+        where_span2_idx: u32,
+        /// Whether the annotation has a `where` clause.
+        has_where: bool,
+        /// Whether the annotation mentions any type variable — a fresh
+        /// `.rigid_var` or a `.rigid_var_lookup` reference to an enclosing one.
+        mentions_type_var: bool,
+        /// Whether the annotation *introduces* a type variable (`.rigid_var`), as
+        /// opposed to only referencing one from an enclosing scope.
+        introduces_type_var: bool,
+        _padding: [1]u8 = .{0},
     };
 
     // === Diagnostic payload structs ===
@@ -1110,5 +1120,9 @@ pub const Payload = extern union {
     // Compile-time size verification
     comptime {
         std.debug.assert(@sizeOf(Payload) == 16);
+        // anno + where_span2_idx (2 x u32) + 3 bool flags + 1 byte padding. The
+        // explicit `_padding` keeps the trailing byte defined for deterministic
+        // serialization; assert the size so a stray field can't silently grow it.
+        std.debug.assert(@sizeOf(Annotation) == 12);
     }
 };

--- a/src/canonicalize/NodeStore.zig
+++ b/src/canonicalize/NodeStore.zig
@@ -1960,7 +1960,7 @@ pub fn getAnnotation(store: *const NodeStore, annotation: CIR.Annotation.Idx) CI
     const p = payload.annotation;
     const anno: CIR.TypeAnno.Idx = @enumFromInt(p.anno);
 
-    const where_clause = if (p.has_where == 1) blk: {
+    const where_clause = if (p.has_where) blk: {
         const where_data = store.span2_data.items.items[p.where_span2_idx];
         break :blk CIR.WhereClause.Span{ .span = DataSpan.init(where_data.start, where_data.len) };
     } else null;
@@ -1968,6 +1968,8 @@ pub fn getAnnotation(store: *const NodeStore, annotation: CIR.Annotation.Idx) CI
     return CIR.Annotation{
         .anno = anno,
         .where = where_clause,
+        .mentions_type_var = p.mentions_type_var,
+        .introduces_type_var = p.introduces_type_var,
     };
 }
 
@@ -3194,6 +3196,11 @@ pub fn addAnnoRecordField(store: *NodeStore, annoRecordField: CIR.TypeAnno.Recor
 pub fn addAnnotation(store: *NodeStore, annotation: CIR.Annotation, region: base.Region) Allocator.Error!CIR.Annotation.Idx {
     var node = Node.init(.annotation);
 
+    // Derive the type-variable flags once, here, so the check phase can read them
+    // off the annotation rather than re-walking the type tree (see getAnnotation).
+    const mentions_type_var = store.typeAnnoHasTypeVar(annotation.anno, .any);
+    const introduces_type_var = store.typeAnnoHasTypeVar(annotation.anno, .introduced_only);
+
     if (annotation.where) |where_clause| {
         const where_span2_idx: u32 = @intCast(store.span2_data.len());
         _ = try store.span2_data.append(store.gpa, .{
@@ -3202,20 +3209,66 @@ pub fn addAnnotation(store: *NodeStore, annotation: CIR.Annotation, region: base
         });
         node.setPayload(.{ .annotation = .{
             .anno = @intFromEnum(annotation.anno),
-            .has_where = 1,
             .where_span2_idx = where_span2_idx,
+            .has_where = true,
+            .mentions_type_var = mentions_type_var,
+            .introduces_type_var = introduces_type_var,
         } });
     } else {
         node.setPayload(.{ .annotation = .{
             .anno = @intFromEnum(annotation.anno),
-            .has_where = 0,
             .where_span2_idx = 0,
+            .has_where = false,
+            .mentions_type_var = mentions_type_var,
+            .introduces_type_var = introduces_type_var,
         } });
     }
 
     const nid = try store.nodes.append(store.gpa, node);
     _ = try store.regions.append(store.gpa, region);
     return @enumFromInt(@intFromEnum(nid));
+}
+
+/// Which type-variable occurrences to count when scanning an annotation.
+pub const TypeVarScan = enum {
+    /// Any type variable: a fresh introduction (`.rigid_var`) or a reference to
+    /// an enclosing-scope variable (`.rigid_var_lookup`).
+    any,
+    /// Only a type variable this annotation *introduces* (`.rigid_var`), not one
+    /// it references from an enclosing scope.
+    introduced_only,
+};
+
+/// Returns true if the type annotation mentions a type variable (a user-written
+/// var like `a`, or an anonymous open-extension var from `..`). `.any` is the
+/// pre-filter for value generalization; `.introduced_only` detects a variable the
+/// annotation introduces but cannot bind (used to reject one on a mutable `var`).
+fn typeAnnoHasTypeVar(store: *const NodeStore, anno_idx: CIR.TypeAnno.Idx, comptime scan: TypeVarScan) bool {
+    return switch (store.getTypeAnno(anno_idx)) {
+        .rigid_var => true,
+        .rigid_var_lookup => scan == .any,
+        .underscore, .lookup, .malformed => false,
+        .apply => |a| store.anyTypeAnnoHasTypeVar(a.args, scan),
+        .tag_union => |tu| store.anyTypeAnnoHasTypeVar(tu.tags, scan) or
+            (if (tu.ext) |ext| store.typeAnnoHasTypeVar(ext, scan) else false),
+        .tag => |t| store.anyTypeAnnoHasTypeVar(t.args, scan),
+        .tuple => |t| store.anyTypeAnnoHasTypeVar(t.elems, scan),
+        .record => |r| blk: {
+            for (store.sliceAnnoRecordFields(r.fields)) |field_idx| {
+                if (store.typeAnnoHasTypeVar(store.getAnnoRecordField(field_idx).ty, scan)) break :blk true;
+            }
+            break :blk if (r.ext) |ext| store.typeAnnoHasTypeVar(ext, scan) else false;
+        },
+        .@"fn" => |f| store.anyTypeAnnoHasTypeVar(f.args, scan) or store.typeAnnoHasTypeVar(f.ret, scan),
+        .parens => |p| store.typeAnnoHasTypeVar(p.anno, scan),
+    };
+}
+
+fn anyTypeAnnoHasTypeVar(store: *const NodeStore, annos: CIR.TypeAnno.Span, comptime scan: TypeVarScan) bool {
+    for (store.sliceTypeAnnos(annos)) |anno_idx| {
+        if (store.typeAnnoHasTypeVar(anno_idx, scan)) return true;
+    }
+    return false;
 }
 
 /// Adds an exposed item to the store.

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -3125,6 +3125,15 @@ fn reportPolymorphicTopLevelValues(self: *Self) std.mem.Allocator.Error!void {
         // `requires` type unifies it to a concrete type anyway.)
         if (self.varIsFunctionType(def_var)) continue;
 
+        // A generalized annotated value is a scheme, not an unresolved
+        // polymorphic value: its free variable is quantified and any
+        // static-dispatch constraint rides along as a scheme constraint (like a
+        // function `where` clause), so skip the POLYMORPHIC VALUE error. Sound at
+        // top level because after generalization every def var is generalized or
+        // concrete — none can escape to an outer rank. Uses the same predicate as
+        // the generalization decision (checkExpr) so the two never diverge.
+        if (self.isGeneralizableValueBinding(def.annotation, true)) continue;
+
         self.var_set.clearRetainingCapacity();
         if (!try self.varHasUnresolvedStaticDispatchConstraints(def_var, &self.var_set)) continue;
 
@@ -5797,7 +5806,15 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
     // out from under their surrounding context.
     const is_value_alias = is_binding_rhs and
         (expr == .e_lookup_local or expr == .e_lookup_external);
-    const should_generalize = (isFunctionDef(&self.cir.store, expr) and expr != .e_closure and !is_call_arg) or is_value_alias;
+    // An annotated value binding generalizes to its scheme; the polymorphic
+    // annotation is the opt-in. Pushing a rank lets the generalizer quantify
+    // exactly the generalizable variables — with none (e.g. a concrete
+    // annotation) the generalize call is a no-op and the value stays monomorphic.
+    // Evaluated last so `or` short-circuits past the annotation scan when this is
+    // already a generalizing function def or value alias.
+    const should_generalize = (isFunctionDef(&self.cir.store, expr) and expr != .e_closure and !is_call_arg) or
+        is_value_alias or
+        self.isGeneralizableValueBinding(expected.annotation, is_binding_rhs);
 
     // Push/pop ranks based on if we should generalize
     if (should_generalize) try env.var_pool.pushRank();
@@ -7980,6 +7997,73 @@ fn isFunctionDef(store: *const CIR.NodeStore, expr: CIR.Expr) bool {
         .e_hosted_lambda => true,
         else => false,
     };
+}
+
+/// True when a value binding generalizes to its annotated scheme: it sits in
+/// binding-RHS position (only a binding's own right-hand side qualifies; a call
+/// argument never generalizes on its own) and has an annotation introducing a
+/// type variable. The polymorphic annotation is the opt-in, honored regardless
+/// of whether the RHS does work (an expansive definition pays per-specialization
+/// — the cost the author chose by writing the scheme). Single source of truth
+/// for both the generalization decision and the top-level "POLYMORPHIC VALUE"
+/// skip, which must never diverge.
+fn isGeneralizableValueBinding(
+    self: *const Self,
+    annotation: ?CIR.Annotation.Idx,
+    is_binding_rhs: bool,
+) bool {
+    if (!is_binding_rhs) return false;
+    const annotation_idx = annotation orelse return false;
+    return self.annotationHasTypeVar(annotation_idx, .any);
+}
+
+/// Which type-variable occurrences to count when scanning an annotation.
+const TypeVarScan = enum {
+    /// Any type variable: a fresh introduction (`.rigid_var`) or a reference to
+    /// an enclosing-scope variable (`.rigid_var_lookup`).
+    any,
+    /// Only a type variable this annotation *introduces* (`.rigid_var`), not one
+    /// it references from an enclosing scope.
+    introduced_only,
+};
+
+/// Returns true if the annotation mentions a type variable (a user-written var
+/// like `a`, or an anonymous open-extension var from `..`). `.any` is the cheap,
+/// sound pre-filter for value generalization (over-triggering only costs a rank
+/// push the generalizer no-ops). `.introduced_only` detects a variable the
+/// annotation introduces but cannot bind — used to reject a polymorphic
+/// annotation on a mutable `var`.
+fn annotationHasTypeVar(self: *const Self, annotation_idx: CIR.Annotation.Idx, comptime scan: TypeVarScan) bool {
+    return self.typeAnnoHasTypeVar(self.cir.store.getAnnotation(annotation_idx).anno, scan);
+}
+
+fn typeAnnoHasTypeVar(self: *const Self, anno_idx: CIR.TypeAnno.Idx, comptime scan: TypeVarScan) bool {
+    const store = &self.cir.store;
+    return switch (store.getTypeAnno(anno_idx)) {
+        .rigid_var => true,
+        .rigid_var_lookup => scan == .any,
+        .underscore, .lookup, .malformed => false,
+        .apply => |a| self.anyTypeAnnoHasTypeVar(a.args, scan),
+        .tag_union => |tu| self.anyTypeAnnoHasTypeVar(tu.tags, scan) or
+            (if (tu.ext) |ext| self.typeAnnoHasTypeVar(ext, scan) else false),
+        .tag => |t| self.anyTypeAnnoHasTypeVar(t.args, scan),
+        .tuple => |t| self.anyTypeAnnoHasTypeVar(t.elems, scan),
+        .record => |r| blk: {
+            for (store.sliceAnnoRecordFields(r.fields)) |field_idx| {
+                if (self.typeAnnoHasTypeVar(store.getAnnoRecordField(field_idx).ty, scan)) break :blk true;
+            }
+            break :blk if (r.ext) |ext| self.typeAnnoHasTypeVar(ext, scan) else false;
+        },
+        .@"fn" => |f| self.anyTypeAnnoHasTypeVar(f.args, scan) or self.typeAnnoHasTypeVar(f.ret, scan),
+        .parens => |p| self.typeAnnoHasTypeVar(p.anno, scan),
+    };
+}
+
+fn anyTypeAnnoHasTypeVar(self: *const Self, annos: CIR.TypeAnno.Span, comptime scan: TypeVarScan) bool {
+    for (self.cir.store.sliceTypeAnnos(annos)) |anno_idx| {
+        if (self.typeAnnoHasTypeVar(anno_idx, scan)) return true;
+    }
+    return false;
 }
 
 fn exprAlwaysCrashes(self: *const Self, expr_idx: CIR.Expr.Idx) bool {

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -8013,56 +8013,7 @@ fn isGeneralizableValueBinding(
 ) bool {
     if (!is_binding_rhs) return false;
     const annotation_idx = annotation orelse return false;
-    return self.annotationHasTypeVar(annotation_idx, .any);
-}
-
-/// Which type-variable occurrences to count when scanning an annotation.
-const TypeVarScan = enum {
-    /// Any type variable: a fresh introduction (`.rigid_var`) or a reference to
-    /// an enclosing-scope variable (`.rigid_var_lookup`).
-    any,
-    /// Only a type variable this annotation *introduces* (`.rigid_var`), not one
-    /// it references from an enclosing scope.
-    introduced_only,
-};
-
-/// Returns true if the annotation mentions a type variable (a user-written var
-/// like `a`, or an anonymous open-extension var from `..`). `.any` is the cheap,
-/// sound pre-filter for value generalization (over-triggering only costs a rank
-/// push the generalizer no-ops). `.introduced_only` detects a variable the
-/// annotation introduces but cannot bind — used to reject a polymorphic
-/// annotation on a mutable `var`.
-fn annotationHasTypeVar(self: *const Self, annotation_idx: CIR.Annotation.Idx, comptime scan: TypeVarScan) bool {
-    return self.typeAnnoHasTypeVar(self.cir.store.getAnnotation(annotation_idx).anno, scan);
-}
-
-fn typeAnnoHasTypeVar(self: *const Self, anno_idx: CIR.TypeAnno.Idx, comptime scan: TypeVarScan) bool {
-    const store = &self.cir.store;
-    return switch (store.getTypeAnno(anno_idx)) {
-        .rigid_var => true,
-        .rigid_var_lookup => scan == .any,
-        .underscore, .lookup, .malformed => false,
-        .apply => |a| self.anyTypeAnnoHasTypeVar(a.args, scan),
-        .tag_union => |tu| self.anyTypeAnnoHasTypeVar(tu.tags, scan) or
-            (if (tu.ext) |ext| self.typeAnnoHasTypeVar(ext, scan) else false),
-        .tag => |t| self.anyTypeAnnoHasTypeVar(t.args, scan),
-        .tuple => |t| self.anyTypeAnnoHasTypeVar(t.elems, scan),
-        .record => |r| blk: {
-            for (store.sliceAnnoRecordFields(r.fields)) |field_idx| {
-                if (self.typeAnnoHasTypeVar(store.getAnnoRecordField(field_idx).ty, scan)) break :blk true;
-            }
-            break :blk if (r.ext) |ext| self.typeAnnoHasTypeVar(ext, scan) else false;
-        },
-        .@"fn" => |f| self.anyTypeAnnoHasTypeVar(f.args, scan) or self.typeAnnoHasTypeVar(f.ret, scan),
-        .parens => |p| self.typeAnnoHasTypeVar(p.anno, scan),
-    };
-}
-
-fn anyTypeAnnoHasTypeVar(self: *const Self, annos: CIR.TypeAnno.Span, comptime scan: TypeVarScan) bool {
-    for (self.cir.store.sliceTypeAnnos(annos)) |anno_idx| {
-        if (self.typeAnnoHasTypeVar(anno_idx, scan)) return true;
-    }
-    return false;
+    return self.cir.store.getAnnotation(annotation_idx).mentions_type_var;
 }
 
 fn exprAlwaysCrashes(self: *const Self, expr_idx: CIR.Expr.Idx) bool {
@@ -8405,7 +8356,7 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                 // body instead, so it doesn't cascade into confusing mismatches.
                 const expectation = blk: {
                     if (var_stmt.anno) |annotation_idx| {
-                        if (self.annotationHasTypeVar(annotation_idx, .introduced_only)) {
+                        if (self.cir.store.getAnnotation(annotation_idx).introduces_type_var) {
                             _ = try self.problems.appendProblem(self.gpa, .{ .polymorphic_var_annotation = .{ .region = self.cir.store.getAnnotationRegion(annotation_idx) } });
                             break :blk Expected.none();
                         }

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -3125,15 +3125,6 @@ fn reportPolymorphicTopLevelValues(self: *Self) std.mem.Allocator.Error!void {
         // `requires` type unifies it to a concrete type anyway.)
         if (self.varIsFunctionType(def_var)) continue;
 
-        // A generalized annotated value is a scheme, not an unresolved
-        // polymorphic value: its free variable is quantified and any
-        // static-dispatch constraint rides along as a scheme constraint (like a
-        // function `where` clause), so skip the POLYMORPHIC VALUE error. Sound at
-        // top level because after generalization every def var is generalized or
-        // concrete — none can escape to an outer rank. Uses the same predicate as
-        // the generalization decision (checkExpr) so the two never diverge.
-        if (self.isGeneralizableValueBinding(def.annotation, true)) continue;
-
         self.var_set.clearRetainingCapacity();
         if (!try self.varHasUnresolvedStaticDispatchConstraints(def_var, &self.var_set)) continue;
 

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -8400,10 +8400,16 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                 try self.checkPattern(var_stmt.pattern_idx, var_pattern_ctx, env);
                 const var_pattern_var: Var = ModuleEnv.varFrom(var_stmt.pattern_idx);
 
-                // Check the annotation, if it exists
+                // Check the annotation, if it exists. A mutable `var` never
+                // generalizes, so a type variable its annotation introduces can
+                // never be bound; reject such an annotation and infer from the
+                // body instead, so it doesn't cascade into confusing mismatches.
                 const expectation = blk: {
                     if (var_stmt.anno) |annotation_idx| {
-                        // Return the expectation
+                        if (self.annotationHasTypeVar(annotation_idx, .introduced_only)) {
+                            _ = try self.problems.appendProblem(self.gpa, .{ .polymorphic_var_annotation = .{ .region = self.cir.store.getAnnotationRegion(annotation_idx) } });
+                            break :blk Expected.none();
+                        }
                         break :blk Expected.fromAnnotation(annotation_idx);
                     } else {
                         break :blk Expected.none();

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -5798,12 +5798,12 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
     // generalized scheme (e.g. `shorthand = FooBar.myfunc`). Such a reference is
     // non-expansive: it performs no work and can hide no `dbg`/`expect`, so it
     // raises none of the duplicate-work or duplicate-effect concerns that motivate
-    // restricting generalization to syntactic functions. In practice the only
-    // generalized schemes are functions (numeric literals use the separate
-    // defaulting path), so this never re-generalizes numbers or tag unions. We
-    // restrict this to binding-RHS position so that bare lookups appearing as
-    // arbitrary subexpressions don't pay generalization cost or get generalized
-    // out from under their surrounding context.
+    // restricting generalization to syntactic functions. The referenced scheme is
+    // a generalized function or annotated value (numeric literals use the separate
+    // defaulting path), never a bare number or tag union. We restrict this to
+    // binding-RHS position so that bare lookups appearing as arbitrary
+    // subexpressions don't pay generalization cost or get generalized out from
+    // under their surrounding context.
     const is_value_alias = is_binding_rhs and
         (expr == .e_lookup_local or expr == .e_lookup_external);
     // An annotated value binding generalizes to its scheme; the polymorphic

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -5779,33 +5779,9 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
     const is_binding_rhs = self.checking_binding_rhs;
     self.checking_binding_rhs = false;
 
-    // Value restriction: only generalize at the inner lambda level, not the
-    // outer e_closure wrapper (which delegates to e_lambda's own checkExpr).
-    // Direct call-argument lambdas are consumed immediately, so they must not
-    // generalize independently. Doing so lets their generalized vars escape
-    // into the enclosing value via unification.
-    //
-    // We also generalize a binding whose RHS is a bare reference to an already-
-    // generalized scheme (e.g. `shorthand = FooBar.myfunc`). Such a reference is
-    // non-expansive: it performs no work and can hide no `dbg`/`expect`, so it
-    // raises none of the duplicate-work or duplicate-effect concerns that motivate
-    // restricting generalization to syntactic functions. The referenced scheme is
-    // a generalized function or annotated value (numeric literals use the separate
-    // defaulting path), never a bare number or tag union. We restrict this to
-    // binding-RHS position so that bare lookups appearing as arbitrary
-    // subexpressions don't pay generalization cost or get generalized out from
-    // under their surrounding context.
-    const is_value_alias = is_binding_rhs and
-        (expr == .e_lookup_local or expr == .e_lookup_external);
-    // An annotated value binding generalizes to its scheme; the polymorphic
-    // annotation is the opt-in. Pushing a rank lets the generalizer quantify
-    // exactly the generalizable variables — with none (e.g. a concrete
-    // annotation) the generalize call is a no-op and the value stays monomorphic.
-    // Evaluated last so `or` short-circuits past the annotation scan when this is
-    // already a generalizing function def or value alias.
-    const should_generalize = (isFunctionDef(&self.cir.store, expr) and expr != .e_closure and !is_call_arg) or
-        is_value_alias or
-        self.isGeneralizableValueBinding(expected.annotation, is_binding_rhs);
+    // Decide whether this binding generalizes — see `shouldGeneralize` for the
+    // three qualifying paths and why each is sound.
+    const should_generalize = self.shouldGeneralize(expr, expected.annotation, is_binding_rhs, is_call_arg);
 
     // Push/pop ranks based on if we should generalize
     if (should_generalize) try env.var_pool.pushRank();
@@ -7990,14 +7966,46 @@ fn isFunctionDef(store: *const CIR.NodeStore, expr: CIR.Expr) bool {
     };
 }
 
+/// Should this expression generalize in its current binding context — i.e. push
+/// a rank so the generalizer can quantify its free vars? Three independent paths
+/// qualify; they are checked in order so the annotation scan runs only when the
+/// cheaper structural checks miss:
+///
+///   - **A function def.** Generalized at the inner lambda level only, not the
+///     outer `e_closure` wrapper (which delegates to `e_lambda`'s own checkExpr),
+///     and not a direct call argument — those are consumed immediately, and
+///     generalizing one lets its vars escape into the enclosing value.
+///   - **A value alias** — a binding whose RHS is a bare reference to an already-
+///     generalized scheme (e.g. `shorthand = FooBar.myfunc`). The reference is
+///     non-expansive: it does no work and can hide no `dbg`/`expect`, so it raises
+///     none of the duplicate-work/effect concerns that restrict generalization to
+///     syntactic functions. The referenced scheme is a generalized function or
+///     annotated value (numeric literals use the separate defaulting path), never
+///     a bare number or tag union. Restricted to binding-RHS position so bare
+///     lookups in arbitrary subexpressions aren't generalized out from under their
+///     surrounding context.
+///   - **An annotated value binding** whose annotation introduces a free type var
+///     (see `isGeneralizableValueBinding`). The rank push lets the generalizer
+///     quantify exactly the generalizable vars — with none (e.g. a concrete
+///     annotation) the generalize call is a no-op and the value stays monomorphic.
+fn shouldGeneralize(
+    self: *const Self,
+    expr: CIR.Expr,
+    annotation: ?CIR.Annotation.Idx,
+    is_binding_rhs: bool,
+    is_call_arg: bool,
+) bool {
+    if (isFunctionDef(&self.cir.store, expr) and expr != .e_closure and !is_call_arg) return true;
+    if (is_binding_rhs and (expr == .e_lookup_local or expr == .e_lookup_external)) return true;
+    return self.isGeneralizableValueBinding(annotation, is_binding_rhs);
+}
+
 /// True when a value binding generalizes to its annotated scheme: it sits in
 /// binding-RHS position (only a binding's own right-hand side qualifies; a call
 /// argument never generalizes on its own) and has an annotation introducing a
 /// type variable. The polymorphic annotation is the opt-in, honored regardless
 /// of whether the RHS does work (an expansive definition pays per-specialization
-/// — the cost the author chose by writing the scheme). Single source of truth
-/// for both the generalization decision and the top-level "POLYMORPHIC VALUE"
-/// skip, which must never diverge.
+/// — the cost the author chose by writing the scheme).
 fn isGeneralizableValueBinding(
     self: *const Self,
     annotation: ?CIR.Annotation.Idx,

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -8386,9 +8386,18 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                 try self.checkPattern(var_stmt.pattern_idx, var_pattern_ctx, env);
                 const var_pattern_var: Var = ModuleEnv.varFrom(var_stmt.pattern_idx);
 
+                // A mutable `var` never generalizes, so a type variable its
+                // annotation introduces can never be bound. With no initializer
+                // there is no body to infer from, so reject the annotation and
+                // leave the pattern var free to be inferred from later
+                // reassignments instead of cascading into confusing mismatches.
                 if (var_stmt.anno) |annotation_idx| {
-                    try self.generateAnnotationType(annotation_idx, env);
-                    _ = try self.unifyInContext(ModuleEnv.varFrom(annotation_idx), var_pattern_var, env, .type_annotation);
+                    if (self.cir.store.getAnnotation(annotation_idx).introduces_type_var) {
+                        _ = try self.problems.appendProblem(self.gpa, .{ .polymorphic_var_annotation = .{ .region = self.cir.store.getAnnotationRegion(annotation_idx) } });
+                    } else {
+                        try self.generateAnnotationType(annotation_idx, env);
+                        _ = try self.unifyInContext(ModuleEnv.varFrom(annotation_idx), var_pattern_var, env, .type_annotation);
+                    }
                 }
 
                 const empty_rec = try self.freshFromContent(.{ .structure = .empty_record }, env, stmt_region);

--- a/src/check/problem.zig
+++ b/src/check/problem.zig
@@ -63,6 +63,7 @@ pub const PlatformDefNotFound = types.PlatformDefNotFound;
 pub const PlatformHostedSection = types.PlatformHostedSection;
 pub const HostedUnboxedFunction = types.HostedUnboxedFunction;
 pub const AnnotationOnlyValue = types.AnnotationOnlyValue;
+pub const PolymorphicVarAnnotation = types.PolymorphicVarAnnotation;
 pub const EffectfulTopLevel = types.EffectfulTopLevel;
 pub const EffectfulExpect = types.EffectfulExpect;
 

--- a/src/check/problem/types.zig
+++ b/src/check/problem/types.zig
@@ -40,6 +40,7 @@ pub const Problem = union(enum) {
     infinite_recursion: VarWithSnapshot,
     anonymous_recursion: VarWithSnapshot,
     polymorphic_value: VarWithSnapshot,
+    polymorphic_var_annotation: PolymorphicVarAnnotation,
     effectful_top_level: EffectfulTopLevel,
     effectful_expect: EffectfulExpect,
     annotation_only_value: AnnotationOnlyValue,
@@ -106,6 +107,13 @@ pub const HostedUnboxedFunction = struct {
 
 /// A standalone type annotation without an implementation cannot be used as a runtime value.
 pub const AnnotationOnlyValue = struct {
+    region: base.Region,
+};
+
+/// A mutable `var` whose annotation introduces an unbound type variable. A `var`
+/// is never generalized, so a free type variable in its annotation can never be
+/// bound — the variable must have a concrete type.
+pub const PolymorphicVarAnnotation = struct {
     region: base.Region,
 };
 

--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -71,6 +71,7 @@ const PlatformDefNotFound = problem_mod.PlatformDefNotFound;
 const PlatformHostedSection = problem_mod.PlatformHostedSection;
 const HostedUnboxedFunction = problem_mod.HostedUnboxedFunction;
 const AnnotationOnlyValue = problem_mod.AnnotationOnlyValue;
+const PolymorphicVarAnnotation = problem_mod.PolymorphicVarAnnotation;
 const EffectfulTopLevel = problem_mod.EffectfulTopLevel;
 const EffectfulExpect = problem_mod.EffectfulExpect;
 
@@ -824,6 +825,9 @@ pub const ReportBuilder = struct {
             },
             .polymorphic_value => |data| {
                 return self.buildPolymorphicValueReport(data);
+            },
+            .polymorphic_var_annotation => |data| {
+                return self.buildPolymorphicVarAnnotationReport(data);
             },
             .effectful_top_level => |data| {
                 return self.buildEffectfulTopLevelReport(data);
@@ -3521,6 +3525,30 @@ pub const ReportBuilder = struct {
         try report.document.addLineBreak();
         try D.renderSlice(&.{
             D.bytes("Add a value body here, or put hosted functions in a platform type module so they are published through the host boundary."),
+        }, self, &report);
+        return report;
+    }
+
+    /// Build a report for a mutable `var` whose annotation introduces an unbound
+    /// type variable.
+    fn buildPolymorphicVarAnnotationReport(self: *Self, data: PolymorphicVarAnnotation) Allocator.Error!Report {
+        var report = Report.init(self.gpa, "POLYMORPHIC VAR", .runtime_error);
+        errdefer report.deinit();
+
+        try D.renderSlice(&.{
+            D.bytes("This"),
+            D.bytes("var").withAnnotation(.inline_code),
+            D.bytes("is declared with a polymorphic type annotation, but a mutable variable must have a single concrete type:"),
+        }, self, &report);
+        try report.document.addLineBreak();
+        try self.addSourceHighlightRegion(&report, data.region);
+
+        try report.document.addLineBreak();
+        try report.document.addLineBreak();
+        try D.renderSlice(&.{
+            D.bytes("Give it a concrete type, or remove the"),
+            D.bytes("var").withAnnotation(.inline_code),
+            D.bytes("keyword to make it an immutable binding, which can be polymorphic."),
         }, self, &report);
         return report;
     }

--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -3546,9 +3546,11 @@ pub const ReportBuilder = struct {
         try report.document.addLineBreak();
         try report.document.addLineBreak();
         try D.renderSlice(&.{
-            D.bytes("Give it a concrete type, or remove the"),
+            D.bytes("Give it a concrete type, or replace the type variable with"),
+            D.bytes("_").withAnnotation(.inline_code),
+            D.bytes("to let the type be inferred from how the"),
             D.bytes("var").withAnnotation(.inline_code),
-            D.bytes("keyword to make it an immutable binding, which can be polymorphic."),
+            D.bytes("is used."),
         }, self, &report);
         return report;
     }

--- a/src/compile/cache_config.zig
+++ b/src/compile/cache_config.zig
@@ -21,8 +21,11 @@ pub const Constants = struct {
     /// Maximum cache file size (256MB)
     pub const MAX_CACHE_SIZE = 256 * 1024 * 1024;
 
-    /// Cache format version
-    pub const CACHE_VERSION = 2;
+    /// Cache format version. Folded into the module-cache version hash, so bump
+    /// this whenever the serialized layout changes in a way the automatic
+    /// top-level-field hash can't see (e.g. a node-payload layout edit).
+    /// 3: annotation node payload gained mentions/introduces-type-var flags.
+    pub const CACHE_VERSION = 3;
 };
 
 /// Configuration for the Roc cache system.

--- a/src/compile/cache_module.zig
+++ b/src/compile/cache_module.zig
@@ -7,6 +7,8 @@ const std = @import("std");
 const can = @import("can");
 const collections = @import("collections");
 
+const Constants = @import("cache_config.zig").Constants;
+
 const ModuleEnv = can.ModuleEnv;
 const Allocator = std.mem.Allocator;
 // Note: We use SHA256 instead of Blake3 because std.crypto.hash.Blake3 has a bug
@@ -19,8 +21,11 @@ const SERIALIZATION_ALIGNMENT = collections.SERIALIZATION_ALIGNMENT;
 const CACHE_MAGIC: u32 = 0x524F4343; // "ROCC" in ASCII
 
 /// Compute a version hash for a struct type using SHA256 at comptime.
-/// This hash changes when the struct layout changes, enabling automatic cache invalidation.
-fn computeVersionHash(comptime StructType: type) [32]u8 {
+/// This hash changes when the struct layout changes, enabling automatic cache
+/// invalidation. The walk only sees the top-level fields' names and type names,
+/// so changes nested inside a field's type (e.g. a node-payload layout edit)
+/// are invisible to it — bump `cache_version` to invalidate those by hand.
+fn computeVersionHash(comptime StructType: type, comptime cache_version: u32) [32]u8 {
     @setEvalBranchQuota(100000);
 
     const type_info = @typeInfo(StructType);
@@ -35,6 +40,7 @@ fn computeVersionHash(comptime StructType: type) [32]u8 {
     };
 
     var hasher = Sha256.init(.{});
+    hasher.update(std.fmt.comptimePrint("cache_v{d};", .{cache_version}));
     hasher.update(layout_str);
     var result: [32]u8 = undefined;
     hasher.final(&result);
@@ -42,7 +48,7 @@ fn computeVersionHash(comptime StructType: type) [32]u8 {
 }
 
 /// Version hash of ModuleEnv.Serialized computed at comptime
-const MODULE_ENV_VERSION_HASH: [32]u8 = computeVersionHash(ModuleEnv.Serialized);
+const MODULE_ENV_VERSION_HASH: [32]u8 = computeVersionHash(ModuleEnv.Serialized, Constants.CACHE_VERSION);
 
 /// Cache header that gets written to disk before the cached data
 pub const Header = struct {

--- a/test/snapshots/generalize_annotated_value_block_local.md
+++ b/test/snapshots/generalize_annotated_value_block_local.md
@@ -1,0 +1,152 @@
+# META
+~~~ini
+description=An annotated, non-expansive value bound inside a block (not top-level) is still a true scheme, instantiable at two different concrete types (tier-2 generalization)
+type=file
+~~~
+# SOURCE
+~~~roc
+app [main!] { pf: platform "../basic-cli/main.roc" }
+
+main! = |_| {
+    empty : List(a)
+    empty = []
+
+    nums : List(U64)
+    nums = empty
+
+    strs : List(Str)
+    strs = empty
+
+    _ = nums
+    _ = strs
+    {}
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+KwApp,OpenSquare,LowerIdent,CloseSquare,OpenCurly,LowerIdent,OpColon,KwPlatform,StringStart,StringPart,StringEnd,CloseCurly,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,OpenCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+LowerIdent,OpAssign,OpenSquare,CloseSquare,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,LowerIdent,
+Underscore,OpAssign,LowerIdent,
+Underscore,OpAssign,LowerIdent,
+OpenCurly,CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(app
+		(provides
+			(exposed-lower-ident
+				(text "main!")))
+		(record-field (name "pf")
+			(e-string
+				(e-string-part (raw "../basic-cli/main.roc"))))
+		(packages
+			(record-field (name "pf")
+				(e-string
+					(e-string-part (raw "../basic-cli/main.roc"))))))
+	(statements
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-block
+					(statements
+						(s-type-anno (name "empty")
+							(ty-apply
+								(ty (name "List"))
+								(ty-var (raw "a"))))
+						(s-decl
+							(p-ident (raw "empty"))
+							(e-list))
+						(s-type-anno (name "nums")
+							(ty-apply
+								(ty (name "List"))
+								(ty (name "U64"))))
+						(s-decl
+							(p-ident (raw "nums"))
+							(e-ident (raw "empty")))
+						(s-type-anno (name "strs")
+							(ty-apply
+								(ty (name "List"))
+								(ty (name "Str"))))
+						(s-decl
+							(p-ident (raw "strs"))
+							(e-ident (raw "empty")))
+						(s-decl
+							(p-underscore)
+							(e-ident (raw "nums")))
+						(s-decl
+							(p-underscore)
+							(e-ident (raw "strs")))
+						(e-record)))))))
+~~~
+# FORMATTED
+~~~roc
+app [main!] { pf: platform "../basic-cli/main.roc" }
+
+main! = |_| {
+	empty : List(a)
+	empty = []
+
+	nums : List(U64)
+	nums = empty
+
+	strs : List(Str)
+	strs = empty
+
+	_ = nums
+	_ = strs
+	{}
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-block
+				(s-let
+					(p-assign (ident "empty"))
+					(e-empty_list))
+				(s-let
+					(p-assign (ident "nums"))
+					(e-lookup-local
+						(p-assign (ident "empty"))))
+				(s-let
+					(p-assign (ident "strs"))
+					(e-lookup-local
+						(p-assign (ident "empty"))))
+				(s-let
+					(p-underscore)
+					(e-lookup-local
+						(p-assign (ident "nums"))))
+				(s-let
+					(p-underscore)
+					(e-lookup-local
+						(p-assign (ident "strs"))))
+				(e-empty_record)))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "_arg -> {}")))
+	(expressions
+		(expr (type "_arg -> {}"))))
+~~~

--- a/test/snapshots/generalize_annotated_value_constrained.md
+++ b/test/snapshots/generalize_annotated_value_constrained.md
@@ -1,6 +1,6 @@
 # META
 ~~~ini
-description=An annotated, non-expansive value carrying a static-dispatch where-constraint generalizes to a constrained scheme rather than erroring as a polymorphic value (tier-2)
+description=A top-level annotated value carrying a static-dispatch where-constraint is rejected as a polymorphic value, since top-level values can't have free type variables (tier-2)
 type=file
 ~~~
 # SOURCE

--- a/test/snapshots/generalize_annotated_value_constrained.md
+++ b/test/snapshots/generalize_annotated_value_constrained.md
@@ -13,9 +13,23 @@ items = []
 main! = |_| {}
 ~~~
 # EXPECTED
-NIL
+POLYMORPHIC VALUE - generalize_annotated_value_constrained.md:4:1:4:6
 # PROBLEMS
-NIL
+**POLYMORPHIC VALUE**
+This top-level value still has an unresolved polymorphic type:
+**generalize_annotated_value_constrained.md:4:1:4:6:**
+```roc
+items = []
+```
+^^^^^
+
+
+Its type is:
+```roc
+List(a) where [a.to_str : a -> Str]
+```
+Add an annotation or use this value in a way that fixes its concrete type.
+
 # TOKENS
 ~~~zig
 KwApp,OpenSquare,LowerIdent,CloseSquare,OpenCurly,LowerIdent,OpColon,KwPlatform,StringStart,StringPart,StringEnd,CloseCurly,

--- a/test/snapshots/generalize_annotated_value_constrained.md
+++ b/test/snapshots/generalize_annotated_value_constrained.md
@@ -1,0 +1,95 @@
+# META
+~~~ini
+description=An annotated, non-expansive value carrying a static-dispatch where-constraint generalizes to a constrained scheme rather than erroring as a polymorphic value (tier-2)
+type=file
+~~~
+# SOURCE
+~~~roc
+app [main!] { pf: platform "../basic-cli/main.roc" }
+
+items : List(a) where [a.to_str : a -> Str]
+items = []
+
+main! = |_| {}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+KwApp,OpenSquare,LowerIdent,CloseSquare,OpenCurly,LowerIdent,OpColon,KwPlatform,StringStart,StringPart,StringEnd,CloseCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,KwWhere,OpenSquare,LowerIdent,NoSpaceDotLowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,CloseSquare,
+LowerIdent,OpAssign,OpenSquare,CloseSquare,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,OpenCurly,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(app
+		(provides
+			(exposed-lower-ident
+				(text "main!")))
+		(record-field (name "pf")
+			(e-string
+				(e-string-part (raw "../basic-cli/main.roc"))))
+		(packages
+			(record-field (name "pf")
+				(e-string
+					(e-string-part (raw "../basic-cli/main.roc"))))))
+	(statements
+		(s-type-anno (name "items")
+			(ty-apply
+				(ty (name "List"))
+				(ty-var (raw "a")))
+			(where
+				(method (module-of "a") (name "to_str")
+					(args
+						(ty-var (raw "a")))
+					(ty (name "Str")))))
+		(s-decl
+			(p-ident (raw "items"))
+			(e-list))
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-record)))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "items"))
+		(e-empty_list)
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-rigid-var (name "a")))
+			(where
+				(method (ty-rigid-var-lookup (ty-rigid-var (name "a"))) (name "to_str")
+					(args
+						(ty-rigid-var-lookup (ty-rigid-var (name "a"))))
+					(ty-lookup (name "Str") (builtin))))))
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-empty_record))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "List(a) where [a.to_str : a -> Str]"))
+		(patt (type "_arg -> {}")))
+	(expressions
+		(expr (type "List(a) where [a.to_str : a -> Str]"))
+		(expr (type "_arg -> {}"))))
+~~~

--- a/test/snapshots/generalize_annotated_value_expansive.md
+++ b/test/snapshots/generalize_annotated_value_expansive.md
@@ -1,0 +1,160 @@
+# META
+~~~ini
+description=An annotated value with an expansive RHS (a call) is generalized to its scheme - the annotation is the opt-in, so expansiveness does not block generalization - and is usable at two concrete types
+type=file
+~~~
+# SOURCE
+~~~roc
+app [main!] { pf: platform "../basic-cli/main.roc" }
+
+identity : a -> a
+identity = |x| x
+
+made : List(a)
+made = identity([])
+
+nums : List(U64)
+nums = made
+
+strs : List(Str)
+strs = made
+
+main! = |_| {}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+KwApp,OpenSquare,LowerIdent,CloseSquare,OpenCurly,LowerIdent,OpColon,KwPlatform,StringStart,StringPart,StringEnd,CloseCurly,
+LowerIdent,OpColon,LowerIdent,OpArrow,LowerIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+LowerIdent,OpAssign,LowerIdent,NoSpaceOpenRound,OpenSquare,CloseSquare,CloseRound,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,OpenCurly,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(app
+		(provides
+			(exposed-lower-ident
+				(text "main!")))
+		(record-field (name "pf")
+			(e-string
+				(e-string-part (raw "../basic-cli/main.roc"))))
+		(packages
+			(record-field (name "pf")
+				(e-string
+					(e-string-part (raw "../basic-cli/main.roc"))))))
+	(statements
+		(s-type-anno (name "identity")
+			(ty-fn
+				(ty-var (raw "a"))
+				(ty-var (raw "a"))))
+		(s-decl
+			(p-ident (raw "identity"))
+			(e-lambda
+				(args
+					(p-ident (raw "x")))
+				(e-ident (raw "x"))))
+		(s-type-anno (name "made")
+			(ty-apply
+				(ty (name "List"))
+				(ty-var (raw "a"))))
+		(s-decl
+			(p-ident (raw "made"))
+			(e-apply
+				(e-ident (raw "identity"))
+				(e-list)))
+		(s-type-anno (name "nums")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "U64"))))
+		(s-decl
+			(p-ident (raw "nums"))
+			(e-ident (raw "made")))
+		(s-type-anno (name "strs")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "Str"))))
+		(s-decl
+			(p-ident (raw "strs"))
+			(e-ident (raw "made")))
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-record)))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "identity"))
+		(e-lambda
+			(args
+				(p-assign (ident "x")))
+			(e-lookup-local
+				(p-assign (ident "x"))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-rigid-var (name "a"))
+				(ty-rigid-var-lookup (ty-rigid-var (name "a"))))))
+	(d-let
+		(p-assign (ident "made"))
+		(e-call (constraint-fn-var 58)
+			(e-lookup-local
+				(p-assign (ident "identity")))
+			(e-empty_list))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-rigid-var (name "a")))))
+	(d-let
+		(p-assign (ident "nums"))
+		(e-lookup-local
+			(p-assign (ident "made")))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "U64") (builtin)))))
+	(d-let
+		(p-assign (ident "strs"))
+		(e-lookup-local
+			(p-assign (ident "made")))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "Str") (builtin)))))
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-empty_record))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> a"))
+		(patt (type "List(a)"))
+		(patt (type "List(U64)"))
+		(patt (type "List(Str)"))
+		(patt (type "_arg -> {}")))
+	(expressions
+		(expr (type "a -> a"))
+		(expr (type "List(a)"))
+		(expr (type "List(U64)"))
+		(expr (type "List(Str)"))
+		(expr (type "_arg -> {}"))))
+~~~

--- a/test/snapshots/generalize_annotated_value_multi_type.md
+++ b/test/snapshots/generalize_annotated_value_multi_type.md
@@ -1,0 +1,127 @@
+# META
+~~~ini
+description=An annotated, non-expansive value is a true scheme, instantiable at two different concrete types (tier-2 generalization)
+type=file
+~~~
+# SOURCE
+~~~roc
+app [main!] { pf: platform "../basic-cli/main.roc" }
+
+empty : List(a)
+empty = []
+
+nums : List(U64)
+nums = empty
+
+strs : List(Str)
+strs = empty
+
+main! = |_| {}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+KwApp,OpenSquare,LowerIdent,CloseSquare,OpenCurly,LowerIdent,OpColon,KwPlatform,StringStart,StringPart,StringEnd,CloseCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+LowerIdent,OpAssign,OpenSquare,CloseSquare,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,OpenCurly,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(app
+		(provides
+			(exposed-lower-ident
+				(text "main!")))
+		(record-field (name "pf")
+			(e-string
+				(e-string-part (raw "../basic-cli/main.roc"))))
+		(packages
+			(record-field (name "pf")
+				(e-string
+					(e-string-part (raw "../basic-cli/main.roc"))))))
+	(statements
+		(s-type-anno (name "empty")
+			(ty-apply
+				(ty (name "List"))
+				(ty-var (raw "a"))))
+		(s-decl
+			(p-ident (raw "empty"))
+			(e-list))
+		(s-type-anno (name "nums")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "U64"))))
+		(s-decl
+			(p-ident (raw "nums"))
+			(e-ident (raw "empty")))
+		(s-type-anno (name "strs")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "Str"))))
+		(s-decl
+			(p-ident (raw "strs"))
+			(e-ident (raw "empty")))
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-record)))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "empty"))
+		(e-empty_list)
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-rigid-var (name "a")))))
+	(d-let
+		(p-assign (ident "nums"))
+		(e-lookup-local
+			(p-assign (ident "empty")))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "U64") (builtin)))))
+	(d-let
+		(p-assign (ident "strs"))
+		(e-lookup-local
+			(p-assign (ident "empty")))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "Str") (builtin)))))
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-empty_record))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "List(a)"))
+		(patt (type "List(U64)"))
+		(patt (type "List(Str)"))
+		(patt (type "_arg -> {}")))
+	(expressions
+		(expr (type "List(a)"))
+		(expr (type "List(U64)"))
+		(expr (type "List(Str)"))
+		(expr (type "_arg -> {}"))))
+~~~

--- a/test/snapshots/generalize_annotated_value_nested_expansive.md
+++ b/test/snapshots/generalize_annotated_value_nested_expansive.md
@@ -1,0 +1,182 @@
+# META
+~~~ini
+description=A constructor wrapping an expansive call is generalized when annotated (expansiveness no longer blocks generalization), usable at two concrete types
+type=file
+~~~
+# SOURCE
+~~~roc
+app [main!] { pf: platform "../basic-cli/main.roc" }
+
+identity : a -> a
+identity = |x| x
+
+made : [Wrap(List(a))]
+made = Wrap(identity([]))
+
+nums : [Wrap(List(U64))]
+nums = made
+
+strs : [Wrap(List(Str))]
+strs = made
+
+main! = |_| {}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+KwApp,OpenSquare,LowerIdent,CloseSquare,OpenCurly,LowerIdent,OpColon,KwPlatform,StringStart,StringPart,StringEnd,CloseCurly,
+LowerIdent,OpColon,LowerIdent,OpArrow,LowerIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,LowerIdent,
+LowerIdent,OpColon,OpenSquare,UpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,CloseRound,CloseSquare,
+LowerIdent,OpAssign,UpperIdent,NoSpaceOpenRound,LowerIdent,NoSpaceOpenRound,OpenSquare,CloseSquare,CloseRound,CloseRound,
+LowerIdent,OpColon,OpenSquare,UpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,CloseRound,CloseSquare,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpColon,OpenSquare,UpperIdent,NoSpaceOpenRound,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,CloseRound,CloseSquare,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,OpenCurly,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(app
+		(provides
+			(exposed-lower-ident
+				(text "main!")))
+		(record-field (name "pf")
+			(e-string
+				(e-string-part (raw "../basic-cli/main.roc"))))
+		(packages
+			(record-field (name "pf")
+				(e-string
+					(e-string-part (raw "../basic-cli/main.roc"))))))
+	(statements
+		(s-type-anno (name "identity")
+			(ty-fn
+				(ty-var (raw "a"))
+				(ty-var (raw "a"))))
+		(s-decl
+			(p-ident (raw "identity"))
+			(e-lambda
+				(args
+					(p-ident (raw "x")))
+				(e-ident (raw "x"))))
+		(s-type-anno (name "made")
+			(ty-tag-union
+				(tags
+					(ty-apply
+						(ty (name "Wrap"))
+						(ty-apply
+							(ty (name "List"))
+							(ty-var (raw "a")))))))
+		(s-decl
+			(p-ident (raw "made"))
+			(e-apply
+				(e-tag (raw "Wrap"))
+				(e-apply
+					(e-ident (raw "identity"))
+					(e-list))))
+		(s-type-anno (name "nums")
+			(ty-tag-union
+				(tags
+					(ty-apply
+						(ty (name "Wrap"))
+						(ty-apply
+							(ty (name "List"))
+							(ty (name "U64")))))))
+		(s-decl
+			(p-ident (raw "nums"))
+			(e-ident (raw "made")))
+		(s-type-anno (name "strs")
+			(ty-tag-union
+				(tags
+					(ty-apply
+						(ty (name "Wrap"))
+						(ty-apply
+							(ty (name "List"))
+							(ty (name "Str")))))))
+		(s-decl
+			(p-ident (raw "strs"))
+			(e-ident (raw "made")))
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-record)))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "identity"))
+		(e-lambda
+			(args
+				(p-assign (ident "x")))
+			(e-lookup-local
+				(p-assign (ident "x"))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-rigid-var (name "a"))
+				(ty-rigid-var-lookup (ty-rigid-var (name "a"))))))
+	(d-let
+		(p-assign (ident "made"))
+		(e-tag (name "Wrap")
+			(args
+				(e-call (constraint-fn-var 68)
+					(e-lookup-local
+						(p-assign (ident "identity")))
+					(e-empty_list))))
+		(annotation
+			(ty-tag-union
+				(ty-tag-name (name "Wrap")
+					(ty-apply (name "List") (builtin)
+						(ty-rigid-var (name "a")))))))
+	(d-let
+		(p-assign (ident "nums"))
+		(e-lookup-local
+			(p-assign (ident "made")))
+		(annotation
+			(ty-tag-union
+				(ty-tag-name (name "Wrap")
+					(ty-apply (name "List") (builtin)
+						(ty-lookup (name "U64") (builtin)))))))
+	(d-let
+		(p-assign (ident "strs"))
+		(e-lookup-local
+			(p-assign (ident "made")))
+		(annotation
+			(ty-tag-union
+				(ty-tag-name (name "Wrap")
+					(ty-apply (name "List") (builtin)
+						(ty-lookup (name "Str") (builtin)))))))
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-empty_record))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> a"))
+		(patt (type "[Wrap(List(a))]"))
+		(patt (type "[Wrap(List(U64))]"))
+		(patt (type "[Wrap(List(Str))]"))
+		(patt (type "_arg -> {}")))
+	(expressions
+		(expr (type "a -> a"))
+		(expr (type "[Wrap(List(a))]"))
+		(expr (type "[Wrap(List(U64))]"))
+		(expr (type "[Wrap(List(Str))]"))
+		(expr (type "_arg -> {}"))))
+~~~

--- a/test/snapshots/generalize_annotated_value_record_function_field.md
+++ b/test/snapshots/generalize_annotated_value_record_function_field.md
@@ -1,0 +1,179 @@
+# META
+~~~ini
+description=A non-expansive value whose type embeds a function (lambda) generalizes and instantiates at two concrete record types - the RFC's lambda-set-in-scheme hazard does not arise since lambda sets are not in the type system (tier-2)
+type=file
+~~~
+# SOURCE
+~~~roc
+app [main!] { pf: platform "../basic-cli/main.roc" }
+
+rec : { f : a -> a, n : List(b) }
+rec = { f: |x| x, n: [] }
+
+r1 : { f : U64 -> U64, n : List(U64) }
+r1 = rec
+
+r2 : { f : Str -> Str, n : List(Str) }
+r2 = rec
+
+main! = |_| {}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+KwApp,OpenSquare,LowerIdent,CloseSquare,OpenCurly,LowerIdent,OpColon,KwPlatform,StringStart,StringPart,StringEnd,CloseCurly,
+LowerIdent,OpColon,OpenCurly,LowerIdent,OpColon,LowerIdent,OpArrow,LowerIdent,Comma,LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,CloseCurly,
+LowerIdent,OpAssign,OpenCurly,LowerIdent,OpColon,OpBar,LowerIdent,OpBar,LowerIdent,Comma,LowerIdent,OpColon,OpenSquare,CloseSquare,CloseCurly,
+LowerIdent,OpColon,OpenCurly,LowerIdent,OpColon,UpperIdent,OpArrow,UpperIdent,Comma,LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,CloseCurly,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpColon,OpenCurly,LowerIdent,OpColon,UpperIdent,OpArrow,UpperIdent,Comma,LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,CloseCurly,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,OpenCurly,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(app
+		(provides
+			(exposed-lower-ident
+				(text "main!")))
+		(record-field (name "pf")
+			(e-string
+				(e-string-part (raw "../basic-cli/main.roc"))))
+		(packages
+			(record-field (name "pf")
+				(e-string
+					(e-string-part (raw "../basic-cli/main.roc"))))))
+	(statements
+		(s-type-anno (name "rec")
+			(ty-record
+				(anno-record-field (name "f")
+					(ty-fn
+						(ty-var (raw "a"))
+						(ty-var (raw "a"))))
+				(anno-record-field (name "n")
+					(ty-apply
+						(ty (name "List"))
+						(ty-var (raw "b"))))))
+		(s-decl
+			(p-ident (raw "rec"))
+			(e-record
+				(field (field "f")
+					(e-lambda
+						(args
+							(p-ident (raw "x")))
+						(e-ident (raw "x"))))
+				(field (field "n")
+					(e-list))))
+		(s-type-anno (name "r1")
+			(ty-record
+				(anno-record-field (name "f")
+					(ty-fn
+						(ty (name "U64"))
+						(ty (name "U64"))))
+				(anno-record-field (name "n")
+					(ty-apply
+						(ty (name "List"))
+						(ty (name "U64"))))))
+		(s-decl
+			(p-ident (raw "r1"))
+			(e-ident (raw "rec")))
+		(s-type-anno (name "r2")
+			(ty-record
+				(anno-record-field (name "f")
+					(ty-fn
+						(ty (name "Str"))
+						(ty (name "Str"))))
+				(anno-record-field (name "n")
+					(ty-apply
+						(ty (name "List"))
+						(ty (name "Str"))))))
+		(s-decl
+			(p-ident (raw "r2"))
+			(e-ident (raw "rec")))
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-record)))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "rec"))
+		(e-record
+			(fields
+				(field (name "f")
+					(e-lambda
+						(args
+							(p-assign (ident "x")))
+						(e-lookup-local
+							(p-assign (ident "x")))))
+				(field (name "n")
+					(e-empty_list))))
+		(annotation
+			(ty-record
+				(field (field "f")
+					(ty-fn (effectful false)
+						(ty-rigid-var (name "a"))
+						(ty-rigid-var-lookup (ty-rigid-var (name "a")))))
+				(field (field "n")
+					(ty-apply (name "List") (builtin)
+						(ty-rigid-var (name "b")))))))
+	(d-let
+		(p-assign (ident "r1"))
+		(e-lookup-local
+			(p-assign (ident "rec")))
+		(annotation
+			(ty-record
+				(field (field "f")
+					(ty-fn (effectful false)
+						(ty-lookup (name "U64") (builtin))
+						(ty-lookup (name "U64") (builtin))))
+				(field (field "n")
+					(ty-apply (name "List") (builtin)
+						(ty-lookup (name "U64") (builtin)))))))
+	(d-let
+		(p-assign (ident "r2"))
+		(e-lookup-local
+			(p-assign (ident "rec")))
+		(annotation
+			(ty-record
+				(field (field "f")
+					(ty-fn (effectful false)
+						(ty-lookup (name "Str") (builtin))
+						(ty-lookup (name "Str") (builtin))))
+				(field (field "n")
+					(ty-apply (name "List") (builtin)
+						(ty-lookup (name "Str") (builtin)))))))
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-empty_record))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "{ f: a -> a, n: List(b) }"))
+		(patt (type "{ f: U64 -> U64, n: List(U64) }"))
+		(patt (type "{ f: Str -> Str, n: List(Str) }"))
+		(patt (type "_arg -> {}")))
+	(expressions
+		(expr (type "{ f: a -> a, n: List(b) }"))
+		(expr (type "{ f: U64 -> U64, n: List(U64) }"))
+		(expr (type "{ f: Str -> Str, n: List(Str) }"))
+		(expr (type "_arg -> {}"))))
+~~~

--- a/test/snapshots/generalize_annotated_value_tag_widening.md
+++ b/test/snapshots/generalize_annotated_value_tag_widening.md
@@ -1,0 +1,116 @@
+# META
+~~~ini
+description=An annotated, non-expansive value generalizes its extension variable, so it is usable at a wider tag union (tier-2 generalization)
+type=file
+~~~
+# SOURCE
+~~~roc
+app [main!] { pf: platform "../basic-cli/main.roc" }
+
+f : [Red, Green, ..]
+f = Red
+
+g : [Red, Green, Blue, ..]
+g = f
+
+main! = |_| {}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+KwApp,OpenSquare,LowerIdent,CloseSquare,OpenCurly,LowerIdent,OpColon,KwPlatform,StringStart,StringPart,StringEnd,CloseCurly,
+LowerIdent,OpColon,OpenSquare,UpperIdent,Comma,UpperIdent,Comma,DoubleDot,CloseSquare,
+LowerIdent,OpAssign,UpperIdent,
+LowerIdent,OpColon,OpenSquare,UpperIdent,Comma,UpperIdent,Comma,UpperIdent,Comma,DoubleDot,CloseSquare,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,OpenCurly,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(app
+		(provides
+			(exposed-lower-ident
+				(text "main!")))
+		(record-field (name "pf")
+			(e-string
+				(e-string-part (raw "../basic-cli/main.roc"))))
+		(packages
+			(record-field (name "pf")
+				(e-string
+					(e-string-part (raw "../basic-cli/main.roc"))))))
+	(statements
+		(s-type-anno (name "f")
+			(ty-tag-union
+				(tags
+					(ty (name "Red"))
+					(ty (name "Green")))
+				..))
+		(s-decl
+			(p-ident (raw "f"))
+			(e-tag (raw "Red")))
+		(s-type-anno (name "g")
+			(ty-tag-union
+				(tags
+					(ty (name "Red"))
+					(ty (name "Green"))
+					(ty (name "Blue")))
+				..))
+		(s-decl
+			(p-ident (raw "g"))
+			(e-ident (raw "f")))
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-record)))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "f"))
+		(e-tag (name "Red"))
+		(annotation
+			(ty-tag-union
+				(ty-tag-name (name "Red"))
+				(ty-tag-name (name "Green"))
+				(ty-rigid-var (name "#others")))))
+	(d-let
+		(p-assign (ident "g"))
+		(e-lookup-local
+			(p-assign (ident "f")))
+		(annotation
+			(ty-tag-union
+				(ty-tag-name (name "Red"))
+				(ty-tag-name (name "Green"))
+				(ty-tag-name (name "Blue"))
+				(ty-rigid-var (name "#others")))))
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-empty_record))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "[Green, Red, ..]"))
+		(patt (type "[Blue, Green, Red, ..]"))
+		(patt (type "_arg -> {}")))
+	(expressions
+		(expr (type "[Green, Red, ..]"))
+		(expr (type "[Blue, Green, Red, ..]"))
+		(expr (type "_arg -> {}"))))
+~~~

--- a/test/snapshots/generalize_annotated_value_unannotated_not_generalized.md
+++ b/test/snapshots/generalize_annotated_value_unannotated_not_generalized.md
@@ -1,0 +1,131 @@
+# META
+~~~ini
+description=An UNANNOTATED non-expansive value is not generalized (annotation is the opt-in), so using it at two concrete types is a type mismatch (tier-2 gate)
+type=file
+~~~
+# SOURCE
+~~~roc
+app [main!] { pf: platform "../basic-cli/main.roc" }
+
+bare = []
+
+nums : List(U64)
+nums = bare
+
+strs : List(Str)
+strs = bare
+
+main! = |_| {}
+~~~
+# EXPECTED
+TYPE MISMATCH - generalize_annotated_value_unannotated_not_generalized.md:9:8:9:12
+# PROBLEMS
+**TYPE MISMATCH**
+This expression is used in an unexpected way:
+**generalize_annotated_value_unannotated_not_generalized.md:9:8:9:12:**
+```roc
+strs = bare
+```
+       ^^^^
+
+It has the type:
+
+    List(U64)
+
+But the annotation say it should be:
+
+    List(Str)
+
+# TOKENS
+~~~zig
+KwApp,OpenSquare,LowerIdent,CloseSquare,OpenCurly,LowerIdent,OpColon,KwPlatform,StringStart,StringPart,StringEnd,CloseCurly,
+LowerIdent,OpAssign,OpenSquare,CloseSquare,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,OpenCurly,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(app
+		(provides
+			(exposed-lower-ident
+				(text "main!")))
+		(record-field (name "pf")
+			(e-string
+				(e-string-part (raw "../basic-cli/main.roc"))))
+		(packages
+			(record-field (name "pf")
+				(e-string
+					(e-string-part (raw "../basic-cli/main.roc"))))))
+	(statements
+		(s-decl
+			(p-ident (raw "bare"))
+			(e-list))
+		(s-type-anno (name "nums")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "U64"))))
+		(s-decl
+			(p-ident (raw "nums"))
+			(e-ident (raw "bare")))
+		(s-type-anno (name "strs")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "Str"))))
+		(s-decl
+			(p-ident (raw "strs"))
+			(e-ident (raw "bare")))
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-record)))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "bare"))
+		(e-empty_list))
+	(d-let
+		(p-assign (ident "nums"))
+		(e-runtime-error (tag "erroneous_value_use"))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "U64") (builtin)))))
+	(d-let
+		(p-assign (ident "strs"))
+		(e-runtime-error (tag "erroneous_value_use"))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "Str") (builtin)))))
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-empty_record))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Error"))
+		(patt (type "Error"))
+		(patt (type "List(Str)"))
+		(patt (type "_arg -> {}")))
+	(expressions
+		(expr (type "Error"))
+		(expr (type "Error"))
+		(expr (type "List(Str)"))
+		(expr (type "_arg -> {}"))))
+~~~

--- a/test/snapshots/var_polymorphic_annotation_rejected.md
+++ b/test/snapshots/var_polymorphic_annotation_rejected.md
@@ -1,0 +1,126 @@
+# META
+~~~ini
+description=A mutable var whose annotation introduces an unbound type variable is rejected (a var must have a concrete type)
+type=file
+~~~
+# SOURCE
+~~~roc
+app [main!] { pf: platform "../basic-cli/main.roc" }
+
+main! = |_| {
+    xs : List(a)
+    var xs = []
+    xs = [1]
+    {}
+}
+~~~
+# EXPECTED
+UNUSED VARIABLE - var_polymorphic_annotation_rejected.md:5:5:5:16
+POLYMORPHIC VAR - var_polymorphic_annotation_rejected.md:4:5:4:17
+# PROBLEMS
+**UNUSED VARIABLE**
+Variable `xs` is not used anywhere in your code.
+
+If you don't need this variable, prefix it with an underscore like `_xs` to suppress this warning.
+The unused variable is declared here:
+**var_polymorphic_annotation_rejected.md:5:5:5:16:**
+```roc
+    var xs = []
+```
+    ^^^^^^^^^^^
+
+
+**POLYMORPHIC VAR**
+This `var` is declared with a polymorphic type annotation, but a mutable variable must have a single concrete type:
+**var_polymorphic_annotation_rejected.md:4:5:4:17:**
+```roc
+    xs : List(a)
+```
+    ^^^^^^^^^^^^
+
+
+Give it a concrete type, or remove the `var` keyword to make it an immutable binding, which can be polymorphic.
+
+# TOKENS
+~~~zig
+KwApp,OpenSquare,LowerIdent,CloseSquare,OpenCurly,LowerIdent,OpColon,KwPlatform,StringStart,StringPart,StringEnd,CloseCurly,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,OpenCurly,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+KwVar,LowerIdent,OpAssign,OpenSquare,CloseSquare,
+LowerIdent,OpAssign,OpenSquare,Int,CloseSquare,
+OpenCurly,CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(app
+		(provides
+			(exposed-lower-ident
+				(text "main!")))
+		(record-field (name "pf")
+			(e-string
+				(e-string-part (raw "../basic-cli/main.roc"))))
+		(packages
+			(record-field (name "pf")
+				(e-string
+					(e-string-part (raw "../basic-cli/main.roc"))))))
+	(statements
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-block
+					(statements
+						(s-type-anno (name "xs")
+							(ty-apply
+								(ty (name "List"))
+								(ty-var (raw "a"))))
+						(s-var (name "xs")
+							(e-list))
+						(s-decl
+							(p-ident (raw "xs"))
+							(e-list
+								(e-int (raw "1"))))
+						(e-record)))))))
+~~~
+# FORMATTED
+~~~roc
+app [main!] { pf: platform "../basic-cli/main.roc" }
+
+main! = |_| {
+	xs : List(a)
+	var xs = []
+	xs = [1]
+	{}
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-block
+				(s-var
+					(p-assign (ident "xs"))
+					(e-empty_list))
+				(s-reassign
+					(p-assign (ident "xs"))
+					(e-list
+						(elems
+							(e-num (value "1")))))
+				(e-empty_record)))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "_arg -> {}")))
+	(expressions
+		(expr (type "_arg -> {}"))))
+~~~

--- a/test/snapshots/var_polymorphic_annotation_uninitialized_rejected.md
+++ b/test/snapshots/var_polymorphic_annotation_uninitialized_rejected.md
@@ -1,6 +1,6 @@
 # META
 ~~~ini
-description=A mutable var whose annotation introduces an unbound type variable is rejected (a var must have a concrete type)
+description=An uninitialized mutable var whose annotation introduces an unbound type variable is rejected, suggesting `_` to infer the type instead
 type=file
 ~~~
 # SOURCE
@@ -8,35 +8,33 @@ type=file
 app [main!] { pf: platform "../basic-cli/main.roc" }
 
 main! = |_| {
-    xs : List(a)
-    var xs = []
-    xs = [1]
+    var xs : List(a)
     {}
 }
 ~~~
 # EXPECTED
-UNUSED VARIABLE - var_polymorphic_annotation_rejected.md:5:5:5:16
-POLYMORPHIC VAR - var_polymorphic_annotation_rejected.md:4:5:4:17
+UNUSED VARIABLE - var_polymorphic_annotation_uninitialized_rejected.md:4:5:4:21
+POLYMORPHIC VAR - var_polymorphic_annotation_uninitialized_rejected.md:4:5:4:21
 # PROBLEMS
 **UNUSED VARIABLE**
 Variable `xs` is not used anywhere in your code.
 
 If you don't need this variable, prefix it with an underscore like `_xs` to suppress this warning.
 The unused variable is declared here:
-**var_polymorphic_annotation_rejected.md:5:5:5:16:**
+**var_polymorphic_annotation_uninitialized_rejected.md:4:5:4:21:**
 ```roc
-    var xs = []
+    var xs : List(a)
 ```
-    ^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^
 
 
 **POLYMORPHIC VAR**
 This `var` is declared with a polymorphic type annotation, but a mutable variable must have a single concrete type:
-**var_polymorphic_annotation_rejected.md:4:5:4:17:**
+**var_polymorphic_annotation_uninitialized_rejected.md:4:5:4:21:**
 ```roc
-    xs : List(a)
+    var xs : List(a)
 ```
-    ^^^^^^^^^^^^
+    ^^^^^^^^^^^^^^^^
 
 
 Give it a concrete type, or replace the type variable with `_` to let the type be inferred from how the `var` is used.
@@ -45,9 +43,7 @@ Give it a concrete type, or replace the type variable with `_` to let the type b
 ~~~zig
 KwApp,OpenSquare,LowerIdent,CloseSquare,OpenCurly,LowerIdent,OpColon,KwPlatform,StringStart,StringPart,StringEnd,CloseCurly,
 LowerIdent,OpAssign,OpBar,Underscore,OpBar,OpenCurly,
-LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
-KwVar,LowerIdent,OpAssign,OpenSquare,CloseSquare,
-LowerIdent,OpAssign,OpenSquare,Int,CloseSquare,
+KwVar,LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
 OpenCurly,CloseCurly,
 CloseCurly,
 EndOfFile,
@@ -78,12 +74,6 @@ EndOfFile,
 							(ty-apply
 								(ty (name "List"))
 								(ty-var (raw "a"))))
-						(s-var (name "xs")
-							(e-list))
-						(s-decl
-							(p-ident (raw "xs"))
-							(e-list
-								(e-int (raw "1"))))
 						(e-record)))))))
 ~~~
 # FORMATTED
@@ -91,9 +81,7 @@ EndOfFile,
 app [main!] { pf: platform "../basic-cli/main.roc" }
 
 main! = |_| {
-	xs : List(a)
-	var xs = []
-	xs = [1]
+	var xs : List(a)
 	{}
 }
 ~~~
@@ -106,14 +94,8 @@ main! = |_| {
 			(args
 				(p-underscore))
 			(e-block
-				(s-var
-					(p-assign (ident "xs"))
-					(e-empty_list))
-				(s-reassign
-					(p-assign (ident "xs"))
-					(e-list
-						(elems
-							(e-num (value "1")))))
+				(s-var-uninitialized
+					(p-assign (ident "xs")))
 				(e-empty_record)))))
 ~~~
 # TYPES


### PR DESCRIPTION
## Summary

Implements "Tier 2" value generalization in the type checker: an annotated value binding whose annotation introduces a free type variable is treated as a true polymorphic type scheme rather than getting stuck as an un-quantified rigid. The annotation is the sole opt-in — an unannotated value is still value-restricted, exactly as before.

This fixes a class of type mismatches. Today these fail:

```roc
fn = || {
  f : [Red, Green, ..]
  f = Red

  g : [Red, Green, Blue, ..]
  g = f # type mismatch,  the `..` rigid extension can't widen

  empty : List(a)
  empty = []

  nums : List(U64)
  nums = empty   # Same as above
}
```

Both now type-check.

## Motivation / current state

Before this change, `f` above becomes `[Red, Green, ..a]`, where `a` is a rigid var. Because `f` is never generalized nor instantiated, the `rigid` constrains it and `f` can never really be used. So either:

* A: `f` is generalized, so `a` can be instantiated
* B: `f` is disallowed

This PR chooses A. The core idea: if a user writes a type annotation with an unbound variable, they _intended_ it to be polymorphic. All non-annotated let-defs stay value-restricted. This diverges slightly from the [Let's Not RFC](https://github.com/seanpm2001/Roc-Lang_RFCs/blob/main/0010-let-generalization-lets-not.md), under which the examples above would instead emit a `POLYMORPHIC VALUE` error.

The base motivating example from the original RFC is still solved, because the relevant let-def is unannotated:

```python
chomp_while : (U8 -> Bool), (List U8) -> (List U8)
chomp_while = |while, input| {
	index = input.fold_until(0, |i, _| if while i { Continue(i + 1) } else { Break i })

	if index == 0 {
	    input
	} else {
	    input.drop_first(index)
  }
}
```

Here `index` is value-restricted, and is constrained to `U64` by `drop_first` _before_ it can be defaulted to `Dec`. The pathological case only reappears if the user explicitly annotates `index` with a polymorphic numeral type, which seems very unlikely in practice. (If we later decide that should be impossible, the `POLYMORPHIC VALUE` error could be extended to local defs too.)

## Improved Var polymorphic error message

Previously, it was possible to assign a `var` To be a polymorphic type, but this would not actually work when you try to use it with anything because it would hit the static error outlined above. In this PR, we introduce a new custom error message for this case along with a tip:

```
POLYMORPHIC VAR
  This `var` is declared with a polymorphic type annotation, but a mutable
  variable must have a single concrete type:

      var xs : List(a)
      ^^^^^^^^^^^^^^^^

  Give it a concrete type, or replace the type variable with `_` to let the
  type be inferred from how the `var` is used.
```
