### PR TITLE
Fix ModuleIdentityId type mismatch in checked_artifact test

### DIFF
--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -28148,7 +28148,7 @@ test "platform app relation resolver substitutes required identity in provided f
     var names = canonical.CanonicalNameStore.init(allocator);
     defer names.deinit();
 
-    const module_name = try names.internModuleName("Test");
+    const module_name = try names.internModuleIdentity(&([_]u8{0x88} ** 32));
     const type_name = try names.internTypeName("Player");
     const model_alias_name = try names.internTypeName("Model");
     const tag_name = try names.internTagLabel("Player");


### PR DESCRIPTION
The "platform app relation resolver substitutes required identity in provided function root" test still interned its module via internModuleName (returning a ModuleNameId), but
appendRecursiveNominalTestType and the alias origin_module field now expect a ModuleIdentityId. This call site was missed when the module identity type was split out, breaking the check test build. Switch it to internModuleIdentity with a 32-byte hash, matching the sibling tests.