### PR TITLE
Enable Valgrind client requests in zig-valgrind

### DIFF
--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -466,7 +466,7 @@ jobs:
       - name: build roc + repro executables for valgrind
         uses: ./.github/actions/flaky-retry
         with:
-          command: git clean -fdx && zig build -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast -Dcpu=x86_64_v3 -Dtarget=x86_64-linux-musl -Dstrip=false -Dshared-memory-size=268435456
+          command: git clean -fdx && zig build -Dvalgrind=true -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast -Dcpu=x86_64_v3 -Dtarget=x86_64-linux-musl -Dstrip=false -Dshared-memory-size=268435456
           error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
           retry_count: 3
 

--- a/build.zig
+++ b/build.zig
@@ -2329,6 +2329,12 @@ pub fn build(b: *std.Build) void {
     const eval_no_fork = b.option(bool, "eval-no-fork", "Run eval tests in-process instead of through fork isolation") orelse false;
     const eval_time_worker = b.option(bool, "eval-time-worker", "Print eval worker startup timing instrumentation") orelse false;
     const glue_release_tag = b.option([]const u8, "glue-release-tag", "Nightly release tag used in generated glue package URLs");
+    const enable_valgrind = b.option(bool, "valgrind", "Emit Valgrind client request support") orelse false;
+    if (enable_valgrind and (builtin.target.os.tag != .linux or target.result.os.tag != .linux)) {
+        std.log.err("-Dvalgrind=true requires a Linux build host and Linux target", .{});
+        std.process.exit(1);
+    }
+    const valgrind_support = if (enable_valgrind) true else null;
     if (shared_memory_size) |size| {
         if (size == 0) {
             std.log.err("-Dshared-memory-size must be greater than 0", .{});
@@ -2451,7 +2457,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    const roc_modules = modules.RocModules.create(b, build_options, zstd);
+    const roc_modules = modules.RocModules.create(b, build_options, zstd, valgrind_support);
 
     // Build-time compiler for builtin .roc modules
     //
@@ -2691,7 +2697,7 @@ pub fn build(b: *std.Build) void {
     llvm_codegen_module.addImport("roc_target", roc_modules.roc_target);
     llvm_codegen_module.addImport("vendor_llvm_ir", roc_modules.vendor_llvm_ir);
 
-    const roc_exe = addMainExe(b, roc_modules, target, optimize, strip, omit_frame_pointer, use_system_llvm, user_llvm_path, flag_enable_tracy, zstd, compiled_builtins_module, write_compiled_builtins, llvm_codegen_module, flag_enable_tracy, true) orelse return;
+    const roc_exe = addMainExe(b, roc_modules, target, optimize, strip, omit_frame_pointer, use_system_llvm, user_llvm_path, flag_enable_tracy, zstd, compiled_builtins_module, write_compiled_builtins, llvm_codegen_module, flag_enable_tracy, true, valgrind_support) orelse return;
     roc_modules.addAll(roc_exe);
     _ = install_and_run(b, no_bin, roc_exe, build_roc_step, run_roc_step, run_args);
 
@@ -2731,6 +2737,7 @@ pub fn build(b: *std.Build) void {
             llvm_codegen_module,
             null, // No tracy
             false,
+            valgrind_support,
         );
         if (release_exe) |exe| {
             roc_modules.addAll(exe);
@@ -3136,6 +3143,7 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = optimize,
             .link_libc = true,
+            .valgrind = valgrind_support,
         }),
     });
     configureBackend(snapshot_exe, target);
@@ -5302,6 +5310,7 @@ fn addMainExe(
     llvm_codegen_module: *std.Build.Module,
     flag_enable_tracy: ?[]const u8,
     add_machine_code_shim_test: bool,
+    valgrind_support: ?bool,
 ) ?*Step.Compile {
     const exe = b.addExecutable(.{
         .name = "roc",
@@ -5312,6 +5321,7 @@ fn addMainExe(
             .strip = strip,
             .omit_frame_pointer = omit_frame_pointer,
             .link_libc = true,
+            .valgrind = valgrind_support,
         }),
     });
     // The in-process interpreter (used by `--opt=interpreter`) recurses Zig stack

--- a/ci/valgrind_snapshots.sh
+++ b/ci/valgrind_snapshots.sh
@@ -21,6 +21,7 @@ if [ -z "$snapshot_bin" ]; then
   valgrind_shared_memory_size="${VALGRIND_SNAPSHOT_SHARED_MEMORY_SIZE:-268435456}"
   echo "Building snapshot tool for Valgrind with shared-memory arena size ${valgrind_shared_memory_size}"
   zig build \
+    -Dvalgrind=true \
     -Doptimize="${VALGRIND_SNAPSHOT_OPTIMIZE:-ReleaseFast}" \
     -Dstrip=false \
     -Dshared-memory-size="${valgrind_shared_memory_size}" \

--- a/src/build/modules.zig
+++ b/src/build/modules.zig
@@ -423,7 +423,7 @@ pub const RocModules = struct {
     vendor_llvm_ir: *Module,
     vendor_llvm_compile_bindings: *Module,
 
-    pub fn create(b: *Build, build_options_step: *Step.Options, zstd: ?*Dependency) RocModules {
+    pub fn create(b: *Build, build_options_step: *Step.Options, zstd: ?*Dependency, valgrind: ?bool) RocModules {
         const self = RocModules{
             .collections = b.addModule(
                 "collections",
@@ -478,6 +478,10 @@ pub const RocModules = struct {
             .vendor_llvm_ir = b.addModule("vendor_llvm_ir", .{ .root_source_file = b.path("vendor/llvm_ir/mod.zig") }),
             .vendor_llvm_compile_bindings = b.addModule("vendor_llvm_compile_bindings", .{ .root_source_file = b.path("vendor/llvm_compile_bindings.zig") }),
         };
+
+        if (valgrind) |enabled| {
+            self.ctx.valgrind = enabled;
+        }
 
         // Link zstd to bundle module if available (it's unsupported on wasm32, so don't link it)
         // Note: unbundle uses Zig's stdlib zstd for WASM compatibility

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -941,8 +941,8 @@ pub fn main(init: std.process.Init) Allocator.Error!void {
         if (use_debug_allocator) {
             // Under Valgrind, use libc's malloc instead: Valgrind can't see the
             // debug allocator's sub-allocations (it carves them out of mmap'd
-            // pages) but tracks every malloc/free. Debug builds carry the client
-            // requests, so this auto-switches with no flag.
+            // pages) but tracks every malloc/free. Builds with Valgrind support
+            // carry the client requests, so this can auto-switch under Valgrind.
             if (builtin.link_libc and std.valgrind.runningOnValgrind() != 0) {
                 break :gpa .{ std.heap.c_allocator, false };
             }


### PR DESCRIPTION
The zig-valgrind job was running Valgrind against binaries built without Zig's Valgrind client request support, so the existing `CoreCtx.osCanonicalize` annotations were compiled out and musl `realpath` taint still reached Memcheck. This adds an explicit `-Dvalgrind=true` build option, wires it to the `roc` and snapshot roots plus the shared `ctx` module that contains the Valgrind annotations, and enables it in the Valgrind CI paths.

The option is limited to Linux host/target builds so it fails early instead of leaking `-fvalgrind` into unsupported targets.