### PR TITLE
Add project specs from the cor lss comparative review

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -22,6 +22,39 @@ duplicated computation. `design.md` at the repo root is the authoritative
 post-check design; these projects implement its stated principles more
 completely.
 
+A second batch of projects came out of the 2026-07 comparative review of
+the post-check pipeline against the cor `lss` prototype it was
+productionized from (stage-by-stage divergence review; no shipped
+miscompile found, but several unstated load-bearing invariants, one
+termination hazard, and one verification coverage gap):
+
+- [small/spec-constr-specialization-limits.md](small/spec-constr-specialization-limits.md)
+  — termination budgets for call-pattern specialization (compile-time
+  divergence is reachable today).
+- [small/empty-tag-union-yield-provenance.md](small/empty-tag-union-yield-provenance.md)
+  — key Lambda Solved's one unification escape hatch on carried provenance
+  instead of shape.
+- [small/pin-lambda-solved-invariants.md](small/pin-lambda-solved-invariants.md)
+  — state, assert, and test the four invariants that make monomorphic
+  lambda-set solving sound.
+- [small/lambda-mono-oracle-fidelity.md](small/lambda-mono-oracle-fidelity.md)
+  — agreement asserts and contract pins for the Debug Lambda Mono oracle;
+  delete its dead Queue.
+- [small/monotype-machinery-hardening.md](small/monotype-machinery-hardening.md)
+  — release-gate verification-only type checks; measure-first fixes for
+  digest depth fallback, unify memo, spec duplication, cross-store reuse.
+- [small/lift-capture-single-sourcing.md](small/lift-capture-single-sourcing.md)
+  — one capture-fixpoint driver, the `if_initialized_payload` binder
+  question, and the capture-id override path.
+- [big/solved-lir-body-verification.md](big/solved-lir-body-verification.md)
+  — a body-level oracle for the fused solved-to-LIR path (decision
+  verification exists; statement bodies are unverified).
+
+Within this batch: land `lambda-mono-oracle-fidelity` before
+`solved-lir-body-verification`; the rest are independent.
+`spec-constr-specialization-limits` pairs naturally with
+`spec-constr-static-match-soundness`.
+
 ## Recommended order
 
 ### Start here

--- a/projects/big/solved-lir-body-verification.md
+++ b/projects/big/solved-lir-body-verification.md
@@ -22,7 +22,7 @@ faithful body-level port of cor's `ir/lower.ml` (`postcheck/lir_lower.zig`)
 was dead code and was deleted in the duplication-audit cleanup
 (PR roc-lang/roc#10079) — correctly, since an unexercised oracle is drift,
 not protection. But its deletion makes the gap permanent by default: a
-body-lowering bug in `solved_lir_lower.zig` (a mis-ordered capture field,
+body-lowering bug in `solved_lir_lower.zig` (a misordered capture field,
 a wrong variant index, a swapped branch target) is caught today only if an
 end-to-end test happens to execute the affected construct with a
 discriminating input.

--- a/projects/big/solved-lir-body-verification.md
+++ b/projects/big/solved-lir-body-verification.md
@@ -1,0 +1,190 @@
+# Body-Level Verification for the Direct Solved-to-LIR Path
+
+## Problem
+
+The production pipeline's final lowering fuses two prototype stages: the
+cor `lss` pipeline goes lambdasolved → lambdamono → ir as separate,
+individually-inspectable passes, while production lowers Lambda Solved
+directly to LIR in one pass (`src/postcheck/solved_lir_lower.zig`,
+~7,700 lines), computing Lambda Mono decisions inline. design.md sanctions
+this and prescribes the guard: a Debug-only verifier that materializes the
+logical Lambda Mono tree and checks it against the direct path
+(`verifyMaterializedDecisions`, `solved_lir_lower.zig:1876`).
+
+The guard has a structural coverage gap: it verifies **decisions only** —
+function specializations, callable variants, capture records,
+roots/layout/schema requests (design.md lists these; the implementation
+matches). It never verifies **lowered statement bodies**: the actual
+LIR — capture pack/unpack sequences, discriminant switches, match branch
+chains, field indices, evaluation order — is produced exactly once, by the
+direct path, and compared against nothing. The one artifact that was a
+faithful body-level port of cor's `ir/lower.ml` (`postcheck/lir_lower.zig`)
+was dead code and was deleted in the duplication-audit cleanup
+(PR roc-lang/roc#10079) — correctly, since an unexercised oracle is drift,
+not protection. But its deletion makes the gap permanent by default: a
+body-lowering bug in `solved_lir_lower.zig` (a mis-ordered capture field,
+a wrong variant index, a swapped branch target) is caught today only if an
+end-to-end test happens to execute the affected construct with a
+discriminating input.
+
+The 2026-07 cor-comparison review found no body-lowering bug — the
+construct-by-construct comparison against cor's `ir/lower.ml` and `eval/`
+semantics checked out, with the classic hazards (capture pack/unpack
+alignment, trailing capture argument, record field canonicalization)
+explicitly `invariant()`-guarded. The finding is not a defect; it is that
+the fused path's correctness currently rests on hand-verification plus
+whatever the eval corpus happens to cover, and both erode as the file
+changes. This is the highest-leverage remaining structural risk from that
+review.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck:
+Monotype IR → Monotype Lifted → Lambda Solved → **direct solved-to-LIR
+lowering** (with Debug Lambda Mono decision verification) → TRMC →
+ScalarizeJoins → ReachableProcs → ARC → backends. design.md's "Debug
+Lambda Mono Verification" section is the contract; note its list of
+checked decisions is prefixed "at least these explicit decisions" — body
+verification is an extension it already permits, not a policy change. The
+verifier must remain release-free: no tree allocation, no verifier data
+structures, compile-time-dead in release.
+
+cor's own architecture points at the answer it used: cor never verified
+lowering against lowering — it verified by **executing**. Its `eval/`
+stage is a tiny interpreter over the final IR, and the test suite compares
+evaluated results. Production has richer analogs: the LIR interpreter
+(`src/eval/`), the dev backend, the LLVM backend, and the wasm backend all
+execute the same LIR, and cross-opt/cross-backend agreement is already the
+stated ground truth in sibling projects.
+
+## Evidence
+
+All symbols verified in the current tree (post-#10079).
+
+- `src/postcheck/solved_lir_lower.zig`: `verifyMaterializedDecisions`
+  (`:1876`) — Debug-gated (`:1877`), checks fn entries, roots, layout
+  requests, runtime schema requests (`:~1896-1899`), nothing below the
+  proc-signature level; the direct body lowering it does not cover:
+  pattern/match chains (`lowerBranchChain`, `:~4222`), capture record
+  build (`lowerCaptureRecordFromCaptureExprsInto`, `:~2364`) and bind
+  (`bindCaptureRecord`, `:~799`), callable dispatch
+  (`lowerCallableValueCallInto`, `:~3374`), list patterns
+  (`lowerListPatternThen`, `:~2588` in the deleted twin's numbering —
+  re-locate).
+- `src/postcheck/lambda_mono/lower.zig`: the Debug oracle already
+  materializes full Lambda Mono **bodies** (expressions, patterns,
+  statements) — the tree exists in Debug runs; only the comparison
+  stops at decisions.
+- design.md "Debug Lambda Mono Verification": "checks at least these
+  explicit decisions" — extension-friendly wording; release-zero-cost
+  requirement.
+- cor reference: `ir/lower.ml` + `eval/runtime.ml` (execution as the
+  oracle); the review's construct-by-construct comparison table.
+
+## Solution design
+
+This project needs a design decision first; the two viable shapes, with a
+recommendation:
+
+**Option A — execute the oracle (recommended).** Give the Debug-only
+Lambda Mono tree a small tree-walking evaluator — cor's `eval/` stage,
+productionized to Lambda Mono instead of a second LIR lowerer. In Debug
+runs (or a dedicated CI mode), evaluate test-program roots over the
+materialized Lambda Mono tree and compare results against the LIR
+interpreter executing the direct path's output. Divergence pinpoints a
+body-lowering bug (or an oracle bug — either is worth knowing) with a
+concrete program and value in hand.
+
+- Pro: an evaluator over the *pre-LIR* tree is a genuinely independent
+  derivation (different representation, different traversal), immune to
+  the correlated-bug problem a second lowerer had; it is also far smaller
+  than a lowerer (cor's whole evaluator is ~250 lines; the production
+  tree is richer but the same order of magnitude, because Lambda Mono is
+  decisions-plus-monotype-shapes, not layouts).
+- Con: it duplicates runtime semantics (numeric ops, string ops) that
+  must be delegated to the shared builtins where possible; scope the
+  evaluated corpus to programs whose ops it supports and fail loudly on
+  unsupported constructs rather than approximating.
+
+**Option B — differential execution without a new evaluator.** Skip the
+oracle entirely; build the harness that runs every eval-corpus program
+under interpreter, `--opt=dev`, and `--opt=speed` across backends and
+asserts identical output, then grow the corpus adversarially toward the
+uncovered constructs (generated programs sweeping capture counts/orders,
+lambda-set sizes, match shapes, list-pattern rests, guard combinations).
+
+- Pro: no new semantic surface to maintain; strengthens the whole
+  pipeline, not just this pass.
+- Con: coverage is empirical, not structural — a body bug still hides if
+  no generated program discriminates it; and failures localize to "these
+  two backends disagree", not to the lowering site.
+
+Recommendation: **A**, seeded with B's generated-program corpus as the
+input set (the generator is useful to both and is the bulk of B's work
+anyway). Decide explicitly at kickoff; if A's evaluator turns out to need
+more than ~2 weeks, descope to B and file the evaluator as follow-up —
+recorded, not implicit.
+
+Mutation-hardening either way: whichever harness lands must be validated
+by seeded mutations — deliberately break `solved_lir_lower.zig` in five
+representative ways (swap capture order at pack site only, off-by-one a
+variant index, reorder two match branches, drop a list-rest binding, swap
+argument evaluation order) and confirm each is caught. A verifier that
+passes on mutants is theater; this is the acceptance test *of the
+verifier*.
+
+## What success looks like
+
+- A body-level divergence in `solved_lir_lower.zig` is caught by Debug CI
+  on the existing corpus, demonstrated by the five seeded mutations each
+  failing the harness.
+- Release builds are bit-identical and pay zero cost (compile-time-dead
+  verification branches, per design.md).
+- The verifier's coverage is stated: which constructs the evaluator
+  executes (A) or which construct dimensions the generator sweeps (B),
+  with unsupported/unswept constructs listed in the harness, not silently
+  skipped.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- Independence: the oracle derivation shares no lowering code with the
+  direct path (A: a tree evaluator; B: whole other backends). Shared
+  builtins are acceptable shared ground truth.
+- Localization: a failure names the first diverging root/value (A) — or,
+  under B, the failing program plus disagreeing backend pair — and
+  reproduces deterministically.
+- The decision-level verifier stays exactly as design.md specifies; this
+  project adds a layer, it does not restructure the existing one.
+
+### Performance ideal
+
+Debug/CI cost only. Measure Debug corpus wall time with the harness on;
+budget it as a CI lane rather than forcing it into every local Debug run
+if it exceeds ~10% of suite time (a `zig build` step flag, mirroring the
+guarded-list violation harness pattern).
+
+## Tests to add
+
+- The five seeded-mutation checks, automated (apply patch, expect harness
+  failure, revert) or maintained as a documented manual release-checklist
+  item if patch automation is too brittle — decided at implementation.
+- The generated-program corpus: sweeps over capture count (0, 1, 2, 8),
+  capture types (scalar, heap, closure-in-closure, recursive closure),
+  lambda-set size (1, 2, 5, erased), match shapes (guards, wildcards,
+  string/list patterns with and without rests, nested nominals), argument
+  evaluation-order probes (effectful `dbg` ordering).
+- Cross-opt agreement assertions on that corpus (interpreter / dev /
+  speed), which stand alone as regression value even under option A.
+
+## Related projects
+
+- [../small/lambda-mono-oracle-fidelity.md](../small/lambda-mono-oracle-fidelity.md)
+  — do first: it hardens the materialized tree this project builds on.
+- [../small/pin-lambda-solved-invariants.md](../small/pin-lambda-solved-invariants.md)
+  — its dispatch matrix tests become early members of this project's
+  corpus.
+- [decision-tree-match-compiler.md](./decision-tree-match-compiler.md) —
+  if that lands first, match lowering changes shape; land this harness
+  before or alongside it so the rewrite inherits a body-level net.

--- a/projects/small/empty-tag-union-yield-provenance.md
+++ b/projects/small/empty-tag-union-yield-provenance.md
@@ -1,0 +1,165 @@
+# Provenance for the Empty-Tag-Union Yield in Lambda Solved Unification
+
+## Problem
+
+Lambda Solved unification is exact-match by design — same counts, same
+positional order, same names — because both sides of every unification were
+lowered from the same closed Monotype. It has one escape hatch: when exactly
+one side is an empty tag union, that side yields and links to the peer
+unconditionally (`src/postcheck/lambda_solved/solve.zig:1264-1271`),
+whatever the peer is — function, record, primitive. The comment justifies
+this from design.md's doctrine: an empty tag union is the seal for a slot
+no evidence reached (a variable defaulted at Monotype materialization), it
+fixes no layout, so it yields to concrete local evidence.
+
+The reasoning is sound **for defaulted slots**. But the hatch keys on the
+*shape* `[]`, not on the *fact* "this slot was defaulted" — it re-derives
+provenance from structure, which is the codebase's recurring disease shape.
+Any upstream bug that leaves an empty tag union somewhere it should not be
+(a genuine mis-unification, a wrongly-sealed row, a future refactor of
+Monotype defaulting) is silently absorbed here instead of tripping the
+exact-match invariant: the wrong peer wins, the slot is silently retyped,
+and the divergence surfaces — if at all — stages later as a layout or
+dispatch anomaly with no trail back to this link.
+
+The 2026-07 comparative review against the cor `lss` prototype rated this
+the likeliest hiding place for a real semantic bug in the stage: cor's
+open-row unifier (`lambdasolved/solve.ml`) has no analogous unconditional
+yield, so this hatch is production-only surface with no reference
+semantics.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck:
+Monotype IR → Monotype Lifted → **Lambda Solved** (lambda-set solving;
+`src/postcheck/lambda_solved/`) → Lambda Mono decisions → LIR → ARC →
+backends. `design.md` is authoritative; read the Monotype instantiation
+section (an unconstrained checked variable "lowers to the empty tag union
+in Monotype. This is not a default choice. It records the invariant that no
+runtime value can be constructed at that type").
+
+Monotype materialization is where the fact is born: an unresolved graph
+node with no evidence seals as the empty tag union
+(`src/postcheck/monotype/solve.zig:~2038`, `materializeUnresolved`). The
+Monotype type store interns nodes, so the sealed `[]` is the *same
+interned TypeId* as any legitimately-constructed empty tag union —
+interning collapses provenance at the type level. Provenance therefore
+cannot be a bit on the type; it must either travel per *slot* (per graph
+node / per use), or be verified rather than carried.
+
+## Evidence
+
+All symbols verified in the current tree.
+
+- `src/postcheck/lambda_solved/solve.zig:1252-1271`: the yield, with the
+  design rationale comment (phantom argument types of a function value
+  inspected but never called are the motivating case).
+- `src/postcheck/monotype/solve.zig:~2038`: unresolved-node defaulting at
+  materialization (the only sanctioned producer of "defaulted `[]`" slots).
+- design.md: exact-match doctrine for post-Monotype unification; empty tag
+  union as the uninhabited-slot seal; debug-assert/release-unreachable
+  invariant policy ("Post-check stages ... do not add release-build runtime
+  checks for compiler invariants") — so the fix must be structural or
+  Debug-time, not a release check.
+- cor reference: `lambdasolved/solve.ml` unifies rows openly and has no
+  yield-to-anything case; the hatch exists only because production unifies
+  exactly over already-closed monotypes.
+
+## Solution design
+
+Decide between two routes during implementation; route A is the
+design-conformant destination, route B is the acceptable floor.
+
+**Route A — carry the fact.** Record defaulted-slot provenance where it is
+created and consume it where the hatch fires:
+
+1. At Monotype materialization, when a node seals by default to the empty
+   tag union, record it in a per-spec side set keyed by the position that
+   will be visible downstream (the lifted type reference, not the interned
+   TypeId — interning collapses TypeIds).
+2. Thread the set through Monotype Lifted into Lambda Solved's input
+   (`Lifted.Program`), the same way layout/schema requests already travel.
+3. The hatch consults the carried set: yield only when the `[]` side's slot
+   is recorded as defaulted; otherwise fall through to the exact-match
+   invariant, which is the enforcement design.md prescribes for everything
+   else.
+
+The design wrinkle to resolve first (this is why the project needs a
+half-day of investigation before coding): Lambda Solved clones types from
+Monotype TypeIds via its `TypeCloner`, and a slot's identity must survive
+that cloning. If per-slot keying proves too invasive, weaken the carried
+fact to per-TypeId-occurrence-in-context (the lifted expression or local
+whose type contains the defaulted node) — the hatch fires during
+unifications rooted at typed expressions, so context is available.
+
+**Route B — verify the fact (floor).** Keep the shape-keyed hatch, but make
+drift observable:
+
+1. Debug-build check at the yield: walk back to the checked type behind the
+   `[]` side (Monotype AST retains checked source references) and assert
+   the checked slot was genuinely unconstrained. If the back-reference is
+   not retained today, add a Debug-only side map from mono type creation.
+2. A Debug counter for hatch firings, asserted against expected sites on
+   the snapshot corpus, so a new producer of `[]`-meets-non-`[]` shows up
+   as a corpus diff rather than silence.
+
+Either route keeps release builds at zero cost per design.md. Do not ship
+both halves half-done: pick A or B explicitly, and if B, file A as
+follow-up.
+
+## What success looks like
+
+- The yield at `solve.zig:1264` is conditioned on (route A) or verified
+  against (route B) the *fact* "defaulted at materialization" — never on
+  shape alone.
+- An artificially mis-sealed `[]` (test-injected) trips the exact-match
+  invariant in Debug instead of silently linking.
+- The motivating phantom case (a function value rendered as `<function>`
+  whose phantom argument type seals as `[]` at the reference site) still
+  compiles and runs — the hatch's legitimate work is untouched.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- One producer, one consumer, explicit data between them: the set of slots
+  allowed to yield is exactly the set Monotype defaulted, by construction
+  (A) or by Debug verification on every firing (B).
+- The exact-match invariant regains full coverage for every non-defaulted
+  slot; behavior on checked programs is unchanged (the hatch only ever
+  fires on defaulted slots today, if the doctrine holds — this project
+  proves it holds and keeps it proven).
+
+### Performance ideal
+
+Release: zero — provenance is either data already flowing through stage
+handoff (a side slice, O(defaulted slots), typically tiny) or Debug-only.
+Measure Lambda Solved stage time on the corpus; require parity within
+noise. Zero effect on generated code.
+
+## Tests to add
+
+- The phantom-slot case from the hatch's own comment: an inspected-never-
+  called polymorphic function value (`|x, y| x + y` bound and rendered),
+  compiled and run — pins the legitimate yield.
+- A generic-container case where an element type seals as `[]` on one path
+  and concrete on another (e.g. an empty list literal flowing into a
+  function that also receives a populated list) — the other known
+  legitimate firing family.
+- Debug tripwire: a unit test over the Lambda Solved solver constructing a
+  non-defaulted `[]` (route A: absent from the carried set; route B:
+  checked-concrete) unified against a function type; asserts the
+  exact-match invariant fires.
+- Corpus check: hatch-firing counter across the snapshot corpus and CLI
+  suite recorded once and asserted stable (Debug builds), so new firings
+  are reviewed rather than absorbed.
+
+## Related projects
+
+- [pin-lambda-solved-invariants.md](./pin-lambda-solved-invariants.md) —
+  sibling: the same stage's other unstated assumptions (FnId granularity,
+  capture order, member order, erasure triggers).
+- [pin-deferred-spec-requests.md](./pin-deferred-spec-requests.md) — the
+  same disease shape one stage earlier (a default papering over a fact the
+  checker proved), and the template for "carry the checked fact to the
+  consumer".

--- a/projects/small/empty-tag-union-yield-provenance.md
+++ b/projects/small/empty-tag-union-yield-provenance.md
@@ -16,7 +16,7 @@ The reasoning is sound **for defaulted slots**. But the hatch keys on the
 *shape* `[]`, not on the *fact* "this slot was defaulted" — it re-derives
 provenance from structure, which is the codebase's recurring disease shape.
 Any upstream bug that leaves an empty tag union somewhere it should not be
-(a genuine mis-unification, a wrongly-sealed row, a future refactor of
+(a genuinely wrong unification, a wrongly-sealed row, a future refactor of
 Monotype defaulting) is silently absorbed here instead of tripping the
 exact-match invariant: the wrong peer wins, the slot is silently retyped,
 and the divergence surfaces — if at all — stages later as a layout or
@@ -112,7 +112,7 @@ follow-up.
 - The yield at `solve.zig:1264` is conditioned on (route A) or verified
   against (route B) the *fact* "defaulted at materialization" — never on
   shape alone.
-- An artificially mis-sealed `[]` (test-injected) trips the exact-match
+- An artificially wrongly-sealed `[]` (test-injected) trips the exact-match
   invariant in Debug instead of silently linking.
 - The motivating phantom case (a function value rendered as `<function>`
   whose phantom argument type seals as `[]` at the reference site) still

--- a/projects/small/lambda-mono-oracle-fidelity.md
+++ b/projects/small/lambda-mono-oracle-fidelity.md
@@ -1,0 +1,164 @@
+# Lambda Mono Oracle Fidelity and Dead Machinery
+
+## Problem
+
+Per design.md ("Debug Lambda Mono Verification"), release builds never
+materialize the Lambda Mono tree; `src/postcheck/lambda_mono/lower.zig`
+runs only inside the Debug verifier (`verifyMaterializedDecisions`,
+`src/postcheck/solved_lir_lower.zig:1876`) as the oracle the direct
+solved-to-LIR path is checked against. An oracle is only as good as its
+own fidelity, and the 2026-07 cor-comparison review found three hygiene
+gaps in it — none a shipped-code bug (the file cannot reach release
+output), all of them ways the verifier can drift from what it is supposed
+to verify, which is the failure mode that makes a verifier worse than
+none:
+
+**G1 — `localFor` is first-write-wins with no agreement check.**
+`localFor` (`lambda_mono/lower.zig:1222-1230`) caches a local's Lambda Mono
+type from whichever caller reaches it first and ignores the type every
+later caller passes. Callers derive that type from *different* sources
+(function signature args, pattern types, expression types, loop-param
+types, payload-local types). In a correctly unified Lambda Solved program
+all sources share one root, so the cache is deterministic — but nothing
+asserts later callers agree with the cached type. If those sources ever
+drift to structurally-equal-but-distinct roots (the codebase's recurring
+disease), the oracle's local types become traversal-order-dependent, and
+the verifier would be comparing the direct path against a nondeterministic
+reference. cor avoids this structurally: within one specialization its
+`ty_cache`/`venv` share one physical tvar per logical variable
+(`lambdamono/type_clone_inst.ml`).
+
+**G2 — the folded-match replay channel is unpinned.** The direct lowerer
+folds statically-impossible `list_map_can_reuse` matches and records each
+fold as explicit data (`FoldedMatch`, appended Debug-only at
+`solved_lir_lower.zig:3730`); the oracle replays the recorded resolutions
+(`lambda_mono/lower.zig:617-623`) by emitting the folded body and skipping
+the scrutinee entirely. Today this is sound because the only recorded
+scrutinees are compiler-synthesized `list_map_can_reuse` ops — pure, no
+user code, no bindings (`Lifted.Program.exprIsListMapCanReuseOp`,
+`monotype_lifted/ast.zig:~982`). But the replay site checks none of that:
+any future producer that appends a `FoldedMatch` with an effectful
+scrutinee or a binding-carrying pattern would be replayed as silent
+elision, and the oracle would ratify whatever the direct path did instead
+of checking it.
+
+**G3 — dead parallel machinery.** `lambda_mono/specialize.zig` exports a
+`Queue` (`:15`) with O(n²) `std.meta.eql` dedup (`:27-34`) that the
+lowerer does not use (it uses `fn_spec_map`). It is a vestigial parallel
+of the cor prototype's `Specializations` module — the
+dead-but-still-maintained pattern the duplication audit targets, one file
+over from live code that does the same job.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck:
+Monotype IR → Monotype Lifted → Lambda Solved → **Lambda Mono decisions +
+Debug oracle** → LIR → ARC → backends. design.md's "Debug Lambda Mono
+Verification" section defines the oracle's contract: materialized in Debug
+only, never an input to production lowering, checked against the direct
+path's decisions. The direct path records the decisions; the oracle
+re-derives them independently — so every place the oracle *copies* a
+direct-path decision instead of re-deriving it (the folded-match channel
+is exactly such a place, by documented necessity: the oracle runs before
+layout selection and cannot recompute layout-dependent folds) must pin
+what it is copying, or that slice of the verifier is circular.
+
+## Evidence
+
+All symbols verified in the current tree.
+
+- `src/postcheck/lambda_mono/lower.zig`: `localFor` first-write-wins
+  (`:1222-1230`); typed sources feeding it from signatures (`:~354`),
+  patterns (`:~919`), expressions (`:~547`), loop params (`:~1274`),
+  payload locals (`:~637-652`); folded-match replay (`:617-623`).
+- `src/postcheck/solved_lir_lower.zig`: fold decision + Debug-only record
+  (`foldListMapCanReuseMatch`, `:3713-3736`, append at `:3730`) with the
+  layout-interchangeability bailout that keeps genuinely layout-dependent
+  matches unfolded (`:3724-3728`); oracle invocation passing
+  `folded_map_matches` (`:1884`).
+- `src/postcheck/monotype_lifted/ast.zig`: `FoldedMatch` contract comment
+  ("recorded so the debug materializer replays the identical resolution",
+  `:~977`), `exprIsListMapCanReuseOp` (`:~982`).
+- `src/postcheck/lambda_mono/specialize.zig`: unused `Queue` (`:15`),
+  linear-scan `enqueue` (`:27-34`). Consumers: only
+  `postcheck/mod.zig`'s export and `refAllDecls`-style test references
+  (`src/collections/guarded_list_violation_test.zig` uses the *ast/type*
+  modules, not `Queue` — confirm during implementation with a final grep).
+- Review provenance: 2026-07 cor-vs-production review, Lambda Mono stage
+  report (divergences D4, C1; performance note PERF-3).
+
+## Solution design
+
+1. **G1 — assert agreement on every `localFor` call.** The whole file is
+   Debug-only, so the check is free where it matters: when the cache hits,
+   assert the passed `ty` equals the cached `ty` (`Common.invariant` on
+   mismatch, per policy). This converts "all five type sources agree" from
+   folklore into a machine-checked property of every Debug run — which is
+   also exactly the early-warning tripwire for root-drift upstream in
+   Lambda Solved.
+
+2. **G2 — pin the replay channel's contract.** At the replay site (or at
+   `FoldedMatch` append), assert the recorded scrutinee satisfies
+   `exprIsListMapCanReuseOp` — the structural predicate already written —
+   so the channel's "pure, binding-free, compiler-synthesized" premise is
+   enforced, not assumed. A future fold kind then has to either satisfy
+   the predicate or extend it consciously, with the contract comment
+   updated in the same commit.
+
+3. **G3 — delete `Queue`.** Remove it and its export; final grep for
+   consumers first. If anything does consume it, that consumer is using
+   O(n²) dedup one file away from the O(1) live index and should be
+   migrated in the same change.
+
+## What success looks like
+
+- A Debug corpus run (snapshot corpus + CLI suite) passes with the G1 and
+  G2 asserts active and zero firings.
+- `lambda_mono/specialize.zig` contains only what the live path uses.
+- The oracle's copied-decision surface (folded matches) is exactly
+  enumerated: one channel, one structural predicate, both asserted.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- The verifier verifies: every value it compares against the direct path
+  is either independently re-derived or pinned by an asserted structural
+  contract — no unchecked copies.
+- G1's assert doubles as the detection mechanism for the Lambda Solved
+  root-sharing invariant (see related project): if type sources ever
+  stop sharing roots, Debug CI fails at the first affected local with a
+  named site, instead of the oracle silently absorbing the drift.
+
+### Performance ideal
+
+All three changes are Debug-only or deletions; release builds are
+bit-identical (verify by hashing `--opt=speed` output on the corpus).
+Debug-build verifier time may rise negligibly from the per-call type
+compare; measure Debug corpus wall time, require parity within noise.
+
+## Tests to add
+
+- G1 tripwire: a unit test over the oracle constructing a program whose
+  local is reached with two distinct (structurally equal, different-id)
+  types; asserts the new invariant fires. This is the negative control
+  proving the assert works.
+- G2 tripwire: unit test appending a `FoldedMatch` whose scrutinee is not
+  a `list_map_can_reuse` op; asserts the replay-site invariant fires.
+- G2 positive: the `List.map` fold path end-to-end in Debug (a program
+  where element layouts are not interchangeable, so the fold fires),
+  asserting the oracle verification passes — pins that the legitimate
+  channel still flows.
+- Grep-level guard in `ci/semantic_audit.pl` if `Queue` deletion reveals
+  the export pattern recurring elsewhere (optional; judgment call during
+  implementation).
+
+## Related projects
+
+- [pin-lambda-solved-invariants.md](./pin-lambda-solved-invariants.md) —
+  G1's assert is the downstream detector for that project's root-sharing
+  invariant; land in either order, they reinforce each other.
+- [../big/solved-lir-body-verification.md](../big/solved-lir-body-verification.md)
+  — extends what the oracle *covers*; this project fixes what the oracle
+  *is*. Do this one first — it is days, not weeks, and a higher-fidelity
+  oracle strengthens whatever body-verification design that project picks.

--- a/projects/small/lift-capture-single-sourcing.md
+++ b/projects/small/lift-capture-single-sourcing.md
@@ -1,0 +1,154 @@
+# Single-Source the Lift Stage's Capture Solving
+
+## Problem
+
+The Monotype Lifted stage's capture analysis is the best-guarded code the
+2026-07 cor-comparison review looked at — the flattening fixpoint is a
+true least fixed point, and `verifyCaptureInvariants` machine-checks the
+slot/operand joins after lifting and after every rewrite. Three residues
+keep it from being fully single-sourced, and each is the seed of a
+familiar failure mode:
+
+**L1 — the capture fixpoint has two driver loops.** The initial lift
+solves captures via `computeCaptureFixpoint` + `solveInto`
+(`src/postcheck/monotype_lifted/lift.zig:762`, `:794`); the
+post-spec_constr re-solve (`recomputeCaptures`, `:178`, called from
+`src/lir/checked_pipeline.zig:240`) uses a near-verbatim duplicate,
+`solveCaptureFixpoint` (`:1020`). Both delegate the actual free-variable
+walk to the shared `CaptureSet.collectExpr`, so the core is
+single-sourced — but the driver (iteration, scratch handling,
+convergence condition) exists twice. If one loop is edited and the other
+is not, initial-lift captures and post-spec_constr captures can disagree,
+and the disagreement would surface as a Debug verifier panic at best and
+a wrong capture set in release at worst. This is precisely the
+duplicated-driver drift the codebase's audits keep finding.
+
+**L2 — `if_initialized_payload`'s payload has ambiguous binder
+semantics.** `CaptureSet.collectExpr` treats the construct's `payload`
+local as *potentially free* (`addIfFree`, `lift.zig:1358`), i.e. an outer
+local that becomes a capture if unbound locally — while `rewriteExpr`
+for the same construct never touches `payload` (`:668-672`), and no code
+path binds it the way match binders are bound. If the construct
+semantically *binds* `payload` (the natural reading: a payload extracted
+in the initialized branch), the current handling over-captures — a
+harmless-but-wasteful extra capture slot threaded through every closure
+that contains the construct. If it is genuinely an outer local, the code
+is right and one comment away from staying right. The review could not
+determine the intent from the lifted stage alone; the producer of the
+construct (Monotype lowering) knows.
+
+**L3 — the capture-id override path tolerates stale ids by trusting a
+live one.** `operandValueForSlotId` (`lift.zig:915`) lets a value-local's
+*current* `CaptureId` override the operand's stored id, explicitly to
+tolerate spec_constr substitution leaving stale ids behind. The keyed
+Debug verifier checks operand-id/slot-id equality, but not this override
+path: a spec_constr-substituted operand whose value coincidentally
+carries a `CaptureId` equal to a *different* slot's id would be silently
+routed to the wrong slot. No such case is known; the tolerance is
+unverified rather than wrong.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck:
+Monotype IR → **Monotype Lifted** (`lift.zig` closure lifting;
+`spec_constr.zig` call-pattern specialization in optimized builds, after
+which `recomputeCaptures` re-solves all capture sets) → Lambda Solved →
+Lambda Mono decisions → LIR → ARC → backends. Capture identity is carried
+as `CaptureId` (binder-derived or lift-synthesized), and all
+slot/operand/field joins are keyed by it; ordering is ascending
+`CaptureId` throughout.
+
+The re-solve after spec_constr is intentional — specialization rewrites
+bodies, so captures must be re-derived — which is exactly why the two
+derivations must share one driver: they are *supposed* to be the same
+computation run twice.
+
+## Evidence
+
+All symbols verified in the current tree.
+
+- `src/postcheck/monotype_lifted/lift.zig`: `computeCaptureFixpoint`
+  (`:762-789`) + `solveInto` (`:794`); `solveCaptureFixpoint` (`:1020`);
+  `recomputeCaptures` (`:178`); shared walk `CaptureSet.collectExpr`
+  (`:~1225`); `if_initialized_payload` in collect (`:1356-1361`,
+  `addIfFree` on `payload` at `:1358`) vs rewrite (`:668-672`, payload
+  untouched); `operandValueForSlotId` (`:915-933`); the capture-invariant
+  verifier (`verifyCaptureInvariants`, `:~208`).
+- `src/lir/checked_pipeline.zig:237-240`: SpecConstr then
+  `recomputeCaptures` sequencing.
+- Review provenance: 2026-07 cor-vs-production review, lambda-lifting
+  stage report (C2, C3, open question 4).
+
+## Solution design
+
+1. **L1 — one driver.** Extract the fixpoint loop into a single function
+   parameterized by its input program view, and have both the Lifter and
+   `recomputeCaptures` call it. The diff should delete one of the two
+   loops; if the extraction reveals a real difference between them (not
+   just drift potential), that difference is a finding — document which
+   behavior is correct and pin it with a test before unifying.
+2. **L2 — resolve the binder question at the producer.** Read the
+   Monotype lowering site that emits `if_initialized_payload` and decide:
+   if `payload` is construct-bound, add it to the bound set in
+   `collectExpr` (mirroring match binders) and confirm no capture slot
+   for it survives — the over-capture disappears; if it is an outer
+   local, state that in a comment on both the collect and rewrite arms
+   citing the producer. Either way the ambiguity dies.
+3. **L3 — verify the override.** Extend the keyed capture verifier to
+   cover the override path: when `operandValueForSlotId` accepts a value
+   whose current id differs from the operand's stored id, Debug-assert
+   the *stored* id does not match any other slot in the same span (the
+   coincidental-collision case). If spec_constr can be cheaply taught to
+   rewrite stored operand ids at substitution time instead, prefer that —
+   it deletes the tolerance rather than guarding it — but only if the
+   rewrite is genuinely local; otherwise the assert suffices.
+
+## What success looks like
+
+- Exactly one capture-fixpoint driver exists; `recomputeCaptures` and the
+  Lifter call the same function.
+- `if_initialized_payload`'s payload is either bound (with the capture
+  slot gone) or documented as an outer local at both arms — not silently
+  split between the two readings.
+- The override path is covered by the verifier; a synthetic
+  colliding-id case trips it in Debug.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- Post-spec_constr capture sets are the same computation as initial-lift
+  capture sets, by construction. The existing verifier (which already
+  runs after both) becomes a check on one algorithm, not a referee
+  between two.
+- Behavioral: full snapshot corpus and cross-opt eval corpus unchanged.
+  If L2 resolves to "bound", closures containing the construct shrink by
+  one capture slot — confirm via the Debug capture verifier and spot-check
+  one affected closure's capture record; no other output may change.
+
+### Performance ideal
+
+Zero release-cost change from L1/L3 (refactor + Debug assert). L2's
+bound resolution removes a capture slot from affected closures — a small
+size/copy win, not a regression risk. Debug corpus time parity.
+
+## Tests to add
+
+- L1: a unit test running lift, a body-mutating rewrite, and
+  `recomputeCaptures`, asserting capture sets match a from-scratch lift
+  of the rewritten program (the two-derivations-agree property, now
+  trivially true, pinned against future re-forking).
+- L2: whichever resolution — a program exercising
+  `if_initialized_payload` inside a closure, asserting the expected
+  capture set (with or without the payload slot).
+- L3: a Debug unit test constructing the coincidental-collision case
+  (operand stored id matching a sibling slot, value carrying a different
+  live id), asserting the new verifier check fires.
+
+## Related projects
+
+- [spec-constr-specialization-limits.md](./spec-constr-specialization-limits.md)
+  — same pass pairing: spec_constr is why `recomputeCaptures` exists.
+- [store-generation-counters.md](./store-generation-counters.md) — the
+  landed guarded-store work; L1's refactor must keep using the guarded
+  span APIs it introduced.

--- a/projects/small/monotype-machinery-hardening.md
+++ b/projects/small/monotype-machinery-hardening.md
@@ -1,0 +1,234 @@
+# Monotype Machinery Hardening: Verification Cost, Digest Depth, Graph Memos
+
+## Problem
+
+The 2026-07 comparative review of the Monotype stage against the cor `lss`
+prototype confirmed the core machinery is sound (memoized instantiation
+with placeholder-before-recurse, path-compressed union-find, structural
+equality as the specialization-cache authority) and found no algorithmic
+regression versus the prototype. What it did find is a cluster of bounded
+hardening items — one design-policy violation, one measured-risk fallback,
+and three could-not-disprove memos — none big enough for its own project,
+all in the same few files:
+
+**H1 — verification-only `sameType` checks run in release builds.**
+`sameType` (`src/postcheck/monotype/lower.zig:16354`) structurally compares
+two monotypes, computing SHA-256 digests via `typeDigestCached`
+(`monotype/type.zig:589`) when the fast paths miss. Its call sites split
+into two classes: *semantic* uses whose result feeds real control flow
+(e.g. `lower.zig:6661`, `:7742`), and *verification* uses of the form
+`if (!sameType(...)) Common.invariant(...)` (e.g. `lower.zig:8968`,
+`:9017`, `:9290`, `:3863`, and the `lowerExprAtType` reconciliation guards
+around `:16295-16348`). `Common.invariant` is `unreachable` in release
+(`postcheck/common.zig:105-110`), but the *condition computation* still
+executes (digest memoization mutates the cache, so the optimizer cannot
+drop it). design.md is explicit: post-check stages "do not add
+release-build runtime checks for compiler invariants" — these checks
+predate that discipline being applied here, and cor does zero per-node
+cross-checking at this stage. The digest cache is properly granular
+(generation bumps only on reserved-slot refill, `type.zig:299`, with a
+test pinning it), so the cost is bounded — but it is nonzero, on the
+hottest lowering path, buying nothing in release.
+
+**H2 — digest depth fallback degrades to identity hashing at depth 256.**
+Both digest walks stop recursing at `digest_visiting_max = 256`
+(`monotype/type.zig:633`) and hash the raw `@intFromEnum(ty)` instead
+(`:756`, `:970-976`). Two structurally identical types deeper than 256
+with different TypeIds then get different digests, land in different
+specialization buckets, and `typeEql` (which has a cycle guard but no
+depth cap) is never consulted — duplicate specialization of identical
+functions. Correctness-preserving (identical duplicates, never a false
+merge), but a silent-cap code-size/compile-time cost with no counter.
+
+**H3 — `processed_relations` is a permanent cross-call unify memo that
+could not be proven safe.** `unifyRoots` skips any node pair whose
+version-stamped relation was ever processed
+(`monotype/solve.zig:571-572`); the map lives for the whole graph
+(`:226`). Re-unification is re-enabled only by a version bump, and
+`union_` bumps only the winner's version (`:~506`). The review could not
+construct a missed-constraint case — and could not prove one impossible.
+An untested load-bearing memo in the unifier deserves a targeted stress
+test more than trust.
+
+**H4 — specialization-key refinement can split what cor shared.** The
+spec cache keys on (callable, checked source digest, request digest)
+(`monotype/specialize.zig` header, `SpecLookupAddress`); cor keyed on
+(symbol, lowered monotype) (`specializations.ml:15`). The added source
+component can only *split* buckets, never merge them — sound, but the
+same monomorphic instantiation reached via two distinct checked source
+types emits two byte-identical specializations. Unmeasured; if material
+on real programs it is compile-time and code-size waste.
+
+**H4b — two documented-trust hazards in the type store, guard with
+comments and one audit.** (i) The *full* `typeDigest` hashes a plain
+nominal's backing while `typeEql` compares plain nominals by
+identity+args and ignores backing — the two authorities diverge for
+equal-identity/different-backing pairs. The spec cache is safe (it keys
+on the identity-only `specializationDigest`, consistent with `typeEql`),
+and a false merge would need a SHA-256 collision; the hazard is any
+*other* consumer using the full digest as a sole identity, which yields
+avoidable duplicate identities. Audit full-digest consumers once, then
+pin the invariant with a comment on both digest modes. (ii) `Store.add`
+(`type.zig:253`) trusts callers to pre-sort record fields and tag rows;
+digest and equality are positional, and only `Store.verify` (Debug)
+catches an unsorted row. Sealing always routes through the sorting
+adders today — say so on `add` itself so a future direct caller learns
+the contract before shipping a type whose digest and equality disagree
+with its sorted twin.
+
+**H5 — three micro-costs.** `union_` (`solve.zig:499`) has no
+union-by-rank/size (path compression in `find`, `:407`, keeps this
+near-harmless, but adversarial merge orders exist); `layoutOfType`
+(`src/postcheck/solved_lir_lower.zig:6714`) allocates an
+O(total-type-count) scratch array per cache miss (`:6725`) instead of
+O(reachable subgraph); `captureBindingForLocal`
+(`solved_lir_lower.zig:833`) falls back to a linear scan of the captures
+map on a direct-key miss (bounded by a function's capture count — note
+and fix only if the direct key can be made total).
+
+**H6 — the cross-store specialization reuse path is unverified.**
+Loaded (cache-shard) specialization reuse compares a live request against
+a deserialized record with `typeEqlAcrossStores`
+(`monotype/specialize.zig:367`), and reserved records get a one-time
+request-view refinement (`refineReservedRequestView`) — both
+production-only surfaces with no cor analog and no targeted test. The
+review flagged (without finding a bug) the question of whether a
+reserved record's refinement can narrow a view another in-flight
+requester already matched against. This wants a test, not trust.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck:
+**Monotype IR** (`src/postcheck/monotype/`: per-spec instantiation graphs
+in `solve.zig`, interned monotypes and digests in `type.zig`,
+specialization identity in `specialize.zig`, body lowering in `lower.zig`)
+→ Monotype Lifted → Lambda Solved → Lambda Mono decisions → LIR → ARC →
+backends. design.md is authoritative, particularly the invariant policy
+(Debug assertion / release unreachable, zero release verification cost)
+and the TypeDigest doctrine (digests identify closed structural content;
+graph nodes are never cached by digest).
+
+This is a measure-first project: H1 and H5 want profiles before surgery,
+H2 and H4 want counters before redesign, H3 wants a test before any code
+change. The deliverable is as much the measurements as the fixes.
+
+## Evidence
+
+All symbols verified in the current tree.
+
+- `src/postcheck/monotype/lower.zig`: `sameType` (`:16354`), semantic uses
+  (`:6661`, `:7742`), verification-only uses (`:3806`, `:3863`, `:3971`,
+  `:8834`, `:8968`, `:9017`, `:9063`, `:9290`, `:9528`, `:9560`, and the
+  at-type reconciliation cluster `:~16295-16348`).
+- `src/postcheck/monotype/type.zig`: `typeDigestCached` (`:589`),
+  generation bump only in `fillReservedSlot` (`:296-299`) with the
+  invalidation test (`:2533`); `digest_visiting_max = 256` (`:633`), deep
+  fallbacks (`:756`, `:970-976`).
+- `src/postcheck/monotype/solve.zig`: `find` with path compression
+  (`:407`), `union_` without rank (`:499`), `processed_relations`
+  (`:226`, skip at `:571-572`).
+- `src/postcheck/monotype/specialize.zig`: keying doctrine (header),
+  `SpecLookupAddress` construction sites (`:242`, `:258`, `:320`).
+- `src/postcheck/solved_lir_lower.zig`: `layoutOfType` (`:6714`),
+  per-miss `local_nodes` allocation (`:6725-6727`).
+- cor references: `monotype/specializations.ml:15` (structural key),
+  `monotype/lower.ml` (no per-node cross-checking).
+
+## Solution design
+
+1. **H1 — classify, then gate.** Audit every `sameType` call site into
+   semantic vs verification-only (the grep list above is the starting
+   set; the classification is the reviewable artifact). Wrap
+   verification-only sites in `if (builtin.mode == .Debug)` so the release
+   branch is compile-time dead, per design.md's verifier rule. Semantic
+   sites stay. Measure Monotype lowering time on the corpus before/after
+   in ReleaseFast; whatever the number, the policy violation goes away.
+2. **H2 — count, then decide.** Debug counter on the deep fallback; run
+   the corpus and the deep-nesting stress test below. If it never fires
+   outside the stress test, raise nothing and keep the counter as the
+   tripwire (documented cap, no longer silent). If it fires on real code,
+   switch the fallback from identity-hash to a truncated structural
+   summary (hash the content one level deep) so equal types keep equal
+   digests with bounded work.
+3. **H3 — stress test the memo.** A solver-level test that unifies, then
+   mutates row content through the sanctioned mutation paths, then
+   re-unifies the same roots, asserting the second unification is not
+   skipped while content differs (probe via sealed results, not
+   internals). If the test finds a skip, the fix is bumping the loser's
+   root version in `union_` alongside the winner's; if it cannot, the
+   memo gets a comment stating the version-bump argument it relies on.
+4. **H4 — measure duplicate emission.** Debug-build pass over
+   `SpecBuilder` records at teardown: group by (callable, request digest)
+   and count groups with >1 record whose solved monotypes are `typeEql`.
+   Report the count and total duplicated body size on the corpus. If
+   material (judgment: >1% of specs or any hot builtin duplicated), add a
+   content-keyed reuse alias (the digest machinery already exists) —
+   *as alias entries, never a rekey*, per the store's identity doctrine.
+5. **H5 — smallest fixes last.** Union-by-size in `union_` is a few lines
+   (store sizes alongside `versions`); take it only if a profile shows
+   `find` chains at all. `layoutOfType`: replace the per-miss full-store
+   array with a reusable scratch map (or per-Lowerer array allocated
+   once), sized by what the graph actually visits.
+6. **H6 — test the cross-store reuse contract.** Two tests: (a) a
+   two-shard round trip where a loaded record is reused by a live request
+   whose type is structurally equal across stores, and a near-miss
+   variant (one leaf differs) asserting no reuse; (b) a concurrency-shaped
+   sequential test of the reserved-refinement window — reserve, match a
+   second requester against the pre-refinement view, refine, assert the
+   second requester's reuse decision is still consistent with the
+   refined record (or that the ordering is impossible by construction,
+   asserted at the refinement site).
+
+## What success looks like
+
+- Zero verification-only `sameType` computation in ReleaseFast Monotype
+  lowering (verified by inspecting one representative call site's release
+  assembly, or by a `comptime` mode split making the dead branch
+  structural).
+- H2/H4 counters exist, ran on the corpus, and their numbers are recorded
+  in the PR description; each either triggered its fix or pinned the
+  do-nothing decision with data.
+- The H3 stress test exists and passes, whichever way it resolved.
+- Corpus compile time (ReleaseFast build of the compiler, timing the
+  Monotype stage on roc-parser + examples) at parity or better; use CI
+  benchmarks, not local timing.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- No behavior change on checked programs, at all, in any item: H1 removes
+  release-dead checks, H2/H4 deduplicate identical work, H3 is a test,
+  H5 is allocation shape. Full snapshot corpus + cross-backend eval
+  corpus bit-identical output is the acceptance bar (H4's dedup may
+  change proc ordering in the LIR store; if so, assert semantic
+  equivalence via the eval corpus and note the ordering delta).
+
+### Performance ideal
+
+- Monotype stage time strictly ≤ baseline on CI benchmarks; H1 is the
+  expected win.
+- `--opt=speed` binary size ≤ baseline (H4's dedup is the only item that
+  can move it).
+
+## Tests to add
+
+- Deep-nesting stress: a generated 300-level nested record/tag type
+  compiled twice via paths yielding distinct TypeIds; asserts one
+  specialization (post-H2-fix) or documents two (pre-fix, counter test).
+- The H3 re-unification stress test described above.
+- H4 duplicate-emission counter test: two checked source types
+  instantiating to the same monotype; asserts the counter sees them, and
+  (if the fix lands) that one body is emitted.
+- A `builtin.mode` compile test or assembly-grep guard pinning that the
+  gated `sameType` sites contribute no release code (mirrors the
+  GuardedList release-layout test pattern).
+
+## Related projects
+
+- [store-generation-counters.md](./store-generation-counters.md) — the
+  landed guarded-store work whose release-zero-cost discipline H1 copies.
+- [pin-deferred-spec-requests.md](./pin-deferred-spec-requests.md) — the
+  live correctness project in the same solver; land that first if both
+  are in flight, since H3's stress test will exercise the same
+  deferred-request paths it changes.

--- a/projects/small/pin-lambda-solved-invariants.md
+++ b/projects/small/pin-lambda-solved-invariants.md
@@ -1,0 +1,196 @@
+# Pin the Lambda Solved Stage's Load-Bearing Invariants
+
+## Problem
+
+The Lambda Solved stage (`src/postcheck/lambda_solved/`) is the semantic
+heart of closure compilation: it decides which lambdas can flow to which
+call sites. The cor `lss` prototype it was productionized from solves this
+with a full Hindley-Milner-style pass — generalization, per-use
+instantiation, and SCC-ordered solving (`lambdasolved/solve.ml`,
+`defs_graph.ml`, `inst.ml`). Production deliberately dropped all three and
+solves monomorphically over shared type nodes. The 2026-07 comparative
+review confirmed this is sound — but only because of four upstream
+invariants that are nowhere stated, asserted, or tested at this stage's
+boundary. Each is a silent-wrong-code bug if it ever breaks, because the
+stage has no mechanism left that would catch the violation:
+
+**I1 — FnId granularity (the big one).** Sharing type nodes across a
+function's call sites computes the *union* of lambda sets over those
+sites. That is the correct set only because Monotype specialization keys
+every `LiftedFnId` on the checked source function type digest
+(`src/postcheck/monotype/specialize.zig` header, `source_digest` at
+`:112-127`), which includes lambda-set structure — so two call sites
+needing different lambda sets always land in different FnIds. If any path
+ever produces one FnId for two checked-lambda-set-distinct instantiations,
+Lambda Solved merges their sets silently and dispatch calls the wrong
+function. No error, no panic — wrong behavior at runtime.
+
+**I2 — Positional capture matching.** `unifyCaptures`
+(`lambda_solved/solve.zig:1473`) matches capture lists positionally,
+asserting `capture_id` equality per index. cor matches by symbol-set,
+order-independent. Production's positional match is correct only because
+every member's captures always come from the same FnId's capture span in
+the same order — an invariant that holds today by construction and is
+enforced only by `Common.invariant` (Debug-only per design.md policy).
+
+**I3 — Lambda-set member order.** `mergeLambdaSets`
+(`lambda_solved/solve.zig:1452`) appends new members in encounter order;
+cor keeps members canonically sorted by lambda symbol. Order is
+deterministic but traversal-dependent. It is safe today because every
+consumer (variant construction and dispatch in Lambda Mono decisions /
+direct LIR lowering) reads the *same* span — but nothing pins that a
+consumer never materializes order-sensitive data (discriminants) from two
+differently-ordered copies.
+
+**I4 — Erasure trigger completeness.** cor erases closures at explicit
+`~erase`/`~unerase` kernel calls (`lambdasolved/erased.ml`). Production
+re-derives erasure from structure: `markErasedCallablesReachedByType`
+(`lambda_solved/solve.zig:924`) fires on box ops (`:1080`, `:1085`) and on
+every layout request (`:155`) and runtime schema request (`:166`). Nothing
+argues these triggers cover every position where a callable's
+specialization becomes unknowable; a missed trigger means a finite
+lambda-set representation crosses a boundary that needed the erased
+encoding.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck:
+Monotype IR (monomorphization; specialization identity in
+`monotype/specialize.zig`) → Monotype Lifted → **Lambda Solved** → Lambda
+Mono decisions → LIR → ARC → backends. `design.md` is authoritative; its
+invariant policy (debug assertion / release unreachable, no release-build
+invariant checks) governs the form every new check takes.
+
+This project is deliberately test-and-assert-heavy rather than
+code-change-heavy: the review found no violation of I1–I4 in the current
+tree. The work is making each invariant *stated* (a comment at the
+consuming site naming the producer), *asserted* (Debug checks at the stage
+boundary), and *tested* (end-to-end programs that would fail today if the
+invariant broke), so the next refactor of Monotype specialization or
+lambda-set merging cannot break one silently.
+
+## Evidence
+
+All symbols verified in the current tree.
+
+- `src/postcheck/lambda_solved/solve.zig`: global fn-type pre-registration
+  before any body solves (`:131-147`), no SCC/generalization machinery
+  anywhere in the stage; `unifyCaptures` positional loop (`:1473`);
+  `mergeLambdaSets` append-in-encounter-order (`:1452-1471`);
+  `markErasedCallablesReachedByType` (`:924`) and its three trigger sites
+  (`:155`, `:166`, `:1080`, `:1085`); `closeUnfilledCallableSlots`
+  (`:279`) as the end-of-stage sweep that finalizes callable slots.
+- `src/postcheck/monotype/specialize.zig`: identity doctrine in the header
+  ("callable, checked source function type digest, requested type —
+  written once, never rewritten"), `source_digest` (`:112-127`).
+- cor reference: `lambdasolved/solve.ml` (gen/inst), `defs_graph.ml`
+  (SCC), `inst.ml` (per-use instantiation), `erased.ml` (explicit erasure
+  propagation) — all deliberately absent from production.
+- Review provenance: 2026-07 cor-vs-production comparative review, Lambda
+  Solved stage report.
+
+## Solution design
+
+1. **I1 — test and boundary assert.** End-to-end tests (below) that fail
+   with wrong output if two lambda sets merge. Plus a Debug check at
+   Lambda Solved intake: for every pair of distinct FnIds sharing a source
+   symbol, assert their checked source digests differ (the cheap
+   contrapositive of "same digest ⇒ same FnId", catchable at the boundary
+   without re-deriving lambda sets).
+2. **I2 — state and assert at the producer.** Document the ascending-order
+   contract on the capture span where members are built, and add a Debug
+   assert at `unifyCaptures` entry that both spans are `capture_id`-sorted
+   (today's per-index equality assert catches mismatches only after
+   partially unifying).
+3. **I3 — canonicalize instead of documenting.** Sort members by lambda
+   `Symbol` at creation and in `mergeLambdaSets` (cor's behavior). This
+   deletes the invariant rather than pinning it: member order becomes
+   canonical, and any future consumer that materializes order-derived data
+   is safe by construction. Confirm Lambda Mono decisions and the direct
+   LIR lowerer assign variant indices from the (now canonical) span, and
+   that the Debug Lambda Mono verifier still matches.
+4. **I4 — erasure audit with a closing check.** Enumerate the positions
+   where a callable type can reach a representation-committing boundary
+   (layout roots, schema roots, box payloads, const-store materialization,
+   host ABI surfaces), confirm each routes through
+   `markErasedCallablesReachedByType`, and add the closing Debug sweep:
+   after `closeUnfilledCallableSlots`, no type reachable from a layout or
+   schema request may contain a *finite* lambda-set whose layout was
+   committed as erased, and vice versa. The sweep turns "we think the
+   triggers are complete" into a per-program proof.
+5. **Def ordering (minor, document only).** cor SCC-orders output defs;
+   production emits source order (`solve.zig:134-142`). Confirm no
+   consumer assumes dependency order (LIR uses explicit references) and
+   say so in the stage doc comment.
+6. **`returnTargetTy` re-derivation (minor).** `returnTargetTy`
+   (`solve.zig:900-907`) licenses reusing the enclosing function's solved
+   return slot by structurally comparing monotypes (`sameMonoType`,
+   `:909-912`, a full `typeEql` per `return_` statement) — a
+   verification-flavored re-derivation where a direct id link would be
+   authoritative. Carry the return target's solved type var explicitly
+   from where the return context is entered, and demote the structural
+   compare to a Debug assert. Same shape, smaller scale, as the other
+   items: replace a re-derived fact with a carried one. (This also
+   removes a per-return structural walk from release builds; while in the
+   file, note the two stage-level perf micro-costs for the same audit:
+   `solvedTypeDigest`'s SHA-256 walk per erased callable (`:1485+`) and
+   the fresh `AutoHashMap` allocated per `markErasedCallablesReachedByType`
+   call (`:925`) — pool the map if profiling ever surfaces it; neither
+   needs action beyond a comment today.)
+
+## What success looks like
+
+- Each of I1–I4 is named in a comment at its consuming site, Debug-asserted
+  at a boundary (not deep inside a unify loop), and covered by an
+  end-to-end test that fails on violation.
+- I3 no longer exists: member order is canonical by construction.
+- The I4 closing sweep runs on the full snapshot corpus and CLI suite in
+  Debug CI with zero firings.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- The stage's soundness argument is written down and machine-checked: a
+  reviewer can read the intake asserts and the closing sweep and conclude
+  "monomorphic solving is sound for this input" without trusting folklore.
+- Behavioral: full snapshot corpus and cross-backend eval corpus
+  unchanged; canonical member ordering must not change any program's
+  output (dispatch is by matched symbol, not position — if any output
+  changes, that is a latent I3 consumer, which is exactly what the change
+  exists to surface).
+
+### Performance ideal
+
+Sorting members costs O(set size log set size) at merge points on sets that
+are almost always tiny (1–3 members); boundary asserts and the closing
+sweep are Debug-only. Release stage time on the corpus: parity within
+noise. Zero effect on generated code (verify: bit-identical `--opt=speed`
+output on the corpus before/after, modulo the I3 caveat above).
+
+## Tests to add
+
+- **I1 dispatch matrix** (the review's highest-value missing test): one
+  polymorphic higher-order function applied at the same value types with
+  two different closures (different captures, different bodies), both
+  paths' results asserted; variants with the closures defined in
+  different modules, with a recursive closure, and with one closure
+  reaching the call through a data structure. Today these pass; they must
+  fail loudly if FnId granularity ever coarsens.
+- **I2/I3 unit tests** over the solver: merge two lambda sets built in
+  opposite encounter orders; assert canonical result order and correct
+  capture unification.
+- **I4 boundary matrix**: a function value (a) stored in a box, (b) in a
+  record requested as a layout root, (c) in a value crossing the host ABI,
+  (d) inside a const-materialized structure — each compiled and run;
+  Debug closing sweep clean on all four.
+- Debug-build corpus run asserting zero firings of every new assert.
+
+## Related projects
+
+- [empty-tag-union-yield-provenance.md](./empty-tag-union-yield-provenance.md)
+  — the same stage's other shape-keyed assumption, split out because it
+  needs a carry-vs-verify design decision.
+- [cross-phase-coverage-parity-tests.md](./cross-phase-coverage-parity-tests.md)
+  — the same producer/consumer parity discipline; its harness is the
+  natural home for the I1 intake assert's corpus run.

--- a/projects/small/spec-constr-specialization-limits.md
+++ b/projects/small/spec-constr-specialization-limits.md
@@ -1,0 +1,178 @@
+# Specialization Limits for spec_constr
+
+## Problem
+
+The call-pattern specialization pass has no spec-count, shape-depth, or fuel
+limit of any kind (verified by search: no cap identifier exists in
+`src/postcheck/monotype_lifted/spec_constr.zig`). GHC's SpecConstr — the
+pass's cited ancestor — ships `-fspec-constr-count` and depth limits
+precisely because call-pattern specialization can manufacture ever-deeper
+patterns and diverge. This implementation can too, and the divergent path is
+concrete:
+
+- `createSpecializations` loops `while (wrote_spec)`
+  (`spec_constr.zig:484`); writing a specialization can append new specs,
+  keeping the loop alive.
+- New specs are spawned *during cloning* by `ensureCallPatternForValues`
+  (`spec_constr.zig:853`), which records a `Spec` for any new
+  constructor-shaped pattern. Dedup is exact-structural
+  (`patternEql`/`shapeEql`), so a strictly deeper shape is never deduped.
+- The spawn site for a recursive self-call: when the callee is already on
+  `inline_stack` (the guard that prevents infinite *inlining*,
+  `spec_constr.zig:~2699`), cloning falls back to the plain path
+  (`cloneExprPlain` → `cloneCallProc` → `ensureCallPatternForValues`). The
+  recursion guard against infinite inlining is exactly what feeds unbounded
+  *specialization*.
+- Shape growth: cloning substitutes the specialized parameter with its known
+  `Value`; if the body's recursive call wraps that parameter in a
+  constructor, the resulting value is one constructor deeper,
+  `shapeFromValue` (`spec_constr.zig:1276`, no depth cap) yields a deeper
+  `Shape`, and a new distinct spec is recorded. The next round deepens
+  again.
+
+Failure scenario, expressible in ordinary Roc — a function that matches a
+recursive tag-union parameter and rebuilds it one constructor deeper on the
+recursive call:
+
+```roc
+Tree : [Leaf, Node(Tree, I64)]
+deepen = |t, n| when t is
+    Leaf -> if n == 0 then Leaf else deepen(Node(Leaf, n), n - 1)
+    Node(_, _) -> if n == 0 then t else deepen(Node(t, n), n - 1)
+```
+
+`t` is deconstructed (so its argument position is specializable), and each
+recursive call passes `Node(<known t>, _)` — specs for `Node(Leaf)`,
+`Node(Node(Leaf))`, … are generated without bound: a compile-time infinite
+loop. All shapes and values live in `pass.arena` and are freed only at pass
+end, so non-termination is also unbounded memory. Consumer-style recursion
+(passing sub-parts; shapes shrink or stabilize) and the intended
+Stream/Iter pipelines (static, finite nesting) are safe; the risk is
+specifically match-and-rebuild-deeper. The pass runs whenever
+`inline_mode != .none` (`src/lir/checked_pipeline.zig:237-239`), i.e. in
+every optimized build.
+
+A secondary quality defect in the same machinery: `rewriteCallProc` /
+`cloneCallProc` select the **first** matching spec in insertion order, so a
+more-general pattern recorded earlier shadows a more-specific one recorded
+later — correctness-neutral, but the call gets a less-specialized worker.
+
+This project comes out of the 2026-07 comparative review of postcheck
+against the cor `lss` prototype it was productionized from; spec_constr has
+no cor counterpart, so it lacks the reference-implementation scrutiny the
+rest of the pipeline got.
+
+## Background
+
+The compiler pipeline: parse → canonicalize → type-check → postcheck:
+Monotype IR → **Monotype Lifted** (closure lifting; plus `spec_constr.zig`
+call-pattern specialization for optimized builds) → Lambda Solved → Lambda
+Mono decisions → LIR → ARC → backends. `design.md` is authoritative.
+
+spec_constr records constructor-shaped call patterns at direct calls,
+reserves worker function ids per pattern, and clones each source function
+into per-pattern workers over a symbolic `Value` environment that folds
+field reads and known matches and inlines known calls. Specialization is an
+optimization: the sound fallback for "don't specialize this call" is to
+leave the original direct call in the output. A cap therefore never costs
+correctness — only optimization on pathological shapes that today do not
+compile at all.
+
+## Evidence
+
+All symbols verified in the current tree.
+
+- `src/postcheck/monotype_lifted/spec_constr.zig`: `createSpecializations`
+  drain loop (`:482-498`), `ensureCallPatternForValues` (`:853`),
+  `shapeFromValue` with no depth cap (`:1276`), `inline_stack` membership
+  check feeding the plain-clone fallback (`:~2699`, append at `:2767`),
+  exact-structural `patternEql`/`shapeEql` (`:~4014`), arena-lifetime shape
+  storage. No `limit`/`fuel`/`cap`/`max_*` identifier in the file.
+- `src/lir/checked_pipeline.zig:237-239`: pass gated only on
+  `inline_mode != .none`.
+- GHC precedent: SpecConstr's `-fspec-constr-count` / `-fspec-constr-recursive`
+  exist for exactly this divergence class.
+
+## Solution design
+
+1. **Per-source-function spec budget.** A comptime constant (GHC's default
+   count is 3; start near that, tune on the corpus). `ensureCallPatternForValues`
+   checks the count of specs already recorded for the source function; at
+   the cap it records nothing and the call lowers as the ordinary direct
+   call. The `while (wrote_spec)` drain then terminates structurally:
+   total specs ≤ functions × budget.
+
+2. **Shape-depth cap in `shapeFromValue`.** Constructor nesting beyond a
+   small comptime depth (e.g. 8) degrades that subtree to the opaque
+   "any value" shape rather than a deeper pattern. This kills the
+   deepening ratchet even within the budget, and keeps the specs that do
+   get minted shallow enough to match future calls (deep specs rarely
+   match anything again).
+
+3. **Most-specific spec selection.** When several recorded specs match a
+   call, prefer the most specific (deepest total shape) rather than
+   first-inserted. With the budget in place this is a handful of
+   comparisons per call.
+
+4. **No silent-cap invisibility.** Count cap hits in a Debug-build counter
+   surfaced by the pass's existing debug reporting, so a corpus run shows
+   how often the budget binds (per the no-silent-caps discipline).
+
+## What success looks like
+
+- The `deepen` repro above compiles under `--opt=speed` in bounded time and
+  memory, and runs correctly.
+- Total specs recorded for any source function never exceeds the budget;
+  the drain loop's termination no longer depends on the shape lattice being
+  finite.
+- On the existing corpus (examples, roc-parser suite, snapshot corpus),
+  `--opt=speed` output binaries are unchanged, or changed only where the
+  most-specific-selection fix picks a better worker.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+- A cap can only leave a residual direct call — never fold, redirect, or
+  specialize incorrectly. Cross-opt agreement (interpreter vs `--opt=dev`
+  vs `--opt=speed`) on the repro and the corpus is the ground truth.
+- Termination is structural (budget arithmetic), not empirical.
+
+### Performance ideal
+
+- Compile time on the corpus unchanged within noise (the caps should not
+  bind on realistic programs — confirm via the item-4 counter).
+- Runtime of specialization-benefiting benchmarks (Stream/Iter pipelines)
+  unchanged: the caps must be generous enough that the intended
+  specializations all still fire. Use CI benchmarks.
+
+## Tests to add
+
+Write the divergence regression first and confirm it hangs (or trips a
+timeout) on the unmodified tree:
+
+- `spec_constr_deepen`: the match-and-rebuild-deeper program under
+  `roc build --opt=speed` with the CLI test harness timeout
+  (`src/cli/test/parallel_cli_runner.zig` convention), asserting successful
+  build and correct run output.
+- A consumer-recursion control (list/tree fold that only destructures):
+  must still specialize (assert via the debug counter or emitted-spec
+  count) — pins that the caps don't lobotomize the pass.
+- Most-specific selection: a function called with both `Cons(1, Nil)`-shaped
+  and `Cons(x, xs)`-shaped patterns; assert the deeper-shaped call binds to
+  the deeper spec (unit-level test over the pass, or output-shape
+  assertion).
+- Budget tripwire: unit test constructing more distinct call patterns than
+  the budget for one function; asserts spec count == budget and all calls
+  still lower (residual direct calls).
+
+## Related projects
+
+- [spec-constr-static-match-soundness.md](./spec-constr-static-match-soundness.md)
+  — the same pass's match-verdict soundness; both projects touch
+  `bindPatToValue`-adjacent code and can share test scaffolding. Land in
+  either order.
+- [store-generation-counters.md](./store-generation-counters.md) — the
+  landed GuardedList work that already hardened this pass's
+  iterate-while-mutate hazards; this project addresses its termination
+  hazard.


### PR DESCRIPTION
Stacked on #10079. A stage-by-stage comparative review of the postcheck pipeline against the cor `lss` prototype it was productionized from found no shipped miscompile in the translated core — capture handling, dispatch lowering, and the type-cloning recursion guards all match the prototype, and several mechanisms are more robust than cor's — but it surfaced real remaining work: a reachable compile-time non-termination in spec_constr (no specialization budget, where GHC's SpecConstr ships one precisely for this divergence class), several unstated invariants that monomorphic lambda-set solving silently depends on (FnId-per-checked-lambda-set granularity, positional capture order, an empty-tag-union unification yield keyed on shape rather than provenance), fidelity gaps in the Debug Lambda Mono oracle, verification-only type comparisons still computing in release builds against design.md's zero-release-cost rule, and — once #10079 deletes the dead second lowerer — no body-level oracle anywhere for the fused solved-to-LIR path.

This adds seven projects/ specs capturing that work in the established format (six small, one big) and indexes them in projects/README.md as a second batch alongside the existing bugfix-analysis batch. It stacks on #10079 because the body-verification spec is premised on that PR's lir_lower.zig deletion and both branches edit projects/README.md.