### PR TITLE
Apply confirmed findings from the dispatch-evidence review

### DIFF
--- a/design.md
+++ b/design.md
@@ -3088,8 +3088,9 @@ constraints to guess a target.
 Totality is enforced at the boundary: `validateDispatchEvidence`, run by the
 checked module's `verifyComplete`, asserts that every dispatch-bearing
 checked expression names a plan and that every plan and evidence reference
-lands inside the checked module data's evidence tables. A missing or corrupt
-record is a compiler bug reported at the boundary, not a lowering panic.
+lands inside the checked module data's evidence tables. In debug builds —
+where the boundary verifiers run — a missing or corrupt record is a compiler
+bug reported at the boundary, not a lowering panic.
 
 **Evidence params.** Every type scheme with dispatch requirements has one
 deterministic ordered list of (dispatcher var, constraint) pairs —

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -13068,8 +13068,7 @@ const EvidencePass = struct {
         var params = std.ArrayListUnmanaged(EvidenceParam).empty;
         defer params.deinit(self.allocator);
 
-        // by_def maps source defs to templates; entry wrappers and intrinsic
-        // wrappers have no scheme of their own (empty params).
+        // by_def maps source defs to templates.
         var template_defs = std.AutoHashMap(u32, CIR.Def.Idx).init(self.allocator);
         defer template_defs.deinit();
         for (self.templates.by_def) |entry| {
@@ -13078,7 +13077,13 @@ const EvidencePass = struct {
 
         for (self.templates.templates, 0..) |*template, template_index| {
             params.clearRetainingCapacity();
-            if (template_defs.get(@intFromEnum(template.template_id))) |def_idx| {
+            if (template.body == .intrinsic_wrapper) {
+                // Intrinsic wrappers have no scheme of their own: their
+                // published evidence params are empty by construction, even
+                // though their annotation defs appear in `by_def`. Monotype
+                // lowering relies on this — an under-supplied intrinsic
+                // wrapper request is a consumer invariant.
+            } else if (template_defs.get(@intFromEnum(template.template_id))) |def_idx| {
                 try self.enumerateParams(ModuleEnv.varFrom(def_idx), &params);
             } else switch (template.body) {
                 // An entry wrapper evaluates a compile-time root; plans inside

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -26730,6 +26730,40 @@ pub const CheckedModuleArtifact = struct {
         }
     }
 
+    /// One dispatch-expression plan reference checked for the boundary
+    /// validator: `required` distinguishes expressions that must always name
+    /// a plan from the numeral/quote fast paths, where a null plan means the
+    /// concrete-builtin route that never consults one.
+    fn dispatchPlanFailure(
+        table: *const static_dispatch.StaticDispatchPlanTable,
+        maybe_plan: ?StaticDispatchPlanId,
+        expr: CheckedExprId,
+        required: bool,
+    ) ?DispatchEvidenceFailure {
+        const plan = maybe_plan orelse
+            return if (required) .{ .kind = .dispatch_expr_missing_plan, .expr = expr } else null;
+        if (@intFromEnum(plan) >= table.plans.len) {
+            return .{ .kind = .dispatch_expr_plan_out_of_bounds, .expr = expr };
+        }
+        return null;
+    }
+
+    /// The iterator-plan twin of `dispatchPlanFailure`; `for_` always
+    /// requires a plan, anchored by expression or statement index.
+    fn iteratorPlanFailure(
+        table: *const static_dispatch.StaticDispatchPlanTable,
+        maybe_plan: ?static_dispatch.IteratorForPlanId,
+        expr: ?CheckedExprId,
+        index: ?u32,
+    ) ?DispatchEvidenceFailure {
+        const plan = maybe_plan orelse
+            return .{ .kind = .iterator_for_missing_plan, .expr = expr, .index = index };
+        if (@intFromEnum(plan) >= table.iterator_for_plans.len) {
+            return .{ .kind = .iterator_for_plan_out_of_bounds, .expr = expr, .index = index };
+        }
+        return null;
+    }
+
     /// Public `validateDispatchEvidence` function.
     ///
     /// Dispatch-evidence totality at the check/postcheck boundary: every
@@ -26737,62 +26771,30 @@ pub const CheckedModuleArtifact = struct {
     /// evidence reference lands inside the artifact's evidence tables, and
     /// the site-evidence index is sound. Monotype lowering consumes these
     /// records without re-deriving targets, so a violation is a compiler bug
-    /// reported here at the boundary — not a lowering panic. Returns the
-    /// first failure found, or null when the artifact is total.
+    /// reported here at the boundary (in debug builds, where `verifyComplete`
+    /// runs) — not a lowering panic. Returns the first failure found, or
+    /// null when the artifact is total.
     pub fn validateDispatchEvidence(self: *const CheckedModuleArtifact) ?DispatchEvidenceFailure {
         const table = &self.static_dispatch_plans;
 
         for (self.checked_bodies.stored_exprs.items) |expr| {
-            switch (expr.data) {
-                .dispatch_call, .type_dispatch_call, .method_eq => |maybe_plan| {
-                    const plan = maybe_plan orelse
-                        return .{ .kind = .dispatch_expr_missing_plan, .expr = expr.id };
-                    if (@intFromEnum(plan) >= table.plans.len) {
-                        return .{ .kind = .dispatch_expr_plan_out_of_bounds, .expr = expr.id };
-                    }
-                },
-                .interpolation => |interpolation| {
-                    const plan = interpolation.plan orelse
-                        return .{ .kind = .dispatch_expr_missing_plan, .expr = expr.id };
-                    if (@intFromEnum(plan) >= table.plans.len) {
-                        return .{ .kind = .dispatch_expr_plan_out_of_bounds, .expr = expr.id };
-                    }
-                },
-                // A null numeral/quote plan is the concrete-builtin fast
-                // path: monotype lowering produces the bits directly and
-                // never consults a plan.
-                .numeral => |numeral| if (numeral.plan) |plan| {
-                    if (@intFromEnum(plan) >= table.plans.len) {
-                        return .{ .kind = .dispatch_expr_plan_out_of_bounds, .expr = expr.id };
-                    }
-                },
-                .str_from_quote => |quote| if (quote.plan) |plan| {
-                    if (@intFromEnum(plan) >= table.plans.len) {
-                        return .{ .kind = .dispatch_expr_plan_out_of_bounds, .expr = expr.id };
-                    }
-                },
-                .for_ => |for_| {
-                    const plan = for_.plan orelse
-                        return .{ .kind = .iterator_for_missing_plan, .expr = expr.id };
-                    if (@intFromEnum(plan) >= table.iterator_for_plans.len) {
-                        return .{ .kind = .iterator_for_plan_out_of_bounds, .expr = expr.id };
-                    }
-                },
-                else => {},
-            }
+            const expr_failure: ?DispatchEvidenceFailure = switch (expr.data) {
+                .dispatch_call, .type_dispatch_call, .method_eq => |maybe_plan| dispatchPlanFailure(table, maybe_plan, expr.id, true),
+                .interpolation => |interpolation| dispatchPlanFailure(table, interpolation.plan, expr.id, true),
+                .numeral => |numeral| dispatchPlanFailure(table, numeral.plan, expr.id, false),
+                .str_from_quote => |quote| dispatchPlanFailure(table, quote.plan, expr.id, false),
+                .for_ => |for_| iteratorPlanFailure(table, for_.plan, expr.id, null),
+                else => null,
+            };
+            if (expr_failure) |failure| return failure;
         }
 
         for (self.checked_bodies.stored_statements.items, 0..) |statement, i| {
-            switch (statement.data) {
-                .for_ => |for_| {
-                    const plan = for_.plan orelse
-                        return .{ .kind = .iterator_for_missing_plan, .index = @intCast(i) };
-                    if (@intFromEnum(plan) >= table.iterator_for_plans.len) {
-                        return .{ .kind = .iterator_for_plan_out_of_bounds, .index = @intCast(i) };
-                    }
-                },
-                else => {},
-            }
+            const statement_failure: ?DispatchEvidenceFailure = switch (statement.data) {
+                .for_ => |for_| iteratorPlanFailure(table, for_.plan, null, @intCast(i)),
+                else => null,
+            };
+            if (statement_failure) |failure| return failure;
         }
 
         for (table.plans, 0..) |plan, i| {

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -2837,7 +2837,8 @@ test "compiler-generated dispatch classes lower via checked evidence" {
     // `Str.inspect` through a custom `to_inspect`, and parser-format
     // synthesis with builtin Set helpers (JSON parse of a Set field).
     // Debug-mode lowering asserts dispatch-evidence totality by invariant
-    // throughout, so completing the lowering is the assertion.
+    // throughout, and the evaluated output asserts every class resolved to
+    // the RIGHT target, not merely some lowerable one.
     const source =
         \\module [main]
         \\
@@ -2848,7 +2849,7 @@ test "compiler-generated dispatch classes lower via checked evidence" {
         \\    to_inspect = |Speed.Mph(mph)| Str.inspect(mph)
         \\}
         \\
-        \\main : Str
+        \\main : Bool
         \\main = {
         \\    var $sum = 0.U64
         \\    for item in [1.U64, 2.U64, 3.U64] {
@@ -2862,15 +2863,19 @@ test "compiler-generated dispatch classes lower via checked evidence" {
         \\        Ok(rec) => rec.names.len()
         \\        Err(_) => 0
         \\    }
-        \\    if lhs == rhs and parsed_count > 0 Str.inspect(lhs.speed) else "no"
+        \\    lhs == rhs and parsed_count == 2 and Str.inspect(lhs.speed) == "6"
         \\}
     ;
 
-    var mono = try lowerMonotypeModule(allocator, source);
-    defer mono.deinit(allocator);
+    var compiled = try helpers.compileInspectedProgramWithBuiltin(allocator, std.testing.io, .module, source, &.{}, try sharedPrePublishedBuiltin(), null);
+    defer compiled.deinit(allocator);
 
     // The program must check cleanly: a reported problem would resolve the
     // dispatch plans as checked errors and crash-lower the very classes this
     // test exists to exercise.
-    try std.testing.expectEqual(@as(usize, 0), mono.resources.checker.problems.problems.items.len);
+    try std.testing.expectEqual(@as(usize, 0), compiled.resources.checker.problems.problems.items.len);
+
+    const output = try helpers.lirInterpreterInspectedStr(allocator, &compiled.lowered);
+    defer allocator.free(output);
+    try std.testing.expectEqualStrings("True", output);
 }

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -2857,13 +2857,14 @@ test "compiler-generated dispatch classes lower via checked evidence" {
         \\    }
         \\    lhs = { speed: Speed.Mph($sum), label: "total" }
         \\    rhs = { speed: Speed.Mph(6), label: "total" }
+        \\    other = { speed: Speed.Mph(7), label: "total" }
         \\    parsed : Try({ names : Set(Str) }, Json.ParseErr)
         \\    parsed = Json.parse("{ \"names\": [\"a\", \"b\"] }")
         \\    parsed_count = match parsed {
         \\        Ok(rec) => rec.names.len()
         \\        Err(_) => 0
         \\    }
-        \\    lhs == rhs and parsed_count == 2 and Str.inspect(lhs.speed) == "6"
+        \\    lhs == rhs and lhs != other and parsed_count == 2 and Str.inspect(lhs.speed) == "6"
         \\}
     ;
 

--- a/src/postcheck/common.zig
+++ b/src/postcheck/common.zig
@@ -109,6 +109,14 @@ pub fn invariant(comptime message: []const u8) noreturn {
     unreachable;
 }
 
+/// `invariant` with runtime context formatted into the panic message.
+pub fn invariantFmt(comptime fmt: []const u8, args: anytype) noreturn {
+    if (@import("builtin").mode == .Debug) {
+        std.debug.panic("postcheck invariant violated: " ++ fmt, args);
+    }
+    unreachable;
+}
+
 /// Monotonic symbol id generator for post-check stages.
 pub const SymbolGen = struct {
     next: u32 = 0,

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -2500,8 +2500,8 @@ const Builder = struct {
     /// user dispatch never resolves here — its targets are consumed from
     /// checked evidence.
     fn componentMethodTargetByName(self: *Builder, ty: Type.TypeId, method_name: []const u8) ?MethodLookup {
+        const owner = componentDispatchOwner(&self.program.types, ty) orelse return null;
         const method = self.program.names.lookupMethodName(method_name) orelse return null;
-        const owner = self.componentDispatchOwner(ty) orelse return null;
         return self.component_method_targets.get(.{ .owner = owner, .method = method });
     }
 
@@ -2514,29 +2514,6 @@ const Builder = struct {
         method: names.MethodNameId,
     ) ?MethodLookup {
         return self.componentMethodTargetByName(ty, method_view.names.methodNameText(method));
-    }
-
-    /// The registry key naming `ty`'s dispatch head, read from the checked
-    /// type identity the monotype carries; null for shapes with no head
-    /// (structural rows, functions, unsolved placeholders).
-    fn componentDispatchOwner(self: *Builder, ty: Type.TypeId) ?static_dispatch.MethodOwner {
-        return switch (self.program.types.dispatchHeadContent(ty)) {
-            .primitive => |primitive| .{ .builtin = Type.builtinOwnerForPrimitive(primitive) },
-            .list => .{ .builtin = .list },
-            .box => .{ .builtin = .box },
-            .named => |named| if (named.builtin_owner) |owner|
-                .{ .builtin = owner }
-            else if (named.kind == .alias)
-                // An alias with no backing has no head.
-                null
-            else
-                .{ .nominal = .{
-                    .module = named.def.module,
-                    .type_name = named.def.type_name,
-                    .source_decl = named.def.source_decl,
-                } },
-            else => null,
-        };
     }
 
     fn importModuleAlreadyScanned(self: *Builder, module_id: checked.ModuleId, import_index: usize) bool {
@@ -17520,41 +17497,19 @@ const BodyContext = struct {
         return self.materializeEvidence(refs);
     }
 
-    /// Evidence vector for a dispatch plan's chosen target (the target's own
-    /// requirements): a direct plan carries it as the evidence node's nested
-    /// refs; a constraint plan's edge-supplied target carries it materialized.
-    fn evidenceForDispatchTarget(self: *BodyContext, plan: static_dispatch.StaticDispatchCallPlan) Allocator.Error!SpecEvidenceVector {
-        switch (plan.resolution) {
+    /// Evidence vector for a dispatch plan's or iterator call's chosen target
+    /// (the target's own requirements): a direct resolution carries it as the
+    /// evidence node's nested refs; a constraint resolution's edge-supplied
+    /// target carries it materialized.
+    fn evidenceForResolvedTarget(self: *BodyContext, resolution: static_dispatch.StaticDispatchResolution) Allocator.Error!SpecEvidenceVector {
+        switch (resolution) {
             .direct => |node_id| {
                 const node = self.view.static_dispatch_plans.evidenceNode(node_id);
                 return .{ .resolved = try self.materializeEvidence(self.view.static_dispatch_plans.nestedEvidence(node)) };
             },
             .constraint => |constraint_ref| {
                 const entry = self.evidence.at(constraint_ref) orelse
-                    Common.invariant("dispatch plan's constraint ref was outside the edge's evidence chain");
-                return switch (entry) {
-                    .target => |target| switch (target.nested) {
-                        .resolved => |nested| .{ .resolved = nested },
-                        .synthesize => .synthesize,
-                    },
-                    .structural, .unreachable_value, .checked_error => .{ .resolved = &.{} },
-                };
-            },
-            .structural, .checked_error, .unreachable_dispatch => return .{ .resolved = &.{} },
-        }
-    }
-
-    /// Evidence vector for an iterator dispatch call's chosen target,
-    /// mirroring `evidenceForDispatchTarget` for `IteratorDispatchCall`s.
-    fn evidenceForIteratorCall(self: *BodyContext, call: static_dispatch.IteratorDispatchCall) Allocator.Error!SpecEvidenceVector {
-        switch (call.resolution) {
-            .direct => |node_id| {
-                const node = self.view.static_dispatch_plans.evidenceNode(node_id);
-                return .{ .resolved = try self.materializeEvidence(self.view.static_dispatch_plans.nestedEvidence(node)) };
-            },
-            .constraint => |constraint_ref| {
-                const entry = self.evidence.at(constraint_ref) orelse
-                    Common.invariant("iterator dispatch plan's constraint ref was outside the edge's evidence chain");
+                    Common.invariant("dispatch resolution's constraint ref was outside the edge's evidence chain");
                 return switch (entry) {
                     .target => |target| switch (target.nested) {
                         .resolved => |nested| .{ .resolved = nested },
@@ -17774,7 +17729,7 @@ const BodyContext = struct {
         method_name: []const u8,
     ) MethodLookup {
         return self.builder.componentMethodTargetByName(owner_ty, method_name) orelse
-            Common.invariant("checked method registry is missing a compiler-generated helper method");
+            Common.invariantFmt("checked method registry is missing compiler-generated helper method {s}", .{method_name});
     }
 
     /// Resolve a target's requirements from its checked dispatcher paths
@@ -18046,7 +18001,7 @@ const BodyContext = struct {
         const fn_data = self.builder.functionShape(callable_mono_ty, "checked dispatch target had a non-function type");
         const args = try arg_ctx.lowerDispatchOperandsAtTypes(plan.argsSlice(self.view.static_dispatch_plans), self.builder.program.types.span(fn_data.args), pre_lowered);
         return .{ .call_proc = .{
-            .callee = draftProcCalleeFromAst(Ast.procCalleeForSlot(try self.methodTargetCalleeWithMono(lookup, callable_mono_ty, try self.evidenceForDispatchTarget(plan)))),
+            .callee = draftProcCalleeFromAst(Ast.procCalleeForSlot(try self.methodTargetCalleeWithMono(lookup, callable_mono_ty, try self.evidenceForResolvedTarget(plan.resolution)))),
             .args = args,
         } };
     }
@@ -23213,7 +23168,7 @@ const BodyContext = struct {
         return try self.addExpr(.{
             .ty = fn_data.ret,
             .data = .{ .call_proc = .{
-                .callee = draftProcCalleeFromAst(Ast.procCalleeForSlot(try self.methodTargetCalleeWithMono(lookup, target_mono_ty, try self.evidenceForIteratorCall(plan)))),
+                .callee = draftProcCalleeFromAst(Ast.procCalleeForSlot(try self.methodTargetCalleeWithMono(lookup, target_mono_ty, try self.evidenceForResolvedTarget(plan.resolution)))),
                 .args = try self.addExprSpan(args),
             } },
         });
@@ -25193,28 +25148,46 @@ fn hostedTemplate(hosted: anytype) names.ProcTemplate {
     @compileError("unsupported hosted function payload");
 }
 
+/// The registry key naming `ty`'s dispatch head, read from the checked type
+/// identity the monotype carries (`named.def` / `builtin_owner`,
+/// alias-transparently); null for shapes with no head (structural rows,
+/// functions, unsolved placeholders). The one head reader: the component
+/// lookup and the shape predicates below all derive from it.
+fn componentDispatchOwner(types: *const Type.Store, ty: Type.TypeId) ?static_dispatch.MethodOwner {
+    return switch (types.dispatchHeadContent(ty)) {
+        .primitive => |primitive| .{ .builtin = Type.builtinOwnerForPrimitive(primitive) },
+        .list => .{ .builtin = .list },
+        .box => .{ .builtin = .box },
+        .named => |named| if (named.builtin_owner) |owner|
+            .{ .builtin = owner }
+        else if (named.kind == .alias)
+            // An alias with no backing has no head.
+            null
+        else
+            .{ .nominal = .{
+                .module = named.def.module,
+                .type_name = named.def.type_name,
+                .source_decl = named.def.source_decl,
+            } },
+        else => null,
+    };
+}
+
 /// Whether a dispatcher's monotype has grounded to a shape that names a
 /// dispatch head (a builtin or nominal type, alias-transparently). This only
 /// orders lowering — operand pre-lowering and argument-evidence passes wait
 /// for ungrounded dispatchers to solve; dispatch targets themselves are
 /// always consumed from checked evidence, never resolved from this shape.
 fn dispatcherIsGrounded(types: *const Type.Store, ty: Type.TypeId) bool {
-    return switch (types.dispatchHeadContent(ty)) {
-        .primitive, .list, .box => true,
-        .named => |named| named.builtin_owner != null or named.kind != .alias,
-        else => false,
-    };
+    return componentDispatchOwner(types, ty) != null;
 }
 
 /// Whether `ty`'s dispatch head is the given builtin (alias-transparently).
 /// Shape predicate only — never resolves a dispatch target.
 fn typeHasBuiltinHead(types: *const Type.Store, ty: Type.TypeId, owner: static_dispatch.BuiltinOwner) bool {
-    return switch (types.dispatchHeadContent(ty)) {
-        .primitive => |primitive| Type.builtinOwnerForPrimitive(primitive) == owner,
-        .list => owner == .list,
-        .box => owner == .box,
-        .named => |named| if (named.builtin_owner) |builtin| builtin == owner else false,
-        else => false,
+    return switch (componentDispatchOwner(types, ty) orelse return false) {
+        .builtin => |builtin| builtin == owner,
+        .nominal => false,
     };
 }
 

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -25220,34 +25220,7 @@ fn nominalHasDeclarationBacking(nominal: checked.CheckedNominalType) bool {
 }
 
 fn builtinOwner(builtin: ?checked.CheckedBuiltinNominal) ?static_dispatch.BuiltinOwner {
-    return switch (builtin orelse return null) {
-        .bool => .bool,
-        .str => .str,
-        .u8 => .u8,
-        .i8 => .i8,
-        .u16 => .u16,
-        .i16 => .i16,
-        .u32 => .u32,
-        .i32 => .i32,
-        .u64 => .u64,
-        .i64 => .i64,
-        .u128 => .u128,
-        .i128 => .i128,
-        .f32 => .f32,
-        .f64 => .f64,
-        .dec => .dec,
-        .list => .list,
-        .box => .box,
-        .dict => .dict,
-        .set => .set,
-        .parse_tag_union_spec => .parse_tag_union_spec,
-        .fields => .fields,
-        .field => .field,
-        .crypto_sha256_digest => .crypto_sha256_digest,
-        .crypto_sha256_hasher => .crypto_sha256_hasher,
-        .crypto_blake3_digest => .crypto_blake3_digest,
-        .crypto_blake3_hasher => .crypto_blake3_hasher,
-    };
+    return static_dispatch.builtinOwnerForCheckedBuiltin(builtin orelse return null);
 }
 
 fn primitiveInspectLowLevelOp(primitive: Type.Primitive) can.CIR.Expr.LowLevel {


### PR DESCRIPTION
An adversarial review of the dispatch-evidence migration (#10108, #10113) confirmed a handful of cleanups, applied here. The two byte-identical evidence-vector functions (`evidenceForDispatchTarget` / `evidenceForIteratorCall`) collapse into one function keyed on the shared `StaticDispatchResolution`; the component-lookup seam's dispatch-head read becomes a single free `componentDispatchOwner` that the `dispatcherIsGrounded` and `typeHasBuiltinHead` predicates derive from, replacing three hand-synced switches; and the seam checks the head before hashing the method name, restoring the short-circuit that predicate-style callers (e.g. `typeHasParserForTarget`) had before the consolidation.

Two diagnostics/robustness items: `methodLookupForTypeName`'s registry-miss panic now names the missing helper method via a new `Common.invariantFmt` (the plain `invariant` only takes comptime text, and one message had come to cover ~15 different helper methods), and the evidence pass now structurally excludes intrinsic-wrapper templates from evidence-param enumeration — their annotation defs sit in `by_def`, so they previously flowed through `enumerateParams` and their published params were empty only because both current intrinsics happen to be constraint-free. Finally, the per-class dispatch test now evaluates its program and asserts the output, so it observes that every compiler-generated edge resolved to the right target rather than merely completing the lowering.

A second commit folds in the review's minor notes: the boundary validator's six near-identical plan-bounds blocks collapse into two helpers, `lower.zig`'s `builtinOwner` delegates to the registry's identical `builtinOwnerForCheckedBuiltin` map, and the validator doc plus design.md say explicitly that the boundary report happens in debug builds.

The review's one confirmed bug is tracked separately in #10118 (pre-existing restored-closure evidence miscompile) and is not addressed here.
