### PR TITLE
Fix method calls on associated constants

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3998,7 +3998,7 @@ pub fn build(b: *std.Build) void {
     build_test_lsp_integration_runner_step.dependOn(&lsp_integration_runner_exe.step);
 
     const run_lsp_integration = b.addRunArtifact(lsp_integration_runner_exe);
-    run_lsp_integration.expectExitCode(0);
+    run_lsp_integration.stdio = .inherit;
     for (test_filters) |filter| {
         run_lsp_integration.addArg("--filter");
         run_lsp_integration.addArg(filter);

--- a/src/check/test/cross_module_test.zig
+++ b/src/check/test/cross_module_test.zig
@@ -146,6 +146,30 @@ test "cross-module - check type - static dispatch - no annotation & indirection"
     try test_env_b.assertDefType("main", "(Str, Str, Str)");
 }
 
+test "cross-module - check type - method call on imported associated constant" {
+    const source_html =
+        \\Html := { foo : U8 }.{
+        \\  href : Html, Str -> Html
+        \\  href = |html, _val| html
+        \\
+        \\  a : Html
+        \\  a = { foo: 4 }
+        \\}
+    ;
+    var test_env_html = try TestEnv.init("Html", source_html);
+    defer test_env_html.deinit();
+
+    const source_main =
+        \\import Html
+        \\
+        \\main : Html
+        \\main = Html.a.href("./other-page.html")
+    ;
+    var test_env_main = try TestEnv.initWithImport("Main", source_main, "Html", &test_env_html);
+    defer test_env_main.deinit();
+    try test_env_main.assertDefType("main", "Html");
+}
+
 test "cross-module - check type - opaque types 1" {
     const source_a =
         \\A :: [A(Str)].{}

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -764,7 +764,7 @@ fn parseExposedItemTokens(self: *Parser) std.mem.Allocator.Error!AST.ExposedItem
         },
         .UpperIdent => {
             var as: ?TokenIdx = null;
-            const qual_result = try self.readQualificationChain();
+            const qual_result = try self.readQualificationChain(.all_segments);
             self.pos = qual_result.final_token + 1;
             const ident = qual_result.final_token;
             if (self.peek() == .KwAs) {
@@ -1943,6 +1943,11 @@ const QualificationResult = struct {
     is_upper: bool,
 };
 
+const QualificationMode = enum {
+    all_segments,
+    expression_value_boundary,
+};
+
 fn CurrentStack(comptime State: type) type {
     return struct {
         current: ?State = null,
@@ -2668,7 +2673,7 @@ const TypeFnAfterRetState = struct {
 
 /// Parses a qualification chain (e.g., "json.Core.Utf8" -> ["json", "Core"])
 /// Returns the qualifiers and the final token
-fn readQualificationChain(self: *Parser) std.mem.Allocator.Error!QualificationResult {
+fn readQualificationChain(self: *Parser, mode: QualificationMode) std.mem.Allocator.Error!QualificationResult {
     std.debug.assert(self.peek() == .UpperIdent or self.peek() == .LowerIdent);
 
     const scratch_top = self.store.scratchTokenTop();
@@ -2679,6 +2684,7 @@ fn readQualificationChain(self: *Parser) std.mem.Allocator.Error!QualificationRe
     self.advance();
 
     var saw_qualifier = false;
+    var saw_lower_segment = false;
     while (true) {
         switch (self.peek()) {
             .NoSpaceDotUpperIdent => {
@@ -2689,10 +2695,14 @@ fn readQualificationChain(self: *Parser) std.mem.Allocator.Error!QualificationRe
                 self.advance();
             },
             .NoSpaceDotLowerIdent => {
+                if (mode == .expression_value_boundary and saw_lower_segment) {
+                    break;
+                }
                 saw_qualifier = true;
                 try self.store.addScratchToken(final_token);
                 final_token = self.pos;
                 is_upper = false;
+                saw_lower_segment = true;
                 self.advance();
             },
             else => break,
@@ -3034,7 +3044,7 @@ fn runExprStatementKernel(
                 }
                 if (tok == .UpperIdent) {
                     const start = self.pos;
-                    const qual_result = try self.readQualificationChain();
+                    const qual_result = try self.readQualificationChain(.expression_value_boundary);
                     self.pos = qual_result.final_token + 1;
                     const expr = if (qual_result.is_upper)
                         try self.store.addExpr(.{ .tag = .{
@@ -3487,7 +3497,7 @@ fn runExprStatementKernel(
                 const first_token_tag = self.peek();
                 if (first_token_tag == .LowerIdent or first_token_tag == .UpperIdent) {
                     const ident_start = self.pos;
-                    const qual_result = try self.readQualificationChain();
+                    const qual_result = try self.readQualificationChain(.expression_value_boundary);
                     self.pos = qual_result.final_token + 1;
                     const is_tag = if (qual_result.qualifiers.span.len == 0)
                         first_token_tag == .UpperIdent
@@ -4293,7 +4303,7 @@ fn runExprStatementKernel(
                 if (tok == .UpperIdent or tok == .LowerIdent) {
                     const start = self.pos;
                     const first_token_tag = self.peek();
-                    const qual_result = try self.readQualificationChain();
+                    const qual_result = try self.readQualificationChain(.all_segments);
                     self.pos = qual_result.final_token + 1;
 
                     const base_anno = if (first_token_tag == .LowerIdent and qual_result.qualifiers.span.len == 0)
@@ -5631,7 +5641,7 @@ fn runExprStatementKernel(
             } else if (tok_int < @intFromEnum(Token.Tag.OpPlus)) {
                 if (tok == .UpperIdent) {
                     const start = self.pos;
-                    const qual_result = try self.readQualificationChain();
+                    const qual_result = try self.readQualificationChain(.all_segments);
                     self.pos = qual_result.final_token + 1;
                     if (!qual_result.is_upper) {
                         last_pattern = try self.pushMalformed(AST.Pattern.Idx, .pattern_unexpected_token, start);


### PR DESCRIPTION
Fixes #9773 by parsing `Html.a.href(...)` as a method call on the imported associated constant `Html.a` instead of greedily treating `Html.a.href` as one qualified value. The parser now stops qualified expression parsing at the associated-value boundary while preserving full qualification for declarations, types, and patterns; this also adds a cross-module regression test and keeps the LSP integration harness from reporting successful stderr output as a failed Zig command.