### PR TITLE
Fix Json.parse input string ownership

### DIFF
--- a/src/base/LowLevel.zig
+++ b/src/base/LowLevel.zig
@@ -608,7 +608,6 @@ pub const LowLevel = enum(u16) {
             return .{
                 .may_retain_or_release = true,
                 .result_shares_args = mask,
-                .result_unique = true,
             };
         }
 
@@ -617,7 +616,6 @@ pub const LowLevel = enum(u16) {
                 .may_retain_or_release = mask != 0,
                 .retain_args = mask,
                 .result_shares_args = mask,
-                .result_unique = true,
             };
         }
 
@@ -634,7 +632,6 @@ pub const LowLevel = enum(u16) {
                 .may_allocate = true,
                 .may_retain_or_release = true,
                 .result_shares_args = mask,
-                .result_unique = true,
             };
         }
 
@@ -672,10 +669,12 @@ pub const LowLevel = enum(u16) {
             => RcEffect.runtimeUniqueness(argMask(&.{0})),
 
             .str_drop_prefix,
-            .str_drop_prefix_caseless_ascii,
             .str_drop_suffix,
-            .str_find_first,
             => RcEffect.retainsSharingArgs(argMask(&.{0})),
+
+            .str_drop_prefix_caseless_ascii,
+            .str_find_first,
+            => RcEffect.retainsOrReleasesSharingArgs(argMask(&.{0})),
 
             .str_from_utf8 => RcEffect.retainsOrReleasesSharingArgs(argMask(&.{0})),
 

--- a/src/eval/test/host_effects_tests.zig
+++ b/src/eval/test/host_effects_tests.zig
@@ -1047,6 +1047,26 @@ pub const tests = [_]TestCase{
         .returned,
         0,
     ),
+    // Repro for https://github.com/roc-lang/roc/issues/9953:
+    // successful Json.parse should release a runtime-allocated input string.
+    exprTestWithLiveAllocations(
+        "rc balance: Json.parse releases runtime string input after success",
+        \\{
+        \\    json = Str.concat("{ \"name\": \"", "a value long enough to force a heap allocation for the whole json string\" }")
+        \\    result : Try({ name : Str }, _)
+        \\    result = Json.parse(json)
+        \\    n = match result {
+        \\        Ok(rec) => Str.count_utf8_bytes(rec.name)
+        \\        Err(_) => 0
+        \\    }
+        \\    expect n > 0
+        \\    {}
+        \\}
+    ,
+        &.{},
+        .returned,
+        0,
+    ),
     moduleTestWithLiveAllocations(
         "rc balance: recursive tag union with boxed children is fully released",
         \\Tree := [Leaf(Str), Node(Box(Tree), Box(Tree))]


### PR DESCRIPTION
Fixes #9953. This fixes a refcount imbalance in successful Json.parse calls on runtime-allocated input strings. The string helpers used while parsing returned already-retained slices, but their low-level RC metadata also made ARC retain the source, leaving one extra live reference to the input buffer; the primitive ownership metadata now distinguishes runtime-retained sharing results from ARC-retained sharing results and adds a host-effects regression.