### PR TITLE
feat(#7339): ROC cli flag to suppress ANSI escapes in output

### DIFF
--- a/src/cli/CliCtx.zig
+++ b/src/cli/CliCtx.zig
@@ -209,6 +209,8 @@ pub const CliCtx = struct {
     command: Command,
     /// Exit code based on problem severity
     exit_code: u8,
+    /// Explicit CLI override. This is folded into `color_policy` on first use.
+    no_color: bool,
     /// Lazily loaded once because color environment variables are process-wide.
     color_policy: ?ColorPolicy,
 
@@ -224,6 +226,7 @@ pub const CliCtx = struct {
             .problems = std.ArrayList(CliProblem).empty,
             .command = command,
             .exit_code = 0,
+            .no_color = false,
             .color_policy = null,
         };
     }
@@ -237,6 +240,12 @@ pub const CliCtx = struct {
     /// Create a CoreCtx from this CLI context's allocators and I/O.
     pub fn coreCtx(self: *const Self) CoreCtx {
         return CoreCtx.default(self.gpa, self.arena, self.io.std_io);
+    }
+
+    /// Set the parser-owned CLI override before the color policy is consumed.
+    pub fn setNoColor(self: *Self, no_color: bool) void {
+        std.debug.assert(self.color_policy == null);
+        self.no_color = no_color;
     }
 
     /// Build the terminal-layout defaults before applying color policy.
@@ -262,7 +271,7 @@ pub const CliCtx = struct {
 
         const core_ctx = self.coreCtx();
         const policy = ColorPolicy.resolve(.{
-            .no_color = core_ctx.envVarIsNonEmpty("NO_COLOR"),
+            .no_color = self.no_color or core_ctx.envVarIsNonEmpty("NO_COLOR"),
             .force_color = core_ctx.envVarIsNonEmpty("FORCE_COLOR"),
             .dumb_terminal = core_ctx.envVarEquals("TERM", "dumb"),
             .high_contrast = core_ctx.envVarEquals("ROC_HIGH_CONTRAST", "1"),
@@ -395,7 +404,7 @@ pub const CliCtx = struct {
         for (self.problems.items) |problem| {
             var report = try problem.toReport(self.gpa);
             defer report.deinit();
-            try reporting.renderReportToTerminal(&report, writer, ColorPalette.ANSI, config);
+            try reporting.renderReportToTerminal(&report, writer, reporting.ColorUtils.getPaletteForConfig(config), config);
         }
     }
 
@@ -443,7 +452,7 @@ pub fn renderProblem(ctx: *CliCtx, problem: CliProblem) Allocator.Error!void {
     defer report.deinit();
 
     const config = ctx.reportConfig(.stderr);
-    reporting.renderReportToTerminal(&report, ctx.io.stderr(), ColorPalette.ANSI, config) catch {};
+    reporting.renderReportToTerminal(&report, ctx.io.stderr(), reporting.ColorUtils.getPaletteForConfig(config), config) catch {};
 }
 
 // Tests
@@ -466,6 +475,20 @@ test "CliCtx accumulates problems" {
     try std.testing.expect(ctx.hasErrors());
     try std.testing.expectEqual(@as(usize, 1), ctx.problemCount());
     try std.testing.expectEqual(@as(u8, 1), ctx.exitCode());
+}
+
+test "CliCtx no_color selects plain reporting" {
+    const allocator = std.testing.allocator;
+    var io = Io.create(std.testing.io);
+    var ctx = CliCtx.init(allocator, allocator, &io, .build);
+    ctx.setNoColor(true);
+    ctx.initIo();
+    defer ctx.deinit();
+
+    try std.testing.expectEqual(ColorMode.never, ctx.colorPolicy().mode);
+    const config = ctx.reportConfig(.stderr);
+    try std.testing.expect(!config.shouldUseColors());
+    try std.testing.expectEqual(ColorPalette.NO_COLOR, reporting.ColorUtils.getPaletteForConfig(config));
 }
 
 test "CliCtx counts errors vs warnings correctly" {

--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -131,10 +131,10 @@ pub fn stepWithConfig(self: *ReplSession, input: []const u8, report_config: repo
     if (line.len == 0) return .none;
 
     if (std.mem.eql(u8, line, ":help")) return .{ .output = try self.helpText() };
-    if (std.mem.eql(u8, line, ":defs")) return .{ .output = try self.printDefs() };
+    if (std.mem.eql(u8, line, ":defs")) return .{ .output = try self.printDefs(report_config.shouldUseColors()) };
     if (std.mem.startsWith(u8, line, ":t ")) {
         const rest = std.mem.trim(u8, line[3..], " \t");
-        return .{ .output = try self.printTypeOfVar(rest) };
+        return .{ .output = try self.printTypeOfVar(rest, report_config.shouldUseColors()) };
     }
     if (std.mem.eql(u8, line, ":exit") or
         std.mem.eql(u8, line, ":quit") or
@@ -509,7 +509,7 @@ fn helpText(self: *ReplSession) Allocator.Error![]u8 {
     );
 }
 
-fn printDefs(self: *ReplSession) ReplStepError![]u8 {
+fn printDefs(self: *ReplSession, use_color: bool) ReplStepError![]u8 {
     var out = std.ArrayList(u8).empty;
     errdefer out.deinit(self.allocator);
 
@@ -527,18 +527,26 @@ fn printDefs(self: *ReplSession) ReplStepError![]u8 {
                 const def_idx = getDefOfName(env, name) orelse continue;
                 try tw.write(ModuleEnv.varFrom(def_idx), .one_line);
 
-                try out.print(
-                    self.allocator,
-                    "\x1b[3m\x1b[90m{s} : {s}\x1b[0m\n{s}\n\n",
-                    .{ name, tw.get(), item.source },
-                );
+                if (use_color) {
+                    try out.print(self.allocator, "\x1b[3m\x1b[90m{s} : {s}\x1b[0m\n{s}\n\n", .{ name, tw.get(), item.source });
+                } else {
+                    try out.print(self.allocator, "{s} : {s}\n{s}\n\n", .{ name, tw.get(), item.source });
+                }
             },
             .annotation => {
                 // italics, usually succeeded by a .value let-binding
-                try out.print(self.allocator, "\x1b[3m{s}\x1b[0m\n", .{item.source});
+                if (use_color) {
+                    try out.print(self.allocator, "\x1b[3m{s}\x1b[0m\n", .{item.source});
+                } else {
+                    try out.print(self.allocator, "{s}\n", .{item.source});
+                }
             },
             .type_decl, .import => {
-                try out.print(self.allocator, "\x1b[3m{s}\x1b[0m\n\n", .{item.source});
+                if (use_color) {
+                    try out.print(self.allocator, "\x1b[3m{s}\x1b[0m\n\n", .{item.source});
+                } else {
+                    try out.print(self.allocator, "{s}\n\n", .{item.source});
+                }
             },
         }
     }
@@ -546,7 +554,7 @@ fn printDefs(self: *ReplSession) ReplStepError![]u8 {
     return try out.toOwnedSlice(self.allocator);
 }
 
-fn printTypeOfVar(self: *ReplSession, name: []const u8) ReplStepError![]u8 {
+fn printTypeOfVar(self: *ReplSession, name: []const u8, use_color: bool) ReplStepError![]u8 {
     var out = std.ArrayList(u8).empty;
     defer out.deinit(self.allocator);
 
@@ -559,7 +567,11 @@ fn printTypeOfVar(self: *ReplSession, name: []const u8) ReplStepError![]u8 {
 
     if (getDefOfName(env, name)) |def_idx| {
         try tw.write(ModuleEnv.varFrom(def_idx), .one_line);
-        try out.print(self.allocator, "\x1b[3m\x1b[90m{s} : {s}\x1b[0m\n", .{ name, tw.get() });
+        if (use_color) {
+            try out.print(self.allocator, "\x1b[3m\x1b[90m{s} : {s}\x1b[0m\n", .{ name, tw.get() });
+        } else {
+            try out.print(self.allocator, "{s} : {s}\n", .{ name, tw.get() });
+        }
     } else {
         try out.print(self.allocator, "Did not find a definition for `{s}`\n", .{name});
     }

--- a/src/cli/builder.zig
+++ b/src/cli/builder.zig
@@ -50,6 +50,7 @@ pub const CompileConfig = struct {
     output_path: []const u8,
     optimization: OptimizationLevel,
     target: target.RocTarget,
+    report_config: reporting.ReportingConfig,
     cpu: []const u8 = "",
     features: []const u8 = "",
     debug: bool = false, // Enable debug info generation in output
@@ -346,7 +347,7 @@ pub fn initializeLLVM() void {
 /// Compile LLVM bitcode file to object file
 pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileConfig) (Allocator.Error || error{LLVMNotAvailable})!bool {
     if (comptime !llvm_available) {
-        try renderLLVMNotAvailableError(gpa);
+        try renderLLVMNotAvailableError(gpa, config.report_config);
         return error.LLVMNotAvailable;
     }
 
@@ -360,7 +361,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
 
     // Verify input file exists
     std.Io.Dir.cwd().access(std_io, config.input_path, .{}) catch |err| {
-        try renderFileNotAccessibleError(gpa, config.input_path, err);
+        try renderFileNotAccessibleError(gpa, config.input_path, err, config.report_config);
         return false;
     };
 
@@ -378,7 +379,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
     defer gpa.free(bitcode_path_z);
 
     if (externs.LLVMCreateMemoryBufferWithContentsOfFile(bitcode_path_z.ptr, &mem_buf, &error_message) != 0) {
-        try renderLLVMError(gpa, "Bitcode Load Error", "Failed to load bitcode file.", std.mem.span(error_message));
+        try renderLLVMError(gpa, "Bitcode Load Error", "Failed to load bitcode file.", std.mem.span(error_message), config.report_config);
         externs.LLVMDisposeMessage(error_message);
         return false;
     }
@@ -389,7 +390,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
     std.log.debug("Parsing bitcode into LLVM module...", .{});
     var module: ?*anyopaque = null;
     if (externs.LLVMParseBitcode(mem_buf, &module, &error_message) != 0) {
-        try renderLLVMError(gpa, "Bitcode Parse Error", "Failed to parse bitcode.", std.mem.span(error_message));
+        try renderLLVMError(gpa, "Bitcode Parse Error", "Failed to parse bitcode.", std.mem.span(error_message), config.report_config);
         externs.LLVMDisposeMessage(error_message);
         return false;
     }
@@ -567,7 +568,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
     std.log.debug("Getting LLVM target for triple: {s}", .{target_triple});
     var llvm_target: ?*anyopaque = null;
     if (externs.LLVMGetTargetFromTriple(target_triple_z.ptr, &llvm_target, &error_message) != 0) {
-        try renderTargetError(gpa, target_triple, std.mem.span(error_message));
+        try renderTargetError(gpa, target_triple, std.mem.span(error_message), config.report_config);
         externs.LLVMDisposeMessage(error_message);
         return false;
     }
@@ -595,7 +596,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
         false, // emulated_tls
     );
     if (target_machine == null) {
-        try renderTargetMachineError(gpa, target_triple, config.cpu, config.features);
+        try renderTargetMachineError(gpa, target_triple, config.cpu, config.features, config.report_config);
         return false;
     }
     defer externs.LLVMDisposeTargetMachine(target_machine);
@@ -639,7 +640,7 @@ pub fn compileBitcodeToObject(gpa: Allocator, std_io: std.Io, config: CompileCon
     );
 
     if (emit_result) {
-        try renderEmitError(gpa, config.output_path, std.mem.span(emit_error_message));
+        try renderEmitError(gpa, config.output_path, std.mem.span(emit_error_message), config.report_config);
         externs.LLVMDisposeMessage(emit_error_message);
         return false;
     }
@@ -662,7 +663,7 @@ pub fn isLLVMAvailable() bool {
 
 // --- Error Reporting Helpers ---
 
-fn renderLLVMNotAvailableError(allocator: Allocator) Allocator.Error!void {
+fn renderLLVMNotAvailableError(allocator: Allocator, config: reporting.ReportingConfig) Allocator.Error!void {
     var report = try reporting.Report.init(allocator, "LLVM Not Available", "LLVM is not available at compile time.", .fatal);
     defer report.deinit();
 
@@ -675,12 +676,17 @@ fn renderLLVMNotAvailableError(allocator: Allocator) Allocator.Error!void {
     reporting.renderReportToTerminal(
         &report,
         stderrWriter(),
-        .ANSI,
-        reporting.ReportingConfig.initColorTerminal(),
+        reporting.ColorUtils.getPaletteForConfig(config),
+        config,
     ) catch {};
 }
 
-fn renderFileNotAccessibleError(allocator: Allocator, path: []const u8, err: std.Io.Dir.AccessError) Allocator.Error!void {
+fn renderFileNotAccessibleError(
+    allocator: Allocator,
+    path: []const u8,
+    err: std.Io.Dir.AccessError,
+    config: reporting.ReportingConfig,
+) Allocator.Error!void {
     var report = try reporting.Report.init(allocator, "File Not Accessible", "Input bitcode file does not exist or is not accessible.", .fatal);
     defer report.deinit();
 
@@ -696,12 +702,18 @@ fn renderFileNotAccessibleError(allocator: Allocator, path: []const u8, err: std
     reporting.renderReportToTerminal(
         &report,
         stderrWriter(),
-        .ANSI,
-        reporting.ReportingConfig.initColorTerminal(),
+        reporting.ColorUtils.getPaletteForConfig(config),
+        config,
     ) catch {};
 }
 
-fn renderLLVMError(allocator: Allocator, title: []const u8, message: []const u8, llvm_message: []const u8) Allocator.Error!void {
+fn renderLLVMError(
+    allocator: Allocator,
+    title: []const u8,
+    message: []const u8,
+    llvm_message: []const u8,
+    config: reporting.ReportingConfig,
+) Allocator.Error!void {
     var report = try reporting.Report.init(allocator, title, message, .fatal);
     defer report.deinit();
 
@@ -713,12 +725,17 @@ fn renderLLVMError(allocator: Allocator, title: []const u8, message: []const u8,
     reporting.renderReportToTerminal(
         &report,
         stderrWriter(),
-        .ANSI,
-        reporting.ReportingConfig.initColorTerminal(),
+        reporting.ColorUtils.getPaletteForConfig(config),
+        config,
     ) catch {};
 }
 
-fn renderTargetError(allocator: Allocator, triple: []const u8, llvm_message: []const u8) Allocator.Error!void {
+fn renderTargetError(
+    allocator: Allocator,
+    triple: []const u8,
+    llvm_message: []const u8,
+    config: reporting.ReportingConfig,
+) Allocator.Error!void {
     var report = try reporting.Report.init(allocator, "Invalid Target", "Failed to get LLVM target for triple.", .fatal);
     defer report.deinit();
 
@@ -734,12 +751,18 @@ fn renderTargetError(allocator: Allocator, triple: []const u8, llvm_message: []c
     reporting.renderReportToTerminal(
         &report,
         stderrWriter(),
-        .ANSI,
-        reporting.ReportingConfig.initColorTerminal(),
+        reporting.ColorUtils.getPaletteForConfig(config),
+        config,
     ) catch {};
 }
 
-fn renderTargetMachineError(allocator: Allocator, triple: []const u8, cpu: []const u8, features: []const u8) Allocator.Error!void {
+fn renderTargetMachineError(
+    allocator: Allocator,
+    triple: []const u8,
+    cpu: []const u8,
+    features: []const u8,
+    config: reporting.ReportingConfig,
+) Allocator.Error!void {
     var report = try reporting.Report.init(allocator, "Target Machine Error", "Failed to create LLVM target machine with configuration.", .fatal);
     defer report.deinit();
 
@@ -768,12 +791,17 @@ fn renderTargetMachineError(allocator: Allocator, triple: []const u8, cpu: []con
     reporting.renderReportToTerminal(
         &report,
         stderrWriter(),
-        .ANSI,
-        reporting.ReportingConfig.initColorTerminal(),
+        reporting.ColorUtils.getPaletteForConfig(config),
+        config,
     ) catch {};
 }
 
-fn renderEmitError(allocator: Allocator, output_path: []const u8, llvm_message: []const u8) Allocator.Error!void {
+fn renderEmitError(
+    allocator: Allocator,
+    output_path: []const u8,
+    llvm_message: []const u8,
+    config: reporting.ReportingConfig,
+) Allocator.Error!void {
     var report = try reporting.Report.init(allocator, "Object File Emit Error", "Failed to emit object file.", .fatal);
     defer report.deinit();
 
@@ -789,7 +817,7 @@ fn renderEmitError(allocator: Allocator, output_path: []const u8, llvm_message: 
     reporting.renderReportToTerminal(
         &report,
         stderrWriter(),
-        .ANSI,
-        reporting.ReportingConfig.initColorTerminal(),
+        reporting.ColorUtils.getPaletteForConfig(config),
+        config,
     ) catch {};
 }

--- a/src/cli/cli_args.zig
+++ b/src/cli/cli_args.zig
@@ -41,6 +41,12 @@ pub const CliArgs = union(enum) {
     }
 };
 
+/// Parsed command plus CLI-wide output settings.
+pub const ParsedArgs = struct {
+    command: CliArgs,
+    no_color: bool,
+};
+
 /// Errors that can occur due to bad input while parsing the arguments
 pub const ArgProblem = union(enum) {
     missing_flag_value: struct {
@@ -272,7 +278,6 @@ pub const ExperimentalLspArgs = struct {
 /// Arguments for `roc repl`
 pub const ReplArgs = struct {
     opt: OptLevel = default_dev_opt,
-    no_color: bool = false,
 };
 
 /// Arguments for `roc glue`
@@ -286,6 +291,38 @@ pub const GlueArgs = struct {
 
 /// Parse a list of arguments.
 pub fn parse(alloc: mem.Allocator, std_io: std.Io, args: []const []const u8) ParseError!CliArgs {
+    return (try parseWithGlobalOptions(alloc, std_io, args)).command;
+}
+
+/// Parse CLI-wide options before dispatching to a command parser.
+///
+/// `--no-color` is consumed before command parsing so every command shares one
+/// explicit output setting. Arguments after `--` belong to the executed Roc
+/// application and remain untouched.
+pub fn parseWithGlobalOptions(alloc: mem.Allocator, std_io: std.Io, args: []const []const u8) ParseError!ParsedArgs {
+    var command_args = try alloc.alloc([]const u8, args.len);
+    defer alloc.free(command_args);
+
+    var no_color = false;
+    var after_separator = false;
+    var command_arg_count: usize = 0;
+    for (args) |arg| {
+        if (mem.eql(u8, arg, "--")) after_separator = true;
+        if (!after_separator and mem.eql(u8, arg, "--no-color")) {
+            no_color = true;
+            continue;
+        }
+        command_args[command_arg_count] = arg;
+        command_arg_count += 1;
+    }
+
+    return .{
+        .command = try parseCommand(alloc, std_io, command_args[0..command_arg_count]),
+        .no_color = no_color,
+    };
+}
+
+fn parseCommand(alloc: mem.Allocator, std_io: std.Io, args: []const []const u8) ParseError!CliArgs {
     if (args.len == 0) return try parseRun(alloc, args, .default);
 
     // `roc run` accepts everything the default run accepts, plus installed
@@ -344,6 +381,7 @@ const main_help =
     \\      --opt=<opt>                    Execution mode: dev (default, fast compilation), interpreter, size (LLVM) or speed (LLVM)
     \\      --target=<target>              Target to compile for (e.g., x64musl, x64glibc, arm64musl). Defaults to native target with musl for static linking
     \\      --no-cache                     Disable compilation and executable caches (useful for compiler and platform developers)
+    \\      --no-color                     Do not use ANSI escape codes in CLI output
     \\  -j, --jobs=<N>                     Max worker threads for parallel compilation (default: auto-detect CPU count)
     \\
 ;
@@ -865,7 +903,6 @@ fn parseTest(args: []const []const u8) CliArgs {
 
 fn parseRepl(args: []const []const u8) CliArgs {
     var opt: OptLevel = default_dev_opt;
-    var no_color: bool = false;
 
     for (args) |arg| {
         if (isHelpFlag(arg)) {
@@ -876,12 +913,9 @@ fn parseRepl(args: []const []const u8) CliArgs {
             \\
             \\Options:
             \\      --opt=<opt>  Execution mode: dev (default, fast compilation), interpreter, size (LLVM) or speed (LLVM)
-            \\      --no-color   Do not use ANSI color codes in REPL diagnostics
             \\  -h, --help       Print help
             \\
             };
-        } else if (mem.eql(u8, arg, "--no-color")) {
-            no_color = true;
         } else if (mem.startsWith(u8, arg, "--opt")) {
             if (getFlagValue(arg)) |value| {
                 if (OptLevel.from_str(value)) |level| {
@@ -896,7 +930,7 @@ fn parseRepl(args: []const []const u8) CliArgs {
             return CliArgs{ .problem = ArgProblem{ .unexpected_argument = .{ .cmd = "repl", .arg = arg } } };
         }
     }
-    return CliArgs{ .repl = .{ .opt = opt, .no_color = no_color } };
+    return CliArgs{ .repl = .{ .opt = opt } };
 }
 
 fn parseGlue(args: []const []const u8) CliArgs {
@@ -1954,11 +1988,21 @@ test "roc repl" {
         try testing.expectEqual(.help, std.meta.activeTag(result));
     }
     {
-        const result = try parse(gpa, testing.io, &[_][]const u8{ "repl", "--no-color" });
-        defer result.deinit(gpa);
-        try testing.expectEqual(.repl, std.meta.activeTag(result));
-        try testing.expect(result.repl.no_color);
+        const parsed = try parseWithGlobalOptions(gpa, testing.io, &[_][]const u8{ "repl", "--no-color" });
+        defer parsed.command.deinit(gpa);
+        try testing.expectEqual(.repl, std.meta.activeTag(parsed.command));
+        try testing.expect(parsed.no_color);
     }
+}
+
+test "global no-color is not forwarded to the app" {
+    const gpa = testing.allocator;
+
+    const parsed = try parseWithGlobalOptions(gpa, testing.io, &[_][]const u8{ "--no-color", "app.roc", "--", "--no-color" });
+    defer parsed.command.deinit(gpa);
+
+    try testing.expect(parsed.no_color);
+    try testing.expectEqualSlices([]const u8, &.{"--no-color"}, parsed.command.run.app_args);
 }
 
 test "roc glue" {

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -715,7 +715,6 @@ const windows = if (is_windows) struct {
 } else struct {};
 
 const Allocator = std.mem.Allocator;
-const ColorPalette = reporting.ColorPalette;
 
 const legalDetailsFileContent = @embedFile("legal_details");
 
@@ -1003,16 +1002,20 @@ var debug_allocator: std.heap.DebugAllocator(.{ .stack_trace_frames = build_opti
 };
 
 fn renderValidationError(
-    allocator: std.mem.Allocator,
+    ctx: *CliCtx,
     result: platform_validation.ValidationResult,
-    stderr: anytype,
 ) void {
-    const rendered = platform_validation.renderValidationError(allocator, result, stderr);
+    const rendered = platform_validation.renderValidationError(
+        ctx.gpa,
+        result,
+        ctx.io.stderr(),
+        ctx.reportConfig(.stderr),
+    );
     if (rendered) {} else {}
 }
 
-fn renderDiagnostics(build_env: *BuildEnv, stderr: anytype) Allocator.Error!void {
-    const diag = try build_env.renderDiagnostics(stderr);
+fn renderDiagnostics(ctx: *CliCtx, build_env: *BuildEnv) Allocator.Error!void {
+    const diag = try build_env.renderDiagnostics(ctx.io.stderr(), ctx.reportConfig(.stderr));
     if (diag.errors > 0) {} else {}
 }
 
@@ -1157,7 +1160,8 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8, std_io: 
         return rocInternalHotReloadDev(&ctx, args[2..]);
     }
 
-    const parsed_args = try cli_args.parse(arena, std_io, args[1..]);
+    const parsed = try cli_args.parseWithGlobalOptions(arena, std_io, args[1..]);
+    const parsed_args = parsed.command;
     if (parsedArgsStartBackgroundCleanup(parsed_args)) {
         startBackgroundCacheCleanup(gpa, arena, std_io);
     }
@@ -1178,6 +1182,7 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8, std_io: 
 
     // Create CLI context at the top level - this is passed to all command handlers
     var ctx = CliCtx.init(gpa, arena, &io, command);
+    ctx.setNoColor(parsed.no_color);
     ctx.initIo(); // Must be called after ctx is at its final stack location
     defer ctx.deinit(); // deinit flushes I/O
 
@@ -1439,6 +1444,7 @@ fn generatePlatformHostShimFromLirData(
         .output_path = object_path,
         .optimization = .speed,
         .target = target,
+        .report_config = ctx.reportConfig(.stderr),
         .cpu = llvm_cpu,
         .features = llvm_features,
         .debug = debug, // Use the debug flag passed from caller
@@ -2536,7 +2542,13 @@ fn rocRunSharedMemoryShim(ctx: *CliCtx, args: cli_args.RunArgs, arg0: []const u8
     var link_spec: ?roc_target.TargetLinkSpec = null;
     var targets_config: ?roc_target.TargetsConfig = null;
     if (platform_paths.platform_source_path) |platform_source| {
-        if (platform_validation.validatePlatformHeader(ctx.arena, ctx.io.std_io, platform_source)) |validation| {
+        if (platform_validation.validatePlatformHeader(
+            ctx.arena,
+            ctx.io.std_io,
+            platform_source,
+            ctx.io.stderr(),
+            ctx.reportConfig(.stderr),
+        )) |validation| {
             targets_config = validation.config;
 
             const selected = try selectRunPlatformTarget(ctx, validation.config, platform_source, args.target);
@@ -3170,7 +3182,7 @@ fn finishCompiledRun(
             const result = platform_validation.targets_validator.ValidationResult{
                 .process_signaled = .{ .signal = sig_num },
             };
-            renderValidationError(ctx.gpa, result, ctx.io.stderr());
+            renderValidationError(ctx, result);
             ctx.io.flush();
             std.process.exit(128 +| @as(u8, @truncate(sig_num)));
         },
@@ -3765,12 +3777,12 @@ fn runWithWindowsHandleInheritance(
             const result = platform_validation.targets_validator.ValidationResult{
                 .process_crashed = .{ .exit_code = exit_code, .is_access_violation = true },
             };
-            renderValidationError(ctx.gpa, result, ctx.io.stderr());
+            renderValidationError(ctx, result);
         } else if (exit_code >= 0xC0000000) { // NT status codes for exceptions
             const result = platform_validation.targets_validator.ValidationResult{
                 .process_crashed = .{ .exit_code = exit_code, .is_access_violation = false },
             };
-            renderValidationError(ctx.gpa, result, ctx.io.stderr());
+            renderValidationError(ctx, result);
         }
         // Propagate the exit code (truncated to u8 for compatibility)
         std.process.exit(@truncate(exit_code));
@@ -3877,7 +3889,7 @@ fn runWithPosixFdInheritance(
             const result = platform_validation.targets_validator.ValidationResult{
                 .process_signaled = .{ .signal = sig_num },
             };
-            renderValidationError(ctx.gpa, result, ctx.io.stderr());
+            renderValidationError(ctx, result);
             // Standard POSIX convention: exit with 128 + signal number
             std.process.exit(128 +| @as(u8, @truncate(sig_num)));
         },
@@ -4106,6 +4118,7 @@ fn buildHotReloadChildArgv(
     }
     if (args.max_threads) |jobs| try appendOwnedArg(ctx.gpa, &argv, &owned, "--jobs={}", .{jobs});
     if (args.no_cache) try appendOwnedArg(ctx.gpa, &argv, &owned, "--no-cache={}", .{@as(u8, 1)});
+    try appendOwnedArg(ctx.gpa, &argv, &owned, "--no-color={}", .{if (ctx.no_color) @as(u8, 1) else @as(u8, 0)});
     try appendResolveLimitArgs(ctx.gpa, &argv, &owned, args.resolve_limits);
 
     return .{
@@ -4811,6 +4824,7 @@ test "hot reload worker args require append offset" {
         "--shm-size=8192",
         "--expected-host=" ++ zero_host,
         "--watch-inputs-file=watch-inputs",
+        "--no-color=1",
     });
 
     try std.testing.expectEqual(@as(u64, 2), parsed.generation);
@@ -4820,6 +4834,7 @@ test "hot reload worker args require append offset" {
     try std.testing.expectEqual(@as(usize, 3072), parsed.region_end);
     try std.testing.expectEqual(@as(usize, 4096), parsed.append_offset);
     try std.testing.expectEqual(true, parsed.preserve_descriptor_refs);
+    try std.testing.expect(parsed.no_color);
     try std.testing.expectError(error.InvalidArguments, parseHotReloadDevWorkerArgs(&.{
         "--path=app.roc",
         "--target=x64linux",
@@ -5237,7 +5252,7 @@ fn renderDrainedBuildEnvReports(ctx: *CliCtx, build_env: *BuildEnv, display_path
                 .warning => counts.warnings += 1,
             }
             if (!builtin.is_test) {
-                reporting.renderReportToTerminal(report, ctx.io.stderr(), ColorPalette.ANSI, report_config) catch {};
+                reporting.renderReportToTerminal(report, ctx.io.stderr(), reporting.ColorUtils.getPaletteForConfig(report_config), report_config) catch {};
             }
         }
     }
@@ -5343,6 +5358,7 @@ const HotReloadDevWorkerArgs = struct {
     source_dir_override: ?[]const u8,
     max_threads: ?usize,
     no_cache: bool,
+    no_color: bool,
     resolve_limits: cli_args.ResolveLimitArgs,
 };
 
@@ -5389,6 +5405,7 @@ fn parseHotReloadDevWorkerArgs(args: []const []const u8) error{InvalidArguments}
     var source_dir_override: ?[]const u8 = null;
     var max_threads: ?usize = null;
     var no_cache: bool = false;
+    var no_color: bool = false;
     var resolve_limits = cli_args.ResolveLimitArgs{};
 
     for (args) |arg| {
@@ -5428,6 +5445,8 @@ fn parseHotReloadDevWorkerArgs(args: []const []const u8) error{InvalidArguments}
             max_threads = std.fmt.parseInt(usize, value, 10) catch return error.InvalidArguments;
         } else if (hotReloadFlagValue(arg, "--no-cache")) |value| {
             no_cache = try parseHotReloadBool(value);
+        } else if (hotReloadFlagValue(arg, "--no-color")) |value| {
+            no_color = try parseHotReloadBool(value);
         } else if (hotReloadFlagValue(arg, "--max-package-mb")) |value| {
             resolve_limits.max_package_mb = std.fmt.parseInt(u32, value, 10) catch return error.InvalidArguments;
         } else if (hotReloadFlagValue(arg, "--max-transitive-mb")) |value| {
@@ -5456,6 +5475,7 @@ fn parseHotReloadDevWorkerArgs(args: []const []const u8) error{InvalidArguments}
         .source_dir_override = source_dir_override,
         .max_threads = max_threads,
         .no_cache = no_cache,
+        .no_color = no_color,
         .resolve_limits = resolve_limits,
     };
 }
@@ -5465,6 +5485,7 @@ fn rocInternalHotReloadDev(ctx: *CliCtx, raw_args: []const []const u8) CliMainEr
         try ctx.io.stderr().print("Error: invalid internal hot-reload compiler arguments: {}\n", .{err});
         return err;
     };
+    ctx.setNoColor(args.no_color);
 
     const selected_target = RocTarget.fromString(args.target) orelse {
         try ctx.io.stderr().print("Error: invalid internal hot-reload target: {s}\n", .{args.target});
@@ -6611,7 +6632,15 @@ fn rocInstall(ctx: *CliCtx, args: cli_args.InstallArgs, arg0: []const u8) CliMai
             try ctx.io.stdout().print("Building {s} glue plugin with --opt=speed ...\n", .{args.shorthand});
             ctx.io.flush();
 
-            try glue.buildGlueSpecDylibFile(ctx.gpa, ctx.io.stderr(), staging.main_roc_path, staging.glue_dylib_path, .speed, ctx.io.std_io);
+            try glue.buildGlueSpecDylibFile(
+                ctx.gpa,
+                ctx.io.stderr(),
+                staging.main_roc_path,
+                staging.glue_dylib_path,
+                .speed,
+                ctx.reportConfig(.stderr),
+                ctx.io.std_io,
+            );
         },
     }
 
@@ -6836,7 +6865,7 @@ fn discoverAndAddBundleModules(
         if (build_env.getPlatformTargetsConfig()) |tc| {
             const pf_dir = std.fs.path.dirname(pf) orelse ".";
             if (platform_validation.validateAllTargetFilesExist(ctx.arena, ctx.io.std_io, tc, pf_dir)) |result| {
-                _ = platform_validation.renderValidationError(ctx.gpa, result, stderr);
+                _ = platform_validation.renderValidationError(ctx.gpa, result, stderr, ctx.reportConfig(.stderr));
                 return switch (result) {
                     .missing_target_file => error.MissingTargetFile,
                     .missing_files_directory => error.MissingFilesDirectory,
@@ -7426,7 +7455,7 @@ fn selectBuildPlatformTarget(
     return switch (target_selection.selectBuildTarget(targets_config, target_arg)) {
         .selected => |selected| selected,
         .invalid_target => |target_str| {
-            renderValidationError(ctx.gpa, .{ .invalid_target = .{ .target_str = target_str } }, ctx.io.stderr());
+            renderValidationError(ctx, .{ .invalid_target = .{ .target_str = target_str } });
             return error.InvalidTarget;
         },
         .unsupported_target => |target| {
@@ -7435,15 +7464,15 @@ fn selectBuildPlatformTarget(
                 target,
                 targets_config,
             );
-            renderValidationError(ctx.gpa, result, ctx.io.stderr());
+            renderValidationError(ctx, result);
             return error.UnsupportedTarget;
         },
         .requires_executable => unreachable,
         .no_default => {
             if (targets_config.targets.len == 0) {
-                renderValidationError(ctx.gpa, .{
+                renderValidationError(ctx, .{
                     .empty_targets = .{ .platform_path = platform_source orelse "<unknown>" },
-                }, ctx.io.stderr());
+                });
                 return error.UnsupportedTarget;
             }
             const native_target = RocTarget.detectNative();
@@ -7469,7 +7498,7 @@ fn selectRunPlatformTarget(
             const result = platform_validation.targets_validator.ValidationResult{
                 .invalid_target = .{ .target_str = target_str },
             };
-            renderValidationError(ctx.gpa, result, ctx.io.stderr());
+            renderValidationError(ctx, result);
             return error.InvalidTarget;
         },
         .unsupported_target => |target| {
@@ -7478,7 +7507,7 @@ fn selectRunPlatformTarget(
                 target,
                 targets_config,
             );
-            renderValidationError(ctx.gpa, result, ctx.io.stderr());
+            renderValidationError(ctx, result);
             return error.UnsupportedTarget;
         },
         .requires_executable => |selected| {
@@ -7487,9 +7516,9 @@ fn selectRunPlatformTarget(
         },
         .no_default => {
             if (targets_config.targets.len == 0) {
-                renderValidationError(ctx.gpa, .{
+                renderValidationError(ctx, .{
                     .empty_targets = .{ .platform_path = platform_source orelse "<unknown>" },
-                }, ctx.io.stderr());
+                });
                 return error.UnsupportedTarget;
             }
             const native_target = RocTarget.detectNative();
@@ -7498,7 +7527,7 @@ fn selectRunPlatformTarget(
                 native_target,
                 targets_config,
             );
-            renderValidationError(ctx.gpa, result, ctx.io.stderr());
+            renderValidationError(ctx, result);
             return error.UnsupportedTarget;
         },
         .not_runnable_on_host => |target| {
@@ -7683,12 +7712,12 @@ fn collectPlatformLinkInputs(
             .file_path => |path| {
                 const full_path = try std.fs.path.join(ctx.arena, &.{ platform_dir, files_dir, target_name, path });
                 std.Io.Dir.cwd().access(ctx.io.std_io, full_path, .{}) catch {
-                    renderValidationError(ctx.gpa, .{ .missing_target_file = .{
+                    renderValidationError(ctx, .{ .missing_target_file = .{
                         .target = target,
                         .output = link_type,
                         .file_path = path,
                         .expected_full_path = full_path,
-                    } }, ctx.io.stderr());
+                    } });
                     return error.MissingTargetFile;
                 };
                 if (!hit_app) {
@@ -8427,6 +8456,7 @@ fn compileLlvmAppObject(
         .output_path = object_path,
         .optimization = llvmOptimizationLevel(args.opt),
         .target = target,
+        .report_config = ctx.reportConfig(.stderr),
         .cpu = llvm_cpu,
         .features = llvm_features,
         .debug = args.debug,
@@ -8706,7 +8736,7 @@ fn rocBuildLlvm(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
     reporter.begin("Resolving Dependencies");
     build_env.discoverDependencies(args.path) catch |err| {
         reporter.fail();
-        try renderDiagnostics(&build_env, ctx.io.stderr());
+        try renderDiagnostics(ctx, &build_env);
         return err;
     };
     reporter.end();
@@ -8728,12 +8758,12 @@ fn rocBuildLlvm(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
     const link_type = selected.output;
 
     if (target.isDynamic() and builtin.target.os.tag != .linux) {
-        renderValidationError(ctx.gpa, .{
+        renderValidationError(ctx, .{
             .unsupported_glibc_cross = .{
                 .target = target,
                 .host_os = @tagName(builtin.target.os.tag),
             },
-        }, ctx.io.stderr());
+        });
         return error.UnsupportedCrossCompilation;
     }
 
@@ -8774,12 +8804,12 @@ fn rocBuildLlvm(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
     reporter.begin("Type Checking");
     build_env.compileDiscovered() catch |err| {
         reporter.fail();
-        try renderDiagnostics(&build_env, ctx.io.stderr());
+        try renderDiagnostics(ctx, &build_env);
         return err;
     };
     reporter.endWithBreakdown(&frontEndBreakdown(build_env.getTimingInfo()));
 
-    const diag = try build_env.renderDiagnostics(ctx.io.stderr());
+    const diag = try build_env.renderDiagnostics(ctx.io.stderr(), ctx.reportConfig(.stderr));
     var total_warning_count = diag.warnings;
     total_warning_count += try optimizedDbgWarningsForBuild(ctx, &build_env, args.opt);
     const resolved_targets_config = build_env.getPlatformTargetsConfig() orelse {
@@ -9022,7 +9052,7 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
     reporter.begin("Resolving Dependencies");
     build_env.discoverDependencies(args.path) catch |err| {
         reporter.fail();
-        try renderDiagnostics(&build_env, ctx.io.stderr());
+        try renderDiagnostics(ctx, &build_env);
         return err;
     };
     reporter.end();
@@ -9050,12 +9080,12 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
     const target_arch = target.toCpuArch();
     const target_os = target.toOsTag();
     if (target.isDynamic() and builtin.target.os.tag != .linux) {
-        renderValidationError(ctx.gpa, .{
+        renderValidationError(ctx, .{
             .unsupported_glibc_cross = .{
                 .target = target,
                 .host_os = @tagName(builtin.target.os.tag),
             },
-        }, ctx.io.stderr());
+        });
         return error.UnsupportedCrossCompilation;
     }
 
@@ -9082,12 +9112,12 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
     reporter.begin("Type Checking");
     build_env.compileDiscovered() catch |err| {
         reporter.fail();
-        try renderDiagnostics(&build_env, ctx.io.stderr());
+        try renderDiagnostics(ctx, &build_env);
         return err;
     };
     reporter.endWithBreakdown(&frontEndBreakdown(build_env.getTimingInfo()));
 
-    const diag = try build_env.renderDiagnostics(ctx.io.stderr());
+    const diag = try build_env.renderDiagnostics(ctx.io.stderr(), ctx.reportConfig(.stderr));
     var total_warning_count = diag.warnings;
     total_warning_count += try optimizedDbgWarningsForBuild(ctx, &build_env, args.opt);
     const resolved_targets_config = build_env.getPlatformTargetsConfig() orelse {
@@ -9347,7 +9377,7 @@ fn rocBuildEmbedded(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
     reporter.begin("Resolving Dependencies");
     build_env.discoverDependencies(args.path) catch |err| {
         reporter.fail();
-        try renderDiagnostics(&build_env, ctx.io.stderr());
+        try renderDiagnostics(ctx, &build_env);
         return err;
     };
     reporter.end();
@@ -9395,12 +9425,12 @@ fn rocBuildEmbedded(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
     reporter.begin("Type Checking");
     build_env.compileDiscovered() catch |err| {
         reporter.fail();
-        try renderDiagnostics(&build_env, ctx.io.stderr());
+        try renderDiagnostics(ctx, &build_env);
         return err;
     };
     reporter.endWithBreakdown(&frontEndBreakdown(build_env.getTimingInfo()));
 
-    const diag = try build_env.renderDiagnostics(ctx.io.stderr());
+    const diag = try build_env.renderDiagnostics(ctx.io.stderr(), ctx.reportConfig(.stderr));
     var total_warning_count = diag.warnings;
     total_warning_count += try optimizedDbgWarningsForBuild(ctx, &build_env, args.opt);
     const resolved_targets_config = build_env.getPlatformTargetsConfig() orelse {
@@ -10323,7 +10353,11 @@ fn optimizedDbgWarningsForBuild(
     opt: cli_args.OptLevel,
 ) Allocator.Error!usize {
     return switch (opt) {
-        .size, .speed => try build_env.renderOptimizedDbgWarnings(ctx.io.stderr(), @tagName(opt)),
+        .size, .speed => try build_env.renderOptimizedDbgWarnings(
+            ctx.io.stderr(),
+            @tagName(opt),
+            ctx.reportConfig(.stderr),
+        ),
         .dev, .interpreter => 0,
     };
 }
@@ -12191,6 +12225,7 @@ fn buildWatchChildArgv(ctx: *CliCtx, arg0: []const u8, command: WatchCommand, in
     }
 
     try argv.append(ctx.gpa, arg0);
+    if (ctx.no_color) try argv.append(ctx.gpa, "--no-color");
 
     switch (command) {
         .check => |args| {
@@ -12238,6 +12273,24 @@ fn buildWatchChildArgv(ctx: *CliCtx, arg0: []const u8, command: WatchCommand, in
         .argv = try argv.toOwnedSlice(ctx.gpa),
         .owned = try owned.toOwnedSlice(ctx.gpa),
     };
+}
+
+test "watch child argv propagates no-color" {
+    var io = Io.create(std.testing.io);
+    var ctx = CliCtx.init(std.testing.allocator, std.testing.allocator, &io, .check);
+    ctx.setNoColor(true);
+    ctx.initIo();
+    defer ctx.deinit();
+
+    var child_argv = try buildWatchChildArgv(
+        &ctx,
+        "roc",
+        .{ .check = .{ .path = "app.roc", .main = null } },
+        "watch-inputs",
+    );
+    defer child_argv.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings("--no-color", child_argv.argv[1]);
 }
 
 fn spawnWatchChild(ctx: *CliCtx, argv: []const []const u8) WatchSpawnChildError!*WatchChild {
@@ -12411,7 +12464,7 @@ fn rocTest(ctx: *CliCtx, args_in: cli_args.TestArgs, arg0: []const u8) RocTestEr
 
     if (args.main) |main_path| {
         build_env.buildWithMain(args.path, main_path) catch |err| {
-            _ = try build_env.renderDiagnostics(stderr);
+            _ = try build_env.renderDiagnostics(stderr, ctx.reportConfig(.stderr));
             if (args.watch_inputs_file) |file_path| {
                 try writeWatchInputsFile(ctx, file_path, &build_env, extra_paths);
             }
@@ -12419,14 +12472,14 @@ fn rocTest(ctx: *CliCtx, args_in: cli_args.TestArgs, arg0: []const u8) RocTestEr
         };
     } else {
         build_env.discoverDependencies(args.path) catch |err| {
-            _ = try build_env.renderDiagnostics(stderr);
+            _ = try build_env.renderDiagnostics(stderr, ctx.reportConfig(.stderr));
             if (args.watch_inputs_file) |file_path| {
                 try writeWatchInputsFile(ctx, file_path, &build_env, extra_paths);
             }
             return err;
         };
         build_env.compileDiscovered() catch |err| {
-            _ = try build_env.renderDiagnostics(stderr);
+            _ = try build_env.renderDiagnostics(stderr, ctx.reportConfig(.stderr));
             if (args.watch_inputs_file) |file_path| {
                 try writeWatchInputsFile(ctx, file_path, &build_env, extra_paths);
             }
@@ -12434,7 +12487,7 @@ fn rocTest(ctx: *CliCtx, args_in: cli_args.TestArgs, arg0: []const u8) RocTestEr
         };
     }
 
-    const diag = try build_env.renderDiagnostics(stderr);
+    const diag = try build_env.renderDiagnostics(stderr, ctx.reportConfig(.stderr));
     if (args.watch_inputs_file) |file_path| {
         try writeWatchInputsFile(ctx, file_path, &build_env, extra_paths);
     }
@@ -13469,9 +13522,8 @@ fn rocRepl(ctx: *CliCtx, repl_args: cli_args.ReplArgs) CliMainError!void {
     const stdin_is_tty = stdin.isTty(ctx.io.std_io) catch false;
     const stdout_is_tty = std.Io.File.stdout().isTty(ctx.io.std_io) catch false;
     const mode: ReplMode = if (stdin_is_tty and stdout_is_tty) .interactive else .batch;
-    const report_config = replReportingConfig(ctx, repl_args, mode);
-
-    const use_color = mode == .interactive and !repl_args.no_color and ctx.usesColor(.stdout);
+    const report_config = replReportingConfig(ctx, mode);
+    const use_color = mode == .interactive and ctx.usesColor(.stdout);
 
     // The line editor handles Ctrl-C itself (press twice in a row to quit).
     // Ignore SIGINT at the process level so a Ctrl-C while the terminal is
@@ -13594,10 +13646,10 @@ fn processReplInput(
     return false;
 }
 
-fn replReportingConfig(ctx: *CliCtx, repl_args: cli_args.ReplArgs, mode: ReplMode) reporting.ReportingConfig {
+fn replReportingConfig(ctx: *CliCtx, mode: ReplMode) reporting.ReportingConfig {
     const policy = ctx.colorPolicy();
     var config = ctx.reportConfig(.stderr);
-    if (repl_args.no_color or (mode == .batch and policy.mode != .always)) {
+    if (mode == .batch and policy.mode != .always) {
         config.color_preference = .never;
     }
     return config;
@@ -13636,6 +13688,7 @@ fn rocGlue(ctx: *CliCtx, args: cli_args.GlueArgs) RocGlueError!void {
         .glue_spec = glue_spec,
         .output_dir = args.output_dir,
         .platform_path = platform_path,
+        .report_config = ctx.reportConfig(.stderr),
         .no_cache = args.no_cache,
         .installed_dylib_path = installed_dylib_path,
         .opt = switch (args.opt) {
@@ -13741,7 +13794,7 @@ fn makeReporter(ctx: *CliCtx, op_label: []const u8, timings_flag: bool) progress
         .writer = ctx.io.stderr(),
         .op_label = op_label,
         .timings_flag = timings_flag,
-        .is_tty = is_tty,
+        .is_tty = is_tty and ctx.colorPolicy().mode != .never,
     });
 }
 
@@ -14344,7 +14397,7 @@ fn finishRocCheck(
 
     for (check_result.reports) |module| {
         for (module.reports) |*report| {
-            try reporting.renderReportToTerminal(report, stderr, ColorPalette.ANSI, stderr_report_config);
+            try reporting.renderReportToTerminal(report, stderr, reporting.ColorUtils.getPaletteForConfig(stderr_report_config), stderr_report_config);
         }
     }
 
@@ -15043,7 +15096,7 @@ fn bumpCheckSide(
 
     for (result.check_result.reports) |module| {
         for (module.reports) |*report| {
-            reporting.renderReportToTerminal(report, stderr, ColorPalette.ANSI, report_config) catch {};
+            reporting.renderReportToTerminal(report, stderr, reporting.ColorUtils.getPaletteForConfig(report_config), report_config) catch {};
         }
     }
     if (result.check_result.error_count > 0) {
@@ -15301,7 +15354,7 @@ fn rocDocs(ctx: *CliCtx, args_in: cli_args.DocsArgs) CliMainError!void {
         for (module.reports) |*report| {
 
             // Render the diagnostic report to stderr
-            reporting.renderReportToTerminal(report, stderr, ColorPalette.ANSI, report_config) catch |render_err| {
+            reporting.renderReportToTerminal(report, stderr, reporting.ColorUtils.getPaletteForConfig(report_config), report_config) catch |render_err| {
                 stderr.print("Error rendering diagnostic report: {}", .{render_err}) catch {};
                 // Fallback to just printing the title
                 stderr.print("  {s}", .{report.title}) catch {};

--- a/src/cli/platform_validation.zig
+++ b/src/cli/platform_validation.zig
@@ -9,7 +9,6 @@
 //! This module is used by both `roc build` and `roc bundle` commands.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const parse = @import("parse");
 const base = @import("base");
 const reporting = @import("reporting");
@@ -18,20 +17,6 @@ pub const targets_validator = @import("targets_validator.zig");
 
 const TargetsConfig = target_mod.TargetsConfig;
 const RocTarget = target_mod.RocTarget;
-
-const is_windows = builtin.target.os.tag == .windows;
-
-var stderr_file_writer: std.Io.File.Writer = .{
-    .io = std.Io.Threaded.global_single_threaded.io(),
-    .interface = std.Io.File.Writer.initInterface(&.{}),
-    .file = if (is_windows) undefined else std.Io.File.stderr(),
-    .mode = .streaming,
-};
-
-fn stderrWriter() *std.Io.Writer {
-    if (is_windows) stderr_file_writer.file = std.Io.File.stderr();
-    return &stderr_file_writer.interface;
-}
 
 /// Re-export ValidationResult for callers that need to create reports
 pub const ValidationResult = targets_validator.ValidationResult;
@@ -68,10 +53,12 @@ pub fn validatePlatformHeader(
     allocator: std.mem.Allocator,
     std_io: std.Io,
     platform_source_path: []const u8,
+    stderr: *std.Io.Writer,
+    report_config: reporting.ReportingConfig,
 ) ValidationError!PlatformValidation {
     // Read platform source
     var source = std.Io.Dir.cwd().readFileAlloc(std_io, platform_source_path, allocator, .unlimited) catch {
-        try renderFileReadError(allocator, platform_source_path);
+        try renderFileReadError(allocator, platform_source_path, stderr, report_config);
         return error.FileReadError;
     };
     source = base.source_utils.normalizeLineEndingsRealloc(allocator, source) catch {
@@ -86,7 +73,7 @@ pub fn validatePlatformHeader(
     };
 
     const ast = parse.file(allocator, &env) catch {
-        try renderParseError(allocator, platform_source_path);
+        try renderParseError(allocator, platform_source_path, stderr, report_config);
         return error.ParseError;
     };
     defer ast.deinit();
@@ -95,7 +82,7 @@ pub fn validatePlatformHeader(
     const config = TargetsConfig.fromAST(allocator, ast) catch {
         return error.ParseError;
     } orelse {
-        try renderMissingTargetsError(allocator, platform_source_path);
+        try renderMissingTargetsError(allocator, platform_source_path, stderr, report_config);
         return error.MissingTargetsSection;
     };
 
@@ -106,7 +93,12 @@ pub fn validatePlatformHeader(
 }
 
 /// Render a file read error report to stderr.
-fn renderFileReadError(allocator: std.mem.Allocator, path: []const u8) std.mem.Allocator.Error!void {
+fn renderFileReadError(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    stderr: *std.Io.Writer,
+    report_config: reporting.ReportingConfig,
+) std.mem.Allocator.Error!void {
     var report = try reporting.Report.init(allocator, "File Read Error", "Failed to read platform source file.", .fatal);
     defer report.deinit();
 
@@ -119,14 +111,19 @@ fn renderFileReadError(allocator: std.mem.Allocator, path: []const u8) std.mem.A
 
     reporting.renderReportToTerminal(
         &report,
-        stderrWriter(),
-        .ANSI,
-        reporting.ReportingConfig.initColorTerminal(),
+        stderr,
+        reporting.ColorUtils.getPaletteForConfig(report_config),
+        report_config,
     ) catch {};
 }
 
 /// Render a parse error report to stderr.
-fn renderParseError(allocator: std.mem.Allocator, path: []const u8) std.mem.Allocator.Error!void {
+fn renderParseError(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    stderr: *std.Io.Writer,
+    report_config: reporting.ReportingConfig,
+) std.mem.Allocator.Error!void {
     var report = try reporting.Report.init(allocator, "Parse Error", "Failed to parse platform header.", .fatal);
     defer report.deinit();
 
@@ -139,14 +136,19 @@ fn renderParseError(allocator: std.mem.Allocator, path: []const u8) std.mem.Allo
 
     reporting.renderReportToTerminal(
         &report,
-        stderrWriter(),
-        .ANSI,
-        reporting.ReportingConfig.initColorTerminal(),
+        stderr,
+        reporting.ColorUtils.getPaletteForConfig(report_config),
+        report_config,
     ) catch {};
 }
 
 /// Render a missing targets section error report to stderr.
-fn renderMissingTargetsError(allocator: std.mem.Allocator, path: []const u8) std.mem.Allocator.Error!void {
+fn renderMissingTargetsError(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    stderr: *std.Io.Writer,
+    report_config: reporting.ReportingConfig,
+) std.mem.Allocator.Error!void {
     const headline = try std.fmt.allocPrint(allocator, "Platform at {s} does not have a 'targets:' section.", .{path});
     defer allocator.free(headline);
     var report = try reporting.Report.init(allocator, "Missing Targets Section", headline, .fatal);
@@ -166,9 +168,9 @@ fn renderMissingTargetsError(allocator: std.mem.Allocator, path: []const u8) std
 
     reporting.renderReportToTerminal(
         &report,
-        stderrWriter(),
-        .ANSI,
-        reporting.ReportingConfig.initColorTerminal(),
+        stderr,
+        reporting.ColorUtils.getPaletteForConfig(report_config),
+        report_config,
     ) catch {};
 }
 
@@ -206,6 +208,7 @@ pub fn renderValidationError(
     allocator: std.mem.Allocator,
     result: ValidationResult,
     stderr: anytype,
+    report_config: reporting.ReportingConfig,
 ) bool {
     switch (result) {
         .valid => return false,
@@ -220,8 +223,8 @@ pub fn renderValidationError(
             reporting.renderReportToTerminal(
                 &report,
                 stderr,
-                .ANSI,
-                reporting.ReportingConfig.initColorTerminal(),
+                reporting.ColorUtils.getPaletteForConfig(report_config),
+                report_config,
             ) catch {};
             return true;
         },

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -5265,6 +5265,7 @@ fn parityCompareVerbs(
     timeout_ms: u64,
     fixture: []const u8,
     expected_exits: [4]u32,
+    expect_no_ansi: bool,
 ) ?TestResult {
     const build_out = std.fs.path.join(allocator, &.{ env.dirs.work_dir, "parity-build-out" }) catch |err|
         return customInfraFailure(allocator, timer, "failed to allocate build output path: {}", .{err});
@@ -5275,10 +5276,10 @@ fn parityCompareVerbs(
         name: []const u8,
         args: []const []const u8,
     }{
-        .{ .name = "check", .args = &.{ "check", "--no-cache" } },
-        .{ .name = "build", .args = &.{ "build", "--no-cache", build_out_arg } },
-        .{ .name = "run", .args = &.{"--no-cache"} },
-        .{ .name = "test", .args = &.{ "test", "--no-cache" } },
+        .{ .name = "check", .args = &.{ "--no-color", "check", "--no-cache" } },
+        .{ .name = "build", .args = &.{ "--no-color", "build", "--no-cache", build_out_arg } },
+        .{ .name = "run", .args = &.{ "--no-color", "--no-cache" } },
+        .{ .name = "test", .args = &.{ "--no-color", "test", "--no-cache" } },
     };
 
     var normalized: [verbs.len][]u8 = undefined;
@@ -5292,6 +5293,9 @@ fn parityCompareVerbs(
             .failure => |failure| return failure,
             .result => |result| result,
         };
+        if (expect_no_ansi) {
+            if (expectNoAnsiInPreSummary(allocator, timer, verb.name, result)) |failure| return failure;
+        }
         normalized[i] = parityNormalizedReports(allocator, result.stderr) catch |err|
             return customInfraFailure(allocator, timer, "parity normalization failed: {}", .{err});
     }
@@ -5311,11 +5315,11 @@ fn parityCompareVerbs(
 
 fn customPipelineParityDiagnostics(io: std.Io, allocator: Allocator, env: *const CaseEnv, timer: *harness.Timer, timeout_ms: u64) ?TestResult {
     // Warnings retain the shared exit-2 policy after every verb completes.
-    if (parityCompareVerbs(io, allocator, env, timer, timeout_ms, "test/cli/pipeline_parity/warn_app/main.roc", .{ 2, 2, 2, 2 })) |failure| return failure;
+    if (parityCompareVerbs(io, allocator, env, timer, timeout_ms, "test/cli/pipeline_parity/warn_app/main.roc", .{ 2, 2, 2, 2 }, true)) |failure| return failure;
     // A build completes and emits its executable despite the diagnostic; check
     // reports failure, run reaches the checked error, and test reports failure
     // only after executing all independent roots.
-    if (parityCompareVerbs(io, allocator, env, timer, timeout_ms, "test/cli/pipeline_parity/error_app/main.roc", .{ 1, 0, 1, 1 })) |failure| return failure;
+    if (parityCompareVerbs(io, allocator, env, timer, timeout_ms, "test/cli/pipeline_parity/error_app/main.roc", .{ 1, 0, 1, 1 }, false)) |failure| return failure;
     return null;
 }
 

--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -3217,12 +3217,17 @@ pub const BuildEnv = struct {
 
     /// Drain reports and render them to a writer. Returns error/warning counts.
     /// Replaces the repeated drain → iterate → render boilerplate pattern.
-    pub fn renderDiagnostics(self: *BuildEnv, writer: anytype) Allocator.Error!RenderDiagnosticsResult {
+    pub fn renderDiagnostics(
+        self: *BuildEnv,
+        writer: anytype,
+        config: reporting.ReportingConfig,
+    ) Allocator.Error!RenderDiagnosticsResult {
         const drained = try self.drainReports();
         defer self.freeDrainedReports(drained);
 
         var total_error_count: usize = 0;
         var total_warning_count: usize = 0;
+        const palette = reporting.ColorUtils.getPaletteForConfig(config);
 
         for (drained) |mod| {
             for (mod.reports) |*report| {
@@ -3231,8 +3236,6 @@ pub const BuildEnv = struct {
                     .runtime_error, .fatal => total_error_count += 1,
                     .warning => total_warning_count += 1,
                 }
-                const palette = reporting.ColorUtils.getPaletteForConfig(reporting.ReportingConfig.initColorTerminal());
-                const config = reporting.ReportingConfig.initColorTerminal();
                 reporting.renderReportToTerminal(report, writer, palette, config) catch {};
             }
         }
@@ -3246,7 +3249,12 @@ pub const BuildEnv = struct {
     /// Render one warning for each `dbg` that remains in an optimized build.
     /// Optimized builds intentionally keep `dbg` so users can debug performance
     /// problems, but release artifacts should make those call sites visible.
-    pub fn renderOptimizedDbgWarnings(self: *BuildEnv, writer: anytype, opt_name: []const u8) Allocator.Error!usize {
+    pub fn renderOptimizedDbgWarnings(
+        self: *BuildEnv,
+        writer: anytype,
+        opt_name: []const u8,
+        config: reporting.ReportingConfig,
+    ) Allocator.Error!usize {
         const modules = try self.getCompiledModules(self.gpa);
         defer self.gpa.free(modules);
 
@@ -3257,7 +3265,7 @@ pub const BuildEnv = struct {
 
             try collectDbgRegionsInModule(self.gpa, mod.semantic.env, &regions);
             for (regions.items) |region| {
-                try self.renderOptimizedDbgWarning(writer, mod.semantic.env, mod.path, opt_name, region);
+                try self.renderOptimizedDbgWarning(writer, mod.semantic.env, mod.path, opt_name, region, config);
                 total += 1;
             }
         }
@@ -3271,6 +3279,7 @@ pub const BuildEnv = struct {
         path: []const u8,
         opt_name: []const u8,
         region: base.Region,
+        config: reporting.ReportingConfig,
     ) Allocator.Error!void {
         var report = try Report.init(self.gpa, "`dbg` in Optimized Build", "", .warning);
         defer report.deinit();
@@ -3293,8 +3302,7 @@ pub const BuildEnv = struct {
         try report.document.addInlineCode("dbg");
         try report.document.addReflowingText(" is intended for debugging.");
 
-        const palette = reporting.ColorUtils.getPaletteForConfig(reporting.ReportingConfig.initColorTerminal());
-        const config = reporting.ReportingConfig.initColorTerminal();
+        const palette = reporting.ColorUtils.getPaletteForConfig(config);
         reporting.renderReportToTerminal(&report, writer, palette, config) catch {};
     }
 

--- a/src/glue/glue.zig
+++ b/src/glue/glue.zig
@@ -31,6 +31,7 @@ const parse = @import("parse");
 const compile = @import("compile");
 const check = @import("check");
 const can = @import("can");
+const reporting = @import("reporting");
 const roc_target = @import("roc_target");
 const layout = @import("layout");
 const lir = @import("lir");
@@ -64,6 +65,7 @@ pub const GlueArgs = struct {
     glue_spec: []const u8,
     output_dir: []const u8,
     platform_path: []const u8,
+    report_config: reporting.ReportingConfig,
     opt: GlueOpt = .dev,
     no_cache: bool = false,
     /// Prebuilt plugin dylib from a `roc install`ed glue spec. When set, it
@@ -158,10 +160,10 @@ fn rocGlueInner(gpa: Allocator, stderr: *std.Io.Writer, stdout: *std.Io.Writer, 
     };
 
     build_env.build(platform_abs_path) catch {
-        _ = try build_env.renderDiagnostics(stderr);
+        _ = try build_env.renderDiagnostics(stderr, args.report_config);
         return error.CompilationFailed;
     };
-    _ = try build_env.renderDiagnostics(stderr);
+    _ = try build_env.renderDiagnostics(stderr, args.report_config);
 
     const modules = build_env.getModulesInSerializationOrder(gpa) catch {
         return error.ModuleRetrieval;
@@ -284,7 +286,7 @@ fn rocGlueInner(gpa: Allocator, stderr: *std.Io.Writer, stdout: *std.Io.Writer, 
     };
 
     // 5. Compile glue spec through checked artifacts and lower to LIR.
-    var spec = try compileGlueSpec(gpa, stderr, args.glue_spec, args.no_cache, std_io);
+    var spec = try compileGlueSpec(gpa, stderr, args.glue_spec, args.no_cache, args.report_config, std_io);
     defer spec.deinit(gpa);
     const lowered = &spec.lowered;
     const root_artifact = spec.root_artifact;
@@ -394,7 +396,14 @@ const CompiledGlueSpec = struct {
 
 /// Compile a glue spec (an app on the compiler-owned glue platform) and
 /// lower it to LIR, ready for plugin-dylib codegen or interpretation.
-fn compileGlueSpec(gpa: Allocator, stderr: *std.Io.Writer, glue_spec: []const u8, no_cache: bool, std_io: std.Io) GlueError!CompiledGlueSpec {
+fn compileGlueSpec(
+    gpa: Allocator,
+    stderr: *std.Io.Writer,
+    glue_spec: []const u8,
+    no_cache: bool,
+    report_config: reporting.ReportingConfig,
+    std_io: std.Io,
+) GlueError!CompiledGlueSpec {
     std.Io.Dir.cwd().access(std_io, glue_spec, .{}) catch {
         return error.GlueSpecNotFound;
     };
@@ -420,10 +429,10 @@ fn compileGlueSpec(gpa: Allocator, stderr: *std.Io.Writer, glue_spec: []const u8
     };
 
     build_env.build(glue_spec_abs) catch {
-        _ = try build_env.renderDiagnostics(stderr);
+        _ = try build_env.renderDiagnostics(stderr, report_config);
         return error.CompilationFailed;
     };
-    _ = try build_env.renderDiagnostics(stderr);
+    _ = try build_env.renderDiagnostics(stderr, report_config);
     if (!build_env.executable_artifacts_finalized) {
         return error.CompilationFailed;
     }
@@ -499,9 +508,10 @@ pub fn buildGlueSpecDylibFile(
     glue_spec: []const u8,
     output_path: []const u8,
     opt: GlueOpt,
+    report_config: reporting.ReportingConfig,
     std_io: std.Io,
 ) GlueError!void {
-    buildGlueSpecDylibFileInner(gpa, stderr, glue_spec, output_path, opt, std_io) catch |err| {
+    buildGlueSpecDylibFileInner(gpa, stderr, glue_spec, output_path, opt, report_config, std_io) catch |err| {
         (switch (err) {
             error.GlueSpecNotFound => stderr.print("Error: Glue spec file not found: '{s}'\n", .{glue_spec}),
             error.BuildEnvInit => stderr.print("Error: Failed to initialize build environment\n", .{}),
@@ -520,11 +530,12 @@ fn buildGlueSpecDylibFileInner(
     glue_spec: []const u8,
     output_path: []const u8,
     opt: GlueOpt,
+    report_config: reporting.ReportingConfig,
     std_io: std.Io,
 ) GlueError!void {
     if (builtin.target.os.tag == .freestanding) return error.GlueDylibUnavailable;
 
-    var spec = try compileGlueSpec(gpa, stderr, glue_spec, false, std_io);
+    var spec = try compileGlueSpec(gpa, stderr, glue_spec, false, report_config, std_io);
     defer spec.deinit(gpa);
 
     const stamp = gluePluginStamp(spec.root_artifact.key);


### PR DESCRIPTION
## Summary

Adds global `--no-color` support for CLI output.

- Applies to all CLI commands, not only `roc repl`.
- Keeps `--no-color` after an app-argument separator (`--`) untouched.
- Disables ANSI styling in diagnostics, build/test summaries, progress output, and REPL commands such as `:defs` and `:t`.
- Keeps existing default color behavior and `NO_COLOR` support.

Closes #7339

## Testing

```sh
zig fmt src/cli/cli_args.zig src/cli/CliCtx.zig src/cli/main.zig src/cli/ReplSession.zig
zig build run-test-zig-cli-main
```
