### PR TITLE
Honor component equality in structural values

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4608,7 +4608,7 @@ Builtin :: [].{
 
 				for (key, value) in data.entries {
 					entry_hash = hasher_finish(Value.to_hash(value, Key.to_hash(key, hasher)))
-					$entry_hashes = dict_combine_entry_hashes($entry_hashes, entry_hash)
+					$entry_hashes = combine_unordered_hashes($entry_hashes, entry_hash)
 				}
 
 				Hasher.write_u64(Hasher.write_u64(hasher, List.len(data.entries)), $entry_hashes)
@@ -5079,6 +5079,22 @@ Builtin :: [].{
 						},
 				)
 				state.all_found
+			}
+		}
+
+		## Feed a [Set] into a [Hasher]. The hash is independent of insertion order.
+		to_hash : Set(a), Hasher -> Hasher
+			where [a.to_hash : a, Hasher -> Hasher]
+		to_hash = |set, hasher| match set {
+			Items(items) => {
+				var $item_hashes = 0
+
+				for item in items {
+					item_hash = hasher_finish(item.to_hash(hasher))
+					$item_hashes = combine_unordered_hashes($item_hashes, item_hash)
+				}
+
+				Hasher.write_u64(Hasher.write_u64(hasher, List.len(items)), $item_hashes)
 			}
 		}
 
@@ -15764,8 +15780,8 @@ crypto_blake3_hasher_finish : List(U8) -> List(U8)
 dict_seed : () -> U64
 dict_seed = || dict_pseudo_seed()
 
-dict_combine_entry_hashes : U64, U64 -> U64
-dict_combine_entry_hashes = |a, b| U64.bitwise_xor(a, b)
+combine_unordered_hashes : U64, U64 -> U64
+combine_unordered_hashes = |a, b| U64.bitwise_xor(a, b)
 
 dict_empty_bucket : Dict.DictBucket
 dict_empty_bucket = { dist_and_fingerprint: 0, entry_index: 0 }

--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -502,6 +502,31 @@ pub const tests = [_]TestCase{
         .expected = .{ .inspect_str = "Ok(22.0)" },
     },
     .{
+        // https://github.com/roc-lang/roc/issues/10049
+        // Structural derivation must call a named component's exact equality
+        // and hash methods instead of inspecting its backing representation.
+        .name = "issue 10049: structural containers honor component equality and hash methods",
+        .source_kind = .module,
+        .source =
+        \\main = {
+        \\    d1 = Dict.from_list([("Bob", 3.1), ("John", 4.2)])
+        \\    d2 = Dict.from_list([("John", 4.2), ("Bob", 3.1)])
+        \\    records_equal = { owes: d1 } == { owes: d2 }
+        \\    tuples_equal = (d1, 0) == (d2, 0)
+        \\    tags_equal = Owes(d1) == Owes(d2)
+        \\    lists_equal = [d1] == [d2]
+        \\    sets_equal = { items: Set.from_list([1, 2]) } == { items: Set.from_list([2, 1]) }
+        \\    hash_round_trip = Dict.empty().insert({ owes: d1 }, "found").get({ owes: d2 }) == Ok("found")
+        \\    tuple_hash_round_trip = Dict.empty().insert((d1, 0), "found").get((d2, 0)) == Ok("found")
+        \\    tag_hash_round_trip = Dict.empty().insert(Owes(d1), "found").get(Owes(d2)) == Ok("found")
+        \\    set_hash_round_trip = Dict.empty().insert(Set.from_list([1, 2]), "found").get(Set.from_list([2, 1])) == Ok("found")
+        \\
+        \\    records_equal and tuples_equal and tags_equal and lists_equal and sets_equal and hash_round_trip and tuple_hash_round_trip and tag_hash_round_trip and set_hash_round_trip
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
         // https://github.com/roc-lang/roc/issues/9783
         // The exact mathematical result is 16129, which does not fit in I8.
         .name = "issue 9783: signed times crashes on overflow",

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -23363,10 +23363,11 @@ const BodyContext = struct {
     //
     // is_eq and to_hash share one recursive ladder: walk a type one layer at a
     // time, decomposing aggregates (records/tuples/tag unions) and transparent
-    // nominals, dispatching owned types (List) to their real method, and
-    // emitting a leaf node (`structural_eq` / `structural_hash`) for scalars,
-    // opaque nominals, and other inline-handled leaves. Recursion is broken by
-    // an expansion stack plus a memoized generated helper def.
+    // nominals that have no exact component method. A List or named component
+    // with an exact method dispatches to that method before its representation
+    // can be inspected. Scalars, opaque nominals, and other inline-handled
+    // leaves emit a leaf node (`structural_eq` / `structural_hash`). Recursion is
+    // broken by an expansion stack plus a memoized generated helper def.
     //
     // The per-derivation specifics are supplied by a comptime `Deriver` type
     // (`EqDeriver` / `HashDeriver`). A Deriver provides:
@@ -23381,8 +23382,8 @@ const BodyContext = struct {
     //   - `combineSeed` / `combine` plus `forward`: fold the per-component
     //     results (equality conjoins component bools with AND; hashing threads
     //     the accumulator left to right).
-    //   - `ownedCall` / `named` / `tagUnion`: the shapes whose decomposition
-    //     differs structurally between the two derivations.
+    //   - `methodArgTypes` / `named` / `tagUnion`: method call types and the
+    //     shapes whose decomposition differs between the two derivations.
     //
     // A `DerivationCtx` carries the runtime parameters shared by every step:
     // the derivation's result type (Bool / Hasher) and the method name.
@@ -23400,6 +23401,21 @@ const BodyContext = struct {
         ctx: DerivationCtx,
     ) Allocator.Error!DraftExprId {
         const shape = self.builder.program.types.get(ty);
+
+        switch (shape) {
+            .list => {
+                const lookup = (try self.builder.componentMethodTargetByName(self.method_scope, ty, ctx.method_name)) orelse
+                    Common.invariant(D.missing_component_method_msg);
+                return try self.derivationMethodCall(D, lookup, ty, operand, ctx);
+            },
+            .named => {
+                if (try self.builder.componentMethodTargetByName(self.method_scope, ty, ctx.method_name)) |lookup| {
+                    return try self.derivationMethodCall(D, lookup, ty, operand, ctx);
+                }
+            },
+            else => {},
+        }
+
         const expands_structurally = structurallyExpands(shape);
         var remove_active_expansion = false;
         const stack = D.expansionStack(self);
@@ -23415,7 +23431,7 @@ const BodyContext = struct {
         }
 
         return switch (shape) {
-            .list => try D.ownedCall(self, ty, operand, ctx),
+            .list => unreachable,
             .record => |fields| try self.derivationRecord(D, self.builder.program.types.fieldSpan(fields), operand, ctx),
             .tuple => |items| try self.derivationTuple(D, self.builder.program.types.span(items), operand, ctx),
             .tag_union => |tags| try D.tagUnion(self, ty, tags, operand, ctx),
@@ -23456,21 +23472,18 @@ const BodyContext = struct {
         });
     }
 
-    /// Dispatch an owned (non-structural) type to its real derived method,
-    /// shared by every derivation. The argument types and the per-derivation
-    /// invariant wording come from the comptime `Deriver`; the operand-to-args
-    /// mapping reuses `D.callArgs`.
-    fn derivationOwnedCall(
+    /// Dispatch a component to its exact checked method target, shared by every
+    /// derivation. The argument types come from the comptime `Deriver`; the
+    /// operand-to-args mapping reuses `D.callArgs`.
+    fn derivationMethodCall(
         self: *BodyContext,
         comptime D: type,
+        lookup: MethodLookup,
         ty: Type.TypeId,
         operand: D.Operand,
         ctx: DerivationCtx,
     ) Allocator.Error!DraftExprId {
-        const lookup = (try self.builder.componentMethodTargetByName(self.method_scope, ty, ctx.method_name)) orelse
-            Common.invariant(D.owned_missing_target_msg);
-
-        const arg_tys = D.ownedArgTypes(ty, ctx.result_ty);
+        const arg_tys = D.methodArgTypes(ty, ctx.result_ty);
         const callable_mono_ty = try self.methodTargetMonoTypeFromArgs(lookup, &arg_tys, ctx.result_ty);
         const args = D.callArgs(operand);
         return try self.addExpr(.{ .ty = ctx.result_ty, .data = .{ .call_proc = .{
@@ -27281,14 +27294,10 @@ const EqDeriver = struct {
         return .{ .lhs = lhs_item, .rhs = rhs_item };
     }
 
-    const owned_missing_target_msg = "checked method registry is missing owned equality target";
+    const missing_component_method_msg = "checked method registry is missing List equality target";
 
-    fn ownedArgTypes(ty: Type.TypeId, _: Type.TypeId) [2]Type.TypeId {
+    fn methodArgTypes(ty: Type.TypeId, _: Type.TypeId) [2]Type.TypeId {
         return .{ ty, ty };
-    }
-
-    fn ownedCall(self: *BodyContext, ty: Type.TypeId, operand: Operand, ctx: BodyContext.DerivationCtx) Allocator.Error!DraftExprId {
-        return try self.derivationOwnedCall(EqDeriver, ty, operand, ctx);
     }
 
     /// Decomposes structural equality on a nominal type. Record and tuple backings are
@@ -27503,14 +27512,10 @@ const HashDeriver = struct {
         return .{ .value = item_value, .hasher = state };
     }
 
-    const owned_missing_target_msg = "checked method registry is missing owned to_hash target";
+    const missing_component_method_msg = "checked method registry is missing List to_hash target";
 
-    fn ownedArgTypes(ty: Type.TypeId, result_ty: Type.TypeId) [2]Type.TypeId {
+    fn methodArgTypes(ty: Type.TypeId, result_ty: Type.TypeId) [2]Type.TypeId {
         return .{ ty, result_ty };
-    }
-
-    fn ownedCall(self: *BodyContext, ty: Type.TypeId, operand: Operand, ctx: BodyContext.DerivationCtx) Allocator.Error!DraftExprId {
-        return try self.derivationOwnedCall(HashDeriver, ty, operand, ctx);
     }
 
     fn named(self: *BodyContext, named_ty: Type.TypeId, backing_ty: Type.TypeId, operand: Operand, ctx: BodyContext.DerivationCtx) Allocator.Error!DraftExprId {

--- a/test/snapshots/repl/component_equality_in_structural_containers.md
+++ b/test/snapshots/repl/component_equality_in_structural_containers.md
@@ -1,0 +1,34 @@
+# META
+~~~ini
+description=Structural containers use their components' equality and hash methods
+type=repl
+~~~
+# SOURCE
+~~~roc
+» d1 = Dict.from_list([("Bob", 3.1), ("John", 4.2)])
+» d2 = Dict.from_list([("John", 4.2), ("Bob", 3.1)])
+» (d1, 0) == (d2, 0)
+» Owes(d1) == Owes(d2)
+» [d1] == [d2]
+» { items: Set.from_list([1, 2]) } == { items: Set.from_list([2, 1]) }
+» Dict.empty().insert({ owes: d1 }, "found").get({ owes: d2 })
+» Dict.empty().insert(Set.from_list([1, 2]), "found").get(Set.from_list([2, 1]))
+~~~
+# OUTPUT
+assigned `d1`
+---
+assigned `d2`
+---
+True
+---
+True
+---
+True
+---
+True
+---
+Ok("found")
+---
+Ok("found")
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/dict_record_equality_entry_order.md
+++ b/test/snapshots/repl/dict_record_equality_entry_order.md
@@ -1,0 +1,13 @@
+# META
+~~~ini
+description=Record fields use Dict equality independent of entry order (https://github.com/roc-lang/roc/issues/10049)
+type=repl
+~~~
+# SOURCE
+~~~roc
+» { owes: Dict.from_list([("Bob", 3.1), ("John", 4.2)]) } == { owes: Dict.from_list([("John", 4.2), ("Bob", 3.1)]) }
+~~~
+# OUTPUT
+True
+# PROBLEMS
+NIL


### PR DESCRIPTION
Structural equality and hashing now dispatch to checked methods on named components before examining their backing representations, so Dict values compare and hash consistently inside records, tuples, and tags. This also adds an order-independent Set.to_hash and regression coverage for structural comparisons and Dict-key round trips.

Fixes #10049