### PR TITLE
Fix Nix bootstrap deps and Node action warnings

### DIFF
--- a/.github/workflows/basic_cli_build_release.yml
+++ b/.github/workflows/basic_cli_build_release.yml
@@ -43,7 +43,7 @@ jobs:
       - run: curl -fOL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-macos_apple_silicon-latest.tar.gz
 
       - name: Save roc_nightly archives
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           path: roc_nightly-*
 
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - name: build basic-cli with surgical linker and also with legacy linker
         env:
@@ -62,7 +62,7 @@ jobs:
         run: ./ci/build_basic_cli.sh linux_x86_64
 
       - name: Save .rh, .rm and .a file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: linux-x86_64-files
           path: |
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - name: build basic-cli
         env:
@@ -89,7 +89,7 @@ jobs:
         run: ./ci/build_basic_cli.sh linux_arm64
 
       - name: Save .a file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: linux-arm64-files
           path: |
@@ -102,12 +102,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - run: ./ci/build_basic_cli.sh macos_x86_64
 
       - name: Save .a file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: macos-x86_64-files
           path: |
@@ -121,12 +121,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - run: ./ci/build_basic_cli.sh macos_apple_silicon
 
       - name: Save macos-arm64.a file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: macos-apple-silicon-files
           path: |
@@ -149,7 +149,7 @@ jobs:
         run: ls | grep -v  ci | xargs rm -rf
 
       - name: Download the previously uploaded files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - name: mv roc nightly and simplify name
         run: mv $(ls -d artifact/* | grep "roc_nightly.*tar\.gz" | grep "linux_x86_64") ./roc_nightly.tar.gz
@@ -190,14 +190,14 @@ jobs:
       - run: echo "TAR_FILENAME=$(ls -d basic-cli/platform/* | grep ${{ env.ARCHIVE_FORMAT }})" >> $GITHUB_ENV
 
       - name: Upload platform archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: basic-cli-platform
           path: |
             ${{ env.TAR_FILENAME }}
 
       - name: Upload docs archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: release-assets-docs
           path: |
@@ -211,7 +211,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Download the previously uploaded files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - name: Set OS-specific variables
         id: vars

--- a/.github/workflows/basic_webserver_build_release.yml
+++ b/.github/workflows/basic_webserver_build_release.yml
@@ -28,7 +28,7 @@ jobs:
       - run: curl -fOL https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-macos_apple_silicon-latest.tar.gz
 
       - name: Save roc_nightly archives
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           path: roc_nightly-*
 
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - name: build basic-webserver with legacy linker
         env:
@@ -47,7 +47,7 @@ jobs:
         run: ./ci/build_basic_webserver.sh linux_x86_64
 
       - name: Save .rh, .rm and .a file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: linux-x86_64-files
           path: |
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - name: build basic-webserver
         env:
@@ -70,7 +70,7 @@ jobs:
         run: ./ci/build_basic_webserver.sh linux_arm64
 
       - name: Save .a file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: linux-arm64-files
           path: |
@@ -83,12 +83,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - run: ./ci/build_basic_webserver.sh macos_x86_64
 
       - name: Save .a files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: macos-x86_64-files
           path: |
@@ -102,12 +102,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Download the previously uploaded roc_nightly archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - run: ./ci/build_basic_webserver.sh macos_apple_silicon
 
       - name: Save macos-arm64.a file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: macos-apple-silicon-files
           path: |
@@ -130,7 +130,7 @@ jobs:
         run: ls | grep -v  ci | xargs rm -rf
 
       - name: Download the previously uploaded files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - name: mv roc nightly and simplify name
         run: mv $(ls -d artifact/* | grep "roc_nightly.*tar\.gz" | grep "linux_x86_64") ./roc_nightly.tar.gz
@@ -163,7 +163,7 @@ jobs:
       - run: echo "TAR_FILENAME=$(ls -d basic-webserver/platform/* | grep ${{ env.ARCHIVE_FORMAT }})" >> $GITHUB_ENV
 
       - name: Upload platform archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: basic-webserver-platform
           path: |
@@ -177,7 +177,7 @@ jobs:
           tar -czvf docs.tar.gz generated-docs/
 
       - name: Upload docs archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: release-assets-docs
           path: |
@@ -191,7 +191,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Download the previously uploaded files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
 
       - name: Set OS-specific variables
         id: vars

--- a/.github/workflows/ci_cross_compile.yml
+++ b/.github/workflows/ci_cross_compile.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
+      - uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # ratchet:xyzzylabs/setup-zig@v1.0.2
         with:
           version: 0.16.0
           use-cache: true
 
       - name: Cache Zig dependency packages
-        uses: actions/cache@v4 # ratchet:actions/cache@v4
+        uses: actions/cache@v6.1.0 # ratchet:actions/cache@v6.1.0
         with:
           # See ci_zig.yml: cache Zig's fetched-package subdir under a stable
           # build.zig.zon key so a cold runner doesn't re-download deps and hit
@@ -45,7 +45,7 @@ jobs:
 
       - name: Setup MSVC (Windows)
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # ratchet:ilammy/msvc-dev-cmd@v1.13.0
+        uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c  # ratchet:TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
           arch: x64
 
@@ -81,7 +81,7 @@ jobs:
           zig-out\bin\roc.exe build --target=${{ matrix.target }} --output=int_app_${{ matrix.target }}_${{ matrix.host }} test/int/app.roc
 
       - name: Upload cross-compiled int app executables
-        uses: actions/upload-artifact@v4 # ratchet:actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1 # ratchet:actions/upload-artifact@v7.0.1
         with:
           name: cross-compiled-${{ matrix.host }}-${{ matrix.target }}
           path: |
@@ -106,7 +106,7 @@ jobs:
             arch: arm64
     steps:
       - name: Download all cross-compiled artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: cross-compiled-*-${{ matrix.target }}
           merge-multiple: true

--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
 
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
+      - uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # ratchet:xyzzylabs/setup-zig@v1.0.2
         with:
           version: 0.16.0
           use-cache: true
@@ -132,14 +132,14 @@ jobs:
         run: rustup target add x86_64-unknown-linux-musl
 
       - name: Cache Zig dependency packages
-        uses: actions/cache@v4 # ratchet:actions/cache@v4
+        uses: actions/cache@v6.1.0 # ratchet:actions/cache@v6.1.0
         with:
           # Zig stores fetched packages in the `p/` subdir of the global cache.
           # Caching just that under a stable build.zig.zon-hash key keeps deps
           # present across runs: it is read every run, so it stays warm and is
-          # not evicted by mlugg's churnier per-run cache. A cold runner then no
+          # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while mlugg's own cache still handles build artifacts for speed.
+          # while the setup action's own cache still handles build artifacts for speed.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
@@ -150,7 +150,7 @@ jobs:
       # run-test-cli / run-test-dylib / run-test-archive inside minici).
       - name: Setup MSVC (Windows)
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # ratchet:ilammy/msvc-dev-cmd@v1.13.0
+        uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c # ratchet:TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
           arch: x64
 
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload MiniCI report and logs
         if: failure()
-        uses: actions/upload-artifact@v4 # ratchet:actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1 # ratchet:actions/upload-artifact@v7.0.1
         with:
           name: minici-${{ matrix.os }}
           path: zig-out/minici/

--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -37,20 +37,20 @@ jobs:
             exit 1
           fi
 
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
+      - uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # ratchet:xyzzylabs/setup-zig@v1.0.2
         with:
           version: 0.16.0
           use-cache: true
 
       - name: Cache Zig dependency packages
-        uses: actions/cache@v4 # ratchet:actions/cache@v4
+        uses: actions/cache@v6.1.0 # ratchet:actions/cache@v6.1.0
         with:
           # Zig stores fetched packages in the `p/` subdir of the global cache.
           # Caching just that under a stable build.zig.zon-hash key keeps deps
           # present across runs: it is read every run, so it stays warm and is
-          # not evicted by mlugg's churnier per-run cache. A cold runner then no
+          # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while mlugg's own cache still handles build artifacts for speed.
+          # while the setup action's own cache still handles build artifacts for speed.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
@@ -205,20 +205,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
+      - uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # ratchet:xyzzylabs/setup-zig@v1.0.2
         with:
           version: 0.16.0
           use-cache: true
 
       - name: Cache Zig dependency packages
-        uses: actions/cache@v4 # ratchet:actions/cache@v4
+        uses: actions/cache@v6.1.0 # ratchet:actions/cache@v6.1.0
         with:
           # Zig stores fetched packages in the `p/` subdir of the global cache.
           # Caching just that under a stable build.zig.zon-hash key keeps deps
           # present across runs: it is read every run, so it stays warm and is
-          # not evicted by mlugg's churnier per-run cache. A cold runner then no
+          # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while mlugg's own cache still handles build artifacts for speed.
+          # while the setup action's own cache still handles build artifacts for speed.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
@@ -228,7 +228,7 @@ jobs:
       # linker locates the Windows SDK/MSVC libpaths at runtime.
       - name: Setup MSVC (Windows)
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # ratchet:ilammy/msvc-dev-cmd@v1.13.0
+        uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c # ratchet:TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
           arch: x64
 
@@ -306,7 +306,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
+      - uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # ratchet:xyzzylabs/setup-zig@v1.0.2
         with:
           version: 0.16.0
           use-cache: true
@@ -323,14 +323,14 @@ jobs:
         run: rustup target add ${{ runner.arch == 'ARM64' && 'aarch64-unknown-linux-musl' || 'x86_64-unknown-linux-musl' }}
 
       - name: Cache Zig dependency packages
-        uses: actions/cache@v4 # ratchet:actions/cache@v4
+        uses: actions/cache@v6.1.0 # ratchet:actions/cache@v6.1.0
         with:
           # Zig stores fetched packages in the `p/` subdir of the global cache.
           # Caching just that under a stable build.zig.zon-hash key keeps deps
           # present across runs: it is read every run, so it stays warm and is
-          # not evicted by mlugg's churnier per-run cache. A cold runner then no
+          # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while mlugg's own cache still handles build artifacts for speed.
+          # while the setup action's own cache still handles build artifacts for speed.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
@@ -354,7 +354,7 @@ jobs:
 
       - name: Setup MSVC (Windows)
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # ratchet:ilammy/msvc-dev-cmd@v1.13.0
+        uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c # ratchet:TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
           arch: ${{ matrix.os == 'windows-11-arm' && 'arm64' || 'x64' }}
 
@@ -449,20 +449,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
+      - uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # ratchet:xyzzylabs/setup-zig@v1.0.2
         with:
           version: 0.16.0
           use-cache: true
 
       - name: Cache Zig dependency packages
-        uses: actions/cache@v4 # ratchet:actions/cache@v4
+        uses: actions/cache@v6.1.0 # ratchet:actions/cache@v6.1.0
         with:
           # Zig stores fetched packages in the `p/` subdir of the global cache.
           # Caching just that under a stable build.zig.zon-hash key keeps deps
           # present across runs: it is read every run, so it stays warm and is
-          # not evicted by mlugg's churnier per-run cache. A cold runner then no
+          # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while mlugg's own cache still handles build artifacts for speed.
+          # while the setup action's own cache still handles build artifacts for speed.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
@@ -508,20 +508,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
+      - uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # ratchet:xyzzylabs/setup-zig@v1.0.2
         with:
           version: 0.16.0
           use-cache: true
 
       - name: Cache Zig dependency packages
-        uses: actions/cache@v4 # ratchet:actions/cache@v4
+        uses: actions/cache@v6.1.0 # ratchet:actions/cache@v6.1.0
         with:
           # Zig stores fetched packages in the `p/` subdir of the global cache.
           # Caching just that under a stable build.zig.zon-hash key keeps deps
           # present across runs: it is read every run, so it stays warm and is
-          # not evicted by mlugg's churnier per-run cache. A cold runner then no
+          # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while mlugg's own cache still handles build artifacts for speed.
+          # while the setup action's own cache still handles build artifacts for speed.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |

--- a/.github/workflows/ci_zig_nix.yml
+++ b/.github/workflows/ci_zig_nix.yml
@@ -28,14 +28,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
 
-      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
+      - uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1 # ratchet:xyzzylabs/setup-zig@v1.0.2
         with:
           version: 0.16.0
           use-cache: true
 
       - name: Restore Zig dependency packages
         id: zig-deps-cache
-        uses: actions/cache/restore@v4 # ratchet:actions/cache/restore@v4
+        uses: actions/cache/restore@v6.1.0 # ratchet:actions/cache/restore@v6.1.0
         with:
           # Keep this key and path in sync with ci_zig.yml. The daily Nightly
           # Gate run executes this workflow on main, so new PRs can restore
@@ -73,7 +73,7 @@ jobs:
 
       - name: Save Zig dependency packages
         if: always() && steps.zig-deps-cache.outputs.cache-hit != 'true' && steps.zig-deps-cache-contents.outputs.present == 'true'
-        uses: actions/cache/save@v4 # ratchet:actions/cache/save@v4
+        uses: actions/cache/save@v6.1.0 # ratchet:actions/cache/save@v6.1.0
         with:
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
@@ -83,6 +83,7 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: |
+            set -euo pipefail
             nix build ./src#roc
             result/bin/roc check CONTRIBUTING/profiling/bench_repeated_check.roc
           error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"

--- a/.github/workflows/nightly_gate.yml
+++ b/.github/workflows/nightly_gate.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Notify maintainers on Zulip
-        uses: zulip/github-actions-zulip/send-message@v1
+        uses: zulip/github-actions-zulip/send-message@f675f2b4eb2a95fae974215476dcb7ad8dfeff6b # ratchet:zulip/github-actions-zulip@v2.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY_ISSUE_BOT }}
           email: "high-priority-issues-bot@roc.zulipchat.com"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # ratchet:actions/stale@v10.4.0
         with:
           delete-branch: true
           exempt-pr-labels: 'blocked'

--- a/.github/workflows/zulip_bot_high_p_issues.yml
+++ b/.github/workflows/zulip_bot_high_p_issues.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.label.name == 'P-high'
     steps:
       - name: Send a stream message
-        uses: zulip/github-actions-zulip/send-message@v1
+        uses: zulip/github-actions-zulip/send-message@f675f2b4eb2a95fae974215476dcb7ad8dfeff6b # ratchet:zulip/github-actions-zulip@v2.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY_ISSUE_BOT }}
           email: "high-priority-issues-bot@roc.zulipchat.com"

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -69,67 +69,67 @@ linkFarm name (map unpackZig [
     };
   }
   {
-    name = "N-V-__8AAEvEEA9B1q8qGkm3rJW_bkae4wn1SvyrfDa0w1lp.tar.gz";
+    name = "N-V-__8AAKS-VRH7JXsaDHpnFPSd-B5fSdtnDbh0XrfnncWc.tar.gz";
     path = fetchZig {
       name = "roc_deps_aarch64_macos_none";
-      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0/aarch64-macos-none.tar.xz";
-      hash = "sha256-MiACPvTNxHcXnI2q45kRlpldDm21t270ng1z9ewnhfc=";
+      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0-binaryen/aarch64-macos-none.tar.xz";
+      hash = "sha256-PHSLa/8IAE0rqFVJGqt0NAQxAfcPy8QciTutttiqCTo=";
     };
   }
   {
-    name = "N-V-__8AAHPjwBNV6lTtxPO6DYe4lg2Gx5Qakmeg1PO7N5k7.tar.gz";
+    name = "N-V-__8AACK4KheKSiltX0PPURTNh0CvJhsopNXzcXpvq9pS.tar.gz";
     path = fetchZig {
       name = "roc_deps_aarch64_linux_musl";
-      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0/aarch64-linux-musl.tar.xz";
-      hash = "sha256-f3U0foiuXE+9p/cg9WEb7fCMEXBAE+Cae745eRQJLJY=";
+      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0-binaryen/aarch64-linux-musl.tar.xz";
+      hash = "sha256-fQOa0r5EVMenjRH2LhUYN6BKeMKtO5yDRVgOO0+ktIs=";
     };
   }
   {
-    name = "N-V-__8AAI4OFxV11RN1xAhLXxLTyaxZh3Wbi4U1Dza1OESo.tar.gz";
+    name = "N-V-__8AAPEjNhjVXuc6-b70fcyHFGS_ckUIx5_ICD3-3HZk.tar.gz";
     path = fetchZig {
       name = "roc_deps_aarch64_windows_gnu";
-      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0/aarch64-windows-gnu.zip";
-      hash = "sha256-UAZPFs8MfyoOP3NFBWMwbugpMqq18NSN3ztuh773os0=";
+      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0-binaryen/aarch64-windows-gnu.zip";
+      hash = "sha256-Pb22bvfTgAgMIShfDxejvvVFE9TBLjGAnzNxt1WlD/c=";
     };
   }
   {
-    name = "N-V-__8AAHU1FhRO-2yZIDQWw5rkVVuUYn5purRT9mAqykzw.tar.gz";
+    name = "N-V-__8AAKywPxfY01H2OMTuZllxIuavfyGGm3kpW7-1RmkP.tar.gz";
     path = fetchZig {
       name = "roc_deps_arm_linux_musleabihf";
-      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0/arm-linux-musleabihf.tar.xz";
-      hash = "sha256-oSxJwhRlKIzYLUm21JZSoySaf7pxWjO5/87D8HxlJSU=";
+      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0-binaryen/arm-linux-musleabihf.tar.xz";
+      hash = "sha256-OEvSYrTtt3sroPN2jxcZw7Oqolb6jHeKY7z+7CgnaWs=";
     };
   }
   {
-    name = "N-V-__8AACNk7BFESU37UNPvVOXf2dGyPMjtDSsji-VYqvmz.tar.gz";
+    name = "N-V-__8AAMg8ihSrg9Udc8ZJ1trVVUgglxJg8CbHoYG51dZq.tar.gz";
     path = fetchZig {
       name = "roc_deps_x86_linux_musl";
-      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0/x86-linux-musl.tar.xz";
-      hash = "sha256-wliAwsrhsON2/GNf5gqnnXPs53B0YBYMGaaJQJ93I2w=";
+      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0-binaryen/x86-linux-musl.tar.xz";
+      hash = "sha256-9jCTSnMCLmEUbqPX+iDQ/KR+04jy6JlX9jb7fPCgQI4=";
     };
   }
   {
-    name = "N-V-__8AAJmm4xTmXSEZeLYLtOlZWKI_Kitjx2TOzm9vhCWM.tar.gz";
+    name = "N-V-__8AAGJLMhhn8pu3uyxtKTIlha8CxCjE6TNpLYvvj-cz.tar.gz";
     path = fetchZig {
       name = "roc_deps_x86_64_linux_musl";
-      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0/x86_64-linux-musl.tar.xz";
-      hash = "sha256-LjMD6jfUOP1UKvPYSYKlTN01Q5iHYBA0bS4hnFADJdo=";
+      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0-binaryen/x86_64-linux-musl.tar.xz";
+      hash = "sha256-f7zDjI+VYBAkiBGVRNbSn6FI+2W7zpeoUa1ZuEFibwA=";
     };
   }
   {
-    name = "N-V-__8AAJGgsQ-GR2yR2tLFM4OM0z7ClQ0Rx7SjviQbx8Ks.tar.gz";
+    name = "N-V-__8AAJrG0hG7ZWMT8yxRBa17ivn77bWqDpseO904PYT7.tar.gz";
     path = fetchZig {
       name = "roc_deps_x86_64_macos_none";
-      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0/x86_64-macos-none.tar.xz";
-      hash = "sha256-2Bqk1Xg+1niHcKzxpNl3Cr+ThXeSD5xE1lTzRkrpuDM=";
+      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0-binaryen/x86_64-macos-none.tar.xz";
+      hash = "sha256-quDJkY/ts7Z7UDrqxOxa+DV4AIfidbO6rZRIHRt3sFQ=";
     };
   }
   {
-    name = "N-V-__8AAJAOJxiRcaWQZpXytjyF8_Q7Mj9g7xXQWtegD-6C.tar.gz";
+    name = "N-V-__8AADfFZhvsrNly3AbA2PmVP9piXKNto_CmeqLuNNsd.tar.gz";
     path = fetchZig {
       name = "roc_deps_x86_64_windows_gnu";
-      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0/x86_64-windows-gnu.zip";
-      hash = "sha256-8jPIAh01og2FZ8DUAor0hHZ3EDWWIhbXa0X1+CvQG0s=";
+      url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0-binaryen/x86_64-windows-gnu.zip";
+      hash = "sha256-aWM3aagVe0qgTtHmcpFKniaqVTdsVJwneDfTtcDVWgE=";
     };
   }
   {


### PR DESCRIPTION
Nightly Gate failed because the generated Nix package manifest still pointed at the old `zig-0.16.0` Roc bootstrap bundles while `build.zig.zon` now uses the `zig-0.16.0-binaryen` bundles. This updates `build.zig.zon.nix` to match the current dependency hashes, makes the Nix package check stop immediately when `nix build` fails, and moves GitHub workflow actions to Node 24-capable versions so the deprecation annotations go away.