### PR TITLE
Format documentation type signatures

### DIFF
--- a/src/docs/DocModel.zig
+++ b/src/docs/DocModel.zig
@@ -999,6 +999,11 @@ pub const DocType = union(enum) {
     /// Error/unknown type
     @"error",
 
+    pub const Layout = enum {
+        compact,
+        multiline,
+    };
+
     pub const TypeRef = struct {
         /// Module path where this type is defined, as provided by the compiler.
         /// Currently basenames like "Builtin", "Counter", "Num".
@@ -1023,6 +1028,7 @@ pub const DocType = union(enum) {
         ext: ?*const DocType,
         /// True when the record is open (`..` or `..name`).
         is_open: bool,
+        layout: Layout = .compact,
     };
 
     pub const Field = struct {
@@ -1037,25 +1043,30 @@ pub const DocType = union(enum) {
         ext: ?*const DocType,
         /// True when the union is open (`..` or `..name`).
         is_open: bool,
+        layout: Layout = .compact,
     };
 
     pub const Tag = struct {
         name: []const u8,
         args: []const *const DocType,
+        layout: Layout = .compact,
     };
 
     pub const Tuple = struct {
         elems: []const *const DocType,
+        layout: Layout = .compact,
     };
 
     pub const Apply = struct {
         constructor: *const DocType, // the type being applied (e.g., List)
         args: []const *const DocType,
+        layout: Layout = .compact,
     };
 
     pub const WhereClause = struct {
         type: *const DocType,
         constraints: []const Constraint,
+        layout: Layout = .compact,
     };
 
     pub const Constraint = struct {

--- a/src/docs/extract.zig
+++ b/src/docs/extract.zig
@@ -675,8 +675,7 @@ fn extractDefEntry(
             // is already available in CIR.
             const type_sig: ?*const DocType = blk: {
                 if (def.annotation) |anno_idx| {
-                    const annotation = module_env.store.getAnnotation(anno_idx);
-                    break :blk try extractAnnotationAsDocType(gpa, module_env, local_module_path, annotation);
+                    break :blk try extractAnnotationAsDocType(gpa, module_env, local_module_path, anno_idx);
                 }
 
                 const def_var = ModuleEnv.varFrom(def_idx);
@@ -845,8 +844,9 @@ fn extractAnnotationAsDocType(
     gpa: Allocator,
     module_env: *const ModuleEnv,
     local_module_path: []const u8,
-    annotation: CIR.Annotation,
+    annotation_idx: CIR.Annotation.Idx,
 ) Allocator.Error!?*const DocType {
+    const annotation = module_env.store.getAnnotation(annotation_idx);
     const base_type = try extractTypeAnnoAsDocType(gpa, module_env, local_module_path, annotation.anno) orelse return null;
     var base_type_moved = false;
     errdefer if (!base_type_moved) {
@@ -902,6 +902,7 @@ fn extractAnnotationAsDocType(
     const wrapped = try allocDocType(gpa, .{ .where_clause = .{
         .type = base_type,
         .constraints = owned_constraints,
+        .layout = sourceWhereClauseLayout(module_env, where_span),
     } });
     base_type_moved = true;
     constraints_moved = true;
@@ -1030,6 +1031,81 @@ fn isAnonymousOpenExt(module_env: *const ModuleEnv, ext_idx: CIR.TypeAnno.Idx) b
     return name.len > 0 and name[0] == '#';
 }
 
+/// Recover the parser's explicit collection-layout choice from a CIR source
+/// region. A trailing comma requests expanded formatting; line breaks alone do
+/// not. Comments after the comma are ignored, matching the parser's token-based
+/// decision.
+fn sourceCollectionLayout(module_env: *const ModuleEnv, region: base.Region) DocType.Layout {
+    return collectionLayoutFromSource(module_env.getSourceAll(), region);
+}
+
+fn collectionLayoutFromSource(source: []const u8, region: base.Region) DocType.Layout {
+    const start: usize = @min(region.start.offset, source.len);
+    const end: usize = @min(region.end.offset, source.len);
+    if (start >= end) return .compact;
+
+    var last_significant: ?u8 = null;
+    var in_comment = false;
+    for (source[start..end]) |byte| {
+        if (in_comment) {
+            if (byte == '\n' or byte == '\r') in_comment = false;
+            continue;
+        }
+        if (byte == '#') {
+            in_comment = true;
+            continue;
+        }
+        if (!std.ascii.isWhitespace(byte) and byte != ')' and byte != ']' and byte != '}') {
+            last_significant = byte;
+        }
+    }
+
+    return if (last_significant == ',') .multiline else .compact;
+}
+
+fn sourceWhereClauseLayout(module_env: *const ModuleEnv, where_span: CIR.WhereClause.Span) DocType.Layout {
+    const clauses = module_env.store.sliceWhereClauses(where_span);
+    if (clauses.len == 0) return .compact;
+
+    const last_node: CIR.Node.Idx = @enumFromInt(@intFromEnum(clauses[clauses.len - 1]));
+    const last_region = module_env.store.getNodeRegion(last_node);
+    const source = module_env.getSourceAll();
+    const start: usize = @min(last_region.end.offset, source.len);
+
+    var in_comment = false;
+    for (source[start..]) |byte| {
+        if (in_comment) {
+            if (byte == '\n' or byte == '\r') in_comment = false;
+            continue;
+        }
+        if (byte == '#') {
+            in_comment = true;
+            continue;
+        }
+        if (std.ascii.isWhitespace(byte)) continue;
+        return if (byte == ',') .multiline else .compact;
+    }
+    return .compact;
+}
+
+test "collection layout follows trailing commas rather than source newlines" {
+    const compact_source = "List(\n    U8\n)";
+    try std.testing.expectEqual(
+        DocType.Layout.compact,
+        collectionLayoutFromSource(compact_source, base.Region.from_raw_offsets(0, compact_source.len)),
+    );
+
+    const multiline_source = "List(U8, # preserve expanded layout\n)";
+    try std.testing.expectEqual(
+        DocType.Layout.multiline,
+        collectionLayoutFromSource(multiline_source, base.Region.from_raw_offsets(0, multiline_source.len)),
+    );
+}
+
+fn sourceTypeLayout(module_env: *const ModuleEnv, anno_idx: CIR.TypeAnno.Idx) DocType.Layout {
+    return sourceCollectionLayout(module_env, module_env.store.getTypeAnnoRegion(anno_idx));
+}
+
 /// Extract a CIR TypeAnno as a structured DocType.
 fn extractTypeAnnoAsDocType(
     gpa: Allocator,
@@ -1044,21 +1120,28 @@ fn extractTypeAnnoAsDocType(
             name: []const u8,
             module_path: []const u8,
             arg_count: usize,
+            layout: DocType.Layout,
         },
         finish_tag: struct {
             name: []const u8,
             arg_count: usize,
+            layout: DocType.Layout,
         },
         finish_tag_union: struct {
             tag_count: usize,
             has_ext: bool,
             is_open: bool,
+            layout: DocType.Layout,
         },
-        finish_tuple: usize,
+        finish_tuple: struct {
+            elem_count: usize,
+            layout: DocType.Layout,
+        },
         finish_record: struct {
             fields: []CIR.TypeAnno.RecordField.Idx,
             has_ext: bool,
             is_open: bool,
+            layout: DocType.Layout,
         },
         finish_fn: struct {
             arg_count: usize,
@@ -1136,6 +1219,7 @@ fn extractTypeAnnoAsDocType(
                                 .name = name,
                                 .module_path = module_path,
                                 .arg_count = args_slice.len,
+                                .layout = sourceTypeLayout(module_env, idx),
                             } });
                             try Builder.pushVisitsReversed(&frames, gpa, args_slice);
                         }
@@ -1166,6 +1250,7 @@ fn extractTypeAnnoAsDocType(
                             .tag_count = tags_slice.len,
                             .has_ext = has_ext,
                             .is_open = tu.ext != null,
+                            .layout = sourceTypeLayout(module_env, idx),
                         } });
                         if (has_ext) {
                             try frames.append(gpa, .{ .visit = tu.ext.? });
@@ -1180,6 +1265,7 @@ fn extractTypeAnnoAsDocType(
                                     try frames.append(gpa, .{ .finish_tag = .{
                                         .name = module_env.getIdentText(t.name),
                                         .arg_count = tag_args_slice.len,
+                                        .layout = sourceTypeLayout(module_env, tags_slice[i]),
                                     } });
                                     try Builder.pushVisitsReversed(&frames, gpa, tag_args_slice);
                                 },
@@ -1194,12 +1280,16 @@ fn extractTypeAnnoAsDocType(
                         try frames.append(gpa, .{ .finish_tag = .{
                             .name = module_env.getIdentText(t.name),
                             .arg_count = tag_args_slice.len,
+                            .layout = sourceTypeLayout(module_env, idx),
                         } });
                         try Builder.pushVisitsReversed(&frames, gpa, tag_args_slice);
                     },
                     .tuple => |t| {
                         const elems_slice = module_env.store.sliceTypeAnnos(t.elems);
-                        try frames.append(gpa, .{ .finish_tuple = elems_slice.len });
+                        try frames.append(gpa, .{ .finish_tuple = .{
+                            .elem_count = elems_slice.len,
+                            .layout = sourceTypeLayout(module_env, idx),
+                        } });
                         try Builder.pushVisitsReversed(&frames, gpa, elems_slice);
                     },
                     .record => |r| {
@@ -1209,6 +1299,7 @@ fn extractTypeAnnoAsDocType(
                             .fields = fields_slice,
                             .has_ext = has_ext,
                             .is_open = r.ext != null,
+                            .layout = sourceTypeLayout(module_env, idx),
                         } });
                         if (has_ext) {
                             try frames.append(gpa, .{ .visit = r.ext.? });
@@ -1255,6 +1346,7 @@ fn extractTypeAnnoAsDocType(
                 tags[0] = .{
                     .name = try gpa.dupe(u8, "?"),
                     .args = tag_args,
+                    .layout = .compact,
                 };
                 tags_len = 1;
                 tag_args_moved = true;
@@ -1292,6 +1384,7 @@ fn extractTypeAnnoAsDocType(
                 const app = try allocDocType(gpa, .{ .apply = .{
                     .constructor = constructor,
                     .args = args,
+                    .layout = finish.layout,
                 } });
                 args_moved = true;
                 constructor_moved = true;
@@ -1321,6 +1414,7 @@ fn extractTypeAnnoAsDocType(
                 tags[0] = .{
                     .name = try gpa.dupe(u8, finish.name),
                     .args = tag_args,
+                    .layout = finish.layout,
                 };
                 tags_len = 1;
                 tag_args_moved = true;
@@ -1377,15 +1471,16 @@ fn extractTypeAnnoAsDocType(
                     .tags = tags,
                     .ext = ext,
                     .is_open = finish.is_open,
+                    .layout = finish.layout,
                 } });
                 tags_moved = true;
                 ext_moved = true;
                 try Builder.pushResult(&results, gpa, tag_union);
             },
-            .finish_tuple => |elem_count| {
-                std.debug.assert(results.items.len >= elem_count);
-                const start = results.items.len - elem_count;
-                const elems = try gpa.alloc(*const DocType, elem_count);
+            .finish_tuple => |finish| {
+                std.debug.assert(results.items.len >= finish.elem_count);
+                const start = results.items.len - finish.elem_count;
+                const elems = try gpa.alloc(*const DocType, finish.elem_count);
                 var elems_moved = false;
                 errdefer if (!elems_moved) {
                     Builder.cleanupDocTypes(gpa, elems);
@@ -1394,7 +1489,10 @@ fn extractTypeAnnoAsDocType(
                 @memcpy(elems, results.items[start..]);
                 results.shrinkRetainingCapacity(start);
 
-                const tuple = try allocDocType(gpa, .{ .tuple = .{ .elems = elems } });
+                const tuple = try allocDocType(gpa, .{ .tuple = .{
+                    .elems = elems,
+                    .layout = finish.layout,
+                } });
                 elems_moved = true;
                 try Builder.pushResult(&results, gpa, tuple);
             },
@@ -1450,6 +1548,7 @@ fn extractTypeAnnoAsDocType(
                     .fields = fields,
                     .ext = ext,
                     .is_open = finish.is_open,
+                    .layout = finish.layout,
                 } });
                 fields_moved = true;
                 ext_moved = true;
@@ -1641,6 +1740,7 @@ fn extractDocType(
         return try allocDocType(gpa, .{ .where_clause = .{
             .type = base_type.?,
             .constraints = owned_constraints,
+            .layout = .multiline,
         } });
     }
 
@@ -1779,6 +1879,7 @@ fn extractDocTypeInner(
                 return try allocDocType(gpa, .{ .apply = .{
                     .constructor = constructor,
                     .args = args_slice,
+                    .layout = .multiline,
                 } });
             } else {
                 // Simple type reference
@@ -1832,6 +1933,7 @@ fn extractFlatType(
                 .fields = try gpa.alloc(DocType.Field, 0),
                 .ext = null,
                 .is_open = false,
+                .layout = .multiline,
             } });
         },
         .empty_tag_union => {
@@ -1839,6 +1941,7 @@ fn extractFlatType(
                 .tags = try gpa.alloc(DocType.Tag, 0),
                 .ext = null,
                 .is_open = false,
+                .layout = .multiline,
             } });
         },
     }
@@ -1905,6 +2008,7 @@ fn extractNominalType(
         return try allocDocType(gpa, .{ .apply = .{
             .constructor = constructor,
             .args = args_slice,
+            .layout = .multiline,
         } });
     } else {
         return try allocDocType(gpa, .{ .type_ref = .{
@@ -2035,6 +2139,7 @@ fn extractRecord(
         .fields = doc_fields,
         .ext = ext_doc_type,
         .is_open = is_open,
+        .layout = .multiline,
     } });
 }
 
@@ -2049,6 +2154,7 @@ fn extractRecordUnbound(
             .fields = try gpa.alloc(DocType.Field, 0),
             .ext = null,
             .is_open = false,
+            .layout = .multiline,
         } });
     }
 
@@ -2075,6 +2181,7 @@ fn extractRecordUnbound(
         .fields = fields,
         .ext = null,
         .is_open = false,
+        .layout = .multiline,
     } });
 }
 
@@ -2089,7 +2196,10 @@ fn extractTuple(
         elems[i] = try extractDocTypeInner(ctx, elem_var) orelse
             try allocDocType(gpa, .@"error");
     }
-    return try allocDocType(gpa, .{ .tuple = .{ .elems = elems } });
+    return try allocDocType(gpa, .{ .tuple = .{
+        .elems = elems,
+        .layout = .multiline,
+    } });
 }
 
 fn extractTagUnion(
@@ -2122,7 +2232,11 @@ fn extractTagUnion(
                 try allocDocType(gpa, .@"error");
         }
 
-        try tags.append(gpa, .{ .name = tag_name, .args = tag_args });
+        try tags.append(gpa, .{
+            .name = tag_name,
+            .args = tag_args,
+            .layout = .multiline,
+        });
     }
 
     // Handle extension variable
@@ -2185,6 +2299,7 @@ fn extractTagUnion(
         .tags = tags_slice,
         .ext = ext_type,
         .is_open = is_open,
+        .layout = .multiline,
     } });
 }
 

--- a/src/docs/render_html.zig
+++ b/src/docs/render_html.zig
@@ -1886,6 +1886,62 @@ fn validateAnchor(
     try ctx.reportBrokenLink(label, anchor, bracket_offset);
 }
 
+fn tagWillRenderMultiline(tag: DocType.Tag) bool {
+    if (tag.layout == .multiline and tag.args.len > 0) return true;
+    for (tag.args) |arg| {
+        if (docTypeWillRenderMultiline(arg)) return true;
+    }
+    return false;
+}
+
+fn docTypeWillRenderMultiline(doc_type: *const DocType) bool {
+    return switch (doc_type.*) {
+        .type_ref, .type_var, .wildcard, .@"error" => false,
+        .function => |func| blk: {
+            for (func.args) |arg| {
+                if (docTypeWillRenderMultiline(arg)) break :blk true;
+            }
+            break :blk docTypeWillRenderMultiline(func.ret);
+        },
+        .record => |rec| blk: {
+            if (rec.layout == .multiline and (rec.fields.len > 0 or rec.is_open)) break :blk true;
+            for (rec.fields) |field| {
+                if (docTypeWillRenderMultiline(field.type)) break :blk true;
+            }
+            break :blk if (rec.ext) |ext| docTypeWillRenderMultiline(ext) else false;
+        },
+        .tag_union => |tu| blk: {
+            if (tu.layout == .multiline and (tu.tags.len > 0 or tu.is_open)) break :blk true;
+            for (tu.tags) |tag| {
+                if (tagWillRenderMultiline(tag)) break :blk true;
+            }
+            break :blk if (tu.ext) |ext| docTypeWillRenderMultiline(ext) else false;
+        },
+        .tuple => |tup| blk: {
+            if (tup.layout == .multiline and tup.elems.len > 0) break :blk true;
+            for (tup.elems) |elem| {
+                if (docTypeWillRenderMultiline(elem)) break :blk true;
+            }
+            break :blk false;
+        },
+        .apply => |app| blk: {
+            if (app.layout == .multiline and app.args.len > 0) break :blk true;
+            for (app.args) |arg| {
+                if (docTypeWillRenderMultiline(arg)) break :blk true;
+            }
+            break :blk false;
+        },
+        .where_clause => |wc| blk: {
+            if (wc.layout == .multiline and wc.constraints.len > 0) break :blk true;
+            if (docTypeWillRenderMultiline(wc.type)) break :blk true;
+            for (wc.constraints) |constraint| {
+                if (docTypeWillRenderMultiline(constraint.signature)) break :blk true;
+            }
+            break :blk false;
+        },
+    };
+}
+
 fn renderDocTypeHtml(
     w: Writer,
     ctx: *const RenderContext,
@@ -1897,7 +1953,13 @@ fn renderDocTypeHtml(
         doc_type: struct {
             value: *const DocType,
             needs_parens: bool,
+            indent: usize,
         },
+        tag: struct {
+            value: DocType.Tag,
+            indent: usize,
+        },
+        indent: usize,
         html: []const u8,
         escaped: []const u8,
         type_ref: DocType.TypeRef,
@@ -1906,10 +1968,15 @@ fn renderDocTypeHtml(
     var frames = std.ArrayList(RenderFrame).empty;
     defer frames.deinit(gpa);
 
-    try frames.append(gpa, .{ .doc_type = .{ .value = doc_type, .needs_parens = needs_parens } });
+    try frames.append(gpa, .{ .doc_type = .{
+        .value = doc_type,
+        .needs_parens = needs_parens,
+        .indent = 0,
+    } });
     while (frames.pop()) |frame| {
         switch (frame) {
             .html => |html| try w.writeAll(html),
+            .indent => |level| for (0..level) |_| try w.writeAll("    "),
             .escaped => |text| try writeHtmlEscaped(w, text),
             .type_ref => |ref| {
                 const display_name = if (std.mem.findScalarLast(u8, ref.type_name, '.')) |idx|
@@ -1941,7 +2008,11 @@ fn renderDocTypeHtml(
                     },
                     .function => |func| {
                         if (item.needs_parens) try frames.append(gpa, .{ .html = ")" });
-                        try frames.append(gpa, .{ .doc_type = .{ .value = func.ret, .needs_parens = false } });
+                        try frames.append(gpa, .{ .doc_type = .{
+                            .value = func.ret,
+                            .needs_parens = false,
+                            .indent = item.indent,
+                        } });
                         try frames.append(gpa, .{ .html = if (func.effectful)
                             "<span class=\"sig-arrow\"> =&gt; </span>"
                         else
@@ -1949,84 +2020,199 @@ fn renderDocTypeHtml(
                         var i = func.args.len;
                         while (i > 0) {
                             i -= 1;
-                            try frames.append(gpa, .{ .doc_type = .{ .value = func.args[i], .needs_parens = true } });
+                            try frames.append(gpa, .{ .doc_type = .{
+                                .value = func.args[i],
+                                .needs_parens = true,
+                                .indent = item.indent,
+                            } });
                             if (i > 0) try frames.append(gpa, .{ .html = ", " });
                         }
                         if (item.needs_parens) try frames.append(gpa, .{ .html = "(" });
                     },
                     .record => |rec| {
-                        try frames.append(gpa, .{ .html = " }" });
-                        var i = rec.fields.len;
-                        while (i > 0) {
-                            i -= 1;
-                            const field = rec.fields[i];
-                            try frames.append(gpa, .{ .doc_type = .{ .value = field.type, .needs_parens = false } });
-                            try frames.append(gpa, .{ .html = " : " });
-                            try frames.append(gpa, .{ .escaped = field.name });
-                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
-                        }
-                        if (rec.is_open) {
-                            if (rec.fields.len > 0) try frames.append(gpa, .{ .html = ", " });
-                            if (rec.ext) |ext| {
-                                try frames.append(gpa, .{ .doc_type = .{ .value = ext, .needs_parens = false } });
+                        const multiline = !ctx.single_line_signatures and docTypeWillRenderMultiline(item.value);
+                        if (multiline) {
+                            try frames.append(gpa, .{ .html = "}" });
+                            try frames.append(gpa, .{ .indent = item.indent });
+                            if (rec.is_open) {
+                                try frames.append(gpa, .{ .html = ",\n" });
+                                if (rec.ext) |ext| {
+                                    try frames.append(gpa, .{ .doc_type = .{
+                                        .value = ext,
+                                        .needs_parens = false,
+                                        .indent = item.indent + 1,
+                                    } });
+                                }
+                                try frames.append(gpa, .{ .html = ".." });
+                                try frames.append(gpa, .{ .indent = item.indent + 1 });
                             }
-                            try frames.append(gpa, .{ .html = ".." });
+                            var i = rec.fields.len;
+                            while (i > 0) {
+                                i -= 1;
+                                const field = rec.fields[i];
+                                try frames.append(gpa, .{ .html = ",\n" });
+                                try frames.append(gpa, .{ .doc_type = .{
+                                    .value = field.type,
+                                    .needs_parens = false,
+                                    .indent = item.indent + 1,
+                                } });
+                                try frames.append(gpa, .{ .html = " : " });
+                                try frames.append(gpa, .{ .escaped = field.name });
+                                try frames.append(gpa, .{ .indent = item.indent + 1 });
+                            }
+                            try frames.append(gpa, .{ .html = "{\n" });
+                        } else {
+                            try frames.append(gpa, .{ .html = " }" });
+                            var i = rec.fields.len;
+                            while (i > 0) {
+                                i -= 1;
+                                const field = rec.fields[i];
+                                try frames.append(gpa, .{ .doc_type = .{
+                                    .value = field.type,
+                                    .needs_parens = false,
+                                    .indent = item.indent,
+                                } });
+                                try frames.append(gpa, .{ .html = " : " });
+                                try frames.append(gpa, .{ .escaped = field.name });
+                                if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                            }
+                            if (rec.is_open) {
+                                if (rec.fields.len > 0) try frames.append(gpa, .{ .html = ", " });
+                                if (rec.ext) |ext| {
+                                    try frames.append(gpa, .{ .doc_type = .{
+                                        .value = ext,
+                                        .needs_parens = false,
+                                        .indent = item.indent,
+                                    } });
+                                }
+                                try frames.append(gpa, .{ .html = ".." });
+                            }
+                            try frames.append(gpa, .{ .html = "{ " });
                         }
-                        try frames.append(gpa, .{ .html = "{ " });
                     },
                     .tag_union => |tu| {
-                        try frames.append(gpa, .{ .html = "]" });
-                        if (tu.is_open) {
-                            if (tu.ext) |ext| {
-                                try frames.append(gpa, .{ .doc_type = .{ .value = ext, .needs_parens = false } });
-                            }
-                            try frames.append(gpa, .{ .html = ".." });
-                            if (tu.tags.len > 0) try frames.append(gpa, .{ .html = ", " });
-                        }
-                        var i = tu.tags.len;
-                        while (i > 0) {
-                            i -= 1;
-                            const tag = tu.tags[i];
-                            if (tag.args.len > 0) {
-                                try frames.append(gpa, .{ .html = ")" });
-                                var j = tag.args.len;
-                                while (j > 0) {
-                                    j -= 1;
-                                    try frames.append(gpa, .{ .doc_type = .{ .value = tag.args[j], .needs_parens = false } });
-                                    if (j > 0) try frames.append(gpa, .{ .html = ", " });
+                        const multiline = !ctx.single_line_signatures and docTypeWillRenderMultiline(item.value);
+                        if (multiline) {
+                            try frames.append(gpa, .{ .html = "]" });
+                            try frames.append(gpa, .{ .indent = item.indent });
+                            if (tu.is_open) {
+                                try frames.append(gpa, .{ .html = ",\n" });
+                                if (tu.ext) |ext| {
+                                    try frames.append(gpa, .{ .doc_type = .{
+                                        .value = ext,
+                                        .needs_parens = false,
+                                        .indent = item.indent + 1,
+                                    } });
                                 }
-                                try frames.append(gpa, .{ .html = "(" });
+                                try frames.append(gpa, .{ .html = ".." });
+                                try frames.append(gpa, .{ .indent = item.indent + 1 });
                             }
-                            try frames.append(gpa, .{ .html = "</span>" });
-                            try frames.append(gpa, .{ .escaped = tag.name });
-                            try frames.append(gpa, .{ .html = "<span class=\"type\">" });
-                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                            var i = tu.tags.len;
+                            while (i > 0) {
+                                i -= 1;
+                                try frames.append(gpa, .{ .html = ",\n" });
+                                try frames.append(gpa, .{ .tag = .{
+                                    .value = tu.tags[i],
+                                    .indent = item.indent + 1,
+                                } });
+                                try frames.append(gpa, .{ .indent = item.indent + 1 });
+                            }
+                            try frames.append(gpa, .{ .html = "[\n" });
+                        } else {
+                            try frames.append(gpa, .{ .html = "]" });
+                            if (tu.is_open) {
+                                if (tu.ext) |ext| {
+                                    try frames.append(gpa, .{ .doc_type = .{
+                                        .value = ext,
+                                        .needs_parens = false,
+                                        .indent = item.indent,
+                                    } });
+                                }
+                                try frames.append(gpa, .{ .html = ".." });
+                                if (tu.tags.len > 0) try frames.append(gpa, .{ .html = ", " });
+                            }
+                            var i = tu.tags.len;
+                            while (i > 0) {
+                                i -= 1;
+                                try frames.append(gpa, .{ .tag = .{
+                                    .value = tu.tags[i],
+                                    .indent = item.indent,
+                                } });
+                                if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                            }
+                            try frames.append(gpa, .{ .html = "[" });
                         }
-                        try frames.append(gpa, .{ .html = "[" });
                     },
                     .tuple => |tup| {
                         try frames.append(gpa, .{ .html = ")" });
-                        var i = tup.elems.len;
-                        while (i > 0) {
-                            i -= 1;
-                            try frames.append(gpa, .{ .doc_type = .{ .value = tup.elems[i], .needs_parens = false } });
-                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                        const multiline = !ctx.single_line_signatures and docTypeWillRenderMultiline(item.value);
+                        if (multiline) {
+                            try frames.append(gpa, .{ .indent = item.indent });
+                            var i = tup.elems.len;
+                            while (i > 0) {
+                                i -= 1;
+                                try frames.append(gpa, .{ .html = ",\n" });
+                                try frames.append(gpa, .{ .doc_type = .{
+                                    .value = tup.elems[i],
+                                    .needs_parens = false,
+                                    .indent = item.indent + 1,
+                                } });
+                                try frames.append(gpa, .{ .indent = item.indent + 1 });
+                            }
+                            try frames.append(gpa, .{ .html = "(\n" });
+                        } else {
+                            var i = tup.elems.len;
+                            while (i > 0) {
+                                i -= 1;
+                                try frames.append(gpa, .{ .doc_type = .{
+                                    .value = tup.elems[i],
+                                    .needs_parens = false,
+                                    .indent = item.indent,
+                                } });
+                                if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                            }
+                            try frames.append(gpa, .{ .html = "(" });
                         }
-                        try frames.append(gpa, .{ .html = "(" });
                     },
                     .apply => |app| {
                         try frames.append(gpa, .{ .html = ")" });
-                        var i = app.args.len;
-                        while (i > 0) {
-                            i -= 1;
-                            try frames.append(gpa, .{ .doc_type = .{ .value = app.args[i], .needs_parens = false } });
-                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                        const multiline = !ctx.single_line_signatures and docTypeWillRenderMultiline(item.value);
+                        if (multiline) {
+                            try frames.append(gpa, .{ .indent = item.indent });
+                            var i = app.args.len;
+                            while (i > 0) {
+                                i -= 1;
+                                try frames.append(gpa, .{ .html = ",\n" });
+                                try frames.append(gpa, .{ .doc_type = .{
+                                    .value = app.args[i],
+                                    .needs_parens = false,
+                                    .indent = item.indent + 1,
+                                } });
+                                try frames.append(gpa, .{ .indent = item.indent + 1 });
+                            }
+                            try frames.append(gpa, .{ .html = "(\n" });
+                        } else {
+                            var i = app.args.len;
+                            while (i > 0) {
+                                i -= 1;
+                                try frames.append(gpa, .{ .doc_type = .{
+                                    .value = app.args[i],
+                                    .needs_parens = false,
+                                    .indent = item.indent,
+                                } });
+                                if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                            }
+                            try frames.append(gpa, .{ .html = "(" });
                         }
-                        try frames.append(gpa, .{ .html = "(" });
-                        try frames.append(gpa, .{ .doc_type = .{ .value = app.constructor, .needs_parens = false } });
+                        try frames.append(gpa, .{ .doc_type = .{
+                            .value = app.constructor,
+                            .needs_parens = false,
+                            .indent = item.indent,
+                        } });
                     },
                     .where_clause => |wc| {
-                        if (ctx.single_line_signatures) {
+                        const multiline = !ctx.single_line_signatures and docTypeWillRenderMultiline(item.value);
+                        if (!multiline) {
                             // Inline layout keeps the whole where clause on one
                             // line, matching the nowrap search entries.
                             try frames.append(gpa, .{ .html = "]" });
@@ -2034,7 +2220,11 @@ fn renderDocTypeHtml(
                             while (i > 0) {
                                 i -= 1;
                                 const constraint = wc.constraints[i];
-                                try frames.append(gpa, .{ .doc_type = .{ .value = constraint.signature, .needs_parens = false } });
+                                try frames.append(gpa, .{ .doc_type = .{
+                                    .value = constraint.signature,
+                                    .needs_parens = false,
+                                    .indent = item.indent,
+                                } });
                                 try frames.append(gpa, .{ .html = " : " });
                                 try frames.append(gpa, .{ .escaped = constraint.method_name });
                                 try frames.append(gpa, .{ .html = "</span>." });
@@ -2043,28 +2233,43 @@ fn renderDocTypeHtml(
                                 if (i > 0) try frames.append(gpa, .{ .html = ", " });
                             }
                             try frames.append(gpa, .{ .html = " <span class=\"kw\">where</span> [" });
-                            try frames.append(gpa, .{ .doc_type = .{ .value = wc.type, .needs_parens = item.needs_parens } });
+                            try frames.append(gpa, .{ .doc_type = .{
+                                .value = wc.type,
+                                .needs_parens = item.needs_parens,
+                                .indent = item.indent,
+                            } });
                         } else {
                             // Multi-line layout mirrors how `roc format` lays
                             // out where clauses; the enclosing block uses
                             // white-space: pre-wrap so the literal newlines and
                             // indentation render as written.
-                            try frames.append(gpa, .{ .html = "    ]" });
+                            try frames.append(gpa, .{ .html = "]" });
+                            try frames.append(gpa, .{ .indent = item.indent + 1 });
                             var i = wc.constraints.len;
                             while (i > 0) {
                                 i -= 1;
                                 const constraint = wc.constraints[i];
                                 try frames.append(gpa, .{ .html = ",\n" });
-                                try frames.append(gpa, .{ .doc_type = .{ .value = constraint.signature, .needs_parens = false } });
+                                try frames.append(gpa, .{ .doc_type = .{
+                                    .value = constraint.signature,
+                                    .needs_parens = false,
+                                    .indent = item.indent + 2,
+                                } });
                                 try frames.append(gpa, .{ .html = " : " });
                                 try frames.append(gpa, .{ .escaped = constraint.method_name });
                                 try frames.append(gpa, .{ .html = "</span>." });
                                 try frames.append(gpa, .{ .escaped = constraint.type_var });
                                 try frames.append(gpa, .{ .html = "<span class=\"type-var\">" });
-                                try frames.append(gpa, .{ .html = "        " });
+                                try frames.append(gpa, .{ .indent = item.indent + 2 });
                             }
-                            try frames.append(gpa, .{ .html = "\n    <span class=\"kw\">where</span> [\n" });
-                            try frames.append(gpa, .{ .doc_type = .{ .value = wc.type, .needs_parens = item.needs_parens } });
+                            try frames.append(gpa, .{ .html = "<span class=\"kw\">where</span> [\n" });
+                            try frames.append(gpa, .{ .indent = item.indent + 1 });
+                            try frames.append(gpa, .{ .html = "\n" });
+                            try frames.append(gpa, .{ .doc_type = .{
+                                .value = wc.type,
+                                .needs_parens = item.needs_parens,
+                                .indent = item.indent,
+                            } });
                         }
                     },
                     .wildcard => {
@@ -2074,6 +2279,42 @@ fn renderDocTypeHtml(
                         try frames.append(gpa, .{ .html = "?" });
                     },
                 }
+            },
+            .tag => |item| {
+                const multiline = !ctx.single_line_signatures and tagWillRenderMultiline(item.value);
+                if (item.value.args.len > 0) {
+                    try frames.append(gpa, .{ .html = ")" });
+                    if (multiline) {
+                        try frames.append(gpa, .{ .indent = item.indent });
+                        var i = item.value.args.len;
+                        while (i > 0) {
+                            i -= 1;
+                            try frames.append(gpa, .{ .html = ",\n" });
+                            try frames.append(gpa, .{ .doc_type = .{
+                                .value = item.value.args[i],
+                                .needs_parens = false,
+                                .indent = item.indent + 1,
+                            } });
+                            try frames.append(gpa, .{ .indent = item.indent + 1 });
+                        }
+                        try frames.append(gpa, .{ .html = "(\n" });
+                    } else {
+                        var i = item.value.args.len;
+                        while (i > 0) {
+                            i -= 1;
+                            try frames.append(gpa, .{ .doc_type = .{
+                                .value = item.value.args[i],
+                                .needs_parens = false,
+                                .indent = item.indent,
+                            } });
+                            if (i > 0) try frames.append(gpa, .{ .html = ", " });
+                        }
+                        try frames.append(gpa, .{ .html = "(" });
+                    }
+                }
+                try frames.append(gpa, .{ .html = "</span>" });
+                try frames.append(gpa, .{ .escaped = item.value.name });
+                try frames.append(gpa, .{ .html = "<span class=\"type\">" });
             },
         }
     }
@@ -2482,6 +2723,62 @@ test "renderDocTypeHtml renders where clause single-line when single_line_signat
     );
 }
 
+test "renderDocTypeHtml expands trailing-comma collections and their parents" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    const list_constructor = try gpa.create(DocType);
+    list_constructor.* = .{ .type_ref = .{
+        .module_path = try gpa.dupe(u8, ""),
+        .type_name = try gpa.dupe(u8, "List"),
+    } };
+    const u8_type = try gpa.create(DocType);
+    u8_type.* = .{ .type_ref = .{
+        .module_path = try gpa.dupe(u8, ""),
+        .type_name = try gpa.dupe(u8, "U8"),
+    } };
+    const list_args = try gpa.alloc(*const DocType, 1);
+    list_args[0] = u8_type;
+    const list_type = try gpa.create(DocType);
+    list_type.* = .{ .apply = .{
+        .constructor = list_constructor,
+        .args = list_args,
+        .layout = .multiline,
+    } };
+    const tuple_elems = try gpa.alloc(*const DocType, 1);
+    tuple_elems[0] = list_type;
+    const root = try gpa.create(DocType);
+    root.* = .{ .tuple = .{
+        .elems = tuple_elems,
+        .layout = .compact,
+    } };
+    defer {
+        root.deinit(gpa);
+        gpa.destroy(root);
+    }
+
+    const package_docs = DocModel.PackageDocs{
+        .name = "Test",
+        .modules = &[_]DocModel.ModuleDocs{},
+    };
+    var ctx = try RenderContext.init(&package_docs, gpa);
+    defer ctx.deinit(gpa);
+    ctx.suppress_type_links = true;
+
+    var output: std.Io.Writer.Allocating = .init(gpa);
+    defer output.deinit();
+
+    try renderDocTypeHtml(&output.writer, &ctx, gpa, root, false);
+    try testing.expectEqualStrings(
+        "(\n" ++
+            "    <span class=\"type\">List</span>(\n" ++
+            "        <span class=\"type\">U8</span>,\n" ++
+            "    ),\n" ++
+            ")",
+        output.written(),
+    );
+}
+
 /// Builds a heap-allocated `where` clause DocType for the rendering tests:
 /// `Bool where [ k.is_eq : k, v.to_hash : v ]`.
 fn buildWhereClauseFixture(gpa: Allocator) Allocator.Error!*const DocType {
@@ -2513,6 +2810,7 @@ fn buildWhereClauseFixture(gpa: Allocator) Allocator.Error!*const DocType {
     root.* = .{ .where_clause = .{
         .type = bool_type,
         .constraints = constraints,
+        .layout = .multiline,
     } };
     return root;
 }

--- a/src/docs/render_html.zig
+++ b/src/docs/render_html.zig
@@ -1886,61 +1886,140 @@ fn validateAnchor(
     try ctx.reportBrokenLink(label, anchor, bracket_offset);
 }
 
-fn tagWillRenderMultiline(tag: DocType.Tag) bool {
-    if (tag.layout == .multiline and tag.args.len > 0) return true;
-    for (tag.args) |arg| {
-        if (docTypeWillRenderMultiline(arg)) return true;
-    }
-    return false;
-}
+const MultilineLayoutSet = struct {
+    values: std.AutoHashMapUnmanaged(*const DocType, void) = .empty,
 
-fn docTypeWillRenderMultiline(doc_type: *const DocType) bool {
-    return switch (doc_type.*) {
-        .type_ref, .type_var, .wildcard, .@"error" => false,
-        .function => |func| blk: {
-            for (func.args) |arg| {
-                if (docTypeWillRenderMultiline(arg)) break :blk true;
+    fn init(gpa: Allocator, root: *const DocType) Allocator.Error!MultilineLayoutSet {
+        const Frame = struct {
+            value: *const DocType,
+            children_visited: bool,
+        };
+
+        var result = MultilineLayoutSet{};
+        errdefer result.deinit(gpa);
+
+        var frames = std.ArrayList(Frame).empty;
+        defer frames.deinit(gpa);
+        try frames.append(gpa, .{ .value = root, .children_visited = false });
+
+        while (frames.pop()) |frame| {
+            if (frame.children_visited) {
+                if (result.nodeIsMultiline(frame.value)) {
+                    try result.values.put(gpa, frame.value, {});
+                }
+                continue;
             }
-            break :blk docTypeWillRenderMultiline(func.ret);
-        },
-        .record => |rec| blk: {
-            if (rec.layout == .multiline and (rec.fields.len > 0 or rec.is_open)) break :blk true;
-            for (rec.fields) |field| {
-                if (docTypeWillRenderMultiline(field.type)) break :blk true;
+
+            try frames.append(gpa, .{ .value = frame.value, .children_visited = true });
+            switch (frame.value.*) {
+                .type_ref, .type_var, .wildcard, .@"error" => {},
+                .function => |func| {
+                    try frames.append(gpa, .{ .value = func.ret, .children_visited = false });
+                    for (func.args) |arg| {
+                        try frames.append(gpa, .{ .value = arg, .children_visited = false });
+                    }
+                },
+                .record => |rec| {
+                    if (rec.ext) |ext| try frames.append(gpa, .{ .value = ext, .children_visited = false });
+                    for (rec.fields) |field| {
+                        try frames.append(gpa, .{ .value = field.type, .children_visited = false });
+                    }
+                },
+                .tag_union => |tu| {
+                    if (tu.ext) |ext| try frames.append(gpa, .{ .value = ext, .children_visited = false });
+                    for (tu.tags) |tag| {
+                        for (tag.args) |arg| {
+                            try frames.append(gpa, .{ .value = arg, .children_visited = false });
+                        }
+                    }
+                },
+                .tuple => |tup| {
+                    for (tup.elems) |elem| {
+                        try frames.append(gpa, .{ .value = elem, .children_visited = false });
+                    }
+                },
+                .apply => |app| {
+                    try frames.append(gpa, .{ .value = app.constructor, .children_visited = false });
+                    for (app.args) |arg| {
+                        try frames.append(gpa, .{ .value = arg, .children_visited = false });
+                    }
+                },
+                .where_clause => |wc| {
+                    try frames.append(gpa, .{ .value = wc.type, .children_visited = false });
+                    for (wc.constraints) |constraint| {
+                        try frames.append(gpa, .{ .value = constraint.signature, .children_visited = false });
+                    }
+                },
             }
-            break :blk if (rec.ext) |ext| docTypeWillRenderMultiline(ext) else false;
-        },
-        .tag_union => |tu| blk: {
-            if (tu.layout == .multiline and (tu.tags.len > 0 or tu.is_open)) break :blk true;
-            for (tu.tags) |tag| {
-                if (tagWillRenderMultiline(tag)) break :blk true;
-            }
-            break :blk if (tu.ext) |ext| docTypeWillRenderMultiline(ext) else false;
-        },
-        .tuple => |tup| blk: {
-            if (tup.layout == .multiline and tup.elems.len > 0) break :blk true;
-            for (tup.elems) |elem| {
-                if (docTypeWillRenderMultiline(elem)) break :blk true;
-            }
-            break :blk false;
-        },
-        .apply => |app| blk: {
-            if (app.layout == .multiline and app.args.len > 0) break :blk true;
-            for (app.args) |arg| {
-                if (docTypeWillRenderMultiline(arg)) break :blk true;
-            }
-            break :blk false;
-        },
-        .where_clause => |wc| blk: {
-            if (wc.layout == .multiline and wc.constraints.len > 0) break :blk true;
-            if (docTypeWillRenderMultiline(wc.type)) break :blk true;
-            for (wc.constraints) |constraint| {
-                if (docTypeWillRenderMultiline(constraint.signature)) break :blk true;
-            }
-            break :blk false;
-        },
-    };
-}
+        }
+
+        return result;
+    }
+
+    fn deinit(self: *MultilineLayoutSet, gpa: Allocator) void {
+        self.values.deinit(gpa);
+    }
+
+    fn contains(self: *const MultilineLayoutSet, value: *const DocType) bool {
+        return self.values.contains(value);
+    }
+
+    fn tagIsMultiline(self: *const MultilineLayoutSet, tag: DocType.Tag) bool {
+        if (tag.layout == .multiline and tag.args.len > 0) return true;
+        for (tag.args) |arg| {
+            if (self.contains(arg)) return true;
+        }
+        return false;
+    }
+
+    fn nodeIsMultiline(self: *const MultilineLayoutSet, value: *const DocType) bool {
+        return switch (value.*) {
+            .type_ref, .type_var, .wildcard, .@"error" => false,
+            .function => |func| blk: {
+                for (func.args) |arg| {
+                    if (self.contains(arg)) break :blk true;
+                }
+                break :blk self.contains(func.ret);
+            },
+            .record => |rec| blk: {
+                if (rec.layout == .multiline and (rec.fields.len > 0 or rec.is_open)) break :blk true;
+                for (rec.fields) |field| {
+                    if (self.contains(field.type)) break :blk true;
+                }
+                break :blk if (rec.ext) |ext| self.contains(ext) else false;
+            },
+            .tag_union => |tu| blk: {
+                if (tu.layout == .multiline and (tu.tags.len > 0 or tu.is_open)) break :blk true;
+                for (tu.tags) |tag| {
+                    if (self.tagIsMultiline(tag)) break :blk true;
+                }
+                break :blk if (tu.ext) |ext| self.contains(ext) else false;
+            },
+            .tuple => |tup| blk: {
+                if (tup.layout == .multiline and tup.elems.len > 0) break :blk true;
+                for (tup.elems) |elem| {
+                    if (self.contains(elem)) break :blk true;
+                }
+                break :blk false;
+            },
+            .apply => |app| blk: {
+                if (app.layout == .multiline and app.args.len > 0) break :blk true;
+                for (app.args) |arg| {
+                    if (self.contains(arg)) break :blk true;
+                }
+                break :blk false;
+            },
+            .where_clause => |wc| blk: {
+                if (wc.layout == .multiline and wc.constraints.len > 0) break :blk true;
+                if (self.contains(wc.type)) break :blk true;
+                for (wc.constraints) |constraint| {
+                    if (self.contains(constraint.signature)) break :blk true;
+                }
+                break :blk false;
+            },
+        };
+    }
+};
 
 fn renderDocTypeHtml(
     w: Writer,
@@ -1964,6 +2043,9 @@ fn renderDocTypeHtml(
         escaped: []const u8,
         type_ref: DocType.TypeRef,
     };
+
+    var multiline_layouts = try MultilineLayoutSet.init(gpa, doc_type);
+    defer multiline_layouts.deinit(gpa);
 
     var frames = std.ArrayList(RenderFrame).empty;
     defer frames.deinit(gpa);
@@ -2030,7 +2112,7 @@ fn renderDocTypeHtml(
                         if (item.needs_parens) try frames.append(gpa, .{ .html = "(" });
                     },
                     .record => |rec| {
-                        const multiline = !ctx.single_line_signatures and docTypeWillRenderMultiline(item.value);
+                        const multiline = !ctx.single_line_signatures and multiline_layouts.contains(item.value);
                         if (multiline) {
                             try frames.append(gpa, .{ .html = "}" });
                             try frames.append(gpa, .{ .indent = item.indent });
@@ -2091,7 +2173,7 @@ fn renderDocTypeHtml(
                         }
                     },
                     .tag_union => |tu| {
-                        const multiline = !ctx.single_line_signatures and docTypeWillRenderMultiline(item.value);
+                        const multiline = !ctx.single_line_signatures and multiline_layouts.contains(item.value);
                         if (multiline) {
                             try frames.append(gpa, .{ .html = "]" });
                             try frames.append(gpa, .{ .indent = item.indent });
@@ -2145,7 +2227,7 @@ fn renderDocTypeHtml(
                     },
                     .tuple => |tup| {
                         try frames.append(gpa, .{ .html = ")" });
-                        const multiline = !ctx.single_line_signatures and docTypeWillRenderMultiline(item.value);
+                        const multiline = !ctx.single_line_signatures and multiline_layouts.contains(item.value);
                         if (multiline) {
                             try frames.append(gpa, .{ .indent = item.indent });
                             var i = tup.elems.len;
@@ -2176,7 +2258,7 @@ fn renderDocTypeHtml(
                     },
                     .apply => |app| {
                         try frames.append(gpa, .{ .html = ")" });
-                        const multiline = !ctx.single_line_signatures and docTypeWillRenderMultiline(item.value);
+                        const multiline = !ctx.single_line_signatures and multiline_layouts.contains(item.value);
                         if (multiline) {
                             try frames.append(gpa, .{ .indent = item.indent });
                             var i = app.args.len;
@@ -2211,7 +2293,7 @@ fn renderDocTypeHtml(
                         } });
                     },
                     .where_clause => |wc| {
-                        const multiline = !ctx.single_line_signatures and docTypeWillRenderMultiline(item.value);
+                        const multiline = !ctx.single_line_signatures and multiline_layouts.contains(item.value);
                         if (!multiline) {
                             // Inline layout keeps the whole where clause on one
                             // line, matching the nowrap search entries.
@@ -2281,7 +2363,7 @@ fn renderDocTypeHtml(
                 }
             },
             .tag => |item| {
-                const multiline = !ctx.single_line_signatures and tagWillRenderMultiline(item.value);
+                const multiline = !ctx.single_line_signatures and multiline_layouts.tagIsMultiline(item.value);
                 if (item.value.args.len > 0) {
                     try frames.append(gpa, .{ .html = ")" });
                     if (multiline) {


### PR DESCRIPTION
Documentation signatures now preserve trailing-comma collection layout from explicit source annotations and render expanded collections with formatter-style indentation and trailing commas. Inferred signatures default collection-shaped types to expanded layout, while search entries remain single-line.