### PR TITLE
Fix formatter preserving comments and open tag union vars

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -957,13 +957,21 @@ const Formatter = struct {
     };
 
     fn formatCollection(fmt: *Formatter, region: AST.TokenizedRegion, braces: Braces, comptime T: type, items: []T, formatter: fn (*Formatter, T) FormatAstError!AST.TokenizedRegion) FormatAstError!void {
-        const multiline = fmt.ast.regionIsMultiline(region) or fmt.nodesWillBeMultiline(T, items);
+        const empty_has_comment = items.len == 0 and fmt.regionHasInteriorComment(region);
+        const multiline = fmt.ast.regionIsMultiline(region) or fmt.nodesWillBeMultiline(T, items) or empty_has_comment;
         const curr_indent = fmt.curr_indent;
         defer {
             fmt.curr_indent = curr_indent;
         }
         try fmt.push(braces.start());
         if (items.len == 0) {
+            if (empty_has_comment) {
+                fmt.curr_indent += 1;
+                try fmt.flushCommentsBeforeDiscard(fmt.regionClosingToken(region).?);
+                fmt.curr_indent -= 1;
+                try fmt.ensureNewline();
+                try fmt.pushIndent();
+            }
             try fmt.push(braces.end());
             return;
         }
@@ -1476,6 +1484,7 @@ const Formatter = struct {
 
                 const fields = fmt.ast.store.recordFieldSlice(r.fields);
                 var has_extension = false;
+                const empty_has_comment = r.ext == null and fields.len == 0 and fmt.regionHasInteriorComment(r.region);
 
                 // Handle extension if present
                 if (r.ext) |ext| {
@@ -1527,6 +1536,14 @@ const Formatter = struct {
                     } else if (i < fields.len - 1) {
                         try fmt.pushAll(",");
                     }
+                }
+
+                if (empty_has_comment) {
+                    fmt.curr_indent += 1;
+                    try fmt.flushCommentsBeforeDiscard(fmt.regionClosingToken(r.region).?);
+                    fmt.curr_indent -= 1;
+                    try fmt.ensureNewline();
+                    try fmt.pushIndent();
                 }
 
                 if ((has_extension or fields.len > 0) and !multiline) {
@@ -2151,11 +2168,22 @@ const Formatter = struct {
     /// Format a symbol map section: { "roc_main": main_for_host!, ... }
     fn formatSymbolMapSection(fmt: *Formatter, span: AST.SymbolMapEntry.Span, base_indent: u32) (Allocator.Error || error{WriteFailed})!void {
         const entries = fmt.ast.store.symbolMapEntrySlice(span);
+        const has_comments = fmt.regionHasInteriorComment(span.region);
         if (entries.len == 0) {
+            if (has_comments) {
+                try fmt.push('{');
+                fmt.curr_indent = base_indent + 1;
+                try fmt.flushCommentsBeforeDiscard(fmt.regionClosingToken(span.region).?);
+                fmt.curr_indent = base_indent;
+                try fmt.ensureNewline();
+                try fmt.pushIndent();
+                try fmt.push('}');
+                return;
+            }
             try fmt.pushAll("{}");
             return;
         }
-        if (entries.len <= 2) {
+        if (entries.len <= 2 and !has_comments) {
             try fmt.pushAll("{ ");
             for (entries, 0..) |entry_idx, i| {
                 if (i > 0) {
@@ -2168,12 +2196,15 @@ const Formatter = struct {
         }
         try fmt.push('{');
         for (entries) |entry_idx| {
+            const entry = fmt.ast.store.getSymbolMapEntry(entry_idx);
+            try fmt.flushCommentsBeforeDiscard(entry.region.start);
             try fmt.ensureNewline();
             fmt.curr_indent = base_indent + 1;
             try fmt.pushIndent();
             try fmt.formatSymbolMapEntry(entry_idx);
             try fmt.push(',');
         }
+        try fmt.flushCommentsBeforeDiscard(fmt.regionClosingToken(span.region).?);
         try fmt.ensureNewline();
         fmt.curr_indent = base_indent;
         try fmt.pushIndent();
@@ -2596,7 +2627,7 @@ const Formatter = struct {
                 try fmt.pushAll("provides ");
                 try fmt.formatSymbolMapSection(p.provides, start_indent + 1);
 
-                if (p.hosted.span.len > 0) {
+                if (p.hosted.span.len > 0 or fmt.regionHasInteriorComment(p.hosted.region)) {
                     try fmt.ensureNewline();
                     fmt.curr_indent = start_indent + 1;
                     try fmt.pushIndent();
@@ -2639,6 +2670,14 @@ const Formatter = struct {
             }
             try fmt.ensureNewline();
             fmt.curr_indent -= 1;
+            try fmt.pushIndent();
+            try fmt.push('}');
+        } else if (fmt.regionHasInteriorComment(block.region)) {
+            try fmt.push('{');
+            fmt.curr_indent += 1;
+            try fmt.flushCommentsBeforeDiscard(fmt.regionClosingToken(block.region).?);
+            fmt.curr_indent -= 1;
+            try fmt.ensureNewline();
             try fmt.pushIndent();
             try fmt.push('}');
         } else {
@@ -2848,7 +2887,7 @@ const Formatter = struct {
                             try fmt.pushAll(", ");
                         }
                     }
-                    // Handle open tag unions - always format as just ".." (silently drop any named extension)
+                    // Handle open tag unions.
                     if (is_open) {
                         // Get the token position for flushing comments before the ..
                         const double_dot_token: Token.Idx = switch (t.ext) {
@@ -2862,6 +2901,11 @@ const Formatter = struct {
                             try fmt.pushIndent();
                         }
                         try fmt.pushAll("..");
+                        switch (t.ext) {
+                            .named => |named| try fmt.formatTypeAnnoDiscard(named.anno),
+                            .open => {},
+                            .closed => unreachable,
+                        }
                         if (tag_multiline) {
                             try fmt.push(',');
                         }
@@ -2960,6 +3004,41 @@ const Formatter = struct {
         const start = if (tokenIdx == 0) 0 else fmt.ast.tokens.resolve(tokenIdx - 1).end.offset;
         const end = fmt.ast.tokens.resolve(tokenIdx).start.offset;
         return std.mem.findScalar(u8, fmt.ast.env.source[start..end], '#') != null;
+    }
+
+    fn regionHasInteriorComment(fmt: *Formatter, region: AST.TokenizedRegion) bool {
+        const close_token = fmt.regionClosingToken(region) orelse return false;
+        if (close_token <= region.start) return false;
+        const start = fmt.ast.tokens.resolve(region.start).end.offset;
+        const end = fmt.ast.tokens.resolve(close_token).start.offset;
+        if (start >= end) {
+            return false;
+        }
+        return std.mem.findScalar(u8, fmt.ast.env.source[start..end], '#') != null;
+    }
+
+    fn regionClosingToken(fmt: *Formatter, region: AST.TokenizedRegion) ?Token.Idx {
+        const tags = fmt.ast.tokens.tokens.items(.tag);
+
+        if (region.end > region.start) {
+            const previous = region.end - 1;
+            if (Formatter.isClosingDelimiter(tags[previous])) {
+                return previous;
+            }
+        }
+
+        if (region.end < tags.len and Formatter.isClosingDelimiter(tags[region.end])) {
+            return region.end;
+        }
+
+        return null;
+    }
+
+    fn isClosingDelimiter(tag: Token.Tag) bool {
+        return switch (tag) {
+            .CloseRound, .CloseSquare, .CloseCurly => true,
+            else => false,
+        };
     }
 
     /// Like `flushCommentsBefore`, but ensures at least `min_leading_newlines` newlines
@@ -3580,6 +3659,82 @@ test "issue 9646: multiline method chain keeps short args inline without trailin
             "\t.rotation(90)\n",
         result,
     );
+}
+
+test "issue 9939: named open tag union type variable is preserved" {
+    const result = try moduleFmtsStable(std.testing.allocator, "T(a) : [..a]", false);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("T(a) : [..a]\n", result);
+}
+
+test "issue 9940: comments in empty collections and blocks are preserved" {
+    const result = try moduleFmtsStable(std.testing.allocator,
+        \\test = |{}| {
+        \\    # Some informational comment on why this is empty
+        \\}
+        \\empty_list = [
+        \\    # Keeping this list item disabled
+        \\]
+        \\empty_record = {
+        \\    # Keeping this record field disabled
+        \\}
+    , false);
+    defer std.testing.allocator.free(result);
+
+    const expected =
+        "test = |{}| {\n" ++
+        "\t# Some informational comment on why this is empty\n" ++
+        "}\n" ++
+        "\n" ++
+        "empty_list = [\n" ++
+        "\t# Keeping this list item disabled\n" ++
+        "]\n" ++
+        "\n" ++
+        "empty_record = {\n" ++
+        "\t# Keeping this record field disabled\n" ++
+        "}\n";
+    try std.testing.expectEqualStrings(expected, result);
+}
+
+test "issue 9940: comments in platform header sections are preserved" {
+    const result = try moduleFmtsStable(std.testing.allocator,
+        \\platform "pf"
+        \\    requires {}
+        \\    exposes [
+        \\        # Stderr,
+        \\    ]
+        \\    packages {
+        \\        # This is where all the package stuff goes
+        \\    }
+        \\    provides {
+        \\        "roc_init": init_for_host!,
+        \\        # "roc_generate": generate_for_host!,
+        \\    }
+        \\    hosted {
+        \\        "hosted_stderr_line": Stderr.line!,
+        \\        # "hosted_event_queue_enqueue": EventQueue.enqueue!
+        \\    }
+    , false);
+    defer std.testing.allocator.free(result);
+
+    const expected =
+        "platform \"pf\"\n" ++
+        "\trequires {}\n" ++
+        "\texposes [\n" ++
+        "\t\t# Stderr,\n" ++
+        "\t]\n" ++
+        "\tpackages {\n" ++
+        "\t\t# This is where all the package stuff goes\n" ++
+        "\t}\n" ++
+        "\tprovides {\n" ++
+        "\t\t\"roc_init\": init_for_host!,\n" ++
+        "\t\t# \"roc_generate\": generate_for_host!,\n" ++
+        "\t}\n" ++
+        "\thosted {\n" ++
+        "\t\t\"hosted_stderr_line\": Stderr.line!,\n" ++
+        "\t\t# \"hosted_event_queue_enqueue\": EventQueue.enqueue!\n" ++
+        "\t}\n";
+    try std.testing.expectEqualStrings(expected, result);
 }
 
 test "issue 8989: platform header targets section is preserved" {

--- a/src/parse/AST.zig
+++ b/src/parse/AST.zig
@@ -2246,7 +2246,10 @@ pub const SymbolMapEntry = struct {
     region: TokenizedRegion,
 
     pub const Idx = enum(u32) { _ };
-    pub const Span = struct { span: base.DataSpan };
+    pub const Span = struct {
+        span: base.DataSpan,
+        region: TokenizedRegion = TokenizedRegion.empty(),
+    };
 };
 
 /// Single target entry: x64musl: { inputs: ["crt1.o", "host.o", app], output: Exe }

--- a/src/parse/NodeStore.zig
+++ b/src/parse/NodeStore.zig
@@ -457,7 +457,7 @@ pub fn addHeader(store: *NodeStore, header: AST.Header) std.mem.Allocator.Error!
             node.tag = .platform_header;
             node.main_token = platform.name;
 
-            const ed_start = try store.reserveExtraDataStart(9);
+            const ed_start = try store.reserveExtraDataStart(13);
             // Store requires_entries span (start and len)
             store.extra_data.appendAssumeCapacity(platform.requires_entries.span.start);
             store.extra_data.appendAssumeCapacity(platform.requires_entries.span.len);
@@ -465,12 +465,16 @@ pub fn addHeader(store: *NodeStore, header: AST.Header) std.mem.Allocator.Error!
             store.extra_data.appendAssumeCapacity(@intFromEnum(platform.packages));
             store.extra_data.appendAssumeCapacity(platform.provides.span.start);
             store.extra_data.appendAssumeCapacity(platform.provides.span.len);
+            store.extra_data.appendAssumeCapacity(platform.provides.region.start);
+            store.extra_data.appendAssumeCapacity(platform.provides.region.end);
             store.extra_data.appendAssumeCapacity(platform.hosted.span.start);
             store.extra_data.appendAssumeCapacity(platform.hosted.span.len);
+            store.extra_data.appendAssumeCapacity(platform.hosted.region.start);
+            store.extra_data.appendAssumeCapacity(platform.hosted.region.end);
             store.extra_data.appendAssumeCapacity(try packOptionalIndex(platform.targets));
 
             node.data.lhs = ed_start;
-            node.data.rhs = 9;
+            node.data.rhs = 13;
 
             node.region = platform.region;
         },
@@ -1453,9 +1457,9 @@ pub fn getHeader(store: *const NodeStore, header_idx: AST.Header.Idx) AST.Header
         },
         .platform_header => {
             const ed_start = node.data.lhs;
-            std.debug.assert(node.data.rhs == 9);
+            std.debug.assert(node.data.rhs == 13);
 
-            const targets_val = store.extra_data.items[ed_start + 8];
+            const targets_val = store.extra_data.items[ed_start + 12];
             const targets = unpackOptionalIndex(AST.TargetsSection.Idx, targets_val);
 
             return .{ .platform = .{
@@ -1469,10 +1473,16 @@ pub fn getHeader(store: *const NodeStore, header_idx: AST.Header.Idx) AST.Header
                 .provides = .{ .span = .{
                     .start = store.extra_data.items[ed_start + 4],
                     .len = store.extra_data.items[ed_start + 5],
+                }, .region = .{
+                    .start = store.extra_data.items[ed_start + 6],
+                    .end = store.extra_data.items[ed_start + 7],
                 } },
                 .hosted = .{ .span = .{
-                    .start = store.extra_data.items[ed_start + 6],
-                    .len = store.extra_data.items[ed_start + 7],
+                    .start = store.extra_data.items[ed_start + 8],
+                    .len = store.extra_data.items[ed_start + 9],
+                }, .region = .{
+                    .start = store.extra_data.items[ed_start + 10],
+                    .end = store.extra_data.items[ed_start + 11],
                 } },
                 .targets = targets,
                 .region = node.region,
@@ -3232,7 +3242,7 @@ pub fn clearScratchSymbolMapEntriesFrom(store: *NodeStore, start: u32) void {
 }
 
 /// Creates a SymbolMapEntry span from scratch entries added since start.
-pub fn symbolMapEntrySpanFrom(store: *NodeStore, start: u32) std.mem.Allocator.Error!AST.SymbolMapEntry.Span {
+pub fn symbolMapEntrySpanFrom(store: *NodeStore, start: u32, region: AST.TokenizedRegion) std.mem.Allocator.Error!AST.SymbolMapEntry.Span {
     const end = store.scratch_symbol_map_entries.top();
     defer store.scratch_symbol_map_entries.clearFrom(start);
     var i = @as(usize, @intCast(start));
@@ -3241,7 +3251,7 @@ pub fn symbolMapEntrySpanFrom(store: *NodeStore, start: u32) std.mem.Allocator.E
         try store.extra_data.append(store.gpa, @intFromEnum(store.scratch_symbol_map_entries.items.items[i]));
         i += 1;
     }
-    return .{ .span = .{ .start = ed_start, .len = @as(u32, @intCast(end)) - start } };
+    return .{ .span = .{ .start = ed_start, .len = @as(u32, @intCast(end)) - start }, .region = region };
 }
 
 /// Returns a SymbolMapEntry slice for iteration over a span.

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -1773,9 +1773,10 @@ fn parseSymbolMapCollectionTokens(
     open_tag: AST.Diagnostic.Tag,
     close_tag: AST.Diagnostic.Tag,
 ) std.mem.Allocator.Error!AST.SymbolMapEntry.Span {
+    const start = self.pos;
     self.expect(.OpenCurly) catch {
         _ = try self.pushMalformed(AST.SymbolMapEntry.Idx, open_tag, self.pos);
-        return .{ .span = .{ .start = 0, .len = 0 } };
+        return .{ .span = .{ .start = 0, .len = 0 }, .region = .{ .start = start, .end = self.pos } };
     };
     const top = self.store.scratchSymbolMapEntryTop();
     while (self.peek() != .CloseCurly and self.peek() != .EndOfFile) {
@@ -1787,9 +1788,9 @@ fn parseSymbolMapCollectionTokens(
     self.expect(.CloseCurly) catch {
         self.store.clearScratchSymbolMapEntriesFrom(top);
         _ = try self.pushMalformed(AST.SymbolMapEntry.Idx, close_tag, self.pos);
-        return .{ .span = .{ .start = 0, .len = 0 } };
+        return .{ .span = .{ .start = 0, .len = 0 }, .region = .{ .start = start, .end = self.pos } };
     };
-    return try self.store.symbolMapEntrySpanFrom(top);
+    return try self.store.symbolMapEntrySpanFrom(top, .{ .start = start, .end = self.pos });
 }
 
 fn parsePlatformHeaderTokens(self: *Parser) std.mem.Allocator.Error!AST.Header.Idx {

--- a/test/snapshots/fuzz_crash/fuzz_crash_019.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_019.md
@@ -1628,17 +1628,21 @@ Map(a, b) : Lis, (ab) -> List(b)
 
 MapML # Ag
 	: # Aon
-		List(),
+		List( # rg
+		),
 		(ab) -> # row
 			List(b) # z)
 
-line : () # Co
+line : ( # Cm
+) # Co
 
 Som : { foo : O, bar : g }
 
-Ml(a) : {}
+Ml(a) : { # ld
+}
 
-Soine(a) : {} #
+Soine(a) : { #
+} #
 
 Maybe(a) : [Somne]
 

--- a/test/snapshots/fuzz_crash/fuzz_crash_020.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_020.md
@@ -1621,17 +1621,21 @@ Map(a, b) : Lis, (ab) -> List(b)
 
 MapML # Ag
 	: # Aon
-		List(),
+		List( # rg
+		),
 		(ab) -> # row
 			List(b) # z)
 
-line : () # Co
+line : ( # Cm
+) # Co
 
 Som : { foo : O, bar : g }
 
-Ml(a) : {}
+Ml(a) : { # ld
+}
 
-Soine(a) : {} #
+Soine(a) : { #
+} #
 
 Maybe(a) : [Somne]
 

--- a/test/snapshots/fuzz_crash/fuzz_crash_027.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_027.md
@@ -1533,7 +1533,8 @@ MapML( # Cere
 	b,
 ) # Ag
 	: # Aon
-		List(),
+		List( # rg
+		),
 		(a -> b) -> # row
 			List(b) #
 

--- a/test/snapshots/issue/inspect_open_union.md
+++ b/test/snapshots/issue/inspect_open_union.md
@@ -74,7 +74,7 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-main_for_host : Try({}, [Exit(I32), ..]) -> Str
+main_for_host : Try({}, [Exit(I32), ..others]) -> Str
 main_for_host = |result|
 	match result {
 		Ok({}) => "ok"


### PR DESCRIPTION
Fixes roc fmt dropping named open tag-union extensions and comments inside empty or comment-only formatted regions. The formatter now emits named open extensions like `..others`, keeps comments when empty collections, blocks, records, and platform symbol-map sections would otherwise collapse, and parser output carries symbol-map section regions so the formatter can preserve those comments from explicit source ranges. Fixes #9939 and fixes #9940.