### PR TITLE
Add build-echo-wasm-archive step to zstd-compress echo.wasm

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2300,6 +2300,7 @@ pub fn build(b: *std.Build) void {
     const run_fmt_zig_step = b.step("run-fmt-zig", "Format all zig code");
     const run_snapshot_tool_step = b.step("run-snapshot-tool", "Run the snapshot tool to update snapshot files");
     const echo_wasm_step = b.step("build-echo-wasm", "Build the echo platform to zig-out/lib/echo.wasm");
+    const echo_wasm_archive_step = b.step("build-echo-wasm-archive", "Build echo.wasm and zstd-compress it to zig-out/lib/echo.wasm.zst");
 
     const build_test_hosts_step = b.step("build-test-hosts", "Build test platform host libraries");
     const build_release_step = b.step("build-release", "Build optimized release binary for distribution");
@@ -3352,6 +3353,26 @@ pub fn build(b: *std.Build) void {
         });
         build_playground_step.dependOn(&echo_wasm_install.step);
         echo_wasm_step.dependOn(&echo_wasm_install.step);
+
+        // build-echo-wasm-archive: compress echo.wasm into echo.wasm.zst using
+        // the same zstd streaming compressor as `roc bundle` (src/bundle/).
+        const echo_wasm_archive_exe = b.addExecutable(.{
+            .name = "echo_wasm_archive",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/echo_platform/echo_wasm_archive.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
+        });
+        configureBackend(echo_wasm_archive_exe, target);
+        echo_wasm_archive_exe.root_module.addImport("bundle", roc_modules.bundle);
+        echo_wasm_archive_exe.root_module.linkLibrary(zstd.artifact("zstd"));
+
+        const echo_wasm_archive_cmd = b.addRunArtifact(echo_wasm_archive_exe);
+        echo_wasm_archive_cmd.addFileArg(echo_wasm.getEmittedBin());
+        const echo_wasm_archive_out = echo_wasm_archive_cmd.addOutputFileArg("echo.wasm.zst");
+        const echo_wasm_archive_install = b.addInstallFileWithDir(echo_wasm_archive_out, .lib, "echo.wasm.zst");
+        echo_wasm_archive_step.dependOn(&echo_wasm_archive_install.step);
 
         // Copy the echo platform www files alongside echo.wasm
         inline for (.{ "index.html", "app.js" }) |filename| {

--- a/src/echo_platform/echo_wasm_archive.zig
+++ b/src/echo_platform/echo_wasm_archive.zig
@@ -1,0 +1,66 @@
+//! Build helper: compress `echo.wasm` into a `.zst` archive, reusing the same
+//! zstd streaming compressor that powers `roc bundle` (see `src/bundle/`).
+//!
+//! Usage: echo_wasm_archive <input.wasm> <output.wasm.zst>
+//!
+//! Invoked by `zig build build-echo-wasm-archive`, which builds `echo.wasm`
+//! first and then runs this tool to emit `zig-out/lib/echo.wasm.zst`.
+
+const std = @import("std");
+const bundle = @import("bundle");
+
+const ArchiveError = std.process.Args.ToSliceError ||
+    std.Io.Dir.ReadFileAllocError ||
+    std.Io.Dir.WriteFileError ||
+    std.Io.Writer.Error ||
+    std.mem.Allocator.Error;
+
+/// Reads the input wasm path (argv[1]), zstd-compresses it with the shared
+/// `roc bundle` compressor, and writes the archive to the output path (argv[2]).
+pub fn main(init: std.process.Init) ArchiveError!void {
+    const io = init.io;
+
+    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa_impl.deinit();
+    var gpa = gpa_impl.allocator();
+
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const stderr_file: std.Io.File = .stderr();
+
+    const args = try init.minimal.args.toSlice(arena);
+    if (args.len != 3) {
+        stderr_file.writeStreamingAll(io, "Usage: echo_wasm_archive <input.wasm> <output.wasm.zst>\n") catch {};
+        std.process.exit(2);
+    }
+
+    const input_path = args[1];
+    const output_path = args[2];
+
+    const input = try std.Io.Dir.cwd().readFileAlloc(io, input_path, arena, .unlimited);
+
+    // Compress into memory using the shared zstd streaming compressor. The
+    // BLAKE3 hash it also computes is unused here; we only want the bytes.
+    var out: std.Io.Writer.Allocating = .init(arena);
+
+    var compressor = try bundle.streaming_writer.CompressingHashWriter.init(
+        &gpa,
+        bundle.DEFAULT_COMPRESSION_LEVEL,
+        &out.writer,
+        bundle.allocForZstd,
+        bundle.freeForZstd,
+    );
+    defer compressor.deinit();
+
+    try compressor.interface.writeAll(input);
+    try compressor.finish();
+
+    const compressed = out.written();
+
+    try std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = output_path,
+        .data = compressed,
+    });
+}


### PR DESCRIPTION
Adds a `zig build build-echo-wasm-archive` step that builds echo.wasm and compresses it to zig-out/lib/echo.wasm.zst, reusing the existing zstd streaming compressor from the `roc bundle` machinery (src/bundle/).

echo.wasm had significantly increased in size due to inclusion of the pre-compiled builtins.