### PR TITLE
Add scroll to roc docs search

### DIFF
--- a/src/docs/static/search.js
+++ b/src/docs/static/search.js
@@ -173,6 +173,7 @@ const setupSearch = () => {
             }
           } else {
             entry.classList.add("hidden");
+            searchTypeAhead.scrollTop = 0;
           }
         });
         if (totalResults < 1) {

--- a/src/docs/static/styles.css
+++ b/src/docs/static/styles.css
@@ -781,6 +781,8 @@ pre>code {
   list-style-type: none;
   margin: 0;
   padding: 0;
+  overflow-y: auto;
+  max-height: 60vh;
 }
 
 #search-type-ahead .type-ahead-link {


### PR DESCRIPTION
Before, if there were enough results, the search box would overflow off screen without any scroll bar. Scroll resets on typing.

Before |  After
:-------------------------:|:-------------------------:
<img width="831" height="873" alt="Screenshot 2026-07-02 at 16 01 20" src="https://github.com/user-attachments/assets/7bf829b9-42a9-4d11-af23-f8938e092c4d" />  |  <img width="831" height="873" alt="Screenshot 2026-07-02 at 16 03 41" src="https://github.com/user-attachments/assets/157d0504-19c6-48fd-af38-972165550e4c" />

