### PR TITLE
Document range operators in langref

### DIFF
--- a/docs/langref/loops.md
+++ b/docs/langref/loops.md
@@ -9,12 +9,12 @@ A `for` loop lets you run code on each item in an [iterator](iterators). For exa
 ```roc
 var $sum = 0
 
-for n in 1.to(5) {
+for n in 1..<5 {
     $sum = $sum + n
 }
 ```
 
-> The `to` method returns a [range](numbers#ranges) which is an `Iter` of the number in question. For example, `I64.to` returns `Iter(I64)`, and so `n` in this example would be an `I64`.
+> `1..<5` is a [range](numbers#ranges): an `Iter` of the numbers from 1 up to (but not including) 5. Writing `1..=5` instead would include the 5. A range is an `Iter` of its bounds' type — for example, if the bounds are `I64` values, the range is an `Iter(I64)`, and so `n` in this example would be an `I64`.
 
 A loop body only includes statements; it does not have a final expression. The loop itself evaluates to `{}`.
 
@@ -34,7 +34,7 @@ for n in [1, 2, 3, 4] {
 }
 ```
 
-At runtime, this `[1, 2, 3, 4]` code snippet is exactly as efficient as the earlier `1.to(5)` one. In one case, `1.to(5)` will be evaluated to an `Iter` at compile time, and in the other, `[1, 2, 3, 4].iter()` will be evaluated at compile time to an identical `Iter`. By the time either program actually runs, they will have the same memory contents and will be executing the same instructions.
+At runtime, this `[1, 2, 3, 4]` code snippet is exactly as efficient as the earlier `1..<5` one. In one case, `1..<5` will be evaluated to an `Iter` at compile time, and in the other, `[1, 2, 3, 4].iter()` will be evaluated at compile time to an identical `Iter`. By the time either program actually runs, they will have the same memory contents and will be executing the same instructions.
 
 ### Pattern matching in `for`
 

--- a/docs/langref/numbers.md
+++ b/docs/langref/numbers.md
@@ -115,6 +115,36 @@ general trade-offs are:
 * Smaller integer sizes take up less memory. These savings rarely matter in variables and function arguments, but the sizes of integers that you use in data structures can add up. This can also affect whether those data structures fit in [cache lines](https://en.wikipedia.org/wiki/CPU_cache#Cache_performance), which can be a performance bottleneck.
 * Certain CPUs work faster on some numeric sizes than others. If the CPU is taking too long to run numeric calculations, you may find a performance improvement by experimenting with numeric sizes that are larger than otherwise necessary. However, in practice, doing this typically degrades overall performance, so be careful to measure properly!
 
+## Ranges
+
+The range operators build an [iterator](iterators) over a span of numbers.
+`start..<end` counts up from `start` to `end` without including `end`, and
+`start..=end` includes `end`:
+
+```roc
+var $sum = 0
+
+for n in 0..<3 {
+    $sum = $sum + n  # runs with n = 0, then 1, then 2
+}
+```
+
+Both bounds must have the same type, and the range is an `Iter` of that type:
+a `U8` range is an `Iter(U8)`, a `Dec` range is an `Iter(Dec)`, and so on.
+When nothing pins the bounds' type, range literals [default](#defaulting-to-dec)
+the same way other number literals do.
+
+A range counts up in steps of 1, and is empty when `start` is not below (`..<`)
+or at (`..=`) `end` — there are no reversed ranges. All the builtin number
+types support ranges, including the fractional ones: `0.5..<3.5` yields `0.5`,
+`1.5`, and `2.5`. For `F32` and `F64`, once the values are large enough that
+adding 1 can no longer produce a bigger float, the range yields that value once
+and then ends.
+
+Like the other operators, ranges use [static dispatch](static-dispatch#operators):
+`start..<end` calls the `range_exclusive` method on the bounds' type, and
+`start..=end` calls `range_inclusive`, so custom number types can support range
+syntax by defining those methods.
 
 ## Custom Number Types
 

--- a/docs/langref/operators.md
+++ b/docs/langref/operators.md
@@ -19,6 +19,8 @@ The method is selected at compile time from the operand types.
 | `<=` | `is_lte` |
 | `>` | `is_gt` |
 | `>=` | `is_gte` |
+| `..<` | `range_exclusive` |
+| `..=` | `range_inclusive` |
 | `-x` | `negate` |
 | `!x` | `not` |
 
@@ -44,6 +46,19 @@ in the static dispatch page.
 Comparison operators dispatch to methods that return `Bool`. Both operands must
 have the same type. See [Operators](static-dispatch.md#operators) in the static
 dispatch page.
+
+### Range Operators
+
+`start..<end` and `start..=end` build an [`Iter`](../builtins/Iter) over the
+numbers from `start` up to `end` — excluding `end` with `..<`, including it
+with `..=`. They dispatch to methods on the bound type: `..<` calls
+`range_exclusive` and `..=` calls `range_inclusive`. Both operands must have
+the same type, and the result is an `Iter` of that type. See
+[Ranges](numbers#ranges) in the numbers page.
+
+Range operators bind more loosely than the other binary operators, so
+`1..<n + 1` parses as `1..<(n + 1)`. They cannot be chained: `1..<5..<10` is
+an error.
 
 ### `??` (default value on `Err`)
 

--- a/docs/langref/static-dispatch.md
+++ b/docs/langref/static-dispatch.md
@@ -52,6 +52,7 @@ packages can define and require their own methods with `where` clauses.
 | `to_hash : T, Hasher -> Hasher` | `Dict`, `Set`, and hash-based APIs | Values of the type should participate in hashing. |
 | `plus`, `minus`, `times`, `div_by`, `div_trunc_by`, `rem_by` | `+`, `-`, `*`, `/`, `//`, `%` | The type has arithmetic-like operations. |
 | `is_lt`, `is_lte`, `is_gt`, `is_gte` | `<`, `<=`, `>`, `>=` | The type has an ordering. |
+| `range_exclusive : T, T -> Iter(T)`, `range_inclusive : T, T -> Iter(T)` | `..<`, `..=` | The type supports range syntax. |
 | `negate`, `not` | Unary `-`, unary `!` | The type has a unary negation or complement operation. |
 | `from_numeral : Num.Numeral -> Try(T, [InvalidNumeral(Str)])` | Number literals with target type `T` | Plain numeric literal syntax should construct the type. |
 | `from_quote : Str -> Try(T, [BadQuotedBytes(Str)])` | Quoted string literals with target type `T` | Plain quoted literal syntax should construct the type. |
@@ -174,6 +175,29 @@ must have the same type.
 | `<=` | `is_lte` |
 | `>` | `is_gt` |
 | `>=` | `is_gte` |
+
+Range operators dispatch to methods whose result is an `Iter` of the operand
+type. Both operands must have the same type.
+
+| Operator | Method |
+| --- | --- |
+| `..<` | `range_exclusive` |
+| `..=` | `range_inclusive` |
+
+All the builtin number types have these methods, and a custom type can support
+range syntax by defining them:
+
+```roc
+PageNum := { num : U32 }.{
+    range_exclusive : PageNum, PageNum -> Iter(PageNum)
+    range_exclusive = |start, end|
+        Iter.map(start.num..<end.num, |num| PageNum.{ num })
+}
+
+for page in first_page..<last_page {
+    render(page)
+}
+```
 
 Unary operators dispatch to methods whose argument and return type are the same:
 


### PR DESCRIPTION
The langref still described ranges as `to`/`until` method calls (which no longer exist) and linked to a `numbers#ranges` section that was never written. This documents the `..<` and `..=` operators as they now work after #10081: the operator desugaring tables on the operators and static dispatch pages gain `range_exclusive`/`range_inclusive` rows, the static dispatch page gets a short section with a custom-type example (verified to type-check), the numbers page gains the missing Ranges section (semantics, `Iter(bound)` result type, literal defaulting, float step-by-1 behavior, precedence), and the `for` loop examples use range syntax.