### PR TITLE
Clean up dispatch-evidence residue left after the migration

### DIFF
--- a/design.md
+++ b/design.md
@@ -2347,8 +2347,9 @@ const DispatchOwnerHead = union(enum) {
 };
 ```
 
-`DispatchOwnerHead` is not stored as a duplicate field on every type node. It is
-the result of a total function over Monotype type content:
+`DispatchOwnerHead` is not stored as a duplicate field on every type node. It
+is read from type content on demand (the alias-transparent
+`dispatchHeadContent` accessor plus the component-lookup seam's key builder):
 
 ```zig
 fn dispatchOwnerHead(types: *const TypeStore, ty: TypeId) DispatchOwnerHead
@@ -2358,6 +2359,12 @@ Builtin type content returns the corresponding builtin owner. `named` type
 content returns `type_def` when the definition can own methods, even if
 its runtime representation later uses a transparent backing. Anonymous
 structural types and non-owning internal nodes return `none`.
+
+This head is only ever a lookup KEY for the exact `(MethodOwner,
+MethodNameId)` registry table, consulted for compiler-generated call edges —
+it is checked type identity carried on the monotype, not a dispatch decision.
+Plan-resolved user dispatch never reads it; those targets come from checked
+evidence alone.
 
 Record fields and tag variants are stored in lexicographic order by name. Tag
 payloads are stored in payload position order. The index of a field or tag
@@ -3077,6 +3084,12 @@ its plan:
 Nothing else exists. Monotype lowering never derives a method owner from type
 content, never searches a registry by method name, and never intersects
 constraints to guess a target.
+
+Totality is enforced at the boundary: `validateDispatchEvidence`, run by the
+checked module's `verifyComplete`, asserts that every dispatch-bearing
+checked expression names a plan and that every plan and evidence reference
+lands inside the checked module data's evidence tables. A missing or corrupt
+record is a compiler bug reported at the boundary, not a lowering panic.
 
 **Evidence params.** Every type scheme with dispatch requirements has one
 deterministic ordered list of (dispatcher var, constraint) pairs —

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -12906,10 +12906,10 @@ fn sealCheckedProcedureTemplateRefs(
 /// Runs after `sealCheckedProcedureTemplateRefs` so plans and value refs are
 /// grouped per template: `constraint(k)` indexes the enclosing template's
 /// canonical evidence-param list. Concrete dispatchers resolve through the
-/// checked registry exactly as the pre-total inline resolution did; where-var
-/// dispatchers resolve to their param index; evidence for call edges comes
-/// from the checker's persisted `SchemeInstantiationRecord`s, whose fresh vars
-/// are resolved against the settled type store.
+/// checked registry; where-var dispatchers resolve to their param index;
+/// evidence for call edges comes from the checker's persisted
+/// `SchemeInstantiationRecord`s, whose fresh vars are resolved against the
+/// settled type store.
 const EvidencePass = struct {
     allocator: Allocator,
     module: TypedCIR.Module,
@@ -13563,7 +13563,8 @@ const EvidencePass = struct {
     }
 
     /// The method owner of a settled source var, walking alias content
-    /// transparently (mirrors `methodOwnerForCheckedType` on published types).
+    /// transparently (the source-var analog of monotype lowering's
+    /// dispatch-head read of published type identity).
     fn methodOwnerForSourceContent(self: *EvidencePass, var_: Var) ?static_dispatch.MethodOwner {
         var current = var_;
         var remaining: u64 = self.types.len();
@@ -13705,12 +13706,13 @@ const EvidencePass = struct {
     }
 
     /// The derived-structural kind a constraint method admits, if any.
+    /// Ident-keyed view of `static_dispatch.structural_method_kinds`: each
+    /// table entry's name doubles as the matching `CommonIdents` field.
     fn structuralKindForMethodIdent(self: *EvidencePass, fn_name: anytype) ?static_dispatch.StructuralKind {
         const common = self.module.commonIdents();
-        if (fn_name.eql(common.is_eq)) return .equality;
-        if (fn_name.eql(common.to_hash)) return .hash;
-        if (fn_name.eql(common.parser_for)) return .parser;
-        if (fn_name.eql(common.encoder_for)) return .encoder;
+        inline for (static_dispatch.structural_method_kinds) |entry| {
+            if (fn_name.eql(@field(common, entry.name))) return entry.kind;
+        }
         return null;
     }
 
@@ -26137,6 +26139,7 @@ pub const DispatchEvidenceFailure = struct {
         plan_evidence_node_out_of_bounds,
         evidence_node_nested_refs_out_of_bounds,
         evidence_ref_node_out_of_bounds,
+        site_evidence_key_out_of_bounds,
         site_evidence_refs_out_of_bounds,
         site_evidence_keys_unsorted,
         template_plan_ref_out_of_bounds,
@@ -26830,6 +26833,9 @@ pub const CheckedModuleArtifact = struct {
         }
 
         for (table.site_evidence, 0..) |entry, i| {
+            if (entry.key >= self.checked_bodies.exprCount()) {
+                return .{ .kind = .site_evidence_key_out_of_bounds, .index = @intCast(i) };
+            }
             if (@as(u64, entry.start) + entry.len > table.evidence_refs.len) {
                 return .{ .kind = .site_evidence_refs_out_of_bounds, .index = @intCast(i) };
             }

--- a/src/check/dispatch_evidence.zig
+++ b/src/check/dispatch_evidence.zig
@@ -146,21 +146,6 @@ pub fn enumerateEvidenceParams(
     }
 }
 
-/// The canonical index of `dispatcher_root`'s `fn_name` constraint within
-/// `params`, or null.
-pub fn paramIndex(
-    params: []const EvidenceParam,
-    dispatcher_root: Var,
-    fn_name: anytype,
-) ?u32 {
-    for (params, 0..) |param, k| {
-        if (param.dispatcher_var == dispatcher_root and param.constraint.fn_name.eql(fn_name)) {
-            return @intCast(k);
-        }
-    }
-    return null;
-}
-
 fn walk(
     gpa: Allocator,
     store: *const types_mod.Store,
@@ -217,9 +202,9 @@ fn walk(
                 .nominal_type => |nominal| {
                     // A nominal application's structure is its args; backing
                     // structure is declaration data and is not part of the
-                    // scheme's type graph. (`.nominal_backing` path steps are
-                    // no longer produced; the kind remains for alias-style
-                    // walkers and old artifacts.)
+                    // scheme's type graph, so this enumerator never emits a
+                    // `.nominal_backing` step (consumers treat that kind
+                    // exactly like `.alias_backing`).
                     scratch.children.clearRetainingCapacity();
                     for (store.sliceNominalArgs(nominal), 0..) |arg, i| {
                         try scratch.children.append(gpa, .{ .var_ = arg, .step = step(.nominal_arg, @intCast(i)) });

--- a/src/check/static_dispatch_registry.zig
+++ b/src/check/static_dispatch_registry.zig
@@ -771,6 +771,21 @@ pub const StructuralKind = enum(u8) {
     encoder,
 };
 
+/// Public `structural_method_kinds` declaration.
+///
+/// The one table mapping the method names that can discharge structurally to
+/// their `StructuralKind`. Each `name` matches the corresponding
+/// `CommonIdents` field name, so the evidence pass compares interned idents
+/// via `@field` over this table while monotype lowering's component synthesis
+/// classifies its view-local method names by text — both from this single
+/// source.
+pub const structural_method_kinds = [_]struct { name: [:0]const u8, kind: StructuralKind }{
+    .{ .name = "is_eq", .kind = .equality },
+    .{ .name = "to_hash", .kind = .hash },
+    .{ .name = "parser_for", .kind = .parser },
+    .{ .name = "encoder_for", .kind = .encoder },
+};
+
 /// Public `EvidenceNodeId` declaration. Index into
 /// `StaticDispatchPlanTable.evidence_nodes`.
 pub const EvidenceNodeId = enum(u32) { _ };
@@ -1638,54 +1653,6 @@ fn checkedTypeIsBuiltinBool(checked_types: anytype, ty: CheckedTypeId) bool {
     return switch (checked_types.store.payload(ty)) {
         .nominal => |nominal| if (nominal.builtin) |builtin_owner| builtin_owner == .bool else false,
         else => false,
-    };
-}
-
-/// Public `methodOwnerForCheckedType` declaration: the method owner of a
-/// published checked type, walking alias chains transparently.
-pub fn methodOwnerForCheckedType(checked_types: anytype, ty: CheckedTypeId) ?MethodOwner {
-    var current = ty;
-    // Aliases are transparent for static dispatch: an alias's method owner is its
-    // backing's owner. Walk the (finite) alias chain so an alias-over-nominal,
-    // alias-over-alias, or alias-over-builtin resolves to the underlying owner
-    // rather than the alias's own identity, where no methods are registered. The
-    // bound on iterations is the store size, so a cyclic chain cannot loop here.
-    var remaining = checked_types.store.payloads.items.len;
-    while (true) {
-        const raw = @intFromEnum(current);
-        if (raw >= checked_types.store.payloads.items.len) {
-            if (@import("builtin").mode == .Debug) {
-                std.debug.panic("checked static dispatch invariant violated: dispatcher type root was outside the checked type store", .{});
-            }
-            unreachable;
-        }
-        switch (checked_types.store.payloads.items[raw]) {
-            .alias => |alias| {
-                if (remaining == 0) {
-                    if (@import("builtin").mode == .Debug) {
-                        std.debug.panic("checked static dispatch invariant violated: checked type alias chain was cyclic", .{});
-                    }
-                    unreachable;
-                }
-                remaining -= 1;
-                current = alias.backing;
-            },
-            else => |payload| return methodOwnerForCheckedPayload(payload),
-        }
-    }
-}
-
-fn methodOwnerForCheckedPayload(payload: anytype) ?MethodOwner {
-    return switch (payload) {
-        .nominal => |nominal| if (nominal.builtin) |builtin|
-            .{ .builtin = builtinOwnerForCheckedBuiltin(builtin) }
-        else
-            .{ .nominal = .{
-                .module = nominal.origin_module,
-                .type_name = nominal.name,
-                .source_decl = nominal.source_decl,
-            } },
-        else => null,
     };
 }
 

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -2798,6 +2798,37 @@ test "dispatch evidence boundary validator names the method of a dangling eviden
     try std.testing.expectEqualStrings(corrupted_method.?, named_method);
 }
 
+test "dispatch evidence boundary validator reports a site-evidence key outside the body store" {
+    const allocator = std.testing.allocator;
+    // A where-constrained helper instantiated at a concrete type gives the
+    // instantiation site a site-evidence entry to corrupt.
+    const source =
+        \\module [main]
+        \\
+        \\Thing := [Val(Str)].{
+        \\    to_str : Thing -> Str
+        \\    to_str = |Thing.Val(s)| s
+        \\}
+        \\
+        \\helper : a -> Str where [a.to_str : a -> Str]
+        \\helper = |x| x.to_str()
+        \\
+        \\main : Str
+        \\main = helper(Thing.Val("hi"))
+    ;
+    var resources = try helpers.parseAndCanonicalizeProgramWithBuiltin(allocator, .module, source, &.{}, try sharedPrePublishedBuiltin());
+    defer helpers.cleanupParseAndCanonical(allocator, resources);
+
+    const table = &resources.checked_artifact.static_dispatch_plans;
+    try std.testing.expect(table.site_evidence.len > 0);
+    table.site_evidence[0].key = @intCast(resources.checked_artifact.checked_bodies.exprCount());
+
+    const failure = resources.checked_artifact.validateDispatchEvidence() orelse
+        return error.TestUnexpectedResult;
+    try std.testing.expectEqual(check.CheckedArtifact.DispatchEvidenceFailure.Kind.site_evidence_key_out_of_bounds, failure.kind);
+    try std.testing.expectEqual(@as(?u32, 0), failure.index);
+}
+
 test "compiler-generated dispatch classes lower via checked evidence" {
     const allocator = std.testing.allocator;
     // One program exercising every compiler-generated dispatch class served

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -1767,14 +1767,7 @@ fn generatedBackingScore(content: Type.Content) ?u8 {
 }
 
 fn isGeneratedOpaqueEvidenceOwner(owner: ?static_dispatch.BuiltinOwner) bool {
-    const actual = owner orelse return false;
-    return switch (actual) {
-        .fields,
-        .field,
-        .parse_tag_union_spec,
-        => true,
-        else => false,
-    };
+    return MonoType.generatedEvidenceOwnerUsesBacking(owner orelse return false);
 }
 
 fn sameMonoTypeDef(left: MonoType.TypeDef, right: MonoType.TypeDef) bool {

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -17628,11 +17628,13 @@ const BodyContext = struct {
         };
     }
 
+    /// Text-keyed view of `static_dispatch.structural_method_kinds`, for
+    /// classifying a checked module view's method names during component
+    /// synthesis.
     fn structuralKindForMethodText(method_text: []const u8) ?static_dispatch.StructuralKind {
-        if (std.mem.eql(u8, method_text, "is_eq")) return .equality;
-        if (std.mem.eql(u8, method_text, "to_hash")) return .hash;
-        if (std.mem.eql(u8, method_text, "parser_for")) return .parser;
-        if (std.mem.eql(u8, method_text, "encoder_for")) return .encoder;
+        inline for (static_dispatch.structural_method_kinds) |entry| {
+            if (std.mem.eql(u8, method_text, entry.name)) return entry.kind;
+        }
         return null;
     }
 

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -1984,7 +1984,11 @@ fn writeBytes(hasher: *std.crypto.hash.sha2.Sha256, bytes: []const u8) void {
     hasher.update(bytes);
 }
 
-fn generatedEvidenceOwnerUsesBacking(owner: static_dispatch.BuiltinOwner) bool {
+/// Whether a builtin owner is a compiler-generated evidence carrier whose
+/// backing structure distinguishes otherwise same-named applications: the
+/// backing then participates in type digests, identity comparison, and
+/// public-type equivalence. One definition serves every postcheck stage.
+pub fn generatedEvidenceOwnerUsesBacking(owner: static_dispatch.BuiltinOwner) bool {
     return switch (owner) {
         .fields,
         .field,

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -6573,7 +6573,7 @@ const Lowerer = struct {
         }
 
         if (lhs.builtin_owner) |owner| {
-            if (generatedEvidenceOwnerUsesBacking(owner)) {
+            if (MonoType.generatedEvidenceOwnerUsesBacking(owner)) {
                 const lhs_backing = lhs.backing orelse return rhs.backing == null;
                 const rhs_backing = rhs.backing orelse return false;
                 return try self.publicTypesEquivalent(lhs_backing.ty, rhs_backing.ty, visited);
@@ -6581,15 +6581,6 @@ const Lowerer = struct {
         }
 
         return true;
-    }
-
-    fn generatedEvidenceOwnerUsesBacking(owner: check.StaticDispatchRegistry.BuiltinOwner) bool {
-        return switch (owner) {
-            .fields,
-            .parse_tag_union_spec,
-            => true,
-            else => false,
-        };
     }
 
     fn publicTypeSpansEquivalent(


### PR DESCRIPTION
A thorough residue pass after the dispatch-evidence migration (#10108) surfaced a handful of leftovers, the most substantive being a drifted duplicate predicate: `generatedEvidenceOwnerUsesBacking` existed in three places, and `solved_lir_lower.zig`'s private copy was missing `.field` — so `Field`-owned named types compared as equivalent for layout reuse without comparing the backings that participate in their identity in the digest/identity walkers and lambda_solved. It is now one pub fn in `monotype/type.zig` consumed by all three sites.

The other mirrored pair — the method-name → `StructuralKind` mapping, maintained independently in the evidence pass (ident-keyed) and monotype lowering (text-keyed) — is now one `structural_method_kinds` table in `static_dispatch_registry`; each entry's name doubles as the matching `CommonIdents` field, so the evidence pass iterates it with interned-ident comparisons while lowering's component synthesis classifies view-local method names by text, both from the single source. Two exports orphaned by the migration are deleted (`methodOwnerForCheckedType` plus its payload helper, and `dispatch_evidence.paramIndex`), the boundary validator gains the one cheap module-local rule it was missing (a site-evidence key must land inside the checked body store), and a few comments that still referenced deleted machinery are reworded. design.md now documents the boundary validator and clarifies that the owner head read from monotype content is only ever the lookup key for the compiler-generated-edge registry table, never a dispatch decision.
