### PR TITLE
Improve dollar-prefixed record field name errors and cover app headers

### DIFF
--- a/src/parse/AST.zig
+++ b/src/parse/AST.zig
@@ -279,6 +279,7 @@ pub fn parseDiagnosticToReport(self: *AST, env: *const CommonEnv, diagnostic: Di
         .nominal_associated_cannot_have_final_expression => "Expression In Associated Items",
         .deprecated_number_suffix => "Deprecated Number Suffix",
         .expr_double_dot_is_not_range => "Not A Range Operator",
+        .record_field_name_cannot_be_var => "Invalid Record Field Name",
         else => "Parse Error",
     };
 
@@ -311,6 +312,7 @@ pub fn parseDiagnosticToReport(self: *AST, env: *const CommonEnv, diagnostic: Di
         .nominal_associated_cannot_have_final_expression => "Associated items (such as types or methods) can only have associated types and values, not plain expressions.",
         .deprecated_number_suffix => "This number literal uses a deprecated suffix syntax.",
         .expr_double_dot_is_not_range => ".. is not an operator. For an exclusive range use ..<; for an inclusive range use ..=.",
+        .record_field_name_cannot_be_var => "Record field names cannot start with a dollar sign.",
         else => "",
     };
 
@@ -585,6 +587,13 @@ pub fn parseDiagnosticToReport(self: *AST, env: *const CommonEnv, diagnostic: Di
             return report;
         },
         .expr_double_dot_is_not_range => {},
+        .record_field_name_cannot_be_var => {
+            try report.document.addReflowingText("Names that start with ");
+            try report.document.addAnnotated("$", .emphasized);
+            try report.document.addReflowingText(" are reassignable variables declared with the ");
+            try report.document.addKeyword("var");
+            try report.document.addReflowingText(" keyword, so they cannot be used as record field names.");
+        },
         else => {
             const tag_name = @tagName(diagnostic.tag);
             const owned_tag = try report.addOwnedString(tag_name);
@@ -711,6 +720,8 @@ pub const Diagnostic = struct {
         var_must_have_ident,
         var_expected_equals,
         var_type_anno_needs_var_keyword,
+        /// `$name` idents are reassignable variables and cannot name record fields
+        record_field_name_cannot_be_var,
         for_expected_in,
         match_branch_wrong_arrow,
         match_branch_missing_arrow,

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -137,10 +137,6 @@ fn isVarIdent(self: *Parser, token: Token.Idx) bool {
     return false;
 }
 
-fn isLowerRecordFieldName(self: *Parser, token: Token.Idx) bool {
-    return self.tok_buf.tokens.items(.tag)[token] == .LowerIdent and !self.isVarIdent(token);
-}
-
 /// Check if the current position looks like a type declaration with a valid type following.
 /// This peeks ahead without consuming tokens to determine if we have:
 /// - `Name :` followed by a valid type start token
@@ -808,10 +804,12 @@ fn parseStringExprTokens(self: *Parser) std.mem.Allocator.Error!AST.Expr.Idx {
 
 fn parseRecordFieldTokens(self: *Parser) std.mem.Allocator.Error!AST.RecordField.Idx {
     const start = self.pos;
-    if (!self.isLowerRecordFieldName(start)) {
+    self.expect(.LowerIdent) catch {
         return try self.pushMalformed(AST.RecordField.Idx, .expected_expr_record_field_name, start);
+    };
+    if (self.isVarIdent(start)) {
+        try self.pushDiagnostic(.record_field_name_cannot_be_var, .{ .start = start, .end = start + 1 });
     }
-    self.advance();
     const name = start;
     var value: ?AST.Expr.Idx = null;
     if (self.peek() == .OpColon) {
@@ -1220,6 +1218,9 @@ fn parseAppHeaderTokens(self: *Parser) std.mem.Allocator.Error!AST.Header.Idx {
             return try self.pushMalformed(AST.Header.Idx, .expected_package_or_platform_name, start);
         }
         const name_tok = self.pos;
+        if (self.isVarIdent(name_tok)) {
+            try self.pushDiagnostic(.record_field_name_cannot_be_var, .{ .start = name_tok, .end = name_tok + 1 });
+        }
         self.advance();
         if (self.peek() != .OpColon) {
             self.store.clearScratchRecordFieldsFrom(fields_scratch_top);
@@ -4185,12 +4186,8 @@ fn runExprStatementKernel(
             .CloseCurly => continue :expr_kernel .record_finish,
             .LowerIdent => {
                 const field_start = self.pos;
-                if (!self.isLowerRecordFieldName(field_start)) {
-                    const malformed_field = try self.pushMalformed(AST.RecordField.Idx, .expected_expr_record_field_name, field_start);
-                    try self.store.addScratchRecordField(malformed_field);
-                    const expr = try self.pushMalformed(AST.Expr.Idx, .expected_expr_close_curly_or_comma, self.pos);
-                    expr_finish_state = .{ .start = expr_record_state.start, .min_bp = expr_record_state.min_bp, .expr = expr };
-                    continue :expr_kernel .suffix;
+                if (self.isVarIdent(field_start)) {
+                    try self.pushDiagnostic(.record_field_name_cannot_be_var, .{ .start = field_start, .end = field_start + 1 });
                 }
                 self.advance();
                 const name = field_start;
@@ -4838,15 +4835,8 @@ fn runExprStatementKernel(
             // record types. They parse like any other field name.
             .LowerIdent, .Underscore, .NamedUnderscore => {
                 const field_start = self.pos;
-                if (self.peek() == .LowerIdent and !self.isLowerRecordFieldName(field_start)) {
-                    while (self.peek() != .CloseCurly and self.peek() != .Comma and self.peek() != .EndOfFile) {
-                        self.advance();
-                    }
-                    const malformed_field = try self.pushMalformed(AST.AnnoRecordField.Idx, .expected_type_field_name, field_start);
-                    try self.store.addScratchAnnoRecordField(malformed_field);
-                    self.store.clearScratchAnnoRecordFieldsFrom(type_record_state.scratch_top);
-                    last_type_anno = try self.pushMalformed(AST.TypeAnno.Idx, .expected_ty_close_curly_or_comma, self.pos);
-                    continue :expr_kernel .type_complete;
+                if (self.peek() == .LowerIdent and self.isVarIdent(field_start)) {
+                    try self.pushDiagnostic(.record_field_name_cannot_be_var, .{ .start = field_start, .end = field_start + 1 });
                 }
                 const name = self.pos;
                 self.advance();
@@ -6125,12 +6115,8 @@ fn runExprStatementKernel(
             },
             .LowerIdent => {
                 const field_start = self.pos;
-                if (!self.isLowerRecordFieldName(field_start)) {
-                    while (self.peek() != .EndOfFile and self.peek() != .CloseCurly) {
-                        self.advance();
-                    }
-                    last_pattern = try self.pushMalformed(AST.Pattern.Idx, .expected_lower_ident_pat_field_name, field_start);
-                    continue :expr_kernel .pattern_complete;
+                if (self.isVarIdent(field_start)) {
+                    try self.pushDiagnostic(.record_field_name_cannot_be_var, .{ .start = field_start, .end = field_start + 1 });
                 }
                 const name = self.pos;
                 self.advance();

--- a/src/parse/mod.zig
+++ b/src/parse/mod.zig
@@ -189,30 +189,34 @@ test "bare .. in expression position is a helpful parse error" {
     );
 }
 
-test "dollar-prefixed record field names are rejected" {
+test "dollar-prefixed record field names are rejected with a single diagnostic" {
     const gpa = std.testing.allocator;
 
     const Case = struct {
         source: []const u8,
         parse: *const fn (Allocator, *CommonEnv) Allocator.Error!*AST,
-        tag: AST.Diagnostic.Tag,
     };
 
     for ([_]Case{
         .{
             .source = "{ $field : \"value\" }",
             .parse = expr,
-            .tag = .expected_expr_record_field_name,
         },
         .{
             .source = "value : { $field : Str }",
             .parse = statement,
-            .tag = .expected_type_field_name,
         },
         .{
-            .source = "match value { { $field } => $field }",
+            .source = "match value { { $field } => \"matched\" }",
             .parse = expr,
-            .tag = .expected_lower_ident_pat_field_name,
+        },
+        .{
+            .source = "app [main!] { $pf: platform \"./platform/main.roc\" }",
+            .parse = header,
+        },
+        .{
+            .source = "package [Foo] { $dep: \"../dep/main.roc\" }",
+            .parse = header,
         },
     }) |case| {
         var env = try CommonEnv.init(gpa, case.source);
@@ -222,8 +226,11 @@ test "dollar-prefixed record field names are rejected" {
         defer ast.deinit();
 
         try std.testing.expectEqual(@as(usize, 0), ast.tokenize_diagnostics.items.len);
-        try std.testing.expect(ast.parse_diagnostics.items.len > 0);
-        try std.testing.expectEqual(case.tag, ast.parse_diagnostics.items[0].tag);
+        try std.testing.expectEqual(@as(usize, 1), ast.parse_diagnostics.items.len);
+        try std.testing.expectEqual(
+            AST.Diagnostic.Tag.record_field_name_cannot_be_var,
+            ast.parse_diagnostics.items[0].tag,
+        );
     }
 }
 

--- a/test/snapshots/record_field_name_cannot_be_var.md
+++ b/test/snapshots/record_field_name_cannot_be_var.md
@@ -1,0 +1,164 @@
+# META
+~~~ini
+description=Reassignable ($-prefixed) identifiers are rejected as record field names in expressions, patterns, and type annotations
+type=snippet
+~~~
+# SOURCE
+~~~roc
+my_record = { $field: "value", ok: 1 }
+
+f = |{ $a }| "y"
+
+g : { $b : Str } -> Str
+g = |_| "x"
+~~~
+# EXPECTED
+INVALID RECORD FIELD NAME - record_field_name_cannot_be_var.md:1:15:1:21
+INVALID RECORD FIELD NAME - record_field_name_cannot_be_var.md:3:8:3:10
+INVALID RECORD FIELD NAME - record_field_name_cannot_be_var.md:5:7:5:9
+UNUSED VARIABLE - record_field_name_cannot_be_var.md:3:8:3:10
+# PROBLEMS
+
+┌───────────────────────────┐
+│ INVALID RECORD FIELD NAME ├─ Record field names cannot start with a ────────┐
+└┬──────────────────────────┘  dollar sign.                                   │
+ │                                                                            │
+ │  my_record = { $field: "value", ok: 1 }                                    │
+ │                ‾‾‾‾‾‾                                                      │
+ └─────────────────────────────────── record_field_name_cannot_be_var.md:1:15 ┘
+
+    Names that start with $ are reassignable variables declared with the `var`
+    keyword, so they cannot be used as record field names.
+
+
+┌───────────────────────────┐
+│ INVALID RECORD FIELD NAME ├─ Record field names cannot start with a ────────┐
+└┬──────────────────────────┘  dollar sign.                                   │
+ │                                                                            │
+ │  f = |{ $a }| "y"                                                          │
+ │         ‾‾                                                                 │
+ └──────────────────────────────────── record_field_name_cannot_be_var.md:3:8 ┘
+
+    Names that start with $ are reassignable variables declared with the `var`
+    keyword, so they cannot be used as record field names.
+
+
+┌───────────────────────────┐
+│ INVALID RECORD FIELD NAME ├─ Record field names cannot start with a ────────┐
+└┬──────────────────────────┘  dollar sign.                                   │
+ │                                                                            │
+ │  g : { $b : Str } -> Str                                                   │
+ │        ‾‾                                                                  │
+ └──────────────────────────────────── record_field_name_cannot_be_var.md:5:7 ┘
+
+    Names that start with $ are reassignable variables declared with the `var`
+    keyword, so they cannot be used as record field names.
+
+
+┌─────────────────┐
+│ UNUSED VARIABLE ├─ Variable `$a` is defined here and then never used. ──────┐
+└┬────────────────┘                                                           │
+ │                                                                            │
+ │  f = |{ $a }| "y"                                                          │
+ │         ‾‾                                                                 │
+ └──────────────────────────────────── record_field_name_cannot_be_var.md:3:8 ┘
+
+    If you don't need this variable, prefix it with an underscore like `_$a` to
+    suppress this warning.
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpenCurly,LowerIdent,OpColon,StringStart,StringPart,StringEnd,Comma,LowerIdent,OpColon,Int,CloseCurly,
+LowerIdent,OpAssign,OpBar,OpenCurly,LowerIdent,CloseCurly,OpBar,StringStart,StringPart,StringEnd,
+LowerIdent,OpColon,OpenCurly,LowerIdent,OpColon,UpperIdent,CloseCurly,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,Underscore,OpBar,StringStart,StringPart,StringEnd,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "my_record"))
+			(e-record
+				(field (field "$field")
+					(e-string
+						(e-string-part (raw "value"))))
+				(field (field "ok")
+					(e-int (raw "1")))))
+		(s-decl
+			(p-ident (raw "f"))
+			(e-lambda
+				(args
+					(p-record
+						(field (name "$a") (rest false))))
+				(e-string
+					(e-string-part (raw "y")))))
+		(s-type-anno (name "g")
+			(ty-fn
+				(ty-record
+					(anno-record-field (name "$b")
+						(ty (name "Str"))))
+				(ty (name "Str"))))
+		(s-decl
+			(p-ident (raw "g"))
+			(e-lambda
+				(args
+					(p-underscore))
+				(e-string
+					(e-string-part (raw "x")))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "my_record"))
+		(e-record
+			(fields
+				(field (name "$field")
+					(e-string
+						(e-literal (string "value"))))
+				(field (name "ok")
+					(e-num (value "1"))))))
+	(d-let
+		(p-assign (ident "f"))
+		(e-lambda
+			(args
+				(p-record-destructure
+					(destructs
+						(record-destruct (label "$a") (ident "$a")
+							(required
+								(p-assign (ident "$a")))))))
+			(e-string
+				(e-literal (string "y")))))
+	(d-let
+		(p-assign (ident "g"))
+		(e-lambda
+			(args
+				(p-underscore))
+			(e-string
+				(e-literal (string "x"))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-record
+					(field (field "$b")
+						(ty-lookup (name "Str") (builtin))))
+				(ty-lookup (name "Str") (builtin))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "{ $field: Str, ok: Dec }"))
+		(patt (type "{ $a: _field } -> a where [a.from_quote : Str -> Try(a, [BadQuotedBytes(Str)])]"))
+		(patt (type "{ $b: Str } -> Str")))
+	(expressions
+		(expr (type "{ $field: Str, ok: Dec }"))
+		(expr (type "{ $a: _field } -> a where [a.from_quote : Str -> Try(a, [BadQuotedBytes(Str)])]"))
+		(expr (type "{ $b: Str } -> Str"))))
+~~~

--- a/test/snapshots/records/dollar_prefix_field_name.md
+++ b/test/snapshots/records/dollar_prefix_field_name.md
@@ -8,30 +8,19 @@ type=expr
 { $field : "value" }
 ~~~
 # EXPECTED
-PARSE ERROR - dollar_prefix_field_name.md:1:3:1:9
-PARSE ERROR - dollar_prefix_field_name.md:1:10:1:11
+INVALID RECORD FIELD NAME - dollar_prefix_field_name.md:1:3:1:9
 # PROBLEMS
 
-┌─────────────┐
-│ PARSE ERROR ├─ A parsing error occurred: expected_expr_record_field_name ───┐
-└┬────────────┘                                                               │
+┌───────────────────────────┐
+│ INVALID RECORD FIELD NAME ├─ Record field names cannot start with a ────────┐
+└┬──────────────────────────┘  dollar sign.                                   │
  │                                                                            │
  │  { $field : "value" }                                                      │
  │    ‾‾‾‾‾‾                                                                  │
  └─────────────────────────────────────────── dollar_prefix_field_name.md:1:3 ┘
 
-    This is an unexpected parsing error. Please check your syntax.
-
-
-┌─────────────┐
-│ PARSE ERROR ├─ A parsing error occurred: ───────────────────────────────────┐
-└┬────────────┘  expected_expr_close_curly_or_comma                           │
- │                                                                            │
- │  { $field : "value" }                                                      │
- │           ‾                                                                │
- └────────────────────────────────────────── dollar_prefix_field_name.md:1:10 ┘
-
-    This is an unexpected parsing error. Please check your syntax.
+    Names that start with $ are reassignable variables declared with the `var`
+    keyword, so they cannot be used as record field names.
 
 # TOKENS
 ~~~zig
@@ -40,19 +29,24 @@ EndOfFile,
 ~~~
 # PARSE
 ~~~clojure
-(e-malformed (reason "expected_expr_close_curly_or_comma"))
+(e-record
+	(field (field "$field")
+		(e-string
+			(e-string-part (raw "value")))))
 ~~~
 # FORMATTED
 ~~~roc
-
+{ $field: "value" }
 ~~~
 # CANONICALIZE
 ~~~clojure
-(can-ir (empty true))
+(e-record
+	(fields
+		(field (name "$field")
+			(e-string
+				(e-literal (string "value"))))))
 ~~~
 # TYPES
 ~~~clojure
-(inferred-types
-	(defs)
-	(expressions))
+(expr (type "{ $field: Str }"))
 ~~~


### PR DESCRIPTION
#9979 disallowed `$`-prefixed record field names, but it reused generic parse diagnostics, reported multiple cascading errors for a single bad field, and recovered by aborting the surrounding construct — aggressively enough that `roc format` would erase a record expression containing one. It also left the app header's inline packages collection unguarded, so `app [main!] { $pf: platform "..." }` was still accepted with no errors at all.

This replaces those guards with a dedicated diagnostic explaining that `$` names are reassignable variables and cannot be field labels, switches recovery to diagnose-and-continue so exactly one error is reported per bad field and both the parse tree and formatter output preserve the source, and extends the rejection to all five field-name sites: record literals, record patterns, record type annotations, package headers, and app headers. The header path also no longer manufactures a malformed record-field node for `$` names, which previously decoded as a phantom field named after token zero.
