### PR TITLE
Explicit nominal construction for primitive/value/tuple-backed types (#9770)

### DIFF
--- a/design.md
+++ b/design.md
@@ -1751,6 +1751,22 @@ attaches an `is_eq` constraint to the pattern's type so this lowering is
 total. Literal patterns on builtin types keep their direct literal-pattern
 encoding.
 
+### Constructing Nominal Values
+
+Nominal construction is expression-directed, not a unification side effect.
+Explicit construction syntax — `Type.(value)`, `Type.(a, b)`, `Type.{ field }`,
+`Type.Tag(payload)` — canonicalizes to a single `e_nominal` (or
+`e_nominal_external`) expression whose `backing_type` records the surface form
+(`value`, `tuple`, `record`, `tag`). Checking instantiates the nominal
+declaration, unifies the user-written backing expression against the
+declaration's backing variable, and gives the whole expression the nominal type.
+The backing variable is read **only** during this unification; nominal identity
+is defined by origin, name, and arguments, and two nominals of different identity
+never unify. A value already typed as a different nominal or primitive therefore
+does not silently lift into a nominal — the implicit path is reserved for
+literals, which convert through the `from_numeral` / `from_quote` mechanism above
+(walking transparent newtype chains to reach the builtin backing).
+
 ### String Interpolation
 
 An interpolated string literal is its own CIR expression. It is not

--- a/docs/langref/types.md
+++ b/docs/langref/types.md
@@ -133,6 +133,28 @@ uid : UserId
 uid = 0               # a bare U64 becomes a UserId here
 ```
 
+You can also construct a nominal value **explicitly** by naming the type. This is
+required when no expected type drives the conversion — for example, returning a
+nominal from a function whose argument is the plain backing value:
+
+```roc
+Distance := U64
+Pair := (U64, Str)
+
+d = Distance.(26)         # value backing
+pair = Pair.(1, "two")    # tuple backing
+p = Point.{ x: 1, y: 2 }  # record backing
+c = Color.Red             # tag backing (with a payload: `Color.Tag(payload)`)
+
+to_distance : U64 -> Distance
+to_distance = |n| Distance.(n)   # `|n| n` is a type error: a plain U64 is not a Distance
+```
+
+A *literal* (number, string, record, or tag) coerces into a nominal type
+implicitly when the expected type supplies the identity. A value that already has
+a concrete type — like the `U64` parameter `n` above — must be constructed
+explicitly; it does not silently become a different nominal.
+
 ### Destructuring Nominal Types
 
 Pattern can be destructured to access inner values.

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -11817,7 +11817,7 @@ fn runExprKernel(
                 break :blk CanonicalizedExpr{ .idx = malformed_idx, .free_vars = DataSpan.empty() };
             };
 
-            const result_expr = try self.finishNominalRecordExpr(state.mapper, backing_expr.idx, state.region, backing_expr.free_vars);
+            const result_expr = try self.finishNominalConstructionExpr(state.mapper, backing_expr.idx, .record, state.region, backing_expr.free_vars);
 
             child_slots.shrinkRetainingCapacity(result_start);
             try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, result_expr);
@@ -11836,7 +11836,7 @@ fn runExprKernel(
                 break :blk CanonicalizedExpr{ .idx = malformed_idx, .free_vars = DataSpan.empty() };
             };
 
-            const result_expr = try self.finishNominalApplyExpr(state.mapper, backing_expr.idx, state.backing_type, state.region, backing_expr.free_vars);
+            const result_expr = try self.finishNominalConstructionExpr(state.mapper, backing_expr.idx, state.backing_type, state.region, backing_expr.free_vars);
 
             child_slots.shrinkRetainingCapacity(result_start);
             try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, result_expr);
@@ -13289,247 +13289,7 @@ fn lookupExposedTargetByText(
     return null;
 }
 
-fn finishNominalRecordExpr(
-    self: *Self,
-    mapper_idx: AST.Expr.Idx,
-    backing_expr_idx: Expr.Idx,
-    region: Region,
-    free_vars: DataSpan,
-) std.mem.Allocator.Error!CanonicalizedExpr {
-    const mapper = self.parse_ir.store.getExpr(mapper_idx);
-    return switch (mapper) {
-        .tag => |tag| try self.finishNominalRecordForType(tag, backing_expr_idx, region, free_vars),
-        else => CanonicalizedExpr{
-            .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
-                .region = region,
-            } }),
-            .free_vars = DataSpan.empty(),
-        },
-    };
-}
-
-fn finishNominalRecordForType(
-    self: *Self,
-    type_expr: AST.TagExpr,
-    backing_expr_idx: Expr.Idx,
-    region: Region,
-    free_vars: DataSpan,
-) std.mem.Allocator.Error!CanonicalizedExpr {
-    const type_region = self.parse_ir.tokens.resolve(type_expr.token);
-
-    if (type_expr.qualifiers.span.len == 0) {
-        const type_ident = self.parse_ir.tokens.resolveIdentifier(type_expr.token) orelse {
-            return CanonicalizedExpr{
-                .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
-                    .region = region,
-                } }),
-                .free_vars = DataSpan.empty(),
-            };
-        };
-
-        if (try self.scopeLookupOrPrepareTypeDecl(type_ident)) |nominal_type_decl_stmt_idx| {
-            switch (self.env.store.getStatement(nominal_type_decl_stmt_idx)) {
-                .s_nominal_decl => {
-                    const expr_idx = try self.env.addExpr(CIR.Expr{
-                        .e_nominal = .{
-                            .nominal_type_decl = nominal_type_decl_stmt_idx,
-                            .backing_expr = backing_expr_idx,
-                            .backing_type = .record,
-                        },
-                    }, region);
-                    return CanonicalizedExpr{ .idx = expr_idx, .free_vars = free_vars };
-                },
-                .s_alias_decl => {
-                    return CanonicalizedExpr{
-                        .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .type_alias_but_needed_nominal = .{
-                            .name = type_ident,
-                            .region = type_region,
-                        } }),
-                        .free_vars = DataSpan.empty(),
-                    };
-                },
-                else => {
-                    return CanonicalizedExpr{
-                        .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
-                            .region = type_region,
-                        } }),
-                        .free_vars = DataSpan.empty(),
-                    };
-                },
-            }
-        }
-
-        if (self.scopeLookupExposedItem(type_ident)) |exposed_info| {
-            const module_name = exposed_info.module_name;
-            const import_idx = self.scopeLookupImportedModule(module_name) orelse {
-                return CanonicalizedExpr{
-                    .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .module_not_imported = .{
-                        .module_name = module_name,
-                        .region = region,
-                    } }),
-                    .free_vars = DataSpan.empty(),
-                };
-            };
-            const imported_type = self.lookupAvailableModuleEnv(module_name) orelse {
-                return CanonicalizedExpr{
-                    .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_not_exposed = .{
-                        .module_name = module_name,
-                        .type_name = type_ident,
-                        .region = type_region,
-                    } }),
-                    .free_vars = DataSpan.empty(),
-                };
-            };
-            const target_node_idx = blk: {
-                if (exposed_info.target) |target| {
-                    if (target.typeDeclNode()) |node_idx| break :blk node_idx;
-                } else {
-                    const original_name_text = self.env.getIdent(exposed_info.original_name);
-                    if (try self.lookupImportedExposedTypeNode(imported_type.env, original_name_text)) |node_idx| break :blk node_idx;
-                }
-                return CanonicalizedExpr{
-                    .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_not_exposed = .{
-                        .module_name = module_name,
-                        .type_name = type_ident,
-                        .region = type_region,
-                    } }),
-                    .free_vars = DataSpan.empty(),
-                };
-            };
-            if (try self.validateImportedNominalTagTarget(Expr.Idx, imported_type.env, target_node_idx, module_name, type_ident, type_region)) |malformed_idx| {
-                return CanonicalizedExpr{ .idx = malformed_idx, .free_vars = DataSpan.empty() };
-            }
-            const expr_idx = try self.env.addExpr(CIR.Expr{
-                .e_nominal_external = .{
-                    .module_idx = import_idx,
-                    .target_node_idx = target_node_idx,
-                    .backing_expr = backing_expr_idx,
-                    .backing_type = .record,
-                },
-            }, region);
-            return CanonicalizedExpr{ .idx = expr_idx, .free_vars = free_vars };
-        }
-
-        return CanonicalizedExpr{
-            .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .undeclared_type = .{
-                .name = type_ident,
-                .region = type_region,
-            } }),
-            .free_vars = DataSpan.empty(),
-        };
-    }
-
-    const qualifier_toks = self.parse_ir.store.tokenSlice(type_expr.qualifiers);
-    const strip_tokens = [_]tokenize.Token.Tag{.NoSpaceDotUpperIdent};
-    const first_tok_idx = qualifier_toks[0];
-    const first_tok_ident = self.parse_ir.tokens.resolveIdentifier(first_tok_idx) orelse {
-        return CanonicalizedExpr{
-            .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
-                .region = region,
-            } }),
-            .free_vars = DataSpan.empty(),
-        };
-    };
-    const is_imported = self.scopeLookupModule(first_tok_ident) != null;
-    const full_type_name = self.parse_ir.resolveQualifiedName(type_expr.qualifiers, type_expr.token, &strip_tokens);
-
-    if (!is_imported) {
-        const full_type_ident = try self.env.insertIdent(base.Ident.for_text(full_type_name));
-        const nominal_type_decl_stmt_idx = (try self.scopeLookupOrPrepareTypeDecl(full_type_ident)) orelse {
-            return CanonicalizedExpr{
-                .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .undeclared_type = .{
-                    .name = full_type_ident,
-                    .region = type_region,
-                } }),
-                .free_vars = DataSpan.empty(),
-            };
-        };
-
-        switch (self.env.store.getStatement(nominal_type_decl_stmt_idx)) {
-            .s_nominal_decl => {
-                const expr_idx = try self.env.addExpr(CIR.Expr{
-                    .e_nominal = .{
-                        .nominal_type_decl = nominal_type_decl_stmt_idx,
-                        .backing_expr = backing_expr_idx,
-                        .backing_type = .record,
-                    },
-                }, region);
-                return CanonicalizedExpr{ .idx = expr_idx, .free_vars = free_vars };
-            },
-            .s_alias_decl => {
-                return CanonicalizedExpr{
-                    .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .type_alias_but_needed_nominal = .{
-                        .name = full_type_ident,
-                        .region = type_region,
-                    } }),
-                    .free_vars = DataSpan.empty(),
-                };
-            },
-            else => {
-                return CanonicalizedExpr{
-                    .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
-                        .region = type_region,
-                    } }),
-                    .free_vars = DataSpan.empty(),
-                };
-            },
-        }
-    }
-
-    const module_info = self.scopeLookupModule(first_tok_ident).?;
-    const module_name = module_info.module_name;
-    const import_idx = self.scopeLookupImportedModule(module_name) orelse {
-        return CanonicalizedExpr{
-            .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .module_not_imported = .{
-                .module_name = module_name,
-                .region = region,
-            } }),
-            .free_vars = DataSpan.empty(),
-        };
-    };
-
-    const first_alias_len = self.env.getIdent(first_tok_ident).len;
-    std.debug.assert(full_type_name.len > first_alias_len);
-    std.debug.assert(full_type_name[first_alias_len] == '.');
-    const type_name = full_type_name[first_alias_len + 1 ..];
-    const type_name_ident = try self.env.insertIdent(base.Ident.for_text(type_name));
-    const imported_type = self.lookupAvailableModuleEnv(module_name) orelse {
-        return CanonicalizedExpr{
-            .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_from_missing_module = .{
-                .module_name = module_name,
-                .type_name = type_name_ident,
-                .region = type_region,
-            } }),
-            .free_vars = DataSpan.empty(),
-        };
-    };
-    const target_node_idx = (try self.lookupImportedExposedTypeNode(imported_type.env, type_name)) orelse {
-        return CanonicalizedExpr{
-            .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_not_exposed = .{
-                .module_name = module_name,
-                .type_name = type_name_ident,
-                .region = type_region,
-            } }),
-            .free_vars = DataSpan.empty(),
-        };
-    };
-
-    if (try self.validateImportedNominalTagTarget(Expr.Idx, imported_type.env, target_node_idx, module_name, type_name_ident, type_region)) |malformed_idx| {
-        return CanonicalizedExpr{ .idx = malformed_idx, .free_vars = DataSpan.empty() };
-    }
-
-    const expr_idx = try self.env.addExpr(CIR.Expr{
-        .e_nominal_external = .{
-            .module_idx = import_idx,
-            .target_node_idx = target_node_idx,
-            .backing_expr = backing_expr_idx,
-            .backing_type = .record,
-        },
-    }, region);
-    return CanonicalizedExpr{ .idx = expr_idx, .free_vars = free_vars };
-}
-
-fn finishNominalApplyExpr(
+fn finishNominalConstructionExpr(
     self: *Self,
     mapper_idx: AST.Expr.Idx,
     backing_expr_idx: Expr.Idx,
@@ -13539,7 +13299,7 @@ fn finishNominalApplyExpr(
 ) std.mem.Allocator.Error!CanonicalizedExpr {
     const mapper = self.parse_ir.store.getExpr(mapper_idx);
     return switch (mapper) {
-        .tag => |tag| try self.finishNominalApplyForType(tag, backing_expr_idx, backing_type, region, free_vars),
+        .tag => |tag| try self.finishNominalConstructionForType(tag, backing_expr_idx, backing_type, region, free_vars),
         else => CanonicalizedExpr{
             .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
                 .region = region,
@@ -13549,7 +13309,7 @@ fn finishNominalApplyExpr(
     };
 }
 
-fn finishNominalApplyForType(
+fn finishNominalConstructionForType(
     self: *Self,
     type_expr: AST.TagExpr,
     backing_expr_idx: Expr.Idx,

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -9586,15 +9586,36 @@ fn runExprKernel(
                     try stacks.pushParse(frame_allocator, .{ .idx = nr.backing, .target = .scratch });
                 },
                 .nominal_apply => |na| {
-                    // Canonicalization of nominal value/tuple construction is a later task.
                     const region = self.parse_ir.tokenizedRegionToRegion(na.region);
-                    const feature = try self.env.insertString("nominal value/tuple construction");
-                    const expr_idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .not_implemented = .{
-                        .feature = feature,
+                    const args_slice = self.parse_ir.store.exprSlice(na.args);
+
+                    if (args_slice.len == 0) {
+                        const malformed_idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
+                            .region = region,
+                        } });
+                        try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, CanonicalizedExpr{ .idx = malformed_idx, .free_vars = DataSpan.empty() });
+                        continue :expr_kernel_loop .dispatch;
+                    }
+
+                    // A single argument backs the nominal value directly; two or more
+                    // arguments are wrapped in a tuple backing expression. We canonicalize
+                    // the backing child through the same stack machinery as nominal_record.
+                    const backing_idx: AST.Expr.Idx = if (args_slice.len == 1)
+                        args_slice[0]
+                    else
+                        try self.parse_ir.store.addExpr(AST.Expr{ .tuple = .{
+                            .items = na.args,
+                            .region = na.region,
+                        } });
+                    const backing_type: CIR.Expr.NominalBackingType = if (args_slice.len == 1) .value else .tuple;
+
+                    try stacks.pushFinishNominalApply(frame_allocator, .{
                         .region = region,
-                    } });
-                    try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, CanonicalizedExpr{ .idx = expr_idx, .free_vars = DataSpan.empty() });
-                    continue :expr_kernel_loop .dispatch;
+                        .mapper = na.mapper,
+                        .backing_type = backing_type,
+                        .captures_top = self.scratch_captures.top(),
+                    });
+                    try stacks.pushParse(frame_allocator, .{ .idx = backing_idx, .target = .scratch });
                 },
                 .record_builder => |rb| {
                     const region = self.parse_ir.tokenizedRegionToRegion(rb.region);
@@ -11803,6 +11824,25 @@ fn runExprKernel(
 
             continue :expr_kernel_loop .dispatch;
         },
+        .finish_nominal_apply => {
+            const state = stacks.takeFinishNominalApply();
+            defer self.scratch_captures.clearFrom(state.captures_top);
+
+            const result_start = child_slots.items.len - 1;
+            const backing_expr = child_slots.items[result_start].expr orelse blk: {
+                const malformed_idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
+                    .region = state.region,
+                } });
+                break :blk CanonicalizedExpr{ .idx = malformed_idx, .free_vars = DataSpan.empty() };
+            };
+
+            const result_expr = try self.finishNominalApplyExpr(state.mapper, backing_expr.idx, state.backing_type, state.region, backing_expr.free_vars);
+
+            child_slots.shrinkRetainingCapacity(result_start);
+            try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, result_expr);
+
+            continue :expr_kernel_loop .dispatch;
+        },
         .finish_record_builder => {
             const state = stacks.takeFinishRecordBuilder();
             defer frame_allocator.free(state.fields);
@@ -13489,6 +13529,248 @@ fn finishNominalRecordForType(
     return CanonicalizedExpr{ .idx = expr_idx, .free_vars = free_vars };
 }
 
+fn finishNominalApplyExpr(
+    self: *Self,
+    mapper_idx: AST.Expr.Idx,
+    backing_expr_idx: Expr.Idx,
+    backing_type: CIR.Expr.NominalBackingType,
+    region: Region,
+    free_vars: DataSpan,
+) std.mem.Allocator.Error!CanonicalizedExpr {
+    const mapper = self.parse_ir.store.getExpr(mapper_idx);
+    return switch (mapper) {
+        .tag => |tag| try self.finishNominalApplyForType(tag, backing_expr_idx, backing_type, region, free_vars),
+        else => CanonicalizedExpr{
+            .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
+                .region = region,
+            } }),
+            .free_vars = DataSpan.empty(),
+        },
+    };
+}
+
+fn finishNominalApplyForType(
+    self: *Self,
+    type_expr: AST.TagExpr,
+    backing_expr_idx: Expr.Idx,
+    backing_type: CIR.Expr.NominalBackingType,
+    region: Region,
+    free_vars: DataSpan,
+) std.mem.Allocator.Error!CanonicalizedExpr {
+    const type_region = self.parse_ir.tokens.resolve(type_expr.token);
+
+    if (type_expr.qualifiers.span.len == 0) {
+        const type_ident = self.parse_ir.tokens.resolveIdentifier(type_expr.token) orelse {
+            return CanonicalizedExpr{
+                .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
+                    .region = region,
+                } }),
+                .free_vars = DataSpan.empty(),
+            };
+        };
+
+        if (try self.scopeLookupOrPrepareTypeDecl(type_ident)) |nominal_type_decl_stmt_idx| {
+            switch (self.env.store.getStatement(nominal_type_decl_stmt_idx)) {
+                .s_nominal_decl => {
+                    const expr_idx = try self.env.addExpr(CIR.Expr{
+                        .e_nominal = .{
+                            .nominal_type_decl = nominal_type_decl_stmt_idx,
+                            .backing_expr = backing_expr_idx,
+                            .backing_type = backing_type,
+                        },
+                    }, region);
+                    return CanonicalizedExpr{ .idx = expr_idx, .free_vars = free_vars };
+                },
+                .s_alias_decl => {
+                    return CanonicalizedExpr{
+                        .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .type_alias_but_needed_nominal = .{
+                            .name = type_ident,
+                            .region = type_region,
+                        } }),
+                        .free_vars = DataSpan.empty(),
+                    };
+                },
+                else => {
+                    return CanonicalizedExpr{
+                        .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
+                            .region = type_region,
+                        } }),
+                        .free_vars = DataSpan.empty(),
+                    };
+                },
+            }
+        }
+
+        if (self.scopeLookupExposedItem(type_ident)) |exposed_info| {
+            const module_name = exposed_info.module_name;
+            const import_idx = self.scopeLookupImportedModule(module_name) orelse {
+                return CanonicalizedExpr{
+                    .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .module_not_imported = .{
+                        .module_name = module_name,
+                        .region = region,
+                    } }),
+                    .free_vars = DataSpan.empty(),
+                };
+            };
+            const imported_type = self.lookupAvailableModuleEnv(module_name) orelse {
+                return CanonicalizedExpr{
+                    .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_not_exposed = .{
+                        .module_name = module_name,
+                        .type_name = type_ident,
+                        .region = type_region,
+                    } }),
+                    .free_vars = DataSpan.empty(),
+                };
+            };
+            const target_node_idx = blk: {
+                if (exposed_info.target) |target| {
+                    if (target.typeDeclNode()) |node_idx| break :blk node_idx;
+                } else {
+                    const original_name_text = self.env.getIdent(exposed_info.original_name);
+                    if (try self.lookupImportedExposedTypeNode(imported_type.env, original_name_text)) |node_idx| break :blk node_idx;
+                }
+                return CanonicalizedExpr{
+                    .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_not_exposed = .{
+                        .module_name = module_name,
+                        .type_name = type_ident,
+                        .region = type_region,
+                    } }),
+                    .free_vars = DataSpan.empty(),
+                };
+            };
+            if (try self.validateImportedNominalTagTarget(Expr.Idx, imported_type.env, target_node_idx, module_name, type_ident, type_region)) |malformed_idx| {
+                return CanonicalizedExpr{ .idx = malformed_idx, .free_vars = DataSpan.empty() };
+            }
+            const expr_idx = try self.env.addExpr(CIR.Expr{
+                .e_nominal_external = .{
+                    .module_idx = import_idx,
+                    .target_node_idx = target_node_idx,
+                    .backing_expr = backing_expr_idx,
+                    .backing_type = backing_type,
+                },
+            }, region);
+            return CanonicalizedExpr{ .idx = expr_idx, .free_vars = free_vars };
+        }
+
+        return CanonicalizedExpr{
+            .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .undeclared_type = .{
+                .name = type_ident,
+                .region = type_region,
+            } }),
+            .free_vars = DataSpan.empty(),
+        };
+    }
+
+    const qualifier_toks = self.parse_ir.store.tokenSlice(type_expr.qualifiers);
+    const strip_tokens = [_]tokenize.Token.Tag{.NoSpaceDotUpperIdent};
+    const first_tok_idx = qualifier_toks[0];
+    const first_tok_ident = self.parse_ir.tokens.resolveIdentifier(first_tok_idx) orelse {
+        return CanonicalizedExpr{
+            .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
+                .region = region,
+            } }),
+            .free_vars = DataSpan.empty(),
+        };
+    };
+    const is_imported = self.scopeLookupModule(first_tok_ident) != null;
+    const full_type_name = self.parse_ir.resolveQualifiedName(type_expr.qualifiers, type_expr.token, &strip_tokens);
+
+    if (!is_imported) {
+        const full_type_ident = try self.env.insertIdent(base.Ident.for_text(full_type_name));
+        const nominal_type_decl_stmt_idx = (try self.scopeLookupOrPrepareTypeDecl(full_type_ident)) orelse {
+            return CanonicalizedExpr{
+                .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .undeclared_type = .{
+                    .name = full_type_ident,
+                    .region = type_region,
+                } }),
+                .free_vars = DataSpan.empty(),
+            };
+        };
+
+        switch (self.env.store.getStatement(nominal_type_decl_stmt_idx)) {
+            .s_nominal_decl => {
+                const expr_idx = try self.env.addExpr(CIR.Expr{
+                    .e_nominal = .{
+                        .nominal_type_decl = nominal_type_decl_stmt_idx,
+                        .backing_expr = backing_expr_idx,
+                        .backing_type = backing_type,
+                    },
+                }, region);
+                return CanonicalizedExpr{ .idx = expr_idx, .free_vars = free_vars };
+            },
+            .s_alias_decl => {
+                return CanonicalizedExpr{
+                    .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .type_alias_but_needed_nominal = .{
+                        .name = full_type_ident,
+                        .region = type_region,
+                    } }),
+                    .free_vars = DataSpan.empty(),
+                };
+            },
+            else => {
+                return CanonicalizedExpr{
+                    .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .expr_not_canonicalized = .{
+                        .region = type_region,
+                    } }),
+                    .free_vars = DataSpan.empty(),
+                };
+            },
+        }
+    }
+
+    const module_info = self.scopeLookupModule(first_tok_ident).?;
+    const module_name = module_info.module_name;
+    const import_idx = self.scopeLookupImportedModule(module_name) orelse {
+        return CanonicalizedExpr{
+            .idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .module_not_imported = .{
+                .module_name = module_name,
+                .region = region,
+            } }),
+            .free_vars = DataSpan.empty(),
+        };
+    };
+
+    const first_alias_len = self.env.getIdent(first_tok_ident).len;
+    std.debug.assert(full_type_name.len > first_alias_len);
+    std.debug.assert(full_type_name[first_alias_len] == '.');
+    const type_name = full_type_name[first_alias_len + 1 ..];
+    const type_name_ident = try self.env.insertIdent(base.Ident.for_text(type_name));
+    const imported_type = self.lookupAvailableModuleEnv(module_name) orelse {
+        return CanonicalizedExpr{
+            .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_from_missing_module = .{
+                .module_name = module_name,
+                .type_name = type_name_ident,
+                .region = type_region,
+            } }),
+            .free_vars = DataSpan.empty(),
+        };
+    };
+    const target_node_idx = (try self.lookupImportedExposedTypeNode(imported_type.env, type_name)) orelse {
+        return CanonicalizedExpr{
+            .idx = try self.env.pushMalformed(Expr.Idx, CIR.Diagnostic{ .type_not_exposed = .{
+                .module_name = module_name,
+                .type_name = type_name_ident,
+                .region = type_region,
+            } }),
+            .free_vars = DataSpan.empty(),
+        };
+    };
+
+    if (try self.validateImportedNominalTagTarget(Expr.Idx, imported_type.env, target_node_idx, module_name, type_name_ident, type_region)) |malformed_idx| {
+        return CanonicalizedExpr{ .idx = malformed_idx, .free_vars = DataSpan.empty() };
+    }
+
+    const expr_idx = try self.env.addExpr(CIR.Expr{
+        .e_nominal_external = .{
+            .module_idx = import_idx,
+            .target_node_idx = target_node_idx,
+            .backing_expr = backing_expr_idx,
+            .backing_type = backing_type,
+        },
+    }, region);
+    return CanonicalizedExpr{ .idx = expr_idx, .free_vars = free_vars };
+}
+
 fn finishTagExprWithArgs(
     self: *Self,
     e: AST.TagExpr,
@@ -14693,6 +14975,7 @@ const ExprKernelLabel = enum {
     finish_if_then_else,
     finish_if_without_else,
     finish_nominal_record,
+    finish_nominal_apply,
     finish_record_builder,
     for_after_list,
     finish_for_expr,
@@ -15032,6 +15315,13 @@ const ExprFinishNominalRecordWork = struct {
     captures_top: u32,
 };
 
+const ExprFinishNominalApplyWork = struct {
+    region: Region,
+    mapper: AST.Expr.Idx,
+    backing_type: CIR.Expr.NominalBackingType,
+    captures_top: u32,
+};
+
 const ExprForAfterListWork = struct {
     region: Region,
     ast_patt: AST.Pattern.Idx,
@@ -15152,6 +15442,7 @@ const ExprKernelWork = struct {
     finish_if_then_else: std.ArrayList(ExprFinishIfThenElseWork) = .empty,
     finish_if_without_else: std.ArrayList(ExprFinishIfWithoutElseWork) = .empty,
     finish_nominal_record: std.ArrayList(ExprFinishNominalRecordWork) = .empty,
+    finish_nominal_apply: std.ArrayList(ExprFinishNominalApplyWork) = .empty,
     finish_record_builder: std.ArrayList(ExprFinishRecordBuilderWork) = .empty,
     for_after_list: std.ArrayList(ExprForAfterListWork) = .empty,
     finish_for_expr: std.ArrayList(ExprFinishForExprWork) = .empty,
@@ -15206,6 +15497,7 @@ const ExprKernelWork = struct {
             .finish_if_then_else => _ = self.takeFinishIfThenElse(),
             .finish_if_without_else => _ = self.takeFinishIfWithoutElse(),
             .finish_nominal_record => _ = self.takeFinishNominalRecord(),
+            .finish_nominal_apply => _ = self.takeFinishNominalApply(),
             .finish_record_builder => _ = self.takeFinishRecordBuilder(),
             .for_after_list => _ = self.takeForAfterList(),
             .finish_for_expr => _ = self.takeFinishForExpr(),
@@ -15289,6 +15581,7 @@ const ExprKernelWork = struct {
         self.finish_if_then_else.deinit(allocator);
         self.finish_if_without_else.deinit(allocator);
         self.finish_nominal_record.deinit(allocator);
+        self.finish_nominal_apply.deinit(allocator);
         self.finish_record_builder.deinit(allocator);
         self.for_after_list.deinit(allocator);
         self.finish_for_expr.deinit(allocator);
@@ -15345,6 +15638,7 @@ const ExprKernelWork = struct {
         self.finish_if_then_else.clearRetainingCapacity();
         self.finish_if_without_else.clearRetainingCapacity();
         self.finish_nominal_record.clearRetainingCapacity();
+        self.finish_nominal_apply.clearRetainingCapacity();
         self.finish_record_builder.clearRetainingCapacity();
         self.for_after_list.clearRetainingCapacity();
         self.finish_for_expr.clearRetainingCapacity();
@@ -15618,6 +15912,12 @@ const ExprKernelWork = struct {
         try self.pushLabel(allocator, .finish_nominal_record, self.current_target);
     }
 
+    inline fn pushFinishNominalApply(self: *ExprKernelWork, allocator: std.mem.Allocator, item: ExprFinishNominalApplyWork) std.mem.Allocator.Error!void {
+        try self.finish_nominal_apply.append(allocator, item);
+        errdefer _ = self.finish_nominal_apply.pop();
+        try self.pushLabel(allocator, .finish_nominal_apply, self.current_target);
+    }
+
     inline fn pushFinishRecordBuilder(self: *ExprKernelWork, allocator: std.mem.Allocator, item: ExprFinishRecordBuilderWork) std.mem.Allocator.Error!void {
         try self.finish_record_builder.append(allocator, item);
         errdefer _ = self.finish_record_builder.pop();
@@ -15836,6 +16136,10 @@ const ExprKernelWork = struct {
 
     inline fn takeFinishNominalRecord(self: *ExprKernelWork) ExprFinishNominalRecordWork {
         return self.finish_nominal_record.pop() orelse unreachable;
+    }
+
+    inline fn takeFinishNominalApply(self: *ExprKernelWork) ExprFinishNominalApplyWork {
+        return self.finish_nominal_apply.pop() orelse unreachable;
     }
 
     inline fn takeFinishRecordBuilder(self: *ExprKernelWork) ExprFinishRecordBuilderWork {

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -9585,6 +9585,17 @@ fn runExprKernel(
                     });
                     try stacks.pushParse(frame_allocator, .{ .idx = nr.backing, .target = .scratch });
                 },
+                .nominal_apply => |na| {
+                    // Canonicalization of nominal value/tuple construction is a later task.
+                    const region = self.parse_ir.tokenizedRegionToRegion(na.region);
+                    const feature = try self.env.insertString("nominal value/tuple construction");
+                    const expr_idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .not_implemented = .{
+                        .feature = feature,
+                        .region = region,
+                    } });
+                    try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, CanonicalizedExpr{ .idx = expr_idx, .free_vars = DataSpan.empty() });
+                    continue :expr_kernel_loop .dispatch;
+                },
                 .record_builder => |rb| {
                     const region = self.parse_ir.tokenizedRegionToRegion(rb.region);
                     const fields_slice = self.parse_ir.store.recordFieldSlice(rb.fields);

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -15814,7 +15814,18 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
                         // If this constraint is already an error, the skip this pass
                         continue;
                     }
-                    if (try self.literalConstraintSatisfiedByNominalBacking(
+                    // Run the builtin-backing walk only when this nominal does not
+                    // define its own literal-conversion method. If it defines its own
+                    // `from_numeral` / `from_quote` / …, that method takes precedence,
+                    // so skip the walk and let the dispatch below resolve and run it.
+                    // Otherwise the walk would validate against the builtin backing and
+                    // shadow the user's own conversion.
+                    const nominal_defines_literal_method = original_env.lookupMethodBindingFromEnvAndDeclConst(
+                        self.cir,
+                        nominal_type.sourceDeclOptional(),
+                        constraint.fn_name,
+                    ) != null;
+                    if (!nominal_defines_literal_method and try self.literalConstraintSatisfiedByNominalBacking(
                         deferred_constraint.var_,
                         constraint,
                         nominal_type,

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -15814,6 +15814,15 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
                         // If this constraint is already an error, the skip this pass
                         continue;
                     }
+                    if (try self.literalConstraintSatisfiedByNominalBacking(
+                        deferred_constraint.var_,
+                        constraint,
+                        nominal_type,
+                        env,
+                        is_numeric_default_pass,
+                    )) {
+                        continue;
+                    }
                     if (!try self.validateFromNumeralLiteralForBuiltinNominal(
                         deferred_constraint.var_,
                         constraint,
@@ -17237,6 +17246,62 @@ fn validateResolvedOpenNumeralLiterals(
             continue;
         }
         _ = try self.reportInvalidBuiltinFromNumeralInfo(resolved.var_, num_kind, entry.info, env);
+    }
+}
+
+fn literalConstraintSatisfiedByNominalBacking(
+    self: *Self,
+    dispatcher_var: Var,
+    constraint: StaticDispatchConstraint,
+    nominal_type: types_mod.NominalType,
+    env: *Env,
+    is_numeric_default_pass: bool,
+) Allocator.Error!bool {
+    const literal_kind = constraint.origin.literalKind() orelse return false;
+    if (!nominal_type.canLiftInner(self.cir.qualified_module_ident)) return false;
+
+    const visited_top = self.scratch_vars.top();
+    defer self.scratch_vars.clearFrom(visited_top);
+
+    var current = nominal_type;
+    while (true) {
+        const backing_var = self.types.getNominalBackingVar(current);
+        const backing_resolved = self.types.resolveVar(backing_var);
+        if (backing_resolved.desc.content != .structure) return false;
+        const backing_flat = backing_resolved.desc.content.structure;
+        if (backing_flat != .nominal_type) return false;
+
+        const backing_nominal = backing_flat.nominal_type;
+        switch (literal_kind) {
+            .numeral => {
+                if (self.builtinNumKindFromNominalType(backing_nominal) != null) {
+                    _ = try self.validateFromNumeralLiteralForBuiltinNominal(
+                        dispatcher_var,
+                        constraint,
+                        backing_nominal,
+                        env,
+                        is_numeric_default_pass,
+                    );
+                    return true;
+                }
+            },
+            .quote => {
+                if (self.nominalIsBuiltinStrType(backing_nominal)) return true;
+            },
+            .interpolation => {
+                if (self.nominalIsBuiltinStrType(backing_nominal)) {
+                    _ = try self.satisfyBuiltinStrInterpolation(dispatcher_var, constraint, env);
+                    return true;
+                }
+            },
+        }
+
+        for (self.scratch_vars.sliceFromStart(visited_top)) |visited_var| {
+            const visited_resolved = self.types.resolveVar(visited_var);
+            if (visited_resolved.desc_idx == backing_resolved.desc_idx) return false;
+        }
+        try self.scratch_vars.append(backing_var);
+        current = backing_nominal;
     }
 }
 

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -17296,6 +17296,13 @@ fn literalConstraintSatisfiedByNominalBacking(
             },
         }
 
+        // `backing_nominal` didn't match the terminal builtin above, so we are
+        // about to lift *through* it to a deeper backing. Re-check opacity at
+        // this level: a literal must not be coerced through an opaque boundary
+        // this module is not allowed to see past, even when the outer nominal
+        // is transparent.
+        if (!backing_nominal.canLiftInner(self.cir.qualified_module_ident)) return false;
+
         for (self.scratch_vars.sliceFromStart(visited_top)) |visited_var| {
             const visited_resolved = self.types.resolveVar(visited_var);
             if (visited_resolved.desc_idx == backing_resolved.desc_idx) return false;

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -17303,11 +17303,14 @@ fn literalConstraintSatisfiedByNominalBacking(
         // is transparent.
         if (!backing_nominal.canLiftInner(self.cir.qualified_module_ident)) return false;
 
+        // Cycle guard: store and compare already-resolved representative vars so
+        // we never re-resolve a visited entry. A representative var is 1:1 with
+        // its descriptor, so this is equivalent to the previous desc_idx compare
+        // but avoids the per-iteration resolveVar (no O(depth) work per step).
         for (self.scratch_vars.sliceFromStart(visited_top)) |visited_var| {
-            const visited_resolved = self.types.resolveVar(visited_var);
-            if (visited_resolved.desc_idx == backing_resolved.desc_idx) return false;
+            if (visited_var == backing_resolved.var_) return false;
         }
-        try self.scratch_vars.append(backing_var);
+        try self.scratch_vars.append(backing_resolved.var_);
         current = backing_nominal;
     }
 }

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -4823,6 +4823,54 @@ test "check type - primitive-backed nominal lifts string literal" {
     try checkTypesModule(source, .{ .pass = .last_def }, "Token");
 }
 
+test "check type - explicit value-backed nominal construction" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Distance := U64
+        \\
+        \\toDistance : U64 -> Distance
+        \\toDistance = |n| Distance.(n)
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "U64 -> Distance");
+}
+
+test "check type - bare value does not lift into nominal" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Distance := U64
+        \\
+        \\toDistance : U64 -> Distance
+        \\toDistance = |n| n
+    ;
+    try checkTypesModule(source, .fail, "TYPE MISMATCH");
+}
+
+test "check type - explicit construction backing mismatch" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Distance := U64
+        \\
+        \\d : Distance
+        \\d = Distance.("x")
+    ;
+    try checkTypesModule(source, .fail, "TYPE MISMATCH");
+}
+
+test "check type - opaque nominal construction in defining module" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Secret :: U64
+        \\
+        \\s : Secret
+        \\s = Secret.(7)
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "Secret");
+}
+
 // early return //
 
 test "check type - early return - pass" {

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -4855,6 +4855,26 @@ test "check type - builtin-backed nominal does not inherit backing methods" {
     try checkTypesModule(source, .fail, "MISSING METHOD");
 }
 
+test "check type - custom from_numeral wins over builtin-backing validation" {
+    // `Tiny` is U8-backed but defines its OWN `from_numeral` that accepts any
+    // numeral (it ignores the value and yields Tiny.(0)). The literal `300` does
+    // NOT fit U8, so if the builtin-backing walk shadowed the custom method we'd
+    // get an InvalidNumeral error. The custom `from_numeral` must take precedence,
+    // so this should type-check cleanly.
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Tiny := U8.{
+        \\    from_numeral : Numeral -> Try(Tiny, [InvalidNumeral(Str)])
+        \\    from_numeral = |_| Ok(Tiny.(0))
+        \\}
+        \\
+        \\t : Tiny
+        \\t = 300
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "Tiny");
+}
+
 test "check type - explicit value-backed nominal construction" {
     const source =
         \\main! = |_| {}

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -4799,6 +4799,30 @@ test "check type - nested same-module mutually recursive nominal types" {
     try checkTypesModule(source, .{ .pass = .{ .def = "mk" } }, "{} -> Tree");
 }
 
+test "check type - primitive-backed nominal lifts numeric literal" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Distance := U64
+        \\
+        \\d : Distance
+        \\d = 0
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "Distance");
+}
+
+test "check type - primitive-backed nominal lifts string literal" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Token := Str
+        \\
+        \\token : Token
+        \\token = "abc"
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "Token");
+}
+
 // early return //
 
 test "check type - early return - pass" {

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -4823,6 +4823,38 @@ test "check type - primitive-backed nominal lifts string literal" {
     try checkTypesModule(source, .{ .pass = .last_def }, "Token");
 }
 
+test "check type - multi-level numeric nominal chain lifts numeric literal" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Inner := U64
+        \\Outer := Inner
+        \\
+        \\x : Outer
+        \\x = 0
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "Outer");
+}
+
+test "check type - builtin-backed nominal does not inherit backing methods" {
+    // A literal lifts into `Distance` because `from_numeral` is inherited from
+    // the `U64` backing (the backing-chain walk). Other methods are NOT inherited
+    // that way: `+` requires `Distance` to provide `add`, which it does not, so
+    // this is a MISSING METHOD error — not a TYPE MISMATCH. This pins the
+    // asymmetry: only the literal conversion rides through the backing chain.
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Distance := U64
+        \\
+        \\d : Distance
+        \\d = 0
+        \\
+        \\total = d + d
+    ;
+    try checkTypesModule(source, .fail, "MISSING METHOD");
+}
+
 test "check type - explicit value-backed nominal construction" {
     const source =
         \\main! = |_| {}

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -1835,6 +1835,14 @@ const Formatter = struct {
                     },
                 }
             },
+            .nominal_apply => |na| {
+                // Format nominal value/tuple construction: Type.(arg1, arg2, ...)
+                try fmt.formatExprDiscard(na.mapper);
+                try fmt.push('.');
+                const mapper_region = fmt.nodeRegion(@intFromEnum(na.mapper));
+                const args_region = AST.TokenizedRegion{ .start = mapper_region.end, .end = region.end };
+                try fmt.formatCollection(args_region, .round, AST.Expr.Idx, fmt.ast.store.exprSlice(na.args), Formatter.formatExpr);
+            },
             .malformed => {
                 // Output nothing for malformed node
             },
@@ -3173,6 +3181,13 @@ const Formatter = struct {
                         }
 
                         return fmt.nodesWillBeMultiline(AST.Expr.Idx, fmt.ast.store.exprSlice(m.args));
+                    },
+                    .nominal_apply => |na| {
+                        if (fmt.nodeWillBeMultiline(AST.Expr.Idx, na.mapper)) {
+                            return true;
+                        }
+
+                        return fmt.nodesWillBeMultiline(AST.Expr.Idx, fmt.ast.store.exprSlice(na.args));
                     },
                     .lambda => |l| {
                         if (fmt.nodeWillBeMultiline(AST.Expr.Idx, l.body)) {

--- a/src/lsp/handlers/selection_range.zig
+++ b/src/lsp/handlers/selection_range.zig
@@ -462,6 +462,12 @@ fn collectContainingRegionsFromExpr(
             try collectContainingRegionsFromExpr(allocator, ast, nr.mapper, target_offset, regions);
             try collectContainingRegionsFromExpr(allocator, ast, nr.backing, target_offset, regions);
         },
+        .nominal_apply => |na| {
+            try collectContainingRegionsFromExpr(allocator, ast, na.mapper, target_offset, regions);
+            for (ast.store.exprSlice(na.args)) |arg| {
+                try collectContainingRegionsFromExpr(allocator, ast, arg, target_offset, regions);
+            }
+        },
         .for_expr => |f| {
             try collectContainingRegionsFromExpr(allocator, ast, f.expr, target_offset, regions);
             try collectContainingRegionsFromExpr(allocator, ast, f.body, target_offset, regions);

--- a/src/parse/AST.zig
+++ b/src/parse/AST.zig
@@ -2901,6 +2901,11 @@ pub const Expr = union(enum) {
         backing: Expr.Idx,
         region: TokenizedRegion,
     },
+    nominal_apply: struct {
+        mapper: Expr.Idx,
+        args: Expr.Span,
+        region: TokenizedRegion,
+    },
     ellipsis: struct {
         region: TokenizedRegion,
     },
@@ -2980,6 +2985,7 @@ pub const Expr = union(enum) {
             .block => |e| e.region,
             .record_builder => |e| e.region,
             .nominal_record => |e| e.region,
+            .nominal_apply => |e| e.region,
             .ellipsis => |e| e.region,
             .@"break" => |e| e.region,
             .@"return" => |e| e.region,
@@ -3330,6 +3336,24 @@ pub const Expr = union(enum) {
                 try ast.store.getExpr(a.backing).pushToSExprTree(gpa, env, ast, tree);
                 const backing_attrs = tree.beginNode();
                 try tree.endNode(backing_wrapper, backing_attrs);
+
+                try tree.endNode(begin, attrs);
+            },
+            .nominal_apply => |a| {
+                const begin = tree.beginNode();
+                try tree.pushStaticAtom("e-nominal-apply");
+                try ast.appendRegionInfoToSexprTree(env, tree, a.region);
+                const attrs = tree.beginNode();
+
+                const mapper_wrapper = tree.beginNode();
+                try tree.pushStaticAtom("mapper");
+                try ast.store.getExpr(a.mapper).pushToSExprTree(gpa, env, ast, tree);
+                const mapper_attrs = tree.beginNode();
+                try tree.endNode(mapper_wrapper, mapper_attrs);
+
+                for (ast.store.exprSlice(a.args)) |arg_idx| {
+                    try ast.store.getExpr(arg_idx).pushToSExprTree(gpa, env, ast, tree);
+                }
 
                 try tree.endNode(begin, attrs);
             },

--- a/src/parse/Node.zig
+++ b/src/parse/Node.zig
@@ -492,6 +492,10 @@ pub const Tag = enum {
     /// * lhs - mapper/type expression
     /// * rhs - backing record expression
     nominal_record,
+    /// Direct nominal value/tuple construction: Type.(arg1, arg2, ...)
+    /// * lhs - mapper/type expression
+    /// * rhs - extra_data index of [args.span.start, args.span.len]
+    nominal_apply,
     /// A block of statements
     /// Main token is newline preceding the block
     /// * lhs - first statement node

--- a/src/parse/NodeStore.zig
+++ b/src/parse/NodeStore.zig
@@ -1071,6 +1071,15 @@ pub fn addExpr(store: *NodeStore, expr: AST.Expr) std.mem.Allocator.Error!AST.Ex
             node.data.lhs = @intFromEnum(nr.mapper);
             node.data.rhs = @intFromEnum(nr.backing);
         },
+        .nominal_apply => |na| {
+            node.tag = .nominal_apply;
+            node.region = na.region;
+            node.data.lhs = @intFromEnum(na.mapper);
+            const args_data_idx = store.extra_data.items.len;
+            try store.extra_data.append(store.gpa, na.args.span.start);
+            try store.extra_data.append(store.gpa, na.args.span.len);
+            node.data.rhs = @as(u32, @intCast(args_data_idx));
+        },
         .block => |body| {
             node.tag = .block;
             node.region = body.region;
@@ -2186,6 +2195,17 @@ pub fn getExpr(store: *const NodeStore, expr_idx: AST.Expr.Idx) AST.Expr {
             return .{ .nominal_record = .{
                 .mapper = @enumFromInt(node.data.lhs),
                 .backing = @enumFromInt(node.data.rhs),
+                .region = node.region,
+            } };
+        },
+        .nominal_apply => {
+            const args_data_idx = @as(usize, @intCast(node.data.rhs));
+            return .{ .nominal_apply = .{
+                .mapper = @enumFromInt(node.data.lhs),
+                .args = .{ .span = .{
+                    .start = store.extra_data.items[args_data_idx],
+                    .len = store.extra_data.items[args_data_idx + 1],
+                } },
                 .region = node.region,
             } };
         },

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -2154,6 +2154,7 @@ const ExprCollectionResult = union(enum) {
     tuple,
     apply: ExprAfterApplyArgsState,
     method_apply: ExprAfterMethodArgsState,
+    nominal_apply: ExprAfterNominalApplyArgsState,
     arrow_apply: ExprArrowAppAfterArgsState,
 };
 
@@ -2177,6 +2178,12 @@ const ExprAfterMethodArgsState = struct {
     min_bp: u8,
     receiver: AST.Expr.Idx,
     method_token: Token.Idx,
+};
+
+const ExprAfterNominalApplyArgsState = struct {
+    start: Token.Idx,
+    min_bp: u8,
+    mapper: AST.Expr.Idx,
 };
 
 const ExprAfterBinaryRhsState = struct {
@@ -3343,6 +3350,24 @@ fn runExprStatementKernel(
                 continue :expr_kernel .record_fields_next;
             }
 
+            if (tok == .Dot and self.peekN(1) == .NoSpaceOpenRound) {
+                self.advance();
+                self.advance();
+                try expr_collections.enter(open_allocator, .{
+                    .start = expr_finish_state.start,
+                    .min_bp = null,
+                    .scratch_top = self.store.scratchExprTop(),
+                    .end_token = .CloseRound,
+                    .result = .{ .nominal_apply = .{
+                        .start = expr_finish_state.start,
+                        .min_bp = expr_finish_state.min_bp,
+                        .mapper = expr_finish_state.expr,
+                    } },
+                    .close_error = .expected_expr_apply_close_round,
+                });
+                continue :expr_kernel .collection_next;
+            }
+
             if (tok_int < @intFromEnum(Token.Tag.OpenRound)) {
                 if (tok == .NoSpaceDotInt or tok == .DotInt) {
                     const elem_token = self.pos;
@@ -3961,6 +3986,15 @@ fn runExprStatementKernel(
                                 .region = .{ .start = method_state.start, .end = self.pos },
                             } });
                             expr_finish_state = .{ .start = method_state.start, .min_bp = method_state.min_bp, .expr = expr };
+                            continue :expr_kernel .suffix;
+                        },
+                        .nominal_apply => |nominal_state| {
+                            const expr = try self.store.addExpr(.{ .nominal_apply = .{
+                                .mapper = nominal_state.mapper,
+                                .args = span,
+                                .region = .{ .start = nominal_state.start, .end = self.pos },
+                            } });
+                            expr_finish_state = .{ .start = nominal_state.start, .min_bp = nominal_state.min_bp, .expr = expr };
                             continue :expr_kernel .suffix;
                         },
                         .arrow_apply => |arrow_state| {

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -3350,7 +3350,12 @@ fn runExprStatementKernel(
                 continue :expr_kernel .record_fields_next;
             }
 
-            if (tok == .Dot and self.peekN(1) == .NoSpaceOpenRound) {
+            // `Type.(args)` nominal value/tuple construction. Only treat `.(` as
+            // construction when the mapper is a tag/type path (`Distance`,
+            // `Module.Type`); for any other mapper (e.g. `0.(`) leave the tokens
+            // unconsumed so it surfaces as a parse error instead of a construction
+            // node canonicalization would only reject.
+            if (tok == .Dot and self.peekN(1) == .NoSpaceOpenRound and self.store.getExpr(expr_finish_state.expr) == .tag) {
                 self.advance();
                 self.advance();
                 try expr_collections.enter(open_allocator, .{

--- a/src/parse/test/ast_node_store_test.zig
+++ b/src/parse/test/ast_node_store_test.zig
@@ -836,6 +836,13 @@ test "NodeStore round trip - Expr" {
         },
     });
     try expressions.append(gpa, AST.Expr{
+        .nominal_apply = .{
+            .mapper = rand_idx(random, AST.Expr.Idx),
+            .args = AST.Expr.Span{ .span = rand_span(random) },
+            .region = rand_region(random),
+        },
+    });
+    try expressions.append(gpa, AST.Expr{
         .ellipsis = .{ .region = rand_region(random) },
     });
     try expressions.append(gpa, AST.Expr{

--- a/test/snapshots/expr/nominal_tuple_construction.md
+++ b/test/snapshots/expr/nominal_tuple_construction.md
@@ -1,0 +1,37 @@
+# META
+~~~ini
+description=Nominal tuple construction syntax
+type=expr
+~~~
+# SOURCE
+~~~roc
+Pair.(1, 2)
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+UpperIdent,Dot,NoSpaceOpenRound,Int,Comma,Int,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-nominal-apply
+	(mapper (e-tag (raw "Pair")))
+	(e-int (raw "1"))
+	(e-int (raw "2")))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-runtime-error (tag "not_implemented"))
+~~~
+# TYPES
+~~~clojure
+(expr (type "Error"))
+~~~

--- a/test/snapshots/expr/nominal_tuple_construction.md
+++ b/test/snapshots/expr/nominal_tuple_construction.md
@@ -1,11 +1,14 @@
 # META
 ~~~ini
-description=Nominal tuple construction syntax
-type=expr
+description=Nominal tuple construction with Type.(a, b) syntax
+type=snippet
 ~~~
 # SOURCE
 ~~~roc
-Pair.(1, 2)
+Pair := (U64, Str)
+
+p : Pair
+p = Pair.(1, "x")
 ~~~
 # EXPECTED
 NIL
@@ -13,15 +16,31 @@ NIL
 NIL
 # TOKENS
 ~~~zig
-UpperIdent,Dot,NoSpaceOpenRound,Int,Comma,Int,CloseRound,
+UpperIdent,OpColonEqual,OpenRound,UpperIdent,Comma,UpperIdent,CloseRound,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,UpperIdent,Dot,NoSpaceOpenRound,Int,Comma,StringStart,StringPart,StringEnd,CloseRound,
 EndOfFile,
 ~~~
 # PARSE
 ~~~clojure
-(e-nominal-apply
-	(mapper (e-tag (raw "Pair")))
-	(e-int (raw "1"))
-	(e-int (raw "2")))
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "Pair")
+				(args))
+			(ty-tuple
+				(ty (name "U64"))
+				(ty (name "Str"))))
+		(s-type-anno (name "p")
+			(ty (name "Pair")))
+		(s-decl
+			(p-ident (raw "p"))
+			(e-nominal-apply
+				(mapper (e-tag (raw "Pair")))
+				(e-int (raw "1"))
+				(e-string
+					(e-string-part (raw "x")))))))
 ~~~
 # FORMATTED
 ~~~roc
@@ -29,9 +48,31 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-runtime-error (tag "not_implemented"))
+(can-ir
+	(d-let
+		(p-assign (ident "p"))
+		(e-nominal (nominal "Pair")
+			(e-tuple
+				(elems
+					(e-num (value "1"))
+					(e-string
+						(e-literal (string "x"))))))
+		(annotation
+			(ty-lookup (name "Pair") (local))))
+	(s-nominal-decl
+		(ty-header (name "Pair"))
+		(ty-tuple
+			(ty-lookup (name "U64") (builtin))
+			(ty-lookup (name "Str") (builtin)))))
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Error"))
+(inferred-types
+	(defs
+		(patt (type "Pair")))
+	(type_decls
+		(nominal (type "Pair")
+			(ty-header (name "Pair"))))
+	(expressions
+		(expr (type "Pair"))))
 ~~~

--- a/test/snapshots/expr/nominal_value_construction.md
+++ b/test/snapshots/expr/nominal_value_construction.md
@@ -1,0 +1,36 @@
+# META
+~~~ini
+description=Nominal value construction syntax
+type=expr
+~~~
+# SOURCE
+~~~roc
+Distance.(26)
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+UpperIdent,Dot,NoSpaceOpenRound,Int,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-nominal-apply
+	(mapper (e-tag (raw "Distance")))
+	(e-int (raw "26")))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-runtime-error (tag "not_implemented"))
+~~~
+# TYPES
+~~~clojure
+(expr (type "Error"))
+~~~

--- a/test/snapshots/expr/nominal_value_construction.md
+++ b/test/snapshots/expr/nominal_value_construction.md
@@ -1,11 +1,14 @@
 # META
 ~~~ini
-description=Nominal value construction syntax
-type=expr
+description=Nominal value construction with Type.(value) syntax
+type=snippet
 ~~~
 # SOURCE
 ~~~roc
-Distance.(26)
+Distance := U64
+
+d : Distance
+d = Distance.(26)
 ~~~
 # EXPECTED
 NIL
@@ -13,14 +16,27 @@ NIL
 NIL
 # TOKENS
 ~~~zig
-UpperIdent,Dot,NoSpaceOpenRound,Int,CloseRound,
+UpperIdent,OpColonEqual,UpperIdent,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,UpperIdent,Dot,NoSpaceOpenRound,Int,CloseRound,
 EndOfFile,
 ~~~
 # PARSE
 ~~~clojure
-(e-nominal-apply
-	(mapper (e-tag (raw "Distance")))
-	(e-int (raw "26")))
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "Distance")
+				(args))
+			(ty (name "U64")))
+		(s-type-anno (name "d")
+			(ty (name "Distance")))
+		(s-decl
+			(p-ident (raw "d"))
+			(e-nominal-apply
+				(mapper (e-tag (raw "Distance")))
+				(e-int (raw "26"))))))
 ~~~
 # FORMATTED
 ~~~roc
@@ -28,9 +44,25 @@ NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
-(e-runtime-error (tag "not_implemented"))
+(can-ir
+	(d-let
+		(p-assign (ident "d"))
+		(e-nominal (nominal "Distance")
+			(e-num (value "26")))
+		(annotation
+			(ty-lookup (name "Distance") (local))))
+	(s-nominal-decl
+		(ty-header (name "Distance"))
+		(ty-lookup (name "U64") (builtin))))
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Error"))
+(inferred-types
+	(defs
+		(patt (type "Distance")))
+	(type_decls
+		(nominal (type "Distance")
+			(ty-header (name "Distance"))))
+	(expressions
+		(expr (type "Distance"))))
 ~~~

--- a/test/snapshots/fuzz_crash/fuzz_crash_081.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_081.md
@@ -8,18 +8,42 @@ type=snippet
 x = 0.()
 ~~~
 # EXPECTED
-UNRECOGNIZED SYNTAX - fuzz_crash_081.md:1:5:1:9
+PARSE ERROR - fuzz_crash_081.md:1:6:1:7
+PARSE ERROR - fuzz_crash_081.md:1:7:1:8
+PARSE ERROR - fuzz_crash_081.md:1:8:1:9
 # PROBLEMS
-**UNRECOGNIZED SYNTAX**
-I don't recognize this syntax.
+**PARSE ERROR**
+A parsing error occurred: `statement_unexpected_token`
+This is an unexpected parsing error. Please check your syntax.
 
-**fuzz_crash_081.md:1:5:1:9:**
+**fuzz_crash_081.md:1:6:1:7:**
 ```roc
 x = 0.()
 ```
-    ^^^^
+     ^
 
-This might be a syntax error, an unsupported language feature, or a typo.
+
+**PARSE ERROR**
+A parsing error occurred: `statement_unexpected_token`
+This is an unexpected parsing error. Please check your syntax.
+
+**fuzz_crash_081.md:1:7:1:8:**
+```roc
+x = 0.()
+```
+      ^
+
+
+**PARSE ERROR**
+A parsing error occurred: `statement_unexpected_token`
+This is an unexpected parsing error. Please check your syntax.
+
+**fuzz_crash_081.md:1:8:1:9:**
+```roc
+x = 0.()
+```
+       ^
+
 
 # TOKENS
 ~~~zig
@@ -33,25 +57,27 @@ EndOfFile,
 	(statements
 		(s-decl
 			(p-ident (raw "x"))
-			(e-nominal-apply
-				(mapper (e-int (raw "0")))))))
+			(e-int (raw "0")))
+		(s-malformed (tag "statement_unexpected_token"))
+		(s-malformed (tag "statement_unexpected_token"))
+		(s-malformed (tag "statement_unexpected_token"))))
 ~~~
 # FORMATTED
 ~~~roc
-NO CHANGE
+x = 0
 ~~~
 # CANONICALIZE
 ~~~clojure
 (can-ir
 	(d-let
 		(p-assign (ident "x"))
-		(e-runtime-error (tag "expr_not_canonicalized"))))
+		(e-num (value "0"))))
 ~~~
 # TYPES
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "Error")))
+		(patt (type "Dec")))
 	(expressions
-		(expr (type "Error"))))
+		(expr (type "Dec"))))
 ~~~

--- a/test/snapshots/fuzz_crash/fuzz_crash_081.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_081.md
@@ -8,41 +8,18 @@ type=snippet
 x = 0.()
 ~~~
 # EXPECTED
-PARSE ERROR - fuzz_crash_081.md:1:6:1:7
-PARSE ERROR - fuzz_crash_081.md:1:7:1:8
-PARSE ERROR - fuzz_crash_081.md:1:8:1:9
+NOT IMPLEMENTED - fuzz_crash_081.md:1:5:1:9
 # PROBLEMS
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
+**NOT IMPLEMENTED**
+This feature is not yet implemented: nominal value/tuple construction
 
-**fuzz_crash_081.md:1:6:1:7:**
+**fuzz_crash_081.md:1:5:1:9:**
 ```roc
 x = 0.()
 ```
-     ^
+    ^^^^
 
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**fuzz_crash_081.md:1:7:1:8:**
-```roc
-x = 0.()
-```
-      ^
-
-
-**PARSE ERROR**
-A parsing error occurred: `statement_unexpected_token`
-This is an unexpected parsing error. Please check your syntax.
-
-**fuzz_crash_081.md:1:8:1:9:**
-```roc
-x = 0.()
-```
-       ^
+This error doesn't have a proper diagnostic report yet. Let us know if you want to help improve Roc's error messages!
 
 
 # TOKENS
@@ -57,27 +34,25 @@ EndOfFile,
 	(statements
 		(s-decl
 			(p-ident (raw "x"))
-			(e-int (raw "0")))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))))
+			(e-nominal-apply
+				(mapper (e-int (raw "0")))))))
 ~~~
 # FORMATTED
 ~~~roc
-x = 0
+NO CHANGE
 ~~~
 # CANONICALIZE
 ~~~clojure
 (can-ir
 	(d-let
 		(p-assign (ident "x"))
-		(e-num (value "0"))))
+		(e-runtime-error (tag "not_implemented"))))
 ~~~
 # TYPES
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "Dec")))
+		(patt (type "Error")))
 	(expressions
-		(expr (type "Dec"))))
+		(expr (type "Error"))))
 ~~~

--- a/test/snapshots/fuzz_crash/fuzz_crash_081.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_081.md
@@ -8,10 +8,10 @@ type=snippet
 x = 0.()
 ~~~
 # EXPECTED
-NOT IMPLEMENTED - fuzz_crash_081.md:1:5:1:9
+UNRECOGNIZED SYNTAX - fuzz_crash_081.md:1:5:1:9
 # PROBLEMS
-**NOT IMPLEMENTED**
-This feature is not yet implemented: nominal value/tuple construction
+**UNRECOGNIZED SYNTAX**
+I don't recognize this syntax.
 
 **fuzz_crash_081.md:1:5:1:9:**
 ```roc
@@ -19,8 +19,7 @@ x = 0.()
 ```
     ^^^^
 
-This error doesn't have a proper diagnostic report yet. Let us know if you want to help improve Roc's error messages!
-
+This might be a syntax error, an unsupported language feature, or a typo.
 
 # TOKENS
 ~~~zig
@@ -46,7 +45,7 @@ NO CHANGE
 (can-ir
 	(d-let
 		(p-assign (ident "x"))
-		(e-runtime-error (tag "not_implemented"))))
+		(e-runtime-error (tag "expr_not_canonicalized"))))
 ~~~
 # TYPES
 ~~~clojure

--- a/test/snapshots/issue/nominal_primitive_literal_construction.md
+++ b/test/snapshots/issue/nominal_primitive_literal_construction.md
@@ -1,54 +1,35 @@
 # META
 ~~~ini
-description=Error types should propagate through aliases when underscores are used
+description=Primitive-backed nominal types accept matching number/string literals
 type=snippet
 ~~~
 # SOURCE
 ~~~roc
-BadBase := _
+UserId := U64
 
-BadDerived := BadBase
+uid : UserId
+uid = 0
 
-value : BadDerived
-value = "test"
+Token := Str
+
+token : Token
+token = "abc"
 
 GoodBase := Str
-
 GoodDerived := GoodBase
 
 goodValue : GoodDerived
 goodValue = "test"
 ~~~
 # EXPECTED
-UNDERSCORE IN TYPE ALIAS - underscore_error_propagation.md:1:1:1:1
-TYPE MISMATCH - underscore_error_propagation.md:6:9:6:15
+NIL
 # PROBLEMS
-**UNDERSCORE IN TYPE ALIAS**
-Underscores are not allowed in type alias declarations.
-
-**underscore_error_propagation.md:1:1:1:1:**
-```roc
-BadBase := _
-```
-^
-
-Underscores in type annotations mean "I don't care about this type", which doesn't make sense when declaring a type. If you need a placeholder type variable, use a named type variable like `a` instead.
-
-**TYPE MISMATCH**
-This string literal is being used where a non-string type is needed:
-**underscore_error_propagation.md:6:9:6:15:**
-```roc
-value = "test"
-```
-        ^^^^^^
-
-The type was determined to be:
-
-    BadDerived
-
+NIL
 # TOKENS
 ~~~zig
-UpperIdent,OpColonEqual,Underscore,
+UpperIdent,OpColonEqual,UpperIdent,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,Int,
 UpperIdent,OpColonEqual,UpperIdent,
 LowerIdent,OpColon,UpperIdent,
 LowerIdent,OpAssign,StringStart,StringPart,StringEnd,
@@ -64,19 +45,24 @@ EndOfFile,
 	(type-module)
 	(statements
 		(s-type-decl
-			(header (name "BadBase")
+			(header (name "UserId")
 				(args))
-			(_))
-		(s-type-decl
-			(header (name "BadDerived")
-				(args))
-			(ty (name "BadBase")))
-		(s-type-anno (name "value")
-			(ty (name "BadDerived")))
+			(ty (name "U64")))
+		(s-type-anno (name "uid")
+			(ty (name "UserId")))
 		(s-decl
-			(p-ident (raw "value"))
+			(p-ident (raw "uid"))
+			(e-int (raw "0")))
+		(s-type-decl
+			(header (name "Token")
+				(args))
+			(ty (name "Str")))
+		(s-type-anno (name "token")
+			(ty (name "Token")))
+		(s-decl
+			(p-ident (raw "token"))
 			(e-string
-				(e-string-part (raw "test"))))
+				(e-string-part (raw "abc"))))
 		(s-type-decl
 			(header (name "GoodBase")
 				(args))
@@ -94,17 +80,37 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-NO CHANGE
+UserId := U64
+
+uid : UserId
+uid = 0
+
+Token := Str
+
+token : Token
+token = "abc"
+
+GoodBase := Str
+
+GoodDerived := GoodBase
+
+goodValue : GoodDerived
+goodValue = "test"
 ~~~
 # CANONICALIZE
 ~~~clojure
 (can-ir
 	(d-let
-		(p-assign (ident "value"))
-		(e-string
-			(e-literal (string "test")))
+		(p-assign (ident "uid"))
+		(e-num (value "0"))
 		(annotation
-			(ty-lookup (name "BadDerived") (local))))
+			(ty-lookup (name "UserId") (local))))
+	(d-let
+		(p-assign (ident "token"))
+		(e-string
+			(e-literal (string "abc")))
+		(annotation
+			(ty-lookup (name "Token") (local))))
 	(d-let
 		(p-assign (ident "goodValue"))
 		(e-string
@@ -112,11 +118,11 @@ NO CHANGE
 		(annotation
 			(ty-lookup (name "GoodDerived") (local))))
 	(s-nominal-decl
-		(ty-header (name "BadBase"))
-		(ty-underscore))
+		(ty-header (name "UserId"))
+		(ty-lookup (name "U64") (builtin)))
 	(s-nominal-decl
-		(ty-header (name "BadDerived"))
-		(ty-lookup (name "BadBase") (local)))
+		(ty-header (name "Token"))
+		(ty-lookup (name "Str") (builtin)))
 	(s-nominal-decl
 		(ty-header (name "GoodBase"))
 		(ty-lookup (name "Str") (builtin)))
@@ -128,18 +134,20 @@ NO CHANGE
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "BadDerived"))
+		(patt (type "UserId"))
+		(patt (type "Token"))
 		(patt (type "GoodDerived")))
 	(type_decls
-		(nominal (type "BadBase")
-			(ty-header (name "BadBase")))
-		(nominal (type "BadDerived")
-			(ty-header (name "BadDerived")))
+		(nominal (type "UserId")
+			(ty-header (name "UserId")))
+		(nominal (type "Token")
+			(ty-header (name "Token")))
 		(nominal (type "GoodBase")
 			(ty-header (name "GoodBase")))
 		(nominal (type "GoodDerived")
 			(ty-header (name "GoodDerived"))))
 	(expressions
-		(expr (type "BadDerived"))
+		(expr (type "UserId"))
+		(expr (type "Token"))
 		(expr (type "GoodDerived"))))
 ~~~


### PR DESCRIPTION
## Summary

Resolves #9770. You can now **construct values of nominal types backed by a primitive, value, or tuple** — both implicitly (a literal where the nominal is expected) and explicitly with new construction syntax. Previously only record- and tag-union-backed nominals could be constructed; a primitive-backed nominal like `Distance := U64` could be *declared* but never instantiated, so any attempt failed with a `TYPE MISMATCH`.

## New nominal construction

Construction is **expression-directed** and named like a tag — you name the type and give it its backing value. This activates the previously-dead `value`/`tuple` nominal backing variants end-to-end (parse → canonicalize → type-check), reusing the existing `checkNominalTypeUsage` path that already handled record and tag backings (so the type-checker needed no new logic for the new variants).

## New syntax

`Nominal.(…)` — dot-paren — for value and tuple backings, alongside the existing record and tag forms:

```roc
Distance := U64
Pair := (U64, Str)
Point := { x : U64, y : U64 }
Color := [Red, Green, Blue]

d = Distance.(26)          # value backing    (NEW)
pair = Pair.(1, "two")     # tuple backing    (NEW)
p = Point.{ x: 1, y: 2 }   # record backing   (existing)
c = Color.Red              # tag backing      (existing)
```

Arity decides value vs tuple (one arg → `.value`, two or more → `.tuple`). The `.(` form only begins construction after a type/tag path (`Distance`, `Module.Type`); any other mapper (e.g. `0.(`) is a parse error.

## Lifting to a nominal

A **literal** lifts into a nominal implicitly when an expected type supplies the identity — the documented langref behavior — by resolving the literal's `from_numeral`/`from_quote` conversion against the nominal's backing, walking transparent newtype chains:

```roc
UserId := U64
uid : UserId
uid = 0                    # the literal 0 becomes a UserId

Token := Str
token : Token
token = "abc"              # the literal "abc" becomes a Token
```

A value that already has a concrete type does **not** silently lift — two nominals of different identity never unify. To wrap such a value, construct it explicitly:

```roc
toDistance : U64 -> Distance
toDistance = |n| Distance.(n)   # `|n| n` would be a TYPE MISMATCH: a U64 is not a Distance
```

## Corrected code from the issue

The issue's associated-constructor reproduction used `new = |d| d`, which is **not** valid — it relied on an implicit lift this PR intentionally does not allow. With the new construction syntax it becomes:

```roc
Distance := U64.{
    new : U64 -> Distance
    new = |d| Distance.(d)   # was `|d| d` in the issue — now explicit construction
}

main! = |_| {
    d = Distance.new(123)
    dbg d
    Ok({})
}
```

And the bare-annotation form from the issue now works directly via literal lifting:

```roc
Distance := U64
d : Distance
d = 0                        # the literal lifts into Distance
```

## Notes / follow-ups

- The literal backing-chain walk re-checks opacity **at each level**, so a literal cannot be coerced through a foreign opaque boundary even when an outer wrapper is transparent. This guard is *defensive depth*: it is not reachable through any single-module program today and has no behavioral regression test (single-module code can't produce a foreign-opaque intermediate).
- Two **pre-existing, orthogonal** cross-module gaps were surfaced while testing and are intentionally **not** addressed here (tracked as follow-ups): (a) explicit cross-module value construction of an opaque type (`A.Secret.(7)`) currently produces no diagnostic (silent `unifyWith(.err)` on the external-resolution path in `Check.zig`); and (b) literal coercion does not descend through a transparent *imported* newtype intermediate.

## Testing

- New integration tests: value/tuple/opaque-in-module construction type-checks; `|n| n` and wrong-backing-type are `TYPE MISMATCH`.
- New snapshots for value, tuple, and primitive-literal construction.
- Full suite green: 2914 Zig unit tests, multi-backend eval, and snapshot CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
