### PR TITLE
Use worklist for lifted capture solving

### DIFF
--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -117,6 +117,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_9825_test.zig"));
     std.testing.refAllDecls(@import("test/issue_9884_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10021_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10132_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));
     std.testing.refAllDecls(@import("test/platform_box_update_lir_test.zig"));

--- a/src/compile/test/issue_10132_test.zig
+++ b/src/compile/test/issue_10132_test.zig
@@ -1,0 +1,24 @@
+//! Regression test for issue #10132.
+
+const harness = @import("lower_to_lir_harness.zig");
+
+test "issue 10132: try suffix in capturing effectful closure lowers with specialization" {
+    // Repro for https://github.com/roc-lang/roc/issues/10132.
+    try harness.expectLowersToLirWithOptions(
+        \\check : Str -> Try({}, [Empty])
+        \\check = |s| if Str.is_empty(s) { Err(Empty) } else { Ok({}) }
+        \\
+        \\main! = |_args| {
+        \\    name = "x"
+        \\    helper! = || {
+        \\        echo!("hi ${name}")
+        \\        check(name)?
+        \\        Ok({})
+        \\    }
+        \\    match helper!() {
+        \\        Ok({}) => Ok({})
+        \\        Err(_) => Ok({})
+        \\    }
+        \\}
+    , .{ .inline_mode = .wrappers });
+}

--- a/src/compile/test/lower_to_lir_harness.zig
+++ b/src/compile/test/lower_to_lir_harness.zig
@@ -79,6 +79,13 @@ pub fn expectLowersToLir(app_body: []const u8) LowerToLirHarnessError!void {
     try runToLir(app_body, null, .{}, null);
 }
 
+/// Lower an app whose body is `app_body` to LIR with explicit lowering
+/// options. Reaching the end without a panic means the program checked cleanly
+/// and passed ARC certification.
+pub fn expectLowersToLirWithOptions(app_body: []const u8, opts: LirLoweringOptions) LowerToLirHarnessError!void {
+    try runToLir(app_body, null, opts, null);
+}
+
 /// Lower an app at `app_path` to LIR. Reaching the end without a panic means
 /// the app checked cleanly and passed ARC certification.
 pub fn expectAppPathLowersToLir(app_path: []const u8) LowerToLirHarnessError!void {

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -180,15 +180,15 @@ fn movedMonoView(source: *const Mono.Program, moved: *const Ast.Program) Mono.Pr
 /// because substitutions can change the capture shape of the rewritten
 /// functions.
 pub fn recomputeCaptures(allocator: Allocator, program: *Ast.Program) Allocator.Error!void {
-    const fn_captures = try allocateCaptureTable(allocator, program.fnCount());
-    defer deinitCaptureTable(allocator, fn_captures);
-
-    try solveCaptureFixpoint(allocator, program, fn_captures);
-    try finalizeProgramFunctionReferenceCaptures(program, fn_captures);
+    var graph = try CaptureDependencyGraph.init(allocator, program, null);
+    defer graph.deinit();
+    try graph.buildPostLift();
+    try graph.solve();
+    try graph.finalizePostLiftOperands();
 
     for (0..program.fnCount()) |index| {
         const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(index)));
-        program.setFnCaptures(fn_id, try program.addTypedLocalSpan(fn_captures[index].items));
+        program.setFnCaptures(fn_id, try program.addTypedLocalSpan(graph.states[index].captures.items));
     }
 
     verifyCaptureInvariants(program);
@@ -732,53 +732,25 @@ const Lifter = struct {
     }
 
     /// Solve every function's capture set as a fixed point over the
-    /// function-reference graph. Each function's captures are the free locals
-    /// of its body, where a reference to another function contributes that
-    /// callee's current captures filtered by the locals bound at the reference
-    /// site. The stored order is the body's discovery order under the final
-    /// callee sets.
+    /// function-reference graph. Each function body and conditional capture
+    /// operand expression is summarized once; a worklist then propagates only
+    /// newly discovered captures through affected reference edges.
     fn computeCaptureFixpoint(self: *Lifter) Allocator.Error!void {
         // `count` covers top-level defs and nested defs only; inline lambdas are
         // reserved later, during `rewriteExpr`/`liftLambda`. Sizing here is what
-        // keeps inline lambdas out of the fixpoint, which is sound because they
-        // are never the target of a reference that reaches `collectFnCaptures`
-        // (only defs and nested defs are) — an invariant that function enforces.
+        // keeps inline lambdas out of the graph, which is sound because they are
+        // never direct-call targets. Their captures are computed when lifting
+        // reaches the lambda, from the already-solved def/nested-def states.
+        var graph = try CaptureDependencyGraph.init(self.allocator, self.output, self);
+        defer graph.deinit();
+        try graph.buildPreLift(self.fn_bodies.items);
+        try graph.solve();
+
         const count = self.output.fnCount();
         self.fn_captures = try allocateCaptureTable(self.allocator, count);
-
-        var scratch = CaptureSet.init(self);
-        defer scratch.deinit();
-        var bound = BoundSet.init(self.allocator);
-        defer bound.deinit();
-
-        var changed = true;
-        while (changed) {
-            changed = false;
-            for (0..count) |raw| {
-                const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(raw)));
-                try self.solveInto(fn_id, &scratch, &bound);
-                if (!captureListEql(scratch.items.items, self.fn_captures[raw].items)) {
-                    self.fn_captures[raw].clearRetainingCapacity();
-                    try self.fn_captures[raw].appendSlice(self.allocator, scratch.items.items);
-                    changed = true;
-                }
-            }
+        for (0..count) |index| {
+            try self.fn_captures[index].appendSlice(self.allocator, graph.states[index].captures.items);
         }
-    }
-
-    /// Solve one function's captures into the reusable `scratch`/`bound`,
-    /// reading the current solved sets of referenced functions. Both scratch
-    /// buffers are cleared first.
-    fn solveInto(self: *Lifter, fn_id: Ast.FnId, scratch: *CaptureSet, bound: *BoundSet) Allocator.Error!void {
-        scratch.clear();
-        bound.clear();
-        const body = self.fn_bodies.items[@intFromEnum(fn_id)] orelse return;
-        try bindTypedLocals(self.output, bound, self.output.typedLocalSpan(body.args));
-        switch (body.body) {
-            .roc => |expr| try scratch.collectExpr(expr, bound),
-            .hosted => {},
-        }
-        sortCaptureSlots(self.output, scratch.items.items);
     }
 
     fn registerFn(self: *Lifter, mono_fn_id: Mono.FnId, fn_id: Ast.FnId) void {
@@ -870,11 +842,6 @@ fn allocateCaptureTable(allocator: Allocator, count: usize) Allocator.Error![]st
     const captures = try allocator.alloc(std.ArrayList(Ast.TypedLocal), count);
     for (captures) |*capture| capture.* = .empty;
     return captures;
-}
-
-fn deinitCaptureTable(allocator: Allocator, captures: []std.ArrayList(Ast.TypedLocal)) void {
-    for (captures) |*capture| capture.deinit(allocator);
-    if (captures.len > 0) allocator.free(captures);
 }
 
 /// Find the existing operand value that supplies capture `id`.
@@ -995,49 +962,6 @@ fn finalizeProgramFunctionReferenceCaptures(
             .hosted => {},
         }
     }
-}
-
-fn solveCaptureFixpoint(
-    allocator: Allocator,
-    program: *Ast.Program,
-    fn_captures: []std.ArrayList(Ast.TypedLocal),
-) Allocator.Error!void {
-    var scratch = CaptureSet.initForProgram(allocator, program, fn_captures);
-    defer scratch.deinit();
-    var bound = BoundSet.init(allocator);
-    defer bound.deinit();
-
-    var changed = true;
-    while (changed) {
-        changed = false;
-        for (0..program.fnCount()) |raw| {
-            const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(raw)));
-            const fn_ = program.getFn(fn_id);
-            scratch.clear();
-            bound.clear();
-
-            try bindTypedLocals(program, &bound, program.typedLocalSpan(fn_.args));
-            switch (fn_.body) {
-                .roc => |expr| try scratch.collectExpr(expr, &bound),
-                .hosted => {},
-            }
-            sortCaptureSlots(program, scratch.items.items);
-
-            if (!captureListEql(scratch.items.items, fn_captures[raw].items)) {
-                fn_captures[raw].clearRetainingCapacity();
-                try fn_captures[raw].appendSlice(allocator, scratch.items.items);
-                changed = true;
-            }
-        }
-    }
-}
-
-fn captureListEql(lhs: []const Ast.TypedLocal, rhs: []const Ast.TypedLocal) bool {
-    if (lhs.len != rhs.len) return false;
-    for (lhs, rhs) |a, b| {
-        if (a.local != b.local or a.ty != b.ty) return false;
-    }
-    return true;
 }
 
 /// The CaptureId of a capture slot. Every capture slot's
@@ -1580,6 +1504,746 @@ fn removeBound(input: *const Ast.Program, bound: *BoundSet, locals: []const Mono
     }
 }
 
+const CaptureNodeId = enum(u32) { _ };
+const CaptureEdgeId = enum(u32) { _ };
+const CaptureScopeId = enum(u32) { _ };
+
+const CaptureGraphNode = struct {
+    owner: Ast.FnId,
+    direct: std.ArrayList(Ast.TypedLocal) = .empty,
+    edges: std.ArrayList(CaptureEdgeId) = .empty,
+    active: bool = false,
+};
+
+const CaptureSupply = struct {
+    id: checked.CaptureId,
+    value: Ast.ExprId,
+    node: CaptureNodeId,
+};
+
+const CaptureEdgeSite = union(enum) {
+    pre_lift,
+    fn_ref: Ast.ExprId,
+    call_proc: Ast.ExprId,
+};
+
+const CaptureGraphEdge = struct {
+    owner: Ast.FnId,
+    target: Ast.FnId,
+    scope: ?CaptureScopeId,
+    site: CaptureEdgeSite,
+    exact_supplies: std.ArrayList(CaptureSupply) = .empty,
+    declared_supplies: std.ArrayList(CaptureSupply) = .empty,
+    active: bool = false,
+};
+
+const CaptureScopeEntry = struct {
+    parent: ?CaptureScopeId,
+    local: Ast.LocalId,
+};
+
+const CaptureFnState = struct {
+    captures: std.ArrayList(Ast.TypedLocal) = .empty,
+    by_id: std.AutoHashMap(checked.CaptureId, Ast.TypedLocal),
+    reverse_edges: std.ArrayList(CaptureEdgeId) = .empty,
+
+    fn init(allocator: Allocator) CaptureFnState {
+        return .{ .by_id = std.AutoHashMap(checked.CaptureId, Ast.TypedLocal).init(allocator) };
+    }
+};
+
+const CaptureUpdate = struct {
+    function: Ast.FnId,
+    capture: Ast.TypedLocal,
+};
+
+/// Exact free-variable dataflow for lifted functions.
+///
+/// A root node represents the unconditionally evaluated part of one function
+/// body. Each explicit capture operand is represented by a dormant child node:
+/// it becomes active only if the target function actually has the CaptureId
+/// that operand supplies. Active call/reference edges subscribe to their
+/// target's capture set. A newly discovered capture therefore visits only the
+/// affected edges, and each operand-expression node is activated at most once.
+const CaptureDependencyGraph = struct {
+    backing_allocator: Allocator,
+    arena: *std.heap.ArenaAllocator,
+    allocator: Allocator,
+    program: *Ast.Program,
+    lifter: ?*Lifter,
+    states: []CaptureFnState,
+    nodes: std.ArrayList(CaptureGraphNode),
+    edges: std.ArrayList(CaptureGraphEdge),
+    scopes: std.ArrayList(CaptureScopeEntry),
+    roots: std.ArrayList(CaptureNodeId),
+    pending_nodes: std.ArrayList(CaptureNodeId),
+    updates: std.ArrayList(CaptureUpdate),
+    next_node: usize,
+    next_update: usize,
+
+    fn init(allocator: Allocator, program: *Ast.Program, lifter: ?*Lifter) Allocator.Error!CaptureDependencyGraph {
+        const arena = try allocator.create(std.heap.ArenaAllocator);
+        errdefer allocator.destroy(arena);
+        arena.* = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+        const scratch = arena.allocator();
+        const states = try scratch.alloc(CaptureFnState, program.fnCount());
+        for (states) |*state| state.* = CaptureFnState.init(scratch);
+        return .{
+            .backing_allocator = allocator,
+            .arena = arena,
+            .allocator = scratch,
+            .program = program,
+            .lifter = lifter,
+            .states = states,
+            .nodes = .empty,
+            .edges = .empty,
+            .scopes = .empty,
+            .roots = .empty,
+            .pending_nodes = .empty,
+            .updates = .empty,
+            .next_node = 0,
+            .next_update = 0,
+        };
+    }
+
+    fn deinit(self: *CaptureDependencyGraph) void {
+        self.arena.deinit();
+        self.backing_allocator.destroy(self.arena);
+    }
+
+    fn addNode(self: *CaptureDependencyGraph, owner: Ast.FnId) Allocator.Error!CaptureNodeId {
+        const id: CaptureNodeId = @enumFromInt(@as(u32, @intCast(self.nodes.items.len)));
+        try self.nodes.append(self.allocator, .{ .owner = owner });
+        return id;
+    }
+
+    fn addScopeEntry(self: *CaptureDependencyGraph, parent: ?CaptureScopeId, local: Ast.LocalId) Allocator.Error!CaptureScopeId {
+        const id: CaptureScopeId = @enumFromInt(@as(u32, @intCast(self.scopes.items.len)));
+        try self.scopes.append(self.allocator, .{ .parent = parent, .local = local });
+        return id;
+    }
+
+    fn scopeBindingFor(self: *const CaptureDependencyGraph, scope: ?CaptureScopeId, local: Ast.LocalId) ?Ast.LocalId {
+        const binder = self.program.getLocal(local).binder;
+        var current = scope;
+        while (current) |id| {
+            const entry = self.scopes.items[@intFromEnum(id)];
+            if (entry.local == local) return entry.local;
+            if (binder) |identity| {
+                if (self.program.getLocal(entry.local).binder == identity) return entry.local;
+            }
+            current = entry.parent;
+        }
+        return null;
+    }
+
+    fn buildPreLift(self: *CaptureDependencyGraph, bodies: []const ?MonoFnBody) Allocator.Error!void {
+        if (self.lifter == null) Common.invariant("pre-lift capture graph had no lifter");
+        if (bodies.len != self.states.len) Common.invariant("pre-lift capture body count differed from reserved function count");
+        var builder = CaptureGraphBuilder.init(self);
+        defer builder.deinit();
+        for (bodies, 0..) |maybe_body, raw| {
+            const body = maybe_body orelse continue;
+            const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(raw)));
+            const root = try self.addNode(fn_id);
+            try self.roots.append(self.allocator, root);
+            builder.reset();
+            try builder.bindTypedLocals(self.program.typedLocalSpan(body.args), null);
+            switch (body.body) {
+                .roc => |expr| try builder.collectExpr(expr, root),
+                .hosted => {},
+            }
+        }
+    }
+
+    fn buildPostLift(self: *CaptureDependencyGraph) Allocator.Error!void {
+        if (self.lifter != null) Common.invariant("post-lift capture graph unexpectedly had a lifter");
+        var builder = CaptureGraphBuilder.init(self);
+        defer builder.deinit();
+        for (0..self.program.fnCount()) |raw| {
+            const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(raw)));
+            const fn_ = self.program.getFn(fn_id);
+            const root = try self.addNode(fn_id);
+            try self.roots.append(self.allocator, root);
+            builder.reset();
+            try builder.bindTypedLocals(self.program.typedLocalSpan(fn_.args), null);
+            switch (fn_.body) {
+                .roc => |expr| try builder.collectExpr(expr, root),
+                .hosted => {},
+            }
+        }
+    }
+
+    fn queueNode(self: *CaptureDependencyGraph, node_id: CaptureNodeId) Allocator.Error!void {
+        const node = &self.nodes.items[@intFromEnum(node_id)];
+        if (node.active) return;
+        node.active = true;
+        try self.pending_nodes.append(self.allocator, node_id);
+    }
+
+    fn addCaptureUpdate(self: *CaptureDependencyGraph, fn_id: Ast.FnId, capture: Ast.TypedLocal) Allocator.Error!void {
+        const local_data = self.program.getLocal(capture.local);
+        if (capture.ty != local_data.ty) Common.invariant("capture graph entry type differed from its local type");
+        const id = self.program.ensureLiftCaptureId(capture.local);
+        const state = &self.states[@intFromEnum(fn_id)];
+        const result = try state.by_id.getOrPut(id);
+        if (result.found_existing) {
+            if (result.value_ptr.local != capture.local or result.value_ptr.ty != capture.ty) {
+                Common.invariant("capture graph found two locals for one CaptureId in a function");
+            }
+            return;
+        }
+        result.value_ptr.* = capture;
+        try state.captures.append(self.allocator, capture);
+        try self.updates.append(self.allocator, .{ .function = fn_id, .capture = capture });
+    }
+
+    fn processNode(self: *CaptureDependencyGraph, node_id: CaptureNodeId) Allocator.Error!void {
+        const node_index = @intFromEnum(node_id);
+        const owner = self.nodes.items[node_index].owner;
+        var direct_index: usize = 0;
+        while (direct_index < self.nodes.items[node_index].direct.items.len) : (direct_index += 1) {
+            try self.addCaptureUpdate(owner, self.nodes.items[node_index].direct.items[direct_index]);
+        }
+        var edge_index: usize = 0;
+        while (edge_index < self.nodes.items[node_index].edges.items.len) : (edge_index += 1) {
+            try self.activateEdge(self.nodes.items[node_index].edges.items[edge_index]);
+        }
+    }
+
+    fn activateEdge(self: *CaptureDependencyGraph, edge_id: CaptureEdgeId) Allocator.Error!void {
+        const edge_index = @intFromEnum(edge_id);
+        if (self.edges.items[edge_index].active) return;
+        self.edges.items[edge_index].active = true;
+        const target = self.edges.items[edge_index].target;
+        const state = &self.states[@intFromEnum(target)];
+        try state.reverse_edges.append(self.allocator, edge_id);
+        var capture_index: usize = 0;
+        while (capture_index < state.captures.items.len) : (capture_index += 1) {
+            try self.applyCaptureToEdge(edge_id, state.captures.items[capture_index]);
+        }
+    }
+
+    fn supplyLessThan(_: void, lhs: CaptureSupply, rhs: CaptureSupply) bool {
+        return @intFromEnum(lhs.id) < @intFromEnum(rhs.id);
+    }
+
+    fn findSupply(supplies: []const CaptureSupply, id: checked.CaptureId) ?CaptureSupply {
+        var low: usize = 0;
+        var high: usize = supplies.len;
+        const wanted = @intFromEnum(id);
+        while (low < high) {
+            const mid = low + (high - low) / 2;
+            const found = @intFromEnum(supplies[mid].id);
+            if (found < wanted) {
+                low = mid + 1;
+            } else if (found > wanted) {
+                high = mid;
+            } else {
+                return supplies[mid];
+            }
+        }
+        return null;
+    }
+
+    fn edgeSupply(self: *const CaptureDependencyGraph, edge_id: CaptureEdgeId, id: checked.CaptureId) ?CaptureSupply {
+        const edge = self.edges.items[@intFromEnum(edge_id)];
+        return findSupply(edge.exact_supplies.items, id) orelse findSupply(edge.declared_supplies.items, id);
+    }
+
+    fn applyCaptureToEdge(self: *CaptureDependencyGraph, edge_id: CaptureEdgeId, capture: Ast.TypedLocal) Allocator.Error!void {
+        const id = slotCaptureId(self.program, capture);
+        if (self.edgeSupply(edge_id, id)) |supply| {
+            try self.queueNode(supply.node);
+            return;
+        }
+        const edge = self.edges.items[@intFromEnum(edge_id)];
+        if (self.scopeBindingFor(edge.scope, capture.local) == null) {
+            try self.addCaptureUpdate(edge.owner, capture);
+        }
+    }
+
+    fn processUpdate(self: *CaptureDependencyGraph, update: CaptureUpdate) Allocator.Error!void {
+        const state = &self.states[@intFromEnum(update.function)];
+        var index: usize = 0;
+        while (index < state.reverse_edges.items.len) : (index += 1) {
+            try self.applyCaptureToEdge(state.reverse_edges.items[index], update.capture);
+        }
+    }
+
+    fn solve(self: *CaptureDependencyGraph) Allocator.Error!void {
+        for (self.roots.items) |root| try self.queueNode(root);
+        while (self.next_node < self.pending_nodes.items.len or self.next_update < self.updates.items.len) {
+            if (self.next_node < self.pending_nodes.items.len) {
+                const node = self.pending_nodes.items[self.next_node];
+                self.next_node += 1;
+                try self.processNode(node);
+            } else {
+                const update = self.updates.items[self.next_update];
+                self.next_update += 1;
+                try self.processUpdate(update);
+            }
+        }
+        for (self.states) |*state| sortCaptureSlots(self.program, state.captures.items);
+    }
+
+    fn resolvedOperandValue(self: *CaptureDependencyGraph, edge_id: CaptureEdgeId, slot: Ast.TypedLocal) Allocator.Error!Ast.ExprId {
+        const edge = self.edges.items[@intFromEnum(edge_id)];
+        const id = slotCaptureId(self.program, slot);
+        if (self.edgeSupply(edge_id, id)) |supply| {
+            const candidate_local = switch (self.program.getExpr(supply.value).data) {
+                .local => |local| local,
+                else => return supply.value,
+            };
+            if (self.program.getLocal(candidate_local).capture_id != id) return supply.value;
+            const active = self.scopeBindingFor(edge.scope, candidate_local) orelse return supply.value;
+            if (active == candidate_local) return supply.value;
+            return try self.program.addExpr(.{ .ty = slot.ty, .data = .{ .local = active } });
+        }
+        const active = self.scopeBindingFor(edge.scope, slot.local) orelse slot.local;
+        return try self.program.addExpr(.{ .ty = slot.ty, .data = .{ .local = active } });
+    }
+
+    fn finalizedSpan(self: *CaptureDependencyGraph, edge_id: CaptureEdgeId, call_expr: Ast.ExprId) Allocator.Error!Ast.Span(Ast.CaptureOperand) {
+        const edge = self.edges.items[@intFromEnum(edge_id)];
+        const slots = self.states[@intFromEnum(edge.target)].captures.items;
+        if (slots.len == 0) return .empty();
+
+        const saved_loc = self.program.current_loc;
+        defer self.program.current_loc = saved_loc;
+        const saved_region = self.program.current_region;
+        defer self.program.current_region = saved_region;
+        const call_loc = self.program.exprLoc(call_expr);
+        if (call_loc.hasLocation()) self.program.current_loc = call_loc;
+        const call_region = self.program.exprRegion(call_expr);
+        if (!call_region.isEmpty()) self.program.current_region = call_region;
+
+        const operands = try self.allocator.alloc(Ast.CaptureOperand, slots.len);
+        defer self.allocator.free(operands);
+        for (slots, 0..) |slot, index| {
+            operands[index] = .{
+                .id = slotCaptureId(self.program, slot),
+                .value = try self.resolvedOperandValue(edge_id, slot),
+            };
+        }
+        return try self.program.addCaptureOperandSpan(operands);
+    }
+
+    fn finalizePostLiftOperands(self: *CaptureDependencyGraph) Allocator.Error!void {
+        for (self.edges.items, 0..) |edge, raw| {
+            const edge_id: CaptureEdgeId = @enumFromInt(@as(u32, @intCast(raw)));
+            switch (edge.site) {
+                .pre_lift => {},
+                .fn_ref => |expr_id| {
+                    const fn_ref = switch (self.program.getExpr(expr_id).data) {
+                        .fn_ref => |fn_ref| fn_ref,
+                        else => Common.invariant("capture graph function-reference site changed expression kind"),
+                    };
+                    if (fn_ref.fn_id != edge.target) Common.invariant("capture graph function-reference target changed");
+                    self.program.setExprData(expr_id, .{ .fn_ref = .{
+                        .fn_id = fn_ref.fn_id,
+                        .captures = try self.finalizedSpan(edge_id, expr_id),
+                    } });
+                },
+                .call_proc => |expr_id| {
+                    const call = switch (self.program.getExpr(expr_id).data) {
+                        .call_proc => |call| call,
+                        else => Common.invariant("capture graph direct-call site changed expression kind"),
+                    };
+                    const target = switch (call.callee) {
+                        .lifted => |fn_id| fn_id,
+                        .func => Common.invariant("capture graph direct-call site changed target kind"),
+                    };
+                    if (target != edge.target) Common.invariant("capture graph direct-call target changed");
+                    self.program.setExprData(expr_id, .{ .call_proc = .{
+                        .callee = call.callee,
+                        .args = call.args,
+                        .captures = try self.finalizedSpan(edge_id, expr_id),
+                        .is_cold = call.is_cold,
+                    } });
+                },
+            }
+        }
+    }
+};
+
+const CaptureGraphBuilder = struct {
+    graph: *CaptureDependencyGraph,
+    bound: BoundSet,
+    current_scope: ?CaptureScopeId,
+
+    fn init(graph: *CaptureDependencyGraph) CaptureGraphBuilder {
+        return .{
+            .graph = graph,
+            .bound = BoundSet.init(graph.allocator),
+            .current_scope = null,
+        };
+    }
+
+    fn deinit(self: *CaptureGraphBuilder) void {
+        self.bound.deinit();
+    }
+
+    fn reset(self: *CaptureGraphBuilder) void {
+        self.bound.clear();
+        self.current_scope = null;
+    }
+
+    fn bindLocal(self: *CaptureGraphBuilder, local: Ast.LocalId, added: ?*std.ArrayList(Ast.LocalId)) Allocator.Error!void {
+        try self.bound.put(self.graph.program, local);
+        self.current_scope = try self.graph.addScopeEntry(self.current_scope, local);
+        if (added) |list| try list.append(self.graph.allocator, local);
+    }
+
+    fn removeLocal(self: *CaptureGraphBuilder, local: Ast.LocalId) void {
+        const scope_id = self.current_scope orelse Common.invariant("capture graph scope stack underflow");
+        const entry = self.graph.scopes.items[@intFromEnum(scope_id)];
+        if (entry.local != local) Common.invariant("capture graph removed a lexical binding out of order");
+        self.current_scope = entry.parent;
+        self.bound.remove(self.graph.program, local);
+    }
+
+    fn removeLocals(self: *CaptureGraphBuilder, locals: []const Ast.LocalId) void {
+        var index = locals.len;
+        while (index > 0) {
+            index -= 1;
+            self.removeLocal(locals[index]);
+        }
+    }
+
+    fn bindTypedLocals(self: *CaptureGraphBuilder, locals: anytype, added: ?*std.ArrayList(Ast.LocalId)) Allocator.Error!void {
+        for (0..locals.len) |index| try self.bindLocal(GuardedList.at(locals, index).local, added);
+    }
+
+    fn bindPat(self: *CaptureGraphBuilder, pat_id: Ast.PatId, added: *std.ArrayList(Ast.LocalId)) Allocator.Error!void {
+        const input = self.graph.program;
+        switch (input.getPat(pat_id).data) {
+            .bind => |local| try self.bindLocal(local, added),
+            .wildcard,
+            .int_lit,
+            .dec_lit,
+            .frac_f32_lit,
+            .frac_f64_lit,
+            .str_lit,
+            => {},
+            .str_pattern => |str| {
+                const steps = input.strPatternStepSpan(str.steps);
+                for (0..steps.len) |index| {
+                    if (GuardedList.at(steps, index).capture) |capture| try self.bindPat(capture, added);
+                }
+            },
+            .as => |as| {
+                try self.bindPat(as.pattern, added);
+                try self.bindLocal(as.local, added);
+            },
+            .record => |fields| {
+                const destructs = input.recordDestructSpan(fields);
+                for (0..destructs.len) |index| try self.bindPat(GuardedList.at(destructs, index).pattern, added);
+            },
+            .tuple => |items| {
+                const children = input.patSpan(items);
+                for (0..children.len) |index| try self.bindPat(GuardedList.at(children, index), added);
+            },
+            .list => |list| {
+                const children = input.patSpan(list.patterns);
+                for (0..children.len) |index| try self.bindPat(GuardedList.at(children, index), added);
+                if (list.rest) |rest| if (rest.pattern) |rest_pattern| try self.bindPat(rest_pattern, added);
+            },
+            .tag => |tag| {
+                const payloads = input.patSpan(tag.payloads);
+                for (0..payloads.len) |index| try self.bindPat(GuardedList.at(payloads, index), added);
+            },
+            .nominal => |backing| try self.bindPat(backing, added),
+        }
+    }
+
+    fn addDirect(self: *CaptureGraphBuilder, node_id: CaptureNodeId, local: Ast.LocalId) Allocator.Error!void {
+        if (self.bound.contains(self.graph.program, local)) return;
+        _ = self.graph.program.ensureLiftCaptureId(local);
+        const local_data = self.graph.program.getLocal(local);
+        try self.graph.nodes.items[@intFromEnum(node_id)].direct.append(self.graph.allocator, .{
+            .local = local,
+            .ty = local_data.ty,
+        });
+    }
+
+    fn hasSupplyId(supplies: []const CaptureSupply, id: checked.CaptureId) bool {
+        for (supplies) |supply| if (supply.id == id) return true;
+        return false;
+    }
+
+    fn finishEdge(
+        self: *CaptureGraphBuilder,
+        parent: CaptureNodeId,
+        target: Ast.FnId,
+        site: CaptureEdgeSite,
+        exact_supplies: *std.ArrayList(CaptureSupply),
+        declared_supplies: *std.ArrayList(CaptureSupply),
+    ) Allocator.Error!void {
+        std.sort.pdq(CaptureSupply, exact_supplies.items, {}, CaptureDependencyGraph.supplyLessThan);
+        std.sort.pdq(CaptureSupply, declared_supplies.items, {}, CaptureDependencyGraph.supplyLessThan);
+        if (declared_supplies.items.len > 1) {
+            for (declared_supplies.items[1..], declared_supplies.items[0 .. declared_supplies.items.len - 1]) |current, previous| {
+                if (current.id == previous.id) Common.invariant("capture edge declared one CaptureId more than once");
+            }
+        }
+        const edge_id: CaptureEdgeId = @enumFromInt(@as(u32, @intCast(self.graph.edges.items.len)));
+        try self.graph.edges.append(self.graph.allocator, .{
+            .owner = self.graph.nodes.items[@intFromEnum(parent)].owner,
+            .target = target,
+            .scope = self.current_scope,
+            .site = site,
+            .exact_supplies = exact_supplies.*,
+            .declared_supplies = declared_supplies.*,
+        });
+        exact_supplies.* = .empty;
+        declared_supplies.* = .empty;
+        try self.graph.nodes.items[@intFromEnum(parent)].edges.append(self.graph.allocator, edge_id);
+    }
+
+    fn addCaptureOperandEdge(
+        self: *CaptureGraphBuilder,
+        parent: CaptureNodeId,
+        target: Ast.FnId,
+        site: CaptureEdgeSite,
+        span: Ast.Span(Ast.CaptureOperand),
+    ) Allocator.Error!void {
+        var exact: std.ArrayList(CaptureSupply) = .empty;
+        errdefer exact.deinit(self.graph.allocator);
+        var declared: std.ArrayList(CaptureSupply) = .empty;
+        errdefer declared.deinit(self.graph.allocator);
+        const operands = self.graph.program.captureOperandSpan(span);
+        for (0..operands.len) |index| {
+            const operand = GuardedList.at(operands, index);
+            const child = try self.graph.addNode(self.graph.nodes.items[@intFromEnum(parent)].owner);
+            try self.collectExpr(operand.value, child);
+            const supply = CaptureSupply{ .id = operand.id, .value = operand.value, .node = child };
+            try declared.append(self.graph.allocator, supply);
+            switch (self.graph.program.getExpr(operand.value).data) {
+                .local => |local| if (self.graph.program.getLocal(local).capture_id) |id| {
+                    if (!hasSupplyId(exact.items, id)) {
+                        try exact.append(self.graph.allocator, .{ .id = id, .value = operand.value, .node = child });
+                    }
+                },
+                else => {},
+            }
+        }
+        try self.finishEdge(parent, target, site, &exact, &declared);
+    }
+
+    fn addFnDefEdge(self: *CaptureGraphBuilder, parent: CaptureNodeId, target: Ast.FnId, span: Ast.Span(Ast.FnDefCapture)) Allocator.Error!void {
+        var exact: std.ArrayList(CaptureSupply) = .empty;
+        errdefer exact.deinit(self.graph.allocator);
+        var declared: std.ArrayList(CaptureSupply) = .empty;
+        errdefer declared.deinit(self.graph.allocator);
+        const captures = self.graph.program.fnDefCaptureSpan(span);
+        for (0..captures.len) |index| {
+            const capture = GuardedList.at(captures, index);
+            const id = self.graph.program.getLocal(capture.local).capture_id orelse
+                Common.invariant("pre-lift explicit capture local had no CaptureId");
+            const child = try self.graph.addNode(self.graph.nodes.items[@intFromEnum(parent)].owner);
+            try self.collectExpr(capture.value, child);
+            const supply = CaptureSupply{ .id = id, .value = capture.value, .node = child };
+            try declared.append(self.graph.allocator, supply);
+            if (!hasSupplyId(exact.items, id)) try exact.append(self.graph.allocator, supply);
+        }
+        try self.finishEdge(parent, target, .pre_lift, &exact, &declared);
+    }
+
+    fn collectExprSpan(self: *CaptureGraphBuilder, span: Ast.Span(Ast.ExprId), node: CaptureNodeId) Allocator.Error!void {
+        const values = self.graph.program.exprSpan(span);
+        for (0..values.len) |index| try self.collectExpr(GuardedList.at(values, index), node);
+    }
+
+    fn collectStmt(self: *CaptureGraphBuilder, stmt_id: Ast.StmtId, node: CaptureNodeId, added: *std.ArrayList(Ast.LocalId)) Allocator.Error!void {
+        const input = self.graph.program;
+        switch (input.getStmt(stmt_id)) {
+            .uninitialized => |pat| try self.bindPat(pat, added),
+            .let_ => |let_| {
+                if (let_.recursive) {
+                    try self.bindPat(let_.pat, added);
+                    try self.collectExpr(let_.value, node);
+                } else {
+                    try self.collectExpr(let_.value, node);
+                    try self.bindPat(let_.pat, added);
+                }
+            },
+            .expr,
+            .expect,
+            .dbg,
+            => |expr| try self.collectExpr(expr, node),
+            .return_ => |ret| try self.collectExpr(ret.value, node),
+            .crash => {},
+        }
+    }
+
+    fn collectExpr(self: *CaptureGraphBuilder, expr_id: Ast.ExprId, node: CaptureNodeId) Allocator.Error!void {
+        const input = self.graph.program;
+        const expr = input.getExpr(expr_id);
+        switch (expr.data) {
+            .local => |local| try self.addDirect(node, local),
+            .unit,
+            .int_lit,
+            .frac_f32_lit,
+            .frac_f64_lit,
+            .dec_lit,
+            .str_lit,
+            .bytes_lit,
+            .uninitialized,
+            .uninitialized_payload,
+            .crash,
+            .comptime_exhaustiveness_failed,
+            => {},
+            .def_ref => if (self.graph.lifter == null) Common.invariant("post-lift capture graph saw a definition reference"),
+            .fn_ref => |fn_ref| {
+                if (self.graph.lifter == null) {
+                    try self.addCaptureOperandEdge(node, fn_ref.fn_id, .{ .fn_ref = expr_id }, fn_ref.captures);
+                } else {
+                    // A pre-existing lifted reference already carries its exact
+                    // capture payload. It is not part of the local Monotype
+                    // definition graph, so its explicit values contribute
+                    // directly and its lifted target is not subscribed here.
+                    const operands = input.captureOperandSpan(fn_ref.captures);
+                    for (0..operands.len) |index| try self.collectExpr(GuardedList.at(operands, index).value, node);
+                }
+            },
+            .fn_def => |fn_def| {
+                const lifter = self.graph.lifter orelse Common.invariant("post-lift capture graph saw a function definition");
+                try self.addFnDefEdge(node, lifter.liftedFn(fn_def.fn_id), fn_def.captures);
+            },
+            .list,
+            .tuple,
+            => |items| try self.collectExprSpan(items, node),
+            .record => |fields| {
+                const field_exprs = input.fieldExprSpan(fields);
+                for (0..field_exprs.len) |index| try self.collectExpr(GuardedList.at(field_exprs, index).value, node);
+            },
+            .tag => |tag| try self.collectExprSpan(tag.payloads, node),
+            .static_data_candidate => |candidate| try self.collectExpr(candidate.runtime_expr, node),
+            .nominal,
+            .dbg,
+            .expect,
+            => |child| try self.collectExpr(child, node),
+            .return_ => |ret| try self.collectExpr(ret.value, node),
+            .expect_err => |expect_err| try self.collectExpr(expect_err.msg, node),
+            .comptime_branch_taken => |taken| try self.collectExpr(taken.body, node),
+            .let_ => |let_| {
+                try self.collectExpr(let_.value, node);
+                var added: std.ArrayList(Ast.LocalId) = .empty;
+                defer added.deinit(self.graph.allocator);
+                try self.bindPat(let_.bind, &added);
+                try self.collectExpr(let_.rest, node);
+                self.removeLocals(added.items);
+            },
+            .lambda => |lambda| {
+                if (self.graph.lifter == null) Common.invariant("post-lift capture graph saw an inline lambda");
+                var added: std.ArrayList(Ast.LocalId) = .empty;
+                defer added.deinit(self.graph.allocator);
+                try self.bindTypedLocals(input.typedLocalSpan(lambda.args), &added);
+                try self.collectExpr(lambda.body, node);
+                self.removeLocals(added.items);
+            },
+            .call_value => |call| {
+                try self.collectExpr(call.callee, node);
+                try self.collectExprSpan(call.args, node);
+            },
+            .call_proc => |call| {
+                const maybe_target: ?Ast.FnId = switch (call.callee) {
+                    .func => |slot| switch (slot) {
+                        .local => |mono_fn_id| blk: {
+                            const lifter = self.graph.lifter orelse Common.invariant("post-lift capture graph saw a pre-lift direct call");
+                            break :blk lifter.liftedFn(mono_fn_id);
+                        },
+                        .imported => null,
+                    },
+                    .lifted => |fn_id| fn_id,
+                };
+                try self.collectExprSpan(call.args, node);
+                if (maybe_target) |target| {
+                    try self.addCaptureOperandEdge(
+                        node,
+                        target,
+                        if (self.graph.lifter == null) .{ .call_proc = expr_id } else .pre_lift,
+                        call.captures,
+                    );
+                }
+            },
+            .low_level => |call| try self.collectExprSpan(call.args, node),
+            .field_access => |field| try self.collectExpr(field.receiver, node),
+            .tuple_access => |access| try self.collectExpr(access.tuple, node),
+            .structural_eq => |eq| {
+                try self.collectExpr(eq.lhs, node);
+                try self.collectExpr(eq.rhs, node);
+            },
+            .structural_hash => |hash| {
+                try self.collectExpr(hash.value, node);
+                try self.collectExpr(hash.hasher, node);
+            },
+            .match_ => |match| {
+                try self.collectExpr(match.scrutinee, node);
+                const branches = input.branchSpan(match.branches);
+                for (0..branches.len) |index| {
+                    const branch = GuardedList.at(branches, index);
+                    var added: std.ArrayList(Ast.LocalId) = .empty;
+                    defer added.deinit(self.graph.allocator);
+                    try self.bindPat(branch.pat, &added);
+                    if (branch.guard) |guard| try self.collectExpr(guard, node);
+                    try self.collectExpr(branch.body, node);
+                    self.removeLocals(added.items);
+                }
+            },
+            .if_ => |if_| {
+                const branches = input.ifBranchSpan(if_.branches);
+                for (0..branches.len) |index| {
+                    const branch = GuardedList.at(branches, index);
+                    try self.collectExpr(branch.cond, node);
+                    try self.collectExpr(branch.body, node);
+                }
+                try self.collectExpr(if_.final_else, node);
+            },
+            .if_initialized_payload => |payload_switch| {
+                try self.collectExpr(payload_switch.cond, node);
+                try self.addDirect(node, payload_switch.payload);
+                try self.collectExpr(payload_switch.initialized, node);
+                try self.collectExpr(payload_switch.uninitialized, node);
+            },
+            .try_sequence => |sequence| {
+                try self.collectExpr(sequence.try_expr, node);
+                try self.bindLocal(sequence.ok_local, null);
+                try self.collectExpr(sequence.ok_body, node);
+                self.removeLocal(sequence.ok_local);
+            },
+            .try_record_sequence => |sequence| {
+                try self.collectExpr(sequence.try_expr, node);
+                try self.bindLocal(sequence.value_local, null);
+                try self.bindLocal(sequence.rest_local, null);
+                try self.collectExpr(sequence.ok_body, node);
+                self.removeLocal(sequence.rest_local);
+                self.removeLocal(sequence.value_local);
+            },
+            .block => |block| {
+                var added: std.ArrayList(Ast.LocalId) = .empty;
+                defer added.deinit(self.graph.allocator);
+                const statements = input.stmtSpan(block.statements);
+                for (0..statements.len) |index| try self.collectStmt(GuardedList.at(statements, index), node, &added);
+                try self.collectExpr(block.final_expr, node);
+                self.removeLocals(added.items);
+            },
+            .loop_ => |loop| {
+                try self.collectExprSpan(loop.initial_values, node);
+                var added: std.ArrayList(Ast.LocalId) = .empty;
+                defer added.deinit(self.graph.allocator);
+                try self.bindTypedLocals(input.typedLocalSpan(loop.params), &added);
+                try self.collectExpr(loop.body, node);
+                self.removeLocals(added.items);
+            },
+            .break_ => |maybe| if (maybe) |value| try self.collectExpr(value, node),
+            .continue_ => |continue_| try self.collectExprSpan(continue_.values, node),
+        }
+    }
+};
+
 fn functionRet(types: *const MonoType.Store, ty: MonoType.TypeId) MonoType.TypeId {
     return switch (shapeContent(types, ty)) {
         .func => |fn_ty| fn_ty.ret,
@@ -1600,6 +2264,40 @@ fn shapeContent(types: *const MonoType.Store, ty: MonoType.TypeId) MonoType.Cont
             else => |content| return content,
         }
     }
+}
+
+fn initCaptureTestProgram(allocator: Allocator) Ast.Program {
+    return Ast.Program.init(
+        allocator,
+        @import("check").CheckedNames.NameStore.init(allocator),
+        MonoType.Store.init(allocator),
+        .empty, // imported_fns
+        .empty, // exprs
+        .empty, // pats
+        .empty, // stmts
+        .empty, // locals
+        .empty, // expr_ids
+        .empty, // pat_ids
+        .empty, // typed_locals
+        .empty, // stmt_ids
+        .empty, // field_exprs
+        .empty, // fn_def_captures
+        .empty, // record_destructs
+        .empty, // str_pattern_steps
+        .empty, // branches
+        .empty, // if_branches
+        .empty, // string_literals
+        Ast.ProcDebugNameMap.init(allocator),
+        .empty, // source_files
+        .empty, // expr_locs
+        .empty, // expr_regions
+        .empty, // stmt_locs
+        .empty, // stmt_regions
+        .empty, // local_names
+        .empty, // static_data_values
+        .empty, // comptime_sites
+        0, // next_symbol
+    );
 }
 
 test "monotype lifting preserves imported direct call slots" {
@@ -1786,6 +2484,105 @@ test "capture finalization supplies the caller's active binder local" {
         else => return error.TestUnexpectedResult,
     };
     try std.testing.expectEqual(active_arg, supplied);
+}
+
+test "capture graph does not activate an operand for a removed target slot" {
+    const allocator = std.testing.allocator;
+    var program = initCaptureTestProgram(allocator);
+    defer program.deinit();
+
+    const ty = try program.types.add(.zst);
+    const binder: checked.PatternBinderId = @enumFromInt(1);
+    const stale_capture = try program.addLocalWithBinder(@enumFromInt(1), ty, binder);
+    const stale_slots = try program.addTypedLocalSpan(&.{.{ .local = stale_capture, .ty = ty }});
+    const callee_body = try program.addExpr(.{ .ty = ty, .data = .unit });
+    const callee = try program.addFn(.{
+        .symbol = @enumFromInt(1),
+        .args = .empty(),
+        .captures = stale_slots,
+        .body = .{ .roc = callee_body },
+        .ret = ty,
+    });
+
+    const supplied_value = try program.addExpr(.{ .ty = ty, .data = .{ .local = stale_capture } });
+    const supplied_span = try program.addCaptureOperandSpan(&.{.{
+        .id = checked.CaptureId.fromBinder(binder),
+        .value = supplied_value,
+    }});
+    const reference = try program.addExpr(.{ .ty = ty, .data = .{ .fn_ref = .{
+        .fn_id = callee,
+        .captures = supplied_span,
+    } } });
+    const caller = try program.addFn(.{
+        .symbol = @enumFromInt(2),
+        .args = .empty(),
+        .captures = .empty(),
+        .body = .{ .roc = reference },
+        .ret = ty,
+    });
+
+    try recomputeCaptures(allocator, &program);
+
+    try std.testing.expectEqual(@as(usize, 0), program.typedLocalSpan(program.getFn(callee).captures).len);
+    try std.testing.expectEqual(@as(usize, 0), program.typedLocalSpan(program.getFn(caller).captures).len);
+    const finalized = switch (program.getExpr(reference).data) {
+        .fn_ref => |fn_ref| fn_ref,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqual(@as(usize, 0), program.captureOperandSpan(finalized.captures).len);
+}
+
+test "capture graph propagates recursive captures with a worklist" {
+    const allocator = std.testing.allocator;
+    var program = initCaptureTestProgram(allocator);
+    defer program.deinit();
+
+    const ty = try program.types.add(.zst);
+    const captured = try program.addLocalWithBinder(@enumFromInt(1), ty, @enumFromInt(1));
+    const first = try program.reserveFnSlot();
+    const second = try program.reserveFnSlot();
+
+    const captured_value = try program.addExpr(.{ .ty = ty, .data = .{ .local = captured } });
+    const call_second = try program.addExpr(.{ .ty = ty, .data = .{ .call_proc = .{
+        .callee = .{ .lifted = second },
+        .args = .empty(),
+        .captures = .empty(),
+    } } });
+    const first_body = try program.addExpr(.{ .ty = ty, .data = .{ .tuple = try program.addExprSpan(&.{ captured_value, call_second }) } });
+    const call_first = try program.addExpr(.{ .ty = ty, .data = .{ .call_proc = .{
+        .callee = .{ .lifted = first },
+        .args = .empty(),
+        .captures = .empty(),
+    } } });
+    program.setFn(first, .{
+        .symbol = @enumFromInt(1),
+        .args = .empty(),
+        .captures = .empty(),
+        .body = .{ .roc = first_body },
+        .ret = ty,
+    });
+    program.setFn(second, .{
+        .symbol = @enumFromInt(2),
+        .args = .empty(),
+        .captures = .empty(),
+        .body = .{ .roc = call_first },
+        .ret = ty,
+    });
+
+    try recomputeCaptures(allocator, &program);
+
+    try std.testing.expectEqual(@as(usize, 1), program.typedLocalSpan(program.getFn(first).captures).len);
+    try std.testing.expectEqual(@as(usize, 1), program.typedLocalSpan(program.getFn(second).captures).len);
+    const finalized_first = switch (program.getExpr(call_first).data) {
+        .call_proc => |call| call,
+        else => return error.TestUnexpectedResult,
+    };
+    const finalized_second = switch (program.getExpr(call_second).data) {
+        .call_proc => |call| call,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqual(@as(usize, 1), program.captureOperandSpan(finalized_first.captures).len);
+    try std.testing.expectEqual(@as(usize, 1), program.captureOperandSpan(finalized_second.captures).len);
 }
 
 test "monotype lifted lower declarations are referenced" {


### PR DESCRIPTION
Optimized lowering could give callers phantom captures because capture recomputation imported callee slot locals even when explicit keyed operands supplied those slots. This replaces repeated whole-program rescans with an exact dependency graph and reverse-edge worklist, then finalizes operands from those same solved mappings.

Capture operand expressions now activate only for slots the callee actually retains, preserving lexical binding identity while avoiding repeated full-body scans and quadratic operand lookup. Fixes #10132.