### PR TITLE
Avoid hoisting roots inside expect bodies

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -6705,7 +6705,7 @@ fn checkExpectBody(
     self.current_expect_region = expect_region;
     defer self.current_expect_region = saved_expect_region;
 
-    return try self.checkExpr(body, env, expected);
+    return try self.checkExprWithHoistSelectionSuppressed(body, env, expected);
 }
 
 fn varIsFunctionType(self: *Self, var_: Var) bool {

--- a/src/check/test/hoist_roots_test.zig
+++ b/src/check/test/hoist_roots_test.zig
@@ -864,6 +864,22 @@ test "hoist roots are not selected inside ordinary top-level constants" {
     try std.testing.expectEqual(@as(usize, 0), test_env.checker.selectedHoistedRoots().len);
 }
 
+test "hoist roots are not selected inside top-level expects" {
+    var test_env = try TestEnv.init("Test",
+        \\expensive = |n| n + 1.I64
+        \\
+        \\expect {
+        \\    result = expensive(41.I64)
+        \\    result == 42.I64
+        \\}
+    );
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+    // repro for https://github.com/roc-lang/roc/issues/9747
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.selectedHoistedRoots().len);
+}
+
 test "hoist roots are not selected for runtime-controlled branch bodies" {
     var test_env = try TestEnv.init("Test",
         \\main = |arg| {


### PR DESCRIPTION
## Summary

- suppress hoist root selection while checking expect bodies
- add a regression test for #9747 covering top-level expect bodies

## Tests

- zig build run-test-zig-module-check -- --test-filter "hoist roots are not selected inside top-level expects"
- zig build run-test-zig-module-check -- --test-filter "hoist roots"
- zig build minici