### PR TITLE
fix(nix): build kcov in the dev shell on macOS

### DIFF
--- a/src/flake.nix
+++ b/src/flake.nix
@@ -37,12 +37,32 @@
         pkgs = import nixpkgs { inherit system; };
         isLinux = pkgs.stdenv.isLinux;
 
-        # kcov build dependencies for Linux (coverage uses custom kcov fork built from source)
+        # kcov (built from source for coverage on every platform) links system
+        # libs via pkg-config, but asks for "z"/"curl"/"dwarf" while nixpkgs
+        # ships "zlib"/"libcurl"/"libdwarf". Provide alias .pc files so those
+        # resolve; they must be packages since the nix pkg-config wrapper only
+        # reads .pc dirs from buildInputs. On macOS the bare "-l" fallback only
+        # searches the SDK (which has neither libz nor libcurl), so every lib
+        # must resolve through pkg-config here.
+        pcConfigAlias = name: pkg: pcName: pkgs.runCommand "pkgconfig-alias-${name}" { } ''
+          mkdir -p "$out/lib/pkgconfig"
+          cp "$(find ${pkg} -name '${pcName}.pc' | head -n1)" "$out/lib/pkgconfig/${name}.pc"
+        '';
         kcovBuildDeps = with pkgs; [
-          elfutils
           pkg-config
           curl
           zlib
+          (pcConfigAlias "z" zlib.dev "zlib")
+          (pcConfigAlias "curl" curl.dev "libcurl")
+        ];
+        # elfutils (libdw/libelf for DWARF parsing) is used by kcov on Linux.
+        kcovLinuxOnlyDeps = with pkgs; [
+          elfutils
+        ];
+        # macOS kcov uses libdwarf (linked as "dwarf") instead of elfutils.
+        kcovDarwinOnlyDeps = with pkgs; [
+          libdwarf
+          (pcConfigAlias "dwarf" libdwarf.dev "libdwarf")
         ];
         zig = pkgs.zig_0_16;
         dependencies = [
@@ -53,7 +73,9 @@
           pkgs.jq # see ci/benchmarks_zig.sh
           (pkgs.writeShellScriptBin "zon2nix" "nix run github:Cloudef/zig2nix -- zon2nix")
         ]
-        ++ pkgs.lib.optionals isLinux kcovBuildDeps;
+        ++ kcovBuildDeps
+        ++ pkgs.lib.optionals isLinux kcovLinuxOnlyDeps
+        ++ pkgs.lib.optionals (!isLinux) kcovDarwinOnlyDeps;
 
         shellFunctions = ''
           buildcmd() {


### PR DESCRIPTION
## Problem

`zig build build-ci` (the `minici` flow) builds the custom kcov coverage tool from source on every platform, but the dev shell only provided kcov's link dependencies on Linux (`++ optionals isLinux kcovBuildDeps`). On macOS the build failed:

```
error: unable to find dynamic system library 'z' using strategy 'paths_first'
```

## Root cause

kcov links its system libraries via zig's `linkSystemLibrary`, which resolves them through pkg-config. nixpkgs ships these as the modules `zlib`/`libcurl`/`libdwarf`, but kcov asks for `z`/`curl`/`dwarf`. `curl` happens to resolve; `z` and `dwarf` do not. The nix pkg-config wrapper only reads `.pc` directories from `buildInputs` (via `PKG_CONFIG_PATH_FOR_TARGET`), not an exported `PKG_CONFIG_PATH`, so the aliases must be real packages.

## Fix (`src/flake.nix`)

- Provide `pkg-config`/`curl`/`zlib` on all platforms (not just Linux).
- Add alias `.pc` packages so `pkg-config z` → zlib and `pkg-config dwarf` → libdwarf resolve.
- On macOS add `libdwarf` (kcov links it as `dwarf`); keep `elfutils` Linux-only (kcov uses libdw/libelf there).

## Verification (macOS, inside `nix develop ./src`)

- `pkg-config z` and `pkg-config dwarf` both resolve
- `zig build build-coverage-tools` → exit 0
- `zig build build-ci --summary all --color off` → exit 0, no failures (kcov compiles + installs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)