### PR TITLE
Fix exponential LIR blowup for long list-pattern matches

### DIFF
--- a/src/eval/test/eval_bughunt_repros.zig
+++ b/src/eval/test/eval_bughunt_repros.zig
@@ -708,4 +708,43 @@ pub const tests = [_]TestCase{
         ,
         .expected = .{ .inspect_str = "0" },
     },
+    .{
+        // #9700: a match with many fixed-length list patterns must lower to LIR
+        // whose size is linear in the patterns, not exponential. Each list
+        // branch shares one miss target, so this compiles quickly; before the
+        // fix the shared fallback was re-materialized per element test, giving
+        // ~(elements+1)^branches statements that exhausted memory at compile
+        // time. A regression here reappears as an out-of-memory/timeout, not a
+        // wrong value.
+        .name = "issue 9700: long match of List(U8) does not blow up compilation",
+        .source_kind = .module,
+        .source =
+        \\to_instruction : List(U8) -> Try(U8, [InvalidCodon])
+        \\to_instruction = |codon| {
+        \\    match codon {
+        \\        ['A', 'U', 'G'] => Ok(1)
+        \\        ['U', 'U', 'U'] => Ok(2)
+        \\        ['U', 'U', 'C'] => Ok(3)
+        \\        ['U', 'U', 'A'] => Ok(4)
+        \\        ['U', 'U', 'G'] => Ok(5)
+        \\        ['U', 'C', 'U'] => Ok(6)
+        \\        ['U', 'C', 'C'] => Ok(7)
+        \\        ['U', 'C', 'A'] => Ok(8)
+        \\        ['U', 'C', 'G'] => Ok(9)
+        \\        ['U', 'A', 'U'] => Ok(10)
+        \\        ['U', 'A', 'C'] => Ok(11)
+        \\        ['U', 'G', 'U'] => Ok(12)
+        \\        ['U', 'G', 'C'] => Ok(13)
+        \\        ['U', 'G', 'G'] => Ok(14)
+        \\        ['U', 'A', 'A'] => Ok(15)
+        \\        ['U', 'A', 'G'] => Ok(16)
+        \\        ['U', 'G', 'A'] => Ok(17)
+        \\        _ => Err(InvalidCodon)
+        \\    }
+        \\}
+        \\
+        \\main = to_instruction(Str.to_utf8("UUC"))
+        ,
+        .expected = .{ .inspect_str = "Ok(3)" },
+    },
 };

--- a/src/postcheck/lambda_mono/ast.zig
+++ b/src/postcheck/lambda_mono/ast.zig
@@ -71,6 +71,18 @@ pub const RecordDestruct = struct {
     pattern: PatId,
 };
 
+/// List destructuring pattern: fixed element patterns plus an optional rest.
+pub const ListPattern = struct {
+    patterns: Span(PatId),
+    rest: ?ListRestPattern,
+};
+
+/// `..`/`.. as name` portion of a list pattern.
+pub const ListRestPattern = struct {
+    index: u32,
+    pattern: ?PatId,
+};
+
 /// Read of one capture from a capture record.
 pub const CaptureSlot = struct {
     record: ExprId,
@@ -229,6 +241,7 @@ pub const PatData = union(enum) {
     },
     record: Span(RecordDestruct),
     tuple: Span(PatId),
+    list: ListPattern,
     tag: struct {
         name: Type.names.TagNameId,
         payloads: Span(PatId),

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -769,6 +769,13 @@ const Lowerer = struct {
             } },
             .record => |fields| .{ .record = try self.lowerRecordDestructSpan(fields) },
             .tuple => |items| .{ .tuple = try self.lowerPatSpan(items) },
+            .list => |list| .{ .list = .{
+                .patterns = try self.lowerPatSpan(list.patterns),
+                .rest = if (list.rest) |rest| .{
+                    .index = rest.index,
+                    .pattern = if (rest.pattern) |rest_pattern| try self.lowerPat(rest_pattern) else null,
+                } else null,
+            } },
             .tag => |tag| .{ .tag = .{
                 .name = tag.name,
                 .payloads = try self.lowerPatSpan(tag.payloads),

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -582,6 +582,14 @@ const Solver = struct {
                     try self.bindPattern(child, item_ty);
                 }
             },
+            .list => |list| {
+                const elem_ty = try self.listElem(pat_ty);
+                for (self.program.lifted.patSpan(list.patterns)) |child| {
+                    try self.bindPattern(child, elem_ty);
+                }
+                // A captured rest is itself a list with the same element type.
+                if (list.rest) |rest| if (rest.pattern) |rest_pattern| try self.bindPattern(rest_pattern, pat_ty);
+            },
             .tag => |tag| {
                 const payload_tys = try self.tagPayloadsSpan(pat_ty, tag.name);
                 const payloads = self.program.lifted.patSpan(tag.payloads);

--- a/src/postcheck/lir_lower.zig
+++ b/src/postcheck/lir_lower.zig
@@ -1499,6 +1499,19 @@ const Lowerer = struct {
                 }
                 break :blk current;
             },
+            .list => |list| blk: {
+                var current = next;
+                if (list.rest) |rest| {
+                    if (rest.pattern) |rest_pattern| current = try self.initUninitializedPattern(rest_pattern, current);
+                }
+                const pats = self.program.patSpan(list.patterns);
+                var i = pats.len;
+                while (i > 0) {
+                    i -= 1;
+                    current = try self.initUninitializedPattern(pats[i], current);
+                }
+                break :blk current;
+            },
             .tag => |tag| blk: {
                 var current = next;
                 const payloads = self.program.patSpan(tag.payloads);
@@ -1738,6 +1751,9 @@ const Lowerer = struct {
                 }
                 break :blk false;
             },
+            // Only `[.. as rest]` / `[..]` imposes no length constraint and is
+            // irrefutable; any fixed elements or an exact length can fail.
+            .list => |list| list.patterns.len > 0 or list.rest == null,
             .nominal => |inner| self.patternCanMiss(inner),
             .tag, .callable, .int_lit, .dec_lit, .frac_f32_lit, .frac_f64_lit, .str_lit, .str_pattern => true,
         };
@@ -1753,6 +1769,7 @@ const Lowerer = struct {
             },
             .record => |fields| try self.lowerRecordPatternThen(pat_data.ty, fields, source, on_match, miss, continuation),
             .tuple => |items| try self.lowerTuplePatternThen(items, source, on_match, miss, continuation),
+            .list => |list| try self.lowerListPatternThen(list, source, on_match, miss, continuation),
             .nominal => |inner| try self.lowerPatternThen(inner, source, on_match, miss, continuation),
             .tag => |tag| try self.lowerTagPatternThen(pat_data.ty, tag.name, tag.payloads, source, on_match, miss, continuation),
             .callable => |callable| try self.lowerCallablePatternThen(pat_data.ty, callable.variant, callable.payload, source, on_match, miss, continuation),
@@ -1925,6 +1942,101 @@ const Lowerer = struct {
         return current;
     }
 
+    /// Lower a list pattern as a length test plus extracted-and-matched
+    /// elements (and an optional captured rest), all sharing one `miss` target
+    /// so the result is linear in the pattern's size. See the equivalent in
+    /// `solved_lir_lower.zig` for the detailed rationale.
+    fn lowerListPatternThen(
+        self: *Lowerer,
+        list: LambdaMono.ListPattern,
+        source: LIR.LocalId,
+        on_match: LIR.CFStmtId,
+        miss: ?PatternMiss,
+        continuation: LIR.CFStmtId,
+    ) Common.LowerError!LIR.CFStmtId {
+        const elems = self.program.patSpan(list.patterns);
+        const fixed_count: i64 = @intCast(elems.len);
+        const len_local = try self.addLocalForLayout(.u64);
+
+        var current = on_match;
+
+        if (list.rest) |rest| {
+            if (rest.pattern) |rest_pattern| {
+                if (elems.len == 0) {
+                    current = try self.bindPattern(rest_pattern, source, current);
+                } else {
+                    const source_layout = self.result.store.getLocal(source).layout_idx;
+                    const rest_local = try self.addLocalForLayout(source_layout);
+                    current = try self.bindPattern(rest_pattern, rest_local, current);
+                    const front_dropped = try self.addLocalForLayout(source_layout);
+                    const keep_len = try self.addLocalForLayout(.u64);
+                    current = try self.assignBinaryLowLevel(rest_local, .list_take_first, front_dropped, keep_len, current);
+                    current = try self.lenMinusConst(keep_len, len_local, fixed_count, current);
+                    const keep_after_front = try self.addLocalForLayout(.u64);
+                    current = try self.assignBinaryLowLevel(front_dropped, .list_take_last, source, keep_after_front, current);
+                    current = try self.lenMinusConst(keep_after_front, len_local, @intCast(rest.index), current);
+                }
+            }
+        }
+
+        const rest_index: ?u32 = if (list.rest) |rest| rest.index else null;
+        var i = elems.len;
+        while (i > 0) {
+            i -= 1;
+            const elem_local = try self.addTemp(self.pat(elems[i]).ty);
+            current = try self.lowerPatternThen(elems[i], elem_local, current, miss, continuation);
+            const index_local = try self.addLocalForLayout(.u64);
+            current = try self.assignBinaryLowLevel(elem_local, .list_get_unsafe, source, index_local, current);
+            const matches_from_back = if (rest_index) |ri| i >= ri else false;
+            if (matches_from_back) {
+                current = try self.lenMinusConst(index_local, len_local, fixed_count - @as(i64, @intCast(i)), current);
+            } else {
+                current = try self.assignU64Literal(index_local, @intCast(i), current);
+            }
+        }
+
+        const required = try self.addLocalForLayout(.u64);
+        const cond = try self.addLocalForLayout(.bool);
+        const cmp_op: LIR.LowLevel = if (list.rest == null) .num_is_eq else .num_is_gte;
+        const length_check = try self.boolSwitchNoContinuation(cond, current, try self.patternMissJump(miss));
+        var head = try self.assignBinaryLowLevel(cond, cmp_op, len_local, required, length_check);
+        head = try self.assignU64Literal(required, fixed_count, head);
+        head = try self.assignUnaryLowLevel(len_local, .list_len, source, head);
+        return head;
+    }
+
+    fn assignU64Literal(self: *Lowerer, target: LIR.LocalId, value: i64, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
+        return try self.result.store.addCFStmt(.{ .assign_literal = .{
+            .target = target,
+            .value = .{ .i64_literal = .{ .value = value, .layout_idx = .u64 } },
+            .next = next,
+        } });
+    }
+
+    fn assignBinaryLowLevel(
+        self: *Lowerer,
+        target: LIR.LocalId,
+        op: LIR.LowLevel,
+        lhs: LIR.LocalId,
+        rhs: LIR.LocalId,
+        next: LIR.CFStmtId,
+    ) Common.LowerError!LIR.CFStmtId {
+        const args = [_]LIR.LocalId{ lhs, rhs };
+        return try self.result.store.addCFStmt(.{ .assign_low_level = .{
+            .target = target,
+            .op = op,
+            .rc_effect = op.rcEffect(),
+            .args = try self.result.store.addLocalSpan(&args),
+            .next = next,
+        } });
+    }
+
+    fn lenMinusConst(self: *Lowerer, target: LIR.LocalId, len_local: LIR.LocalId, value: i64, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
+        const operand = try self.addLocalForLayout(.u64);
+        const subtract = try self.assignBinaryLowLevel(target, .num_minus, len_local, operand, next);
+        return try self.assignU64Literal(operand, value, subtract);
+    }
+
     fn bindPattern(self: *Lowerer, pat_id: LambdaMono.PatId, source: LIR.LocalId, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
         const pat_data = self.pat(pat_id);
         return switch (pat_data.data) {
@@ -1936,6 +2048,12 @@ const Lowerer = struct {
             },
             .record => |fields| try self.bindRecordPattern(pat_data.ty, fields, source, next),
             .tuple => |items| try self.bindTuplePattern(items, source, next),
+            // Only an irrefutable list pattern reaches binding: `[.. as rest]`
+            // binds the whole list (aliasing the source); `[..]` binds nothing.
+            .list => |list| if (list.rest) |rest| (if (rest.pattern) |rest_pattern|
+                try self.bindPattern(rest_pattern, source, next)
+            else
+                next) else next,
             .tag => |tag| try self.bindTagPayloadPatterns(self.tagIndex(pat_data.ty, tag.name), tag.payloads, source, next),
             .callable => |callable| if (callable.payload) |payload_pat| blk: {
                 const variant_index = self.callableVariantIndex(pat_data.ty, callable.variant);

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -361,6 +361,7 @@ pub const PatData = union(enum) {
     },
     record: Span(RecordDestruct),
     tuple: Span(PatId),
+    list: ListPattern,
     tag: struct {
         name: names.TagNameId,
         payloads: Span(PatId),
@@ -397,6 +398,22 @@ pub const StrPatternStep = struct {
 pub const RecordDestruct = struct {
     name: names.RecordFieldNameId,
     pattern: PatId,
+};
+
+/// List destructuring pattern: fixed element patterns plus an optional rest
+/// that captures the remaining slice. The element patterns before the rest
+/// match from the front; those at or after the rest's index match from the
+/// back.
+pub const ListPattern = struct {
+    patterns: Span(PatId),
+    rest: ?ListRestPattern,
+};
+
+/// The `..`/`.. as name` portion of a list pattern. `index` is how many fixed
+/// element patterns precede it; `pattern` binds the captured slice when present.
+pub const ListRestPattern = struct {
+    index: u32,
+    pattern: ?PatId,
 };
 
 /// Match branch.

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -2749,13 +2749,6 @@ const BinderRestore = struct {
     previous: ?Ast.LocalId,
 };
 
-const CollectedListPattern = struct {
-    local: Ast.LocalId,
-    ty: Type.TypeId,
-    patterns: []const checked.CheckedPatternId,
-    rest: ?checked.CheckedListRestPattern,
-};
-
 const BodyContext = struct {
     allocator: Allocator,
     builder: *Builder,
@@ -6205,83 +6198,10 @@ const BodyContext = struct {
         comptime_site: ?Ast.ComptimeSiteId,
     ) Allocator.Error!Ast.ExprId {
         const output_ty = self.matchOutputType(output);
-        if (!self.matchContainsListPattern(match)) {
-            return try self.builder.program.addExpr(.{
-                .ty = output_ty,
-                .data = try self.lowerMatch(match, output, comptime_site),
-            });
-        }
-
-        const scrutinee = try self.lowerExpr(match.cond);
-        const scrutinee_ty = self.builder.program.exprs.items[@intFromEnum(scrutinee)].ty;
-        const scrutinee_local = try self.builder.program.addLocal(self.builder.symbols.fresh(), scrutinee_ty);
-        const scrutinee_expr = try self.builder.localExpr(scrutinee_local, scrutinee_ty);
-        const rest = try self.lowerListPatternMatchAlternatives(scrutinee_expr, scrutinee_ty, match.branches, output, comptime_site);
-        return try self.builder.program.addExpr(.{ .ty = output_ty, .data = .{ .let_ = .{
-            .bind = try self.builder.bindPat(scrutinee_local, scrutinee_ty),
-            .value = scrutinee,
-            .rest = rest,
-        } } });
-    }
-
-    fn matchContainsListPattern(self: *BodyContext, match: anytype) bool {
-        for (match.branches) |branch| {
-            for (branch.patterns) |pattern| {
-                if (self.patternContainsList(pattern.pattern)) return true;
-            }
-        }
-        return false;
-    }
-
-    fn patternContainsList(self: *BodyContext, pattern_id: checked.CheckedPatternId) bool {
-        const pattern = self.view.bodies.patterns[@intFromEnum(pattern_id)];
-        return switch (pattern.data) {
-            .list => true,
-            .as => |as| self.patternContainsList(as.pattern),
-            .applied_tag => |tag| blk: {
-                for (tag.args) |child| {
-                    if (self.patternContainsList(child)) break :blk true;
-                }
-                break :blk false;
-            },
-            .nominal => |nominal| self.patternContainsList(nominal.backing_pattern),
-            .record_destructure => |destructs| blk: {
-                for (destructs) |destruct| {
-                    const child = switch (destruct.kind) {
-                        .required => |child_pattern| child_pattern,
-                        .sub_pattern => |child_pattern| child_pattern,
-                        .rest => |child_pattern| child_pattern,
-                    };
-                    if (self.patternContainsList(child)) break :blk true;
-                }
-                break :blk false;
-            },
-            .tuple => |items| blk: {
-                for (items) |child| {
-                    if (self.patternContainsList(child)) break :blk true;
-                }
-                break :blk false;
-            },
-            .str_interpolation => |str| blk: {
-                for (str.steps) |step| {
-                    if (step.capture) |capture| {
-                        if (self.patternContainsList(capture)) break :blk true;
-                    }
-                }
-                break :blk false;
-            },
-            .assign,
-            .pending,
-            .num_literal,
-            .small_dec_literal,
-            .dec_literal,
-            .frac_f32_literal,
-            .frac_f64_literal,
-            .str_literal,
-            .underscore,
-            .runtime_error,
-            => false,
-        };
+        return try self.builder.program.addExpr(.{
+            .ty = output_ty,
+            .data = try self.lowerMatch(match, output, comptime_site),
+        });
     }
 
     fn patternNeedsExplicitBinding(self: *BodyContext, pattern_id: checked.CheckedPatternId) bool {
@@ -6340,270 +6260,6 @@ const BodyContext = struct {
             }
         }
         return false;
-    }
-
-    fn lowerListPatternMatchAlternatives(
-        self: *BodyContext,
-        scrutinee: Ast.ExprId,
-        scrutinee_ty: Type.TypeId,
-        branches: []const checked.CheckedMatchBranch,
-        output: MatchOutput,
-        comptime_site: ?Ast.ComptimeSiteId,
-    ) Allocator.Error!Ast.ExprId {
-        const output_ty = self.matchOutputType(output);
-        var fallback = if (comptime_site) |site|
-            try self.comptimeExhaustivenessFailedExpr(output_ty, site)
-        else blk: {
-            const msg = try self.builder.program.addStringLiteral("non-exhaustive checked match reached Monotype");
-            break :blk try self.builder.program.addExpr(.{ .ty = output_ty, .data = .{ .crash = msg } });
-        };
-
-        var branch_index = branches.len;
-        var alternative_index = branchCount(branches);
-        while (branch_index > 0) {
-            branch_index -= 1;
-            const branch = branches[branch_index];
-            var pattern_index = branch.patterns.len;
-            while (pattern_index > 0) {
-                pattern_index -= 1;
-                alternative_index -= 1;
-                fallback = try self.lowerListPatternMatchAlternative(
-                    scrutinee,
-                    scrutinee_ty,
-                    branch.patterns[pattern_index],
-                    branch.guard,
-                    branch.value,
-                    fallback,
-                    output,
-                    comptime_site,
-                    alternative_index,
-                );
-            }
-        }
-
-        return fallback;
-    }
-
-    fn lowerListPatternMatchAlternative(
-        self: *BodyContext,
-        scrutinee: Ast.ExprId,
-        scrutinee_ty: Type.TypeId,
-        pattern: checked.CheckedMatchBranchPattern,
-        guard: ?checked.CheckedExprId,
-        body: checked.CheckedExprId,
-        fallback: Ast.ExprId,
-        output: MatchOutput,
-        comptime_site: ?Ast.ComptimeSiteId,
-        alternative_index: usize,
-    ) Allocator.Error!Ast.ExprId {
-        const output_ty = self.matchOutputType(output);
-        const checked_pattern = self.view.bodies.patterns[@intFromEnum(pattern.pattern)];
-        switch (checked_pattern.data) {
-            .list => |list| {
-                var branch_ctx = try self.childContext(self.current_fn_key);
-                defer branch_ctx.deinit();
-                var saved = std.ArrayList(BinderRestore).empty;
-                defer saved.deinit(self.allocator);
-                try branch_ctx.saveMatchPatternBinders(pattern, &saved);
-                defer branch_ctx.restoreBinders(saved.items);
-
-                try branch_ctx.preRegisterPatternBinders(pattern.pattern, scrutinee_ty);
-                try branch_ctx.applyAlternativeBinderRemaps(pattern.binder_remaps);
-
-                var body_lowered = try branch_ctx.wrapComptimeBranch(
-                    comptime_site,
-                    alternative_index,
-                    try branch_ctx.lowerMatchBranchBody(body, output),
-                );
-                if (guard) |guard_expr| {
-                    const guard_cond = try branch_ctx.lowerExpr(guard_expr);
-                    body_lowered = try branch_ctx.builder.ifExpr(guard_cond, body_lowered, fallback, output_ty);
-                }
-
-                return try branch_ctx.applyListCheck(scrutinee, scrutinee_ty, list, body_lowered, fallback, output_ty);
-            },
-            .underscore => {
-                var branch_ctx = try self.childContext(self.current_fn_key);
-                defer branch_ctx.deinit();
-                var saved = std.ArrayList(BinderRestore).empty;
-                defer saved.deinit(self.allocator);
-                try branch_ctx.saveMatchPatternBinders(pattern, &saved);
-                defer branch_ctx.restoreBinders(saved.items);
-                try branch_ctx.applyAlternativeBinderRemaps(pattern.binder_remaps);
-                const branch_body = try branch_ctx.wrapComptimeBranch(
-                    comptime_site,
-                    alternative_index,
-                    try branch_ctx.lowerMatchBranchBody(body, output),
-                );
-                if (guard) |guard_expr| {
-                    const guard_cond = try branch_ctx.lowerExpr(guard_expr);
-                    return try branch_ctx.builder.ifExpr(guard_cond, branch_body, fallback, output_ty);
-                }
-                return branch_body;
-            },
-            else => {
-                var branch_ctx = try self.childContext(self.current_fn_key);
-                defer branch_ctx.deinit();
-                var saved = std.ArrayList(BinderRestore).empty;
-                defer saved.deinit(self.allocator);
-                try branch_ctx.saveMatchPatternBinders(pattern, &saved);
-                defer branch_ctx.restoreBinders(saved.items);
-
-                try branch_ctx.preRegisterPatternBinders(pattern.pattern, scrutinee_ty);
-
-                var checks = std.ArrayList(CollectedListPattern).empty;
-                defer checks.deinit(branch_ctx.allocator);
-                const literal_guards_start = branch_ctx.pattern_literal_guards.items.len;
-                const pat = try branch_ctx.lowerPatternAtTypeCollectingLists(pattern.pattern, scrutinee_ty, &checks);
-                const literal_guards = try branch_ctx.drainPatternLiteralGuards(literal_guards_start);
-                defer branch_ctx.allocator.free(literal_guards);
-
-                try branch_ctx.applyAlternativeBinderRemaps(pattern.binder_remaps);
-
-                var body_lowered = try branch_ctx.wrapComptimeBranch(
-                    comptime_site,
-                    alternative_index,
-                    try branch_ctx.lowerMatchBranchBody(body, output),
-                );
-                if (guard) |guard_expr| {
-                    const guard_cond = try branch_ctx.lowerExpr(guard_expr);
-                    body_lowered = try branch_ctx.builder.ifExpr(guard_cond, body_lowered, fallback, output_ty);
-                }
-
-                body_lowered = try branch_ctx.applyPatternLiteralGuards(literal_guards, body_lowered, fallback, output_ty);
-
-                var i = checks.items.len;
-                while (i > 0) {
-                    i -= 1;
-                    const entry = checks.items[i];
-                    const scrut_expr = try branch_ctx.builder.localExpr(entry.local, entry.ty);
-                    body_lowered = try branch_ctx.applyListCheck(scrut_expr, entry.ty, entry, body_lowered, fallback, output_ty);
-                }
-
-                const wildcard = try self.builder.program.addPat(.{ .ty = scrutinee_ty, .data = .wildcard });
-                const match_branches = [_]Ast.Branch{
-                    .{ .pat = pat, .body = body_lowered },
-                    .{ .pat = wildcard, .body = fallback },
-                };
-                return try self.builder.program.addExpr(.{ .ty = output_ty, .data = .{ .match_ = .{
-                    .scrutinee = scrutinee,
-                    .branches = try self.builder.program.addBranchSpan(&match_branches),
-                } } });
-            },
-        }
-    }
-
-    fn listPatternCondition(
-        self: *BodyContext,
-        scrutinee: Ast.ExprId,
-        list: anytype,
-    ) Allocator.Error!Ast.ExprId {
-        const u64_ty = try self.builder.primitiveType(.u64);
-        const bool_ty = try self.builder.primitiveType(.bool);
-        const len = try self.builder.lowLevelExpr(.list_len, &.{scrutinee}, u64_ty);
-        const required = try self.builder.intLiteralExpr(list.patterns.len, u64_ty);
-        const op: can.CIR.Expr.LowLevel = if (list.rest == null) .num_is_eq else .num_is_gte;
-        return try self.builder.lowLevelExpr(op, &.{ len, required }, bool_ty);
-    }
-
-    fn applyListCheck(
-        self: *BodyContext,
-        scrutinee: Ast.ExprId,
-        scrutinee_ty: Type.TypeId,
-        list: anytype,
-        body: Ast.ExprId,
-        fallback: Ast.ExprId,
-        output_ty: Type.TypeId,
-    ) Allocator.Error!Ast.ExprId {
-        const elem_ty = self.constListElemType(scrutinee_ty);
-        const u64_ty = try self.builder.primitiveType(.u64);
-        const needs_len = if (list.rest) |rest| rest.index < list.patterns.len or rest.pattern != null else false;
-        const len = if (needs_len) try self.builder.lowLevelExpr(.list_len, &.{scrutinee}, u64_ty) else null;
-
-        const values = try self.allocator.alloc(Ast.ExprId, list.patterns.len);
-        defer self.allocator.free(values);
-        const patterns = try self.allocator.alloc(Ast.PatId, list.patterns.len);
-        defer self.allocator.free(patterns);
-        const sub_checks_per_elem = try self.allocator.alloc(std.ArrayList(CollectedListPattern), list.patterns.len);
-        defer {
-            for (sub_checks_per_elem) |*sub| sub.deinit(self.allocator);
-            self.allocator.free(sub_checks_per_elem);
-        }
-        for (sub_checks_per_elem) |*sub| sub.* = std.ArrayList(CollectedListPattern).empty;
-        const literal_guards_per_elem = try self.allocator.alloc([]PatternLiteralGuard, list.patterns.len);
-        defer {
-            for (literal_guards_per_elem) |guards| self.allocator.free(guards);
-            self.allocator.free(literal_guards_per_elem);
-        }
-        for (literal_guards_per_elem) |*guards| guards.* = &.{};
-
-        for (list.patterns, 0..) |pattern_id, index| {
-            const item_index = try self.listPatternItemIndex(index, list.patterns.len, list.rest, len, u64_ty);
-            values[index] = try self.builder.lowLevelExpr(.list_get_unsafe, &.{ scrutinee, item_index }, elem_ty);
-            const guards_start = self.pattern_literal_guards.items.len;
-            patterns[index] = try self.lowerPatternAtTypeCollectingLists(pattern_id, elem_ty, &sub_checks_per_elem[index]);
-            literal_guards_per_elem[index] = try self.drainPatternLiteralGuards(guards_start);
-        }
-
-        var rest_pat: ?Ast.PatId = null;
-        var rest_value: ?Ast.ExprId = null;
-        var rest_sub_checks = std.ArrayList(CollectedListPattern).empty;
-        defer rest_sub_checks.deinit(self.allocator);
-        var rest_literal_guards: []PatternLiteralGuard = &.{};
-        defer self.allocator.free(rest_literal_guards);
-        if (list.rest) |rest| {
-            if (rest.pattern) |rest_pattern| {
-                const list_len = len orelse try self.builder.lowLevelExpr(.list_len, &.{scrutinee}, u64_ty);
-                const fixed_count = try self.builder.intLiteralExpr(list.patterns.len, u64_ty);
-                const rest_len = try self.builder.lowLevelExpr(.num_minus, &.{ list_len, fixed_count }, u64_ty);
-                const rest_start = try self.builder.intLiteralExpr(rest.index, u64_ty);
-                const range = try self.sublistRangeExpr(rest_start, rest_len, u64_ty);
-                rest_value = try self.builder.lowLevelExpr(.list_sublist, &.{ scrutinee, range }, scrutinee_ty);
-                const guards_start = self.pattern_literal_guards.items.len;
-                rest_pat = try self.lowerPatternAtTypeCollectingLists(rest_pattern, scrutinee_ty, &rest_sub_checks);
-                rest_literal_guards = try self.drainPatternLiteralGuards(guards_start);
-            }
-        }
-
-        var success = body;
-
-        var index = patterns.len;
-        while (index > 0) {
-            index -= 1;
-            var elem_success = success;
-            var sub_index = sub_checks_per_elem[index].items.len;
-            while (sub_index > 0) {
-                sub_index -= 1;
-                const sub = sub_checks_per_elem[index].items[sub_index];
-                const sub_scrut = try self.builder.localExpr(sub.local, sub.ty);
-                elem_success = try self.applyListCheck(sub_scrut, sub.ty, sub, elem_success, fallback, output_ty);
-            }
-            elem_success = try self.applyPatternLiteralGuards(literal_guards_per_elem[index], elem_success, fallback, output_ty);
-            success = try self.wrapPatternMatch(values[index], elem_ty, patterns[index], elem_success, fallback, output_ty);
-        }
-
-        if (rest_pat) |pat| {
-            var rest_success = success;
-            var sub_index = rest_sub_checks.items.len;
-            while (sub_index > 0) {
-                sub_index -= 1;
-                const sub = rest_sub_checks.items[sub_index];
-                const sub_scrut = try self.builder.localExpr(sub.local, sub.ty);
-                rest_success = try self.applyListCheck(sub_scrut, sub.ty, sub, rest_success, fallback, output_ty);
-            }
-            rest_success = try self.applyPatternLiteralGuards(rest_literal_guards, rest_success, fallback, output_ty);
-            success = try self.wrapPatternMatch(
-                rest_value orelse Common.invariant("list rest pattern had no lowered rest value"),
-                scrutinee_ty,
-                pat,
-                rest_success,
-                fallback,
-                output_ty,
-            );
-        }
-
-        const cond = try self.listPatternCondition(scrutinee, list);
-        return try self.builder.ifExpr(cond, success, fallback, output_ty);
     }
 
     fn preRegisterPatternBinders(
@@ -6693,161 +6349,6 @@ const BodyContext = struct {
         }
     }
 
-    fn lowerPatternAtTypeCollectingLists(
-        self: *BodyContext,
-        pattern_id: checked.CheckedPatternId,
-        ty: Type.TypeId,
-        checks_out: *std.ArrayList(CollectedListPattern),
-    ) Allocator.Error!Ast.PatId {
-        const pattern = self.view.bodies.patterns[@intFromEnum(pattern_id)];
-        try self.constrainTypeToMono(pattern.ty, ty);
-        const data: Ast.PatData = switch (pattern.data) {
-            .pending,
-            .runtime_error,
-            => Common.invariant("non-runtime checked pattern reached Monotype lowering"),
-            .assign => |binder| blk: {
-                const local = if (self.binders.get(binder)) |existing| existing else inner: {
-                    const new_local = try self.builder.program.addLocalWithBinder(self.builder.symbols.fresh(), ty, binder);
-                    try bindLocalName(self.builder.program, self.view, new_local, binder);
-                    try self.binders.put(binder, new_local);
-                    break :inner new_local;
-                };
-                break :blk .{ .bind = local };
-            },
-            .as => |as| blk: {
-                const local = if (self.binders.get(as.binder)) |existing| existing else inner: {
-                    const new_local = try self.builder.program.addLocalWithBinder(self.builder.symbols.fresh(), ty, as.binder);
-                    try bindLocalName(self.builder.program, self.view, new_local, as.binder);
-                    try self.binders.put(as.binder, new_local);
-                    break :inner new_local;
-                };
-                break :blk .{ .as = .{
-                    .pattern = try self.lowerPatternAtTypeCollectingLists(as.pattern, ty, checks_out),
-                    .local = local,
-                } };
-            },
-            .applied_tag => |tag| try self.lowerTagPatternCollectingLists(tag, ty, checks_out),
-            .nominal => |nominal| .{ .nominal = try self.lowerPatternAtTypeCollectingLists(nominal.backing_pattern, self.builder.namedBackingType(ty) orelse ty, checks_out) },
-            .record_destructure => |destructs| try self.lowerRecordPatternCollectingLists(destructs, ty, checks_out),
-            .list => |list| blk: {
-                const local = try self.builder.program.addLocal(self.builder.symbols.fresh(), ty);
-                try checks_out.append(self.allocator, .{
-                    .local = local,
-                    .ty = ty,
-                    .patterns = list.patterns,
-                    .rest = list.rest,
-                });
-                break :blk .{ .bind = local };
-            },
-            .tuple => |items| .{ .tuple = try self.lowerPatternSpanAtTypesCollectingLists(items, self.builder.tupleItemTypes(ty), checks_out) },
-            .num_literal => |num| if (num.conversion) |conversion|
-                try self.bindLiteralGuardPattern(conversion, ty)
-            else
-                self.lowerNumPattern(num.value, ty),
-            .small_dec_literal => |dec| if (dec.conversion) |conversion|
-                try self.bindLiteralGuardPattern(conversion, ty)
-            else
-                Common.invariant("small decimal pattern reached Monotype after numeric finalization"),
-            .dec_literal => |dec| if (dec.conversion) |conversion|
-                try self.bindLiteralGuardPattern(conversion, ty)
-            else
-                .{ .dec_lit = dec.value },
-            .frac_f32_literal => |value| .{ .frac_f32_lit = value },
-            .frac_f64_literal => |value| .{ .frac_f64_lit = value },
-            .str_literal => |str| if (str.conversion) |conversion|
-                try self.bindLiteralGuardPattern(conversion, ty)
-            else
-                .{ .str_lit = try self.lowerStringLiteral(str.literal) },
-            .str_interpolation => |str| try self.lowerStrPatternCollectingLists(str, ty, checks_out),
-            .underscore => .wildcard,
-        };
-        return try self.builder.program.addPat(.{ .ty = ty, .data = data });
-    }
-
-    fn lowerStrPatternCollectingLists(
-        self: *BodyContext,
-        str: anytype,
-        ty: Type.TypeId,
-        checks_out: *std.ArrayList(CollectedListPattern),
-    ) Allocator.Error!Ast.PatData {
-        const steps = try self.allocator.alloc(Ast.StrPatternStep, str.steps.len);
-        defer self.allocator.free(steps);
-
-        for (str.steps, 0..) |step, i| {
-            steps[i] = .{
-                .capture = if (step.capture) |capture| try self.lowerPatternAtTypeCollectingLists(capture, ty, checks_out) else null,
-                .delimiter = try self.lowerStringLiteral(step.delimiter),
-            };
-        }
-
-        return .{ .str_pattern = .{
-            .prefix = try self.lowerStringLiteral(str.prefix),
-            .steps = try self.builder.program.addStrPatternStepSpan(steps),
-            .end = switch (str.end) {
-                .exact => .exact,
-                .tail => .tail,
-            },
-        } };
-    }
-
-    fn lowerPatternSpanAtTypesCollectingLists(
-        self: *BodyContext,
-        checked_patterns: []const checked.CheckedPatternId,
-        tys: []const Type.TypeId,
-        checks_out: *std.ArrayList(CollectedListPattern),
-    ) Allocator.Error!Ast.Span(Ast.PatId) {
-        if (checked_patterns.len != tys.len) Common.invariant("pattern arity differs from concrete checked type");
-        const lowered = try self.allocator.alloc(Ast.PatId, checked_patterns.len);
-        defer self.allocator.free(lowered);
-        for (checked_patterns, tys, 0..) |child, child_ty, i| {
-            lowered[i] = try self.lowerPatternAtTypeCollectingLists(child, child_ty, checks_out);
-        }
-        return try self.builder.program.addPatSpan(lowered);
-    }
-
-    fn lowerTagPatternCollectingLists(
-        self: *BodyContext,
-        tag: anytype,
-        ty: Type.TypeId,
-        checks_out: *std.ArrayList(CollectedListPattern),
-    ) Allocator.Error!Ast.PatData {
-        const name = try self.builder.tagName(self.view, tag.name);
-        return .{ .tag = .{
-            .name = name,
-            .payloads = try self.lowerPatternSpanAtTypesCollectingLists(tag.args, self.builder.tagPayloadTypes(ty, name), checks_out),
-        } };
-    }
-
-    fn lowerRecordPatternCollectingLists(
-        self: *BodyContext,
-        destructs: []const checked.CheckedRecordDestruct,
-        ty: Type.TypeId,
-        checks_out: *std.ArrayList(CollectedListPattern),
-    ) Allocator.Error!Ast.PatData {
-        var lowered = std.ArrayList(Ast.RecordDestruct).empty;
-        defer lowered.deinit(self.allocator);
-        for (destructs) |destruct| {
-            const child = switch (destruct.kind) {
-                .required => |pattern| pattern,
-                .sub_pattern => |pattern| pattern,
-                .rest => |pattern| {
-                    if (self.patternIsIgnored(pattern)) continue;
-                    Common.invariant("record rest pattern must be lowered to explicit rest-record construction before Monotype output");
-                },
-            };
-            const name = try self.builder.recordFieldName(self.view, destruct.label);
-            const child_ty = switch (destruct.kind) {
-                .required, .sub_pattern => self.builder.recordFieldType(ty, name),
-                .rest => unreachable,
-            };
-            try lowered.append(self.allocator, .{
-                .name = name,
-                .pattern = try self.lowerPatternAtTypeCollectingLists(child, child_ty, checks_out),
-            });
-        }
-        return .{ .record = try self.builder.program.addRecordDestructSpan(lowered.items) };
-    }
-
     fn wrapPatternMatch(
         self: *BodyContext,
         value: Ast.ExprId,
@@ -6866,44 +6367,6 @@ const BodyContext = struct {
             .scrutinee = value,
             .branches = try self.builder.program.addBranchSpan(&branches),
         } } });
-    }
-
-    fn listPatternItemIndex(
-        self: *BodyContext,
-        index: usize,
-        pattern_count: usize,
-        rest: ?checked.CheckedListRestPattern,
-        len: ?Ast.ExprId,
-        u64_ty: Type.TypeId,
-    ) Allocator.Error!Ast.ExprId {
-        if (rest) |rest_info| {
-            if (index >= rest_info.index) {
-                const list_len = len orelse Common.invariant("list pattern trailing item index required list length");
-                const trailing_count = try self.builder.intLiteralExpr(pattern_count - index, u64_ty);
-                return try self.builder.lowLevelExpr(.num_minus, &.{ list_len, trailing_count }, u64_ty);
-            }
-        }
-        return try self.builder.intLiteralExpr(index, u64_ty);
-    }
-
-    fn sublistRangeExpr(
-        self: *BodyContext,
-        start: Ast.ExprId,
-        len: Ast.ExprId,
-        u64_ty: Type.TypeId,
-    ) Allocator.Error!Ast.ExprId {
-        const len_name = try self.builder.program.names.internRecordFieldLabel("len");
-        const start_name = try self.builder.program.names.internRecordFieldLabel("start");
-        const fields = [_]Type.Field{
-            .{ .name = len_name, .ty = u64_ty },
-            .{ .name = start_name, .ty = u64_ty },
-        };
-        const ty = try self.builder.program.types.add(.{ .record = try self.builder.program.types.addFields(&fields) });
-        const exprs = [_]Ast.FieldExpr{
-            .{ .name = len_name, .value = len },
-            .{ .name = start_name, .value = start },
-        };
-        return try self.builder.program.addExpr(.{ .ty = ty, .data = .{ .record = try self.builder.program.addFieldExprSpan(&exprs) } });
     }
 
     fn lowerBindingContinuation(
@@ -7001,6 +6464,57 @@ const BodyContext = struct {
         const success = try self.lowerListPatternBindingSuccess(value, value_ty, list, result_ty, continuation, miss);
         const cond = try self.listPatternCondition(value, list);
         return try self.builder.ifExpr(cond, success, miss, result_ty);
+    }
+
+    fn listPatternCondition(
+        self: *BodyContext,
+        scrutinee: Ast.ExprId,
+        list: anytype,
+    ) Allocator.Error!Ast.ExprId {
+        const u64_ty = try self.builder.primitiveType(.u64);
+        const bool_ty = try self.builder.primitiveType(.bool);
+        const len = try self.builder.lowLevelExpr(.list_len, &.{scrutinee}, u64_ty);
+        const required = try self.builder.intLiteralExpr(list.patterns.len, u64_ty);
+        const op: can.CIR.Expr.LowLevel = if (list.rest == null) .num_is_eq else .num_is_gte;
+        return try self.builder.lowLevelExpr(op, &.{ len, required }, bool_ty);
+    }
+
+    fn listPatternItemIndex(
+        self: *BodyContext,
+        index: usize,
+        pattern_count: usize,
+        rest: ?checked.CheckedListRestPattern,
+        len: ?Ast.ExprId,
+        u64_ty: Type.TypeId,
+    ) Allocator.Error!Ast.ExprId {
+        if (rest) |rest_info| {
+            if (index >= rest_info.index) {
+                const list_len = len orelse Common.invariant("list pattern trailing item index required list length");
+                const trailing_count = try self.builder.intLiteralExpr(pattern_count - index, u64_ty);
+                return try self.builder.lowLevelExpr(.num_minus, &.{ list_len, trailing_count }, u64_ty);
+            }
+        }
+        return try self.builder.intLiteralExpr(index, u64_ty);
+    }
+
+    fn sublistRangeExpr(
+        self: *BodyContext,
+        start: Ast.ExprId,
+        len: Ast.ExprId,
+        u64_ty: Type.TypeId,
+    ) Allocator.Error!Ast.ExprId {
+        const len_name = try self.builder.program.names.internRecordFieldLabel("len");
+        const start_name = try self.builder.program.names.internRecordFieldLabel("start");
+        const fields = [_]Type.Field{
+            .{ .name = len_name, .ty = u64_ty },
+            .{ .name = start_name, .ty = u64_ty },
+        };
+        const ty = try self.builder.program.types.add(.{ .record = try self.builder.program.types.addFields(&fields) });
+        const exprs = [_]Ast.FieldExpr{
+            .{ .name = len_name, .value = len },
+            .{ .name = start_name, .value = start },
+        };
+        return try self.builder.program.addExpr(.{ .ty = ty, .data = .{ .record = try self.builder.program.addFieldExprSpan(&exprs) } });
     }
 
     fn lowerListPatternBindingSuccess(
@@ -8941,7 +8455,7 @@ const BodyContext = struct {
             .applied_tag => |tag| try self.lowerTagPattern(tag, ty),
             .nominal => |nominal| .{ .nominal = try self.lowerPatternAtType(nominal.backing_pattern, self.builder.namedBackingType(ty) orelse ty) },
             .record_destructure => |destructs| try self.lowerRecordPattern(destructs, ty),
-            .list => Common.invariant("list pattern must be lowered to explicit list operations before Monotype output"),
+            .list => |list| try self.lowerListPattern(list, ty),
             .tuple => |items| .{ .tuple = try self.lowerTuplePattern(items, ty) },
             .num_literal => |num| if (num.conversion) |conversion|
                 try self.bindLiteralGuardPattern(conversion, ty)
@@ -9008,6 +8522,25 @@ const BodyContext = struct {
 
     fn lowerTuplePattern(self: *BodyContext, items: []const checked.CheckedPatternId, ty: Type.TypeId) Allocator.Error!Ast.Span(Ast.PatId) {
         return try self.lowerPatternSpanAtTypes(items, self.builder.tupleItemTypes(ty));
+    }
+
+    fn lowerListPattern(self: *BodyContext, list: anytype, ty: Type.TypeId) Allocator.Error!Ast.PatData {
+        const elem_ty = self.constListElemType(ty);
+        const lowered = try self.allocator.alloc(Ast.PatId, list.patterns.len);
+        defer self.allocator.free(lowered);
+        for (list.patterns, 0..) |child, i| {
+            lowered[i] = try self.lowerPatternAtType(child, elem_ty);
+        }
+        const rest: ?Ast.ListRestPattern = if (list.rest) |r| .{
+            .index = r.index,
+            // A captured rest binds the remaining slice, which has the same
+            // list type as the scrutinee.
+            .pattern = if (r.pattern) |rest_pattern| try self.lowerPatternAtType(rest_pattern, ty) else null,
+        } else null;
+        return .{ .list = .{
+            .patterns = try self.builder.program.addPatSpan(lowered),
+            .rest = rest,
+        } };
     }
 
     fn lowerTagPattern(self: *BodyContext, tag: anytype, ty: Type.TypeId) Allocator.Error!Ast.PatData {
@@ -9088,33 +8621,6 @@ const BodyContext = struct {
             }
         }
         return try self.lowerEqualityExpr(entry.ty, scrutinee, expected, "is_eq", try self.builder.primitiveType(.bool));
-    }
-
-    /// Take ownership of the literal-equality conditions collected since
-    /// `start`, restoring the collection to that length.
-    fn drainPatternLiteralGuards(self: *BodyContext, start: usize) Allocator.Error![]PatternLiteralGuard {
-        const drained = try self.allocator.dupe(PatternLiteralGuard, self.pattern_literal_guards.items[start..]);
-        self.pattern_literal_guards.shrinkRetainingCapacity(start);
-        return drained;
-    }
-
-    /// Wrap a match-branch body so it only runs when every collected literal
-    /// equality holds, jumping to the branch's miss target otherwise.
-    fn applyPatternLiteralGuards(
-        self: *BodyContext,
-        guards: []const PatternLiteralGuard,
-        body: Ast.ExprId,
-        fallback: Ast.ExprId,
-        output_ty: Type.TypeId,
-    ) Allocator.Error!Ast.ExprId {
-        var result = body;
-        var i = guards.len;
-        while (i > 0) {
-            i -= 1;
-            const eq = try self.lowerPatternLiteralEq(guards[i]);
-            result = try self.builder.ifExpr(eq, result, fallback, output_ty);
-        }
-        return result;
     }
 
     /// Conjoin the branch's collected literal-equality conditions with its

--- a/src/postcheck/monotype_lifted/ast.zig
+++ b/src/postcheck/monotype_lifted/ast.zig
@@ -42,6 +42,10 @@ pub const ComptimeSite = Mono.ComptimeSite;
 pub const FieldExpr = Mono.FieldExpr;
 /// Record destructuring field pattern.
 pub const RecordDestruct = Mono.RecordDestruct;
+/// List destructuring pattern.
+pub const ListPattern = Mono.ListPattern;
+/// `..`/`.. as name` portion of a list pattern.
+pub const ListRestPattern = Mono.ListRestPattern;
 
 /// Typed Monotype Lifted expression.
 pub const Expr = Mono.Expr;

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -877,6 +877,10 @@ fn bindPat(allocator: Allocator, input: *const Ast.Program, pat_id: Mono.PatId, 
         },
         .record => |fields| for (input.recordDestructSpan(fields)) |field| try bindPat(allocator, input, field.pattern, bound, added),
         .tuple => |items| for (input.patSpan(items)) |child| try bindPat(allocator, input, child, bound, added),
+        .list => |list| {
+            for (input.patSpan(list.patterns)) |child| try bindPat(allocator, input, child, bound, added);
+            if (list.rest) |rest| if (rest.pattern) |rest_pattern| try bindPat(allocator, input, rest_pattern, bound, added);
+        },
         .tag => |tag| for (input.patSpan(tag.payloads)) |child| try bindPat(allocator, input, child, bound, added),
         .nominal => |backing| try bindPat(allocator, input, backing, bound, added),
     }

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -2211,6 +2211,9 @@ const Cloner = struct {
                     .backing = backing,
                 } };
             },
+            // List patterns are not statically destructured during
+            // specialization; fall back to the runtime match.
+            .list,
             .int_lit,
             .dec_lit,
             .frac_f32_lit,
@@ -2608,6 +2611,8 @@ const Cloner = struct {
                 };
                 return try self.bindPatToValue(backing_pat, nominal.backing.*);
             },
+            // List patterns are not statically bound during specialization.
+            .list,
             .int_lit,
             .dec_lit,
             .frac_f32_lit,
@@ -2634,6 +2639,13 @@ const Cloner = struct {
             } },
             .record => |fields| .{ .record = try self.cloneRecordDestructSpan(fields) },
             .tuple => |items| .{ .tuple = try self.clonePatSpan(items) },
+            .list => |list| .{ .list = .{
+                .patterns = try self.clonePatSpan(list.patterns),
+                .rest = if (list.rest) |rest| .{
+                    .index = rest.index,
+                    .pattern = if (rest.pattern) |rest_pattern| try self.clonePat(rest_pattern) else null,
+                } else null,
+            } },
             .tag => |tag| .{ .tag = .{
                 .name = tag.name,
                 .payloads = try self.clonePatSpan(tag.payloads),

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -2624,6 +2624,19 @@ const Lowerer = struct {
                 }
                 break :blk current;
             },
+            .list => |list| blk: {
+                var current = next;
+                if (list.rest) |rest| {
+                    if (rest.pattern) |rest_pattern| current = try self.initUninitializedPattern(rest_pattern, current);
+                }
+                const pats = self.solved.lifted.patSpan(list.patterns);
+                var i = pats.len;
+                while (i > 0) {
+                    i -= 1;
+                    current = try self.initUninitializedPattern(pats[i], current);
+                }
+                break :blk current;
+            },
             .tag => |tag| blk: {
                 var current = next;
                 const payloads = self.solved.lifted.patSpan(tag.payloads);
@@ -2862,6 +2875,10 @@ const Lowerer = struct {
                 }
                 break :blk false;
             },
+            // A list pattern can fail unless it imposes no length constraint:
+            // only `[.. as rest]` / `[..]` (a rest with no fixed elements, which
+            // matches every list) is irrefutable.
+            .list => |list| list.patterns.len > 0 or list.rest == null,
             .nominal => |inner| self.patternCanMiss(inner),
             .tag, .int_lit, .dec_lit, .frac_f32_lit, .frac_f64_lit, .str_lit, .str_pattern => true,
         };
@@ -2878,6 +2895,7 @@ const Lowerer = struct {
             },
             .record => |fields| try self.lowerRecordPatternThen(pat_ty, fields, source, on_match, miss, continuation),
             .tuple => |items| try self.lowerTuplePatternThen(items, source, on_match, miss, continuation),
+            .list => |list| try self.lowerListPatternThen(list, source, on_match, miss, continuation),
             .nominal => |inner| try self.lowerPatternThen(inner, source, on_match, miss, continuation),
             .tag => |tag| try self.lowerTagPatternThen(pat_ty, tag.name, tag.payloads, source, on_match, miss, continuation),
             .int_lit => |value| try self.lowerLiteralPatternThen(source, pat_ty, .{ .int_lit = value }, on_match, miss),
@@ -3018,6 +3036,116 @@ const Lowerer = struct {
         return current;
     }
 
+    /// Lower a list pattern as a sequence of tests that all share a single
+    /// `miss` target: a length test, then one extracted-and-matched element per
+    /// fixed pattern, then the optional captured rest slice. Because every miss
+    /// jumps to the one shared join, the lowered control flow is linear in the
+    /// pattern's size rather than duplicating the remainder of the match per
+    /// element.
+    fn lowerListPatternThen(
+        self: *Lowerer,
+        list: Lifted.ListPattern,
+        source: LIR.LocalId,
+        on_match: LIR.CFStmtId,
+        miss: ?PatternMiss,
+        continuation: LIR.CFStmtId,
+    ) Common.LowerError!LIR.CFStmtId {
+        const elems = self.solved.lifted.patSpan(list.patterns);
+        const fixed_count: i64 = @intCast(elems.len);
+
+        // The list length is read by the length test, by the indices of fixed
+        // elements that match from the back, and by the rest slice. It is
+        // assigned once at the head of the chain so every reader sees it.
+        const len_local = try self.addLocalForLayout(.u64);
+
+        var current = on_match;
+
+        // The captured rest binds the slice between the matched front and back
+        // elements. `[.. as rest]` with no fixed elements is the whole list and
+        // simply aliases the source; a bare `..` binds nothing.
+        if (list.rest) |rest| {
+            if (rest.pattern) |rest_pattern| {
+                if (elems.len == 0) {
+                    current = try self.bindPattern(rest_pattern, source, current);
+                } else {
+                    const source_layout = self.result.store.getLocal(source).layout_idx;
+                    const rest_local = try self.addLocalForLayout(source_layout);
+                    current = try self.bindPattern(rest_pattern, rest_local, current);
+                    // rest = take_first(take_last(source, len - rest.index), len - fixed_count)
+                    const front_dropped = try self.addLocalForLayout(source_layout);
+                    const keep_len = try self.addLocalForLayout(.u64);
+                    current = try self.assignBinaryLowLevel(rest_local, .list_take_first, front_dropped, keep_len, current);
+                    current = try self.lenMinusConst(keep_len, len_local, fixed_count, current);
+                    const keep_after_front = try self.addLocalForLayout(.u64);
+                    current = try self.assignBinaryLowLevel(front_dropped, .list_take_last, source, keep_after_front, current);
+                    current = try self.lenMinusConst(keep_after_front, len_local, @intCast(rest.index), current);
+                }
+            }
+        }
+
+        const rest_index: ?u32 = if (list.rest) |rest| rest.index else null;
+        var i = elems.len;
+        while (i > 0) {
+            i -= 1;
+            const elem_local = try self.addTemp(try self.lowerPatTy(elems[i]));
+            current = try self.lowerPatternThen(elems[i], elem_local, current, miss, continuation);
+            const index_local = try self.addLocalForLayout(.u64);
+            current = try self.assignBinaryLowLevel(elem_local, .list_get_unsafe, source, index_local, current);
+            const matches_from_back = if (rest_index) |ri| i >= ri else false;
+            if (matches_from_back) {
+                // Elements after the rest are indexed relative to the end:
+                // len - (fixed_count - i).
+                current = try self.lenMinusConst(index_local, len_local, fixed_count - @as(i64, @intCast(i)), current);
+            } else {
+                current = try self.assignU64Literal(index_local, @intCast(i), current);
+            }
+        }
+
+        // Length test at the head: an exact match needs `len == fixed_count`; a
+        // pattern with a rest needs `len >= fixed_count`.
+        const required = try self.addLocalForLayout(.u64);
+        const cond = try self.addLocalForLayout(.bool);
+        const cmp_op: LIR.LowLevel = if (list.rest == null) .num_is_eq else .num_is_gte;
+        const length_check = try self.boolSwitchNoContinuation(cond, current, try self.patternMissJump(miss));
+        var head = try self.assignBinaryLowLevel(cond, cmp_op, len_local, required, length_check);
+        head = try self.assignU64Literal(required, fixed_count, head);
+        head = try self.assignUnaryLowLevel(len_local, .list_len, source, head);
+        return head;
+    }
+
+    fn assignU64Literal(self: *Lowerer, target: LIR.LocalId, value: i64, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
+        return try self.result.store.addCFStmt(.{ .assign_literal = .{
+            .target = target,
+            .value = .{ .i64_literal = .{ .value = value, .layout_idx = .u64 } },
+            .next = next,
+        } });
+    }
+
+    fn assignBinaryLowLevel(
+        self: *Lowerer,
+        target: LIR.LocalId,
+        op: LIR.LowLevel,
+        lhs: LIR.LocalId,
+        rhs: LIR.LocalId,
+        next: LIR.CFStmtId,
+    ) Common.LowerError!LIR.CFStmtId {
+        const args = [_]LIR.LocalId{ lhs, rhs };
+        return try self.result.store.addCFStmt(.{ .assign_low_level = .{
+            .target = target,
+            .op = op,
+            .rc_effect = op.rcEffect(),
+            .args = try self.result.store.addLocalSpan(&args),
+            .next = next,
+        } });
+    }
+
+    /// Emit `target = len_local - value` using a fresh u64 literal operand.
+    fn lenMinusConst(self: *Lowerer, target: LIR.LocalId, len_local: LIR.LocalId, value: i64, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
+        const operand = try self.addLocalForLayout(.u64);
+        const subtract = try self.assignBinaryLowLevel(target, .num_minus, len_local, operand, next);
+        return try self.assignU64Literal(operand, value, subtract);
+    }
+
     fn bindPattern(self: *Lowerer, pat_id: Lifted.PatId, source: LIR.LocalId, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
         const pat_data = self.pat(pat_id);
         const pat_ty = try self.lowerPatTy(pat_id);
@@ -3030,6 +3158,12 @@ const Lowerer = struct {
             },
             .record => |fields| try self.bindRecordPattern(pat_ty, fields, source, next),
             .tuple => |items| try self.bindTuplePattern(items, source, next),
+            // Only an irrefutable list pattern reaches binding: `[.. as rest]`
+            // binds the whole list (aliasing the source); `[..]` binds nothing.
+            .list => |list| if (list.rest) |rest| (if (rest.pattern) |rest_pattern|
+                try self.bindPattern(rest_pattern, source, next)
+            else
+                next) else next,
             .tag => |tag| try self.bindTagPayloadPatterns(self.tagIndex(pat_ty, tag.name), tag.payloads, source, next),
             .nominal => |inner| try self.bindPattern(inner, source, next),
             .int_lit, .dec_lit, .frac_f32_lit, .frac_f64_lit, .str_lit, .str_pattern => next,

--- a/test/snapshots/generalize_annotated_value_unannotated_not_generalized.md
+++ b/test/snapshots/generalize_annotated_value_unannotated_not_generalized.md
@@ -32,7 +32,7 @@ It has the type:
 
     List(U64)
 
-But the annotation say it should be:
+But the annotation says it should be:
 
     List(Str)
 


### PR DESCRIPTION
Fixes #9700.

A `match` on a `List` was desugared into a tree of nested `if`/two-armed-`match` expressions whose miss arm pointed at the shared "rest of the match" expression. The Monotype IR kept that fallback shared by id, so it stayed linear, but LIR lowering re-lowers each referenced expression, so a `k`-element list pattern re-materialized the entire fallback `k+1` times (one per element test plus the length test). Composed across branches this produced roughly `(elements+1)^branches` LIR statements, which exhausted memory or hung the compiler — e.g. the codon example in the issue grew ~4x per added branch (1136 → 4272 → 16816 statements for 3 → 4 → 5 branches). String-literal branches were unaffected because they share a single `on_miss`, and tag/tuple/record patterns were unaffected because they already share each branch's miss through a join point.

List patterns are now first-class through the post-check pipeline (Monotype, Lifted, Lambda Solved, Lambda Mono) and are lowered by the same decision machinery as every other pattern: `lowerListPatternThen` emits a length test, per-element `list_get_unsafe` extraction, and the optional captured rest, all jumping to the one shared miss join that `lowerBranchChain` already creates per branch. The rest slice uses `list_take_first`/`list_take_last` with scalar counts rather than reconstructing a `{start, len}` record. This makes the generated LIR linear in the pattern size, so the issue's program now compiles in well under a second instead of running out of memory. The separate refutable let-binding path for list patterns is unchanged.