### PR TITLE
Stabilize main CI runner timeouts

### DIFF
--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -272,26 +272,32 @@ jobs:
             cpu_flag: -Dcpu=x86_64_v3
             target_flag: ''
             release_jobs_flag: ''
+            zig_test_timeout_flag: ''
           - os: macos-15
             cpu_flag: ''
             target_flag: ''
             release_jobs_flag: ''
+            zig_test_timeout_flag: ''
           - os: ubuntu-24.04
             cpu_flag: ""
             target_flag: -Dtarget=x86_64-linux-musl
             release_jobs_flag: ''
+            zig_test_timeout_flag: ''
           - os: ubuntu-24.04-arm
             cpu_flag: ''
             target_flag: ''  # Native build for kcov (Zig 0.15.2 x86_64 has DWARF bug) # TODO ZIG 16: re-check if DWARF bug is fixed in 0.16
             release_jobs_flag: -j2  # Avoid hosted ARM runner disconnects under ReleaseFast parallelism.
+            zig_test_timeout_flag: ''
           - os: windows-2022
             cpu_flag: -Dcpu=x86_64_v3
             target_flag: ''
             release_jobs_flag: ''
+            zig_test_timeout_flag: --test-timeout 5m
           - os: windows-2025
             cpu_flag: -Dcpu=x86_64_v3
             target_flag: ''
             release_jobs_flag: ''
+            zig_test_timeout_flag: --test-timeout 5m
 
     steps:
       - name: Checkout
@@ -357,11 +363,11 @@ jobs:
 
       # 1) in debug mode
       - name: build and execute tests, build repro executables
-        run: zig build run-test-zig -Dfuzz -Dsystem-afl=false ${{ matrix.target_flag }}
+        run: zig build ${{ matrix.zig_test_timeout_flag }} run-test-zig -Dfuzz -Dsystem-afl=false ${{ matrix.target_flag }}
 
       # 2) in release mode
       - name: Build and execute tests, build repro executables. All in release mode.
-        run: zig build ${{ matrix.release_jobs_flag }} run-test-zig -Doptimize=ReleaseFast -Dfuzz -Dsystem-afl=false ${{ matrix.cpu_flag }} ${{ matrix.target_flag }}
+        run: zig build ${{ matrix.release_jobs_flag }} ${{ matrix.zig_test_timeout_flag }} run-test-zig -Doptimize=ReleaseFast -Dfuzz -Dsystem-afl=false ${{ matrix.cpu_flag }} ${{ matrix.target_flag }}
 
       - name: Check for snapshot changes
         run: |

--- a/ci/valgrind.supp
+++ b/ci/valgrind.supp
@@ -27,3 +27,12 @@
    fun:realpath
    fun:Io.Threaded.dirRealPathFilePosix
 }
+
+{
+   musl-realpath-small-copy-dir-realpath
+   Memcheck:Cond
+   fun:copySmallLength
+   fun:memcpy
+   fun:realpath
+   fun:Io.Threaded.dirRealPathFilePosix
+}


### PR DESCRIPTION
This stabilizes two CI failures seen on main: Windows Zig unit-test jobs now pass an explicit Zig test timeout so the Zig test-runner response watchdog does not kill slow-starting test binaries on hosted Windows runners, and Valgrind now suppresses the musl realpath variant that goes through Zig's small memcpy helper before returning to std.fs realpath.