### PR TITLE
Filter type module docs to the main type

### DIFF
--- a/src/docs/extract.zig
+++ b/src/docs/extract.zig
@@ -444,15 +444,10 @@ fn filterTypeModuleEntries(
     var idx: usize = 0;
     while (idx < entries_list.items.len) {
         const entry = &entries_list.items[idx];
-        // Keep the main type entry (name matches the module name) and any entries
-        // that are prefixed with the module name (e.g. "Color.helper" which would
-        // have been a method moved under Color by the hierarchical pass, but if not
-        // yet moved, we still keep it).
-        if (std.mem.eql(u8, entry.name, module_name) or
-            (std.mem.startsWith(u8, entry.name, module_name) and
-                entry.name.len > module_name.len and
-                entry.name[module_name.len] == '.'))
-        {
+        // At this point the hierarchical pass has already moved associated
+        // entries under their parent. Anything still at top level is a sibling
+        // declaration, so a type module keeps only its main type entry.
+        if (std.mem.eql(u8, entry.name, module_name)) {
             idx += 1;
         } else {
             var removed = entries_list.orderedRemove(idx);

--- a/test/snapshots/docs_package_hides_private_modules.md
+++ b/test/snapshots/docs_package_hides_private_modules.md
@@ -1,6 +1,6 @@
 # META
 ~~~ini
-description=Issue 10077: package docs hide private modules and private type declarations
+description=Issue 10077: package docs hide private mods and private type declarations
 type=docs
 ~~~
 # SOURCE
@@ -13,7 +13,10 @@ package [Date, Time] {}
 import Util
 
 ## A calendar date.
-Date :: {}
+Date :: {}.{
+    ## Date formatting options.
+    Format :: {}
+}
 
 ## Private implementation details.
 Help :: {}
@@ -32,21 +35,27 @@ Util :: {}
 ~~~clojure
 (package-docs
   (name "test-app")
-  (module
+  (mod
     (name "Date")
-    (package "module")
-    (kind type_module)
+    (package "mod")
+    (kind type_mod)
     (entry
       (name "Date")
       (kind opaque)
       (type "Date :: " (record))
       (doc "A calendar date.")
+      (entry
+        (name "Format")
+        (kind opaque)
+        (type "Format :: " (record))
+        (doc "Date formatting options.")
+      )
     )
   )
-  (module
+  (mod
     (name "Time")
-    (package "module")
-    (kind type_module)
+    (package "mod")
+    (kind type_mod)
     (doc "A time of day.")
     (entry
       (name "Time")


### PR DESCRIPTION
`roc docs` now treats type modules as documenting the type named by the module: after associated items have been nested under that type, any remaining sibling top-level declarations are excluded. This is a follow-up to #10245 and prevents helper types such as `Help` from appearing in generated docs while keeping nested types like `Date.Format` with their parent type.