### PR TITLE
Fix doc shorthand links to builtins

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -13252,6 +13252,7 @@ fn generateDocs(
     // Promote the builtin types (Str, Num, …) to top-level modules so the
     // internal `Builtin` container never surfaces in the generated docs.
     try package_docs.reshapeBuiltin(ctx.gpa);
+    try package_docs.resolveDocRefs(ctx.gpa);
 
     // Remove existing output directory to ensure a clean build
     try std.Io.Dir.cwd().deleteTree(ctx.io.std_io, base_output_dir);

--- a/src/docs/DocModel.zig
+++ b/src/docs/DocModel.zig
@@ -37,6 +37,20 @@ pub const PackageDocs = struct {
         try writer.writeAll(")\n");
     }
 
+    /// Resolve every shorthand `[Name]` reference in doc comments against the
+    /// final package docs layout.
+    pub fn resolveDocRefs(self: *PackageDocs, gpa: Allocator) Allocator.Error!void {
+        clearDocRefs(self, gpa);
+        errdefer clearDocRefs(self, gpa);
+
+        var resolver = try PackageDocRefResolver.init(gpa, self);
+        defer resolver.deinit();
+
+        for (self.modules) |*mod| {
+            try resolver.resolveModule(gpa, mod);
+        }
+    }
+
     /// Promote the builtin types to top-level modules.
     ///
     /// The compiler models every builtin type (`Str`, `List`, `Num`, `Hasher`, …)
@@ -89,6 +103,7 @@ pub const PackageDocs = struct {
         // the backing slice, not the elements.
         gpa.free(builtin.entries);
         if (builtin.module_doc) |doc| gpa.free(doc);
+        deinitDocRefs(gpa, builtin.module_doc_refs);
         if (builtin.source_path) |p| gpa.free(p);
         gpa.free(builtin.name);
         gpa.free(builtin.package_name);
@@ -114,6 +129,419 @@ pub const PackageDocs = struct {
         }
     }
 };
+
+fn clearDocRefs(package_docs: *PackageDocs, gpa: Allocator) void {
+    for (package_docs.modules) |*mod| {
+        deinitDocRefs(gpa, mod.module_doc_refs);
+        mod.module_doc_refs = &.{};
+        for (mod.entries) |*entry| {
+            clearEntryDocRefs(entry, gpa);
+        }
+    }
+}
+
+fn clearEntryDocRefs(entry: *DocEntry, gpa: Allocator) void {
+    deinitDocRefs(gpa, entry.doc_refs);
+    entry.doc_refs = &.{};
+    for (entry.children) |*child| {
+        clearEntryDocRefs(child, gpa);
+    }
+}
+
+const PackageDocRefResolver = struct {
+    gpa: Allocator,
+    package_docs: *const PackageDocs,
+    known_modules: std.StringHashMapUnmanaged(*const ModuleDocs),
+    builtin_type_owners: std.StringHashMapUnmanaged([]const u8),
+    documenting_builtin: bool,
+
+    fn init(gpa: Allocator, package_docs: *const PackageDocs) Allocator.Error!PackageDocRefResolver {
+        var known_modules = std.StringHashMapUnmanaged(*const ModuleDocs).empty;
+        errdefer known_modules.deinit(gpa);
+
+        var builtin_type_owners = std.StringHashMapUnmanaged([]const u8).empty;
+        errdefer builtin_type_owners.deinit(gpa);
+
+        var documenting_builtin = false;
+        for (package_docs.modules) |*mod| {
+            try known_modules.put(gpa, mod.name, mod);
+            if (std.mem.eql(u8, mod.name, "Builtin") or mod.builtin_derived) {
+                documenting_builtin = true;
+            }
+            if (mod.builtin_derived) {
+                for (mod.entries) |*entry| {
+                    try collectBuiltinDocTypeOwners(&builtin_type_owners, gpa, entry, mod.name);
+                }
+            }
+        }
+
+        return .{
+            .gpa = gpa,
+            .package_docs = package_docs,
+            .known_modules = known_modules,
+            .builtin_type_owners = builtin_type_owners,
+            .documenting_builtin = documenting_builtin,
+        };
+    }
+
+    fn deinit(self: *PackageDocRefResolver) void {
+        self.known_modules.deinit(self.gpa);
+        self.builtin_type_owners.deinit(self.gpa);
+    }
+
+    fn resolveModule(
+        self: *const PackageDocRefResolver,
+        gpa: Allocator,
+        mod: *ModuleDocs,
+    ) Allocator.Error!void {
+        var module_resolver = try ModuleDocRefResolver.init(gpa, self, mod);
+        defer module_resolver.deinit();
+
+        if (mod.module_doc) |doc| {
+            mod.module_doc_refs = try module_resolver.resolveDocComment(gpa, doc);
+        }
+        for (mod.entries) |*entry| {
+            try module_resolver.resolveEntry(gpa, entry);
+        }
+    }
+};
+
+const ModuleDocRefResolver = struct {
+    package: *const PackageDocRefResolver,
+    module: *const ModuleDocs,
+    local_anchors: std.StringHashMapUnmanaged([]const u8),
+    local_arena: std.heap.ArenaAllocator,
+
+    fn init(
+        gpa: Allocator,
+        package: *const PackageDocRefResolver,
+        mod: *const ModuleDocs,
+    ) Allocator.Error!ModuleDocRefResolver {
+        var resolver = ModuleDocRefResolver{
+            .package = package,
+            .module = mod,
+            .local_anchors = .empty,
+            .local_arena = std.heap.ArenaAllocator.init(gpa),
+        };
+        errdefer resolver.deinit();
+
+        for (mod.entries) |*entry| {
+            try resolver.registerEntry(gpa, entry, "");
+        }
+
+        return resolver;
+    }
+
+    fn deinit(self: *ModuleDocRefResolver) void {
+        self.local_anchors.deinit(self.package.gpa);
+        self.local_arena.deinit();
+    }
+
+    fn resolveEntry(self: *ModuleDocRefResolver, gpa: Allocator, entry: *DocEntry) Allocator.Error!void {
+        if (entry.doc_comment) |doc| {
+            entry.doc_refs = try self.resolveDocComment(gpa, doc);
+        }
+        for (entry.children) |*child| {
+            try self.resolveEntry(gpa, child);
+        }
+    }
+
+    fn resolveDocComment(
+        self: *const ModuleDocRefResolver,
+        gpa: Allocator,
+        doc: []const u8,
+    ) Allocator.Error![]const DocRef {
+        var refs = std.ArrayList(DocRef).empty;
+        errdefer {
+            for (refs.items) |*ref| {
+                ref.deinit(gpa);
+            }
+            refs.deinit(gpa);
+        }
+
+        var i: usize = 0;
+        var line_start: usize = 0;
+        var in_fence = false;
+        while (i < doc.len) {
+            if (i == line_start and std.mem.startsWith(u8, doc[i..], "```")) {
+                in_fence = !in_fence;
+                i = skipLine(doc, i);
+                line_start = i;
+                continue;
+            }
+
+            if (in_fence) {
+                i = skipLine(doc, i);
+                line_start = i;
+                continue;
+            }
+
+            if (doc[i] == '\n') {
+                i += 1;
+                line_start = i;
+                continue;
+            }
+
+            if (doc[i] == '`') {
+                i = skipInlineCode(doc, i);
+                continue;
+            }
+
+            if (doc[i] == '[') {
+                if (parseMarkdownLink(doc, i)) |link| {
+                    i = link.end;
+                    continue;
+                }
+                if (parseDocRef(doc, i)) |parsed| {
+                    const label = try gpa.dupe(u8, parsed.label);
+                    var label_moved = false;
+                    errdefer if (!label_moved) gpa.free(label);
+
+                    var target = try self.resolveLabel(gpa, parsed.label);
+                    var target_moved = false;
+                    errdefer if (!target_moved) target.deinit(gpa);
+
+                    try refs.append(gpa, .{
+                        .byte_offset = @intCast(i),
+                        .label = label,
+                        .target = target,
+                    });
+                    label_moved = true;
+                    target_moved = true;
+
+                    i = parsed.end;
+                    continue;
+                }
+            }
+
+            i += 1;
+        }
+
+        if (refs.items.len == 0) {
+            refs.deinit(gpa);
+            return &.{};
+        }
+
+        return refs.toOwnedSlice(gpa);
+    }
+
+    fn resolveLabel(
+        self: *const ModuleDocRefResolver,
+        gpa: Allocator,
+        label: []const u8,
+    ) Allocator.Error!DocRefTarget {
+        if (self.local_anchors.get(label)) |anchor| {
+            return .{ .local_anchor = try gpa.dupe(u8, anchor) };
+        }
+
+        const first_dot = std.mem.findScalar(u8, label, '.');
+        const head = if (first_dot) |d| label[0..d] else label;
+        const tail: []const u8 = if (first_dot) |d| label[d..] else "";
+
+        if (self.local_anchors.get(head)) |anchor_head| {
+            const anchor = if (tail.len == 0)
+                try gpa.dupe(u8, anchor_head)
+            else
+                try std.fmt.allocPrint(gpa, "{s}{s}", .{ anchor_head, tail });
+            return .{ .local_anchor = anchor };
+        }
+
+        if (self.package.known_modules.get(head)) |target_module| {
+            if (tail.len == 0) {
+                return .{ .module_page = try gpa.dupe(u8, head) };
+            }
+
+            const anchor = if (target_module.builtin_derived)
+                try gpa.dupe(u8, tail[1..])
+            else
+                try gpa.dupe(u8, label);
+            errdefer gpa.free(anchor);
+
+            return .{ .module_anchor = .{
+                .module = try gpa.dupe(u8, head),
+                .anchor = anchor,
+            } };
+        }
+
+        if (self.package.documenting_builtin) {
+            if (self.package.builtin_type_owners.get(head)) |owner| {
+                const anchor = if (tail.len == 0)
+                    try gpa.dupe(u8, head)
+                else
+                    try std.fmt.allocPrint(gpa, "{s}{s}", .{ head, tail });
+                errdefer gpa.free(anchor);
+
+                if (std.mem.eql(u8, owner, self.module.name)) {
+                    return .{ .local_anchor = anchor };
+                }
+
+                return .{ .module_anchor = .{
+                    .module = try gpa.dupe(u8, owner),
+                    .anchor = anchor,
+                } };
+            }
+        } else if (isBuiltinDocTypeName(head)) {
+            return .{ .builtin_type = try gpa.dupe(u8, label) };
+        }
+
+        return .{ .unresolved_anchor = try unresolvedAnchor(gpa, self.module.name, label) };
+    }
+
+    fn registerEntry(
+        self: *ModuleDocRefResolver,
+        gpa: Allocator,
+        entry: *const DocEntry,
+        parent_path: []const u8,
+    ) Allocator.Error!void {
+        const arena = self.local_arena.allocator();
+        const full_path = if (parent_path.len == 0) blk: {
+            if (entryNameHasModulePrefix(self.module.name, entry.name)) {
+                break :blk try arena.dupe(u8, entry.name);
+            }
+            break :blk try std.fmt.allocPrint(arena, "{s}.{s}", .{ self.module.name, entry.name });
+        } else try std.fmt.allocPrint(arena, "{s}.{s}", .{ parent_path, entry.name });
+
+        const anchor_path = if (self.module.builtin_derived)
+            moduleRelativeEntryName(self.module.name, full_path)
+        else
+            full_path;
+
+        try self.putLocalAnchor(gpa, anchor_path, anchor_path);
+        if (!std.mem.eql(u8, full_path, anchor_path)) {
+            try self.putLocalAnchor(gpa, full_path, anchor_path);
+        }
+
+        var prefix_end: usize = anchor_path.len;
+        if (entry.kind == .value) {
+            if (std.mem.findScalarLast(u8, anchor_path, '.')) |last_dot| {
+                prefix_end = last_dot;
+            } else {
+                prefix_end = 0;
+            }
+        }
+
+        var seg_start: usize = 0;
+        while (seg_start < prefix_end) {
+            const next_dot = std.mem.findScalarPos(u8, anchor_path[0..prefix_end], seg_start, '.');
+            const seg_end = next_dot orelse prefix_end;
+            const short_name = anchor_path[seg_start..seg_end];
+            const prefix_path = anchor_path[0..seg_end];
+            try self.putLocalAnchor(gpa, short_name, prefix_path);
+            try self.putLocalAnchor(gpa, prefix_path, prefix_path);
+            seg_start = if (next_dot) |d| d + 1 else prefix_end;
+        }
+
+        for (entry.children) |*child| {
+            try self.registerEntry(gpa, child, full_path);
+        }
+    }
+
+    fn putLocalAnchor(
+        self: *ModuleDocRefResolver,
+        gpa: Allocator,
+        key: []const u8,
+        anchor: []const u8,
+    ) Allocator.Error!void {
+        const result = try self.local_anchors.getOrPut(gpa, key);
+        if (!result.found_existing) {
+            const arena = self.local_arena.allocator();
+            result.key_ptr.* = try arena.dupe(u8, key);
+            result.value_ptr.* = try arena.dupe(u8, anchor);
+        }
+    }
+};
+
+fn collectBuiltinDocTypeOwners(
+    map: *std.StringHashMapUnmanaged([]const u8),
+    gpa: Allocator,
+    entry: *const DocEntry,
+    module_name: []const u8,
+) Allocator.Error!void {
+    if (entry.kind != .value) {
+        const short = if (std.mem.findScalarLast(u8, entry.name, '.')) |d| entry.name[d + 1 ..] else entry.name;
+        const result = try map.getOrPut(gpa, short);
+        if (!result.found_existing) {
+            result.value_ptr.* = module_name;
+        }
+    }
+    for (entry.children) |*child| {
+        try collectBuiltinDocTypeOwners(map, gpa, child, module_name);
+    }
+}
+
+fn unresolvedAnchor(gpa: Allocator, module_name: []const u8, label: []const u8) Allocator.Error![]const u8 {
+    if (std.mem.eql(u8, label, module_name) or
+        (std.mem.startsWith(u8, label, module_name) and
+            label.len > module_name.len and
+            label[module_name.len] == '.'))
+    {
+        return try gpa.dupe(u8, label);
+    }
+    return try std.fmt.allocPrint(gpa, "{s}.{s}", .{ module_name, label });
+}
+
+fn skipLine(text: []const u8, start: usize) usize {
+    var i = start;
+    while (i < text.len and text[i] != '\n') {
+        i += 1;
+    }
+    return if (i < text.len) i + 1 else i;
+}
+
+fn skipInlineCode(text: []const u8, start: usize) usize {
+    var i = start + 1;
+    while (i < text.len and text[i] != '`' and text[i] != '\n') {
+        i += 1;
+    }
+    return if (i < text.len and text[i] == '`') i + 1 else start + 1;
+}
+
+fn entryNameHasModulePrefix(module_name: []const u8, entry_name: []const u8) bool {
+    return std.mem.eql(u8, entry_name, module_name) or
+        (std.mem.startsWith(u8, entry_name, module_name) and
+            entry_name.len > module_name.len and
+            entry_name[module_name.len] == '.');
+}
+
+fn moduleRelativeEntryName(module_name: []const u8, entry_name: []const u8) []const u8 {
+    if (std.mem.startsWith(u8, entry_name, module_name) and
+        entry_name.len > module_name.len and
+        entry_name[module_name.len] == '.')
+    {
+        return entry_name[module_name.len + 1 ..];
+    }
+    return entry_name;
+}
+
+fn isBuiltinDocTypeName(name: []const u8) bool {
+    inline for (.{
+        "Str",
+        "List",
+        "Bool",
+        "Num",
+        "U8",
+        "U16",
+        "U32",
+        "U64",
+        "U128",
+        "I8",
+        "I16",
+        "I32",
+        "I64",
+        "I128",
+        "F32",
+        "F64",
+        "Dec",
+        "Box",
+        "Dict",
+        "Set",
+        "Iter",
+        "Try",
+    }) |builtin| {
+        if (std.mem.eql(u8, name, builtin)) return true;
+    }
+    return false;
+}
 
 /// Short (final dotted segment) of a possibly-qualified name.
 fn shortTypeName(name: []const u8) []const u8 {
@@ -302,6 +730,141 @@ pub const ModuleKind = enum {
     }
 };
 
+/// A resolved shorthand reference from doc-comment text, such as `[Str]` or
+/// `[Utf8.default]`.
+pub const DocRef = struct {
+    /// Byte offset of the opening `[` within the owning doc-comment string.
+    byte_offset: u32,
+    /// Label as written by the user, without brackets.
+    label: []const u8,
+    target: DocRefTarget,
+
+    pub fn deinit(self: *const DocRef, gpa: Allocator) void {
+        gpa.free(self.label);
+        self.target.deinit(gpa);
+    }
+};
+
+/// Destination for a resolved shorthand doc reference.
+pub const DocRefTarget = union(enum) {
+    /// Exact HTML fragment id in the current page, without the leading `#`.
+    local_anchor: []const u8,
+    /// Another module's index page.
+    module_page: []const u8,
+    /// Exact HTML fragment id in another module's page.
+    module_anchor: ModuleAnchor,
+    /// Builtin type path in the published builtin docs, e.g. `Str` or `U8`.
+    builtin_type: []const u8,
+    /// Explicitly unresolved target used only for diagnostics.
+    unresolved_anchor: []const u8,
+
+    pub const ModuleAnchor = struct {
+        module: []const u8,
+        anchor: []const u8,
+    };
+
+    pub fn deinit(self: *const DocRefTarget, gpa: Allocator) void {
+        switch (self.*) {
+            .local_anchor, .module_page, .builtin_type, .unresolved_anchor => |s| gpa.free(s),
+            .module_anchor => |ma| {
+                gpa.free(ma.module);
+                gpa.free(ma.anchor);
+            },
+        }
+    }
+};
+
+pub fn deinitDocRefs(gpa: Allocator, refs: []const DocRef) void {
+    for (refs) |*ref| {
+        ref.deinit(gpa);
+    }
+    if (refs.len > 0) {
+        gpa.free(refs);
+    }
+}
+
+/// Parsed Markdown inline link, `[label](url)`.
+pub const MarkdownLink = struct {
+    label: []const u8,
+    url: []const u8,
+    end: usize,
+};
+
+/// Parses a `[label](url)` markdown link starting at `start`, which must point
+/// to `[`. Returns null if the pattern doesn't match.
+pub fn parseMarkdownLink(text: []const u8, start: usize) ?MarkdownLink {
+    std.debug.assert(text[start] == '[');
+    var j = start + 1;
+    while (j < text.len and text[j] != ']') {
+        if (text[j] == '\n') return null;
+        j += 1;
+    }
+    if (j >= text.len) return null;
+    const label_end = j;
+    if (label_end + 1 >= text.len or text[label_end + 1] != '(') return null;
+    // Allow balanced parentheses inside the URL (e.g. a trailing ')' in a
+    // Wikipedia link like `Union_(set_theory)`): only a `)` at depth 0
+    // terminates the destination.
+    var k = label_end + 2;
+    var depth: usize = 0;
+    while (k < text.len) : (k += 1) {
+        const c = text[k];
+        if (c == '\n') return null;
+        if (c == '(') {
+            depth += 1;
+        } else if (c == ')') {
+            if (depth == 0) break;
+            depth -= 1;
+        }
+    }
+    if (k >= text.len) return null;
+    return .{
+        .label = text[start + 1 .. label_end],
+        .url = text[label_end + 2 .. k],
+        .end = k + 1,
+    };
+}
+
+/// Parsed shorthand doc reference, `[Name]` or `[Name.member]`.
+pub const ParsedDocRef = struct {
+    label: []const u8,
+    end: usize,
+};
+
+/// Parses a shorthand `[Name]` or `[Name.member]` reference to another doc
+/// entry. The label must be a (possibly dotted) identifier, and the closing
+/// bracket must not be followed by `(`.
+pub fn parseDocRef(text: []const u8, start: usize) ?ParsedDocRef {
+    std.debug.assert(text[start] == '[');
+    const label_start = start + 1;
+    if (label_start >= text.len) return null;
+    if (!isDocIdentStart(text[label_start])) return null;
+    var j = label_start + 1;
+    while (j < text.len and text[j] != ']') {
+        const c = text[j];
+        if (c == '.') {
+            if (j + 1 >= text.len or !isDocIdentStart(text[j + 1])) return null;
+        } else if (!isDocIdentCont(c)) {
+            return null;
+        }
+        j += 1;
+    }
+    if (j >= text.len) return null;
+    if (j + 1 < text.len and text[j + 1] == '(') return null;
+    return .{
+        .label = text[label_start..j],
+        .end = j + 1,
+    };
+}
+
+fn isDocIdentStart(c: u8) bool {
+    return (c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z') or c == '_';
+}
+
+fn isDocIdentCont(c: u8) bool {
+    return isDocIdentStart(c) or (c >= '0' and c <= '9');
+}
+
 /// Orders modules by (package name, module name) so docs output is
 /// deterministic regardless of the hash-map order modules are collected in.
 pub fn moduleDocsLessThan(_: void, a: ModuleDocs, b: ModuleDocs) bool {
@@ -316,6 +879,7 @@ pub const ModuleDocs = struct {
     package_name: []const u8,
     kind: ModuleKind,
     module_doc: ?[]const u8,
+    module_doc_refs: []const DocRef = &.{},
     entries: []DocEntry,
     /// Filesystem path to the module's source `.roc` file. Used by the
     /// renderer when reporting source-level diagnostics (e.g. broken
@@ -337,6 +901,7 @@ pub const ModuleDocs = struct {
         }
         gpa.free(self.entries);
         if (self.module_doc) |doc| gpa.free(doc);
+        deinitDocRefs(gpa, self.module_doc_refs);
         if (self.source_path) |p| gpa.free(p);
         gpa.free(self.name);
         gpa.free(self.package_name);
@@ -729,6 +1294,7 @@ pub const DocEntry = struct {
     kind: DocEntryKind,
     type_signature: ?*const DocType,
     doc_comment: ?[]const u8,
+    doc_refs: []const DocRef = &.{},
     children: []DocEntry,
     /// 1-based source line where `doc_comment`'s first `##` line begins.
     /// Zero when there is no doc comment or the line is unknown.
@@ -744,6 +1310,7 @@ pub const DocEntry = struct {
             gpa.destroy(sig);
         }
         if (self.doc_comment) |doc| gpa.free(doc);
+        deinitDocRefs(gpa, self.doc_refs);
         gpa.free(self.name);
     }
 

--- a/src/docs/extract.zig
+++ b/src/docs/extract.zig
@@ -2298,6 +2298,7 @@ fn moveEntryForReparenting(
     entry.children = empty_children;
     entry.type_signature = null;
     entry.doc_comment = null;
+    entry.doc_refs = &.{};
 
     return moved;
 }

--- a/src/docs/render_html.zig
+++ b/src/docs/render_html.zig
@@ -141,12 +141,6 @@ const RenderContext = struct {
     /// True when the package being documented is Builtin itself, so references
     /// to builtin types stay local instead of pointing at roc-lang.org.
     documenting_builtin: bool = false,
-    /// Maps a builtin type's short name to its owning promoted module (e.g.
-    /// "U8" -> "Num", "Utf8Problem" -> "Str"), for the modules reshaped out of
-    /// `Builtin`. Lets a bare `[U8]` shorthand in one type's docs resolve to the
-    /// page that actually documents it. Keys/values are slices into the
-    /// PackageDocs and live for the duration of rendering.
-    builtin_type_owners: std.StringHashMapUnmanaged([]const u8) = .empty,
     /// Names of the modules promoted out of `Builtin` by `reshapeBuiltin`. These
     /// use bare anchors (no `<module>.` prefix). Keys are slices into PackageDocs.
     builtin_modules: std.StringHashMapUnmanaged(void) = .empty,
@@ -179,6 +173,8 @@ const RenderContext = struct {
     pub const ActiveDoc = struct {
         /// Full doc-comment string currently being walked.
         doc: []const u8 = "",
+        /// Resolved shorthand references in `doc`.
+        refs: []const DocModel.DocRef = &.{},
         /// 1-based source line of the first character of `doc`. Zero
         /// when unknown — broken-link reports then get `source_line = 0`.
         start_line: u32 = 0,
@@ -188,8 +184,6 @@ const RenderContext = struct {
         var known = std.StringHashMapUnmanaged(void){};
         errdefer known.deinit(gpa);
         var documenting_builtin = false;
-        var builtin_type_owners = std.StringHashMapUnmanaged([]const u8){};
-        errdefer builtin_type_owners.deinit(gpa);
         var builtin_modules = std.StringHashMapUnmanaged(void){};
         errdefer builtin_modules.deinit(gpa);
         for (package_docs.modules) |mod| {
@@ -201,9 +195,6 @@ const RenderContext = struct {
             if (std.mem.eql(u8, mod.name, "Builtin") or mod.builtin_derived) documenting_builtin = true;
             if (mod.builtin_derived) {
                 try builtin_modules.put(gpa, mod.name, {});
-                for (mod.entries) |*entry| {
-                    try collectBuiltinTypeOwners(&builtin_type_owners, gpa, entry, mod.name);
-                }
             }
         }
 
@@ -230,7 +221,6 @@ const RenderContext = struct {
             .current_module = null,
             .current_module_entries = null,
             .documenting_builtin = documenting_builtin,
-            .builtin_type_owners = builtin_type_owners,
             .builtin_modules = builtin_modules,
             .all_anchors = anchors,
             .anchor_arena = arena,
@@ -242,16 +232,9 @@ const RenderContext = struct {
     fn deinit(self: *RenderContext, gpa: Allocator) void {
         self.current_module_anchors.deinit(gpa);
         self.known_modules.deinit(gpa);
-        self.builtin_type_owners.deinit(gpa);
         self.builtin_modules.deinit(gpa);
         self.all_anchors.deinit(gpa);
         self.anchor_arena.deinit();
-    }
-
-    /// The promoted module that documents builtin type `head` (e.g. "Num" for
-    /// "U8"), or null when `head` is not a builtin type.
-    fn builtinTypeOwner(self: *const RenderContext, head: []const u8) ?[]const u8 {
-        return self.builtin_type_owners.get(head);
     }
 
     /// Whether `module_name` was promoted out of `Builtin` and therefore uses
@@ -381,25 +364,6 @@ fn populateAnchorMap(
         }
 
         try populateAnchorMap(map, gpa, arena, module_name, entry.children, entry_rel_path);
-    }
-}
-
-/// Record every type (not value) reachable from `entry` as owned by `module`,
-/// keyed by its short name, so a bare `[U8]` reference resolves to the page that
-/// documents it. First-seen wins on short-name collisions.
-fn collectBuiltinTypeOwners(
-    map: *std.StringHashMapUnmanaged([]const u8),
-    gpa: Allocator,
-    entry: *const DocModel.DocEntry,
-    module: []const u8,
-) Allocator.Error!void {
-    if (entry.kind != .value) {
-        const short = if (std.mem.findScalarLast(u8, entry.name, '.')) |d| entry.name[d + 1 ..] else entry.name;
-        const result = try map.getOrPut(gpa, short);
-        if (!result.found_existing) result.value_ptr.* = module;
-    }
-    for (entry.children) |*child| {
-        try collectBuiltinTypeOwners(map, gpa, child, module);
     }
 }
 
@@ -713,15 +677,15 @@ fn writeModulePageToDir(ctx: *const RenderContext, gpa: Allocator, io: std.Io, d
     }
 
     // Module doc comment (fall back to collapsed entry's doc if module has none)
-    const doc_with_line: ?struct { doc: []const u8, start_line: u32 } = if (mod.module_doc) |doc|
-        .{ .doc = doc, .start_line = mod.module_doc_start_line }
+    const doc_with_line: ?struct { doc: []const u8, refs: []const DocModel.DocRef, start_line: u32 } = if (mod.module_doc) |doc|
+        .{ .doc = doc, .refs = mod.module_doc_refs, .start_line = mod.module_doc_start_line }
     else if (entry_tree.collapsed_entry) |entry|
-        if (entry.doc_comment) |doc| .{ .doc = doc, .start_line = entry.doc_comment_start_line } else null
+        if (entry.doc_comment) |doc| .{ .doc = doc, .refs = entry.doc_refs, .start_line = entry.doc_comment_start_line } else null
     else
         null;
     if (doc_with_line) |dwl| {
         try w.writeAll("        <div class=\"module-doc\">\n");
-        try renderDocComment(w, ctx, dwl.doc, dwl.start_line);
+        try renderDocComment(w, ctx, dwl.doc, dwl.refs, dwl.start_line);
         try w.writeAll("        </div>\n");
     }
 
@@ -1110,7 +1074,7 @@ fn renderEntryTree(
             if (entry.doc_comment) |doc| {
                 try writeIndent(w, base + 1);
                 try w.writeAll("<div class=\"entry-doc\">\n");
-                try renderDocComment(w, ctx, doc, entry.doc_comment_start_line);
+                try renderDocComment(w, ctx, doc, entry.doc_refs, entry.doc_comment_start_line);
                 try writeIndent(w, base + 1);
                 try w.writeAll("</div>\n");
             }
@@ -1544,13 +1508,19 @@ fn renderEntrySignature(w: Writer, ctx: *const RenderContext, gpa: Allocator, en
     }
 }
 
-fn renderDocComment(w: Writer, ctx: *const RenderContext, doc: []const u8, start_line: u32) (Allocator.Error || error{WriteFailed})!void {
+fn renderDocComment(
+    w: Writer,
+    ctx: *const RenderContext,
+    doc: []const u8,
+    refs: []const DocModel.DocRef,
+    start_line: u32,
+) (Allocator.Error || error{WriteFailed})!void {
     // Track the active doc so writeDocRefHref can resolve a `[label]` byte
     // offset within `doc` back to a 1-based source line. Restored on exit
     // to support nested rendering (e.g. a module doc above an entry doc).
     const previous = ctx.active_doc.*;
     defer ctx.active_doc.* = previous;
-    ctx.active_doc.* = .{ .doc = doc, .start_line = start_line };
+    ctx.active_doc.* = .{ .doc = doc, .refs = refs, .start_line = start_line };
 
     var pos: usize = 0;
 
@@ -1680,7 +1650,7 @@ fn writeDocText(w: Writer, ctx: *const RenderContext, text: []const u8) (Allocat
             }
             plain_start = i;
         } else if (text[i] == '[') {
-            if (parseMarkdownLink(text, i)) |link| {
+            if (DocModel.parseMarkdownLink(text, i)) |link| {
                 try writeHtmlEscaped(w, text[plain_start..i]);
                 try w.writeAll("<a href=\"");
                 try writeHtmlEscaped(w, link.url);
@@ -1690,11 +1660,15 @@ fn writeDocText(w: Writer, ctx: *const RenderContext, text: []const u8) (Allocat
                 try w.writeAll("</a>");
                 i = link.end;
                 plain_start = i;
-            } else if (parseDocRef(text, i)) |ref| {
+            } else if (DocModel.parseDocRef(text, i)) |ref| {
                 try writeHtmlEscaped(w, text[plain_start..i]);
                 try w.writeAll("<a href=\"");
                 const bracket_offset = bracketOffsetInActiveDoc(ctx, text, i);
-                try writeDocRefHref(w, ctx, ref.label, bracket_offset);
+                if (lookupActiveDocRef(ctx, bracket_offset)) |resolved_ref| {
+                    try writeDocRefHref(w, ctx, resolved_ref, bracket_offset);
+                } else {
+                    try writeMissingDocRefHref(w, ctx, ref.label, bracket_offset);
+                }
                 try w.writeAll("\">");
                 try writeHtmlEscaped(w, ref.label);
                 try w.writeAll("</a>");
@@ -1725,237 +1699,109 @@ fn bracketOffsetInActiveDoc(ctx: *const RenderContext, text: []const u8, i: usiz
     return text_offset + i;
 }
 
-const MarkdownLink = struct {
+fn lookupActiveDocRef(ctx: *const RenderContext, bracket_offset: usize) ?*const DocModel.DocRef {
+    if (bracket_offset > std.math.maxInt(u32)) return null;
+    const offset: u32 = @intCast(bracket_offset);
+    for (ctx.active_doc.refs) |*ref| {
+        if (ref.byte_offset == offset) return ref;
+    }
+    return null;
+}
+
+/// Writes the href for a shorthand doc reference whose target was resolved by
+/// `PackageDocs.resolveDocRefs`.
+fn writeDocRefHref(
+    w: Writer,
+    ctx: *const RenderContext,
+    ref: *const DocModel.DocRef,
+    bracket_offset: usize,
+) (Allocator.Error || error{WriteFailed})!void {
+    switch (ref.target) {
+        .local_anchor => |anchor| {
+            try w.writeAll("#");
+            try writeHtmlEscaped(w, anchor);
+            try validateAnchor(ctx, ref.label, anchor, false, bracket_offset);
+        },
+        .module_page => |module| {
+            try writeModuleRefPrefix(w, ctx, module);
+        },
+        .module_anchor => |target| {
+            try writeModuleAnchorPrefix(w, ctx, target.module);
+            try writeHtmlEscaped(w, target.anchor);
+            try validateAnchor(ctx, ref.label, target.anchor, false, bracket_offset);
+        },
+        .builtin_type => |builtin_ref| {
+            try writeBuiltinDocRefUrl(w, builtin_ref);
+        },
+        .unresolved_anchor => |anchor| {
+            try w.writeAll("#");
+            try writeHtmlEscaped(w, anchor);
+            try validateAnchor(ctx, ref.label, anchor, false, bracket_offset);
+        },
+    }
+}
+
+fn writeMissingDocRefHref(
+    w: Writer,
+    ctx: *const RenderContext,
     label: []const u8,
-    url: []const u8,
-    end: usize,
-};
+    bracket_offset: usize,
+) (Allocator.Error || error{WriteFailed})!void {
+    try w.writeAll("#");
+    try writeHtmlEscaped(w, label);
+    try ctx.reportBrokenLink(label, label, bracket_offset);
+}
 
-/// Parses a `[label](url)` markdown link starting at `start`, which must point
-/// to `[`. Returns null if the pattern doesn't match — in that case the caller
-/// should treat the `[` as literal text.
-fn parseMarkdownLink(text: []const u8, start: usize) ?MarkdownLink {
-    std.debug.assert(text[start] == '[');
-    var j = start + 1;
-    while (j < text.len and text[j] != ']') {
-        if (text[j] == '\n') return null;
-        j += 1;
+fn writeModuleRefPrefix(w: Writer, ctx: *const RenderContext, module: []const u8) (Allocator.Error || error{WriteFailed})!void {
+    const is_same_module = if (ctx.current_module) |cur| std.mem.eql(u8, module, cur) else false;
+    if (is_same_module) {
+        try w.writeAll("#");
+        return;
     }
-    if (j >= text.len) return null;
-    const label_end = j;
-    if (label_end + 1 >= text.len or text[label_end + 1] != '(') return null;
-    // Allow balanced parentheses inside the URL (e.g. a trailing ')' in a
-    // Wikipedia link like `Union_(set_theory)`): only a `)` at depth 0
-    // terminates the destination.
-    var k = label_end + 2;
-    var depth: usize = 0;
-    while (k < text.len) : (k += 1) {
-        const c = text[k];
-        if (c == '\n') return null;
-        if (c == '(') {
-            depth += 1;
-        } else if (c == ')') {
-            if (depth == 0) break;
-            depth -= 1;
-        }
+    if (ctx.current_module != null and !ctx.single_module_at_root) {
+        try w.writeAll("../");
     }
-    if (k >= text.len) return null;
-    return .{
-        .label = text[start + 1 .. label_end],
-        .url = text[label_end + 2 .. k],
-        .end = k + 1,
-    };
+    try writeHtmlEscaped(w, module);
+    try w.writeAll("/");
 }
 
-const DocRef = struct {
-    label: []const u8,
-    end: usize,
-};
-
-/// Parses a shorthand `[Name]` or `[Name.member]` reference to another doc
-/// entry. The label must be a (possibly dotted) identifier, and the closing
-/// bracket must NOT be followed by `(` — that case is handled by
-/// `parseMarkdownLink`. Returns null otherwise.
-fn parseDocRef(text: []const u8, start: usize) ?DocRef {
-    std.debug.assert(text[start] == '[');
-    const label_start = start + 1;
-    if (label_start >= text.len) return null;
-    if (!isIdentStart(text[label_start])) return null;
-    var j = label_start + 1;
-    while (j < text.len and text[j] != ']') {
-        const c = text[j];
-        if (c == '.') {
-            // A dot must be followed by an identifier start char
-            if (j + 1 >= text.len or !isIdentStart(text[j + 1])) return null;
-        } else if (!isIdentCont(c)) {
-            return null;
-        }
-        j += 1;
+fn writeModuleAnchorPrefix(w: Writer, ctx: *const RenderContext, module: []const u8) (Allocator.Error || error{WriteFailed})!void {
+    const is_same_module = if (ctx.current_module) |cur| std.mem.eql(u8, module, cur) else false;
+    if (is_same_module) {
+        try w.writeAll("#");
+        return;
     }
-    if (j >= text.len) return null;
-    // Reject if followed by '(' — that's a markdown link, handled elsewhere.
-    if (j + 1 < text.len and text[j + 1] == '(') return null;
-    return .{
-        .label = text[label_start..j],
-        .end = j + 1,
-    };
+    if (ctx.current_module != null and !ctx.single_module_at_root) {
+        try w.writeAll("../");
+    }
+    try writeHtmlEscaped(w, module);
+    try w.writeAll("/#");
 }
 
-fn isIdentStart(c: u8) bool {
-    return (c >= 'A' and c <= 'Z') or (c >= 'a' and c <= 'z') or c == '_';
-}
+fn writeBuiltinDocRefUrl(w: Writer, builtin_ref: []const u8) (Allocator.Error || error{WriteFailed})!void {
+    const first_dot = std.mem.findScalar(u8, builtin_ref, '.');
+    const head = if (first_dot) |d| builtin_ref[0..d] else builtin_ref;
+    const tail: []const u8 = if (first_dot) |d| builtin_ref[d + 1 ..] else "";
 
-fn isIdentCont(c: u8) bool {
-    return isIdentStart(c) or (c >= '0' and c <= '9');
-}
-
-/// Writes the href for a shorthand doc reference like `Str` or `Str.reserve`.
-/// If the label's first segment names a known module, the link points at that
-/// module's page; otherwise it falls back to an anchor on the current page.
-///
-/// As a side effect, when the resolved fragment (`#…`) does not correspond
-/// to any `id="…"` in the rendered site, the reference is reported via
-/// `ctx.reportBrokenLink` (with the source line derived from
-/// `bracket_offset`). The href is still written so output is unchanged —
-/// broken-link collection is observational.
-fn writeDocRefHref(w: Writer, ctx: *const RenderContext, label: []const u8, bracket_offset: usize) (Allocator.Error || error{WriteFailed})!void {
-    const first_dot = std.mem.findScalar(u8, label, '.');
-    const head = if (first_dot) |d| label[0..d] else label;
-
-    // Build the anchor we are about to write into a small stack buffer so we
-    // can both emit it and validate it against `all_anchors`. The buffer is
-    // sized for the longest realistic label (module + dotted path).
-    var anchor_buf: [512]u8 = undefined;
-    var anchor_len: usize = 0;
-    var anchor_overflow = false;
-    const append = struct {
-        fn run(buf: *[512]u8, len: *usize, overflow: *bool, s: []const u8) void {
-            if (overflow.*) return;
-            if (len.* + s.len > buf.len) {
-                overflow.* = true;
-                return;
-            }
-            @memcpy(buf[len.* .. len.* + s.len], s);
-            len.* += s.len;
-        }
-    }.run;
-
-    if (ctx.known_modules.contains(head)) {
-        const is_same_module = if (ctx.current_module) |cur|
-            std.mem.eql(u8, head, cur)
-        else
-            false;
-
-        // Promoted builtin modules use bare anchors, so the fragment drops the
-        // `<module>.` head: `[Str.reserve]` -> `#reserve`, `[List.first]` ->
-        // `../List/#first`, and `[Str]`/`[List]` land on the page itself.
-        if (ctx.isBuiltinDerived(head)) {
-            const frag = if (first_dot) |d| label[d + 1 ..] else "";
-            if (is_same_module) {
-                try w.writeAll("#");
-            } else {
-                if (ctx.current_module) |_| try w.writeAll("../");
-                try writeHtmlEscaped(w, head);
-                try w.writeAll("/");
-                if (frag.len > 0) try w.writeAll("#");
-            }
-            try writeHtmlEscaped(w, frag);
-            append(&anchor_buf, &anchor_len, &anchor_overflow, frag);
-            try validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
-            return;
-        }
-
-        if (is_same_module) {
-            // Same-page anchor. Entry ids are prefixed with the module name.
+    try w.writeAll(builtins_docs_base_url);
+    for (builtin_nested_type_owners) |nested| {
+        if (std.mem.eql(u8, nested.name, head)) {
+            try writeHtmlEscaped(w, nested.owner);
             try w.writeAll("#");
             try writeHtmlEscaped(w, head);
-            append(&anchor_buf, &anchor_len, &anchor_overflow, head);
-            if (first_dot) |d| {
-                try writeHtmlEscaped(w, label[d..]);
-                append(&anchor_buf, &anchor_len, &anchor_overflow, label[d..]);
+            if (tail.len > 0) {
+                try w.writeAll(".");
+                try writeHtmlEscaped(w, tail);
             }
-            try validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
             return;
         }
-
-        // Cross-module link.
-        if (ctx.current_module) |_| {
-            try w.writeAll("../");
-        }
-        try writeHtmlEscaped(w, head);
-        try w.writeAll("/");
-        if (first_dot != null) {
-            try w.writeAll("#");
-            try writeHtmlEscaped(w, label);
-            append(&anchor_buf, &anchor_len, &anchor_overflow, label);
-            try validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
-        }
-        // No fragment — the link points at the module's index page, which is
-        // guaranteed to exist by the `known_modules.contains` check above.
-        return;
     }
 
-    // A bare reference to a builtin type that lives on another promoted page
-    // (e.g. `[U8]` from `Str`, where `U8` is documented under `Num`). Its id is
-    // `<owner>.<label>`, so link there directly.
-    if (ctx.builtinTypeOwner(head)) |owner| {
-        // Bare anchors: the owning page's id for this type is `label` itself
-        // (e.g. `U8`, `U8.default`), with no `<owner>.` prefix.
-        const is_same_module = if (ctx.current_module) |cur| std.mem.eql(u8, owner, cur) else false;
-        if (is_same_module) {
-            try w.writeAll("#");
-        } else {
-            if (ctx.current_module) |_| try w.writeAll("../");
-            try writeHtmlEscaped(w, owner);
-            try w.writeAll("/#");
-        }
-        try writeHtmlEscaped(w, label);
-        append(&anchor_buf, &anchor_len, &anchor_overflow, label);
-        try validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
-        return;
-    }
-
-    // Not a known module — treat as a reference relative to the current
-    // module. Entry ids are `<module>.<label>`. Substitute the first segment
-    // through the anchor map so a label like `U8` resolves to `Num.U8` and
-    // `U8.default` resolves to `Num.U8.default`.
-    const resolved_head = ctx.lookupAnchorHead(head) orelse head;
-
-    // Promoted builtin modules use bare anchors, so strip any current-module
-    // prefix the anchor map left on the resolved head (`Num.F32` -> `F32`).
-    if (if (ctx.current_module) |cur| ctx.isBuiltinDerived(cur) else false) {
-        const bare_head = if (ctx.current_module) |cur|
-            (if (std.mem.startsWith(u8, resolved_head, cur) and resolved_head.len > cur.len and resolved_head[cur.len] == '.')
-                resolved_head[cur.len + 1 ..]
-            else
-                resolved_head)
-        else
-            resolved_head;
+    try writeHtmlEscaped(w, head);
+    if (tail.len > 0) {
         try w.writeAll("#");
-        try writeHtmlEscaped(w, bare_head);
-        append(&anchor_buf, &anchor_len, &anchor_overflow, bare_head);
-        if (first_dot) |d| {
-            try writeHtmlEscaped(w, label[d..]);
-            append(&anchor_buf, &anchor_len, &anchor_overflow, label[d..]);
-        }
-        try validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
-        return;
+        try writeHtmlEscaped(w, tail);
     }
-
-    try w.writeAll("#");
-    if (ctx.current_module) |cur| {
-        try writeHtmlEscaped(w, cur);
-        try w.writeAll(".");
-        append(&anchor_buf, &anchor_len, &anchor_overflow, cur);
-        append(&anchor_buf, &anchor_len, &anchor_overflow, ".");
-    }
-    try writeHtmlEscaped(w, resolved_head);
-    append(&anchor_buf, &anchor_len, &anchor_overflow, resolved_head);
-    if (first_dot) |d| {
-        try writeHtmlEscaped(w, label[d..]);
-        append(&anchor_buf, &anchor_len, &anchor_overflow, label[d..]);
-    }
-    try validateAnchor(ctx, label, anchor_buf[0..anchor_len], anchor_overflow, bracket_offset);
 }
 
 /// Report `label` as broken when its resolved anchor isn't in `all_anchors`.
@@ -2351,11 +2197,12 @@ test "writeDocRefHref reports broken shorthand refs" {
     // remain valid for that deinit call. Free the slice here to balance.
     defer gpa.free(modules);
 
-    const package_docs = DocModel.PackageDocs{
+    var package_docs = DocModel.PackageDocs{
         .name = try gpa.dupe(u8, "Builtin"),
         .modules = modules,
     };
     defer gpa.free(package_docs.name);
+    try package_docs.resolveDocRefs(gpa);
 
     // Render to a tmp dir so we exercise the full pipeline.
     var tmp = testing.tmpDir(.{});
@@ -2383,6 +2230,97 @@ test "writeDocRefHref reports broken shorthand refs" {
     try testing.expectEqual(@as(u32, 43), bl.source_line);
     try testing.expectEqualStrings("div_by", bl.label);
     try testing.expectEqualStrings("Builtin.div_by", bl.resolved_anchor);
+}
+
+test "doc shorthand refs in package docs resolve builtins and nested type-module anchors" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    // Repro for https://github.com/roc-lang/roc/issues/9886.
+    // `[Str]` should link to the published builtin docs, and `[Utf8]` should
+    // link to the nested alias in this type module.
+    const utf8_entry = DocModel.DocEntry{
+        .name = try gpa.dupe(u8, "Utf8"),
+        .kind = .alias,
+        .type_signature = null,
+        .doc_comment = null,
+        .children = try gpa.alloc(DocModel.DocEntry, 0),
+    };
+
+    const any_thing_entry = DocModel.DocEntry{
+        .name = try gpa.dupe(u8, "any_thing"),
+        .kind = .value,
+        .type_signature = null,
+        .doc_comment = try gpa.dupe(u8, "Matches any [Utf8] and consumes all the input without fail."),
+        .children = try gpa.alloc(DocModel.DocEntry, 0),
+        .doc_comment_start_line = 8,
+    };
+
+    const string_children = try gpa.alloc(DocModel.DocEntry, 2);
+    string_children[0] = utf8_entry;
+    string_children[1] = any_thing_entry;
+
+    const string_entry = DocModel.DocEntry{
+        .name = try gpa.dupe(u8, "String"),
+        .kind = .@"opaque",
+        .type_signature = null,
+        .doc_comment = try gpa.dupe(u8, "Parse a [Str] using a parser."),
+        .children = string_children,
+        .doc_comment_start_line = 4,
+    };
+
+    const entries = try gpa.alloc(DocModel.DocEntry, 1);
+    entries[0] = string_entry;
+
+    var module = DocModel.ModuleDocs{
+        .name = try gpa.dupe(u8, "String"),
+        .package_name = try gpa.dupe(u8, "roc-parser"),
+        .kind = .type_module,
+        .module_doc = null,
+        .entries = entries,
+        .source_path = try gpa.dupe(u8, "/fake/roc-parser/package/String.roc"),
+    };
+    defer module.deinit(gpa);
+
+    const modules = try gpa.alloc(DocModel.ModuleDocs, 1);
+    modules[0] = module;
+    defer gpa.free(modules);
+
+    var package_docs = DocModel.PackageDocs{
+        .name = try gpa.dupe(u8, "roc-parser"),
+        .modules = modules,
+    };
+    defer gpa.free(package_docs.name);
+    try package_docs.resolveDocRefs(gpa);
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(std.testing.io, ".", gpa);
+    defer gpa.free(tmp_path);
+
+    var broken_links: std.ArrayListUnmanaged(BrokenLink) = .empty;
+    defer {
+        for (broken_links.items) |bl| {
+            gpa.free(bl.label);
+            gpa.free(bl.resolved_anchor);
+        }
+        broken_links.deinit(gpa);
+    }
+
+    try renderPackageDocs(gpa, std.testing.io, &package_docs, tmp_path, &broken_links, null);
+
+    if (broken_links.items.len != 0) {
+        for (broken_links.items) |bl| {
+            std.debug.print("[{s}] -> #{s}\n", .{ bl.label, bl.resolved_anchor });
+        }
+    }
+    try testing.expectEqual(@as(usize, 0), broken_links.items.len);
+
+    const html = try tmp.dir.readFileAlloc(std.testing.io, "index.html", gpa, .limited(1024 * 1024));
+    defer gpa.free(html);
+
+    try testing.expect(std.mem.find(u8, html, "href=\"https://roc-lang.org/builtins/main/Str\"") != null);
+    try testing.expect(std.mem.find(u8, html, "href=\"#String.Utf8\"") != null);
 }
 
 test "builtin_nested_type_owners lists every numeric type under Num" {


### PR DESCRIPTION
Doc comment shorthand refs now resolve against the final docs model before HTML rendering, so package docs can distinguish local anchors like `[Utf8]` from external builtin links like `[Str]`. This moves the resolution data into `PackageDocs`, keeps unresolved refs explicit for diagnostics, and adds a regression test for the broken roc-parser links from #9886.\n\nFixes #9886.