### PR TITLE
Fix x86 float abs RocOps clobber

### DIFF
--- a/src/backend/dev/x86_64/CodeGen.zig
+++ b/src/backend/dev/x86_64/CodeGen.zig
@@ -671,24 +671,16 @@ pub fn CodeGen(comptime target: RocTarget) type {
         /// Emit float64 negation: dst = -src
         /// Uses XOR with sign bit mask to properly handle -0.0
         pub fn emitNegF64(self: *Self, dst: FloatReg, src: FloatReg) Allocator.Error!void {
-            // Load sign bit mask (0x8000_0000_0000_0000) into dst
-            // Then XOR with src to flip the sign bit
-            const sign_bit_mask: i64 = @bitCast(@as(u64, 0x8000_0000_0000_0000));
-            const stack_offset: i32 = -16; // Temporary stack location
-            try self.emit.movRegImm64(.R11, sign_bit_mask);
-            try self.emit.movMemReg(.w64, .RBP, stack_offset, .R11);
-            try self.emit.movsdRegMem(dst, .RBP, stack_offset);
+            // Build the sign-bit mask in XMM space; no frame scratch slot.
+            try self.emit.pcmpeqdRegReg(dst, dst);
+            try self.emit.psllqRegImm8(dst, 63);
             try self.emit.xorpdRegReg(dst, src);
         }
 
         pub fn emitAbsF64(self: *Self, dst: FloatReg, src: FloatReg) Allocator.Error!void {
-            // Load abs mask (0x7FFF_FFFF_FFFF_FFFF) into dst
-            // Then AND with src to clear the sign bit
-            const abs_mask: i64 = @bitCast(@as(u64, 0x7FFF_FFFF_FFFF_FFFF));
-            const stack_offset: i32 = -16; // Temporary stack location
-            try self.emit.movRegImm64(.R11, abs_mask);
-            try self.emit.movMemReg(.w64, .RBP, stack_offset, .R11);
-            try self.emit.movsdRegMem(dst, .RBP, stack_offset);
+            // Build the abs mask in XMM space; no frame scratch slot.
+            try self.emit.pcmpeqdRegReg(dst, dst);
+            try self.emit.psrlqRegImm8(dst, 1);
             try self.emit.andpdRegReg(dst, src);
         }
 
@@ -727,13 +719,9 @@ pub fn CodeGen(comptime target: RocTarget) type {
         /// Emit float32 negation: dst = -src
         /// Uses XOR with sign bit mask to properly handle -0.0
         pub fn emitNegF32(self: *Self, dst: FloatReg, src: FloatReg) Allocator.Error!void {
-            // Load sign bit mask (0x80000000) into dst
-            // Then XOR with src to flip the sign bit
-            const sign_bit_mask: i32 = @bitCast(@as(u32, 0x80000000));
-            const stack_offset: i32 = -16; // Temporary stack location
-            try self.emit.movRegImm32(.w32, .R11, sign_bit_mask);
-            try self.emit.movMemReg(.w32, .RBP, stack_offset, .R11);
-            try self.emit.movssRegMem(dst, .RBP, stack_offset);
+            // Build the sign-bit mask in XMM space; no frame scratch slot.
+            try self.emit.pcmpeqdRegReg(dst, dst);
+            try self.emit.pslldRegImm8(dst, 31);
             try self.emit.xorpsRegReg(dst, src);
         }
 

--- a/src/backend/dev/x86_64/Emit.zig
+++ b/src/backend/dev/x86_64/Emit.zig
@@ -1079,6 +1079,51 @@ pub fn Emit(comptime target: RocTarget) type {
             try self.buf.append(self.allocator, modRM(0b11, dst.enc(), src.enc()));
         }
 
+        /// PCMPEQD xmm, xmm (compare packed dwords for equality)
+        pub fn pcmpeqdRegReg(self: *Self, dst: FloatReg, src: FloatReg) Allocator.Error!void {
+            try self.buf.append(self.allocator, 0x66);
+            try self.emitFloatRex(dst, src);
+            try self.buf.append(self.allocator, 0x0F);
+            try self.buf.append(self.allocator, 0x76);
+            try self.buf.append(self.allocator, modRM(0b11, dst.enc(), src.enc()));
+        }
+
+        /// PSLLD xmm, imm8 (shift packed dwords left)
+        pub fn pslldRegImm8(self: *Self, dst: FloatReg, imm: u8) Allocator.Error!void {
+            try self.buf.append(self.allocator, 0x66);
+            if (dst.rexB() == 1) {
+                try self.buf.append(self.allocator, rex(0, 0, 0, 1));
+            }
+            try self.buf.append(self.allocator, 0x0F);
+            try self.buf.append(self.allocator, 0x72);
+            try self.buf.append(self.allocator, modRM(0b11, 0b110, dst.enc()));
+            try self.buf.append(self.allocator, imm);
+        }
+
+        /// PSLLQ xmm, imm8 (shift packed qwords left)
+        pub fn psllqRegImm8(self: *Self, dst: FloatReg, imm: u8) Allocator.Error!void {
+            try self.buf.append(self.allocator, 0x66);
+            if (dst.rexB() == 1) {
+                try self.buf.append(self.allocator, rex(0, 0, 0, 1));
+            }
+            try self.buf.append(self.allocator, 0x0F);
+            try self.buf.append(self.allocator, 0x73);
+            try self.buf.append(self.allocator, modRM(0b11, 0b110, dst.enc()));
+            try self.buf.append(self.allocator, imm);
+        }
+
+        /// PSRLQ xmm, imm8 (shift packed qwords right)
+        pub fn psrlqRegImm8(self: *Self, dst: FloatReg, imm: u8) Allocator.Error!void {
+            try self.buf.append(self.allocator, 0x66);
+            if (dst.rexB() == 1) {
+                try self.buf.append(self.allocator, rex(0, 0, 0, 1));
+            }
+            try self.buf.append(self.allocator, 0x0F);
+            try self.buf.append(self.allocator, 0x73);
+            try self.buf.append(self.allocator, modRM(0b11, 0b010, dst.enc()));
+            try self.buf.append(self.allocator, imm);
+        }
+
         /// XORPD xmm, xmm (XOR packed double - used for zeroing)
         pub fn xorpdRegReg(self: *Self, dst: FloatReg, src: FloatReg) Allocator.Error!void {
             try self.buf.append(self.allocator, 0x66);
@@ -1572,6 +1617,26 @@ test "xorpd zeroing" {
 
     try emit.xorpdRegReg(.XMM0, .XMM0);
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x66, 0x0F, 0x57, 0xC0 }, emit.buf.items);
+}
+
+test "sse2 packed mask ops" {
+    var emit = LinuxEmit.init(std.testing.allocator);
+    defer emit.deinit();
+
+    try emit.pcmpeqdRegReg(.XMM0, .XMM0);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x66, 0x0F, 0x76, 0xC0 }, emit.buf.items);
+
+    emit.buf.clearRetainingCapacity();
+    try emit.psllqRegImm8(.XMM0, 63);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x66, 0x0F, 0x73, 0xF0, 63 }, emit.buf.items);
+
+    emit.buf.clearRetainingCapacity();
+    try emit.psrlqRegImm8(.XMM0, 1);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x66, 0x0F, 0x73, 0xD0, 1 }, emit.buf.items);
+
+    emit.buf.clearRetainingCapacity();
+    try emit.pslldRegImm8(.XMM0, 31);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x66, 0x0F, 0x72, 0xF0, 31 }, emit.buf.items);
 }
 
 test "function prologue sequence" {

--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -342,6 +342,23 @@ test "fx platform boxed erased callable host boundary (dev backend)" {
     try runIoSpecTest("--opt=dev", fx_test_specs.host_boxed_fn_boundary_test);
 }
 
+test "fx platform direct run preserves RocOps after F32.abs before list allocation" {
+    const allocator = testing.allocator;
+
+    // Repro for https://github.com/roc-lang/roc/issues/9846:
+    // direct-run should preserve RocOps across F32.abs and the later list allocation.
+    const result = try util.runRocCommand(std.testing.io, allocator, &.{
+        "test/fx/issue_9846_direct_abs_list.roc",
+        "--",
+        "--test",
+        "1>count 1",
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    try util.checkTestSuccess(result);
+}
+
 test "provided static data exports are host-linkable readonly constants" {
     const allocator = testing.allocator;
 

--- a/test/fx/issue_9846_direct_abs_list.roc
+++ b/test/fx/issue_9846_direct_abs_list.roc
@@ -1,0 +1,34 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+import pf.Host
+
+Model : { count : U64 }
+
+render! : Model, Host.Host => Try(Model, [Exit(I64), ..])
+render! = |_model, host| {
+    runtime = host.get_greeting!()
+    runtime_len = Str.count_utf8_bytes(runtime)
+
+    input : F32
+    input = if runtime_len > 0 { -1.0 } else { 1.0 }
+
+    abs_value = F32.abs(input)
+    values = if abs_value >= 0 and runtime_len > 0 [1] else []
+
+    next_model = {
+        count: match List.first(values) {
+            Ok(_) => 1
+            Err(_) => 0
+        },
+    }
+
+    if runtime_len > 0 { Ok(next_model) } else { Err(Exit(1)) }
+}
+
+main! = || {
+    match render!({ count: 0 }, Host.new("issue-9846")) {
+        Ok(model) => Stdout.line!("count ${model.count.to_str()}")
+        Err(_) => Stdout.line!("unexpected error")
+    }
+}


### PR DESCRIPTION
## Summary
- stop x86_64 float abs/neg helpers from writing masks to a fixed RBP-relative scratch slot
- synthesize the masks in XMM registers with SSE2 instructions instead
- add a direct-run fx regression for issue #9846

## Testing
- zig build run-test-zig-module-backend -- --test-filter "sse2 packed mask ops"
- zig build run-test-zig-fx-platform -- --test-filter "fx platform direct run preserves RocOps after F32.abs before list allocation"
- ./zig-out/bin/roc test/fx/issue_9846_direct_abs_list.roc -- --test "1>count 1"
- zig build run-check-fx-platform-test-coverage