### PR TITLE
Add Iter concat, single, and append

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -617,6 +617,16 @@ Builtin :: [].{
 		iter : Iter(item) -> Iter(item)
 		iter = |self| self
 
+		## Returns an iterator that yields exactly one item.
+		## ```roc
+		## expect Iter.fold(Iter.single(42.I64), [], |acc, item| acc.append(item)) == [42]
+		## ```
+		single : item -> Iter(item)
+		single = |item| {
+			len_if_known: Known(1),
+			step: || One({ item, rest: range_done() }),
+		}
+
 		## Returns an iterator that yields the given item first, followed by
 		## everything the given iterator yields.
 		##
@@ -632,6 +642,55 @@ Builtin :: [].{
 				Unknown => Unknown
 			},
 			step: || One({ item, rest }),
+		}
+
+		## Returns an iterator that yields all items from the first iterator,
+		## then all items from the second iterator.
+		## ```roc
+		## expect Iter.fold([1.I64, 2].iter().concat([3, 4].iter()), [], |acc, item| acc.append(item)) == [1, 2, 3, 4]
+		## ```
+		concat : Iter(item), Iter(item) -> Iter(item)
+		concat = |first, second| {
+			len_if_known: match first.len_if_known {
+				Known(first_len) => match second.len_if_known {
+					Known(second_len) => if second_len > 18446744073709551615 - first_len {
+						Unknown
+					} else {
+						Known(first_len + second_len)
+					}
+					Unknown => Unknown
+				}
+				Unknown => Unknown
+			},
+			step: ||
+				match Iter.next(first) {
+					Done => Iter.next(second)
+					Skip({ rest }) => Skip({ rest: Iter.concat(rest, second) })
+					One({ item, rest }) => One({ item, rest: Iter.concat(rest, second) })
+				},
+		}
+
+		## Returns an iterator that yields everything from the given iterator,
+		## followed by the given item.
+		## ```roc
+		## expect Iter.fold([1.I64, 2].iter().append(3), [], |acc, item| acc.append(item)) == [1, 2, 3]
+		## ```
+		append : Iter(item), item -> Iter(item)
+		append = |iterator, last| {
+			len_if_known: match iterator.len_if_known {
+				Known(len) => if len == 18446744073709551615 {
+					Unknown
+				} else {
+					Known(len + 1)
+				}
+				Unknown => Unknown
+			},
+			step: ||
+				match Iter.next(iterator) {
+					Done => One({ item: last, rest: range_done() })
+					Skip({ rest }) => Skip({ rest: Iter.append(rest, last) })
+					One({ item, rest }) => One({ item, rest: Iter.append(rest, last) })
+				},
 		}
 
 		next : Iter(item) -> [One({ item : item, rest : Iter(item) }), Skip({ rest : Iter(item) }), Done]

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -3523,6 +3523,77 @@ const core_tests = [_]TestCase{
         .expected = .{ .inspect_str = "3" },
     },
     .{
+        .name = "inspect: Iter.single yields one item",
+        .source =
+        \\{
+        \\    iter = Iter.single(42.I64)
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[42]" },
+    },
+    .{
+        .name = "inspect: Iter.single reports known length one",
+        .source = "Iter.size_hint(Iter.single(42.I64))",
+        .expected = .{ .inspect_str = "Known(1)" },
+    },
+    .{
+        .name = "inspect: Iter.concat yields first then second",
+        .source =
+        \\{
+        \\    iter = [1.I64, 2].iter().concat([3, 4].iter())
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[1, 2, 3, 4]" },
+    },
+    .{
+        .name = "inspect: Iter.concat starts second after empty first",
+        .source =
+        \\{
+        \\    iter = [].iter().concat([1.I64, 2].iter())
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[1, 2]" },
+    },
+    .{
+        .name = "inspect: Iter.concat continues after skips",
+        .source =
+        \\{
+        \\    first = [1.I64, 2, 3].iter().keep_if(|item| item > 1)
+        \\    iter = first.concat([4, 5].iter())
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[2, 3, 4, 5]" },
+    },
+    .{
+        .name = "inspect: Iter.concat reports summed known length",
+        .source = "Iter.size_hint([1.I64, 2].iter().concat([3, 4, 5].iter()))",
+        .expected = .{ .inspect_str = "Known(5)" },
+    },
+    .{
+        .name = "inspect: Iter.concat reports unknown length when either side is unknown",
+        .source = "Iter.size_hint([1.I64, 2, 3].iter().keep_if(|item| item > 1).concat([4].iter()))",
+        .expected = .{ .inspect_str = "Unknown" },
+    },
+    .{
+        .name = "inspect: Iter.append yields item after iterator",
+        .source =
+        \\{
+        \\    iter = [1.I64, 2].iter().append(3)
+        \\    Iter.fold(iter, [], |acc, item| acc.append(item))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "[1, 2, 3]" },
+    },
+    .{
+        .name = "inspect: Iter.append reports incremented known length",
+        .source = "Iter.size_hint([1.I64, 2, 3].iter().append(4))",
+        .expected = .{ .inspect_str = "Known(4)" },
+    },
+    .{
         .name = "inspect: Iter.keep_if emits skip with rest iterator",
         .source =
         \\match Iter.next(Iter.keep_if([1.I64, 2].iter(), |item| item > 1)) {


### PR DESCRIPTION
This adds iterator helpers for creating a single-item iterator, lazily concatenating two iterators, and appending one item to the end of an iterator. The new helpers preserve exact size hints when the resulting length is known, and report Unknown when upstream length information is unavailable or the length addition would overflow.