### PR TITLE
Correct the fmt --check hint to name the real subcommand

### DIFF
--- a/src/cli/cli_args.zig
+++ b/src/cli/cli_args.zig
@@ -193,7 +193,7 @@ pub const TestArgs = struct {
     resolve_limits: ResolveLimitArgs = .{}, // package download size limits
 };
 
-/// Arguments for `roc format`
+/// Arguments for `roc fmt`
 pub const FormatArgs = struct {
     paths: []const []const u8, // the paths of files to be formatted
     stdin: bool = false, // if the input should be read in from stdin and output to stdout

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -13028,11 +13028,11 @@ fn rocFormat(ctx: *CliCtx, args: cli_args.FormatArgs) CliMainError!void {
 
         elapsed = @as(u64, @intCast(std.Io.Timestamp.now(ctx.io.std_io, .real).nanoseconds - timer_start_ns));
         if (unformatted_files.items.len > 0) {
-            try stdout.print("The following file(s) failed `roc format --check`:", .{});
+            try stdout.print("The following file(s) failed `roc fmt --check`:", .{});
             for (unformatted_files.items) |file_name| {
                 try stdout.print("    {s}\n", .{file_name});
             }
-            try stdout.print("You can fix this with `roc format FILENAME.roc`.", .{});
+            try stdout.print("You can fix this with `roc fmt FILENAME.roc`.", .{});
             had_errors = true;
         } else {
             try stdout.print("All formatting valid.\n", .{});

--- a/src/docs/render_html.zig
+++ b/src/docs/render_html.zig
@@ -2391,7 +2391,7 @@ fn renderDocTypeHtml(
                                 .indent = item.indent,
                             } });
                         } else {
-                            // Multi-line layout mirrors how `roc format` lays
+                            // Multi-line layout mirrors how `roc fmt` lays
                             // out where clauses; the enclosing block uses
                             // white-space: pre-wrap so the literal newlines and
                             // indentation render as written.

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -38,7 +38,7 @@ const FormatFlags = enum {
 pub const FormattingResult = struct {
     success: usize,
     failure: usize,
-    /// Only relevant when using `roc format --check`
+    /// Only relevant when using `roc fmt --check`
     unformatted_files: ?std.array_list.Managed([]const u8),
 
     pub fn deinit(self: *@This()) void {
@@ -57,7 +57,7 @@ pub fn formatPath(gpa: std.mem.Allocator, arena: std.mem.Allocator, base_dir: st
 
     var success_count: usize = 0;
     var failed_count: usize = 0;
-    // Only used for `roc format --check`. If we aren't doing check, don't bother allocating
+    // Only used for `roc fmt --check`. If we aren't doing check, don't bother allocating
     var unformatted_files = if (check) std.array_list.Managed([]const u8).init(gpa) else null;
 
     // First try as a directory.


### PR DESCRIPTION
The failure message for `roc fmt --check` tells users to run `roc format FILENAME.roc`, but no `format` subcommand exists — `roc format file.roc` is parsed as "run the file `format`" and fails with FILE NOT FOUND, leaving the file untouched. (Discovered the hard way: following the hint made formatting a silent no-op.)

Before:

```
The following file(s) failed `roc format --check`:    /tmp/probe.roc
You can fix this with `roc format FILENAME.roc`.
```

After:

```
The following file(s) failed `roc fmt --check`:    /tmp/probe.roc
You can fix this with `roc fmt FILENAME.roc`.
```

Also fixes four code comments that referenced the same nonexistent subcommand. No behavior changes beyond the message text.
