### PR TITLE
Fix Windows CI timeouts: decouple granular test steps from the Windows serialization chain

### DIFF
--- a/.github/actions/flaky-retry/action.yml
+++ b/.github/actions/flaky-retry/action.yml
@@ -5,9 +5,29 @@ inputs:
     description: 'Number of times to retry on failure'
     required: false
     default: '3'
+  # Keep this list narrow and anchored. It is matched case-sensitively against
+  # the *whole* combined output of a failed command, and these steps wrap real
+  # test commands -- not just dependency fetches -- so anything that can appear
+  # incidentally in test output will silently re-run the entire suite.
+  #
+  # A bare `503` used to be in this list and did exactly that: the eval timing
+  # line "... stops within bounds (19503.1ms)" matched, re-running a 25-minute
+  # suite. `bad HTTP response code` already covers the real Zig message
+  # ("error: bad HTTP response code: '503 ...'"), so the bare code is gone.
+  #
+  # `EndOfStream` and `WriteFailed` are bare Zig error names with the same
+  # hazard -- `WriteFailed` is even in the CLI tests' own error set
+  # (src/cli/test/util.zig). They are kept because they are the observed
+  # signature of a truncated dependency fetch, but if a real failure is ever
+  # seen retrying because of them, anchor them to an `error:` prefix.
   error_string_contains:
-    description: 'Retry only if error output contains this string'
-    required: true
+    description: >-
+      Regex matched case-sensitively against the failed command's combined
+      output; the command is retried only on a match. Defaults to the
+      transient-network signature set. Override only for a command with a
+      genuinely different flake signature.
+    required: false
+    default: 'HttpConnectionClosing|build\.zig\.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|bad HTTP response code'
   command:
     description: 'The command to run'
     required: true
@@ -103,8 +123,9 @@ runs:
             exit $exitCode
           }
 
-          # Check if error matches retry condition
-          if ($output -match "${{ inputs.error_string_contains }}") {
+          # Check if error matches retry condition. `-cmatch` (not `-match`) so
+          # this lane is case-sensitive like the bash lane's `grep -Eq`.
+          if ($output -cmatch "${{ inputs.error_string_contains }}") {
             Write-Host "Command failed with exit code $exitCode and error output contains '${{ inputs.error_string_contains }}'"
             Write-Host "Retrying..."
             $attempt++

--- a/.github/workflows/ci_cross_compile.yml
+++ b/.github/workflows/ci_cross_compile.yml
@@ -53,7 +53,6 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Run fx platform cross-compilation tests (Unix)

--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -170,7 +170,13 @@ jobs:
           # present across runs: it is read every run, so it stays warm and is
           # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while the setup action's own cache still handles build artifacts for speed.
+          #
+          # Note this step is currently the ONLY working cache. The setup
+          # action also caches build artifacts, but `.zig-cache` exceeds its
+          # 2048 MiB cache-size-limit on every platform, so the action clears
+          # the directory in its post step and saves nothing -- every run then
+          # starts from a cold build cache. The "Report .zig-cache composition"
+          # step below measures this; sizing the limit is left to a follow-up.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
@@ -238,7 +244,7 @@ jobs:
           $limitMb = [int]$env:ZIG_CACHE_SIZE_LIMIT_MB
           Write-Host "root=$root  TEMP=$env:TEMP"
           if (-not (Test-Path -LiteralPath $root)) { Write-Host '(no .zig-cache)'; exit 0 }
-          # -Force or dotted/hidden subdirs are silently missed.
+          # -Force is required, or dotted/hidden subdirs are silently missed.
           # -ErrorAction SilentlyContinue because deep Zig cache paths can exceed
           # the enumerator's MAX_PATH; a partial number beats a red step.
           $rows = Get-ChildItem -LiteralPath $root -Force | ForEach-Object {

--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -186,7 +186,6 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build build-ci
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Run MiniCI

--- a/.github/workflows/ci_manager.yml
+++ b/.github/workflows/ci_manager.yml
@@ -106,6 +106,13 @@ jobs:
     name: zig-minici (${{ matrix.shard }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
+    env:
+      # Must match the `cache-size-limit` that setup-zig is operating under.
+      # It is currently unset below, so this is the action's own default (MiB).
+      # The "Report .zig-cache composition" step compares against this and warns
+      # when the cache is over budget -- otherwise setup-zig clears it in its
+      # post step and says so only in a line nobody reads.
+      ZIG_CACHE_SIZE_LIMIT_MB: '2048'
     strategy:
       fail-fast: false
       matrix:
@@ -190,6 +197,66 @@ jobs:
 
       - name: Run MiniCI
         run: zig build minici -- ${{ join(matrix.minici_args, ' ') }}
+
+      # `.zig-cache` doubles as Zig's global cache, its local cache, the build
+      # temp dir, and (until it was moved out) the CLI tests' per-run scratch
+      # trees. When the total exceeds setup-zig's cache-size-limit the action
+      # clears the directory in its post step and saves nothing, so the next run
+      # does a fully cold build -- 30-39 minutes on Windows. That failure mode is
+      # invisible in the log, so report the composition on every run.
+      # One level deep on purpose: o/, h/, p/, tmp/ is the whole question.
+      - name: Report .zig-cache composition
+        if: always() && runner.os != 'Windows'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -uo pipefail
+          root="${ZIG_LOCAL_CACHE_DIR:-$GITHUB_WORKSPACE/.zig-cache}"
+          limit_mb="$ZIG_CACHE_SIZE_LIMIT_MB"
+          echo "root=$root  TMPDIR=${TMPDIR:-unset}"
+          if [ ! -d "$root" ]; then echo "(no .zig-cache)"; exit 0; fi
+          # `du -sk`, not `-sh`/`--block-size`: -k is POSIX and identical on BSD
+          # (macOS) and GNU du, and its output can be sorted numerically.
+          for d in "$root"/* "$root"/.[!.]*; do
+            [ -e "$d" ] || continue
+            du -sk "$d"
+          done | sort -rn | awk '{ printf "%10.1f MB  %s\n", $1/1024, $2 }'
+          total_kb="$(du -sk "$root" | awk '{ print $1 }')"
+          awk -v k="$total_kb" -v l="$limit_mb" \
+            'BEGIN { printf "%10.1f MB  TOTAL (limit %s MB)\n", k/1024, l }'
+          if [ "$total_kb" -gt "$(( limit_mb * 1024 ))" ]; then
+            echo "::warning::.zig-cache is $(( total_kb / 1024 )) MB, over the ${limit_mb} MB cache-size-limit. setup-zig will clear it instead of saving it, so the next run starts from a cold build cache."
+          fi
+
+      - name: Report .zig-cache composition (Windows)
+        if: always() && runner.os == 'Windows'
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $root = if ($env:ZIG_LOCAL_CACHE_DIR) { $env:ZIG_LOCAL_CACHE_DIR }
+                  else { Join-Path $env:GITHUB_WORKSPACE '.zig-cache' }
+          $limitMb = [int]$env:ZIG_CACHE_SIZE_LIMIT_MB
+          Write-Host "root=$root  TEMP=$env:TEMP"
+          if (-not (Test-Path -LiteralPath $root)) { Write-Host '(no .zig-cache)'; exit 0 }
+          # -Force or dotted/hidden subdirs are silently missed.
+          # -ErrorAction SilentlyContinue because deep Zig cache paths can exceed
+          # the enumerator's MAX_PATH; a partial number beats a red step.
+          $rows = Get-ChildItem -LiteralPath $root -Force | ForEach-Object {
+            $m = Get-ChildItem -LiteralPath $_.FullName -Recurse -Force -File -ErrorAction SilentlyContinue |
+                 Measure-Object -Property Length -Sum
+            [pscustomobject]@{
+              Name  = $_.Name
+              MB    = [math]::Round(($m.Sum / 1MB), 1)
+              Files = $m.Count
+            }
+          }
+          $rows | Sort-Object MB -Descending | Format-Table -AutoSize | Out-String -Width 200 | Write-Host
+          $totalMb = [math]::Round((($rows | Measure-Object MB -Sum).Sum), 1)
+          $totalFiles = ($rows | Measure-Object Files -Sum).Sum
+          Write-Host ("TOTAL {0} MB across {1} files (limit {2} MB)" -f $totalMb, $totalFiles, $limitMb)
+          if ($totalMb -gt $limitMb) {
+            Write-Host ("::warning::.zig-cache is {0} MB, over the {1} MB cache-size-limit. setup-zig will clear it instead of saving it, so the next run starts from a cold build cache." -f $totalMb, $limitMb)
+          }
 
       - name: Upload MiniCI report and logs
         if: failure()

--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -60,7 +60,6 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build run-check-zig-lints
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: code tidiness
@@ -237,7 +236,6 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build run-test-eval -- --llvm
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       # Windows has no fork(), so the runner spawns a fresh worker process per
@@ -253,7 +251,6 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build run-test-eval -- --llvm --timeout 120000
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Run CLI platform tests (LLVM size/speed backends)
@@ -345,7 +342,6 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build ${{ matrix.release_jobs_flag }} -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast ${{ matrix.cpu_flag }} ${{ matrix.target_flag }}
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Run Test Platforms (Unix)
@@ -490,7 +486,6 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: git clean -fdx && zig build -Dvalgrind=true -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast -Dcpu=x86_64_v3 -Dtarget=x86_64-linux-musl -Dstrip=false -Dshared-memory-size=268435456
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: install valgrind
@@ -549,7 +544,6 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: zig build -Dtarget=${{ matrix.target }}
-          error_string_contains: "HttpConnectionClosing|build.zig.zon|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
   # Test cross-compilation with Roc's cross-compilation system (musl + glibc)

--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -50,7 +50,14 @@ jobs:
           # present across runs: it is read every run, so it stays warm and is
           # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while the setup action's own cache still handles build artifacts for speed.
+          #
+          # Note this step is currently the ONLY working cache. The setup
+          # action also caches build artifacts, but `.zig-cache` exceeds its
+          # 2048 MiB cache-size-limit on every platform, so the action clears
+          # the directory in its post step and saves nothing -- every run then
+          # starts from a cold build cache. See the "Report .zig-cache
+          # composition" step in ci_manager.yml; sizing the limit is a
+          # follow-up.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
@@ -217,7 +224,14 @@ jobs:
           # present across runs: it is read every run, so it stays warm and is
           # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while the setup action's own cache still handles build artifacts for speed.
+          #
+          # Note this step is currently the ONLY working cache. The setup
+          # action also caches build artifacts, but `.zig-cache` exceeds its
+          # 2048 MiB cache-size-limit on every platform, so the action clears
+          # the directory in its post step and saves nothing -- every run then
+          # starts from a cold build cache. See the "Report .zig-cache
+          # composition" step in ci_manager.yml; sizing the limit is a
+          # follow-up.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
@@ -327,7 +341,14 @@ jobs:
           # present across runs: it is read every run, so it stays warm and is
           # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while the setup action's own cache still handles build artifacts for speed.
+          #
+          # Note this step is currently the ONLY working cache. The setup
+          # action also caches build artifacts, but `.zig-cache` exceeds its
+          # 2048 MiB cache-size-limit on every platform, so the action clears
+          # the directory in its post step and saves nothing -- every run then
+          # starts from a cold build cache. See the "Report .zig-cache
+          # composition" step in ci_manager.yml; sizing the limit is a
+          # follow-up.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
@@ -476,7 +497,14 @@ jobs:
           # present across runs: it is read every run, so it stays warm and is
           # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while the setup action's own cache still handles build artifacts for speed.
+          #
+          # Note this step is currently the ONLY working cache. The setup
+          # action also caches build artifacts, but `.zig-cache` exceeds its
+          # 2048 MiB cache-size-limit on every platform, so the action clears
+          # the directory in its post step and saves nothing -- every run then
+          # starts from a cold build cache. See the "Report .zig-cache
+          # composition" step in ci_manager.yml; sizing the limit is a
+          # follow-up.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |
@@ -543,7 +571,14 @@ jobs:
           # present across runs: it is read every run, so it stays warm and is
           # not evicted by the setup action's churnier per-run cache. A cold runner then no
           # longer re-downloads deps from GitHub and hits HttpConnectionClosing,
-          # while the setup action's own cache still handles build artifacts for speed.
+          #
+          # Note this step is currently the ONLY working cache. The setup
+          # action also caches build artifacts, but `.zig-cache` exceeds its
+          # 2048 MiB cache-size-limit on every platform, so the action clears
+          # the directory in its post step and saves nothing -- every run then
+          # starts from a cold build cache. See the "Report .zig-cache
+          # composition" step in ci_manager.yml; sizing the limit is a
+          # follow-up.
           path: ${{ env.ZIG_GLOBAL_CACHE_DIR }}/p
           key: zig-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.zig.zon') }}
           restore-keys: |

--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -485,7 +485,16 @@ jobs:
       - name: build roc + repro executables for valgrind
         uses: ./.github/actions/flaky-retry
         with:
-          command: git clean -fdx && zig build -Dvalgrind=true -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast -Dcpu=x86_64_v3 -Dtarget=x86_64-linux-musl -Dstrip=false -Dshared-memory-size=268435456
+          # `-e .zig-cache` is load-bearing: `git clean -x` removes ignored
+          # files, so without it this deletes the `p/` package dir that the
+          # cache step above restored one step earlier -- forcing a full
+          # re-download of every dependency and producing exactly the
+          # HttpConnectionClosing flake that this flaky-retry wrapper then
+          # absorbs. Keeping the rest of `.zig-cache` is safe: Zig keys cache
+          # entries on the full build configuration, so the valgrind build
+          # (-Dvalgrind=true, musl target, ReleaseFast) hashes to different
+          # entries than any other job's and cannot pick up stale artifacts.
+          command: git clean -fdx -e .zig-cache && zig build -Dvalgrind=true -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast -Dcpu=x86_64_v3 -Dtarget=x86_64-linux-musl -Dstrip=false -Dshared-memory-size=268435456
           retry_count: 3
 
       - name: install valgrind

--- a/.github/workflows/ci_zig_benchmarks.yml
+++ b/.github/workflows/ci_zig_benchmarks.yml
@@ -35,7 +35,6 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: "nix develop ./src/ -c bash -c 'zig build build-release'"
-          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Prepare main artifacts
@@ -56,7 +55,6 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: "nix develop ./src/ -c bash -c 'zig build build-release'"
-          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Prepare PR artifacts

--- a/.github/workflows/ci_zig_nix.yml
+++ b/.github/workflows/ci_zig_nix.yml
@@ -57,7 +57,6 @@ jobs:
         uses: ./.github/actions/flaky-retry
         with:
           command: 'nix develop ./src/ -c bash ci/zig_nix_ci.sh ${{ matrix.nix_ci_mode }} ${{ matrix.target_flag }}'
-          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3
 
       - name: Check Zig dependency package cache contents
@@ -86,5 +85,4 @@ jobs:
             set -euo pipefail
             nix build ./src#roc
             result/bin/roc check CONTRIBUTING/profiling/bench_repeated_check.roc
-          error_string_contains: "build.zig.zon|HttpConnectionClosing|TemporaryNameServerFailure|error: cannot download|EndOfStream|WriteFailed|503|bad HTTP response code"
           retry_count: 3

--- a/build.zig
+++ b/build.zig
@@ -181,7 +181,6 @@ const TestsSummaryStep = struct {
     has_filters: bool,
     test_filters: []const []const u8,
     forced_passes: u64,
-    run_prerequisite: ?*Step,
     serialize_runs: bool,
     last_run: ?*Step,
     run_steps: std.ArrayList(*Step),
@@ -202,7 +201,6 @@ const TestsSummaryStep = struct {
             .has_filters = test_filters.len > 0,
             .test_filters = test_filters,
             .forced_passes = @intCast(forced_passes),
-            .run_prerequisite = null,
             .serialize_runs = false,
             .last_run = null,
             .run_steps = .empty,
@@ -214,11 +212,13 @@ const TestsSummaryStep = struct {
         self.serialize_runs = true;
     }
 
+    /// Registers `run_step` with the summary. On Windows the registered runs
+    /// are chained so that test binaries start one at a time; that chain is
+    /// private to the summary and must never be reachable from a public
+    /// `run-test-zig-*` step. Prefer `TestSuiteRegistry.register`, which
+    /// guarantees that by construction.
     fn addRun(self: *TestsSummaryStep, run_step: *Step) void {
         self.run_steps.append(self.step.owner.allocator, run_step) catch @panic("OOM");
-        if (self.run_prerequisite) |prerequisite| {
-            run_step.dependOn(prerequisite);
-        }
         if (self.serialize_runs) {
             if (self.last_run) |last_run| {
                 run_step.dependOn(last_run);
@@ -310,17 +310,91 @@ const TestsSummaryStep = struct {
     }
 };
 
-fn addTestRunArtifact(
+/// One environment variable, applied identically to both runs of a test suite.
+const TestSuiteEnv = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+/// Everything that differs between the Zig test suites registered with
+/// `TestsSummaryStep`. Anything not expressible here is applied uniformly by
+/// `TestSuiteRegistry.register`. If a suite ever needs a knob that is missing
+/// (a working directory, `has_side_effects`, ...), add a field here rather than
+/// hand-wiring that one suite at its call site -- see the note on `register`.
+const TestSuiteSpec = struct {
+    /// Suffix appended to `run-test-zig-`. This is also the MiniCI job name in
+    /// `src/build/minici.zig`, so it must stay stable.
+    step_suffix: []const u8,
+    /// Description for the public `run-test-zig-<step_suffix>` step.
+    description: []const u8,
+    /// The test binary. Both runs execute this one `Step.Compile`, so it is
+    /// compiled once no matter which step was asked for.
+    compile: *Step.Compile,
+    /// Extra edges both runs need: copied host libraries, installed prebuilt
+    /// apps, the `roc` CLI, and so on.
+    deps: []const *Step = &.{},
+    /// Environment variables both runs need.
+    env: []const TestSuiteEnv = &.{},
+    /// Whether a bare `zig build` should also build this test binary.
+    default_step: bool = false,
+};
+
+/// Owns every cross-cutting edge a Zig test suite needs, so that a suite is
+/// wired up in exactly one call.
+///
+/// The failure this type exists to prevent: on Windows `TestsSummaryStep`
+/// chains its registered runs (see `setRunSerialization`) so that test binaries
+/// start one at a time. If a granular `run-test-zig-<suite>` step is pointed at
+/// the *same* `Step.Run` that the chain owns, it inherits the entire prefix of
+/// that chain. `run-test-zig-minici` is a std-only suite of ~11 string-parsing
+/// tests; wired that way it re-ran 41 unrelated test binaries and took 441s
+/// instead of ~2s. MiniCI runs each granular step as its own `zig build`
+/// process, so it replayed that prefix once per affected job -- which is what
+/// pushed the Windows CI job past its two-hour limit.
+///
+/// `register` builds *both* runs from one spec, so the summary's run and the
+/// public step's run can neither be the same object nor drift apart in their
+/// configuration. `assertGranularTestStepsAreIsolated` re-checks the finished
+/// graph, in case a suite is ever wired by hand anyway.
+const TestSuiteRegistry = struct {
     b: *std.Build,
-    artifact: *Step.Compile,
+    summary: *TestsSummaryStep,
+    build_test_zig_step: *Step,
+    /// Non-null only while the test-wiring check is enumerating test binaries.
+    wiring_run: ?*Step.Run,
+    /// Args forwarded from `zig build -- <args>`, e.g. `--test-filter`.
     run_args: []const []const u8,
-) *std.Build.Step.Run {
-    const run = b.addRunArtifact(artifact);
-    if (run_args.len != 0) {
-        run.addArgs(run_args);
+
+    fn register(self: TestSuiteRegistry, spec: TestSuiteSpec) void {
+        const b = self.b;
+
+        // Build-side wiring, uniform for every suite.
+        self.build_test_zig_step.dependOn(&spec.compile.step);
+        if (spec.default_step) b.default_step.dependOn(&spec.compile.step);
+        if (self.wiring_run) |wiring| wiring.addArtifactArg(spec.compile);
+
+        // Two runs over one compile. Only the summary's run joins the Windows
+        // serialization chain; the public step gets a run with no chain edges,
+        // which is what every non-Windows platform already does implicitly.
+        self.summary.addRun(&self.configuredRun(spec).step);
+
+        const public_step = b.step(
+            b.fmt("run-test-zig-{s}", .{spec.step_suffix}),
+            spec.description,
+        );
+        public_step.dependOn(&self.configuredRun(spec).step);
     }
-    return run;
-}
+
+    /// Both runs are produced by this one function from one spec, so there is
+    /// never a second copy of the configuration to fall out of sync.
+    fn configuredRun(self: TestSuiteRegistry, spec: TestSuiteSpec) *Step.Run {
+        const run = self.b.addRunArtifact(spec.compile);
+        if (self.run_args.len != 0) run.addArgs(self.run_args);
+        for (spec.env) |entry| run.setEnvironmentVariable(entry.key, entry.value);
+        for (spec.deps) |dep| run.step.dependOn(dep);
+        return run;
+    }
+};
 
 /// Build step that checks for forbidden patterns in the type checker code.
 ///
@@ -4474,6 +4548,10 @@ pub fn build(b: *std.Build) void {
         // Zig 0.16's Windows test runner IPC can time out while many Roc test
         // binaries are starting at once. Keep the same tests, but start them
         // in a deterministic order.
+        //
+        // Only the summary's own runs are chained. The public run-test-zig-*
+        // steps get separate, unchained runs via `TestSuiteRegistry`, so asking
+        // for one suite never drags in the whole chain -- see the note there.
         tests_summary.setRunSerialization();
     }
 

--- a/build.zig
+++ b/build.zig
@@ -212,8 +212,9 @@ const TestsSummaryStep = struct {
         self.serialize_runs = true;
     }
 
-    /// Registers `run_step` with the summary. On Windows the registered runs
-    /// are chained so that test binaries start one at a time; that chain is
+    /// Registers `run_step` with the summary. When run serialization is
+    /// enabled, registered runs are chained so that test binaries start one at
+    /// a time. The build currently enables this on Windows. That chain is
     /// private to the summary and must never be reachable from a public
     /// `run-test-zig-*` step. Prefer `TestSuiteRegistry.register`, which
     /// guarantees that by construction.
@@ -373,9 +374,9 @@ const TestSuiteRegistry = struct {
         if (spec.default_step) b.default_step.dependOn(&spec.compile.step);
         if (self.wiring_run) |wiring| wiring.addArtifactArg(spec.compile);
 
-        // Two runs over one compile. Only the summary's run joins the Windows
-        // serialization chain; the public step gets a run with no chain edges,
-        // which is what every non-Windows platform already does implicitly.
+        // Two runs over one compile. Only the summary's run joins the
+        // serialization chain (currently enabled only on Windows); the public
+        // step gets a run with no chain edges.
         self.summary.addRun(&self.configuredRun(spec).step);
 
         const public_step = b.step(
@@ -5735,8 +5736,9 @@ pub fn build(b: *std.Build) void {
     assertGranularTestStepsAreIsolated(b);
 }
 
-/// Configure-time guard: a public `run-test-zig-*` step must never pull more
-/// than one test binary into its graph.
+/// Configure-time guard: a public `run-test-zig-*` step must pull exactly the
+/// explicitly declared number of Zig test binaries into its graph. That is one
+/// by default; custom executable-backed runners declare zero below.
 ///
 /// On Windows `TestsSummaryStep` chains its registered runs so that test
 /// binaries start one at a time. Pointing a granular step at the *same*
@@ -5761,7 +5763,24 @@ fn assertGranularTestStepsAreIsolated(b: *std.Build) void {
         var found_len: usize = 0;
         collectTestRuns(b, &tls.step, &visited, &found, &found_len);
 
-        if (found_len > 1) {
+        const expected_len = expectedGranularZigTestBinaries(name);
+        if (found_len == expected_len) continue;
+
+        if (found_len == 0) {
+            std.debug.panic(
+                "build.zig: step \"{s}\" runs no Zig test binary; granular test steps " ++
+                    "must run exactly one unless they are an explicitly declared custom " ++
+                    "executable-backed runner.",
+                .{name},
+            );
+        } else if (expected_len == 0) {
+            std.debug.panic(
+                "build.zig: custom executable-backed step \"{s}\" unexpectedly also " ++
+                    "runs {d} Zig test binaries (first: {s}); update its wiring or its " ++
+                    "explicit declaration.",
+                .{ name, found_len, found[0] },
+            );
+        } else {
             std.debug.panic(
                 "build.zig: step \"{s}\" runs at least {d} test binaries ({s}, {s}, ...). " ++
                     "A granular run-test-zig-* step must run exactly one; wire the suite " ++
@@ -5771,6 +5790,17 @@ fn assertGranularTestStepsAreIsolated(b: *std.Build) void {
             );
         }
     }
+}
+
+/// Expected `Step.Compile` test producers beneath a granular test step.
+///
+/// The LSP integration suite is intentionally an ordinary executable: its own
+/// process-pool harness discovers and runs the integration specs. Keeping that
+/// exception explicit means a newly orphaned `run-test-zig-*` step cannot pass
+/// configuration merely because it reaches zero Zig test binaries.
+fn expectedGranularZigTestBinaries(name: []const u8) usize {
+    if (std.mem.eql(u8, name, "run-test-zig-module-lsp_integration")) return 0;
+    return 1;
 }
 
 /// Walks `step`'s transitive dependencies, recording the names of the test

--- a/build.zig
+++ b/build.zig
@@ -5836,6 +5836,74 @@ pub fn build(b: *std.Build) void {
             name,
         );
     }
+
+    // Last, so that every top-level step exists -- including the ones created
+    // inside addMainExe.
+    assertGranularTestStepsAreIsolated(b);
+}
+
+/// Configure-time guard: a public `run-test-zig-*` step must never pull more
+/// than one test binary into its graph.
+///
+/// On Windows `TestsSummaryStep` chains its registered runs so that test
+/// binaries start one at a time. Pointing a granular step at the *same*
+/// `Step.Run` that the chain owns makes that step inherit the whole chain
+/// prefix: `run-test-zig-minici` (~11 std-only string-parsing tests, ~2s) once
+/// re-ran 41 unrelated binaries and took 441s, and MiniCI replayed that prefix
+/// once per affected job. `TestSuiteRegistry.register` makes that shape
+/// unrepresentable; this re-checks the finished graph in case a suite is ever
+/// wired up by hand instead.
+///
+/// The aggregate step is named exactly "run-test-zig" (no trailing hyphen), so
+/// the prefix test excludes it without needing an allowlist.
+fn assertGranularTestStepsAreIsolated(b: *std.Build) void {
+    var visited: std.AutoHashMapUnmanaged(*Step, void) = .empty;
+    defer visited.deinit(b.allocator);
+
+    for (b.top_level_steps.keys(), b.top_level_steps.values()) |name, tls| {
+        if (!std.mem.startsWith(u8, name, "run-test-zig-")) continue;
+
+        visited.clearRetainingCapacity();
+        var found: [4][]const u8 = undefined;
+        var found_len: usize = 0;
+        collectTestRuns(b, &tls.step, &visited, &found, &found_len);
+
+        if (found_len > 1) {
+            std.log.warn(
+                "build.zig: step \"{s}\" runs at least {d} test binaries ({s}, {s}, ...). " ++
+                    "A granular run-test-zig-* step must run exactly one; wire the suite " ++
+                    "through TestSuiteRegistry.register rather than handing the summary's " ++
+                    "Step.Run to b.step().",
+                .{ name, found_len, found[0], found[1] },
+            );
+        }
+    }
+}
+
+/// Walks `step`'s transitive dependencies, recording the names of the test
+/// binaries executed along the way. Stops recording at `found.len` names; the
+/// caller only needs to know "more than one" and two names for its message.
+fn collectTestRuns(
+    b: *std.Build,
+    step: *Step,
+    visited: *std.AutoHashMapUnmanaged(*Step, void),
+    found: *[4][]const u8,
+    found_len: *usize,
+) void {
+    const gop = visited.getOrPut(b.allocator, step) catch @panic("OOM");
+    if (gop.found_existing) return;
+
+    if (step.id == .run) {
+        const run: *Step.Run = @fieldParentPtr("step", step);
+        if (run.producer) |producer| {
+            if (producer.kind.isTest() and found_len.* < found.len) {
+                found[found_len.*] = producer.name;
+                found_len.* += 1;
+            }
+        }
+    }
+
+    for (step.dependencies.items) |dep| collectTestRuns(b, dep, visited, found, found_len);
 }
 
 fn discoverBuiltinRocFiles(b: *std.Build) ![]const []const u8 {

--- a/build.zig
+++ b/build.zig
@@ -3030,7 +3030,8 @@ pub fn build(b: *std.Build) void {
     llvm_codegen_module.addImport("roc_target", roc_modules.roc_target);
     llvm_codegen_module.addImport("vendor_llvm_ir", roc_modules.vendor_llvm_ir);
 
-    const roc_exe = addMainExe(b, roc_modules, target, optimize, strip, omit_frame_pointer, use_system_llvm, user_llvm_path, flag_enable_tracy, zstd, compiled_builtins_module, write_compiled_builtins, llvm_codegen_module, flag_enable_tracy, true, if (enumerate_tests_for_wiring_check) run_test_wiring else null, valgrind_support) orelse return;
+    const main_exe_result = addMainExe(b, roc_modules, target, optimize, strip, omit_frame_pointer, use_system_llvm, user_llvm_path, flag_enable_tracy, zstd, compiled_builtins_module, write_compiled_builtins, llvm_codegen_module, flag_enable_tracy, test_filters, true, valgrind_support) orelse return;
+    const roc_exe = main_exe_result.exe;
     roc_modules.addAll(roc_exe);
     _ = install_and_run(b, no_bin, roc_exe, build_roc_step, run_roc_step, run_args);
 
@@ -3090,7 +3091,7 @@ pub fn build(b: *std.Build) void {
             .target = release_target,
             .optimize = .ReleaseFast,
         });
-        const release_exe = addMainExe(
+        const release_exe_result = addMainExe(
             b,
             roc_modules,
             release_target,
@@ -3105,11 +3106,12 @@ pub fn build(b: *std.Build) void {
             write_compiled_builtins,
             llvm_codegen_module,
             null, // No tracy
+            test_filters,
             false,
-            null, // No machine-code shim test, so nothing to enumerate
             valgrind_support,
         );
-        if (release_exe) |exe| {
+        if (release_exe_result) |result| {
+            const exe = result.exe;
             roc_modules.addAll(exe);
             exe.root_module.addImport("compiled_builtins", compiled_builtins_module);
             exe.step.dependOn(&write_compiled_builtins.step);
@@ -4564,6 +4566,14 @@ pub fn build(b: *std.Build) void {
         .run_args = run_args,
     };
 
+    if (main_exe_result.machine_code_shim_test) |machine_code_shim_test| {
+        test_suites.register(.{
+            .step_suffix = "machine-code-shim",
+            .description = "Run machine-code shim Zig tests",
+            .compile = machine_code_shim_test,
+        });
+    }
+
     const guarded_list_violation_exe = b.addExecutable(.{
         .name = "guarded_list_violation_test",
         .root_module = b.createModule(.{
@@ -6016,6 +6026,11 @@ fn addMacosAflFuzzExe(
     return exe.getEmittedBin();
 }
 
+const MainExeResult = struct {
+    exe: *Step.Compile,
+    machine_code_shim_test: ?*Step.Compile,
+};
+
 fn addMainExe(
     b: *std.Build,
     roc_modules: modules.RocModules,
@@ -6031,12 +6046,10 @@ fn addMainExe(
     write_compiled_builtins: *Step.WriteFile,
     llvm_codegen_module: *std.Build.Module,
     flag_enable_tracy: ?[]const u8,
+    test_filters: []const []const u8,
     add_machine_code_shim_test: bool,
-    /// When set, the machine-code shim test binary is registered with the
-    /// test-wiring checker's semantic enumeration.
-    test_wiring_run: ?*Step.Run,
     valgrind_support: ?bool,
-) ?*Step.Compile {
+) ?MainExeResult {
     const exe = b.addExecutable(.{
         .name = "roc",
         .root_module = b.createModule(.{
@@ -6240,6 +6253,7 @@ fn addMainExe(
     machine_code_shim_lib.root_module.addObjectFile(builtins_obj.getEmittedBin());
     machine_code_shim_lib.bundle_compiler_rt = true;
 
+    var machine_code_shim_test_for_registry: ?*Step.Compile = null;
     if (add_machine_code_shim_test) {
         const machine_code_shim_test = b.addTest(.{
             .name = "machine_code_shim",
@@ -6249,6 +6263,7 @@ fn addMainExe(
                 .optimize = optimize,
                 .link_libc = true,
             }),
+            .filters = test_filters,
         });
         configureBackend(machine_code_shim_test, target);
         roc_modules.addAll(machine_code_shim_test);
@@ -6274,14 +6289,7 @@ fn addMainExe(
         machine_code_shim_test.root_module.addObject(machine_code_shim_test_host);
         machine_code_shim_test.bundle_compiler_rt = true;
         add_tracy(b, roc_modules.build_options, machine_code_shim_test, b.graph.host, false, flag_enable_tracy);
-        if (test_wiring_run) |wiring_run| wiring_run.addArtifactArg(machine_code_shim_test);
-
-        const run_machine_code_shim_test = b.addRunArtifact(machine_code_shim_test);
-        const run_machine_code_shim_test_step = b.step(
-            "run-test-zig-machine-code-shim",
-            "Run machine-code shim Zig tests",
-        );
-        run_machine_code_shim_test_step.dependOn(&run_machine_code_shim_test.step);
+        machine_code_shim_test_for_registry = machine_code_shim_test;
     }
 
     const install_machine_code_shim = b.addInstallArtifact(machine_code_shim_lib, .{});
@@ -6483,7 +6491,10 @@ fn addMainExe(
 
     exe.root_module.linkLibrary(zstd.artifact("zstd"));
 
-    return exe;
+    return .{
+        .exe = exe,
+        .machine_code_shim_test = machine_code_shim_test_for_registry,
+    };
 }
 
 fn install_and_run(

--- a/build.zig
+++ b/build.zig
@@ -4555,6 +4555,14 @@ pub fn build(b: *std.Build) void {
         tests_summary.setRunSerialization();
     }
 
+    const test_suites = TestSuiteRegistry{
+        .b = b,
+        .summary = tests_summary,
+        .build_test_zig_step = build_test_zig_step,
+        .wiring_run = if (enumerate_tests_for_wiring_check) run_test_wiring else null,
+        .run_args = run_args,
+    };
+
     const guarded_list_violation_exe = b.addExecutable(.{
         .name = "guarded_list_violation_test",
         .root_module = b.createModule(.{
@@ -4764,16 +4772,11 @@ pub fn build(b: *std.Build) void {
         }),
         .filters = test_filters,
     });
-    build_test_zig_step.dependOn(&build_helpers_test.step);
-    if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(build_helpers_test);
-    const run_build_helpers_test_for_summary = addTestRunArtifact(b, build_helpers_test, run_args);
-    tests_summary.addRun(&run_build_helpers_test_for_summary.step);
-    const run_build_helpers_test = addTestRunArtifact(b, build_helpers_test, run_args);
-    const run_build_helpers_step = b.step(
-        "run-test-zig-build-helpers",
-        "Run build-helper Zig unit tests",
-    );
-    run_build_helpers_step.dependOn(&run_build_helpers_test.step);
+    test_suites.register(.{
+        .step_suffix = "build-helpers",
+        .description = "Run build-helper Zig unit tests",
+        .compile = build_helpers_test,
+    });
 
     // CLI runner unit tests: parallel_cli_runner.zig is an executable root, so
     // its test decls are only collected by this dedicated test compile.
@@ -4794,16 +4797,11 @@ pub fn build(b: *std.Build) void {
         }),
         .filters = test_filters,
     });
-    build_test_zig_step.dependOn(&cli_runner_unit_test.step);
-    if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(cli_runner_unit_test);
-    const run_cli_runner_unit_test_for_summary = addTestRunArtifact(b, cli_runner_unit_test, run_args);
-    tests_summary.addRun(&run_cli_runner_unit_test_for_summary.step);
-    const run_cli_runner_unit_test = addTestRunArtifact(b, cli_runner_unit_test, run_args);
-    const run_cli_runner_unit_step = b.step(
-        "run-test-zig-cli-runner-unit",
-        "Run CLI runner Zig unit tests",
-    );
-    run_cli_runner_unit_step.dependOn(&run_cli_runner_unit_test.step);
+    test_suites.register(.{
+        .step_suffix = "cli-runner-unit",
+        .description = "Run CLI runner Zig unit tests",
+        .compile = cli_runner_unit_test,
+    });
 
     // LLVM backend aggregator test: src/backend/llvm/mod.zig is not the root of
     // the llvm_codegen module, so its refAllDecls compile coverage needs its own
@@ -4843,16 +4841,11 @@ pub fn build(b: *std.Build) void {
     {
         backend_llvm_test.root_module.link_libcpp = true;
     }
-    build_test_zig_step.dependOn(&backend_llvm_test.step);
-    if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(backend_llvm_test);
-    const run_backend_llvm_test_for_summary = addTestRunArtifact(b, backend_llvm_test, run_args);
-    tests_summary.addRun(&run_backend_llvm_test_for_summary.step);
-    const run_backend_llvm_test = addTestRunArtifact(b, backend_llvm_test, run_args);
-    const run_backend_llvm_step = b.step(
-        "run-test-zig-backend-llvm",
-        "Run LLVM backend aggregator Zig tests",
-    );
-    run_backend_llvm_step.dependOn(&run_backend_llvm_test.step);
+    test_suites.register(.{
+        .step_suffix = "backend-llvm",
+        .description = "Run LLVM backend aggregator Zig tests",
+        .compile = backend_llvm_test,
+    });
 
     // Add snapshot tool test
     const enable_snapshot_tests = b.option(bool, "snapshot-tests", "Enable snapshot tests") orelse true;
@@ -4888,25 +4881,21 @@ pub fn build(b: *std.Build) void {
         }
 
         add_tracy(b, roc_modules.build_options, snapshot_test, target, true, flag_enable_tracy);
-        build_test_zig_step.dependOn(&snapshot_test.step);
-        if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(snapshot_test);
 
-        const run_snapshot_test_for_summary = addTestRunArtifact(b, snapshot_test, run_args);
-        if (snapshot_exe_install) |install| {
-            run_snapshot_test_for_summary.step.dependOn(&install.step);
-        }
-        tests_summary.addRun(&run_snapshot_test_for_summary.step);
+        // The install step is optional, so hoist the dep list into a local with
+        // an explicit type: peer-type resolution on an inline
+        // `if (c) &.{x} else &.{}` inside a struct literal field is fragile.
+        const snapshot_deps: []const *Step = if (snapshot_exe_install) |install|
+            &.{&install.step}
+        else
+            &.{};
 
-        const run_snapshot_test = addTestRunArtifact(b, snapshot_test, run_args);
-        if (snapshot_exe_install) |install| {
-            run_snapshot_test.step.dependOn(&install.step);
-        }
-
-        const run_snapshot_tool_test_step = b.step(
-            "run-test-zig-snapshot-tool",
-            "Run snapshot tool Zig tests",
-        );
-        run_snapshot_tool_test_step.dependOn(&run_snapshot_test.step);
+        test_suites.register(.{
+            .step_suffix = "snapshot-tool",
+            .description = "Run snapshot tool Zig tests",
+            .compile = snapshot_test,
+            .deps = snapshot_deps,
+        });
     }
 
     // Add Builtin.roc doc code-block tests. Verifies every ```roc block in
@@ -4945,19 +4934,12 @@ pub fn build(b: *std.Build) void {
             builtin_doc_test.root_module.link_libcpp = true;
         }
         add_tracy(b, roc_modules.build_options, builtin_doc_test, target, true, flag_enable_tracy);
-        build_test_zig_step.dependOn(&builtin_doc_test.step);
-        if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(builtin_doc_test);
 
-        const run_builtin_doc_test_for_summary = addTestRunArtifact(b, builtin_doc_test, run_args);
-        tests_summary.addRun(&run_builtin_doc_test_for_summary.step);
-
-        const run_builtin_doc_test = addTestRunArtifact(b, builtin_doc_test, run_args);
-
-        const run_builtin_doc_test_step = b.step(
-            "run-test-zig-builtin-doc",
-            "Run Builtin.roc doc code-block Zig tests",
-        );
-        run_builtin_doc_test_step.dependOn(&run_builtin_doc_test.step);
+        test_suites.register(.{
+            .step_suffix = "builtin-doc",
+            .description = "Run Builtin.roc doc code-block Zig tests",
+            .compile = builtin_doc_test,
+        });
     }
 
     const lir_inline_test = b.addTest(.{
@@ -4990,19 +4972,12 @@ pub fn build(b: *std.Build) void {
         lir_inline_test.root_module.link_libcpp = true;
     }
     add_tracy(b, roc_modules.build_options, lir_inline_test, target, true, flag_enable_tracy);
-    build_test_zig_step.dependOn(&lir_inline_test.step);
-    if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(lir_inline_test);
 
-    const run_lir_inline_test_for_summary = addTestRunArtifact(b, lir_inline_test, run_args);
-    tests_summary.addRun(&run_lir_inline_test_for_summary.step);
-
-    const run_lir_inline_test = addTestRunArtifact(b, lir_inline_test, run_args);
-
-    const run_lir_inline_test_step = b.step(
-        "run-test-zig-lir-inline",
-        "Run LIR inline Zig tests",
-    );
-    run_lir_inline_test_step.dependOn(&run_lir_inline_test.step);
+    test_suites.register(.{
+        .step_suffix = "lir-inline",
+        .description = "Run LIR inline Zig tests",
+        .compile = lir_inline_test,
+    });
 
     const trmc_lir_test = b.addTest(.{
         .name = "trmc_lir_test",
@@ -5034,19 +5009,12 @@ pub fn build(b: *std.Build) void {
         trmc_lir_test.root_module.link_libcpp = true;
     }
     add_tracy(b, roc_modules.build_options, trmc_lir_test, target, true, flag_enable_tracy);
-    build_test_zig_step.dependOn(&trmc_lir_test.step);
-    if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(trmc_lir_test);
 
-    const run_trmc_lir_test_for_summary = addTestRunArtifact(b, trmc_lir_test, run_args);
-    tests_summary.addRun(&run_trmc_lir_test_for_summary.step);
-
-    const run_trmc_lir_test = addTestRunArtifact(b, trmc_lir_test, run_args);
-
-    const run_trmc_lir_test_step = b.step(
-        "run-test-zig-trmc-lir",
-        "Run TRMC LIR Zig tests",
-    );
-    run_trmc_lir_test_step.dependOn(&run_trmc_lir_test.step);
+    test_suites.register(.{
+        .step_suffix = "trmc-lir",
+        .description = "Run TRMC LIR Zig tests",
+        .compile = trmc_lir_test,
+    });
 
     // Add CLI test
     const enable_cli_tests = b.option(bool, "cli-tests", "Enable cli tests") orelse true;
@@ -5083,19 +5051,12 @@ pub fn build(b: *std.Build) void {
         add_tracy(b, roc_modules.build_options, cli_test, target, true, flag_enable_tracy);
         cli_test.root_module.addImport("compiled_builtins", compiled_builtins_module);
         cli_test.step.dependOn(&write_compiled_builtins.step);
-        build_test_zig_step.dependOn(&cli_test.step);
-        if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(cli_test);
 
-        const run_cli_test_for_summary = addTestRunArtifact(b, cli_test, run_args);
-        tests_summary.addRun(&run_cli_test_for_summary.step);
-
-        const run_cli_test = addTestRunArtifact(b, cli_test, run_args);
-
-        const run_cli_main_test_step = b.step(
-            "run-test-zig-cli-main",
-            "Run roc CLI main Zig tests",
-        );
-        run_cli_main_test_step.dependOn(&run_cli_test.step);
+        test_suites.register(.{
+            .step_suffix = "cli-main",
+            .description = "Run roc CLI main Zig tests",
+            .compile = cli_test,
+        });
     }
 
     // Add watch tests
@@ -5117,25 +5078,19 @@ pub fn build(b: *std.Build) void {
         // Link platform-specific libraries for file watching
         linkWatchPlatformLibs(watch_test, target);
 
-        build_test_zig_step.dependOn(&watch_test.step);
-        if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(watch_test);
-
-        const run_watch_test_for_summary = addTestRunArtifact(b, watch_test, run_args);
-        tests_summary.addRun(&run_watch_test_for_summary.step);
-
-        const run_watch_test = addTestRunArtifact(b, watch_test, run_args);
-
-        const run_watch_cli_test_step = b.step(
-            "run-test-zig-watch-cli",
-            "Run watch command Zig tests",
-        );
-        run_watch_cli_test_step.dependOn(&run_watch_test.step);
+        test_suites.register(.{
+            .step_suffix = "watch-cli",
+            .description = "Run watch command Zig tests",
+            .compile = watch_test,
+        });
     }
 
     // MiniCI output-filter tests. MiniCI is a standalone host build tool that
     // only imports `std`, so it needs no module wiring.
-    {
-        const minici_test = b.addTest(.{
+    test_suites.register(.{
+        .step_suffix = "minici",
+        .description = "Run MiniCI output-filter Zig tests",
+        .compile = b.addTest(.{
             .name = "minici_test",
             .root_module = b.createModule(.{
                 .root_source_file = b.path("src/build/minici.zig"),
@@ -5143,21 +5098,8 @@ pub fn build(b: *std.Build) void {
                 .optimize = .Debug,
             }),
             .filters = test_filters,
-        });
-        build_test_zig_step.dependOn(&minici_test.step);
-        if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(minici_test);
-
-        const run_minici_test_for_summary = addTestRunArtifact(b, minici_test, run_args);
-        tests_summary.addRun(&run_minici_test_for_summary.step);
-
-        const run_minici_test = addTestRunArtifact(b, minici_test, run_args);
-
-        const run_minici_test_step = b.step(
-            "run-test-zig-minici",
-            "Run MiniCI output-filter Zig tests",
-        );
-        run_minici_test_step.dependOn(&run_minici_test.step);
-    }
+        }),
+    });
 
     // Add check for forbidden patterns in type checker code
     const check_patterns = CheckTypeCheckerPatternsStep.create(b);
@@ -5539,27 +5481,18 @@ pub fn build(b: *std.Build) void {
             .filters = test_filters,
         });
 
-        build_test_zig_step.dependOn(&fx_platform_test.step);
-        if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(fx_platform_test);
-
-        const run_fx_platform_test_for_summary = addTestRunArtifact(b, fx_platform_test, run_args);
-        run_fx_platform_test_for_summary.step.dependOn(final_fx_host_step);
-        run_fx_platform_test_for_summary.step.dependOn(final_static_data_platform_step);
-        run_fx_platform_test_for_summary.step.dependOn(build_roc_step);
-        tests_summary.addRun(&run_fx_platform_test_for_summary.step);
-
-        const run_fx_platform_test = addTestRunArtifact(b, fx_platform_test, run_args);
-        // Ensure host library is copied AND fixed before running the test
-        run_fx_platform_test.step.dependOn(final_fx_host_step);
-        run_fx_platform_test.step.dependOn(final_static_data_platform_step);
-        // Ensure roc binary is built before running the test (tests invoke roc CLI)
-        run_fx_platform_test.step.dependOn(build_roc_step);
-
-        const run_fx_platform_zig_test_step = b.step(
-            "run-test-zig-fx-platform",
-            "Run fx platform Zig tests",
-        );
-        run_fx_platform_zig_test_step.dependOn(&run_fx_platform_test.step);
+        test_suites.register(.{
+            .step_suffix = "fx-platform",
+            .description = "Run fx platform Zig tests",
+            .compile = fx_platform_test,
+            .deps = &.{
+                // The host library must be copied AND fixed before the test runs.
+                final_fx_host_step,
+                final_static_data_platform_step,
+                // The tests shell out to the roc CLI.
+                build_roc_step,
+            },
+        });
 
         const http_host_target, const http_host_target_dir: ?[]const u8 = switch (target.result.os.tag) {
             .linux => switch (target.result.cpu.arch) {

--- a/build.zig
+++ b/build.zig
@@ -4688,34 +4688,24 @@ pub fn build(b: *std.Build) void {
             );
         }
 
-        if (run_args.len != 0) {
-            module_test.run_step.addArgs(run_args);
-        }
-        if (std.mem.eql(u8, module_test.test_step.name, "base")) {
-            module_test.run_step.step.dependOn(&install_stack_overflow_test_helper.step);
-        }
-
-        // Create individual test step for this module
         const test_exe_name = module_test.test_step.name;
-        const run_module_test_step = b.step(
-            b.fmt("run-test-zig-module-{s}", .{test_exe_name}),
-            b.fmt("Run {s} Zig module tests", .{test_exe_name}),
-        );
 
-        // Create run step that accepts command line args (including --test-filter)
-        const individual_run = b.addRunArtifact(module_test.test_step);
-        if (run_args.len != 0) {
-            individual_run.addArgs(run_args);
-        }
-        if (std.mem.eql(u8, module_test.test_step.name, "base")) {
-            individual_run.step.dependOn(&install_stack_overflow_test_helper.step);
-        }
-        run_module_test_step.dependOn(&individual_run.step);
+        // The `base` module's tests exec a helper binary, so it must be
+        // installed first. Hoisted into an explicitly typed local because
+        // peer-type resolution on an inline conditional slice literal inside a
+        // struct literal field is fragile.
+        const module_deps: []const *Step = if (std.mem.eql(u8, test_exe_name, "base"))
+            &.{&install_stack_overflow_test_helper.step}
+        else
+            &.{};
 
-        b.default_step.dependOn(&module_test.test_step.step);
-        build_test_zig_step.dependOn(&module_test.test_step.step);
-        if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(module_test.test_step);
-        tests_summary.addRun(&module_test.run_step.step);
+        test_suites.register(.{
+            .step_suffix = b.fmt("module-{s}", .{test_exe_name}),
+            .description = b.fmt("Run {s} Zig module tests", .{test_exe_name}),
+            .compile = module_test.test_step,
+            .deps = module_deps,
+            .default_step = true,
+        });
     }
 
     const lsp_integration_test_harness_module = createTestHarnessModule(b, roc_modules);
@@ -5571,32 +5561,19 @@ pub fn build(b: *std.Build) void {
                 .filters = test_filters,
             });
 
-            const run_http_header_decoder_platform_test = b.addRunArtifact(http_header_decoder_platform_test);
-            run_http_header_decoder_platform_test.setEnvironmentVariable("ROC_HTTP_HEADER_DECODER_PREBUILT_EXE", http_app_installed_path);
-            if (run_args.len != 0) {
-                run_http_header_decoder_platform_test.addArgs(run_args);
-            }
-            build_test_zig_step.dependOn(&http_header_decoder_platform_test.step);
-            if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(http_header_decoder_platform_test);
-            run_http_header_decoder_platform_test.step.dependOn(final_http_host_step);
-            run_http_header_decoder_platform_test.step.dependOn(&install_http_app.step);
-            run_http_header_decoder_platform_test.step.dependOn(build_roc_step);
-
-            const run_http_header_decoder_platform_test_for_summary = b.addRunArtifact(http_header_decoder_platform_test);
-            run_http_header_decoder_platform_test_for_summary.setEnvironmentVariable("ROC_HTTP_HEADER_DECODER_PREBUILT_EXE", http_app_installed_path);
-            if (run_args.len != 0) {
-                run_http_header_decoder_platform_test_for_summary.addArgs(run_args);
-            }
-            run_http_header_decoder_platform_test_for_summary.step.dependOn(final_http_host_step);
-            run_http_header_decoder_platform_test_for_summary.step.dependOn(&install_http_app.step);
-            run_http_header_decoder_platform_test_for_summary.step.dependOn(build_roc_step);
-            tests_summary.addRun(&run_http_header_decoder_platform_test_for_summary.step);
-
-            const run_http_header_decoder_platform_zig_test_step = b.step(
-                "run-test-zig-http-header-decoder-platform",
-                "Run HTTP header Decoder platform Zig test",
-            );
-            run_http_header_decoder_platform_zig_test_step.dependOn(&run_http_header_decoder_platform_test.step);
+            test_suites.register(.{
+                .step_suffix = "http-header-decoder-platform",
+                .description = "Run HTTP header Decoder platform Zig test",
+                .compile = http_header_decoder_platform_test,
+                .deps = &.{
+                    final_http_host_step,
+                    &install_http_app.step,
+                    build_roc_step,
+                },
+                .env = &.{
+                    .{ .key = "ROC_HTTP_HEADER_DECODER_PREBUILT_EXE", .value = http_app_installed_path },
+                },
+            });
 
             const json_decoder_host_lib = createTestPlatformHostLib(
                 b,
@@ -5689,40 +5666,23 @@ pub fn build(b: *std.Build) void {
                 .filters = test_filters,
             });
 
-            const run_json_decoder_platform_test = b.addRunArtifact(json_decoder_platform_test);
-            run_json_decoder_platform_test.setEnvironmentVariable("ROC_JSON_DECODER_PREBUILT_EXE", json_app_installed_path);
-            run_json_decoder_platform_test.setEnvironmentVariable("ROC_JSON_DECODER_CAMEL_PREBUILT_EXE", json_camel_app_installed_path);
-            run_json_decoder_platform_test.setEnvironmentVariable("ROC_JSON_DECODER_CAMEL_DIRECT_PREBUILT_EXE", json_camel_direct_app_installed_path);
-            if (run_args.len != 0) {
-                run_json_decoder_platform_test.addArgs(run_args);
-            }
-            build_test_zig_step.dependOn(&json_decoder_platform_test.step);
-            if (enumerate_tests_for_wiring_check) run_test_wiring.addArtifactArg(json_decoder_platform_test);
-            run_json_decoder_platform_test.step.dependOn(final_json_host_step);
-            run_json_decoder_platform_test.step.dependOn(&install_json_app.step);
-            run_json_decoder_platform_test.step.dependOn(&install_json_camel_app.step);
-            run_json_decoder_platform_test.step.dependOn(&install_json_camel_direct_app.step);
-            run_json_decoder_platform_test.step.dependOn(build_roc_step);
-
-            const run_json_decoder_platform_test_for_summary = b.addRunArtifact(json_decoder_platform_test);
-            run_json_decoder_platform_test_for_summary.setEnvironmentVariable("ROC_JSON_DECODER_PREBUILT_EXE", json_app_installed_path);
-            run_json_decoder_platform_test_for_summary.setEnvironmentVariable("ROC_JSON_DECODER_CAMEL_PREBUILT_EXE", json_camel_app_installed_path);
-            run_json_decoder_platform_test_for_summary.setEnvironmentVariable("ROC_JSON_DECODER_CAMEL_DIRECT_PREBUILT_EXE", json_camel_direct_app_installed_path);
-            if (run_args.len != 0) {
-                run_json_decoder_platform_test_for_summary.addArgs(run_args);
-            }
-            run_json_decoder_platform_test_for_summary.step.dependOn(final_json_host_step);
-            run_json_decoder_platform_test_for_summary.step.dependOn(&install_json_app.step);
-            run_json_decoder_platform_test_for_summary.step.dependOn(&install_json_camel_app.step);
-            run_json_decoder_platform_test_for_summary.step.dependOn(&install_json_camel_direct_app.step);
-            run_json_decoder_platform_test_for_summary.step.dependOn(build_roc_step);
-            tests_summary.addRun(&run_json_decoder_platform_test_for_summary.step);
-
-            const run_json_decoder_platform_zig_test_step = b.step(
-                "run-test-zig-json-decoder-platform",
-                "Run JSON Decoder platform Zig test",
-            );
-            run_json_decoder_platform_zig_test_step.dependOn(&run_json_decoder_platform_test.step);
+            test_suites.register(.{
+                .step_suffix = "json-decoder-platform",
+                .description = "Run JSON Decoder platform Zig test",
+                .compile = json_decoder_platform_test,
+                .deps = &.{
+                    final_json_host_step,
+                    &install_json_app.step,
+                    &install_json_camel_app.step,
+                    &install_json_camel_direct_app.step,
+                    build_roc_step,
+                },
+                .env = &.{
+                    .{ .key = "ROC_JSON_DECODER_PREBUILT_EXE", .value = json_app_installed_path },
+                    .{ .key = "ROC_JSON_DECODER_CAMEL_PREBUILT_EXE", .value = json_camel_app_installed_path },
+                    .{ .key = "ROC_JSON_DECODER_CAMEL_DIRECT_PREBUILT_EXE", .value = json_camel_direct_app_installed_path },
+                },
+            });
         }
     }
 

--- a/build.zig
+++ b/build.zig
@@ -5762,7 +5762,7 @@ fn assertGranularTestStepsAreIsolated(b: *std.Build) void {
         collectTestRuns(b, &tls.step, &visited, &found, &found_len);
 
         if (found_len > 1) {
-            std.log.warn(
+            std.debug.panic(
                 "build.zig: step \"{s}\" runs at least {d} test binaries ({s}, {s}, ...). " ++
                     "A granular run-test-zig-* step must run exactly one; wire the suite " ++
                     "through TestSuiteRegistry.register rather than handing the summary's " ++

--- a/src/base/LowLevelBuiltins.zig
+++ b/src/base/LowLevelBuiltins.zig
@@ -206,9 +206,17 @@ pub fn listEq(elem: ListEqElem) BuiltinFn {
     };
 }
 
-/// Hasher primitives. Scalar writes funnel into the width-normalized
-/// wrappers (everything up to 64 bits hashes through `hasher_write_u64`;
-/// f64 and Dec share `hasher_write_f64_bits`).
+/// Hasher primitives. Scalar writes funnel into the width-normalized wrappers:
+/// everything up to 64 bits hashes through `hasher_write_u64`, and `Dec` --
+/// which is a 128-bit fixed-point value, not a float -- hashes through
+/// `hasher_write_u128` alongside u128/i128.
+///
+/// `Dec` used to be mapped onto `hasher_write_f64_bits` here. That wrapper takes
+/// (seed, bits), while the 128-bit wrapper takes (seed, domain, low, high), so
+/// the one caller that passes a runtime `op` rather than a comptime literal --
+/// the LLVM backend -- emitted a four-argument call to a two-parameter function.
+/// The Dec's actual value was never read, and Dict lookups on Dec-keyed records
+/// and tuples returned KeyNotFound on x86_64-windows.
 pub fn hasherOp(op: LowLevel) BuiltinFn {
     return switch (op) {
         .dict_pseudo_seed => .dict_pseudo_seed,
@@ -223,9 +231,9 @@ pub fn hasherOp(op: LowLevel) BuiltinFn {
         .hasher_write_i32,
         .hasher_write_i64,
         => .hasher_write_u64,
-        .hasher_write_u128, .hasher_write_i128 => .hasher_write_u128,
+        .hasher_write_u128, .hasher_write_i128, .hasher_write_dec => .hasher_write_u128,
         .hasher_write_f32 => .hasher_write_f32_bits,
-        .hasher_write_f64, .hasher_write_dec => .hasher_write_f64_bits,
+        .hasher_write_f64 => .hasher_write_f64_bits,
         .hasher_write_bytes => .hasher_write_bytes,
         .hasher_write_str => .hasher_write_str,
         else => unreachable,

--- a/src/build/modules.zig
+++ b/src/build/modules.zig
@@ -268,10 +268,17 @@ fn targetMatchesHost(target: ResolvedTarget) bool {
         target.result.abi == builtin.target.abi;
 }
 
-/// Represents a test module with its compilation and execution steps.
+/// Represents a test module's compilation step.
+///
+/// Deliberately does not carry a pre-made `Step.Run`. Every run of these
+/// binaries is created by `TestSuiteRegistry` in build.zig, which builds one
+/// run for the tests summary and a separate one for the public
+/// `run-test-zig-module-*` step. A ready-made run stored here is exactly the
+/// convenient thing to hand to `TestsSummaryStep.addRun` *and* to a public
+/// step -- which is how eleven other suites ended up sharing one run and, on
+/// Windows, dragging the whole serialization chain behind them.
 pub const ModuleTest = struct {
     test_step: *Step.Compile,
-    run_step: *Step.Run,
 };
 
 /// Bundles the per-module test steps with accounting for forced passes (aggregators +
@@ -801,11 +808,8 @@ pub const RocModules = struct {
                 }
             }
 
-            const run_step = b.addRunArtifact(test_step);
-
             tests[i] = .{
                 .test_step = test_step,
-                .run_step = run_step,
             };
         }
 

--- a/src/build/test_harness.zig
+++ b/src/build/test_harness.zig
@@ -1,16 +1,24 @@
 //! Shared runtime harness for parallel test runners.
 //!
-//! Provides a comptime-generic fork-based process pool, timing statistics,
-//! pipe I/O helpers, and standardized CLI argument parsing. Used by:
+//! Provides a comptime-generic process pool, timing statistics, pipe I/O
+//! helpers, and standardized CLI argument parsing. Used by:
 //! - src/eval/test/parallel_runner.zig (eval expression tests)
+//! - src/eval/test/lambda_mono_differential_runner.zig (body-lowering differential)
+//! - src/eval/test/host_effects_runner.zig (runtime host-effects tests)
 //! - src/cli/test/parallel_cli_runner.zig (platform integration tests)
+//! - src/lsp/test/parallel_integration_runner.zig (LSP integration tests)
 //!
-//! The pool forks child processes, each running one test. Results are
-//! serialized over a pipe and collected by the single-threaded parent.
+//! On POSIX the pool forks child processes, each running one test; results
+//! are serialized over a pipe and collected by the single-threaded parent.
+//! On Windows the pool spawns worker copies of the runner binary instead
+//! (`ProcessPool.runChildPool`), driven through `--worker <idx>` /
+//! `--worker-stream`; the worker side of that protocol lives in
+//! `ProcessPool.runWorkerMode` so every runner shares one implementation.
 
 const std = @import("std");
 const builtin = @import("builtin");
 const build_options = @import("build_options");
+const collections = @import("collections");
 const posix = std.posix;
 const Allocator = std.mem.Allocator;
 
@@ -380,6 +388,15 @@ pub fn writeAll(fd: posix.fd_t, data: []const u8) void {
     }
 }
 
+/// Write the u32 length prefix that frames one persistent-worker-mode result.
+/// The runner's raw serializer must write exactly `payload_len` bytes next;
+/// the parent (`ProcessPool.workerThread`) reads the prefix, then that many
+/// payload bytes, to frame results sharing the worker's stdout pipe.
+pub fn writeFrameHeader(fd: posix.fd_t, payload_len: usize) void {
+    const length: u32 = @intCast(payload_len);
+    writeAll(fd, std.mem.asBytes(&length));
+}
+
 /// Read a string of given length from buffer, advancing offset. Dupe into gpa.
 pub fn readStr(buf: []const u8, offset: *usize, len: u32, gpa: Allocator) ?[]const u8 {
     if (len == 0) return null;
@@ -610,6 +627,42 @@ pub fn workerTemplateArgConsumesValue(arg: []const u8) bool {
 /// Returns true when a worker argv flag should be removed by itself.
 pub fn workerTemplateDropsFlag(arg: []const u8) bool {
     return std.mem.eql(u8, arg, "--worker-stream");
+}
+
+/// Errors from `buildWorkerArgvTemplate`.
+pub const WorkerArgvError = Allocator.Error || std.process.ExecutablePathError || std.process.Args.ToSliceError;
+
+/// Build the argv template the Windows Child-based executor uses to re-invoke
+/// the current binary as a worker: the executable path followed by every
+/// original argument except per-worker flags (`--worker N`,
+/// `--worker-backend NAME`, `--stats-json PATH`) and the `--worker-stream`
+/// mode flag, which the pool appends itself. Selection flags (filters,
+/// suites, positionals) survive so parent and worker derive identical spec
+/// lists and protocol indices stay aligned. On POSIX the template is unused
+/// (children fork in place); build it unconditionally for a uniform call site.
+pub fn buildWorkerArgvTemplate(io: std.Io, arena: Allocator, process_args: std.process.Args) WorkerArgvError![]const []const u8 {
+    var self_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const self_path_len = try std.process.executablePath(io, &self_path_buf);
+    const self_path = try arena.dupe(u8, self_path_buf[0..self_path_len]);
+
+    const raw = try process_args.toSlice(arena);
+    const original_args: []const []const u8 = @ptrCast(raw);
+
+    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
+    try argv.append(arena, self_path);
+
+    var i: usize = 1;
+    while (i < original_args.len) : (i += 1) {
+        const arg = original_args[i];
+        if (workerTemplateArgConsumesValue(arg)) {
+            i += 1;
+            continue;
+        }
+        if (workerTemplateDropsFlag(arg)) continue;
+        try argv.append(arena, arg);
+    }
+
+    return try argv.toOwnedSlice(arena);
 }
 
 /// Writes a self-contained runner stats JSON file.
@@ -906,7 +959,24 @@ pub fn PoolConfig(comptime Spec: type, comptime Result: type) type {
         /// and the same timeout budget enforced by the parent watchdog.
         runTest: *const fn (std.Io, Allocator, Spec, u64) Result,
         /// Serialize a result to the pipe fd.
+        ///
+        /// TODO(follow-up PR): unify `serialize` and `serializeStreamed` into
+        /// one buffer-building serializer
+        /// (`fn (*std.ArrayListUnmanaged(u8), Allocator, Result) void`) and
+        /// have the pool write the buffer raw (fork pipe / one-shot worker)
+        /// or behind a `writeFrameHeader` prefix (persistent worker). Every
+        /// runner currently carries both variants of the same wire format.
+        /// Deliberately NOT unified in this PR: doing so rewrites the POSIX
+        /// fork-path serializers of every Unix runner at the same time as the
+        /// Windows worker-pool change, which would make it hard to attribute
+        /// any performance shift to one change or the other.
         serialize: *const fn (posix.fd_t, Result) void,
+        /// Streamed variant of `serialize` for persistent worker mode: writes
+        /// the same wire bytes behind a u32 length prefix (`writeFrameHeader`)
+        /// so many results can share a worker's stdout pipe. Called by
+        /// `runWorkerMode` under `--worker-stream`. See the unification TODO
+        /// on `serialize`.
+        serializeStreamed: *const fn (posix.fd_t, Result) void,
         /// Deserialize a result from the accumulated pipe buffer.
         deserialize: *const fn ([]const u8, Allocator) ?Result,
         /// Default result for crash/timeout (before deserialization).
@@ -933,6 +1003,10 @@ pub fn PoolConfig(comptime Spec: type, comptime Result: type) type {
         /// Called from the parent thread right before launching each test.
         /// Use for "RUN <name>" logging — keeps it coherent across N workers.
         onTestStarted: ?*const fn (Spec) void = null,
+        /// Restrict a spec to one named backend when the parent passes
+        /// `--worker-backend <name>` alongside `--worker <idx>` (Phase-2
+        /// crash attribution). The runner interprets the name.
+        applyWorkerBackend: ?*const fn (*Spec, []const u8) void = null,
     };
 }
 
@@ -1245,6 +1319,57 @@ pub fn ProcessPool(comptime Spec: type, comptime Result: type, comptime cfg: Poo
 
             if (is_tty) {
                 std.debug.print("\r{s}\r", .{" " ** 72});
+            }
+        }
+
+        /// Run this process as one pool worker when the parent spawned it
+        /// with `--worker <idx>` (single-shot: run that spec, serialize the
+        /// result to stdout, exit) or `--worker-stream` (persistent: read
+        /// decimal spec indices from stdin one per line, write a
+        /// u32-length-prefixed result frame per index, loop until stdin
+        /// EOFs). Returns true when the process served as a worker and the
+        /// caller must return without starting its own pool — a worker that
+        /// fell through would recursively spawn workers. The caller must pass
+        /// the same specs, in the same order, that the parent pool sees:
+        /// `buildWorkerArgvTemplate` preserves every selection flag so both
+        /// sides derive identical spec lists, keeping protocol indices
+        /// aligned.
+        pub fn runWorkerMode(io: std.Io, cli: StandardArgs, specs: []const Spec, timeout_ms: u64) bool {
+            if (cli.worker_index) |idx| {
+                if (idx >= specs.len) std.process.exit(2);
+                var spec = specs[idx];
+                if (cli.worker_backend) |backend| {
+                    if (cfg.applyWorkerBackend) |apply| apply(&spec, backend);
+                }
+                var arena = collections.SingleThreadArena.init(std.heap.smp_allocator);
+                defer arena.deinit();
+                const result = cfg.runTest(io, arena.allocator(), spec, timeoutForSpec(spec, timeout_ms));
+                cfg.serialize(stdoutFd(), result);
+                return true;
+            }
+            if (!cli.worker_stream) return false;
+
+            var arena = collections.SingleThreadArena.init(std.heap.smp_allocator);
+            defer arena.deinit();
+            const stdout_handle = stdoutFd();
+            const stdin_handle = stdinFd();
+
+            var line_buf: [32]u8 = undefined;
+            while (true) {
+                var line_len: usize = 0;
+                const line = while (true) {
+                    if (line_len >= line_buf.len) return true; // malformed index line
+                    const n = posixRead(stdin_handle, line_buf[line_len .. line_len + 1]) catch return true;
+                    if (n == 0) return true; // EOF — parent is done
+                    if (line_buf[line_len] == '\n') break line_buf[0..line_len];
+                    line_len += 1;
+                };
+                const idx = std.fmt.parseInt(usize, line, 10) catch continue;
+                if (idx >= specs.len) continue;
+
+                _ = arena.reset(.retain_capacity);
+                const result = cfg.runTest(io, arena.allocator(), specs[idx], timeoutForSpec(specs[idx], timeout_ms));
+                cfg.serializeStreamed(stdout_handle, result);
             }
         }
 

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -893,8 +893,11 @@ pub fn writeFdCoordinationFile(ctx: *CliCtx, temp_exe_path: []const u8, shm_hand
     };
     defer fd_file.close(ctx.io.std_io);
 
-    // Write shared memory info to file
-    const fd_str = try std.fmt.allocPrint(ctx.arena, "{}\n{}", .{ shm_handle.fd, shm_handle.size });
+    // Write shared memory info to file. The handle is written as a plain
+    // integer on both platforms -- on Windows it is a HANDLE (a pointer), and
+    // `ipc.coordination.parseHandle` turns the integer back into one.
+    const handle_int = if (is_windows) @intFromPtr(shm_handle.fd) else shm_handle.fd;
+    const fd_str = try std.fmt.allocPrint(ctx.arena, "{}\n{}", .{ handle_int, shm_handle.size });
     try fd_file.writeStreamingAll(ctx.io.std_io, fd_str);
     try fd_file.sync(ctx.io.std_io);
 }
@@ -3353,15 +3356,31 @@ fn runWithWindowsHandleInheritance(ctx: *CliCtx, exe_path: []const u8, shm_handl
         } }),
     };
 
-    // Create command line with handle and size as arguments, plus any app arguments
-    const handle_uint = @intFromPtr(shm_handle.fd);
+    // Hand the shared-memory handle and size to the child out of band, the same
+    // way the POSIX path does.
+    //
+    // These used to be passed as the first two command-line arguments. That put
+    // them in the child's argv, where the platform host has no way to tell them
+    // apart from the user's arguments and passes them straight through to the
+    // Roc application: `roc --opt=interpreter app.roc` gave the app
+    // `["...app.roc.exe", "448", "976608"]` instead of just the executable path.
+    // No platform host can be expected to know about roc's IPC plumbing, and
+    // none of them compensate for it, so keep argv clean instead.
+    writeFdCoordinationFile(ctx, exe_path, shm_handle) catch |err| {
+        const temp_dir = std.fs.path.dirname(exe_path) orelse exe_path;
+        const fd_file_path = std.fmt.allocPrint(ctx.arena, "{s}.txt", .{temp_dir}) catch exe_path;
+        return ctx.fail(.{ .file_write_failed = .{
+            .path = fd_file_path,
+            .err = err,
+        } });
+    };
 
     // Build command line string with proper quoting for Windows
     var cmd_builder = std.array_list.Managed(u8).initCapacity(ctx.gpa, 256) catch {
         return error.OutOfMemory;
     };
     defer cmd_builder.deinit();
-    try cmd_builder.print("\"{s}\" {} {}", .{ exe_path, handle_uint, shm_handle.size });
+    try cmd_builder.print("\"{s}\"", .{exe_path});
     for (app_args) |arg| {
         try cmd_builder.append(' ');
         try appendWindowsQuotedArg(&cmd_builder, arg);
@@ -3650,29 +3669,24 @@ fn spawnHotShimChild(
     shm_handle: SharedMemoryHandle,
     app_args: []const []const u8,
 ) (CliError || Allocator.Error || std.Thread.SpawnError || std.process.SpawnError)!*HotShimChild {
-    if (comptime !is_windows) {
-        writeFdCoordinationFile(ctx, exe_path, shm_handle) catch |err| {
-            const temp_dir = std.fs.path.dirname(exe_path) orelse exe_path;
-            const fd_file_path = std.fmt.allocPrint(ctx.arena, "{s}.txt", .{temp_dir}) catch exe_path;
-            return ctx.fail(.{ .file_write_failed = .{
-                .path = fd_file_path,
-                .err = err,
-            } });
-        };
-    }
+    // Every platform hands the shared-memory handle and size to the child
+    // through the coordination file. Windows used to append them to argv
+    // instead, which leaked roc's IPC plumbing into the Roc application's
+    // arguments -- see the note in `runWithWindowsHandleInheritance`.
+    writeFdCoordinationFile(ctx, exe_path, shm_handle) catch |err| {
+        const temp_dir = std.fs.path.dirname(exe_path) orelse exe_path;
+        const fd_file_path = std.fmt.allocPrint(ctx.arena, "{s}.txt", .{temp_dir}) catch exe_path;
+        return ctx.fail(.{ .file_write_failed = .{
+            .path = fd_file_path,
+            .err = err,
+        } });
+    };
     try makeSharedMemoryHandleInheritable(ctx, shm_handle);
 
-    const coordination_arg_count: usize = if (comptime is_windows) 2 else 0;
-    const argv = try ctx.arena.alloc([]const u8, 1 + coordination_arg_count + app_args.len);
+    const argv = try ctx.arena.alloc([]const u8, 1 + app_args.len);
     argv[0] = exe_path;
-    var app_arg_offset: usize = 1;
-    if (comptime is_windows) {
-        argv[1] = try std.fmt.allocPrint(ctx.arena, "{}", .{@intFromPtr(shm_handle.fd)});
-        argv[2] = try std.fmt.allocPrint(ctx.arena, "{}", .{shm_handle.size});
-        app_arg_offset = 3;
-    }
     for (app_args, 0..) |arg, i| {
-        argv[app_arg_offset + i] = arg;
+        argv[1 + i] = arg;
     }
 
     const child = std.process.spawn(ctx.io.std_io, .{

--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -814,8 +814,8 @@ test "fx platform run from different cwd" {
     // Get absolute path to roc binary since we'll change cwd
     const roc_abs_path = try std.Io.Dir.cwd().realPathFileAlloc(std.testing.io, util.roc_binary_path, allocator);
     defer allocator.free(roc_abs_path);
-    var env_map = try util.buildIsolatedTestEnvMap(std.testing.io, allocator, null);
-    defer env_map.deinit();
+    var env = try util.buildIsolatedTestEnvMap(std.testing.io, allocator, null);
+    defer env.deinit(std.testing.io, allocator);
 
     // Run roc from the test/fx directory with a relative path to app.roc
     const run_result = try util.runChildWithTimeout(std.testing.io, allocator, &[_][]const u8{
@@ -823,7 +823,7 @@ test "fx platform run from different cwd" {
         "app.roc",
     }, .{
         .cwd = "test/fx",
-        .env_map = &env_map,
+        .env_map = &env.env_map,
         .max_output_bytes = 10 * 1024 * 1024,
     });
     defer allocator.free(run_result.stdout);
@@ -1478,8 +1478,8 @@ test "fx platform invalid nested where-clause static dispatch fails in check" {
     // must reject the where-clause contract before post-check lowering.
     const allocator = testing.allocator;
 
-    var env_map = try util.buildIsolatedTestEnvMap(std.testing.io, allocator, null);
-    defer env_map.deinit();
+    var env = try util.buildIsolatedTestEnvMap(std.testing.io, allocator, null);
+    defer env.deinit(std.testing.io, allocator);
 
     const check_result = try util.runChildWithTimeout(std.testing.io, allocator, &[_][]const u8{
         util.roc_binary_path,
@@ -1487,7 +1487,7 @@ test "fx platform invalid nested where-clause static dispatch fails in check" {
         "--no-cache",
         "test/fx/nested_static_dispatch_where_repro.roc",
     }, .{
-        .env_map = &env_map,
+        .env_map = &env.env_map,
         .max_output_bytes = 10 * 1024 * 1024,
     });
     defer allocator.free(check_result.stdout);
@@ -1519,8 +1519,8 @@ test "fx platform valid nested where-clause static dispatch builds" {
     const output_arg = try std.fmt.allocPrint(allocator, "--output={s}", .{output_path});
     defer allocator.free(output_arg);
 
-    var env_map = try util.buildIsolatedTestEnvMap(std.testing.io, allocator, null);
-    defer env_map.deinit();
+    var env = try util.buildIsolatedTestEnvMap(std.testing.io, allocator, null);
+    defer env.deinit(std.testing.io, allocator);
 
     const build_result = try util.runChildWithTimeout(std.testing.io, allocator, &[_][]const u8{
         util.roc_binary_path,
@@ -1531,7 +1531,7 @@ test "fx platform valid nested where-clause static dispatch builds" {
         output_arg,
         "test/fx/nested_static_dispatch_where_valid.roc",
     }, .{
-        .env_map = &env_map,
+        .env_map = &env.env_map,
         .max_output_bytes = 10 * 1024 * 1024,
     });
     defer allocator.free(build_result.stdout);
@@ -1548,8 +1548,8 @@ test "fx platform valid nested where-clause static dispatch builds" {
 test "fx platform divergent if with all crash branches does not hit postcheck invariant" {
     const allocator = testing.allocator;
 
-    var env_map = try util.buildIsolatedTestEnvMap(std.testing.io, allocator, null);
-    defer env_map.deinit();
+    var env = try util.buildIsolatedTestEnvMap(std.testing.io, allocator, null);
+    defer env.deinit(std.testing.io, allocator);
 
     const build_result = try util.runChildWithTimeout(std.testing.io, allocator, &[_][]const u8{
         util.roc_binary_path,
@@ -1557,7 +1557,7 @@ test "fx platform divergent if with all crash branches does not hit postcheck in
         "--no-cache",
         "test/fx/divergent_if_all_branches_crash_repro.roc",
     }, .{
-        .env_map = &env_map,
+        .env_map = &env.env_map,
         .max_output_bytes = 10 * 1024 * 1024,
     });
     defer allocator.free(build_result.stdout);

--- a/src/cli/test/http_header_decoder_platform_test.zig
+++ b/src/cli/test/http_header_decoder_platform_test.zig
@@ -100,8 +100,8 @@ test "HTTP header parsing platform derives structural parser without runtime all
     defer allocator.free(output_path);
 
     if (prebuilt_path == null) {
-        var env_map = try util.buildIsolatedTestEnvMap(io, allocator, null);
-        defer env_map.deinit();
+        var env = try util.buildIsolatedTestEnvMap(io, allocator, null);
+        defer env.deinit(io, allocator);
 
         const target_arg = try std.fmt.allocPrint(allocator, "--target={s}", .{target_name});
         defer allocator.free(target_arg);
@@ -117,7 +117,7 @@ test "HTTP header parsing platform derives structural parser without runtime all
             output_arg,
             "test/http-headers/app.roc",
         }, .{
-            .env_map = &env_map,
+            .env_map = &env.env_map,
             .max_output_bytes = 10 * 1024 * 1024,
         });
         defer allocator.free(build_result.stdout);

--- a/src/cli/test/json_decoder_platform_test.zig
+++ b/src/cli/test/json_decoder_platform_test.zig
@@ -108,11 +108,11 @@ test "JSON parsing platform derives structural parser without runtime allocation
         try std.fs.path.join(allocator, &.{ tmp_path, camel_direct_exe_name });
     defer allocator.free(camel_direct_output_path);
 
-    var env_map = try util.buildIsolatedTestEnvMap(io, allocator, null);
-    defer env_map.deinit();
+    var env = try util.buildIsolatedTestEnvMap(io, allocator, null);
+    defer env.deinit(io, allocator);
 
     if (prebuilt_path == null) {
-        try buildRocApp(allocator, &env_map, target_name, output_path, "test/json-decoder/app.roc");
+        try buildRocApp(allocator, &env.env_map, target_name, output_path, "test/json-decoder/app.roc");
     }
 
     for (0..8) |case_index| {
@@ -160,7 +160,7 @@ test "JSON parsing platform derives structural parser without runtime allocation
     try runJsonDecoderAndCheckInvalidUtf8(allocator, output_path);
 
     if (camel_prebuilt_path == null) {
-        try buildRocApp(allocator, &env_map, target_name, camel_output_path, "test/json-decoder/camel_app.roc");
+        try buildRocApp(allocator, &env.env_map, target_name, camel_output_path, "test/json-decoder/camel_app.roc");
     }
     try expectBinaryOmits(allocator, camel_output_path, &.{ "cache_control", "first_value", "inner_value", "nested_record", "second_value", "user_id" });
     try runJsonDecoderAndCheckOutput(
@@ -171,7 +171,7 @@ test "JSON parsing platform derives structural parser without runtime allocation
     );
 
     if (camel_direct_prebuilt_path == null) {
-        try buildRocApp(allocator, &env_map, target_name, camel_direct_output_path, "test/json-decoder/camel_direct_app.roc");
+        try buildRocApp(allocator, &env.env_map, target_name, camel_direct_output_path, "test/json-decoder/camel_direct_app.roc");
     }
     try runJsonDecoderAndCheckOutput(
         allocator,

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -1353,15 +1353,17 @@ const TestResult = struct {
     message: ?[]const u8 = null,
 };
 
-fn serializeResult(fd: posix.fd_t, result: TestResult) void {
-    const stderr_data = result.stderr_capture orelse "";
-    const stdout_data = result.stdout_capture orelse "";
-    const message_data = result.message orelse "";
+const max_capture = 8192;
 
-    const max_capture = 8192;
-    const stderr_out = stderr_data[0..@min(stderr_data.len, max_capture)];
-    const stdout_out = stdout_data[0..@min(stdout_data.len, max_capture)];
-    const message_out = message_data[0..@min(message_data.len, max_capture)];
+fn cappedCapture(data: ?[]const u8) []const u8 {
+    const bytes = data orelse "";
+    return bytes[0..@min(bytes.len, max_capture)];
+}
+
+fn serializeResult(fd: posix.fd_t, result: TestResult) void {
+    const stderr_out = cappedCapture(result.stderr_capture);
+    const stdout_out = cappedCapture(result.stdout_capture);
+    const message_out = cappedCapture(result.message);
 
     const header = WireHeader{
         .status = @intFromEnum(result.status),
@@ -1381,37 +1383,15 @@ fn serializeResult(fd: posix.fd_t, result: TestResult) void {
     harness.writeAll(fd, message_out);
 }
 
-/// Streamed variant for persistent worker mode: writes a `u32` length prefix
-/// before the wire bytes so the parent can frame multiple results sharing
-/// the same stdout pipe.
+/// Streamed variant for persistent worker mode: the same wire bytes behind a
+/// u32 frame-length prefix.
 fn serializeResultStreamed(fd: posix.fd_t, result: TestResult) void {
-    const stderr_data = result.stderr_capture orelse "";
-    const stdout_data = result.stdout_capture orelse "";
-    const message_data = result.message orelse "";
-
-    const max_capture = 8192;
-    const stderr_out = stderr_data[0..@min(stderr_data.len, max_capture)];
-    const stdout_out = stdout_data[0..@min(stdout_data.len, max_capture)];
-    const message_out = message_data[0..@min(message_data.len, max_capture)];
-
-    const header = WireHeader{
-        .status = @intFromEnum(result.status),
-        .phase = @intFromEnum(result.phase),
-        .duration_ns = result.duration_ns,
-        .build_ns = result.build_ns,
-        .run_ns = result.run_ns,
-        .exit_code = result.exit_code,
-        .stderr_len = @intCast(stderr_out.len),
-        .stdout_len = @intCast(stdout_out.len),
-        .message_len = @intCast(message_out.len),
-    };
-
-    const length: u32 = @intCast(@sizeOf(WireHeader) + stderr_out.len + stdout_out.len + message_out.len);
-    harness.writeAll(fd, std.mem.asBytes(&length));
-    harness.writeAll(fd, std.mem.asBytes(&header));
-    harness.writeAll(fd, stderr_out);
-    harness.writeAll(fd, stdout_out);
-    harness.writeAll(fd, message_out);
+    const payload_len = @sizeOf(WireHeader) +
+        cappedCapture(result.stderr_capture).len +
+        cappedCapture(result.stdout_capture).len +
+        cappedCapture(result.message).len;
+    harness.writeFrameHeader(fd, payload_len);
+    serializeResult(fd, result);
 }
 
 fn deserializeResult(buf: []const u8, gpa: Allocator) ?TestResult {
@@ -7814,33 +7794,6 @@ fn customGlueCTests(io: std.Io, allocator: Allocator, env: *const CaseEnv, timer
 /// this runner. Starts with `selfExePath`, then preserves every original arg
 /// *except* `--worker N` / `--worker-backend NAME` (stripped to avoid
 /// duplication when the harness appends `--worker <idx>` per spawn).
-fn buildCliWorkerArgvTemplate(io: std.Io, arena: Allocator, process_args: std.process.Args) CliRunnerError![]const []const u8 {
-    var self_path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const self_path_len = try std.process.executablePath(io, &self_path_buf);
-    const self_path = try arena.dupe(u8, self_path_buf[0..self_path_len]);
-
-    const raw = try process_args.toSlice(arena);
-    const original_args: []const []const u8 = @ptrCast(raw);
-
-    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
-    try argv.append(arena, self_path);
-
-    var i: usize = 1;
-    while (i < original_args.len) : (i += 1) {
-        const arg = original_args[i];
-        if (harness.workerTemplateArgConsumesValue(arg)) {
-            i += 1;
-            continue;
-        }
-        if (harness.workerTemplateDropsFlag(arg)) {
-            continue;
-        }
-        try argv.append(arena, arg);
-    }
-
-    return try argv.toOwnedSlice(arena);
-}
-
 fn getTestName(spec: CliCase) []const u8 {
     return spec.name;
 }
@@ -7868,6 +7821,7 @@ fn stabilizeResult(gpa: Allocator, result: TestResult) TestResult {
 const Pool = harness.ProcessPool(CliCase, TestResult, .{
     .runTest = &runSingleTest,
     .serialize = &serializeResult,
+    .serializeStreamed = &serializeResultStreamed,
     .deserialize = &deserializeResult,
     .default_result = .{ .status = .crash },
     .timeout_result = .{ .status = .timeout },
@@ -8386,50 +8340,13 @@ pub fn main(init: std.process.Init) CliRunnerError!void {
     if (tests.len == 0) return;
     const timeout_ms = effectiveTimeoutMs(args, parsed.suites);
 
-    // Worker mode: parent spawned us with `--worker <idx>` to run a single
-    // test and serialize the result to stdout. Used on Windows where the
-    // harness runs N worker processes in parallel instead of forking.
-    if (args.worker_index) |idx| {
-        if (idx >= tests.len) std.process.exit(2);
-        var arena = collections.SingleThreadArena.init(std.heap.smp_allocator);
-        defer arena.deinit();
-        const result = runSingleTest(init.io, arena.allocator(), tests[idx], timeout_ms);
-        serializeResult(std.Io.File.stdout().handle, result);
-        return;
-    }
-
-    // Persistent worker mode: read test indices from stdin (one decimal per
-    // line), run each, write a u32-length-prefixed result to stdout, loop
-    // until stdin EOFs. Amortizes the per-Child process-boot cost across
-    // many tests on the same worker. Without this branch, a worker spawned
-    // with `--worker-stream` would fall through to the parent path below
-    // and reentrantly spawn its own pool of workers — fork-bombing the box.
-    if (args.worker_stream) {
-        var arena = collections.SingleThreadArena.init(std.heap.smp_allocator);
-        defer arena.deinit();
-
-        const stdin_handle = std.Io.File.stdin().handle;
-        const stdout_handle = std.Io.File.stdout().handle;
-
-        var line_buf: [32]u8 = undefined;
-        outer: while (true) {
-            var line_len: usize = 0;
-            while (true) {
-                if (line_len >= line_buf.len) break :outer;
-                const n = harness.posixRead(stdin_handle, line_buf[line_len .. line_len + 1]) catch break :outer;
-                if (n == 0) break :outer;
-                if (line_buf[line_len] == '\n') break;
-                line_len += 1;
-            }
-            const idx = std.fmt.parseInt(usize, line_buf[0..line_len], 10) catch continue;
-            if (idx >= tests.len) continue;
-
-            _ = arena.reset(.retain_capacity);
-            const result = runSingleTest(init.io, arena.allocator(), tests[idx], timeout_ms);
-            serializeResultStreamed(stdout_handle, result);
-        }
-        return;
-    }
+    // Worker modes: on Windows the harness pool spawned this process with
+    // `--worker <idx>` (single test) or `--worker-stream` (persistent). The
+    // worker rebuilt the same case list above, so indices stay aligned with
+    // the parent's. Handling these before the parent path matters: a worker
+    // that fell through would reentrantly spawn its own pool of workers —
+    // fork-bombing the box.
+    if (Pool.runWorkerMode(init.io, args, tests, timeout_ms)) return;
 
     const cpu_count = std.Thread.getCpuCount() catch 4;
     const max_children = args.max_threads orelse @min(cpu_count, tests.len);
@@ -8459,7 +8376,7 @@ pub fn main(init: std.process.Init) CliRunnerError!void {
     // single-test Child worker. On POSIX it's unused (fork path doesn't
     // re-exec). Always pass the positional `roc_binary` path through so the
     // child uses the same binary.
-    const worker_argv_template = try buildCliWorkerArgvTemplate(init.io, spec_arena.allocator(), init.minimal.args);
+    const worker_argv_template = try harness.buildWorkerArgvTemplate(init.io, spec_arena.allocator(), init.minimal.args);
 
     var wall_timer = harness.Timer.start() catch @panic("no clock");
     Pool.runWithSpans(init.io, tests, results, spans, max_children, timeout_ms, gpa, worker_argv_template);

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -2328,9 +2328,13 @@ fn customCliCacheRootsDistinct(io: std.Io, allocator: Allocator, timer: *harness
     const first = util.createIsolatedTestCacheDirs(io, allocator) catch |err|
         return customInfraFailure(allocator, timer, "failed to create first cache dirs: {}", .{err});
     defer first.deinit(allocator);
+    // Registered after the deinit defers so they run first, and after the
+    // openability assertions below, which need the directories to still exist.
+    defer util.cleanupTestCacheDirs(io, first);
     const second = util.createIsolatedTestCacheDirs(io, allocator) catch |err|
         return customInfraFailure(allocator, timer, "failed to create second cache dirs: {}", .{err});
     defer second.deinit(allocator);
+    defer util.cleanupTestCacheDirs(io, second);
 
     if (std.mem.eql(u8, first.roc_cache_dir, second.roc_cache_dir)) {
         return customFailure(allocator, timer, "ROC_CACHE_DIR paths were not distinct", .{});

--- a/src/cli/test/runner_core.zig
+++ b/src/cli/test/runner_core.zig
@@ -56,6 +56,9 @@ fn runRocChildWithOutputLimit(allocator: Allocator, std_io: std.Io, argv: []cons
     // another's cache state.
     const cache_dirs = try util.createIsolatedTestCacheDirs(std_io, allocator);
     defer cache_dirs.deinit(allocator);
+    // This is the per-child-spawn path, so it is the dominant source of these
+    // trees: without this the CLI suite left one behind per subprocess.
+    defer util.cleanupTestCacheDirs(std_io, cache_dirs);
     try env_map.put("ROC_CACHE_DIR", cache_dirs.roc_cache_dir);
     try env_map.put("ZIG_LOCAL_CACHE_DIR", cache_dirs.zig_local_cache_dir);
 

--- a/src/cli/test/util.zig
+++ b/src/cli/test/util.zig
@@ -14,6 +14,10 @@ pub const default_child_timeout_ms: u64 = 5 * std.time.ms_per_min;
 
 /// Absolute cache directory paths reserved for a single CLI test subprocess.
 pub const IsolatedCacheDirs = struct {
+    /// The reserved tree that contains the three directories below. Kept so the
+    /// whole thing can be deleted again; without it there was nothing to pass to
+    /// deleteTree and these trees accumulated, one per subprocess, forever.
+    root: []u8,
     roc_cache_dir: []u8,
     zig_local_cache_dir: []u8,
     /// Per-subprocess temp dir; see TestProcessDirs.temp_dir for why this must
@@ -24,6 +28,7 @@ pub const IsolatedCacheDirs = struct {
         allocator.free(self.temp_dir);
         allocator.free(self.zig_local_cache_dir);
         allocator.free(self.roc_cache_dir);
+        allocator.free(self.root);
     }
 };
 
@@ -311,10 +316,32 @@ pub fn createIsolatedTestCacheDirs(io: std.Io, allocator: std.mem.Allocator) Tes
     try std.Io.Dir.cwd().createDirPath(io, temp_rel);
 
     return .{
+        .root = try std.fs.path.join(allocator, &.{ cwd_path, cache_root_rel }),
         .roc_cache_dir = try std.fs.path.join(allocator, &.{ cwd_path, roc_cache_rel }),
         .zig_local_cache_dir = try std.fs.path.join(allocator, &.{ cwd_path, zig_local_cache_rel }),
         .temp_dir = try std.fs.path.join(allocator, &.{ cwd_path, temp_rel }),
     };
+}
+
+/// Remove the per-subprocess cache tree reserved by createIsolatedTestCacheDirs.
+///
+/// Unlike the work dir, this is cleaned *unconditionally* rather than only on
+/// pass. Three reasons:
+///
+///   - It holds a private roc module cache and Zig local cache. Nothing in it
+///     is read by a human triaging a failure; the artifacts that are (compiled
+///     app, copied sources, watch inputs) live in the work dir, whose
+///     preserve-on-failure policy is deliberately left alone.
+///   - The scope that owns one of these trees is a single subprocess, which
+///     cannot see the test's verdict.
+///   - Keying it on the child's exit code would be actively wrong: many CLI
+///     cases assert a *non-zero* exit, so that rule would preserve a tree for
+///     most passing tests and delete it for failing ones.
+///
+/// Deletes the root rather than the three children, so the leaf directory goes
+/// too and the reservation counter stays honest.
+pub fn cleanupTestCacheDirs(io: std.Io, dirs: IsolatedCacheDirs) void {
+    std.Io.Dir.cwd().deleteTree(io, dirs.root) catch {};
 }
 
 /// Create unique Roc cache, Zig local cache, and work directories for one CLI test job.
@@ -350,14 +377,38 @@ pub fn cleanupTestWorkDir(io: std.Io, work_dir: []const u8) void {
     std.Io.Dir.cwd().deleteTree(io, work_dir) catch {};
 }
 
+/// An environment map for a test Roc subprocess, together with any scratch
+/// directories that were reserved on its behalf.
+///
+/// The directories are bundled with the map rather than returned separately so
+/// that a caller cannot take the environment and forget the cleanup: a single
+/// `defer env.deinit(io, allocator)` releases both.
+pub const IsolatedTestEnv = struct {
+    env_map: std.process.Environ.Map,
+    /// Null when the caller had already supplied all three cache variables, in
+    /// which case nothing was reserved and there is nothing to remove.
+    owned_cache: ?IsolatedCacheDirs,
+
+    pub fn deinit(self: *IsolatedTestEnv, io: std.Io, allocator: std.mem.Allocator) void {
+        self.env_map.deinit();
+        if (self.owned_cache) |dirs| {
+            cleanupTestCacheDirs(io, dirs);
+            dirs.deinit(allocator);
+        }
+    }
+};
+
 /// Build an environment map for a test Roc subprocess.
 /// Unless the caller already set them, this gives the subprocess unique Roc,
 /// URL package, and Zig local cache roots.
+///
+/// Returns the reserved directories alongside the map so the caller can delete
+/// them when the subprocess is done; see `IsolatedTestEnv`.
 pub fn buildIsolatedTestEnvMap(
     io: std.Io,
     allocator: std.mem.Allocator,
     extra_env: ?*const std.process.Environ.Map,
-) EnvMapError!std.process.Environ.Map {
+) EnvMapError!IsolatedTestEnv {
     // In Zig 0.16, Environ.Block is GlobalBlock on Windows (read from PEB on use) and
     // PosixBlock on POSIX (must point at std.c.environ).
     const environ: std.process.Environ = if (builtin.os.tag == .windows) .{
@@ -381,7 +432,10 @@ pub fn buildIsolatedTestEnvMap(
         env_map.get("ZIG_LOCAL_CACHE_DIR") == null)
     {
         const cache_dirs = try createIsolatedTestCacheDirs(io, allocator);
-        defer cache_dirs.deinit(allocator);
+        errdefer {
+            cleanupTestCacheDirs(io, cache_dirs);
+            cache_dirs.deinit(allocator);
+        }
 
         if (env_map.get("ROC_CACHE_DIR") == null) {
             try env_map.put("ROC_CACHE_DIR", cache_dirs.roc_cache_dir);
@@ -398,9 +452,11 @@ pub fn buildIsolatedTestEnvMap(
         // Isolate the temp dir too, so roc's background temp-cleanup thread
         // can't race other concurrent roc processes' temp files.
         try putIsolatedTempEnv(&env_map, cache_dirs.temp_dir);
+
+        return .{ .env_map = env_map, .owned_cache = cache_dirs };
     }
 
-    return env_map;
+    return .{ .env_map = env_map, .owned_cache = null };
 }
 
 fn runChild(
@@ -410,12 +466,12 @@ fn runChild(
     cwd_path: []const u8,
     extra_env: ?*const std.process.Environ.Map,
 ) RocRunError!RocResult {
-    var env_map = try buildIsolatedTestEnvMap(io, allocator, extra_env);
-    defer env_map.deinit();
+    var env = try buildIsolatedTestEnvMap(io, allocator, extra_env);
+    defer env.deinit(io, allocator);
 
     const result = try runChildWithTimeout(io, allocator, argv, .{
         .cwd = cwd_path,
-        .env_map = &env_map,
+        .env_map = &env.env_map,
         .max_output_bytes = 10 * 1024 * 1024, // 10MB
     });
 
@@ -604,11 +660,11 @@ pub fn runRocWithStdin(io: std.Io, allocator: std.mem.Allocator, args: []const [
     });
     defer allocator.free(argv);
 
-    var env_map = try buildIsolatedTestEnvMap(io, allocator, null);
-    defer env_map.deinit();
+    var env = try buildIsolatedTestEnvMap(io, allocator, null);
+    defer env.deinit(io, allocator);
     const result = try runChildWithTimeout(io, allocator, argv, .{
         .cwd = cwd_path,
-        .env_map = &env_map,
+        .env_map = &env.env_map,
         .max_output_bytes = 10 * 1024 * 1024,
         .stdin = stdin_input,
     });

--- a/src/eval/test/host_effects_runner.zig
+++ b/src/eval/test/host_effects_runner.zig
@@ -542,11 +542,18 @@ fn runSingleTest(io: std.Io, allocator: std.mem.Allocator, tc: TestCase) TestOut
     return .{ .status = .pass, .backends = backends };
 }
 
-fn serializeOutcome(fd: posix.fd_t, outcome: TestOutcome, duration_ns: u64) void {
+/// Build the wire bytes for a TestOutcome into `out`. Shared by the raw
+/// pipe serializer and the u32-length-prefixed streamed variant.
+fn appendOutcomeBytes(
+    out: *std.ArrayListUnmanaged(u8),
+    gpa: std.mem.Allocator,
+    outcome: TestOutcome,
+    duration_ns: u64,
+) std.mem.Allocator.Error!void {
     var run_bufs: [NUM_BACKENDS]?[]u8 = .{ null, null };
     defer {
         for (run_bufs) |maybe_buf| {
-            if (maybe_buf) |buf| base.defaultGpa().free(buf);
+            if (maybe_buf) |buf| gpa.free(buf);
         }
     }
 
@@ -566,12 +573,13 @@ fn serializeOutcome(fd: posix.fd_t, outcome: TestOutcome, duration_ns: u64) void
         header.backend_message_lens[i] = if (backend_detail.message) |msg| @intCast(msg.len) else 0;
         if (backend_detail.run) |run| {
             var buf: std.ArrayListUnmanaged(u8) = .empty;
-            appendEncodedRun(base.defaultGpa(), &buf, run) catch {
+            appendEncodedRun(gpa, &buf, run) catch {
+                buf.deinit(gpa);
                 header.backend_run_lens[i] = 0;
                 continue;
             };
-            const owned = buf.toOwnedSlice(base.defaultGpa()) catch {
-                buf.deinit(base.defaultGpa());
+            const owned = buf.toOwnedSlice(gpa) catch {
+                buf.deinit(gpa);
                 header.backend_run_lens[i] = 0;
                 continue;
             };
@@ -582,14 +590,21 @@ fn serializeOutcome(fd: posix.fd_t, outcome: TestOutcome, duration_ns: u64) void
         }
     }
 
-    harness.writeAll(fd, std.mem.asBytes(&header));
-    if (outcome.message) |msg| harness.writeAll(fd, msg);
+    try out.appendSlice(gpa, std.mem.asBytes(&header));
+    if (outcome.message) |msg| try out.appendSlice(gpa, msg);
     for (outcome.backends) |backend_detail| {
-        if (backend_detail.message) |msg| harness.writeAll(fd, msg);
+        if (backend_detail.message) |msg| try out.appendSlice(gpa, msg);
     }
     for (run_bufs) |maybe_buf| {
-        if (maybe_buf) |buf| harness.writeAll(fd, buf);
+        if (maybe_buf) |buf| try out.appendSlice(gpa, buf);
     }
+}
+
+fn serializeOutcome(fd: posix.fd_t, outcome: TestOutcome, duration_ns: u64) void {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(base.defaultGpa());
+    appendOutcomeBytes(&out, base.defaultGpa(), outcome, duration_ns) catch return;
+    harness.writeAll(fd, out.items);
 }
 
 fn deserializeOutcome(buf: []const u8, gpa: std.mem.Allocator) ?TestResult {
@@ -648,6 +663,23 @@ fn serializeResultForPool(fd: posix.fd_t, result: TestResult) void {
     serializeOutcome(fd, outcome, result.duration_ns);
 }
 
+/// Streamed variant for persistent worker mode: the same wire bytes behind a
+/// u32 frame-length prefix. This runner passes a null worker argv template,
+/// so the pool never spawns streaming workers today; wired for the shared
+/// PoolConfig contract.
+fn serializeResultStreamedForPool(fd: posix.fd_t, result: TestResult) void {
+    const outcome: TestOutcome = .{
+        .status = result.status,
+        .message = result.message,
+        .backends = result.backends,
+    };
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(base.defaultGpa());
+    appendOutcomeBytes(&out, base.defaultGpa(), outcome, result.duration_ns) catch return;
+    harness.writeFrameHeader(fd, out.items.len);
+    harness.writeAll(fd, out.items);
+}
+
 fn dupeOptional(gpa: std.mem.Allocator, value: ?[]const u8) ?[]const u8 {
     return if (value) |slice| gpa.dupe(u8, slice) catch null else null;
 }
@@ -694,6 +726,7 @@ const timeout_result: TestResult = .{
 const Pool = harness.ProcessPool(TestCase, TestResult, .{
     .runTest = &runTestForPool,
     .serialize = &serializeResultForPool,
+    .serializeStreamed = &serializeResultStreamedForPool,
     .deserialize = &deserializeOutcome,
     .default_result = default_result,
     .timeout_result = timeout_result,

--- a/src/eval/test/lambda_mono_differential_runner.zig
+++ b/src/eval/test/lambda_mono_differential_runner.zig
@@ -21,6 +21,12 @@
 //! Generated corpus cases additionally run under the dev JIT backend and must
 //! agree with the interpreter (cross-backend agreement on the sweep corpus).
 //!
+//! Cases run through `test_harness.ProcessPool`: forked children on POSIX,
+//! persistent `--worker-stream` worker processes on Windows. Either way each
+//! case is isolated, so a compiler panic, evaluator crash, or hang is
+//! attributed to that case instead of killing the whole run. The `fail-fast`
+//! flag switches to sequential in-process execution for debugging.
+//!
 //! The harness only works in Debug builds: release builds never materialize
 //! the Lambda Mono tree.
 
@@ -38,7 +44,7 @@ const LambdaMonoEval = postcheck.LambdaMono.Eval;
 const LambdaMonoProgram = postcheck.LambdaMono.Ast.Program;
 
 /// Errors the runner's entry point can surface.
-const RunnerError = std.mem.Allocator.Error || test_harness.Timer.Error || std.fmt.ParseIntError || error{
+const RunnerError = std.mem.Allocator.Error || test_harness.Timer.Error || test_harness.WorkerArgvError || std.fmt.ParseIntError || error{
     RequiresDebugBuild,
     InvalidArgument,
     Diverged,
@@ -82,6 +88,10 @@ const CaseResult = struct {
     status: CaseStatus,
     /// Owned detail text for diverged/unsupported/interpreter_error.
     detail: ?[]u8 = null,
+    /// Set only by the pool's watchdog (`timeout_result`): the isolated case
+    /// process exceeded its budget and was killed, so there is no owned
+    /// detail text to attribute the failure with.
+    timed_out: bool = false,
 };
 
 const Totals = struct {
@@ -111,11 +121,15 @@ const Report = struct {
     total_cases: usize,
     executed: usize = 0,
     saw_failure: bool = false,
+    /// True when cases record as they execute (fail-fast sequential mode),
+    /// where a periodic progress line is useful. Pool runs record all results
+    /// after completion and rely on the pool's own progress reporting.
+    live_progress: bool = false,
 
     fn record(self: *Report, case: Case, result: *CaseResult) std.mem.Allocator.Error!void {
         const gpa = self.gpa;
         self.executed += 1;
-        if (!verbose_logging and self.executed % 200 == 0) {
+        if (self.live_progress and !verbose_logging and self.executed % 200 == 0) {
             std.debug.print("... {d}/{d} cases\n", .{ self.executed, self.total_cases });
         }
         switch (result.status) {
@@ -173,10 +187,14 @@ const Report = struct {
                     self.totals.unexpected_child_failed += 1;
                     self.saw_failure = true;
                 }
+                const fallback: []const u8 = if (result.timed_out)
+                    "timed out"
+                else
+                    "child died without a result (compiler panic or signal)";
                 std.debug.print("CHILD-FAIL {s}{s}: {s}\n", .{
                     case.name,
                     if (case.known_panic) " (known panic)" else "",
-                    result.detail orelse "(no detail)",
+                    result.detail orelse fallback,
                 });
                 if (result.detail) |detail| gpa.free(detail);
             },
@@ -193,9 +211,8 @@ fn logVerbose(comptime fmt: []const u8, args: anytype) void {
 }
 
 const posix = std.posix;
-const has_fork = builtin.os.tag != .windows;
 
-/// Wire status bytes for the child-to-parent result protocol.
+/// Wire status bytes for the case-to-parent result protocol.
 fn statusByte(status: CaseStatus) u8 {
     return switch (status) {
         .pass => 'P',
@@ -221,218 +238,65 @@ fn statusFromByte(byte: u8) ?CaseStatus {
     };
 }
 
-/// One forked case whose result the parent has not yet collected.
-const PendingChild = struct {
-    case: Case,
-    pid: posix.pid_t,
-    fd: posix.fd_t,
-    deadline_ns: u64,
-    payload: std.ArrayList(u8),
-};
-
-/// Fork one case into an isolated child so a compiler panic, evaluator
-/// crash, or hang is attributed to that case instead of killing the whole
-/// run. The child writes one status byte plus the detail text and exits.
-/// Returns null when the fork machinery is unavailable (caller runs inline).
-fn spawnCase(
-    gpa: std.mem.Allocator,
-    io: std.Io,
-    case: Case,
-    timeout_ms: u64,
-    siblings: []const PendingChild,
-) std.mem.Allocator.Error!?PendingChild {
-    if (comptime !has_fork) return null;
-
-    const pipe_fds = test_harness.pipe() catch return null;
-    const pipe_read = pipe_fds[0];
-    const pipe_write = pipe_fds[1];
-
-    const fork_result = test_harness.fork() catch {
-        test_harness.closeFd(pipe_read);
-        test_harness.closeFd(pipe_write);
-        return null;
+/// Run one case for the process pool. Harness errors (only OOM) are folded
+/// into a child-failed result so the pool's fixed Result type can carry them.
+fn runCaseForPool(io: std.Io, allocator: std.mem.Allocator, case: Case, timeout_ms: u64) CaseResult {
+    _ = timeout_ms; // the pool's parent-side watchdog enforces the budget
+    return runCase(allocator, io, case) catch |err| .{
+        .status = .child_failed,
+        .detail = std.fmt.allocPrint(allocator, "child error: {s}", .{@errorName(err)}) catch null,
     };
+}
 
-    if (fork_result == 0) {
-        // Child: close inherited pipe ends (ours and every sibling's, so
-        // sibling EOFs are not held open by this process), run the case, and
-        // serialize the result. The child _exit()s, so the OS reclaims all
-        // memory — no deinit needed.
-        test_harness.closeFd(pipe_read);
-        for (siblings) |sibling| test_harness.closeFd(sibling.fd);
-        _ = std.c.setsid();
-        var child_arena = collections.SingleThreadArena.init(gpa);
-        const result = runCase(child_arena.allocator(), io, case) catch |err| {
-            test_harness.writeAll(pipe_write, &[_]u8{'E'});
-            test_harness.writeAll(pipe_write, @errorName(err));
-            test_harness.closeFd(pipe_write);
-            std.c._exit(2);
-        };
-        test_harness.writeAll(pipe_write, &[_]u8{statusByte(result.status)});
-        if (result.detail) |detail| test_harness.writeAll(pipe_write, detail);
-        test_harness.closeFd(pipe_write);
-        std.c._exit(0);
-    }
+/// Serialize a case result for the pool: one status byte followed by the
+/// detail text, uncapped — divergence details are the harness's product.
+fn serializeCaseResult(fd: posix.fd_t, result: CaseResult) void {
+    test_harness.writeAll(fd, &[_]u8{statusByte(result.status)});
+    if (result.detail) |detail| test_harness.writeAll(fd, detail);
+}
 
-    test_harness.closeFd(pipe_write);
+/// Streamed variant for persistent worker mode: the same bytes behind a u32
+/// frame-length prefix.
+fn serializeCaseResultStreamed(fd: posix.fd_t, result: CaseResult) void {
+    const detail_len = if (result.detail) |detail| detail.len else 0;
+    test_harness.writeFrameHeader(fd, 1 + detail_len);
+    serializeCaseResult(fd, result);
+}
+
+fn deserializeCaseResult(buf: []const u8, gpa: std.mem.Allocator) ?CaseResult {
+    if (buf.len == 0) return null;
+    const status = statusFromByte(buf[0]) orelse return null;
+    const detail: ?[]u8 = if (buf.len > 1) gpa.dupe(u8, buf[1..]) catch null else null;
+    return .{ .status = status, .detail = detail };
+}
+
+fn stabilizeCaseResult(gpa: std.mem.Allocator, result: CaseResult) CaseResult {
     return .{
-        .case = case,
-        .pid = fork_result,
-        .fd = pipe_read,
-        .deadline_ns = test_harness.monotonicNs() + timeout_ms * 1_000_000,
-        .payload = .empty,
+        .status = result.status,
+        .detail = if (result.detail) |detail| gpa.dupe(u8, detail) catch null else null,
+        .timed_out = result.timed_out,
     };
 }
 
-/// Reap a finished (or timed-out) child and turn its payload into a result.
-/// Closes the pipe and frees the payload buffer.
-fn finalizeChild(gpa: std.mem.Allocator, child: *PendingChild, timed_out: bool) std.mem.Allocator.Error!CaseResult {
-    if (timed_out) {
-        posix.kill(-child.pid, posix.SIG.KILL) catch {
-            posix.kill(child.pid, posix.SIG.KILL) catch {};
-        };
-    }
-    const wait_result = test_harness.waitpid(child.pid, 0);
-    test_harness.closeFd(child.fd);
-    defer child.payload.deinit(gpa);
-
-    if (timed_out) {
-        return CaseResult{
-            .status = .child_failed,
-            .detail = try gpa.dupe(u8, "timed out"),
-        };
-    }
-    if (child.payload.items.len == 0) {
-        return CaseResult{
-            .status = .child_failed,
-            .detail = try std.fmt.allocPrint(
-                gpa,
-                "child died without a result (compiler panic or signal; wait status {d})",
-                .{wait_result.status},
-            ),
-        };
-    }
-    const first = child.payload.items[0];
-    if (first == 'E') {
-        return CaseResult{
-            .status = .child_failed,
-            .detail = try std.fmt.allocPrint(gpa, "child error: {s}", .{child.payload.items[1..]}),
-        };
-    }
-    const status = statusFromByte(first) orelse {
-        return CaseResult{
-            .status = .child_failed,
-            .detail = try std.fmt.allocPrint(gpa, "malformed child payload ({d} bytes)", .{child.payload.items.len}),
-        };
-    };
-    const detail: ?[]u8 = if (child.payload.items.len > 1)
-        try gpa.dupe(u8, child.payload.items[1..])
-    else
-        null;
-    return CaseResult{ .status = status, .detail = detail };
+fn getCaseName(case: Case) []const u8 {
+    return case.name;
 }
 
-/// Run cases through a pool of forked children, collecting results as each
-/// child finishes. Result ordering follows completion, not submission.
-fn runPool(
-    gpa: std.mem.Allocator,
-    io: std.Io,
-    run_list: []const Case,
-    job_limit: usize,
-    timeout_ms: u64,
-    fail_fast: bool,
-    report: *Report,
-) std.mem.Allocator.Error!void {
-    var pending: std.ArrayList(PendingChild) = .empty;
-    defer {
-        for (pending.items) |*child| {
-            posix.kill(-child.pid, posix.SIG.KILL) catch {
-                posix.kill(child.pid, posix.SIG.KILL) catch {};
-            };
-            _ = test_harness.waitpid(child.pid, 0);
-            test_harness.closeFd(child.fd);
-            child.payload.deinit(gpa);
-        }
-        pending.deinit(gpa);
-    }
-
-    var next: usize = 0;
-    var read_buf: [4096]u8 = undefined;
-    while (next < run_list.len or pending.items.len > 0) {
-        const stop_spawning = fail_fast and report.saw_failure;
-        while (next < run_list.len and pending.items.len < job_limit and !stop_spawning) {
-            const case = run_list[next];
-            next += 1;
-            if (try spawnCase(gpa, io, case, timeout_ms, pending.items)) |child| {
-                try pending.append(gpa, child);
-            } else {
-                var result = try runCase(gpa, io, case);
-                try report.record(case, &result);
-            }
-        }
-        if (pending.items.len == 0) {
-            if (stop_spawning) break;
-            continue;
-        }
-
-        const poll_fds = try gpa.alloc(posix.pollfd, pending.items.len);
-        defer gpa.free(poll_fds);
-        var min_deadline: u64 = std.math.maxInt(u64);
-        for (pending.items, poll_fds) |child, *pfd| {
-            pfd.* = .{
-                .fd = child.fd,
-                .events = posix.POLL.IN | posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL,
-                .revents = 0,
-            };
-            min_deadline = @min(min_deadline, child.deadline_ns);
-        }
-        const now_ns = test_harness.monotonicNs();
-        const poll_timeout_ms: i32 = if (min_deadline <= now_ns)
-            0
-        else
-            @intCast(@min((min_deadline - now_ns) / 1_000_000 + 1, 60_000));
-        _ = posix.poll(poll_fds, poll_timeout_ms) catch {};
-
-        // Scan with stable indices, then remove finished children from the
-        // highest index down so swapRemove never disturbs a lower index.
-        var finished_buf: [64]struct { index: usize, timed_out: bool } = undefined;
-        var finished_count: usize = 0;
-        const scan_now_ns = test_harness.monotonicNs();
-        for (pending.items, poll_fds, 0..) |*child, pfd, index| {
-            if (finished_count == finished_buf.len) break;
-            const revents = pfd.revents;
-            var eof = false;
-            if (revents & (posix.POLL.IN | posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL) != 0) {
-                const bytes_read = posix.read(child.fd, &read_buf) catch blk: {
-                    eof = true;
-                    break :blk 0;
-                };
-                if (bytes_read == 0) {
-                    eof = true;
-                } else {
-                    try child.payload.appendSlice(gpa, read_buf[0..bytes_read]);
-                }
-            }
-            if (eof) {
-                finished_buf[finished_count] = .{ .index = index, .timed_out = false };
-                finished_count += 1;
-            } else if (scan_now_ns >= child.deadline_ns) {
-                finished_buf[finished_count] = .{ .index = index, .timed_out = true };
-                finished_count += 1;
-            }
-        }
-
-        var f = finished_count;
-        while (f > 0) {
-            f -= 1;
-            const entry = finished_buf[f];
-            var child = pending.items[entry.index];
-            _ = pending.swapRemove(entry.index);
-            var result = try finalizeChild(gpa, &child, entry.timed_out);
-            try report.record(child.case, &result);
-        }
-    }
-}
+/// Process pool: forked children on POSIX, persistent `--worker-stream`
+/// worker processes on Windows. Both isolate each case, so a compiler panic,
+/// evaluator crash, or hang is attributed to that case instead of killing
+/// the whole run.
+const Pool = test_harness.ProcessPool(Case, CaseResult, .{
+    .runTest = &runCaseForPool,
+    .serialize = &serializeCaseResult,
+    .serializeStreamed = &serializeCaseResultStreamed,
+    .deserialize = &deserializeCaseResult,
+    .default_result = .{ .status = .child_failed },
+    .timeout_result = .{ .status = .child_failed, .timed_out = true },
+    .stabilizeResult = &stabilizeCaseResult,
+    .getName = &getCaseName,
+    .use_process_groups = true,
+});
 
 /// Entry point for the Lambda Mono differential harness.
 pub fn main(init: std.process.Init) RunnerError!void {
@@ -552,16 +416,35 @@ pub fn main(init: std.process.Init) RunnerError!void {
         .total_cases = run_list.items.len,
     };
 
-    if (comptime has_fork) {
-        const cpu_count = std.Thread.getCpuCount() catch 4;
-        const default_jobs = @min(@max(cpu_count / 2, 1), 12);
-        const job_limit = @max(cli.max_threads orelse default_jobs, 1);
-        try runPool(gpa, io, run_list.items, job_limit, cli.timeout_ms, fail_fast, &report);
-    } else {
+    // Worker modes: the Windows pool spawned this process to execute specific
+    // cases. The worker argv template preserves every selection flag, so the
+    // run_list built above matches the parent's and indices stay aligned.
+    if (Pool.runWorkerMode(io, cli, run_list.items, cli.timeout_ms)) return;
+
+    if (fail_fast) {
+        // Sequential in-process debugging mode: deterministic order, live
+        // output, stop at the first failure. No crash isolation — a compiler
+        // panic surfaces directly in this process.
+        report.live_progress = true;
         for (run_list.items) |case| {
             var result = try runCase(gpa, io, case);
             try report.record(case, &result);
-            if (fail_fast and report.saw_failure) break;
+            if (report.saw_failure) break;
+        }
+    } else {
+        const results = try gpa.alloc(CaseResult, run_list.items.len);
+        defer gpa.free(results);
+        @memset(results, .{ .status = .child_failed });
+
+        const worker_argv_template = try test_harness.buildWorkerArgvTemplate(io, args_arena.allocator(), init.minimal.args);
+
+        const cpu_count = std.Thread.getCpuCount() catch 4;
+        const job_limit = @max(cli.max_threads orelse @min(cpu_count, run_list.items.len), 1);
+        Pool.run(io, run_list.items, results, job_limit, cli.timeout_ms, gpa, worker_argv_template);
+
+        for (run_list.items, results) |case, pool_result| {
+            var result = pool_result;
+            try report.record(case, &result);
         }
     }
     const executed = report.executed;
@@ -624,13 +507,18 @@ fn printHelp() void {
     std.debug.print(
         "lambda-mono differential runner\n\n" ++
             "Compares the LIR interpreter (direct solved-to-LIR lowering) against a\n" ++
-            "tree-walking evaluator over the Debug-materialized Lambda Mono program.\n\n" ++
+            "tree-walking evaluator over the Debug-materialized Lambda Mono program.\n" ++
+            "Cases run in parallel isolated processes (forked children on POSIX,\n" ++
+            "persistent worker processes on Windows).\n\n" ++
             "Options:\n" ++
             "  --filter <substr>   only run cases whose name/source matches (repeatable)\n" ++
+            "  --threads <N>       max concurrent case processes (default: CPU count)\n" ++
+            "  --timeout <ms>      per-case watchdog budget (default: 120000)\n" ++
             "  --verbose           per-case logging\n" ++
             "  corpus-only         only the checked-in eval corpus\n" ++
             "  generated-only      only the generated sweep corpus\n" ++
-            "  fail-fast           stop at the first divergence\n" ++
+            "  fail-fast           stop at the first failure; runs cases sequentially\n" ++
+            "                      in-process (no crash isolation) for debugging\n" ++
             "  max-cases=N         stop after N cases\n",
         .{},
     );

--- a/src/eval/test/parallel_runner.zig
+++ b/src/eval/test/parallel_runner.zig
@@ -1401,8 +1401,7 @@ fn serializeOutcomeStreamed(fd: posix.fd_t, outcome: TestOutcome, duration_ns: u
     defer buf.deinit(base.defaultGpa());
     serializeOutcomeToBuffer(&buf, base.defaultGpa(), outcome, duration_ns) catch return;
 
-    const length: u32 = @intCast(buf.items.len);
-    harness.writeAll(fd, std.mem.asBytes(&length));
+    harness.writeFrameHeader(fd, buf.items.len);
     harness.writeAll(fd, buf.items);
 }
 
@@ -1486,36 +1485,6 @@ fn applyBackendIsolation(skip: *TestCase.Skip, name: []const u8) void {
     skip.dev = !std.mem.eql(u8, name, "dev");
     skip.wasm = !std.mem.eql(u8, name, "wasm");
     skip.llvm = !std.mem.eql(u8, name, "llvm");
-}
-
-/// Build argv used by the Windows ChildProcessPool to spawn worker copies of
-/// this runner. Starts with `selfExePath`, then preserves every original arg
-/// *except* `--worker N` / `--worker-backend NAME` (the harness appends those
-/// per-worker; we strip any pre-existing instance so we don't double-add).
-fn buildWorkerArgvTemplate(io: std.Io, arena: std.mem.Allocator, process_args: std.process.Args) RunnerError![]const []const u8 {
-    // std.fs.selfExePath was removed in Zig 0.16; use std.process.executablePathAlloc instead.
-    const self_path = try std.process.executablePathAlloc(io, arena);
-
-    const raw = try process_args.toSlice(arena);
-    const original_args: []const []const u8 = @ptrCast(raw);
-
-    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
-    try argv.append(arena, self_path);
-
-    var i: usize = 1;
-    while (i < original_args.len) : (i += 1) {
-        const arg = original_args[i];
-        if (harness.workerTemplateArgConsumesValue(arg)) {
-            i += 1;
-            continue;
-        }
-        if (harness.workerTemplateDropsFlag(arg)) {
-            continue;
-        }
-        try argv.append(arena, arg);
-    }
-
-    return try argv.toOwnedSlice(arena);
 }
 
 /// Phase-2 retry: re-run each failing/crashing/timed-out test once per
@@ -1633,6 +1602,12 @@ fn getTestName(tc: TestCase) []const u8 {
     return tc.name;
 }
 
+/// Pool hook: restrict a spec to one named backend in `--worker` mode
+/// (Phase-2 crash attribution; see `retryFailedForAttribution`).
+fn applyWorkerBackendToSpec(tc: *TestCase, name: []const u8) void {
+    applyBackendIsolation(&tc.skip, name);
+}
+
 fn dupeOptional(gpa: std.mem.Allocator, value: ?[]const u8) ?[]const u8 {
     return if (value) |slice| gpa.dupe(u8, slice) catch null else null;
 }
@@ -1677,6 +1652,7 @@ const timeout_result: TestResult = .{
 const Pool = harness.ProcessPool(TestCase, TestResult, .{
     .runTest = &runTestForPool,
     .serialize = &serializeResultForPool,
+    .serializeStreamed = &serializeResultStreamed,
     .deserialize = &deserializeOutcome,
     .default_result = default_result,
     .timeout_result = timeout_result,
@@ -1688,6 +1664,7 @@ const Pool = harness.ProcessPool(TestCase, TestResult, .{
     // being killed at the same instant.
     .timeout_report_grace_ms = LLVM_BACKEND_TIMEOUT_MS + BACKEND_TIMEOUT_REPORT_GRACE_MS,
     .onTestStarted = &onTestStarted,
+    .applyWorkerBackend = &applyWorkerBackendToSpec,
 });
 
 //
@@ -2222,84 +2199,15 @@ pub fn main(init: std.process.Init) RunnerError!void {
     const max_children: usize = effectiveMaxChildren(cli, cpu_count, tests.len);
     llvm_eval_slot_count = max_children;
 
-    // Worker mode: the parent spawned us with `--worker <idx>` (and optionally
-    // `--worker-backend <name>`) to run a single test, serialize the result to
-    // stdout, and exit. Used on Windows where the harness runs N worker
-    // processes in parallel instead of forking. The child re-applies the same
-    // filters so idx is stable between parent and child.
-    if (cli.worker_index) |idx| {
-        if (idx >= tests.len) std.process.exit(2);
-        var tc = tests[idx];
-        if (cli.worker_backend) |name| applyBackendIsolation(&tc.skip, name);
-        const worker_timeout_ms: u64 = if (cli.timeout_provided and cli.timeout_ms > 0) cli.timeout_ms else DEFAULT_EVAL_TIMEOUT_MS;
-
-        var arena = collections.SingleThreadArena.init(base.defaultGpa());
-        defer arena.deinit();
-
-        trace_worker.stamp("pre runSingleTest");
-        var timer = Timer.start() catch unreachable;
-        const outcome = runSingleTest(io, arena.allocator(), tc, worker_timeout_ms);
-        const duration = timer.read();
-        trace_worker.stamp("post runSingleTest");
-        var backends: [NUM_BACKENDS]BackendDetail = undefined;
-        if (outcome.has_backend_details) backends = outcome.backends;
-        const result = TestResult{
-            .status = outcome.status,
-            .message = outcome.message,
-            .duration_ns = duration,
-            .timings = outcome.timings,
-            .has_backend_details = outcome.has_backend_details,
-            .backends = backends,
-            .expected_str = outcome.expected_str,
-        };
-        serializeResultForPool(harness.stdoutFd(), result);
-        trace_worker.stamp("serialize done");
-        return;
-    }
-
-    // Persistent worker mode: read test indices from stdin (one decimal per
-    // line), run each, write a u32-length-prefixed result to stdout, loop
-    // until stdin EOFs. Amortizes the per-Child process-boot cost across
-    // many tests on the same worker.
-    if (cli.worker_stream) {
-        const worker_timeout_ms: u64 = if (cli.timeout_provided and cli.timeout_ms > 0) cli.timeout_ms else DEFAULT_EVAL_TIMEOUT_MS;
-        var arena = collections.SingleThreadArena.init(base.defaultGpa());
-        defer arena.deinit();
-
-        const stdout_handle = harness.stdoutFd();
-        const stdin_handle = harness.stdinFd();
-
-        var line_buf: [32]u8 = undefined;
-        outer: while (true) {
-            var line_len: usize = 0;
-            while (true) {
-                if (line_len >= line_buf.len) break :outer; // malformed
-                const n = harness.posixRead(stdin_handle, line_buf[line_len .. line_len + 1]) catch break :outer;
-                if (n == 0) break :outer; // EOF — parent done
-                if (line_buf[line_len] == '\n') break;
-                line_len += 1;
-            }
-            const idx = std.fmt.parseInt(usize, line_buf[0..line_len], 10) catch continue;
-            if (idx >= tests.len) continue;
-
-            _ = arena.reset(.retain_capacity);
-
-            var timer = Timer.start() catch unreachable;
-            const outcome = runSingleTest(io, arena.allocator(), tests[idx], worker_timeout_ms);
-            const duration = timer.read();
-            var backends: [NUM_BACKENDS]BackendDetail = undefined;
-            if (outcome.has_backend_details) backends = outcome.backends;
-            const result = TestResult{
-                .status = outcome.status,
-                .message = outcome.message,
-                .duration_ns = duration,
-                .timings = outcome.timings,
-                .has_backend_details = outcome.has_backend_details,
-                .backends = backends,
-                .expected_str = outcome.expected_str,
-            };
-            serializeResultStreamed(stdout_handle, result);
-        }
+    // Worker modes: on Windows the harness pool spawned this process with
+    // `--worker <idx>` (single test, optionally `--worker-backend <name>` for
+    // Phase-2 attribution) or `--worker-stream` (persistent: indices arrive
+    // on stdin, u32-length-prefixed results leave on stdout). The worker
+    // re-applied the same filters above, so indices stay aligned with the
+    // parent's test list.
+    trace_worker.stamp("pre worker mode");
+    if (Pool.runWorkerMode(io, cli, tests, effectiveHangTimeoutMs(cli))) {
+        trace_worker.stamp("worker mode done");
         return;
     }
 
@@ -2361,7 +2269,7 @@ pub fn main(init: std.process.Init) RunnerError!void {
     // Build a worker_argv_template so Windows can spawn `Child` workers that
     // re-invoke this binary with `--worker <idx>`. On POSIX the template is
     // unused (fork path doesn't re-exec) but we build it uniformly.
-    const worker_argv_template = try buildWorkerArgvTemplate(io, args_arena.allocator(), init.minimal.args);
+    const worker_argv_template = try harness.buildWorkerArgvTemplate(io, args_arena.allocator(), init.minimal.args);
 
     Pool.runWithSpans(io, tests, results, spans, max_children, hang_timeout_ms, gpa, worker_argv_template);
 

--- a/src/ipc/coordination.zig
+++ b/src/ipc/coordination.zig
@@ -25,15 +25,16 @@ pub const CoordinationError = error{
     AllocationFailed,
 };
 
-/// Read shared memory coordination info from platform-specific source
-/// On Windows: reads from command line arguments
-/// On POSIX: reads from a file next to the executable
+/// Read shared memory coordination info, written by the parent `roc` process
+/// as a file next to the executable's temp directory.
+///
+/// Windows used to receive this on the command line instead. That leaked the
+/// handle and size into the child's argv, where a platform host cannot
+/// distinguish them from the user's arguments and hands them to the Roc
+/// application -- so `roc --opt=interpreter app.roc` gave the app three args
+/// rather than one. Both platforms now use the same out-of-band file.
 pub fn readFdInfo(allocator: std.mem.Allocator, io: std.Io) CoordinationError!FdInfo {
-    if (comptime platform.is_windows) {
-        return readFdInfoFromCommandLine(allocator);
-    } else {
-        return readFdInfoFromFile(allocator, io);
-    }
+    return readFdInfoFromFile(allocator, io);
 }
 
 /// Parse platform-specific handle from string
@@ -51,49 +52,8 @@ pub fn parseHandle(handle_str: []const u8) CoordinationError!platform.Handle {
     }
 }
 
-/// Windows: Read handle and size from command line arguments
-fn readFdInfoFromCommandLine(allocator: std.mem.Allocator) CoordinationError!FdInfo {
-    // In Zig 0.16 `std.process.argsAlloc` was removed; on Windows we read the raw
-    // command line from the PEB and parse it with the standard library iterator.
-    // The shim entry point is not driven by Zig's `main(init: Init)`, so we cannot
-    // receive an `Args` value from the runtime.
-    const cmd_line_w = std.os.windows.peb().ProcessParameters.CommandLine.slice();
-    var iter = std.process.Args.Iterator.Windows.init(allocator, cmd_line_w) catch {
-        std.log.err("Failed to initialize command line iterator", .{});
-        return error.AllocationFailed;
-    };
-    defer iter.deinit();
-
-    // Skip argv[0] (program name).
-    _ = iter.next();
-
-    const handle_str = iter.next() orelse {
-        std.log.err("Invalid command line arguments: missing handle", .{});
-        return error.ArgumentsInvalid;
-    };
-    const size_str = iter.next() orelse {
-        std.log.err("Invalid command line arguments: missing size", .{});
-        return error.ArgumentsInvalid;
-    };
-
-    const fd_str = allocator.dupe(u8, handle_str) catch {
-        std.log.err("Failed to duplicate handle string", .{});
-        return error.AllocationFailed;
-    };
-
-    const size = std.fmt.parseInt(usize, size_str, 10) catch {
-        std.log.err("Failed to parse size from '{s}'", .{size_str});
-        allocator.free(fd_str);
-        return error.ArgumentsInvalid;
-    };
-
-    return FdInfo{
-        .fd_str = fd_str,
-        .size = size,
-    };
-}
-
-/// POSIX: Read fd and size from temporary file
+/// Read the fd/handle and size from the coordination file the parent wrote
+/// next to the executable's temp directory. Used on every platform.
 fn readFdInfoFromFile(allocator: std.mem.Allocator, io: std.Io) CoordinationError!FdInfo {
     // Get our own executable path
     const exe_path = std.process.executablePathAlloc(io, allocator) catch |err| switch (err) {
@@ -176,55 +136,4 @@ fn readFdInfoFromFile(allocator: std.mem.Allocator, io: std.Io) CoordinationErro
         .fd_str = fd_str,
         .size = size,
     };
-}
-
-/// Write shared memory coordination info for child process
-/// On Windows: returns command line arguments to pass
-/// On POSIX: writes a file next to the target executable
-pub fn writeFdInfo(
-    allocator: std.mem.Allocator,
-    io: std.Io,
-    handle: platform.Handle,
-    size: usize,
-    target_path: []const u8,
-) (std.mem.Allocator.Error || std.Io.File.OpenError || std.Io.File.Writer.Error || error{InvalidTargetPath})![]const u8 {
-    if (comptime platform.is_windows) {
-        // On Windows, return command line arguments
-        const handle_int = @intFromPtr(handle);
-        return std.fmt.allocPrint(allocator, "{} {}", .{ handle_int, size });
-    } else {
-        // On POSIX, write a coordination file
-        const fd = @as(c_int, @intCast(handle));
-
-        // Get the directory of the target executable
-        const target_dir = std.fs.path.dirname(target_path) orelse {
-            return error.InvalidTargetPath;
-        };
-
-        // Create the coordination file path
-        const coord_file_path = std.fmt.allocPrint(allocator, "{s}.txt", .{target_dir}) catch {
-            return error.OutOfMemory;
-        };
-        defer allocator.free(coord_file_path);
-
-        // Write the coordination file
-        const file = std.Io.Dir.cwd().createFile(io, coord_file_path, .{}) catch |err| {
-            std.log.err("Failed to create coordination file at '{s}': {}", .{ coord_file_path, err });
-            return err;
-        };
-        defer file.close(io);
-
-        const content = std.fmt.allocPrint(allocator, "{}\n{}\n", .{ fd, size }) catch {
-            return error.OutOfMemory;
-        };
-        defer allocator.free(content);
-
-        file.writeStreamingAll(io, content) catch |err| {
-            std.log.err("Failed to write coordination file: {}", .{err});
-            return err;
-        };
-
-        // Return empty string for POSIX (no command line args needed)
-        return "";
-    }
 }

--- a/src/lsp/test/parallel_integration_runner.zig
+++ b/src/lsp/test/parallel_integration_runner.zig
@@ -22,8 +22,7 @@ const wrapper_name = "lsp integration tests";
 
 const BuildSpecsError = Allocator.Error;
 const StatsJsonError = Allocator.Error || std.Io.Dir.AccessError || std.Io.Dir.CreateDirPathError || std.Io.File.OpenError || std.Io.File.Writer.Error;
-const WorkerArgvError = Allocator.Error || std.process.ExecutablePathError || std.process.Args.ToSliceError;
-const RunnerMainError = BuildSpecsError || StatsJsonError || WorkerArgvError || std.process.Args.ToSliceError;
+const RunnerMainError = BuildSpecsError || StatsJsonError || harness.WorkerArgvError || std.process.Args.ToSliceError;
 
 const TestStatus = enum(u8) {
     pass,
@@ -142,11 +141,15 @@ fn runSingleTest(io: std.Io, allocator: Allocator, spec: integration.Spec, _: u6
     };
 }
 
-fn serializeResult(fd: posix.fd_t, result: TestResult) void {
-    const message_data = result.message orelse "";
-    const max_message = 8192;
-    const message_out = message_data[0..@min(message_data.len, max_message)];
+const max_message = 8192;
 
+fn truncatedMessage(result: TestResult) []const u8 {
+    const message_data = result.message orelse "";
+    return message_data[0..@min(message_data.len, max_message)];
+}
+
+fn serializeResult(fd: posix.fd_t, result: TestResult) void {
+    const message_out = truncatedMessage(result);
     const header = WireHeader{
         .status = @intFromEnum(result.status),
         .duration_ns = result.duration_ns,
@@ -157,21 +160,11 @@ fn serializeResult(fd: posix.fd_t, result: TestResult) void {
     harness.writeAll(fd, message_out);
 }
 
+/// Streamed variant for persistent worker mode: the same wire bytes behind a
+/// u32 frame-length prefix.
 fn serializeResultStreamed(fd: posix.fd_t, result: TestResult) void {
-    const message_data = result.message orelse "";
-    const max_message = 8192;
-    const message_out = message_data[0..@min(message_data.len, max_message)];
-
-    const header = WireHeader{
-        .status = @intFromEnum(result.status),
-        .duration_ns = result.duration_ns,
-        .message_len = @intCast(message_out.len),
-    };
-
-    const length: u32 = @intCast(@sizeOf(WireHeader) + message_out.len);
-    harness.writeAll(fd, std.mem.asBytes(&length));
-    harness.writeAll(fd, std.mem.asBytes(&header));
-    harness.writeAll(fd, message_out);
+    harness.writeFrameHeader(fd, @sizeOf(WireHeader) + truncatedMessage(result).len);
+    serializeResult(fd, result);
 }
 
 fn deserializeResult(buf: []const u8, allocator: Allocator) ?TestResult {
@@ -207,6 +200,7 @@ fn getTestName(spec: integration.Spec) []const u8 {
 const Pool = harness.ProcessPool(integration.Spec, TestResult, .{
     .runTest = &runSingleTest,
     .serialize = &serializeResult,
+    .serializeStreamed = &serializeResultStreamed,
     .deserialize = &deserializeResult,
     .default_result = .{ .status = .crash },
     .timeout_result = .{ .status = .timeout },
@@ -354,33 +348,6 @@ fn writeStatsJson(
     });
 }
 
-fn buildWorkerArgvTemplate(io: std.Io, allocator: Allocator, process_args: std.process.Args) WorkerArgvError![]const []const u8 {
-    var self_path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const self_path_len = try std.process.executablePath(io, &self_path_buf);
-    const self_path = try allocator.dupe(u8, self_path_buf[0..self_path_len]);
-
-    const raw = try process_args.toSlice(allocator);
-    const original_args: []const []const u8 = @ptrCast(raw);
-
-    var argv: std.ArrayListUnmanaged([]const u8) = .empty;
-    try argv.append(allocator, self_path);
-
-    var i: usize = 1;
-    while (i < original_args.len) : (i += 1) {
-        const arg = original_args[i];
-        if (harness.workerTemplateArgConsumesValue(arg)) {
-            i += 1;
-            continue;
-        }
-        if (harness.workerTemplateDropsFlag(arg)) {
-            continue;
-        }
-        try argv.append(allocator, arg);
-    }
-
-    return try argv.toOwnedSlice(allocator);
-}
-
 fn printUsage() void {
     std.debug.print(
         \\Usage: lsp_integration [options]
@@ -421,41 +388,10 @@ pub fn main(init: std.process.Init) RunnerMainError!void {
         return;
     }
 
-    if (args.worker_index) |idx| {
-        if (idx >= specs.len) std.process.exit(2);
-        var worker_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-        defer worker_arena.deinit();
-        const result = runSingleTest(init.io, worker_arena.allocator(), specs[idx], args.timeout_ms);
-        serializeResult(std.Io.File.stdout().handle, result);
-        return;
-    }
-
-    if (args.worker_stream) {
-        var worker_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-        defer worker_arena.deinit();
-
-        const stdin_handle = std.Io.File.stdin().handle;
-        const stdout_handle = std.Io.File.stdout().handle;
-
-        var line_buf: [32]u8 = undefined;
-        outer: while (true) {
-            var line_len: usize = 0;
-            while (true) {
-                if (line_len >= line_buf.len) break :outer;
-                const n = harness.posixRead(stdin_handle, line_buf[line_len .. line_len + 1]) catch break :outer;
-                if (n == 0) break :outer;
-                if (line_buf[line_len] == '\n') break;
-                line_len += 1;
-            }
-            const idx = std.fmt.parseInt(usize, line_buf[0..line_len], 10) catch continue;
-            if (idx >= specs.len) continue;
-
-            _ = worker_arena.reset(.retain_capacity);
-            const result = runSingleTest(init.io, worker_arena.allocator(), specs[idx], args.timeout_ms);
-            serializeResultStreamed(stdout_handle, result);
-        }
-        return;
-    }
+    // Worker modes: on Windows the harness pool spawned this process with
+    // `--worker <idx>` or `--worker-stream`. The worker re-applied the same
+    // filters above, so indices stay aligned with the parent's spec list.
+    if (Pool.runWorkerMode(init.io, args, specs, args.timeout_ms)) return;
 
     const cpu_count = std.Thread.getCpuCount() catch 4;
     const max_children = args.max_threads orelse @min(cpu_count, specs.len);
@@ -470,7 +406,7 @@ pub fn main(init: std.process.Init) RunnerMainError!void {
     defer gpa.free(spans);
     @memset(spans, null);
 
-    const worker_argv_template = try buildWorkerArgvTemplate(init.io, arena, init.minimal.args);
+    const worker_argv_template = try harness.buildWorkerArgvTemplate(init.io, arena, init.minimal.args);
 
     var wall_timer = harness.Timer.start() catch @panic("no clock");
     Pool.runWithSpans(init.io, specs, results, spans, max_children, args.timeout_ms, gpa, worker_argv_template);


### PR DESCRIPTION
## Summary

This PR fixes the Windows MiniCI timeout regression and several failures uncovered while validating it:

- prevents granular `run-test-zig-*` steps from inheriting the Windows summary serialization chain;
- gives the Lambda Mono differential harness a Windows worker pool and consolidates the Windows worker plumbing that three runners had duplicated into the shared test harness;
- cleans up per-subprocess CLI test caches instead of accumulating hundreds of disposable trees;
- stops `flaky-retry` from treating ordinary output containing `503` as a network failure;
- preserves the restored Zig package cache across the valgrind job's `git clean`;
- fixes LLVM hashing of `Dec` dictionary keys;
- stops Windows shared-memory coordination values leaking into Roc applications' command-line arguments; and
- brings `run-test-zig-machine-code-shim` into the aggregate test summary so its passes are counted there.

This PR is intentionally based on `fix-run-test-zig-failures` from #10278. That PR supplies the underlying test fixes and the sharded macOS/Windows MiniCI workflow. Once #10278 merges, this branch should be rebased onto its destination branch.

## Why MiniCI timed out

`build.zig` currently enables serialized Zig test runs on Windows so Zig 0.16's test-runner IPC is not overwhelmed by many binaries starting simultaneously. `TestsSummaryStep.addRun` implements serialization by making each summary run depend on the previous one.

That chain was intended to be private to the aggregate summary, but 11 test suites handed the **same** `Step.Run` to both the summary and their public `run-test-zig-<suite>` step. Asking for one granular suite on Windows therefore ran every test binary earlier in the chain.

MiniCI invokes every granular step in its own `zig build` process, so it replayed those prefixes repeatedly. The clearest example was `run-test-zig-minici`: its small std-only test binary took **441 seconds** because it also ran 41 unrelated test binaries.

The trigger was added work in the `compile` module. That work was then multiplied across each affected chain prefix. A later change added more coupled granular steps to MiniCI, taking the amplification from 7x to 11x and pushing the slow tail past the two-hour job limit.

## Build-graph fix

`TestSuiteRegistry` now creates two separately configured runs from one declarative suite spec:

- the summary-owned run may join the serialization chain;
- the public granular run never receives those chain edges.

The spec is also the single source of truth for forwarded arguments, environment variables, prerequisite steps, default-build membership, and test-wiring enumeration, so the two runs cannot drift apart.

A configure-time graph audit enforces the resulting invariant. Every public `run-test-zig-*` step must reach exactly one Zig test binary unless it is explicitly declared as a custom executable-backed runner. The LSP integration process-pool runner is the sole zero-binary exception. This catches both forms of accidental coverage loss: a granular step pulling in multiple test binaries or silently running none.

The fix restores the behavior non-Windows platforms already had; it does not reduce test coverage or disable Windows serialization for the aggregate suite.

## Lambda Mono differential: Windows worker pool

The serialization-chain fix alone was not enough: run [29726091866](https://github.com/roc-lang/roc/actions/runs/29726091866) still hit the 120-minute cap on Windows, killed inside `run-test-lambda-mono-differential` (job 66/73) with everything before it passing. The harness parallelised only via `fork` (up to 12-way on POSIX), so Windows fell through to a strictly serial loop — and also lost the per-case isolation that attributes a compiler panic or hang to its case. Details in [this comment](https://github.com/roc-lang/roc/pull/10266#issuecomment-5020028091).

The runner now goes through `test_harness.ProcessPool`, the same executor the eval, CLI, and LSP runners already use: forked children on POSIX, persistent `--worker-stream` worker processes on Windows (JobObject-managed, with process-boot and builtin-setup cost amortised across the cases each worker runs). Its bespoke fork pool — ~240 lines duplicating the ProcessPool POSIX path — is deleted, and each case keeps its one-status-byte wire format and watchdog timeout on both platforms.

Rather than adding a fourth copy of the Windows worker plumbing the eval, CLI, and LSP runners had each duplicated, that plumbing moves into the shared harness: `buildWorkerArgvTemplate`, the `--worker <idx>` / `--worker-stream` worker modes (now `ProcessPool.runWorkerMode`, colocated with the parent side of the same protocol), and the u32 result-frame prefix (`writeFrameHeader`). Net across the six files: **−193 lines**.

Behavior changes worth reviewing:

- `fail-fast` now runs cases sequentially in-process (documented in `--help`): `ProcessPool` has no early-abort, and inline execution is the more useful debugging mode anyway.
- The POSIX default concurrency changes from `min(max(cpus/2, 1), 12)` to the eval runner's `min(cpus, cases)`, so 4-vCPU ubuntu CI goes from 2-way to 4-way as well.
- Results report in submission order after the pool completes, instead of completion order during the run; live progress comes from the pool's standard ticker.

Unifying each runner's streamed and non-streamed serializer variants is deliberately deferred to a follow-up PR (fat TODO on `PoolConfig.serialize`): that rewrite touches the Unix runners' fork-path serializers, and landing it here would make this change's CI performance delta unattributable.

Local Windows measurements, same machine as the 2282.8s serial number reported earlier:

| | serial (before) | worker pool (after) |
|---|---|---|
| full corpus (1479 cases) | 2282.8s | **185.2s (12.3×)** |
| 300-case slice | 452.7s | **31.9s (14.2×)** |

Totals are identical across both modes: 1459 agreed, 20 unsupported (the stated coverage gaps), 0 divergences, 0 child failures. CI needed roughly a 2× speedup to fit its budget; the remaining gap to those numbers on CI is runner core count, not architecture.

## Test scratch and cache behavior

#10278 already moves disposable CLI test scratch out of `.zig-cache` and into `zig-out/roc-test`. This PR builds on that location rather than introducing another scratch root.

The per-subprocess `cache` namespace was still never deleted. A single development checkout had accumulated 445 abandoned trees, and CI runs inflated `.zig-cache` to 8–14 GB before the move. This PR returns ownership of each reserved tree with its environment map and deletes it after the subprocess completes. Preserved failure work directories retain their existing behavior.

The CI diagnostic now reports `.zig-cache` composition and warns when it exceeds setup-zig's current 2048 MiB limit. This PR deliberately does **not** raise that limit; the post-cleanup measurements should inform a separate cache-policy change.

## Retry and package-cache fixes

The shared retry action previously matched a bare, unanchored `503` against the failed command's entire output. An eval timing such as `stops within bounds (19503.1ms)` therefore looked like a transient HTTP failure and reran a roughly 25-minute suite.

The retry signature is now centralized in the action, the bare status code is removed, and Unix and Windows both match case-sensitively. The contextual `bad HTTP response code` signature still covers actual HTTP 503 failures.

The valgrind job also ran `git clean -fdx` immediately after restoring `.zig-cache/p`, deleting the package cache it had just restored. It now excludes `.zig-cache` from that clean so dependency downloads remain available to the build.

## Two correctness bugs found during validation

### `Dec` dictionary hashing on LLVM

`LowLevelBuiltins.hasherOp` mapped `hasher_write_dec` to the two-argument `hasher_write_f64_bits` wrapper. The LLVM backend emits the 128-bit hasher ABI—seed, domain, low bits, and high bits—so the selected symbol had the wrong signature and the `Dec` value was not hashed correctly. This caused the `issue 9725` nightly dictionary-key failure.

`Dec` is now routed to `hasher_write_u128`, matching its 128-bit fixed-point representation and the ABI already emitted by every backend.

### Windows application arguments

Windows passed the inherited shared-memory handle and size as the child process's first two command-line arguments. Platform hosts cannot distinguish those implementation details from user arguments, so they were exposed directly to the Roc application:

```text
roc --opt=interpreter app.roc
  args = ["...app.roc.exe", "448", "976608"]
```

POSIX already communicates this information through a coordination file next to the temporary executable. Windows now uses the same out-of-band mechanism in both the one-shot and hot-reload spawn paths, leaving the application's argv untouched.

## Verification

Focused checks on the rebased branch:

| Check | Result |
|---|---|
| `zig build --help` | build graph configures successfully |
| `zig build run-test-zig-minici` | **19/19 passed** |
| `zig build run-test-zig-cli-main` | **214/214 passed** |
| `zig build run-check-test-wiring` | **78/78 steps passed**; all 3,380 named declarations run by at least one of 46 binaries |
| argument-sensitive `fx-open three-branch...` CLI case | **passed** |
| `git diff --check` | clean |

Worker-pool checks, all on Windows:

| Check | Result |
|---|---|
| `run-test-zig-build-helpers` + `run-test-zig-cli-runner-unit` | **passed** (harness and CLI-runner unit tests) |
| lambda-mono 300-case slice, serial vs pool | **identical totals**; 452.7s → 31.9s |
| lambda-mono full corpus through the pool | **1459 agreed / 0 diverged / 0 child failures**, 185.2s |
| `--filter`, `generated-only`, `max-cases` selection in workers | parent/worker indices stay aligned; clean passes |
| `fail-fast` | sequential in-process at the serial per-case rate |
| forced `--timeout 400` | watchdog kills attributed as `CHILD-FAIL <case>: timed out`; generated-origin timeouts fail the run |
| eval runner (`--filter list`, 8 workers) | **252/252 passed** |
| host-effects runner | **81/81 passed** |
| LSP integration (`hover` specs) and CLI `fx-open` suite | **passed** |
| `zig fmt --check` on all six files | clean |

Earlier Windows validation of the functional changes:

| Check | Result |
|---|---|
| formerly coupled granular steps | **~44 minutes removed** in aggregate |
| `run-test-zig-minici` | one binary instead of 41 unrelated predecessors |
| `run-test-eval --llvm --filter "issue 9725"` | **2 passed / 3 failed -> 5 passed / 0 failed** |
| full local `zig build minici` | **73/73 passed**, 53-minute wall time |
| full CLI suite | **704 passed / 0 failed / 55 skipped** |
| per-subprocess cache namespace after passing runs | empty; owned trees cleaned |

POSIX builds of the migrated runners are unverified locally (Windows machine); the shared worker-mode code is platform-neutral and the fork path is untouched, so the ubuntu/macOS lanes of the next CI run are the real check.

## Follow-ups not included here

- Choose an appropriate setup-zig cache size after the new composition diagnostics provide clean measurements.
- Unify each runner's streamed/non-streamed result serializers into one buffer-building serializer in `PoolConfig` (fat TODO on `PoolConfig.serialize`); kept out of this PR because it rewrites the Unix runners' fork-path serializers and would confound the worker-pool timing measurement.
- Investigate the macOS-specific 6–10× slowdowns in `run-test-zig-module-compile` and `run-test-zig-lir-inline` ([CI run 2 comment](https://github.com/roc-lang/roc/pull/10266#issuecomment-5021739529)); macOS has `fork`, so the worker pool does not address it.
