### PR TITLE
Improve docs rendering of type signatures and doc refs

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4452,8 +4452,8 @@ Builtin :: [].{
 			shifts : U8,
 		}
 
-		## Returns `Bool.True` if the two dictionaries contain the same key-value
-		## pairs, and `Bool.False` otherwise.
+		## Returns [True] if the two dictionaries contain the same key-value
+		## pairs, and [False] otherwise.
 		is_eq : Dict(k, v), Dict(k, v) -> Bool
 			where [
 				k.is_eq : k, k -> Bool,

--- a/src/docs/DocModel.zig
+++ b/src/docs/DocModel.zig
@@ -384,6 +384,12 @@ const ModuleDocRefResolver = struct {
             return .{ .builtin_type = try gpa.dupe(u8, label) };
         }
 
+        // A handful of builtin tag names have no doc entry of their own, so
+        // resolve them via their owning nominal type's page instead.
+        if (builtinTagOwner(label)) |owner| {
+            return self.resolveLabel(gpa, owner);
+        }
+
         return .{ .unresolved_anchor = try unresolvedAnchor(gpa, self.module.name, label) };
     }
 
@@ -541,6 +547,19 @@ fn isBuiltinDocTypeName(name: []const u8) bool {
         if (std.mem.eql(u8, name, builtin)) return true;
     }
     return false;
+}
+
+/// Maps the well-known builtin tag names that lack their own doc entry to the
+/// nominal type that owns them, so a bare `[True]`/`[Ok]`/etc. reference can be
+/// resolved through that type's docs. Returns null for any other label.
+fn builtinTagOwner(label: []const u8) ?[]const u8 {
+    if (std.mem.eql(u8, label, "True") or std.mem.eql(u8, label, "False")) {
+        return "Bool";
+    }
+    if (std.mem.eql(u8, label, "Ok") or std.mem.eql(u8, label, "Err")) {
+        return "Try";
+    }
+    return null;
 }
 
 /// Short (final dotted segment) of a possibly-qualified name.
@@ -1390,4 +1409,132 @@ fn writeEscaped(writer: anytype, s: []const u8) (Allocator.Error || error{WriteF
             else => try writer.writeAll(&[_]u8{c}),
         }
     }
+}
+
+test "doc shorthand tag refs resolve to owning builtin types in package docs" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    // A third-party package with no `Bool`/`Try` modules of its own: `[True]`
+    // and `[Ok]` should resolve through their owning nominal type to the
+    // published builtin docs (`Bool` / `Try`) rather than staying unresolved.
+    const entry = DocEntry{
+        .name = try gpa.dupe(u8, "any_thing"),
+        .kind = .value,
+        .type_signature = null,
+        .doc_comment = try gpa.dupe(u8, "Returns [True] on success and [Ok] otherwise."),
+        .children = try gpa.alloc(DocEntry, 0),
+        .doc_comment_start_line = 1,
+    };
+
+    const entries = try gpa.alloc(DocEntry, 1);
+    entries[0] = entry;
+
+    var module = ModuleDocs{
+        .name = try gpa.dupe(u8, "Thing"),
+        .package_name = try gpa.dupe(u8, "roc-thing"),
+        .kind = .type_module,
+        .module_doc = null,
+        .entries = entries,
+        .source_path = try gpa.dupe(u8, "/fake/roc-thing/package/Thing.roc"),
+    };
+    defer module.deinit(gpa);
+
+    const modules = try gpa.alloc(ModuleDocs, 1);
+    modules[0] = module;
+    defer gpa.free(modules);
+
+    var package_docs = PackageDocs{
+        .name = try gpa.dupe(u8, "roc-thing"),
+        .modules = modules,
+    };
+    defer gpa.free(package_docs.name);
+
+    try package_docs.resolveDocRefs(gpa);
+
+    const refs = package_docs.modules[0].entries[0].doc_refs;
+    try testing.expectEqual(@as(usize, 2), refs.len);
+
+    try testing.expectEqualStrings("True", refs[0].label);
+    try testing.expect(refs[0].target == .builtin_type);
+    try testing.expectEqualStrings("Bool", refs[0].target.builtin_type);
+
+    try testing.expectEqualStrings("Ok", refs[1].label);
+    try testing.expect(refs[1].target == .builtin_type);
+    try testing.expectEqualStrings("Try", refs[1].target.builtin_type);
+}
+
+test "doc shorthand tag refs resolve to owning type module pages when present" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    // When the package itself publishes the owning type as a module (as the
+    // builtin docs do after `Bool`/`Try` are promoted), `[True]`/`[Ok]` should
+    // resolve to those module pages.
+    const referring_entry = DocEntry{
+        .name = try gpa.dupe(u8, "helper"),
+        .kind = .value,
+        .type_signature = null,
+        .doc_comment = try gpa.dupe(u8, "Uses [True] and [Ok]."),
+        .children = try gpa.alloc(DocEntry, 0),
+        .doc_comment_start_line = 1,
+    };
+
+    const thing_entries = try gpa.alloc(DocEntry, 1);
+    thing_entries[0] = referring_entry;
+
+    var thing_module = ModuleDocs{
+        .name = try gpa.dupe(u8, "Thing"),
+        .package_name = try gpa.dupe(u8, "roc-thing"),
+        .kind = .type_module,
+        .module_doc = null,
+        .entries = thing_entries,
+        .source_path = try gpa.dupe(u8, "/fake/roc-thing/package/Thing.roc"),
+    };
+
+    var bool_module = ModuleDocs{
+        .name = try gpa.dupe(u8, "Bool"),
+        .package_name = try gpa.dupe(u8, "roc-thing"),
+        .kind = .type_module,
+        .module_doc = null,
+        .entries = try gpa.alloc(DocEntry, 0),
+        .source_path = try gpa.dupe(u8, "/fake/roc-thing/package/Bool.roc"),
+    };
+
+    var try_module = ModuleDocs{
+        .name = try gpa.dupe(u8, "Try"),
+        .package_name = try gpa.dupe(u8, "roc-thing"),
+        .kind = .type_module,
+        .module_doc = null,
+        .entries = try gpa.alloc(DocEntry, 0),
+        .source_path = try gpa.dupe(u8, "/fake/roc-thing/package/Try.roc"),
+    };
+
+    const modules = try gpa.alloc(ModuleDocs, 3);
+    modules[0] = thing_module;
+    modules[1] = bool_module;
+    modules[2] = try_module;
+    defer {
+        thing_module.deinit(gpa);
+        bool_module.deinit(gpa);
+        try_module.deinit(gpa);
+        gpa.free(modules);
+    }
+
+    var package_docs = PackageDocs{
+        .name = try gpa.dupe(u8, "roc-thing"),
+        .modules = modules,
+    };
+    defer gpa.free(package_docs.name);
+
+    try package_docs.resolveDocRefs(gpa);
+
+    const refs = package_docs.modules[0].entries[0].doc_refs;
+    try testing.expectEqual(@as(usize, 2), refs.len);
+
+    try testing.expect(refs[0].target == .module_page);
+    try testing.expectEqualStrings("Bool", refs[0].target.module_page);
+
+    try testing.expect(refs[1].target == .module_page);
+    try testing.expectEqualStrings("Try", refs[1].target.module_page);
 }

--- a/src/docs/render_html.zig
+++ b/src/docs/render_html.zig
@@ -138,6 +138,10 @@ const RenderContext = struct {
     /// When true, renderDocTypeHtml emits plain <span> instead of <a> for type
     /// references. Used inside search entries to avoid invalid nested <a> tags.
     suppress_type_links: bool = false,
+    /// When true, where clauses render on a single line instead of the
+    /// multi-line layout. Used inside inline search entries, which must stay on
+    /// one line.
+    single_line_signatures: bool = false,
     /// True when the package being documented is Builtin itself, so references
     /// to builtin types stay local instead of pointing at roc-lang.org.
     documenting_builtin: bool = false,
@@ -1486,6 +1490,7 @@ fn renderSearchTree(
             // nested <a> tags (the entire entry is already wrapped in <a>).
             var no_links_ctx = ctx.*;
             no_links_ctx.suppress_type_links = true;
+            no_links_ctx.single_line_signatures = true;
             const sig_ctx: *const RenderContext = &no_links_ctx;
 
             try w.writeAll(" <span class=\"type-ahead-signature\">");
@@ -1706,9 +1711,9 @@ fn writeDocText(w: Writer, ctx: *const RenderContext, text: []const u8) (Allocat
                 } else {
                     try writeMissingDocRefHref(w, ctx, ref.label, bracket_offset);
                 }
-                try w.writeAll("\">");
+                try w.writeAll("\"><code>");
                 try writeHtmlEscaped(w, ref.label);
-                try w.writeAll("</a>");
+                try w.writeAll("</code></a>");
                 i = ref.end;
                 plain_start = i;
             } else {
@@ -1998,21 +2003,46 @@ fn renderDocTypeHtml(
                         try frames.append(gpa, .{ .doc_type = .{ .value = app.constructor, .needs_parens = false } });
                     },
                     .where_clause => |wc| {
-                        try frames.append(gpa, .{ .html = " }" });
-                        var i = wc.constraints.len;
-                        while (i > 0) {
-                            i -= 1;
-                            const constraint = wc.constraints[i];
-                            try frames.append(gpa, .{ .doc_type = .{ .value = constraint.signature, .needs_parens = false } });
-                            try frames.append(gpa, .{ .html = " : " });
-                            try frames.append(gpa, .{ .escaped = constraint.method_name });
-                            try frames.append(gpa, .{ .html = "</span>." });
-                            try frames.append(gpa, .{ .escaped = constraint.type_var });
-                            try frames.append(gpa, .{ .html = "<span class=\"type-var\">" });
-                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                        if (ctx.single_line_signatures) {
+                            // Inline layout keeps the whole where clause on one
+                            // line, matching the nowrap search entries.
+                            try frames.append(gpa, .{ .html = "]" });
+                            var i = wc.constraints.len;
+                            while (i > 0) {
+                                i -= 1;
+                                const constraint = wc.constraints[i];
+                                try frames.append(gpa, .{ .doc_type = .{ .value = constraint.signature, .needs_parens = false } });
+                                try frames.append(gpa, .{ .html = " : " });
+                                try frames.append(gpa, .{ .escaped = constraint.method_name });
+                                try frames.append(gpa, .{ .html = "</span>." });
+                                try frames.append(gpa, .{ .escaped = constraint.type_var });
+                                try frames.append(gpa, .{ .html = "<span class=\"type-var\">" });
+                                if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                            }
+                            try frames.append(gpa, .{ .html = " <span class=\"kw\">where</span> [" });
+                            try frames.append(gpa, .{ .doc_type = .{ .value = wc.type, .needs_parens = item.needs_parens } });
+                        } else {
+                            // Multi-line layout mirrors how `roc format` lays
+                            // out where clauses; the enclosing block uses
+                            // white-space: pre-wrap so the literal newlines and
+                            // indentation render as written.
+                            try frames.append(gpa, .{ .html = "    ]" });
+                            var i = wc.constraints.len;
+                            while (i > 0) {
+                                i -= 1;
+                                const constraint = wc.constraints[i];
+                                try frames.append(gpa, .{ .html = ",\n" });
+                                try frames.append(gpa, .{ .doc_type = .{ .value = constraint.signature, .needs_parens = false } });
+                                try frames.append(gpa, .{ .html = " : " });
+                                try frames.append(gpa, .{ .escaped = constraint.method_name });
+                                try frames.append(gpa, .{ .html = "</span>." });
+                                try frames.append(gpa, .{ .escaped = constraint.type_var });
+                                try frames.append(gpa, .{ .html = "<span class=\"type-var\">" });
+                                try frames.append(gpa, .{ .html = "        " });
+                            }
+                            try frames.append(gpa, .{ .html = "\n    <span class=\"kw\">where</span> [\n" });
+                            try frames.append(gpa, .{ .doc_type = .{ .value = wc.type, .needs_parens = item.needs_parens } });
                         }
-                        try frames.append(gpa, .{ .html = " <span class=\"kw\">where</span> { " });
-                        try frames.append(gpa, .{ .doc_type = .{ .value = wc.type, .needs_parens = item.needs_parens } });
                     },
                     .wildcard => {
                         try frames.append(gpa, .{ .html = "_" });
@@ -2358,6 +2388,108 @@ test "doc shorthand refs in package docs resolve builtins and nested type-module
 
     try testing.expect(std.mem.find(u8, html, "href=\"https://roc-lang.org/builtins/main/Str\"") != null);
     try testing.expect(std.mem.find(u8, html, "href=\"#String.Utf8\"") != null);
+
+    // Shorthand `[Name]` refs wrap their label in <code>.
+    try testing.expect(std.mem.find(u8, html, "href=\"https://roc-lang.org/builtins/main/Str\"><code>Str</code></a>") != null);
+    try testing.expect(std.mem.find(u8, html, "href=\"#String.Utf8\"><code>Utf8</code></a>") != null);
+}
+
+test "renderDocTypeHtml renders where clause multi-line with square brackets" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    const root = try buildWhereClauseFixture(gpa);
+    defer {
+        root.deinit(gpa);
+        gpa.destroy(root);
+    }
+
+    const package_docs = DocModel.PackageDocs{
+        .name = "Test",
+        .modules = &[_]DocModel.ModuleDocs{},
+    };
+    var ctx = try RenderContext.init(&package_docs, gpa);
+    defer ctx.deinit(gpa);
+    ctx.suppress_type_links = true;
+
+    var output: std.Io.Writer.Allocating = .init(gpa);
+    defer output.deinit();
+
+    try renderDocTypeHtml(&output.writer, &ctx, gpa, root, false);
+    try testing.expectEqualStrings(
+        "<span class=\"type\">Bool</span>\n" ++
+            "    <span class=\"kw\">where</span> [\n" ++
+            "        <span class=\"type-var\">k</span>.is_eq : <span class=\"type-var\">k</span>,\n" ++
+            "        <span class=\"type-var\">v</span>.to_hash : <span class=\"type-var\">v</span>,\n" ++
+            "    ]",
+        output.written(),
+    );
+}
+
+test "renderDocTypeHtml renders where clause single-line when single_line_signatures set" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    const root = try buildWhereClauseFixture(gpa);
+    defer {
+        root.deinit(gpa);
+        gpa.destroy(root);
+    }
+
+    const package_docs = DocModel.PackageDocs{
+        .name = "Test",
+        .modules = &[_]DocModel.ModuleDocs{},
+    };
+    var ctx = try RenderContext.init(&package_docs, gpa);
+    defer ctx.deinit(gpa);
+    ctx.suppress_type_links = true;
+    ctx.single_line_signatures = true;
+
+    var output: std.Io.Writer.Allocating = .init(gpa);
+    defer output.deinit();
+
+    try renderDocTypeHtml(&output.writer, &ctx, gpa, root, false);
+    try testing.expectEqualStrings(
+        "<span class=\"type\">Bool</span> <span class=\"kw\">where</span> [" ++
+            "<span class=\"type-var\">k</span>.is_eq : <span class=\"type-var\">k</span>, " ++
+            "<span class=\"type-var\">v</span>.to_hash : <span class=\"type-var\">v</span>]",
+        output.written(),
+    );
+}
+
+/// Builds a heap-allocated `where` clause DocType for the rendering tests:
+/// `Bool where [ k.is_eq : k, v.to_hash : v ]`.
+fn buildWhereClauseFixture(gpa: Allocator) Allocator.Error!*const DocType {
+    const bool_type = try gpa.create(DocType);
+    bool_type.* = .{ .type_ref = .{
+        .module_path = try gpa.dupe(u8, ""),
+        .type_name = try gpa.dupe(u8, "Bool"),
+    } };
+
+    const k_sig = try gpa.create(DocType);
+    k_sig.* = .{ .type_var = try gpa.dupe(u8, "k") };
+
+    const v_sig = try gpa.create(DocType);
+    v_sig.* = .{ .type_var = try gpa.dupe(u8, "v") };
+
+    const constraints = try gpa.alloc(DocType.Constraint, 2);
+    constraints[0] = .{
+        .type_var = try gpa.dupe(u8, "k"),
+        .method_name = try gpa.dupe(u8, "is_eq"),
+        .signature = k_sig,
+    };
+    constraints[1] = .{
+        .type_var = try gpa.dupe(u8, "v"),
+        .method_name = try gpa.dupe(u8, "to_hash"),
+        .signature = v_sig,
+    };
+
+    const root = try gpa.create(DocType);
+    root.* = .{ .where_clause = .{
+        .type = bool_type,
+        .constraints = constraints,
+    } };
+    return root;
 }
 
 test "builtin_nested_type_owners lists every numeric type under Num" {


### PR DESCRIPTION
Generated docs previously rendered type signatures as a single line, which made signatures with where clauses (like Dict.is_eq) nearly unreadable, and the where clause was rendered with outdated brace syntax (`where { ... }` instead of `where [ ... ]`). Signatures now render multi-line with the same layout `roc format` produces in source: the where clause on its own indented line, one constraint per line with trailing commas. The inline signatures in search type-ahead entries keep a single-line rendering (with the corrected bracket syntax) since they must stay on one line.

This also makes bare `[True]`, `[False]`, `[Ok]`, and `[Err]` doc refs resolve to their owning `Bool` and `Try` types instead of producing broken links — these four tag names are hardcoded, and the check runs after all other resolution steps so a package defining its own entry with one of those names still wins. Finally, shorthand doc refs like `[Dict]` now emit `<code>` inside the generated `<a>` tag so the link text renders as code.