### PR TITLE
Fix dev default-app inline expect exit status

### DIFF
--- a/src/machine_code_shim/main.zig
+++ b/src/machine_code_shim/main.zig
@@ -796,12 +796,14 @@ fn shimDefaultMain(argc: usize, argv: [*][*:0]const u8) callconv(.c) usize {
     };
 
     var result: u8 align(16) = 0;
+    shim_host_abi.resetInlineExpectFailed();
     evaluateEntrypoint(0, ops, &result, &cli_args_list) catch |err| switch (err) {
         error.ImageUnavailable,
         error.InvalidEntrypoint,
         error.OutOfMemory,
         => return 1,
     };
+    if (result == 0 and shim_host_abi.takeInlineExpectFailed()) return 1;
     return result;
 }
 

--- a/src/shim_host_abi.zig
+++ b/src/shim_host_abi.zig
@@ -38,7 +38,10 @@ fn shimDbg(_: *RocOps, bytes: [*]const u8, len: usize) callconv(.c) void {
     extern_host.roc_dbg(bytes, len);
 }
 
+var inline_expect_failed = false;
+
 fn shimExpectFailed(_: *RocOps, bytes: [*]const u8, len: usize) callconv(.c) void {
+    inline_expect_failed = true;
     extern_host.roc_expect_failed(bytes, len);
 }
 
@@ -73,6 +76,19 @@ pub fn getOps() *RocOps {
 /// Return the RocOps value as an opaque pointer for the C ABI export.
 pub fn getOpsOpaque() *anyopaque {
     return @ptrCast(getOps());
+}
+
+/// Clear the default-run inline expect status before entering Roc code.
+pub fn resetInlineExpectFailed() void {
+    inline_expect_failed = false;
+}
+
+/// Return and clear whether the current default-run invocation failed an inline
+/// expect through this shim's RocOps.
+pub fn takeInlineExpectFailed() bool {
+    const failed = inline_expect_failed;
+    inline_expect_failed = false;
+    return failed;
 }
 
 /// Build the default platform's `List(Str)` CLI argument value.


### PR DESCRIPTION
Linux dev default-app runs go through roc_shim_default_main, whose RocOps callback reported failed inline expects but did not preserve that fact when returning the final status byte. This records failed inline expects in the shim host ABI, resets that state before each default-run invocation, and returns status 1 when Roc otherwise returns 0 after an inline expect failure, matching the interpreter and default runtime behavior.