### PR TITLE
Search language reference docs entries

### DIFF
--- a/src/docs/static/search.js
+++ b/src/docs/static/search.js
@@ -83,6 +83,45 @@ const setupSearch = () => {
 
     searchForm.addEventListener("keydown", searchKeyDown);
 
+    function addLangRefSearchEntries() {
+      if (searchTypeAhead.dataset.langRefReady === "true") return;
+
+      document
+        .querySelectorAll("#sidebar-nav .langref-articles a[href]")
+        .forEach((sidebarLink) => {
+          const name = sidebarLink.textContent.replace(/\s+/g, " ").trim();
+          if (name === "") return;
+
+          const item = document.createElement("li");
+          item.classList.add("hidden");
+
+          const link = document.createElement("a");
+          link.classList.add("type-ahead-link", "type-ahead-langref");
+          link.href = sidebarLink.getAttribute("href");
+
+          const defName = document.createElement("span");
+          defName.classList.add("type-ahead-def-name", "type-ahead-langref-title");
+          defName.textContent = name;
+
+          const context = document.createElement("span");
+          context.classList.add("type-ahead-langref-context");
+          context.textContent = "Language Reference";
+
+          const signature = document.createElement("span");
+          signature.classList.add("type-ahead-signature");
+          signature.textContent = "Language Reference";
+          signature.hidden = true;
+
+          link.append(defName, " in ", context, signature);
+          item.appendChild(link);
+          searchTypeAhead.appendChild(item);
+        });
+
+      searchTypeAhead.dataset.langRefReady = "true";
+    }
+
+    addLangRefSearchEntries();
+
     function search() {
       topSearchResultListItem = undefined;
       let text = searchBox.value.toLowerCase(); // Search is case-insensitive.

--- a/src/docs/static/styles.css
+++ b/src/docs/static/styles.css
@@ -916,6 +916,21 @@ pre>code {
   }
 }
 
+#search-type-ahead .type-ahead-link.type-ahead-langref {
+  font-family: var(--font-sans);
+}
+
+#search-type-ahead .type-ahead-link.type-ahead-langref,
+#search-type-ahead .type-ahead-link.type-ahead-langref .type-ahead-langref-context {
+  color: var(--text-color);
+}
+
+#search-type-ahead .type-ahead-link.type-ahead-langref .type-ahead-langref-title {
+  color: var(--text-color);
+  font-family: var(--font-sans);
+  font-weight: var(--weight-bold);
+}
+
 #search-type-ahead li {
   box-sizing: border-box;
   position: relative;


### PR DESCRIPTION
This adds the language reference sidebar links to the docs search results at runtime, so queries like "expressions" can find the corresponding language reference page. These results use a prose-style label like "Expressions in Language Reference" instead of the builtin symbol search formatting.