### PR TITLE
Restore the rockin' roc repl greeting and prompt

### DIFF
--- a/src/cli/ReplLine.zig
+++ b/src/cli/ReplLine.zig
@@ -244,6 +244,9 @@ const LineState = struct {
     in_buffer: [8]u8,
     history: *History,
     history_index: ?usize,
+    /// Set after a Ctrl-C so that a second consecutive Ctrl-C quits. Any other
+    /// input event clears it, so the two presses must be back-to-back.
+    ctrl_c_armed: bool,
 };
 
 fn printChar(state: *LineState) CommandError!void {
@@ -283,15 +286,21 @@ fn acceptLine(_: *LineState) CommandError!void {
     return error.NewLine;
 }
 
-fn cancelLine(state: *LineState) CommandError!void {
-    // Clear the buffer and reset cursor position
+fn handleCtrlC(state: *LineState) CommandError!void {
+    // Discard whatever was on the current line.
     state.line_buffer.clearAndFree(state.temp);
     state.col_offset = 0;
+    state.history_index = null;
 
-    // Move cursor to start of line, print prompt, clear rest of line
-    try ansi_term.setCursorColumn(state.out, 0);
+    // A second consecutive Ctrl-C (with no other input in between) quits.
+    if (state.ctrl_c_armed) return error.ExitRepl;
+    state.ctrl_c_armed = true;
+
+    // Move to a fresh line, show the hint, and redraw the prompt.
+    try state.out.writeAll(NEW_LINE);
+    try state.out.writeAll("Ctrl-C again to quit (or enter :quit, :q, or :exit)");
+    try state.out.writeAll(NEW_LINE);
     try state.out.writeAll(state.prompt);
-    try ansi_term.clearFromCursorToLineEnd(state.out);
     try ansi_term.setCursorColumn(state.out, state.prompt_width);
 }
 
@@ -367,7 +376,7 @@ fn findCommandFn(state: *LineState) CommandFn {
         ansi_term.BACKSPACE => deleteBefore,
         ansi_term.ctrlKey('D') => exitRepl,
         ansi_term.ctrlKey('L') => clearScreen,
-        ansi_term.ctrlKey('C') => cancelLine,
+        ansi_term.ctrlKey('C') => handleCtrlC,
         control_code.lf, control_code.cr => acceptLine,
         control_code.esc => {
             if (state.bytes_read >= 3 and state.in_buffer[1] == '[') {
@@ -485,6 +494,7 @@ fn helper(self: *ReplLine, outlive: Allocator, std_io: std.Io, prompt: []const u
         .in_buffer = undefined,
         .history = &self.history,
         .history_index = null,
+        .ctrl_c_armed = false,
     };
 
     const old = switch (SUPPORTED_OS) {
@@ -527,6 +537,14 @@ fn helper(self: *ReplLine, outlive: Allocator, std_io: std.Io, prompt: []const u
 
         var done = false;
         for (events.items) |event| {
+            // The Ctrl-C "press again to quit" arming only survives consecutive
+            // Ctrl-C presses; any other input event disarms it.
+            const is_ctrl_c = switch (event) {
+                .byte => |b| b == ansi_term.ctrlKey('C'),
+                else => false,
+            };
+            if (!is_ctrl_c) state.ctrl_c_armed = false;
+
             switch (event) {
                 .byte => |b| {
                     state.in_buffer[0] = b;

--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -111,6 +111,7 @@ pub fn stepWithConfig(self: *ReplSession, input: []const u8, report_config: repo
     if (std.mem.eql(u8, line, ":help")) return .{ .output = try self.helpText() };
     if (std.mem.eql(u8, line, ":exit") or
         std.mem.eql(u8, line, ":quit") or
+        std.mem.eql(u8, line, ":q") or
         std.mem.eql(u8, line, "exit"))
     {
         return .exit;
@@ -260,9 +261,8 @@ fn helpText(self: *ReplSession) Allocator.Error![]u8 {
         \\Enter an expression or definition.
         \\
         \\Commands:
-        \\  :help    Show this help
-        \\  :exit    Exit the REPL
-        \\  :quit    Exit the REPL
+        \\  :help               Show this help
+        \\  :quit, :q, :exit    Exit the REPL
         \\
     );
 }

--- a/src/cli/ansi_term.zig
+++ b/src/cli/ansi_term.zig
@@ -1,6 +1,7 @@
 //! ANSI terminal escape sequence utilities for cursor control and screen manipulation.
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const control_code = std.ascii.control_code;
 
 const CSI = "\x1B[";
 
@@ -65,13 +66,45 @@ pub fn queryCursorPosition(out: *std.Io.Writer) Allocator.Error!void {
     try out.writeAll(CSI ++ "6n");
 }
 
-/// Computes the display width of a UTF-8 string by counting codepoints.
+/// Computes the display width of a UTF-8 string by counting codepoints, skipping
+/// ANSI CSI escape sequences (e.g. color codes) since they occupy no columns.
 pub fn computeDisplayWidth(prompt: []const u8) (Allocator.Error || error{InvalidUtf8})!usize {
     var utf8 = try std.unicode.Utf8View.init(prompt);
     var it = utf8.iterator();
     var width: usize = 0;
-    while (it.nextCodepointSlice()) |_| {
+    while (it.nextCodepointSlice()) |slice| {
+        if (slice.len == 1 and slice[0] == control_code.esc) {
+            // Skip a CSI sequence: ESC '[' params... final-byte (0x40-0x7E).
+            if (it.nextCodepointSlice()) |bracket| {
+                if (bracket.len == 1 and bracket[0] == '[') {
+                    while (it.nextCodepointSlice()) |seq| {
+                        if (seq.len == 1 and seq[0] >= 0x40 and seq[0] <= 0x7E) break;
+                    }
+                    continue;
+                }
+                // Not a CSI sequence; count the consumed codepoint normally.
+                width += 1;
+                continue;
+            }
+            continue;
+        }
         width += 1;
     }
     return width;
+}
+
+const testing = std.testing;
+
+test "computeDisplayWidth: plain ascii" {
+    try testing.expectEqual(@as(usize, 2), try computeDisplayWidth("» "));
+}
+
+test "computeDisplayWidth: skips ANSI color codes" {
+    // The cyan REPL prompt: ESC[1;36m » ESC[0m space — visible width is 2.
+    try testing.expectEqual(@as(usize, 2), try computeDisplayWidth("\x1b[1;36m»\x1b[0m "));
+    try testing.expectEqual(@as(usize, 2), try computeDisplayWidth("\x1b[1;36m…\x1b[0m "));
+}
+
+test "computeDisplayWidth: lone ESC not followed by bracket counts following codepoint" {
+    try testing.expectEqual(@as(usize, 1), try computeDisplayWidth("\x1bx"));
 }

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -6979,6 +6979,17 @@ const ReplMode = enum {
     batch,
 };
 
+// The colorful "rockin' roc repl" greeting and prompts. The colored variants
+// embed ANSI cyan (`\x1b[1;36m`) reset (`\x1b[0m`) sequences; the plain variants
+// are used when color is disabled (e.g. NO_COLOR or `--no-color`).
+const REPL_WELCOME_COLOR = "\n  The rockin' \x1b[1;36mroc repl\n────────────────────────\x1b[0m\n\n";
+const REPL_WELCOME_PLAIN = "\n  The rockin' roc repl\n────────────────────────\n\n";
+const REPL_SHORT_INSTRUCTIONS = "Enter an expression, or :help, or :q to quit.\n\n";
+const REPL_PROMPT_COLOR = "\x1b[1;36m»\x1b[0m ";
+const REPL_PROMPT_PLAIN = "» ";
+const REPL_CONT_PROMPT_COLOR = "\x1b[1;36m…\x1b[0m ";
+const REPL_CONT_PROMPT_PLAIN = "… ";
+
 fn rocRepl(ctx: *CliCtx, repl_args: cli_args.ReplArgs) anyerror!void {
     const stdout = ctx.io.stdout();
     const backend_kind = repl_args.opt.toBackend();
@@ -6988,16 +6999,37 @@ fn rocRepl(ctx: *CliCtx, repl_args: cli_args.ReplArgs) anyerror!void {
     const mode: ReplMode = if (stdin_is_tty and stdout_is_tty) .interactive else .batch;
     const report_config = try replReportingConfig(ctx, repl_args, mode);
 
-    if (mode == .interactive) {
-        try stdout.writeAll("Roc REPL\nType :help for commands.\n");
-        ctx.io.flush();
+    const no_color_env = try envVarNonEmpty(ctx.gpa, "NO_COLOR");
+    const use_color = mode == .interactive and !repl_args.no_color and !no_color_env;
+
+    // The line editor handles Ctrl-C itself (press twice in a row to quit).
+    // Ignore SIGINT at the process level so a Ctrl-C while the terminal is
+    // momentarily in cooked mode — during startup or while evaluating — can't
+    // hard-kill the REPL instead of going through that flow.
+    if (mode == .interactive and builtin.os.tag != .windows) {
+        const ignore_sigint = std.posix.Sigaction{
+            .handler = .{ .handler = std.posix.SIG.IGN },
+            .mask = std.posix.sigemptyset(),
+            .flags = 0,
+        };
+        std.posix.sigaction(std.posix.SIG.INT, &ignore_sigint, null);
     }
 
     var reader = ReplLine.init(ctx.gpa);
     defer reader.deinit();
 
+    // Publishing the Builtin module here is the dominant startup cost (~1s). Do
+    // it before printing the greeting so the greeting and the first prompt appear
+    // together and the REPL is immediately interactive — otherwise the greeting
+    // shows with no prompt until this finishes.
     var session = try ReplSession.init(ctx.gpa, ctx.io.std_io, backend_kind);
     defer session.deinit();
+
+    if (mode == .interactive) {
+        try stdout.writeAll(if (use_color) REPL_WELCOME_COLOR else REPL_WELCOME_PLAIN);
+        try stdout.writeAll(REPL_SHORT_INSTRUCTIONS);
+        ctx.io.flush();
+    }
 
     var pending = std.ArrayList(u8).empty;
     defer pending.deinit(ctx.gpa);
@@ -7006,7 +7038,10 @@ fn rocRepl(ctx: *CliCtx, repl_args: cli_args.ReplArgs) anyerror!void {
     var had_diagnostics = false;
     while (!should_exit) {
         const prompt: []const u8 = if (mode == .interactive)
-            if (pending.items.len == 0) "> " else "| "
+            if (pending.items.len == 0)
+                (if (use_color) REPL_PROMPT_COLOR else REPL_PROMPT_PLAIN)
+            else
+                (if (use_color) REPL_CONT_PROMPT_COLOR else REPL_CONT_PROMPT_PLAIN)
         else
             "";
 
@@ -7014,10 +7049,8 @@ fn rocRepl(ctx: *CliCtx, repl_args: cli_args.ReplArgs) anyerror!void {
         switch (read_result) {
             .eof => {
                 if (pending.items.len > 0) {
-                    should_exit = try processReplInput(ctx, &session, pending.items, report_config, mode, &had_diagnostics);
+                    should_exit = try processReplInput(ctx, &session, pending.items, report_config, &had_diagnostics);
                     pending.clearRetainingCapacity();
-                } else if (mode == .interactive) {
-                    try stdout.writeAll("Goodbye!\n");
                 }
                 break;
             },
@@ -7029,7 +7062,7 @@ fn rocRepl(ctx: *CliCtx, repl_args: cli_args.ReplArgs) anyerror!void {
                 }
 
                 if (pending.items.len == 0 and std.mem.findAny(u8, raw_line, "\n\r") != null) {
-                    should_exit = try processReplInput(ctx, &session, raw_line, report_config, mode, &had_diagnostics);
+                    should_exit = try processReplInput(ctx, &session, raw_line, report_config, &had_diagnostics);
                     continue;
                 }
 
@@ -7039,7 +7072,7 @@ fn rocRepl(ctx: *CliCtx, repl_args: cli_args.ReplArgs) anyerror!void {
                 switch (try session.inputStatus(pending.items)) {
                     .incomplete => {},
                     .complete, .invalid => {
-                        should_exit = try processReplInput(ctx, &session, pending.items, report_config, mode, &had_diagnostics);
+                        should_exit = try processReplInput(ctx, &session, pending.items, report_config, &had_diagnostics);
                         pending.clearRetainingCapacity();
                     },
                 }
@@ -7058,7 +7091,6 @@ fn processReplInput(
     session: *ReplSession,
     input: []const u8,
     report_config: reporting.ReportingConfig,
-    mode: ReplMode,
     had_diagnostics: *bool,
 ) anyerror!bool {
     const stdout = ctx.io.stdout();
@@ -7084,12 +7116,7 @@ fn processReplInput(
                 }
             },
             .none => {},
-            .exit => {
-                if (mode == .interactive) {
-                    try stdout.writeAll("Goodbye!\n");
-                }
-                return true;
-            },
+            .exit => return true,
         }
     }
 


### PR DESCRIPTION
The `roc repl` greeting and prompt now match the old REPL: it prints the colorful "The rockin' roc repl" banner with the cyan `roc repl` and box-drawing rule, followed by the short instructions, and uses the cyan `»` primary prompt and `…` continuation prompt. Color is stripped when `NO_COLOR` or `--no-color` is set, and `computeDisplayWidth` now skips ANSI escape sequences so the colored prompt's cursor positioning stays correct.

The Builtin module is now published before the greeting is printed. Previously the greeting appeared instantly but the first prompt lagged ~1-2s behind while builtins were published, so the REPL looked like it had a greeting with no prompt; now they appear together and it's immediately interactive.

Ctrl-C at the prompt prints `Ctrl-C again to quit (or enter :quit, :q, or :exit)` and discards the current line; a second consecutive Ctrl-C quits, and any other input in between resets it. SIGINT is ignored for the interactive session so a Ctrl-C during startup or evaluation (when the terminal is briefly in cooked mode) can't hard-kill the REPL. `:q` is accepted as a quit alias alongside `:quit`/`:exit`, and the `Goodbye!` message on quit is removed.