### PR TITLE
Regenerate where_to snapshots for shifted constraint vars

### DIFF
--- a/test/snapshots/where_to_i32_wrap_accepts_i32.md
+++ b/test/snapshots/where_to_i32_wrap_accepts_i32.md
@@ -87,7 +87,7 @@ _ = function(value)
 			(args
 				(p-assign (ident "convertible")))
 			(e-block
-				(e-dispatch-call (method "to_i32_wrap") (constraint-fn-var 47)
+				(e-dispatch-call (method "to_i32_wrap") (constraint-fn-var 50)
 					(receiver
 						(e-lookup-local
 							(p-assign (ident "convertible"))))
@@ -108,7 +108,7 @@ _ = function(value)
 			(ty-lookup (name "I32") (builtin))))
 	(d-let
 		(p-underscore)
-		(e-call (constraint-fn-var 161)
+		(e-call (constraint-fn-var 164)
 			(e-lookup-local
 				(p-assign (ident "function")))
 			(e-lookup-local

--- a/test/snapshots/where_to_str_accepts_str.md
+++ b/test/snapshots/where_to_str_accepts_str.md
@@ -83,7 +83,7 @@ _ = function(value)
 			(args
 				(p-assign (ident "convertible")))
 			(e-block
-				(e-dispatch-call (method "to_str") (constraint-fn-var 51)
+				(e-dispatch-call (method "to_str") (constraint-fn-var 54)
 					(receiver
 						(e-lookup-local
 							(p-assign (ident "convertible"))))
@@ -103,7 +103,7 @@ _ = function(value)
 			(e-literal (string "my string"))))
 	(d-let
 		(p-underscore)
-		(e-call (constraint-fn-var 72)
+		(e-call (constraint-fn-var 75)
 			(e-lookup-local
 				(p-assign (ident "function")))
 			(e-lookup-local

--- a/test/snapshots/where_to_u32_try_accepts_u32.md
+++ b/test/snapshots/where_to_u32_try_accepts_u32.md
@@ -94,9 +94,9 @@ _ = function(value)
 			(args
 				(p-assign (ident "convertible")))
 			(e-block
-				(e-dispatch-call (method "ok_or") (constraint-fn-var 100)
+				(e-dispatch-call (method "ok_or") (constraint-fn-var 103)
 					(receiver
-						(e-dispatch-call (method "to_u32_try") (constraint-fn-var 65)
+						(e-dispatch-call (method "to_u32_try") (constraint-fn-var 68)
 							(receiver
 								(e-lookup-local
 									(p-assign (ident "convertible"))))
@@ -121,7 +121,7 @@ _ = function(value)
 			(ty-lookup (name "U32") (builtin))))
 	(d-let
 		(p-underscore)
-		(e-call (constraint-fn-var 299)
+		(e-call (constraint-fn-var 302)
 			(e-lookup-local
 				(p-assign (ident "function")))
 			(e-lookup-local

--- a/test/snapshots/where_to_u64_accepts_u64.md
+++ b/test/snapshots/where_to_u64_accepts_u64.md
@@ -87,7 +87,7 @@ _ = function(value)
 			(args
 				(p-assign (ident "convertible")))
 			(e-block
-				(e-dispatch-call (method "to_u64") (constraint-fn-var 47)
+				(e-dispatch-call (method "to_u64") (constraint-fn-var 50)
 					(receiver
 						(e-lookup-local
 							(p-assign (ident "convertible"))))
@@ -108,7 +108,7 @@ _ = function(value)
 			(ty-lookup (name "U64") (builtin))))
 	(d-let
 		(p-underscore)
-		(e-call (constraint-fn-var 161)
+		(e-call (constraint-fn-var 164)
 			(e-lookup-local
 				(p-assign (ident "function")))
 			(e-lookup-local


### PR DESCRIPTION
`zig build run-check-snapshots` is currently red on `main`: the four `where_to_*` snapshots added in #9896 were generated before neighboring merges shifted `constraint-fn-var` numbering by three, so regenerating them on current main produces a diff. This regenerates them with no other changes.

Verified by checking out `561c050716` (current main) into a clean worktree and running `zig build run-check-snapshots` — it fails with exactly this diff before, and passes after.

Every PR that builds a merge with current main inherits this failure (e.g. #9913's minici runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)