### PR TITLE
Single-source hand-mirrored ABI and layout facts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5721,6 +5721,7 @@ fn addMainExe(
                     .single_threaded = true,
                 }),
             });
+            default_platform_runtime_obj.root_module.addImport("roc_str_view", roc_modules.roc_str_view);
             default_platform_runtime_obj.root_module.stack_check = false;
             default_platform_runtime_obj.root_module.link_libc = false;
             default_platform_runtime_obj.bundle_compiler_rt = false;

--- a/src/backend/dev/RunImage.zig
+++ b/src/backend/dev/RunImage.zig
@@ -18,7 +18,9 @@ pub const MAGIC: u32 = 0x56454452;
 /// Version of the shared-memory dev run image format.
 pub const FORMAT_VERSION: u32 = 2;
 
-/// Maximum bytes needed for one host jump stub on the supported dev-shim hosts.
+/// Maximum bytes reserved per host jump stub on the supported dev-shim hosts.
+/// The machine-code shim owns the per-arch emitted sizes and asserts at compile
+/// time that each fits within this reservation (see `machine_code_shim/main.zig`).
 pub const max_jump_stub_size = 20;
 
 /// Errors raised when a mapped dev run image is malformed or unsupported.

--- a/src/backend/llvm/layout_types.zig
+++ b/src/backend/llvm/layout_types.zig
@@ -12,6 +12,7 @@
 //! - ZST (zero-sized types) → void/i1 placeholder
 
 const std = @import("std");
+const builtins = @import("builtins");
 const Builder = @import("vendor_llvm_ir").Builder;
 const layout = @import("../../layout/mod.zig");
 const types = @import("../../types/types.zig");
@@ -132,18 +133,33 @@ fn fracPrecisionToLlvmType(precision: types.Frac.Precision) Builder.Type {
     };
 }
 
-/// Get the LLVM type for a Roc List (3-element struct: ptr, len, capacity)
+/// Get the LLVM type for a Roc List: a pointer word followed by length and
+/// encoded-capacity words. The field count comes from the canonical `RocList`
+/// definition in `builtins/list.zig` (`word_count`). This LLVM backend targets
+/// 64-bit only, so each non-pointer word is an `i64`.
 fn listLlvmType(builder: *Builder) Error!Builder.Type {
-    // List layout: { ptr: *T, len: u64, capacity: u64 }
-    const fields = [_]Builder.Type{ .ptr, .i64, .i64 };
-    return builder.structType(.normal, &fields) catch return error.OutOfMemory;
+    return rocHeaderLlvmType(builder, builtins.list.RocList);
 }
 
-/// Get the LLVM type for a Roc Str (3-element struct: ptr, encoded capacity, len)
-/// Note: Str also has seamless small string optimization, but the LLVM type
-/// is the same (the SSO is handled at runtime)
+/// Get the LLVM type for a Roc Str: a pointer word followed by encoded-capacity
+/// and length words. The field count comes from the canonical `RocStr`
+/// definition in `builtins/str.zig` (`word_count`). Str also uses the seamless
+/// small-string optimization, but the LLVM type is the same (the SSO is handled
+/// at runtime). This LLVM backend targets 64-bit only, so each non-pointer word
+/// is an `i64`.
 pub fn strLlvmType(builder: *Builder) Error!Builder.Type {
-    const fields = [_]Builder.Type{ .ptr, .i64, .i64 };
+    return rocHeaderLlvmType(builder, builtins.str.RocStr);
+}
+
+/// Build the LLVM struct type for a `word_count`-word Roc header (RocStr or
+/// RocList): the first word is the byte pointer, the remaining words are
+/// integer words. The word count is derived from the canonical builtin struct,
+/// and the comptime assertion ties that count to the struct's host-width size.
+fn rocHeaderLlvmType(builder: *Builder, comptime RocHeader: type) Error!Builder.Type {
+    comptime std.debug.assert(RocHeader.word_count * @sizeOf(usize) == @sizeOf(RocHeader));
+    var fields: [RocHeader.word_count]Builder.Type = undefined;
+    fields[0] = .ptr;
+    for (fields[1..]) |*field| field.* = .i64;
     return builder.structType(.normal, &fields) catch return error.OutOfMemory;
 }
 

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -9303,8 +9303,8 @@ fn layoutStorageByteAlign(self: *const Self, layout_idx: layout.Idx) Allocator.E
             },
         },
         .list, .list_of_zst, .box, .box_of_zst => 4,
-        .tag_union => (try WasmLayout.tagUnionLayoutWithStore(l.getTagUnion().idx, ls)).alignment,
-        .struct_ => try WasmLayout.structAlignWithStore(l.getStruct().idx, ls),
+        .tag_union => WasmLayout.layoutAlignWasm(l),
+        .struct_ => WasmLayout.layoutAlignWasm(l),
         else => try self.layoutByteAlign(layout_idx),
     };
 }
@@ -9609,7 +9609,7 @@ fn generateStruct(self: *Self, r: anytype) Allocator.Error!void {
         return;
     }
 
-    const align_val: u32 = try WasmLayout.structAlignWithStore(l.getStruct().idx, ls);
+    const align_val: u32 = WasmLayout.layoutAlignWasm(l);
 
     const frame_offset = try self.allocStackMemory(size, align_val);
 
@@ -9815,7 +9815,7 @@ fn generateTag(self: *Self, t: anytype) Allocator.Error!void {
         return;
     }
 
-    const align_val: u32 = tu_layout.alignment;
+    const align_val: u32 = WasmLayout.layoutAlignWasm(l);
     const frame_offset = try self.allocStackMemory(tu_size, align_val);
 
     const base_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;

--- a/src/backend/wasm/WasmLayout.zig
+++ b/src/backend/wasm/WasmLayout.zig
@@ -4,17 +4,23 @@
 //! - Primitives that fit in a wasm value type are returned directly
 //! - Composites (i128, Dec, Str, List, records) use linear memory
 //!
-//! Size and alignment of composite layouts are computed iteratively (via
-//! `wasmSizeAlign`) using an explicit work stack, so deeply nested types never
-//! grow the native call stack.
+//! This module only performs the wasm-specific classification (which layouts map
+//! to a wasm value type versus linear memory). Every concrete size, offset,
+//! alignment, and discriminant width is read from `layout.Store` at the wasm32
+//! pointer width (`.u32`), which is the single source of truth shared with the
+//! dev and LLVM backends.
 
-const std = @import("std");
+const base = @import("base");
 const layout = @import("layout");
 const WasmModule = @import("WasmModule.zig");
 const ValType = WasmModule.ValType;
 
-/// Errors returned while computing wasm layout sizes (only out-of-memory, when
-/// an unusually deep type spills the inline work-stack buffer onto the heap).
+/// The pointer width wasm codegen targets. wasm32 uses 32-bit pointers, so every
+/// store query in this module is made at this width.
+const wasm_target: base.target.TargetUsize = .u32;
+
+/// Error set for the fallible wasm layout query API, keeping these queries
+/// uniform with the rest of wasm codegen's fallible layout accessors.
 pub const Error = error{OutOfMemory};
 
 /// How a Roc value is represented in wasm
@@ -23,12 +29,6 @@ pub const WasmRepr = union(enum) {
     primitive: ValType,
     /// Value lives in linear memory (returned as i32 pointer)
     stack_memory: u32, // size in bytes
-};
-
-/// Size and alignment of a layout in wasm linear memory (bytes).
-const SizeAlign = struct {
-    size: u32,
-    alignment: u32,
 };
 
 /// Map a layout.Idx to its wasm representation.
@@ -79,7 +79,7 @@ pub fn wasmReprWithStore(layout_idx: layout.Idx, ls: *const layout.Store) Error!
                 }
                 const repr: WasmRepr = switch (l.tag) {
                     .scalar => .{ .primitive = scalarValType(l) },
-                    .struct_ => .{ .stack_memory = try structSizeWasm(ls, l.getStruct().idx) },
+                    .struct_ => .{ .stack_memory = ls.sizeAt(l, wasm_target) },
                     .tag_union => blk: {
                         const tu_layout = try tagUnionLayoutWithStore(l.getTagUnion().idx, ls);
                         // Discriminant-only tag unions (enums, disc_offset == 0) with size ≤ 4
@@ -91,7 +91,7 @@ pub fn wasmReprWithStore(layout_idx: layout.Idx, ls: *const layout.Store) Error!
                     },
                     .zst => .{ .primitive = .i32 }, // zero-sized, dummy i32
                     .box, .box_of_zst, .erased_callable, .ptr => .{ .primitive = .i32 }, // pointer
-                    .list, .list_of_zst => .{ .stack_memory = 12 }, // RocList
+                    .list, .list_of_zst => .{ .stack_memory = ls.sizeAt(l, wasm_target) }, // RocList
                     .closure => unreachable, // handled above
                 };
                 if (outer_closure) |outer| {
@@ -106,208 +106,30 @@ pub fn wasmReprWithStore(layout_idx: layout.Idx, ls: *const layout.Store) Error!
     }
 }
 
-/// Public struct `TagUnionWasmLayout`.
+/// wasm-level size, discriminant offset, and discriminant width of a tag union,
+/// all read from the layout store at the wasm32 pointer width.
 pub const TagUnionWasmLayout = struct {
     size: u32,
     discriminant_offset: u32,
     discriminant_size: u8,
-    alignment: u32,
 };
 
-/// Public function `structSizeWithStore`.
+/// wasm32 byte size of a struct, read from the layout store's committed size.
 pub fn structSizeWithStore(struct_idx: layout.StructIdx, ls: *const layout.Store) Error!u32 {
-    return structSizeWasm(ls, struct_idx);
+    return ls.getStructSizeAt(struct_idx, wasm_target);
 }
 
-/// Public function `structAlignWithStore`.
-pub fn structAlignWithStore(struct_idx: layout.StructIdx, ls: *const layout.Store) Error!u32 {
-    return structAlignWasm(ls, struct_idx);
+/// wasm32 byte alignment of a layout, read from its committed alignment class.
+pub fn layoutAlignWasm(l: layout.Layout) u32 {
+    return @intCast(l.alignment(wasm_target).toByteUnits());
 }
 
-/// Public function `tagUnionLayoutWithStore`.
+/// wasm32 size/discriminant metrics of a tag union, all read from the store.
 pub fn tagUnionLayoutWithStore(tu_idx: layout.TagUnionIdx, ls: *const layout.Store) Error!TagUnionWasmLayout {
-    const tu_data = ls.getTagUnionData(tu_idx);
-    const variants = ls.getTagUnionVariants(tu_data);
-
-    var max_payload_size: u32 = 0;
-    var max_payload_align: u32 = 1;
-    for (0..variants.len) |i| {
-        const payload_layout = variants.get(i).payload_layout;
-        const payload = try wasmSizeAlign(payload_layout, ls);
-        if (payload.size > max_payload_size) max_payload_size = payload.size;
-        if (payload.alignment > max_payload_align) max_payload_align = payload.alignment;
-    }
-
-    const discriminant_size: u8 = layout.TagUnionData.discriminantSize(variants.len);
-    const disc_align = layout.TagUnionData.alignmentForDiscriminantSize(discriminant_size);
-    const disc_align_bytes: u32 = @intCast(disc_align.toByteUnits());
-    const discriminant_offset: u32 = alignUp(max_payload_size, disc_align_bytes);
-    const tag_union_alignment: u32 = if (max_payload_align > disc_align_bytes) max_payload_align else disc_align_bytes;
-    const total_size: u32 = alignUp(discriminant_offset + discriminant_size, tag_union_alignment);
-
     return .{
-        .size = total_size,
-        .discriminant_offset = discriminant_offset,
-        .discriminant_size = discriminant_size,
-        .alignment = tag_union_alignment,
-    };
-}
-
-fn structAlignWasm(ls: *const layout.Store, struct_idx: layout.StructIdx) Error!u32 {
-    const sd = ls.getStructData(struct_idx);
-    const sorted_fields = ls.struct_fields.sliceRange(sd.getFields());
-    var max_align: u32 = 1;
-    for (0..sorted_fields.len) |i| {
-        const field = sorted_fields.get(i);
-        // Padding spacers are alignment 1 and never inflate the struct's alignment.
-        if (field.is_padding) continue;
-        const field_align = (try wasmSizeAlign(field.layout, ls)).alignment;
-        if (field_align > max_align) max_align = field_align;
-    }
-    return max_align;
-}
-
-fn structSizeWasm(ls: *const layout.Store, struct_idx: layout.StructIdx) Error!u32 {
-    const sd = ls.getStructData(struct_idx);
-    const sorted_fields = ls.struct_fields.sliceRange(sd.getFields());
-    var offset: u32 = 0;
-    var max_align: u32 = 1;
-    for (0..sorted_fields.len) |i| {
-        const field = sorted_fields.get(i);
-        const field_sa = try wasmSizeAlign(field.layout, ls);
-        // Padding spacers are alignment 1 (their value layout's alignment is ignored).
-        const field_align: u32 = if (field.is_padding) 1 else field_sa.alignment;
-        if (field_align > max_align) max_align = field_align;
-        offset = alignUp(offset, field_align);
-        offset += field_sa.size;
-    }
-    return alignUp(offset, max_align);
-}
-
-/// Compute the wasm linear-memory size and alignment of a layout. Walks nested
-/// records/tag-union payloads/closures with an explicit work stack (post-order)
-/// instead of recursion. Boxes are pointers, which is where recursive types
-/// bottom out, so the traversal always terminates.
-fn wasmSizeAlign(root_idx: layout.Idx, ls: *const layout.Store) Error!SizeAlign {
-    const Item = union(enum) {
-        enter: layout.Idx,
-        combine_struct: layout.StructIdx,
-        combine_tag: u32,
-    };
-
-    var work_sfa = std.heap.stackFallback(64 * @sizeOf(Item), ls.allocator);
-    const wa = work_sfa.get();
-    var work = std.ArrayList(Item).empty;
-    defer work.deinit(wa);
-
-    var res_sfa = std.heap.stackFallback(64 * @sizeOf(SizeAlign), ls.allocator);
-    const ra = res_sfa.get();
-    var results = std.ArrayList(SizeAlign).empty;
-    defer results.deinit(ra);
-
-    try work.append(wa, .{ .enter = root_idx });
-    while (work.pop()) |item| switch (item) {
-        .enter => |idx| {
-            const l = ls.getLayout(idx);
-            switch (l.tag) {
-                .zst => try results.append(ra, .{ .size = 0, .alignment = 1 }),
-                .scalar => try results.append(ra, scalarSizeAlign(l)),
-                .list, .list_of_zst => try results.append(ra, .{ .size = 12, .alignment = 4 }),
-                .box, .box_of_zst, .erased_callable, .ptr => try results.append(ra, .{ .size = 4, .alignment = 4 }),
-                .closure => {
-                    const sa = ls.layoutSizeAlign(l);
-                    try results.append(ra, .{ .size = sa.size, .alignment = @intCast(sa.alignment.toByteUnits()) });
-                },
-                .struct_ => {
-                    const sd = ls.getStructData(l.getStruct().idx);
-                    const fields = ls.struct_fields.sliceRange(sd.getFields());
-                    try work.append(wa, .{ .combine_struct = l.getStruct().idx });
-                    var i: usize = fields.len;
-                    while (i > 0) {
-                        i -= 1;
-                        try work.append(wa, .{ .enter = fields.get(i).layout });
-                    }
-                },
-                .tag_union => {
-                    const tu_data = ls.getTagUnionData(l.getTagUnion().idx);
-                    const variants = ls.getTagUnionVariants(tu_data);
-                    try work.append(wa, .{ .combine_tag = @intCast(variants.len) });
-                    var i: usize = variants.len;
-                    while (i > 0) {
-                        i -= 1;
-                        try work.append(wa, .{ .enter = variants.get(i).payload_layout });
-                    }
-                },
-            }
-        },
-        .combine_struct => |struct_idx| {
-            const sd = ls.getStructData(struct_idx);
-            const fields = ls.struct_fields.sliceRange(sd.getFields());
-            const field_count: u32 = @intCast(fields.len);
-            const base = results.items.len - field_count;
-            var offset: u32 = 0;
-            var max_align: u32 = 1;
-            for (results.items[base..], 0..) |field_sa, fi| {
-                // Padding spacers are alignment 1 and never inflate the struct's alignment.
-                const field_align: u32 = if (fields.get(fi).is_padding) 1 else field_sa.alignment;
-                if (field_align > max_align) max_align = field_align;
-                offset = alignUp(offset, field_align);
-                offset += field_sa.size;
-            }
-            const size = alignUp(offset, max_align);
-            results.shrinkRetainingCapacity(base);
-            try results.append(ra, .{ .size = size, .alignment = max_align });
-        },
-        .combine_tag => |variant_count| {
-            const base = results.items.len - variant_count;
-            var max_payload_size: u32 = 0;
-            var max_payload_align: u32 = 1;
-            for (results.items[base..]) |payload| {
-                if (payload.size > max_payload_size) max_payload_size = payload.size;
-                if (payload.alignment > max_payload_align) max_payload_align = payload.alignment;
-            }
-            const discriminant_size: u8 = layout.TagUnionData.discriminantSize(variant_count);
-            const disc_align = layout.TagUnionData.alignmentForDiscriminantSize(discriminant_size);
-            const disc_align_bytes: u32 = @intCast(disc_align.toByteUnits());
-            const discriminant_offset: u32 = alignUp(max_payload_size, disc_align_bytes);
-            const tag_union_alignment: u32 = if (max_payload_align > disc_align_bytes) max_payload_align else disc_align_bytes;
-            const total_size: u32 = alignUp(discriminant_offset + discriminant_size, tag_union_alignment);
-            results.shrinkRetainingCapacity(base);
-            try results.append(ra, .{ .size = total_size, .alignment = tag_union_alignment });
-        },
-    };
-
-    return results.items[0];
-}
-
-fn alignUp(value: u32, alignment: u32) u32 {
-    if (alignment <= 1) return value;
-    return (value + alignment - 1) & ~(alignment - 1);
-}
-
-/// Extract the wasm linear-memory size and alignment of a scalar Layout.
-fn scalarSizeAlign(l: layout.Layout) SizeAlign {
-    return switch (l.getScalar().tag) {
-        .str => .{ .size = 12, .alignment = 4 },
-        .opaque_ptr => .{ .size = 4, .alignment = 4 },
-        .int => .{
-            .size = switch (l.getScalar().getInt()) {
-                .u8, .i8 => 1,
-                .u16, .i16 => 2,
-                .u32, .i32 => 4,
-                .u64, .i64 => 8,
-                .u128, .i128 => 16,
-            },
-            .alignment = @intCast(l.getScalar().getInt().alignment().toByteUnits()),
-        },
-        .frac => .{
-            .size = switch (l.getScalar().getFrac()) {
-                .f32 => 4,
-                .f64 => 8,
-                .dec => 16,
-            },
-            .alignment = @intCast(l.getScalar().getFrac().alignment().toByteUnits()),
-        },
+        .size = ls.getTagUnionSizeAt(tu_idx, wasm_target),
+        .discriminant_offset = ls.getTagUnionDiscriminantOffsetAt(tu_idx, wasm_target),
+        .discriminant_size = ls.getTagUnionDiscriminantSize(tu_idx),
     };
 }
 

--- a/src/backend/wasm/builtin_signatures.zig
+++ b/src/backend/wasm/builtin_signatures.zig
@@ -217,13 +217,100 @@ pub fn populateForRelocs(module: *const WasmModule) WasmModule.SymbolLookupError
     return result;
 }
 
+/// The wasm32 `ValType` a single wrapper parameter or return type lowers to.
+///
+/// wasm32 lowering rules (each Zig scalar/pointer maps to exactly one ValType,
+/// because the wrappers already decompose 128-bit values into two `u64`s and pass
+/// `RocStr`/`RocList` by pointer):
+/// - `usize`/`isize` and every pointer are 32-bit on wasm32 → `.i32`
+/// - `bool`, enums, and integers up to 32 bits → `.i32`
+/// - 64-bit integers → `.i64`
+/// - `f32` → `.f32`, `f64` → `.f64`
+///
+/// Any other shape (a by-value aggregate, a >64-bit integer, a non-pointer
+/// optional) is a compile error, so a newly added wrapper cannot silently bypass
+/// verification.
+fn wasmValTypeOf(comptime T: type) ValType {
+    // On wasm32 `usize`/`isize` are 32-bit even though the verifier itself is
+    // compiled for a 64-bit host (`usize` and `u64` are distinct types, so this
+    // check does not also catch genuine `u64` params).
+    if (T == usize or T == isize) return .i32;
+    return switch (@typeInfo(T)) {
+        .bool => .i32,
+        .int => |info| switch (info.bits) {
+            0...32 => .i32,
+            33...64 => .i64,
+            else => @compileError("builtin wrapper integer wider than 64 bits must be decomposed: " ++ @typeName(T)),
+        },
+        .float => |info| switch (info.bits) {
+            32 => .f32,
+            64 => .f64,
+            else => @compileError("unsupported float width in builtin wrapper: " ++ @typeName(T)),
+        },
+        .pointer => .i32, // wasm32 pointer
+        .optional => |o| if (@typeInfo(o.child) == .pointer) .i32 else @compileError("unsupported optional (non-pointer) builtin wrapper type: " ++ @typeName(T)),
+        .@"enum" => |info| wasmValTypeOf(info.tag_type),
+        else => @compileError("unsupported builtin wrapper type: " ++ @typeName(T)),
+    };
+}
+
+// Pin every `sigs` row to the real Zig wrapper signature it names.
+//
+// Each row's `.name` is the pub wrapper function in `builtins.dev_wrappers`; a
+// wrong ValType, arity, result, or `takes_roc_ops` flag is silent stack
+// corruption at runtime, so this comptime block re-derives the whole wasm ABI
+// from `@typeInfo` of the wrapper and asserts it matches the hand-written row.
+//
+// Row-to-wrapper mapping: `@field(dev_wrappers, row.name)`. Every row must
+// resolve to a wrapper — the `@hasDecl` guard makes a missing wrapper a compile
+// error. There is deliberately no exceptions list: all rows map to a wrapper,
+// and if that ever stops holding the guard fails loudly rather than skipping.
 comptime {
+    @setEvalBranchQuota(100_000);
     const dw = @import("builtins").dev_wrappers;
+    const RocOps = @import("builtins").host_abi.RocOps;
     for (sigs) |sig| {
         if (!@hasDecl(dw, sig.name)) @compileError("missing dev wrapper: " ++ sig.name);
-        const wrapper_type = @typeInfo(@TypeOf(@field(dw, sig.name))).@"fn";
-        if (wrapper_type.params.len != sig.wasm_params.len) {
-            @compileError("builtin arity mismatch: " ++ sig.name);
+        const fn_info = @typeInfo(@TypeOf(@field(dw, sig.name))).@"fn";
+
+        if (fn_info.params.len != sig.wasm_params.len) {
+            @compileError("builtin ABI mismatch (" ++ sig.name ++ "): wrapper param count differs from wasm_params length");
+        }
+
+        for (fn_info.params, sig.wasm_params, 0..) |param, want, i| {
+            const got = wasmValTypeOf(param.type.?);
+            if (got != want) {
+                @compileError(std.fmt.comptimePrint(
+                    "builtin ABI mismatch ({s}): param {d} wrapper lowers to .{s} but sigs row declares .{s}",
+                    .{ sig.name, i, @tagName(got), @tagName(want) },
+                ));
+            }
+        }
+
+        const ret = fn_info.return_type.?;
+        if (ret == void) {
+            if (sig.wasm_results.len != 0) {
+                @compileError("builtin ABI mismatch (" ++ sig.name ++ "): wrapper returns void but sigs row lists a result");
+            }
+        } else {
+            if (sig.wasm_results.len != 1) {
+                @compileError("builtin ABI mismatch (" ++ sig.name ++ "): wrapper returns a value but sigs row does not list exactly one result");
+            }
+            const got = wasmValTypeOf(ret);
+            if (got != sig.wasm_results[0]) {
+                @compileError(std.fmt.comptimePrint(
+                    "builtin ABI mismatch ({s}): result wrapper returns .{s} but sigs row declares .{s}",
+                    .{ sig.name, @tagName(got), @tagName(sig.wasm_results[0]) },
+                ));
+            }
+        }
+
+        const takes_roc_ops = fn_info.params.len > 0 and blk: {
+            const last = fn_info.params[fn_info.params.len - 1].type.?;
+            break :blk @typeInfo(last) == .pointer and @typeInfo(last).pointer.child == RocOps;
+        };
+        if (takes_roc_ops != sig.takes_roc_ops) {
+            @compileError("builtin ABI mismatch (" ++ sig.name ++ "): takes_roc_ops flag disagrees with trailing *RocOps param");
         }
     }
 }

--- a/src/build/modules.zig
+++ b/src/build/modules.zig
@@ -406,6 +406,13 @@ pub const RocModules = struct {
     glue: *Module,
     embedded_lld: *Module,
 
+    // The default-platform runtimes (`src/default_platform/*_runtime.zig`) are
+    // compiled as standalone freestanding objects without the `builtins` module,
+    // so they read the host-boundary `RocStr` encoding through this single-file
+    // module instead of restating it. It is wired into the `builtins` module too
+    // so a `builtins` test can assert the view matches the canonical `RocStr`.
+    roc_str_view: *Module,
+
     // Vendored-from-Zig modules. Kept out of the `ModuleType` dependency graph
     // (like `embedded_lld`) and wired into their specific consumers via
     // `applyVendorImports`, so it stays clear which code comes from elsewhere.
@@ -462,6 +469,7 @@ pub const RocModules = struct {
             .bump = b.addModule("bump", .{ .root_source_file = b.path("src/bump/mod.zig") }),
             .glue = b.addModule("glue", .{ .root_source_file = b.path("src/glue/mod.zig") }),
             .embedded_lld = b.addModule("embedded_lld", .{ .root_source_file = b.path("src/build/embedded_lld.zig") }),
+            .roc_str_view = b.addModule("roc_str_view", .{ .root_source_file = b.path("src/default_platform/roc_str_view.zig") }),
 
             .vendor_parse_float = b.addModule("vendor_parse_float", .{ .root_source_file = b.path("vendor/parse_float/parse_float.zig") }),
             .vendor_ryu = b.addModule("vendor_ryu", .{ .root_source_file = b.path("vendor/ryu.zig") }),
@@ -570,6 +578,9 @@ pub const RocModules = struct {
             .builtins => {
                 module.addImport("vendor_parse_float", self.vendor_parse_float);
                 module.addImport("vendor_ryu", self.vendor_ryu);
+                // Lets a `builtins` test assert the default-platform `RocStr` view
+                // matches the canonical `RocStr` (see `roc_str_view` above).
+                module.addImport("roc_str_view", self.roc_str_view);
             },
             .eval => {
                 module.addImport("vendor_eval_loader", self.vendor_eval_loader);

--- a/src/builtins/host_abi.zig
+++ b/src/builtins/host_abi.zig
@@ -53,13 +53,19 @@ else
     .vtable;
 
 /// The fixed runtime symbols every host defines under the symbol ABI.
-const extern_host = struct {
-    extern fn roc_alloc(length: usize, alignment: usize) ?*anyopaque;
-    extern fn roc_dealloc(ptr: *anyopaque, alignment: usize) void;
-    extern fn roc_realloc(ptr: *anyopaque, new_length: usize, alignment: usize) ?*anyopaque;
-    extern fn roc_dbg(bytes: [*]const u8, len: usize) void;
-    extern fn roc_expect_failed(bytes: [*]const u8, len: usize) void;
-    extern fn roc_crashed(bytes: [*]const u8, len: usize) void;
+///
+/// These are the same operations as the `RocOps` vtable methods below, but
+/// without the leading `*RocOps` parameter: compiled output resolves them as
+/// linker symbols instead of calling through the vtable. The shim host
+/// (`src/shim_host_abi.zig`) reuses this declaration rather than restating it,
+/// so the extern symbol ABI is written down in exactly one place.
+pub const extern_host = struct {
+    pub extern fn roc_alloc(length: usize, alignment: usize) ?*anyopaque;
+    pub extern fn roc_dealloc(ptr: *anyopaque, alignment: usize) void;
+    pub extern fn roc_realloc(ptr: *anyopaque, new_length: usize, alignment: usize) ?*anyopaque;
+    pub extern fn roc_dbg(bytes: [*]const u8, len: usize) void;
+    pub extern fn roc_expect_failed(bytes: [*]const u8, len: usize) void;
+    pub extern fn roc_crashed(bytes: [*]const u8, len: usize) void;
 };
 
 /// Type-erased pointer to a hosted platform function stored in the

--- a/src/builtins/list.zig
+++ b/src/builtins/list.zig
@@ -32,12 +32,37 @@ pub const RocList = extern struct {
     // This pointer is to the first element of the original list.
     capacity_or_alloc_ptr: usize,
 
+    /// Number of pointer-sized words in a RocList's in-memory layout. The layout
+    /// is target-width parameterized: its byte size is `word_count` times the
+    /// target pointer width. Sites that build a RocList for a target of a
+    /// different width than the host multiply this by the target word size.
+    pub const word_count = 3;
+
+    /// Big-list capacities are stored shifted left by this many bits so the low
+    /// bit stays free for the seamless-slice tag.
+    pub const capacity_shift = 1;
+
+    comptime {
+        std.debug.assert(word_count * @sizeOf(usize) == @sizeOf(RocList));
+    }
+
+    fn encodeCapacityGeneric(comptime T: type, capacity: T) T {
+        return capacity << capacity_shift;
+    }
+
     pub inline fn encodeCapacity(capacity: usize) usize {
-        return capacity << 1;
+        return encodeCapacityGeneric(usize, capacity);
+    }
+
+    /// Encode a big-list capacity for a target whose pointer width may differ
+    /// from the host's. Applies the same shift as the host-width
+    /// `encodeCapacity`, but on a `u64` so it can hold any target word's value.
+    pub fn encodeCapacityForWidth(capacity: u64) u64 {
+        return encodeCapacityGeneric(u64, capacity);
     }
 
     pub inline fn decodeCapacity(encoded_capacity: usize) usize {
-        return encoded_capacity >> 1;
+        return encoded_capacity >> capacity_shift;
     }
 
     pub inline fn encodeSliceAllocationPtr(alloc_ptr: [*]u8) usize {

--- a/src/builtins/str.zig
+++ b/src/builtins/str.zig
@@ -59,6 +59,26 @@ pub const RocStr = extern struct {
 
     pub const alignment = @alignOf(usize);
 
+    /// Number of pointer-sized words in a RocStr's in-memory layout. The layout
+    /// is target-width parameterized: its byte size is `word_count` times the
+    /// target pointer width. Sites that build a RocStr for a target of a
+    /// different width than the host multiply this by the target word size.
+    pub const word_count = 3;
+
+    /// The high bit of a RocStr's final byte marks the small-string
+    /// representation. The low seven bits of that byte hold the small-string
+    /// length.
+    pub const small_str_flag: u8 = 0b1000_0000;
+
+    /// Big-string capacities are stored shifted left by this many bits so the
+    /// low bit stays free for the seamless-slice tag.
+    pub const capacity_shift = 1;
+
+    comptime {
+        std.debug.assert(word_count * @sizeOf(usize) == @sizeOf(RocStr));
+        std.debug.assert(SMALL_STR_BIT == @as(usize, small_str_flag) << (@bitSizeOf(usize) - 8));
+    }
+
     pub inline fn empty() RocStr {
         return RocStr{
             .bytes = null,
@@ -67,12 +87,35 @@ pub const RocStr = extern struct {
         };
     }
 
+    fn encodeCapacityGeneric(comptime T: type, capacity: T) T {
+        return capacity << capacity_shift;
+    }
+
     pub inline fn encodeCapacity(capacity: usize) usize {
-        return capacity << 1;
+        return encodeCapacityGeneric(usize, capacity);
+    }
+
+    /// Encode a big-string capacity for a target whose pointer width may differ
+    /// from the host's. Applies the same shift as the host-width
+    /// `encodeCapacity`, but on a `u64` so it can hold any target word's value.
+    pub fn encodeCapacityForWidth(capacity: u64) u64 {
+        return encodeCapacityGeneric(u64, capacity);
     }
 
     pub inline fn decodeCapacity(encoded: usize) usize {
-        return encoded >> 1;
+        return encoded >> capacity_shift;
+    }
+
+    /// The final byte of a small RocStr: the small-string flag OR'd with the
+    /// small-string length. Target-width independent, since the flag and length
+    /// always live in the layout's final byte.
+    pub fn smallStrFlagByte(length: usize) u8 {
+        return @as(u8, @intCast(length)) | small_str_flag;
+    }
+
+    /// Recover the small-string length from a RocStr's final byte.
+    pub fn smallStrLenFromFlagByte(byte: u8) u8 {
+        return byte & ~small_str_flag;
     }
 
     pub inline fn encodeSliceAllocationPtr(ptr: [*]u8) usize {
@@ -143,7 +186,7 @@ pub const RocStr = extern struct {
         std.debug.assert(slice.len < SMALL_STRING_SIZE);
         var result = RocStr.empty();
         @memcpy(result.asU8ptrMut()[0..slice.len], slice);
-        result.asU8ptrMut()[@sizeOf(RocStr) - 1] = @as(u8, @intCast(slice.len)) | 0b1000_0000;
+        result.asU8ptrMut()[@sizeOf(RocStr) - 1] = smallStrFlagByte(slice.len);
         return result;
     }
 
@@ -186,7 +229,7 @@ pub const RocStr = extern struct {
         } else {
             var string = RocStr.empty();
 
-            string.asU8ptrMut()[@sizeOf(RocStr) - 1] = @as(u8, @intCast(length)) | 0b1000_0000;
+            string.asU8ptrMut()[@sizeOf(RocStr) - 1] = smallStrFlagByte(length);
 
             return string;
         }
@@ -205,7 +248,7 @@ pub const RocStr = extern struct {
         } else {
             var string = RocStr.empty();
 
-            string.asU8ptrMut()[@sizeOf(RocStr) - 1] = @as(u8, @intCast(length)) | 0b1000_0000;
+            string.asU8ptrMut()[@sizeOf(RocStr) - 1] = smallStrFlagByte(length);
 
             return string;
         }
@@ -460,7 +503,7 @@ pub const RocStr = extern struct {
             // I believe taking this reference on the stack here is important for correctness.
             // Doing it via a method call seemed to cause issues
             const dest_ptr = @as([*]u8, @ptrCast(&string));
-            dest_ptr[@sizeOf(RocStr) - 1] = @as(u8, @intCast(new_length)) | 0b1000_0000;
+            dest_ptr[@sizeOf(RocStr) - 1] = smallStrFlagByte(new_length);
 
             const source_ptr = self.asU8ptr();
 
@@ -490,7 +533,7 @@ pub const RocStr = extern struct {
 
     pub fn len(self: RocStr) usize {
         if (self.isSmallStr()) {
-            return self.asArray()[@sizeOf(RocStr) - 1] ^ 0b1000_0000;
+            return smallStrLenFromFlagByte(self.asArray()[@sizeOf(RocStr) - 1]);
         } else {
             return self.length;
         }
@@ -498,7 +541,7 @@ pub const RocStr = extern struct {
 
     pub fn setLen(self: *RocStr, length: usize) void {
         if (self.isSmallStr()) {
-            self.asU8ptrMut()[@sizeOf(RocStr) - 1] = @as(u8, @intCast(length)) | 0b1000_0000;
+            self.asU8ptrMut()[@sizeOf(RocStr) - 1] = smallStrFlagByte(length);
         } else {
             self.length = length;
         }
@@ -4884,4 +4927,24 @@ test "strConcat Immutable copies a shared big allocation" {
     try std.testing.expect(result.bytes != original_bytes);
     try std.testing.expect(std.mem.eql(u8, result.asSlice(), "a string long enough to be heap allocated!?"));
     try std.testing.expect(std.mem.eql(u8, base.asSlice(), "a string long enough to be heap allocated"));
+}
+
+test "default-platform RocStr view matches canonical RocStr layout" {
+    // The freestanding default-platform runtimes cannot import this module, so
+    // they read the RocStr encoding through `default_platform/roc_str_view.zig`.
+    // Assert that view's layout stays byte-for-byte identical to the canonical
+    // struct so the host boundary cannot silently drift.
+    const View = @import("roc_str_view").RocStr;
+
+    try std.testing.expectEqual(@sizeOf(RocStr), @sizeOf(View));
+    try std.testing.expectEqual(@alignOf(RocStr), @alignOf(View));
+
+    const canonical_fields = @typeInfo(RocStr).@"struct".fields;
+    const view_fields = @typeInfo(View).@"struct".fields;
+    try std.testing.expectEqual(canonical_fields.len, view_fields.len);
+    inline for (canonical_fields, view_fields) |cf, vf| {
+        try std.testing.expect(std.mem.eql(u8, cf.name, vf.name));
+        try std.testing.expectEqual(cf.type, vf.type);
+        try std.testing.expectEqual(@offsetOf(RocStr, cf.name), @offsetOf(View, vf.name));
+    }
 }

--- a/src/bundle/bundle.zig
+++ b/src/bundle/bundle.zig
@@ -20,6 +20,7 @@ const Allocator = std.mem.Allocator;
 const base58 = @import("base58");
 const streaming_writer = @import("streaming_writer.zig");
 const streaming_reader = @import("streaming_reader.zig");
+const format = @import("unbundle").format;
 const c = @cImport({
     @cDefine("ZSTD_STATIC_LINKING_ONLY", "1");
     @cInclude("zstd.h");
@@ -31,8 +32,8 @@ const SIZE_STORAGE_BYTES: usize = 16; // Extra bytes for storing allocation size
 const ZSTD_ALLOC_ALIGNMENT: std.mem.Alignment = .@"16";
 const TAR_PATH_MAX_LENGTH: usize = 255; // Maximum path length for tar compatibility
 /// Size of the buffer used for streaming operations (in bytes)
-pub const STREAM_BUFFER_SIZE: usize = 64 * 1024;
-const TAR_EXTENSION = ".tar.zst";
+pub const STREAM_BUFFER_SIZE = format.STREAM_BUFFER_SIZE;
+const TAR_EXTENSION = format.TAR_EXTENSION;
 /// Default compression level for zstd (22 = maximum compression)
 pub const DEFAULT_COMPRESSION_LEVEL: c_int = 22;
 

--- a/src/compile/static_data_exports.zig
+++ b/src/compile/static_data_exports.zig
@@ -390,10 +390,10 @@ const StaticDataBuilder = struct {
         const str_bytes = source.store.strBytes(str);
         const backing = source.store.strData(str.data);
         const whole_backing = str.offset == 0 and @as(usize, str.len) == backing.len;
-        const roc_str_size = self.word_size * 3;
+        const roc_str_size = self.word_size * builtins.str.RocStr.word_count;
         if (backing.len < roc_str_size and str_bytes.len < roc_str_size) {
             self.writeBytes(bytes, base_offset, str_bytes);
-            bytes[base_offset + roc_str_size - 1] = @as(u8, @intCast(str_bytes.len)) | 0x80;
+            bytes[base_offset + roc_str_size - 1] = builtins.str.RocStr.smallStrFlagByte(str_bytes.len);
             return;
         }
 
@@ -948,16 +948,16 @@ const StaticDataBuilder = struct {
 
     fn encodeRocStrCapacity(self: *StaticDataBuilder, capacity: usize) u64 {
         const target_capacity: u64 = @intCast(capacity);
-        const max_capacity = self.targetWordMax() >> 1;
+        const max_capacity = self.targetWordMax() >> builtins.str.RocStr.capacity_shift;
         if (target_capacity > max_capacity) staticDataInvariant("static string exceeds RocStr capacity limit for target");
-        return target_capacity << 1;
+        return builtins.str.RocStr.encodeCapacityForWidth(target_capacity);
     }
 
     fn encodeRocListCapacity(self: *StaticDataBuilder, capacity: usize) u64 {
         const target_capacity: u64 = @intCast(capacity);
-        const max_capacity = self.targetWordMax() >> 1;
+        const max_capacity = self.targetWordMax() >> builtins.list.RocList.capacity_shift;
         if (target_capacity > max_capacity) staticDataInvariant("static list exceeds RocList capacity limit for target");
-        return target_capacity << 1;
+        return builtins.list.RocList.encodeCapacityForWidth(target_capacity);
     }
 
     fn writeTargetSignedWord(self: *StaticDataBuilder, bytes: []u8, offset: u32, value: i64) void {

--- a/src/default_platform/c_runtime.zig
+++ b/src/default_platform/c_runtime.zig
@@ -6,7 +6,7 @@
 
 const builtin = @import("builtin");
 
-const seamless_slice_tag: usize = 1;
+const RocStr = @import("roc_str_view").RocStr;
 
 const c = switch (builtin.os.tag) {
     .windows => struct {
@@ -33,56 +33,6 @@ const AllocationHeader = extern struct {
     len: usize,
 };
 
-const RocStr = extern struct {
-    bytes: ?[*]u8,
-    capacity_or_alloc_ptr: usize,
-    length: usize,
-
-    fn isSmallStr(self: RocStr) bool {
-        return @as(isize, @bitCast(self.length)) < 0;
-    }
-
-    fn isSeamlessSlice(self: RocStr) bool {
-        return !self.isSmallStr() and (self.capacity_or_alloc_ptr & seamless_slice_tag) == seamless_slice_tag;
-    }
-
-    fn len(self: RocStr) usize {
-        if (self.isSmallStr()) {
-            const raw: *const [@sizeOf(RocStr)]u8 = @ptrCast(&self);
-            return raw.*[@sizeOf(RocStr) - 1] ^ 0b1000_0000;
-        }
-        return self.length;
-    }
-
-    fn allocationPtr(self: RocStr) ?[*]u8 {
-        if (self.isSmallStr()) return null;
-        if (self.isSeamlessSlice()) {
-            return @ptrFromInt(self.capacity_or_alloc_ptr & ~seamless_slice_tag);
-        }
-        return self.bytes;
-    }
-
-    fn asSlice(self: *const RocStr) []const u8 {
-        const ptr: [*]const u8 = if (self.isSmallStr())
-            @ptrCast(self)
-        else
-            @ptrCast(self.bytes.?);
-        return ptr[0..self.len()];
-    }
-
-    fn decref(self: *RocStr) void {
-        const data = self.allocationPtr() orelse return;
-        const refcount_ptr: *isize = @ptrCast(@alignCast(data - @sizeOf(usize)));
-        const refcount = refcount_ptr.*;
-        if (refcount == 0) return;
-
-        const last = @atomicRmw(isize, refcount_ptr, .Sub, 1, .monotonic);
-        if (last == 1) {
-            roc_dealloc(data - @sizeOf(usize), @alignOf(usize));
-        }
-    }
-};
-
 export fn roc_default_runtime_init() callconv(.c) void {}
 
 export fn roc_default_exit(code: u8) callconv(.c) noreturn {
@@ -94,7 +44,7 @@ export fn roc_default_echo_line(str: RocStr) callconv(.c) void {
     const message = owned.asSlice();
     writeAll(1, message);
     writeAll(1, "\n");
-    owned.decref();
+    owned.decref(roc_dealloc);
 }
 
 export fn roc_dbg(bytes: [*]const u8, len: usize) callconv(.c) void {

--- a/src/default_platform/linux_runtime.zig
+++ b/src/default_platform/linux_runtime.zig
@@ -7,6 +7,8 @@ const std = @import("std");
 const builtin = @import("builtin");
 const linux = std.os.linux;
 
+const RocStr = @import("roc_str_view").RocStr;
+
 pub const panic = std.debug.no_panic;
 
 const stdout_fd: i32 = 1;
@@ -18,7 +20,6 @@ const allocation_header_words = 3;
 const allocation_header_size = allocation_header_words * @sizeOf(usize);
 const alt_signal_stack_size: usize = 64 * 1024;
 const max_backtrace_frames = 64;
-const seamless_slice_tag: usize = 1;
 
 const BacktraceEntry = extern struct {
     start: usize,
@@ -81,7 +82,7 @@ export fn roc_default_echo_line(str: RocStr) callconv(.c) void {
     const message = owned.asSlice();
     writeAll(stdout_fd, message);
     writeLiteral(stdout_fd, "\n");
-    owned.decref();
+    owned.decref(roc_dealloc);
 }
 
 export fn roc_default_exit(code: u8) callconv(.c) noreturn {
@@ -440,53 +441,3 @@ fn defaultTrunc(value: f64) callconv(.c) f64 {
     const fraction_mask = (@as(u64, 1) << fraction_bits) - 1;
     return @bitCast(bits & ~fraction_mask);
 }
-
-const RocStr = extern struct {
-    bytes: ?[*]u8,
-    capacity_or_alloc_ptr: usize,
-    length: usize,
-
-    fn isSmallStr(self: RocStr) bool {
-        return @as(isize, @bitCast(self.length)) < 0;
-    }
-
-    fn isSeamlessSlice(self: RocStr) bool {
-        return !self.isSmallStr() and (self.capacity_or_alloc_ptr & seamless_slice_tag) == seamless_slice_tag;
-    }
-
-    fn len(self: RocStr) usize {
-        if (self.isSmallStr()) {
-            const raw: *const [@sizeOf(RocStr)]u8 = @ptrCast(&self);
-            return raw.*[@sizeOf(RocStr) - 1] ^ 0b1000_0000;
-        }
-        return self.length;
-    }
-
-    fn allocationPtr(self: RocStr) ?[*]u8 {
-        if (self.isSmallStr()) return null;
-        if (self.isSeamlessSlice()) {
-            return @ptrFromInt(self.capacity_or_alloc_ptr & ~seamless_slice_tag);
-        }
-        return self.bytes;
-    }
-
-    fn asSlice(self: *const RocStr) []const u8 {
-        const ptr: [*]const u8 = if (self.isSmallStr())
-            @ptrCast(self)
-        else
-            @ptrCast(self.bytes.?);
-        return ptr[0..self.len()];
-    }
-
-    fn decref(self: *RocStr) void {
-        const data = self.allocationPtr() orelse return;
-        const refcount_ptr: *isize = @ptrCast(@alignCast(data - @sizeOf(usize)));
-        const refcount = refcount_ptr.*;
-        if (refcount == 0) return;
-
-        const last = @atomicRmw(isize, refcount_ptr, .Sub, 1, .monotonic);
-        if (last == 1) {
-            roc_dealloc(data - @sizeOf(usize), @alignOf(usize));
-        }
-    }
-};

--- a/src/default_platform/roc_str_view.zig
+++ b/src/default_platform/roc_str_view.zig
@@ -1,0 +1,69 @@
+//! Minimal read-only view of `builtins.str.RocStr` for the freestanding
+//! default-platform runtimes.
+//!
+//! `c_runtime.zig` and `linux_runtime.zig` are compiled as standalone objects
+//! (freestanding, no libc, no compiler-rt) without the `builtins` module, so
+//! they cannot import `builtins.str.RocStr` directly the way `echo_platform` and
+//! the glue host do. This file is the one place the host-boundary `RocStr`
+//! encoding those runtimes depend on is written down. `src/builtins/str.zig`
+//! carries a test asserting this view's size, alignment, and field layout match
+//! the canonical `RocStr`, so the two definitions cannot drift.
+
+const seamless_slice_tag: usize = 1;
+
+/// Read-only view over a host-boundary `RocStr`, exposing only the byte access
+/// and reference-count release that the default-platform runtimes need. The
+/// field layout mirrors `builtins.str.RocStr`.
+pub const RocStr = extern struct {
+    bytes: ?[*]u8,
+    capacity_or_alloc_ptr: usize,
+    length: usize,
+
+    fn isSmallStr(self: RocStr) bool {
+        return @as(isize, @bitCast(self.length)) < 0;
+    }
+
+    fn isSeamlessSlice(self: RocStr) bool {
+        return !self.isSmallStr() and (self.capacity_or_alloc_ptr & seamless_slice_tag) == seamless_slice_tag;
+    }
+
+    fn len(self: RocStr) usize {
+        if (self.isSmallStr()) {
+            const raw: *const [@sizeOf(RocStr)]u8 = @ptrCast(&self);
+            return raw.*[@sizeOf(RocStr) - 1] ^ 0b1000_0000;
+        }
+        return self.length;
+    }
+
+    fn allocationPtr(self: RocStr) ?[*]u8 {
+        if (self.isSmallStr()) return null;
+        if (self.isSeamlessSlice()) {
+            return @ptrFromInt(self.capacity_or_alloc_ptr & ~seamless_slice_tag);
+        }
+        return self.bytes;
+    }
+
+    /// The string's bytes, borrowed for the lifetime of the view.
+    pub fn asSlice(self: *const RocStr) []const u8 {
+        const ptr: [*]const u8 = if (self.isSmallStr())
+            @ptrCast(self)
+        else
+            @ptrCast(self.bytes.?);
+        return ptr[0..self.len()];
+    }
+
+    /// Release one reference to the string, freeing the backing allocation with
+    /// `deallocFn` (the runtime's `roc_dealloc`) when the last reference drops.
+    /// Small strings and static-lifetime allocations (refcount 0) are no-ops.
+    pub fn decref(self: *RocStr, deallocFn: *const fn (*anyopaque, usize) callconv(.c) void) void {
+        const data = self.allocationPtr() orelse return;
+        const refcount_ptr: *isize = @ptrCast(@alignCast(data - @sizeOf(usize)));
+        const refcount = refcount_ptr.*;
+        if (refcount == 0) return;
+
+        const last = @atomicRmw(isize, refcount_ptr, .Sub, 1, .monotonic);
+        if (last == 1) {
+            deallocFn(data - @sizeOf(usize), @alignOf(usize));
+        }
+    }
+};

--- a/src/eval/wasm_runner.zig
+++ b/src/eval/wasm_runner.zig
@@ -93,6 +93,22 @@ const WasmStr = struct {
     is_small: bool,
 };
 
+/// Pointer width in bytes for the wasm32 target this runner drives.
+const wasm_word_size = 4;
+
+/// Byte size of a RocStr or RocList header in wasm32 linear memory. Both headers
+/// are `word_count` pointer-sized words wide; the runner materializes RocStr
+/// values (and lists of them) directly into wasm memory using this size.
+const wasm_roc_str_size = builtins.str.RocStr.word_count * wasm_word_size;
+
+comptime {
+    std.debug.assert(builtins.str.RocStr.word_count == builtins.list.RocList.word_count);
+}
+
+/// Largest length that fits in a small RocStr on wasm32 (the final byte holds
+/// the small-string flag, so the inline bytes span the rest of the header).
+const wasm_small_str_max_len = wasm_roc_str_size - 1;
+
 /// Captures a wasm eval run's string output and host-observed allocation count.
 pub const RunWasmStrResult = struct {
     output: []u8,
@@ -311,17 +327,17 @@ pub fn runWasmStrWithStats(
 
     const str_ptr: u32 = @bitCast(returns[0].I32);
     const mem_slice = module_instance.memoryAll();
-    if (str_ptr + 12 > mem_slice.len) {
+    if (str_ptr + wasm_roc_str_size > mem_slice.len) {
         if (std.debug.runtime_safety) {
             debugPrint("wasm invalid str ptr: ptr={d} mem_len={d}\n", .{ str_ptr, mem_slice.len });
         }
         return error.WasmExecFailed;
     }
 
-    const byte11 = mem_slice[str_ptr + 11];
-    const str_data: []const u8 = if (byte11 & 0x80 != 0) sd: {
-        const sso_len: u32 = byte11 & 0x7F;
-        if (sso_len > 11) {
+    const byte11 = mem_slice[str_ptr + wasm_small_str_max_len];
+    const str_data: []const u8 = if (byte11 & builtins.str.RocStr.small_str_flag != 0) sd: {
+        const sso_len: u32 = builtins.str.RocStr.smallStrLenFromFlagByte(byte11);
+        if (sso_len > wasm_small_str_max_len) {
             if (std.debug.runtime_safety) {
                 debugPrint("wasm invalid sso len: ptr={d} len={d}\n", .{ str_ptr, sso_len });
             }
@@ -394,7 +410,7 @@ fn hostStrEq(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]const b
     const buffer = module.store.getMemory(0).buffer();
     const a_ptr: usize = @intCast(params[0].I32);
     const b_ptr: usize = @intCast(params[1].I32);
-    if (a_ptr + 12 > buffer.len or b_ptr + 12 > buffer.len) {
+    if (a_ptr + wasm_roc_str_size > buffer.len or b_ptr + wasm_roc_str_size > buffer.len) {
         results[0] = .{ .I32 = 0 };
         return;
     }
@@ -408,7 +424,7 @@ fn hostListEq(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]const 
     const a_list_ptr: usize = @intCast(params[0].I32);
     const b_list_ptr: usize = @intCast(params[1].I32);
     const elem_size: usize = @intCast(params[2].I32);
-    if (a_list_ptr + 12 > buffer.len or b_list_ptr + 12 > buffer.len) {
+    if (a_list_ptr + wasm_roc_str_size > buffer.len or b_list_ptr + wasm_roc_str_size > buffer.len) {
         results[0] = .{ .I32 = 0 };
         return;
     }
@@ -1079,7 +1095,7 @@ fn hostListStrEq(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]con
     const buffer = module.store.getMemory(0).buffer();
     const a_list_ptr: usize = @intCast(params[0].I32);
     const b_list_ptr: usize = @intCast(params[1].I32);
-    if (a_list_ptr + 12 > buffer.len or b_list_ptr + 12 > buffer.len) {
+    if (a_list_ptr + wasm_roc_str_size > buffer.len or b_list_ptr + wasm_roc_str_size > buffer.len) {
         results[0] = .{ .I32 = 0 };
         return;
     }
@@ -1096,8 +1112,8 @@ fn hostListStrEq(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]con
         return;
     }
     for (0..a_len) |i| {
-        const a_elem_ptr = a_data_ptr + i * 12;
-        const b_elem_ptr = b_data_ptr + i * 12;
+        const a_elem_ptr = a_data_ptr + i * wasm_roc_str_size;
+        const b_elem_ptr = b_data_ptr + i * wasm_roc_str_size;
         const a = readWasmStr(buffer, a_elem_ptr);
         const b = readWasmStr(buffer, b_elem_ptr);
         if (a.len != b.len) {
@@ -1117,7 +1133,7 @@ fn hostListListEq(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]co
     const a_list_ptr: usize = @intCast(params[0].I32);
     const b_list_ptr: usize = @intCast(params[1].I32);
     const inner_elem_size: usize = @intCast(params[2].I32);
-    if (a_list_ptr + 12 > buffer.len or b_list_ptr + 12 > buffer.len) {
+    if (a_list_ptr + wasm_roc_str_size > buffer.len or b_list_ptr + wasm_roc_str_size > buffer.len) {
         results[0] = .{ .I32 = 0 };
         return;
     }
@@ -1134,8 +1150,8 @@ fn hostListListEq(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]co
         return;
     }
     for (0..a_len) |i| {
-        const a_elem_ptr = a_data_ptr + i * 12;
-        const b_elem_ptr = b_data_ptr + i * 12;
+        const a_elem_ptr = a_data_ptr + i * wasm_roc_str_size;
+        const b_elem_ptr = b_data_ptr + i * wasm_roc_str_size;
         const a_data_inner: usize = @intCast(readIntLittle(u32, buffer, a_elem_ptr));
         const a_len_inner: usize = @intCast(readIntLittle(u32, buffer, a_elem_ptr + 4));
         const b_data_inner: usize = @intCast(readIntLittle(u32, buffer, b_elem_ptr));
@@ -1160,25 +1176,25 @@ fn hostListListEq(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]co
 
 fn readWasmStr(buffer: []u8, str_ptr: usize) WasmStr {
     if (builtin.mode == .Debug and std.debug.runtime_safety) {
-        if (str_ptr + 12 > buffer.len) {
+        if (str_ptr + wasm_roc_str_size > buffer.len) {
             std.debug.panic(
                 "wasm_runner invariant violated: string header ptr={} exceeds memory len={}",
                 .{ str_ptr, buffer.len },
             );
         }
     }
-    const bytes = buffer[str_ptr..][0..12];
-    if ((bytes[11] & 0x80) != 0) {
-        const len = bytes[11] & 0x7F;
+    const bytes = buffer[str_ptr..][0..wasm_roc_str_size];
+    if ((bytes[wasm_small_str_max_len] & builtins.str.RocStr.small_str_flag) != 0) {
+        const len = builtins.str.RocStr.smallStrLenFromFlagByte(bytes[wasm_small_str_max_len]);
         if (builtin.mode == .Debug and std.debug.runtime_safety) {
-            if (len > 11) {
+            if (len > wasm_small_str_max_len) {
                 std.debug.panic(
                     "wasm_runner invariant violated: invalid SSO string len={} at ptr={}",
                     .{ len, str_ptr },
                 );
             }
         }
-        return .{ .data = bytes[0..11].ptr, .data_offset = str_ptr, .len = len, .cap_or_alloc = 0, .is_small = true };
+        return .{ .data = bytes[0..wasm_small_str_max_len].ptr, .data_offset = str_ptr, .len = len, .cap_or_alloc = 0, .is_small = true };
     } else {
         const data_ptr: usize = @intCast(readIntLittle(u32, buffer, str_ptr));
         const cap_or_alloc = readIntLittle(u32, buffer, str_ptr + 4);
@@ -1196,11 +1212,11 @@ fn readWasmStr(buffer: []u8, str_ptr: usize) WasmStr {
 }
 
 fn encodeWasmListCapacity(capacity: usize) u32 {
-    return @intCast(capacity << 1);
+    return @intCast(builtins.list.RocList.encodeCapacityForWidth(@intCast(capacity)));
 }
 
 fn decodeWasmListCapacity(encoded_capacity: usize) usize {
-    return encoded_capacity >> 1;
+    return builtins.list.RocList.decodeCapacity(encoded_capacity);
 }
 
 fn wasmAllocPtrFromCapOrData(cap_or_alloc: usize, data_offset: usize) usize {
@@ -1220,15 +1236,15 @@ fn increfWasmDataPtr(buffer: []u8, data_ptr: usize) void {
 }
 
 fn writeWasmStr(buffer: []u8, result_ptr: usize, data: [*]const u8, len: usize) void {
-    if (len < 12) {
-        @memset(buffer[result_ptr..][0..12], 0);
+    if (len < wasm_roc_str_size) {
+        @memset(buffer[result_ptr..][0..wasm_roc_str_size], 0);
         @memcpy(buffer[result_ptr..][0..len], data[0..len]);
-        buffer[result_ptr + 11] = @intCast(len | 0x80);
+        buffer[result_ptr + wasm_small_str_max_len] = builtins.str.RocStr.smallStrFlagByte(len);
     } else {
         const data_ptr = allocWasmData(buffer, 1, len);
         @memcpy(buffer[data_ptr..][0..len], data[0..len]);
         writeIntLittle(u32, buffer, result_ptr, @intCast(data_ptr));
-        writeIntLittle(u32, buffer, result_ptr + 4, @intCast(len << 1));
+        writeIntLittle(u32, buffer, result_ptr + 4, @intCast(builtins.str.RocStr.encodeCapacityForWidth(@intCast(len))));
         writeIntLittle(u32, buffer, result_ptr + 8, @intCast(len));
     }
 }
@@ -1254,7 +1270,7 @@ fn writeWasmStrViewFromList(buffer: []u8, result_ptr: usize, list_ptr: usize, le
     }
     const data_offset: usize = @intCast(readIntLittle(u32, buffer, list_ptr));
     const cap_or_alloc = readIntLittle(u32, buffer, list_ptr + 8);
-    if (len < 12) {
+    if (len < wasm_roc_str_size) {
         writeWasmStr(buffer, result_ptr, buffer[data_offset..].ptr, len);
         return;
     }
@@ -1267,8 +1283,8 @@ fn writeWasmStrViewFromList(buffer: []u8, result_ptr: usize, list_ptr: usize, le
 }
 
 fn writeWasmEmptyStr(buffer: []u8, result_ptr: usize) void {
-    @memset(buffer[result_ptr..][0..12], 0);
-    buffer[result_ptr + 11] = 0x80;
+    @memset(buffer[result_ptr..][0..wasm_roc_str_size], 0);
+    buffer[result_ptr + wasm_small_str_max_len] = builtins.str.RocStr.smallStrFlagByte(0);
 }
 
 fn rocStrFromWasmSlice(data: [*]const u8, len: usize) builtins.str.RocStr {
@@ -1427,13 +1443,13 @@ fn hostStrWithCapacity(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: 
     const buffer = module.store.getMemory(0).buffer();
     const cap: usize = @intCast(@as(u32, @bitCast(params[0].I32)));
     const result_ptr: usize = @intCast(params[1].I32);
-    if (cap < 12) {
+    if (cap < wasm_roc_str_size) {
         writeWasmEmptyStr(buffer, result_ptr);
         return;
     }
     const dest_start = allocWasmData(buffer, 1, cap);
     writeIntLittle(u32, buffer, result_ptr, @intCast(dest_start));
-    writeIntLittle(u32, buffer, result_ptr + 4, @intCast(cap << 1));
+    writeIntLittle(u32, buffer, result_ptr + 4, @intCast(builtins.str.RocStr.encodeCapacityForWidth(@intCast(cap))));
     writeIntLittle(u32, buffer, result_ptr + 8, 0);
 }
 
@@ -1449,8 +1465,8 @@ fn hostStrEscapeAndQuote(_: ?*anyopaque, module: *bytebox.ModuleInstance, params
     }
 
     const result_len = slice.len + extra + 2;
-    if (result_len < 12) {
-        var small: [12]u8 = .{0} ** 12;
+    if (result_len < wasm_roc_str_size) {
+        var small: [wasm_roc_str_size]u8 = .{0} ** wasm_roc_str_size;
         small[0] = '"';
         var pos: usize = 1;
         for (slice) |ch| {
@@ -1599,14 +1615,14 @@ fn hostStrSplit(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]cons
             }
         }
     }
-    const list_data_start = allocWasmData(buffer, 4, count * 12);
+    const list_data_start = allocWasmData(buffer, 4, count * wasm_roc_str_size);
     var part_idx: usize = 0;
     var start: usize = 0;
     if (sep.len > 0) {
         var i: usize = 0;
         while (i + sep.len <= str.len) {
             if (bytesEqual(str_slice[i..][0..sep.len], sep_slice)) {
-                writeWasmStr(buffer, list_data_start + part_idx * 12, str_slice[start..].ptr, i - start);
+                writeWasmStr(buffer, list_data_start + part_idx * wasm_roc_str_size, str_slice[start..].ptr, i - start);
                 part_idx += 1;
                 start = i + sep.len;
                 i = start;
@@ -1615,7 +1631,7 @@ fn hostStrSplit(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]cons
             }
         }
     }
-    writeWasmStr(buffer, list_data_start + part_idx * 12, str_slice[start..].ptr, str.len - start);
+    writeWasmStr(buffer, list_data_start + part_idx * wasm_roc_str_size, str_slice[start..].ptr, str.len - start);
     writeIntLittle(u32, buffer, result_ptr, @intCast(list_data_start));
     writeIntLittle(u32, buffer, result_ptr + 4, @intCast(count));
     writeIntLittle(u32, buffer, result_ptr + 8, encodeWasmListCapacity(count));
@@ -1632,7 +1648,7 @@ fn hostStrJoinWith(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]c
         return;
     }
     var total_len: usize = 0;
-    for (0..list_len) |i| total_len += readWasmStr(buffer, list_data + i * 12).len;
+    for (0..list_len) |i| total_len += readWasmStr(buffer, list_data + i * wasm_roc_str_size).len;
     total_len += sep.len * (list_len - 1);
     if (total_len == 0) {
         writeWasmEmptyStr(buffer, @intCast(params[2].I32));
@@ -1646,7 +1662,7 @@ fn hostStrJoinWith(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]c
             @memcpy(buffer[dest_start + offset ..][0..sep.len], sep.data[0..sep.len]);
             offset += sep.len;
         }
-        const elem = readWasmStr(buffer, list_data + i * 12);
+        const elem = readWasmStr(buffer, list_data + i * wasm_roc_str_size);
         if (elem.len > 0) {
             @memcpy(buffer[dest_start + offset ..][0..elem.len], elem.data[0..elem.len]);
             offset += elem.len;
@@ -1680,14 +1696,14 @@ fn hostStrReserve(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]co
     const extra_cap: usize = @intCast(@as(u32, @bitCast(params[1].I32)));
     const result_ptr: usize = @intCast(params[2].I32);
     const needed = str.len + extra_cap;
-    if (needed < 12) {
+    if (needed < wasm_roc_str_size) {
         writeWasmStr(buffer, result_ptr, str.data, str.len);
         return;
     }
     const dest_start = allocWasmData(buffer, 1, needed);
     @memcpy(buffer[dest_start..][0..str.len], str.data[0..str.len]);
     writeIntLittle(u32, buffer, result_ptr, @intCast(dest_start));
-    writeIntLittle(u32, buffer, result_ptr + 4, @intCast(needed << 1));
+    writeIntLittle(u32, buffer, result_ptr + 4, @intCast(builtins.str.RocStr.encodeCapacityForWidth(@intCast(needed))));
     writeIntLittle(u32, buffer, result_ptr + 8, @intCast(str.len));
 }
 
@@ -2003,7 +2019,7 @@ fn hostStrFromUtf8(_: ?*anyopaque, module: *bytebox.ModuleInstance, params: [*]c
     const inner_disc_offset: usize = @intCast(params[11].I32);
     const inner_disc_size: usize = @intCast(params[12].I32);
     const inner_bad_utf8_disc: u32 = @bitCast(params[13].I32);
-    if (list_ptr + 12 > buffer.len or result_ptr + result_size > buffer.len) return;
+    if (list_ptr + wasm_roc_str_size > buffer.len or result_ptr + result_size > buffer.len) return;
     const data_ptr: usize = @intCast(readIntLittle(u32, buffer, list_ptr));
     const len: usize = @intCast(readIntLittle(u32, buffer, list_ptr + 4));
     if (data_ptr + len > buffer.len) return;

--- a/src/lir/lir_image.zig
+++ b/src/lir/lir_image.zig
@@ -219,6 +219,19 @@ pub const LayoutStoreImage = extern struct {
     }
 };
 
+comptime {
+    // The LIR image mirrors these three stores field-for-field. When a
+    // serialized field is added to or removed from a store, update the matching
+    // `*Image` extern struct, its `fromStore` and `view` methods, and the
+    // "LIR image round-trips every populated store field" test at the bottom of
+    // this file, then update the expected field count below. A same-build
+    // omission (a new store field left out of the image plumbing) is otherwise
+    // silent, since `FORMAT_VERSION` only guards cross-version mismatches.
+    std.debug.assert(@typeInfo(LirStore).@"struct".fields.len == 25);
+    std.debug.assert(@typeInfo(layout_mod.Store).@"struct".fields.len == 11);
+    std.debug.assert(@typeInfo(base.StringLiteral.Store).@"struct".fields.len == 1);
+}
+
 /// Fill the reserved LIR image header in a contiguous buffer.
 ///
 /// `lowered` must already have been allocated from an allocator that owns
@@ -446,4 +459,203 @@ fn checkedOffset(ref: ArrayRef) ImageError!usize {
 
 test "LIR image declarations are referenced" {
     std.testing.refAllDecls(@This());
+}
+
+/// The 16 `LirStore` array-backed lists serialized as `ArrayRef`s, in the order
+/// they appear in `LirStoreImage`. `strings` (a sub-image) and the scalar
+/// `next_synthetic_symbol` are serialized too but exercised separately below.
+const serialized_guarded_fields = [_][]const u8{
+    "cf_stmts",
+    "cf_switch_branches",
+    "str_match_steps",
+    "str_match_arms",
+    "join_points",
+    "locals",
+    "local_ids",
+    "u64s",
+    "proc_specs",
+    "source_file_bytes",
+    "source_file_ends",
+    "cf_stmt_locs",
+    "cf_stmt_regions",
+    "proc_locs",
+    "proc_debug_names",
+    "local_names",
+};
+
+test "LIR image round-trips every populated store field" {
+    const gpa = std.testing.allocator;
+
+    // One contiguous buffer owns every array the image references. The image
+    // records offsets relative to `buffer.ptr`, so all backing storage below is
+    // allocated from this fixed buffer rather than from `gpa` directly.
+    const buffer = try gpa.alignedAlloc(u8, .@"16", 1 << 20);
+    defer gpa.free(buffer);
+    var fba_state = std.heap.FixedBufferAllocator.init(buffer);
+    const fba = fba_state.allocator();
+
+    const target_usize = base.target.TargetUsize.native;
+
+    const h = struct {
+        /// Allocate `count` elements of `T` and fill their raw bytes with a
+        /// per-field-distinctive, per-index pattern so a dropped or swapped
+        /// field (same or different element type) is detectable after view.
+        fn distinct(comptime T: type, alloc: std.mem.Allocator, count: usize, seed: u8) std.mem.Allocator.Error![]T {
+            const slice = try alloc.alloc(T, count);
+            const bytes = std.mem.sliceAsBytes(slice);
+            for (bytes, 0..) |*b, i| b.* = seed +% @as(u8, @truncate(i));
+            return slice;
+        }
+        /// Build a populated `GuardedList` for a `LirStore` field of type `FieldT`.
+        fn guarded(comptime FieldT: type, alloc: std.mem.Allocator, count: usize, seed: u8) std.mem.Allocator.Error!FieldT {
+            const T = std.meta.Child(FieldT.Slice);
+            const slice = try distinct(T, alloc, count, seed);
+            return FieldT.fromArrayList(.{ .items = slice, .capacity = count });
+        }
+        /// Build a populated `SafeList(T)` backed by the fixed buffer.
+        fn safeList(comptime T: type, alloc: std.mem.Allocator, count: usize, seed: u8) std.mem.Allocator.Error!collections.SafeList(T) {
+            const slice = try distinct(T, alloc, count, seed);
+            return .{ .items = .{ .items = slice, .capacity = count } };
+        }
+        /// Build a populated `SafeMultiList(T)` backed by the fixed buffer.
+        fn multiList(comptime T: type, alloc: std.mem.Allocator, count: usize, seed: u8) std.mem.Allocator.Error!collections.SafeMultiList(T) {
+            var mal: std.MultiArrayList(T) = .{};
+            try mal.resize(alloc, count);
+            const total = std.MultiArrayList(T).capacityInBytes(mal.capacity);
+            for (mal.bytes[0..total], 0..) |*b, i| b.* = seed +% @as(u8, @truncate(i));
+            return .{ .items = mal };
+        }
+        /// Assert two byte spans are equal and non-empty.
+        fn expectBytesEq(a: []const u8, b: []const u8) error{ TestExpectedEqual, TestUnexpectedResult }!void {
+            try std.testing.expect(a.len > 0);
+            try std.testing.expectEqualSlices(u8, a, b);
+        }
+    };
+
+    // A LirStore with every serialized list populated distinctively. `init`
+    // seeds the non-serialized scalar/ambient fields; the arrays it creates are
+    // empty and immediately overwritten with fixed-buffer-backed storage, so the
+    // store is never deinitialized (its arrays are not owned by `gpa`).
+    var store = LirStore.init(gpa);
+    inline for (serialized_guarded_fields, 0..) |fname, i| {
+        @field(store, fname) = try h.guarded(@FieldType(LirStore, fname), fba, 2 + i, @intCast(0x20 + i));
+    }
+    store.next_synthetic_symbol = 0x0123_4567_89ab_cdef;
+    store.strings = .{ .buffer = .{ .items = .{ .items = try h.distinct(u8, fba, 24, 0x90), .capacity = 24 } } };
+
+    // A layout Store with every serialized list populated distinctively. Only
+    // the seven array-backed fields are serialized; the interning caches are not
+    // read by `fromStore`, so they are left undefined here.
+    var layouts = layout_mod.Store{
+        .allocator = gpa,
+        .layouts = try h.safeList(layout_mod.Layout, fba, 3, 0x40),
+        .resolved_list_layouts = .{ .items = try h.distinct(?layout_mod.Idx, fba, 4, 0x50), .capacity = 4 },
+        .tuple_elems = try h.safeList(layout_mod.Idx, fba, 5, 0x60),
+        .struct_fields = try h.multiList(layout_mod.StructField, fba, 6, 0x70),
+        .struct_data = try h.safeList(layout_mod.StructData, fba, 7, 0x80),
+        .tag_union_variants = try h.multiList(layout_mod.TagUnionVariant, fba, 8, 0x88),
+        .tag_union_data = try h.safeList(layout_mod.TagUnionData, fba, 9, 0xa0),
+        .interned_layouts = undefined,
+        .scratch_intern_key = undefined,
+        .target_usize = target_usize,
+    };
+
+    const root_procs = try h.distinct(LIR.LirProcSpecId, fba, 3, 0xb0);
+    const entrypoints = try h.distinct(PlatformEntrypoint, fba, 2, 0xc0);
+
+    const base_ptr = buffer.ptr;
+    const image_size = fba_state.end_index;
+
+    // Serialize: fill the header exactly as `fillHeaderInBuffer` does, so this
+    // drives the real `fromStore`/`arrayRef` plumbing under test.
+    const header: Header = .{
+        .magic = MAGIC,
+        .format_version = FORMAT_VERSION,
+        .image_size = image_size,
+        .root_procs = try arrayRef(base_ptr, image_size, root_procs),
+        .platform_entrypoints = try arrayRef(base_ptr, image_size, entrypoints),
+        .store = try LirStoreImage.fromStore(base_ptr, image_size, &store),
+        .layouts = try LayoutStoreImage.fromStore(base_ptr, image_size, &layouts),
+    };
+
+    // View back over the same buffer.
+    var view = try viewMappedImageWithAllocator(&header, base_ptr, buffer.len, target_usize, gpa);
+    defer view.layouts.interned_layouts.deinit();
+    defer view.layouts.scratch_intern_key.deinit(gpa);
+
+    // Every serialized guarded list must round-trip byte-for-byte. A field
+    // omitted from `fromStore`/`view` would read back as empty and fail here.
+    inline for (serialized_guarded_fields) |fname| {
+        const a = @field(store, fname).unsafeRawItemsForView();
+        const b = @field(view.store, fname).unsafeRawItemsForView();
+        try std.testing.expectEqual(a.len, b.len);
+        try h.expectBytesEq(std.mem.sliceAsBytes(a), std.mem.sliceAsBytes(b));
+    }
+
+    // Scalar and sub-image fields.
+    try std.testing.expectEqual(@as(u64, 0x0123_4567_89ab_cdef), view.store.next_synthetic_symbol);
+    try h.expectBytesEq(store.strings.buffer.items.items, view.store.strings.buffer.items.items);
+
+    // `patterns`/`pattern_ids` carry no data in statement-only LIR (nothing
+    // lowers into the LIR-level pattern lists), so the image intentionally omits
+    // them and `view` restores them empty. Assert that intent explicitly rather
+    // than round-tripping populated data.
+    try std.testing.expectEqual(@as(usize, 0), view.store.patterns.len());
+    try std.testing.expectEqual(@as(usize, 0), view.store.pattern_ids.len());
+
+    // Ambient lowering state is reset by `view`; it is not image data.
+    try std.testing.expectEqual(base.SourceLoc.none, view.store.current_loc);
+    try std.testing.expectEqual(base.Region.zero(), view.store.current_region);
+    // A viewed image is read-only, so string insertion is disabled.
+    try std.testing.expectEqual(false, view.store.strings_insertable);
+
+    // Layout store: seven serialized lists plus the view-supplied target width.
+    try h.expectBytesEq(
+        std.mem.sliceAsBytes(layouts.layouts.items.items),
+        std.mem.sliceAsBytes(view.layouts.layouts.items.items),
+    );
+    try h.expectBytesEq(
+        std.mem.sliceAsBytes(layouts.resolved_list_layouts.items),
+        std.mem.sliceAsBytes(view.layouts.resolved_list_layouts.items),
+    );
+    try h.expectBytesEq(
+        std.mem.sliceAsBytes(layouts.tuple_elems.items.items),
+        std.mem.sliceAsBytes(view.layouts.tuple_elems.items.items),
+    );
+    try h.expectBytesEq(
+        std.mem.sliceAsBytes(layouts.struct_data.items.items),
+        std.mem.sliceAsBytes(view.layouts.struct_data.items.items),
+    );
+    try h.expectBytesEq(
+        std.mem.sliceAsBytes(layouts.tag_union_data.items.items),
+        std.mem.sliceAsBytes(view.layouts.tag_union_data.items.items),
+    );
+    {
+        const T = layout_mod.StructField;
+        const orig = &layouts.struct_fields.items;
+        const seen = &view.layouts.struct_fields.items;
+        try std.testing.expectEqual(orig.len, seen.len);
+        try h.expectBytesEq(
+            orig.bytes[0..std.MultiArrayList(T).capacityInBytes(orig.capacity)],
+            seen.bytes[0..std.MultiArrayList(T).capacityInBytes(seen.capacity)],
+        );
+    }
+    {
+        const T = layout_mod.TagUnionVariant;
+        const orig = &layouts.tag_union_variants.items;
+        const seen = &view.layouts.tag_union_variants.items;
+        try std.testing.expectEqual(orig.len, seen.len);
+        try h.expectBytesEq(
+            orig.bytes[0..std.MultiArrayList(T).capacityInBytes(orig.capacity)],
+            seen.bytes[0..std.MultiArrayList(T).capacityInBytes(seen.capacity)],
+        );
+    }
+    try std.testing.expectEqual(target_usize, view.layouts.target_usize);
+    try std.testing.expectEqual(target_usize, view.target_usize);
+
+    // Header-level array refs.
+    try std.testing.expectEqual(@as(usize, 3), view.root_procs.len);
+    try std.testing.expectEqual(@as(usize, 2), view.platform_entrypoints.len);
+    try h.expectBytesEq(std.mem.sliceAsBytes(root_procs), std.mem.sliceAsBytes(view.root_procs));
+    try h.expectBytesEq(std.mem.sliceAsBytes(entrypoints), std.mem.sliceAsBytes(view.platform_entrypoints));
 }

--- a/src/machine_code_shim/main.zig
+++ b/src/machine_code_shim/main.zig
@@ -422,10 +422,25 @@ fn maxDevDataAlignment(view: *const RunImage.ProgramView) RunImage.ImageError!us
 
 const JumpStubError = RunImage.ImageError || error{UnsupportedPlatform};
 
+/// Bytes emitted for one host jump stub on x86_64 (`movabs r11, imm64; jmp r11`).
+const x86_64_jump_stub_size = 13;
+/// Bytes emitted for one host jump stub on aarch64 (four `movk`/`movz x16`
+/// instructions followed by `br x16`).
+const aarch64_jump_stub_size = 20;
+
+comptime {
+    // `RunImage` reserves `max_jump_stub_size` bytes per stub in the shared image;
+    // the stub this shim emits for every supported host arch must fit within that
+    // reservation. This is the single compile-time link between the emitted sizes
+    // (owned here) and the reservation (owned by `RunImage`).
+    std.debug.assert(x86_64_jump_stub_size <= RunImage.max_jump_stub_size);
+    std.debug.assert(aarch64_jump_stub_size <= RunImage.max_jump_stub_size);
+}
+
 fn jumpStubSize() JumpStubError!usize {
     return switch (builtin.cpu.arch) {
-        .x86_64 => 13,
-        .aarch64, .aarch64_be => 20,
+        .x86_64 => x86_64_jump_stub_size,
+        .aarch64, .aarch64_be => aarch64_jump_stub_size,
         else => error.UnsupportedPlatform,
     };
 }
@@ -433,7 +448,7 @@ fn jumpStubSize() JumpStubError!usize {
 fn writeJumpStub(buf: []u8, target_addr: usize) JumpStubError!void {
     switch (builtin.cpu.arch) {
         .x86_64 => {
-            if (buf.len < 13) return error.InvalidDevRunImage;
+            if (buf.len < x86_64_jump_stub_size) return error.InvalidDevRunImage;
             buf[0] = 0x49; // movabs r11, imm64
             buf[1] = 0xBB;
             std.mem.writeInt(u64, buf[2..][0..8], @intCast(target_addr), .little);
@@ -442,7 +457,7 @@ fn writeJumpStub(buf: []u8, target_addr: usize) JumpStubError!void {
             buf[12] = 0xE3;
         },
         .aarch64, .aarch64_be => {
-            if (buf.len < 20) return error.InvalidDevRunImage;
+            if (buf.len < aarch64_jump_stub_size) return error.InvalidDevRunImage;
             const addr: u64 = @intCast(target_addr);
             std.mem.writeInt(u32, buf[0..][0..4], movzX16(@truncate(addr), 0), .little);
             std.mem.writeInt(u32, buf[4..][0..4], movkX16(@truncate(addr >> 16), 16), .little);

--- a/src/shim_host_abi.zig
+++ b/src/shim_host_abi.zig
@@ -12,14 +12,7 @@ const RocOps = builtins.host_abi.RocOps;
 const RocList = builtins.list.RocList;
 const RocStr = builtins.str.RocStr;
 
-const extern_host = struct {
-    extern fn roc_alloc(length: usize, alignment: usize) ?*anyopaque;
-    extern fn roc_dealloc(ptr: *anyopaque, alignment: usize) void;
-    extern fn roc_realloc(ptr: *anyopaque, new_length: usize, alignment: usize) ?*anyopaque;
-    extern fn roc_dbg(bytes: [*]const u8, len: usize) void;
-    extern fn roc_expect_failed(bytes: [*]const u8, len: usize) void;
-    extern fn roc_crashed(bytes: [*]const u8, len: usize) void;
-};
+const extern_host = builtins.host_abi.extern_host;
 
 /// Hosted dispatch table defined by the generated platform shim module, in
 /// hosted-section order.

--- a/src/unbundle/format.zig
+++ b/src/unbundle/format.zig
@@ -1,0 +1,10 @@
+//! Shared on-disk format constants for bundled Roc packages (`.tar.zst`
+//! archives). `unbundle` is the lower, WebAssembly-compatible layer that `bundle`
+//! depends on, so it owns the single definition of these constants; the `bundle`
+//! writer references them through the `unbundle` module.
+
+/// File extension for a bundled Roc package: a zstd-compressed tar archive.
+pub const TAR_EXTENSION = ".tar.zst";
+
+/// Size of the buffer used for streaming bundle/unbundle operations, in bytes.
+pub const STREAM_BUFFER_SIZE: usize = 64 * 1024;

--- a/src/unbundle/mod.zig
+++ b/src/unbundle/mod.zig
@@ -15,6 +15,9 @@ pub const unbundle = @import("unbundle.zig");
 pub const download = @import("download.zig");
 pub const localhost = @import("localhost.zig");
 
+/// Shared `.tar.zst` format constants, referenced by both `unbundle` and `bundle`.
+pub const format = @import("format.zig");
+
 // Re-export commonly used functions and types
 pub const unbundleFiles = unbundle.unbundle;
 pub const unbundleStream = unbundle.unbundleStream;

--- a/src/unbundle/unbundle.zig
+++ b/src/unbundle/unbundle.zig
@@ -8,10 +8,11 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const base58 = @import("base58");
 const zstd = std.compress.zstd;
+const format = @import("format.zig");
 
 // Constants
-const TAR_EXTENSION = ".tar.zst";
-const STREAM_BUFFER_SIZE: usize = 64 * 1024; // 64KB buffer for streaming operations
+const TAR_EXTENSION = format.TAR_EXTENSION;
+const STREAM_BUFFER_SIZE = format.STREAM_BUFFER_SIZE;
 // Buffer size for stdlib zstd decompressor: window_len + block_size_max for tar extraction
 const DECOMPRESS_BUFFER_SIZE: usize = zstd.default_window_len + zstd.block_size_max;
 // Max path bytes - use 4096 on WASM/freestanding, std.Io.Dir.max_path_bytes elsewhere


### PR DESCRIPTION
Stacked on #10080 (which stacks on #10079). This PR eliminates the remaining hand-mirrored ABI and memory-layout facts the duplication audit found — the class where drift means memory corruption or silent link mismatches rather than a compile error. The default platform's two runtimes carried byte-identical private re-declarations of the RocStr struct, its bit-level encodings, and the decref protocol; they now share one `roc_str_view.zig` (they're freestanding objects that can't import builtins), with a builtins-side test asserting the view matches the canonical struct field-for-field. The six `roc_alloc`-family extern signatures declared in both the shim and `host_abi.zig` now have one `pub` declaration. The Str/List encoding facts (three-word shape, 0x80 small-string flag, capacity shift) that the static-data emitter, wasm test runner, and LLVM backend each restated are now exported from `builtins/str.zig`/`list.zig` with comptime assertions.

WasmLayout stops recomputing struct/tag-union sizing with hardcoded wasm32 literals and reads the layout store's per-width answers like the other backends (golden wasm output is byte-identical), and the hand-written wasm builtin ABI table is now pinned by a comptime verifier that re-derives every row from the corresponding wrapper's function type — a wrong row is now a compile error naming the builtin. Finally, serialization pairs that must stay mirrored get structural guards: a LirImage round-trip test that fails if a store field is added without image plumbing, shared bundle/unbundle format constants, and a compile-time assertion that jump stubs fit RunImage's reservation.