### PR TITLE
Parse `{ { x } }` as a single-field record inside a block

### DIFF
--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -5183,6 +5183,22 @@ fn runExprStatementKernel(
                     last_statement = try self.addTopLevelUnexpectedStatement();
                     continue :expr_kernel .statement_complete;
                 }
+                // `{ x }` on its own is a block whose body is the expression `x`,
+                // since a single-field record would otherwise be useless. As a
+                // statement inside an enclosing block, however, `{ x }` is a punned
+                // single-field record, so that `{ { x } }` yields a record nested in
+                // a do-nothing block (and further braces add more do-nothing blocks).
+                if (isCurly and self.peekNext() == .LowerIdent and self.peekN(2) == .CloseCurly) {
+                    self.advance();
+                    try open_syntax.pushExpr(open_allocator, .statement_expr_body, Token.Idx, start);
+                    expr_record_state = .{
+                        .start = start,
+                        .min_bp = 0,
+                        .scratch_top = self.store.scratchRecordFieldTop(),
+                        .ext = null,
+                    };
+                    continue :expr_kernel .record_fields_next;
+                }
                 try open_syntax.pushExpr(open_allocator, .statement_expr_body, Token.Idx, start);
                 expr_state = .{ .start = start, .min_bp = 0 };
                 continue :expr_kernel .prefix;

--- a/test/snapshots/expr/single_field_record_double_braces.md
+++ b/test/snapshots/expr/single_field_record_double_braces.md
@@ -1,0 +1,54 @@
+# META
+~~~ini
+description=Single-field record written with double braces inside a block
+type=expr
+~~~
+# SOURCE
+~~~roc
+{
+	x = 5
+	{ x }
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+OpenCurly,
+LowerIdent,OpAssign,Int,
+OpenCurly,LowerIdent,CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-block
+	(statements
+		(s-decl
+			(p-ident (raw "x"))
+			(e-int (raw "5")))
+		(e-record
+			(field (field "x")))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-block
+	(s-let
+		(p-assign (ident "x"))
+		(e-num (value "5")))
+	(e-record
+		(fields
+			(field (name "x")
+				(e-lookup-local
+					(p-assign (ident "x")))))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "{ x: Dec }"))
+~~~

--- a/test/snapshots/expr/single_field_record_else_double_brace.md
+++ b/test/snapshots/expr/single_field_record_else_double_brace.md
@@ -1,0 +1,82 @@
+# META
+~~~ini
+description=An else branch of `{ { x } }` is a single-field record (issue #9723)
+type=expr
+~~~
+# SOURCE
+~~~roc
+{
+	x = 5
+	if True {
+		{ x }
+	} else {
+		{ x }
+	}
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+OpenCurly,
+LowerIdent,OpAssign,Int,
+KwIf,UpperIdent,OpenCurly,
+OpenCurly,LowerIdent,CloseCurly,
+CloseCurly,KwElse,OpenCurly,
+OpenCurly,LowerIdent,CloseCurly,
+CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-block
+	(statements
+		(s-decl
+			(p-ident (raw "x"))
+			(e-int (raw "5")))
+		(e-if-then-else
+			(e-tag (raw "True"))
+			(e-block
+				(statements
+					(e-record
+						(field (field "x")))))
+			(e-block
+				(statements
+					(e-record
+						(field (field "x"))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-block
+	(s-let
+		(p-assign (ident "x"))
+		(e-num (value "5")))
+	(e-if
+		(if-branches
+			(if-branch
+				(e-tag (name "True"))
+				(e-block
+					(e-record
+						(fields
+							(field (name "x")
+								(e-lookup-local
+									(p-assign (ident "x")))))))))
+		(if-else
+			(e-block
+				(e-record
+					(fields
+						(field (name "x")
+							(e-lookup-local
+								(p-assign (ident "x"))))))))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "{ x: Dec }"))
+~~~

--- a/test/snapshots/expr/single_field_record_else_single_brace.md
+++ b/test/snapshots/expr/single_field_record_else_single_brace.md
@@ -1,0 +1,74 @@
+# META
+~~~ini
+description=An else branch of `{ x }` stays a block evaluating to x, not a record (issue #9723)
+type=expr
+~~~
+# SOURCE
+~~~roc
+{
+	x = 5
+	if True {
+		x
+	} else {
+		x
+	}
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+OpenCurly,
+LowerIdent,OpAssign,Int,
+KwIf,UpperIdent,OpenCurly,
+LowerIdent,
+CloseCurly,KwElse,OpenCurly,
+LowerIdent,
+CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-block
+	(statements
+		(s-decl
+			(p-ident (raw "x"))
+			(e-int (raw "5")))
+		(e-if-then-else
+			(e-tag (raw "True"))
+			(e-block
+				(statements
+					(e-ident (raw "x"))))
+			(e-block
+				(statements
+					(e-ident (raw "x")))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-block
+	(s-let
+		(p-assign (ident "x"))
+		(e-num (value "5")))
+	(e-if
+		(if-branches
+			(if-branch
+				(e-tag (name "True"))
+				(e-block
+					(e-lookup-local
+						(p-assign (ident "x"))))))
+		(if-else
+			(e-block
+				(e-lookup-local
+					(p-assign (ident "x")))))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "Dec"))
+~~~

--- a/test/snapshots/expr/single_field_record_in_if_branch.md
+++ b/test/snapshots/expr/single_field_record_in_if_branch.md
@@ -1,0 +1,96 @@
+# META
+~~~ini
+description=Punned single-field record in an if branch matches an explicit record branch (issue #9723)
+type=expr
+~~~
+# SOURCE
+~~~roc
+{
+	items = [1, 2, 3]
+	if True {
+		{ items }
+	} else {
+		{ items: [4, 5, 6] }
+	}
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+OpenCurly,
+LowerIdent,OpAssign,OpenSquare,Int,Comma,Int,Comma,Int,CloseSquare,
+KwIf,UpperIdent,OpenCurly,
+OpenCurly,LowerIdent,CloseCurly,
+CloseCurly,KwElse,OpenCurly,
+OpenCurly,LowerIdent,OpColon,OpenSquare,Int,Comma,Int,Comma,Int,CloseSquare,CloseCurly,
+CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-block
+	(statements
+		(s-decl
+			(p-ident (raw "items"))
+			(e-list
+				(e-int (raw "1"))
+				(e-int (raw "2"))
+				(e-int (raw "3"))))
+		(e-if-then-else
+			(e-tag (raw "True"))
+			(e-block
+				(statements
+					(e-record
+						(field (field "items")))))
+			(e-block
+				(statements
+					(e-record
+						(field (field "items")
+							(e-list
+								(e-int (raw "4"))
+								(e-int (raw "5"))
+								(e-int (raw "6"))))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-block
+	(s-let
+		(p-assign (ident "items"))
+		(e-list
+			(elems
+				(e-num (value "1"))
+				(e-num (value "2"))
+				(e-num (value "3")))))
+	(e-if
+		(if-branches
+			(if-branch
+				(e-tag (name "True"))
+				(e-block
+					(e-record
+						(fields
+							(field (name "items")
+								(e-lookup-local
+									(p-assign (ident "items")))))))))
+		(if-else
+			(e-block
+				(e-record
+					(fields
+						(field (name "items")
+							(e-list
+								(elems
+									(e-num (value "4"))
+									(e-num (value "5"))
+									(e-num (value "6")))))))))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "{ items: List(Dec) }"))
+~~~

--- a/test/snapshots/expr/single_field_record_nested_braces.md
+++ b/test/snapshots/expr/single_field_record_nested_braces.md
@@ -1,0 +1,67 @@
+# META
+~~~ini
+description=Extra braces around a single-field record are do-nothing blocks (issue #9723)
+type=expr
+~~~
+# SOURCE
+~~~roc
+{
+	x = 5
+	{ { { x } } }
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+OpenCurly,
+LowerIdent,OpAssign,Int,
+OpenCurly,OpenCurly,OpenCurly,LowerIdent,CloseCurly,CloseCurly,CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-block
+	(statements
+		(s-decl
+			(p-ident (raw "x"))
+			(e-int (raw "5")))
+		(e-block
+			(statements
+				(e-block
+					(statements
+						(e-record
+							(field (field "x")))))))))
+~~~
+# FORMATTED
+~~~roc
+{
+	x = 5
+	{
+		{
+			{ x }
+		}
+	}
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(e-block
+	(s-let
+		(p-assign (ident "x"))
+		(e-num (value "5")))
+	(e-block
+		(e-block
+			(e-record
+				(fields
+					(field (name "x")
+						(e-lookup-local
+							(p-assign (ident "x")))))))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "{ x: Dec }"))
+~~~


### PR DESCRIPTION
A standalone `{ x }` parses as a block whose body is the expression `x`, because a single-field record would otherwise be useless—but that left no obvious way to write a single-field record, and it made `{ { x } }` silently evaluate to `x` rather than the record the author clearly intended (the cause of the type mismatch in #9723, where a punned `{ items }` branch didn't match an explicit `{ items: ... }` branch). This makes `{ x }` parse as a punned single-field record (`{ x: x }`) when it appears as a statement inside an enclosing block, so `{ { x } }` is a record wrapped in a do-nothing block while a standalone `{ x }` is unchanged. Extra braces are all do-nothing blocks, so `{ { { x } } }` is one record inside two blocks.

The decision lives in the block-statement path of the parser and is a two-token lookahead for `{ ident }` with no backtracking, so it stays cheap and doesn't touch any other `{`-led position (function arguments, `if`/`match` branches, lambda bodies, top level), all of which continue to treat `{ x }` as a block. Because the new node is an ordinary punned record, it canonicalizes identically to `{ x: x }` and needs no changes downstream.

Closes #9723