### PR TITLE
Fix dispatch evidence for functions stored in containers

### DIFF
--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -619,12 +619,14 @@ pub const NumeralDispatchPlan = extern struct {
 pub const SchemeUseRecord = extern struct {
     node_idx: u32,
     /// `Slot` — distinguishes several schemes instantiated at one node (a value
-    /// use vs. the target of a dispatch constraint).
+    /// use, an expression-position function stored as a value, or the target
+    /// of a dispatch constraint).
     slot_kind: u32,
     /// For `dispatch_target` slots, the raw fn `Var` of the constraint whose
     /// discharge instantiated this scheme — unique per constraint
     /// instantiation, so nested evidence chains resolve without ambiguity.
-    /// 0 for `value_use` slots (keyed by `node_idx` instead).
+    /// 0 for value and nested-function use slots (keyed by `node_idx`
+    /// instead).
     slot_data: u32,
     /// The scheme root `Var` used at this edge. For imported schemes this is
     /// the pristine local copy; for shared uses it is the in-flight local root.
@@ -639,6 +641,10 @@ pub const SchemeUseRecord = extern struct {
         /// The scheme of a value that was referenced (e.g. an `e_lookup` of a
         /// generalized definition).
         value_use,
+        /// A generalized expression-position function instantiated when a
+        /// containing value (record, tuple, list, tag, or nominal) stores it.
+        /// The nested function specialization consumes this edge's evidence.
+        nested_function_use,
         /// The scheme of the method target chosen while discharging a static
         /// dispatch constraint originating at this node.
         dispatch_target,
@@ -3764,7 +3770,7 @@ pub fn recordQuoteDispatchPlan(
 
 /// Record a constrained-scheme use for static-dispatch evidence.
 /// `slot_data` is the raw fn `Var` of the discharged constraint for
-/// `dispatch_target` slots and 0 for value-use slots.
+/// `dispatch_target` slots and 0 for value and nested-function use slots.
 pub fn recordSchemeUse(
     self: *Self,
     node_idx: u32,

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -468,6 +468,11 @@ instantiation_source_expr: ?CIR.Expr.Idx = null,
 /// recorded against that node's `dispatch_target` evidence slot (see
 /// `recordSchemeUse`).
 evidence_target_site: ?EvidenceTargetSite = null,
+/// One-shot attribution for the outer scheme instantiation performed when a
+/// containing value stores a generalized expression-position function. It is
+/// consumed at `instantiateVarHelp` entry so any instantiations triggered
+/// while processing that edge cannot be misattributed to the same site.
+pending_nested_function_use: ?CIR.Expr.Idx = null,
 /// Scratch buffer for the (scheme var → fresh var) pairs of one constrained
 /// scheme instantiation, flushed into `cir.scheme_uses`.
 scratch_evidence_pairs: std.ArrayListUnmanaged(ModuleEnv.SchemeUsePair) = .empty,
@@ -3888,6 +3893,9 @@ fn instantiateVarHelp(
     const trace = tracy.trace(@src());
     defer trace.end();
 
+    const nested_function_use = self.pending_nested_function_use;
+    self.pending_nested_function_use = null;
+
     // First, reset state
     instantiator.var_map.clearRetainingCapacity();
     self.constraint_fn_var_map.clearRetainingCapacity();
@@ -4037,7 +4045,15 @@ fn instantiateVarHelp(
     // evidence: publication resolves the fresh vars once checking settles to
     // decide how each of the scheme's dispatch constraints was satisfied here.
     if (self.scratch_evidence_pairs.items.len > 0) {
-        if (self.evidence_target_site) |target| {
+        if (nested_function_use) |source_expr| {
+            try self.cir.recordSchemeUse(
+                @intFromEnum(source_expr),
+                .nested_function_use,
+                0,
+                var_to_instantiate,
+                self.scratch_evidence_pairs.items,
+            );
+        } else if (self.evidence_target_site) |target| {
             try self.cir.recordSchemeUse(
                 target.node_idx,
                 .dispatch_target,
@@ -4047,9 +4063,10 @@ fn instantiateVarHelp(
             );
         } else if (self.instantiation_source_expr) |source_expr| {
             // Only value uses of definitions instantiate schemes whose
-            // constraints later need per-site evidence; other in-expression
-            // instantiations (nominal constructors, Try copies, iterator
-            // declarations, …) never become specialization edges.
+            // constraints later need per-site evidence here; the explicit
+            // nested-function construction edge is handled above. Other
+            // in-expression instantiations (nominal constructors, Try copies,
+            // iterator declarations, …) never become specialization edges.
             switch (self.cir.store.nodes.get(@enumFromInt(@intFromEnum(source_expr))).tag) {
                 .expr_var,
                 .expr_external_lookup,
@@ -12085,6 +12102,41 @@ fn unifyMatchAltPatternBindings(
 
 // expr //
 
+const CheckedStoredValue = struct {
+    does_fx: bool,
+    var_: Var,
+};
+
+/// Check an expression that a containing value stores, instantiating an
+/// expression-position function scheme at this exact construction edge. The
+/// containing value must refer to the fresh instance: embedding the pristine
+/// generalized scheme would let later projections bypass the scheme-use edge
+/// that supplies the nested function's static-dispatch evidence.
+fn checkStoredValueExpr(
+    self: *Self,
+    expr_idx: CIR.Expr.Idx,
+    env: *Env,
+    expected: Expected,
+) std.mem.Allocator.Error!CheckedStoredValue {
+    const does_fx = try self.checkExpr(expr_idx, env, expected);
+    const source_var = ModuleEnv.varFrom(expr_idx);
+    if (self.types.resolveVar(source_var).desc.rank != .generalized) {
+        return .{ .does_fx = does_fx, .var_ = source_var };
+    }
+
+    const previous_source = self.instantiation_source_expr;
+    self.instantiation_source_expr = expr_idx;
+    defer self.instantiation_source_expr = previous_source;
+    std.debug.assert(self.pending_nested_function_use == null);
+    self.pending_nested_function_use = expr_idx;
+    const instance_var = try self.instantiateVar(source_var, env, .use_last_var);
+    std.debug.assert(self.pending_nested_function_use == null);
+    return .{
+        .does_fx = does_fx,
+        .var_ = instance_var,
+    };
+}
+
 fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected) std.mem.Allocator.Error!bool {
     const trace = tracy.trace(@src());
     defer trace.end();
@@ -12355,14 +12407,16 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                 // constrain the rest of the list
 
                 // Check the first elem
-                does_fx = try self.checkExpr(elems[0], env, child_expected) or does_fx;
+                const first_elem = try self.checkStoredValueExpr(elems[0], env, child_expected);
+                does_fx = first_elem.does_fx or does_fx;
 
                 // Iterate over the remaining elements
-                const elem_var = ModuleEnv.varFrom(elems[0]);
+                const elem_var = first_elem.var_;
                 var last_elem_expr_idx = elems[0];
                 for (elems[1..], 1..) |elem_expr_idx, i| {
-                    does_fx = try self.checkExpr(elem_expr_idx, env, child_expected) or does_fx;
-                    const cur_elem_var = ModuleEnv.varFrom(elem_expr_idx);
+                    const current_elem = try self.checkStoredValueExpr(elem_expr_idx, env, child_expected);
+                    does_fx = current_elem.does_fx or does_fx;
+                    const cur_elem_var = current_elem.var_;
 
                     // Unify each element's var with the list's elem var
                     const result = try self.unifyInContext(elem_var, cur_elem_var, env, .{ .list_entry = .{
@@ -12375,7 +12429,8 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                     // to the elem_var to catch their individual errors
                     if (!result.isOk()) {
                         for (elems[i + 1 ..]) |remaining_elem_expr_idx| {
-                            does_fx = try self.checkExpr(remaining_elem_expr_idx, env, child_expected) or does_fx;
+                            const remaining_elem = try self.checkStoredValueExpr(remaining_elem_expr_idx, env, child_expected);
+                            does_fx = remaining_elem.does_fx or does_fx;
                         }
 
                         // Break to avoid cascading errors
@@ -12394,12 +12449,15 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
         .e_tuple => |tuple| {
             // Check tuple elements
             const elems_slice = self.cir.store.exprSlice(tuple.elems);
+            const scratch_vars_top = self.scratch_vars.top();
+            defer self.scratch_vars.clearFrom(scratch_vars_top);
             for (elems_slice) |single_elem_expr_idx| {
-                does_fx = try self.checkExpr(single_elem_expr_idx, env, child_expected) or does_fx;
+                const elem = try self.checkStoredValueExpr(single_elem_expr_idx, env, child_expected);
+                does_fx = elem.does_fx or does_fx;
+                try self.scratch_vars.append(elem.var_);
             }
 
-            // Cast the elems idxs to vars (this works because Anno Idx are 1-1 with type Vars)
-            const elem_vars_slice = try self.types.appendVars(@ptrCast(elems_slice));
+            const elem_vars_slice = try self.types.appendVars(self.scratch_vars.sliceFromStart(scratch_vars_top));
 
             // Set the type in the store
             try self.unifyWith(expr_var, .{ .structure = .{
@@ -12438,13 +12496,14 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                     const field = self.cir.store.getRecordField(field_idx);
 
                     // Check the field value expression
-                    does_fx = try self.checkExpr(field.value, env, child_expected) or does_fx;
+                    const field_value = try self.checkStoredValueExpr(field.value, env, child_expected);
+                    does_fx = field_value.does_fx or does_fx;
 
                     // Create an unbound record with this field
                     const single_field_record = try self.freshFromContent(.{ .structure = .{
                         .record_unbound = try self.types.appendRecordFields(&.{types_mod.RecordField{
                             .name = field.name,
-                            .var_ = ModuleEnv.varFrom(field.value),
+                            .var_ = field_value.var_,
                         }}),
                     } }, env, expr_region);
 
@@ -12469,12 +12528,13 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                     const field = self.cir.store.getRecordField(field_idx);
 
                     // Check the field value expression
-                    does_fx = try self.checkExpr(field.value, env, child_expected) or does_fx;
+                    const field_value = try self.checkStoredValueExpr(field.value, env, child_expected);
+                    does_fx = field_value.does_fx or does_fx;
 
                     // Append it to the scratch records array
                     try self.scratch_record_fields.append(types_mod.RecordField{
                         .name = field.name,
-                        .var_ = ModuleEnv.varFrom(field.value),
+                        .var_ = field_value.var_,
                     });
                 }
 
@@ -12513,14 +12573,18 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
 
             // Process each tag arg
             const arg_expr_idx_slice = self.cir.store.sliceExpr(e.args);
+            const scratch_vars_top = self.scratch_vars.top();
+            defer self.scratch_vars.clearFrom(scratch_vars_top);
             for (arg_expr_idx_slice) |arg_expr_idx| {
-                does_fx = try self.checkExpr(arg_expr_idx, env, child_expected) or does_fx;
+                const arg = try self.checkStoredValueExpr(arg_expr_idx, env, child_expected);
+                does_fx = arg.does_fx or does_fx;
+                try self.scratch_vars.append(arg.var_);
             }
 
             // Create the type
             const ext_var = try self.fresh(env, expr_region);
 
-            const tag = try self.types.mkTag(e.name, @ptrCast(arg_expr_idx_slice));
+            const tag = try self.types.mkTag(e.name, self.scratch_vars.sliceFromStart(scratch_vars_top));
             const tag_union_content = try self.types.mkTagUnion(&[_]types_mod.Tag{tag}, ext_var);
 
             // Update the expr to point to the new type
@@ -12529,8 +12593,9 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
         // nominal //
         .e_nominal => |nominal| {
             // Check the backing expression first
-            does_fx = try self.checkExpr(nominal.backing_expr, env, child_expected) or does_fx;
-            const actual_backing_var = ModuleEnv.varFrom(nominal.backing_expr);
+            const backing = try self.checkStoredValueExpr(nominal.backing_expr, env, child_expected);
+            does_fx = backing.does_fx or does_fx;
+            const actual_backing_var = backing.var_;
 
             // Use shared nominal type checking logic
             _ = try self.checkNominalTypeUsage(
@@ -12544,8 +12609,9 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
         },
         .e_nominal_external => |nominal| {
             // Check the backing expression first
-            does_fx = try self.checkExpr(nominal.backing_expr, env, child_expected) or does_fx;
-            const actual_backing_var = ModuleEnv.varFrom(nominal.backing_expr);
+            const backing = try self.checkStoredValueExpr(nominal.backing_expr, env, child_expected);
+            does_fx = backing.does_fx or does_fx;
+            const actual_backing_var = backing.var_;
 
             // Resolve the external type declaration
             if (try self.resolveVarFromExternal(nominal.module_idx, nominal.target_node_idx)) |ext_ref| {

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -12583,6 +12583,11 @@ const RefScopeRecord = struct {
 /// Sentinel scope id: the template's own evidence params.
 const ref_scope_root: u32 = std.math.maxInt(u32);
 
+const CollectedSchemeUseSite = struct {
+    record_idx: u32,
+    checked_expr: CheckedExprId,
+};
+
 /// Build-time-only per-template data collected by
 /// `sealCheckedProcedureTemplateRefs` for the total-resolution pass; never
 /// serialized (mono looks iterator plans up by node and receives evidence
@@ -12601,6 +12606,12 @@ const TemplateIteratorRefs = struct {
     value_ref_scopes: []u32 = &.{},
     /// Scope of each collected iterator plan ref (parallel to `pool`).
     iterator_scopes: []u32 = &.{},
+    /// Expression-position function instantiation sites, grouped per template.
+    scheme_use_spans: []artifact_serialize.Span = &.{},
+    scheme_use_sites: []CollectedSchemeUseSite = &.{},
+    /// Scope of each collected scheme-use site (parallel to
+    /// `scheme_use_sites`).
+    scheme_use_scopes: []u32 = &.{},
 
     fn deinit(self: *TemplateIteratorRefs, allocator: Allocator) void {
         allocator.free(self.spans);
@@ -12609,6 +12620,9 @@ const TemplateIteratorRefs = struct {
         allocator.free(self.plan_scopes);
         allocator.free(self.value_ref_scopes);
         allocator.free(self.iterator_scopes);
+        allocator.free(self.scheme_use_spans);
+        allocator.free(self.scheme_use_sites);
+        allocator.free(self.scheme_use_scopes);
         self.* = .{};
     }
 };
@@ -12623,11 +12637,14 @@ fn sealCheckedProcedureTemplateRefs(
     resolved_value_refs: *ResolvedValueRefTable,
     template_iterator_refs: *TemplateIteratorRefs,
 ) Allocator.Error!void {
-    // Generalized local function decls with dispatch obligations: entering one
-    // while collecting pushes an evidence scope (checked lambda expr id ->
-    // decl pattern var).
+    // Generalized local functions with dispatch obligations: entering one
+    // while collecting pushes an evidence scope. Declarations map to their
+    // pattern scheme; expression-position functions stored in a containing
+    // value map to the pristine scheme instantiated at that construction edge.
     var local_schemes = std.AutoHashMap(u32, Var).init(allocator);
     defer local_schemes.deinit();
+    var nested_function_uses = std.AutoHashMap(u32, u32).init(allocator);
+    defer nested_function_uses.deinit();
     {
         const types_store = module.typeStoreConst();
         var enum_scratch = dispatch_evidence.Scratch{};
@@ -12655,9 +12672,16 @@ fn sealCheckedProcedureTemplateRefs(
             const checked_expr = checked_bodies.exprIdForSource(decl.expr) orelse continue;
             try local_schemes.put(@intFromEnum(checked_expr), pattern_var);
         }
+
+        for (module.moduleEnvConst().scheme_uses.items.items, 0..) |record, record_idx| {
+            if (record.slot_kind != @intFromEnum(ModuleEnv.SchemeUseRecord.Slot.nested_function_use)) continue;
+            const checked_expr = checked_bodies.exprIdForSource(@enumFromInt(record.node_idx)) orelse continue;
+            try local_schemes.put(@intFromEnum(checked_expr), @enumFromInt(record.scheme_root));
+            try nested_function_uses.put(@intFromEnum(checked_expr), @intCast(record_idx));
+        }
     }
 
-    var collector = CheckedTemplateRefCollector.init(allocator, checked_bodies, static_dispatch_plans, &local_schemes);
+    var collector = CheckedTemplateRefCollector.init(allocator, checked_bodies, static_dispatch_plans, &local_schemes, &nested_function_uses);
     defer collector.deinit();
 
     // Flatten each template's collected refs into the two shared per-table pools,
@@ -12676,8 +12700,14 @@ fn sealCheckedProcedureTemplateRefs(
     errdefer dispatch_ref_scope_pool.deinit(allocator);
     var iterator_scope_pool = std.ArrayList(u32).empty;
     errdefer iterator_scope_pool.deinit(allocator);
+    var scheme_use_pool = std.ArrayList(CollectedSchemeUseSite).empty;
+    errdefer scheme_use_pool.deinit(allocator);
+    var scheme_use_scope_pool = std.ArrayList(u32).empty;
+    errdefer scheme_use_scope_pool.deinit(allocator);
     const iterator_spans = try allocator.alloc(artifact_serialize.Span, templates.templates.len);
     errdefer allocator.free(iterator_spans);
+    const scheme_use_spans = try allocator.alloc(artifact_serialize.Span, templates.templates.len);
+    errdefer allocator.free(scheme_use_spans);
 
     for (templates.templates, 0..) |*template, template_index| {
         collector.clear();
@@ -12697,9 +12727,11 @@ fn sealCheckedProcedureTemplateRefs(
         template.resolved_value_refs = try artifact_serialize.appendSpan(ResolvedValueRefTableRef, ResolvedValueRefId, &value_ref_pool, allocator, collector.value_refs.items);
         template.static_dispatch_plans = try artifact_serialize.appendSpan(@TypeOf(template.static_dispatch_plans), static_dispatch.StaticDispatchPlanId, &dispatch_ref_pool, allocator, collector.dispatch_refs.items);
         iterator_spans[template_index] = try artifact_serialize.appendSpan(artifact_serialize.Span, static_dispatch.IteratorForPlanId, &iterator_ref_pool, allocator, collector.iterator_refs.items);
+        scheme_use_spans[template_index] = try artifact_serialize.appendSpan(artifact_serialize.Span, CollectedSchemeUseSite, &scheme_use_pool, allocator, collector.scheme_use_sites.items);
         try value_ref_scope_pool.appendSlice(allocator, collector.value_ref_scopes.items);
         try dispatch_ref_scope_pool.appendSlice(allocator, collector.dispatch_ref_scopes.items);
         try iterator_scope_pool.appendSlice(allocator, collector.iterator_ref_scopes.items);
+        try scheme_use_scope_pool.appendSlice(allocator, collector.scheme_use_scopes.items);
     }
 
     resolved_value_refs.template_refs = try value_ref_pool.toOwnedSlice(allocator);
@@ -12711,6 +12743,9 @@ fn sealCheckedProcedureTemplateRefs(
         .plan_scopes = try dispatch_ref_scope_pool.toOwnedSlice(allocator),
         .value_ref_scopes = try value_ref_scope_pool.toOwnedSlice(allocator),
         .iterator_scopes = try iterator_scope_pool.toOwnedSlice(allocator),
+        .scheme_use_spans = scheme_use_spans,
+        .scheme_use_sites = try scheme_use_pool.toOwnedSlice(allocator),
+        .scheme_use_scopes = try scheme_use_scope_pool.toOwnedSlice(allocator),
     };
 }
 
@@ -12956,6 +12991,13 @@ const EvidencePass = struct {
                 const chain = try self.chainFor(self.template_iterator_refs.value_ref_scopes[value_ref_start + i], params.items);
                 try self.emitSiteEvidence(ref_id, chain);
             }
+
+            const scheme_use_span = self.template_iterator_refs.scheme_use_spans[template_index];
+            const scheme_use_sites = self.template_iterator_refs.scheme_use_sites[scheme_use_span.start .. scheme_use_span.start + scheme_use_span.len];
+            for (scheme_use_sites, 0..) |site, i| {
+                const chain = try self.chainFor(self.template_iterator_refs.scheme_use_scopes[scheme_use_span.start + i], params.items);
+                try self.emitSchemeUseSiteEvidence(site.record_idx, @intFromEnum(site.checked_expr), chain);
+            }
         }
 
         // Root edges are their templates' only callers (nothing instantiates
@@ -13037,6 +13079,7 @@ const EvidencePass = struct {
                     const entry = try self.target_by_fn_var.getOrPut(@intFromEnum(root));
                     if (!entry.found_existing) entry.value_ptr.* = @intCast(i);
                 },
+                .nested_function_use => {},
             }
         }
 
@@ -13617,26 +13660,36 @@ const EvidencePass = struct {
 
         const source_node = self.source_by_checked_expr.get(site_key) orelse return;
 
-        self.current_chain = chain;
-        defer self.current_chain = &.{};
-
         if (self.value_use_by_node.get(source_node)) |record_idx| {
-            const record = self.module.moduleEnvConst().scheme_uses.items.items[record_idx];
-            const shared = record.slot_kind == @intFromEnum(ModuleEnv.SchemeUseRecord.Slot.shared_value_use);
-            const span = (try self.evidenceRefsForRecord(record_idx, !shared)) orelse {
-                try self.deferred_use_sites.append(self.allocator, .{ .record_idx = record_idx, .site_key = site_key });
-                return;
-            };
-            if (span.len == 0) return;
-            try self.site_seen.put(site_key, {});
-            try self.site_evidence.append(self.allocator, .{ .key = site_key, .start = span.start, .len = span.len });
-            return;
+            try self.emitSchemeUseSiteEvidence(record_idx, site_key, chain);
         }
 
         // References that do not become specialization edges intentionally
         // have no site evidence. Shared recursive uses are explicit records
         // and therefore returned through the branch above.
         return;
+    }
+
+    fn emitSchemeUseSiteEvidence(
+        self: *EvidencePass,
+        record_idx: u32,
+        site_key: u32,
+        chain: []const []const EvidenceParam,
+    ) Allocator.Error!void {
+        if (self.site_seen.contains(site_key)) return;
+
+        self.current_chain = chain;
+        defer self.current_chain = &.{};
+
+        const record = self.module.moduleEnvConst().scheme_uses.items.items[record_idx];
+        const shared = record.slot_kind == @intFromEnum(ModuleEnv.SchemeUseRecord.Slot.shared_value_use);
+        const span = (try self.evidenceRefsForRecord(record_idx, !shared)) orelse {
+            try self.deferred_use_sites.append(self.allocator, .{ .record_idx = record_idx, .site_key = site_key });
+            return;
+        };
+        if (span.len == 0) return;
+        try self.site_seen.put(site_key, {});
+        try self.site_evidence.append(self.allocator, .{ .key = site_key, .start = span.start, .len = span.len });
     }
 
     /// `pairFor`, but comparing RESOLVED roots on both sides: finalization
@@ -13747,6 +13800,9 @@ const CheckedTemplateRefCollector = struct {
     /// id -> decl pattern var), prebuilt by the seal pass; entering one pushes
     /// an evidence scope.
     local_schemes: *const std.AutoHashMap(u32, Var),
+    /// Checked nested function expr -> `SchemeUseRecord` index for the
+    /// construction edge that instantiated it.
+    nested_function_uses: *const std.AutoHashMap(u32, u32),
     value_refs: std.ArrayList(ResolvedValueRefId),
     dispatch_refs: std.ArrayList(static_dispatch.StaticDispatchPlanId),
     iterator_refs: std.ArrayList(static_dispatch.IteratorForPlanId),
@@ -13754,6 +13810,8 @@ const CheckedTemplateRefCollector = struct {
     value_ref_scopes: std.ArrayList(u32),
     dispatch_ref_scopes: std.ArrayList(u32),
     iterator_ref_scopes: std.ArrayList(u32),
+    scheme_use_sites: std.ArrayList(CollectedSchemeUseSite),
+    scheme_use_scopes: std.ArrayList(u32),
     /// Pooled across templates (ids are global); the stack resets per template.
     scopes: std.ArrayList(RefScopeRecord),
     scope_stack: std.ArrayList(u32),
@@ -13766,18 +13824,22 @@ const CheckedTemplateRefCollector = struct {
         checked_bodies: *const CheckedBodyStore,
         static_dispatch_plans: *const static_dispatch.StaticDispatchPlanTable,
         local_schemes: *const std.AutoHashMap(u32, Var),
+        nested_function_uses: *const std.AutoHashMap(u32, u32),
     ) CheckedTemplateRefCollector {
         return .{
             .allocator = allocator,
             .checked_bodies = checked_bodies,
             .static_dispatch_plans = static_dispatch_plans,
             .local_schemes = local_schemes,
+            .nested_function_uses = nested_function_uses,
             .value_refs = .empty,
             .dispatch_refs = .empty,
             .iterator_refs = .empty,
             .value_ref_scopes = .empty,
             .dispatch_ref_scopes = .empty,
             .iterator_ref_scopes = .empty,
+            .scheme_use_sites = .empty,
+            .scheme_use_scopes = .empty,
             .scopes = .empty,
             .scope_stack = .empty,
             .visited_exprs = std.AutoHashMap(CheckedExprId, void).init(allocator),
@@ -13796,6 +13858,8 @@ const CheckedTemplateRefCollector = struct {
         self.value_ref_scopes.deinit(self.allocator);
         self.dispatch_ref_scopes.deinit(self.allocator);
         self.iterator_ref_scopes.deinit(self.allocator);
+        self.scheme_use_sites.deinit(self.allocator);
+        self.scheme_use_scopes.deinit(self.allocator);
         self.scopes.deinit(self.allocator);
         self.scope_stack.deinit(self.allocator);
     }
@@ -13807,6 +13871,8 @@ const CheckedTemplateRefCollector = struct {
         self.value_ref_scopes.clearRetainingCapacity();
         self.dispatch_ref_scopes.clearRetainingCapacity();
         self.iterator_ref_scopes.clearRetainingCapacity();
+        self.scheme_use_sites.clearRetainingCapacity();
+        self.scheme_use_scopes.clearRetainingCapacity();
         // `scopes` pools across templates; only the stack resets.
         self.scope_stack.clearRetainingCapacity();
         self.visited_exprs.clearRetainingCapacity();
@@ -13832,6 +13898,27 @@ const CheckedTemplateRefCollector = struct {
     fn collectExpr(self: *CheckedTemplateRefCollector, expr_id: CheckedExprId) Allocator.Error!void {
         const entry = try self.visited_exprs.getOrPut(expr_id);
         if (entry.found_existing) return;
+
+        const raw_expr = @intFromEnum(expr_id);
+        if (self.nested_function_uses.get(raw_expr)) |record_idx| {
+            try self.scheme_use_sites.append(self.allocator, .{
+                .record_idx = record_idx,
+                .checked_expr = expr_id,
+            });
+            // The construction edge lives in the enclosing scope; the nested
+            // function's own evidence scope begins below.
+            try self.scheme_use_scopes.append(self.allocator, self.currentScope());
+        }
+
+        const local_scheme = self.local_schemes.get(raw_expr);
+        if (local_scheme) |scheme_var| {
+            const scope_id: u32 = @intCast(self.scopes.items.len);
+            try self.scopes.append(self.allocator, .{ .parent = self.currentScope(), .scheme_var = scheme_var });
+            try self.scope_stack.append(self.allocator, scope_id);
+        }
+        defer {
+            if (local_scheme != null) _ = self.scope_stack.pop();
+        }
 
         const expr = self.checked_bodies.expr(expr_id);
         switch (expr.data) {
@@ -14068,18 +14155,7 @@ const CheckedTemplateRefCollector = struct {
         switch (statement.data) {
             .decl => |decl| {
                 try self.collectPattern(decl.pattern);
-                if (self.local_schemes.get(@intFromEnum(decl.expr))) |scheme_var| {
-                    // A generalized local function with dispatch obligations:
-                    // plans and refs inside its body resolve against its own
-                    // evidence params at depth 0.
-                    const scope_id: u32 = @intCast(self.scopes.items.len);
-                    try self.scopes.append(self.allocator, .{ .parent = self.currentScope(), .scheme_var = scheme_var });
-                    try self.scope_stack.append(self.allocator, scope_id);
-                    defer _ = self.scope_stack.pop();
-                    try self.collectExpr(decl.expr);
-                } else {
-                    try self.collectExpr(decl.expr);
-                }
+                try self.collectExpr(decl.expr);
             },
             .var_ => |var_| {
                 try self.collectPattern(var_.pattern);

--- a/src/check/static_dispatch_registry.zig
+++ b/src/check/static_dispatch_registry.zig
@@ -1479,9 +1479,10 @@ pub const StaticDispatchPlanTable = struct {
         return self.evidence_refs[node.nested.start .. node.nested.start + node.nested.len];
     }
 
-    /// Evidence for the scheme instantiated at `expr` (a value use of a
-    /// constrained definition), in the callee scheme's canonical
-    /// evidence-param order; null when the use needed no evidence.
+    /// Evidence for the scheme instantiated at `expr` (a constrained
+    /// definition reference or an expression-position function construction
+    /// edge), in the scheme's canonical evidence-param order; null when the
+    /// use needed no evidence.
     pub fn siteEvidence(self: *const StaticDispatchPlanTable, expr: CheckedExprId) ?[]const CheckedEvidence {
         const found = artifact_serialize.binarySearchByKey(SiteEvidenceEntry, u32, self.site_evidence, @intFromEnum(expr), siteEvidenceOrder) orelse return null;
         return self.evidence_refs[found.start .. found.start + found.len];

--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -642,4 +642,16 @@ pub const tests = [_]TestCase{
         .source = "Dec.div_trunc_by(1.0, 0.0)",
         .expected = .{ .crash = {} },
     },
+    .{
+        // https://github.com/roc-lang/roc/issues/10209
+        // A concrete-number lambda remains callable directly from its record field.
+        .name = "issue 10209: concrete-number function stored in record field remains callable",
+        .source =
+        \\{
+        \\    r = { op: |x| x * 11.I64 }
+        \\    (r.op)(4.I64)
+        \\}
+        ,
+        .expected = .{ .inspect_str = "44" },
+    },
 };

--- a/src/eval/test/lambda_mono_generated_corpus.zig
+++ b/src/eval/test/lambda_mono_generated_corpus.zig
@@ -156,7 +156,6 @@ pub const cases = [_]Case{
         \\    }
         \\}
         ,
-        .known_panic = true,
     },
     .{
         .name = "gen: closures stored in a list",
@@ -170,7 +169,6 @@ pub const cases = [_]Case{
         \\    }
         \\}
         ,
-        .known_panic = true,
     },
     .{
         .name = "gen: closure stored in a record field",
@@ -181,7 +179,6 @@ pub const cases = [_]Case{
         \\    (r.op)(4.I64)
         \\}
         ,
-        .known_panic = true,
     },
     .{
         .name = "gen: capturing closure called via List.first",
@@ -195,7 +192,6 @@ pub const cases = [_]Case{
         \\    }
         \\}
         ,
-        .known_panic = true,
     },
     .{
         .name = "gen: capturing closure rebound from record field",

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -19200,8 +19200,9 @@ const BodyContext = struct {
                     .nested => {},
                     else => Common.invariant("closure expression was not assigned a nested function identity"),
                 }
+                const evidence = try self.evidenceForUseSite(expr_id);
                 break :blk .{ .fn_def = .{
-                    .fn_id = draftFinalFn(try self.builder.lowerNestedFnFromContext(self, expr_id, nested, null)),
+                    .fn_id = draftFinalFn(try self.builder.lowerNestedFnFromContext(self, expr_id, nested, if (evidence.len > 0) evidence else null)),
                     .captures = try self.lowerClosureCaptureExprSpan(closure.captures),
                 } };
             },
@@ -19270,7 +19271,8 @@ const BodyContext = struct {
             .nested => {},
             else => Common.invariant("expression-position lambda was not assigned a nested function identity"),
         }
-        return .{ .fn_def = .{ .fn_id = draftFinalFn(try self.builder.lowerNestedFnFromContext(self, expr_id, nested, null)) } };
+        const evidence = try self.evidenceForUseSite(expr_id);
+        return .{ .fn_def = .{ .fn_id = draftFinalFn(try self.builder.lowerNestedFnFromContext(self, expr_id, nested, if (evidence.len > 0) evidence else null)) } };
     }
 
     fn lowerDispatchExpr(
@@ -20135,8 +20137,8 @@ const BodyContext = struct {
     }
 
     /// Evidence vector for the constrained scheme instantiated at `expr` (a
-    /// value use resolved in this context's module), or empty when the use
-    /// carries no requirements.
+    /// value reference or nested function construction edge resolved in this
+    /// context's module), or empty when the use carries no requirements.
     fn evidenceForUseSite(self: *BodyContext, expr: checked.CheckedExprId) Allocator.Error![]const SpecEvidence {
         const refs = self.view.static_dispatch_plans.siteEvidence(expr) orelse return &.{};
         return self.materializeEvidence(refs);


### PR DESCRIPTION
Calling a concrete-number lambda directly from a container embedded its generalized checked scheme without an instantiation edge, so its dispatch plan defaulted to Dec while Monotype specialized the body as I64. This records the construction-site scheme use, scopes nested dispatch plans to the callable evidence, and passes that checked evidence into nested Monotype specialization.

Adds a regression for #10209 and enables the existing tuple, list, record, and Result differential cases.