### PR TITLE
Fix tag payload evidence path traversal

### DIFF
--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -886,6 +886,43 @@ test "issue 10153 nested loops do not multiply SpecConstr callable functions" {
     try std.testing.expect(nested_loop.lifted.exprCount() <= single_loop.lifted.exprCount() * 2);
 }
 
+test "issue 10165 higher-order decoder widens propagated error row" {
+    const allocator = std.testing.allocator;
+    // Repro for https://github.com/roc-lang/roc/issues/10165. A decoder that
+    // propagates a leaf error with `?` may add its own error tag, and the
+    // resulting higher-order callable must lower with that wider error row.
+    const source =
+        \\Stmt : {}
+        \\
+        \\str_dec : Str -> (List(Str) -> (Stmt -> Try(Str, [NoSuchField(Str), ..])))
+        \\str_dec = |_name| |_cols| |_stmt| Ok("todo")
+        \\
+        \\main : {} -> Try({}, _)
+        \\main = |_args| {
+        \\    dec = decode_row(["status"])
+        \\    row = dec({})?
+        \\    _ = row
+        \\    Ok({})
+        \\}
+        \\
+        \\decode_row = |cols|
+        \\    |stmt| {
+        \\        status_str = str_dec("status")(cols)(stmt)?
+        \\        match status_str {
+        \\            "todo" => Ok(Todo)
+        \\            _ => Err(ParseError("unknown status"))
+        \\        }
+        \\    }
+    ;
+
+    var lowered = try lowerModule(allocator, source, .none);
+    defer lowered.deinit(allocator);
+
+    var run = try runLoweredWithHostEvents(allocator, &lowered.lowered);
+    defer run.deinit(allocator);
+    try std.testing.expectEqual(eval.RuntimeHostEnv.Termination.returned, run.termination);
+}
+
 fn expectInlinePlanDecision(
     source: []const u8,
     fn_name: []const u8,

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -20569,7 +20569,10 @@ const BodyContext = struct {
         path: []const static_dispatch.EvidencePathStep,
     ) Allocator.Error!?Type.TypeId {
         var ty = start_ty;
-        for (path) |path_step| {
+        var path_index: usize = 0;
+        while (path_index < path.len) {
+            const path_step = path[path_index];
+            path_index += 1;
             const content = self.builder.program.types.get(ty);
             switch (path_step.stepKind()) {
                 .fn_arg => switch (content) {
@@ -20632,8 +20635,15 @@ const BodyContext = struct {
                             const tag = GuardedList.at(tags, index);
                             if (tag.name == label) break tag;
                         } else return null;
-                        // The next step must be the payload index.
-                        return try self.walkTagPayloadPath(view, tag, path[1..]);
+
+                        if (path_index >= path.len) return null;
+                        const payload_step = path[path_index];
+                        if (payload_step.stepKind() != .tag_payload_index) return null;
+                        path_index += 1;
+
+                        const payloads = self.builder.program.types.span(tag.payloads);
+                        if (payload_step.data >= payloads.len) return null;
+                        ty = GuardedList.at(payloads, payload_step.data);
                     },
                     else => return null,
                 },
@@ -20642,19 +20652,6 @@ const BodyContext = struct {
             }
         }
         return ty;
-    }
-
-    fn walkTagPayloadPath(
-        self: *BodyContext,
-        view: ModuleView,
-        tag: Type.Tag,
-        rest: []const static_dispatch.EvidencePathStep,
-    ) Allocator.Error!?Type.TypeId {
-        if (rest.len == 0) return null;
-        if (rest[0].stepKind() != .tag_payload_index) return null;
-        const payloads = self.builder.program.types.span(tag.payloads);
-        if (rest[0].data >= payloads.len) return null;
-        return try self.walkEvidencePath(view, GuardedList.at(payloads, rest[0].data), rest[1..]);
     }
 
     fn methodTargetCalleeWithMono(


### PR DESCRIPTION
Monotype evidence synthesis restarted tag-payload paths from the beginning of the full path, so a higher-order decoder that widened its propagated error row panicked after checking. This changes evidence traversal to consume every path component with one monotonic cursor and adds a regression that lowers and executes the widened decoder.

Fixes #10165.