### PR TITLE
Fix echo platform wasm hosted-call dispatch

### DIFF
--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Run Playground Tests
         run: zig build run-test-playground -Doptimize=ReleaseSmall -- --verbose
 
+      - name: Run echo.wasm integration test
+        run: zig build run-test-echo-wasm
+
       # We run zig check with tracy enabled.
       # This ensure it compiles and doesn't go stale.
       - name: Checkout Tracy

--- a/src/echo_platform/mod.zig
+++ b/src/echo_platform/mod.zig
@@ -179,6 +179,28 @@ pub fn echoHostedFn(str: RocStr) callconv(.c) void {
     // Returns {} (ZST) — no bytes to write to ret_bytes
 }
 
+/// wasm uniform-ABI entry for `Echo.line!`. On wasm32 the interpreter cannot
+/// synthesize a dynamic-signature C call (see `host_trampoline.available`), so
+/// it invokes hosted functions through a uniform `(args_buf, ret_buf)` ABI. The
+/// interpreter packs `line!`'s single `Str` argument at offset 0 of `args` and
+/// expects no return value, so this reads the RocStr back out and forwards to
+/// `echoHostedFn`, which owns and decrefs it exactly as on native.
+pub fn echoHostedFnWasm(args: [*]u8, _: [*]u8) callconv(.c) void {
+    const str: *const RocStr = @ptrCast(@alignCast(args));
+    echoHostedFn(str.*);
+}
+
+/// The hosted function pointer the echo platform registers for `Echo.line!`,
+/// selected for the current target's hosted-call ABI: the natural-C-ABI
+/// `echoHostedFn` on architectures with a register-image trampoline, or the
+/// uniform-ABI `echoHostedFnWasm` shim where one is unavailable (wasm).
+pub fn echoLineHostedFn() host_abi.HostedFn {
+    return if (comptime is_wasm)
+        host_abi.hostedFn(&echoHostedFnWasm)
+    else
+        host_abi.hostedFn(&echoHostedFn);
+}
+
 fn appendTemporaryNewline(str: *RocStr) ?[]u8 {
     const len = str.len();
     if (len >= str.getCapacity()) return null;

--- a/src/echo_platform/runner.zig
+++ b/src/echo_platform/runner.zig
@@ -265,7 +265,7 @@ fn runEchoView(
     // stripped). The echo platform has only `Echo.line`, so order is
     // trivially correct — but additions must respect alphabetical order or
     // the wrong function will be called silently. See README "Host functions".
-    var hosted_fn_array = [_]HostedFn{echo_platform.host_abi.hostedFn(&echo_platform.echoHostedFn)};
+    var hosted_fn_array = [_]HostedFn{echo_platform.echoLineHostedFn()};
     var echo_env: echo_platform.EchoEnv = .{ .std_io = std_io };
     var roc_ops = echo_platform.makeDefaultRocOps(&echo_env, &hosted_fn_array);
     echo_platform.g_roc_ops = &roc_ops;

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -3305,23 +3305,35 @@ pub const Interpreter = struct {
 
         const hosted_fn = self.roc_ops.hosted_fns.fns[hosted.dispatch_index];
 
-        // Call the hosted function with the platform C ABI via the fixed register-image
-        // trampoline (no runtime code generation).
-        var arena_state = std.heap.ArenaAllocator.init(self.allocator);
-        defer arena_state.deinit();
-        host_trampoline.call(
-            self.layout_store,
-            arena_state.allocator(),
-            @ptrCast(hosted_fn),
-            arg_layouts,
-            ret_layout,
-            args_buf.ptr,
-            arg_offsets,
-            ret_buf.ptr,
-        ) catch |err| return self.invariantFailedError(
-            "hosted call C-ABI lowering failed for proc {d}: {s}",
-            .{ @intFromEnum(proc_id), @errorName(err) },
-        );
+        if (comptime host_trampoline.available) {
+            // Call the hosted function with the platform C ABI via the fixed register-image
+            // trampoline (no runtime code generation).
+            var arena_state = std.heap.ArenaAllocator.init(self.allocator);
+            defer arena_state.deinit();
+            host_trampoline.call(
+                self.layout_store,
+                arena_state.allocator(),
+                @ptrCast(hosted_fn),
+                arg_layouts,
+                ret_layout,
+                args_buf.ptr,
+                arg_offsets,
+                ret_buf.ptr,
+            ) catch |err| return self.invariantFailedError(
+                "hosted call C-ABI lowering failed for proc {d}: {s}",
+                .{ @intFromEnum(proc_id), @errorName(err) },
+            );
+        } else {
+            // Architectures without a register-image trampoline (e.g. wasm32, where
+            // a dynamic-signature call cannot be synthesized) call hosted functions
+            // through a uniform `(args_buf, ret_buf)` ABI instead. The arguments are
+            // already packed contiguously above in Roc layout order, so the host reads
+            // each one from `args_buf` at its layout offset and writes the return value
+            // into `ret_buf`. Platforms register their hosted functions in this shape
+            // when `host_trampoline.available` is false (see the echo platform).
+            const uniform: *const fn ([*]u8, [*]u8) callconv(.c) void = @ptrCast(hosted_fn);
+            uniform(args_buf.ptr, ret_buf.ptr);
+        }
 
         if (self.roc_env.crashed) return error.Crash;
         if (ret_sa.size == 0) return Value.zst;

--- a/test/echo-wasm-test/main.zig
+++ b/test/echo-wasm-test/main.zig
@@ -37,7 +37,7 @@ fn hostJsStderr(_: ?*anyopaque, _: *bytebox.ModuleInstance, params: [*]const byt
     capture_ctx.stderr.appendSlice(capture_ctx.gpa, mem[ptr .. ptr + len]) catch return;
 }
 
-fn invokeAlloc(instance: *bytebox.ModuleInstance, handle: bytebox.FunctionHandle, size: u32) Allocator.Error!u32 {
+fn invokeAlloc(instance: *bytebox.ModuleInstance, handle: bytebox.FunctionHandle, size: u32) anyerror!u32 {
     var params = [_]bytebox.Val{.{ .I32 = @intCast(size) }};
     var returns = [_]bytebox.Val{.{ .I32 = 0 }};
     try instance.invoke(handle, &params, &returns, .{});
@@ -46,7 +46,7 @@ fn invokeAlloc(instance: *bytebox.ModuleInstance, handle: bytebox.FunctionHandle
     return result;
 }
 
-fn writeBytesToWasm(instance: *bytebox.ModuleInstance, alloc_handle: bytebox.FunctionHandle, data: []const u8) Allocator.Error!struct { ptr: u32, len: u32 } {
+fn writeBytesToWasm(instance: *bytebox.ModuleInstance, alloc_handle: bytebox.FunctionHandle, data: []const u8) anyerror!struct { ptr: u32, len: u32 } {
     const ptr = try invokeAlloc(instance, alloc_handle, @intCast(data.len));
     const mem = memory_instance.buffer();
     if (@as(usize, ptr) + data.len > mem.len) return error.WasmBufferOutOfBounds;
@@ -54,8 +54,10 @@ fn writeBytesToWasm(instance: *bytebox.ModuleInstance, alloc_handle: bytebox.Fun
     return .{ .ptr = ptr, .len = @intCast(data.len) };
 }
 
-pub fn main() Allocator.Error!void {
-    var gpa_impl: std.heap.GeneralPurposeAllocator(.{}) = .init;
+pub fn main(init: std.process.Init) anyerror!void {
+    const io = init.io;
+
+    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa_impl.deinit();
     const gpa = gpa_impl.allocator();
 
@@ -73,7 +75,7 @@ pub fn main() Allocator.Error!void {
 
     // Locate echo.wasm relative to repo root (cwd when run via `zig build`).
     const wasm_path = "zig-out/lib/echo.wasm";
-    const wasm_bytes = std.fs.cwd().readFileAlloc(arena, wasm_path, std.math.maxInt(usize)) catch |err| {
+    const wasm_bytes = std.Io.Dir.cwd().readFileAlloc(io, wasm_path, arena, .unlimited) catch |err| {
         std.debug.print("FAIL: could not read {s}: {s}\n", .{ wasm_path, @errorName(err) });
         std.debug.print("(Did you run `zig build build-playground` first?)\n", .{});
         std.process.exit(2);


### PR DESCRIPTION
On wasm32 the echo platform compiled and ran user programs but produced no output: `echo!` calls (`Echo.line!`) never reached the host. The LIR interpreter dispatches hosted functions through `host_trampoline`, a fixed register-image assembly stub that only exists for aarch64/x86_64. On wasm `host_trampoline.call` returned UnsupportedArch, which the interpreter turned into an `invariantFailedError` (`unreachable`). Since echo.wasm is built ReleaseSmall that `unreachable` was UB rather than a trap, so the call silently no-op'd and `main!` returned 0 with no output.

A dynamic-signature C call can't be synthesized on wasm, but the interpreter already packs arguments contiguously in `args_buf`. So on architectures without a register-image trampoline, call hosted functions through a uniform `(args_buf, ret_buf)` ABI instead. The native path is gated by `comptime host_trampoline.available`, so its codegen is unchanged.

The echo platform registers `echoHostedFnWasm` (reads the RocStr from the argument buffer and forwards to `echoHostedFn`, preserving ownership and decref) via `echoLineHostedFn()` on wasm.

Also restore the bytebox integration test (test/echo-wasm-test), which no longer compiled against Zig 0.16 (GeneralPurposeAllocator -> DebugAllocator, std.fs.cwd -> std.Io.Dir.cwd, widened helper error sets), and wire it into ci_zig.yml so this can't regress silently again.