### PR TITLE
Add docs stream markers

### DIFF
--- a/src/docs/render_html.zig
+++ b/src/docs/render_html.zig
@@ -643,6 +643,7 @@ fn writePackageIndex(ctx: *const RenderContext, gpa: Allocator, io: std.Io, dir:
     try w.writeAll("        <h1 class=\"module-name\">");
     try writeHtmlEscaped(w, display_name);
     try w.writeAll("</h1>\n");
+    try writeDocsStreamChunk(w);
 
     // Module list
     try w.writeAll("        <ul class=\"index-module-links\">\n");
@@ -654,6 +655,7 @@ fn writePackageIndex(ctx: *const RenderContext, gpa: Allocator, io: std.Io, dir:
         try w.writeAll("</a></li>\n");
     }
     try w.writeAll("        </ul>\n");
+    try writeDocsStreamChunk(w);
 
     try writeFooter(w);
     try w.writeAll("    </main>\n");
@@ -694,6 +696,7 @@ fn writeModulePageToDir(ctx: *const RenderContext, gpa: Allocator, io: std.Io, d
     try w.writeAll("        <h1 class=\"module-name\">");
     try writeHtmlEscaped(w, mod.name);
     try w.writeAll("</h1>\n");
+    try writeDocsStreamChunk(w);
 
     // Build entry tree (automatically collapses redundant top-level node
     // matching the module name, e.g. Parser > Parser or Builtin > Builtin).
@@ -708,6 +711,7 @@ fn writeModulePageToDir(ctx: *const RenderContext, gpa: Allocator, io: std.Io, d
                 try w.writeAll(":= ");
                 try renderDocTypeHtml(w, ctx, gpa, sig, false);
                 try w.writeAll("</code>\n");
+                try writeDocsStreamChunk(w);
             }
         }
     }
@@ -723,6 +727,7 @@ fn writeModulePageToDir(ctx: *const RenderContext, gpa: Allocator, io: std.Io, d
         try w.writeAll("        <div class=\"module-doc\">\n");
         try renderDocComment(w, ctx, dwl.doc, dwl.start_line);
         try w.writeAll("        </div>\n");
+        try writeDocsStreamChunk(w);
     }
 
     // Render entries
@@ -802,9 +807,35 @@ fn writeMainOpen(w: Writer, ctx: *const RenderContext, gpa: Allocator, base: []c
     try w.writeAll("            </ul>\n");
     try w.writeAll("        </form>\n");
     try w.writeAll("        <div class=\"main-content\">\n");
+    try writeDocsStreamStart(w);
+}
+
+// These bang comments are invisible during ordinary document loads, but the
+// docs soft-navigation code fetches pages as bytes and uses them as stream
+// boundaries. The NUL start marker tells the runtime where .main-content
+// begins; chunk markers are emitted only after complete top-level chunks that
+// can be safely appended to the live DOM and syntax-highlighted immediately;
+// the end marker lets the runtime flush the final content chunk and cancel the
+// response before reading footer/closing document HTML. This lets long docs
+// pages show useful highlighted content before the whole HTML file has loaded.
+// NUL, Unit Separator, and Record Separator are all one-byte unprintable
+// ASCII control characters, and Roc source cannot contain any of them
+// naturally. Browsers replace NULs while parsing HTML, but fetch() exposes the
+// original byte before the HTML parser sees it.
+fn writeDocsStreamStart(w: Writer) error{WriteFailed}!void {
+    try w.writeAll("<!--!\x00-->\n");
+}
+
+fn writeDocsStreamChunk(w: Writer) error{WriteFailed}!void {
+    try w.writeAll("<!--!\x1f-->\n");
+}
+
+fn writeDocsStreamEnd(w: Writer) error{WriteFailed}!void {
+    try w.writeAll("<!--!\x1e-->\n");
 }
 
 fn writeFooter(w: Writer) error{WriteFailed}!void {
+    try writeDocsStreamEnd(w);
     try w.writeAll("        </div>\n");
     try w.writeAll("        <footer><p>Made by people who like to make nice things.</p></footer>\n");
 }
@@ -1128,6 +1159,9 @@ fn renderEntryTree(
 
             try writeIndent(w, base);
             try w.writeAll("</article>\n");
+            if (depth == 1) {
+                try writeDocsStreamChunk(w);
+            }
         }
     } else if (node.children.items.len > 0) {
         // Non-leaf group node — render a group header and recurse at deeper depth
@@ -1145,6 +1179,9 @@ fn renderEntryTree(
         }
         try writeIndent(w, base);
         try w.writeAll("</section>\n");
+        if (depth == 1) {
+            try writeDocsStreamChunk(w);
+        }
     }
 }
 

--- a/src/docs/static/search.js
+++ b/src/docs/static/search.js
@@ -1,57 +1,3 @@
-const toggleSidebarEntryActive = (moduleName) => {
-  let sidebar = document.getElementById("sidebar-nav");
-
-  if (sidebar != null) {
-    // Un-hide everything
-    sidebar.querySelectorAll(".sidebar-entry").forEach((entry) => {
-      let link = entry.querySelector(".sidebar-module-link");
-      if (moduleName === link.dataset.moduleName) {
-        link.classList.toggle("active");
-      }
-    });
-  }
-};
-
-const setupSidebarNav = () => {
-  // Re-hide all the sub-entries except for those of the current module
-  let currentModuleName = document.querySelector(".module-name").textContent;
-  toggleSidebarEntryActive(currentModuleName);
-
-  // Use event delegation for entry toggles and sidebar group toggles
-  document.addEventListener("click", (e) => {
-    // Handle entry toggle buttons
-    if (e.target.classList.contains("entry-toggle")) {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      const moduleName = e.target.parentElement.dataset.moduleName;
-      toggleSidebarEntryActive(moduleName);
-      return;
-    }
-
-    // Handle sidebar group name clicks — toggle expanded and navigate
-    const groupName = e.target.closest(".sidebar-type-name");
-    if (groupName) {
-      const group = groupName.closest(".sidebar-type");
-      if (group) {
-        group.classList.toggle("expanded");
-      }
-      return;
-    }
-  });
-
-  // Auto-expand groups in the active module
-  const activeModule = document.querySelector(".sidebar-module-link.active");
-  if (activeModule) {
-    const subEntries = activeModule.parentElement?.querySelector(".sidebar-sub-entries");
-    if (subEntries) {
-      // Mark groups in active module as expanded
-      subEntries.querySelectorAll(".sidebar-type").forEach((group) => {
-        group.classList.add("expanded");
-      });
-    }
-  }
-};
-
 const setupSearch = () => {
   let searchTypeAhead = document.getElementById("search-type-ahead");
   let searchBox = document.getElementById("module-search");
@@ -227,37 +173,30 @@ const setupSearch = () => {
   }
 };
 
-const isTouchSupported = () => {
-  try {
-    document.createEvent("TouchEvent");
-    return true;
-  } catch (e) {
-    return false;
+const closestElement = (target, selector) =>
+  target?.closest?.(selector) ?? target?.parentElement?.closest?.(selector);
+
+const clickedLink = (event) => {
+  for (const node of event.composedPath?.() ?? []) {
+    if (node?.matches?.("a[href]")) return node;
   }
+
+  return closestElement(event.target, "a[href]");
 };
 
-const setupCodeBlocks = () => {
+const setupCodeBlocks = (root = document) => {
   // Select all <samp> elements that are children of <pre> elements
-  const codeBlocks = document.querySelectorAll("pre > samp");
+  const codeBlocks = root.querySelectorAll("pre > samp");
 
   // Iterate over each code block
   codeBlocks.forEach((codeBlock) => {
+    if (codeBlock.dataset.copyButtonReady === "true") return;
+    codeBlock.dataset.copyButtonReady = "true";
+
     // Create a "Copy" button
     const copyButton = document.createElement("button");
     copyButton.classList.add("copy-button");
     copyButton.textContent = "Copy";
-
-    // Add event listener to copy button
-    copyButton.addEventListener("click", () => {
-      const codeText = codeBlock.innerText;
-      navigator.clipboard.writeText(codeText);
-      copyButton.textContent = "Copied!";
-      copyButton.classList.add("copy-button-copied");
-      copyButton.addEventListener("mouseleave", () => {
-        copyButton.textContent = "Copy";
-        copyButton.classList.remove("copy-button-copied");
-      });
-    });
 
     // Create a container for the copy button and append it to the document
     const buttonContainer = document.createElement("div");
@@ -265,29 +204,34 @@ const setupCodeBlocks = () => {
     buttonContainer.appendChild(copyButton);
     codeBlock.parentNode.insertBefore(buttonContainer, codeBlock);
 
-    // Hide the button container by default
-    buttonContainer.style.display = "none";
-
-    if (isTouchSupported()) {
-      // Show the button container on click for touch support (e.g. mobile)
-      document.addEventListener("click", (event) => {
-        if (event.target.closest("pre > samp") !== codeBlock) {
-          buttonContainer.style.display = "none";
-        } else {
-          buttonContainer.style.display = "block";
-        }
-      });
-    } else {
-      // Show the button container on hover for non-touch support (e.g. desktop)
-      codeBlock.parentNode.addEventListener("mouseenter", () => {
-        buttonContainer.style.display = "block";
-      });
-
-      codeBlock.parentNode.addEventListener("mouseleave", () => {
-        buttonContainer.style.display = "none";
-      });
-    }
   });
+};
+
+const setupCopyButtonActions = () => {
+  document.addEventListener("click", (event) => {
+    const copyButton = closestElement(event.target, ".copy-button");
+    if (!copyButton) return;
+
+    const codeBlock = copyButton
+      .closest(".button-container")
+      ?.nextElementSibling;
+    if (!codeBlock?.matches?.("samp")) return;
+
+    navigator.clipboard.writeText(codeBlock.innerText);
+    copyButton.textContent = "Copied!";
+    copyButton.classList.add("copy-button-copied");
+  });
+
+  document.addEventListener(
+    "pointerleave",
+    (event) => {
+      if (!event.target?.matches?.(".copy-button")) return;
+
+      event.target.textContent = "Copy";
+      event.target.classList.remove("copy-button-copied");
+    },
+    true,
+  );
 };
 
 const setupSidebarToggle = () => {
@@ -312,16 +256,689 @@ const setupSidebarToggle = () => {
   );
 };
 
-// Only run setup functions if their required elements are present
-if (document.querySelector(".module-name")) {
-  setupSidebarNav();
-}
+const docsScriptRootPath = (() => {
+  const scriptUrl = document.currentScript?.src;
+  if (!scriptUrl) return "/";
 
+  const path = new URL(scriptUrl, window.location.href).pathname;
+  return path.replace(/search\.js$/, "");
+})();
+
+const setupDocsSoftNavigation = () => {
+  const docsRootPath = docsScriptRootPath;
+  const mainSelector = "main";
+  const contentSelector = ".main-content";
+  let activeNavController = undefined;
+  let navigationId = 0;
+  let loaderResetTimer = undefined;
+  let loaderShowTimer = undefined;
+  let scrollStateTimer = undefined;
+  let mainScrollBox = document.querySelector(mainSelector);
+  let cachedMainScrollTop = mainScrollBox?.scrollTop ?? 0;
+  let cachedSidebarScrollTop = 0;
+
+  if (!mainScrollBox?.querySelector(".main-content") || !window.DOMParser) return;
+
+  if ("scrollRestoration" in history) {
+    history.scrollRestoration = "manual";
+  }
+
+  const docsUrl = (href, base = window.location.href) => {
+    let url;
+
+    try {
+      url = new URL(href, base);
+    } catch (_) {
+      return undefined;
+    }
+
+    if (url.origin !== window.location.origin) return undefined;
+    if (!url.pathname.startsWith(docsRootPath)) return undefined;
+
+    return url;
+  };
+
+  const fetchKey = (url) => {
+    const key = new URL(url.href);
+    key.hash = "";
+    return key.href;
+  };
+
+  const canonicalDocsPath = (pathname) =>
+    pathname
+      .replace(/\/index\.html$/, "")
+      .replace(/\/$/, "");
+
+  const fragmentKey = (url) =>
+    `${url.origin}${canonicalDocsPath(url.pathname)}${url.search}`;
+
+  const sameDocumentFragmentLink = (link, url) => {
+    const href = link.getAttribute("href")?.trim() ?? "";
+    const hasFragmentIntent = url.hash !== "" || href.startsWith("#");
+    const current = new URL(window.location.href);
+
+    return (
+      hasFragmentIntent &&
+      fragmentKey(url) === fragmentKey(current)
+    );
+  };
+  let activeDocumentKey = fragmentKey(new URL(window.location.href));
+
+  const eligibleLinkUrl = (link) => {
+    if (!link || link.hasAttribute("download")) return undefined;
+
+    const target = link.getAttribute("target");
+    if (target && target !== "_self") return undefined;
+
+    return docsUrl(link.getAttribute("href"));
+  };
+
+  const normalizeDocsLinks = (root, base) => {
+    root.querySelectorAll("a[href]").forEach((link) => {
+      const url = docsUrl(link.getAttribute("href"), base);
+      if (!url) return;
+
+      link.setAttribute("href", `${url.pathname}${url.search}${url.hash}`);
+    });
+  };
+
+  const getSidebarScrollBox = () =>
+    document.querySelector("#sidebar-nav .module-links-container");
+
+  const getMainScrollTop = () => cachedMainScrollTop;
+
+  const setMainScrollTop = (scrollTop) => {
+    const main = document.querySelector(mainSelector);
+    if (main && cachedMainScrollTop !== scrollTop) {
+      main.scrollTop = scrollTop;
+      cachedMainScrollTop = scrollTop;
+    }
+  };
+
+  const getSidebarScrollTop = () => cachedSidebarScrollTop;
+
+  const setSidebarScrollTop = (scrollTop) => {
+    const scrollBox = getSidebarScrollBox();
+    if (scrollBox && cachedSidebarScrollTop !== scrollTop) {
+      scrollBox.scrollTop = scrollTop;
+      cachedSidebarScrollTop = scrollTop;
+    }
+  };
+
+  const currentHistoryState = () => ({
+    ...(history.state ?? {}),
+    scrollY: getMainScrollTop(),
+    sidebarScrollTop: getSidebarScrollTop(),
+  });
+
+  const saveCurrentHistoryState = () => {
+    history.replaceState(currentHistoryState(), "", window.location.href);
+  };
+
+  const scheduleScrollStateSave = () => {
+    clearTimeout(scrollStateTimer);
+
+    scrollStateTimer = setTimeout(() => {
+      saveCurrentHistoryState();
+    }, 200);
+  };
+
+  const updateMainScrollState = () => {
+    cachedMainScrollTop = document.querySelector(mainSelector)?.scrollTop ?? 0;
+    scheduleScrollStateSave();
+  };
+
+  const updateSidebarScrollState = () => {
+    cachedSidebarScrollTop = getSidebarScrollBox()?.scrollTop ?? 0;
+    scheduleScrollStateSave();
+  };
+
+  const bindMainScrollBox = () => {
+    const nextMainScrollBox = document.querySelector(mainSelector);
+    if (mainScrollBox === nextMainScrollBox) return;
+
+    mainScrollBox?.removeEventListener("scroll", updateMainScrollState);
+    mainScrollBox = nextMainScrollBox;
+    mainScrollBox?.addEventListener("scroll", updateMainScrollState, {
+      passive: true,
+    });
+    cachedMainScrollTop = mainScrollBox?.scrollTop ?? 0;
+  };
+
+  const ensureLoader = (parent = document.querySelector(mainSelector)) => {
+    let loader = document.getElementById("docs-loader");
+
+    if (!loader) {
+      loader = document.createElement("div");
+      loader.id = "docs-loader";
+      loader.setAttribute("aria-hidden", "true");
+    }
+
+    if (parent && loader.parentElement !== parent) {
+      parent.appendChild(loader);
+    }
+
+    return loader;
+  };
+
+  const startLoader = () => {
+    const loader = ensureLoader();
+    clearTimeout(loaderResetTimer);
+    clearTimeout(loaderShowTimer);
+    loader.classList.remove("is-done");
+    loader.classList.remove("is-loading");
+
+    loaderShowTimer = setTimeout(() => {
+      loader.classList.add("is-loading");
+      loaderShowTimer = undefined;
+    }, 1000);
+  };
+
+  const finishLoader = () => {
+    const loader = ensureLoader();
+    clearTimeout(loaderShowTimer);
+    loaderShowTimer = undefined;
+
+    const wasVisible = loader.classList.contains("is-loading");
+    loader.classList.remove("is-loading");
+    if (!wasVisible) {
+      loader.classList.remove("is-done");
+      return;
+    }
+
+    loader.classList.add("is-done");
+
+    clearTimeout(loaderResetTimer);
+    loaderResetTimer = setTimeout(() => {
+      loader.classList.remove("is-done");
+    }, 180);
+  };
+
+  const markerBytes = (kind) =>
+    new Uint8Array([60, 33, 45, 45, 33, kind, 45, 45, 62]);
+  // Generated docs pages use invisible bang-comments as byte-level stream
+  // markers: NUL starts .main-content, Unit Separator flushes a complete
+  // appendable/highlightable chunk, and Record Separator ends the stream.
+  const streamMarkers = [
+    { type: "start", bytes: markerBytes(0x00) },
+    { type: "chunk", bytes: markerBytes(0x1f) },
+    { type: "end", bytes: markerBytes(0x1e) },
+  ];
+  const markerTailLength =
+    Math.max(...streamMarkers.map((marker) => marker.bytes.length)) - 1;
+
+  const concatBytes = (left, right) => {
+    if (left.length === 0) return right;
+    if (right.length === 0) return left;
+
+    const combined = new Uint8Array(left.length + right.length);
+    combined.set(left);
+    combined.set(right, left.length);
+    return combined;
+  };
+
+  const byteSequenceAt = (bytes, sequence, index) => {
+    if (index + sequence.length > bytes.length) return false;
+
+    for (let offset = 0; offset < sequence.length; offset += 1) {
+      if (bytes[index + offset] !== sequence[offset]) return false;
+    }
+
+    return true;
+  };
+
+  const findStreamMarker = (bytes) => {
+    for (let index = 0; index < bytes.length; index += 1) {
+      for (const marker of streamMarkers) {
+        if (byteSequenceAt(bytes, marker.bytes, index)) {
+          return { ...marker, index };
+        }
+      }
+    }
+
+    return undefined;
+  };
+
+  const decodeHtmlEntities = (text) => {
+    const element = document.createElement("textarea");
+    element.innerHTML = text;
+    return element.value;
+  };
+
+  const titleFromBytes = (bytes) => {
+    const html = new TextDecoder().decode(bytes);
+    const match = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+    return match ? decodeHtmlEntities(match[1].trim()) : undefined;
+  };
+
+  const appendPreviewBytes = (current, bytes, limit = 65536) => {
+    if (current.length >= limit || bytes.length === 0) return current;
+
+    const available = Math.min(bytes.length, limit - current.length);
+    return concatBytes(current, bytes.subarray(0, available));
+  };
+
+  const fetchDocsResponse = (url, signal) => {
+    const key = fetchKey(url);
+    return fetch(key, { credentials: "same-origin", signal }).then((response) => {
+        if (!response.ok) {
+          throw new Error(`Could not load ${url.pathname}: ${response.status}`);
+        }
+
+        return response;
+      });
+  };
+
+  const streamMainContent = async (response, url, content, signal) => {
+    if (!response.body) {
+      throw new Error("Readable response streams are not available");
+    }
+
+    const reader = response.body.getReader();
+    let pending = new Uint8Array(0);
+    let decoder = new TextDecoder();
+    let titlePreview = new Uint8Array(0);
+    let parts = [];
+    let started = false;
+    let title = undefined;
+    let chunks = 0;
+    let bytesDecoded = 0;
+    let appendMs = 0;
+    let highlightMs = 0;
+
+    const readBodyPart = (bytes) => {
+      if (bytes.length === 0) return;
+
+      bytesDecoded += bytes.length;
+      const text = decoder.decode(bytes, { stream: true });
+      if (text) parts.push(text);
+    };
+
+    const flushChunk = async () => {
+      const tail = decoder.decode();
+      if (tail) parts.push(tail);
+
+      const html = parts.join("");
+      parts = [];
+      decoder = new TextDecoder();
+
+      if (html.length === 0) return;
+
+      const appendStart = performance.now();
+      const template = document.createElement("template");
+      template.innerHTML = html;
+      template.content.querySelectorAll("script").forEach((script) => script.remove());
+      normalizeDocsLinks(template.content, fetchKey(url));
+      setupCodeBlocks(template.content);
+      const nodes = Array.from(template.content.childNodes);
+      content.appendChild(template.content);
+      appendMs += performance.now() - appendStart;
+
+      const highlightStart = performance.now();
+      window.rocSyntax?.highlightNodes?.(nodes);
+      highlightMs += performance.now() - highlightStart;
+      chunks += 1;
+
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+
+      if (signal.aborted) {
+        throw new DOMException("Navigation aborted", "AbortError");
+      }
+    };
+
+    while (true) {
+      const { value, done } = await reader.read();
+
+      if (done) break;
+
+      pending = concatBytes(pending, value);
+
+      while (pending.length > 0) {
+        const marker = findStreamMarker(pending);
+
+        if (!marker) {
+          const safeLength = pending.length - markerTailLength;
+          if (safeLength <= 0) break;
+
+          const safeBytes = pending.subarray(0, safeLength);
+          if (started) {
+            readBodyPart(safeBytes);
+          } else {
+            titlePreview = appendPreviewBytes(titlePreview, safeBytes);
+          }
+          pending = pending.subarray(safeLength);
+          break;
+        }
+
+        const beforeMarker = pending.subarray(0, marker.index);
+        if (started) {
+          readBodyPart(beforeMarker);
+        } else {
+          titlePreview = appendPreviewBytes(titlePreview, beforeMarker);
+        }
+        pending = pending.subarray(marker.index + marker.bytes.length);
+
+        if (!started) {
+          if (marker.type === "start") {
+            started = true;
+            title = titleFromBytes(titlePreview);
+          }
+          continue;
+        }
+
+        if (marker.type === "chunk") {
+          await flushChunk();
+        } else if (marker.type === "end") {
+          await flushChunk();
+          await reader.cancel();
+          return { title, chunks, bytesDecoded, appendMs, highlightMs };
+        }
+      }
+    }
+
+    if (!started) {
+      throw new Error("Could not find docs stream start marker");
+    }
+
+    readBodyPart(pending);
+    await flushChunk();
+    return { title, chunks, bytesDecoded, appendMs, highlightMs };
+  };
+
+  const syncSidebarForUrl = (targetUrl) => {
+    const currentSidebar = document.getElementById("sidebar-nav");
+    if (!currentSidebar) return;
+
+    currentSidebar
+      .querySelectorAll(".sidebar-module-link[data-module-name]")
+      .forEach((link) => {
+        const moduleName = link.getAttribute("data-module-name");
+        if (moduleName?.startsWith("__")) return;
+
+        const linkUrl = docsUrl(link.getAttribute("href"), window.location.href);
+        if (!linkUrl) return;
+
+        link.classList.toggle(
+          "active",
+          linkUrl.pathname === targetUrl.pathname &&
+            linkUrl.search === targetUrl.search,
+        );
+      });
+
+    currentSidebar.querySelectorAll(".sidebar-value[href]").forEach((link) => {
+      const url = docsUrl(link.getAttribute("href"), window.location.href);
+      if (!url) return;
+
+      link.classList.toggle(
+        "active",
+        url.pathname === targetUrl.pathname &&
+          url.search === targetUrl.search &&
+          url.hash === targetUrl.hash,
+      );
+    });
+  };
+
+  const hashTarget = (hash) => {
+    if (!hash) return undefined;
+
+    let id = hash.slice(1);
+    try {
+      id = decodeURIComponent(id);
+    } catch (_) {
+      return undefined;
+    }
+
+    return document.getElementById(id);
+  };
+
+  const scrollToDestination = (url, restoreScroll) => {
+    if (typeof restoreScroll === "number") {
+      setMainScrollTop(restoreScroll);
+      return;
+    }
+
+    const target = hashTarget(url.hash);
+    if (target) {
+      target.scrollIntoView();
+      cachedMainScrollTop = mainScrollBox?.scrollTop ?? 0;
+    }
+  };
+
+  const restoreSameDocumentLocation = (url, state) => {
+    if (typeof state.scrollY === "number") {
+      setMainScrollTop(state.scrollY);
+    } else {
+      scrollToDestination(url);
+    }
+
+    if (typeof state.sidebarScrollTop === "number") {
+      setSidebarScrollTop(state.sidebarScrollTop);
+    }
+  };
+
+  const hideSearchResults = () => {
+    document.getElementById("search-type-ahead")?.classList.add("hidden");
+  };
+
+  const closeSidebar = () => {
+    document.body.classList.remove("sidebar-open");
+  };
+
+  const logTiming = (label, start) => {
+    // console.log(`[docs-nav] ${label} ${(performance.now() - start).toFixed(1)}ms`);
+  };
+
+  const navigate = async (href, options = {}) => {
+    const url = docsUrl(href);
+    if (!url) {
+      window.location.href = href;
+      return;
+    }
+
+    navigationId += 1;
+    const thisNavigation = navigationId;
+
+    if (activeNavController) {
+      activeNavController.abort();
+    }
+
+    activeNavController = new AbortController();
+    const signal = activeNavController.signal;
+    const oldMain = document.querySelector(mainSelector);
+    const oldContent = oldMain?.querySelector(contentSelector);
+    const sidebarScrollTop =
+      options.sidebarScrollTop ?? getSidebarScrollTop();
+    const stageUntilReady =
+      typeof options.scrollY === "number" && options.history !== "push";
+    const totalStart = performance.now();
+    // console.log(`[docs-nav] start ${url.pathname}${url.hash}`);
+
+    startLoader();
+    oldMain?.setAttribute("aria-busy", "true");
+
+    try {
+      let phaseStart = performance.now();
+      const response = await fetchDocsResponse(url, signal);
+      logTiming("fetch response", phaseStart);
+      if (thisNavigation !== navigationId) return;
+
+      if (!oldMain || !oldContent) {
+        throw new Error(`Could not find docs main content`);
+      }
+
+      phaseStart = performance.now();
+      const nextMain = oldMain.cloneNode(false);
+      const nextContent = oldContent.cloneNode(false);
+      const currentSearch = document.getElementById("module-search-form");
+      nextContent.textContent = "";
+      nextContent.removeAttribute("data-roc-highlight-id");
+      nextMain.appendChild(nextContent);
+      if (!stageUntilReady) {
+        const loader = ensureLoader();
+        if (currentSearch) nextMain.insertBefore(currentSearch, nextContent);
+        nextMain.appendChild(loader);
+      }
+      logTiming("create shell", phaseStart);
+
+      if (!stageUntilReady) {
+        phaseStart = performance.now();
+        window.rocSyntax?.clear(oldContent, false);
+        logTiming("clear highlights", phaseStart);
+
+        phaseStart = performance.now();
+        oldMain.replaceWith(nextMain);
+        bindMainScrollBox();
+        activeDocumentKey = fragmentKey(url);
+        logTiming("swap shell", phaseStart);
+
+        phaseStart = performance.now();
+        syncSidebarForUrl(url);
+        hideSearchResults();
+        closeSidebar();
+        logTiming("sidebar", phaseStart);
+      }
+
+      if (options.history === "push") {
+        phaseStart = performance.now();
+        const state = { sidebarScrollTop };
+        if (!url.hash) state.scrollY = 0;
+        history.pushState(state, "", url.href);
+        logTiming("push state", phaseStart);
+      }
+
+      if (!stageUntilReady) {
+        phaseStart = performance.now();
+        nextContent.setAttribute("tabindex", "-1");
+        logTiming("focus prep", phaseStart);
+
+        phaseStart = performance.now();
+        nextContent.focus({ preventScroll: true });
+        logTiming("focus content", phaseStart);
+      }
+
+      phaseStart = performance.now();
+      const streamStats = await streamMainContent(response, url, nextContent, signal);
+      if (streamStats.title) document.title = streamStats.title;
+      // console.log(
+      //   `[docs-nav] stream chunks=${streamStats.chunks} bytes=${streamStats.bytesDecoded} append=${streamStats.appendMs.toFixed(1)}ms highlight=${streamStats.highlightMs.toFixed(1)}ms`,
+      // );
+      logTiming("stream content", phaseStart);
+
+      if (stageUntilReady) {
+        phaseStart = performance.now();
+        window.rocSyntax?.clear(oldContent, false);
+        logTiming("clear highlights", phaseStart);
+
+        phaseStart = performance.now();
+        const currentSearchAfterStream =
+          document.getElementById("module-search-form");
+        const loader = ensureLoader();
+        if (currentSearchAfterStream) {
+          nextMain.insertBefore(currentSearchAfterStream, nextContent);
+        }
+        nextMain.appendChild(loader);
+        oldMain.replaceWith(nextMain);
+        bindMainScrollBox();
+        activeDocumentKey = fragmentKey(url);
+        logTiming("swap restored shell", phaseStart);
+
+        phaseStart = performance.now();
+        syncSidebarForUrl(url);
+        hideSearchResults();
+        closeSidebar();
+        logTiming("sidebar", phaseStart);
+
+        phaseStart = performance.now();
+        nextContent.setAttribute("tabindex", "-1");
+        logTiming("focus prep", phaseStart);
+
+        phaseStart = performance.now();
+        nextContent.focus({ preventScroll: true });
+        logTiming("focus content", phaseStart);
+      }
+
+      phaseStart = performance.now();
+      scrollToDestination(url, options.scrollY);
+      logTiming("main scroll", phaseStart);
+
+      phaseStart = performance.now();
+      setSidebarScrollTop(sidebarScrollTop);
+      logTiming("sidebar scroll", phaseStart);
+      logTiming("total", totalStart);
+    } catch (error) {
+      if (thisNavigation !== navigationId) return;
+      if (error.name === "AbortError") return;
+
+      window.location.href = url.href;
+    } finally {
+      if (thisNavigation === navigationId) {
+        activeNavController = undefined;
+        finishLoader();
+      }
+    }
+  };
+
+  normalizeDocsLinks(document, window.location.href);
+  cachedSidebarScrollTop = getSidebarScrollBox()?.scrollTop ?? 0;
+  mainScrollBox?.addEventListener("scroll", updateMainScrollState, {
+    passive: true,
+  });
+  saveCurrentHistoryState();
+
+  getSidebarScrollBox()?.addEventListener("scroll", updateSidebarScrollState, {
+    passive: true,
+  });
+
+  document.addEventListener("click", (event) => {
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+
+    const link = clickedLink(event);
+    const url = eligibleLinkUrl(link);
+    if (!url) return;
+    if (sameDocumentFragmentLink(link, url)) {
+      saveCurrentHistoryState();
+      return;
+    }
+
+    event.preventDefault();
+    saveCurrentHistoryState();
+    navigate(url.href, { history: "push" });
+  });
+
+  window.addEventListener("popstate", (event) => {
+    const state = event.state ?? {};
+    const url = docsUrl(window.location.href);
+
+    if (url && fragmentKey(url) === activeDocumentKey) {
+      restoreSameDocumentLocation(url, state);
+      return;
+    }
+
+    navigate(window.location.href, {
+      history: "replace",
+      scrollY: state.scrollY,
+      sidebarScrollTop: state.sidebarScrollTop,
+    });
+  });
+};
+
+// Only run setup functions if their required elements are present
 if (document.getElementById("module-search")) {
   setupSearch();
 }
 
 setupCodeBlocks();
+setupCopyButtonActions();
+setupDocsSoftNavigation();
 
 if (document.querySelector(".menu-toggle")) {
   setupSidebarToggle();

--- a/src/docs/static/styles.css
+++ b/src/docs/static/styles.css
@@ -187,7 +187,8 @@ table tr td {
   visibility: visible;
 }
 
-.entry-name-link {
+.entry-name-link,
+.entry-name-link:visited {
   color: inherit;
   text-decoration: none;
 }
@@ -1247,6 +1248,54 @@ code .dim {
 .copy-button:hover {
   border-color: var(--link-hover-color);
   color: var(--link-hover-color);
+}
+
+/* Docs soft navigation */
+#docs-loader {
+    display: block;
+    height: 24px;
+    margin: 32px 0 0;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 120ms ease-out;
+    width: 100%;
+}
+
+#docs-loader::before {
+    background: var(--cyan);
+    content: "";
+    display: block;
+    height: 3px;
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0s linear;
+    width: 100%;
+}
+
+#docs-loader.is-loading {
+    opacity: 1;
+}
+
+#docs-loader.is-loading::before {
+    transform: scaleX(0.7);
+    transition: transform 2s cubic-bezier(0.1, 0.8, 0.2, 1);
+}
+
+#docs-loader.is-done {
+    opacity: 1;
+}
+
+#docs-loader.is-done::before {
+    transform: scaleX(1);
+    transition: transform 160ms ease-out;
+}
+
+main > .main-content[tabindex="-1"]:focus {
+    outline: none;
+}
+
+main > .main-content[aria-busy="true"] {
+    cursor: progress;
 }
 
 /* Search container and input styling */


### PR DESCRIPTION
Generated docs now include invisible bang-comment stream markers at the start of main content, after complete top-level chunks, and at the end of the stream. The docs runtime can use those one-byte boundaries to append and highlight long pages incrementally while ordinary static HTML page loads continue to work normally.