### PR TITLE
Fix cross-platform CI breakage from watch merge

### DIFF
--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -347,10 +347,15 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           otool_out="$(otool -L ./zig-out/bin/roc)"
-          num_lines=$(echo "$otool_out" | wc -l)
-          if [ "$num_lines" -ne 2 ]; then
-            echo "$otool_out"
-            echo "Looks like you added a new dynamic dependency to the Roc executable, we want Roc to be super easy to install, so libSystem should be the only dynamic dependency."
+          echo "$otool_out"
+          # Roc must only depend on libraries that ship with every macOS install, so it
+          # stays trivial to install. FSEvents-based file watching links CoreFoundation
+          # and CoreServices (which pull in libobjc); all of these are part of the OS.
+          unexpected="$(echo "$otool_out" | tail -n +2 | grep -vE '^[[:space:]]+(/usr/lib/libSystem\.B\.dylib|/usr/lib/libobjc\.A\.dylib|/System/Library/Frameworks/CoreFoundation\.framework/|/System/Library/Frameworks/CoreServices\.framework/)' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "Looks like you added a new dynamic dependency to the Roc executable, we want Roc to be super easy to install, so it should only depend on libraries that ship with macOS."
+            echo "Unexpected dependencies:"
+            echo "$unexpected"
             exit 1
           fi
 

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -5575,7 +5575,9 @@ test "Coordinator collectWatchInputStates includes package root state" {
     defer coord.freeWatchInputStates(inputs);
 
     try std.testing.expectEqual(@as(usize, 1), inputs.len);
-    try std.testing.expectEqualStrings("/test/pkg/main.roc", inputs[0].path);
+    const expected_root = try std.fs.path.resolve(allocator, &.{"/test/pkg/main.roc"});
+    defer allocator.free(expected_root);
+    try std.testing.expectEqualStrings(expected_root, inputs[0].path);
     switch (inputs[0].state) {
         .hash => |hash| try std.testing.expectEqualSlices(u8, &root_hash, &hash),
         .missing, .unreadable => try std.testing.expect(false),
@@ -5649,8 +5651,12 @@ test "Coordinator collectWatchInputStates includes module source file state" {
     defer coord.freeWatchInputStates(inputs);
 
     try std.testing.expectEqual(@as(usize, 2), inputs.len);
-    try std.testing.expectEqualStrings("/test/pkg/main.roc", inputs[0].path);
-    try std.testing.expectEqualStrings("/test/pkg/Foo.roc", inputs[1].path);
+    const expected_root = try std.fs.path.resolve(allocator, &.{"/test/pkg/main.roc"});
+    defer allocator.free(expected_root);
+    const expected_module = try std.fs.path.resolve(allocator, &.{"/test/pkg/Foo.roc"});
+    defer allocator.free(expected_module);
+    try std.testing.expectEqualStrings(expected_root, inputs[0].path);
+    try std.testing.expectEqualStrings(expected_module, inputs[1].path);
     switch (inputs[1].state) {
         .hash => |hash| try std.testing.expectEqualSlices(u8, &module_hash, &hash),
         .missing, .unreadable => try std.testing.expect(false),


### PR DESCRIPTION
The watch merge (#9739) introduced two platform-specific CI failures that are unrelated to the change under test on any given PR, so they currently block every PR.

On macOS, file-watching links the CoreFoundation and CoreServices frameworks for FSEvents (which transitively pull in libobjc), so the `roc` executable now lists those alongside libSystem. The macOS "statically linked" check counted `otool -L` lines and required exactly one dependency, so it failed. This replaces the line count with an allowlist of libraries that ship with every macOS install; it still rejects any genuinely new third-party dependency but permits the OS frameworks that FSEvents needs.

On Windows, the watch-input coordinator tests compared collected paths against hard-coded forward-slash strings, but `collectWatchInputStates` runs each path through `std.fs.path.resolve`, which yields native separators (backslashes on Windows). The expected paths are now resolved the same way, so the comparison holds on every platform.