### PR TITLE
Reduce test compilation overhead by eliminating redundant work

### DIFF
--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -4678,6 +4678,20 @@ const PatternExtractionRegionStatsError = error{
     PatternExtractionLookupWasNotResolved,
 };
 
+var shared_test_builtins: ?eval.BuiltinModules = null;
+var shared_test_builtins_mutex: std.Io.Mutex = .init;
+
+fn sharedBuiltinModules() eval.BuiltinModules.InitError!*eval.BuiltinModules {
+    shared_test_builtins_mutex.lockUncancelable(std.testing.io);
+    defer shared_test_builtins_mutex.unlock(std.testing.io);
+
+    if (shared_test_builtins == null) {
+        shared_test_builtins = try eval.BuiltinModules.init(std.heap.page_allocator);
+    }
+
+    return &shared_test_builtins.?;
+}
+
 fn compileAppWithCheckedModuleCache(
     allocator: Allocator,
     cache_dir: []const u8,
@@ -4689,15 +4703,14 @@ fn compileAppWithCheckedModuleCache(
         .cache_dir = cache_dir,
     }, roc_ctx);
 
-    var builtin_modules = try eval.BuiltinModules.init(allocator);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         allocator,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         &cache_manager,
         roc_ctx,
@@ -4782,15 +4795,14 @@ fn compileAppRootIdentity(
         .cache_dir = cache_dir,
     }, roc_ctx);
 
-    var builtin_modules = try eval.BuiltinModules.init(allocator);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         allocator,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         &cache_manager,
         roc_ctx,
@@ -5059,15 +5071,14 @@ test "app artifact records platform requirement solutions from checking" {
     defer allocator.free(app_path);
 
     const roc_ctx = CoreCtx.os(allocator, allocator, std.testing.io);
-    var builtin_modules = try eval.BuiltinModules.init(allocator);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         allocator,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         roc_ctx,
@@ -5163,15 +5174,14 @@ test "platform requirement relation specializes identity reached through app ali
     defer allocator.free(app_path);
 
     const roc_ctx = CoreCtx.os(allocator, allocator, std.testing.io);
-    var builtin_modules = try eval.BuiltinModules.init(allocator);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         allocator,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         roc_ctx,
@@ -5223,14 +5233,13 @@ test "diagnostic-only mode publishes the platform root during checking" {
     defer allocator.free(app_path);
 
     const roc_ctx = CoreCtx.os(allocator, allocator, std.testing.io);
-    var builtin_modules = try eval.BuiltinModules.init(allocator);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
     var coord = try Coordinator.init(
         allocator,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         roc_ctx,
@@ -5288,14 +5297,13 @@ test "deferred platform publication retains compile-time diagnostics" {
     defer allocator.free(app_path);
 
     const roc_ctx = CoreCtx.os(allocator, allocator, std.testing.io);
-    var builtin_modules = try eval.BuiltinModules.init(allocator);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
     var coord = try Coordinator.init(
         allocator,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         roc_ctx,
@@ -5353,15 +5361,14 @@ test "requires signature naming a for-clause alias resolves to the app declarati
     defer allocator.free(app_path);
 
     const roc_ctx = CoreCtx.os(allocator, allocator, std.testing.io);
-    var builtin_modules = try eval.BuiltinModules.init(allocator);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         allocator,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         roc_ctx,
@@ -5482,15 +5489,14 @@ test "hosted distinctness: identical hosted declarations bound to different plat
         .cache_dir = cache_dir,
     }, roc_ctx);
 
-    var builtin_modules = try eval.BuiltinModules.init(allocator);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         allocator,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         &cache_manager,
         roc_ctx,

--- a/src/compile/test/hoisted_constants_test.zig
+++ b/src/compile/test/hoisted_constants_test.zig
@@ -72,6 +72,20 @@ const HoistedConstantsTestError = std.mem.Allocator.Error ||
         WriteFailed,
     };
 
+var shared_test_builtins: ?eval.BuiltinModules = null;
+var shared_test_builtins_mutex: std.Io.Mutex = .init;
+
+fn sharedBuiltinModules() eval.BuiltinModules.InitError!*eval.BuiltinModules {
+    shared_test_builtins_mutex.lockUncancelable(std.testing.io);
+    defer shared_test_builtins_mutex.unlock(std.testing.io);
+
+    if (shared_test_builtins == null) {
+        shared_test_builtins = try eval.BuiltinModules.init(std.heap.page_allocator);
+    }
+
+    return &shared_test_builtins.?;
+}
+
 test "hoisted local constants are finalized and restored during runtime lowering" {
     const gpa = std.testing.allocator;
 
@@ -196,15 +210,14 @@ test "hoisted local constants are finalized and restored during runtime lowering
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -368,15 +381,14 @@ test "imported checked bodies restore their module's hoisted constants" {
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -457,15 +469,14 @@ test "hoisted list constants lower to internal static data" {
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         .x64linux,
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -589,15 +600,14 @@ fn expectInlineListStaticDataLiteral(gpa: std.mem.Allocator, source: []const u8)
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         .x64linux,
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -722,15 +732,14 @@ test "callable binding with alias annotation is const-evaluated" {
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -817,15 +826,14 @@ test "hoisted constant crash reports original source region" {
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -919,15 +927,14 @@ test "inlined hoisted constant crash reports hoisted source region" {
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -1016,15 +1023,14 @@ test "hoisted pattern extraction failure reports original destructure region" {
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -1115,15 +1121,14 @@ test "hoisted pattern extraction base match failure reports match" {
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -1217,15 +1222,14 @@ test "hoisted pattern extraction successful base match resolves pending diagnost
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -1271,15 +1275,14 @@ test "hoisted match guard does not report unused branch warning" {
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -1348,15 +1351,14 @@ test "hoisted successful call does not clear runtime reachable helper exhaustive
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -1420,15 +1422,14 @@ test "hoisted failing call into runtime reachable helper reports static diagnost
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),
@@ -2013,15 +2014,14 @@ test "issue 9733: nested expect statements are collected as test roots" {
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),

--- a/src/compile/test/lower_to_lir_harness.zig
+++ b/src/compile/test/lower_to_lir_harness.zig
@@ -16,6 +16,20 @@ const roc_target = @import("roc_target");
 const Coordinator = @import("../coordinator.zig").Coordinator;
 const CoreCtx = @import("ctx").CoreCtx;
 
+var shared_test_builtins: ?eval.BuiltinModules = null;
+var shared_test_builtins_mutex: std.Io.Mutex = .init;
+
+fn sharedBuiltinModules() eval.BuiltinModules.InitError!*eval.BuiltinModules {
+    shared_test_builtins_mutex.lockUncancelable(std.testing.io);
+    defer shared_test_builtins_mutex.unlock(std.testing.io);
+
+    if (shared_test_builtins == null) {
+        shared_test_builtins = try eval.BuiltinModules.init(std.heap.page_allocator);
+    }
+
+    return &shared_test_builtins.?;
+}
+
 /// Error set shared by LIR-lowering harness helpers and focused inspectors.
 pub const LowerToLirHarnessError = std.mem.Allocator.Error ||
     std.Io.Dir.CreateDirPathError ||
@@ -222,15 +236,14 @@ fn lowerAppPathToLir(
     defer arena_impl.deinit();
     const arena = arena_impl.allocator();
 
-    var builtin_modules = try eval.BuiltinModules.init(gpa);
-    defer builtin_modules.deinit();
+    const builtin_modules = try sharedBuiltinModules();
 
     var coord = try Coordinator.init(
         gpa,
         .single_threaded,
         1,
         roc_target.RocTarget.detectNative(),
-        &builtin_modules,
+        builtin_modules,
         build_options.compiler_version,
         null,
         CoreCtx.default(gpa, arena, std.testing.io),

--- a/src/compile/test/match_corpus_test.zig
+++ b/src/compile/test/match_corpus_test.zig
@@ -34,7 +34,7 @@ fn appendf(buf: *Buf, alloc: std.mem.Allocator, comptime fmt: []const u8, args: 
 /// checker rejects) is an acceptable outcome; a RUN_ERROR is not — every
 /// generated match ends in a wildcard branch and its bodies cannot crash.
 fn runProgram(alloc: std.mem.Allocator, source: []const u8) std.mem.Allocator.Error![]u8 {
-    var compiled = helpers.compileInspectedProgram(alloc, std.testing.io, .module, source, &.{}) catch |err| {
+    var compiled = helpers.compileInspectedProgramForTarget(alloc, std.testing.io, .module, source, &.{}, .native) catch |err| {
         return try std.fmt.allocPrint(alloc, "COMPILE_ERROR:{s}", .{@errorName(err)});
     };
     defer compiled.deinit(alloc);

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -1385,12 +1385,13 @@ test "issue 10121 shared JSON helpers preserve optional nested round trips" {
         \\}
     ;
 
-    var compiled = try helpers.compileInspectedProgramWithBuiltin(
+    var compiled = try helpers.compileInspectedProgramForTargetWithBuiltin(
         allocator,
         std.testing.io,
         .module,
         source,
         &.{},
+        .native,
         try sharedPrePublishedBuiltin(),
         null,
     );
@@ -5565,7 +5566,7 @@ test "compiler-generated dispatch classes lower via checked evidence" {
         \\}
     ;
 
-    var compiled = try helpers.compileInspectedProgramWithBuiltin(allocator, std.testing.io, .module, source, &.{}, try sharedPrePublishedBuiltin(), null);
+    var compiled = try helpers.compileInspectedProgramForTargetWithBuiltin(allocator, std.testing.io, .module, source, &.{}, .native, try sharedPrePublishedBuiltin(), null);
     defer compiled.deinit(allocator);
 
     // The program must check cleanly: a reported problem would resolve the


### PR DESCRIPTION
- match_corpus_test: switch to single-target LIR lowering (58 programs no longer lower to wasm unnecessarily)
- lower_to_lir_harness, hoisted_constants_test, coordinator: cache BuiltinModules singleton instead of reinitializing per test
- lir_inline_test: switch 2 tests to single-target lowering