### PR TITLE
Fix LLVM codegen of captured tail-recursive closures (#9690)

### DIFF
--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -1710,10 +1710,15 @@ pub const MonoLlvmCodeGen = struct {
         }
     }
 
-    /// Plain TCE installs the proc body as `join J { remainder: jump J, body: old_body }`.
-    /// That shape does not need the generic join continuation block: proc entry
-    /// branches directly to the loop body, and recursive sites jump back there
-    /// after their explicit `initialize_join_param` writes.
+    /// TCE installs the proc body as `join J { remainder: <entry>, body: old_body }`.
+    /// That shape does not need the generic join continuation block: the
+    /// remainder is the run-once entry path that branches into the loop body,
+    /// and recursive sites jump back there after their explicit
+    /// `initialize_join_param` writes. The entry path is a bare `jump J` for a
+    /// plain TCE loop; when `scalarize_joins` splits a struct-typed join
+    /// parameter (such as a closure's capture record) it seeds the per-field
+    /// parameters on the remainder before that jump, so the entry path is a
+    /// statement chain ending in `jump J` rather than a single jump.
     fn compileDirectEntryTceLoop(self: *MonoLlvmCodeGen, proc: LirProcSpec, stmt_id: CFStmtId) Error!bool {
         if (proc.tail_transform != .tce) return false;
 
@@ -1721,17 +1726,16 @@ pub const MonoLlvmCodeGen = struct {
             .join => |j| j,
             else => return error.CompilationFailed,
         };
-        switch (self.store.getCFStmt(join_stmt.remainder)) {
-            .jump => |j| if (j.target != join_stmt.id) return error.CompilationFailed,
-            else => return error.CompilationFailed,
-        }
 
         const wip = self.wip orelse return error.CompilationFailed;
         const key = @intFromEnum(join_stmt.id);
         const loop_block = wip.block(0, "tce_loop") catch return error.OutOfMemory;
         try self.join_points.put(key, .{ .block = loop_block, .params = join_stmt.params, .body = join_stmt.body });
 
-        _ = wip.br(loop_block) catch return error.OutOfMemory;
+        // Emit the run-once entry path, then the loop body. The remainder's
+        // terminal `jump J` branches into `loop_block` through `emitJump`, after
+        // any seeded join parameters have been initialized in the entry block.
+        try self.compileStmt(join_stmt.remainder);
         wip.cursor = .{ .block = loop_block };
         try self.compileStmt(join_stmt.body);
         return true;

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -538,6 +538,11 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "roc check succeeds on valid file", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/simple_success.roc", .not_contains = &.{ .{ .stream = .stderr, .text = "Failed to check" }, .{ .stream = .stderr, .text = "error" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build --opt=speed emits no invalid LLVM debug info", .backend = .speed, .body = .{ .command = .{ .args = &.{ "build", "--opt=speed", "--no-cache" }, .roc_file = "test/cli/simple_success.roc", .contains = &.{.{ .stream = .stdout, .text = "Built " }}, .not_contains = &invalid_llvm_debug_info_needles } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build --opt=speed --debug emits valid LLVM debug info", .backend = .speed, .body = .{ .command = .{ .args = &.{ "build", "--opt=speed", "--debug", "--no-cache" }, .roc_file = "test/cli/simple_success.roc", .contains = &.{.{ .stream = .stdout, .text = "Built " }}, .not_contains = &invalid_llvm_debug_info_needles } } },
+    // repro for https://github.com/roc-lang/roc/issues/9690: a self-recursive
+    // closure that captures an enclosing value must compile through the LLVM
+    // size/speed backend. The crash guard inside the program makes a wrong
+    // result fail too, so a clean exit means it both built and computed 25.
+    .{ .id = 0, .suite = .subcommands, .name = "issue 9690: recursive capturing closure builds and runs on LLVM size backend", .backend = .size, .body = .{ .command = .{ .args = &.{ "--opt=size", "--no-cache" }, .roc_file = "test/cli/Issue9690RecursiveCaptureClosure.roc", .exit = .success } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc check generated module graph succeeds with 1 file and 1 symbol", .body = .{ .custom = .generated_graph_1_1 } },
     .{ .id = 0, .suite = .subcommands, .name = "roc check generated module graph succeeds with 5 files and 5 symbols", .body = .{ .custom = .generated_graph_5_5 } },
     .{ .id = 0, .suite = .subcommands, .name = "roc check generated module graph handles many symbols per file", .body = .{ .custom = .generated_graph_2_100 } },

--- a/test/cli/Issue9690RecursiveCaptureClosure.roc
+++ b/test/cli/Issue9690RecursiveCaptureClosure.roc
@@ -1,0 +1,28 @@
+# repro for https://github.com/roc-lang/roc/issues/9690
+# A nested, self-recursive closure that captures a value ("radicand") from its
+# enclosing function must compile and run through the LLVM (size/speed) backend.
+# sqrt(625) == 25; the crash guard makes a wrong result observable even though
+# `dbg` output is elided in optimized builds.
+square_root : U64 -> U64
+square_root = |radicand| {
+	binary_search = |min, max| {
+		val = (min + max) // 2
+		square = val * val
+		if square == radicand or min >= max {
+			val
+		} else if square > radicand {
+			binary_search(min, (val - 1))
+		} else {
+			binary_search((val + 1), max)
+		}
+	}
+	binary_search(0, radicand)
+}
+
+main! = |_args| {
+	result = square_root(25 * 25)
+	if result != 25 {
+		crash "square_root(625) should be 25"
+	}
+	Ok({})
+}


### PR DESCRIPTION
A self-recursive nested closure that captures a value from its enclosing function (the issue's `binary_search` capturing `radicand`) failed to compile through the LLVM backend, so `roc build --opt=size` and `--opt=speed` aborted with a silent exit 1 while the interpreter and dev backends ran it fine. The failure was `error.CompilationFailed` raised inside `compileDirectEntryTceLoop`.

That function compiles a tail-call-elimination loop and assumed the loop join's remainder (its run-once entry path) was always a bare `jump J`, ignoring it and emitting only a branch into the loop body. The `scalarize_joins` pass, however, splits struct-typed join parameters into one parameter per field, and a closure's captured-value record is exactly such a struct parameter. For a TCE loop it seeds the resulting per-field parameters on the remainder, before the jump, so the remainder becomes a statement chain ending in `jump J` rather than a single jump. The backend rejected that shape; the interpreter and dev backend, which compile the remainder normally, did not. The non-capturing case kept working because it has no struct join parameter to scalarize.

The fix compiles the remainder as the loop's run-once preheader: its seed statements emit in the entry block and its terminal jump branches into the loop through the same `emitJump` path the general join lowering already uses. This handles the scalarized shape while preserving the direct-entry loop optimization (no dead generic join-continuation block), so it is strictly more correct at equal cost.

Regression coverage: `test/cli/Issue9690RecursiveCaptureClosure.roc` plus a subcommands case in `parallel_cli_runner.zig` build and run the issue program through the LLVM size backend; the program crash-guards on a wrong result, so the test stays red on both a build failure and a miscompile.


Fixes #9690
