### PR TITLE
Commit hot-reload descriptor page in test helper on Windows

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -4512,7 +4512,9 @@ fn testingSharedMemoryHandle(shm: *SharedMemoryAllocator) SharedMemoryHandle {
 }
 
 fn testingHotReloadDescriptor(shm: *SharedMemoryAllocator, offset: usize) *ipc.hot_reload.ImageDescriptor {
-    return @ptrCast(@alignCast(shm.base_ptr + offset));
+    // Route through the production helper so tests commit the descriptor's page on
+    // Windows (SEC_RESERVE leaves it reserved-but-uncommitted) exactly as a real run does.
+    return hotReloadDescriptorForWrite(shm, offset) catch unreachable;
 }
 
 fn testingPrepareHotReloadDescriptor(


### PR DESCRIPTION
The hot-reload Zig tests in `src/cli/main.zig` segfault on Windows because the test helper `testingHotReloadDescriptor` raw-casts `base_ptr + offset` into a writable `ImageDescriptor` pointer without committing the page. On Windows the shared-memory region is backed by `SEC_RESERVE`, so pages are reserved but not committed until `VirtualAlloc(MEM_COMMIT)` is called. The descriptor lives at the very top of the region, on a page the bump allocator never hands out, so when `prepareDescriptor` writes its fields the access faults on uncommitted memory (the `0x…ffc8` crash address CI reported sits right at the top of the 64 KB test region). On macOS and Linux the whole region is committed up front, so the shortcut happened to work there.

The production write path already commits that page via `hotReloadDescriptorForWrite` before writing the descriptor. This routes the test helper through the same function so tests exercise the identical commit path instead of diverging from it.

Verified on a Windows 11 ARM64 VM: the cross-compiled `cli_test` binary segfaults at the first descriptor-writing hot-reload test before the change and reports `125 passed; 1 skipped; 0 failed` after it.