### PR TITLE
Update mini-tutorial-new-compiler.md

### DIFF
--- a/docs/mini-tutorial-new-compiler.md
+++ b/docs/mini-tutorial-new-compiler.md
@@ -215,7 +215,7 @@ digits_to_num = |digits| digits.fold(0, |num, digit| (num * 10) + digit)
 
 ### Blocks
 
-Note that there are no curly braces in this one. That's because actually every Roc function has one expression
+Note that there are no curly braces in the previous one. That's because actually every Roc function has one expression
 after its arguments (e.g. you can write `|arg| arg.to_str()`), but that expression can be a _block_ if you like.
 Here's an example of a block expression:
 

--- a/docs/mini-tutorial-new-compiler.md
+++ b/docs/mini-tutorial-new-compiler.md
@@ -215,7 +215,7 @@ digits_to_num = |digits| digits.fold(0, |num, digit| (num * 10) + digit)
 
 ### Blocks
 
-Note that there are no curly braces in the previous one. That's because actually every Roc function has one expression
+Note that there are no curly braces in the `digits_to_num` definition. That's because every Roc function has one expression
 after its arguments (e.g. you can write `|arg| arg.to_str()`), but that expression can be a _block_ if you like.
 Here's an example of a block expression:
 


### PR DESCRIPTION
to clarify which code example is being referred to.

I read the sentence over and over, trying to reconcile the fact that there were definitely curly braces in the next code example with the statement that there were no curly braces.  Finally I figured out that "this" was meant to refer to the previous code.  Without a doing a deep linguistic dive, I think "this" normally refers forward in time or conversation and "that" normally refers backwards in time or conversation, but in order to avoid any possibility of confusion I made the reference utterly unambiguous.