### PR TITLE
Add self-conversions for number primitives

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3638,6 +3638,10 @@ Builtin :: [].{
             to_u8_try : U8 -> Try(U8, _never_fails)
             to_u8_try = |self| Ok(self)
 
+            ## No-op: leave a [U8] unchanged as a [U8].
+            to_u8_wrap : U8 -> U8
+            to_u8_wrap = |self| self
+
 			# Conversions to unsigned integers (all safe widening)
 			## Convert a [U8] to a [U16]. This widening conversion preserves
 			## every [U8] value exactly.
@@ -4270,6 +4274,10 @@ Builtin :: [].{
             ## Leave an [I8] unchanged as an [I8]. Always succeeds.
             to_i8_try : I8 -> Try(I8, _never_fails)
             to_i8_try = |self| Ok(self)
+
+            ## No-op: leave an [I8] unchanged as an [I8].
+            to_i8_wrap : I8 -> I8
+            to_i8_wrap = |self| self
 
 			# Conversions to signed integers (all safe widening)
 			## Convert an [I8] to an [I16]. This widening conversion preserves
@@ -5006,6 +5014,10 @@ Builtin :: [].{
             to_u16_try : U16 -> Try(U16, _never_fails)
             to_u16_try = |self| Ok(self)
 
+            ## No-op: leave a [U16] unchanged as a [U16].
+            to_u16_wrap : U16 -> U16
+            to_u16_wrap = |self| self
+
 			## Convert a [U16] to a [U32]. This widening conversion preserves
 			## every [U16] value exactly.
 			to_u32 : U16 -> U32
@@ -5654,6 +5666,10 @@ Builtin :: [].{
             ## Leave an [I16] unchanged as an [I16]. Always succeeds.
             to_i16_try : I16 -> Try(I16, _never_fails)
             to_i16_try = |self| Ok(self)
+
+            ## No-op: leave an [I16] unchanged as an [I16].
+            to_i16_wrap : I16 -> I16
+            to_i16_wrap = |self| self
 
 			## Convert an [I16] to an [I32]. This widening conversion preserves
 			## every [I16] value exactly.
@@ -6419,6 +6435,10 @@ Builtin :: [].{
             to_u32_try : U32 -> Try(U32, _never_fails)
             to_u32_try = |self| Ok(self)
 
+            ## No-op: leave a [U32] unchanged as a [U32].
+            to_u32_wrap : U32 -> U32
+            to_u32_wrap = |self| self
+
 			## Convert a [U32] to a [U64]. This widening conversion preserves
 			## every [U32] value exactly.
 			to_u64 : U32 -> U64
@@ -7083,6 +7103,10 @@ Builtin :: [].{
             ## Leave an [I32] unchanged as an [I32]. Always succeeds.
             to_i32_try : I32 -> Try(I32, _never_fails)
             to_i32_try = |self| Ok(self)
+
+            ## No-op: leave an [I32] unchanged as an [I32].
+            to_i32_wrap : I32 -> I32
+            to_i32_wrap = |self| self
 
 			## Convert an [I32] to an [I64]. This widening conversion preserves
 			## every [I32] value exactly.
@@ -7885,6 +7909,10 @@ Builtin :: [].{
             to_u64_try : U64 -> Try(U64, _never_fails)
             to_u64_try = |self| Ok(self)
 
+            ## No-op: leave a [U64] unchanged as a [U64].
+            to_u64_wrap : U64 -> U64
+            to_u64_wrap = |self| self
+
 			## Convert a [U64] to a [U128]. This widening conversion preserves
 			## every [U64] value exactly.
 			to_u128 : U64 -> U128
@@ -8576,6 +8604,10 @@ Builtin :: [].{
             ## Leave an [I64] unchanged as an [I64]. Always succeeds.
             to_i64_try : I64 -> Try(I64, _never_fails)
             to_i64_try = |self| Ok(self)
+
+            ## No-op: leave an [I64] unchanged as an [I64].
+            to_i64_wrap : I64 -> I64
+            to_i64_wrap = |self| self
 
 			## Convert an [I64] to an [I128]. This widening conversion preserves
 			## every [I64] value exactly.
@@ -9414,6 +9446,10 @@ Builtin :: [].{
             to_u128_try : U128 -> Try(U128, _never_fails)
             to_u128_try = |self| Ok(self)
 
+            ## No-op: leave a [U128] unchanged as a [U128].
+            to_u128_wrap : U128 -> U128
+            to_u128_wrap = |self| self
+
 			# Conversions to floating point (all safe)
 			## Convert a [U128] to an [F32]. This conversion may round, and the
 			## largest [U128] values may become `inf`.
@@ -10133,6 +10169,10 @@ Builtin :: [].{
             ## Leave an [I128] unchanged as an [I128]. Always succeeds.
             to_i128_try : I128 -> Try(I128, _never_fails)
             to_i128_try = |self| Ok(self)
+
+            ## No-op: leave an [I128] unchanged as an [I128].
+            to_i128_wrap : I128 -> I128
+            to_i128_wrap = |self| self
 
 			# Conversions to unsigned integers (all lossy for negative values)
 

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3634,6 +3634,10 @@ Builtin :: [].{
             to_u8 : U8 -> U8
             to_u8 = |self| self
 
+            ## Leave a [U8] unchanged as a [U8]. Always succeeds.
+            to_u8_try : U8 -> Try(U8, _never_fails)
+            to_u8_try = |self| Ok(self)
+
 			# Conversions to unsigned integers (all safe widening)
 			## Convert a [U8] to a [U16]. This widening conversion preserves
 			## every [U8] value exactly.
@@ -4262,6 +4266,10 @@ Builtin :: [].{
             ## No-op: leave an [I8] unchanged as an [I8].
             to_i8 : I8 -> I8
             to_i8 = |self| self
+
+            ## Leave an [I8] unchanged as an [I8]. Always succeeds.
+            to_i8_try : I8 -> Try(I8, _never_fails)
+            to_i8_try = |self| Ok(self)
 
 			# Conversions to signed integers (all safe widening)
 			## Convert an [I8] to an [I16]. This widening conversion preserves
@@ -4994,6 +5002,10 @@ Builtin :: [].{
             to_u16 : U16 -> U16
             to_u16 = |self| self
 
+            ## Leave a [U16] unchanged as a [U16]. Always succeeds.
+            to_u16_try : U16 -> Try(U16, _never_fails)
+            to_u16_try = |self| Ok(self)
+
 			## Convert a [U16] to a [U32]. This widening conversion preserves
 			## every [U16] value exactly.
 			to_u32 : U16 -> U32
@@ -5638,6 +5650,10 @@ Builtin :: [].{
             ## No-op: leave an [I16] unchanged as an [I16].
             to_i16 : I16 -> I16
             to_i16 = |self| self
+
+            ## Leave an [I16] unchanged as an [I16]. Always succeeds.
+            to_i16_try : I16 -> Try(I16, _never_fails)
+            to_i16_try = |self| Ok(self)
 
 			## Convert an [I16] to an [I32]. This widening conversion preserves
 			## every [I16] value exactly.
@@ -6399,6 +6415,10 @@ Builtin :: [].{
             to_u32 : U32 -> U32
             to_u32 = |self| self
 
+            ## Leave a [U32] unchanged as a [U32]. Always succeeds.
+            to_u32_try : U32 -> Try(U32, _never_fails)
+            to_u32_try = |self| Ok(self)
+
 			## Convert a [U32] to a [U64]. This widening conversion preserves
 			## every [U32] value exactly.
 			to_u64 : U32 -> U64
@@ -7059,6 +7079,10 @@ Builtin :: [].{
             ## No-op: leave an [I32] unchanged as an [I32].
             to_i32 : I32 -> I32
             to_i32 = |self| self
+
+            ## Leave an [I32] unchanged as an [I32]. Always succeeds.
+            to_i32_try : I32 -> Try(I32, _never_fails)
+            to_i32_try = |self| Ok(self)
 
 			## Convert an [I32] to an [I64]. This widening conversion preserves
 			## every [I32] value exactly.
@@ -7857,6 +7881,10 @@ Builtin :: [].{
             to_u64 : U64 -> U64
             to_u64 = |self| self
 
+            ## Leave a [U64] unchanged as a [U64]. Always succeeds.
+            to_u64_try : U64 -> Try(U64, _never_fails)
+            to_u64_try = |self| Ok(self)
+
 			## Convert a [U64] to a [U128]. This widening conversion preserves
 			## every [U64] value exactly.
 			to_u128 : U64 -> U128
@@ -8544,6 +8572,10 @@ Builtin :: [].{
             ## No-op: leave an [I64] unchanged as an [I64].
             to_i64 : I64 -> I64
             to_i64 = |self| self
+
+            ## Leave an [I64] unchanged as an [I64]. Always succeeds.
+            to_i64_try : I64 -> Try(I64, _never_fails)
+            to_i64_try = |self| Ok(self)
 
 			## Convert an [I64] to an [I128]. This widening conversion preserves
 			## every [I64] value exactly.
@@ -9378,6 +9410,10 @@ Builtin :: [].{
             to_u128 : U128 -> U128
             to_u128 = |self| self
 
+            ## Leave a [U128] unchanged as a [U128]. Always succeeds.
+            to_u128_try : U128 -> Try(U128, _never_fails)
+            to_u128_try = |self| Ok(self)
+
 			# Conversions to floating point (all safe)
 			## Convert a [U128] to an [F32]. This conversion may round, and the
 			## largest [U128] values may become `inf`.
@@ -10093,6 +10129,10 @@ Builtin :: [].{
             ## No-op: leave an [I128] unchanged as an [I128].
             to_i128 : I128 -> I128
             to_i128 = |self| self
+
+            ## Leave an [I128] unchanged as an [I128]. Always succeeds.
+            to_i128_try : I128 -> Try(I128, _never_fails)
+            to_i128_try = |self| Ok(self)
 
 			# Conversions to unsigned integers (all lossy for negative values)
 

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -11154,6 +11154,14 @@ Builtin :: [].{
 			## represent exactly.
 			to_f64 : Dec -> F64
 
+			## No-op: leave a [Dec] unchanged as a [Dec].
+			to_dec : Dec -> Dec
+			to_dec = |self| self
+
+			## Leave a [Dec] unchanged as a [Dec]. Always succeeds.
+			to_dec_try : Dec -> Try(Dec, _never_fails)
+			to_dec_try = |self| Ok(self)
+
 			## Iterator of decimals beginning with this `Dec` and ending with the
 			## other `Dec`, stepping by `1.0`. (Use [Dec.until] instead to end with
 			## the other `Dec` minus one.) Returns an empty iterator if this `Dec`
@@ -12095,6 +12103,18 @@ Builtin :: [].{
 			to_u128_try : F32 -> Try(U128, [OutOfRange])
 			to_u128_try = |num| out_of_range_try(f32_to_u128_try_unsafe(num))
 
+			## No-op: leave an [F32] unchanged as an [F32].
+			to_f32 : F32 -> F32
+			to_f32 = |self| self
+
+			## No-op: leave an [F32] unchanged as an [F32].
+			to_f32_wrap : F32 -> F32
+			to_f32_wrap = |self| self
+
+			## Leave an [F32] unchanged as an [F32]. Always succeeds.
+			to_f32_try : F32 -> Try(F32, _never_fails)
+			to_f32_try = |self| Ok(self)
+
 			## Convert an [F32] to an [F64]. This is a safe widening conversion:
 			## every [F32] value is exactly representable as an [F64], including
 			## `NaN`, `inf`, and `-inf`.
@@ -12994,6 +13014,18 @@ Builtin :: [].{
 			## ```
 			to_f32_try : F64 -> Try(F32, [OutOfRange])
 			to_f32_try = |num| out_of_range_try(f64_to_f32_try_unsafe(num))
+
+			## No-op: leave an [F64] unchanged as an [F64].
+			to_f64 : F64 -> F64
+			to_f64 = |self| self
+
+			## No-op: leave an [F64] unchanged as an [F64].
+			to_f64_wrap : F64 -> F64
+			to_f64_wrap = |self| self
+
+			## Leave an [F64] unchanged as an [F64]. Always succeeds.
+			to_f64_try : F64 -> Try(F64, _never_fails)
+			to_f64_try = |self| Ok(self)
 
 			## Encode an F64 using a format that provides encode_f64
 			encode : F64, fmt -> Try(encoded, err)

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3630,6 +3630,10 @@ Builtin :: [].{
 			## every [U8] value exactly.
 			to_i128 : U8 -> I128
 
+            ## No-op: leave a [U8] unchanged as a [U8].
+            to_u8 : U8 -> U8
+            to_u8 = |self| self
+
 			# Conversions to unsigned integers (all safe widening)
 			## Convert a [U8] to a [U16]. This widening conversion preserves
 			## every [U8] value exactly.
@@ -4254,6 +4258,10 @@ Builtin :: [].{
 			## expect I8.from_str("200") == Err(BadNumStr)
 			## ```
 			from_str : Str -> Try(I8, [BadNumStr, ..])
+
+            ## No-op: leave an [I8] unchanged as an [I8].
+            to_i8 : I8 -> I8
+            to_i8 = |self| self
 
 			# Conversions to signed integers (all safe widening)
 			## Convert an [I8] to an [I16]. This widening conversion preserves
@@ -4982,6 +4990,10 @@ Builtin :: [].{
 			## ```
 			to_u8_try : U16 -> Try(U8, [OutOfRange, ..])
 
+            ## No-op: leave a [U16] unchanged as a [U16].
+            to_u16 : U16 -> U16
+            to_u16 = |self| self
+
 			## Convert a [U16] to a [U32]. This widening conversion preserves
 			## every [U16] value exactly.
 			to_u32 : U16 -> U32
@@ -5622,6 +5634,10 @@ Builtin :: [].{
 			## expect I16.to_i8_try(200) == Err(OutOfRange)
 			## ```
 			to_i8_try : I16 -> Try(I8, [OutOfRange, ..])
+
+            ## No-op: leave an [I16] unchanged as an [I16].
+            to_i16 : I16 -> I16
+            to_i16 = |self| self
 
 			## Convert an [I16] to an [I32]. This widening conversion preserves
 			## every [I16] value exactly.
@@ -6379,6 +6395,10 @@ Builtin :: [].{
 			## ```
 			to_u16_try : U32 -> Try(U16, [OutOfRange, ..])
 
+            ## No-op: leave a [U32] unchanged as a [U32].
+            to_u32 : U32 -> U32
+            to_u32 = |self| self
+
 			## Convert a [U32] to a [U64]. This widening conversion preserves
 			## every [U32] value exactly.
 			to_u64 : U32 -> U64
@@ -7035,6 +7055,10 @@ Builtin :: [].{
 			## expect I32.to_i16_try(40000) == Err(OutOfRange)
 			## ```
 			to_i16_try : I32 -> Try(I16, [OutOfRange, ..])
+
+            ## No-op: leave an [I32] unchanged as an [I32].
+            to_i32 : I32 -> I32
+            to_i32 = |self| self
 
 			## Convert an [I32] to an [I64]. This widening conversion preserves
 			## every [I32] value exactly.
@@ -7829,6 +7853,10 @@ Builtin :: [].{
 			## ```
 			to_u32_try : U64 -> Try(U32, [OutOfRange, ..])
 
+            ## No-op: leave a [U64] unchanged as a [U64].
+            to_u64 : U64 -> U64
+            to_u64 = |self| self
+
 			## Convert a [U64] to a [U128]. This widening conversion preserves
 			## every [U64] value exactly.
 			to_u128 : U64 -> U128
@@ -8512,6 +8540,10 @@ Builtin :: [].{
 			## expect I64.to_i32_try(3000000000) == Err(OutOfRange)
 			## ```
 			to_i32_try : I64 -> Try(I32, [OutOfRange, ..])
+
+            ## No-op: leave an [I64] unchanged as an [I64].
+            to_i64 : I64 -> I64
+            to_i64 = |self| self
 
 			## Convert an [I64] to an [I128]. This widening conversion preserves
 			## every [I64] value exactly.
@@ -9342,6 +9374,10 @@ Builtin :: [].{
 			## ```
 			to_u64_try : U128 -> Try(U64, [OutOfRange, ..])
 
+            ## No-op: leave a [U128] unchanged as a [U128].
+            to_u128 : U128 -> U128
+            to_u128 = |self| self
+
 			# Conversions to floating point (all safe)
 			## Convert a [U128] to an [F32]. This conversion may round, and the
 			## largest [U128] values may become `inf`.
@@ -10053,6 +10089,10 @@ Builtin :: [].{
 			## expect I128.to_i64_try(42) == Ok(42)
 			## ```
 			to_i64_try : I128 -> Try(I64, [OutOfRange, ..])
+
+            ## No-op: leave an [I128] unchanged as an [I128].
+            to_i128 : I128 -> I128
+            to_i128 = |self| self
 
 			# Conversions to unsigned integers (all lossy for negative values)
 

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -365,6 +365,10 @@ Builtin :: [].{
 		## ```
 		to_utf8 : Str -> List(U8)
 
+        ## No-op: leave a [Str] unchanged as a [Str].
+        to_str : Str -> Str
+        to_str = |self| self
+
 		## Converts a [List] of [U8] UTF-8 [code units](https://unicode.org/glossary/#code_unit) to a string.
 		## Any grouping of invalid byte sequences are replaced with a single unicode replacement character '�'.
 		##

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -365,9 +365,9 @@ Builtin :: [].{
 		## ```
 		to_utf8 : Str -> List(U8)
 
-        ## No-op: leave a [Str] unchanged as a [Str].
-        to_str : Str -> Str
-        to_str = |self| self
+		## No-op: leave a [Str] unchanged as a [Str].
+		to_str : Str -> Str
+		to_str = |self| self
 
 		## Converts a [List] of [U8] UTF-8 [code units](https://unicode.org/glossary/#code_unit) to a string.
 		## Any grouping of invalid byte sequences are replaced with a single unicode replacement character '�'.
@@ -3634,17 +3634,17 @@ Builtin :: [].{
 			## every [U8] value exactly.
 			to_i128 : U8 -> I128
 
-            ## No-op: leave a [U8] unchanged as a [U8].
-            to_u8 : U8 -> U8
-            to_u8 = |self| self
+			## No-op: leave a [U8] unchanged as a [U8].
+			to_u8 : U8 -> U8
+			to_u8 = |self| self
 
-            ## Leave a [U8] unchanged as a [U8]. Always succeeds.
-            to_u8_try : U8 -> Try(U8, _never_fails)
-            to_u8_try = |self| Ok(self)
+			## Leave a [U8] unchanged as a [U8]. Always succeeds.
+			to_u8_try : U8 -> Try(U8, _never_fails)
+			to_u8_try = |self| Ok(self)
 
-            ## No-op: leave a [U8] unchanged as a [U8].
-            to_u8_wrap : U8 -> U8
-            to_u8_wrap = |self| self
+			## No-op: leave a [U8] unchanged as a [U8].
+			to_u8_wrap : U8 -> U8
+			to_u8_wrap = |self| self
 
 			# Conversions to unsigned integers (all safe widening)
 			## Convert a [U8] to a [U16]. This widening conversion preserves
@@ -4271,17 +4271,17 @@ Builtin :: [].{
 			## ```
 			from_str : Str -> Try(I8, [BadNumStr, ..])
 
-            ## No-op: leave an [I8] unchanged as an [I8].
-            to_i8 : I8 -> I8
-            to_i8 = |self| self
+			## No-op: leave an [I8] unchanged as an [I8].
+			to_i8 : I8 -> I8
+			to_i8 = |self| self
 
-            ## Leave an [I8] unchanged as an [I8]. Always succeeds.
-            to_i8_try : I8 -> Try(I8, _never_fails)
-            to_i8_try = |self| Ok(self)
+			## Leave an [I8] unchanged as an [I8]. Always succeeds.
+			to_i8_try : I8 -> Try(I8, _never_fails)
+			to_i8_try = |self| Ok(self)
 
-            ## No-op: leave an [I8] unchanged as an [I8].
-            to_i8_wrap : I8 -> I8
-            to_i8_wrap = |self| self
+			## No-op: leave an [I8] unchanged as an [I8].
+			to_i8_wrap : I8 -> I8
+			to_i8_wrap = |self| self
 
 			# Conversions to signed integers (all safe widening)
 			## Convert an [I8] to an [I16]. This widening conversion preserves
@@ -5010,17 +5010,17 @@ Builtin :: [].{
 			## ```
 			to_u8_try : U16 -> Try(U8, [OutOfRange, ..])
 
-            ## No-op: leave a [U16] unchanged as a [U16].
-            to_u16 : U16 -> U16
-            to_u16 = |self| self
+			## No-op: leave a [U16] unchanged as a [U16].
+			to_u16 : U16 -> U16
+			to_u16 = |self| self
 
-            ## Leave a [U16] unchanged as a [U16]. Always succeeds.
-            to_u16_try : U16 -> Try(U16, _never_fails)
-            to_u16_try = |self| Ok(self)
+			## Leave a [U16] unchanged as a [U16]. Always succeeds.
+			to_u16_try : U16 -> Try(U16, _never_fails)
+			to_u16_try = |self| Ok(self)
 
-            ## No-op: leave a [U16] unchanged as a [U16].
-            to_u16_wrap : U16 -> U16
-            to_u16_wrap = |self| self
+			## No-op: leave a [U16] unchanged as a [U16].
+			to_u16_wrap : U16 -> U16
+			to_u16_wrap = |self| self
 
 			## Convert a [U16] to a [U32]. This widening conversion preserves
 			## every [U16] value exactly.
@@ -5663,17 +5663,17 @@ Builtin :: [].{
 			## ```
 			to_i8_try : I16 -> Try(I8, [OutOfRange, ..])
 
-            ## No-op: leave an [I16] unchanged as an [I16].
-            to_i16 : I16 -> I16
-            to_i16 = |self| self
+			## No-op: leave an [I16] unchanged as an [I16].
+			to_i16 : I16 -> I16
+			to_i16 = |self| self
 
-            ## Leave an [I16] unchanged as an [I16]. Always succeeds.
-            to_i16_try : I16 -> Try(I16, _never_fails)
-            to_i16_try = |self| Ok(self)
+			## Leave an [I16] unchanged as an [I16]. Always succeeds.
+			to_i16_try : I16 -> Try(I16, _never_fails)
+			to_i16_try = |self| Ok(self)
 
-            ## No-op: leave an [I16] unchanged as an [I16].
-            to_i16_wrap : I16 -> I16
-            to_i16_wrap = |self| self
+			## No-op: leave an [I16] unchanged as an [I16].
+			to_i16_wrap : I16 -> I16
+			to_i16_wrap = |self| self
 
 			## Convert an [I16] to an [I32]. This widening conversion preserves
 			## every [I16] value exactly.
@@ -6431,17 +6431,17 @@ Builtin :: [].{
 			## ```
 			to_u16_try : U32 -> Try(U16, [OutOfRange, ..])
 
-            ## No-op: leave a [U32] unchanged as a [U32].
-            to_u32 : U32 -> U32
-            to_u32 = |self| self
+			## No-op: leave a [U32] unchanged as a [U32].
+			to_u32 : U32 -> U32
+			to_u32 = |self| self
 
-            ## Leave a [U32] unchanged as a [U32]. Always succeeds.
-            to_u32_try : U32 -> Try(U32, _never_fails)
-            to_u32_try = |self| Ok(self)
+			## Leave a [U32] unchanged as a [U32]. Always succeeds.
+			to_u32_try : U32 -> Try(U32, _never_fails)
+			to_u32_try = |self| Ok(self)
 
-            ## No-op: leave a [U32] unchanged as a [U32].
-            to_u32_wrap : U32 -> U32
-            to_u32_wrap = |self| self
+			## No-op: leave a [U32] unchanged as a [U32].
+			to_u32_wrap : U32 -> U32
+			to_u32_wrap = |self| self
 
 			## Convert a [U32] to a [U64]. This widening conversion preserves
 			## every [U32] value exactly.
@@ -7100,17 +7100,17 @@ Builtin :: [].{
 			## ```
 			to_i16_try : I32 -> Try(I16, [OutOfRange, ..])
 
-            ## No-op: leave an [I32] unchanged as an [I32].
-            to_i32 : I32 -> I32
-            to_i32 = |self| self
+			## No-op: leave an [I32] unchanged as an [I32].
+			to_i32 : I32 -> I32
+			to_i32 = |self| self
 
-            ## Leave an [I32] unchanged as an [I32]. Always succeeds.
-            to_i32_try : I32 -> Try(I32, _never_fails)
-            to_i32_try = |self| Ok(self)
+			## Leave an [I32] unchanged as an [I32]. Always succeeds.
+			to_i32_try : I32 -> Try(I32, _never_fails)
+			to_i32_try = |self| Ok(self)
 
-            ## No-op: leave an [I32] unchanged as an [I32].
-            to_i32_wrap : I32 -> I32
-            to_i32_wrap = |self| self
+			## No-op: leave an [I32] unchanged as an [I32].
+			to_i32_wrap : I32 -> I32
+			to_i32_wrap = |self| self
 
 			## Convert an [I32] to an [I64]. This widening conversion preserves
 			## every [I32] value exactly.
@@ -7905,17 +7905,17 @@ Builtin :: [].{
 			## ```
 			to_u32_try : U64 -> Try(U32, [OutOfRange, ..])
 
-            ## No-op: leave a [U64] unchanged as a [U64].
-            to_u64 : U64 -> U64
-            to_u64 = |self| self
+			## No-op: leave a [U64] unchanged as a [U64].
+			to_u64 : U64 -> U64
+			to_u64 = |self| self
 
-            ## Leave a [U64] unchanged as a [U64]. Always succeeds.
-            to_u64_try : U64 -> Try(U64, _never_fails)
-            to_u64_try = |self| Ok(self)
+			## Leave a [U64] unchanged as a [U64]. Always succeeds.
+			to_u64_try : U64 -> Try(U64, _never_fails)
+			to_u64_try = |self| Ok(self)
 
-            ## No-op: leave a [U64] unchanged as a [U64].
-            to_u64_wrap : U64 -> U64
-            to_u64_wrap = |self| self
+			## No-op: leave a [U64] unchanged as a [U64].
+			to_u64_wrap : U64 -> U64
+			to_u64_wrap = |self| self
 
 			## Convert a [U64] to a [U128]. This widening conversion preserves
 			## every [U64] value exactly.
@@ -8601,17 +8601,17 @@ Builtin :: [].{
 			## ```
 			to_i32_try : I64 -> Try(I32, [OutOfRange, ..])
 
-            ## No-op: leave an [I64] unchanged as an [I64].
-            to_i64 : I64 -> I64
-            to_i64 = |self| self
+			## No-op: leave an [I64] unchanged as an [I64].
+			to_i64 : I64 -> I64
+			to_i64 = |self| self
 
-            ## Leave an [I64] unchanged as an [I64]. Always succeeds.
-            to_i64_try : I64 -> Try(I64, _never_fails)
-            to_i64_try = |self| Ok(self)
+			## Leave an [I64] unchanged as an [I64]. Always succeeds.
+			to_i64_try : I64 -> Try(I64, _never_fails)
+			to_i64_try = |self| Ok(self)
 
-            ## No-op: leave an [I64] unchanged as an [I64].
-            to_i64_wrap : I64 -> I64
-            to_i64_wrap = |self| self
+			## No-op: leave an [I64] unchanged as an [I64].
+			to_i64_wrap : I64 -> I64
+			to_i64_wrap = |self| self
 
 			## Convert an [I64] to an [I128]. This widening conversion preserves
 			## every [I64] value exactly.
@@ -9442,17 +9442,17 @@ Builtin :: [].{
 			## ```
 			to_u64_try : U128 -> Try(U64, [OutOfRange, ..])
 
-            ## No-op: leave a [U128] unchanged as a [U128].
-            to_u128 : U128 -> U128
-            to_u128 = |self| self
+			## No-op: leave a [U128] unchanged as a [U128].
+			to_u128 : U128 -> U128
+			to_u128 = |self| self
 
-            ## Leave a [U128] unchanged as a [U128]. Always succeeds.
-            to_u128_try : U128 -> Try(U128, _never_fails)
-            to_u128_try = |self| Ok(self)
+			## Leave a [U128] unchanged as a [U128]. Always succeeds.
+			to_u128_try : U128 -> Try(U128, _never_fails)
+			to_u128_try = |self| Ok(self)
 
-            ## No-op: leave a [U128] unchanged as a [U128].
-            to_u128_wrap : U128 -> U128
-            to_u128_wrap = |self| self
+			## No-op: leave a [U128] unchanged as a [U128].
+			to_u128_wrap : U128 -> U128
+			to_u128_wrap = |self| self
 
 			# Conversions to floating point (all safe)
 			## Convert a [U128] to an [F32]. This conversion may round, and the
@@ -10166,17 +10166,17 @@ Builtin :: [].{
 			## ```
 			to_i64_try : I128 -> Try(I64, [OutOfRange, ..])
 
-            ## No-op: leave an [I128] unchanged as an [I128].
-            to_i128 : I128 -> I128
-            to_i128 = |self| self
+			## No-op: leave an [I128] unchanged as an [I128].
+			to_i128 : I128 -> I128
+			to_i128 = |self| self
 
-            ## Leave an [I128] unchanged as an [I128]. Always succeeds.
-            to_i128_try : I128 -> Try(I128, _never_fails)
-            to_i128_try = |self| Ok(self)
+			## Leave an [I128] unchanged as an [I128]. Always succeeds.
+			to_i128_try : I128 -> Try(I128, _never_fails)
+			to_i128_try = |self| Ok(self)
 
-            ## No-op: leave an [I128] unchanged as an [I128].
-            to_i128_wrap : I128 -> I128
-            to_i128_wrap = |self| self
+			## No-op: leave an [I128] unchanged as an [I128].
+			to_i128_wrap : I128 -> I128
+			to_i128_wrap = |self| self
 
 			# Conversions to unsigned integers (all lossy for negative values)
 

--- a/test/snapshots/repl/number_self_conversion_signed.md
+++ b/test/snapshots/repl/number_self_conversion_signed.md
@@ -1,0 +1,55 @@
+# META
+~~~ini
+description=Signed `to_i<n>` - a noop that returns the value
+type=repl
+~~~
+# SOURCE
+~~~roc
+» I8.to_i8(I8.highest) == I8.highest
+» I16.to_i16(I16.highest) == I16.highest
+» I32.to_i32(I32.highest) == I32.highest
+» I64.to_i64(I64.highest) == I64.highest
+» I128.to_i128(I128.highest) == I128.highest
+» I8.to_i8_wrap(I8.highest) == I8.highest
+» I16.to_i16_wrap(I16.highest) == I16.highest
+» I32.to_i32_wrap(I32.highest) == I32.highest
+» I64.to_i64_wrap(I64.highest) == I64.highest
+» I128.to_i128_wrap(I128.highest) == I128.highest
+» I8.to_i8_try(I8.highest) == Ok(I8.highest)
+» I16.to_i16_try(I16.highest) == Ok(I16.highest)
+» I32.to_i32_try(I32.highest) == Ok(I32.highest)
+» I64.to_i64_try(I64.highest) == Ok(I64.highest)
+» I128.to_i128_try(I128.highest) == Ok(I128.highest)
+~~~
+# OUTPUT
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/number_self_conversion_unsigned.md
+++ b/test/snapshots/repl/number_self_conversion_unsigned.md
@@ -1,0 +1,55 @@
+# META
+~~~ini
+description=Unsigned `to_u<n>` - a noop that returns the value
+type=repl
+~~~
+# SOURCE
+~~~roc
+» U8.to_u8(U8.highest) == U8.highest
+» U16.to_u16(U16.highest) == U16.highest
+» U32.to_u32(U32.highest) == U32.highest
+» U64.to_u64(U64.highest) == U64.highest
+» U128.to_u128(U128.highest) == U128.highest
+» U8.to_u8_wrap(U8.highest) == U8.highest
+» U16.to_u16_wrap(U16.highest) == U16.highest
+» U32.to_u32_wrap(U32.highest) == U32.highest
+» U64.to_u64_wrap(U64.highest) == U64.highest
+» U128.to_u128_wrap(U128.highest) == U128.highest
+» U8.to_u8_try(U8.highest) == Ok(U8.highest)
+» U16.to_u16_try(U16.highest) == Ok(U16.highest)
+» U32.to_u32_try(U32.highest) == Ok(U32.highest)
+» U64.to_u64_try(U64.highest) == Ok(U64.highest)
+» U128.to_u128_try(U128.highest) == Ok(U128.highest)
+~~~
+# OUTPUT
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+---
+True
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/string_self_conversion.md
+++ b/test/snapshots/repl/string_self_conversion.md
@@ -1,0 +1,13 @@
+# META
+~~~ini
+description=`Str.to_str` - a noop that returns the value
+type=repl
+~~~
+# SOURCE
+~~~roc
+» Str.to_str("my string") == "my string"
+~~~
+# OUTPUT
+True
+# PROBLEMS
+NIL

--- a/test/snapshots/where_to_i32_wrap_accepts_i32.md
+++ b/test/snapshots/where_to_i32_wrap_accepts_i32.md
@@ -1,0 +1,127 @@
+# META
+~~~ini
+description=to_i32_wrap should accept I32
+type=snippet
+~~~
+# SOURCE
+~~~roc
+function : a -> I32 where [ a.to_i32_wrap : a -> I32 ]
+function = |convertible| {
+    convertible.to_i32_wrap()
+}
+
+value : I32
+value = -123
+
+_ = function(value)
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,KwWhere,OpenSquare,LowerIdent,NoSpaceDotLowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,CloseSquare,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,
+CloseCurly,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,Int,
+Underscore,OpAssign,LowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-anno (name "function")
+			(ty-fn
+				(ty-var (raw "a"))
+				(ty (name "I32")))
+			(where
+				(method (module-of "a") (name "to_i32_wrap")
+					(args
+						(ty-var (raw "a")))
+					(ty (name "I32")))))
+		(s-decl
+			(p-ident (raw "function"))
+			(e-lambda
+				(args
+					(p-ident (raw "convertible")))
+				(e-block
+					(statements
+						(e-method-call (method ".to_i32_wrap")
+							(receiver
+								(e-ident (raw "convertible")))
+							(args))))))
+		(s-type-anno (name "value")
+			(ty (name "I32")))
+		(s-decl
+			(p-ident (raw "value"))
+			(e-int (raw "-123")))
+		(s-decl
+			(p-underscore)
+			(e-apply
+				(e-ident (raw "function"))
+				(e-ident (raw "value"))))))
+~~~
+# FORMATTED
+~~~roc
+function : a -> I32 where [a.to_i32_wrap : a -> I32]
+function = |convertible| {
+	convertible.to_i32_wrap()
+}
+
+value : I32
+value = -123
+
+_ = function(value)
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "function"))
+		(e-lambda
+			(args
+				(p-assign (ident "convertible")))
+			(e-block
+				(e-dispatch-call (method "to_i32_wrap") (constraint-fn-var 47)
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "convertible"))))
+					(args))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-rigid-var (name "a"))
+				(ty-lookup (name "I32") (builtin)))
+			(where
+				(method (ty-rigid-var-lookup (ty-rigid-var (name "a"))) (name "to_i32_wrap")
+					(args
+						(ty-rigid-var-lookup (ty-rigid-var (name "a"))))
+					(ty-lookup (name "I32") (builtin))))))
+	(d-let
+		(p-assign (ident "value"))
+		(e-num (value "-123"))
+		(annotation
+			(ty-lookup (name "I32") (builtin))))
+	(d-let
+		(p-underscore)
+		(e-call (constraint-fn-var 161)
+			(e-lookup-local
+				(p-assign (ident "function")))
+			(e-lookup-local
+				(p-assign (ident "value"))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> I32 where [a.to_i32_wrap : a -> I32]"))
+		(patt (type "I32")))
+	(expressions
+		(expr (type "a -> I32 where [a.to_i32_wrap : a -> I32]"))
+		(expr (type "I32"))
+		(expr (type "I32"))))
+~~~

--- a/test/snapshots/where_to_str_accepts_str.md
+++ b/test/snapshots/where_to_str_accepts_str.md
@@ -1,0 +1,122 @@
+# META
+~~~ini
+description=to_str should accept Str
+type=snippet
+~~~
+# SOURCE
+~~~roc
+function : a -> Str where [ a.to_str : a -> Str ]
+function = |convertible| {
+    convertible.to_str()
+}
+
+value = "my string"
+
+_ = function(value)
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,KwWhere,OpenSquare,LowerIdent,NoSpaceDotLowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,CloseSquare,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,
+CloseCurly,
+LowerIdent,OpAssign,StringStart,StringPart,StringEnd,
+Underscore,OpAssign,LowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-anno (name "function")
+			(ty-fn
+				(ty-var (raw "a"))
+				(ty (name "Str")))
+			(where
+				(method (module-of "a") (name "to_str")
+					(args
+						(ty-var (raw "a")))
+					(ty (name "Str")))))
+		(s-decl
+			(p-ident (raw "function"))
+			(e-lambda
+				(args
+					(p-ident (raw "convertible")))
+				(e-block
+					(statements
+						(e-method-call (method ".to_str")
+							(receiver
+								(e-ident (raw "convertible")))
+							(args))))))
+		(s-decl
+			(p-ident (raw "value"))
+			(e-string
+				(e-string-part (raw "my string"))))
+		(s-decl
+			(p-underscore)
+			(e-apply
+				(e-ident (raw "function"))
+				(e-ident (raw "value"))))))
+~~~
+# FORMATTED
+~~~roc
+function : a -> Str where [a.to_str : a -> Str]
+function = |convertible| {
+	convertible.to_str()
+}
+
+value = "my string"
+
+_ = function(value)
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "function"))
+		(e-lambda
+			(args
+				(p-assign (ident "convertible")))
+			(e-block
+				(e-dispatch-call (method "to_str") (constraint-fn-var 51)
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "convertible"))))
+					(args))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-rigid-var (name "a"))
+				(ty-lookup (name "Str") (builtin)))
+			(where
+				(method (ty-rigid-var-lookup (ty-rigid-var (name "a"))) (name "to_str")
+					(args
+						(ty-rigid-var-lookup (ty-rigid-var (name "a"))))
+					(ty-lookup (name "Str") (builtin))))))
+	(d-let
+		(p-assign (ident "value"))
+		(e-string
+			(e-literal (string "my string"))))
+	(d-let
+		(p-underscore)
+		(e-call (constraint-fn-var 72)
+			(e-lookup-local
+				(p-assign (ident "function")))
+			(e-lookup-local
+				(p-assign (ident "value"))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> Str where [a.to_str : a -> Str]"))
+		(patt (type "Str")))
+	(expressions
+		(expr (type "a -> Str where [a.to_str : a -> Str]"))
+		(expr (type "Str"))
+		(expr (type "Str"))))
+~~~

--- a/test/snapshots/where_to_u32_try_accepts_u32.md
+++ b/test/snapshots/where_to_u32_try_accepts_u32.md
@@ -1,0 +1,140 @@
+# META
+~~~ini
+description=to_u32_try should accept U32
+type=snippet
+~~~
+# SOURCE
+~~~roc
+function : a -> U32 where [ a.to_u32_try : a -> Try(U32, _) ]
+function = |convertible| {
+    convertible.to_u32_try().ok_or(0)
+}
+
+value : U32
+value = 123
+
+_ = function(value)
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,KwWhere,OpenSquare,LowerIdent,NoSpaceDotLowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,NoSpaceOpenRound,UpperIdent,Comma,Underscore,CloseRound,CloseSquare,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,NoSpaceDotLowerIdent,NoSpaceOpenRound,Int,CloseRound,
+CloseCurly,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,Int,
+Underscore,OpAssign,LowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-anno (name "function")
+			(ty-fn
+				(ty-var (raw "a"))
+				(ty (name "U32")))
+			(where
+				(method (module-of "a") (name "to_u32_try")
+					(args
+						(ty-var (raw "a")))
+					(ty-apply
+						(ty (name "Try"))
+						(ty (name "U32"))
+						(_)))))
+		(s-decl
+			(p-ident (raw "function"))
+			(e-lambda
+				(args
+					(p-ident (raw "convertible")))
+				(e-block
+					(statements
+						(e-method-call (method ".ok_or")
+							(receiver
+								(e-method-call (method ".to_u32_try")
+									(receiver
+										(e-ident (raw "convertible")))
+									(args)))
+							(args
+								(e-int (raw "0"))))))))
+		(s-type-anno (name "value")
+			(ty (name "U32")))
+		(s-decl
+			(p-ident (raw "value"))
+			(e-int (raw "123")))
+		(s-decl
+			(p-underscore)
+			(e-apply
+				(e-ident (raw "function"))
+				(e-ident (raw "value"))))))
+~~~
+# FORMATTED
+~~~roc
+function : a -> U32 where [a.to_u32_try : a -> Try(U32, _)]
+function = |convertible| {
+	convertible.to_u32_try().ok_or(0)
+}
+
+value : U32
+value = 123
+
+_ = function(value)
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "function"))
+		(e-lambda
+			(args
+				(p-assign (ident "convertible")))
+			(e-block
+				(e-dispatch-call (method "ok_or") (constraint-fn-var 100)
+					(receiver
+						(e-dispatch-call (method "to_u32_try") (constraint-fn-var 65)
+							(receiver
+								(e-lookup-local
+									(p-assign (ident "convertible"))))
+							(args)))
+					(args
+						(e-num (value "0"))))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-rigid-var (name "a"))
+				(ty-lookup (name "U32") (builtin)))
+			(where
+				(method (ty-rigid-var-lookup (ty-rigid-var (name "a"))) (name "to_u32_try")
+					(args
+						(ty-rigid-var-lookup (ty-rigid-var (name "a"))))
+					(ty-apply (name "Try") (builtin)
+						(ty-lookup (name "U32") (builtin))
+						(ty-underscore))))))
+	(d-let
+		(p-assign (ident "value"))
+		(e-num (value "123"))
+		(annotation
+			(ty-lookup (name "U32") (builtin))))
+	(d-let
+		(p-underscore)
+		(e-call (constraint-fn-var 299)
+			(e-lookup-local
+				(p-assign (ident "function")))
+			(e-lookup-local
+				(p-assign (ident "value"))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> U32 where [a.to_u32_try : a -> Try(U32, _err)]"))
+		(patt (type "U32")))
+	(expressions
+		(expr (type "a -> U32 where [a.to_u32_try : a -> Try(U32, _err)]"))
+		(expr (type "U32"))
+		(expr (type "U32"))))
+~~~

--- a/test/snapshots/where_to_u64_accepts_u64.md
+++ b/test/snapshots/where_to_u64_accepts_u64.md
@@ -1,0 +1,127 @@
+# META
+~~~ini
+description=to_u64 should accept U64
+type=snippet
+~~~
+# SOURCE
+~~~roc
+function : a -> U64 where [ a.to_u64 : a -> U64 ]
+function = |convertible| {
+    convertible.to_u64()
+}
+
+value : U64
+value = 123
+
+_ = function(value)
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,KwWhere,OpenSquare,LowerIdent,NoSpaceDotLowerIdent,OpColon,LowerIdent,OpArrow,UpperIdent,CloseSquare,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,
+CloseCurly,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,Int,
+Underscore,OpAssign,LowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-anno (name "function")
+			(ty-fn
+				(ty-var (raw "a"))
+				(ty (name "U64")))
+			(where
+				(method (module-of "a") (name "to_u64")
+					(args
+						(ty-var (raw "a")))
+					(ty (name "U64")))))
+		(s-decl
+			(p-ident (raw "function"))
+			(e-lambda
+				(args
+					(p-ident (raw "convertible")))
+				(e-block
+					(statements
+						(e-method-call (method ".to_u64")
+							(receiver
+								(e-ident (raw "convertible")))
+							(args))))))
+		(s-type-anno (name "value")
+			(ty (name "U64")))
+		(s-decl
+			(p-ident (raw "value"))
+			(e-int (raw "123")))
+		(s-decl
+			(p-underscore)
+			(e-apply
+				(e-ident (raw "function"))
+				(e-ident (raw "value"))))))
+~~~
+# FORMATTED
+~~~roc
+function : a -> U64 where [a.to_u64 : a -> U64]
+function = |convertible| {
+	convertible.to_u64()
+}
+
+value : U64
+value = 123
+
+_ = function(value)
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "function"))
+		(e-lambda
+			(args
+				(p-assign (ident "convertible")))
+			(e-block
+				(e-dispatch-call (method "to_u64") (constraint-fn-var 47)
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "convertible"))))
+					(args))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-rigid-var (name "a"))
+				(ty-lookup (name "U64") (builtin)))
+			(where
+				(method (ty-rigid-var-lookup (ty-rigid-var (name "a"))) (name "to_u64")
+					(args
+						(ty-rigid-var-lookup (ty-rigid-var (name "a"))))
+					(ty-lookup (name "U64") (builtin))))))
+	(d-let
+		(p-assign (ident "value"))
+		(e-num (value "123"))
+		(annotation
+			(ty-lookup (name "U64") (builtin))))
+	(d-let
+		(p-underscore)
+		(e-call (constraint-fn-var 161)
+			(e-lookup-local
+				(p-assign (ident "function")))
+			(e-lookup-local
+				(p-assign (ident "value"))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a -> U64 where [a.to_u64 : a -> U64]"))
+		(patt (type "U64")))
+	(expressions
+		(expr (type "a -> U64 where [a.to_u64 : a -> U64]"))
+		(expr (type "U64"))
+		(expr (type "U64"))))
+~~~


### PR DESCRIPTION
Resolves #9830. Adds `to_<self>` methods for all signed and unsigned integers (e.g., `U64.to_u64`). These are functionally noops that were added to permit interfaces that accept anything that can be turned into e.g., a U64, which should include U64 itself. `to_<self>_try` and `to_<self>_wrap` were also added for consistency. Snapshot tests check that the value is returned as-is, as well as demonstrate a `<number type>` satisfying a `to_<number type>` `where` constraint.

## Remaining
- [x] Floats, Dec
- [x] Distinct, but it would also follow that Str should have to_str