### PR TITLE
Make echo write without a newline

### DIFF
--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -7992,17 +7992,15 @@ pub const MonoLlvmCodeGen = struct {
             return error.CompilationFailed;
         }
 
-        try self.emitDefaultPlatformWriteLine(arg_ptrs[0]);
+        try self.emitDefaultPlatformWrite(arg_ptrs[0]);
 
         return true;
     }
 
-    fn emitDefaultPlatformWriteLine(self: *MonoLlvmCodeGen, str_ptr: LlvmBuilder.Value) Error!void {
+    fn emitDefaultPlatformWrite(self: *MonoLlvmCodeGen, str_ptr: LlvmBuilder.Value) Error!void {
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
         const usize_ty = self.ptrSizedIntType();
-        const static_newline = try self.staticBytes("\n");
-        const static_newline_len = builder.intValue(usize_ty, 1) catch return error.OutOfMemory;
 
         const raw_len = try self.loadUsize(try self.offsetPtr(str_ptr, self.rocStrLenOffset()));
         const is_small = wip.icmp(.slt, raw_len, builder.intValue(usize_ty, 0) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
@@ -8016,57 +8014,15 @@ pub const MonoLlvmCodeGen = struct {
         const last_byte = wip.load(.normal, .i8, try self.offsetPtr(str_ptr, last_byte_offset), LlvmBuilder.Alignment.fromByteUnits(1), "") catch return error.OutOfMemory;
         const small_len_byte = wip.bin(.@"and", last_byte, builder.intValue(.i8, 0x7f) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
         const small_len = try self.coerceScalar(small_len_byte, usize_ty, false);
-        const small_has_spare = wip.icmp(.ult, small_len, builder.intValue(usize_ty, self.targetWordSize() * 3 - 1) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
-        try self.emitDefaultPlatformWriteLineFromBuffer(str_ptr, small_len, small_has_spare, static_newline, static_newline_len, after);
+        try self.emitDefaultPlatformWriteStdout(str_ptr, small_len);
+        _ = wip.br(after) catch return error.OutOfMemory;
 
         wip.cursor = .{ .block = heap_block };
         const big_ptr = try self.loadPointer(str_ptr);
-        const cap_or_alloc = try self.loadUsize(try self.offsetPtr(str_ptr, self.rocStrCapacityOffset()));
-        const slice_tag = wip.bin(.@"and", cap_or_alloc, builder.intValue(usize_ty, 1) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
-        const not_slice = wip.icmp(.eq, slice_tag, builder.intValue(usize_ty, 0) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
-        const capacity = wip.bin(.lshr, cap_or_alloc, builder.intValue(usize_ty, 1) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
-        const has_spare = wip.icmp(.ugt, capacity, raw_len, "") catch return error.OutOfMemory;
-        const data_ptr = try self.loadStrDataPtrForRc(str_ptr);
-        const rc_offset: i64 = -@as(i64, @intCast(self.targetWordSize()));
-        const rc_ptr = wip.gep(.inbounds, .i8, data_ptr, &.{builder.intValue(.i32, rc_offset) catch return error.OutOfMemory}, "") catch return error.OutOfMemory;
-        const refcount = wip.load(.normal, usize_ty, rc_ptr, self.targetPointerAlignment(), "") catch return error.OutOfMemory;
-        const is_unique = wip.icmp(.eq, refcount, builder.intValue(usize_ty, 1) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
-        const writable_heap = wip.bin(.@"and", not_slice, is_unique, "") catch return error.OutOfMemory;
-        const heap_can_append = wip.bin(.@"and", writable_heap, has_spare, "") catch return error.OutOfMemory;
-        try self.emitDefaultPlatformWriteLineFromBuffer(big_ptr, raw_len, heap_can_append, static_newline, static_newline_len, after);
+        try self.emitDefaultPlatformWriteStdout(big_ptr, raw_len);
+        _ = wip.br(after) catch return error.OutOfMemory;
 
         wip.cursor = .{ .block = after };
-    }
-
-    fn emitDefaultPlatformWriteLineFromBuffer(
-        self: *MonoLlvmCodeGen,
-        ptr: LlvmBuilder.Value,
-        len: LlvmBuilder.Value,
-        can_append_newline: LlvmBuilder.Value,
-        static_newline: LlvmBuilder.Value,
-        static_newline_len: LlvmBuilder.Value,
-        after: LlvmBuilder.Function.Block.Index,
-    ) Error!void {
-        const builder = self.builder orelse return error.CompilationFailed;
-        const wip = self.wip orelse return error.CompilationFailed;
-        const usize_ty = self.ptrSizedIntType();
-
-        const append_block = wip.block(0, "echo_append_newline") catch return error.OutOfMemory;
-        const separate_block = wip.block(0, "echo_separate_newline") catch return error.OutOfMemory;
-        _ = wip.brCond(can_append_newline, append_block, separate_block, .then_likely) catch return error.OutOfMemory;
-
-        wip.cursor = .{ .block = append_block };
-        const newline_ptr = wip.gep(.inbounds, .i8, ptr, &.{len}, "") catch return error.OutOfMemory;
-        _ = wip.store(.normal, builder.intValue(.i8, '\n') catch return error.OutOfMemory, newline_ptr, LlvmBuilder.Alignment.fromByteUnits(1)) catch return error.OutOfMemory;
-        const len_with_newline = wip.bin(.add, len, builder.intValue(usize_ty, 1) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
-        try self.emitDefaultPlatformWriteStdout(ptr, len_with_newline);
-        _ = wip.store(.normal, builder.intValue(.i8, 0) catch return error.OutOfMemory, newline_ptr, LlvmBuilder.Alignment.fromByteUnits(1)) catch return error.OutOfMemory;
-        _ = wip.br(after) catch return error.OutOfMemory;
-
-        wip.cursor = .{ .block = separate_block };
-        try self.emitDefaultPlatformWriteStdout(ptr, len);
-        try self.emitDefaultPlatformWriteStdout(static_newline, static_newline_len);
-        _ = wip.br(after) catch return error.OutOfMemory;
     }
 
     fn emitDefaultPlatformWriteStdout(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, len: LlvmBuilder.Value) Error!void {

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -710,17 +710,17 @@ const all_syntax_expected_stderr =
 ;
 
 const echo_cases = [_]CliCase{
-    .{ .id = 0, .suite = .echo, .name = "echo platform: hello (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/hello.roc", .stdout_exact = "Hello, World!\n" } } },
-    .{ .id = 0, .suite = .echo, .name = "echo platform: hello (dev backend)", .backend = .dev, .skip = .{ .always = "TODO: dev backend default platform build does not provide roc_default_echo_line" }, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/hello.roc", .stdout_exact = "Hello, World!\n" } } },
-    .{ .id = 0, .suite = .echo, .name = "echo platform: multiple echo calls (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/multi.roc", .stdout_exact = "Hello, \nWorld!\n" } } },
-    .{ .id = 0, .suite = .echo, .name = "echo platform: multiple echo calls (dev backend)", .backend = .dev, .skip = .{ .always = "TODO: dev backend default platform build does not provide roc_default_echo_line" }, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/multi.roc", .stdout_exact = "Hello, \nWorld!\n" } } },
-    .{ .id = 0, .suite = .echo, .name = "echo platform: exit ok (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/exit_ok.roc", .stdout_exact = "success\n" } } },
-    .{ .id = 0, .suite = .echo, .name = "echo platform: exit ok (dev backend)", .backend = .dev, .skip = .{ .always = "TODO: dev backend default platform build does not provide roc_default_echo_line" }, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/exit_ok.roc", .stdout_exact = "success\n" } } },
+    .{ .id = 0, .suite = .echo, .name = "echo platform: hello (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/hello.roc", .stdout_exact = "Hello, World!" } } },
+    .{ .id = 0, .suite = .echo, .name = "echo platform: hello (dev backend)", .backend = .dev, .skip = .{ .always = "TODO: dev backend default platform build does not provide roc_default_echo_line" }, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/hello.roc", .stdout_exact = "Hello, World!" } } },
+    .{ .id = 0, .suite = .echo, .name = "echo platform: consecutive raw writes (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/multi.roc", .stdout_exact = "Hello, World!" } } },
+    .{ .id = 0, .suite = .echo, .name = "echo platform: consecutive raw writes (dev backend)", .backend = .dev, .skip = .{ .always = "TODO: dev backend default platform build does not provide roc_default_echo_line" }, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/multi.roc", .stdout_exact = "Hello, World!" } } },
+    .{ .id = 0, .suite = .echo, .name = "echo platform: exit ok (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/exit_ok.roc", .stdout_exact = "success" } } },
+    .{ .id = 0, .suite = .echo, .name = "echo platform: exit ok (dev backend)", .backend = .dev, .skip = .{ .always = "TODO: dev backend default platform build does not provide roc_default_echo_line" }, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/exit_ok.roc", .stdout_exact = "success" } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: exit code (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/exit_code.roc", .exit = .{ .code = 255 } } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: exit code (dev backend)", .backend = .dev, .skip = .{ .always = "TODO: dev backend default platform build does not provide roc_default_echo_line" }, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/exit_code.roc", .exit = .{ .code = 255 } } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: custom error issue 9255 repro (dev backend)", .backend = .dev, .skip = .{ .always = "TODO: dev backend default platform build does not provide roc_default_echo_line" }, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/exit_custom_error.roc", .exit = .{ .code = 1 }, .stdout_exact = "Program exited with error: SomeCustomError(41.0)\n" } } },
-    .{ .id = 0, .suite = .echo, .name = "echo platform: list concat with refcounted elements issue 9316 (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/issue_9316.roc", .stdout_exact = "[\"BAZ\", \"DUCK\", \"XYZ\", \"ABC\"]\n" } } },
-    .{ .id = 0, .suite = .echo, .name = "echo platform: list concat with refcounted elements issue 9316 (dev backend)", .backend = .dev, .skip = .{ .always = "TODO: dev backend default platform build does not provide roc_default_echo_line" }, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/issue_9316.roc", .stdout_exact = "[\"BAZ\", \"DUCK\", \"XYZ\", \"ABC\"]\n" } } },
+    .{ .id = 0, .suite = .echo, .name = "echo platform: list concat with refcounted elements issue 9316 (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/issue_9316.roc", .stdout_exact = "[\"BAZ\", \"DUCK\", \"XYZ\", \"ABC\"]" } } },
+    .{ .id = 0, .suite = .echo, .name = "echo platform: list concat with refcounted elements issue 9316 (dev backend)", .backend = .dev, .skip = .{ .always = "TODO: dev backend default platform build does not provide roc_default_echo_line" }, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/issue_9316.roc", .stdout_exact = "[\"BAZ\", \"DUCK\", \"XYZ\", \"ABC\"]" } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: cmd-test OOM repro compiles and runs (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/repro_oom_cmd_test.roc", .stdout_exact = "" } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: cmd-test OOM repro compiles and runs (dev backend)", .backend = .dev, .skip = .{ .always = "TODO: dev backend default platform build does not provide roc_default_echo_line" }, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/repro_oom_cmd_test.roc", .stdout_exact = "" } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: no main is not a default app (interpreter)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--opt=interpreter"}, .roc_file = "test/echo/no_main.roc", .exit = .failure } } },
@@ -3571,7 +3571,7 @@ fn customHotReloadDefaultApp(
     if (checkCommandExpectation(allocator, result, .{
         .args = &.{"--watch"},
         .exit = .success,
-        .stdout_exact = "headerless watch\n",
+        .stdout_exact = "headerless watch",
         .not_contains = &.{
             .{ .stream = .stderr, .text = "unsupported" },
             .{ .stream = .stderr, .text = "panic" },
@@ -4248,7 +4248,7 @@ fn customDefaultPlatformBuild(
 
         if (runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{executable_path}, env.dirs.work_dir, .{
             .args = &.{},
-            .stdout_exact = "Hello, World!\n",
+            .stdout_exact = "Hello, World!",
             .stderr_exact = "",
         })) |failure| return failure;
     }
@@ -4342,7 +4342,7 @@ fn customMacosOutputBasenameReproducible(
     const opts = [_][]const u8{ "dev", "speed", "size" };
     for (opts) |opt| {
         if (checkMacosOutputBasenameReproducible(io, allocator, env, timer, timeout_ms, opt, "real_platform", "test/fx/hello_world.roc", "Hello, world!\n")) |failure| return failure;
-        if (checkMacosOutputBasenameReproducible(io, allocator, env, timer, timeout_ms, opt, "default_platform", default_app_path, "Hello, World!\n")) |failure| return failure;
+        if (checkMacosOutputBasenameReproducible(io, allocator, env, timer, timeout_ms, opt, "default_platform", default_app_path, "Hello, World!")) |failure| return failure;
     }
 
     return null;

--- a/src/default_platform/c_runtime.zig
+++ b/src/default_platform/c_runtime.zig
@@ -43,7 +43,6 @@ export fn roc_default_echo_line(str: RocStr) callconv(.c) void {
     var owned = str;
     const message = owned.asSlice();
     writeAll(1, message);
-    writeAll(1, "\n");
     owned.decref(roc_dealloc);
 }
 

--- a/src/default_platform/linux_runtime.zig
+++ b/src/default_platform/linux_runtime.zig
@@ -81,7 +81,6 @@ export fn roc_default_echo_line(str: RocStr) callconv(.c) void {
     var owned = str;
     const message = owned.asSlice();
     writeAll(stdout_fd, message);
-    writeLiteral(stdout_fd, "\n");
     owned.decref(roc_dealloc);
 }
 

--- a/src/echo_platform/mod.zig
+++ b/src/echo_platform/mod.zig
@@ -39,7 +39,7 @@ pub const run_shim_platform_main_source =
     \\        Ok(_) => 0
     \\        Err(Exit(code)) => code
     \\        Err(other) => {
-    \\            Echo.line!("Program exited with error: ${Str.inspect(other)}")
+    \\            Echo.line!("Program exited with error: ${Str.inspect(other)}\n")
     \\            1
     \\        }
     \\    }
@@ -147,7 +147,7 @@ pub const EchoEnv = struct {
 /// parameter, so the runner stores its RocOps here before running any Roc code.
 pub var g_roc_ops: ?*host_abi.RocOps = null;
 
-/// Echo host function: reads a RocStr arg and prints it + newline to stdout.
+/// Echo host function: reads a RocStr arg and writes it unchanged to stdout.
 /// Ownership of `roc_str` transfers to this host function — the RC insertion
 /// pass emits zero RC ops for hosted-call args (see test in `src/lir/arc.zig`
 /// "RC hosted call transfers unused refcounted arg to host", and the test
@@ -168,13 +168,7 @@ pub fn echoHostedFn(str: RocStr) callconv(.c) void {
     } else {
         const env: *EchoEnv = @ptrCast(@alignCast(ops.env));
         const stdout_file: std.Io.File = .stdout();
-        if (appendTemporaryNewline(&owned)) |message_with_newline| {
-            stdout_file.writeStreamingAll(env.std_io, message_with_newline) catch |err| handleStdoutError(err);
-            message_with_newline[message_with_newline.len - 1] = 0;
-        } else {
-            stdout_file.writeStreamingAll(env.std_io, message) catch |err| handleStdoutError(err);
-            stdout_file.writeStreamingAll(env.std_io, "\n") catch |err| handleStdoutError(err);
-        }
+        stdout_file.writeStreamingAll(env.std_io, message) catch |err| handleStdoutError(err);
     }
     // Returns {} (ZST) — no bytes to write to ret_bytes
 }
@@ -199,16 +193,6 @@ pub fn echoLineHostedFn() host_abi.HostedFn {
         host_abi.hostedFn(&echoHostedFnWasm)
     else
         host_abi.hostedFn(&echoHostedFn);
-}
-
-fn appendTemporaryNewline(str: *RocStr) ?[]u8 {
-    const len = str.len();
-    if (len >= str.getCapacity()) return null;
-    if (!(str.isSmallStr() or (!str.isSeamlessSlice() and str.isUnique()))) return null;
-
-    const bytes = str.asSliceWithCapacityMut();
-    bytes[len] = '\n';
-    return bytes[0 .. len + 1];
 }
 
 /// Handle stdout write errors: exit cleanly on broken pipe (standard
@@ -415,48 +399,6 @@ fn sanitizeUtf8(input: []const u8, allocator: std.mem.Allocator) std.mem.Allocat
 
 const testing = std.testing;
 const test_allocator = std.testing.allocator;
-
-test "appendTemporaryNewline: small string uses spare inline byte" {
-    var str = RocStr.fromSliceSmall("hello");
-
-    const message = appendTemporaryNewline(&str) orelse return error.TestUnexpectedResult;
-    try testing.expectEqualStrings("hello\n", message);
-    try testing.expectEqualStrings("hello", str.asSlice());
-
-    message[message.len - 1] = 0;
-    try testing.expectEqual(@as(u8, 0), str.asSliceWithCapacity()[str.len()]);
-}
-
-test "appendTemporaryNewline: unique heap string with spare capacity is writable" {
-    var test_env = builtins.utils.TestEnv.init(test_allocator);
-    defer test_env.deinit();
-    const ops = test_env.getOps();
-
-    var str = RocStr.fromSlice("a string long enough to require heap allocation", ops);
-    str = builtins.str.reserve(str, 1, .Immutable, ops);
-    defer str.decref(ops);
-
-    const message = appendTemporaryNewline(&str) orelse return error.TestUnexpectedResult;
-    try testing.expectEqualStrings("a string long enough to require heap allocation\n", message);
-    try testing.expectEqualStrings("a string long enough to require heap allocation", str.asSlice());
-
-    message[message.len - 1] = 0;
-    try testing.expectEqual(@as(u8, 0), str.asSliceWithCapacity()[str.len()]);
-}
-
-test "appendTemporaryNewline: shared heap string is not writable" {
-    var test_env = builtins.utils.TestEnv.init(test_allocator);
-    defer test_env.deinit();
-    const ops = test_env.getOps();
-
-    var str = RocStr.fromSlice("a string long enough to require heap allocation", ops);
-    str = builtins.str.reserve(str, 1, .Immutable, ops);
-    defer str.decref(ops);
-    str.incref(1, ops);
-    defer str.decref(ops);
-
-    try testing.expectEqual(@as(?[]u8, null), appendTemporaryNewline(&str));
-}
 
 test "sanitizeUtf8: valid ASCII passes through unchanged" {
     const input = "hello world";

--- a/src/echo_platform/platform/main.roc
+++ b/src/echo_platform/platform/main.roc
@@ -13,7 +13,7 @@ main_for_host! = |args|
         Ok(_) => 0
         Err(Exit(code)) => code
         Err(other) => {
-            Echo.line!("Program exited with error: ${Str.inspect(other)}")
+            Echo.line!("Program exited with error: ${Str.inspect(other)}\n")
             1
         }
     }

--- a/src/echo_platform/www/app.js
+++ b/src/echo_platform/www/app.js
@@ -146,7 +146,7 @@ const importObject = {
   env: {
     js_echo(ptr, len) {
       const bytes = new Uint8Array(wasm.instance.exports.memory.buffer, ptr, len);
-      outputEl.textContent += decoder.decode(bytes) + "\n";
+      outputEl.textContent += decoder.decode(bytes);
     },
     js_stderr(ptr, len) {
       const bytes = new Uint8Array(wasm.instance.exports.memory.buffer, ptr, len);

--- a/test/echo-wasm-test/main.zig
+++ b/test/echo-wasm-test/main.zig
@@ -4,7 +4,7 @@
 //! functions that capture output into in-process buffers, and drives the
 //! exported API (init / allocateBuffer / addFile / compileAndRun) the same
 //! way `www/app.js` does. Validates that the tutorial example produces
-//! "Hello from the Greeting module!" as its single echo line.
+//! "Hello from the Greeting module!" as raw echo output.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
@@ -26,7 +26,6 @@ fn hostJsEcho(_: ?*anyopaque, _: *bytebox.ModuleInstance, params: [*]const byteb
     const mem = memory_instance.buffer();
     if (@as(usize, ptr) + @as(usize, len) > mem.len) return;
     capture_ctx.echoed.appendSlice(capture_ctx.gpa, mem[ptr .. ptr + len]) catch return;
-    capture_ctx.echoed.append(capture_ctx.gpa, '\n') catch return;
 }
 
 fn hostJsStderr(_: ?*anyopaque, _: *bytebox.ModuleInstance, params: [*]const bytebox.Val, _: [*]bytebox.Val) error{}!void {
@@ -198,7 +197,7 @@ pub fn main(init: std.process.Init) anyerror!void {
     ;
     const exit_code = try compileAndRunSource(module_instance, alloc_handle, run_handle, main_src);
 
-    const expected_output = "Hello from the Greeting module!\n";
+    const expected_output = "Hello from the Greeting module!";
     const got_output = capture_ctx.echoed.items;
     const got_stderr = capture_ctx.stderr.items;
 

--- a/test/echo/all_syntax_test.roc
+++ b/test/echo/all_syntax_test.roc
@@ -91,7 +91,7 @@ multiline_str = |number|
 # `=>` shows effectfulness in the type signature
 effect_demo! : Str => {}
 effect_demo! = |msg|
-	echo!(msg)
+	echo!("${msg}\n")
 
 question_postfix : List(Str) -> Try(I64, _)
 question_postfix = |strings| {
@@ -163,7 +163,7 @@ while_loop = |limit| {
 }
 
 print! = |something| {
-	echo!(Str.inspect(something))
+	echo!("${Str.inspect(something)}\n")
 }
 
 dbg_keyword = || {
@@ -341,10 +341,10 @@ stringify : a -> Str where [a.to_str : a -> Str]
 stringify = |value| value.to_str()
 
 main! = |_args| {
-	echo!("Hello, world!")
-	echo!("Hello, world! (using alias)")
+	echo!("Hello, world!\n")
+	echo!("Hello, world! (using alias)\n")
 
-	echo!(Str.inspect(number_operators(10, 5)))
+	echo!("${Str.inspect(number_operators(10, 5))}\n")
 	print!(boolean_operators(Bool.True, Bool.False))
 
 	# pizza operator (|>) is gone, we now have static dispatch instead.
@@ -354,12 +354,12 @@ main! = |_args| {
 	# If you want a very similar style for a function that is not defined on the type but is in scope, you can use `->`:
 	print!("Three"->my_concat(" Four"))
 
-	echo!(simple_match(Red))
+	echo!("${simple_match(Red)}\n")
 	print!(match_list_patterns([1, 10]))
-	echo!(match_tag_union_advanced(Ok({})))
+	echo!("${match_tag_union_advanced(Ok({}))}\n")
 
-	echo!(multiline_str(3))
-	echo!("Unicode escape sequence: \u(00A0)")
+	echo!("${multiline_str(3)}\n")
+	echo!("Unicode escape sequence: \u(00A0)\n")
 
 	effect_demo!("This is an effectful function!")
 
@@ -380,7 +380,7 @@ main! = |_args| {
 
 	print!(dbg_keyword())
 
-	echo!(if_demo(2))
+	echo!("${if_demo(2)}\n")
 
 	print!(tuple_demo)
 


### PR DESCRIPTION
## Summary

- make the default echo effect write its string unchanged across native, WASM, C-runtime, Linux-runtime, and LLVM-generated hosts
- remove the LLVM newline buffer mutation and its backend-side refcount/capacity inspection
- update browser/test hosts and CLI expectations for raw consecutive writes
- keep line-oriented examples explicit by appending \n in Roc code

## Verification

- zig build run-test-echo-wasm
- zig build run-test-cli -- --suite echo
- zig build run-test-cli -- --suite subcommands --filter "roc build default platform x64glibc succeeds"
- zig build minici (61/61 passed)