### PR TITLE
Register Windows JIT unwind metadata

### DIFF
--- a/src/backend/dev/ExecutableMemory.zig
+++ b/src/backend/dev/ExecutableMemory.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const builtin = @import("builtin");
+const coff = @import("object/coff.zig");
 
 // std.os.windows.VirtualAlloc / VirtualFree / VirtualProtect were removed in Zig 0.16.
 // Declare the thin extern bindings we need locally; only referenced on Windows.
@@ -21,6 +22,19 @@ const win32 = struct {
     const MEM_RELEASE: DWORD = 0x8000;
     const PAGE_READWRITE: DWORD = 0x04;
     const PAGE_EXECUTE_READ: DWORD = 0x20;
+
+    const RuntimeFunction = switch (builtin.cpu.arch) {
+        .x86_64 => extern struct {
+            BeginAddress: DWORD,
+            EndAddress: DWORD,
+            UnwindData: DWORD,
+        },
+        .aarch64 => extern struct {
+            BeginAddress: DWORD,
+            UnwindData: DWORD,
+        },
+        else => void,
+    };
 
     extern "kernel32" fn VirtualAlloc(
         lpAddress: LPVOID,
@@ -39,6 +53,140 @@ const win32 = struct {
         flNewProtect: DWORD,
         lpflOldProtect: PDWORD,
     ) callconv(.winapi) std.os.windows.BOOL;
+    extern "ntdll" fn RtlAddFunctionTable(
+        FunctionTable: [*]RuntimeFunction,
+        EntryCount: DWORD,
+        BaseAddress: usize,
+    ) callconv(.winapi) std.os.windows.BOOLEAN;
+    extern "ntdll" fn RtlDeleteFunctionTable(
+        FunctionTable: [*]RuntimeFunction,
+    ) callconv(.winapi) std.os.windows.BOOLEAN;
+};
+
+const WindowsUnwindState = if (builtin.os.tag == .windows) struct {
+    entries: []win32.RuntimeFunction = &.{},
+    registered: bool = false,
+
+    const allocator = std.heap.smp_allocator;
+
+    fn coffArch() error{UnsupportedPlatform}!coff.Architecture {
+        return switch (builtin.cpu.arch) {
+            .x86_64 => .x86_64,
+            .aarch64 => .aarch64,
+            else => error.UnsupportedPlatform,
+        };
+    }
+
+    fn xdataSize(functions: []const coff.FunctionInfo) (Allocator.Error || error{UnsupportedPlatform})!usize {
+        if (functions.len == 0) return 0;
+        var writer = try coff.CoffWriter.init(allocator, try coffArch());
+        defer writer.deinit();
+
+        var total: usize = 0;
+        for (functions) |function| {
+            if (function.start_offset >= function.end_offset) {
+                if (builtin.mode == .Debug) {
+                    std.debug.panic("JIT unwind invariant violated: invalid function range {d}-{d}", .{ function.start_offset, function.end_offset });
+                }
+                unreachable;
+            }
+            total += try writer.functionXdataSize(function);
+        }
+        return total;
+    }
+
+    fn lessThanFunction(_: void, lhs: coff.FunctionInfo, rhs: coff.FunctionInfo) bool {
+        return lhs.start_offset < rhs.start_offset;
+    }
+
+    fn init(
+        memory: []align(std.heap.page_size_min) u8,
+        code_size: usize,
+        xdata_offset: usize,
+        functions: []const coff.FunctionInfo,
+    ) (Allocator.Error || error{ UnsupportedPlatform, UnwindRegistrationFailed })!WindowsUnwindState {
+        if (functions.len == 0) return .{};
+
+        const sorted_functions = try allocator.dupe(coff.FunctionInfo, functions);
+        defer allocator.free(sorted_functions);
+        std.mem.sort(coff.FunctionInfo, sorted_functions, {}, lessThanFunction);
+
+        var writer = try coff.CoffWriter.init(allocator, try coffArch());
+        defer writer.deinit();
+
+        var xdata: std.ArrayList(u8) = .empty;
+        defer xdata.deinit(allocator);
+
+        const xdata_offsets = try allocator.alloc(u32, sorted_functions.len);
+        defer allocator.free(xdata_offsets);
+
+        var previous_end: u32 = 0;
+        for (sorted_functions, 0..) |function, i| {
+            if (function.start_offset >= function.end_offset or function.end_offset > code_size or function.start_offset < previous_end) {
+                if (builtin.mode == .Debug) {
+                    std.debug.panic("JIT unwind invariant violated: invalid or overlapping function range {d}-{d} for code size {d}", .{ function.start_offset, function.end_offset, code_size });
+                }
+                unreachable;
+            }
+            previous_end = function.end_offset;
+
+            xdata_offsets[i] = @intCast(xdata.items.len);
+            try writer.appendFunctionXdata(&xdata, function);
+        }
+
+        @memcpy(memory[xdata_offset..][0..xdata.items.len], xdata.items);
+
+        const entries = try allocator.alloc(win32.RuntimeFunction, sorted_functions.len);
+        errdefer allocator.free(entries);
+
+        for (sorted_functions, xdata_offsets, 0..) |function, xdata_function_offset, i| {
+            const xdata_rva: u32 = @intCast(xdata_offset + xdata_function_offset);
+            entries[i] = switch (builtin.cpu.arch) {
+                .x86_64 => .{
+                    .BeginAddress = function.start_offset,
+                    .EndAddress = function.end_offset,
+                    .UnwindData = xdata_rva,
+                },
+                .aarch64 => .{
+                    .BeginAddress = function.start_offset,
+                    .UnwindData = xdata_rva,
+                },
+                else => unreachable,
+            };
+        }
+
+        if (win32.RtlAddFunctionTable(entries.ptr, @intCast(entries.len), @intFromPtr(memory.ptr)) == .FALSE) {
+            return error.UnwindRegistrationFailed;
+        }
+
+        return .{
+            .entries = entries,
+            .registered = true,
+        };
+    }
+
+    fn deinit(self: *WindowsUnwindState) void {
+        if (self.registered) {
+            _ = win32.RtlDeleteFunctionTable(self.entries.ptr);
+        }
+        allocator.free(self.entries);
+        self.* = .{};
+    }
+} else struct {
+    fn xdataSize(_: []const coff.FunctionInfo) (Allocator.Error || error{UnsupportedPlatform})!usize {
+        return 0;
+    }
+
+    fn init(
+        _: []align(std.heap.page_size_min) u8,
+        _: usize,
+        _: usize,
+        _: []const coff.FunctionInfo,
+    ) (Allocator.Error || error{ UnsupportedPlatform, UnwindRegistrationFailed })!WindowsUnwindState {
+        return .{};
+    }
+
+    fn deinit(_: *WindowsUnwindState) void {}
 };
 
 /// A region of memory that can be executed as code.
@@ -49,25 +197,38 @@ pub const ExecutableMemory = struct {
     code_size: usize,
     /// Offset from start where execution should begin (for compiled procedures)
     entry_offset: usize,
+    windows_unwind: WindowsUnwindState = .{},
 
     const Self = @This();
 
     /// Allocate executable memory and copy the given code into it.
     /// The code bytes should already have any relocations applied.
-    pub fn init(code: []const u8) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform })!Self {
+    pub fn init(code: []const u8) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform, UnwindRegistrationFailed })!Self {
         return initWithEntryOffset(code, 0);
     }
 
     /// Allocate executable memory with a specific entry offset.
     /// Use this when procedures are compiled before the main expression.
-    pub fn initWithEntryOffset(code: []const u8, entry_offset: usize) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform })!Self {
+    pub fn initWithEntryOffset(code: []const u8, entry_offset: usize) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform, UnwindRegistrationFailed })!Self {
+        return initWithEntryOffsetAndUnwindInfo(code, entry_offset, &.{});
+    }
+
+    pub fn initWithEntryOffsetAndUnwindInfo(
+        code: []const u8,
+        entry_offset: usize,
+        functions: []const coff.FunctionInfo,
+    ) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform, UnwindRegistrationFailed })!Self {
         if (code.len == 0) {
             return error.EmptyCode;
         }
 
+        const xdata_size = try WindowsUnwindState.xdataSize(functions);
+        const xdata_offset = std.mem.alignForward(usize, code.len, 4);
+        const used_size = if (xdata_size == 0) code.len else xdata_offset + xdata_size;
+
         // Round up to page size
         const page_size = std.heap.page_size_min;
-        const alloc_size = std.mem.alignForward(usize, code.len, page_size);
+        const alloc_size = std.mem.alignForward(usize, used_size, page_size);
 
         // Allocate memory with read-write permissions initially
         const memory = try allocateMemory(alloc_size);
@@ -75,6 +236,10 @@ pub const ExecutableMemory = struct {
 
         // Copy the code
         @memcpy(memory[0..code.len], code);
+        @memset(memory[code.len..], 0);
+
+        var windows_unwind = try WindowsUnwindState.init(memory, code.len, xdata_offset, functions);
+        errdefer windows_unwind.deinit();
 
         // Make the memory executable (and read-only)
         try protectExecutable(memory);
@@ -83,6 +248,7 @@ pub const ExecutableMemory = struct {
             .memory = memory,
             .code_size = code.len,
             .entry_offset = entry_offset,
+            .windows_unwind = windows_unwind,
         };
     }
 
@@ -111,6 +277,7 @@ pub const ExecutableMemory = struct {
 
     /// Free the executable memory
     pub fn deinit(self: *Self) void {
+        self.windows_unwind.deinit();
         freeMemory(self.memory);
         self.memory = &.{};
         self.code_size = 0;

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -81,6 +81,7 @@ const strWithAsciiUppercased = builtins.str.strWithAsciiUppercased;
 const strFromUtf8Lossy = builtins.str.fromUtf8Lossy;
 
 const Relocation = @import("Relocation.zig").Relocation;
+const coff = @import("object/coff.zig");
 
 const StaticStringData = @import("StaticStringData.zig");
 
@@ -847,6 +848,9 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         /// Registry of compiled RC helpers keyed by canonical RC helper identity.
         compiled_rc_helpers: std.AutoHashMap(u64, usize),
 
+        /// Generated callable ranges with Windows unwind metadata.
+        unwind_functions: std.ArrayListUnmanaged(coff.FunctionInfo),
+
         /// Worklist of RC helpers awaiting compilation. RC helpers are compiled
         /// iteratively from this worklist (never via recursion): a helper body
         /// references its child helpers through pending refs and schedules them
@@ -1208,6 +1212,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 .line_entries = .empty,
                 .proc_registry = std.AutoHashMap(u32, CompiledProc).init(allocator),
                 .compiled_rc_helpers = std.AutoHashMap(u64, usize).init(allocator),
+                .unwind_functions = .empty,
                 .rc_helper_worklist = std.ArrayList(RcHelperVariant).empty,
                 .rc_helper_scheduled = std.AutoHashMap(u64, void).init(allocator),
                 .pending_rc_addrs = std.ArrayList(PendingRcRef).empty,
@@ -1243,6 +1248,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.line_entries.deinit(self.allocator);
             self.proc_registry.deinit();
             self.compiled_rc_helpers.deinit();
+            self.unwind_functions.deinit(self.allocator);
             self.rc_helper_worklist.deinit(self.allocator);
             self.rc_helper_scheduled.deinit();
             self.pending_rc_addrs.deinit(self.allocator);
@@ -1276,6 +1282,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.stmt_locations.clearRetainingCapacity();
             self.proc_registry.clearRetainingCapacity();
             self.compiled_rc_helpers.clearRetainingCapacity();
+            self.unwind_functions.clearRetainingCapacity();
             self.rc_helper_worklist.clearRetainingCapacity();
             self.rc_helper_scheduled.clearRetainingCapacity();
             self.pending_rc_addrs.clearRetainingCapacity();
@@ -1322,6 +1329,31 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 list.deinit(self.allocator);
             }
             map.deinit();
+        }
+
+        fn recordUnwindFunction(
+            self: *Self,
+            start_offset: usize,
+            end_offset: usize,
+            prologue_size: u32,
+            stack_alloc: u32,
+            frame_size: u32,
+            callee_saved_mask: u32,
+            epilogue_offset: u32,
+            uses_frame_pointer: bool,
+        ) Allocator.Error!void {
+            if (start_offset == end_offset) return;
+            try self.unwind_functions.append(self.allocator, .{
+                .start_offset = @intCast(start_offset),
+                .end_offset = @intCast(end_offset),
+                .prologue_size = prologue_size,
+                .frame_reg_offset = 0,
+                .uses_frame_pointer = uses_frame_pointer,
+                .stack_alloc = stack_alloc,
+                .frame_size = frame_size,
+                .callee_saved_mask = callee_saved_mask,
+                .epilogue_offset = epilogue_offset,
+            });
         }
 
         const StmtEnvSnapshot = struct {
@@ -1479,15 +1511,21 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.codegen.emit.buf.shrinkRetainingCapacity(body_start);
 
             const prologue_start = self.codegen.currentOffset();
+            var root_stack_alloc: u32 = 0;
+            var root_frame_size: u32 = 0;
             if (comptime target.toCpuArch() == .x86_64) {
                 const actual_locals_x86: u32 = @intCast(-self.codegen.stack_offset - CodeGen.CALLEE_SAVED_AREA_SIZE);
                 try self.codegen.emitPrologueWithAlloc(actual_locals_x86);
+                root_stack_alloc = actual_locals_x86;
+                root_frame_size = actual_locals_x86;
             } else {
                 const actual_locals: u32 = @intCast(self.codegen.stack_offset - 16 - CodeGen.CALLEE_SAVED_AREA_SIZE);
                 var frame_builder = CodeGen.DeferredFrameBuilder.init();
                 frame_builder.setCalleeSavedMask(self.codegen.callee_saved_used);
                 frame_builder.setStackSize(actual_locals);
                 _ = try frame_builder.emitPrologue(&self.codegen.emit);
+                root_stack_alloc = actual_locals;
+                root_frame_size = frame_builder.actual_stack_alloc;
             }
             const prologue_size = self.codegen.currentOffset() - prologue_start;
 
@@ -1503,6 +1541,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.shiftNestedCompiledRcHelperOffsets(body_start, body_end, prologue_size, std.math.maxInt(u64));
             self.shiftPendingCalls(body_start, body_end, prologue_size);
             self.shiftPendingProcAddrs(body_start, body_end, prologue_size);
+            self.shiftPendingRcRefs(body_start, body_end, prologue_size);
             self.repatchInternalCalls(body_start, body_end, prologue_size, body_start);
             self.repatchInternalAddrPatches(body_start, body_end, prologue_size, body_start);
 
@@ -1511,6 +1550,17 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             for (self.early_return_patches.items) |patch| {
                 self.codegen.patchJump(patch + prologue_size, final_epilogue);
             }
+            try self.recordUnwindFunction(
+                prologue_start,
+                self.codegen.currentOffset(),
+                @intCast(prologue_size),
+                root_stack_alloc,
+                root_frame_size,
+                self.codegen.callee_saved_used,
+                @intCast(final_epilogue - prologue_start),
+                true,
+            );
+            try self.maybeDrainRcHelpers();
 
             const all_code = self.codegen.getCode();
             const code_copy = self.allocator.dupe(u8, all_code) catch return error.OutOfMemory;
@@ -9890,6 +9940,14 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     entry.value_ptr.* = offset + prologue_size;
                 }
             }
+
+            for (self.unwind_functions.items) |*function| {
+                const start_offset: usize = function.start_offset;
+                if (start_offset > body_start and start_offset < body_end) {
+                    function.start_offset += @intCast(prologue_size);
+                    function.end_offset += @intCast(prologue_size);
+                }
+            }
         }
 
         fn emitInternalCodeAddress(self: *Self, target_offset: usize, dst_reg: GeneralReg) Allocator.Error!void {
@@ -10086,8 +10144,6 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     try self.emitCallRcHelperFromStackSlots(helper, ptr_slot, null, roc_ops_slot);
                 },
             }
-
-            try self.maybeDrainRcHelpers();
         }
 
         fn emitExplicitRcHelperCallForValue(
@@ -10147,7 +10203,6 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const callback_reg = try self.allocTempGeneral();
             try self.emitPendingRcAddr(helper, callback_reg);
             try self.scheduleRcHelper(helper);
-            try self.maybeDrainRcHelpers();
             return callback_reg;
         }
 
@@ -10728,6 +10783,12 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.codegen.patchJump(early_return_patch, body_epilogue_offset);
             const body_end = self.codegen.currentOffset();
 
+            var helper_prologue_size: u32 = 0;
+            var helper_stack_alloc: u32 = 0;
+            var helper_frame_size: u32 = 0;
+            var helper_callee_saved_mask: u32 = 0;
+            var helper_epilogue_offset: u32 = 0;
+
             const final_offset = if (comptime target.toCpuArch() == .x86_64) blk: {
                 const body_bytes = self.allocator.dupe(u8, self.codegen.emit.buf.items[body_start..body_end]) catch return error.OutOfMemory;
                 defer self.allocator.free(body_bytes);
@@ -10738,6 +10799,11 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 const actual_locals_x86: u32 = @intCast(-self.codegen.stack_offset - CodeGen.CALLEE_SAVED_AREA_SIZE);
                 try self.codegen.emitPrologueWithAlloc(actual_locals_x86);
                 const prologue_size = self.codegen.currentOffset() - prologue_start;
+                helper_prologue_size = @intCast(prologue_size);
+                helper_stack_alloc = actual_locals_x86;
+                helper_frame_size = actual_locals_x86;
+                helper_callee_saved_mask = self.codegen.callee_saved_used;
+                helper_epilogue_offset = @intCast(body_epilogue_offset - body_start + prologue_size);
 
                 self.codegen.emit.buf.appendSlice(self.allocator, body_bytes) catch return error.OutOfMemory;
 
@@ -10763,6 +10829,11 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 frame_builder.setStackSize(actual_locals);
                 _ = try frame_builder.emitPrologue(&self.codegen.emit);
                 const prologue_size = self.codegen.currentOffset() - prologue_start;
+                helper_prologue_size = @intCast(prologue_size);
+                helper_stack_alloc = actual_locals;
+                helper_frame_size = frame_builder.actual_stack_alloc;
+                helper_callee_saved_mask = self.codegen.callee_saved_used;
+                helper_epilogue_offset = @intCast(body_epilogue_offset - body_start + prologue_size);
 
                 self.codegen.emit.buf.appendSlice(self.allocator, body_bytes) catch return error.OutOfMemory;
 
@@ -10780,6 +10851,16 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             if (self.compiled_rc_helpers.getPtr(cache_key)) |entry| {
                 entry.* = final_offset;
             }
+            try self.recordUnwindFunction(
+                final_offset,
+                self.codegen.currentOffset(),
+                helper_prologue_size,
+                helper_stack_alloc,
+                helper_frame_size,
+                helper_callee_saved_mask,
+                helper_epilogue_offset,
+                true,
+            );
 
             self.codegen.stack_offset = saved_stack_offset;
             self.codegen.callee_saved_used = saved_callee_saved_used;
@@ -11716,7 +11797,6 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         const helper = RcHelperVariant{ .key = helper_key, .atomicity = .atomic };
                         try self.emitPendingRcAddr(helper, on_drop_reg);
                         try self.scheduleRcHelper(helper);
-                        try self.maybeDrainRcHelpers();
                     }
                 },
                 .interpreter_context_drop => {
@@ -14157,6 +14237,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 self.shiftNestedCompiledRcHelperOffsets(body_start, body_end, prologue_size, std.math.maxInt(u64));
                 self.shiftPendingCalls(body_start, body_end, prologue_size);
                 self.shiftPendingProcAddrs(body_start, body_end, prologue_size);
+                self.shiftPendingRcRefs(body_start, body_end, prologue_size);
 
                 // Re-patch internal calls/addr whose targets are outside the shifted body
                 self.repatchInternalCalls(body_start, body_end, prologue_size, body_start);
@@ -14184,6 +14265,16 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     entry.epilogue_offset = @intCast(final_epilogue - prologue_start);
                     entry.uses_frame_pointer = true;
                 }
+                try self.recordUnwindFunction(
+                    prologue_start,
+                    self.codegen.currentOffset(),
+                    @intCast(prologue_size),
+                    actual_locals_x86,
+                    actual_locals_x86,
+                    self.codegen.callee_saved_used,
+                    @intCast(final_epilogue - prologue_start),
+                    true,
+                );
             } else {
                 // aarch64: Prepend prologue to generated body
                 // Since body was generated without prologue, we need to prepend it.
@@ -14220,6 +14311,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 self.shiftNestedCompiledRcHelperOffsets(body_start, body_end, prologue_size, std.math.maxInt(u64));
                 self.shiftPendingCalls(body_start, body_end, prologue_size);
                 self.shiftPendingProcAddrs(body_start, body_end, prologue_size);
+                self.shiftPendingRcRefs(body_start, body_end, prologue_size);
 
                 // Re-patch internal calls/addr whose targets are outside the shifted body
                 self.repatchInternalCalls(body_start, body_end, prologue_size, body_start);
@@ -14247,6 +14339,16 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     entry.epilogue_offset = @intCast(final_epilogue - prologue_start);
                     entry.uses_frame_pointer = true;
                 }
+                try self.recordUnwindFunction(
+                    prologue_start,
+                    self.codegen.currentOffset(),
+                    @intCast(prologue_size),
+                    actual_locals,
+                    frame_size,
+                    self.codegen.callee_saved_used,
+                    @intCast(final_epilogue - prologue_start),
+                    true,
+                );
             }
 
             // Restore state
@@ -14280,6 +14382,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.loop_break_patch_starts = try saved_loop_break_patch_starts.clone(self.allocator);
             self.loop_break_patches.deinit(self.allocator);
             self.loop_break_patches = try saved_loop_break_patches.clone(self.allocator);
+
+            try self.maybeDrainRcHelpers();
         }
 
         fn requireProcBody(proc: LirProcSpec) lir.LIR.CFStmtId {
@@ -16941,6 +17045,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 self.shiftNestedCompiledRcHelperOffsets(body_start, body_end, prologue_size_val, std.math.maxInt(u64));
                 self.shiftPendingCalls(body_start, body_end, prologue_size_val);
                 self.shiftPendingProcAddrs(body_start, body_end, prologue_size_val);
+                self.shiftPendingRcRefs(body_start, body_end, prologue_size_val);
                 self.repatchInternalCalls(body_start, body_end, prologue_size_val, body_start);
                 self.repatchInternalAddrPatches(body_start, body_end, prologue_size_val, body_start);
 
@@ -17033,6 +17138,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 self.shiftNestedCompiledRcHelperOffsets(body_start, body_end, prologue_size_x86, std.math.maxInt(u64));
                 self.shiftPendingCalls(body_start, body_end, prologue_size_x86);
                 self.shiftPendingProcAddrs(body_start, body_end, prologue_size_x86);
+                self.shiftPendingRcRefs(body_start, body_end, prologue_size_x86);
                 self.repatchInternalCalls(body_start, body_end, prologue_size_x86, body_start);
                 self.repatchInternalAddrPatches(body_start, body_end, prologue_size_x86, body_start);
 
@@ -17052,6 +17158,17 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             }
 
             const func_end = self.codegen.currentOffset();
+            try self.recordUnwindFunction(
+                func_start,
+                func_end,
+                prologue_size,
+                stack_alloc,
+                frame_size,
+                callee_saved_mask,
+                epilogue_offset,
+                true,
+            );
+            try self.maybeDrainRcHelpers();
 
             return ExportedSymbol{
                 .name = "",
@@ -17716,6 +17833,11 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             return self.codegen.getCode();
         }
 
+        /// Get generated callable ranges for dynamic unwind registration.
+        pub fn getUnwindFunctions(self: *const Self) []const coff.FunctionInfo {
+            return self.unwind_functions.items;
+        }
+
         /// Get relocations for the generated code buffer.
         pub fn getRelocations(self: *Self) []const Relocation {
             return self.codegen.relocations.items;
@@ -17945,6 +18067,7 @@ fn addBinaryLowLevelProc(
 
 fn compileRoot(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR.LirProcSpecId, ret_layout: layout.Idx) Allocator.Error!struct {
     code: []const u8,
+    unwind_functions: []const coff.FunctionInfo,
     entry_offset: usize,
 } {
     const allocator = std.testing.allocator;
@@ -17953,15 +18076,18 @@ fn compileRoot(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR
     try codegen.compileAllProcSpecs(store.getProcSpecs());
 
     const result = try codegen.generateCode(root_proc, ret_layout, 1);
-    return .{ .code = result.code, .entry_offset = result.entry_offset };
+    errdefer allocator.free(result.code);
+    const unwind_functions = try allocator.dupe(coff.FunctionInfo, codegen.getUnwindFunctions());
+    return .{ .code = result.code, .unwind_functions = unwind_functions, .entry_offset = result.entry_offset };
 }
 
-fn runRootI64(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR.LirProcSpecId) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform })!i64 {
+fn runRootI64(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR.LirProcSpecId) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform, UnwindRegistrationFailed })!i64 {
     const allocator = std.testing.allocator;
     const compiled = try compileRoot(store, layout_store, root_proc, .i64);
     defer allocator.free(compiled.code);
+    defer allocator.free(compiled.unwind_functions);
 
-    var executable = try ExecutableMemory.initWithEntryOffset(compiled.code, compiled.entry_offset);
+    var executable = try ExecutableMemory.initWithEntryOffsetAndUnwindInfo(compiled.code, compiled.entry_offset, compiled.unwind_functions);
     defer executable.deinit();
 
     var test_ops = TestRocOps.init(allocator);
@@ -17971,12 +18097,13 @@ fn runRootI64(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR.
     return out;
 }
 
-fn runRootU64(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR.LirProcSpecId, ret_layout: layout.Idx) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform })!u64 {
+fn runRootU64(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR.LirProcSpecId, ret_layout: layout.Idx) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform, UnwindRegistrationFailed })!u64 {
     const allocator = std.testing.allocator;
     const compiled = try compileRoot(store, layout_store, root_proc, ret_layout);
     defer allocator.free(compiled.code);
+    defer allocator.free(compiled.unwind_functions);
 
-    var executable = try ExecutableMemory.initWithEntryOffset(compiled.code, compiled.entry_offset);
+    var executable = try ExecutableMemory.initWithEntryOffsetAndUnwindInfo(compiled.code, compiled.entry_offset, compiled.unwind_functions);
     defer executable.deinit();
 
     var test_ops = TestRocOps.init(allocator);
@@ -17986,12 +18113,13 @@ fn runRootU64(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR.
     return out;
 }
 
-fn runRootU8(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR.LirProcSpecId, ret_layout: layout.Idx) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform })!u8 {
+fn runRootU8(store: *LirStore, layout_store: *layout.Store, root_proc: lir.LIR.LirProcSpecId, ret_layout: layout.Idx) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform, UnwindRegistrationFailed })!u8 {
     const allocator = std.testing.allocator;
     const compiled = try compileRoot(store, layout_store, root_proc, ret_layout);
     defer allocator.free(compiled.code);
+    defer allocator.free(compiled.unwind_functions);
 
-    var executable = try ExecutableMemory.initWithEntryOffset(compiled.code, compiled.entry_offset);
+    var executable = try ExecutableMemory.initWithEntryOffsetAndUnwindInfo(compiled.code, compiled.entry_offset, compiled.unwind_functions);
     defer executable.deinit();
 
     var test_ops = TestRocOps.init(allocator);

--- a/src/backend/dev/object/coff.zig
+++ b/src/backend/dev/object/coff.zig
@@ -556,11 +556,114 @@ pub const CoffWriter = struct {
         return data.recordSize();
     }
 
-    fn functionXdataSize(self: *Self, func: FunctionInfo) Allocator.Error!u32 {
+    pub fn functionXdataSize(self: *Self, func: FunctionInfo) Allocator.Error!u32 {
         return switch (self.arch) {
             .x86_64 => x64UnwindSize(func),
             .aarch64 => try self.arm64XdataSize(func),
         };
+    }
+
+    pub fn appendFunctionXdata(self: *Self, output: *std.ArrayList(u8), func: FunctionInfo) Allocator.Error!void {
+        switch (self.arch) {
+            .x86_64 => {
+                var unwind_codes: std.ArrayList(u8) = .empty;
+                defer unwind_codes.deinit(self.allocator);
+
+                if (builtin.mode == .Debug and func.prologue_size > std.math.maxInt(u8)) {
+                    std.debug.panic("COFF invariant violated: x64 prologue too large for UNWIND_INFO: {d}", .{func.prologue_size});
+                }
+                if (func.prologue_size > std.math.maxInt(u8)) unreachable;
+                const prolog_offset: u8 = @intCast(func.prologue_size);
+
+                if (func.stack_alloc > 0) {
+                    if (func.stack_alloc <= 128) {
+                        const op_info: u8 = @intCast((func.stack_alloc - 8) / 8);
+                        try unwind_codes.append(self.allocator, prolog_offset);
+                        try unwind_codes.append(self.allocator, (op_info << 4) | COFF.UWOP_ALLOC_SMALL);
+                    } else if (func.stack_alloc <= 512 * 1024 - 8) {
+                        try unwind_codes.append(self.allocator, prolog_offset);
+                        try unwind_codes.append(self.allocator, COFF.UWOP_ALLOC_LARGE);
+                        const size_scaled: u16 = @intCast(func.stack_alloc / 8);
+                        try unwind_codes.append(self.allocator, @truncate(size_scaled));
+                        try unwind_codes.append(self.allocator, @truncate(size_scaled >> 8));
+                    } else {
+                        try unwind_codes.append(self.allocator, prolog_offset);
+                        try unwind_codes.append(self.allocator, (1 << 4) | COFF.UWOP_ALLOC_LARGE);
+                        try unwind_codes.append(self.allocator, @truncate(func.stack_alloc));
+                        try unwind_codes.append(self.allocator, @truncate(func.stack_alloc >> 8));
+                        try unwind_codes.append(self.allocator, @truncate(func.stack_alloc >> 16));
+                        try unwind_codes.append(self.allocator, @truncate(func.stack_alloc >> 24));
+                    }
+                }
+
+                if (func.uses_frame_pointer) {
+                    const set_fpreg_offset: u8 = if (prolog_offset > 4) 4 else prolog_offset;
+                    try unwind_codes.append(self.allocator, set_fpreg_offset);
+                    try unwind_codes.append(self.allocator, COFF.UWOP_SET_FPREG);
+                    try unwind_codes.append(self.allocator, 1);
+                    try unwind_codes.append(self.allocator, (COFF.UNWIND_REG_RBP << 4) | COFF.UWOP_PUSH_NONVOL);
+                }
+
+                const code_count: u8 = @intCast(unwind_codes.items.len / 2);
+                const version_flags: u8 = 1;
+                const frame_reg: u8 = if (func.uses_frame_pointer) COFF.UNWIND_REG_RBP else 0;
+                const frame_offset: u8 = func.frame_reg_offset;
+
+                try output.append(self.allocator, version_flags);
+                try output.append(self.allocator, prolog_offset);
+                try output.append(self.allocator, code_count);
+                try output.append(self.allocator, (frame_offset << 4) | frame_reg);
+                try output.appendSlice(self.allocator, unwind_codes.items);
+
+                const total_size = 4 + unwind_codes.items.len;
+                const padded_size = (total_size + 3) & ~@as(usize, 3);
+                try output.appendNTimes(self.allocator, 0, padded_size - total_size);
+            },
+            .aarch64 => {
+                var data = try self.buildArm64UnwindData(func);
+                defer data.codes.deinit(self.allocator);
+
+                const function_bytes = func.end_offset - func.start_offset;
+                if (builtin.mode == .Debug and (function_bytes % 4 != 0 or function_bytes / 4 > 0x3ffff)) {
+                    std.debug.panic("COFF invariant violated: ARM64 function length is not encodable: {d}", .{function_bytes});
+                }
+                if (function_bytes % 4 != 0 or function_bytes / 4 > 0x3ffff) unreachable;
+
+                const code_words = data.codeWords();
+                const extended = code_words > 31;
+                const header_code_words: u32 = if (extended) 0 else code_words;
+                const header_epilog_count: u32 = if (extended) 0 else 1;
+                const arm64_header =
+                    (header_code_words << 27) |
+                    (header_epilog_count << 22) |
+                    (0 << 21) |
+                    (0 << 20) |
+                    (function_bytes / 4);
+                var header_bytes: [4]u8 = undefined;
+                std.mem.writeInt(u32, &header_bytes, arm64_header, .little);
+                try output.appendSlice(self.allocator, &header_bytes);
+
+                if (extended) {
+                    const extension = (code_words << 16) | 1;
+                    var extension_bytes: [4]u8 = undefined;
+                    std.mem.writeInt(u32, &extension_bytes, extension, .little);
+                    try output.appendSlice(self.allocator, &extension_bytes);
+                }
+
+                if (builtin.mode == .Debug and (func.epilogue_offset % 4 != 0 or func.epilogue_offset / 4 > 0x3ffff or data.epilogue_index > 1023)) {
+                    std.debug.panic("COFF invariant violated: ARM64 epilogue scope is not encodable: offset={d} index={d}", .{ func.epilogue_offset, data.epilogue_index });
+                }
+                if (func.epilogue_offset % 4 != 0 or func.epilogue_offset / 4 > 0x3ffff or data.epilogue_index > 1023) unreachable;
+
+                const epilog_scope = (data.epilogue_index << 22) | (func.epilogue_offset / 4);
+                var epilog_bytes: [4]u8 = undefined;
+                std.mem.writeInt(u32, &epilog_bytes, epilog_scope, .little);
+                try output.appendSlice(self.allocator, &epilog_bytes);
+
+                try output.appendSlice(self.allocator, data.codes.items);
+                try output.appendNTimes(self.allocator, 0, code_words * 4 - data.codes.items.len);
+            },
+        }
     }
 
     /// Write the COFF object file to a buffer
@@ -825,109 +928,9 @@ pub const CoffWriter = struct {
             var current_xdata_offset: u32 = 0;
             for (self.functions.items) |func| {
                 try xdata_offsets.append(self.allocator, current_xdata_offset);
-
-                switch (self.arch) {
-                    .x86_64 => {
-                        var unwind_codes: std.ArrayList(u8) = .empty;
-                        defer unwind_codes.deinit(self.allocator);
-
-                        if (builtin.mode == .Debug and func.prologue_size > std.math.maxInt(u8)) {
-                            std.debug.panic("COFF invariant violated: x64 prologue too large for UNWIND_INFO: {d}", .{func.prologue_size});
-                        }
-                        if (func.prologue_size > std.math.maxInt(u8)) unreachable;
-                        const prolog_offset: u8 = @intCast(func.prologue_size);
-
-                        if (func.stack_alloc > 0) {
-                            if (func.stack_alloc <= 128) {
-                                const op_info: u8 = @intCast((func.stack_alloc - 8) / 8);
-                                try unwind_codes.append(self.allocator, prolog_offset);
-                                try unwind_codes.append(self.allocator, (op_info << 4) | COFF.UWOP_ALLOC_SMALL);
-                            } else if (func.stack_alloc <= 512 * 1024 - 8) {
-                                try unwind_codes.append(self.allocator, prolog_offset);
-                                try unwind_codes.append(self.allocator, COFF.UWOP_ALLOC_LARGE);
-                                const size_scaled: u16 = @intCast(func.stack_alloc / 8);
-                                try unwind_codes.append(self.allocator, @truncate(size_scaled));
-                                try unwind_codes.append(self.allocator, @truncate(size_scaled >> 8));
-                            } else {
-                                try unwind_codes.append(self.allocator, prolog_offset);
-                                try unwind_codes.append(self.allocator, (1 << 4) | COFF.UWOP_ALLOC_LARGE);
-                                try unwind_codes.append(self.allocator, @truncate(func.stack_alloc));
-                                try unwind_codes.append(self.allocator, @truncate(func.stack_alloc >> 8));
-                                try unwind_codes.append(self.allocator, @truncate(func.stack_alloc >> 16));
-                                try unwind_codes.append(self.allocator, @truncate(func.stack_alloc >> 24));
-                            }
-                        }
-
-                        if (func.uses_frame_pointer) {
-                            const set_fpreg_offset: u8 = if (prolog_offset > 4) 4 else prolog_offset;
-                            try unwind_codes.append(self.allocator, set_fpreg_offset);
-                            try unwind_codes.append(self.allocator, COFF.UWOP_SET_FPREG);
-                            try unwind_codes.append(self.allocator, 1);
-                            try unwind_codes.append(self.allocator, (COFF.UNWIND_REG_RBP << 4) | COFF.UWOP_PUSH_NONVOL);
-                        }
-
-                        const code_count: u8 = @intCast(unwind_codes.items.len / 2);
-                        const version_flags: u8 = 1;
-                        const frame_reg: u8 = if (func.uses_frame_pointer) COFF.UNWIND_REG_RBP else 0;
-                        const frame_offset: u8 = func.frame_reg_offset;
-
-                        try output.append(self.allocator, version_flags);
-                        try output.append(self.allocator, prolog_offset);
-                        try output.append(self.allocator, code_count);
-                        try output.append(self.allocator, (frame_offset << 4) | frame_reg);
-                        try output.appendSlice(self.allocator, unwind_codes.items);
-
-                        const total_size = 4 + unwind_codes.items.len;
-                        const padded_size = (total_size + 3) & ~@as(usize, 3);
-                        try output.appendNTimes(self.allocator, 0, padded_size - total_size);
-                        current_xdata_offset += @intCast(padded_size);
-                    },
-                    .aarch64 => {
-                        var data = try self.buildArm64UnwindData(func);
-                        defer data.codes.deinit(self.allocator);
-
-                        const function_bytes = func.end_offset - func.start_offset;
-                        if (builtin.mode == .Debug and (function_bytes % 4 != 0 or function_bytes / 4 > 0x3ffff)) {
-                            std.debug.panic("COFF invariant violated: ARM64 function length is not encodable: {d}", .{function_bytes});
-                        }
-                        if (function_bytes % 4 != 0 or function_bytes / 4 > 0x3ffff) unreachable;
-
-                        const code_words = data.codeWords();
-                        const extended = code_words > 31;
-                        const header_code_words: u32 = if (extended) 0 else code_words;
-                        const header_epilog_count: u32 = if (extended) 0 else 1;
-                        const arm64_header =
-                            (header_code_words << 27) |
-                            (header_epilog_count << 22) |
-                            (0 << 21) |
-                            (0 << 20) |
-                            (function_bytes / 4);
-                        var header_bytes: [4]u8 = undefined;
-                        std.mem.writeInt(u32, &header_bytes, arm64_header, .little);
-                        try output.appendSlice(self.allocator, &header_bytes);
-
-                        if (extended) {
-                            const extension = (code_words << 16) | 1;
-                            var extension_bytes: [4]u8 = undefined;
-                            std.mem.writeInt(u32, &extension_bytes, extension, .little);
-                            try output.appendSlice(self.allocator, &extension_bytes);
-                        }
-
-                        if (builtin.mode == .Debug and (func.epilogue_offset % 4 != 0 or func.epilogue_offset / 4 > 0x3ffff or data.epilogue_index > 1023)) {
-                            std.debug.panic("COFF invariant violated: ARM64 epilogue scope is not encodable: offset={d} index={d}", .{ func.epilogue_offset, data.epilogue_index });
-                        }
-                        if (func.epilogue_offset % 4 != 0 or func.epilogue_offset / 4 > 0x3ffff or data.epilogue_index > 1023) unreachable;
-
-                        const epilog_scope = (data.epilogue_index << 22) | (func.epilogue_offset / 4);
-                        var epilog_bytes: [4]u8 = undefined;
-                        std.mem.writeInt(u32, &epilog_bytes, epilog_scope, .little);
-                        try output.appendSlice(self.allocator, &epilog_bytes);
-
-                        try output.appendSlice(self.allocator, data.codes.items);
-                        try output.appendNTimes(self.allocator, 0, code_words * 4 - data.codes.items.len);
-                        current_xdata_offset += data.recordSize();
-                    },
-                }
+                const before_len = output.items.len;
+                try self.appendFunctionXdata(output, func);
+                current_xdata_offset += @intCast(output.items.len - before_len);
             }
         }
 

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -459,6 +459,7 @@ pub const CompileTimeFinalizer = struct {
         MmapFailed,
         MprotectFailed,
         UnsupportedPlatform,
+        UnwindRegistrationFailed,
         VirtualAllocFailed,
         VirtualProtectFailed,
     };

--- a/src/eval/compile_time_finalization.zig
+++ b/src/eval/compile_time_finalization.zig
@@ -968,7 +968,11 @@ fn lowerDevEvalAndFinishRoots(
         allocator.free(jobs);
     }
 
-    var executable = try backend.ExecutableMemory.initWithEntryOffset(codegen.getGeneratedCode(), 0);
+    var executable = try backend.ExecutableMemory.initWithEntryOffsetAndUnwindInfo(
+        codegen.getGeneratedCode(),
+        0,
+        codegen.getUnwindFunctions(),
+    );
     defer executable.deinit();
 
     var progress = DevProgressReporter.init(options, jobs[0..jobs_len]);

--- a/src/eval/compile_time_host.zig
+++ b/src/eval/compile_time_host.zig
@@ -301,9 +301,6 @@ fn allocateBytes(allocator: Allocator, len: usize, alignment: usize) ?[*]u8 {
 fn hostBytesAllocator(allocator: Allocator) Allocator {
     return switch (@import("builtin").target.os.tag) {
         .freestanding => std.heap.wasm_allocator,
-        // Windows stack-capturing allocators need registered unwind metadata
-        // for every JIT frame. The dev-backend JIT does not publish that yet.
-        .windows => std.heap.smp_allocator,
         else => allocator,
     };
 }

--- a/src/eval/test/RuntimeHostEnv.zig
+++ b/src/eval/test/RuntimeHostEnv.zig
@@ -109,11 +109,8 @@ allocation_call_count: u32 = 0,
 longjmp_on_crash: bool = true,
 
 pub fn init(allocator: std.mem.Allocator) RuntimeHostEnv {
-    // The allocation_tracker grows from inside rocAllocFn, which on Windows
-    // is invoked from JIT'd dev-backend code. Stack-capturing allocators
-    // (testing.allocator) crash inside walkStackWindows when unwinding
-    // through JIT memory that lacks Windows unwind data, so the tracker
-    // uses a non-tracing allocator regardless of what was passed in.
+    // Runtime byte leak checking is handled by allocation_tracker itself, so
+    // keep the tracker's backing allocations out of the caller's leak reports.
     return .{
         .allocator = allocator,
         .allocation_tracker = std.AutoHashMap(usize, AllocationInfo).init(runtime_bytes_allocator),
@@ -325,12 +322,9 @@ fn rocReallocFn(ops: *RocOps, ptr: *anyopaque, new_length: usize, alignment: usi
     return @ptrCast(new_base_ptr);
 }
 
-// Use a non-tracing allocator for Roc runtime bytes. On Windows the
-// dev-backend JIT emits code without unwind data, so a stack-capturing
-// allocator (e.g. DebugAllocator/testing.allocator) crashes inside
-// walkStackWindows when an alloc happens from JIT'd code. RuntimeHostEnv
-// owns its own allocation_tracker for leak detection, so we don't need the
-// underlying allocator to track.
+// Use a non-tracing allocator for Roc runtime bytes. RuntimeHostEnv owns the
+// allocation_tracker that powers these tests' leak checks, so the underlying
+// allocator does not need to track the same bytes a second time.
 const runtime_bytes_allocator: std.mem.Allocator = if (@import("builtin").target.os.tag == .freestanding)
     std.heap.wasm_allocator
 else

--- a/src/eval/test/host_effects_runner.zig
+++ b/src/eval/test/host_effects_runner.zig
@@ -375,9 +375,10 @@ fn runDev(allocator: std.mem.Allocator, lowered: *const LoweredProgram) BackendE
             arg_layouts,
             proc.ret_layout,
         );
-        var exec_mem = try ExecutableMemory.initWithEntryOffset(
+        var exec_mem = try ExecutableMemory.initWithEntryOffsetAndUnwindInfo(
             codegen.getGeneratedCode(),
             entrypoint.offset,
+            codegen.getUnwindFunctions(),
         );
         defer exec_mem.deinit();
 

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -56,6 +56,7 @@ pub const TestHelperError = Allocator.Error || std.DynLib.Error || std.Io.File.O
     Internal,
     UnsupportedTarget,
     UnsupportedPlatform,
+    UnwindRegistrationFailed,
     SysctlFailed,
     CreateFileMappingFailed,
     OpenFileMappingFailed,
@@ -2016,9 +2017,10 @@ pub fn devEvalBoolRoots(
                 root.arg_layouts,
                 root.ret_layout,
             );
-            var executable = try ExecutableMemory.initWithEntryOffset(
+            var executable = try ExecutableMemory.initWithEntryOffsetAndUnwindInfo(
                 codegen.getGeneratedCode(),
                 entrypoint.offset,
+                codegen.getUnwindFunctions(),
             );
             defer executable.deinit();
 
@@ -2249,9 +2251,10 @@ pub fn devEvaluatorStrWithStats(allocator: Allocator, lowered: *const LoweredPro
             arg_layouts,
             proc.ret_layout,
         );
-        var exec_mem = try ExecutableMemory.initWithEntryOffset(
+        var exec_mem = try ExecutableMemory.initWithEntryOffsetAndUnwindInfo(
             codegen.getGeneratedCode(),
             entrypoint.offset,
+            codegen.getUnwindFunctions(),
         );
         defer exec_mem.deinit();
 

--- a/src/glue/glue.zig
+++ b/src/glue/glue.zig
@@ -501,9 +501,10 @@ fn runGlueSpecDev(
             proc.ret_layout,
         ) catch return error.OutOfMemory;
 
-        var executable = backend.ExecutableMemory.initWithEntryOffset(
+        var executable = backend.ExecutableMemory.initWithEntryOffsetAndUnwindInfo(
             codegen.getGeneratedCode(),
             entrypoint.offset,
+            codegen.getUnwindFunctions(),
         ) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             else => return error.CompilationFailed,


### PR DESCRIPTION
This teaches executable-memory setup to register Windows unwind metadata for generated dev-backend code, using the same COFF unwind encoding already used for object files. Generated callable ranges are now recorded explicitly, RC helpers are emitted after enclosing function ranges instead of as overlapping islands, and executable memory registers a sorted dynamic function table before JIT code runs. With that in place, compile-time host allocations can use the caller allocator on Windows again instead of bypassing stack capture.