### PR TITLE
Document well-known static dispatch methods

### DIFF
--- a/docs/langref/loops.md
+++ b/docs/langref/loops.md
@@ -20,7 +20,11 @@ A loop body only includes statements; it does not have a final expression. The l
 
 ### Iterating over types that have `iter`
 
-`for` can also be used on types that have an `iter` method, as long as that method returns an [`Iter`](builtins/Iter). For example, [`List`](builtins/list) has (`List.iter`)[builtins/List#iter], so you can do a `for` loop over a list:
+`for` can also be used on types that have an
+[`iter`](static-dispatch.md#iteration) method, as long as that method returns an
+[`Iter`](../builtins/Iter). The loop then calls `next` on the returned iterator.
+For example, [`List`](../builtins/List) has `List.iter`, so you can do a `for`
+loop over a list:
 
 ```roc
 var $sum = 0

--- a/docs/langref/numbers.md
+++ b/docs/langref/numbers.md
@@ -137,6 +137,9 @@ Here's what will happen if you write this:
 * `Ratio.from_numeral` will return a `Try` representing whether the specified digits are a valid `Ratio`. (Some custom number types may have limits on the size of the numbers they store, may or may not support negative numbers, may or may not support digits after the decimal point, etc.)
   * If `Ratio.from_numeral` returned a [`Try.Ok`](../builtins/Try) tag, then that tag's [payload](tag-unions#payloads) will contain the actual number value that these digits resolved to.
   * If it returned an `Err`, then (since this is all being evaluated at compile time), the compiler will report an error for this number literal before the program even runs.
+
+`from_numeral` is one of Roc's
+[well-known static-dispatch methods](static-dispatch.md#literal-conversion).
   
 ### Inferred Custom Number Types
 

--- a/docs/langref/operators.md
+++ b/docs/langref/operators.md
@@ -2,7 +2,25 @@
 
 ## Desugaring
 
-TODO
+Several operators are syntax for [well-known static-dispatch methods](static-dispatch.md#well-known-methods).
+The method is selected at compile time from the operand types.
+
+| Operator | Method |
+| --- | --- |
+| `+` | `plus` |
+| `-` | `minus` |
+| `*` | `times` |
+| `/` | `div_by` |
+| `//` | `div_trunc_by` |
+| `%` | `rem_by` |
+| `==` | `is_eq` |
+| `!=` | `is_eq`, then `Bool.not` |
+| `<` | `is_lt` |
+| `<=` | `is_lte` |
+| `>` | `is_gt` |
+| `>=` | `is_gte` |
+| `-x` | `negate` |
+| `!x` | `not` |
 
 ## Binary Infix Operations
 
@@ -16,11 +34,16 @@ TODO
 
 ### Arithmetic Operators
 
-TODO
+Arithmetic operators dispatch to methods on the left operand. Their result type
+is the left operand's type, but the right operand can have a different type if
+the method signature allows it. See [Operators](static-dispatch.md#operators)
+in the static dispatch page.
 
 ### Comparison Operators
 
-TODO
+Comparison operators dispatch to methods that return `Bool`. Both operands must
+have the same type. See [Operators](static-dispatch.md#operators) in the static
+dispatch page.
 
 ### `??` (default value on `Err`)
 
@@ -52,11 +75,12 @@ Unlike the `?` operator which propagates errors via early return, `??` handles t
 
 ### `-` (`.negate()`)
 
-TODO
+Unary `-x` dispatches to `x.negate()`. The operand and result have the same
+type.
 
 ### `!` (`.not()`)
 
-TODO
+Unary `!x` dispatches to `x.not()`. The operand and result have the same type.
 
 ## Unary Postfix Operators
 

--- a/docs/langref/static-dispatch.md
+++ b/docs/langref/static-dispatch.md
@@ -8,14 +8,15 @@ at compile time affect which function gets run. This is in contrast to [_dynamic
 which uses runtime information to decide which function gets run.
 
 Roc's only ad hoc polymorphism system is static dispatch, and dynamic dispatch is unsupported
-by design. A major reason for this is that Roc's static dispatch has no runtime overhead; 
-after compilation, it's exactly as if you had called the function directly. (In contrast, 
-it's impossible to avoid runtime overhead in dynamic dispatch, because it has to process 
-information at runtime to do the dispatch.) 
+by design. A major reason for this is that Roc's static dispatch has no runtime overhead;
+after compilation, it's exactly as if you had called the function directly. (In contrast,
+it's impossible to avoid runtime overhead in dynamic dispatch, because it has to process
+information at runtime to do the dispatch.)
 
 ## Methods
 
-A _method_ is a function that's associated with a type and are defined in the `.{ }` block after a nominal type:
+A _method_ is a function associated with a type. On a nominal type, methods are
+defined in the `.{ }` block after the type declaration:
 
 ```roc
 Counter := { value: I64 }.{
@@ -32,46 +33,63 @@ counter : Counter
 counter = Counter.new().increment()
 ```
 
-## Special Methods
+Most method names are only used when they are called explicitly. Some names are
+also recognized by language syntax or builtin APIs. Defining one of those
+well-known methods opts the type into that syntax or API while still using
+ordinary static dispatch.
 
-Roc recognizes certain method names as having special meaning. When defined on a nominal type, these methods are called automatically in specific contexts.
+## Well-Known Methods
+
+These methods are not dynamic interfaces. The checker resolves each use to a
+specific method implementation, and later compilation emits a direct call or a
+derived structural operation. This table is not a limit on method names;
+packages can define and require their own methods with `where` clauses.
+
+| Method | Used by | Implement when |
+| --- | --- | --- |
+| `to_inspect : T -> Str` | `Str.inspect(value)` | The type needs a custom debug representation. |
+| `is_eq : T, T -> Bool` | `==`, `!=` | Equality should be available or customized. |
+| `to_hash : T, Hasher -> Hasher` | `Dict`, `Set`, and hash-based APIs | Values of the type should participate in hashing. |
+| `plus`, `minus`, `times`, `div_by`, `div_trunc_by`, `rem_by` | `+`, `-`, `*`, `/`, `//`, `%` | The type has arithmetic-like operations. |
+| `is_lt`, `is_lte`, `is_gt`, `is_gte` | `<`, `<=`, `>`, `>=` | The type has an ordering. |
+| `negate`, `not` | Unary `-`, unary `!` | The type has a unary negation or complement operation. |
+| `from_numeral : Num.Numeral -> Try(T, [InvalidNumeral(Str)])` | Number literals with target type `T` | Plain numeric literal syntax should construct the type. |
+| `from_quote : Str -> Try(T, [BadQuotedBytes(Str)])` | Quoted string literals with target type `T` | Plain quoted literal syntax should construct the type. |
+| `from_interpolation : Str, Iter((item, Str)) -> T` | Interpolated string literals with target type `T` | Interpolation should construct the type. |
+| `iter : T -> Iter(item)` | `for item in value` | The type should be iterable in `for` loops. |
+| `next` | `for` loop iteration steps | Usually provided by `Iter`; collection authors usually implement `iter`. |
+| `parser_for : encoding -> (state -> Try({ value : T, rest : state }, err))` | Generic parser APIs such as JSON parsing | A format should be able to parse the type. |
+| `encode_to : T, encoding -> (state -> Try(state, err))` | Generic encoder APIs such as JSON encoding | A format should be able to encode the type. |
 
 ### `to_inspect`
 
 The `to_inspect` method customizes how a value is rendered by `Str.inspect`.
+Use it for debug, logging, and test-failure output.
 
 ```roc
 Color := [Red, Green, Blue].{
     to_inspect : Color -> Str
     to_inspect = |color| match color {
-        Red => "Color::Red"
-        Green => "Color::Green"
-        Blue => "Color::Blue"
+        Red => "Color.Red"
+        Green => "Color.Green"
+        Blue => "Color.Blue"
     }
 }
 ```
 
-When `Str.inspect` is called on a `Color` value, it uses the `to_inspect` method instead of the default rendering:
+When `Str.inspect` is called on a `Color` value, it uses `Color.to_inspect`:
 
 ```roc
 red : Color
 red = Red
 
-Str.inspect(red)  # "Color::Red"
+Str.inspect(red)  # "Color.Red"
 ```
 
-Without a `to_inspect` method, the default rendering includes the type name:
+Without `to_inspect`, `Str.inspect` uses Roc's built-in structural
+representation for the value.
 
-```roc
-ColorDefault := [Red, Green, Blue]
-
-c : ColorDefault
-c = Red
-
-Str.inspect(c)  # "ColorDefault.Red"
-```
-
-### `is_eq`
+### Equality and Hashing
 
 The `is_eq` method customizes how equality is checked using the `==` and `!=` operators.
 
@@ -95,9 +113,27 @@ expect p1 == p2  # calls Point.is_eq(p1, p2)
 expect (p1 != p2) == False
 ```
 
-### `plus`
+For `!=`, Roc calls `is_eq` and negates the `Bool` result.
 
-The `plus` method customizes the `+` operator for a nominal type.
+The `to_hash` method feeds a value into a `Hasher`:
+
+```roc
+to_hash : T, Hasher -> Hasher
+```
+
+Hash-based APIs use `to_hash` together with `is_eq`. For example, dictionary
+keys must be hashable and comparable. If you define custom equality, make sure
+the hash is consistent with it: equal values must feed the same hash data.
+
+Roc can derive structural equality and hashing for supported structural shapes.
+Define explicit methods when the derived behavior is not the behavior you want,
+or when a nominal type should expose a stable custom definition.
+
+### Operators
+
+Binary arithmetic operators dispatch to methods on the left operand. The return
+type is the left operand's type, but the right operand can have a different
+type if the method signature allows it.
 
 ```roc
 Vec := { x: I64, y: I64 }.{
@@ -115,83 +151,55 @@ v1 = { x: 1, y: 2 }
 v2 : Vec
 v2 = { x: 3, y: 4 }
 
-# v1 + v2  calls Vec.plus(v1, v2), returns { x: 4, y: 6 }
+# v1 + v2 calls Vec.plus(v1, v2)
 ```
 
-### `minus`
-
-The `minus` method customizes the `-` operator for a nominal type.
-
-```roc
-Vec := { x: I64, y: I64 }.{
-    minus : Vec, Vec -> Vec
-    minus = |a, b| { x: a.x - b.x, y: a.y - b.y }
-}
-```
-
-When `-` is used on `Vec` values, it calls the custom `minus` method:
-
-```roc
-v1 : Vec
-v1 = { x: 5, y: 10 }
-
-v2 : Vec
-v2 = { x: 3, y: 4 }
-
-# v1 - v2 calls Vec.minus(v1, v2), returns { x: 2, y: 6 }
-```
-
-### `times`
-
-The `times` method customizes the `*` operator for a nominal type.
-
-```roc
-Vec := { x: I64, y: I64 }.{
-    times : Vec, Vec -> Vec
-    times = |a, b| { x: a.x * b.x, y: a.y * b.y }
-}
-```
-
-When `*` is used on `Vec` values, it calls the custom `times` method:
-
-```roc
-v1 : Vec
-v1 = { x: 2, y: 3 }
-
-v2 : Vec
-v2 = { x: 4, y: 5 }
-
-# v1 * v2 calls Vec.times(v1, v2), returns { x: 8, y: 15 }
-```
-### Other Operators
-
-The remaining operators desugar to method calls the same way:
+The arithmetic operator mapping is:
 
 | Operator | Method |
 | --- | --- |
+| `+` | `plus` |
+| `-` | `minus` |
+| `*` | `times` |
 | `/` | `div_by` |
 | `//` | `div_trunc_by` |
 | `%` | `rem_by` |
+
+Comparison operators dispatch to methods whose result is `Bool`. Both operands
+must have the same type.
+
+| Operator | Method |
+| --- | --- |
 | `<` | `is_lt` |
 | `<=` | `is_lte` |
 | `>` | `is_gt` |
 | `>=` | `is_gte` |
-| `-x` (unary) | `negate` |
+
+Unary operators dispatch to methods whose argument and return type are the same:
+
+| Operator | Method |
+| --- | --- |
+| `-x` | `negate` |
 | `!x` | `not` |
 
-Comparison operators return `Bool` and require both operands to have the same
-type. Arithmetic operators are homogeneous in their return type only: `a + b`
-has the type of `a`, but the second argument is the method's to choose — so a
-heterogeneous method like `times : Duration, I64 -> Duration` works with `*`.
+```roc
+Duration := { millis : I64 }.{
+    times : Duration, I64 -> Duration
+    times = |duration, scale| { millis: duration.millis * scale }
+}
 
-### `from_numeral`
+longer : Duration
+longer = Duration.{ millis: 10 } * 3
+```
 
-Number literals dispatch the `from_numeral` method, so a nominal type that
-defines it can be written as a plain literal:
+### Literal Conversion
+
+Number literals dispatch the `from_numeral` method when the target type is a
+nominal type that defines it:
 
 ```roc
 Celsius := { degrees: I64 }.{
-    from_numeral : Numeral -> Try(Celsius, [InvalidNumeral(Str), ..])
+    from_numeral : Num.Numeral -> Try(Celsius, [InvalidNumeral(Str)])
     from_numeral = |n| match I64.from_numeral(n) {
         Ok(degrees) => Ok({ degrees })
         Err(err) => Err(err)
@@ -202,9 +210,107 @@ temp : Celsius
 temp = 21  # calls Celsius.from_numeral
 ```
 
-`Numeral` carries the literal's exact digits, so a custom type can accept
-literals of any size its representation supports, and reject the rest with
+`Num.Numeral` carries the literal's exact digits, so a custom type can accept
+the literal range its representation supports and reject the rest with
 `InvalidNumeral`.
+
+Quoted string literals dispatch `from_quote` when the target type defines it:
+
+```roc
+HttpMethod := [Get, Post, Put, Delete].{
+    from_quote : Str -> Try(HttpMethod, [BadQuotedBytes(Str)])
+    from_quote = |raw| match raw {
+        "GET" => Ok(Get)
+        "POST" => Ok(Post)
+        "PUT" => Ok(Put)
+        "DELETE" => Ok(Delete)
+        _ => Err(BadQuotedBytes("expected GET, POST, PUT, or DELETE"))
+    }
+}
+
+method : HttpMethod
+method = "POST"  # calls HttpMethod.from_quote
+```
+
+If the method returns `Err(BadQuotedBytes(message))`, the compiler reports the
+literal conversion error before the program runs.
+
+Interpolated string literals dispatch `from_interpolation` based on the result
+type. The first argument is the literal segment before the first interpolation.
+The iterator yields each interpolated value paired with the literal segment that
+follows it.
+
+```roc
+# For a target type named Html:
+from_interpolation : Str, Iter((Html, Str)) -> Html
+```
+
+Plain quoted string segments inside an interpolation are always `Str` values;
+the interpolated values are the `item` type in `Iter((item, Str))`.
+
+### Iteration
+
+A `for` loop calls `iter` on the value after `in`. The `iter` method must return
+an `Iter(item)` whose item type matches the loop pattern.
+
+```roc
+Rows := { items : List(Row) }.{
+    iter : Rows -> Iter(Row)
+    iter = |rows| rows.items.iter()
+}
+
+for row in rows {
+    process(row)
+}
+```
+
+The loop then repeatedly calls `next` on the `Iter(item)` value:
+
+```roc
+next : Iter(item) -> [One({ item : item, rest : Iter(item) }), Skip({ rest : Iter(item) }), Done]
+```
+
+Package authors usually implement `iter` for their collection type and build
+the returned iterator with the `Iter` APIs. The `next` method is the hook on the
+iterator value itself.
+
+### Parsing and Encoding
+
+Generic parser and encoder APIs use `parser_for` and `encode_to` to ask a type
+how it should be read or written for a particular format.
+
+```roc
+Token := { raw : Str }.{
+    parser_for : encoding -> (state -> Try({ value : Token, rest : state }, err))
+        where [
+            encoding.parse_str : encoding, state -> Try({ value : Str, rest : state }, err),
+        ]
+    parser_for = |encoding| {
+        Encoding : encoding
+
+        |state| {
+            parsed = Encoding.parse_str(encoding, state)?
+            Ok({ value: Token.{ raw: parsed.value }, rest: parsed.rest })
+        }
+    }
+
+    encode_to : Token, encoding -> (state -> Try(state, err))
+        where [
+            encoding.encode_str : encoding, Str, state -> Try(state, err),
+        ]
+    encode_to = |token, encoding| {
+        Encoding : encoding
+
+        |state| Encoding.encode_str(encoding, token.raw, state)
+    }
+}
+```
+
+Structural records, tag unions, lists, sets, dictionaries, and supported
+builtins can use derived parser and encoder implementations when the selected
+format supports their shape. A nominal type can provide explicit `parser_for`
+or `encode_to` methods when it wants a custom representation or when its
+backing should remain hidden.
 
 ### Number Literal Defaulting
 

--- a/docs/langref/strings.md
+++ b/docs/langref/strings.md
@@ -97,6 +97,17 @@ Bool.true : Bool
 
 Double quotes (`"`), on the other hand, are not type-compatible with integers—not only because strings can be empty (`""` is valid, but `''` is not) but also because there may be more than one code point involved in any given string!
 
+## String literal conversion and interpolation
+
+Double-quoted literals default to `Str`. When a quoted literal has a nominal
+target type, that type can opt in by defining
+[`from_quote`](static-dispatch.md#literal-conversion).
+
+Interpolated string literals use
+[`from_interpolation`](static-dispatch.md#literal-conversion) on the result
+type. The literal segments are `Str` values, and each interpolated value is
+paired with the literal segment that follows it.
+
 ## String equality and normalization
 
 Besides emoji like 👩‍👩‍👦‍👦, another classic example of code points combining to render as one grapheme has to do with accent marks. Try putting these two different strings into `roc repl`:

--- a/docs/langref/types.md
+++ b/docs/langref/types.md
@@ -156,8 +156,9 @@ literal *is* the backing shape, so it lifts by unification.
 
 **Number and string** literals do not implicitly become a nominal. They coerce
 only into a builtin number/string type, or into a nominal that declares its own
-`from_numeral` / `from_quote`. For any other nominal — including a transparent
-newtype like `UserId := U64` — use explicit construction (`UserId.(0)`).
+[`from_numeral` / `from_quote`](static-dispatch.md#literal-conversion). For
+any other nominal — including a transparent newtype like `UserId := U64` — use
+explicit construction (`UserId.(0)`).
 
 A value that already has a concrete type — like the `U64` parameter `n` above —
 must also be constructed explicitly; it does not silently become a different


### PR DESCRIPTION
## Summary
- document the well-known static dispatch methods in the langref
- add cross-links from operators, nominal types, strings, loops, and custom number docs
- clarify iteration, literal conversion, inspect, equality/hash, parser, and encoder hooks

## Testing
- git diff --check