### PR TITLE
Guarantee distinct Box.box allocations per runtime evaluation (fixes #10171)

### DIFF
--- a/src/base/LowLevel.zig
+++ b/src/base/LowLevel.zig
@@ -1129,6 +1129,48 @@ pub const LowLevel = enum(u16) {
         };
     }
 
+    /// Whether this primitive's result is a heap cell whose allocation
+    /// identity is program-observable (issue #10171).
+    ///
+    /// A `Box`'s runtime representation at the host ABI is its payload
+    /// pointer: hosts receive it, refcount it, and may key on it as a stable
+    /// identity. The language guarantees that each dynamic execution of one of
+    /// these ops whose result escapes yields a DISTINCT allocation. Passes and
+    /// backends must therefore never:
+    ///   - merge two executions into one (no CSE/GVN over these ops — none
+    ///     exists today; this property is the axiom for any future pass),
+    ///   - hoist one execution across its executing scope (one call site
+    ///     executed N times must allocate N times), or
+    ///   - share a result as static data (the checker's hoisted-root keep
+    ///     gate, `varMayContainBoxAllocation`, and compile-time finalization's
+    ///     `constNodeContainsBox` backstop enforce this for compile-time
+    ///     constants; top-level bindings are exempt because one binding is one
+    ///     value).
+    ///
+    /// Reusing a DEAD allocation is fine: `box_prepare_update`'s consume
+    /// semantics (and src/lir/box_reuse.zig's rewrite to it) recycle an input
+    /// box only when it is uniquely owned and about to be dropped — the moral
+    /// equivalent of free-then-malloc returning the same address. Likewise,
+    /// eliding an allocation that provably never escapes is legal, since its
+    /// identity is unobservable in-language (Roc has no pointer equality).
+    ///
+    /// Deliberately excluded:
+    ///   - Str/List/Dict/Set allocations: value semantics; their addresses are
+    ///     not identities and static sharing/interning stays legal.
+    ///   - `ptr_alloca`: a stack slot, documented as prologue-hoistable.
+    ///   - erased-callable creation: function identity is unobservable (no
+    ///     function equality); their capture PAYLOADS are covered because the
+    ///     captures themselves hold boxes.
+    pub fn resultIdentityObservable(self: LowLevel) bool {
+        return switch (self) {
+            .box_box,
+            .box_alloc_zeroed,
+            .box_prepare_update,
+            => true,
+            else => false,
+        };
+    }
+
     /// Whether this primitive can consume borrowed string views directly,
     /// without first materializing them into RocStr values.
     pub fn acceptsStrViewArgs(self: LowLevel) bool {
@@ -1184,3 +1226,15 @@ pub const LowLevel = enum(u16) {
         };
     }
 };
+
+test "resultIdentityObservable covers exactly the box allocation ops" {
+    const testing = @import("std").testing;
+    try testing.expect(LowLevel.box_box.resultIdentityObservable());
+    try testing.expect(LowLevel.box_alloc_zeroed.resultIdentityObservable());
+    try testing.expect(LowLevel.box_prepare_update.resultIdentityObservable());
+    // Value-semantic allocations and stack slots are deliberately excluded.
+    try testing.expect(!LowLevel.box_unbox.resultIdentityObservable());
+    try testing.expect(!LowLevel.str_concat.resultIdentityObservable());
+    try testing.expect(!LowLevel.list_with_capacity.resultIdentityObservable());
+    try testing.expect(!LowLevel.ptr_alloca.resultIdentityObservable());
+}

--- a/src/base/mod.zig
+++ b/src/base/mod.zig
@@ -132,6 +132,7 @@ test "base tests" {
     std.testing.refAllDecls(@import("DataSpan.zig"));
     std.testing.refAllDecls(@import("Ident.zig"));
     std.testing.refAllDecls(@import("InternedBytes.zig"));
+    std.testing.refAllDecls(@import("LowLevel.zig"));
     std.testing.refAllDecls(@import("module_identity.zig"));
     std.testing.refAllDecls(@import("PackedDataSpan.zig"));
     std.testing.refAllDecls(@import("parallel.zig"));

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4348,6 +4348,14 @@ Builtin :: [].{
 		## Wraps a value in a generic, opaque representation (box) that can easily be passed to the platform.
 		## Boxing is an expensive process because it copies the value from the stack to the heap.
 		## This may provide a performance optimization for advanced use cases with large values.
+		##
+		## A box is a heap cell, and its address is its identity: each runtime
+		## call to `Box.box` allocates a fresh cell, so two boxes created by
+		## separate calls are never the same allocation. Platforms may rely on
+		## a live box's address as a stable identity (for example, as a handle
+		## key). The one deliberate exception is a top-level constant: it is one
+		## binding evaluated once, so every reference shares its single
+		## program-lifetime allocation.
 		box : item -> Box(item)
 
 		## Unwraps a value from a box. This is the inverse of `Box.box`, and is also an expensive operation.

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -5619,7 +5619,11 @@ fn hoistedRootIsIntrinsicallyKept(
     if (self.cir.store.getExpr(root.expr) == .e_runtime_error) return true;
     if (isFunctionDef(&self.cir.store, self.cir.store.getExpr(root.expr))) return false;
     if (self.varIsFunctionType(type_var)) return false;
-    return try self.varIsConcreteHoistedConstType(type_var);
+    if (!try self.varIsConcreteHoistedConstType(type_var)) return false;
+    // A root whose value may contain a Box allocation must stay runtime code:
+    // storing it would share one static allocation across every runtime
+    // evaluation, violating Box.box's distinct-allocation guarantee (#10171).
+    return !try self.varMayContainBoxAllocation(type_var);
 }
 
 fn debugVerifyKeptHoistedRootDependencies(self: *Self) Allocator.Error!void {
@@ -5764,6 +5768,110 @@ fn flatTypeIsConcreteHoistedConst(
             // checked above, so the template walk admits rigids.
             const template = self.nominalDeclBackingTemplate(nominal) orelse break :blk false;
             break :blk try self.varIsConcreteHoistedConstTypeInternal(.decl_template, template, visited);
+        },
+    };
+}
+
+/// Whether a settled value type may transitively contain a `Box` allocation —
+/// directly, or hidden inside a closure capture (function types are
+/// conservatively box-bearing, since a stored function constant carries
+/// capture VALUES that types cannot see). Hoisted compile-time roots must not
+/// store such values: a stored constant is rematerialized as shared static
+/// data, but `Box.box` guarantees a distinct heap allocation per runtime
+/// evaluation whose result escapes (issue #10171; the axiom is documented on
+/// `LowLevel.resultIdentityObservable`). Unlike the concreteness
+/// walk above, this walk pierces OPAQUE nominal backings — wrapping a box in
+/// an opaque type does not make its allocation identity unobservable to the
+/// host. Top-level bindings are unaffected (one binding is one value, so its
+/// single shared allocation is the declared semantics); only hoisted roots
+/// consult this walk.
+fn varMayContainBoxAllocation(self: *Self, var_: Var) Allocator.Error!bool {
+    self.var_set.clearRetainingCapacity();
+    return try self.varMayContainBoxAllocationInternal(var_, &self.var_set);
+}
+
+fn varMayContainBoxAllocationInternal(
+    self: *Self,
+    var_: Var,
+    visited: *std.AutoHashMap(Var, void),
+) Allocator.Error!bool {
+    const resolved = self.types.resolveVar(var_);
+    if (visited.contains(resolved.var_)) return false;
+    try visited.put(resolved.var_, {});
+
+    return switch (resolved.desc.content) {
+        // Conservative: an unsettled type could stand for a box. The
+        // concreteness gate rejects these roots already; kept for
+        // self-containedness.
+        .flex, .err => true,
+        // Value-graph rigids are rejected by the concreteness gate; backing
+        // template formals stand for application args walked at the use site
+        // (same rationale as the concreteness walk's template handling).
+        .rigid => false,
+        .alias => |alias| (try self.varsMayContainBoxAllocation(self.types.sliceAliasArgs(alias), visited)) or
+            try self.varMayContainBoxAllocationInternal(self.types.getAliasBackingVar(alias), visited),
+        .structure => |flat| try self.flatTypeMayContainBoxAllocation(flat, visited),
+    };
+}
+
+fn varsMayContainBoxAllocation(
+    self: *Self,
+    vars: []const Var,
+    visited: *std.AutoHashMap(Var, void),
+) Allocator.Error!bool {
+    for (vars) |var_| {
+        if (try self.varMayContainBoxAllocationInternal(var_, visited)) return true;
+    }
+    return false;
+}
+
+fn flatTypeMayContainBoxAllocation(
+    self: *Self,
+    flat: FlatType,
+    visited: *std.AutoHashMap(Var, void),
+) Allocator.Error!bool {
+    return switch (flat) {
+        .empty_record, .empty_tag_union => false,
+        // Conservative: closure captures are invisible at the type level, and
+        // a stored function constant carries capture values (which may hold
+        // boxes) into shared static data. Direct function-typed roots are
+        // already rejected, but a function can hide behind an opaque nominal
+        // backing, which this walk pierces.
+        .fn_pure, .fn_effectful, .fn_unbound => true,
+        .record => |record| blk: {
+            const fields = self.types.getRecordFieldsSlice(record.fields);
+            if (try self.varsMayContainBoxAllocation(fields.items(.var_), visited)) break :blk true;
+            break :blk try self.varMayContainBoxAllocationInternal(record.ext, visited);
+        },
+        .record_unbound => |fields| blk: {
+            const fields_slice = self.types.getRecordFieldsSlice(fields);
+            break :blk try self.varsMayContainBoxAllocation(fields_slice.items(.var_), visited);
+        },
+        .tuple => |tuple| try self.varsMayContainBoxAllocation(self.types.sliceVars(tuple.elems), visited),
+        .tag_union => |tag_union| blk: {
+            const tags = self.types.getTagsSlice(tag_union.tags);
+            for (tags.items(.args)) |tag_args| {
+                if (try self.varsMayContainBoxAllocation(self.types.sliceVars(tag_args), visited)) break :blk true;
+            }
+            break :blk try self.varMayContainBoxAllocationInternal(tag_union.ext, visited);
+        },
+        .nominal_type => |nominal| blk: {
+            if (self.nominalIsBoxType(nominal)) break :blk true;
+            if (try self.varsMayContainBoxAllocation(self.types.sliceNominalArgs(nominal), visited)) break :blk true;
+            if (self.builtinNominalDeclForBuiltinSourceDecl(nominal.sourceDeclOptional())) |builtin_decl| {
+                switch (builtin_decl) {
+                    // Value-semantic builtin containers: element/key/value
+                    // types are exactly the nominal args walked above.
+                    .list, .dict, .set, .fields, .field, .num => break :blk false,
+                    .box => break :blk true,
+                    .try_type, .numeral => {},
+                }
+            }
+            // Pierce the declaration backing — including opaque nominals.
+            // Formals in the template are rigid leaves standing for the args
+            // walked above. A missing backing is conservatively box-bearing.
+            const template = self.nominalDeclBackingTemplate(nominal) orelse break :blk true;
+            break :blk try self.varMayContainBoxAllocationInternal(template, visited);
         },
     };
 }
@@ -6042,6 +6150,11 @@ fn hoistedExprAllowsStoredConst(
 ) Allocator.Error!bool {
     if (self.moduleHoistExprInvalidated(module, expr)) return false;
     return switch (module.store.getExpr(expr)) {
+        // `box_box` is deliberately allowed here: only the root's RESULT
+        // value is stored, and the keep-gate (`hoistedRootIsIntrinsicallyKept`
+        // via `varMayContainBoxAllocation`) rejects roots whose result may
+        // contain a box. Boxes that exist only as compile-time intermediates
+        // never escape into shared static data.
         .e_run_low_level => |run| run.op != .dict_pseudo_seed and
             try self.hoistedExprSpanAllowsStoredConst(module, run.args, context),
         .e_lookup_local,
@@ -6541,6 +6654,11 @@ fn hoistedRootPatternSelectedDependenciesAreKept(
     };
 }
 
+/// Note: internal binders are checked for concreteness only, NOT for box
+/// containment — a box-typed local inside a root whose RESULT is box-free is
+/// a legitimate compile-time intermediate (its allocation never escapes into
+/// stored data). Box rejection happens once, on the root's own value type,
+/// in `hoistedRootIsIntrinsicallyKept`.
 fn hoistedRootPatternBindersAreConcrete(
     self: *Self,
     pattern: CIR.Pattern.Idx,
@@ -7841,6 +7959,10 @@ fn varIsEffectfulFunction(self: *Self, var_: Var) bool {
 /// A constrained or otherwise open dispatcher needs specialization-edge
 /// evidence, so selecting it as a caller-less compile-time root would erase the
 /// evidence scope that gives the dispatch meaning.
+/// Note: a box-typed dispatcher is deliberately NOT rejected here — a dispatch
+/// on a box inside a root whose result is box-free (e.g. unboxing an
+/// intermediate) is legitimate compile-time work. Box rejection happens on the
+/// root's own value type in `hoistedRootIsIntrinsicallyKept`.
 fn staticDispatchAllowsHoistedRoot(self: *Self, dispatcher_var: Var, callable_var: Var) Allocator.Error!bool {
     if (!self.varIsFunctionType(callable_var) or self.varIsEffectfulFunction(callable_var)) return false;
     return try self.varIsConcreteHoistedConstType(dispatcher_var);

--- a/src/check/hoist_roots.zig
+++ b/src/check/hoist_roots.zig
@@ -6,9 +6,6 @@ const can = @import("can");
 const CIR = can.CIR;
 const Allocator = std.mem.Allocator;
 
-/// Version tag for the checked-stage hoisted-root selection algorithm.
-pub const selection_algorithm_version: u64 = 1;
-
 /// Collection of hoisted roots selected for a checked module.
 pub const SelectedHoistedRootSet = struct {
     roots: []const SelectedHoistedRoot,

--- a/src/check/test/hoist_roots_test.zig
+++ b/src/check/test/hoist_roots_test.zig
@@ -1248,6 +1248,182 @@ test "hoist roots are not selected for effectful static dispatch calls" {
     try std.testing.expectEqual(@as(usize, 0), test_env.checker.selectedHoistedRoots().len);
 }
 
+test "hoist roots are not selected for direct box allocation function body" {
+    var test_env = try TestEnv.init("Test",
+        \\main = |_| Box.box(42.U64)
+    );
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.selectedHoistedRoots().len);
+}
+
+test "hoist roots are not selected for box bindings or their dependents" {
+    var test_env = try TestEnv.init("Test",
+        \\main = |arg| {
+        \\    b = Box.box(42.U64)
+        \\    Box.unbox(b) + arg
+        \\}
+    );
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.selectedHoistedRoots().len);
+}
+
+test "hoist roots are selected for box-free results with internal box intermediates" {
+    var test_env = try TestEnv.init("Test",
+        \\main = |arg| {
+        \\    v = {
+        \\        b = Box.box(41.U64)
+        \\        Box.unbox(b) + 1.U64
+        \\    }
+        \\    v + arg
+        \\}
+    );
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+    const roots = test_env.checker.selectedHoistedRoots();
+    try std.testing.expectEqual(@as(usize, 1), roots.len);
+    try std.testing.expect(roots[0].pattern != null);
+    try expectExprTag(&test_env, roots[0].expr, .e_block);
+}
+
+test "hoist roots are not selected for records containing boxes" {
+    var test_env = try TestEnv.init("Test",
+        \\main = |arg| {
+        \\    r = { boxed: Box.box(1.U64), num: 2.U64 }
+        \\    r.num + arg
+        \\}
+    );
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.selectedHoistedRoots().len);
+}
+
+test "hoist roots are not selected for lists containing boxes" {
+    var test_env = try TestEnv.init("Test",
+        \\main = |_| [Box.box(1.U64), Box.box(2.U64)]
+    );
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.selectedHoistedRoots().len);
+}
+
+test "hoist roots are not selected for box helper bodies in generic associated methods" {
+    // The exact shape from issue #10171: pre-fix, fresh's body `Box.box(0)`
+    // was hoisted to one shared static box returned by every runtime call.
+    var test_env = try TestEnv.init("Test",
+        \\fresh : () -> Box(U64)
+        \\fresh = || Box.box(0)
+        \\
+        \\Signal(a) := { token : Box(U64) }.{
+        \\    const : a -> Signal(a)
+        \\    const = |_| { token: fresh() }
+        \\
+        \\    map : Signal(a), (a -> b) -> Signal(b)
+        \\    map = |_, _| { token: fresh() }
+        \\}
+        \\
+        \\main = |_| {
+        \\    base = Signal.const("base")
+        \\    base.map(|value| value)
+        \\}
+    );
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.selectedHoistedRoots().len);
+}
+
+test "hoist roots are not selected for boxes behind opaque nominal backings" {
+    var test_env = try TestEnv.init("Test",
+        \\Token :: { boxed : Box(U64) }.{
+        \\    new : () -> Token
+        \\    new = || { boxed: Box.box(0.U64) }
+        \\}
+        \\
+        \\main = |arg| {
+        \\    t = Token.new()
+        \\    _ = t
+        \\    arg
+        \\}
+    );
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.selectedHoistedRoots().len);
+}
+
+test "hoist roots are not selected for boxes captured by closures behind opaque backings" {
+    // Closure captures are invisible at the type level; a stored function
+    // constant would carry the captured box into shared static data, so
+    // function-containing backings are conservatively rejected.
+    var test_env = try TestEnv.init("Test",
+        \\Thunk :: [Mk(() -> Box(U64))].{
+        \\    make : () -> Thunk
+        \\    make = || {
+        \\        b = Box.box(0.U64)
+        \\        Mk(|| b)
+        \\    }
+        \\}
+        \\
+        \\main = |arg| {
+        \\    t = Thunk.make()
+        \\    _ = t
+        \\    arg
+        \\}
+    );
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.selectedHoistedRoots().len);
+}
+
+test "hoist extraction roots keep box-free binders and drop box binders" {
+    var test_env = try TestEnv.init("Test",
+        \\main = |arg| {
+        \\    { num, boxed } = { num: 41.U64, boxed: Box.box(7.U64) }
+        \\    Box.unbox(boxed) + num + arg
+        \\}
+    );
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+    const roots = test_env.checker.selectedHoistedRoots();
+    try std.testing.expectEqual(@as(usize, 1), roots.len);
+    try expectPatternExtractionRoot(roots[0]);
+}
+
+test "hoist roots are not selected for imported opaque box tokens" {
+    var token_env = try TestEnv.init("Token",
+        \\Token :: { boxed : Box(U64) }.{
+        \\    new : () -> Token
+        \\    new = || { boxed: Box.box(0.U64) }
+        \\}
+    );
+    defer token_env.deinit();
+    try token_env.assertNoErrors();
+    try std.testing.expectEqual(@as(usize, 0), token_env.checker.selectedHoistedRoots().len);
+
+    var test_env = try TestEnv.initWithImport("Main",
+        \\import Token
+        \\
+        \\main = |arg| {
+        \\    t = Token.new()
+        \\    _ = t
+        \\    arg
+        \\}
+    , "Token", &token_env);
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+    try std.testing.expectEqual(@as(usize, 0), test_env.checker.selectedHoistedRoots().len);
+}
+
 test "hoist roots are not selected for dict pseudo-seed dependent values" {
     var test_env = try TestEnv.init("Test",
         \\main! = || {

--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -188,6 +188,41 @@ pub const io_spec_tests = [_]TestSpec{
         .io_spec = "1>b",
         .description = "Regression test: compiled Dict operations call the hasher builtins",
     },
+    // Issue #10171: each runtime evaluation of `Box.box` whose result escapes
+    // yields a distinct allocation. Hoisted-root compile-time evaluation must
+    // never intern a box into shared static data (the pre-fix bug reported
+    // "same allocation" for the shapes below). Top-level bindings are the one
+    // deliberate exception: one binding is one value (see box_top_level tests).
+    .{
+        .roc_file = "test/fx/box_freshness_repro.roc",
+        .io_spec = "1>distinct allocations",
+        .description = "Issue #10171: zero-arg Box helper called from a generic associated method allocates per call",
+    },
+    .{
+        .roc_file = "test/fx/box_freshness_variants.roc",
+        .io_spec = "1>direct fresh() twice: distinct allocations|1>plain fn calling fresh(): distinct allocations|1>plain fn inlining Box.box(0): distinct allocations",
+        .description = "Issue #10171: Box allocation freshness per hoisted-root shape (plain functions)",
+    },
+    .{
+        .roc_file = "test/fx/box_freshness_generic.roc",
+        .io_spec = "1>generic method inlining Box.box(0): distinct allocations|1>fresh() across two specializations: distinct allocations",
+        .description = "Issue #10171: Box allocation freshness per hoisted-root shape (generic associated methods)",
+    },
+    .{
+        .roc_file = "test/fx/box_freshness_capture.roc",
+        .io_spec = "1>distinct allocations",
+        .description = "Issue #10171: boxes captured by closures behind opaque nominals allocate per call",
+    },
+    .{
+        .roc_file = "test/fx/box_top_level_static.roc",
+        .io_spec = "1>same allocation",
+        .description = "Issue #10171: a top-level box binding is one value sharing one static allocation",
+    },
+    .{
+        .roc_file = "test/fx/box_top_level_two_bindings.roc",
+        .io_spec = "1>distinct allocations",
+        .description = "Issue #10171: two identical top-level box bindings keep distinct allocation identities",
+    },
     .{
         .roc_file = "test/fx/issue_10038_top_level_dict.roc",
         .io_spec = "0<a|1>b",

--- a/src/eval/compile_time_finalization.zig
+++ b/src/eval/compile_time_finalization.zig
@@ -1704,6 +1704,11 @@ fn finishConstRoot(
         .expect,
         => finalizationInvariant("constant root finalized with non-constant payload"),
     };
+    const hoisted_entry: ?checked.HoistedConstEntry = switch (root.kind) {
+        .hoisted_constant => module.hoisted_constants.lookupByRoot(root.id) orelse
+            finalizationInvariant("hoisted constant root had no hoisted const entry"),
+        else => null,
+    };
     const const_ref = switch (root.kind) {
         .constant => blk: {
             const pattern = root.pattern orelse finalizationInvariant("constant root had no checked pattern");
@@ -1714,17 +1719,35 @@ fn finishConstRoot(
                 .procedure_binding => finalizationInvariant("constant root top-level value was not a constant"),
             };
         },
-        .hoisted_constant => blk: {
-            const hoisted = module.hoisted_constants.lookupByRoot(root.id) orelse
-                finalizationInvariant("hoisted constant root had no hoisted const entry");
-            break :blk hoisted.const_ref;
-        },
+        .hoisted_constant => hoisted_entry.?.const_ref,
         .callable_binding,
         .expect,
         .numeral_conversion,
         .quote_conversion,
         => unreachable,
     };
+    // Backstop for Box allocation identity (#10171): a hoisted root's stored
+    // value must never contain a box — storing it would share one static
+    // allocation across every runtime evaluation, but `Box.box` guarantees a
+    // distinct allocation per evaluation whose result escapes (see
+    // `LowLevel.resultIdentityObservable`). The checker's keep-gate
+    // (`varMayContainBoxAllocation`) prunes such roots before they get here,
+    // so this branch is a tripwire in Debug builds. Top-level `.constant`
+    // roots are exempt: one binding is one value, so its single shared
+    // (static, refcount-pinned) allocation is the declared semantics.
+    if (root.kind == .hoisted_constant and constNodeContainsBox(&module.const_store, node)) {
+        if (builtin.mode == .Debug) {
+            std.debug.panic("compile-time finalization invariant violated: hoisted root stored a Box allocation; the checker prune (varMayContainBoxAllocation) should have rejected it", .{});
+        }
+        // Release fallback: an expr-shaped root left as `.eval_template`
+        // re-lowers inline at its one use site — one runtime evaluation per
+        // dynamic execution, preserving freshness. A binding-shaped root must
+        // NOT take that fallback: reads go through the binding, so per-READ
+        // re-evaluation would break local binding sharing. Keeping the stored
+        // const there preserves the status-quo behavior on a path the checker
+        // prune makes unreachable.
+        if (hoisted_entry.?.pattern == null) return;
+    }
     const stored = checked.StoredConstTemplate{
         .node = node,
         .root_type = root_type orelse finalizationInvariant("constant root finalized without exact Monotype representation evidence"),
@@ -1733,6 +1756,37 @@ fn finishConstRoot(
     if (root.kind == .constant) {
         module.exported_const_templates.fillStoredConst(const_ref, stored);
     }
+}
+
+/// Whether a stored compile-time value transitively contains a box allocation,
+/// including boxes held by closure captures. The const store is a tree — nodes
+/// are appended without content dedup and Debug-mode `verifyComplete` proves
+/// acyclicity — so no visited set is needed.
+pub fn constNodeContainsBox(store: *const check.ConstStore.ConstStore, node: check.ConstStore.ConstNodeId) bool {
+    return switch (store.get(node)) {
+        .box => true,
+        .zst, .scalar, .str, .crash => false,
+        .pending => finalizationInvariant("stored constant contained a pending node"),
+        .list, .tuple, .record => |children| blk: {
+            for (children) |child| {
+                if (constNodeContainsBox(store, child)) break :blk true;
+            }
+            break :blk false;
+        },
+        .tag => |tag| blk: {
+            for (tag.payloads) |payload| {
+                if (constNodeContainsBox(store, payload)) break :blk true;
+            }
+            break :blk false;
+        },
+        .nominal => |nominal| constNodeContainsBox(store, nominal.backing),
+        .fn_value => |fn_id| blk: {
+            for (store.getFn(fn_id).captures) |capture| {
+                if (constNodeContainsBox(store, capture.value)) break :blk true;
+            }
+            break :blk false;
+        },
+    };
 }
 
 fn rootSourceEql(a: checked.RootSource, b: checked.RootSource) bool {
@@ -1773,4 +1827,60 @@ test "compile-time progress wait avoids timestamp wraparound" {
 
 test "compile-time finalization declarations are referenced" {
     std.testing.refAllDecls(@This());
+}
+
+test "constNodeContainsBox finds boxes nested in structural values" {
+    var store = check.ConstStore.ConstStore.init(std.testing.allocator);
+    defer store.deinit();
+
+    const payload = try store.append(.{ .scalar = .{ .u64 = 7 } });
+    const boxed = try store.append(.{ .box = payload });
+    const num = try store.append(.{ .scalar = .{ .i64 = 41 } });
+    const record = try store.append(.{ .record = &.{ num, boxed } });
+    const nominal_over_record = try store.append(.{ .nominal = .{
+        .named_type = .{ .module = .{}, .ty = @enumFromInt(0) },
+        .backing = record,
+    } });
+    const tag_over_box = try store.append(.{ .tag = .{ .tag_name = "Mk", .payloads = &.{boxed} } });
+    const box_free_list = try store.append(.{ .list = &.{ num, num } });
+
+    try std.testing.expect(constNodeContainsBox(&store, boxed));
+    try std.testing.expect(constNodeContainsBox(&store, record));
+    try std.testing.expect(constNodeContainsBox(&store, nominal_over_record));
+    try std.testing.expect(constNodeContainsBox(&store, tag_over_box));
+    try std.testing.expect(!constNodeContainsBox(&store, payload));
+    try std.testing.expect(!constNodeContainsBox(&store, num));
+    try std.testing.expect(!constNodeContainsBox(&store, box_free_list));
+}
+
+test "constNodeContainsBox finds boxes held by closure captures" {
+    var store = check.ConstStore.ConstStore.init(std.testing.allocator);
+    defer store.deinit();
+
+    const payload = try store.append(.{ .scalar = .{ .u64 = 0 } });
+    const boxed = try store.append(.{ .box = payload });
+    const num = try store.append(.{ .scalar = .{ .i64 = 1 } });
+
+    const template = canonical.ProcTemplate{
+        .proc_base = @enumFromInt(0),
+        .template = @enumFromInt(0),
+    };
+    const capturing_fn = try store.appendFn(.{
+        .fn_def = .{ .local_template = template },
+        .source_fn_ty = @enumFromInt(0),
+        .source_fn_key = .{},
+        .captures = &.{.{ .id = @enumFromInt(0), .ty = @enumFromInt(0), .value = boxed }},
+    });
+    const capturing_value = try store.append(.{ .fn_value = capturing_fn });
+
+    const box_free_fn = try store.appendFn(.{
+        .fn_def = .{ .local_template = template },
+        .source_fn_ty = @enumFromInt(0),
+        .source_fn_key = .{},
+        .captures = &.{.{ .id = @enumFromInt(0), .ty = @enumFromInt(0), .value = num }},
+    });
+    const box_free_value = try store.append(.{ .fn_value = box_free_fn });
+
+    try std.testing.expect(constNodeContainsBox(&store, capturing_value));
+    try std.testing.expect(!constNodeContainsBox(&store, box_free_value));
 }

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -5577,3 +5577,57 @@ test "compiler-generated dispatch classes lower via checked evidence" {
     defer allocator.free(output);
     try std.testing.expectEqualStrings("True", output);
 }
+
+test "hoisted const templates never store box-carrying values" {
+    // Box allocation identity (#10171): the checker's keep-gate
+    // (`varMayContainBoxAllocation`) must prevent any hoisted root whose
+    // value contains a box from being published, and finalization's backstop
+    // (`constNodeContainsBox` in compile_time_finalization.zig) must never
+    // upgrade one to a stored constant. This publishes a program full of
+    // box-adjacent shapes and asserts the finalized artifact holds no
+    // box-carrying stored template.
+    const allocator = std.testing.allocator;
+    const source =
+        \\fresh : () -> Box(U64)
+        \\fresh = || Box.box(0)
+        \\
+        \\make_token : () -> { token : Box(U64) }
+        \\make_token = || { token: fresh() }
+        \\
+        \\add_one : U64 -> U64
+        \\add_one = |n| n + 1
+        \\
+        \\unbox_sum : () -> U64
+        \\unbox_sum = || {
+        \\    b = Box.box(41.U64)
+        \\    Box.unbox(b) + 1.U64
+        \\}
+        \\
+        \\main = |_| {
+        \\    forty_two = add_one(41.U64)
+        \\    t = make_token()
+        \\    Box.unbox(t.token) + unbox_sum() + forty_two
+        \\}
+    ;
+
+    var resources = try helpers.parseAndCanonicalizeProgramWithBuiltinPublishingHoistedRoots(allocator, .module, source, &.{}, try sharedPrePublishedBuiltin());
+    defer helpers.cleanupParseAndCanonical(allocator, resources);
+
+    const artifact = &resources.checked_artifact;
+    var stored_count: usize = 0;
+    for (artifact.hoisted_constants.entries) |entry| {
+        switch (artifact.const_templates.get(entry.const_ref).state) {
+            .stored_const => |stored| {
+                stored_count += 1;
+                try std.testing.expect(!eval.CompileTimeFinalization.constNodeContainsBox(&artifact.const_store, stored.node));
+            },
+            .eval_template, .reserved => {},
+        }
+    }
+    // `forty_two`'s box-free binding must still be hoisted and stored —
+    // otherwise this test is vacuous. (`unbox_sum`'s direct body root is
+    // conservatively cascade-pruned: its internal box binding root is
+    // rejected by the keep gate, and the body root's dependency check follows
+    // it — safe direction, less hoisting than strictly necessary.)
+    try std.testing.expect(stored_count >= 1);
+}

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -1091,6 +1091,7 @@ fn publishProgramForComptimeProblemsImpl(
         pre_published_builtin,
         .report_comptime_problems,
         null,
+        .omit,
     ) catch |err| switch (err) {
         error.CompileTimeProblem => return .comptime_problems,
         else => return err,
@@ -1124,6 +1125,32 @@ pub fn publishProgramKeepingReportedComptimeProblems(
         .published_roots_only,
         null,
         .report_comptime_problems,
+        null,
+        .omit,
+    );
+}
+
+/// Same as `parseAndCanonicalizeProgramWithBuiltin`, but publishes the
+/// checker's selected hoisted compile-time roots the way the production
+/// drivers do. See `HoistedRootPublication` for when to use which.
+pub fn parseAndCanonicalizeProgramWithBuiltinPublishingHoistedRoots(
+    allocator: Allocator,
+    source_kind: SourceKind,
+    source: []const u8,
+    imports: []const ModuleSource,
+    pre_published_builtin: PrePublishedBuiltin,
+) TestHelperError!ParsedResources {
+    return parseAndCanonicalizeProgramWithRootModeReporting(
+        allocator,
+        source_kind,
+        source,
+        imports,
+        false,
+        .{ .eval_root = false },
+        pre_published_builtin,
+        .ignore_comptime_problems,
+        null,
+        .publish,
     );
 }
 
@@ -1151,6 +1178,18 @@ fn checkedModuleHasArtifactBlockingProblems(module: *const CheckedModule) bool {
     return module.module_env.types.containsErrContent();
 }
 
+/// Whether publication carries the checker's selected hoisted compile-time
+/// roots, as the production drivers do (compile_package.zig, coordinator.zig).
+///
+/// `.omit` is the harness default: most structural tests pin lowering shapes
+/// for deliberately CLOSED programs, and faithful hoisted publication would
+/// fold their entire bodies to compile-time constants, erasing the very
+/// machinery they exist to inspect. Tests that assert production hoisted-const
+/// behavior (e.g. Box allocation identity, issue #10171) opt in with
+/// `.publish`; end-to-end production fidelity is covered by the CLI fx suite,
+/// which runs the real drivers.
+pub const HoistedRootPublication = enum { omit, publish };
+
 fn parseAndCanonicalizeProgramWithRootMode(
     allocator: Allocator,
     source_kind: SourceKind,
@@ -1171,6 +1210,7 @@ fn parseAndCanonicalizeProgramWithRootMode(
         pre_published_builtin,
         .ignore_comptime_problems,
         roc_ctx,
+        .omit,
     );
 }
 
@@ -1184,6 +1224,7 @@ fn parseAndCanonicalizeProgramWithRootModeReporting(
     pre_published_builtin: ?PrePublishedBuiltin,
     problem_reporting: ComptimeProblemReporting,
     roc_ctx: ?CoreCtx,
+    hoisted_root_publication: HoistedRootPublication,
 ) TestHelperError!ParsedResources {
     const builtin_indices: CIR.BuiltinIndices = if (pre_published_builtin) |ppb|
         ppb.indices
@@ -1358,6 +1399,14 @@ fn parseAndCanonicalizeProgramWithRootModeReporting(
             .imports = publish_imports,
             .available_artifacts = available_artifacts,
             .explicit_roots = explicit_roots,
+            // `.publish` matches the production drivers (compile_package.zig,
+            // coordinator.zig), which carry the checker's selected hoisted
+            // compile-time roots into publication. See HoistedRootPublication
+            // for why the harness defaults to `.omit`.
+            .hoisted_roots = switch (hoisted_root_publication) {
+                .publish => main_checked.checker.selectedHoistedRoots(),
+                .omit => &.{},
+            },
             .compile_time_finalizer = CompileTimeFinalization.finalizer(),
             .problem_store = switch (problem_reporting) {
                 .ignore_comptime_problems => null,

--- a/src/glue/README.md
+++ b/src/glue/README.md
@@ -16,6 +16,12 @@ ownership, and refcounting contracts:
   alignment, discriminants, payload offsets, and pointer-width differences
 - `Str`, `List`, `Box`, and erased callables have runtime allocation headers
   and ownership rules that are not visible from the Roc source type alone
+- a `Box`'s payload pointer is the value's representation and a stable
+  identity: each runtime `Box.box` evaluation whose result reaches the host is
+  a distinct allocation, so hosts may key on live box addresses (boxes inside
+  top-level constants are the exception — one binding shares one static,
+  refcount-pinned allocation whose retain/release are no-ops). `Str` and
+  `List` addresses carry no such guarantee and may be shared or interned.
 - lists of refcounted elements need different allocation metadata and teardown
   than lists of plain bytes
 - seamless slices do not necessarily point at the allocation base that must be
@@ -156,6 +162,7 @@ language-specific.
 | Lists with refcounted elements, including backing element-count headers | List helpers that know element width, alignment, and whether element teardown is required | `glue runtime: cli-main` constructs `List(Str)` args and validates the refcounted element-count header; `glue runtime: app-model` renders and decrefs `View.messages : List(Msg)`. |
 | Seamless slices for `Str` and `List` | Allocation-base recovery helpers that never free the visible slice pointer directly | `glue runtime: cli-main` uses generated Zig/Rust `RocStr.fromSlice` and `RocList.fromSlice` helpers and decrefs through allocation-base recovery; CGlue helper source is covered by `glue command generated C header compiles with zig cc` and `CGlue.roc expect tests pass`. |
 | Roc allocation headers, static refcount zero, and deallocation alignment | Allocator wrappers and assertions for header size, alignment, canaries, and static-data no-op release | `glue runtime: cli-main` and `glue runtime: app-model` use adversarial host allocators with alignment/live-allocation checks; `glue regression: ZigGlue decrefs non-refcounted boxed payloads with payload alignment` and the Rust equivalent cover boxed payload alignment/static-release helpers. |
+| Box allocation identity as a host-visible handle (issue #10171) | Documentation and helpers must treat live `RocBox` addresses as stable identities; only boxes from top-level constants are shared static data | The fx platform `box_freshness_*` and `box_top_level_*` specs (src/cli/test/fx_test_specs.zig) pin distinct-per-call allocation and top-level static sharing across interpreter and dev backends; the compiler-side guarantee lives at `LowLevel.resultIdentityObservable`. |
 | `RocStr` small, big, static, and sliced representations | Safe byte/as-str views, constructors with UTF-8 policy, retain/release helpers, and no C-string assumptions | `glue runtime: cli-main` covers `roc_cli_read`, `roc_cli_log`, and app args; `glue runtime: type-catalog` covers provided/result strings in records and tag payloads; `glue runtime: app-model` covers `View.title`. |
 | `RocList` representation, including different field order from `RocStr` | Typed list helpers for allocation, initialization, slicing, element access, retain, and release | `glue runtime: cli-main` validates `List(Str)` construction and teardown; `glue runtime: type-catalog` covers `List(Bool)` fields; `glue runtime: app-model` checks `List(Msg)` layout in `View`. |
 | Erased callable invocation from the host | Generated callable wrapper APIs for args buffer, return buffer, capture pointer, host context, and owned result handling | `glue command with CGlue generates expected C header`, `glue regression: RustGlue succeeds on fx platform`, `glue command generated Zig compiles with zig build-obj`, and `glue regression: ZigGlue decrefs non-refcounted boxed payloads with payload alignment` cover generated callable payload, capture, call, and drop APIs. |

--- a/src/lir/box_reuse.zig
+++ b/src/lir/box_reuse.zig
@@ -27,6 +27,15 @@
 //! platform-entrypoint form where the unbox and update call live in the join's
 //! remainder. The join matchers only cross local aliases and zero-sized struct
 //! statements, and validate the payload/box layouts before rewriting.
+//!
+//! Allocation identity: box allocations are identity-observable across the
+//! host ABI (`LowLevel.resultIdentityObservable`, issue #10171) — every
+//! dynamic execution of an escaping `box_box` must yield a distinct
+//! allocation. This rewrite is legal under that axiom because it recycles
+//! only the CONSUMED input box: `box_prepare_update` takes the in-place path
+//! solely when the input is uniquely owned and about to be dropped (the moral
+//! equivalent of free-then-malloc returning the same address), and otherwise
+//! copies into a fresh allocation. It never gives two live boxes one address.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;

--- a/test/fx/box_freshness_capture.roc
+++ b/test/fx/box_freshness_capture.roc
@@ -1,0 +1,32 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Host
+import pf.Stdout
+
+# Boxes can hide from type-level analysis inside closure captures behind an
+# opaque nominal. Each `make()` call must still allocate a fresh box (issue
+# #10171): the hoist keep-gate treats function-containing backings as
+# conservatively box-bearing precisely because captures are invisible to types.
+Thunk :: [Mk(() -> Box(U64))].{
+    make : () -> Thunk
+    make = || {
+        b = Box.box(0)
+        Mk(|| b)
+    }
+
+    get : Thunk -> Box(U64)
+    get = |t| match t {
+        Mk(f) => f()
+    }
+}
+
+main! = || {
+    t1 = Thunk.make()
+    t2 = Thunk.make()
+
+    if Host.same_box_u64!(Thunk.get(t1), Thunk.get(t2)) == 1 {
+        Stdout.line!("same allocation")
+    } else {
+        Stdout.line!("distinct allocations")
+    }
+}

--- a/test/fx/box_freshness_generic.roc
+++ b/test/fx/box_freshness_generic.roc
@@ -1,0 +1,42 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Host
+import pf.Stdout
+
+fresh : () -> Box(U64)
+fresh = || Box.box(0)
+
+# Same shape as the issue, but the generic method inlines Box.box(0).
+SignalInline(a) := { token : Box(U64) }.{
+    const : a -> SignalInline(a)
+    const = |_| { token: Box.box(0) }
+
+    map : SignalInline(a), (a -> b) -> SignalInline(b)
+    map = |_, _| { token: Box.box(0) }
+}
+
+# Helper-call version, used to test sharing across distinct specializations.
+Signal(a) := { token : Box(U64) }.{
+    const : a -> Signal(a)
+    const = |_| { token: fresh() }
+}
+
+report! : Str, Box(U64), Box(U64) => {}
+report! = |label, left, right| {
+    if Host.same_box_u64!(left, right) == 1 {
+        Stdout.line!("${label}: same allocation")
+    } else {
+        Stdout.line!("${label}: distinct allocations")
+    }
+}
+
+main! = || {
+    base = SignalInline.const("base")
+    first = base.map(|value| "${value}-first")
+    second = first.map(|value| "${value}-second")
+    report!("generic method inlining Box.box(0)", first.token, second.token)
+
+    str_signal = Signal.const("hello")
+    num_signal = Signal.const(42.U8)
+    report!("fresh() across two specializations", str_signal.token, num_signal.token)
+}

--- a/test/fx/box_freshness_repro.roc
+++ b/test/fx/box_freshness_repro.roc
@@ -1,0 +1,27 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Host
+import pf.Stdout
+
+fresh : () -> Box(U64)
+fresh = || Box.box(0)
+
+Signal(a) := { token : Box(U64) }.{
+    const : a -> Signal(a)
+    const = |_| { token: fresh() }
+
+    map : Signal(a), (a -> b) -> Signal(b)
+    map = |_, _| { token: fresh() }
+}
+
+main! = || {
+    base = Signal.const("base")
+    first = base.map(|value| "${value}-first")
+    second = first.map(|value| "${value}-second")
+
+    if Host.same_box_u64!(first.token, second.token) == 1 {
+        Stdout.line!("same allocation")
+    } else {
+        Stdout.line!("distinct allocations")
+    }
+}

--- a/test/fx/box_freshness_variants.roc
+++ b/test/fx/box_freshness_variants.roc
@@ -1,0 +1,38 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Host
+import pf.Stdout
+
+fresh : () -> Box(U64)
+fresh = || Box.box(0)
+
+# Non-generic plain function with a single textual fresh() call site.
+make_token : () -> { token : Box(U64) }
+make_token = || { token: fresh() }
+
+# Non-generic plain function inlining Box.box directly.
+make_inline : () -> { token : Box(U64) }
+make_inline = || { token: Box.box(0) }
+
+report! : Str, Box(U64), Box(U64) => {}
+report! = |label, left, right| {
+    if Host.same_box_u64!(left, right) == 1 {
+        Stdout.line!("${label}: same allocation")
+    } else {
+        Stdout.line!("${label}: distinct allocations")
+    }
+}
+
+main! = || {
+    a = fresh()
+    b = fresh()
+    report!("direct fresh() twice", a, b)
+
+    c = make_token()
+    d = make_token()
+    report!("plain fn calling fresh()", c.token, d.token)
+
+    e = make_inline()
+    f = make_inline()
+    report!("plain fn inlining Box.box(0)", e.token, f.token)
+}

--- a/test/fx/box_top_level_static.roc
+++ b/test/fx/box_top_level_static.roc
@@ -1,0 +1,18 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Host
+import pf.Stdout
+
+# A top-level binding is one value: every reference shares the single
+# (static, refcount-pinned) allocation. This is the deliberate exception to
+# Box.box's distinct-allocation-per-evaluation guarantee (issue #10171).
+boxed : Box(U64)
+boxed = Box.box(0)
+
+main! = || {
+    if Host.same_box_u64!(boxed, boxed) == 1 {
+        Stdout.line!("same allocation")
+    } else {
+        Stdout.line!("distinct allocations")
+    }
+}

--- a/test/fx/box_top_level_two_bindings.roc
+++ b/test/fx/box_top_level_two_bindings.roc
@@ -1,0 +1,21 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Host
+import pf.Stdout
+
+# Two textually identical top-level box bindings are two values: the const
+# store never dedupes by content, so each binding keeps its own allocation
+# identity (issue #10171).
+first : Box(U64)
+first = Box.box(0)
+
+second : Box(U64)
+second = Box.box(0)
+
+main! = || {
+    if Host.same_box_u64!(first, second) == 1 {
+        Stdout.line!("same allocation")
+    } else {
+        Stdout.line!("distinct allocations")
+    }
+}

--- a/test/fx/platform/Host.roc
+++ b/test/fx/platform/Host.roc
@@ -44,6 +44,9 @@ Host :: {
     ## Return the same boxed function back to Roc after taking a host reference.
     roundtrip_boxed! : Box(I64ToI64) => Box(I64ToI64)
 
+    ## Report whether two boxed U64 payloads share one allocation.
+    same_box_u64! : Box(U64), Box(U64) => U64
+
     ## Store a boxed function in the host by incrementing its outer refcount.
     store_boxed! : Box(I64ToI64) => {}
 

--- a/test/fx/platform/host.zig
+++ b/test/fx/platform/host.zig
@@ -1312,6 +1312,13 @@ fn hostedHostRoundtripBoxed(boxed: ?[*]u8) callconv(.c) ?[*]u8 {
     return boxed;
 }
 
+fn hostedHostSameBoxU64(left: ?[*]u8, right: ?[*]u8) callconv(.c) u64 {
+    const ops = g_roc_ops.?;
+    defer builtins.dev_wrappers.roc_builtins_box_decref_with(left, @alignOf(u64), null, ops);
+    defer builtins.dev_wrappers.roc_builtins_box_decref_with(right, @alignOf(u64), null, ops);
+    return @intFromBool(left == right);
+}
+
 fn hostedHostStoreBoxed(boxed: ?[*]u8) callconv(.c) void {
     const ops = g_roc_ops.?;
     if (stored_boxed_callable) |prev| {
@@ -1373,6 +1380,7 @@ comptime {
     @export(&hostedHostReleaseStoredBoxed, .{ .name = "roc_host_release_stored_boxed", .visibility = .hidden });
     @export(&hostedHostResetBoxedDropReport, .{ .name = "roc_host_reset_boxed_drop_report", .visibility = .hidden });
     @export(&hostedHostRoundtripBoxed, .{ .name = "roc_host_roundtrip_boxed", .visibility = .hidden });
+    @export(&hostedHostSameBoxU64, .{ .name = "roc_host_same_box_u64", .visibility = .hidden });
     @export(&hostedHostStoreBoxed, .{ .name = "roc_host_store_boxed", .visibility = .hidden });
     @export(&hostedHostStoredBoxedCall, .{ .name = "roc_host_stored_boxed_call", .visibility = .hidden });
     @export(&hostedPaddedCheck, .{ .name = "roc_padded_check", .visibility = .hidden });

--- a/test/fx/platform/main.roc
+++ b/test/fx/platform/main.roc
@@ -17,6 +17,7 @@ platform ""
         "roc_host_release_stored_boxed": Host.release_stored_boxed!,
         "roc_host_reset_boxed_drop_report": Host.reset_boxed_drop_report!,
         "roc_host_roundtrip_boxed": Host.roundtrip_boxed!,
+        "roc_host_same_box_u64": Host.same_box_u64!,
         "roc_host_store_boxed": Host.store_boxed!,
         "roc_host_stored_boxed_call": Host.stored_boxed_call!,
         "roc_padded_check": Padded.check!,

--- a/test/glue/fx_platform_cglue_expected.h
+++ b/test/glue/fx_platform_cglue_expected.h
@@ -153,7 +153,7 @@ typedef void (*HostedFn)(void);
 
 // Hosted Function Count
 
-#define HOSTED_FUNCTION_COUNT 17
+#define HOSTED_FUNCTION_COUNT 18
 
 
 #define HOSTED_IDX_BUILDER_PRINT_VALUE 0
@@ -167,12 +167,13 @@ typedef void (*HostedFn)(void);
 #define HOSTED_IDX_HOST_RELEASE_STORED_BOXED 8
 #define HOSTED_IDX_HOST_RESET_BOXED_DROP_REPORT 9
 #define HOSTED_IDX_HOST_ROUNDTRIP_BOXED 10
-#define HOSTED_IDX_HOST_STORE_BOXED 11
-#define HOSTED_IDX_HOST_STORED_BOXED_CALL 12
-#define HOSTED_IDX_PADDED_CHECK 13
-#define HOSTED_IDX_STDERR_LINE 14
-#define HOSTED_IDX_STDIN_LINE 15
-#define HOSTED_IDX_STDOUT_LINE 16
+#define HOSTED_IDX_HOST_SAME_BOX_U64 11
+#define HOSTED_IDX_HOST_STORE_BOXED 12
+#define HOSTED_IDX_HOST_STORED_BOXED_CALL 13
+#define HOSTED_IDX_PADDED_CHECK 14
+#define HOSTED_IDX_STDERR_LINE 15
+#define HOSTED_IDX_STDIN_LINE 16
+#define HOSTED_IDX_STDOUT_LINE 17
 
 // Argument Structures
 
@@ -274,6 +275,16 @@ typedef struct {
 } HostRoundtripBoxedArgs;
 
 /**
+ * Arguments for Host.same_box_u64!
+ * Roc signature: Box(U64), Box(U64) => U64
+ * Refcounted fields are owned by the hosted function.
+ */
+typedef struct {
+    uint64_t* arg0;
+    uint64_t* arg1;
+} HostSameBoxU64Args;
+
+/**
  * Arguments for Host.store_boxed!
  * Roc signature: Box(I64 -> I64) => {}
  * Refcounted fields are owned by the hosted function.
@@ -368,6 +379,9 @@ extern void roc_host_reset_boxed_drop_report(void);
 /* Host.roundtrip_boxed!: Box(I64 -> I64) => Box(I64 -> I64) */
 extern RocErasedCallable roc_host_roundtrip_boxed(RocErasedCallable arg0);
 
+/* Host.same_box_u64!: Box(U64), Box(U64) => U64 */
+extern uint64_t roc_host_same_box_u64(uint64_t* arg0, uint64_t* arg1);
+
 /* Host.store_boxed!: Box(I64 -> I64) => {} */
 extern void roc_host_store_boxed(RocErasedCallable arg0);
 
@@ -411,12 +425,13 @@ typedef struct {
     HostedFn host_release_stored_boxed_bang;  /* index 8, C name: host_release_stored_boxed */
     HostedFn host_reset_boxed_drop_report_bang;  /* index 9, C name: host_reset_boxed_drop_report */
     HostedFn host_roundtrip_boxed_bang;  /* index 10, C name: host_roundtrip_boxed */
-    HostedFn host_store_boxed_bang;  /* index 11, C name: host_store_boxed */
-    HostedFn host_stored_boxed_call_bang;  /* index 12, C name: host_stored_boxed_call */
-    HostedFn padded_check_bang;  /* index 13, C name: padded_check */
-    HostedFn stderr_line_bang;  /* index 14, C name: stderr_line */
-    HostedFn stdin_line_bang;  /* index 15, C name: stdin_line */
-    HostedFn stdout_line_bang;  /* index 16, C name: stdout_line */
+    HostedFn host_same_box_u64_bang;  /* index 11, C name: host_same_box_u64 */
+    HostedFn host_store_boxed_bang;  /* index 12, C name: host_store_boxed */
+    HostedFn host_stored_boxed_call_bang;  /* index 13, C name: host_stored_boxed_call */
+    HostedFn padded_check_bang;  /* index 14, C name: padded_check */
+    HostedFn stderr_line_bang;  /* index 15, C name: stderr_line */
+    HostedFn stdin_line_bang;  /* index 16, C name: stdin_line */
+    HostedFn stdout_line_bang;  /* index 17, C name: stdout_line */
 } HostedFunctions;
 
 


### PR DESCRIPTION
Fixes #10171.

Implements Position B from the issue discussion: **`Box` is a heap cell whose address is its identity — each runtime evaluation of `Box.box` whose result escapes yields a distinct allocation.** Roc is strict, so evaluation count is operationally defined and the guarantee is crisp. This lands the guarantee as a durable axiom rather than a spot fix.

## Root cause

The checker's hoisted-roots mechanism compile-time-evaluates closed, pure, effect-free expressions in function bodies and rematerializes them as shared static data. `Box.box` results passed every gate, so a zero-arg helper `fresh = || Box.box(0)` compiled to "return one static box" — every runtime call, across all specializations and all backends (dev/LLVM/interpreter), returned one allocation. Hosts receive a box's payload pointer as the value's representation and refcount it (roc-signals keys graph tokens on it), so allocation identity is observable at the host ABI. Full mechanism trace with permalinks: https://github.com/roc-lang/roc/issues/10171#issuecomment-4987198268

## Design — four layers, one per commit

1. **Checker keep-gate (primary).** `varMayContainBoxAllocation` in `Check.zig`, consulted by `hoistedRootIsIntrinsicallyKept` (the single prune choke point every kept root passes). A root whose settled value type may contain a `Box` stays runtime code. The walk pierces opaque nominal backings (wrapping a box in an opaque type does not hide its identity — the roc-signals `Node.Token` shape) and treats function types as conservatively box-bearing, because stored function constants carry capture *values* that types cannot see. Boxes remain hoistable as compile-time intermediates when the stored result is box-free; top-level bindings are untouched (one binding = one value; its single shared static allocation is the declared semantics).
2. **Finalization backstop.** `finishConstRoot` walks the stored value tree (`constNodeContainsBox`, including closure captures) before upgrading a hoisted template to `stored_const`. Debug builds panic — the test corpus is the tripwire proving the checker gate is total. Release builds skip the upgrade for expr-shaped roots (falls back to the existing `.eval_template` per-use inline re-evaluation, which preserves freshness); binding-shaped roots keep the stored const because per-read re-evaluation would break local binding sharing.
3. **The written axiom.** `LowLevel.resultIdentityObservable` (true for `box_box`, `box_alloc_zeroed`, `box_prepare_update`) documents the rule for any future CSE/GVN or transparent-allocation lowering; no merging pass exists today. `box_reuse.zig` documents why its dead-box recycling is legal under the axiom. Dead `selection_algorithm_version` removed.
4. **Docs.** `Box.box`'s builtin doc states the guarantee; `glue/README.md` states the host-ABI contract (live `RocBox` addresses are stable identities; `Str`/`List` addresses carry no such guarantee).

## Behavior after this PR

| Shape | Allocation identity |
|---|---|
| `fresh()` called twice (any context, incl. generic methods, across specializations) | distinct |
| Inline `Box.box(0)` per call site execution | distinct |
| Box captured by a closure behind an opaque nominal, two instances | distinct |
| Two textually identical top-level bindings | distinct |
| One top-level binding referenced twice | **same** (one binding is one value; static, refcount-pinned) |

## Verification

- Issue repro and all variants wired into `test/fx` with a new `same_box_u64!` hosted function; specs assert the table above on **both** `--opt=interpreter` and `--opt=dev`.
- Tripwire verified by temporarily disabling the checker gate: Debug panic fires in both the test harness and a real `roc build`; with the panic also disabled, the Release fallback alone restores distinct allocations. (Both temporary edits reverted; this is recorded here in lieu of an un-writable test for an intentionally unreachable branch.)
- Full gate tally: `run-test-zig` 3532/3532 · lir-inline 119/119 · `run-test-cli` 692 run / 0 failed (238 platform specs) · `run-test-eval` 1588/1588 (interpreter/dev/wasm) · snapshots zero diffs · fx coverage and Builtin format checks green.

## Notes for reviewers

- **Harness finding:** the eval test harness never published hoisted compile-time roots (the publication option silently defaulted to empty, unlike the production drivers) — which is why this bug class was invisible to the entire eval suite. It is now an explicit `HoistedRootPublication` choice in `test_helpers.zig`: `.omit` default preserves the 13 lir-inline structural tests whose deliberately-closed programs would fold away entirely under faithful publication; `.publish` opts in and is used by a new integration test asserting no published hoisted template stores a box. Flipping the default (and rewriting those 13 closed programs to take runtime inputs) is a candidate follow-up.
- **Known minor conservatism:** a zero-arg function whose direct body block contains an internal box binding loses hoisting via the dependency cascade even when its result is box-free (the internal binding's root is pruned; the body root's dependency check follows it). The binding-RHS variant stays hoisted and is test-pinned. Safe direction — strictly less compile-time folding, never wrong values.
- The CGlue golden header (`test/glue/fx_platform_cglue_expected.h`) is regenerated because the fx platform gained the `same_box_u64!` hosted function.
- Even with this fix, pure `fresh()` calls are only protected from *this compiler's* merging by the layered guards plus the written axiom; the durable design guidance for identity tokens (documented in the issue thread) remains an effectful constructor or host-minted handles if the language ever wants to relax the axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
