### PR TITLE
Persist dispatch evidence for stored closures

### DIFF
--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -22881,7 +22881,7 @@ pub const CheckedModuleArtifact = struct {
             // `proc_bases`; `checked_types` includes its `var_names` interner = 3).
             // POD inline `key`/`module_identity` contribute 0. Fixed at compile time,
             // independent of stored data size.
-            std.debug.assert(artifact_serialize.relocatablePointerCount(Serialized) == 194);
+            std.debug.assert(artifact_serialize.relocatablePointerCount(Serialized) == 196);
         }
 
         /// Append every sub-store's bytes to `writer` in field order, recording
@@ -23029,7 +23029,7 @@ pub const CheckedModuleArtifact = struct {
     /// Manual discriminant for `SERIALIZED_VERSION_HASH`: bump to force a cache /
     /// baked-blob invalidation for a layout change the structural fingerprint below
     /// cannot observe (e.g. a semantic change to how a field is interpreted).
-    const serialized_layout_version: u32 = 20;
+    const serialized_layout_version: u32 = 21;
 
     /// Comptime fingerprint of `Serialized`'s layout, mirroring
     /// `cache_module.MODULE_ENV_VERSION_HASH`. It is appended to the baked builtin
@@ -27633,8 +27633,8 @@ test "SERIALIZED_VERSION_HASH golden value" {
     // change, bump `serialized_layout_version` and replace the golden bytes below with
     // the ones this assertion prints.
     const golden: [32]u8 = .{
-        0x7A, 0x9A, 0xFC, 0x33, 0xC3, 0x17, 0x47, 0x9C, 0xDD, 0xDA, 0xEA, 0x68, 0xF2, 0x52, 0x65, 0x3C,
-        0x9F, 0x27, 0x0E, 0xE1, 0xAE, 0x37, 0x69, 0xBC, 0x8E, 0x05, 0xBA, 0xFB, 0x37, 0x08, 0x5C, 0x71,
+        0x05, 0xE6, 0x4C, 0x8D, 0x66, 0x02, 0xA7, 0x77, 0xB6, 0xE7, 0xFC, 0x6D, 0x50, 0x86, 0xA9, 0x13,
+        0x71, 0xEA, 0xA9, 0x2E, 0xE9, 0x10, 0xF6, 0x89, 0x9E, 0x33, 0x62, 0xA9, 0x72, 0x2F, 0xD8, 0x1E,
     };
     try std.testing.expectEqualSlices(u8, &golden, &CheckedModuleArtifact.SERIALIZED_VERSION_HASH);
 }

--- a/src/check/const_store.zig
+++ b/src/check/const_store.zig
@@ -18,6 +18,9 @@ pub const ConstStrDataId = enum(u32) { _ };
 /// Identifier for a stored monomorphic type used by checked constants.
 pub const ConstTypeId = enum(u32) { _ };
 
+/// `(start, len)` range into one of `ConstStore`'s flat side pools (transform B).
+pub const ConstRange = extern struct { start: u32 = 0, len: u32 = 0 };
+
 /// Scalar value stored by compile-time evaluation.
 pub const ConstScalar = union(enum) {
     i8: i8,
@@ -140,12 +143,37 @@ pub const ConstCapture = struct {
     value: ConstNodeId,
 };
 
+/// Nested evidence carried by a concrete dispatch target. Checked source edges
+/// publish resolved nested vectors; compiler-generated structural edges retain
+/// their explicit request to synthesize at the target consumption site.
+pub const ConstNestedEvidence = union(enum) {
+    resolved: ConstRange,
+    synthesize,
+};
+
+/// Target-independent dispatch evidence stored with compile-time function
+/// values. Concrete targets name their checked module by deep content identity;
+/// every range indexes the owning store's `evidence_pool`.
+pub const ConstEvidence = union(enum) {
+    target: struct {
+        module: names.CheckedModuleDigest,
+        method: static_dispatch.MethodTarget,
+        nested: ConstNestedEvidence,
+    },
+    structural: static_dispatch.StructuralKind,
+    unreachable_value,
+    checked_error,
+};
+
 /// Function value stored by compile-time evaluation.
 pub const ConstFn = struct {
     fn_def: FnDef,
     source_fn_ty: checked_ids.CheckedTypeId,
     source_fn_key: names.TypeDigest,
     captures: []const ConstCapture = &.{},
+    /// Evidence vectors ordered from the function body's innermost scope to
+    /// its lexical parents. Each range indexes `ConstStore.evidence_pool`.
+    evidence_chain: []const ConstRange = &.{},
 };
 
 /// Named type owner for a stored nominal constant.
@@ -210,9 +238,6 @@ pub const ConstValue = union(enum) {
     fn_value: ConstFnId,
 };
 
-/// `(start, len)` range into one of `ConstStore`'s flat side pools (transform B).
-pub const ConstRange = extern struct { start: u32 = 0, len: u32 = 0 };
-
 /// Internal, relocation-invariant (POD) form of `ConstValue`: variant slices are
 /// replaced by `ConstRange`s into the store's flat pools. The public `ConstValue`
 /// (with slices) is reconstructed on demand by `get`.
@@ -237,6 +262,7 @@ const StoredFn = struct {
     source_fn_ty: checked_ids.CheckedTypeId,
     source_fn_key: names.TypeDigest,
     captures: ConstRange = .{},
+    evidence_chain: ConstRange = .{},
 };
 
 /// Store of monomorphic type evidence attached to compile-time constants.
@@ -507,6 +533,12 @@ pub const ConstStore = struct {
     type_store: ConstTypeStore,
     /// Flat pool of function captures.
     capture_pool: std.ArrayList(ConstCapture),
+    /// Flat pool of target-independent dispatch evidence. Nested target ranges
+    /// index this same pool.
+    evidence_pool: std.ArrayList(ConstEvidence),
+    /// Flat pool of evidence-vector ranges. Stored functions point at a range
+    /// here to retain the full lexical evidence chain.
+    evidence_chain_pool: std.ArrayList(ConstRange),
     /// Flat pool of all string backing bytes; `str_views` indexes into it.
     str_backing: std.ArrayList(u8),
     /// `ConstStrDataId` -> range into `str_backing`.
@@ -524,6 +556,8 @@ pub const ConstStore = struct {
             .tag_name_pool = .empty,
             .type_store = ConstTypeStore.init(allocator),
             .capture_pool = .empty,
+            .evidence_pool = .empty,
+            .evidence_chain_pool = .empty,
             .str_backing = .empty,
             .str_views = .empty,
         };
@@ -584,13 +618,25 @@ pub const ConstStore = struct {
     pub fn appendFn(self: *ConstStore, fn_value: ConstFn) Allocator.Error!ConstFnId {
         const id: ConstFnId = @enumFromInt(@as(u32, @intCast(self.fns.items.len)));
         const captures_range = try artifact_serialize.appendSpan(ConstRange, ConstCapture, &self.capture_pool, self.allocator, fn_value.captures);
+        const evidence_chain_range = try artifact_serialize.appendSpan(ConstRange, ConstRange, &self.evidence_chain_pool, self.allocator, fn_value.evidence_chain);
         try self.fns.append(self.allocator, .{
             .fn_def = fn_value.fn_def,
             .source_fn_ty = fn_value.source_fn_ty,
             .source_fn_key = fn_value.source_fn_key,
             .captures = captures_range,
+            .evidence_chain = evidence_chain_range,
         });
         return id;
+    }
+
+    /// Append one already-relocated evidence vector. Nested ranges in `values`
+    /// must already index this store's `evidence_pool`.
+    pub fn appendEvidence(self: *ConstStore, values: []const ConstEvidence) Allocator.Error!ConstRange {
+        return artifact_serialize.appendSpan(ConstRange, ConstEvidence, &self.evidence_pool, self.allocator, values);
+    }
+
+    pub fn evidenceSlice(self: *const ConstStore, range: ConstRange) []const ConstEvidence {
+        return self.evidence_pool.items[range.start .. range.start + range.len];
     }
 
     pub fn addStrData(self: *ConstStore, bytes: []const u8) Allocator.Error!ConstStrDataId {
@@ -631,6 +677,7 @@ pub const ConstStore = struct {
             .source_fn_ty = stored.source_fn_ty,
             .source_fn_key = stored.source_fn_key,
             .captures = self.capture_pool.items[stored.captures.start .. stored.captures.start + stored.captures.len],
+            .evidence_chain = self.evidence_chain_pool.items[stored.evidence_chain.start .. stored.evidence_chain.start + stored.evidence_chain.len],
         };
     }
 
@@ -652,12 +699,14 @@ pub const ConstStore = struct {
         tag_name_pool: artifact_serialize.SerializedSlice(u8) = .{},
         type_store: ConstTypeStore.Serialized = .{},
         capture_pool: artifact_serialize.SerializedSlice(ConstCapture) = .{},
+        evidence_pool: artifact_serialize.SerializedSlice(ConstEvidence) = .{},
+        evidence_chain_pool: artifact_serialize.SerializedSlice(ConstRange) = .{},
         str_backing: artifact_serialize.SerializedSlice(u8) = .{},
         str_views: artifact_serialize.SerializedSlice(ConstRange) = .{},
 
         comptime {
-            // 7 value/function side lists + 5 nested type-store lists.
-            std.debug.assert(artifact_serialize.relocatablePointerCount(Serialized) == 12);
+            // 9 value/function side lists + 5 nested type-store lists.
+            std.debug.assert(artifact_serialize.relocatablePointerCount(Serialized) == 14);
         }
 
         const Serde = artifact_serialize.SliceStoreSerde(ConstStore, @This());
@@ -708,6 +757,8 @@ pub const ConstStore = struct {
             self.node_pool.deinit(self.allocator);
             self.tag_name_pool.deinit(self.allocator);
             self.capture_pool.deinit(self.allocator);
+            self.evidence_pool.deinit(self.allocator);
+            self.evidence_chain_pool.deinit(self.allocator);
             self.str_backing.deinit(self.allocator);
             self.str_views.deinit(self.allocator);
         }
@@ -814,6 +865,18 @@ test "ConstStore: build, serialize/relocate, and read back values, fns, strings"
     const capture_ty = try store.type_store.append(.{ .primitive = .u64 });
     const caps = try gpa.dupe(ConstCapture, &.{.{ .id = CaptureId.fromBinder(@enumFromInt(1)), .ty = capture_ty, .value = a }});
     defer gpa.free(caps);
+    const nested_evidence = try store.appendEvidence(&.{.{ .structural = .hash }});
+    const evidence = try store.appendEvidence(&.{.{ .target = .{
+        .module = .{},
+        .method = .{
+            .module_idx = 4,
+            .def_idx = @enumFromInt(5),
+            .kind = .generated_structural_parser,
+            .callable_ty = @enumFromInt(6),
+        },
+        .nested = .{ .resolved = nested_evidence },
+    } }});
+    const evidence_chain = [_]ConstRange{evidence};
     const fn_id = try store.appendFn(.{
         // Distinct non-zero ids: this test asserts captures round-trip; the fn_def
         // fields just need to survive, not be specific values.
@@ -821,6 +884,7 @@ test "ConstStore: build, serialize/relocate, and read back values, fns, strings"
         .source_fn_ty = @enumFromInt(3),
         .source_fn_key = .{},
         .captures = caps,
+        .evidence_chain = &evidence_chain,
     });
 
     // Serialize → aligned buffer → deserialize.
@@ -856,6 +920,13 @@ test "ConstStore: build, serialize/relocate, and read back values, fns, strings"
     try std.testing.expectEqual(capture_ty, loaded_fn.captures[0].ty);
     try std.testing.expectEqual(ConstType{ .primitive = .u64 }, loaded.type_store.get(loaded_fn.captures[0].ty));
     try std.testing.expectEqual(a, loaded_fn.captures[0].value);
+    try std.testing.expectEqual(@as(usize, 1), loaded_fn.evidence_chain.len);
+    const loaded_evidence = loaded.evidenceSlice(loaded_fn.evidence_chain[0]);
+    try std.testing.expectEqual(@as(usize, 1), loaded_evidence.len);
+    const loaded_target = loaded_evidence[0].target;
+    try std.testing.expectEqual(@as(u32, 4), loaded_target.method.module_idx);
+    try std.testing.expectEqual(@as(usize, 1), loaded.evidenceSlice(loaded_target.nested.resolved).len);
+    try std.testing.expectEqual(static_dispatch.StructuralKind.hash, loaded.evidenceSlice(loaded_target.nested.resolved)[0].structural);
 }
 
 test "ConstStore.appendFn: no leak or double-free under allocation failure" {

--- a/src/eval/const_store_writer.zig
+++ b/src/eval/const_store_writer.zig
@@ -394,11 +394,14 @@ pub const Writer = struct {
         const variant = self.selectFnVariant(set, tag_base.layout_idx, tag_base.value);
         const captures = try self.storeCaptures(variant.captures, variant.payload_layout, tag_base.value);
         defer self.module.const_store.allocator.free(captures);
+        const evidence_chain = try self.storeEvidenceChain(variant.template.const_evidence_chain);
+        defer self.module.const_store.allocator.free(evidence_chain);
         return try self.module.const_store.appendFn(.{
             .fn_def = variant.template.fn_def,
             .source_fn_ty = variant.template.source_fn_ty,
             .source_fn_key = variant.template.source_fn_key,
             .captures = captures,
+            .evidence_chain = evidence_chain,
         });
     }
 
@@ -414,14 +417,50 @@ pub const Writer = struct {
             if (entry.entry != resolved.proc) continue;
             const captures = try self.storeCaptures(entry.captures, entry.capture_layout, .{ .ptr = resolved.capture_ptr });
             defer self.module.const_store.allocator.free(captures);
+            const evidence_chain = try self.storeEvidenceChain(entry.template.const_evidence_chain);
+            defer self.module.const_store.allocator.free(evidence_chain);
             return try self.module.const_store.appendFn(.{
                 .fn_def = entry.template.fn_def,
                 .source_fn_ty = entry.template.source_fn_ty,
                 .source_fn_key = entry.template.source_fn_key,
                 .captures = captures,
+                .evidence_chain = evidence_chain,
             });
         }
         writerInvariant("erased callable result did not match an explicit erased function entry");
+    }
+
+    fn storeEvidenceChain(self: *Writer, range: const_store.ConstRange) Allocator.Error![]const const_store.ConstRange {
+        const source = self.program.const_evidence_chain_pool.items[range.start .. range.start + range.len];
+        const stored = try self.module.const_store.allocator.alloc(const_store.ConstRange, source.len);
+        errdefer self.module.const_store.allocator.free(stored);
+        for (source, 0..) |vector, index| {
+            stored[index] = try self.storeEvidenceVector(vector);
+        }
+        return stored;
+    }
+
+    fn storeEvidenceVector(self: *Writer, range: const_store.ConstRange) Allocator.Error!const_store.ConstRange {
+        const source = self.program.const_evidence_pool.items[range.start .. range.start + range.len];
+        const relocated = try self.module.const_store.allocator.alloc(const_store.ConstEvidence, source.len);
+        defer self.module.const_store.allocator.free(relocated);
+
+        for (source, 0..) |evidence, index| {
+            relocated[index] = switch (evidence) {
+                .target => |target| .{ .target = .{
+                    .module = target.module,
+                    .method = target.method,
+                    .nested = switch (target.nested) {
+                        .resolved => |nested| .{ .resolved = try self.storeEvidenceVector(nested) },
+                        .synthesize => .synthesize,
+                    },
+                } },
+                .structural => |kind| .{ .structural = kind },
+                .unreachable_value => .unreachable_value,
+                .checked_error => .checked_error,
+            };
+        }
+        return try self.module.const_store.appendEvidence(relocated);
     }
 
     fn storeCaptures(

--- a/src/eval/test/eval_comptime_finalization_tests.zig
+++ b/src/eval/test/eval_comptime_finalization_tests.zig
@@ -736,6 +736,22 @@ const opaque_function_field =
     \\main = W.run(W.mk("x")) == V("x")
 ;
 
+// Repro for https://github.com/roc-lang/roc/issues/10118
+const stored_where_constrained_closure =
+    \\Item := [It(Str)].{
+    \\    to_str : Item -> Str
+    \\    to_str = |Item.It(s)| s
+    \\}
+    \\
+    \\mk : a -> ({} -> Str) where [a.to_str : a -> Str]
+    \\mk = |x| |{}| x.to_str()
+    \\
+    \\p : {} -> Str
+    \\p = mk(Item.It("whereconstrained"))
+    \\
+    \\main = p({})
+;
+
 const top_level_expect_type_error =
     \\foo : U64 -> U64
     \\foo = |x| x
@@ -983,6 +999,7 @@ pub const tests = [_]TestCase{
         .expected = .{ .inspect_str = "42" },
     },
     .{ .name = "issue 9262: dev evaluator handles opaque function field lookup", .source_kind = .module, .source = opaque_function_field, .expected = .{ .inspect_str = "True" } },
+    .{ .name = "issue 10118: stored where-constrained closure keeps dispatch evidence", .source_kind = .module, .source = stored_where_constrained_closure, .expected = .{ .inspect_str = "\"whereconstrained\"" } },
     .{
         .name = "issue 9281: dev evaluator stack overflow with nested recursive opaque types across modules",
         .source_kind = .module,

--- a/src/lir/program.zig
+++ b/src/lir/program.zig
@@ -41,6 +41,7 @@ pub const FnTemplate = struct {
     fn_def: const_store.FnDef,
     source_fn_ty: checked.CheckedTypeId,
     source_fn_key: names.TypeDigest,
+    const_evidence_chain: const_store.ConstRange = .{},
 };
 
 /// Capture field copied from a checked binder into a callable payload.
@@ -146,6 +147,10 @@ pub const Result = struct {
     requested_layouts: std.ArrayList(RequestedLayout),
     const_types: const_store.ConstTypeStore,
     const_type_names: names.NameStore,
+    /// Target-independent evidence copied from Monotype. FnTemplate ranges and
+    /// nested target ranges index these pools until ConstStore materialization.
+    const_evidence_pool: std.ArrayList(const_store.ConstEvidence),
+    const_evidence_chain_pool: std.ArrayList(const_store.ConstRange),
     fn_sets: std.ArrayList(FnSet),
     erased_fns: std.ArrayList(ErasedFns),
     const_plans: std.ArrayList(ConstPlan),
@@ -162,6 +167,8 @@ pub const Result = struct {
             .requested_layouts = .empty,
             .const_types = const_store.ConstTypeStore.init(allocator),
             .const_type_names = names.NameStore.init(allocator),
+            .const_evidence_pool = .empty,
+            .const_evidence_chain_pool = .empty,
             .fn_sets = .empty,
             .erased_fns = .empty,
             .const_plans = .empty,
@@ -185,6 +192,8 @@ pub const Result = struct {
         deinitErasedFns(allocator, self.erased_fns.items);
         self.erased_fns.deinit(allocator);
         self.fn_sets.deinit(allocator);
+        self.const_evidence_chain_pool.deinit(allocator);
+        self.const_evidence_pool.deinit(allocator);
         self.const_type_names.deinit();
         self.const_types.deinit();
         self.requested_layouts.deinit(allocator);

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -79,6 +79,8 @@ fn movedSolvedView(source: *const Solved.Program, moved: *const Ast.Program) Sol
             .stmt_ids = lifted.stmt_ids,
             .field_exprs = lifted.field_exprs,
             .fn_def_captures = lifted.fn_def_captures,
+            .const_evidence_pool = lifted.const_evidence_pool,
+            .const_evidence_chain_pool = lifted.const_evidence_chain_pool,
             .capture_operands = lifted.capture_operands,
             .record_destructs = lifted.record_destructs,
             .str_pattern_steps = lifted.str_pattern_steps,

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -125,6 +125,10 @@ pub const FnTemplate = struct {
     source_fn_ty: checked.CheckedTypeId,
     source_fn_key: names.TypeDigest,
     mono_fn_ty: Type.TypeId,
+    /// Range into the owning program's `const_evidence_chain_pool`. The chain
+    /// is explicit producer data used only if this function value is frozen
+    /// into ConstStore.
+    const_evidence_chain: check.ConstStore.ConstRange = .{},
 };
 
 /// Monotype function-specialization metadata.
@@ -868,6 +872,8 @@ pub const ProgramView = struct {
     stmt_ids: []const StmtId,
     field_exprs: []const FieldExpr,
     fn_def_captures: []const FnDefCapture,
+    const_evidence_pool: []const check.ConstStore.ConstEvidence,
+    const_evidence_chain_pool: []const check.ConstStore.ConstRange,
     capture_operands: []const CaptureOperand,
     record_destructs: []const RecordDestruct,
     str_pattern_steps: []const StrPatternStep,
@@ -1029,6 +1035,11 @@ pub const ProgramBuilder = struct {
     stmt_ids: ProgramList(StmtId, "stmt_ids"),
     field_exprs: ProgramList(FieldExpr, "field_exprs"),
     fn_def_captures: ProgramList(FnDefCapture, "fn_def_captures"),
+    /// Target-independent evidence trees attached to function templates that
+    /// may cross the compile-time constant boundary.
+    const_evidence_pool: ProgramList(check.ConstStore.ConstEvidence, "const_evidence_pool"),
+    /// Evidence-vector ranges, flattened innermost-to-outermost per function.
+    const_evidence_chain_pool: ProgramList(check.ConstStore.ConstRange, "const_evidence_chain_pool"),
     /// Backing pool for lifted `Span(CaptureOperand)` capture operand spans.
     /// Empty in the pre-lift Monotype program (populated by closure lifting).
     capture_operands: ProgramList(CaptureOperand, "capture_operands"),
@@ -1085,6 +1096,8 @@ pub const ProgramBuilder = struct {
             .stmt_ids = .empty,
             .field_exprs = .empty,
             .fn_def_captures = .empty,
+            .const_evidence_pool = .empty,
+            .const_evidence_chain_pool = .empty,
             .capture_operands = .empty,
             .record_destructs = .empty,
             .str_pattern_steps = .empty,
@@ -1135,6 +1148,8 @@ pub const ProgramBuilder = struct {
         self.str_pattern_steps.deinit(self.allocator);
         self.record_destructs.deinit(self.allocator);
         self.fn_def_captures.deinit(self.allocator);
+        self.const_evidence_chain_pool.deinit(self.allocator);
+        self.const_evidence_pool.deinit(self.allocator);
         self.capture_operands.deinit(self.allocator);
         self.field_exprs.deinit(self.allocator);
         self.stmt_ids.deinit(self.allocator);
@@ -1283,6 +1298,8 @@ pub const ProgramBuilder = struct {
             .stmt_ids = self.stmt_ids.unsafeRawItemsForView(),
             .field_exprs = self.field_exprs.unsafeRawItemsForView(),
             .fn_def_captures = self.fn_def_captures.unsafeRawItemsForView(),
+            .const_evidence_pool = self.const_evidence_pool.unsafeRawItemsForView(),
+            .const_evidence_chain_pool = self.const_evidence_chain_pool.unsafeRawItemsForView(),
             .capture_operands = self.capture_operands.unsafeRawItemsForView(),
             .record_destructs = self.record_destructs.unsafeRawItemsForView(),
             .str_pattern_steps = self.str_pattern_steps.unsafeRawItemsForView(),
@@ -1677,6 +1694,26 @@ pub const ProgramBuilder = struct {
         const start: u32 = @intCast(self.fn_def_captures.len());
         try self.fn_def_captures.appendSlice(self.allocator, values);
         return .{ .start = start, .len = @intCast(values.len) };
+    }
+
+    pub fn addConstEvidenceSpan(self: *ProgramBuilder, values: []const check.ConstStore.ConstEvidence) std.mem.Allocator.Error!check.ConstStore.ConstRange {
+        const start: u32 = @intCast(self.const_evidence_pool.len());
+        try self.const_evidence_pool.appendSlice(self.allocator, values);
+        return .{ .start = start, .len = @intCast(values.len) };
+    }
+
+    pub fn addConstEvidenceChain(self: *ProgramBuilder, vectors: []const check.ConstStore.ConstRange) std.mem.Allocator.Error!check.ConstStore.ConstRange {
+        const start: u32 = @intCast(self.const_evidence_chain_pool.len());
+        try self.const_evidence_chain_pool.appendSlice(self.allocator, vectors);
+        return .{ .start = start, .len = @intCast(vectors.len) };
+    }
+
+    pub fn constEvidenceSpan(self: *const ProgramBuilder, range: check.ConstStore.ConstRange) []const check.ConstStore.ConstEvidence {
+        return self.const_evidence_pool.unsafeRawItemsForView()[range.start..][0..range.len];
+    }
+
+    pub fn constEvidenceChain(self: *const ProgramBuilder, range: check.ConstStore.ConstRange) []const check.ConstStore.ConstRange {
+        return self.const_evidence_chain_pool.unsafeRawItemsForView()[range.start..][0..range.len];
     }
 
     pub fn addRecordDestructSpan(self: *ProgramBuilder, values: []const RecordDestruct) std.mem.Allocator.Error!Span(RecordDestruct) {

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -743,6 +743,45 @@ const Builder = struct {
         }
     }
 
+    /// Freeze one fully materialized evidence vector into target-independent
+    /// Monotype side data. Concrete targets retain checked module identity and
+    /// nested evidence for direct consumption by every later stage.
+    fn persistEvidenceVector(self: *Builder, vector: []const SpecEvidence) Allocator.Error!check.ConstStore.ConstRange {
+        const stored = try self.allocator.alloc(check.ConstStore.ConstEvidence, vector.len);
+        defer self.allocator.free(stored);
+
+        for (vector, 0..) |evidence, index| {
+            stored[index] = switch (evidence) {
+                .target => |target| .{ .target = .{
+                    .module = moduleDigestFromId(target.view.key),
+                    .method = target.target,
+                    .nested = switch (target.nested) {
+                        .resolved => |nested| .{ .resolved = try self.persistEvidenceVector(nested) },
+                        .synthesize => .synthesize,
+                    },
+                } },
+                .structural => |kind| .{ .structural = kind },
+                .unreachable_value => .unreachable_value,
+                .checked_error => .checked_error,
+            };
+        }
+        return try self.program.addConstEvidenceSpan(stored);
+    }
+
+    /// Persist every vector in a function body's lexical evidence chain,
+    /// ordered from the innermost scope to its parents.
+    fn persistEvidenceChain(self: *Builder, chain: EvidenceChain) Allocator.Error!check.ConstStore.ConstRange {
+        if (chain.vector.len == 0 and chain.parent == null) return .{};
+
+        var vectors = std.ArrayList(check.ConstStore.ConstRange).empty;
+        defer vectors.deinit(self.allocator);
+        var current: ?*const EvidenceChain = &chain;
+        while (current) |entry| : (current = entry.parent) {
+            try vectors.append(self.allocator, try self.persistEvidenceVector(entry.vector));
+        }
+        return try self.program.addConstEvidenceChain(vectors.items);
+    }
+
     fn specializationTypeDigest(self: *Builder, ty: Type.TypeId) names.TypeDigest {
         if (self.counters != null) {
             self.count("specialization_type_digest_requests");
@@ -1361,7 +1400,7 @@ const Builder = struct {
 
         const view = self.moduleForDigest(names.procTemplateModuleDigest(template_ref));
         const template = view.templates.get(template_ref.template);
-        const fn_template = self.fnDefForTemplate(view, template_ref, source_fn_ty, source_fn_key, lower_fn_ty);
+        var fn_template = self.fnDefForTemplate(view, template_ref, source_fn_ty, source_fn_key, lower_fn_ty);
 
         const Reservation = struct {
             def: Ast.DefId,
@@ -1517,6 +1556,7 @@ const Builder = struct {
                 Common.invariant("intrinsic wrapper specialization request supplied fewer evidence entries than its scheme's params");
             }
         }
+        fn_template.const_evidence_chain = try self.persistEvidenceChain(body_ctx.evidence);
         body_ctx.source_region_override = source_region_override;
         body_ctx.current_entry_root = current_entry_root;
         const root_fn_key = Ast.fnTemplateDigest(fn_template, &self.program.types, &self.program.names);
@@ -3037,13 +3077,15 @@ const Builder = struct {
             parent.* = source_ctx.evidence;
             nested_ctx.evidence = .{ .vector = vector, .parent = parent };
         }
+        var stored_template = fn_template;
+        stored_template.const_evidence_chain = try self.persistEvidenceChain(nested_ctx.evidence);
         // Nested functions share the requester's graph, and an inferred local
         // procedure's body pins signature variables (its own evidence) that
         // the requester's remaining body relies on, so the body lowers now.
         return try self.lowerNestedFnRequest(.{
             .ctx = nested_ctx,
             .expr_id = expr_id,
-            .fn_template = fn_template,
+            .fn_template = stored_template,
         });
     }
 
@@ -3103,6 +3145,7 @@ const Builder = struct {
                 .source_fn_ty = def_template.source_fn_ty,
                 .source_fn_key = def_template.source_fn_key,
                 .mono_fn_ty = try DraftTypeCell.fromActiveType(request.ctx.graph, def_template.mono_fn_ty),
+                .const_evidence_chain = def_template.const_evidence_chain,
             },
             .fn_id = draftFinalFn(fn_id),
             .args = lowered.args,
@@ -5230,6 +5273,7 @@ const DraftFnTemplate = struct {
     source_fn_ty: checked.CheckedTypeId,
     source_fn_key: names.TypeDigest,
     mono_fn_ty: DraftTypeCell,
+    const_evidence_chain: check.ConstStore.ConstRange = .{},
 };
 
 const DraftFn = struct {
@@ -6247,6 +6291,7 @@ const BodyDraftStore = struct {
             .source_fn_ty = template.source_fn_ty,
             .source_fn_key = template.source_fn_key,
             .mono_fn_ty = try template.mono_fn_ty.seal(graph, sealer),
+            .const_evidence_chain = template.const_evidence_chain,
         };
     }
 
@@ -6731,11 +6776,6 @@ const BodyContext = struct {
     /// restored from the constant lower their bodies against this chain
     /// (their plans' `constraint(k)` refs index the constant's scheme).
     restore_evidence: EvidenceChain = .{},
-    /// While recursively restoring a stored constant, the concrete type of the
-    /// whole restored value. Nested stored closures use this to instantiate the
-    /// owner callable's return when synthesizing the constant scheme's evidence.
-    restore_const_result_ty: ?Type.TypeId = null,
-
     const PatternLiteralGuard = struct {
         local: DraftLocalId,
         ty: Type.TypeId,
@@ -7288,6 +7328,7 @@ const BodyContext = struct {
                 .source_fn_ty = source.source_fn_ty,
                 .source_fn_key = source.source_fn_key,
                 .mono_fn_ty = try self.draftTypeCellPreservingGenerated(source.mono_fn_ty),
+                .const_evidence_chain = source.const_evidence_chain,
             },
         });
     }
@@ -7763,7 +7804,6 @@ const BodyContext = struct {
         child.generated_encoder_lambda_index = self.generated_encoder_lambda_index;
         child.source_region_override = self.source_region_override;
         child.current_entry_root = self.current_entry_root;
-        child.restore_const_result_ty = self.restore_const_result_ty;
         child.restored_local_proc_context_digest = self.restored_local_proc_context_digest;
         child.restored_local_proc_base_key = self.restored_local_proc_base_key;
 
@@ -17358,10 +17398,6 @@ const BodyContext = struct {
         ty: Type.TypeId,
         static_data_const_locator: ?checked.ConstLocator,
     ) Allocator.Error!DraftExprId {
-        const previous_restore_const_result_ty = self.restore_const_result_ty;
-        if (previous_restore_const_result_ty == null) self.restore_const_result_ty = ty;
-        defer self.restore_const_result_ty = previous_restore_const_result_ty;
-
         const value = store_view.const_store.get(node);
         switch (value) {
             .fn_value => |fn_id| {
@@ -17722,6 +17758,58 @@ const BodyContext = struct {
         return self.builder.program.types.fieldSpan(self.builder.recordFieldsSpan(ty));
     }
 
+    fn restoreStoredEvidenceChain(
+        self: *BodyContext,
+        store_view: ModuleView,
+        stored_chain: []const check.ConstStore.ConstRange,
+    ) Allocator.Error!EvidenceChain {
+        if (stored_chain.len == 0) return .{};
+
+        const arena = self.builder.evidence_arena.allocator();
+        var parent: ?*const EvidenceChain = null;
+        var index = stored_chain.len;
+        while (index > 0) {
+            index -= 1;
+            const node = try arena.create(EvidenceChain);
+            node.* = .{
+                .vector = try self.restoreStoredEvidenceVector(store_view, stored_chain[index]),
+                .parent = parent,
+            };
+            parent = node;
+        }
+        return parent.?.*;
+    }
+
+    fn restoreStoredEvidenceVector(
+        self: *BodyContext,
+        store_view: ModuleView,
+        range: check.ConstStore.ConstRange,
+    ) Allocator.Error![]const SpecEvidence {
+        const stored = store_view.const_store.evidenceSlice(range);
+        const arena = self.builder.evidence_arena.allocator();
+        const restored = try arena.alloc(SpecEvidence, stored.len);
+        for (stored, 0..) |evidence, index| {
+            restored[index] = switch (evidence) {
+                .target => |target| blk: {
+                    const restored_target = try arena.create(SpecEvidenceTarget);
+                    restored_target.* = .{
+                        .view = self.builder.moduleForDigest(target.module),
+                        .target = target.method,
+                        .nested = switch (target.nested) {
+                            .resolved => |nested| .{ .resolved = try self.restoreStoredEvidenceVector(store_view, nested) },
+                            .synthesize => .synthesize,
+                        },
+                    };
+                    break :blk .{ .target = restored_target };
+                },
+                .structural => |kind| .{ .structural = kind },
+                .unreachable_value => .unreachable_value,
+                .checked_error => .checked_error,
+            };
+        }
+        return restored;
+    }
+
     fn restoreConstFn(
         self: *BodyContext,
         store_view: ModuleView,
@@ -17742,7 +17830,7 @@ const BodyContext = struct {
         if (fn_value.captures.len != 0) {
             return try self.restoreCapturingConstFn(store_view, fn_id, fn_value, template, ty, static_data_const_locator);
         }
-        const mono_fn_id = try self.restoreConstFnTemplate(fn_value, template);
+        const mono_fn_id = try self.restoreConstFnTemplate(store_view, fn_value, template);
         return try self.addExpr(.{
             .ty = self.builder.program.fnSource(mono_fn_id).mono_fn_ty,
             .data = .{ .fn_def = .{ .fn_id = draftFinalFn(mono_fn_id) } },
@@ -17751,44 +17839,39 @@ const BodyContext = struct {
 
     fn restoreConstFnTemplate(
         self: *BodyContext,
+        store_view: ModuleView,
         fn_value: check.ConstStore.ConstFn,
         template: Ast.FnTemplate,
     ) Allocator.Error!Ast.FnId {
+        const stored_evidence = if (fn_value.evidence_chain.len > 0)
+            try self.restoreStoredEvidenceChain(store_view, fn_value.evidence_chain)
+        else
+            self.restore_evidence;
         return switch (template.fn_def) {
             .nested => {
                 const fn_view = self.builder.moduleForConstFnDef(fn_value.fn_def);
                 var fn_ctx = try BodyContext.initWithMethodScope(self.allocator, self.builder, fn_view, self.method_scope, ownerTemplateForConstFnDef(fn_value.fn_def), self.graph, self.draft);
                 defer fn_ctx.deinit();
-                try self.prepareRestoredFnEvidence(&fn_ctx, fn_view, fn_value, template);
+                try self.prepareRestoredFnEvidence(&fn_ctx, stored_evidence, fn_value, template);
                 return try self.builder.lowerNestedFnFromContext(&fn_ctx, checkedLambdaExprIdForConstFn(fn_view, fn_value.fn_def), template, null);
             },
-            else => try self.builder.lowerFnTemplateDefFromContext(self, template, self.restore_evidence.vector),
+            else => try self.builder.lowerFnTemplateDefFromContext(self, template, stored_evidence.vector),
         };
     }
 
     fn prepareRestoredFnEvidence(
-        self: *BodyContext,
+        _: *BodyContext,
         fn_ctx: *BodyContext,
-        fn_view: ModuleView,
+        stored_evidence: EvidenceChain,
         fn_value: check.ConstStore.ConstFn,
         template: Ast.FnTemplate,
     ) Allocator.Error!void {
-        fn_ctx.evidence = self.restore_evidence;
+        fn_ctx.evidence = stored_evidence;
         try fn_ctx.constrainTypeToMono(fn_value.source_fn_ty, template.mono_fn_ty);
 
-        if (self.restore_evidence.vector.len == 0) {
-            const nested = switch (template.fn_def) {
-                .nested => |nested| nested,
-                else => Common.invariant("stored function evidence preparation requires a nested function identity"),
-            };
-            if (try fn_ctx.synthesizeRestoredClosureEvidence(fn_view, nested.owner, template.mono_fn_ty, null)) |synthesized| {
-                fn_ctx.evidence = .{ .vector = synthesized };
-            }
-        }
-
         // Captured ConstStore values belong to the same restored constant.
-        // Propagate the explicit use-edge or synthesized owner evidence before
-        // recursively restoring them.
+        // Propagate the stored producer evidence before recursively restoring
+        // them.
         fn_ctx.restore_evidence = fn_ctx.evidence;
     }
 
@@ -17803,8 +17886,11 @@ const BodyContext = struct {
     ) Allocator.Error!DraftExprId {
         const fn_view = self.builder.moduleForConstFnDef(fn_value.fn_def);
         var fn_ctx = try BodyContext.initWithMethodScope(self.allocator, self.builder, fn_view, self.method_scope, ownerTemplateForConstFnDef(fn_value.fn_def), self.graph, self.draft);
-        fn_ctx.evidence = self.restore_evidence;
-        fn_ctx.restore_evidence = self.restore_evidence;
+        fn_ctx.evidence = if (fn_value.evidence_chain.len > 0)
+            try self.restoreStoredEvidenceChain(store_view, fn_value.evidence_chain)
+        else
+            self.restore_evidence;
+        fn_ctx.restore_evidence = fn_ctx.evidence;
         defer fn_ctx.deinit();
         fn_ctx.current_fn_key = restoredConstFnContextKey(store_view.key, fn_id, fn_value.source_fn_key);
         fn_ctx.restored_local_proc_context_digest = fn_value.fn_def.nested.local_proc_context_digest;
@@ -17875,16 +17961,7 @@ const BodyContext = struct {
                     .context_fn_key = try fn_ctx.lexicalContextKey(),
                     .local_proc_context_digest = nested.local_proc_context_digest,
                 } };
-                // A compile-time-evaluated closure keeps its dispatch evidence
-                // params even when the outer scheme is concrete. Capture types
-                // and the enclosing constant result together instantiate the
-                // owner callable before its checked evidence paths are read.
-                if (self.restore_evidence.vector.len == 0) {
-                    const result_ty = self.restore_const_result_ty orelse ty;
-                    if (try fn_ctx.synthesizeRestoredClosureEvidence(fn_view, nested.owner, ty, result_ty)) |synthesized| {
-                        fn_ctx.evidence = .{ .vector = synthesized };
-                    }
-                }
+                capture_template.const_evidence_chain = try self.builder.persistEvidenceChain(fn_ctx.evidence);
                 fn_ctx.restore_evidence = fn_ctx.evidence;
             },
             else => Common.invariant("capturing stored function had no nested function identity"),
@@ -20247,45 +20324,6 @@ const BodyContext = struct {
     ) Allocator.Error![]const SpecEvidence {
         const template = lookup.view.templates.get(template_ref.template);
         return try self.synthesizeParamsEvidence(lookup.view, template, callable_mono_ty);
-    }
-
-    /// Evidence vector for a compile-time-evaluated closure restored without a
-    /// use-site vector: resolve the owner scheme's evidence params from its
-    /// checked dispatcher paths over the closure's concrete restored callable.
-    ///
-    /// The owner scheme's evidence-param paths run over the owner's whole
-    /// callable (a `constraint(0, k)` in the closure body forwards to the
-    /// owner's `k`th param). Instantiate the owner root, pin its return to the
-    /// result value that created this stored closure, and synthesize each param's
-    /// target over the resulting concrete owner callable. When the owner returns
-    /// the closure directly, that result is the restored closure type itself; an
-    /// ambient restored constant result only applies when the owner returns an
-    /// aggregate that contains this closure.
-    fn synthesizeRestoredClosureEvidence(
-        self: *BodyContext,
-        owner_view: ModuleView,
-        owner_ref: names.ProcTemplate,
-        ty: Type.TypeId,
-        owner_result_ty: ?Type.TypeId,
-    ) Allocator.Error!?[]const SpecEvidence {
-        const owner_template = owner_view.templates.get(owner_ref.template);
-        if (owner_template.evidence_params.len == 0) return null;
-
-        const owner_node = try self.instNode(owner_template.checked_fn_root);
-        const owner_mono_ty = try self.activeTypeFromNode(owner_node);
-        const owner_ret = self.functionReturnType(owner_mono_ty);
-        switch (self.builder.shapeContent(ty)) {
-            .func => {},
-            else => Common.invariant("stored capturing function had a non-function restored type"),
-        }
-        const restored_owner_result_ty = switch (self.builder.shapeContent(owner_ret)) {
-            .func => ty,
-            else => owner_result_ty orelse owner_ret,
-        };
-        try self.graph.unify(try self.graph.importMono(owner_ret), try self.graph.importMono(restored_owner_result_ty));
-        try self.graph.drainDirty();
-        const owner_callable_ty = try self.activeTypeFromNode(owner_node);
-        return try self.synthesizeParamsEvidence(owner_view, owner_template, owner_callable_ty);
     }
 
     /// Resolve a template's requirements from its checked dispatcher paths

--- a/src/postcheck/monotype_lifted/ast.zig
+++ b/src/postcheck/monotype_lifted/ast.zig
@@ -154,6 +154,8 @@ pub const ProgramView = struct {
     stmt_ids: []const StmtId,
     field_exprs: []const FieldExpr,
     fn_def_captures: []const FnDefCapture,
+    const_evidence_pool: []const check.ConstStore.ConstEvidence,
+    const_evidence_chain_pool: []const check.ConstStore.ConstRange,
     capture_operands: []const CaptureOperand,
     record_destructs: []const RecordDestruct,
     str_pattern_steps: []const Mono.StrPatternStep,
@@ -379,6 +381,8 @@ pub const Program = struct {
     stmt_ids: ProgramList(StmtId, "stmt_ids"),
     field_exprs: ProgramList(FieldExpr, "field_exprs"),
     fn_def_captures: ProgramList(FnDefCapture, "fn_def_captures"),
+    const_evidence_pool: ProgramList(check.ConstStore.ConstEvidence, "const_evidence_pool"),
+    const_evidence_chain_pool: ProgramList(check.ConstStore.ConstRange, "const_evidence_chain_pool"),
     /// Backing pool for `Span(CaptureOperand)` capture operand spans on lifted
     /// `fn_ref`/`call_proc` nodes.
     capture_operands: ProgramList(CaptureOperand, "capture_operands"),
@@ -462,6 +466,8 @@ pub const Program = struct {
             .stmt_ids = ProgramList(StmtId, "stmt_ids").fromArrayList(stmt_ids),
             .field_exprs = ProgramList(FieldExpr, "field_exprs").fromArrayList(field_exprs),
             .fn_def_captures = ProgramList(FnDefCapture, "fn_def_captures").fromArrayList(fn_def_captures),
+            .const_evidence_pool = .empty,
+            .const_evidence_chain_pool = .empty,
             .capture_operands = .empty,
             .record_destructs = ProgramList(RecordDestruct, "record_destructs").fromArrayList(record_destructs),
             .str_pattern_steps = ProgramList(Mono.StrPatternStep, "str_pattern_steps").fromArrayList(str_pattern_steps),
@@ -513,6 +519,8 @@ pub const Program = struct {
         self.str_pattern_steps.deinit(self.allocator);
         self.record_destructs.deinit(self.allocator);
         self.fn_def_captures.deinit(self.allocator);
+        self.const_evidence_chain_pool.deinit(self.allocator);
+        self.const_evidence_pool.deinit(self.allocator);
         self.capture_operands.deinit(self.allocator);
         self.field_exprs.deinit(self.allocator);
         self.stmt_ids.deinit(self.allocator);
@@ -546,6 +554,8 @@ pub const Program = struct {
             .stmt_ids = self.stmt_ids.unsafeRawItemsForView(),
             .field_exprs = self.field_exprs.unsafeRawItemsForView(),
             .fn_def_captures = self.fn_def_captures.unsafeRawItemsForView(),
+            .const_evidence_pool = self.const_evidence_pool.unsafeRawItemsForView(),
+            .const_evidence_chain_pool = self.const_evidence_chain_pool.unsafeRawItemsForView(),
             .capture_operands = self.capture_operands.unsafeRawItemsForView(),
             .record_destructs = self.record_destructs.unsafeRawItemsForView(),
             .str_pattern_steps = self.str_pattern_steps.unsafeRawItemsForView(),

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -35,6 +35,8 @@ pub fn run(
     var stmt_ids = owned.stmt_ids.takeArrayList();
     var field_exprs = owned.field_exprs.takeArrayList();
     var fn_def_captures = owned.fn_def_captures.takeArrayList();
+    var const_evidence_pool = owned.const_evidence_pool.takeArrayList();
+    var const_evidence_chain_pool = owned.const_evidence_chain_pool.takeArrayList();
     var record_destructs = owned.record_destructs.takeArrayList();
     var str_pattern_steps = owned.str_pattern_steps.takeArrayList();
     var branches = owned.branches.takeArrayList();
@@ -112,6 +114,10 @@ pub fn run(
     comptime_sites = undefined;
     program.runtime_schema_requests = Ast.ProgramList(Ast.RuntimeSchemaRequest, "runtime_schema_requests").fromArrayList(runtime_schema_requests);
     runtime_schema_requests = undefined;
+    program.const_evidence_pool = Ast.ProgramList(@import("check").ConstStore.ConstEvidence, "const_evidence_pool").fromArrayList(const_evidence_pool);
+    const_evidence_pool = undefined;
+    program.const_evidence_chain_pool = Ast.ProgramList(@import("check").ConstStore.ConstRange, "const_evidence_chain_pool").fromArrayList(const_evidence_chain_pool);
+    const_evidence_chain_pool = undefined;
     errdefer program.deinit();
 
     const source_view = movedMonoView(&owned, &program);
@@ -151,6 +157,8 @@ fn movedMonoView(source: *const Mono.Program, moved: *const Ast.Program) Mono.Pr
         .stmt_ids = moved_view.stmt_ids,
         .field_exprs = moved_view.field_exprs,
         .fn_def_captures = moved_view.fn_def_captures,
+        .const_evidence_pool = moved_view.const_evidence_pool,
+        .const_evidence_chain_pool = moved_view.const_evidence_chain_pool,
         .capture_operands = moved_view.capture_operands,
         .record_destructs = moved_view.record_destructs,
         .str_pattern_steps = moved_view.str_pattern_steps,

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -491,6 +491,8 @@ const Lowerer = struct {
     }
 
     fn lower(self: *Lowerer) Common.LowerError!void {
+        try self.result.const_evidence_pool.appendSlice(self.allocator, self.solved.lifted.const_evidence_pool.unsafeRawItemsForView());
+        try self.result.const_evidence_chain_pool.appendSlice(self.allocator, self.solved.lifted.const_evidence_chain_pool.unsafeRawItemsForView());
         try self.indexSourceFns();
 
         try self.roots.ensureTotalCapacity(self.allocator, self.solved.lifted.rootCount());
@@ -7434,6 +7436,8 @@ fn cloneLiftedProgram(allocator: std.mem.Allocator, program: *const Lifted.Progr
         .stmt_ids = try clonedLiftedProgramList(Lifted.StmtId, "stmt_ids", allocator, view.stmt_ids),
         .field_exprs = try clonedLiftedProgramList(Lifted.FieldExpr, "field_exprs", allocator, view.field_exprs),
         .fn_def_captures = try clonedLiftedProgramList(Lifted.FnDefCapture, "fn_def_captures", allocator, view.fn_def_captures),
+        .const_evidence_pool = try clonedLiftedProgramList(check.ConstStore.ConstEvidence, "const_evidence_pool", allocator, view.const_evidence_pool),
+        .const_evidence_chain_pool = try clonedLiftedProgramList(check.ConstStore.ConstRange, "const_evidence_chain_pool", allocator, view.const_evidence_chain_pool),
         .capture_operands = try clonedLiftedProgramList(Lifted.CaptureOperand, "capture_operands", allocator, view.capture_operands),
         .record_destructs = try clonedLiftedProgramList(Lifted.RecordDestruct, "record_destructs", allocator, view.record_destructs),
         .str_pattern_steps = try clonedLiftedProgramList(Lifted.StrPatternStep, "str_pattern_steps", allocator, view.str_pattern_steps),
@@ -7644,6 +7648,7 @@ fn constFnTemplateFromMono(template: Mono.FnTemplate) LirProgram.FnTemplate {
         .fn_def = constFnDefFromMono(template.fn_def),
         .source_fn_ty = template.source_fn_ty,
         .source_fn_key = template.source_fn_key,
+        .const_evidence_chain = template.const_evidence_chain,
     };
 }
 


### PR DESCRIPTION
Compile-time function values now retain their fully resolved dispatch-evidence chain through Monotype and LIR into ConstStore, and restoration consumes that explicit data instead of reconstructing it from the closure's result type. This prevents where-constrained closures stored in constants from lowering their dispatch as unreachable.

The checked-artifact serialization version is bumped for the new evidence pools, and the regression covers the stored capturing closure shape.

Fixes #10118