### PR TITLE
Fix json_decoder_platform_test: const-eval alias-annotated parsers

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -1541,7 +1541,7 @@ Builtin :: [].{
 			skip_record_field = |encoding, state| Json.skip_json_value(encoding, state)
 
 			missing_record_field : JsonEncoding, Str, JsonState -> Json.ParseErr
-			missing_record_field = |_, field, _| MissingRequiredField(Str.concat("Missing required field: ", field))
+			missing_record_field = |_, field, _| MissingRequiredField(field)
 
 			missing_optional_field : JsonEncoding, Str, JsonState -> [Missing, ..]
 			missing_optional_field = |_, _, _| Missing

--- a/src/compile/test/hoisted_constants_test.zig
+++ b/src/compile/test/hoisted_constants_test.zig
@@ -387,6 +387,120 @@ test "imported checked bodies restore their module's hoisted constants" {
     defer lowered.deinit();
 }
 
+test "callable binding with alias annotation is const-evaluated" {
+    // Regression test: a function-typed top-level def whose annotation
+    // mentions a type alias (here `MyErr`) must still be scheduled for
+    // compile-time evaluation when the alias expands to a fully concrete
+    // type. The internal type store conservatively marks any type that
+    // mentions an alias as needing instantiation; if the published checked
+    // type inherits that flag, the def is kept template-only and silently
+    // degrades to runtime construction (observed with Json.parser_camel()).
+    const gpa = std.testing.allocator;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(std.testing.io, ".roc_echo_platform");
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "main.roc",
+        .data =
+        \\app [main!] { pf: platform "./.roc_echo_platform/main.roc" }
+        \\
+        \\import pf.Echo
+        \\
+        \\MyErr : [Small(Str)]
+        \\
+        \\make_validator = |limit| {
+        \\    |n| if n > limit { Ok(n) } else { Err(Small("too small")) }
+        \\}
+        \\
+        \\validate : I64 -> Try(I64, MyErr)
+        \\validate = make_validator(0.I64)
+        \\
+        \\main! = |args| {
+        \\    validated = match validate(List.len(args).to_i64_wrap()) {
+        \\        Ok(n) => n
+        \\        Err(Small(_)) => 0.I64
+        \\    }
+        \\    _ = validated
+        \\    Echo.line!("done")
+        \\    Ok({})
+        \\}
+        ,
+    });
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = ".roc_echo_platform/main.roc",
+        .data =
+        \\platform ""
+        \\    requires {} { main! : List(Str) => Try({}, [Exit(I8), ..]) }
+        \\    exposes [Echo]
+        \\    packages {}
+        \\    provides { "roc_main": main_for_host! }
+        \\    hosted { "roc_echo_line": Echo.line! }
+        \\
+        \\import Echo
+        \\
+        \\main_for_host! : List(Str) => I8
+        \\main_for_host! = |args|
+        \\    match main!(args) {
+        \\        Ok({}) => 0
+        \\        Err(Exit(code)) => code
+        \\        Err(other) => {
+        \\            Echo.line!("Program exited with error: ${Str.inspect(other)}")
+        \\            1
+        \\        }
+        \\    }
+        ,
+    });
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = ".roc_echo_platform/Echo.roc",
+        .data =
+        \\Echo := [].{
+        \\    line! : Str => {}
+        \\}
+        ,
+    });
+    const app_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "main.roc", gpa);
+    defer gpa.free(app_path);
+
+    var arena_impl = collections.SingleThreadArena.init(gpa);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    var builtin_modules = try eval.BuiltinModules.init(gpa);
+    defer builtin_modules.deinit();
+
+    var coord = try Coordinator.init(
+        gpa,
+        .single_threaded,
+        1,
+        roc_target.RocTarget.detectNative(),
+        &builtin_modules,
+        build_options.compiler_version,
+        null,
+        CoreCtx.default(gpa, arena, std.testing.io),
+    );
+    defer coord.deinit();
+    coord.enable_hosted_transform = true;
+
+    try coord.start();
+    try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
+    try coord.coordinatorLoop();
+    try std.testing.expect(!coord.hasUserErrors());
+
+    try coord.finalizeExecutableArtifacts();
+    try std.testing.expect(!coord.hasUserErrors());
+
+    const app_artifact = coord.appRootCheckedArtifact();
+    var saw_callable_binding = false;
+    for (app_artifact.compile_time_roots.roots) |root| {
+        if (root.kind != .callable_binding) continue;
+        saw_callable_binding = true;
+        if (root.payload != .fn_value) return error.CallableBindingConstFnNotStored;
+    }
+    try std.testing.expect(saw_callable_binding);
+}
+
 test "hoisted constant crash reports original source region" {
     const gpa = std.testing.allocator;
 

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -776,7 +776,12 @@ pub const Store = struct {
         return switch (content) {
             .flex => true, // Flexible variables need instantiation
             .rigid => true, // Rigid variables need instantiation when used outside their defining scope
-            .alias => true, // Aliases may contain type variables, so assume they need instantiation
+            // An alias is transparent: it needs instantiation exactly when its
+            // backing type does. Aliases cannot be recursive, so this walk
+            // terminates. Treating every alias as needing instantiation would
+            // (among other things) exclude concrete alias-annotated top-level
+            // values from compile-time evaluation.
+            .alias => |alias| self.needsInstantiation(self.getAliasBackingVar(alias)),
             .structure => |flat_type| self.needsInstantiationFlatType(flat_type),
             .err => false,
         };

--- a/test/cli/JsonEncodeNullContainerEdgeCases.roc
+++ b/test/cli/JsonEncodeNullContainerEdgeCases.roc
@@ -62,7 +62,7 @@ expect {
 expect {
 	result : Try({ field : Try(Str, [Null]) }, Json.ParseErr)
 	result = Json.parse("{}")
-	result == Err(MissingRequiredField("Missing required field: field"))
+	result == Err(MissingRequiredField("field"))
 }
 
 expect {


### PR DESCRIPTION
Fixes the CamelCase-parser half of the json_decoder_platform_test failure (the missing-required-field half is the Builtin.roc change below). Bisected to 89574af505 (PR #9965), which changed the JSON error type from the nominal `Json := [...]` to the alias `Json.ParseErr : [...]`.

Root cause: in the type store, `needsInstantiation` treated every alias as needing instantiation (`.alias => true`), so the annotation `parse_camel_record : Str -> Try(..., Json.ParseErr)` produced a function type flagged needs_instantiation. That flag flows into the published checked artifact, where checkedTypeIsConcreteCompileTimeRoot uses it to decide which top-level defs get compile-time evaluated. The def was silently kept template-only, so `Json.parser_camel()` was constructed at runtime: the snake_to_camel field renames ran per call (heap allocation, which the test platform's host turns into an abort) and the original snake_case field-name strings stayed embedded in the optimized binary, failing expectBinaryOmits.

Fix (src/types/store.zig): treat aliases as transparent in needsInstantiationContent - an alias needs instantiation exactly when its backing type does. Aliases cannot be recursive, so the walk terminates. This restores exact pre-#9965 behavior: a concrete alias behaves like the concrete nominal it replaced, and the parser is const-evaluated again with the renamed field names baked in as static strings.

A broader fix was tried and deliberately backed out: recomputing needs_instantiation exactly from the published checked types in copyCheckedFunctionType. It fixed the camel case but also admitted every instantiated-generic function value (e.g. roc-parser combinator constants) into compile-time evaluation, which the downstream machinery is not ready for - it broke 4 CLI tests: a "compile-time root dependency cycle reached request scheduling" panic on a self-referential parser constant (ParserBoxedRecursiveConst), and "dispatch plan reached monotype lowering without a resolution" in the issue_9889_roc_parser fixtures. The alias-level fix keeps all of those exactly as they were.

Also included:
- src/build/roc/Builtin.roc: missing_record_field now returns MissingRequiredField(field) instead of building the message with Str.concat, which heap-allocated at runtime and aborted the alloc-trapping test host on the missing-required case.
- test/cli/JsonEncodeNullContainerEdgeCases.roc: updated the one test pinning the old "Missing required field: ..." message text.
- src/compile/test/hoisted_constants_test.zig: new regression test asserting that a function-typed top-level def whose annotation mentions a concrete type alias is scheduled for compile-time evaluation and stores a fn_value const. Verified it fails without the store.zig fix (CallableBindingConstFnNotStored) and passes with it.

Verified: json_decoder_platform_test passes (both camel binaries produce correct output with zero runtime allocations, camelCase field names baked in, snake_case names absent); ParserBoxedRecursiveConst and issue_9889_roc_parser Numbers/Letters/CsvMovies all pass; full `zig build minici` passes.

Note for future debugging: the prebuilt test apps' roc cache (.zig-cache/roc-prebuilt-cache) is not keyed on the compiler binary, so after compiler changes it can serve stale artifacts and make prebuilt-dependent tests fail spuriously; rm -rf .zig-cache/roc-prebuilt-cache clears it. Possibly worth a build.zig follow-up.