### PR TITLE
allow unexpected_cfgs in RustGlue.roc

### DIFF
--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -8135,6 +8135,8 @@ fn customGlueRust(io: std.Io, allocator: Allocator, env: *const CaseEnv, timer: 
         "--edition=2021",
         "-D",
         "warnings",
+        "--check-cfg",
+        "cfg()",
         "--crate-type",
         "lib",
         generated_path,

--- a/src/glue/src/RustGlue.roc
+++ b/src/glue/src/RustGlue.roc
@@ -916,6 +916,7 @@ generate_rust_file_header =
 	\\#![allow(dead_code)]
 	\\#![allow(improper_ctypes)]
 	\\#![allow(improper_ctypes_definitions)]
+	\\// `no_roc_std_helpers` is supplied by host build tooling and cannot be registered from source.
 	\\#![allow(unexpected_cfgs)]
 	\\
 	\\

--- a/src/glue/src/RustGlue.roc
+++ b/src/glue/src/RustGlue.roc
@@ -916,6 +916,7 @@ generate_rust_file_header =
 	\\#![allow(dead_code)]
 	\\#![allow(improper_ctypes)]
 	\\#![allow(improper_ctypes_definitions)]
+	\\#![allow(unexpected_cfgs)]
 	\\
 	\\
 


### PR DESCRIPTION
This is a tiny quality of life change for the rust platform template. If you're writing a non-no-std rust platform (ie, using the rust standard library), and you generate code with `RustGlue.roc`, the generated code trips a warning for an unrecognized `cfg` of `no_roc_std_helpers`. But, this is expected in that case.

This change is to specifically allow unrecognized cfgs in the generated file. There may be a better solution I haven't thought of.