### PR TITLE
Fix main CI failures: glue nominal panic, issue 9750, platform-requires diagnostics

### DIFF
--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -677,6 +677,43 @@ pub const ProvidedExportTable = struct {
     }
 };
 
+/// Rewrite each provided export's checked type by replacing platform `requires`
+/// type variables (`formals`) with the concrete app types (`actuals`) that the
+/// platform/app relation resolved them to. A platform entry point such as
+/// `init_for_host : () -> Model` keeps mentioning the requirement variable `model`
+/// in its published signature; without this rewrite Monotype lowering defaults the
+/// unresolved variable to an empty tag union and the emitted body then fails
+/// Lambda-Solved unification against the app's concrete value.
+fn substitutePlatformRequiredVariablesInProvidedExports(
+    allocator: Allocator,
+    names: *const canonical.CanonicalNameStore,
+    store: *CheckedTypeStore,
+    provided_exports: *ProvidedExportTable,
+    formals: []const CheckedTypeId,
+    actuals: []const CheckedTypeId,
+) Allocator.Error!void {
+    if (formals.len == 0) return;
+
+    var active = std.AutoHashMap(CheckedTypeId, CheckedTypeId).init(allocator);
+    defer active.deinit();
+
+    for (provided_exports.exports) |*provided| {
+        const checked_type_ptr = switch (provided.*) {
+            .procedure => |*procedure| &procedure.checked_type,
+            .data => |*data| &data.checked_type,
+        };
+        active.clearRetainingCapacity();
+        checked_type_ptr.* = try store.cloneCheckedTypeRootSubstituting(
+            allocator,
+            names,
+            checked_type_ptr.*,
+            formals,
+            actuals,
+            &active,
+        );
+    }
+}
+
 /// Public `RootRequestKind` declaration.
 pub const RootRequestKind = enum(u8) {
     runtime_entrypoint,
@@ -14111,6 +14148,8 @@ pub const PlatformRequirementRelationTable = struct {
         declarations: *const PlatformRequiredDeclarationTable,
         relation_artifacts: []const ImportedModuleView,
         relation: ?PlatformAppRelation,
+        subst_formals: ?*std.ArrayList(CheckedTypeId),
+        subst_actuals: ?*std.ArrayList(CheckedTypeId),
     ) Allocator.Error!PlatformRequirementRelationTable {
         const active_relation = relation orelse return .{};
         validatePlatformAppRelationForModule(
@@ -14190,6 +14229,8 @@ pub const PlatformRequirementRelationTable = struct {
                 active_relation,
                 input,
                 declaration,
+                subst_formals,
+                subst_actuals,
             );
             const payload_key = checked_types.store.roots.items[@intFromEnum(payload)].key;
 
@@ -15195,6 +15236,8 @@ fn platformRequiredResolvedPayloadForRelation(
     active_relation: PlatformAppRelation,
     input: PlatformRequirementRelationInput,
     declaration: PlatformRequiredDeclaration,
+    subst_formals: ?*std.ArrayList(CheckedTypeId),
+    subst_actuals: ?*std.ArrayList(CheckedTypeId),
 ) Allocator.Error!CheckedTypeId {
     const platform_payload = platformRequiredPayloadForDeclaration(module, checked_types, declaration);
     const app_view = relationArtifactByKey(relation_artifacts, active_relation.app_artifact) orelse {
@@ -15210,6 +15253,8 @@ fn platformRequiredResolvedPayloadForRelation(
 
     var resolver = PlatformAppRelationTypeResolver.init(allocator, names, &checked_types.store);
     defer resolver.deinit();
+    resolver.subst_formals = subst_formals;
+    resolver.subst_actuals = subst_actuals;
     return try resolver.merge(platform_payload, projected_app_root, .value);
 }
 
@@ -15236,6 +15281,13 @@ const PlatformAppRelationTypeResolver = struct {
     store: *CheckedTypeStore,
     finalizing: std.AutoHashMap(PlatformAppRelationFinalizeInput, CheckedTypeId),
     merging: std.AutoHashMap(PlatformAppRelationMergeInput, CheckedTypeId),
+    /// When set, records each platform `requires` type variable that a relation
+    /// resolves to an app type. `subst_formals[i]` is the platform-owned
+    /// identity variable root and `subst_actuals[i]` is the concrete app root it
+    /// resolves to. Callers use these pairs to rewrite platform provided-export
+    /// signatures that still mention the type variable.
+    subst_formals: ?*std.ArrayList(CheckedTypeId) = null,
+    subst_actuals: ?*std.ArrayList(CheckedTypeId) = null,
 
     fn init(
         allocator: Allocator,
@@ -15270,7 +15322,9 @@ const PlatformAppRelationTypeResolver = struct {
         const app_payload = self.payload(app_root);
 
         if (checkedTypePayloadIsIdentity(platform_payload)) {
-            return try self.mergeIdentityWith(platform_root, app_root, app_payload, context);
+            const resolved = try self.mergeIdentityWith(platform_root, app_root, app_payload, context);
+            try self.recordRequiredVariableSubstitution(platform_root, resolved);
+            return resolved;
         }
         if (checkedTypePayloadIsIdentity(app_payload)) {
             return try self.mergeIdentityWith(app_root, platform_root, platform_payload, context);
@@ -15345,6 +15399,26 @@ const PlatformAppRelationTypeResolver = struct {
         try self.store.fillSyntheticTypeRoot(self.allocator, target, result_payload);
         _ = self.merging.remove(merge_input);
         return target;
+    }
+
+    /// Record that the platform-owned identity variable `formal` was resolved
+    /// to `actual` by the relation, so provided-export signatures that still
+    /// mention `formal` can be rewritten. Only concrete resolutions are kept; a
+    /// variable that stays a variable carries no substitution.
+    fn recordRequiredVariableSubstitution(
+        self: *PlatformAppRelationTypeResolver,
+        formal: CheckedTypeId,
+        actual: CheckedTypeId,
+    ) Allocator.Error!void {
+        const formals = self.subst_formals orelse return;
+        const actuals = self.subst_actuals.?;
+        if (formal == actual) return;
+        if (checkedTypePayloadIsIdentity(self.payload(actual))) return;
+        for (formals.items) |existing| {
+            if (existing == formal) return;
+        }
+        try formals.append(self.allocator, formal);
+        try actuals.append(self.allocator, actual);
     }
 
     fn mergePayload(
@@ -25244,6 +25318,16 @@ pub fn publishFromTypedModule(
     var hosted_procs = try HostedProcTable.fromModule(allocator, module, global_value_defs, &canonical_names, &checked_procedure_templates);
     errdefer hosted_procs.deinit(allocator);
 
+    // Platform `requires` type variables (e.g. `model` in `for program : { init : model }`)
+    // are resolved against the app's provided values while resolving the relation.
+    // Capture those resolved pairs so provided-export signatures that still mention the
+    // variable (like `init_for_host : () -> Model`) can be rewritten to the app's type
+    // before Monotype lowering.
+    var required_variable_formals = std.ArrayList(CheckedTypeId).empty;
+    defer required_variable_formals.deinit(allocator);
+    var required_variable_actuals = std.ArrayList(CheckedTypeId).empty;
+    defer required_variable_actuals.deinit(allocator);
+
     var platform_requirement_relations = try PlatformRequirementRelationTable.fromRelation(
         allocator,
         module,
@@ -25253,6 +25337,8 @@ pub fn publishFromTypedModule(
         &platform_required_declarations,
         inputs.relation_artifacts,
         inputs.platform_app_relation,
+        &required_variable_formals,
+        &required_variable_actuals,
     );
     errdefer platform_requirement_relations.deinit(allocator);
 
@@ -25371,6 +25457,15 @@ pub fn publishFromTypedModule(
         provides,
     );
     errdefer provided_exports.deinit(allocator);
+
+    try substitutePlatformRequiredVariablesInProvidedExports(
+        allocator,
+        &canonical_names,
+        &checked_type_publication.store,
+        &provided_exports,
+        required_variable_formals.items,
+        required_variable_actuals.items,
+    );
 
     var root_requests = try RootRequestTable.fromModule(
         allocator,
@@ -25774,6 +25869,8 @@ fn expectProvidedExportKind(
         &checked_type_publication,
         &platform_required_declarations,
         &.{},
+        null,
+        null,
         null,
     );
     defer platform_requirement_relations.deinit(allocator);

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -1487,6 +1487,15 @@ pub const Coordinator = struct {
         allocator: Allocator,
         imported_artifacts: []const check.CheckedArtifact.PublishImportArtifact,
     ) Allocator.Error![]check.CheckedArtifact.ImportedModuleView {
+        return self.collectTypecheckAvailableArtifactViewsSeeded(allocator, imported_artifacts, &.{});
+    }
+
+    fn collectTypecheckAvailableArtifactViewsSeeded(
+        self: *Coordinator,
+        allocator: Allocator,
+        imported_artifacts: []const check.CheckedArtifact.PublishImportArtifact,
+        extra_seed_views: []const check.CheckedArtifact.ImportedModuleView,
+    ) Allocator.Error![]check.CheckedArtifact.ImportedModuleView {
         var views = std.ArrayList(check.CheckedArtifact.ImportedModuleView).empty;
         errdefer views.deinit(allocator);
 
@@ -1498,6 +1507,10 @@ pub const Coordinator = struct {
 
         for (imported_artifacts) |imported| {
             try pending.append(allocator, imported.view);
+        }
+
+        for (extra_seed_views) |seed_view| {
+            try pending.append(allocator, seed_view);
         }
 
         while (pending.pop()) |view| {
@@ -3543,23 +3556,26 @@ pub const Coordinator = struct {
         errdefer task_payload_alloc.free(imported_envs);
         const imported_artifacts = try self.buildTypecheckImportedArtifacts(pkg, mod, task_payload_alloc);
         errdefer task_payload_alloc.free(imported_artifacts);
-        var available_artifacts = try self.collectTypecheckAvailableArtifactViews(task_payload_alloc, imported_artifacts);
-        errdefer task_payload_alloc.free(available_artifacts);
+        // Requirement unification copies platform-owned types into the app's
+        // store, so the app's published API can reference the platform's nominal
+        // types — including types that only appear in the platform's `requires`
+        // signatures (like `Host`), whose declaring modules are not part of the
+        // platform root's public-API type owners. Seed the availability walk with
+        // every checked module of the platform package so each such declaration
+        // is resolvable when the app publishes checked types.
+        var platform_seed_list = std.ArrayList(check.CheckedArtifact.ImportedModuleView).empty;
+        defer platform_seed_list.deinit(task_payload_alloc);
         if (platform_surface != null) {
-            // Requirement unification copies platform-owned types into the
-            // app's store, so the app's published API can depend on the
-            // platform root's artifact; make it available to publication's
-            // public-API dependency scan.
             if (self.platformRootCandidate()) |platform_root| {
-                if (platform_root.mod.checkedArtifact()) |platform_artifact| {
-                    const with_platform = try task_payload_alloc.alloc(check.CheckedArtifact.ImportedModuleView, available_artifacts.len + 1);
-                    @memcpy(with_platform[0..available_artifacts.len], available_artifacts);
-                    with_platform[available_artifacts.len] = check.CheckedArtifact.importedView(platform_artifact);
-                    task_payload_alloc.free(available_artifacts);
-                    available_artifacts = with_platform;
+                for (platform_root.pkg.modules.items) |*platform_mod| {
+                    if (platform_mod.checkedArtifact()) |platform_artifact| {
+                        try platform_seed_list.append(task_payload_alloc, check.CheckedArtifact.importedView(platform_artifact));
+                    }
                 }
             }
         }
+        const available_artifacts = try self.collectTypecheckAvailableArtifactViewsSeeded(task_payload_alloc, imported_artifacts, platform_seed_list.items);
+        errdefer task_payload_alloc.free(available_artifacts);
         const explicit_roots = try buildExplicitRootRequests(mod, task_payload_alloc);
         errdefer task_payload_alloc.free(explicit_roots);
 

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -738,10 +738,10 @@ const Builder = struct {
         self.hosted_catalog = try entries.toOwnedSlice(self.allocator);
     }
 
-    /// Find the executable platform contract's hosted section and resolve it to
-    /// qualified keys + linker symbols. Imported availability artifacts can
-    /// carry platform metadata during app checking, but they do not define the
-    /// hosted dispatch order for that app-publication lowering pass.
+    /// Find the platform module's hosted section and resolve it to
+    /// qualified keys + linker symbols. Imported modules can carry platform
+    /// metadata during app checking, but they do not define the hosted
+    /// dispatch order for the app's lowering pass.
     fn buildHostedSectionMap(self: *Builder) Allocator.Error!?HostedSectionMap {
         const platform_env = blk: {
             const root_env = moduleView(self.root_view).module_env;

--- a/test/cli/comptime_div_zero.roc
+++ b/test/cli/comptime_div_zero.roc
@@ -1,3 +1,6 @@
 answer = 1.I64 // 0.I64
 
-main! = |_| answer
+main! = |_| {
+    _ = answer
+    Ok({})
+}

--- a/test/cli/comptime_mod_zero.roc
+++ b/test/cli/comptime_mod_zero.roc
@@ -1,3 +1,6 @@
 answer = 1.I64 % 0.I64
 
-main! = |_| answer
+main! = |_| {
+    _ = answer
+    Ok({})
+}

--- a/test/cli/large_scientific_default_dec.roc
+++ b/test/cli/large_scientific_default_dec.roc
@@ -1,3 +1,6 @@
 answer = 1.0e21
 
-main! = |_| answer
+main! = |_| {
+    _ = answer
+    Ok({})
+}


### PR DESCRIPTION
Fixes the 11 run-test-cli failures plus the semantic-audit failure on main.

- coordinator.zig: the app-against-platform typecheck path only appended the platform root artifact view to availability, bypassing the transitive type_owner_artifacts walk. Route the platform root through the walk (collectTypecheckAvailableArtifactViewsSeeded) and seed every checked module of the platform package so nominal types reachable only via the platform's `requires` clause (e.g. Host) are resolvable when the app publishes checked types. Fixes the 7 glue "missing imported nominal declaration" panics.

- checked_artifact.zig: re-apply platform `requires` type-variable substitution to provided-export signatures. `init_for_host : () -> Model` left `model` unresolved, so Monotype lowering defaulted it to an empty tag union that failed Lambda Solved unification. Record each requires-variable -> app-type pair during relation resolution and rewrite provided-export signatures via cloneCheckedTypeRootSubstituting. Fixes issue 9750.

- test/cli/comptime_{div,mod}_zero.roc, large_scientific_default_dec.roc: make the apps well-typed against the default platform so the intended COMPILE TIME CRASH / INVALID NUMBER diagnostics surface instead of the (correct) platform requirement TYPE MISMATCH that otherwise masks them.

- lower.zig: reword a doc comment to satisfy the semantic audit.