### PR TITLE
Add `List.keep_oks` and `List.keep_errs`

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3728,6 +3728,24 @@ Builtin :: [].{
 					},
 			)
 
+		## Run the given function on each element of a list, and return a list of
+		## the values it wrapped in `Ok`. Elements the function maps to `Err` are
+		## dropped. Use [List.keep_errs] to keep the `Err` values instead.
+		## ```roc
+		## expect [1.I64, 2, 3, 4].keep_oks(|n| if n.is_even() { Ok(n) } else { Err({}) }) == [2, 4]
+		## ```
+		keep_oks : List(before), (before -> Try(after, _err)) -> List(after)
+		keep_oks = |list, transform|
+			List.fold(
+				list,
+				[],
+				|acc, elem|
+					match transform(elem) {
+						Ok(after) => List.concat(acc, [after])
+						Err(_) => acc
+					},
+			)
+
 		## Run the given function on each element of a list, and return the
 		## number of elements for which the function returned `Bool.True`.
 		## ```roc

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3746,6 +3746,24 @@ Builtin :: [].{
 					},
 			)
 
+		## Run the given function on each element of a list, and return a list of
+		## the values it wrapped in `Err`. Elements the function maps to `Ok` are
+		## dropped. Use [List.keep_oks] to keep the `Ok` values instead.
+		## ```roc
+		## expect [1.I64, 2, 3, 4].keep_errs(|n| if n.is_even() { Ok(n) } else { Err(n) }) == [1, 3]
+		## ```
+		keep_errs : List(before), (before -> Try(_ok, after)) -> List(after)
+		keep_errs = |list, transform|
+			List.fold(
+				list,
+				[],
+				|acc, elem|
+					match transform(elem) {
+						Err(after) => List.concat(acc, [after])
+						Ok(_) => acc
+					},
+			)
+
 		## Run the given function on each element of a list, and return the
 		## number of elements for which the function returned `Bool.True`.
 		## ```roc

--- a/test/snapshots/repl/list_keep_errs.md
+++ b/test/snapshots/repl/list_keep_errs.md
@@ -1,0 +1,25 @@
+# META
+~~~ini
+description=List.keep_errs keeps the Err values
+type=repl
+~~~
+# SOURCE
+~~~roc
+» [1, 2, 3, 4].keep_errs(|n| if n.is_even() { Ok(n) } else { Err(n) })
+» [1.I64, 2, 3].keep_errs(|n| Ok(n))
+» mixed = ["a long heap-allocated string number one that will not fit inline", "a long heap-allocated string number two that will not fit inline"]
+» List.keep_errs(mixed, |s| if s.starts_with("a long heap-allocated string number one") { Ok(s) } else { Err(s) })
+» mixed
+~~~
+# OUTPUT
+[1, 3]
+---
+[]
+---
+assigned `mixed`
+---
+["a long heap-allocated string number two that will not fit inline"]
+---
+["a long heap-allocated string number one that will not fit inline", "a long heap-allocated string number two that will not fit inline"]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/list_keep_oks.md
+++ b/test/snapshots/repl/list_keep_oks.md
@@ -1,0 +1,25 @@
+# META
+~~~ini
+description=List.keep_oks keeps the Ok values
+type=repl
+~~~
+# SOURCE
+~~~roc
+» [1, 2, 3, 4].keep_oks(|n| if n.is_even() { Ok(n) } else { Err({}) })
+» [1.I64, 2, 3].keep_oks(|_| Err({}))
+» mixed = ["a long heap-allocated string number one that will not fit inline", "a long heap-allocated string number two that will not fit inline"]
+» List.keep_oks(mixed, |s| if s.starts_with("a long heap-allocated string number one") { Ok(s) } else { Err({}) })
+» mixed
+~~~
+# OUTPUT
+[2, 4]
+---
+[]
+---
+assigned `mixed`
+---
+["a long heap-allocated string number one that will not fit inline"]
+---
+["a long heap-allocated string number one that will not fit inline", "a long heap-allocated string number two that will not fit inline"]
+# PROBLEMS
+NIL


### PR DESCRIPTION
Adds `List.keep_oks` and `List.keep_errs` from #9596 — run a `Try`-returning function on each element and keep the values it wrapped in `Ok` (resp. `Err`), dropping the others.

Pure Roc, modelled on `List.keep_if` (fold + grow-by-one, since the result size isn't known up front). No new low-level op. One commit per function.

**Tests:** a repl snapshot per function under `test/snapshots/repl/`, covering the normal cases plus a refcounting case that drops a heap-allocated element and checks the source list survives.
