### PR TITLE
Disallow dollar-prefixed record field names

### DIFF
--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -137,6 +137,10 @@ fn isVarIdent(self: *Parser, token: Token.Idx) bool {
     return false;
 }
 
+fn isLowerRecordFieldName(self: *Parser, token: Token.Idx) bool {
+    return self.tok_buf.tokens.items(.tag)[token] == .LowerIdent and !self.isVarIdent(token);
+}
+
 /// Check if the current position looks like a type declaration with a valid type following.
 /// This peeks ahead without consuming tokens to determine if we have:
 /// - `Name :` followed by a valid type start token
@@ -804,9 +808,10 @@ fn parseStringExprTokens(self: *Parser) std.mem.Allocator.Error!AST.Expr.Idx {
 
 fn parseRecordFieldTokens(self: *Parser) std.mem.Allocator.Error!AST.RecordField.Idx {
     const start = self.pos;
-    self.expect(.LowerIdent) catch {
+    if (!self.isLowerRecordFieldName(start)) {
         return try self.pushMalformed(AST.RecordField.Idx, .expected_expr_record_field_name, start);
-    };
+    }
+    self.advance();
     const name = start;
     var value: ?AST.Expr.Idx = null;
     if (self.peek() == .OpColon) {
@@ -4179,6 +4184,13 @@ fn runExprStatementKernel(
             .CloseCurly => continue :expr_kernel .record_finish,
             .LowerIdent => {
                 const field_start = self.pos;
+                if (!self.isLowerRecordFieldName(field_start)) {
+                    const malformed_field = try self.pushMalformed(AST.RecordField.Idx, .expected_expr_record_field_name, field_start);
+                    try self.store.addScratchRecordField(malformed_field);
+                    const expr = try self.pushMalformed(AST.Expr.Idx, .expected_expr_close_curly_or_comma, self.pos);
+                    expr_finish_state = .{ .start = expr_record_state.start, .min_bp = expr_record_state.min_bp, .expr = expr };
+                    continue :expr_kernel .suffix;
+                }
                 self.advance();
                 const name = field_start;
                 if (self.peek() == .OpColon) {
@@ -4825,6 +4837,16 @@ fn runExprStatementKernel(
             // record types. They parse like any other field name.
             .LowerIdent, .Underscore, .NamedUnderscore => {
                 const field_start = self.pos;
+                if (self.peek() == .LowerIdent and !self.isLowerRecordFieldName(field_start)) {
+                    while (self.peek() != .CloseCurly and self.peek() != .Comma and self.peek() != .EndOfFile) {
+                        self.advance();
+                    }
+                    const malformed_field = try self.pushMalformed(AST.AnnoRecordField.Idx, .expected_type_field_name, field_start);
+                    try self.store.addScratchAnnoRecordField(malformed_field);
+                    self.store.clearScratchAnnoRecordFieldsFrom(type_record_state.scratch_top);
+                    last_type_anno = try self.pushMalformed(AST.TypeAnno.Idx, .expected_ty_close_curly_or_comma, self.pos);
+                    continue :expr_kernel .type_complete;
+                }
                 const name = self.pos;
                 self.advance();
                 if (self.peek() != .OpColon) {
@@ -6102,6 +6124,13 @@ fn runExprStatementKernel(
             },
             .LowerIdent => {
                 const field_start = self.pos;
+                if (!self.isLowerRecordFieldName(field_start)) {
+                    while (self.peek() != .EndOfFile and self.peek() != .CloseCurly) {
+                        self.advance();
+                    }
+                    last_pattern = try self.pushMalformed(AST.Pattern.Idx, .expected_lower_ident_pat_field_name, field_start);
+                    continue :expr_kernel .pattern_complete;
+                }
                 const name = self.pos;
                 self.advance();
                 if (self.peek() == .Comma or self.peek() == .CloseCurly) {

--- a/src/parse/mod.zig
+++ b/src/parse/mod.zig
@@ -189,6 +189,44 @@ test "bare .. in expression position is a helpful parse error" {
     );
 }
 
+test "dollar-prefixed record field names are rejected" {
+    const gpa = std.testing.allocator;
+
+    const Case = struct {
+        source: []const u8,
+        parse: *const fn (Allocator, *CommonEnv) Allocator.Error!*AST,
+        tag: AST.Diagnostic.Tag,
+    };
+
+    for ([_]Case{
+        .{
+            .source = "{ $field : \"value\" }",
+            .parse = expr,
+            .tag = .expected_expr_record_field_name,
+        },
+        .{
+            .source = "value : { $field : Str }",
+            .parse = statement,
+            .tag = .expected_type_field_name,
+        },
+        .{
+            .source = "match value { { $field } => $field }",
+            .parse = expr,
+            .tag = .expected_lower_ident_pat_field_name,
+        },
+    }) |case| {
+        var env = try CommonEnv.init(gpa, case.source);
+        defer env.deinit(gpa);
+
+        const ast = try case.parse(gpa, &env);
+        defer ast.deinit();
+
+        try std.testing.expectEqual(@as(usize, 0), ast.tokenize_diagnostics.items.len);
+        try std.testing.expect(ast.parse_diagnostics.items.len > 0);
+        try std.testing.expectEqual(case.tag, ast.parse_diagnostics.items[0].tag);
+    }
+}
+
 fn vmExprAllocationFailureImpl(allocator: Allocator, tokens: tokenize.TokenizedBuffer) Allocator.Error!void {
     var parser = try Parser.init(tokens, allocator);
     defer parser.store.deinit();

--- a/test/snapshots/records/dollar_prefix_field_name.md
+++ b/test/snapshots/records/dollar_prefix_field_name.md
@@ -1,0 +1,58 @@
+# META
+~~~ini
+description=Dollar-prefixed record field names are rejected
+type=expr
+~~~
+# SOURCE
+~~~roc
+{ $field : "value" }
+~~~
+# EXPECTED
+PARSE ERROR - dollar_prefix_field_name.md:1:3:1:9
+PARSE ERROR - dollar_prefix_field_name.md:1:10:1:11
+# PROBLEMS
+
+┌─────────────┐
+│ PARSE ERROR ├─ A parsing error occurred: expected_expr_record_field_name ───┐
+└┬────────────┘                                                               │
+ │                                                                            │
+ │  { $field : "value" }                                                      │
+ │    ‾‾‾‾‾‾                                                                  │
+ └─────────────────────────────────────────── dollar_prefix_field_name.md:1:3 ┘
+
+    This is an unexpected parsing error. Please check your syntax.
+
+
+┌─────────────┐
+│ PARSE ERROR ├─ A parsing error occurred: ───────────────────────────────────┐
+└┬────────────┘  expected_expr_close_curly_or_comma                           │
+ │                                                                            │
+ │  { $field : "value" }                                                      │
+ │           ‾                                                                │
+ └────────────────────────────────────────── dollar_prefix_field_name.md:1:10 ┘
+
+    This is an unexpected parsing error. Please check your syntax.
+
+# TOKENS
+~~~zig
+OpenCurly,LowerIdent,OpColon,StringStart,StringPart,StringEnd,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-malformed (reason "expected_expr_close_curly_or_comma"))
+~~~
+# FORMATTED
+~~~roc
+
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir (empty true))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(expressions))
+~~~


### PR DESCRIPTION
Disallows `$`-prefixed identifiers as record field labels during parsing, while keeping `$` identifiers available where they mean reassignable variables. This rejects record literals such as `{ $field : "value" }` at the parser boundary, matching the existing field-access syntax that cannot address such labels. Fixes #9936.