### PR TITLE
Honor HTTP proxy environment variables in package downloads

### DIFF
--- a/src/unbundle/download.zig
+++ b/src/unbundle/download.zig
@@ -70,6 +70,7 @@ pub const DownloadError = error{
     NoHashInUrl,
     NetworkError,
     FileError,
+    InvalidProxyUrl,
 } || unbundle.UnbundleError || std.mem.Allocator.Error;
 
 pub const Version = base.url.Version;
@@ -189,9 +190,17 @@ fn downloadToFile(
     filename_prefix: []const u8,
     filename_out: []u8,
 ) DownloadError![]const u8 {
+    // Proxy configuration must outlive the client, so its arena is declared first.
+    var proxy_arena = std.heap.ArenaAllocator.init(allocator.*);
+    defer proxy_arena.deinit();
+
     // Create HTTP client
     var client = std.http.Client{ .allocator = allocator.*, .io = io };
     defer client.deinit();
+
+    // Honor the standard proxy environment variables so downloads work in
+    // proxied/network-restricted environments (same variables `zig fetch` uses).
+    try initProxiesFromEnv(&client, proxy_arena.allocator());
 
     // Parse the URL
     const uri = std.Uri.parse(url) catch return error.InvalidUrl;
@@ -260,6 +269,27 @@ fn downloadToFile(
 
     // Exhausted all retries (extremely unlikely with 16-char random suffix)
     return error.FileError;
+}
+
+/// Populate the client's proxy configuration from the standard proxy
+/// environment variables (http_proxy/HTTP_PROXY, https_proxy/HTTPS_PROXY,
+/// all_proxy/ALL_PROXY). `arena` owns the proxy allocations and must outlive
+/// `client`.
+fn initProxiesFromEnv(client: *std.http.Client, arena: Allocator) DownloadError!void {
+    var environ_map = std.process.Environ.Map.init(arena);
+    const proxy_env_vars = [_][:0]const u8{
+        "http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY", "all_proxy", "ALL_PROXY",
+    };
+    for (proxy_env_vars) |name| {
+        const value = std.c.getenv(name.ptr) orelse continue;
+        const value_slice = std.mem.span(value);
+        if (value_slice.len == 0) continue;
+        environ_map.put(name, value_slice) catch return error.OutOfMemory;
+    }
+    client.initDefaultProxies(arena, &environ_map) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidProxyUrl,
+    };
 }
 
 /// Download and extract a bundled tar.zst file to memory buffers.


### PR DESCRIPTION
Fixes #9895

## Problem

The package downloader creates a `std.http.Client` with no proxy configuration, so it always makes direct connections. In network-restricted environments (sandboxes, corporate networks) where `git clone` works through `HTTPS_PROXY`, `roc check`/`build`/`test` still fail to download URL packages.

## Change

Configure the client from the standard proxy environment variables (`http_proxy`/`HTTP_PROXY`, `https_proxy`/`HTTPS_PROXY`, `all_proxy`/`ALL_PROXY`) via `std.http.Client.initDefaultProxies`, so proxy URL parsing and CONNECT tunneling reuse the std implementation — the same behavior as `zig fetch`. Env access uses `std.c.getenv`, the existing pattern in this codebase (e.g. `CoreCtx.osGetEnvVar`).

A malformed proxy URL now fails explicitly with a new `error.InvalidProxyUrl` rather than being silently ignored.

## Verification

Built with `zig build roc` and traced syscalls against an app whose platform URL points at a (valid-hash) https URL:

- `HTTPS_PROXY=http://127.0.0.1:3128 roc check main.roc` → `connect(..., 127.0.0.1:3128)` — the download goes through the proxy.
- Without proxy env vars → direct `connect(..., <target>:443)` — default behavior unchanged.

`zig fmt --check` passes on the changed file.