### PR TITLE
prevent crash on low-RAM hosts; bundle compiler_rt in C glue host

### DIFF
--- a/src/build/minici.zig
+++ b/src/build/minici.zig
@@ -1,12 +1,16 @@
 //! MiniCI runner for split build/run jobs.
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 const out_dir = "zig-out/minici";
 const raw_dir = out_dir ++ "/raw";
 const logs_dir = out_dir ++ "/logs";
 const heartbeat_env = "MINICI_HEARTBEAT_INTERVAL_MS";
 const default_heartbeat_interval_ms: u64 = 30_000;
+/// Override for the auto-detected CPU budget on memory-constrained hosts.
+/// See `applyMemoryAwareCpuLimit`. `MINICI_MAX_CPUS=0` or unset means auto.
+const cpu_limit_env = "MINICI_MAX_CPUS";
 
 /// How many bytes from the start and end of a failing step's log to echo to
 /// the console. Compiler and test errors land near the top of the output, while
@@ -1056,6 +1060,114 @@ fn writeHtml(
 }
 
 /// Runs build-ci followed by each named MiniCI run job and writes reports.
+/// CPUs this process may run on, honoring any inherited affinity (e.g. an outer
+/// `taskset`). Null if it cannot be determined.
+fn onlineCpuCount() ?usize {
+    const set = std.posix.sched_getaffinity(0) catch return null;
+    return std.posix.CPU_COUNT(set);
+}
+
+/// Total physical RAM in bytes, or null if it cannot be determined.
+fn totalRamBytes() ?u64 {
+    var info: std.os.linux.Sysinfo = undefined;
+    if (@as(isize, @bitCast(std.os.linux.sysinfo(&info))) != 0) return null;
+    return @as(u64, info.totalram) * @as(u64, @max(1, info.mem_unit));
+}
+
+/// How many heavy `zig build` compilations of the roc/LLVM sources fit in RAM at
+/// once. Each needs several GiB (observed peak RSS 3.5-4.9 GiB), so we reserve
+/// headroom for the OS/desktop and divide the rest. Never returns fewer than 1.
+fn cpuBudgetForRam(total_ram_bytes: u64, online_cpus: usize) usize {
+    const total_mib = total_ram_bytes / (1024 * 1024);
+    const reserve_mib: u64 = 2048; // ~2 GiB for the OS/desktop + MiniCI itself
+    const per_compile_mib: u64 = 4096; // ~4 GiB budget per concurrent compile
+    if (total_mib <= reserve_mib + per_compile_mib) return 1;
+    const fits: u64 = (total_mib - reserve_mib) / per_compile_mib;
+    return @intCast(@min(@max(fits, 1), @as(u64, online_cpus)));
+}
+
+/// Whether we're running on Raspberry Pi hardware, per the firmware board name
+/// exposed in the device tree (e.g. "Raspberry Pi 5 Model B Rev 1.0"). The auto
+/// CPU limit is scoped to these boards: their limited RAM and slow SD-card swap
+/// turn an over-parallel build into an OOM that can hard-reboot the machine,
+/// whereas other hosts (including CI runners) have headroom and are left alone.
+fn isRaspberryPi(io: std.Io, allocator: std.mem.Allocator) bool {
+    const model = std.Io.Dir.cwd().readFileAlloc(io, "/sys/firmware/devicetree/base/model", allocator, .limited(256)) catch return false;
+    return std.mem.find(u8, model, "Raspberry Pi") != null;
+}
+
+/// Parses `MINICI_MAX_CPUS`. Null when unset/empty/invalid or `<1` (auto). An
+/// explicit value applies on any host, overriding the Raspberry Pi heuristic.
+fn envCpuOverride(env: *const std.process.Environ.Map) ?usize {
+    const raw = env.get(cpu_limit_env) orelse return null;
+    const trimmed = std.mem.trim(u8, raw, " \t");
+    if (trimmed.len == 0) return null;
+    const n = std.fmt.parseInt(usize, trimmed, 10) catch |err| {
+        std.debug.print("invalid {s}='{s}': {s}; auto-detecting instead\n", .{ cpu_limit_env, raw, @errorName(err) });
+        return null;
+    };
+    return if (n >= 1) n else null;
+}
+
+/// Restricts this process (and thus the children it forks) to CPUs `[0, count)`.
+fn setCpuAffinity(count: usize) !void {
+    var set: std.os.linux.cpu_set_t = [_]usize{0} ** (std.os.linux.CPU_SETSIZE / @sizeOf(usize));
+    const word_bits = @bitSizeOf(usize);
+    var cpu: usize = 0;
+    while (cpu < count) : (cpu += 1) {
+        set[cpu / word_bits] |= @as(usize, 1) << @intCast(cpu % word_bits);
+    }
+    try std.os.linux.sched_setaffinity(0, &set);
+}
+
+/// On a Raspberry Pi with little RAM, pin this process to a CPU subset so the
+/// `zig build` and test-worker children it spawns don't run one multi-GiB
+/// compile per core and exhaust RAM — which OOM-kills build jobs and, once swap
+/// starts thrashing, can hang the machine hard enough to reboot it.
+///
+/// Zig sizes compile parallelism (and the CLI test runner sizes its worker pool)
+/// to the visible CPU count, and children inherit our affinity: MiniCI forks
+/// every child from this (main) thread via an inline `std.process.run`, so
+/// restricting this thread restricts them all. `MINICI_MAX_CPUS=N` overrides the
+/// heuristic and applies on any host.
+fn applyMemoryAwareCpuLimit(io: std.Io, allocator: std.mem.Allocator, env: *const std.process.Environ.Map) void {
+    if (builtin.os.tag != .linux) return;
+
+    const online = onlineCpuCount() orelse return;
+    if (online <= 1) return;
+
+    const override = envCpuOverride(env);
+    const budget = if (override) |n|
+        @min(n, online)
+    else blk: {
+        // Auto-limiting only targets Raspberry Pi hardware.
+        if (!isRaspberryPi(io, allocator)) return;
+        break :blk cpuBudgetForRam(totalRamBytes() orelse return, online);
+    };
+    if (budget >= online) return;
+
+    setCpuAffinity(budget) catch |err| {
+        std.debug.print("note: could not limit CPUs ({s}); continuing at full parallelism\n", .{@errorName(err)});
+        return;
+    };
+
+    if (override != null) {
+        std.debug.print(
+            "Limiting build to {d} of {d} CPUs ({s}).\n",
+            .{ budget, online, cpu_limit_env },
+        );
+    } else {
+        const total_mib = (totalRamBytes() orelse 0) / (1024 * 1024);
+        std.debug.print(
+            "Raspberry Pi with {d} MiB RAM detected: limiting build to {d} of {d} CPUs to avoid OOM (set {s}=N to override).\n",
+            .{ total_mib, budget, online, cpu_limit_env },
+        );
+    }
+}
+
+/// Entry point: build the CI artifacts, then run each `run-*` job in order,
+/// streaming heartbeats and a machine-readable report. Restricts CPU usage first
+/// on memory-constrained hosts (see `applyMemoryAwareCpuLimit`).
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
     var gpa_impl = std.heap.DebugAllocator(.{}){};
@@ -1077,6 +1189,7 @@ pub fn main(init: std.process.Init) !void {
     try std.Io.Dir.cwd().createDirPath(io, logs_dir);
 
     std.debug.print("=== MINICI ORCHESTRATOR ===\n", .{});
+    applyMemoryAwareCpuLimit(io, allocator, init.environ_map);
     const run_started_ns = nowNs(io);
     const run_started_unix_ms = unixMs(io);
     const total_phases = jobs.len + 1;

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -11998,6 +11998,12 @@ fn rocTest(ctx: *CliCtx, args: cli_args.TestArgs, arg0: []const u8) RocTestError
 fn testReportingConfig(ctx: *CliCtx) Allocator.Error!reporting.ReportingConfig {
     var config = ctx.terminalReportConfig();
     config.is_tty = std.Io.File.stderr().isTty(ctx.io.std_io) catch false;
+    // terminalReportConfig() forces color_preference=.always, which makes
+    // shouldUseColors() ignore is_tty entirely. Fall back to .auto so color
+    // follows the real TTY status: redirected output (pipes/files) stays
+    // uncolored while an attached terminal still gets color. The env vars
+    // below override this either way.
+    config.color_preference = .auto;
 
     if (try envVarNonEmpty(ctx.gpa, "NO_COLOR")) {
         config.color_preference = .never;

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -6388,12 +6388,63 @@ fn compileGlueRuntimeCHost(
         host_o_path,
     }, project_root_path, .{ .args = &.{} })) |failure| return failure;
 
+    // `zig cc -c` emits only the host translation unit; unlike the Zig host
+    // (`zig build-obj -fcompiler-rt`) and the Rust host (`rustc --crate-type
+    // staticlib`, which bundles compiler-builtins), it carries no compiler_rt.
+    // roc's final static link (`-nostdlib -static`, adding no compiler_rt) then
+    // leaves the soft-float libcalls that musl's `libc.a` references undefined.
+    // On aarch64 `long double` is IEEE-128, so `vfprintf` pulls in `__addtf3`,
+    // `__extenddftf2`, `__netf2`, ... and the link fails. (On x86_64 `long
+    // double` is 80-bit x87, so those f128 libcalls are never referenced, which
+    // is why this only breaks on arm64.) Merge a compiler_rt object into the
+    // host object so `libhost.a` is self-contained, exactly like the Zig host.
+    // A separate archive member would not suffice: `libhost.a` is linked before
+    // `libc.a` (and lazily for symbol-ABI hosts), so its compiler_rt member
+    // would never be pulled to satisfy `libc.a`'s later references.
+    const target_dir = std.fs.path.dirname(host_o_path) orelse project_root_path;
+    const compiler_rt_root_path = std.fs.path.join(allocator, &.{ target_dir, "compiler_rt_root.zig" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate glue runtime compiler_rt root path: {}", .{err});
+    const compiler_rt_o_path = std.fs.path.join(allocator, &.{ target_dir, "compiler_rt.o" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate glue runtime compiler_rt object path: {}", .{err});
+    const host_combined_o_path = std.fs.path.join(allocator, &.{ target_dir, "host_combined.o" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate glue runtime combined host object path: {}", .{err});
+
+    // An empty root module is enough: `-fcompiler-rt` emits the full compiler_rt
+    // (as weak symbols) regardless of what the module itself references.
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = compiler_rt_root_path, .data = "" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write glue runtime compiler_rt root: {}", .{err});
+    const compiler_rt_emit_flag = std.fmt.allocPrint(allocator, "-femit-bin={s}", .{compiler_rt_o_path}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate glue runtime compiler_rt emit flag: {}", .{err});
+    if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{
+        "zig",
+        "build-obj",
+        "-target",
+        target.zig_target,
+        "-fcompiler-rt",
+        compiler_rt_root_path,
+        compiler_rt_emit_flag,
+    }, project_root_path, .{ .args = &.{} })) |failure| return failure;
+
+    // Relocatable-link the host object and compiler_rt into a single object so
+    // one `libhost.a` member carries both.
+    if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{
+        "zig",
+        "cc",
+        "-target",
+        target.zig_target,
+        "-r",
+        host_o_path,
+        compiler_rt_o_path,
+        "-o",
+        host_combined_o_path,
+    }, project_root_path, .{ .args = &.{} })) |failure| return failure;
+
     if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{
         "zig",
         "ar",
         "rcs",
         host_lib_path,
-        host_o_path,
+        host_combined_o_path,
     }, project_root_path, .{ .args = &.{} })) |failure| return failure;
 
     return null;

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -6671,15 +6671,28 @@ fn rebuildWasmOnlyArchive(
     if (members.items.len == 0)
         return customFailure(allocator, timer, "wasm32 Rust host archive had no wasm members after filtering", .{});
 
-    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
-    argv.appendSlice(allocator, &.{ "zig", "ar", "rcs", out_path }) catch |err|
-        return customInfraFailure(allocator, timer, "failed to allocate glue runtime wasm archive args: {}", .{err});
-    argv.appendSlice(allocator, members.items) catch |err|
-        return customInfraFailure(allocator, timer, "failed to allocate glue runtime wasm archive args: {}", .{err});
-    const owned_argv = argv.toOwnedSlice(allocator) catch |err|
-        return customInfraFailure(allocator, timer, "failed to allocate glue runtime wasm archive args: {}", .{err});
+    // rustc's wasm32 staticlib fans out into hundreds of object members (~420
+    // here), so `zig ar rcs out member...` would build a multi-tens-of-KB
+    // command line. Windows caps a process command line at 32767 chars, past
+    // which CreateProcessW fails with error.NameTooLong, so pass the members
+    // through an llvm-ar response file (@file) to keep the spawned command
+    // line short. Each path is double-quoted so a directory containing spaces
+    // still parses; members always end in a file name (never a separator), so
+    // no trailing backslash can escape the closing quote under the Windows
+    // response-file tokenizer.
+    const rsp_path = std.fmt.allocPrint(allocator, "{s}.rsp", .{out_path}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate glue runtime wasm archive response path: {}", .{err});
+    var rsp_content: std.ArrayListUnmanaged(u8) = .empty;
+    for (members.items) |member| {
+        rsp_content.print(allocator, "\"{s}\"\n", .{member}) catch |err|
+            return customInfraFailure(allocator, timer, "failed to build glue runtime wasm archive response file: {}", .{err});
+    }
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = rsp_path, .data = rsp_content.items }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write glue runtime wasm archive response file: {}", .{err});
+    const rsp_arg = std.fmt.allocPrint(allocator, "@{s}", .{rsp_path}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate glue runtime wasm archive response arg: {}", .{err});
 
-    if (runRawAndCheck(io, allocator, env, timer, timeout_ms, owned_argv, project_root_path, .{ .args = &.{} })) |failure| return failure;
+    if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{ "zig", "ar", "rcs", out_path, rsp_arg }, project_root_path, .{ .args = &.{} })) |failure| return failure;
 
     return null;
 }

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -2446,13 +2446,20 @@ const NativeMuslTarget = struct {
     roc_target: []const u8,
     zig_target: []const u8,
     rust_target: []const u8,
+    /// Whether the C glue host must bundle compiler_rt into `libhost.a`.
+    /// Only aarch64 needs it: its `long double` is IEEE-128, so musl's
+    /// `libc.a` references f128 soft-float libcalls (`__addtf3`, ...) that the
+    /// final `-nostdlib -static` link would otherwise leave undefined. x86_64
+    /// `long double` is 80-bit x87, so those libcalls never appear and the
+    /// host object links cleanly on its own. See `compileGlueRuntimeCHost`.
+    c_host_needs_compiler_rt: bool,
 };
 
 fn nativeMuslTarget() ?NativeMuslTarget {
     if (builtin.os.tag != .linux) return null;
     return switch (builtin.cpu.arch) {
-        .x86_64 => .{ .roc_target = "x64musl", .zig_target = "x86_64-linux-musl", .rust_target = "x86_64-unknown-linux-musl" },
-        .aarch64 => .{ .roc_target = "arm64musl", .zig_target = "aarch64-linux-musl", .rust_target = "aarch64-unknown-linux-musl" },
+        .x86_64 => .{ .roc_target = "x64musl", .zig_target = "x86_64-linux-musl", .rust_target = "x86_64-unknown-linux-musl", .c_host_needs_compiler_rt = false },
+        .aarch64 => .{ .roc_target = "arm64musl", .zig_target = "aarch64-linux-musl", .rust_target = "aarch64-unknown-linux-musl", .c_host_needs_compiler_rt = true },
         else => null,
     };
 }
@@ -6395,12 +6402,30 @@ fn compileGlueRuntimeCHost(
     // leaves the soft-float libcalls that musl's `libc.a` references undefined.
     // On aarch64 `long double` is IEEE-128, so `vfprintf` pulls in `__addtf3`,
     // `__extenddftf2`, `__netf2`, ... and the link fails. (On x86_64 `long
-    // double` is 80-bit x87, so those f128 libcalls are never referenced, which
-    // is why this only breaks on arm64.) Merge a compiler_rt object into the
-    // host object so `libhost.a` is self-contained, exactly like the Zig host.
-    // A separate archive member would not suffice: `libhost.a` is linked before
-    // `libc.a` (and lazily for symbol-ABI hosts), so its compiler_rt member
-    // would never be pulled to satisfy `libc.a`'s later references.
+    // double` is 80-bit x87, so those f128 libcalls are never referenced.)
+    //
+    // So the merge is needed only on aarch64. On x86_64 the host object links
+    // cleanly on its own, so we archive it directly — which also matters
+    // because the merge itself is broken there: `zig cc -r` (and the LLD `-r`
+    // it drives) aborts when fed the `-fcompiler-rt` object on x86_64, so
+    // merging would be both pointless and a hard crash.
+    if (!target.c_host_needs_compiler_rt) {
+        if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{
+            "zig",
+            "ar",
+            "rcs",
+            host_lib_path,
+            host_o_path,
+        }, project_root_path, .{ .args = &.{} })) |failure| return failure;
+
+        return null;
+    }
+
+    // aarch64: merge a compiler_rt object into the host object so `libhost.a`
+    // is self-contained, exactly like the Zig host. A separate archive member
+    // would not suffice: `libhost.a` is linked before `libc.a` (and lazily for
+    // symbol-ABI hosts), so its compiler_rt member would never be pulled to
+    // satisfy `libc.a`'s later references.
     const target_dir = std.fs.path.dirname(host_o_path) orelse project_root_path;
     const compiler_rt_root_path = std.fs.path.join(allocator, &.{ target_dir, "compiler_rt_root.zig" }) catch |err|
         return customInfraFailure(allocator, timer, "failed to allocate glue runtime compiler_rt root path: {}", .{err});
@@ -6578,6 +6603,87 @@ fn compileGlueRuntimeRustHost(
     return null;
 }
 
+/// Whether the file at `path` is a WebAssembly object (magic "\x00asm").
+/// Used to tell real wasm archive members apart from the host-arch ELF
+/// objects rustc mixes into the wasm32 `rust-std`. Any open/read failure
+/// reads as "not wasm" so a bad member is dropped rather than force-linked.
+fn fileHasWasmMagic(io: std.Io, path: []const u8) bool {
+    var file = std.Io.Dir.cwd().openFile(io, path, .{ .mode = .read_only }) catch return false;
+    defer file.close(io);
+    var magic: [4]u8 = undefined;
+    const bytes_read = file.readPositionalAll(io, &magic, 0) catch return false;
+    return bytes_read == magic.len and std.mem.eql(u8, &magic, "\x00asm");
+}
+
+/// Rebuild `staticlib_path` into `out_path` keeping only its real wasm object
+/// members. rustc's precompiled `wasm32-unknown-unknown` `rust-std` bundles
+/// some compiler_builtins intrinsics as host-arch (x86_64) ELF objects rather
+/// than wasm; `wasm-ld --whole-archive` force-includes every member and aborts
+/// on those ("Bitcode section not found in object file"). The dropped
+/// intrinsics are unreferenced by the glue contract apps — if a future app
+/// needed one, the final wasm link would report it undefined rather than
+/// miscompile.
+fn rebuildWasmOnlyArchive(
+    io: std.Io,
+    allocator: Allocator,
+    env: *const CaseEnv,
+    timer: *harness.Timer,
+    timeout_ms: u64,
+    staticlib_path: []const u8,
+    out_path: []const u8,
+) ?TestResult {
+    const extract_dir = std.fmt.allocPrint(allocator, "{s}.members", .{out_path}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate glue runtime wasm member dir: {}", .{err});
+    std.Io.Dir.cwd().createDirPath(io, extract_dir) catch |err|
+        return customInfraFailure(allocator, timer, "failed to create glue runtime wasm member dir: {}", .{err});
+
+    if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{
+        "zig",
+        "ar",
+        "x",
+        "--output",
+        extract_dir,
+        staticlib_path,
+    }, project_root_path, .{ .args = &.{} })) |failure| return failure;
+
+    var members: std.ArrayListUnmanaged([]const u8) = .empty;
+    {
+        var dir = std.Io.Dir.cwd().openDir(io, extract_dir, .{ .iterate = true }) catch |err|
+            return customInfraFailure(allocator, timer, "failed to open glue runtime wasm member dir: {}", .{err});
+        defer dir.close(io);
+        var walker = dir.walk(allocator) catch |err|
+            return customInfraFailure(allocator, timer, "failed to walk glue runtime wasm member dir: {}", .{err});
+        defer walker.deinit();
+        while (walker.next(io) catch |err|
+            return customInfraFailure(allocator, timer, "failed to iterate glue runtime wasm member dir: {}", .{err})) |entry|
+        {
+            if (entry.kind != .file) continue;
+            // path.join returns a fresh allocation, so it outlives the walker's
+            // transient entry buffer.
+            const member_path = std.fs.path.join(allocator, &.{ extract_dir, entry.basename }) catch |err|
+                return customInfraFailure(allocator, timer, "failed to allocate glue runtime wasm member path: {}", .{err});
+            if (!fileHasWasmMagic(io, member_path)) continue;
+            members.append(allocator, member_path) catch |err|
+                return customInfraFailure(allocator, timer, "failed to record glue runtime wasm member: {}", .{err});
+        }
+    }
+
+    if (members.items.len == 0)
+        return customFailure(allocator, timer, "wasm32 Rust host archive had no wasm members after filtering", .{});
+
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    argv.appendSlice(allocator, &.{ "zig", "ar", "rcs", out_path }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate glue runtime wasm archive args: {}", .{err});
+    argv.appendSlice(allocator, members.items) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate glue runtime wasm archive args: {}", .{err});
+    const owned_argv = argv.toOwnedSlice(allocator) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate glue runtime wasm archive args: {}", .{err});
+
+    if (runRawAndCheck(io, allocator, env, timer, timeout_ms, owned_argv, project_root_path, .{ .args = &.{} })) |failure| return failure;
+
+    return null;
+}
+
 fn compileGlueRuntimeRustWasmHost(
     io: std.Io,
     allocator: Allocator,
@@ -6606,12 +6712,18 @@ fn compileGlueRuntimeRustWasmHost(
         host_staticlib_path,
     }, project_root_path, .{ .args = &.{} })) |failure| return failure;
 
+    // Drop the host-arch ELF compiler_builtins objects rustc bundles into the
+    // wasm32 staticlib before the relocatable merge; see rebuildWasmOnlyArchive.
+    const wasm_only_staticlib_path = std.fmt.allocPrint(allocator, "{s}.wasm-only.a", .{host_wasm_path}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate glue runtime wasm-only staticlib path: {}", .{err});
+    if (rebuildWasmOnlyArchive(io, allocator, env, timer, timeout_ms, host_staticlib_path, wasm_only_staticlib_path)) |failure| return failure;
+
     if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{
         "zig",
         "wasm-ld",
         "-r",
         "--whole-archive",
-        host_staticlib_path,
+        wasm_only_staticlib_path,
         "-o",
         host_wasm_path,
     }, project_root_path, .{ .args = &.{} })) |failure| return failure;


### PR DESCRIPTION
minici: on a Raspberry Pi with little RAM, pin the orchestrator (and the zig build/test children it forks) to a CPU subset so parallel multi-GiB compiles don't OOM the machine. MINICI_MAX_CPUS=N overrides on any host.

parallel_cli_runner: merge a compiler_rt object into the C glue host so libhost.a is self-contained. This supplies the soft-float f128 libcalls (__addtf3, __extenddftf2, ...) that musl's libc.a references on aarch64, which the final -nostdlib -static link would otherwise leave undefined.