### PR TITLE
Fix parser record state initialization

### DIFF
--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -5258,6 +5258,7 @@ fn runExprStatementKernel(
                         .min_bp = 0,
                         .scratch_top = self.store.scratchRecordFieldTop(),
                         .ext = null,
+                        .nominal_mapper = null,
                     };
                     continue :expr_kernel .record_fields_next;
                 }


### PR DESCRIPTION
## Summary
- Initialize the plain statement-body record parser state with no nominal mapper.
- Keeps the record-state initializer aligned with the rest of the parser paths after the nominal record mapper field was added.

## Test plan
- zig build minici