### PR TITLE
Dedupe canonicalization policy

### DIFF
--- a/design.md
+++ b/design.md
@@ -527,6 +527,105 @@ The recommended migration order is:
 8. Verify with focused canonicalization tests, `zig build minici`, and
    parser/canonicalization benchmarks.
 
+## Canonicalization Policy Ownership
+
+Canonicalization owns source-name scope policy before checking. Any rule that
+decides whether a source type name is inserted, shadows another type, replaces
+an auto-imported type, redeclares an existing type, or repeats the same external
+type must live in one place. Callers may choose which source operation they are
+performing, but they must not duplicate the type-binding collision matrix.
+
+The `Scope.type_bindings` table has one ordinary mutation API for type names.
+It accepts the full scope slice, the target scope index, the introduced name,
+and the incoming binding:
+
+```zig
+const TypeBindingInput = union(enum) {
+    local_nominal: CIR.Statement.Idx,
+    local_alias: CIR.Statement.Idx,
+    associated_nominal: CIR.Statement.Idx,
+    external_nominal: Scope.ExternalTypeBinding,
+};
+
+const TypeBindingDecision = union(enum) {
+    inserted,
+    inserted_shadowing_parent: Scope.TypeBinding,
+    replaced_current_external: Scope.ExternalTypeBinding,
+    idempotent_current,
+    rejected_current_conflict: Scope.TypeBinding,
+    redeclared_current: Scope.TypeBinding,
+};
+```
+
+The exact names may change with implementation, but the shape must remain:
+one `Scope` function mutates `type_bindings`, and its return value carries the
+old binding that caused any warning or error. `Scope` does not push diagnostics,
+does not inspect source regions from `ModuleEnv`, and does not update import
+display mappings. `Can` maps the returned decision to diagnostics and performs
+the import-mapping side effects that are specific to external imports.
+
+Parent-scope shadowing must be computed by the same type-binding API. The
+function receives the scope slice and target index directly; it does not use an
+untyped callback or a callback without context. The parent walk chooses the
+nearest parent binding and returns that binding to the caller. This preserves
+regions for both local statements and external imports without reconstructing
+them at each call site.
+
+The current-scope collision matrix is:
+
+- A same statement already bound to the same name is idempotent.
+- A same external module/original-name pair already bound to the same name is
+  idempotent.
+- A local declaration replacing an external binding succeeds and returns the
+  replaced external binding so `Can` can report the shadowing region.
+- An external binding colliding with any different current binding is rejected
+  and returns the existing binding.
+- A local alias colliding with a current local alias reports alias
+  redeclaration.
+- A local nominal colliding with a current local nominal or associated nominal
+  reports type redeclaration.
+- A local declaration colliding with the other local kind reports the diagnostic
+  chosen by the existing binding, not by the incoming binding.
+
+Direct writes to `Scope.type_bindings` are allowed only for explicit
+initialization paths that prove the binding cannot collide, such as seeding the
+compiler-owned builtin scope before source declarations are introduced. If that
+proof stops being local and obvious, the initialization path must use the same
+type-binding API.
+
+Result suffix desugaring has a separate owner inside `Can`. The suffix forms
+`expr?`, `expr ? handler`, and `expr ?? default` all lower to a match over the
+same `Try` shape. They must share one concrete builder for the common structure:
+
+- resolve the compiler-owned `Try` nominal target once,
+- wrap `Ok` and `Err` tag patterns with that nominal target,
+- append the `Ok(#ok) => #ok` branch,
+- construct the `Err(...)` tag expression used by early return,
+- create the final match with the caller-selected `is_try_suffix` value.
+
+The builder must support both local and external nominal targets because the
+Builtin module may refer to its own `Try`, while ordinary modules use the
+compiler-owned external builtin. It must not silently fall back to bare `Ok` and
+`Err` patterns when `Try` is missing. A missing compiler-owned `Try` target is a
+compiler invariant violation after builtin setup, not an alternate
+canonicalization mode.
+
+The three suffix callers provide only the distinct error-branch body:
+
+- `expr?` returns the original error payload from the enclosing function, or
+  emits `e_expect_err` inside a top-level `expect`.
+- `expr ? handler` transforms the error payload and then returns `Err(...)`, or
+  emits `e_expect_err` inside a top-level `expect`.
+- `expr ?? default` uses the default expression and does not mark the match as a
+  try suffix.
+
+Do not introduce a generic desugaring interpreter for these cases. The helper
+should be a small set of concrete `Can` functions that emit the same CIR nodes
+and scratch spans as the current hand-written paths. This keeps
+canonicalization output explicit, keeps diagnostics in `Can`, and keeps release
+builds fast: the work runs once per source suffix or type declaration, with no
+runtime cost in the compiled program.
+
 ## Type Alias Invariant
 
 Source type aliases are transparent views of their backing type. An alias root

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -166,6 +166,14 @@ const NestedTypeDeclRegistration = struct {
     is_redeclaration: bool,
 };
 
+const TryNominalTarget = union(enum) {
+    local: Statement.Idx,
+    external: struct {
+        import_idx: Import.Idx,
+        target_node_idx: u32,
+    },
+};
+
 env: *ModuleEnv,
 parse_ir: *AST,
 /// Track whether we're in statement position (true) or expression position (false)
@@ -1034,6 +1042,9 @@ pub fn setupAutoImportedBuiltinTypes(
             else
                 null;
 
+            // Compiler-owned builtin seed data is installed before any source
+            // declaration can exist in this module scope, so this is not a
+            // source-level collision policy decision.
             try current_scope.type_bindings.put(gpa, type_ident, Scope.TypeBinding{
                 .external_nominal = .{
                     .module_ident = builtin_ident,
@@ -1051,6 +1062,8 @@ pub fn setupAutoImportedBuiltinTypes(
     for (primitive_builtins) |type_name_text| {
         const type_ident = try env.insertIdent(base.Ident.for_text(type_name_text));
 
+        // Primitive builtins are compiler-owned seed bindings installed before
+        // source declarations, so collision policy is not involved here.
         try current_scope.type_bindings.put(gpa, type_ident, Scope.TypeBinding{
             .external_nominal = .{
                 .module_ident = builtin_ident,
@@ -1944,8 +1957,11 @@ fn registerTypeDecl(
     // E.g., when introducing "Builtin.Bool", also add "Bool" -> "Builtin.Bool"
     // This allows nested scopes (like Str's or Num.U8's associated blocks) to find Bool via scope lookup
     if (parent_name != null) {
-        const current_scope = &self.scopes.items[self.scopes.items.len - 1];
-        try current_scope.introduceTypeAlias(self.env.gpa, type_header.name, type_decl_stmt_idx);
+        try self.introduceAssociatedTypeAliasInScope(
+            self.scopes.items.len - 1,
+            type_header.name,
+            type_decl_stmt_idx,
+        );
     }
 
     // Process type parameters and annotation in a separate scope
@@ -2059,19 +2075,131 @@ fn registerTypeDecl(
 }
 
 fn typeBindingStatement(binding: Scope.TypeBinding) ?Statement.Idx {
-    return switch (binding) {
-        .local_nominal => |stmt| stmt,
-        .local_alias => |stmt| stmt,
-        .associated_nominal => |stmt| stmt,
-        .external_nominal => null,
+    return Scope.typeBindingStatement(binding);
+}
+
+fn localTypeBindingInputForKind(kind: AST.TypeDeclKind, stmt_idx: Statement.Idx) Scope.TypeBindingInput {
+    return switch (kind) {
+        .alias => Scope.TypeBindingInput{ .local_alias = stmt_idx },
+        .nominal, .@"opaque" => Scope.TypeBindingInput{ .local_nominal = stmt_idx },
     };
 }
 
 fn localTypeBindingForKind(kind: AST.TypeDeclKind, stmt_idx: Statement.Idx) Scope.TypeBinding {
-    return switch (kind) {
-        .alias => Scope.TypeBinding{ .local_alias = stmt_idx },
-        .nominal, .@"opaque" => Scope.TypeBinding{ .local_nominal = stmt_idx },
+    return Scope.inputToBinding(localTypeBindingInputForKind(kind, stmt_idx));
+}
+
+fn typeBindingOriginalRegion(self: *Self, binding: Scope.TypeBinding) Region {
+    return switch (binding) {
+        .local_nominal, .local_alias, .associated_nominal => |stmt| self.env.store.getStatementRegion(stmt),
+        .external_nominal => |external| external.origin_region,
     };
+}
+
+fn pushTypeRedeclarationForBinding(
+    self: *Self,
+    existing: Scope.TypeBinding,
+    name_ident: Ident.Idx,
+    redeclared_region: Region,
+) std.mem.Allocator.Error!void {
+    const original_region = self.typeBindingOriginalRegion(existing);
+    switch (existing) {
+        .local_alias => try self.env.pushDiagnostic(Diagnostic{ .type_alias_redeclared = .{
+            .name = name_ident,
+            .original_region = original_region,
+            .redeclared_region = redeclared_region,
+        } }),
+        .local_nominal, .associated_nominal => try self.env.pushDiagnostic(Diagnostic{ .type_redeclared = .{
+            .original_region = original_region,
+            .redeclared_region = redeclared_region,
+            .name = name_ident,
+        } }),
+        .external_nominal => try self.env.pushDiagnostic(Diagnostic{ .shadowing_warning = .{
+            .ident = name_ident,
+            .region = redeclared_region,
+            .original_region = original_region,
+        } }),
+    }
+}
+
+fn pushTypeShadowingWarning(
+    self: *Self,
+    name_ident: Ident.Idx,
+    region: Region,
+    shadowed: Scope.TypeBinding,
+) std.mem.Allocator.Error!void {
+    try self.env.pushDiagnostic(Diagnostic{
+        .shadowing_warning = .{
+            .ident = name_ident,
+            .region = region,
+            .original_region = self.typeBindingOriginalRegion(shadowed),
+        },
+    });
+}
+
+fn handleTypeBindingDecision(
+    self: *Self,
+    name_ident: Ident.Idx,
+    region: Region,
+    decision: Scope.TypeBindingDecision,
+    report_parent_shadowing: bool,
+) std.mem.Allocator.Error!void {
+    switch (decision) {
+        .inserted,
+        .idempotent_current,
+        => {},
+        .inserted_shadowing_parent => |shadowed| {
+            if (report_parent_shadowing) {
+                try self.pushTypeShadowingWarning(name_ident, region, shadowed);
+            }
+        },
+        .replaced_current_external => |external| {
+            try self.pushTypeShadowingWarning(name_ident, region, Scope.TypeBinding{ .external_nominal = external });
+        },
+        .rejected_current_conflict => |existing| {
+            try self.pushTypeShadowingWarning(name_ident, region, existing);
+        },
+        .redeclared_current => |existing| {
+            try self.pushTypeRedeclarationForBinding(existing, name_ident, region);
+        },
+    }
+}
+
+fn typeBindingInputFromBinding(binding: Scope.TypeBinding) Scope.TypeBindingInput {
+    return switch (binding) {
+        .local_nominal => |stmt| Scope.TypeBindingInput{ .local_nominal = stmt },
+        .local_alias => |stmt| Scope.TypeBindingInput{ .local_alias = stmt },
+        .associated_nominal => |stmt| Scope.TypeBindingInput{ .associated_nominal = stmt },
+        .external_nominal => |external| Scope.TypeBindingInput{ .external_nominal = external },
+    };
+}
+
+fn introduceTypeBindingWithoutDiagnostics(
+    self: *Self,
+    scope_idx: usize,
+    name_ident: Ident.Idx,
+    input: Scope.TypeBindingInput,
+) std.mem.Allocator.Error!void {
+    _ = try Scope.introduceTypeBinding(
+        self.env.gpa,
+        self.scopes.items,
+        scope_idx,
+        name_ident,
+        input,
+    );
+}
+
+fn introduceAssociatedTypeAliasInScope(
+    self: *Self,
+    scope_idx: usize,
+    alias_name: Ident.Idx,
+    stmt_idx: Statement.Idx,
+) std.mem.Allocator.Error!void {
+    try self.introduceTypeBindingWithoutDiagnostics(
+        scope_idx,
+        alias_name,
+        Scope.TypeBindingInput{ .associated_nominal = stmt_idx },
+    );
 }
 
 fn typeStatementAwaitingRealDecl(self: *Self, stmt_idx: Statement.Idx) bool {
@@ -2099,7 +2227,11 @@ fn adoptPlaceholderTypeAlias(
         if (!self.typeStatementAwaitingRealDecl(stmt_idx)) continue;
 
         const binding_copy = binding;
-        try self.currentScope().type_bindings.put(self.env.gpa, target_name, binding_copy);
+        try self.introduceTypeBindingWithoutDiagnostics(
+            self.scopes.items.len - 1,
+            target_name,
+            typeBindingInputFromBinding(binding_copy),
+        );
         return;
     }
 }
@@ -2251,54 +2383,14 @@ fn putTypeBindingInScope(
     kind: AST.TypeDeclKind,
     region: Region,
 ) std.mem.Allocator.Error!void {
-    const binding = localTypeBindingForKind(kind, stmt_idx);
-    const scope = &self.scopes.items[scope_idx];
-    if (scope.type_bindings.get(name_ident)) |existing| {
-        if (typeBindingStatement(existing)) |existing_stmt| {
-            if (existing_stmt == stmt_idx) return;
-            const original_region = self.env.store.getStatementRegion(existing_stmt);
-            switch (existing) {
-                .local_alias => try self.env.pushDiagnostic(Diagnostic{ .type_alias_redeclared = .{
-                    .name = name_ident,
-                    .original_region = original_region,
-                    .redeclared_region = region,
-                } }),
-                .local_nominal, .associated_nominal => try self.env.pushDiagnostic(Diagnostic{ .type_redeclared = .{
-                    .original_region = original_region,
-                    .redeclared_region = region,
-                    .name = name_ident,
-                } }),
-                .external_nominal => unreachable,
-            }
-            return;
-        }
-    }
-
-    var shadowed_in_parent: ?Statement.Idx = null;
-    if (scope_idx > 0) {
-        var i = scope_idx;
-        while (i > 0) {
-            i -= 1;
-            const parent_scope = &self.scopes.items[i];
-            if (parent_scope.type_bindings.get(name_ident)) |parent_binding| {
-                shadowed_in_parent = typeBindingStatement(parent_binding);
-                if (shadowed_in_parent != null) break;
-            }
-        }
-    }
-
-    try scope.type_bindings.put(self.env.gpa, name_ident, binding);
-
-    if (shadowed_in_parent) |shadowed_stmt| {
-        const original_region = self.env.store.getStatementRegion(shadowed_stmt);
-        try self.env.pushDiagnostic(Diagnostic{
-            .shadowing_warning = .{
-                .ident = name_ident,
-                .region = region,
-                .original_region = original_region,
-            },
-        });
-    }
+    const decision = try Scope.introduceTypeBinding(
+        self.env.gpa,
+        self.scopes.items,
+        scope_idx,
+        name_ident,
+        localTypeBindingInputForKind(kind, stmt_idx),
+    );
+    try self.handleTypeBindingDecision(name_ident, region, decision, true);
 }
 
 fn putTypeAliasInScope(
@@ -2307,14 +2399,23 @@ fn putTypeAliasInScope(
     alias_name: Ident.Idx,
     stmt_idx: Statement.Idx,
 ) std.mem.Allocator.Error!void {
-    const scope = &self.scopes.items[scope_idx];
-    if (scope.type_bindings.get(alias_name)) |existing| {
-        if (typeBindingStatement(existing)) |existing_stmt| {
-            if (existing_stmt == stmt_idx) return;
-        }
-        return;
+    const decision = try Scope.introduceTypeBinding(
+        self.env.gpa,
+        self.scopes.items,
+        scope_idx,
+        alias_name,
+        Scope.TypeBindingInput{ .associated_nominal = stmt_idx },
+    );
+    switch (decision) {
+        .inserted,
+        .inserted_shadowing_parent,
+        .idempotent_current,
+        => {},
+        .replaced_current_external,
+        .rejected_current_conflict,
+        .redeclared_current,
+        => {},
     }
-    try scope.introduceTypeAlias(self.env.gpa, alias_name, stmt_idx);
 }
 
 fn ensureParserTypeDeclBinding(
@@ -2458,10 +2559,14 @@ fn enterAssociatedBlockState(
     try self.declScopeEnter(work.scope);
     errdefer self.declScopeExit();
 
-    const current_scope = &self.scopes.items[self.scopes.items.len - 1];
-    current_scope.associated_type_name = work.type_name;
+    const current_scope_idx = self.scopes.items.len - 1;
+    self.scopes.items[current_scope_idx].associated_type_name = work.type_name;
 
-    try current_scope.introduceTypeAlias(self.env.gpa, work.type_name, work.owner_stmt_idx);
+    try self.introduceAssociatedTypeAliasInScope(
+        current_scope_idx,
+        work.type_name,
+        work.owner_stmt_idx,
+    );
 
     return state;
 }
@@ -3020,14 +3125,14 @@ fn registerNestedTypeDecl(
     const node_idx_u32: u32 = @intFromEnum(nested_type_decl_idx);
     try self.env.setExposedTypeNodeIndexById(nested_qualified_idx, node_idx_u32);
 
-    const current_scope = &self.scopes.items[self.scopes.items.len - 1];
-    try current_scope.introduceTypeAlias(self.env.gpa, nested_type_ident, nested_type_decl_idx);
+    const current_scope_idx = self.scopes.items.len - 1;
+    try self.introduceAssociatedTypeAliasInScope(current_scope_idx, nested_type_ident, nested_type_decl_idx);
 
     const user_qualified_ident_idx = try self.insertQualifiedIdent(
         self.env.getIdent(type_name),
         self.env.getIdent(nested_type_ident),
     );
-    try current_scope.introduceTypeAlias(self.env.gpa, user_qualified_ident_idx, nested_type_decl_idx);
+    try self.introduceAssociatedTypeAliasInScope(current_scope_idx, user_qualified_ident_idx, nested_type_decl_idx);
 
     const parser_path = self.parserTypePathForAstStatement(ast_stmt_idx);
     const root_scope = if (parser_path) |path| self.typePathRootScope(path) else null;
@@ -3036,13 +3141,13 @@ fn registerNestedTypeDecl(
         // at the module scope so references from outside the associated
         // block — like `x = Test.MyBool.method(...)` at top level —
         // can still resolve the nested type after this scope is exited.
-        try self.scopes.items[0].introduceTypeAlias(self.env.gpa, user_qualified_ident_idx, nested_type_decl_idx);
+        try self.introduceAssociatedTypeAliasInScope(0, user_qualified_ident_idx, nested_type_decl_idx);
 
         // The module's main type IS the module namespace, so its direct nested
         // types are part of the module's own type surface: file-level items
         // reference them by their bare name.
         if (std.mem.eql(u8, self.env.getIdent(type_name), self.env.module_name)) {
-            try self.scopes.items[0].introduceTypeAlias(self.env.gpa, nested_type_ident, nested_type_decl_idx);
+            try self.introduceAssociatedTypeAliasInScope(0, nested_type_ident, nested_type_decl_idx);
         }
     }
 
@@ -4973,12 +5078,16 @@ fn processRequiresEntries(self: *Self, requires_entries: AST.RequiresEntry.Span)
             };
             const alias_stmt_idx = try self.env.addStatement(alias_stmt, alias_region);
 
-            // Add to the module-level scope (index 0) as a local_alias binding
-            // This makes Model available for use in type annotations throughout the platform module
-            const module_scope = &self.scopes.items[0];
-            try module_scope.type_bindings.put(self.env.gpa, alias_name, Scope.TypeBinding{
-                .local_alias = alias_stmt_idx,
-            });
+            // Add to the module-level scope (index 0) as a local_alias binding.
+            // This makes Model available for use in type annotations throughout the platform module.
+            const alias_decision = try Scope.introduceTypeBinding(
+                self.env.gpa,
+                self.scopes.items,
+                0,
+                alias_name,
+                Scope.TypeBindingInput{ .local_alias = alias_stmt_idx },
+            );
+            try self.handleTypeBindingDecision(alias_name, alias_region, alias_decision, true);
 
             // Store the alias mapping for use during type checking
             _ = try self.env.for_clause_aliases.append(self.env.gpa, .{
@@ -6004,7 +6113,8 @@ fn introduceItemsAliased(
     module_import_idx: CIR.Import.Idx,
 ) std.mem.Allocator.Error!void {
     const exposed_items_slice = self.env.store.sliceExposedItems(exposed_items_span);
-    const current_scope = self.currentScope();
+    const current_scope_idx = self.scopes.items.len - 1;
+    const current_scope = &self.scopes.items[current_scope_idx];
 
     if (self.explicit_module_envs) |envs_map| {
         const module_entry = envs_map.get(module_name) orelse {
@@ -6064,7 +6174,7 @@ fn introduceItemsAliased(
                         try self.scopeIntroduceExposedItem(module_alias, item_info, import_region);
 
                         try self.setExternalTypeBinding(
-                            current_scope,
+                            current_scope_idx,
                             module_alias,
                             module_name,
                             original_ident,
@@ -6143,7 +6253,7 @@ fn introduceItemsAliased(
             if (is_type_name) {
                 if (target.typeDeclNode()) |type_node_idx| {
                     try self.setExternalTypeBinding(
-                        current_scope,
+                        current_scope_idx,
                         item_name,
                         module_name,
                         exposed_item.name,
@@ -6183,7 +6293,8 @@ fn introduceItemsUnaliased(
     module_import_idx: CIR.Import.Idx,
 ) std.mem.Allocator.Error!void {
     const exposed_items_slice = self.env.store.sliceExposedItems(exposed_items_span);
-    const current_scope = self.currentScope();
+    const current_scope_idx = self.scopes.items.len - 1;
+    const current_scope = &self.scopes.items[current_scope_idx];
 
     if (self.explicit_module_envs) |envs_map| {
         const module_entry = envs_map.get(module_name) orelse {
@@ -6260,7 +6371,7 @@ fn introduceItemsUnaliased(
                     const original_type_name = self.env.getIdent(exposed_item.name);
 
                     try self.setExternalTypeBinding(
-                        current_scope,
+                        current_scope_idx,
                         local_ident,
                         module_name,
                         exposed_item.name,
@@ -6302,7 +6413,7 @@ fn introduceItemsUnaliased(
                 const original_type_name = self.env.getIdent(exposed_item.name);
 
                 try self.setExternalTypeBinding(
-                    current_scope,
+                    current_scope_idx,
                     local_ident,
                     module_name,
                     exposed_item.name,
@@ -7166,247 +7277,267 @@ fn canonicalizeUnqualifiedIdentExpr(
     }
 }
 
+fn resolveTryNominalTarget(self: *Self) std.mem.Allocator.Error!TryNominalTarget {
+    if (self.builtin_auto_imported_types.get(self.env.idents.@"try")) |try_info| {
+        const try_stmt_idx = try_info.statement_idx orelse {
+            @panic("Builtin Try had no statement during try suffix canonicalization");
+        };
+        const target_node_idx = try_info.env.getExposedNodeIndexByStatementIdx(try_stmt_idx) orelse {
+            @panic("Builtin Try had no target node during try suffix canonicalization");
+        };
+        return TryNominalTarget{ .external = .{
+            .import_idx = try self.getOrCreateCompilerBuiltinAutoImport(),
+            .target_node_idx = target_node_idx,
+        } };
+    }
+
+    const binding_location = (try self.scopeLookupTypeBinding(self.env.idents.@"try")) orelse {
+        @panic("Try type binding was absent during try suffix canonicalization");
+    };
+
+    return switch (binding_location.binding.*) {
+        .local_nominal, .associated_nominal => |stmt| TryNominalTarget{ .local = stmt },
+        .external_nominal => |external| blk: {
+            const import_idx = external.import_idx orelse {
+                @panic("Try type binding had no import during try suffix canonicalization");
+            };
+            const target_node_idx = external.target_node_idx orelse {
+                @panic("Try type binding had no target node during try suffix canonicalization");
+            };
+            break :blk TryNominalTarget{ .external = .{
+                .import_idx = import_idx,
+                .target_node_idx = target_node_idx,
+            } };
+        },
+        .local_alias => @panic("Try type binding was not a nominal type during try suffix canonicalization"),
+    };
+}
+
+fn addTryTagPattern(
+    self: *Self,
+    target: TryNominalTarget,
+    tag_ident: Ident.Idx,
+    args_span: Pattern.Span,
+    region: Region,
+) std.mem.Allocator.Error!Pattern.Idx {
+    const applied_tag_pattern = try self.env.addPattern(Pattern{
+        .applied_tag = .{
+            .name = tag_ident,
+            .args = args_span,
+        },
+    }, region);
+
+    return switch (target) {
+        .local => |stmt| try self.env.addPattern(Pattern{
+            .nominal = .{
+                .nominal_type_decl = stmt,
+                .backing_pattern = applied_tag_pattern,
+                .backing_type = .tag,
+            },
+        }, region),
+        .external => |external| try self.env.addPattern(Pattern{
+            .nominal_external = .{
+                .module_idx = external.import_idx,
+                .target_node_idx = external.target_node_idx,
+                .backing_pattern = applied_tag_pattern,
+                .backing_type = .tag,
+            },
+        }, region),
+    };
+}
+
+fn addTryTagExpr(
+    self: *Self,
+    target: TryNominalTarget,
+    tag_ident: Ident.Idx,
+    args_span: Expr.Span,
+    region: Region,
+) std.mem.Allocator.Error!Expr.Idx {
+    const tag_expr = try self.env.addExpr(CIR.Expr{
+        .e_tag = .{
+            .name = tag_ident,
+            .args = args_span,
+        },
+    }, region);
+
+    return switch (target) {
+        .local => |stmt| try self.env.addExpr(CIR.Expr{
+            .e_nominal = .{
+                .nominal_type_decl = stmt,
+                .backing_expr = tag_expr,
+                .backing_type = .tag,
+            },
+        }, region),
+        .external => |external| try self.env.addExpr(CIR.Expr{
+            .e_nominal_external = .{
+                .module_idx = external.import_idx,
+                .target_node_idx = external.target_node_idx,
+                .backing_expr = tag_expr,
+                .backing_type = .tag,
+            },
+        }, region),
+    };
+}
+
+fn addTryBranchPattern(
+    self: *Self,
+    pattern_idx: Pattern.Idx,
+    region: Region,
+) std.mem.Allocator.Error!Expr.Match.BranchPattern.Span {
+    const branch_pat_scratch_top = self.env.store.scratchMatchBranchPatternTop();
+    const branch_pattern_idx = try self.env.addMatchBranchPattern(Expr.Match.BranchPattern{
+        .pattern = pattern_idx,
+        .degenerate = false,
+    }, region);
+    try self.env.store.addScratchMatchBranchPattern(branch_pattern_idx);
+    return try self.env.store.matchBranchPatternSpanFrom(branch_pat_scratch_top);
+}
+
+fn appendTryMatchBranch(
+    self: *Self,
+    patterns: Expr.Match.BranchPattern.Span,
+    value: Expr.Idx,
+    region: Region,
+) std.mem.Allocator.Error!void {
+    const branch_idx = try self.env.addMatchBranch(
+        Expr.Match.Branch{
+            .patterns = patterns,
+            .value = value,
+            .guard = null,
+            .redundant = try self.env.types.fresh(),
+        },
+        region,
+    );
+    try self.env.store.addScratchMatchBranch(branch_idx);
+}
+
+fn appendTryOkPassthroughBranch(
+    self: *Self,
+    target: TryNominalTarget,
+    region: Region,
+) std.mem.Allocator.Error!void {
+    try self.scopeEnter(self.env.gpa, false);
+    defer self.scopeExit(self.env.gpa) catch |err| self.recordScopeExitError(err);
+
+    const ok_assign_pattern_idx = try self.env.addPattern(Pattern{
+        .assign = .{ .ident = self.env.idents.question_ok },
+    }, region);
+
+    _ = try self.scopeIntroduceInternal(self.env.gpa, .ident, self.env.idents.question_ok, ok_assign_pattern_idx, false, true);
+
+    const ok_patterns_start = self.env.store.scratchPatternTop();
+    try self.env.store.addScratchPattern(ok_assign_pattern_idx);
+    const ok_args_span = try self.env.store.patternSpanFrom(ok_patterns_start);
+    const ok_tag_pattern_idx = try self.addTryTagPattern(target, self.env.idents.ok, ok_args_span, region);
+    const ok_branch_pat_span = try self.addTryBranchPattern(ok_tag_pattern_idx, region);
+
+    const ok_lookup_idx = try self.env.addExpr(CIR.Expr{ .e_lookup_local = .{
+        .pattern_idx = ok_assign_pattern_idx,
+    } }, region);
+    try self.used_patterns.put(self.env.gpa, ok_assign_pattern_idx, {});
+
+    try self.appendTryMatchBranch(ok_branch_pat_span, ok_lookup_idx, region);
+}
+
+fn appendTryErrPayloadPattern(
+    self: *Self,
+    target: TryNominalTarget,
+    payload_pattern: Pattern.Idx,
+    region: Region,
+) std.mem.Allocator.Error!Expr.Match.BranchPattern.Span {
+    const err_patterns_start = self.env.store.scratchPatternTop();
+    try self.env.store.addScratchPattern(payload_pattern);
+    const err_args_span = try self.env.store.patternSpanFrom(err_patterns_start);
+    const err_tag_pattern_idx = try self.addTryTagPattern(target, self.env.idents.err, err_args_span, region);
+    return try self.addTryBranchPattern(err_tag_pattern_idx, region);
+}
+
+fn addTryErrAssignPatternInCurrentScope(
+    self: *Self,
+    region: Region,
+) std.mem.Allocator.Error!Pattern.Idx {
+    const err_assign_pattern_idx = try self.env.addPattern(Pattern{
+        .assign = .{ .ident = self.env.idents.question_err },
+    }, region);
+    _ = try self.scopeIntroduceInternal(self.env.gpa, .ident, self.env.idents.question_err, err_assign_pattern_idx, false, true);
+    return err_assign_pattern_idx;
+}
+
+fn addTryReturnErr(
+    self: *Self,
+    target: TryNominalTarget,
+    payload_expr: Expr.Idx,
+    region: Region,
+) std.mem.Allocator.Error!Expr.Idx {
+    const err_tag_args_start = self.env.store.scratchExprTop();
+    try self.env.store.addScratchExpr(payload_expr);
+    const err_tag_args_span = try self.env.store.exprSpanFrom(err_tag_args_start);
+    const err_tag_expr_idx = try self.addTryTagExpr(target, self.env.idents.err, err_tag_args_span, region);
+
+    return if (self.enclosing_lambda) |lambda_idx|
+        try self.env.addExpr(CIR.Expr{ .e_return = .{
+            .expr = err_tag_expr_idx,
+            .lambda = lambda_idx,
+            .context = .try_suffix,
+        } }, region)
+    else
+        try self.env.pushMalformed(Expr.Idx, Diagnostic{ .return_outside_fn = .{
+            .region = region,
+            .context = .try_suffix,
+        } });
+}
+
+fn addTryMatch(
+    self: *Self,
+    cond: Expr.Idx,
+    branches: Expr.Match.Branch.Span,
+    is_try_suffix: bool,
+    region: Region,
+) std.mem.Allocator.Error!Expr.Idx {
+    return try self.env.addExpr(CIR.Expr{ .e_match = .{
+        .cond = cond,
+        .branches = branches,
+        .exhaustive = try self.env.types.fresh(),
+        .is_try_suffix = is_try_suffix,
+        .skip_exhaustiveness = true,
+    } }, region);
+}
+
 fn finishSuffixSingleQuestionExpr(
     self: *Self,
     region: Region,
     can_cond: CanonicalizedExpr,
     free_vars_start: u32,
 ) std.mem.Allocator.Error!CanonicalizedExpr {
-    // Use pre-interned identifiers for the Ok/Err values and tag names
-    const ok_val_ident = self.env.idents.question_ok;
-    const err_val_ident = self.env.idents.question_err;
-    const ok_tag_ident = self.env.idents.ok;
-    const err_tag_ident = self.env.idents.err;
+    const try_target = try self.resolveTryNominalTarget();
 
-    // Look up Try type for nominal wrapping (improves error messages)
-    const try_ident = self.env.idents.@"try";
-    const try_nominal_info: ?struct { import_idx: CIR.Import.Idx, target_node_idx: u32 } = blk: {
-        if (try self.scopeLookupTypeBinding(try_ident)) |type_binding_loc| {
-            switch (type_binding_loc.binding.*) {
-                .external_nominal => |ext| {
-                    if (ext.import_idx) |import_idx| {
-                        if (ext.target_node_idx) |target_node_idx| {
-                            break :blk .{ .import_idx = import_idx, .target_node_idx = target_node_idx };
-                        }
-                    }
-                },
-                else => {},
-            }
-        }
-        break :blk null;
-    };
-
-    // Mark the start of scratch match branches
     const scratch_top = self.env.store.scratchMatchBranchTop();
+    try self.appendTryOkPassthroughBranch(try_target, region);
 
-    // === Branch 1: Ok(#ok) => #ok ===
     {
-        // Enter a new scope for this branch
         try self.scopeEnter(self.env.gpa, false);
         defer self.scopeExit(self.env.gpa) catch |err| self.recordScopeExitError(err);
 
-        // Create the assign pattern for the Ok value
-        const ok_assign_pattern_idx = try self.env.addPattern(Pattern{
-            .assign = .{ .ident = ok_val_ident },
-        }, region);
+        const err_assign_pattern_idx = try self.addTryErrAssignPatternInCurrentScope(region);
+        const err_branch_pat_span = try self.appendTryErrPayloadPattern(try_target, err_assign_pattern_idx, region);
 
-        // Introduce the pattern into scope
-        _ = try self.scopeIntroduceInternal(self.env.gpa, .ident, ok_val_ident, ok_assign_pattern_idx, false, true);
-
-        // Create pattern span for Ok tag argument
-        const ok_patterns_start = self.env.store.scratchPatternTop();
-        try self.env.store.addScratchPattern(ok_assign_pattern_idx);
-        const ok_args_span = try self.env.store.patternSpanFrom(ok_patterns_start);
-
-        // Create the Ok tag pattern: Ok(#ok), wrapped in nominal_external if Try type is available
-        const ok_tag_pattern_idx = blk: {
-            const applied_tag_pattern = try self.env.addPattern(Pattern{
-                .applied_tag = .{
-                    .name = ok_tag_ident,
-                    .args = ok_args_span,
-                },
-            }, region);
-
-            if (try_nominal_info) |info| {
-                break :blk try self.env.addPattern(Pattern{
-                    .nominal_external = .{
-                        .module_idx = info.import_idx,
-                        .target_node_idx = info.target_node_idx,
-                        .backing_pattern = applied_tag_pattern,
-                        .backing_type = .tag,
-                    },
-                }, region);
-            }
-            break :blk applied_tag_pattern;
-        };
-
-        // Create branch pattern
-        const branch_pat_scratch_top = self.env.store.scratchMatchBranchPatternTop();
-        const ok_branch_pattern_idx = try self.env.addMatchBranchPattern(Expr.Match.BranchPattern{
-            .pattern = ok_tag_pattern_idx,
-            .degenerate = false,
-        }, region);
-        try self.env.store.addScratchMatchBranchPattern(ok_branch_pattern_idx);
-        const ok_branch_pat_span = try self.env.store.matchBranchPatternSpanFrom(branch_pat_scratch_top);
-
-        // Create the branch body: lookup #ok
-        const ok_lookup_idx = try self.env.addExpr(CIR.Expr{ .e_lookup_local = .{
-            .pattern_idx = ok_assign_pattern_idx,
+        const err_lookup_idx = try self.env.addExpr(CIR.Expr{ .e_lookup_local = .{
+            .pattern_idx = err_assign_pattern_idx,
         } }, region);
-        // Mark the pattern as used
-        try self.used_patterns.put(self.env.gpa, ok_assign_pattern_idx, {});
+        try self.used_patterns.put(self.env.gpa, err_assign_pattern_idx, {});
 
-        // Create the Ok branch
-        const ok_branch_idx = try self.env.addMatchBranch(
-            Expr.Match.Branch{
-                .patterns = ok_branch_pat_span,
-                .value = ok_lookup_idx,
-                .guard = null,
-                .redundant = try self.env.types.fresh(),
-            },
-            region,
-        );
-        try self.env.store.addScratchMatchBranch(ok_branch_idx);
-    }
-
-    // === Branch 2: Err(#err) => return Err(#err) ===
-    {
-        // Enter a new scope for this branch
-        try self.scopeEnter(self.env.gpa, false);
-        defer self.scopeExit(self.env.gpa) catch |err| self.recordScopeExitError(err);
-
-        // Create the assign pattern for the Err value
-        const err_assign_pattern_idx = try self.env.addPattern(Pattern{
-            .assign = .{ .ident = err_val_ident },
-        }, region);
-
-        // Introduce the pattern into scope
-        _ = try self.scopeIntroduceInternal(self.env.gpa, .ident, err_val_ident, err_assign_pattern_idx, false, true);
-
-        // Create pattern span for Err tag argument
-        const err_patterns_start = self.env.store.scratchPatternTop();
-        try self.env.store.addScratchPattern(err_assign_pattern_idx);
-        const err_args_span = try self.env.store.patternSpanFrom(err_patterns_start);
-
-        // Create the Err tag pattern: Err(#err), wrapped in nominal_external if Try type is available
-        const err_tag_pattern_idx = blk: {
-            const applied_tag_pattern = try self.env.addPattern(Pattern{
-                .applied_tag = .{
-                    .name = err_tag_ident,
-                    .args = err_args_span,
-                },
-            }, region);
-
-            if (try_nominal_info) |info| {
-                break :blk try self.env.addPattern(Pattern{
-                    .nominal_external = .{
-                        .module_idx = info.import_idx,
-                        .target_node_idx = info.target_node_idx,
-                        .backing_pattern = applied_tag_pattern,
-                        .backing_type = .tag,
-                    },
-                }, region);
-            }
-            break :blk applied_tag_pattern;
-        };
-
-        // Create branch pattern
-        const branch_pat_scratch_top = self.env.store.scratchMatchBranchPatternTop();
-        const err_branch_pattern_idx = try self.env.addMatchBranchPattern(Expr.Match.BranchPattern{
-            .pattern = err_tag_pattern_idx,
-            .degenerate = false,
-        }, region);
-        try self.env.store.addScratchMatchBranchPattern(err_branch_pattern_idx);
-        const err_branch_pat_span = try self.env.store.matchBranchPatternSpanFrom(branch_pat_scratch_top);
-
-        // Create the branch body
         const branch_value_idx = if (self.in_expect) blk: {
-            // Inside a top-level expect: consume the Err payload and fail the
-            // entire expect at runtime, reporting the payload value.
-            const err_lookup_idx = try self.env.addExpr(CIR.Expr{ .e_lookup_local = .{
-                .pattern_idx = err_assign_pattern_idx,
-            } }, region);
-            try self.used_patterns.put(self.env.gpa, err_assign_pattern_idx, {});
-
             break :blk try self.env.addExpr(CIR.Expr{ .e_expect_err = .{
                 .expr = err_lookup_idx,
                 .snippet = try self.env.insertString(self.env.getSource(region)),
             } }, region);
-        } else blk: {
-            // Normal case: return Err(#err)
-            // First, create lookup for #err
-            const err_lookup_idx = try self.env.addExpr(CIR.Expr{ .e_lookup_local = .{
-                .pattern_idx = err_assign_pattern_idx,
-            } }, region);
-            // Mark the pattern as used
-            try self.used_patterns.put(self.env.gpa, err_assign_pattern_idx, {});
+        } else try self.addTryReturnErr(try_target, err_lookup_idx, region);
 
-            // Create Err(#err) tag expression, wrapped in e_nominal_external if Try type is available
-            const err_tag_args_start = self.env.store.scratchExprTop();
-            try self.env.store.addScratchExpr(err_lookup_idx);
-            const err_tag_args_span = try self.env.store.exprSpanFrom(err_tag_args_start);
-
-            const err_tag_expr_idx = expr_blk: {
-                const tag_expr = try self.env.addExpr(CIR.Expr{
-                    .e_tag = .{
-                        .name = err_tag_ident,
-                        .args = err_tag_args_span,
-                    },
-                }, region);
-
-                if (try_nominal_info) |info| {
-                    break :expr_blk try self.env.addExpr(CIR.Expr{
-                        .e_nominal_external = .{
-                            .module_idx = info.import_idx,
-                            .target_node_idx = info.target_node_idx,
-                            .backing_expr = tag_expr,
-                            .backing_type = .tag,
-                        },
-                    }, region);
-                }
-                break :expr_blk tag_expr;
-            };
-
-            // Create return Err(#err) expression
-            break :blk if (self.enclosing_lambda) |lambda_idx|
-                try self.env.addExpr(CIR.Expr{ .e_return = .{
-                    .expr = err_tag_expr_idx,
-                    .lambda = lambda_idx,
-                    .context = .try_suffix,
-                } }, region)
-            else
-                try self.env.pushMalformed(Expr.Idx, Diagnostic{ .return_outside_fn = .{
-                    .region = region,
-                    .context = .try_suffix,
-                } });
-        };
-
-        // Create the Err branch
-        const err_branch_idx = try self.env.addMatchBranch(
-            Expr.Match.Branch{
-                .patterns = err_branch_pat_span,
-                .value = branch_value_idx,
-                .guard = null,
-                .redundant = try self.env.types.fresh(),
-            },
-            region,
-        );
-        try self.env.store.addScratchMatchBranch(err_branch_idx);
+        try self.appendTryMatchBranch(err_branch_pat_span, branch_value_idx, region);
     }
 
-    // Create span from scratch branches
     const branches_span = try self.env.store.matchBranchSpanFrom(scratch_top);
-
-    // Create the match expression (is_try_suffix = true since this comes from `?`)
-    const match_expr = Expr.Match{
-        .cond = can_cond.idx,
-        .branches = branches_span,
-        .exhaustive = try self.env.types.fresh(),
-        .is_try_suffix = true,
-        .skip_exhaustiveness = true,
-    };
-    const expr_idx = try self.env.addExpr(CIR.Expr{ .e_match = match_expr }, region);
-
+    const expr_idx = try self.addTryMatch(can_cond.idx, branches_span, true, region);
     const free_vars_span = self.scratch_free_vars.spanFrom(free_vars_start);
     return CanonicalizedExpr{ .idx = expr_idx, .free_vars = free_vars_span };
 }
@@ -7434,139 +7565,18 @@ fn finishSingleQuestionBinop(
     const rhs_is_bare_tag = rhs_ast == .tag;
     std.debug.assert(rhs_is_bare_tag == (can_rhs_idx == null));
 
-    // Use pre-interned identifiers for the Ok/Err values and tag names
-    const ok_val_ident = self.env.idents.question_ok;
-    const err_val_ident = self.env.idents.question_err;
-    const ok_tag_ident = self.env.idents.ok;
-    const err_tag_ident = self.env.idents.err;
+    const try_target = try self.resolveTryNominalTarget();
 
-    // Look up Try type for nominal wrapping (improves error messages)
-    const try_ident = self.env.idents.@"try";
-    const try_nominal_info: ?struct { import_idx: CIR.Import.Idx, target_node_idx: u32 } = blk: {
-        if (try self.scopeLookupTypeBinding(try_ident)) |type_binding_loc| {
-            switch (type_binding_loc.binding.*) {
-                .external_nominal => |ext| {
-                    if (ext.import_idx) |import_idx| {
-                        if (ext.target_node_idx) |target_node_idx| {
-                            break :blk .{ .import_idx = import_idx, .target_node_idx = target_node_idx };
-                        }
-                    }
-                },
-                else => {},
-            }
-        }
-        break :blk null;
-    };
-
-    // Mark the start of scratch match branches
     const scratch_top = self.env.store.scratchMatchBranchTop();
+    try self.appendTryOkPassthroughBranch(try_target, region);
 
-    // === Branch 1: Ok(#ok) => #ok ===
     {
         try self.scopeEnter(self.env.gpa, false);
         defer self.scopeExit(self.env.gpa) catch |err| self.recordScopeExitError(err);
 
-        const ok_assign_pattern_idx = try self.env.addPattern(Pattern{
-            .assign = .{ .ident = ok_val_ident },
-        }, region);
+        const err_assign_pattern_idx = try self.addTryErrAssignPatternInCurrentScope(region);
+        const err_branch_pat_span = try self.appendTryErrPayloadPattern(try_target, err_assign_pattern_idx, region);
 
-        _ = try self.scopeIntroduceInternal(self.env.gpa, .ident, ok_val_ident, ok_assign_pattern_idx, false, true);
-
-        const ok_patterns_start = self.env.store.scratchPatternTop();
-        try self.env.store.addScratchPattern(ok_assign_pattern_idx);
-        const ok_args_span = try self.env.store.patternSpanFrom(ok_patterns_start);
-
-        const ok_tag_pattern_idx = ok_blk: {
-            const applied_tag_pattern = try self.env.addPattern(Pattern{
-                .applied_tag = .{
-                    .name = ok_tag_ident,
-                    .args = ok_args_span,
-                },
-            }, region);
-
-            if (try_nominal_info) |info| {
-                break :ok_blk try self.env.addPattern(Pattern{
-                    .nominal_external = .{
-                        .module_idx = info.import_idx,
-                        .target_node_idx = info.target_node_idx,
-                        .backing_pattern = applied_tag_pattern,
-                        .backing_type = .tag,
-                    },
-                }, region);
-            }
-            break :ok_blk applied_tag_pattern;
-        };
-
-        const branch_pat_scratch_top = self.env.store.scratchMatchBranchPatternTop();
-        const ok_branch_pattern_idx = try self.env.addMatchBranchPattern(Expr.Match.BranchPattern{
-            .pattern = ok_tag_pattern_idx,
-            .degenerate = false,
-        }, region);
-        try self.env.store.addScratchMatchBranchPattern(ok_branch_pattern_idx);
-        const ok_branch_pat_span = try self.env.store.matchBranchPatternSpanFrom(branch_pat_scratch_top);
-
-        const ok_lookup_idx = try self.env.addExpr(CIR.Expr{ .e_lookup_local = .{
-            .pattern_idx = ok_assign_pattern_idx,
-        } }, region);
-        try self.used_patterns.put(self.env.gpa, ok_assign_pattern_idx, {});
-
-        const ok_branch_idx = try self.env.addMatchBranch(
-            Expr.Match.Branch{
-                .patterns = ok_branch_pat_span,
-                .value = ok_lookup_idx,
-                .guard = null,
-                .redundant = try self.env.types.fresh(),
-            },
-            region,
-        );
-        try self.env.store.addScratchMatchBranch(ok_branch_idx);
-    }
-
-    // === Branch 2: Err(#err) => return Err(<handler>(#err)) ===
-    {
-        try self.scopeEnter(self.env.gpa, false);
-        defer self.scopeExit(self.env.gpa) catch |err| self.recordScopeExitError(err);
-
-        const err_assign_pattern_idx = try self.env.addPattern(Pattern{
-            .assign = .{ .ident = err_val_ident },
-        }, region);
-
-        _ = try self.scopeIntroduceInternal(self.env.gpa, .ident, err_val_ident, err_assign_pattern_idx, false, true);
-
-        const err_patterns_start = self.env.store.scratchPatternTop();
-        try self.env.store.addScratchPattern(err_assign_pattern_idx);
-        const err_args_span = try self.env.store.patternSpanFrom(err_patterns_start);
-
-        const err_tag_pattern_idx = err_blk: {
-            const applied_tag_pattern = try self.env.addPattern(Pattern{
-                .applied_tag = .{
-                    .name = err_tag_ident,
-                    .args = err_args_span,
-                },
-            }, region);
-
-            if (try_nominal_info) |info| {
-                break :err_blk try self.env.addPattern(Pattern{
-                    .nominal_external = .{
-                        .module_idx = info.import_idx,
-                        .target_node_idx = info.target_node_idx,
-                        .backing_pattern = applied_tag_pattern,
-                        .backing_type = .tag,
-                    },
-                }, region);
-            }
-            break :err_blk applied_tag_pattern;
-        };
-
-        const branch_pat_scratch_top = self.env.store.scratchMatchBranchPatternTop();
-        const err_branch_pattern_idx = try self.env.addMatchBranchPattern(Expr.Match.BranchPattern{
-            .pattern = err_tag_pattern_idx,
-            .degenerate = false,
-        }, region);
-        try self.env.store.addScratchMatchBranchPattern(err_branch_pattern_idx);
-        const err_branch_pat_span = try self.env.store.matchBranchPatternSpanFrom(branch_pat_scratch_top);
-
-        // Build lookup for the bound #err
         const err_lookup_idx = try self.env.addExpr(CIR.Expr{ .e_lookup_local = .{
             .pattern_idx = err_assign_pattern_idx,
         } }, region);
@@ -7612,72 +7622,13 @@ fn finishSingleQuestionBinop(
                 .expr = transformed_err_idx,
                 .snippet = try self.env.insertString(self.env.getSource(region)),
             } }, region);
-        } else blk: {
-            // Wrap the mapped err in Err(...), itself wrapped in e_nominal_external
-            // if the Try type is available.
-            const err_tag_args_start = self.env.store.scratchExprTop();
-            try self.env.store.addScratchExpr(transformed_err_idx);
-            const err_tag_args_span = try self.env.store.exprSpanFrom(err_tag_args_start);
+        } else try self.addTryReturnErr(try_target, transformed_err_idx, region);
 
-            const err_tag_expr_idx = expr_blk: {
-                const tag_expr = try self.env.addExpr(CIR.Expr{
-                    .e_tag = .{
-                        .name = err_tag_ident,
-                        .args = err_tag_args_span,
-                    },
-                }, region);
-
-                if (try_nominal_info) |info| {
-                    break :expr_blk try self.env.addExpr(CIR.Expr{
-                        .e_nominal_external = .{
-                            .module_idx = info.import_idx,
-                            .target_node_idx = info.target_node_idx,
-                            .backing_expr = tag_expr,
-                            .backing_type = .tag,
-                        },
-                    }, region);
-                }
-                break :expr_blk tag_expr;
-            };
-
-            // Wrap in return
-            break :blk if (self.enclosing_lambda) |lambda_idx|
-                try self.env.addExpr(CIR.Expr{ .e_return = .{
-                    .expr = err_tag_expr_idx,
-                    .lambda = lambda_idx,
-                    .context = .try_suffix,
-                } }, region)
-            else
-                try self.env.pushMalformed(Expr.Idx, Diagnostic{ .return_outside_fn = .{
-                    .region = region,
-                    .context = .try_suffix,
-                } });
-        };
-
-        const err_branch_idx = try self.env.addMatchBranch(
-            Expr.Match.Branch{
-                .patterns = err_branch_pat_span,
-                .value = branch_value_idx,
-                .guard = null,
-                .redundant = try self.env.types.fresh(),
-            },
-            region,
-        );
-        try self.env.store.addScratchMatchBranch(err_branch_idx);
+        try self.appendTryMatchBranch(err_branch_pat_span, branch_value_idx, region);
     }
 
     const branches_span = try self.env.store.matchBranchSpanFrom(scratch_top);
-
-    // is_try_suffix = true since this comes from `?` (early return semantics)
-    const match_expr = Expr.Match{
-        .cond = can_lhs.idx,
-        .branches = branches_span,
-        .exhaustive = try self.env.types.fresh(),
-        .is_try_suffix = true,
-        .skip_exhaustiveness = true,
-    };
-    const expr_idx = try self.env.addExpr(CIR.Expr{ .e_match = match_expr }, region);
-
+    const expr_idx = try self.addTryMatch(can_lhs.idx, branches_span, true, region);
     const free_vars_span = self.scratch_free_vars.spanFrom(free_vars_start);
 
     return CanonicalizedExpr{ .idx = expr_idx, .free_vars = free_vars_span };
@@ -12965,180 +12916,26 @@ fn canonicalizeDoubleQuestionOp(
     can_rhs: CanonicalizedExpr,
     free_vars_start: u32,
 ) std.mem.Allocator.Error!CanonicalizedExpr {
-    // Use pre-interned identifiers for the Ok value and tag names
-    const ok_val_ident = self.env.idents.question_ok;
-    const ok_tag_ident = self.env.idents.ok;
-    const err_tag_ident = self.env.idents.err;
+    const try_target = try self.resolveTryNominalTarget();
 
-    // Look up Try type for nominal wrapping (improves error messages)
-    const try_ident = self.env.idents.@"try";
-    const try_nominal_info: ?struct { import_idx: CIR.Import.Idx, target_node_idx: u32 } = blk: {
-        if (try self.scopeLookupTypeBinding(try_ident)) |type_binding_loc| {
-            switch (type_binding_loc.binding.*) {
-                .external_nominal => |ext| {
-                    if (ext.import_idx) |import_idx| {
-                        if (ext.target_node_idx) |target_node_idx| {
-                            break :blk .{ .import_idx = import_idx, .target_node_idx = target_node_idx };
-                        }
-                    }
-                },
-                else => {},
-            }
-        }
-        break :blk null;
-    };
-
-    // Mark the start of scratch match branches
     const scratch_top = self.env.store.scratchMatchBranchTop();
+    try self.appendTryOkPassthroughBranch(try_target, region);
 
-    // === Branch 1: Ok(#ok) => #ok ===
     {
-        // Enter a new scope for this branch
         try self.scopeEnter(self.env.gpa, false);
         defer self.scopeExit(self.env.gpa) catch |err| self.recordScopeExitError(err);
 
-        // Create the assign pattern for the Ok value
-        const ok_assign_pattern_idx = try self.env.addPattern(Pattern{
-            .assign = .{ .ident = ok_val_ident },
-        }, region);
-
-        // Introduce the pattern into scope
-        _ = try self.scopeIntroduceInternal(self.env.gpa, .ident, ok_val_ident, ok_assign_pattern_idx, false, true);
-
-        // Create pattern span for Ok tag argument
-        const ok_patterns_start = self.env.store.scratchPatternTop();
-        try self.env.store.addScratchPattern(ok_assign_pattern_idx);
-        const ok_args_span = try self.env.store.patternSpanFrom(ok_patterns_start);
-
-        // Create the Ok tag pattern: Ok(#ok), wrapped in nominal_external if Try type is available
-        const ok_tag_pattern_idx = ok_blk: {
-            const applied_tag_pattern = try self.env.addPattern(Pattern{
-                .applied_tag = .{
-                    .name = ok_tag_ident,
-                    .args = ok_args_span,
-                },
-            }, region);
-
-            if (try_nominal_info) |info| {
-                break :ok_blk try self.env.addPattern(Pattern{
-                    .nominal_external = .{
-                        .module_idx = info.import_idx,
-                        .target_node_idx = info.target_node_idx,
-                        .backing_pattern = applied_tag_pattern,
-                        .backing_type = .tag,
-                    },
-                }, region);
-            }
-            break :ok_blk applied_tag_pattern;
-        };
-
-        // Create branch pattern
-        const branch_pat_scratch_top = self.env.store.scratchMatchBranchPatternTop();
-        const ok_branch_pattern_idx = try self.env.addMatchBranchPattern(Expr.Match.BranchPattern{
-            .pattern = ok_tag_pattern_idx,
-            .degenerate = false,
-        }, region);
-        try self.env.store.addScratchMatchBranchPattern(ok_branch_pattern_idx);
-        const ok_branch_pat_span = try self.env.store.matchBranchPatternSpanFrom(branch_pat_scratch_top);
-
-        // Create the branch body: lookup #ok
-        const ok_lookup_idx = try self.env.addExpr(CIR.Expr{ .e_lookup_local = .{
-            .pattern_idx = ok_assign_pattern_idx,
-        } }, region);
-        // Mark the pattern as used
-        try self.used_patterns.put(self.env.gpa, ok_assign_pattern_idx, {});
-
-        // Create the Ok branch
-        const ok_branch_idx = try self.env.addMatchBranch(
-            Expr.Match.Branch{
-                .patterns = ok_branch_pat_span,
-                .value = ok_lookup_idx,
-                .guard = null,
-                .redundant = try self.env.types.fresh(),
-            },
-            region,
-        );
-        try self.env.store.addScratchMatchBranch(ok_branch_idx);
-    }
-
-    // === Branch 2: Err(_) => default value ===
-    {
-        // Enter a new scope for this branch
-        try self.scopeEnter(self.env.gpa, false);
-        defer self.scopeExit(self.env.gpa) catch |err| self.recordScopeExitError(err);
-
-        // Create a wildcard pattern for the Err payload (we don't use it)
         const wildcard_pattern_idx = try self.env.addPattern(Pattern{
             .underscore = {},
         }, region);
+        const err_branch_pat_span = try self.appendTryErrPayloadPattern(try_target, wildcard_pattern_idx, region);
 
-        // Create pattern span for Err tag argument (the wildcard)
-        const err_patterns_start = self.env.store.scratchPatternTop();
-        try self.env.store.addScratchPattern(wildcard_pattern_idx);
-        const err_args_span = try self.env.store.patternSpanFrom(err_patterns_start);
-
-        // Create the Err tag pattern: Err(_), wrapped in nominal_external if Try type is available
-        const err_tag_pattern_idx = err_blk: {
-            const applied_tag_pattern = try self.env.addPattern(Pattern{
-                .applied_tag = .{
-                    .name = err_tag_ident,
-                    .args = err_args_span,
-                },
-            }, region);
-
-            if (try_nominal_info) |info| {
-                break :err_blk try self.env.addPattern(Pattern{
-                    .nominal_external = .{
-                        .module_idx = info.import_idx,
-                        .target_node_idx = info.target_node_idx,
-                        .backing_pattern = applied_tag_pattern,
-                        .backing_type = .tag,
-                    },
-                }, region);
-            }
-            break :err_blk applied_tag_pattern;
-        };
-
-        // Create branch pattern
-        const branch_pat_scratch_top = self.env.store.scratchMatchBranchPatternTop();
-        const err_branch_pattern_idx = try self.env.addMatchBranchPattern(Expr.Match.BranchPattern{
-            .pattern = err_tag_pattern_idx,
-            .degenerate = false,
-        }, region);
-        try self.env.store.addScratchMatchBranchPattern(err_branch_pattern_idx);
-        const err_branch_pat_span = try self.env.store.matchBranchPatternSpanFrom(branch_pat_scratch_top);
-
-        // Branch value is the rhs expression (already canonicalized as can_rhs)
-        const branch_value_idx = can_rhs.idx;
-
-        // Create the Err branch
-        const err_branch_idx = try self.env.addMatchBranch(
-            Expr.Match.Branch{
-                .patterns = err_branch_pat_span,
-                .value = branch_value_idx,
-                .guard = null,
-                .redundant = try self.env.types.fresh(),
-            },
-            region,
-        );
-        try self.env.store.addScratchMatchBranch(err_branch_idx);
+        try self.appendTryMatchBranch(err_branch_pat_span, can_rhs.idx, region);
     }
 
-    // Create span from scratch branches
     const branches_span = try self.env.store.matchBranchSpanFrom(scratch_top);
+    const expr_idx = try self.addTryMatch(can_lhs.idx, branches_span, false, region);
 
-    // Create the match expression
-    // Note: is_try_suffix = false since ?? doesn't do early return like ?
-    const match_expr = Expr.Match{
-        .cond = can_lhs.idx,
-        .branches = branches_span,
-        .exhaustive = try self.env.types.fresh(),
-        .is_try_suffix = false,
-        .skip_exhaustiveness = true,
-    };
-    const expr_idx = try self.env.addExpr(CIR.Expr{ .e_match = match_expr }, region);
-
-    // Combine free vars from both lhs and rhs
     const free_vars_span = self.scratch_free_vars.spanFrom(free_vars_start);
     _ = e; // unused, but kept for consistency with other handlers
 
@@ -19413,132 +19210,20 @@ pub fn introduceType(
     type_decl_stmt: Statement.Idx,
     region: Region,
 ) std.mem.Allocator.Error!void {
-    const gpa = self.env.gpa;
-
-    const current_scope = &self.scopes.items[self.scopes.items.len - 1];
-    const shadowed_external_region: ?Region = if (current_scope.type_bindings.get(name_ident)) |binding| switch (binding) {
-        .external_nominal => |external| external.origin_region,
-        else => null,
-    } else null;
-
-    const ShadowedType = union(enum) {
-        statement: Statement.Idx,
-        region: Region,
-    };
-
-    // Check for shadowing in parent scopes
-    var shadowed_in_parent: ?ShadowedType = null;
-    if (self.scopes.items.len > 1) {
-        var i = self.scopes.items.len - 1;
-        while (i > 0) {
-            i -= 1;
-            const scope = &self.scopes.items[i];
-            if (scope.type_bindings.get(name_ident)) |binding| {
-                shadowed_in_parent = switch (binding) {
-                    .local_nominal => |stmt| .{ .statement = stmt },
-                    .local_alias => |stmt| .{ .statement = stmt },
-                    .associated_nominal => |stmt| .{ .statement = stmt },
-                    .external_nominal => |external| .{ .region = external.origin_region },
-                };
-                break;
-            }
-        }
-    }
-
-    // Determine if this is an alias or nominal type based on the statement
     const stmt = self.env.store.getStatement(type_decl_stmt);
-    const is_alias = stmt == .s_alias_decl;
-    if (shadowed_external_region) |original_region| {
-        try current_scope.type_bindings.put(
-            gpa,
-            name_ident,
-            if (is_alias) Scope.TypeBinding{ .local_alias = type_decl_stmt } else Scope.TypeBinding{ .local_nominal = type_decl_stmt },
-        );
-        try self.env.pushDiagnostic(Diagnostic{
-            .shadowing_warning = .{
-                .ident = name_ident,
-                .region = region,
-                .original_region = original_region,
-            },
-        });
-        return;
-    }
+    const input = if (stmt == .s_alias_decl)
+        Scope.TypeBindingInput{ .local_alias = type_decl_stmt }
+    else
+        Scope.TypeBindingInput{ .local_nominal = type_decl_stmt };
 
-    const result = try current_scope.introduceTypeDeclWithKind(gpa, name_ident, type_decl_stmt, is_alias, null);
-
-    switch (result) {
-        .success => {
-            // Check if we're shadowing a type in a parent scope
-            if (shadowed_in_parent) |shadowed| {
-                const original_region = switch (shadowed) {
-                    .statement => |shadowed_stmt| self.env.store.getStatementRegion(shadowed_stmt),
-                    .region => |original_region| original_region,
-                };
-                try self.env.pushDiagnostic(Diagnostic{
-                    .shadowing_warning = .{
-                        .ident = name_ident,
-                        .region = region,
-                        .original_region = original_region,
-                    },
-                });
-            }
-        },
-        // No parent lookup function is passed, so shadowing can't be detected
-        .shadowing_warning => unreachable,
-        .redeclared_error => |original_stmt| {
-            // Extract region information from the original statement
-            const original_region = self.env.store.getStatementRegion(original_stmt);
-            try self.env.pushDiagnostic(Diagnostic{
-                .type_redeclared = .{
-                    .original_region = original_region,
-                    .redeclared_region = region,
-                    .name = name_ident,
-                },
-            });
-        },
-        .type_alias_redeclared => |original_stmt| {
-            const original_region = self.env.store.getStatementRegion(original_stmt);
-            try self.env.pushDiagnostic(Diagnostic{
-                .type_alias_redeclared = .{
-                    .name = name_ident,
-                    .original_region = original_region,
-                    .redeclared_region = region,
-                },
-            });
-        },
-        .nominal_type_redeclared => |original_stmt| {
-            const original_region = self.env.store.getStatementRegion(original_stmt);
-            try self.env.pushDiagnostic(Diagnostic{
-                .nominal_type_redeclared = .{
-                    .name = name_ident,
-                    .original_region = original_region,
-                    .redeclared_region = region,
-                },
-            });
-        },
-        .cross_scope_shadowing => |shadowed_stmt| {
-            const original_region = self.env.store.getStatementRegion(shadowed_stmt);
-            try self.env.pushDiagnostic(Diagnostic{
-                .type_shadowed_warning = .{
-                    .name = name_ident,
-                    .region = region,
-                    .original_region = original_region,
-                    .cross_scope = true,
-                },
-            });
-        },
-        .parameter_conflict => |conflict| {
-            const original_region = self.env.store.getStatementRegion(conflict.original_stmt);
-            try self.env.pushDiagnostic(Diagnostic{
-                .type_parameter_conflict = .{
-                    .name = name_ident,
-                    .parameter_name = conflict.conflicting_parameter,
-                    .region = region,
-                    .original_region = original_region,
-                },
-            });
-        },
-    }
+    const decision = try Scope.introduceTypeBinding(
+        self.env.gpa,
+        self.scopes.items,
+        self.scopes.items.len - 1,
+        name_ident,
+        input,
+    );
+    try self.handleTypeBindingDecision(name_ident, region, decision, true);
 }
 
 /// Check if an identifier is a placeholder, with fast path for empty map (99% of files).
@@ -19776,7 +19461,7 @@ pub fn scopeIntroduceExposedItem(self: *Self, item_name: Ident.Idx, item_info: S
 /// Also adds the qualified type name to the import mapping for error message display.
 fn setExternalTypeBinding(
     self: *Self,
-    scope: *Scope,
+    scope_idx: usize,
     local_ident: Ident.Idx,
     module_ident: Ident.Idx,
     original_ident: Ident.Idx,
@@ -19786,49 +19471,40 @@ fn setExternalTypeBinding(
     origin_region: Region,
     module_found_status: ModuleFoundStatus,
 ) Allocator.Error!void {
-    // Check if type already exists in this scope (mirrors Scope.introduceTypeDecl logic)
-    if (scope.type_bindings.get(local_ident)) |existing_binding| {
-        // Binding the same external type to the same name twice is idempotent,
-        // not a conflict. This happens when a type module's main type is both
-        // auto-exposed and named explicitly, as in `import M exposing [M]`.
-        switch (existing_binding) {
-            .external_nominal => |ext| {
-                if (ext.module_ident.eql(module_ident) and ext.original_ident.eql(original_ident)) {
-                    return;
-                }
-            },
-            else => {},
-        }
+    const external = Scope.ExternalTypeBinding{
+        .module_ident = module_ident,
+        .original_ident = original_ident,
+        .target_node_idx = target_node_idx,
+        .import_idx = module_import_idx,
+        .origin_region = origin_region,
+        .module_not_found = module_found_status == .module_not_found,
+    };
 
-        // Extract the original region from the existing binding for the diagnostic
-        const original_region = switch (existing_binding) {
-            .local_nominal, .local_alias, .associated_nominal => Region.zero(),
-            .external_nominal => |ext| ext.origin_region,
-        };
+    const decision = try Scope.introduceTypeBinding(
+        self.env.gpa,
+        self.scopes.items,
+        scope_idx,
+        local_ident,
+        Scope.TypeBindingInput{ .external_nominal = external },
+    );
 
-        // Report duplicate definition error
-        try self.env.pushDiagnostic(Diagnostic{
-            .shadowing_warning = .{
-                .ident = local_ident,
-                .region = origin_region,
-                .original_region = original_region,
-            },
-        });
+    const add_import_mapping = switch (decision) {
+        .inserted,
+        .inserted_shadowing_parent,
+        .idempotent_current,
+        => true,
+        .replaced_current_external,
+        .rejected_current_conflict,
+        .redeclared_current,
+        => false,
+    };
 
-        // Don't add the duplicate binding
+    if (!add_import_mapping) {
+        try self.handleTypeBindingDecision(local_ident, origin_region, decision, true);
         return;
     }
 
-    try scope.type_bindings.put(self.env.gpa, local_ident, Scope.TypeBinding{
-        .external_nominal = .{
-            .module_ident = module_ident,
-            .original_ident = original_ident,
-            .target_node_idx = target_node_idx,
-            .import_idx = module_import_idx,
-            .origin_region = origin_region,
-            .module_not_found = module_found_status == .module_not_found,
-        },
-    });
+    try self.handleTypeBindingDecision(local_ident, origin_region, decision, true);
 
     // Add to import mapping: qualified_name -> local_name
     // This allows error messages to display the user's preferred name for the type

--- a/src/canonicalize/Scope.zig
+++ b/src/canonicalize/Scope.zig
@@ -189,18 +189,22 @@ pub const IntroduceResult = union(enum) {
     var_reassignment_ok: CIR.Pattern.Idx, // Var reassignment - return existing pattern
 };
 
-/// Result of introducing a type declaration
-pub const TypeIntroduceResult = union(enum) {
-    success: void,
-    shadowing_warning: CIR.Statement.Idx, // The type declaration that was shadowed
-    redeclared_error: CIR.Statement.Idx, // The type declaration that was redeclared
-    type_alias_redeclared: CIR.Statement.Idx, // The type alias that was redeclared
-    nominal_type_redeclared: CIR.Statement.Idx, // The nominal type that was redeclared
-    cross_scope_shadowing: CIR.Statement.Idx, // Type shadowed across different scopes
-    parameter_conflict: struct {
-        original_stmt: CIR.Statement.Idx,
-        conflicting_parameter: base.Ident.Idx,
-    },
+/// A requested type-name binding introduction.
+pub const TypeBindingInput = union(enum) {
+    local_nominal: CIR.Statement.Idx,
+    local_alias: CIR.Statement.Idx,
+    associated_nominal: CIR.Statement.Idx,
+    external_nominal: ExternalTypeBinding,
+};
+
+/// The outcome of applying type-name binding policy to a scope.
+pub const TypeBindingDecision = union(enum) {
+    inserted,
+    inserted_shadowing_parent: TypeBinding,
+    replaced_current_external: ExternalTypeBinding,
+    idempotent_current,
+    rejected_current_conflict: TypeBinding,
+    redeclared_current: TypeBinding,
 };
 
 /// Result of introducing a type variable
@@ -281,123 +285,107 @@ pub fn put(scope: *Scope, gpa: std.mem.Allocator, comptime item_kind: ItemKind, 
     try scope.items(item_kind).put(gpa, name, value);
 }
 
-/// Introduce a type declaration into the scope
-pub fn introduceTypeDecl(
-    scope: *Scope,
-    gpa: std.mem.Allocator,
+/// Return the statement behind a local type binding, if it has one.
+pub fn typeBindingStatement(binding: TypeBinding) ?CIR.Statement.Idx {
+    return switch (binding) {
+        .local_nominal => |stmt| stmt,
+        .local_alias => |stmt| stmt,
+        .associated_nominal => |stmt| stmt,
+        .external_nominal => null,
+    };
+}
+
+/// Convert an introduction request to the binding that would be stored.
+pub fn inputToBinding(input: TypeBindingInput) TypeBinding {
+    return switch (input) {
+        .local_nominal => |stmt| TypeBinding{ .local_nominal = stmt },
+        .local_alias => |stmt| TypeBinding{ .local_alias = stmt },
+        .associated_nominal => |stmt| TypeBinding{ .associated_nominal = stmt },
+        .external_nominal => |external| TypeBinding{ .external_nominal = external },
+    };
+}
+
+fn inputStatement(input: TypeBindingInput) ?CIR.Statement.Idx {
+    return switch (input) {
+        .local_nominal => |stmt| stmt,
+        .local_alias => |stmt| stmt,
+        .associated_nominal => |stmt| stmt,
+        .external_nominal => null,
+    };
+}
+
+/// Return whether two external bindings refer to the same imported type name.
+pub fn sameExternal(a: ExternalTypeBinding, b: ExternalTypeBinding) bool {
+    return a.module_ident.eql(b.module_ident) and a.original_ident.eql(b.original_ident);
+}
+
+fn currentCollisionDecision(existing: TypeBinding, incoming: TypeBindingInput) TypeBindingDecision {
+    if (inputStatement(incoming)) |incoming_stmt| {
+        if (typeBindingStatement(existing)) |existing_stmt| {
+            if (existing_stmt == incoming_stmt) return .idempotent_current;
+        }
+    }
+
+    return switch (incoming) {
+        .external_nominal => |incoming_external| switch (existing) {
+            .external_nominal => |existing_external| if (sameExternal(existing_external, incoming_external))
+                .idempotent_current
+            else
+                TypeBindingDecision{ .rejected_current_conflict = existing },
+            .local_nominal, .local_alias, .associated_nominal => TypeBindingDecision{ .rejected_current_conflict = existing },
+        },
+        .local_nominal, .local_alias => switch (existing) {
+            .external_nominal => |existing_external| TypeBindingDecision{ .replaced_current_external = existing_external },
+            .local_nominal, .local_alias, .associated_nominal => TypeBindingDecision{ .redeclared_current = existing },
+        },
+        .associated_nominal => TypeBindingDecision{ .redeclared_current = existing },
+    };
+}
+
+/// Introduce or reject a type binding according to the canonical type-name policy.
+pub fn introduceTypeBinding(
+    gpa: Allocator,
+    scopes: []Scope,
+    scope_idx: usize,
     name: Ident.Idx,
-    type_decl: CIR.Statement.Idx,
-    parent_lookup_fn: ?fn (Ident.Idx) ?CIR.Statement.Idx,
-) std.mem.Allocator.Error!TypeIntroduceResult {
-    // Check if type already exists in this scope
-    if (scope.type_bindings.getPtr(name)) |existing| {
-        return switch (existing.*) {
-            .local_nominal => |stmt| TypeIntroduceResult{ .redeclared_error = stmt },
-            .local_alias => |stmt| TypeIntroduceResult{ .type_alias_redeclared = stmt },
-            .associated_nominal => |stmt| TypeIntroduceResult{ .nominal_type_redeclared = stmt },
-            .external_nominal => blk: {
-                try scope.type_bindings.put(gpa, name, TypeBinding{ .local_nominal = type_decl });
-                break :blk TypeIntroduceResult{ .success = {} };
+    incoming: TypeBindingInput,
+) Allocator.Error!TypeBindingDecision {
+    std.debug.assert(scope_idx < scopes.len);
+
+    const incoming_binding = inputToBinding(incoming);
+    const scope = &scopes[scope_idx];
+
+    if (scope.type_bindings.get(name)) |existing| {
+        const decision = currentCollisionDecision(existing, incoming);
+        switch (decision) {
+            .replaced_current_external => {
+                try scope.type_bindings.put(gpa, name, incoming_binding);
             },
-        };
+            .inserted,
+            .inserted_shadowing_parent,
+            .idempotent_current,
+            .rejected_current_conflict,
+            .redeclared_current,
+            => {},
+        }
+        return decision;
     }
 
-    // Check for shadowing in parent scopes and issue warnings
-    var shadowed_stmt: ?CIR.Statement.Idx = null;
-    if (parent_lookup_fn) |lookup_fn| {
-        shadowed_stmt = lookup_fn(name);
+    var shadowed_parent: ?TypeBinding = null;
+    var parent_idx = scope_idx;
+    while (parent_idx > 0) {
+        parent_idx -= 1;
+        if (scopes[parent_idx].type_bindings.get(name)) |parent_binding| {
+            shadowed_parent = parent_binding;
+            break;
+        }
     }
 
-    // Add type binding (single source of truth)
-    // Use the correct binding type based on the statement type
-    try scope.type_bindings.put(gpa, name, TypeBinding{ .local_nominal = type_decl });
-
-    if (shadowed_stmt) |stmt| {
-        return TypeIntroduceResult{ .shadowing_warning = stmt };
+    try scope.type_bindings.put(gpa, name, incoming_binding);
+    if (shadowed_parent) |binding| {
+        return TypeBindingDecision{ .inserted_shadowing_parent = binding };
     }
-
-    return TypeIntroduceResult{ .success = {} };
-}
-
-/// Introduce a type declaration into the scope with explicit binding type
-pub fn introduceTypeDeclWithKind(
-    scope: *Scope,
-    gpa: std.mem.Allocator,
-    name: Ident.Idx,
-    type_decl: CIR.Statement.Idx,
-    is_alias: bool,
-    parent_lookup_fn: ?fn (Ident.Idx) ?CIR.Statement.Idx,
-) std.mem.Allocator.Error!TypeIntroduceResult {
-    // Check if type already exists in this scope
-    if (scope.type_bindings.getPtr(name)) |existing| {
-        return switch (existing.*) {
-            .local_nominal => |stmt| TypeIntroduceResult{ .redeclared_error = stmt },
-            .local_alias => |stmt| TypeIntroduceResult{ .type_alias_redeclared = stmt },
-            .associated_nominal => |stmt| TypeIntroduceResult{ .nominal_type_redeclared = stmt },
-            .external_nominal => blk: {
-                const binding = if (is_alias)
-                    TypeBinding{ .local_alias = type_decl }
-                else
-                    TypeBinding{ .local_nominal = type_decl };
-                try scope.type_bindings.put(gpa, name, binding);
-                break :blk TypeIntroduceResult{ .success = {} };
-            },
-        };
-    }
-
-    // Check for shadowing in parent scopes and issue warnings
-    var shadowed_stmt: ?CIR.Statement.Idx = null;
-    if (parent_lookup_fn) |lookup_fn| {
-        shadowed_stmt = lookup_fn(name);
-    }
-
-    // Add type binding with the correct type (alias vs nominal)
-    const binding = if (is_alias)
-        TypeBinding{ .local_alias = type_decl }
-    else
-        TypeBinding{ .local_nominal = type_decl };
-    try scope.type_bindings.put(gpa, name, binding);
-
-    if (shadowed_stmt) |stmt| {
-        return TypeIntroduceResult{ .shadowing_warning = stmt };
-    }
-
-    return TypeIntroduceResult{ .success = {} };
-}
-
-/// Introduce an unqualified type alias (for associated types)
-/// Maps an unqualified name to a fully qualified type declaration
-pub fn introduceTypeAlias(
-    scope: *Scope,
-    gpa: std.mem.Allocator,
-    unqualified_name: Ident.Idx,
-    qualified_type_decl: CIR.Statement.Idx,
-) Allocator.Error!void {
-    try scope.type_bindings.put(gpa, unqualified_name, TypeBinding{
-        .associated_nominal = qualified_type_decl,
-    });
-}
-
-/// Update an existing type declaration in the scope
-/// This is used for recursive type declarations where we need to update
-/// the statement index after canonicalizing the type annotation
-pub fn updateTypeDecl(
-    scope: *Scope,
-    gpa: std.mem.Allocator,
-    name: Ident.Idx,
-    new_type_decl: CIR.Statement.Idx,
-) std.mem.Allocator.Error!void {
-    if (scope.type_bindings.getPtr(name)) |binding_ptr| {
-        const current = binding_ptr.*;
-        binding_ptr.* = switch (current) {
-            .local_nominal => TypeBinding{ .local_nominal = new_type_decl },
-            .local_alias => TypeBinding{ .local_alias = new_type_decl },
-            .associated_nominal => TypeBinding{ .associated_nominal = new_type_decl },
-            .external_nominal => current,
-        };
-    } else {
-        try scope.type_bindings.put(gpa, name, TypeBinding{ .local_nominal = new_type_decl });
-    }
+    return .inserted;
 }
 
 /// Introduce a type variable into the scope

--- a/src/canonicalize/mod.zig
+++ b/src/canonicalize/mod.zig
@@ -112,6 +112,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/record_test.zig"));
     std.testing.refAllDecls(@import("test/string_pattern_test.zig"));
     std.testing.refAllDecls(@import("test/type_decl_stmt_test.zig"));
+    std.testing.refAllDecls(@import("test/try_suffix_test.zig"));
     std.testing.refAllDecls(@import("test/local_let_scoping_test.zig"));
     std.testing.refAllDecls(@import("test/uninitialized_var_test.zig"));
     std.testing.refAllDecls(@import("test/while_loop_test.zig"));

--- a/src/canonicalize/test/scope_test.zig
+++ b/src/canonicalize/test/scope_test.zig
@@ -10,7 +10,9 @@ const ModuleEnv = @import("../ModuleEnv.zig");
 const Scope = @import("../Scope.zig");
 const BuiltinTestContext = @import("./BuiltinTestContext.zig").BuiltinTestContext;
 const Ident = base.Ident;
+const Region = base.Region;
 const Pattern = CIR.Pattern;
+const Statement = CIR.Statement;
 const TypeAnno = CIR.TypeAnno;
 const CoreCtx = @import("ctx").CoreCtx;
 
@@ -47,6 +49,33 @@ const ScopeTestContext = struct {
         ctx.builtin_ctx.deinit();
     }
 };
+
+fn zeroRegion() Region {
+    return .{ .start = Region.Position.zero(), .end = Region.Position.zero() };
+}
+
+fn externalTypeBinding(
+    module_ident: Ident.Idx,
+    original_ident: Ident.Idx,
+) Scope.ExternalTypeBinding {
+    return .{
+        .module_ident = module_ident,
+        .original_ident = original_ident,
+        .target_node_idx = null,
+        .import_idx = null,
+        .origin_region = zeroRegion(),
+        .module_not_found = false,
+    };
+}
+
+fn expectTypeBinding(
+    scope: *const Scope,
+    name: Ident.Idx,
+    expected: Scope.TypeBinding,
+) error{TestExpectedEqual}!void {
+    const actual = scope.type_bindings.get(name) orelse return error.TestExpectedEqual;
+    try std.testing.expectEqual(expected, actual);
+}
 
 test "basic scope initialization" {
     const gpa = std.testing.allocator;
@@ -281,4 +310,222 @@ test "aliases work separately from idents" {
 
     try std.testing.expectEqual(Scope.LookupResult{ .found = ident_pattern }, ident_lookup);
     try std.testing.expectEqual(Scope.LookupResult{ .found = alias_pattern }, alias_lookup);
+}
+
+test "type binding introduction handles same-scope local conflicts" {
+    const gpa = std.testing.allocator;
+
+    var ctx = try ScopeTestContext.init(gpa);
+    defer ctx.deinit();
+
+    var scopes = [_]Scope{Scope.init(false)};
+    defer scopes[0].deinit(gpa);
+
+    const type_ident = try ctx.module_env.insertIdent(Ident.for_text("Thing"));
+    const first_stmt: Statement.Idx = @enumFromInt(1);
+    const second_stmt: Statement.Idx = @enumFromInt(2);
+
+    const inserted = try Scope.introduceTypeBinding(
+        gpa,
+        scopes[0..],
+        0,
+        type_ident,
+        Scope.TypeBindingInput{ .local_nominal = first_stmt },
+    );
+    try std.testing.expectEqual(Scope.TypeBindingDecision.inserted, inserted);
+    try expectTypeBinding(&scopes[0], type_ident, Scope.TypeBinding{ .local_nominal = first_stmt });
+
+    const idempotent = try Scope.introduceTypeBinding(
+        gpa,
+        scopes[0..],
+        0,
+        type_ident,
+        Scope.TypeBindingInput{ .local_nominal = first_stmt },
+    );
+    try std.testing.expectEqual(Scope.TypeBindingDecision.idempotent_current, idempotent);
+    try expectTypeBinding(&scopes[0], type_ident, Scope.TypeBinding{ .local_nominal = first_stmt });
+
+    const redeclared = try Scope.introduceTypeBinding(
+        gpa,
+        scopes[0..],
+        0,
+        type_ident,
+        Scope.TypeBindingInput{ .local_alias = second_stmt },
+    );
+    try std.testing.expectEqual(
+        Scope.TypeBindingDecision{ .redeclared_current = Scope.TypeBinding{ .local_nominal = first_stmt } },
+        redeclared,
+    );
+    try expectTypeBinding(&scopes[0], type_ident, Scope.TypeBinding{ .local_nominal = first_stmt });
+}
+
+test "type binding introduction reports parent shadowing without changing parent" {
+    const gpa = std.testing.allocator;
+
+    var ctx = try ScopeTestContext.init(gpa);
+    defer ctx.deinit();
+
+    var scopes = [_]Scope{ Scope.init(false), Scope.init(false) };
+    defer {
+        scopes[1].deinit(gpa);
+        scopes[0].deinit(gpa);
+    }
+
+    const type_ident = try ctx.module_env.insertIdent(Ident.for_text("Thing"));
+    const parent_stmt: Statement.Idx = @enumFromInt(1);
+    const child_stmt: Statement.Idx = @enumFromInt(2);
+
+    try std.testing.expectEqual(
+        Scope.TypeBindingDecision.inserted,
+        try Scope.introduceTypeBinding(
+            gpa,
+            scopes[0..],
+            0,
+            type_ident,
+            Scope.TypeBindingInput{ .local_nominal = parent_stmt },
+        ),
+    );
+
+    const child_decision = try Scope.introduceTypeBinding(
+        gpa,
+        scopes[0..],
+        1,
+        type_ident,
+        Scope.TypeBindingInput{ .local_alias = child_stmt },
+    );
+    try std.testing.expectEqual(
+        Scope.TypeBindingDecision{ .inserted_shadowing_parent = Scope.TypeBinding{ .local_nominal = parent_stmt } },
+        child_decision,
+    );
+    try expectTypeBinding(&scopes[0], type_ident, Scope.TypeBinding{ .local_nominal = parent_stmt });
+    try expectTypeBinding(&scopes[1], type_ident, Scope.TypeBinding{ .local_alias = child_stmt });
+}
+
+test "local type bindings replace current external imports" {
+    const gpa = std.testing.allocator;
+
+    var ctx = try ScopeTestContext.init(gpa);
+    defer ctx.deinit();
+
+    var scopes = [_]Scope{Scope.init(false)};
+    defer scopes[0].deinit(gpa);
+
+    const type_ident = try ctx.module_env.insertIdent(Ident.for_text("Thing"));
+    const module_ident = try ctx.module_env.insertIdent(Ident.for_text("Imported"));
+    const external = externalTypeBinding(module_ident, type_ident);
+    const local_stmt: Statement.Idx = @enumFromInt(1);
+
+    try std.testing.expectEqual(
+        Scope.TypeBindingDecision.inserted,
+        try Scope.introduceTypeBinding(
+            gpa,
+            scopes[0..],
+            0,
+            type_ident,
+            Scope.TypeBindingInput{ .external_nominal = external },
+        ),
+    );
+
+    const replaced = try Scope.introduceTypeBinding(
+        gpa,
+        scopes[0..],
+        0,
+        type_ident,
+        Scope.TypeBindingInput{ .local_nominal = local_stmt },
+    );
+    try std.testing.expectEqual(
+        Scope.TypeBindingDecision{ .replaced_current_external = external },
+        replaced,
+    );
+    try expectTypeBinding(&scopes[0], type_ident, Scope.TypeBinding{ .local_nominal = local_stmt });
+}
+
+test "external type bindings are idempotent only for the same imported type" {
+    const gpa = std.testing.allocator;
+
+    var ctx = try ScopeTestContext.init(gpa);
+    defer ctx.deinit();
+
+    var scopes = [_]Scope{Scope.init(false)};
+    defer scopes[0].deinit(gpa);
+
+    const type_ident = try ctx.module_env.insertIdent(Ident.for_text("Thing"));
+    const module_ident = try ctx.module_env.insertIdent(Ident.for_text("Imported"));
+    const other_module_ident = try ctx.module_env.insertIdent(Ident.for_text("Other"));
+    const external = externalTypeBinding(module_ident, type_ident);
+    const different_external = externalTypeBinding(other_module_ident, type_ident);
+
+    try std.testing.expectEqual(
+        Scope.TypeBindingDecision.inserted,
+        try Scope.introduceTypeBinding(
+            gpa,
+            scopes[0..],
+            0,
+            type_ident,
+            Scope.TypeBindingInput{ .external_nominal = external },
+        ),
+    );
+
+    try std.testing.expectEqual(
+        Scope.TypeBindingDecision.idempotent_current,
+        try Scope.introduceTypeBinding(
+            gpa,
+            scopes[0..],
+            0,
+            type_ident,
+            Scope.TypeBindingInput{ .external_nominal = external },
+        ),
+    );
+
+    const rejected = try Scope.introduceTypeBinding(
+        gpa,
+        scopes[0..],
+        0,
+        type_ident,
+        Scope.TypeBindingInput{ .external_nominal = different_external },
+    );
+    try std.testing.expectEqual(
+        Scope.TypeBindingDecision{ .rejected_current_conflict = Scope.TypeBinding{ .external_nominal = external } },
+        rejected,
+    );
+    try expectTypeBinding(&scopes[0], type_ident, Scope.TypeBinding{ .external_nominal = external });
+}
+
+test "associated type aliases do not replace current external imports" {
+    const gpa = std.testing.allocator;
+
+    var ctx = try ScopeTestContext.init(gpa);
+    defer ctx.deinit();
+
+    var scopes = [_]Scope{Scope.init(false)};
+    defer scopes[0].deinit(gpa);
+
+    const type_ident = try ctx.module_env.insertIdent(Ident.for_text("Thing"));
+    const module_ident = try ctx.module_env.insertIdent(Ident.for_text("Imported"));
+    const external = externalTypeBinding(module_ident, type_ident);
+    const associated_stmt: Statement.Idx = @enumFromInt(1);
+
+    try std.testing.expectEqual(
+        Scope.TypeBindingDecision.inserted,
+        try Scope.introduceTypeBinding(
+            gpa,
+            scopes[0..],
+            0,
+            type_ident,
+            Scope.TypeBindingInput{ .external_nominal = external },
+        ),
+    );
+
+    const rejected = try Scope.introduceTypeBinding(
+        gpa,
+        scopes[0..],
+        0,
+        type_ident,
+        Scope.TypeBindingInput{ .associated_nominal = associated_stmt },
+    );
+    try std.testing.expectEqual(
+        Scope.TypeBindingDecision{ .redeclared_current = Scope.TypeBinding{ .external_nominal = external } },
+        rejected,
+    );
+    try expectTypeBinding(&scopes[0], type_ident, Scope.TypeBinding{ .external_nominal = external });
 }

--- a/src/canonicalize/test/try_suffix_test.zig
+++ b/src/canonicalize/test/try_suffix_test.zig
@@ -1,0 +1,210 @@
+//! Tests for Try suffix desugaring shape.
+
+const std = @import("std");
+const testing = std.testing;
+
+const parse = @import("parse");
+const CIR = @import("../CIR.zig");
+const Can = @import("../Can.zig");
+const ModuleEnv = @import("../ModuleEnv.zig");
+const BuiltinTestContext = @import("BuiltinTestContext.zig").BuiltinTestContext;
+const TestEnv = @import("TestEnv.zig").TestEnv;
+const CoreCtx = @import("ctx").CoreCtx;
+
+const TrySuffixTestError = std.mem.Allocator.Error || error{
+    TestExpectedEqual,
+    TestUnexpectedResult,
+    ExpectedLambda,
+    ExpectedNominalTryPattern,
+    ExpectedNominalTryExpr,
+};
+
+fn expectMatch(
+    test_env: *TestEnv,
+    expr_idx: CIR.Expr.Idx,
+    is_try_suffix: bool,
+) TrySuffixTestError!CIR.Expr.Match {
+    const expr = test_env.getCanonicalExpr(expr_idx);
+    try testing.expectEqual(.e_match, std.meta.activeTag(expr));
+    const match = expr.e_match;
+    try testing.expectEqual(is_try_suffix, match.is_try_suffix);
+    try testing.expectEqual(@as(usize, 2), test_env.module_env.store.sliceMatchBranches(match.branches).len);
+    return match;
+}
+
+fn finalExpr(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) CIR.Expr.Idx {
+    return switch (test_env.getCanonicalExpr(expr_idx)) {
+        .e_block => |block| block.final_expr,
+        else => expr_idx,
+    };
+}
+
+fn lambdaBodyFinalExpr(test_env: *TestEnv, expr_idx: CIR.Expr.Idx) TrySuffixTestError!CIR.Expr.Idx {
+    const expr = test_env.getCanonicalExpr(expr_idx);
+    const lambda_idx = switch (expr) {
+        .e_lambda => expr_idx,
+        .e_closure => |closure| closure.lambda_idx,
+        else => return error.ExpectedLambda,
+    };
+
+    const lambda = test_env.getCanonicalExpr(lambda_idx);
+    try testing.expectEqual(.e_lambda, std.meta.activeTag(lambda));
+    return finalExpr(test_env, lambda.e_lambda.body);
+}
+
+fn branchAt(
+    test_env: *TestEnv,
+    match: CIR.Expr.Match,
+    index: usize,
+) TrySuffixTestError!CIR.Expr.Match.Branch {
+    const branch_idxs = test_env.module_env.store.sliceMatchBranches(match.branches);
+    try testing.expect(index < branch_idxs.len);
+    return test_env.module_env.store.getMatchBranch(branch_idxs[index]);
+}
+
+fn branchPatternAt(
+    test_env: *TestEnv,
+    branch: CIR.Expr.Match.Branch,
+    index: usize,
+) TrySuffixTestError!CIR.Pattern.Idx {
+    const branch_pattern_idxs = test_env.module_env.store.sliceMatchBranchPatterns(branch.patterns);
+    try testing.expect(index < branch_pattern_idxs.len);
+    const branch_pattern = test_env.module_env.store.getMatchBranchPattern(branch_pattern_idxs[index]);
+    try testing.expect(!branch_pattern.degenerate);
+    return branch_pattern.pattern;
+}
+
+fn expectTryTagPattern(
+    test_env: *TestEnv,
+    pattern_idx: CIR.Pattern.Idx,
+    expected_tag: []const u8,
+) TrySuffixTestError!void {
+    const pattern = test_env.module_env.store.getPattern(pattern_idx);
+    const backing_pattern_idx = switch (pattern) {
+        .nominal => |nominal| nominal.backing_pattern,
+        .nominal_external => |nominal| nominal.backing_pattern,
+        else => return error.ExpectedNominalTryPattern,
+    };
+
+    const backing_pattern = test_env.module_env.store.getPattern(backing_pattern_idx);
+    try testing.expectEqual(.applied_tag, std.meta.activeTag(backing_pattern));
+    try testing.expectEqualStrings(expected_tag, test_env.getIdent(backing_pattern.applied_tag.name));
+}
+
+fn expectTryTagExpr(
+    test_env: *TestEnv,
+    expr_idx: CIR.Expr.Idx,
+    expected_tag: []const u8,
+) TrySuffixTestError!void {
+    const expr = test_env.getCanonicalExpr(expr_idx);
+    const backing_expr_idx = switch (expr) {
+        .e_nominal => |nominal| nominal.backing_expr,
+        .e_nominal_external => |nominal| nominal.backing_expr,
+        else => return error.ExpectedNominalTryExpr,
+    };
+
+    const backing_expr = test_env.getCanonicalExpr(backing_expr_idx);
+    try testing.expectEqual(.e_tag, std.meta.activeTag(backing_expr));
+    try testing.expectEqualStrings(expected_tag, test_env.getIdent(backing_expr.e_tag.name));
+}
+
+fn expectBranchPatternTag(
+    test_env: *TestEnv,
+    branch: CIR.Expr.Match.Branch,
+    expected_tag: []const u8,
+) TrySuffixTestError!void {
+    const pattern_idx = try branchPatternAt(test_env, branch, 0);
+    try expectTryTagPattern(test_env, pattern_idx, expected_tag);
+}
+
+fn moduleContainsExpectErr(source: []const u8) TrySuffixTestError!bool {
+    const allocator = testing.allocator;
+
+    var builtin_ctx = try BuiltinTestContext.init(allocator);
+    defer builtin_ctx.deinit();
+
+    var env = try ModuleEnv.init(allocator, source);
+    defer env.deinit();
+    try env.initCIRFields("Test");
+
+    const ast = try parse.file(allocator, &env.common);
+    defer ast.deinit();
+
+    const roc_ctx = CoreCtx.testing(allocator, allocator);
+    var can = try Can.initModule(roc_ctx, &env, ast, builtin_ctx.canInitContext());
+    defer can.deinit();
+
+    try can.canonicalizeFile();
+
+    var raw_node_idx: u32 = 0;
+    while (raw_node_idx < env.store.nodes.len()) : (raw_node_idx += 1) {
+        const node_idx: CIR.Node.Idx = @enumFromInt(raw_node_idx);
+        if (env.store.nodes.get(node_idx).tag == .expr_expect_err) return true;
+    }
+
+    return false;
+}
+
+test "try suffix creates nominal wrapped try match" {
+    var test_env = try TestEnv.init("Try.Ok(1)?");
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const match = try expectMatch(&test_env, canonical_expr.get_idx(), true);
+    const ok_branch = try branchAt(&test_env, match, 0);
+    const err_branch = try branchAt(&test_env, match, 1);
+
+    try expectBranchPatternTag(&test_env, ok_branch, "Ok");
+    try expectBranchPatternTag(&test_env, err_branch, "Err");
+}
+
+test "try suffix err branch returns nominal Err inside lambda" {
+    var test_env = try TestEnv.init("|_| Try.Err(\"x\")?");
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const body_idx = try lambdaBodyFinalExpr(&test_env, canonical_expr.get_idx());
+    const match = try expectMatch(&test_env, body_idx, true);
+    const err_branch = try branchAt(&test_env, match, 1);
+
+    const branch_value = test_env.getCanonicalExpr(err_branch.value);
+    try testing.expectEqual(.e_return, std.meta.activeTag(branch_value));
+    try expectTryTagExpr(&test_env, branch_value.e_return.expr, "Err");
+}
+
+test "single question binop shares try suffix ok branch shape" {
+    var test_env = try TestEnv.init("|_| Try.Err(\"x\") ? Bad");
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const body_idx = try lambdaBodyFinalExpr(&test_env, canonical_expr.get_idx());
+    const match = try expectMatch(&test_env, body_idx, true);
+    const ok_branch = try branchAt(&test_env, match, 0);
+
+    try expectBranchPatternTag(&test_env, ok_branch, "Ok");
+}
+
+test "double question shares try branch patterns without try suffix flag" {
+    var test_env = try TestEnv.init("Try.Err(\"x\") ?? 0");
+    defer test_env.deinit();
+
+    const canonical_expr = try test_env.canonicalizeExpr() orelse unreachable;
+    const match = try expectMatch(&test_env, canonical_expr.get_idx(), false);
+    const ok_branch = try branchAt(&test_env, match, 0);
+    const err_branch = try branchAt(&test_env, match, 1);
+
+    try expectBranchPatternTag(&test_env, ok_branch, "Ok");
+    try expectBranchPatternTag(&test_env, err_branch, "Err");
+    try testing.expectEqual(.e_num, std.meta.activeTag(test_env.getCanonicalExpr(err_branch.value)));
+}
+
+test "try suffix inside expect emits expect err" {
+    const source =
+        \\module [main]
+        \\
+        \\expect Try.Err("x")? == "ok"
+        \\
+        \\main = {}
+    ;
+    try testing.expect(try moduleContainsExpectErr(source));
+}


### PR DESCRIPTION
Canonicalization had several caller-local copies of type binding collision logic and Try suffix construction. This centralizes type-name binding decisions in Scope, lets Can handle diagnostics and import side effects from explicit decisions, and funnels ?, binary ?, and ?? through one Try suffix builder so nominal wrapping and branch shape stay consistent.