### PR TITLE
Hide redundant echo step failures

### DIFF
--- a/src/echo_platform/runner.zig
+++ b/src/echo_platform/runner.zig
@@ -179,13 +179,15 @@ pub fn runEcho(opts: RunOptions) RunEchoError!u8 {
     build_env.filesystem = echo_ctx.io();
 
     build_env.discoverDependencies(opts.paths.app_abs) catch |err| {
-        _ = try emitDiagnostics(&build_env, diag, allocator);
-        diag.step("discoverDependencies", err);
+        if (!try emitDiagnostics(&build_env, diag, allocator)) {
+            diag.step("discoverDependencies", err);
+        }
         return err;
     };
     build_env.compileDiscovered() catch |err| {
-        _ = try emitDiagnostics(&build_env, diag, allocator);
-        diag.step("compileDiscovered", err);
+        if (!try emitDiagnostics(&build_env, diag, allocator)) {
+            diag.step("compileDiscovered", err);
+        }
         return err;
     };
 

--- a/test/echo-wasm-test/main.zig
+++ b/test/echo-wasm-test/main.zig
@@ -254,7 +254,7 @@ pub fn main(init: std.process.Init) anyerror!void {
 
     const malformed_src =
         \\main! = |_| {
-        \\    todo = { nam"Call mom", done: False }
+        \\    todo = { name "Call mom", done: False }
         \\    Ok({})
         \\}
     ;

--- a/test/echo-wasm-test/main.zig
+++ b/test/echo-wasm-test/main.zig
@@ -247,6 +247,29 @@ pub fn main(init: std.process.Init) anyerror!void {
     requireNotContains(bad_stderr, "/app/main.roc", "diagnostic stderr");
     requireNotContains(bad_stderr, "<div", "diagnostic stderr");
     requireNotContains(bad_stderr, "<span", "diagnostic stderr");
+    requireNotContains(bad_stderr, "echo: step", "diagnostic stderr");
+
+    resetCapturedOutput();
+    try invokeInit(module_instance, init_handle);
+
+    const malformed_src =
+        \\main! = |_| {
+        \\    todo = { nam"Call mom", done: False }
+        \\    Ok({})
+        \\}
+    ;
+    const malformed_exit_code = try compileAndRunSource(module_instance, alloc_handle, run_handle, malformed_src);
+    const malformed_stderr = capture_ctx.stderr.items;
+
+    if (malformed_exit_code != 255) {
+        std.debug.print("FAIL: malformed source returned exit code {d}\n", .{malformed_exit_code});
+        std.debug.print("stderr:\n{s}\n", .{malformed_stderr});
+        std.process.exit(1);
+    }
+
+    requireContains(malformed_stderr, "SYNTAX", "syntax diagnostic stderr");
+    requireContains(malformed_stderr, "main.roc", "syntax diagnostic stderr");
+    requireNotContains(malformed_stderr, "echo: step", "syntax diagnostic stderr");
 
     std.debug.print("PASS: echo.wasm tutorial and diagnostic cases produced expected output.\n", .{});
 }


### PR DESCRIPTION
Avoid appending an internal echo pipeline step failure after the compiler has already emitted a blocking user-facing diagnostic. Generic step failures remain visible when no compiler report explains the failure.