### PR TITLE
Fix bare U128 returns on Windows x64

### DIFF
--- a/src/backend/dev/CallingConvention.zig
+++ b/src/backend/dev/CallingConvention.zig
@@ -432,11 +432,11 @@ pub fn CallBuilder(comptime EmitType: type) type {
         /// Add a float argument by loading from memory.
         /// Windows x64: Uses position-based registers (XMM0-3 mirror arg positions 0-3).
         /// System V / AAPCS64: Uses a separate float register pool.
-        pub fn addFloatMemArg(self: *Self, base_reg: GeneralReg, offset: i32, is_f64: bool) Allocator.Error!void {
+        pub fn addFloatMemArg(self: *Self, base_reg: GeneralReg, offset: i32, size: u8) Allocator.Error!void {
             if (comptime uses_position_based_float_args) {
                 // Windows x64: float args use same position as int args
                 if (self.int_arg_index < CC_EMIT.FLOAT_PARAM_REGS.len) {
-                    try self.emitFloatLoad(CC_EMIT.FLOAT_PARAM_REGS[self.int_arg_index], base_reg, offset, is_f64);
+                    try self.emitFloatLoad(CC_EMIT.FLOAT_PARAM_REGS[self.int_arg_index], base_reg, offset, size);
                     self.int_arg_index += 1;
                 } else {
                     // TODO: Implement stack float args for Windows CallBuilder.
@@ -445,7 +445,7 @@ pub fn CallBuilder(comptime EmitType: type) type {
             } else {
                 // System V / AAPCS64: separate float register pool
                 if (self.float_arg_index < CC_EMIT.FLOAT_PARAM_REGS.len) {
-                    try self.emitFloatLoad(CC_EMIT.FLOAT_PARAM_REGS[self.float_arg_index], base_reg, offset, is_f64);
+                    try self.emitFloatLoad(CC_EMIT.FLOAT_PARAM_REGS[self.float_arg_index], base_reg, offset, size);
                     self.float_arg_index += 1;
                 } else {
                     // TODO: Implement stack float args for System V CallBuilder.
@@ -455,34 +455,37 @@ pub fn CallBuilder(comptime EmitType: type) type {
         }
 
         /// Load a float from memory into a float register, dispatching to the target's emit.
-        fn emitFloatLoad(self: *Self, dst: FloatReg, base_reg: GeneralReg, offset: i32, is_f64: bool) Allocator.Error!void {
+        fn emitFloatLoad(self: *Self, dst: FloatReg, base_reg: GeneralReg, offset: i32, size: u8) Allocator.Error!void {
             if (comptime @hasDecl(EmitType, "fldrRegMemSoff")) {
-                if (is_f64) {
-                    try self.emit.fldrRegMemSoff(.double, dst, base_reg, offset);
-                } else {
-                    try self.emit.fldrRegMemSoff(.single, dst, base_reg, offset);
+                switch (size) {
+                    4 => try self.emit.fldrRegMemSoff(.single, dst, base_reg, offset),
+                    8 => try self.emit.fldrRegMemSoff(.double, dst, base_reg, offset),
+                    else => unreachable,
                 }
             } else if (comptime @hasDecl(EmitType, "fldrRegMemUoff")) {
-                if (is_f64) {
-                    try self.emit.fldrRegMemUoff(.double, dst, base_reg, @intCast(offset));
-                } else {
-                    try self.emit.fldrRegMemUoff(.single, dst, base_reg, @intCast(offset));
+                switch (size) {
+                    4 => try self.emit.fldrRegMemUoff(.single, dst, base_reg, @intCast(offset)),
+                    8 => try self.emit.fldrRegMemUoff(.double, dst, base_reg, @intCast(offset)),
+                    else => unreachable,
                 }
-            } else if (is_f64) {
-                try self.emit.movsdRegMem(dst, base_reg, offset);
             } else {
-                try self.emit.movssRegMem(dst, base_reg, offset);
+                switch (size) {
+                    4 => try self.emit.movssRegMem(dst, base_reg, offset),
+                    8 => try self.emit.movsdRegMem(dst, base_reg, offset),
+                    16 => try self.emit.movdquRegMem(dst, base_reg, offset),
+                    else => unreachable,
+                }
             }
         }
 
         /// Add a f64 float argument by loading from memory (convenience wrapper).
         pub fn addF64MemArg(self: *Self, base_reg: GeneralReg, offset: i32) Allocator.Error!void {
-            try self.addFloatMemArg(base_reg, offset, true);
+            try self.addFloatMemArg(base_reg, offset, 8);
         }
 
         /// Add a f32 float argument by loading from memory (convenience wrapper).
         pub fn addF32MemArg(self: *Self, base_reg: GeneralReg, offset: i32) Allocator.Error!void {
-            try self.addFloatMemArg(base_reg, offset, false);
+            try self.addFloatMemArg(base_reg, offset, 4);
         }
 
         /// Get the number of float argument registers available

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -11706,7 +11706,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                             const piece_off = slot_off + @as(i32, @intCast(piece.offset));
                             switch (piece.class) {
                                 .integer => try builder.addMemArg(frame_ptr, piece_off),
-                                .float => try builder.addFloatMemArg(frame_ptr, piece_off, piece.size == 8),
+                                .float => try builder.addFloatMemArg(frame_ptr, piece_off, piece.size),
                             }
                         }
                     },
@@ -11745,7 +11745,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                                 gp_i += 1;
                             },
                             .float => {
-                                try self.emitHostedFloatResultStore(dst_off, sse_i, piece.size == 8);
+                                try self.emitHostedFloatResultStore(dst_off, sse_i, piece.size);
                                 sse_i += 1;
                             },
                         }
@@ -11768,20 +11768,23 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         }
 
         /// Store hosted-call float result register `index` (0 or 1) into the return slot.
-        fn emitHostedFloatResultStore(self: *Self, dst_off: i32, index: usize, is_f64: bool) Allocator.Error!void {
+        fn emitHostedFloatResultStore(self: *Self, dst_off: i32, index: usize, size: u8) Allocator.Error!void {
             const freg0: FloatReg = if (arch == .x86_64) .XMM0 else .V0;
             const freg1: FloatReg = if (arch == .x86_64) .XMM1 else .V1;
             const freg = if (index == 0) freg0 else freg1;
             if (comptime target.toCpuArch() == .aarch64) {
-                if (is_f64) {
-                    try self.codegen.emitStoreStackF64(dst_off, freg);
-                } else {
-                    try self.codegen.emitStoreStackF32(dst_off, freg);
+                switch (size) {
+                    4 => try self.codegen.emitStoreStackF32(dst_off, freg),
+                    8 => try self.codegen.emitStoreStackF64(dst_off, freg),
+                    else => unreachable,
                 }
-            } else if (is_f64) {
-                try self.codegen.emit.movsdMemReg(frame_ptr, dst_off, freg);
             } else {
-                try self.codegen.emit.movssMemReg(frame_ptr, dst_off, freg);
+                switch (size) {
+                    4 => try self.codegen.emit.movssMemReg(frame_ptr, dst_off, freg),
+                    8 => try self.codegen.emit.movsdMemReg(frame_ptr, dst_off, freg),
+                    16 => try self.codegen.emit.movdquMemReg(frame_ptr, dst_off, freg),
+                    else => unreachable,
+                }
             }
         }
 
@@ -17371,7 +17374,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                                     }
                                 },
                                 .float => {
-                                    const width: u8 = if (piece.size == 8) 8 else 4;
+                                    const width = piece.size;
                                     const pos = if (shared_arg_positions) blk: {
                                         const taken = int_idx;
                                         int_idx += 1;
@@ -17468,7 +17471,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             for (reg_captures.items) |cap| {
                 if (cap.is_float) {
                     const freg = float_param_regs[cap.reg_index];
-                    try self.emitEntryFloatStore(cap.dest_off, freg, cap.width == 8);
+                    try self.emitEntryFloatStore(cap.dest_off, freg, cap.width);
                 } else {
                     const reg = int_param_regs[cap.reg_index];
                     if (cap.width <= 4) {
@@ -17556,7 +17559,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                                 }
                             },
                             .float => {
-                                try self.emitEntryFloatLoad(src_off, fp_i, piece.size == 8);
+                                try self.emitEntryFloatLoad(src_off, fp_i, piece.size);
                                 fp_i += 1;
                             },
                         }
@@ -17566,38 +17569,42 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         }
 
         /// Store an incoming float argument register into the frame.
-        fn emitEntryFloatStore(self: *Self, dest_off: i32, freg: FloatReg, is_f64: bool) Allocator.Error!void {
+        fn emitEntryFloatStore(self: *Self, dest_off: i32, freg: FloatReg, size: u8) Allocator.Error!void {
             if (comptime target.toCpuArch() == .aarch64) {
-                if (is_f64) {
-                    try self.codegen.emitStoreStackF64(dest_off, freg);
-                } else {
-                    try self.codegen.emitStoreStackF32(dest_off, freg);
+                switch (size) {
+                    4 => try self.codegen.emitStoreStackF32(dest_off, freg),
+                    8 => try self.codegen.emitStoreStackF64(dest_off, freg),
+                    else => unreachable,
                 }
-            } else if (is_f64) {
-                try self.codegen.emit.movsdMemReg(frame_ptr, dest_off, freg);
             } else {
-                try self.codegen.emit.movssMemReg(frame_ptr, dest_off, freg);
+                switch (size) {
+                    4 => try self.codegen.emit.movssMemReg(frame_ptr, dest_off, freg),
+                    8 => try self.codegen.emit.movsdMemReg(frame_ptr, dest_off, freg),
+                    16 => try self.codegen.emit.movdquMemReg(frame_ptr, dest_off, freg),
+                    else => unreachable,
+                }
             }
         }
 
         /// Load C-ABI float return piece `index` from the frame into the
         /// float return register sequence (V0..V3 / XMM0..XMM1).
-        fn emitEntryFloatLoad(self: *Self, src_off: i32, index: usize, is_f64: bool) Allocator.Error!void {
+        fn emitEntryFloatLoad(self: *Self, src_off: i32, index: usize, size: u8) Allocator.Error!void {
             if (comptime target.toCpuArch() == .aarch64) {
                 const fregs = [_]FloatReg{ .V0, .V1, .V2, .V3 };
                 const freg = fregs[index];
-                if (is_f64) {
-                    try self.codegen.emitLoadStackF64(freg, src_off);
-                } else {
-                    try self.codegen.emitLoadStackF32(freg, src_off);
+                switch (size) {
+                    4 => try self.codegen.emitLoadStackF32(freg, src_off),
+                    8 => try self.codegen.emitLoadStackF64(freg, src_off),
+                    else => unreachable,
                 }
             } else {
                 const fregs = [_]FloatReg{ .XMM0, .XMM1 };
                 const freg = fregs[index];
-                if (is_f64) {
-                    try self.codegen.emit.movsdRegMem(freg, frame_ptr, src_off);
-                } else {
-                    try self.codegen.emit.movssRegMem(freg, frame_ptr, src_off);
+                switch (size) {
+                    4 => try self.codegen.emit.movssRegMem(freg, frame_ptr, src_off),
+                    8 => try self.codegen.emit.movsdRegMem(freg, frame_ptr, src_off),
+                    16 => try self.codegen.emit.movdquRegMem(freg, frame_ptr, src_off),
+                    else => unreachable,
                 }
             }
         }

--- a/src/backend/dev/x86_64/Emit.zig
+++ b/src/backend/dev/x86_64/Emit.zig
@@ -899,6 +899,27 @@ pub fn Emit(comptime target: RocTarget) type {
             try self.buf.appendSlice(self.allocator, &@as([4]u8, @bitCast(disp)));
         }
 
+        /// MOVDQU xmm, [base + disp32] (load 128-bit unaligned from memory)
+        pub fn movdquRegMem(self: *Self, dst: FloatReg, base: GeneralReg, disp: i32) Allocator.Error!void {
+            try self.buf.append(self.allocator, 0xF3);
+            const r: u1 = dst.rexB();
+            const b: u1 = base.rexB();
+            if (r == 1 or b == 1) {
+                try self.buf.append(self.allocator, rex(0, r, 0, b));
+            }
+            try self.buf.append(self.allocator, 0x0F);
+            try self.buf.append(self.allocator, 0x6F); // MOVDQU xmm, m128
+
+            const base_enc = base.enc();
+            if (base_enc == 4) {
+                try self.buf.append(self.allocator, modRM(0b10, dst.enc(), 0b100));
+                try self.buf.append(self.allocator, 0x24);
+            } else {
+                try self.buf.append(self.allocator, modRM(0b10, dst.enc(), base_enc));
+            }
+            try self.buf.appendSlice(self.allocator, &@as([4]u8, @bitCast(disp)));
+        }
+
         /// MOVSD [base + disp32], xmm (store scalar double to memory)
         pub fn movsdMemReg(self: *Self, base: GeneralReg, disp: i32, src: FloatReg) Allocator.Error!void {
             try self.buf.append(self.allocator, 0xF2);
@@ -1492,6 +1513,18 @@ test "movsd xmm, xmm - all combinations" {
             try std.testing.expectEqual(@as(u8, 0xF2), emit.buf.items[0]);
         }
     }
+}
+
+test "movdqu load and store unaligned 128-bit values" {
+    var emit = LinuxEmit.init(std.testing.allocator);
+    defer emit.deinit();
+
+    try emit.movdquRegMem(.XMM0, .RBP, -16);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xF3, 0x0F, 0x6F, 0x85, 0xF0, 0xFF, 0xFF, 0xFF }, emit.buf.items);
+
+    emit.buf.clearRetainingCapacity();
+    try emit.movdquMemReg(.RBP, -16, .XMM0);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xF3, 0x0F, 0x7F, 0x85, 0xF0, 0xFF, 0xFF, 0xFF }, emit.buf.items);
 }
 
 test "addsd xmm, xmm - all combinations" {

--- a/src/backend/mod.zig
+++ b/src/backend/mod.zig
@@ -49,3 +49,91 @@ test "backend tests" {
     std.testing.refAllDecls(dev);
     std.testing.refAllDecls(wasm);
 }
+
+test "x86_64 Windows hosted U128 return stores all 16 bytes from XMM0" {
+    const std = @import("std");
+    const layout = @import("layout");
+    const lir = @import("lir");
+
+    const allocator = std.testing.allocator;
+    var store = lir.LirStore.init(allocator);
+    defer store.deinit();
+    var layout_store = try layout.Store.init(allocator, .u64);
+    defer layout_store.deinit();
+
+    // Repro for https://github.com/roc-lang/roc/issues/10163: the clang/Rust
+    // Windows x64 ABI returns a bare U128 in XMM0, so the caller must copy the
+    // complete 16-byte register into Roc's result slot.
+    const symbol = try store.insertString("hosted_u128_identity");
+    _ = try store.addProcSpec(.{
+        .name = store.freshSyntheticSymbol(),
+        .args = lir.LIR.LocalSpan.empty(),
+        .ret_layout = .u128,
+        .hosted = .{ .symbol = symbol, .dispatch_index = 0 },
+    });
+
+    const WinCodeGen = dev.LirCodeGenMod.LirCodeGen(.x64win);
+    var codegen = try WinCodeGen.init(allocator, &store, &layout_store, &.{});
+    defer codegen.deinit();
+    codegen.generation_mode = .object_file;
+
+    try codegen.compileAllProcSpecs(store.getProcSpecs());
+
+    // MOVDQU m128, XMM0 is the unaligned full-width store into the result slot.
+    const code = codegen.getGeneratedCode();
+    var return_code: ?[]const u8 = null;
+    for (codegen.getRelocations()) |relocation| {
+        switch (relocation) {
+            .linked_function => |linked| {
+                if (std.mem.eql(u8, linked.name, "hosted_u128_identity")) {
+                    const call_end: usize = @intCast(linked.offset + 4);
+                    return_code = code[call_end..@min(call_end + 32, code.len)];
+                    break;
+                }
+            },
+            else => {},
+        }
+    }
+    const after_hosted_call = return_code orelse return error.TestUnexpectedResult;
+    const store_start = std.mem.find(u8, after_hosted_call, &.{ 0xF3, 0x0F }) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualSlices(u8, &.{ 0xF3, 0x0F, 0x7F, 0x85 }, after_hosted_call[store_start..][0..4]);
+}
+
+test "x86_64 Windows U128 entrypoint return loads all 16 bytes into XMM0" {
+    const std = @import("std");
+    const layout = @import("layout");
+    const lir = @import("lir");
+
+    const allocator = std.testing.allocator;
+    var store = lir.LirStore.init(allocator);
+    defer store.deinit();
+    var layout_store = try layout.Store.init(allocator, .u64);
+    defer layout_store.deinit();
+
+    const result = try store.addLocal(.{ .layout_idx = .u128 });
+    const ret = try store.addCFStmt(.{ .ret = .{ .value = result } });
+    const body = try store.addCFStmt(.{ .assign_literal = .{
+        .target = result,
+        .value = .{ .i128_literal = .{ .value = 0x11111111111111112222222222222222, .layout_idx = .u128 } },
+        .next = ret,
+    } });
+    const proc = try store.addProcSpec(.{
+        .name = store.freshSyntheticSymbol(),
+        .args = lir.LIR.LocalSpan.empty(),
+        .body = body,
+        .ret_layout = .u128,
+    });
+
+    const WinCodeGen = dev.LirCodeGenMod.LirCodeGen(.x64win);
+    var codegen = try WinCodeGen.init(allocator, &store, &layout_store, &.{});
+    defer codegen.deinit();
+    codegen.generation_mode = .object_file;
+
+    try codegen.compileAllProcSpecs(store.getProcSpecs());
+    const entrypoint = try codegen.generateEntrypointWrapper("roc_u128_identity", proc, &.{}, .u128);
+    const code = codegen.getGeneratedCode();
+    const entrypoint_code = code[entrypoint.offset..][0..entrypoint.size];
+
+    // MOVDQU XMM0, m128 returns the complete value using clang/Rust's convention.
+    try std.testing.expect(std.mem.find(u8, entrypoint_code, &.{ 0xF3, 0x0F, 0x6F, 0x85 }) != null);
+}


### PR DESCRIPTION
On Windows x64, bare 128-bit integers cross the clang/Rust C ABI in XMM0. Preserve explicit ABI register-piece widths through dev-backend marshalling and use unaligned 128-bit XMM loads and stores for hosted calls and exported entrypoints, preventing U128 returns from being truncated to a 32-bit MOVSS store. Fixes #10163.