### PR TITLE
fix docs scrolling up while typing

### DIFF
--- a/src/docs/static/styles.css
+++ b/src/docs/static/styles.css
@@ -217,6 +217,13 @@ table tr td {
     margin-bottom: 24px;
 }
 
+/* Targets of anchor-link navigation (permalink clicks, # references). */
+.entry[id],
+.entry-group[id] {
+  /* Offset so the target lands below the sticky search bar. */
+  scroll-margin-top: var(--module-search-form-height);
+}
+
 .entry-children-container {
     margin-top: 16px;
     margin-left: var(--entry-anchor-offset);
@@ -320,7 +327,6 @@ main {
   grid-template-rows: auto 1fr auto;
   scrollbar-color: var(--violet) var(--body-bg-color);
   scrollbar-gutter: stable both-edges;
-  scroll-padding-top: var(--module-search-form-height);
 }
 
 main > * {
@@ -613,7 +619,7 @@ a.sidebar-module-link {
     font-size: 0.8rem;
     cursor: pointer;
     padding: 8px 16px;
-    
+
     &:hover {
         color: var(--violet);
     }


### PR DESCRIPTION
This fixes #9602 

The issue was the `scroll-padding-top` on the scroll container made the browser think the sticky search bar was "hidden", triggering a scroll on every keystroke.

This PR moves the offset from the scroll container (`scroll-padding`) to the anchor targets (`scroll-margin`) which fixes the focus-scroll loop.