### PR TITLE
Normalize dispatch evidence paths across row tails

### DIFF
--- a/design.md
+++ b/design.md
@@ -3285,6 +3285,18 @@ over the concrete monomorphic callable at the consumption site, recursively:
 component owners consume the registry's explicit callable-or-structural result;
 ownerless shapes take the structural implementations.
 
+Evidence paths describe the normalized logical type, never checked-store row
+topology. Record and tag extension chains, including transparent aliases along
+those chains, are traversed by the evidence-param producer but are not emitted
+as path steps; a field or tag payload in any tail is addressed directly by its
+label from the logical row root. A static-dispatch requirement on an open-row
+remainder is pathless because closure erases that remainder as a standalone
+component; ordinary checked edges can still supply it, while a
+compiler-generated edge cannot synthesize it from the closed callable. The
+CheckedModule boundary validates both the path grammar and that every nonempty
+path resolves over its template's checked callable type before Monotype may
+consume it.
+
 Exact registry lookups — `(MethodOwner, MethodNameId)` — happen during
 checking, and during path synthesis for compiler-generated
 edges. The registry only ever answers exact lookups after the owner is known

--- a/src/check/canonical_names.zig
+++ b/src/check/canonical_names.zig
@@ -526,6 +526,10 @@ pub const CanonicalNameStore = struct {
         return self.record_field_labels.getText(@intFromEnum(id));
     }
 
+    pub fn recordFieldLabelCount(self: *const CanonicalNameStore) u32 {
+        return self.record_field_labels.count();
+    }
+
     /// Compare two record field label ids by their canonical text.
     pub fn recordFieldLabelTextEql(self: *const CanonicalNameStore, a: RecordFieldLabelId, b: RecordFieldLabelId) bool {
         return Ident.textEql(self.recordFieldLabelText(a), self.recordFieldLabelText(b));
@@ -538,6 +542,10 @@ pub const CanonicalNameStore = struct {
 
     pub fn tagLabelText(self: *const CanonicalNameStore, id: TagLabelId) []const u8 {
         return self.tag_labels.getText(@intFromEnum(id));
+    }
+
+    pub fn tagLabelCount(self: *const CanonicalNameStore) u32 {
+        return self.tag_labels.count();
     }
 
     /// Compare two tag label ids by their canonical text.

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -22752,6 +22752,9 @@ pub const DispatchEvidenceFailure = struct {
         template_plan_refs_out_of_bounds,
         template_evidence_params_out_of_bounds,
         evidence_param_path_out_of_bounds,
+        evidence_param_path_invalid_kind,
+        evidence_param_path_invalid_shape,
+        evidence_param_path_diverges_from_checked_type,
     };
 
     kind: Kind,
@@ -23137,7 +23140,7 @@ pub const CheckedModuleArtifact = struct {
     /// Manual discriminant for `SERIALIZED_VERSION_HASH`: bump to force a cache /
     /// baked-blob invalidation for a layout change the structural fingerprint below
     /// cannot observe (e.g. a semantic change to how a field is interpreted).
-    const serialized_layout_version: u32 = 24;
+    const serialized_layout_version: u32 = 25;
 
     /// Comptime fingerprint of `Serialized`'s layout, mirroring
     /// `cache_module.MODULE_ENV_VERSION_HASH`. It is appended to the baked builtin
@@ -23375,6 +23378,181 @@ pub const CheckedModuleArtifact = struct {
         return null;
     }
 
+    fn evidencePathGrammarFailure(path: []const static_dispatch.EvidencePathStep) ?DispatchEvidenceFailure.Kind {
+        var path_index: usize = 0;
+        while (path_index < path.len) {
+            const path_step = path[path_index];
+            const kind = path_step.kindOrNull() orelse return .evidence_param_path_invalid_kind;
+            path_index += 1;
+            switch (kind) {
+                .fn_ret, .alias_backing, .nominal_backing => {
+                    if (path_step.data != 0) return .evidence_param_path_invalid_shape;
+                },
+                .tag_payload_tag => {
+                    if (path_index >= path.len) return .evidence_param_path_invalid_shape;
+                    const payload_kind = path[path_index].kindOrNull() orelse return .evidence_param_path_invalid_kind;
+                    if (payload_kind != .tag_payload_index) return .evidence_param_path_invalid_shape;
+                    path_index += 1;
+                },
+                .tag_payload_index => return .evidence_param_path_invalid_shape,
+                .fn_arg, .alias_arg, .nominal_arg, .tuple_elem, .record_field => {},
+            }
+        }
+        return null;
+    }
+
+    fn checkedPayloadOrNull(view: CheckedTypeStoreView, ty: CheckedTypeId) ?CheckedTypePayload {
+        if (@intFromEnum(ty) >= view.payloadCount()) return null;
+        return view.payload(ty);
+    }
+
+    /// Resolve one logical record-field selection over the published checked
+    /// row. Aliases and row extensions are transparent producer topology; a
+    /// nominal is not, matching the durable path and Monotype consumer.
+    fn checkedEvidenceRecordFieldChild(
+        view: CheckedTypeStoreView,
+        names: *const canonical.CanonicalNameStore,
+        root: CheckedTypeId,
+        label: canonical.RecordFieldLabelId,
+    ) ?CheckedTypeId {
+        var current = root;
+        var remaining = view.payloadCount() + 1;
+        while (remaining > 0) : (remaining -= 1) {
+            switch (checkedPayloadOrNull(view, current) orelse return null) {
+                .alias => |alias| current = alias.backing,
+                .record => |record| {
+                    for (record.fields) |field| {
+                        if (names.recordFieldLabelTextEql(field.name, label)) return field.ty;
+                    }
+                    current = record.ext;
+                },
+                .record_unbound => |fields| {
+                    for (fields) |field| {
+                        if (names.recordFieldLabelTextEql(field.name, label)) return field.ty;
+                    }
+                    return null;
+                },
+                else => return null,
+            }
+        }
+        return null;
+    }
+
+    /// Resolve one logical tag-payload selection over the published checked
+    /// row, with the same alias/extension normalization as record fields.
+    fn checkedEvidenceTagPayloadChild(
+        view: CheckedTypeStoreView,
+        names: *const canonical.CanonicalNameStore,
+        root: CheckedTypeId,
+        label: canonical.TagLabelId,
+        payload_index: u32,
+    ) ?CheckedTypeId {
+        var current = root;
+        var remaining = view.payloadCount() + 1;
+        while (remaining > 0) : (remaining -= 1) {
+            switch (checkedPayloadOrNull(view, current) orelse return null) {
+                .alias => |alias| current = alias.backing,
+                .tag_union => |tag_union| {
+                    for (tag_union.tags) |tag| {
+                        if (!names.tagLabelTextEql(tag.name, label)) continue;
+                        const payloads = tag.argsSlice(view);
+                        if (payload_index >= payloads.len) return null;
+                        return payloads[payload_index];
+                    }
+                    current = tag_union.ext;
+                },
+                else => return null,
+            }
+        }
+        return null;
+    }
+
+    /// Verify that a normalized path selects a real component of the
+    /// template's published checked callable. This mirrors Monotype's path
+    /// vocabulary while resolving row labels across complete logical rows.
+    fn checkedEvidencePathResolves(
+        self: *const CheckedModuleArtifact,
+        start_ty: CheckedTypeId,
+        path: []const static_dispatch.EvidencePathStep,
+    ) bool {
+        const view = self.checked_types.view();
+        var ty = start_ty;
+        var path_index: usize = 0;
+        while (path_index < path.len) {
+            const path_step = path[path_index];
+            const kind = path_step.kindOrNull() orelse return false;
+            path_index += 1;
+            const payload = checkedPayloadOrNull(view, ty) orelse return false;
+            switch (kind) {
+                .fn_arg => switch (payload) {
+                    .function => |func| {
+                        if (path_step.data >= func.args.len) return false;
+                        ty = func.args[path_step.data];
+                    },
+                    else => return false,
+                },
+                .fn_ret => switch (payload) {
+                    .function => |func| ty = func.ret,
+                    else => return false,
+                },
+                .alias_arg => switch (payload) {
+                    .alias => |alias| {
+                        if (path_step.data >= alias.args.len) return false;
+                        ty = alias.args[path_step.data];
+                    },
+                    else => return false,
+                },
+                .alias_backing => switch (payload) {
+                    .alias => |alias| ty = alias.backing,
+                    else => return false,
+                },
+                .nominal_arg => switch (payload) {
+                    .nominal => |nominal| {
+                        if (path_step.data >= nominal.args.len) return false;
+                        ty = nominal.args[path_step.data];
+                    },
+                    else => return false,
+                },
+                .nominal_backing => switch (payload) {
+                    .nominal => |nominal| ty = view.nominalBackingTemplateForPayload(nominal) orelse return false,
+                    else => return false,
+                },
+                .tuple_elem => switch (payload) {
+                    .tuple => |elems| {
+                        if (path_step.data >= elems.len) return false;
+                        ty = elems[path_step.data];
+                    },
+                    else => return false,
+                },
+                .record_field => {
+                    if (path_step.data >= self.canonical_names.recordFieldLabelCount()) return false;
+                    ty = checkedEvidenceRecordFieldChild(
+                        view,
+                        &self.canonical_names,
+                        ty,
+                        @enumFromInt(path_step.data),
+                    ) orelse return false;
+                },
+                .tag_payload_tag => {
+                    if (path_index >= path.len) return false;
+                    const payload_step = path[path_index];
+                    if (payload_step.kindOrNull() != .tag_payload_index) return false;
+                    path_index += 1;
+                    if (path_step.data >= self.canonical_names.tagLabelCount()) return false;
+                    ty = checkedEvidenceTagPayloadChild(
+                        view,
+                        &self.canonical_names,
+                        ty,
+                        @enumFromInt(path_step.data),
+                        payload_step.data,
+                    ) orelse return false;
+                },
+                .tag_payload_index => return false,
+            }
+        }
+        return true;
+    }
+
     /// Public `validateDispatchEvidence` function.
     ///
     /// Dispatch-evidence totality at the check/postcheck boundary: every
@@ -23480,6 +23658,24 @@ pub const CheckedModuleArtifact = struct {
         for (templates.evidence_params_pool, 0..) |param, i| {
             if (@as(u64, param.path.start) + param.path.len > templates.evidence_param_paths.len) {
                 return .{ .kind = .evidence_param_path_out_of_bounds, .index = @intCast(i), .method = param.method };
+            }
+            const path = templates.evidenceParamPath(param);
+            if (evidencePathGrammarFailure(path)) |kind| {
+                return .{ .kind = kind, .index = @intCast(i), .method = param.method };
+            }
+        }
+        for (templates.templates) |template| {
+            const params = templates.evidenceParams(&template);
+            for (params, 0..) |param, param_offset| {
+                const path = templates.evidenceParamPath(param);
+                if (path.len == 0) continue;
+                if (!self.checkedEvidencePathResolves(template.checked_fn_root, path)) {
+                    return .{
+                        .kind = .evidence_param_path_diverges_from_checked_type,
+                        .index = template.evidence_params.start + @as(u32, @intCast(param_offset)),
+                        .method = param.method,
+                    };
+                }
             }
         }
 
@@ -27750,8 +27946,8 @@ test "SERIALIZED_VERSION_HASH golden value" {
     // change, bump `serialized_layout_version` and replace the golden bytes below with
     // the ones this assertion prints.
     const golden: [32]u8 = .{
-        0x6A, 0x38, 0x1B, 0x6C, 0x78, 0x7F, 0x16, 0xA6, 0x0E, 0x22, 0x6A, 0xEE, 0x36, 0xF1, 0x13, 0x36,
-        0x78, 0x77, 0x71, 0xD2, 0x9D, 0x19, 0xB6, 0x80, 0x73, 0x8D, 0xE3, 0x5D, 0x02, 0x71, 0xC0, 0xFB,
+        0x84, 0x42, 0x29, 0x9E, 0x9F, 0xCB, 0x4F, 0x12, 0x90, 0x16, 0xFF, 0xCD, 0xD2, 0x5B, 0xE9, 0x3D,
+        0xEC, 0x53, 0x60, 0x36, 0xD8, 0x87, 0xA6, 0xC8, 0xDA, 0x78, 0x1E, 0x70, 0x40, 0x96, 0x4F, 0x03,
     };
     try std.testing.expectEqualSlices(u8, &golden, &CheckedModuleArtifact.SERIALIZED_VERSION_HASH);
 }

--- a/src/check/dispatch_evidence.zig
+++ b/src/check/dispatch_evidence.zig
@@ -10,15 +10,18 @@
 //! enumerate identical lists without sharing var identities.
 //!
 //! Order contract: depth-first over the resolved type structure — function
-//! args then return, alias/nominal args then backing, row fields/tags then
-//! extension, all in store order — emitting each constrained var's
-//! constraints in range order at its first occurrence; then the collected
+//! args then return, ordinary alias/nominal args then backing, and logical row
+//! fields/tags across the complete extension chain, all in store order —
+//! emitting each constrained var's constraints in range order at its first
+//! occurrence; then the collected
 //! constraints' fn types are walked the same way in emission order (they can
 //! bind further constrained vars, e.g. `where [a.iter : a -> i, i.next : ..]`).
 //!
 //! Each param also carries the semantic PATH from the scheme root to its
 //! dispatcher's first occurrence (function arg positions, type arguments,
-//! row labels, …). Compiler-generated call edges — structural-derivation
+//! row labels, …). Row-extension storage chains, including transparent aliases
+//! within them, are normalized away: a field or tag payload in any tail is
+//! addressed directly from the logical row root. Compiler-generated call edges — structural-derivation
 //! component calls, builtin helper calls — have no checked instantiation
 //! records, so monotype resolves a target's obligations by walking these
 //! paths over the concrete monomorphic callable instead.
@@ -39,22 +42,42 @@ pub const PathStep = extern struct {
     data: u32,
 
     pub const Kind = enum(u32) {
-        fn_arg,
-        fn_ret,
-        alias_arg,
-        alias_backing,
-        nominal_arg,
-        nominal_backing,
-        tuple_elem,
-        record_field,
-        record_ext,
-        tag_payload_tag,
-        tag_payload_index,
-        tag_ext,
+        fn_arg = 0,
+        fn_ret = 1,
+        alias_arg = 2,
+        alias_backing = 3,
+        nominal_arg = 4,
+        nominal_backing = 5,
+        tuple_elem = 6,
+        record_field = 7,
+        // 8 was the checked-store `record_ext` step. Durable paths normalize
+        // row-extension topology away, so the value remains retired.
+        tag_payload_tag = 9,
+        tag_payload_index = 10,
+        // 11 was the checked-store `tag_ext` step and remains retired.
     };
 
+    /// Decode a serialized path kind without trapping on a retired or corrupt
+    /// discriminant. Artifact boundary validation uses this before consumers
+    /// call `stepKind`.
+    pub fn kindOrNull(self: PathStep) ?Kind {
+        return switch (self.kind) {
+            @intFromEnum(Kind.fn_arg) => .fn_arg,
+            @intFromEnum(Kind.fn_ret) => .fn_ret,
+            @intFromEnum(Kind.alias_arg) => .alias_arg,
+            @intFromEnum(Kind.alias_backing) => .alias_backing,
+            @intFromEnum(Kind.nominal_arg) => .nominal_arg,
+            @intFromEnum(Kind.nominal_backing) => .nominal_backing,
+            @intFromEnum(Kind.tuple_elem) => .tuple_elem,
+            @intFromEnum(Kind.record_field) => .record_field,
+            @intFromEnum(Kind.tag_payload_tag) => .tag_payload_tag,
+            @intFromEnum(Kind.tag_payload_index) => .tag_payload_index,
+            else => null,
+        };
+    }
+
     pub fn stepKind(self: PathStep) Kind {
-        return @enumFromInt(self.kind);
+        return self.kindOrNull() orelse unreachable;
     }
 };
 
@@ -64,10 +87,11 @@ pub const EvidenceParam = struct {
     dispatcher_var: Var,
     constraint: StaticDispatchConstraint,
     /// Semantic steps from the scheme root to the dispatcher's first
-    /// occurrence. Empty for dispatchers reachable only through a
-    /// constraint's fn type (no path over the callable exists). Aliases the
-    /// scratch path pool: valid until the next `enumerateEvidenceParams`
-    /// call with the same scratch.
+    /// occurrence. Empty when no path over the normalized callable exists:
+    /// dispatchers reachable only through a constraint's fn type, and open-row
+    /// remainder vars erased when the row closes. Aliases the scratch path
+    /// pool: valid until the next `enumerateEvidenceParams` call with the same
+    /// scratch.
     path: []const PathStep = &.{},
     /// Pool offsets backing `path`; fixed up into the slice once the walk's
     /// pool stops growing.
@@ -79,7 +103,12 @@ const StackEntry = struct {
     var_: Var,
     path_start: u32,
     path_len: u32,
+    /// A row continuation is checked-store traversal state, not a semantic
+    /// path component. Its fields/tags extend the logical row at `path`.
+    row_context: RowContext = .none,
 };
+
+const RowContext = enum { none, record, tag };
 
 /// Reusable scratch state for `enumerateEvidenceParams`.
 pub const Scratch = struct {
@@ -93,7 +122,9 @@ pub const Scratch = struct {
 
     const Child = struct {
         var_: Var,
-        step: PathStep,
+        steps: [2]PathStep = undefined,
+        step_len: u32,
+        row_context: RowContext = .none,
     };
 
     pub fn deinit(self: *Scratch, gpa: Allocator) void {
@@ -163,39 +194,36 @@ fn walk(
         const seen = try scratch.visited.getOrPut(gpa, resolved.var_);
         if (seen.found_existing) continue;
 
+        if (entry.row_context != .none) {
+            try walkRowContinuation(gpa, store, resolved, entry, scratch, out);
+            continue;
+        }
+
         switch (resolved.desc.content) {
             .flex => |flex| try emitConstraints(gpa, store, resolved.var_, flex.constraints, entry, with_paths, scratch, out),
             .rigid => |rigid| try emitConstraints(gpa, store, resolved.var_, rigid.constraints, entry, with_paths, scratch, out),
             .alias => |alias| {
                 scratch.children.clearRetainingCapacity();
                 for (store.sliceAliasArgs(alias), 0..) |arg, i| {
-                    try scratch.children.append(gpa, .{ .var_ = arg, .step = step(.alias_arg, @intCast(i)) });
+                    try scratch.children.append(gpa, child(arg, step(.alias_arg, @intCast(i))));
                 }
-                try scratch.children.append(gpa, .{ .var_ = store.getAliasBackingVar(alias), .step = step(.alias_backing, 0) });
+                try scratch.children.append(gpa, child(store.getAliasBackingVar(alias), step(.alias_backing, 0)));
                 try pushChildren(gpa, scratch, entry);
             },
             .structure => |flat_type| switch (flat_type) {
-                .record => |record| {
-                    scratch.children.clearRetainingCapacity();
-                    const fields = store.getRecordFieldsSlice(record.fields);
-                    for (fields.items(.name), fields.items(.var_)) |name, field_var| {
-                        try scratch.children.append(gpa, .{ .var_ = field_var, .step = step(.record_field, @bitCast(name)) });
-                    }
-                    try scratch.children.append(gpa, .{ .var_ = record.ext, .step = step(.record_ext, 0) });
-                    try pushChildren(gpa, scratch, entry);
-                },
+                .record => |record| try pushRecordChildren(gpa, scratch, entry, store, record.fields, record.ext),
                 .record_unbound => |fields_range| {
                     scratch.children.clearRetainingCapacity();
                     const fields = store.getRecordFieldsSlice(fields_range);
                     for (fields.items(.name), fields.items(.var_)) |name, field_var| {
-                        try scratch.children.append(gpa, .{ .var_ = field_var, .step = step(.record_field, @bitCast(name)) });
+                        try scratch.children.append(gpa, child(field_var, step(.record_field, @bitCast(name))));
                     }
                     try pushChildren(gpa, scratch, entry);
                 },
                 .tuple => |tuple| {
                     scratch.children.clearRetainingCapacity();
                     for (store.sliceVars(tuple.elems), 0..) |elem, i| {
-                        try scratch.children.append(gpa, .{ .var_ = elem, .step = step(.tuple_elem, @intCast(i)) });
+                        try scratch.children.append(gpa, child(elem, step(.tuple_elem, @intCast(i))));
                     }
                     try pushChildren(gpa, scratch, entry);
                 },
@@ -207,19 +235,19 @@ fn walk(
                     // exactly like `.alias_backing`).
                     scratch.children.clearRetainingCapacity();
                     for (store.sliceNominalArgs(nominal), 0..) |arg, i| {
-                        try scratch.children.append(gpa, .{ .var_ = arg, .step = step(.nominal_arg, @intCast(i)) });
+                        try scratch.children.append(gpa, child(arg, step(.nominal_arg, @intCast(i))));
                     }
                     try pushChildren(gpa, scratch, entry);
                 },
                 .fn_pure, .fn_effectful, .fn_unbound => |func| {
                     scratch.children.clearRetainingCapacity();
                     for (store.sliceVars(func.args), 0..) |arg, i| {
-                        try scratch.children.append(gpa, .{ .var_ = arg, .step = step(.fn_arg, @intCast(i)) });
+                        try scratch.children.append(gpa, child(arg, step(.fn_arg, @intCast(i))));
                     }
-                    try scratch.children.append(gpa, .{ .var_ = func.ret, .step = step(.fn_ret, 0) });
+                    try scratch.children.append(gpa, child(func.ret, step(.fn_ret, 0)));
                     try pushChildren(gpa, scratch, entry);
                 },
-                .tag_union => |tag_union| try pushChildrenTagged(gpa, scratch, entry, store, tag_union),
+                .tag_union => |tag_union| try pushTagChildren(gpa, scratch, entry, store, tag_union),
                 .empty_record, .empty_tag_union => {},
             },
             .err => {},
@@ -227,64 +255,144 @@ fn walk(
     }
 }
 
+/// Traverse a checked row tail while keeping the path anchored at the logical
+/// row root. Transparent aliases and extension links are producer topology;
+/// neither is present after Monotype flattens the row.
+fn walkRowContinuation(
+    gpa: Allocator,
+    store: *const types_mod.Store,
+    resolved: types_mod.ResolvedVarDesc,
+    entry: StackEntry,
+    scratch: *Scratch,
+    out: *std.ArrayListUnmanaged(EvidenceParam),
+) Allocator.Error!void {
+    switch (resolved.desc.content) {
+        // An open row remainder is not a standalone component of the closed,
+        // flattened monomorphic row. Keep its obligation in canonical order,
+        // but publish it pathless rather than misidentifying the whole row as
+        // its dispatcher.
+        .flex => |flex| try emitConstraints(gpa, store, resolved.var_, flex.constraints, entry, false, scratch, out),
+        .rigid => |rigid| try emitConstraints(gpa, store, resolved.var_, rigid.constraints, entry, false, scratch, out),
+        .alias => |alias| {
+            scratch.children.clearRetainingCapacity();
+            try scratch.children.append(gpa, rowContinuation(store.getAliasBackingVar(alias), entry.row_context));
+            try pushChildren(gpa, scratch, entry);
+        },
+        .structure => |flat_type| switch (entry.row_context) {
+            .record => switch (flat_type) {
+                .record => |record| try pushRecordChildren(gpa, scratch, entry, store, record.fields, record.ext),
+                .record_unbound => |fields_range| {
+                    scratch.children.clearRetainingCapacity();
+                    const fields = store.getRecordFieldsSlice(fields_range);
+                    for (fields.items(.name), fields.items(.var_)) |name, field_var| {
+                        try scratch.children.append(gpa, child(field_var, step(.record_field, @bitCast(name))));
+                    }
+                    try pushChildren(gpa, scratch, entry);
+                },
+                .empty_record => {},
+                else => unreachable,
+            },
+            .tag => switch (flat_type) {
+                .tag_union => |tag_union| try pushTagChildren(gpa, scratch, entry, store, tag_union),
+                .empty_tag_union => {},
+                else => unreachable,
+            },
+            .none => unreachable,
+        },
+        .err => {},
+    }
+}
+
 fn step(kind: PathStep.Kind, data: u32) PathStep {
     return .{ .kind = @intFromEnum(kind), .data = data };
 }
 
+fn child(var_: Var, path_step: PathStep) Scratch.Child {
+    return .{ .var_ = var_, .steps = .{ path_step, undefined }, .step_len = 1 };
+}
+
+fn tagPayloadChild(var_: Var, tag_name_bits: u32, payload_index: u32) Scratch.Child {
+    return .{
+        .var_ = var_,
+        .steps = .{
+            step(.tag_payload_tag, tag_name_bits),
+            step(.tag_payload_index, payload_index),
+        },
+        .step_len = 2,
+    };
+}
+
+fn rowContinuation(var_: Var, context: RowContext) Scratch.Child {
+    std.debug.assert(context != .none);
+    return .{ .var_ = var_, .step_len = 0, .row_context = context };
+}
+
 /// Push the collected children so pops visit them in declared order, each
-/// with `entry`'s path extended by its own step.
+/// with `entry`'s path extended by its semantic steps. A zero-step child is a
+/// checked-store row continuation and retains the logical row-root path.
 fn pushChildren(gpa: Allocator, scratch: *Scratch, entry: StackEntry) Allocator.Error!void {
     var i = scratch.children.items.len;
     while (i > 0) {
         i -= 1;
-        const child = scratch.children.items[i];
+        const next_child = scratch.children.items[i];
+        if (next_child.step_len == 0) {
+            try scratch.stack.append(gpa, .{
+                .var_ = next_child.var_,
+                .path_start = entry.path_start,
+                .path_len = entry.path_len,
+                .row_context = next_child.row_context,
+            });
+            continue;
+        }
         const path_start: u32 = @intCast(scratch.path_pool.items.len);
         // Reserve before self-append: the source range aliases the pool.
-        try scratch.path_pool.ensureUnusedCapacity(gpa, entry.path_len + 1);
+        try scratch.path_pool.ensureUnusedCapacity(gpa, entry.path_len + next_child.step_len);
         scratch.path_pool.appendSliceAssumeCapacity(scratch.pathSlice(entry.path_start, entry.path_len));
-        scratch.path_pool.appendAssumeCapacity(child.step);
+        scratch.path_pool.appendSliceAssumeCapacity(next_child.steps[0..next_child.step_len]);
         try scratch.stack.append(gpa, .{
-            .var_ = child.var_,
+            .var_ = next_child.var_,
             .path_start = path_start,
-            .path_len = entry.path_len + 1,
+            .path_len = entry.path_len + next_child.step_len,
+            .row_context = next_child.row_context,
         });
     }
 }
 
-/// Tag-union variant of `pushChildren`: each payload gets a
-/// (tag label, payload index) step pair.
-fn pushChildrenTagged(
+fn pushRecordChildren(
+    gpa: Allocator,
+    scratch: *Scratch,
+    entry: StackEntry,
+    store: *const types_mod.Store,
+    fields_range: types_mod.RecordField.SafeMultiList.Range,
+    ext: Var,
+) Allocator.Error!void {
+    scratch.children.clearRetainingCapacity();
+    const fields = store.getRecordFieldsSlice(fields_range);
+    for (fields.items(.name), fields.items(.var_)) |name, field_var| {
+        try scratch.children.append(gpa, child(field_var, step(.record_field, @bitCast(name))));
+    }
+    try scratch.children.append(gpa, rowContinuation(ext, .record));
+    try pushChildren(gpa, scratch, entry);
+}
+
+/// Each payload gets a (tag label, payload index) semantic step pair. The
+/// extension is scheduled last as zero-step producer traversal state.
+fn pushTagChildren(
     gpa: Allocator,
     scratch: *Scratch,
     entry: StackEntry,
     store: *const types_mod.Store,
     tag_union: types_mod.TagUnion,
 ) Allocator.Error!void {
+    scratch.children.clearRetainingCapacity();
     const tags = store.getTagsSlice(tag_union.tags);
-    // Push ext first so it pops last.
-    {
-        const path_start: u32 = @intCast(scratch.path_pool.items.len);
-        try scratch.path_pool.ensureUnusedCapacity(gpa, entry.path_len + 1);
-        scratch.path_pool.appendSliceAssumeCapacity(scratch.pathSlice(entry.path_start, entry.path_len));
-        scratch.path_pool.appendAssumeCapacity(step(.tag_ext, 0));
-        try scratch.stack.append(gpa, .{ .var_ = tag_union.ext, .path_start = path_start, .path_len = entry.path_len + 1 });
-    }
-    var i: usize = tags.len;
-    while (i > 0) {
-        i -= 1;
-        const tag_name = tags.items(.name)[i];
-        const tag_args = store.sliceVars(tags.items(.args)[i]);
-        var j: usize = tag_args.len;
-        while (j > 0) {
-            j -= 1;
-            const path_start: u32 = @intCast(scratch.path_pool.items.len);
-            try scratch.path_pool.ensureUnusedCapacity(gpa, entry.path_len + 2);
-            scratch.path_pool.appendSliceAssumeCapacity(scratch.pathSlice(entry.path_start, entry.path_len));
-            scratch.path_pool.appendAssumeCapacity(step(.tag_payload_tag, @bitCast(tag_name)));
-            scratch.path_pool.appendAssumeCapacity(step(.tag_payload_index, @intCast(j)));
-            try scratch.stack.append(gpa, .{ .var_ = tag_args[j], .path_start = path_start, .path_len = entry.path_len + 2 });
+    for (tags.items(.name), tags.items(.args)) |tag_name, args| {
+        for (store.sliceVars(args), 0..) |arg, payload_index| {
+            try scratch.children.append(gpa, tagPayloadChild(arg, @bitCast(tag_name), @intCast(payload_index)));
         }
     }
+    try scratch.children.append(gpa, rowContinuation(tag_union.ext, .tag));
+    try pushChildren(gpa, scratch, entry);
 }
 
 fn emitConstraints(

--- a/src/check/static_dispatch_registry.zig
+++ b/src/check/static_dispatch_registry.zig
@@ -925,8 +925,9 @@ pub const EvidencePathStep = dispatch_evidence.PathStep;
 /// method name identifies the obligation, and `path` locates the dispatcher
 /// within the scheme's callable so compiler-generated call edges (which have
 /// no checked instantiation records) can resolve the obligation from the
-/// concrete monomorphic callable. An empty path means the dispatcher is only
-/// reachable through a constraint's fn type.
+/// concrete monomorphic callable. An empty path means the dispatcher has no
+/// component path over the normalized callable (it is reachable only through
+/// a constraint's fn type, or is an open-row remainder erased on closure).
 pub const EvidenceParamRecord = struct {
     method: canonical.MethodNameId,
     path: artifact_serialize.Span = .{},

--- a/src/check/test/dispatch_evidence_test.zig
+++ b/src/check/test/dispatch_evidence_test.zig
@@ -11,7 +11,8 @@ const ModuleEnv = @import("can").ModuleEnv;
 const dispatch_evidence = @import("../dispatch_evidence.zig");
 const TestEnv = @import("./TestEnv.zig");
 
-const Var = @import("types").Var;
+const types = @import("types");
+const Var = types.Var;
 
 fn defVar(env: *const ModuleEnv, name: []const u8) error{TestUnexpectedResult}!Var {
     const idents = env.getIdentStoreConst();
@@ -50,6 +51,36 @@ fn enumerate(
     var scratch = dispatch_evidence.Scratch{};
     defer scratch.deinit(gpa);
     try dispatch_evidence.enumerateEvidenceParams(gpa, &env.types, root, &scratch, out);
+}
+
+fn constrainedVar(env: *ModuleEnv, method_name: []const u8) std.mem.Allocator.Error!Var {
+    const unit_var = try env.types.freshFromContent(.{ .structure = .empty_record });
+    const fn_args = try env.types.appendVars(&.{unit_var});
+    const fn_var = try env.types.freshFromContent(.{ .structure = .{ .fn_pure = .{
+        .args = fn_args,
+        .ret = unit_var,
+    } } });
+    const constraint = types.StaticDispatchConstraint{
+        .fn_name = try env.insertIdent(@import("base").Ident.for_text(method_name)),
+        .fn_var = fn_var,
+        .origin = .{ .where_clause = .{} },
+    };
+    const constraints = try env.types.appendStaticDispatchConstraints(&.{constraint});
+    return try env.types.freshFromContent(.{ .flex = .{
+        .name = null,
+        .constraints = constraints,
+    } });
+}
+
+fn transparentAlias(env: *ModuleEnv, name: []const u8, backing: Var, args: []const Var) std.mem.Allocator.Error!Var {
+    const ident = try env.insertIdent(@import("base").Ident.for_text(name));
+    const content = try env.types.mkAlias(
+        .{ .ident_idx = ident },
+        backing,
+        args,
+        env.selfModuleIdentity(),
+    );
+    return try env.types.freshFromContent(content);
 }
 
 test "evidence params enumerate in signature order" {
@@ -108,6 +139,74 @@ test "evidence params reach vars bound only inside constraint fn types" {
     const idents = env.getIdentStoreConst();
     try std.testing.expectEqualStrings("step", idents.getText(params.items[0].constraint.fn_name));
     try std.testing.expectEqualStrings("to_str", idents.getText(params.items[1].constraint.fn_name));
+}
+
+test "record-tail evidence path is normalized to its logical row field" {
+    var test_env = try TestEnv.init("Test", "");
+    defer test_env.deinit();
+
+    const gpa = std.testing.allocator;
+    const env = test_env.module_env;
+    const dispatcher = try constrainedVar(env, "inspect_tail");
+    const head_value = try env.types.freshFromContent(.{ .structure = .empty_record });
+    const empty_tail = try env.types.freshFromContent(.{ .structure = .empty_record });
+    const head_name = try env.insertIdent(@import("base").Ident.for_text("head"));
+    const tail_name = try env.insertIdent(@import("base").Ident.for_text("tail"));
+
+    const tail_fields = try env.types.appendRecordFields(&.{.{ .name = tail_name, .var_ = dispatcher }});
+    const tail_row = try env.types.freshFromContent(.{ .structure = .{ .record = .{
+        .fields = tail_fields,
+        .ext = empty_tail,
+    } } });
+    const aliased_tail = try transparentAlias(env, "TailFields", tail_row, &.{dispatcher});
+    const head_fields = try env.types.appendRecordFields(&.{.{ .name = head_name, .var_ = head_value }});
+    const root = try env.types.freshFromContent(.{ .structure = .{ .record = .{
+        .fields = head_fields,
+        .ext = aliased_tail,
+    } } });
+
+    var params = std.ArrayListUnmanaged(dispatch_evidence.EvidenceParam).empty;
+    defer params.deinit(gpa);
+    var scratch = dispatch_evidence.Scratch{};
+    defer scratch.deinit(gpa);
+    try dispatch_evidence.enumerateEvidenceParams(gpa, &env.types, root, &scratch, &params);
+
+    try std.testing.expectEqual(@as(usize, 1), params.items.len);
+    try std.testing.expectEqual(@as(usize, 1), params.items[0].path.len);
+    try std.testing.expectEqual(@intFromEnum(dispatch_evidence.PathStep.Kind.record_field), params.items[0].path[0].kind);
+    try std.testing.expectEqual(@as(u32, @bitCast(tail_name)), params.items[0].path[0].data);
+}
+
+test "tag-tail evidence path is normalized to its logical tag payload" {
+    var test_env = try TestEnv.init("Test", "");
+    defer test_env.deinit();
+
+    const gpa = std.testing.allocator;
+    const env = test_env.module_env;
+    const dispatcher = try constrainedVar(env, "inspect_tail");
+    const head_value = try env.types.freshFromContent(.{ .structure = .empty_record });
+    const empty_tail = try env.types.freshFromContent(.{ .structure = .empty_tag_union });
+    const head_name = try env.insertIdent(@import("base").Ident.for_text("Head"));
+    const tail_name = try env.insertIdent(@import("base").Ident.for_text("Tail"));
+
+    const tail_tag = try env.types.mkTag(tail_name, &.{dispatcher});
+    const tail_row = try env.types.freshFromContent(try env.types.mkTagUnion(&.{tail_tag}, empty_tail));
+    const aliased_tail = try transparentAlias(env, "TailTags", tail_row, &.{dispatcher});
+    const head_tag = try env.types.mkTag(head_name, &.{head_value});
+    const root = try env.types.freshFromContent(try env.types.mkTagUnion(&.{head_tag}, aliased_tail));
+
+    var params = std.ArrayListUnmanaged(dispatch_evidence.EvidenceParam).empty;
+    defer params.deinit(gpa);
+    var scratch = dispatch_evidence.Scratch{};
+    defer scratch.deinit(gpa);
+    try dispatch_evidence.enumerateEvidenceParams(gpa, &env.types, root, &scratch, &params);
+
+    try std.testing.expectEqual(@as(usize, 1), params.items.len);
+    try std.testing.expectEqual(@as(usize, 2), params.items[0].path.len);
+    try std.testing.expectEqual(@intFromEnum(dispatch_evidence.PathStep.Kind.tag_payload_tag), params.items[0].path[0].kind);
+    try std.testing.expectEqual(@as(u32, @bitCast(tail_name)), params.items[0].path[0].data);
+    try std.testing.expectEqual(@intFromEnum(dispatch_evidence.PathStep.Kind.tag_payload_index), params.items[0].path[1].kind);
+    try std.testing.expectEqual(@as(u32, 0), params.items[0].path[1].data);
 }
 
 test "imported scheme copy enumerates the same param list as the defining module" {

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -120,6 +120,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10105_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10132_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10218_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10271_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));
     std.testing.refAllDecls(@import("test/platform_box_update_lir_test.zig"));

--- a/src/compile/test/issue_10271_test.zig
+++ b/src/compile/test/issue_10271_test.zig
@@ -1,0 +1,30 @@
+//! Regression test for issue #10271.
+
+const expectLowersToLir = @import("lower_to_lir_harness.zig").expectLowersToLir;
+
+test "issue 10271: nested effectful try mapping lowers to LIR" {
+    // Repro for https://github.com/roc-lang/roc/issues/10271.
+    // Nested effectful `?` calls with an error mapper must preserve the
+    // concrete callable's dispatcher paths through post-check lowering.
+    try expectLowersToLir(
+        \\step! : () => Try({}, [StepErr(Str), ..])
+        \\step! = || Ok({})
+        \\
+        \\run! = |task| {
+        \\    _ = step!()?
+        \\    Ok(task()?)
+        \\}
+        \\
+        \\main! : List(Str) => Try({}, _)
+        \\main! = |_args| {
+        \\    result = run!(
+        \\        || {
+        \\            _ = step!()?
+        \\            Err(BadInput("oops"))
+        \\        },
+        \\    ) ? |err| RunFailed(err)
+        \\    _ = result
+        \\    Ok({})
+        \\}
+    );
+}

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -5442,6 +5442,41 @@ test "dispatch evidence boundary validator accepts a published artifact" {
     try std.testing.expect(resources.checked_artifact.validateDispatchEvidence() == null);
 }
 
+test "dispatch evidence boundary validator rejects non-normalized and malformed paths" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\helper : a -> Str where [a.to_str : a -> Str]
+        \\helper = |_x| "ok"
+        \\
+        \\main : Str
+        \\main = helper("hi")
+    ;
+    var resources = try helpers.parseAndCanonicalizeProgramWithBuiltin(allocator, .module, source, &.{}, try sharedPrePublishedBuiltin());
+    defer helpers.cleanupParseAndCanonical(allocator, resources);
+
+    const paths = resources.checked_artifact.checked_procedure_templates.evidence_param_paths;
+    try std.testing.expect(paths.len > 0);
+
+    // Raw discriminant 8 is the retired checked-store `record_ext` step.
+    paths[0].kind = 8;
+    var failure = resources.checked_artifact.validateDispatchEvidence() orelse
+        return error.TestUnexpectedResult;
+    try std.testing.expectEqual(check.CheckedArtifact.DispatchEvidenceFailure.Kind.evidence_param_path_invalid_kind, failure.kind);
+
+    // A tag label must be immediately paired with a payload-index step.
+    paths[0].kind = 9;
+    failure = resources.checked_artifact.validateDispatchEvidence() orelse
+        return error.TestUnexpectedResult;
+    try std.testing.expectEqual(check.CheckedArtifact.DispatchEvidenceFailure.Kind.evidence_param_path_invalid_shape, failure.kind);
+
+    // A well-formed selector must still resolve over the checked callable.
+    paths[0].kind = 0;
+    paths[0].data = std.math.maxInt(u32);
+    failure = resources.checked_artifact.validateDispatchEvidence() orelse
+        return error.TestUnexpectedResult;
+    try std.testing.expectEqual(check.CheckedArtifact.DispatchEvidenceFailure.Kind.evidence_param_path_diverges_from_checked_type, failure.kind);
+}
+
 test "dispatch evidence boundary validator reports a removed dispatch plan by expression" {
     const allocator = std.testing.allocator;
     var resources = try helpers.parseAndCanonicalizeProgramWithBuiltin(allocator, .module, dispatch_boundary_source, &.{}, try sharedPrePublishedBuiltin());

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -20648,7 +20648,6 @@ const BodyContext = struct {
                     else => return null,
                 },
                 .tag_payload_index => return null, // only valid after tag_payload_tag
-                .record_ext, .tag_ext => return null, // rows are closed in mono
             }
         }
         return ty;


### PR DESCRIPTION
Evidence paths now describe normalized logical rows instead of checked-store extension topology, so Monotype can resolve compiler-generated evidence against flattened callable types without diverging. This validates path grammar and checked-type resolution at the CheckedModule boundary, retires the extension discriminants with a checked-artifact version bump, and adds focused record/tag-tail coverage plus the issue reproduction.

Fixes #10271