### PR TITLE
Warn on effectful functions without bang names

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -444,6 +444,10 @@ bench_probe_refuted: usize = 0,
 /// Union-find roots resolve at consumption time (eager roots would go stale).
 /// Duplicates are harmless — the consumer inserts into a set.
 checked_lambda_params: std.ArrayListUnmanaged(CIR.Pattern.Span),
+/// Lambdas whose bodies actually perform effects. This records direct checker
+/// output so binding-name diagnostics do not infer effectfulness from
+/// annotations that only make a pure body have an effectful function type.
+effectful_lambda_bodies: std.AutoHashMap(CIR.Expr.Idx, void),
 /// Scratch for `beginCommitProbe`: the caller env's var-pool length per rank
 /// at probe start, restored on a failed probe's rollback. One buffer suffices
 /// because commit-probes never nest — but the type store's trail-based
@@ -1301,6 +1305,7 @@ fn initAssumePrepared(
         .known_empty_payload_vars_destructure = .empty,
         .known_empty_payload_vars_match = .empty,
         .checked_lambda_params = .empty,
+        .effectful_lambda_bodies = std.AutoHashMap(CIR.Expr.Idx, void).init(gpa),
         .probe_var_pool_lens = .empty,
     };
 
@@ -1413,6 +1418,7 @@ pub fn deinit(self: *Self) void {
     self.known_empty_payload_vars_destructure.deinit(self.gpa);
     self.known_empty_payload_vars_match.deinit(self.gpa);
     self.checked_lambda_params.deinit(self.gpa);
+    self.effectful_lambda_bodies.deinit();
     self.probe_var_pool_lens.deinit(self.gpa);
 }
 
@@ -7310,6 +7316,25 @@ fn varIsEffectfulFunction(self: *Self, var_: Var) bool {
     }
 }
 
+fn exprHasEffectfulFunctionBody(self: *const Self, expr_idx: CIR.Expr.Idx) bool {
+    return switch (self.cir.store.getExpr(expr_idx)) {
+        .e_lambda => self.effectful_lambda_bodies.contains(expr_idx),
+        .e_closure => |closure| self.effectful_lambda_bodies.contains(closure.lambda_idx),
+        .e_hosted_lambda => true,
+        else => false,
+    };
+}
+
+fn checkEffectfulFunctionName(self: *Self, pattern_idx: CIR.Pattern.Idx, expr_idx: CIR.Expr.Idx) std.mem.Allocator.Error!void {
+    const ident = self.getPatternIdent(pattern_idx) orelse return;
+    if (ident.attributes.effectful) return;
+    if (!self.exprHasEffectfulFunctionBody(expr_idx)) return;
+
+    _ = try self.problems.appendProblem(self.gpa, .{ .effectful_function_name = .{
+        .region = self.cir.store.getNodeRegion(ModuleEnv.nodeIdxFrom(pattern_idx)),
+    } });
+}
+
 fn varHasUnresolvedContent(
     self: *Self,
     var_: Var,
@@ -8274,6 +8299,9 @@ fn checkDef(self: *Self, def_idx: CIR.Def.Idx, env: *Env) std.mem.Allocator.Erro
         try self.erroneous_value_patterns.put(self.gpa, def.pattern, {});
     }
     try self.closeAbsentConstructedPayloadVars(def.expr, expr_var);
+    if (isFunctionDef(&self.cir.store, self.cir.store.getExpr(def.expr))) {
+        try self.checkEffectfulFunctionName(def.pattern, def.expr);
+    }
 
     if (self.defer_generalize) {
         // defer_generalize is only set when a cycle root has been identified.
@@ -11600,6 +11628,7 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
 
             // Create the function type
             if (body_does_fx) {
+                try self.effectful_lambda_bodies.put(expr_idx, {});
                 try self.unifyWith(expr_var, try self.types.mkFuncEffectful(arg_vars, body_var), env);
             } else {
                 try self.unifyWith(expr_var, try self.types.mkFuncUnbound(arg_vars, body_var), env);
@@ -13364,6 +13393,9 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                     try self.erroneous_value_patterns.put(self.gpa, decl_stmt.pattern, {});
                 }
                 try self.closeAbsentConstructedPayloadVars(decl_stmt.expr, decl_expr_var);
+                if (decl_is_fn) {
+                    try self.checkEffectfulFunctionName(decl_stmt.pattern, decl_stmt.expr);
+                }
 
                 // A record-destructure binding gets a dedicated context so the
                 // report can suggest `field: _` or `..` when the pattern is too

--- a/src/check/problem.zig
+++ b/src/check/problem.zig
@@ -70,6 +70,7 @@ pub const AnnotationOnlyValue = types.AnnotationOnlyValue;
 pub const PolymorphicVarAnnotation = types.PolymorphicVarAnnotation;
 pub const EffectfulTopLevel = types.EffectfulTopLevel;
 pub const EffectfulExpect = types.EffectfulExpect;
+pub const EffectfulFunctionName = types.EffectfulFunctionName;
 
 // Comptime errors
 pub const ComptimeCrash = types.ComptimeCrash;

--- a/src/check/problem/types.zig
+++ b/src/check/problem/types.zig
@@ -43,6 +43,7 @@ pub const Problem = union(enum) {
     polymorphic_var_annotation: PolymorphicVarAnnotation,
     effectful_top_level: EffectfulTopLevel,
     effectful_expect: EffectfulExpect,
+    effectful_function_name: EffectfulFunctionName,
     annotation_only_value: AnnotationOnlyValue,
     hosted_unboxed_function: HostedUnboxedFunction,
     host_boundary_open_row: HostBoundaryOpenRow,
@@ -139,6 +140,11 @@ pub const EffectfulTopLevel = struct {
 
 /// An expect expression performs effects while evaluating its condition.
 pub const EffectfulExpect = struct {
+    region: base.Region,
+};
+
+/// Warning for an effectful function binding whose name does not end in `!`.
+pub const EffectfulFunctionName = struct {
     region: base.Region,
 };
 

--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -78,6 +78,7 @@ const AnnotationOnlyValue = problem_mod.AnnotationOnlyValue;
 const PolymorphicVarAnnotation = problem_mod.PolymorphicVarAnnotation;
 const EffectfulTopLevel = problem_mod.EffectfulTopLevel;
 const EffectfulExpect = problem_mod.EffectfulExpect;
+const EffectfulFunctionName = problem_mod.EffectfulFunctionName;
 
 // Comptime errors
 const ComptimeCrash = problem_mod.ComptimeCrash;
@@ -213,6 +214,18 @@ pub const ReportBuilder = struct {
         try report.document.addSourceRegion(
             region_info,
             .error_highlight,
+            self.filename,
+            self.source,
+            self.module_env.getLineStarts(),
+        );
+    }
+
+    /// Add source code warning highlighting for a region.
+    fn addSourceWarningRegion(self: *Self, report: *Report, region: Region) Allocator.Error!void {
+        const region_info = self.module_env.calcRegionInfo(region);
+        try report.document.addSourceRegion(
+            region_info,
+            .warning_highlight,
             self.filename,
             self.source,
             self.module_env.getLineStarts(),
@@ -884,6 +897,9 @@ pub const ReportBuilder = struct {
             },
             .effectful_expect => |data| {
                 return self.buildEffectfulExpectReport(data);
+            },
+            .effectful_function_name => |data| {
+                return self.buildEffectfulFunctionNameReport(data);
             },
             .annotation_only_value => |data| {
                 return self.buildAnnotationOnlyValueReport(data);
@@ -3636,6 +3652,22 @@ pub const ReportBuilder = struct {
         try report.document.addLineBreak();
         try D.renderSlice(&.{
             D.bytes("Keep expect conditions pure, and test effectful behavior from a function body instead."),
+        }, self, &report);
+        return report;
+    }
+
+    fn buildEffectfulFunctionNameReport(self: *Self, data: EffectfulFunctionName) Allocator.Error!Report {
+        var report = try Report.init(self.gpa, "Effectful Function Name", "This function performs an effect, so its name must end in `!`.", .warning);
+        errdefer report.deinit();
+
+        try self.addSourceWarningRegion(&report, data.region);
+
+        try report.document.addLineBreak();
+        try report.document.addLineBreak();
+        try D.renderSlice(&.{
+            D.bytes("Add a trailing"),
+            D.bytes("!").withAnnotation(.inline_code),
+            D.bytes("to this function name."),
         }, self, &report);
         return report;
     }

--- a/src/compile/compile_package.zig
+++ b/src/compile/compile_package.zig
@@ -383,7 +383,7 @@ fn problemBlocksCheckedArtifact(problem: check.problem.Problem) bool {
             .recursive_dispatch,
             => true,
         },
-        .redundant_pattern, .unmatchable_pattern, .comptime_unused_branch, .comptime_condition, .literal_defaulted => false,
+        .effectful_function_name, .redundant_pattern, .unmatchable_pattern, .comptime_unused_branch, .comptime_condition, .literal_defaulted => false,
         else => true,
     };
 }
@@ -391,6 +391,7 @@ fn problemBlocksCheckedArtifact(problem: check.problem.Problem) bool {
 fn problemAllowsLoweringWithUserErrors(problem: check.problem.Problem) bool {
     return switch (problem) {
         .static_dispatch => |static_dispatch| staticDispatchAllowsLoweringWithUserErrors(static_dispatch),
+        .effectful_function_name => true,
         .type_mismatch,
         .type_apply_mismatch_arities,
         .cannot_access_opaque_nominal,
@@ -454,6 +455,7 @@ fn problemLoweringWithUserErrorsRationale(kind: check.problem.Problem.Tag) []con
         .polymorphic_var_annotation => "Polymorphic var annotations cannot produce a concrete mutable storage type.",
         .effectful_top_level => "Effectful top-level initialization cannot be represented as a checked constant.",
         .effectful_expect => "Effectful expect evaluation cannot be treated as ordinary lowered user code.",
+        .effectful_function_name => "Effectful function-name reports are warnings and do not block lowering.",
         .annotation_only_value => "Annotation-only values have no runtime expression to lower.",
         .hosted_unboxed_function => "Hosted unboxed functions violate the host boundary representation contract.",
         .host_boundary_open_row => "Open rows at host boundaries have no concrete ABI shape.",

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -993,7 +993,7 @@ const ComptimeProblemReporting = enum {
 
 fn problemBlocksCheckedArtifact(problem: check.problem.Problem) bool {
     return switch (problem) {
-        .redundant_pattern, .unmatchable_pattern, .comptime_unused_branch, .comptime_condition, .literal_defaulted => false,
+        .effectful_function_name, .redundant_pattern, .unmatchable_pattern, .comptime_unused_branch, .comptime_condition, .literal_defaulted => false,
         else => true,
     };
 }

--- a/test/fx/string_pattern_matching.roc
+++ b/test/fx/string_pattern_matching.roc
@@ -5,11 +5,11 @@ import pf.Stdout
 # Tests pattern matching on string literals in match expressions.
 
 main! = || {
-    greet("Alice")
-    greet("Bob")
+    greet!("Alice")
+    greet!("Bob")
 }
 
-greet = |name| {
+greet! = |name| {
     message = match name {
         "Alice" => "Hello Alice!"
         "Bob" => "Hey Bob!"

--- a/test/snapshots/repro_issue_9962_effectful_local_function_name.md
+++ b/test/snapshots/repro_issue_9962_effectful_local_function_name.md
@@ -1,0 +1,160 @@
+# META
+~~~ini
+description=repro for https://github.com/roc-lang/roc/issues/9962 - effectful functions should warn without bang names
+type=file
+~~~
+# SOURCE
+~~~roc
+topThunk = || echo!("top")
+
+main! = |_| {
+    thunk = || echo!("local")
+    thunk()
+    topThunk()
+    Ok({})
+}
+~~~
+# EXPECTED
+EFFECTFUL FUNCTION NAME - repro_issue_9962_effectful_local_function_name.md:1:1:1:9
+EFFECTFUL FUNCTION NAME - repro_issue_9962_effectful_local_function_name.md:4:5:4:10
+# PROBLEMS
+
+┌─────────────────────────┐
+│ EFFECTFUL FUNCTION NAME ├─ This function performs an effect, so its name ───┐
+└┬────────────────────────┘  must end in `!`.                                 │
+ │                                                                            │
+ │  topThunk = || echo!("top")                                                │
+ │  ‾‾‾‾‾‾‾‾                                                                  │
+ └───────────────────── repro_issue_9962_effectful_local_function_name.md:1:1 ┘
+
+    Add a trailing `!` to this function name.
+
+
+┌─────────────────────────┐
+│ EFFECTFUL FUNCTION NAME ├─ This function performs an effect, so its name ───┐
+└┬────────────────────────┘  must end in `!`.                                 │
+ │                                                                            │
+ │  thunk = || echo!("local")                                                 │
+ │  ‾‾‾‾‾                                                                     │
+ └───────────────────── repro_issue_9962_effectful_local_function_name.md:4:5 ┘
+
+    Add a trailing `!` to this function name.
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,OpBar,LowerIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,OpenCurly,
+LowerIdent,OpAssign,OpBar,OpBar,LowerIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,
+LowerIdent,NoSpaceOpenRound,CloseRound,
+LowerIdent,NoSpaceOpenRound,CloseRound,
+UpperIdent,NoSpaceOpenRound,OpenCurly,CloseCurly,CloseRound,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "topThunk"))
+			(e-lambda
+				(args)
+				(e-apply
+					(e-ident (raw "echo!"))
+					(e-string
+						(e-string-part (raw "top"))))))
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-block
+					(statements
+						(s-decl
+							(p-ident (raw "thunk"))
+							(e-lambda
+								(args)
+								(e-apply
+									(e-ident (raw "echo!"))
+									(e-string
+										(e-string-part (raw "local"))))))
+						(e-apply
+							(e-ident (raw "thunk")))
+						(e-apply
+							(e-ident (raw "topThunk")))
+						(e-apply
+							(e-tag (raw "Ok"))
+							(e-record))))))))
+~~~
+# FORMATTED
+~~~roc
+topThunk = || echo!("top")
+
+main! = |_| {
+	thunk = || echo!("local")
+	thunk()
+	topThunk()
+	Ok({})
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "echo!"))
+		(e-hosted-lambda (symbol "echo!")
+			(args
+				(p-assign (ident "_echo_arg"))))
+		(annotation
+			(ty-fn (effectful true)
+				(ty-lookup (name "Str") (builtin))
+				(ty-record))))
+	(d-let
+		(p-assign (ident "topThunk"))
+		(e-lambda
+			(args)
+			(e-call (constraint-fn-var 74)
+				(e-lookup-local
+					(p-assign (ident "echo!")))
+				(e-string
+					(e-literal (string "top"))))))
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-block
+				(s-let
+					(p-assign (ident "thunk"))
+					(e-lambda
+						(args)
+						(e-call (constraint-fn-var 115)
+							(e-lookup-local
+								(p-assign (ident "echo!")))
+							(e-string
+								(e-literal (string "local"))))))
+				(s-expr
+					(e-call (constraint-fn-var 140)
+						(e-lookup-local
+							(p-assign (ident "thunk")))))
+				(s-expr
+					(e-call (constraint-fn-var 142)
+						(e-lookup-local
+							(p-assign (ident "topThunk")))))
+				(e-tag (name "Ok")
+					(args
+						(e-empty_record)))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Str => {}"))
+		(patt (type "({}) => {}"))
+		(patt (type "_arg => [Ok({}), ..]")))
+	(expressions
+		(expr (type "Str => {}"))
+		(expr (type "({}) => {}"))
+		(expr (type "_arg => [Ok({}), ..]"))))
+~~~


### PR DESCRIPTION
Effectful function bindings whose bodies perform platform effects can currently slip through without the `!` naming convention in local scopes. This adds one shared checker warning for effectful function bindings without bang names and calls it from both top-level and local binding checks, without blocking checked artifact publication. Fixes #9962.