### PR TITLE
Fix stale "Missing Method" title expectation in where_clause_test

### DIFF
--- a/src/check/test/where_clause_test.zig
+++ b/src/check/test/where_clause_test.zig
@@ -286,7 +286,7 @@ test "where clause - discarded unpinned return type reports missing method" {
     var test_env = try TestEnv.init("Test", source);
     defer test_env.deinit();
 
-    try test_env.assertOneTypeError("MISSING METHOD");
+    try test_env.assertOneTypeError("Missing Method");
     try std.testing.expect(hasRuntimeErrorExpr(&test_env));
 }
 


### PR DESCRIPTION
`run-test-zig-module-check` currently fails on `main`. The test `where clause - discarded unpinned return type reports missing method` asserts the report title `"MISSING METHOD"`, but the Missing Method title was renamed to `"Missing Method"` in #9754 (error-report-styling), which updated `report.zig` and the sibling check tests. The failing test was added by #9819 around the same time and wasn't in #9754's diff, so its old uppercase expectation slipped through — leaving `main` red on that one assertion. This aligns it with the title the report now produces.
