### PR TITLE
Render echo wasm diagnostics as terminal output

### DIFF
--- a/ci/valgrind.supp
+++ b/ci/valgrind.supp
@@ -20,19 +20,12 @@
 # musl realpath conditionally inspects internal path-buffer bytes while
 # canonicalizing a path. Valgrind 3.26 reports this inside libc before control
 # returns to Zig's std.fs realpath wrapper; this does not indicate that Roc
-# read uninitialized program memory.
+# read uninitialized program memory. Match any internal realpath helper frames
+# because Zig's optimized libc memcpy path varies by source/destination length.
 {
    musl-realpath-dir-realpath
    Memcheck:Cond
-   fun:realpath
-   fun:Io.Threaded.dirRealPathFilePosix
-}
-
-{
-   musl-realpath-small-copy-dir-realpath
-   Memcheck:Cond
-   fun:copySmallLength
-   fun:memcpy
+   ...
    fun:realpath
    fun:Io.Threaded.dirRealPathFilePosix
 }

--- a/ci/valgrind.supp
+++ b/ci/valgrind.supp
@@ -29,3 +29,11 @@
    fun:realpath
    fun:Io.Threaded.dirRealPathFilePosix
 }
+
+{
+   musl-realpath-value-dir-realpath
+   Memcheck:Value8
+   ...
+   fun:realpath
+   fun:Io.Threaded.dirRealPathFilePosix
+}

--- a/ci/valgrind.supp
+++ b/ci/valgrind.supp
@@ -37,3 +37,12 @@
    fun:realpath
    fun:Io.Threaded.dirRealPathFilePosix
 }
+
+{
+   musl-realpath-readlink-dir-realpath
+   Memcheck:Param
+   readlink(buf)
+   fun:readlink
+   fun:realpath
+   fun:Io.Threaded.dirRealPathFilePosix
+}

--- a/ci/valgrind.supp
+++ b/ci/valgrind.supp
@@ -46,3 +46,12 @@
    fun:realpath
    fun:Io.Threaded.dirRealPathFilePosix
 }
+
+{
+   musl-realpath-readlink-bufsiz-dir-realpath
+   Memcheck:Param
+   readlink(bufsiz)
+   fun:readlink
+   fun:realpath
+   fun:Io.Threaded.dirRealPathFilePosix
+}

--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -206,6 +206,7 @@ pub const BuildEnv = struct {
     synthetic_root_original_path: ?[]const u8 = null,
     synthetic_root_original_source: ?[]const u8 = null,
     synthetic_root_header_len: usize = 0,
+    synthetic_root_header_lines: u32 = 0,
     synthetic_root_identity: bool = false,
     synthetic_root_platform_identity: bool = false,
 
@@ -484,8 +485,20 @@ pub const BuildEnv = struct {
         self.synthetic_root_original_path = original_path;
         self.synthetic_root_original_source = original_source;
         self.synthetic_root_header_len = header_len;
+        self.synthetic_root_header_lines = 0;
         self.setSyntheticRootPackageIdentity();
         self.setSyntheticRootPlatformPackageIdentity();
+    }
+
+    pub fn setSyntheticRootSourceMappingWithLineOffset(
+        self: *BuildEnv,
+        original_path: []const u8,
+        original_source: []const u8,
+        header_len: usize,
+        header_lines: u32,
+    ) void {
+        self.setSyntheticRootSourceMapping(original_path, original_source, header_len);
+        self.synthetic_root_header_lines = header_lines;
     }
 
     pub fn setSyntheticRootPackageIdentity(self: *BuildEnv) void {
@@ -2080,6 +2093,109 @@ pub const BuildEnv = struct {
         return error.InvalidPackageName;
     }
 
+    fn syntheticRootDisplayPath(self: *BuildEnv, path: []const u8) ?[]const u8 {
+        const original_path = self.synthetic_root_original_path orelse return null;
+        const root_path = self.discovered_root_abs orelse return null;
+        if (!std.mem.eql(u8, path, root_path)) return null;
+        return original_path;
+    }
+
+    fn remapSyntheticRootSourceRegion(
+        self: *BuildEnv,
+        allocator: Allocator,
+        region: *reporting.SourceCodeDisplayRegion,
+        original_line_starts: []const u32,
+    ) Allocator.Error!void {
+        const original_path = self.synthetic_root_original_path orelse return;
+        const original_source = self.synthetic_root_original_source orelse return;
+        const filename = region.filename orelse return;
+        if (self.syntheticRootDisplayPath(filename) == null) return;
+
+        const header_lines = self.synthetic_root_header_lines;
+        if (header_lines == 0) {
+            const owned_filename = try allocator.dupe(u8, original_path);
+            if (region.filename) |old_filename| allocator.free(old_filename);
+            region.filename = owned_filename;
+            return;
+        }
+
+        if (region.start_line <= header_lines or region.end_line <= header_lines) return;
+        if (original_line_starts.len == 0) return;
+
+        const original_start_line = region.start_line - header_lines;
+        const original_end_line = region.end_line - header_lines;
+        const region_info = base.RegionInfo{
+            .start_line_idx = original_start_line - 1,
+            .start_col_idx = region.start_column - 1,
+            .end_line_idx = original_end_line - 1,
+            .end_col_idx = region.end_column - 1,
+        };
+
+        const line_text = try allocator.dupe(u8, region_info.calculateLineText(original_source, original_line_starts));
+        errdefer allocator.free(line_text);
+        const owned_filename = try allocator.dupe(u8, original_path);
+        errdefer allocator.free(owned_filename);
+
+        allocator.free(region.line_text);
+        if (region.filename) |old_filename| allocator.free(old_filename);
+
+        region.line_text = line_text;
+        region.filename = owned_filename;
+        region.start_line = original_start_line;
+        region.end_line = original_end_line;
+    }
+
+    fn remapSyntheticRootDocumentElement(
+        self: *BuildEnv,
+        allocator: Allocator,
+        element: *reporting.DocumentElement,
+        original_line_starts: []const u32,
+    ) Allocator.Error!void {
+        switch (element.*) {
+            .source_code_region => |*region| try self.remapSyntheticRootSourceRegion(allocator, region, original_line_starts),
+            .source_code_with_underlines => |*underlines| {
+                const old_start_line = underlines.display_region.start_line;
+                try self.remapSyntheticRootSourceRegion(allocator, &underlines.display_region, original_line_starts);
+                const header_lines = self.synthetic_root_header_lines;
+                if (header_lines == 0 or old_start_line <= header_lines) return;
+                for (underlines.underline_regions) |*underline| {
+                    if (underline.start_line > header_lines) {
+                        underline.start_line -= header_lines;
+                    }
+                    if (underline.end_line > header_lines) {
+                        underline.end_line -= header_lines;
+                    }
+                }
+            },
+            else => {},
+        }
+    }
+
+    fn remapSyntheticRootReport(self: *BuildEnv, report: *Report) Allocator.Error!void {
+        if (self.synthetic_root_original_path == null or self.synthetic_root_original_source == null) return;
+
+        if (self.synthetic_root_header_lines == 0) {
+            for (report.document.elements.items) |*element| {
+                try self.remapSyntheticRootDocumentElement(
+                    report.document.allocator,
+                    element,
+                    &.{},
+                );
+            }
+            return;
+        }
+
+        var original_line_starts = try base.RegionInfo.findLineStarts(self.gpa, self.synthetic_root_original_source.?);
+        defer original_line_starts.deinit(self.gpa);
+        for (report.document.elements.items) |*element| {
+            try self.remapSyntheticRootDocumentElement(
+                report.document.allocator,
+                element,
+                original_line_starts.items.items,
+            );
+        }
+    }
+
     pub const DrainedModuleReports = struct {
         abs_path: []const u8,
         reports: []Report,
@@ -2095,10 +2211,15 @@ pub const BuildEnv = struct {
         var out = try self.gpa.alloc(DrainedModuleReports, drained.len);
         var i: usize = 0;
         while (i < drained.len) : (i += 1) {
-            const path = self.moduleToPath(drained[i].pkg_name, drained[i].module_name) catch |err| switch (err) {
+            var path = self.moduleToPath(drained[i].pkg_name, drained[i].module_name) catch |err| switch (err) {
                 error.OutOfMemory => return error.OutOfMemory,
                 error.InvalidPackageName, error.PathOutsideWorkspace => try self.gpa.dupe(u8, ""),
             };
+
+            if (self.syntheticRootDisplayPath(path)) |display_path| {
+                self.gpa.free(path);
+                path = try self.gpa.dupe(u8, display_path);
+            }
 
             // When a package that was compiled against a bumped dependency
             // version has errors, attach its version note to the first error
@@ -2113,6 +2234,10 @@ pub const BuildEnv = struct {
                         break;
                     }
                 }
+            }
+
+            for (drained[i].reports) |*report| {
+                try self.remapSyntheticRootReport(report);
             }
 
             out[i] = .{

--- a/src/ctx/CoreCtx.zig
+++ b/src/ctx/CoreCtx.zig
@@ -652,6 +652,10 @@ fn osCanonicalize(_: ?*anyopaque, std_io: std.Io, path: []const u8, allocator: A
         error.AccessDenied => error.AccessDenied,
         else => error.IoError,
     };
+    // musl realpath can leave Memcheck taint on bytes it has actually written.
+    if (builtin.link_libc and std.valgrind.runningOnValgrind() != 0) {
+        std.valgrind.memcheck.makeMemDefined(buffer[0..len]);
+    }
     return allocator.dupe(u8, buffer[0..len]) catch error.OutOfMemory;
 }
 

--- a/src/ctx/CoreCtx.zig
+++ b/src/ctx/CoreCtx.zig
@@ -652,8 +652,9 @@ fn osCanonicalize(_: ?*anyopaque, std_io: std.Io, path: []const u8, allocator: A
         error.AccessDenied => error.AccessDenied,
         else => error.IoError,
     };
-    // musl realpath can leave Memcheck taint on bytes it has actually written.
+    // musl realpath can leave Memcheck taint on its successful outputs.
     if (builtin.link_libc and std.valgrind.runningOnValgrind() != 0) {
+        std.valgrind.memcheck.makeMemDefined(std.mem.asBytes(&len));
         std.valgrind.memcheck.makeMemDefined(buffer[0..len]);
     }
     return allocator.dupe(u8, buffer[0..len]) catch error.OutOfMemory;

--- a/src/echo_platform/echo.zig
+++ b/src/echo_platform/echo.zig
@@ -18,7 +18,8 @@ const WasmFilesystem = @import("WasmFilesystem.zig");
 const Allocator = std.mem.Allocator;
 const Diagnostics = runner.Diagnostics;
 const ExtraFile = runner.ExtraFile;
-const ReportingConfig = reporting.ReportingConfig;
+
+const REPORT_WIDTH: u32 = 64;
 
 /// Public API.
 pub const std_options: std.Options = .{
@@ -48,16 +49,18 @@ const js = struct {
     extern "env" fn js_stderr(ptr: [*]const u8, len: usize) void;
 };
 
-// --- Diagnostics implementation: emits HTML reports + step labels via js_stderr ---
+// --- Diagnostics implementation: emits terminal reports + step labels via js_stderr ---
 
 fn jsWrite(_: ?*anyopaque, msg: []const u8) void {
     js.js_stderr(msg.ptr, msg.len);
 }
 
 fn jsEmitReport(_: ?*anyopaque, gpa: Allocator, report: *reporting.Report) void {
-    const config = ReportingConfig.initHtml();
     var diag_writer: std.Io.Writer.Allocating = .init(gpa);
-    reporting.renderReportToHtml(report, &diag_writer.writer, config) catch return;
+    defer diag_writer.deinit();
+    var config = reporting.ReportingConfig.initColorTerminal();
+    config.max_line_width = REPORT_WIDTH;
+    reporting.renderReportToTerminal(report, &diag_writer.writer, reporting.ColorPalette.ANSI, config) catch return;
     const output = diag_writer.written();
     if (output.len > 0) {
         js.js_stderr(output.ptr, output.len);

--- a/src/echo_platform/runner.zig
+++ b/src/echo_platform/runner.zig
@@ -35,8 +35,8 @@ pub const RunEchoError = Allocator.Error ||
         EntrypointNotFound,
     };
 
-/// Diagnostic-emission interface. The wasm host renders HTML to `js_stderr`;
-/// the native host renders plain text to its real stderr.
+/// Diagnostic-emission interface. The browser wasm host writes terminal text
+/// to `js_stderr`; the native host writes terminal text to its real stderr.
 pub const Diagnostics = struct {
     ctx: ?*anyopaque,
     vtable: *const VTable,
@@ -72,6 +72,14 @@ pub const ExtraFile = struct {
     name: []const u8,
     content: []const u8,
 };
+
+fn countNewlines(bytes: []const u8) u32 {
+    var count: u32 = 0;
+    for (bytes) |byte| {
+        if (byte == '\n') count += 1;
+    }
+    return count;
+}
 
 /// Caller-controlled paths for the synthetic app & embedded platform files.
 /// Both the wasm and native flows generate a synthetic app whose `app [main!]`
@@ -162,6 +170,12 @@ pub fn runEcho(opts: RunOptions) RunEchoError!u8 {
         return err;
     };
     defer build_env.deinit();
+    build_env.setSyntheticRootSourceMappingWithLineOffset(
+        std.fs.path.basename(opts.paths.app_abs),
+        opts.source,
+        header_str.len,
+        countNewlines(header_str),
+    );
     build_env.filesystem = echo_ctx.io();
 
     build_env.discoverDependencies(opts.paths.app_abs) catch |err| {

--- a/src/echo_platform/www/app.js
+++ b/src/echo_platform/www/app.js
@@ -8,6 +8,140 @@ const modulesListEl = document.getElementById("modules-list");
 const addModuleBtn = document.getElementById("add-module");
 const moduleTemplate = document.getElementById("module-template");
 
+const ANSI_FG_CLASSES = {
+  30: "ansi-fg-black",
+  31: "ansi-fg-red",
+  32: "ansi-fg-green",
+  33: "ansi-fg-yellow",
+  34: "ansi-fg-blue",
+  35: "ansi-fg-magenta",
+  36: "ansi-fg-cyan",
+  37: "ansi-fg-white",
+  90: "ansi-fg-bright-black",
+  91: "ansi-fg-bright-red",
+  92: "ansi-fg-bright-green",
+  93: "ansi-fg-bright-yellow",
+  94: "ansi-fg-bright-blue",
+  95: "ansi-fg-bright-magenta",
+  96: "ansi-fg-bright-cyan",
+  97: "ansi-fg-bright-white",
+};
+
+function resetAnsiState(state) {
+  state.bold = false;
+  state.dim = false;
+  state.italic = false;
+  state.underline = false;
+  state.fg = "";
+}
+
+function freshAnsiState() {
+  const state = {};
+  resetAnsiState(state);
+  return state;
+}
+
+const ansiState = freshAnsiState();
+
+function applyAnsiSgr(params, state) {
+  if (params.length === 0) params = [0];
+
+  for (const code of params) {
+    if (code === 0) {
+      resetAnsiState(state);
+    } else if (code === 1) {
+      state.bold = true;
+    } else if (code === 2) {
+      state.dim = true;
+    } else if (code === 3) {
+      state.italic = true;
+    } else if (code === 4) {
+      state.underline = true;
+    } else if (code === 22) {
+      state.bold = false;
+      state.dim = false;
+    } else if (code === 23) {
+      state.italic = false;
+    } else if (code === 24) {
+      state.underline = false;
+    } else if (code === 39) {
+      state.fg = "";
+    } else if (ANSI_FG_CLASSES[code]) {
+      state.fg = ANSI_FG_CLASSES[code];
+    }
+  }
+}
+
+function ansiClassName(state) {
+  return [
+    state.bold && "ansi-bold",
+    state.dim && "ansi-dim",
+    state.italic && "ansi-italic",
+    state.underline && "ansi-underline",
+    state.fg,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function appendAnsiText(parent, text, state) {
+  if (!text) return;
+
+  const className = ansiClassName(state);
+  if (!className) {
+    parent.appendChild(document.createTextNode(text));
+    return;
+  }
+
+  const span = document.createElement("span");
+  span.className = className;
+  span.textContent = text;
+  parent.appendChild(span);
+}
+
+function appendAnsi(parent, text, state) {
+  let index = 0;
+
+  while (index < text.length) {
+    const esc = text.indexOf("\u001b", index);
+    if (esc === -1) {
+      appendAnsiText(parent, text.slice(index), state);
+      break;
+    }
+
+    appendAnsiText(parent, text.slice(index, esc), state);
+    index = esc + 1;
+
+    if (text[index] !== "[") continue;
+
+    const finalIndex = text.slice(index + 1).search(/[@-~]/);
+    if (finalIndex === -1) break;
+
+    const end = index + 1 + finalIndex;
+    if (text[end] === "m") {
+      const body = text.slice(index + 1, end);
+      const params = body
+        ? body
+            .split(";")
+            .map((part) => (part === "" ? 0 : Number(part)))
+            .filter((value) => Number.isInteger(value))
+        : [0];
+      applyAnsiSgr(params, state);
+    }
+    index = end + 1;
+  }
+}
+
+function appendErrorsTerminal(text) {
+  let terminal = errorsEl.querySelector(".terminal");
+  if (!terminal) {
+    terminal = document.createElement("pre");
+    terminal.className = "terminal";
+    errorsEl.appendChild(terminal);
+  }
+  appendAnsi(terminal, text, ansiState);
+}
+
 const importObject = {
   env: {
     js_echo(ptr, len) {
@@ -16,24 +150,19 @@ const importObject = {
     },
     js_stderr(ptr, len) {
       const bytes = new Uint8Array(wasm.instance.exports.memory.buffer, ptr, len);
-      errorsEl.innerHTML += decoder.decode(bytes);
+      appendErrorsTerminal(decoder.decode(bytes));
     },
   },
 };
 
 function appendTrapNotice(err) {
-  const div = document.createElement("div");
-  div.className = "report error";
-  const h = document.createElement("h1");
-  h.textContent = "Compiler crashed";
-  const p = document.createElement("pre");
-  p.textContent =
-    "The Roc compiler hit an unrecoverable error while compiling your code. " +
-    "This is a bug in Roc — please report it.\n\n" +
-    String(err);
-  div.appendChild(h);
-  div.appendChild(p);
-  errorsEl.appendChild(div);
+  appendErrorsTerminal(
+    "\u001b[1;31mCompiler crashed\u001b[0m\n" +
+      "The Roc compiler hit an unrecoverable error while compiling your code. " +
+      "This is a bug in Roc - please report it.\n\n" +
+      String(err) +
+      "\n",
+  );
 }
 
 async function reinstantiate() {
@@ -77,7 +206,8 @@ function appendSkipNotice(msg) {
 
 async function run() {
   outputEl.textContent = "";
-  errorsEl.innerHTML = "";
+  errorsEl.textContent = "";
+  resetAnsiState(ansiState);
 
   let trapped = false;
   let code = 255;
@@ -112,7 +242,7 @@ async function run() {
     return;
   }
 
-  if (code === 255 && !errorsEl.innerHTML) {
+  if (code === 255 && !errorsEl.textContent) {
     errorsEl.textContent = "Compilation or execution failed";
   } else if (code !== 0 && code !== 255) {
     outputEl.textContent += `Exit code: ${code}\n`;

--- a/src/echo_platform/www/index.html
+++ b/src/echo_platform/www/index.html
@@ -64,6 +64,13 @@
             #errors {
                 padding: 0.5em 0;
             }
+            #errors .terminal {
+                background: #111;
+                color: #ddd;
+                padding: 1em;
+                white-space: pre-wrap;
+                overflow-x: auto;
+            }
             button {
                 padding: 0.4em 1.2em;
                 font-size: 14px;
@@ -78,31 +85,65 @@
             #add-module {
                 margin-bottom: 0.5em;
             }
-            .report {
-                border-left: 3px solid #ccc;
-                padding: 0.5em 1em;
-                margin: 0.5em 0;
-                font-size: 13px;
+            .ansi-bold {
+                font-weight: 700;
             }
-            .report.error {
-                border-color: #e55;
-                background: #fee;
+            .ansi-dim {
+                opacity: 0.72;
             }
-            .report.warning {
-                border-color: #ea0;
-                background: #ffe;
+            .ansi-italic {
+                font-style: italic;
             }
-            .report.info {
-                border-color: #48f;
-                background: #eef;
+            .ansi-underline {
+                text-decoration: underline;
             }
-            .report h1 {
-                font-size: 14px;
-                margin: 0 0 0.25em;
+            .ansi-fg-black {
+                color: #282a36;
             }
-            .report pre {
-                margin: 0.25em 0;
-                white-space: pre-wrap;
+            .ansi-fg-red {
+                color: #ff6b6b;
+            }
+            .ansi-fg-green {
+                color: #62d68f;
+            }
+            .ansi-fg-yellow {
+                color: #f4d35e;
+            }
+            .ansi-fg-blue {
+                color: #74b9ff;
+            }
+            .ansi-fg-magenta {
+                color: #d59cff;
+            }
+            .ansi-fg-cyan {
+                color: #55e6d9;
+            }
+            .ansi-fg-white {
+                color: #f5f2ff;
+            }
+            .ansi-fg-bright-black {
+                color: #8b90a3;
+            }
+            .ansi-fg-bright-red {
+                color: #ff8a8a;
+            }
+            .ansi-fg-bright-green {
+                color: #7ee89f;
+            }
+            .ansi-fg-bright-yellow {
+                color: #ffea7a;
+            }
+            .ansi-fg-bright-blue {
+                color: #9ad4ff;
+            }
+            .ansi-fg-bright-magenta {
+                color: #e0b3ff;
+            }
+            .ansi-fg-bright-cyan {
+                color: #71fff1;
+            }
+            .ansi-fg-bright-white {
+                color: #fff;
             }
             .skip-notice {
                 color: #a60;

--- a/test/echo-wasm-test/main.zig
+++ b/test/echo-wasm-test/main.zig
@@ -227,7 +227,7 @@ pub fn main(init: std.process.Init) anyerror!void {
         \\main! = |_| {
         \\    todos = [
         \\        { name: "Learn Roc", done: True },
-        \\        { nam: "Call mom", done: False },
+        \\        { label: "Call mom", done: False },
         \\    ]
         \\    Ok({})
         \\}

--- a/test/echo-wasm-test/main.zig
+++ b/test/echo-wasm-test/main.zig
@@ -82,13 +82,13 @@ fn resetCapturedOutput() void {
 }
 
 fn requireContains(haystack: []const u8, needle: []const u8, label: []const u8) void {
-    if (std.mem.indexOf(u8, haystack, needle) != null) return;
+    if (std.mem.find(u8, haystack, needle) != null) return;
     std.debug.print("FAIL: expected {s} to contain {s}\n{s}\n", .{ label, needle, haystack });
     std.process.exit(1);
 }
 
 fn requireNotContains(haystack: []const u8, needle: []const u8, label: []const u8) void {
-    if (std.mem.indexOf(u8, haystack, needle) == null) return;
+    if (std.mem.find(u8, haystack, needle) == null) return;
     std.debug.print("FAIL: expected {s} not to contain {s}\n{s}\n", .{ label, needle, haystack });
     std.process.exit(1);
 }

--- a/test/echo-wasm-test/main.zig
+++ b/test/echo-wasm-test/main.zig
@@ -54,6 +54,45 @@ fn writeBytesToWasm(instance: *bytebox.ModuleInstance, alloc_handle: bytebox.Fun
     return .{ .ptr = ptr, .len = @intCast(data.len) };
 }
 
+fn invokeInit(instance: *bytebox.ModuleInstance, init_handle: bytebox.FunctionHandle) anyerror!void {
+    var params = [_]bytebox.Val{};
+    var returns = [_]bytebox.Val{};
+    try instance.invoke(init_handle, &params, &returns, .{});
+}
+
+fn compileAndRunSource(
+    instance: *bytebox.ModuleInstance,
+    alloc_handle: bytebox.FunctionHandle,
+    run_handle: bytebox.FunctionHandle,
+    source: []const u8,
+) anyerror!u32 {
+    const main_buf = try writeBytesToWasm(instance, alloc_handle, source);
+    var run_params = [_]bytebox.Val{
+        .{ .I32 = @intCast(main_buf.ptr) },
+        .{ .I32 = @intCast(main_buf.len) },
+    };
+    var run_returns = [_]bytebox.Val{.{ .I32 = 0 }};
+    try instance.invoke(run_handle, &run_params, &run_returns, .{});
+    return @intCast(run_returns[0].I32);
+}
+
+fn resetCapturedOutput() void {
+    capture_ctx.echoed.clearRetainingCapacity();
+    capture_ctx.stderr.clearRetainingCapacity();
+}
+
+fn requireContains(haystack: []const u8, needle: []const u8, label: []const u8) void {
+    if (std.mem.indexOf(u8, haystack, needle) != null) return;
+    std.debug.print("FAIL: expected {s} to contain {s}\n{s}\n", .{ label, needle, haystack });
+    std.process.exit(1);
+}
+
+fn requireNotContains(haystack: []const u8, needle: []const u8, label: []const u8) void {
+    if (std.mem.indexOf(u8, haystack, needle) == null) return;
+    std.debug.print("FAIL: expected {s} not to contain {s}\n{s}\n", .{ label, needle, haystack });
+    std.process.exit(1);
+}
+
 pub fn main(init: std.process.Init) anyerror!void {
     const io = init.io;
 
@@ -121,12 +160,7 @@ pub fn main(init: std.process.Init) anyerror!void {
     const addfile_handle = try module_instance.getFunctionHandle("addFile");
     const run_handle = try module_instance.getFunctionHandle("compileAndRun");
 
-    // init()
-    {
-        var params = [_]bytebox.Val{};
-        var returns = [_]bytebox.Val{};
-        try module_instance.invoke(init_handle, &params, &returns, .{});
-    }
+    try invokeInit(module_instance, init_handle);
 
     // addFile("Greeting", "<content>")
     const greeting_name = try writeBytesToWasm(module_instance, alloc_handle, "Greeting");
@@ -162,15 +196,7 @@ pub fn main(init: std.process.Init) anyerror!void {
         \\    Ok({})
         \\}
     ;
-    const main_buf = try writeBytesToWasm(module_instance, alloc_handle, main_src);
-    var run_params = [_]bytebox.Val{
-        .{ .I32 = @intCast(main_buf.ptr) },
-        .{ .I32 = @intCast(main_buf.len) },
-    };
-    var run_returns = [_]bytebox.Val{.{ .I32 = 0 }};
-    try module_instance.invoke(run_handle, &run_params, &run_returns, .{});
-
-    const exit_code: u32 = @intCast(run_returns[0].I32);
+    const exit_code = try compileAndRunSource(module_instance, alloc_handle, run_handle, main_src);
 
     const expected_output = "Hello from the Greeting module!\n";
     const got_output = capture_ctx.echoed.items;
@@ -194,5 +220,33 @@ pub fn main(init: std.process.Init) anyerror!void {
         std.process.exit(1);
     }
 
-    std.debug.print("PASS: echo.wasm tutorial example produced expected output.\n", .{});
+    resetCapturedOutput();
+    try invokeInit(module_instance, init_handle);
+
+    const bad_src =
+        \\main! = |_| {
+        \\    todos = [
+        \\        { name: "Learn Roc", done: True },
+        \\        { nam: "Call mom", done: False },
+        \\    ]
+        \\    Ok({})
+        \\}
+    ;
+    const bad_exit_code = try compileAndRunSource(module_instance, alloc_handle, run_handle, bad_src);
+    const bad_stderr = capture_ctx.stderr.items;
+
+    if (bad_exit_code != 255) {
+        std.debug.print("FAIL: bad source returned exit code {d}\n", .{bad_exit_code});
+        std.debug.print("stderr:\n{s}\n", .{bad_stderr});
+        std.process.exit(1);
+    }
+
+    requireContains(bad_stderr, "TYPE MISMATCH", "diagnostic stderr");
+    requireContains(bad_stderr, "\xE2\x94", "diagnostic stderr");
+    requireContains(bad_stderr, "main.roc", "diagnostic stderr");
+    requireNotContains(bad_stderr, "/app/main.roc", "diagnostic stderr");
+    requireNotContains(bad_stderr, "<div", "diagnostic stderr");
+    requireNotContains(bad_stderr, "<span", "diagnostic stderr");
+
+    std.debug.print("PASS: echo.wasm tutorial and diagnostic cases produced expected output.\n", .{});
 }


### PR DESCRIPTION
This changes the echo wasm host to emit the same terminal diagnostics as native Roc instead of HTML reports, so browser consumers can render the box-art diagnostics rather than escaped markup. It also carries the synthetic root source mapping through drained reports so generated header lines are removed and diagnostics refer to the user source filename instead of the synthetic `/app/main.roc` path.