### PR TITLE
Fix roc docs --main for platform URL packages

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -13080,7 +13080,7 @@ fn rocDocs(ctx: *CliCtx, args: cli_args.DocsArgs) CliMainError!void {
     var result_with_env = checkFileWithBuildEnvPreserved(
         ctx,
         args.path,
-        null,
+        args.main,
         args.time,
         cache_config,
         null, // max_threads: use default (single-threaded for now)

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -378,6 +378,7 @@ const CustomCase = enum {
     verbose_and_non_verbose_failure_format_match,
     build_warning_interpreter,
     issue_9392_deterministic_no_cache,
+    docs_main_platform_url_package,
     build_issue_9435_hosted_nominal_return,
     bundle_complex_package,
     glue_debug,
@@ -1117,6 +1118,7 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "issue 9961: non-colliding associated alias and qualified self-module reference keep resolving", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_9961_assoc_reexport/Controls.roc", .exit = .success, .contains_any = &.{.{ .needles = &no_errors_needles }}, .not_contains = &.{ .{ .stream = .stderr, .text = "RECURSIVE ALIAS" }, .{ .stream = .stderr, .text = "panic" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "issue 9912: associated value self-reference reports invalid assignment instead of overflowing", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_9912_assoc_self_value/SelfRef.roc", .exit = .not_panic, .stderr_min_len = 1, .contains = &.{.{ .stream = .stderr, .text = "INVALID ASSIGNMENT TO ITSELF" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "overflowed its stack" }, .{ .stream = .stderr, .text = "panic" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "issue 9912: platform module via --main with unresolvable package reports import errors without overflow", .body = .{ .command = .{ .args = &.{ "check", "--main=test/cli/issue_9912_platform_url_package/platform/main.roc", "--no-cache" }, .roc_file = "test/cli/issue_9912_platform_url_package/platform/Api.roc", .exit = .not_panic, .stderr_min_len = 1, .not_contains = &.{ .{ .stream = .stderr, .text = "overflowed its stack" }, .{ .stream = .stderr, .text = "panic" } } } } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 9912: roc docs uses --main platform URL package dependencies", .body = .{ .custom = .docs_main_platform_url_package } },
     .{ .id = 0, .suite = .subcommands, .name = "roc check succeeds on Parser type module", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/package_simple_parser/Parser.roc", .not_contains = &.{.{ .stream = .stderr, .text = "error" }} } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc check succeeds when block-local associated value captures local value", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/block_local_assoc_capture/Test.roc", .exit = .success } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc test runs expects in Parser type module (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{ "test", "--opt=interpreter", "--no-cache" }, .roc_file = "test/package_simple_parser/Parser.roc", .contains = &.{ .{ .stream = .stdout, .text = "passed" }, .{ .stream = .stdout, .text = "(7)" } } } } },
@@ -2025,6 +2027,7 @@ fn runCustomCase(
         .verbose_and_non_verbose_failure_format_match => customVerboseAndNonVerboseFailureFormatMatch(io, allocator, &timer, timeout_ms, spec.backend orelse .interpreter),
         .build_warning_interpreter => customBuildWarningInterpreter(io, allocator, &env, &timer, timeout_ms),
         .issue_9392_deterministic_no_cache => customIssue9392Deterministic(io, allocator, &env, &timer, timeout_ms),
+        .docs_main_platform_url_package => customDocsMainPlatformUrlPackage(io, allocator, &env, &timer, timeout_ms),
         .build_issue_9435_hosted_nominal_return => customBuildIssue9435(io, allocator, &env, &timer, timeout_ms),
         .bundle_complex_package => customBundleComplexPackage(io, allocator, &env, &timer, timeout_ms),
         .glue_debug => customGlueDebug(io, allocator, &env, &timer, timeout_ms),
@@ -4897,6 +4900,113 @@ fn customIssue9392Deterministic(io: std.Io, allocator: Allocator, env: *const Ca
     };
     if (runRocAndCheck(io, allocator, env, timer, timeout_ms, command)) |failure| return failure;
     if (runRocAndCheck(io, allocator, env, timer, timeout_ms, command)) |failure| return failure;
+    return null;
+}
+
+fn customDocsMainPlatformUrlPackage(
+    io: std.Io,
+    allocator: Allocator,
+    env: *const CaseEnv,
+    timer: *harness.Timer,
+    timeout_ms: u64,
+) ?TestResult {
+    const fake_hash = "FakeHashAbcDefGhiJkLmNoPqRsTuVwXyZ123456789o";
+    const package_url = "https://example.com/roc/http/1.2.3/" ++ fake_hash ++ ".tar.zst";
+
+    const cache_package_dir = std.fs.path.join(allocator, &.{ env.dirs.roc_cache_dir, "roc", "packages", fake_hash }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate package cache path: {}", .{err});
+    defer allocator.free(cache_package_dir);
+    std.Io.Dir.cwd().createDirPath(io, cache_package_dir) catch |err|
+        return customInfraFailure(allocator, timer, "failed to create package cache: {}", .{err});
+
+    const cached_main = std.fs.path.join(allocator, &.{ cache_package_dir, "main.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate cached package main path: {}", .{err});
+    defer allocator.free(cached_main);
+    std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = cached_main,
+        .data = "package [Request] {}\n",
+    }) catch |err| return customInfraFailure(allocator, timer, "failed to write cached package main: {}", .{err});
+
+    const cached_request = std.fs.path.join(allocator, &.{ cache_package_dir, "Request.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate cached Request module path: {}", .{err});
+    defer allocator.free(cached_request);
+    std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = cached_request,
+        .data =
+        \\Request := {}.{
+        \\    ## Set a request URI.
+        \\    with_uri : Request, Str -> Request
+        \\    with_uri = |request, _uri| request
+        \\}
+        \\
+        ,
+    }) catch |err| return customInfraFailure(allocator, timer, "failed to write cached Request module: {}", .{err});
+
+    const platform_dir = std.fs.path.join(allocator, &.{ env.dirs.work_dir, "issue_9912_docs_platform", "platform" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate platform path: {}", .{err});
+    defer allocator.free(platform_dir);
+    std.Io.Dir.cwd().createDirPath(io, platform_dir) catch |err|
+        return customInfraFailure(allocator, timer, "failed to create platform directory: {}", .{err});
+
+    const platform_main = std.fs.path.join(allocator, &.{ platform_dir, "main.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate platform main path: {}", .{err});
+    defer allocator.free(platform_main);
+    const platform_source = std.mem.concat(allocator, u8, &.{
+        "platform \"docs-url-repro\"\n",
+        "    requires {} { main : {} -> {} }\n",
+        "    exposes [Api]\n",
+        "    packages {\n",
+        "        http: \"",
+        package_url,
+        "\",\n",
+        "    }\n",
+        "    provides { \"roc_main\": main_for_host }\n",
+        "    hosted {}\n",
+        "    targets: {}\n\n",
+        "import Api\n\n",
+        "main_for_host : {} -> {}\n",
+        "main_for_host = |{}| main({})\n",
+    }) catch |err| return customInfraFailure(allocator, timer, "failed to render platform source: {}", .{err});
+    defer allocator.free(platform_source);
+    std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = platform_main,
+        .data = platform_source,
+    }) catch |err| return customInfraFailure(allocator, timer, "failed to write platform main: {}", .{err});
+
+    const api_path = std.fs.path.join(allocator, &.{ platform_dir, "Api.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate Api module path: {}", .{err});
+    defer allocator.free(api_path);
+    std.Io.Dir.cwd().writeFile(io, .{
+        .sub_path = api_path,
+        .data =
+        \\import http.Request
+        \\
+        \\## Re-export request helper from the URL package.
+        \\request_with_uri = Request.with_uri
+        \\
+        ,
+    }) catch |err| return customInfraFailure(allocator, timer, "failed to write Api module: {}", .{err});
+
+    const main_arg = std.fmt.allocPrint(allocator, "--main={s}", .{platform_main}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate --main arg: {}", .{err});
+    defer allocator.free(main_arg);
+    const output_dir = std.fs.path.join(allocator, &.{ env.dirs.work_dir, "issue_9912_docs_out" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate docs output path: {}", .{err});
+    defer allocator.free(output_dir);
+    const output_arg = std.fmt.allocPrint(allocator, "--output={s}", .{output_dir}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate --output arg: {}", .{err});
+    defer allocator.free(output_arg);
+
+    const args = [_][]const u8{ "docs", "--no-cache", main_arg, output_arg };
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &args,
+        .roc_file = api_path,
+        .file_path_mode = .absolute,
+        .exit = .success,
+        .contains = &.{.{ .stream = .stdout, .text = "Generated docs for" }},
+        .not_contains = &.{ .{ .stream = .stderr, .text = "overflowed its stack" }, .{ .stream = .stderr, .text = "panic" } },
+    })) |failure| return failure;
+
     return null;
 }
 

--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -230,6 +230,7 @@ pub const BuildEnv = struct {
     discovered_root_abs: ?[]const u8 = null,
     discovered_root_dir: ?[]const u8 = null,
     discovered_pkg_name: ?[]const u8 = null,
+    entry_module_abs: ?[]const u8 = null,
 
     // Owned resolver ctx pointers for cleanup (typed)
     resolver_ctxs: std.array_list.Managed(*ResolverCtx),
@@ -352,6 +353,7 @@ pub const BuildEnv = struct {
         // Free discovery state
         if (self.discovered_root_abs) |ra| self.gpa.free(ra);
         if (self.discovered_root_dir) |rd| self.gpa.free(rd);
+        if (self.entry_module_abs) |entry| self.gpa.free(@constCast(entry));
         // discovered_pkg_name is borrowed from the packages map key.
 
         // Free resolver ctxs owned by this BuildEnv (if any)
@@ -548,49 +550,16 @@ pub const BuildEnv = struct {
 
     pub fn buildWithMain(self: *BuildEnv, root_file: []const u8, main_file: []const u8) BuildWithMainError!void {
         try self.discoverDependencies(main_file);
-        try self.replaceDiscoveredRootFile(root_file);
+        try self.setDiscoveredEntryModule(root_file);
         try self.compileDiscovered();
     }
 
-    fn replaceDiscoveredRootFile(self: *BuildEnv, root_file: []const u8) BuildError!void {
-        const pkg_name = self.discovered_pkg_name orelse return error.Internal;
-        const pkg = self.packages.getPtr(pkg_name) orelse return error.Internal;
-
+    fn setDiscoveredEntryModule(self: *BuildEnv, root_file: []const u8) BuildError!void {
+        _ = self.discovered_pkg_name orelse return error.Internal;
         const root_abs = try self.makeAbsolute(root_file);
         errdefer self.gpa.free(root_abs);
-
-        var header_info = try self.parseHeaderDeps(root_abs);
-        defer header_info.deinit(self.gpa);
-
-        const is_executable = header_info.kind == .app or header_info.kind == .default_app;
-        if (!is_executable and header_info.kind != .module and header_info.kind != .type_module and header_info.kind != .package and header_info.kind != .platform) {
-            return error.UnsupportedHeader;
-        }
-
-        freeSlice(self.gpa, pkg.root_file);
-        pkg.root_file = root_abs;
-        pkg.root_file_state = header_info.source_file_state;
-        pkg.kind = header_info.kind;
-
-        for (pkg.provides_entries.items) |entry| {
-            freeConstSlice(self.gpa, entry.roc_ident);
-            freeConstSlice(self.gpa, entry.ffi_symbol);
-        }
-        pkg.provides_entries.deinit(self.gpa);
-        pkg.provides_entries = .empty;
-        self.clearPackageExposes(pkg);
-        if (pkg.targets_config) |tc| tc.deinit(self.gpa);
-        pkg.targets_config = null;
-
-        if (header_info.kind == .platform or header_info.kind == .app or header_info.kind == .default_app) {
-            pkg.provides_entries = header_info.provides_entries;
-            header_info.provides_entries = .empty;
-            pkg.targets_config = header_info.targets_config;
-            header_info.targets_config = null;
-            if (header_info.kind == .platform) {
-                self.moveHeaderExposesToPackage(pkg, &header_info);
-            }
-        }
+        if (self.entry_module_abs) |old| self.gpa.free(@constCast(old));
+        self.entry_module_abs = root_abs;
     }
 
     /// Initialize the actor model coordinator.
@@ -688,7 +657,7 @@ pub const BuildEnv = struct {
 
         // Resolve the full dependency graph (downloads plus version solving),
         // then materialize the resolved packages and their shorthands.
-        if (header_info.kind == .app or header_info.kind == .default_app or header_info.kind == .package) {
+        if (header_info.kind == .app or header_info.kind == .default_app or header_info.kind == .package or header_info.kind == .platform) {
             try self.resolveAndMaterialize(key_pkg);
         }
     }
@@ -789,6 +758,21 @@ pub const BuildEnv = struct {
 
         // Queue initial parse task
         try coord.enqueueParseTask(pkg_name, root_id);
+
+        if (self.entry_module_abs) |entry_file| {
+            if (!std.mem.eql(u8, entry_file, pkg_root_file)) {
+                const entry_module_name = PackageEnv.moduleNameFromPath(entry_file);
+                const entry_id = try coord_pkg.ensureModule(self.gpa, entry_module_name, entry_file);
+                const entry_module = &coord_pkg.modules.items[entry_id];
+                entry_module.validate_as_explicit_roots = true;
+                if (entry_module.phase == .Parse) {
+                    entry_module.depth = 0;
+                    coord_pkg.remaining_modules += 1;
+                    coord.total_remaining += 1;
+                    try coord.enqueueParseTask(pkg_name, entry_id);
+                }
+            }
+        }
 
         // Also queue the platform's root module if this is an app
         // The platform's root module contains the `requires` clause which must be compiled

--- a/src/compile/compile_package.zig
+++ b/src/compile/compile_package.zig
@@ -1439,6 +1439,7 @@ pub const PackageEnv = struct {
             self.resolver,
             self.additional_known_modules.items,
             &.{},
+            false,
         );
 
         self.total_canonicalize_ns += readStageTimer(self.roc_ctx.std_io, &canonicalize_timer);
@@ -1717,6 +1718,7 @@ pub const PackageEnv = struct {
         resolver: ?ImportResolver,
         additional_known_modules: []const KnownModule,
         pre_resolved_imports: []const messages.CanonicalizeImport,
+        validate_as_explicit_roots: bool,
     ) Allocator.Error!void {
         const gpa = roc_ctx.gpa;
 
@@ -1853,7 +1855,11 @@ pub const PackageEnv = struct {
         });
         czer.source_dir = root_dir;
         try czer.canonicalizeFile();
-        try czer.validateForChecking();
+        if (validate_as_explicit_roots) {
+            try czer.validateForExplicitRoots();
+        } else {
+            try czer.validateForChecking();
+        }
         czer.deinit();
     }
 

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -429,6 +429,7 @@ pub const ModuleState = struct {
     module_role: ModuleEnv.ModuleRole = .user,
     /// Top-level names that package metadata requires as compile-time roots.
     explicit_root_ident_names: []const []const u8 = &.{},
+    validate_as_explicit_roots: bool = false,
     /// Owned semantic module payload. Earlier phases populate only `module_env`;
     /// type checking later fills in the checked artifact.
     semantic: ?OwnedSemanticModuleData = null,
@@ -4307,6 +4308,7 @@ pub const Coordinator = struct {
                     std.debug.panic("compile.coordinator.tryUnblock missing cached AST for {s}", .{mod.name}),
                 .depth = mod.depth,
                 .imported_modules = imported_modules,
+                .validate_as_explicit_roots = mod.validate_as_explicit_roots,
             },
         });
     }
@@ -4687,6 +4689,7 @@ pub const Coordinator = struct {
             null, // Coordinator handles import resolution separately
             known_modules.items,
             task.imported_modules,
+            task.validate_as_explicit_roots,
         );
 
         const canonicalize_ns = readStageTimer(self.roc_ctx.std_io, &canonicalize_timer);

--- a/src/compile/messages.zig
+++ b/src/compile/messages.zig
@@ -94,6 +94,9 @@ pub const CanonicalizeTask = struct {
     cached_ast: *AST,
     /// Real imported semantic envs available to canonicalization
     imported_modules: []const CanonicalizeImport,
+    /// Validate this module as an explicitly requested checked-artifact root
+    /// instead of as a standalone `roc check` root.
+    validate_as_explicit_roots: bool,
 };
 
 /// Task to type-check a canonicalized module


### PR DESCRIPTION
Fixes #9912. This makes roc docs pass --main through to checking and keeps BuildEnv rooted at the platform/app root discovered from --main while queueing the requested docs/check file as an explicit entry module in that package. Platform roots now materialize URL package dependencies during dependency discovery, so exposed platform modules can resolve package-qualified imports before docs extraction.

The regression builds a deterministic platform-plus-URL-package cache fixture and verifies roc docs succeeds with --main instead of treating the exposed module as a standalone default app.