### PR TITLE
Use existing signal thunks as identity tokens

### DIFF
--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -527,6 +527,11 @@ pub const io_spec_tests = [_]TestSpec{
         .description = "Cross-module recursive nominal types with pattern matching",
     },
     .{
+        .roc_file = "test/fx/nested_recursive_opaque_bug.roc",
+        .io_spec = "0<hello|1>Div (correct)",
+        .description = "Nested recursive opaque imports preserve tag identity during pattern matching",
+    },
+    .{
         .roc_file = "test/fx/transitive_import_nominal_equality/main.roc",
         .io_spec = "1>True",
         .description = "Regression test: transitive imports preserve nominal method owner environments for equality",

--- a/src/postcheck/lir_lower.zig
+++ b/src/postcheck/lir_lower.zig
@@ -924,7 +924,7 @@ const Lowerer = struct {
             .loop_ => |loop| try self.lowerLoopInto(target, loop, next),
             .break_ => |value| try self.lowerBreak(value),
             .continue_ => |continue_| try self.lowerContinue(continue_.values),
-            .return_ => |ret| try self.lowerReturn(ret.value),
+            .return_ => |value| try self.lowerReturn(value),
             .crash => |msg| try self.result.store.addCFStmt(.{ .crash = .{
                 .msg = try self.result.store.insertString(self.program.stringLiteralText(msg)),
             } }),
@@ -2225,7 +2225,7 @@ const Lowerer = struct {
                 const debug_stmt = try self.result.store.addCFStmt(.{ .debug = .{ .message = temp, .next = next } });
                 break :blk try self.lowerExprInto(temp, expr_id, debug_stmt);
             },
-            .return_ => |ret| try self.lowerReturn(ret.value),
+            .return_ => |value| try self.lowerReturn(value),
             .crash => |msg| try self.result.store.addCFStmt(.{ .crash = .{
                 .msg = try self.result.store.insertString(self.program.stringLiteralText(msg)),
             } }),

--- a/test/fx/nested_recursive_opaque_bug.roc
+++ b/test/fx/nested_recursive_opaque_bug.roc
@@ -4,10 +4,11 @@ app [main!] {
 }
 
 import pf.Stdout
+import pf.Stdin
 import pkg.Outer
 
 main! = || {
-    tree = Outer.div([Outer.text("hello")])
+    tree = Outer.div([Outer.text(Stdin.line!())])
 
     match tree {
         Div(_) => Stdout.line!("Div (correct)")

--- a/test/signals/platform/Node.roc
+++ b/test/signals/platform/Node.roc
@@ -1,24 +1,21 @@
 import HostValue exposing [HostValue]
 
 ## Pure UI descriptor tree produced by `build`. This is the explicit data the
-## host ingests. Identity is NOT threaded in Roc: the tree is immutable and pure,
-## and the host assigns construction-order identity by a deterministic pre-order
-## walk. Only identity-bearing nodes (state binders, `when` sites, `each` sites)
-## advance the per-scope ordinal in that walk; ordinary markup does not.
+## host ingests. Structural UI identity comes from a deterministic pre-order host
+## walk. Signal graph identity comes from boxed initializer/transform thunks that
+## already exist to evaluate signal records, so signal construction does not need
+## a separate token allocation.
 ##
 ## A `Signal` is an expression that references state/source binders by a binder
 ## ref (a path-relative index assigned during the host walk). Declaration of a
 ## binder (via `Ui.state`) mints identity; a use (`map`, sink) does not.
 	Node := [].{
 
-		new_token : {} -> Box(U64)
-		new_token = |_| Box.box(0)
-
-		## Reference to a state/source binder. The token is minted by `Ui.state` and
-	## copied into both the state declaration and all signal/message references to
-	## that declaration. The host maps tokens to construction-order node ids during
-	## the active descriptor walk; the token is not the state identity.
-	BinderRef := [BinderRef(Box(U64))]
+	## Reference to a state/source binder. The boxed initializer thunk is
+	## shared by the state declaration and all signal/message references to that
+	## declaration. The host maps this pointer to the construction-order node id
+	## during the active descriptor walk; the pointer is not the state identity.
+	BinderRef := [BinderRef(Box(({} -> HostValue)))]
 
 	## A reducer message: applies `transform` to the bound source's current value.
 	## The host routes a fired event to the referenced binder and applies the
@@ -31,16 +28,15 @@ import HostValue exposing [HostValue]
 		payload_reducer : HostValue.EventReducerHandle,
 	}
 
-	## Signal expression. `Ref` reads a binder's current value. Other variants
-	## carry a copied token allocated at the typed signal construction site, so the
-	## host can identify shared derived nodes from explicit data. `ConstValue`
-	## carries a boxed value initializer plus output equality. `Map`/`Map2`/
-	## `Combine` are derived nodes carrying boxed typed transforms (confined
-	## erasure) and a boxed `is_eq` thunk for change pruning. `TaskSource` and
-	## `IntervalSource` are host-owned effect sources whose results enter the
-	## same signal graph.
+	## Signal expression. `Ref` reads a binder's current value. Other variants are
+	## identified by their existing boxed initializer or transform thunk, so no
+	## separate identity allocation is required. `ConstValue` carries a boxed value
+	## initializer plus output capability. `Map`/`Map2`/`Combine` are derived nodes
+	## carrying boxed typed transforms (confined erasure) and an output capability
+	## for change pruning. `TaskSource` and `IntervalSource` are host-owned effect
+	## sources whose results enter the same signal graph.
 	TaskSource : {
-		token : Box(U64),
+		token : Box(({} -> HostValue)),
 		name : Str,
 		cap : HostValue.CapabilityHandle,
 		payload_cap : HostValue.CapabilityHandle,
@@ -51,7 +47,7 @@ import HostValue exposing [HostValue]
 	}
 
 	IntervalSource : {
-		token : Box(U64),
+		token : Box(({} -> HostValue)),
 		period_ms : U64,
 		cap : HostValue.CapabilityHandle,
 		initial : Box(({} -> HostValue)),
@@ -60,10 +56,10 @@ import HostValue exposing [HostValue]
 
 	SignalExpr := [
 		Ref(BinderRef),
-		ConstValue(Box(U64), Box(({} -> HostValue)), HostValue.CapabilityHandle),
-		Map(Box(U64), Box(SignalExpr), Box((HostValue -> HostValue)), HostValue.CapabilityHandle),
-		Map2(Box(U64), Box(SignalExpr), Box(SignalExpr), Box((HostValue, HostValue -> HostValue)), HostValue.CapabilityHandle),
-		Combine(Box(U64), List(SignalExpr), Box((List(HostValue) -> HostValue)), HostValue.CapabilityHandle),
+		ConstValue(Box(({} -> HostValue)), Box(({} -> HostValue)), HostValue.CapabilityHandle),
+		Map(Box((HostValue -> HostValue)), Box(SignalExpr), Box((HostValue -> HostValue)), HostValue.CapabilityHandle),
+		Map2(Box((HostValue, HostValue -> HostValue)), Box(SignalExpr), Box(SignalExpr), Box((HostValue, HostValue -> HostValue)), HostValue.CapabilityHandle),
+		Combine(Box((List(HostValue) -> HostValue)), List(SignalExpr), Box((List(HostValue) -> HostValue)), HostValue.CapabilityHandle),
 		TaskSource(TaskSource),
 		IntervalSource(IntervalSource),
 	]
@@ -71,7 +67,7 @@ import HostValue exposing [HostValue]
 	Cmd := [
 		StartTask(
 			{
-				task_token : Box(U64),
+				task_token : Box(({} -> HostValue)),
 				task_name : Str,
 				request_init : Box(({} -> HostValue)),
 				request_read : HostValue.TaskRequestReadHandle,

--- a/test/signals/platform/Signal.roc
+++ b/test/signals/platform/Signal.roc
@@ -58,8 +58,6 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 				err.is_eq : err, err -> Bool,
 			]
 	task_source = |name, to_done, to_failed, reset_on_start| {
-		token : Box(U64)
-		token = Node.new_token({})
 		status_cap =
 			Capability.new_with_eq(
 				|left, right|
@@ -85,6 +83,7 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 
 		initial : {} -> HostValue
 		initial = |_| Capability.store(Box.box(loading), status_cap)
+		initial_box = Box.box(initial)
 
 		done : HostValue -> HostValue
 		done = |payload_hv| {
@@ -106,11 +105,11 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 
 		{
 				source: {
-					token,
+					token: initial_box,
 					name,
 					cap: Capability.handle(status_cap),
 					payload_cap: Capability.handle(payload_cap),
-					initial: Box.box(initial),
+					initial: initial_box,
 				done: Box.box(done),
 				failed: Box.box(failed),
 				reset_on_start,
@@ -147,12 +146,11 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 					a.is_eq : a, a -> Bool,
 				]
 			source_from_tick = |initial_value, next| {
-				token : Box(U64)
-				token = Node.new_token({})
 				cap = Capability.new({})
 
 			initial : {} -> HostValue
 			initial = |_| Capability.store(Box.box(initial_value), cap)
+			initial_box = Box.box(initial)
 
 			tick : HostValue -> HostValue
 			tick = |current_hv| {
@@ -165,10 +163,10 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 				expr: Box.box(
 					Node.SignalExpr.IntervalSource(
 						{
-							token,
+							token: initial_box,
 							period_ms,
 							cap: Capability.handle(cap),
-							initial: Box.box(initial),
+							initial: initial_box,
 							tick: Box.box(tick),
 						},
 					),
@@ -186,16 +184,15 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 			a.is_eq : a, a -> Bool,
 		]
 	const = |value| {
-		token : Box(U64)
-		token = Node.new_token({})
 		cap = Capability.new({})
 		init : {} -> HostValue
 		init = |_| Capability.store(Box.box(value), cap)
+		init_box = Box.box(init)
 		{
 			expr: Box.box(
 				Node.SignalExpr.ConstValue(
-					token,
-					Box.box(init),
+					init_box,
+					init_box,
 					Capability.handle(cap),
 				),
 			),
@@ -212,8 +209,6 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 				b.is_eq : b, b -> Bool,
 			]
 	map = |signal, f| {
-		token : Box(U64)
-		token = Node.new_token({})
 		output_cap = Capability.new({})
 		wrapped : HostValue -> HostValue
 		wrapped = |input_hv| {
@@ -223,13 +218,14 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 			typed_output = f(typed_input)
 			Capability.store(Box.box(typed_output), output_cap)
 		}
+		transform_box = Box.box(wrapped)
 
 		{
 			expr: Box.box(
 				Node.SignalExpr.Map(
-					token,
+					transform_box,
 					signal.expr,
-					Box.box(wrapped),
+					transform_box,
 					Capability.handle(output_cap),
 				),
 			),
@@ -243,8 +239,6 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 				c.is_eq : c, c -> Bool,
 			]
 	map2 = |left, right, f| {
-		token : Box(U64)
-		token = Node.new_token({})
 		output_cap = Capability.new({})
 		wrapped : HostValue, HostValue -> HostValue
 		wrapped = |left_hv, right_hv| {
@@ -256,14 +250,15 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 			output = f(left_v, right_v)
 			Capability.store(Box.box(output), output_cap)
 		}
+		transform_box = Box.box(wrapped)
 
 		{
 			expr: Box.box(
 				Node.SignalExpr.Map2(
-					token,
+					transform_box,
 					left.expr,
 					right.expr,
-					Box.box(wrapped),
+					transform_box,
 					Capability.handle(output_cap),
 				),
 			),
@@ -278,8 +273,6 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 				a.is_eq : a, a -> Bool,
 			]
 	combine = |signals| {
-		token : Box(U64)
-		token = Node.new_token({})
 		input_cap =
 			match List.first(signals) {
 				Ok(first) => first.cap
@@ -293,12 +286,13 @@ Signal(a) := { expr : Box(Node.SignalExpr), cap : Capability(a) }.{
 			values = List.map(items, |host_value| Box.unbox(Capability.get(host_value, input_cap)))
 			Capability.store(Box.box(values), output_cap)
 		}
+		transform_box = Box.box(transform)
 		{
 			expr: Box.box(
 				Node.SignalExpr.Combine(
-					token,
+					transform_box,
 					exprs,
-					Box.box(transform),
+					transform_box,
 					Capability.handle(output_cap),
 				),
 			),

--- a/test/signals/platform/Ui.roc
+++ b/test/signals/platform/Ui.roc
@@ -187,15 +187,14 @@ Ui := [].{
 			cap = Capability.new({})
 				initial : {} -> HostValue
 				initial = |_| Capability.store(Box.box(init), cap)
-				token : Box(U64)
-				token = Node.new_token({})
+				initial_box = Box.box(initial)
 			handle : State(a)
-			handle = { ref: Node.BinderRef.BinderRef(token), cap }
+			handle = { ref: Node.BinderRef.BinderRef(initial_box), cap }
 		child = body(handle)
 		Elem.State(
 			{
 				binder: handle.ref,
-				initial: Box.box(initial),
+				initial: initial_box,
 				cap: Capability.handle(cap),
 				child: Box.box(child),
 			},
@@ -280,14 +279,13 @@ Ui := [].{
 			key = Box.unbox(Capability.get(key_hv, key_cap))
 			row_item : {} -> HostValue
 			row_item = |_| HostValue.clone(item_hv)
-			row_signal_token : Box(U64)
-			row_signal_token = Node.new_token({})
+			row_item_box = Box.box(row_item)
 			row(
 				key,
 				Signal.from_expr(
 					Node.SignalExpr.ConstValue(
-						row_signal_token,
-						Box.box(row_item),
+						row_item_box,
+						row_item_box,
 						Capability.handle(item_cap),
 					),
 					item_cap,

--- a/test/signals/src/native_host.zig
+++ b/test/signals/src/native_host.zig
@@ -110,7 +110,6 @@ const HostSignalCacheSlot = engine.HostSignalCacheSlot;
 
 const HostNodeScopeSiteKind = engine.HostNodeScopeSiteKind;
 const HostBinderToken = engine.HostBinderToken;
-const HostSignalToken = engine.HostSignalToken;
 const HostBinderBinding = engine.HostBinderBinding;
 
 const HostSignalRecordPayload = engine.HostSignalRecordPayload;

--- a/test/signals/src/native_host.zig
+++ b/test/signals/src/native_host.zig
@@ -1373,7 +1373,7 @@ fn resolvePendingTask(host: *HostEnv, roc_host: *abi.RocHost, name: []const u8, 
         .task_source => |payload| payload,
         .ref, .const_value, .map, .map2, .combine, .interval_source => unreachable,
     };
-    if (task_payload.token != pending.task_token) {
+    if (record.token().? != pending.task_token) {
         failHost("fake task result matched a pending request for a different task source");
     }
 
@@ -2968,7 +2968,7 @@ fn testCapabilityCloneOnDrop(capture_ptr: ?[*]u8, roc_host: *abi.RocHost) callco
 fn testBinderCaptureOnDrop(capture_ptr: ?[*]u8, roc_host: *abi.RocHost) callconv(.c) void {
     test_erased_callable_drop_count += 1;
     const capture = testCapturePtrAs(TestErasedBinderCapture, capture_ptr);
-    hv.releaseU64Box(capture.condition_binder, roc_host);
+    abi.decrefErasedCallable(capture.condition_binder, roc_host);
     hv.releaseHostValueCapability(capture.condition_cap, roc_host);
 }
 
@@ -3048,17 +3048,17 @@ fn makeTestConsumingTaskSourceRecord(host: *HostEnv, roc_host: *abi.RocHost, nam
     const allocator = host.hostAllocator();
     const payload_cap = testHostValueCapability(roc_host);
     const capture = TestTaskPayloadCapture{ .payload_cap = payload_cap };
+    const initial = writeTestErasedCallable(
+        TestErasedI64Capture,
+        roc_host,
+        &testStableStrHostValueCallable,
+        null,
+        .{ .amount = 0 },
+    );
     return HostSignalRecord.init(allocator, .{ .task_source = .{
-        .token = newTestSignalToken(roc_host),
         .name = allocator.dupe(u8, name) catch @panic("out of memory"),
         .payload_cap = payload_cap,
-        .initial = writeTestErasedCallable(
-            TestErasedI64Capture,
-            roc_host,
-            &testStableStrHostValueCallable,
-            null,
-            .{ .amount = 0 },
-        ),
+        .initial = initial,
         .done = writeTestErasedCallable(
             TestTaskPayloadCapture,
             roc_host,
@@ -3187,19 +3187,13 @@ test "signals host task result callbacks consume heap string payloads" {
     }
 
     const success_payload = "successful task payload that is intentionally longer than the Roc small string limit";
-    _ = host.engine.appendPendingTask(&host, 0, switch (record.payload) {
-        .task_source => |payload| payload.token,
-        else => unreachable,
-    }, "lookup", "/api/test");
+    _ = host.engine.appendPendingTask(&host, 0, record.token().?, "lookup", "/api/test");
     _ = resolvePendingTask(&host, &roc_host, "lookup", success_payload, false);
     try expectCachedTaskSourceText(&roc_host, record, success_payload);
     try std.testing.expectEqual(@as(usize, 0), host.engine.pending_tasks.items.len);
 
     const failed_payload = "failed task payload that is intentionally longer than the Roc small string limit";
-    _ = host.engine.appendPendingTask(&host, 0, switch (record.payload) {
-        .task_source => |payload| payload.token,
-        else => unreachable,
-    }, "lookup", "/api/test");
+    _ = host.engine.appendPendingTask(&host, 0, record.token().?, "lookup", "/api/test");
     _ = resolvePendingTask(&host, &roc_host, "lookup", failed_payload, true);
     try expectCachedTaskSourceText(&roc_host, record, failed_payload);
     try std.testing.expectEqual(@as(usize, 0), host.engine.pending_tasks.items.len);
@@ -4362,28 +4356,22 @@ fn boxTestNodeSignalExpr(roc_host: *abi.RocHost, expr: abi.NodeSignalExpr) *abi.
 }
 
 fn newTestBinderToken(roc_host: *abi.RocHost) HostBinderToken {
-    const token: *u64 = @ptrCast(@alignCast(abi.allocateBox(@sizeOf(u64), @alignOf(u64), false, roc_host)));
-    token.* = 0;
-    return token;
+    return testHostValueInitialThunk(roc_host, testHostValueI64(0)) orelse @panic("test binder initializer was null");
 }
 
 fn cloneTestBinderToken(token: HostBinderToken) HostBinderToken {
-    abi.increfBox(@ptrCast(token), 1);
-    return token;
-}
-
-fn newTestSignalToken(roc_host: *abi.RocHost) HostSignalToken {
-    const token: *u64 = @ptrCast(@alignCast(abi.allocateBox(@sizeOf(u64), @alignOf(u64), false, roc_host)));
-    token.* = 0;
+    abi.increfErasedCallable(token, 1);
     return token;
 }
 
 fn testNodeConstExpr(roc_host: *abi.RocHost, value: HostValue) abi.NodeSignalExpr {
     const cap = testHostValueCapability(roc_host);
+    const init = testHostValueInitialThunk(roc_host, value);
+    abi.increfErasedCallable(init, 1);
     return .{
         .payload = .{ .const_value = .{
-            ._0 = newTestSignalToken(roc_host),
-            ._1 = testHostValueInitialThunk(roc_host, value),
+            ._0 = init,
+            ._1 = init,
             ._2 = cap,
         } },
         .tag = .ConstValue,
@@ -4436,10 +4424,11 @@ fn testNodeMapExpr(roc_host: *abi.RocHost, input: abi.NodeSignalExpr) abi.NodeSi
         .{ .amount = 1 },
     );
     const cap = testHostValueCapability(roc_host);
+    abi.increfErasedCallable(transform, 1);
     return .{
         .payload = .{
             .map = .{
-                ._0 = newTestSignalToken(roc_host),
+                ._0 = transform,
                 ._1 = boxTestNodeSignalExpr(roc_host, input),
                 ._2 = transform,
                 ._3 = cap,
@@ -4458,10 +4447,11 @@ fn testNodeStableStrMapExpr(roc_host: *abi.RocHost, input: abi.NodeSignalExpr) a
         .{ .amount = 0 },
     );
     const cap = testHostValueCapability(roc_host);
+    abi.increfErasedCallable(transform, 1);
     return .{
         .payload = .{
             .map = .{
-                ._0 = newTestSignalToken(roc_host),
+                ._0 = transform,
                 ._1 = boxTestNodeSignalExpr(roc_host, input),
                 ._2 = transform,
                 ._3 = cap,
@@ -4480,10 +4470,11 @@ fn testNodeStableI64MapExpr(roc_host: *abi.RocHost, input: abi.NodeSignalExpr, v
         .{ .amount = value },
     );
     const cap = testHostValueCapability(roc_host);
+    abi.increfErasedCallable(transform, 1);
     return .{
         .payload = .{
             .map = .{
-                ._0 = newTestSignalToken(roc_host),
+                ._0 = transform,
                 ._1 = boxTestNodeSignalExpr(roc_host, input),
                 ._2 = transform,
                 ._3 = cap,
@@ -4502,10 +4493,11 @@ fn testNodeStableBoolMapExpr(roc_host: *abi.RocHost, input: abi.NodeSignalExpr) 
         .{ .amount = 0 },
     );
     const cap = testHostValueCapability(roc_host);
+    abi.increfErasedCallable(transform, 1);
     return .{
         .payload = .{
             .map = .{
-                ._0 = newTestSignalToken(roc_host),
+                ._0 = transform,
                 ._1 = boxTestNodeSignalExpr(roc_host, input),
                 ._2 = transform,
                 ._3 = cap,
@@ -4524,10 +4516,11 @@ fn testNodeBoolIdentityMapExpr(roc_host: *abi.RocHost, input: abi.NodeSignalExpr
         .{ .amount = 0 },
     );
     const cap = testHostValueCapability(roc_host);
+    abi.increfErasedCallable(transform, 1);
     return .{
         .payload = .{
             .map = .{
-                ._0 = newTestSignalToken(roc_host),
+                ._0 = transform,
                 ._1 = boxTestNodeSignalExpr(roc_host, input),
                 ._2 = transform,
                 ._3 = cap,
@@ -4546,10 +4539,11 @@ fn testNodeCombineExpr(roc_host: *abi.RocHost, children: []const abi.NodeSignalE
         .{ .amount = 0 },
     );
     const cap = testHostValueCapabilityWithEq(roc_host, &testAlwaysEqualHostValueCallable);
+    abi.increfErasedCallable(transform, 1);
     return .{
         .payload = .{
             .combine = .{
-                ._0 = newTestSignalToken(roc_host),
+                ._0 = transform,
                 ._1 = abi.RocList(abi.NodeSignalExpr).fromSlice(children, roc_host),
                 ._2 = transform,
                 ._3 = cap,
@@ -5348,7 +5342,7 @@ test "signals host preserves explicit signal tokens across cloned descriptors" {
     try std.testing.expect(first == second);
     try std.testing.expectEqual(@as(std.meta.Tag(HostSignalRecordPayload), .map), std.meta.activeTag(first.payload));
     try std.testing.expectEqual(@as(std.meta.Tag(HostSignalRecordPayload), .map), std.meta.activeTag(second.payload));
-    try std.testing.expect(first.payload.map.token == second.payload.map.token);
+    try std.testing.expect(first.token().? == second.token().?);
 }
 
 test "signals host retains state equality outside descriptor stream" {

--- a/test/signals/src/signals/active_signal_graph.zig
+++ b/test/signals/src/signals/active_signal_graph.zig
@@ -586,7 +586,7 @@ pub fn retainRecord(
     switch (record.payload) {
         .ref => |source_node_id| appendSourceRoute(allocator, source_routes, source_node_count, source_node_id, record_id),
         .const_value, .task_source => {},
-        .interval_source => |payload| hooks.ensureInterval(payload.token, payload.period_ms),
+        .interval_source => |payload| hooks.ensureInterval(record.token().?, payload.period_ms),
         .map => |payload| appendDependentId(Record, allocator, nodes.items, requireRecordId(Record, nodes.items, payload.input), record_id),
         .map2 => |payload| {
             appendDependentId(Record, allocator, nodes.items, requireRecordId(Record, nodes.items, payload.left), record_id);
@@ -629,7 +629,7 @@ pub fn releaseRecord(
     switch (record.payload) {
         .ref => |source_node_id| removeSourceRoute(source_routes, source_node_id, record_id),
         .const_value, .task_source => {},
-        .interval_source => |payload| hooks.removeInterval(payload.token),
+        .interval_source => hooks.removeInterval(record.token().?),
         .map, .map2, .combine => {},
     }
 
@@ -887,7 +887,6 @@ const LifecycleTestRecord = struct {
     };
 
     const IntervalPayload = struct {
-        token: u64,
         period_ms: u64,
     };
 
@@ -904,6 +903,13 @@ const LifecycleTestRecord = struct {
     pub fn retain(self: *LifecycleTestRecord) *LifecycleTestRecord {
         self.ref_count += 1;
         return self;
+    }
+
+    pub fn token(self: *const LifecycleTestRecord) ?u64 {
+        return switch (self.payload) {
+            .ref => null,
+            .const_value, .map, .map2, .combine, .task_source, .interval_source => self.id,
+        };
     }
 };
 
@@ -1202,7 +1208,7 @@ test "active graph retain and release update moved record ids and routes" {
 }
 
 test "active graph interval records use explicit lifecycle hooks" {
-    var interval = LifecycleTestRecord{ .id = 0, .payload = .{ .interval_source = .{ .token = 7, .period_ms = 250 } } };
+    var interval = LifecycleTestRecord{ .id = 7, .payload = .{ .interval_source = .{ .period_ms = 250 } } };
 
     var nodes: std.ArrayListUnmanaged(Node(LifecycleTestRecord)) = .empty;
     defer nodes.deinit(std.testing.allocator);

--- a/test/signals/src/signals/descriptor_stream.zig
+++ b/test/signals/src/signals/descriptor_stream.zig
@@ -78,8 +78,8 @@ pub const CleanupDesc = struct {
     name: []const u8,
 };
 
-/// Identity token interned per `Ui.state` binder.
-pub const BinderToken = *u64;
+/// Boxed state initializer shared by `Ui.state` and its references.
+pub const BinderToken = retained.HostSignalToken;
 
 /// Binds a state binder token to the node id it resolves to within a scope.
 pub const BinderBinding = struct {

--- a/test/signals/src/signals/effects_runtime.zig
+++ b/test/signals/src/signals/effects_runtime.zig
@@ -51,8 +51,8 @@ pub fn deinitCleanupEvents(allocator: std.mem.Allocator, events: *CleanupEvents)
 pub fn activeTaskRecordByToken(active_signal_graph: anytype, token: HostSignalToken) ?*HostSignalRecord {
     for (active_signal_graph) |node| {
         switch (node.record.payload) {
-            .task_source => |payload| {
-                if (payload.token == token) return node.record;
+            .task_source => {
+                if (node.record.token().? == token) return node.record;
             },
             .ref, .const_value, .map, .map2, .combine, .interval_source => {},
         }
@@ -92,8 +92,8 @@ pub fn activeIntervalRecordByToken(active_signal_graph: anytype, source_token: H
     var found: ?*HostSignalRecord = null;
     for (active_signal_graph) |node| {
         switch (node.record.payload) {
-            .interval_source => |payload| {
-                if (payload.token != source_token) continue;
+            .interval_source => {
+                if (node.record.token().? != source_token) continue;
                 if (found != null) @panic("interval token matched more than one active interval source");
                 found = node.record;
             },
@@ -408,7 +408,7 @@ pub fn syncActiveIntervalsFromGraph(
         switch (node.record.payload) {
             .interval_source => |payload| {
                 const host = roc_host orelse @panic("active interval cannot retain token without a Roc host");
-                ensureActiveInterval(Ctx, ctx, allocator, intervals, next_interval_token, host, payload.token, payload.period_ms);
+                ensureActiveInterval(Ctx, ctx, allocator, intervals, next_interval_token, host, node.record.token().?, payload.period_ms);
             },
             .ref, .const_value, .map, .map2, .combine, .task_source => {},
         }
@@ -459,10 +459,9 @@ fn testTaskRecord(token: HostSignalToken, name: []const u8) HostSignalRecord {
     return .{
         .ref_count = 1,
         .payload = .{ .task_source = .{
-            .token = token,
             .name = name,
             .payload_cap = undefined,
-            .initial = undefined,
+            .initial = token,
             .done = undefined,
             .failed = undefined,
             .cap = undefined,
@@ -475,9 +474,8 @@ fn testIntervalRecord(token: HostSignalToken, period_ms: u64) HostSignalRecord {
     return .{
         .ref_count = 1,
         .payload = .{ .interval_source = .{
-            .token = token,
             .period_ms = period_ms,
-            .initial = undefined,
+            .initial = token,
             .tick = undefined,
             .cap = undefined,
         } },
@@ -485,15 +483,17 @@ fn testIntervalRecord(token: HostSignalToken, period_ms: u64) HostSignalRecord {
 }
 
 test "effects runtime finds and removes pending tasks" {
-    var first_token: u64 = 0;
-    var second_token: u64 = 0;
+    var first_token_storage = [_]u8{0};
+    var second_token_storage = [_]u8{0};
+    const first_token = first_token_storage[0..].ptr;
+    const second_token = second_token_storage[0..].ptr;
     var tasks: std.ArrayListUnmanaged(PendingTask) = .empty;
     defer tasks.deinit(std.testing.allocator);
 
     tasks.append(std.testing.allocator, .{
         .request_id = 1,
         .owner_scope_id = 10,
-        .task_token = &first_token,
+        .task_token = first_token,
         .task_name = "load",
         .request = "a",
         .active = true,
@@ -501,7 +501,7 @@ test "effects runtime finds and removes pending tasks" {
     tasks.append(std.testing.allocator, .{
         .request_id = 2,
         .owner_scope_id = 11,
-        .task_token = &second_token,
+        .task_token = second_token,
         .task_name = "save",
         .request = "b",
         .active = true,
@@ -515,12 +515,15 @@ test "effects runtime finds and removes pending tasks" {
 }
 
 test "effects runtime finds active effect source records" {
-    var task_token: u64 = 0;
-    var first_interval_token: u64 = 0;
-    var second_interval_token: u64 = 0;
-    var task_record = testTaskRecord(&task_token, "load");
-    var first_interval_record = testIntervalRecord(&first_interval_token, 250);
-    var second_interval_record = testIntervalRecord(&second_interval_token, 500);
+    var task_token_storage = [_]u8{0};
+    var first_interval_token_storage = [_]u8{0};
+    var second_interval_token_storage = [_]u8{0};
+    const task_token = task_token_storage[0..].ptr;
+    const first_interval_token = first_interval_token_storage[0..].ptr;
+    const second_interval_token = second_interval_token_storage[0..].ptr;
+    var task_record = testTaskRecord(task_token, "load");
+    var first_interval_record = testIntervalRecord(first_interval_token, 250);
+    var second_interval_record = testIntervalRecord(second_interval_token, 500);
     var ref_record = HostSignalRecord{
         .ref_count = 1,
         .payload = .{ .ref = 42 },
@@ -532,10 +535,10 @@ test "effects runtime finds active effect source records" {
         .{ .record = &second_interval_record },
     };
 
-    try std.testing.expectEqual(@as(?*HostSignalRecord, &task_record), activeTaskRecordByToken(active_nodes[0..], &task_token));
+    try std.testing.expectEqual(@as(?*HostSignalRecord, &task_record), activeTaskRecordByToken(active_nodes[0..], task_token));
     try std.testing.expectEqual(@as(?*HostSignalRecord, &task_record), activeTaskRecordByName(active_nodes[0..], "load"));
     try std.testing.expectEqual(@as(u64, 1), activeIntervalRecordCountByPeriod(active_nodes[0..], 250));
-    try std.testing.expectEqual(@as(?*HostSignalRecord, &first_interval_record), activeIntervalRecordByToken(active_nodes[0..], &first_interval_token));
+    try std.testing.expectEqual(@as(?*HostSignalRecord, &first_interval_record), activeIntervalRecordByToken(active_nodes[0..], first_interval_token));
     try std.testing.expectEqual(@as(?*HostSignalRecord, &second_interval_record), activeIntervalRecordByPeriod(active_nodes[0..], 500));
     try std.testing.expectEqual(@as(?*HostSignalRecord, null), activeTaskRecordByName(active_nodes[0..], "missing"));
 }
@@ -554,15 +557,17 @@ test "effects runtime owns cleanup event storage" {
 }
 
 test "effects runtime indexes pending tasks" {
-    var first_token: u64 = 0;
-    var second_token: u64 = 0;
+    var first_token_storage = [_]u8{0};
+    var second_token_storage = [_]u8{0};
+    const first_token = first_token_storage[0..].ptr;
+    const second_token = second_token_storage[0..].ptr;
     var tasks: std.ArrayListUnmanaged(PendingTask) = .empty;
     defer tasks.deinit(std.testing.allocator);
 
     tasks.append(std.testing.allocator, .{
         .request_id = 10,
         .owner_scope_id = 1,
-        .task_token = &first_token,
+        .task_token = first_token,
         .task_name = "load",
         .request = "a",
         .active = true,
@@ -570,7 +575,7 @@ test "effects runtime indexes pending tasks" {
     tasks.append(std.testing.allocator, .{
         .request_id = 11,
         .owner_scope_id = 2,
-        .task_token = &second_token,
+        .task_token = second_token,
         .task_name = "load",
         .request = "b",
         .active = false,
@@ -582,28 +587,30 @@ test "effects runtime indexes pending tasks" {
 }
 
 test "effects runtime updates active interval table" {
-    var first_token: u64 = 0;
-    var second_token: u64 = 0;
+    var first_token_storage = [_]u8{0};
+    var second_token_storage = [_]u8{0};
+    const first_token = first_token_storage[0..].ptr;
+    const second_token = second_token_storage[0..].ptr;
     var intervals: std.ArrayListUnmanaged(ActiveInterval) = .empty;
     defer intervals.deinit(std.testing.allocator);
 
     intervals.append(std.testing.allocator, .{
         .token = 10,
-        .source_token = &first_token,
+        .source_token = first_token,
         .period_ms = 100,
         .active = true,
     }) catch @panic("out of memory");
     intervals.append(std.testing.allocator, .{
         .token = 11,
-        .source_token = &second_token,
+        .source_token = second_token,
         .period_ms = 200,
         .active = true,
     }) catch @panic("out of memory");
 
-    try std.testing.expectEqual(@as(?HostSignalToken, &first_token), activeIntervalSourceTokenByRuntimeToken(intervals.items, 10));
+    try std.testing.expectEqual(@as(?HostSignalToken, first_token), activeIntervalSourceTokenByRuntimeToken(intervals.items, 10));
     markActiveIntervalsInactive(intervals.items);
     try std.testing.expect(!intervals.items[0].active);
-    try std.testing.expectEqual(@as(?*ActiveInterval, &intervals.items[1]), activeIntervalBySourceToken(intervals.items, &second_token));
+    try std.testing.expectEqual(@as(?*ActiveInterval, &intervals.items[1]), activeIntervalBySourceToken(intervals.items, second_token));
     const removed = removeActiveIntervalAt(&intervals, 0);
     try std.testing.expectEqual(@as(u64, 10), removed.token);
     try std.testing.expectEqual(@as(usize, 1), intervals.items.len);
@@ -611,8 +618,9 @@ test "effects runtime updates active interval table" {
 }
 
 test "effects runtime syncs existing active intervals from graph" {
-    var source_token: u64 = 0;
-    var interval_record = testIntervalRecord(&source_token, 250);
+    var source_token_storage = [_]u8{0};
+    const source_token = source_token_storage[0..].ptr;
+    var interval_record = testIntervalRecord(source_token, 250);
     const active_nodes = [_]TestActiveNode{
         .{ .record = &interval_record },
     };
@@ -621,7 +629,7 @@ test "effects runtime syncs existing active intervals from graph" {
     defer intervals.deinit(std.testing.allocator);
     intervals.append(std.testing.allocator, .{
         .token = 10,
-        .source_token = &source_token,
+        .source_token = source_token,
         .period_ms = 250,
         .active = true,
     }) catch @panic("out of memory");

--- a/test/signals/src/signals/engine.zig
+++ b/test/signals/src/signals/engine.zig
@@ -91,7 +91,6 @@ pub const HostEachOps = retained_values.HostEachOps;
 pub const HostSignalToken = retained_values.HostSignalToken;
 pub const HostValueCell = retained_values.HostValueCell;
 pub const retainHostCallable = retained_values.retainHostCallable;
-pub const retainHostSignalToken = retained_values.retainHostSignalToken;
 const retainHostValueCapability = retained_values.retainHostValueCapability;
 const releaseHostValueCapability = retained_values.releaseHostValueCapability;
 const assertHostValueCapabilitiesMatch = retained_values.assertHostValueCapabilitiesMatch;
@@ -1257,18 +1256,17 @@ pub fn Engine(comptime Ctx: type) type {
         pub fn bindNodeSignalExpr(self: *Self, allocator: std.mem.Allocator, stream: *HostNodeDescriptorStream, expr: abi.NodeSignalExpr, binder_stack: []const HostBinderBinding) *HostSignalRecord {
             return switch (expr.tag) {
                 .Ref => blk: {
-                    const node_id = resolveNodeBinderRef(binder_stack, expr.payload_ref());
+                    const node_id = resolveNodeBinderRef(binder_stack, retained_values.hostSignalTokenFromCallable(expr.payload_ref()));
                     break :blk HostSignalRecord.init(allocator, .{ .ref = node_id });
                 },
                 .ConstValue => blk: {
                     const payload = expr.payload_const_value();
-                    const token = payload._0;
+                    const token = retained_values.hostSignalTokenFromCallable(payload._0);
                     if (self.retainExistingSignalRecordForStream(allocator, stream, token, .const_value)) |record| {
                         break :blk record;
                     }
 
                     const record = HostSignalRecord.init(allocator, .{ .const_value = .{
-                        .token = retainHostSignalToken(token),
                         .init = retainHostCallable(payload._1, &self.pending_roc_metrics),
                         .cap = retainHostValueCapability(payload._2, &self.pending_roc_metrics),
                     } });
@@ -1277,14 +1275,13 @@ pub fn Engine(comptime Ctx: type) type {
                 },
                 .Map => blk: {
                     const payload = expr.payload_map();
-                    const token = payload._0;
+                    const token = retained_values.hostSignalTokenFromCallable(payload._0);
                     if (self.retainExistingSignalRecordForStream(allocator, stream, token, .map)) |record| {
                         break :blk record;
                     }
 
                     const input = self.bindNodeSignalExpr(allocator, stream, payload._1.*, binder_stack);
                     const record = HostSignalRecord.init(allocator, .{ .map = .{
-                        .token = retainHostSignalToken(token),
                         .input = input,
                         .transform = retainHostCallable(payload._2, &self.pending_roc_metrics),
                         .cap = retainHostValueCapability(payload._3, &self.pending_roc_metrics),
@@ -1294,7 +1291,7 @@ pub fn Engine(comptime Ctx: type) type {
                 },
                 .Map2 => blk: {
                     const payload = expr.payload_map2();
-                    const token = payload._0;
+                    const token = retained_values.hostSignalTokenFromCallable(payload._0);
                     if (self.retainExistingSignalRecordForStream(allocator, stream, token, .map2)) |record| {
                         break :blk record;
                     }
@@ -1302,7 +1299,6 @@ pub fn Engine(comptime Ctx: type) type {
                     const left = self.bindNodeSignalExpr(allocator, stream, payload._1.*, binder_stack);
                     const right = self.bindNodeSignalExpr(allocator, stream, payload._2.*, binder_stack);
                     const record = HostSignalRecord.init(allocator, .{ .map2 = .{
-                        .token = retainHostSignalToken(token),
                         .left = left,
                         .right = right,
                         .transform = retainHostCallable(payload._3, &self.pending_roc_metrics),
@@ -1313,7 +1309,7 @@ pub fn Engine(comptime Ctx: type) type {
                 },
                 .Combine => blk: {
                     const payload = expr.payload_combine();
-                    const token = payload._0;
+                    const token = retained_values.hostSignalTokenFromCallable(payload._0);
                     if (self.retainExistingSignalRecordForStream(allocator, stream, token, .combine)) |record| {
                         break :blk record;
                     }
@@ -1324,7 +1320,6 @@ pub fn Engine(comptime Ctx: type) type {
                         dest.* = self.bindNodeSignalExpr(allocator, stream, child, binder_stack);
                     }
                     const record = HostSignalRecord.init(allocator, .{ .combine = .{
-                        .token = retainHostSignalToken(token),
                         .children = children,
                         .transform = retainHostCallable(payload._2, &self.pending_roc_metrics),
                         .cap = retainHostValueCapability(payload._3, &self.pending_roc_metrics),
@@ -1334,13 +1329,12 @@ pub fn Engine(comptime Ctx: type) type {
                 },
                 .TaskSource => blk: {
                     const payload = expr.payload_task_source();
-                    const token = payload.token;
+                    const token = retained_values.hostSignalTokenFromCallable(payload.token);
                     if (self.retainExistingSignalRecordForStream(allocator, stream, token, .task_source)) |record| {
                         break :blk record;
                     }
 
                     const record = HostSignalRecord.init(allocator, .{ .task_source = .{
-                        .token = retainHostSignalToken(token),
                         .name = allocator.dupe(u8, payload.name.asSlice()) catch @panic("out of memory"),
                         .payload_cap = retainHostValueCapability(payload.payload_cap, &self.pending_roc_metrics),
                         .initial = retainHostCallable(payload.initial, &self.pending_roc_metrics),
@@ -1354,13 +1348,12 @@ pub fn Engine(comptime Ctx: type) type {
                 },
                 .IntervalSource => blk: {
                     const payload = expr.payload_interval_source();
-                    const token = payload.token;
+                    const token = retained_values.hostSignalTokenFromCallable(payload.token);
                     if (self.retainExistingSignalRecordForStream(allocator, stream, token, .interval_source)) |record| {
                         break :blk record;
                     }
 
                     const record = HostSignalRecord.init(allocator, .{ .interval_source = .{
-                        .token = retainHostSignalToken(token),
                         .period_ms = payload.period_ms,
                         .initial = retainHostCallable(payload.initial, &self.pending_roc_metrics),
                         .tick = retainHostCallable(payload.tick, &self.pending_roc_metrics),
@@ -1705,16 +1698,18 @@ pub fn Engine(comptime Ctx: type) type {
                     const kind = renderEventKindFromAbi(payload.kind);
                     const payload_kind = eventPayloadKindFromAbi(msg.payload_kind);
                     const payload_accessor = eventPayloadAccessorFromAbi(msg.payload_accessor);
-                    const target_node_id = resolveNodeBinderRef(binder_stack, msg.binder);
-                    stream.appendEvent(allocator, roc_host, &self.pending_roc_metrics, elem_id, kind, msg.binder, target_node_id, payload_kind, payload_accessor, msg.payload_reducer);
+                    const binder_token = retained_values.hostSignalTokenFromCallable(msg.binder);
+                    const target_node_id = resolveNodeBinderRef(binder_stack, binder_token);
+                    stream.appendEvent(allocator, roc_host, &self.pending_roc_metrics, elem_id, kind, binder_token, target_node_id, payload_kind, payload_accessor, msg.payload_reducer);
                 },
                 .OnNamedEvent => {
                     const payload = attr.payload_on_named_event();
                     const msg = payload.msg;
                     const payload_kind = eventPayloadKindFromAbi(msg.payload_kind);
                     const payload_accessor = eventPayloadAccessorFromAbi(msg.payload_accessor);
-                    const target_node_id = resolveNodeBinderRef(binder_stack, msg.binder);
-                    stream.appendNamedEvent(allocator, roc_host, &self.pending_roc_metrics, elem_id, payload.name.asSlice(), payload.options, msg.binder, target_node_id, payload_kind, payload_accessor, msg.payload_reducer);
+                    const binder_token = retained_values.hostSignalTokenFromCallable(msg.binder);
+                    const target_node_id = resolveNodeBinderRef(binder_stack, binder_token);
+                    stream.appendNamedEvent(allocator, roc_host, &self.pending_roc_metrics, elem_id, payload.name.asSlice(), payload.options, binder_token, target_node_id, payload_kind, payload_accessor, msg.payload_reducer);
                 },
             }
         }
@@ -1838,7 +1833,7 @@ pub fn Engine(comptime Ctx: type) type {
                     const state = elem.payload_state();
                     stream.appendState(allocator, roc_host, &self.pending_roc_metrics, node_id, state.initial, state.cap);
                     self.ensureStateFromDesc(ctx, roc_host, stream.states.items[stream.states.items.len - 1]);
-                    binder_stack.append(allocator, .{ .token = state.binder, .node_id = node_id }) catch @panic("out of memory");
+                    binder_stack.append(allocator, .{ .token = retained_values.hostSignalTokenFromCallable(state.binder), .node_id = node_id }) catch @panic("out of memory");
                     self.collectActiveElemDescriptors(ctx, roc_host, stream, state.child.*, scope_id, parent_elem_id, ordinal, dom_ordinal, binder_stack, scope_created, dirty_source_node_ids);
                     _ = binder_stack.pop() orelse unreachable;
                 },
@@ -3738,7 +3733,7 @@ pub fn Engine(comptime Ctx: type) type {
             desc.run_on_mount = false;
 
             const cmd = erased_calls.callUnitToStartTaskCmd(roc_host, desc.to_cmd);
-            defer abi.decref__AnonStruct85(cmd, roc_host);
+            defer abi.decref__AnonStruct84(cmd, roc_host);
             return self.startTaskCommand(ctx, roc_host, desc.scope_id, cmd);
         }
 
@@ -4623,7 +4618,8 @@ pub fn Engine(comptime Ctx: type) type {
         }
 
         pub fn startTaskCommand(self: *Self, ctx: Ctx.Handle, roc_host: *abi.RocHost, owner_scope_id: u64, cmd: erased_calls.StartTaskCmd) render.Counts {
-            const record = self.activeTaskRecordByToken(cmd.task_token) orelse @panic("StartTask referenced a task source that is not active");
+            const task_token = retained_values.hostSignalTokenFromCallable(cmd.task_token);
+            const record = self.activeTaskRecordByToken(task_token) orelse @panic("StartTask referenced a task source that is not active");
             const task_payload = switch (record.payload) {
                 .task_source => |payload| payload,
                 .ref, .const_value, .map, .map2, .combine, .interval_source => unreachable,
@@ -4637,8 +4633,8 @@ pub fn Engine(comptime Ctx: type) type {
             const request = callHostValueToStrWithCapability(ctx, roc_host, cmd.request_read.capability, cmd.request_read.read, request_value);
             defer request.decref(roc_host);
 
-            self.cancelPendingTasksByTaskToken(ctx, cmd.task_token);
-            _ = effects_runtime.appendAndStartPendingTask(Ctx, ctx, Ctx.allocator(ctx), &self.pending_tasks, &self.next_task_request_id, self.roc_host.?, owner_scope_id, cmd.task_token, cmd.task_name.asSlice(), request.asSlice());
+            self.cancelPendingTasksByTaskToken(ctx, task_token);
+            _ = effects_runtime.appendAndStartPendingTask(Ctx, ctx, Ctx.allocator(ctx), &self.pending_tasks, &self.next_task_request_id, self.roc_host.?, owner_scope_id, task_token, cmd.task_name.asSlice(), request.asSlice());
 
             if (task_payload.reset_on_start) {
                 const loading = erased_calls.callValueInitThunk(roc_host, task_payload.initial);
@@ -4685,7 +4681,7 @@ pub fn Engine(comptime Ctx: type) type {
             if (!self.updateDirtySignalCache(ctx, roc_host, &desc.cached_value, result.value, cap)) return .{};
 
             const cmd = callHostValueToStartTaskCmdWithCapability(ctx, roc_host, cap, desc.to_cmd, result.value);
-            defer abi.decref__AnonStruct85(cmd, roc_host);
+            defer abi.decref__AnonStruct84(cmd, roc_host);
             return self.startTaskCommand(ctx, roc_host, desc.scope_id, cmd);
         }
 

--- a/test/signals/src/signals/engine.zig
+++ b/test/signals/src/signals/engine.zig
@@ -94,13 +94,9 @@ pub const retainHostCallable = retained_values.retainHostCallable;
 const retainHostValueCapability = retained_values.retainHostValueCapability;
 const releaseHostValueCapability = retained_values.releaseHostValueCapability;
 const assertHostValueCapabilitiesMatch = retained_values.assertHostValueCapabilitiesMatch;
-const retainHostTextRead = retained_values.retainHostTextRead;
 const releaseHostTextRead = retained_values.releaseHostTextRead;
-const retainHostBoolRead = retained_values.retainHostBoolRead;
 const releaseHostBoolRead = retained_values.releaseHostBoolRead;
-const retainHostEventReducer = retained_values.retainHostEventReducer;
 const releaseHostEventReducer = retained_values.releaseHostEventReducer;
-const retainHostEachOps = retained_values.retainHostEachOps;
 const releaseHostEachOps = retained_values.releaseHostEachOps;
 pub const HostSignalCacheSlot = signal_records.CacheSlot;
 pub const HostSignalEvalResult = signal_records.EvalResult;
@@ -128,13 +124,6 @@ fn u64SliceContains(items: []const u64, target: u64) bool {
 pub fn appendUniqueU64(allocator: std.mem.Allocator, values: *std.ArrayListUnmanaged(u64), value: u64) void {
     if (u64SliceContains(values.items, value)) return;
     values.append(allocator, value) catch @panic("out of memory");
-}
-
-fn renderNodeSliceContainsElem(items: []const HostRenderNode, elem_id: u64) bool {
-    for (items) |item| {
-        if (item.elem_id == elem_id) return true;
-    }
-    return false;
 }
 
 pub const HostEachRowScopeStep = scope_runtime.EachRowScopeStep;

--- a/test/signals/src/signals/erased_calls.zig
+++ b/test/signals/src/signals/erased_calls.zig
@@ -10,7 +10,7 @@ const abi = @import("roc_platform_abi.zig");
 
 pub const HostValue = u64;
 pub const HostValueList = abi.RocListWith(HostValue, false);
-pub const StartTaskCmd = abi.__AnonStruct85;
+pub const StartTaskCmd = abi.__AnonStruct84;
 pub const RocBoxPair = extern struct {
     keep: abi.RocBox,
     out: abi.RocBox,

--- a/test/signals/src/signals/host_values.zig
+++ b/test/signals/src/signals/host_values.zig
@@ -61,10 +61,9 @@ pub const ActiveCapabilityStack = struct {
 /// uses it for debug type assertions; the browser host ignores it.
 pub const ValueKind = enum { unit, str, bool, i64, u8_list };
 
-/// Signals represents signal tokens and binder tokens as boxed `U64` payloads
-/// in Roc. On wasm32 their payload alignment is 8 while pointer width is 4, so
-/// releasing them must not use the pointer-aligned `decrefBox` convenience
-/// helper.
+/// Release a boxed `U64` payload whose allocation used 8-byte payload
+/// alignment. On wasm32, releasing one of these through pointer-aligned
+/// `decrefBox` would read the wrong header word.
 pub fn releaseU64Box(box: anytype, roc_host: *abi.RocHost) void {
     abi.decrefBoxWith(@ptrCast(box), @alignOf(u64), false, null, roc_host);
 }

--- a/test/signals/src/signals/mod.zig
+++ b/test/signals/src/signals/mod.zig
@@ -14,6 +14,7 @@ pub const effects_runtime = @import("effects_runtime.zig");
 pub const engine = @import("engine.zig");
 pub const engine_contract = @import("engine_contract.zig");
 pub const engine_metrics = @import("engine_metrics.zig");
+pub const engine_scratch = @import("engine_scratch.zig");
 pub const erased_calls = @import("erased_calls.zig");
 pub const host_value_registry = @import("host_value_registry.zig");
 pub const host_values = @import("host_values.zig");
@@ -36,6 +37,7 @@ test {
     std.testing.refAllDecls(engine);
     std.testing.refAllDecls(engine_contract);
     std.testing.refAllDecls(engine_metrics);
+    std.testing.refAllDecls(engine_scratch);
     std.testing.refAllDecls(host_value_registry);
     std.testing.refAllDecls(identity_table);
     std.testing.refAllDecls(render);

--- a/test/signals/src/signals/retained_values.zig
+++ b/test/signals/src/signals/retained_values.zig
@@ -8,8 +8,8 @@ pub const HostTextRead = abi.HostValueTextReadHandle;
 pub const HostBoolRead = abi.HostValueBoolReadHandle;
 pub const HostEventReducer = abi.HostValueEventReducerHandle;
 pub const HostTaskRequestRead = abi.HostValueTaskRequestReadHandle;
-pub const HostEachOps = abi.__AnonStruct58;
-pub const HostSignalToken = *u64;
+pub const HostEachOps = abi.__AnonStruct57;
+pub const HostSignalToken = [*]u8;
 pub const HostValueList = abi.RocListWith(HostValue, false);
 
 /// A retained Roc value plus the capability that owns its equality/drop
@@ -82,12 +82,16 @@ pub fn retainHostCallable(callable: abi.RocErasedCallable, metrics: anytype) abi
 }
 
 pub fn retainHostSignalToken(token: HostSignalToken) HostSignalToken {
-    abi.increfBox(@ptrCast(token), 1);
+    abi.increfErasedCallable(token, 1);
     return token;
 }
 
 pub fn releaseHostSignalToken(token: HostSignalToken, roc_host: *abi.RocHost) void {
-    hv.releaseU64Box(token, roc_host);
+    abi.decrefErasedCallable(token, roc_host);
+}
+
+pub fn hostSignalTokenFromCallable(callable: abi.RocErasedCallable) HostSignalToken {
+    return callable orelse @panic("signal identity callable was null");
 }
 
 pub fn retainHostValueCapability(capability: HostValueCapability, metrics: anytype) HostValueCapability {

--- a/test/signals/src/signals/roc_platform_abi.zig
+++ b/test/signals/src/signals/roc_platform_abi.zig
@@ -640,10 +640,10 @@ comptime {
 /// Element type for __AnonStruct33
 pub const __AnonStruct33 = if (@sizeOf(usize) == 4) extern struct {
     items: *NodeSignalExpr,
-    ops: __AnonStruct58,
+    ops: __AnonStruct57,
 } else extern struct {
     items: *NodeSignalExpr,
-    ops: __AnonStruct58,
+    ops: __AnonStruct57,
 };
 
 comptime {
@@ -657,157 +657,157 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct53
-pub const __AnonStruct53 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct52
+pub const __AnonStruct52 = if (@sizeOf(usize) == 4) extern struct {
     period_ms: u64,
     cap: HostValueCapabilityHandle,
     initial: RocErasedCallable,
     tick: RocErasedCallable,
-    token: *u64,
+    token: RocErasedCallable,
 } else extern struct {
     period_ms: u64,
     cap: HostValueCapabilityHandle,
     initial: RocErasedCallable,
     tick: RocErasedCallable,
-    token: *u64,
+    token: RocErasedCallable,
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct53) != 56) @compileError("__AnonStruct53 size mismatch");
-        if (@alignOf(__AnonStruct53) != 8) @compileError("__AnonStruct53 alignment mismatch");
+        if (@sizeOf(__AnonStruct52) != 56) @compileError("__AnonStruct52 size mismatch");
+        if (@alignOf(__AnonStruct52) != 8) @compileError("__AnonStruct52 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct53) != 32) @compileError("__AnonStruct53 size mismatch");
-        if (@alignOf(__AnonStruct53) != 8) @compileError("__AnonStruct53 alignment mismatch");
+        if (@sizeOf(__AnonStruct52) != 32) @compileError("__AnonStruct52 size mismatch");
+        if (@alignOf(__AnonStruct52) != 8) @compileError("__AnonStruct52 alignment mismatch");
+    }
+}
+
+/// Element type for __AnonStruct56
+pub const __AnonStruct56 = if (@sizeOf(usize) == 4) extern struct {
+    cap: HostValueCapabilityHandle,
+    done: RocErasedCallable,
+    failed: RocErasedCallable,
+    initial: RocErasedCallable,
+    name: RocStr,
+    payload_cap: HostValueCapabilityHandle,
+    token: RocErasedCallable,
+    reset_on_start: bool,
+} else extern struct {
+    cap: HostValueCapabilityHandle,
+    done: RocErasedCallable,
+    failed: RocErasedCallable,
+    initial: RocErasedCallable,
+    name: RocStr,
+    payload_cap: HostValueCapabilityHandle,
+    token: RocErasedCallable,
+    reset_on_start: bool,
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(__AnonStruct56) != 112) @compileError("__AnonStruct56 size mismatch");
+        if (@alignOf(__AnonStruct56) != 8) @compileError("__AnonStruct56 alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(__AnonStruct56) != 56) @compileError("__AnonStruct56 size mismatch");
+        if (@alignOf(__AnonStruct56) != 4) @compileError("__AnonStruct56 alignment mismatch");
     }
 }
 
 /// Element type for __AnonStruct57
 pub const __AnonStruct57 = if (@sizeOf(usize) == 4) extern struct {
-    cap: HostValueCapabilityHandle,
-    done: RocErasedCallable,
-    failed: RocErasedCallable,
-    initial: RocErasedCallable,
-    name: RocStr,
-    payload_cap: HostValueCapabilityHandle,
-    token: *u64,
-    reset_on_start: bool,
+    item_capability: HostValueCapabilityHandle,
+    items_capability: HostValueCapabilityHandle,
+    items_to_values: RocErasedCallable,
+    key_capability: HostValueCapabilityHandle,
+    key_of: RocErasedCallable,
+    key_text: RocErasedCallable,
+    row: RocErasedCallable,
 } else extern struct {
-    cap: HostValueCapabilityHandle,
-    done: RocErasedCallable,
-    failed: RocErasedCallable,
-    initial: RocErasedCallable,
-    name: RocStr,
-    payload_cap: HostValueCapabilityHandle,
-    token: *u64,
-    reset_on_start: bool,
+    item_capability: HostValueCapabilityHandle,
+    items_capability: HostValueCapabilityHandle,
+    items_to_values: RocErasedCallable,
+    key_capability: HostValueCapabilityHandle,
+    key_of: RocErasedCallable,
+    key_text: RocErasedCallable,
+    row: RocErasedCallable,
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct57) != 112) @compileError("__AnonStruct57 size mismatch");
+        if (@sizeOf(__AnonStruct57) != 104) @compileError("__AnonStruct57 size mismatch");
         if (@alignOf(__AnonStruct57) != 8) @compileError("__AnonStruct57 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct57) != 56) @compileError("__AnonStruct57 size mismatch");
+        if (@sizeOf(__AnonStruct57) != 52) @compileError("__AnonStruct57 size mismatch");
         if (@alignOf(__AnonStruct57) != 4) @compileError("__AnonStruct57 alignment mismatch");
     }
 }
 
-/// Element type for __AnonStruct58
-pub const __AnonStruct58 = if (@sizeOf(usize) == 4) extern struct {
-    item_capability: HostValueCapabilityHandle,
-    items_capability: HostValueCapabilityHandle,
-    items_to_values: RocErasedCallable,
-    key_capability: HostValueCapabilityHandle,
-    key_of: RocErasedCallable,
-    key_text: RocErasedCallable,
-    row: RocErasedCallable,
+/// Element type for __AnonStruct64
+pub const __AnonStruct64 = if (@sizeOf(usize) == 4) extern struct {
+    attrs: RocList(NodeAttr),
+    children: RocList(Elem),
+    tag: RocStr,
 } else extern struct {
-    item_capability: HostValueCapabilityHandle,
-    items_capability: HostValueCapabilityHandle,
-    items_to_values: RocErasedCallable,
-    key_capability: HostValueCapabilityHandle,
-    key_of: RocErasedCallable,
-    key_text: RocErasedCallable,
-    row: RocErasedCallable,
+    attrs: RocList(NodeAttr),
+    children: RocList(Elem),
+    tag: RocStr,
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct58) != 104) @compileError("__AnonStruct58 size mismatch");
-        if (@alignOf(__AnonStruct58) != 8) @compileError("__AnonStruct58 alignment mismatch");
+        if (@sizeOf(__AnonStruct64) != 72) @compileError("__AnonStruct64 size mismatch");
+        if (@alignOf(__AnonStruct64) != 8) @compileError("__AnonStruct64 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct58) != 52) @compileError("__AnonStruct58 size mismatch");
-        if (@alignOf(__AnonStruct58) != 4) @compileError("__AnonStruct58 alignment mismatch");
+        if (@sizeOf(__AnonStruct64) != 36) @compileError("__AnonStruct64 size mismatch");
+        if (@alignOf(__AnonStruct64) != 4) @compileError("__AnonStruct64 alignment mismatch");
     }
 }
 
-/// Element type for __AnonStruct65
-pub const __AnonStruct65 = if (@sizeOf(usize) == 4) extern struct {
-    attrs: RocList(NodeAttr),
-    children: RocList(Elem),
-    tag: RocStr,
+/// Element type for __AnonStruct67
+pub const __AnonStruct67 = if (@sizeOf(usize) == 4) extern struct {
+    kind: u64,
+    msg: __AnonStruct68,
 } else extern struct {
-    attrs: RocList(NodeAttr),
-    children: RocList(Elem),
-    tag: RocStr,
+    kind: u64,
+    msg: __AnonStruct68,
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct65) != 72) @compileError("__AnonStruct65 size mismatch");
-        if (@alignOf(__AnonStruct65) != 8) @compileError("__AnonStruct65 alignment mismatch");
+        if (@sizeOf(__AnonStruct67) != 64) @compileError("__AnonStruct67 size mismatch");
+        if (@alignOf(__AnonStruct67) != 8) @compileError("__AnonStruct67 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct65) != 36) @compileError("__AnonStruct65 size mismatch");
-        if (@alignOf(__AnonStruct65) != 4) @compileError("__AnonStruct65 alignment mismatch");
+        if (@sizeOf(__AnonStruct67) != 48) @compileError("__AnonStruct67 size mismatch");
+        if (@alignOf(__AnonStruct67) != 8) @compileError("__AnonStruct67 alignment mismatch");
     }
 }
 
 /// Element type for __AnonStruct68
 pub const __AnonStruct68 = if (@sizeOf(usize) == 4) extern struct {
-    kind: u64,
-    msg: __AnonStruct69,
-} else extern struct {
-    kind: u64,
-    msg: __AnonStruct69,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct68) != 64) @compileError("__AnonStruct68 size mismatch");
-        if (@alignOf(__AnonStruct68) != 8) @compileError("__AnonStruct68 alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct68) != 48) @compileError("__AnonStruct68 size mismatch");
-        if (@alignOf(__AnonStruct68) != 8) @compileError("__AnonStruct68 alignment mismatch");
-    }
-}
-
-/// Element type for __AnonStruct69
-pub const __AnonStruct69 = if (@sizeOf(usize) == 4) extern struct {
     payload_accessor: u64,
     payload_kind: u64,
-    binder: *u64,
+    binder: RocErasedCallable,
     payload_reducer: HostValueEventReducerHandle,
 } else extern struct {
     payload_accessor: u64,
     payload_kind: u64,
-    binder: *u64,
+    binder: RocErasedCallable,
     payload_reducer: HostValueEventReducerHandle,
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct69) != 56) @compileError("__AnonStruct69 size mismatch");
-        if (@alignOf(__AnonStruct69) != 8) @compileError("__AnonStruct69 alignment mismatch");
+        if (@sizeOf(__AnonStruct68) != 56) @compileError("__AnonStruct68 size mismatch");
+        if (@alignOf(__AnonStruct68) != 8) @compileError("__AnonStruct68 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct69) != 40) @compileError("__AnonStruct69 size mismatch");
-        if (@alignOf(__AnonStruct69) != 8) @compileError("__AnonStruct69 alignment mismatch");
+        if (@sizeOf(__AnonStruct68) != 40) @compileError("__AnonStruct68 size mismatch");
+        if (@alignOf(__AnonStruct68) != 8) @compileError("__AnonStruct68 alignment mismatch");
     }
 }
 
@@ -828,30 +828,30 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct71
-pub const __AnonStruct71 = if (@sizeOf(usize) == 4) extern struct {
-    msg: __AnonStruct69,
+/// Element type for __AnonStruct70
+pub const __AnonStruct70 = if (@sizeOf(usize) == 4) extern struct {
+    msg: __AnonStruct68,
     options: u64,
     name: RocStr,
 } else extern struct {
-    msg: __AnonStruct69,
+    msg: __AnonStruct68,
     options: u64,
     name: RocStr,
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct71) != 88) @compileError("__AnonStruct71 size mismatch");
-        if (@alignOf(__AnonStruct71) != 8) @compileError("__AnonStruct71 alignment mismatch");
+        if (@sizeOf(__AnonStruct70) != 88) @compileError("__AnonStruct70 size mismatch");
+        if (@alignOf(__AnonStruct70) != 8) @compileError("__AnonStruct70 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct71) != 64) @compileError("__AnonStruct71 size mismatch");
-        if (@alignOf(__AnonStruct71) != 8) @compileError("__AnonStruct71 alignment mismatch");
+        if (@sizeOf(__AnonStruct70) != 64) @compileError("__AnonStruct70 size mismatch");
+        if (@alignOf(__AnonStruct70) != 8) @compileError("__AnonStruct70 alignment mismatch");
     }
 }
 
-/// Element type for __AnonStruct72
-pub const __AnonStruct72 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct71
+pub const __AnonStruct71 = if (@sizeOf(usize) == 4) extern struct {
     field: u64,
     read: HostValueBoolReadHandle,
     signal: *NodeSignalExpr,
@@ -863,12 +863,12 @@ pub const __AnonStruct72 = if (@sizeOf(usize) == 4) extern struct {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct72) != 48) @compileError("__AnonStruct72 size mismatch");
-        if (@alignOf(__AnonStruct72) != 8) @compileError("__AnonStruct72 alignment mismatch");
+        if (@sizeOf(__AnonStruct71) != 48) @compileError("__AnonStruct71 size mismatch");
+        if (@alignOf(__AnonStruct71) != 8) @compileError("__AnonStruct71 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct72) != 32) @compileError("__AnonStruct72 size mismatch");
-        if (@alignOf(__AnonStruct72) != 8) @compileError("__AnonStruct72 alignment mismatch");
+        if (@sizeOf(__AnonStruct71) != 32) @compileError("__AnonStruct71 size mismatch");
+        if (@alignOf(__AnonStruct71) != 8) @compileError("__AnonStruct71 alignment mismatch");
     }
 }
 
@@ -889,8 +889,8 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct76
-pub const __AnonStruct76 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct75
+pub const __AnonStruct75 = if (@sizeOf(usize) == 4) extern struct {
     field: u64,
     name: RocStr,
     read: HostValueTextReadHandle,
@@ -904,12 +904,12 @@ pub const __AnonStruct76 = if (@sizeOf(usize) == 4) extern struct {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct76) != 72) @compileError("__AnonStruct76 size mismatch");
-        if (@alignOf(__AnonStruct76) != 8) @compileError("__AnonStruct76 alignment mismatch");
+        if (@sizeOf(__AnonStruct75) != 72) @compileError("__AnonStruct75 size mismatch");
+        if (@alignOf(__AnonStruct75) != 8) @compileError("__AnonStruct75 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct76) != 40) @compileError("__AnonStruct76 size mismatch");
-        if (@alignOf(__AnonStruct76) != 8) @compileError("__AnonStruct76 alignment mismatch");
+        if (@sizeOf(__AnonStruct75) != 40) @compileError("__AnonStruct75 size mismatch");
+        if (@alignOf(__AnonStruct75) != 8) @compileError("__AnonStruct75 alignment mismatch");
     }
 }
 
@@ -930,29 +930,29 @@ comptime {
     }
 }
 
+/// Element type for __AnonStruct77
+pub const __AnonStruct77 = if (@sizeOf(usize) == 4) extern struct {
+    field: u64,
+    value: bool,
+} else extern struct {
+    field: u64,
+    value: bool,
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(__AnonStruct77) != 16) @compileError("__AnonStruct77 size mismatch");
+        if (@alignOf(__AnonStruct77) != 8) @compileError("__AnonStruct77 alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(__AnonStruct77) != 16) @compileError("__AnonStruct77 size mismatch");
+        if (@alignOf(__AnonStruct77) != 8) @compileError("__AnonStruct77 alignment mismatch");
+    }
+}
+
 /// Element type for __AnonStruct78
 pub const __AnonStruct78 = if (@sizeOf(usize) == 4) extern struct {
     field: u64,
-    value: bool,
-} else extern struct {
-    field: u64,
-    value: bool,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct78) != 16) @compileError("__AnonStruct78 size mismatch");
-        if (@alignOf(__AnonStruct78) != 8) @compileError("__AnonStruct78 alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct78) != 16) @compileError("__AnonStruct78 size mismatch");
-        if (@alignOf(__AnonStruct78) != 8) @compileError("__AnonStruct78 alignment mismatch");
-    }
-}
-
-/// Element type for __AnonStruct79
-pub const __AnonStruct79 = if (@sizeOf(usize) == 4) extern struct {
-    field: u64,
     name: RocStr,
     value: RocStr,
 } else extern struct {
@@ -963,17 +963,17 @@ pub const __AnonStruct79 = if (@sizeOf(usize) == 4) extern struct {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct79) != 56) @compileError("__AnonStruct79 size mismatch");
-        if (@alignOf(__AnonStruct79) != 8) @compileError("__AnonStruct79 alignment mismatch");
+        if (@sizeOf(__AnonStruct78) != 56) @compileError("__AnonStruct78 size mismatch");
+        if (@alignOf(__AnonStruct78) != 8) @compileError("__AnonStruct78 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct79) != 32) @compileError("__AnonStruct79 size mismatch");
-        if (@alignOf(__AnonStruct79) != 8) @compileError("__AnonStruct79 alignment mismatch");
+        if (@sizeOf(__AnonStruct78) != 32) @compileError("__AnonStruct78 size mismatch");
+        if (@alignOf(__AnonStruct78) != 8) @compileError("__AnonStruct78 alignment mismatch");
     }
 }
 
-/// Element type for __AnonStruct81
-pub const __AnonStruct81 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct80
+pub const __AnonStruct80 = if (@sizeOf(usize) == 4) extern struct {
     signal: *NodeSignalExpr,
     to_cmd: RocErasedCallable,
 } else extern struct {
@@ -983,36 +983,36 @@ pub const __AnonStruct81 = if (@sizeOf(usize) == 4) extern struct {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct81) != 16) @compileError("__AnonStruct81 size mismatch");
-        if (@alignOf(__AnonStruct81) != 8) @compileError("__AnonStruct81 alignment mismatch");
+        if (@sizeOf(__AnonStruct80) != 16) @compileError("__AnonStruct80 size mismatch");
+        if (@alignOf(__AnonStruct80) != 8) @compileError("__AnonStruct80 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct81) != 8) @compileError("__AnonStruct81 size mismatch");
-        if (@alignOf(__AnonStruct81) != 4) @compileError("__AnonStruct81 alignment mismatch");
+        if (@sizeOf(__AnonStruct80) != 8) @compileError("__AnonStruct80 size mismatch");
+        if (@alignOf(__AnonStruct80) != 4) @compileError("__AnonStruct80 alignment mismatch");
     }
 }
 
-/// Element type for __AnonStruct85
-pub const __AnonStruct85 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct84
+pub const __AnonStruct84 = if (@sizeOf(usize) == 4) extern struct {
     request_init: RocErasedCallable,
     request_read: HostValueTaskRequestReadHandle,
     task_name: RocStr,
-    task_token: *u64,
+    task_token: RocErasedCallable,
 } else extern struct {
     request_init: RocErasedCallable,
     request_read: HostValueTaskRequestReadHandle,
     task_name: RocStr,
-    task_token: *u64,
+    task_token: RocErasedCallable,
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct85) != 72) @compileError("__AnonStruct85 size mismatch");
-        if (@alignOf(__AnonStruct85) != 8) @compileError("__AnonStruct85 alignment mismatch");
+        if (@sizeOf(__AnonStruct84) != 72) @compileError("__AnonStruct84 size mismatch");
+        if (@alignOf(__AnonStruct84) != 8) @compileError("__AnonStruct84 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct85) != 36) @compileError("__AnonStruct85 size mismatch");
-        if (@alignOf(__AnonStruct85) != 4) @compileError("__AnonStruct85 alignment mismatch");
+        if (@sizeOf(__AnonStruct84) != 36) @compileError("__AnonStruct84 size mismatch");
+        if (@alignOf(__AnonStruct84) != 4) @compileError("__AnonStruct84 alignment mismatch");
     }
 }
 
@@ -1033,8 +1033,8 @@ comptime {
     }
 }
 
-/// Element type for __AnonStruct87
-pub const __AnonStruct87 = if (@sizeOf(usize) == 4) extern struct {
+/// Element type for __AnonStruct86
+pub const __AnonStruct86 = if (@sizeOf(usize) == 4) extern struct {
     to_cmd: RocErasedCallable,
 } else extern struct {
     to_cmd: RocErasedCallable,
@@ -1042,80 +1042,80 @@ pub const __AnonStruct87 = if (@sizeOf(usize) == 4) extern struct {
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct87) != 8) @compileError("__AnonStruct87 size mismatch");
-        if (@alignOf(__AnonStruct87) != 8) @compileError("__AnonStruct87 alignment mismatch");
+        if (@sizeOf(__AnonStruct86) != 8) @compileError("__AnonStruct86 size mismatch");
+        if (@alignOf(__AnonStruct86) != 8) @compileError("__AnonStruct86 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct87) != 4) @compileError("__AnonStruct87 size mismatch");
-        if (@alignOf(__AnonStruct87) != 4) @compileError("__AnonStruct87 alignment mismatch");
+        if (@sizeOf(__AnonStruct86) != 4) @compileError("__AnonStruct86 size mismatch");
+        if (@alignOf(__AnonStruct86) != 4) @compileError("__AnonStruct86 alignment mismatch");
+    }
+}
+
+/// Element type for __AnonStruct89
+pub const __AnonStruct89 = if (@sizeOf(usize) == 4) extern struct {
+    binder: RocErasedCallable,
+    cap: HostValueCapabilityHandle,
+    child: *Elem,
+    initial: RocErasedCallable,
+} else extern struct {
+    binder: RocErasedCallable,
+    cap: HostValueCapabilityHandle,
+    child: *Elem,
+    initial: RocErasedCallable,
+};
+
+comptime {
+    if (@sizeOf(usize) == 8) {
+        if (@sizeOf(__AnonStruct89) != 48) @compileError("__AnonStruct89 size mismatch");
+        if (@alignOf(__AnonStruct89) != 8) @compileError("__AnonStruct89 alignment mismatch");
+    }
+    if (@sizeOf(usize) == 4) {
+        if (@sizeOf(__AnonStruct89) != 24) @compileError("__AnonStruct89 size mismatch");
+        if (@alignOf(__AnonStruct89) != 4) @compileError("__AnonStruct89 alignment mismatch");
     }
 }
 
 /// Element type for __AnonStruct90
 pub const __AnonStruct90 = if (@sizeOf(usize) == 4) extern struct {
-    binder: *u64,
-    cap: HostValueCapabilityHandle,
-    child: *Elem,
-    initial: RocErasedCallable,
+    read: HostValueTextReadHandle,
+    signal: *NodeSignalExpr,
 } else extern struct {
-    binder: *u64,
-    cap: HostValueCapabilityHandle,
-    child: *Elem,
-    initial: RocErasedCallable,
+    read: HostValueTextReadHandle,
+    signal: *NodeSignalExpr,
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct90) != 48) @compileError("__AnonStruct90 size mismatch");
+        if (@sizeOf(__AnonStruct90) != 40) @compileError("__AnonStruct90 size mismatch");
         if (@alignOf(__AnonStruct90) != 8) @compileError("__AnonStruct90 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct90) != 24) @compileError("__AnonStruct90 size mismatch");
+        if (@sizeOf(__AnonStruct90) != 20) @compileError("__AnonStruct90 size mismatch");
         if (@alignOf(__AnonStruct90) != 4) @compileError("__AnonStruct90 alignment mismatch");
     }
 }
 
 /// Element type for __AnonStruct91
 pub const __AnonStruct91 = if (@sizeOf(usize) == 4) extern struct {
-    read: HostValueTextReadHandle,
-    signal: *NodeSignalExpr,
+    condition: *NodeSignalExpr,
+    read: HostValueBoolReadHandle,
+    when_false: *Elem,
+    when_true: *Elem,
 } else extern struct {
-    read: HostValueTextReadHandle,
-    signal: *NodeSignalExpr,
+    condition: *NodeSignalExpr,
+    read: HostValueBoolReadHandle,
+    when_false: *Elem,
+    when_true: *Elem,
 };
 
 comptime {
     if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct91) != 40) @compileError("__AnonStruct91 size mismatch");
+        if (@sizeOf(__AnonStruct91) != 56) @compileError("__AnonStruct91 size mismatch");
         if (@alignOf(__AnonStruct91) != 8) @compileError("__AnonStruct91 alignment mismatch");
     }
     if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct91) != 20) @compileError("__AnonStruct91 size mismatch");
+        if (@sizeOf(__AnonStruct91) != 28) @compileError("__AnonStruct91 size mismatch");
         if (@alignOf(__AnonStruct91) != 4) @compileError("__AnonStruct91 alignment mismatch");
-    }
-}
-
-/// Element type for __AnonStruct92
-pub const __AnonStruct92 = if (@sizeOf(usize) == 4) extern struct {
-    condition: *NodeSignalExpr,
-    read: HostValueBoolReadHandle,
-    when_false: *Elem,
-    when_true: *Elem,
-} else extern struct {
-    condition: *NodeSignalExpr,
-    read: HostValueBoolReadHandle,
-    when_false: *Elem,
-    when_true: *Elem,
-};
-
-comptime {
-    if (@sizeOf(usize) == 8) {
-        if (@sizeOf(__AnonStruct92) != 56) @compileError("__AnonStruct92 size mismatch");
-        if (@alignOf(__AnonStruct92) != 8) @compileError("__AnonStruct92 alignment mismatch");
-    }
-    if (@sizeOf(usize) == 4) {
-        if (@sizeOf(__AnonStruct92) != 28) @compileError("__AnonStruct92 size mismatch");
-        if (@alignOf(__AnonStruct92) != 4) @compileError("__AnonStruct92 alignment mismatch");
     }
 }
 
@@ -1138,13 +1138,13 @@ pub const ElemPayload = extern union {
     cleanup: __AnonStruct28,
     component: __AnonStruct31,
     each: __AnonStruct33,
-    element: __AnonStruct65,
-    on_change: __AnonStruct81,
-    on_mount: __AnonStruct87,
-    state: __AnonStruct90,
+    element: __AnonStruct64,
+    on_change: __AnonStruct80,
+    on_mount: __AnonStruct86,
+    state: __AnonStruct89,
     text: RocStr,
-    text_signal: __AnonStruct91,
-    when: __AnonStruct92,
+    text_signal: __AnonStruct90,
+    when: __AnonStruct91,
 };
 
 /// Tag union: Elem
@@ -1163,32 +1163,32 @@ pub const Elem = if (@sizeOf(usize) == 4) extern struct {
         const ptr: *const __AnonStruct33 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_element(self: *const @This()) __AnonStruct65 {
-        const ptr: *const __AnonStruct65 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_element(self: *const @This()) __AnonStruct64 {
+        const ptr: *const __AnonStruct64 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_on_change(self: *const @This()) __AnonStruct81 {
-        const ptr: *const __AnonStruct81 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_on_change(self: *const @This()) __AnonStruct80 {
+        const ptr: *const __AnonStruct80 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_on_mount(self: *const @This()) __AnonStruct87 {
-        const ptr: *const __AnonStruct87 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_on_mount(self: *const @This()) __AnonStruct86 {
+        const ptr: *const __AnonStruct86 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_state(self: *const @This()) __AnonStruct90 {
-        const ptr: *const __AnonStruct90 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_state(self: *const @This()) __AnonStruct89 {
+        const ptr: *const __AnonStruct89 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_text(self: *const @This()) RocStr {
         const ptr: *const RocStr = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_text_signal(self: *const @This()) __AnonStruct91 {
-        const ptr: *const __AnonStruct91 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_text_signal(self: *const @This()) __AnonStruct90 {
+        const ptr: *const __AnonStruct90 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_when(self: *const @This()) __AnonStruct92 {
-        const ptr: *const __AnonStruct92 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_when(self: *const @This()) __AnonStruct91 {
+        const ptr: *const __AnonStruct91 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
 } else extern struct {
@@ -1203,25 +1203,25 @@ pub const Elem = if (@sizeOf(usize) == 4) extern struct {
     pub fn payload_each(self: *const @This()) __AnonStruct33 {
         return self.payload.each;
     }
-    pub fn payload_element(self: *const @This()) __AnonStruct65 {
+    pub fn payload_element(self: *const @This()) __AnonStruct64 {
         return self.payload.element;
     }
-    pub fn payload_on_change(self: *const @This()) __AnonStruct81 {
+    pub fn payload_on_change(self: *const @This()) __AnonStruct80 {
         return self.payload.on_change;
     }
-    pub fn payload_on_mount(self: *const @This()) __AnonStruct87 {
+    pub fn payload_on_mount(self: *const @This()) __AnonStruct86 {
         return self.payload.on_mount;
     }
-    pub fn payload_state(self: *const @This()) __AnonStruct90 {
+    pub fn payload_state(self: *const @This()) __AnonStruct89 {
         return self.payload.state;
     }
     pub fn payload_text(self: *const @This()) RocStr {
         return self.payload.text;
     }
-    pub fn payload_text_signal(self: *const @This()) __AnonStruct91 {
+    pub fn payload_text_signal(self: *const @This()) __AnonStruct90 {
         return self.payload.text_signal;
     }
-    pub fn payload_when(self: *const @This()) __AnonStruct92 {
+    pub fn payload_when(self: *const @This()) __AnonStruct91 {
         return self.payload.when;
     }
 };
@@ -1241,7 +1241,7 @@ comptime {
 
 /// Payload struct for Combine variant.
 pub const NodeSignalExprCombinePayload = extern struct {
-    _0: *u64,
+    _0: RocErasedCallable,
     _1: RocList(NodeSignalExpr),
     _2: RocErasedCallable,
     _3: HostValueCapabilityHandle,
@@ -1249,14 +1249,14 @@ pub const NodeSignalExprCombinePayload = extern struct {
 
 /// Payload struct for ConstValue variant.
 pub const NodeSignalExprConstValuePayload = extern struct {
-    _0: *u64,
+    _0: RocErasedCallable,
     _1: RocErasedCallable,
     _2: HostValueCapabilityHandle,
 };
 
 /// Payload struct for Map variant.
 pub const NodeSignalExprMapPayload = extern struct {
-    _0: *u64,
+    _0: RocErasedCallable,
     _1: *NodeSignalExpr,
     _2: RocErasedCallable,
     _3: HostValueCapabilityHandle,
@@ -1264,7 +1264,7 @@ pub const NodeSignalExprMapPayload = extern struct {
 
 /// Payload struct for Map2 variant.
 pub const NodeSignalExprMap2Payload = extern struct {
-    _0: *u64,
+    _0: RocErasedCallable,
     _1: *NodeSignalExpr,
     _2: *NodeSignalExpr,
     _3: RocErasedCallable,
@@ -1286,11 +1286,11 @@ pub const NodeSignalExprTag = enum(u8) {
 pub const NodeSignalExprPayload = extern union {
     combine: NodeSignalExprCombinePayload,
     const_value: NodeSignalExprConstValuePayload,
-    interval_source: __AnonStruct53,
+    interval_source: __AnonStruct52,
     map: NodeSignalExprMapPayload,
     map2: NodeSignalExprMap2Payload,
-    ref: *u64,
-    task_source: __AnonStruct57,
+    ref: RocErasedCallable,
+    task_source: __AnonStruct56,
 };
 
 /// Tag union: Node.SignalExpr
@@ -1305,8 +1305,8 @@ pub const NodeSignalExpr = if (@sizeOf(usize) == 4) extern struct {
         const ptr: *const NodeSignalExprConstValuePayload = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_interval_source(self: *const @This()) __AnonStruct53 {
-        const ptr: *const __AnonStruct53 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_interval_source(self: *const @This()) __AnonStruct52 {
+        const ptr: *const __AnonStruct52 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
     pub fn payload_map(self: *const @This()) NodeSignalExprMapPayload {
@@ -1317,12 +1317,12 @@ pub const NodeSignalExpr = if (@sizeOf(usize) == 4) extern struct {
         const ptr: *const NodeSignalExprMap2Payload = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_ref(self: *const @This()) *u64 {
-        const ptr: *const *u64 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_ref(self: *const @This()) RocErasedCallable {
+        const ptr: *const RocErasedCallable = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_task_source(self: *const @This()) __AnonStruct57 {
-        const ptr: *const __AnonStruct57 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_task_source(self: *const @This()) __AnonStruct56 {
+        const ptr: *const __AnonStruct56 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
 } else extern struct {
@@ -1334,7 +1334,7 @@ pub const NodeSignalExpr = if (@sizeOf(usize) == 4) extern struct {
     pub fn payload_const_value(self: *const @This()) NodeSignalExprConstValuePayload {
         return self.payload.const_value;
     }
-    pub fn payload_interval_source(self: *const @This()) __AnonStruct53 {
+    pub fn payload_interval_source(self: *const @This()) __AnonStruct52 {
         return self.payload.interval_source;
     }
     pub fn payload_map(self: *const @This()) NodeSignalExprMapPayload {
@@ -1343,10 +1343,10 @@ pub const NodeSignalExpr = if (@sizeOf(usize) == 4) extern struct {
     pub fn payload_map2(self: *const @This()) NodeSignalExprMap2Payload {
         return self.payload.map2;
     }
-    pub fn payload_ref(self: *const @This()) *u64 {
+    pub fn payload_ref(self: *const @This()) RocErasedCallable {
         return self.payload.ref;
     }
-    pub fn payload_task_source(self: *const @This()) __AnonStruct57 {
+    pub fn payload_task_source(self: *const @This()) __AnonStruct56 {
         return self.payload.task_source;
     }
 };
@@ -1376,61 +1376,61 @@ pub const NodeAttrTag = enum(u8) {
 
 /// Payload union for Node.Attr.
 pub const NodeAttrPayload = extern union {
-    on_event: __AnonStruct68,
-    on_named_event: __AnonStruct71,
-    signal_bool: __AnonStruct72,
-    signal_text: __AnonStruct76,
-    static_bool: __AnonStruct78,
-    static_text: __AnonStruct79,
+    on_event: __AnonStruct67,
+    on_named_event: __AnonStruct70,
+    signal_bool: __AnonStruct71,
+    signal_text: __AnonStruct75,
+    static_bool: __AnonStruct77,
+    static_text: __AnonStruct78,
 };
 
 /// Tag union: Node.Attr
 pub const NodeAttr = if (@sizeOf(usize) == 4) extern struct {
     payload: [64]u8 align(8),
     tag: NodeAttrTag,
-    pub fn payload_on_event(self: *const @This()) __AnonStruct68 {
-        const ptr: *const __AnonStruct68 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_on_event(self: *const @This()) __AnonStruct67 {
+        const ptr: *const __AnonStruct67 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_on_named_event(self: *const @This()) __AnonStruct71 {
+    pub fn payload_on_named_event(self: *const @This()) __AnonStruct70 {
+        const ptr: *const __AnonStruct70 = @ptrCast(@alignCast(&self.payload));
+        return ptr.*;
+    }
+    pub fn payload_signal_bool(self: *const @This()) __AnonStruct71 {
         const ptr: *const __AnonStruct71 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_signal_bool(self: *const @This()) __AnonStruct72 {
-        const ptr: *const __AnonStruct72 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_signal_text(self: *const @This()) __AnonStruct75 {
+        const ptr: *const __AnonStruct75 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_signal_text(self: *const @This()) __AnonStruct76 {
-        const ptr: *const __AnonStruct76 = @ptrCast(@alignCast(&self.payload));
+    pub fn payload_static_bool(self: *const @This()) __AnonStruct77 {
+        const ptr: *const __AnonStruct77 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
-    pub fn payload_static_bool(self: *const @This()) __AnonStruct78 {
+    pub fn payload_static_text(self: *const @This()) __AnonStruct78 {
         const ptr: *const __AnonStruct78 = @ptrCast(@alignCast(&self.payload));
-        return ptr.*;
-    }
-    pub fn payload_static_text(self: *const @This()) __AnonStruct79 {
-        const ptr: *const __AnonStruct79 = @ptrCast(@alignCast(&self.payload));
         return ptr.*;
     }
 } else extern struct {
     payload: NodeAttrPayload,
     tag: NodeAttrTag,
-    pub fn payload_on_event(self: *const @This()) __AnonStruct68 {
+    pub fn payload_on_event(self: *const @This()) __AnonStruct67 {
         return self.payload.on_event;
     }
-    pub fn payload_on_named_event(self: *const @This()) __AnonStruct71 {
+    pub fn payload_on_named_event(self: *const @This()) __AnonStruct70 {
         return self.payload.on_named_event;
     }
-    pub fn payload_signal_bool(self: *const @This()) __AnonStruct72 {
+    pub fn payload_signal_bool(self: *const @This()) __AnonStruct71 {
         return self.payload.signal_bool;
     }
-    pub fn payload_signal_text(self: *const @This()) __AnonStruct76 {
+    pub fn payload_signal_text(self: *const @This()) __AnonStruct75 {
         return self.payload.signal_text;
     }
-    pub fn payload_static_bool(self: *const @This()) __AnonStruct78 {
+    pub fn payload_static_bool(self: *const @This()) __AnonStruct77 {
         return self.payload.static_bool;
     }
-    pub fn payload_static_text(self: *const @This()) __AnonStruct79 {
+    pub fn payload_static_text(self: *const @This()) __AnonStruct78 {
         return self.payload.static_text;
     }
 };
@@ -1551,25 +1551,25 @@ pub fn decrefElem(value: Elem, roc_host: *RocHost) void {
             decref__AnonStruct33(value.payload_each(), roc_host);
         },
         .Element => {
-            decref__AnonStruct65(value.payload_element(), roc_host);
+            decref__AnonStruct64(value.payload_element(), roc_host);
         },
         .OnChange => {
-            decref__AnonStruct81(value.payload_on_change(), roc_host);
+            decref__AnonStruct80(value.payload_on_change(), roc_host);
         },
         .OnMount => {
-            decref__AnonStruct87(value.payload_on_mount(), roc_host);
+            decref__AnonStruct86(value.payload_on_mount(), roc_host);
         },
         .State => {
-            decref__AnonStruct90(value.payload_state(), roc_host);
+            decref__AnonStruct89(value.payload_state(), roc_host);
         },
         .Text => {
             value.payload_text().decref(roc_host);
         },
         .TextSignal => {
-            decref__AnonStruct91(value.payload_text_signal(), roc_host);
+            decref__AnonStruct90(value.payload_text_signal(), roc_host);
         },
         .When => {
-            decref__AnonStruct92(value.payload_when(), roc_host);
+            decref__AnonStruct91(value.payload_when(), roc_host);
         },
     }
 }
@@ -1587,25 +1587,25 @@ pub fn increfElem(value: Elem, amount: isize) void {
             incref__AnonStruct33(value.payload_each(), amount);
         },
         .Element => {
-            incref__AnonStruct65(value.payload_element(), amount);
+            incref__AnonStruct64(value.payload_element(), amount);
         },
         .OnChange => {
-            incref__AnonStruct81(value.payload_on_change(), amount);
+            incref__AnonStruct80(value.payload_on_change(), amount);
         },
         .OnMount => {
-            incref__AnonStruct87(value.payload_on_mount(), amount);
+            incref__AnonStruct86(value.payload_on_mount(), amount);
         },
         .State => {
-            incref__AnonStruct90(value.payload_state(), amount);
+            incref__AnonStruct89(value.payload_state(), amount);
         },
         .Text => {
             value.payload_text().incref(amount);
         },
         .TextSignal => {
-            incref__AnonStruct91(value.payload_text_signal(), amount);
+            incref__AnonStruct90(value.payload_text_signal(), amount);
         },
         .When => {
-            incref__AnonStruct92(value.payload_when(), amount);
+            incref__AnonStruct91(value.payload_when(), amount);
         },
     }
 }
@@ -1633,13 +1633,13 @@ pub fn incref__AnonStruct31(value: __AnonStruct31, amount: isize) void {
 /// Recursively decrement Roc-owned fields in __AnonStruct33.
 pub fn decref__AnonStruct33(value: __AnonStruct33, roc_host: *RocHost) void {
     decrefBoxWith(@ptrCast(value.items), @alignOf(NodeSignalExpr), true, &decrefBoxPayloadType35, roc_host);
-    decref__AnonStruct58(value.ops, roc_host);
+    decref__AnonStruct57(value.ops, roc_host);
 }
 
 /// Increment Roc-owned fields in __AnonStruct33.
 pub fn incref__AnonStruct33(value: __AnonStruct33, amount: isize) void {
     increfBox(@ptrCast(value.items), amount);
-    incref__AnonStruct58(value.ops, amount);
+    incref__AnonStruct57(value.ops, amount);
 }
 
 /// Recursively decrement Roc-owned payloads in NodeSignalExpr.
@@ -1647,7 +1647,7 @@ pub fn decrefNodeSignalExpr(value: NodeSignalExpr, roc_host: *RocHost) void {
     switch (value.tag) {
         .Combine => {
             const payload = value.payload_combine();
-            decrefBoxWith(@ptrCast(payload._0), @alignOf(u64), false, null, roc_host);
+            decrefErasedCallable(payload._0, roc_host);
             {
                 const list = payload._1;
                 if (list.hasOneRef()) {
@@ -1662,33 +1662,33 @@ pub fn decrefNodeSignalExpr(value: NodeSignalExpr, roc_host: *RocHost) void {
         },
         .ConstValue => {
             const payload = value.payload_const_value();
-            decrefBoxWith(@ptrCast(payload._0), @alignOf(u64), false, null, roc_host);
+            decrefErasedCallable(payload._0, roc_host);
             decrefErasedCallable(payload._1, roc_host);
             decrefHostValueCapabilityHandle(payload._2, roc_host);
         },
         .IntervalSource => {
-            decref__AnonStruct53(value.payload_interval_source(), roc_host);
+            decref__AnonStruct52(value.payload_interval_source(), roc_host);
         },
         .Map => {
             const payload = value.payload_map();
-            decrefBoxWith(@ptrCast(payload._0), @alignOf(u64), false, null, roc_host);
+            decrefErasedCallable(payload._0, roc_host);
             decrefBoxWith(@ptrCast(payload._1), @alignOf(NodeSignalExpr), true, &decrefBoxPayloadType35, roc_host);
             decrefErasedCallable(payload._2, roc_host);
             decrefHostValueCapabilityHandle(payload._3, roc_host);
         },
         .Map2 => {
             const payload = value.payload_map2();
-            decrefBoxWith(@ptrCast(payload._0), @alignOf(u64), false, null, roc_host);
+            decrefErasedCallable(payload._0, roc_host);
             decrefBoxWith(@ptrCast(payload._1), @alignOf(NodeSignalExpr), true, &decrefBoxPayloadType35, roc_host);
             decrefBoxWith(@ptrCast(payload._2), @alignOf(NodeSignalExpr), true, &decrefBoxPayloadType35, roc_host);
             decrefErasedCallable(payload._3, roc_host);
             decrefHostValueCapabilityHandle(payload._4, roc_host);
         },
         .Ref => {
-            decrefBoxWith(@ptrCast(value.payload_ref()), @alignOf(u64), false, null, roc_host);
+            decrefErasedCallable(value.payload_ref(), roc_host);
         },
         .TaskSource => {
-            decref__AnonStruct57(value.payload_task_source(), roc_host);
+            decref__AnonStruct56(value.payload_task_source(), roc_host);
         },
     }
 }
@@ -1698,84 +1698,84 @@ pub fn increfNodeSignalExpr(value: NodeSignalExpr, amount: isize) void {
     switch (value.tag) {
         .Combine => {
             const payload = value.payload_combine();
-            increfBox(@ptrCast(payload._0), amount);
+            increfErasedCallable(payload._0, amount);
             payload._1.incref(amount);
             increfErasedCallable(payload._2, amount);
             increfHostValueCapabilityHandle(payload._3, amount);
         },
         .ConstValue => {
             const payload = value.payload_const_value();
-            increfBox(@ptrCast(payload._0), amount);
+            increfErasedCallable(payload._0, amount);
             increfErasedCallable(payload._1, amount);
             increfHostValueCapabilityHandle(payload._2, amount);
         },
         .IntervalSource => {
-            incref__AnonStruct53(value.payload_interval_source(), amount);
+            incref__AnonStruct52(value.payload_interval_source(), amount);
         },
         .Map => {
             const payload = value.payload_map();
-            increfBox(@ptrCast(payload._0), amount);
+            increfErasedCallable(payload._0, amount);
             increfBox(@ptrCast(payload._1), amount);
             increfErasedCallable(payload._2, amount);
             increfHostValueCapabilityHandle(payload._3, amount);
         },
         .Map2 => {
             const payload = value.payload_map2();
-            increfBox(@ptrCast(payload._0), amount);
+            increfErasedCallable(payload._0, amount);
             increfBox(@ptrCast(payload._1), amount);
             increfBox(@ptrCast(payload._2), amount);
             increfErasedCallable(payload._3, amount);
             increfHostValueCapabilityHandle(payload._4, amount);
         },
         .Ref => {
-            increfBox(@ptrCast(value.payload_ref()), amount);
+            increfErasedCallable(value.payload_ref(), amount);
         },
         .TaskSource => {
-            incref__AnonStruct57(value.payload_task_source(), amount);
+            incref__AnonStruct56(value.payload_task_source(), amount);
         },
     }
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct53.
-pub fn decref__AnonStruct53(value: __AnonStruct53, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct52.
+pub fn decref__AnonStruct52(value: __AnonStruct52, roc_host: *RocHost) void {
     decrefHostValueCapabilityHandle(value.cap, roc_host);
     decrefErasedCallable(value.initial, roc_host);
     decrefErasedCallable(value.tick, roc_host);
-    decrefBoxWith(@ptrCast(value.token), @alignOf(u64), false, null, roc_host);
+    decrefErasedCallable(value.token, roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct53.
-pub fn incref__AnonStruct53(value: __AnonStruct53, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct52.
+pub fn incref__AnonStruct52(value: __AnonStruct52, amount: isize) void {
     increfHostValueCapabilityHandle(value.cap, amount);
     increfErasedCallable(value.initial, amount);
     increfErasedCallable(value.tick, amount);
-    increfBox(@ptrCast(value.token), amount);
+    increfErasedCallable(value.token, amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct57.
-pub fn decref__AnonStruct57(value: __AnonStruct57, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct56.
+pub fn decref__AnonStruct56(value: __AnonStruct56, roc_host: *RocHost) void {
     decrefHostValueCapabilityHandle(value.cap, roc_host);
     decrefErasedCallable(value.done, roc_host);
     decrefErasedCallable(value.failed, roc_host);
     decrefErasedCallable(value.initial, roc_host);
     value.name.decref(roc_host);
     decrefHostValueCapabilityHandle(value.payload_cap, roc_host);
-    decrefBoxWith(@ptrCast(value.token), @alignOf(u64), false, null, roc_host);
+    decrefErasedCallable(value.token, roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct57.
-pub fn incref__AnonStruct57(value: __AnonStruct57, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct56.
+pub fn incref__AnonStruct56(value: __AnonStruct56, amount: isize) void {
     increfHostValueCapabilityHandle(value.cap, amount);
     increfErasedCallable(value.done, amount);
     increfErasedCallable(value.failed, amount);
     increfErasedCallable(value.initial, amount);
     value.name.incref(amount);
     increfHostValueCapabilityHandle(value.payload_cap, amount);
-    increfBox(@ptrCast(value.token), amount);
+    increfErasedCallable(value.token, amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct58.
-pub fn decref__AnonStruct58(value: __AnonStruct58, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct57.
+pub fn decref__AnonStruct57(value: __AnonStruct57, roc_host: *RocHost) void {
     decrefHostValueCapabilityHandle(value.item_capability, roc_host);
     decrefHostValueCapabilityHandle(value.items_capability, roc_host);
     decrefErasedCallable(value.items_to_values, roc_host);
@@ -1785,8 +1785,8 @@ pub fn decref__AnonStruct58(value: __AnonStruct58, roc_host: *RocHost) void {
     decrefErasedCallable(value.row, roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct58.
-pub fn incref__AnonStruct58(value: __AnonStruct58, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct57.
+pub fn incref__AnonStruct57(value: __AnonStruct57, amount: isize) void {
     increfHostValueCapabilityHandle(value.item_capability, amount);
     increfHostValueCapabilityHandle(value.items_capability, amount);
     increfErasedCallable(value.items_to_values, amount);
@@ -1796,8 +1796,8 @@ pub fn incref__AnonStruct58(value: __AnonStruct58, amount: isize) void {
     increfErasedCallable(value.row, amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct65.
-pub fn decref__AnonStruct65(value: __AnonStruct65, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct64.
+pub fn decref__AnonStruct64(value: __AnonStruct64, roc_host: *RocHost) void {
     {
         const list = value.attrs;
         if (list.hasOneRef()) {
@@ -1819,8 +1819,8 @@ pub fn decref__AnonStruct65(value: __AnonStruct65, roc_host: *RocHost) void {
     value.tag.decref(roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct65.
-pub fn incref__AnonStruct65(value: __AnonStruct65, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct64.
+pub fn incref__AnonStruct64(value: __AnonStruct64, amount: isize) void {
     value.attrs.incref(amount);
     value.children.incref(amount);
     value.tag.incref(amount);
@@ -1830,22 +1830,22 @@ pub fn incref__AnonStruct65(value: __AnonStruct65, amount: isize) void {
 pub fn decrefNodeAttr(value: NodeAttr, roc_host: *RocHost) void {
     switch (value.tag) {
         .OnEvent => {
-            decref__AnonStruct68(value.payload_on_event(), roc_host);
+            decref__AnonStruct67(value.payload_on_event(), roc_host);
         },
         .OnNamedEvent => {
-            decref__AnonStruct71(value.payload_on_named_event(), roc_host);
+            decref__AnonStruct70(value.payload_on_named_event(), roc_host);
         },
         .SignalBool => {
-            decref__AnonStruct72(value.payload_signal_bool(), roc_host);
+            decref__AnonStruct71(value.payload_signal_bool(), roc_host);
         },
         .SignalText => {
-            decref__AnonStruct76(value.payload_signal_text(), roc_host);
+            decref__AnonStruct75(value.payload_signal_text(), roc_host);
         },
         .StaticBool => {
-            decref__AnonStruct78(value.payload_static_bool(), roc_host);
+            decref__AnonStruct77(value.payload_static_bool(), roc_host);
         },
         .StaticText => {
-            decref__AnonStruct79(value.payload_static_text(), roc_host);
+            decref__AnonStruct78(value.payload_static_text(), roc_host);
         },
     }
 }
@@ -1854,45 +1854,45 @@ pub fn decrefNodeAttr(value: NodeAttr, roc_host: *RocHost) void {
 pub fn increfNodeAttr(value: NodeAttr, amount: isize) void {
     switch (value.tag) {
         .OnEvent => {
-            incref__AnonStruct68(value.payload_on_event(), amount);
+            incref__AnonStruct67(value.payload_on_event(), amount);
         },
         .OnNamedEvent => {
-            incref__AnonStruct71(value.payload_on_named_event(), amount);
+            incref__AnonStruct70(value.payload_on_named_event(), amount);
         },
         .SignalBool => {
-            incref__AnonStruct72(value.payload_signal_bool(), amount);
+            incref__AnonStruct71(value.payload_signal_bool(), amount);
         },
         .SignalText => {
-            incref__AnonStruct76(value.payload_signal_text(), amount);
+            incref__AnonStruct75(value.payload_signal_text(), amount);
         },
         .StaticBool => {
-            incref__AnonStruct78(value.payload_static_bool(), amount);
+            incref__AnonStruct77(value.payload_static_bool(), amount);
         },
         .StaticText => {
-            incref__AnonStruct79(value.payload_static_text(), amount);
+            incref__AnonStruct78(value.payload_static_text(), amount);
         },
     }
 }
 
+/// Recursively decrement Roc-owned fields in __AnonStruct67.
+pub fn decref__AnonStruct67(value: __AnonStruct67, roc_host: *RocHost) void {
+    decref__AnonStruct68(value.msg, roc_host);
+}
+
+/// Increment Roc-owned fields in __AnonStruct67.
+pub fn incref__AnonStruct67(value: __AnonStruct67, amount: isize) void {
+    incref__AnonStruct68(value.msg, amount);
+}
+
 /// Recursively decrement Roc-owned fields in __AnonStruct68.
 pub fn decref__AnonStruct68(value: __AnonStruct68, roc_host: *RocHost) void {
-    decref__AnonStruct69(value.msg, roc_host);
+    decrefErasedCallable(value.binder, roc_host);
+    decrefHostValueEventReducerHandle(value.payload_reducer, roc_host);
 }
 
 /// Increment Roc-owned fields in __AnonStruct68.
 pub fn incref__AnonStruct68(value: __AnonStruct68, amount: isize) void {
-    incref__AnonStruct69(value.msg, amount);
-}
-
-/// Recursively decrement Roc-owned fields in __AnonStruct69.
-pub fn decref__AnonStruct69(value: __AnonStruct69, roc_host: *RocHost) void {
-    decrefBoxWith(@ptrCast(value.binder), @alignOf(u64), false, null, roc_host);
-    decrefHostValueEventReducerHandle(value.payload_reducer, roc_host);
-}
-
-/// Increment Roc-owned fields in __AnonStruct69.
-pub fn incref__AnonStruct69(value: __AnonStruct69, amount: isize) void {
-    increfBox(@ptrCast(value.binder), amount);
+    increfErasedCallable(value.binder, amount);
     increfHostValueEventReducerHandle(value.payload_reducer, amount);
 }
 
@@ -1908,26 +1908,26 @@ pub fn increfHostValueEventReducerHandle(value: HostValueEventReducerHandle, amo
     increfErasedCallable(value.transform, amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct71.
-pub fn decref__AnonStruct71(value: __AnonStruct71, roc_host: *RocHost) void {
-    decref__AnonStruct69(value.msg, roc_host);
+/// Recursively decrement Roc-owned fields in __AnonStruct70.
+pub fn decref__AnonStruct70(value: __AnonStruct70, roc_host: *RocHost) void {
+    decref__AnonStruct68(value.msg, roc_host);
     value.name.decref(roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct71.
-pub fn incref__AnonStruct71(value: __AnonStruct71, amount: isize) void {
-    incref__AnonStruct69(value.msg, amount);
+/// Increment Roc-owned fields in __AnonStruct70.
+pub fn incref__AnonStruct70(value: __AnonStruct70, amount: isize) void {
+    incref__AnonStruct68(value.msg, amount);
     value.name.incref(amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct72.
-pub fn decref__AnonStruct72(value: __AnonStruct72, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct71.
+pub fn decref__AnonStruct71(value: __AnonStruct71, roc_host: *RocHost) void {
     decrefHostValueBoolReadHandle(value.read, roc_host);
     decrefBoxWith(@ptrCast(value.signal), @alignOf(NodeSignalExpr), true, &decrefBoxPayloadType35, roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct72.
-pub fn incref__AnonStruct72(value: __AnonStruct72, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct71.
+pub fn incref__AnonStruct71(value: __AnonStruct71, amount: isize) void {
     increfHostValueBoolReadHandle(value.read, amount);
     increfBox(@ptrCast(value.signal), amount);
 }
@@ -1944,15 +1944,15 @@ pub fn increfHostValueBoolReadHandle(value: HostValueBoolReadHandle, amount: isi
     increfErasedCallable(value.read, amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct76.
-pub fn decref__AnonStruct76(value: __AnonStruct76, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct75.
+pub fn decref__AnonStruct75(value: __AnonStruct75, roc_host: *RocHost) void {
     value.name.decref(roc_host);
     decrefHostValueTextReadHandle(value.read, roc_host);
     decrefBoxWith(@ptrCast(value.signal), @alignOf(NodeSignalExpr), true, &decrefBoxPayloadType35, roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct76.
-pub fn incref__AnonStruct76(value: __AnonStruct76, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct75.
+pub fn incref__AnonStruct75(value: __AnonStruct75, amount: isize) void {
     value.name.incref(amount);
     increfHostValueTextReadHandle(value.read, amount);
     increfBox(@ptrCast(value.signal), amount);
@@ -1970,56 +1970,56 @@ pub fn increfHostValueTextReadHandle(value: HostValueTextReadHandle, amount: isi
     increfErasedCallable(value.read, amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct78.
-pub fn decref__AnonStruct78(value: __AnonStruct78, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct77.
+pub fn decref__AnonStruct77(value: __AnonStruct77, roc_host: *RocHost) void {
     _ = value;
     _ = roc_host;
 }
 
-/// Increment Roc-owned fields in __AnonStruct78.
-pub fn incref__AnonStruct78(value: __AnonStruct78, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct77.
+pub fn incref__AnonStruct77(value: __AnonStruct77, amount: isize) void {
     _ = value;
     _ = amount;
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct79.
-pub fn decref__AnonStruct79(value: __AnonStruct79, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct78.
+pub fn decref__AnonStruct78(value: __AnonStruct78, roc_host: *RocHost) void {
     value.name.decref(roc_host);
     value.value.decref(roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct79.
-pub fn incref__AnonStruct79(value: __AnonStruct79, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct78.
+pub fn incref__AnonStruct78(value: __AnonStruct78, amount: isize) void {
     value.name.incref(amount);
     value.value.incref(amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct81.
-pub fn decref__AnonStruct81(value: __AnonStruct81, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct80.
+pub fn decref__AnonStruct80(value: __AnonStruct80, roc_host: *RocHost) void {
     decrefBoxWith(@ptrCast(value.signal), @alignOf(NodeSignalExpr), true, &decrefBoxPayloadType35, roc_host);
     decrefErasedCallable(value.to_cmd, roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct81.
-pub fn incref__AnonStruct81(value: __AnonStruct81, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct80.
+pub fn incref__AnonStruct80(value: __AnonStruct80, amount: isize) void {
     increfBox(@ptrCast(value.signal), amount);
     increfErasedCallable(value.to_cmd, amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct85.
-pub fn decref__AnonStruct85(value: __AnonStruct85, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct84.
+pub fn decref__AnonStruct84(value: __AnonStruct84, roc_host: *RocHost) void {
     decrefErasedCallable(value.request_init, roc_host);
     decrefHostValueTaskRequestReadHandle(value.request_read, roc_host);
     value.task_name.decref(roc_host);
-    decrefBoxWith(@ptrCast(value.task_token), @alignOf(u64), false, null, roc_host);
+    decrefErasedCallable(value.task_token, roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct85.
-pub fn incref__AnonStruct85(value: __AnonStruct85, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct84.
+pub fn incref__AnonStruct84(value: __AnonStruct84, amount: isize) void {
     increfErasedCallable(value.request_init, amount);
     increfHostValueTaskRequestReadHandle(value.request_read, amount);
     value.task_name.incref(amount);
-    increfBox(@ptrCast(value.task_token), amount);
+    increfErasedCallable(value.task_token, amount);
 }
 
 /// Recursively decrement Roc-owned fields in HostValueTaskRequestReadHandle.
@@ -2034,54 +2034,54 @@ pub fn increfHostValueTaskRequestReadHandle(value: HostValueTaskRequestReadHandl
     increfErasedCallable(value.read, amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct87.
-pub fn decref__AnonStruct87(value: __AnonStruct87, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct86.
+pub fn decref__AnonStruct86(value: __AnonStruct86, roc_host: *RocHost) void {
     decrefErasedCallable(value.to_cmd, roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct87.
-pub fn incref__AnonStruct87(value: __AnonStruct87, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct86.
+pub fn incref__AnonStruct86(value: __AnonStruct86, amount: isize) void {
     increfErasedCallable(value.to_cmd, amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct90.
-pub fn decref__AnonStruct90(value: __AnonStruct90, roc_host: *RocHost) void {
-    decrefBoxWith(@ptrCast(value.binder), @alignOf(u64), false, null, roc_host);
+/// Recursively decrement Roc-owned fields in __AnonStruct89.
+pub fn decref__AnonStruct89(value: __AnonStruct89, roc_host: *RocHost) void {
+    decrefErasedCallable(value.binder, roc_host);
     decrefHostValueCapabilityHandle(value.cap, roc_host);
     decrefBoxWith(@ptrCast(value.child), @alignOf(Elem), true, &decrefBoxPayloadType27, roc_host);
     decrefErasedCallable(value.initial, roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct90.
-pub fn incref__AnonStruct90(value: __AnonStruct90, amount: isize) void {
-    increfBox(@ptrCast(value.binder), amount);
+/// Increment Roc-owned fields in __AnonStruct89.
+pub fn incref__AnonStruct89(value: __AnonStruct89, amount: isize) void {
+    increfErasedCallable(value.binder, amount);
     increfHostValueCapabilityHandle(value.cap, amount);
     increfBox(@ptrCast(value.child), amount);
     increfErasedCallable(value.initial, amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct91.
-pub fn decref__AnonStruct91(value: __AnonStruct91, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct90.
+pub fn decref__AnonStruct90(value: __AnonStruct90, roc_host: *RocHost) void {
     decrefHostValueTextReadHandle(value.read, roc_host);
     decrefBoxWith(@ptrCast(value.signal), @alignOf(NodeSignalExpr), true, &decrefBoxPayloadType35, roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct91.
-pub fn incref__AnonStruct91(value: __AnonStruct91, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct90.
+pub fn incref__AnonStruct90(value: __AnonStruct90, amount: isize) void {
     increfHostValueTextReadHandle(value.read, amount);
     increfBox(@ptrCast(value.signal), amount);
 }
 
-/// Recursively decrement Roc-owned fields in __AnonStruct92.
-pub fn decref__AnonStruct92(value: __AnonStruct92, roc_host: *RocHost) void {
+/// Recursively decrement Roc-owned fields in __AnonStruct91.
+pub fn decref__AnonStruct91(value: __AnonStruct91, roc_host: *RocHost) void {
     decrefBoxWith(@ptrCast(value.condition), @alignOf(NodeSignalExpr), true, &decrefBoxPayloadType35, roc_host);
     decrefHostValueBoolReadHandle(value.read, roc_host);
     decrefBoxWith(@ptrCast(value.when_false), @alignOf(Elem), true, &decrefBoxPayloadType27, roc_host);
     decrefBoxWith(@ptrCast(value.when_true), @alignOf(Elem), true, &decrefBoxPayloadType27, roc_host);
 }
 
-/// Increment Roc-owned fields in __AnonStruct92.
-pub fn incref__AnonStruct92(value: __AnonStruct92, amount: isize) void {
+/// Increment Roc-owned fields in __AnonStruct91.
+pub fn incref__AnonStruct91(value: __AnonStruct91, amount: isize) void {
     increfBox(@ptrCast(value.condition), amount);
     increfHostValueBoolReadHandle(value.read, amount);
     increfBox(@ptrCast(value.when_false), amount);

--- a/test/signals/src/signals/roc_platform_abi.zig
+++ b/test/signals/src/signals/roc_platform_abi.zig
@@ -1503,14 +1503,12 @@ pub const HostValueTake_with_splitArgs = extern struct {
     arg1: RocErasedCallable,
 };
 
-// =============================================================================
 // Generated Refcount Helpers
 //
 // These helpers recursively retain or release Roc-owned fields using the explicit
 // TypeRepr layout supplied to glue generation. For RocList(T), element release
 // only runs when the list allocation is uniquely owned, immediately before the
 // outer list allocation is decremented and potentially freed.
-// =============================================================================
 
 /// Recursively decrement Roc-owned fields in HostValueCapabilityHandle.
 pub fn decrefHostValueCapabilityHandle(value: HostValueCapabilityHandle, roc_host: *RocHost) void {
@@ -2098,11 +2096,9 @@ fn decrefBoxPayloadType35(data_ptr: ?*anyopaque, roc_host: *RocHost) callconv(.c
     decrefNodeSignalExpr(payload.*, roc_host);
 }
 
-// =============================================================================
 // Runtime Symbols
 //
 // The host defines these linker symbols. Compiled Roc code calls them directly.
-// =============================================================================
 
 pub extern fn roc_alloc(length: usize, alignment: usize) callconv(.c) ?*anyopaque;
 pub extern fn roc_dealloc(ptr: *anyopaque, alignment: usize) callconv(.c) void;
@@ -2111,12 +2107,10 @@ pub extern fn roc_dbg(bytes: [*]const u8, len: usize) callconv(.c) void;
 pub extern fn roc_expect_failed(bytes: [*]const u8, len: usize) callconv(.c) void;
 pub extern fn roc_crashed(bytes: [*]const u8, len: usize) callconv(.c) void;
 
-// =============================================================================
 // Hosted Symbols
 //
 // The platform host must export these symbols with the exact direct C ABI signatures.
 // Refcounted arguments are owned by the hosted function.
-// =============================================================================
 
 /// Hosted symbol for HostValue.clone
 /// Roc signature: HostValue -> HostValue
@@ -2281,11 +2275,9 @@ pub fn makeRocHost(env: *RocEnv) RocHost {
     };
 }
 
-// =============================================================================
 // Provided Symbols
 //
 // Roc exports these symbols from the app with their natural C ABI signatures.
-// =============================================================================
 
 /// Entrypoint: ui_init
 pub extern fn roc_ui_init() callconv(.c) *Elem;

--- a/test/signals/src/signals/signal_records.zig
+++ b/test/signals/src/signals/signal_records.zig
@@ -7,7 +7,6 @@ pub const HostValueCell = retained.HostValueCell;
 pub const HostValueCapability = retained.HostValueCapability;
 pub const HostSignalToken = retained.HostSignalToken;
 
-const releaseHostSignalToken = retained.releaseHostSignalToken;
 const releaseHostValueCapability = retained.releaseHostValueCapability;
 
 fn u64SliceContains(items: []const u64, target: u64) bool {
@@ -57,14 +56,12 @@ pub const EvalResult = struct {
 };
 
 pub const ConstRecord = struct {
-    token: HostSignalToken,
     init: abi.RocErasedCallable,
     cap: HostValueCapability,
     cached_value: CacheSlot = .absent,
 };
 
 pub const MapRecord = struct {
-    token: HostSignalToken,
     input: *Record,
     transform: abi.RocErasedCallable,
     cap: HostValueCapability,
@@ -72,7 +69,6 @@ pub const MapRecord = struct {
 };
 
 pub const Map2Record = struct {
-    token: HostSignalToken,
     left: *Record,
     right: *Record,
     transform: abi.RocErasedCallable,
@@ -81,7 +77,6 @@ pub const Map2Record = struct {
 };
 
 pub const CombineRecord = struct {
-    token: HostSignalToken,
     children: []*Record,
     transform: abi.RocErasedCallable,
     cap: HostValueCapability,
@@ -89,7 +84,6 @@ pub const CombineRecord = struct {
 };
 
 pub const TaskSourceRecord = struct {
-    token: HostSignalToken,
     name: []const u8,
     payload_cap: HostValueCapability,
     initial: abi.RocErasedCallable,
@@ -101,7 +95,6 @@ pub const TaskSourceRecord = struct {
 };
 
 pub const IntervalSourceRecord = struct {
-    token: HostSignalToken,
     period_ms: u64,
     initial: abi.RocErasedCallable,
     tick: abi.RocErasedCallable,
@@ -142,12 +135,12 @@ pub const Record = struct {
     pub fn token(self: *const Record) ?HostSignalToken {
         return switch (self.payload) {
             .ref => null,
-            .const_value => |payload| payload.token,
-            .map => |payload| payload.token,
-            .map2 => |payload| payload.token,
-            .combine => |payload| payload.token,
-            .task_source => |payload| payload.token,
-            .interval_source => |payload| payload.token,
+            .const_value => |payload| retained.hostSignalTokenFromCallable(payload.init),
+            .map => |payload| retained.hostSignalTokenFromCallable(payload.transform),
+            .map2 => |payload| retained.hostSignalTokenFromCallable(payload.transform),
+            .combine => |payload| retained.hostSignalTokenFromCallable(payload.transform),
+            .task_source => |payload| retained.hostSignalTokenFromCallable(payload.initial),
+            .interval_source => |payload| retained.hostSignalTokenFromCallable(payload.initial),
         };
     }
 
@@ -167,7 +160,6 @@ pub const Record = struct {
             .const_value => |payload| {
                 var cached_value = payload.cached_value;
                 cached_value.deinit(ctx, roc_host, metrics);
-                releaseHostSignalToken(payload.token, roc_host);
                 abi.decrefErasedCallable(payload.init, roc_host);
                 releaseHostValueCapability(payload.cap, roc_host, metrics);
                 metrics.bump(.closure_releases, 1);
@@ -176,7 +168,6 @@ pub const Record = struct {
                 payload.input.release(allocator, ctx, roc_host, metrics);
                 var cached_value = payload.cached_value;
                 cached_value.deinit(ctx, roc_host, metrics);
-                releaseHostSignalToken(payload.token, roc_host);
                 abi.decrefErasedCallable(payload.transform, roc_host);
                 releaseHostValueCapability(payload.cap, roc_host, metrics);
                 metrics.bump(.closure_releases, 1);
@@ -186,7 +177,6 @@ pub const Record = struct {
                 payload.right.release(allocator, ctx, roc_host, metrics);
                 var cached_value = payload.cached_value;
                 cached_value.deinit(ctx, roc_host, metrics);
-                releaseHostSignalToken(payload.token, roc_host);
                 abi.decrefErasedCallable(payload.transform, roc_host);
                 releaseHostValueCapability(payload.cap, roc_host, metrics);
                 metrics.bump(.closure_releases, 1);
@@ -198,7 +188,6 @@ pub const Record = struct {
                 allocator.free(payload.children);
                 var cached_value = payload.cached_value;
                 cached_value.deinit(ctx, roc_host, metrics);
-                releaseHostSignalToken(payload.token, roc_host);
                 abi.decrefErasedCallable(payload.transform, roc_host);
                 releaseHostValueCapability(payload.cap, roc_host, metrics);
                 metrics.bump(.closure_releases, 1);
@@ -206,7 +195,6 @@ pub const Record = struct {
             .task_source => |payload| {
                 var cached_value = payload.cached_value;
                 cached_value.deinit(ctx, roc_host, metrics);
-                releaseHostSignalToken(payload.token, roc_host);
                 allocator.free(payload.name);
                 releaseHostValueCapability(payload.payload_cap, roc_host, metrics);
                 abi.decrefErasedCallable(payload.initial, roc_host);
@@ -218,7 +206,6 @@ pub const Record = struct {
             .interval_source => |payload| {
                 var cached_value = payload.cached_value;
                 cached_value.deinit(ctx, roc_host, metrics);
-                releaseHostSignalToken(payload.token, roc_host);
                 abi.decrefErasedCallable(payload.initial, roc_host);
                 abi.decrefErasedCallable(payload.tick, roc_host);
                 releaseHostValueCapability(payload.cap, roc_host, metrics);
@@ -287,7 +274,6 @@ test "appendSignalRecordSourceNodeIds deduplicates source refs" {
     var combine = Record{
         .ref_count = 1,
         .payload = .{ .combine = .{
-            .token = undefined,
             .children = @constCast(children[0..]),
             .transform = undefined,
             .cap = undefined,

--- a/test/signals/src/spec/spec_runner.zig
+++ b/test/signals/src/spec/spec_runner.zig
@@ -5,8 +5,6 @@ const engine = signals.engine;
 const render = signals.render;
 const spec_parser = @import("spec_parser.zig");
 
-const EventPayloadAccessor = render.EventPayloadAccessor;
-const EventPayloadKind = render.EventPayloadKind;
 const RuntimeMetrics = engine.RuntimeMetrics;
 const SpecCommand = spec_parser.SpecCommand;
 const SpecCommandType = spec_parser.SpecCommandType;

--- a/test/signals/src/wasm_host.zig
+++ b/test/signals/src/wasm_host.zig
@@ -541,7 +541,7 @@ fn resolveTask(request_id: u64, payload_text: []const u8, failed: bool) void {
         .task_source => |payload| payload,
         .ref, .const_value, .map, .map2, .combine, .interval_source => unreachable,
     };
-    if (task_payload.token != pending.task_token) failHostWith("task result matched a pending request for a different task source");
+    if (record.token().? != pending.task_token) failHostWith("task result matched a pending request for a different task source");
 
     roc_allocation_phase = 10;
     const payload = hostValueStr(payload_text);

--- a/test/snapshots/expr/ann_effectful_fn.md
+++ b/test/snapshots/expr/ann_effectful_fn.md
@@ -13,10 +13,21 @@ type=expr
 }
 ~~~
 # EXPECTED
+TOO FEW ARGS - ann_effectful_fn.md:2:28:2:31
 DECLARATION HAS NO VALUE - ann_effectful_fn.md:2:5:2:31
 TYPE MISMATCH - ann_effectful_fn.md:2:32:2:36
 TYPE MISMATCH - ann_effectful_fn.md:2:37:2:50
 # PROBLEMS
+
+┌──────────────┐
+│ TOO FEW ARGS ├─ The type Try expects 2 arguments, but got 0 instead. ───────┐
+└┬─────────────┘                                                              │
+ │                                                                            │
+ │  launchTheNukes : {} => Try Bool LaunchNukeErr                             │
+ │                         ‾‾‾                                                │
+ └────────────────────────────────────────────────── ann_effectful_fn.md:2:28 ┘
+
+
 
 ┌──────────────────────────┐
 │ DECLARATION HAS NO VALUE ├─ This declaration has a type annotation but no ──┐

--- a/test/snapshots/type_apply_bare_parameterized_too_few_args.md
+++ b/test/snapshots/type_apply_bare_parameterized_too_few_args.md
@@ -21,40 +21,44 @@ TOO FEW ARGS - type_apply_bare_parameterized_too_few_args.md:5:26:5:33
 TOO FEW ARGS - type_apply_bare_parameterized_too_few_args.md:8:13:8:17
 TOO FEW ARGS - type_apply_bare_parameterized_too_few_args.md:8:21:8:25
 # PROBLEMS
-**TOO FEW ARGS**
-The type _Wrapper_ expects 1 argument, but got 0 instead.
-**type_apply_bare_parameterized_too_few_args.md:5:15:5:22:**
-```roc
-use_nominal : Wrapper -> Wrapper
-```
-              ^^^^^^^
+
+┌──────────────┐
+│ TOO FEW ARGS ├─ The type Wrapper expects 1 argument, but got 0 instead. ────┐
+└┬─────────────┘                                                              │
+ │                                                                            │
+ │  use_nominal : Wrapper -> Wrapper                                          │
+ │                ‾‾‾‾‾‾‾                                                     │
+ └──────────────────────── type_apply_bare_parameterized_too_few_args.md:5:15 ┘
 
 
-**TOO FEW ARGS**
-The type _Wrapper_ expects 1 argument, but got 0 instead.
-**type_apply_bare_parameterized_too_few_args.md:5:26:5:33:**
-```roc
-use_nominal : Wrapper -> Wrapper
-```
-                         ^^^^^^^
+
+┌──────────────┐
+│ TOO FEW ARGS ├─ The type Wrapper expects 1 argument, but got 0 instead. ────┐
+└┬─────────────┘                                                              │
+ │                                                                            │
+ │  use_nominal : Wrapper -> Wrapper                                          │
+ │                           ‾‾‾‾‾‾‾                                          │
+ └──────────────────────── type_apply_bare_parameterized_too_few_args.md:5:26 ┘
 
 
-**TOO FEW ARGS**
-The type _Pair_ expects 1 argument, but got 0 instead.
-**type_apply_bare_parameterized_too_few_args.md:8:13:8:17:**
-```roc
-use_alias : Pair -> Pair
-```
-            ^^^^
+
+┌──────────────┐
+│ TOO FEW ARGS ├─ The type Pair expects 1 argument, but got 0 instead. ───────┐
+└┬─────────────┘                                                              │
+ │                                                                            │
+ │  use_alias : Pair -> Pair                                                  │
+ │              ‾‾‾‾                                                          │
+ └──────────────────────── type_apply_bare_parameterized_too_few_args.md:8:13 ┘
 
 
-**TOO FEW ARGS**
-The type _Pair_ expects 1 argument, but got 0 instead.
-**type_apply_bare_parameterized_too_few_args.md:8:21:8:25:**
-```roc
-use_alias : Pair -> Pair
-```
-                    ^^^^
+
+┌──────────────┐
+│ TOO FEW ARGS ├─ The type Pair expects 1 argument, but got 0 instead. ───────┐
+└┬─────────────┘                                                              │
+ │                                                                            │
+ │  use_alias : Pair -> Pair                                                  │
+ │                      ‾‾‾‾                                                  │
+ └──────────────────────── type_apply_bare_parameterized_too_few_args.md:8:21 ┘
 
 
 # TOKENS

--- a/typos.toml
+++ b/typos.toml
@@ -31,6 +31,7 @@ caf = "caf" # Part of the word "café"
 clos = "clos" # Closure
 ful = "ful" # Suffix, as in "effectful"
 rela = "rela" # Relative
+Rin = "Rin" # Name used in the signals kanban app fixture
 SEH = "SEH" # Structured Exception Handling
 ser = "ser" # Part of the word "serializing"
 sigfault = "sigfault"


### PR DESCRIPTION
`roc-signals` was using `Node.new_token = |_| Box.box(0)` to allocate dummy identity objects for state binders, signal expressions, task sources, interval sources, and per-row item signals. That made signal graph correctness depend on every runtime evaluation of `Box.box(0)` producing a distinct heap allocation, even though the payload was just a zero-sized identity marker from the platform's point of view. This draft removes that dependency by reusing heap allocations that the platform already needs for evaluation: boxed initializer thunks identify const/task/interval/state sources, and boxed transform thunks identify derived signal records.

The key point is that this does not ask the compiler to special-case boxed values or change hoisting. A signal node still carries explicit identity data in the descriptor ABI, but that identity field is populated with the same boxed callable that the node already carries as its initializer or transform. For example, `Signal.const` now boxes its initializer once and passes that same box as both the identity token and the initializer. `Signal.map`, `map2`, and `combine` do the same with their boxed transform. `Ui.state` uses its boxed initializer as the binder reference shared by the state declaration, `State.signal`, and event messages. Task and interval sources use their boxed initializers as source tokens, and `StartTask` passes that token back to the host.

On the host side, `HostSignalToken` is now an erased callable pointer instead of a boxed `U64` pointer. The engine reads the explicit token field for lookup, but host signal records no longer store or retain a separate token field; a record's identity is derived from the initializer or transform callable it already owns. Pending tasks and active intervals still retain the token when they need to keep an identity pointer outside the descriptor/record lifetime. This keeps ownership explicit while deleting the duplicate token retain/release path from signal records themselves.

This keeps the runtime behavior that `roc-signals` needs: repeated descriptor walks can still intern shared signal records by pointer identity, cloned descriptors preserve identity, state binder refs still resolve through the active binder stack, task completions still route to the active task source, and interval lifecycles still use stable source tokens. The memory improvement is that constructing a state, const, map, map2, combine, task source, interval source, or each-row const no longer allocates a separate boxed `U64` whose payload is unused. The signal descriptor field count is intentionally not reduced in this draft; the identity field remains, but it points at an existing allocation.

While trying the more compact tokenless descriptor shape, I found a separate compiler crash: `roc check` accepts the changed `identity_stress.roc` app, but `roc build --opt=dev` panics in `postcheck/monotype_lifted/lift.zig`. I filed that as https://github.com/roc-lang/roc/issues/10263. This draft avoids depending on that compiler fix; it demonstrates that `roc-signals` can stop depending on dummy boxed-token identity using existing Roc and host behavior.
