### PR TITLE
Do not store index of platform node twice

### DIFF
--- a/src/parse/NodeStore.zig
+++ b/src/parse/NodeStore.zig
@@ -435,8 +435,6 @@ pub fn addHeader(store: *NodeStore, header: AST.Header) std.mem.Allocator.Error!
             node.data.lhs = @intFromEnum(app.provides);
             node.data.rhs = @intFromEnum(app.packages);
             node.region = app.region;
-
-            try store.extra_data.append(store.gpa, @intFromEnum(app.platform_idx));
         },
         .module => |mod| {
             node.tag = .module_header;


### PR DESCRIPTION
The index of the platform is already stored in the AST node's main_token -- there is no need to store it in the extra data, too.