### PR TITLE
Surface ARC certifier capacity skips

### DIFF
--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -98,7 +98,7 @@ jobs:
         run: zig build run-check-cli-global-stdio
 
       - name: zig snapshot tests
-        run: zig build run-check-snapshots -- --debug
+        run: zig build run-check-snapshots -Dforbid-arc-certifier-skips -- --debug
 
       - name: Run Playground Tests
         run: zig build run-test-playground -Doptimize=ReleaseSmall -- --verbose
@@ -226,7 +226,7 @@ jobs:
         if: runner.os != 'Windows'
         uses: ./.github/actions/flaky-retry
         with:
-          command: zig build run-test-eval -- --llvm
+          command: zig build run-test-eval -Dforbid-arc-certifier-skips -- --llvm
           error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
           retry_count: 3
 
@@ -242,24 +242,24 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/flaky-retry
         with:
-          command: zig build run-test-eval -- --llvm --timeout 120000
+          command: zig build run-test-eval -Dforbid-arc-certifier-skips -- --llvm --timeout 120000
           error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
           retry_count: 3
 
       - name: Run CLI platform tests (LLVM size/speed backends)
         if: runner.os != 'Windows'
-        run: zig build run-test-cli -- --include-llvm --filter "[size]" --filter "[speed]"
+        run: zig build run-test-cli -Dforbid-arc-certifier-skips -- --include-llvm --filter "[size]" --filter "[speed]"
 
       - name: Run CLI platform tests (LLVM size/speed backends, Windows)
         if: runner.os == 'Windows'
         run: |
-          zig build run-test-cli -- --include-llvm --filter "[size]" --filter "[speed]"
+          zig build run-test-cli -Dforbid-arc-certifier-skips -- --include-llvm --filter "[size]" --filter "[speed]"
 
       - name: Shared-library build-and-run test (roc build --opt=size)
-        run: zig build run-test-dylib
+        run: zig build run-test-dylib -Dforbid-arc-certifier-skips
 
       - name: Static-archive build-and-run test
-        run: zig build run-test-archive
+        run: zig build run-test-archive -Dforbid-arc-certifier-skips
 
   zig-tests:
     needs: check-once
@@ -329,7 +329,7 @@ jobs:
 
       - name: Run Test Platforms (Unix)
         if: runner.os != 'Windows'
-        run: zig build run-test-cli ${{ matrix.target_flag }}
+        run: zig build run-test-cli -Dforbid-arc-certifier-skips ${{ matrix.target_flag }}
 
       - name: Setup MSVC (Windows)
         if: runner.os == 'Windows'
@@ -340,7 +340,7 @@ jobs:
       - name: Run Test Platforms (Windows)
         if: runner.os == 'Windows'
         run: |
-          zig build run-test-cli
+          zig build run-test-cli -Dforbid-arc-certifier-skips
 
       - name: roc executable minimal check (Unix)
         if: runner.os != 'Windows'
@@ -353,11 +353,11 @@ jobs:
           zig-out\bin\roc.exe check ./CONTRIBUTING/profiling/bench_repeated_check.roc
 
       - name: zig snapshot tests
-        run: zig build run-check-snapshots ${{ matrix.target_flag }} -- --debug
+        run: zig build run-check-snapshots -Dforbid-arc-certifier-skips ${{ matrix.target_flag }} -- --debug
 
       # 1) in debug mode
       - name: build and execute tests, build repro executables
-        run: zig build run-test-zig -Dfuzz -Dsystem-afl=false ${{ matrix.target_flag }}
+        run: zig build run-test-zig -Dforbid-arc-certifier-skips -Dfuzz -Dsystem-afl=false ${{ matrix.target_flag }}
 
       # 2) in release mode
       - name: Build and execute tests, build repro executables. All in release mode.

--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -98,7 +98,7 @@ jobs:
         run: zig build run-check-cli-global-stdio
 
       - name: zig snapshot tests
-        run: zig build run-check-snapshots -Dforbid-arc-certifier-skips -- --debug
+        run: zig build run-check-snapshots -- --debug
 
       - name: Run Playground Tests
         run: zig build run-test-playground -Doptimize=ReleaseSmall -- --verbose
@@ -226,7 +226,7 @@ jobs:
         if: runner.os != 'Windows'
         uses: ./.github/actions/flaky-retry
         with:
-          command: zig build run-test-eval -Dforbid-arc-certifier-skips -- --llvm
+          command: zig build run-test-eval -- --llvm
           error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
           retry_count: 3
 
@@ -242,24 +242,24 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/flaky-retry
         with:
-          command: zig build run-test-eval -Dforbid-arc-certifier-skips -- --llvm --timeout 120000
+          command: zig build run-test-eval -- --llvm --timeout 120000
           error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
           retry_count: 3
 
       - name: Run CLI platform tests (LLVM size/speed backends)
         if: runner.os != 'Windows'
-        run: zig build run-test-cli -Dforbid-arc-certifier-skips -- --include-llvm --filter "[size]" --filter "[speed]"
+        run: zig build run-test-cli -- --include-llvm --filter "[size]" --filter "[speed]"
 
       - name: Run CLI platform tests (LLVM size/speed backends, Windows)
         if: runner.os == 'Windows'
         run: |
-          zig build run-test-cli -Dforbid-arc-certifier-skips -- --include-llvm --filter "[size]" --filter "[speed]"
+          zig build run-test-cli -- --include-llvm --filter "[size]" --filter "[speed]"
 
       - name: Shared-library build-and-run test (roc build --opt=size)
-        run: zig build run-test-dylib -Dforbid-arc-certifier-skips
+        run: zig build run-test-dylib
 
       - name: Static-archive build-and-run test
-        run: zig build run-test-archive -Dforbid-arc-certifier-skips
+        run: zig build run-test-archive
 
   zig-tests:
     needs: check-once
@@ -329,7 +329,7 @@ jobs:
 
       - name: Run Test Platforms (Unix)
         if: runner.os != 'Windows'
-        run: zig build run-test-cli -Dforbid-arc-certifier-skips ${{ matrix.target_flag }}
+        run: zig build run-test-cli ${{ matrix.target_flag }}
 
       - name: Setup MSVC (Windows)
         if: runner.os == 'Windows'
@@ -340,7 +340,7 @@ jobs:
       - name: Run Test Platforms (Windows)
         if: runner.os == 'Windows'
         run: |
-          zig build run-test-cli -Dforbid-arc-certifier-skips
+          zig build run-test-cli
 
       - name: roc executable minimal check (Unix)
         if: runner.os != 'Windows'
@@ -353,11 +353,11 @@ jobs:
           zig-out\bin\roc.exe check ./CONTRIBUTING/profiling/bench_repeated_check.roc
 
       - name: zig snapshot tests
-        run: zig build run-check-snapshots -Dforbid-arc-certifier-skips ${{ matrix.target_flag }} -- --debug
+        run: zig build run-check-snapshots ${{ matrix.target_flag }} -- --debug
 
       # 1) in debug mode
       - name: build and execute tests, build repro executables
-        run: zig build run-test-zig -Dforbid-arc-certifier-skips -Dfuzz -Dsystem-afl=false ${{ matrix.target_flag }}
+        run: zig build run-test-zig -Dfuzz -Dsystem-afl=false ${{ matrix.target_flag }}
 
       # 2) in release mode
       - name: Build and execute tests, build repro executables. All in release mode.

--- a/build.zig
+++ b/build.zig
@@ -2317,7 +2317,8 @@ pub fn build(b: *std.Build) void {
     const cli_test_llvm = b.option(bool, "cli-test-llvm", "Include LLVM size/speed backend jobs in CLI platform tests") orelse false;
     const trace_build = b.option(bool, "trace-build", "Enable detailed build pipeline tracing") orelse false;
     const debug_gpa = b.option(bool, "debug-gpa", "Use the leak-checking DebugAllocator for the roc binary even when libc is linked (default: off, so libc's malloc and its ASan/Valgrind/LD_PRELOAD tooling are used)") orelse false;
-    const forbid_arc_certifier_skips = b.option(bool, "forbid-arc-certifier-skips", "Panic in debug builds if the ARC certifier skips any procedure") orelse false;
+    const ci_env_set = if (b.graph.environ_map.get("CI")) |ci| ci.len != 0 else false;
+    const forbid_arc_certifier_skips = b.option(bool, "forbid-arc-certifier-skips", "Panic in debug builds if the ARC certifier skips any procedure (defaults to on when the CI environment variable is set)") orelse ci_env_set;
     const shared_memory_size = b.option(u64, "shared-memory-size", "Explicitly set shared-memory arena sizes in bytes");
     const print_trmc = b.option(bool, "print-trmc", "Print one line for each transformed TRMC/TCE proc") orelse false;
     const print_ir_after_trmc = b.option(bool, "print-ir-after-trmc", "Print full LIR for each proc transformed by TRMC/TCE") orelse false;

--- a/build.zig
+++ b/build.zig
@@ -2317,6 +2317,7 @@ pub fn build(b: *std.Build) void {
     const cli_test_llvm = b.option(bool, "cli-test-llvm", "Include LLVM size/speed backend jobs in CLI platform tests") orelse false;
     const trace_build = b.option(bool, "trace-build", "Enable detailed build pipeline tracing") orelse false;
     const debug_gpa = b.option(bool, "debug-gpa", "Use the leak-checking DebugAllocator for the roc binary even when libc is linked (default: off, so libc's malloc and its ASan/Valgrind/LD_PRELOAD tooling are used)") orelse false;
+    const forbid_arc_certifier_skips = b.option(bool, "forbid-arc-certifier-skips", "Panic in debug builds if the ARC certifier skips any procedure") orelse false;
     const shared_memory_size = b.option(u64, "shared-memory-size", "Explicitly set shared-memory arena sizes in bytes");
     const print_trmc = b.option(bool, "print-trmc", "Print one line for each transformed TRMC/TCE proc") orelse false;
     const print_ir_after_trmc = b.option(bool, "print-ir-after-trmc", "Print full LIR for each proc transformed by TRMC/TCE") orelse false;
@@ -2369,6 +2370,7 @@ pub fn build(b: *std.Build) void {
     build_options.addOption(bool, "trace_modules", trace_modules);
     build_options.addOption(bool, "trace_build", trace_build);
     build_options.addOption(bool, "debug_gpa", debug_gpa);
+    build_options.addOption(bool, "forbid_arc_certifier_skips", forbid_arc_certifier_skips);
     build_options.addOption(bool, "has_shared_memory_size", shared_memory_size != null);
     build_options.addOption(u64, "shared_memory_size", shared_memory_size orelse 0);
     build_options.addOption(bool, "print_trmc", print_trmc);

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,129 @@
+# Compiler Improvement Projects
+
+This folder contains self-contained project specifications for structural
+improvements to the compiler. Each `.md` file is written so that someone brand
+new to the codebase (human or agent) can read that one file and understand the
+problem, the solution approach, what success looks like, how to evaluate the
+result for long-term correctness and performance, and what tests to add.
+
+- `small/` — projects on the order of days each: localized, mostly additive
+  checks or deletions, low design risk.
+- `big/` — projects on the order of weeks each: cross-cutting, and several
+  require a design decision before implementation starts.
+
+The projects came out of a root-cause analysis of eight weeks of bug fixes
+(May–June 2026). The recurring disease across independent bug clusters was:
+facts proven during checking get re-derived downstream from type, name, or
+structure content instead of traveling as explicit data, keyed by fragile
+identity (name strings, positional order, mutable keys) and enforced only by
+panics at the consumption site. Most of these projects either move a fact into
+an explicit artifact, assign an identity once and carry it, or delete a
+duplicated computation. `design.md` at the repo root is the authoritative
+post-check design; these projects implement its stated principles more
+completely.
+
+## Recommended order
+
+### Start here
+
+1. [small/check-app-against-platform-requires.md](small/check-app-against-platform-requires.md)
+   — highest leverage per unit of work in the whole set. Deletes the
+   coordinator's shadow-validation layer, kills the most active bug cascade,
+   and is a prerequisite for two big projects (total dispatch plans, exact
+   numeral pipeline).
+
+### Dependency chains
+
+**Chain A — dispatch:**
+1. `small/check-app-against-platform-requires.md` (prerequisite: dispatch
+   plans cannot be total while platform-typed values are still flex at check
+   time)
+2. [big/total-dispatch-plans.md](big/total-dispatch-plans.md)
+3. [big/generalization-time-ambiguity.md](big/generalization-time-ambiguity.md)
+   — shares the constraint-provenance foundation with total dispatch plans;
+   doable before it, but cheaper after.
+
+**Chain B — identity:**
+1. [small/single-package-identity-function.md](small/single-package-identity-function.md)
+   — the interim fix; small and immediately useful.
+2. [big/content-based-nominal-identity.md](big/content-based-nominal-identity.md)
+   — the durable fix; absorbs and supersedes the interim one.
+3. [big/immutable-specialization-identity.md](big/immutable-specialization-identity.md)
+   — can proceed independently using today's module digests, but its
+   `CallableIdentity` components get cleaner after content-based identity.
+
+Chain B also strengthens Chain A (stable cross-module references for resolved
+dispatch targets) and the glue project, but does not block them.
+
+**Chain C — captures:**
+- [big/canonical-capture-id.md](big/canonical-capture-id.md) is independent,
+  but do it before or together with the evidence-threading part of
+  `big/total-dispatch-plans.md`: where-clause evidence flows through nested
+  closures exactly like a compile-time capture, and it should ride the same
+  identity discipline rather than invent a parallel one.
+
+**Chain D — ARC:**
+1. [small/surface-arc-certifier-skips.md](small/surface-arc-certifier-skips.md)
+   — trivial; do immediately so the current certification hole is visible.
+2. [big/arc-certifier-lattice-join.md](big/arc-certifier-lattice-join.md)
+   — closes the hole for real and centralizes ownership-transfer keying.
+
+**Chain E — numerics:**
+1. `small/check-app-against-platform-requires.md` (removes one of the two
+   places literal range facts get dropped)
+2. [big/exact-numeral-pipeline.md](big/exact-numeral-pipeline.md)
+- [small/checked-arithmetic-lir-ops.md](small/checked-arithmetic-lir-ops.md)
+  is independent of both and can land any time.
+
+### Independent — start any time, in any order
+
+Small:
+- [small/cross-phase-coverage-parity-tests.md](small/cross-phase-coverage-parity-tests.md)
+  — cheap insurance; ideally land early so later projects inherit the harness.
+- [small/centralize-slice-reuse-predicate.md](small/centralize-slice-reuse-predicate.md)
+- [small/store-generation-counters.md](small/store-generation-counters.md)
+- [small/shared-checked-type-traversal.md](small/shared-checked-type-traversal.md)
+- [small/cache-hardening.md](small/cache-hardening.md)
+- [small/glue-consumes-committed-layouts.md](small/glue-consumes-committed-layouts.md)
+  — benefits mildly from content-based identity but does not depend on it.
+- [small/structural-hoist-contexts.md](small/structural-hoist-contexts.md)
+
+Big:
+- [big/decision-tree-match-compiler.md](big/decision-tree-match-compiler.md)
+  — independent; benefits from landing the coverage-parity test harness first,
+  and pairs naturally with pipeline unification (below) since today every
+  match-lowering change must be made twice.
+- [big/unify-build-pipelines.md](big/unify-build-pipelines.md) — independent;
+  benefits from `small/single-package-identity-function.md` landing first so
+  the shared layer starts with one naming scheme.
+- [big/row-subsumption.md](big/row-subsumption.md) — independent of all other
+  projects, but requires a language-semantics decision before implementation
+  starts (see the file).
+
+### Suggested overall sequence
+
+If one person or agent works through everything serially, this order front-loads
+leverage and keeps prerequisites satisfied:
+
+1. `small/surface-arc-certifier-skips.md`
+2. `small/cross-phase-coverage-parity-tests.md`
+3. `small/check-app-against-platform-requires.md`
+4. `small/single-package-identity-function.md`
+5. `small/centralize-slice-reuse-predicate.md`
+6. `small/store-generation-counters.md`
+7. `small/checked-arithmetic-lir-ops.md`
+8. `big/total-dispatch-plans.md`
+9. `big/canonical-capture-id.md` (or interleave with 8; see Chain C)
+10. `big/content-based-nominal-identity.md`
+11. `big/immutable-specialization-identity.md`
+12. `small/shared-checked-type-traversal.md`
+13. `small/cache-hardening.md`
+14. `big/arc-certifier-lattice-join.md`
+15. `big/exact-numeral-pipeline.md`
+16. `big/generalization-time-ambiguity.md`
+17. `big/unify-build-pipelines.md`
+18. `big/decision-tree-match-compiler.md`
+19. `small/glue-consumes-committed-layouts.md`
+20. `small/structural-hoist-contexts.md`
+21. `big/row-subsumption.md` (whenever the language decision is made; nothing
+    blocks on it)

--- a/projects/big/arc-certifier-lattice-join.md
+++ b/projects/big/arc-certifier-lattice-join.md
@@ -1,0 +1,300 @@
+# ARC Certifier Lattice Join and Centralized Ownership-Transfer Keying
+
+## Problem
+
+Two related weaknesses in the ARC (automatic reference counting) stage
+together mean the compiler's only safety net over hand-maintained refcount
+bookkeeping has a hole exactly where the bookkeeping is most likely wrong.
+
+First: the debug borrow certifier (`src/lir/arc_certify.zig`) verifies
+each join point once per **distinct entry-state summary**, with no
+widening or join operator. For a loop carrying K refcounted mutable locals
+whose body merges and re-splits their alias groups, the number of distinct
+(alias-partition × balance) summaries grows like the Bell number of K
+(B(6) = 203). Issue roc-lang/roc#9658 was a **valid** program
+(~6 refcounted mutable locals in nested loops) that exceeded the then-cap
+of 64 distinct states; the certifier reported that the entry states of a
+join diverge across jumps and aborted the build. PR roc-lang/roc#9746
+raised the cap to 4096 and converted exceedance into
+`error.CertifierCapacityExceeded`, which `certifyStore` catches per
+procedure: the procedure is left **unverified** and the build continues.
+The in-code comment above the cap check is candid that a real
+per-iteration leak in such a procedure would be *skipped rather than
+reported*, and names the sound fix — a converging dataflow fixpoint over a
+finite-height lattice — as future work. `Diagnostic.skipped_proc_count`
+counts skips but is surfaced nowhere (see
+[Surface ARC Certifier Skips](../small/surface-arc-certifier-skips.md)).
+
+Second: the RC inserter (`src/lir/arc.zig`) makes ownership-transfer
+decisions open-coded per instruction kind, at roughly 13 sites spread
+across two parallel abstract-interpretation walks over the LIR. Issue
+roc-lang/roc#9703 was one flaw of exactly the kind this invites: the
+solver (`src/lir/arc_solve.zig`) puts the ownership unit of a borrowed
+pure alias on the alias's **source** local, while the inserter tested and
+cleared its `OwnedSet` bitset by the **alias** local id — the bitset index
+was not the semantic key. The fix introduced `Solution.unitLocalOf()` to
+centralize alias-to-unit resolution, but the transfer *decision* logic
+remains duplicated per instruction kind, so every new ownership-moving LIR
+instruction is a fresh opportunity for the same class of bug.
+
+The certifier is the only mechanism that catches inserter bookkeeping bugs
+before they become silent memory unsafety — and state-complex procedures
+are both the ones it skips and the ones most likely to be wrong.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck IRs
+(Monotype → Lifted → Lambda Solved → Lambda Mono) → LIR lowering → ARC
+insertion → backends (LLVM / dev x86+aarch64 / wasm / interpreter).
+
+ARC insertion works in three parts, all stage-local to `src/lir/`:
+
+- `arc_solve.zig` computes a whole-program borrows-with-lifetimes solution
+  over ownership-neutral LIR. The design is documented in `design.md`
+  (repo root), section "ARC Borrow Inference", which is authoritative.
+- `arc.zig` (`insert`) consumes the solution and rewrites each procedure
+  body, emitting explicit `incref` / `decref` / `free` statements. It
+  threads an `OwnedSet` (a bitset over `LIR.LocalId`) along every control
+  path: a set bit means "this local currently carries an ownership unit
+  that this path must release or transfer exactly once."
+- `arc_certify.zig` is a debug-build-only certifier (`design.md` section
+  "Debug Borrow Certifier", authoritative) that re-checks the emitted RC
+  statements against the ownership rules using only the emitted LIR and
+  the ARC-stage signature table. `arc.insert` invokes it under
+  `builtin.mode == .Debug` via `certifyStoreOrPanic`; release builds
+  compile it away entirely.
+
+Borrow inference deliberately keeps refcounts at 1 across read-only uses:
+that is what lets the `refcount == 1` fast paths in the runtime list/str
+builtins (`src/builtins/list.zig`, `src/builtins/str.zig`) mutate in place
+instead of copying. The flip side is that a misplaced RC statement is not a
+theoretical concern — it directly produces leaks, double-frees, or wrongful
+in-place mutation observable in program output.
+
+Vocabulary: an **ownership unit** is one retained count on one runtime
+value; the inserter's `OwnedSet` bit for a local means that local's *unit
+local* (`Solution.unitLocalOf`) carries a unit. A **join point** is the LIR
+merge construct (`.join` / `.jump` CF statements); the certifier summarizes
+the state flowing into a join over the locals the join body reads before
+rebinding (`computeJoinRelevant`) and today re-walks the body once per
+distinct summary digest (`JoinRecord.scheduled`, `summaryDigest`).
+
+## Evidence
+
+All paths relative to the repo root; verified against the current tree.
+
+- `src/lir/arc_certify.zig`
+  - `CertifyError = error{ OutOfMemory, Certification,
+    CertifierCapacityExceeded }`.
+  - The `.jump` handler: on a new distinct summary,
+    `if (record.scheduled.count() > 4096) return
+    error.CertifierCapacityExceeded;`, preceded by a comment naming issue
+    9658, the Bell-number growth, the leak-masking risk, and the lattice
+    fixpoint as the ideal fix. `certifyStore` catches the error per
+    procedure, increments `Diagnostic.skipped_proc_count`, and continues.
+  - `LocalSummary` (fields `class`, `repr`, `balance`, `lender_repr`,
+    `condition`, `condition_mask`) and `LocalClass` (`unbound`, `owned`,
+    `conditional_owned`, `borrowed`) are the existing per-join state
+    quotient. `JoinRecord.scheduled` / `pending` hold the enumeration.
+  - The pre-9746 behavior (cap 64, hard "entry states of join diverge
+    across jumps" error) is gone; only the capacity error remains.
+- `src/lir/arc_solve.zig` — `Solution.unitLocalOf` walks `alias_source` to
+  the unit-carrying local when `isBorrowed(local)`; introduced by the fix
+  for issue roc-lang/roc#9703.
+- `src/lir/arc.zig`
+  - Two parallel walks duplicate per-instruction ownership-transfer logic:
+    the rewrite walk (`processRewritePath`) and the analysis walk
+    (`analyzeUntil`). Both have open-coded cases for `.set_local`,
+    `.assign_call`, `.assign_call_erased`, aggregates
+    (`spanTransferMask` / `preserveConsumedArgMask`), `.ret`, and
+    `.expect_err`.
+  - `ownsUnit` / `unsetOwnedUnit` route through `unitLocalOf`, but
+    decision helpers remain scattered: `canMoveSetLocalValue`,
+    `callArgOwnership`, `unsetArgs`, `retainArgs`, `retainMaskedArgs`,
+    `releaseOldTargetIfNeeded` (which tests `owned.contains(target)` on the
+    raw local id — audit whether rebind targets can ever be aliases).
+  - PR roc-lang/roc#9474 fixed a >64-argument call crash by making
+    `CallArgOwnership.retain_args` / `transfer_args` heap `ArrayList`s;
+    the `argMaskBit` `u64` helper remains on bounded paths behind
+    explicit `i >= 64` guards (e.g. `retainMaskedArgs`).
+  - `test "RC alias into set_local moves the leader unit"` is the existing
+    regression test for the 9703 keying class.
+- `design.md` sections "ARC Borrow Inference" and "Debug Borrow Certifier".
+
+## Solution design
+
+### Part 1: certifier dataflow fixpoint
+
+Replace enumerate-distinct-entry-states with a forward dataflow fixpoint:
+one abstract state per join, a join operator, iterate until stable.
+
+Abstract domain, per join, over the join's relevant dense locals:
+
+1. **Must-alias partition**: locals x, y are in one class iff they are
+   bound to the same value on *every* in-edge seen so far. Join = common
+   refinement (intersection of the pair relations). Each join step can only
+   refine, and a partition over n locals refines at most n−1 times, so this
+   component has height n−1.
+2. **May-alias relation**: union of the per-edge alias relations. Join =
+   set union; height ≤ n².
+3. **Per must-class ownership mode**, a lattice with ⊥ below the four
+   concrete classes `unbound`, `borrowed(anchor)`, `owned(balance)`,
+   `conditional_owned(cond, mask)`, and ⊤ above them all:
+   ⊥ = no in-edge seen; equal concrete modes join to themselves;
+   `owned(b) ⊔ owned(b) = owned(b)`; anything else joins to ⊤ (conflict).
+   Valid inserter output keeps balances at 0 or 1 outside transient
+   aggregate windows and expresses path-dependent ownership as conditional
+   accounting (`decref_if_initialized`, maybe-uninitialized params), which
+   `conditional_owned` represents — so ⊤ is rare and meaningful.
+
+The join is pointwise over these components; every component only moves up
+its finite-height lattice, so the joined state at each join point changes
+at most O(n²) times and termination is structural, not capped. Monotonicity
+must be argued in a doc comment: each per-statement transfer function
+(already implemented as the certifier's concrete walk) is extended to
+abstract states such that a higher input never yields a lower output —
+⊤ propagates, must-alias facts only shrink through the same rebindings,
+may-alias facts only grow.
+
+A join body is verified under the current joined state, and re-verified
+only when a new jump strictly increases that state. Checks are adapted to
+the abstraction:
+
+- Balance accounting is per must-class. A release through local L consumes
+  a unit from L's must-class.
+- Where a check's verdict depends on an *undecided* fact — a pair that is
+  may- but not must-aliased, or a mode joined to ⊤ — the certifier
+  refines: it splits the join's abstraction on that one fact and
+  re-verifies each variant. Every variant is satisfied by a nonempty
+  subset of the real in-edges, so refinement never manufactures false
+  positives; in the worst case it degenerates to today's finite
+  enumeration, but *without a cap or skip path*, because the widened walk
+  absorbs the combinatorial bulk (the 9658 class — many alias partitions,
+  same ownership behavior — converges in one widened walk).
+- A residual ⊤ that a check depends on and that refinement traces to a
+  genuine disagreement between in-edges about unit carriage is a
+  certification **failure** (a positive finding), reported with the join
+  id, the local, and the two conflicting predecessor summaries.
+
+Deletions when this lands:
+
+- the 4096 cap and its comment block;
+- `error.CertifierCapacityExceeded` from `CertifyError` and both catch
+  sites (`certifyStore`, `certifyStoreOrPanic`);
+- `Diagnostic.skipped_proc_count` and the surfacing added by the stopgap
+  project (its CI zero-skip assertion becomes vacuous and is removed);
+- `JoinRecord.scheduled` / `pending` digest-enumeration machinery
+  (`summaryDigest`-keyed scheduling; the `memo` for shared switch suffixes
+  is a separate mechanism and stays).
+
+Write the soundness argument in the module doc comment: the guaranteed
+property is that every emitted schedule balances ownership on all paths
+(each unit released or transferred exactly once, no use after death, no
+release of a borrow) for **every** procedure, with no unverified residue.
+
+### Part 2: centralized ownership-transfer keying in the inserter
+
+Create one shared keying/transfer layer (a struct in `arc.zig` or a new
+`src/lir/arc_transfer.zig`) through which *all* transfer sites route:
+
+- `unitOf(local)` — delegates to `Solution.unitLocalOf`, the **only**
+  alias-to-unit resolution in the inserter (already true for
+  `ownsUnit`/`unsetOwnedUnit`; make it true everywhere, auditing
+  `releaseOldTargetIfNeeded`'s raw `owned.contains(target)`).
+- `owns(set, local)`, `take(set, local)` (test-and-clear by unit key,
+  returning whether a unit moved), `place(set, local)`.
+- Decision helpers shared by both walks: `moveForSetLocal(...)` (wrapping
+  `canMoveSetLocalValue` plus the mode-specific target handling),
+  `transferForCall(...)` (wrapping `callArgOwnership` + `unsetArgs` +
+  `retainArgs`), `transferForAggregate(...)` (wrapping `spanTransferMask` /
+  `preserveConsumedArgMask` keying), `consumeAtTerminal(...)` (ret,
+  expect_err).
+
+The rewrite walk (`processRewritePath`) and the analysis walk
+(`analyzeUntil`) then differ only in whether they materialize RC
+statements; each per-instruction case shrinks to a call into the shared
+helper, computed once as a small decision struct and consumed by both.
+Open-coded `owned.unset`/`owned.contains` at transfer sites is deleted.
+Adding an ownership-moving LIR instruction then requires exactly one new
+decision function, used identically by both walks, instead of two
+hand-synchronized copies.
+
+### Migration order
+
+1. Land [Surface ARC Certifier Skips](../small/surface-arc-certifier-skips.md)
+   so any regression during this work is visible.
+2. Inserter keying refactor (Part 2), gated by a byte-identical-LIR check
+   on the corpus (see below). No behavior change intended.
+3. Certifier fixpoint (Part 1) behind a comptime or option flag; run both
+   old and new certifiers over the full test corpus and diff findings.
+4. Remove the enumeration path, the cap, the error, the counter, and the
+   stopgap surfacing.
+
+## What success looks like
+
+- Zero skipped procedures on the full test corpus in debug builds; the
+  skip path no longer exists in the code.
+- The issue 9658 reproduction certifies successfully (no abort, no skip).
+- The issue 9703 keying bug, if reintroduced (transfer by alias id instead
+  of unit id), is caught by the certifier on the existing corpus.
+- Every ownership-transfer site in `arc.zig` resolves its key through the
+  shared layer; grepping for raw `owned.unset(` / `owned.contains(` at
+  transfer sites finds only the shared helpers.
+- The lattice, its join, monotonicity, and the certified property are in
+  `arc_certify.zig`'s module doc comment and reflected in `design.md`'s
+  "Debug Borrow Certifier" section.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- Mutation testing: deliberately break `arc.zig` transfer logic in several
+  distinct ways — drop a decref, transfer by alias id instead of
+  `unitLocalOf`, skip a join's `entry_keep`, double-transfer a call
+  argument — and verify the certifier flags each one on the corpus.
+- The lattice join is proven monotone in a doc comment, with the height
+  bound stated; the soundness argument (the certifier guarantees every
+  emitted schedule balances ownership on all paths) is written down.
+- Old and new certifiers agree on every finding across the corpus during
+  the flag-gated transition (step 3 above).
+
+### Performance ideal
+
+The certifier is debug-only, so its budget is generous — but the fixpoint
+should be near-linear in (joins × locals): measure certifier wall time on
+the largest corpus tests before and after; the join-heavy stress tests
+below must complete in seconds, not minutes. Release builds never run the
+certifier, so release compile time and generated code are unaffected by
+Part 1 by construction. The Part 2 refactor must not change emitted RC
+statements: capture the post-ARC LIR for the corpus before and after and
+require byte-identical output, except where a latent keying bug is fixed —
+diff and account for every change explicitly.
+
+## Tests to add
+
+- A reproduction of issue 9658 (nested loops over ~6 refcounted mutable
+  locals) asserting full certification with zero skips.
+- A reproduction of issue 9703 (borrowed pure alias whose unit lives on
+  the source local, moved through `set_local` and call arguments),
+  extending `test "RC alias into set_local moves the leader unit"`.
+- A join-heavy stress generator: N refcounted mutable locals rebound and
+  re-aliased in nested loops, N up to ~12, asserting certification
+  completes and time stays within budget.
+- Injected-leak tests proving detection: build LIR with a known
+  per-iteration leak / double-release / use-after-move inside a
+  state-complex loop (the shape the old cap would have skipped) and
+  assert `error.Certification` with the expected diagnostic; use the
+  `ArcTest` harness in `arc.zig`, which already builds LIR directly.
+
+## Related projects
+
+- [Surface ARC Certifier Skips](../small/surface-arc-certifier-skips.md) —
+  the stopgap that makes the current hole visible until this project
+  removes it.
+- [Centralize the Seamless-Slice Allocation-Reuse Predicate](../small/centralize-slice-reuse-predicate.md)
+  — the runtime-side twin: one predicate definition instead of per-site
+  open-coded uniqueness checks.
+- [Store Generation Counters](../small/store-generation-counters.md) —
+  `arc.zig` has a hoisted-pointer hazard site of the class that project
+  addresses (`insert` re-fetches the proc-spec pointer after rewrites
+  because the backing storage may have been reallocated).

--- a/projects/big/canonical-capture-id.md
+++ b/projects/big/canonical-capture-id.md
@@ -1,0 +1,236 @@
+# One Canonical CaptureId Through Every IR
+
+## Problem
+
+A closure capture has no single identity in this compiler. The same captured
+binding is keyed four different ways across the post-check IRs — a lifted
+`LocalId`, a `Common.Symbol`, a checked `PatternBinderId`, and a generated
+`capture_id: u32` — and the stages are joined by fuzzy matchers whose rules
+differ per file. When a matcher misses, one file silently substitutes a
+different value, another silently drops the operand, and a third panics.
+Capture operand spans are positional parallel arrays whose order comes from
+fixpoint discovery, so any pass that clones or reorders functions must
+re-derive the world and hope the matchers re-align it.
+
+Four PRs in eight weeks patched this machinery (9677, 9852, 9853, 9874), each
+making one more piece of capture data explicit, and the class is still open:
+issue 9897 panics with "function reference capture count differs from its
+target" on a simple nested-closure program.
+
+## Background
+
+The compiler pipeline is: parse → canonicalize → type-check (producing
+"checked artifacts" per module) → postcheck: Monotype IR (monomorphization,
+`src/postcheck/monotype/`) → Monotype Lifted (closure lifting,
+`src/postcheck/monotype_lifted/`) → Lambda Solved → Lambda Mono → LIR
+lowering → ARC insertion → backends. `design.md` at the repo root is the
+authoritative design; its Core Principles forbid post-check stages from
+recovering missing data by heuristics or fallbacks, and state "Identity
+provenance follows meaning provenance."
+
+Captures in this pipeline: type checking records which bindings a lambda
+captures (`CheckedCapture` in `src/check/checked_artifact.zig`: a
+`CheckedPatternId` plus `scope_depth`). Monotype lowering turns each into an
+explicit operand (`FnDefCapture` in `src/postcheck/monotype/ast.zig`: a local
+plus a value expr). Closure lifting (`src/postcheck/monotype_lifted/lift.zig`)
+computes each lifted function's capture SET as a least fixpoint over the
+function-reference graph and stores it as a `TypedLocal` span per `FnId`;
+every `fn_ref`/`call_proc` carries a positional operand span that must align
+with that set. Lambda Solved re-checks types over the lifted program
+(`src/postcheck/lambda_solved/solve.zig`); its lambda-set members carry
+`Capture` records (`src/postcheck/lambda_solved/type.zig`: `local`, `symbol`,
+`binder`, `capture_id`, `ty`). Lambda Mono and LIR lowering then build the
+runtime capture records. Compile-time evaluation (CTFE) has a parallel
+representation: `ConstStore` closures use `CaptureId` (binder | generated)
+plus `ConstTypeStore` type evidence (`src/check/const_store.zig`).
+
+Caching constraint (this design must respect it): canonicalization output
+must be serializable keyed on a pure function of (module name, module source
+bytes) and NOTHING else; type-checking output is keyed on that hash combined
+with the type-checked hashes of imports — a Merkle DAG. Any id serialized in
+a stage's artifact must be a deterministic function of that stage's cache-key
+inputs. Global uniqueness comes from pairing module-local ids with module
+identity, never from global counters or coordinator state. Name-based
+resolution is legitimate in exactly one place: resolving imports at the
+canonicalize→check boundary. A capture id assigned during canonicalization in
+deterministic traversal order satisfies this; `ConstStore` lives in checked
+artifacts, so any generated id stored there must be deterministic from
+checked inputs alone.
+
+## Evidence
+
+The fuzzy matchers, each with different rules:
+
+- `fnDefCaptureLocalMatches`, `src/postcheck/monotype_lifted/lift.zig`:
+  matches local == explicit ∨ same `symbol` ∨ same `binder` ∨ same
+  `capture_id`, gated by `monotypeTypeEql` structural type equality.
+- `captureExprForMemberCapture`, `src/postcheck/lambda_mono/lower.zig`:
+  matches local ∨ binder only; on a miss the caller silently FALLS BACK to an
+  implicit local read via `lowerLocalValue(capture.local, field.ty)` — the
+  pre-explicit-captures mechanism surviving as a fallback.
+- `captureExprForMemberCapture` → `captureLocalMatchesMember`,
+  `src/postcheck/solved_lir_lower.zig`: matches local ∨ symbol ∨
+  `capture_id` (three keys; unlike lift's matcher it does not consult the
+  binder), and a miss is `Common.invariant("callable capture payload field
+  had no explicit operand")`. One of the two `captureExprForMemberCapture`
+  policies — silent fallback vs. hard invariant — must be wrong.
+- `lowerClosureCaptureExprSpan`, `src/postcheck/monotype/lower.zig`:
+  `self.binders.get(binder) orelse continue` — silently drops any checked
+  capture whose binder it cannot resolve.
+
+The positional-order machinery: operand spans are parallel arrays in
+fixpoint-discovery order. PR 9874 (fix-capture-finalization-order) introduced
+`CaptureIdentity` (`binder` | `generated` | `local`, plus a monotype type) in
+`lift.zig`, but only to REPAIR order at the `recomputeCaptures` boundary —
+`finalizeCaptureExprSpanFromOperands` re-sorts operands against the new slot
+order using the `capture_operands_by_expr` side table, and
+`captureOperandsFromPositionals` still derives identity from positional
+alignment once per recompute. `Lift.recomputeCaptures` re-derives all capture
+sets after mutation; it runs twice per pipeline (inside
+`SpecConstr.run` via `src/postcheck/monotype_lifted/spec_constr.zig`, and
+again from `src/lir/checked_pipeline.zig`). PR 9853 reverted an edge-driven
+worklist back to a full fixpoint because explicit operands let capture sets
+shrink.
+
+Bug history: issue 9634 → PR 9677 made the capture SET a solved fixpoint
+artifact computed before body rewriting (it was previously derived during
+rewriting — both wrong and exponential); issue 9825 → PR 9852 made capture
+VALUES explicit operand spans through four IRs with arity/type invariants at
+Lambda Solved, Lambda Mono, and LIR; PR 9853 made capture TYPES explicit on
+the CTFE path (`CaptureId` + `ConstTypeStore`); PR 9874 added identity-keyed
+order repair. Open issue 9897: `Common.invariant("function reference capture
+count differs from its target")` in `src/postcheck/lambda_solved/solve.zig`,
+reproducible with a simple nested closure — the class is still open.
+
+## Solution design
+
+Separate the two concerns that are currently conflated:
+
+- **Capture IDENTITY** is owned by canonicalization. Assign a `CaptureId` —
+  module-local, dense, allocated in traversal order — to every captured
+  binding. Being a pure function of (module name, source bytes), it is
+  cache-safe to serialize in checked artifacts per the caching constraint.
+- **Capture SET membership** stays owned by the lift-time fixpoint, and it
+  must: devirtualized sibling-def recursion produces captures that no checked
+  closure ever listed, so the set cannot come from canonicalization. But
+  every member the fixpoint adds refers to a binding that already has a
+  `CaptureId` (or to a compiler-synthesized local, below).
+
+Data structures:
+
+1. `CaptureId` becomes a single `enum(u32)` in `src/check/checked_ids.zig`
+   with two deterministic ranges: canonical ids (dense, from
+   canonicalization) and generated ids (high-bit range, allocated
+   deterministically by the pass that synthesizes a capturable local — CTFE
+   during checking, lifting/spec_constr after). Generated ids serialized in
+   `ConstStore` are deterministic from checked inputs (CTFE evaluation order
+   is deterministic), so the caching constraint holds; post-check generated
+   ids never enter checked artifacts (design.md: post-check IRs are not
+   cached).
+2. `CheckedCapture` gains `capture_id: CaptureId` alongside its pattern.
+3. Monotype `FnDefCapture`, lifted capture slots (`TypedLocal` spans — the
+   id lives on the local, replacing today's `binder`/`capture_id` pair of
+   optionals), operand spans, Lambda Solved `Capture`, and LIR capture
+   records all carry the same `CaptureId`, immutably.
+4. Every operand↔slot join becomes an exact keyed lookup on `CaptureId`.
+   Spans are canonically sorted by `CaptureId` (or stored keyed), so order is
+   never load-bearing; `recomputeCaptures` produces sorted spans directly and
+   the order-repair machinery disappears.
+5. `ConstStore` captures reference the same `CaptureId` type; the current
+   binder|generated union in `src/check/const_store.zig` collapses into it.
+
+What gets DELETED:
+
+- `fnDefCaptureLocalMatches` and `captureIdentityForTypedLocal` /
+  `captureIdentityEql` / `findCaptureOperand` fuzzy matching in `lift.zig`,
+  plus `CaptureIdentity`, `captureOperandsFromPositionals`, and
+  `finalizeCaptureExprSpanFromOperands` (spans are keyed; nothing to repair).
+- Both `captureExprForMemberCapture` matchers, replaced by exact lookup.
+- The lambda_mono silent fallback to `lowerLocalValue`: a missing operand is
+  a hard invariant EVERYWHERE, adopting `solved_lir_lower.zig`'s policy
+  (design.md Core Principles already forbids the fallback).
+- The `orelse continue` silent drop in `lowerClosureCaptureExprSpan`
+  (`src/postcheck/monotype/lower.zig`): unresolvable binder = invariant.
+
+Add `verifyCaptureInvariants`, a debug-only pass over a Lifted program, run
+after EVERY Lifted-IR mutation (lifting itself, spec_constr, inlining, any
+future pass), so a pass that forgets capture maintenance fails
+deterministically at its own boundary instead of five stages later. It
+checks, per function and per `fn_ref`/`call_proc` site: operand span and
+capture slot span contain the same `CaptureId` multiset, sorted; no duplicate
+ids in a span; every operand's local exists with a type equal to its slot's;
+every canonical id resolves to a live binder.
+
+Migration order: (1) allocate `CaptureId` in canonicalization and thread it
+into `CheckedCapture`; (2) carry it through monotype lowering (fixing the
+`orelse continue` into an invariant); (3) switch lift slots and operands to
+keyed/sorted form, delete the lift matchers and order repair; (4) switch
+Lambda Solved / Lambda Mono / solved_lir_lower joins to exact lookups, delete
+both matchers and the fallback; (5) collapse `ConstStore`'s `CaptureId`
+union; (6) land `verifyCaptureInvariants` and wire it after every mutation.
+
+Note for `../big/total-dispatch-plans.md`: where-clause dispatch evidence
+threads through nested closures exactly like a compile-time capture and
+should ride this same identity discipline rather than invent a fifth key.
+
+## What success looks like
+
+- One `CaptureId` type; `grep` finds no capture join on `symbol`, `binder`,
+  or `LocalId` equality anywhere in `src/postcheck/`.
+- Missing capture operands are impossible to paper over: every consumer
+  panics in debug and is `unreachable` in release, per design.md.
+- Capture spans have a defined canonical order; shuffling fixpoint discovery
+  order changes no output.
+- Issues 9634, 9825, and 9897 repros pass; the 9897 panic site becomes an
+  exact-lookup invariant that no longer fires.
+- `CaptureIdentity`, `captureOperandsFromPositionals`,
+  `finalizeCaptureExprSpanFromOperands`, `fnDefCaptureLocalMatches`, and both
+  `captureExprForMemberCapture` bodies are gone from the tree.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+Every capture join in the pipeline is an exact key lookup that either
+succeeds or halts the compiler at the stage that broke the invariant — never
+a heuristic that can pick the wrong value. A new Lifted-IR pass that clones,
+reorders, or rewrites functions either maintains captures or fails
+`verifyCaptureInvariants` on the first test that exercises it. Capture ids in
+checked artifacts are byte-stable across runs, machines, and entry points,
+because they are functions of (module name, source bytes) only.
+
+### Performance ideal
+
+Given perfect correctness: joins drop from O(slots) linear scans with
+structural type equality per candidate (today's `fnDefCaptureLocalMatches`
+calls `monotypeTypeEql` per comparison) to O(1) id lookups or a merged walk
+of two sorted spans — measure lift + lambda-solve + LIR-lower time on
+closure-heavy code (the recursive-parser corpus from PR 9853 is the
+benchmark). `recomputeCaptures` keeps its fixpoint but stops rebuilding
+identity tables; measure its share of pipeline time before/after.
+`verifyCaptureInvariants` must be debug-only: release-mode cost is zero.
+
+## Tests to add
+
+- Repros for issues 9634 (capture set correctness), 9825 (explicit capture
+  values), and 9897 (nested-closure fn_ref capture count) as pipeline tests.
+- PR 9874's 5-deep curried closure chains (order-sensitivity regression).
+- PR 9853's recursive parser const closures (CTFE `CaptureId` path).
+- spec_constr stress test: a program whose specialization clones functions
+  and reorders their capture sets; assert output equivalence and invariant
+  pass.
+- Mutation test for the debug pass: intentionally skip capture maintenance
+  after a synthetic Lifted mutation in a unit test; assert
+  `verifyCaptureInvariants` fails with the expected message.
+- Determinism test: canonicalize the same source twice (and with shuffled
+  allocator behavior); assert identical `CaptureId` assignment bytes in the
+  serialized checked artifact.
+
+## Related projects
+
+- `../big/total-dispatch-plans.md` — where-clause evidence as compile-time
+  captures rides this identity discipline.
+- `../big/content-based-nominal-identity.md` — same disease (fuzzy identity
+  joins at stage boundaries) applied to nominal types; shares the
+  "assign identity once, carry it immutably" principle and the caching
+  constraint.

--- a/projects/big/content-based-nominal-identity.md
+++ b/projects/big/content-based-nominal-identity.md
@@ -1,0 +1,247 @@
+# Content-Based Canonical Identity for Nominal Types and Methods
+
+## Problem
+
+A nominal type in this compiler has no single identity. What it has is a
+bundle of name strings — a module name, a display module name, a
+package-qualified module name, a type name, and sometimes a statement index —
+interned separately into every artifact that mentions the type, and re-matched
+BY TEXT at every artifact boundary. Whether `Json.Value` from one package is
+the same type as `Json.Value` from another is decided by string comparison,
+and the strings being compared were assigned by whichever code path happened
+to build that artifact (build, check, run, glue, LSP — each with its own
+naming scheme; see `../small/single-package-identity-function.md`).
+
+Concretely, `MethodOwner` in `src/check/static_dispatch_registry.zig` is a
+union over `NominalTypeKey` (`module_name: ModuleNameId`, `type_name:
+TypeNameId`, `source_decl: ?u32` — a statement index) and a `source_decl`
+variant of (`ModuleNameId`, statement index). Those `NameId`s are per-artifact
+interner indices, so every cross-artifact lookup round-trips through text:
+`methodOwnerInImportedNames` calls
+`imported_names.lookupModuleName(source_names.moduleNameText(...))`; monotype
+lowering re-interns every name and resolves a type's declaring module by
+trying `Ident.textEql` against three different spellings of each candidate
+module's name.
+
+This has produced a sustained bug cluster: types that should unify and don't,
+dispatch that resolves to the wrong module or nothing, cache keys polluted by
+per-run strings, and glue indexing the wrong artifact by name. Every fix so
+far has patched one text-matching site; the sites keep multiplying.
+
+## Background
+
+The compiler pipeline is: parse → canonicalize → type-check (producing
+"checked artifacts" per module) → postcheck: Monotype IR (monomorphization,
+`src/postcheck/monotype/`) → Monotype Lifted (closure lifting,
+`src/postcheck/monotype_lifted/`) → Lambda Solved → Lambda Mono → LIR
+lowering → ARC insertion → backends. `design.md` at the repo root is the
+authoritative design. Two parts of it govern this project:
+
+- The Core Principles paragraph "Identity provenance follows meaning
+  provenance": an identity may be derived from module content (module name,
+  source bytes, identities of imports) only for definitions whose entire
+  meaning is determined by that content; externally-bound definitions (hosted
+  functions, `provides` entrypoints) are identified by their platform-header
+  symbol strings instead, and may never be merged.
+- The Cache Boundary section: the checked module cache id is `CheckedModuleId
+  = source_hash + compiler_build_hash + module_identity +
+  checking_context_identity + direct_import_checked_module_ids`, and
+  `module_identity` includes the module's name because a type module's main
+  type takes its name from the module's file name.
+
+Caching constraint (this document must not violate it anywhere):
+canonicalization output must be serializable keyed on a pure function of
+(module name, module source bytes) and NOTHING else; type-checking output is
+keyed on that hash combined with the type-checked hashes of the module's
+imports — a Merkle DAG (`CheckedModuleArtifactKey` in
+`src/check/checked_artifact.zig` already has this shape, including
+`direct_import_artifact_keys_hash`). Any id serialized in a stage's artifact
+must be a deterministic function of that stage's cache-key inputs. Global
+uniqueness comes from pairing module-local ids with module identity, never
+from global counters or coordinator state. Name-based resolution is
+legitimate in exactly one place: resolving imports at the canonicalize→check
+boundary; everything downstream consumes resolved ids.
+
+## Evidence
+
+- `MethodOwner` and `methodOwnerInImportedNames`,
+  `src/check/static_dispatch_registry.zig`: cross-artifact owner remapping via
+  `lookupModuleName(moduleNameText(...))` / `lookupTypeName(typeNameText(...))`.
+- `NominalTypeKey`, `src/check/canonical_names.zig`: (`module_name`,
+  `type_name`, `source_decl: ?u32` statement index).
+- `moduleViewNameMatches` and `moduleDigestForOrigin`,
+  `src/postcheck/monotype/lower.zig`: declaring-module resolution by
+  `Ident.textEql` against three name spellings (`module_name`,
+  `display_module_name`, `qualified_module_name`); `methodOwnerInProgramNames`
+  re-interns owner names per program.
+- `sameNominalIdentity`, `src/check/unify.zig`: compares `origin_module`
+  (an `Ident.Idx` of a coordinator-assigned qualified name string), then
+  `source_decl` / ident. `ownerEnvForOriginModule` in `src/check/Check.zig`
+  resolves owner envs from `origin_module` ident text.
+- `computeStableModuleIdentityHash`, `src/check/checked_artifact.zig`: hashes
+  the module name plus display and `qualified_module_ident` strings — the
+  latter assigned as `"{package_name}.{module_name}"` in
+  `src/compile/coordinator.zig`, where `package_name` is computed
+  independently by at least three call sites
+  (see `../small/single-package-identity-function.md`).
+- Associated items resolve through concatenated qualified-name strings
+  (`insertQualifiedIdent` in `src/canonicalize/ModuleEnv.zig` builds
+  `"{parent}.{child}"`; PR 9714 fixed exposed nested-type associated items by
+  adjusting this string plumbing).
+- `moduleEnvNamesMatch`, `src/compile/compile_package.zig` (introduced around
+  PR 9430): dedups owner envs by comparing qualified/display/bare name strings
+  with fallbacks.
+- Bug history: PR 9627 fixed "Json.Value is not Json.Value" (same package
+  under two aliases produced non-unifying nominal types); issue 9875 (static
+  dispatch lost through `ThingAlias : Thing` re-exports); issue 9864
+  (platform methods on package-owned nominals); issue 9865 / PR 9894 (glue
+  resolved a declaring module by name text, fell back to the wrong artifact,
+  and indexed a statement of the wrong kind — `src/glue/glue.zig` still does
+  module-name prefix matching on def names); PR 9811 (per-run temp-dir-derived
+  package identity broke cache keys for default apps).
+
+## Solution design
+
+Identity becomes content: a nominal type or method owner is identified by
+**(deep content hash of its declaring module, declared name)**.
+
+The deep hash is `H(module name ‖ source bytes ‖ identity hashes of resolved
+imports)` — SHA-256, the codebase digest standard (used throughout
+`src/postcheck/monotype/type.zig` and the cache keys). It is a pure function
+of the transitive closure's module names and source bytes, so it satisfies the
+caching constraint, and it is computable at import-graph load time, BEFORE
+type-checking begins — the unifier only ever compares precomputed identities.
+It mirrors the Merkle discipline of `CheckedModuleArtifactKey` but excludes
+`compiler_build_hash` and checking-context identity: those invalidate caches;
+they do not change what a type *is*. The module name must be part of the hash:
+per design.md's Cache Boundary section, a type module's main type takes its
+name from its file name, so source bytes alone underdetermine meaning.
+
+Deep (not shallow) hashing is required for soundness, not just hygiene: two
+byte-identical modules over different transitive dependencies could otherwise
+share identity while their field layouts differ. This is reachable in
+practice because PR 9627's resolver allows different major versions of a
+package to coexist in one build.
+
+The local component is the declared **name**, not a statement index. The
+current `source_decl: ?u32` statement index breaks under declaration
+reordering and was part of 9894's fragility (glue indexed a statement of the
+wrong kind in the wrong artifact). A decl name is unique within its module
+namespace and stable under reordering.
+
+Representation and memory:
+
+- 32-byte hashes exist only at rest and at artifact boundaries. In memory,
+  every identity is a dense `u32` (`IdentityId`) into a per-build identity
+  table: an append-only array of 32-byte hashes plus a hash→id map. 10k
+  distinct types ≈ 0.5 MB. Optionally truncate to 128 bits for in-memory map
+  keys only; serialized bytes stay 256-bit.
+- Serialized artifacts store a local identity table (array of 32-byte hashes)
+  plus `u32` references into it — never inline hashes at each use site.
+- Artifact load performs a **rebase**: one map lookup per distinct identity
+  per artifact, producing an old-u32 → build-u32 remap array. Rebase is the
+  SINGLE cross-artifact identity resolution point in the whole compiler,
+  replacing every text-remapping site. The map compares full 256-bit values
+  on insert, so a hash collision is detected, not silently merged.
+
+Exception, per design.md "Identity provenance follows meaning provenance":
+hosted functions and `provides` entrypoints are identified by the symbol
+strings in the platform header, NEVER by content hash. design.md's Debug
+Invariants section already requires that no deduplication or merging step
+collapse two `hosted` or `provides` identities even when their declaring
+modules are byte-identical. This project must preserve that carve-out
+verbatim.
+
+Semantic consequence to document in user-facing docs: two types whose
+declaring modules have byte-identical transitive closures unify — across
+package versions, mirror URLs, and vendored copies. This is desirable:
+a type that did not change interoperates across a version bump.
+
+Migration order:
+
+1. Compute the deep hash bottom-up during import-graph loading in the
+   coordinator (sources and the import DAG are already in hand there).
+   Store it on `ModuleEnv` / the checked artifact's module identity.
+2. Replace the string inputs of `computeStableModuleIdentityHash` with the
+   deep hash. This absorbs `../small/single-package-identity-function.md`:
+   package display names stop participating in identity entirely.
+3. Introduce the per-build identity table and `IdentityId`. Change
+   `types.NominalType.origin_module` from `Ident.Idx` to `IdentityId`;
+   `sameNominalIdentity` becomes integer equality on (identity, decl name).
+4. Change `NominalTypeKey` / `MethodOwner` to (`IdentityId`, decl-name id),
+   dropping the statement index. Static-dispatch lookups become exact keys.
+5. Add rebase to artifact load; route monotype lowering, glue, and the LSP
+   through rebased ids.
+6. Delete the text paths (below) and add a debug assertion that no post-check
+   stage calls any name interner for identity purposes.
+
+What gets DELETED:
+
+- `methodOwnerInImportedNames` (`src/check/static_dispatch_registry.zig`).
+- `moduleViewNameMatches` and the three-spelling `textEql` matching in
+  `moduleDigestForOrigin` (`src/postcheck/monotype/lower.zig`).
+- Concatenated qualified-name ("M.T.method"-style) probing for associated
+  items in canonicalize/check resolution paths (PR 9714's plumbing).
+- `moduleEnvNamesMatch` (`src/compile/compile_package.zig`).
+- Glue's module-name/prefix probing in `src/glue/glue.zig`.
+
+## What success looks like
+
+- `grep` finds zero call sites that compare module or type name TEXT to
+  decide identity anywhere downstream of import resolution.
+- `sameNominalIdentity` is two integer comparisons; no ident-store access.
+- The same module reached via check, run, glue, and LSP pipelines produces
+  bit-identical serialized identities.
+- Cache keys contain no coordinator-assigned display strings and no paths.
+- Issues 9875, 9864, and 9865 repros pass; PR 9627's two-alias scenario
+  unifies; PR 9811's scenario gets cache hits across runs.
+- Two byte-identical hosted modules wired to different platform symbols
+  remain distinct identities.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+Identity equality is decidable by a single integer compare whose answer never
+depends on which pipeline built the artifact, what the coordinator named a
+package, what directory the build ran in, or declaration order within a
+module. Every cross-artifact identity question is answered at rebase time or
+not at all. A collision between distinct 256-bit hashes is detected at rebase
+and reported as a compiler bug rather than merging types.
+
+### Performance ideal
+
+Given perfect correctness, the ceiling is: zero per-comparison string work in
+unification and dispatch (measure unifier time on a workspace with many
+cross-package nominal types, before/after); rebase cost linear in distinct
+identities per artifact, one hash-map probe each (measure artifact load time);
+identity table memory ~32–48 bytes per distinct type (measure RSS delta on a
+10k-type synthetic workspace). Deep-hash computation is amortized into I/O at
+load time and must not appear in check-phase profiles.
+
+## Tests to add
+
+- Cross-package unification: the same package content fetched via two
+  different URLs; a nominal type from each must unify.
+- Version coexistence: two majors of a package in one build (per PR 9627's
+  resolver); unchanged modules unify across versions, changed ones do not.
+- Repros for issues 9875 (alias re-export dispatch), 9864 (platform methods
+  on package-owned nominals), 9865 (glue on package nominal API, extending
+  `test/glue/package-nominal-api/`).
+- Cache-key purity: build the same default app from two different temp
+  directories under two coordinator naming schemes; identity bytes and cache
+  keys are bit-identical (PR 9811's repro).
+- Hosted distinctness: two byte-identical hosted modules bound to different
+  platform-header symbols stay distinct through every merging pass.
+- Decl reordering: reordering declarations in a module changes no identity
+  except via the module's own source hash input.
+
+## Related projects
+
+- `../small/single-package-identity-function.md` — interim fix; absorbed by
+  this project (step 2 above).
+- `../big/total-dispatch-plans.md` — dispatch plans consume these identities.
+- `../big/immutable-specialization-identity.md` — specialization keys build on
+  stable nominal identity.
+- `../small/glue-consumes-committed-layouts.md` — glue stops re-deriving what
+  identity plus committed layouts already state.

--- a/projects/big/decision-tree-match-compiler.md
+++ b/projects/big/decision-tree-match-compiler.md
@@ -1,0 +1,242 @@
+# A Decision-Tree Match Compiler
+
+## Problem
+
+Match compilation in LIR lowering is a per-branch backtracking chain, not a
+decision tree. Each branch of a `match` is lowered as an independent test
+chain that jumps to a per-branch "miss" join point on failure, falling through
+to the next branch's chain. Concretely:
+
+- `lowerBranchChain` (src/postcheck/solved_lir_lower.zig, duplicated in
+  src/postcheck/lir_lower.zig) iterates branches in reverse, wrapping each in
+  its own miss join (`patternCanMiss` decides whether one is needed).
+- `lowerTagPatternThen` calls `discriminantSwitch`, which emits a ONE-ARMED
+  `switch_stmt` per branch: it allocates a fresh `.u16` local, re-reads the
+  scrutinee's discriminant into it via `assign_ref` with a `.discriminant`
+  op, and switches on that single value with everything else going to the
+  miss default. An N-tag match therefore becomes N chained one-armed
+  switches, each re-reading the same discriminant.
+- String patterns could not tolerate this shape at all: `lowerBranchChain`
+  contains a hand-written special case (`strPatternBranchGroupStart` /
+  `lowerStrPatternBranchGroup`) that scans for runs of adjacent string
+  patterns and emits a single `str_match_set` statement for the group.
+
+The costs are concrete. The dev backends (x86-64, aarch64) ship these naive
+chains verbatim — no later pass cleans them up. The LLVM backend relies on
+LLVM to rediscover the jump table that a decision-tree compiler would have
+emitted directly. And an entire compensating optimization pass exists
+largely because of branches a decision tree would never emit (see Evidence:
+PR 9726's tag-reachability pass).
+
+There is also a residual correctness hazard from the last round of fixes:
+the invariant "Monotype expression ids referenced from multiple positions
+get DUPLICATED downstream; sharing must go through join points" is
+undocumented and unenforced. PR 9707 removed the one known violator (the
+list-pattern desugarer), but nothing prevents a recurrence.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck:
+Monotype IR → Monotype Lifted → Lambda Solved → Lambda Mono → LIR lowering →
+ARC insertion → backends. design.md at the repo root is authoritative.
+
+There are TWO LIR lowerers:
+
+- src/postcheck/solved_lir_lower.zig (~7.7k lines) — production. Lowers
+  Lambda Solved IR directly to LIR, keeping Lambda Mono decisions without
+  materializing Lambda Mono trees in release builds.
+- src/postcheck/lir_lower.zig (~4.2k lines) — a parallel Lambda-Mono-based
+  lowerer used by debug verification and test harnesses.
+
+Several fixes have had to land twice, once in each, and the copies drift.
+
+FIVE executors run Roc code: the interpreter (src/eval/interpreter.zig), the
+dev backends for x86-64 and aarch64 (src/backend/dev/), the LLVM backend
+(src/backend/llvm/MonoLlvmCodeGen.zig), and the wasm backend
+(src/backend/wasm/). Engine divergence — `roc test` and `roc run` giving
+different answers — has been the de facto bug detector.
+
+Two pipeline facts matter for match compilation:
+
+1. Monotype is a DAG: an expression id may be referenced from multiple
+   positions, and LIR lowering re-lowers each reference (tree semantics).
+   Sharing a continuation in LIR must go through LIR join points (`join` /
+   `jump` control-flow statements), which is exactly what the per-branch
+   miss joins do today.
+2. Exhaustiveness is decided by the checker. `closeExhaustiveVars`
+   (src/check/Check.zig) commits exhaustiveness verdicts into the type store
+   (closing extension and payload vars). Per design.md, lowering must
+   consume those verdicts, not re-derive them; the chain's terminal
+   statement is `runtime_error` or `comptime_exhaustiveness_failed`.
+
+## Evidence
+
+- `lowerBranchChain`: src/postcheck/solved_lir_lower.zig and
+  src/postcheck/lir_lower.zig (near-duplicate copies).
+- `lowerTagPatternThen` → `discriminantSwitch`
+  (src/postcheck/solved_lir_lower.zig): fresh `.u16` local + `assign_ref`
+  discriminant read + one-armed `switch_stmt` per branch.
+- String special case: `strPatternBranchGroupStart`,
+  `lowerStrPatternBranchGroup`, `directStrPattern`, emitting
+  `str_match_set` — inside `lowerBranchChain` in both lowerers.
+- PR roc-lang/roc#9478: patched holes in the out-of-band list-pattern
+  desugarer (nested list patterns panicked; the desugarer expanded to
+  expression-level if-cascades).
+- PR roc-lang/roc#9707: DELETED that desugarer after discovering exponential
+  blowup. Monotype desugared list patterns to trees whose miss arm
+  referenced the shared rest-of-match by expression id (a DAG in Monotype);
+  LIR lowering re-lowers each reference, giving ~(elements+1)^branches
+  statements — measured 1136 → 4272 → 16816 LIR statements for 3 → 4 → 5
+  branches. 9707 made list patterns first-class (`PatData.list` /
+  `ListPattern` in src/postcheck/monotype/ast.zig, re-exported by
+  monotype_lifted/ast.zig, mirrored in lambda_mono/ast.zig) through four IR
+  stages, lowered via the shared per-branch miss join (linear).
+- PR roc-lang/roc#9726: added src/lir/tag_reachability.zig (~1.1k lines) —
+  a whole-program fixpoint over all proc specs that deletes switch edges on
+  tag discriminants no construction site can produce. It runs only at
+  `--opt=size`/`--opt=speed` (`tagReachabilityForOpt` in src/cli/main.zig;
+  invoked via the `tag_reachability` flag in src/lir/checked_pipeline.zig).
+  Much of what it cleans up is branches a decision-tree compiler would
+  never emit.
+- PR roc-lang/roc#9849: derived equality/patterns on nominal records must
+  decompose through the NOMINAL operand — nominal layout ≠ backing layout
+  since declared field order. Pattern compilation must unwrap nominals the
+  same way (`lowerNominalPatternThen` today).
+- `closeExhaustiveVars`: src/check/Check.zig; exhaustiveness analysis in
+  src/check/exhaustive.zig.
+
+## Solution design
+
+Implement a Maranget-style decision-tree match compiler (Maranget 2008,
+"Compiling Pattern Matching to Good Decision Trees") at ONE stage: the
+LIR-lowering boundary, as a single shared module consumed by both lowerers.
+
+Data structures:
+
+1. **Pattern matrix**: rows = branches (pattern vector + optional guard +
+   body id), columns = occurrences (paths into the scrutinee: root, tag
+   payload i, field i, tuple item i, list element i / rest). Built from the
+   input IR's `PatData` via a thin accessor interface so the same module
+   works over Lambda Solved (`Lifted.Branch`) and Lambda Mono
+   (`LambdaMono.Branch`) inputs.
+2. **Occurrence table**: each occurrence lowers to at most one LIR local,
+   computed once (one discriminant read per tested position, one field read
+   per destructured position).
+3. **Tree nodes**: `Switch(occurrence, arms, default)`, `Leaf(branch)`,
+   `Guard(branch, then-leaf, else-subtree)`, `Fail(verdict)`. Arms are
+   multiway: tag discriminants, int/dec literals, string arms (lowered to
+   `str_match_set`), list-length buckets (exact lengths, plus a `>= k` arm
+   when any row has a rest pattern).
+
+Algorithm:
+
+- Column selection by necessity-based heuristics (Maranget's `f`, `d`,
+  `b` combination is the reference; pick by measuring on the test corpus).
+- Specialization/defaulting of the matrix per constructor, standard
+  Maranget rules; records/tuples destructure without a test; nominal
+  patterns unwrap through the nominal operand per the 9849 rules before
+  testing the backing value.
+- **Join points for shared continuations**: each branch body is lowered
+  exactly once and bound to a LIR `join` whose params carry the branch's
+  pattern bindings; leaves `jump` to it with the bound locals. Guards lower
+  as a conditional between the body join and a jump to the residual
+  subtree (guard fallthrough re-enters the tree, never re-tests columns
+  already known).
+- **Default arms** consume the checker's committed exhaustiveness verdicts:
+  if the checker closed the match (via `closeExhaustiveVars`), the tree has
+  no `Fail` node and the last arm becomes the switch default; otherwise
+  `Fail` lowers to `runtime_error` / `comptime_exhaustiveness_failed`
+  exactly as today. Lowering must never re-derive exhaustiveness.
+- Binding order and guard side-effect order must match the current chain
+  semantics (source order of branches; guard evaluated only after its
+  branch's pattern fully matches).
+
+Document the sharing invariant explicitly (in design.md and in the module
+doc comment): Monotype expression ids referenced from multiple positions
+are duplicated downstream; sharing must go through join points. Add a
+debug-build statement-count lint: after lowering a match, assert the
+statement count is O(total pattern size) — a hard multiplier bound, using
+PR 9707's counting methodology — so exponential regressions fail loudly.
+
+Migration order:
+
+1. Extract the shared module (e.g. src/postcheck/match_tree.zig) with the
+   accessor interface; coordinate with ../big/unify-build-pipelines.md — if
+   that lands first, only one call site exists.
+2. Implement tree construction + LIR emission with statement-count tests.
+3. Switch solved_lir_lower.zig to it behind a flag; differential-test old
+   vs new across all five executors on a generated pattern corpus.
+4. Switch lir_lower.zig; delete the flag.
+5. DELETE: the per-branch tag path of `lowerBranchChain` (chained one-armed
+   `discriminantSwitch` calls and per-branch discriminant re-reads), and
+   the string-grouping special case (`strPatternBranchGroupStart`,
+   `lowerStrPatternBranchGroup`) — strings become ordinary tree arms.
+6. Re-measure src/lir/tag_reachability.zig. Keep the pass (it may still
+   catch cross-function narrowing), but quantify its remaining benefit; if
+   intra-function wins were most of it, consider disabling it at some opt
+   levels.
+
+## What success looks like
+
+- An N-branch match on tags of one scrutinee lowers to exactly ONE
+  `switch_stmt` with N arms (plus a checker-sanctioned default), with ONE
+  discriminant read.
+- PR 9707's measured counts (1136/4272/16816 for 3/4/5 branches) become
+  linear and are asserted by tests.
+- `strPatternBranchGroupStart` / `lowerStrPatternBranchGroup` no longer
+  exist; `str_match_set` is emitted by the tree like any other arm kind.
+- Both LIR pipelines call one match-compilation module; no duplicated
+  match-lowering logic remains.
+- The sharing invariant is documented and the debug statement-count lint is
+  active.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- Semantics identical to the chain, including guard side-effect order and
+  binding order.
+- Differential testing across all five executors (interpreter, dev x86-64,
+  dev aarch64, LLVM, wasm) on a generated pattern corpus: random nesting of
+  tags, records, tuples, lists (with rests), strings, literals, guards.
+- Exhaustive small-universe enumeration: for small types, run all patterns
+  × all values and compare against the interpreter.
+- The ARC certifier (src/lir/arc_certify.zig) passes: join-point
+  restructuring changes lifetimes — verify RC schedules stay balanced.
+
+### Performance ideal
+
+- Generated-code benchmarks on match-heavy code, dev backend especially (it
+  gets no LLVM cleanup): expect large wins from one switch replacing N
+  chained tests.
+- LIR statement counts asserted for representative matches.
+- tag_reachability time re-measured; the whole-program fixpoint may shrink
+  or become removable at some opt levels.
+- Compile time must not regress: decision-tree construction is near-linear
+  for typical matches; track LIR-lowering time on match-heavy modules.
+
+## Tests to add
+
+- Statement-count regression tests using PR 9707's methodology: assert
+  linear growth for the 3/4/5-branch list-match family and for N-branch
+  tag matches.
+- Differential engine tests over a generated pattern corpus (all five
+  executors agree on result and on crash/exhaustiveness diagnostics).
+- Guard-order tests: guards with observable side effects (dbg/expect) fire
+  in source branch order, and only after their pattern matches.
+- Binding-order tests: `as` and nested bindings visible to guards and
+  bodies with correct values.
+- Exhaustiveness-default-arm tests: matches where the checker committed
+  impossibility (closed ext var) lower with no `runtime_error` node; open
+  matches still produce one.
+- Nominal-record pattern tests per PR 9849 (declared field order differs
+  from backing layout order).
+
+## Related projects
+
+- [Unify the two build pipelines](../big/unify-build-pipelines.md) — removes
+  the second copy of match lowering; this project's shared module is the
+  fallback if that lands later.
+- [Checked arithmetic ops in LIR](../small/checked-arithmetic-lir-ops.md) —
+  same duplicated-lowerer failure mode; its cross-engine conformance suite
+  is the harness this project's differential tests should extend.

--- a/projects/big/exact-numeral-pipeline.md
+++ b/projects/big/exact-numeral-pipeline.md
@@ -1,0 +1,206 @@
+# A Single Exact-Numeral Pipeline
+
+## Problem
+
+A numeric literal's type and bit pattern are decided at least three times,
+by machinery that must agree by convention rather than by construction:
+
+(a) **Defaulting** ("what type does `1.5` get when nothing pins it?") is
+distributed across at least six coordinating sites:
+`finalizeLiteralDefaults`, `defaultLiteralsAtGeneralizationBoundary`,
+`runLiteralDefaultingRounds`, `commitLiteralGroupDefault`,
+`checkFlexVarConstraintCompatibility`, and `varLiteralKind` in
+src/check/Check.zig; `flexLiteralDefaultKind` in
+src/check/canonical_type_keys.zig; and `numericDefaultPhaseForConstraints`
+in src/check/checked_artifact.zig. The shared tie-break helper
+`dominantLiteralKind` in src/types/types.zig carries an in-code warning
+that the checker, the canonical-key builder, and the mono default-phase
+scan "MUST agree, or mirror-image programs get different keys/diagnostics."
+
+(b) **Checker finalization bakes concrete bits** (Dec/f64/i128) before the
+instantiation type is known. The doc comment on `lowerFracLiteral`
+(src/postcheck/monotype/lower.zig) states it plainly: "The checked stage
+finalizes a fractional literal's value to one numeric representation, but a
+generalized literal can be instantiated at a different fractional primitive
+than its finalized default."
+
+(c) **Monotype lowering converts bits across representations** to fix (b):
+`lowerFracLiteral` selects the constant kind from the instantiated type and
+converts via lossy Dec↔F64 (`FracLiteralValue.asDec` calls
+`RocDec.fromF64(...) orelse` an invariant panic; `asF64`/`asF32` go through
+`Dec.toF64`). `lowerIntLiteral` adapts int values into f32/f64/dec slots
+similarly.
+
+Each decision point has produced real bugs (see Evidence), and range/fit
+validation now exists in at least three independent implementations — one
+of which validates by reconstructing the literal's decimal TEXT from digit
+limbs.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck:
+Monotype IR → Monotype Lifted → Lambda Solved → Lambda Mono → LIR lowering →
+ARC insertion → backends. design.md at the repo root is authoritative.
+FIVE executors run Roc code (interpreter, dev x86-64/aarch64, LLVM, wasm);
+engine divergence has been the de facto bug detector, and wrong literal
+bits are exactly the kind of bug it catches late.
+
+How a literal flows today: the parser (src/parse/NumericLiteral.zig)
+records exact digit facts — the module env exposes big-endian base-256
+digit bytes via `numeralDigitsBefore` / `numeralDigitsAfter`, and the
+parser's arithmetic works in base-1e9 limbs. Canonicalization and checking
+carry a compact `NumeralInfo` (src/types/types.zig): 16 value bytes
+(i128/u128, Dec-scaled if fractional) plus flags (`is_negative`,
+`is_fractional`, `fits_dec`, `frac_requirements`). The checker defaults
+unresolved literal vars (Dec for fractional, i128-family for ints),
+finalizes a concrete representation, and the checked artifact hands
+Monotype lowering a value that lowering then re-shapes for the instantiated
+primitive (`lowerIntLiteral` / `lowerFracLiteral`).
+
+Custom number types dispatch literals through their own `from_numeral`
+method — see design.md, section "Compile-Time Literal Conversions".
+`numeralLiteralDecimalText` (src/check/checked_artifact.zig) renders a
+recorded numeral back to canonical decimal text so monotype lowering can
+fold a monomorphized `from_numeral` call into a constant.
+
+## Evidence
+
+- The "MUST agree" contract: `dominantLiteralKind` in src/types/types.zig,
+  naming `varLiteralKind` (checker), `flexLiteralDefaultKind`
+  (canonical-key builder), and `numericDefaultPhaseForConstraints` (mono
+  default-phase scan). Note: earlier notes placed `flexLiteralDefaultKind`
+  in monotype; in the code it lives in src/check/canonical_type_keys.zig,
+  and the mono-side scan is `numericDefaultPhaseForConstraints` in
+  src/check/checked_artifact.zig.
+- Bit conversion at lowering: `lowerIntLiteral`, `lowerFracLiteral`, and
+  `FracLiteralValue` (`asDec` → `RocDec.fromF64 orelse` invariant panic) in
+  src/postcheck/monotype/lower.zig.
+- Issue roc-lang/roc#9691 / PR #9701: a Dec bit pattern stored into an f64
+  constant slot; the dev backend multiplied garbage; the interpreter
+  coerced on read and masked it.
+- Issue roc-lang/roc#9693 / PR #9702: the validator checked a generalized
+  flex var against the Dec default → spurious MISSING METHOD; fixed by a
+  one-line rank guard.
+- Issue roc-lang/roc#9740: a literal in a U64-annotated recursive call arg
+  defaulted to Dec because defaulting ran before deferred recursive-def
+  constraints; fixed by annotation-peeking seeding — another guard.
+- Issues roc-lang/roc#9567 + #9561 / PR #9760: huge exponents (`1E80000`)
+  caused a parser panic and a 42-second check from reconstructing an
+  80,000-digit decimal string; fixed with exact base-256/base-1e9 digit
+  facts and u128 checked arithmetic — proving the parser already records
+  exact numeral facts sufficient for every downstream decision.
+- Issue roc-lang/roc#9565: literal range facts were discarded once the
+  union-find root became a nominal. Range/fit validation now exists in at
+  least three independent implementations: `numeralInfoFitsDec`
+  (src/check/unify.zig), `numeralLiteralFitsDec` and
+  `rangeNumeralDigitsFit` (src/check/Check.zig), and
+  `numeralLiteralFitsBuiltin` / `numeralTextFitsBuiltin`
+  (src/check/checked_artifact.zig) — the last validating against decimal
+  text reconstructed from base-256 limbs (`numeralLiteralDecimalText`,
+  `base256DecimalText`).
+
+## Solution design
+
+Carry the exact numeral as THE literal's value payload from parser through
+checking; decide the default in one module; produce bits exactly once.
+
+1. **Exact numeral payload**: `{ sign, digits (base-256 or base-1e9
+   limbs), decimal_scale }` — the facts the parser already computes (PR
+   9760). Replace `NumeralInfo`'s pre-baked 16-byte value as the source of
+   truth; small literals may keep an inline fast path (limbs that fit u128)
+   but the exact facts are always recoverable without re-reading source
+   text. Canonicalization stores this payload; checking never converts it
+   to a concrete representation.
+2. **One defaulting oracle**: a module owning "given this literal group's
+   constraints, what type does it default to?" — the logic now smeared
+   across `dominantLiteralKind` + the six sites above. Migration: every
+   current site calls the oracle first (behavior-preserving); then the
+   sites collapse — `flexLiteralDefaultKind` and
+   `numericDefaultPhaseForConstraints` become thin calls or disappear, and
+   the "MUST agree" comment is deleted because there is nothing left to
+   agree.
+3. **Range/fit validation from exact facts**: one function `fits(exact,
+   target_type) -> bool` computed on limbs (digit-count prefilter + u128
+   checked arithmetic, per 9760). It runs whenever the concrete type
+   becomes known — entirely within the checker once
+   ../small/check-app-against-platform-requires.md lands, which removes the
+   second drop site where platform-implied types arrive after checking.
+   DELETE `numeralInfoFitsDec`, `numeralLiteralFitsDec`, and the
+   text-reconstruction validation path; `rangeNumeralDigitsFit` becomes a
+   call into the shared function.
+4. **Bits produced exactly once**, at monotype lowering, for the
+   instantiated primitive, from the exact facts: exact → i8..i128/u128 by
+   limb assembly + fit check, exact → Dec by scale shift with exact
+   rounding rules, exact → f32/f64 by correctly-rounded decimal→binary
+   conversion. DELETE the finalized-bits storage in the checked stage and
+   the `FracLiteralValue` Dec↔F64 conversion lattice including its
+   `RocDec.fromF64 orelse` panic. `from_numeral` folding consumes the exact
+   payload directly instead of round-tripping through
+   `numeralLiteralDecimalText`.
+5. **Ordering interaction**: ../big/total-dispatch-plans.md requires a
+   single type-finalization point; defaulting must be complete before
+   dispatch plans freeze, so the oracle runs as part of that finalization
+   point, not scattered across generalization boundaries.
+
+Unrepresentable literals become check-time errors at step 3; lowering-time
+panics for representability are deleted, not relocated.
+
+## What success looks like
+
+- One function decides literal defaults; one function produces literal
+  bits; one function answers fit questions.
+- The "MUST agree" comment in src/types/types.zig and its three coordinated
+  sites are gone.
+- `FracLiteralValue`'s conversion lattice and its invariant panic no longer
+  exist in src/postcheck/monotype/lower.zig.
+- No code path reconstructs decimal text to validate or convert a literal.
+- Repros for 9691, 9693, 9740, 9567, 9561, and 9565 all pass.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- Property tests: for every primitive numeric type and every representable
+  exact numeral, literal → bits → value round-trips exactly; for f32/f64
+  the produced bits equal correctly-rounded decimal conversion.
+- Unrepresentable literals are check-time errors, never lowering panics —
+  fuzz literals at type boundaries (max_i128 ± 1, Dec scale edges, f32
+  overflow thresholds) at multiple instantiation types.
+- Cross-engine agreement on literal-heavy programs (all five executors),
+  including `from_numeral` custom types.
+
+### Performance ideal
+
+- Check time bounded on adversarial literals: `1E80000` must stay fast —
+  keep PR 9760's regression tests with a time bound.
+- No decimal-text reconstruction anywhere in the pipeline (grep-able:
+  `numeralLiteralDecimalText` and `base256DecimalText` callers limited to
+  error reporting, or deleted).
+- Defaulting oracle O(1) per literal group — no per-literal re-scans at
+  every generalization boundary; measure check time on modules with tens of
+  thousands of literals.
+- Generated code unchanged or better: constants are already folded; verify
+  no new lowering-time cost from limb conversion (it replaces conversion
+  work, not adds to it).
+
+## Tests to add
+
+- Repro suite: 9691 (Dec bits in f64 slot), 9693 (generalized flex var vs
+  Dec default), 9740 (U64-annotated recursive call arg), 9567/9561 (huge
+  exponents), 9565 (range facts through nominal roots).
+- Property round-trip tests as described above, per primitive type.
+- The 9760 performance tests with explicit time bounds.
+- Cross-engine literal conformance programs, run in the harness from
+  ../small/checked-arithmetic-lir-ops.md.
+- A test that mirror-image programs (same literals, swapped branch order)
+  produce identical types, keys, and diagnostics — the failure mode the
+  "MUST agree" comment warned about.
+
+## Related projects
+
+- [Check app against platform requires](../small/check-app-against-platform-requires.md)
+  — removes the post-checking type-arrival path this design depends on.
+- [Total dispatch plans](../big/total-dispatch-plans.md) — defines the
+  single type-finalization point the defaulting oracle plugs into.
+- [Checked arithmetic ops in LIR](../small/checked-arithmetic-lir-ops.md)
+  — its cross-engine conformance suite hosts the literal tests.

--- a/projects/big/generalization-time-ambiguity.md
+++ b/projects/big/generalization-time-ambiguity.md
@@ -1,0 +1,256 @@
+# Replace the Dispatch Ambiguity Sweep with a Generalization-Time Rule
+
+## Problem
+
+A static dispatch is *ambiguous* when the receiver's type variable can never
+be pinned to a concrete type by anything in the program — no argument, no
+annotation, no data flow determines it. Such a dispatch has no principled
+target; if it survives checking, monomorphization either picks arbitrarily or
+crashes. Issue roc-lang/roc#9485 showed the stakes: `roc check` reported a
+clean program while `roc build` produced undefined behavior, because a
+dispatch receiver was an unpinnable flex var.
+
+PR roc-lang/roc#9504 fixed this by rejecting ambiguous dispatch at check time
+— but its mechanism is a whole-CIR post-pass that *reconstructs* pinnability
+after the fact, because the information needed to judge ambiguity was not
+kept when the constraint was created. In `src/check/Check.zig` today:
+
+- `collectPinnableVars` walks the module collecting every var reachable
+  through argument positions and lambda parameters ("someone could pin this
+  from outside").
+- `collectDataReachableVars` implements a data-position test.
+- `instantiateVarHelp` records per-instantiation receivers so
+  `reportAmbiguousStaticDispatchPerInstantiation` can judge instantiated
+  copies; `reportAmbiguousStaticDispatch` judges the rest.
+- Side tables map vars back to source expressions across instantiation:
+  `constraint_fn_var_map`, `constraint_expr_by_fn_var`,
+  `expect_region_by_constraint_fn_var` (added/extended by PR
+  roc-lang/roc#9660 for nested where-clauses).
+- Special carve-outs exempt `from_numeral` (literal) and `is_eq` constraints
+  (see the "non-literal/non-`is_eq` dispatch constraint" bookkeeping around
+  the sweep's worklists).
+- PR roc-lang/roc#9819 threaded `discarded_binding_rhs_expr` so discarded
+  `_ =` bindings are judged correctly.
+- PR roc-lang/roc#9746 added a `body_required` bit on where-clause constraint
+  origins (`src/types/types.zig`, `where_clause: struct { body_required: bool
+  = false }`), set by fn-name matching in `src/check/Check.zig` (the
+  `backing[i].fn_name.eql(constraint.fn_name)` loop) and preserved across
+  unification merges in `src/check/unify.zig` — where a comment documents
+  that the bit is deliberately dropped for `from_literal`/operator origins.
+  The sweep is now a four-way decision table over constraint origins.
+
+This reconstruction has misfired in both directions: false positives (issue
+roc-lang/roc#9632 — valid recursive method calls rejected; fixed by PR
+roc-lang/roc#9664) and false negatives (issues roc-lang/roc#9657 and #9815 —
+ambiguous programs accepted, #9815 reaching a runtime crash). Each fix adds
+another side table or origin bit. The sweep grows because it stands at the
+wrong place: it tries to recover, module-wide and after the fact, a judgment
+that is local and cheap at the moment a type variable generalizes.
+
+## Background
+
+The compiler pipeline is: parse → canonicalize → type-check (producing
+"checked artifacts" per module; all user-facing diagnostics end here) →
+postcheck: Monotype IR (monomorphization/specialization,
+`src/postcheck/monotype/`) → Monotype Lifted (closure lifting) → Lambda
+Solved → Lambda Mono → LIR lowering (`src/postcheck/solved_lir_lower.zig`) →
+ARC insertion (`src/lir/arc*.zig`) → backends. `design.md` at the repo root
+is the authoritative post-check design; its Core Principles require all
+user-facing failures to be reported during checking, and forbid later stages
+from recovering missing facts — which is why ambiguity *must* be a check-time
+error and why the monotype stage's crash fallback for it (see Related
+projects) is a design violation.
+
+Key type-checker concepts:
+
+- *Flex var*: an unsolved type variable. *Rigid var*: a variable bound by an
+  annotation. Static dispatch constraints (`where a.method : ...`, or
+  implicit ones from method calls, literals via `from_numeral`, and operators
+  like `is_eq`) attach to variables.
+- *Generalization*: when a definition's type is finalized, unsolved variables
+  local to it are promoted into a *scheme* (a polymorphic type). Each use
+  *instantiates* the scheme with fresh variables.
+- A dispatch-constrained variable is legitimate in a scheme if a *use site
+  can pin it* — i.e. it is reachable from the scheme's argument or data
+  positions, so instantiation at a concrete type determines the dispatch. It
+  is *ambiguous* if it appears nowhere a caller can influence (the classic
+  example: a variable appearing only in constraints, like Haskell's
+  `show . read`).
+- Haskell performs exactly this judgment as the *ambiguity check* at
+  generalization time. That is the model here.
+
+Why the sweep exists instead: rank information is not usable for this
+judgment in the current solver — the generalizer promotes orphan vars to
+generalized rank, erasing the distinction the check needs — and the
+constraint store lacks *provenance*: when a constraint is created there is no
+durable record of which expression introduced it and in what role, so error
+reporting after the fact requires the side tables listed above.
+
+## Evidence
+
+All symbols verified in the current tree; search `src/check/Check.zig` for
+`reportAmbiguousStaticDispatch` and `collectPinnableVars` to find the sweep.
+
+- `src/check/Check.zig`: `collectPinnableVars`, `collectDataReachableVars`,
+  `reportAmbiguousStaticDispatch`,
+  `reportAmbiguousStaticDispatchPerInstantiation`, `instantiateVarHelp`
+  (constraint-metadata copying), fields `constraint_fn_var_map`,
+  `constraint_expr_by_fn_var`, `expect_region_by_constraint_fn_var`,
+  `discarded_binding_rhs_expr`; the sweep runs from `checkFileInternal` after
+  def checking.
+- `src/types/types.zig`: constraint origin union with `where_clause { body_required }`,
+  `method_call`, `from_literal`, `desugared_binop`, `desugared_unaryop`.
+- `src/check/unify.zig`: the constraint-merge logic preserving/promoting
+  `body_required`, with the comment explaining why `from_literal`/operator
+  origins deliberately drop it.
+- History: PR #9504 (introduced sweep; fixed issue #9485), PR #9660 (nested
+  where-clauses; added the var→expr side tables), PR #9762 and PR #9819
+  (further tuning; discarded `_ =` bindings), PR #9746 (`body_required`),
+  issue #9632 / PR #9664 (false positive on recursive method calls), issues
+  #9657 and #9815 (false negatives; #9815 escaped to a runtime crash in
+  monotype lowering).
+
+## Solution design
+
+Enforce ambiguity **at the moment of generalization**: when a
+dispatch-constrained type variable is about to be generalized into a scheme
+without being reachable from the scheme's argument or data positions, report
+the error right there, pointing at the dispatch site that introduced the
+constraint.
+
+1. **Constraint provenance (foundation).** Extend the static dispatch
+   constraint record so that every constraint carries, from creation:
+   - the introducing expression (`CIR.Expr.Idx`) and region,
+   - its role (where-clause of an annotation, method call, literal
+     `from_numeral`, desugared operator — the origin union already encodes
+     role; add the expression/region payload to it),
+   - and make instantiation copy provenance verbatim (instantiated
+     constraints point at the original introducing site).
+   This replaces the after-the-fact var→expr side tables: provenance travels
+   *inside* the constraint instead of alongside it in maps keyed by mutable
+   vars.
+2. **The generalization-time rule.** At generalization of a definition:
+   - compute the set of variables reachable from the scheme's argument and
+     data positions (a local traversal of the def's type, not the module —
+     this is the existing `collectDataReachableVars` logic scoped to one
+     scheme);
+   - for each variable being generalized that carries a dispatch constraint
+     whose role requires pinning (where-clause with a forcing body, method
+     call; literals default instead, `is_eq` resolves structurally), check
+     membership;
+   - if unreachable, emit the ambiguity diagnostic using the constraint's
+     provenance: "this method call's receiver type can never be determined",
+     pointing at the introducing expression.
+   Recursive definitions judge against the fully-solved scheme (the #9632
+   lesson: a constraint on the function's own type variable that unifies with
+   the definition's scheme is not ambiguous).
+3. **Literal and operator handling.** `from_literal` constraints are pinned
+   by numeric defaulting, which runs before generalization finalizes — the
+   rule sees them already solved, so no carve-out logic is needed; the same
+   for structural `is_eq`. What remains is a single reachable-or-error
+   judgment, not a four-way origin table.
+4. **Deletions.** After the rule lands and the regression corpus passes,
+   delete from `src/check/Check.zig`: `collectPinnableVars`,
+   `reportAmbiguousStaticDispatch`,
+   `reportAmbiguousStaticDispatchPerInstantiation`, the per-instantiation
+   receiver recording in `instantiateVarHelp`, `constraint_fn_var_map`,
+   `constraint_expr_by_fn_var`, `expect_region_by_constraint_fn_var`,
+   `discarded_binding_rhs_expr` threading, and the sweep invocations in
+   `checkFileInternal`. `body_required` in `src/types/types.zig` and its
+   unify.zig merge logic go too if provenance + the local rule subsume them
+   (the "body forces this where-clause" fact becomes: the constraint's
+   introducing site is a body dispatch — provenance carries it).
+5. **Migration order.** (a) add provenance to constraint creation and
+   instantiation (mechanical, no behavior change); (b) implement the
+   generalization-time rule behind a debug flag that runs *both* rule and
+   sweep, logging disagreements; (c) burn down disagreements against the
+   regression corpus (all five Evidence issues); (d) flip to the rule alone
+   and delete the sweep in one PR.
+
+Interaction with total dispatch plans: that project's `constraint(k)`
+representation (see Related projects) gives each where-clause constraint a
+stable index and site — natural provenance. Either project can land first,
+but they share the constraint-provenance foundation; build it once so both
+consume the same record.
+
+## What success looks like
+
+- Ambiguity is judged by a local rule inside generalization; no whole-module
+  pass named `reportAmbiguousStaticDispatch*` or `collectPinnableVars`
+  exists in the tree.
+- The three var→expr side tables and `discarded_binding_rhs_expr` are gone
+  from `src/check/Check.zig`.
+- The #9632 repro (recursive method calls) is accepted; the #9485, #9657,
+  #9815, and #9819 discarded-binding repros are rejected at check time, each
+  diagnostic naming the introducing dispatch site.
+- Every ambiguity diagnostic points at an expression the user wrote, derived
+  from stored provenance rather than reconstructed mappings.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+The rule is a *local judgment at generalization*: its inputs are one scheme,
+its constraint set, and per-constraint provenance — never a module-wide
+traversal. Invariants and enforcement points:
+
+- *No dispatch-constrained var generalizes unpinnably*: enforced inside the
+  generalizer itself; in debug builds, additionally assert at artifact
+  publication that every generalized var carrying a pin-requiring dispatch
+  constraint is argument/data-reachable in its scheme (a cheap re-walk, debug
+  only).
+- *Provenance totality*: debug-assert at constraint creation and at
+  instantiation copy that every dispatch constraint has an introducing
+  expression/region.
+- *Downstream corollary*: monotype lowering never sees an unpinned dispatch
+  receiver — the crash fallback for it can be deleted (coordinated with the
+  total-dispatch-plans project).
+- Maintain a false-positive/false-negative regression corpus built from all
+  five issues (#9485, #9632, #9657, #9815, #9819's case) plus the existing
+  snapshot suite; the rule must match the corpus exactly, with no
+  origin-specific carve-out code paths left to drift.
+
+### Performance ideal
+
+Check time strictly improves: the sweep's whole-CIR passes
+(`collectPinnableVars` over every def, per-instantiation receiver recording
+in `instantiateVarHelp`, the final report passes in `checkFileInternal`)
+disappear, replaced by an O(scheme size) traversal per generalized
+definition. Instantiation gets cheaper: no side-table writes per instantiated
+constraint (provenance is copied inline with the constraint it already
+copies). Measure `roc check` wall time on a module-heavy corpus (the builtins
+plus a many-module app or package workspace) before and after; expect neutral
+to slightly faster, and any regression in single-module check time is a bug.
+Memory: three hash maps per Check instance are removed; constraint records
+grow by one expr index + region, which must not measurably increase peak
+check memory.
+
+## Tests to add
+
+- Acceptance: the #9632 recursive-method-call repro stays accepted (guard
+  against reintroducing the false positive).
+- Rejection with provenance: #9485, #9657, #9815, and the #9819 discarded
+  `_ =` binding case each rejected at check time; snapshot the diagnostics
+  and assert they name the introducing dispatch expression's region.
+- Scheme-position matrix: dispatch-constrained var reachable via (a) direct
+  argument, (b) nested data position inside an argument, (c) return-only
+  position, (d) constraint-only position — (a)/(b) accepted, (c)/(d) rejected
+  per the rule's definition of pinnable.
+- Instantiation provenance: a generic function whose ambiguous constraint is
+  introduced in module A and instantiated in module B reports against the
+  site in A.
+- Literal/operator non-interference: numeric-literal-only and `==`-only
+  programs never trigger the rule (defaulting/structural resolution pins
+  them first).
+- Differential harness (temporary, during migration step b): run sweep and
+  rule together over the snapshot corpus and fail on any disagreement.
+
+## Related projects
+
+- [../big/total-dispatch-plans.md](../big/total-dispatch-plans.md) — shares
+  the constraint-provenance foundation; its `constraint(k)` indices are
+  natural provenance carriers. Either order works; build provenance once.
+- [../small/check-app-against-platform-requires.md](../small/check-app-against-platform-requires.md)
+  — upstream of both dispatch projects: platform-typed receivers must be
+  concrete at check time for pinnability judgments to be meaningful in app
+  modules.

--- a/projects/big/immutable-specialization-identity.md
+++ b/projects/big/immutable-specialization-identity.md
@@ -1,0 +1,240 @@
+# Immutable Specialization Identity
+
+## Problem
+
+The identity of a Monotype specialization — the key that decides whether a
+call site reuses an existing lowered function or creates a new one — has been
+redefined four times in six weeks, and the current definition is still wrong
+in one fundamental way: **the key is mutable**. A specialization's identity
+includes its closed monomorphic function type, but that type is an *output*
+of lowering the specialization's own body (body evidence refines the
+requested type). So the compiler rekeys specialization records mid-flight,
+maintains dual "request"/"solved" lookup entries, and synchronizes at least
+four parallel lookup structures by hand inside
+`src/postcheck/monotype/lower.zig`.
+
+The four redefinitions:
+
+1. **Pre-rework:** identity was an `Ast.FnTemplate` value (fn-def reference +
+   SHA-256 digest of the source type + an un-interned mono `TypeId`). The
+   Monotype builder compared these by struct equality, but the closure lifter
+   *recomputed* digests and compared those — two inconsistent equality
+   relations over the same conceptual key. Result: issue roc-lang/roc#9519,
+   "Monotype function template was assigned two lifted function ids" (that
+   invariant string still exists, reworded, in
+   `src/postcheck/monotype_lifted/lift.zig`), flaky depending on file-split
+   order.
+2. **PR roc-lang/roc#9639:** an explicit `Ast.FnId` assigned once at lowering
+   time, so downstream passes stop re-deriving identity.
+3. **PR roc-lang/roc#9848** (+16,516 / −4,986 lines across 57 files,
+   motivated by issue roc-lang/roc#9802: seconds spent specializing a small
+   generic higher-order app — the pre-fix lookup scanned every
+   `LoweredTemplate` in a family and recomputed a full recursive SHA-256
+   `typeDigest` per candidate, roughly O(n³) in call sites): a new
+   `SpecBuilder` in `src/postcheck/monotype/specialize.zig` keyed by
+   `SpecLookupDigest`, with exact structural `typeEql` as the collision
+   authority; `src/postcheck/monotype/type.zig` became a proper interner with
+   per-node cached child-derived digests; draft graph-owned type cells sealed
+   once (`DraftTypeCell`, defined in `lower.zig`); and
+   `src/postcheck/monotype/serialize.zig` added an on-disk specialization
+   cache (magic bytes `ROCSPEC`).
+4. **Separately, PR roc-lang/roc#9593** added
+   `src/postcheck/monotype_lifted/spec_constr.zig`, which keys *its*
+   specializations by call-pattern shape (`CallPattern`) — a second
+   specialization space with its own identity rules.
+
+Each redefinition fixed real bugs and introduced new ones. The last two fixes
+in this area produced fresh regressions: issue roc-lang/roc#9889 (roc-parser
+`numbers.roc` crashes in monotype_lifted after PR #9848) and issue
+roc-lang/roc#9890 (`letters.roc` crashes in monotype lowering after PR
+roc-lang/roc#9873). The root cause is not any single bug; it is that identity
+mutates, so every structure that indexes by identity needs a second entry and
+a manual synchronization step, and every new consumer gets one of them wrong.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check (produces "checked
+artifacts" per module) → postcheck: **Monotype IR**
+(monomorphization/specialization, `src/postcheck/monotype/` — `lower.zig` is
+~21k lines and owns type lowering, dispatch resolution, specialization, and
+statement lowering) → **Monotype Lifted** (closure lifting; also
+`spec_constr.zig` call-pattern specialization for optimized builds) →
+**Lambda Solved** → **Lambda Mono** → **LIR** → **ARC** → backends.
+
+`design.md` at the repo root is authoritative. Its "Monotype Specialization"
+section documents the intended shapes: `SpecIdentity` (callable identity +
+source-fn-type digest + closed mono-fn-type digest + mono `TypeId`),
+`SpecStatus` (`reserved` → `lowering` → `ready`), and `SpecRecord`. These are
+implemented in `src/postcheck/monotype/ast.zig` (`CallableIdentity`,
+`SpecIdentity`, `SpecStatus`, `SpecRecord`).
+
+Why the type is an output: Monotype lowering solves each specialization in an
+instantiation graph (`src/postcheck/monotype/solve.zig` — "Monotypes are
+materialized views of solved nodes, refilled in place when their node gains
+evidence"). A template is *reserved* at the requested type, its body is
+lowered, and body evidence (numeric defaults, row evidence, empty-tag-union
+resolution) can produce a more specific *solved* type. Ready entries flow
+their solved type back into requesters (see the comment above
+`Builder.lowerTemplateWithMonoFor` in `lower.zig`). `design.md` also fixes
+the one-way
+snapshot rule: "A Monotype imported into another specialization's graph is a
+finished snapshot, never a refreshable view" — a specialization that needs
+more than its requested type is a unification conflict, not a silent rewrite.
+
+## Evidence
+
+All in `src/postcheck/monotype/` unless noted; symbols verified.
+
+- `lower.zig` `Builder` fields — the manually-synced lookup structures:
+  `spec_store: specialize.SpecBuilder`, `lowered_template_lookup:
+  AutoHashMap(TemplateSpecLookup, ArrayList(u32))`, `lowered_nested_lookup:
+  AutoHashMap(NestedSpecLookup, ArrayList(u32))`, the generated-helper caches
+  `inspect_defs`/`equality_defs`/`hash_defs` (keyed by
+  `GeneratedHelperDefAddress`), plus side indices `lowered_template_by_fn`,
+  `lowered_template_by_def`, `lowered_nested_by_fn`.
+- Dual lookup kinds: `SpecLookupKind = enum { request, solved }`;
+  `TemplateSpecLookup`/`NestedSpecLookup` embed it; `findLoweredTemplate`
+  probes `.request` first, then `.solved` (ready entries only).
+- `lower.zig` `markTemplateReady`: mutates the `LoweredTemplate` in
+  `lowered_templates`, rebuilds the record's `SpecIdentity` with the solved
+  type, calls `spec_store.updateLocalIdentity` to REKEY the spec record
+  mid-flight, appends a second `.solved` lookup entry via
+  `appendTemplateLookup`, and `markReady` pokes the record. The nested-fn
+  path repeats the same dance (two more `updateLocalIdentity` call sites).
+- `specialize.zig` `SpecBuilder.updateLocalIdentity`: overwrites
+  `record.identity` and appends the record under the new
+  `SpecLookupDigest` — while the entry under the *old* digest is never
+  removed, so one record is reachable from two keys.
+- Direct status pokes bypassing the builder API:
+  `self.program.specs.items[@intFromEnum(existing.spec)].status = .lowering;`
+  appears twice in `lower.zig` (in the template reuse paths), alongside the
+  official `SpecBuilder.markLowering`/`markReady`.
+- `specialize.zig` `Queue.enqueue` linear-scans `entries.items` with
+  `specEql` per insertion — O(n²) across a compilation.
+- Cross-store equality: `Type.typeEqlAcrossStores` (in `type.zig`) and
+  `SpecBuilder.entryMatches` compare a local requested type against a loaded
+  cache record's type; these must agree with the one-way snapshot rule above.
+- Regressions: issues roc-lang/roc#9889 and roc-lang/roc#9890 (see Problem).
+- Historical: issue roc-lang/roc#9519; `Ast.FnTemplate`,
+  `fnTemplateIdentityEql`, `fnTemplateDigest` still exist in `ast.zig` and
+  feed `specialize.zig`'s queue `Spec.fn_def`.
+
+## Solution design
+
+**Make the key immutable.** `SpecIdentity` becomes `(CallableIdentity, digest
+of the closed REQUESTED function type)` — nothing else. The solved/refined
+type becomes *data* on the `SpecRecord` (a `solved_fn_ty: Type.TypeId` field,
+plus its cached digest), never a rekey. Requesters read the solved type
+through the record. If `source_fn_ty_digest` is still needed to separate
+distinct checked source types that close to the same mono type, fold it into
+`CallableIdentity` so the only type in the key is the requested type.
+
+Steps, in migration order:
+
+1. **Add `solved_fn_ty`/`solved_digest` to `SpecRecord`** (`ast.zig`),
+   defaulting to the requested type at reservation. `SpecBuilder.markReady`
+   takes the solved type and writes it here. Bump the `ROCSPEC` cache format
+   in `serialize.zig` (records change layout; loaded records carry both).
+2. **Replace rekeying with alias entries.** When a record becomes ready and
+   its solved digest differs from its request digest, `SpecBuilder` adds an
+   *additional* lookup entry `solved_digest → record` — an alias, not a
+   rekey. `record.identity` is written once at `reserve` and never again.
+   This makes the requested-type → record map explicitly many-to-one. The
+   join rule lives in `SpecBuilder.find`: a request matches a record if the
+   callable matches and the requested type is structurally equal
+   (`typeEql`/`typeEqlAcrossStores`) to either the record's requested type or
+   its solved type (solved only when status is `.ready`, mirroring today's
+   `findLoweredTemplateInLookup` guard). A request whose type is LESS
+   specific than the solved type therefore reuses the record through the
+   request-digest alias; it never widens the record (one-way snapshot rule).
+3. **Collapse the parallel tables into `SpecBuilder`.** Move the roles of
+   `lowered_template_lookup` and `lowered_nested_lookup` into `SpecBuilder`'s
+   single `lookup` map; `LoweredTemplate`/`LoweredNestedFn` keep only
+   pass-local lowering state (def/fn ids, status mirror if needed), not
+   digests. `lowered_template_by_fn`/`by_def`/`lowered_nested_by_fn` become
+   derived indices owned by `SpecBuilder` or are replaced by fields on the
+   record.
+4. **Single mutation API.** `SpecBuilder` owns the status machine
+   `reserved → lowering → ready` behind `reserve`/`markLowering`/
+   `markReady(solved_ty)`. Delete the two direct
+   `program.specs.items[...].status = .lowering` pokes in `lower.zig`.
+5. **DELETE:** `SpecBuilder.updateLocalIdentity`; `SpecLookupKind` and the
+   dual `.request`/`.solved` key kinds; `TemplateSpecLookup` and
+   `NestedSpecLookup` plus the two maps; `appendTemplateLookup` /
+   `findLoweredTemplateInLookup` (folded into `SpecBuilder`); the mutable
+   `identity.mono_fn_ty`/`mono_fn_ty_digest` rewrite in `markTemplateReady`;
+   the legacy `Ast.FnTemplate`-keyed queue `Spec.fn_def` once the queue
+   carries `SpecId`s.
+6. **Fix `Queue.enqueue`** with a hash set (`AutoHashMap` over the same
+   digest key), O(1) membership; keep the `ArrayList` for FIFO order.
+7. **Optional last:** route the generated-helper caches
+   (`inspect_defs`/`equality_defs`/`hash_defs`) through
+   `CallableIdentity.generated` so `SpecBuilder` is the only specialization
+   index in the pass. `spec_constr.zig`'s call-pattern space stays separate
+   (it specializes on value shape, not type), but document the boundary.
+8. **Debug validator** (comptime-gated): after lowering, walk
+   `SpecBuilder.lookup` and assert every record is reachable from exactly the
+   keys that map to it (its request digest, plus its solved digest iff ready
+   and different) and from no others; assert `record.identity` equals the
+   identity captured at `reserve` (store a creation-time copy in debug
+   builds, or make the field `const`-like via an opaque write-once wrapper).
+
+## What success looks like
+
+- The issue #9889 and #9890 repros compile and pass.
+- No rekeying API exists: `updateLocalIdentity` is deleted and nothing
+  mutates `SpecRecord.identity` after `reserve`.
+- One lookup structure (`SpecBuilder.lookup`) answers every specialization
+  reuse question in `lower.zig`; `lowered_template_lookup`,
+  `lowered_nested_lookup`, and `SpecLookupKind` no longer exist.
+- Status transitions happen only through `SpecBuilder`; grepping for
+  `.status =` outside `specialize.zig` finds nothing in the pass.
+- `Queue.enqueue` is O(1); the debug validator passes on the full test corpus.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+Identity is assigned once at record creation and is provably never used as a
+map key after mutation — because mutation is impossible (write-once field,
+alias entries instead of rekeys). The debug validator asserts every spec
+record is reachable from exactly the keys that map to it, on every test-suite
+run. Cross-store matching (`entryMatches`/`typeEqlAcrossStores`) and local
+matching implement the same join rule, verified by unit tests that load a
+`ROCSPEC` shard and issue requests at request-shaped and solved-shaped types.
+
+### Performance ideal
+
+O(1) expected lookup preserved (digest-keyed hash map with exact `typeEql`
+only on digest collision); zero SHA-256 recomputation on the lookup path (the
+per-node child-derived digest caching from PR #9848 stays); `enqueue` O(1).
+Measure with issue #9802's benchmark (a `map2`-style generic higher-order app
+with 63 call sites) and a nested structural accumulator variant; track wall
+time and the `SpecializationCounters` statement/candidate counts
+(`template_lookup_candidates`, `exact_type_checks`). Consider truncating
+in-memory lookup digests to 128 bits (collision authority remains exact
+`typeEql`), keeping full 256-bit digests only in the `ROCSPEC` file.
+
+## Tests to add
+
+- Issue #9889 / #9890 repros: roc-parser `numbers.roc` and `letters.roc` run
+  via `roc test --no-cache`, added to the CLI test corpus.
+- Issue #9519 flaky-identity repro: the same generic function reached via two
+  file-split orders must produce one lifted function id (assert the
+  `lift.zig` invariant never fires; run with both module orderings).
+- Issue #9802 perf benchmark with an enforced bound on time and on the
+  specialization counters (fail if candidate scans regress past a threshold).
+- `SpecBuilder` unit tests (extend the existing ones in `specialize.zig`):
+  alias-entry reuse at a less-specific requested type; no reuse across
+  distinct callables with equal types; loaded-shard matching through
+  `typeEqlAcrossStores`; validator catches a hand-corrupted identity.
+- A debug-mode CI run of the existing corpus with the validator enabled.
+
+## Related projects
+
+- [Content-Based Nominal Identity](../big/content-based-nominal-identity.md)
+  — cleaner `CallableIdentity` components.
+- [Total Dispatch Plans](../big/total-dispatch-plans.md) — removes the other
+  large identity-rederivation surface in `lower.zig`.
+- [Debug Generation Counters on Growable Stores](../small/store-generation-counters.md)
+  — guards `program.specs`/`program.fns` borrow hazards in the same pass.

--- a/projects/big/row-subsumption.md
+++ b/projects/big/row-subsumption.md
@@ -1,0 +1,223 @@
+# Row Subsumption as a First-Class Judgment
+
+## Problem
+
+The type system has no row subtyping. A value whose tag row is CLOSED (for
+example a callee's error union `[InnerErr]`) cannot unify with an OPEN but
+RIGID annotated row (`[InnerErr, ..]` from a function's `Try` annotation),
+even though using the narrower value at the wider type is semantically valid:
+every tag the value can carry is one the annotation admits.
+
+Users hit this with `?`, the early-return error-propagation operator. Issue
+roc-lang/roc#9798: calling `inner({})?` inside a function annotated
+`Try({}, [InnerErr, ..])` was rejected, while the equivalent explicit `match`
+type-checked. The `match` works because re-tagging (`Err(e) => Err(e)`)
+constructs a fresh value whose row variables are fresh and open, so they
+unify with the annotation; the `?` condition's type is the callee's return
+type itself, closed row and all.
+
+PR roc-lang/roc#9834 fixed only that one construct, and did so by mutating
+the union-find graph mid-inference (`dangerousSetVarRedirect`). The fix
+applies exclusively to desugared `?` conditions. Any other construct with the
+same closed-into-open shape — returning a stored closed `Try` value from a
+function with an open-row annotation, pipeline combinators, or any future
+syntax — needs its own copy of the special case, each with its own
+hand-written row-inclusion probe and its own union-find rewrite.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check (src/check/Check.zig;
+unification in src/check/unify.zig) → checked artifacts → postcheck:
+Monotype IR → Lifted → Lambda Solved → Lambda Mono → LIR → ARC → backends.
+design.md at the repo root is authoritative for pipeline design.
+
+Rows are how records and tag unions are typed. A row is a set of labels
+(fields or tags) plus an extension: a row can be OPEN (its extension is a
+type variable, so more labels may exist) or CLOSED (empty extension; the
+listed labels are all there are). An open row's extension variable can be
+FLEX (inference may bind it freely) or RIGID (it came from a user annotation
+and must not be bound to new structure — doing so would let inference invent
+types the user did not write).
+
+Unification is equational: it makes two types identical, it never proves one
+is usable AT the other. Unifying closed `[InnerErr]` with rigid-open
+`[InnerErr, ..a]` fails because success would require binding the rigid
+extension `..a` to the empty row. Subsumption — "a closed row may be USED
+where a wider row is expected" — is a different judgment, and today the
+checker does not have it.
+
+Related row handling that is already sound and NOT in scope here:
+
+- Postcheck rows were fixed structurally: rows stay open inside the
+  per-specialization instantiation graph and are only defaulted/closed at
+  sealing (`GraphTypeFinals`, `sealNode`/`sealType` in
+  src/postcheck/monotype/solve.zig).
+- Record destructures are closed by default (PR roc-lang/roc#9687).
+- Open rows are banned at host boundaries (PR roc-lang/roc#9870).
+
+The remaining gap is checker-side: subsumption at annotated use positions.
+
+## Evidence
+
+- Issue roc-lang/roc#9798; fix PR roc-lang/roc#9834
+  (merge commit 7199fe106d, branch `fix-9798/question-open-error-row`).
+- src/check/Check.zig — PR 9834's legitimate plumbing: the `Expected` struct
+  gained `return_result: ?Var` plus the `returnResult()` accessor, and the
+  derived-expectation constructors (`forBranchBody`, `forStatement`, etc.)
+  thread it through nested statements so `?` and `return` can unify against
+  the ENCLOSING function's return type. This part should stay.
+- src/check/Check.zig — the workaround: when checking a `match` with
+  `match.is_try_suffix` set (`?` desugars to such a match), after unifying
+  the condition with the builtin `Try` type, the checker calls
+  `widenTryConditionForExpectedReturn(cond_var, expected_return, ...)`.
+  That function:
+  - `tryErrorRowNeedsUseSiteWidening` first tries an ordinary probe
+    unification (`probeCanUseAs`, rolled back either way); only if that
+    fails does it run the hand-written inclusion check.
+  - `actualTagRowIsIncludedInExpected`, with helpers
+    `expectedTagRowContainsTag`, `findVisibleTagInRow`, and
+    `tagsCanUseSamePayloads`, is a bespoke one-shot structural walk proving
+    every tag of the actual row appears in the expected row.
+  - On success it mints a fresh `Try(ok, expectedErr)` var and REWRITES THE
+    UNION-FIND GRAPH: `self.types.dangerousSetVarRedirect(cond_root,
+    widened_try_var)`.
+- src/types/store.zig — `dangerousSetVarRedirect` carries the codebase's own
+  warning: "During type-checking, you probably don't want to use this
+  function. ... it's possible to loose `rank` information! You should prefer
+  to use regular `unify`". Check.zig has exactly two call sites: the
+  widening path above, and `markErroneousBranchWithExpected` (error
+  poisoning after a reported problem — out of scope for this project).
+- src/postcheck/monotype/solve.zig — instantiation-graph sealing, showing
+  the postcheck side already treats row openness structurally.
+
+## Solution design
+
+**A LANGUAGE-SEMANTICS DECISION IS REQUIRED FIRST.** Before any code is
+written, decide: at which positions may a value of a smaller CLOSED tag
+union be used at a BIGGER union type? This is a language design question,
+not an implementation detail, and the answer determines which of the two
+designs below is built. Both designs share the same machinery; they differ
+only in where the judgment is invoked.
+
+**Design A — subsumption at annotated-use positions.** One function,
+`rowSubsumes(actual, expected)`, invoked at:
+
+1. `?` conditions (the 9798 case),
+2. return positions (explicit `return` and function-final expressions)
+   checked against an annotated return type,
+3. use sites of annotated bindings (a stored closed `Try` value used where
+   an open-annotated type is expected).
+
+**Design B — restrict to today's `?`-only behavior**, but re-implement it as
+the same judgment plus explicit coercion, deleting the union-find rewrite.
+Semantics stay exactly as after PR 9834; only the mechanism changes.
+
+Shared machinery, step by step:
+
+1. Implement `rowSubsumes(actual, expected)` next to unification: actual
+   must be a closed (or error/empty) tag row; every tag of actual must be
+   present in expected with payloads that themselves unify (payloads stay
+   equational — subsumption is shallow at first; document this). The
+   existing `actualTagRowIsIncludedInExpected` walk is a starting sketch of
+   the logic, but the new judgment must be specified, named, and tested as
+   THE row-subsumption judgment, not a `?`-local probe.
+2. On success, do NOT touch the union-find graph. Instead emit an EXPLICIT
+   coercion node in the checked output — a re-tag conversion carried in the
+   checked expression data (`CheckedExprData` in
+   src/check/checked_artifact.zig), wrapping the coerced expression. This
+   matches design.md's principle that post-check consumes explicit checked
+   data rather than re-deriving decisions. The coercion is exactly what an
+   explicit `match` does implicitly today.
+3. The coercion node's data structure carries BOTH types: the actual
+   (source) row and the expected (target) row, as checked type references.
+   Lowering must be total from the node alone — no re-inference.
+4. Lowering (src/postcheck/monotype/lower.zig): for tag unions whose source
+   and target representations are identical (same discriminants, same
+   payload layouts), the coercion lowers to a no-op. Otherwise it lowers to
+   a discriminant remap (and payload move if layouts differ).
+5. Exhaustiveness must keep seeing the NARROWED source row: a `match` on a
+   coerced value scrutinizes the coercion's source type, so users are not
+   forced to write arms for tags the value can never carry. Specify this
+   explicitly in the judgment's contract.
+
+**What gets DELETED** (both designs):
+
+- The `dangerousSetVarRedirect` call in the widening path, and
+  `widenTryConditionForExpectedReturn` itself.
+- `tryErrorRowNeedsUseSiteWidening`, `actualTagRowIsIncludedInExpected`,
+  `expectedTagRowContainsTag`, `findVisibleTagInRow`, and
+  `tagsCanUseSamePayloads` (fold anything still needed into the judgment).
+
+Why the union-find mutation must go: a redirect rebinds an entire
+equivalence class. Every other expression already unified with the condition
+var — anything aliased through prior unification — silently changes type,
+with no problem report and no record in the checked output. It can lose rank
+information (the store's own comment), which corrupts generalization. The
+`dangerous` prefix is the codebase's own warning that this is not a normal
+inference operation; an explicit coercion node has none of these hazards
+because it adds data instead of mutating shared state.
+
+## What success looks like
+
+- 9798-class code type-checks via the subsumption judgment: `inner({})?`
+  under an annotation `Try({}, [InnerErr, ..])` compiles, and (under Design
+  A) so does returning a stored closed `Try` from an open-annotated
+  function.
+- The judgment is the ONLY closed-into-open mechanism in the checker. Grep
+  for `dangerousSetVarRedirect` finds no coercion-motivated call sites
+  (error poisoning may remain).
+- Every accepted subsumption is visible in the checked output as a coercion
+  node; postcheck never infers a coercion.
+- A new construct with the closed-into-open shape needs one new CALL to the
+  judgment, not a new probe + rewrite.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- Principal types are preserved: no inference regressions across the full
+  snapshot corpus (src/snapshots/) — types printed for unrelated programs do
+  not change.
+- Coercion nodes carry both source and target types, so lowering is total:
+  no lowering path needs to consult the type store to decide what a coercion
+  means.
+- The judgment is reflexive (`rowSubsumes(r, r)` for any closed r) and
+  coherent under transitivity: if A subsumes into B and B into C, composing
+  the two coercions equals the direct A-into-C coercion. Document this
+  metatheory sketch alongside the implementation.
+- Exhaustiveness checking still sees the narrowed source rows at coerced
+  scrutinees.
+
+### Performance ideal
+
+- The judgment is O(row size) with interned tag-name comparisons; no
+  quadratic re-walks of the expected row per actual tag beyond what interned
+  lookup requires.
+- Representation-identical coercions lower to NOTHING: assert via LIR
+  statement-count tests that a `?` requiring subsumption emits the same LIR
+  as one that does not.
+- No new fixed-point passes anywhere in check or postcheck.
+
+## Tests to add
+
+- The 9798 reproduction: `inner({})?` under `Try({}, [InnerErr, ..])`,
+  as a snapshot test and an end-to-end eval test.
+- Stored-closed-Try-returned-at-open-annotation (Design A) — or, under
+  Design B, a test asserting it still errors with a clear message.
+- Combinator chains: a closed-error callee threaded through a pipeline into
+  an open-annotated consumer.
+- Negative tests: genuinely incompatible rows (missing tag; same tag with
+  non-unifiable payload) still produce type errors, not coercions.
+- Representation tests: no-op coercions emit no code (LIR statement-count
+  parity); discriminant-remap coercions produce correct runtime values.
+- Judgment unit tests: reflexivity, empty row into anything, closed into
+  closed superset, closed into rigid-open, flex-open actual rejected.
+
+## Related projects
+
+- [../small/cross-phase-coverage-parity-tests.md](../small/cross-phase-coverage-parity-tests.md)
+  — the coercion node is a new producer/consumer pair (checker emits,
+  lowerer consumes) and should ship with a parity test in that suite's
+  pattern.
+- [../small/check-app-against-platform-requires.md](../small/check-app-against-platform-requires.md)
+  — adjacent checker-side work on annotation boundaries.

--- a/projects/big/total-dispatch-plans.md
+++ b/projects/big/total-dispatch-plans.md
@@ -1,0 +1,255 @@
+# Total Dispatch Plans: Resolve Every Dispatch at Check Time
+
+## Problem
+
+Static dispatch — picking which concrete method a call like `value.method(..)`
+invokes — is resolved or re-derived in roughly seven places across three
+different type representations:
+
+1. Parser qualification chains (PR roc-lang/roc#9838).
+2. Canonicalization associated-item lookup via concatenated `"M.T.method"`
+   strings (PR roc-lang/roc#9714).
+3. Constraint solving in `src/check/Check.zig`.
+4. End-of-check ambiguity sweeps (PRs roc-lang/roc#9504, #9660, #9819).
+5. Artifact publication (PR roc-lang/roc#9718).
+6. Coordinator platform finalization (PRs roc-lang/roc#9762, #9873).
+7. Monotype lowering (`src/postcheck/monotype/lower.zig`).
+
+PR #9718 added a `resolution` field to `StaticDispatchCallPlan`
+(`src/check/static_dispatch_registry.zig`) with variants
+`unresolved_checked_plan` and `resolved_target: MethodTarget` — but the plan
+artifact is half-done. Only dispatchers that are concrete at check time get
+`resolved_target`. Parametric plans fall through to `dispatchTarget` in
+`src/postcheck/monotype/lower.zig`, which derives a `MethodOwner` from lowered
+monotype content via `methodOwnerFromType` (20+ call sites) and looks it up in
+a `method_lookup_index` built by re-interning module/type names **by text**
+across module views (`initMethodLookupIndex`, `appendMethodLookupIndexFromView`,
+`methodOwnerInProgramNames`; module identity is matched by `Ident.textEql`
+against three name spellings in `moduleViewNameMatches`). When derivation
+fails, lowering panics with
+`Common.invariant("checked method registry is missing resolved dispatch target")`
+— and this fires in the wild on ordinary programs: issues roc-lang/roc#9858
+(trivial `args.get(0)? * 10`), #9892, #9875 (dispatch lost through nominal
+aliases), #9864 (package-owned nominal platform methods).
+
+There is also a runtime-crash fallback: lowering compiles unresolved
+where-clause dispatch to
+`runtimeCrashExpr(..., "unresolved \`where\`-clause method dispatch on a polymorphic value")`.
+Issue roc-lang/roc#9815 hit it at runtime. `design.md`'s Core Principles say
+post-check stages "do not emit fallback code", and its Forbidden Shapes ban
+exactly this category.
+
+Finally, derived structural equality/hash/encode dispatch is resolved nowhere:
+lowering synthesizes it on the fly, gated by `planAllowsStructural` sniffing
+the plan's result mode.
+
+## Background
+
+The compiler pipeline is: parse → canonicalize → type-check (producing
+"checked artifacts" per module; all user-facing diagnostics end here) →
+postcheck: Monotype IR (monomorphization/specialization,
+`src/postcheck/monotype/`) → Monotype Lifted (closure lifting) → Lambda
+Solved → Lambda Mono → LIR lowering (`src/postcheck/solved_lir_lower.zig`) →
+ARC insertion (`src/lir/arc*.zig`) → backends (LLVM/dev/wasm/interpreter).
+
+Roc's static dispatch: `x.method(args)` resolves against the nominal type of
+`x`. Inside a generic function, the dispatcher's type may be a type variable
+constrained by a `where` clause (e.g. `where a.method : ...`); each concrete
+specialization created during monomorphization must pick the concrete method.
+Monotype IR is produced per specialization: checked bodies are instantiated at
+concrete types, so every dispatcher type is concrete *by the time a
+specialization is built* — the question is only where the resolution decision
+is made and what data carries it.
+
+`design.md` at the repo root is the authoritative post-check design. Read its
+sections "Static Dispatch At The Checked Boundary" and "Static Dispatch In
+Monotype" before starting. Note: "Static Dispatch In Monotype" currently
+*prescribes* deriving the `MethodOwner` from instantiated monotype type
+content. This project revises that section — owner derivation from lowered
+type content is exactly the re-derivation that keeps breaking. The Core
+Principles ("consumers must not recover missing data from source syntax,
+names, body scans, ... or incidental data structure shape") are the part that
+stays; the monotype dispatch algorithm changes to consume explicit evidence.
+
+Prerequisite context: the app module must see the platform's `requires` types
+during checking (see Related projects), otherwise platform-typed dispatchers
+are still flex vars when plans freeze and cannot be resolved at check time.
+
+## Evidence
+
+All symbols verified in the current tree.
+
+- `src/check/static_dispatch_registry.zig`: `StaticDispatchCallPlan` with
+  `resolution` (`unresolved_checked_plan` | `resolved_target: MethodTarget`);
+  every plan construction site initializes `.resolution = .unresolved_checked_plan`
+  and a separate pass upgrades some to `resolved_target`.
+- `src/postcheck/monotype/lower.zig`: `dispatchTarget` (derives owner via
+  `methodOwnerFromType`, then binary-searches `method_lookup_index` in
+  `lookupMethodTargetInIndex`); `MethodLookupIndexEntry`;
+  `methodOwnerInProgramNames` re-interning names by text;
+  `moduleViewNameMatches` matching module identity by `Ident.textEql` against
+  `module_name`, `display_module_name`, and `qualified_module_name`;
+  `planAllowsStructural`; the `runtimeCrashExpr` where-clause fallback; the
+  `Common.invariant("checked method registry is missing resolved dispatch target")`
+  panic.
+- Issue history: #9858, #9892, #9875, #9864 (missing-target panics), #9815
+  (runtime crash fallback reached), #9782/#9857/#9890 (coordinator-side
+  dispatch revalidation cascade), #9889/#9890 (regressions from
+  specialization-heavy roc-parser package code).
+- `src/check/checked_artifact.zig`: `specializeResolvedStaticDispatchPlanCallables`
+  (PR #9873) — publication-time re-projection of resolved plan callables,
+  part of place (5)/(6) above.
+
+## Solution design
+
+Make the plan artifact **total**: every dispatch site leaves checking with an
+explicit resolution. This is dictionary passing evaluated entirely at compile
+time — evidence is part of the specialization graph, never a runtime value,
+and generated code is unchanged.
+
+1. **New resolution representation.** Replace the current two-variant
+   `resolution` with:
+
+   ```zig
+   resolution: union(enum) {
+       direct: MethodTarget,      // dispatcher concrete at check time
+       constraint: u32,           // k: index into the enclosing def's
+                                  // where-clause constraint list
+       structural: StructuralKind // derived eq/hash/encode chosen by checker
+   },
+   ```
+
+   `direct` is produced when the checker can resolve the dispatcher through
+   its own alias/import machinery (the checker already understands nominal
+   aliases and imports — the alias-loss bug #9875 cannot happen there).
+   `constraint(k)` is produced when the dispatcher's type is a where-clause
+   type variable of the enclosing definition; `k` indexes that definition's
+   where-clause list. `structural` replaces the implicit
+   `planAllowsStructural` sniffing: the checker decides derived
+   equality/hash/encode explicitly.
+
+2. **Monomorphization resolves `constraint(k)` by substitution only.** At
+   every specialization call edge, the caller knows what each callee
+   where-clause variable was instantiated to: either a concrete type — in
+   which case the caller resolves the evidence from *checked* data at the
+   constraint-introduction site (the checker recorded which `MethodTarget`
+   satisfies that constraint for that concrete type) — or one of the caller's
+   own where-clause variables, in which case the caller forwards its own
+   constraint index. Evidence flows along specialization edges exactly like
+   type arguments do. No monotype-content inspection, no name lookup.
+
+3. **Single type-finalization point in checking (prerequisite).** Literal
+   defaulting and row closure must be frozen *before* plans freeze, so the
+   #9858 shape (`x * 10` where `x`'s number type defaults) is resolvable at
+   plan-freeze time. Concretely: order `checkFileInternal`'s numeric
+   defaulting passes ahead of dispatch-plan finalization and assert no plan
+   dispatcher root changes afterward.
+
+4. **Evidence through nested closures.** A where-clause evidence index used
+   inside a nested closure behaves exactly like a compile-time capture: it is
+   introduced by the enclosing definition and threaded inward. Ride the same
+   identity discipline as canonical capture IDs (see Related projects) rather
+   than inventing a parallel mechanism.
+
+5. **Deletions (not fallbacks).** After migration:
+   - `methodOwnerFromType`-based dispatch resolution in
+     `src/postcheck/monotype/lower.zig` (`dispatchTarget`'s derivation path);
+     `methodOwnerFromType` itself survives only if non-dispatch callers
+     remain, else it goes too
+   - the text-keyed `method_lookup_index` (`MethodLookupIndexEntry`,
+     `initMethodLookupIndex`, `appendMethodLookupIndexFromView`,
+     `lookupMethodTargetInIndex`, `methodOwnerInProgramNames`,
+     `moduleViewNameMatches`)
+   - the `runtimeCrashExpr` where-clause fallback and `planAllowsStructural`
+   - `unresolved_checked_plan` as a variant — its absence is the point.
+
+6. **Migration order.** Migrate one plan class at a time, each landing with a
+   debug boundary check "no unresolved plan of this class reaches lowering":
+   (a) value dispatch; (b) iterator `for` plans (`.iter`/`.next`);
+   (c) equality/hash; (d) `parser_for`/`encode_to`. Only after all classes
+   migrate does the deletion PR land.
+
+7. **Serialization/caching.** Checked artifacts are cached. `direct(target)`
+   serializes as (dependency artifact reference, proc template id) — legal in
+   check artifacts because dependency artifact hashes are already part of the
+   cache key, so a stale target reference cannot survive a cache hit.
+   `constraint(k)` is module-local data and serializes as the integer.
+
+## What success looks like
+
+- Every `StaticDispatchCallPlan` in every published artifact carries
+  `direct`, `constraint`, or `structural`; the compiler contains no
+  representation of an unresolved dispatch after checking.
+- The repros from #9858, #9892, #9875, #9864 compile and run correctly; the
+  "checked method registry is missing resolved dispatch target" panic string
+  no longer exists in the tree.
+- The #9815 program either compiles correctly or is rejected at check time;
+  the "unresolved `where`-clause method dispatch" runtime crash string no
+  longer exists in the tree.
+- `grep -rn "method_lookup_index" src/` returns nothing.
+- `design.md`'s "Static Dispatch In Monotype" section is rewritten to
+  describe evidence consumption, and the tree matches it.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+Invariants, and where they are enforced:
+
+- *Totality at the checked boundary*: asserted at artifact publication in
+  `src/check/checked_artifact.zig` — a plan without a resolution is a
+  compiler bug (debug assertion / release unreachable per design.md).
+- *Substitution-only resolution in monotype*: `src/postcheck/monotype/` never
+  consults names or type content to pick a target; enforceable by review plus
+  a debug counter asserting zero name-interner lookups on the dispatch path.
+- *Evidence/type agreement*: at each specialization edge, debug-assert that
+  the resolved target's callable type instantiates to the plan's callable
+  type (this check exists today post-lookup; it becomes the only check).
+- Behavioral: the full snapshot corpus, all examples, and the roc-parser
+  package suite produce identical output before/after; the Evidence issues'
+  repros are added as permanent regression tests.
+
+### Performance ideal
+
+Resolution work is bounded: once per dispatch site at check time, plus once
+per constraint per specialization edge during monomorphization — both O(1)
+table operations. All registry/name-lookup work leaves the hot monotype
+loop: no binary search, no text interning, no per-call-site owner derivation.
+Measure monotype lowering time and total build time on specialization-heavy
+code — the roc-parser package examples that produced regressions #9889/#9890
+are a good corpus — plus `examples/`. Expect lowering to get measurably
+faster (deleting per-site text interning and index construction); check-time
+cost rises only by plan-resolution bookkeeping, which must stay within noise
+on `roc check` benchmarks. Artifact size grows by one small union per plan;
+cache serialization time must not measurably regress.
+
+## Tests to add
+
+- Regression repros for #9858, #9892, #9875, #9864, #9815 as end-to-end run
+  tests with expected output.
+- A where-clause forwarding chain: generic `f` calls generic `g` calls
+  generic `h`, dispatch resolved three levels up; assert correct target per
+  specialization (exercises `constraint(k)` forwarding).
+- Nested-closure evidence: a closure inside a generic function dispatches on
+  the outer where-clause variable.
+- Alias/import matrix: dispatcher behind a nominal alias, a re-export, and a
+  package-qualified import (the #9875/#9864 shapes) resolving to `direct`.
+- Structural evidence: derived eq/hash/encode on records/tag unions chosen by
+  the checker; assert the plan carries `structural`, not a lowering guess.
+- Cache round-trip: serialize and reload an artifact with `direct` targets
+  into a dependent build; assert identical resolution.
+- Per-class boundary tests during migration: feed each plan class through
+  lowering with the debug check active.
+
+## Related projects
+
+- [../small/check-app-against-platform-requires.md](../small/check-app-against-platform-requires.md)
+  — prerequisite: plans cannot be total while platform-typed dispatchers are
+  flex vars at check time.
+- [../big/canonical-capture-id.md](../big/canonical-capture-id.md) — evidence
+  threading through nested closures rides the same compile-time-capture
+  discipline; do it before or together with step 4.
+- [../big/generalization-time-ambiguity.md](../big/generalization-time-ambiguity.md)
+  — shares the constraint-provenance foundation; `constraint(k)` gives each
+  dispatch constraint a stable identity that ambiguity reporting can also
+  use. Build provenance once, serve both.

--- a/projects/big/unify-build-pipelines.md
+++ b/projects/big/unify-build-pipelines.md
@@ -1,0 +1,232 @@
+# Unify the Build Pipelines
+
+## Problem
+
+The compiler has two parallel build-orchestration paths that both wrap the
+same `Coordinator` but independently reimplement package registration, cache
+wiring, report rendering, and platform-relation setup. Every feature or fix
+must land twice, and five recent shipped bugs were exactly "one pipeline had
+it, the other didn't":
+
+- PR 9811 — the run path passed a literal `null` cache manager to the
+  Coordinator (with a comment to the effect of "no cache for IPC"), so
+  `roc run` NEVER used the checked-module cache — a month after PR 9459 had
+  wired caching into the check path. Issue 9788 presented as "the compiler
+  feels slow"; nobody realized an entire pipeline was compiling from source
+  every time.
+- PR 9698 (issue 9694) — `roc file.roc --opt=speed` silently ran the
+  interpreter anyway because the run entry point was hard-wired to the
+  interpreter path and ignored the optimization flag.
+- PR 9627 — the run path registered only the packages named directly in the
+  app header, so transitive URL dependencies failed on `roc run` but worked
+  on `roc build`.
+- PR 9759 — duplicate diagnostics on run only: the run path rendered the
+  Coordinator's accumulated reports both before and after executable
+  finalization, and the rendering function re-renders ALL accumulated
+  reports on every call.
+- Also fixed in PR 9759 — the shared-memory shim path did not exit with
+  code 2 on warnings, while the build path did.
+
+Each fix patched one divergence. The generator of the bug class — two code
+paths that must be kept in sync by hand — is still in the tree.
+
+## Background
+
+The compiler pipeline is: parse → canonicalize → type-check (producing
+checked artifacts per module) → postcheck lowering → LIR → backends. All
+compilation is scheduled by the `Coordinator`
+(`src/compile/coordinator.zig`), which owns packages, modules, worker
+threads, the checked-module cache load/store, and per-module report
+storage.
+
+Two wrappers drive the Coordinator today:
+
+1. **BuildEnv** (`pub const BuildEnv` in `src/compile/compile_build.zig`).
+   Used by `roc check` (`rocCheck` → `checkFileWithBuildEnvPreserved` in
+   `src/cli/main.zig`), `roc build` (`rocBuildNative`/`rocBuildLlvm`/...),
+   docs generation (which reuses the preserved check BuildEnv), `roc glue`
+   (`rocGlueInner` in `src/glue/glue.zig` constructs a `BuildEnv`), and —
+   since its migration — the compile half of `roc test` (`rocTest` in
+   `src/cli/main.zig` calls `BuildEnv.init`, `buildWithMain` /
+   `discoverDependencies` + `compileDiscovered`, then `renderDiagnostics`).
+   BuildEnv owns package materialization, an ordered report sink
+   (`emitReport`/`drainReports` — reports are drained, not re-iterated),
+   and cache wiring via `setCacheManager`.
+
+2. **`lowerLirWithCoordinator`** (`src/cli/main.zig`). The interpreter /
+   LIR-image path used by dev-mode `roc run` and hot reload
+   (`rocRunSharedMemoryShim`, `rocRunDefaultAppSharedMemoryShim`,
+   `rocInternalHotReloadDev`, all via `buildLirImageWithCoordinator`). It
+   hand-wires everything BuildEnv also does: parses the app header
+   (`compile.app_header.parseAppHeader`), runs package version resolution,
+   constructs the Coordinator, registers the "app" package and every
+   resolved package with `ensurePackage`/`ensurePackageWithUrl`, builds a
+   `package_names` array mapping root → `"app"` and the platform → `"pf"`,
+   wires shorthands, enqueues parse tasks, runs `coordinatorLoop`,
+   finalizes executable artifacts, and renders reports via
+   `renderCoordinatorReports`.
+
+The checked-module cache both paths feed: the key is a Merkle DAG —
+SHA-256 over source hash (including ingested deps), compiler artifact
+hash, module identity hash, checking-context hash, and the ordered direct
+import artifact keys — stored content-addressed under
+`~/.cache/roc/<version>/mod/` with atomic temp+rename writes. PR 9720 made
+artifacts relocate-on-load (memcpy + comptime-audited pointer fixups); PR
+9768 removed body checksums as redundant. `design.md`'s "Cache Boundary"
+and "Host Symbol ABI" sections are authoritative for what the cache and
+the platform relation must preserve. A pipeline that forgets to pass a
+cache manager silently opts out of all of this.
+
+Note one discrepancy with older descriptions of this split: `roc test` no
+longer goes through `lowerLirWithCoordinator` — its compile half already
+uses BuildEnv (see `rocTest`), though it still hand-wires its own cache
+pass-through (`if (args.no_cache) null else build_env.cache_manager`) into
+`runCheckedArtifactTests`. The run path is the remaining full duplicate.
+
+## Evidence
+
+- `src/compile/compile_build.zig` — `BuildEnv`, `build`, `buildWithMain`,
+  `discoverDependencies`, `compileDiscovered`, `setCacheManager`,
+  `drainReports`, `emitReport` (ordered sink).
+- `src/cli/main.zig` — `lowerLirWithCoordinator`,
+  `buildLirImageWithCoordinator`, `rocRun`, `rocRunBuildAndExec`,
+  `rocRunSharedMemoryShim`, `rocRunDefaultAppSharedMemoryShim`,
+  `rocInternalHotReloadDev`, `renderCoordinatorReports`, `rocTest`.
+- Report re-rendering is accommodated, not prevented:
+  `Coordinator.iterReports` returns a `ReportIter` that walks every report
+  of every module of every package from the start on each call
+  (`src/compile/coordinator.zig`), and `renderCoordinatorReports` carries a
+  comment on its version-note handling — "Consuming the note keeps
+  re-renders from attaching it twice." PR 9759's fix is call-ordering:
+  `lowerLirWithCoordinator` renders early only under
+  `coord.hasUserErrors()` and returns, otherwise renders exactly once
+  after `finalizeExecutableArtifacts` / the AllowUserErrors variant.
+- The naming skew PR 9811 left behind: `lowerLirWithCoordinator` builds
+  `package_names` with root → `"app"`, platform → `"pf"`, justified only
+  by the comment "matching Coordinator.discoverAppFromPath". See
+  `../small/single-package-identity-function.md`.
+- A `null` cache manager call site still exists:
+  `setupSharedMemoryWithCoordinator` (`src/cli/main.zig`) forwards to
+  `buildLirImageWithCoordinator` with `null` for the cache manager (no
+  in-tree callers were found; it is a `pub` embedding surface, and it
+  reproduces the exact PR 9811 pattern for anything that calls it).
+- The delegation model that already works: `rocRun` dispatches
+  `.size, .speed => rocRunBuildAndExec(ctx, args, arg0)`, and
+  `rocRunBuildAndExec` simply calls `rocBuild` with run-shaped `BuildArgs`
+  and then executes the produced binary (including the exit-2-on-warnings
+  contract). One back half reusing the other path's front half — this is
+  the shape the whole CLI should have.
+- PRs (roc-lang/roc): 9811, 9459, 9698, 9627, 9759, 9720, 9768. Issues:
+  9788 (run never cached, filed as slowness), 9694 (`--opt` ignored),
+  9509 (transitive package failure on run, fixed by PR 9627).
+
+## Solution design
+
+One orchestration core, used by every entry path, owning exactly four
+things: package registration / graph construction, cache wiring, report
+accumulation and rendering, and the platform relation. Entry paths differ
+only in their back half: executable link (`roc build`), LIR image +
+interpreter/shim (`roc run` dev), test execution (`roc test`), diagnostics
+only (`roc check`), docs extraction, glue extraction.
+
+1. **Extract the core from BuildEnv** (or promote BuildEnv to be it).
+   BuildEnv is the closest existing thing: it already serves check, build,
+   docs, glue, and test compilation. Factor its front half (header parse,
+   package resolution and registration, Coordinator construction, cache
+   manager attachment, coordinator loop, finalization) into an API that
+   yields a finished Coordinator plus drained diagnostics, without
+   assuming the caller wants linked output.
+2. **Collapse `lowerLirWithCoordinator` onto the core.** Its LIR-image
+   production becomes a back half consuming the core's finished
+   Coordinator. DELETE from `src/cli/main.zig`: the hand-rolled header
+   parse + `resolvePackages` + `ensurePackage`/`ensurePackageWithUrl`
+   loops, the `package_names` array and its "matching
+   Coordinator.discoverAppFromPath" comment, the shorthand wiring, and the
+   parse-task enqueueing — all of it exists in the core.
+3. **Make report rendering structurally idempotent.** Replace the
+   "render exactly once by call-site discipline" contract with either a
+   draining cursor (BuildEnv's `drainReports` model, extended to the run
+   path) or a per-report `rendered` flag consulted by the renderer. DELETE
+   the re-render accommodations in `renderCoordinatorReports` (the
+   version-note `fetchRemove` dance) once re-rendering is impossible.
+   Keep `hasUserErrors`-style queries as pure queries, fully separate from
+   rendering side effects.
+4. **Unify exit-code policy.** Warning exit 2 and error exit codes are
+   computed by the core from drained counts; back halves never invent
+   their own exit logic (the shared-memory shim bug class).
+5. **Route the stragglers.** `roc test`'s cache pass-through and execution
+   half consume the core's cache manager rather than re-deriving it;
+   `setupSharedMemoryWithCoordinator` either gains the core's cache wiring
+   or is deleted if truly dead. Glue, the LSP, and the playground consume
+   the core — no new entry path may construct a Coordinator directly.
+6. **Enumerate the known divergences as the acceptance checklist**:
+   caching parity, `--opt` parity, transitive package registration parity,
+   diagnostic single-render, warning exit codes, package-name parity.
+
+Land `../small/single-package-identity-function.md` first: it shrinks the
+naming surface the core must absorb to a single function.
+
+## What success looks like
+
+- The five bug classes above are impossible by construction: there is one
+  code path for package registration, one for cache attachment, one for
+  report rendering, one for exit codes.
+- No Coordinator setup code (ensurePackage loops, parse-task enqueueing,
+  package-name computation) exists outside the core — `grep -rn
+  "ensurePackage" src/cli src/glue` matches nothing.
+- `renderCoordinatorReports` in its current form is gone; rendering the
+  same report twice is a type/state impossibility, not a convention.
+- Adding a feature to build orchestration (a new cache, a new package
+  source, a new diagnostic channel) lands in run/test/docs/glue
+  automatically.
+- No call site anywhere passes a `null` cache manager except an explicit
+  `--no-cache` flag path.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+The pipeline-parity test suite (below) is total over entry paths: every
+assertion runs against check, build, run, and test, and any future entry
+path is added to the same matrix or fails CI. Divergence between two entry
+paths on diagnostics, exit code, cache behavior, or package resolution is
+a test failure, not a user bug report.
+
+### Performance ideal
+
+Run-path compile times are unchanged or better — it gains caching by
+default, so measure second-invocation speedup on a warm cache, which today
+is zero on any path that opted out (issue 9788's repro is the benchmark).
+`roc check` must not regress: the core must not force LIR-image or
+interpreter machinery onto paths that do not need it (check's back half
+stops after diagnostics). Cold-build times are unchanged: the core adds no
+work, it deduplicates it.
+
+## Tests to add
+
+- **Pipeline-parity suite**: drive the SAME multi-package project (with a
+  transitive URL dependency and at least one warning and one error
+  variant) through `roc check`, `roc build`, `roc run`, and `roc test`;
+  assert identical diagnostic text and counts, identical exit codes
+  (including warning exit 2), identical package resolution, and identical
+  cache behavior (second invocation hits the checked-module cache on every
+  path — assert via cache stats).
+- Issue 9788 repro: default app, `roc run` twice, second run must load
+  checked modules from cache.
+- Issue 9694 repro: `roc file.roc --opt=speed` produces and executes a
+  compiled binary (not the interpreter).
+- Issue 9509 repro: app → package → transitive URL package, `roc run`
+  succeeds exactly when `roc build` does.
+- Single-render test: a program with N diagnostics renders exactly N
+  reports on the run path (PR 9759 regression test).
+
+## Related projects
+
+- [Single package-identity function](../small/single-package-identity-function.md)
+  — land first; removes the naming skew the core must otherwise absorb.
+- [Cache hardening](../small/cache-hardening.md) — the cache the unified
+  core wires everywhere; hardening its edges pays off more once every
+  pipeline uses it.
+- [Decision-tree match compiler](../big/decision-tree-match-compiler.md)
+  — the single-lowerer story pairs with this project's single-orchestrator
+  story.

--- a/projects/small/cache-hardening.md
+++ b/projects/small/cache-hardening.md
@@ -1,0 +1,219 @@
+# Cache Hardening at the Enforcement Edges
+
+## Problem
+
+PR 9720 gave the checked-module cache a mechanically enforced
+serialization framework: comptime pointer audits, a strict bidirectional
+field-set audit over every slice-backed sub-store, a load-time structural
+layout fingerprint, and bounds validation of relocation markers. Inside
+that framework, forgetting to serialize a field is a compile error and a
+corrupt blob is a clean cache miss.
+
+The enforcement stops at four edges, and each edge has either already
+shipped a bug or is one refactor away from one:
+
+- (a) The hand-written ~34-field top-level artifact `Serialized` struct
+  has NO field-set audit. `exhaustiveness_sites` is a live proof: it is a
+  field of `CheckedModuleArtifact` but absent from `Serialized`, so every
+  cache-loaded artifact silently gets an empty table — while
+  `ImportedModuleView` still exposes it to postcheck consumers whose
+  mismatch handling is a `finalizationInvariant` panic. Historically the
+  same gap shipped dead-stub deserialization for dispatch-plan tables
+  (fixed during PR 9459's wiring).
+- (b) The `ModuleEnv` blob inside a cache entry has NO layout-version hash
+  and NO bounds-validation pass. PR 9768 removed body checksums as
+  redundant with artifact-side checks — correct for the artifact blob,
+  but the env blob now has neither a checksum nor bounds checking. An
+  env-layout change without a manual format bump relocates stale bytes
+  into a mismatched struct.
+- (c) The layout fingerprint hashes DECLARED structure (field names and
+  type names), not `@sizeOf`/`@offsetOf`/endianness, and the cache
+  directory is compiler-version-scoped but not arch-scoped. A cache
+  directory shared across architectures (network home dir, container
+  volume) could admit a blob whose bytes mean something else.
+- (d) Cache failures are silent. Every load/store error degrades to
+  compile-from-source with only `CacheStats` counters (printed only under
+  verbose); one failure path records no stat at all. A systematic store
+  failure — read-only cache dir, serialization bug — looks like a slow
+  compiler forever. That is exactly how issue 9788 presented.
+
+## Background
+
+The checked-module cache stores one entry per type-checked module under
+`~/.cache/roc/<version>/mod/`, written via atomic temp+rename
+(`CacheManager.storeRawBytes`, `src/compile/cache_manager.zig`). The key
+is a Merkle DAG: SHA-256 over the module's source hash (including
+ingested deps), the compiler artifact hash, the module identity hash, the
+checking-context hash, and the ordered artifact keys of its direct
+imports — so a hit implies matching imports by construction. `design.md`'s
+"Cache Boundary" section is authoritative: cache reads validate only the
+header, format version, key, serialized layout, and ordinary binary
+decoding; they must not re-run checked validation.
+
+Both build-orchestration paths feed this cache — `roc check`/`roc build`
+via `BuildEnv` (`src/compile/compile_build.zig`) and the run path via
+`lowerLirWithCoordinator` (`src/cli/main.zig`); both wrap the
+`Coordinator` (`src/compile/coordinator.zig`), which owns the load/store
+functions this document hardens.
+
+An entry is `[header][env blob][artifact blob]`. The header
+(`writeCheckedModuleCacheHeader` / `decodeCheckedModuleCacheEntry` in
+`src/compile/coordinator.zig`) is: magic, format version (u64), the
+artifact layout hash `SERIALIZED_VERSION_HASH` (32 bytes), the artifact
+key (32 bytes), and the two body lengths. PR 9720's relocate-on-load
+framework then materializes the artifact blob with memcpy + pointer
+fixups, with these mechanical guarantees (`src/check/artifact_serialize.zig`):
+
+- `assertSerializedRelocatable` — comptime walk proving every field is a
+  relocatable marker or relocation-invariant POD.
+- `SliceStoreSerde(Store, Serialized)` — a comptime BIDIRECTIONAL
+  field-set audit: a field present in one struct but unhandled in the
+  other is a compile error. Used by the slice-backed sub-stores
+  (`ConstStore`, `StaticDispatchPlanTable`, `CanonicalNameStore`, ... —
+  on the order of 29 across the artifact).
+- `layoutVersionHash` — a comptime structural fingerprint of the
+  `Serialized` type tree (plus a manual bump discriminant and the
+  relocatable-pointer count), stored in the header and checked on load.
+- `validate` (the "L-10" pass) — bounds-checks every relocation marker's
+  `(offset, len)` against the blob before any slice aliases it; the
+  artifact load path calls it (`installCachedCheckedArtifact`).
+
+PR 9768 then removed body checksums as redundant with the above — the
+header comment in `coordinator.zig` documents the reasoning. The removal
+is sound exactly where the above enforcement applies; the edges below are
+where it does not.
+
+## Evidence
+
+- (a) `src/check/checked_artifact.zig`: `CheckedModuleArtifact` declares
+  `exhaustiveness_sites: CheckedExhaustivenessSiteTable = .{}` but the
+  top-level `pub const Serialized` (~34 fields, `key` through
+  `const_store`) has no such field; `serialize` and
+  `deserializeWithBacking` never touch it, so the default `.{}` survives
+  every cache load. `ImportedModuleView` (same file) exposes
+  `exhaustiveness_sites: *const CheckedExhaustivenessSiteTable` built from
+  `&artifact.exhaustiveness_sites`. Consumers in
+  `src/eval/compile_time_finalization.zig` (`comptimeSiteMayResolvePending`,
+  `discardUnreachedRootComptimeSites`, and the empirical-exhaustiveness
+  path) call `.get(checked_site)` on it and treat inconsistency as
+  `finalizationInvariant` panics ("compile-time exhaustiveness failure had
+  an impossible site policy"). The only existing top-level comptime check
+  is `relocatablePointerCount(Serialized) == 181`, which audits fields
+  that ARE present — it cannot see an absent one.
+- (b) `decodeCheckedModuleCacheEntry` checks the env body only for
+  `env_body.len < @sizeOf(ModuleEnv.Serialized)`; the load path
+  (`installCachedCheckedArtifact` in `src/compile/coordinator.zig`) then
+  memcpys the blob and calls `ModuleEnv.Serialized.deserializeWithMutableTypes`
+  (`src/canonicalize/ModuleEnv.zig`) with no marker bounds pass and no
+  env-layout hash in the header. A suitable hash already exists:
+  `MODULE_ENV_VERSION_HASH` in `src/compile/cache_module.zig` (validated
+  by the separate `CacheModule` path) — the checked-module entry header
+  simply does not include it.
+- (c) `serializedLayoutFingerprint` in `src/check/artifact_serialize.zig`
+  hashes field names and `@typeName` for scalars ("the name fully
+  captures its size/representation" — untrue for `usize` across
+  pointer widths) and never folds `@sizeOf`, `@offsetOf`, or endianness.
+  `src/compile/cache_config.zig`: `getVersionCacheDir` /
+  `getCompilerVersionDir` scope the cache by
+  `build_options.compiler_version` only — no target/arch component.
+- (d) `CacheStats` (`src/compile/cache_config.zig`) counts hits, misses,
+  invalidations, stores, and store failures; `CacheManager.printStats`
+  and `verboseLog` are gated on `config.verbose`. In
+  `Coordinator.tryLoadCachedCheckedModule`, the key-derivation failure
+  path is `self.checkedModuleCacheKey(...) catch return false` — no stat
+  recorded at all. Issues 9787 and 9789 track surfacing these stats.
+- PRs (roc-lang/roc): 9720, 9768, 9459. Issues: 9788, 9787, 9789.
+
+## Solution design
+
+1. **(a) Extend the field-set audit to the two hand-written top-level
+   structs.** Add a `SliceStoreSerde`-style comptime bidirectional audit
+   binding `CheckedModuleArtifact` ↔ its `Serialized` (with an explicit,
+   audited allowlist for intentionally unserialized fields such as
+   `module_env` and `serialized_backing`, each carrying a comment saying
+   why), and the same for `ModuleEnv` ↔ `ModuleEnv.Serialized`. A field
+   added without serde handling (or an allowlist entry) becomes a compile
+   error. Fix `exhaustiveness_sites` serialization as the proof case: add
+   it to `Serialized`, `serialize`, `deserializeWithBacking`, and bump
+   `serialized_layout_version`. DELETE nothing here — this edge is
+   missing code, not excess code.
+2. **(b) Give the env blob the artifact blob's protections.** Add the env
+   layout hash (reuse/relocate `MODULE_ENV_VERSION_HASH`) as a third
+   32-byte field in the checked-module entry header, rejected in
+   `decodeCheckedModuleCacheEntry`; add a `validate(backing_len)`
+   marker-bounds pass over `ModuleEnv.Serialized` mirroring the artifact
+   side, called before `deserializeWithMutableTypes`. Bump
+   `checked_module_cache_format_version`.
+3. **(c) Bind the fingerprint to the physical layout.** Fold the target
+   arch triple (or `@sizeOf(usize)` + endianness + `@sizeOf`/`@offsetOf`
+   of each fingerprinted struct) into `layoutVersionHash`, or — simpler
+   and sufficient — add the arch to the cache directory path next to the
+   compiler version in `getVersionCacheDir`. Either closes the cross-arch
+   shared-dir hazard; doing both is cheap.
+4. **(d) Make failure visible.** A rate-limited (once per process)
+   non-verbose warning when cache stores fail repeatedly (threshold on
+   `CacheStats.store_failures`), e.g. "cache writes are failing
+   (<reason>); compilation will not be cached". Record a stat in the
+   `checkedModuleCacheKey(...) catch return false` path. Surface
+   hit/miss/store-failure counters in `--verbose` output, wired into the
+   issues-9787/9789 stats work so both efforts land one surface.
+
+## What success looks like
+
+- All four edges have the same mechanical enforcement as the framework
+  interior: adding a field to `CheckedModuleArtifact` or `ModuleEnv`
+  without serde support does not compile.
+- A cache-loaded artifact's `exhaustiveness_sites` equals the freshly
+  compiled one's (assertable in a round-trip test).
+- A cache entry written by a compiler with a different `ModuleEnv` layout
+  is a recorded cache miss, never a misread.
+- A read-only cache directory produces a visible warning on the first
+  affected compile, not a permanently slower compiler.
+- No re-hashing of blob bodies is reintroduced (PR 9768's win preserved).
+
+## How to evaluate the result
+
+### Correctness ideal
+
+Canary tests prove each edge mechanically: (1) in a throwaway branch, add
+a dummy field to `CheckedModuleArtifact` and to `ModuleEnv` with no serde
+handling and verify the build fails at comptime; (2) corrupt and truncate
+env blobs at every byte-range boundary and verify rejection (recorded as
+invalidation), never a misread or crash; (3) mutate the stored env-layout
+hash and verify a miss; (4) simulate cross-arch by flipping the arch
+component and verify a miss. No possible cache entry — corrupt, stale,
+foreign — can reach `deserializeWithMutableTypes` with mismatched bytes.
+
+### Performance ideal
+
+The env bounds pass is O(number of markers) once per load — measure that
+it stays a small fraction of cache-load time (the artifact-side `validate`
+is the existing baseline; the env side should cost proportionally the
+same). The warning path costs nothing when healthy (a counter compare).
+Header grows by 32 bytes per entry — negligible. Cache hit-path wall time
+before/after must be within noise; no body hashing on read or write.
+
+## Tests to add
+
+- The four canaries above (comptime-failure canaries live as documented
+  manual checks or a build-mode test harness if comptime-failure testing
+  is available; the runtime ones as ordinary tests).
+- Round-trip equality for `exhaustiveness_sites` (compile, store, load,
+  compare against fresh compile).
+- Corrupted-entry rejection matrix over the entry format: bad magic, bad
+  format version, bad artifact layout hash, bad env layout hash, bad key,
+  truncation at each section boundary, oversized lengths — each must be a
+  recorded miss/invalidation with a from-source fallback.
+- Store-failure warning test: point the cache at a read-only directory,
+  compile, assert the warning appears exactly once and compilation
+  succeeds.
+- Stats-surfacing assertion: verbose compile of a warm project reports
+  nonzero hits; with the read-only dir it reports store failures.
+
+## Related projects
+
+- [Unify the build pipelines](../big/unify-build-pipelines.md) — makes
+  every entry path use this cache, multiplying the value of hardening it.
+- [Content-based nominal identity](../big/content-based-nominal-identity.md)
+  — the identity inputs to the cache key; this project hardens the value
+  side, that one the key side.

--- a/projects/small/centralize-slice-reuse-predicate.md
+++ b/projects/small/centralize-slice-reuse-predicate.md
@@ -1,0 +1,201 @@
+# Centralize the Seamless-Slice Allocation-Reuse Predicate
+
+## Problem
+
+Roc lists and strings use "seamless slices": a value may be a window into a
+larger backing allocation. For such values the runtime predicate
+"refcount == 1 ⇒ safe to destructively reuse the allocation" is **false**:
+a unique slice still owns cleanup for the *entire* backing allocation,
+including elements outside its window. Any builtin fast path that keys
+reuse on `isUnique` alone can duplicate, prematurely release, or leak the
+refcounted elements outside the window, or resize/free an allocation whose
+true extent it does not know.
+
+Issue roc-lang/roc#9742 was exactly this class: `roc test` and `roc run`
+disagreed because refcounted elements outside a slice window were
+mishandled. PR roc-lang/roc#9841 fixed `listSublist`, `listDropAt`,
+`listConcat`, and `RocList.reallocate` by adding per-site
+`can_reuse_allocation = !list.isSeamlessSlice() and (update_mode == .InPlace
+or list.isUnique(roc_ops))` locals, plus a new
+`decrefAfterMovingSliceElements` consume path (dec the elements outside the
+window, then decref the raw allocation), threading the element-dec callback
+ABI through the four backend surfaces (LLVM, dev, interpreter, wasm — plus
+the wasm signature table). But the predicate now exists as several
+open-coded copies, other sites are safe only by *encoding accident*, and at
+least one `isUnique` fast path has no slice guard at all (see Evidence).
+Because borrow inference deliberately drives refcounts to 1 to enable
+in-place mutation, every unique-fast-path builtin is a live hazard — and
+this class produces silently wrong program output, not compiler panics.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck IRs
+(Monotype → Lifted → Lambda Solved → Lambda Mono) → LIR lowering → ARC
+insertion (`src/lir/arc.zig`, from the whole-program borrow solution in
+`src/lir/arc_solve.zig`; `src/lir/arc_certify.zig` is the debug-build
+certifier; `design.md` sections "ARC Borrow Inference" and "Debug Borrow
+Certifier" are authoritative) → backends (LLVM / dev x86+aarch64 / wasm /
+interpreter). Runtime list/str builtins live in `src/builtins/` and use
+`refcount == 1` checks for in-place mutation. Borrow inference (PRs
+roc-lang/roc#9595 and roc-lang/roc#9604) keeps refcounts at 1 across
+read-only uses precisely so those in-place paths fire — which makes any
+uniqueness-predicate bug in the runtime highly reachable from ordinary
+programs.
+
+Representation (`src/builtins/list.zig`, `RocList`): `capacity_or_alloc_ptr`
+holds capacity shifted left by one for normal lists, or the backing
+allocation pointer with the low bit (`SEAMLESS_SLICE_TAG = 1`) set for
+slices. `isSeamlessSlice()` tests that bit; `getCapacity()` returns the
+*length* for slices; `getAllocationDataPtr()` returns the backing
+allocation; `getAllocationElementCount()` reads the whole-allocation
+element count from the heap header for slices with refcounted elements
+(written by `setAllocationElementCount` when a slice is created from a
+unique list). `RocStr` mirrors this, plus a small-string inline form.
+
+The static side already models slices specially: slice-producing low-level
+ops (`list_sublist`, `list_drop_at`, ...) use
+`RcEffect.runtimeUniquenessMaybeSharedResult` in `src/base/LowLevel.zig` —
+their results alias their argument and are *not* marked `result_unique`, so
+slice results are excluded from the born-unique analysis; `RcEffect` also
+has an explicit `result_shares_args` mask; and PR roc-lang/roc#9610 added
+`listMapCanReuse` (`src/builtins/list.zig`) so `List.map` never reuses a
+slice's allocation. The runtime predicate is the remaining gap.
+
+## Evidence
+
+Verified against the current tree (`src/builtins/list.zig` unless noted):
+
+Sites already carrying the correct compound predicate (PR 9841), each as a
+separate open-coded copy:
+
+- `listSublist` — `can_reuse_allocation` local with explanatory comment.
+- `listDropAt` — `can_reuse_allocation` local.
+- `listConcat` — `can_consume_a`/`can_consume_b` plus
+  `a_reuses_allocation`/`b_reuses_allocation` (slice-guarded).
+- `RocList.reallocate` — `isUnique(...) and !isSeamlessSlice()`; the copy
+  path `reallocateFresh` computes `move_slice_elements` and calls
+  `decrefAfterMovingSliceElements` (asserts `isSeamlessSlice()` and
+  `isUnique()`; decs elements outside the window, then raw decref).
+- `listMapCanReuse` — `!isSeamlessSlice() and isUnique(...)`.
+
+Sites safe only by encoding accident:
+
+- `listReserve` — `(update_mode == .InPlace or list.isUnique(roc_ops)) and
+  cap >= desired_cap`: no slice guard; safe only because `getCapacity()`
+  returns the length for slices, so a unique slice passes only when
+  `spare == 0`, where returning it unchanged happens to be harmless.
+- `listReleaseExcessCapacity` — in-place test compares
+  `list.capacity_or_alloc_ptr == RocList.encodeCapacity(old_length)`: safe
+  only because `encodeCapacity` yields even values and a slice's tag bit
+  is set, so the equality can never hold for a slice (the comment says as
+  much, but nothing enforces it).
+
+`isUnique` fast paths without a slice guard, to audit and convert (or
+annotate with an assert explaining why they are safe):
+
+- `RocList.decref` — `elements_refcounted and self.isUnique(roc_ops)` then
+  decs `getAllocationElementCount` elements from the allocation base:
+  correct for slices, but only via the heap-stored count contract.
+- `RocList.makeUnique` — returns `self` for any unique value including a
+  unique slice; safe for element writes inside the window, not for
+  allocation reuse; audit callers.
+- `listIsUnique` (exported) — `list.isEmpty() or list.isUnique(roc_ops)`;
+  audit what generated code uses it to justify.
+- `RocList.increfWithAtomicity` — slice-guarded already (writes the
+  allocation element count); keep, but document against the predicate.
+
+`src/builtins/str.zig` (`RocStr.isUnique` takes no `roc_ops`):
+`RocStr.reallocate`, `fromSubListUnsafe`, and `strReleaseExcessCapacity`
+are slice-guarded; `substringUnsafe`, `strTrim`, `strTrimStart`,
+`strTrimEnd`, `strWithAsciiLowercased`, `strWithAsciiUppercased`, and
+`strJoinWithC` take `isUnique` fast paths with no slice guard — strings
+have no refcounted elements, so window-local length/byte edits are
+believed safe, but each site must be audited and annotated.
+
+## Solution design
+
+1. Add one predicate method on `RocList`:
+   `canReuseAllocation(self, update_mode, roc_ops) = !isSeamlessSlice() and
+   (update_mode == .InPlace or isUnique(roc_ops))`, and the `RocStr`
+   equivalent (no `roc_ops`; also `false` for small strings, which have no
+   heap allocation to reuse — callers handle the inline form first). The
+   doc comment states the contract: *unique means sole owner of the WHOLE
+   allocation; that equals "safe to reuse" only when the window IS the
+   allocation.*
+2. Convert every predicate copy from PR 9841 (`listSublist`, `listDropAt`,
+   `listConcat`, `RocList.reallocate`, `listMapCanReuse`) to call it.
+3. Audit every `isUnique` call site in `list.zig` and `str.zig` (the lists
+   above enumerate them) and either convert it to the predicate or attach
+   a `std.debug.assert` plus comment stating exactly why the site is safe
+   without the slice guard. The accidental-safety sites (`listReserve`'s
+   `getCapacity`-returns-length, `listReleaseExcessCapacity`'s tag-bit
+   inequality) must stop being accidents: use the predicate, or assert
+   the encoding fact they rely on next to the reliance.
+4. Make `decrefAfterMovingSliceElements` the single
+   consume-a-unique-slice path: any site that takes ownership of a unique
+   slice's backing allocation goes through it (today `reallocateFresh` is
+   the only caller; the audit may find more).
+5. Longer-term option, explicitly **not** this project: encode the
+   window/allocation relationship in the list header so the predicate
+   becomes a single flag test.
+
+Nothing is deleted structurally; the deletions are the open-coded
+`!isSeamlessSlice() and (... or isUnique(...))` expressions replaced by
+predicate calls.
+
+## What success looks like
+
+- No direct `isUnique`-based reuse decision remains in `list.zig` or
+  `str.zig` outside `canReuseAllocation`; every remaining bare `isUnique`
+  call site carries an assert/comment documenting why the slice guard is
+  unnecessary there.
+- `listReserve` and `listReleaseExcessCapacity` either use the predicate
+  or assert the encoding fact they depend on.
+- `decrefAfterMovingSliceElements` is the only code path that consumes a
+  unique slice's backing allocation.
+- The issue 9742 reproduction passes identically under `roc test` and
+  `roc run` across all backends.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+For every list/str builtin with a fast path, a test triple:
+(a) a unique slice of a shared backing allocation,
+(b) a unique slice that is the sole owner of its backing allocation,
+(c) refcounted elements (e.g. strings) outside the slice window —
+asserting both value correctness and refcount balance: no leak, no
+double-free, using the existing `utils.TestEnv` shadow-refcount leak
+detection (`src/builtins/utils.zig` reports allocations whose refcount
+never reaches 0, with operation history).
+
+### Performance ideal
+
+The predicate inlines to the same instructions as today's open-coded
+checks — spot-check ReleaseFast codegen for `listSublist` and `listDropAt`
+before/after. In-place fast paths are still taken in every legitimate
+case: add a counter (test builds) or a test asserting reuse actually
+happens for case (b)-style inputs and for plain unique non-slice lists,
+so the fix never silently degrades to copy-always. Generated-code
+performance and release compile time must not regress; this is a
+runtime-builtins change only, so compile time is unaffected by
+construction.
+
+## Tests to add
+
+- The (a)/(b)/(c) triples above for each converted builtin, in the
+  existing Zig test blocks of `list.zig` / `str.zig`.
+- An end-to-end reproduction of issue 9742 (slice of a list of strings,
+  mutated through a unique-fast-path builtin, output compared between
+  interpreter and compiled backends).
+- A randomized (fuzz-ish) sequence test: build a list of refcounted
+  elements, apply a random sequence of sublist/dropAt/concat/reserve/
+  releaseExcessCapacity operations with random sharing (extra increfs),
+  compare against a naive reference implementation, and assert zero
+  leaks via `TestEnv`.
+
+## Related projects
+
+- [ARC Certifier Lattice Join and Centralized Ownership-Transfer Keying](../big/arc-certifier-lattice-join.md)
+  — the compile-time twin of this cleanup: both replace per-site
+  open-coded ownership reasoning with one shared, documented definition.

--- a/projects/small/check-app-against-platform-requires.md
+++ b/projects/small/check-app-against-platform-requires.md
@@ -1,0 +1,230 @@
+# Check the App Against the Platform's `requires` Signature
+
+## Problem
+
+A Roc platform declares the types it demands from an app in its `requires`
+clause (e.g. `requires { main! : List(Arg) => Try({}, [Exit(I32)]) }`). Today
+the app module is type-checked **without** that signature. In an app like
+
+```roc
+main! = |args| ...
+```
+
+`args` stays an unconstrained flex var through the entire check of the app
+module. The platform's declared type is grafted on *after* the app's checked
+artifact has already been published: `applyPlatformRequiredSignatureSubstitutions`
+in `src/check/checked_artifact.zig` structurally matches the platform's
+declared scheme against the app def's checked root and rewrites the published
+checked type roots via `cloneCheckedTypeRootSubstituting`. Then the build
+coordinator (`src/compile/coordinator.zig`, `finalizeExecutableArtifactsInternal`,
+called via `finalizeExecutableArtifacts`) re-validates everything the checker
+would have caught had it known the types: it snapshots per-plan type keys
+before republish with `PlatformRequiredValidationSnapshot`, diffs them after,
+runs hand-rolled numeric fit checks, and hand-builds `Report` documents that
+duplicate checker diagnostics.
+
+This is a shadow type checker living outside the checker. It re-implements
+type propagation, dispatch validation, and literal range checking on checked
+artifacts, and it has produced a sustained bug cascade (see Evidence). Every
+fix has grown the layer instead of shrinking the problem, because the root
+cause is architectural: the checker never sees the platform types, so
+everything downstream must guess at what the checker would have said.
+
+## Background
+
+The compiler pipeline is: parse → canonicalize → type-check (producing
+"checked artifacts" per module — all user-facing diagnostics end here) →
+postcheck: Monotype IR (monomorphization, `src/postcheck/monotype/`) →
+Monotype Lifted (closure lifting) → Lambda Solved → Lambda Mono → LIR lowering
+(`src/postcheck/solved_lir_lower.zig`) → ARC insertion (`src/lir/arc*.zig`) →
+backends (LLVM/dev/wasm/interpreter). `design.md` at the repo root is the
+authoritative post-check design. Its Core Principles state that every stage
+after checking consumes explicit data produced by earlier stages, that all
+user-facing failures are reported during checking at the latest, and that
+post-check stages must not re-derive facts from names or structure.
+
+Platform/app model: a platform module's header has a `requires` clause naming
+the definitions the app must provide, with full type annotations. The clause
+can also have a *for-clause* naming types the app supplies (e.g. `Model`) that
+the requires signature itself refers to. So the relationship is bidirectional:
+the platform's scheme is parameterized over app-supplied types. The checker
+already has machinery for this: `processRequiresTypes` in `src/check/Check.zig`
+processes requires-clause types, and for-clause aliases are tracked in
+`for_clause_aliases` (see `isForClauseAliasStatement`), added for alias
+handling in PR roc-lang/roc#9850.
+
+The build coordinator (`src/compile/coordinator.zig`) orchestrates per-module
+checking and artifact publication. Today the app is checked as if standalone,
+its artifact is published, and only then does the platform signature get
+substituted in — which is why validation had to be bolted on after the fact.
+
+Error-recovery contract: PR roc-lang/roc#9819 added `allow_user_errors`
+plumbing (coordinator + `src/cli/main.zig`) and `runtime_error_inserted`
+markers in `src/check/Check.zig` so runs can proceed past user errors by
+inserting runtime errors. That contract is orthogonal to this project and
+stays.
+
+## Evidence
+
+All symbols below verified in the current tree.
+
+- `applyPlatformRequiredSignatureSubstitutions`,
+  `cloneCheckedTypeRootSubstituting` — `src/check/checked_artifact.zig`.
+  Post-publication grafting of the platform scheme onto app checked roots.
+- `PlatformRequiredValidationSnapshot`, `finalizeExecutableArtifactsInternal`,
+  `appendPlatformRequiredUnresolvedDispatchReports`,
+  `staticDispatchPlanDispatcherExpr`, `platformRequiredOkTagPayload` —
+  `src/compile/coordinator.zig`. The snapshot records a `CanonicalTypeKey`
+  per dispatch plan (dispatcher + callable), per iterator plan, and per
+  checked pattern, then diffs after republish to find plans the substitution
+  changed. `platformRequiredOkTagPayload` finds `Try`'s success type by
+  string-comparing tag label text to `"Ok"`.
+- `specializeResolvedStaticDispatchPlanCallables` —
+  `src/check/checked_artifact.zig` (added by PR roc-lang/roc#9873).
+- The numeric-literal sweep: `appendPlatformRequiredInvalidNumeralDispatchReportIfNeeded`
+  in `src/compile/coordinator.zig` plus `numeralLiteralFitsBuiltin` /
+  `builtinNominalAcceptsNumeralLiteral` in `src/check/checked_artifact.zig`,
+  which re-render literal text and re-parse it (`parseIntFits`,
+  `parseFloatFits`) to decide range fit — outside the checker.
+- Bug cascade: issues roc-lang/roc#9540, #9541, #9542, #9559 (platform-typed
+  values misbehaving because the app never saw the platform types) → PR #9762
+  (~3k lines adding the snapshot/diff layer) → issue #9782 (nested dispatch
+  missed by the snapshot diff) → PR #9835 (chases one call-hop via
+  `staticDispatchPlanDispatcherExpr`) → issue #9857 → PR #9873 (+750 lines
+  incl. `specializeResolvedStaticDispatchPlanCallables` and
+  `platformRequiredOkTagPayload`) → regression issue #9890.
+- Issue roc-lang/roc#9565: a literal silently wraps when the platform implies
+  `I8`; fixed by the ~470-line coordinator/artifact literal sweep above,
+  matching by canonical-type-key equality — all because the checker never saw
+  the platform type at the literal's site.
+- PR roc-lang/roc#9762 also made headerless `roc check` synthesize a temp-dir
+  echo platform so that check sees platform types (see the default_app /
+  "echo platform" path in `src/cli/main.zig`) — a tacit admission that
+  checking against the real signature is the correct model.
+
+## Solution design
+
+Check the app *with* the platform's requires signature, the same way an
+explicit type annotation constrains a def.
+
+1. **Sequencing.** The coordinator already resolves the platform before the
+   app (the app header names it). Ensure the platform's header declarations —
+   the requires signature and any for-clause type parameters — are parsed,
+   canonicalized, and checked before the app module's check begins. Only the
+   platform *header/requires* surface is needed, not the platform's full body
+   check, so this does not lengthen the critical path materially.
+2. **For-clause instantiation.** For-clauses are bidirectional: the app
+   supplies types (like `Model`) that the requires signature references.
+   Ordering within the app's check: canonicalize the app far enough to know
+   its for-clause type declarations, instantiate the platform's requires
+   scheme with those types substituted for the for-clause parameters, then
+   check app defs.
+3. **Unification.** For each required definition (e.g. `main!`), unify the
+   instantiated scheme into the app def's type variable during checking,
+   exactly like `processRequiresTypes` handles annotation-shaped requires
+   types today. From that point on, `args` in `main! = |args|` has the
+   platform's type from the start; dispatch plans freeze against concrete
+   types; literals default and range-check against the real expected type;
+   pattern exhaustiveness sees the real unions.
+4. **Diagnostics.** All dispatch/pattern/literal validation for
+   platform-typed values becomes ordinary check-time diagnostics emitted by
+   the checker with real regions — no hand-built Reports in the coordinator.
+5. **Delete the shadow layer.** Once the checker owns this, delete (verify
+   exact current names by reading the code first, as they may drift):
+   - `PlatformRequiredValidationSnapshot` and its diff helpers
+     (`dispatchPlanChanged` etc.) in `src/compile/coordinator.zig`
+   - `appendPlatformRequiredUnresolvedDispatchReports`,
+     `staticDispatchPlanDispatcherExpr`, `platformRequiredOkTagPayload`,
+     `appendPlatformRequiredInvalidNumeralDispatchReportIfNeeded`, and the
+     other `platformRequired*` report builders in the coordinator
+   - the literal re-parse sweep support (`numeralLiteralFitsBuiltin` and
+     friends in `src/check/checked_artifact.zig`) once no caller remains —
+     the checker's own numeral machinery takes over
+   - most of `applyPlatformRequiredSignatureSubstitutions` and
+     `specializeResolvedStaticDispatchPlanCallables` in
+     `src/check/checked_artifact.zig`; whatever survives should be a
+     verification step (debug assertion that published roots already match),
+     not a rewrite step
+   - the temp-dir echo-platform synthesis for headerless `roc check` can
+     remain (it is now just "the default platform"), but it no longer papers
+     over a checking gap.
+6. **Migration order.** (a) land platform-before-app sequencing with the
+   unification behind a flag defaulting on; (b) port the repro suite from the
+   Evidence issues to expect check-time diagnostics; (c) delete the shadow
+   layer in one PR so no dead validation path lingers; (d) remove the flag.
+
+Data structures: no new ones. The requires scheme already exists in checked
+form (`requires_types` on the platform's ModuleEnv); the app-side change is a
+unification call plus for-clause substitution using existing
+instantiation machinery.
+
+## What success looks like
+
+- In an app compiled against a platform, `args` in `main! = |args|` has the
+  platform's declared type immediately after the app's check — observable in
+  the checked artifact without any coordinator post-processing.
+- The repros from issues #9540, #9541, #9542, #9559, #9782, #9857, and #9565
+  all produce ordinary check-time type errors with correct source regions.
+- `roc check` and `roc run` report byte-identical diagnostics for these
+  programs; nothing new appears only at build/finalize time.
+- `PlatformRequiredValidationSnapshot` and the `platformRequired*` coordinator
+  functions no longer exist in the tree.
+- Net line count in coordinator + checked_artifact drops by thousands.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+The invariant: **after the app module's check completes, no published checked
+type root changes.** Artifact publication is append/freeze, not rewrite.
+Enforce it with a debug assertion at publication: recompute the canonical type
+key of every root touched by platform-requirement finalization and assert
+equality with the pre-finalization key (the inverse of today's snapshot diff —
+kept only as a debug check, then removed once trusted). Secondary invariant:
+the coordinator constructs zero `Report` documents describing type errors; all
+type diagnostics originate in `src/check/`. A grep-level check ("no
+`platformRequired` identifiers outside tests") should hold. The full existing
+snapshot test corpus and the platform integration tests must pass with
+diagnostics moved earlier, never lost.
+
+### Performance ideal
+
+Checking the app against real types does strictly less total work than
+check-then-graft-then-revalidate: one unification during check replaces a
+whole-artifact substitution pass plus a whole-artifact snapshot/diff pass.
+Measure end-to-end `roc check` and `roc build` wall time on a platform-based
+app corpus (examples/ plus a large app). `roc build` must get faster (the
+snapshot alloc/diff over every plan and every pattern disappears). `roc check`
+on an app may pay for checking the platform's header surface first; keep that
+to header-only work so single-module check time regresses by no more than the
+cost of parsing/canonicalizing the platform header. Peak memory in the
+coordinator drops (no `CanonicalTypeKey` arrays sized by pattern count).
+
+## Tests to add
+
+- Repro tests (snapshot or integration) for #9540, #9541, #9542, #9559,
+  #9782, #9857, #9565, each asserting a check-time diagnostic naming the
+  app-side source region — and asserting `roc check` output equals `roc run`
+  output.
+- A for-clause test: platform requires signature referencing an app-supplied
+  `Model`; app provides it; a deliberate mismatch inside `main!` reports at
+  check time against the substituted scheme.
+- A regression guard for #9890's shape (whatever the coordinator sweep last
+  broke) now passing through the checker path.
+- A literal-range matrix: each builtin numeric type implied by a platform
+  signature × in-range/out-of-range literal → check-time fit error, no silent
+  wrap (the #9565 family).
+- A debug-build test asserting checked roots are identical before and after
+  executable finalization (the publication-freeze invariant).
+
+## Related projects
+
+- [../big/total-dispatch-plans.md](../big/total-dispatch-plans.md) — depends
+  on this project: dispatch plans cannot be total while platform-typed values
+  are still flex vars at check time.
+- [../big/exact-numeral-pipeline.md](../big/exact-numeral-pipeline.md) —
+  depends on this project: it removes one of the two places literal range
+  facts get dropped.
+- [../big/unify-build-pipelines.md](../big/unify-build-pipelines.md) —
+  independent, but benefits from the coordinator shedding its shadow
+  validation layer first.

--- a/projects/small/checked-arithmetic-lir-ops.md
+++ b/projects/small/checked-arithmetic-lir-ops.md
@@ -95,7 +95,7 @@ DEFINED at the LIR level so all five executors inherit one contract.
    the existing `assign_low_level` statement unchanged. (A
    `traps_on_overflow` flag on `assign_low_level` would also work, but
    every backend already switches on `op`; distinct ops keep those switches
-   flat and make unchecked ops impossible to mis-flag.) Define the
+   flat and make unchecked ops impossible to flag incorrectly.) Define the
    canonical crash message for each checked op in ONE table next to the op
    definitions; executors must use it verbatim.
 2. **Lowering**: both LIR lowerers emit the single checked op for integer

--- a/projects/small/checked-arithmetic-lir-ops.md
+++ b/projects/small/checked-arithmetic-lir-ops.md
@@ -1,0 +1,181 @@
+# Checked Arithmetic Ops in LIR
+
+## Problem
+
+Roc integer operations trap on overflow. That one sentence of semantics is
+currently implemented in THREE different layers, with three different
+mechanisms, and the layers do not agree on coverage or crash messages:
+
+1. **LIR lowering** (PR 9818) macro-expands overflow checks for multiply,
+   negate, abs, and division: `num_times` becomes a wrapping multiply
+   followed by "if rhs != 0 then quotient = result / rhs; crash if
+   quotient != lhs" (signed types additionally pre-check lowest × −1). So
+   EVERY integer multiplication in generated code carries a compare, a REAL
+   DIVISION, and another compare — at every opt level, on every backend.
+   The expansion was duplicated near-verbatim (~312 lines each) into BOTH
+   LIR lowerers, and the copies already show cosmetic drift. The "is this
+   an integer layout" predicate is literally
+   `integerDivisionByZeroMessage(layout) == null` — a diagnostic-message
+   table reused as a type test.
+2. **The dev backend and interpreter** (PR 9761) implement add/sub overflow
+   themselves: `emitCheckedIntAddSubOverflow` in
+   src/backend/dev/LirCodeGen.zig, ADCS support in the aarch64 emitter, and
+   `@addWithOverflow`-based checks in src/eval/interpreter.zig.
+3. **The LLVM backend** was untouched by 9761: `num_plus` maps to a plain
+   `add` in `emitNumericBinary` (src/backend/llvm/MonoLlvmCodeGen.zig) —
+   add/sub overflow there is only "checked" because LIR lowering never
+   expands add/sub, i.e. it is not checked at all by that layer.
+
+This split produced a stream of engine-divergence bugs: issues 9360/9361
+(dev backend silently wrapped u8 add/sub while the interpreter errored —
+differently), and 9783/9812/9813/9814 (mul/negate/abs/div wrapped or hit
+UB). Engine divergence is the current bug detector.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck:
+Monotype IR → Monotype Lifted → Lambda Solved → Lambda Mono → LIR lowering →
+ARC insertion → backends. design.md at the repo root is authoritative.
+
+There are TWO LIR lowerers — src/postcheck/solved_lir_lower.zig (~7.7k
+lines, production, lowers Lambda Solved IR directly) and
+src/postcheck/lir_lower.zig (~4.2k lines, a parallel Lambda-Mono-based
+lowerer used by debug verification/test harnesses). Fixes routinely have to
+land twice, and the copies drift.
+
+FIVE executors run Roc code: the interpreter (src/eval/interpreter.zig),
+dev backends for x86-64 and aarch64 (src/backend/dev/), the LLVM backend
+(src/backend/llvm/MonoLlvmCodeGen.zig), and the wasm backend
+(src/backend/wasm/). LIR is the last IR they all share, which makes it the
+right place to define semantics once.
+
+LIR op encoding: numeric primitives are members of the shared `LowLevel`
+enum (src/base/LowLevel.zig — `num_plus`, `num_minus`, `num_times`,
+`num_negate`, `num_abs`, `num_div_by`, `num_div_trunc_by`, ...) carried on
+the `assign_low_level` control-flow statement in src/lir/LIR.zig
+(`{ target, op, rc_effect, args, next }`).
+
+## Evidence
+
+- PR roc-lang/roc#9818 (fix-integer-overflow-lir):
+  `lowerIntegerOverflowCheckedMultiplicationLowLevelInto`,
+  `lowLevelNeedsIntegerMultiplicationOverflowCheck` (matches `num_times`),
+  `lowLevelNeedsSignedIntegerLowestCheck` (`num_negate`, `num_abs`),
+  `signedIntegerLowestValue`, and the div-by-zero / lowest÷−1 expansion —
+  all in src/postcheck/solved_lir_lower.zig AND src/postcheck/lir_lower.zig.
+  The type test `integerDivisionByZeroMessage(lhs_layout) == null` gates
+  the expansion in both.
+- PR roc-lang/roc#9761 (fix-dev-checked-int-arithmetic):
+  `emitCheckedIntAddSubOverflow` and `emitCheckedI128AddSubOverflow` in
+  src/backend/dev/LirCodeGen.zig — u64/i64/i128/u128 via CPU flags
+  (`condOverflow`, `condUnsignedAddOverflow`), narrower-than-64-bit ints do
+  the op at 64-bit then range-check (`emitUnsignedIntRangeCheck`,
+  `emitSignedIntRangeCheck`); `adcsRegRegReg` added to
+  src/backend/dev/aarch64/Emit.zig; interpreter `checkedIntAdd` /
+  `checkedIntSub` → `triggerCrash` using `@addWithOverflow` in
+  src/eval/interpreter.zig.
+- LLVM gap: `emitNumericBinary` in src/backend/llvm/MonoLlvmCodeGen.zig
+  maps `.num_plus => .add` (plain, no overflow intrinsic).
+- Message drift is already visible: the LIR expansion crashes with
+  "integer multiplication overflowed" while dev/interpreter add/sub crash
+  with "Integer addition overflowed!".
+- Issues: roc-lang/roc#9360, #9361, #9783, #9812, #9813, #9814. The same
+  engine-divergence bug class extends beyond overflow, e.g. float→int
+  conversions (PR roc-lang/roc#9648).
+
+## Solution design
+
+Add checked arithmetic to LIR itself, with crash-on-overflow semantics
+DEFINED at the LIR level so all five executors inherit one contract.
+
+1. **Encoding**: add checked members to the `LowLevel` enum, following the
+   existing naming scheme: `num_plus_checked`, `num_minus_checked`,
+   `num_times_checked`, `num_negate_checked`, `num_abs_checked`, and
+   checked division variants covering div-by-zero and lowest÷−1. They ride
+   the existing `assign_low_level` statement unchanged. (A
+   `traps_on_overflow` flag on `assign_low_level` would also work, but
+   every backend already switches on `op`; distinct ops keep those switches
+   flat and make unchecked ops impossible to mis-flag.) Define the
+   canonical crash message for each checked op in ONE table next to the op
+   definitions; executors must use it verbatim.
+2. **Lowering**: both LIR lowerers emit the single checked op for integer
+   layouts (one shared predicate on `layout.Idx`, replacing the
+   `integerDivisionByZeroMessage(...) == null` trick) and the plain op
+   otherwise. DELETE the macro-expansions from both lowerers:
+   `lowerIntegerOverflowCheckedMultiplicationLowLevelInto`, the
+   signed-lowest expansion for negate/abs, the div-by-zero/lowest÷−1
+   expansion, and the diagnostic-table type test (~312 lines × 2).
+3. **Backends** map checked ops to native facilities:
+   - LLVM: `@llvm.sadd/uadd/ssub/usub/smul/umul.with.overflow` intrinsics +
+     conditional branch to a crash block.
+   - Dev x86-64: flags — `jo`/`seto` after add/sub/imul; unsigned mul via
+     the carry/overflow flag of `mul`/`mulx` (high-half nonzero check).
+   - Dev aarch64: `ADDS`/`SUBS`/`ADCS` + overflow flag; mul via widening
+     multiply (`smulh`/`umulh`) high-half check. PR 9761's existing
+     machinery (`emitCheckedIntAddSubOverflow` and friends) moves behind
+     the checked ops rather than behind `num_plus`.
+   - Wasm: explicit compare-based expansion written ONCE, in the wasm
+     backend (src/backend/wasm/WasmCodeGen.zig), which already has
+     carry-tracking 128-bit routines to build on.
+   - Interpreter: `@addWithOverflow` / `@subWithOverflow` /
+     `@mulWithOverflow` → `triggerCrash` with the canonical message.
+4. **Migration order**: add ops + interpreter support; port LLVM (closing
+   the add/sub gap); port dev backends; port wasm; flip both lowerers to
+   emit checked ops; delete the expansions; land the conformance suite
+   before the flip so old and new paths are compared.
+
+## What success looks like
+
+- No division instruction is emitted anywhere for a multiply overflow
+  check, on any backend.
+- One place (the LIR op table) defines overflow semantics and crash
+  messages; all five executors inherit them.
+- Both lowerers emit the same single checked op; the ~624 duplicated
+  expansion lines and the diagnostic-table type test are gone.
+- LLVM-compiled code traps on add/sub overflow (it currently does not).
+
+## How to evaluate the result
+
+### Correctness ideal
+
+A cross-engine conformance suite: identical numeric programs run on
+interpreter / dev-x86-64 / dev-aarch64 / LLVM / wasm, asserting identical
+results INCLUDING crash messages, over boundary values per width and op:
+min/max, min±1/max±1, 0, lowest × −1, lowest ÷ −1, div by zero — for every
+integer width u8..u128/i8..i128. Build the suite to be extended: the
+engine-divergence bug class is bigger than overflow (float→int conversions,
+PR 9648, belong in the same harness).
+
+### Performance ideal
+
+- Hot numeric loop benchmarks (dev and LLVM) before/after:
+  multiplication-heavy code should speed up materially since the division
+  disappears from every multiply.
+- ReleaseFast assembly spot-check: LLVM emits a mul + `jo`-style pattern
+  (or `umulh` check on aarch64), not a `div`.
+- No regression for unchecked ops (float math, wrapping intrinsics) — they
+  keep their existing single-instruction paths.
+- Compile speed: LIR statement counts per function drop (no expansion
+  trees), which should slightly improve downstream pass times; verify
+  LIR-lowering time does not regress.
+
+## Tests to add
+
+- The cross-engine conformance suite described above (all five executors,
+  identical outputs and crash messages).
+- Per-op boundary tests for each integer width: add/sub/mul/negate/abs/div
+  at min, max, ±1 around them, 0, lowest × −1, lowest ÷ −1, div by zero.
+- A codegen test asserting the lowered LIR for an integer multiply contains
+  no `num_div_trunc_by` (statement-level assertion on the lowered output).
+- A test that both lowerers produce identical LIR for the same numeric
+  function (guards against future drift until the pipelines unify).
+
+## Related projects
+
+- [Unify the two build pipelines](../big/unify-build-pipelines.md) — ends
+  the land-every-fix-twice tax that doubled this feature's cost.
+- [A decision-tree match compiler](../big/decision-tree-match-compiler.md)
+  — same philosophy: define behavior once at the LIR boundary instead of
+  patching each consumer.
+- [A single exact-numeral pipeline](../big/exact-numeral-pipeline.md) — its
+  literal-heavy conformance tests should run in this suite's harness.

--- a/projects/small/cross-phase-coverage-parity-tests.md
+++ b/projects/small/cross-phase-coverage-parity-tests.md
@@ -1,0 +1,220 @@
+# Coverage-Parity Tests for Cross-Phase Predicates
+
+## Problem
+
+Several facts in the compiler are computed by a PRODUCER enumeration in one
+phase and consumed by a SEPARATE hand-enumerated switch in another phase,
+with no mechanical coupling between the two. When the enumerations drift —
+a new variant on the producer side, a missing arm on the consumer side —
+the failure mode is a user-visible compiler panic on some future program,
+not a test failure at development time.
+
+This has already happened: issue roc-lang/roc#9696 was a panic because the
+divergence producer could mark an `if` expression divergent while the
+Monotype consumer had no lowering arm for it; PR roc-lang/roc#9719 added
+the `.if_` arm AFTER the panic shipped. An audit of the two switches today
+shows the same gap is still open for roughly seventeen more expression
+kinds (eighteen by direct comparison; see Evidence). Nothing prevents the
+next drift, and nothing detects it before a user does.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check (src/check/Check.zig;
+unification in src/check/unify.zig; rows are how records and tag unions are
+typed — a row can be open or closed) → checked artifacts → postcheck:
+Monotype IR → Lifted → Lambda Solved → Lambda Mono → LIR → ARC → backends.
+design.md at the repo root is authoritative.
+
+The checker publishes checked artifacts (src/check/checked_artifact.zig)
+that postcheck consumes without re-inference. Several properties cross that
+boundary as PREDICATES rather than as explicit data: "this expression
+diverges", "this pattern can fail to match", "this exhaustiveness site is
+compile-time-only", "this problem still permits lowering". Each side of the
+boundary encodes the predicate as its own switch over its own IR's variants.
+The two switches are supposed to agree; agreement is currently enforced by
+nothing (cases 1, 2), by runtime panics during compile-time finalization
+(case 3), or by a conservative default chosen by human judgment (case 4).
+
+## Evidence
+
+Four concrete producer/consumer pairs, all verified in the current tree:
+
+1. **Divergence.** Producer: `checkedExprDataDiverges` in
+   src/check/checked_artifact.zig can mark ~26 expression kinds divergent —
+   `crash`/`ellipsis`/`break_`/`return_`/`expect_err` directly, and
+   `str`, `list`, `tuple`, `match_`, `if_`, `call`, `record`, `block`,
+   `tag`, `nominal`, `binop`, `unary_minus`, `unary_not`, `dbg`, `expect`,
+   `field_access`, `structural_eq`, `structural_hash`, `tuple_access`,
+   `for_`, `run_low_level` via divergent children. Consumer:
+   `lowerDivergentExprDataAtType` in src/postcheck/monotype/lower.zig
+   hand-enumerates NINE arms (`block`, `match_`, `if_`, `ellipsis`,
+   `crash`, `runtime_error`, `expect_err`, `break_`, `return_`) and ends
+   with `else => Common.invariant("checked expression was marked divergent
+   but has no divergent lowering path")`. Direct comparison: 18 kinds the
+   producer can mark that have NO consumer arm — e.g. a divergent
+   `.nominal` via `Ok({ crash "x" })`, a divergent `.call` argument, a
+   divergent `.binop` operand. The 9696-class panic is open TODAY for all
+   of them. Divergence is also independently re-derived at least four
+   times across the pipeline: `checkedExprDataDiverges` (producer),
+   `checkedExprDivergesInLoweredRuntime` /
+   `checkedStatementDivergesInLoweredRuntime` (monotype/lower.zig, because
+   optimized builds omit inline expects), and the statement-position
+   variants `exprAlwaysCrashes` / `exprIsAllCrashConditional` in
+   src/check/Check.zig from PR 9719 — the latter recognizes only `e_if`
+   (looking through `e_block` finals).
+
+2. **Refutability.** Three syntactic predicates over three different IRs:
+   `patternNeedsExhaustiveness` (src/check/Check.zig, over CIR patterns),
+   `patternCanMiss` (src/postcheck/monotype/lower.zig `BodyContext`, over
+   checked patterns), and `patternCanMiss` (src/postcheck/lir_lower.zig
+   `Lowerer`, over Lambda Mono patterns). Their verdicts are NOT identical:
+   the Check.zig and monotype versions treat every `.list` pattern as
+   refutable, while the LIR version knows `[..]` / `[.. as rest]` is
+   irrefutable. All disagreements happen to err conservative today (extra
+   miss paths, never missing ones), but nothing checks the three against
+   each other or against the exhaustiveness matrix's verdict.
+
+3. **Comptime-site classification.** Two parallel depth counters that must
+   stay synchronized: `empirical_exhaustiveness_depth` (src/check/Check.zig
+   checker field) classifies exhaustiveness diagnostics under compile-time
+   value construction as "empirical candidates";
+   `comptime_exhaustiveness_depth` (src/postcheck/monotype/lower.zig,
+   specialization-context field) must classify the SAME sites the same way
+   during lowering. Agreement is enforced only by finalization panics in
+   src/eval/compile_time_finalization.zig (`finalizationInvariant("empirical
+   exhaustiveness failure had no pending static diagnostic")`, "...had an
+   impossible site policy") — PR roc-lang/roc#9642's regime. Its site
+   identity already broke once within five days of landing, when PR
+   roc-lang/roc#9722's hoisting duplicated checked regions.
+
+4. **Error-recovery lowerability.** `problemAllowsLoweringWithUserErrors`
+   in src/compile/compile_package.zig (from PR roc-lang/roc#9819) decides
+   per problem kind whether lowering may proceed with user errors present.
+   Discrepancy with the expected shape, noted per the code: the top-level
+   switch is NOT comptime-exhaustive — it enumerates only
+   `.static_dispatch` (whose inner switch IS exhaustive) and ends with
+   `else => false`. New problem kinds therefore get a silent conservative
+   default by omission, not an explicit entry by human judgment: safe
+   against panics, but silently degrades error-recovery behavior with no
+   forcing function to consider each new kind.
+
+## Solution design
+
+Build an architecture-test suite — ordinary Zig test files, run by
+`zig build test` — that mechanically asserts parity for each pair. The
+suite is also a copyable PATTERN: future producer/consumer pairs get parity
+tests by convention, with these four as the templates.
+
+1. **Divergence parity suite.** A table-driven fixture that constructs a
+   minimal checked-artifact instance of EVERY expression kind placed in a
+   divergent position (e.g. wrapping a `crash` child), then asserts: if
+   `checkedExprDataDiverges` marks it, `lowerDivergentExprDataAtType`
+   lowers it without reaching the `else => invariant` arm. Where feasible,
+   use comptime reflection over the `CheckedExprData` enum to force the
+   fixture list to cover every variant — a newly added variant becomes a
+   COMPILE ERROR in the test until a fixture (or an explicit
+   cannot-be-divergent justification entry) is added. The FIRST deliverable
+   of this suite is triaging the 18 currently-open kinds: for each, either
+   fix the consumer (add a lowering arm), fix the producer (prove the kind
+   cannot be marked divergent and encode that), or document why the
+   combination is unreachable — with the test enforcing whichever answer.
+2. **Refutability parity suite.** A generated pattern corpus covering every
+   pattern kind of each IR, including nested combinations (tags in tuples,
+   lists in records, `as` wrappers, nominal backing patterns). For each
+   pattern, run all three predicates on the corresponding representation
+   and assert either agreement, or that any disagreement is in the
+   documented-conservative direction (a later phase may say "cannot miss"
+   only if an earlier phase agreed, never the reverse). Cross-check against
+   the exhaustiveness matrix where a checked type is available.
+3. **Depth-counter parity suite.** Preferred fix: EXTRACT one shared
+   site classifier that both `empirical_exhaustiveness_depth` maintenance
+   in Check.zig and `comptime_exhaustiveness_depth` maintenance in
+   monotype/lower.zig call, so divergence is structurally impossible.
+   If extraction proves impractical across the two IRs, the fallback is a
+   cross-check test: compile a set of representative programs (comptime
+   constructions containing matches, destructures, hoisted roots, nested
+   guards) and assert the two counters classify every exhaustiveness site
+   identically — turning the finalization panic into a test failure.
+4. **Problem-kind suite.** Restructure `problemAllowsLoweringWithUserErrors`
+   so the top-level switch is comptime-exhaustive over problem kinds (no
+   `else`), forcing an explicit entry per kind; then add a test asserting
+   every entry carries an explicit rationale — either by restructuring into
+   a table with a required `rationale` field per row, or by a doc-comment
+   convention checked in review. The conservative meaning of "not listed"
+   is preserved by writing it explicitly.
+
+Nothing in the compiler's runtime path changes except where a suite's first
+deliverable finds a real bug (the divergence arms, possibly a shared site
+classifier). What gets DELETED: nothing initially; if suite 3's shared
+classifier lands, the duplicated per-phase classification logic around the
+two depth counters is deleted in favor of the shared function.
+
+## What success looks like
+
+- Adding a divergence-markable expression kind without a corresponding
+  lowering arm fails `zig build test` — not a user's build, months later.
+- The 18 open divergence kinds are resolved: lowered, producer-restricted,
+  or proven unreachable, each with a test pinning the answer.
+- The three refutability predicates are either in agreement or their
+  disagreements are enumerated in one test file with the conservative
+  direction asserted.
+- The two exhaustiveness depth counters cannot silently diverge: either one
+  shared classifier exists, or the cross-check test covers every site kind.
+- Every problem kind has an explicit, visible lowerability decision.
+- A CONTRIBUTING-visible pattern exists: new producer/consumer predicate
+  pairs ship with a parity test.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- The parity property is total over enum variants BY CONSTRUCTION: where
+  comptime reflection is feasible, the test enumerates variants from the
+  type itself, so coverage cannot rot through fixture-list discipline. Only
+  where reflection is genuinely infeasible does a hand-maintained fixture
+  list (guarded by a variant-count assertion) substitute.
+- Each suite fails with a message naming the exact variant and the exact
+  producer/consumer pair that drifted.
+- The finalization invariants in src/eval/compile_time_finalization.zig
+  remain as last-resort backstops but are no longer the FIRST line of
+  defense for counter drift.
+
+### Performance ideal
+
+- Zero compiler runtime cost: these are tests only; no new checks, passes,
+  or data structures in the compiled compiler (except the optional shared
+  site classifier, which replaces duplicated logic rather than adding any).
+- The whole suite runs in seconds as part of `zig build test` — fixtures
+  are minimal constructed IR instances, not end-to-end compiles, except the
+  small representative-program set in suite 3.
+
+## Tests to add
+
+This project IS tests. The four suites, concretely:
+
+1. Divergence: comptime-enumerated fixture per `CheckedExprData` variant in
+   a divergent position; assert producer-marked implies consumer-lowerable;
+   regression fixtures for `Ok({ crash "x" })` (divergent `.nominal`) and
+   the original 9696 `if` shape.
+2. Refutability: generated nested-pattern corpus; three-way predicate
+   agreement with documented-conservative exceptions; list-rest patterns
+   (`[..]`, `[.. as rest]`, `[x, ..]`) as pinned cases.
+3. Depth counters: representative comptime programs; assert per-site
+   classification parity between checker and monotype lowering (or unit
+   tests of the extracted shared classifier).
+4. Problem kinds: comptime-exhaustive switch (compile failure on a new
+   kind) plus the rationale-per-entry assertion.
+
+## Related projects
+
+- [../big/decision-tree-match-compiler.md](../big/decision-tree-match-compiler.md)
+  — consumes the refutability suite: a decision-tree match compiler
+  replaces per-IR `patternCanMiss` walks with one authoritative analysis.
+- [../big/total-dispatch-plans.md](../big/total-dispatch-plans.md) — the
+  same explicit-data discipline applied to dispatch, shrinking the set of
+  cross-phase predicates that need parity tests at all.
+- [../small/check-app-against-platform-requires.md](../small/check-app-against-platform-requires.md)
+  — another boundary where producer and consumer enumerations must agree.
+- [./structural-hoist-contexts.md](./structural-hoist-contexts.md) — PR
+  9722's hoisting broke comptime-site identity (suite 3's history); its
+  structural-context fix removes one source of site duplication.

--- a/projects/small/glue-consumes-committed-layouts.md
+++ b/projects/small/glue-consumes-committed-layouts.md
@@ -24,7 +24,7 @@ History proves the hazard. PR 9721 changed nominal record layout
 kept emitting the OLD order the same day — shipped wrong bindings until
 PR 9738. That fix shared only the field-ORDERING function; the
 offset/size/padding arithmetic is still duplicated. Open issues in the
-same area: 9824 (glue mis-sizes unresolved type variables as zero-sized
+same area: 9824 (glue incorrectly sizes unresolved type variables as zero-sized
 — visible in `getSizeAlign`'s out-of-range and `.unknown` fallbacks
 returning `.{ .size = 0, ... }`) and 9645 (ZigGlue stale entrypoint ABI
 declarations).

--- a/projects/small/glue-consumes-committed-layouts.md
+++ b/projects/small/glue-consumes-committed-layouts.md
@@ -1,0 +1,216 @@
+# Glue Consumes Committed Layouts
+
+## Problem
+
+`roc glue` generates host-language bindings (Zig, Rust, C headers) whose
+struct layouts MUST byte-match the layouts the compiler commits for
+runtime values — a wrong offset is silent memory corruption at the
+host/app boundary. Today glue does not read those layouts; it
+re-implements the layout arithmetic and hopes to agree.
+
+The duplication is threefold. The layout store computes committed layouts
+for codegen (`putNominalStructFields` in `src/layout/store.zig`). Glue's
+`TypeTable` recomputes offsets, sizes, and padding in Zig
+(`nominalRecordInDeclaredOrder` in `src/glue/glue.zig`, whose doc comment
+says "matching the layout store's `putNominalStructFields`" — a comment
+is the only binding). And the glue generator scripts recompute it a third
+time in Roc: `src/glue/src/ZigGlue.roc` carries its own
+`record_layout_from_fields`/`record_layout_from_fields_32`,
+`type_layout_32`/`type_layout_64`, and `tag_union_layout_32` to emit both
+64-bit and wasm32 struct variants and their comptime assertions.
+
+History proves the hazard. PR 9721 changed nominal record layout
+(declared field order plus explicit padding fields) and glue silently
+kept emitting the OLD order the same day — shipped wrong bindings until
+PR 9738. That fix shared only the field-ORDERING function; the
+offset/size/padding arithmetic is still duplicated. Open issues in the
+same area: 9824 (glue mis-sizes unresolved type variables as zero-sized
+— visible in `getSizeAlign`'s out-of-range and `.unknown` fallbacks
+returning `.{ .size = 0, ... }`) and 9645 (ZigGlue stale entrypoint ABI
+declarations).
+
+## Background
+
+The compiler pipeline is: parse → canonicalize → type-check (producing
+checked artifacts per module) → postcheck lowering → LIR → backends. Two
+build-orchestration paths wrap the `Coordinator`
+(`src/compile/coordinator.zig`): `roc check`/`roc build`/docs go through
+`BuildEnv` (`src/compile/compile_build.zig`), and the dev-mode run path
+goes through `lowerLirWithCoordinator` (`src/cli/main.zig`). Glue is a
+BuildEnv consumer: `rocGlueInner` (`src/glue/glue.zig`) builds the
+platform with a `BuildEnv`, walks the checked artifacts of the platform's
+modules into a `TypeTable`, serializes that table into a Roc value, and
+runs a generator script (`ZigGlue.roc`, `RustGlue.roc`, ...) that emits
+the binding source text.
+
+Layout facts a newcomer needs (`design.md` sections "Nominal Record Field
+Order" and "Host Symbol ABI" are authoritative):
+
+- Structural (anonymous) records lay out by a target-independent sort
+  (descending sort key, then name); nominal records that opt in with an
+  unnamed `_` field lay out in DECLARED order with C-style padding, so a
+  Roc nominal record can mirror an exact C struct. PR 9738 extracted the
+  ordering into `src/layout/field_order.zig`
+  (`computeStructuralFieldOrder`), called by BOTH `src/layout/store.zig`
+  and `src/glue/glue.zig`. (Older notes mention a
+  `computeNominalFieldOrder` there; it does not exist — nominal
+  declared-order layout is implemented separately in the store AND in
+  glue, which is precisely this project's target.)
+- Layouts are target-dependent via pointer width. PR 9831 ("consolidate
+  the layout stores") made layout/LIR pointer-width independent with
+  per-target resolution: the layout `Store` is parameterized by
+  `target_usize` (`store.init(allocator, target_usize)`), and sizes
+  resolve per target (`sizeAt(layout, target_usize)`). Glue's `TypeTable`
+  is likewise parameterized but is constructed with
+  `base.target.TargetUsize.native` only; the wasm32 numbers in generated
+  Zig come from ZigGlue.roc's own Roc-side arithmetic.
+- PR 9894 (issue 9865) is the model this project extends: glue used to
+  resolve a nominal type's DECLARING MODULE by module-name text with a
+  wrong-artifact fallback (indexing a CIR statement of the wrong kind →
+  panic). The fix stores declared field order in checked artifacts
+  (`CheckedNominalRecordField`, `declaredRecordFields` in
+  `src/check/checked_artifact.zig`) and resolves declarations through the
+  nominal REPRESENTATION keyed by artifact
+  (`nominalDeclarationFor`/`artifactByKey` in `src/glue/glue.zig`,
+  `importedNominalDeclarationModuleId`). Data glue needs now travels in
+  the artifact instead of being re-derived — layout values should travel
+  the same way.
+
+Agreement today is checked only downstream: generated bindings embed
+comptime size/align/offset assertions (see the `@compileError` emission
+in ZigGlue.roc), and the glue CLI suite
+(`src/cli/test/parallel_cli_runner.zig`, fixtures under `test/glue/` such
+as `zig-layout-platform` and `platform-shapes`) compiles them. That
+catches some drift at test time — it does not make drift impossible, and
+it only covers shapes the fixtures happen to exercise.
+
+## Evidence
+
+- `src/glue/glue.zig`: `rocGlue`/`rocGlueInner`; `TypeTable.init(gpa,
+  target_usize, &artifacts_by_key)` with `TargetUsize.native`;
+  `nominalRecordInDeclaredOrder` (the duplicated offset walk: align-up
+  per field, accumulate, round size up to max alignment);
+  `getSizeAlignForRepr` (re-derives scalar/str/list/box sizes from
+  `target_usize`; `.unknown` and out-of-range ids → size 0 — issue 9824);
+  `nominalDeclarationFor` (PR 9894's artifact-keyed resolution).
+- `src/layout/store.zig`: `putNominalStructFields`, `targetUsize`,
+  `sizeAt`; tests "putNominalStructFields keeps a padding-free declared
+  order verbatim" and "... inserts C-style padding".
+- `src/layout/field_order.zig`: `computeStructuralFieldOrder`, shared by
+  store and glue since PR 9738; its header comment states nominal
+  declared-order layout is done "directly by the layout store and the
+  glue generator, not here".
+- `src/glue/src/ZigGlue.roc`: third copy of the arithmetic
+  (`record_layout_from_fields`, `record_field_layout_32/64`,
+  `type_layout_32/64`, `tag_union_layout_32`) and the emitted comptime
+  assertions for `@sizeOf(usize) == 8` and `== 4`.
+- `src/layout/abi/` (`x86_64.zig`, `aarch64.zig`, `wasm.zig`, `call.zig`):
+  per-target C-ABI call classification lives compiler-side already.
+- `src/check/checked_artifact.zig`: `CheckedNominalRecordField`,
+  `declaredRecordFields`, `paddingFieldTypes`.
+- PRs (roc-lang/roc): 9721, 9738, 9894, 9831. Issues: 9865, 9824, 9645.
+
+## Solution design
+
+Glue stops computing layout and CONSUMES the layout store's committed
+layouts. Offsets, sizes, alignment, and padding for every glue-exposed
+type come from the same source codegen uses.
+
+1. **Expose committed layouts to glue.** Give glue access to a layout
+   `Store` (or a serialized per-target layout view derived from one)
+   resolved from the platform's checked artifacts — one store per target
+   pointer width glue emits (today: native/64-bit and wasm32; the store
+   is already `target_usize`-parameterized, so this is two
+   instantiations, not new machinery). For each type reaching the
+   `TypeTable`, record the committed `size`, `alignment`, and per-field
+   offsets per target, alongside the existing shape description.
+2. **DELETE glue's Zig-side arithmetic.** `nominalRecordInDeclaredOrder`'s
+   offset walk (the align-up/accumulate/round-up block) and the
+   size-deriving arms of `getSizeAlignForRepr` are deleted;
+   declared-order field NAMES and padding spacers still come from
+   `declaredRecordFields` (PR 9894's data), but every number attached to
+   them is read from the store. An unresolved type variable has no
+   committed layout — that becomes a glue-time error, fixing issue 9824's
+   class (never a zero-sized field).
+3. **DELETE the Roc-side arithmetic.** Extend the glue platform's
+   `TypeTable`/`RecordField` Roc types (under `src/glue/platform/`) to
+   carry per-target layout values, and delete
+   `record_layout_from_fields*`, `type_layout_32/64`, and
+   `tag_union_layout_32` from ZigGlue.roc (and any Rust/C equivalents).
+   Generators format numbers; they do not derive them. The emitted
+   comptime assertions REMAIN — they become a check of the host
+   toolchain's agreement with committed layouts rather than of one
+   duplicate against another.
+4. **Keep per-language/per-ABI emission in glue, fed by committed
+   values.** Deciding how to spell an extern struct, a discriminant type,
+   or an entrypoint signature per language stays in the generators; call
+   classification stays compiler-side in `src/layout/abi/`. Glue takes
+   layout values as INPUTS everywhere.
+5. **Direction (out of scope here): a host ABI manifest.** The long-term
+   shape is a per-platform manifest — boundary symbol signatures plus
+   committed layouts — derived once, hashed into the platform artifact,
+   consumed by codegen AND glue, making host/app layout drift a load-time
+   error rather than a codegen-time one. This project creates the
+   committed-layout consumption path that manifest would formalize.
+
+## What success looks like
+
+- No offset/size/padding arithmetic exists under `src/glue/` — `grep -rn
+  "alignment - rem\|% field.alignment" src/glue` matches nothing, and
+  ZigGlue.roc contains no `*_layout_*` arithmetic functions.
+- A compiler layout-rule change cannot produce stale bindings: glue reads
+  the changed store, so regenerated bindings move in lockstep, and the
+  emitted comptime assertions verify the host compiler agrees.
+- Issue 9824's class is closed: a type with no committed layout is a
+  reported glue error naming the type, never a zero-sized field.
+- Every layout number in generated output is traceable to a layout-store
+  read for an explicit target.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+End-to-end FFI layout probes: for EVERY glue-exposed type shape —
+structural records, nominal records with the `_` padding opt-in, boxed
+values, tag unions including single-variant and >u8 discriminant counts,
+slices/strings — a generated host program asserts
+`offsetof`/`sizeof`/`alignof` equality against compiler-emitted values,
+per target, extending the FFI e2e coverage added around PR 9721
+(`src/cli/test/parallel_cli_runner.zig` glue suite + `test/glue/`
+fixtures). Plus repros for issues 9824 and 9865. Ideal state: it is not
+possible to construct a platform type whose generated binding disagrees
+with the committed layout, because there is exactly one producer of
+layout numbers.
+
+### Performance ideal
+
+Glue generation time unchanged or better — reading committed layouts
+beats recomputing them (and the per-target store instantiations are
+amortized over the whole platform). Zero compiler-runtime cost: the
+layout store already computes everything codegen needs; this project only
+adds reads at glue time. Generated-binding compile time is unchanged (the
+comptime assertions already exist).
+
+## Tests to add
+
+- The probe matrix above, parameterized over type shape × target
+  (native 64-bit and wasm32 at minimum), asserting offset/size/alignment
+  agreement end to end.
+- A drift canary: mutate a layout rule in a test build (e.g. flip the
+  structural sort tie-break) and verify glue output changes in lockstep —
+  or, if the mutation is host-visible, that the generated comptime
+  assertions fail loudly. Either outcome proves no silent stale-binding
+  path exists.
+- Issue 9824 repro: a platform exposing an unresolved type variable must
+  produce a glue-time error naming the type, not a zero-sized field.
+- Issue 9865 repro stays green: nominal record declared in one platform
+  module, re-exported and used from another, glued and byte-checked.
+
+## Related projects
+
+- [Content-based nominal identity](../big/content-based-nominal-identity.md)
+  — fully fixes the declaring-module resolution class PR 9894 patched;
+  this project consumes its artifact-keyed resolution model.
+- [Cache hardening](../small/cache-hardening.md) — committed layouts read
+  from cached artifacts are only as trustworthy as the cache's
+  enforcement edges.

--- a/projects/small/shared-checked-type-traversal.md
+++ b/projects/small/shared-checked-type-traversal.md
@@ -1,0 +1,193 @@
+# A Shared Cycle-Guarded Checked-Type Traversal
+
+## Problem
+
+Every traversal of checked types must guard against cycles, and today that
+discipline is per-site folklore. Grepping for the dominant idiom —
+`AutoHashMap(_, void).init` visited/active sets — finds **105** instantiation
+sites across `src/check`, `src/types`, and `src/postcheck`, **34 of them in
+`src/check/checked_artifact.zig` alone**. At least four *other* cycle-guard
+idioms coexist:
+
+- `src/check/occurs.zig` uses a shared `Scratch` of visited vars,
+- `src/types/TypeWriter.zig` keeps `seen` / `seen_count_var_occurrences`
+  linear lists,
+- `src/check/snapshot.zig` keeps `seen_vars: base.Scratch(Var)`,
+- `src/postcheck/monotype_lifted/spec_constr.zig` linear-scans active stacks
+  (`inline_stack`, `callable_stack`, `loop_stack`).
+
+On top of that, `checked_artifact.zig` contains many near-copies of the same
+"does this type contain identity variables" walk: `checkedTypeContains-`
+`IdentityVariables` (+ slice/payload variants), two separate
+`typeContainsIdentityVariables` families on different structs,
+`typeWriteContainsIdentityVariables`, `sourceTypeContainsIdentityVariables`,
+`finalizeContainsIdentityVariables`, `mergeContainsIdentityVariables` (record
+and tag variants), and `pendingRootContainsIdentityVariables` — each with its
+own hand-rolled cycle guard.
+
+The failure this causes is not hypothetical. In the platform-relation
+resolver (`PlatformAppRelationTypeResolver` in `checked_artifact.zig`, which
+merges platform and app types across a platform `requires` boundary), the
+`finalizing` memo map was declared, initialized, deinited, and **read** —
+`if (self.finalizing.get(root)) |existing| return existing;` — but never
+**written**, from the commit that introduced it. Dead scaffolding. A
+recursive type crossing the boundary recursed forever
+(`test/cli/issue9717-platform`, the recursive `Elem` tree), fixed by PR
+roc-lang/roc#9727. When each traversal hand-rolls its guard, "forgot the
+`put`" compiles cleanly and only fails on recursive inputs.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check (produces "checked
+artifacts" per module) → postcheck: Monotype IR (monomorphization/
+specialization, `src/postcheck/monotype/` — `lower.zig` is ~21k lines) →
+Monotype Lifted (closure lifting; also `spec_constr.zig` call-pattern
+specialization for optimized builds) → Lambda Solved → Lambda Mono → LIR →
+ARC → backends. `design.md` at the repo root is authoritative.
+
+Checked artifacts store types in a `CheckedTypeStore`
+(`src/check/checked_artifact.zig`; ids in `src/check/checked_ids.zig` as
+`CheckedTypeId`). Recursive types are represented as **cyclic `CheckedTypeId`
+graphs** — there is no implicit tree structure — so every traversal, without
+exception, must either memoize visited roots or track an active path. The
+store's house pattern for *building* possibly-recursive results is
+reserve-then-fill with content-addressed keys: `reserveSyntheticTypeRoot`
+allocates a root with a `.pending` payload before descending, so back-edges
+can reference it, and `fillSyntheticTypeRoot` completes it. Keys are computed
+by a shadow digest traversal that encodes back-edges as depth indices into
+the active path (de Bruijn-style), so structurally identical recursive
+results share one root. `design.md`'s "Type Alias Invariant" section
+describes the degenerate self-referential backing case any such traversal
+must tolerate.
+
+## Evidence
+
+- Counts (verified by grep): `AutoHashMap(..., void).init` — 34 sites in
+  `src/check/checked_artifact.zig`, 105 total across `src/check`,
+  `src/types`, `src/postcheck`. Files include `Check.zig`,
+  `exhaustive.zig`, `generalize.zig`, `monotype/lower.zig`,
+  `monotype/type.zig`, `monotype/solve.zig`, `monotype_lifted/lift.zig`,
+  `lambda_solved/solve.zig`, `solved_lir_lower.zig`.
+- Other idioms: `src/check/occurs.zig` (`Scratch`, `occurs`);
+  `src/types/TypeWriter.zig` (`seen`, `seen_count_var_occurrences`);
+  `src/check/snapshot.zig` (`seen_vars`);
+  `src/postcheck/monotype_lifted/spec_constr.zig` (linear scan over
+  `inline_stack.items` for recursion detection).
+- PR roc-lang/roc#9727 ("Fix platform relation recursive stack overflow"):
+  the introducing commit shows `finalizing` read but never written; the fix
+  added `reserveSyntheticTypeRoot` + `finalizing.put` before descending, and
+  the `test/cli/issue9717-platform` suite (recursive `Elem` across
+  `requires`).
+- The fix duplicated merge/finalize semantics roughly four times inside
+  `checked_artifact.zig`, as four parallel walks over the same input space:
+  1. the resolver's clone traversal (`PlatformAppRelationTypeResolver`, memo
+     maps `finalizing: AutoHashMap(PlatformAppRelationFinalizeInput,
+     CheckedTypeId)` and `merging: AutoHashMap(PlatformAppRelationMergeInput,
+     CheckedTypeId)`);
+  2. the shadow digest hasher (`PlatformAppRelationTypeDigestBuilder`, with
+     `source_active`/`finalizing`/`merging` maps to `u32` depths and
+     `activeDepth` for back-edge encoding — feeding
+     `platformAppRelationMergeResultKey` / `...FinalizeResultKey`);
+  3. the empty-normalization prescans
+     (`platformAppRelationMergeResultIsEmptyRecord` /
+     `...IsEmptyTagUnion` / `...FinalizeResultIsEmptyRecord` /
+     `...IsEmptyTagUnion`, each running `mergeIsEmpty*` / `finalizeIsEmpty*`
+     walks on a fresh digest-builder instance);
+  4. the pending-tolerant `containsIdentityVariables` fork
+     (`pendingRootContainsIdentityVariables` plus the resolver-local
+     `typeContainsIdentityVariables` family), needed because reserved roots
+     have `.pending` payloads mid-build.
+
+## Solution design
+
+One utility (suggested home: `src/types/` or `src/check/`, imported by both
+check and postcheck) providing the three traversal shapes that exist today as
+copies:
+
+1. **Memoized visit-map traversal** over `CheckedTypeId` graphs: generic over
+   a caller Context with `visit(root) → Result`; the utility owns the
+   `AutoHashMap(Key, Result)` memo, guarantees the memo is written *before*
+   descending (a reserve slot or sentinel), and re-entrancy returns the
+   in-progress entry. Boolean predicates (`containsIdentityVariables`-style)
+   are this shape with `Result = bool` and an active-set short-circuit.
+2. **Reserve-then-fill variant** for graph-building consumers: the utility
+   calls `reserveSyntheticTypeRoot` (or a caller-supplied reserve hook)
+   before descending and `fillSyntheticTypeRoot` after, so back-edges tie the
+   knot; the memo maps input keys to reserved roots. The 9727 bug —
+   reading a memo nobody writes — is unrepresentable because the caller never
+   touches the memo directly.
+3. **Digest variant** with de Bruijn-encoded back-edges for
+   content-addressed keys: the utility owns the active-path depth maps and
+   emits `back_edge(depth)` markers into a caller-supplied hasher, matching
+   `PlatformAppRelationTypeDigestBuilder.activeDepth` semantics.
+
+Keys are caller-defined (plain `CheckedTypeId`, or composite inputs like
+`PlatformAppRelationMergeInput`) so multi-input walks fit.
+
+Migration order:
+
+1. Land the utility with unit tests on hand-built cyclic stores.
+2. Migrate the platform-relation resolver's four parallel walks — the proof
+   case: clone traversal, digest hasher, empty prescans, and the
+   pending-tolerant identity-variable fork should collapse onto shapes 2, 3,
+   1, and 1 respectively, sharing one traversal skeleton and one
+   pending-tolerance policy. DELETE the bespoke memo plumbing they replace.
+3. Migrate the remaining `*ContainsIdentityVariables` copies in
+   `checked_artifact.zig` onto shape 1; DELETE the duplicates.
+4. Opportunistic migration of the other 100-odd sites as they are touched.
+5. Add a review/lint note (CONTRIBUTING or a comment on `CheckedTypeStore`):
+   new `CheckedTypeId` traversals must use the utility.
+
+## What success looks like
+
+- The four parallel platform-relation walks share one traversal skeleton;
+  the resolver's memo maps are owned by the utility, not by hand.
+- All `containsIdentityVariables` logic in `checked_artifact.zig` exists
+  exactly once (per payload policy), parameterized over pending-tolerance.
+- New traversals cannot ship without cycle discipline: the utility API has no
+  "read the memo but skip the write" path.
+- The `AutoHashMap(_, void).init` count in `checked_artifact.zig` drops
+  substantially and trends down repo-wide.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+The utility is unit-tested on cyclic stores, including a self-referential
+backing (the degenerate case `design.md`'s Type Alias Invariant describes)
+and mutually recursive roots. Mutation test: reintroduce 9727's missing memo
+write in a copy of the old resolver code and show that expressing the same
+walk through the utility API makes the bug unrepresentable (the write happens
+inside the utility before user code can descend). The
+`test/cli/issue9717-platform` suite passes before and after each migration
+step, byte-identical artifacts.
+
+### Performance ideal
+
+Memoized traversal is O(nodes + edges) with one hash probe per node — no
+worse than today's correct sites. No digest recomputation for shared
+subgraphs (the digest variant memoizes completed-subtree digests). Verify no
+regression in checked-artifact publication time on the largest test
+platforms (`test/cli/issue9717-platform` and the compiler's own corpus);
+scratch-map reuse (retained-capacity reset) keeps allocation churn at or
+below current levels.
+
+## Tests to add
+
+- Issue #9717 repro kept green: recursive `Elem` across `requires`
+  (`test/cli/issue9717-platform`), plus
+  `test/cli/Issue9717SpecConstrSpanInvalidation.roc`.
+- Utility unit tests: cyclic graph memoization (each node visited once),
+  reserve-then-fill producing a well-formed recursive root, digest stability
+  across traversal order, back-edge depth encoding, pending-payload
+  tolerance.
+- A stress test with deep alias/backing chains and a wide mutually-recursive
+  tag-union family, run in debug mode (catches both stack overflow and
+  missing-memo livelock via a step budget).
+
+## Related projects
+
+- [Debug Generation Counters on Growable Stores](../small/store-generation-counters.md)
+  — the sibling "make the invariant structural" project for store borrows.
+- [Immutable Specialization Identity](../big/immutable-specialization-identity.md)
+  — the Monotype-side consumer of digest/traversal discipline.

--- a/projects/small/single-package-identity-function.md
+++ b/projects/small/single-package-identity-function.md
@@ -1,0 +1,195 @@
+# One Package-Identity Function for Every Pipeline
+
+## Problem
+
+The string that names a package — "app", "pf", a resolved package identity, a
+shorthand alias — is an input to type identity and to the checked-module cache
+key. It is computed independently, with different rules, by at least three
+places in the compiler. Nothing enforces that they agree except a code
+comment. When they disagree, the failure is silent and structural: the same
+module gets two different identities (types stop unifying, dispatch misses)
+or two different cache keys (cache never hits), depending on which entry
+point — build, check, run, glue, LSP — happened to compile it.
+
+This has already produced shipped bugs in both directions. Alias-keyed
+identity merged unrelated packages that shared a shorthand and split one
+package imported under two aliases into non-unifying nominal types (fixed by
+PR 9627's global version resolution). Then the run path derived a default
+app's package identity from a per-run temp staging directory, so its cache
+key never matched across runs (fixed by PR 9811 hand-mirroring the
+coordinator's naming). The mirror is still by hand today.
+
+## Background
+
+The compiler pipeline is: parse → canonicalize → type-check (producing
+"checked artifacts" per module) → postcheck: Monotype IR (monomorphization,
+`src/postcheck/monotype/`) → Monotype Lifted (closure lifting,
+`src/postcheck/monotype_lifted/`) → Lambda Solved → Lambda Mono → LIR
+lowering → ARC insertion → backends. `design.md` at the repo root is the
+authoritative design; its Cache Boundary section defines the checked-module
+cache id as `CheckedModuleId = source_hash + compiler_build_hash +
+module_identity + checking_context_identity +
+direct_import_checked_module_ids`, and its Core Principles include "Identity
+provenance follows meaning provenance."
+
+How the package name reaches identity today: when the coordinator creates a
+module's `ModuleEnv`, it sets `env.qualified_module_ident` to
+`"{package_name}.{module_name}"` (`src/compile/coordinator.zig`, parse-task
+setup). `computeStableModuleIdentityHash` in `src/check/checked_artifact.zig`
+hashes that string (with the bare and display names) into the module identity
+hash, which feeds both the checked-module cache key
+(`CheckedModuleArtifactKey`) and nominal-type origin identity — the
+`origin_module` ident compared by `sameNominalIdentity` in
+`src/check/unify.zig` is this qualified name.
+
+Caching constraint (stated here because this project touches cache-key
+inputs): canonicalization output must be serializable keyed on a pure
+function of (module name, module source bytes) and NOTHING else;
+type-checking output is keyed on that hash combined with the type-checked
+hashes of imports — a Merkle DAG. Any id serialized in a stage's artifact
+must be a deterministic function of that stage's cache-key inputs. Global
+uniqueness comes from pairing module-local ids with module identity, never
+from global counters or coordinator state. Name-based resolution is
+legitimate in exactly one place: resolving imports at the canonicalize→check
+boundary; everything downstream consumes resolved ids. A package display
+string computed by a coordinator violates this constraint in spirit; this
+project cannot remove it (that is
+`../big/content-based-nominal-identity.md`), but it can make it a single
+deterministic function so every pipeline computes the same value.
+
+## Evidence
+
+The three independent computation sites, each with its own scheme:
+
+- BuildEnv package materialization, `src/compile/compile_build.zig`: names
+  the root package `"app"` for executables and `"module"` otherwise
+  (`discovered_pkg_name`), registers dependency packages under their
+  workspace shorthand aliases via `ensurePackage`, and uses `"pkg"` for a
+  generated package in one path.
+- `Coordinator.discoverAppFromPath`, `src/compile/coordinator.zig`: names the
+  root `"app"`, names the platform package `"pf"` (via
+  `registerPlatformPackage` — see its doc comment), and registers inline
+  packages under their header shorthands.
+- The run path, `lowerLirWithCoordinator` in `src/cli/main.zig`: after
+  PR 9627 it used `package.identity` from version resolution — which, for
+  default apps, derived from a per-run temp staging dir, so cache keys never
+  matched across runs. PR 9811 fixed it by hand-building a `package_names`
+  array mapping root→`"app"` and platform deps→`"pf"`, with a comment
+  ("matching Coordinator.discoverAppFromPath") as the only enforcement.
+
+Consumers: `env.qualified_module_ident` assignment in
+`src/compile/coordinator.zig`; `computeStableModuleIdentityHash` and
+`CheckedModuleArtifactKey` in `src/check/checked_artifact.zig`;
+`sameNominalIdentity` in `src/check/unify.zig`; `moduleEnvNamesMatch` in
+`src/compile/compile_package.zig` (dedups owner envs by these strings).
+
+Bug history: PR 9627 (version-resolution) — alias-keyed identity both merged
+unrelated packages and split same-package-two-aliases into non-unifying
+nominal types; PR 9811 (fix/default-app-checked-cache) — per-run temp-dir
+identity meant issue 9788's default apps missed the cache on every run.
+
+## Solution design
+
+One function, one owner. Add to `src/compile` (or `src/base` if the CLI must
+call it without depending on compile):
+
+```zig
+pub const PackageIdentity = struct {
+    /// Stable identity string used in qualified module idents and
+    /// therefore in module identity hashes and cache keys.
+    identity: []const u8,
+    /// Short display name for diagnostics ("app", "pf", "json").
+    shorthand: []const u8,
+};
+
+pub fn packageIdentityFor(role: PackageRole, resolved: ?ResolvedPackage)
+    PackageIdentity;
+```
+
+where `PackageRole` distinguishes: root app, root non-app module, platform of
+the root app, URL dependency (uses the resolver's content-derived
+`package.identity`), path dependency, and synthesized/default platform.
+Rules:
+
+1. Root app is always `identity = "app"`; the root platform is always
+   `identity = "pf"`. These are the defined synthetic identities.
+2. URL packages use the version-resolver identity (content-derived), never
+   the shorthand alias under which a workspace imported them.
+3. No rule may consult an absolute path, a temp directory, or any per-run
+   state. The default/synthesized platform gets a fixed synthetic identity,
+   not one derived from its staging location.
+4. The function is total: every entry point (BuildEnv, coordinator discovery,
+   the run path, glue, LSP, playground, future ones) calls it; none computes
+   a name locally.
+
+Migration order:
+
+1. Add the function with exhaustive tests over `PackageRole`.
+2. Convert `Coordinator.discoverAppFromPath` and `registerPlatformPackage`
+   to call it.
+3. Convert BuildEnv materialization in `src/compile/compile_build.zig`.
+4. Convert `lowerLirWithCoordinator` in `src/cli/main.zig`; DELETE the
+   hand-built `package_names` array and its "matching
+   Coordinator.discoverAppFromPath" comment.
+5. Audit glue (`src/glue/glue.zig`) and the LSP for locally computed package
+   names; route them through the function.
+
+What gets DELETED: the `package_names` array construction in
+`src/cli/main.zig`; the literal `"app"`/`"pf"`/`"module"` strings at each
+former site (they move inside the one function).
+
+Scope statement: this is the interim fix.
+`../big/content-based-nominal-identity.md` supersedes it by removing display
+strings from identity entirely — identity becomes a content hash and the
+shorthand becomes diagnostics-only. This project is still worth doing first:
+it is days-scale, it immediately stops the "three sites drift" bug class, and
+it leaves exactly one call site to rewrite when content-based identity lands.
+
+## What success looks like
+
+- Exactly one function in the tree returns a package identity or shorthand;
+  every pipeline entry point calls it.
+- `grep -rn '"pf"' src` and `grep -rn '"app"' src` (as package names) match
+  only that function and tests.
+- A default app compiled twice in a row gets a checked-module cache hit on
+  the second run.
+- The same module compiled via `roc check` and via `roc run` produces the
+  same `computeStableModuleIdentityHash` output.
+- No cache-key input contains an absolute path or temp-dir component.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+Package identity is a deterministic function of (role, resolved package
+identity) — nothing else. Two pipelines given the same workspace can never
+disagree on any package's identity, so no module can acquire two identities
+and no cache key can silently change between entry points. Drift is
+structurally impossible rather than comment-enforced.
+
+### Performance ideal
+
+Given perfect correctness: cache hit rate for unchanged default apps is 100%
+across consecutive runs (measure: second-run wall time for issue 9788's
+repro app approaches cache-hit floor). The function itself is negligible
+(string selection, no I/O); the win to measure is eliminated recompilation —
+compare cold vs warm `roc run` times before/after on a default app and on a
+multi-package workspace.
+
+## Tests to add
+
+- Issue 9788 repro: default app, run twice, assert the second run loads the
+  checked module from cache (cache-hit counter or log assertion).
+- Identity convergence: compile the same module through the check pipeline
+  and the run pipeline; assert identical
+  `computeStableModuleIdentityHash` values.
+- Purity: build the same app from two different temp working directories;
+  assert bit-identical cache keys, and assert no cache-key input string
+  contains either directory's path.
+- Unit tests for `packageIdentityFor` covering every `PackageRole`,
+  including the synthesized default platform.
+
+## Related projects
+
+- `../big/content-based-nominal-identity.md` — supersedes this project by
+  removing name strings from identity entirely; do this one first.

--- a/projects/small/store-generation-counters.md
+++ b/projects/small/store-generation-counters.md
@@ -1,0 +1,197 @@
+# Debug Generation Counters on Growable Stores
+
+## Problem
+
+The postcheck passes store their IRs in growable `std.ArrayList`-backed
+stores and routinely take slices or pointers into them ("borrows") while the
+same pass appends to the same store. An append that reallocates dangles the
+borrow. This exact bug has recurred as independent fixes at least eight times
+in May–June 2026 alone:
+
+- **PR roc-lang/roc#9808** (issue roc-lang/roc#9801):
+  `src/postcheck/monotype_lifted/spec_constr.zig` iterated a slice of
+  `program.fns` while the loop body materialized specialized callables via
+  `Cloner.specializedCallableRef`, which appends to `program.fns` — the first
+  realloc dangled the slice. Symptom: a function index of `2863311530`
+  (`0xAAAAAAAA`, Zig's freed-memory fill) and a panic. Fixed by index-based
+  re-reads in `collectCallPatterns` and a debug `items.ptr` equality assert
+  in `collectArgUses`; repro at `test/wasm/issue_9801_spec_constr_realloc/`.
+- **PR roc-lang/roc#9727**: `Cloner.cloneExprValue` and friends in the same
+  file held `exprSpan`/`typedLocalSpan`/`fieldExprSpan` slices into program
+  storage while recursive cloning appended. Fixed by dupe-before-iterate at
+  six sites (`buildArgs`, tag payloads, record fields, tuple items,
+  `cloneLoop` params/initial values, continue values); repro at
+  `test/cli/Issue9717SpecConstrSpanInvalidation.roc`. Git history shows the
+  same shape fixed repeatedly in this file before (dozens of commits touch
+  `allocator.dupe` in `spec_constr.zig`).
+- **PR roc-lang/roc#9459**: three result-location stale-slot bugs of the form
+  `list.items[i] = .{ .f = try appendToSameList(...) }` — the address
+  `list.items[i]` is computed before the call, the call reallocates, the
+  write lands in freed memory — in `src/postcheck/monotype/lower.zig`,
+  `src/postcheck/lambda_mono/lower.zig`, and
+  `src/postcheck/monotype_lifted/lift.zig`.
+- **PR roc-lang/roc#9478**: equality lowering in
+  `src/postcheck/monotype/lower.zig` iterated `types.spans` while recursion
+  appended; fixed by copying ("Copy because recursive lowerEqualityExpr may
+  reallocate types.spans, invalidating the slice" — the comment survives
+  today naming `lowerDerivation`, alongside a twin for `types.fields`).
+
+Current mitigations are all per-site convention: dupe-before-iterate,
+index-based re-reads, and hand-written pointer asserts. A live
+guarded-by-comment instance sits in `src/lir/arc.zig`, in the loop that
+rewrites emitted procs: "`rewritePath` may append mode-specialized proc
+variants via `addProcSpec`, which can reallocate `store.proc_specs` and
+invalidate the `proc` pointer captured above. Re-fetch the slot before
+writing the rewritten body and join points so they land in the live backing
+storage rather than a freed buffer." — followed by a manual
+`store.getProcSpecPtr(emit_proc)` re-fetch. Nothing enforces any of this.
+The recurrence of the bug in files where it had already been fixed proves
+convention does not hold.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check (produces "checked
+artifacts" per module) → postcheck: Monotype IR (monomorphization/
+specialization, `src/postcheck/monotype/` — `lower.zig` is ~21k lines) →
+Monotype Lifted (closure lifting; also `spec_constr.zig` call-pattern
+specialization for optimized builds) → Lambda Solved → Lambda Mono → LIR →
+ARC → backends. `design.md` at the repo root is authoritative.
+
+Each pass mutates flat index-addressed stores in place. The main offenders
+(all `std.ArrayList` fields, verified):
+
+- `src/postcheck/monotype/ast.zig` `ProgramBuilder` (aliased as
+  `Ast.Program`): `fns`, `exprs`, `pats`, `stmts`, `locals`, `expr_ids`,
+  `pat_ids`, `typed_locals`, `stmt_ids`, `field_exprs`, `specs`, and more.
+- `src/postcheck/monotype/type.zig` `Store`: `spans` (plus `fields`, tag
+  arrays); same shape in `src/postcheck/lambda_mono/type.zig`.
+- `src/postcheck/monotype_lifted/ast.zig` `Program`: `fns`, `exprs`,
+  `typed_locals`, `field_exprs`, etc. (span getters `exprSpan`,
+  `typedLocalSpan`, `fieldExprSpan` return raw slices into these lists).
+- `src/postcheck/lambda_mono/ast.zig` `Program`: `fns`, `exprs`, etc.
+- `src/lir/LirStore.zig`: `proc_specs: std.ArrayList(LirProcSpec)` with
+  `addProcSpec` (appends) and `getProcSpecPtr` (returns a pointer into it).
+
+Recursive lowering makes append-while-borrowing natural to write: cloning an
+expression clones its children, and any child may append to the very list
+the parent took its span slice from.
+
+## Evidence
+
+See the PR list above; all symbols verified in the current tree:
+`collectCallPatterns` / `collectArgUses` / `Cloner.specializedCallableRef` /
+`Cloner.cloneExprValue` in `src/postcheck/monotype_lifted/spec_constr.zig`
+(the `fns_base = self.program.fns.items.ptr` capture and
+`std.debug.assert(self.program.fns.items.ptr == fns_base)` in
+`collectArgUses`; the "Re-read `items` by index" comment in
+`collectCallPatterns`); the `addProcSpec` re-fetch comment and
+`getProcSpecPtr` call in `src/lir/arc.zig`; the "may reallocate
+types.spans/types.fields, invalidating the slice" comments in
+`src/postcheck/monotype/lower.zig`.
+
+## Solution design
+
+Add **debug-build generation counters** to the growable index stores that
+passes mutate in place, so a stale borrow panics deterministically at the
+point of use instead of corrupting memory.
+
+Data structures:
+
+1. `generation: u32` on each store listed in Background (one counter per
+   store struct is sufficient; per-list counters are optional refinement for
+   `ProgramBuilder`). Every append path that may move memory — anything that
+   calls `ArrayList.append`/`appendSlice`/`ensureUnusedCapacity` growth —
+   bumps it. Wrap the raw lists behind existing add-methods (`addProcSpec`,
+   `addExpr`, span-add helpers) so the bump has a single home per list.
+2. A borrow-token API on each store:
+   `store.borrowSpan(span)` / `store.borrowPtr(id)` returns a small guard
+   struct recording `{ data, generation_at_borrow, *store }`. In debug
+   builds, every access through the guard (or a single `guard.assertValid()`
+   at scope end, for hot paths) asserts
+   `store.generation == generation_at_borrow` and panics with the store and
+   call-site names otherwise.
+3. Comptime gating: guard fields and checks exist only when
+   `builtin.mode == .Debug` (the pattern `collectArgUses` already uses); in
+   `ReleaseFast` the guard is a zero-sized wrapper around the slice/pointer
+   and compiles to nothing.
+4. Where a pass genuinely must append while iterating, the API forces one of
+   the two already-correct idioms explicitly: `store.dupeSpan(allocator,
+   span)` (owned copy, the PR #9727 fix shape) or index-based re-reads
+   (`store.at(i)` per step, the PR #9808 fix shape). Raw
+   `store.list.items[...]` access from pass code is removed as call sites
+   migrate.
+
+Migration order:
+
+1. Land the counter + guard machinery in one store
+   (`src/lir/LirStore.zig` `proc_specs` — smallest surface), convert the
+   `arc.zig` re-fetch site to a guard, and DELETE the hand-written comment
+   discipline there.
+2. `monotype_lifted` `Program` + `spec_constr.zig`: replace the `fns_base`
+   pointer asserts with the store guard; route `exprSpan`-style getters
+   through `borrowSpan`.
+3. `monotype` `ProgramBuilder` and `Type.Store` spans (the PR #9459 / #9478
+   sites), then `lambda_mono`.
+4. Audit sweep: list every remaining store a pass mutates and either add the
+   counter or document why it cannot realloc (fixed capacity).
+
+Stronger alternative, noted for the hottest stores: segmented arenas
+(chunked storage with stable addresses) make borrows immune to appends
+entirely, trading memory locality for immunity. Generation counters are the
+cheap first step and remain useful even for segmented stores (they still
+catch index-stability violations like shrink/reorder).
+
+## What success looks like
+
+- Reintroducing any of the four historical bugs (revert the fix hunk from
+  PRs #9808, #9727, #9459, or #9478 locally) panics in debug tests with a
+  message naming the store, instead of corrupting memory or producing
+  `0xAAAAAAAA` indices.
+- The `fns_base` pointer asserts in `spec_constr.zig` and the comment-plus-
+  re-fetch discipline in `arc.zig` are replaced by store guards (the ad-hoc
+  versions are DELETED).
+- Every store in the Background list has a generation counter; the audit
+  list of exceptions is empty or justified in code comments.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+Every store a pass mutates carries the counter, and every cross-append
+borrow in postcheck/LIR code flows through the guard API — verified by the
+audit list in this doc's implementation PR and by grepping for raw
+`.items` access into guarded lists from pass code. A CI debug-mode run of
+the existing test corpus passes with guards active: the counters catch
+violations passively, so the whole corpus becomes a borrow-safety test.
+
+### Performance ideal
+
+Zero `ReleaseFast` overhead: the guard type is zero-sized and the counter
+bump is behind `comptime` gating — verify via an IR/assembly spot-check of
+one hot function (e.g. `collectCallPatterns`) or a comptime proof that the
+release-mode guard struct has size 0 and no runtime methods. Debug overhead
+is one `u32` compare per guarded access (or per scope with
+`assertValid`) — acceptable; confirm debug-suite wall time regresses by less
+than a few percent.
+
+## Tests to add
+
+- Unit tests that intentionally violate a borrow and expect the debug panic,
+  one per store type: `LirStore.proc_specs` (borrow a proc ptr, call
+  `addProcSpec`, access), `monotype_lifted` `Program.fns`/`exprs` span
+  borrows, `monotype` `ProgramBuilder.exprs` and `Type.Store.spans`,
+  `lambda_mono` equivalents. Use `std.testing` expected-panic harnesses in
+  debug builds; skip in release.
+- Keep the existing regression repros green:
+  `test/wasm/issue_9801_spec_constr_realloc/`,
+  `test/cli/Issue9717SpecConstrSpanInvalidation.roc`, and the PR #9478
+  nested-list-pattern tests.
+- A CI debug-mode run of the full existing test corpus with counters active.
+
+## Related projects
+
+- [A Shared Cycle-Guarded Checked-Type Traversal](../small/shared-checked-type-traversal.md)
+  — the sibling "make the invariant structural" project for traversals.
+- [Immutable Specialization Identity](../big/immutable-specialization-identity.md)
+  — reduces how often specialization code appends mid-iteration in the first
+  place.

--- a/projects/small/structural-hoist-contexts.md
+++ b/projects/small/structural-hoist-contexts.md
@@ -1,0 +1,188 @@
+# Structural Hoist-Suppression Contexts
+
+## Problem
+
+Compile-time constant hoisting selects eligible expressions inside runtime
+bodies as compile-time-evaluation roots DURING type checking. The contexts
+where selection must NOT fire are a manually-maintained blacklist: a wrapper
+function, `checkExprWithHoistSelectionSuppressed` in src/check/Check.zig, is
+called at roughly ten hand-picked sites (if/match branch bodies, match
+guards, certain block final expressions, and — since PR roc-lang/roc#9862 —
+expect bodies), bumping a suppression-depth counter around the recursive
+`checkExpr` call.
+
+Every context MISSING from that blacklist is a latent bug of the same shape.
+Issue roc-lang/roc#9747: `expect { result = prime(10001); ... }` ran a
+multi-minute interpreter compile-time evaluation during `roc check`, because
+expect bodies were not yet in the blacklist — the binding inside the expect
+was selected as a hoisted root and evaluated at checking finalization.
+PR 9862 added that ONE case. The debug consistency assertion
+(`debugAssertHoistSelectionConsistent`) verifies selected-root index
+bookkeeping and can catch frame errors, but it CANNOT catch a missing
+suppression context: to the assert, a wrongly-selected root is perfectly
+consistent state.
+
+The next syntactic context anyone adds to the checker — or the next existing
+context someone realizes should suppress — is one forgotten wrapper call
+away from being the next 9747.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check (src/check/Check.zig;
+unification in src/check/unify.zig; rows are how records and tag unions are
+typed — a row can be open or closed) → checked artifacts → postcheck:
+Monotype IR → Lifted → Lambda Solved → Lambda Mono → LIR → ARC → backends.
+design.md at the repo root is authoritative; its section "Compile-Time
+Constants and Hoisted Roots" governs this feature.
+
+Hoisting (PR roc-lang/roc#9722) selects "top-level-equivalent" expressions —
+closed, pure, concrete, no runtime arguments or mutable state — from runtime
+function bodies. Selected roots are evaluated at checking finalization and
+stored in `ConstStore`; later lowering restores the stored value instead of
+emitting runtime work. Per design.md, hoistability is computed as part of
+the SINGLE recursive checking traversal that already determines types and
+effects; it must not add a second pass or permanent per-expression
+summaries. That single-traversal design is mandated for compile speed and
+must be preserved by this project.
+
+**Policy constraint (a deliberate decision by the project lead):** hoisting
+must NOT gain a cost model. Whether an eligible expression evaluates at
+compile time is LANGUAGE SEMANTICS and must not depend on a heuristic
+threshold ("this looks expensive, skip it"). The cost of compile-time
+evaluation is addressed separately by making CTFE fast — native-code CTFE
+via the dev backend (PR roc-lang/roc#9868) and caching of hoisted-root
+results — never by refusing to hoist. This project is about WHERE selection
+fires, not WHETHER eligible work is worth doing.
+
+## Evidence
+
+- src/check/Check.zig — `checkExprWithHoistSelectionSuppressed` increments
+  `hoist_selection_suppressed_depth` around `checkExpr`. Eleven call sites
+  today: expect bodies (via `checkExpectBody`, the PR 9862 fix), block
+  final expressions when a preceding statement blocks later hoists, if
+  branch bodies and the final else, and match guards and branch values.
+- src/check/Check.zig — selection entry points check the counters, e.g.
+  `recordHoistBindingCandidate` begins with
+  `if (self.hoist_suppressed_depth != 0 or
+  self.hoist_selection_suppressed_depth != 0) return;`.
+- src/check/Check.zig — hoist state threaded through the checker: about
+  fifteen fields (`hoist_frames`, `hoist_expr_candidates`,
+  `hoist_binding_candidates`, `hoist_known_values`,
+  `hoist_contextual_bindings`, `hoist_selected_bindings`,
+  `hoist_selected_exprs`, `selected_hoisted_roots`, `last_hoist_result`,
+  `hoist_suppressed_depth`, `hoist_selection_suppressed_depth`, plus scope
+  stacks), the `HoistFrame` struct, and helpers like
+  `beginHoistLexicalScope` / `currentHoistFrameIndexForExpr`. The word
+  "hoist" appears ~500 times in Check.zig (511 at time of writing).
+- src/check/Check.zig — `debugAssertHoistSelectionConsistent`: checks that
+  `hoist_selected_exprs` / `hoist_selected_bindings` indexes agree with
+  `selected_hoisted_roots`; nothing checks WHERE selection happened.
+- src/check/hoist_roots.zig — `SelectedHoistedRoot`, `Body`
+  (`expr` / `pattern_extraction`): the producer-side selected-root data.
+- design.md, "Compile-Time Constants and Hoisted Roots" — single-traversal
+  mandate, allowed/rejected dependency rules, sparse selected-root storage.
+- Issue roc-lang/roc#9747; PR roc-lang/roc#9862 (merge be8fdf22cc); PR
+  roc-lang/roc#9722 (merge 5264f0ea95); PR roc-lang/roc#9868 (merge
+  c3e1d7472f, native CTFE via dev backend).
+
+## Solution design
+
+Invert the blacklist into a STRUCTURAL WHITELIST: define hoist-ELIGIBLE
+positions structurally, make everything else suppressed by default, and
+carry the context as data passed down `checkExpr` rather than as mutable
+counter state that call sites must remember to bump.
+
+1. Derive the exact current-eligible position set by reading the code. As
+   implemented today, selection fires for: immutable statement-level def
+   right-hand sides in unconditionally-executed statement positions of
+   runtime bodies (`recordHoistBindingCandidate`), whole-expression
+   candidates accumulated per `HoistFrame` (`hoist_expr_candidates`), and
+   single-branch match pattern extractions
+   (`recordHoistPatternExtractionProvenance`). Write this set down in the
+   code as the definition of eligibility, and confirm it against the
+   suppressed-site list (anything neither eligible nor suppressed today is
+   a bug to triage before the refactor).
+2. Add a hoist-position field to the checking context that flows down
+   `checkExpr` — the `Expected` struct already flows to every recursive
+   call and already models per-position facts (e.g.
+   `comptime_condition_warnings`); either extend it or introduce a small
+   context struct passed alongside. The field is an enum such as
+   `hoist_position: enum { suppressed, eligible_statement_rhs, ... }` with
+   `suppressed` as the DEFAULT for every derived context (`forBranchBody`,
+   `forStatement`, guard contexts, etc. all produce `suppressed` unless
+   they explicitly opt in).
+3. Only the enumerated structural positions construct an eligible context.
+   A NEW syntactic context added to the checker gets `suppressed` for free:
+   a missed enumeration is now impossible rather than a latent bug —
+   forgetting to opt IN costs a missed optimization caught by snapshot
+   tests, never a wrong compile-time evaluation.
+4. Selection entry points (`recordHoistBindingCandidate` and friends) read
+   the context field instead of the counters.
+5. **DELETE**: `checkExprWithHoistSelectionSuppressed` and all eleven call
+   sites; the `hoist_selection_suppressed_depth` counter; fold
+   `hoist_suppressed_depth` (suppression inside top-level constant bodies,
+   where the whole body is already a compile-time root) into the same
+   context field so one mechanism remains.
+6. Keep the single-traversal design. This project moves a fact from mutable
+   checker state into the down-flowing context; it must NOT add a second
+   pass over the CIR (design.md forbids it).
+
+## What success looks like
+
+- `checkExprWithHoistSelectionSuppressed` no longer exists; grep finds no
+  suppression-depth counters in the checker.
+- Adding a new expression or statement kind to the checker CANNOT silently
+  make its subexpressions hoist-eligible: eligibility requires explicitly
+  constructing an eligible context, and the default is suppressed.
+- The set of hoist-eligible positions is readable in ONE place (the context
+  constructors), not reverse-engineered from wrapper call sites.
+- All currently-selected roots are still selected (no optimization
+  regression) and all currently-suppressed contexts stay suppressed.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- A context-matrix snapshot test exists: one eligible expression placed in
+  EVERY syntactic position (def RHS, if condition, if branch, match
+  scrutinee, match guard, match branch, block final, expect body, lambda
+  body, call argument, record field, ...) with a snapshot of which
+  positions produced hoisted roots. Future syntax must extend the matrix or
+  fail review.
+- Hoisted semantics are unchanged for all currently-eligible positions:
+  the full snapshot corpus (src/snapshots/) shows no diffs in selected
+  roots, diagnostics, or evaluated values.
+- The 9747 scenario (expensive pure call bound inside an `expect` body)
+  performs no compile-time evaluation during `roc check`.
+
+### Performance ideal
+
+- No additional traversal of the CIR; the context is computed from the
+  parent context in O(1) at each recursive call.
+- The context struct passes by value in registers; checker struct size
+  shrinks (two counters and their bookkeeping removed).
+- `roc check` wall-time is unchanged on a large module (measure before and
+  after on the same corpus).
+- CTFE RUNTIME performance is explicitly out of scope here: it is tracked
+  by the native-CTFE dev-backend work (PR 9868) and hoisted-root result
+  caching, per the no-cost-model policy above.
+
+## Tests to add
+
+- The context matrix described above, as a snapshot test.
+- A regression test for issue 9747: an `expect` body binding a pure but
+  expensive call, asserting no hoisted root is selected from it (checkable
+  via the selected-roots debug output rather than by timing).
+- A new-context default-suppressed unit test: introduce a synthetic derived
+  context in test code (mimicking a future syntax addition) and assert that
+  an otherwise-eligible expression under it is NOT selected — proving the
+  default is suppression, not eligibility.
+- Unit tests for each eligible position constructor asserting selection
+  still fires there (guards the no-regression half of the inversion).
+
+## Related projects
+
+- [./cross-phase-coverage-parity-tests.md](./cross-phase-coverage-parity-tests.md)
+  — the same class of fix (replacing hand-enumerated site lists with
+  structural guarantees); its comptime-site suite exercises hoisting's
+  interaction with exhaustiveness site identity, which PR 9722 once broke.

--- a/projects/small/surface-arc-certifier-skips.md
+++ b/projects/small/surface-arc-certifier-skips.md
@@ -1,0 +1,164 @@
+# Surface ARC Certifier Skips
+
+## Problem
+
+The debug borrow certifier can silently decline to verify a procedure, and
+nothing tells anyone it happened.
+
+Since PR roc-lang/roc#9746, a procedure whose join-entry-state count exceeds
+the certifier's capacity budget (currently 4096 distinct entry-state
+summaries per join, checked in the `.jump` handler in
+`src/lir/arc_certify.zig`) makes `certifyProc` return
+`error.CertifierCapacityExceeded`. `certifyStore` catches that error per
+procedure, increments `Diagnostic.skipped_proc_count`, and continues with
+the rest of the store. That was the right call for build viability — the
+cap is a capacity limit, not a finding, and it must never abort a valid
+build (issue roc-lang/roc#9658 was a valid program that tripped the old cap
+of 64) — but the result is that the procedure is left **unverified** and
+the count is exposed only as a struct field that no caller reads.
+`certifyStoreOrPanic`, the production entry point invoked from
+`arc.insert` in debug builds, swallows the error variant defensively and
+prints nothing.
+
+This matters because the procedures most likely to exceed the cap — many
+refcounted mutable locals rebound in nested loops — are exactly the
+procedures where the hand-maintained RC inserter (`src/lir/arc.zig`) is
+most likely to have a bookkeeping bug. A real refcount leak in such a
+procedure would be skipped rather than reported, and nobody would know the
+net had a hole until a user hit the leak at runtime.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck IRs
+(Monotype → Lifted → Lambda Solved → Lambda Mono) → LIR lowering → ARC
+insertion → backends (LLVM / dev x86+aarch64 / wasm / interpreter).
+
+ARC insertion (`src/lir/arc.zig`) emits explicit `incref` / `decref` /
+`free` statements from a whole-program borrows-with-lifetimes solution
+computed in `src/lir/arc_solve.zig`. Because the inserter's ownership
+bookkeeping is hand-maintained per LIR instruction kind, debug builds run
+an independent certifier, `src/lir/arc_certify.zig`, which re-checks every
+emitted procedure against the ownership rules (every unit released or
+transferred exactly once on every path, no use after death, no release of
+a borrow). `design.md` at the repo root, sections "ARC Borrow Inference"
+and "Debug Borrow Certifier", is the authoritative design reference. The
+certifier is compiled away entirely in release builds.
+
+Borrow inference deliberately keeps refcounts at 1 so the runtime list/str
+builtins in `src/builtins/` can take `refcount == 1` in-place fast paths —
+so a missed leak or double-release is not cosmetic; it changes program
+behavior. The certifier is the only automated check standing between an
+inserter bug and shipped memory unsafety, which is why a silent gap in its
+coverage is worth closing loudly even before the gap itself is removed.
+
+## Evidence
+
+Verified against the current tree:
+
+- `src/lir/arc_certify.zig`:
+  - `CertifyError = error{ OutOfMemory, Certification,
+    CertifierCapacityExceeded }`, with a doc comment stating the capacity
+    variant "must never abort a valid build".
+  - The cap: `if (record.scheduled.count() > 4096) return
+    error.CertifierCapacityExceeded;` in the `.jump` case of the
+    certifier walk.
+  - `certifyStore`: catches the error per procedure and runs
+    `diag.skipped_proc_count += 1; continue;`.
+  - `Diagnostic.skipped_proc_count: usize = 0` — doc comment says
+    "Exposed for tests/debugging"; no caller reads it.
+  - `certifyStoreOrPanic`: `error.CertifierCapacityExceeded => {}` (a
+    defensive no-op; the per-proc catch means it cannot reach here).
+  - `LirStore.procDebugName(proc_id)` exists (used by
+    `writeFailureContext`) and can name a skipped procedure.
+- `src/lir/arc.zig`: `insert` calls `arc_certify.certifyStoreOrPanic`
+  under `builtin.mode == .Debug`.
+- Existing stats/verbose infrastructure: `BuildStats` in
+  `src/compile/compile_build.zig` (`getBuildStats`), rendered by
+  `printBuildSuccess` in `src/cli/main.zig` when `args.verbose` is set.
+  Issues roc-lang/roc#9787 and roc-lang/roc#9789 discuss a debug stats
+  compiler; verify what exists when implementing and wire into it rather
+  than inventing a parallel channel.
+
+## Solution design
+
+Three pieces, all small; this is a stopgap that makes the hole visible.
+[ARC Certifier Lattice Join](../big/arc-certifier-lattice-join.md) removes
+the hole, at which point this surfacing (and the counter) is deleted.
+
+1. **Warn on skip in debug builds.** In `certifyStore`'s
+   `error.CertifierCapacityExceeded` catch, record the skipped
+   `LirProcSpecId`; after the loop (or in `certifyStoreOrPanic`), if
+   `diag.skipped_proc_count > 0`, emit a warning via `std.log.warn`
+   naming each skipped procedure — id plus `store.procDebugName(...)`
+   when available — or a summary count if the list is long (cap the
+   listing at, say, 10 names plus "and N more"). The warning text should
+   state plainly what it means: "ARC certifier skipped N procedure(s)
+   whose join-state enumeration exceeded capacity; their RC schedules are
+   UNVERIFIED."
+2. **Surface the count in stats/verbose output.** Extend the diagnostic
+   plumbing so the skip count reaches the compiler's existing stats
+   surface: verify the current state of the debug stats work
+   (issues 9787/9789) and add `arc_certifier_skipped_procs` to whatever
+   structure feeds verbose output (`BuildStats` /
+   `printBuildSuccess` today). If no per-stage stats channel exists yet,
+   the `std.log.warn` from item 1 is the minimum viable surface; do not
+   build new infrastructure for this stopgap.
+3. **CI zero-skip check.** Add an assertion mode so CI fails the day a
+   corpus procedure starts being skipped, rather than letting unverified
+   procedures silently accumulate: a build option or environment variable
+   (e.g. `ROC_CERTIFIER_FORBID_SKIPS`) checked after `certifyStore`
+   returns — when set and `skipped_proc_count > 0`, panic with the same
+   listing as item 1. Enable it for the debug test jobs in CI so the
+   repo's own test corpus (unit tests, snapshot tests, eval tests — all
+   of which run `arc.insert` in debug builds) certifies with zero skips.
+
+What gets deleted later: all three pieces, together with
+`skipped_proc_count` and `error.CertifierCapacityExceeded`, when the big
+project's dataflow fixpoint removes the skip path entirely.
+
+## What success looks like
+
+- A certifier skip is impossible to miss: it prints a warning naming the
+  procedure(s) in any debug build, and it fails CI on the repo's corpus.
+- The count appears in verbose/stats output alongside existing build
+  stats, so a developer investigating RC behavior can see at a glance
+  whether certification was exhaustive.
+- No behavior change whatsoever when zero procedures are skipped, and no
+  change of any kind in release builds.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+The warning fires exactly when certification was skipped — no false
+positives, no misses. Unit-test the plumbing with a synthetic exceedance:
+either lower the cap in a test build (make the cap a comptime-known
+constant that tests can override, or inject it through the `Certifier`
+struct) or construct a Bell-heavy procedure with the `ArcTest` harness in
+`src/lir/arc.zig` that legitimately exceeds the real cap. Assert both the
+counter value and the warning text, including the procedure name. Assert
+the forbid-skips mode panics on the same input and is silent on a normal
+corpus.
+
+### Performance ideal
+
+Trivially zero cost when no skips occur: one integer compare after
+certification. The certifier is debug-only, so release compile time and
+generated code are untouched by construction. The warning path allocates
+only when it fires.
+
+## Tests to add
+
+- Synthetic exceedance test (lowered cap or Bell-heavy generated proc)
+  asserting `skipped_proc_count`, the warning text, and the procedure
+  name appearing in it.
+- A test that the forbid-skips mode turns the same situation into a
+  hard failure, and that it passes on a small normal store.
+- CI: enable the zero-skip assertion on the existing debug test corpus
+  (no new test content — the corpus itself is the fixture).
+
+## Related projects
+
+- [ARC Certifier Lattice Join and Centralized Ownership-Transfer Keying](../big/arc-certifier-lattice-join.md)
+  — replaces join-state enumeration with a dataflow fixpoint, removing
+  the cap and the skip path; this project's surfacing is deleted with it.

--- a/projects/small/surface-arc-certifier-skips.md
+++ b/projects/small/surface-arc-certifier-skips.md
@@ -75,9 +75,10 @@ Verified against the pre-fix tree:
 - Existing stats/verbose infrastructure: `BuildStats` in
   `src/compile/compile_build.zig` (`getBuildStats`), rendered by
   `printBuildSuccess` in `src/cli/main.zig` when `args.verbose` is set.
-  Issues roc-lang/roc#9787 and roc-lang/roc#9789 discuss a debug stats
-  compiler; verify what exists when implementing and wire into it rather
-  than inventing a parallel channel.
+  The struct and its rendering exist today, but no channel carries
+  LIR-stage certification diagnostics into them; building that channel is
+  part of the debug stats compiler discussed in roc-lang/roc#9787 and
+  roc-lang/roc#9789, which is why this stopgap only logs and gates.
 
 ## Solution design
 
@@ -101,16 +102,22 @@ the hole, at which point this surfacing (and the counter) is deleted.
    procedures silently accumulate: the `-Dforbid-arc-certifier-skips`
    build option is checked after `certifyStore` returns. When it is set and
    `skipped_proc_count > 0`, `certifyStoreOrPanic` panics with the same
-   listing as item 1. Enable it for the debug test jobs in CI so the repo's
-   own test corpus (unit tests, snapshot tests, eval tests — all of which
-   run `arc.insert` in debug builds) certifies with zero skips.
+   listing as item 1. The option defaults to on whenever the `CI`
+   environment variable is non-empty, so every debug job — the ci_zig.yml
+   steps, the nix legs driven by `ci/zig_nix_ci.sh`, and future workflow
+   additions — enforces zero skips without per-step flags, and mixed
+   flagged/unflagged steps cannot split the build cache into two
+   `build_options` variants. MiniCI passes the flag explicitly so the
+   local CI mirror matches GitHub. A plain local `zig build` stays
+   warn-only.
 
 The count should also flow into the debug stats compiler once the #9787/#9789
 stats work exists, but this stopgap intentionally does not add new stats
 infrastructure.
 
 What gets deleted later: both pieces, together with `skipped_proc_count`,
-the sampled skipped-proc ids, the build option, the CI flag, and
+the sampled skipped-proc ids, the build option with its CI-environment
+default, the MiniCI flag, and
 `error.CertifierCapacityExceeded`, when the big project's dataflow fixpoint
 removes the skip path entirely.
 

--- a/projects/small/surface-arc-certifier-skips.md
+++ b/projects/small/surface-arc-certifier-skips.md
@@ -53,7 +53,7 @@ coverage is worth closing loudly even before the gap itself is removed.
 
 ## Evidence
 
-Verified against the current tree:
+Verified against the pre-fix tree:
 
 - `src/lir/arc_certify.zig`:
   - `CertifyError = error{ OutOfMemory, Certification,
@@ -81,48 +81,43 @@ Verified against the current tree:
 
 ## Solution design
 
-Three pieces, all small; this is a stopgap that makes the hole visible.
+Two implemented pieces, both small; this is a stopgap that makes the hole
+visible without building a parallel stats channel.
 [ARC Certifier Lattice Join](../big/arc-certifier-lattice-join.md) removes
 the hole, at which point this surfacing (and the counter) is deleted.
 
 1. **Warn on skip in debug builds.** In `certifyStore`'s
    `error.CertifierCapacityExceeded` catch, record the skipped
-   `LirProcSpecId`; after the loop (or in `certifyStoreOrPanic`), if
-   `diag.skipped_proc_count > 0`, emit a warning via `std.log.warn`
-   naming each skipped procedure — id plus `store.procDebugName(...)`
-   when available — or a summary count if the list is long (cap the
-   listing at, say, 10 names plus "and N more"). The warning text should
-   state plainly what it means: "ARC certifier skipped N procedure(s)
+   `LirProcSpecId` in a fixed-size diagnostic sample. Keep `certifyStore`
+   policy-free: after it returns, `certifyStoreOrPanic` emits a warning via
+   `std.log.warn` naming the first 16 skipped procedures — id plus
+   `store.procDebugName(...)` when available — with a trailing
+   "... and N more" when the total exceeds the sample. The warning text
+   states plainly what it means: "ARC certifier skipped N procedure(s)
    whose join-state enumeration exceeded capacity; their RC schedules are
    UNVERIFIED."
-2. **Surface the count in stats/verbose output.** Extend the diagnostic
-   plumbing so the skip count reaches the compiler's existing stats
-   surface: verify the current state of the debug stats work
-   (issues 9787/9789) and add `arc_certifier_skipped_procs` to whatever
-   structure feeds verbose output (`BuildStats` /
-   `printBuildSuccess` today). If no per-stage stats channel exists yet,
-   the `std.log.warn` from item 1 is the minimum viable surface; do not
-   build new infrastructure for this stopgap.
-3. **CI zero-skip check.** Add an assertion mode so CI fails the day a
+2. **CI zero-skip check.** Add an assertion mode so CI fails the day a
    corpus procedure starts being skipped, rather than letting unverified
-   procedures silently accumulate: a build option or environment variable
-   (e.g. `ROC_CERTIFIER_FORBID_SKIPS`) checked after `certifyStore`
-   returns — when set and `skipped_proc_count > 0`, panic with the same
-   listing as item 1. Enable it for the debug test jobs in CI so the
-   repo's own test corpus (unit tests, snapshot tests, eval tests — all
-   of which run `arc.insert` in debug builds) certifies with zero skips.
+   procedures silently accumulate: the `-Dforbid-arc-certifier-skips`
+   build option is checked after `certifyStore` returns. When it is set and
+   `skipped_proc_count > 0`, `certifyStoreOrPanic` panics with the same
+   listing as item 1. Enable it for the debug test jobs in CI so the repo's
+   own test corpus (unit tests, snapshot tests, eval tests — all of which
+   run `arc.insert` in debug builds) certifies with zero skips.
 
-What gets deleted later: all three pieces, together with
-`skipped_proc_count` and `error.CertifierCapacityExceeded`, when the big
-project's dataflow fixpoint removes the skip path entirely.
+The count should also flow into the debug stats compiler once the #9787/#9789
+stats work exists, but this stopgap intentionally does not add new stats
+infrastructure.
+
+What gets deleted later: both pieces, together with `skipped_proc_count`,
+the sampled skipped-proc ids, the build option, the CI flag, and
+`error.CertifierCapacityExceeded`, when the big project's dataflow fixpoint
+removes the skip path entirely.
 
 ## What success looks like
 
 - A certifier skip is impossible to miss: it prints a warning naming the
   procedure(s) in any debug build, and it fails CI on the repo's corpus.
-- The count appears in verbose/stats output alongside existing build
-  stats, so a developer investigating RC behavior can see at a glance
-  whether certification was exhaustive.
 - No behavior change whatsoever when zero procedures are skipped, and no
   change of any kind in release builds.
 
@@ -132,28 +127,26 @@ project's dataflow fixpoint removes the skip path entirely.
 
 The warning fires exactly when certification was skipped — no false
 positives, no misses. Unit-test the plumbing with a synthetic exceedance:
-either lower the cap in a test build (make the cap a comptime-known
-constant that tests can override, or inject it through the `Certifier`
-struct) or construct a Bell-heavy procedure with the `ArcTest` harness in
-`src/lir/arc.zig` that legitimately exceeds the real cap. Assert both the
-counter value and the warning text, including the procedure name. Assert
-the forbid-skips mode panics on the same input and is silent on a normal
-corpus.
+lower the cap through the `Certifier`'s runtime capacity field rather than
+constructing a Bell-heavy procedure. Assert both the counter value and the
+warning text, including the procedure name. The `-Dforbid-arc-certifier-skips`
+mode is validated by running the debug CI corpus with the option enabled:
+the expected result is zero skipped procedures, so any skip becomes a hard
+failure at the production wrapper.
 
 ### Performance ideal
 
 Trivially zero cost when no skips occur: one integer compare after
 certification. The certifier is debug-only, so release compile time and
-generated code are untouched by construction. The warning path allocates
-only when it fires.
+generated code are untouched by construction. The warning path formats only
+when it fires.
 
 ## Tests to add
 
 - Synthetic exceedance test (lowered cap or Bell-heavy generated proc)
   asserting `skipped_proc_count`, the warning text, and the procedure
   name appearing in it.
-- A test that the forbid-skips mode turns the same situation into a
-  hard failure, and that it passes on a small normal store.
+- A guard test asserting the production capacity remains 4096.
 - CI: enable the zero-skip assertion on the existing debug test corpus
   (no new test content — the corpus itself is the fixture).
 

--- a/src/build/minici.zig
+++ b/src/build/minici.zig
@@ -341,6 +341,9 @@ fn buildCommand(
     try argv.append(allocator, zig_exe);
     try argv.append(allocator, "build");
     try argv.append(allocator, step);
+    // GitHub CI gets this via the option's CI-environment default; passing it
+    // explicitly keeps local MiniCI runs mirroring CI.
+    try argv.append(allocator, "-Dforbid-arc-certifier-skips");
     try argv.append(allocator, "--summary");
     try argv.append(allocator, "all");
     try argv.append(allocator, "--color");

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -26,6 +26,8 @@
 //! entry point panics in debug builds; release builds never run the certifier.
 
 const std = @import("std");
+const builtin = @import("builtin");
+const build_options = @import("build_options");
 const core = @import("lir_core");
 const layout_mod = @import("layout");
 const arc_sig = @import("arc_sig.zig");
@@ -34,6 +36,10 @@ const arc_solve = @import("arc_solve.zig");
 const LIR = core.LIR;
 const LirStore = core.LirStore;
 const Allocator = std.mem.Allocator;
+
+pub const production_join_state_capacity: usize = 4096;
+const skipped_proc_record_limit = 16;
+const forbid_skips = builtin.mode == .Debug and build_options.forbid_arc_certifier_skips;
 
 /// Errors produced while certifying: allocation failure or a violation of
 /// the ownership rules (a compiler bug in ARC insertion).
@@ -62,6 +68,10 @@ pub const Diagnostic = struct {
     /// exceeded the certifier's budget (incompleteness, not a finding). Exposed for
     /// tests/debugging; a nonzero value means certification was not exhaustive.
     skipped_proc_count: usize = 0,
+    /// First skipped procedures, for warning/panic context. The count above is
+    /// authoritative; this fixed-size list is only a bounded diagnostic sample.
+    skipped_procs: [skipped_proc_record_limit]LIR.LirProcSpecId = undefined,
+    skipped_proc_len: usize = 0,
 
     pub const ChainLink = struct {
         value: u32,
@@ -82,6 +92,18 @@ pub const Diagnostic = struct {
             return;
         }).len;
     }
+
+    fn recordSkippedProc(self: *Diagnostic, proc_id: LIR.LirProcSpecId) void {
+        if (self.skipped_proc_len < self.skipped_procs.len) {
+            self.skipped_procs[self.skipped_proc_len] = proc_id;
+            self.skipped_proc_len += 1;
+        }
+        self.skipped_proc_count += 1;
+    }
+};
+
+const CertifyOptions = struct {
+    join_state_capacity: usize = production_join_state_capacity,
 };
 
 /// Certifies every proc body in the store. Returns `error.Certification`
@@ -93,6 +115,18 @@ pub fn certifyStore(
     sigs: arc_sig.SigTable,
     roots: []const LIR.LirProcSpecId,
     diag: *Diagnostic,
+) CertifyError!void {
+    return certifyStoreWithOptions(allocator, store, layouts, sigs, roots, diag, .{});
+}
+
+fn certifyStoreWithOptions(
+    allocator: Allocator,
+    store: *const LirStore,
+    layouts: *const layout_mod.Store,
+    sigs: arc_sig.SigTable,
+    roots: []const LIR.LirProcSpecId,
+    diag: *Diagnostic,
+    options: CertifyOptions,
 ) CertifyError!void {
     var rc_local = try allocator.alloc(bool, store.locals.items.len);
     defer allocator.free(rc_local);
@@ -115,6 +149,7 @@ pub fn certifyStore(
         .join_bodies = std.AutoHashMap(LIR.JoinPointId, LIR.CFStmtId).init(allocator),
         .reads_before_rebind_cache = std.AutoHashMap(LIR.CFStmtId, std.bit_set.DynamicBitSetUnmanaged).init(allocator),
         .diag = diag,
+        .join_state_capacity = options.join_state_capacity,
     };
     defer certifier.deinit();
 
@@ -127,7 +162,7 @@ pub fn certifyStore(
             // its work stack is cleaned up on unwind, so skipping is safe. Real findings surface as
             // `error.Certification` and still propagate.
             error.CertifierCapacityExceeded => {
-                diag.skipped_proc_count += 1;
+                diag.recordSkippedProc(@enumFromInt(@as(u32, @intCast(index))));
                 continue;
             },
             else => |e| return e,
@@ -309,6 +344,15 @@ pub fn certifyStoreOrPanic(
             std.debug.panic("ARC borrow certifier: {s}{s}", .{ diag.message(), context.text() });
         },
     };
+    if (diag.skipped_proc_count != 0) {
+        var context = FailureContext{};
+        writeSkippedProcReport(&context, store, &diag);
+        // When the debug stats compiler from #9787/#9789 lands, route this count there too.
+        std.log.warn("{s}", .{context.text()});
+        if (comptime forbid_skips) {
+            std.debug.panic("{s}", .{context.text()});
+        }
+    }
 }
 
 /// Bounded, allocation-free text buffer for panic context. Output past the
@@ -327,6 +371,26 @@ const FailureContext = struct {
         self.len += written.len;
     }
 };
+
+fn writeSkippedProcReport(
+    context: *FailureContext,
+    store: *const LirStore,
+    diag: *const Diagnostic,
+) void {
+    context.append(
+        "ARC certifier skipped {d} procedure(s) whose join-state enumeration exceeded capacity; their RC schedules are UNVERIFIED.",
+        .{diag.skipped_proc_count},
+    );
+    for (diag.skipped_procs[0..diag.skipped_proc_len]) |proc_id| {
+        context.append("\n  proc={d}", .{@intFromEnum(proc_id)});
+        if (store.procDebugName(proc_id)) |name| {
+            context.append(" name={s}", .{name});
+        }
+    }
+    if (diag.skipped_proc_count > diag.skipped_proc_len) {
+        context.append("\n  ... and {d} more", .{diag.skipped_proc_count - diag.skipped_proc_len});
+    }
+}
 
 /// Writes every statement of the failing proc that mentions the implicated
 /// local, plus all join/jump structure, into the panic context buffer.
@@ -804,6 +868,7 @@ const Certifier = struct {
     /// Scratch bitset over store locals, reused by join-relevance extension.
     relevant_scratch: std.bit_set.DynamicBitSetUnmanaged = .{},
     diag: *Diagnostic,
+    join_state_capacity: usize = production_join_state_capacity,
     /// Proc and statement being certified; written by `certifyProc` and
     /// `runSegment` before any read.
     current_proc: LIR.LirProcSpecId = undefined,
@@ -2248,7 +2313,7 @@ const Certifier = struct {
                         // that carry different balances (e.g. `if c then x = dup(y) else x = y`)
                         // would be unsound. Until then the bound is generous enough to fully
                         // certify realistic procedures and only skips genuinely pathological ones.
-                        if (record.scheduled.count() > 4096) {
+                        if (record.scheduled.count() > self.join_state_capacity) {
                             return error.CertifierCapacityExceeded;
                         }
                         const copy = try self.allocator.dupe(LocalSummary, jump_summary);
@@ -2598,7 +2663,15 @@ const CertifyTest = struct {
     fn certifyWith(self: *CertifyTest, sigs: arc_sig.SigTable) CertifyError!void {
         return certifyStore(self.allocator, &self.store, &self.layouts, sigs, &.{}, &self.diag);
     }
+
+    fn certifyWithOptions(self: *CertifyTest, options: CertifyOptions) CertifyError!void {
+        return certifyStoreWithOptions(self.allocator, &self.store, &self.layouts, arc_sig.SigTable.all_owned, &.{}, &self.diag, options);
+    }
 };
+
+test "certifier production join-state capacity remains 4096" {
+    try testing.expectEqual(@as(usize, 4096), production_join_state_capacity);
+}
 
 test "certify accepts owned binding released once" {
     var f = try CertifyTest.init(testing.allocator);
@@ -2611,6 +2684,67 @@ test "certify accepts owned binding released once" {
     const body = try f.assignStr(value, result_assign);
     _ = try f.addProc(&.{}, body, .i64);
     try f.certify();
+    try testing.expectEqual(@as(usize, 0), f.diag.skipped_proc_count);
+}
+
+test "certify records skipped proc when join-state capacity is exceeded" {
+    var f = try CertifyTest.init(testing.allocator);
+    defer f.deinit();
+    const result = try f.local(.i64);
+
+    const join_id = f.freshJoinPointId();
+    const ret = try f.ret(result);
+    const result_assign = try f.assignI64(result, ret);
+    const jump = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const join_stmt = try f.store.addCFStmt(.{ .join = .{
+        .id = join_id,
+        .params = LIR.LocalSpan.empty(),
+        .body = result_assign,
+        .remainder = jump,
+    } });
+    const proc = try f.addProc(&.{}, join_stmt, .i64);
+    try f.store.setProcDebugName(proc, "capacitySkip");
+
+    try f.certifyWithOptions(.{ .join_state_capacity = 0 });
+
+    try testing.expectEqual(@as(usize, 1), f.diag.skipped_proc_count);
+    try testing.expectEqual(@as(usize, 1), f.diag.skipped_proc_len);
+    try testing.expectEqual(proc, f.diag.skipped_procs[0]);
+
+    var report = FailureContext{};
+    writeSkippedProcReport(&report, &f.store, &f.diag);
+    try testing.expect(std.mem.find(u8, report.text(), "ARC certifier skipped 1 procedure(s)") != null);
+    try testing.expect(std.mem.find(u8, report.text(), "UNVERIFIED") != null);
+    try testing.expect(std.mem.find(u8, report.text(), "capacitySkip") != null);
+}
+
+test "skipped proc report caps listed names and preserves total count" {
+    var f = try CertifyTest.init(testing.allocator);
+    defer f.deinit();
+
+    var diag = Diagnostic{};
+    for (0..skipped_proc_record_limit + 1) |index| {
+        const proc = try f.store.addProcSpec(.{
+            .name = f.store.freshSyntheticSymbol(),
+            .args = LIR.LocalSpan.empty(),
+            .ret_layout = .i64,
+        });
+        var name_buf: [32]u8 = undefined;
+        const name = try std.fmt.bufPrint(&name_buf, "proc-{d}", .{index});
+        try f.store.setProcDebugName(proc, name);
+        diag.recordSkippedProc(proc);
+    }
+
+    var report = FailureContext{};
+    writeSkippedProcReport(&report, &f.store, &diag);
+
+    try testing.expectEqual(@as(usize, skipped_proc_record_limit + 1), diag.skipped_proc_count);
+    try testing.expectEqual(@as(usize, skipped_proc_record_limit), diag.skipped_proc_len);
+    try testing.expect(std.mem.find(u8, report.text(), "ARC certifier skipped 17 procedure(s)") != null);
+    try testing.expect(std.mem.find(u8, report.text(), "proc-0") != null);
+    try testing.expect(std.mem.find(u8, report.text(), "proc-15") != null);
+    try testing.expect(std.mem.find(u8, report.text(), "proc-16") == null);
+    try testing.expect(std.mem.find(u8, report.text(), "... and 1 more") != null);
 }
 
 test "certify flags a leaked binding" {

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -37,6 +37,8 @@ const LIR = core.LIR;
 const LirStore = core.LirStore;
 const Allocator = std.mem.Allocator;
 
+/// Join-state budget for full-store certification. The production bound is
+/// written here in exactly one place; tests override it via `CertifyOptions`.
 pub const production_join_state_capacity: usize = 4096;
 const skipped_proc_record_limit = 16;
 const forbid_skips = builtin.mode == .Debug and build_options.forbid_arc_certifier_skips;
@@ -68,10 +70,10 @@ pub const Diagnostic = struct {
     /// exceeded the certifier's budget (incompleteness, not a finding). Exposed for
     /// tests/debugging; a nonzero value means certification was not exhaustive.
     skipped_proc_count: usize = 0,
-    /// First skipped procedures, for warning/panic context. The count above is
-    /// authoritative; this fixed-size list is only a bounded diagnostic sample.
+    /// Storage for the first skipped procedures. Read it only through
+    /// `skippedSample`, which bounds the slice; entries past the sample are
+    /// undefined.
     skipped_procs: [skipped_proc_record_limit]LIR.LirProcSpecId = undefined,
-    skipped_proc_len: usize = 0,
 
     pub const ChainLink = struct {
         value: u32,
@@ -94,11 +96,16 @@ pub const Diagnostic = struct {
     }
 
     fn recordSkippedProc(self: *Diagnostic, proc_id: LIR.LirProcSpecId) void {
-        if (self.skipped_proc_len < self.skipped_procs.len) {
-            self.skipped_procs[self.skipped_proc_len] = proc_id;
-            self.skipped_proc_len += 1;
+        if (self.skipped_proc_count < self.skipped_procs.len) {
+            self.skipped_procs[self.skipped_proc_count] = proc_id;
         }
         self.skipped_proc_count += 1;
+    }
+
+    /// The bounded sample of skipped procedures: the first
+    /// `skipped_proc_record_limit` of the `skipped_proc_count` total.
+    pub fn skippedSample(self: *const Diagnostic) []const LIR.LirProcSpecId {
+        return self.skipped_procs[0..@min(self.skipped_proc_count, self.skipped_procs.len)];
     }
 };
 
@@ -154,15 +161,16 @@ fn certifyStoreWithOptions(
     defer certifier.deinit();
 
     for (store.proc_specs.items, 0..) |proc, index| {
+        const proc_id: LIR.LirProcSpecId = @enumFromInt(@as(u32, @intCast(index)));
         const body = proc.body orelse continue;
-        certifier.certifyProc(@enumFromInt(@as(u32, @intCast(index))), proc, body) catch |err| switch (err) {
+        certifier.certifyProc(proc_id, proc, body) catch |err| switch (err) {
             // Incompleteness, not a finding: this procedure's join-state space exceeded the
             // certifier's budget. Leave it unverified and keep certifying the rest, rather than
             // failing a valid build. `certifyProc` resets all per-proc state on the next call, and
             // its work stack is cleaned up on unwind, so skipping is safe. Real findings surface as
             // `error.Certification` and still propagate.
             error.CertifierCapacityExceeded => {
-                diag.recordSkippedProc(@enumFromInt(@as(u32, @intCast(index))));
+                diag.recordSkippedProc(proc_id);
                 continue;
             },
             else => |e| return e,
@@ -341,18 +349,33 @@ pub fn certifyStoreOrPanic(
                 }
                 writeFailureContext(&context, store, sigs, proc_id, diag.context_stmt, diag.context_local, extra_locals[0..diag.chain_len]);
             }
+            if (diag.skipped_proc_count != 0) {
+                context.append("\n", .{});
+                writeSkippedProcReport(&context, store, &diag);
+            }
             std.debug.panic("ARC borrow certifier: {s}{s}", .{ diag.message(), context.text() });
         },
     };
-    if (diag.skipped_proc_count != 0) {
+    const outcome = skipOutcome(diag.skipped_proc_count, forbid_skips);
+    if (outcome != .none) {
         var context = FailureContext{};
         writeSkippedProcReport(&context, store, &diag);
         // When the debug stats compiler from #9787/#9789 lands, route this count there too.
-        std.log.warn("{s}", .{context.text()});
-        if (comptime forbid_skips) {
-            std.debug.panic("{s}", .{context.text()});
+        switch (outcome) {
+            .none => unreachable,
+            .fail => std.debug.panic("{s}", .{context.text()}),
+            .warn => std.log.warn("{s}", .{context.text()}),
         }
     }
+}
+
+/// What `certifyStoreOrPanic` does about capacity skips. Split out from the
+/// wrapper so the escalation decision is unit-testable.
+const SkipOutcome = enum { none, warn, fail };
+
+fn skipOutcome(skipped_proc_count: usize, forbid: bool) SkipOutcome {
+    if (skipped_proc_count == 0) return .none;
+    return if (forbid) .fail else .warn;
 }
 
 /// Bounded, allocation-free text buffer for panic context. Output past the
@@ -381,14 +404,15 @@ fn writeSkippedProcReport(
         "ARC certifier skipped {d} procedure(s) whose join-state enumeration exceeded capacity; their RC schedules are UNVERIFIED.",
         .{diag.skipped_proc_count},
     );
-    for (diag.skipped_procs[0..diag.skipped_proc_len]) |proc_id| {
+    const sample = diag.skippedSample();
+    for (sample) |proc_id| {
         context.append("\n  proc={d}", .{@intFromEnum(proc_id)});
         if (store.procDebugName(proc_id)) |name| {
             context.append(" name={s}", .{name});
         }
     }
-    if (diag.skipped_proc_count > diag.skipped_proc_len) {
-        context.append("\n  ... and {d} more", .{diag.skipped_proc_count - diag.skipped_proc_len});
+    if (diag.skipped_proc_count > sample.len) {
+        context.append("\n  ... and {d} more", .{diag.skipped_proc_count - sample.len});
     }
 }
 
@@ -868,7 +892,7 @@ const Certifier = struct {
     /// Scratch bitset over store locals, reused by join-relevance extension.
     relevant_scratch: std.bit_set.DynamicBitSetUnmanaged = .{},
     diag: *Diagnostic,
-    join_state_capacity: usize = production_join_state_capacity,
+    join_state_capacity: usize,
     /// Proc and statement being certified; written by `certifyProc` and
     /// `runSegment` before any read.
     current_proc: LIR.LirProcSpecId = undefined,
@@ -2669,8 +2693,11 @@ const CertifyTest = struct {
     }
 };
 
-test "certifier production join-state capacity remains 4096" {
-    try testing.expectEqual(@as(usize, 4096), production_join_state_capacity);
+test "skip outcome escalates to fail only in forbid mode" {
+    try testing.expectEqual(SkipOutcome.none, skipOutcome(0, false));
+    try testing.expectEqual(SkipOutcome.none, skipOutcome(0, true));
+    try testing.expectEqual(SkipOutcome.warn, skipOutcome(3, false));
+    try testing.expectEqual(SkipOutcome.fail, skipOutcome(3, true));
 }
 
 test "certify accepts owned binding released once" {
@@ -2708,8 +2735,8 @@ test "certify records skipped proc when join-state capacity is exceeded" {
     try f.certifyWithOptions(.{ .join_state_capacity = 0 });
 
     try testing.expectEqual(@as(usize, 1), f.diag.skipped_proc_count);
-    try testing.expectEqual(@as(usize, 1), f.diag.skipped_proc_len);
-    try testing.expectEqual(proc, f.diag.skipped_procs[0]);
+    try testing.expectEqual(@as(usize, 1), f.diag.skippedSample().len);
+    try testing.expectEqual(proc, f.diag.skippedSample()[0]);
 
     var report = FailureContext{};
     writeSkippedProcReport(&report, &f.store, &f.diag);
@@ -2739,11 +2766,17 @@ test "skipped proc report caps listed names and preserves total count" {
     writeSkippedProcReport(&report, &f.store, &diag);
 
     try testing.expectEqual(@as(usize, skipped_proc_record_limit + 1), diag.skipped_proc_count);
-    try testing.expectEqual(@as(usize, skipped_proc_record_limit), diag.skipped_proc_len);
-    try testing.expect(std.mem.find(u8, report.text(), "ARC certifier skipped 17 procedure(s)") != null);
+    try testing.expectEqual(@as(usize, skipped_proc_record_limit), diag.skippedSample().len);
+    var header_buf: [64]u8 = undefined;
+    const header = try std.fmt.bufPrint(&header_buf, "ARC certifier skipped {d} procedure(s)", .{skipped_proc_record_limit + 1});
+    try testing.expect(std.mem.find(u8, report.text(), header) != null);
     try testing.expect(std.mem.find(u8, report.text(), "proc-0") != null);
-    try testing.expect(std.mem.find(u8, report.text(), "proc-15") != null);
-    try testing.expect(std.mem.find(u8, report.text(), "proc-16") == null);
+    var included_buf: [32]u8 = undefined;
+    const last_included = try std.fmt.bufPrint(&included_buf, "proc-{d}", .{skipped_proc_record_limit - 1});
+    try testing.expect(std.mem.find(u8, report.text(), last_included) != null);
+    var excluded_buf: [32]u8 = undefined;
+    const first_excluded = try std.fmt.bufPrint(&excluded_buf, "proc-{d}", .{skipped_proc_record_limit});
+    try testing.expect(std.mem.find(u8, report.text(), first_excluded) == null);
     try testing.expect(std.mem.find(u8, report.text(), "... and 1 more") != null);
 }
 


### PR DESCRIPTION
ARC certification can leave a procedure unverified when join-state enumeration exceeds its capacity budget. This makes those skips visible in debug builds, records a bounded sample of skipped procedure ids for diagnostics, and adds a debug-only build option that panics on any skip so CI keeps the corpus at zero skipped procedures. The stats plumbing is intentionally left for the existing debug-stats work instead of adding a parallel channel here.