### PR TITLE
Walk JSON strings and scalars in place instead of materializing byte lists

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -58,6 +58,8 @@ const strContains = builtins.str.strContains;
 const strStartsWith = builtins.str.startsWith;
 const strEndsWith = builtins.str.endsWith;
 const strCountUtf8Bytes = builtins.str.countUtf8Bytes;
+const strGetUtf8ByteUnsafe = builtins.str.getUnsafeC;
+const strSubstringUnsafe = builtins.str.substringUnsafeC;
 const strCaselessAsciiEquals = builtins.str.strCaselessAsciiEquals;
 const strEqual = builtins.str.strEqual;
 const strEqualStaticSmall = builtins.str.strEqualStaticSmall;
@@ -210,6 +212,8 @@ pub const BuiltinFn = enum {
     str_static_small_word_eq,
     str_static_small_word_caseless_eq,
     str_count_utf8_bytes,
+    str_get_utf8_byte_unsafe,
+    str_substring_unsafe,
     str_find_first,
     str_drop_prefix_caseless_ascii,
     str_caseless_ascii_equals,
@@ -366,6 +370,8 @@ pub const BuiltinFn = enum {
             .str_static_small_word_eq => "roc_builtins_str_static_small_word_eq",
             .str_static_small_word_caseless_eq => "roc_builtins_str_static_small_word_caseless_eq",
             .str_count_utf8_bytes => "roc_builtins_str_count_utf8_bytes",
+            .str_get_utf8_byte_unsafe => "roc_builtins_str_get_utf8_byte_unsafe",
+            .str_substring_unsafe => "roc_builtins_str_substring_unsafe",
             .str_find_first => "roc_builtins_str_find_first",
             .str_drop_prefix_caseless_ascii => "roc_builtins_str_drop_prefix_caseless_ascii",
             .str_caseless_ascii_equals => "roc_builtins_str_caseless_ascii_equals",
@@ -603,6 +609,16 @@ fn wrapStrStaticSmallWordCaselessEq(a_bytes: ?[*]u8, a_len: usize, a_cap: usize,
 fn wrapStrCountUtf8Bytes(str_bytes: ?[*]u8, str_len: usize, str_cap: usize) callconv(.c) u64 {
     const s = RocStr{ .bytes = str_bytes, .length = str_len, .capacity_or_alloc_ptr = str_cap };
     return strCountUtf8Bytes(s);
+}
+
+fn wrapStrGetUtf8ByteUnsafe(str_bytes: ?[*]u8, str_len: usize, str_cap: usize, index: u64) callconv(.c) u8 {
+    const s = RocStr{ .bytes = str_bytes, .length = str_len, .capacity_or_alloc_ptr = str_cap };
+    return strGetUtf8ByteUnsafe(s, index);
+}
+
+fn wrapStrSubstringUnsafe(out: *RocStr, str_bytes: ?[*]u8, str_len: usize, str_cap: usize, start: u64, length: u64, roc_ops: *RocOps) callconv(.c) void {
+    const s = RocStr{ .bytes = str_bytes, .length = str_len, .capacity_or_alloc_ptr = str_cap };
+    out.* = strSubstringUnsafe(s, start, length, roc_ops);
 }
 
 fn wrapStrFindFirst(out: *anyopaque, a_bytes: ?[*]u8, a_len: usize, a_cap: usize, b_bytes: ?[*]u8, b_len: usize, b_cap: usize, find_layout: *const dev_wrappers.StrFindFirstLayout, roc_ops: *RocOps) callconv(.c) void {
@@ -3102,6 +3118,24 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     const str_off = try self.ensureOnStack(str_loc, roc_str_size);
                     return try self.callStr1ToScalar(str_off, @intFromPtr(&wrapStrCountUtf8Bytes), .str_count_utf8_bytes);
                 },
+                .str_get_utf8_byte_unsafe => {
+                    if (args.len != 2) unreachable;
+                    const str_loc = try self.emitValueLocal(GuardedList.at(args, 0));
+                    const index_loc = try self.emitValueLocal(GuardedList.at(args, 1));
+                    const str_off = try self.ensureOnStack(str_loc, roc_str_size);
+                    const index_off = try self.ensureOnStack(index_loc, 8);
+                    return try self.callStr1U64ToByte(str_off, index_off, @intFromPtr(&wrapStrGetUtf8ByteUnsafe), .str_get_utf8_byte_unsafe);
+                },
+                .str_substring_unsafe => {
+                    if (args.len != 3) unreachable;
+                    const str_loc = try self.emitValueLocal(GuardedList.at(args, 0));
+                    const start_loc = try self.emitValueLocal(GuardedList.at(args, 1));
+                    const length_loc = try self.emitValueLocal(GuardedList.at(args, 2));
+                    const str_off = try self.ensureOnStack(str_loc, roc_str_size);
+                    const start_off = try self.ensureOnStack(start_loc, 8);
+                    const length_off = try self.ensureOnStack(length_loc, 8);
+                    return try self.callStr2U64RocOpsToStr(str_off, start_off, length_off, @intFromPtr(&wrapStrSubstringUnsafe), .str_substring_unsafe);
+                },
                 .str_find_first => {
                     if (args.len != 2) unreachable;
                     const a_loc = try self.emitValueLocal(GuardedList.at(args, 0));
@@ -5017,6 +5051,26 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             return .{ .general_reg = result_reg };
         }
 
+        fn callStr1U64ToByte(self: *Self, str_off: i32, u64_off: i32, fn_addr: usize, builtin_fn: BuiltinFn) Allocator.Error!ValueLocation {
+            var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
+            try builder.addMemArg(frame_ptr, str_off);
+            try builder.addMemArg(frame_ptr, str_off + 16);
+            try builder.addMemArg(frame_ptr, str_off + 8);
+            try builder.addMemArg(frame_ptr, u64_off);
+            try self.callBuiltin(&builder, fn_addr, builtin_fn);
+
+            const result_reg = try self.allocTempGeneral();
+            if (comptime target.toCpuArch() == .aarch64) {
+                try self.codegen.emit.movRegReg(.w64, result_reg, .X0);
+            } else {
+                try self.codegen.emit.movRegReg(.w64, result_reg, .RAX);
+            }
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.codegen.emit.andRegImm32(result_reg, 0xff);
+            }
+            return .{ .general_reg = result_reg };
+        }
+
         /// Call a C wrapper: fn(a_f0, a_f1, a_f2, b_f0, b_f1, b_f2) -> bool
         /// Used for (str, str) -> bool comparison ops (equal, contains, starts_with, etc.)
         fn callStr2ToScalar(self: *Self, a_off: i32, b_off: i32, fn_addr: usize, builtin_fn: BuiltinFn) Allocator.Error!ValueLocation {
@@ -5142,6 +5196,23 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             try builder.addMemArg(base_ptr, str_off + 8);
             try builder.addMemArg(base_ptr, u64_off);
             if (update_mode_imm) |imm| try builder.addImmArg(imm);
+            try builder.addRegArg(roc_ops_reg);
+            try self.callBuiltin(&builder, fn_addr, builtin_fn);
+
+            return .{ .stack_str = result_offset };
+        }
+
+        fn callStr2U64RocOpsToStr(self: *Self, str_off: i32, first_off: i32, second_off: i32, fn_addr: usize, builtin_fn: BuiltinFn) Allocator.Error!ValueLocation {
+            const roc_ops_reg = self.roc_ops_reg orelse unreachable;
+            const result_offset = self.codegen.allocStackSlot(roc_str_size);
+
+            var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
+            try builder.addLeaArg(frame_ptr, result_offset);
+            try builder.addMemArg(frame_ptr, str_off);
+            try builder.addMemArg(frame_ptr, str_off + 16);
+            try builder.addMemArg(frame_ptr, str_off + 8);
+            try builder.addMemArg(frame_ptr, first_off);
+            try builder.addMemArg(frame_ptr, second_off);
             try builder.addRegArg(roc_ops_reg);
             try self.callBuiltin(&builder, fn_addr, builtin_fn);
 

--- a/src/backend/dev/object_reader.zig
+++ b/src/backend/dev/object_reader.zig
@@ -835,6 +835,8 @@ fn resolveBuiltinWrapper(name: []const u8) ?usize {
         .{ .name = "incref_rc_ptr", .addr = @intFromPtr(&utils.increfRcPtrC) },
         .{ .name = "decref_rc_ptr", .addr = @intFromPtr(&utils.decrefRcPtrC) },
         .{ .name = "roc_builtins_str_to_utf8", .addr = @intFromPtr(&dev_wrappers.roc_builtins_str_to_utf8) },
+        .{ .name = "roc_builtins_str_get_utf8_byte_unsafe", .addr = @intFromPtr(&dev_wrappers.roc_builtins_str_get_utf8_byte_unsafe) },
+        .{ .name = "roc_builtins_str_substring_unsafe", .addr = @intFromPtr(&dev_wrappers.roc_builtins_str_substring_unsafe) },
         .{ .name = "roc_builtins_str_concat", .addr = @intFromPtr(&dev_wrappers.roc_builtins_str_concat) },
         .{ .name = "roc_builtins_str_contains", .addr = @intFromPtr(&dev_wrappers.roc_builtins_str_contains) },
         .{ .name = "roc_builtins_str_starts_with", .addr = @intFromPtr(&dev_wrappers.roc_builtins_str_starts_with) },

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -2848,6 +2848,8 @@ pub const MonoLlvmCodeGen = struct {
             .str_ends_with => try self.emitStrEndsWith(target, arg_locals),
             .str_caseless_ascii_equals => try self.emitStrCaselessAsciiEquals(target, arg_locals),
             .str_count_utf8_bytes => try self.emitStrCountUtf8Bytes(target, GuardedList.at(arg_locals, 0)),
+            .str_get_utf8_byte_unsafe => try self.emitStrGetUtf8ByteUnsafe(target, arg_locals),
+            .str_substring_unsafe => try self.emitStrSubstringUnsafe(target, arg_locals),
             .str_find_first => try self.emitStrFindFirst(target, arg_locals),
             .str_drop_prefix_caseless_ascii => try self.emitStrDropPrefixCaselessAscii(target, arg_locals),
             .str_concat => try self.emitStrRetBuiltin(target, "roc_builtins_str_concat", arg_locals, unique_args),
@@ -5792,6 +5794,48 @@ pub const MonoLlvmCodeGen = struct {
         else
             try self.emitRocStrLen(self.slot(arg).ptr);
         try self.storeIntToLayout(self.slot(target).ptr, result, self.localLayout(target));
+    }
+
+    fn emitStrGetUtf8ByteUnsafe(self: *MonoLlvmCodeGen, target: LocalId, args: anytype) Error!void {
+        var call_args = try self.rocStrArgs1(GuardedList.at(args, 0));
+        defer call_args.deinit(self.allocator);
+        const index = try self.coerceScalar(
+            try self.loadScalar(self.slot(GuardedList.at(args, 1)).ptr, self.localLayout(GuardedList.at(args, 1))),
+            .i64,
+            false,
+        );
+        try call_args.append(self.allocator, .i64, index);
+        const result = try self.callBuiltin(
+            "roc_builtins_str_get_utf8_byte_unsafe",
+            .i8,
+            call_args.types.items,
+            call_args.values.items,
+        );
+        try self.storeScalar(self.slot(target).ptr, self.localLayout(target), result);
+    }
+
+    fn emitStrSubstringUnsafe(self: *MonoLlvmCodeGen, target: LocalId, args: anytype) Error!void {
+        var call_args = try self.rocStrArgs1(GuardedList.at(args, 0));
+        defer call_args.deinit(self.allocator);
+        try call_args.prepend(self.allocator, try self.ptrType(), self.slot(target).ptr);
+        const start = try self.coerceScalar(
+            try self.loadScalar(self.slot(GuardedList.at(args, 1)).ptr, self.localLayout(GuardedList.at(args, 1))),
+            .i64,
+            false,
+        );
+        const length = try self.coerceScalar(
+            try self.loadScalar(self.slot(GuardedList.at(args, 2)).ptr, self.localLayout(GuardedList.at(args, 2))),
+            .i64,
+            false,
+        );
+        try call_args.append(self.allocator, .i64, start);
+        try call_args.append(self.allocator, .i64, length);
+        try call_args.append(self.allocator, try self.ptrType(), self.rocOps());
+        try self.callBuiltinVoid(
+            "roc_builtins_str_substring_unsafe",
+            call_args.types.items,
+            call_args.values.items,
+        );
     }
 
     fn emitStrFindFirst(self: *MonoLlvmCodeGen, target: LocalId, args: anytype) Error!void {

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -11714,7 +11714,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             // Returns the length of the string in UTF-8 bytes
             try self.emitProcLocal(GuardedList.at(args, 0));
             // For SSO (byte 11 high bit set): length = byte 11 & 0x7F
-            // For heap: length at offset 4
+            // For heap: length at offset 8
             // We use the simplified approach: load byte 11, check SSO bit
             const str_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
             self.currentCode().append(self.allocator, Op.local_set) catch return error.OutOfMemory;
@@ -11733,7 +11733,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 0x80) catch return error.OutOfMemory;
             self.currentCode().append(self.allocator, Op.i32_and) catch return error.OutOfMemory;
 
-            // if SSO: len = tag_byte & 0x7F; else: len = load i32 from offset 4
+            // if SSO: len = tag_byte & 0x7F; else: len = load i32 from offset 8
             self.currentCode().append(self.allocator, Op.@"if") catch return error.OutOfMemory;
             self.currentCode().append(self.allocator, @intFromEnum(ValType.i32)) catch return error.OutOfMemory;
             // SSO path
@@ -11746,7 +11746,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             // Heap path
             self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
             WasmModule.leb128WriteU32(self.allocator, self.currentCode(), str_local) catch return error.OutOfMemory;
-            try self.emitLoadOp(.i32, 4);
+            try self.emitLoadOp(.i32, 8);
             self.currentCode().append(self.allocator, Op.end) catch return error.OutOfMemory;
 
             // Result is length as i32. If ret_layout expects i64, extend.
@@ -11754,6 +11754,14 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             if (ret_vt == .i64) {
                 self.currentCode().append(self.allocator, Op.i64_extend_i32_u) catch return error.OutOfMemory;
             }
+        },
+
+        .str_get_utf8_byte_unsafe => {
+            try self.emitStrGetUtf8ByteUnsafe(args);
+        },
+
+        .str_substring_unsafe => {
+            try self.emitStrSubstringUnsafe(args);
         },
 
         .str_find_first => {
@@ -15431,6 +15439,101 @@ fn emitStrEscapeAndQuote(self: *Self, value: ProcLocalId) Allocator.Error!void {
     }
     try self.emitBuiltinCall(.str_escape_and_quote, self.str_escape_and_quote_import);
     try self.emitFpOffset(result_offset);
+}
+
+fn emitStrGetUtf8ByteUnsafe(self: *Self, args: anytype) Allocator.Error!void {
+    try self.emitProcLocal(GuardedList.at(args, 0));
+    const str_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitLocalSet(str_ptr);
+
+    const data_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    const len = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitExtractStrPtrLen(str_ptr, data_ptr, len);
+
+    try self.emitProcLocal(GuardedList.at(args, 1));
+    if (try self.procLocalValType(GuardedList.at(args, 1)) == .i64) {
+        self.currentCode().append(self.allocator, Op.i32_wrap_i64) catch return error.OutOfMemory;
+    }
+    try self.emitLocalGet(data_ptr);
+    self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+    try self.emitLoadOpSized(.i32, 1, 0);
+}
+
+fn emitStrSubstringUnsafe(self: *Self, args: anytype) Allocator.Error!void {
+    try self.emitProcLocal(GuardedList.at(args, 0));
+    const str_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitLocalSet(str_ptr);
+
+    const start = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitProcLocal(GuardedList.at(args, 1));
+    if (try self.procLocalValType(GuardedList.at(args, 1)) == .i64) {
+        self.currentCode().append(self.allocator, Op.i32_wrap_i64) catch return error.OutOfMemory;
+    }
+    try self.emitLocalSet(start);
+
+    const length = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitProcLocal(GuardedList.at(args, 2));
+    if (try self.procLocalValType(GuardedList.at(args, 2)) == .i64) {
+        self.currentCode().append(self.allocator, Op.i32_wrap_i64) catch return error.OutOfMemory;
+    }
+    try self.emitLocalSet(length);
+
+    const data_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    const source_len = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitExtractStrPtrLen(str_ptr, data_ptr, source_len);
+
+    const result_offset = try self.allocStackMemory(12, 4);
+    const result_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitFpOffset(result_offset);
+    try self.emitLocalSet(result_ptr);
+
+    const is_small = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    const allocation_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitDecodeStrAllocPtr(str_ptr, allocation_ptr, is_small);
+
+    try self.emitLocalGet(is_small);
+    self.currentCode().append(self.allocator, Op.@"if") catch return error.OutOfMemory;
+    self.currentCode().append(self.allocator, @intFromEnum(BlockType.void)) catch return error.OutOfMemory;
+    {
+        try self.emitZeroInit(result_ptr, 12);
+        const source = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitLocalGet(data_ptr);
+        try self.emitLocalGet(start);
+        self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+        try self.emitLocalSet(source);
+        const zero = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitI32Const(0);
+        try self.emitLocalSet(zero);
+        try self.emitMemCopyLoop(result_ptr, zero, source, length);
+
+        try self.emitLocalGet(result_ptr);
+        try self.emitLocalGet(length);
+        try self.emitI32Const(0x80);
+        self.currentCode().append(self.allocator, Op.i32_or) catch return error.OutOfMemory;
+        self.currentCode().append(self.allocator, Op.i32_store8) catch return error.OutOfMemory;
+        WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+        WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 11) catch return error.OutOfMemory;
+    }
+    self.currentCode().append(self.allocator, Op.@"else") catch return error.OutOfMemory;
+    {
+        try self.emitLocalGet(result_ptr);
+        try self.emitLocalGet(data_ptr);
+        try self.emitLocalGet(start);
+        self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+        try self.emitStoreOp(.i32, 0);
+
+        try self.emitLocalGet(result_ptr);
+        try self.emitLocalGet(allocation_ptr);
+        try self.emitI32Const(1);
+        self.currentCode().append(self.allocator, Op.i32_or) catch return error.OutOfMemory;
+        try self.emitStoreOp(.i32, 4);
+
+        try self.emitLocalGet(result_ptr);
+        try self.emitLocalGet(length);
+        try self.emitStoreOp(.i32, 8);
+    }
+    self.currentCode().append(self.allocator, Op.end) catch return error.OutOfMemory;
+    try self.emitLocalGet(result_ptr);
 }
 
 /// Generate str_to_utf8: convert RocStr to RocList(U8).

--- a/src/base/LowLevel.zig
+++ b/src/base/LowLevel.zig
@@ -27,6 +27,8 @@ pub const LowLevel = enum(u16) {
     str_drop_suffix,
     str_find_first,
     str_count_utf8_bytes,
+    str_get_utf8_byte_unsafe,
+    str_substring_unsafe,
     str_with_capacity,
     str_reserve,
     str_release_excess_capacity,
@@ -674,6 +676,7 @@ pub const LowLevel = enum(u16) {
 
             .str_drop_prefix,
             .str_drop_suffix,
+            .str_substring_unsafe,
             => RcEffect.retainsSharingArgs(argMask(&.{0})),
 
             .str_drop_prefix_caseless_ascii,
@@ -797,6 +800,7 @@ pub const LowLevel = enum(u16) {
             .str_starts_with,
             .str_ends_with,
             .str_count_utf8_bytes,
+            .str_get_utf8_byte_unsafe,
             .list_len,
             .bool_not,
             .dict_pseudo_seed,

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -1172,14 +1172,13 @@ Builtin :: [].{
 
 			is_json_unsigned_int_literal : Str -> Bool
 			is_json_unsigned_int_literal = |value| {
-				bytes = Str.to_utf8(value)
-				len = List.len(bytes)
+				len = Str.count_utf8_bytes(value)
 
 				if len == 0 {
 					return False
 				}
 
-				first = list_get_unsafe(bytes, 0)
+				first = str_get_utf8_byte_unsafe(value, 0)
 
 				if first == 48 {
 					return len == 1
@@ -1192,7 +1191,7 @@ Builtin :: [].{
 				var $index = 1
 
 				while $index < len {
-					byte = list_get_unsafe(bytes, $index)
+					byte = str_get_utf8_byte_unsafe(value, $index)
 
 					if Json.is_json_digit(byte) {
 						$index = $index + 1
@@ -1265,35 +1264,41 @@ Builtin :: [].{
 			## keeps that delimiter. Both results are zero-copy slices.
 			split_json_scalar_tail : Str -> Try({ value : Str, after : Str }, Json.ParseErr)
 			split_json_scalar_tail = |raw| {
-				bytes = Str.to_utf8(raw)
+				len = Str.count_utf8_bytes(raw)
+				var $index = 0
+				var $found = False
 
-				match List.find_first_index(bytes, is_json_scalar_delimiter) {
-					Ok(0) => {
-						# missing scalar value
-						Err(Json.invalid_json)
+				while $index < len {
+					if is_json_scalar_delimiter(str_get_utf8_byte_unsafe(raw, $index)) {
+						$found = True
+						break
+					} else {
+						$index = $index + 1
 					}
-					Ok(index) => {
-						value = match Str.from_utf8(List.take_first(bytes, index)) {
+				}
+
+				if $found {
+					if $index == 0 {
+						Err(Json.invalid_json)
+					} else {
+						value = match Str.drop_last_bytes(raw, len - $index) {
 							Ok(v) => v
-							# unreachable: the split point is an ASCII delimiter, so the prefix is always valid UTF-8
-							Err(_) => {
-								crash "Json scalar splitter invariant violated: split at a delimiter was not valid UTF-8"
+							Err(BadUtf8) => {
+								crash "Json scalar splitter invariant violated: ASCII delimiter was not a UTF-8 boundary"
 							}
 						}
-
-						# `value` is a content-matched prefix of `raw`, so dropping it yields the
-						# tail beginning with the delimiter — a zero-copy slice operation.
-						Ok({ value, after: Str.drop_prefix(raw, value) })
-					}
-					Err(NotFound) => {
-						if Str.is_empty(raw) {
-							# missing scalar value (end of input)
-							Err(Json.invalid_json)
-						} else {
-							# the scalar runs to the end of the input
-							Ok({ value: raw, after: "" })
+						after = match Str.drop_first_bytes(raw, $index) {
+							Ok(v) => v
+							Err(BadUtf8) => {
+								crash "Json scalar splitter invariant violated: ASCII delimiter was not a UTF-8 boundary"
+							}
 						}
+						Ok({ value, after })
 					}
+				} else if $index == 0 {
+					Err(Json.invalid_json)
+				} else {
+					Ok({ value: raw, after: "" })
 				}
 			}
 		}
@@ -2109,6 +2114,68 @@ Builtin :: [].{
 		## expect "Hello World".count_utf8_bytes() == 11
 		## ```
 		count_utf8_bytes : Str -> U64
+
+		## Iterate over this string's UTF-8 code units in byte order. The iterator's
+		## known length is the string's byte length. Iteration does not allocate.
+		iter_utf8 : Str -> Iter(U8)
+		iter_utf8 = |str| {
+			make = |index| {
+				len = Str.count_utf8_bytes(str)
+
+				iter_from_step(
+					Known(len - index),
+					||
+						if index == len {
+							Done
+						} else {
+							One({ item: str_get_utf8_byte_unsafe(str, index), rest: make(index + 1) })
+						},
+				)
+			}
+
+			make(0)
+		}
+
+		## Drop a byte count from the start of a string. Counts at or beyond the
+		## byte length return `Ok("")`; an in-range cut inside a UTF-8 code point
+		## returns `Err(BadUtf8)`. Valid slices do not allocate.
+		drop_first_bytes : Str, U64 -> Try(Str, [BadUtf8, ..])
+		drop_first_bytes = |str, count| {
+			len = Str.count_utf8_bytes(str)
+			if count >= len {
+				Ok("")
+			} else {
+				byte = str_get_utf8_byte_unsafe(str, count)
+				if byte >= 128 and byte < 192 {
+					Err(BadUtf8)
+				} else {
+					Ok(str_substring_unsafe(str, count, len - count))
+				}
+			}
+		}
+
+		## Drop a byte count from the end of a string. Counts at or beyond the byte
+		## length return `Ok("")`; an in-range cut inside a UTF-8 code point returns
+		## `Err(BadUtf8)`. Valid slices do not allocate.
+		drop_last_bytes : Str, U64 -> Try(Str, [BadUtf8, ..])
+		drop_last_bytes = |str, count| {
+			if count == 0 {
+				Ok(str)
+			} else {
+				len = Str.count_utf8_bytes(str)
+				if count >= len {
+					Ok("")
+				} else {
+					end = len - count
+					byte = str_get_utf8_byte_unsafe(str, end)
+					if byte >= 128 and byte < 192 {
+						Err(BadUtf8)
+					} else {
+						Ok(str_substring_unsafe(str, 0, end))
+					}
+				}
+			}
+		}
 
 		## Returns a string of the specified capacity without any content.
 		##
@@ -17332,22 +17399,23 @@ is_json_whitespace = |byte|
 ## or revalidated, so a call costs O(leading whitespace).
 json_trim_start : Str -> Str
 json_trim_start = |s| {
-	bytes = Str.to_utf8(s)
-
-	index = match List.find_first_index(bytes, |byte| !is_json_whitespace(byte)) {
-		Ok(idx) => idx
-		Err(NotFound) => List.len(bytes)
+	len = Str.count_utf8_bytes(s)
+	var $index = 0
+	while $index < len {
+		if is_json_whitespace(str_get_utf8_byte_unsafe(s, $index)) {
+			$index = $index + 1
+		} else {
+			break
+		}
 	}
 
-	if index == 0 {
+	if $index == 0 {
 		s
 	} else {
-		match Str.from_utf8(List.take_first(bytes, index)) {
-			# the prefix is ASCII whitespace, so it is always valid UTF-8 and
-			# dropping it is a byte compare plus a zero-copy slice
-			Ok(prefix) => Str.drop_prefix(s, prefix)
-			Err(_) => {
-				crash "json_trim_start invariant violated: an ASCII whitespace prefix was not valid UTF-8"
+		match Str.drop_first_bytes(s, $index) {
+			Ok(trimmed) => trimmed
+			Err(BadUtf8) => {
+				crash "json_trim_start invariant violated: ASCII whitespace ended inside UTF-8"
 			}
 		}
 	}
@@ -17406,6 +17474,13 @@ str_find_first_raw : Str, Str -> { before : Str, found : Bool, after : Str }
 # Implemented by the compiler. Returns a string slice after the prefix when the
 # source starts with the prefix using ASCII-caseless comparison.
 str_drop_prefix_caseless_ascii_raw : Str, Str -> { after : Str, found : Bool }
+
+# Implemented by the compiler. The caller guarantees the index is in bounds.
+str_get_utf8_byte_unsafe : Str, U64 -> U8
+
+# Implemented by the compiler. The caller guarantees the byte range is in bounds.
+# The result shares the source string's allocation.
+str_substring_unsafe : Str, U64, U64 -> Str
 
 # Implemented by the compiler. Returns 1 (otherwise 0) when List.map may reuse
 # the input list's allocation for its output: the input and output element

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -411,9 +411,7 @@ Builtin :: [].{
 
 			json_dec_digits_are_zero : Str -> Bool
 			json_dec_digits_are_zero = |digits| {
-				bytes = Str.to_utf8(digits)
-
-				for byte in bytes {
+				for byte in Str.iter_utf8(digits) {
 					if byte != 48 {
 						return False
 					}
@@ -424,16 +422,16 @@ Builtin :: [].{
 
 			trim_json_dec_leading_zeros : Str, I64 -> { digits : Str, digits_len : U64, point : I64 }
 			trim_json_dec_leading_zeros = |digits, point| {
-				bytes = Str.to_utf8(digits)
-				len = List.len(bytes)
+				len = Str.count_utf8_bytes(digits)
 				var $index = 0
 
-				while $index < len and list_get_unsafe(bytes, $index) == 48 {
+				while $index < len and str_get_utf8_byte_unsafe(digits, $index) == 48 {
 					$index = $index + 1
 				}
 
 				{
-					digits: Str.from_utf8_lossy(List.drop_first(bytes, $index)),
+					# the dropped prefix is ASCII zeros, so the cut is a UTF-8 boundary
+					digits: str_drop_first_bytes_unsafe(digits, $index),
 					digits_len: len - $index,
 					point: point - $index.to_i64_wrap(),
 				}
@@ -459,9 +457,9 @@ Builtin :: [].{
 						zero_count = point_u64 - digits_len
 						Ok(Str.concat(sign, Str.concat(digits, Str.repeat("0", zero_count))))
 					} else {
-						bytes = Str.to_utf8(digits)
-						before = Str.from_utf8_lossy(List.take_first(bytes, point_u64))
-						after = Str.from_utf8_lossy(List.drop_first(bytes, point_u64))
+						# digits holds only ASCII digits, so any cut is a UTF-8 boundary
+						before = str_substring_unsafe(digits, 0, point_u64)
+						after = str_drop_first_bytes_unsafe(digits, point_u64)
 
 						Ok(Str.concat(sign, Str.concat(before, Str.concat(".", after))))
 					}
@@ -1059,8 +1057,7 @@ Builtin :: [].{
 
 			is_json_number : Str -> Bool
 			is_json_number = |value| {
-				bytes = Str.to_utf8(value)
-				len = List.len(bytes)
+				len = Str.count_utf8_bytes(value)
 
 				if len == 0 {
 					return False
@@ -1068,7 +1065,7 @@ Builtin :: [].{
 
 				var $index = 0
 
-				first = list_get_unsafe(bytes, $index)
+				first = str_get_utf8_byte_unsafe(value, $index)
 
 				if first == 45 {
 					$index = $index + 1
@@ -1078,7 +1075,7 @@ Builtin :: [].{
 					}
 				}
 
-				int_first = list_get_unsafe(bytes, $index)
+				int_first = str_get_utf8_byte_unsafe(value, $index)
 
 				if int_first == 48 {
 					$index = $index + 1
@@ -1086,7 +1083,7 @@ Builtin :: [].{
 					$index = $index + 1
 
 					while $index < len {
-						byte = list_get_unsafe(bytes, $index)
+						byte = str_get_utf8_byte_unsafe(value, $index)
 
 						if Json.is_json_digit(byte) {
 							$index = $index + 1
@@ -1099,7 +1096,7 @@ Builtin :: [].{
 				}
 
 				if $index < len {
-					byte = list_get_unsafe(bytes, $index)
+					byte = str_get_utf8_byte_unsafe(value, $index)
 
 					if byte == 46 {
 						$index = $index + 1
@@ -1108,14 +1105,14 @@ Builtin :: [].{
 							return False
 						}
 
-						first_fraction_byte = list_get_unsafe(bytes, $index)
+						first_fraction_byte = str_get_utf8_byte_unsafe(value, $index)
 
 						if !Json.is_json_digit(first_fraction_byte) {
 							return False
 						}
 
 						while $index < len {
-							fraction_byte = list_get_unsafe(bytes, $index)
+							fraction_byte = str_get_utf8_byte_unsafe(value, $index)
 
 							if Json.is_json_digit(fraction_byte) {
 								$index = $index + 1
@@ -1127,7 +1124,7 @@ Builtin :: [].{
 				}
 
 				if $index < len {
-					byte = list_get_unsafe(bytes, $index)
+					byte = str_get_utf8_byte_unsafe(value, $index)
 
 					if Json.is_json_exponent_marker(byte) {
 						$index = $index + 1
@@ -1136,7 +1133,7 @@ Builtin :: [].{
 							return False
 						}
 
-						exponent_first_byte = list_get_unsafe(bytes, $index)
+						exponent_first_byte = str_get_utf8_byte_unsafe(value, $index)
 
 						if Json.is_json_sign(exponent_first_byte) {
 							$index = $index + 1
@@ -1146,14 +1143,14 @@ Builtin :: [].{
 							}
 						}
 
-						first_exponent_digit = list_get_unsafe(bytes, $index)
+						first_exponent_digit = str_get_utf8_byte_unsafe(value, $index)
 
 						if !Json.is_json_digit(first_exponent_digit) {
 							return False
 						}
 
 						while $index < len {
-							exponent_byte = list_get_unsafe(bytes, $index)
+							exponent_byte = str_get_utf8_byte_unsafe(value, $index)
 
 							if Json.is_json_digit(exponent_byte) {
 								$index = $index + 1

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -2141,17 +2141,13 @@ Builtin :: [].{
 		## returns `Err(BadUtf8)`. Valid slices do not allocate.
 		drop_first_bytes : Str, U64 -> Try(Str, [BadUtf8, ..])
 		drop_first_bytes = |str, count| {
-			len = Str.count_utf8_bytes(str)
-			if count >= len {
-				Ok("")
-			} else {
+			if count < Str.count_utf8_bytes(str) {
 				byte = str_get_utf8_byte_unsafe(str, count)
 				if byte >= 128 and byte < 192 {
-					Err(BadUtf8)
-				} else {
-					Ok(str_substring_unsafe(str, count, len - count))
+					return Err(BadUtf8)
 				}
 			}
+			Ok(str_drop_first_bytes_unsafe(str, count))
 		}
 
 		## Drop a byte count from the end of a string. Counts at or beyond the byte
@@ -17231,32 +17227,23 @@ ScannedJsonString : { after : Str, body : [NoEscapes(Str), HasEscapes(Str)] }
 ## along the way.
 scan_json_string_tail : Str -> Try(ScannedJsonString, Json.ParseErr)
 scan_json_string_tail = |tail| {
-	bytes = Str.to_utf8(tail)
-	len = List.len(bytes)
+	len = Str.count_utf8_bytes(tail)
 	var $index = 0
 	var $had_escape = False
 
-	# Walk the bytes, consuming each escape atomically, until the closing quote.
-	# Every escape must be validated so that invalid escapes are rejected as invalid JSON
-	# (even inside skipped strings).
+	# Walk the string's bytes in place, consuming each escape atomically, until the
+	# closing quote. Every escape must be validated so that invalid escapes are
+	# rejected as invalid JSON (even inside skipped strings).
 	while $index < len {
-		byte = list_get_unsafe(bytes, $index)
+		byte = str_get_utf8_byte_unsafe(tail, $index)
 		match byte {
 			# Because we consume escapes atomically, if we hit a quote we know that it's the end
 			# of the string.
 			'"' => {
-				raw = match Str.from_utf8(List.take_first(bytes, $index)) {
-					Ok(body) => body
-					# unreachable: the split point is an ASCII quote, so the prefix is always valid UTF-8
-					Err(_) => {
-						crash "Json scanner invariant violated: split at a quote was not valid UTF-8"
-					}
-				}
-
-				# Str has no index-based slicing, so recover `after` by dropping the
-				# body (a content-matched prefix of `tail`) and then the closing
-				# quote — both zero-copy slice operations.
-				after = Str.drop_prefix(Str.drop_prefix(tail, raw), "\"")
+				# The quote is ASCII, so both cut points are UTF-8 boundaries and the
+				# slices are valid strings; slicing past the quote also skips it.
+				raw = str_substring_unsafe(tail, 0, $index)
+				after = str_drop_first_bytes_unsafe(tail, $index + 1)
 
 				return Ok({ after, body: if $had_escape HasEscapes(raw) else NoEscapes(raw) })
 			}
@@ -17264,10 +17251,10 @@ scan_json_string_tail = |tail| {
 			# escape sequence atomically
 			'\\' => {
 				$had_escape = True
-				escape = parse_json_escape_sequence(List.drop_first(bytes, $index + 1))?
-				$index = $index + 1 + escape.consumed
+				escape = parse_json_escaped_code_point(tail, $index)?
+				$index = $index + escape.consumed
 			}
-			# For any other character besides a quote or a backslash, we continue.
+			# For any other byte besides a quote or a backslash, we continue.
 			_ => {
 				# JSON requires U+0000 through U+001F to be escaped inside strings.
 				if byte < 32 {
@@ -17294,20 +17281,23 @@ skip_json_string_tail = |tail| {
 
 ## Decode a JSON string body: walk it, mapping each escape sequence to its code point and
 ## copying everything else.
+##
+## The scan already validated every escape, so decoding re-parses them. This double
+## parse is deliberate: it keeps scanning allocation-free, and skipped strings and
+## clean strings never decode at all.
 decode_json_string_body : Str -> Try(Str, Json.ParseErr)
 decode_json_string_body = |raw| {
-	bytes = Str.to_utf8(raw)
-	len = List.len(bytes)
+	len = Str.count_utf8_bytes(raw)
 	var $out = u8_list_reserve([], len)
 	var $index = 0
 
 	while $index < len {
-		byte = list_get_unsafe(bytes, $index)
+		byte = str_get_utf8_byte_unsafe(raw, $index)
 		match byte {
 			'\\' => {
-				escape = parse_json_escape_sequence(List.drop_first(bytes, $index + 1))?
+				escape = parse_json_escaped_code_point(raw, $index)?
 				$out = append_utf8_code_point($out, escape.code_point)
-				$index = $index + 1 + escape.consumed
+				$index = $index + escape.consumed
 			}
 			_ => {
 				$out = u8_append($out, byte)
@@ -17326,49 +17316,81 @@ decode_json_string_body = |raw| {
 	}
 }
 
-## Parse one JSON escape sequence. `rest` is expected to hold the bytes after a backslash.
-## Every JSON escape denotes exactly one code point (surrogate pairs combine into one), so
-## this returns that code point plus the number of bytes consumed from `rest`.
-parse_json_escape_sequence : List(U8) -> Try({ code_point : U64, consumed : U64 }, Json.ParseErr)
-parse_json_escape_sequence = |rest| match rest {
-	['"', ..] => Ok({ code_point: '"', consumed: 1 })
-	['\\', ..] => Ok({ code_point: '\\', consumed: 1 })
-	['/', ..] => Ok({ code_point: '/', consumed: 1 })
-	# backspace
-	['b', ..] => Ok({ code_point: 8, consumed: 1 })
-	# form feed
-	['f', ..] => Ok({ code_point: 12, consumed: 1 })
-	# newline
-	['n', ..] => Ok({ code_point: 10, consumed: 1 })
-	# carriage return
-	['r', ..] => Ok({ code_point: 13, consumed: 1 })
-	# tab
-	['t', ..] => Ok({ code_point: 9, consumed: 1 })
-	# \uXXXX names a UTF-16 code unit, not a code point, so surrogates may need pairing
-	['u', h0, h1, h2, h3, .. as tail] => {
-		unit = decode_json_hex4(h0, h1, h2, h3)?
-		if unit >= 55296 and unit <= 56319 {
-			# high surrogate (U+D800..U+DBFF): a \uDC00..\uDFFF escape must follow
-			match tail {
-				['\\', 'u', h4, h5, h6, h7, ..] => {
-					low = decode_json_hex4(h4, h5, h6, h7)?
-					if low >= 56320 and low <= 57343 {
-						Ok({ code_point: 65536 + (unit - 55296) * 1024 + (low - 56320), consumed: 11 })
-					} else {
-						Err(Json.invalid_json)
-					}
-				}
-				_ => Err(Json.invalid_json)
-			}
-		} else if unit >= 56320 and unit <= 57343 {
-			# unpaired low surrogate (U+DC00..U+DFFF)
-			Err(Json.invalid_json)
-		} else {
-			Ok({ code_point: unit, consumed: 5 })
-		}
+## Parse one escaped character from string `s`, starting at byte `index`.
+##
+## `index` is expected (but not verified) to be the index of the `\` character that starts
+## the escape. (Note that we index into `s`, rather than taking a slice and starting at 0,
+## because the latter was found to be slower empirically.)
+##
+## Returns the character's code point and the number of bytes consumed, which could be:
+##   2, for simple sequences like `\n`
+##   6, for characters represented by a single UTF-16 code unit, like `\u00E9` (é)
+##  12, for characters represented by a pair of UTF-16 code units, like `\uD83D\uDE00` (😀)
+parse_json_escaped_code_point : Str, U64 -> Try({ code_point : U64, consumed : U64 }, Json.ParseErr)
+parse_json_escaped_code_point = |s, index| {
+	len = Str.count_utf8_bytes(s)
+	if index + 2 > len {
+		# the backslash ends the input: a truncated escape
+		return Err(Json.invalid_json)
 	}
-	# truncated or unknown escape
-	_ => Err(Json.invalid_json)
+
+	match str_get_utf8_byte_unsafe(s, index + 1) {
+		'"' => Ok({ code_point: '"', consumed: 2 })
+		'\\' => Ok({ code_point: '\\', consumed: 2 })
+		'/' => Ok({ code_point: '/', consumed: 2 })
+		# backspace
+		'b' => Ok({ code_point: 8, consumed: 2 })
+		# form feed
+		'f' => Ok({ code_point: 12, consumed: 2 })
+		# newline
+		'n' => Ok({ code_point: 10, consumed: 2 })
+		# carriage return
+		'r' => Ok({ code_point: 13, consumed: 2 })
+		# tab
+		't' => Ok({ code_point: 9, consumed: 2 })
+		# the four hex digits name a UTF-16 code unit
+		'u' => {
+			if index + 6 > len {
+				# truncated \uXXXX escape
+				return Err(Json.invalid_json)
+			}
+			unit = decode_json_hex4(
+				str_get_utf8_byte_unsafe(s, index + 2),
+				str_get_utf8_byte_unsafe(s, index + 3),
+				str_get_utf8_byte_unsafe(s, index + 4),
+				str_get_utf8_byte_unsafe(s, index + 5),
+			)?
+			if unit >= 0xD800 and unit <= 0xDBFF {
+				# a high surrogate (U+D800..U+DBFF) merges with the low
+				# surrogate escape that must follow
+				if index + 12 > len {
+					return Err(Json.invalid_json)
+				}
+				if str_get_utf8_byte_unsafe(s, index + 6) != '\\' or str_get_utf8_byte_unsafe(s, index + 7) != 'u' {
+					return Err(Json.invalid_json)
+				}
+				low = decode_json_hex4(
+					str_get_utf8_byte_unsafe(s, index + 8),
+					str_get_utf8_byte_unsafe(s, index + 9),
+					str_get_utf8_byte_unsafe(s, index + 10),
+					str_get_utf8_byte_unsafe(s, index + 11),
+				)?
+				if low >= 0xDC00 and low <= 0xDFFF {
+					Ok({ code_point: 0x10000 + (unit - 0xD800) * 0x400 + (low - 0xDC00), consumed: 12 })
+				} else {
+					Err(Json.invalid_json)
+				}
+			} else if unit >= 0xDC00 and unit <= 0xDFFF {
+				# unpaired low surrogate (U+DC00..U+DFFF)
+				Err(Json.invalid_json)
+			} else {
+				# a BMP code unit already is the code point
+				Ok({ code_point: unit, consumed: 6 })
+			}
+		}
+		# unknown escape
+		_ => Err(Json.invalid_json)
+	}
 }
 
 ## Combine 4 hex-digit bytes (as in \uXXXX) into their numeric value.
@@ -17481,6 +17503,21 @@ str_get_utf8_byte_unsafe : Str, U64 -> U8
 # Implemented by the compiler. The caller guarantees the byte range is in bounds.
 # The result shares the source string's allocation.
 str_substring_unsafe : Str, U64, U64 -> Str
+
+## Drop `count` bytes from the front of a string as a zero-copy slice ("" when
+## `count` is at or past the end). Bounds are handled; what is NOT checked is
+## that `count` falls on a UTF-8 boundary — the caller guarantees that, so the
+## slice is a valid string. (`Str.drop_first_bytes` is the checked version.)
+str_drop_first_bytes_unsafe : Str, U64 -> Str
+str_drop_first_bytes_unsafe = |s, count| {
+	len = Str.count_utf8_bytes(s)
+	if count >= len {
+		""
+	} else {
+		str_substring_unsafe(s, count, len - count)
+	}
+}
+
 
 # Implemented by the compiler. Returns 1 (otherwise 0) when List.map may reuse
 # the input list's allocation for its output: the input and output element

--- a/src/builtins/dev_wrappers.zig
+++ b/src/builtins/dev_wrappers.zig
@@ -243,6 +243,18 @@ pub fn roc_builtins_str_count_utf8_bytes(str_bytes: ?[*]u8, str_len: usize, str_
     return countUtf8Bytes(s);
 }
 
+/// Read one in-bounds UTF-8 code unit without allocating or retaining the string.
+pub fn roc_builtins_str_get_utf8_byte_unsafe(str_bytes: ?[*]u8, str_len: usize, str_cap: usize, index: u64) callconv(.c) u8 {
+    const s = RocStr{ .bytes = str_bytes, .length = str_len, .capacity_or_alloc_ptr = str_cap };
+    return str.getUnsafeC(s, index);
+}
+
+/// Build an in-bounds byte substring; ARC retains the shared source allocation.
+pub fn roc_builtins_str_substring_unsafe(out: *RocStr, str_bytes: ?[*]u8, str_len: usize, str_cap: usize, start: u64, length: u64, roc_ops: *RocOps) callconv(.c) void {
+    const s = RocStr{ .bytes = str_bytes, .length = str_len, .capacity_or_alloc_ptr = str_cap };
+    out.* = str.substringUnsafeC(s, start, length, roc_ops);
+}
+
 /// Wrapper: findFirst(RocStr, RocStr, *RocOps) -> { before, found, after }
 pub fn roc_builtins_str_find_first(out: *anyopaque, a_bytes: ?[*]u8, a_len: usize, a_cap: usize, b_bytes: ?[*]u8, b_len: usize, b_cap: usize, layout: *const StrFindFirstLayout, roc_ops: *RocOps) callconv(.c) void {
     const a = RocStr{ .bytes = a_bytes, .length = a_len, .capacity_or_alloc_ptr = a_cap };

--- a/src/builtins/static_lib.zig
+++ b/src/builtins/static_lib.zig
@@ -49,6 +49,8 @@ comptime {
     @export(&dw.roc_builtins_str_static_small_word_eq, .{ .name = "roc_builtins_str_static_small_word_eq" });
     @export(&dw.roc_builtins_str_static_small_word_caseless_eq, .{ .name = "roc_builtins_str_static_small_word_caseless_eq" });
     @export(&dw.roc_builtins_str_count_utf8_bytes, .{ .name = "roc_builtins_str_count_utf8_bytes" });
+    @export(&dw.roc_builtins_str_get_utf8_byte_unsafe, .{ .name = "roc_builtins_str_get_utf8_byte_unsafe" });
+    @export(&dw.roc_builtins_str_substring_unsafe, .{ .name = "roc_builtins_str_substring_unsafe" });
     @export(&dw.roc_builtins_str_find_first, .{ .name = "roc_builtins_str_find_first" });
     @export(&dw.roc_builtins_str_drop_prefix_caseless_ascii, .{ .name = "roc_builtins_str_drop_prefix_caseless_ascii" });
     @export(&dw.roc_builtins_str_caseless_ascii_equals, .{ .name = "roc_builtins_str_caseless_ascii_equals" });

--- a/src/builtins/static_lib_core.zig
+++ b/src/builtins/static_lib_core.zig
@@ -45,6 +45,8 @@ comptime {
     @export(&dw.roc_builtins_str_static_small_word_eq, .{ .name = "roc_builtins_str_static_small_word_eq" });
     @export(&dw.roc_builtins_str_static_small_word_caseless_eq, .{ .name = "roc_builtins_str_static_small_word_caseless_eq" });
     @export(&dw.roc_builtins_str_count_utf8_bytes, .{ .name = "roc_builtins_str_count_utf8_bytes" });
+    @export(&dw.roc_builtins_str_get_utf8_byte_unsafe, .{ .name = "roc_builtins_str_get_utf8_byte_unsafe" });
+    @export(&dw.roc_builtins_str_substring_unsafe, .{ .name = "roc_builtins_str_substring_unsafe" });
     @export(&dw.roc_builtins_str_find_first, .{ .name = "roc_builtins_str_find_first" });
     @export(&dw.roc_builtins_str_drop_prefix_caseless_ascii, .{ .name = "roc_builtins_str_drop_prefix_caseless_ascii" });
     @export(&dw.roc_builtins_str_caseless_ascii_equals, .{ .name = "roc_builtins_str_caseless_ascii_equals" });

--- a/src/builtins/str.zig
+++ b/src/builtins/str.zig
@@ -2941,6 +2941,44 @@ test "RocStr.eq: utf8 content uses exact byte equality" {
     try std.testing.expect(!roc_str1.eql(roc_str3));
 }
 
+test "unchecked UTF-8 byte access reads SSO and heap strings" {
+    var test_env = TestEnv.init(std.testing.allocator);
+    defer test_env.deinit();
+
+    const small = RocStr.fromSlice("A\x00\xc3\xa9", test_env.getOps());
+    const large = RocStr.fromSlice("012345678901234567890123456789\xf0\x9f\x8e\x89", test_env.getOps());
+    defer small.decref(test_env.getOps());
+    defer large.decref(test_env.getOps());
+
+    try std.testing.expect(small.isSmallStr());
+    try std.testing.expect(!large.isSmallStr());
+    try std.testing.expectEqual(@as(u8, 0), getUnsafeC(small, 1));
+    try std.testing.expectEqual(@as(u8, 0xc3), getUnsafeC(small, 2));
+    try std.testing.expectEqual(@as(u8, 0xf0), getUnsafeC(large, 30));
+    try std.testing.expectEqual(@as(u8, 0x89), getUnsafeC(large, 33));
+}
+
+test "unchecked substrings cover SSO and retained heap slices" {
+    var test_env = TestEnv.init(std.testing.allocator);
+    defer test_env.deinit();
+
+    const small = RocStr.fromSlice("abcdef", test_env.getOps());
+    const small_middle = substringUnsafeC(small, 2, 3, test_env.getOps());
+    try std.testing.expect(small_middle.eqlSlice("cde"));
+    try std.testing.expect(small.eqlSlice("abcdef"));
+
+    const source = RocStr.fromSlice("012345678901234567890123456789", test_env.getOps());
+    source.incref(1, test_env.getOps());
+    const middle = substringUnsafeC(source, 5, 20, test_env.getOps());
+    try std.testing.expect(middle.isSeamlessSlice());
+    source.decref(test_env.getOps());
+    try std.testing.expect(middle.eqlSlice("56789012345678901234"));
+
+    const empty = substringUnsafeC(middle, middle.len(), 0, test_env.getOps());
+    try std.testing.expect(empty.isEmpty());
+    middle.decref(test_env.getOps());
+}
+
 test "RocStr.eq: boundary between small and heap strings" {
     var test_env = TestEnv.init(std.testing.allocator);
     defer test_env.deinit();

--- a/src/canonicalize/BuiltinLowLevel.zig
+++ b/src/canonicalize/BuiltinLowLevel.zig
@@ -197,6 +197,12 @@ fn replaceProvidedByCompilerLowLevels(env: *ModuleEnv) (Allocator.Error || error
     if (env.common.findIdent("Builtin.Str.count_utf8_bytes")) |str_count_utf8_bytes_ident| {
         try low_level_map.put(str_count_utf8_bytes_ident, .str_count_utf8_bytes);
     }
+    if (env.common.findIdent("str_get_utf8_byte_unsafe")) |ident| {
+        try low_level_map.put(ident, .str_get_utf8_byte_unsafe);
+    }
+    if (env.common.findIdent("str_substring_unsafe")) |ident| {
+        try low_level_map.put(ident, .str_substring_unsafe);
+    }
     if (env.common.findIdent("Builtin.Str.with_capacity")) |str_with_capacity_ident| {
         try low_level_map.put(str_with_capacity_ident, .str_with_capacity);
     }

--- a/src/check/const_store.zig
+++ b/src/check/const_store.zig
@@ -79,6 +79,7 @@ pub const IteratorKind = enum(u8) {
     none,
     custom,
     list,
+    str,
     single,
     range_exclusive,
     range_inclusive,

--- a/src/cli/builder.zig
+++ b/src/cli/builder.zig
@@ -305,6 +305,8 @@ const core_builtin_roots = std.StaticStringMap(void).initComptime(.{
     .{ "roc_builtins_str_split", {} },
     .{ "roc_builtins_str_starts_with", {} },
     .{ "roc_builtins_str_to_utf8", {} },
+    .{ "roc_builtins_str_get_utf8_byte_unsafe", {} },
+    .{ "roc_builtins_str_substring_unsafe", {} },
     .{ "roc_builtins_str_trim", {} },
     .{ "roc_builtins_str_trim_end", {} },
     .{ "roc_builtins_str_trim_start", {} },

--- a/src/cli/test/json_decoder_platform_test.zig
+++ b/src/cli/test/json_decoder_platform_test.zig
@@ -115,6 +115,15 @@ test "JSON parsing platform derives structural parser without runtime allocation
         try buildRocApp(allocator, &env_map, target_name, output_path, "test/json-decoder/app.roc");
     }
 
+    try runJsonDecoderAndCheckOutput(allocator, output_path, "42", "42\n");
+    try runJsonDecoderAndCheckOutput(allocator, output_path, " \t42\r\n", "42\n");
+    try runJsonDecoderAndCheckOutput(
+        allocator,
+        output_path,
+        "                                                                42                                                                ",
+        "42\n",
+    );
+
     for (0..8) |case_index| {
         const mask: u8 = @intCast(case_index);
         const status_index = case_index % status_values.len;

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -4715,6 +4715,21 @@ pub const Interpreter = struct {
                 val.write(u64, result);
                 break :blk val;
             },
+            .str_get_utf8_byte_unsafe => blk: {
+                const result = builtins.str.getUnsafeC(valueToRocStr(args[0]), args[1].read(u64));
+                const val = try self.alloc(ll.ret_layout);
+                val.write(u8, result);
+                break :blk val;
+            },
+            .str_substring_unsafe => blk: {
+                const result = builtins.str.substringUnsafeC(
+                    valueToRocStr(args[0]),
+                    args[1].read(u64),
+                    args[2].read(u64),
+                    &self.roc_ops,
+                );
+                break :blk self.rocStrToValue(result, ll.ret_layout);
+            },
             .str_to_utf8 => blk: {
                 var crash_boundary = self.enterCrashBoundary();
                 defer crash_boundary.deinit();

--- a/src/eval/test/eval_low_level_tests.zig
+++ b/src/eval/test/eval_low_level_tests.zig
@@ -2699,6 +2699,80 @@ pub const tests = [_]TestCase{
         .expected = .{ .inspect_str = "4" },
     },
     .{
+        .name = "low_level - Str.iter_utf8 exact bytes and known length",
+        .source =
+        \\{
+        \\iter = Str.iter_utf8("A\u(0000)é🎉")
+        \\bytes = Iter.fold(iter, [], |list, byte| List.append(list, byte))
+        \\{ bytes, size: Iter.size_hint(Str.iter_utf8("A\u(0000)é🎉")) }
+        \\}
+        ,
+        .expected = .{ .inspect_str = "{ bytes: [65, 0, 195, 169, 240, 159, 142, 137], size: Known(8) }" },
+    },
+    .{
+        .name = "low_level - Str.iter_utf8 empty SSO and heap strings",
+        .source =
+        \\{
+        \\small = Iter.fold(Str.iter_utf8("Roc"), 0, |sum, byte| sum + U8.to_u64(byte))
+        \\large = Iter.fold(Str.iter_utf8("abcdefghijklmnopqrstuvwxyz0123456789"), 0, |sum, byte| sum + U8.to_u64(byte))
+        \\{ empty: Iter.size_hint(Str.iter_utf8("")), small, large }
+        \\}
+        ,
+        .expected = .{ .inspect_str = "{ empty: Known(0), large: 3372, small: 292 }" },
+    },
+    .{
+        .name = "low_level - Str.iter_utf8 repeated next and for consumption",
+        .source =
+        \\{
+        \\iter = Str.iter_utf8("AéZ")
+        \\first = Iter.next(iter)
+        \\{ first_byte, rest } = match first {
+        \\    One({ item, rest }) => { first_byte: item, rest }
+        \\    _ => { first_byte: 0, rest: Str.iter_utf8("") }
+        \\}
+        \\second = Iter.next(rest)
+        \\{ second_byte, tail } = match second {
+        \\    One({ item, rest: next }) => { second_byte: item, tail: next }
+        \\    _ => { second_byte: 0, tail: Str.iter_utf8("") }
+        \\}
+        \\var $sum = 0
+        \\for byte in tail { $sum = $sum + byte.to_u64() }
+        \\{ first_byte, second_byte, tail_sum: $sum }
+        \\}
+        ,
+        .expected = .{ .inspect_str = "{ first_byte: 65, second_byte: 195, tail_sum: 259 }" },
+    },
+    .{
+        .name = "low_level - Str byte drops preserve source and slice at boundaries",
+        .source =
+        \\{
+        \\source = "aé🎉z"
+        \\first = Str.drop_first_bytes(source, 3)
+        \\last = Str.drop_last_bytes(source, 5)
+        \\whole = Str.drop_first_bytes(source, 8)
+        \\beyond = Str.drop_last_bytes(source, 100)
+        \\zero = Str.drop_last_bytes(source, 0)
+        \\{ source, first, last, whole, beyond, zero }
+        \\}
+        ,
+        .expected = .{ .inspect_str = "{ beyond: Ok(\"\"), first: Ok(\"🎉z\"), last: Ok(\"aé\"), source: \"aé🎉z\", whole: Ok(\"\"), zero: Ok(\"aé🎉z\") }" },
+    },
+    .{
+        .name = "low_level - Str byte drops reject cuts inside UTF-8 sequences",
+        .source =
+        \\{
+        \\is_bad = |result| match result { Err(BadUtf8) => True, Ok(_) => False }
+        \\is_bad(Str.drop_first_bytes("é", 1))
+        \\    and is_bad(Str.drop_first_bytes("€", 1))
+        \\    and is_bad(Str.drop_first_bytes("🎉", 2))
+        \\    and is_bad(Str.drop_last_bytes("é", 1))
+        \\    and is_bad(Str.drop_last_bytes("€", 2))
+        \\    and is_bad(Str.drop_last_bytes("🎉", 3))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
         .name = "low_level - Str.with_capacity returns empty string",
         .source =
         \\{

--- a/src/llvm_compile/compile.zig
+++ b/src/llvm_compile/compile.zig
@@ -252,6 +252,8 @@ const core_builtin_roots = std.StaticStringMap(void).initComptime(.{
     .{ "roc_builtins_str_split", {} },
     .{ "roc_builtins_str_starts_with", {} },
     .{ "roc_builtins_str_to_utf8", {} },
+    .{ "roc_builtins_str_get_utf8_byte_unsafe", {} },
+    .{ "roc_builtins_str_substring_unsafe", {} },
     .{ "roc_builtins_str_trim", {} },
     .{ "roc_builtins_str_trim_end", {} },
     .{ "roc_builtins_str_trim_start", {} },

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -9975,6 +9975,10 @@ const BodyContext = struct {
         return Ident.textEql(text, "Builtin.List.iter");
     }
 
+    fn isBuiltinStrIterUtf8Text(text: []const u8) bool {
+        return Ident.textEql(text, "Builtin.Str.iter_utf8");
+    }
+
     fn isBuiltinIterMapText(text: []const u8) bool {
         return Ident.textEql(text, "Builtin.Iter.map");
     }
@@ -11179,6 +11183,23 @@ const BodyContext = struct {
             }
             const components = [_]Type.TypeId{arg_tys[0]};
             return try self.functionTypeWithReturn(arg_tys, try self.generatedIteratorType(.list, fn_data.ret, &components, null));
+        }
+
+        if (isBuiltinStrIterUtf8Text(text)) {
+            if (checked_args.len != 1 or arg_tys.len != 1) Common.invariant("Str.iter_utf8 reached Monotype with an unexpected arity");
+            if (expected_ret_ty) |expected| {
+                if (self.isGeneratedIteratorEvidenceType(expected)) {
+                    const stable_expected = try self.stableGeneratedIteratorEvidenceType(expected);
+                    if (self.isForcedDynamicIteratorType(stable_expected)) {
+                        return try self.functionTypeWithReturn(arg_tys, stable_expected);
+                    }
+                    const expected_args = try self.generatedIteratorComponentArgs(stable_expected, 1);
+                    defer self.allocator.free(expected_args);
+                    return try self.functionTypeWithReturn(expected_args, stable_expected);
+                }
+            }
+            const components = [_]Type.TypeId{arg_tys[0]};
+            return try self.functionTypeWithReturn(arg_tys, try self.generatedIteratorType(.str, fn_data.ret, &components, null));
         }
 
         if (isBuiltinIterSingleText(text)) {

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -80,6 +80,7 @@ pub const IteratorKind = enum(u8) {
     none,
     custom,
     list,
+    str,
     single,
     range_exclusive,
     range_inclusive,

--- a/test/alloc-count/app.roc
+++ b/test/alloc-count/app.roc
@@ -31,6 +31,7 @@ run! = |input| {
 	check_large_to_utf8_allocs!(large)
 	check_drop_allocs!(large)
 	check_rejected_drop_allocs!(multibyte)
+	check_json_parse_allocs!(input)
 
     "sum: ${$sum.to_str()}, loop allocations: ${loop_allocs.to_str()}"
 }
@@ -68,6 +69,36 @@ check_drop_allocs! = |str| {
 	last_allocs = Host.alloc_count!() - last_before
 	expect last_allocs == 0
 	expect last == Ok(Str.drop_suffix(str, "t"))
+	{}
+}
+
+# Parsing a small (SSO) JSON document whose string fields are clean (no escapes)
+# performs zero allocations, whether the string field is decoded or skipped: the
+# scanner walks the Str in place and clean bodies decode as zero-copy slices.
+check_json_parse_allocs! : Str => {}
+check_json_parse_allocs! = |input| {
+	# first two bytes of the hosted input, so the document is runtime data
+	two = match Str.drop_last_bytes(input, Str.count_utf8_bytes(input) - 2) {
+		Ok(s) => s
+		Err(_) => {
+			crash "alloc-count harness invariant violated: input shorter than 2 bytes"
+		}
+	}
+	doc = Str.concat("{\"s\":\"", Str.concat(two, "\",\"a\":7}"))
+
+	decode_before = Host.alloc_count!()
+	decoded : Try({ s : Str, a : U64 }, Json.ParseErr)
+	decoded = Json.parse(doc)
+	decode_allocs = Host.alloc_count!() - decode_before
+	expect decode_allocs == 0
+	expect decoded == Ok({ s: two, a: 7 })
+
+	skip_before = Host.alloc_count!()
+	skipped : Try({ a : U64 }, Json.ParseErr)
+	skipped = Json.parse(doc)
+	skip_allocs = Host.alloc_count!() - skip_before
+	expect skip_allocs == 0
+	expect skipped == Ok({ a: 7 })
 	{}
 }
 

--- a/test/alloc-count/app.roc
+++ b/test/alloc-count/app.roc
@@ -99,6 +99,15 @@ check_json_parse_allocs! = |input| {
 	skip_allocs = Host.alloc_count!() - skip_before
 	expect skip_allocs == 0
 	expect skipped == Ok({ a: 7 })
+
+	# a skipped numeric field: scalar validation must not allocate either
+	num_doc = Str.concat("{\"z\":", Str.concat(Str.repeat("7", 1 + Str.count_utf8_bytes(input) % 3), ",\"a\":1}"))
+	skip_num_before = Host.alloc_count!()
+	skipped_num : Try({ a : U64 }, Json.ParseErr)
+	skipped_num = Json.parse(num_doc)
+	skip_num_allocs = Host.alloc_count!() - skip_num_before
+	expect skip_num_allocs == 0
+	expect skipped_num == Ok({ a: 1 })
 	{}
 }
 

--- a/test/alloc-count/app.roc
+++ b/test/alloc-count/app.roc
@@ -2,12 +2,16 @@ app [run!] { pf: platform "./platform/main.roc" }
 
 import pf.Host
 
-# Regression test: a `for` loop over a list's bytes must not allocate on each
-# iteration. Setup work (Str.to_utf8's copy) happens before the first count is
-# taken, so `loop_allocs` measures the loop alone.
+# Allocation regression coverage for lazy UTF-8 string iteration and byte
+# slicing. All measured strings depend on the hosted input so compile-time
+# evaluation cannot remove the operations.
 run! : Str => Str
 run! = |input| {
+	# Harness control: converting an SSO string to List(U8) must allocate.
+	control_before = Host.alloc_count!()
     bytes = Str.to_utf8(input)
+	control_allocs = Host.alloc_count!() - control_before
+	expect control_allocs == 1
 
     before = Host.alloc_count!()
 
@@ -19,5 +23,66 @@ run! = |input| {
     loop_allocs = Host.alloc_count!() - before
     expect loop_allocs == 0
 
+	large = Str.concat(input, input)
+	multibyte = Str.concat(large, "é")
+
+	check_iter_allocs!(input, $sum)
+	check_iter_allocs!(large, $sum * 2)
+	check_large_to_utf8_allocs!(large)
+	check_drop_allocs!(large)
+	check_rejected_drop_allocs!(multibyte)
+
     "sum: ${$sum.to_str()}, loop allocations: ${loop_allocs.to_str()}"
+}
+
+check_iter_allocs! : Str, U64 => {}
+check_iter_allocs! = |str, expected| {
+	before = Host.alloc_count!()
+	sum = Iter.fold(Str.iter_utf8(str), 0, |acc, byte| acc + byte.to_u64())
+	allocs = Host.alloc_count!() - before
+	expect allocs == 0
+	expect sum == expected
+	{}
+}
+
+check_large_to_utf8_allocs! : Str => {}
+check_large_to_utf8_allocs! = |str| {
+	before = Host.alloc_count!()
+	bytes = Str.to_utf8(str)
+	allocs = Host.alloc_count!() - before
+	expect allocs == 0
+	expect List.len(bytes) == Str.count_utf8_bytes(str)
+	{}
+}
+
+check_drop_allocs! : Str => {}
+check_drop_allocs! = |str| {
+	first_before = Host.alloc_count!()
+	first = Str.drop_first_bytes(str, 1)
+	first_allocs = Host.alloc_count!() - first_before
+	expect first_allocs == 0
+	expect first == Ok(Str.drop_prefix(str, "s"))
+
+	last_before = Host.alloc_count!()
+	last = Str.drop_last_bytes(str, 1)
+	last_allocs = Host.alloc_count!() - last_before
+	expect last_allocs == 0
+	expect last == Ok(Str.drop_suffix(str, "t"))
+	{}
+}
+
+check_rejected_drop_allocs! : Str => {}
+check_rejected_drop_allocs! = |str| {
+	first_before = Host.alloc_count!()
+	first = Str.drop_first_bytes(str, Str.count_utf8_bytes(str) - 1)
+	first_allocs = Host.alloc_count!() - first_before
+	expect first_allocs == 0
+	expect first == Err(BadUtf8)
+
+	last_before = Host.alloc_count!()
+	last = Str.drop_last_bytes(str, 1)
+	last_allocs = Host.alloc_count!() - last_before
+	expect last_allocs == 0
+	expect last == Err(BadUtf8)
+	{}
 }

--- a/test/cli/JsonStringEscapes.roc
+++ b/test/cli/JsonStringEscapes.roc
@@ -553,3 +553,32 @@ expect {
 
 	round_tripped == Ok(original)
 }
+
+# the maximum code point (U+10FFFF) arrives as the highest surrogate pair
+expect {
+	result : Try(Str, Json.ParseErr)
+	result = Json.parse("\"\\uDBFF\\uDFFF\"")
+
+	expected = Str.from_utf8([244, 143, 191, 191])
+
+	match (result, expected) {
+		(Ok(parsed), Ok(want)) => parsed == want
+		_ => False
+	}
+}
+
+# a surrogate pair truncated inside its second escape is rejected
+expect {
+	result : Try(Str, Json.ParseErr)
+	result = Json.parse("\"\\uD83D\\uDE\"")
+
+	result == Err(Json.invalid_json)
+}
+
+# a high surrogate followed by literal characters is rejected
+expect {
+	result : Try(Str, Json.ParseErr)
+	result = Json.parse("\"\\uD83Dxy\"")
+
+	result == Err(Json.invalid_json)
+}

--- a/test/json-decoder/app.roc
+++ b/test/json-decoder/app.roc
@@ -2,6 +2,15 @@ app [main!] { pf: platform "./platform/main.roc" }
 
 main! : Str => U64
 main! = |json| {
+	if !Str.starts_with(json, "{") {
+		scalar_result : Try(U64, Json.ParseErr)
+		scalar_result = Json.parse(json)
+		return match scalar_result {
+			Ok(value) => value
+			Err(_) => 999999
+		}
+	}
+
 	decoded_result : Try(
 		{
 			explicit_optional : Try(Str, [Missing]),


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #10173, which should merge first. Two commits: strings, then scalars. (Supersedes ESRogs/roc#1.)

## Summary

- rewrite JSON string scanning and decoding to walk the `Str` directly; the closing-quote split becomes two zero-copy slices instead of two O(length) passes per string
- rework the shared escape parser into `parse_json_escaped_code_point`, reading bytes at an index
- refactor `Str.drop_first_bytes` to validate-then-delegate to a private unchecked slice helper shared with the scanner
- convert the scalar/Dec validators (`is_json_number`, `json_dec_digits_are_zero`, `trim_json_dec_leading_zeros`, `normalize_json_dec_digits`) to the same in-place style
- net effect: the JSON parse path never converts `Str` to `List(U8)`, and parsing a small (SSO) document with clean string fields is zero-allocation, pinned by new alloc-count checks

## Benchmarks

20,000 `Json.parse` calls decoding `{ k0 : Str }`; interleaved medians, this branch vs #10173's tip (default LLVM `--opt=speed`, macOS arm64):

| document | base | this PR |
|---|---|---|
| 500 short string fields | 1.20 s | 1.00 s (-16%) |
| 3 × 4.9 KB string fields | 0.19 s | 0.17 s (-9%) |
| 300 escape-bearing fields (validated during skip) | 0.95 s | 0.76 s (-20%) |
| 500 numeric fields | 1.21 s | 1.15 s (-5%) |

<details>
<summary>Methodology and raw runs</summary>

```
# 20,000 Json.parse calls decoding { k0 : Str } per run; 10 alternating runs per corpus
# this branch vs #10173's tip, macOS arm64, roc build --opt=speed
short_strings base: 1194 1193 1197 1195 1193 1197 1195 1196 1191 2105
short_strings pr:   996 1001 1000 1010 1006 1009 1006 1007 996 999
large_strings base: 190 191 191 190 193 190 191 191 191 193
large_strings pr:   173 173 173 173 173 173 173 173 173 173
escapes base: 947 949 941 939 945 945 946 950 942 932
escapes pr:   752 756 758 757 754 760 760 752 762 768
numbers base: 1212 1211 1214 1216 1223 1217 1214 1212 1209 1212
numbers pr:   1154 1168 1151 1155 1150 1156 1151 1150 1159 1150
```

Corpora are generated JSON objects (pretty-printed, 2-space indent): `k0` is the decoded field; remaining fields are skipped. The escape corpus interleaves `\n`, `\t`, `\"`, and `\u00e9` escapes; the numeric corpus is floats with one string anchor at `k0`.
</details>

## Testing

- `roc test`: JsonStringEscapes (67, including new max-code-point and truncated-pair cases), JsonScalarParseEdgeCases (51), JsonEncodeNumberEdgeCases (13), JsonEncodeRoundTrip (27)
- alloc-count platform app on the dev backend and `--opt=speed`, including the new zero-allocation checks

## Known debt

Parse failures all collapse into `Json.invalid_json` with no position information. Enriching `ParseErr` (the way `InvalidHex` carries `{ index, byte }`) is follow-up work.
