### PR TITLE
Fix package header dependency discovery

### DIFF
--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -809,7 +809,7 @@ pub const BuildEnv = struct {
         // Resolve the full dependency graph (downloads plus version solving),
         // then materialize the resolved packages and their shorthands.
         if (header_info.kind == .app or header_info.kind == .default_app or header_info.kind == .package or header_info.kind == .platform) {
-            try self.resolveAndMaterialize(key_pkg);
+            try self.resolveAndMaterialize(key_pkg, header_info.resolver_root);
         }
     }
 
@@ -1402,9 +1402,7 @@ pub const BuildEnv = struct {
     const HeaderInfo = struct {
         kind: PackageKind,
         source_file_state: ?watch_inputs.State,
-        platform_alias: ?[]u8 = null,
-        platform_path: ?[]u8 = null,
-        shorthands: std.StringHashMapUnmanaged([]const u8) = .{},
+        resolver_root: package_resolution.FetchedPackage,
         /// Platform-exposed modules (e.g., Stdout, Stderr) that apps can import
         exposes: std.ArrayListUnmanaged([]const u8) = .empty,
         /// Platform provides entries (roc_ident -> ffi_symbol mapping)
@@ -1414,14 +1412,7 @@ pub const BuildEnv = struct {
 
         fn deinit(self: *HeaderInfo, gpa: Allocator) void {
             if (self.targets_config) |tc| tc.deinit(gpa);
-            if (self.platform_alias) |a| freeSlice(gpa, a);
-            if (self.platform_path) |p| freeSlice(gpa, p);
-            var it = self.shorthands.iterator();
-            while (it.next()) |e| {
-                freeConstSlice(gpa, e.key_ptr.*);
-                freeConstSlice(gpa, e.value_ptr.*);
-            }
-            self.shorthands.deinit(gpa);
+            self.resolver_root.deinit(gpa);
             for (self.exposes.items) |e| {
                 freeConstSlice(gpa, e);
             }
@@ -1446,27 +1437,6 @@ pub const BuildEnv = struct {
         self.clearPackageExposes(pkg);
         pkg.exposes = header_info.exposes;
         header_info.exposes = .empty;
-    }
-
-    fn putHeaderShorthand(
-        self: *BuildEnv,
-        info: *HeaderInfo,
-        key: []const u8,
-        path: []const u8,
-    ) BuildError!void {
-        var path_transferred = false;
-        errdefer if (!path_transferred) freeConstSlice(self.gpa, path);
-
-        if (info.shorthands.fetchRemove(key)) |entry| {
-            self.gpa.free(entry.key);
-            self.gpa.free(entry.value);
-        }
-
-        const key_owned = try self.gpa.dupe(u8, key);
-        errdefer self.gpa.free(key_owned);
-
-        try info.shorthands.put(self.gpa, key_owned, path);
-        path_transferred = true;
     }
 
     fn parseHeaderDeps(self: *BuildEnv, file_path: []const u8) BuildError!HeaderInfo {
@@ -1537,133 +1507,26 @@ pub const BuildEnv = struct {
         const file = ast.store.getFile();
         const header = ast.store.getHeader(file.header);
 
-        var info = HeaderInfo{ .kind = .package, .source_file_state = source_read.file_state };
+        const resolver_root = package_resolution.scanParsedHeader(self.gpa, file_abs, src, ast, header) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.HeaderParseFailed => return error.ExpectedString,
+        };
+        var info = HeaderInfo{
+            .kind = .package,
+            .source_file_state = source_read.file_state,
+            .resolver_root = resolver_root,
+        };
         errdefer info.deinit(self.gpa);
 
         switch (header) {
-            .app => |a| {
+            .app => {
                 info.kind = .app;
-
-                // Platform field
-                const pf = ast.store.getRecordField(a.platform_idx);
-                const alias = ast.resolve(pf.name);
-                const value_expr = pf.value orelse return error.ExpectedPlatformString;
-                const plat_rel = try self.stringFromExpr(ast, value_expr);
-                defer self.gpa.free(plat_rel);
-
-                // URL specs are resolved (downloaded and version-solved) by
-                // package resolution; keep them verbatim here.
-                const plat_path = if (base.url.isSafeUrl(plat_rel)) blk: {
-                    break :blk try self.gpa.dupe(u8, plat_rel);
-                } else blk: {
-                    const header_dir = std.fs.path.dirname(file_abs) orelse ".";
-                    const abs_path = try PathUtils.makeAbsolute(self.gpa, header_dir, plat_rel);
-                    // Add the platform directory to workspace roots so that
-                    // imports within the platform can be resolved, even when
-                    // it lives outside the app directory (e.g. ../platform).
-                    if (std.fs.path.dirname(abs_path)) |plat_dir| {
-                        try self.addWorkspaceRoot(plat_dir);
-                    }
-                    break :blk abs_path;
-                };
-
-                info.platform_path = @constCast(plat_path);
-                info.platform_alias = try self.gpa.dupe(u8, alias);
-
-                // Packages map
-                const coll = ast.store.getCollection(a.packages);
-                const fields = ast.store.recordFieldSlice(.{ .span = coll.span });
-                for (fields) |idx| {
-                    const rf = ast.store.getRecordField(idx);
-                    const k = ast.resolve(rf.name);
-                    if (rf.value == null) {
-                        // If no value is provided for an app field, skip it
-                        continue;
-                    }
-                    const relp = try self.stringFromExpr(ast, rf.value.?);
-                    defer self.gpa.free(relp);
-
-                    // URL specs are resolved by package resolution; keep them
-                    // verbatim here.
-                    const v = if (base.url.isSafeUrl(relp)) blk: {
-                        break :blk try self.gpa.dupe(u8, relp);
-                    } else blk: {
-                        const header_dir2 = std.fs.path.dirname(file_abs) orelse ".";
-                        const abs_path = try PathUtils.makeAbsolute(self.gpa, header_dir2, relp);
-                        errdefer self.gpa.free(abs_path);
-                        if (std.fs.path.dirname(abs_path)) |pkg_dir| {
-                            try self.addWorkspaceRoot(pkg_dir);
-                        }
-                        break :blk abs_path;
-                    };
-
-                    try self.putHeaderShorthand(&info, k, v);
-                }
             },
-            .package => |p| {
+            .package => {
                 info.kind = .package;
-                const coll = ast.store.getCollection(p.packages);
-                const fields = ast.store.recordFieldSlice(.{ .span = coll.span });
-                for (fields) |idx| {
-                    const rf = ast.store.getRecordField(idx);
-                    const k = ast.resolve(rf.name);
-                    if (rf.value == null) {
-                        // If no value is provided for a package field, skip it
-                        continue;
-                    }
-                    const relp = try self.stringFromExpr(ast, rf.value.?);
-                    defer self.gpa.free(relp);
-
-                    // URL specs are resolved by package resolution; keep them
-                    // verbatim here.
-                    const v = if (base.url.isSafeUrl(relp)) blk: {
-                        break :blk try self.gpa.dupe(u8, relp);
-                    } else blk: {
-                        const header_dir2 = std.fs.path.dirname(file_abs) orelse ".";
-                        const abs_path = try PathUtils.makeAbsolute(self.gpa, header_dir2, relp);
-                        // Enforce: package header deps must be within workspace roots
-                        if (!PathUtils.isWithinRoot(abs_path, self.workspace_roots.items)) {
-                            self.gpa.free(abs_path);
-                            return error.PathOutsideWorkspace;
-                        }
-                        break :blk abs_path;
-                    };
-
-                    try self.putHeaderShorthand(&info, k, v);
-                }
             },
             .platform => |p| {
                 info.kind = .platform;
-                const coll = ast.store.getCollection(p.packages);
-                const fields = ast.store.recordFieldSlice(.{ .span = coll.span });
-                for (fields) |idx| {
-                    const rf = ast.store.getRecordField(idx);
-                    const k = ast.resolve(rf.name);
-                    if (rf.value == null) {
-                        // If no value is provided for a platform field, skip it
-                        continue;
-                    }
-                    const relp = try self.stringFromExpr(ast, rf.value.?);
-                    defer self.gpa.free(relp);
-
-                    // URL specs are resolved by package resolution; keep them
-                    // verbatim here.
-                    const v = if (base.url.isSafeUrl(relp)) blk: {
-                        break :blk try self.gpa.dupe(u8, relp);
-                    } else blk: {
-                        const header_dir2 = std.fs.path.dirname(file_abs) orelse ".";
-                        const abs_path = try PathUtils.makeAbsolute(self.gpa, header_dir2, relp);
-                        // Enforce: platform header deps must be within workspace roots
-                        if (!PathUtils.isWithinRoot(abs_path, self.workspace_roots.items)) {
-                            self.gpa.free(abs_path);
-                            return error.PathOutsideWorkspace;
-                        }
-                        break :blk abs_path;
-                    };
-
-                    try self.putHeaderShorthand(&info, k, v);
-                }
-
                 // Extract platform-exposed modules (e.g., Stdout, Stderr)
                 // These are modules that apps can import from the platform
                 const exposes_coll = ast.store.getCollection(p.exposes);
@@ -1715,37 +1578,6 @@ pub const BuildEnv = struct {
         }
 
         return info;
-    }
-
-    fn stringFromExpr(self: *BuildEnv, ast: *parse.AST, expr_idx: parse.AST.Expr.Idx) BuildError![]const u8 {
-        const e = ast.store.getExpr(expr_idx);
-        return switch (e) {
-            .string => |s| blk: {
-                var buf = std.ArrayList(u8).empty;
-                errdefer buf.deinit(self.gpa);
-
-                // Use exprSlice to properly iterate through string parts
-                for (ast.store.exprSlice(s.parts)) |part_idx| {
-                    const part = ast.store.getExpr(part_idx);
-                    if (part == .string_part) {
-                        const tok = part.string_part.token;
-                        const slice = ast.resolve(tok);
-                        try buf.appendSlice(self.gpa, slice);
-                    }
-                }
-
-                const result = try buf.toOwnedSlice(self.gpa);
-
-                // Check for null bytes in the string, which are invalid in file paths
-                if (std.mem.findScalar(u8, result, 0) != null) {
-                    self.gpa.free(result);
-                    return error.InvalidNullByteInPath;
-                }
-
-                break :blk result;
-            },
-            else => error.ExpectedString,
-        };
     }
 
     fn makeAbsolute(self: *BuildEnv, path: []const u8) Allocator.Error![]u8 {
@@ -2025,9 +1857,11 @@ pub const BuildEnv = struct {
     /// package (named by its unique identity - full URL or absolute path),
     /// wire every package's shorthand aliases to the packages its specs
     /// resolved to, and transfer platform metadata.
-    fn resolveAndMaterialize(self: *BuildEnv, root_pkg_name: []const u8) BuildError!void {
-        const root_abs = self.discovered_root_abs orelse return error.Internal;
-
+    fn resolveAndMaterialize(
+        self: *BuildEnv,
+        root_pkg_name: []const u8,
+        scanned_root: package_resolution.FetchedPackage,
+    ) BuildError!void {
         // Without a cache directory, resolution still works for graphs with
         // no URL dependencies; URL specs report a download failure.
         if (self.package_cache_dir == null) {
@@ -2045,7 +1879,7 @@ pub const BuildEnv = struct {
         var resolver = package_resolution.Resolver.init(self.gpa, ctx_fetcher.fetcher(), self.resolution_config);
         defer resolver.deinit();
 
-        var resolved = resolver.resolve(root_abs) catch |err| switch (err) {
+        var resolved = resolver.resolveScannedRoot(scanned_root) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             error.ResolutionFailed => {
                 for (resolver.diagnostics.items) |diagnostic| {

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -117,6 +117,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_9884_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10021_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10057_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10105_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10132_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10218_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));

--- a/src/compile/package_resolution.zig
+++ b/src/compile/package_resolution.zig
@@ -98,6 +98,16 @@ pub const FetchedPackage = struct {
     /// packages, which are not downloaded and not size-limited).
     content_bytes: u64,
     deps: []const ScannedDep,
+
+    pub fn deinit(self: *FetchedPackage, allocator: Allocator) void {
+        for (self.deps) |dep| {
+            allocator.free(dep.alias);
+            allocator.free(dep.spec);
+        }
+        allocator.free(self.deps);
+        allocator.free(self.root_file);
+        allocator.free(self.root_dir);
+    }
 };
 
 /// Errors a fetcher can produce for a single package.
@@ -390,6 +400,22 @@ pub const Resolver = struct {
                 return error.ResolutionFailed;
             },
         };
+        return self.resolveLoadedRoot(root_path, root_node);
+    }
+
+    /// Resolve using a root header the caller already scanned. The package is
+    /// copied into the resolver's arena so the returned graph owns everything
+    /// it needs independently of the caller.
+    pub fn resolveScannedRoot(self: *Resolver, scanned_root: FetchedPackage) error{ OutOfMemory, ResolutionFailed }!Resolved {
+        const root_node = try copyFetchedPackage(self.arena(), scanned_root);
+        return self.resolveLoadedRoot(root_node.root_file, root_node);
+    }
+
+    fn resolveLoadedRoot(
+        self: *Resolver,
+        root_path: []const u8,
+        root_node: FetchedPackage,
+    ) error{ OutOfMemory, ResolutionFailed }!Resolved {
         try self.local_nodes.put(self.arena(), root_path, root_node);
 
         var chosen: std.StringHashMapUnmanaged(GroupChoice) = .{};
@@ -1280,21 +1306,39 @@ pub fn scanHeaderSource(
         }
     }
 
+    return scanParsedHeader(allocator, root_file_abs, src, ast, header);
+}
+
+/// Extract dependency-resolution input from an already parsed Roc header.
+/// This lets callers that need other header metadata hand the exact same parse
+/// to the resolver instead of reading and parsing the root file a second time.
+pub fn scanParsedHeader(
+    allocator: Allocator,
+    root_file_abs: []const u8,
+    src: []const u8,
+    ast: *parse.AST,
+    header: parse.AST.Header,
+) error{ OutOfMemory, HeaderParseFailed }!FetchedPackage {
     var deps = std.ArrayListUnmanaged(ScannedDep).empty;
+    errdefer {
+        for (deps.items) |dep| {
+            allocator.free(dep.alias);
+            allocator.free(dep.spec);
+        }
+        deps.deinit(allocator);
+    }
 
     const root_file = try allocator.dupe(u8, root_file_abs);
+    errdefer allocator.free(root_file);
     const root_dir = try allocator.dupe(u8, std.fs.path.dirname(root_file_abs) orelse ".");
+    errdefer allocator.free(root_dir);
 
     const kind: HeaderKind = switch (header) {
         .app => |a| blk: {
             const platform_field = ast.store.getRecordField(a.platform_idx);
             if (platform_field.value) |value_expr| {
                 const spec = (try stringFromExpr(allocator, ast, value_expr)) orelse return error.HeaderParseFailed;
-                try deps.append(allocator, .{
-                    .alias = try allocator.dupe(u8, ast.resolve(platform_field.name)),
-                    .spec = spec,
-                    .is_platform = true,
-                });
+                try appendScannedDep(allocator, &deps, ast.resolve(platform_field.name), spec, true);
             } else {
                 return error.HeaderParseFailed;
             }
@@ -1312,7 +1356,7 @@ pub fn scanHeaderSource(
             break :blk .platform;
         },
         .module, .hosted, .type_module, .default_app => .module,
-        .malformed => unreachable,
+        .malformed => return error.HeaderParseFailed,
     };
 
     return .{
@@ -1321,7 +1365,7 @@ pub fn scanHeaderSource(
         .root_dir = root_dir,
         .root_source_hash = sha256Bytes(src),
         .content_bytes = 0,
-        .deps = deps.items,
+        .deps = try deps.toOwnedSlice(allocator),
     };
 }
 
@@ -1358,12 +1402,25 @@ fn appendPackagesCollection(
         const field = ast.store.getRecordField(idx);
         const value_expr = field.value orelse continue;
         const spec = (try stringFromExpr(allocator, ast, value_expr)) orelse return error.HeaderParseFailed;
-        try deps.append(allocator, .{
-            .alias = try allocator.dupe(u8, ast.resolve(field.name)),
-            .spec = spec,
-            .is_platform = false,
-        });
+        try appendScannedDep(allocator, deps, ast.resolve(field.name), spec, false);
     }
+}
+
+fn appendScannedDep(
+    allocator: Allocator,
+    deps: *std.ArrayListUnmanaged(ScannedDep),
+    alias: []const u8,
+    owned_spec: []const u8,
+    is_platform: bool,
+) Allocator.Error!void {
+    errdefer allocator.free(owned_spec);
+    const owned_alias = try allocator.dupe(u8, alias);
+    errdefer allocator.free(owned_alias);
+    try deps.append(allocator, .{
+        .alias = owned_alias,
+        .spec = owned_spec,
+        .is_platform = is_platform,
+    });
 }
 
 fn stringFromExpr(allocator: Allocator, ast: *parse.AST, expr_idx: parse.AST.Expr.Idx) Allocator.Error!?[]const u8 {
@@ -1371,6 +1428,7 @@ fn stringFromExpr(allocator: Allocator, ast: *parse.AST, expr_idx: parse.AST.Exp
     switch (expr) {
         .string => |s| {
             var buf = std.ArrayListUnmanaged(u8).empty;
+            errdefer buf.deinit(allocator);
             for (ast.store.exprSlice(s.parts)) |part_idx| {
                 const part = ast.store.getExpr(part_idx);
                 if (part == .string_part) {
@@ -1378,8 +1436,11 @@ fn stringFromExpr(allocator: Allocator, ast: *parse.AST, expr_idx: parse.AST.Exp
                 }
             }
             // Null bytes are invalid in both file paths and URLs.
-            if (std.mem.findScalar(u8, buf.items, 0) != null) return null;
-            return buf.items;
+            if (std.mem.findScalar(u8, buf.items, 0) != null) {
+                buf.deinit(allocator);
+                return null;
+            }
+            return try buf.toOwnedSlice(allocator);
         },
         else => return null,
     }

--- a/src/compile/test/issue_10105_test.zig
+++ b/src/compile/test/issue_10105_test.zig
@@ -1,0 +1,45 @@
+//! Regression test for issue #10105.
+
+const std = @import("std");
+const roc_target = @import("roc_target");
+
+const BuildEnv = @import("../compile_build.zig").BuildEnv;
+
+test "issue 10105: package header resolves a local sibling package" {
+    // Repro for https://github.com/roc-lang/roc/issues/10105.
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(io, "root");
+    try tmp_dir.dir.createDirPath(io, "dep");
+    try tmp_dir.dir.writeFile(io, .{
+        .sub_path = "root/main.roc",
+        .data = "package [Root] { dep: \"../dep/main.roc\" }\n",
+    });
+    try tmp_dir.dir.writeFile(io, .{
+        .sub_path = "dep/main.roc",
+        .data = "package [Dep] {}\n",
+    });
+
+    const cwd = try tmp_dir.dir.realPathFileAlloc(io, ".", gpa);
+    defer gpa.free(cwd);
+    const root_main = try tmp_dir.dir.realPathFileAlloc(io, "root/main.roc", gpa);
+    defer gpa.free(root_main);
+    const dep_main = try tmp_dir.dir.realPathFileAlloc(io, "dep/main.roc", gpa);
+    defer gpa.free(dep_main);
+
+    var build_env = try BuildEnv.init(gpa, .single_threaded, 1, roc_target.RocTarget.detectNative(), cwd, io);
+    defer build_env.deinit();
+
+    try build_env.discoverDependencies(root_main);
+
+    const root_pkg_name = build_env.discovered_pkg_name orelse return error.TestUnexpectedResult;
+    const root_pkg = build_env.packages.getPtr(root_pkg_name) orelse return error.TestUnexpectedResult;
+    const dep = root_pkg.shorthands.get("dep") orelse return error.TestUnexpectedResult;
+
+    try std.testing.expectEqualStrings(dep_main, dep.root_file);
+    try std.testing.expect(build_env.packages.getPtr(dep.name) != null);
+}


### PR DESCRIPTION
Package roots with local dependencies were rejected while BuildEnv parsed their headers because the workspace contained only the root package at that point. This makes package resolution the single owner of dependency-path resolution: BuildEnv passes resolver records from the same parsed root header, and materialization admits workspace roots and wires shorthands from the completed graph. Fixes #10105.