### PR TITLE
Make roc build outputs reproducible

### DIFF
--- a/src/build/zig_llvm.cpp
+++ b/src/build/zig_llvm.cpp
@@ -44,6 +44,7 @@
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/ErrorHandling.h>
 #include <llvm/Support/FileSystem.h>
+#include <llvm/Support/Path.h>
 #include <llvm/Support/Process.h>
 #include <llvm/Support/TimeProfiler.h>
 #include <llvm/Support/Timer.h>
@@ -671,6 +672,7 @@ bool ZigLLVMWriteArchiveFlattened(const char *archive_name, const char **file_na
                 consumeError(member.takeError());
                 return true;
             }
+            member->MemberName = sys::path::filename(file_names[i]);
             new_members.push_back(std::move(*member));
         }
     }

--- a/src/cli/linker.zig
+++ b/src/cli/linker.zig
@@ -426,6 +426,12 @@ fn buildLinkArgs(ctx: *CliCtx, config: LinkConfig) LinkError!std.array_list.Mana
                 else => try args.append("arm64"), // default to arm64
             }
 
+            // Roc rewrites the ad-hoc code signature after patching Mach-O
+            // load commands. Suppress lld's content-derived LC_UUID so the
+            // final executable bytes do not depend on lld's pre-patch view of
+            // the output, which includes the output basename in the signature.
+            try args.append("-no_uuid");
+
             // Add platform version metadata required by Mach-O links.
             try args.append("-platform_version");
             try args.append("macos");
@@ -834,6 +840,8 @@ pub fn link(ctx: *CliCtx, config: LinkConfig) LinkError!void {
 
 const macho = std.macho;
 
+const deterministic_macho_code_signature_identifier = "roc";
+
 /// Patch a freshly-linked macOS executable's LC_MAIN stacksize field. See the
 /// callsite in `link` for why this is needed.
 fn patchMachoStackSize(path: []const u8, stacksize: u64, io: std.Io) anyerror!void {
@@ -914,21 +922,31 @@ fn resignMachoAdHoc(ctx: *CliCtx, path: []const u8) anyerror!void {
     const linkedit = linkedit_seg orelse return error.MissingLinkeditSegment;
 
     const page_size: u16 = if (header.cputype == macho.CPU_TYPE_ARM64) 0x4000 else 0x1000;
-    const ident = std.fs.path.basename(path);
+    const ident = deterministic_macho_code_signature_identifier;
 
     // The signature hashes every page before LC_CODE_SIGNATURE's dataoff,
     // including page 0 with the load commands. Its exact size is known up
     // front (one CodeDirectory blob, no special slots), so any load command
-    // growth must be written back before hashing.
+    // size changes must be written back before hashing.
     const hash_size = std.crypto.hash.sha2.Sha256.digest_length;
     const total_pages = std.mem.alignForward(usize, cs.dataoff, page_size) / page_size;
     const exact_size = @sizeOf(macho.SuperBlob) + @sizeOf(macho.BlobIndex) +
         @sizeOf(macho.CodeDirectory) + ident.len + 1 + total_pages * hash_size;
 
-    if (exact_size > cs.datasize) {
-        const grow = exact_size - cs.datasize;
+    const old_datasize = cs.datasize;
+    const old_sig_end: u64 = @as(u64, cs.dataoff) + @as(u64, old_datasize);
+    if (try file.length(io) != old_sig_end) return error.CodeSignatureNotAtEnd;
+
+    if (exact_size != old_datasize) {
         cs.datasize = @intCast(exact_size);
-        linkedit.filesize += grow;
+        if (exact_size > old_datasize) {
+            const grow: u64 = @intCast(exact_size - old_datasize);
+            linkedit.filesize += grow;
+        } else {
+            const shrink: u64 = @intCast(old_datasize - exact_size);
+            if (linkedit.filesize < shrink) return error.InvalidCodeSignatureSize;
+            linkedit.filesize -= shrink;
+        }
         linkedit.vmsize = std.mem.alignForward(u64, linkedit.filesize, page_size);
         try file.writePositionalAll(io, cmds_buf, @sizeOf(macho.mach_header_64));
     }
@@ -950,13 +968,8 @@ fn resignMachoAdHoc(ctx: *CliCtx, path: []const u8) anyerror!void {
     const sig = sig_bytes.written();
     std.debug.assert(sig.len == exact_size);
     try file.writePositionalAll(io, sig, cs.dataoff);
-    if (sig.len < cs.datasize) {
-        // Zero the slack so stale signature bytes cannot survive within the
-        // load command's extent.
-        const slack = try ctx.arena.alloc(u8, cs.datasize - sig.len);
-        @memset(slack, 0);
-        try file.writePositionalAll(io, slack, cs.dataoff + sig.len);
-    }
+    const new_sig_end: u64 = @as(u64, cs.dataoff) + @as(u64, @intCast(sig.len));
+    try file.setLength(io, new_sig_end);
 }
 
 fn findArg(args: []const []const u8, needle: []const u8) ?usize {

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -1997,7 +1997,7 @@ fn customDefaultPlatformWasm32ArchiveReproducible(
     std.Io.Dir.cwd().writeFile(io, .{ .sub_path = app_path, .data = default_platform_echo_app }) catch |err|
         return customInfraFailure(allocator, timer, "failed to write default platform app: {}", .{err});
 
-    const opts = [_][]const u8{ "speed", "size" };
+    const opts = [_][]const u8{ "dev", "speed", "size" };
     for (opts) |opt| {
         const output_path = std.fmt.allocPrint(allocator, "{s}/default_platform_wasm32_repro_{s}.a", .{ env.dirs.work_dir, opt }) catch |err|
             return customInfraFailure(allocator, timer, "failed to allocate default platform output path: {}", .{err});
@@ -2016,9 +2016,14 @@ fn customDefaultPlatformWasm32ArchiveReproducible(
             return customInfraFailure(allocator, timer, "failed to read first archive {s}: {}", .{ output_path, err });
         defer allocator.free(first);
 
-        const bad_forward_member = std.fmt.allocPrint(allocator, "/roc_app_llvm_wasm32_{s}.o/", .{opt}) catch |err|
+        const member_basename = if (std.mem.eql(u8, opt, "dev"))
+            "roc_app_wasm32.o"
+        else
+            std.fmt.allocPrint(allocator, "roc_app_llvm_wasm32_{s}.o", .{opt}) catch |err|
+                return customInfraFailure(allocator, timer, "failed to allocate archive member check: {}", .{err});
+        const bad_forward_member = std.fmt.allocPrint(allocator, "/{s}/", .{member_basename}) catch |err|
             return customInfraFailure(allocator, timer, "failed to allocate archive member check: {}", .{err});
-        const bad_backslash_member = std.fmt.allocPrint(allocator, "\\roc_app_llvm_wasm32_{s}.o/", .{opt}) catch |err|
+        const bad_backslash_member = std.fmt.allocPrint(allocator, "\\{s}/", .{member_basename}) catch |err|
             return customInfraFailure(allocator, timer, "failed to allocate archive member check: {}", .{err});
         if (std.mem.find(u8, first, bad_forward_member) != null or
             std.mem.find(u8, first, bad_backslash_member) != null)
@@ -2058,47 +2063,69 @@ fn customMacosOutputBasenameReproducible(
         return .{ .status = .skip, .phase = .setup, .duration_ns = timer.read(), .message = "macOS Mach-O reproducibility test only runs on macOS" };
     }
 
+    const default_app_path = std.fs.path.join(allocator, &.{ env.dirs.work_dir, "default_platform_macos_repro.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate default platform app path: {}", .{err});
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = default_app_path, .data = default_platform_echo_app }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write default platform app: {}", .{err});
+
     const opts = [_][]const u8{ "dev", "speed", "size" };
     for (opts) |opt| {
-        const short_output = std.fmt.allocPrint(allocator, "{s}/a_{s}", .{ env.dirs.work_dir, opt }) catch |err|
-            return customInfraFailure(allocator, timer, "failed to allocate short macOS output path: {}", .{err});
-        const long_output = std.fmt.allocPrint(allocator, "{s}/very-long-output-name-for-macos-repro-{s}", .{ env.dirs.work_dir, opt }) catch |err|
-            return customInfraFailure(allocator, timer, "failed to allocate long macOS output path: {}", .{err});
-        const opt_arg = std.fmt.allocPrint(allocator, "--opt={s}", .{opt}) catch |err|
-            return customInfraFailure(allocator, timer, "failed to allocate opt arg: {}", .{err});
-        const short_out_arg = outputArg(allocator, short_output) catch |err|
-            return customInfraFailure(allocator, timer, "failed to allocate short output arg: {}", .{err});
-        const long_out_arg = outputArg(allocator, long_output) catch |err|
-            return customInfraFailure(allocator, timer, "failed to allocate long output arg: {}", .{err});
-
-        if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
-            .args = &.{ "build", "--no-cache", opt_arg, short_out_arg },
-            .roc_file = "test/fx/hello_world.roc",
-            .contains = &.{.{ .stream = .stdout, .text = "successfully building" }},
-        })) |failure| return failure;
-        if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
-            .args = &.{ "build", "--no-cache", opt_arg, long_out_arg },
-            .roc_file = "test/fx/hello_world.roc",
-            .contains = &.{.{ .stream = .stdout, .text = "successfully building" }},
-        })) |failure| return failure;
-
-        const short_bytes = std.Io.Dir.cwd().readFileAlloc(io, short_output, allocator, .limited(256 * 1024 * 1024)) catch |err|
-            return customInfraFailure(allocator, timer, "failed to read short macOS output {s}: {}", .{ short_output, err });
-        defer allocator.free(short_bytes);
-        const long_bytes = std.Io.Dir.cwd().readFileAlloc(io, long_output, allocator, .limited(256 * 1024 * 1024)) catch |err|
-            return customInfraFailure(allocator, timer, "failed to read long macOS output {s}: {}", .{ long_output, err });
-        defer allocator.free(long_bytes);
-
-        if (!std.mem.eql(u8, short_bytes, long_bytes)) {
-            return customFailure(allocator, timer, "macOS {s} output bytes changed when only the output basename changed", .{opt});
-        }
-
-        if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{short_output}, env.dirs.work_dir, .{
-            .args = &.{},
-            .stdout_exact = "Hello, world!\n",
-            .stderr_exact = "",
-        })) |failure| return failure;
+        if (checkMacosOutputBasenameReproducible(io, allocator, env, timer, timeout_ms, opt, "real_platform", "test/fx/hello_world.roc", "Hello, world!\n")) |failure| return failure;
+        if (checkMacosOutputBasenameReproducible(io, allocator, env, timer, timeout_ms, opt, "default_platform", default_app_path, "Hello, World!\n")) |failure| return failure;
     }
+
+    return null;
+}
+
+fn checkMacosOutputBasenameReproducible(
+    io: std.Io,
+    allocator: Allocator,
+    env: *const CaseEnv,
+    timer: *harness.Timer,
+    timeout_ms: u64,
+    opt: []const u8,
+    label: []const u8,
+    roc_file: []const u8,
+    expected_stdout: []const u8,
+) ?TestResult {
+    const short_output = std.fmt.allocPrint(allocator, "{s}/{s}_a_{s}", .{ env.dirs.work_dir, label, opt }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate short macOS output path: {}", .{err});
+    const long_output = std.fmt.allocPrint(allocator, "{s}/very-long-{s}-output-name-for-macos-repro-{s}", .{ env.dirs.work_dir, label, opt }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate long macOS output path: {}", .{err});
+    const opt_arg = std.fmt.allocPrint(allocator, "--opt={s}", .{opt}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate opt arg: {}", .{err});
+    const short_out_arg = outputArg(allocator, short_output) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate short output arg: {}", .{err});
+    const long_out_arg = outputArg(allocator, long_output) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate long output arg: {}", .{err});
+
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "build", "--no-cache", opt_arg, short_out_arg },
+        .roc_file = roc_file,
+        .contains = &.{.{ .stream = .stdout, .text = "successfully building" }},
+    })) |failure| return failure;
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "build", "--no-cache", opt_arg, long_out_arg },
+        .roc_file = roc_file,
+        .contains = &.{.{ .stream = .stdout, .text = "successfully building" }},
+    })) |failure| return failure;
+
+    const short_bytes = std.Io.Dir.cwd().readFileAlloc(io, short_output, allocator, .limited(256 * 1024 * 1024)) catch |err|
+        return customInfraFailure(allocator, timer, "failed to read short macOS output {s}: {}", .{ short_output, err });
+    defer allocator.free(short_bytes);
+    const long_bytes = std.Io.Dir.cwd().readFileAlloc(io, long_output, allocator, .limited(256 * 1024 * 1024)) catch |err|
+        return customInfraFailure(allocator, timer, "failed to read long macOS output {s}: {}", .{ long_output, err });
+    defer allocator.free(long_bytes);
+
+    if (!std.mem.eql(u8, short_bytes, long_bytes)) {
+        return customFailure(allocator, timer, "macOS {s} {s} output bytes changed when only the output basename changed", .{ label, opt });
+    }
+
+    if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{short_output}, env.dirs.work_dir, .{
+        .args = &.{},
+        .stdout_exact = expected_stdout,
+        .stderr_exact = "",
+    })) |failure| return failure;
 
     return null;
 }

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -177,6 +177,8 @@ const CustomCase = enum {
     default_platform_build_x64glibc,
     default_platform_build_arm64glibc,
     default_platform_build_wasm32,
+    default_platform_wasm32_archive_reproducible,
+    macos_output_basename_reproducible,
     default_platform_crash_x64musl,
     default_platform_crash_arm64musl,
     default_platform_crash_x64mac,
@@ -558,6 +560,8 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "roc build default platform x64glibc succeeds", .body = .{ .custom = .default_platform_build_x64glibc } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build default platform arm64glibc succeeds", .body = .{ .custom = .default_platform_build_arm64glibc } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build default platform wasm32 archive succeeds", .body = .{ .custom = .default_platform_build_wasm32 } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc build default platform wasm32 archive output is reproducible", .body = .{ .custom = .default_platform_wasm32_archive_reproducible } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc build macOS output basename does not affect bytes", .body = .{ .custom = .macos_output_basename_reproducible } },
     .{ .id = 0, .suite = .subcommands, .name = "default platform crash prints debug backtrace on x64musl", .body = .{ .custom = .default_platform_crash_x64musl } },
     .{ .id = 0, .suite = .subcommands, .name = "default platform crash prints debug backtrace on arm64musl", .body = .{ .custom = .default_platform_crash_arm64musl } },
     .{ .id = 0, .suite = .subcommands, .name = "default platform crash prints debug backtrace on x64mac", .body = .{ .custom = .default_platform_crash_x64mac } },
@@ -1493,6 +1497,8 @@ fn runCustomCase(
         .default_platform_build_x64glibc => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .x64glibc),
         .default_platform_build_arm64glibc => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .arm64glibc),
         .default_platform_build_wasm32 => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .wasm32),
+        .default_platform_wasm32_archive_reproducible => customDefaultPlatformWasm32ArchiveReproducible(io, allocator, &env, &timer, timeout_ms),
+        .macos_output_basename_reproducible => customMacosOutputBasenameReproducible(io, allocator, &env, &timer, timeout_ms),
         .default_platform_crash_x64musl => customDefaultPlatformDebugBacktrace(io, allocator, &env, &timer, timeout_ms, .x64musl, .crash),
         .default_platform_crash_arm64musl => customDefaultPlatformDebugBacktrace(io, allocator, &env, &timer, timeout_ms, .arm64musl, .crash),
         .default_platform_crash_x64mac => customDefaultPlatformDebugBacktrace(io, allocator, &env, &timer, timeout_ms, .x64mac, .crash),
@@ -1972,6 +1978,124 @@ fn customDefaultPlatformBuild(
         if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{executable_path}, env.dirs.work_dir, .{
             .args = &.{},
             .stdout_exact = "Hello, World!\n",
+            .stderr_exact = "",
+        })) |failure| return failure;
+    }
+
+    return null;
+}
+
+fn customDefaultPlatformWasm32ArchiveReproducible(
+    io: std.Io,
+    allocator: Allocator,
+    env: *const CaseEnv,
+    timer: *harness.Timer,
+    timeout_ms: u64,
+) ?TestResult {
+    const app_path = std.fs.path.join(allocator, &.{ env.dirs.work_dir, "default_platform_wasm32_repro.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate default platform app path: {}", .{err});
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = app_path, .data = default_platform_echo_app }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write default platform app: {}", .{err});
+
+    const opts = [_][]const u8{ "speed", "size" };
+    for (opts) |opt| {
+        const output_path = std.fmt.allocPrint(allocator, "{s}/default_platform_wasm32_repro_{s}.a", .{ env.dirs.work_dir, opt }) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate default platform output path: {}", .{err});
+        const opt_arg = std.fmt.allocPrint(allocator, "--opt={s}", .{opt}) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate opt arg: {}", .{err});
+        const out_arg = outputArg(allocator, output_path) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate output arg: {}", .{err});
+
+        if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+            .args = &.{ "build", "--no-cache", "--target=wasm32", opt_arg, out_arg },
+            .roc_file = app_path,
+            .contains = &.{.{ .stream = .stdout, .text = "successfully building" }},
+        })) |failure| return failure;
+
+        const first = std.Io.Dir.cwd().readFileAlloc(io, output_path, allocator, .limited(64 * 1024 * 1024)) catch |err|
+            return customInfraFailure(allocator, timer, "failed to read first archive {s}: {}", .{ output_path, err });
+        defer allocator.free(first);
+
+        const bad_forward_member = std.fmt.allocPrint(allocator, "/roc_app_llvm_wasm32_{s}.o/", .{opt}) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate archive member check: {}", .{err});
+        const bad_backslash_member = std.fmt.allocPrint(allocator, "\\roc_app_llvm_wasm32_{s}.o/", .{opt}) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate archive member check: {}", .{err});
+        if (std.mem.find(u8, first, bad_forward_member) != null or
+            std.mem.find(u8, first, bad_backslash_member) != null)
+        {
+            return customFailure(allocator, timer, "default wasm {s} archive leaked an object path into its member name", .{opt});
+        }
+
+        std.Io.Dir.cwd().deleteFile(io, output_path) catch |err|
+            return customInfraFailure(allocator, timer, "failed to delete first archive {s}: {}", .{ output_path, err });
+
+        if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+            .args = &.{ "build", "--no-cache", "--target=wasm32", opt_arg, out_arg },
+            .roc_file = app_path,
+            .contains = &.{.{ .stream = .stdout, .text = "successfully building" }},
+        })) |failure| return failure;
+
+        const second = std.Io.Dir.cwd().readFileAlloc(io, output_path, allocator, .limited(64 * 1024 * 1024)) catch |err|
+            return customInfraFailure(allocator, timer, "failed to read second archive {s}: {}", .{ output_path, err });
+        defer allocator.free(second);
+
+        if (!std.mem.eql(u8, first, second)) {
+            return customFailure(allocator, timer, "default wasm {s} archive bytes were not reproducible", .{opt});
+        }
+    }
+
+    return null;
+}
+
+fn customMacosOutputBasenameReproducible(
+    io: std.Io,
+    allocator: Allocator,
+    env: *const CaseEnv,
+    timer: *harness.Timer,
+    timeout_ms: u64,
+) ?TestResult {
+    if (builtin.os.tag != .macos) {
+        return .{ .status = .skip, .phase = .setup, .duration_ns = timer.read(), .message = "macOS Mach-O reproducibility test only runs on macOS" };
+    }
+
+    const opts = [_][]const u8{ "dev", "speed", "size" };
+    for (opts) |opt| {
+        const short_output = std.fmt.allocPrint(allocator, "{s}/a_{s}", .{ env.dirs.work_dir, opt }) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate short macOS output path: {}", .{err});
+        const long_output = std.fmt.allocPrint(allocator, "{s}/very-long-output-name-for-macos-repro-{s}", .{ env.dirs.work_dir, opt }) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate long macOS output path: {}", .{err});
+        const opt_arg = std.fmt.allocPrint(allocator, "--opt={s}", .{opt}) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate opt arg: {}", .{err});
+        const short_out_arg = outputArg(allocator, short_output) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate short output arg: {}", .{err});
+        const long_out_arg = outputArg(allocator, long_output) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate long output arg: {}", .{err});
+
+        if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+            .args = &.{ "build", "--no-cache", opt_arg, short_out_arg },
+            .roc_file = "test/fx/hello_world.roc",
+            .contains = &.{.{ .stream = .stdout, .text = "successfully building" }},
+        })) |failure| return failure;
+        if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+            .args = &.{ "build", "--no-cache", opt_arg, long_out_arg },
+            .roc_file = "test/fx/hello_world.roc",
+            .contains = &.{.{ .stream = .stdout, .text = "successfully building" }},
+        })) |failure| return failure;
+
+        const short_bytes = std.Io.Dir.cwd().readFileAlloc(io, short_output, allocator, .limited(256 * 1024 * 1024)) catch |err|
+            return customInfraFailure(allocator, timer, "failed to read short macOS output {s}: {}", .{ short_output, err });
+        defer allocator.free(short_bytes);
+        const long_bytes = std.Io.Dir.cwd().readFileAlloc(io, long_output, allocator, .limited(256 * 1024 * 1024)) catch |err|
+            return customInfraFailure(allocator, timer, "failed to read long macOS output {s}: {}", .{ long_output, err });
+        defer allocator.free(long_bytes);
+
+        if (!std.mem.eql(u8, short_bytes, long_bytes)) {
+            return customFailure(allocator, timer, "macOS {s} output bytes changed when only the output basename changed", .{opt});
+        }
+
+        if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{short_output}, env.dirs.work_dir, .{
+            .args = &.{},
+            .stdout_exact = "Hello, world!\n",
             .stderr_exact = "",
         })) |failure| return failure;
     }


### PR DESCRIPTION
This makes Roc build outputs independent of incidental output paths. Mach-O links now suppress lld's content-derived UUID, and Roc's post-link ad-hoc signing uses a fixed identifier while refusing to resize the signature unless the old signature is at end-of-file. Static archive creation now stores object basenames instead of full temporary paths, so default-platform wasm archives no longer embed random artifact directories. The CLI suite gains regression coverage for default wasm archive byte reproducibility and macOS output-basename independence.