### PR TITLE
Add remaining `Try` builtins (map_both, map2, on_err, catch, collapse)

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4476,6 +4476,40 @@ Builtin :: [].{
 			Ok(ok) => Ok(ok)
 		}
 
+		## Transforms whichever value this result holds, by running one conversion
+		## function on an `Ok` and a different one on an `Err`. Only the function
+		## matching the variant is run. Use [Try.map_ok] or [Try.map_err] to transform
+		## just one variant, and [Try.catch] when both should produce the same type.
+		## ```roc
+		## expect {
+		## 	ok : Try(I64, Str)
+		## 	ok = Ok(12)
+		## 	ok.map_both(|n| -n, |_| Failed) == Ok(-12)
+		## }
+		##
+		## expect {
+		## 	err : Try(I64, Str)
+		## 	err = Err("uh oh")
+		## 	err.map_both(|n| -n, |_| Failed) == Err(Failed)
+		## }
+		## ```
+		map_both : Try(a, b), (a -> c), (b -> d) -> Try(c, d)
+		map_both = |try, ok_transform, err_transform| match try {
+			Err(b) => Err(err_transform(b))
+			Ok(a) => Ok(ok_transform(a))
+		}
+
+		## Like [Try.map_both], but the transform functions are effectful. Only the
+		## effect matching the variant this result holds is run; the other is not.
+		## ```roc
+		## request.map_both!(|ok| Log.info!("succeeded: ${ok}"), |e| Log.warn!("failed: ${e}"))
+		## ```
+		map_both! : Try(a, b), (a => c), (b => d) => Try(c, d)
+		map_both! = |try, ok_transform!, err_transform!| match try {
+			Err(b) => Err(err_transform!(b))
+			Ok(a) => Ok(ok_transform!(a))
+		}
+
 		## Returns `Bool.True` if the two `Try` values are the same variant (`Ok` or `Err`) and their contents are pairwise equal. Otherwise, returns `Bool.False`.
 		is_eq : Try(ok, err), Try(ok, err) -> Bool
 			where [

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4575,6 +4575,36 @@ Builtin :: [].{
 			Ok(ok) => Ok(ok)
 		}
 
+		## Collapses the result into a plain value by converting whichever variant it
+		## holds into a common type: `err_transform` runs on an `Err`, `ok_transform`
+		## on an `Ok`. Unlike [Try.map_both], both functions return the same type, so
+		## the answer is a plain value rather than another result.
+		## ```roc
+		## expect Try.Ok(12.I64).catch(|_| 0, |n| n * 2) == 24
+		##
+		## expect {
+		## 	err : Try(I64, Str)
+		## 	err = Err("uh oh")
+		## 	err.catch(|_| 0, |n| n * 2) == 0
+		## }
+		## ```
+		catch : Try(ok, err), (err -> a), (ok -> a) -> a
+		catch = |try, err_transform, ok_transform| match try {
+			Err(err) => err_transform(err)
+			Ok(ok) => ok_transform(ok)
+		}
+
+		## Like [Try.catch], but the conversion functions are effectful. Only the
+		## effect matching the variant this result holds is run.
+		## ```roc
+		## response.catch!(|e| Log.error!("request failed: ${e}"), |body| Log.info!("got ${body}"))
+		## ```
+		catch! : Try(ok, err), (err => a), (ok => a) => a
+		catch! = |try, err_transform!, ok_transform!| match try {
+			Err(err) => err_transform!(err)
+			Ok(ok) => ok_transform!(ok)
+		}
+
 		## Returns `Bool.True` if the two `Try` values are the same variant (`Ok` or `Err`) and their contents are pairwise equal. Otherwise, returns `Bool.False`.
 		is_eq : Try(ok, err), Try(ok, err) -> Bool
 			where [

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4605,6 +4605,19 @@ Builtin :: [].{
 			Ok(ok) => ok_transform!(ok)
 		}
 
+		## Returns whichever value this result holds, for a result whose `Ok` and `Err`
+		## hold the same type. This is [Try.catch] with two identity functions.
+		## ```roc
+		## expect Try.Ok(5.I64).collapse() == 5
+		##
+		## expect Try.Err(7.I64).collapse() == 7
+		## ```
+		collapse : Try(a, a) -> a
+		collapse = |try| match try {
+			Err(a) => a
+			Ok(a) => a
+		}
+
 		## Returns `Bool.True` if the two `Try` values are the same variant (`Ok` or `Err`) and their contents are pairwise equal. Otherwise, returns `Bool.False`.
 		is_eq : Try(ok, err), Try(ok, err) -> Bool
 			where [

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4510,6 +4510,37 @@ Builtin :: [].{
 			Ok(a) => Ok(ok_transform!(a))
 		}
 
+		## Combines two results by running a function on both `Ok` values. If either
+		## is an `Err`, that `Err` is returned instead and the function is not run.
+		## When both are `Err`, the first one wins.
+		## ```roc
+		## expect Try.map2(Try.Ok(2.I64), Try.Ok(3), |a, b| a * b) == Ok(6)
+		##
+		## expect {
+		## 	err : Try(I64, Str)
+		## 	err = Err("uh oh")
+		## 	Try.map2(Try.Ok(2), err, |a, b| a * b) == Err("uh oh")
+		## }
+		## ```
+		map2 : Try(a, err), Try(b, err), (a, b -> c) -> Try(c, err)
+		map2 = |first, second, transform| match (first, second) {
+			(Err(err), _) => Err(err)
+			(_, Err(err)) => Err(err)
+			(Ok(a), Ok(b)) => Ok(transform(a, b))
+		}
+
+		## Like [Try.map2], but the combining function is effectful. It runs only when
+		## both arguments are `Ok`.
+		## ```roc
+		## Try.map2!(user_try, album_try, |u, a| SQL.execute!("INSERT INTO plays (user, album) VALUES (?, ?)", [u.id, a.id]))
+		## ```
+		map2! : Try(a, err), Try(b, err), (a, b => c) => Try(c, err)
+		map2! = |first, second, transform!| match (first, second) {
+			(Err(err), _) => Err(err)
+			(_, Err(err)) => Err(err)
+			(Ok(a), Ok(b)) => Ok(transform!(a, b))
+		}
+
 		## Returns `Bool.True` if the two `Try` values are the same variant (`Ok` or `Err`) and their contents are pairwise equal. Otherwise, returns `Bool.False`.
 		is_eq : Try(ok, err), Try(ok, err) -> Bool
 			where [

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4541,6 +4541,40 @@ Builtin :: [].{
 			(Ok(a), Ok(b)) => Ok(transform!(a, b))
 		}
 
+		## If the result is `Err`, runs a recovery function on the value it holds. That
+		## function returns a new result, so recovering can itself fail — with a
+		## different error type if you like. If the result is `Ok`, this has no effect.
+		## Use [Try.map_err] when the recovery cannot fail.
+		## ```roc
+		## expect {
+		## 	err : Try(I64, Str)
+		## 	err = Err("uh oh")
+		## 	err.on_err(|_| Ok(0)) == Ok(0)
+		## }
+		##
+		## expect {
+		## 	ok : Try(I64, Str)
+		## 	ok = Ok(7)
+		## 	ok.on_err(|_| Ok(0)) == Ok(7)
+		## }
+		## ```
+		on_err : Try(ok, a), (a -> Try(ok, b)) -> Try(ok, b)
+		on_err = |try, recover| match try {
+			Err(a) => recover(a)
+			Ok(ok) => Ok(ok)
+		}
+
+		## Like [Try.on_err], but the recovery function is effectful. It runs only when
+		## the result is an `Err`.
+		## ```roc
+		## config_try.on_err!(|_| Http.get!("https://example.com/fallback-config"))
+		## ```
+		on_err! : Try(ok, a), (a => Try(ok, b)) => Try(ok, b)
+		on_err! = |try, recover!| match try {
+			Err(a) => recover!(a)
+			Ok(ok) => Ok(ok)
+		}
+
 		## Returns `Bool.True` if the two `Try` values are the same variant (`Ok` or `Err`) and their contents are pairwise equal. Otherwise, returns `Bool.False`.
 		is_eq : Try(ok, err), Try(ok, err) -> Bool
 			where [

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4544,7 +4544,8 @@ Builtin :: [].{
 		## If the result is `Err`, runs a recovery function on the value it holds. That
 		## function returns a new result, so recovering can itself fail — with a
 		## different error type if you like. If the result is `Ok`, this has no effect.
-		## Use [Try.map_err] when the recovery cannot fail.
+		## Use [Try.map_err] when you only want to transform the error without
+		## recovering from it.
 		## ```roc
 		## expect {
 		## 	err : Try(I64, Str)

--- a/test/snapshots/repl/try_catch.md
+++ b/test/snapshots/repl/try_catch.md
@@ -1,0 +1,31 @@
+# META
+~~~ini
+description=Try.catch collapsing both variants to one type
+type=repl
+~~~
+# SOURCE
+~~~roc
+» Try.catch(Try.Err("failed"), |_| 0, |val| val * 2)
+» Try.catch!(Try.Err("failed"), |_| 0, |val| val * 2)
+» Try.catch(Try.Ok(12), |_| 0, |val| val * 2)
+» Try.catch!(Try.Ok(12), |_| 0, |val| val * 2)
+» t = Try.Ok("a string long enough to be heap-allocated instead of stored inline")
+» Try.catch(t, |x| x, |x| x)
+» t
+~~~
+# OUTPUT
+0.0
+---
+0.0
+---
+24.0
+---
+24.0
+---
+assigned `t`
+---
+"a string long enough to be heap-allocated instead of stored inline"
+---
+Ok("a string long enough to be heap-allocated instead of stored inline")
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/try_collapse.md
+++ b/test/snapshots/repl/try_collapse.md
@@ -1,0 +1,25 @@
+# META
+~~~ini
+description=Try.collapse on Ok and Err holding the same type
+type=repl
+~~~
+# SOURCE
+~~~roc
+» Try.collapse(Try.Ok(5))
+» Try.collapse(Try.Err(7))
+» t = Try.Ok("a string long enough to be heap-allocated instead of stored inline")
+» Try.collapse(t)
+» t
+~~~
+# OUTPUT
+5.0
+---
+7.0
+---
+assigned `t`
+---
+"a string long enough to be heap-allocated instead of stored inline"
+---
+Ok("a string long enough to be heap-allocated instead of stored inline")
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/try_map2.md
+++ b/test/snapshots/repl/try_map2.md
@@ -1,0 +1,37 @@
+# META
+~~~ini
+description=Try.map2 combining two results
+type=repl
+~~~
+# SOURCE
+~~~roc
+» Try.map2(Try.Ok(2), Try.Ok(3), |a, b| a * b)
+» Try.map2!(Try.Ok(2), Try.Ok(3), |a, b| a * b)
+» Try.map2(Try.Err("first"), Try.Ok(3), |a, b| a * b)
+» Try.map2(Try.Ok(2), Try.Err("second"), |a, b| a * b)
+» Try.map2(Try.Err("first"), Try.Err("second"), |a, b| a * b)
+» Try.map2!(Try.Err("first"), Try.Err("second"), |a, b| a * b)
+» a = Try.Ok("a string long enough to be heap-allocated instead of stored inline")
+» Try.map2(a, Try.Ok("another heap-allocated string that will not fit inline either"), |x, y| Str.concat(x, y))
+» a
+~~~
+# OUTPUT
+Ok(6.0)
+---
+Ok(6.0)
+---
+Err("first")
+---
+Err("second")
+---
+Err("first")
+---
+Err("first")
+---
+assigned `a`
+---
+Ok("a string long enough to be heap-allocated instead of stored inlineanother heap-allocated string that will not fit inline either")
+---
+Ok("a string long enough to be heap-allocated instead of stored inline")
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/try_map_both.md
+++ b/test/snapshots/repl/try_map_both.md
@@ -1,0 +1,31 @@
+# META
+~~~ini
+description=Try.map_both with Ok and Err variants
+type=repl
+~~~
+# SOURCE
+~~~roc
+» Try.map_both(Try.Err("failed"), |val| val + 1, |_| Failed)
+» Try.map_both!(Try.Err("failed"), |val| val + 1, |_| Failed)
+» Try.map_both(Try.Ok(100), |val| val - 50, |_| Failed)
+» Try.map_both!(Try.Ok(100), |val| val - 50, |_| Failed)
+» t = Try.Ok("a string long enough to be heap-allocated instead of stored inline")
+» Try.map_both(t, |s| s, |e| e)
+» t
+~~~
+# OUTPUT
+Err(Failed)
+---
+Err(Failed)
+---
+Ok(50.0)
+---
+Ok(50.0)
+---
+assigned `t`
+---
+Ok("a string long enough to be heap-allocated instead of stored inline")
+---
+Ok("a string long enough to be heap-allocated instead of stored inline")
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/try_on_err.md
+++ b/test/snapshots/repl/try_on_err.md
@@ -1,0 +1,34 @@
+# META
+~~~ini
+description=Try.on_err recovering from an Err
+type=repl
+~~~
+# SOURCE
+~~~roc
+» Try.on_err(Try.Err("failed"), |_| Try.Ok(0))
+» Try.on_err!(Try.Err("failed"), |_| Try.Ok(0))
+» Try.on_err(Try.Ok(7), |_| Try.Ok(0))
+» Try.on_err!(Try.Ok(7), |_| Try.Ok(0))
+» Try.on_err(Try.Err("first"), |_| Try.Err("recovery also failed"))
+» e = Try.Err("a string long enough to be heap-allocated instead of stored inline")
+» Try.on_err(e, |s| Try.Err(s))
+» e
+~~~
+# OUTPUT
+Ok(0.0)
+---
+Ok(0.0)
+---
+Ok(7.0)
+---
+Ok(7.0)
+---
+Err("recovery also failed")
+---
+assigned `e`
+---
+Err("a string long enough to be heap-allocated instead of stored inline")
+---
+Err("a string long enough to be heap-allocated instead of stored inline")
+# PROBLEMS
+NIL


### PR DESCRIPTION
Completes the `## Try Builtins` section of #9596 — nine functions, all unclaimed. Announced on Zulip (`#contributing > "Finishing the Try builtins (#9596)"`); @lukewilliamboswell confirmed the whole-section PR and asked for it split across commits, which is how it's laid out here.

All pure Roc with an inline `match`, no new low-level op, modelled on the existing `map_ok`/`map_ok!`/`map_err`/`map_err!`. These fill out the `Try` combinator matrix — {transform one side / both sides} × {stay in `Try` / leave it} — where `?`, `map_ok` and `map_err` already cover the rest.

**Commits (one pair per commit, each self-contained with its own snapshot):**
- `Try.map_both` / `map_both!` — transform both variants at once
- `Try.map2` / `map2!` — combine two results; first `Err` wins
- `Try.on_err` / `on_err!` — recover from an `Err` with a function that may itself fail
- `Try.catch` / `catch!` — collapse both variants to a common type (#6759)
- `Try.collapse` — `catch` with identity functions, for `Try(a, a)` (#3439)

**On argument order:** `map_both` takes `(ok_fn, err_fn)` while `catch` takes `(err_fn, ok_fn)`. This matches the signatures in #9596 verbatim; `catch`'s err-first order mirrors Rust's `Result::map_or_else`. Happy to align them if you'd prefer consistency within the module.

**Tests:** a repl snapshot per function under `test/snapshots/`, covering both variants plus the edge cases the docs promise (two-`Err` precedence for `map2`, a failing recovery for `on_err`). Note that `## expect` doc-tests type-check but don't assert values, so the snapshots are the behavioural coverage. Local `zig build minici` is green (62/62).
