### PR TITLE
Share field-ordering between layout and glue; fix glue nominal records

### DIFF
--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -2668,10 +2668,18 @@ fn customGlueZigCompiles(io: std.Io, allocator: Allocator, env: *const CaseEnv, 
         \\    var str: abi.RocStr = undefined;
         \\    var builder_args: abi.BuilderPrint_valueArgs = undefined;
         \\    const tree: abi.HostTree = undefined;
+        \\    // Reference the nominal record `Padded` and its args struct so their
+        \\    // comptime size/alignment assertions run. `Padded := {{ z, _, a }}` must
+        \\    // lay out in declared order with the unnamed field reserved as padding
+        \\    // (z@0, _pad0@4, a@8, size 12) for these to hold.
+        \\    var padded: abi.Padded = undefined;
+        \\    var padded_args: abi.PaddedCheckArgs = undefined;
         \\    _ = &host;
         \\    _ = &box;
         \\    _ = &str;
         \\    _ = &builder_args;
+        \\    _ = &padded;
+        \\    _ = &padded_args;
         \\    abi.increfHostTree(tree, 1);
         \\    abi.decrefHostTree(tree, &host);
         \\}}

--- a/src/glue/glue.zig
+++ b/src/glue/glue.zig
@@ -209,7 +209,21 @@ fn rocGlueInner(gpa: Allocator, stderr: *std.Io.Writer, stdout: *std.Io.Writer, 
 
     const target_usize = base.target.TargetUsize.native;
 
-    var type_table = TypeTable.init(gpa, target_usize);
+    // Index every platform artifact by its own module name so a nominal type
+    // declared in one platform module can have its declared field order read
+    // from that module's CIR, even when referenced from another module.
+    var module_artifacts = ModuleArtifactMap.init(gpa);
+    defer module_artifacts.deinit();
+    for (modules) |mod| {
+        if (!(mod.is_platform_sibling or mod.is_platform_main)) continue;
+        const artifact = mod.semantic.checked_artifact orelse continue;
+        // Key on the qualified module name: a nominal's `origin_module` text
+        // resolves to that qualified form, not the short module name.
+        const module_name = artifact.canonical_names.moduleNameText(artifact.module_identity.qualified_module_name);
+        try module_artifacts.put(module_name, artifact);
+    }
+
+    var type_table = TypeTable.init(gpa, target_usize, &module_artifacts);
     defer type_table.deinit();
 
     for (modules) |mod| {
@@ -897,6 +911,11 @@ const CollectedRecordField = struct {
     type_id: u64,
     size: u64,
     alignment: u64,
+    /// True for an unnamed nominal-record padding field (`_` / `_name`). The
+    /// emitters render it as a fixed-size `size`-byte array (`[size]u8` in Zig,
+    /// `uint8_t name[size]` in C) and skip it for refcount helpers. `type_id` is
+    /// unused for padding fields.
+    is_padding: bool = false,
 };
 
 const CollectedTagInfo = struct {
@@ -906,19 +925,33 @@ const CollectedTagInfo = struct {
     payload_alignment: u64,
 };
 
+/// Maps a platform module's name text to its checked artifact, so a nominal
+/// declared in one module can have its declared field order read from the CIR
+/// of the module that declares it (its `source_decl` indexes that module's
+/// statements). Populated once from the compiled module list before collection.
+const ModuleArtifactMap = std.StringHashMap(*const CheckedArtifact.CheckedModuleArtifact);
+
 /// Builds a type table from artifact-owned checked type payloads.
 const TypeTable = struct {
     entries: std.ArrayList(CollectedTypeRepr),
     var_map: std.AutoHashMap(CheckedArtifact.CheckedTypeId, u64),
     target_usize: base.target.TargetUsize,
     gpa: std.mem.Allocator,
+    /// Lookup from module name text to declaring artifact, for cross-module
+    /// declared-field-order reads. Borrowed; not owned by the type table.
+    module_artifacts: *const ModuleArtifactMap,
 
-    fn init(gpa: std.mem.Allocator, target_usize: base.target.TargetUsize) TypeTable {
+    fn init(
+        gpa: std.mem.Allocator,
+        target_usize: base.target.TargetUsize,
+        module_artifacts: *const ModuleArtifactMap,
+    ) TypeTable {
         return .{
             .entries = std.ArrayList(CollectedTypeRepr).empty,
             .var_map = std.AutoHashMap(CheckedArtifact.CheckedTypeId, u64).init(gpa),
             .target_usize = target_usize,
             .gpa = gpa,
+            .module_artifacts = module_artifacts,
         };
     }
 
@@ -980,6 +1013,14 @@ const TypeTable = struct {
     fn freeDuped(self: *TypeTable, slice: []const u8) void {
         if (slice.len == 0) return;
         self.gpa.free(slice);
+    }
+
+    /// Free the first `populated` field names in `fields` (each duped) and the
+    /// `fields` array itself. Used to unwind a partially-built declared-order
+    /// nominal record on an error or `null` fallback.
+    fn freeCollectedRecordFields(self: *TypeTable, fields: []const CollectedRecordField, populated: usize) void {
+        for (fields[0..populated]) |field| self.freeDuped(field.name);
+        self.gpa.free(fields);
     }
 
     /// Clear the checked-type map when switching modules (checked ids are artifact-local).
@@ -1128,13 +1169,29 @@ const TypeTable = struct {
 
         const backing_repr = try self.convertCheckedType(artifact, nominal.backing);
         return switch (backing_repr) {
-            .record => |rec| .{ .record = .{
-                .name = try self.gpa.dupe(u8, display_name),
-                .anonymous = false,
-                .fields = rec.fields,
-                .size = rec.size,
-                .alignment = rec.alignment,
-            } },
+            .record => |rec| blk: {
+                // The backing record `rec.fields` is in the structural (sorted)
+                // order. A nominal record must instead lay out in DECLARED source
+                // order, with unnamed `_` fields reinstated as padding spacers.
+                const declared = try self.nominalRecordInDeclaredOrder(artifact, nominal, rec) orelse
+                    break :blk .{ .record = .{
+                        .name = try self.gpa.dupe(u8, display_name),
+                        .anonymous = false,
+                        .fields = rec.fields,
+                        .size = rec.size,
+                        .alignment = rec.alignment,
+                    } };
+                // `declared.fields` replaces `rec.fields`, which we now own and free.
+                for (rec.fields) |field| self.freeDuped(field.name);
+                self.gpa.free(rec.fields);
+                break :blk .{ .record = .{
+                    .name = try self.gpa.dupe(u8, display_name),
+                    .anonymous = false,
+                    .fields = declared.fields,
+                    .size = declared.size,
+                    .alignment = declared.alignment,
+                } };
+            },
             .tag_union => |tu| blk: {
                 self.freeDuped(tu.name);
                 break :blk .{ .tag_union = .{
@@ -1146,6 +1203,167 @@ const TypeTable = struct {
             },
             else => backing_repr,
         };
+    }
+
+    const NominalRecordLayout = struct {
+        fields: []const CollectedRecordField,
+        size: u64,
+        alignment: u64,
+    };
+
+    /// Reconstructs a nominal record in DECLARED source order, with unnamed `_` /
+    /// `_name` fields reinstated as padding spacers, then reordered into the
+    /// runtime field order by the shared `field_order.computeNominalFieldOrder`
+    /// (the exact function the layout store uses). Returns `null` when the
+    /// declaration is unavailable (no `source_decl`, declaring module not found,
+    /// or the annotation is not a record), so the caller falls back to the
+    /// structural backing order. `backing` provides each named field's already
+    /// converted `type_id`/size/alignment, matched by field-name text.
+    fn nominalRecordInDeclaredOrder(
+        self: *TypeTable,
+        artifact: *const CheckedArtifact.CheckedModuleArtifact,
+        nominal: CheckedArtifact.CheckedNominalType,
+        backing: anytype,
+    ) Allocator.Error!?NominalRecordLayout {
+        const source_decl = nominal.source_decl orelse return null;
+
+        // The nominal's declared field order lives in the CIR of the module that
+        // declares it. `source_decl` indexes that module's statements.
+        const origin_text = artifact.canonical_names.moduleNameText(nominal.origin_module);
+        const decl_artifact = self.module_artifacts.get(origin_text) orelse artifact;
+        const module_env = decl_artifact.moduleEnvConst();
+
+        const anno_idx = switch (module_env.store.getStatement(@enumFromInt(source_decl))) {
+            .s_nominal_decl => |decl| decl.anno,
+            else => return null,
+        };
+        // The backing record annotation may be wrapped in parentheses.
+        var record_anno = anno_idx;
+        const record = while (true) {
+            switch (module_env.store.getTypeAnno(record_anno)) {
+                .parens => |parens| record_anno = parens.anno,
+                .record => |record| break record,
+                else => return null,
+            }
+        };
+        const anno_fields = module_env.store.sliceAnnoRecordFields(record.fields);
+        if (anno_fields.len == 0) return null;
+
+        // The unnamed fields' resolved types live on the nominal declaration in
+        // the declaring artifact (the nominal *reference* in a signature carries
+        // an empty padding list), indexing that artifact's checked type store.
+        const padding_types = nominalDeclarationPaddingTypes(decl_artifact, source_decl) orelse return null;
+
+        // Each named declared field recovers its converted shape from the backing
+        // record (matched by name); each unnamed field becomes a padding spacer
+        // whose size is its declared type's size and whose alignment is 1.
+        const collected = try self.gpa.alloc(CollectedRecordField, anno_fields.len);
+        const shapes = try self.gpa.alloc(layout.field_order.FieldShape, anno_fields.len);
+        defer self.gpa.free(shapes);
+
+        var padding_cursor: usize = 0;
+        var pad_index: usize = 0;
+        var populated: usize = 0;
+        // Free the field names duped into `collected` so far plus the array on any
+        // failure or `null` fallback path. `populated` is read at unwind time.
+        errdefer self.freeCollectedRecordFields(collected, populated);
+        for (anno_fields, 0..) |field_idx, i| {
+            const field = module_env.store.getAnnoRecordField(field_idx);
+            if (field.is_unnamed) {
+                if (padding_cursor >= padding_types.len) {
+                    self.freeCollectedRecordFields(collected, populated);
+                    return null;
+                }
+                // Padding field types index the declaring artifact's type store.
+                const padding_ty = padding_types[padding_cursor];
+                padding_cursor += 1;
+                const padding_type_id = try self.getOrInsert(decl_artifact, padding_ty);
+                const sa = self.getSizeAlign(padding_type_id);
+                const name = try std.fmt.allocPrint(self.gpa, "_pad{d}", .{pad_index});
+                pad_index += 1;
+                collected[i] = .{
+                    .name = name,
+                    .type_id = 0,
+                    .size = sa.size,
+                    .alignment = 1,
+                    .is_padding = true,
+                };
+                shapes[i] = .{ .size = @intCast(sa.size), .alignment = 1 };
+            } else {
+                const field_name = module_env.getIdentText(field.name);
+                const match = backingFieldByName(backing, field_name) orelse {
+                    self.freeCollectedRecordFields(collected, populated);
+                    return null;
+                };
+                collected[i] = .{
+                    .name = try self.gpa.dupe(u8, field_name),
+                    .type_id = match.type_id,
+                    .size = match.size,
+                    .alignment = match.alignment,
+                    .is_padding = false,
+                };
+                shapes[i] = .{ .size = @intCast(match.size), .alignment = @intCast(match.alignment) };
+            }
+            populated = i + 1;
+        }
+
+        // Runtime order: the shared nominal field-order permutation. This keeps
+        // declared order when it is already padding-free (the common case).
+        const order = try self.gpa.alloc(u16, anno_fields.len);
+        defer self.gpa.free(order);
+        try layout.field_order.computeNominalFieldOrder(self.gpa, shapes, order);
+
+        const ordered = try self.gpa.alloc(CollectedRecordField, anno_fields.len);
+        for (order, 0..) |src, dst| ordered[dst] = collected[src];
+        self.gpa.free(collected);
+
+        // Size/alignment from laying the ordered fields out with no padding.
+        var max_alignment: u64 = 1;
+        var offset: u64 = 0;
+        for (ordered) |field| {
+            if (field.alignment > max_alignment) max_alignment = field.alignment;
+            if (field.alignment > 0) {
+                const rem = offset % field.alignment;
+                if (rem != 0) offset += field.alignment - rem;
+            }
+            offset += field.size;
+        }
+        var record_size = offset;
+        if (max_alignment > 0) {
+            const rem = record_size % max_alignment;
+            if (rem != 0) record_size += max_alignment - rem;
+        }
+
+        return .{ .fields = ordered, .size = record_size, .alignment = max_alignment };
+    }
+
+    /// Finds a backing record field by its name text, returning its converted
+    /// shape (`type_id`, size, alignment). The backing is a structurally-ordered
+    /// `CollectedTypeRepr.record` payload.
+    fn backingFieldByName(backing: anytype, name: []const u8) ?struct { type_id: u64, size: u64, alignment: u64 } {
+        for (backing.fields) |field| {
+            if (std.mem.eql(u8, field.name, name)) {
+                return .{ .type_id = field.type_id, .size = field.size, .alignment = field.alignment };
+            }
+        }
+        return null;
+    }
+
+    /// Resolved types of a nominal's unnamed (`_`) padding fields, in declared
+    /// order, read from the declaration in `decl_artifact` identified by its
+    /// `source_decl` statement index. The returned ids index `decl_artifact`'s
+    /// checked type store. `null` when no matching declaration is found.
+    fn nominalDeclarationPaddingTypes(
+        decl_artifact: *const CheckedArtifact.CheckedModuleArtifact,
+        source_decl: u32,
+    ) ?[]const CheckedArtifact.CheckedTypeId {
+        for (decl_artifact.checked_types.nominal_declarations.items) |declaration| {
+            const decl_source = declaration.nominal.source_decl orelse continue;
+            if (decl_source == source_decl) {
+                return declaration.paddingFieldTypes(&decl_artifact.checked_types);
+            }
+        }
+        return null;
     }
 
     fn convertRecord(
@@ -1179,30 +1397,24 @@ const TypeTable = struct {
             field_sizes[i] = self.getSizeAlign(field_type_ids[i]);
         }
 
-        var field_indices = try self.gpa.alloc(usize, fields.len);
-        defer self.gpa.free(field_indices);
-        for (0..fields.len) |i| field_indices[i] = i;
-
-        const SortCtx = struct {
-            fields: []const CheckedArtifact.CheckedRecordField,
-            names: *const CanonicalNameStore,
-            sizes: []const SizeAlign,
-
-            pub fn lessThan(ctx: @This(), a: usize, b: usize) bool {
-                const a_align = ctx.sizes[a].alignment;
-                const b_align = ctx.sizes[b].alignment;
-                if (a_align != b_align) return a_align > b_align;
-                const a_text = ctx.names.recordFieldLabelText(ctx.fields[a].name);
-                const b_text = ctx.names.recordFieldLabelText(ctx.fields[b].name);
-                return std.mem.order(u8, a_text, b_text) == .lt;
-            }
-        };
-        std.mem.sort(usize, field_indices, SortCtx{ .fields = fields, .names = &artifact.canonical_names, .sizes = field_sizes }, SortCtx.lessThan);
+        // Structural records order by descending alignment then ascending field
+        // name, computed by the shared field-order module the layout store uses.
+        const structural = try self.gpa.alloc(layout.field_order.StructuralField, fields.len);
+        defer self.gpa.free(structural);
+        for (fields, 0..) |field, i| {
+            structural[i] = .{
+                .alignment = @intCast(field_sizes[i].alignment),
+                .name = artifact.canonical_names.recordFieldLabelText(field.name),
+            };
+        }
+        const order = try self.gpa.alloc(u16, fields.len);
+        defer self.gpa.free(order);
+        layout.field_order.computeStructuralFieldOrder(structural, order);
 
         const collected_fields = try self.gpa.alloc(CollectedRecordField, fields.len);
         var max_alignment: u64 = 0;
         var current_offset: u64 = 0;
-        for (field_indices, 0..) |src_idx, dst_idx| {
+        for (order, 0..) |src_idx, dst_idx| {
             const f_size = field_sizes[src_idx].size;
             const f_align = field_sizes[src_idx].alignment;
             if (f_align > max_alignment) max_alignment = f_align;
@@ -1724,6 +1936,7 @@ fn writeRecordFieldTypeRepr(
 ) void {
     writer.zeroValue(value_base, record_field_layout);
     writer.writeField(value_base, record_field_layout, "RecordField", "alignment", u64, field.alignment);
+    writer.writeField(value_base, record_field_layout, "RecordField", "is_padding", bool, field.is_padding);
     writer.writeField(value_base, record_field_layout, "RecordField", "name", RocStr, createBigRocStr(field.name, writer.roc_ops));
     writer.writeField(value_base, record_field_layout, "RecordField", "size", u64, field.size);
     writer.writeField(value_base, record_field_layout, "RecordField", "type_id", u64, field.type_id);

--- a/src/glue/platform/RecordField.roc
+++ b/src/glue/platform/RecordField.roc
@@ -1,1 +1,1 @@
-RecordField := { alignment : U64, name : Str, size : U64, type_id : U64 }
+RecordField := { alignment : U64, is_padding : Bool, name : Str, size : U64, type_id : U64 }

--- a/src/glue/src/RustGlue.roc
+++ b/src/glue/src/RustGlue.roc
@@ -202,6 +202,19 @@ type_id_to_rust = |type_table, type_id| {
 	}
 }
 
+## Render one struct field declaration for a record field. Unnamed
+## nominal-record padding fields become fixed-size byte arrays (`[u8; size]`);
+## named fields use their resolved Rust type.
+rust_record_field_decl : List(TypeRepr), RecordField -> Str
+rust_record_field_decl = |type_table, field| {
+	rust_type = if field.is_padding {
+		"[u8; ${U64.to_str(field.size)}]"
+	} else {
+		type_id_to_rust(type_table, field.type_id)
+	}
+	"    pub ${field.name}: ${rust_type},\n"
+}
+
 ## Convert a TypeRepr to its Rust type string
 type_repr_to_rust : List(TypeRepr), TypeRepr -> Str
 type_repr_to_rust = |type_table, type_repr| {
@@ -281,7 +294,7 @@ is_repr_refcounted = |type_table, type_repr| {
 		RocBox(_) => Bool.True
 		RocList(_) => Bool.True
 		RocFunction(_) => Bool.True
-		RocRecord(rec) => List.any(rec.fields, |field| is_type_refcounted(type_table, field.type_id))
+		RocRecord(rec) => List.any(rec.fields, |field| !field.is_padding and is_type_refcounted(type_table, field.type_id))
 		RocTagUnion(tu) => List.any(tu.tags, |tag| List.any(tag.payload, |pid| is_type_refcounted(type_table, pid)))
 		_ => Bool.False
 	}
@@ -1053,11 +1066,7 @@ generate_element_type_structs_rust = |type_table| {
 					struct_name = name_to_struct_name(rec.name)
 					var $field_strs = ""
 					for field in rec.fields {
-						rust_type = type_id_to_rust(type_table, field.type_id)
-						$field_strs = Str.concat(
-							$field_strs,
-							"    pub ${field.name}: ${rust_type},\n",
-						)
+						$field_strs = Str.concat($field_strs, rust_record_field_decl(type_table, field))
 					}
 
 					# Size/alignment assertions (guarded by pointer width)
@@ -1185,11 +1194,7 @@ generate_all_record_structs_rust = |hosted_functions, type_table| {
 
 			var $fields = ""
 			for field in type_table_result.fields {
-				rust_type = type_id_to_rust(type_table, field.type_id)
-				$fields = Str.concat(
-					$fields,
-					"    pub ${field.name}: ${rust_type},\n",
-				)
+				$fields = Str.concat($fields, rust_record_field_decl(type_table, field))
 			}
 
 			assertions = if type_table_result.size > 0 {
@@ -1240,11 +1245,7 @@ generate_args_struct_rust = |func, type_table| {
 	if type_table_result.found {
 		var $fields = ""
 		for field in type_table_result.fields {
-			rust_type = type_id_to_rust(type_table, field.type_id)
-			$fields = Str.concat(
-				$fields,
-				"    pub ${field.name}: ${rust_type},\n",
-			)
+			$fields = Str.concat($fields, rust_record_field_decl(type_table, field))
 		}
 
 		assertions = if type_table_result.size > 0 {

--- a/src/glue/src/ZigGlue.roc
+++ b/src/glue/src/ZigGlue.roc
@@ -74,6 +74,20 @@ type_id_to_zig = |type_table, type_id| {
 	}
 }
 
+## Render one `extern struct` field declaration for a record field. Unnamed
+## nominal-record padding fields become fixed-size byte arrays (`[size]u8`);
+## named fields use their resolved Zig type.
+zig_record_field_decl : List(TypeRepr), RecordField -> Str
+zig_record_field_decl = |type_table, field| {
+	field_name = name_to_zig_quoted_ident(field.name)
+	zig_type = if field.is_padding {
+		"[${U64.to_str(field.size)}]u8"
+	} else {
+		type_id_to_zig(type_table, field.type_id)
+	}
+	"    ${field_name}: ${zig_type},\n"
+}
+
 ## Convert a TypeRepr to its Zig type string
 type_repr_to_zig : List(TypeRepr), TypeRepr -> Str
 type_repr_to_zig = |type_table, type_repr| {
@@ -142,7 +156,7 @@ is_repr_refcounted = |type_table, type_repr| {
 		RocBox(_) => Bool.True
 		RocList(_) => Bool.True
 		RocFunction(_) => Bool.True
-		RocRecord(rec) => List.any(rec.fields, |field| is_type_refcounted(type_table, field.type_id))
+		RocRecord(rec) => List.any(rec.fields, |field| !field.is_padding and is_type_refcounted(type_table, field.type_id))
 		RocTagUnion(tu) => List.any(tu.tags, |tag| List.any(tag.payload, |pid| is_type_refcounted(type_table, pid)))
 		RocBool => Bool.False
 		RocDec => Bool.False
@@ -434,12 +448,7 @@ generate_element_type_structs = |type_table| {
 					struct_name = name_to_struct_name(rec.name)
 					var $field_strs = ""
 					for field in rec.fields {
-						zig_type = type_id_to_zig(type_table, field.type_id)
-						field_name = name_to_zig_quoted_ident(field.name)
-						$field_strs = Str.concat(
-							$field_strs,
-							"    ${field_name}: ${zig_type},\n",
-						)
+						$field_strs = Str.concat($field_strs, zig_record_field_decl(type_table, field))
 					}
 
 					# Comptime size/alignment assertions (guarded by pointer width)
@@ -783,9 +792,13 @@ generate_record_refcount_helpers = |type_table, rec| {
 	var $incref_body = ""
 
 	for field in rec.fields {
-		field_expr = "value.${name_to_zig_quoted_ident(field.name)}"
-		$decref_body = Str.concat($decref_body, decref_stmt_for_type_id(type_table, field.type_id, field_expr))
-		$incref_body = Str.concat($incref_body, incref_stmt_for_type_id(type_table, field.type_id, field_expr))
+		# Padding fields are raw bytes with no Roc type, so they are never
+		# refcounted and contribute no incref/decref statements.
+		if !field.is_padding {
+			field_expr = "value.${name_to_zig_quoted_ident(field.name)}"
+			$decref_body = Str.concat($decref_body, decref_stmt_for_type_id(type_table, field.type_id, field_expr))
+			$incref_body = Str.concat($incref_body, incref_stmt_for_type_id(type_table, field.type_id, field_expr))
+		}
 	}
 
 	if $decref_body == "" {
@@ -1537,12 +1550,7 @@ generate_all_record_structs = |hosted_functions, type_table| {
 
 			var $fields = ""
 			for field in type_table_result.fields {
-				zig_type = type_id_to_zig(type_table, field.type_id)
-				field_name = name_to_zig_quoted_ident(field.name)
-				$fields = Str.concat(
-					$fields,
-					"    ${field_name}: ${zig_type},\n",
-				)
+				$fields = Str.concat($fields, zig_record_field_decl(type_table, field))
 			}
 
 			assertions = if type_table_result.size > 0 {
@@ -1593,12 +1601,7 @@ generate_args_struct = |func, type_table| {
 	if type_table_result.found {
 		var $fields = ""
 		for field in type_table_result.fields {
-			zig_type = type_id_to_zig(type_table, field.type_id)
-			field_name = name_to_zig_quoted_ident(field.name)
-			$fields = Str.concat(
-				$fields,
-				"    ${field_name}: ${zig_type},\n",
-			)
+			$fields = Str.concat($fields, zig_record_field_decl(type_table, field))
 		}
 
 		assertions = if type_table_result.size > 0 {

--- a/src/layout/field_order.zig
+++ b/src/layout/field_order.zig
@@ -1,16 +1,24 @@
-//! Nominal record field ordering.
+//! Record field ordering, shared by the layout store and the `roc glue`
+//! generator so the two can never disagree on how a record lays out in memory.
 //!
-//! Structural records lay their fields out by descending alignment, so source
-//! order never reaches memory. Nominal records instead keep declared order so a
-//! Roc type can mirror a chosen C struct exactly. The one invariant both share
-//! is that a committed struct has no internal alignment padding between fields.
+//! Two ordering disciplines live here:
 //!
-//! This module turns a nominal record's declared field order into a no-padding
-//! order that stays as close to declared order as that invariant allows. When
-//! the declared order is already padding-free it is kept verbatim; otherwise it
-//! is repaired into the no-padding order that is lexicographically closest to
-//! declared order. A repaired order always exists because descending alignment
-//! witnesses one from offset zero, so this is total and never an error.
+//! - Structural (anonymous) records lay their fields out by descending
+//!   alignment, then ascending field name, so source order never reaches memory.
+//!   `computeStructuralFieldOrder` produces that permutation.
+//! - Nominal records (`:=` / `::`) instead keep declared source order so a Roc
+//!   type can mirror a chosen C struct exactly, including unnamed `_` padding
+//!   fields. `computeNominalFieldOrder` produces that permutation.
+//!
+//! The one invariant both disciplines share is that a committed struct has no
+//! internal alignment padding between fields.
+//!
+//! For nominal records this module turns the declared field order into a
+//! no-padding order that stays as close to declared order as that invariant
+//! allows. When the declared order is already padding-free it is kept verbatim;
+//! otherwise it is repaired into the no-padding order that is lexicographically
+//! closest to declared order. A repaired order always exists because descending
+//! alignment witnesses one from offset zero, so this is total and never an error.
 //!
 //! See design.md "Nominal Record Field Order".
 
@@ -25,6 +33,47 @@ pub const FieldShape = struct {
     /// their bytes are uninitialized and impose no alignment requirement.
     alignment: u32,
 };
+
+/// The alignment and name of one structural-record field.
+pub const StructuralField = struct {
+    /// Alignment in bytes; a power of two. Padding fields pass 1.
+    alignment: u32,
+    /// Field name, used only as the tie-break among equal-alignment fields.
+    /// Pass `""` to fall back to a pure stable alignment sort (the layout
+    /// store's pair-struct path, whose callers presort by name elsewhere).
+    name: []const u8,
+};
+
+/// Stable sort of structural-record fields: alignment descending, then field
+/// name ascending. Empty names degrade to a pure stable alignment sort,
+/// preserving input order for equal alignment (matching the layout store's
+/// existing pair-struct behavior).
+///
+/// `out_order` is filled with a permutation of `0..fields.len`: `out_order[k]`
+/// is the index into `fields` of the field that occupies memory slot `k`. No
+/// allocation is required (the block sort works in place).
+pub fn computeStructuralFieldOrder(
+    fields: []const StructuralField,
+    out_order: []u16,
+) void {
+    std.debug.assert(out_order.len == fields.len);
+
+    for (out_order, 0..) |*slot, i| slot.* = @intCast(i);
+
+    const Ctx = struct {
+        fields: []const StructuralField,
+
+        pub fn lessThan(ctx: @This(), a: u16, b: u16) bool {
+            const fa = ctx.fields[a];
+            const fb = ctx.fields[b];
+            if (fa.alignment != fb.alignment) return fa.alignment > fb.alignment;
+            return std.mem.order(u8, fa.name, fb.name) == .lt;
+        }
+    };
+
+    // `std.sort.block` is a stable sort, so equal-key fields keep input order.
+    std.sort.block(u16, out_order, Ctx{ .fields = fields }, Ctx.lessThan);
+}
 
 /// Computes the in-memory field order for a nominal record.
 ///
@@ -302,4 +351,59 @@ test "repair result is always padding-free for a larger shuffled record" {
         try testing.expect(!seen[i]);
         seen[i] = true;
     }
+}
+
+fn expectStructuralOrder(fields: []const StructuralField, expected: []const u16) anyerror!void {
+    var order: [64]u16 = undefined;
+    computeStructuralFieldOrder(fields, order[0..fields.len]);
+    try testing.expectEqualSlices(u16, expected, order[0..fields.len]);
+}
+
+test "structural order sorts by descending alignment" {
+    // Declared [u8, u64, u16] sorts to [u64, u16, u8] by descending alignment.
+    const fields = [_]StructuralField{
+        .{ .alignment = 1, .name = "a" },
+        .{ .alignment = 8, .name = "b" },
+        .{ .alignment = 2, .name = "c" },
+    };
+    try expectStructuralOrder(&fields, &.{ 1, 2, 0 });
+}
+
+test "structural order tie-breaks by ascending field name" {
+    // All same alignment, so the order is purely by ascending name: c, m, z.
+    const fields = [_]StructuralField{
+        .{ .alignment = 4, .name = "z" },
+        .{ .alignment = 4, .name = "m" },
+        .{ .alignment = 4, .name = "c" },
+    };
+    try expectStructuralOrder(&fields, &.{ 2, 1, 0 });
+}
+
+test "structural order tie-breaks by name within each alignment band" {
+    // align-8 band {y, a} sorts to a, y; align-4 band {x, b} sorts to b, x;
+    // the align-8 band precedes the align-4 band.
+    const fields = [_]StructuralField{
+        .{ .alignment = 8, .name = "y" },
+        .{ .alignment = 4, .name = "x" },
+        .{ .alignment = 8, .name = "a" },
+        .{ .alignment = 4, .name = "b" },
+    };
+    try expectStructuralOrder(&fields, &.{ 2, 0, 3, 1 });
+}
+
+test "structural order with empty names is a stable alignment sort" {
+    // Empty names degrade to a pure stable alignment sort: equal-alignment
+    // fields keep their input order (matching the layout store's pair structs).
+    const fields = [_]StructuralField{
+        .{ .alignment = 4, .name = "" },
+        .{ .alignment = 8, .name = "" },
+        .{ .alignment = 4, .name = "" },
+        .{ .alignment = 8, .name = "" },
+    };
+    try expectStructuralOrder(&fields, &.{ 1, 3, 0, 2 });
+}
+
+test "structural order of a single field is trivial" {
+    const fields = [_]StructuralField{.{ .alignment = 16, .name = "only" }};
+    try expectStructuralOrder(&fields, &.{0});
 }

--- a/src/layout/graph.zig
+++ b/src/layout/graph.zig
@@ -81,7 +81,7 @@ pub const Graph = struct {
     /// ordinary `.struct_` nodes for every graph pass (cycle detection,
     /// refcounting, boxing); only the final commit differs, keeping declared
     /// order (repaired for padding) instead of sorting by alignment. See
-    /// `nominal_order` and design.md "Nominal Record Field Order".
+    /// `field_order` and design.md "Nominal Record Field Order".
     nominal_structs: std.ArrayListUnmanaged(NodeId) = .empty,
 
     /// Release all graph storage.

--- a/src/layout/mod.zig
+++ b/src/layout/mod.zig
@@ -60,6 +60,10 @@ pub const ScalarInfo = @import("layout.zig").ScalarInfo;
 // Per-target C-ABI parameter/return classification.
 pub const abi = @import("abi/mod.zig");
 
+// Record field ordering, shared by the layout store and `roc glue` so the two
+// can never disagree on how a record lays out in memory.
+pub const field_order = @import("field_order.zig");
+
 // Re-export store functionality
 pub const Store = @import("store.zig").Store;
 pub const Graph = @import("graph.zig").Graph;
@@ -120,7 +124,7 @@ test "layout tests" {
     std.testing.refAllDecls(@import("graph.zig"));
     std.testing.refAllDecls(@import("rc_helper.zig"));
     std.testing.refAllDecls(@import("store.zig"));
-    std.testing.refAllDecls(@import("nominal_order.zig"));
+    std.testing.refAllDecls(@import("field_order.zig"));
     std.testing.refAllDecls(@import("abi/mod.zig"));
     std.testing.refAllDecls(@import("abi/aarch64.zig"));
     std.testing.refAllDecls(@import("abi/x86_64.zig"));

--- a/src/layout/store.zig
+++ b/src/layout/store.zig
@@ -12,7 +12,7 @@ const layout_mod = @import("layout.zig");
 const graph_mod = @import("./graph.zig");
 const rc_helper = @import("./rc_helper.zig");
 const work_mod = @import("./work.zig");
-const nominal_order = @import("./nominal_order.zig");
+const field_order = @import("./field_order.zig");
 
 const target = base.target;
 const Layout = layout_mod.Layout;
@@ -564,7 +564,7 @@ pub const Store = struct {
         var temp_fields = std.ArrayList(StructField).empty;
         defer temp_fields.deinit(self.allocator);
         try temp_fields.appendSlice(self.allocator, fields);
-        self.stableSortStructFieldsByLayoutAlignment(temp_fields.items);
+        try self.stableSortStructFieldsByLayoutAlignment(temp_fields.items);
 
         var max_alignment: usize = 1;
         var current_offset: u32 = 0;
@@ -592,7 +592,7 @@ pub const Store = struct {
     /// DECLARED order. Unlike `putStructFields`, which sorts structural records
     /// and tuples by descending alignment, this keeps declared order, repairing
     /// it only as far as the no-internal-padding invariant requires (see
-    /// `nominal_order` and design.md "Nominal Record Field Order").
+    /// `field_order` and design.md "Nominal Record Field Order").
     /// `fields[i].index` is the canonical semantic field index used for
     /// name resolution; the slice order is the source declaration order.
     pub fn putNominalStructFields(self: *Self, fields: []const StructField) std.mem.Allocator.Error!Idx {
@@ -600,7 +600,7 @@ pub const Store = struct {
             return self.getEmptyStructLayout();
         }
 
-        var shapes = std.ArrayList(nominal_order.FieldShape).empty;
+        var shapes = std.ArrayList(field_order.FieldShape).empty;
         defer shapes.deinit(self.allocator);
         try shapes.ensureTotalCapacity(self.allocator, fields.len);
         for (fields) |field| {
@@ -613,7 +613,7 @@ pub const Store = struct {
 
         const order = try self.allocator.alloc(u16, fields.len);
         defer self.allocator.free(order);
-        try nominal_order.computeNominalFieldOrder(self.allocator, shapes.items, order);
+        try field_order.computeNominalFieldOrder(self.allocator, shapes.items, order);
 
         var ordered_fields = std.ArrayList(StructField).empty;
         defer ordered_fields.deinit(self.allocator);
@@ -656,24 +656,36 @@ pub const Store = struct {
         return self.putStructFields(temp_fields.items);
     }
 
-    fn stableSortStructFieldsByLayoutAlignment(self: *Self, fields: []StructField) void {
-        const AlignmentSortCtx = struct {
-            store: *Self,
-            target_usize: target.TargetUsize,
+    /// Sort structural-record / tuple fields by descending alignment, stably.
+    /// Routes through the shared `field_order.computeStructuralFieldOrder` so the
+    /// layout store and `roc glue` order structural records by the exact same
+    /// logic. Empty field names keep the pure stable alignment sort: callers
+    /// presort by name elsewhere, so equal-alignment fields stay in input order.
+    fn stableSortStructFieldsByLayoutAlignment(self: *Self, fields: []StructField) std.mem.Allocator.Error!void {
+        if (fields.len <= 1) return;
 
-            pub fn lessThan(ctx: @This(), lhs: StructField, rhs: StructField) bool {
-                const lhs_alignment: u64 = if (lhs.is_padding) 1 else ctx.store.getLayout(lhs.layout).alignment(ctx.target_usize).toByteUnits();
-                const rhs_alignment: u64 = if (rhs.is_padding) 1 else ctx.store.getLayout(rhs.layout).alignment(ctx.target_usize).toByteUnits();
-                return lhs_alignment > rhs_alignment;
-            }
-        };
+        const target_usize = self.targetUsize();
 
-        std.sort.block(
-            StructField,
-            fields,
-            AlignmentSortCtx{ .store = self, .target_usize = self.targetUsize() },
-            AlignmentSortCtx.lessThan,
-        );
+        const structural = try self.allocator.alloc(field_order.StructuralField, fields.len);
+        defer self.allocator.free(structural);
+        for (fields, structural) |field, *out| {
+            out.* = .{
+                .alignment = if (field.is_padding)
+                    1
+                else
+                    @intCast(self.getLayout(field.layout).alignment(target_usize).toByteUnits()),
+                .name = "",
+            };
+        }
+
+        const order = try self.allocator.alloc(u16, fields.len);
+        defer self.allocator.free(order);
+        field_order.computeStructuralFieldOrder(structural, order);
+
+        const scratch = try self.allocator.alloc(StructField, fields.len);
+        defer self.allocator.free(scratch);
+        for (order, scratch) |src, *dst| dst.* = fields[src];
+        @memcpy(fields, scratch);
     }
 
     /// Create a tag union layout from pre-computed variant payload layouts.
@@ -727,7 +739,7 @@ pub const Store = struct {
         var temp_fields = std.ArrayList(StructField).empty;
         defer temp_fields.deinit(self.allocator);
         try temp_fields.appendSlice(self.allocator, input_fields);
-        self.stableSortStructFieldsByLayoutAlignment(temp_fields.items);
+        try self.stableSortStructFieldsByLayoutAlignment(temp_fields.items);
 
         var max_alignment: usize = 1;
         var current_offset: u32 = 0;


### PR DESCRIPTION
Now that nominal records lay out in declared field order with unnamed padding fields, `roc glue` was generating wrong host bindings: it emitted nominal records in the old structural (alphabetical-then-alignment) order and dropped the padding fields entirely, so the generated extern structs no longer matched the runtime layout. The root cause was that glue had its own copy of the field-ordering logic instead of sharing the compiler's.

This makes the field-ordering a single shared implementation that both the layout store and glue call, so the two can no longer drift. `layout/nominal_order.zig` is renamed to `layout/field_order.zig` and owns both orderings: the existing `computeNominalFieldOrder` plus a new `computeStructuralFieldOrder` (stable sort by descending alignment, then field name). The layout store's structural sort and glue's structural records both route through `computeStructuralFieldOrder`, and the layout store's nominal path and glue's nominal records both route through `computeNominalFieldOrder`.

For nominal records, glue reconstructs the declared field order from the declaring module's CIR annotation (mirroring what Monotype lowering does), pulls the unnamed padding field types off the declaration, runs the shared order function, and emits the padding as fixed-size byte-array spacers in the Zig and Rust generators. C glue is unaffected because it renders records as opaque `void*`. Structural records keep their previous ordering.