### PR TITLE
Fix run-check-snapshots on Windows and document the wasm32 test prerequisite

### DIFF
--- a/CONTRIBUTING/README.md
+++ b/CONTRIBUTING/README.md
@@ -65,6 +65,19 @@ first builds the inputs behind `build-ci`, then runs the leaf `run-check-*` and
 `run-test-*` jobs with separate logs and report entries. It actually runs the
 tests; it does not just build them.
 
+### Test prerequisites
+
+The `run-test-cli` job includes the glue test suite, which compiles generated
+Rust glue for the `wasm32` target. Install a Rust toolchain (via [rustup]) with
+the WebAssembly target so those cases can build:
+
+```sh
+rustup target add wasm32-unknown-unknown
+```
+
+Without it, the glue cases fail with `error[E0463]: can't find crate for std`
+(`the wasm32-unknown-unknown target may not be installed`).
+
 After each run, MiniCI writes a report directory:
 
 - `zig-out/minici/index.html` is a static dashboard you can open directly in a
@@ -157,5 +170,6 @@ If you already pushed unsigned commits, you may have to do a force push with `gi
 Feel free to open an issue if you think this document can be improved!
 
 [roc-zulip]: https://roc.zulipchat.com
+[rustup]: https://rustup.rs
 [good-first-issues]: https://github.com/roc-lang/roc/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
 [project-ideas]: https://docs.google.com/document/d/1mMaxIi7vxyUyNAUCs98d68jYj6C9Fpq4JIZRU735Kwg/edit?usp=sharing

--- a/build.zig
+++ b/build.zig
@@ -958,6 +958,80 @@ const CheckWasmBuiltinRoutingStep = struct {
     }
 };
 
+/// Build step that fails when tracked snapshots differ from the freshly regenerated
+/// output. Detects whether the build root is backed by Git or JJ and invokes the
+/// matching diff command directly. This deliberately avoids shelling out through
+/// `sh -c`, which is not available on Windows (it fails to spawn with FileNotFound).
+const CheckSnapshotDiffStep = struct {
+    step: Step,
+
+    const regen_hint = "Tracked snapshots changed after regeneration. Run 'zig build run-snapshot-tool' and commit the result.\n{s}";
+
+    fn create(b: *std.Build) *CheckSnapshotDiffStep {
+        const self = b.allocator.create(CheckSnapshotDiffStep) catch @panic("OOM");
+        self.* = .{
+            .step = Step.init(.{
+                .id = Step.Id.custom,
+                .name = "check-snapshot-diff",
+                .owner = b,
+                .makeFn = make,
+            }),
+        };
+        return self;
+    }
+
+    fn make(step: *Step, _: Step.MakeOptions) !void {
+        const b = step.owner;
+        const io = b.graph.io;
+
+        // Prefer Git when the working directory is inside a Git work tree.
+        const in_git = blk: {
+            const probe = std.process.run(b.allocator, io, .{
+                .argv = &.{ "git", "rev-parse", "--is-inside-work-tree" },
+            }) catch break :blk false;
+            defer b.allocator.free(probe.stdout);
+            defer b.allocator.free(probe.stderr);
+            break :blk probe.term == .exited and probe.term.exited == 0 and
+                std.mem.eql(u8, std.mem.trim(u8, probe.stdout, " \n\r\t"), "true");
+        };
+
+        if (in_git) {
+            const result = try std.process.run(b.allocator, io, .{
+                .argv = &.{ "git", "diff", "--exit-code", "test/snapshots" },
+            });
+            defer b.allocator.free(result.stdout);
+            defer b.allocator.free(result.stderr);
+            if (!(result.term == .exited and result.term.exited == 0)) {
+                return step.fail(regen_hint, .{result.stdout});
+            }
+            return;
+        }
+
+        // Fall back to JJ for a standalone JJ workspace (no Git backing).
+        const in_jj = blk: {
+            std.Io.Dir.cwd().access(io, ".jj", .{}) catch break :blk false;
+            break :blk true;
+        };
+
+        if (in_jj) {
+            const result = try std.process.run(b.allocator, io, .{
+                .argv = &.{ "jj", "diff", "--summary", "test/snapshots" },
+            });
+            defer b.allocator.free(result.stdout);
+            defer b.allocator.free(result.stderr);
+            if (!(result.term == .exited and result.term.exited == 0)) {
+                return step.fail("jj diff --summary test/snapshots failed:\n{s}", .{result.stderr});
+            }
+            if (std.mem.trim(u8, result.stdout, " \n\r\t").len != 0) {
+                return step.fail(regen_hint, .{result.stdout});
+            }
+            return;
+        }
+
+        return step.fail("run-check-snapshots requires a Git or JJ workspace", .{});
+    }
+};
+
 /// Build step that checks for @panic and std.debug.panic usage in interpreter and builtins.
 ///
 /// In Roc's design philosophy, compile-time errors become runtime errors with helpful messages.
@@ -3220,11 +3294,7 @@ pub fn build(b: *std.Build) void {
         run_snapshot_tool_step,
         run_args,
     );
-    const check_snapshot_diff = b.addSystemCommand(&.{
-        "sh",
-        "-c",
-        "if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then git diff --exit-code test/snapshots; elif test -d .jj; then test -z \"$(jj diff --summary test/snapshots)\"; else echo 'run-check-snapshots requires a Git or JJ workspace' >&2; exit 1; fi",
-    });
+    const check_snapshot_diff = CheckSnapshotDiffStep.create(b);
     check_snapshot_diff.step.dependOn(run_snapshot_tool_step);
     run_check_snapshots_step.dependOn(&check_snapshot_diff.step);
 


### PR DESCRIPTION
## What

Two Windows-focused fixes surfaced while getting MiniCI green on Windows.

### 1. `run-check-snapshots` fix (`build.zig`)

The snapshot diff check shelled out through `sh -c`, which doesn't exist on Windows and fails to spawn:

```
run-check-snapshots
+- run sh failure
error: failed to spawn and capture stdio from sh: FileNotFound
```

Replaced it with a cross-platform custom build step (`CheckSnapshotDiffStep`) that detects a Git or JJ workspace and runs the matching diff command directly, preserving the JJ-workspace support that motivated the original shell-out (from "build: support jj check workspaces").

### 2. Document the wasm32 test prerequisite (`CONTRIBUTING/README.md`)

The `run-test-cli` glue suite compiles generated Rust glue for `wasm32`, so running MiniCI needs the `wasm32-unknown-unknown` rustup target. Documented it under **Running Tests** so contributors don't hit the opaque `error[E0463]: can't find crate for std` (`the wasm32-unknown-unknown target may not be installed`).

## Validation

Full MiniCI on Windows (`x86_64-windows-msvc`):

- `run-check-snapshots` now **passes** (previously died with `sh: FileNotFound`).
- After `rustup target add wasm32-unknown-unknown`, `run-test-cli` **passes**: `657 passed, 60 skipped (717 total)`, glue `46 run, 0 failed`.

## Note

The commits are not yet signed — I'll sign and force-push before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
