### PR TITLE
Add bug postmortem small project specs

### DIFF
--- a/projects/small/associated-block-defining-exclusion.md
+++ b/projects/small/associated-block-defining-exclusion.md
@@ -1,0 +1,220 @@
+# Currently-Defining Exclusion for Associated Blocks
+
+## Problem
+
+Associated blocks (`Type := ... .{ ... }`) are missing one scoping concept
+that ordinary declarations already have: **the item currently being defined
+must not satisfy name lookups from its own right-hand side**. The gap exists
+independently on the type side and the value side, and each side ships an
+open bug:
+
+- roc-lang/roc#9961 (type side) — a type module that imports another type
+  module and re-exports it under the same name inside its associated block
+  (`Thing : Thing`, intending "associated alias `Thing` = the *imported*
+  `Thing`") is wrongly reported as a RECURSIVE ALIAS. Verified mechanism:
+  the imported type module lives in scope as a **module alias**, not a
+  canonical-scope type binding, so the RHS lookup of `Thing` misses
+  `scopeLookupTypeBindingInCanonicalScopes` and falls into
+  `ensureParserTypeBinding` (`src/canonicalize/Can.zig:2615`), whose
+  last-resort branch — `activeDeclScopeDeclaresType(ident)`
+  (`Can.zig:2648`, implementation at `:1310`) — finds that the active
+  associated decl scope declares `Thing`… which is **the very alias whose
+  RHS is being canonicalized**. It prepares a placeholder binding for it and
+  resolves the RHS to itself; checking then correctly reports the
+  self-alias it was handed. Controls: `Other : Thing` in the same block
+  resolves the import fine, and qualified `Thing.Thing` works — only the
+  name collision breaks, and only for the item's *own* RHS.
+
+- roc-lang/roc#9912, middle layer (value side) — associated-block value
+  items skip the defining-bound-vars self-reference guard that ordinary
+  declarations get. Top-level `x = x` reports INVALID ASSIGNMENT TO ITSELF
+  via `beginDefiningBoundVars`/`isDefiningBoundVar`
+  (`Can.zig:4723`/`:4759`, diagnostic emitted at the lookup consumer,
+  `:7291`); the begin calls guard ordinary decl forms (`:6580`, `:8519`,
+  `:8948`) but not associated value items. Minimal repro needing no
+  imports, packages, or `--main`:
+  `SelfRef := [].{ with_uri = with_uri }` — the self-reference resolves to
+  the item being defined, flows downstream as a manufactured self-cycle,
+  and `roc check` dies in a canonicalization dependency-graph stack
+  overflow instead of reporting a diagnostic. (That overflow — the
+  unguarded `DemandAnalyzer` recursion — is the crash *surface*, owned by
+  [../big/dependency-ordered-def-checking.md](../big/dependency-ordered-def-checking.md)
+  item 1. This project owns the *producer*: the self-cycle should never be
+  manufactured, and the user should get the same diagnostic top-level
+  `x = x` gets.)
+
+In the #9912 original (a platform checked via `--main` with unresolvable
+URL-package imports), error recovery degrades `Request.with_uri` to an
+*unqualified* lookup of `with_uri`, which then resolves to the associated
+item being defined — the same value-side gap reached through a different
+door. The remaining layer of #9912 (platform roots never materializing URL
+packages) belongs to
+[../big/unify-build-pipelines.md](../big/unify-build-pipelines.md).
+
+Both bugs are the fragile-identity leg of the backlog disease: name-string
+scope resolution lets a definition shadow what its own RHS means, because
+"currently being defined" is not part of the lookup's input.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck.
+Canonicalization owns scoping; a name-resolution error here must surface as
+a canonicalization diagnostic, never as downstream misbehavior. `design.md`
+(Canonicalization Policy Ownership) and AGENTS.md apply.
+
+Type modules expose a main type plus associated items declared in the
+`.{ ... }` block. During canonicalization of an associated block, an
+"active decl scope" tracks the block's declarations so that items can
+reference each other (forward references between *different* items in the
+same block are legal and must keep working).
+`ensureParserTypeBinding` (`Can.zig:2615-2654`) prepares type bindings
+on demand from parser declarations when a type name is not yet in canonical
+scope; its fallback chain ends at `activeDeclScopeDeclaresType`, which
+answers purely by name — with no notion of *which* declaration is currently
+being canonicalized. `activeDeclScopeDeclaresType` has a second consumer at
+`Can.zig:1499` (qualifier-path resolution) that must be audited for the
+same self-satisfaction hazard.
+
+On the value side, the defining-bound-vars mechanism is exactly the missing
+concept, already built: `beginDefiningBoundVars` (`Can.zig:4723`) records
+the pattern(s) being defined before the RHS is canonicalized (restored
+strictly LIFO, per the doc comment at `:4748`), `isDefiningBoundVar`
+(`:4759`) answers "is this lookup target the thing being defined right
+now", and the lookup consumer at `:7291` turns a hit into the INVALID
+ASSIGNMENT diagnostic. Associated value items canonicalize their RHS
+without a surrounding begin/end pair.
+
+## Evidence
+
+All symbols verified in the current tree.
+
+- Type side: `activeDeclScopeDeclaresType` (`Can.zig:1310`), consumers at
+  `:1499` and `:2648`; `ensureParserTypeBinding` (`:2615-2654`).
+  Repro behavior at HEAD: the #9961 shape reports RECURSIVE ALIAS; the
+  `Other : Thing` and `Thing.Thing` controls work.
+- Value side: `beginDefiningBoundVars` (`:4723`, LIFO doc `:4748`),
+  `isDefiningBoundVar` (`:4759`), diagnostic consumer (`:7291`), begin
+  sites for ordinary decl forms (`:6580`, `:8519`, `:8948`) with no
+  associated-item counterpart. Repro behavior at HEAD:
+  `SelfRef := [].{ with_uri = with_uri }` stack-overflows `roc check`;
+  top-level `x = x` reports INVALID ASSIGNMENT TO ITSELF.
+- Downstream crash surface (owned elsewhere, listed for the failure chain):
+  `DemandAnalyzer.lambdaFromDef` ↔ `lambdaFromExprWithLocals` unbounded
+  mutual recursion, `src/canonicalize/DependencyGraph.zig:241-263`.
+- The #9912 issue shape: `.platform` root via `--main` +
+  URL-package imports → unresolved import → error recovery degrades a
+  qualified access to an unqualified lookup → this gap → overflow.
+
+## Solution design
+
+One concept, applied to both sides: **the declaration whose RHS is being
+canonicalized is excluded from satisfying lookups made by that RHS**, and a
+self-reference that would have resolved to it gets an explicit diagnostic
+(value side) or falls through to outer scopes (type side, where shadowing
+an import is the legitimate meaning).
+
+1. **Type side.** Track the associated-block declaration currently being
+   canonicalized (a single index — associated items canonicalize one at a
+   time; if nesting exists, a LIFO stack mirroring the defining-bound-vars
+   discipline). `ensureParserTypeBinding`'s last-resort
+   `activeDeclScopeDeclaresType` consult (`:2648`) skips the
+   currently-defining declaration, so resolution proceeds outward — to the
+   module-alias path for #9961, where `Thing` correctly means the import.
+   Audit the `:1499` consumer for the same exclusion. Two behaviors must be
+   preserved and pinned by tests: forward references from *other* items in
+   the block to this one, and genuinely recursive type declarations (a
+   nominal type whose definition references itself is legal and is not an
+   associated-*alias* self-reference — the exclusion applies to the alias
+   RHS resolution path, not to recursive nominal structure).
+
+2. **Value side.** Wrap associated value items' RHS canonicalization in the
+   existing `beginDefiningBoundVars`/restore discipline (same LIFO
+   contract), so the lookup consumer at `:7291` produces the same INVALID
+   ASSIGNMENT TO ITSELF diagnostic that top-level bindings get. No new
+   mechanism: extend the begin-site coverage to the missing form.
+
+3. **No downstream tolerance.** Do not add cycle-tolerance to
+   `DemandAnalyzer` or the checker as part of this project — the producer
+   fix means canonicalization output contains no manufactured self-cycles,
+   and the downstream zero-recursion hardening lands independently in the
+   dependency-ordered-def-checking project. A debug assertion in
+   canonicalization output ("no def's dependency summary contains itself
+   unless the def is a function") is cheap and catches recurrence.
+
+## What success looks like
+
+- The #9961 shape checks clean: the associated alias re-export resolves to
+  the imported type module, and uses of it through the re-export work.
+- `SelfRef := [].{ with_uri = with_uri }` reports INVALID ASSIGNMENT TO
+  ITSELF (or the type-appropriate sibling diagnostic) from `roc check` —
+  no stack overflow, no downstream involvement.
+- Forward references between distinct associated items, recursive nominal
+  types, and top-level self-reference diagnostics all behave exactly as
+  before (pinned by the matrix below).
+- Value-side and type-side "currently defining" use the same discipline
+  (LIFO begin/restore), not two bespoke trackers.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- *Lookup inputs are complete*: "is this the declaration being defined"
+  is part of the lookup, not recovered later from graph shape or checker
+  behavior. Diagnostics for self-reference are canonicalization
+  diagnostics.
+- *No semantic change beyond the two bugs*: the only programs whose
+  behavior changes are (a) self-named re-exports (now legal and correct)
+  and (b) direct self-references in associated values (now a clean
+  diagnostic instead of a crash).
+- Behavioral: full snapshot corpus unchanged except the two new
+  diagnostics/acceptances; `roc docs` and `roc check` on the #9912 shape no
+  longer overflow (its import-resolution errors still report — that layer
+  is out of scope here).
+
+### Performance ideal
+
+The exclusion is an integer compare against the currently-defining index
+during (rare) fallback lookups, and the value side reuses an existing
+mechanism at its existing cost. No new allocations on the hot path, no new
+traversals. Nothing to measure beyond confirming `roc check` timing is
+unchanged on the stress corpus.
+
+## Tests to add
+
+Write the regression tests first and confirm each fails on the unmodified
+tree (RECURSIVE ALIAS report for #9961; stack overflow for the value-side
+repro):
+
+- `issue_9961`: two-module CLI check test — type module `Thing`, importer
+  re-exporting `Thing : Thing` in an associated block; asserts clean check
+  and a use of the re-exported type checking end-to-end.
+- Value-side self-reference: `SelfRef := [].{ with_uri = with_uri }` as a
+  snapshot test asserting the INVALID ASSIGNMENT diagnostic (and
+  `.exit = .not_panic` in a CLI test to pin "no overflow").
+- Preservation matrix, all as snapshots:
+  - forward reference from one associated item to a *later* sibling
+    (legal today, stays legal);
+  - associated alias referencing a *different* imported type of a
+    non-colliding name (`Other : Thing`);
+  - qualified self-module reference (`Thing.Thing`) — stays working;
+  - genuinely recursive nominal type in an associated block — stays legal;
+  - top-level `x = x` — diagnostic unchanged (guards against the exclusion
+    logic drifting into ordinary decls);
+  - an associated value shadowing a top-level function of the same name,
+    where the RHS references that top-level function by that name — decide
+    and pin the intended resolution (outer def, by the exclusion rule) so
+    the semantics are explicit rather than accidental.
+- The #9912-shaped harness (platform via `--main` with an unresolvable
+  import) asserting `roc check` reports import errors without overflow —
+  shared with the dependency-ordered-def-checking project's DemandAnalyzer
+  test once both land.
+
+## Related projects
+
+- [../big/dependency-ordered-def-checking.md](../big/dependency-ordered-def-checking.md)
+  — item 1 (DemandAnalyzer worklist rewrite) removes the crash surface this
+  project's producer fix makes unreachable; land in either order, test the
+  chain in both.
+- [../big/unify-build-pipelines.md](../big/unify-build-pipelines.md) —
+  owns the remaining #9912 layer (`.platform` roots via `--main` never
+  materialize URL packages, `src/compile/compile_build.zig:~685`).

--- a/projects/small/pin-deferred-spec-requests.md
+++ b/projects/small/pin-deferred-spec-requests.md
@@ -1,0 +1,211 @@
+# Pin Deferred Spec Requests to Checked Use-Site Types
+
+## Problem
+
+A program that `roc check` accepts panics during `roc build`/`roc run` in the
+Monotype instantiation solver:
+
+- roc-lang/roc#9968 — a parser built from record-combinators (an optional
+  parameter followed by a rest parameter) panics with `instantiation unified
+  a non-empty record with an empty record`
+  (`src/postcheck/monotype/solve.zig:793`, `unifyRowWithEmpty`, reached from
+  `unifyConcrete` at `solve.zig:524`).
+
+The mechanism, verified in lldb on the repro: the combinator chain threads a
+phantom, type-level-only row through a shared type variable — the failing
+binding is `to_action = { get_params : {} }`, which appears **only as an
+unused type argument of a nominal `Builder` type**, never as a value. The
+checker solves this fine. During Monotype lowering, however, the requester's
+per-spec instantiation graph re-derives call types by replaying value-flow
+constraints, and a phantom position has no value-level edge to travel on:
+`unifyThroughBacking` (`solve.zig:657`) relates a named node to a structural
+node through the *backing* type and never pairs the named type arguments, so
+no evidence ever delivers `{ get_params : {} }` to the graph node behind the
+deferred request. When the deferred request seals
+(`sealDeferredSpecRequestsFrom`, `src/postcheck/monotype/lower.zig:2829`),
+the unresolved row node takes its `row_default` and closes to `{}`. The
+callee template's own checked annotation then contradicts the sealed request
+— and the solver panics **by design**: its header doctrine says a
+"specialization that needs more than its requested type is a unification
+conflict rather than a silent rewrite" (`solve.zig:7-8`).
+
+The defect is not the panic; the panic is correct enforcement. The defect is
+that the request was sealed from *re-derived* value-flow evidence instead of
+from the type the checker already proved for the use site. This is the
+backlog's core disease shape — a fact proven during checking (the phantom-row
+binding), re-derived downstream through structural replay, a default papering
+over the gap, and a panic at the consumption site — landing inside the
+recently-landed instantiation-graph machinery itself.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check (checked artifacts;
+all user-facing failures end here) → postcheck: Monotype IR
+(monomorphization; `src/postcheck/monotype/`) → Monotype Lifted → Lambda
+Solved → Lambda Mono → LIR → ARC → backends. `design.md` is authoritative;
+read "Monotype Instantiation" and "Row, Nominal, Alias, And Opaque
+Authority" before starting.
+
+Monotype lowering solves each specialization in a per-spec instantiation
+graph (`src/postcheck/monotype/solve.zig`). Procedure-template body requests
+discovered while lowering a specialization are **deferred to the end of the
+requesting specialization** and sealed then, so that requests are made at
+final types and specialization keys stay stable (`solve.zig:25-27`). A row
+node that no evidence has pinned by seal time takes its `row_default` —
+which is the correct treatment for *genuinely unconstrained* rows (that is
+what defaults are for), and the wrong treatment for rows the checker already
+solved but the graph never learned about.
+
+Each deferred request already carries the checked identity of what it is
+requesting: the `deferred_templates` entry records `source_fn_ty` (the
+checked function type at the use site) alongside the mono `fn_ty`
+(`lower.zig:2586-2596`). Today that checked type is consulted only on the
+**callee** side, **after** sealing, and **only when the requester and the
+template live in the same module**: `lowerTemplateWithMonoFor` constrains
+`source_fn_ty` against the template's public function type solely under
+`moduleBytesEqual(source_ty_view.key.bytes, view.key.bytes)`
+(`lower.zig:1451-1453`), then constrains the template's checked root
+(`constrainTypeToMono`, call at `lower.zig:1455`, implementation in
+`BodyContext` at `lower.zig:~7376`). By that point the requester's graph has
+already sealed the request with the defaulted row, and the contradiction is
+unrecoverable.
+
+The check-side sibling of this bug was already fixed once: the open-row
+widening work (issue roc-lang/roc#9614, PR roc-lang/roc#9617) kept
+`row_default`-closed rows widenable during constraint solving. This project
+is the Monotype-side counterpart, at a stage where widening is by-design
+impossible (sealed snapshots) — so the row must arrive *before* sealing,
+from checked data.
+
+## Evidence
+
+All symbols verified in the current tree.
+
+- `src/postcheck/monotype/solve.zig`: header doctrine (`:7-8`), deferred
+  request rationale (`:25-27`), `unifyConcrete` (`:524`),
+  `unifyThroughBacking` (`:657` — relates named↔structural through the
+  backing; named type arguments are not paired), `unifyRowWithEmpty`
+  (`:793`, the panic).
+- `src/postcheck/monotype/lower.zig`: deferred request creation carrying
+  `source_fn_ty` (`:2586-2596`), `sealDeferredSpecRequestsFrom` (`:2829`,
+  drain at `:~2887`), the same-module-only `constrainKnownType` condition
+  (`:1451-1453`) followed by `constrainTypeToMono` (`:1455`);
+  `BodyContext.constrainTypeToMono` (`:~7376`).
+- lldb specifics from the #9968 repro: failing template `Param.maybe_str`;
+  the non-empty side is the phantom `to_action = { get_params : {} }`
+  (field label resolved through the interner); the empty side is the sealed
+  request mono, requested from the app spec's graph via the
+  `main!`/`cli_parser` chain.
+- Discriminating experiments (all preserved in the investigation scratchpad,
+  reproducible from the issue): replacing `{ get_params : {} }` with `{}`
+  fixes it; making the second combinator's phantom concrete fixes it;
+  decoupling the combinators' shared type variable fixes it (the shared-var
+  chain is load-bearing); changing the phantom's *other* argument from `{}`
+  to `I64` does **not** change the panic (rules out positional/slot-pairing
+  bugs); local-vs-top-level placement of the parser is irrelevant.
+- The landed instantiation-graph work this extends: the per-spec solver
+  graph (merged to main ~2026-06-12) whose eager-materialize/refresh and
+  request-deferral design this project completes rather than revises.
+
+## Solution design
+
+Make every deferred request consume the checker's solved use-site type as
+explicit input to its graph node, before sealing can default anything.
+
+1. **Pin at request creation.** When a deferred template request is created
+   (`lower.zig:2586-2596`), constrain the request's function-type node in
+   the *requester's* graph against `instNode(request.source_fn_ty)` — the
+   checked use-site type it already carries. "Requesting at final types"
+   then means *final per the checker*, not "whatever the graph learned
+   through value flow". Phantom bindings travel as checked data;
+   `row_default` at seal time goes back to meaning "genuinely unconstrained".
+
+2. **Delete the same-module restriction, don't widen it.** The
+   `moduleBytesEqual` condition at `lower.zig:1451` exists because the
+   callee-side constraint needs the source type expressed in the callee's
+   type space. With pinning done requester-side (where `source_fn_ty` is
+   native), the callee-side special case becomes redundant for what it was
+   compensating for; remove it or reduce it to a debug agreement check —
+   whichever the migration shows, but do not leave two overlapping
+   constraint paths with different module conditions.
+
+3. **Audit `unifyThroughBacking`'s named-argument pairing.** Pinning fixes
+   the delivery of checked facts to requests; the propagation hole — a named
+   node meeting a structural node loses the named arguments' pairing — may
+   still starve *intra-graph* nodes that only connect through a backing.
+   Decide with evidence: add a debug counter/assert for "row node defaulted
+   at seal while its checked counterpart was concrete", run the full corpus,
+   and pair named arguments through the backing if any site still fires.
+
+4. **Enforcement stays.** The seal-time contradiction panic remains exactly
+   as it is (debug assertion / release unreachable per design.md). After
+   this project it is unreachable for checked programs; it is the regression
+   tripwire, not a condition to soften.
+
+## What success looks like
+
+- The #9968 repro checks, builds, and runs correctly on all backends.
+- The debug check from item 3 fires nowhere on the snapshot corpus, the
+  examples, and the roc-parser package suite.
+- There is exactly one place where a deferred request learns its type — the
+  pin at creation — and no module-conditional constraint path shadows it.
+- `row_default` at seal time is reachable only for rows the checker left
+  genuinely unconstrained (assertable in debug by comparing against the
+  checked type's row).
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- *Requests consume checked types*: a deferred request's sealed type is a
+  function of `source_fn_ty` plus genuine defaults — never of which
+  value-flow edges happened to exist. Enforced by the pin plus the item-3
+  debug check.
+- *No silent rewrite*: the solver's conflict-over-rewrite doctrine is
+  untouched; the panic remains the enforcement of record.
+- Behavioral: full snapshot corpus and cross-backend eval corpus
+  (interpreter/dev/LLVM/wasm agreement) unchanged; the #9968 repro and the
+  matrix below become permanent tests.
+
+### Performance ideal
+
+One `instNode` + one unification per deferred request, each bounded by the
+size of the requested function type — work proportional to data the request
+already stores. No new traversals, no name lookups, no per-seal re-walks.
+Measure Monotype lowering time on the specialization-heavy corpus
+(roc-parser examples) and `examples/`; require parity within noise. Zero
+effect on generated code.
+
+## Tests to add
+
+Write the regression test first and confirm it panics on the unmodified
+tree:
+
+- `issue_9968`: the issue's optional-param + rest-param parser as a CLI run
+  test (`test/cli/issue_*.roc` + `src/cli/test/parallel_cli_runner.zig`
+  convention): `.exit = .not_panic`, `not_contains` the
+  `instantiation unified` panic strings, expected program output.
+- Phantom-row matrix: a nominal type with a phantom type argument bound to a
+  non-empty record row / a tag row / a nested nominal, each threaded through
+  a combinator chain with a shared type variable, each consumed only at the
+  type level; assert build + run output.
+- The discriminating controls from the investigation, pinned as tests: the
+  concrete-phantom variant (must keep working) and the `I64`-argument
+  variant (must now also work, and guards against slot-pairing regressions).
+- Cross-module split: requester and template in different modules with a
+  phantom-carrying request (exercises the deleted `moduleBytesEqual`
+  condition).
+- Debug-build corpus check: the item-3 counter asserts zero
+  defaulted-while-checked-concrete rows across `zig build snapshot` and the
+  CLI suite.
+
+## Related projects
+
+- [../big/total-dispatch-plans.md](../big/total-dispatch-plans.md) — the
+  same discipline (downstream consumes checked data; no re-derivation)
+  applied to dispatch; this project applies it to specialization request
+  types.
+- [../big/immutable-specialization-identity.md](../big/immutable-specialization-identity.md)
+  — the other identity/typing surface of `lower.zig` specialization records;
+  pinning requests at checked types also reduces the pressure that made
+  request/solved dual entries diverge.

--- a/projects/small/spec-constr-static-match-soundness.md
+++ b/projects/small/spec-constr-static-match-soundness.md
@@ -1,0 +1,230 @@
+# Sound Static-Match Verdicts and One Nominal Representation in spec_constr
+
+## Problem
+
+Two open issues panic at the same invariant in the call-pattern
+specialization pass, for two different underlying defects:
+
+- roc-lang/roc#9975 — `roc test --opt=speed` on a small list-indexing
+  program panics `known constructor match had no matching branch`
+  (`src/postcheck/monotype_lifted/spec_constr.zig:2332`, in
+  `simplifyKnownMatchValue`).
+- roc-lang/roc#9969 — `roc build` on a list-parser app panics at the same
+  invariant through a different path.
+
+Both programs are valid; both were verified in lldb.
+
+**Defect 1 (9975): a two-valued verdict where three values are needed.**
+`simplifyKnownMatchValue` (`spec_constr.zig:2311`) statically evaluates a
+match against a symbolic `Value`. Its branch test, `bindPatToValue`
+(`spec_constr.zig:2812`), returns `bool` — but the pass's `Value` union
+(`spec_constr.zig:268-275`: `expr`, `tag`, `record`, `tuple`, `nominal`,
+`callable`) has no list or literal payload representations, so list
+patterns, string patterns, and numeric-literal patterns are **statically
+undecidable** and simply `return false`
+(`spec_constr.zig:2860-2868`, "List patterns are not statically bound during
+specialization"). `false` means "cannot decide", but the caller treats it as
+"definitely does not match": in the 9975 repro the scrutinee clones to a
+`Value.tuple` whose elements are opaque `Value.expr`s, every branch pattern
+is a tuple whose first element is a list pattern, all three branches "fail",
+and the invariant concludes checker exhaustiveness was violated. The
+depth-0 guard (`if (scrutinee == .expr) return null`, `spec_constr.zig:2312`)
+only protects fully-opaque scrutinees, not opaque *components*.
+
+**Defect 2 (9969): one fact, two IR representations, a one-directional
+consumer.** Per design.md "Constructing Nominal Values", only explicit
+`Type.Tag(..)` syntax canonicalizes to a nominal-wrapper expression;
+unqualified tags promoted to a nominal type by unification stay **bare** tag
+expressions, and Monotype lowering preserves that (bare `.tag` created at a
+nominal type at `src/postcheck/monotype/lower.zig:~8339`; `.nominal` exprs
+only from checked `.nominal` at `:~8347`). Checked *patterns* on nominal
+scrutinees always carry the wrapper (`lower.zig:~20611`). So
+"bare-tag-at-nominal-type" is a sanctioned IR state — and spec_constr's
+matcher is asymmetric about it: the value-side helpers `tagFromValue` /
+`recordFromValue` / `tupleFromValue` (`spec_constr.zig:3973-3995`) look
+*through* `.nominal` values, but the `.nominal`-**pattern** case
+(`spec_constr.zig:2853-2859`) requires the value to be syntactically
+`.nominal` and returns `false` otherwise. In the 9969 repro, case-of-case
+rewriting (`cloneCaseOfCaseValue`, `spec_constr.zig:2596`) pushes outer
+`Try`-nominal-wrapped patterns against a bare `Value.tag` (`Err(ArgErr)`
+from `extract_param_loop`) **at the same nominal type** — every branch
+"fails", same panic. Empirical confirmation: qualifying the constructors as
+`Try.Err(..)`/`Try.Ok(..)` in the source makes the identical program build
+cleanly.
+
+Context that elevates this beyond two point fixes: these are the **third and
+fourth** shipped bugs in this one pass — issue roc-lang/roc#9717 (span
+invalidation) and roc-lang/roc#9801 (slice captured across `Cloner` appends,
+realloc, dangling slice) were iterate-while-mutate memory bugs in the same
+file. spec_constr re-implements pattern-match semantics, inlining, and
+use-counting as a second interpreter over the IR; it is the highest
+invariant-density consumer in postcheck, and its match semantics are
+enforced only by this panic.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck:
+Monotype IR → **Monotype Lifted** (closure lifting; plus
+`spec_constr.zig` call-pattern specialization for optimized builds, added in
+PR roc-lang/roc#9593) → Lambda Solved → Lambda Mono → LIR → ARC → backends.
+`design.md` is authoritative; read "Constructing Nominal Values" and "Row,
+Nominal, Alias, And Opaque Authority" before starting.
+
+spec_constr specializes functions by call-pattern shape: while recording
+call patterns (`recordCallPattern`, `spec_constr.zig:791`) and writing
+specializations (`writeSpecialization`, `spec_constr.zig:871`), it inlines
+and partially evaluates bodies over symbolic `Value`s, and
+`simplifyKnownMatchValue` folds a match whose scrutinee is statically known
+to a single branch. Folding is an optimization: the sound fallback for "I
+can't decide this match statically" is to **leave the residual match in the
+output**, which costs nothing at runtime beyond the match that was going to
+execute anyway. The current code has no way to express that fallback per
+branch — only per whole-scrutinee (the depth-0 `.expr` guard).
+
+The panic at `spec_constr.zig:2332` is the correct enforcement of a real
+invariant — a *known* constructor that matches *no* branch of an exhaustive
+match is a checker bug — but only when every branch verdict is a definite
+no-match. Today it also fires when any verdict was merely unknown.
+
+## Evidence
+
+All symbols verified in the current tree.
+
+- `src/postcheck/monotype_lifted/spec_constr.zig`: `Value` union with no
+  list/literal payloads (`:268-275`); `simplifyKnownMatchValue` (`:2311`)
+  with depth-0 guard (`:2312`) and the invariant
+  `Common.invariant("known constructor match had no matching branch")`
+  (`:2332`); `bindPatToValue` (`:2812`) — `.nominal` pattern case demanding
+  a syntactic `.nominal` value (`:2853-2859`), undecidable pattern set
+  returning `false` (`:2860-2868`); one-directional look-through helpers
+  `tagFromValue` (`:3973`) and siblings; reach paths `recordCallPattern`
+  (`:791`) → inline/clone for 9975 and `writeSpecialization` (`:871`) →
+  `cloneCaseOfCaseValue` (`:2596`) for 9969.
+- `src/postcheck/monotype/lower.zig`: bare `.tag` construction at nominal
+  types (`:~8339`), `.nominal` wrappers only from checked `.nominal`
+  (`:~8347`), patterns always wrapped (`:~20611`).
+- lldb specifics: 9975 — scrutinee `Value.tuple` of two `Value.expr`s,
+  branch patterns tuples with list-pattern heads; 9969 — bare `Value.tag`
+  (`Err`, payload `ArgErr`, same `TypeId` as the `.nominal`-wrapped
+  patterns).
+- Discriminating experiment: qualifying the four constructors
+  (`Try.Err`/`Try.Ok`) in the 9969 repro's `Param.roc` builds cleanly —
+  pinning defect 2 on the representation split, not the match logic.
+- Prior same-pass bugs (different mechanism — mutation safety, both fixed):
+  roc-lang/roc#9717, roc-lang/roc#9801.
+- Not the decision-tree project: 9969/9975 live in this mid-pipeline
+  optimizer, several stages before LIR match lowering; a decision-tree
+  compiler at the LIR boundary
+  ([../big/decision-tree-match-compiler.md](../big/decision-tree-match-compiler.md))
+  would neither remove this static matcher nor its need for sound verdicts.
+
+## Solution design
+
+1. **Three-valued verdicts.** Replace the matcher's `bool` with
+   `enum { match, no_match, unknown }` through `bindPatToValue` and its
+   callers (`bindPatToMatchValue`, `bindPatToReusableValue`,
+   `simplifyKnownMatchValue`, `cloneCaseOfCaseValue`). Semantics:
+   - statically undecidable pattern forms (list, string, numeric literals)
+     and any pattern probing a `Value.expr` component yield `unknown`;
+   - `unknown` on any branch **aborts the fold** for that match — the
+     residual match stays in the output (the optimization simply does not
+     fire); guards already abort today and keep doing so;
+   - the `spec_constr.zig:2332` invariant fires **only** when every branch
+     is a definite `no_match` — which really is a checker-exhaustiveness
+     violation, and stays debug-assert/release-unreachable per design.md.
+
+2. **One representation for nominal values.** Kill defect 2 at the root
+   rather than symmetrizing the workaround: Monotype lowering wraps every
+   tag/record/tuple expression whose type is nominal in the `.nominal`
+   wrapper at construction (the type is in hand at the creation site,
+   `lower.zig:~8339`), making "value is `.nominal`-wrapped iff its type is
+   nominal" a **total IR invariant**. Then delete spec_constr's
+   one-directional look-throughs (`tagFromValue`-family `.nominal` cases)
+   instead of adding a second direction, and debug-assert the invariant at
+   spec_constr's `Value` construction sites. The wrapper is type-level
+   structure only — no layout or runtime-representation change.
+   - Scope escape hatch: if the consumer audit finds a genuine dependent of
+     bare-tag-at-nominal-type that cannot be migrated in this project's
+     budget, the minimal *sound* fallback is a type-directed look-through in
+     the `.nominal` pattern case (mirror `tagFromValue`, keyed on the
+     value's `TypeId`, both directions). That is strictly a fallback: the
+     normalization is the design-conformant fix (one fact, one
+     representation), and choosing the fallback graduates the normalization
+     into its own follow-up.
+
+3. **Pin the pass's match semantics with tests, not folklore.** The verdict
+   enum makes "unknown ≠ no-match" a type-level distinction; add the
+   assertion matrix below so the next `Value` variant or pattern form added
+   to the pass must decide its verdict explicitly.
+
+## What success looks like
+
+- The #9969 and #9975 repros build, test, and run correctly.
+- `bindPatToValue` and its callers contain no `bool` verdicts;
+  grepping the pass for the verdict enum shows every pattern form mapped to
+  an explicit `match`/`no_match`/`unknown`.
+- Either no consumer of bare-tag-at-nominal-type exists in Monotype Lifted
+  (normalization landed, look-throughs deleted), or the explicitly-chosen
+  fallback is in place with the normalization filed as follow-up — not both
+  paths half-done.
+- The `:2332` invariant still exists and still fires on a synthetic
+  all-definite-no-match corpus (it must remain the enforcement of record).
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- *Verdict soundness*: a fold happens only when a branch definitely matches
+  and all earlier branches definitely do not. `unknown` can only make the
+  output less optimized, never wrong.
+- *Representation totality*: one nominal fact has one representation;
+  enforced by the construction-site debug assert, not by consumer
+  tolerance.
+- Behavioral: `--opt=speed` output equals `--opt=dev`/interpreter output on
+  the full eval corpus (the pass is optimization-only, so cross-opt
+  agreement is the ground truth); snapshot corpus unchanged.
+
+### Performance ideal
+
+Where the fold still fires, generated code is unchanged. Where it now
+aborts, the residual match was previously being folded **unsoundly** (panic
+or miscompile), so no legitimate optimization is lost; confirm on the
+roc-parser corpus that `--opt=speed` binary size and spec_constr pass time
+stay within noise. The normalization adds one wrapper node per
+nominal-typed constructor expression at compile time — no runtime cost, no
+layout change; measure Monotype lowering time to confirm noise-level.
+
+## Tests to add
+
+Write the two regression tests first and confirm each panics on the
+unmodified tree:
+
+- `issue_9975`: the issue's `nth` program under `roc test --opt=speed`
+  (`test/cli/` + `parallel_cli_runner.zig` convention; `.exit = .not_panic`,
+  `not_contains` the invariant string, expected test output).
+- `issue_9969`: the list-parser app under `roc build` and `roc run`,
+  expected output asserted.
+- The qualified-constructor control (`Try.Err`/`Try.Ok` variant of 9969)
+  stays green — pins that both representations behave identically after
+  normalization.
+- Verdict matrix, exercised end-to-end through `--opt=speed` (list patterns,
+  string patterns, numeric-literal patterns, each nested inside
+  tuple/record/tag patterns over partially-symbolic scrutinees): asserts
+  correct runtime output (residual match executed) and no panic.
+- All-definite-no-match tripwire: a debug-build unit test constructing a
+  known tag value against branches that definitely exclude it, asserting the
+  invariant still fires (guards the enforcement from being softened).
+- Cross-opt agreement: run the affected repros under interpreter, dev, and
+  `--opt=speed`, asserting identical output (the pass's ground truth).
+
+## Related projects
+
+- [../big/decision-tree-match-compiler.md](../big/decision-tree-match-compiler.md)
+  — orthogonal (LIR-stage match compilation); noted here because the two are
+  easy to conflate. This project fixes the *optimizer's* static matcher.
+- [cross-phase-coverage-parity-tests.md](./cross-phase-coverage-parity-tests.md)
+  — the same producer/consumer discipline; the refutability suite is the
+  natural home for the verdict matrix.
+- [../big/immutable-specialization-identity.md](../big/immutable-specialization-identity.md)
+  — documents spec_constr's second specialization-identity space
+  (`CallPattern`); relevant context for anyone extending the pass.


### PR DESCRIPTION
Adds three projects/small entries distilled from recent bug postmortems: associated-block self-resolution, deferred Monotype specialization request pinning, and spec_constr static-match soundness. These are project planning docs only, intended to get the scoped fixes onto the main backlog.