### PR TITLE
Fix AArch64 dev backend stack args

### DIFF
--- a/src/backend/dev/CallingConvention.zig
+++ b/src/backend/dev/CallingConvention.zig
@@ -456,7 +456,13 @@ pub fn CallBuilder(comptime EmitType: type) type {
 
         /// Load a float from memory into a float register, dispatching to the target's emit.
         fn emitFloatLoad(self: *Self, dst: FloatReg, base_reg: GeneralReg, offset: i32, is_f64: bool) Allocator.Error!void {
-            if (comptime @hasDecl(EmitType, "fldrRegMemUoff")) {
+            if (comptime @hasDecl(EmitType, "fldrRegMemSoff")) {
+                if (is_f64) {
+                    try self.emit.fldrRegMemSoff(.double, dst, base_reg, offset);
+                } else {
+                    try self.emit.fldrRegMemSoff(.single, dst, base_reg, offset);
+                }
+            } else if (comptime @hasDecl(EmitType, "fldrRegMemUoff")) {
                 if (is_f64) {
                     try self.emit.fldrRegMemUoff(.double, dst, base_reg, @intCast(offset));
                 } else {

--- a/src/backend/dev/FrameBuilder.zig
+++ b/src/backend/dev/FrameBuilder.zig
@@ -88,6 +88,13 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
         /// This does NOT include space for callee-saved registers.
         stack_size: u32 = 0,
 
+        /// AArch64-only register that should hold the caller's stack-argument
+        /// base, which is the value of SP on callee entry. Deferred AArch64
+        /// prologues set FP to the bottom of the allocated frame, so incoming
+        /// stack arguments are at FP + actual_stack_alloc rather than a fixed
+        /// FP offset.
+        caller_stack_arg_base_reg: ?GeneralReg = null,
+
         /// Frame-pointer strategy for this function.
         frame_pointer_policy: FramePointerPolicy = FramePointerPolicy.forTarget(roc_target),
 
@@ -108,6 +115,20 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
         /// Set the stack space needed for local variables.
         pub fn setStackSize(self: *Self, size: u32) void {
             self.stack_size = size;
+        }
+
+        /// Ask the AArch64 prologue to materialize the caller's stack-argument
+        /// base into a callee-saved register. The caller is responsible for
+        /// marking that register as used so the normal callee-saved save/restore
+        /// path preserves the incoming value before this prologue overwrites it.
+        pub fn setCallerStackArgBaseReg(self: *Self, reg: GeneralReg) void {
+            if (!is_aarch64) {
+                if (std.debug.runtime_safety) {
+                    @panic("caller stack-argument base register is only meaningful on aarch64");
+                }
+                unreachable;
+            }
+            self.caller_stack_arg_base_reg = reg;
         }
 
         /// Override the frame-pointer strategy for this function.
@@ -401,6 +422,10 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
                 }
             }
 
+            if (self.caller_stack_arg_base_reg != null) {
+                size += if (aligned_frame <= 4095) 4 else 8;
+            }
+
             return size;
         }
 
@@ -450,6 +475,16 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
             }
         }
 
+        fn emitCallerStackArgBaseAarch64(self: *Self, emit: *EmitType, aligned_frame: u32) Allocator.Error!void {
+            const reg = self.caller_stack_arg_base_reg orelse return;
+            if (aligned_frame <= 4095) {
+                try emit.addRegRegImm12(.w64, reg, .FP, @intCast(aligned_frame));
+            } else {
+                try emit.movRegImm64(.IP0, aligned_frame);
+                try emit.addRegRegReg(.w64, reg, .FP, .IP0);
+            }
+        }
+
         fn emitPrologueAarch64(self: *Self, emit: *EmitType) Allocator.Error!i32 {
             // Calculate total frame size.
             // Use the FULL callee-saved area size (not just used pairs) because
@@ -484,6 +519,11 @@ pub fn DeferredFrameBuilder(comptime EmitType: type) type {
 
             // 3. Save callee-saved register pairs at fixed FP offsets
             try self.emitSaveCalleeSavedAarch64(emit);
+
+            // 4. The caller's outgoing stack arguments are above this frame.
+            // Materialize their base after saving callee-saved registers so the
+            // original value of this register is preserved in the save area.
+            try self.emitCallerStackArgBaseAarch64(emit, aligned_frame);
 
             self.actual_stack_alloc = aligned_frame;
 
@@ -1046,6 +1086,26 @@ test "DeferredFrameBuilder Windows aarch64 large frame prologue size matches emi
     _ = try frame.emitPrologue(&emit);
 
     try std.testing.expect(frame.actual_stack_alloc >= 4096);
+    try std.testing.expectEqual(calculated_size, @as(u32, @intCast(emit.buf.items.len)));
+}
+
+test "DeferredFrameBuilder aarch64 caller stack arg base prologue size matches emitted bytes" {
+    const Emit = aarch64.MacEmit;
+    const Builder = DeferredFrameBuilder(Emit);
+
+    var emit = Emit.init(std.testing.allocator);
+    defer emit.deinit();
+
+    var frame = Builder.init();
+    const x28_bit = @as(u32, 1) << @intFromEnum(aarch64.GeneralReg.X28);
+    frame.setCalleeSavedMask(x28_bit);
+    frame.setStackSize(64);
+    frame.setCallerStackArgBaseReg(.X28);
+
+    const calculated_size = frame.calculatePrologueSize();
+    _ = try frame.emitPrologue(&emit);
+
+    try std.testing.expect(frame.actual_stack_alloc >= 64);
     try std.testing.expectEqual(calculated_size, @as(u32, @intCast(emit.buf.items.len)));
 }
 

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -646,6 +646,10 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         /// Scratch/temporary register (not preserved across calls)
         const scratch_reg: GeneralReg = if (arch == .x86_64) .R11 else .X9;
 
+        /// AArch64 callee-saved register reserved for the caller's stack-argument
+        /// base in internal procs that actually receive stack arguments.
+        const caller_stack_arg_base_reg: GeneralReg = if (arch == .x86_64) frame_ptr else .X28;
+
         /// Return value registers (first, second, third)
         const ret_reg_0: GeneralReg = if (arch == .x86_64) .RAX else .X0;
         const ret_reg_1: GeneralReg = if (arch == .x86_64) .RDX else .X1;
@@ -655,7 +659,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         const EmitType = @TypeOf(@as(CodeGen, undefined).emit);
         const Builder = CallingConventionMod.CallBuilder(EmitType);
         const abi_shadow_space: i32 = @intCast(EmitType.CC.SHADOW_SPACE);
-        const incoming_stack_arg_base_offset: i32 = 16 + abi_shadow_space;
+        const incoming_stack_arg_base_offset: i32 = if (arch == .x86_64) 16 + abi_shadow_space else 0;
         const outgoing_stack_arg_base_offset: i32 = abi_shadow_space;
         const max_arg_regs: u8 = @intCast(EmitType.CC.PARAM_REGS.len);
 
@@ -779,6 +783,10 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         /// Set during deferred-prologue proc compilation, used by moveToReturnRegisterWithLayout
         /// and generateEarlyReturn.
         ret_ptr_slot: ?i32 = null,
+
+        /// The current AArch64 proc reads incoming stack arguments. Its prologue
+        /// must initialize `caller_stack_arg_base_reg` to the callee-entry SP.
+        uses_caller_stack_arg_base: bool = false,
 
         /// Per-proc shared stack slot for debug-assertion crash messages.
         /// Debug asserts each emit a unique msg, but only one fires at runtime
@@ -1211,6 +1219,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.local_locations.clearRetainingCapacity();
             self.proc_debug_msg_slot = null;
             self.codegen.callee_saved_used = 0;
+            self.uses_caller_stack_arg_base = false;
 
             // Initialize stack_offset to reserve space for callee-saved area
             // (same convention as compileProcSpec — positive offsets, deferred prologue)
@@ -8038,32 +8047,9 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             // Store appropriate size - architecture specific
             if (comptime target.toCpuArch() == .aarch64) {
                 // aarch64 only has .w32 and .w64 for emitStoreStack, use direct emit for smaller sizes.
-                // The offset >= 0 checks below are not defensive guards — they select the
-                // unsigned-immediate instruction encoding (STRB/STRH), which only accepts
-                // non-negative offsets. Negative offsets (valid because the stack grows down
-                // from FP) use the register-addressed path instead.
                 switch (disc_size) {
-                    1 => {
-                        // Use strb for 1-byte store
-                        if (offset >= 0 and offset <= 4095) {
-                            try self.codegen.emit.strbRegMem(reg, .FP, @intCast(offset));
-                        } else {
-                            // For negative/large offsets, compute address first
-                            try self.codegen.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                            try self.codegen.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                            try self.codegen.emit.strbRegMem(reg, .IP0, 0);
-                        }
-                    },
-                    2 => {
-                        // Use strh for 2-byte store
-                        if (offset >= 0 and offset <= 8190) {
-                            try self.codegen.emit.strhRegMem(reg, .FP, @intCast(@as(u32, @intCast(offset)) >> 1));
-                        } else {
-                            try self.codegen.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                            try self.codegen.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                            try self.codegen.emit.strhRegMem(reg, .IP0, 0);
-                        }
-                    },
+                    1 => try self.codegen.emit.strbRegMemSoff(reg, .FP, offset),
+                    2 => try self.codegen.emit.strhRegMemSoff(reg, .FP, offset),
                     else => {
                         // 4 or 8 bytes - use standard store
                         try self.codegen.emitStoreStack(.w64, offset, reg);
@@ -8093,14 +8079,14 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             switch (disc_size) {
                 1 => {
                     if (comptime target.toCpuArch() == .aarch64) {
-                        try self.codegen.emit.strbRegMem(reg, ptr_reg, @intCast(offset));
+                        try self.codegen.emit.strbRegMemSoff(reg, ptr_reg, @intCast(offset));
                     } else {
                         try self.codegen.emit.movMemReg(.w8, ptr_reg, @intCast(offset), reg);
                     }
                 },
                 2 => {
                     if (comptime target.toCpuArch() == .aarch64) {
-                        try self.codegen.emit.strhRegMem(reg, ptr_reg, @intCast(offset >> 1));
+                        try self.codegen.emit.strhRegMemSoff(reg, ptr_reg, @intCast(offset));
                     } else {
                         try self.codegen.emit.movMemReg(.w16, ptr_reg, @intCast(offset), reg);
                     }
@@ -8288,26 +8274,14 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             switch (size) {
                 .byte => {
                     if (comptime arch == .aarch64 or arch == .aarch64_be) {
-                        if (offset >= -256 and offset <= 255) {
-                            try self.codegen.emit.ldurbRegMem(dst, base_reg, @intCast(offset));
-                        } else {
-                            try self.codegen.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                            try self.codegen.emit.addRegRegReg(.w64, .IP0, base_reg, .IP0);
-                            try self.codegen.emit.ldrbRegMem(dst, .IP0, 0);
-                        }
+                        try self.codegen.emit.ldrbRegMemSoff(dst, base_reg, offset);
                     } else {
                         try self.codegen.emit.movzxBRegMem(dst, base_reg, offset);
                     }
                 },
                 .word => {
                     if (comptime arch == .aarch64 or arch == .aarch64_be) {
-                        if (offset >= -256 and offset <= 255) {
-                            try self.codegen.emit.ldurhRegMem(dst, base_reg, @intCast(offset));
-                        } else {
-                            try self.codegen.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                            try self.codegen.emit.addRegRegReg(.w64, .IP0, base_reg, .IP0);
-                            try self.codegen.emit.ldrhRegMem(dst, .IP0, 0);
-                        }
+                        try self.codegen.emit.ldrhRegMemSoff(dst, base_reg, offset);
                     } else {
                         try self.codegen.emit.movzxWRegMem(dst, base_reg, offset);
                     }
@@ -8322,26 +8296,14 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             switch (size) {
                 .byte => {
                     if (comptime arch == .aarch64 or arch == .aarch64_be) {
-                        if (offset >= -256 and offset <= 255) {
-                            try self.codegen.emit.sturbRegMem(src, base_reg, @intCast(offset));
-                        } else {
-                            try self.codegen.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                            try self.codegen.emit.addRegRegReg(.w64, .IP0, base_reg, .IP0);
-                            try self.codegen.emit.strbRegMem(src, .IP0, 0);
-                        }
+                        try self.codegen.emit.strbRegMemSoff(src, base_reg, offset);
                     } else {
                         try self.codegen.emit.movMemReg(.w8, base_reg, offset, src);
                     }
                 },
                 .word => {
                     if (comptime arch == .aarch64 or arch == .aarch64_be) {
-                        if (offset >= -256 and offset <= 255) {
-                            try self.codegen.emit.sturhRegMem(src, base_reg, @intCast(offset));
-                        } else {
-                            try self.codegen.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                            try self.codegen.emit.addRegRegReg(.w64, .IP0, base_reg, .IP0);
-                            try self.codegen.emit.strhRegMem(src, .IP0, 0);
-                        }
+                        try self.codegen.emit.strhRegMemSoff(src, base_reg, offset);
                     } else {
                         try self.codegen.emit.movMemReg(.w16, base_reg, offset, src);
                     }
@@ -9286,6 +9248,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const saved_float_owners = self.codegen.float_owners;
             const saved_roc_ops_reg = self.roc_ops_reg;
             const saved_ret_ptr_slot = self.ret_ptr_slot;
+            const saved_uses_caller_stack_arg_base = self.uses_caller_stack_arg_base;
             // Reset register state for new function scope — each RC helper is a
             // separate callable with its own prologue/epilogue, so it starts with
             // a full set of registers regardless of what the parent is using.
@@ -9296,6 +9259,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.codegen.free_float = CodeGen.INITIAL_FREE_FLOAT;
             self.codegen.float_owners = [_]?u32{null} ** CodeGen.NUM_FLOAT_REGS;
             self.roc_ops_reg = null;
+            self.ret_ptr_slot = null;
+            self.uses_caller_stack_arg_base = false;
 
             if (comptime target.toCpuArch() == .x86_64) {
                 self.codegen.stack_offset = -CodeGen.CALLEE_SAVED_AREA_SIZE;
@@ -9318,6 +9283,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 self.codegen.float_owners = saved_float_owners;
                 self.roc_ops_reg = saved_roc_ops_reg;
                 self.ret_ptr_slot = saved_ret_ptr_slot;
+                self.uses_caller_stack_arg_base = saved_uses_caller_stack_arg_base;
                 self.codegen.patchJump(skip_jump, self.codegen.currentOffset());
             }
 
@@ -9425,6 +9391,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.codegen.free_float = saved_free_float;
             self.codegen.float_owners = saved_float_owners;
             self.roc_ops_reg = saved_roc_ops_reg;
+            self.ret_ptr_slot = saved_ret_ptr_slot;
+            self.uses_caller_stack_arg_base = saved_uses_caller_stack_arg_base;
 
             self.codegen.patchJump(skip_jump, self.codegen.currentOffset());
             return final_offset;
@@ -11547,7 +11515,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     if (remaining >= 2) {
                         if (comptime target.toCpuArch() == .aarch64) {
                             try self.codegen.emitLoadStackHalfword(temp_reg, src_offset);
-                            try self.codegen.emit.strhRegMem(temp_reg, ptr_reg, @intCast(@as(u32, @intCast(dst_offset)) >> 1));
+                            try self.codegen.emit.strhRegMemSoff(temp_reg, ptr_reg, dst_offset);
                         } else {
                             try self.codegen.emitLoadStack(.w16, temp_reg, src_offset);
                             try self.codegen.emit.movMemReg(.w16, ptr_reg, dst_offset, temp_reg);
@@ -11559,7 +11527,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     if (remaining >= 1) {
                         if (comptime target.toCpuArch() == .aarch64) {
                             try self.codegen.emitLoadStackByte(temp_reg, src_offset);
-                            try self.codegen.emit.strbRegMem(temp_reg, ptr_reg, @intCast(dst_offset));
+                            try self.codegen.emit.strbRegMemSoff(temp_reg, ptr_reg, dst_offset);
                         } else {
                             try self.codegen.emitLoadStack(.w8, temp_reg, src_offset);
                             try self.codegen.emit.movMemReg(.w8, ptr_reg, dst_offset, temp_reg);
@@ -11668,9 +11636,9 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     // by arithmetic-shifting right by 63 to fill high word.
                     const sign_reg = try self.allocTempGeneral();
                     if (comptime target.toCpuArch() == .aarch64) {
-                        try self.codegen.emit.strRegMemUoff(.w64, reg, ptr_reg, 0);
+                        try self.emitStoreToPtr(.w64, reg, ptr_reg, 0);
                         try self.codegen.emit.asrRegRegImm(.w64, sign_reg, reg, 63);
-                        try self.codegen.emit.strRegMemUoff(.w64, sign_reg, ptr_reg, 1);
+                        try self.emitStoreToPtr(.w64, sign_reg, ptr_reg, 8);
                     } else {
                         try self.codegen.emit.movMemReg(.w64, ptr_reg, 0, reg);
                         try self.emitMovRegReg(sign_reg, reg);
@@ -11824,14 +11792,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
         fn emitLoadW8(self: *Self, dst: GeneralReg, base_reg: GeneralReg, offset: i32) Allocator.Error!void {
             if (comptime arch == .aarch64 or arch == .aarch64_be) {
-                if (offset >= -256 and offset <= 255) {
-                    try self.codegen.emit.ldurbRegMem(dst, base_reg, @intCast(offset));
-                } else {
-                    const addr_reg: GeneralReg = if (base_reg == .IP0 or dst == .IP0) .IP1 else .IP0;
-                    try self.codegen.emit.movRegImm64(addr_reg, @bitCast(@as(i64, offset)));
-                    try self.codegen.emit.addRegRegReg(.w64, addr_reg, base_reg, addr_reg);
-                    try self.codegen.emit.ldrbRegMem(dst, addr_reg, 0);
-                }
+                try self.codegen.emit.ldrbRegMemSoff(dst, base_reg, offset);
             } else {
                 try self.codegen.emit.movzxBRegMem(dst, base_reg, offset);
             }
@@ -11839,14 +11800,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
         fn emitLoadW16(self: *Self, dst: GeneralReg, base_reg: GeneralReg, offset: i32) Allocator.Error!void {
             if (comptime arch == .aarch64 or arch == .aarch64_be) {
-                if (offset >= -256 and offset <= 255) {
-                    try self.codegen.emit.ldurhRegMem(dst, base_reg, @intCast(offset));
-                } else {
-                    const addr_reg: GeneralReg = if (base_reg == .IP0 or dst == .IP0) .IP1 else .IP0;
-                    try self.codegen.emit.movRegImm64(addr_reg, @bitCast(@as(i64, offset)));
-                    try self.codegen.emit.addRegRegReg(.w64, addr_reg, base_reg, addr_reg);
-                    try self.codegen.emit.ldrhRegMem(dst, addr_reg, 0);
-                }
+                try self.codegen.emit.ldrhRegMemSoff(dst, base_reg, offset);
             } else {
                 try self.codegen.emit.movzxWRegMem(dst, base_reg, offset);
             }
@@ -11854,14 +11808,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
         fn emitStoreW8(self: *Self, base_reg: GeneralReg, offset: i32, src: GeneralReg) Allocator.Error!void {
             if (comptime arch == .aarch64 or arch == .aarch64_be) {
-                if (offset >= -256 and offset <= 255) {
-                    try self.codegen.emit.sturbRegMem(src, base_reg, @intCast(offset));
-                } else {
-                    const addr_reg: GeneralReg = if (base_reg == .IP0 or src == .IP0) .IP1 else .IP0;
-                    try self.codegen.emit.movRegImm64(addr_reg, @bitCast(@as(i64, offset)));
-                    try self.codegen.emit.addRegRegReg(.w64, addr_reg, base_reg, addr_reg);
-                    try self.codegen.emit.strbRegMem(src, addr_reg, 0);
-                }
+                try self.codegen.emit.strbRegMemSoff(src, base_reg, offset);
             } else {
                 try self.codegen.emit.movMemReg(.w8, base_reg, offset, src);
             }
@@ -11869,14 +11816,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
         fn emitStoreW16(self: *Self, base_reg: GeneralReg, offset: i32, src: GeneralReg) Allocator.Error!void {
             if (comptime arch == .aarch64 or arch == .aarch64_be) {
-                if (offset >= -256 and offset <= 255) {
-                    try self.codegen.emit.sturhRegMem(src, base_reg, @intCast(offset));
-                } else {
-                    const addr_reg: GeneralReg = if (base_reg == .IP0 or src == .IP0) .IP1 else .IP0;
-                    try self.codegen.emit.movRegImm64(addr_reg, @bitCast(@as(i64, offset)));
-                    try self.codegen.emit.addRegRegReg(.w64, addr_reg, base_reg, addr_reg);
-                    try self.codegen.emit.strhRegMem(src, addr_reg, 0);
-                }
+                try self.codegen.emit.strhRegMemSoff(src, base_reg, offset);
             } else {
                 try self.codegen.emit.movMemReg(.w16, base_reg, offset, src);
             }
@@ -12222,14 +12162,10 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
         fn emitStoreToPtr(self: *Self, comptime width: anytype, src: GeneralReg, ptr_reg: GeneralReg, byte_offset: i32) Allocator.Error!void {
             if (comptime arch == .aarch64 or arch == .aarch64_be) {
-                const shift = comptime switch (width) {
-                    .w64 => @as(u5, 3),
-                    .w32 => @as(u5, 2),
+                switch (width) {
+                    .w64, .w32 => try self.codegen.emit.strRegMemSoff(width, src, ptr_reg, byte_offset),
                     else => @compileError("Use strhRegMem/strbRegMem for .w16/.w8"),
-                };
-                const unsigned_offset: u32 = @intCast(byte_offset);
-                std.debug.assert(@rem(unsigned_offset, @as(u32, 1) << shift) == 0);
-                try self.codegen.emit.strRegMemUoff(width, src, ptr_reg, @intCast(unsigned_offset >> shift));
+                }
             } else {
                 try self.codegen.emit.movMemReg(width, ptr_reg, byte_offset, src);
             }
@@ -12475,6 +12411,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const saved_float_owners = self.codegen.float_owners;
             const saved_roc_ops_reg = self.roc_ops_reg;
             const saved_ret_ptr_slot = self.ret_ptr_slot;
+            const saved_uses_caller_stack_arg_base = self.uses_caller_stack_arg_base;
             const saved_current_proc_name = self.current_proc_name;
             const saved_current_proc_args = self.current_proc_args;
             const saved_current_stmt_id = self.current_stmt_id;
@@ -12507,6 +12444,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.codegen.free_float = CodeGen.INITIAL_FREE_FLOAT;
             self.codegen.float_owners = [_]?u32{null} ** CodeGen.NUM_FLOAT_REGS;
             self.roc_ops_reg = null;
+            self.uses_caller_stack_arg_base = false;
             self.current_proc_name = proc.name;
             self.current_proc_args = proc.args;
             self.current_stmt_id = null;
@@ -12573,6 +12511,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 self.codegen.free_float = saved_free_float;
                 self.codegen.float_owners = saved_float_owners;
                 self.roc_ops_reg = saved_roc_ops_reg;
+                self.uses_caller_stack_arg_base = saved_uses_caller_stack_arg_base;
                 self.current_proc_name = saved_current_proc_name;
                 self.current_proc_args = saved_current_proc_args;
                 self.current_stmt_id = saved_current_stmt_id;
@@ -12711,6 +12650,9 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 var frame_builder = CodeGen.DeferredFrameBuilder.init();
                 frame_builder.setCalleeSavedMask(self.codegen.callee_saved_used);
                 frame_builder.setStackSize(actual_locals);
+                if (self.uses_caller_stack_arg_base) {
+                    frame_builder.setCallerStackArgBaseReg(caller_stack_arg_base_reg);
+                }
                 _ = try frame_builder.emitPrologue(&self.codegen.emit);
                 const prologue_size = self.codegen.currentOffset() - prologue_start;
                 const frame_size = frame_builder.actual_stack_alloc;
@@ -12766,6 +12708,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.codegen.free_float = saved_free_float;
             self.codegen.float_owners = saved_float_owners;
             self.roc_ops_reg = saved_roc_ops_reg;
+            self.uses_caller_stack_arg_base = saved_uses_caller_stack_arg_base;
             self.ret_ptr_slot = saved_ret_ptr_slot;
             self.current_proc_name = saved_current_proc_name;
             self.current_proc_args = saved_current_proc_args;
@@ -13357,17 +13300,37 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             return 1;
         }
 
-        /// Copy parameter data from caller's stack frame to local stack.
-        /// caller_offset is the offset from RBP/FP to the caller's argument.
-        /// For System V and aarch64: first stack arg is at [RBP/FP+16].
-        /// For Windows x64: the 32-byte caller shadow space sits before stack args,
-        /// so the first stack arg is at [RBP+48].
-        fn copyFromCallerStack(self: *Self, caller_offset: i32, local_offset: i32, num_regs: u8) Allocator.Error!void {
+        fn markCallerStackArgBaseUsed(self: *Self) void {
+            if (comptime arch == .aarch64 or arch == .aarch64_be) {
+                const bit = @as(u32, 1) << @intFromEnum(caller_stack_arg_base_reg);
+                if (std.debug.runtime_safety) {
+                    std.debug.assert(self.codegen.general_owners[@intFromEnum(caller_stack_arg_base_reg)] == null);
+                }
+                self.uses_caller_stack_arg_base = true;
+                self.codegen.callee_saved_used |= bit;
+                self.codegen.callee_saved_available &= ~bit;
+            }
+        }
+
+        fn callerStackArgBaseReg(self: *Self) GeneralReg {
+            if (comptime arch == .aarch64 or arch == .aarch64_be) {
+                self.markCallerStackArgBaseUsed();
+                return caller_stack_arg_base_reg;
+            } else {
+                return frame_ptr;
+            }
+        }
+
+        /// Copy parameter data from caller stack-argument slots to local stack.
+        /// On x86_64 this uses FP plus the ABI's fixed stack-arg offset. On
+        /// AArch64 it uses `caller_stack_arg_base_reg`, which the prologue
+        /// initializes to the callee-entry SP when this proc has stack args.
+        fn copyFromCallerStack(self: *Self, caller_base: GeneralReg, caller_offset: i32, local_offset: i32, num_regs: u8) Allocator.Error!void {
             const temp_reg: GeneralReg = scratch_reg;
             var ri: u8 = 0;
             while (ri < num_regs) : (ri += 1) {
                 const off: i32 = @as(i32, ri) * 8;
-                try self.emitLoad(.w64, temp_reg, frame_ptr, caller_offset + off);
+                try self.emitLoad(.w64, temp_reg, caller_base, caller_offset + off);
                 try self.emitStore(.w64, frame_ptr, local_offset + off, temp_reg);
             }
         }
@@ -13533,8 +13496,9 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         ptr_reg = self.getArgumentRegister(reg_idx);
                         reg_idx += 1;
                     } else {
+                        const caller_base = self.callerStackArgBaseReg();
                         ptr_reg = scratch_reg;
-                        try self.emitLoad(.w64, ptr_reg, frame_ptr, stack_arg_offset);
+                        try self.emitLoad(.w64, ptr_reg, caller_base, stack_arg_offset);
                         stack_arg_offset += 8;
                         reg_idx = max_arg_regs;
                     }
@@ -13572,9 +13536,10 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     try self.local_locations.put(localKey(local), stable_loc);
                     reg_idx += num_regs;
                 } else {
+                    const caller_base = self.callerStackArgBaseReg();
                     const size: u32 = @as(u32, num_regs) * 8;
                     const stack_offset = self.codegen.allocStackSlot(@intCast(size));
-                    try self.copyFromCallerStack(stack_arg_offset, stack_offset, num_regs);
+                    try self.copyFromCallerStack(caller_base, stack_arg_offset, stack_offset, num_regs);
                     const stable_loc = self.stackLocationForLayout(self.localLayout(local), stack_offset);
                     try self.local_locations.put(localKey(local), stable_loc);
                     stack_arg_offset += @as(i32, num_regs) * 8;
@@ -13596,7 +13561,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         try self.codegen.emit.movRegReg(.w64, roc_ops_save_reg, arg_reg);
                     }
                 } else {
-                    try self.emitLoad(.w64, roc_ops_save_reg, frame_ptr, stack_arg_offset);
+                    const caller_base = self.callerStackArgBaseReg();
+                    try self.emitLoad(.w64, roc_ops_save_reg, caller_base, stack_arg_offset);
                 }
             } else {
                 // Symbol-ABI procs receive no RocOps. Builtins helper
@@ -15818,6 +15784,43 @@ test "Windows internal proc ABI reads stack arguments after shadow space" {
     try codegen.bindProcParams(args, 0);
 
     _ = codegen.local_locations.get(@intFromEnum(list)) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(codegen.codegen.getCode().len > 0);
+}
+
+test "AArch64 internal proc ABI uses caller stack arg base for stack arguments" {
+    const allocator = std.testing.allocator;
+    var store = LirStore.init(allocator);
+    defer store.deinit();
+    var test_state = try TestLayoutState.init(allocator);
+    defer test_state.deinit();
+
+    const ArmCodeGen = LirCodeGen(.arm64mac);
+    try std.testing.expectEqual(@as(i32, 0), ArmCodeGen.incoming_stack_arg_base_offset);
+
+    const a0 = try addLocal(&store, .u64);
+    const a1 = try addLocal(&store, .u64);
+    const a2 = try addLocal(&store, .u64);
+    const a3 = try addLocal(&store, .u64);
+    const a4 = try addLocal(&store, .u64);
+    const a5 = try addLocal(&store, .u64);
+    const a6 = try addLocal(&store, .u64);
+    const a7 = try addLocal(&store, .u64);
+    const stack_arg = try addLocal(&store, .u64);
+    const args = try store.addLocalSpan(&.{ a0, a1, a2, a3, a4, a5, a6, a7, stack_arg });
+
+    var codegen = try ArmCodeGen.init(allocator, &store, &test_state.layout_store, &.{});
+    defer codegen.deinit();
+
+    const InnerCodeGen = @TypeOf(codegen.codegen);
+    codegen.codegen.stack_offset = 16 + InnerCodeGen.CALLEE_SAVED_AREA_SIZE;
+
+    try codegen.bindProcParams(args, 0);
+
+    const x28_bit = @as(u32, 1) << @intFromEnum(aarch64.GeneralReg.X28);
+    try std.testing.expect(codegen.uses_caller_stack_arg_base);
+    try std.testing.expect((codegen.codegen.callee_saved_used & x28_bit) != 0);
+    try std.testing.expect((codegen.codegen.callee_saved_available & x28_bit) == 0);
+    _ = codegen.local_locations.get(@intFromEnum(stack_arg)) orelse return error.TestUnexpectedResult;
     try std.testing.expect(codegen.codegen.getCode().len > 0);
 }
 

--- a/src/backend/dev/aarch64/CodeGen.zig
+++ b/src/backend/dev/aarch64/CodeGen.zig
@@ -606,158 +606,52 @@ pub fn CodeGen(comptime target: RocTarget) type {
 
         /// Load from stack slot into register
         pub fn emitLoadStack(self: *Self, width: RegisterWidth, dst: GeneralReg, offset: i32) Allocator.Error!void {
-            if (offset >= -256 and offset <= 255) {
-                try self.emit.ldurRegMem(width, dst, .FP, @intCast(offset));
-            } else if (offset > 0) {
-                // Positive offset - try scaled unsigned form
-                const shift: u5 = if (width == .w64) 3 else 2;
-                const shifted = @as(u32, @intCast(offset)) >> shift;
-                if (shifted <= std.math.maxInt(u12)) {
-                    try self.emit.ldrRegMemUoff(width, dst, .FP, @intCast(shifted));
-                    return;
-                }
-                // Large positive offset - add offset to FP, then load
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.ldrRegMemUoff(width, dst, .IP0, 0);
-            } else {
-                // Large negative offset - add offset to FP, then load
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.ldrRegMemUoff(width, dst, .IP0, 0);
-            }
+            try self.emit.ldrRegMemSoff(width, dst, .FP, offset);
         }
 
         /// Store register to stack slot
         pub fn emitStoreStack(self: *Self, width: RegisterWidth, offset: i32, src: GeneralReg) Allocator.Error!void {
-            if (offset >= -256 and offset <= 255) {
-                try self.emit.sturRegMem(width, src, .FP, @intCast(offset));
-            } else if (offset > 0) {
-                // Positive offset - try scaled unsigned form
-                const shift: u5 = if (width == .w64) 3 else 2;
-                const shifted = @as(u32, @intCast(offset)) >> shift;
-                if (shifted <= std.math.maxInt(u12)) {
-                    try self.emit.strRegMemUoff(width, src, .FP, @intCast(shifted));
-                    return;
-                }
-                // Large positive offset - add offset to FP, then store
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.strRegMemUoff(width, src, .IP0, 0);
-            } else {
-                // Large negative offset - add offset to FP, then store
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.strRegMemUoff(width, src, .IP0, 0);
-            }
+            try self.emit.strRegMemSoff(width, src, .FP, offset);
         }
 
         /// Store byte to stack slot
         pub fn emitStoreStackByte(self: *Self, offset: i32, src: GeneralReg) Allocator.Error!void {
-            if (offset >= -256 and offset <= 255) {
-                try self.emit.sturbRegMem(src, .FP, @intCast(offset));
-            } else {
-                // Large offset - add offset to FP, then store
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.strbRegMem(src, .IP0, 0);
-            }
+            try self.emit.strbRegMemSoff(src, .FP, offset);
         }
 
         /// Store halfword (2 bytes) to stack slot
         pub fn emitStoreStackHalfword(self: *Self, offset: i32, src: GeneralReg) Allocator.Error!void {
-            if (offset >= -256 and offset <= 255) {
-                try self.emit.sturhRegMem(src, .FP, @intCast(offset));
-            } else {
-                // Large offset - add offset to FP, then store
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.strhRegMem(src, .IP0, 0);
-            }
+            try self.emit.strhRegMemSoff(src, .FP, offset);
         }
 
         /// Load byte (zero-extended) from stack slot
         pub fn emitLoadStackByte(self: *Self, dst: GeneralReg, offset: i32) Allocator.Error!void {
-            if (offset >= -256 and offset <= 255) {
-                try self.emit.ldurbRegMem(dst, .FP, @intCast(offset));
-            } else if (offset > 0 and offset <= 4095) {
-                // Positive offset - use scaled unsigned form (byte: no shift needed)
-                const uoffset: u12 = @intCast(@as(u32, @intCast(offset)));
-                try self.emit.ldrbRegMem(dst, .FP, uoffset);
-            } else {
-                // Large offset - add offset to FP, then load
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.ldrbRegMem(dst, .IP0, 0);
-            }
+            try self.emit.ldrbRegMemSoff(dst, .FP, offset);
         }
 
         /// Load halfword (zero-extended) from stack slot
         pub fn emitLoadStackHalfword(self: *Self, dst: GeneralReg, offset: i32) Allocator.Error!void {
-            if (offset >= -256 and offset <= 255) {
-                try self.emit.ldurhRegMem(dst, .FP, @intCast(offset));
-            } else if (offset > 0 and offset <= 8190) {
-                // Positive offset - use scaled unsigned form (halfword: shift by 1)
-                const uoffset: u12 = @intCast(@as(u32, @intCast(offset)) >> 1);
-                try self.emit.ldrhRegMem(dst, .FP, uoffset);
-            } else {
-                // Large offset - add offset to FP, then load
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.ldrhRegMem(dst, .IP0, 0);
-            }
+            try self.emit.ldrhRegMemSoff(dst, .FP, offset);
         }
 
         /// Load float64 from stack slot
         pub fn emitLoadStackF64(self: *Self, dst: FloatReg, offset: i32) Allocator.Error!void {
-            if (offset >= 0 and offset <= 32760) {
-                // Positive offset - use scaled unsigned form
-                const uoffset: u12 = @intCast(@as(u32, @intCast(offset)) >> 3);
-                try self.emit.fldrRegMemUoff(.double, dst, .FP, uoffset);
-            } else {
-                // Large or negative offset - add offset to FP, then load
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.fldrRegMemUoff(.double, dst, .IP0, 0);
-            }
+            try self.emit.fldrRegMemSoff(.double, dst, .FP, offset);
         }
 
         /// Store float64 to stack slot
         pub fn emitStoreStackF64(self: *Self, offset: i32, src: FloatReg) Allocator.Error!void {
-            if (offset >= 0 and offset <= 32760) {
-                // Positive offset - use scaled unsigned form
-                const uoffset: u12 = @intCast(@as(u32, @intCast(offset)) >> 3);
-                try self.emit.fstrRegMemUoff(.double, src, .FP, uoffset);
-            } else {
-                // Large or negative offset - add offset to FP, then store
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.fstrRegMemUoff(.double, src, .IP0, 0);
-            }
+            try self.emit.fstrRegMemSoff(.double, src, .FP, offset);
         }
 
         /// Load float32 from stack slot.
         pub fn emitLoadStackF32(self: *Self, dst: FloatReg, offset: i32) Allocator.Error!void {
-            if (offset >= 0 and offset <= 16380) {
-                const uoffset: u12 = @intCast(@as(u32, @intCast(offset)) >> 2);
-                try self.emit.fldrRegMemUoff(.single, dst, .FP, uoffset);
-            } else {
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.fldrRegMemUoff(.single, dst, .IP0, 0);
-            }
+            try self.emit.fldrRegMemSoff(.single, dst, .FP, offset);
         }
 
         /// Store float32 to stack slot.
         pub fn emitStoreStackF32(self: *Self, offset: i32, src: FloatReg) Allocator.Error!void {
-            if (offset >= 0 and offset <= 16380) {
-                const uoffset: u12 = @intCast(@as(u32, @intCast(offset)) >> 2);
-                try self.emit.fstrRegMemUoff(.single, src, .FP, uoffset);
-            } else {
-                try self.emit.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-                try self.emit.addRegRegReg(.w64, .IP0, .FP, .IP0);
-                try self.emit.fstrRegMemUoff(.single, src, .IP0, 0);
-            }
+            try self.emit.fstrRegMemSoff(.single, src, .FP, offset);
         }
 
         // Immediate loading

--- a/src/backend/dev/aarch64/Emit.zig
+++ b/src/backend/dev/aarch64/Emit.zig
@@ -905,6 +905,22 @@ pub fn Emit(comptime target: RocTarget) type {
 
         // Memory instructions
 
+        fn addressScratchReg(base: GeneralReg, preserved: ?GeneralReg) GeneralReg {
+            if (base != .IP0 and preserved != .IP0) return .IP0;
+            if (base != .IP1 and preserved != .IP1) return .IP1;
+
+            std.debug.panic(
+                "aarch64 memory emitter needs an address scratch register, but base {s} and preserved register {s} occupy both IP0 and IP1",
+                .{ base.name64(), preserved.?.name64() },
+            );
+        }
+
+        fn emitAddressOffset(self: *Self, dst: GeneralReg, base: GeneralReg, offset: i32) Allocator.Error!void {
+            std.debug.assert(dst != base);
+            try self.movRegImm64(dst, @bitCast(@as(i64, offset)));
+            try self.addRegRegReg(.w64, dst, base, dst);
+        }
+
         /// LDR (load register) with unsigned offset
         pub fn ldrRegMemUoff(self: *Self, width: RegisterWidth, dst: GeneralReg, base: GeneralReg, uoffset: u12) Allocator.Error!void {
             // LDR <Xt>, [<Xn|SP>, #<pimm>]
@@ -1049,7 +1065,7 @@ pub fn Emit(comptime target: RocTarget) type {
         /// Handles arbitrary signed offsets by choosing appropriate encoding:
         /// - Small offsets (-256 to 255): use LDUR (unscaled)
         /// - Positive aligned offsets (0 to 32760 for 64-bit): use LDR with unsigned offset
-        /// - Other offsets: compute address in IP0 then load with zero offset
+        /// - Other offsets: compute address in an IP scratch register, then load with zero offset
         pub fn ldrRegMemSoff(self: *Self, width: RegisterWidth, dst: GeneralReg, base: GeneralReg, offset: i32) Allocator.Error!void {
             // Try LDUR for small signed offsets
             if (offset >= -256 and offset <= 255) {
@@ -1070,11 +1086,9 @@ pub fn Emit(comptime target: RocTarget) type {
                 }
             }
 
-            // Handle offsets outside LDUR range [-256,255] and not suitable for unsigned encoding
-            // Use movRegImm64 for correct sign extension of negative offsets
-            try self.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-            try self.addRegRegReg(.w64, .IP0, base, .IP0);
-            try self.ldurRegMem(width, dst, .IP0, 0);
+            const scratch = addressScratchReg(base, null);
+            try self.emitAddressOffset(scratch, base, offset);
+            try self.ldurRegMem(width, dst, scratch, 0);
         }
 
         /// STR with signed offset (i32)
@@ -1099,11 +1113,9 @@ pub fn Emit(comptime target: RocTarget) type {
                 }
             }
 
-            // Handle offsets outside STUR range [-256,255] and not suitable for unsigned encoding
-            // Use movRegImm64 for correct sign extension of negative offsets
-            try self.movRegImm64(.IP0, @bitCast(@as(i64, offset)));
-            try self.addRegRegReg(.w64, .IP0, base, .IP0);
-            try self.sturRegMem(width, src, .IP0, 0);
+            const scratch = addressScratchReg(base, src);
+            try self.emitAddressOffset(scratch, base, offset);
+            try self.sturRegMem(width, src, scratch, 0);
         }
 
         /// LDRB (load register byte, zero-extend)
@@ -1144,6 +1156,90 @@ pub fn Emit(comptime target: RocTarget) type {
                 (@as(u32, base.enc()) << 5) |
                 src.enc();
             try self.emit32(inst);
+        }
+
+        /// LDRB with signed offset (i32).
+        /// Handles arbitrary signed offsets by choosing the shortest exact encoding.
+        pub fn ldrbRegMemSoff(self: *Self, dst: GeneralReg, base: GeneralReg, offset: i32) Allocator.Error!void {
+            if (offset >= -256 and offset <= 255) {
+                try self.ldurbRegMem(dst, base, @intCast(offset));
+                return;
+            }
+
+            if (offset >= 0 and offset <= 4095) {
+                try self.ldrbRegMem(dst, base, @intCast(@as(u32, @intCast(offset))));
+                return;
+            }
+
+            const scratch = addressScratchReg(base, null);
+            try self.emitAddressOffset(scratch, base, offset);
+            try self.ldurbRegMem(dst, scratch, 0);
+        }
+
+        /// STRB with signed offset (i32).
+        /// Handles arbitrary signed offsets by choosing the shortest exact encoding.
+        pub fn strbRegMemSoff(self: *Self, src: GeneralReg, base: GeneralReg, offset: i32) Allocator.Error!void {
+            if (offset >= -256 and offset <= 255) {
+                try self.sturbRegMem(src, base, @intCast(offset));
+                return;
+            }
+
+            if (offset >= 0 and offset <= 4095) {
+                try self.strbRegMem(src, base, @intCast(@as(u32, @intCast(offset))));
+                return;
+            }
+
+            const scratch = addressScratchReg(base, src);
+            try self.emitAddressOffset(scratch, base, offset);
+            try self.sturbRegMem(src, scratch, 0);
+        }
+
+        /// LDRH with signed offset (i32).
+        /// Handles arbitrary signed offsets by choosing the shortest exact encoding.
+        pub fn ldrhRegMemSoff(self: *Self, dst: GeneralReg, base: GeneralReg, offset: i32) Allocator.Error!void {
+            if (offset >= -256 and offset <= 255) {
+                try self.ldurhRegMem(dst, base, @intCast(offset));
+                return;
+            }
+
+            if (offset >= 0) {
+                const uoff: u32 = @intCast(offset);
+                if ((uoff & 1) == 0) {
+                    const scaled = uoff >> 1;
+                    if (scaled <= 4095) {
+                        try self.ldrhRegMem(dst, base, @intCast(scaled));
+                        return;
+                    }
+                }
+            }
+
+            const scratch = addressScratchReg(base, null);
+            try self.emitAddressOffset(scratch, base, offset);
+            try self.ldurhRegMem(dst, scratch, 0);
+        }
+
+        /// STRH with signed offset (i32).
+        /// Handles arbitrary signed offsets by choosing the shortest exact encoding.
+        pub fn strhRegMemSoff(self: *Self, src: GeneralReg, base: GeneralReg, offset: i32) Allocator.Error!void {
+            if (offset >= -256 and offset <= 255) {
+                try self.sturhRegMem(src, base, @intCast(offset));
+                return;
+            }
+
+            if (offset >= 0) {
+                const uoff: u32 = @intCast(offset);
+                if ((uoff & 1) == 0) {
+                    const scaled = uoff >> 1;
+                    if (scaled <= 4095) {
+                        try self.strhRegMem(src, base, @intCast(scaled));
+                        return;
+                    }
+                }
+            }
+
+            const scratch = addressScratchReg(base, src);
+            try self.emitAddressOffset(scratch, base, offset);
+            try self.sturhRegMem(src, scratch, 0);
         }
 
         // Stack instructions
@@ -1572,6 +1668,46 @@ pub fn Emit(comptime target: RocTarget) type {
                 src.enc();
             try self.emit32(inst);
         }
+
+        /// LDR floating-point register with signed offset (i32).
+        /// Handles arbitrary signed offsets by choosing the shortest exact encoding.
+        pub fn fldrRegMemSoff(self: *Self, ftype: FloatType, dst: FloatReg, base: GeneralReg, offset: i32) Allocator.Error!void {
+            if (offset >= 0) {
+                const scale: u5 = if (ftype == .double) 3 else 2;
+                const uoff: u32 = @intCast(offset);
+                if ((uoff & ((@as(u32, 1) << scale) - 1)) == 0) {
+                    const scaled = uoff >> scale;
+                    if (scaled <= 4095) {
+                        try self.fldrRegMemUoff(ftype, dst, base, @intCast(scaled));
+                        return;
+                    }
+                }
+            }
+
+            const scratch = addressScratchReg(base, null);
+            try self.emitAddressOffset(scratch, base, offset);
+            try self.fldrRegMemUoff(ftype, dst, scratch, 0);
+        }
+
+        /// STR floating-point register with signed offset (i32).
+        /// Handles arbitrary signed offsets by choosing the shortest exact encoding.
+        pub fn fstrRegMemSoff(self: *Self, ftype: FloatType, src: FloatReg, base: GeneralReg, offset: i32) Allocator.Error!void {
+            if (offset >= 0) {
+                const scale: u5 = if (ftype == .double) 3 else 2;
+                const uoff: u32 = @intCast(offset);
+                if ((uoff & ((@as(u32, 1) << scale) - 1)) == 0) {
+                    const scaled = uoff >> scale;
+                    if (scaled <= 4095) {
+                        try self.fstrRegMemUoff(ftype, src, base, @intCast(scaled));
+                        return;
+                    }
+                }
+            }
+
+            const scratch = addressScratchReg(base, null);
+            try self.emitAddressOffset(scratch, base, offset);
+            try self.fstrRegMemUoff(ftype, src, scratch, 0);
+        }
     }; // end of struct returned by Emit
 }
 
@@ -1579,6 +1715,18 @@ pub fn Emit(comptime target: RocTarget) type {
 const LinuxEmit = Emit(.arm64linux);
 const WinEmit = Emit(.arm64win);
 const MacEmit = Emit(.arm64mac);
+
+fn testReadInst(buf: []const u8, inst_index: usize) u32 {
+    const byte_index = inst_index * 4;
+    return @as(u32, buf[byte_index]) |
+        (@as(u32, buf[byte_index + 1]) << 8) |
+        (@as(u32, buf[byte_index + 2]) << 16) |
+        (@as(u32, buf[byte_index + 3]) << 24);
+}
+
+fn testInstBaseReg(inst: u32) u32 {
+    return (inst >> 5) & 0x1F;
+}
 
 // Tests
 
@@ -1648,6 +1796,30 @@ test "fadd" {
     // fadd d0, d1, d2 (0x1E622820)
     try asm_buf.faddRegRegReg(.double, .V0, .V1, .V2);
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x20, 0x28, 0x62, 0x1E }, asm_buf.buf.items);
+}
+
+test "signed-offset memory helpers use exact byte offsets" {
+    var asm_buf = LinuxEmit.init(std.testing.allocator);
+    defer asm_buf.deinit();
+
+    try asm_buf.ldrRegMemSoff(.w64, .X0, .FP, 260);
+    try std.testing.expectEqual(@as(usize, 12), asm_buf.buf.items.len);
+    try std.testing.expectEqual(@as(u32, @intFromEnum(Registers.GeneralReg.IP0)), testInstBaseReg(testReadInst(asm_buf.buf.items, 2)));
+
+    asm_buf.buf.clearRetainingCapacity();
+    try asm_buf.fldrRegMemSoff(.double, .V0, .FP, 260);
+    try std.testing.expectEqual(@as(usize, 12), asm_buf.buf.items.len);
+    try std.testing.expectEqual(@as(u32, @intFromEnum(Registers.GeneralReg.IP0)), testInstBaseReg(testReadInst(asm_buf.buf.items, 2)));
+
+    asm_buf.buf.clearRetainingCapacity();
+    try asm_buf.strhRegMemSoff(.IP0, .FP, 257);
+    try std.testing.expectEqual(@as(usize, 12), asm_buf.buf.items.len);
+    try std.testing.expectEqual(@as(u32, @intFromEnum(Registers.GeneralReg.IP1)), testInstBaseReg(testReadInst(asm_buf.buf.items, 2)));
+
+    asm_buf.buf.clearRetainingCapacity();
+    try asm_buf.ldrbRegMemSoff(.X0, .IP0, 5000);
+    try std.testing.expectEqual(@as(usize, 12), asm_buf.buf.items.len);
+    try std.testing.expectEqual(@as(u32, @intFromEnum(Registers.GeneralReg.IP1)), testInstBaseReg(testReadInst(asm_buf.buf.items, 2)));
 }
 
 test "condition invert" {


### PR DESCRIPTION
The AArch64 dev backend was binding incoming stack arguments relative to FP as if the frame matched x86_64, but deferred AArch64 prologues move FP to the bottom of the allocated frame. This materializes the callee-entry SP into a callee-saved register when a proc reads stack arguments, uses that as the stack-argument base, and adds focused ABI/prologue coverage.

While auditing the same path, this also routes AArch64 memory helpers through signed byte-offset emitters so scaled immediates cannot silently round offsets, fixes float memory loads in CallBuilder to use byte offsets, and restores per-proc RC helper codegen state after helper generation.