### PR TITLE
Support typed numeric literal patterns

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -5451,46 +5451,41 @@ fn externalTypeBindingIsCompilerBuiltin(self: *const Self, external: Scope.Exter
     return CIR.Import.isCompilerBuiltinImportName(self.env.common.getString(import_name_idx));
 }
 
-/// Record, for an explicitly-suffixed numeric literal (e.g. `123.U8` or
-/// `5.Foo`), what its suffix target resolves to in the current scope. The type
-/// checker consumes this so it can unify the literal against the right concrete
-/// type without re-running scope resolution. The caller has already verified
-/// `type_ident` names a type binding in scope.
-fn recordTypedNumericSuffix(self: *Self, expr_idx: Expr.Idx, type_ident: Ident.Idx) std.mem.Allocator.Error!void {
-    const node_idx = ModuleEnv.nodeIdxFrom(expr_idx);
+/// Resolve a literal suffix once, while the canonicalizer still owns scope
+/// information. A null result means the suffix does not name a type in scope;
+/// `.invalid` means it names an incomplete external binding already diagnosed
+/// by import canonicalization.
+fn resolveNumericSuffixTarget(self: *Self, type_ident: Ident.Idx) std.mem.Allocator.Error!?ModuleEnv.NumericSuffixTarget.Target {
     const binding_location = (try self.scopeLookupOrPrepareTypeBinding(type_ident)) orelse {
         if (self.builtinNumKindFromTypeIdent(type_ident)) |num_kind| {
-            try self.env.recordNumericSuffixTarget(node_idx, .{ .builtin = num_kind });
-        } else {
-            try self.env.recordNumericSuffixTarget(node_idx, .invalid);
+            return .{ .builtin = num_kind };
         }
-        return;
+        return null;
     };
-    switch (binding_location.binding.*) {
-        .local_nominal, .local_alias, .associated_nominal => |stmt_idx| {
-            try self.env.recordNumericSuffixTarget(node_idx, .{ .local = stmt_idx });
-        },
-        .external_nominal => |external| {
+    return switch (binding_location.binding.*) {
+        .local_nominal, .local_alias, .associated_nominal => |stmt_idx| .{ .local = stmt_idx },
+        .external_nominal => |external| blk: {
             if (self.externalTypeBindingIsCompilerBuiltin(external)) {
                 if (self.builtinNumKindFromTypeIdent(external.original_ident) orelse self.builtinNumKindFromTypeIdent(type_ident)) |num_kind| {
-                    try self.env.recordNumericSuffixTarget(node_idx, .{ .builtin = num_kind });
-                    return;
+                    break :blk .{ .builtin = num_kind };
                 }
             }
-            const import_idx = external.import_idx orelse {
-                try self.env.recordNumericSuffixTarget(node_idx, .invalid);
-                return;
-            };
-            const target_node_idx = external.target_node_idx orelse {
-                try self.env.recordNumericSuffixTarget(node_idx, .invalid);
-                return;
-            };
-            try self.env.recordNumericSuffixTarget(node_idx, .{ .external = .{
+            const import_idx = external.import_idx orelse break :blk .invalid;
+            const target_node_idx = external.target_node_idx orelse break :blk .invalid;
+            break :blk .{ .external = .{
                 .import_idx = import_idx,
                 .target_node_idx = target_node_idx,
-            } });
+            } };
         },
-    }
+    };
+}
+
+/// Record a literal suffix target for syntax paths that preserve an unresolved
+/// target as `.invalid`. Exact numeral canonicalization calls the resolver
+/// directly so validation and recording share one lookup.
+fn recordTypedNumericSuffix(self: *Self, node_idx: Node.Idx, type_ident: Ident.Idx) std.mem.Allocator.Error!void {
+    const target = (try self.resolveNumericSuffixTarget(type_ident)) orelse .invalid;
+    try self.env.recordNumericSuffixTarget(node_idx, target);
 }
 
 fn populateExports(self: *Self) std.mem.Allocator.Error!void {
@@ -6879,15 +6874,15 @@ fn cirSmallDec(value: NumericLiteral.SmallDecValue) CIR.SmallDecValue {
 }
 
 /// Record the exact base-256 digits of a parsed numeric literal against the
-/// CIR expression node we just emitted. Check.zig reads this when classifying
-/// numerics (via `recordedNumeralLiteralForExpr`).
-fn recordNumeralLiteralForExpr(
+/// CIR expression or pattern node we just emitted. Checking consumes these
+/// facts through the same occurrence-generic numeral path.
+fn recordNumeralLiteralForNode(
     self: *Self,
-    expr_idx: Expr.Idx,
+    node_idx: Node.Idx,
     literal: NumericLiteral.Stored,
 ) std.mem.Allocator.Error!void {
     try self.env.recordNumeralLiteral(
-        ModuleEnv.nodeIdxFrom(expr_idx),
+        node_idx,
         self.parse_ir.store.numericDigitsBefore(literal),
         self.parse_ir.store.numericDigitsAfter(literal),
         literal.after_decimal_digit_count,
@@ -6898,24 +6893,48 @@ fn recordNumeralLiteralForExpr(
     );
 }
 
-/// Record the exact base-256 digits of a parsed numeric literal against the
-/// CIR pattern node we just emitted, so literal patterns can dispatch through
-/// `from_numeral` when matched against a non-builtin number type.
-fn recordNumeralLiteralForPattern(
+/// Canonicalize one numeric literal pattern while keeping its exact parser-owned
+/// digits and optional resolved suffix target as node data. Checking consumes
+/// those data identically for compact and large literals.
+fn canonicalizeNumeralPattern(
     self: *Self,
-    pattern_idx: Pattern.Idx,
     literal: NumericLiteral.Stored,
-) std.mem.Allocator.Error!void {
-    try self.env.recordNumeralLiteral(
-        ModuleEnv.nodeIdxFrom(pattern_idx),
-        self.parse_ir.store.numericDigitsBefore(literal),
-        self.parse_ir.store.numericDigitsAfter(literal),
-        literal.after_decimal_digit_count,
-        literal.isNegative(),
-        literal.kind == .frac,
-        literal.flags.had_decimal_point,
-        literal.isMaterialized(),
-    );
+    region: Region,
+    type_ident: ?Ident.Idx,
+) std.mem.Allocator.Error!Pattern.Idx {
+    const suffix_target = if (type_ident) |ident|
+        (try self.resolveNumericSuffixTarget(ident)) orelse {
+            return try self.env.pushMalformed(Pattern.Idx, Diagnostic{ .undeclared_type = .{
+                .name = ident,
+                .region = region,
+            } });
+        }
+    else
+        null;
+
+    const pattern: Pattern = switch (literal.compact) {
+        .int => |value| .{ .num_literal = .{
+            .value = cirIntValue(value),
+            .kind = .num_unbound,
+        } },
+        .small_dec => |value| .{ .small_dec_literal = .{
+            .value = cirSmallDec(value),
+            .has_suffix = false,
+        } },
+        .dec => |value| .{ .dec_literal = .{
+            .value = builtins.dec.RocDec{ .num = value },
+            .has_suffix = false,
+        } },
+        .exact => .{ .num_from_numeral_literal = .{} },
+        else => return try self.env.pushMalformed(Pattern.Idx, Diagnostic{ .invalid_num_literal = .{ .region = region } }),
+    };
+
+    const pattern_idx = try self.env.addPattern(pattern, region);
+    try self.recordNumeralLiteralForNode(ModuleEnv.nodeIdxFrom(pattern_idx), literal);
+    if (suffix_target) |target| {
+        try self.env.recordNumericSuffixTarget(ModuleEnv.nodeIdxFrom(pattern_idx), target);
+    }
+    return pattern_idx;
 }
 
 /// Canonicalize an expression.
@@ -9720,7 +9739,7 @@ fn runExprKernel(
                         },
                     };
                     const expr_idx = try self.env.addExpr(numeric_expr, region);
-                    try self.recordNumeralLiteralForExpr(expr_idx, literal);
+                    try self.recordNumeralLiteralForNode(ModuleEnv.nodeIdxFrom(expr_idx), literal);
                     try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, CanonicalizedExpr{ .idx = expr_idx, .free_vars = DataSpan.empty() });
                 },
                 .frac => |e| {
@@ -9743,7 +9762,7 @@ fn runExprKernel(
                         },
                     };
                     const expr_idx = try self.env.addExpr(numeric_expr, region);
-                    try self.recordNumeralLiteralForExpr(expr_idx, literal);
+                    try self.recordNumeralLiteralForNode(ModuleEnv.nodeIdxFrom(expr_idx), literal);
                     try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, CanonicalizedExpr{ .idx = expr_idx, .free_vars = DataSpan.empty() });
                 },
                 .typed_int => |e| {
@@ -9751,14 +9770,14 @@ fn runExprKernel(
                     const literal = self.parse_ir.store.getNumericLiteral(e.literal);
                     const type_ident = e.type_ident;
 
-                    if ((try self.scopeLookupOrPrepareTypeBinding(type_ident)) == null) {
+                    const suffix_target = (try self.resolveNumericSuffixTarget(type_ident)) orelse {
                         const expr_idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .undeclared_type = .{
                             .name = type_ident,
                             .region = region,
                         } });
                         try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, CanonicalizedExpr{ .idx = expr_idx, .free_vars = DataSpan.empty() });
                         continue :expr_kernel_loop .dispatch;
-                    }
+                    };
 
                     const numeric_expr: CIR.Expr = switch (literal.compact) {
                         .int => |value| CIR.Expr{ .e_typed_int = .{
@@ -9773,8 +9792,8 @@ fn runExprKernel(
                         },
                     };
                     const expr_idx = try self.env.addExpr(numeric_expr, region);
-                    try self.recordNumeralLiteralForExpr(expr_idx, literal);
-                    try self.recordTypedNumericSuffix(expr_idx, type_ident);
+                    try self.recordNumeralLiteralForNode(ModuleEnv.nodeIdxFrom(expr_idx), literal);
+                    try self.env.recordNumericSuffixTarget(ModuleEnv.nodeIdxFrom(expr_idx), suffix_target);
                     try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, CanonicalizedExpr{ .idx = expr_idx, .free_vars = DataSpan.empty() });
                 },
                 .typed_frac => |e| {
@@ -9782,14 +9801,14 @@ fn runExprKernel(
                     const literal = self.parse_ir.store.getNumericLiteral(e.literal);
                     const type_ident = e.type_ident;
 
-                    if ((try self.scopeLookupOrPrepareTypeBinding(type_ident)) == null) {
+                    const suffix_target = (try self.resolveNumericSuffixTarget(type_ident)) orelse {
                         const expr_idx = try self.env.pushMalformed(Expr.Idx, Diagnostic{ .undeclared_type = .{
                             .name = type_ident,
                             .region = region,
                         } });
                         try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, CanonicalizedExpr{ .idx = expr_idx, .free_vars = DataSpan.empty() });
                         continue :expr_kernel_loop .dispatch;
-                    }
+                    };
 
                     const numeric_expr: CIR.Expr = switch (literal.compact) {
                         .small_dec => |value| blk: {
@@ -9813,8 +9832,8 @@ fn runExprKernel(
                         },
                     };
                     const expr_idx = try self.env.addExpr(numeric_expr, region);
-                    try self.recordNumeralLiteralForExpr(expr_idx, literal);
-                    try self.recordTypedNumericSuffix(expr_idx, type_ident);
+                    try self.recordNumeralLiteralForNode(ModuleEnv.nodeIdxFrom(expr_idx), literal);
+                    try self.env.recordNumericSuffixTarget(ModuleEnv.nodeIdxFrom(expr_idx), suffix_target);
                     try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, CanonicalizedExpr{ .idx = expr_idx, .free_vars = DataSpan.empty() });
                 },
                 .single_quote => |e| {
@@ -11605,7 +11624,7 @@ fn runExprKernel(
                     .span = can_str_span,
                 } }, state.region);
                 if (state.type_ident) |type_ident| {
-                    try self.recordTypedNumericSuffix(str_idx, type_ident);
+                    try self.recordTypedNumericSuffix(ModuleEnv.nodeIdxFrom(str_idx), type_ident);
                 }
                 break :blk str_idx;
             } else try self.desugarInterpolatedString(can_str_span, state.region, state.type_ident);
@@ -14691,7 +14710,7 @@ fn desugarInterpolatedString(
                 .region = region,
             } });
         }
-        try self.recordTypedNumericSuffix(final_idx, suffix_ident);
+        try self.recordTypedNumericSuffix(ModuleEnv.nodeIdxFrom(final_idx), suffix_ident);
     }
 
     return try self.env.addExpr(CIR.Expr{ .e_block = .{
@@ -16639,13 +16658,13 @@ pub fn canonicalizePattern(
                 },
                 .typed_int => |e| {
                     const region = self.parse_ir.tokenizedRegionToRegion(e.region);
-                    const feature = try self.env.insertString("typed_int pattern");
-                    last_pattern = try self.env.pushMalformed(Pattern.Idx, Diagnostic{ .not_implemented = .{ .feature = feature, .region = region } });
+                    const literal = self.parse_ir.store.getNumericLiteral(e.literal);
+                    last_pattern = try self.canonicalizeNumeralPattern(literal, region, e.type_ident);
                 },
                 .typed_frac => |e| {
                     const region = self.parse_ir.tokenizedRegionToRegion(e.region);
-                    const feature = try self.env.insertString("typed_frac pattern");
-                    last_pattern = try self.env.pushMalformed(Pattern.Idx, Diagnostic{ .not_implemented = .{ .feature = feature, .region = region } });
+                    const literal = self.parse_ir.store.getNumericLiteral(e.literal);
+                    last_pattern = try self.canonicalizeNumeralPattern(literal, region, e.type_ident);
                 },
                 .var_ident => |e| {
                     // Mutable variable binding in a pattern (e.g., `|var $x, y|`)
@@ -16696,50 +16715,12 @@ pub fn canonicalizePattern(
                 .int => |e| {
                     const region = self.parse_ir.tokenizedRegionToRegion(e.region);
                     const literal = self.parse_ir.store.getNumericLiteral(e.literal);
-                    last_pattern = switch (literal.compact) {
-                        .int => |value| blk: {
-                            const pat_idx = try self.env.addPattern(Pattern{ .num_literal = .{
-                                .value = cirIntValue(value),
-                                .kind = .num_unbound,
-                            } }, region);
-                            try self.recordNumeralLiteralForPattern(pat_idx, literal);
-                            break :blk pat_idx;
-                        },
-                        .exact => blk: {
-                            const pat_idx = try self.env.addPattern(Pattern{ .num_from_numeral_literal = .{} }, region);
-                            try self.recordNumeralLiteralForPattern(pat_idx, literal);
-                            break :blk pat_idx;
-                        },
-                        else => try self.env.pushMalformed(Pattern.Idx, Diagnostic{ .invalid_num_literal = .{ .region = region } }),
-                    };
+                    last_pattern = try self.canonicalizeNumeralPattern(literal, region, null);
                 },
                 .frac => |e| {
                     const region = self.parse_ir.tokenizedRegionToRegion(e.region);
                     const literal = self.parse_ir.store.getNumericLiteral(e.literal);
-                    last_pattern = switch (literal.compact) {
-                        .small_dec => |value| blk: {
-                            const pat_idx = try self.env.addPattern(Pattern{ .small_dec_literal = .{
-                                .value = cirSmallDec(value),
-                                .has_suffix = false,
-                            } }, region);
-                            try self.recordNumeralLiteralForPattern(pat_idx, literal);
-                            break :blk pat_idx;
-                        },
-                        .dec => |value| blk: {
-                            const pat_idx = try self.env.addPattern(Pattern{ .dec_literal = .{
-                                .value = builtins.dec.RocDec{ .num = value },
-                                .has_suffix = false,
-                            } }, region);
-                            try self.recordNumeralLiteralForPattern(pat_idx, literal);
-                            break :blk pat_idx;
-                        },
-                        .exact => blk: {
-                            const pat_idx = try self.env.addPattern(Pattern{ .num_from_numeral_literal = .{} }, region);
-                            try self.recordNumeralLiteralForPattern(pat_idx, literal);
-                            break :blk pat_idx;
-                        },
-                        else => try self.env.pushMalformed(Pattern.Idx, Diagnostic{ .invalid_num_literal = .{ .region = region } }),
-                    };
+                    last_pattern = try self.canonicalizeNumeralPattern(literal, region, null);
                 },
                 .string => |e| {
                     last_pattern = try self.canonicalizeStringPattern(e);

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -4492,20 +4492,13 @@ fn findLocalTypeDeclByNameInSpan(
     return null;
 }
 
-fn unifyTypedLiteralWithExplicitType(
+fn unifyLiteralWithSuffixTarget(
     self: *Self,
     flex_var: Var,
-    expr_idx: CIR.Expr.Idx,
-    expr_region: Region,
+    suffix_target: ModuleEnv.NumericSuffixTarget,
+    region: Region,
     env: *Env,
 ) Allocator.Error!void {
-    const suffix_target = self.cir.numericSuffixTargetForNode(ModuleEnv.nodeIdxFrom(expr_idx)) orelse {
-        if (builtin.mode == .Debug) {
-            std.debug.panic("typed numeric literal reached checking without a canonicalized suffix target", .{});
-        }
-        unreachable;
-    };
-
     switch (suffix_target.target()) {
         .builtin => |num_kind| {
             try self.unifyWith(flex_var, try self.mkBuiltinNumberTypeContentFromKind(num_kind), env);
@@ -4515,7 +4508,7 @@ fn unifyTypedLiteralWithExplicitType(
             const resolved_var = if (self.isForClauseAliasStatement(stmt_idx))
                 local_decl_var
             else
-                try self.instantiateVar(local_decl_var, env, .{ .explicit = expr_region });
+                try self.instantiateVar(local_decl_var, env, .{ .explicit = region });
 
             _ = try self.unify(flex_var, resolved_var, env);
         },
@@ -4524,7 +4517,7 @@ fn unifyTypedLiteralWithExplicitType(
                 const instantiated_var = try self.instantiateVar(
                     ext_ref.local_var,
                     env,
-                    .{ .explicit = expr_region },
+                    .{ .explicit = region },
                 );
                 _ = try self.unify(flex_var, instantiated_var, env);
             } else {
@@ -4545,46 +4538,8 @@ fn explicitTypeSuffixVar(
 ) Allocator.Error!?Var {
     const suffix_target = self.cir.numericSuffixTargetForNode(ModuleEnv.nodeIdxFrom(expr_idx)) orelse return null;
     const suffix_var = try self.fresh(env, expr_region);
-
-    switch (suffix_target.target()) {
-        .builtin => |num_kind| {
-            try self.unifyWith(suffix_var, try self.mkBuiltinNumberTypeContentFromKind(num_kind), env);
-        },
-        .local => |stmt_idx| {
-            const local_decl_var = ModuleEnv.varFrom(stmt_idx);
-            const resolved_var = if (self.isForClauseAliasStatement(stmt_idx))
-                local_decl_var
-            else
-                try self.instantiateVar(local_decl_var, env, .{ .explicit = expr_region });
-
-            _ = try self.unify(suffix_var, resolved_var, env);
-        },
-        .external => |external| {
-            if (try self.resolveVarFromExternal(external.import_idx, external.target_node_idx)) |ext_ref| {
-                const instantiated_var = try self.instantiateVar(
-                    ext_ref.local_var,
-                    env,
-                    .{ .explicit = expr_region },
-                );
-                _ = try self.unify(suffix_var, instantiated_var, env);
-            } else {
-                try self.unifyWith(suffix_var, .err, env);
-            }
-        },
-        .invalid => {
-            try self.unifyWith(suffix_var, .err, env);
-        },
-    }
-
+    try self.unifyLiteralWithSuffixTarget(suffix_var, suffix_target, expr_region, env);
     return suffix_var;
-}
-
-fn typedLiteralTargetsBuiltin(self: *const Self, expr_idx: CIR.Expr.Idx, num_kind: CIR.NumKind) bool {
-    const suffix_target = self.cir.numericSuffixTargetForNode(ModuleEnv.nodeIdxFrom(expr_idx)) orelse return false;
-    return switch (suffix_target.target()) {
-        .builtin => |target_kind| target_kind == num_kind,
-        .local, .external, .invalid => false,
-    };
 }
 
 fn recordOpenLiteralVar(
@@ -4780,32 +4735,13 @@ fn mkFlexWithFromQuoteConstraint(
     return flex_var;
 }
 
-fn recordedNumeralLiteralForExpr(self: *const Self, expr_idx: CIR.Expr.Idx) ModuleEnv.NumeralLiteral {
-    return self.cir.numeralLiteralForNode(ModuleEnv.nodeIdxFrom(expr_idx)) orelse {
+fn recordedNumeralLiteralForNode(self: *const Self, node_idx: CIR.Node.Idx) ModuleEnv.NumeralLiteral {
+    return self.cir.numeralLiteralForNode(node_idx) orelse {
         if (builtin.mode == .Debug) {
-            std.debug.panic("missing recorded exact numeral for expression {}", .{@intFromEnum(expr_idx)});
+            std.debug.panic("missing recorded exact numeral for source node {}", .{@intFromEnum(node_idx)});
         }
         unreachable;
     };
-}
-
-/// Build the constraint-carried value facts for a literal expression from its
-/// recorded exact digits: the ONLY construction path for `NumeralInfo`, so
-/// compact and exact literals cannot disagree about fit answers.
-fn exactNumeralInfoForExpr(self: *const Self, expr_idx: CIR.Expr.Idx, region: Region) Allocator.Error!types_mod.NumeralInfo {
-    const literal = self.recordedNumeralLiteralForExpr(expr_idx);
-    return self.exactNumeralInfoForLiteral(literal, region);
-}
-
-/// Pattern-node counterpart of `exactNumeralInfoForExpr`.
-fn exactNumeralInfoForPattern(self: *const Self, pattern_idx: CIR.Pattern.Idx, region: Region) Allocator.Error!types_mod.NumeralInfo {
-    const literal = self.cir.numeralLiteralForNode(ModuleEnv.nodeIdxFrom(pattern_idx)) orelse {
-        if (builtin.mode == .Debug) {
-            std.debug.panic("missing recorded exact numeral for pattern {}", .{@intFromEnum(pattern_idx)});
-        }
-        unreachable;
-    };
-    return self.exactNumeralInfoForLiteral(literal, region);
 }
 
 fn exactNumeralInfoForLiteral(self: *const Self, literal: ModuleEnv.NumeralLiteral, region: Region) Allocator.Error!types_mod.NumeralInfo {
@@ -4821,38 +4757,40 @@ fn exactNumeralInfoForLiteral(self: *const Self, literal: ModuleEnv.NumeralLiter
     return types_mod.NumeralInfo.fromExact(exact, fit_set, literal.isMaterialized(), region);
 }
 
-/// Bind an unsuffixed (open) numeral literal expression: a fresh flex var
-/// carrying the literal's `from_numeral` constraint, unified with the
-/// expression var.
-fn checkOpenNumeralLiteralExpr(self: *Self, expr_idx: CIR.Expr.Idx, expr_var: Var, expr_region: Region, env: *Env) Allocator.Error!void {
-    const num_literal_info = try self.exactNumeralInfoForExpr(expr_idx, expr_region);
-    const flex_var = try self.mkFlexWithFromNumeralConstraint(ModuleEnv.nodeIdxFrom(expr_idx), num_literal_info, env);
-    _ = try self.unify(expr_var, flex_var, env);
-}
+const NumeralOccurrence = enum { expression, pattern };
 
-/// Bind a suffix-typed numeral literal expression (`123.U64`, `3.14.Dec`, or
-/// a custom-type suffix): the `from_numeral` flex var unifies with the
-/// explicit type, with Dec range validated eagerly when the suffix names Dec.
-fn checkSuffixedNumeralLiteralExpr(self: *Self, expr_idx: CIR.Expr.Idx, expr_var: Var, expr_region: Region, env: *Env) Allocator.Error!void {
-    var num_literal_info = try self.exactNumeralInfoForExpr(expr_idx, expr_region);
-    num_literal_info.explicit_suffix = true;
-    const flex_var = try self.mkFlexWithFromNumeralConstraint(ModuleEnv.nodeIdxFrom(expr_idx), num_literal_info, env);
+/// Check one exact numeric source occurrence. Exact digits and the optional
+/// resolved suffix target are producer-owned node data shared by expressions
+/// and patterns; patterns add only the equality requirement needed for matching.
+fn checkNumeralLiteral(
+    self: *Self,
+    node_idx: CIR.Node.Idx,
+    occurrence_var: Var,
+    region: Region,
+    comptime occurrence: NumeralOccurrence,
+    env: *Env,
+) Allocator.Error!void {
+    const suffix_target = self.cir.numericSuffixTargetForNode(node_idx);
+    const literal = self.recordedNumeralLiteralForNode(node_idx);
+    var num_literal_info = try self.exactNumeralInfoForLiteral(literal, region);
+    num_literal_info.explicit_suffix = suffix_target != null;
+    const flex_var = try self.mkFlexWithFromNumeralConstraint(node_idx, num_literal_info, env);
 
-    try self.unifyTypedLiteralWithExplicitType(flex_var, expr_idx, expr_region, env);
-    if (self.typedLiteralTargetsBuiltin(expr_idx, .dec)) {
-        _ = try self.reportInvalidBuiltinFromNumeralInfo(flex_var, .dec, num_literal_info, env);
+    if (suffix_target) |target| {
+        try self.unifyLiteralWithSuffixTarget(flex_var, target, region, env);
+        const targets_dec = switch (target.target()) {
+            .builtin => |kind| kind == .dec,
+            .local, .external, .invalid => false,
+        };
+        if (targets_dec) {
+            _ = try self.reportInvalidBuiltinFromNumeralInfo(flex_var, .dec, num_literal_info, env);
+        }
     }
 
-    _ = try self.unify(expr_var, flex_var, env);
-}
-
-/// Pattern flavor of `checkOpenNumeralLiteralExpr`, adding the pattern's
-/// value-equality obligation.
-fn checkOpenNumeralLiteralPattern(self: *Self, pattern_idx: CIR.Pattern.Idx, pattern_var: Var, pattern_region: Region, env: *Env) Allocator.Error!void {
-    const num_literal_info = try self.exactNumeralInfoForPattern(pattern_idx, pattern_region);
-    const flex_var = try self.mkFlexWithFromNumeralConstraint(ModuleEnv.nodeIdxFrom(pattern_idx), num_literal_info, env);
-    _ = try self.unify(pattern_var, flex_var, env);
-    try self.mkPatternLiteralEqConstraint(pattern_var, env, pattern_region);
+    _ = try self.unify(occurrence_var, flex_var, env);
+    if (occurrence == .pattern) {
+        try self.mkPatternLiteralEqConstraint(occurrence_var, env, region);
+    }
 }
 
 /// Create a nominal Box type with the given element type
@@ -11294,12 +11232,12 @@ fn checkPatternHelp(
         },
         // nums //
         .num_from_numeral_literal => {
-            try self.checkOpenNumeralLiteralPattern(pattern_idx, pattern_var, pattern_region, env);
+            try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(pattern_idx), pattern_var, pattern_region, .pattern, env);
         },
         .num_literal => |num| {
             switch (num.kind) {
                 // For unannotated literals, create a flex var with from_numeral constraint
-                .num_unbound, .int_unbound => try self.checkOpenNumeralLiteralPattern(pattern_idx, pattern_var, pattern_region, env),
+                .num_unbound, .int_unbound => try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(pattern_idx), pattern_var, pattern_region, .pattern, env),
                 // Phase 5: For explicitly typed literals, use nominal types from Builtin
                 else => try self.unifyWith(pattern_var, try self.mkNumberTypeContent(num.kind), env),
             }
@@ -11317,7 +11255,7 @@ fn checkPatternHelp(
                 // Explicit suffix like `3.14dec` - use nominal Dec type
                 try self.unifyWith(pattern_var, try self.mkNumberTypeContent(.dec), env);
             } else {
-                try self.checkOpenNumeralLiteralPattern(pattern_idx, pattern_var, pattern_region, env);
+                try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(pattern_idx), pattern_var, pattern_region, .pattern, env);
             }
         },
         .small_dec_literal => |dec| {
@@ -11325,7 +11263,7 @@ fn checkPatternHelp(
                 // Explicit suffix - use nominal Dec type
                 try self.unifyWith(pattern_var, try self.mkNumberTypeContent(.dec), env);
             } else {
-                try self.checkOpenNumeralLiteralPattern(pattern_idx, pattern_var, pattern_region, env);
+                try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(pattern_idx), pattern_var, pattern_region, .pattern, env);
             }
         },
         .runtime_error => {
@@ -12013,9 +11951,9 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                 // A plain literal converts to its target type through from_quote,
                 // defaulting to Str if nothing pins it.
                 const flex_var = try self.mkFlexWithFromQuoteConstraint(ModuleEnv.nodeIdxFrom(expr_idx), expr_region, env);
-                if (self.cir.numericSuffixTargetForNode(ModuleEnv.nodeIdxFrom(expr_idx)) != null) {
+                if (self.cir.numericSuffixTargetForNode(ModuleEnv.nodeIdxFrom(expr_idx))) |suffix_target| {
                     // Explicit type suffix, e.g. `"foo".MyType`.
-                    try self.unifyTypedLiteralWithExplicitType(flex_var, expr_idx, expr_region, env);
+                    try self.unifyLiteralWithSuffixTarget(flex_var, suffix_target, expr_region, env);
                 }
                 _ = try self.unify(expr_var, flex_var, env);
             }
@@ -12024,55 +11962,57 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
         .e_num => |num| {
             switch (num.kind) {
                 // For unannotated literals, create a flex var with from_numeral constraint
-                .num_unbound, .int_unbound => try self.checkOpenNumeralLiteralExpr(expr_idx, expr_var, expr_region, env),
+                .num_unbound, .int_unbound => try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(expr_idx), expr_var, expr_region, .expression, env),
                 else => try self.unifyWith(expr_var, try self.mkNumberTypeContent(num.kind), env),
             }
         },
         .e_num_from_numeral => {
-            try self.checkOpenNumeralLiteralExpr(expr_idx, expr_var, expr_region, env);
+            try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(expr_idx), expr_var, expr_region, .expression, env);
         },
         .e_frac_f32 => |frac| {
             if (frac.has_suffix) {
                 try self.unifyWith(expr_var, try self.mkNumberTypeContent(.f32), env);
             } else {
-                try self.checkOpenNumeralLiteralExpr(expr_idx, expr_var, expr_region, env);
+                try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(expr_idx), expr_var, expr_region, .expression, env);
             }
         },
         .e_frac_f64 => |frac| {
             if (frac.has_suffix) {
                 try self.unifyWith(expr_var, try self.mkNumberTypeContent(.f64), env);
             } else {
-                try self.checkOpenNumeralLiteralExpr(expr_idx, expr_var, expr_region, env);
+                try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(expr_idx), expr_var, expr_region, .expression, env);
             }
         },
         .e_dec => |frac| {
             if (frac.has_suffix) {
-                const num_literal_info = try self.exactNumeralInfoForExpr(expr_idx, expr_region);
+                const literal = self.recordedNumeralLiteralForNode(ModuleEnv.nodeIdxFrom(expr_idx));
+                const num_literal_info = try self.exactNumeralInfoForLiteral(literal, expr_region);
                 _ = try self.reportInvalidBuiltinFromNumeralInfo(expr_var, .dec, num_literal_info, env);
                 try self.unifyWith(expr_var, try self.mkNumberTypeContent(.dec), env);
             } else {
-                try self.checkOpenNumeralLiteralExpr(expr_idx, expr_var, expr_region, env);
+                try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(expr_idx), expr_var, expr_region, .expression, env);
             }
         },
         .e_dec_small => |frac| {
             if (frac.has_suffix) {
-                const num_literal_info = try self.exactNumeralInfoForExpr(expr_idx, expr_region);
+                const literal = self.recordedNumeralLiteralForNode(ModuleEnv.nodeIdxFrom(expr_idx));
+                const num_literal_info = try self.exactNumeralInfoForLiteral(literal, expr_region);
                 _ = try self.reportInvalidBuiltinFromNumeralInfo(expr_var, .dec, num_literal_info, env);
                 try self.unifyWith(expr_var, try self.mkNumberTypeContent(.dec), env);
             } else {
-                try self.checkOpenNumeralLiteralExpr(expr_idx, expr_var, expr_region, env);
+                try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(expr_idx), expr_var, expr_region, .expression, env);
             }
         },
         .e_typed_int => {
             // Typed integer literal like 123.U64
-            try self.checkSuffixedNumeralLiteralExpr(expr_idx, expr_var, expr_region, env);
+            try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(expr_idx), expr_var, expr_region, .expression, env);
         },
         .e_typed_frac => {
             // Typed fractional literal like 3.14.Dec
-            try self.checkSuffixedNumeralLiteralExpr(expr_idx, expr_var, expr_region, env);
+            try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(expr_idx), expr_var, expr_region, .expression, env);
         },
         .e_typed_num_from_numeral => {
-            try self.checkSuffixedNumeralLiteralExpr(expr_idx, expr_var, expr_region, env);
+            try self.checkNumeralLiteral(ModuleEnv.nodeIdxFrom(expr_idx), expr_var, expr_region, .expression, env);
         },
         // list //
         .e_empty_list => {

--- a/test/snapshots/issue/issue_10134_typed_frac_pattern_suffix_mismatch.md
+++ b/test/snapshots/issue/issue_10134_typed_frac_pattern_suffix_mismatch.md
@@ -1,0 +1,114 @@
+# META
+~~~ini
+description=An explicit fractional pattern suffix constrains the pattern independently of its match context
+type=snippet
+~~~
+# SOURCE
+~~~roc
+classify : F64 -> I64
+classify = |n| match n {
+	1.5.F32 => 1
+	_ => 0
+}
+~~~
+# EXPECTED
+TYPE MISMATCH - issue_10134_typed_frac_pattern_suffix_mismatch.md:2:16:2:16
+# PROBLEMS
+
+┌───────────────┐
+│ TYPE MISMATCH ├─ The first pattern in this `match` is incompatible. ────────┐
+└┬──────────────┘                                                             │
+ │                                                                            │
+ │  classify = |n| match n {                                                  │
+ │      1.5.F32 => 1                                                          │
+ │      _ => 0                                                                │
+ │  }                                                                         │
+ │                                                                            │
+ └───────────────────── issue_10134_typed_frac_pattern_suffix_mismatch.md:2:2 ┘
+
+    The first pattern is trying to match:
+
+        F32
+
+    But the expression between the `match` parenthesis has the type:
+
+        F64
+
+    These can never match! Either the pattern or expression has a problem.
+
+# TOKENS
+~~~zig
+LowerIdent,OpColon,UpperIdent,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,KwMatch,LowerIdent,OpenCurly,
+Float,NoSpaceDotUpperIdent,OpFatArrow,Int,
+Underscore,OpFatArrow,Int,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-anno (name "classify")
+			(ty-fn
+				(ty (name "F64"))
+				(ty (name "I64"))))
+		(s-decl
+			(p-ident (raw "classify"))
+			(e-lambda
+				(args
+					(p-ident (raw "n")))
+				(e-match
+					(e-ident (raw "n"))
+					(branches
+						(branch
+							(p-typed-frac (raw "1.5") (type "F32"))
+							(e-int (raw "1")))
+						(branch
+							(p-underscore)
+							(e-int (raw "0")))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "classify"))
+		(e-lambda
+			(args
+				(p-assign (ident "n")))
+			(e-match
+				(match
+					(cond
+						(e-lookup-local
+							(p-assign (ident "n"))))
+					(branches
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-small-dec)))
+							(value
+								(e-num (value "1"))))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-underscore)))
+							(value
+								(e-num (value "0"))))))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-lookup (name "F64") (builtin))
+				(ty-lookup (name "I64") (builtin))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "F64 -> I64")))
+	(expressions
+		(expr (type "F64 -> I64"))))
+~~~

--- a/test/snapshots/issue/issue_10134_typed_frac_patterns.md
+++ b/test/snapshots/issue/issue_10134_typed_frac_patterns.md
@@ -1,0 +1,151 @@
+# META
+~~~ini
+description=Explicitly typed F32 and F64 fractional literals are valid patterns
+type=snippet
+~~~
+# SOURCE
+~~~roc
+classify32 : F32 -> I64
+classify32 = |n| match n {
+	1.5.F32 => 1
+	_ => 0
+}
+
+classify64 : F64 -> I64
+classify64 = |n| match n {
+	1.5.F64 => 1
+	_ => 0
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpColon,UpperIdent,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,KwMatch,LowerIdent,OpenCurly,
+Float,NoSpaceDotUpperIdent,OpFatArrow,Int,
+Underscore,OpFatArrow,Int,
+CloseCurly,
+LowerIdent,OpColon,UpperIdent,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,KwMatch,LowerIdent,OpenCurly,
+Float,NoSpaceDotUpperIdent,OpFatArrow,Int,
+Underscore,OpFatArrow,Int,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-module)
+	(statements
+		(s-type-anno (name "classify32")
+			(ty-fn
+				(ty (name "F32"))
+				(ty (name "I64"))))
+		(s-decl
+			(p-ident (raw "classify32"))
+			(e-lambda
+				(args
+					(p-ident (raw "n")))
+				(e-match
+					(e-ident (raw "n"))
+					(branches
+						(branch
+							(p-typed-frac (raw "1.5") (type "F32"))
+							(e-int (raw "1")))
+						(branch
+							(p-underscore)
+							(e-int (raw "0")))))))
+		(s-type-anno (name "classify64")
+			(ty-fn
+				(ty (name "F64"))
+				(ty (name "I64"))))
+		(s-decl
+			(p-ident (raw "classify64"))
+			(e-lambda
+				(args
+					(p-ident (raw "n")))
+				(e-match
+					(e-ident (raw "n"))
+					(branches
+						(branch
+							(p-typed-frac (raw "1.5") (type "F64"))
+							(e-int (raw "1")))
+						(branch
+							(p-underscore)
+							(e-int (raw "0")))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "classify32"))
+		(e-lambda
+			(args
+				(p-assign (ident "n")))
+			(e-match
+				(match
+					(cond
+						(e-lookup-local
+							(p-assign (ident "n"))))
+					(branches
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-small-dec)))
+							(value
+								(e-num (value "1"))))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-underscore)))
+							(value
+								(e-num (value "0"))))))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-lookup (name "F32") (builtin))
+				(ty-lookup (name "I64") (builtin)))))
+	(d-let
+		(p-assign (ident "classify64"))
+		(e-lambda
+			(args
+				(p-assign (ident "n")))
+			(e-match
+				(match
+					(cond
+						(e-lookup-local
+							(p-assign (ident "n"))))
+					(branches
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-small-dec)))
+							(value
+								(e-num (value "1"))))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-underscore)))
+							(value
+								(e-num (value "0"))))))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-lookup (name "F64") (builtin))
+				(ty-lookup (name "I64") (builtin))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "F32 -> I64"))
+		(patt (type "F64 -> I64")))
+	(expressions
+		(expr (type "F32 -> I64"))
+		(expr (type "F64 -> I64"))))
+~~~


### PR DESCRIPTION
Typed numeric literal patterns now reuse the same exact-numeral and suffix-target pipeline as expressions, so explicitly typed F32 and F64 patterns canonicalize and check instead of producing a NOT IMPLEMENTED diagnostic. Suffix targets are resolved once during canonicalization, and a mismatch regression test ensures the explicit suffix cannot be ignored by match context.

Closes #10134.