### PR TITLE
Propagate Dec division crashes in evaluators

### DIFF
--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -7134,6 +7134,14 @@ pub const Interpreter = struct {
         };
     }
 
+    fn callDecBinaryBuiltin(self: *LirInterpreter, comptime func: anytype, av: i128, bv: i128) Error!i128 {
+        var crash_boundary = self.enterCrashBoundary();
+        defer crash_boundary.deinit();
+        const sj = crash_boundary.set();
+        if (sj != 0) return error.Crash;
+        return func(RocDec{ .num = av }, RocDec{ .num = bv }, &self.roc_ops);
+    }
+
     /// Dec (fixed-point i128 with 10^18 scale) binary operation.
     fn decBinOp(self: *LirInterpreter, av: i128, bv: i128, op: NumOp) Error!i128 {
         return switch (op) {
@@ -7147,28 +7155,10 @@ pub const Interpreter = struct {
                 if (result.has_overflowed) return self.triggerCrash("Decimal multiplication overflowed!");
                 break :blk result.value.num;
             },
-            .div => blk: {
-                var crash_boundary = self.enterCrashBoundary();
-                defer crash_boundary.deinit();
-                const sj = crash_boundary.set();
-                if (sj != 0) break :blk @as(i128, 0);
-                break :blk builtins.dec.divC(RocDec{ .num = av }, RocDec{ .num = bv }, &self.roc_ops);
-            },
-            .div_trunc => blk: {
-                var crash_boundary = self.enterCrashBoundary();
-                defer crash_boundary.deinit();
-                const sj = crash_boundary.set();
-                if (sj != 0) break :blk @as(i128, 0);
-                break :blk builtins.dec.divTruncC(RocDec{ .num = av }, RocDec{ .num = bv }, &self.roc_ops);
-            },
-            .rem => blk: {
-                if (bv == 0) break :blk @as(i128, 0);
-                break :blk builtins.dec.remC(RocDec{ .num = av }, RocDec{ .num = bv }, &self.roc_ops);
-            },
-            .mod => blk: {
-                if (bv == 0) break :blk @as(i128, 0);
-                break :blk builtins.dec.modC(RocDec{ .num = av }, RocDec{ .num = bv }, &self.roc_ops);
-            },
+            .div => self.callDecBinaryBuiltin(builtins.dec.divC, av, bv),
+            .div_trunc => self.callDecBinaryBuiltin(builtins.dec.divTruncC, av, bv),
+            .rem => self.callDecBinaryBuiltin(builtins.dec.remC, av, bv),
+            .mod => self.callDecBinaryBuiltin(builtins.dec.modC, av, bv),
         };
     }
 

--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -626,4 +626,20 @@ pub const tests = [_]TestCase{
         ,
         .expected = .{ .inspect_str = "42" },
     },
+    .{
+        // https://github.com/roc-lang/roc/issues/10210
+        .name = "issue 10210: Dec division by zero crashes on every executor",
+        .source =
+        \\{
+        \\    f = |a, b| a / b
+        \\    f(1.0.Dec, 0.0.Dec)
+        \\}
+        ,
+        .expected = .{ .crash = {} },
+    },
+    .{
+        .name = "issue 10210: Dec truncating division by zero crashes on every executor",
+        .source = "Dec.div_trunc_by(1.0, 0.0)",
+        .expected = .{ .crash = {} },
+    },
 };

--- a/src/eval/test/lambda_mono_differential_runner.zig
+++ b/src/eval/test/lambda_mono_differential_runner.zig
@@ -59,10 +59,6 @@ const Case = struct {
     /// pre-existing bug tracked in the generated corpus). Such a child
     /// failure is reported but does not fail the run.
     known_panic: bool = false,
-    /// Generated case with a known pre-existing interpreter-vs-dev backend
-    /// disagreement; the dev comparison is skipped, the tree-evaluator
-    /// comparison still runs.
-    skip_dev: bool = false,
 };
 
 const CaseStatus = enum {
@@ -491,7 +487,6 @@ pub fn main(init: std.process.Init) RunnerError!void {
                 .source_kind = if (case.module) .module else .expr,
                 .origin = .generated,
                 .known_panic = case.known_panic,
-                .skip_dev = case.skip_dev,
             });
         }
     }
@@ -708,7 +703,7 @@ fn runCase(gpa: std.mem.Allocator, io: std.Io, case: Case) std.mem.Allocator.Err
 
     // Cross-backend agreement for the sweep corpus: the dev JIT must agree
     // with the interpreter on the same compile.
-    if (case.origin == .generated and !case.skip_dev) {
+    if (case.origin == .generated) {
         if (try compareDevBackend(gpa, case, &compiled.lowered, &transcript)) |detail| {
             return CaseResult{ .status = .dev_diverged, .detail = detail };
         }

--- a/src/eval/test/lambda_mono_generated_corpus.zig
+++ b/src/eval/test/lambda_mono_generated_corpus.zig
@@ -28,12 +28,6 @@ pub const Case = struct {
     /// from a container). Kept in the sweep so the harness reports them
     /// loudly; they stop counting as expected once the compiler bug is fixed.
     known_panic: bool = false,
-    /// True for programs where the dev backend is known to disagree with the
-    /// LIR interpreter (a pre-existing backend divergence, not a Lambda Mono
-    /// lowering concern): the interpreter returns 0.0 for Dec division by
-    /// zero while the dev backend crashes. The interpreter-vs-tree-evaluator
-    /// comparison still runs for these.
-    skip_dev: bool = false,
 };
 
 /// All generated sweep cases.
@@ -617,7 +611,6 @@ pub const cases = [_]Case{
         \\    f(1.0.Dec, 0.0.Dec)
         \\}
         ,
-        .skip_dev = true,
     },
     .{
         .name = "gen: dec division result agreement",

--- a/src/postcheck/lambda_mono/eval.zig
+++ b/src/postcheck/lambda_mono/eval.zig
@@ -1417,23 +1417,47 @@ pub const Evaluator = struct {
             .negate => return .{ .dec = -%a },
             .abs => return .{ .dec = if (a < 0) -%a else a },
             .abs_diff => return .{ .dec = if (a > b) a -% b else b -% a },
-            // The interpreter runs these through a crash boundary that yields 0
-            // on any divide-by-zero or overflow, so the observable result is 0
-            // in every failing case; this mirrors that outcome without a crash.
-            .div => return .{ .dec = decDivRaw(a, b) },
-            .div_trunc => return .{ .dec = decTrunc(decDivRaw(a, b)) },
+            .div => return .{ .dec = try self.decDiv(a, b) },
+            .div_trunc => return .{ .dec = decTrunc(try self.decDiv(a, b)) },
             .rem => {
-                if (b == 0) return .{ .dec = 0 };
+                if (b == 0) return self.crashAbort("Decimal remainder by 0!");
                 return .{ .dec = @rem(a, b) };
             },
             .mod => {
-                if (b == 0) return .{ .dec = 0 };
+                if (b == 0) return self.crashAbort("Decimal modulo by 0!");
                 const remainder = @rem(a, b);
                 if (remainder == 0) return .{ .dec = 0 };
                 if ((remainder > 0) != (b > 0)) return .{ .dec = remainder +% b };
                 return .{ .dec = remainder };
             },
         }
+    }
+
+    fn decDiv(self: *Evaluator, a: i128, b: i128) EvalError!i128 {
+        if (b == 0) return self.crashAbort("Decimal division by 0!");
+        if (a == 0) return 0;
+
+        const one = RocDec.one_point_zero_i128;
+        const max_i128: u128 = @intCast(std.math.maxInt(i128));
+        const is_negative = (a < 0) != (b < 0);
+        const numerator = absU128(a);
+        if (numerator > max_i128) {
+            if (b == one) return a;
+            return self.crashAbort("Decimal division overflow in numerator!");
+        }
+
+        const denominator = absU128(b);
+        if (denominator > max_i128) {
+            if (a == one) return b;
+            return self.crashAbort("Decimal division overflow in denominator!");
+        }
+
+        const scaled: u256 = @as(u256, numerator) * @as(u256, @intCast(one));
+        const quotient: u256 = scaled / @as(u256, denominator);
+        if (quotient > @as(u256, max_i128)) return self.crashAbort("Decimal division overflow!");
+
+        const magnitude: i128 = @intCast(quotient);
+        return if (is_negative) -magnitude else magnitude;
     }
 
     // transcendental / rounding
@@ -2305,25 +2329,6 @@ fn intType(comptime prim: Primitive) type {
 
 fn absU128(x: i128) u128 {
     return if (x < 0) @bitCast(-%x) else @intCast(x);
-}
-
-/// Divide two Dec fixed-point values, mirroring `RocDec.div`. The production
-/// path catches every divide-by-zero and overflow crash and yields 0, so this
-/// returns 0 in exactly those cases and the scaled quotient otherwise.
-fn decDivRaw(a: i128, b: i128) i128 {
-    if (b == 0 or a == 0) return 0;
-    const one = RocDec.one_point_zero_i128;
-    const max_i128: u128 = @intCast(std.math.maxInt(i128));
-    const neg = (a < 0) != (b < 0);
-    const num_u = absU128(a);
-    if (num_u > max_i128) return if (b == one) a else 0;
-    const den_u = absU128(b);
-    if (den_u > max_i128) return if (a == one) b else 0;
-    const scaled: u256 = @as(u256, num_u) * @as(u256, @intCast(one));
-    const quotient: u256 = scaled / @as(u256, den_u);
-    if (quotient > @as(u256, max_i128)) return 0;
-    const magnitude: i128 = @intCast(quotient);
-    return if (neg) -magnitude else magnitude;
 }
 
 /// Truncate a Dec fixed-point value toward zero, mirroring `RocDec.trunc`.


### PR DESCRIPTION
Decimal division-like operations in the LIR interpreter and Lambda Mono evaluator were converting builtin crashes into 0, causing executor disagreement for zero divisors and other decimal division failures. This propagates the builtin crash through both evaluators, adds cross-backend regression coverage, and removes the differential harness escape hatch for the known divergence. Closes #10210.