### PR TITLE
Make DebugAllocator stack traces opt-in via -Ddebug-gpa-traces

### DIFF
--- a/.github/actions/debug-gpa-retrace/action.yml
+++ b/.github/actions/debug-gpa-retrace/action.yml
@@ -1,0 +1,71 @@
+name: 'Debug GPA retrace'
+description: >
+  Run a zig build command; if it fails and its output contains DebugAllocator
+  leak reports (which carry no allocation-site stack traces in default builds),
+  re-run the command with -Ddebug-gpa-traces so the log gains the traces.
+  The step still fails with the original exit code; the re-run is diagnostics only.
+inputs:
+  command:
+    description: 'The zig build command to run'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Run command with leak retrace
+      shell: bash
+      run: |
+        heartbeat() {
+          while true; do
+            sleep 300
+            echo "[debug-gpa-retrace] command still running after ${SECONDS}s..."
+          done
+        }
+
+        # Avoid piping through tee: some Zig build children can inherit the
+        # pipe and keep it open after Zig has already exited successfully
+        # (same workaround as flaky-retry). `set +e` must come before the
+        # background launch: a backgrounded subshell inherits -e, and bash 3.2
+        # (macOS) then collapses the command's exit status to 1.
+        run_captured() {
+          set +e
+          heartbeat &
+          local heartbeat_pid=$!
+          eval "$1" > "$output_file" 2>&1 &
+          local command_pid=$!
+          wait "$command_pid"
+          captured_exit_code=$?
+          set -e
+          kill "$heartbeat_pid" 2>/dev/null || true
+          wait "$heartbeat_pid" 2>/dev/null || true
+          cat "$output_file"
+        }
+
+        output_file=$(mktemp)
+        trap 'rm -f "$output_file"' EXIT
+
+        echo "Running command: ${{ inputs.command }}"
+        run_captured "${{ inputs.command }}"
+        exit_code=$captured_exit_code
+
+        if [ "$exit_code" -eq 0 ]; then
+          exit 0
+        fi
+
+        if ! grep -qiE "leaked:|memory leak" "$output_file"; then
+          exit "$exit_code"
+        fi
+
+        # Insert -Ddebug-gpa-traces before any `--` run-args separator.
+        command="${{ inputs.command }}"
+        if [[ "$command" == *" -- "* ]]; then
+          traced_command="${command/ -- / -Ddebug-gpa-traces -- }"
+        else
+          traced_command="$command -Ddebug-gpa-traces"
+        fi
+
+        echo ""
+        echo "[debug-gpa-retrace] leak report detected; re-running with allocation-site stack traces:"
+        echo "[debug-gpa-retrace]   $traced_command"
+        run_captured "$traced_command"
+
+        exit "$exit_code"

--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -165,8 +165,13 @@ jobs:
           error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
+      # On a leak failure this re-runs `zig build minici -Ddebug-gpa-traces`,
+      # which MiniCI forwards to every child `zig build` step, so the re-run's
+      # leak reports include allocation-site stack traces.
       - name: Run MiniCI
-        run: zig build minici
+        uses: ./.github/actions/debug-gpa-retrace
+        with:
+          command: zig build minici
 
       - name: Upload MiniCI report and logs
         if: failure()

--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -108,7 +108,9 @@ jobs:
         run: zig build run-check-cli-global-stdio
 
       - name: zig snapshot tests
-        run: zig build run-check-snapshots -- --debug
+        uses: ./.github/actions/debug-gpa-retrace
+        with:
+          command: zig build run-check-snapshots -- --debug
 
       - name: Run Playground Tests
         run: zig build run-test-playground -Doptimize=ReleaseSmall -- --verbose
@@ -257,13 +259,9 @@ jobs:
           retry_count: 3
 
       - name: Run CLI platform tests (LLVM size/speed backends)
-        if: runner.os != 'Windows'
-        run: zig build run-test-cli -- --include-llvm --filter "[size]" --filter "[speed]"
-
-      - name: Run CLI platform tests (LLVM size/speed backends, Windows)
-        if: runner.os == 'Windows'
-        run: |
-          zig build run-test-cli -- --include-llvm --filter "[size]" --filter "[speed]"
+        uses: ./.github/actions/debug-gpa-retrace
+        with:
+          command: zig build run-test-cli -- --include-llvm --filter "[size]" --filter "[speed]"
 
       - name: Shared-library build-and-run test (roc build --opt=size)
         run: zig build run-test-dylib
@@ -348,7 +346,9 @@ jobs:
 
       - name: Run Test Platforms (Unix)
         if: runner.os != 'Windows'
-        run: zig build run-test-cli ${{ matrix.target_flag }}
+        uses: ./.github/actions/debug-gpa-retrace
+        with:
+          command: zig build run-test-cli ${{ matrix.target_flag }}
 
       - name: Setup MSVC (Windows)
         if: runner.os == 'Windows'
@@ -358,8 +358,9 @@ jobs:
 
       - name: Run Test Platforms (Windows)
         if: runner.os == 'Windows'
-        run: |
-          zig build run-test-cli
+        uses: ./.github/actions/debug-gpa-retrace
+        with:
+          command: zig build run-test-cli
 
       - name: roc executable minimal check (Unix)
         if: runner.os != 'Windows'
@@ -372,7 +373,9 @@ jobs:
           zig-out\bin\roc.exe check ./CONTRIBUTING/profiling/bench_repeated_check.roc
 
       - name: zig snapshot tests
-        run: zig build run-check-snapshots ${{ matrix.target_flag }} -- --debug
+        uses: ./.github/actions/debug-gpa-retrace
+        with:
+          command: zig build run-check-snapshots ${{ matrix.target_flag }} -- --debug
 
       # 1) in debug mode
       - name: build and execute tests, build repro executables

--- a/build.zig
+++ b/build.zig
@@ -2434,6 +2434,7 @@ pub fn build(b: *std.Build) void {
     const cli_test_llvm = b.option(bool, "cli-test-llvm", "Include LLVM size/speed backend jobs in CLI platform tests") orelse false;
     const trace_build = b.option(bool, "trace-build", "Enable detailed build pipeline tracing") orelse false;
     const debug_gpa = b.option(bool, "debug-gpa", "Use the leak-checking DebugAllocator for the roc binary even when libc is linked (default: off, so libc's malloc and its ASan/Valgrind/LD_PRELOAD tooling are used)") orelse false;
+    const debug_gpa_traces = b.option(bool, "debug-gpa-traces", "Capture an allocation-site stack trace on every DebugAllocator allocation so leak reports show where the leaked memory was allocated (default: off, because capturing traces dominates Debug-build runtime; leaks are detected either way)") orelse false;
     const shared_memory_size = b.option(u64, "shared-memory-size", "Explicitly set shared-memory arena sizes in bytes");
     const print_trmc = b.option(bool, "print-trmc", "Print one line for each transformed TRMC/TCE proc") orelse false;
     const print_ir_after_trmc = b.option(bool, "print-ir-after-trmc", "Print full LIR for each proc transformed by TRMC/TCE") orelse false;
@@ -2493,6 +2494,7 @@ pub fn build(b: *std.Build) void {
     build_options.addOption(bool, "trace_modules", trace_modules);
     build_options.addOption(bool, "trace_build", trace_build);
     build_options.addOption(bool, "debug_gpa", debug_gpa);
+    build_options.addOption(bool, "debug_gpa_traces", debug_gpa_traces);
     build_options.addOption(bool, "has_shared_memory_size", shared_memory_size != null);
     build_options.addOption(u64, "shared_memory_size", shared_memory_size orelse 0);
     build_options.addOption(bool, "print_trmc", print_trmc);
@@ -2523,6 +2525,34 @@ pub fn build(b: *std.Build) void {
         \\    },
         \\    compiler_version_git,
         \\});
+        \\
+    ) catch @panic("OOM");
+    // Shared config for every first-party leak-checking DebugAllocator. Capturing a
+    // stack trace per allocation dominates Debug-build runtime (~80% of `roc test`
+    // wall time on macOS arm64), so traces are off unless -Ddebug-gpa-traces is
+    // passed; leaks are still detected without them. Lives in the generated
+    // build_options module because it is imported by everything that instantiates
+    // a DebugAllocator, including minimal test platform hosts.
+    build_options.contents.appendSlice(b.allocator,
+        \\
+        \\pub const debug_gpa_stack_trace_frames: usize =
+        \\    if (debug_gpa_traces and @import("std").debug.sys_can_stack_trace) 6 else 0;
+        \\
+        \\/// Appended to leak reports in traceless builds; empty when traces are on.
+        \\pub const debug_gpa_leak_hint: []const u8 = if (debug_gpa_stack_trace_frames == 0)
+        \\    "note: leak reports above have no allocation-site stack traces; rebuild with `-Ddebug-gpa-traces` to capture them\n"
+        \\else
+        \\    "";
+        \\
+        \\/// Deinit-check for leak-checking DebugAllocators: prints the
+        \\/// -Ddebug-gpa-traces hint when `check` reports a leak in a traceless
+        \\/// build, then returns whether the check passed.
+        \\pub fn debugGpaOk(check: @import("std").heap.Check) bool {
+        \\    if (check == .leak) {
+        \\        @import("std").debug.print("{s}", .{debug_gpa_leak_hint});
+        \\    }
+        \\    return check == .ok;
+        \\}
         \\
     ) catch @panic("OOM");
     build_options.addOption(bool, "enable_tracy_callstack", flag_tracy_callstack);
@@ -2708,6 +2738,12 @@ pub fn build(b: *std.Build) void {
         run_minici.addArg("--search-prefix");
         run_minici.addArg(search_prefix);
     }
+    // MiniCI forwards these args to every child `zig build` it runs, so
+    // `zig build minici -Ddebug-gpa-traces` gives all child steps traced
+    // leak reports (CI re-runs failed leaky jobs this way).
+    if (debug_gpa_traces) {
+        run_minici.addArg("-Ddebug-gpa-traces");
+    }
     run_minici.step.dependOn(&install_minici.step);
     run_minici_step.dependOn(&run_minici.step);
 
@@ -2872,7 +2908,9 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/cli/test/test_runner.zig"),
             .target = target,
             .optimize = optimize,
-            .imports = &.{},
+            .imports = &.{
+                .{ .name = "build_options", .module = roc_modules.build_options },
+            },
             // runner_core.zig uses std.c.{timespec,clock_gettime,environ}; Zig 0.16 requires
             // explicit libc linkage for any module that touches std.c.
             .link_libc = true,
@@ -2900,6 +2938,7 @@ pub fn build(b: *std.Build) void {
                     .{ .name = "collections", .module = roc_modules.collections },
                     .{ .name = "backend", .module = roc_modules.backend },
                     .{ .name = "bytebox", .module = bytebox.module("bytebox") },
+                    .{ .name = "build_options", .module = roc_modules.build_options },
                 },
             }),
         });
@@ -3493,6 +3532,7 @@ pub fn build(b: *std.Build) void {
         });
         configureBackend(echo_wasm_archive_exe, target);
         echo_wasm_archive_exe.root_module.addImport("bundle", roc_modules.bundle);
+        echo_wasm_archive_exe.root_module.addImport("build_options", roc_modules.build_options);
         echo_wasm_archive_exe.root_module.linkLibrary(zstd.artifact("zstd"));
 
         const echo_wasm_archive_cmd = b.addRunArtifact(echo_wasm_archive_exe);
@@ -3524,6 +3564,7 @@ pub fn build(b: *std.Build) void {
             }),
         });
         configureBackend(echo_native_exe, target);
+        echo_native_exe.root_module.addImport("build_options", roc_modules.build_options);
         echo_native_exe.root_module.addImport("compile", roc_modules.compile);
         echo_native_exe.root_module.addImport("check", roc_modules.check);
         echo_native_exe.root_module.addImport("eval", roc_modules.eval);
@@ -3576,6 +3617,7 @@ pub fn build(b: *std.Build) void {
             }),
         });
         configureBackend(glue_release_exe, target);
+        glue_release_exe.root_module.addImport("build_options", roc_modules.build_options);
 
         const glue_package_cmd = b.addRunArtifact(roc_exe);
         glue_package_cmd.setCwd(b.path("src/glue/platform"));
@@ -3868,6 +3910,7 @@ pub fn build(b: *std.Build) void {
         });
         configureBackend(wasm_test_exe, target);
         wasm_test_exe.root_module.addImport("bytebox", bytebox.module("bytebox"));
+        wasm_test_exe.root_module.addImport("build_options", roc_modules.build_options);
 
         const install = b.addInstallArtifact(wasm_test_exe, .{});
         build_test_wasm_static_lib_runner_step.dependOn(&install.step);
@@ -5474,6 +5517,7 @@ fn add_fuzz_target(
     });
     configureBackend(repro_exe, target);
     repro_exe.root_module.addImport("fuzz_test", fuzz_obj.root_module);
+    repro_exe.root_module.addImport("build_options", roc_modules.build_options);
 
     _ = install_and_run(b, no_bin, repro_exe, build_repro_step, run_repro_step, run_args);
 

--- a/ci/check_test_wiring.zig
+++ b/ci/check_test_wiring.zig
@@ -20,6 +20,9 @@ const TermColor = struct {
 
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
+    // This tool stays standalone (no build_options wiring), so unlike the
+    // first-party DebugAllocators behind -Ddebug-gpa-traces it keeps std's
+    // default allocation-site traces; it allocates too little to matter.
     var gpa_impl = std.heap.DebugAllocator(.{}){};
     defer _ = gpa_impl.deinit();
     const gpa = gpa_impl.allocator();

--- a/ci/tidy.zig
+++ b/ci/tidy.zig
@@ -34,6 +34,9 @@ const TermColor = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
+    // This tool stays standalone (no build_options wiring), so unlike the
+    // first-party DebugAllocators behind -Ddebug-gpa-traces it keeps std's
+    // default allocation-site traces; it allocates too little to matter.
     var gpa_impl = std.heap.DebugAllocator(.{}){};
     defer _ = gpa_impl.deinit();
     const gpa = gpa_impl.allocator();

--- a/ci/zig_lints.zig
+++ b/ci/zig_lints.zig
@@ -13,6 +13,9 @@ const TermColor = struct {
 
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
+    // This tool stays standalone (no build_options wiring), so unlike the
+    // first-party DebugAllocators behind -Ddebug-gpa-traces it keeps std's
+    // default allocation-site traces; it allocates too little to matter.
     var gpa_impl = std.heap.DebugAllocator(.{}){};
     defer _ = gpa_impl.deinit();
     const gpa = gpa_impl.allocator();

--- a/src/build/glue_release.zig
+++ b/src/build/glue_release.zig
@@ -12,6 +12,7 @@
 //!   - glue/env
 
 const std = @import("std");
+const build_options = @import("build_options");
 
 const glue_specs = [_]Spec{
     .{ .source = "src/glue/src/RustGlue.roc", .dest = "RustGlue.roc" },
@@ -30,8 +31,8 @@ const Spec = struct {
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
 
-    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
-    defer _ = gpa_impl.deinit();
+    var gpa_impl: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .init;
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
 
     var arena_impl = std.heap.ArenaAllocator.init(gpa);

--- a/src/build/minici.zig
+++ b/src/build/minici.zig
@@ -1171,6 +1171,9 @@ fn applyMemoryAwareCpuLimit(io: std.Io, allocator: std.mem.Allocator, env: *cons
 /// on memory-constrained hosts (see `applyMemoryAwareCpuLimit`).
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
+    // MiniCI stays standalone (no build_options wiring), so unlike the other
+    // first-party DebugAllocators this one keeps std's default allocation-site
+    // traces; it allocates too little for -Ddebug-gpa-traces to matter here.
     var gpa_impl = std.heap.DebugAllocator(.{}){};
     defer _ = gpa_impl.deinit();
     const gpa = gpa_impl.allocator();

--- a/src/builtins/fuzz_sort.zig
+++ b/src/builtins/fuzz_sort.zig
@@ -5,6 +5,7 @@
 //! comparison mechanisms.
 
 const std = @import("std");
+const build_options = @import("build_options");
 const Allocator = std.mem.Allocator;
 const sort = @import("sort.zig");
 
@@ -24,9 +25,9 @@ var allocator: std.mem.Allocator = undefined;
 /// TODO: Document fuzz_main.
 pub fn fuzz_main() Allocator.Error!void {
     // Setup an allocator that will detect leaks/use-after-free/etc
-    var gpa = std.heap.DebugAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
     // this will check for leaks and crash the program if it finds any
-    defer std.debug.assert(gpa.deinit() == .ok);
+    defer std.debug.assert(build_options.debugGpaOk(gpa.deinit()));
     allocator = gpa.allocator();
 
     // Read the data from stdin.

--- a/src/canonicalize/test/import_validation_test.zig
+++ b/src/canonicalize/test/import_validation_test.zig
@@ -6,6 +6,7 @@
 //! the canonicalization process.
 
 const std = @import("std");
+const build_options = @import("build_options");
 const Allocator = std.mem.Allocator;
 const base = @import("base");
 const parse = @import("parse");
@@ -79,8 +80,8 @@ fn parseAndCanonicalizeSource(
 }
 
 test "file imports reject absolute paths before recording dependencies" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
 
     const source =
@@ -121,8 +122,8 @@ test "file imports reject absolute paths before recording dependencies" {
 }
 
 test "import validation - mix of MODULE NOT FOUND, TYPE NOT EXPOSED, VALUE NOT EXPOSED, and working imports" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
 
     // First, create some module environments with exposed items
@@ -258,8 +259,8 @@ test "import validation - mix of MODULE NOT FOUND, TYPE NOT EXPOSED, VALUE NOT E
 }
 
 test "import validation - type module associated values are importable via exposing" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
     const Ident = base.Ident;
 
@@ -362,8 +363,8 @@ test "import validation - exposed nested type associated function resolves via s
     // `Square` resolves fine as a *type*; the bug is that `Square.create` (a
     // static-dispatch lookup of the nested type's associated value) is reported
     // as "does not exist".
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
     const Ident = base.Ident;
 
@@ -470,8 +471,8 @@ test "import validation - exposing a type module's main type by name is not a re
     // `exposing` (as platform code does with `import NodeB exposing [NodeB]`)
     // binds the same external type to the same name twice. That is idempotent,
     // not a DUPLICATE DEFINITION.
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
     const Ident = base.Ident;
 
@@ -552,8 +553,8 @@ test "import validation - exposing a type module's main type by name is not a re
 }
 
 test "unresolved exposed value is not imported as external lookup target zero" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
     const Ident = base.Ident;
 
@@ -639,8 +640,8 @@ test "unresolved exposed value is not imported as external lookup target zero" {
 }
 
 test "import validation - no module_envs provided" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
 
     // Parse source code with import statements
@@ -685,8 +686,8 @@ test "import validation - no module_envs provided" {
 }
 
 test "import interner - Import.Idx functionality" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
     // Parse source code with multiple imports, including duplicates
     const source =
@@ -742,8 +743,8 @@ test "import interner - Import.Idx functionality" {
 }
 
 test "import interner - many imports keep stable module identity keys" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
 
     const import_count = 320;
@@ -783,8 +784,8 @@ test "import interner - many imports keep stable module identity keys" {
 }
 
 test "import interner - comprehensive usage example" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
     // Parse source with imports used in different contexts
     const source =
@@ -842,8 +843,8 @@ test "import interner - comprehensive usage example" {
 }
 
 test "module scopes - imports work in module scope" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
     // Parse source with imports used in module scope
     const source =
@@ -882,8 +883,8 @@ test "module scopes - imports work in module scope" {
 }
 
 test "module-qualified lookups with e_lookup_external" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
     // Parse source with module-qualified lookups
     const source =
@@ -921,8 +922,8 @@ test "module-qualified lookups with e_lookup_external" {
 }
 
 test "exposed_items - tracking CIR node indices for exposed items" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
 
     // Create module environments with exposed items
@@ -987,8 +988,8 @@ test "exposed_items - tracking CIR node indices for exposed items" {
 }
 
 test "imported type-module tag rejects alias target" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
 
     var builtin_ctx = try BuiltinTestContext.init(allocator);
@@ -1063,8 +1064,8 @@ test "imported type-module tag rejects alias target" {
 }
 
 test "imported nested associated types resolve by qualified export key" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
 
     var builtin_ctx = try BuiltinTestContext.init(allocator);
@@ -1147,8 +1148,8 @@ test "imported nested associated types resolve by qualified export key" {
 }
 
 test "export count safety - ensures safe u16 casting" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const allocator = gpa_state.allocator();
 
     // This test verifies that we check export counts to ensure safe casting to u16

--- a/src/canonicalize/test/int_test.zig
+++ b/src/canonicalize/test/int_test.zig
@@ -5,6 +5,7 @@
 //! compiler's canonical internal representation (CIR).
 
 const std = @import("std");
+const build_options = @import("build_options");
 const testing = std.testing;
 const base = @import("base");
 const parse = @import("parse");
@@ -563,8 +564,8 @@ test "hexadecimal integer literals" {
         .{ .literal = "-0x8000000000000001", .expected_value = @as(i128, -9223372036854775809) },
     };
 
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const gpa = gpa_state.allocator();
     var builtin_ctx = try BuiltinTestContext.init(gpa);
     defer builtin_ctx.deinit();
@@ -626,8 +627,8 @@ test "binary integer literals" {
         .{ .literal = "-0b1000000000000001", .expected_value = -32769 },
     };
 
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const gpa = gpa_state.allocator();
     var builtin_ctx = try BuiltinTestContext.init(gpa);
     defer builtin_ctx.deinit();
@@ -689,8 +690,8 @@ test "octal integer literals" {
         .{ .literal = "-0o100001", .expected_value = -32769 },
     };
 
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const gpa = gpa_state.allocator();
     var builtin_ctx = try BuiltinTestContext.init(gpa);
     defer builtin_ctx.deinit();
@@ -752,8 +753,8 @@ test "integer literals with uppercase base prefixes" {
         .{ .literal = "0XaBcD", .expected_value = 43981 },
     };
 
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const gpa = gpa_state.allocator();
     var builtin_ctx = try BuiltinTestContext.init(gpa);
     defer builtin_ctx.deinit();
@@ -788,8 +789,8 @@ test "integer literals with uppercase base prefixes" {
 }
 
 test "numeric literal patterns use pattern idx as type var" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const gpa = gpa_state.allocator();
 
     // Test that int literal patterns work and use the pattern index as the type variable
@@ -841,8 +842,8 @@ test "numeric literal patterns use pattern idx as type var" {
 }
 
 test "pattern numeric literal value edge cases" {
-    var gpa_state = std.heap.DebugAllocator(.{ .safety = true }){};
-    defer std.debug.assert(gpa_state.deinit() == .ok);
+    var gpa_state = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer std.debug.assert(build_options.debugGpaOk(gpa_state.deinit()));
     const gpa = gpa_state.allocator();
 
     // Test max/min integer values

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -970,7 +970,7 @@ pub fn createTempDirStructure(ctx: *CliCtx, exe_path: []const u8, exe_display_na
     return error.FailedToCreateUniqueTempDir;
 }
 
-var debug_allocator: std.heap.DebugAllocator(.{}) = .{
+var debug_allocator: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .{
     .backing_allocator = std.heap.page_allocator,
 };
 
@@ -1029,8 +1029,7 @@ pub fn main(init: std.process.Init) Allocator.Error!void {
     };
     defer restoreWindowsConsoleCodePage();
     defer if (is_safe) {
-        const mem_state = debug_allocator.deinit();
-        std.debug.assert(mem_state == .ok);
+        std.debug.assert(build_options.debugGpaOk(debug_allocator.deinit()));
     };
 
     if (tracy.enable_allocation) {

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -17,6 +17,7 @@
 //!   --verbose            Print PASS results and timing details
 
 const std = @import("std");
+const build_options = @import("build_options");
 const builtin = @import("builtin");
 const posix = std.posix;
 const Allocator = std.mem.Allocator;
@@ -8274,8 +8275,8 @@ test "effectiveTimeoutMs extends default for glue suite only" {
 
 /// Entry point for the parallel CLI test runner.
 pub fn main(init: std.process.Init) CliRunnerError!void {
-    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
-    defer _ = gpa_impl.deinit();
+    var gpa_impl: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .init;
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
 
     var spec_arena = collections.SingleThreadArena.init(gpa);

--- a/src/cli/test/test_runner.zig
+++ b/src/cli/test/test_runner.zig
@@ -34,6 +34,7 @@
 //!   test_runner ./zig-out/bin/roc fx --opt=dev           # fx with dev backend
 
 const std = @import("std");
+const build_options = @import("build_options");
 const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 
@@ -65,8 +66,8 @@ const Args = struct {
 
 /// Entry point for the unified test platform runner.
 pub fn main(init: std.process.Init) TestRunnerError!void {
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
+    var gpa = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer _ = build_options.debugGpaOk(gpa.deinit());
     const allocator = gpa.allocator();
 
     const args = try parseArgs(init.minimal.args, allocator);

--- a/src/cli/test_shared_memory_system.zig
+++ b/src/cli/test_shared_memory_system.zig
@@ -1,6 +1,7 @@
 //! Tests for CLI platform resolution that do not cross the post-check lowering boundary
 
 const std = @import("std");
+const build_options = @import("build_options");
 const testing = std.testing;
 const main = @import("main.zig");
 const base = @import("base");
@@ -30,8 +31,8 @@ fn sharedPrePublishedBuiltin() SharedMemorySystemTestError!test_helpers.PrePubli
 }
 
 test "platform resolution - basic cli platform" {
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa_impl.deinit();
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
     var arena_impl = base.SingleThreadArena.init(gpa);
     defer arena_impl.deinit();
@@ -69,8 +70,8 @@ test "platform resolution - basic cli platform" {
 }
 
 test "platform resolution - no platform in file" {
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa_impl.deinit();
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
     var arena_impl = base.SingleThreadArena.init(gpa);
     defer arena_impl.deinit();
@@ -103,8 +104,8 @@ test "platform resolution - no platform in file" {
 }
 
 test "platform resolution - file not found" {
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa_impl.deinit();
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
     var arena_impl = base.SingleThreadArena.init(gpa);
     defer arena_impl.deinit();
@@ -121,8 +122,8 @@ test "platform resolution - file not found" {
 }
 
 test "platform resolution - insecure HTTP URL rejected" {
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa_impl.deinit();
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
     var arena_impl = base.SingleThreadArena.init(gpa);
     defer arena_impl.deinit();
@@ -278,8 +279,8 @@ test "integration - one LIR image resolves layouts for both pointer widths" {
 }
 
 test "integration - error handling for non-existent file" {
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa_impl.deinit();
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
     var arena_impl = base.SingleThreadArena.init(gpa);
     defer arena_impl.deinit();

--- a/src/echo_platform/echo_native.zig
+++ b/src/echo_platform/echo_native.zig
@@ -9,6 +9,7 @@
 //! it in an `app [main!]` header that imports the embedded echo platform.
 
 const std = @import("std");
+const build_options = @import("build_options");
 const compile = @import("compile");
 const reporting = @import("reporting");
 const roc_target = @import("roc_target");
@@ -77,8 +78,8 @@ pub fn main(init: std.process.Init) EchoNativeError!void {
     process_io = init.io;
     const io = init.io;
 
-    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
-    defer _ = gpa_impl.deinit();
+    var gpa_impl: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .init;
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
 
     var arena_impl = base.SingleThreadArena.init(gpa);

--- a/src/echo_platform/echo_wasm_archive.zig
+++ b/src/echo_platform/echo_wasm_archive.zig
@@ -7,6 +7,7 @@
 //! first and then runs this tool to emit `zig-out/lib/echo.wasm.zst`.
 
 const std = @import("std");
+const build_options = @import("build_options");
 const bundle = @import("bundle");
 
 const ArchiveError = std.process.Args.ToSliceError ||
@@ -20,8 +21,8 @@ const ArchiveError = std.process.Args.ToSliceError ||
 pub fn main(init: std.process.Init) ArchiveError!void {
     const io = init.io;
 
-    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
-    defer _ = gpa_impl.deinit();
+    var gpa_impl: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .init;
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     var gpa = gpa_impl.allocator();
 
     var arena_impl = std.heap.ArenaAllocator.init(gpa);

--- a/src/eval/test/host_effects_runner.zig
+++ b/src/eval/test/host_effects_runner.zig
@@ -12,6 +12,7 @@
 //! order, and whether execution returned or terminated via crash.
 
 const std = @import("std");
+const build_options = @import("build_options");
 const Allocator = std.mem.Allocator;
 const posix = std.posix;
 const eval = @import("eval");
@@ -1016,8 +1017,8 @@ fn writeStatsJson(
 
 /// Public function `main`.
 pub fn main(init: std.process.Init) RunnerMainError!void {
-    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
-    defer _ = gpa_impl.deinit();
+    var gpa_impl: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .init;
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
 
     const io = init.io;

--- a/src/eval/test/parallel_runner.zig
+++ b/src/eval/test/parallel_runner.zig
@@ -2167,8 +2167,8 @@ pub fn main(init: std.process.Init) RunnerError!void {
     var trace_worker = WorkerTrace.init(io);
     trace_worker.stamp("main entry");
 
-    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
-    defer _ = gpa_impl.deinit();
+    var gpa_impl: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .init;
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
     trace_worker.stamp("gpa init");
 

--- a/src/glue/platform/host.zig
+++ b/src/glue/platform/host.zig
@@ -148,7 +148,7 @@ const RocAllocation = struct {
 
 /// Host environment - contains DebugAllocator for leak detection
 const HostEnv = struct {
-    gpa: std.heap.DebugAllocator(.{ .safety = true }),
+    gpa: std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }),
     std_io: std.Io,
     /// Track Roc allocations for cleanup on test failure
     roc_allocations: std.ArrayListUnmanaged(RocAllocation) = .{ .items = &.{}, .capacity = 0 },
@@ -704,7 +704,7 @@ fn platform_main(args: [][*:0]u8, std_io: std.Io) (Allocator.Error || error{ Mis
     }
 
     var host_env = HostEnv{
-        .gpa = std.heap.DebugAllocator(.{ .safety = true }){},
+        .gpa = std.heap.DebugAllocator(.{ .safety = true, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){},
         .std_io = std_io,
     };
 
@@ -740,6 +740,7 @@ fn platform_main(args: [][*:0]u8, std_io: std.Io) (Allocator.Error || error{ Mis
                 \\[Roc Memory Info] Additional memory leak detected by GPA.
                 \\
             ) catch {};
+            stderr_file.writeStreamingAll(host_env.std_io, build_options.debug_gpa_leak_hint) catch {};
         }
     }
 

--- a/src/lsp/test/parallel_integration_runner.zig
+++ b/src/lsp/test/parallel_integration_runner.zig
@@ -4,6 +4,7 @@
 //! filtering, process-level parallelism, timeout reporting, and MiniCI stats.
 
 const std = @import("std");
+const build_options = @import("build_options");
 const posix = std.posix;
 const Allocator = std.mem.Allocator;
 
@@ -108,7 +109,7 @@ fn buildMessage(
 fn runSingleTest(io: std.Io, allocator: Allocator, spec: integration.Spec, _: u64) TestResult {
     var timer = harness.Timer.start() catch @panic("no clock");
 
-    var spec_allocator_impl: std.heap.DebugAllocator(.{}) = .init;
+    var spec_allocator_impl: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .init;
     const spec_allocator = spec_allocator_impl.allocator();
     test_env.init(spec_allocator, io);
     log_err_count = 0;
@@ -128,7 +129,7 @@ fn runSingleTest(io: std.Io, allocator: Allocator, spec: integration.Spec, _: u6
         },
     }
 
-    const leaks: usize = if (spec_allocator_impl.deinit() == .leak) 1 else 0;
+    const leaks: usize = if (build_options.debugGpaOk(spec_allocator_impl.deinit())) 0 else 1;
 
     if (log_err_count != 0 or leaks != 0) {
         if (status == .pass or status == .skip) status = .fail;
@@ -396,8 +397,8 @@ fn printUsage() void {
 
 /// Runs the parallel LSP integration harness or one worker process.
 pub fn main(init: std.process.Init) RunnerMainError!void {
-    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
-    defer _ = gpa_impl.deinit();
+    var gpa_impl: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .init;
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
 
     var arena_impl = std.heap.ArenaAllocator.init(gpa);

--- a/src/snapshot_tool/main.zig
+++ b/src/snapshot_tool/main.zig
@@ -7,6 +7,7 @@
 //! the given Roc code snippet.
 
 const std = @import("std");
+const build_options = @import("build_options");
 
 /// Application IO instance, initialized from `std.process.Init` in `main`.
 /// Use this instead of `app_io` for all application IO.
@@ -439,7 +440,7 @@ fn renderReportsToExpectedContent(allocator: std.mem.Allocator, reports: *const 
     return try generateExpectedContent(allocator, entries.items);
 }
 
-var debug_allocator: std.heap.DebugAllocator(.{}) = .{
+var debug_allocator: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .{
     .backing_allocator = std.heap.page_allocator,
 };
 
@@ -458,8 +459,7 @@ pub fn main(init: std.process.Init) SnapshotError!void {
     var gpa_tracy: tracy.TracyAllocator(null) = undefined;
     var gpa = debug_allocator.allocator();
     defer {
-        const mem_state = debug_allocator.deinit();
-        std.debug.assert(mem_state == .ok);
+        std.debug.assert(build_options.debugGpaOk(debug_allocator.deinit()));
     }
 
     // Wrap with Tracy for allocation profiling when enabled

--- a/test/echo-wasm-test/main.zig
+++ b/test/echo-wasm-test/main.zig
@@ -7,6 +7,7 @@
 //! "Hello from the Greeting module!" as raw echo output.
 
 const std = @import("std");
+const build_options = @import("build_options");
 const Allocator = std.mem.Allocator;
 const bytebox = @import("bytebox");
 
@@ -95,8 +96,8 @@ fn requireNotContains(haystack: []const u8, needle: []const u8, label: []const u
 pub fn main(init: std.process.Init) anyerror!void {
     const io = init.io;
 
-    var gpa_impl: std.heap.DebugAllocator(.{}) = .init;
-    defer _ = gpa_impl.deinit();
+    var gpa_impl: std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }) = .init;
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
 
     var arena_impl = std.heap.ArenaAllocator.init(gpa);

--- a/test/fuzzing/fuzz-build.zig
+++ b/test/fuzzing/fuzz-build.zig
@@ -13,6 +13,7 @@
 //!   ./zig-out/AFLplusplus/bin/afl-fuzz -t 480000+ -i /tmp/roc-build-corpus -o /tmp/roc-build-out zig-out/bin/fuzz-build
 
 const std = @import("std");
+const build_options = @import("build_options");
 const builtin = @import("builtin");
 const base = @import("base");
 const check = @import("check");
@@ -33,10 +34,10 @@ pub export fn zig_fuzz_test(buf: [*]u8, len: isize) void {
 }
 
 pub fn zig_fuzz_test_inner(buf: [*]u8, len: isize, debug: bool) void {
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
     defer {
         if (!builtin.fuzz or debug) {
-            _ = gpa_impl.deinit();
+            _ = build_options.debugGpaOk(gpa_impl.deinit());
         }
     }
     const gpa = if (builtin.fuzz and !debug) base.defaultGpa() else gpa_impl.allocator();

--- a/test/fuzzing/fuzz-canonicalize.zig
+++ b/test/fuzzing/fuzz-canonicalize.zig
@@ -37,6 +37,7 @@
 //! Other afl commands also available in `./zig-out/AFLplusplus/bin`
 
 const std = @import("std");
+const build_options = @import("build_options");
 const compile = @import("compile");
 const roc_target = @import("roc_target");
 const FuzzHarness = @import("FuzzHarness.zig");
@@ -55,9 +56,9 @@ pub export fn zig_fuzz_test(buf: [*]u8, len: isize) void {
 pub fn zig_fuzz_test_inner(buf: [*]u8, len: isize, debug: bool) void {
     // We reinitialize the gpa on every loop of the fuzzer.
     // This enables the gpa to do leak checking on each iteration.
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
     defer {
-        _ = gpa_impl.deinit();
+        _ = build_options.debugGpaOk(gpa_impl.deinit());
     }
     const gpa = gpa_impl.allocator();
 

--- a/test/fuzzing/fuzz-parse.zig
+++ b/test/fuzzing/fuzz-parse.zig
@@ -8,6 +8,7 @@
 //! Other afl commands also available in `./zig-out/AFLplusplus/bin`
 
 const std = @import("std");
+const build_options = @import("build_options");
 const fmt = @import("fmt");
 
 /// Hook for AFL++ to initialize the fuzz test environment.
@@ -22,9 +23,9 @@ pub export fn zig_fuzz_test(buf: [*]u8, len: isize) void {
 pub fn zig_fuzz_test_inner(buf: [*]u8, len: isize, debug: bool) void {
     // We reinitialize the gpa on every loop of the fuzzer.
     // This enables the gpa to do leak checking on each iteration.
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
     defer {
-        _ = gpa_impl.deinit();
+        _ = build_options.debugGpaOk(gpa_impl.deinit());
     }
     const gpa = gpa_impl.allocator();
 

--- a/test/fuzzing/fuzz-repro.zig
+++ b/test/fuzzing/fuzz-repro.zig
@@ -4,6 +4,7 @@
 //! This runners makes a simple script to reproduce failures from the command line (stdin or file).
 
 const std = @import("std");
+const build_options = @import("build_options");
 const fuzz_test = @import("fuzz_test");
 
 // TODO: add a func zig_pretty_print or something to dump the test case in a pretty printed format.
@@ -28,9 +29,9 @@ const HELP =
 
 /// CLI entrypoint for fuzzing failure reproducer.
 pub fn main(init: std.process.Init) anyerror!void {
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
     defer {
-        _ = gpa_impl.deinit();
+        _ = build_options.debugGpaOk(gpa_impl.deinit());
     }
     const gpa = gpa_impl.allocator();
 

--- a/test/fuzzing/fuzz-tokenize.zig
+++ b/test/fuzzing/fuzz-tokenize.zig
@@ -8,6 +8,7 @@
 //! Other afl commands also available in `./zig-out/AFLplusplus/bin`
 
 const std = @import("std");
+const build_options = @import("build_options");
 const parse = @import("parse");
 
 /// Hook for AFL++ to initialize the fuzz test environment.
@@ -22,9 +23,9 @@ pub export fn zig_fuzz_test(buf: [*]u8, len: isize) void {
 pub fn zig_fuzz_test_inner(buf: [*]u8, len: isize, debug: bool) void {
     // We reinitialize the gpa on every loop of the fuzzer.
     // This enables the gpa to do leak checking on each iteration.
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
     defer {
-        _ = gpa_impl.deinit();
+        _ = build_options.debugGpaOk(gpa_impl.deinit());
     }
     const gpa = gpa_impl.allocator();
 

--- a/test/fuzzing/fuzz-typecheck.zig
+++ b/test/fuzzing/fuzz-typecheck.zig
@@ -13,6 +13,7 @@
 //!   ./zig-out/AFLplusplus/bin/afl-fuzz -i /tmp/roc-typecheck-corpus -o /tmp/roc-typecheck-out zig-out/bin/fuzz-typecheck
 
 const std = @import("std");
+const build_options = @import("build_options");
 const compile = @import("compile");
 const roc_target = @import("roc_target");
 const FuzzHarness = @import("FuzzHarness.zig");
@@ -28,9 +29,9 @@ pub export fn zig_fuzz_test(buf: [*]u8, len: isize) void {
 }
 
 pub fn zig_fuzz_test_inner(buf: [*]u8, len: isize, debug: bool) void {
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
     defer {
-        _ = gpa_impl.deinit();
+        _ = build_options.debugGpaOk(gpa_impl.deinit());
     }
     const gpa = gpa_impl.allocator();
 

--- a/test/fx-open/platform/host.zig
+++ b/test/fx-open/platform/host.zig
@@ -15,7 +15,7 @@ pub const std_options = shim_io.std_options_no_stack_tracing;
 
 /// Host environment - contains DebugAllocator for leak detection
 const HostEnv = struct {
-    gpa: std.heap.DebugAllocator(.{ .thread_safe = false }),
+    gpa: std.heap.DebugAllocator(.{ .thread_safe = false, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }),
     std_io: std.Io,
 };
 
@@ -342,13 +342,14 @@ fn buildArgsList(ops: *builtins.host_abi.RocOps, argc: c_int, argv: [*][*:0]u8) 
 /// Platform host entrypoint
 fn platform_main(argc: c_int, argv: [*][*:0]u8) Allocator.Error!c_int {
     var host_env = HostEnv{
-        .gpa = std.heap.DebugAllocator(.{ .thread_safe = false }){},
+        .gpa = std.heap.DebugAllocator(.{ .thread_safe = false, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){},
         .std_io = shim_io.io(),
     };
     defer {
         const leaked = host_env.gpa.deinit();
         if (leaked == .leak) {
             std.log.err("\x1b[33mMemory leak detected!\x1b[0m", .{});
+            std.debug.print("{s}", .{build_options.debug_gpa_leak_hint});
         }
     }
 

--- a/test/fx/platform/host.zig
+++ b/test/fx/platform/host.zig
@@ -373,7 +373,7 @@ const RocAllocation = struct {
 
 /// Host environment - contains DebugAllocator for leak detection
 const HostEnv = struct {
-    gpa: std.heap.DebugAllocator(.{ .safety = true, .thread_safe = false }),
+    gpa: std.heap.DebugAllocator(.{ .safety = true, .thread_safe = false, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }),
     test_state: TestState,
     std_io: std.Io,
     /// Track Roc allocations for cleanup on test failure
@@ -1424,7 +1424,7 @@ fn platform_main(test_spec: ?[]const u8, test_verbose: bool) (Allocator.Error ||
     }
 
     var host_env = HostEnv{
-        .gpa = std.heap.DebugAllocator(.{ .safety = true, .thread_safe = false }){},
+        .gpa = std.heap.DebugAllocator(.{ .safety = true, .thread_safe = false, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){},
         .test_state = TestState.init(),
         .std_io = shim_io.io(),
     };
@@ -1494,6 +1494,7 @@ fn platform_main(test_spec: ?[]const u8, test_verbose: bool) (Allocator.Error ||
                 \\  This is internal to Roc's compiler/runtime, not application code.
                 \\
             });
+            std.debug.print("{s}", .{build_options.debug_gpa_leak_hint});
         }
     }
 

--- a/test/playground-integration/main.zig
+++ b/test/playground-integration/main.zig
@@ -1164,8 +1164,8 @@ fn matchesAnyFilter(name: []const u8, filters: []const []const u8) bool {
 pub fn main(init: std.process.Init) anyerror!void {
     const std_io = init.io;
     // Setup gpa allocator used for bytebox WASM VM
-    var gpa = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa.deinit();
+    var gpa = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer _ = build_options.debugGpaOk(gpa.deinit());
 
     // Setup arena allocator used for test harness
     var arena = std.heap.ArenaAllocator.init(gpa.allocator());

--- a/test/static-data-host/platform/host.zig
+++ b/test/static-data-host/platform/host.zig
@@ -6,6 +6,7 @@
 //! header is `REFCOUNT_STATIC_DATA`.
 
 const std = @import("std");
+const build_options = @import("build_options");
 const builtin = @import("builtin");
 const builtins = @import("builtins");
 const shim_io = @import("shim_io");
@@ -34,7 +35,7 @@ const HostEnv = struct {
     // thread_safe = false: this single-threaded test host must stay compiler_rt-free,
     // but DebugAllocator's thread-safe mutex pulls in std.Io.Threaded (timestampToPosix
     // -> i128 division -> __divti3/__modti3, which this archive does not link).
-    gpa: std.heap.DebugAllocator(.{ .thread_safe = false }),
+    gpa: std.heap.DebugAllocator(.{ .thread_safe = false, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }),
     dealloc_count: usize,
 };
 
@@ -146,10 +147,10 @@ fn main(argc: c_int, argv: [*][*:0]u8) callconv(.c) c_int {
     _ = argv;
 
     var host_env = HostEnv{
-        .gpa = std.heap.DebugAllocator(.{ .thread_safe = false }){},
+        .gpa = std.heap.DebugAllocator(.{ .thread_safe = false, .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){},
         .dealloc_count = 0,
     };
-    defer _ = host_env.gpa.deinit();
+    defer _ = build_options.debugGpaOk(host_env.gpa.deinit());
 
     var roc_ops = RocOps{
         .env = @ptrCast(&host_env),

--- a/test/wasm/main.zig
+++ b/test/wasm/main.zig
@@ -6,6 +6,7 @@
 //! Run with: zig build run-test-wasm-static-lib
 
 const std = @import("std");
+const build_options = @import("build_options");
 const Allocator = std.mem.Allocator;
 const bytebox = @import("bytebox");
 
@@ -332,8 +333,8 @@ fn runTest(gpa: std.mem.Allocator, arena: std.mem.Allocator, io: std.Io, wasm_pa
 }
 
 pub fn main(init: std.process.Init) anyerror!void {
-    var gpa_impl = std.heap.DebugAllocator(.{}){};
-    defer _ = gpa_impl.deinit();
+    var gpa_impl = std.heap.DebugAllocator(.{ .stack_trace_frames = build_options.debug_gpa_stack_trace_frames }){};
+    defer _ = build_options.debugGpaOk(gpa_impl.deinit());
     const gpa = gpa_impl.allocator();
 
     var arena_impl = std.heap.ArenaAllocator.init(gpa);


### PR DESCRIPTION
Capturing a 6-frame stack trace on every allocation dominated Debug-build runtime (~80% of `roc test` wall time on macOS arm64) and was timing out the JSON CLI tests. Leaks are still detected without traces; traceless leak reports now print a hint to rebuild with -Ddebug-gpa-traces.

JsonStringEscapes 57s -> 3.6s, JsonEncodeRoundTrip 89s -> 11s, run-check-snapshots 70s -> 16s.

CI re-runs a failed step with -Ddebug-gpa-traces (via the new debug-gpa-retrace action) when its output contains leak reports, so the log gains allocation-site traces; the job still fails with the original exit code.