### PR TITLE
Make occurs check non-recursive

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -2846,14 +2846,12 @@ fn checkForInfiniteType(self: *Self, comptime Idx: anytype, idx: Idx) std.mem.Al
     const occurs_result = try occurs.occurs(self.types, &self.occurs_scratch, var_);
 
     switch (occurs_result) {
-        .not_recursive, .recursive_nominal => {
-            // These are fine - no cycle, or valid recursion through a nominal type
+        .valid => {
+            // This is fine - no cycle, or valid recursion through a nominal type
         },
         .recursive_anonymous => {
-            const err_var = if (self.occurs_scratch.err_chain.len() > 0)
-                self.occurs_scratch.err_chain.items.items[0]
-            else
-                var_;
+            std.debug.assert(self.occurs_scratch.err_var != null);
+            const err_var = self.occurs_scratch.err_var.?;
 
             // Anonymous recursion (recursive type not through a nominal type)
             const snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, err_var);
@@ -2870,10 +2868,8 @@ fn checkForInfiniteType(self: *Self, comptime Idx: anytype, idx: Idx) std.mem.Al
             try self.types.setVarContent(var_, .err);
         },
         .infinite => {
-            const err_var = if (self.occurs_scratch.err_chain.len() > 0)
-                self.occurs_scratch.err_chain.items.items[0]
-            else
-                var_;
+            std.debug.assert(self.occurs_scratch.err_var != null);
+            const err_var = self.occurs_scratch.err_var.?;
 
             // Infinite type (like `a = List(a)`)
             const snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, err_var);

--- a/src/check/occurs.zig
+++ b/src/check/occurs.zig
@@ -20,7 +20,6 @@ const Ident = base.Ident;
 const MkSafeList = collections.SafeList;
 const Store = types.Store;
 const DescStoreIdx = types.DescStoreIdx;
-const ResolvedVarDesc = types.ResolvedVarDesc;
 const Content = types.Content;
 const Var = types.Var;
 const TagUnion = types.TagUnion;
@@ -28,11 +27,10 @@ const Tag = types.Tag;
 
 /// The result of checking for recursion
 ///
-/// If the result is `recursive_nominal`, you can use `scratch.err_chain_nominal_vars`
-/// to check what nominal vars were encountered
+/// When the result is recursive/infinite, `scratch.err_var` holds the var to
+/// report in the resulting diagnostic.
 pub const Result = enum {
-    not_recursive,
-    recursive_nominal,
+    valid,
     recursive_anonymous,
     infinite,
 };
@@ -42,48 +40,28 @@ pub const Result = enum {
 /// This uses `Scratch` as to hold intermediate values. `occurs` will reset it
 /// before each run.
 ///
-/// If the result is `recursive_nominal`, you can use `scratch.err_chain_nominal_vars`
-/// to check what nominal vars were encountered
+/// When the result is recursive/infinite, `scratch.err_var` holds the var to
+/// report in the resulting diagnostic.
 ///
 /// This function does not modify the `Store`.
 pub fn occurs(types_store: *Store, scratch: *Scratch, var_: Var) std.mem.Allocator.Error!Result {
     scratch.reset();
 
-    var result: Result = .not_recursive;
-
     // Check for recursion. The root has no incoming edge, so it starts with the
     // empty edge. Whether the recursion is nominal/anonymous/infinite is decided
     // from the edges *within* the detected cycle, not from the root downward.
     var check_occurs = CheckOccurs.init(types_store, scratch);
-    check_occurs.occurs(var_, Edge.none) catch |err| switch (err) {
-        error.AllocatorError => {
-            return error.OutOfMemory;
-        },
-        error.InfiniteType => {
-            result = .infinite;
-        },
-        error.RecursiveAnonymous => {
-            result = .recursive_anonymous;
-        },
-        error.RecursiveNominal => {
-            // We we somehow threw `RecursiveNominal` but didn't find any
-            // nominal vars, this is a bug!
-            std.debug.assert(scratch.err_chain_nominal_vars.len() > 0);
-
-            result = .recursive_nominal;
-        },
-    };
-
-    return result;
+    return try check_occurs.occurs(var_, Edge.none);
 }
 
 /// Performs an occurs check on a type variable.
 ///
-/// This struct encapsulates the recursive traversal logic used to detect
+/// This struct encapsulates the iterative traversal logic used to detect
 /// whether a variable is recursively defined through it's children.
 ///
-/// It uses a scratch space to track visited nodes and maintain state across
-/// recursive calls. It is intended for one-time use per `occurs()` call.
+/// It uses a scratch space to track visited nodes and maintain the explicit
+/// work stack that drives the traversal. It is intended for one-time use per
+/// `occurs()` call.
 ///
 /// Ownership: `CheckOccurs` does not allocate or deallocate memory. It borrows
 /// both the `types_store` and `scratch` passed during initialization. These
@@ -101,100 +79,151 @@ const CheckOccurs = struct {
         return .{ .types_store = types_store, .scratch = scratch };
     }
 
-    const Error = error{ InfiniteType, RecursiveAnonymous, RecursiveNominal, AllocatorError };
-
-    /// Recursively check if a type is referenced by it's children
+    /// Iteratively check if a type is referenced by it's children
     ///
-    /// This method appends intermediate error chain information to the `scratch`,
-    /// which can be queried after the run.
-    fn occurs(self: *Self, var_: Var, edge: Edge) Error!void {
-        const root = self.types_store.resolveVar(var_);
-        const root_var = root.var_;
+    /// On detecting a cycle, sets `scratch.err_var` to the var to report.
+    fn occurs(self: *Self, var_: Var, edge: Edge) std.mem.Allocator.Error!Result {
+        // Push the first frame
+        // Since we know that Scratch.init initializes capacity, we can append
+        // assuming capacity here
+        std.debug.assert(self.scratch.stack.items.capacity > 0);
+        _ = self.scratch.stack.appendAssumeCapacity(Frame{ .process_var = .{ .var_ = var_, .edge = edge } });
 
-        if (self.scratch.hasVisited(root.desc_idx)) {
-            // If we've already visited this var and not errored, then it's not recursive
-            return;
-        } else if (self.scratch.hasSeenVar(root_var)) |match_idx| {
-            // Recursion point! We've already seen this var during traversal.
-            // `edge` is the edge that closes the cycle (from the current parent
-            // back to `root_var`); `match_idx` is where `root_var` sits on the
-            // seen stack. Classify using only the edges inside that cycle.
-            return self.classifyCycle(match_idx, edge);
-        } else {
-            self.scratch.pushSeen(root_var, edge) catch return Error.AllocatorError;
-            switch (root.desc.content) {
-                .structure => |flat_type| {
-                    switch (flat_type) {
-                        .tuple => |tuple| {
-                            const elems = self.types_store.sliceVars(tuple.elems);
-                            try self.occursSubVars(root, elems, Edge.none);
-                        },
-                        .nominal_type => |nominal_type| {
-                            // Arguments are ordinary positions; only the backing
-                            // var is "through" the nominal.
-                            var arg_iter = self.types_store.iterNominalArgs(nominal_type);
-                            while (arg_iter.next()) |arg_var| {
-                                try self.occursSubVar(root, arg_var, Edge.none);
-                            }
-                            const backing_var = self.types_store.getNominalBackingVar(nominal_type);
-                            try self.occursSubVar(root, backing_var, Edge.nominal);
-                        },
-                        .fn_pure => |func| {
-                            const args = self.types_store.sliceVars(func.args);
-                            try self.occursSubVars(root, args, Edge.none);
-                            try self.occursSubVar(root, func.ret, Edge.none);
-                        },
-                        .fn_effectful => |func| {
-                            const args = self.types_store.sliceVars(func.args);
-                            try self.occursSubVars(root, args, Edge.none);
-                            try self.occursSubVar(root, func.ret, Edge.none);
-                        },
-                        .fn_unbound => |func| {
-                            const args = self.types_store.sliceVars(func.args);
-                            try self.occursSubVars(root, args, Edge.none);
-                            try self.occursSubVar(root, func.ret, Edge.none);
-                        },
-                        .record => |record| {
-                            const fields = self.types_store.getRecordFieldsSlice(record.fields);
-                            try self.occursSubVars(root, fields.items(.var_), Edge.recursion);
-                            try self.occursSubVar(root, record.ext, Edge.none);
-                        },
-                        .record_unbound => |fields| {
-                            const fields_slice = self.types_store.getRecordFieldsSlice(fields);
-                            try self.occursSubVars(root, fields_slice.items(.var_), Edge.recursion);
-                        },
-                        .tag_union => |tag_union| {
-                            const tags = self.types_store.getTagsSlice(tag_union.tags);
-                            for (tags.items(.args)) |tag_args| {
-                                const args = self.types_store.sliceVars(tag_args);
-                                try self.occursSubVars(root, args, Edge.recursion);
-                            }
-                            try self.occursSubVar(root, tag_union.ext, Edge.none);
-                        },
-                        .empty_record => {},
-                        .empty_tag_union => {},
+        // Process frames
+        return try self.occursIter();
+    }
+
+    /// Iteratively process frames
+    fn occursIter(self: *Self) std.mem.Allocator.Error!Result {
+        while (self.scratch.stack.items.pop()) |frame| {
+            switch (frame) {
+                .process_var => |start| {
+                    const root = self.types_store.resolveVar(start.var_);
+                    const root_var = root.var_;
+
+                    if (self.scratch.hasVisited(root.desc_idx)) {
+                        // If we've already visited this var and not returned, then it's not recursive
+                        continue;
+                    } else if (self.scratch.hasSeenVar(root_var)) |match_idx| {
+                        // Recursion point!
+
+                        // We've already seen this var during traversal. `edge`
+                        // is the edge that closes the cycle (from the current
+                        // parent back to `root_var`); `match_idx` is where
+                        // `root_var` sits on the seen stack.
+
+                        // Classify using only the edges inside that cycle.
+                        const classified = self.classifyCycle(match_idx, start.edge);
+                        switch (classified) {
+                            .valid => {
+                                // It the recursion was valid (ie passed thru
+                                // nominal) then continue processing
+                                continue;
+                            },
+                            else => {
+                                // If the recursion observed is invalid (infinite or
+                                // anonymous) then return the error immediately.
+
+                                // Report the deepest var on the seen stack (the
+                                // parent of the cycle-closing edge) as the error
+                                // var.
+                                const seen_len: usize = @intCast(self.scratch.seen.len());
+                                std.debug.assert(seen_len > 0);
+                                self.scratch.err_var = self.scratch.seen.items.items[seen_len - 1].var_;
+
+                                return classified;
+                            },
+                        }
+                    } else {
+                        // Push this var to the seen stack
+                        try self.scratch.pushSeen(root_var, start.edge);
+
+                        // Schedule the finish frame to run after processing children
+                        _ = try self.scratch.stack.append(self.scratch.gpa, Frame{ .finish_process_var = .{
+                            .desc_idx = root.desc_idx,
+                        } });
+
+                        // Process this frame & schedule children
+                        switch (root.desc.content) {
+                            .structure => |flat_type| {
+                                switch (flat_type) {
+                                    .tuple => |tuple| {
+                                        const elems = self.types_store.sliceVars(tuple.elems);
+                                        try self.pushVarsToProcess(elems, Edge.none);
+                                    },
+                                    .nominal_type => |nominal_type| {
+                                        const backing_var = self.types_store.getNominalBackingVar(nominal_type);
+                                        try self.pushVarToProcess(backing_var, Edge.nominal);
+
+                                        // Arguments are ordinary positions; only the backing
+                                        // var is "through" the nominal.
+                                        var arg_iter = self.types_store.iterNominalArgs(nominal_type);
+                                        while (arg_iter.next()) |arg_var| {
+                                            try self.pushVarToProcess(arg_var, Edge.none);
+                                        }
+                                    },
+                                    .fn_pure => |func| {
+                                        try self.pushVarToProcess(func.ret, Edge.none);
+                                        const args = self.types_store.sliceVars(func.args);
+                                        try self.pushVarsToProcess(args, Edge.none);
+                                    },
+                                    .fn_effectful => |func| {
+                                        try self.pushVarToProcess(func.ret, Edge.none);
+                                        const args = self.types_store.sliceVars(func.args);
+                                        try self.pushVarsToProcess(args, Edge.none);
+                                    },
+                                    .fn_unbound => |func| {
+                                        try self.pushVarToProcess(func.ret, Edge.none);
+                                        const args = self.types_store.sliceVars(func.args);
+                                        try self.pushVarsToProcess(args, Edge.none);
+                                    },
+                                    .record => |record| {
+                                        try self.pushVarToProcess(record.ext, Edge.none);
+                                        const fields = self.types_store.getRecordFieldsSlice(record.fields);
+                                        try self.pushVarsToProcess(fields.items(.var_), Edge.recursion);
+                                    },
+                                    .record_unbound => |fields| {
+                                        const fields_slice = self.types_store.getRecordFieldsSlice(fields);
+                                        try self.pushVarsToProcess(fields_slice.items(.var_), Edge.recursion);
+                                    },
+                                    .tag_union => |tag_union| {
+                                        try self.pushVarToProcess(tag_union.ext, Edge.none);
+                                        const tags = self.types_store.getTagsSlice(tag_union.tags);
+                                        for (tags.items(.args)) |tag_args| {
+                                            const args = self.types_store.sliceVars(tag_args);
+                                            try self.pushVarsToProcess(args, Edge.recursion);
+                                        }
+                                    },
+                                    .empty_record => {},
+                                    .empty_tag_union => {},
+                                }
+                            },
+                            .alias => |alias| {
+                                const backing_var = self.types_store.getAliasBackingVar(alias);
+                                try self.pushVarToProcess(backing_var, Edge.none);
+
+                                var arg_iter = self.types_store.iterAliasArgs(alias);
+                                while (arg_iter.next()) |arg_var| {
+                                    try self.pushVarToProcess(arg_var, Edge.none);
+                                }
+                            },
+                            .flex => {
+                                // Flex variables are not checked for cycles - they are allowed to have
+                                // self-referential constraints. Only structural content is checked.
+                            },
+                            .rigid => {},
+                            .err => {},
+                        }
                     }
                 },
-                .alias => |alias| {
-                    // Check all argument vars using iterator
-                    var arg_iter = self.types_store.iterAliasArgs(alias);
-                    while (arg_iter.next()) |arg_var| {
-                        try self.occursSubVar(root, arg_var, Edge.none);
-                    }
-                    const backing_var = self.types_store.getAliasBackingVar(alias);
-                    try self.occursSubVar(root, backing_var, Edge.none);
+                .finish_process_var => |end| {
+                    self.scratch.popSeen();
+                    try self.scratch.appendVisited(end.desc_idx);
                 },
-                .flex => {
-                    // Flex variables are not checked for cycles - they are allowed to have
-                    // self-referential constraints. Only structural content is checked.
-                },
-                .rigid => {},
-                .err => {},
             }
-            self.scratch.popSeen();
-
-            self.scratch.appendVisited(root.desc_idx) catch return Error.AllocatorError;
         }
+
+        return .valid;
     }
 
     /// Classify a detected cycle using only the edges that lie *within* it.
@@ -204,7 +233,7 @@ const CheckOccurs = struct {
     /// parent back to the cycle head at `match_idx`. Edges above the cycle (the
     /// head's own incoming edge and anything before it) are intentionally ignored
     /// so an enclosing nominal/container can't reclassify an unrelated cycle.
-    fn classifyCycle(self: *Self, match_idx: usize, closing: Edge) Error!void {
+    fn classifyCycle(self: *Self, match_idx: usize, closing: Edge) Result {
         var recursion_allowed = closing.recursion_allowed;
         var nominal = closing.nominal_backing;
 
@@ -218,34 +247,33 @@ const CheckOccurs = struct {
         if (recursion_allowed and nominal) {
             // The cycle passes through a recursion-allowed position (record, tag
             // union) AND a nominal's backing: valid recursion through a nominal.
-            return error.RecursiveNominal;
+            return .valid;
         } else if (recursion_allowed) {
             // Through a recursion-allowed position but no nominal: anonymous
             // recursion, which Roc rejects.
-            return error.RecursiveAnonymous;
+            return .recursive_anonymous;
         } else {
             // No recursion-allowed position in the cycle: structurally infinite.
-            return error.InfiniteType;
+            return .infinite;
         }
     }
 
-    /// Check if a sub var is recursive
-    /// In the event of an error, append the root var to the chain
-    fn occursSubVar(self: *Self, root: ResolvedVarDesc, sub_var: Var, edge: Edge) Error!void {
-        self.occurs(sub_var, edge) catch |err| {
-            self.scratch.appendErrChain(root.var_) catch return Error.AllocatorError;
-            if (root.desc.content.unwrapNominalType() != null) {
-                self.scratch.appendErrChainNominalVar(root.var_) catch return Error.AllocatorError;
-            }
-            return err;
-        };
+    /// Push a single sub var onto the work stack to be processed later.
+    fn pushVarToProcess(self: *Self, sub_var: Var, edge: Edge) std.mem.Allocator.Error!void {
+        _ = try self.scratch.stack.append(self.scratch.gpa, Frame{ .process_var = .{
+            .var_ = sub_var,
+            .edge = edge,
+        } });
     }
 
-    /// Check if a slice of sub vars are recursive
-    /// In the event of an error, append the root var to the chain
-    fn occursSubVars(self: *Self, root_var: ResolvedVarDesc, sub_vars: []Var, edge: Edge) Error!void {
+    /// Push a slice of sub vars onto the work stack to be processed later.
+    fn pushVarsToProcess(self: *Self, sub_vars: []Var, edge: Edge) std.mem.Allocator.Error!void {
+        try self.scratch.stack.items.ensureUnusedCapacity(self.scratch.gpa, sub_vars.len);
         for (sub_vars) |sub_var| {
-            try self.occursSubVar(root_var, sub_var, edge);
+            _ = self.scratch.stack.appendAssumeCapacity(Frame{ .process_var = .{
+                .var_ = sub_var,
+                .edge = edge,
+            } });
         }
     }
 };
@@ -280,45 +308,57 @@ const SeenEntry = struct {
     edge: Edge,
 };
 
+/// A single iterative frame
+const Frame = union(enum) {
+    process_var: struct {
+        var_: Var,
+        edge: Edge,
+    },
+    finish_process_var: struct {
+        desc_idx: DescStoreIdx,
+    },
+};
+
 /// Struct to hold intermediate values used during occurs check
 pub const Scratch = struct {
     const Self = @This();
 
     gpa: std.mem.Allocator,
 
+    stack: MkSafeList(Frame),
     seen: MkSafeList(SeenEntry),
-    err_chain: Var.SafeList,
-    err_chain_nominal_vars: Var.SafeList,
     visited: MkSafeList(DescStoreIdx),
+
+    /// The var to report when a cycle is detected: the deepest var on the seen
+    /// stack (the parent of the cycle-closing edge). Null until a cycle is found.
+    err_var: ?Var = null,
 
     pub fn init(gpa: std.mem.Allocator) std.mem.Allocator.Error!Self {
         // Initial capacities are conservative estimates. Lists grow dynamically as needed.
         // Rust compiler uses 1024, but that's likely overkill for typical Roc code.
         // These values handle common cases:
-        // - seen/err_chain: 32 - typical type depth is much shallower
+        // - seen: 32 - typical type depth is much shallower
         // - visited: 64 - covers most type traversals without reallocation
         // Future optimization: profile real codebases to tune these values.
         return .{
             .gpa = gpa,
+            .stack = try MkSafeList(Frame).initCapacity(gpa, 32),
             .seen = try MkSafeList(SeenEntry).initCapacity(gpa, 32),
-            .err_chain = try Var.SafeList.initCapacity(gpa, 32),
-            .err_chain_nominal_vars = try Var.SafeList.initCapacity(gpa, 8),
             .visited = try MkSafeList(DescStoreIdx).initCapacity(gpa, 64),
         };
     }
 
     pub fn deinit(self: *Self) void {
+        self.stack.deinit(self.gpa);
         self.seen.deinit(self.gpa);
-        self.err_chain.deinit(self.gpa);
-        self.err_chain_nominal_vars.deinit(self.gpa);
         self.visited.deinit(self.gpa);
     }
 
     pub fn reset(self: *Self) void {
+        self.stack.items.clearRetainingCapacity();
         self.seen.items.clearRetainingCapacity();
-        self.err_chain.items.clearRetainingCapacity();
-        self.err_chain_nominal_vars.items.clearRetainingCapacity();
         self.visited.items.clearRetainingCapacity();
+        self.err_var = null;
     }
 
     /// Returns the index of `var_` on the seen stack if it's currently being
@@ -348,22 +388,6 @@ pub const Scratch = struct {
     fn appendVisited(self: *Self, desc_idx: DescStoreIdx) std.mem.Allocator.Error!void {
         _ = try self.visited.append(self.gpa, desc_idx);
     }
-
-    fn appendErrChain(self: *Self, var_: Var) std.mem.Allocator.Error!void {
-        _ = try self.err_chain.append(self.gpa, var_);
-    }
-
-    fn appendErrChainNominalVar(self: *Self, var_: Var) std.mem.Allocator.Error!void {
-        _ = try self.err_chain_nominal_vars.append(self.gpa, var_);
-    }
-
-    fn errChainSlice(self: *const Scratch) []const Var {
-        return self.err_chain.items.items;
-    }
-
-    fn errChainNominalVarsSlice(self: *const Scratch) []const Var {
-        return self.err_chain_nominal_vars.items.items;
-    }
 };
 
 test "occurs: no recurcion (v = Str)" {
@@ -378,7 +402,7 @@ test "occurs: no recurcion (v = Str)" {
     const str_var = try types_store.freshFromContent(Content{ .structure = .empty_record });
 
     const result = occurs(&types_store, &scratch, str_var);
-    try std.testing.expectEqual(.not_recursive, result);
+    try std.testing.expectEqual(.valid, result);
 }
 
 test "occurs: no recursion through two levels (v1 = Box(v2), v2 = Str)" {
@@ -404,7 +428,7 @@ test "occurs: no recursion through two levels (v1 = Box(v2), v2 = Str)" {
     try types_store.setRootVarContent(v2, Content{ .structure = .empty_record });
 
     const result = occurs(&types_store, &scratch, v1);
-    try std.testing.expectEqual(.not_recursive, result);
+    try std.testing.expectEqual(.valid, result);
 }
 
 test "occurs: tuple recursion (v = Tuple(v, Str))" {
@@ -426,9 +450,7 @@ test "occurs: tuple recursion (v = Tuple(v, Str))" {
     const result = occurs(&types_store, &scratch, v);
     try std.testing.expectEqual(.infinite, result);
 
-    const err_chain = scratch.errChainSlice();
-    try std.testing.expectEqual(1, err_chain.len);
-    try std.testing.expectEqual(v, err_chain[0]);
+    try std.testing.expectEqual(v, scratch.err_var.?);
 }
 
 test "occurs: tuple not recursive (v = Tuple(Str, Str))" {
@@ -447,7 +469,7 @@ test "occurs: tuple not recursive (v = Tuple(Str, Str))" {
     const v = try types_store.freshFromContent(Content{ .structure = .{ .tuple = tuple } });
 
     const result = occurs(&types_store, &scratch, v);
-    try std.testing.expectEqual(.not_recursive, result);
+    try std.testing.expectEqual(.valid, result);
 
     try std.testing.expectEqual(2, scratch.visited.len());
 }
@@ -474,9 +496,7 @@ test "occurs: recursive alias (v = Alias(List v))" {
     const result = occurs(&types_store, &scratch, v);
     try std.testing.expectEqual(.infinite, result);
 
-    const err_chain = scratch.errChainSlice();
-    try std.testing.expectEqual(1, err_chain.len);
-    try std.testing.expectEqual(v, err_chain[0]);
+    try std.testing.expectEqual(v, scratch.err_var.?);
 }
 
 test "occurs: alias with no recursion (v = Alias Str)" {
@@ -499,7 +519,7 @@ test "occurs: alias with no recursion (v = Alias Str)" {
     ));
 
     const result = occurs(&types_store, &scratch, alias_var);
-    try std.testing.expectEqual(.not_recursive, result);
+    try std.testing.expectEqual(.valid, result);
 }
 
 test "occurs: recursive tag union (v = [ Cons(elem, v), Nil ]" {
@@ -528,9 +548,7 @@ test "occurs: recursive tag union (v = [ Cons(elem, v), Nil ]" {
     const result = occurs(&types_store, &scratch, linked_list);
     try std.testing.expectEqual(.recursive_anonymous, result);
 
-    const err_chain = scratch.errChainSlice();
-    try std.testing.expectEqual(1, err_chain.len);
-    try std.testing.expectEqual(linked_list, err_chain[0]);
+    try std.testing.expectEqual(linked_list, scratch.err_var.?);
 }
 test "occurs: nested recursive tag union (v = [ Cons(elem, Box(v)) ] )" {
     const gpa = std.testing.allocator;
@@ -569,10 +587,7 @@ test "occurs: nested recursive tag union (v = [ Cons(elem, Box(v)) ] )" {
     const result = occurs(&types_store, &scratch, linked_list);
     try std.testing.expectEqual(.recursive_anonymous, result);
 
-    const err_chain = scratch.errChainSlice();
-    try std.testing.expect(err_chain.len == 2);
-    try std.testing.expectEqual(err_chain[0], boxed_linked_list);
-    try std.testing.expectEqual(err_chain[1], linked_list);
+    try std.testing.expectEqual(boxed_linked_list, scratch.err_var.?);
 }
 
 test "occurs: recursive tag union (v = List: [ Cons(Elem, List), Nil ])" {
@@ -603,30 +618,12 @@ test "occurs: recursive tag union (v = List: [ Cons(Elem, List), Nil ])" {
     // assert that starting from the nominal type, it works
 
     const result1 = occurs(&types_store, &scratch, nominal_type);
-    try std.testing.expectEqual(.recursive_nominal, result1);
-
-    const err_chain1 = scratch.errChainSlice();
-    try std.testing.expectEqual(2, err_chain1.len);
-    try std.testing.expectEqual(backing_var, err_chain1[0]);
-    try std.testing.expectEqual(nominal_type, err_chain1[1]);
-
-    const err_chain_nominal1 = scratch.errChainNominalVarsSlice();
-    try std.testing.expectEqual(1, err_chain_nominal1.len);
-    try std.testing.expectEqual(nominal_type, err_chain_nominal1[0]);
+    try std.testing.expectEqual(.valid, result1);
 
     // assert that starting from the the tag union, it works
 
     const result2 = occurs(&types_store, &scratch, backing_var);
-    try std.testing.expectEqual(.recursive_nominal, result2);
-
-    const err_chain2 = scratch.errChainSlice();
-    try std.testing.expectEqual(2, err_chain2.len);
-    try std.testing.expectEqual(nominal_type, err_chain2[0]);
-    try std.testing.expectEqual(backing_var, err_chain2[1]);
-
-    const err_chain_nominal2 = scratch.errChainNominalVarsSlice();
-    try std.testing.expectEqual(1, err_chain_nominal2.len);
-    try std.testing.expectEqual(nominal_type, err_chain_nominal2[0]);
+    try std.testing.expectEqual(.valid, result2);
 }
 
 test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB := [ Cons(Elem, TypeA), Nil ])" {
@@ -669,53 +666,102 @@ test "occurs: recursive tag union with multiple nominals (TypeA := TypeB, TypeB 
 
     // assert that starting from the `TypeA` nominal, it works
     const result1 = occurs(&types_store, &scratch, type_a_nominal);
-    try std.testing.expectEqual(.recursive_nominal, result1);
-
-    const err_chain1 = scratch.errChainSlice();
-    try std.testing.expectEqual(3, err_chain1.len);
-    try std.testing.expectEqual(type_b_backing, err_chain1[0]);
-    try std.testing.expectEqual(type_b_nominal, err_chain1[1]);
-    try std.testing.expectEqual(type_a_nominal, err_chain1[2]);
-
-    const err_chain_nominal1 = scratch.errChainNominalVarsSlice();
-    try std.testing.expectEqual(2, err_chain_nominal1.len);
-    try std.testing.expectEqual(type_b_nominal, err_chain_nominal1[0]);
-    try std.testing.expectEqual(type_a_nominal, err_chain_nominal1[1]);
+    try std.testing.expectEqual(.valid, result1);
 
     // assert that starting from the `TypeB` nominal, it works
 
     const result2 = occurs(&types_store, &scratch, type_b_nominal);
-    try std.testing.expectEqual(.recursive_nominal, result2);
-
-    const err_chain2 = scratch.errChainSlice();
-    try std.testing.expectEqual(3, err_chain2.len);
-    try std.testing.expectEqual(type_a_nominal, err_chain2[0]);
-    try std.testing.expectEqual(type_b_backing, err_chain2[1]);
-    try std.testing.expectEqual(type_b_nominal, err_chain2[2]);
-
-    const err_chain_nominal2 = scratch.errChainNominalVarsSlice();
-    try std.testing.expectEqual(2, err_chain_nominal2.len);
-    try std.testing.expectEqual(type_a_nominal, err_chain_nominal2[0]);
-    try std.testing.expectEqual(type_b_nominal, err_chain_nominal2[1]);
+    try std.testing.expectEqual(.valid, result2);
 
     // assert that starting from the the tag union, it works
 
     const result3 = occurs(&types_store, &scratch, type_b_backing);
-    try std.testing.expectEqual(.recursive_nominal, result3);
-
-    const err_chain3 = scratch.errChainSlice();
-    try std.testing.expectEqual(3, err_chain3.len);
-    try std.testing.expectEqual(type_b_nominal, err_chain3[0]);
-    try std.testing.expectEqual(type_a_nominal, err_chain3[1]);
-    try std.testing.expectEqual(type_b_backing, err_chain3[2]);
-
-    const err_chain_nominal3 = scratch.errChainNominalVarsSlice();
-    try std.testing.expectEqual(2, err_chain_nominal3.len);
-    try std.testing.expectEqual(type_b_nominal, err_chain_nominal3[0]);
-    try std.testing.expectEqual(type_a_nominal, err_chain_nominal3[1]);
+    try std.testing.expectEqual(.valid, result3);
 }
 
-test "occurs: anonymous recursion in a nominal's type argument is not recursive_nominal (regression)" {
+test "occurs: valid nominal recursion does not hide later invalid recursion" {
+    const gpa = std.testing.allocator;
+    var types_store = try Store.init(gpa);
+    defer types_store.deinit();
+
+    var scratch = try Scratch.init(gpa);
+    defer scratch.deinit();
+
+    // Invalid branch: Inner = (Inner,), which is structurally infinite.
+    const invalid_inner = try types_store.fresh();
+    const invalid_tuple_elems = try types_store.appendVars(&[_]Var{invalid_inner});
+    try types_store.setRootVarContent(invalid_inner, .{ .structure = .{ .tuple = .{ .elems = invalid_tuple_elems } } });
+
+    // Valid branch: List := [ Cons(List), Nil ].
+    const list_nominal = try types_store.fresh();
+    const ext = try types_store.fresh();
+    const cons_tag_args = try types_store.appendVars(&[_]Var{list_nominal});
+    const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty() };
+    const list_backing = try types_store.freshFromContent(try types_store.mkTagUnion(&.{ cons_tag, nil_tag }, ext));
+    try types_store.setVarContent(list_nominal, try types_store.mkNominal(
+        undefined,
+        list_backing,
+        &.{},
+        Ident.Idx{ .attributes = .{ .effectful = false, .ignored = false, .reassignable = false }, .idx = 0 },
+        false,
+    ));
+
+    // The tuple elements are pushed in order and popped LIFO, so the valid branch
+    // is observed first. The traversal must keep going and still report the
+    // invalid branch.
+    const root_elems = try types_store.appendVars(&[_]Var{ invalid_inner, list_nominal });
+    const root = try types_store.freshFromContent(.{ .structure = .{ .tuple = .{ .elems = root_elems } } });
+
+    const result = occurs(&types_store, &scratch, root);
+    try std.testing.expectEqual(.infinite, result);
+    try std.testing.expectEqual(invalid_inner, scratch.err_var.?);
+}
+
+test "occurs: valid nominal return recursion does not hide invalid argument recursion" {
+    const gpa = std.testing.allocator;
+    var types_store = try Store.init(gpa);
+    defer types_store.deinit();
+
+    var scratch = try Scratch.init(gpa);
+    defer scratch.deinit();
+
+    // Invalid argument branch: Arg = (Arg,), which is structurally infinite.
+    const invalid_arg = try types_store.fresh();
+    const invalid_arg_tuple_elems = try types_store.appendVars(&[_]Var{invalid_arg});
+    try types_store.setRootVarContent(invalid_arg, .{ .structure = .{ .tuple = .{ .elems = invalid_arg_tuple_elems } } });
+
+    // Valid return branch: List := [ Cons(List), Nil ].
+    const list_nominal = try types_store.fresh();
+    const ext = try types_store.fresh();
+    const cons_tag_args = try types_store.appendVars(&[_]Var{list_nominal});
+    const cons_tag = types.Tag{ .name = undefined, .args = cons_tag_args };
+    const nil_tag = types.Tag{ .name = undefined, .args = Var.SafeList.Range.empty() };
+    const list_backing = try types_store.freshFromContent(try types_store.mkTagUnion(&.{ cons_tag, nil_tag }, ext));
+    try types_store.setVarContent(list_nominal, try types_store.mkNominal(
+        undefined,
+        list_backing,
+        &.{},
+        Ident.Idx{ .attributes = .{ .effectful = false, .ignored = false, .reassignable = false }, .idx = 0 },
+        false,
+    ));
+
+    // This pins the same behavior for function traversal. Even if scheduling is
+    // changed so the return is observed before the args, valid recursion in the
+    // return must not hide an invalid argument cycle.
+    const args = try types_store.appendVars(&.{invalid_arg});
+    const root = try types_store.freshFromContent(.{ .structure = .{ .fn_pure = types.Func{
+        .args = args,
+        .ret = list_nominal,
+        .needs_instantiation = false,
+    } } });
+
+    const result = occurs(&types_store, &scratch, root);
+    try std.testing.expectEqual(.infinite, result);
+    try std.testing.expectEqual(invalid_arg, scratch.err_var.?);
+}
+
+test "occurs: anonymous recursion in a nominal's type argument is not valid (regression)" {
     // Wrapper(Inner) := {}   where   Inner = [ Cons(Inner), Nil ]
     //
     // The recursion cycle is `Inner -> Cons -> Inner`. It lives entirely inside
@@ -752,14 +798,14 @@ test "occurs: anonymous recursion in a nominal's type argument is not recursive_
     try std.testing.expectEqual(.recursive_anonymous, result);
 }
 
-test "occurs: anonymous recursion below a buried nominal is not recursive_nominal (regression)" {
+test "occurs: anonymous recursion below a buried nominal is not valid (regression)" {
     // Root = ( N, )   where   N := Inner   and   Inner = [ Cons(Inner), Nil ]
     //
     // `Root` is a tuple, so no nominal edge is crossed at the root. The only
     // nominal is `N`, buried one level down. The cycle is `Inner -> Cons ->
     // Inner`, which does NOT pass through `N`. A buggy occurs check that lets the
     // nominal marking from N's backing leak downward would wrongly classify this
-    // as recursive_nominal. Correct answer: recursive_anonymous.
+    // as valid. Correct answer: recursive_anonymous.
     const gpa = std.testing.allocator;
     var types_store = try Store.init(gpa);
     defer types_store.deinit();

--- a/src/check/test/unify_test.zig
+++ b/src/check/test/unify_test.zig
@@ -424,7 +424,7 @@ test "unify - alias with concrete" {
     try std.testing.expect(resolved_alias.var_ != resolved_backing.var_);
 
     const occurs_result = try occurs.occurs(&env.module_env.types, &env.occurs_scratch, a);
-    try std.testing.expectEqual(.not_recursive, occurs_result);
+    try std.testing.expectEqual(.valid, occurs_result);
 }
 
 test "unify - alias with concrete other way" {
@@ -456,7 +456,7 @@ test "unify - alias with concrete other way" {
     try std.testing.expect(resolved_alias.var_ != resolved_backing.var_);
 
     const occurs_result = try occurs.occurs(&env.module_env.types, &env.occurs_scratch, b);
-    try std.testing.expectEqual(.not_recursive, occurs_result);
+    try std.testing.expectEqual(.valid, occurs_result);
 }
 
 test "unify - alias with own backing structure" {
@@ -483,7 +483,7 @@ test "unify - alias with own backing structure" {
     try std.testing.expect(resolved_alias.var_ != resolved_backing.var_);
 
     const occurs_result = try occurs.occurs(&env.module_env.types, &env.occurs_scratch, alias_var);
-    try std.testing.expectEqual(.not_recursive, occurs_result);
+    try std.testing.expectEqual(.valid, occurs_result);
 }
 
 test "unify - own backing structure with alias" {
@@ -510,7 +510,7 @@ test "unify - own backing structure with alias" {
     try std.testing.expect(resolved_alias.var_ != resolved_backing.var_);
 
     const occurs_result = try occurs.occurs(&env.module_env.types, &env.occurs_scratch, alias_var);
-    try std.testing.expectEqual(.not_recursive, occurs_result);
+    try std.testing.expectEqual(.valid, occurs_result);
 }
 
 test "unify - alias (flex backing) with rigid" {


### PR DESCRIPTION
This PR is my warm-up to making all parts of the type checker non-recursive. I implemented this by hand to get a sense of how this style works, so I can better review and validate agentic migrations of unify and the main check loop next.

Additionally, this PR fixes a bug in a cycle check where it would bail on the first valid recursion found, even if a different part of the tree contained invalid recursion. 