### PR TITLE
feat(parse): support destructuring nominal types in `=` definitions

### DIFF
--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -197,7 +197,7 @@ fn looksLikeTypeDecl(self: *Parser) bool {
     };
 }
 
-fn looksLikeAppliedTagDestructure(self: *Parser) bool {
+fn looksLikeTagOrNominalDestructure(self: *Parser) bool {
     std.debug.assert(self.peek() == .UpperIdent);
 
     var lookahead: u32 = 1;
@@ -205,11 +205,18 @@ fn looksLikeAppliedTagDestructure(self: *Parser) bool {
         lookahead += 1;
     }
 
-    if (self.peekN(lookahead) != .NoSpaceOpenRound) {
+    // After the (optional) qualifier chain, accept either the applied-tag form
+    // `Tag(args) =` (qualifiers then `(`) or the nominal-value destructure
+    // `Type.(pattern) =` (qualifiers then `.(`). Both then share the same scan
+    // to the matching `)` followed by `=`.
+    if (self.peekN(lookahead) == .NoSpaceOpenRound) {
+        lookahead += 1;
+    } else if (self.peekN(lookahead) == .Dot and self.peekN(lookahead + 1) == .NoSpaceOpenRound) {
+        lookahead += 2;
+    } else {
         return false;
     }
 
-    lookahead += 1;
     var depth: u32 = 1;
     var closing_tok = Token.Tag.EndOfFile;
     while (depth > 0) {
@@ -5216,7 +5223,7 @@ fn runExprStatementKernel(
                 }
                 if (tok == .UpperIdent) {
                     const start = self.pos;
-                    if (self.looksLikeAppliedTagDestructure()) {
+                    if (self.looksLikeTagOrNominalDestructure()) {
                         try open_syntax.pushPattern(open_allocator, .statement_destructure_pattern, Token.Idx, start);
                         pattern_root_state = .{
                             .outer_start = self.pos,

--- a/test/snapshots/nominal_destructure_decl.md
+++ b/test/snapshots/nominal_destructure_decl.md
@@ -16,204 +16,9 @@ double = |d| {
 Distance.(five) = Distance.(5)
 ~~~
 # EXPECTED
-UNEXPECTED TOKEN IN EXPRESSION - nominal_destructure_decl.md:5:18:5:19
-PARSE ERROR - nominal_destructure_decl.md:9:9:9:10
-PARSE ERROR - nominal_destructure_decl.md:9:10:9:11
-PARSE ERROR - nominal_destructure_decl.md:9:11:9:15
-PARSE ERROR - nominal_destructure_decl.md:9:15:9:16
-PARSE ERROR - nominal_destructure_decl.md:9:17:9:18
-PARSE ERROR - nominal_destructure_decl.md:9:27:9:28
-PARSE ERROR - nominal_destructure_decl.md:9:28:9:29
-PARSE ERROR - nominal_destructure_decl.md:9:29:9:30
-PARSE ERROR - nominal_destructure_decl.md:9:30:9:31
-UNDEFINED VARIABLE - nominal_destructure_decl.md:5:15:5:16
-UNRECOGNIZED SYNTAX - nominal_destructure_decl.md:5:18:5:19
-UNDEFINED VARIABLE - nominal_destructure_decl.md:6:5:6:6
-TYPE MISMATCH - nominal_destructure_decl.md:5:20:5:21
+NIL
 # PROBLEMS
-
-┌────────────────────────────────┐
-│ UNEXPECTED TOKEN IN EXPRESSION ├─ The token = is not expected in an ────────┐
-└┬───────────────────────────────┘  expression.                               │
- │                                                                            │
- │  Distance.(n) = d                                                          │
- │               ‾                                                            │
- └────────────────────────────────────────── nominal_destructure_decl.md:5:18 ┘
-
-    Expressions can be identifiers, literals, function calls, or operators.
-
-
-┌─────────────┐
-│ PARSE ERROR ├─ Type applications require parentheses around their type ─────┐
-└┬────────────┘  arguments.                                                   │
- │                                                                            │
- │  Distance.(five) = Distance.(5)                                            │
- │          ‾                                                                 │
- └─────────────────────────────────────────── nominal_destructure_decl.md:9:9 ┘
-
-    I found a type followed by what looks like a type argument, but they need
-    to be connected with parentheses.
-
-    Instead of:
-        List U8
-
-    Use:
-        List(U8)
-
-    Other valid examples:
-        Dict(Str, Num)
-        Try(a, Str)
-        Maybe(List(U64))
-
-
-┌─────────────┐
-│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
-└┬────────────┘                                                               │
- │                                                                            │
- │  Distance.(five) = Distance.(5)                                            │
- │           ‾                                                                │
- └────────────────────────────────────────── nominal_destructure_decl.md:9:10 ┘
-
-    This is an unexpected parsing error. Please check your syntax.
-
-
-┌─────────────┐
-│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
-└┬────────────┘                                                               │
- │                                                                            │
- │  Distance.(five) = Distance.(5)                                            │
- │            ‾‾‾‾                                                            │
- └────────────────────────────────────────── nominal_destructure_decl.md:9:11 ┘
-
-    This is an unexpected parsing error. Please check your syntax.
-
-
-┌─────────────┐
-│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
-└┬────────────┘                                                               │
- │                                                                            │
- │  Distance.(five) = Distance.(5)                                            │
- │                ‾                                                           │
- └────────────────────────────────────────── nominal_destructure_decl.md:9:15 ┘
-
-    This is an unexpected parsing error. Please check your syntax.
-
-
-┌─────────────┐
-│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
-└┬────────────┘                                                               │
- │                                                                            │
- │  Distance.(five) = Distance.(5)                                            │
- │                  ‾                                                         │
- └────────────────────────────────────────── nominal_destructure_decl.md:9:17 ┘
-
-    This is an unexpected parsing error. Please check your syntax.
-
-
-┌─────────────┐
-│ PARSE ERROR ├─ Type applications require parentheses around their type ─────┐
-└┬────────────┘  arguments.                                                   │
- │                                                                            │
- │  Distance.(five) = Distance.(5)                                            │
- │                            ‾                                               │
- └────────────────────────────────────────── nominal_destructure_decl.md:9:27 ┘
-
-    I found a type followed by what looks like a type argument, but they need
-    to be connected with parentheses.
-
-    Instead of:
-        List U8
-
-    Use:
-        List(U8)
-
-    Other valid examples:
-        Dict(Str, Num)
-        Try(a, Str)
-        Maybe(List(U64))
-
-
-┌─────────────┐
-│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
-└┬────────────┘                                                               │
- │                                                                            │
- │  Distance.(five) = Distance.(5)                                            │
- │                             ‾                                              │
- └────────────────────────────────────────── nominal_destructure_decl.md:9:28 ┘
-
-    This is an unexpected parsing error. Please check your syntax.
-
-
-┌─────────────┐
-│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
-└┬────────────┘                                                               │
- │                                                                            │
- │  Distance.(five) = Distance.(5)                                            │
- │                              ‾                                             │
- └────────────────────────────────────────── nominal_destructure_decl.md:9:29 ┘
-
-    This is an unexpected parsing error. Please check your syntax.
-
-
-┌─────────────┐
-│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
-└┬────────────┘                                                               │
- │                                                                            │
- │  Distance.(five) = Distance.(5)                                            │
- │                               ‾                                            │
- └────────────────────────────────────────── nominal_destructure_decl.md:9:30 ┘
-
-    This is an unexpected parsing error. Please check your syntax.
-
-
-┌────────────────────┐
-│ UNDEFINED VARIABLE ├─ Nothing is named `n` in this scope. ──────────────────┐
-└┬───────────────────┘                                                        │
- │                                                                            │
- │  Distance.(n) = d                                                          │
- │            ‾                                                               │
- └────────────────────────────────────────── nominal_destructure_decl.md:5:15 ┘
-
-    Is there an `import` or `exposing` missing up-top?
-
-
-┌─────────────────────┐
-│ UNRECOGNIZED SYNTAX ├─ I don't recognize this syntax. ──────────────────────┐
-└┬────────────────────┘                                                       │
- │                                                                            │
- │  Distance.(n) = d                                                          │
- │               ‾                                                            │
- └────────────────────────────────────────── nominal_destructure_decl.md:5:18 ┘
-
-    This might be a syntax error, an unsupported language feature, or a typo.
-
-
-┌────────────────────┐
-│ UNDEFINED VARIABLE ├─ Nothing is named `n` in this scope. ──────────────────┐
-└┬───────────────────┘                                                        │
- │                                                                            │
- │  n * 2                                                                     │
- │  ‾                                                                         │
- └─────────────────────────────────────────── nominal_destructure_decl.md:6:5 ┘
-
-    Is there an `import` or `exposing` missing up-top?
-
-
-┌───────────────┐
-│ TYPE MISMATCH ├─ This expression produces a value, but it's not being ──────┐
-└┬──────────────┘  used.                                                      │
- │                                                                            │
- │  Distance.(n) = d                                                          │
- │                 ‾                                                          │
- └────────────────────────────────────────── nominal_destructure_decl.md:5:20 ┘
-
-    It has the type:
-
-        Distance
-
-    Since this expression is used as a statement, it must evaluate to `{}`.
-    If you don't need the value, you can ignore it with `_ =`.
-
+NIL
 # TOKENS
 ~~~zig
 UpperIdent,OpColonEqual,UpperIdent,
@@ -245,23 +50,19 @@ EndOfFile,
 					(p-ident (raw "d")))
 				(e-block
 					(statements
-						(e-nominal-apply
-							(mapper (e-tag (raw "Distance")))
-							(e-ident (raw "n")))
-						(e-malformed (reason "expr_unexpected_token"))
-						(e-ident (raw "d"))
+						(s-decl
+							(p-tag (raw "Distance")
+								(p-ident (raw "n")))
+							(e-ident (raw "d")))
 						(e-binop (op "*")
 							(e-ident (raw "n"))
 							(e-int (raw "2")))))))
-		(s-malformed (tag "expected_colon_after_type_annotation"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "expected_colon_after_type_annotation"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))
-		(s-malformed (tag "statement_unexpected_token"))))
+		(s-decl
+			(p-tag (raw "Distance")
+				(p-ident (raw "five")))
+			(e-nominal-apply
+				(mapper (e-tag (raw "Distance")))
+				(e-int (raw "5"))))))
 ~~~
 # FORMATTED
 ~~~roc
@@ -269,10 +70,11 @@ Distance := U64
 
 double : Distance -> U64
 double = |d| {
-	Distance.(n)
-		d
+	Distance.(n) = d
 	n * 2
 }
+
+Distance.(five) = Distance.(5)
 ~~~
 # CANONICALIZE
 ~~~clojure
@@ -283,23 +85,26 @@ double = |d| {
 			(args
 				(p-assign (ident "d")))
 			(e-block
-				(s-expr
-					(e-nominal (nominal "Distance")
-						(e-runtime-error (tag "ident_not_in_scope"))))
-				(s-expr
-					(e-runtime-error (tag "expr_not_canonicalized")))
-				(s-expr
+				(s-let
+					(p-nominal
+						(p-assign (ident "n")))
 					(e-lookup-local
 						(p-assign (ident "d"))))
-				(e-dispatch-call (method "times") (constraint-fn-var 88)
+				(e-dispatch-call (method "times") (constraint-fn-var 84)
 					(receiver
-						(e-runtime-error (tag "ident_not_in_scope")))
+						(e-lookup-local
+							(p-assign (ident "n"))))
 					(args
 						(e-num (value "2"))))))
 		(annotation
 			(ty-fn (effectful false)
 				(ty-lookup (name "Distance") (local))
 				(ty-lookup (name "U64") (builtin)))))
+	(d-let
+		(p-nominal
+			(p-assign (ident "five")))
+		(e-nominal (nominal "Distance")
+			(e-num (value "5"))))
 	(s-nominal-decl
 		(ty-header (name "Distance"))
 		(ty-lookup (name "U64") (builtin))))
@@ -313,5 +118,6 @@ double = |d| {
 		(nominal (type "Distance")
 			(ty-header (name "Distance"))))
 	(expressions
-		(expr (type "Distance -> U64"))))
+		(expr (type "Distance -> U64"))
+		(expr (type "Distance"))))
 ~~~

--- a/test/snapshots/nominal_destructure_decl.md
+++ b/test/snapshots/nominal_destructure_decl.md
@@ -1,0 +1,317 @@
+# META
+~~~ini
+description=Nominal-value destructuring (Type.(pat)) on the LHS of a = definition
+type=snippet
+~~~
+# SOURCE
+~~~roc
+Distance := U64
+
+double : Distance -> U64
+double = |d| {
+    Distance.(n) = d
+    n * 2
+}
+
+Distance.(five) = Distance.(5)
+~~~
+# EXPECTED
+UNEXPECTED TOKEN IN EXPRESSION - nominal_destructure_decl.md:5:18:5:19
+PARSE ERROR - nominal_destructure_decl.md:9:9:9:10
+PARSE ERROR - nominal_destructure_decl.md:9:10:9:11
+PARSE ERROR - nominal_destructure_decl.md:9:11:9:15
+PARSE ERROR - nominal_destructure_decl.md:9:15:9:16
+PARSE ERROR - nominal_destructure_decl.md:9:17:9:18
+PARSE ERROR - nominal_destructure_decl.md:9:27:9:28
+PARSE ERROR - nominal_destructure_decl.md:9:28:9:29
+PARSE ERROR - nominal_destructure_decl.md:9:29:9:30
+PARSE ERROR - nominal_destructure_decl.md:9:30:9:31
+UNDEFINED VARIABLE - nominal_destructure_decl.md:5:15:5:16
+UNRECOGNIZED SYNTAX - nominal_destructure_decl.md:5:18:5:19
+UNDEFINED VARIABLE - nominal_destructure_decl.md:6:5:6:6
+TYPE MISMATCH - nominal_destructure_decl.md:5:20:5:21
+# PROBLEMS
+
+┌────────────────────────────────┐
+│ UNEXPECTED TOKEN IN EXPRESSION ├─ The token = is not expected in an ────────┐
+└┬───────────────────────────────┘  expression.                               │
+ │                                                                            │
+ │  Distance.(n) = d                                                          │
+ │               ‾                                                            │
+ └────────────────────────────────────────── nominal_destructure_decl.md:5:18 ┘
+
+    Expressions can be identifiers, literals, function calls, or operators.
+
+
+┌─────────────┐
+│ PARSE ERROR ├─ Type applications require parentheses around their type ─────┐
+└┬────────────┘  arguments.                                                   │
+ │                                                                            │
+ │  Distance.(five) = Distance.(5)                                            │
+ │          ‾                                                                 │
+ └─────────────────────────────────────────── nominal_destructure_decl.md:9:9 ┘
+
+    I found a type followed by what looks like a type argument, but they need
+    to be connected with parentheses.
+
+    Instead of:
+        List U8
+
+    Use:
+        List(U8)
+
+    Other valid examples:
+        Dict(Str, Num)
+        Try(a, Str)
+        Maybe(List(U64))
+
+
+┌─────────────┐
+│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
+└┬────────────┘                                                               │
+ │                                                                            │
+ │  Distance.(five) = Distance.(5)                                            │
+ │           ‾                                                                │
+ └────────────────────────────────────────── nominal_destructure_decl.md:9:10 ┘
+
+    This is an unexpected parsing error. Please check your syntax.
+
+
+┌─────────────┐
+│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
+└┬────────────┘                                                               │
+ │                                                                            │
+ │  Distance.(five) = Distance.(5)                                            │
+ │            ‾‾‾‾                                                            │
+ └────────────────────────────────────────── nominal_destructure_decl.md:9:11 ┘
+
+    This is an unexpected parsing error. Please check your syntax.
+
+
+┌─────────────┐
+│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
+└┬────────────┘                                                               │
+ │                                                                            │
+ │  Distance.(five) = Distance.(5)                                            │
+ │                ‾                                                           │
+ └────────────────────────────────────────── nominal_destructure_decl.md:9:15 ┘
+
+    This is an unexpected parsing error. Please check your syntax.
+
+
+┌─────────────┐
+│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
+└┬────────────┘                                                               │
+ │                                                                            │
+ │  Distance.(five) = Distance.(5)                                            │
+ │                  ‾                                                         │
+ └────────────────────────────────────────── nominal_destructure_decl.md:9:17 ┘
+
+    This is an unexpected parsing error. Please check your syntax.
+
+
+┌─────────────┐
+│ PARSE ERROR ├─ Type applications require parentheses around their type ─────┐
+└┬────────────┘  arguments.                                                   │
+ │                                                                            │
+ │  Distance.(five) = Distance.(5)                                            │
+ │                            ‾                                               │
+ └────────────────────────────────────────── nominal_destructure_decl.md:9:27 ┘
+
+    I found a type followed by what looks like a type argument, but they need
+    to be connected with parentheses.
+
+    Instead of:
+        List U8
+
+    Use:
+        List(U8)
+
+    Other valid examples:
+        Dict(Str, Num)
+        Try(a, Str)
+        Maybe(List(U64))
+
+
+┌─────────────┐
+│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
+└┬────────────┘                                                               │
+ │                                                                            │
+ │  Distance.(five) = Distance.(5)                                            │
+ │                             ‾                                              │
+ └────────────────────────────────────────── nominal_destructure_decl.md:9:28 ┘
+
+    This is an unexpected parsing error. Please check your syntax.
+
+
+┌─────────────┐
+│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
+└┬────────────┘                                                               │
+ │                                                                            │
+ │  Distance.(five) = Distance.(5)                                            │
+ │                              ‾                                             │
+ └────────────────────────────────────────── nominal_destructure_decl.md:9:29 ┘
+
+    This is an unexpected parsing error. Please check your syntax.
+
+
+┌─────────────┐
+│ PARSE ERROR ├─ A parsing error occurred: statement_unexpected_token ────────┐
+└┬────────────┘                                                               │
+ │                                                                            │
+ │  Distance.(five) = Distance.(5)                                            │
+ │                               ‾                                            │
+ └────────────────────────────────────────── nominal_destructure_decl.md:9:30 ┘
+
+    This is an unexpected parsing error. Please check your syntax.
+
+
+┌────────────────────┐
+│ UNDEFINED VARIABLE ├─ Nothing is named `n` in this scope. ──────────────────┐
+└┬───────────────────┘                                                        │
+ │                                                                            │
+ │  Distance.(n) = d                                                          │
+ │            ‾                                                               │
+ └────────────────────────────────────────── nominal_destructure_decl.md:5:15 ┘
+
+    Is there an `import` or `exposing` missing up-top?
+
+
+┌─────────────────────┐
+│ UNRECOGNIZED SYNTAX ├─ I don't recognize this syntax. ──────────────────────┐
+└┬────────────────────┘                                                       │
+ │                                                                            │
+ │  Distance.(n) = d                                                          │
+ │               ‾                                                            │
+ └────────────────────────────────────────── nominal_destructure_decl.md:5:18 ┘
+
+    This might be a syntax error, an unsupported language feature, or a typo.
+
+
+┌────────────────────┐
+│ UNDEFINED VARIABLE ├─ Nothing is named `n` in this scope. ──────────────────┐
+└┬───────────────────┘                                                        │
+ │                                                                            │
+ │  n * 2                                                                     │
+ │  ‾                                                                         │
+ └─────────────────────────────────────────── nominal_destructure_decl.md:6:5 ┘
+
+    Is there an `import` or `exposing` missing up-top?
+
+
+┌───────────────┐
+│ TYPE MISMATCH ├─ This expression produces a value, but it's not being ──────┐
+└┬──────────────┘  used.                                                      │
+ │                                                                            │
+ │  Distance.(n) = d                                                          │
+ │                 ‾                                                          │
+ └────────────────────────────────────────── nominal_destructure_decl.md:5:20 ┘
+
+    It has the type:
+
+        Distance
+
+    Since this expression is used as a statement, it must evaluate to `{}`.
+    If you don't need the value, you can ignore it with `_ =`.
+
+# TOKENS
+~~~zig
+UpperIdent,OpColonEqual,UpperIdent,
+LowerIdent,OpColon,UpperIdent,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+UpperIdent,Dot,NoSpaceOpenRound,LowerIdent,CloseRound,OpAssign,LowerIdent,
+LowerIdent,OpStar,Int,
+CloseCurly,
+UpperIdent,Dot,NoSpaceOpenRound,LowerIdent,CloseRound,OpAssign,UpperIdent,Dot,NoSpaceOpenRound,Int,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-decl
+			(header (name "Distance")
+				(args))
+			(ty (name "U64")))
+		(s-type-anno (name "double")
+			(ty-fn
+				(ty (name "Distance"))
+				(ty (name "U64"))))
+		(s-decl
+			(p-ident (raw "double"))
+			(e-lambda
+				(args
+					(p-ident (raw "d")))
+				(e-block
+					(statements
+						(e-nominal-apply
+							(mapper (e-tag (raw "Distance")))
+							(e-ident (raw "n")))
+						(e-malformed (reason "expr_unexpected_token"))
+						(e-ident (raw "d"))
+						(e-binop (op "*")
+							(e-ident (raw "n"))
+							(e-int (raw "2")))))))
+		(s-malformed (tag "expected_colon_after_type_annotation"))
+		(s-malformed (tag "statement_unexpected_token"))
+		(s-malformed (tag "statement_unexpected_token"))
+		(s-malformed (tag "statement_unexpected_token"))
+		(s-malformed (tag "statement_unexpected_token"))
+		(s-malformed (tag "expected_colon_after_type_annotation"))
+		(s-malformed (tag "statement_unexpected_token"))
+		(s-malformed (tag "statement_unexpected_token"))
+		(s-malformed (tag "statement_unexpected_token"))))
+~~~
+# FORMATTED
+~~~roc
+Distance := U64
+
+double : Distance -> U64
+double = |d| {
+	Distance.(n)
+		d
+	n * 2
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "double"))
+		(e-lambda
+			(args
+				(p-assign (ident "d")))
+			(e-block
+				(s-expr
+					(e-nominal (nominal "Distance")
+						(e-runtime-error (tag "ident_not_in_scope"))))
+				(s-expr
+					(e-runtime-error (tag "expr_not_canonicalized")))
+				(s-expr
+					(e-lookup-local
+						(p-assign (ident "d"))))
+				(e-dispatch-call (method "times") (constraint-fn-var 88)
+					(receiver
+						(e-runtime-error (tag "ident_not_in_scope")))
+					(args
+						(e-num (value "2"))))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-lookup (name "Distance") (local))
+				(ty-lookup (name "U64") (builtin)))))
+	(s-nominal-decl
+		(ty-header (name "Distance"))
+		(ty-lookup (name "U64") (builtin))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Distance -> U64")))
+	(type_decls
+		(nominal (type "Distance")
+			(ty-header (name "Distance"))))
+	(expressions
+		(expr (type "Distance -> U64"))))
+~~~


### PR DESCRIPTION
## What

Allow a nominal-value destructure pattern, `Type.(pattern)`, on the left-hand side of a `=` definition statement — at both block-body and top-level scope:

```roc
double = |d| {
    Distance.(n) = d   # unwraps the Distance nominal, binds n
    n * 2
}

Distance.(five) = Distance.(5)
```

This is the same nominal-unwrap pattern that already worked in `match` arms and lambda arguments; this change extends it to definition statements.

## Why it was missing

When a statement begins with an `UpperIdent`, the parser uses a predicate (`looksLikeAppliedTagDestructure`) to decide whether to route the line to pattern parsing (a destructure def) or to expression parsing. That predicate only recognized the **applied-tag** form `Tag(args) =` — after skipping qualifier segments it required a `(` immediately. For the nominal form `Distance.(n) =` the next token is `.` then `(`, so the predicate returned `false` and the line was mis-routed to expression parsing (`Distance.(n)` parsed as a nominal *construction* expression, then choked on `=`).

## The change (parser-only)

Widened and renamed the predicate to `looksLikeTagOrNominalDestructure`: after the qualifier chain it now accepts **either** `(` (applied-tag form) **or** `.(` (nominal-value destructure), then runs the existing scan to the matching `)` followed by `=`. The single call site was updated.

No AST, canonicalization, or type-checker changes are needed — the pattern parser already handled `Type.(pattern)` and canonicalization already lowers it to a `nominal` pattern (binding the inner value). The trailing-`=` disambiguation is preserved, so a bare construction expression `Distance.(26)` (no `=`) still parses as an expression.

## Tests

New snapshot `test/snapshots/nominal_destructure_decl.md` covering the block-body and top-level cases:
- PARSE shows each def as an `s-decl` carrying a `p-tag` nominal backing pattern.
- CANONICALIZE shows `p-nominal` binding the inner value.
- `EXPECTED` / `PROBLEMS` are `NIL`.

Parse-module tests pass; `run-snapshot-tool --check-expected` passes; full build passes. (One unrelated unit test, `issue_9825_test`, an LIR/post-check capture-slot invariant, fails identically on `main` and is not affected by this parser change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)