### PR TITLE
Prepare nightly glue package files

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2288,6 +2288,7 @@ pub fn build(b: *std.Build) void {
     const run_snapshot_tool_step = b.step("run-snapshot-tool", "Run the snapshot tool to update snapshot files");
     const echo_wasm_step = b.step("build-echo-wasm", "Build the echo platform to zig-out/lib/echo.wasm");
     const echo_wasm_archive_step = b.step("build-echo-wasm-archive", "Build echo.wasm and zstd-compress it to zig-out/lib/echo.wasm.zst");
+    const build_glue_release_step = b.step("build-glue-release", "Build release-ready glue package and specs");
 
     const build_test_hosts_step = b.step("build-test-hosts", "Build test platform host libraries");
     const build_release_step = b.step("build-release", "Build optimized release binary for distribution");
@@ -2329,6 +2330,7 @@ pub fn build(b: *std.Build) void {
     const test_progress_interval_ms = b.option(u64, "test-progress-interval-ms", "Print non-TTY parallel test progress every N milliseconds; 0 disables it") orelse 0;
     const eval_no_fork = b.option(bool, "eval-no-fork", "Run eval tests in-process instead of through fork isolation") orelse false;
     const eval_time_worker = b.option(bool, "eval-time-worker", "Print eval worker startup timing instrumentation") orelse false;
+    const glue_release_tag = b.option([]const u8, "glue-release-tag", "Nightly release tag used in generated glue package URLs");
     if (shared_memory_size) |size| {
         if (size == 0) {
             std.log.err("-Dshared-memory-size must be greater than 0", .{});
@@ -3443,6 +3445,38 @@ pub fn build(b: *std.Build) void {
         // Ensure the wasm is built before the test runs.
         run_echo_wasm_test.step.dependOn(&echo_wasm_install.step);
         run_test_echo_wasm_step.dependOn(&run_echo_wasm_test.step);
+    }
+
+    {
+        const glue_release_exe = b.addExecutable(.{
+            .name = "glue_release",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/build/glue_release.zig"),
+                .target = target,
+                .optimize = optimize,
+            }),
+        });
+        configureBackend(glue_release_exe, target);
+
+        const glue_package_cmd = b.addRunArtifact(roc_exe);
+        glue_package_cmd.setCwd(b.path("src/glue/platform"));
+        glue_package_cmd.addArgs(&.{ "bundle", "--output-dir" });
+        const glue_package_dir = glue_package_cmd.addOutputDirectoryArg("glue-package");
+        glue_package_cmd.addArg("main.roc");
+
+        const glue_release_cmd = b.addRunArtifact(glue_release_exe);
+        glue_release_cmd.addArg(glue_release_tag orelse "nightly-local");
+        glue_release_cmd.addDirectoryArg(glue_package_dir);
+        const glue_release_dir = glue_release_cmd.addOutputDirectoryArg("glue-release");
+
+        const glue_release_install = b.addInstallDirectory(.{
+            .source_dir = glue_release_dir,
+            .install_dir = .prefix,
+            .install_subdir = "glue-release",
+        });
+        const clean_glue_release_install = RemoveDirTreeStep.create(b, b.getInstallPath(.prefix, "glue-release"));
+        glue_release_install.step.dependOn(&clean_glue_release_install.step);
+        build_glue_release_step.dependOn(&glue_release_install.step);
     }
 
     // Build playground integration tests - now enabled for all optimization modes.

--- a/src/build/glue_release.zig
+++ b/src/build/glue_release.zig
@@ -1,0 +1,152 @@
+//! Build helper: prepare release-ready glue package files.
+//!
+//! Usage:
+//!   glue_release <release-tag> <bundle-dir> <output-dir>
+//!
+//! The output directory receives:
+//!   - package/<hash>.tar.zst
+//!   - glue/RustGlue.roc
+//!   - glue/ZigGlue.roc
+//!   - glue/CGlue.roc
+//!   - glue/README.md
+//!   - glue/env
+
+const std = @import("std");
+
+const glue_specs = [_]Spec{
+    .{ .source = "src/glue/src/RustGlue.roc", .dest = "RustGlue.roc" },
+    .{ .source = "src/glue/src/ZigGlue.roc", .dest = "ZigGlue.roc" },
+    .{ .source = "src/glue/src/CGlue.roc", .dest = "CGlue.roc" },
+};
+
+const source_platform_header = "platform \"../platform/main.roc\"";
+
+const Spec = struct {
+    source: []const u8,
+    dest: []const u8,
+};
+
+/// Copies the bundled glue platform and rewrites glue specs for a nightly release.
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+
+    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa_impl.deinit();
+    const gpa = gpa_impl.allocator();
+
+    var arena_impl = std.heap.ArenaAllocator.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    const stderr_file: std.Io.File = .stderr();
+    const args = try init.minimal.args.toSlice(arena);
+    if (args.len != 4) {
+        stderr_file.writeStreamingAll(io, "Usage: glue_release <release-tag> <bundle-dir> <output-dir>\n") catch {};
+        std.process.exit(2);
+    }
+
+    const release_tag = args[1];
+    const bundle_dir = args[2];
+    const output_dir = args[3];
+
+    if (!std.mem.startsWith(u8, release_tag, "nightly-")) {
+        stderr_file.writeStreamingAll(io, "glue_release: release tag must start with nightly-\n") catch {};
+        std.process.exit(2);
+    }
+
+    std.Io.Dir.cwd().deleteTree(io, output_dir) catch {};
+    try std.Io.Dir.cwd().createDirPath(io, output_dir);
+
+    const package_dir = try std.fs.path.join(arena, &.{ output_dir, "package" });
+    const glue_dir = try std.fs.path.join(arena, &.{ output_dir, "glue" });
+    try std.Io.Dir.cwd().createDirPath(io, package_dir);
+    try std.Io.Dir.cwd().createDirPath(io, glue_dir);
+
+    var bundle_source_dir = try std.Io.Dir.cwd().openDir(io, bundle_dir, .{ .iterate = true });
+    defer bundle_source_dir.close(io);
+    const bundle_name = try findBundleName(arena, &bundle_source_dir, io);
+    const bundle_dest = try std.fs.path.join(arena, &.{ package_dir, bundle_name });
+    try bundle_source_dir.copyFile(bundle_name, std.Io.Dir.cwd(), bundle_dest, io, .{});
+
+    const package_url = try std.fmt.allocPrint(
+        arena,
+        "https://github.com/roc-lang/nightlies/releases/download/{s}/{s}",
+        .{ release_tag, bundle_name },
+    );
+
+    for (glue_specs) |spec| {
+        const source = try std.Io.Dir.cwd().readFileAlloc(io, spec.source, arena, .limited(16 * 1024 * 1024));
+        const rewritten = try replacePlatformHeader(arena, source, package_url);
+        const dest = try std.fs.path.join(arena, &.{ glue_dir, spec.dest });
+        try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = dest, .data = rewritten });
+    }
+
+    const readme = try std.fmt.allocPrint(arena,
+        \\# Roc Glue
+        \\
+        \\These glue specs are generated for {s}.
+        \\
+        \\They reference this matching glue platform package:
+        \\
+        \\```text
+        \\{s}
+        \\```
+        \\
+        \\Use `roc glue` with one of these spec files:
+        \\
+        \\```sh
+        \\roc glue "$ROC_RUST_GLUE" platform/main.roc --output-dir generated
+        \\roc glue "$ROC_ZIG_GLUE" platform/main.roc --output-dir generated
+        \\roc glue "$ROC_C_GLUE" platform/main.roc --output-dir generated
+        \\```
+        \\
+        \\`setup-roc` exports `ROC_GLUE_DIR`, `ROC_RUST_GLUE`, `ROC_ZIG_GLUE`,
+        \\`ROC_C_GLUE`, and `ROC_GLUE_PLATFORM_URL` when these files are present
+        \\in the installed Roc archive.
+        \\
+    , .{ release_tag, package_url });
+    try std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = try std.fs.path.join(arena, &.{ glue_dir, "README.md" }),
+        .data = readme,
+    });
+
+    const env = try std.fmt.allocPrint(arena,
+        \\ROC_GLUE_PLATFORM_URL={s}
+        \\ROC_GLUE_PLATFORM_PACKAGE={s}
+        \\ROC_GLUE_DIR=glue
+        \\ROC_RUST_GLUE=glue/RustGlue.roc
+        \\ROC_ZIG_GLUE=glue/ZigGlue.roc
+        \\ROC_C_GLUE=glue/CGlue.roc
+        \\
+    , .{ package_url, bundle_name });
+    try std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = try std.fs.path.join(arena, &.{ glue_dir, "env" }),
+        .data = env,
+    });
+}
+
+fn replacePlatformHeader(allocator: std.mem.Allocator, source: []const u8, package_url: []const u8) ![]u8 {
+    var count: usize = 0;
+    var search_start: usize = 0;
+    while (std.mem.findPos(u8, source, search_start, source_platform_header)) |match_start| {
+        count += 1;
+        search_start = match_start + source_platform_header.len;
+    }
+
+    if (count != 1) return error.InvalidGlueSpecHeader;
+
+    const replacement = try std.fmt.allocPrint(allocator, "platform \"{s}\"", .{package_url});
+    return std.mem.replaceOwned(u8, allocator, source, source_platform_header, replacement);
+}
+
+fn findBundleName(allocator: std.mem.Allocator, dir: *std.Io.Dir, io: std.Io) ![]const u8 {
+    var found: ?[]const u8 = null;
+    var iterator = dir.iterate();
+    while (try iterator.next(io)) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.name, ".tar.zst")) continue;
+        if (found != null) return error.MultipleBundleFiles;
+        found = try allocator.dupe(u8, entry.name);
+    }
+    return found orelse error.NoBundleFile;
+}

--- a/src/glue/README.md
+++ b/src/glue/README.md
@@ -1,0 +1,46 @@
+# Roc Glue Release Files
+
+The checked-in glue specs under `src/glue/src/` use the source-tree platform at
+`../platform/main.roc`. Keep that form for local compiler development.
+
+Nightly releases should use generated copies instead:
+
+```sh
+zig build build-glue-release -Dglue-release-tag=nightly-YYYY-Month-DD-SHORTSHA
+```
+
+This writes `zig-out/glue-release/`:
+
+```text
+package/<hash>.tar.zst
+glue/RustGlue.roc
+glue/ZigGlue.roc
+glue/CGlue.roc
+glue/README.md
+glue/env
+```
+
+The package archive is produced by running `roc bundle` in `src/glue/platform`
+with `main.roc` as the root file. The release helper only copies that archive
+and rewrites the release specs to point at its content-hash URL.
+
+Upload `package/<hash>.tar.zst` to the matching `roc-lang/nightlies` release.
+Include the generated `glue/` directory in every platform compiler archive for
+that same release. The generated specs reference the exact package URL, so
+downstream repos do not need a Roc source checkout.
+
+When `roc-lang/setup-roc` installs a nightly that contains `glue/`, it exports:
+
+```text
+ROC_GLUE_DIR
+ROC_RUST_GLUE
+ROC_ZIG_GLUE
+ROC_C_GLUE
+ROC_GLUE_PLATFORM_URL
+```
+
+Downstream CI can then run:
+
+```sh
+roc glue "$ROC_RUST_GLUE" ./platform/main.roc --output-dir ./platform
+```


### PR DESCRIPTION
## Summary
- add a build-glue-release step that runs `roc bundle --output-dir ... main.roc` from `src/glue/platform` to produce the content-addressed glue platform package
- generate release-ready Rust/Zig/C glue specs that point at the matching roc-lang/nightlies package URL
- document the release layout and downstream setup-roc environment variables

## Testing
- `zig build build-glue-release -Dglue-release-tag=nightly-2026-July-07-test --summary all --color off`
- verified generated package archive contains `main.roc` at the root
- `zig build run-test-cli -- --suite glue --summary all --color off`

Companion setup-roc PR: https://github.com/roc-lang/setup-roc/pull/8

Part of #9806.