### PR TITLE
Fix record literals in string interpolation

### DIFF
--- a/src/parse/tokenize.zig
+++ b/src/parse/tokenize.zig
@@ -1094,11 +1094,16 @@ const StringKind = enum {
     multi_line,
 };
 
+const StringInterpolationState = struct {
+    kind: StringKind,
+    curly_depth: u32,
+};
+
 /// The tokenizer that uses a Cursor and produces a TokenizedBuffer.
 pub const Tokenizer = struct {
     cursor: Cursor,
     output: TokenizedBuffer,
-    string_interpolation_stack: std.array_list.Managed(StringKind),
+    string_interpolation_stack: std.array_list.Managed(StringInterpolationState),
     env: *CommonEnv,
 
     /// Creates a new Tokenizer.
@@ -1111,7 +1116,7 @@ pub const Tokenizer = struct {
         return Tokenizer{
             .cursor = cursor,
             .output = output,
-            .string_interpolation_stack = std.array_list.Managed(StringKind).init(gpa),
+            .string_interpolation_stack = std.array_list.Managed(StringInterpolationState).init(gpa),
             .env = env,
         };
     }
@@ -1454,6 +1459,10 @@ pub const Tokenizer = struct {
                 },
                 open_curly => {
                     self.cursor.pos += 1;
+                    if (self.string_interpolation_stack.items.len > 0) {
+                        const top = &self.string_interpolation_stack.items[self.string_interpolation_stack.items.len - 1];
+                        top.curly_depth += 1;
+                    }
                     try self.pushTokenNormalHere(gpa, .OpenCurly, start);
                 },
 
@@ -1467,11 +1476,19 @@ pub const Tokenizer = struct {
                 },
                 close_curly => {
                     self.cursor.pos += 1;
-                    if (self.string_interpolation_stack.pop()) |last| {
+                    if (self.string_interpolation_stack.items.len > 0) {
+                        const top = &self.string_interpolation_stack.items[self.string_interpolation_stack.items.len - 1];
+                        if (top.curly_depth > 0) {
+                            top.curly_depth -= 1;
+                            try self.pushTokenNormalHere(gpa, .CloseCurly, start);
+                            continue;
+                        }
+
+                        const last = self.string_interpolation_stack.pop() orelse unreachable;
                         try self.pushTokenNormalHere(gpa, .CloseStringInterpolation, start);
                         // For string interpolations, we don't have the original opening quote position
                         // so we use the current position as a fallback
-                        try self.tokenizeStringLikeLiteralBody(gpa, last, self.cursor.pos);
+                        try self.tokenizeStringLikeLiteralBody(gpa, last.kind, self.cursor.pos);
                     } else {
                         try self.pushTokenNormalHere(gpa, .CloseCurly, start);
                     }
@@ -1663,7 +1680,7 @@ pub const Tokenizer = struct {
                 const dollar_start = self.cursor.pos;
                 self.cursor.pos += 2;
                 try self.pushTokenNormalHere(gpa, .OpenStringInterpolation, dollar_start);
-                try self.string_interpolation_stack.append(kind);
+                try self.string_interpolation_stack.append(.{ .kind = kind, .curly_depth = 0 });
                 return;
             } else if (c == '\n') {
                 try self.pushTokenNormalHere(gpa, string_part_tag, start);
@@ -2426,6 +2443,23 @@ test "tokenizer" {
         .StringPart,
         .OpenStringInterpolation,
         .LowerIdent,
+        .CloseStringInterpolation,
+        .StringPart,
+        .StringEnd,
+    });
+    try testTokenization(gpa, "\"${Str.inspect({ two: 2 })}\"", &[_]Token.Tag{
+        .StringStart,
+        .StringPart,
+        .OpenStringInterpolation,
+        .UpperIdent,
+        .NoSpaceDotLowerIdent,
+        .NoSpaceOpenRound,
+        .OpenCurly,
+        .LowerIdent,
+        .OpColon,
+        .Int,
+        .CloseCurly,
+        .CloseRound,
         .CloseStringInterpolation,
         .StringPart,
         .StringEnd,

--- a/test/snapshots/expr/string_interpolation_record_literal_argument.md
+++ b/test/snapshots/expr/string_interpolation_record_literal_argument.md
@@ -1,0 +1,57 @@
+# META
+~~~ini
+description=String interpolation can contain a record literal function argument
+type=expr
+~~~
+# SOURCE
+~~~roc
+"${Str.inspect({ two: 2 })}"
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+StringStart,StringPart,OpenStringInterpolation,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpenCurly,LowerIdent,OpColon,Int,CloseCurly,CloseRound,CloseStringInterpolation,StringPart,StringEnd,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-string
+	(e-string-part (raw ""))
+	(e-apply
+		(e-ident (raw "Str.inspect"))
+		(e-record
+			(field (field "two")
+				(e-int (raw "2")))))
+	(e-string-part (raw "")))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-block
+	(s-let
+		(p-assign (ident "#interp_0"))
+		(e-call (constraint-fn-var 62)
+			(e-lookup-external
+				(builtin))
+			(e-record
+				(fields
+					(field (name "two")
+						(e-num (value "2")))))))
+	(e-interpolation (constraint-fn-var 117)
+		(first
+			(e-literal (string "")))
+		(parts
+			(e-lookup-local
+				(p-assign (ident "#interp_0")))
+			(e-literal (string "")))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "Str"))
+~~~


### PR DESCRIPTION
## Summary
- track nested curly depth while tokenizing string interpolation expressions
- keep record literal braces inside interpolations as ordinary curly tokens
- add a snapshot regression for `Str.inspect({ two: 2 })` inside interpolation

Fixes #9847

## Testing
- `zig build run-snapshot-tool -- test/snapshots/expr/string_interpolation_record_literal_argument.md --check-expected`
- `zig build run-test-zig -- --test-filter "tokenizer"`
- `zig build minici`