### PR TITLE
Allow nominal record destructure syntax

### DIFF
--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -4877,6 +4877,29 @@ test "check type - nominal destructure pattern in lambda arg binds the backing v
     try checkTypesModule(source, .{ .pass = .last_def }, "Distance -> U64");
 }
 
+test "check type - nominal record destructure syntax works in every pattern position" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Point := { x : U64, y : U64 }
+        \\
+        \\sum_arg : Point -> U64
+        \\sum_arg = |Point.{ x, y }| x + y
+        \\
+        \\sum_let : Point -> U64
+        \\sum_let = |point| {
+        \\    Point.{ x, y } = point
+        \\    x + y
+        \\}
+        \\
+        \\sum_match : Point -> U64
+        \\sum_match = |point| match point {
+        \\    Point.{ x, y } => x + y
+        \\}
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "Point -> U64");
+}
+
 // LITERAL COERCION + STRUCTURAL LIFTING INTO NOMINALS (executable spec)
 //
 // Two DIFFERENT operations, deliberately kept separate:

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -2077,11 +2077,15 @@ const Formatter = struct {
 
                 try fmt.pushTokenText(t.tag_tok);
                 if (t.backing_value) {
-                    // Nominal-value destructure renders as `Type.(args)` (the `.`
-                    // distinguishes it from an ordinary applied-tag `Tag(args)`).
+                    // The `.` distinguishes nominal-value destructuring from an
+                    // ordinary applied-tag pattern.
                     try fmt.push('.');
                 }
-                if (t.backing_value or t.has_args) {
+                if (t.record_shorthand) {
+                    const args = fmt.ast.store.patternSlice(t.args);
+                    std.debug.assert(t.backing_value and args.len == 1);
+                    try fmt.formatPatternDiscard(args[0]);
+                } else if (t.backing_value or t.has_args) {
                     try fmt.formatCollection(region, fmt.ast.store.getCollectionLayout(pi), .round, AST.Pattern.Idx, fmt.ast.store.patternSlice(t.args), Formatter.formatPattern);
                 }
             },
@@ -4092,6 +4096,32 @@ test "issue 10046: empty nominal destructure lambda argument is idempotent" {
     const result = try moduleFmtsStable(std.testing.allocator, "g=|D.()|0", false);
     defer std.testing.allocator.free(result);
     try std.testing.expectEqualStrings("g = |D.()| 0\n", result);
+}
+
+test "nominal record destructure shorthand is preserved in every pattern position" {
+    const input =
+        \\sum_arg = |Point.{x,y}| x+y
+        \\sum_let = |point| {
+        \\Point.{x,y}=point
+        \\x+y
+        \\}
+        \\sum_match = |point| match point {
+        \\Point.{x,y} => x+y
+        \\}
+    ;
+    const result = try moduleFmtsStable(std.testing.allocator, input, false);
+    defer std.testing.allocator.free(result);
+
+    const expected =
+        "sum_arg = |Point.{ x, y }| x + y\n\n" ++
+        "sum_let = |point| {\n" ++
+        "\tPoint.{ x, y } = point\n" ++
+        "\tx + y\n" ++
+        "}\n\n" ++
+        "sum_match = |point| match point {\n" ++
+        "\tPoint.{ x, y } => x + y\n" ++
+        "}\n";
+    try std.testing.expectEqualStrings(expected, result);
 }
 
 test "issue 9940: comments in empty collections and blocks are preserved" {

--- a/src/parse/AST.zig
+++ b/src/parse/AST.zig
@@ -1306,6 +1306,10 @@ pub const Pattern = union(enum) {
         /// nominal type and `args` is the backing pattern. False for ordinary
         /// tag patterns like `Tag(args)` / `Module.Tag`.
         backing_value: bool = false,
+        /// True when a nominal record destructure uses the record shorthand
+        /// `Type.{ fields }` instead of the general `Type.({ fields })` form.
+        /// This implies `backing_value` and exactly one record pattern in `args`.
+        record_shorthand: bool = false,
         region: TokenizedRegion,
     },
     int: struct {

--- a/src/parse/NodeStore.zig
+++ b/src/parse/NodeStore.zig
@@ -738,12 +738,14 @@ pub fn addPattern(store: *NodeStore, pattern: AST.Pattern) std.mem.Allocator.Err
             node.main_token = i.ident_tok;
         },
         .tag => |t| {
+            std.debug.assert(!t.record_shorthand or (t.backing_value and t.args.span.len == 1));
             const data_start = @as(u32, @intCast(store.extra_data.items.len));
             try store.extra_data.append(store.gpa, t.args.span.len);
             try store.extra_data.append(store.gpa, t.qualifiers.span.start);
             try store.extra_data.append(store.gpa, t.qualifiers.span.len);
             try store.extra_data.append(store.gpa, @intFromBool(t.backing_value));
             try store.extra_data.append(store.gpa, @intFromBool(t.has_args));
+            try store.extra_data.append(store.gpa, @intFromBool(t.record_shorthand));
 
             node.tag = .tag_patt;
             node.region = t.region;
@@ -1788,6 +1790,7 @@ pub fn getPattern(store: *const NodeStore, pattern_idx: AST.Pattern.Idx) AST.Pat
             const qualifiers_len = store.extra_data.items[ed_start + 2];
             const backing_value = store.extra_data.items[ed_start + 3] != 0;
             const has_args = store.extra_data.items[ed_start + 4] != 0;
+            const record_shorthand = store.extra_data.items[ed_start + 5] != 0;
 
             return .{ .tag = .{
                 .tag_tok = node.main_token,
@@ -1801,6 +1804,7 @@ pub fn getPattern(store: *const NodeStore, pattern_idx: AST.Pattern.Idx) AST.Pat
                 } },
                 .backing_value = backing_value,
                 .has_args = has_args,
+                .record_shorthand = record_shorthand,
                 .region = node.region,
             } };
         },

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -212,14 +212,17 @@ fn looksLikeTagOrNominalDestructure(self: *Parser) bool {
         lookahead += 1;
     }
 
-    // After the (optional) qualifier chain, accept either the applied-tag form
-    // `Tag(args) =` (qualifiers then `(`) or the nominal-value destructure
-    // `Type.(pattern) =` (qualifiers then `.(`). Both then share the same scan
-    // to the matching `)` followed by `=`.
+    // After the (optional) qualifier chain, accept the applied-tag form
+    // `Tag(args) =`, the general nominal-value destructure `Type.(pattern) =`,
+    // or the nominal-record shorthand `Type.{ fields } =`.
+    var expected_close = Token.Tag.CloseRound;
     if (self.peekN(lookahead) == .NoSpaceOpenRound) {
         lookahead += 1;
     } else if (self.peekN(lookahead) == .Dot and self.peekN(lookahead + 1) == .NoSpaceOpenRound) {
         lookahead += 2;
+    } else if (self.peekN(lookahead) == .Dot and self.peekN(lookahead + 1) == .OpenCurly) {
+        lookahead += 2;
+        expected_close = .CloseCurly;
     } else {
         return false;
     }
@@ -240,7 +243,7 @@ fn looksLikeTagOrNominalDestructure(self: *Parser) bool {
         lookahead += 1;
     }
 
-    if (closing_tok != .CloseRound) {
+    if (closing_tok != expected_close) {
         return false;
     }
 
@@ -2063,6 +2066,8 @@ const PatternTagArgsState = struct {
     /// True when parsing `Type.(pattern)` nominal-value destructuring args,
     /// false for ordinary `Tag(args)` application args.
     backing_value: bool = false,
+    /// True for the single-record-pattern shorthand `Type.{ fields }`.
+    record_shorthand: bool = false,
 };
 
 const PatternListState = struct {
@@ -5798,6 +5803,28 @@ fn runExprStatementKernel(
                         };
                         continue :expr_kernel .pattern_tag_args_next;
                     }
+                    if (self.peek() == .Dot and self.peekN(1) == .OpenCurly) {
+                        // `Type.{ fields }` is record-specific shorthand for the
+                        // general nominal destructure `Type.({ fields })`.
+                        self.advance(); // `.`
+                        const record_start = self.pos;
+                        self.advance(); // `{`
+                        pattern_tag_args_state = .{
+                            .start = start,
+                            .final_token = qual_result.final_token,
+                            .qualifiers = qual_result.qualifiers,
+                            .scratch_top = self.store.scratchPatternTop(),
+                            .backing_value = true,
+                            .record_shorthand = true,
+                        };
+                        try open_syntax.pushPattern(open_allocator, .pattern_tag_args, PatternTagArgsState, pattern_tag_args_state);
+                        pattern_record_state = .{
+                            .start = record_start,
+                            .scratch_top = self.store.scratchPatternRecordFieldTop(),
+                            .alternatives = pattern_alternatives,
+                        };
+                        continue :expr_kernel .pattern_record_next;
+                    }
                     last_pattern = try self.store.addPattern(.{ .tag = .{
                         .region = .{ .start = start, .end = self.pos },
                         .args = .{ .span = .{ .start = 0, .len = 0 } },
@@ -6042,6 +6069,19 @@ fn runExprStatementKernel(
                         pattern_tag_args_state = open_syntax.popPatternPayload(.pattern_tag_args, PatternTagArgsState);
                         last_pattern = null;
                         try self.store.addScratchPattern(completed);
+                        if (pattern_tag_args_state.record_shorthand) {
+                            const args = try self.store.patternSpanFrom(pattern_tag_args_state.scratch_top);
+                            last_pattern = try self.store.addPattern(.{ .tag = .{
+                                .region = .{ .start = pattern_tag_args_state.start, .end = self.pos },
+                                .args = args,
+                                .tag_tok = pattern_tag_args_state.final_token,
+                                .qualifiers = pattern_tag_args_state.qualifiers,
+                                .has_args = true,
+                                .backing_value = true,
+                                .record_shorthand = true,
+                            } });
+                            continue :expr_kernel .pattern_complete;
+                        }
                         if (self.peek() == .Comma or self.peek() == .CloseRound) {
                             if (self.peek() == .Comma) {
                                 self.advance();

--- a/test/snapshots/nominal_destructure_record_decl.md
+++ b/test/snapshots/nominal_destructure_record_decl.md
@@ -1,0 +1,157 @@
+# META
+~~~ini
+description=Nominal-value destructuring (Type.(pat)) on the LHS of a = definition
+type=snippet
+~~~
+# SOURCE
+~~~roc
+Distance := { x : U64 }
+
+double : Distance -> U64
+double = |d| {
+		Distance.({x}) = d
+    x * 2
+}
+
+Distance.{x} = Distance.{ x : 10 }
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+
+┌────────────────────────────────────┐
+│ TYPE APPLICATION NEEDS PARENTHESES ├─ I was parsing a type annotation, ─────┐
+└┬───────────────────────────────────┘  and I found a type argument without   │
+ │                                      parentheses.                          │
+ │                                                                            │
+ │  Distance.{x} = Distance.{ x : 10 }                                        │
+ │          ‾                                                                 │
+ └──────────────────────────────────── nominal_destructure_record_decl.md:9:9 ┘
+
+    Roc type applications use parentheses around their arguments. Write
+    `List(U8)`, not `List U8`.
+
+    For example:
+        List(U8)
+
+    I found `.` here.
+
+# TOKENS
+~~~zig
+UpperIdent,OpColonEqual,OpenCurly,LowerIdent,OpColon,UpperIdent,CloseCurly,
+LowerIdent,OpColon,UpperIdent,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,OpenCurly,
+UpperIdent,Dot,NoSpaceOpenRound,OpenCurly,LowerIdent,CloseCurly,CloseRound,OpAssign,LowerIdent,
+LowerIdent,OpStar,Int,
+CloseCurly,
+UpperIdent,Dot,OpenCurly,LowerIdent,CloseCurly,OpAssign,UpperIdent,Dot,OpenCurly,LowerIdent,OpColon,Int,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-type-decl
+			(header (name "Distance")
+				(args))
+			(ty-record
+				(anno-record-field (name "x")
+					(ty (name "U64")))))
+		(s-type-anno (name "double")
+			(ty-fn
+				(ty (name "Distance"))
+				(ty (name "U64"))))
+		(s-decl
+			(p-ident (raw "double"))
+			(e-lambda
+				(args
+					(p-ident (raw "d")))
+				(e-block
+					(statements
+						(s-decl
+							(p-tag (raw "Distance")
+								(p-record
+									(field (name "x") (rest false))))
+							(e-ident (raw "d")))
+						(e-binop (op "*")
+							(e-ident (raw "x"))
+							(e-int (raw "2")))))))
+		(s-malformed (tag "expected_colon_after_type_annotation"))
+		(s-decl
+			(p-record
+				(field (name "x") (rest false)))
+			(e-nominal-record
+				(mapper (e-tag (raw "Distance")))
+				(backing (e-record
+						(field (field "x")
+							(e-int (raw "10")))))))))
+~~~
+# FORMATTED
+~~~roc
+Distance := { x : U64 }
+
+double : Distance -> U64
+double = |d| {
+	Distance.({ x }) = d
+	x * 2
+}
+{ x } = Distance.{ x: 10 }
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "double"))
+		(e-lambda
+			(args
+				(p-assign (ident "d")))
+			(e-block
+				(s-let
+					(p-nominal
+						(p-record-destructure
+							(destructs
+								(record-destruct (label "x") (ident "x")
+									(required
+										(p-assign (ident "x")))))))
+					(e-lookup-local
+						(p-assign (ident "d"))))
+				(e-dispatch-call (method "times") (constraint-fn-var 224)
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "x"))))
+					(args
+						(e-num (value "2"))))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-lookup (name "Distance") (local))
+				(ty-lookup (name "U64") (builtin)))))
+	(d-let
+		(p-record-destructure
+			(destructs
+				(record-destruct (label "x") (ident "x")
+					(required
+						(p-assign (ident "x"))))))
+		(e-nominal (nominal "Distance")
+			(e-record
+				(fields
+					(field (name "x")
+						(e-num (value "10")))))))
+	(s-nominal-decl
+		(ty-header (name "Distance"))
+		(ty-record
+			(field (field "x")
+				(ty-lookup (name "U64") (builtin))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Distance -> U64")))
+	(type_decls
+		(nominal (type "Distance")
+			(ty-header (name "Distance"))))
+	(expressions
+		(expr (type "Distance -> U64"))
+		(expr (type "Distance"))))
+~~~

--- a/test/snapshots/nominal_destructure_record_decl.md
+++ b/test/snapshots/nominal_destructure_record_decl.md
@@ -1,6 +1,6 @@
 # META
 ~~~ini
-description=Nominal-value destructuring (Type.(pat)) on the LHS of a = definition
+description=Nominal-record shorthand destructuring (Type.{ fields }) on the LHS of a = definition
 type=snippet
 ~~~
 # SOURCE
@@ -18,24 +18,7 @@ Distance.{x} = Distance.{ x : 10 }
 # EXPECTED
 NIL
 # PROBLEMS
-
-┌────────────────────────────────────┐
-│ TYPE APPLICATION NEEDS PARENTHESES ├─ I was parsing a type annotation, ─────┐
-└┬───────────────────────────────────┘  and I found a type argument without   │
- │                                      parentheses.                          │
- │                                                                            │
- │  Distance.{x} = Distance.{ x : 10 }                                        │
- │          ‾                                                                 │
- └──────────────────────────────────── nominal_destructure_record_decl.md:9:9 ┘
-
-    Roc type applications use parentheses around their arguments. Write
-    `List(U8)`, not `List U8`.
-
-    For example:
-        List(U8)
-
-    I found `.` here.
-
+NIL
 # TOKENS
 ~~~zig
 UpperIdent,OpColonEqual,OpenCurly,LowerIdent,OpColon,UpperIdent,CloseCurly,
@@ -77,10 +60,10 @@ EndOfFile,
 						(e-binop (op "*")
 							(e-ident (raw "x"))
 							(e-int (raw "2")))))))
-		(s-malformed (tag "expected_colon_after_type_annotation"))
 		(s-decl
-			(p-record
-				(field (name "x") (rest false)))
+			(p-tag (raw "Distance")
+				(p-record
+					(field (name "x") (rest false))))
 			(e-nominal-record
 				(mapper (e-tag (raw "Distance")))
 				(backing (e-record
@@ -96,7 +79,8 @@ double = |d| {
 	Distance.({ x }) = d
 	x * 2
 }
-{ x } = Distance.{ x: 10 }
+
+Distance.{ x } = Distance.{ x: 10 }
 ~~~
 # CANONICALIZE
 ~~~clojure
@@ -116,7 +100,7 @@ double = |d| {
 										(p-assign (ident "x")))))))
 					(e-lookup-local
 						(p-assign (ident "d"))))
-				(e-dispatch-call (method "times") (constraint-fn-var 224)
+				(e-dispatch-call (method "times") (constraint-fn-var 225)
 					(receiver
 						(e-lookup-local
 							(p-assign (ident "x"))))
@@ -127,11 +111,12 @@ double = |d| {
 				(ty-lookup (name "Distance") (local))
 				(ty-lookup (name "U64") (builtin)))))
 	(d-let
-		(p-record-destructure
-			(destructs
-				(record-destruct (label "x") (ident "x")
-					(required
-						(p-assign (ident "x"))))))
+		(p-nominal
+			(p-record-destructure
+				(destructs
+					(record-destruct (label "x") (ident "x")
+						(required
+							(p-assign (ident "x")))))))
 		(e-nominal (nominal "Distance")
 			(e-record
 				(fields


### PR DESCRIPTION
Fixes https://roc.zulipchat.com/#narrow/channel/463736-bugs/topic/Annotation.20dependent.20inference.20when.20destructuring.20opaque/with/611343898

Allows destructuring of nominal records, like:
```python
my_fn : Stack -> U64
my_fn = |Stack.{x}| x
```