### PR TITLE
Harden CI dependency fetching against transient git flakes

### DIFF
--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -180,8 +180,11 @@ jobs:
 
       - name: Run eval tests with LLVM backend
         if: runner.os != 'Windows'
-        run: |
-          zig build run-test-eval -- --llvm
+        uses: ./.github/actions/flaky-retry
+        with:
+          command: "zig build run-test-eval -- --llvm"
+          error_string_contains: "EndOfStream|503|Timeout|HttpConnectionClosing|WriteFailed|build.zig.zon"
+          retry_count: 3
 
       # Windows has no fork(), so the runner spawns a fresh worker process per
       # test that compiles the whole program (front-end + LIR lowering) before
@@ -193,8 +196,11 @@ jobs:
       # runners where 30s is plenty. Give Windows a larger hang budget.
       - name: Run eval tests with LLVM backend (Windows)
         if: runner.os == 'Windows'
-        run: |
-          zig build run-test-eval -- --llvm --timeout 120000
+        uses: ./.github/actions/flaky-retry
+        with:
+          command: "zig build run-test-eval -- --llvm --timeout 120000"
+          error_string_contains: "EndOfStream|503|Timeout|HttpConnectionClosing|WriteFailed|build.zig.zon"
+          retry_count: 3
 
       - name: Run CLI platform tests (LLVM size/speed backends)
         if: runner.os != 'Windows'
@@ -381,9 +387,11 @@ jobs:
           use-cache: true
 
       - name: build roc + repro executables for valgrind
-        run: |
-          git clean -fdx
-          zig build -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast -Dcpu=x86_64_v3 -Dtarget=x86_64-linux-musl -Dstrip=false -Dshared-memory-size=268435456
+        uses: ./.github/actions/flaky-retry
+        with:
+          command: "git clean -fdx && zig build -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast -Dcpu=x86_64_v3 -Dtarget=x86_64-linux-musl -Dstrip=false -Dshared-memory-size=268435456"
+          error_string_contains: "EndOfStream|503|Timeout|HttpConnectionClosing|WriteFailed|build.zig.zon"
+          retry_count: 3
 
       - name: install valgrind
         run: |

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,7 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .afl_kit = .{
-            .url = "git+https://github.com/bhansconnect/zig-afl-kit.git#c1f7353e006cf326ffab0a35b6e454cb5d8a5d7b",
+            .url = "https://github.com/bhansconnect/zig-afl-kit/archive/c1f7353e006cf326ffab0a35b6e454cb5d8a5d7b.tar.gz",
             .hash = "afl_kit-0.1.0-NdJ3csgfAABGuiQ4P99kFuaVSy4DHMilISiGF_VKX3xl",
             .lazy = true,
         },
@@ -49,15 +49,15 @@
             .lazy = true,
         },
         .bytebox = .{
-            .url = "git+https://github.com/lukewilliamboswell/bytebox.git?ref=zig-0.16.0#88a4b79230eece88030e6779f69ed9683906c02a",
+            .url = "https://github.com/lukewilliamboswell/bytebox/archive/88a4b79230eece88030e6779f69ed9683906c02a.tar.gz",
             .hash = "bytebox-0.0.1-SXc2saRyDwDEw8AkDhp4Hfmd9ZhRmMnIzS7FfzDCmc8r",
         },
         .zstd = .{
-            .url = "git+https://github.com/allyourcodebase/zstd?ref=1.5.7-1#e1a501be57f42c541e8a5597e4b59a074dfd09a3", // 1.5.7-1
+            .url = "https://github.com/allyourcodebase/zstd/archive/e1a501be57f42c541e8a5597e4b59a074dfd09a3.tar.gz", // 1.5.7-1
             .hash = "zstd-1.5.7-1-KEItkAMwAAD6OKY3m0OOmXG7aL-aLUfrDqbP5J5oYapU",
         },
         .kcov = .{
-            .url = "git+https://github.com/roc-lang/zig-kcov.git?ref=zig-0.16.0#5e1954e53ce775a6ecf65abd03ae67deee64ac3c",
+            .url = "https://github.com/roc-lang/zig-kcov/archive/5e1954e53ce775a6ecf65abd03ae67deee64ac3c.tar.gz",
             .hash = "kcov-42.0.1-EuAG4XacCwBu0G8YHvv6sFHfbMPZuwyBuZGqcRMi8IXq",
             .lazy = true,
         },

--- a/ci/tidy.zig
+++ b/ci/tidy.zig
@@ -240,6 +240,18 @@ const Errors = struct {
         );
     }
 
+    pub fn addGitDependency(errors: *Errors, file: SourceFile, offset: usize) void {
+        errors.emit(
+            "{s}:{d}: error: 'git+https://' dependency URLs are banned; use a GitHub archive " ++
+                "tarball instead, e.g. 'https://github.com/OWNER/REPO/archive/<commit>.tar.gz'. " ++
+                "'git+https' makes Zig fetch over the git smart-HTTP protocol, whose ref-discovery " ++
+                "handshake intermittently fails in CI with 'HttpConnectionClosing'; a plain tarball " ++
+                "URL is a reliable HTTP GET and, because Zig hashes the unpacked tree, produces the " ++
+                "exact same package hash.\n",
+            .{ file.path, file.lineNumber(offset) },
+        );
+    }
+
     pub fn addFileUntracked(errors: *Errors, file: []const u8) void {
         errors.emit(
             "{s}: error: imported file untracked by git\n",
@@ -302,6 +314,31 @@ fn tidyFile(
     }
     if (file.hasExtension(".md")) {
         tidyMarkdownTitle(file, errors);
+    }
+    if (file.hasExtension(".zon")) {
+        tidyBannedGitDependency(file, errors);
+    }
+}
+
+/// Ban `git+https://` dependency URLs in build.zig.zon. They make Zig fetch over
+/// the git smart-HTTP protocol, whose ref-discovery handshake intermittently
+/// fails in CI with `HttpConnectionClosing`. GitHub archive tarball URLs hit a
+/// reliable plain HTTP GET and resolve to the same package hash.
+fn tidyBannedGitDependency(file: SourceFile, errors: *Errors) void {
+    const banned = "git+https://";
+
+    var line_start: usize = 0;
+    while (line_start <= file.text.len) {
+        const line_end = std.mem.findScalarPos(u8, file.text, line_start, '\n') orelse file.text.len;
+        const line = file.text[line_start..line_end];
+        const trimmed = std.mem.trim(u8, line, " \t");
+        if (!std.mem.startsWith(u8, trimmed, "//")) {
+            if (std.mem.find(u8, line, banned)) |index| {
+                errors.addGitDependency(file, line_start + index);
+            }
+        }
+        if (line_end == file.text.len) break;
+        line_start = line_end + 1;
     }
 }
 


### PR DESCRIPTION
CI has been intermittently failing with `unable to discover remote git server capabilities: HttpConnectionClosing` when Zig fetches dependencies during `zig build`. The failure only ever hits the `git+https://` dependencies, never the plain-tarball ones, because `git+https` makes Zig run the git smart-HTTP protocol through its own HTTP client, and the ref-discovery handshake intermittently gets its connection dropped by GitHub. The plain `https://.../*.tar.xz` release-asset dependencies (the `roc_deps_*` entries) use a simple HTTP GET and never flake.

This switches the four `git+https://` dependencies (`afl_kit`, `bytebox`, `zstd`, `kcov`) to GitHub archive tarball URLs (`https://github.com/OWNER/REPO/archive/<commit>.tar.gz`), which go through the same reliable plain-HTTP path the `roc_deps_*` entries already use. Each is pinned to its existing full commit SHA, so the content is immutable, and since Zig hashes the unpacked file tree rather than the compressed bytes, every recorded hash is unchanged — `zig fetch` against each new URL reproduces the exact same hash, and a fresh `zig build --fetch` resolves cleanly.

As a second layer, the `eval-llvm` test steps and the `zig-valgrind` build step — which ran a bare `zig build` and so failed the whole job on a transient fetch error — are now wrapped in the existing `flaky-retry` action with the same network-error matcher already used by the cross-compile job. The Zig global package cache is already cached across runs via `mlugg/setup-zig`'s `use-cache: true`, so no additional caching layer is needed.

Finally, a tidy check bans `git+https://` URLs in any `.zon` file so the slow form can't be reintroduced by mistake; its failure message explains the handshake flakiness and points at the archive-tarball alternative.