### PR TITLE
refactor(capture-id): thread a canonical CaptureId through every post-check IR

### DIFF
--- a/ci/tidy.zig
+++ b/ci/tidy.zig
@@ -1121,7 +1121,11 @@ const DeadFilesDetector = struct {
     }
 };
 
-/// Lists all files in the repository using git ls-files.
+/// Lists all files in the repository.
+///
+/// Prefers `git ls-files` (matching CI, which runs in a git checkout). Falls
+/// back to `jj file list` so the check also runs in a non-colocated jj
+/// workspace, where there is no `.git` for git to use.
 fn listFilePaths(allocator: Allocator, io: std.Io) ![][]const u8 {
     var result: std.ArrayList([]const u8) = .empty;
     errdefer {
@@ -1131,26 +1135,46 @@ fn listFilePaths(allocator: Allocator, io: std.Io) ![][]const u8 {
         result.deinit(allocator);
     }
 
-    const run_result = try std.process.run(allocator, io, .{
-        .argv = &.{ "git", "ls-files", "-z" },
-    });
-    defer allocator.free(run_result.stdout);
+    // git ls-files -z: null-separated, exact CI behavior.
+    if (try runForStdout(allocator, io, &.{ "git", "ls-files", "-z" })) |stdout| {
+        defer allocator.free(stdout);
+        try appendListedPaths(allocator, &result, stdout, 0);
+        return result.toOwnedSlice(allocator);
+    }
+
+    // Fall back to jj for a non-colocated jj workspace: newline-separated.
+    if (try runForStdout(allocator, io, &.{ "jj", "file", "list" })) |stdout| {
+        defer allocator.free(stdout);
+        try appendListedPaths(allocator, &result, stdout, '\n');
+        return result.toOwnedSlice(allocator);
+    }
+
+    return error.GitFailed;
+}
+
+/// Runs `argv`, returning its stdout on success (caller owns it) or null if the
+/// command is missing or exits non-zero. Only allocation failures propagate.
+fn runForStdout(allocator: Allocator, io: std.Io, argv: []const []const u8) !?[]u8 {
+    const run_result = std.process.run(allocator, io, .{ .argv = argv }) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return null, // command not found / failed to spawn
+    };
     defer allocator.free(run_result.stderr);
+    if (run_result.term != .exited or run_result.term.exited != 0) {
+        allocator.free(run_result.stdout);
+        return null;
+    }
+    return run_result.stdout;
+}
 
-    const files = run_result.stdout;
-    if (run_result.term != .exited or run_result.term.exited != 0) return error.GitFailed;
-
-    if (files.len == 0) return result.toOwnedSlice(allocator);
-
-    // git ls-files -z outputs null-separated paths
-    var lines = std.mem.splitScalar(u8, files, 0);
+/// Splits `output` on `separator` and appends each non-skipped path to `result`.
+fn appendListedPaths(allocator: Allocator, result: *std.ArrayList([]const u8), output: []const u8, separator: u8) !void {
+    var lines = std.mem.splitScalar(u8, output, separator);
     while (lines.next()) |line| {
         if (line.len == 0) continue;
         if (shouldSkipListedFile(line)) continue;
         try result.append(allocator, try allocator.dupe(u8, line));
     }
-
-    return result.toOwnedSlice(allocator);
 }
 
 fn shouldSkipTopLevelDir(path: []const u8) bool {

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -25256,7 +25256,7 @@ pub const CheckedModuleArtifact = struct {
     /// Manual discriminant for `SERIALIZED_VERSION_HASH`: bump to force a cache /
     /// baked-blob invalidation for a layout change the structural fingerprint below
     /// cannot observe (e.g. a semantic change to how a field is interpreted).
-    const serialized_layout_version: u32 = 6;
+    const serialized_layout_version: u32 = 7;
 
     /// Comptime fingerprint of `Serialized`'s layout, mirroring
     /// `cache_module.MODULE_ENV_VERSION_HASH`. It is appended to the baked builtin
@@ -29102,8 +29102,8 @@ test "SERIALIZED_VERSION_HASH golden value" {
     // change, bump `serialized_layout_version` and replace the golden bytes below with
     // the ones this assertion prints.
     const golden: [32]u8 = .{
-        0xD6, 0x5B, 0xF5, 0xB7, 0x6E, 0xEE, 0x5A, 0xD2, 0xF2, 0x78, 0xA8, 0xC4, 0xDE, 0x79, 0x2E, 0x58,
-        0x70, 0x9E, 0xCD, 0x39, 0x60, 0xDB, 0x3B, 0x05, 0xF3, 0x89, 0x33, 0x1E, 0x39, 0x62, 0x6D, 0xB1,
+        0xFB, 0x58, 0xCC, 0xA0, 0x31, 0xE8, 0x80, 0x87, 0x26, 0x9D, 0x4E, 0x1B, 0xA4, 0xA5, 0x46, 0x0F,
+        0xE0, 0xCF, 0x29, 0x42, 0xE1, 0xC9, 0x31, 0x09, 0xE0, 0xFC, 0xBC, 0x64, 0x2B, 0x21, 0xCD, 0xF6,
     };
     try std.testing.expectEqualSlices(u8, &golden, &CheckedModuleArtifact.SERIALIZED_VERSION_HASH);
 }

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -2090,6 +2090,8 @@ pub const StaticDispatchPlanId = static_dispatch.StaticDispatchPlanId;
 pub const IteratorForPlanId = static_dispatch.IteratorForPlanId;
 /// Public `PatternBinderId` declaration.
 pub const PatternBinderId = checked_ids.PatternBinderId;
+/// Public `CaptureId` declaration.
+pub const CaptureId = checked_ids.CaptureId;
 
 /// Public `CheckedTypeRoot` declaration.
 pub const CheckedTypeRoot = struct {
@@ -6685,6 +6687,10 @@ pub const CheckedExhaustivenessSiteTable = struct {
 pub const CheckedCapture = struct {
     pattern: CheckedPatternId,
     scope_depth: u32,
+    /// Canonical identity of the captured binding, carried immutably through
+    /// every post-check IR. Derived from the capture's binder, so it is a pure
+    /// function of (module name, source bytes) and cache-safe to serialize.
+    capture_id: CaptureId,
 };
 
 /// Public `CheckedRecordDestructKind` declaration.
@@ -10533,9 +10539,11 @@ const CheckedBodyPayloadCopier = struct {
         const out = try self.allocator.alloc(CheckedCapture, source.len);
         for (source, 0..) |capture_idx, i| {
             const capture = self.module.moduleEnvConst().store.getCapture(capture_idx);
+            const binder = try self.patternBinder(capture.pattern_idx);
             out[i] = .{
                 .pattern = self.checkedPattern(capture.pattern_idx),
                 .scope_depth = capture.scope_depth,
+                .capture_id = CaptureId.fromBinder(binder),
             };
         }
         return out;
@@ -25248,7 +25256,7 @@ pub const CheckedModuleArtifact = struct {
     /// Manual discriminant for `SERIALIZED_VERSION_HASH`: bump to force a cache /
     /// baked-blob invalidation for a layout change the structural fingerprint below
     /// cannot observe (e.g. a semantic change to how a field is interpreted).
-    const serialized_layout_version: u32 = 5;
+    const serialized_layout_version: u32 = 6;
 
     /// Comptime fingerprint of `Serialized`'s layout, mirroring
     /// `cache_module.MODULE_ENV_VERSION_HASH`. It is appended to the baked builtin
@@ -29094,8 +29102,8 @@ test "SERIALIZED_VERSION_HASH golden value" {
     // change, bump `serialized_layout_version` and replace the golden bytes below with
     // the ones this assertion prints.
     const golden: [32]u8 = .{
-        0x32, 0xA5, 0x67, 0x52, 0xA5, 0xFF, 0x07, 0x98, 0xC3, 0x20, 0xD9, 0x35, 0xEC, 0x50, 0x59, 0x20,
-        0x82, 0xCD, 0x81, 0xCC, 0x00, 0x46, 0xD9, 0x6E, 0xD8, 0xE4, 0xB7, 0x0B, 0x4E, 0x80, 0xAE, 0x41,
+        0xD6, 0x5B, 0xF5, 0xB7, 0x6E, 0xEE, 0x5A, 0xD2, 0xF2, 0x78, 0xA8, 0xC4, 0xDE, 0x79, 0x2E, 0x58,
+        0x70, 0x9E, 0xCD, 0x39, 0x60, 0xDB, 0x3B, 0x05, 0xF3, 0x89, 0x33, 0x1E, 0x39, 0x62, 0x6D, 0xB1,
     };
     try std.testing.expectEqualSlices(u8, &golden, &CheckedModuleArtifact.SERIALIZED_VERSION_HASH);
 }

--- a/src/check/checked_ids.zig
+++ b/src/check/checked_ids.zig
@@ -1,5 +1,7 @@
 //! Stable ids for checked artifact payload stores.
 
+const std = @import("std");
+
 /// Public `CheckedBodyId` declaration.
 pub const CheckedBodyId = enum(u32) { _ };
 /// Public `CheckedExprId` declaration.
@@ -18,3 +20,73 @@ pub const CheckedTypeId = enum(u32) { _ };
 pub const CheckedTypeSchemeId = enum(u32) { _ };
 /// Public `PatternBinderId` declaration.
 pub const PatternBinderId = enum(u32) { _ };
+
+/// One canonical identity for a closure capture, carried immutably through
+/// every post-check IR so that operand↔slot joins are exact key lookups
+/// instead of fuzzy multi-key matches.
+///
+/// The `u32` is split into two disjoint ranges by the high bit:
+///
+///  - **canonical** (high bit clear, `[0, 2^31)`): the identity of a captured
+///    checked binding. The index is exactly the `PatternBinderId` of the
+///    binder, so a canonical id is a pure function of (module name, source
+///    bytes) and is cache-safe to serialize in checked artifacts. Because the
+///    mapping is the identity function, the originating binder is always
+///    recoverable via `binder()`.
+///  - **generated** (high bit set, `[2^31, 2^32)`): the identity of a
+///    compiler-synthesized capturable local that has no checked binder —
+///    allocated deterministically by the pass that synthesizes it (compile-time
+///    evaluation during checking, closure lifting / spec_constr afterwards).
+///    The index is a per-owner counter (a `ConstStore` closure during checking,
+///    a Monotype/Lifted program afterwards).
+pub const CaptureId = enum(u32) {
+    _,
+
+    /// High bit distinguishing generated ids from canonical ids.
+    const generated_bit: u32 = 0x8000_0000;
+    /// Largest index representable in either range.
+    pub const max_index: u32 = generated_bit - 1;
+
+    /// The canonical capture id for a captured binder.
+    pub fn fromBinder(id: PatternBinderId) CaptureId {
+        const raw = @intFromEnum(id);
+        std.debug.assert(raw <= max_index);
+        return @enumFromInt(raw);
+    }
+
+    /// The canonical capture id for a raw binder index.
+    pub fn canonical(index: u32) CaptureId {
+        std.debug.assert(index <= max_index);
+        return @enumFromInt(index);
+    }
+
+    /// The generated capture id for a per-owner counter value.
+    pub fn generated(index: u32) CaptureId {
+        std.debug.assert(index <= max_index);
+        return @enumFromInt(index | generated_bit);
+    }
+
+    /// Whether this id names a captured checked binder.
+    pub fn isCanonical(self: CaptureId) bool {
+        return (@intFromEnum(self) & generated_bit) == 0;
+    }
+
+    /// Whether this id names a compiler-synthesized capturable local.
+    pub fn isGenerated(self: CaptureId) bool {
+        return !self.isCanonical();
+    }
+
+    /// The `PatternBinderId` this canonical id was derived from. Asserts the id
+    /// is canonical.
+    pub fn binder(self: CaptureId) PatternBinderId {
+        std.debug.assert(self.isCanonical());
+        return @enumFromInt(@intFromEnum(self));
+    }
+
+    /// The per-owner counter value of a generated id. Asserts the id is
+    /// generated.
+    pub fn generatedIndex(self: CaptureId) u32 {
+        std.debug.assert(self.isGenerated());
+        return @intFromEnum(self) & ~generated_bit;
+    }
+};

--- a/src/check/checked_ids.zig
+++ b/src/check/checked_ids.zig
@@ -35,35 +35,52 @@ pub const PatternBinderId = enum(u32) { _ };
 ///    recoverable via `binder()`.
 ///  - **generated** (high bit set, `[2^31, 2^32)`): the identity of a
 ///    compiler-synthesized capturable local that has no checked binder —
-///    allocated deterministically by the pass that synthesizes it (compile-time
-///    evaluation during checking, closure lifting / spec_constr afterwards).
-///    The index is a per-owner counter (a `ConstStore` closure during checking,
-///    a Monotype/Lifted program afterwards).
+///    allocated deterministically by the pass that synthesizes it. The
+///    generated range is split again by the next bit into two disjoint
+///    sub-ranges so ids minted by different synthesizing passes can never
+///    collide inside a single function's capture set:
+///      - **check** (`0x8000_0000` | index): compile-time evaluation during
+///        checking. The index is a per-`ConstStore`-closure counter and must be
+///        stable, because it round-trips through serialized `ConstStore`
+///        captures.
+///      - **lift** (`0xC000_0000` | index): closure lifting / spec_constr after
+///        checking. The index is a per-Lifted-program counter. These ids never
+///        enter checked artifacts (post-check IRs are not cached).
 pub const CaptureId = enum(u32) {
     _,
 
     /// High bit distinguishing generated ids from canonical ids.
     const generated_bit: u32 = 0x8000_0000;
-    /// Largest index representable in either range.
-    pub const max_index: u32 = generated_bit - 1;
+    /// Within the generated range, distinguishes lift-time from check-time ids.
+    const lift_bit: u32 = 0x4000_0000;
+    /// Largest index representable in a canonical id.
+    pub const max_canonical_index: u32 = generated_bit - 1;
+    /// Largest index representable in a generated sub-range.
+    pub const max_generated_index: u32 = lift_bit - 1;
 
     /// The canonical capture id for a captured binder.
     pub fn fromBinder(id: PatternBinderId) CaptureId {
-        const raw = @intFromEnum(id);
-        std.debug.assert(raw <= max_index);
-        return @enumFromInt(raw);
+        return canonical(@intFromEnum(id));
     }
 
     /// The canonical capture id for a raw binder index.
     pub fn canonical(index: u32) CaptureId {
-        std.debug.assert(index <= max_index);
+        std.debug.assert(index <= max_canonical_index);
         return @enumFromInt(index);
     }
 
-    /// The generated capture id for a per-owner counter value.
-    pub fn generated(index: u32) CaptureId {
-        std.debug.assert(index <= max_index);
+    /// The generated capture id minted by compile-time evaluation for a
+    /// per-`ConstStore`-closure counter value.
+    pub fn generatedCheck(index: u32) CaptureId {
+        std.debug.assert(index <= max_generated_index);
         return @enumFromInt(index | generated_bit);
+    }
+
+    /// The generated capture id minted by closure lifting / spec_constr for a
+    /// per-Lifted-program counter value.
+    pub fn generatedLift(index: u32) CaptureId {
+        std.debug.assert(index <= max_generated_index);
+        return @enumFromInt(index | generated_bit | lift_bit);
     }
 
     /// Whether this id names a captured checked binder.
@@ -83,8 +100,8 @@ pub const CaptureId = enum(u32) {
         return @enumFromInt(@intFromEnum(self));
     }
 
-    /// The per-owner counter value of a generated id. Asserts the id is
-    /// generated.
+    /// The opaque low-31-bit index of a generated id, unique within its
+    /// generated sub-range. Asserts the id is generated.
     pub fn generatedIndex(self: CaptureId) u32 {
         std.debug.assert(self.isGenerated());
         return @intFromEnum(self) & ~generated_bit;

--- a/src/check/const_store.zig
+++ b/src/check/const_store.zig
@@ -35,11 +35,11 @@ pub const ConstScalar = union(enum) {
     dec_bits: i128,
 };
 
-/// Identity for a captured value inside a compile-time function value.
-pub const CaptureId = union(enum) {
-    binder: checked_ids.PatternBinderId,
-    generated: u32,
-};
+/// Identity for a captured value inside a compile-time function value. This is
+/// the same canonical/generated CaptureId carried through every post-check IR;
+/// a compile-time closure's captures are either canonical (a checked binder) or
+/// generated (a compiler-synthesized capturable local, minted during CTFE).
+pub const CaptureId = checked_ids.CaptureId;
 
 /// Primitive type stored at the ConstStore boundary. This mirrors
 /// `CheckedPrimitive` without importing `checked_artifact.zig`, which owns the
@@ -807,7 +807,7 @@ test "ConstStore: build, serialize/relocate, and read back values, fns, strings"
     const str = try store.append(.{ .str = .{ .data = sd, .offset = 0, .len = 5 } });
     // A function value with a capture (exercises capture_pool).
     const capture_ty = try store.type_store.append(.{ .primitive = .u64 });
-    const caps = try gpa.dupe(ConstCapture, &.{.{ .id = .{ .binder = @enumFromInt(1) }, .ty = capture_ty, .value = a }});
+    const caps = try gpa.dupe(ConstCapture, &.{.{ .id = CaptureId.fromBinder(@enumFromInt(1)), .ty = capture_ty, .value = a }});
     defer gpa.free(caps);
     const fn_id = try store.appendFn(.{
         // Distinct non-zero ids: this test asserts captures round-trip; the fn_def
@@ -865,8 +865,8 @@ test "ConstStore.appendFn: no leak or double-free under allocation failure" {
             const a = try store.append(.{ .scalar = .{ .u64 = 7 } });
             const capture_ty = try store.type_store.append(.{ .primitive = .u64 });
             const caps = try allocator.dupe(ConstCapture, &.{
-                .{ .id = .{ .binder = @enumFromInt(1) }, .ty = capture_ty, .value = a },
-                .{ .id = .{ .binder = @enumFromInt(2) }, .ty = capture_ty, .value = a },
+                .{ .id = CaptureId.fromBinder(@enumFromInt(1)), .ty = capture_ty, .value = a },
+                .{ .id = CaptureId.fromBinder(@enumFromInt(2)), .ty = capture_ty, .value = a },
             });
             defer allocator.free(caps);
             _ = try store.appendFn(.{

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -1518,6 +1518,63 @@ const core_tests = [_]TestCase{
     },
     .{ .name = "inspect: typed identity closure on string", .source = "(|s| s)(\"Test\")", .expected = .{ .inspect_str = "\"Test\"" } },
 
+    // CaptureId regression suite: exercises the canonical-CaptureId join through
+    // nested/curried closures, closures held before application, capture-set
+    // reshaping, and captures that also appear inside call arguments.
+    // Repro for issue 9897 ("function reference capture count differs from its
+    // target"): the middle closure is bound and applied separately, so each
+    // fn_ref must carry exactly its target's capture slots.
+    .{
+        .name = "capture-id: nested closure held before application",
+        .source =
+        \\{
+        \\    make = |x| |y| |z| x + y + z
+        \\    partial = make(1.I64)(2.I64)
+        \\    partial(3.I64)
+        \\}
+        ,
+        .expected = .{ .inspect_str = "6" },
+    },
+    // Repro for PR 9874's order-sensitivity: a 5-deep curried chain, each level
+    // adding a capture, so the capture spans must stay canonically ordered.
+    .{
+        .name = "capture-id: five-deep curried capture chain",
+        .source = "(|a| |b| |c| |d| |e| a + b + c + d + e)(1.I64)(2.I64)(3.I64)(4.I64)(5.I64)",
+        .expected = .{ .inspect_str = "15" },
+    },
+    // A captured variable that also appears inside a record argument to the
+    // closure it is passed to, reshaped by specialization.
+    .{
+        .name = "capture-id: captured var also used in a record argument",
+        .source =
+        \\{
+        \\    outer = |seed| {
+        \\        inner = |next, arg| seed + next.n + arg
+        \\        inner({ n: seed }, seed * 10.I64)
+        \\    }
+        \\    outer(2.I64)
+        \\}
+        ,
+        .expected = .{ .inspect_str = "24" },
+    },
+    // Two sibling closures capture the same outer binding via a shared helper,
+    // so the capture-set fixpoint must give both the same canonical CaptureId.
+    .{
+        .name = "capture-id: sibling closures share one captured binding",
+        .source =
+        \\{
+        \\    base = 10.I64
+        \\    pick = |flag| {
+        \\        add = |n| base + n
+        \\        sub = |n| base - n
+        \\        if flag add(3.I64) else sub(3.I64)
+        \\    }
+        \\    pick(True) + pick(False)
+        \\}
+        ,
+        .expected = .{ .inspect_str = "20" },
+    },
+
     // Untyped closures, HOFs, and recursion
     .{
         .name = "inspect: closure capturing one local variable",

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -1090,8 +1090,8 @@ fn markReachableLiftedExpr(
         .uninitialized_payload,
         => {},
         .fn_ref => |fn_ref| {
-            for (program.exprSpan(fn_ref.captures)) |capture| {
-                markReachableLiftedExpr(program, capture, reachable);
+            for (program.captureOperandSpan(fn_ref.captures)) |operand| {
+                markReachableLiftedExpr(program, operand.value, reachable);
             }
         },
         .list,
@@ -1133,7 +1133,7 @@ fn markReachableLiftedExpr(
         },
         .call_proc => |call| {
             for (program.exprSpan(call.args)) |arg| markReachableLiftedExpr(program, arg, reachable);
-            for (program.exprSpan(call.captures)) |capture| markReachableLiftedExpr(program, capture, reachable);
+            for (program.captureOperandSpan(call.captures)) |operand| markReachableLiftedExpr(program, operand.value, reachable);
         },
         .low_level => |call| for (program.exprSpan(call.args)) |arg| markReachableLiftedExpr(program, arg, reachable),
         .field_access => |field| markReachableLiftedExpr(program, field.receiver, reachable),

--- a/src/flake.nix
+++ b/src/flake.nix
@@ -37,12 +37,32 @@
         pkgs = import nixpkgs { inherit system; };
         isLinux = pkgs.stdenv.isLinux;
 
-        # kcov build dependencies for Linux (coverage uses custom kcov fork built from source)
+        # kcov (built from source for coverage on every platform) links system
+        # libs via pkg-config, but asks for "z"/"curl"/"dwarf" while nixpkgs
+        # ships "zlib"/"libcurl"/"libdwarf". Provide alias .pc files so those
+        # resolve; they must be packages since the nix pkg-config wrapper only
+        # reads .pc dirs from buildInputs. On macOS the bare "-l" fallback only
+        # searches the SDK (which has neither libz nor libcurl), so every lib
+        # must resolve through pkg-config here.
+        pcConfigAlias = name: pkg: pcName: pkgs.runCommand "pkgconfig-alias-${name}" { } ''
+          mkdir -p "$out/lib/pkgconfig"
+          cp "$(find ${pkg} -name '${pcName}.pc' | head -n1)" "$out/lib/pkgconfig/${name}.pc"
+        '';
         kcovBuildDeps = with pkgs; [
-          elfutils
           pkg-config
           curl
           zlib
+          (pcConfigAlias "z" zlib.dev "zlib")
+          (pcConfigAlias "curl" curl.dev "libcurl")
+        ];
+        # elfutils (libdw/libelf for DWARF parsing) is used by kcov on Linux.
+        kcovLinuxOnlyDeps = with pkgs; [
+          elfutils
+        ];
+        # macOS kcov uses libdwarf (linked as "dwarf") instead of elfutils.
+        kcovDarwinOnlyDeps = with pkgs; [
+          libdwarf
+          (pcConfigAlias "dwarf" libdwarf.dev "libdwarf")
         ];
         zig = pkgs.zig_0_16;
         dependencies = [
@@ -53,7 +73,9 @@
           pkgs.jq # see ci/benchmarks_zig.sh
           (pkgs.writeShellScriptBin "zon2nix" "nix run github:Cloudef/zig2nix -- zon2nix")
         ]
-        ++ pkgs.lib.optionals isLinux kcovBuildDeps;
+        ++ kcovBuildDeps
+        ++ pkgs.lib.optionals isLinux kcovLinuxOnlyDeps
+        ++ pkgs.lib.optionals (!isLinux) kcovDarwinOnlyDeps;
 
         shellFunctions = ''
           buildcmd() {

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -76,6 +76,7 @@ fn movedSolvedView(source: *const Solved.Program, moved: *const Ast.Program) Sol
             .typed_locals = source.lifted.typed_locals.items,
             .stmt_ids = source.lifted.stmt_ids.items,
             .field_exprs = source.lifted.field_exprs.items,
+            .capture_operands = source.lifted.capture_operands.items,
             .record_destructs = source.lifted.record_destructs.items,
             .str_pattern_steps = source.lifted.str_pattern_steps.items,
             .branches = source.lifted.branches.items,
@@ -707,12 +708,12 @@ const Lowerer = struct {
         self: *Lowerer,
         expr_id: Lifted.ExprId,
         fn_id: Lifted.FnId,
-        captures_span: Lifted.Span(Lifted.ExprId),
+        captures_span: Lifted.Span(Lifted.CaptureOperand),
         ty: Type.TypeId,
     ) Allocator.Error!Ast.ExprData {
         const captures = self.memberCapturesForExpr(expr_id, fn_id);
-        const capture_exprs = self.solved.lifted.exprSpan(captures_span);
-        if (self.solved.lifted.typedLocalSpan(self.solved.lifted.fns[@intFromEnum(fn_id)].captures).len != capture_exprs.len) {
+        const capture_operands = self.solved.lifted.captureOperandSpan(captures_span);
+        if (self.solved.lifted.typedLocalSpan(self.solved.lifted.fns[@intFromEnum(fn_id)].captures).len != capture_operands.len) {
             Common.invariant("function reference capture operand count differed from lifted function captures");
         }
         return switch (self.program.types.get(ty)) {
@@ -723,7 +724,7 @@ const Lowerer = struct {
                     break :blk .{ .callable = .{
                         .ty = ty,
                         .variant = variant.id,
-                        .payload = if (variant.capture_ty) |capture_ty| try self.buildCaptureRecordFromExprs(fn_id, captures, capture_exprs, capture_ty) else null,
+                        .payload = if (variant.capture_ty) |capture_ty| try self.buildCaptureRecordFromExprs(captures, capture_operands, capture_ty) else null,
                     } };
                 }
                 Common.invariant("finite callable type did not contain referenced function");
@@ -734,7 +735,7 @@ const Lowerer = struct {
                     if (variant.source != fn_symbol) continue;
                     break :blk .{ .packed_erased_fn = .{
                         .target = variant.target,
-                        .capture = if (variant.capture_ty) |capture_ty| try self.buildCaptureRecordFromExprs(fn_id, captures, capture_exprs, capture_ty) else null,
+                        .capture = if (variant.capture_ty) |capture_ty| try self.buildCaptureRecordFromExprs(captures, capture_operands, capture_ty) else null,
                     } };
                 }
                 Common.invariant("erased callable type did not contain referenced function");
@@ -766,25 +767,25 @@ const Lowerer = struct {
         self: *Lowerer,
         fn_id: Lifted.FnId,
         args_span: Lifted.Span(Lifted.ExprId),
-        capture_exprs_span: Lifted.Span(Lifted.ExprId),
+        capture_operands_span: Lifted.Span(Lifted.CaptureOperand),
     ) Allocator.Error!Ast.Span(Ast.ExprId) {
         const args = try self.lowerExprSlice(self.solved.lifted.exprSpan(args_span));
         defer self.allocator.free(args);
 
         const captures = self.capturesForFn(fn_id);
         if (captures.len != 0) {
-            const capture_exprs = self.solved.lifted.exprSpan(capture_exprs_span);
-            if (capture_exprs.len != captures.len) Common.invariant("direct call capture operand count differed from callee capture count");
+            const capture_operands = self.solved.lifted.captureOperandSpan(capture_operands_span);
+            if (capture_operands.len != captures.len) Common.invariant("direct call capture operand count differed from callee capture count");
             const target_fn = try self.ensureOwnFnSpec(fn_id, .finite);
             const capture_ty = self.fn_specs.items[@intFromEnum(target_fn)].capture_ty orelse
                 Common.invariant("capturing direct call target had no capture record type");
             const call_args = try self.allocator.alloc(Ast.ExprId, args.len + 1);
             defer self.allocator.free(call_args);
             @memcpy(call_args[0..args.len], args);
-            call_args[args.len] = try self.buildCaptureRecordFromExprs(fn_id, captures, capture_exprs, capture_ty);
+            call_args[args.len] = try self.buildCaptureRecordFromExprs(captures, capture_operands, capture_ty);
             return try self.program.addExprSpan(call_args);
         }
-        if (self.solved.lifted.exprSpan(capture_exprs_span).len != 0) {
+        if (self.solved.lifted.captureOperandSpan(capture_operands_span).len != 0) {
             Common.invariant("direct call carried capture operands for a capture-free callee");
         }
 
@@ -863,9 +864,8 @@ const Lowerer = struct {
 
     fn buildCaptureRecordFromExprs(
         self: *Lowerer,
-        fn_id: Lifted.FnId,
         capture_span: SolvedType.Span,
-        capture_exprs: []const Lifted.ExprId,
+        capture_operands: []const Lifted.CaptureOperand,
         capture_ty: Type.TypeId,
     ) Allocator.Error!Ast.ExprId {
         const captures = self.solved.types.captureSpan(capture_span);
@@ -874,45 +874,28 @@ const Lowerer = struct {
             else => Common.invariant("callable capture payload was not a capture record"),
         };
         if (captures.len != fields.len) Common.invariant("callable capture payload arity differed from captured locals");
-        if (self.solved.lifted.typedLocalSpan(self.solved.lifted.fns[@intFromEnum(fn_id)].captures).len != capture_exprs.len) {
+        if (captures.len != capture_operands.len) {
             Common.invariant("function reference capture operand count differed from lifted function captures");
         }
 
+        // Member captures, capture-record fields, and keyed operands are all in
+        // canonical CaptureId order, so the join is an exact indexed walk.
         const values = try self.allocator.alloc(Ast.ExprId, captures.len);
         defer self.allocator.free(values);
-        for (captures, fields, 0..) |capture, field, i| {
+        for (captures, fields, capture_operands, 0..) |capture, field, operand, i| {
             if (capture.symbol != field.symbol or capture.binder != field.binder or capture.capture_id != field.capture_id) {
                 Common.invariant("callable capture payload fields differed from captured locals");
             }
-            values[i] = if (self.captureExprForMemberCapture(fn_id, capture_exprs, capture)) |capture_expr_id|
-                try self.lowerExpr(capture_expr_id)
-            else
-                try self.lowerLocalValue(capture.local, field.ty);
+            const capture_id = capture.capture_id orelse Common.invariant("member capture had no CaptureId");
+            if (operand.id != capture_id) {
+                Common.invariant("capture operand CaptureId did not match its member capture slot");
+            }
+            values[i] = try self.lowerExpr(operand.value);
         }
         return try self.program.addExpr(.{
             .ty = capture_ty,
             .data = .{ .capture_record = try self.program.addExprSpan(values) },
         });
-    }
-
-    fn captureExprForMemberCapture(
-        self: *Lowerer,
-        fn_id: Lifted.FnId,
-        capture_exprs: []const Lifted.ExprId,
-        member_capture: SolvedType.Capture,
-    ) ?Lifted.ExprId {
-        const fn_captures = self.solved.lifted.typedLocalSpan(self.solved.lifted.fns[@intFromEnum(fn_id)].captures);
-        for (fn_captures, capture_exprs) |fn_capture, capture_expr| {
-            if (fn_capture.local == member_capture.local) return capture_expr;
-            const fn_binder = self.solved.lifted.locals[@intFromEnum(fn_capture.local)].binder;
-            if (fn_binder != null and member_capture.binder != null and fn_binder.? == member_capture.binder.?) return capture_expr;
-        }
-        return null;
-    }
-
-    fn lowerLocalValue(self: *Lowerer, local: Lifted.LocalId, ty: Type.TypeId) Allocator.Error!Ast.ExprId {
-        const data = try self.lowerLocalExpr(local, ty);
-        return try self.program.addExpr(.{ .ty = ty, .data = data });
     }
 
     fn lowerPat(self: *Lowerer, pat_id: Lifted.PatId) Allocator.Error!Ast.PatId {

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -492,7 +492,7 @@ const Lowerer = struct {
         if (captures.len != fields.len) Common.invariant("function capture argument arity differed from capture slots");
 
         for (captures, fields) |capture, field| {
-            if (capture.symbol != field.symbol or capture.binder != field.binder or capture.capture_id != field.capture_id) {
+            if (capture.capture_id != field.capture_id) {
                 Common.invariant("function capture argument fields differed from capture slots");
             }
             try self.captures.put(capture.local, .{
@@ -879,11 +879,11 @@ const Lowerer = struct {
         }
 
         // Member captures, capture-record fields, and keyed operands are all in
-        // canonical CaptureId order, so the join is an exact indexed walk.
+        // ascending CaptureId order, so the join is an exact indexed walk.
         const values = try self.allocator.alloc(Ast.ExprId, captures.len);
         defer self.allocator.free(values);
         for (captures, fields, capture_operands, 0..) |capture, field, operand, i| {
-            if (capture.symbol != field.symbol or capture.binder != field.binder or capture.capture_id != field.capture_id) {
+            if (capture.capture_id != field.capture_id) {
                 Common.invariant("callable capture payload fields differed from captured locals");
             }
             const capture_id = capture.capture_id orelse Common.invariant("member capture had no CaptureId");

--- a/src/postcheck/lambda_mono/type.zig
+++ b/src/postcheck/lambda_mono/type.zig
@@ -41,7 +41,7 @@ pub const Field = struct {
 pub const CaptureField = struct {
     symbol: Common.Symbol,
     binder: ?check.CheckedModule.PatternBinderId,
-    capture_id: ?u32 = null,
+    capture_id: ?check.CheckedModule.CaptureId = null,
     ty: TypeId,
 };
 

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -454,12 +454,15 @@ const Solver = struct {
             .fn_ref => |fn_ref| {
                 try self.unify(expected, self.program.fn_tys.items[@intFromEnum(fn_ref.fn_id)]);
                 const captures = self.liftedCapturesForFn(fn_ref.fn_id);
-                const capture_exprs = self.lifted.exprSpan(fn_ref.captures);
-                if (captures.len != capture_exprs.len) {
+                const capture_operands = self.lifted.captureOperandSpan(fn_ref.captures);
+                if (captures.len != capture_operands.len) {
                     Common.invariant("function reference capture count differs from its target");
                 }
-                for (captures, capture_exprs) |capture, capture_expr| {
-                    _ = try self.expectExpr(capture_expr, self.localTy(capture.local));
+                for (captures, capture_operands) |capture, operand| {
+                    if (operand.id != self.lifted.captureIdOfLocal(capture.local)) {
+                        Common.invariant("function reference capture operand CaptureId did not match its slot");
+                    }
+                    _ = try self.expectExpr(operand.value, self.localTy(capture.local));
                 }
             },
             .call_value => |call| {
@@ -482,10 +485,13 @@ const Solver = struct {
                             _ = try self.expectExpr(arg, self.program.types.spanItem(func.args, i));
                         }
                         const captures = self.liftedCapturesForFn(callee);
-                        const capture_exprs = self.lifted.exprSpan(call.captures);
-                        if (captures.len != capture_exprs.len) Common.invariant("procedure call capture count differs from its callee");
-                        for (captures, capture_exprs) |capture, capture_expr| {
-                            _ = try self.expectExpr(capture_expr, self.localTy(capture.local));
+                        const capture_operands = self.lifted.captureOperandSpan(call.captures);
+                        if (captures.len != capture_operands.len) Common.invariant("procedure call capture count differs from its callee");
+                        for (captures, capture_operands) |capture, operand| {
+                            if (operand.id != self.lifted.captureIdOfLocal(capture.local)) {
+                                Common.invariant("procedure call capture operand CaptureId did not match its slot");
+                            }
+                            _ = try self.expectExpr(operand.value, self.localTy(capture.local));
                         }
                     },
                     .imported => {

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -1437,11 +1437,7 @@ const Solver = struct {
         for (0..lhs.count()) |i| {
             const left_capture = self.program.types.captureItem(lhs, i);
             const right_capture = self.program.types.captureItem(rhs, i);
-            if (left_capture.local != right_capture.local or
-                left_capture.symbol != right_capture.symbol or
-                left_capture.binder != right_capture.binder or
-                left_capture.capture_id != right_capture.capture_id)
-            {
+            if (left_capture.capture_id != right_capture.capture_id) {
                 Common.invariant("capture identity failed Lambda Solved unification");
             }
             try self.unify(left_capture.ty, right_capture.ty);

--- a/src/postcheck/lambda_solved/type.zig
+++ b/src/postcheck/lambda_solved/type.zig
@@ -51,7 +51,7 @@ pub const Capture = struct {
     local: @import("../monotype_lifted/ast.zig").LocalId,
     symbol: Common.Symbol,
     binder: ?check.CheckedModule.PatternBinderId,
-    capture_id: ?u32 = null,
+    capture_id: ?check.CheckedModule.CaptureId = null,
     ty: TypeVarId,
 };
 

--- a/src/postcheck/lir_lower.zig
+++ b/src/postcheck/lir_lower.zig
@@ -740,7 +740,7 @@ const Lowerer = struct {
                 .id = if (field.binder) |binder|
                     .{ .binder = binder }
                 else if (field.capture_id) |capture_id|
-                    .{ .generated = capture_id }
+                    .{ .generated = capture_id.generatedIndex() }
                 else
                     .{ .generated = @intFromEnum(field.symbol) },
                 .slot = @intCast(index),

--- a/src/postcheck/lir_lower.zig
+++ b/src/postcheck/lir_lower.zig
@@ -737,12 +737,7 @@ const Lowerer = struct {
         errdefer self.allocator.free(slots);
         for (fields, 0..) |field, index| {
             slots[index] = .{
-                .id = if (field.binder) |binder|
-                    .{ .binder = binder }
-                else if (field.capture_id) |capture_id|
-                    .{ .generated = capture_id.generatedIndex() }
-                else
-                    .{ .generated = @intFromEnum(field.symbol) },
+                .id = field.capture_id orelse Common.invariant("capture record field had no CaptureId"),
                 .slot = @intCast(index),
                 .ty = try self.constTypeOfType(field.ty),
                 .plan = try self.constPlanOfType(field.ty),

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -259,9 +259,9 @@ pub const Local = struct {
     symbol: Common.Symbol,
     ty: Type.TypeId,
     binder: ?checked.PatternBinderId = null,
-    /// Canonical identity of this local as a closure capture, carried
+    /// Exact identity of this local as a closure capture, carried
     /// immutably through every post-check IR. Non-null for a captured binding
-    /// (canonical, derived from `binder`) and for a compiler-synthesized
+    /// (binder-derived) and for a compiler-synthesized
     /// capturable local (generated).
     capture_id: ?checked.CaptureId = null,
 };
@@ -1289,7 +1289,7 @@ pub const ProgramBuilder = struct {
             .symbol = symbol,
             .ty = ty,
             .binder = binder,
-            // A binder-backed local carries the canonical capture identity of
+            // A binder-backed local carries the exact capture identity of
             // its binding, so any function that captures it joins by CaptureId.
             .capture_id = if (binder) |b| checked.CaptureId.fromBinder(b) else null,
         });

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -297,12 +297,23 @@ pub const CallValue = struct {
     args: Span(ExprId),
 };
 
+/// One explicit capture operand supplied at a lifted function reference /
+/// direct call site. `id` is the `CaptureId` of the target function's capture
+/// slot this operand fills; `value` is the expression that supplies it. Operand
+/// spans are stored sorted by `id`, parallel to the target's canonically-sorted
+/// capture slots, so every operand↔slot join is an exact keyed lookup with no
+/// load-bearing order.
+pub const CaptureOperand = struct {
+    id: checked.CaptureId,
+    value: ExprId,
+};
+
 /// Reference to a lifted function value. `captures` contains the explicit
-/// values used to build the callable payload, parallel to that function's
-/// lifted capture span.
+/// operands used to build the callable payload, keyed by `CaptureId` and sorted
+/// to match that function's canonically-sorted capture slots.
 pub const LiftedFunctionValue = struct {
     fn_id: LiftedFnId,
-    captures: Span(ExprId) = Span(ExprId).empty(),
+    captures: Span(CaptureOperand) = Span(CaptureOperand).empty(),
 };
 
 /// Explicit operand for one checked closure capture before lifting. The `local`
@@ -348,10 +359,10 @@ pub fn importedProcCallee(imported: ImportedFnId) ProcCallee {
 pub const CallProc = struct {
     callee: ProcCallee,
     args: Span(ExprId),
-    /// Explicit values for the callee's lifted captures, parallel to that
-    /// callee's capture span. Empty before Monotype lifting has resolved direct
-    /// call targets.
-    captures: Span(ExprId) = Span(ExprId).empty(),
+    /// Explicit operands for the callee's lifted captures, keyed by `CaptureId`
+    /// and sorted to match that callee's canonically-sorted capture slots. Empty
+    /// before Monotype lifting has resolved direct call targets.
+    captures: Span(CaptureOperand) = Span(CaptureOperand).empty(),
     /// This direct call is on an explicitly generated cold path. Later stages
     /// may use this to avoid inlining and to attach backend cold-call metadata;
     /// they must not infer coldness from callee names or source paths.
@@ -799,6 +810,7 @@ pub const ProgramView = struct {
     stmt_ids: []const StmtId,
     field_exprs: []const FieldExpr,
     fn_def_captures: []const FnDefCapture,
+    capture_operands: []const CaptureOperand,
     record_destructs: []const RecordDestruct,
     str_pattern_steps: []const StrPatternStep,
     branches: []const Branch,
@@ -956,6 +968,9 @@ pub const ProgramBuilder = struct {
     stmt_ids: std.ArrayList(StmtId),
     field_exprs: std.ArrayList(FieldExpr),
     fn_def_captures: std.ArrayList(FnDefCapture),
+    /// Backing pool for lifted `Span(CaptureOperand)` capture operand spans.
+    /// Empty in the pre-lift Monotype program (populated by closure lifting).
+    capture_operands: std.ArrayList(CaptureOperand),
     record_destructs: std.ArrayList(RecordDestruct),
     str_pattern_steps: std.ArrayList(StrPatternStep),
     branches: std.ArrayList(Branch),
@@ -1008,6 +1023,7 @@ pub const ProgramBuilder = struct {
             .stmt_ids = .empty,
             .field_exprs = .empty,
             .fn_def_captures = .empty,
+            .capture_operands = .empty,
             .record_destructs = .empty,
             .str_pattern_steps = .empty,
             .branches = .empty,
@@ -1055,6 +1071,7 @@ pub const ProgramBuilder = struct {
         self.str_pattern_steps.deinit(self.allocator);
         self.record_destructs.deinit(self.allocator);
         self.fn_def_captures.deinit(self.allocator);
+        self.capture_operands.deinit(self.allocator);
         self.field_exprs.deinit(self.allocator);
         self.stmt_ids.deinit(self.allocator);
         self.typed_locals.deinit(self.allocator);
@@ -1122,6 +1139,7 @@ pub const ProgramBuilder = struct {
             .stmt_ids = self.stmt_ids.items,
             .field_exprs = self.field_exprs.items,
             .fn_def_captures = self.fn_def_captures.items,
+            .capture_operands = self.capture_operands.items,
             .record_destructs = self.record_destructs.items,
             .str_pattern_steps = self.str_pattern_steps.items,
             .branches = self.branches.items,
@@ -1266,7 +1284,15 @@ pub const ProgramBuilder = struct {
         binder: ?checked.PatternBinderId,
     ) std.mem.Allocator.Error!LocalId {
         const id: LocalId = @enumFromInt(@as(u32, @intCast(self.locals.items.len)));
-        try self.locals.append(self.allocator, .{ .id = id, .symbol = symbol, .ty = ty, .binder = binder });
+        try self.locals.append(self.allocator, .{
+            .id = id,
+            .symbol = symbol,
+            .ty = ty,
+            .binder = binder,
+            // A binder-backed local carries the canonical capture identity of
+            // its binding, so any function that captures it joins by CaptureId.
+            .capture_id = if (binder) |b| checked.CaptureId.fromBinder(b) else null,
+        });
         try self.local_names.append(self.allocator, "");
         return id;
     }
@@ -1275,7 +1301,7 @@ pub const ProgramBuilder = struct {
     /// `capture_id` is the per-owner generated index; it is stored in the
     /// generated range of `CaptureId`.
     pub fn setLocalCaptureId(self: *ProgramBuilder, id: LocalId, capture_id: u32) void {
-        self.locals.items[@intFromEnum(id)].capture_id = checked.CaptureId.generated(capture_id);
+        self.locals.items[@intFromEnum(id)].capture_id = checked.CaptureId.generatedCheck(capture_id);
     }
 
     /// Record the source-level name of a local (dupes; empty means none).
@@ -1386,6 +1412,23 @@ pub const ProgramBuilder = struct {
 
     pub fn fnDefCaptureSpan(self: *const ProgramBuilder, span_: Span(FnDefCapture)) []const FnDefCapture {
         return self.fn_def_captures.items[span_.start..][0..span_.len];
+    }
+
+    pub fn addCaptureOperandSpan(self: *ProgramBuilder, values: []const CaptureOperand) std.mem.Allocator.Error!Span(CaptureOperand) {
+        const start: u32 = @intCast(self.capture_operands.items.len);
+        try self.capture_operands.appendSlice(self.allocator, values);
+        return .{ .start = start, .len = @intCast(values.len) };
+    }
+
+    pub fn captureOperandSpan(self: *const ProgramBuilder, span_: Span(CaptureOperand)) []const CaptureOperand {
+        return self.capture_operands.items[span_.start..][0..span_.len];
+    }
+
+    /// The CaptureId of a local. Every local that participates in a capture set
+    /// carries one; asserts it is present.
+    pub fn captureIdOfLocal(self: *const ProgramBuilder, id: LocalId) checked.CaptureId {
+        return self.locals.items[@intFromEnum(id)].capture_id orelse
+            Common.invariant("Monotype capture local had no CaptureId");
     }
 
     pub fn recordDestructSpan(self: *const ProgramBuilder, span_: Span(RecordDestruct)) []const RecordDestruct {

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -259,7 +259,11 @@ pub const Local = struct {
     symbol: Common.Symbol,
     ty: Type.TypeId,
     binder: ?checked.PatternBinderId = null,
-    capture_id: ?u32 = null,
+    /// Canonical identity of this local as a closure capture, carried
+    /// immutably through every post-check IR. Non-null for a captured binding
+    /// (canonical, derived from `binder`) and for a compiler-synthesized
+    /// capturable local (generated).
+    capture_id: ?checked.CaptureId = null,
 };
 
 /// Local id paired with its monomorphic type.
@@ -1267,8 +1271,11 @@ pub const ProgramBuilder = struct {
         return id;
     }
 
+    /// Assign a generated capture identity to a synthesized capturable local.
+    /// `capture_id` is the per-owner generated index; it is stored in the
+    /// generated range of `CaptureId`.
     pub fn setLocalCaptureId(self: *ProgramBuilder, id: LocalId, capture_id: u32) void {
-        self.locals.items[@intFromEnum(id)].capture_id = capture_id;
+        self.locals.items[@intFromEnum(id)].capture_id = checked.CaptureId.generated(capture_id);
     }
 
     /// Record the source-level name of a local (dupes; empty means none).

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -5286,7 +5286,7 @@ const BodyDraftStore = struct {
             .symbol = symbol,
             .ty = ty,
             .binder = binder,
-            // A binder-backed local carries the canonical capture identity of
+            // A binder-backed local carries the exact capture identity of
             // its binding, so any function that captures it joins by CaptureId.
             .capture_id = if (binder) |b| checked.CaptureId.fromBinder(b) else null,
         });

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -3173,10 +3173,7 @@ const Builder = struct {
     ) Allocator.Error!std.ArrayList(RestoredConstSourceCapture) {
         var capture_count: usize = 0;
         for (fn_value.captures) |capture| {
-            switch (capture.id) {
-                .binder => capture_count += 1,
-                .generated => {},
-            }
+            if (capture.id.isCanonical()) capture_count += 1;
         }
 
         var out = std.ArrayList(RestoredConstSourceCapture).empty;
@@ -3184,10 +3181,8 @@ const Builder = struct {
         try out.ensureTotalCapacity(self.allocator, capture_count);
 
         for (fn_value.captures) |capture| {
-            const binder = switch (capture.id) {
-                .binder => |binder| binder,
-                .generated => continue,
-            };
+            if (!capture.id.isCanonical()) continue;
+            const binder = capture.id.binder();
             const lowered_ty = try fn_ctx.lowerTypeView(checkedBinderType(fn_view, binder));
             const local = try fn_ctx.addLocalWithBinder(self.symbols.fresh(), lowered_ty, binder);
             try fn_ctx.bindLocalName(local, binder);
@@ -3206,10 +3201,7 @@ const Builder = struct {
 
         var out_index: usize = 0;
         for (fn_value.captures) |capture| {
-            switch (capture.id) {
-                .binder => {},
-                .generated => continue,
-            }
+            if (!capture.id.isCanonical()) continue;
             out.items[out_index].value = try fn_ctx.restoreConstNodeAtType(store_view, fn_view, capture.value, out.items[out_index].ty);
             out_index += 1;
         }
@@ -23594,18 +23586,14 @@ fn checkedCaptureBinder(view: ModuleView, pattern: checked.CheckedPatternId) che
 }
 
 fn constCaptureBinder(id: check.ConstStore.CaptureId) checked.PatternBinderId {
-    return switch (id) {
-        .binder => |binder| binder,
-        .generated => Common.invariant("generated capture reached source lambda restore"),
-    };
+    if (!id.isCanonical()) Common.invariant("generated capture reached source lambda restore");
+    return id.binder();
 }
 
 fn constGeneratedCaptureNode(fn_value: check.ConstStore.ConstFn, capture_id: u32) ?checked.ConstNodeId {
+    const needle = checked.CaptureId.generatedCheck(capture_id);
     for (fn_value.captures) |capture| {
-        switch (capture.id) {
-            .generated => |actual| if (actual == capture_id) return capture.value,
-            .binder => {},
-        }
+        if (capture.id == needle) return capture.value;
     }
     return null;
 }

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -3337,8 +3337,8 @@ const Builder = struct {
             .def_ref,
             => return false,
             .fn_ref => |fn_ref| {
-                for (self.program.exprSpan(fn_ref.captures)) |capture| {
-                    if (try self.exprDependsOnFreeLocalInner(capture, target, bound, active_fns)) return true;
+                for (self.program.captureOperandSpan(fn_ref.captures)) |operand| {
+                    if (try self.exprDependsOnFreeLocalInner(operand.value, target, bound, active_fns)) return true;
                 }
                 return false;
             },
@@ -3408,8 +3408,8 @@ const Builder = struct {
                 for (self.program.exprSpan(call.args)) |arg| {
                     if (try self.exprDependsOnFreeLocalInner(arg, target, bound, active_fns)) return true;
                 }
-                for (self.program.exprSpan(call.captures)) |capture| {
-                    if (try self.exprDependsOnFreeLocalInner(capture, target, bound, active_fns)) return true;
+                for (self.program.captureOperandSpan(call.captures)) |operand| {
+                    if (try self.exprDependsOnFreeLocalInner(operand.value, target, bound, active_fns)) return true;
                 }
                 return false;
             },
@@ -5294,6 +5294,9 @@ const BodyDraftStore = struct {
             .symbol = symbol,
             .ty = ty,
             .binder = binder,
+            // A binder-backed local carries the canonical capture identity of
+            // its binding, so any function that captures it joins by CaptureId.
+            .capture_id = if (binder) |b| checked.CaptureId.fromBinder(b) else null,
         });
         try self.local_names.append(self.allocator, .empty());
         return id;
@@ -5442,7 +5445,7 @@ const BodyDraftStore = struct {
     }
 
     fn setLocalCaptureId(self: *BodyDraftStore, id: DraftLocalId, capture_id: u32) void {
-        self.locals.items[@intFromEnum(id)].capture_id = checked.CaptureId.generated(capture_id);
+        self.locals.items[@intFromEnum(id)].capture_id = checked.CaptureId.generatedCheck(capture_id);
     }
 
     fn setLocalType(self: *BodyDraftStore, id: DraftLocalId, ty: DraftTypeCell) void {
@@ -5810,12 +5813,17 @@ const BodyDraftStore = struct {
                 .callee = ids.expr(call.callee),
                 .args = ids.exprSpan(call.args),
             } },
-            .call_proc => |call| .{ .call_proc = .{
-                .callee = ids.procCallee(call.callee),
-                .args = ids.exprSpan(call.args),
-                .captures = ids.exprSpan(call.captures),
-                .is_cold = call.is_cold,
-            } },
+            .call_proc => |call| blk: {
+                // Pre-lift direct calls never carry capture operands; closure
+                // lifting resolves them. Preserve that as an invariant.
+                std.debug.assert(call.captures.len == 0);
+                break :blk .{ .call_proc = .{
+                    .callee = ids.procCallee(call.callee),
+                    .args = ids.exprSpan(call.args),
+                    .captures = Ast.Span(Ast.CaptureOperand).empty(),
+                    .is_cold = call.is_cold,
+                } };
+            },
             .low_level => |call| .{ .low_level = .{
                 .op = call.op,
                 .args = ids.exprSpan(call.args),

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -4725,7 +4725,7 @@ const DraftLocal = struct {
     symbol: Common.Symbol,
     ty: DraftTypeCell,
     binder: ?checked.PatternBinderId = null,
-    capture_id: ?u32 = null,
+    capture_id: ?checked.CaptureId = null,
 };
 
 const DraftTypedLocal = struct {
@@ -5442,7 +5442,7 @@ const BodyDraftStore = struct {
     }
 
     fn setLocalCaptureId(self: *BodyDraftStore, id: DraftLocalId, capture_id: u32) void {
-        self.locals.items[@intFromEnum(id)].capture_id = capture_id;
+        self.locals.items[@intFromEnum(id)].capture_id = checked.CaptureId.generated(capture_id);
     }
 
     fn setLocalType(self: *BodyDraftStore, id: DraftLocalId, ty: DraftTypeCell) void {

--- a/src/postcheck/monotype/serialize.zig
+++ b/src/postcheck/monotype/serialize.zig
@@ -524,7 +524,7 @@ pub const MappedProgramView = struct {
             .fn_def => |fn_def| self.fnRefInBounds(fn_def.fn_id) and self.fnDefCaptureSpanInBounds(fn_def.captures),
             .fn_ref => true,
             .call_value => |call| self.exprRefInBounds(call.callee) and self.exprIdSpanInBounds(call.args),
-            .call_proc => |call| self.exprIdSpanInBounds(call.args) and self.exprIdSpanInBounds(call.captures),
+            .call_proc => |call| self.exprIdSpanInBounds(call.args) and self.captureOperandSpanInBounds(call.captures),
             .low_level => |call| self.exprIdSpanInBounds(call.args),
             .field_access => |field| self.exprRefInBounds(field.receiver),
             .tuple_access => |tuple| self.exprRefInBounds(tuple.tuple),
@@ -653,6 +653,13 @@ pub const MappedProgramView = struct {
 
     fn fnDefCaptureSpanInBounds(self: MappedProgramView, span: Ast.Span(Ast.FnDefCapture)) bool {
         return spanInBounds(self.fn_def_captures.len, span.start, span.len);
+    }
+
+    fn captureOperandSpanInBounds(self: MappedProgramView, span: Ast.Span(Ast.CaptureOperand)) bool {
+        _ = self;
+        // The pre-lift Monotype program never carries capture operands; closure
+        // lifting resolves them, so the serialized program has none.
+        return span.len == 0;
     }
 
     fn recordDestructSpanInBounds(self: MappedProgramView, span: Ast.Span(Ast.RecordDestruct)) bool {

--- a/src/postcheck/monotype/serialize.zig
+++ b/src/postcheck/monotype/serialize.zig
@@ -524,7 +524,7 @@ pub const MappedProgramView = struct {
             .fn_def => |fn_def| self.fnRefInBounds(fn_def.fn_id) and self.fnDefCaptureSpanInBounds(fn_def.captures),
             .fn_ref => true,
             .call_value => |call| self.exprRefInBounds(call.callee) and self.exprIdSpanInBounds(call.args),
-            .call_proc => |call| self.exprIdSpanInBounds(call.args) and self.captureOperandSpanInBounds(call.captures),
+            .call_proc => |call| self.exprIdSpanInBounds(call.args) and captureOperandSpanInBounds(call.captures),
             .low_level => |call| self.exprIdSpanInBounds(call.args),
             .field_access => |field| self.exprRefInBounds(field.receiver),
             .tuple_access => |tuple| self.exprRefInBounds(tuple.tuple),
@@ -655,8 +655,7 @@ pub const MappedProgramView = struct {
         return spanInBounds(self.fn_def_captures.len, span.start, span.len);
     }
 
-    fn captureOperandSpanInBounds(self: MappedProgramView, span: Ast.Span(Ast.CaptureOperand)) bool {
-        _ = self;
+    fn captureOperandSpanInBounds(span: Ast.Span(Ast.CaptureOperand)) bool {
         // The pre-lift Monotype program never carries capture operands; closure
         // lifting resolves them, so the serialized program has none.
         return span.len == 0;

--- a/src/postcheck/monotype_lifted/ast.zig
+++ b/src/postcheck/monotype_lifted/ast.zig
@@ -42,6 +42,8 @@ pub const ComptimeSite = Mono.ComptimeSite;
 pub const FieldExpr = Mono.FieldExpr;
 /// Keyed pre-lift function capture operand.
 pub const FnDefCapture = Mono.FnDefCapture;
+/// Keyed lifted capture operand (CaptureId + supplying expression).
+pub const CaptureOperand = Mono.CaptureOperand;
 /// Record destructuring field pattern.
 pub const RecordDestruct = Mono.RecordDestruct;
 /// Compiler-generated initialized-payload switch shared with Monotype IR.
@@ -137,6 +139,7 @@ pub const ProgramView = struct {
     typed_locals: []const TypedLocal,
     stmt_ids: []const StmtId,
     field_exprs: []const FieldExpr,
+    capture_operands: []const CaptureOperand,
     record_destructs: []const RecordDestruct,
     str_pattern_steps: []const Mono.StrPatternStep,
     branches: []const Branch,
@@ -182,6 +185,13 @@ pub const ProgramView = struct {
         return self.local_names[@intFromEnum(id)];
     }
 
+    /// The CaptureId of a local. Every local that participates in a capture set
+    /// carries one; asserts it is present.
+    pub fn captureIdOfLocal(self: ProgramView, id: LocalId) check.CheckedModule.CaptureId {
+        return self.locals[@intFromEnum(id)].capture_id orelse
+            Common.invariant("lifted capture local had no CaptureId");
+    }
+
     pub fn exprSpan(self: ProgramView, span_: Span(ExprId)) []const ExprId {
         return self.expr_ids[span_.start..][0..span_.len];
     }
@@ -192,6 +202,10 @@ pub const ProgramView = struct {
 
     pub fn typedLocalSpan(self: ProgramView, span_: Span(TypedLocal)) []const TypedLocal {
         return self.typed_locals[span_.start..][0..span_.len];
+    }
+
+    pub fn captureOperandSpan(self: ProgramView, span_: Span(CaptureOperand)) []const CaptureOperand {
+        return self.capture_operands[span_.start..][0..span_.len];
     }
 
     pub fn stmtSpan(self: ProgramView, span_: Span(StmtId)) []const StmtId {
@@ -349,12 +363,17 @@ pub const Program = struct {
     stmt_ids: std.ArrayList(StmtId),
     field_exprs: std.ArrayList(FieldExpr),
     fn_def_captures: std.ArrayList(FnDefCapture),
+    /// Backing pool for `Span(CaptureOperand)` capture operand spans on lifted
+    /// `fn_ref`/`call_proc` nodes.
+    capture_operands: std.ArrayList(CaptureOperand),
     record_destructs: std.ArrayList(RecordDestruct),
     str_pattern_steps: std.ArrayList(Mono.StrPatternStep),
     branches: std.ArrayList(Branch),
     if_branches: std.ArrayList(IfBranch),
     string_literals: std.ArrayList(Mono.StringLiteral),
     proc_debug_names: ProcDebugNameMap,
+    /// Next generated `CaptureId` index for a lift-synthesized capturable local.
+    next_lift_capture_id: u32,
     roots: std.ArrayList(Root),
     layout_requests: std.ArrayList(LayoutRequest),
     runtime_schema_requests: std.ArrayList(RuntimeSchemaRequest),
@@ -425,12 +444,14 @@ pub const Program = struct {
             .stmt_ids = stmt_ids,
             .field_exprs = field_exprs,
             .fn_def_captures = fn_def_captures,
+            .capture_operands = .empty,
             .record_destructs = record_destructs,
             .str_pattern_steps = str_pattern_steps,
             .branches = branches,
             .if_branches = if_branches,
             .string_literals = string_literals,
             .proc_debug_names = proc_debug_names,
+            .next_lift_capture_id = 0,
             .roots = .empty,
             .layout_requests = .empty,
             .runtime_schema_requests = .empty,
@@ -472,6 +493,7 @@ pub const Program = struct {
         self.str_pattern_steps.deinit(self.allocator);
         self.record_destructs.deinit(self.allocator);
         self.fn_def_captures.deinit(self.allocator);
+        self.capture_operands.deinit(self.allocator);
         self.field_exprs.deinit(self.allocator);
         self.stmt_ids.deinit(self.allocator);
         self.typed_locals.deinit(self.allocator);
@@ -503,6 +525,7 @@ pub const Program = struct {
             .typed_locals = self.typed_locals.items,
             .stmt_ids = self.stmt_ids.items,
             .field_exprs = self.field_exprs.items,
+            .capture_operands = self.capture_operands.items,
             .record_destructs = self.record_destructs.items,
             .str_pattern_steps = self.str_pattern_steps.items,
             .branches = self.branches.items,
@@ -598,9 +621,27 @@ pub const Program = struct {
         binder: ?check.CheckedModule.PatternBinderId,
     ) std.mem.Allocator.Error!LocalId {
         const id: LocalId = @enumFromInt(@as(u32, @intCast(self.locals.items.len)));
-        try self.locals.append(self.allocator, .{ .id = id, .symbol = symbol, .ty = ty, .binder = binder });
+        try self.locals.append(self.allocator, .{
+            .id = id,
+            .symbol = symbol,
+            .ty = ty,
+            .binder = binder,
+            // A binder-backed local carries the canonical capture identity of
+            // its binding, so any function that captures it joins by CaptureId.
+            .capture_id = if (binder) |b| check.CheckedModule.CaptureId.fromBinder(b) else null,
+        });
         try self.local_names.append(self.allocator, "");
         return id;
+    }
+
+    /// Allocate the next generated `CaptureId` for a lift-synthesized capturable
+    /// local (a free local with no checked binder). The counter lives on the
+    /// program so the identity is stable across fixpoint rounds and unique
+    /// within the program.
+    pub fn nextLiftCaptureId(self: *Program) check.CheckedModule.CaptureId {
+        const index = self.next_lift_capture_id;
+        self.next_lift_capture_id += 1;
+        return check.CheckedModule.CaptureId.generatedLift(index);
     }
 
     pub fn addTypedLocalSpan(self: *Program, values: []const TypedLocal) std.mem.Allocator.Error!Span(TypedLocal) {
@@ -636,6 +677,12 @@ pub const Program = struct {
     pub fn addFnDefCaptureSpan(self: *Program, values: []const FnDefCapture) std.mem.Allocator.Error!Span(FnDefCapture) {
         const start: u32 = @intCast(self.fn_def_captures.items.len);
         try self.fn_def_captures.appendSlice(self.allocator, values);
+        return .{ .start = start, .len = @intCast(values.len) };
+    }
+
+    pub fn addCaptureOperandSpan(self: *Program, values: []const CaptureOperand) std.mem.Allocator.Error!Span(CaptureOperand) {
+        const start: u32 = @intCast(self.capture_operands.items.len);
+        try self.capture_operands.appendSlice(self.allocator, values);
         return .{ .start = start, .len = @intCast(values.len) };
     }
 
@@ -675,6 +722,13 @@ pub const Program = struct {
         return self.typed_locals.items[span_.start..][0..span_.len];
     }
 
+    /// The CaptureId of a local. Every local that participates in a capture set
+    /// carries one; asserts it is present.
+    pub fn captureIdOfLocal(self: *const Program, id: LocalId) check.CheckedModule.CaptureId {
+        return self.locals.items[@intFromEnum(id)].capture_id orelse
+            Common.invariant("lifted capture local had no CaptureId");
+    }
+
     pub fn stmtSpan(self: *const Program, span_: Span(StmtId)) []const StmtId {
         return self.stmt_ids.items[span_.start..][0..span_.len];
     }
@@ -685,6 +739,10 @@ pub const Program = struct {
 
     pub fn fnDefCaptureSpan(self: *const Program, span_: Span(FnDefCapture)) []const FnDefCapture {
         return self.fn_def_captures.items[span_.start..][0..span_.len];
+    }
+
+    pub fn captureOperandSpan(self: *const Program, span_: Span(CaptureOperand)) []const CaptureOperand {
+        return self.capture_operands.items[span_.start..][0..span_.len];
     }
 
     pub fn recordDestructSpan(self: *const Program, span_: Span(RecordDestruct)) []const RecordDestruct {

--- a/src/postcheck/monotype_lifted/ast.zig
+++ b/src/postcheck/monotype_lifted/ast.zig
@@ -626,7 +626,7 @@ pub const Program = struct {
             .symbol = symbol,
             .ty = ty,
             .binder = binder,
-            // A binder-backed local carries the canonical capture identity of
+            // A binder-backed local carries the exact capture identity of
             // its binding, so any function that captures it joins by CaptureId.
             .capture_id = if (binder) |b| check.CheckedModule.CaptureId.fromBinder(b) else null,
         });

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -139,6 +139,8 @@ pub fn run(
     try lifter.lowerDefsAndRoots();
     program.next_symbol = lifter.symbols.next;
 
+    verifyCaptureInvariants(&program);
+
     owned.deinit();
     return program;
 }
@@ -202,6 +204,88 @@ pub fn recomputeCaptures(allocator: Allocator, program: *Ast.Program) Allocator.
     for (program.fns.items, 0..) |*fn_, index| {
         fn_.captures = try program.addTypedLocalSpan(fn_captures[index].items);
     }
+
+    verifyCaptureInvariants(program);
+}
+
+/// Debug-only structural check that a Lifted program's capture representation is
+/// internally consistent. It is run after every Lifted-IR mutation (the initial
+/// lift and `recomputeCaptures`, which follows spec_constr / any body rewrite),
+/// so a pass that forgets to maintain captures fails deterministically at its
+/// own boundary instead of surfacing as a confusing crash five stages later.
+/// Compiled out entirely in release builds — release cost is zero.
+///
+/// It checks, per function and per `fn_ref`/`call_proc` site:
+///   - every capture slot's local carries a CaptureId, and the slot's type
+///     agrees with that local's type;
+///   - a function's capture slots are sorted by CaptureId with no duplicates;
+///   - every canonical CaptureId names its local's live checked binder;
+///   - an operand span carries exactly the target function's capture slots'
+///     CaptureId sequence (same ids, same sorted order), and each operand's
+///     value type equals its slot's type.
+pub fn verifyCaptureInvariants(program: *const Ast.Program) void {
+    if (@import("builtin").mode != .Debug) return;
+    const violation = checkCaptureInvariants(program) catch |err| switch (err) {
+        error.OutOfMemory => Common.invariant("verifyCaptureInvariants: out of memory during structural check"),
+    };
+    if (violation) |message| std.debug.panic("postcheck invariant violated: {s}", .{message});
+}
+
+/// The check itself, factored out of the panicking wrapper so it can be unit
+/// tested: returns the first violated invariant's message, or null if the
+/// program's capture representation is consistent.
+pub fn checkCaptureInvariants(program: *const Ast.Program) Allocator.Error!?[]const u8 {
+    for (program.fns.items) |fn_| {
+        if (checkCaptureSlotSpan(program, program.typedLocalSpan(fn_.captures))) |message| return message;
+    }
+
+    for (program.exprs.items) |expr| {
+        switch (expr.data) {
+            .fn_ref => |fn_ref| if (try checkOperandSpan(program, fn_ref.fn_id, fn_ref.captures)) |message| return message,
+            .call_proc => |call| switch (call.callee) {
+                .lifted => |fn_id| if (try checkOperandSpan(program, fn_id, call.captures)) |message| return message,
+                .func => {},
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+fn checkCaptureSlotSpan(program: *const Ast.Program, slots: []const Ast.TypedLocal) ?[]const u8 {
+    var previous: ?checked.CaptureId = null;
+    for (slots) |slot| {
+        const local = program.locals.items[@intFromEnum(slot.local)];
+        const id = local.capture_id orelse return "capture slot local had no CaptureId";
+        if (slot.ty != local.ty) return "capture slot type disagreed with its local type";
+        if (id.isCanonical()) {
+            const binder = local.binder orelse return "canonical capture slot had no checked binder";
+            if (id != checked.CaptureId.fromBinder(binder)) return "canonical CaptureId did not match its binder";
+        }
+        if (previous) |prev| {
+            if (@intFromEnum(prev) > @intFromEnum(id)) return "capture slots not sorted by CaptureId";
+            if (@intFromEnum(prev) == @intFromEnum(id)) return "duplicate CaptureId in a capture set";
+        }
+        previous = id;
+    }
+    return null;
+}
+
+fn checkOperandSpan(program: *const Ast.Program, fn_id: Ast.FnId, operand_span: Ast.Span(Ast.CaptureOperand)) Allocator.Error!?[]const u8 {
+    const slots = program.typedLocalSpan(program.fns.items[@intFromEnum(fn_id)].captures);
+    const operands = program.captureOperandSpan(operand_span);
+    if (slots.len != operands.len) return "operand count differed from target capture slot count";
+    for (slots, operands) |slot, operand| {
+        if (operand.id != slotCaptureId(program, slot)) return "operand CaptureId did not match its slot";
+        // Types are compared structurally: monomorphization/specialization may
+        // give the operand value and its slot distinct interned TypeIds for the
+        // same type.
+        const value_ty = program.exprs.items[@intFromEnum(operand.value)].ty;
+        if (!try program.types.typeEql(&program.names, value_ty, slot.ty)) {
+            return "operand value type differed from its capture slot type";
+        }
+    }
+    return null;
 }
 
 const DefMap = []?Ast.FnId;

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -165,6 +165,7 @@ fn movedMonoView(source: *const Mono.Program, moved: *const Ast.Program) Mono.Pr
         .stmt_ids = moved.stmt_ids.items,
         .field_exprs = moved.field_exprs.items,
         .fn_def_captures = moved.fn_def_captures.items,
+        .capture_operands = moved.capture_operands.items,
         .record_destructs = moved.record_destructs.items,
         .str_pattern_steps = moved.str_pattern_steps.items,
         .branches = moved.branches.items,
@@ -196,7 +197,7 @@ pub fn recomputeCaptures(allocator: Allocator, program: *Ast.Program) Allocator.
     defer deinitCaptureTable(allocator, fn_captures);
 
     try solveCaptureFixpoint(allocator, program, fn_captures);
-    try finalizeProgramFunctionReferenceCaptures(allocator, program, fn_captures);
+    try finalizeProgramFunctionReferenceCaptures(program, fn_captures);
 
     for (program.fns.items, 0..) |*fn_, index| {
         fn_.captures = try program.addTypedLocalSpan(fn_captures[index].items);
@@ -212,24 +213,6 @@ const MonoFnBody = struct {
     body: Mono.FnBody,
 };
 
-const CaptureIdentity = struct {
-    const Origin = union(enum) {
-        binder: checked.PatternBinderId,
-        generated: u32,
-        local: Ast.LocalId,
-    };
-
-    origin: Origin,
-    ty: MonoType.TypeId,
-};
-
-const CaptureOperand = struct {
-    identity: CaptureIdentity,
-    value: Ast.ExprId,
-};
-
-const CaptureOperandSpan = Ast.Span(CaptureOperand);
-
 const Lifter = struct {
     allocator: Allocator,
     source: Mono.ProgramView,
@@ -242,8 +225,6 @@ const Lifter = struct {
     fn_bodies: std.ArrayList(?MonoFnBody),
     nested_fn_ids: std.AutoHashMap(Ast.FnId, void),
     initialized_fns: std.AutoHashMap(Ast.FnId, void),
-    capture_operands: std.ArrayList(CaptureOperand),
-    capture_operands_by_expr: std.AutoHashMap(Ast.ExprId, CaptureOperandSpan),
     symbols: Common.SymbolGen,
     /// Solved capture set per lifted function, indexed by `Ast.FnId`. Computed
     /// as a least fixed point over the function-reference graph before any body
@@ -273,8 +254,6 @@ const Lifter = struct {
             .fn_bodies = .empty,
             .nested_fn_ids = std.AutoHashMap(Ast.FnId, void).init(allocator),
             .initialized_fns = std.AutoHashMap(Ast.FnId, void).init(allocator),
-            .capture_operands = .empty,
-            .capture_operands_by_expr = std.AutoHashMap(Ast.ExprId, CaptureOperandSpan).init(allocator),
             .symbols = .{ .next = source.next_symbol },
             .fn_captures = &.{},
         };
@@ -283,8 +262,6 @@ const Lifter = struct {
     fn deinit(self: *Lifter) void {
         for (self.fn_captures) |*captures| captures.deinit(self.allocator);
         if (self.fn_captures.len > 0) self.allocator.free(self.fn_captures);
-        self.capture_operands_by_expr.deinit();
-        self.capture_operands.deinit(self.allocator);
         self.initialized_fns.deinit();
         self.nested_fn_ids.deinit();
         self.fn_bodies.deinit(self.allocator);
@@ -368,30 +345,28 @@ const Lifter = struct {
     }
 
     fn completeFunctionReferenceCaptures(self: *Lifter) Allocator.Error!void {
-        const expr_count = self.expr_done.len;
-        for (0..expr_count) |index| {
-            if (!self.expr_done[index]) continue;
-
+        for (self.expr_done, 0..) |done, index| {
+            if (!done) continue;
             const expr_id: Ast.ExprId = @enumFromInt(@as(u32, @intCast(index)));
             switch (self.output.exprs.items[index].data) {
                 .fn_ref => |fn_ref| {
-                    const captures = self.output.typedLocalSpan(self.output.fns.items[@intFromEnum(fn_ref.fn_id)].captures);
-                    if (captures.len == 0 and fn_ref.captures.len == 0) continue;
-                    const operands = self.captureOperandsForExpr(expr_id, fn_ref.captures);
+                    const slots = self.output.typedLocalSpan(self.output.fns.items[@intFromEnum(fn_ref.fn_id)].captures);
+                    if (slots.len == 0 and fn_ref.captures.len == 0) continue;
+                    const captures = try rebuildCaptureOperandSpan(self.output, fn_ref.captures, slots, expr_id);
                     self.output.exprs.items[index].data = .{ .fn_ref = .{
                         .fn_id = fn_ref.fn_id,
-                        .captures = try finalizeCaptureExprSpanFromOperands(self.allocator, self.output, operands, captures),
+                        .captures = captures,
                     } };
                 },
                 .call_proc => |call| {
                     const fn_id = Ast.localDirectCallee(call) orelse continue;
-                    const captures = self.output.typedLocalSpan(self.output.fns.items[@intFromEnum(fn_id)].captures);
-                    if (captures.len == 0 and call.captures.len == 0) continue;
-                    const operands = self.captureOperandsForExpr(expr_id, call.captures);
+                    const slots = self.output.typedLocalSpan(self.output.fns.items[@intFromEnum(fn_id)].captures);
+                    if (slots.len == 0 and call.captures.len == 0) continue;
+                    const captures = try rebuildCaptureOperandSpan(self.output, call.captures, slots, expr_id);
                     self.output.exprs.items[index].data = .{ .call_proc = .{
                         .callee = call.callee,
                         .args = call.args,
-                        .captures = try finalizeCaptureExprSpanFromOperands(self.allocator, self.output, operands, captures),
+                        .captures = captures,
                         .is_cold = call.is_cold,
                     } };
                 },
@@ -473,7 +448,7 @@ const Lifter = struct {
             .crash,
             .comptime_exhaustiveness_failed,
             => {},
-            .fn_ref => |fn_ref| for (self.output.exprSpan(fn_ref.captures)) |capture| try self.rewriteExpr(capture),
+            .fn_ref => |fn_ref| for (self.output.captureOperandSpan(fn_ref.captures)) |operand| try self.rewriteExpr(operand.value),
             .list,
             .tuple,
             => |items| for (self.output.exprSpan(items)) |child| try self.rewriteExpr(child),
@@ -517,7 +492,7 @@ const Lifter = struct {
             },
             .call_proc => |call| {
                 for (self.output.exprSpan(call.args)) |arg| try self.rewriteExpr(arg);
-                for (self.output.exprSpan(call.captures)) |capture| try self.rewriteExpr(capture);
+                for (self.output.captureOperandSpan(call.captures)) |operand| try self.rewriteExpr(operand.value);
                 const RewrittenProcCall = struct {
                     callee: Mono.ProcCallee,
                     captures: Ast.Span(Ast.ExprId),
@@ -629,8 +604,9 @@ const Lifter = struct {
         defer bound.deinit();
         try bindTypedLocals(self.output, &bound, self.output.typedLocalSpan(lambda.args));
         try captures.collectExpr(lambda.body, &bound);
+        sortCaptureSlots(self.output, captures.items.items);
 
-        const capture_exprs = try self.captureExprSpanFromTypedLocals(captures.items.items, expr_id);
+        const capture_exprs = try self.captureOperandSpanForSlots(captures.items.items, &.{}, expr_id);
         self.output.exprs.items[@intFromEnum(expr_id)].data = .{ .fn_ref = .{
             .fn_id = fn_id,
             .captures = capture_exprs,
@@ -714,6 +690,7 @@ const Lifter = struct {
             .roc => |expr| try scratch.collectExpr(expr, bound),
             .hosted => {},
         }
+        sortCaptureSlots(self.output, scratch.items.items);
     }
 
     fn registerFn(self: *Lifter, mono_fn_id: Mono.FnId, fn_id: Ast.FnId) void {
@@ -733,12 +710,23 @@ const Lifter = struct {
             Common.invariant("Monotype expression referenced a function specialization before lifting registered it");
     }
 
-    fn captureExprSpanForFn(self: *Lifter, fn_id: Ast.FnId, call_expr: Mono.ExprId) Allocator.Error!Ast.Span(Ast.ExprId) {
-        return try self.captureExprSpanFromTypedLocals(self.fn_captures[@intFromEnum(fn_id)].items, call_expr);
+    fn captureExprSpanForFn(self: *Lifter, fn_id: Ast.FnId, call_expr: Mono.ExprId) Allocator.Error!Ast.Span(Ast.CaptureOperand) {
+        return try self.captureOperandSpanForSlots(self.fn_captures[@intFromEnum(fn_id)].items, &.{}, call_expr);
     }
 
-    fn captureExprSpanFromTypedLocals(self: *Lifter, captures: []const Ast.TypedLocal, call_expr: Mono.ExprId) Allocator.Error!Ast.Span(Ast.ExprId) {
-        if (captures.len == 0) return .empty();
+    /// Build the keyed capture operand span for a function reference. `slots`
+    /// are the target function's canonically-sorted capture slots; the result
+    /// is one operand per slot, in the same sorted order, so the join is an
+    /// exact keyed walk. An operand's value comes from a matching explicit
+    /// pre-lift capture operand (`explicit`, keyed by CaptureId) when present,
+    /// otherwise an implicit read of the slot's local in the reference context.
+    fn captureOperandSpanForSlots(
+        self: *Lifter,
+        slots: []const Ast.TypedLocal,
+        explicit: []const Ast.FnDefCapture,
+        call_expr: Mono.ExprId,
+    ) Allocator.Error!Ast.Span(Ast.CaptureOperand) {
+        if (slots.len == 0) return .empty();
 
         const saved_loc = self.output.current_loc;
         defer self.output.current_loc = saved_loc;
@@ -749,20 +737,15 @@ const Lifter = struct {
         const call_region = self.output.exprRegion(call_expr);
         if (!call_region.isEmpty()) self.output.current_region = call_region;
 
-        const exprs = try self.allocator.alloc(Ast.ExprId, captures.len);
-        defer self.allocator.free(exprs);
-        const operands = try self.allocator.alloc(CaptureOperand, captures.len);
+        const operands = try self.allocator.alloc(Ast.CaptureOperand, slots.len);
         defer self.allocator.free(operands);
-        for (captures, 0..) |capture, index| {
-            exprs[index] = try self.output.addExpr(.{
-                .ty = capture.ty,
-                .data = .{ .local = capture.local },
-            });
-            operands[index] = .{ .identity = try captureIdentityForTypedLocal(self.output, capture), .value = exprs[index] };
+        for (slots, 0..) |slot, index| {
+            const id = slotCaptureId(self.output, slot);
+            const value = explicitCaptureValueForId(self.output, explicit, id) orelse
+                try self.output.addExpr(.{ .ty = slot.ty, .data = .{ .local = slot.local } });
+            operands[index] = .{ .id = id, .value = value };
         }
-        const expr_span = try self.output.addExprSpan(exprs);
-        try self.recordCaptureOperands(call_expr, operands);
-        return expr_span;
+        return try self.output.addCaptureOperandSpan(operands);
     }
 
     fn fnRefCaptureExprSpanForFnDef(
@@ -770,83 +753,9 @@ const Lifter = struct {
         fn_id: Ast.FnId,
         explicit_span: Ast.Span(Ast.FnDefCapture),
         call_expr: Mono.ExprId,
-    ) Allocator.Error!Ast.Span(Ast.ExprId) {
-        if (explicit_span.len == 0) return try self.captureExprSpanForFn(fn_id, call_expr);
-
-        const captures = self.fn_captures[@intFromEnum(fn_id)].items;
-        if (captures.len == 0) return .empty();
-
-        const saved_loc = self.output.current_loc;
-        defer self.output.current_loc = saved_loc;
-        const saved_region = self.output.current_region;
-        defer self.output.current_region = saved_region;
-        const call_loc = self.output.exprLoc(call_expr);
-        if (call_loc.hasLocation()) self.output.current_loc = call_loc;
-        const call_region = self.output.exprRegion(call_expr);
-        if (!call_region.isEmpty()) self.output.current_region = call_region;
-
+    ) Allocator.Error!Ast.Span(Ast.CaptureOperand) {
         const explicit = self.output.fnDefCaptureSpan(explicit_span);
-        const exprs = try self.allocator.alloc(Ast.ExprId, captures.len);
-        defer self.allocator.free(exprs);
-        const operands = try self.allocator.alloc(CaptureOperand, captures.len);
-        defer self.allocator.free(operands);
-        for (captures, 0..) |capture, index| {
-            if (try explicitFnDefCaptureValue(self.output, explicit, capture)) |value| {
-                exprs[index] = value;
-            } else {
-                exprs[index] = try self.output.addExpr(.{
-                    .ty = capture.ty,
-                    .data = .{ .local = capture.local },
-                });
-            }
-            operands[index] = .{ .identity = try captureIdentityForTypedLocal(self.output, capture), .value = exprs[index] };
-        }
-        const expr_span = try self.output.addExprSpan(exprs);
-        try self.recordCaptureOperands(call_expr, operands);
-        return expr_span;
-    }
-
-    fn recordCaptureOperands(
-        self: *Lifter,
-        expr_id: Ast.ExprId,
-        operands: []const CaptureOperand,
-    ) Allocator.Error!void {
-        if (operands.len == 0) return;
-        if (self.capture_operands_by_expr.contains(expr_id)) {
-            Common.invariant("lifted function reference capture operands were recorded twice");
-        }
-        const start: u32 = @intCast(self.capture_operands.items.len);
-        try self.capture_operands.appendSlice(self.allocator, operands);
-        try self.capture_operands_by_expr.put(expr_id, .{
-            .start = start,
-            .len = @intCast(operands.len),
-        });
-    }
-
-    fn captureOperandSpan(self: *const Lifter, span: CaptureOperandSpan) []const CaptureOperand {
-        return self.capture_operands.items[span.start..][0..span.len];
-    }
-
-    fn captureOperandsForExpr(
-        self: *const Lifter,
-        expr_id: Ast.ExprId,
-        expr_span: Ast.Span(Ast.ExprId),
-    ) []const CaptureOperand {
-        const span = self.capture_operands_by_expr.get(expr_id) orelse
-            Common.invariant("lifted function reference had captures without keyed operands");
-        const operands = self.captureOperandSpan(span);
-        const exprs = self.output.exprSpan(expr_span);
-        if (exprs.len != 0) {
-            if (span.len != exprs.len) {
-                Common.invariant("lifted function reference capture identity operands disagreed with expression operands");
-            }
-            for (operands, exprs) |operand, expr| {
-                if (operand.value != expr) {
-                    Common.invariant("lifted function reference capture identity operands diverged from expression operands");
-                }
-            }
-        }
-        return operands;
+        return try self.captureOperandSpanForSlots(self.fn_captures[@intFromEnum(fn_id)].items, explicit, call_expr);
     }
 
     fn defSource(self: *Lifter, mono_fn_id: Mono.FnId, expected: ?Mono.FnTemplate) ?Mono.FnTemplate {
@@ -879,28 +788,98 @@ fn deinitCaptureTable(allocator: Allocator, captures: []std.ArrayList(Ast.TypedL
     if (captures.len > 0) allocator.free(captures);
 }
 
+/// Find the existing operand value that supplies capture `id`.
+///
+/// For a plain local read whose value-local carries a CaptureId, that CaptureId
+/// is authoritative — not the operand's stored id: spec_constr substitution can
+/// replace an operand's value with a local of a different capture while leaving
+/// the stored id stale, so the value's current identity wins.
+///
+/// When the value-local carries no CaptureId (e.g. a spec_constr-minted arg or
+/// temp local produced by argument splitting/inlining), no value identity is
+/// available, so the operand's stored id — set when the operand was built for a
+/// specific slot — is the only identity and is honored as a fallback. Genuinely
+/// explicit (non-local) values likewise fall back to their stored id. A
+/// value-id match always takes precedence over a stored-id fallback.
+fn operandValueForSlotId(program: *const Ast.Program, existing: []const Ast.CaptureOperand, id: checked.CaptureId) ?Ast.ExprId {
+    var fallback_by_id: ?Ast.ExprId = null;
+    for (existing) |operand| {
+        switch (program.exprs.items[@intFromEnum(operand.value)].data) {
+            .local => |local| {
+                if (program.locals.items[@intFromEnum(local)].capture_id) |value_id| {
+                    if (value_id == id) return operand.value;
+                } else if (operand.id == id and fallback_by_id == null) {
+                    fallback_by_id = operand.value;
+                }
+            },
+            else => if (operand.id == id and fallback_by_id == null) {
+                fallback_by_id = operand.value;
+            },
+        }
+    }
+    return fallback_by_id;
+}
+
+/// Rebuild a function reference / direct call's keyed capture operand span so it
+/// matches `slots` (the target's canonically-sorted capture slots) exactly, in
+/// the same order. Each operand's value is preserved from the node's existing
+/// operands (keyed by CaptureId) when present — this keeps explicit non-local
+/// values supplied at checked closure creation and const-fn restore — otherwise
+/// it is an implicit read of the slot's local at the reference site.
+fn rebuildCaptureOperandSpan(
+    program: *Ast.Program,
+    existing_span: Ast.Span(Ast.CaptureOperand),
+    slots: []const Ast.TypedLocal,
+    call_expr: Ast.ExprId,
+) Allocator.Error!Ast.Span(Ast.CaptureOperand) {
+    if (slots.len == 0) return .empty();
+
+    const existing = program.captureOperandSpan(existing_span);
+
+    const saved_loc = program.current_loc;
+    defer program.current_loc = saved_loc;
+    const saved_region = program.current_region;
+    defer program.current_region = saved_region;
+    const call_loc = program.exprLoc(call_expr);
+    if (call_loc.hasLocation()) program.current_loc = call_loc;
+    const call_region = program.exprRegion(call_expr);
+    if (!call_region.isEmpty()) program.current_region = call_region;
+
+    const operands = try program.allocator.alloc(Ast.CaptureOperand, slots.len);
+    defer program.allocator.free(operands);
+    for (slots, 0..) |slot, index| {
+        const id = slotCaptureId(program, slot);
+        const value = operandValueForSlotId(program, existing, id) orelse
+            try program.addExpr(.{ .ty = slot.ty, .data = .{ .local = slot.local } });
+        operands[index] = .{ .id = id, .value = value };
+    }
+    return try program.addCaptureOperandSpan(operands);
+}
+
+/// Rebuild every function reference / direct call's capture operand span to
+/// match the recomputed capture slots in `fn_captures`. Used after a Lifted-IR
+/// mutation (spec_constr, inlining) reshapes capture sets.
 fn finalizeProgramFunctionReferenceCaptures(
-    allocator: Allocator,
     program: *Ast.Program,
     fn_captures: []std.ArrayList(Ast.TypedLocal),
 ) Allocator.Error!void {
     const expr_count = program.exprs.items.len;
     for (0..expr_count) |index| {
+        const expr_id: Ast.ExprId = @enumFromInt(@as(u32, @intCast(index)));
         switch (program.exprs.items[index].data) {
             .fn_ref => |fn_ref| {
                 const fn_index = @intFromEnum(fn_ref.fn_id);
                 if (fn_index >= fn_captures.len) Common.invariant("function reference target missing recomputed captures");
 
-                const old_captures = program.typedLocalSpan(program.fns.items[fn_index].captures);
+                // Always rebuild: even when the target's capture set is
+                // unchanged, a caller-side operand value can have been rewritten
+                // by spec_constr, so the operand span must be re-derived from the
+                // current values, keyed to the target's recomputed slots.
                 const new_captures = fn_captures[fn_index].items;
-                const capture_exprs = program.exprSpan(fn_ref.captures);
-                if (captureListEql(old_captures, new_captures) and capture_exprs.len == new_captures.len) continue;
-
-                const operands = try captureOperandsFromPositionals(allocator, program, old_captures, capture_exprs);
-                defer allocator.free(operands);
+                const captures = try rebuildCaptureOperandSpan(program, fn_ref.captures, new_captures, expr_id);
                 program.exprs.items[index].data = .{ .fn_ref = .{
                     .fn_id = fn_ref.fn_id,
-                    .captures = try finalizeCaptureExprSpanFromOperands(allocator, program, operands, new_captures),
+                    .captures = captures,
                 } };
             },
             .call_proc => |call| {
@@ -911,134 +890,18 @@ fn finalizeProgramFunctionReferenceCaptures(
                 const fn_index = @intFromEnum(fn_id);
                 if (fn_index >= fn_captures.len) Common.invariant("direct call target missing recomputed captures");
 
-                const old_captures = program.typedLocalSpan(program.fns.items[fn_index].captures);
                 const new_captures = fn_captures[fn_index].items;
-                const capture_exprs = program.exprSpan(call.captures);
-                if (captureListEql(old_captures, new_captures) and capture_exprs.len == new_captures.len) continue;
-
-                const operands = try captureOperandsFromPositionals(allocator, program, old_captures, capture_exprs);
-                defer allocator.free(operands);
+                const captures = try rebuildCaptureOperandSpan(program, call.captures, new_captures, expr_id);
                 program.exprs.items[index].data = .{ .call_proc = .{
                     .callee = call.callee,
                     .args = call.args,
-                    .captures = try finalizeCaptureExprSpanFromOperands(allocator, program, operands, new_captures),
+                    .captures = captures,
                     .is_cold = call.is_cold,
                 } };
             },
             else => {},
         }
     }
-}
-
-fn captureOperandsFromPositionals(
-    allocator: Allocator,
-    program: *const Ast.Program,
-    captures: []const Ast.TypedLocal,
-    exprs: []const Ast.ExprId,
-) Allocator.Error![]CaptureOperand {
-    if (captures.len != exprs.len) {
-        Common.invariant("function reference capture operand count disagreed with its previous capture slots");
-    }
-
-    const operands = try allocator.alloc(CaptureOperand, captures.len);
-    errdefer allocator.free(operands);
-    for (captures, exprs, 0..) |capture, expr, index| {
-        operands[index] = .{ .identity = try captureIdentityForTypedLocal(program, capture), .value = expr };
-    }
-    return operands;
-}
-
-fn finalizeCaptureExprSpanFromOperands(
-    allocator: Allocator,
-    program: *Ast.Program,
-    operands: []const CaptureOperand,
-    captures: []const Ast.TypedLocal,
-) Allocator.Error!Ast.Span(Ast.ExprId) {
-    if (captures.len == 0) return .empty();
-
-    try assertUniqueOperandIdentities(program, operands);
-    try assertUniqueCaptureIdentities(program, captures);
-
-    const exprs = try allocator.alloc(Ast.ExprId, captures.len);
-    defer allocator.free(exprs);
-
-    for (captures, 0..) |capture, capture_index| {
-        const identity = try captureIdentityForTypedLocal(program, capture);
-        const operand = (try findCaptureOperand(program, operands, identity)) orelse
-            Common.invariant("function reference missing operand for finalized capture slot");
-        const operand_ty = program.exprs.items[@intFromEnum(operand.value)].ty;
-        if (!try monotypeTypeEql(program, operand_ty, capture.ty)) {
-            Common.invariant("function reference capture operand type differed from finalized capture slot");
-        }
-        exprs[capture_index] = operand.value;
-    }
-
-    return try program.addExprSpan(exprs);
-}
-
-fn assertUniqueOperandIdentities(program: *const Ast.Program, operands: []const CaptureOperand) Allocator.Error!void {
-    for (operands, 0..) |operand, index| {
-        for (operands[index + 1 ..]) |other| {
-            if (try captureIdentityEql(program, operand.identity, other.identity)) {
-                Common.invariant("function reference carried duplicate keyed capture operands");
-            }
-        }
-    }
-}
-
-fn assertUniqueCaptureIdentities(program: *const Ast.Program, captures: []const Ast.TypedLocal) Allocator.Error!void {
-    for (captures, 0..) |capture, index| {
-        const identity = try captureIdentityForTypedLocal(program, capture);
-        for (captures[index + 1 ..]) |other| {
-            if (try captureIdentityEql(program, identity, try captureIdentityForTypedLocal(program, other))) {
-                Common.invariant("lifted function declared duplicate capture identities");
-            }
-        }
-    }
-}
-
-fn findCaptureOperand(program: *const Ast.Program, operands: []const CaptureOperand, identity: CaptureIdentity) Allocator.Error!?CaptureOperand {
-    for (operands) |operand| {
-        if (try captureIdentityEql(program, operand.identity, identity)) return operand;
-    }
-    return null;
-}
-
-fn captureIdentityForTypedLocal(program: *const Ast.Program, capture: Ast.TypedLocal) Allocator.Error!CaptureIdentity {
-    const local_data = program.locals.items[@intFromEnum(capture.local)];
-    if (!try monotypeTypeEql(program, local_data.ty, capture.ty)) {
-        Common.invariant("typed capture local disagreed with its local type");
-    }
-    const origin: CaptureIdentity.Origin = if (local_data.binder) |binder|
-        .{ .binder = binder }
-    else if (local_data.capture_id) |capture_id|
-        .{ .generated = capture_id.generatedIndex() }
-    else
-        .{ .local = capture.local };
-    return .{ .origin = origin, .ty = capture.ty };
-}
-
-fn monotypeTypeEql(program: *const Ast.Program, lhs: MonoType.TypeId, rhs: MonoType.TypeId) Allocator.Error!bool {
-    if (lhs == rhs) return true;
-    return try program.types.typeEql(&program.names, lhs, rhs);
-}
-
-fn captureIdentityEql(program: *const Ast.Program, left: CaptureIdentity, right: CaptureIdentity) Allocator.Error!bool {
-    if (!try monotypeTypeEql(program, left.ty, right.ty)) return false;
-    return switch (left.origin) {
-        .binder => |left_binder| switch (right.origin) {
-            .binder => |right_binder| left_binder == right_binder,
-            else => false,
-        },
-        .generated => |left_capture| switch (right.origin) {
-            .generated => |right_capture| left_capture == right_capture,
-            else => false,
-        },
-        .local => |left_local| switch (right.origin) {
-            .local => |right_local| left_local == right_local,
-            else => false,
-        },
-    };
 }
 
 fn solveCaptureFixpoint(
@@ -1063,6 +926,7 @@ fn solveCaptureFixpoint(
                 .roc => |expr| try scratch.collectExpr(expr, &bound),
                 .hosted => {},
             }
+            sortCaptureSlots(program, scratch.items.items);
 
             if (!captureListEql(scratch.items.items, fn_captures[raw].items)) {
                 fn_captures[raw].clearRetainingCapacity();
@@ -1079,6 +943,49 @@ fn captureListEql(lhs: []const Ast.TypedLocal, rhs: []const Ast.TypedLocal) bool
         if (a.local != b.local or a.ty != b.ty) return false;
     }
     return true;
+}
+
+/// The canonical/generated CaptureId of a capture slot. Every capture slot's
+/// local carries a CaptureId (assigned at creation for binder-backed and
+/// compile-time locals, in `addIfFree` for lift-synthesized locals).
+fn slotCaptureId(program: *const Ast.Program, slot: Ast.TypedLocal) checked.CaptureId {
+    return program.locals.items[@intFromEnum(slot.local)].capture_id orelse
+        Common.invariant("lifted capture slot local had no CaptureId");
+}
+
+fn captureSlotLessThan(program: *const Ast.Program, lhs: Ast.TypedLocal, rhs: Ast.TypedLocal) bool {
+    return @intFromEnum(slotCaptureId(program, lhs)) < @intFromEnum(slotCaptureId(program, rhs));
+}
+
+/// Sort a capture set into canonical CaptureId order so operand↔slot joins are
+/// an exact keyed walk and slot order is never load-bearing. Also asserts (in
+/// debug) that no CaptureId appears twice.
+fn sortCaptureSlots(program: *const Ast.Program, items: []Ast.TypedLocal) void {
+    std.sort.pdq(Ast.TypedLocal, items, program, captureSlotLessThan);
+    if (@import("builtin").mode == .Debug) {
+        var index: usize = 1;
+        while (index < items.len) : (index += 1) {
+            if (slotCaptureId(program, items[index - 1]) == slotCaptureId(program, items[index])) {
+                Common.invariant("lifted capture set contained two slots with the same CaptureId");
+            }
+        }
+    }
+}
+
+/// Find the operand value supplied for `id` among explicit pre-lift capture
+/// operands, keyed by the CaptureId of each operand's local.
+fn explicitCaptureValueForId(program: *const Ast.Program, explicit: []const Ast.FnDefCapture, id: checked.CaptureId) ?Ast.ExprId {
+    for (explicit) |capture| {
+        const capture_id = program.locals.items[@intFromEnum(capture.local)].capture_id orelse
+            Common.invariant("pre-lift capture operand local had no CaptureId");
+        if (capture_id == id) return capture.value;
+    }
+    return null;
+}
+
+/// Whether an explicit pre-lift capture operand supplies the given CaptureId.
+fn explicitProvidesCaptureId(program: *const Ast.Program, explicit: []const Ast.FnDefCapture, id: checked.CaptureId) bool {
+    return explicitCaptureValueForId(program, explicit, id) != null;
 }
 
 const BoundSet = struct {
@@ -1137,31 +1044,6 @@ const BoundSet = struct {
     }
 };
 
-fn explicitFnDefCaptureValue(program: *const Ast.Program, captures: []const Ast.FnDefCapture, required: Ast.TypedLocal) Allocator.Error!?Ast.ExprId {
-    for (captures) |capture| {
-        if (try fnDefCaptureLocalMatches(program, required, capture.local)) {
-            return capture.value;
-        }
-    }
-    return null;
-}
-
-fn fnDefCaptureLocalMatches(program: *const Ast.Program, required: Ast.TypedLocal, explicit: Ast.LocalId) Allocator.Error!bool {
-    const required_local = program.locals.items[@intFromEnum(required.local)];
-    const explicit_local = program.locals.items[@intFromEnum(explicit)];
-
-    if (!try monotypeTypeEql(program, required.ty, required_local.ty)) {
-        Common.invariant("typed explicit capture local disagreed with its local type");
-    }
-    if (!try monotypeTypeEql(program, required.ty, explicit_local.ty)) return false;
-    if (required.local == explicit) return true;
-    if (required_local.symbol == explicit_local.symbol) return true;
-    if (required_local.binder != null and explicit_local.binder != null and required_local.binder.? == explicit_local.binder.?) return true;
-    if (required_local.capture_id != null and explicit_local.capture_id != null and required_local.capture_id.? == explicit_local.capture_id.?) return true;
-
-    return false;
-}
-
 const CaptureSet = struct {
     allocator: Allocator,
     lifter: ?*Lifter,
@@ -1209,8 +1091,15 @@ const CaptureSet = struct {
 
     fn addIfFree(self: *CaptureSet, local: Mono.LocalId, bound: *const BoundSet) Allocator.Error!void {
         if (bound.contains(local) or self.seen.contains(local)) return;
-        const local_data = self.program.locals.items[@intFromEnum(local)];
         try self.seen.put(local, {});
+        // Every capture slot needs a stable CaptureId. Binder-backed and
+        // compile-time-synthesized locals already carry one; a local that is
+        // free here without one is lift-synthesized (e.g. a spec_constr temp),
+        // so mint a generated identity that travels with the local.
+        if (self.program.locals.items[@intFromEnum(local)].capture_id == null) {
+            self.program.locals.items[@intFromEnum(local)].capture_id = self.program.nextLiftCaptureId();
+        }
+        const local_data = self.program.locals.items[@intFromEnum(local)];
         try self.items.append(self.allocator, .{
             .local = local,
             .ty = local_data.ty,
@@ -1234,7 +1123,7 @@ const CaptureSet = struct {
             .crash,
             .comptime_exhaustiveness_failed,
             => {},
-            .fn_ref => |fn_ref| for (input.exprSpan(fn_ref.captures)) |capture| try self.collectExpr(capture, bound),
+            .fn_ref => |fn_ref| for (input.captureOperandSpan(fn_ref.captures)) |operand| try self.collectExpr(operand.value, bound),
             .fn_def => |fn_def| {
                 const lifter = self.lifter orelse Common.invariant("post-lift capture recomputation saw a pre-lift function definition");
                 const explicit = input.fnDefCaptureSpan(fn_def.captures);
@@ -1288,7 +1177,7 @@ const CaptureSet = struct {
                     .lifted => |fn_id| try self.collectFnCaptures(fn_id, bound),
                 }
                 for (input.exprSpan(call.args)) |arg| try self.collectExpr(arg, bound);
-                for (input.exprSpan(call.captures)) |capture| try self.collectExpr(capture, bound);
+                for (input.captureOperandSpan(call.captures)) |operand| try self.collectExpr(operand.value, bound);
             },
             .low_level => |call| for (input.exprSpan(call.args)) |arg| try self.collectExpr(arg, bound),
             .field_access => |field| try self.collectExpr(field.receiver, bound),
@@ -1386,7 +1275,8 @@ const CaptureSet = struct {
         const raw = @intFromEnum(fn_id);
         if (raw >= self.fn_captures.len) Common.invariant("capture collection referenced a function without a solved capture set");
         for (self.fn_captures[raw].items) |capture| {
-            if (try explicitFnDefCaptureValue(self.program, explicit, capture) != null) continue;
+            const id = slotCaptureId(self.program, capture);
+            if (explicitProvidesCaptureId(self.program, explicit, id)) continue;
             try self.addIfFree(capture.local, caller_bound);
         }
     }

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -1502,6 +1502,72 @@ test "monotype lifting preserves imported direct call slots" {
     }
 }
 
+test "checkCaptureInvariants accepts a well-formed capture and catches a corrupted operand" {
+    const allocator = std.testing.allocator;
+    var program = Ast.Program.init(
+        allocator,
+        @import("check").CheckedNames.NameStore.init(allocator),
+        MonoType.Store.init(allocator),
+        .empty, // imported_fns
+        .empty, // exprs
+        .empty, // pats
+        .empty, // stmts
+        .empty, // locals
+        .empty, // expr_ids
+        .empty, // pat_ids
+        .empty, // typed_locals
+        .empty, // stmt_ids
+        .empty, // field_exprs
+        .empty, // fn_def_captures
+        .empty, // record_destructs
+        .empty, // str_pattern_steps
+        .empty, // branches
+        .empty, // if_branches
+        .empty, // string_literals
+        Ast.ProcDebugNameMap.init(allocator),
+        .empty, // source_files
+        .empty, // expr_locs
+        .empty, // expr_regions
+        .empty, // stmt_locs
+        .empty, // stmt_regions
+        .empty, // local_names
+        .empty, // comptime_sites
+        0, // next_symbol
+    );
+    defer program.deinit();
+
+    // One capturing function: a single binder-backed capture slot, and a
+    // function reference that supplies it with a keyed operand.
+    const ty = try program.types.add(.zst);
+    const binder: checked.PatternBinderId = @enumFromInt(0);
+    const cap_local = try program.addLocalWithBinder(@enumFromInt(0), ty, binder);
+    const cap_span = try program.addTypedLocalSpan(&.{.{ .local = cap_local, .ty = ty }});
+    try program.fns.append(allocator, .{
+        .symbol = @enumFromInt(0),
+        .args = Ast.Span(Ast.TypedLocal).empty(),
+        .captures = cap_span,
+        .body = .hosted,
+        .ret = ty,
+    });
+    const value = try program.addExpr(.{ .ty = ty, .data = .{ .local = cap_local } });
+    const op_span = try program.addCaptureOperandSpan(&.{.{ .id = checked.CaptureId.fromBinder(binder), .value = value }});
+    _ = try program.addExpr(.{ .ty = ty, .data = .{ .fn_ref = .{
+        .fn_id = @as(Ast.FnId, @enumFromInt(0)),
+        .captures = op_span,
+    } } });
+
+    // A well-formed capture representation reports no violation.
+    try std.testing.expectEqual(@as(?[]const u8, null), try checkCaptureInvariants(&program));
+
+    // Intentionally skip capture maintenance: give the operand a CaptureId that
+    // no longer matches its slot. The debug pass must catch it deterministically.
+    program.capture_operands.items[0].id = checked.CaptureId.fromBinder(@enumFromInt(1));
+    try std.testing.expectEqualStrings(
+        "operand CaptureId did not match its slot",
+        (try checkCaptureInvariants(&program)).?,
+    );
+}
+
 test "monotype lifted lower declarations are referenced" {
     std.testing.refAllDecls(@This());
 }

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -1012,7 +1012,7 @@ fn captureIdentityForTypedLocal(program: *const Ast.Program, capture: Ast.TypedL
     const origin: CaptureIdentity.Origin = if (local_data.binder) |binder|
         .{ .binder = binder }
     else if (local_data.capture_id) |capture_id|
-        .{ .generated = capture_id }
+        .{ .generated = capture_id.generatedIndex() }
     else
         .{ .local = capture.local };
     return .{ .origin = origin, .ty = capture.ty };

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -219,7 +219,7 @@ pub fn recomputeCaptures(allocator: Allocator, program: *Ast.Program) Allocator.
 ///   - every capture slot's local carries a CaptureId, and the slot's type
 ///     agrees with that local's type;
 ///   - a function's capture slots are sorted by CaptureId with no duplicates;
-///   - every canonical CaptureId names its local's live checked binder;
+///   - every binder-derived CaptureId names its local's live checked binder;
 ///   - an operand span carries exactly the target function's capture slots'
 ///     CaptureId sequence (same ids, same sorted order), and each operand's
 ///     value type equals its slot's type.
@@ -259,8 +259,8 @@ fn checkCaptureSlotSpan(program: *const Ast.Program, slots: []const Ast.TypedLoc
         const id = local.capture_id orelse return "capture slot local had no CaptureId";
         if (slot.ty != local.ty) return "capture slot type disagreed with its local type";
         if (id.isCanonical()) {
-            const binder = local.binder orelse return "canonical capture slot had no checked binder";
-            if (id != checked.CaptureId.fromBinder(binder)) return "canonical CaptureId did not match its binder";
+            const binder = local.binder orelse return "binder-derived capture slot had no checked binder";
+            if (id != checked.CaptureId.fromBinder(binder)) return "binder-derived CaptureId did not match its binder";
         }
         if (previous) |prev| {
             if (@intFromEnum(prev) > @intFromEnum(id)) return "capture slots not sorted by CaptureId";
@@ -882,9 +882,9 @@ fn deinitCaptureTable(allocator: Allocator, captures: []std.ArrayList(Ast.TypedL
 /// When the value-local carries no CaptureId (e.g. a spec_constr-minted arg or
 /// temp local produced by argument splitting/inlining), no value identity is
 /// available, so the operand's stored id — set when the operand was built for a
-/// specific slot — is the only identity and is honored as a fallback. Genuinely
+/// specific slot — is the only identity and is honored when present. Genuinely
 /// explicit (non-local) values likewise fall back to their stored id. A
-/// value-id match always takes precedence over a stored-id fallback.
+/// value-id match always takes precedence over the stored id.
 fn operandValueForSlotId(program: *const Ast.Program, existing: []const Ast.CaptureOperand, id: checked.CaptureId) ?Ast.ExprId {
     var fallback_by_id: ?Ast.ExprId = null;
     for (existing) |operand| {
@@ -904,7 +904,7 @@ fn operandValueForSlotId(program: *const Ast.Program, existing: []const Ast.Capt
     return fallback_by_id;
 }
 
-/// Rebuild a function reference / direct call's keyed capture operand span so it
+/// Recompute a function reference / direct call's keyed capture operand span so it
 /// matches `slots` (the target's canonically-sorted capture slots) exactly, in
 /// the same order. Each operand's value is preserved from the node's existing
 /// operands (keyed by CaptureId) when present — this keeps explicit non-local
@@ -940,7 +940,7 @@ fn rebuildCaptureOperandSpan(
     return try program.addCaptureOperandSpan(operands);
 }
 
-/// Rebuild every function reference / direct call's capture operand span to
+/// Recompute every function reference / direct call's capture operand span to
 /// match the recomputed capture slots in `fn_captures`. Used after a Lifted-IR
 /// mutation (spec_constr, inlining) reshapes capture sets.
 fn finalizeProgramFunctionReferenceCaptures(
@@ -955,7 +955,7 @@ fn finalizeProgramFunctionReferenceCaptures(
                 const fn_index = @intFromEnum(fn_ref.fn_id);
                 if (fn_index >= fn_captures.len) Common.invariant("function reference target missing recomputed captures");
 
-                // Always rebuild: even when the target's capture set is
+                // Always recompute: even when the target's capture set is
                 // unchanged, a caller-side operand value can have been rewritten
                 // by spec_constr, so the operand span must be re-derived from the
                 // current values, keyed to the target's recomputed slots.
@@ -1029,7 +1029,7 @@ fn captureListEql(lhs: []const Ast.TypedLocal, rhs: []const Ast.TypedLocal) bool
     return true;
 }
 
-/// The canonical/generated CaptureId of a capture slot. Every capture slot's
+/// The CaptureId of a capture slot. Every capture slot's
 /// local carries a CaptureId (assigned at creation for binder-backed and
 /// compile-time locals, in `addIfFree` for lift-synthesized locals).
 fn slotCaptureId(program: *const Ast.Program, slot: Ast.TypedLocal) checked.CaptureId {
@@ -1041,7 +1041,7 @@ fn captureSlotLessThan(program: *const Ast.Program, lhs: Ast.TypedLocal, rhs: As
     return @intFromEnum(slotCaptureId(program, lhs)) < @intFromEnum(slotCaptureId(program, rhs));
 }
 
-/// Sort a capture set into canonical CaptureId order so operand↔slot joins are
+/// Sort a capture set into ascending CaptureId order so operand↔slot joins are
 /// an exact keyed walk and slot order is never load-bearing. Also asserts (in
 /// debug) that no CaptureId appears twice.
 fn sortCaptureSlots(program: *const Ast.Program, items: []Ast.TypedLocal) void {
@@ -1539,11 +1539,12 @@ test "checkCaptureInvariants accepts a well-formed capture and catches a corrupt
     // One capturing function: a single binder-backed capture slot, and a
     // function reference that supplies it with a keyed operand.
     const ty = try program.types.add(.zst);
-    const binder: checked.PatternBinderId = @enumFromInt(0);
-    const cap_local = try program.addLocalWithBinder(@enumFromInt(0), ty, binder);
+    const binder: checked.PatternBinderId = @enumFromInt(1);
+    const cap_local = try program.addLocalWithBinder(@enumFromInt(1), ty, binder);
     const cap_span = try program.addTypedLocalSpan(&.{.{ .local = cap_local, .ty = ty }});
+    const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(program.fns.items.len)));
     try program.fns.append(allocator, .{
-        .symbol = @enumFromInt(0),
+        .symbol = @enumFromInt(1),
         .args = Ast.Span(Ast.TypedLocal).empty(),
         .captures = cap_span,
         .body = .hosted,
@@ -1552,7 +1553,7 @@ test "checkCaptureInvariants accepts a well-formed capture and catches a corrupt
     const value = try program.addExpr(.{ .ty = ty, .data = .{ .local = cap_local } });
     const op_span = try program.addCaptureOperandSpan(&.{.{ .id = checked.CaptureId.fromBinder(binder), .value = value }});
     _ = try program.addExpr(.{ .ty = ty, .data = .{ .fn_ref = .{
-        .fn_id = @as(Ast.FnId, @enumFromInt(0)),
+        .fn_id = fn_id,
         .captures = op_span,
     } } });
 
@@ -1561,7 +1562,7 @@ test "checkCaptureInvariants accepts a well-formed capture and catches a corrupt
 
     // Intentionally skip capture maintenance: give the operand a CaptureId that
     // no longer matches its slot. The debug pass must catch it deterministically.
-    program.capture_operands.items[0].id = checked.CaptureId.fromBinder(@enumFromInt(1));
+    program.capture_operands.items[0].id = checked.CaptureId.fromBinder(@enumFromInt(2));
     try std.testing.expectEqualStrings(
         "operand CaptureId did not match its slot",
         (try checkCaptureInvariants(&program)).?,

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -300,10 +300,19 @@ const NominalValue = struct {
     backing: *const Value,
 };
 
+/// A cloned capture operand carried on a callable value: its canonical
+/// CaptureId plus the cloned supplying value. Keeping the id lets materialization
+/// pair operands to the (possibly specialized) target's sorted capture slots by
+/// id rather than by position.
+const CaptureValue = struct {
+    id: check.CheckedModule.CaptureId,
+    value: Value,
+};
+
 const CallableValue = struct {
     ty: Type.TypeId,
     fn_id: Ast.FnId,
-    captures: []const Value,
+    captures: []const CaptureValue,
 };
 
 const CallPattern = struct {
@@ -503,7 +512,7 @@ const Pass = struct {
             .uninitialized_payload,
             => {},
             .fn_ref => |fn_ref| {
-                for (self.program.exprSpan(fn_ref.captures)) |capture| try self.markArgUsesInExpr(fn_id, capture, changed);
+                for (self.program.captureOperandSpan(fn_ref.captures)) |operand| try self.markArgUsesInExpr(fn_id, operand.value, changed);
             },
             .list,
             .tuple,
@@ -532,7 +541,7 @@ const Pass = struct {
             .call_proc => |call| {
                 const args = self.program.exprSpan(call.args);
                 for (args) |arg| try self.markArgUsesInExpr(fn_id, arg, changed);
-                for (self.program.exprSpan(call.captures)) |capture| try self.markArgUsesInExpr(fn_id, capture, changed);
+                for (self.program.captureOperandSpan(call.captures)) |operand| try self.markArgUsesInExpr(fn_id, operand.value, changed);
                 const callee = Ast.localDirectCallee(call) orelse return;
                 const callee_raw = @intFromEnum(callee);
                 if (callee_raw < self.plans.len) {
@@ -645,7 +654,7 @@ const Pass = struct {
             .uninitialized,
             .uninitialized_payload,
             => {},
-            .fn_ref => |fn_ref| try self.collectCallPatternsInExprSpan(owner, fn_ref.captures),
+            .fn_ref => |fn_ref| try self.collectCallPatternsInCaptureOperandSpan(owner, fn_ref.captures),
             .list,
             .tuple,
             => |items| try self.collectCallPatternsInExprSpan(owner, items),
@@ -672,7 +681,7 @@ const Pass = struct {
             },
             .call_proc => |call| {
                 try self.collectCallPatternsInExprSpan(owner, call.args);
-                try self.collectCallPatternsInExprSpan(owner, call.captures);
+                try self.collectCallPatternsInCaptureOperandSpan(owner, call.captures);
                 const callee = Ast.localDirectCallee(call) orelse return;
                 if (@intFromEnum(callee) < self.plans.len) try self.recordCallPattern(callee, call.args);
             },
@@ -727,6 +736,12 @@ const Pass = struct {
         const source = try self.allocator.dupe(Ast.ExprId, self.program.exprSpan(span));
         defer self.allocator.free(source);
         for (source) |expr| try self.collectCallPatternsInExpr(owner, expr);
+    }
+
+    fn collectCallPatternsInCaptureOperandSpan(self: *Pass, owner: Ast.FnId, span: Ast.Span(Ast.CaptureOperand)) Allocator.Error!void {
+        const source = try self.allocator.dupe(Ast.CaptureOperand, self.program.captureOperandSpan(span));
+        defer self.allocator.free(source);
+        for (source) |operand| try self.collectCallPatternsInExpr(owner, operand.value);
     }
 
     fn collectCallPatternsInFieldExprSpan(self: *Pass, owner: Ast.FnId, span: Ast.Span(Ast.FieldExpr)) Allocator.Error!void {
@@ -925,7 +940,7 @@ const Pass = struct {
             .uninitialized,
             .uninitialized_payload,
             => {},
-            .fn_ref => |fn_ref| try self.rewriteCallsInExprSpan(fn_ref.captures, done),
+            .fn_ref => |fn_ref| try self.rewriteCallsInCaptureOperandSpan(fn_ref.captures, done),
             .list,
             .tuple,
             => |items| try self.rewriteCallsInExprSpan(items, done),
@@ -952,7 +967,7 @@ const Pass = struct {
             },
             .call_proc => |call| {
                 try self.rewriteCallsInExprSpan(call.args, done);
-                try self.rewriteCallsInExprSpan(call.captures, done);
+                try self.rewriteCallsInCaptureOperandSpan(call.captures, done);
                 try self.rewriteCallProc(expr_id, call);
             },
             .low_level => |call| try self.rewriteCallsInExprSpan(call.args, done),
@@ -1004,6 +1019,12 @@ const Pass = struct {
         const source = try self.allocator.dupe(Ast.ExprId, self.program.exprSpan(span));
         defer self.allocator.free(source);
         for (source) |expr| try self.rewriteCallsInExpr(expr, done);
+    }
+
+    fn rewriteCallsInCaptureOperandSpan(self: *Pass, span: Ast.Span(Ast.CaptureOperand), done: []bool) Allocator.Error!void {
+        const source = try self.allocator.dupe(Ast.CaptureOperand, self.program.captureOperandSpan(span));
+        defer self.allocator.free(source);
+        for (source) |operand| try self.rewriteCallsInExpr(operand.value, done);
     }
 
     fn rewriteCallsInFieldExprSpan(self: *Pass, span: Ast.Span(Ast.FieldExpr), done: []bool) Allocator.Error!void {
@@ -1206,11 +1227,11 @@ const Pass = struct {
                 } };
             },
             .fn_ref => |fn_ref| blk: {
-                const capture_exprs = self.program.exprSpan(fn_ref.captures);
-                const capture_shapes = try self.arena.allocator().alloc(Shape, capture_exprs.len);
-                for (capture_exprs, 0..) |capture, index| {
-                    capture_shapes[index] = (try self.constructorShape(capture)) orelse
-                        .{ .any = self.program.exprs.items[@intFromEnum(capture)].ty };
+                const capture_operands = self.program.captureOperandSpan(fn_ref.captures);
+                const capture_shapes = try self.arena.allocator().alloc(Shape, capture_operands.len);
+                for (capture_operands, 0..) |operand, index| {
+                    capture_shapes[index] = (try self.constructorShape(operand.value)) orelse
+                        .{ .any = self.program.exprs.items[@intFromEnum(operand.value)].ty };
                 }
                 break :blk Shape{ .callable = .{
                     .ty = expr.ty,
@@ -1274,8 +1295,8 @@ const Pass = struct {
             .callable => |callable| blk: {
                 const captures = try self.arena.allocator().alloc(Shape, callable.captures.len);
                 for (callable.captures, 0..) |capture, index| {
-                    captures[index] = (try self.shapeFromValue(capture)) orelse
-                        .{ .any = valueType(self.program, capture) };
+                    captures[index] = (try self.shapeFromValue(capture.value)) orelse
+                        .{ .any = valueType(self.program, capture.value) };
                 }
                 break :blk Shape{ .callable = .{
                     .ty = callable.ty,
@@ -1429,9 +1450,19 @@ const Cloner = struct {
                 } };
             },
             .callable => |callable| {
-                const captures = try self.pass.arena.allocator().alloc(Value, callable.captures.len);
-                for (callable.captures, 0..) |capture, index| {
-                    captures[index] = try self.valueFromShapeArgs(capture, args);
+                // A callable shape's captures are parallel, in canonical
+                // CaptureId order, to its function's sorted capture slots, so we
+                // recover each capture's CaptureId from the matching slot.
+                const slots = self.pass.program.typedLocalSpan(self.pass.program.fns.items[@intFromEnum(callable.fn_id)].captures);
+                if (slots.len != callable.captures.len) {
+                    Common.invariant("callable shape capture count differed from its function capture slots");
+                }
+                const captures = try self.pass.arena.allocator().alloc(CaptureValue, callable.captures.len);
+                for (callable.captures, slots, 0..) |capture, slot, index| {
+                    captures[index] = .{
+                        .id = self.pass.program.captureIdOfLocal(slot.local),
+                        .value = try self.valueFromShapeArgs(capture, args),
+                    };
                 }
                 return .{ .callable = .{
                     .ty = callable.ty,
@@ -1640,7 +1671,7 @@ const Cloner = struct {
             .nominal => |nominal| self.valueCanSubstitute(nominal.backing.*),
             .callable => |callable| blk: {
                 for (callable.captures) |capture| {
-                    if (!self.valueCanSubstitute(capture)) break :blk false;
+                    if (!self.valueCanSubstitute(capture.value)) break :blk false;
                 }
                 break :blk true;
             },
@@ -1657,7 +1688,7 @@ const Cloner = struct {
             .dec_lit,
             .str_lit,
             => true,
-            .fn_ref => |fn_ref| self.exprSpanCanSubstitute(fn_ref.captures),
+            .fn_ref => |fn_ref| self.captureOperandSpanCanSubstitute(fn_ref.captures),
             .field_access => |field| self.exprCanSubstitute(field.receiver),
             .tuple_access => |access| self.exprCanSubstitute(access.tuple),
             else => false,
@@ -1671,11 +1702,18 @@ const Cloner = struct {
         return true;
     }
 
+    fn captureOperandSpanCanSubstitute(self: *Cloner, span: Ast.Span(Ast.CaptureOperand)) bool {
+        for (self.pass.program.captureOperandSpan(span)) |operand| {
+            if (!self.exprCanSubstitute(operand.value)) return false;
+        }
+        return true;
+    }
+
     fn callableValueFromRef(self: *Cloner, ty: Type.TypeId, fn_ref: @import("../monotype/ast.zig").LiftedFunctionValue) Common.LowerError!Value {
-        const source_exprs = self.pass.program.exprSpan(fn_ref.captures);
-        const captures = try self.pass.arena.allocator().alloc(Value, source_exprs.len);
-        for (source_exprs, 0..) |capture, index| {
-            captures[index] = try self.cloneExprValue(capture);
+        const source_operands = self.pass.program.captureOperandSpan(fn_ref.captures);
+        const captures = try self.pass.arena.allocator().alloc(CaptureValue, source_operands.len);
+        for (source_operands, 0..) |operand, index| {
+            captures[index] = .{ .id = operand.id, .value = try self.cloneExprValue(operand.value) };
         }
         return .{ .callable = .{
             .ty = ty,
@@ -1720,7 +1758,7 @@ const Cloner = struct {
             => Common.invariant("pre-lift function expression reached call-pattern specialization"),
             .fn_ref => |fn_ref| .{ .fn_ref = .{
                 .fn_id = fn_ref.fn_id,
-                .captures = try self.cloneExprSpan(fn_ref.captures),
+                .captures = try self.cloneCaptureOperandSpan(fn_ref.captures),
             } },
             .call_value => |call| .{ .call_value = .{
                 .callee = try self.cloneExpr(call.callee),
@@ -2045,7 +2083,7 @@ const Cloner = struct {
             return .{ .call_proc = .{
                 .callee = call.callee,
                 .args = try self.cloneExprSpan(call.args),
-                .captures = try self.cloneExprSpan(call.captures),
+                .captures = try self.cloneCaptureOperandSpan(call.captures),
                 .is_cold = true,
             } };
         }
@@ -2076,7 +2114,7 @@ const Cloner = struct {
                     return .{ .call_proc = .{
                         .callee = .{ .lifted = spec.fn_id orelse Common.invariant("call-pattern specialization id was not assigned before cloning calls") },
                         .args = try self.pass.program.addExprSpan(rewritten_args.items),
-                        .captures = try self.cloneExprSpan(call.captures),
+                        .captures = try self.cloneCaptureOperandSpan(call.captures),
                         .is_cold = call.is_cold,
                     } };
                 }
@@ -2085,7 +2123,7 @@ const Cloner = struct {
         return .{ .call_proc = .{
             .callee = call.callee,
             .args = try self.cloneExprSpan(call.args),
-            .captures = try self.cloneExprSpan(call.captures),
+            .captures = try self.cloneCaptureOperandSpan(call.captures),
             .is_cold = call.is_cold,
         } };
     }
@@ -2176,7 +2214,7 @@ const Cloner = struct {
                     else => Common.invariant("callable call pattern matched a non-callable value"),
                 };
                 for (callable.captures, callable_value.captures) |capture_shape, capture_value| {
-                    try self.appendExprsFromValue(capture_shape, capture_value, out);
+                    try self.appendExprsFromValue(capture_shape, capture_value.value, out);
                 }
             },
         }
@@ -2454,7 +2492,7 @@ const Cloner = struct {
             .nominal => |nominal| self.unsafeLeafCount(nominal.backing.*),
             .callable => |callable| blk: {
                 var count: usize = 0;
-                for (callable.captures) |capture| count += self.unsafeLeafCount(capture);
+                for (callable.captures) |capture| count += self.unsafeLeafCount(capture.value);
                 break :blk count;
             },
         };
@@ -2519,9 +2557,12 @@ const Cloner = struct {
                 } };
             },
             .callable => |callable| blk: {
-                const captures = try self.pass.arena.allocator().alloc(Value, callable.captures.len);
+                const captures = try self.pass.arena.allocator().alloc(CaptureValue, callable.captures.len);
                 for (callable.captures, 0..) |capture, index| {
-                    captures[index] = try self.makeReusableForMatch(capture, pending_lets);
+                    captures[index] = .{
+                        .id = capture.id,
+                        .value = try self.makeReusableForMatch(capture.value, pending_lets),
+                    };
                 }
                 break :blk Value{ .callable = .{
                     .ty = callable.ty,
@@ -2642,9 +2683,12 @@ const Cloner = struct {
         const change_start = self.changes.items.len;
         defer self.restore(change_start);
 
-        const prepared_captures = try self.pass.allocator.alloc(Value, callable.captures.len);
+        const prepared_captures = try self.pass.allocator.alloc(Value, source_captures.len);
         defer self.pass.allocator.free(prepared_captures);
-        for (source_captures, callable.captures, 0..) |source_capture, capture_value, index| {
+        for (source_captures, 0..) |source_capture, index| {
+            const id = self.pass.program.captureIdOfLocal(source_capture.local);
+            const capture_value = self.callableCaptureValueForId(callable.captures, id) orelse
+                Common.invariant("inlined callable had no value for a capture slot");
             prepared_captures[index] = try self.makeReusableForMatch(capture_value, &pending_lets);
             try self.putSubst(source_capture.local, prepared_captures[index]);
         }
@@ -2682,7 +2726,7 @@ const Cloner = struct {
         self: *Cloner,
         callee: Ast.FnId,
         args_span: Ast.Span(Ast.ExprId),
-        captures_span: Ast.Span(Ast.ExprId),
+        captures_span: Ast.Span(Ast.CaptureOperand),
         original_expr: Ast.ExprId,
     ) Common.LowerError!Value {
         for (self.inline_stack.items) |active| {
@@ -2711,16 +2755,19 @@ const Cloner = struct {
 
         const captures = try self.pass.allocator.dupe(Ast.TypedLocal, self.pass.program.typedLocalSpan(source_fn.captures));
         defer self.pass.allocator.free(captures);
-        const capture_exprs = try self.pass.allocator.dupe(Ast.ExprId, self.pass.program.exprSpan(captures_span));
-        defer self.pass.allocator.free(capture_exprs);
-        if (captures.len != capture_exprs.len) {
+        // The call's capture operands are keyed by CaptureId, not positional
+        // with the callee's capture slots. Clone each operand's value keyed by
+        // id, then resolve each slot's value by its own CaptureId below.
+        const operands = try self.pass.allocator.dupe(Ast.CaptureOperand, self.pass.program.captureOperandSpan(captures_span));
+        defer self.pass.allocator.free(operands);
+        if (captures.len != operands.len) {
             Common.invariant("direct call capture count differed from lifted function capture count");
         }
 
-        const capture_values = try self.pass.allocator.alloc(Value, capture_exprs.len);
+        const capture_values = try self.pass.allocator.alloc(CaptureValue, operands.len);
         defer self.pass.allocator.free(capture_values);
-        for (capture_exprs, 0..) |capture_expr, index| {
-            capture_values[index] = try self.cloneExprValue(capture_expr);
+        for (operands, 0..) |operand, index| {
+            capture_values[index] = .{ .id = operand.id, .value = try self.cloneExprValue(operand.value) };
         }
 
         const arg_values = try self.pass.allocator.alloc(Value, args.len);
@@ -2730,12 +2777,15 @@ const Cloner = struct {
         }
 
         var unsafe_count: usize = 0;
-        for (capture_values) |capture_value| unsafe_count += self.unsafeLeafCount(capture_value);
+        for (capture_values) |capture_value| unsafe_count += self.unsafeLeafCount(capture_value.value);
         for (arg_values) |arg_value| unsafe_count += self.unsafeLeafCount(arg_value);
 
-        const prepared_captures = try self.pass.allocator.alloc(Value, capture_values.len);
+        const prepared_captures = try self.pass.allocator.alloc(Value, captures.len);
         defer self.pass.allocator.free(prepared_captures);
-        for (captures, capture_values, 0..) |capture, capture_value, index| {
+        for (captures, 0..) |capture, index| {
+            const id = self.pass.program.captureIdOfLocal(capture.local);
+            const capture_value = self.callableCaptureValueForId(capture_values, id) orelse
+                Common.invariant("inlined direct call had no value for a capture slot");
             prepared_captures[index] = try self.valueForInlineLocal(capture.local, capture_value, body, unsafe_count, &pending_lets);
         }
 
@@ -2923,6 +2973,18 @@ const Cloner = struct {
         return try self.pass.program.addExprSpan(values);
     }
 
+    /// Clone a keyed capture operand span, preserving each operand's CaptureId
+    /// and cloning its supplying expression.
+    fn cloneCaptureOperandSpan(self: *Cloner, span: Ast.Span(Ast.CaptureOperand)) Common.LowerError!Ast.Span(Ast.CaptureOperand) {
+        const source = try self.pass.allocator.dupe(Ast.CaptureOperand, self.pass.program.captureOperandSpan(span));
+        defer self.pass.allocator.free(source);
+
+        const operands = try self.pass.allocator.alloc(Ast.CaptureOperand, source.len);
+        defer self.pass.allocator.free(operands);
+        for (source, 0..) |operand, index| operands[index] = .{ .id = operand.id, .value = try self.cloneExpr(operand.value) };
+        return try self.pass.program.addCaptureOperandSpan(operands);
+    }
+
     fn clonePatSpan(self: *Cloner, span: Ast.Span(Ast.PatId)) Allocator.Error!Ast.Span(Ast.PatId) {
         const source = try self.pass.allocator.dupe(Ast.PatId, self.pass.program.patSpan(span));
         defer self.pass.allocator.free(source);
@@ -3046,7 +3108,11 @@ const Cloner = struct {
         }
 
         var all_original = true;
-        for (captures, callable.captures) |capture, value| {
+        for (captures) |capture| {
+            const value = self.callableCaptureValueForId(callable.captures, self.pass.program.captureIdOfLocal(capture.local)) orelse {
+                all_original = false;
+                break;
+            };
             const expr = switch (value) {
                 .expr => |expr| expr,
                 else => {
@@ -3189,7 +3255,7 @@ const Cloner = struct {
         ty: Type.TypeId,
         fn_id: Ast.FnId,
         captures_span: Ast.Span(Ast.TypedLocal),
-        values: []const Value,
+        values: []const CaptureValue,
     ) Common.LowerError!Ast.ExprId {
         const captures = try self.pass.allocator.dupe(Ast.TypedLocal, self.pass.program.typedLocalSpan(captures_span));
         defer self.pass.allocator.free(captures);
@@ -3197,21 +3263,39 @@ const Cloner = struct {
             Common.invariant("callable value capture count differed from specialized function capture count");
         }
 
-        const value_exprs = try self.pass.allocator.alloc(Ast.ExprId, values.len);
-        defer self.pass.allocator.free(value_exprs);
-        for (captures, values, 0..) |capture, value, index| {
+        // Build one operand per capture slot, keyed by the slot's CaptureId. The
+        // supplying value is looked up by id (not position), so a specialized
+        // callee whose slots differ in order from the source still gets each
+        // capture's correct value.
+        const operands = try self.pass.allocator.alloc(Ast.CaptureOperand, captures.len);
+        defer self.pass.allocator.free(operands);
+        for (captures, 0..) |capture, index| {
+            const id = self.pass.program.captureIdOfLocal(capture.local);
+            const value = self.callableCaptureValueForId(values, id) orelse
+                Common.invariant("specialized callable had no value for a capture slot");
             const value_expr = try self.materialize(value);
             const value_local = localExpr(self.pass.program, value_expr);
-            value_exprs[index] = if (value_local != null and value_local.? == capture.local)
+            const operand_value = if (value_local != null and value_local.? == capture.local)
                 try self.addExpr(.{ .ty = capture.ty, .data = .{ .local = capture.local } })
             else
                 value_expr;
+            operands[index] = .{ .id = id, .value = operand_value };
         }
 
         return try self.addExpr(.{ .ty = ty, .data = .{ .fn_ref = .{
             .fn_id = fn_id,
-            .captures = try self.pass.program.addExprSpan(value_exprs),
+            .captures = try self.pass.program.addCaptureOperandSpan(operands),
         } } });
+    }
+
+    /// Look up the cloned value supplying capture `id` in a callable value's
+    /// keyed captures.
+    fn callableCaptureValueForId(self: *Cloner, values: []const CaptureValue, id: check.CheckedModule.CaptureId) ?Value {
+        _ = self;
+        for (values) |capture_value| {
+            if (capture_value.id == id) return capture_value.value;
+        }
+        return null;
     }
 
     fn copyValue(self: *Cloner, value: Value) Allocator.Error!*const Value {
@@ -3847,7 +3931,7 @@ fn shapeMatchesValue(program: *const Ast.Program, shape: Shape, value: Value) bo
                 break :blk false;
             }
             for (callable.captures, value_callable.captures) |capture_shape, capture_value| {
-                if (!shapeMatchesValue(program, capture_shape, capture_value)) break :blk false;
+                if (!shapeMatchesValue(program, capture_shape, capture_value.value)) break :blk false;
             }
             break :blk true;
         },

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -300,7 +300,7 @@ const NominalValue = struct {
     backing: *const Value,
 };
 
-/// A cloned capture operand carried on a callable value: its canonical
+/// A cloned capture operand carried on a callable value: its exact
 /// CaptureId plus the cloned supplying value. Keeping the id lets materialization
 /// pair operands to the (possibly specialized) target's sorted capture slots by
 /// id rather than by position.
@@ -1450,9 +1450,9 @@ const Cloner = struct {
                 } };
             },
             .callable => |callable| {
-                // A callable shape's captures are parallel, in canonical
+                // A callable shape's captures are parallel, in ascending
                 // CaptureId order, to its function's sorted capture slots, so we
-                // recover each capture's CaptureId from the matching slot.
+                // read each capture's CaptureId from the matching slot.
                 const slots = self.pass.program.typedLocalSpan(self.pass.program.fns.items[@intFromEnum(callable.fn_id)].captures);
                 if (slots.len != callable.captures.len) {
                     Common.invariant("callable shape capture count differed from its function capture slots");
@@ -1693,13 +1693,6 @@ const Cloner = struct {
             .tuple_access => |access| self.exprCanSubstitute(access.tuple),
             else => false,
         };
-    }
-
-    fn exprSpanCanSubstitute(self: *Cloner, span: Ast.Span(Ast.ExprId)) bool {
-        for (self.pass.program.exprSpan(span)) |expr| {
-            if (!self.exprCanSubstitute(expr)) return false;
-        }
-        return true;
     }
 
     fn captureOperandSpanCanSubstitute(self: *Cloner, span: Ast.Span(Ast.CaptureOperand)) bool {
@@ -2687,7 +2680,7 @@ const Cloner = struct {
         defer self.pass.allocator.free(prepared_captures);
         for (source_captures, 0..) |source_capture, index| {
             const id = self.pass.program.captureIdOfLocal(source_capture.local);
-            const capture_value = self.callableCaptureValueForId(callable.captures, id) orelse
+            const capture_value = callableCaptureValueForId(callable.captures, id) orelse
                 Common.invariant("inlined callable had no value for a capture slot");
             prepared_captures[index] = try self.makeReusableForMatch(capture_value, &pending_lets);
             try self.putSubst(source_capture.local, prepared_captures[index]);
@@ -2784,7 +2777,7 @@ const Cloner = struct {
         defer self.pass.allocator.free(prepared_captures);
         for (captures, 0..) |capture, index| {
             const id = self.pass.program.captureIdOfLocal(capture.local);
-            const capture_value = self.callableCaptureValueForId(capture_values, id) orelse
+            const capture_value = callableCaptureValueForId(capture_values, id) orelse
                 Common.invariant("inlined direct call had no value for a capture slot");
             prepared_captures[index] = try self.valueForInlineLocal(capture.local, capture_value, body, unsafe_count, &pending_lets);
         }
@@ -3109,7 +3102,7 @@ const Cloner = struct {
 
         var all_original = true;
         for (captures) |capture| {
-            const value = self.callableCaptureValueForId(callable.captures, self.pass.program.captureIdOfLocal(capture.local)) orelse {
+            const value = callableCaptureValueForId(callable.captures, self.pass.program.captureIdOfLocal(capture.local)) orelse {
                 all_original = false;
                 break;
             };
@@ -3271,7 +3264,7 @@ const Cloner = struct {
         defer self.pass.allocator.free(operands);
         for (captures, 0..) |capture, index| {
             const id = self.pass.program.captureIdOfLocal(capture.local);
-            const value = self.callableCaptureValueForId(values, id) orelse
+            const value = callableCaptureValueForId(values, id) orelse
                 Common.invariant("specialized callable had no value for a capture slot");
             const value_expr = try self.materialize(value);
             const value_local = localExpr(self.pass.program, value_expr);
@@ -3290,8 +3283,7 @@ const Cloner = struct {
 
     /// Look up the cloned value supplying capture `id` in a callable value's
     /// keyed captures.
-    fn callableCaptureValueForId(self: *Cloner, values: []const CaptureValue, id: check.CheckedModule.CaptureId) ?Value {
-        _ = self;
+    fn callableCaptureValueForId(values: []const CaptureValue, id: check.CheckedModule.CaptureId) ?Value {
         for (values) |capture_value| {
             if (capture_value.id == id) return capture_value.value;
         }

--- a/src/postcheck/solved_inline.zig
+++ b/src/postcheck/solved_inline.zig
@@ -211,7 +211,7 @@ const WrapperAnalyzer = struct {
             .str_lit,
             .def_ref,
             => true,
-            .fn_ref => |fn_ref| self.exprSpanReadsOnlyArgs(fn_ref.captures, args),
+            .fn_ref => |fn_ref| self.captureOperandSpanReadsOnlyArgs(fn_ref.captures, args),
             .list,
             .tuple,
             => |items| self.exprSpanReadsOnlyArgs(items, args),
@@ -232,7 +232,7 @@ const WrapperAnalyzer = struct {
             .call_value => |call| self.exprReadsOnlyArgs(call.callee, args) and self.exprSpanReadsOnlyArgs(call.args, args),
             .call_proc => |call| !call.is_cold and
                 self.exprSpanReadsOnlyArgs(call.args, args) and
-                self.exprSpanReadsOnlyArgs(call.captures, args),
+                self.captureOperandSpanReadsOnlyArgs(call.captures, args),
             .low_level => |call| self.exprSpanReadsOnlyArgs(call.args, args),
             .field_access => |field| self.exprReadsOnlyArgs(field.receiver, args),
             .tuple_access => |access| self.exprReadsOnlyArgs(access.tuple, args),
@@ -261,6 +261,13 @@ const WrapperAnalyzer = struct {
     fn exprSpanReadsOnlyArgs(self: *const WrapperAnalyzer, span: Lifted.Span(Lifted.ExprId), args: []const Lifted.TypedLocal) bool {
         for (self.solved.lifted.exprSpan(span)) |expr| {
             if (!self.exprReadsOnlyArgs(expr, args)) return false;
+        }
+        return true;
+    }
+
+    fn captureOperandSpanReadsOnlyArgs(self: *const WrapperAnalyzer, span: Lifted.Span(Lifted.CaptureOperand), args: []const Lifted.TypedLocal) bool {
+        for (self.solved.lifted.captureOperandSpan(span)) |operand| {
+            if (!self.exprReadsOnlyArgs(operand.value, args)) return false;
         }
         return true;
     }
@@ -298,7 +305,7 @@ const WrapperAnalyzer = struct {
             .str_lit,
             .def_ref,
             => {},
-            .fn_ref => |fn_ref| try self.visitSpanCallees(fn_ref.captures),
+            .fn_ref => |fn_ref| try self.visitCaptureOperandSpanCallees(fn_ref.captures),
             .list,
             .tuple,
             => |items| try self.visitSpanCallees(items),
@@ -324,7 +331,7 @@ const WrapperAnalyzer = struct {
                     _ = try self.inlineBody(callee);
                 }
                 try self.visitSpanCallees(call.args);
-                try self.visitSpanCallees(call.captures);
+                try self.visitCaptureOperandSpanCallees(call.captures);
             },
             .low_level => |call| try self.visitSpanCallees(call.args),
             .field_access => |field| try self.visitBodyCallees(field.receiver),
@@ -360,6 +367,12 @@ const WrapperAnalyzer = struct {
     fn visitSpanCallees(self: *WrapperAnalyzer, span: Lifted.Span(Lifted.ExprId)) std.mem.Allocator.Error!void {
         for (self.solved.lifted.exprSpan(span)) |child| {
             try self.visitBodyCallees(child);
+        }
+    }
+
+    fn visitCaptureOperandSpanCallees(self: *WrapperAnalyzer, span: Lifted.Span(Lifted.CaptureOperand)) std.mem.Allocator.Error!void {
+        for (self.solved.lifted.captureOperandSpan(span)) |operand| {
+            try self.visitBodyCallees(operand.value);
         }
     }
 

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -1711,7 +1711,7 @@ const Lowerer = struct {
                 .id = if (field.binder) |binder|
                     .{ .binder = binder }
                 else if (field.capture_id) |capture_id|
-                    .{ .generated = capture_id }
+                    .{ .generated = capture_id.generatedIndex() }
                 else
                     .{ .generated = @intFromEnum(field.symbol) },
                 .slot = @intCast(index),

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -1722,12 +1722,7 @@ const Lowerer = struct {
         errdefer self.allocator.free(slots);
         for (fields, 0..) |field, index| {
             slots[index] = .{
-                .id = if (field.binder) |binder|
-                    .{ .binder = binder }
-                else if (field.capture_id) |capture_id|
-                    .{ .generated = capture_id.generatedIndex() }
-                else
-                    .{ .generated = @intFromEnum(field.symbol) },
+                .id = field.capture_id orelse Common.invariant("capture record field had no CaptureId"),
                 .slot = @intCast(index),
                 .ty = try self.constTypeOfType(field.ty),
                 .plan = try self.constPlanOfType(field.ty),

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -788,7 +788,7 @@ const Lowerer = struct {
         if (captures.len != fields.len) Common.invariant("function capture argument arity differed from capture slots");
 
         for (captures, fields) |capture, field| {
-            if (capture.symbol != field.symbol or capture.binder != field.binder or capture.capture_id != field.capture_id) {
+            if (capture.capture_id != field.capture_id) {
                 Common.invariant("function capture argument fields differed from capture slots");
             }
             try self.captures.put(capture.local, .{
@@ -829,7 +829,7 @@ const Lowerer = struct {
         if (local_id == capture_local) return true;
 
         // A body reference and a capture slot name the same captured binding
-        // iff they carry the same CaptureId (the canonical join key that
+        // iff they carry the same CaptureId (the exact join key that
         // survives specialization/cloning). This is only used to search a
         // function's own capture set, where CaptureIds are unique.
         const local = self.solved.lifted.locals.items[@intFromEnum(local_id)];
@@ -2295,13 +2295,11 @@ const Lowerer = struct {
     fn lowerCaptureRecordFromCaptureExprsInto(
         self: *Lowerer,
         target: LIR.LocalId,
-        fn_id: Lifted.FnId,
         capture_span: SolvedType.Span,
         capture_operands: []const Lifted.CaptureOperand,
         capture_ty: Type.TypeId,
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
-        _ = fn_id;
         const captures = self.solved.types.captureSpan(capture_span);
         const fields = switch (self.types.get(capture_ty)) {
             .capture_record => |fields| self.types.captureFieldSpan(fields),
@@ -2319,9 +2317,9 @@ const Lowerer = struct {
 
         const target_is_zst = self.isZstLocal(target);
         // Member captures, capture-record fields, and keyed operands are all in
-        // canonical CaptureId order, so the join is an exact indexed walk.
+        // ascending CaptureId order, so the join is an exact indexed walk.
         for (captures, fields, capture_operands, 0..) |capture, field, operand, i| {
-            if (capture.symbol != field.symbol or capture.binder != field.binder or capture.capture_id != field.capture_id) {
+            if (capture.capture_id != field.capture_id) {
                 Common.invariant("callable capture payload fields differed from captured locals");
             }
             const capture_id = capture.capture_id orelse Common.invariant("member capture had no CaptureId");
@@ -3041,7 +3039,7 @@ const Lowerer = struct {
                     .payload = payload,
                     .next = next,
                 } });
-            return try self.lowerCaptureRecordFromCaptureExprsInto(payload, lifted_fn_id, captures, capture_operands, payload_ty, assign);
+            return try self.lowerCaptureRecordFromCaptureExprsInto(payload, captures, capture_operands, payload_ty, assign);
         }
         if (capture_operands.len != 0) Common.invariant("finite callable without capture payload carried capture operands");
         if (self.isZstLocal(target)) return try self.assignZst(target, next);
@@ -3085,7 +3083,7 @@ const Lowerer = struct {
             .on_drop = on_drop,
             .next = next,
         } });
-        if (capture_ty) |ty| return try self.lowerCaptureRecordFromCaptureExprsInto(capture.?, lifted_fn_id, captures, capture_operands, ty, assign);
+        if (capture_ty) |ty| return try self.lowerCaptureRecordFromCaptureExprsInto(capture.?, captures, capture_operands, ty, assign);
         if (capture_operands.len != 0) Common.invariant("erased callable without capture payload carried capture operands");
         return assign;
     }
@@ -3111,7 +3109,7 @@ const Lowerer = struct {
             Common.invariant("capturing direct call target had no capture record type");
         const capture_local = try self.addTemp(capture_ty);
         const call = try self.lowerKnownCallInto(target, result_ty, target_fn, args, capture_local, is_cold, next);
-        return try self.lowerCaptureRecordFromCaptureExprsInto(capture_local, callee, captures, capture_operands, capture_ty, call);
+        return try self.lowerCaptureRecordFromCaptureExprsInto(capture_local, captures, capture_operands, capture_ty, call);
     }
 
     fn lowerKnownCallInto(
@@ -6466,7 +6464,7 @@ const Lowerer = struct {
 
     fn captureFieldIndexInFields(fields: []const Type.CaptureField, needle: Type.CaptureField) usize {
         for (fields, 0..) |field, index| {
-            // CaptureId is the canonical identity of a capture-record field.
+            // CaptureId is the exact identity of a capture-record field.
             if (field.capture_id == needle.capture_id) return index;
         }
         Common.invariant("capture record boundary target field was absent from source");
@@ -6681,8 +6679,6 @@ const Lowerer = struct {
         const rhs = self.types.captureFieldSpan(rhs_span);
         if (lhs.len != rhs.len) return false;
         for (lhs, rhs) |lhs_field, rhs_field| {
-            if (lhs_field.symbol != rhs_field.symbol) return false;
-            if (!std.meta.eql(lhs_field.binder, rhs_field.binder)) return false;
             if (!std.meta.eql(lhs_field.capture_id, rhs_field.capture_id)) return false;
             if (!try self.publicTypesEquivalent(lhs_field.ty, rhs_field.ty, visited)) return false;
         }
@@ -7337,8 +7333,6 @@ const TypeEquivalence = struct {
         const rhs = self.materialized.captureFieldSpan(materialized);
         if (lhs.len != rhs.len) return false;
         for (lhs, rhs) |a, b| {
-            if (a.symbol != b.symbol) return false;
-            if (!std.meta.eql(a.binder, b.binder)) return false;
             if (!std.meta.eql(a.capture_id, b.capture_id)) return false;
             if (!try self.equivalent(a.ty, b.ty)) return false;
         }

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -825,15 +825,29 @@ const Lowerer = struct {
         return found;
     }
 
-    fn captureLocalMatchesLocal(self: *Lowerer, local_id: Lifted.LocalId, capture_id: Lifted.LocalId) bool {
-        if (local_id == capture_id) return true;
+    fn captureLocalMatchesLocal(self: *Lowerer, local_id: Lifted.LocalId, capture_local: Lifted.LocalId) bool {
+        if (local_id == capture_local) return true;
 
+        // A body reference and a capture slot name the same captured binding
+        // iff they carry the same CaptureId (the canonical join key that
+        // survives specialization/cloning). This is only used to search a
+        // function's own capture set, where CaptureIds are unique.
         const local = self.solved.lifted.locals.items[@intFromEnum(local_id)];
-        const capture = self.solved.lifted.locals.items[@intFromEnum(capture_id)];
-        if (local.symbol == capture.symbol) return true;
-        if (local.capture_id != null and capture.capture_id != null and local.capture_id.? == capture.capture_id.?) return true;
+        const capture = self.solved.lifted.locals.items[@intFromEnum(capture_local)];
+        return local.capture_id != null and capture.capture_id != null and local.capture_id.? == capture.capture_id.?;
+    }
 
-        return false;
+    /// Whether two lifted locals are aliases of the same lowered binding, used
+    /// to collapse locals that spec_constr cloning produced for one value. This
+    /// is a general local-identity remap, NOT a capture join: it must match by
+    /// the per-binding symbol, because CaptureId is deliberately coarser than a
+    /// symbol (a mutable variable's loop-carried instances all share one
+    /// captured-binder CaptureId yet are distinct lowered bindings).
+    fn aliasedLocalMatches(self: *Lowerer, local_id: Lifted.LocalId, other: Lifted.LocalId) bool {
+        if (local_id == other) return true;
+        const local = self.solved.lifted.locals.items[@intFromEnum(local_id)];
+        const alias = self.solved.lifted.locals.items[@intFromEnum(other)];
+        return local.symbol == alias.symbol;
     }
 
     fn lowerCaptureBindingInto(self: *Lowerer, target: LIR.LocalId, capture: CaptureBinding, next: LIR.CFStmtId) Common.LowerError!LIR.CFStmtId {
@@ -2001,7 +2015,7 @@ const Lowerer = struct {
             .def_ref,
             .fn_def,
             => Common.invariant("pre-lift function expression reached direct LIR lowering"),
-            .fn_ref => |fn_ref| try self.lowerFnRefInto(target, expr_id, fn_ref.fn_id, self.solved.lifted.exprSpan(fn_ref.captures), next),
+            .fn_ref => |fn_ref| try self.lowerFnRefInto(target, expr_id, fn_ref.fn_id, self.solved.lifted.captureOperandSpan(fn_ref.captures), next),
             .nominal => |backing| try self.lowerNominalInto(target, expr_ty, backing, next),
             .let_ => |let_| try self.lowerLetInto(target, let_, next),
             .call_proc => |call| switch (Lifted.directCallee(call)) {
@@ -2010,7 +2024,7 @@ const Lowerer = struct {
                     expr_ty,
                     callee,
                     self.solved.lifted.exprSpan(call.args),
-                    self.solved.lifted.exprSpan(call.captures),
+                    self.solved.lifted.captureOperandSpan(call.captures),
                     call.is_cold,
                     next,
                 ),
@@ -2091,7 +2105,7 @@ const Lowerer = struct {
                     ty,
                     callee,
                     self.solved.lifted.exprSpan(call.args),
-                    self.solved.lifted.exprSpan(call.captures),
+                    self.solved.lifted.captureOperandSpan(call.captures),
                     call.is_cold,
                     next,
                 ),
@@ -2101,7 +2115,7 @@ const Lowerer = struct {
                 target,
                 expr_id,
                 fn_ref.fn_id,
-                self.solved.lifted.exprSpan(fn_ref.captures),
+                self.solved.lifted.captureOperandSpan(fn_ref.captures),
                 ty,
                 next,
             ),
@@ -2288,17 +2302,18 @@ const Lowerer = struct {
         target: LIR.LocalId,
         fn_id: Lifted.FnId,
         capture_span: SolvedType.Span,
-        capture_exprs: []const Lifted.ExprId,
+        capture_operands: []const Lifted.CaptureOperand,
         capture_ty: Type.TypeId,
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
+        _ = fn_id;
         const captures = self.solved.types.captureSpan(capture_span);
         const fields = switch (self.types.get(capture_ty)) {
             .capture_record => |fields| self.types.captureFieldSpan(fields),
             else => Common.invariant("callable capture payload was not a capture record"),
         };
         if (captures.len != fields.len) Common.invariant("callable capture payload arity differed from captured locals");
-        if (self.solved.lifted.typedLocalSpan(self.solved.lifted.fns.items[@intFromEnum(fn_id)].captures).len != capture_exprs.len) {
+        if (captures.len != capture_operands.len) {
             Common.invariant("function reference capture operand count differed from lifted function captures");
         }
 
@@ -2308,10 +2323,14 @@ const Lowerer = struct {
         defer self.allocator.free(field_locals);
 
         const target_is_zst = self.isZstLocal(target);
-        for (captures, fields, 0..) |capture, field, i| {
+        // Member captures, capture-record fields, and keyed operands are all in
+        // canonical CaptureId order, so the join is an exact indexed walk.
+        for (captures, fields, capture_operands, 0..) |capture, field, operand, i| {
             if (capture.symbol != field.symbol or capture.binder != field.binder or capture.capture_id != field.capture_id) {
                 Common.invariant("callable capture payload fields differed from captured locals");
             }
+            const capture_id = capture.capture_id orelse Common.invariant("member capture had no CaptureId");
+            if (operand.id != capture_id) Common.invariant("capture operand CaptureId did not match its member capture slot");
             expr_locals[i] = try self.addTemp(field.ty);
             if (target_is_zst) {
                 field_locals[i] = expr_locals[i];
@@ -2344,38 +2363,9 @@ const Lowerer = struct {
                     current,
                 );
             }
-            const capture_expr = self.captureExprForMemberCapture(fn_id, capture_exprs, captures[i]) orelse
-                Common.invariant("callable capture payload field had no explicit operand");
-            current = try self.lowerExprInto(expr_locals[i], capture_expr, current);
+            current = try self.lowerExprInto(expr_locals[i], capture_operands[i].value, current);
         }
         return current;
-    }
-
-    fn captureExprForMemberCapture(
-        self: *Lowerer,
-        fn_id: Lifted.FnId,
-        capture_exprs: []const Lifted.ExprId,
-        member_capture: SolvedType.Capture,
-    ) ?Lifted.ExprId {
-        const fn_captures = self.solved.lifted.typedLocalSpan(self.solved.lifted.fns.items[@intFromEnum(fn_id)].captures);
-        for (fn_captures, capture_exprs) |fn_capture, capture_expr| {
-            if (self.captureLocalMatchesMember(fn_capture.local, member_capture)) return capture_expr;
-        }
-        return null;
-    }
-
-    fn captureLocalMatchesMember(
-        self: *Lowerer,
-        local_id: Lifted.LocalId,
-        member_capture: SolvedType.Capture,
-    ) bool {
-        if (local_id == member_capture.local) return true;
-
-        const local = self.solved.lifted.locals.items[@intFromEnum(local_id)];
-        if (local.symbol == member_capture.symbol) return true;
-        if (local.capture_id != null and member_capture.capture_id != null and local.capture_id.? == member_capture.capture_id.?) return true;
-
-        return false;
     }
 
     fn lowerRecordInto(
@@ -2988,10 +2978,10 @@ const Lowerer = struct {
         target: LIR.LocalId,
         expr_id: Lifted.ExprId,
         fn_id: Lifted.FnId,
-        capture_exprs: []const Lifted.ExprId,
+        capture_operands: []const Lifted.CaptureOperand,
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
-        return try self.lowerFnRefIntoAtType(target, expr_id, fn_id, capture_exprs, try self.lowerExprTy(expr_id), next);
+        return try self.lowerFnRefIntoAtType(target, expr_id, fn_id, capture_operands, try self.lowerExprTy(expr_id), next);
     }
 
     fn lowerFnRefIntoAtType(
@@ -2999,12 +2989,12 @@ const Lowerer = struct {
         target: LIR.LocalId,
         expr_id: Lifted.ExprId,
         fn_id: Lifted.FnId,
-        capture_exprs: []const Lifted.ExprId,
+        capture_operands: []const Lifted.CaptureOperand,
         ty: Type.TypeId,
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
         const captures = self.memberCapturesForExpr(expr_id, fn_id);
-        if (self.solved.lifted.typedLocalSpan(self.solved.lifted.fns.items[@intFromEnum(fn_id)].captures).len != capture_exprs.len) {
+        if (self.solved.lifted.typedLocalSpan(self.solved.lifted.fns.items[@intFromEnum(fn_id)].captures).len != capture_operands.len) {
             Common.invariant("function reference capture operand count differed from lifted function captures");
         }
         const fn_symbol = self.solved.lifted.fns.items[@intFromEnum(fn_id)].symbol;
@@ -3013,14 +3003,14 @@ const Lowerer = struct {
                 const variants = self.types.fnVariantSpan(variants_span);
                 for (variants, 0..) |variant, variant_index| {
                     if (variant.source != fn_symbol) continue;
-                    break :blk try self.lowerFiniteCallableValueInto(target, @intCast(variant_index), fn_id, captures, capture_exprs, variant.capture_ty, next);
+                    break :blk try self.lowerFiniteCallableValueInto(target, @intCast(variant_index), fn_id, captures, capture_operands, variant.capture_ty, next);
                 }
                 Common.invariant("finite callable type did not contain referenced function");
             },
             .erased_fn => |erased| blk: {
                 for (self.types.fnVariantSpan(erased.members)) |variant| {
                     if (variant.source != fn_symbol) continue;
-                    break :blk try self.lowerPackedErasedFnInto(target, variant.target, fn_id, captures, capture_exprs, variant.capture_ty, next);
+                    break :blk try self.lowerPackedErasedFnInto(target, variant.target, fn_id, captures, capture_operands, variant.capture_ty, next);
                 }
                 Common.invariant("erased callable type did not contain referenced function");
             },
@@ -3034,12 +3024,12 @@ const Lowerer = struct {
         variant_index: u16,
         lifted_fn_id: Lifted.FnId,
         captures: SolvedType.Span,
-        capture_exprs: []const Lifted.ExprId,
+        capture_operands: []const Lifted.CaptureOperand,
         capture_ty: ?Type.TypeId,
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
         if (capture_ty) |payload_ty| {
-            if (self.solved.lifted.typedLocalSpan(self.solved.lifted.fns.items[@intFromEnum(lifted_fn_id)].captures).len != capture_exprs.len) {
+            if (self.solved.lifted.typedLocalSpan(self.solved.lifted.fns.items[@intFromEnum(lifted_fn_id)].captures).len != capture_operands.len) {
                 Common.invariant("finite callable capture operand count differed from lifted function captures");
             }
             const payload = try self.addTemp(payload_ty);
@@ -3056,9 +3046,9 @@ const Lowerer = struct {
                     .payload = payload,
                     .next = next,
                 } });
-            return try self.lowerCaptureRecordFromCaptureExprsInto(payload, lifted_fn_id, captures, capture_exprs, payload_ty, assign);
+            return try self.lowerCaptureRecordFromCaptureExprsInto(payload, lifted_fn_id, captures, capture_operands, payload_ty, assign);
         }
-        if (capture_exprs.len != 0) Common.invariant("finite callable without capture payload carried capture operands");
+        if (capture_operands.len != 0) Common.invariant("finite callable without capture payload carried capture operands");
         if (self.isZstLocal(target)) return try self.assignZst(target, next);
         return try self.result.store.addCFStmt(.{ .assign_tag = .{
             .target = target,
@@ -3075,11 +3065,11 @@ const Lowerer = struct {
         fn_id: Type.FnId,
         lifted_fn_id: Lifted.FnId,
         captures: SolvedType.Span,
-        capture_exprs: []const Lifted.ExprId,
+        capture_operands: []const Lifted.CaptureOperand,
         capture_ty: ?Type.TypeId,
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
-        if (self.solved.lifted.typedLocalSpan(self.solved.lifted.fns.items[@intFromEnum(lifted_fn_id)].captures).len != capture_exprs.len) {
+        if (self.solved.lifted.typedLocalSpan(self.solved.lifted.fns.items[@intFromEnum(lifted_fn_id)].captures).len != capture_operands.len) {
             Common.invariant("erased callable capture operand count differed from lifted function captures");
         }
         const capture = if (capture_ty) |ty| try self.addTemp(ty) else null;
@@ -3100,8 +3090,8 @@ const Lowerer = struct {
             .on_drop = on_drop,
             .next = next,
         } });
-        if (capture_ty) |ty| return try self.lowerCaptureRecordFromCaptureExprsInto(capture.?, lifted_fn_id, captures, capture_exprs, ty, assign);
-        if (capture_exprs.len != 0) Common.invariant("erased callable without capture payload carried capture operands");
+        if (capture_ty) |ty| return try self.lowerCaptureRecordFromCaptureExprsInto(capture.?, lifted_fn_id, captures, capture_operands, ty, assign);
+        if (capture_operands.len != 0) Common.invariant("erased callable without capture payload carried capture operands");
         return assign;
     }
 
@@ -3111,22 +3101,22 @@ const Lowerer = struct {
         result_ty: Type.TypeId,
         callee: Lifted.FnId,
         args: []const Lifted.ExprId,
-        capture_exprs: []const Lifted.ExprId,
+        capture_operands: []const Lifted.CaptureOperand,
         is_cold: bool,
         next: LIR.CFStmtId,
     ) Common.LowerError!LIR.CFStmtId {
         const target_fn = try self.ensureOwnFnSpec(callee, .finite);
         const captures = self.capturesForFn(callee);
         if (captures.len == 0) {
-            if (capture_exprs.len != 0) Common.invariant("direct call carried capture operands for a capture-free callee");
+            if (capture_operands.len != 0) Common.invariant("direct call carried capture operands for a capture-free callee");
             return try self.lowerKnownCallInto(target, result_ty, target_fn, args, null, is_cold, next);
         }
-        if (captures.len != capture_exprs.len) Common.invariant("direct call capture operand count differed from callee capture count");
+        if (captures.len != capture_operands.len) Common.invariant("direct call capture operand count differed from callee capture count");
         const capture_ty = self.fn_entries.items[@intFromEnum(target_fn)].spec.capture_ty orelse
             Common.invariant("capturing direct call target had no capture record type");
         const capture_local = try self.addTemp(capture_ty);
         const call = try self.lowerKnownCallInto(target, result_ty, target_fn, args, capture_local, is_cold, next);
-        return try self.lowerCaptureRecordFromCaptureExprsInto(capture_local, callee, captures, capture_exprs, capture_ty, call);
+        return try self.lowerCaptureRecordFromCaptureExprsInto(capture_local, callee, captures, capture_operands, capture_ty, call);
     }
 
     fn lowerKnownCallInto(
@@ -5843,7 +5833,7 @@ const Lowerer = struct {
         for (self.local_map, 0..) |maybe_existing, raw_other| {
             const existing = maybe_existing orelse continue;
             const other: Lifted.LocalId = @enumFromInt(@as(u32, @intCast(raw_other)));
-            if (!self.captureLocalMatchesLocal(local, other)) continue;
+            if (!self.aliasedLocalMatches(local, other)) continue;
             if (!try self.liftedLocalTypesMatch(local, other)) continue;
             if (found) |previous| {
                 if (previous != existing) {
@@ -6481,9 +6471,8 @@ const Lowerer = struct {
 
     fn captureFieldIndexInFields(fields: []const Type.CaptureField, needle: Type.CaptureField) usize {
         for (fields, 0..) |field, index| {
-            if (field.symbol == needle.symbol and field.binder == needle.binder and field.capture_id == needle.capture_id) {
-                return index;
-            }
+            // CaptureId is the canonical identity of a capture-record field.
+            if (field.capture_id == needle.capture_id) return index;
         }
         Common.invariant("capture record boundary target field was absent from source");
     }
@@ -7446,11 +7435,13 @@ fn cloneLiftedProgram(allocator: std.mem.Allocator, program: *const Lifted.Progr
         .stmt_ids = try cloneArrayList(Lifted.StmtId, allocator, &program.stmt_ids),
         .field_exprs = try cloneArrayList(Lifted.FieldExpr, allocator, &program.field_exprs),
         .fn_def_captures = try cloneArrayList(Lifted.FnDefCapture, allocator, &program.fn_def_captures),
+        .capture_operands = try cloneArrayList(Lifted.CaptureOperand, allocator, &program.capture_operands),
         .record_destructs = try cloneArrayList(Lifted.RecordDestruct, allocator, &program.record_destructs),
         .str_pattern_steps = try cloneArrayList(Lifted.StrPatternStep, allocator, &program.str_pattern_steps),
         .branches = try cloneArrayList(Lifted.Branch, allocator, &program.branches),
         .if_branches = try cloneArrayList(Lifted.IfBranch, allocator, &program.if_branches),
         .string_literals = string_literals,
+        .next_lift_capture_id = program.next_lift_capture_id,
         .proc_debug_names = try cloneProcDebugNameMap(allocator, &program.proc_debug_names),
         .roots = try cloneArrayList(Lifted.Root, allocator, &program.roots),
         .layout_requests = try cloneArrayList(Lifted.LayoutRequest, allocator, &program.layout_requests),


### PR DESCRIPTION
## Canonical `CaptureId` through every post-check IR

Closure captures previously carried up to **four** different keys — the lifted `LocalId`, the `Symbol`, the checked `PatternBinderId`, and a generated `capture_id: u32` — reconciled by fuzzy per-file matchers scattered across the post-check pipeline. This threads **one canonical `CaptureId`** (`enum(u32)`, high-bit split: canonical vs generated) immutably through every post-check IR, so every operand↔slot join is an exact indexed lookup that either succeeds or halts (debug assert / release `unreachable`).

Implements `projects/big/canonical-capture-id.md`.

### The 7 capture-id commits
1. **feat** — introduce the canonical `CaptureId` type and thread it into `CheckedCapture`
2. **refactor** — migrate Monotype `capture_id` fields to `CaptureId`
3. **refactor** — key capture operands and joins by `CaptureId` (sorted `Span(CaptureOperand)`, exact merge joins)
4. **refactor** — collapse the `ConstStore` `CaptureId` union into the unified enum
5. **feat** — add the debug-only `verifyCaptureInvariants` pass (runs after every Lifted-IR mutation; compiled out in release)
6. **test** — regression/repro tests (nested + 5-deep curried closures, record-arg captures, sibling captures) + a mutation test that corrupts a lifted operand and asserts the verify pass catches it
7. **refactor** — finalize joins on `CaptureId` alone and clear all CI check lints

> This branch also carries two small in-flight fixes it was stacked on (`fix(nix): build kcov in the dev shell on macOS`, `fix(ci): list files via jj when git is unavailable`).

### Success criteria (all met)
- One `CaptureId` type; **no** capture join keys on symbol / binder / `LocalId` (grep-clean)
- Deleted fuzzy matchers: `CaptureIdentity`, `captureOperandsFromPositionals`, `finalizeCaptureExprSpanFromOperands`, `fnDefCaptureLocalMatches`, both `captureExprForMemberCapture`
- Capture spans have a defined canonical (ascending-`CaptureId`) order
- Missing operands are impossible to paper over — verified by exact lookups + the debug invariant pass

### Validation
- `run-test-zig` — 3071 unit tests ✅
- `run-test-eval` — 1515 tests across all backends (interpreter/dev/wasm/llvm) ✅
- `minici` check lints (tidy, semantic-audit, enum-from-int-zero, unused-suppression, postcheck-architecture, …), snapshots, serialization-sizes, cli/wasm/dylib/archive ✅
- `SERIALIZED_VERSION_HASH` golden regenerated for the two layout-change points

🤖 Generated with [Claude Code](https://claude.com/claude-code)
