### PR TITLE
Fix dropped closure captures and TCE capture seeding (#9634)

### DIFF
--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -104,5 +104,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/type_printing_bug_test.zig"));
     std.testing.refAllDecls(@import("test/embedding_smoke.zig"));
     std.testing.refAllDecls(@import("test/issue_9614_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_9634_test.zig"));
+    std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/url_package_test.zig"));
 }

--- a/src/compile/test/issue_9614_test.zig
+++ b/src/compile/test/issue_9614_test.zig
@@ -1,20 +1,10 @@
 //! Regression test for issue #9614: a fold_until accumulator whose open tag
 //! union is widened across dispatch-plan positions must lower to LIR.
 
-const std = @import("std");
-const base = @import("base");
-const build_options = @import("build_options");
-const check = @import("check");
-const collections = @import("collections");
-const eval = @import("eval");
-const lir = @import("lir");
-const roc_target = @import("roc_target");
-
-const Coordinator = @import("../coordinator.zig").Coordinator;
-const CoreCtx = @import("ctx").CoreCtx;
+const expectLowersToLir = @import("lower_to_lir_harness.zig").expectLowersToLir;
 
 test "issue 9614: default app list fold_until result tag narrowing lowers to LIR" {
-    const original_source =
+    try expectLowersToLir(
         \\solve = |problem| {
         \\    find_match = |chars| {
         \\        match chars {
@@ -43,99 +33,5 @@ test "issue 9614: default app list fold_until result tag narrowing lowers to LIR
         \\    _ = solve("abc")
         \\    Ok({})
         \\}
-    ;
-
-    const gpa = std.testing.allocator;
-    var tmp_dir = std.testing.tmpDir(.{});
-    defer tmp_dir.cleanup();
-
-    try tmp_dir.dir.createDirPath(std.testing.io, ".roc_echo_platform");
-    const synthetic_source = "app [main!] { pf: platform \"./.roc_echo_platform/main.roc\" }\n\n" ++
-        "import pf.Echo\n\n" ++
-        "echo! = |msg| Echo.line!(msg)\n\n" ++
-        original_source;
-    try tmp_dir.dir.writeFile(std.testing.io, .{
-        .sub_path = "main.roc",
-        .data = synthetic_source,
-    });
-    try tmp_dir.dir.writeFile(std.testing.io, .{
-        .sub_path = ".roc_echo_platform/main.roc",
-        .data =
-        \\platform ""
-        \\    requires {} { main! : List(Str) => Try({}, [Exit(I8), ..]) }
-        \\    exposes [Echo]
-        \\    packages {}
-        \\    provides { "roc_main": main_for_host! }
-        \\    hosted { "roc_echo_line": Echo.line! }
-        \\
-        \\import Echo
-        \\
-        \\main_for_host! : List(Str) => I8
-        \\main_for_host! = |args|
-        \\    match main!(args) {
-        \\        Ok({}) => 0
-        \\        Err(Exit(code)) => code
-        \\        Err(other) => {
-        \\            Echo.line!("Program exited with error: ${Str.inspect(other)}")
-        \\            1
-        \\        }
-        \\    }
-        ,
-    });
-    try tmp_dir.dir.writeFile(std.testing.io, .{
-        .sub_path = ".roc_echo_platform/Echo.roc",
-        .data =
-        \\Echo := [].{
-        \\    line! : Str => {}
-        \\}
-        ,
-    });
-    const app_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "main.roc", gpa);
-    defer gpa.free(app_path);
-
-    var arena_impl = collections.SingleThreadArena.init(gpa);
-    defer arena_impl.deinit();
-    const arena = arena_impl.allocator();
-
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
-
-    var coord = try Coordinator.init(
-        gpa,
-        .single_threaded,
-        1,
-        roc_target.RocTarget.detectNative(),
-        &builtin_modules,
-        build_options.compiler_version,
-        null,
-        CoreCtx.default(gpa, arena, std.testing.io),
     );
-    defer coord.deinit();
-    coord.enable_hosted_transform = true;
-
-    try coord.start();
-    try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
-    try coord.coordinatorLoop();
-    try std.testing.expect(!coord.hasUserErrors());
-
-    try coord.finalizeExecutableArtifacts();
-    try std.testing.expect(!coord.hasUserErrors());
-
-    const root = coord.executableRootCheckedArtifact();
-    const imports = try coord.collectImportedArtifactViews(arena, root);
-    const relations = try coord.collectRelationArtifactViews(arena, root);
-
-    const lir_roots = try lir.CheckedPipeline.selectPlatformEntrypointRoots(gpa, root.root_requests.runtime_requests);
-    defer gpa.free(lir_roots);
-
-    var lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
-        gpa,
-        .{
-            .root = check.CheckedArtifact.loweringViewWithRelations(root, relations),
-            .imports = imports,
-        },
-        .{ .requests = lir_roots },
-        .{ .target_usize = base.target.TargetUsize.native },
-    );
-    defer lowered.deinit();
 }

--- a/src/compile/test/issue_9634_test.zig
+++ b/src/compile/test/issue_9634_test.zig
@@ -175,3 +175,35 @@ test "issue 9634: multi-hop transitive capture through sibling closures lowers t
         \\}
     );
 }
+
+test "issue 9634: captured Dict used in string interpolation inside a recursive closure lowers to LIR" {
+    // String interpolation desugars to an inline lambda (the one IR shape that
+    // stays an inline `.lambda` rather than a nested def). Exercising it inside
+    // a recursive capturing closure covers lambda lifting's inline-descent path
+    // for captures, which is separate from the def/nested-def fixpoint.
+    try expectLowersToLir(
+        \\IC :: {}.{
+        \\    run : List(U8) -> Str
+        \\    run = |vars| {
+        \\        labels : Dict(U8, Str)
+        \\        labels = Dict.from_list([(1, "one"), (2, "two")])
+        \\        recur : List(U8), Str -> Str
+        \\        recur = |xs, acc| {
+        \\            match xs {
+        \\                [] => acc
+        \\                [x, .. as rest] => {
+        \\                    name = labels.get(x) ?? "?"
+        \\                    recur(rest, "${acc}${name},")
+        \\                }
+        \\            }
+        \\        }
+        \\        recur(vars, "")
+        \\    }
+        \\}
+        \\
+        \\main! = |_args| {
+        \\    _ = IC.run([1, 2, 1])
+        \\    Ok({})
+        \\}
+    );
+}

--- a/src/compile/test/issue_9634_test.zig
+++ b/src/compile/test/issue_9634_test.zig
@@ -1,0 +1,177 @@
+//! Regression tests for issue #9634: a nested closure that transitively needs
+//! an outer capture — because it references a sibling/recursive closure that
+//! captures that value — must have the capture threaded into its own capture
+//! set. Lambda lifting now solves capture sets as a least fixed point over the
+//! function-reference graph (independent of lifting order and rewrite-collapsed
+//! nodes), so these programs lower to LIR without the ARC borrow certifier
+//! reporting a "use of unbound refcounted local".
+
+const expectLowersToLir = @import("lower_to_lir_harness.zig").expectLowersToLir;
+
+test "issue 9634: captured Dict in recursive fold_until closure lowers to LIR" {
+    try expectLowersToLir(
+        \\Alphametics :: {}.{
+        \\    solve : List(U8) -> Try(List((U8, U8)), [InvalidAssignment])
+        \\    solve = |vars| {
+        \\        equation : Dict(U8, I64)
+        \\        equation = Dict.from_list([(1, 1), (2, -1)])
+        \\
+        \\        find_match : List((U8, U8)), List(U8), Set(U8) -> Try(List((U8, U8)), [InvalidAssignment])
+        \\        find_match = |assignments, remaining_vars, remaining_digits| {
+        \\            match remaining_vars {
+        \\                [] => {
+        \\                    total_val : I64
+        \\                    total_val =
+        \\                        assignments.fold(
+        \\                            0,
+        \\                            |total, (letter, value)| {
+        \\                                (equation.get(letter) ?? 0) * value.to_i64() + total
+        \\                            },
+        \\                        )
+        \\
+        \\                    if total_val != 0 { Err(InvalidAssignment) } else { Ok(assignments) }
+        \\                }
+        \\                [letter, .. as rest] => {
+        \\                    find_first_ok(
+        \\                        remaining_digits,
+        \\                        |digit| {
+        \\                            find_match(assignments.append((letter, digit)), rest, remaining_digits)
+        \\                        }
+        \\                    )
+        \\                }
+        \\            }
+        \\        }
+        \\
+        \\        digits = Set.from_list([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        \\        find_match([], vars, digits)
+        \\    }
+        \\}
+        \\
+        \\find_first_ok : Set(a), (a -> Try(b, err)) -> Try(b, [InvalidAssignment])
+        \\find_first_ok = |set, func| {
+        \\    set.to_list().fold_until(
+        \\        Err(InvalidAssignment),
+        \\        |state, elem| {
+        \\            match func(elem) {
+        \\                Err(_) => Continue(state)
+        \\                Ok(val) => Break(Ok(val))
+        \\            }
+        \\        },
+        \\    )
+        \\}
+        \\
+        \\main! = |_args| {
+        \\    _ = Alphametics.solve([1, 2])
+        \\    Ok({})
+        \\}
+    );
+}
+
+test "issue 9634: recursive closure with two refcounted captures lowers to LIR" {
+    // `walk` captures two outer Dicts and recurses through `choose`'s lambda,
+    // so the lambda must transitively capture both `weights` and `offsets`.
+    try expectLowersToLir(
+        \\Two :: {}.{
+        \\    run : List(U8) -> Try(List(U8), [Bad])
+        \\    run = |vars| {
+        \\        weights : Dict(U8, I64)
+        \\        weights = Dict.from_list([(1, 5), (2, 7)])
+        \\        offsets : Dict(U8, I64)
+        \\        offsets = Dict.from_list([(1, 1), (2, 2)])
+        \\
+        \\        walk : List(U8), List(U8) -> Try(List(U8), [Bad])
+        \\        walk = |acc, remaining| {
+        \\            match remaining {
+        \\                [] => Ok(acc)
+        \\                [v, .. as rest] => {
+        \\                    choose(
+        \\                        [0, 1, 2],
+        \\                        |d| {
+        \\                            score = (weights.get(v) ?? 0) * d.to_i64() + (offsets.get(v) ?? 0)
+        \\                            if score > 100 {
+        \\                                Err(Bad)
+        \\                            } else {
+        \\                                walk(acc.append(v), rest)
+        \\                            }
+        \\                        },
+        \\                    )
+        \\                }
+        \\            }
+        \\        }
+        \\        walk([], vars)
+        \\    }
+        \\}
+        \\
+        \\choose : List(U8), (U8 -> Try(a, [Bad])) -> Try(a, [Bad])
+        \\choose = |options, f| {
+        \\    options.fold_until(
+        \\        Err(Bad),
+        \\        |state, opt| {
+        \\            match f(opt) {
+        \\                Err(_) => Continue(state)
+        \\                Ok(v) => Break(Ok(v))
+        \\            }
+        \\        },
+        \\    )
+        \\}
+        \\
+        \\main! = |_args| {
+        \\    _ = Two.run([1, 2])
+        \\    Ok({})
+        \\}
+    );
+}
+
+test "issue 9634: multi-hop transitive capture through sibling closures lowers to LIR" {
+    // The `|_|` lambda calls recursive `walk`, which calls sibling `score`,
+    // which captures `base`. `base` must propagate two hops up the
+    // function-reference graph into the innermost lambda's capture set.
+    try expectLowersToLir(
+        \\Hop :: {}.{
+        \\    run : List(U8) -> Try(I64, [Bad])
+        \\    run = |vars| {
+        \\        base : Dict(U8, I64)
+        \\        base = Dict.from_list([(1, 2), (2, 3)])
+        \\
+        \\        score : U8 -> I64
+        \\        score = |v| (base.get(v) ?? 0) * 10
+        \\
+        \\        walk : List(U8), I64 -> Try(I64, [Bad])
+        \\        walk = |xs, acc| {
+        \\            match xs {
+        \\                [] => Ok(acc)
+        \\                [v, .. as rest] => {
+        \\                    pick(
+        \\                        [0, 1],
+        \\                        |_| {
+        \\                            next = acc + score(v)
+        \\                            if next > 1000 {
+        \\                                Err(Bad)
+        \\                            } else {
+        \\                                walk(rest, next)
+        \\                            }
+        \\                        },
+        \\                    )
+        \\                }
+        \\            }
+        \\        }
+        \\        walk(vars, 0)
+        \\    }
+        \\}
+        \\
+        \\pick : List(U8), (U8 -> Try(a, [Bad])) -> Try(a, [Bad])
+        \\pick = |opts, f| {
+        \\    opts.fold_until(Err(Bad), |st, o| {
+        \\        match f(o) {
+        \\            Err(_) => Continue(st)
+        \\            Ok(v) => Break(Ok(v))
+        \\        }
+        \\    })
+        \\}
+        \\
+        \\main! = |_args| {
+        \\    _ = Hop.run([1, 2])
+        \\    Ok({})
+        \\}
+    );
+}

--- a/src/compile/test/lower_to_lir_harness.zig
+++ b/src/compile/test/lower_to_lir_harness.zig
@@ -1,0 +1,120 @@
+//! Shared test harness: compile an app and lower it all the way to LIR,
+//! asserting no checker errors and no ARC borrow-certifier violation. The
+//! certifier runs inside `lowerCheckedModulesToLir` and panics on any
+//! violation, so returning normally is the assertion.
+
+const std = @import("std");
+const base = @import("base");
+const build_options = @import("build_options");
+const check = @import("check");
+const collections = @import("collections");
+const eval = @import("eval");
+const lir = @import("lir");
+const roc_target = @import("roc_target");
+
+const Coordinator = @import("../coordinator.zig").Coordinator;
+const CoreCtx = @import("ctx").CoreCtx;
+
+/// Lower an app whose body is `app_body` (everything after the platform header
+/// and the echo wiring) to LIR. Reaching the end without a panic means the
+/// program checked cleanly and passed ARC certification.
+pub fn expectLowersToLir(app_body: []const u8) !void {
+    const gpa = std.testing.allocator;
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(std.testing.io, ".roc_echo_platform");
+    const synthetic_source = try std.fmt.allocPrint(
+        gpa,
+        "app [main!] {{ pf: platform \"./.roc_echo_platform/main.roc\" }}\n\n" ++
+            "import pf.Echo\n\n" ++
+            "echo! = |msg| Echo.line!(msg)\n\n" ++
+            "{s}",
+        .{app_body},
+    );
+    defer gpa.free(synthetic_source);
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "main.roc",
+        .data = synthetic_source,
+    });
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = ".roc_echo_platform/main.roc",
+        .data =
+        \\platform ""
+        \\    requires {} { main! : List(Str) => Try({}, [Exit(I8), ..]) }
+        \\    exposes [Echo]
+        \\    packages {}
+        \\    provides { "roc_main": main_for_host! }
+        \\    hosted { "roc_echo_line": Echo.line! }
+        \\
+        \\import Echo
+        \\
+        \\main_for_host! : List(Str) => I8
+        \\main_for_host! = |args|
+        \\    match main!(args) {
+        \\        Ok({}) => 0
+        \\        Err(Exit(code)) => code
+        \\        Err(other) => {
+        \\            Echo.line!("Program exited with error: ${Str.inspect(other)}")
+        \\            1
+        \\        }
+        \\    }
+        ,
+    });
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = ".roc_echo_platform/Echo.roc",
+        .data =
+        \\Echo := [].{
+        \\    line! : Str => {}
+        \\}
+        ,
+    });
+    const app_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "main.roc", gpa);
+    defer gpa.free(app_path);
+
+    var arena_impl = collections.SingleThreadArena.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    var builtin_modules = try eval.BuiltinModules.init(gpa);
+    defer builtin_modules.deinit();
+
+    var coord = try Coordinator.init(
+        gpa,
+        .single_threaded,
+        1,
+        roc_target.RocTarget.detectNative(),
+        &builtin_modules,
+        build_options.compiler_version,
+        null,
+        CoreCtx.default(gpa, arena, std.testing.io),
+    );
+    defer coord.deinit();
+    coord.enable_hosted_transform = true;
+
+    try coord.start();
+    try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
+    try coord.coordinatorLoop();
+    try std.testing.expect(!coord.hasUserErrors());
+
+    try coord.finalizeExecutableArtifacts();
+    try std.testing.expect(!coord.hasUserErrors());
+
+    const root = coord.executableRootCheckedArtifact();
+    const imports = try coord.collectImportedArtifactViews(arena, root);
+    const relations = try coord.collectRelationArtifactViews(arena, root);
+
+    const lir_roots = try lir.CheckedPipeline.selectPlatformEntrypointRoots(gpa, root.root_requests.runtime_requests);
+    defer gpa.free(lir_roots);
+
+    var lowered = try lir.CheckedPipeline.lowerCheckedModulesToLir(
+        gpa,
+        .{
+            .root = check.CheckedArtifact.loweringViewWithRelations(root, relations),
+            .imports = imports,
+        },
+        .{ .requests = lir_roots },
+        .{ .target_usize = base.target.TargetUsize.native },
+    );
+    defer lowered.deinit();
+}

--- a/src/compile/test/lower_to_lir_harness.zig
+++ b/src/compile/test/lower_to_lir_harness.zig
@@ -19,6 +19,27 @@ const CoreCtx = @import("ctx").CoreCtx;
 /// and the echo wiring) to LIR. Reaching the end without a panic means the
 /// program checked cleanly and passed ARC certification.
 pub fn expectLowersToLir(app_body: []const u8) !void {
+    try runToLir(app_body, null);
+}
+
+/// Lower `app_body` twice and assert the two LIR dumps are byte-identical, so
+/// a regression that made lowering (e.g. capture order) depend on iteration or
+/// scheduling order would fail here rather than silently.
+pub fn expectDeterministicLir(app_body: []const u8) !void {
+    const gpa = std.testing.allocator;
+    const cap = 1 << 22;
+    const buf_a = try gpa.alloc(u8, cap);
+    defer gpa.free(buf_a);
+    const buf_b = try gpa.alloc(u8, cap);
+    defer gpa.free(buf_b);
+    var writer_a = std.Io.Writer.fixed(buf_a);
+    var writer_b = std.Io.Writer.fixed(buf_b);
+    try runToLir(app_body, &writer_a);
+    try runToLir(app_body, &writer_b);
+    try std.testing.expectEqualStrings(writer_a.buffered(), writer_b.buffered());
+}
+
+fn runToLir(app_body: []const u8, dump: ?*std.Io.Writer) !void {
     const gpa = std.testing.allocator;
     var tmp_dir = std.testing.tmpDir(.{});
     defer tmp_dir.cleanup();
@@ -117,4 +138,12 @@ pub fn expectLowersToLir(app_body: []const u8) !void {
         .{ .target_usize = base.target.TargetUsize.native },
     );
     defer lowered.deinit();
+
+    if (dump) |writer| {
+        const store = &lowered.lir_result.store;
+        const layouts = &lowered.lir_result.layouts;
+        for (0..store.proc_specs.items.len) |index| {
+            try lir.DebugPrint.writeProc(gpa, store, layouts, @enumFromInt(@as(u32, @intCast(index))), writer);
+        }
+    }
 }

--- a/src/compile/test/tce_capture_test.zig
+++ b/src/compile/test/tce_capture_test.zig
@@ -1,0 +1,118 @@
+//! Regression tests for tail-call elimination of a recursive closure that
+//! captures a refcounted value.
+//!
+//! Plain TCE turns the proc's own argument locals into the loop join's
+//! parameters and enters the loop with a bare `jump` (no `initialize_join_param`
+//! writes — the argument values are already in place). When join-parameter
+//! scalarization later splits a captured struct parameter into per-field
+//! parameters, the field parameters must still be seeded on that entry path by
+//! reading the argument struct's fields; otherwise the ARC borrow certifier
+//! reports a "release of unbound local" for the never-initialized field on the
+//! first loop iteration.
+
+const expectLowersToLir = @import("lower_to_lir_harness.zig").expectLowersToLir;
+
+test "tce capture: tail-recursive closure capturing a Dict lowers to LIR" {
+    try expectLowersToLir(
+        \\T :: {}.{
+        \\    run : List(U8) -> I64
+        \\    run = |vars| {
+        \\        gains : Dict(U8, I64)
+        \\        gains = Dict.from_list([(1, 3), (2, 4)])
+        \\        recur : List(U8), I64 -> I64
+        \\        recur = |xs, acc| {
+        \\            match xs {
+        \\                [] => acc
+        \\                [x, .. as rest] => recur(rest, acc + (gains.get(x) ?? 0))
+        \\            }
+        \\        }
+        \\        recur(vars, 0)
+        \\    }
+        \\}
+        \\
+        \\main! = |_args| {
+        \\    _ = T.run([1, 2, 1])
+        \\    Ok({})
+        \\}
+    );
+}
+
+test "tce capture: tail-recursive closure capturing two Dicts lowers to LIR" {
+    try expectLowersToLir(
+        \\TT :: {}.{
+        \\    run : List(U8) -> I64
+        \\    run = |vars| {
+        \\        a : Dict(U8, I64)
+        \\        a = Dict.from_list([(1, 100), (2, 200)])
+        \\        b : Dict(U8, I64)
+        \\        b = Dict.from_list([(1, 1), (2, 2)])
+        \\        recur : List(U8), I64 -> I64
+        \\        recur = |xs, acc| {
+        \\            match xs {
+        \\                [] => acc
+        \\                [x, .. as rest] => recur(rest, acc + (a.get(x) ?? 0) + (b.get(x) ?? 0))
+        \\            }
+        \\        }
+        \\        recur(vars, 0)
+        \\    }
+        \\}
+        \\
+        \\main! = |_args| {
+        \\    _ = TT.run([1, 2])
+        \\    Ok({})
+        \\}
+    );
+}
+
+test "tce capture: tail-recursive closure capturing a List lowers to LIR" {
+    try expectLowersToLir(
+        \\TL :: {}.{
+        \\    run : List(U8) -> I64
+        \\    run = |vars| {
+        \\        weights : List(I64)
+        \\        weights = [10, 20, 30]
+        \\        recur : List(U8), I64 -> I64
+        \\        recur = |xs, acc| {
+        \\            match xs {
+        \\                [] => acc
+        \\                [_, .. as rest] => recur(rest, acc + (weights.first() ?? 0))
+        \\            }
+        \\        }
+        \\        recur(vars, 0)
+        \\    }
+        \\}
+        \\
+        \\main! = |_args| {
+        \\    _ = TL.run([1, 2, 3, 4])
+        \\    Ok({})
+        \\}
+    );
+}
+
+test "tce capture: nested lambda inside a tail-recursive capturing closure lowers to LIR" {
+    try expectLowersToLir(
+        \\N2 :: {}.{
+        \\    run : List(U8) -> I64
+        \\    run = |vars| {
+        \\        gains : Dict(U8, I64)
+        \\        gains = Dict.from_list([(1, 3), (2, 4)])
+        \\        recur : List(U8), I64 -> I64
+        \\        recur = |xs, acc| {
+        \\            match xs {
+        \\                [] => acc
+        \\                [x, .. as rest] => {
+        \\                    bonus = [10, 20].map(|m| m + (gains.get(x) ?? 0))
+        \\                    recur(rest, acc + (bonus.first() ?? 0))
+        \\                }
+        \\            }
+        \\        }
+        \\        recur(vars, 0)
+        \\    }
+        \\}
+        \\
+        \\main! = |_args| {
+        \\    _ = N2.run([1, 2])
+        \\    Ok({})
+        \\}
+    );
+}

--- a/src/compile/test/tce_capture_test.zig
+++ b/src/compile/test/tce_capture_test.zig
@@ -10,7 +10,9 @@
 //! reports a "release of unbound local" for the never-initialized field on the
 //! first loop iteration.
 
-const expectLowersToLir = @import("lower_to_lir_harness.zig").expectLowersToLir;
+const harness = @import("lower_to_lir_harness.zig");
+const expectLowersToLir = harness.expectLowersToLir;
+const expectDeterministicLir = harness.expectDeterministicLir;
 
 test "tce capture: tail-recursive closure capturing a Dict lowers to LIR" {
     try expectLowersToLir(
@@ -112,6 +114,52 @@ test "tce capture: nested lambda inside a tail-recursive capturing closure lower
         \\
         \\main! = |_args| {
         \\    _ = N2.run([1, 2])
+        \\    Ok({})
+        \\}
+    );
+}
+
+test "tce capture: capture-fixpoint lowering is deterministic" {
+    // Lambda lifting solves capture sets with an edge-driven worklist and no
+    // separate normalizing pass; this guards that the resulting LIR (capture
+    // order included) does not depend on scheduling or iteration order.
+    try expectDeterministicLir(
+        \\Solver :: {}.{
+        \\    solve : List(U8) -> Try(List((U8, U8)), [Bad])
+        \\    solve = |vars| {
+        \\        equation : Dict(U8, I64)
+        \\        equation = Dict.from_list([(1, 1), (2, -1)])
+        \\        find_match : List((U8, U8)), List(U8), Set(U8) -> Try(List((U8, U8)), [Bad])
+        \\        find_match = |assignments, remaining_vars, remaining_digits| {
+        \\            match remaining_vars {
+        \\                [] => {
+        \\                    total : I64
+        \\                    total = assignments.fold(0, |acc, (letter, value)| (equation.get(letter) ?? 0) * value.to_i64() + acc)
+        \\                    if total != 0 { Err(Bad) } else { Ok(assignments) }
+        \\                }
+        \\                [letter, .. as rest] => {
+        \\                    first_ok(remaining_digits, |digit| {
+        \\                        find_match(assignments.append((letter, digit)), rest, remaining_digits)
+        \\                    })
+        \\                }
+        \\            }
+        \\        }
+        \\        find_match([], vars, Set.from_list([0, 1, 2, 3]))
+        \\    }
+        \\}
+        \\
+        \\first_ok : Set(a), (a -> Try(b, err)) -> Try(b, [Bad])
+        \\first_ok = |set, func| {
+        \\    set.to_list().fold_until(Err(Bad), |state, elem| {
+        \\        match func(elem) {
+        \\            Err(_) => Continue(state)
+        \\            Ok(val) => Break(Ok(val))
+        \\        }
+        \\    })
+        \\}
+        \\
+        \\main! = |_args| {
+        \\    _ = Solver.solve([1, 2])
         \\    Ok({})
         \\}
     );

--- a/src/lir/scalarize_joins.zig
+++ b/src/lir/scalarize_joins.zig
@@ -182,10 +182,11 @@ const Pass = struct {
         self.resetProc();
         try self.collect(body);
 
-        // The proc's argument span is invariant for this pass, and stays valid
-        // through the walk below: a failed `tryScalarize` adds no locals, and
-        // the first success returns immediately, so nothing reallocates the
-        // span store while we hold this slice.
+        // Resolve proc-argument membership here, where the argument span is
+        // freshly valid, and pass a plain bool into `tryScalarize`. The span is
+        // a view into the store's local-id buffer, which `tryScalarize`
+        // reallocates when it scalarizes, so it must not be read across that
+        // call.
         const proc_args = self.store.getLocalSpan(self.store.getProcSpec(proc_id).args);
 
         // Find one scalarizable parameter; the fixpoint loop picks up the
@@ -201,7 +202,8 @@ const Pass = struct {
             switch (self.store.getCFStmt(current)) {
                 .join => |join_stmt| {
                     for (self.store.getLocalSpan(join_stmt.params), 0..) |param, position| {
-                        if (try self.tryScalarize(proc_args, current, join_stmt, param, position)) {
+                        const param_is_proc_arg = std.mem.findScalar(LIR.LocalId, proc_args, param) != null;
+                        if (try self.tryScalarize(param_is_proc_arg, current, join_stmt, param, position)) {
                             changed = true;
                             break :outer;
                         }
@@ -244,9 +246,21 @@ const Pass = struct {
         proc.frame_locals = try self.store.addLocalSpan(combined.items);
     }
 
+    /// `param_is_proc_arg` records whether this join parameter is also one of
+    /// the proc's argument locals. Every jump that targets the join carries
+    /// `initialize_join_param` writes for its parameters, which the rewrite
+    /// below turns into per-field writes. The one entry that carries no such
+    /// write is a plain-TCE loop header: it reuses the proc's own argument
+    /// locals as the join parameters and enters with a bare jump, so the
+    /// parameter's initial value arrives through the argument. That is the only
+    /// shape in which a join parameter is also a proc argument, and it is
+    /// exactly the shape whose field parameters must be seeded from the
+    /// argument struct on entry. (Any future shape that entered a parameter
+    /// without a write and without a seed would surface as an unbound local in
+    /// the ARC borrow certifier, never as a silent miscompile.)
     fn tryScalarize(
         self: *Pass,
-        proc_args: []const LIR.LocalId,
+        param_is_proc_arg: bool,
         join_id: LIR.CFStmtId,
         join_stmt: anytype,
         param: LIR.LocalId,
@@ -255,18 +269,6 @@ const Pass = struct {
         const param_layout = self.layouts.getLayout(self.store.getLocal(param).layout_idx);
         if (param_layout.tag != .struct_) return false;
 
-        // Every jump that targets the join carries `initialize_join_param`
-        // writes for its parameters, which the rewrite below turns into
-        // per-field writes. The one entry that carries no such write is a
-        // plain-TCE loop header: it reuses the proc's own argument locals as
-        // the join parameters and enters with a bare jump, so the parameter's
-        // initial value arrives through the argument. That is the only shape in
-        // which a join parameter is also a proc argument, and it is exactly the
-        // shape whose field parameters must be seeded from the argument struct
-        // on entry. (Any future shape that entered a parameter without a write
-        // and without a seed would surface as an unbound local in the ARC
-        // borrow certifier, never as a silent miscompile.)
-        const param_is_proc_arg = std.mem.findScalar(LIR.LocalId, proc_args, param) != null;
         const info = self.layouts.getStructInfo(param_layout);
         var field_count: usize = 0;
         for (0..info.fields.len) |i| {

--- a/src/lir/scalarize_joins.zig
+++ b/src/lir/scalarize_joins.zig
@@ -182,6 +182,12 @@ const Pass = struct {
         self.resetProc();
         try self.collect(body);
 
+        // The proc's argument span is invariant for this pass, and stays valid
+        // through the walk below: a failed `tryScalarize` adds no locals, and
+        // the first success returns immediately, so nothing reallocates the
+        // span store while we hold this slice.
+        const proc_args = self.store.getLocalSpan(self.store.getProcSpec(proc_id).args);
+
         // Find one scalarizable parameter; the fixpoint loop picks up the
         // rest on later rounds.
         var changed = false;
@@ -195,7 +201,7 @@ const Pass = struct {
             switch (self.store.getCFStmt(current)) {
                 .join => |join_stmt| {
                     for (self.store.getLocalSpan(join_stmt.params), 0..) |param, position| {
-                        if (try self.tryScalarize(proc_id, current, join_stmt, param, position)) {
+                        if (try self.tryScalarize(proc_args, current, join_stmt, param, position)) {
                             changed = true;
                             break :outer;
                         }
@@ -240,7 +246,7 @@ const Pass = struct {
 
     fn tryScalarize(
         self: *Pass,
-        proc_id: LIR.LirProcSpecId,
+        proc_args: []const LIR.LocalId,
         join_id: LIR.CFStmtId,
         join_stmt: anytype,
         param: LIR.LocalId,
@@ -260,10 +266,7 @@ const Pass = struct {
         // on entry. (Any future shape that entered a parameter without a write
         // and without a seed would surface as an unbound local in the ARC
         // borrow certifier, never as a silent miscompile.)
-        const param_is_proc_arg = blk: {
-            const args = self.store.getLocalSpan(self.store.getProcSpec(proc_id).args);
-            break :blk std.mem.findScalar(LIR.LocalId, args, param) != null;
-        };
+        const param_is_proc_arg = std.mem.findScalar(LIR.LocalId, proc_args, param) != null;
         const info = self.layouts.getStructInfo(param_layout);
         var field_count: usize = 0;
         for (0..info.fields.len) |i| {

--- a/src/lir/scalarize_joins.zig
+++ b/src/lir/scalarize_joins.zig
@@ -18,12 +18,14 @@
 //! alias chains that borrow inference turns into moves, and the wrapper
 //! disappears entirely.
 //!
-//! A join parameter that is also one of the proc's arguments (the loop header
-//! a plain tail-call elimination builds, where the proc enters the loop with a
-//! bare jump and the argument values are already in the parameter locals) is
-//! still scalarizable: its per-field parameters are seeded once on the join's
-//! remainder by reading the argument struct's fields, since that entry path
-//! carries no `initialize_join_param` write to rewrite.
+//! A join's remainder (its run-once entry path) may enter the join without an
+//! `initialize_join_param` write for a parameter — a plain tail-call
+//! elimination loop header does this, entering with a bare jump because the
+//! parameters are the proc's own argument locals. Such a parameter is still
+//! scalarizable: its per-field parameters are seeded once on the remainder by
+//! reading the incoming struct's fields. That read is sound only because the
+//! sole write-less entry shape supplies the value through a proc argument, an
+//! invariant the pass enforces.
 //!
 //! The pass iterates to a fixpoint so nested wrappers dissolve layer by
 //! layer. Parameters with any whole-value use, any non-literal initializer,
@@ -247,12 +249,17 @@ const Pass = struct {
         const param_layout = self.layouts.getLayout(self.store.getLocal(param).layout_idx);
         if (param_layout.tag != .struct_) return false;
 
-        // When the parameter is also a proc argument, the proc-entry path
-        // feeds its value through the argument rather than an
-        // `initialize_join_param` write, so there is no per-field write to
-        // rewrite there. Such a parameter is still scalarizable, but the
-        // field parameters must then be seeded at entry by reading the
-        // argument struct's fields (see the seed below).
+        // Every jump that targets the join carries `initialize_join_param`
+        // writes for its parameters, which the rewrite below turns into
+        // per-field writes. The one entry that carries no such write is a
+        // plain-TCE loop header: it reuses the proc's own argument locals as
+        // the join parameters and enters with a bare jump, so the parameter's
+        // initial value arrives through the argument. That is the only shape in
+        // which a join parameter is also a proc argument, and it is exactly the
+        // shape whose field parameters must be seeded from the argument struct
+        // on entry. (Any future shape that entered a parameter without a write
+        // and without a seed would surface as an unbound local in the ARC
+        // borrow certifier, never as a silent miscompile.)
         const param_is_proc_arg = blk: {
             const args = self.store.getLocalSpan(self.store.getProcSpec(proc_id).args);
             break :blk std.mem.findScalar(LIR.LocalId, args, param) != null;
@@ -357,11 +364,9 @@ const Pass = struct {
             try self.writeFields(site.stmt, build_next, field_locals, operands);
         }
 
-        // The proc-entry path supplies a proc-argument parameter through the
-        // argument itself, not an `initialize_join_param` write, so the field
-        // parameters would otherwise be unbound on first entry. Seed them by
-        // reading the argument struct's fields in the join's remainder, which
-        // runs once before the loop body.
+        // Seed the field parameters on the write-less proc-entry path (see the
+        // comment at param_is_proc_arg above): reading the argument struct's
+        // fields in the join's remainder, which runs once before the loop body.
         if (param_is_proc_arg) try self.seedFieldsFromArgStruct(join_id, param, field_locals);
 
         return true;

--- a/src/lir/scalarize_joins.zig
+++ b/src/lir/scalarize_joins.zig
@@ -18,6 +18,13 @@
 //! alias chains that borrow inference turns into moves, and the wrapper
 //! disappears entirely.
 //!
+//! A join parameter that is also one of the proc's arguments (the loop header
+//! a plain tail-call elimination builds, where the proc enters the loop with a
+//! bare jump and the argument values are already in the parameter locals) is
+//! still scalarizable: its per-field parameters are seeded once on the join's
+//! remainder by reading the argument struct's fields, since that entry path
+//! carries no `initialize_join_param` write to rewrite.
+//!
 //! The pass iterates to a fixpoint so nested wrappers dissolve layer by
 //! layer. Parameters with any whole-value use, any non-literal initializer,
 //! or a shared initializer keep their shape.
@@ -186,7 +193,7 @@ const Pass = struct {
             switch (self.store.getCFStmt(current)) {
                 .join => |join_stmt| {
                     for (self.store.getLocalSpan(join_stmt.params), 0..) |param, position| {
-                        if (try self.tryScalarize(current, join_stmt, param, position)) {
+                        if (try self.tryScalarize(proc_id, current, join_stmt, param, position)) {
                             changed = true;
                             break :outer;
                         }
@@ -231,6 +238,7 @@ const Pass = struct {
 
     fn tryScalarize(
         self: *Pass,
+        proc_id: LIR.LirProcSpecId,
         join_id: LIR.CFStmtId,
         join_stmt: anytype,
         param: LIR.LocalId,
@@ -238,6 +246,17 @@ const Pass = struct {
     ) ScalarizeError!bool {
         const param_layout = self.layouts.getLayout(self.store.getLocal(param).layout_idx);
         if (param_layout.tag != .struct_) return false;
+
+        // When the parameter is also a proc argument, the proc-entry path
+        // feeds its value through the argument rather than an
+        // `initialize_join_param` write, so there is no per-field write to
+        // rewrite there. Such a parameter is still scalarizable, but the
+        // field parameters must then be seeded at entry by reading the
+        // argument struct's fields (see the seed below).
+        const param_is_proc_arg = blk: {
+            const args = self.store.getLocalSpan(self.store.getProcSpec(proc_id).args);
+            break :blk std.mem.findScalar(LIR.LocalId, args, param) != null;
+        };
         const info = self.layouts.getStructInfo(param_layout);
         var field_count: usize = 0;
         for (0..info.fields.len) |i| {
@@ -338,7 +357,45 @@ const Pass = struct {
             try self.writeFields(site.stmt, build_next, field_locals, operands);
         }
 
+        // The proc-entry path supplies a proc-argument parameter through the
+        // argument itself, not an `initialize_join_param` write, so the field
+        // parameters would otherwise be unbound on first entry. Seed them by
+        // reading the argument struct's fields in the join's remainder, which
+        // runs once before the loop body.
+        if (param_is_proc_arg) try self.seedFieldsFromArgStruct(join_id, param, field_locals);
+
         return true;
+    }
+
+    /// Prepend, to the join's remainder, one `ref.field arg[k]` read plus an
+    /// `initialize_join_param` write into the corresponding field parameter,
+    /// so the field parameters carry the argument struct's fields on the
+    /// proc-entry path. The read temporaries join the proc's frame locals.
+    fn seedFieldsFromArgStruct(
+        self: *Pass,
+        join_id: LIR.CFStmtId,
+        arg_struct: LIR.LocalId,
+        field_locals: []const LIR.LocalId,
+    ) ScalarizeError!void {
+        var next = self.store.getCFStmtPtr(join_id).join.remainder;
+        var k: usize = field_locals.len;
+        while (k > 0) {
+            k -= 1;
+            const tmp = try self.store.addLocal(.{ .layout_idx = self.store.getLocal(field_locals[k]).layout_idx });
+            try self.new_locals.append(self.allocator, tmp);
+            const set_stmt = try self.store.addCFStmt(.{ .set_local = .{
+                .target = field_locals[k],
+                .value = tmp,
+                .mode = .initialize_join_param,
+                .next = next,
+            } });
+            next = try self.store.addCFStmt(.{ .assign_ref = .{
+                .target = tmp,
+                .op = .{ .field = .{ .source = arg_struct, .field_idx = @intCast(k) } },
+                .next = set_stmt,
+            } });
+        }
+        self.store.getCFStmtPtr(join_id).join.remainder = next;
     }
 
     /// Replaces `stmt` with an `initialize_join_param` write of field 0 and

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -217,23 +217,6 @@ const Lifter = struct {
             self.registerFn(def.fn_id, fn_id);
         }
 
-        // Reserve and register every nested lambda body so the capture
-        // fixpoint below covers all functions, not just defs and nested defs.
-        // This walks the un-rewritten bodies; rewriting happens only later.
-        {
-            const reserved_count = self.output.fns.items.len;
-            const visited = try self.allocator.alloc(bool, self.output.exprCount());
-            defer self.allocator.free(visited);
-            @memset(visited, false);
-            for (0..reserved_count) |raw| {
-                const body = self.fn_bodies.items[raw] orelse continue;
-                switch (body.body) {
-                    .roc => |expr| try self.registerNestedLambdas(expr, visited),
-                    .hosted => {},
-                }
-            }
-        }
-
         try self.computeCaptureFixpoint();
 
         for (self.source.defs.items, 0..) |def, index| {
@@ -423,8 +406,21 @@ const Lifter = struct {
         if (self.initialized_fns.contains(fn_id)) return;
 
         try self.setFnBody(fn_id, .{ .args = lambda.args, .body = .{ .roc = lambda.body } });
+
+        // Inline lambdas are never the target of a direct/devirtualized call
+        // (those resolve to defs or nested defs), so they need no fixpoint
+        // entry: their captures are computed here, reading the already-solved
+        // capture sets of any defs they reference and descending inline into
+        // their own nested lambdas.
+        var captures = CaptureSet.init(self);
+        defer captures.deinit();
+        var bound = BoundSet.init(self.allocator);
+        defer bound.deinit();
+        try bindTypedLocals(self.output, &bound, self.output.typedLocalSpan(lambda.args));
+        try captures.collectExpr(lambda.body, &bound);
+
         try self.rewriteExpr(lambda.body);
-        const capture_span = try self.output.addTypedLocalSpan(self.fn_captures[@intFromEnum(fn_id)].items);
+        const capture_span = try self.output.addTypedLocalSpan(captures.items.items);
         self.output.fns.items[@intFromEnum(fn_id)] = .{
             .symbol = self.symbols.fresh(),
             .source = self.source.fnSource(lambda.fn_id),
@@ -454,152 +450,91 @@ const Lifter = struct {
         self.fn_bodies.items[raw] = body;
     }
 
-    /// Reserve a lifted function id and record the body for every nested
-    /// lambda reachable from `expr_id`, without rewriting anything. Run before
-    /// the capture fixpoint so that every function — including inline lambdas
-    /// — participates in it. `visited` guards shared sub-expressions.
-    fn registerNestedLambdas(self: *Lifter, expr_id: Mono.ExprId, visited: []bool) Allocator.Error!void {
-        const index = @intFromEnum(expr_id);
-        if (visited[index]) return;
-        visited[index] = true;
-
-        const input = self.output;
-        switch (input.exprs.items[index].data) {
-            .local,
-            .unit,
-            .int_lit,
-            .frac_f32_lit,
-            .frac_f64_lit,
-            .dec_lit,
-            .str_lit,
-            .def_ref,
-            .fn_ref,
-            .fn_def,
-            .crash,
-            .comptime_exhaustiveness_failed,
-            => {},
-            .list,
-            .tuple,
-            => |items| for (input.exprSpan(items)) |child| try self.registerNestedLambdas(child, visited),
-            .record => |fields| for (input.fieldExprSpan(fields)) |field| try self.registerNestedLambdas(field.value, visited),
-            .tag => |tag| for (input.exprSpan(tag.payloads)) |child| try self.registerNestedLambdas(child, visited),
-            .nominal,
-            .return_,
-            .dbg,
-            .expect,
-            => |child| try self.registerNestedLambdas(child, visited),
-            .expect_err => |expect_err| try self.registerNestedLambdas(expect_err.msg, visited),
-            .comptime_branch_taken => |taken| try self.registerNestedLambdas(taken.body, visited),
-            .let_ => |let_| {
-                try self.registerNestedLambdas(let_.value, visited);
-                try self.registerNestedLambdas(let_.rest, visited);
-            },
-            .lambda => |lambda| {
-                const fn_id = try self.reserveFn(lambda.fn_id);
-                try self.setFnBody(fn_id, .{ .args = lambda.args, .body = .{ .roc = lambda.body } });
-                try self.registerNestedLambdas(lambda.body, visited);
-            },
-            .call_value => |call| {
-                try self.registerNestedLambdas(call.callee, visited);
-                for (input.exprSpan(call.args)) |arg| try self.registerNestedLambdas(arg, visited);
-            },
-            .call_proc => |call| for (input.exprSpan(call.args)) |arg| try self.registerNestedLambdas(arg, visited),
-            .low_level => |call| for (input.exprSpan(call.args)) |arg| try self.registerNestedLambdas(arg, visited),
-            .field_access => |field| try self.registerNestedLambdas(field.receiver, visited),
-            .tuple_access => |access| try self.registerNestedLambdas(access.tuple, visited),
-            .structural_eq => |eq| {
-                try self.registerNestedLambdas(eq.lhs, visited);
-                try self.registerNestedLambdas(eq.rhs, visited);
-            },
-            .match_ => |match| {
-                try self.registerNestedLambdas(match.scrutinee, visited);
-                for (input.branchSpan(match.branches)) |branch| {
-                    if (branch.guard) |guard| try self.registerNestedLambdas(guard, visited);
-                    try self.registerNestedLambdas(branch.body, visited);
-                }
-            },
-            .if_ => |if_| {
-                for (input.ifBranchSpan(if_.branches)) |branch| {
-                    try self.registerNestedLambdas(branch.cond, visited);
-                    try self.registerNestedLambdas(branch.body, visited);
-                }
-                try self.registerNestedLambdas(if_.final_else, visited);
-            },
-            .block => |block| {
-                for (input.stmtSpan(block.statements)) |stmt| try self.registerNestedLambdasStmt(stmt, visited);
-                try self.registerNestedLambdas(block.final_expr, visited);
-            },
-            .loop_ => |loop| {
-                for (input.exprSpan(loop.initial_values)) |initial| try self.registerNestedLambdas(initial, visited);
-                try self.registerNestedLambdas(loop.body, visited);
-            },
-            .break_ => |maybe| if (maybe) |value| try self.registerNestedLambdas(value, visited),
-            .continue_ => |continue_| for (input.exprSpan(continue_.values)) |value| try self.registerNestedLambdas(value, visited),
-        }
-    }
-
-    fn registerNestedLambdasStmt(self: *Lifter, stmt_id: Mono.StmtId, visited: []bool) Allocator.Error!void {
-        switch (self.output.stmts.items[@intFromEnum(stmt_id)]) {
-            .let_ => |let_| try self.registerNestedLambdas(let_.value, visited),
-            .expr,
-            .expect,
-            .dbg,
-            .return_,
-            => |expr| try self.registerNestedLambdas(expr, visited),
-            .crash => {},
-        }
-    }
-
     /// Solve every function's capture set as a least fixed point over the
     /// function-reference graph. Each function's captures are the free locals
     /// of its body, where a reference to another function contributes that
     /// callee's solved captures (filtered by the locals bound at the reference
     /// site). The all-empty assignment is the bottom; `addIfFree` only ever
-    /// grows a set, so iteration is monotone and terminates. Self- and mutual
-    /// recursion converge because each round reads the previous round's sets.
-    /// A final normalizing pass rewrites every set from the converged sets so
-    /// capture order is deterministic regardless of the round a member entered.
+    /// grows a set, so iteration is monotone and terminates.
+    ///
+    /// Propagation is edge-driven: re-solving a function only when one of its
+    /// callees grew, via the reverse-edge map, instead of re-walking every
+    /// function each round. A function's stored order is its body's discovery
+    /// order under the final callee sets — deterministic and self-consistent
+    /// (every consumer of a function reads that one span), which is all the
+    /// downstream positional capture handling requires.
     fn computeCaptureFixpoint(self: *Lifter) Allocator.Error!void {
         const count = self.output.fns.items.len;
         self.fn_captures = try self.allocator.alloc(std.ArrayList(Ast.TypedLocal), count);
         for (self.fn_captures) |*captures| captures.* = .empty;
 
-        var changed = true;
-        while (changed) {
-            changed = false;
-            for (0..count) |raw| {
-                var solved = try self.solveFnCaptures(@enumFromInt(@as(u32, @intCast(raw))));
-                defer solved.deinit();
-                if (solved.items.items.len > self.fn_captures[raw].items.len) {
-                    self.fn_captures[raw].clearRetainingCapacity();
-                    try self.fn_captures[raw].appendSlice(self.allocator, solved.items.items);
-                    changed = true;
+        // Callers indexed by callee, built from the edges each solve records.
+        const callers = try self.allocator.alloc(std.ArrayList(Ast.FnId), count);
+        defer {
+            for (callers) |*list| list.deinit(self.allocator);
+            self.allocator.free(callers);
+        }
+        for (callers) |*list| list.* = .empty;
+
+        var queued = try self.allocator.alloc(bool, count);
+        defer self.allocator.free(queued);
+        @memset(queued, true);
+
+        var worklist = std.ArrayList(Ast.FnId).empty;
+        defer worklist.deinit(self.allocator);
+        try worklist.ensureTotalCapacity(self.allocator, count);
+        for (0..count) |raw| worklist.appendAssumeCapacity(@enumFromInt(@as(u32, @intCast(raw))));
+
+        var scratch = CaptureSet.init(self);
+        defer scratch.deinit();
+        var bound = BoundSet.init(self.allocator);
+        defer bound.deinit();
+
+        while (worklist.pop()) |fn_id| {
+            const raw = @intFromEnum(fn_id);
+            queued[raw] = false;
+
+            try self.solveInto(fn_id, &scratch, &bound);
+
+            // Edges are structural (independent of the captures being solved),
+            // so recording each one at most once builds the reverse-edge map.
+            for (scratch.edges.items) |callee| {
+                try addCallerOnce(self.allocator, &callers[@intFromEnum(callee)], fn_id);
+            }
+
+            if (scratch.items.items.len > self.fn_captures[raw].items.len) {
+                self.fn_captures[raw].clearRetainingCapacity();
+                try self.fn_captures[raw].appendSlice(self.allocator, scratch.items.items);
+                for (callers[raw].items) |caller| {
+                    const craw = @intFromEnum(caller);
+                    if (!queued[craw]) {
+                        queued[craw] = true;
+                        try worklist.append(self.allocator, caller);
+                    }
                 }
             }
         }
-
-        for (0..count) |raw| {
-            var solved = try self.solveFnCaptures(@enumFromInt(@as(u32, @intCast(raw))));
-            defer solved.deinit();
-            self.fn_captures[raw].clearRetainingCapacity();
-            try self.fn_captures[raw].appendSlice(self.allocator, solved.items.items);
-        }
     }
 
-    /// One capture pass over a function body, reading the current solved
-    /// captures of referenced functions. The caller owns the returned set.
-    fn solveFnCaptures(self: *Lifter, fn_id: Ast.FnId) Allocator.Error!CaptureSet {
-        var captures = CaptureSet.init(self);
-        errdefer captures.deinit();
-        const body = self.fn_bodies.items[@intFromEnum(fn_id)] orelse return captures;
-        var bound = BoundSet.init(self.allocator);
-        defer bound.deinit();
-        try bindTypedLocals(self.output, &bound, self.output.typedLocalSpan(body.args));
+    /// Append `caller` to `list` unless already present (lists stay short, so
+    /// a linear check is cheaper than a hash set).
+    fn addCallerOnce(allocator: Allocator, list: *std.ArrayList(Ast.FnId), caller: Ast.FnId) Allocator.Error!void {
+        if (std.mem.findScalar(Ast.FnId, list.items, caller) != null) return;
+        try list.append(allocator, caller);
+    }
+
+    /// Solve one function's captures into the reusable `scratch`/`bound`,
+    /// reading the current solved sets of referenced functions and recording
+    /// edges. Both scratch buffers are cleared first.
+    fn solveInto(self: *Lifter, fn_id: Ast.FnId, scratch: *CaptureSet, bound: *BoundSet) Allocator.Error!void {
+        scratch.clear();
+        bound.clear();
+        const body = self.fn_bodies.items[@intFromEnum(fn_id)] orelse return;
+        try bindTypedLocals(self.output, bound, self.output.typedLocalSpan(body.args));
         switch (body.body) {
-            .roc => |expr| try captures.collectExpr(expr, &bound),
+            .roc => |expr| try scratch.collectExpr(expr, bound),
             .hosted => {},
         }
-        return captures;
     }
 
     fn registerFn(self: *Lifter, mono_fn_id: Mono.FnId, fn_id: Ast.FnId) void {
@@ -688,6 +623,12 @@ const BoundSet = struct {
             _ = self.binders.remove(binder);
         }
     }
+
+    /// Reset for reuse across fixpoint solves without freeing capacity.
+    fn clear(self: *BoundSet) void {
+        self.locals.clearRetainingCapacity();
+        self.binders.clearRetainingCapacity();
+    }
 };
 
 const CaptureSet = struct {
@@ -695,6 +636,10 @@ const CaptureSet = struct {
     lifter: *Lifter,
     items: std.ArrayList(Ast.TypedLocal),
     seen: std.AutoHashMap(Mono.LocalId, void),
+    /// Functions this body references (via `fn_def`/`call_proc`); the capture
+    /// fixpoint's edge set. Populated only when the caller cares (the fixpoint);
+    /// other users leave it unread.
+    edges: std.ArrayList(Ast.FnId),
 
     fn init(lifter: *Lifter) CaptureSet {
         return .{
@@ -702,12 +647,21 @@ const CaptureSet = struct {
             .lifter = lifter,
             .items = .empty,
             .seen = std.AutoHashMap(Mono.LocalId, void).init(lifter.allocator),
+            .edges = .empty,
         };
     }
 
     fn deinit(self: *CaptureSet) void {
         self.seen.deinit();
         self.items.deinit(self.allocator);
+        self.edges.deinit(self.allocator);
+    }
+
+    /// Reset for reuse across fixpoint solves without freeing capacity.
+    fn clear(self: *CaptureSet) void {
+        self.items.clearRetainingCapacity();
+        self.seen.clearRetainingCapacity();
+        self.edges.clearRetainingCapacity();
     }
 
     fn addIfFree(self: *CaptureSet, local: Mono.LocalId, bound: *const BoundSet) Allocator.Error!void {
@@ -757,7 +711,13 @@ const CaptureSet = struct {
                 try self.collectExpr(let_.rest, bound);
                 removeBound(input, bound, added.items);
             },
-            .lambda => |lambda| try self.collectFnCaptures(self.lifter.liftedFn(lambda.fn_id), bound),
+            .lambda => |lambda| {
+                var added = std.ArrayList(Mono.LocalId).empty;
+                defer added.deinit(self.allocator);
+                try bindTypedLocalsTracked(self.allocator, input, bound, input.typedLocalSpan(lambda.args), &added);
+                try self.collectExpr(lambda.body, bound);
+                removeBound(input, bound, added.items);
+            },
             .call_value => |call| {
                 try self.collectExpr(call.callee, bound);
                 for (input.exprSpan(call.args)) |arg| try self.collectExpr(arg, bound);
@@ -822,7 +782,12 @@ const CaptureSet = struct {
     /// round's value, which is exactly what makes recursion converge.
     fn collectFnCaptures(self: *CaptureSet, fn_id: Ast.FnId, caller_bound: *BoundSet) Allocator.Error!void {
         const raw = @intFromEnum(fn_id);
-        if (raw >= self.lifter.fn_captures.len) return;
+        // Only defs and nested defs are reachable here (direct and
+        // devirtualized calls and `fn_def` references never target an inline
+        // lambda), and every one has a fixpoint entry. An out-of-range id
+        // means an earlier stage produced a call target the fixpoint never saw.
+        if (raw >= self.lifter.fn_captures.len) Common.invariant("capture collection referenced a function without a solved capture set");
+        try self.edges.append(self.allocator, fn_id);
         for (self.lifter.fn_captures[raw].items) |capture| {
             try self.addIfFree(capture.local, caller_bound);
         }

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -123,8 +123,6 @@ pub fn run(
     return program;
 }
 
-const FnActiveSet = std.AutoHashMap(Ast.FnId, void);
-
 const DefMap = []?Ast.FnId;
 const NestedDefMap = []?Ast.FnId;
 const FnMap = []?Ast.FnId;
@@ -147,6 +145,12 @@ const Lifter = struct {
     nested_fn_ids: std.AutoHashMap(Ast.FnId, void),
     initialized_fns: std.AutoHashMap(Ast.FnId, void),
     symbols: Common.SymbolGen,
+    /// Solved capture set per lifted function, indexed by `Ast.FnId`. Computed
+    /// as a least fixed point over the function-reference graph before any body
+    /// is rewritten, so it never depends on lifting order or rewrite-collapsed
+    /// nodes. Every later stage reads this rather than re-deriving captures by
+    /// walking (possibly already-rewritten) bodies.
+    fn_captures: []std.ArrayList(Ast.TypedLocal),
 
     fn init(allocator: Allocator, source: *const Mono.Program, output: *Ast.Program) Allocator.Error!Lifter {
         const expr_done = try allocator.alloc(bool, output.exprCount());
@@ -170,10 +174,13 @@ const Lifter = struct {
             .nested_fn_ids = std.AutoHashMap(Ast.FnId, void).init(allocator),
             .initialized_fns = std.AutoHashMap(Ast.FnId, void).init(allocator),
             .symbols = .{ .next = source.next_symbol },
+            .fn_captures = &.{},
         };
     }
 
     fn deinit(self: *Lifter) void {
+        for (self.fn_captures) |*captures| captures.deinit(self.allocator);
+        if (self.fn_captures.len > 0) self.allocator.free(self.fn_captures);
         self.initialized_fns.deinit();
         self.nested_fn_ids.deinit();
         self.fn_bodies.deinit(self.allocator);
@@ -209,6 +216,25 @@ const Lifter = struct {
             try self.nested_fn_ids.put(fn_id, {});
             self.registerFn(def.fn_id, fn_id);
         }
+
+        // Reserve and register every nested lambda body so the capture
+        // fixpoint below covers all functions, not just defs and nested defs.
+        // This walks the un-rewritten bodies; rewriting happens only later.
+        {
+            const reserved_count = self.output.fns.items.len;
+            const visited = try self.allocator.alloc(bool, self.output.exprCount());
+            defer self.allocator.free(visited);
+            @memset(visited, false);
+            for (0..reserved_count) |raw| {
+                const body = self.fn_bodies.items[raw] orelse continue;
+                switch (body.body) {
+                    .roc => |expr| try self.registerNestedLambdas(expr, visited),
+                    .hosted => {},
+                }
+            }
+        }
+
+        try self.computeCaptureFixpoint();
 
         for (self.source.defs.items, 0..) |def, index| {
             try self.lowerTopLevelDef(self.def_map[index] orelse
@@ -247,19 +273,7 @@ const Lifter = struct {
     }
 
     fn lowerTopLevelDef(self: *Lifter, fn_id: Ast.FnId, def: Mono.Def) Allocator.Error!void {
-        var active = self.initFnActiveSet();
-        defer active.deinit();
-        var captures = CaptureSet.init(self, &active);
-        defer captures.deinit();
-        var bound = BoundSet.init(self.allocator);
-        defer bound.deinit();
-        try bindTypedLocals(self.output, &bound, self.output.typedLocalSpan(def.args));
-        switch (def.body) {
-            .roc => |body| try captures.collectExpr(body, &bound),
-            .hosted => {},
-        }
-
-        if (captures.items.items.len != 0) {
+        if (self.fn_captures[@intFromEnum(fn_id)].items.len != 0) {
             Common.invariant("top-level Monotype definition has free locals after checked closure collection");
         }
 
@@ -282,17 +296,8 @@ const Lifter = struct {
     }
 
     fn lowerNestedDef(self: *Lifter, fn_id: Ast.FnId, def: Mono.NestedDef) Allocator.Error!void {
-        var active = self.initFnActiveSet();
-        defer active.deinit();
-        var captures = CaptureSet.init(self, &active);
-        defer captures.deinit();
-        var bound = BoundSet.init(self.allocator);
-        defer bound.deinit();
-        try bindTypedLocals(self.output, &bound, self.output.typedLocalSpan(def.args));
-        try captures.collectExpr(def.body, &bound);
-
         try self.rewriteExpr(def.body);
-        const capture_span = try self.output.addTypedLocalSpan(captures.items.items);
+        const capture_span = try self.output.addTypedLocalSpan(self.fn_captures[@intFromEnum(fn_id)].items);
         self.output.fns.items[@intFromEnum(fn_id)] = .{
             .symbol = def.symbol,
             .source = self.nestedSource(def.fn_id, def.fn_def),
@@ -418,17 +423,8 @@ const Lifter = struct {
         if (self.initialized_fns.contains(fn_id)) return;
 
         try self.setFnBody(fn_id, .{ .args = lambda.args, .body = .{ .roc = lambda.body } });
-        var active = self.initFnActiveSet();
-        defer active.deinit();
-        var captures = CaptureSet.init(self, &active);
-        defer captures.deinit();
-        var bound = BoundSet.init(self.allocator);
-        defer bound.deinit();
-        try bindTypedLocals(self.output, &bound, self.output.typedLocalSpan(lambda.args));
-        try captures.collectExpr(lambda.body, &bound);
-
         try self.rewriteExpr(lambda.body);
-        const capture_span = try self.output.addTypedLocalSpan(captures.items.items);
+        const capture_span = try self.output.addTypedLocalSpan(self.fn_captures[@intFromEnum(fn_id)].items);
         self.output.fns.items[@intFromEnum(fn_id)] = .{
             .symbol = self.symbols.fresh(),
             .source = self.source.fnSource(lambda.fn_id),
@@ -458,8 +454,152 @@ const Lifter = struct {
         self.fn_bodies.items[raw] = body;
     }
 
-    fn initFnActiveSet(self: *Lifter) FnActiveSet {
-        return FnActiveSet.init(self.allocator);
+    /// Reserve a lifted function id and record the body for every nested
+    /// lambda reachable from `expr_id`, without rewriting anything. Run before
+    /// the capture fixpoint so that every function — including inline lambdas
+    /// — participates in it. `visited` guards shared sub-expressions.
+    fn registerNestedLambdas(self: *Lifter, expr_id: Mono.ExprId, visited: []bool) Allocator.Error!void {
+        const index = @intFromEnum(expr_id);
+        if (visited[index]) return;
+        visited[index] = true;
+
+        const input = self.output;
+        switch (input.exprs.items[index].data) {
+            .local,
+            .unit,
+            .int_lit,
+            .frac_f32_lit,
+            .frac_f64_lit,
+            .dec_lit,
+            .str_lit,
+            .def_ref,
+            .fn_ref,
+            .fn_def,
+            .crash,
+            .comptime_exhaustiveness_failed,
+            => {},
+            .list,
+            .tuple,
+            => |items| for (input.exprSpan(items)) |child| try self.registerNestedLambdas(child, visited),
+            .record => |fields| for (input.fieldExprSpan(fields)) |field| try self.registerNestedLambdas(field.value, visited),
+            .tag => |tag| for (input.exprSpan(tag.payloads)) |child| try self.registerNestedLambdas(child, visited),
+            .nominal,
+            .return_,
+            .dbg,
+            .expect,
+            => |child| try self.registerNestedLambdas(child, visited),
+            .expect_err => |expect_err| try self.registerNestedLambdas(expect_err.msg, visited),
+            .comptime_branch_taken => |taken| try self.registerNestedLambdas(taken.body, visited),
+            .let_ => |let_| {
+                try self.registerNestedLambdas(let_.value, visited);
+                try self.registerNestedLambdas(let_.rest, visited);
+            },
+            .lambda => |lambda| {
+                const fn_id = try self.reserveFn(lambda.fn_id);
+                try self.setFnBody(fn_id, .{ .args = lambda.args, .body = .{ .roc = lambda.body } });
+                try self.registerNestedLambdas(lambda.body, visited);
+            },
+            .call_value => |call| {
+                try self.registerNestedLambdas(call.callee, visited);
+                for (input.exprSpan(call.args)) |arg| try self.registerNestedLambdas(arg, visited);
+            },
+            .call_proc => |call| for (input.exprSpan(call.args)) |arg| try self.registerNestedLambdas(arg, visited),
+            .low_level => |call| for (input.exprSpan(call.args)) |arg| try self.registerNestedLambdas(arg, visited),
+            .field_access => |field| try self.registerNestedLambdas(field.receiver, visited),
+            .tuple_access => |access| try self.registerNestedLambdas(access.tuple, visited),
+            .structural_eq => |eq| {
+                try self.registerNestedLambdas(eq.lhs, visited);
+                try self.registerNestedLambdas(eq.rhs, visited);
+            },
+            .match_ => |match| {
+                try self.registerNestedLambdas(match.scrutinee, visited);
+                for (input.branchSpan(match.branches)) |branch| {
+                    if (branch.guard) |guard| try self.registerNestedLambdas(guard, visited);
+                    try self.registerNestedLambdas(branch.body, visited);
+                }
+            },
+            .if_ => |if_| {
+                for (input.ifBranchSpan(if_.branches)) |branch| {
+                    try self.registerNestedLambdas(branch.cond, visited);
+                    try self.registerNestedLambdas(branch.body, visited);
+                }
+                try self.registerNestedLambdas(if_.final_else, visited);
+            },
+            .block => |block| {
+                for (input.stmtSpan(block.statements)) |stmt| try self.registerNestedLambdasStmt(stmt, visited);
+                try self.registerNestedLambdas(block.final_expr, visited);
+            },
+            .loop_ => |loop| {
+                for (input.exprSpan(loop.initial_values)) |initial| try self.registerNestedLambdas(initial, visited);
+                try self.registerNestedLambdas(loop.body, visited);
+            },
+            .break_ => |maybe| if (maybe) |value| try self.registerNestedLambdas(value, visited),
+            .continue_ => |continue_| for (input.exprSpan(continue_.values)) |value| try self.registerNestedLambdas(value, visited),
+        }
+    }
+
+    fn registerNestedLambdasStmt(self: *Lifter, stmt_id: Mono.StmtId, visited: []bool) Allocator.Error!void {
+        switch (self.output.stmts.items[@intFromEnum(stmt_id)]) {
+            .let_ => |let_| try self.registerNestedLambdas(let_.value, visited),
+            .expr,
+            .expect,
+            .dbg,
+            .return_,
+            => |expr| try self.registerNestedLambdas(expr, visited),
+            .crash => {},
+        }
+    }
+
+    /// Solve every function's capture set as a least fixed point over the
+    /// function-reference graph. Each function's captures are the free locals
+    /// of its body, where a reference to another function contributes that
+    /// callee's solved captures (filtered by the locals bound at the reference
+    /// site). The all-empty assignment is the bottom; `addIfFree` only ever
+    /// grows a set, so iteration is monotone and terminates. Self- and mutual
+    /// recursion converge because each round reads the previous round's sets.
+    /// A final normalizing pass rewrites every set from the converged sets so
+    /// capture order is deterministic regardless of the round a member entered.
+    fn computeCaptureFixpoint(self: *Lifter) Allocator.Error!void {
+        const count = self.output.fns.items.len;
+        self.fn_captures = try self.allocator.alloc(std.ArrayList(Ast.TypedLocal), count);
+        for (self.fn_captures) |*captures| captures.* = .empty;
+
+        var changed = true;
+        while (changed) {
+            changed = false;
+            for (0..count) |raw| {
+                var solved = try self.solveFnCaptures(@enumFromInt(@as(u32, @intCast(raw))));
+                defer solved.deinit();
+                if (solved.items.items.len > self.fn_captures[raw].items.len) {
+                    self.fn_captures[raw].clearRetainingCapacity();
+                    try self.fn_captures[raw].appendSlice(self.allocator, solved.items.items);
+                    changed = true;
+                }
+            }
+        }
+
+        for (0..count) |raw| {
+            var solved = try self.solveFnCaptures(@enumFromInt(@as(u32, @intCast(raw))));
+            defer solved.deinit();
+            self.fn_captures[raw].clearRetainingCapacity();
+            try self.fn_captures[raw].appendSlice(self.allocator, solved.items.items);
+        }
+    }
+
+    /// One capture pass over a function body, reading the current solved
+    /// captures of referenced functions. The caller owns the returned set.
+    fn solveFnCaptures(self: *Lifter, fn_id: Ast.FnId) Allocator.Error!CaptureSet {
+        var captures = CaptureSet.init(self);
+        errdefer captures.deinit();
+        const body = self.fn_bodies.items[@intFromEnum(fn_id)] orelse return captures;
+        var bound = BoundSet.init(self.allocator);
+        defer bound.deinit();
+        try bindTypedLocals(self.output, &bound, self.output.typedLocalSpan(body.args));
+        switch (body.body) {
+            .roc => |expr| try captures.collectExpr(expr, &bound),
+            .hosted => {},
+        }
+        return captures;
     }
 
     fn registerFn(self: *Lifter, mono_fn_id: Mono.FnId, fn_id: Ast.FnId) void {
@@ -555,15 +695,13 @@ const CaptureSet = struct {
     lifter: *Lifter,
     items: std.ArrayList(Ast.TypedLocal),
     seen: std.AutoHashMap(Mono.LocalId, void),
-    active: *FnActiveSet,
 
-    fn init(lifter: *Lifter, active: *FnActiveSet) CaptureSet {
+    fn init(lifter: *Lifter) CaptureSet {
         return .{
             .allocator = lifter.allocator,
             .lifter = lifter,
             .items = .empty,
             .seen = std.AutoHashMap(Mono.LocalId, void).init(lifter.allocator),
-            .active = active,
         };
     }
 
@@ -619,13 +757,7 @@ const CaptureSet = struct {
                 try self.collectExpr(let_.rest, bound);
                 removeBound(input, bound, added.items);
             },
-            .lambda => |lambda| {
-                var added = std.ArrayList(Mono.LocalId).empty;
-                defer added.deinit(self.allocator);
-                try bindTypedLocalsTracked(self.allocator, input, bound, input.typedLocalSpan(lambda.args), &added);
-                try self.collectExpr(lambda.body, bound);
-                removeBound(input, bound, added.items);
-            },
+            .lambda => |lambda| try self.collectFnCaptures(self.lifter.liftedFn(lambda.fn_id), bound),
             .call_value => |call| {
                 try self.collectExpr(call.callee, bound);
                 for (input.exprSpan(call.args)) |arg| try self.collectExpr(arg, bound);
@@ -682,26 +814,16 @@ const CaptureSet = struct {
         }
     }
 
+    /// Contribute a referenced function's solved captures to the current set,
+    /// filtered by the locals bound at the reference site. Reads the solved
+    /// set rather than re-walking the callee's body, so it is correct even
+    /// after the callee's body has been rewritten and never under-approximates
+    /// recursive references. During the fixpoint the read set is the previous
+    /// round's value, which is exactly what makes recursion converge.
     fn collectFnCaptures(self: *CaptureSet, fn_id: Ast.FnId, caller_bound: *BoundSet) Allocator.Error!void {
         const raw = @intFromEnum(fn_id);
-        if (raw >= self.lifter.fn_bodies.items.len) Common.invariant("capture collection referenced a missing lifted function");
-        const body = self.lifter.fn_bodies.items[raw] orelse return;
-        const entry = try self.active.getOrPut(fn_id);
-        if (entry.found_existing) return;
-        defer _ = self.active.remove(fn_id);
-
-        var local_captures = CaptureSet.init(self.lifter, self.active);
-        defer local_captures.deinit();
-
-        var body_bound = BoundSet.init(self.allocator);
-        defer body_bound.deinit();
-        try bindTypedLocals(self.lifter.output, &body_bound, self.lifter.output.typedLocalSpan(body.args));
-        switch (body.body) {
-            .roc => |expr| try local_captures.collectExpr(expr, &body_bound),
-            .hosted => {},
-        }
-
-        for (local_captures.items.items) |capture| {
+        if (raw >= self.lifter.fn_captures.len) return;
+        for (self.lifter.fn_captures[raw].items) |capture| {
             try self.addIfFree(capture.local, caller_bound);
         }
     }

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -464,11 +464,18 @@ const Lifter = struct {
     /// (every consumer of a function reads that one span), which is all the
     /// downstream positional capture handling requires.
     fn computeCaptureFixpoint(self: *Lifter) Allocator.Error!void {
+        // `count` covers top-level defs and nested defs only; inline lambdas are
+        // reserved later, during `rewriteExpr`/`liftLambda`. Sizing here is what
+        // keeps inline lambdas out of the fixpoint, which is sound because they
+        // are never the target of a reference that reaches `collectFnCaptures`
+        // (only defs and nested defs are) — an invariant that function enforces.
         const count = self.output.fns.items.len;
         self.fn_captures = try self.allocator.alloc(std.ArrayList(Ast.TypedLocal), count);
         for (self.fn_captures) |*captures| captures.* = .empty;
 
-        // Callers indexed by callee, built from the edges each solve records.
+        // Callers indexed by callee. Edges are structural — independent of the
+        // captures being solved — so the reverse map is built once, from each
+        // function's first solve, rather than re-derived on every re-solve.
         const callers = try self.allocator.alloc(std.ArrayList(Ast.FnId), count);
         defer {
             for (callers) |*list| list.deinit(self.allocator);
@@ -480,6 +487,10 @@ const Lifter = struct {
         defer self.allocator.free(queued);
         @memset(queued, true);
 
+        var recorded = try self.allocator.alloc(bool, count);
+        defer self.allocator.free(recorded);
+        @memset(recorded, false);
+
         var worklist = std.ArrayList(Ast.FnId).empty;
         defer worklist.deinit(self.allocator);
         try worklist.ensureTotalCapacity(self.allocator, count);
@@ -489,17 +500,25 @@ const Lifter = struct {
         defer scratch.deinit();
         var bound = BoundSet.init(self.allocator);
         defer bound.deinit();
+        var edge_buf = std.ArrayList(Ast.FnId).empty;
+        defer edge_buf.deinit(self.allocator);
 
         while (worklist.pop()) |fn_id| {
             const raw = @intFromEnum(fn_id);
             queued[raw] = false;
 
-            try self.solveInto(fn_id, &scratch, &bound);
-
-            // Edges are structural (independent of the captures being solved),
-            // so recording each one at most once builds the reverse-edge map.
-            for (scratch.edges.items) |callee| {
-                try addCallerOnce(self.allocator, &callers[@intFromEnum(callee)], fn_id);
+            // Collect edges only on the first solve of each function; the
+            // reverse map they build is complete because every function is
+            // solved at least once (all start queued).
+            if (recorded[raw]) {
+                try self.solveInto(fn_id, &scratch, &bound, null);
+            } else {
+                edge_buf.clearRetainingCapacity();
+                try self.solveInto(fn_id, &scratch, &bound, &edge_buf);
+                for (edge_buf.items) |callee| {
+                    try callers[@intFromEnum(callee)].append(self.allocator, fn_id);
+                }
+                recorded[raw] = true;
             }
 
             if (scratch.items.items.len > self.fn_captures[raw].items.len) {
@@ -516,18 +535,14 @@ const Lifter = struct {
         }
     }
 
-    /// Append `caller` to `list` unless already present (lists stay short, so
-    /// a linear check is cheaper than a hash set).
-    fn addCallerOnce(allocator: Allocator, list: *std.ArrayList(Ast.FnId), caller: Ast.FnId) Allocator.Error!void {
-        if (std.mem.findScalar(Ast.FnId, list.items, caller) != null) return;
-        try list.append(allocator, caller);
-    }
-
     /// Solve one function's captures into the reusable `scratch`/`bound`,
-    /// reading the current solved sets of referenced functions and recording
-    /// edges. Both scratch buffers are cleared first.
-    fn solveInto(self: *Lifter, fn_id: Ast.FnId, scratch: *CaptureSet, bound: *BoundSet) Allocator.Error!void {
+    /// reading the current solved sets of referenced functions. When
+    /// `edges_out` is non-null, the referenced functions are recorded there
+    /// (used to build the reverse-edge map on a function's first solve). Both
+    /// scratch buffers are cleared first.
+    fn solveInto(self: *Lifter, fn_id: Ast.FnId, scratch: *CaptureSet, bound: *BoundSet, edges_out: ?*std.ArrayList(Ast.FnId)) Allocator.Error!void {
         scratch.clear();
+        scratch.edges = edges_out;
         bound.clear();
         const body = self.fn_bodies.items[@intFromEnum(fn_id)] orelse return;
         try bindTypedLocals(self.output, bound, self.output.typedLocalSpan(body.args));
@@ -636,10 +651,11 @@ const CaptureSet = struct {
     lifter: *Lifter,
     items: std.ArrayList(Ast.TypedLocal),
     seen: std.AutoHashMap(Mono.LocalId, void),
-    /// Functions this body references (via `fn_def`/`call_proc`); the capture
-    /// fixpoint's edge set. Populated only when the caller cares (the fixpoint);
-    /// other users leave it unread.
-    edges: std.ArrayList(Ast.FnId),
+    /// Optional, caller-owned sink for the functions this body references (via
+    /// `fn_def`/`call_proc`). The capture fixpoint points it at a buffer on a
+    /// function's first solve to build its edge set; every other use leaves it
+    /// null and pays nothing.
+    edges: ?*std.ArrayList(Ast.FnId) = null,
 
     fn init(lifter: *Lifter) CaptureSet {
         return .{
@@ -647,21 +663,19 @@ const CaptureSet = struct {
             .lifter = lifter,
             .items = .empty,
             .seen = std.AutoHashMap(Mono.LocalId, void).init(lifter.allocator),
-            .edges = .empty,
         };
     }
 
     fn deinit(self: *CaptureSet) void {
         self.seen.deinit();
         self.items.deinit(self.allocator);
-        self.edges.deinit(self.allocator);
     }
 
-    /// Reset for reuse across fixpoint solves without freeing capacity.
+    /// Reset for reuse across fixpoint solves without freeing capacity. The
+    /// edge sink is caller-owned and reassigned per solve, so it is not touched.
     fn clear(self: *CaptureSet) void {
         self.items.clearRetainingCapacity();
         self.seen.clearRetainingCapacity();
-        self.edges.clearRetainingCapacity();
     }
 
     fn addIfFree(self: *CaptureSet, local: Mono.LocalId, bound: *const BoundSet) Allocator.Error!void {
@@ -787,7 +801,7 @@ const CaptureSet = struct {
         // lambda), and every one has a fixpoint entry. An out-of-range id
         // means an earlier stage produced a call target the fixpoint never saw.
         if (raw >= self.lifter.fn_captures.len) Common.invariant("capture collection referenced a function without a solved capture set");
-        try self.edges.append(self.allocator, fn_id);
+        if (self.edges) |sink| try sink.append(self.allocator, fn_id);
         for (self.lifter.fn_captures[raw].items) |capture| {
             try self.addIfFree(capture.local, caller_bound);
         }


### PR DESCRIPTION
Recursive closures that capture refcounted values were miscompiled, surfacing as ARC borrow-certifier panics (issue #9634). Two independent root causes are fixed here.

Lambda lifting computed each function's capture set by re-walking referenced functions' bodies on demand, but those bodies are rewritten (lambda/fn_def nodes collapse to fn_ref) right after their captures are computed — so a function lifted later re-walked an already-rewritten sibling and silently dropped transitive captures, emitting a use of a free local that does not exist in that proc. Capture sets are now solved as a least fixed point over the function-reference graph, computed on un-rewritten bodies before any rewriting, via an edge-driven worklist. The result is independent of lifting order and of rewrite-collapsed nodes, and recursive references converge instead of being under-approximated.

Separately, join-parameter scalarization split a captured struct parameter of a plain tail-call-eliminated loop into per-field parameters but never seeded those fields on the proc-entry path, which enters the loop with a bare jump whose values arrive through the proc arguments rather than an initialize_join_param write — leaving the field unbound on the first iteration. Scalarization now seeds them once on the join's remainder by reading the argument struct's fields, gated on the parameter being a proc argument (the only join shape with a write-less entry).