### PR TITLE
repl: Introduce `:defs` and `:t <identifier>` commands

### DIFF
--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -110,6 +110,10 @@ pub fn stepWithConfig(self: *ReplSession, input: []const u8, report_config: repo
 
     if (std.mem.eql(u8, line, ":help")) return .{ .output = try self.helpText() };
     if (std.mem.eql(u8, line, ":defs")) return .{ .output = try self.printDefs() };
+    if (std.mem.startsWith(u8, line, ":t ")) {
+        const rest = std.mem.trim(u8, line[3..], " \t");
+        return .{ .output = try self.printTypeOfVar(rest) };
+    }
     if (std.mem.eql(u8, line, ":exit") or
         std.mem.eql(u8, line, ":quit") or
         std.mem.eql(u8, line, ":q") or
@@ -303,6 +307,27 @@ fn printDefs(self: *ReplSession) anyerror![]u8 {
     }
 
     return try output.toOwnedSlice(self.allocator);
+}
+
+fn printTypeOfVar(self: *ReplSession, name: []const u8) anyerror![]u8 {
+    var out = std.ArrayList(u8).empty;
+    defer out.deinit(self.allocator);
+
+    var ret = try self.initParsedResources();
+    defer ret.deinit(self.allocator);
+    var env = ret.module_env;
+
+    var tw = try env.initTypeWriter();
+    defer tw.deinit();
+
+    if (getDefOfName(env, name)) |def_idx| {
+        try tw.write(ModuleEnv.varFrom(def_idx), .one_line);
+        try out.print(self.allocator, "\x1b[3m\x1b[90m{s} : {s}\x1b[0m\n", .{ name, tw.get() });
+    } else {
+        try out.print(self.allocator, "Did not find a definition for `{s}`\n", .{name});
+    }
+
+    return out.toOwnedSlice(self.allocator);
 }
 
 fn initParsedResources(self: *ReplSession) anyerror!eval.test_helpers.ParsedResources {

--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -272,26 +272,12 @@ fn printDefs(self: *ReplSession) anyerror![]u8 {
     var output = std.ArrayList(u8).empty;
     errdefer output.deinit(self.allocator);
 
-    // start setup
-    const definitions = try self.definitionsSource();
-    defer self.allocator.free(definitions);
-
-    const source = try std.fmt.allocPrint(self.allocator, "{s}\nmain = \"\"\n", .{definitions});
-    defer self.allocator.free(source);
-
-    var ret = try eval.test_helpers.parseAndCanonicalizeProgramPublishedRootsWithBuiltin(
-        self.allocator,
-        .module,
-        source,
-        &.{},
-        self.prePublishedBuiltin(),
-    );
+    var ret = try self.initParsedResources();
     defer ret.deinit(self.allocator);
     const env = ret.module_env;
 
     var tw = try env.initTypeWriter();
     defer tw.deinit();
-    // end setup
 
     for (self.definitions.items.items) |item| {
         switch (item.kind) {
@@ -317,6 +303,22 @@ fn printDefs(self: *ReplSession) anyerror![]u8 {
     }
 
     return try output.toOwnedSlice(self.allocator);
+}
+
+fn initParsedResources(self: *ReplSession) anyerror!eval.test_helpers.ParsedResources {
+    const definitions = try self.definitionsSource();
+    defer self.allocator.free(definitions);
+
+    const source = try std.fmt.allocPrint(self.allocator, "{s}\nmain = \"\"\n", .{definitions});
+    defer self.allocator.free(source);
+
+    return try eval.test_helpers.parseAndCanonicalizeProgramPublishedRootsWithBuiltin(
+        self.allocator,
+        .module,
+        source,
+        &.{},
+        self.prePublishedBuiltin(),
+    );
 }
 
 fn getDefOfName(env: *ModuleEnv, name: []const u8) ?can.CIR.Def.Idx {

--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -109,6 +109,7 @@ pub fn stepWithConfig(self: *ReplSession, input: []const u8, report_config: repo
     if (line.len == 0) return .none;
 
     if (std.mem.eql(u8, line, ":help")) return .{ .output = try self.helpText() };
+    if (std.mem.eql(u8, line, ":defs")) return .{ .output = try self.printDefs() };
     if (std.mem.eql(u8, line, ":exit") or
         std.mem.eql(u8, line, ":quit") or
         std.mem.eql(u8, line, ":q") or
@@ -265,6 +266,27 @@ fn helpText(self: *ReplSession) Allocator.Error![]u8 {
         \\  :quit, :q, :exit    Exit the REPL
         \\
     );
+}
+
+fn printDefs(self: *ReplSession) Allocator.Error![]u8 {
+    var output = std.ArrayList(u8).empty;
+    errdefer output.deinit(self.allocator);
+
+    for (self.definitions.items.items) |item| {
+        const desc = switch (item.kind) {
+            .value => "value",
+            .annotation => "annotation",
+            .type_decl => "type",
+            .import => "import",
+        };
+        try output.print(
+            self.allocator,
+            "\x1b[90m{s}: {s}\x1b[0m\n",
+            .{ item.name, desc },
+        );
+        try output.print(self.allocator, "{s}\n", .{ item.source });
+    }
+    return try output.toOwnedSlice(self.allocator);
 }
 
 const DefinitionValidation = struct {

--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -268,25 +268,66 @@ fn helpText(self: *ReplSession) Allocator.Error![]u8 {
     );
 }
 
-fn printDefs(self: *ReplSession) Allocator.Error![]u8 {
+fn printDefs(self: *ReplSession) anyerror![]u8 {
     var output = std.ArrayList(u8).empty;
     errdefer output.deinit(self.allocator);
 
+    // start setup
+    const definitions = try self.definitionsSource();
+    defer self.allocator.free(definitions);
+
+    const source = try std.fmt.allocPrint(self.allocator, "{s}\nmain = \"\"\n", .{definitions});
+    defer self.allocator.free(source);
+
+    var ret = try eval.test_helpers.parseAndCanonicalizeProgramPublishedRootsWithBuiltin(
+        self.allocator,
+        .module,
+        source,
+        &.{},
+        self.prePublishedBuiltin(),
+    );
+    defer ret.deinit(self.allocator);
+    const env = ret.module_env;
+
+    var tw = try env.initTypeWriter();
+    defer tw.deinit();
+    // end setup
+
     for (self.definitions.items.items) |item| {
-        const desc = switch (item.kind) {
-            .value => "value",
-            .annotation => "annotation",
-            .type_decl => "type",
-            .import => "import",
-        };
-        try output.print(
-            self.allocator,
-            "\x1b[90m{s}: {s}\x1b[0m\n",
-            .{ item.name, desc },
-        );
-        try output.print(self.allocator, "{s}\n", .{ item.source });
+        switch (item.kind) {
+            .value => {
+                const name = item.name;
+                const def_idx = getDefOfName(env, name) orelse continue;
+                try tw.write(ModuleEnv.varFrom(def_idx), .one_line);
+
+                try output.print(
+                    self.allocator,
+                    "\x1b[90m{s} : {s}\x1b[0m\n{s}\n",
+                    .{ name, tw.get(), item.source },
+                );
+            },
+            .annotation => {
+                // italics, usually succeeded by a .value let-binding
+                try output.print(self.allocator, "\x1b[3m{s}\x1b[0m\n", .{item.source});
+            },
+            .type_decl, .import => {
+                try output.print(self.allocator, "{s}\n", .{item.source});
+            },
+        }
     }
+
     return try output.toOwnedSlice(self.allocator);
+}
+
+fn getDefOfName(env: *ModuleEnv, name: []const u8) ?can.CIR.Def.Idx {
+    for (env.store.sliceDefs(env.all_defs)) |def_idx| {
+        const def = env.store.getDef(def_idx);
+        const pat = env.store.getPattern(def.pattern);
+        if (pat == .assign and std.mem.eql(u8, env.getIdent(pat.assign.ident), name)) {
+            return def_idx;
+        }
+    }
+    return null;
 }
 
 const DefinitionValidation = struct {

--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -268,6 +268,8 @@ fn helpText(self: *ReplSession) Allocator.Error![]u8 {
         \\Commands:
         \\  :help               Show this help
         \\  :quit, :q, :exit    Exit the REPL
+        \\  :defs               Print the currently known definitions
+        \\  :t <identifier>     Print the type of a given identifier
         \\
     );
 }

--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -292,7 +292,7 @@ fn printDefs(self: *ReplSession) anyerror![]u8 {
 
                 try out.print(
                     self.allocator,
-                    "\x1b[90m{s} : {s}\x1b[0m\n{s}\n",
+                    "\x1b[3m\x1b[90m{s} : {s}\x1b[0m\n{s}\n\n",
                     .{ name, tw.get(), item.source },
                 );
             },
@@ -301,7 +301,7 @@ fn printDefs(self: *ReplSession) anyerror![]u8 {
                 try out.print(self.allocator, "\x1b[3m{s}\x1b[0m\n", .{item.source});
             },
             .type_decl, .import => {
-                try out.print(self.allocator, "{s}\n", .{item.source});
+                try out.print(self.allocator, "\x1b[3m{s}\x1b[0m\n\n", .{item.source});
             },
         }
     }

--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -273,8 +273,8 @@ fn helpText(self: *ReplSession) Allocator.Error![]u8 {
 }
 
 fn printDefs(self: *ReplSession) anyerror![]u8 {
-    var output = std.ArrayList(u8).empty;
-    errdefer output.deinit(self.allocator);
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(self.allocator);
 
     var ret = try self.initParsedResources();
     defer ret.deinit(self.allocator);
@@ -290,7 +290,7 @@ fn printDefs(self: *ReplSession) anyerror![]u8 {
                 const def_idx = getDefOfName(env, name) orelse continue;
                 try tw.write(ModuleEnv.varFrom(def_idx), .one_line);
 
-                try output.print(
+                try out.print(
                     self.allocator,
                     "\x1b[90m{s} : {s}\x1b[0m\n{s}\n",
                     .{ name, tw.get(), item.source },
@@ -298,15 +298,15 @@ fn printDefs(self: *ReplSession) anyerror![]u8 {
             },
             .annotation => {
                 // italics, usually succeeded by a .value let-binding
-                try output.print(self.allocator, "\x1b[3m{s}\x1b[0m\n", .{item.source});
+                try out.print(self.allocator, "\x1b[3m{s}\x1b[0m\n", .{item.source});
             },
             .type_decl, .import => {
-                try output.print(self.allocator, "{s}\n", .{item.source});
+                try out.print(self.allocator, "{s}\n", .{item.source});
             },
         }
     }
 
-    return try output.toOwnedSlice(self.allocator);
+    return try out.toOwnedSlice(self.allocator);
 }
 
 fn printTypeOfVar(self: *ReplSession, name: []const u8) anyerror![]u8 {


### PR DESCRIPTION
This is me elaborating on an idea I had in [#ideas > Print type in &#96;roc repl&#96;](https://roc.zulipchat.com/#narrow/channel/304641-ideas/topic/Print.20type.20in.20.60roc.20repl.60/with/603872763), so feel free to discuss/reject/defer API decisions.

## What was added
The repl can now

- print the type of top-level definitions by name using `:t <identifier>`, like `ghci` can
- print all definitions using the `:defs` command

It looks like this:
<img width="977" height="829" alt="image" src="https://github.com/user-attachments/assets/fcc3c677-4095-4005-8d5e-29d93e1e5422" />

Note that `:t` is the actual feature I care about and `:defs` was the way to get me there. but I still think it is useful.
Feel free to reject this PR or parts of it or discuss naming / formatting. I'm happy to start a discussion over at zulip.

## What was not added
- general command dispatching whenever the line starts with `:`
- allowing arbitrary expressions to be typed in after `:t` (which would not be too hard I think)
- **Tests** (what should they look like? interpreter state is not changed here so it's a bit different from the rest)

## AI usage disclaimer
- No vibe coding
- some chat assistance with the zig stdlib and questions about how to write zig code more idiomatically.

All mistakes are my own, so feel free to tell me what I did wrong.
