### PR TITLE
Report type shadow/re-declaration warnings/errors

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -2369,10 +2369,10 @@ fn pushTypeRedeclarationForBinding(
             .redeclared_region = redeclared_region,
             .name = name_ident,
         } }),
-        .external_nominal => try self.env.pushDiagnostic(Diagnostic{ .shadowing_warning = .{
-            .ident = name_ident,
-            .region = redeclared_region,
+        .external_nominal => try self.env.pushDiagnostic(Diagnostic{ .type_redeclared = .{
+            .name = name_ident,
             .original_region = original_region,
+            .redeclared_region = redeclared_region,
         } }),
     }
 }
@@ -2383,13 +2383,25 @@ fn pushTypeShadowingWarning(
     region: Region,
     shadowed: Scope.TypeBinding,
 ) std.mem.Allocator.Error!void {
-    try self.env.pushDiagnostic(Diagnostic{
-        .shadowing_warning = .{
-            .ident = name_ident,
+    switch (shadowed) {
+        .external_nominal => |external| if (self.externalTypeBindingIsCompilerBuiltin(external)) {
+            try self.env.pushDiagnostic(Diagnostic{ .builtin_type_shadowed_warning = .{
+                .name = name_ident,
+                .region = region,
+            } });
+        } else {
+            try self.env.pushDiagnostic(Diagnostic{ .type_shadowed_warning = .{
+                .name = name_ident,
+                .region = region,
+                .original_region = external.origin_region,
+            } });
+        },
+        .local_nominal, .local_alias, .associated_nominal => try self.env.pushDiagnostic(Diagnostic{ .type_shadowed_warning = .{
+            .name = name_ident,
             .region = region,
             .original_region = self.typeBindingOriginalRegion(shadowed),
-        },
-    });
+        } }),
+    }
 }
 
 fn handleTypeBindingDecision(
@@ -2409,10 +2421,15 @@ fn handleTypeBindingDecision(
             }
         },
         .replaced_current_external => |external| {
-            try self.pushTypeShadowingWarning(name_ident, region, Scope.TypeBinding{ .external_nominal = external });
+            const existing = Scope.TypeBinding{ .external_nominal = external };
+            if (self.externalTypeBindingIsCompilerBuiltin(external)) {
+                try self.pushTypeShadowingWarning(name_ident, region, existing);
+            } else {
+                try self.pushTypeRedeclarationForBinding(existing, name_ident, region);
+            }
         },
         .rejected_current_conflict => |existing| {
-            try self.pushTypeShadowingWarning(name_ident, region, existing);
+            try self.pushTypeRedeclarationForBinding(existing, name_ident, region);
         },
         .redeclared_current => |existing| {
             try self.pushTypeRedeclarationForBinding(existing, name_ident, region);

--- a/src/canonicalize/Diagnostic.zig
+++ b/src/canonicalize/Diagnostic.zig
@@ -295,7 +295,10 @@ pub const Diagnostic = union(enum) {
         name: Ident.Idx,
         region: Region,
         original_region: Region,
-        cross_scope: bool,
+    },
+    builtin_type_shadowed_warning: struct {
+        name: Ident.Idx,
+        region: Region,
     },
     type_parameter_conflict: struct {
         name: Ident.Idx,
@@ -447,6 +450,7 @@ pub const Diagnostic = union(enum) {
             .type_alias_redeclared => |d| d.redeclared_region,
             .nominal_type_redeclared => |d| d.redeclared_region,
             .type_shadowed_warning => |d| d.region,
+            .builtin_type_shadowed_warning => |d| d.region,
             .type_parameter_conflict => |d| d.region,
             .unused_variable => |d| d.region,
             .used_underscore_variable => |d| d.region,
@@ -1145,59 +1149,77 @@ pub const Diagnostic = union(enum) {
         return report;
     }
 
-    /// Build a report for "type shadowed warning" diagnostic
+    /// Build a report for shadowing a type from an outer lexical scope.
     pub fn buildTypeShadowedWarningReport(
         allocator: Allocator,
         type_name: []const u8,
         new_region_info: base.RegionInfo,
         original_region_info: base.RegionInfo,
-        cross_scope: bool,
         filename: []const u8,
         source: []const u8,
         line_starts: []const u32,
     ) Allocator.Error!Report {
-        const severity = if (cross_scope) reporting.Severity.warning else reporting.Severity.runtime_error;
-        const title = if (cross_scope) "Type Shadowed" else "Type Duplicate";
-
-        var report = try Report.init(allocator, title, "", severity);
+        var report = try Report.init(allocator, "Type Shadowed", "", .warning);
         const owned_type_name = try report.addOwnedString(type_name);
 
-        if (cross_scope) {
-            try report.headline.addText("The type ");
-            try report.headline.addUnqualifiedSymbol(owned_type_name);
-            try report.headline.addText(" shadows a type from an outer scope.");
-            try report.document.addReflowingText("This may make the outer type inaccessible in this scope.");
-            try report.document.addLineBreak();
-            try report.document.addLineBreak();
-        } else {
-            try report.headline.addText("The type ");
-            try report.headline.addUnqualifiedSymbol(owned_type_name);
-            try report.headline.addText(" is being redeclared in the same scope.");
-        }
+        try report.headline.addText("The type ");
+        try report.headline.addUnqualifiedSymbol(owned_type_name);
+        try report.headline.addText(" shadows a type from an outer scope.");
 
-        // Show where the new declaration is
+        try report.document.addReflowingText("This may make the outer type inaccessible in this scope.");
+        try report.document.addLineBreak();
+        try report.document.addLineBreak();
         try report.document.addText("The new declaration is here:");
         try report.document.addLineBreak();
+
         const owned_filename = try report.addOwnedString(filename);
         try report.document.addSourceRegion(
             new_region_info,
-            .error_highlight,
+            .warning_highlight,
+            owned_filename,
+            source,
+            line_starts,
+        );
+        try report.document.addLineBreak();
+        try report.document.addText("The outer type was declared here:");
+        try report.document.addLineBreak();
+        try report.document.addSourceRegion(
+            original_region_info,
+            .dimmed,
             owned_filename,
             source,
             line_starts,
         );
 
+        return report;
+    }
+
+    /// Build a report for shadowing a compiler-owned builtin type.
+    pub fn buildBuiltinTypeShadowedWarningReport(
+        allocator: Allocator,
+        type_name: []const u8,
+        new_region_info: base.RegionInfo,
+        filename: []const u8,
+        source: []const u8,
+        line_starts: []const u32,
+    ) Allocator.Error!Report {
+        var report = try Report.init(allocator, "Builtin Type Shadowed", "", .warning);
+        const owned_type_name = try report.addOwnedString(type_name);
+
+        try report.headline.addText("The type ");
+        try report.headline.addUnqualifiedSymbol(owned_type_name);
+        try report.headline.addText(" shadows a builtin type.");
+
+        try report.document.addReflowingText("This may make the builtin type inaccessible in this scope.");
         try report.document.addLineBreak();
-        const scope_text = if (cross_scope) "outer scope" else "same scope";
-        try report.document.addText("But ");
-        try report.document.addUnqualifiedSymbol(owned_type_name);
-        try report.document.addText(" was already declared in the ");
-        try report.document.addText(scope_text);
-        try report.document.addText(" here:");
         try report.document.addLineBreak();
+        try report.document.addText("The new declaration is here:");
+        try report.document.addLineBreak();
+
+        const owned_filename = try report.addOwnedString(filename);
         try report.document.addSourceRegion(
-            original_region_info,
-            .dimmed,
+            new_region_info,
+            .warning_highlight,
             owned_filename,
             source,
             line_starts,

--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -3179,7 +3179,17 @@ pub fn diagnosticToReport(self: *Self, diagnostic: CIR.Diagnostic, allocator: st
                 self.getIdent(data.name),
                 new_region_info,
                 original_region_info,
-                data.cross_scope,
+                filename,
+                self.getSourceAll(),
+                self.getLineStartsAll(),
+            );
+        },
+        .builtin_type_shadowed_warning => |data| blk: {
+            const new_region_info = self.calcRegionInfo(data.region);
+            break :blk try CIR.Diagnostic.buildBuiltinTypeShadowedWarningReport(
+                allocator,
+                self.getIdent(data.name),
+                new_region_info,
                 filename,
                 self.getSourceAll(),
                 self.getLineStartsAll(),

--- a/src/canonicalize/Node.zig
+++ b/src/canonicalize/Node.zig
@@ -255,6 +255,7 @@ pub const Tag = enum {
     diag_too_many_exports,
     diag_nominal_type_redeclared,
     diag_type_shadowed_warning,
+    diag_builtin_type_shadowed_warning,
     diag_type_parameter_conflict,
     diag_unused_variable,
     diag_used_underscore_variable,
@@ -1091,7 +1092,7 @@ pub const Payload = extern union {
     };
 
     /// Diagnostics with an identifier and inline region offsets.
-    /// Used by: diag_shadowing_warning, diag_type_redeclared, diag_duplicate_record_field, diag_duplicate_tag, etc.
+    /// Used by: diag_shadowing_warning, diag_type_redeclared, diag_type_shadowed_warning, diag_duplicate_record_field, diag_duplicate_tag, etc.
     pub const DiagIdentWithRegion = extern struct {
         ident: u32, // @bitCast(Ident.Idx)
         region_start: u32, // offset
@@ -1099,7 +1100,7 @@ pub const Payload = extern union {
     };
 
     /// Diagnostics with two values plus region stored in span2_data.
-    /// Used by: diag_type_shadowed_warning, diag_type_parameter_conflict, diag_mutually_recursive_type_aliases
+    /// Used by: diag_type_parameter_conflict, diag_mutually_recursive_type_aliases
     pub const DiagTwoIdentsExtra = extern struct {
         ident1: u32, // @bitCast(Ident.Idx) or value
         ident2: u32, // @bitCast(Ident.Idx) or bool flag

--- a/src/canonicalize/NodeStore.zig
+++ b/src/canonicalize/NodeStore.zig
@@ -434,7 +434,7 @@ pub fn relocate(store: *NodeStore, offset: isize) void {
 /// when adding/removing variants from ModuleEnv unions. Update these when modifying the unions.
 ///
 /// Count of the diagnostic nodes in the ModuleEnv
-pub const MODULEENV_DIAGNOSTIC_NODE_COUNT = 84;
+pub const MODULEENV_DIAGNOSTIC_NODE_COUNT = 85;
 /// Count of the expression nodes in the ModuleEnv
 pub const MODULEENV_EXPR_NODE_COUNT = 55;
 /// Count of the statement nodes in the ModuleEnv
@@ -4503,12 +4503,16 @@ pub fn addDiagnosticUnregistered(store: *NodeStore, reason: CIR.Diagnostic) Allo
         .type_shadowed_warning => |r| {
             node.tag = .diag_type_shadowed_warning;
             region = r.region;
-            const region_span2_idx: u32 = @intCast(store.span2_data.len());
-            _ = try store.span2_data.append(store.gpa, .{
-                .start = r.original_region.start.offset,
-                .len = r.original_region.end.offset,
-            });
-            node.setPayload(.{ .diag_two_idents_extra = .{ .ident1 = @bitCast(r.name), .ident2 = @intFromBool(r.cross_scope), .region_span2_idx = region_span2_idx } });
+            node.setPayload(.{ .diag_ident_with_region = .{
+                .ident = @bitCast(r.name),
+                .region_start = r.original_region.start.offset,
+                .region_end = r.original_region.end.offset,
+            } });
+        },
+        .builtin_type_shadowed_warning => |r| {
+            node.tag = .diag_builtin_type_shadowed_warning;
+            region = r.region;
+            node.setPayload(.{ .diag_single_ident = .{ .ident = @bitCast(r.name) } });
         },
         .type_parameter_conflict => |r| {
             node.tag = .diag_type_parameter_conflict;
@@ -4964,18 +4968,20 @@ pub fn getDiagnostic(store: *const NodeStore, diagnostic: CIR.Diagnostic.Idx) CI
             } };
         },
         .diag_type_shadowed_warning => {
-            const p = payload.diag_two_idents_extra;
-            const region_data = store.span2_data.items.items[p.region_span2_idx];
+            const p = payload.diag_ident_with_region;
             return CIR.Diagnostic{ .type_shadowed_warning = .{
-                .name = @bitCast(p.ident1),
+                .name = @bitCast(p.ident),
                 .region = store.getRegionAt(node_idx),
-                .cross_scope = p.ident2 != 0,
                 .original_region = .{
-                    .start = .{ .offset = region_data.start },
-                    .end = .{ .offset = region_data.len },
+                    .start = .{ .offset = p.region_start },
+                    .end = .{ .offset = p.region_end },
                 },
             } };
         },
+        .diag_builtin_type_shadowed_warning => return CIR.Diagnostic{ .builtin_type_shadowed_warning = .{
+            .name = @bitCast(payload.diag_single_ident.ident),
+            .region = store.getRegionAt(node_idx),
+        } },
         .diag_type_parameter_conflict => {
             const p = payload.diag_two_idents_extra;
             const region_data = store.span2_data.items.items[p.region_span2_idx];

--- a/src/canonicalize/mod.zig
+++ b/src/canonicalize/mod.zig
@@ -121,6 +121,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/uninitialized_var_test.zig"));
     std.testing.refAllDecls(@import("test/while_loop_test.zig"));
     std.testing.refAllDecls(@import("test/where_clause_ownership_test.zig"));
+    std.testing.refAllDecls(@import("test/type_shadowing_test.zig"));
 
     // Backend tests (Roc emitter)
     std.testing.refAllDecls(@import("RocEmitter.zig"));

--- a/src/canonicalize/test/int_test.zig
+++ b/src/canonicalize/test/int_test.zig
@@ -208,7 +208,7 @@ test "typed numeric suffix uses local shadow of builtin numeric type" {
     var found_shadowing_warning = false;
     for (diagnostics) |diagnostic| {
         switch (diagnostic) {
-            .shadowing_warning => found_shadowing_warning = true,
+            .builtin_type_shadowed_warning => found_shadowing_warning = true,
             else => {},
         }
     }

--- a/src/canonicalize/test/node_store_test.zig
+++ b/src/canonicalize/test/node_store_test.zig
@@ -910,7 +910,13 @@ test "NodeStore round trip - Diagnostics" {
             .name = rand_ident_idx(),
             .region = rand_region(),
             .original_region = rand_region(),
-            .cross_scope = rand.random().boolean(),
+        },
+    });
+
+    try diagnostics.append(gpa, CIR.Diagnostic{
+        .builtin_type_shadowed_warning = .{
+            .name = rand_ident_idx(),
+            .region = rand_region(),
         },
     });
 

--- a/src/canonicalize/test/type_shadowing_test.zig
+++ b/src/canonicalize/test/type_shadowing_test.zig
@@ -1,0 +1,81 @@
+//! Tests for type redeclaration and type shadowing diagnostics.
+
+const std = @import("std");
+const TestEnv = @import("./TestEnv.zig");
+
+const testing = std.testing;
+
+test "type declaration shadowing a builtin has a dedicated warning" {
+    const source =
+        \\{
+        \\    U64 := {}
+        \\    123.U64
+        \\}
+    ;
+
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    _ = try test_env.canonicalizeExpr();
+
+    const diagnostics = try test_env.getDiagnostics();
+    defer testing.allocator.free(diagnostics);
+
+    var diag_count: usize = 0;
+    for (diagnostics) |diag| {
+        switch (diag) {
+            .builtin_type_shadowed_warning => {
+                diag_count += 1;
+                var report = try test_env.module_env.diagnosticToReport(
+                    diag,
+                    testing.allocator,
+                    test_env.module_env.module_name,
+                );
+                defer report.deinit();
+                try testing.expectEqualStrings("Builtin Type Shadowed", report.title);
+            },
+            else => {},
+        }
+    }
+    try testing.expectEqual(@as(usize, 1), diag_count);
+}
+
+test "nested type declaration has an outer-scope shadowing warning" {
+    const source =
+        \\{
+        \\    Item := [Outer]
+        \\    {
+        \\        Item := [Inner]
+        \\        {}
+        \\    }
+        \\}
+    ;
+
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    _ = try test_env.canonicalizeExpr();
+
+    const diagnostics = try test_env.getDiagnostics();
+    defer testing.allocator.free(diagnostics);
+
+    var diag_count: usize = 0;
+    for (diagnostics) |diag| {
+        switch (diag) {
+            .type_shadowed_warning => |data| {
+                diag_count += 1;
+                try testing.expect(data.original_region.start.offset < data.region.start.offset);
+
+                var report = try test_env.module_env.diagnosticToReport(
+                    diag,
+                    testing.allocator,
+                    test_env.module_env.module_name,
+                );
+                defer report.deinit();
+                try testing.expectEqualStrings("Type Shadowed", report.title);
+            },
+            else => {},
+        }
+    }
+    try testing.expectEqual(@as(usize, 1), diag_count);
+}

--- a/src/canonicalize/test/type_shadowing_test.zig
+++ b/src/canonicalize/test/type_shadowing_test.zig
@@ -79,3 +79,40 @@ test "nested type declaration has an outer-scope shadowing warning" {
     }
     try testing.expectEqual(@as(usize, 1), diag_count);
 }
+
+test "type redeclaration in the same scope is an error" {
+    const source =
+        \\{
+        \\    Item := [First]
+        \\    Item := [Second]
+        \\    {}
+        \\}
+    ;
+
+    var test_env = try TestEnv.init(source);
+    defer test_env.deinit();
+
+    _ = try test_env.canonicalizeExpr();
+
+    const diagnostics = try test_env.getDiagnostics();
+    defer testing.allocator.free(diagnostics);
+
+    var redeclaration_count: usize = 0;
+    for (diagnostics) |diag| {
+        switch (diag) {
+            .type_redeclared => {
+                redeclaration_count += 1;
+                var report = try test_env.module_env.diagnosticToReport(
+                    diag,
+                    testing.allocator,
+                    test_env.module_env.module_name,
+                );
+                defer report.deinit();
+                try testing.expectEqualStrings("Type Redeclared", report.title);
+            },
+            .type_shadowed_warning, .builtin_type_shadowed_warning => return error.UnexpectedShadowingWarning,
+            else => {},
+        }
+    }
+    try testing.expectEqual(@as(usize, 1), redeclaration_count);
+}

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -23081,6 +23081,7 @@ fn has_can_error_diagnostics(self: *Self) bool {
             .unused_variable,
             .used_underscore_variable,
             .type_shadowed_warning,
+            .builtin_type_shadowed_warning,
             .unused_type_var_name,
             .type_var_marked_unused,
             .underscore_in_type_declaration,

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -5491,7 +5491,7 @@ fn checkFileInternal(self: *Self, skip_numeric_defaults: bool) std.mem.Allocator
     // (top-level defs and local bindings) for infinite types
     try self.checkBindingRootsForInfiniteTypes();
 
-    if (!self.has_can_error_diagnostics()) {
+    if (!self.hasCanErrorDiagnostics()) {
         try self.poisonErroneousValueUses();
         try self.poisonErroneousValueExprs();
     }
@@ -23072,7 +23072,7 @@ fn flatTypeContainsError(self: *Self, flat_type: FlatType, visited: *std.AutoHas
     };
 }
 
-fn has_can_error_diagnostics(self: *Self) bool {
+fn hasCanErrorDiagnostics(self: *Self) bool {
     const diagnostics = self.cir.store.sliceDiagnostics(self.cir.diagnostics);
     for (diagnostics) |diagnostic_idx| {
         const diagnostic = self.cir.store.getDiagnostic(diagnostic_idx);

--- a/src/check/test/issue_9705_test.zig
+++ b/src/check/test/issue_9705_test.zig
@@ -22,7 +22,7 @@ test "issue 9705: Bool shadowing warns but boolean operators still use builtin B
     defer test_env.gpa.free(diagnostics);
 
     try std.testing.expectEqual(@as(usize, 1), diagnostics.len);
-    try std.testing.expect(diagnostics[0] == .shadowing_warning);
+    try std.testing.expectEqual(std.meta.activeTag(diagnostics[0]), .builtin_type_shadowed_warning);
     try std.testing.expectEqual(@as(usize, 0), test_env.checker.problems.problems.items.len);
 }
 
@@ -42,6 +42,6 @@ test "issue 9705: nested Bool shadowing warns but succeeds" {
     defer test_env.gpa.free(diagnostics);
 
     try std.testing.expectEqual(@as(usize, 1), diagnostics.len);
-    try std.testing.expect(diagnostics[0] == .shadowing_warning);
+    try std.testing.expectEqual(std.meta.activeTag(diagnostics[0]), .builtin_type_shadowed_warning);
     try std.testing.expectEqual(@as(usize, 0), test_env.checker.problems.problems.items.len);
 }

--- a/src/compile/compile_package.zig
+++ b/src/compile/compile_package.zig
@@ -545,6 +545,7 @@ fn moduleHasArtifactBlockingCanonicalizeDiagnostics(env: *const ModuleEnv) bool 
             .unused_variable,
             .used_underscore_variable,
             .type_shadowed_warning,
+            .builtin_type_shadowed_warning,
             .unused_type_var_name,
             .type_var_marked_unused,
             .underscore_in_type_declaration,

--- a/test/snapshots/type_alias_decl.md
+++ b/test/snapshots/type_alias_decl.md
@@ -49,25 +49,23 @@ main! = |_| {
 }
 ~~~
 # EXPECTED
-DUPLICATE DEFINITION - type_alias_decl.md:7:1:7:34
+BUILTIN TYPE SHADOWED - type_alias_decl.md:7:1:7:34
 OPEN EXT NOT ALLOWED IN TYPE DECLARATION - type_alias_decl.md:22:18:22:20
 UNUSED VARIABLE - type_alias_decl.md:36:5:36:11
 UNUSED VARIABLE - type_alias_decl.md:39:5:39:10
 # PROBLEMS
 
-┌──────────────────────┐
-│ DUPLICATE DEFINITION ├─ The name `Try` is being redeclared here. ───────────┐
-└┬─────────────────────┘                                                      │
+┌───────────────────────┐
+│ BUILTIN TYPE SHADOWED ├─ The type `Try` shadows a builtin type. ────────────┐
+└┬──────────────────────┘                                                     │
  │                                                                            │
  │  Try(ok, err) : [Ok(ok), Err(err)]                                         │
  │  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                         │
  └──────────────────────────────────────────────────── type_alias_decl.md:7:1 ┘
 
-    In this scope, `Try` was already defined here:
-      ┌───────────────────────────────────────────────────────────────────────┐
-    1 │  app [main!] { pf: platform "../basic-cli/main.roc" }                 │
-      │  ‾                                                                    │
-      └─────────────────────────────────────────────── type_alias_decl.md:1:1 ┘
+    This may make the builtin type inaccessible in this scope.
+
+    The new declaration is here:
 
 
 ┌──────────────────────────────────────────┐

--- a/test/snapshots/type_comprehensive_scope.md
+++ b/test/snapshots/type_comprehensive_scope.md
@@ -43,26 +43,24 @@ Complex : {
 }
 ~~~
 # EXPECTED
-DUPLICATE DEFINITION - type_comprehensive_scope.md:10:1:10:34
+BUILTIN TYPE SHADOWED - type_comprehensive_scope.md:10:1:10:34
 MUTUALLY RECURSIVE TYPE ALIASES - type_comprehensive_scope.md:13:1:13:37
 MUTUALLY RECURSIVE TYPE ALIASES - type_comprehensive_scope.md:16:1:16:48
 TYPE REDECLARED - type_comprehensive_scope.md:22:1:22:13
 UNDECLARED TYPE - type_comprehensive_scope.md:25:11:25:29
 # PROBLEMS
 
-┌──────────────────────┐
-│ DUPLICATE DEFINITION ├─ The name `Try` is being redeclared here. ───────────┐
-└┬─────────────────────┘                                                      │
+┌───────────────────────┐
+│ BUILTIN TYPE SHADOWED ├─ The type `Try` shadows a builtin type. ────────────┐
+└┬──────────────────────┘                                                     │
  │                                                                            │
  │  Try(ok, err) : [Ok(ok), Err(err)]                                         │
  │  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                         │
  └────────────────────────────────────────── type_comprehensive_scope.md:10:1 ┘
 
-    In this scope, `Try` was already defined here:
-      ┌───────────────────────────────────────────────────────────────────────┐
-    1 │  # Built-in types should work                                         │
-      │  ‾                                                                    │
-      └────────────────────────────────────── type_comprehensive_scope.md:1:1 ┘
+    This may make the builtin type inaccessible in this scope.
+
+    The new declaration is here:
 
 
 ┌─────────────────────────────────┐

--- a/test/snapshots/type_shadowing_across_scopes.md
+++ b/test/snapshots/type_shadowing_across_scopes.md
@@ -21,7 +21,7 @@ EXPECTED TYPE FIELD - type_shadowing_across_scopes.md:9:5:9:8
 EXPECTED RECORD TYPE SEPARATOR - type_shadowing_across_scopes.md:9:21:9:28
 UNEXPECTED STATEMENT - type_shadowing_across_scopes.md:9:28:9:29
 UNEXPECTED STATEMENT - type_shadowing_across_scopes.md:10:1:10:2
-DUPLICATE DEFINITION - type_shadowing_across_scopes.md:1:1:1:28
+BUILTIN TYPE SHADOWED - type_shadowing_across_scopes.md:1:1:1:28
 UNUSED VARIABLE - type_shadowing_across_scopes.md:4:16:4:20
 MALFORMED TYPE - type_shadowing_across_scopes.md:9:21:9:28
 # PROBLEMS
@@ -101,19 +101,17 @@ MALFORMED TYPE - type_shadowing_across_scopes.md:9:21:9:28
     missing item before it.
 
 
-┌──────────────────────┐
-│ DUPLICATE DEFINITION ├─ The name `Try` is being redeclared here. ───────────┐
-└┬─────────────────────┘                                                      │
+┌───────────────────────┐
+│ BUILTIN TYPE SHADOWED ├─ The type `Try` shadows a builtin type. ────────────┐
+└┬──────────────────────┘                                                     │
  │                                                                            │
  │  Try(a, b) : [Ok(a), Err(b)]                                               │
  │  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                               │
  └─────────────────────────────────────── type_shadowing_across_scopes.md:1:1 ┘
 
-    In this scope, `Try` was already defined here:
-      ┌───────────────────────────────────────────────────────────────────────┐
-    1 │  Try(a, b) : [Ok(a), Err(b)]                                          │
-      │  ‾                                                                    │
-      └────────────────────────────────── type_shadowing_across_scopes.md:1:1 ┘
+    This may make the builtin type inaccessible in this scope.
+
+    The new declaration is here:
 
 
 ┌─────────────────┐

--- a/test/snapshots/type_tag_union_complex.md
+++ b/test/snapshots/type_tag_union_complex.md
@@ -32,22 +32,20 @@ handleResponse = |_response| "handled"
 main! = |_| {}
 ~~~
 # EXPECTED
-DUPLICATE DEFINITION - type_tag_union_complex.md:7:1:7:52
+BUILTIN TYPE SHADOWED - type_tag_union_complex.md:7:1:7:52
 # PROBLEMS
 
-┌──────────────────────┐
-│ DUPLICATE DEFINITION ├─ The name `Try` is being redeclared here. ───────────┐
-└┬─────────────────────┘                                                      │
+┌───────────────────────┐
+│ BUILTIN TYPE SHADOWED ├─ The type `Try` shadows a builtin type. ────────────┐
+└┬──────────────────────┘                                                     │
  │                                                                            │
  │  Try : [Success(Str), Error(Str), Warning(Str, I32)]                       │
  │  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                       │
  └───────────────────────────────────────────── type_tag_union_complex.md:7:1 ┘
 
-    In this scope, `Try` was already defined here:
-      ┌───────────────────────────────────────────────────────────────────────┐
-    1 │  app [main!] { pf: platform "../basic-cli/main.roc" }                 │
-      │  ‾                                                                    │
-      └──────────────────────────────────────── type_tag_union_complex.md:1:1 ┘
+    This may make the builtin type inaccessible in this scope.
+
+    The new declaration is here:
 
 # TOKENS
 ~~~zig


### PR DESCRIPTION
I noticed that we had a diagnostic for type shadowing/re-declaration, but `Can` never actually reported it. This PR updates the diagnostics to have clear, specific error messages & to detect this case in `Can.zig`