### PR TITLE
Reject refutable for loop patterns

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -5550,6 +5550,7 @@ fn checkFileInternal(self: *Self, skip_numeric_defaults: bool) std.mem.Allocator
     try self.reportPolymorphicExecutableRootResults();
 
     try self.reportNonExhaustiveLambdaParams(&env);
+    try self.reportNonExhaustiveForPatterns(&env);
 
     try self.pruneSelectedHoistedRootsAfterSolving();
 
@@ -14560,6 +14561,31 @@ fn checkDestructureExhaustiveness(
     self.known_empty_payload_vars_destructure.clearRetainingCapacity();
     const value_constructors_known = try self.collectKnownEmptyPayloadVarsForExpr(value_expr_idx, value_var, &self.known_empty_payload_vars_destructure);
 
+    try self.checkPatternExhaustiveness(
+        pattern_idx,
+        value_var,
+        self.known_empty_payload_vars_destructure.items,
+        value_constructors_known,
+        env,
+        region,
+    );
+}
+
+/// Check one pattern in an irrefutable binding position against its settled
+/// scrutinee type. Callers supply constructor facts only when a concrete value
+/// expression proves them; function parameters and iterator items have no such
+/// expression and must conservatively cover every inhabitant of their type.
+fn checkPatternExhaustiveness(
+    self: *Self,
+    pattern_idx: CIR.Pattern.Idx,
+    value_var: Var,
+    known_empty_payload_vars: []const Var,
+    value_constructors_known: bool,
+    env: *Env,
+    region: Region,
+) std.mem.Allocator.Error!void {
+    if (!self.patternNeedsExhaustiveness(pattern_idx)) return;
+
     var open_cache = exhaustive.NominalOpenCache.init(self.gpa);
     defer open_cache.deinit();
     const result_or_err = exhaustive.checkDestructure(
@@ -14570,7 +14596,7 @@ fn checkDestructureExhaustiveness(
         self.exhaustiveBuiltinIdents(&open_cache),
         pattern_idx,
         value_var,
-        self.known_empty_payload_vars_destructure.items,
+        known_empty_payload_vars,
         value_constructors_known,
     );
     try self.backfillRegionsForAnalysisVars();
@@ -14620,16 +14646,25 @@ fn checkDestructureExhaustiveness(
 fn reportNonExhaustiveLambdaParams(self: *Self, env: *Env) std.mem.Allocator.Error!void {
     for (self.checked_lambda_params.items) |arg_span| {
         for (self.cir.store.slicePatterns(arg_span)) |pattern_idx| {
-            try self.checkParamPatternExhaustiveness(pattern_idx, env);
+            try self.checkPatternExhaustivenessWithoutValue(pattern_idx, env);
         }
     }
 }
 
-/// Exhaustiveness check for a single function/lambda parameter pattern. Unlike
-/// `checkDestructureExhaustiveness`, a parameter has no value expression, so the
-/// pattern's own type var is the scrutinee and there is no known-empty-payload
-/// information to collect (passed conservatively as empty / not-known).
-fn checkParamPatternExhaustiveness(
+/// Run exhaustiveness analysis on every source `for` pattern after iterator
+/// dispatch has settled the item type. Iterator items are dynamic values, so
+/// the iterable expression cannot supply constructor facts about them.
+fn reportNonExhaustiveForPatterns(self: *Self, env: *Env) std.mem.Allocator.Error!void {
+    for (self.cir.for_loop_dispatch_plans.items.items) |plan| {
+        const pattern_idx: CIR.Pattern.Idx = @enumFromInt(plan.pattern_idx);
+        try self.checkPatternExhaustivenessWithoutValue(pattern_idx, env);
+    }
+}
+
+/// Exhaustiveness check for a pattern without a concrete value expression.
+/// The pattern's own type var is the scrutinee and there is no constructor
+/// information to narrow the set of values it must cover.
+fn checkPatternExhaustivenessWithoutValue(
     self: *Self,
     pattern_idx: CIR.Pattern.Idx,
     env: *Env,
@@ -14637,51 +14672,8 @@ fn checkParamPatternExhaustiveness(
     if (!self.patternNeedsExhaustiveness(pattern_idx)) return;
 
     const value_var = ModuleEnv.varFrom(pattern_idx);
-    var open_cache = exhaustive.NominalOpenCache.init(self.gpa);
-    defer open_cache.deinit();
-    const result_or_err = exhaustive.checkDestructure(
-        self.cir.gpa,
-        self.types,
-        self.cir,
-        &self.cir.store,
-        self.exhaustiveBuiltinIdents(&open_cache),
-        pattern_idx,
-        value_var,
-        &.{},
-        false,
-    );
-    try self.backfillRegionsForAnalysisVars();
-    const result = result_or_err catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        error.TypeError => return,
-    };
-    defer result.deinit(self.cir.gpa);
-
     const region = self.cir.store.getNodeRegion(ModuleEnv.nodeIdxFrom(pattern_idx));
-    try self.closeExhaustiveVars(result, env, region);
-
-    if (result.is_exhaustive) return;
-
-    const value_snapshot = try self.snapshots.snapshotVarForError(self.types, &self.type_writer, value_var);
-    const missing_patterns_start = self.problems.missing_patterns_backing.items.len;
-    for (result.missing_patterns) |pattern| {
-        const idx = try exhaustive.formatPattern(
-            &self.problems.extra_strings_backing,
-            &self.cir.common.idents,
-            &self.cir.common.strings,
-            pattern,
-        );
-        try self.problems.missing_patterns_backing.append(idx);
-    }
-    const missing_patterns_range = problem.MissingPatternsRange{
-        .start = missing_patterns_start,
-        .count = self.problems.missing_patterns_backing.items.len - missing_patterns_start,
-    };
-    try self.problems.appendPendingStaticExhaustiveness(self.gpa, .destructure, self.pendingExhaustivenessMode(), .{ .destructure_pattern = pattern_idx }, region, .{ .non_exhaustive_destructure = .{
-        .pattern = pattern_idx,
-        .value_snapshot = value_snapshot,
-        .missing_patterns = missing_patterns_range,
-    } });
+    try self.checkPatternExhaustiveness(pattern_idx, value_var, &.{}, false, env, region);
 }
 
 // stmts //
@@ -16528,7 +16520,8 @@ fn checkIteratorForLoop(
     var does_fx = false;
     const child_expected = expected.forStatement();
 
-    try self.checkPattern(pattern, .for_, env);
+    const pattern_ctx: PatternCtx = if (self.patternNeedsExhaustiveness(pattern)) .match_branch else .for_;
+    try self.checkPattern(pattern, pattern_ctx, env);
     const item_var: Var = ModuleEnv.varFrom(pattern);
 
     does_fx = try self.checkExpr(iterable, env, child_expected) or does_fx;

--- a/src/postcheck/monotype_lifted/lift.zig
+++ b/src/postcheck/monotype_lifted/lift.zig
@@ -182,11 +182,13 @@ fn movedMonoView(source: *const Mono.Program, moved: *const Ast.Program) Mono.Pr
 }
 
 /// Recompute every lifted function's capture span from the current function
-/// bodies, then rebase every function reference/direct-call capture operand
-/// span to the recomputed capture slot order. Transformations that clone or
-/// rewrite lifted bodies must call this after they finish mutating the program,
-/// because substitutions can change the capture shape of the rewritten
-/// functions.
+/// bodies, then rebase every reachable function reference/direct-call capture
+/// operand span to the recomputed capture slot order. Transformations that
+/// clone or rewrite lifted bodies must call this after they finish mutating the
+/// program, because substitutions can change the capture shape of the rewritten
+/// functions. Replaced bodies remain in the append-only expression store but
+/// are not part of the executable program and therefore need no capture
+/// operands.
 pub fn recomputeCaptures(allocator: Allocator, program: *Ast.Program) Allocator.Error!void {
     var graph = try CaptureDependencyGraph.init(allocator, program, null);
     defer graph.deinit();
@@ -199,15 +201,28 @@ pub fn recomputeCaptures(allocator: Allocator, program: *Ast.Program) Allocator.
         program.setFnCaptures(fn_id, try program.addTypedLocalSpan(graph.states[index].captures.items));
     }
 
-    verifyCaptureInvariants(program);
+    verifyActiveCaptureInvariants(program, &graph);
 }
 
-/// Debug-only structural check that a Lifted program's capture representation is
-/// internally consistent. It is run after every Lifted-IR mutation (the initial
-/// lift and `recomputeCaptures`, which follows spec_constr / any body rewrite),
-/// so a pass that forgets to maintain captures fails deterministically at its
-/// own boundary instead of surfacing as a confusing crash five stages later.
-/// Compiled out entirely in release builds — release cost is zero.
+/// Verify the capture representation that is reachable from current function
+/// bodies. Post-lift transforms use append-only stores, so expressions from
+/// replaced bodies can retain capture operands for the old function shapes;
+/// they are deliberately absent from the active capture graph and cannot reach
+/// downstream compilation.
+fn verifyActiveCaptureInvariants(program: *const Ast.Program, graph: *const CaptureDependencyGraph) void {
+    if (@import("builtin").mode != .Debug) return;
+    const violation = checkActiveCaptureInvariants(program, graph) catch |err| switch (err) {
+        error.OutOfMemory => Common.invariant("verifyActiveCaptureInvariants: out of memory during structural check"),
+    };
+    if (violation) |message| std.debug.panic("postcheck invariant violated: {s}", .{message});
+}
+
+/// Debug-only structural check that a freshly lifted program's entire capture
+/// backing store is internally consistent. Post-lift transforms use append-only
+/// stores and can leave replaced expressions behind; `recomputeCaptures` checks
+/// the active capture graph instead. Both checks fail at the mutation boundary
+/// instead of surfacing as a confusing crash five stages later. Compiled out
+/// entirely in release builds — release cost is zero.
 ///
 /// It checks, per function and per `fn_ref`/`call_proc` site:
 ///   - every capture slot's local carries a CaptureId, and the slot's type
@@ -241,6 +256,40 @@ pub fn checkCaptureInvariants(program: *const Ast.Program) Allocator.Error!?[]co
                 .func => {},
             },
             else => {},
+        }
+    }
+    return null;
+}
+
+fn checkActiveCaptureInvariants(program: *const Ast.Program, graph: *const CaptureDependencyGraph) Allocator.Error!?[]const u8 {
+    for (program.fnsView()) |fn_| {
+        if (checkCaptureSlotSpan(program, program.typedLocalSpan(fn_.captures))) |message| return message;
+    }
+
+    for (graph.edges.items) |edge| {
+        if (!edge.active) continue;
+        switch (edge.site) {
+            .pre_lift => return "post-lift capture graph contained an active pre-lift edge",
+            .fn_ref => |expr_id| {
+                const fn_ref = switch (program.getExpr(expr_id).data) {
+                    .fn_ref => |fn_ref| fn_ref,
+                    else => return "active capture graph function-reference site changed expression kind",
+                };
+                if (fn_ref.fn_id != edge.target) return "active capture graph function-reference target changed";
+                if (try checkOperandSpan(program, edge.target, fn_ref.captures)) |message| return message;
+            },
+            .call_proc => |expr_id| {
+                const call = switch (program.getExpr(expr_id).data) {
+                    .call_proc => |call| call,
+                    else => return "active capture graph direct-call site changed expression kind",
+                };
+                const target = switch (call.callee) {
+                    .lifted => |fn_id| fn_id,
+                    .func => return "active capture graph direct-call target changed kind",
+                };
+                if (target != edge.target) return "active capture graph direct-call target changed";
+                if (try checkOperandSpan(program, edge.target, call.captures)) |message| return message;
+            },
         }
     }
     return null;
@@ -2538,6 +2587,48 @@ test "capture graph does not activate an operand for a removed target slot" {
         else => return error.TestUnexpectedResult,
     };
     try std.testing.expectEqual(@as(usize, 0), program.captureOperandSpan(finalized.captures).len);
+}
+
+test "capture recomputation excludes replaced bodies from the active invariant" {
+    const allocator = std.testing.allocator;
+    var program = initCaptureTestProgram(allocator);
+    defer program.deinit();
+
+    const ty = try program.types.add(.zst);
+    const binder: checked.PatternBinderId = @enumFromInt(1);
+    const stale_capture = try program.addLocalWithBinder(@enumFromInt(1), ty, binder);
+    const stale_slots = try program.addTypedLocalSpan(&.{.{ .local = stale_capture, .ty = ty }});
+    const callee_body = try program.addExpr(.{ .ty = ty, .data = .unit });
+    const callee = try program.addFn(.{
+        .symbol = @enumFromInt(1),
+        .args = .empty(),
+        .captures = stale_slots,
+        .body = .{ .roc = callee_body },
+        .ret = ty,
+    });
+
+    const supplied_value = try program.addExpr(.{ .ty = ty, .data = .{ .local = stale_capture } });
+    const supplied_span = try program.addCaptureOperandSpan(&.{.{
+        .id = checked.CaptureId.fromBinder(binder),
+        .value = supplied_value,
+    }});
+    const replaced_reference = try program.addExpr(.{ .ty = ty, .data = .{ .fn_ref = .{
+        .fn_id = callee,
+        .captures = supplied_span,
+    } } });
+
+    try recomputeCaptures(allocator, &program);
+
+    try std.testing.expectEqual(@as(usize, 0), program.typedLocalSpan(program.getFn(callee).captures).len);
+    const stale_reference = switch (program.getExpr(replaced_reference).data) {
+        .fn_ref => |fn_ref| fn_ref,
+        else => return error.TestUnexpectedResult,
+    };
+    try std.testing.expectEqual(@as(usize, 1), program.captureOperandSpan(stale_reference.captures).len);
+    try std.testing.expectEqualStrings(
+        "operand count differed from target capture slot count",
+        (try checkCaptureInvariants(&program)).?,
+    );
 }
 
 test "capture graph propagates recursive captures with a worklist" {

--- a/test/cli/ParserTagPayloadProtocol.roc
+++ b/test/cli/ParserTagPayloadProtocol.roc
@@ -1,8 +1,12 @@
 ParserTagPayloadProtocol :: [].{}
 
-Token := [TagName(Str), Start, Next, Finish, StrValue(Str), U64Value(U64)]
+Token := [TagName(Str), Start, Next, Finish, StrValue(Str), U64Value(U64)].{
+	is_eq : _
+}
 
-ParseErr := [Invalid]
+ParseErr := [Invalid].{
+	is_eq : _
+}
 
 Format := [Default].{
 	parse_tag_union : Format, Encoding.ParseTagUnionSpec(a), List(Token) -> Try({ value : a, rest : List(Token) }, ParseErr)

--- a/test/snapshots/statement/for_loop_refutable_literal_pattern.md
+++ b/test/snapshots/statement/for_loop_refutable_literal_pattern.md
@@ -1,0 +1,106 @@
+# META
+~~~ini
+description=A for loop pattern must be exhaustive for every item produced by its iterator
+type=file
+~~~
+# SOURCE
+~~~roc
+main! = |_args| {
+    for 1 in [1, 2] {}
+    Ok({})
+}
+~~~
+# EXPECTED
+NON EXHAUSTIVE DESTRUCTURE - for_loop_refutable_literal_pattern.md:2:9:2:10
+# PROBLEMS
+
+┌────────────────────────────┐
+│ NON EXHAUSTIVE DESTRUCTURE ├─ This destructuring pattern doesn't cover ─────┐
+└┬───────────────────────────┘  all possible cases.                           │
+ │                                                                            │
+ │  for 1 in [1, 2] {}                                                        │
+ │      ‾                                                                     │
+ └───────────────────────────────── for_loop_refutable_literal_pattern.md:2:9 ┘
+
+    The value being destructured has type:
+            Dec
+
+    Missing patterns:
+            _
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,NamedUnderscore,OpBar,OpenCurly,
+KwFor,Int,KwIn,OpenSquare,Int,Comma,Int,CloseSquare,OpenCurly,CloseCurly,
+UpperIdent,NoSpaceOpenRound,OpenCurly,CloseCurly,CloseRound,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-ident (raw "_args")))
+				(e-block
+					(statements
+						(s-for
+							(p-int (raw "1"))
+							(e-list
+								(e-int (raw "1"))
+								(e-int (raw "2")))
+							(e-record))
+						(e-apply
+							(e-tag (raw "Ok"))
+							(e-record))))))))
+~~~
+# FORMATTED
+~~~roc
+main! = |_args| {
+	for 1 in [1, 2] {}
+	Ok({})
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "echo!"))
+		(e-hosted-lambda (symbol "echo!")
+			(args
+				(p-assign (ident "_echo_arg"))))
+		(annotation
+			(ty-fn (effectful true)
+				(ty-lookup (name "Str") (builtin))
+				(ty-record))))
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-assign (ident "_args")))
+			(e-block
+				(s-for
+					(p-num (value "1"))
+					(e-list
+						(elems
+							(e-num (value "1"))
+							(e-num (value "2"))))
+					(e-empty_record))
+				(e-tag (name "Ok")
+					(args
+						(e-empty_record)))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Str => {}"))
+		(patt (type "_arg -> [Ok({}), ..]")))
+	(expressions
+		(expr (type "Str => {}"))
+		(expr (type "_arg -> [Ok({}), ..]"))))
+~~~

--- a/test/snapshots/statement/for_loop_refutable_tag_pattern.md
+++ b/test/snapshots/statement/for_loop_refutable_tag_pattern.md
@@ -1,0 +1,117 @@
+# META
+~~~ini
+description=A for loop tag pattern must cover every tag in the iterator item type
+type=file
+~~~
+# SOURCE
+~~~roc
+main! = |_args| {
+    for Ok(_value) in [Ok(1), Err("bad")] {}
+    Ok({})
+}
+~~~
+# EXPECTED
+NON EXHAUSTIVE DESTRUCTURE - for_loop_refutable_tag_pattern.md:2:9:2:19
+# PROBLEMS
+
+┌────────────────────────────┐
+│ NON EXHAUSTIVE DESTRUCTURE ├─ This destructuring pattern doesn't cover ─────┐
+└┬───────────────────────────┘  all possible cases.                           │
+ │                                                                            │
+ │  for Ok(_value) in [Ok(1), Err("bad")] {}                                  │
+ │      ‾‾‾‾‾‾‾‾‾‾                                                            │
+ └───────────────────────────────────── for_loop_refutable_tag_pattern.md:2:9 ┘
+
+    The value being destructured has type:
+            [Err(Str), Ok(Dec), ..]
+
+    Missing patterns:
+            Err _
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpBar,NamedUnderscore,OpBar,OpenCurly,
+KwFor,UpperIdent,NoSpaceOpenRound,NamedUnderscore,CloseRound,KwIn,OpenSquare,UpperIdent,NoSpaceOpenRound,Int,CloseRound,Comma,UpperIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,CloseSquare,OpenCurly,CloseCurly,
+UpperIdent,NoSpaceOpenRound,OpenCurly,CloseCurly,CloseRound,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-decl
+			(p-ident (raw "main!"))
+			(e-lambda
+				(args
+					(p-ident (raw "_args")))
+				(e-block
+					(statements
+						(s-for
+							(p-tag (raw "Ok")
+								(p-ident (raw "_value")))
+							(e-list
+								(e-apply
+									(e-tag (raw "Ok"))
+									(e-int (raw "1")))
+								(e-apply
+									(e-tag (raw "Err"))
+									(e-string
+										(e-string-part (raw "bad")))))
+							(e-record))
+						(e-apply
+							(e-tag (raw "Ok"))
+							(e-record))))))))
+~~~
+# FORMATTED
+~~~roc
+main! = |_args| {
+	for Ok(_value) in [Ok(1), Err("bad")] {}
+	Ok({})
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "echo!"))
+		(e-hosted-lambda (symbol "echo!")
+			(args
+				(p-assign (ident "_echo_arg"))))
+		(annotation
+			(ty-fn (effectful true)
+				(ty-lookup (name "Str") (builtin))
+				(ty-record))))
+	(d-let
+		(p-assign (ident "main!"))
+		(e-lambda
+			(args
+				(p-assign (ident "_args")))
+			(e-block
+				(s-for
+					(p-applied-tag)
+					(e-list
+						(elems
+							(e-tag (name "Ok")
+								(args
+									(e-num (value "1"))))
+							(e-tag (name "Err")
+								(args
+									(e-string
+										(e-literal (string "bad")))))))
+					(e-empty_record))
+				(e-tag (name "Ok")
+					(args
+						(e-empty_record)))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Str => {}"))
+		(patt (type "_arg -> [Ok({}), ..]")))
+	(expressions
+		(expr (type "Str => {}"))
+		(expr (type "_arg -> [Ok({}), ..]"))))
+~~~


### PR DESCRIPTION
For-loop patterns are irrefutable binding positions, but the checker only type-checked them, allowing literal patterns to compile and fail at runtime. This checks loop patterns for exhaustiveness after iterator dispatch settles their item type and types refutable tag patterns openly, so invalid loops receive the existing NON EXHAUSTIVE DESTRUCTURE diagnostic with the actual missing cases.

Validation exposed a postcheck debug panic: capture recomputation updates references reachable from current function bodies, while the verifier scanned stale expressions retained from replaced append-only bodies. The verifier now checks every active capture-graph edge, with regression coverage for a replaced reference whose target capture set shrinks. The parser payload CLI fixture also declares the required derived equality methods for its nominal Token and ParseErr types.

Fixes #10214.