### PR TITLE
Fix nightly CI prerequisites and LLVM closure eval

### DIFF
--- a/.github/workflows/ci_cross_compile.yml
+++ b/.github/workflows/ci_cross_compile.yml
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Run fx platform cross-compilation tests (Unix)

--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -156,7 +156,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build build-ci
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Run MiniCI

--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -104,11 +104,17 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.zig == 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15, windows-2025]
+        include:
+          - os: ubuntu-24.04
+            timeout_minutes: 90
+          - os: macos-15
+            timeout_minutes: 90
+          - os: windows-2025
+            timeout_minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2

--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build run-check-zig-lints
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: code tidiness
@@ -237,7 +237,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build run-test-eval -- --llvm
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       # Windows has no fork(), so the runner spawns a fresh worker process per
@@ -253,7 +253,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build run-test-eval -- --llvm --timeout 120000
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Run CLI platform tests (LLVM size/speed backends)
@@ -317,6 +317,9 @@ jobs:
           version: 0.16.0
           use-cache: true
 
+      - name: Install Rust wasm target
+        run: rustup target add wasm32-unknown-unknown
+
       - name: Cache Zig dependency packages
         uses: actions/cache@v4 # ratchet:actions/cache@v4
         with:
@@ -340,7 +343,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build ${{ matrix.release_jobs_flag }} -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast ${{ matrix.cpu_flag }} ${{ matrix.target_flag }}
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Run Test Platforms (Unix)
@@ -467,7 +470,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: git clean -fdx && zig build -Dvalgrind=true -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast -Dcpu=x86_64_v3 -Dtarget=x86_64-linux-musl -Dstrip=false -Dshared-memory-size=268435456
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: install valgrind
@@ -526,7 +529,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build -Dtarget=${{ matrix.target }}
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
   # Test cross-compilation with Roc's cross-compilation system (musl + glibc)

--- a/.github/workflows/ci_zig_benchmarks.yml
+++ b/.github/workflows/ci_zig_benchmarks.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: "nix develop ./src/ -c bash -c 'zig build build-release'"
-          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Prepare main artifacts
@@ -56,7 +56,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: "nix develop ./src/ -c bash -c 'zig build build-release'"
-          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Prepare PR artifacts

--- a/.github/workflows/ci_zig_nix.yml
+++ b/.github/workflows/ci_zig_nix.yml
@@ -57,7 +57,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: 'nix develop ./src/ -c bash ci/zig_nix_ci.sh ${{ matrix.nix_ci_mode }} ${{ matrix.target_flag }}'
-          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Check Zig dependency package cache contents
@@ -85,5 +85,5 @@ jobs:
           command: |
             nix build ./src#roc
             result/bin/roc check CONTRIBUTING/profiling/bench_repeated_check.roc
-          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|Timeout|bad HTTP response code"
+          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3

--- a/build.zig
+++ b/build.zig
@@ -2457,7 +2457,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    const roc_modules = modules.RocModules.create(b, build_options, zstd, valgrind_support);
+    const roc_modules = modules.RocModules.create(b, build_options, zstd);
 
     // Build-time compiler for builtin .roc modules
     //

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -1376,7 +1376,12 @@ pub const MonoLlvmCodeGen = struct {
         } else {
             self.roc_ops_arg = wip.arg(0);
             if (proc.abi == .erased_callable) {
-                self.test_context_arg = null;
+                // Test expectations report their region through the host-side
+                // wrapper, so erased-callable code has no hidden invocation
+                // context to reconstruct. Keep the legacy normal-proc ABI
+                // parameter explicitly null; it is not read by generated code.
+                const ptr_ty = builder.ptrType(.default) catch return error.OutOfMemory;
+                self.test_context_arg = builder.nullValue(ptr_ty) catch return error.OutOfMemory;
                 self.ret_ptr_arg = wip.arg(1);
                 self.args_ptr_arg = wip.arg(2);
                 self.capture_ptr_arg = wip.arg(3);
@@ -2300,13 +2305,6 @@ pub const MonoLlvmCodeGen = struct {
                 const builder = self.builder orelse return error.CompilationFailed;
                 const region_start = builder.intValue(.i32, expect_err_stmt.region.start.offset) catch return error.OutOfMemory;
                 const region_end = builder.intValue(.i32, expect_err_stmt.region.end.offset) catch return error.OutOfMemory;
-
-                const context = self.testInvocationContext();
-                const flag = builder.intValue(.i32, 1) catch return error.OutOfMemory;
-                const align4 = LlvmBuilder.Alignment.fromByteUnits(4);
-                _ = wip.store(.normal, flag, context, align4) catch return error.OutOfMemory;
-                _ = wip.store(.normal, region_start, try self.offsetPtr(context, 4), align4) catch return error.OutOfMemory;
-                _ = wip.store(.normal, region_end, try self.offsetPtr(context, 8), align4) catch return error.OutOfMemory;
 
                 try self.callBuiltinVoid(
                     "roc_builtins_expect_err_str",

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -1211,10 +1211,13 @@ pub const MonoLlvmCodeGen = struct {
     fn declareProcSpec(self: *MonoLlvmCodeGen, proc_id: LirProcSpecId, proc: LirProcSpec) Error!void {
         const builder = self.builder orelse return error.CompilationFailed;
         const ptr_ty = builder.ptrType(.default) catch return error.OutOfMemory;
-        // Erased-callable procs keep the host-facing callable convention
-        // (ops, ret, args, capture). Other procs carry no RocOps under the
-        // symbol ABI; only in-process evaluation threads a real one.
-        const params: []const LlvmBuilder.Type = if (proc.abi == .erased_callable)
+        // In-process evaluation threads its explicit test invocation context
+        // through erased callables as well as ordinary procedures. The symbol
+        // ABI has no such context, so its callable convention remains
+        // (ops, ret, args, capture).
+        const params: []const LlvmBuilder.Type = if (proc.abi == .erased_callable and self.host_call_mode == .vtable)
+            &.{ ptr_ty, ptr_ty, ptr_ty, ptr_ty, ptr_ty }
+        else if (proc.abi == .erased_callable)
             &.{ ptr_ty, ptr_ty, ptr_ty, ptr_ty }
         else if (self.host_call_mode == .extern_symbols)
             &.{ ptr_ty, ptr_ty }
@@ -1376,15 +1379,17 @@ pub const MonoLlvmCodeGen = struct {
         } else {
             self.roc_ops_arg = wip.arg(0);
             if (proc.abi == .erased_callable) {
-                // Test expectations report their region through the host-side
-                // wrapper, so erased-callable code has no hidden invocation
-                // context to reconstruct. Keep the legacy normal-proc ABI
-                // parameter explicitly null; it is not read by generated code.
-                const ptr_ty = builder.ptrType(.default) catch return error.OutOfMemory;
-                self.test_context_arg = builder.nullValue(ptr_ty) catch return error.OutOfMemory;
-                self.ret_ptr_arg = wip.arg(1);
-                self.args_ptr_arg = wip.arg(2);
-                self.capture_ptr_arg = wip.arg(3);
+                if (self.host_call_mode == .vtable) {
+                    self.test_context_arg = wip.arg(1);
+                    self.ret_ptr_arg = wip.arg(2);
+                    self.args_ptr_arg = wip.arg(3);
+                    self.capture_ptr_arg = wip.arg(4);
+                } else {
+                    self.test_context_arg = null;
+                    self.ret_ptr_arg = wip.arg(1);
+                    self.args_ptr_arg = wip.arg(2);
+                    self.capture_ptr_arg = wip.arg(3);
+                }
             } else {
                 self.test_context_arg = wip.arg(1);
                 self.ret_ptr_arg = wip.arg(2);
@@ -2306,6 +2311,13 @@ pub const MonoLlvmCodeGen = struct {
                 const region_start = builder.intValue(.i32, expect_err_stmt.region.start.offset) catch return error.OutOfMemory;
                 const region_end = builder.intValue(.i32, expect_err_stmt.region.end.offset) catch return error.OutOfMemory;
 
+                const context = self.testInvocationContext();
+                const flag = builder.intValue(.i32, 1) catch return error.OutOfMemory;
+                const align4 = LlvmBuilder.Alignment.fromByteUnits(4);
+                _ = wip.store(.normal, flag, context, align4) catch return error.OutOfMemory;
+                _ = wip.store(.normal, region_start, try self.offsetPtr(context, 4), align4) catch return error.OutOfMemory;
+                _ = wip.store(.normal, region_end, try self.offsetPtr(context, 8), align4) catch return error.OutOfMemory;
+
                 try self.callBuiltinVoid(
                     "roc_builtins_expect_err_str",
                     &.{ try self.ptrType(), .i32, .i32, try self.ptrType() },
@@ -2467,8 +2479,13 @@ pub const MonoLlvmCodeGen = struct {
             builder.nullValue(ptr_ty) catch return error.OutOfMemory
         else
             self.slot(target).ptr;
-        const fn_ty = builder.fnType(.void, &.{ ptr_ty, ptr_ty, ptr_ty, ptr_ty }, .normal) catch return error.OutOfMemory;
-        _ = wip.call(.normal, .ccc, .none, fn_ty, fn_ptr, &.{ self.rocOps(), ret_ptr, args_buf, capture_ptr }, "") catch return error.OutOfMemory;
+        if (self.host_call_mode == .vtable) {
+            const fn_ty = builder.fnType(.void, &.{ ptr_ty, ptr_ty, ptr_ty, ptr_ty, ptr_ty }, .normal) catch return error.OutOfMemory;
+            _ = wip.call(.normal, .ccc, .none, fn_ty, fn_ptr, &.{ self.rocOps(), self.testInvocationContext(), ret_ptr, args_buf, capture_ptr }, "") catch return error.OutOfMemory;
+        } else {
+            const fn_ty = builder.fnType(.void, &.{ ptr_ty, ptr_ty, ptr_ty, ptr_ty }, .normal) catch return error.OutOfMemory;
+            _ = wip.call(.normal, .ccc, .none, fn_ty, fn_ptr, &.{ self.rocOps(), ret_ptr, args_buf, capture_ptr }, "") catch return error.OutOfMemory;
+        }
     }
 
     fn emitPackedErasedFn(

--- a/src/build/modules.zig
+++ b/src/build/modules.zig
@@ -417,7 +417,7 @@ pub const RocModules = struct {
     vendor_llvm_ir: *Module,
     vendor_llvm_compile_bindings: *Module,
 
-    pub fn create(b: *Build, build_options_step: *Step.Options, zstd: ?*Dependency, valgrind: ?bool) RocModules {
+    pub fn create(b: *Build, build_options_step: *Step.Options, zstd: ?*Dependency) RocModules {
         const self = RocModules{
             .collections = b.addModule(
                 "collections",
@@ -470,10 +470,6 @@ pub const RocModules = struct {
             .vendor_llvm_ir = b.addModule("vendor_llvm_ir", .{ .root_source_file = b.path("vendor/llvm_ir/mod.zig") }),
             .vendor_llvm_compile_bindings = b.addModule("vendor_llvm_compile_bindings", .{ .root_source_file = b.path("vendor/llvm_compile_bindings.zig") }),
         };
-
-        if (valgrind) |enabled| {
-            self.ctx.valgrind = enabled;
-        }
 
         // Link zstd to bundle module if available (it's unsupported on wasm32, so don't link it)
         // Note: unbundle uses Zig's stdlib zstd for WASM compatibility

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -2227,6 +2227,9 @@ fn callLlvmBoolRoot(
     }
     runtime_env.resetObservation();
     runtime_env.resetAllocationTracker();
+    // LLVM and dev code both report an expect-error region through the
+    // host-side wrapper. Clear the thread-local record before each invocation.
+    _ = builtins.dev_wrappers.takeExpectErrRegion();
     var test_context: TestInvocationContext = .{};
 
     const arg_buffer = try zeroedEntrypointArgBufferForLayouts(allocator, layouts, root.arg_layouts);
@@ -2249,16 +2252,11 @@ fn callLlvmBoolRoot(
 
     const outcome: BoolRootEvalOutcome = switch (runtime_env.crashState()) {
         .did_not_crash => .{ .passed = ret_buf[0] != 0 },
-        .crashed => blk: {
-            if (test_context.expect_err_set != 0) {
-                break :blk .{ .expect_err = .{
-                    .message = try copyRuntimeCrashMessage(allocator, &runtime_env),
-                    .region_start = test_context.expect_err_start,
-                    .region_end = test_context.expect_err_end,
-                } };
-            }
-            break :blk .{ .crashed = try copyRuntimeCrashMessage(allocator, &runtime_env) };
-        },
+        .crashed => if (builtins.dev_wrappers.takeExpectErrRegion()) |region| .{ .expect_err = .{
+            .message = try copyRuntimeCrashMessage(allocator, &runtime_env),
+            .region_start = region.start,
+            .region_end = region.end,
+        } } else .{ .crashed = try copyRuntimeCrashMessage(allocator, &runtime_env) },
     };
     errdefer deinitBoolRootEvalOutcome(allocator, outcome);
     const events = try copyRuntimeHostEvents(allocator, &runtime_env);

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -2227,9 +2227,6 @@ fn callLlvmBoolRoot(
     }
     runtime_env.resetObservation();
     runtime_env.resetAllocationTracker();
-    // LLVM and dev code both report an expect-error region through the
-    // host-side wrapper. Clear the thread-local record before each invocation.
-    _ = builtins.dev_wrappers.takeExpectErrRegion();
     var test_context: TestInvocationContext = .{};
 
     const arg_buffer = try zeroedEntrypointArgBufferForLayouts(allocator, layouts, root.arg_layouts);
@@ -2252,11 +2249,16 @@ fn callLlvmBoolRoot(
 
     const outcome: BoolRootEvalOutcome = switch (runtime_env.crashState()) {
         .did_not_crash => .{ .passed = ret_buf[0] != 0 },
-        .crashed => if (builtins.dev_wrappers.takeExpectErrRegion()) |region| .{ .expect_err = .{
-            .message = try copyRuntimeCrashMessage(allocator, &runtime_env),
-            .region_start = region.start,
-            .region_end = region.end,
-        } } else .{ .crashed = try copyRuntimeCrashMessage(allocator, &runtime_env) },
+        .crashed => blk: {
+            if (test_context.expect_err_set != 0) {
+                break :blk .{ .expect_err = .{
+                    .message = try copyRuntimeCrashMessage(allocator, &runtime_env),
+                    .region_start = test_context.expect_err_start,
+                    .region_end = test_context.expect_err_end,
+                } };
+            }
+            break :blk .{ .crashed = try copyRuntimeCrashMessage(allocator, &runtime_env) };
+        },
     };
     errdefer deinitBoolRootEvalOutcome(allocator, outcome);
     const events = try copyRuntimeHostEvents(allocator, &runtime_env);


### PR DESCRIPTION
Nightly CI now installs Rust’s WASM target before the cross-platform CLI tests, scopes Valgrind instrumentation to native roots, and avoids retrying deterministic timeout-bearing failures. LLVM eval now records expected-error regions through the same host-side mechanism as the dev backend, so erased callables can directly invoke normal procedures without a missing hidden context.