### PR TITLE
Windows Notes for a workaround related to a Zig bug

### DIFF
--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -21,3 +21,7 @@ nix develop ./src
 buildcmd
 ./zig-out/bin/roc version
 ```
+
+## Windows Notes
+
+Due to a [Zig bug](https://github.com/ziglang/zig/issues/17652) related to extracting dependencies from tarball files containing symlinks (which is not allowed by default on Windows), you might encounter permission denial issues. The workaround is to enable the `Developer Mode` option on Windows, which could be found under `Settings > System > Advanced`. If that does not work, please review the aforementioned bug for any additional clues.


### PR DESCRIPTION
I tried building the Roc compiler from source on a Windows 11 machine, with zig 0.16. I stumbled on one issue caused by some zig dependency using symlinks, which are not allowed by default on Windows (see: https://github.com/ziglang/zig/issues/17652)

The workaround was to enable the "Developer Mode" in the "System > Advanced" settings on Windows.

Although it is not a Roc issue, until that bug is fixed, I thought it was worthwhile to add a note to that effect in the `BUILDING_FROM_SOURCE.md` file.