### PR TITLE
Add roc install and roc run with URL/shorthand source resolution

### DIFF
--- a/src/cli/CliCtx.zig
+++ b/src/cli/CliCtx.zig
@@ -119,6 +119,7 @@ pub const Command = enum {
     docs,
     bump,
     repl,
+    install,
     unknown,
 
     pub fn name(self: Command) []const u8 {
@@ -134,6 +135,7 @@ pub const Command = enum {
             .docs => "docs",
             .bump => "bump",
             .repl => "repl",
+            .install => "install",
             .unknown => "unknown",
         };
     }

--- a/src/cli/CliProblem.zig
+++ b/src/cli/CliProblem.zig
@@ -277,6 +277,49 @@ pub const CliProblem = union(enum) {
         reason: []const u8,
     },
 
+    // Install Problems
+
+    /// `roc install` was given an invalid shorthand name
+    invalid_shorthand: struct {
+        name: []const u8,
+    },
+
+    /// The shorthand is already installed from a different URL
+    shorthand_conflict: struct {
+        name: []const u8,
+        existing_url: []const u8,
+        new_url: []const u8,
+    },
+
+    /// No installation exists under this shorthand for this compiler version
+    unknown_shorthand: struct {
+        name: []const u8,
+    },
+
+    /// An installed entry exists but its contents are missing or invalid
+    install_entry_corrupt: struct {
+        name: []const u8,
+        path: []const u8,
+        reason: []const u8,
+    },
+
+    /// The persistent install directory could not be determined
+    install_dir_unavailable: struct {
+        reason: []const u8,
+    },
+
+    /// The downloaded bundle has no main.roc at its root
+    install_bundle_missing_main: struct {
+        url: []const u8,
+        searched_path: []const u8,
+    },
+
+    /// Publishing a completed installation into place failed
+    install_publish_failed: struct {
+        name: []const u8,
+        err: ReportedError,
+    },
+
     // Process/Runtime Problems
 
     /// Child process failed to spawn
@@ -369,6 +412,13 @@ pub const CliProblem = union(enum) {
             .bump_failed,
             .download_failed,
             .package_cache_error,
+            .invalid_shorthand,
+            .shorthand_conflict,
+            .unknown_shorthand,
+            .install_entry_corrupt,
+            .install_dir_unavailable,
+            .install_bundle_missing_main,
+            .install_publish_failed,
             .child_process_spawn_failed,
             .child_process_failed,
             .child_process_signaled,
@@ -412,6 +462,13 @@ pub const CliProblem = union(enum) {
             .bump_failed => |info| try createBumpFailedReport(allocator, info),
             .download_failed => |info| try createDownloadFailedReport(allocator, info),
             .package_cache_error => |info| try createPackageCacheErrorReport(allocator, info),
+            .invalid_shorthand => |info| try createInvalidShorthandReport(allocator, info),
+            .shorthand_conflict => |info| try createShorthandConflictReport(allocator, info),
+            .unknown_shorthand => |info| try createUnknownShorthandReport(allocator, info),
+            .install_entry_corrupt => |info| try createInstallEntryCorruptReport(allocator, info),
+            .install_dir_unavailable => |info| try createInstallDirUnavailableReport(allocator, info),
+            .install_bundle_missing_main => |info| try createInstallBundleMissingMainReport(allocator, info),
+            .install_publish_failed => |info| try createInstallPublishFailedReport(allocator, info),
             .child_process_spawn_failed => |info| try createChildProcessSpawnFailedReport(allocator, info),
             .child_process_failed => |info| try createChildProcessFailedReport(allocator, info),
             .child_process_signaled => |info| try createChildProcessSignaledReport(allocator, info),
@@ -812,6 +869,112 @@ fn createPackageCacheErrorReport(allocator: Allocator, info: anytype) Allocator.
 
     try report.document.addText("Reason: ");
     try report.document.addText(info.reason);
+
+    return report;
+}
+
+fn createInvalidShorthandReport(allocator: Allocator, info: anytype) Allocator.Error!Report {
+    const headline = try std.fmt.allocPrint(allocator, "`{s}` is not a valid shorthand name.", .{info.name});
+    defer allocator.free(headline);
+    var report = try Report.init(allocator, "Invalid Shorthand", headline, .runtime_error);
+
+    try report.document.addText("A shorthand starts with a lowercase letter, followed by lowercase letters, digits, or underscores. The name `roc` and Windows reserved device names such as `con` and `nul` are not allowed on any OS.");
+    try report.document.addLineBreaks(2);
+    try report.document.addText("For example: ");
+    try report.document.addAnnotated("tokei", .emphasized);
+    try report.document.addText(" or ");
+    try report.document.addAnnotated("rust_glue", .emphasized);
+
+    return report;
+}
+
+fn createShorthandConflictReport(allocator: Allocator, info: anytype) Allocator.Error!Report {
+    const headline = try std.fmt.allocPrint(allocator, "`{s}` is already installed from a different URL.", .{info.name});
+    defer allocator.free(headline);
+    var report = try Report.init(allocator, "Shorthand Conflict", headline, .runtime_error);
+
+    try report.document.addText("Currently installed from:");
+    try report.document.addLineBreak();
+    try report.document.addText("    ");
+    try report.document.addAnnotated(info.existing_url, .emphasized);
+    try report.document.addLineBreaks(2);
+    try report.document.addText("Requested:");
+    try report.document.addLineBreak();
+    try report.document.addText("    ");
+    try report.document.addAnnotated(info.new_url, .emphasized);
+    try report.document.addLineBreaks(2);
+    try report.document.addSuggestion("The existing installation was left unchanged. To install this URL, choose a different shorthand name.");
+
+    return report;
+}
+
+fn createUnknownShorthandReport(allocator: Allocator, info: anytype) Allocator.Error!Report {
+    const headline = try std.fmt.allocPrint(allocator, "Nothing is installed under the name `{s}` for this compiler version.", .{info.name});
+    defer allocator.free(headline);
+    var report = try Report.init(allocator, "Unknown Shorthand", headline, .runtime_error);
+
+    const install_hint = try std.fmt.allocPrint(allocator, "To install something under that name, run: roc install {s} <URL>", .{info.name});
+    defer allocator.free(install_hint);
+    try report.document.addSuggestion(install_hint);
+    try report.document.addLineBreak();
+    const path_hint = try std.fmt.allocPrint(allocator, "If you meant a local file named `{s}`, write it as `./{s}`.", .{ info.name, info.name });
+    defer allocator.free(path_hint);
+    try report.document.addSuggestion(path_hint);
+
+    return report;
+}
+
+fn createInstallEntryCorruptReport(allocator: Allocator, info: anytype) Allocator.Error!Report {
+    const headline = try std.fmt.allocPrint(allocator, "The installation under `{s}` is corrupt or incomplete.", .{info.name});
+    defer allocator.free(headline);
+    var report = try Report.init(allocator, "Corrupt Installation", headline, .runtime_error);
+
+    try report.document.addText("    ");
+    try report.document.addAnnotated(info.path, .path);
+    try report.document.addLineBreaks(2);
+    try report.document.addText("Reason: ");
+    try report.document.addText(info.reason);
+    try report.document.addLineBreaks(2);
+    const hint = try std.fmt.allocPrint(allocator, "Delete that directory, then reinstall with: roc install {s} <URL>", .{info.name});
+    defer allocator.free(hint);
+    try report.document.addSuggestion(hint);
+
+    return report;
+}
+
+fn createInstallDirUnavailableReport(allocator: Allocator, info: anytype) Allocator.Error!Report {
+    var report = try Report.init(allocator, "Install Directory Unavailable", "I could not determine the install directory.", .runtime_error);
+
+    try report.document.addText("Reason: ");
+    try report.document.addText(info.reason);
+    try report.document.addLineBreaks(2);
+    try report.document.addSuggestion("Set the ROC_INSTALL_DIR environment variable to choose an install directory explicitly.");
+
+    return report;
+}
+
+fn createInstallBundleMissingMainReport(allocator: Allocator, info: anytype) Allocator.Error!Report {
+    const headline = try std.fmt.allocPrint(allocator, "The bundle downloaded from {s} has no main.roc at its root.", .{info.url});
+    defer allocator.free(headline);
+    var report = try Report.init(allocator, "Invalid Bundle", headline, .runtime_error);
+
+    try report.document.addText("I looked for:");
+    try report.document.addLineBreak();
+    try report.document.addText("    ");
+    try report.document.addAnnotated(info.searched_path, .path);
+    try report.document.addLineBreaks(2);
+    try report.document.addText("Installable bundles must contain a main.roc at the archive root.");
+
+    return report;
+}
+
+fn createInstallPublishFailedReport(allocator: Allocator, info: anytype) Allocator.Error!Report {
+    const headline = try std.fmt.allocPrint(allocator, "I could not publish the completed installation for `{s}`.", .{info.name});
+    defer allocator.free(headline);
+    var report = try Report.init(allocator, "Install Publish Failed", headline, .runtime_error);
+
+    try report.document.addText("Error: ");
+    try report.document.addText(@errorName(info.err));
 
     return report;
 }

--- a/src/cli/cli_args.zig
+++ b/src/cli/cli_args.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const testing = std.testing;
 const mem = std.mem;
+const install = @import("install.zig");
 
 /// Errors that can occur while parsing CLI arguments.
 pub const ParseError = Allocator.Error || std.Io.Dir.OpenError || std.Io.Dir.Iterator.Error;
@@ -23,6 +24,7 @@ pub const CliArgs = union(enum) {
     version,
     docs: DocsArgs,
     bump: BumpArgs,
+    install: InstallArgs,
     experimental_lsp: ExperimentalLspArgs,
     help: []const u8,
     licenses,
@@ -45,6 +47,10 @@ pub const ArgProblem = union(enum) {
         flag: []const u8,
     },
     unexpected_argument: struct { cmd: []const u8, arg: []const u8 },
+    // Bare `roc <shorthand>` is rejected so the subcommand namespace can never
+    // be conflated with the user-chosen shorthand namespace; running an
+    // installed shorthand requires the explicit `roc run` subcommand.
+    shorthand_requires_run: struct { name: []const u8 },
     invalid_flag_value: struct {
         value: []const u8,
         flag: []const u8,
@@ -131,8 +137,19 @@ pub const RunArgs = struct {
     no_cache: bool = false, // bypass the executable cache
     allow_errors: bool = false, // allow execution even if there are type errors
     watch: bool = false, // hot reload when source inputs change; implied for dev runs
+    explicit_watch: bool = false, // --watch was passed (as opposed to implied by a dev run)
     timings: bool = false, // always show the per-phase timing breakdown
     max_threads: ?usize = null, // max worker threads (null = auto, 1 = single-threaded)
+    resolve_limits: ResolveLimitArgs = .{}, // package download size limits
+    via_run_subcommand: bool = false, // parsed from explicit `roc run` (permits installed shorthands)
+    root_source_url: ?[]const u8 = null, // internal: bundle URL provenance when the source was a URL or installed shorthand
+};
+
+/// Arguments for `roc install`
+pub const InstallArgs = struct {
+    shorthand: []const u8, // the name to install the bundle under (REQUIRED)
+    url: []const u8, // the bundle URL to install (REQUIRED)
+    max_threads: ?usize = null, // max worker threads for the install-time build
     resolve_limits: ResolveLimitArgs = .{}, // package download size limits
 };
 
@@ -148,6 +165,7 @@ pub const CheckArgs = struct {
     watch_inputs_file: ?[]const u8 = null, // internal: write watch input paths and byte states here
     max_threads: ?usize = null, // max worker threads (null = auto, 1 = single-threaded)
     resolve_limits: ResolveLimitArgs = .{}, // package download size limits
+    root_source_url: ?[]const u8 = null, // internal: bundle URL provenance when the source was a URL or installed shorthand
 };
 
 /// Arguments for `roc build`
@@ -172,6 +190,8 @@ pub const BuildArgs = struct {
     require_host_runnable_output: bool = false, // internal: reject targets that cannot run on this host
     suppress_build_status: bool = false, // suppress "Built..." output (used by `roc` execution)
     resolve_limits: ResolveLimitArgs = .{}, // package download size limits
+    synthetic_output_basename: ?[]const u8 = null, // internal: default output name when the source was a shorthand/URL, not a path
+    root_source_url: ?[]const u8 = null, // internal: bundle URL provenance when the source was a URL or installed shorthand
     synthetic_default_platform: bool = false, // internal: build rewrote a headerless app to the default platform
     source_dir_override: ?[]const u8 = null, // internal: resolve root sibling imports from this directory
     synthetic_root_original_path: ?[]const u8 = null, // internal: original path for a synthetic default-app root
@@ -191,6 +211,7 @@ pub const TestArgs = struct {
     watch_inputs_file: ?[]const u8 = null, // internal: write watch input paths and byte states here
     max_threads: ?usize = null, // max worker threads (null = auto, 1 = single-threaded)
     resolve_limits: ResolveLimitArgs = .{}, // package download size limits
+    root_source_url: ?[]const u8 = null, // internal: bundle URL provenance when the source was a URL or installed shorthand
 };
 
 /// Arguments for `roc fmt`
@@ -223,6 +244,7 @@ pub const DocsArgs = struct {
     serve: bool = false, // start an HTTP server after generating docs
     with_lang_ref: bool = false, // include the language reference articles from docs/langref
     resolve_limits: ResolveLimitArgs = .{}, // package download size limits
+    root_source_url: ?[]const u8 = null, // internal: bundle URL provenance when the source was a URL or installed shorthand
 };
 
 /// Arguments for `roc bump`
@@ -234,6 +256,7 @@ pub const BumpArgs = struct {
     no_cache: bool = false, // disable cache
     verbose: bool = false, // enable verbose output
     resolve_limits: ResolveLimitArgs = .{}, // package download size limits
+    root_source_url: ?[]const u8 = null, // internal: bundle URL provenance when the source was a URL or installed shorthand
 };
 
 /// Arguments for `roc experimental-lsp`
@@ -261,13 +284,13 @@ pub const GlueArgs = struct {
 
 /// Parse a list of arguments.
 pub fn parse(alloc: mem.Allocator, std_io: std.Io, args: []const []const u8) ParseError!CliArgs {
-    if (args.len == 0) return try parseRun(alloc, args);
+    if (args.len == 0) return try parseRun(alloc, args, .default);
 
-    // "run" is not a valid subcommand - give a helpful error
-    // The correct usage is: roc path/to/app.roc (without "run")
-    if (mem.eql(u8, args[0], "run")) {
-        return CliArgs{ .help = run_not_a_command_help };
-    }
+    // `roc run` accepts everything the default run accepts, plus installed
+    // shorthands (which the default run rejects to keep the subcommand
+    // namespace separate from the shorthand namespace).
+    if (mem.eql(u8, args[0], "run")) return try parseRun(alloc, args[1..], .run_subcommand);
+    if (mem.eql(u8, args[0], "install")) return parseInstall(args[1..]);
     if (mem.eql(u8, args[0], "check")) return parseCheck(args[1..]);
     if (mem.eql(u8, args[0], "build")) return parseBuild(args[1..]);
     if (mem.eql(u8, args[0], "bundle")) return try parseBundle(alloc, args[1..]);
@@ -283,7 +306,7 @@ pub fn parse(alloc: mem.Allocator, std_io: std.Io, args: []const []const u8) Par
     if (mem.eql(u8, args[0], "help")) return CliArgs{ .help = main_help };
     if (mem.eql(u8, args[0], "licenses")) return parseLicenses(args[1..]);
 
-    return try parseRun(alloc, args);
+    return try parseRun(alloc, args, .default);
 }
 
 const main_help =
@@ -294,6 +317,8 @@ const main_help =
     \\       roc <COMMAND>
     \\
     \\Commands:
+    \\  run              Run a .roc file, a bundle URL, or an installed shorthand
+    \\  install          Install a Roc app from a bundle URL under a shorthand name
     \\  build            Build a binary from the given .roc file, but don't run it
     \\  bundle           Bundle .roc files into a compressed archive
     \\  unbundle         Extract files from compressed .tar.zst archives
@@ -322,19 +347,42 @@ const main_help =
     \\
 ;
 
-const run_not_a_command_help =
-    \\Error: 'run' is not a valid subcommand.
+const run_help =
+    \\Run a Roc application
     \\
-    \\To run a Roc application, use:
-    \\    roc path/to/app.roc
+    \\Usage: roc run [OPTIONS] [SOURCE] [-- [ARGS_FOR_APP]...]
     \\
-    \\For example:
-    \\    roc main.roc           Run main.roc in the current directory
-    \\    roc examples/hello.roc Run hello.roc from the examples folder
+    \\SOURCE may be:
+    \\  a .roc file path        roc run main.roc
+    \\  a bundle URL            roc run https://example.com/tool/1.2.3/<hash>.tar.zst
+    \\  an installed shorthand  roc run tokei      (see `roc install`)
     \\
-    \\Use 'roc help' to see all available commands.
+    \\Running an installed shorthand executes the optimized binary that was
+    \\built at install time; no compilation or network access is needed.
+    \\File and URL sources accept the same options as the default `roc` command.
     \\
 ;
+
+const install_help =
+    \\Install a Roc app from a bundle URL under a shorthand name
+    \\
+    \\Usage: roc install [OPTIONS] <SHORTHAND> <URL>
+    \\
+    \\Downloads the bundle, verifies its content hash, and builds it with
+    \\--opt=speed so that `roc run <SHORTHAND>` executes an optimized binary
+    \\with no compile step. Installations persist outside the cache and are
+    \\scoped to the compiler version that installed them.
+    \\
+    \\Arguments:
+    \\  <SHORTHAND>  A name of your choice: a lowercase letter followed by
+    \\               lowercase letters, digits, or underscores
+    \\  <URL>        A .tar.zst bundle URL ending in a base58-encoded BLAKE3 hash
+    \\
+    \\Options:
+    \\  -j, --jobs=<N>                 Max worker threads for the install-time build
+;
+
+const install_help_with_limits = install_help ++ "\n" ++ resolve_limit_help ++ "\n";
 
 fn parseCheck(args: []const []const u8) CliArgs {
     var path: ?[]const u8 = null;
@@ -1208,7 +1256,11 @@ fn parseExperimentalLsp(args: []const []const u8) CliArgs {
     } };
 }
 
-fn parseRun(alloc: mem.Allocator, args: []const []const u8) std.mem.Allocator.Error!CliArgs {
+/// How a run parse was reached: the default `roc [ROC_FILE]` form, or the
+/// explicit `roc run` subcommand (the only form that accepts shorthands).
+const RunParseMode = enum { default, run_subcommand };
+
+fn parseRun(alloc: mem.Allocator, args: []const []const u8, mode: RunParseMode) std.mem.Allocator.Error!CliArgs {
     var path: ?[]const u8 = null;
     var opt: OptLevel = default_dev_opt;
     var target: ?[]const u8 = null;
@@ -1237,7 +1289,10 @@ fn parseRun(alloc: mem.Allocator, args: []const []const u8) std.mem.Allocator.Er
         if (isHelpFlag(arg)) {
             // We need to free the paths here because we aren't returning the .run variant
             app_args.deinit();
-            return CliArgs{ .help = main_help };
+            return CliArgs{ .help = switch (mode) {
+                .default => main_help,
+                .run_subcommand => run_help,
+            } };
         } else if (mem.startsWith(u8, arg, "--max-package-mb") or mem.startsWith(u8, arg, "--max-transitive-mb")) {
             switch (parseResolveLimitFlag(arg, &resolve_limits)) {
                 .problem => |problem| return CliArgs{ .problem = problem },
@@ -1303,7 +1358,67 @@ fn parseRun(alloc: mem.Allocator, args: []const []const u8) std.mem.Allocator.Er
             }
         }
     }
-    return CliArgs{ .run = RunArgs{ .path = path orelse "main.roc", .opt = opt, .target = target, .app_args = try app_args.toOwnedSlice(), .no_cache = no_cache, .allow_errors = allow_errors, .watch = watch or (opt == .dev), .timings = timings, .max_threads = max_threads, .resolve_limits = resolve_limits } };
+    if (mode == .default) {
+        if (path) |p| {
+            if (install.classifySourceRef(p) == .shorthand) {
+                app_args.deinit();
+                return CliArgs{ .problem = ArgProblem{ .shorthand_requires_run = .{ .name = p } } };
+            }
+        }
+    }
+
+    return CliArgs{ .run = RunArgs{ .path = path orelse "main.roc", .opt = opt, .target = target, .app_args = try app_args.toOwnedSlice(), .no_cache = no_cache, .allow_errors = allow_errors, .watch = watch or (opt == .dev), .explicit_watch = watch, .timings = timings, .max_threads = max_threads, .resolve_limits = resolve_limits, .via_run_subcommand = mode == .run_subcommand } };
+}
+
+fn parseInstall(args: []const []const u8) CliArgs {
+    var shorthand: ?[]const u8 = null;
+    var url: ?[]const u8 = null;
+    var max_threads: ?usize = null;
+    var resolve_limits: ResolveLimitArgs = .{};
+
+    for (args) |arg| {
+        if (isHelpFlag(arg)) {
+            return CliArgs{ .help = install_help_with_limits };
+        } else if (mem.startsWith(u8, arg, "--max-package-mb") or mem.startsWith(u8, arg, "--max-transitive-mb")) {
+            switch (parseResolveLimitFlag(arg, &resolve_limits)) {
+                .problem => |problem| return CliArgs{ .problem = problem },
+                else => {},
+            }
+        } else if (mem.startsWith(u8, arg, "--jobs")) {
+            if (getFlagValue(arg)) |value| {
+                max_threads = std.fmt.parseInt(usize, value, 10) catch {
+                    return CliArgs{ .problem = ArgProblem{ .invalid_flag_value = .{ .flag = "--jobs", .value = value, .valid_options = "positive integer" } } };
+                };
+            } else {
+                return CliArgs{ .problem = ArgProblem{ .missing_flag_value = .{ .flag = "--jobs" } } };
+            }
+        } else if (mem.startsWith(u8, arg, "-j")) {
+            const value = arg[2..];
+            if (value.len == 0) {
+                return CliArgs{ .problem = ArgProblem{ .missing_flag_value = .{ .flag = "-j" } } };
+            }
+            max_threads = std.fmt.parseInt(usize, value, 10) catch {
+                return CliArgs{ .problem = ArgProblem{ .invalid_flag_value = .{ .flag = "-j", .value = value, .valid_options = "positive integer" } } };
+            };
+        } else if (shorthand == null) {
+            shorthand = arg;
+        } else if (url == null) {
+            url = arg;
+        } else {
+            return CliArgs{ .problem = ArgProblem{ .unexpected_argument = .{ .cmd = "install", .arg = arg } } };
+        }
+    }
+
+    if (shorthand == null or url == null) {
+        return CliArgs{ .help = install_help_with_limits };
+    }
+
+    return CliArgs{ .install = InstallArgs{
+        .shorthand = shorthand.?,
+        .url = url.?,
+        .max_threads = max_threads,
+        .resolve_limits = resolve_limits,
+    } };
 }
 
 fn isHelpFlag(arg: []const u8) bool {
@@ -2108,5 +2223,106 @@ test "roc licenses" {
         const result = try parse(gpa, testing.io, &[_][]const u8{ "licenses", "extrastuff" });
         defer result.deinit(gpa);
         try testing.expectEqualStrings("extrastuff", result.problem.unexpected_argument.arg);
+    }
+}
+
+test "roc install" {
+    const gpa = testing.allocator;
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{ "install", "tokei", "https://example.com/tokei/1.2.3/abc.tar.zst" });
+        defer result.deinit(gpa);
+        try testing.expectEqualStrings("tokei", result.install.shorthand);
+        try testing.expectEqualStrings("https://example.com/tokei/1.2.3/abc.tar.zst", result.install.url);
+        try testing.expectEqual(@as(?usize, null), result.install.max_threads);
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{ "install", "--jobs=4", "--max-package-mb=20", "tokei", "https://example.com/tokei/1.2.3/abc.tar.zst" });
+        defer result.deinit(gpa);
+        try testing.expectEqual(@as(?usize, 4), result.install.max_threads);
+        try testing.expectEqual(@as(?u32, 20), result.install.resolve_limits.max_package_mb);
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{ "install", "tokei" });
+        defer result.deinit(gpa);
+        try testing.expectEqual(.help, std.meta.activeTag(result));
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{"install"});
+        defer result.deinit(gpa);
+        try testing.expectEqual(.help, std.meta.activeTag(result));
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{ "install", "-h" });
+        defer result.deinit(gpa);
+        try testing.expectEqual(.help, std.meta.activeTag(result));
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{ "install", "a", "https://example.com/x/1.0.0/abc.tar.zst", "extra" });
+        defer result.deinit(gpa);
+        try testing.expectEqualStrings("install", result.problem.unexpected_argument.cmd);
+        try testing.expectEqualStrings("extra", result.problem.unexpected_argument.arg);
+    }
+}
+
+test "roc run subcommand" {
+    const gpa = testing.allocator;
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{ "run", "tokei", "--", "arg1", "arg2" });
+        defer result.deinit(gpa);
+        try testing.expectEqualStrings("tokei", result.run.path);
+        try testing.expect(result.run.via_run_subcommand);
+        try testing.expectEqual(@as(usize, 2), result.run.app_args.len);
+        try testing.expectEqualStrings("arg1", result.run.app_args[0]);
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{ "run", "app.roc" });
+        defer result.deinit(gpa);
+        try testing.expectEqualStrings("app.roc", result.run.path);
+        try testing.expect(result.run.via_run_subcommand);
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{ "run", "https://example.com/x/1.0.0/abc.tar.zst" });
+        defer result.deinit(gpa);
+        try testing.expectEqualStrings("https://example.com/x/1.0.0/abc.tar.zst", result.run.path);
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{"run"});
+        defer result.deinit(gpa);
+        try testing.expectEqualStrings("main.roc", result.run.path);
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{ "run", "--help" });
+        defer result.deinit(gpa);
+        try testing.expectEqual(.help, std.meta.activeTag(result));
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{ "run", "tokei", "--watch" });
+        defer result.deinit(gpa);
+        try testing.expect(result.run.explicit_watch);
+    }
+}
+
+test "bare shorthand requires the run subcommand" {
+    const gpa = testing.allocator;
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{"tokei"});
+        defer result.deinit(gpa);
+        try testing.expectEqualStrings("tokei", result.problem.shorthand_requires_run.name);
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{"./tokei"});
+        defer result.deinit(gpa);
+        try testing.expectEqualStrings("./tokei", result.run.path);
+        try testing.expect(!result.run.via_run_subcommand);
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{"https://example.com/x/1.0.0/abc.tar.zst"});
+        defer result.deinit(gpa);
+        try testing.expectEqualStrings("https://example.com/x/1.0.0/abc.tar.zst", result.run.path);
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{"app.roc"});
+        defer result.deinit(gpa);
+        try testing.expectEqualStrings("app.roc", result.run.path);
     }
 }

--- a/src/cli/cli_args.zig
+++ b/src/cli/cli_args.zig
@@ -138,6 +138,7 @@ pub const RunArgs = struct {
     allow_errors: bool = false, // allow execution even if there are type errors
     watch: bool = false, // hot reload when source inputs change; implied for dev runs
     explicit_watch: bool = false, // --watch was passed (as opposed to implied by a dev run)
+    explicit_opt: bool = false, // --opt was passed (as opposed to defaulted)
     timings: bool = false, // always show the per-phase timing breakdown
     max_threads: ?usize = null, // max worker threads (null = auto, 1 = single-threaded)
     resolve_limits: ResolveLimitArgs = .{}, // package download size limits
@@ -166,6 +167,7 @@ pub const CheckArgs = struct {
     max_threads: ?usize = null, // max worker threads (null = auto, 1 = single-threaded)
     resolve_limits: ResolveLimitArgs = .{}, // package download size limits
     root_source_url: ?[]const u8 = null, // internal: bundle URL provenance when the source was a URL or installed shorthand
+    main_source_url: ?[]const u8 = null, // internal: bundle URL provenance when --main was a URL or installed shorthand
 };
 
 /// Arguments for `roc build`
@@ -212,6 +214,7 @@ pub const TestArgs = struct {
     max_threads: ?usize = null, // max worker threads (null = auto, 1 = single-threaded)
     resolve_limits: ResolveLimitArgs = .{}, // package download size limits
     root_source_url: ?[]const u8 = null, // internal: bundle URL provenance when the source was a URL or installed shorthand
+    main_source_url: ?[]const u8 = null, // internal: bundle URL provenance when --main was a URL or installed shorthand
 };
 
 /// Arguments for `roc fmt`
@@ -245,6 +248,7 @@ pub const DocsArgs = struct {
     with_lang_ref: bool = false, // include the language reference articles from docs/langref
     resolve_limits: ResolveLimitArgs = .{}, // package download size limits
     root_source_url: ?[]const u8 = null, // internal: bundle URL provenance when the source was a URL or installed shorthand
+    main_source_url: ?[]const u8 = null, // internal: bundle URL provenance when --main was a URL or installed shorthand
 };
 
 /// Arguments for `roc bump`
@@ -1263,6 +1267,7 @@ const RunParseMode = enum { default, run_subcommand };
 fn parseRun(alloc: mem.Allocator, args: []const []const u8, mode: RunParseMode) std.mem.Allocator.Error!CliArgs {
     var path: ?[]const u8 = null;
     var opt: OptLevel = default_dev_opt;
+    var explicit_opt = false;
     var target: ?[]const u8 = null;
     var no_cache: bool = false;
     var allow_errors: bool = false;
@@ -1313,6 +1318,7 @@ fn parseRun(alloc: mem.Allocator, args: []const []const u8, mode: RunParseMode) 
             if (getFlagValue(arg)) |value| {
                 if (OptLevel.from_str(value)) |level| {
                     opt = level;
+                    explicit_opt = true;
                 } else {
                     app_args.deinit();
                     return CliArgs{ .problem = ArgProblem{ .invalid_flag_value = .{ .flag = "--opt", .value = value, .valid_options = "dev,interpreter,speed,size" } } };
@@ -1367,7 +1373,7 @@ fn parseRun(alloc: mem.Allocator, args: []const []const u8, mode: RunParseMode) 
         }
     }
 
-    return CliArgs{ .run = RunArgs{ .path = path orelse "main.roc", .opt = opt, .target = target, .app_args = try app_args.toOwnedSlice(), .no_cache = no_cache, .allow_errors = allow_errors, .watch = watch or (opt == .dev), .explicit_watch = watch, .timings = timings, .max_threads = max_threads, .resolve_limits = resolve_limits, .via_run_subcommand = mode == .run_subcommand } };
+    return CliArgs{ .run = RunArgs{ .path = path orelse "main.roc", .opt = opt, .target = target, .app_args = try app_args.toOwnedSlice(), .no_cache = no_cache, .allow_errors = allow_errors, .watch = watch or (opt == .dev), .explicit_watch = watch, .explicit_opt = explicit_opt, .timings = timings, .max_threads = max_threads, .resolve_limits = resolve_limits, .via_run_subcommand = mode == .run_subcommand } };
 }
 
 fn parseInstall(args: []const []const u8) CliArgs {
@@ -2299,6 +2305,12 @@ test "roc run subcommand" {
         const result = try parse(gpa, testing.io, &[_][]const u8{ "run", "tokei", "--watch" });
         defer result.deinit(gpa);
         try testing.expect(result.run.explicit_watch);
+        try testing.expect(!result.run.explicit_opt);
+    }
+    {
+        const result = try parse(gpa, testing.io, &[_][]const u8{ "run", "tokei", "--opt=dev" });
+        defer result.deinit(gpa);
+        try testing.expect(result.run.explicit_opt);
     }
 }
 

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -85,8 +85,12 @@ pub const Manifest = struct {
 /// platform-appropriate persistent user data directory (deliberately not a
 /// cache location, so cache cleanup can never touch installed tools).
 pub fn installRootDir(roc_ctx: CoreCtx, allocator: Allocator) (Allocator.Error || error{NoHomeDirectory})![]u8 {
+    // Empty env values are treated as unset (per the XDG spec, and because a
+    // cwd-relative install root would make installs appear and disappear
+    // with the working directory).
     if (roc_ctx.getEnvVar("ROC_INSTALL_DIR", allocator)) |dir| {
-        return dir;
+        if (dir.len != 0) return dir;
+        allocator.free(dir);
     } else |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         error.EnvironmentVariableMissing => {},
@@ -95,7 +99,9 @@ pub fn installRootDir(roc_ctx: CoreCtx, allocator: Allocator) (Allocator.Error |
     if (builtin.target.os.tag != .windows) {
         if (roc_ctx.getEnvVar("XDG_DATA_HOME", allocator)) |xdg_data| {
             defer allocator.free(xdg_data);
-            return std.fs.path.join(allocator, &.{ xdg_data, "roc" });
+            if (xdg_data.len != 0) {
+                return std.fs.path.join(allocator, &.{ xdg_data, "roc" });
+            }
         } else |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             error.EnvironmentVariableMissing => {},
@@ -111,6 +117,7 @@ pub fn installRootDir(roc_ctx: CoreCtx, allocator: Allocator) (Allocator.Error |
         error.EnvironmentVariableMissing => return error.NoHomeDirectory,
     };
     defer allocator.free(home_dir);
+    if (home_dir.len == 0) return error.NoHomeDirectory;
 
     return switch (builtin.target.os.tag) {
         .windows => std.fs.path.join(allocator, &.{ home_dir, "Roc" }),

--- a/src/cli/install.zig
+++ b/src/cli/install.zig
@@ -1,0 +1,283 @@
+//! Persistent install store for `roc install` and installed-shorthand lookups.
+//!
+//! Installed tools live outside the disposable compiler and package caches:
+//! clearing a cache must never break an installed tool. Entries are namespaced
+//! by compiler version so one compiler can never consume another's artifacts,
+//! and each entry is published with staging + atomic rename so a partially
+//! completed installation is never visible under its shorthand.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const build_options = @import("build_options");
+const CoreCtx = @import("ctx").CoreCtx;
+const unbundle = @import("unbundle");
+const Allocator = std.mem.Allocator;
+
+/// Manifest file recorded at the root of every install entry.
+pub const manifest_filename = "install.json";
+/// Directory holding the extracted bundle source within an entry.
+pub const source_dir_name = "source";
+/// Directory holding built artifacts within an entry.
+pub const bin_dir_name = "bin";
+/// Bump when the entry layout or manifest schema changes incompatibly.
+pub const manifest_format_version: u32 = 1;
+
+/// How a CLI source argument is interpreted. Classification is purely
+/// syntactic — no filesystem probing, and never a fallback from one
+/// category to another.
+pub const SourceRefKind = enum {
+    /// A filesystem path (anything that is neither a URL nor a valid shorthand).
+    local_path,
+    /// An `https://` URL (or loopback `http://`, validated later by download).
+    url,
+    /// A bare token matching the installed-shorthand grammar.
+    shorthand,
+};
+
+/// Classify a CLI source argument. A local extensionless file whose name
+/// happens to match the shorthand grammar must be written `./name`.
+pub fn classifySourceRef(input: []const u8) SourceRefKind {
+    if (std.mem.startsWith(u8, input, "https://") or std.mem.startsWith(u8, input, "http://")) {
+        return .url;
+    }
+    if (isValidShorthand(input)) {
+        return .shorthand;
+    }
+    return .local_path;
+}
+
+/// The shorthand grammar: `[a-z][a-z0-9_]*`, minus Windows reserved device
+/// names and the name `roc` itself. The grammar excludes `.`, dashes, path
+/// separators, and uppercase so a shorthand can never be confused with a
+/// path or a URL; reserved device names are rejected on every OS because a
+/// shorthand becomes a directory and executable name, and the grammar must
+/// stay portable; and `roc` is reserved so commands like `roc run roc`
+/// cannot exist.
+pub fn isValidShorthand(name: []const u8) bool {
+    if (name.len == 0) return false;
+    switch (name[0]) {
+        'a'...'z' => {},
+        else => return false,
+    }
+    for (name[1..]) |c| {
+        switch (c) {
+            'a'...'z', '0'...'9', '_' => {},
+            else => return false,
+        }
+    }
+    if (std.mem.eql(u8, name, "roc")) return false;
+    for (unbundle.unbundle.WINDOWS_RESERVED_NAMES) |reserved| {
+        if (std.ascii.eqlIgnoreCase(name, reserved)) return false;
+    }
+    return true;
+}
+
+/// Metadata recorded for every install entry. The URL is the source's
+/// compiler identity; the shorthand and paths are storage details.
+pub const Manifest = struct {
+    format_version: u32,
+    url: []const u8,
+    hash: []const u8,
+    compiler_version: []const u8,
+};
+
+/// Resolve the install root directory: `ROC_INSTALL_DIR` if set, otherwise a
+/// platform-appropriate persistent user data directory (deliberately not a
+/// cache location, so cache cleanup can never touch installed tools).
+pub fn installRootDir(roc_ctx: CoreCtx, allocator: Allocator) (Allocator.Error || error{NoHomeDirectory})![]u8 {
+    if (roc_ctx.getEnvVar("ROC_INSTALL_DIR", allocator)) |dir| {
+        return dir;
+    } else |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.EnvironmentVariableMissing => {},
+    }
+
+    if (builtin.target.os.tag != .windows) {
+        if (roc_ctx.getEnvVar("XDG_DATA_HOME", allocator)) |xdg_data| {
+            defer allocator.free(xdg_data);
+            return std.fs.path.join(allocator, &.{ xdg_data, "roc" });
+        } else |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.EnvironmentVariableMissing => {},
+        }
+    }
+
+    const home_env = switch (builtin.target.os.tag) {
+        .windows => "APPDATA",
+        else => "HOME",
+    };
+    const home_dir = roc_ctx.getEnvVar(home_env, allocator) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.EnvironmentVariableMissing => return error.NoHomeDirectory,
+    };
+    defer allocator.free(home_dir);
+
+    return switch (builtin.target.os.tag) {
+        .windows => std.fs.path.join(allocator, &.{ home_dir, "Roc" }),
+        .macos => std.fs.path.join(allocator, &.{ home_dir, "Library", "Application Support", "roc" }),
+        else => std.fs.path.join(allocator, &.{ home_dir, ".local", "share", "roc" }),
+    };
+}
+
+/// The compiler-version namespace directory under the install root.
+pub fn versionDir(allocator: Allocator, install_root: []const u8) Allocator.Error![]u8 {
+    return std.fs.path.join(allocator, &.{ install_root, build_options.compiler_version });
+}
+
+/// All the paths that make up one install entry.
+pub const EntryPaths = struct {
+    /// `<root>/<compiler_version>/<shorthand>`
+    entry_dir: []const u8,
+    /// `<entry>/install.json`
+    manifest_path: []const u8,
+    /// `<entry>/source`
+    source_dir: []const u8,
+    /// `<entry>/source/main.roc`
+    main_roc_path: []const u8,
+    /// `<entry>/bin`
+    bin_dir: []const u8,
+    /// `<entry>/bin/<shorthand>[.exe]`
+    exe_path: []const u8,
+};
+
+/// Compute the paths for a shorthand's entry under a version directory.
+pub fn entryPaths(allocator: Allocator, version_dir_path: []const u8, shorthand: []const u8) Allocator.Error!EntryPaths {
+    const entry_dir = try std.fs.path.join(allocator, &.{ version_dir_path, shorthand });
+    return entryPathsIn(allocator, entry_dir, shorthand);
+}
+
+/// Compute the intra-entry paths for an entry rooted at `entry_dir` (also
+/// used for staging directories before they are renamed into place).
+pub fn entryPathsIn(allocator: Allocator, entry_dir: []const u8, shorthand: []const u8) Allocator.Error!EntryPaths {
+    const exe_filename = if (builtin.target.os.tag == .windows)
+        try std.fmt.allocPrint(allocator, "{s}.exe", .{shorthand})
+    else
+        shorthand;
+    return .{
+        .entry_dir = entry_dir,
+        .manifest_path = try std.fs.path.join(allocator, &.{ entry_dir, manifest_filename }),
+        .source_dir = try std.fs.path.join(allocator, &.{ entry_dir, source_dir_name }),
+        .main_roc_path = try std.fs.path.join(allocator, &.{ entry_dir, source_dir_name, "main.roc" }),
+        .bin_dir = try std.fs.path.join(allocator, &.{ entry_dir, bin_dir_name }),
+        .exe_path = try std.fs.path.join(allocator, &.{ entry_dir, bin_dir_name, exe_filename }),
+    };
+}
+
+/// Serialize a manifest to JSON. Caller owns the returned slice.
+pub fn manifestToJson(allocator: Allocator, manifest: Manifest) Allocator.Error![]u8 {
+    var buffer: std.Io.Writer.Allocating = .init(allocator);
+    defer buffer.deinit();
+    std.json.Stringify.value(manifest, .{}, &buffer.writer) catch return error.OutOfMemory;
+    return buffer.toOwnedSlice();
+}
+
+/// A parsed manifest together with its backing JSON allocation.
+pub const ParsedManifest = struct {
+    parsed: std.json.Parsed(Manifest),
+
+    pub fn manifest(self: *const ParsedManifest) Manifest {
+        return self.parsed.value;
+    }
+
+    pub fn deinit(self: *ParsedManifest) void {
+        self.parsed.deinit();
+    }
+};
+
+/// Parse and validate manifest JSON. Returns null when the bytes are not a
+/// valid manifest of the current format version — callers must treat that as
+/// a corrupt entry, never fall back to guessing.
+pub fn parseManifest(allocator: Allocator, bytes: []const u8) Allocator.Error!?ParsedManifest {
+    const parsed = std.json.parseFromSlice(Manifest, allocator, bytes, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return null,
+    };
+    if (parsed.value.format_version != manifest_format_version) {
+        var owned = parsed;
+        owned.deinit();
+        return null;
+    }
+    return .{ .parsed = parsed };
+}
+
+test "shorthand grammar" {
+    try std.testing.expect(isValidShorthand("tokei"));
+    try std.testing.expect(isValidShorthand("rust_glue"));
+    try std.testing.expect(isValidShorthand("a"));
+    try std.testing.expect(isValidShorthand("a2_b_c"));
+
+    try std.testing.expect(!isValidShorthand(""));
+    try std.testing.expect(!isValidShorthand("Tokei"));
+    try std.testing.expect(!isValidShorthand("2fast"));
+    try std.testing.expect(!isValidShorthand("rust-glue"));
+    try std.testing.expect(!isValidShorthand("-dash"));
+    try std.testing.expect(!isValidShorthand("_under"));
+    try std.testing.expect(!isValidShorthand("has.dot"));
+    try std.testing.expect(!isValidShorthand("has/slash"));
+    try std.testing.expect(!isValidShorthand("has\\backslash"));
+    try std.testing.expect(!isValidShorthand("has space"));
+    try std.testing.expect(!isValidShorthand("."));
+    try std.testing.expect(!isValidShorthand(".."));
+
+    // `roc` is reserved so `roc run roc` cannot exist.
+    try std.testing.expect(!isValidShorthand("roc"));
+    try std.testing.expect(isValidShorthand("rocky"));
+
+    // Windows reserved device names are rejected on every OS so the grammar
+    // stays portable.
+    try std.testing.expect(!isValidShorthand("con"));
+    try std.testing.expect(!isValidShorthand("nul"));
+    try std.testing.expect(!isValidShorthand("aux"));
+    try std.testing.expect(!isValidShorthand("prn"));
+    try std.testing.expect(!isValidShorthand("com1"));
+    try std.testing.expect(!isValidShorthand("lpt9"));
+    try std.testing.expect(isValidShorthand("console"));
+    try std.testing.expect(isValidShorthand("com"));
+    try std.testing.expect(isValidShorthand("com10"));
+}
+
+test "source ref classification" {
+    try std.testing.expectEqual(SourceRefKind.url, classifySourceRef("https://example.com/tokei/1.2.3/abc.tar.zst"));
+    try std.testing.expectEqual(SourceRefKind.url, classifySourceRef("http://127.0.0.1:8000/abc.tar.zst"));
+
+    try std.testing.expectEqual(SourceRefKind.shorthand, classifySourceRef("tokei"));
+    try std.testing.expectEqual(SourceRefKind.shorthand, classifySourceRef("rust_glue"));
+
+    try std.testing.expectEqual(SourceRefKind.local_path, classifySourceRef("main.roc"));
+    try std.testing.expectEqual(SourceRefKind.local_path, classifySourceRef("./tokei"));
+    try std.testing.expectEqual(SourceRefKind.local_path, classifySourceRef("../tokei"));
+    try std.testing.expectEqual(SourceRefKind.local_path, classifySourceRef("dir/tokei"));
+    try std.testing.expectEqual(SourceRefKind.local_path, classifySourceRef("/abs/tokei"));
+    try std.testing.expectEqual(SourceRefKind.local_path, classifySourceRef("Tokei"));
+    try std.testing.expectEqual(SourceRefKind.local_path, classifySourceRef("foo.roc"));
+}
+
+test "manifest json round trip" {
+    const gpa = std.testing.allocator;
+    const json = try manifestToJson(gpa, .{
+        .format_version = manifest_format_version,
+        .url = "https://example.com/tokei/1.2.3/abc.tar.zst",
+        .hash = "abc",
+        .compiler_version = "test-version",
+    });
+    defer gpa.free(json);
+
+    var parsed = (try parseManifest(gpa, json)) orelse return error.TestUnexpectedResult;
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("https://example.com/tokei/1.2.3/abc.tar.zst", parsed.manifest().url);
+    try std.testing.expectEqualStrings("abc", parsed.manifest().hash);
+}
+
+test "manifest rejects wrong format version" {
+    const gpa = std.testing.allocator;
+    const json = try manifestToJson(gpa, .{
+        .format_version = manifest_format_version + 1,
+        .url = "https://example.com/x/1.0.0/abc.tar.zst",
+        .hash = "abc",
+        .compiler_version = "test-version",
+    });
+    defer gpa.free(json);
+
+    try std.testing.expect((try parseManifest(gpa, json)) == null);
+    try std.testing.expect((try parseManifest(gpa, "not json at all")) == null);
+}

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -174,6 +174,9 @@ const CliBuildEnvOptions = struct {
     /// The bundle URL a URL/installed root came from; becomes the root's
     /// package identity in place of the extracted path.
     root_source_url: ?[]const u8 = null,
+    /// The bundle URL an explicit `--main` came from; becomes the root
+    /// identity if that main file ends up as the discovery root.
+    main_source_url: ?[]const u8 = null,
 };
 
 const InitCliBuildEnvError = Allocator.Error ||
@@ -216,6 +219,12 @@ fn initCliBuildEnv(ctx: *CliCtx, opts: CliBuildEnvOptions) InitCliBuildEnvError!
         // The URL was validated before any pipeline could receive it, so the
         // only reachable failure here is allocation.
         build_env.setRootUrl(url) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.InvalidUrl => unreachable,
+        };
+    }
+    if (opts.main_source_url) |url| {
+        build_env.setMainUrl(url) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             error.InvalidUrl => unreachable,
         };
@@ -2294,7 +2303,7 @@ fn rocRunInstalled(ctx: *CliCtx, args: cli_args.RunArgs) CliMainError!void {
         try ctx.io.stderr().print("Error: --watch is not supported for installed shorthands.\n", .{});
         return error.UnsupportedWatchMode;
     }
-    if (args.opt != cli_args.default_dev_opt) {
+    if (args.explicit_opt) {
         try ctx.io.stderr().print(
             "Error: --opt has no effect on `roc run {s}`; installed tools always run the optimized binary that was built at install time.\n",
             .{name},
@@ -6295,15 +6304,72 @@ fn resolveUrlBundle(ctx: *CliCtx, url: []const u8) (CliError || error{OutOfMemor
     // Platforms must have a main.roc entry point
     const platform_source_path = try std.fs.path.join(ctx.arena, &.{ package_dir_path, "main.roc" });
     std.Io.Dir.cwd().access(ctx.io.std_io, platform_source_path, .{}) catch {
+        // The problem is rendered after this frame returns, so the slice of
+        // searched paths must live on the arena, not this stack frame.
+        const searched_paths = try ctx.arena.alloc([]const u8, 1);
+        searched_paths[0] = platform_source_path;
         return ctx.fail(.{ .platform_source_not_found = .{
             .platform_path = package_dir_path,
-            .searched_paths = &.{platform_source_path},
+            .searched_paths = searched_paths,
         } });
     };
 
     return .{
         .source_path = platform_source_path,
     };
+}
+
+/// Default output basename for `roc build <url>`: the last path segment of
+/// the URL's package id (the part before the version and content hash), e.g.
+/// `tokei` for `https://example.com/tokei/1.2.3/<hash>.tar.zst`. Null when
+/// the URL has no usable segment, in which case the module name is used.
+fn urlDefaultOutputBasename(url: []const u8) ?[]const u8 {
+    const parsed = base.url.parseUrlPath(url) catch return null;
+    var it = std.mem.splitBackwardsScalar(u8, parsed.url_id.prefix(url), '/');
+    while (it.next()) |segment| {
+        if (segment.len == 0) continue;
+        // The host segment can carry a port; a colon is not a usable filename
+        // on Windows, so fall back to the module name instead.
+        if (std.mem.findScalar(u8, segment, ':') != null) return null;
+        return segment;
+    }
+    return null;
+}
+
+test "urlDefaultOutputBasename derives the package segment" {
+    try std.testing.expectEqualStrings("tokei", urlDefaultOutputBasename("https://example.com/tokei/1.2.3/AQmoxbAY7eQfXMbi9XUxBvBGZcxZCs1tdNeFriRRkwSc.tar.zst").?);
+    try std.testing.expectEqualStrings("thing", urlDefaultOutputBasename("https://example.com/thing/AQmoxbAY7eQfXMbi9XUxBvBGZcxZCs1tdNeFriRRkwSc.tar.zst").?);
+    // A bare host:port segment is not a usable filename on Windows.
+    try std.testing.expect(urlDefaultOutputBasename("http://127.0.0.1:8642/AQmoxbAY7eQfXMbi9XUxBvBGZcxZCs1tdNeFriRRkwSc.tar.zst") == null);
+    try std.testing.expect(urlDefaultOutputBasename("not a url") == null);
+}
+
+/// A staging directory older than this cannot belong to a live install and
+/// is safe to reclaim.
+const stale_staging_max_age_ns: i128 = std.time.ns_per_day;
+
+/// Reclaim staging directories stranded by interrupted installs. The install
+/// root is deliberately outside every cache cleanup, and each staging name
+/// embeds a random suffix no later install reuses, so nothing else ever
+/// deletes them. Best-effort: any failure just leaves the sweep to a future
+/// install.
+fn sweepStaleStagingDirs(std_io: std.Io, version_dir: []const u8) void {
+    var dir = std.Io.Dir.cwd().openDir(std_io, version_dir, .{ .iterate = true }) catch return;
+    defer dir.close(std_io);
+
+    const now_ns: i128 = std.Io.Timestamp.now(std_io, .real).nanoseconds;
+    var it = dir.iterate();
+    while (true) {
+        const entry = (it.next(std_io) catch break) orelse break;
+        if (entry.kind != .directory) continue;
+        if (!std.mem.startsWith(u8, entry.name, ".staging-")) continue;
+
+        const info = dir.statFile(std_io, entry.name, .{}) catch continue;
+        const mtime_ns: i128 = @intCast(info.mtime.nanoseconds);
+        if (now_ns - mtime_ns <= stale_staging_max_age_ns) continue;
+
+        dir.deleteTree(std_io, entry.name) catch {};
+    }
 }
 
 /// Install a bundle URL under a shorthand: download and verify it into a
@@ -6384,6 +6450,8 @@ fn rocInstall(ctx: *CliCtx, args: cli_args.InstallArgs, arg0: []const u8) CliMai
     std.Io.Dir.cwd().createDirPath(ctx.io.std_io, version_dir) catch |err| {
         return ctx.fail(.{ .directory_create_failed = .{ .path = version_dir, .err = err } });
     };
+
+    sweepStaleStagingDirs(ctx.io.std_io, version_dir);
 
     // The `.` prefix keeps staging directories out of the shorthand namespace.
     var staging_suffix: [8]u8 = undefined;
@@ -7080,8 +7148,12 @@ fn rocBuild(ctx: *CliCtx, args_in: cli_args.BuildArgs, arg0: []const u8) CliMain
     if (args.root_source_url == null) {
         args.root_source_url = resolved_source.url;
     }
-    if (install_store.classifySourceRef(args_in.path) == .shorthand and args.synthetic_output_basename == null) {
-        args.synthetic_output_basename = args_in.path;
+    if (args.synthetic_output_basename == null) {
+        switch (install_store.classifySourceRef(args_in.path)) {
+            .shorthand => args.synthetic_output_basename = args_in.path,
+            .url => args.synthetic_output_basename = urlDefaultOutputBasename(args_in.path),
+            .local_path => {},
+        }
     }
 
     // `roc build --watch` rebuilds on every change. The watch loop reruns this same
@@ -12218,7 +12290,9 @@ fn rocTest(ctx: *CliCtx, args_in: cli_args.TestArgs, arg0: []const u8) RocTestEr
     args.path = resolved_source.path;
     args.root_source_url = resolved_source.url;
     if (args_in.main) |main_path| {
-        args.main = (try resolveSourceArg(ctx, main_path, args_in.watch)).path;
+        const resolved_main = try resolveSourceArg(ctx, main_path, args_in.watch);
+        args.main = resolved_main.path;
+        args.main_source_url = resolved_main.url;
     }
 
     if (args.watch) {
@@ -12240,6 +12314,7 @@ fn rocTest(ctx: *CliCtx, args_in: cli_args.TestArgs, arg0: []const u8) RocTestEr
         .resolution_config = resolutionConfigFromLimits(args.resolve_limits),
         .track_watch_inputs = args.watch_inputs_file != null,
         .root_source_url = args.root_source_url,
+        .main_source_url = args.main_source_url,
     });
     defer build_env.deinit();
 
@@ -13877,6 +13952,7 @@ fn checkFileWithBuildEnvPreserved(
     filepath: []const u8,
     main_filepath: ?[]const u8,
     root_source_url: ?[]const u8,
+    main_source_url: ?[]const u8,
     _: bool,
     cache_config: CacheConfig,
     max_threads: ?usize,
@@ -13900,6 +13976,7 @@ fn checkFileWithBuildEnvPreserved(
         .source_dir_override = source_dir_override,
         .builtin_role_path = filepath,
         .root_source_url = root_source_url,
+        .main_source_url = main_source_url,
     });
 
     buildForCheckWithOptionalMain(&build_env, filepath, main_filepath) catch |err| {
@@ -14039,6 +14116,7 @@ fn checkFileWithBuildEnv(
     filepath: []const u8,
     main_filepath: ?[]const u8,
     root_source_url: ?[]const u8,
+    main_source_url: ?[]const u8,
     _: bool,
     cache_config: CacheConfig,
     max_threads: ?usize,
@@ -14057,6 +14135,7 @@ fn checkFileWithBuildEnv(
         .source_dir_override = source_dir_override,
         .synthetic_default_app = synthetic_default_app,
         .root_source_url = root_source_url,
+        .main_source_url = main_source_url,
         // Checking is not complete until the platform/app relation output
         // completes, so `roc check` finalizes the relation-bearing platform
         // root once (which also resolves the platform target config constants
@@ -14262,6 +14341,7 @@ fn rocCheckDefaultApp(
         files.app_path,
         null,
         null,
+        null,
         args.time,
         cache_config,
         args.max_threads,
@@ -14314,6 +14394,7 @@ fn rocCheckDefaultAppPreserved(
         files.app_path,
         null,
         null,
+        null,
         args.time,
         cache_config,
         args.max_threads,
@@ -14358,7 +14439,9 @@ fn rocCheck(ctx: *CliCtx, args_in: cli_args.CheckArgs, arg0: []const u8) RocChec
     args.path = resolved_source.path;
     args.root_source_url = resolved_source.url;
     if (args_in.main) |main_path| {
-        args.main = (try resolveSourceArg(ctx, main_path, args_in.watch)).path;
+        const resolved_main = try resolveSourceArg(ctx, main_path, args_in.watch);
+        args.main = resolved_main.path;
+        args.main_source_url = resolved_main.url;
     }
 
     if (args.watch) {
@@ -14418,6 +14501,7 @@ fn rocCheck(ctx: *CliCtx, args_in: cli_args.CheckArgs, arg0: []const u8) RocChec
             args.path,
             args.main,
             args.root_source_url,
+            args.main_source_url,
             args.time,
             cache_config,
             args.max_threads,
@@ -14455,6 +14539,7 @@ fn rocCheck(ctx: *CliCtx, args_in: cli_args.CheckArgs, arg0: []const u8) RocChec
             args.path,
             args.main,
             args.root_source_url,
+            args.main_source_url,
             args.time,
             cache_config,
             args.max_threads,
@@ -14842,6 +14927,7 @@ fn bumpCheckSide(
         path,
         null,
         root_source_url,
+        null,
         false,
         cache_config,
         null,
@@ -15068,7 +15154,9 @@ fn rocDocs(ctx: *CliCtx, args_in: cli_args.DocsArgs) CliMainError!void {
     args.path = resolved_source.path;
     args.root_source_url = resolved_source.url;
     if (args_in.main) |main_path| {
-        args.main = (try resolveSourceArg(ctx, main_path, false)).path;
+        const resolved_main = try resolveSourceArg(ctx, main_path, false);
+        args.main = resolved_main.path;
+        args.main_source_url = resolved_main.url;
     }
 
     const stdout = ctx.io.stdout();
@@ -15089,6 +15177,7 @@ fn rocDocs(ctx: *CliCtx, args_in: cli_args.DocsArgs) CliMainError!void {
         args.path,
         args.main,
         args.root_source_url,
+        args.main_source_url,
         args.time,
         cache_config,
         null, // max_threads: use default (single-threaded for now)

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -90,6 +90,7 @@ const watch_mod = if (builtin.target.cpu.arch == .wasm32) struct {
 } else @import("watch");
 
 const cli_args = @import("cli_args.zig");
+const install_store = @import("install.zig");
 const host_symbols = @import("host_symbols.zig");
 const roc_target = @import("target.zig");
 const target_selection = @import("target_selection.zig");
@@ -170,6 +171,9 @@ const CliBuildEnvOptions = struct {
     /// Root path tested against the compiler-owned builtin sources; matches
     /// are compiled with the `.builtin` module role (check sites).
     builtin_role_path: ?[]const u8 = null,
+    /// The bundle URL a URL/installed root came from; becomes the root's
+    /// package identity in place of the extracted path.
+    root_source_url: ?[]const u8 = null,
 };
 
 const InitCliBuildEnvError = Allocator.Error ||
@@ -207,6 +211,14 @@ fn initCliBuildEnv(ctx: *CliCtx, opts: CliBuildEnvOptions) InitCliBuildEnvError!
         if (isCompilerOwnedBuiltinSourcePath(ctx.gpa, ctx.io.std_io, path)) {
             build_env.setRootModuleRole(.builtin);
         }
+    }
+    if (opts.root_source_url) |url| {
+        // The URL was validated before any pipeline could receive it, so the
+        // only reachable failure here is allocation.
+        build_env.setRootUrl(url) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.InvalidUrl => unreachable,
+        };
     }
     if (!opts.no_cache) try build_env.enableDefaultCacheManager(opts.verbose_cache);
 
@@ -1080,7 +1092,7 @@ pub fn main(init: std.process.Init) Allocator.Error!void {
 
 fn parsedArgsStartBackgroundCleanup(args: cli_args.CliArgs) bool {
     return switch (args) {
-        .run, .build, .check, .test_cmd, .docs, .bump, .glue, .experimental_lsp => true,
+        .run, .build, .check, .test_cmd, .docs, .bump, .glue, .install, .experimental_lsp => true,
         .fmt, .bundle, .unbundle, .repl, .version, .help, .licenses, .problem => false,
     };
 }
@@ -1147,6 +1159,7 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8, std_io: 
         .bundle => .bundle,
         .unbundle => .unbundle,
         .bump => .bump,
+        .install => .install,
         else => .unknown,
     };
 
@@ -1215,6 +1228,12 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8, std_io: 
             },
             else => return err,
         },
+        .install => |install_args| rocInstall(&ctx, install_args, args[0]) catch |err| switch (err) {
+            error.CliError => {
+                // Problems already recorded in context, render them below
+            },
+            else => return err,
+        },
         .experimental_lsp => |lsp_args| try lsp.runWithStdIo(gpa, std_io, .{
             .transport = lsp_args.debug_io,
             .build = lsp_args.debug_build,
@@ -1232,6 +1251,10 @@ fn mainArgs(gpa: Allocator, arena: Allocator, args: []const []const u8, std_io: 
                 .missing_flag_value => |details| ctx.io.stderr().print("Error: no value was supplied for {s}\n", .{details.flag}),
                 .unexpected_argument => |details| ctx.io.stderr().print("Error: roc {s} received an unexpected argument: `{s}`\n", .{ details.cmd, details.arg }),
                 .invalid_flag_value => |details| ctx.io.stderr().print("Error: `{s}` is not a valid value for {s}. The valid options are {s}\n", .{ details.value, details.flag, details.valid_options }),
+                .shorthand_requires_run => |details| ctx.io.stderr().print(
+                    "Error: `{s}` looks like an installed shorthand, and running one requires the `run` subcommand: `roc run {s}`\nIf you meant a local file named `{s}`, write it as `./{s}` instead.\n",
+                    .{ details.name, details.name, details.name, details.name },
+                ),
             };
             return error.InvalidArguments;
         },
@@ -2223,6 +2246,14 @@ fn rejectRunTargetNotExecutable(ctx: *CliCtx, target: RocTarget) error{ WriteFai
 }
 
 fn rocRun(ctx: *CliCtx, args: cli_args.RunArgs, arg0: []const u8) CliMainError!void {
+    switch (install_store.classifySourceRef(args.path)) {
+        .url => return rocRunUrl(ctx, args, arg0),
+        // The parser rejects bare `roc <shorthand>`, so a shorthand here came
+        // from the explicit `roc run` subcommand.
+        .shorthand => return rocRunInstalled(ctx, args),
+        .local_path => {},
+    }
+
     if (args.watch and args.opt != .dev) {
         try ctx.io.stderr().print(
             "Error: `roc --watch` currently supports only the dev backend.\n",
@@ -2235,6 +2266,162 @@ fn rocRun(ctx: *CliCtx, args: cli_args.RunArgs, arg0: []const u8) CliMainError!v
         .interpreter, .dev => rocRunSharedMemoryShim(ctx, args, arg0),
         .size, .speed => rocRunBuildAndExec(ctx, args, arg0),
     };
+}
+
+/// Direct URL run: download into the ordinary disposable package cache,
+/// then build and run once. URL roots are immutable managed sources, so they
+/// are never implicitly watched.
+fn rocRunUrl(ctx: *CliCtx, args: cli_args.RunArgs, arg0: []const u8) CliMainError!void {
+    if (args.explicit_watch) {
+        try ctx.io.stderr().print("Error: --watch is not supported for URL sources.\n", .{});
+        return error.UnsupportedWatchMode;
+    }
+
+    const resolved = try resolveUrlBundle(ctx, args.path);
+    var url_args = args;
+    url_args.path = resolved.source_path;
+    url_args.root_source_url = args.path;
+    url_args.watch = false;
+    return rocRunBuildAndExec(ctx, url_args, arg0);
+}
+
+/// Run the optimized executable that `roc install` built for this shorthand.
+/// No compilation and no network access happen here: the prebuilt binary is
+/// the entire artifact, so this works even with the package cache deleted.
+fn rocRunInstalled(ctx: *CliCtx, args: cli_args.RunArgs) CliMainError!void {
+    const name = args.path;
+    if (args.explicit_watch) {
+        try ctx.io.stderr().print("Error: --watch is not supported for installed shorthands.\n", .{});
+        return error.UnsupportedWatchMode;
+    }
+    if (args.opt != cli_args.default_dev_opt) {
+        try ctx.io.stderr().print(
+            "Error: --opt has no effect on `roc run {s}`; installed tools always run the optimized binary that was built at install time.\n",
+            .{name},
+        );
+        return error.InvalidArguments;
+    }
+    if (args.target != null) {
+        try ctx.io.stderr().print(
+            "Error: --target has no effect on `roc run {s}`; installed tools are built for this machine at install time.\n",
+            .{name},
+        );
+        return error.InvalidArguments;
+    }
+
+    const entry = try resolveInstalledEntry(ctx, name);
+    const term = try runCompiledExecutable(ctx, entry.paths.exe_path, args.app_args);
+    try finishCompiledRun(ctx, entry.paths.exe_path, term, 0);
+}
+
+const install_manifest_size_limit = 64 * 1024;
+
+/// Errors that resolving a URL/shorthand source reference can produce, shared
+/// by every subcommand that accepts one.
+const SourceRefResolveError = CliError || Allocator.Error || error{ UnsupportedWatchMode, WriteFailed };
+
+/// A source argument resolved to a compilable local path, together with the
+/// bundle URL it came from when the source was a managed URL/installed root.
+/// The URL — not the extracted path — is the root's package identity.
+const ResolvedSourceArg = struct {
+    path: []const u8,
+    url: ?[]const u8,
+};
+
+/// Resolve a source argument that may be a bundle URL or an installed
+/// shorthand into a local source path. Local paths pass through unchanged.
+/// URL and installed roots are immutable managed sources, so `--watch` is
+/// rejected for both.
+fn resolveSourceArg(ctx: *CliCtx, path: []const u8, watch: bool) SourceRefResolveError!ResolvedSourceArg {
+    switch (install_store.classifySourceRef(path)) {
+        .local_path => return .{ .path = path, .url = null },
+        .url => {
+            if (watch) {
+                try ctx.io.stderr().print("Error: --watch is not supported for URL sources.\n", .{});
+                return error.UnsupportedWatchMode;
+            }
+            const resolved = try resolveUrlBundle(ctx, path);
+            return .{ .path = resolved.source_path, .url = path };
+        },
+        .shorthand => {
+            if (watch) {
+                try ctx.io.stderr().print("Error: --watch is not supported for installed shorthands.\n", .{});
+                return error.UnsupportedWatchMode;
+            }
+            const entry = try resolveInstalledEntry(ctx, path);
+            return .{ .path = entry.paths.main_roc_path, .url = entry.url };
+        },
+    }
+}
+
+/// A validated install entry: its paths plus the bundle URL recorded in its
+/// manifest (the entry's compiler-level identity).
+const ResolvedInstalledEntry = struct {
+    paths: install_store.EntryPaths,
+    url: []const u8,
+};
+
+/// Resolve a shorthand to its published install entry, validating the
+/// manifest and the presence of the built artifact. Missing or corrupt state
+/// is an explicit error — never a fallback to a cache entry or a redownload.
+fn resolveInstalledEntry(ctx: *CliCtx, name: []const u8) (CliError || Allocator.Error)!ResolvedInstalledEntry {
+    const root = install_store.installRootDir(ctx.coreCtx(), ctx.arena) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.NoHomeDirectory => return ctx.fail(.{ .install_dir_unavailable = .{
+            .reason = "No home directory could be determined",
+        } }),
+    };
+    const version_dir = try install_store.versionDir(ctx.arena, root);
+    const entry = try install_store.entryPaths(ctx.arena, version_dir, name);
+
+    const manifest_bytes = std.Io.Dir.cwd().readFileAlloc(ctx.io.std_io, entry.manifest_path, ctx.arena, .limited(install_manifest_size_limit)) catch |err| switch (err) {
+        error.FileNotFound => {
+            var entry_dir = std.Io.Dir.cwd().openDir(ctx.io.std_io, entry.entry_dir, .{}) catch {
+                return ctx.fail(.{ .unknown_shorthand = .{ .name = name } });
+            };
+            entry_dir.close(ctx.io.std_io);
+            return ctx.fail(.{ .install_entry_corrupt = .{
+                .name = name,
+                .path = entry.entry_dir,
+                .reason = "its install.json manifest is missing",
+            } });
+        },
+        else => return ctx.fail(.{ .install_entry_corrupt = .{
+            .name = name,
+            .path = entry.entry_dir,
+            .reason = "its install.json manifest could not be read",
+        } }),
+    };
+    var parsed = (try install_store.parseManifest(ctx.gpa, manifest_bytes)) orelse {
+        return ctx.fail(.{ .install_entry_corrupt = .{
+            .name = name,
+            .path = entry.entry_dir,
+            .reason = "its install.json manifest is not valid",
+        } });
+    };
+    defer parsed.deinit();
+
+    // The recorded URL is the entry's identity, so it must still be a valid
+    // bundle URL — a manifest that fails this check is corrupt, and nothing
+    // downstream may be handed an unvalidated URL.
+    _ = base.url.parseUrlPath(parsed.manifest().url) catch {
+        return ctx.fail(.{ .install_entry_corrupt = .{
+            .name = name,
+            .path = entry.entry_dir,
+            .reason = "its install.json manifest records an invalid URL",
+        } });
+    };
+    const manifest_url = try ctx.arena.dupe(u8, parsed.manifest().url);
+
+    std.Io.Dir.cwd().access(ctx.io.std_io, entry.exe_path, .{}) catch {
+        return ctx.fail(.{ .install_entry_corrupt = .{
+            .name = name,
+            .path = entry.entry_dir,
+            .reason = "its built executable is missing",
+        } });
+    };
+
+    return .{ .paths = entry, .url = manifest_url };
 }
 
 fn rocRunSharedMemoryShim(ctx: *CliCtx, args: cli_args.RunArgs, arg0: []const u8) CliMainError!void {
@@ -2781,6 +2968,7 @@ fn rocRunBuildAndExec(ctx: *CliCtx, args: cli_args.RunArgs, arg0: []const u8) Cl
         .resolve_limits = args.resolve_limits,
         .synthetic_default_platform = false,
         .source_dir_override = null,
+        .root_source_url = args.root_source_url,
     }, arg0);
 
     const term = try runCompiledExecutable(ctx, exe_path, args.app_args);
@@ -6026,24 +6214,30 @@ const ResolvedUrlBundle = struct {
 /// Resolve a URL bundle (platform or package) by downloading and caching it.
 /// The URL must point to a .tar.zst bundle with a base58-encoded BLAKE3 hash filename.
 /// Returns the path to `main.roc` inside the cache directory.
-fn resolveUrlBundle(ctx: *CliCtx, url: []const u8) (CliError || error{OutOfMemory})!ResolvedUrlBundle {
-    const download = unbundle.download;
-
-    // 1. Validate URL and extract hash
-    const parsed_url = download.validateUrl(url) catch |err| switch (err) {
-        error.InvalidVersion => return ctx.fail(.{ .invalid_url = .{
+/// Validate a bundle URL (https/loopback-http gate plus hash and version
+/// syntax) and report a specific diagnostic for each way it can be invalid.
+fn validateBundleUrl(ctx: *CliCtx, url: []const u8) (CliError || error{OutOfMemory})!base.url.ParsedUrl {
+    return unbundle.download.validateUrl(url) catch |err| switch (err) {
+        error.InvalidVersion => ctx.fail(.{ .invalid_url = .{
             .url = url,
             .reason = "This URL uses the reserved version 0.0.0, which means \"no version\". The lowest publishable version is 0.0.1.",
         } }),
-        error.AmbiguousVersion => return ctx.fail(.{ .invalid_url = .{
+        error.AmbiguousVersion => ctx.fail(.{ .invalid_url = .{
             .url = url,
             .reason = "This URL contains more than one version number. A package URL must contain exactly one MAJOR.MINOR.PATCH version before its hash.",
         } }),
-        else => return ctx.fail(.{ .invalid_url = .{
+        else => ctx.fail(.{ .invalid_url = .{
             .url = url,
             .reason = "Invalid URL format or missing hash. URLs must end with a base58-encoded BLAKE3 hash filename (e.g., '<hash>.tar.zst').",
         } }),
     };
+}
+
+fn resolveUrlBundle(ctx: *CliCtx, url: []const u8) (CliError || error{OutOfMemory})!ResolvedUrlBundle {
+    const download = unbundle.download;
+
+    // 1. Validate URL and extract hash
+    const parsed_url = try validateBundleUrl(ctx, url);
     const base58_hash = parsed_url.hash;
 
     // 2. Get cache directory
@@ -6110,6 +6304,186 @@ fn resolveUrlBundle(ctx: *CliCtx, url: []const u8) (CliError || error{OutOfMemor
     return .{
         .source_path = platform_source_path,
     };
+}
+
+/// Install a bundle URL under a shorthand: download and verify it into a
+/// staging directory, build it with --opt=speed for the host target, then
+/// publish the completed entry with a single atomic rename so a partial
+/// installation is never visible. After this succeeds, `roc run <shorthand>`
+/// needs neither the network nor any cache.
+fn rocInstall(ctx: *CliCtx, args: cli_args.InstallArgs, arg0: []const u8) CliMainError!void {
+    if (!install_store.isValidShorthand(args.shorthand)) {
+        return ctx.fail(.{ .invalid_shorthand = .{ .name = args.shorthand } });
+    }
+    const parsed_url = try validateBundleUrl(ctx, args.url);
+
+    const root = install_store.installRootDir(ctx.coreCtx(), ctx.arena) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.NoHomeDirectory => return ctx.fail(.{ .install_dir_unavailable = .{
+            .reason = "No home directory could be determined",
+        } }),
+    };
+    const version_dir = try install_store.versionDir(ctx.arena, root);
+    const entry = try install_store.entryPaths(ctx.arena, version_dir, args.shorthand);
+
+    // Same name + same URL is idempotent; same name + different URL fails
+    // without touching the existing entry.
+    const existing_bytes: ?[]u8 = std.Io.Dir.cwd().readFileAlloc(ctx.io.std_io, entry.manifest_path, ctx.arena, .limited(install_manifest_size_limit)) catch |err| switch (err) {
+        error.FileNotFound => existing: {
+            var entry_dir = std.Io.Dir.cwd().openDir(ctx.io.std_io, entry.entry_dir, .{}) catch break :existing null;
+            entry_dir.close(ctx.io.std_io);
+            return ctx.fail(.{ .install_entry_corrupt = .{
+                .name = args.shorthand,
+                .path = entry.entry_dir,
+                .reason = "its install.json manifest is missing",
+            } });
+        },
+        else => return ctx.fail(.{ .install_entry_corrupt = .{
+            .name = args.shorthand,
+            .path = entry.entry_dir,
+            .reason = "its install.json manifest could not be read",
+        } }),
+    };
+    if (existing_bytes) |bytes| {
+        var parsed = (try install_store.parseManifest(ctx.gpa, bytes)) orelse {
+            return ctx.fail(.{ .install_entry_corrupt = .{
+                .name = args.shorthand,
+                .path = entry.entry_dir,
+                .reason = "its install.json manifest is not valid",
+            } });
+        };
+        defer parsed.deinit();
+        if (std.mem.eql(u8, parsed.manifest().url, args.url)) {
+            // Same name + same URL: an intact entry makes this a no-op, and a
+            // damaged one is safe to repair since the URL matches.
+            const exe_intact = intact: {
+                std.Io.Dir.cwd().access(ctx.io.std_io, entry.exe_path, .{}) catch break :intact false;
+                break :intact true;
+            };
+            if (exe_intact) {
+                try ctx.io.stdout().print("`{s}` is already installed. Run it with: roc run {s}\n", .{ args.shorthand, args.shorthand });
+                return;
+            }
+            std.Io.Dir.cwd().deleteTree(ctx.io.std_io, entry.entry_dir) catch {
+                return ctx.fail(.{ .install_entry_corrupt = .{
+                    .name = args.shorthand,
+                    .path = entry.entry_dir,
+                    .reason = "its built executable is missing, and the damaged entry could not be removed for repair",
+                } });
+            };
+        } else {
+            const existing_url = try ctx.arena.dupe(u8, parsed.manifest().url);
+            return ctx.fail(.{ .shorthand_conflict = .{
+                .name = args.shorthand,
+                .existing_url = existing_url,
+                .new_url = args.url,
+            } });
+        }
+    }
+
+    std.Io.Dir.cwd().createDirPath(ctx.io.std_io, version_dir) catch |err| {
+        return ctx.fail(.{ .directory_create_failed = .{ .path = version_dir, .err = err } });
+    };
+
+    // The `.` prefix keeps staging directories out of the shorthand namespace.
+    var staging_suffix: [8]u8 = undefined;
+    ctx.io.std_io.random(&staging_suffix);
+    const staging_name = try std.fmt.allocPrint(ctx.arena, ".staging-{s}-{s}", .{ args.shorthand, std.fmt.bytesToHex(staging_suffix, .lower) });
+    const staging_dir = try std.fs.path.join(ctx.arena, &.{ version_dir, staging_name });
+    const staging = try install_store.entryPathsIn(ctx.arena, staging_dir, args.shorthand);
+    defer std.Io.Dir.cwd().deleteTree(ctx.io.std_io, staging_dir) catch {};
+
+    std.Io.Dir.cwd().createDirPath(ctx.io.std_io, staging.source_dir) catch |err| {
+        return ctx.fail(.{ .directory_create_failed = .{ .path = staging.source_dir, .err = err } });
+    };
+    std.Io.Dir.cwd().createDirPath(ctx.io.std_io, staging.bin_dir) catch |err| {
+        return ctx.fail(.{ .directory_create_failed = .{ .path = staging.bin_dir, .err = err } });
+    };
+
+    try ctx.io.stdout().print("Downloading {s} ...\n", .{args.url});
+    ctx.io.flush();
+
+    const limits_config = resolutionConfigFromLimits(args.resolve_limits);
+    var gpa_copy = ctx.gpa;
+    _ = unbundle.download.downloadAndExtract(&gpa_copy, ctx.io.std_io, args.url, staging.source_dir, .{
+        .max_expanded_bytes = limits_config.max_package_expanded_bytes,
+    }) catch |download_err| {
+        return ctx.fail(.{ .download_failed = .{ .url = args.url, .err = download_err } });
+    };
+
+    // The downloader leaves the compressed bundle next to the extraction for
+    // cache reuse; an install entry is not a cache, so drop it.
+    const kept_tar_name = try std.fmt.allocPrint(ctx.arena, "{s}.tar.zst", .{parsed_url.hash});
+    const kept_tar_path = try std.fs.path.join(ctx.arena, &.{ staging.source_dir, kept_tar_name });
+    std.Io.Dir.cwd().deleteFile(ctx.io.std_io, kept_tar_path) catch {};
+
+    std.Io.Dir.cwd().access(ctx.io.std_io, staging.main_roc_path, .{}) catch {
+        return ctx.fail(.{ .install_bundle_missing_main = .{
+            .url = args.url,
+            .searched_path = staging.main_roc_path,
+        } });
+    };
+
+    try ctx.io.stdout().print("Building {s} with --opt=speed ...\n", .{args.shorthand});
+    ctx.io.flush();
+
+    var warning_count: usize = 0;
+    try rocBuild(ctx, .{
+        .path = staging.main_roc_path,
+        .opt = .speed,
+        .target = null,
+        .output = staging.exe_path,
+        .debug = false,
+        .allow_errors = false,
+        .verbose = false,
+        .no_cache = false,
+        .max_threads = args.max_threads,
+        .wasm_memory = null,
+        .wasm_stack_size = null,
+        .exit_on_warnings = false,
+        .warning_count_out = &warning_count,
+        .require_executable_output = true,
+        .require_host_runnable_output = true,
+        .suppress_build_status = true,
+        .resolve_limits = args.resolve_limits,
+        .synthetic_default_platform = false,
+        .source_dir_override = null,
+        .root_source_url = args.url,
+    }, arg0);
+
+    // The manifest is written last, so a staged entry is complete by the time
+    // it can be published.
+    const manifest_json = try install_store.manifestToJson(ctx.arena, .{
+        .format_version = install_store.manifest_format_version,
+        .url = args.url,
+        .hash = parsed_url.hash,
+        .compiler_version = build_options.compiler_version,
+    });
+    std.Io.Dir.cwd().writeFile(ctx.io.std_io, .{ .sub_path = staging.manifest_path, .data = manifest_json }) catch |err| {
+        return ctx.fail(.{ .file_write_failed = .{ .path = staging.manifest_path, .err = err } });
+    };
+
+    std.Io.Dir.cwd().rename(staging_dir, std.Io.Dir.cwd(), entry.entry_dir, ctx.io.std_io) catch |rename_err| {
+        // A concurrent install of the same shorthand may have published first;
+        // a same-URL winner makes this install a success with redundant work.
+        const winner_bytes = std.Io.Dir.cwd().readFileAlloc(ctx.io.std_io, entry.manifest_path, ctx.arena, .limited(install_manifest_size_limit)) catch {
+            return ctx.fail(.{ .install_publish_failed = .{ .name = args.shorthand, .err = rename_err } });
+        };
+        var winner = (try install_store.parseManifest(ctx.gpa, winner_bytes)) orelse {
+            return ctx.fail(.{ .install_publish_failed = .{ .name = args.shorthand, .err = rename_err } });
+        };
+        defer winner.deinit();
+        if (!std.mem.eql(u8, winner.manifest().url, args.url)) {
+            const existing_url = try ctx.arena.dupe(u8, winner.manifest().url);
+            return ctx.fail(.{ .shorthand_conflict = .{
+                .name = args.shorthand,
+                .existing_url = existing_url,
+                .new_url = args.url,
+            } });
+        }
+    };
+
+    try ctx.io.stdout().print("Installed {s}. Run it with: roc run {s}\n", .{ args.shorthand, args.shorthand });
 }
 
 /// Resolve a URL platform specification by downloading and caching the bundle.
@@ -6699,7 +7073,17 @@ fn rocUnbundle(ctx: *CliCtx, args: cli_args.UnbundleArgs) CliMainError!void {
     }
 }
 
-fn rocBuild(ctx: *CliCtx, args: cli_args.BuildArgs, arg0: []const u8) CliMainError!void {
+fn rocBuild(ctx: *CliCtx, args_in: cli_args.BuildArgs, arg0: []const u8) CliMainError!void {
+    var args = args_in;
+    const resolved_source = try resolveSourceArg(ctx, args_in.path, args_in.watch);
+    args.path = resolved_source.path;
+    if (args.root_source_url == null) {
+        args.root_source_url = resolved_source.url;
+    }
+    if (install_store.classifySourceRef(args_in.path) == .shorthand and args.synthetic_output_basename == null) {
+        args.synthetic_output_basename = args_in.path;
+    }
+
     // `roc build --watch` rebuilds on every change. The watch loop reruns this same
     // command (minus --watch) per change; the child writes its discovered inputs to
     // the --watch-inputs-file so the next iteration watches the right files.
@@ -6756,7 +7140,7 @@ fn rocBuildDefaultApp(ctx: *CliCtx, args: cli_args.BuildArgs, original_source: [
     synthetic_args.synthetic_root_header_len = header.len;
     synthetic_args.synthetic_root_header_lines = countNewlines(header);
     if (synthetic_args.output == null) {
-        synthetic_args.output = try base.module_path.getModuleNameAlloc(ctx.arena, args.path);
+        synthetic_args.output = args.synthetic_output_basename orelse try base.module_path.getModuleNameAlloc(ctx.arena, args.path);
     }
 
     switch (synthetic_args.opt) {
@@ -8126,6 +8510,8 @@ fn rocBuildLlvm(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
 
     const output_path = if (args.output) |output|
         try ctx.arena.dupe(u8, output)
+    else if (args.synthetic_output_basename) |basename|
+        try ctx.arena.dupe(u8, basename)
     else
         try base.module_path.getModuleNameAlloc(ctx.arena, args.path);
 
@@ -8136,6 +8522,7 @@ fn rocBuildLlvm(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
         .resolution_config = resolutionConfigFromLimits(args.resolve_limits),
         .track_watch_inputs = args.watch_inputs_file != null,
         .source_dir_override = args.source_dir_override,
+        .root_source_url = args.root_source_url,
     });
     if (args.synthetic_root_original_path) |original_path| {
         if (args.synthetic_root_original_source) |original_source| {
@@ -8429,6 +8816,8 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
 
     const output_path = if (args.output) |output|
         try ctx.arena.dupe(u8, output)
+    else if (args.synthetic_output_basename) |basename|
+        try ctx.arena.dupe(u8, basename)
     else
         try base.module_path.getModuleNameAlloc(ctx.arena, args.path);
 
@@ -8452,6 +8841,7 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
         .resolution_config = resolutionConfigFromLimits(args.resolve_limits),
         .track_watch_inputs = args.watch_inputs_file != null,
         .source_dir_override = args.source_dir_override,
+        .root_source_url = args.root_source_url,
     });
     if (args.synthetic_root_original_path) |original_path| {
         if (args.synthetic_root_original_source) |original_source| {
@@ -8756,6 +9146,8 @@ fn rocBuildEmbedded(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
 
     const output_path = if (args.output) |output|
         try ctx.arena.dupe(u8, output)
+    else if (args.synthetic_output_basename) |basename|
+        try ctx.arena.dupe(u8, basename)
     else
         try base.module_path.getModuleNameAlloc(ctx.arena, args.path);
 
@@ -8779,6 +9171,7 @@ fn rocBuildEmbedded(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!void {
         .resolution_config = resolutionConfigFromLimits(args.resolve_limits),
         .track_watch_inputs = args.watch_inputs_file != null,
         .source_dir_override = args.source_dir_override,
+        .root_source_url = args.root_source_url,
     });
     if (args.synthetic_root_original_path) |original_path| {
         if (args.synthetic_root_original_source) |original_source| {
@@ -10823,8 +11216,8 @@ const WatchChildOutputError = std.Io.File.MultiReader.UnendingError || std.Io.Ti
 const WatchCommandError = error{UnsupportedWatchMode} || WatchInputsPathError || WatchSpawnChildError || WatchCollectPathsError || WatchRefreshError || WatchReadInputsError || WatchChangeError || WatchChildOutputError || CliOutputWriteError;
 const ReportRenderError = Allocator.Error || CliOutputWriteError;
 const CheckFileWithBuildEnvPreservedError = compile.build.InitError || compile.build.BuildError || compile.build.CompileDiscoveredError || compile.build.BuildWithMainError || Allocator.Error || std.Io.Dir.RealPathFileAllocError || error{ ExpectedAppHeader, InvalidPackageName };
-const RocTestError = WatchCommandError || compile.build.InitError || compile.build.BuildError || compile.build.CompileDiscoveredError || compile.build.BuildWithMainError || WatchWriteInputsError || ReportRenderError || std.Io.Dir.RealPathFileAllocError || error{ CompilationFailed, TestsFailed, NoHomeDirectory };
-const RocCheckError = WatchCommandError || CheckFileWithBuildEnvPreservedError || WatchWriteInputsError || ReportRenderError || CliError || std.Io.Dir.CreateDirPathError || std.Io.Dir.WriteFileError || error{CheckFailed};
+const RocTestError = WatchCommandError || compile.build.InitError || compile.build.BuildError || compile.build.CompileDiscoveredError || compile.build.BuildWithMainError || WatchWriteInputsError || ReportRenderError || std.Io.Dir.RealPathFileAllocError || SourceRefResolveError || error{ CompilationFailed, TestsFailed, NoHomeDirectory };
+const RocCheckError = WatchCommandError || CheckFileWithBuildEnvPreservedError || WatchWriteInputsError || ReportRenderError || CliError || std.Io.Dir.CreateDirPathError || std.Io.Dir.WriteFileError || SourceRefResolveError || error{CheckFailed};
 
 const WatchEventSignal = struct {
     dirty: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
@@ -11816,9 +12209,17 @@ fn runWatchCommand(ctx: *CliCtx, arg0: []const u8, command: WatchCommand) WatchC
     }
 }
 
-fn rocTest(ctx: *CliCtx, args: cli_args.TestArgs, arg0: []const u8) RocTestError!void {
+fn rocTest(ctx: *CliCtx, args_in: cli_args.TestArgs, arg0: []const u8) RocTestError!void {
     const trace = tracy.trace(@src());
     defer trace.end();
+
+    var args = args_in;
+    const resolved_source = try resolveSourceArg(ctx, args_in.path, args_in.watch);
+    args.path = resolved_source.path;
+    args.root_source_url = resolved_source.url;
+    if (args_in.main) |main_path| {
+        args.main = (try resolveSourceArg(ctx, main_path, args_in.watch)).path;
+    }
 
     if (args.watch) {
         return runWatchCommand(ctx, arg0, .{ .test_cmd = args });
@@ -11838,6 +12239,7 @@ fn rocTest(ctx: *CliCtx, args: cli_args.TestArgs, arg0: []const u8) RocTestError
         .verbose_cache = args.verbose,
         .resolution_config = resolutionConfigFromLimits(args.resolve_limits),
         .track_watch_inputs = args.watch_inputs_file != null,
+        .root_source_url = args.root_source_url,
     });
     defer build_env.deinit();
 
@@ -13474,6 +13876,7 @@ fn checkFileWithBuildEnvPreserved(
     ctx: *CliCtx,
     filepath: []const u8,
     main_filepath: ?[]const u8,
+    root_source_url: ?[]const u8,
     _: bool,
     cache_config: CacheConfig,
     max_threads: ?usize,
@@ -13496,6 +13899,7 @@ fn checkFileWithBuildEnvPreserved(
         .synthetic_default_app = synthetic_default_app,
         .source_dir_override = source_dir_override,
         .builtin_role_path = filepath,
+        .root_source_url = root_source_url,
     });
 
     buildForCheckWithOptionalMain(&build_env, filepath, main_filepath) catch |err| {
@@ -13634,6 +14038,7 @@ fn checkFileWithBuildEnv(
     ctx: *CliCtx,
     filepath: []const u8,
     main_filepath: ?[]const u8,
+    root_source_url: ?[]const u8,
     _: bool,
     cache_config: CacheConfig,
     max_threads: ?usize,
@@ -13651,6 +14056,7 @@ fn checkFileWithBuildEnv(
         .resolution_config = resolution_config,
         .source_dir_override = source_dir_override,
         .synthetic_default_app = synthetic_default_app,
+        .root_source_url = root_source_url,
         // Checking is not complete until the platform/app relation output
         // completes, so `roc check` finalizes the relation-bearing platform
         // root once (which also resolves the platform target config constants
@@ -13855,6 +14261,7 @@ fn rocCheckDefaultApp(
         ctx,
         files.app_path,
         null,
+        null,
         args.time,
         cache_config,
         args.max_threads,
@@ -13906,6 +14313,7 @@ fn rocCheckDefaultAppPreserved(
         ctx,
         files.app_path,
         null,
+        null,
         args.time,
         cache_config,
         args.max_threads,
@@ -13941,9 +14349,17 @@ fn writeDefaultAppCheckWatchInputs(
     try writeWatchInputSetFile(ctx, file_path, &input_set);
 }
 
-fn rocCheck(ctx: *CliCtx, args: cli_args.CheckArgs, arg0: []const u8) RocCheckError!void {
+fn rocCheck(ctx: *CliCtx, args_in: cli_args.CheckArgs, arg0: []const u8) RocCheckError!void {
     const trace = tracy.trace(@src());
     defer trace.end();
+
+    var args = args_in;
+    const resolved_source = try resolveSourceArg(ctx, args_in.path, args_in.watch);
+    args.path = resolved_source.path;
+    args.root_source_url = resolved_source.url;
+    if (args_in.main) |main_path| {
+        args.main = (try resolveSourceArg(ctx, main_path, args_in.watch)).path;
+    }
 
     if (args.watch) {
         return runWatchCommand(ctx, arg0, .{ .check = args });
@@ -14001,6 +14417,7 @@ fn rocCheck(ctx: *CliCtx, args: cli_args.CheckArgs, arg0: []const u8) RocCheckEr
             ctx,
             args.path,
             args.main,
+            args.root_source_url,
             args.time,
             cache_config,
             args.max_threads,
@@ -14037,6 +14454,7 @@ fn rocCheck(ctx: *CliCtx, args: cli_args.CheckArgs, arg0: []const u8) RocCheckEr
             ctx,
             args.path,
             args.main,
+            args.root_source_url,
             args.time,
             cache_config,
             args.max_threads,
@@ -14265,7 +14683,12 @@ fn sendResponse(
     try w.flush();
 }
 
-fn rocBump(ctx: *CliCtx, args: cli_args.BumpArgs) CliMainError!void {
+fn rocBump(ctx: *CliCtx, args_in: cli_args.BumpArgs) CliMainError!void {
+    var args = args_in;
+    const resolved_source = try resolveSourceArg(ctx, args_in.path, false);
+    args.path = resolved_source.path;
+    args.root_source_url = resolved_source.url;
+
     const stdout = ctx.io.stdout();
 
     // Resolve the old package's version, from --old-version or the URL.
@@ -14328,9 +14751,9 @@ fn rocBump(ctx: *CliCtx, args: cli_args.BumpArgs) CliMainError!void {
         .roc_ctx = ctx.coreCtx(),
     };
 
-    var old_result = try bumpCheckSide(ctx, old_path, cache_config, args, "old");
+    var old_result = try bumpCheckSide(ctx, old_path, null, cache_config, args, "old");
     defer old_result.deinit(ctx.gpa);
-    var new_result = try bumpCheckSide(ctx, args.path, cache_config, args, "new");
+    var new_result = try bumpCheckSide(ctx, args.path, args.root_source_url, cache_config, args, "new");
     defer new_result.deinit(ctx.gpa);
 
     var old_api = try bumpExtractApi(ctx, &old_result.build_env, "old");
@@ -14408,6 +14831,7 @@ fn rocBump(ctx: *CliCtx, args: cli_args.BumpArgs) CliMainError!void {
 fn bumpCheckSide(
     ctx: *CliCtx,
     path: []const u8,
+    root_source_url: ?[]const u8,
     cache_config: CacheConfig,
     args: cli_args.BumpArgs,
     side: []const u8,
@@ -14417,6 +14841,7 @@ fn bumpCheckSide(
         ctx,
         path,
         null,
+        root_source_url,
         false,
         cache_config,
         null,
@@ -14634,9 +15059,17 @@ fn bumpExtractApi(ctx: *CliCtx, build_env: *compile.BuildEnv, side: []const u8) 
     };
 }
 
-fn rocDocs(ctx: *CliCtx, args: cli_args.DocsArgs) CliMainError!void {
+fn rocDocs(ctx: *CliCtx, args_in: cli_args.DocsArgs) CliMainError!void {
     const trace = tracy.trace(@src());
     defer trace.end();
+
+    var args = args_in;
+    const resolved_source = try resolveSourceArg(ctx, args_in.path, false);
+    args.path = resolved_source.path;
+    args.root_source_url = resolved_source.url;
+    if (args_in.main) |main_path| {
+        args.main = (try resolveSourceArg(ctx, main_path, false)).path;
+    }
 
     const stdout = ctx.io.stdout();
     const stderr = ctx.io.stderr();
@@ -14655,6 +15088,7 @@ fn rocDocs(ctx: *CliCtx, args: cli_args.DocsArgs) CliMainError!void {
         ctx,
         args.path,
         args.main,
+        args.root_source_url,
         args.time,
         cache_config,
         null, // max_threads: use default (single-threaded for now)

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -6320,6 +6320,15 @@ const InstallBundleServer = struct {
     }
 };
 
+/// Unblock an InstallBundleServer thread stuck in accept() when the roc
+/// command under test failed before ever connecting, so a clean assertion
+/// failure is reported instead of a join hang that the harness times out.
+fn pokeInstallBundleServer(io: std.Io, port: u16) void {
+    var address = std.Io.net.IpAddress.parse("127.0.0.1", port) catch return;
+    const stream = std.Io.net.IpAddress.connect(&address, io, .{ .mode = .stream }) catch return;
+    stream.close(io);
+}
+
 fn customInstallRunRoundtrip(io: std.Io, allocator: Allocator, env: *const CaseEnv, timer: *harness.Timer, timeout_ms: u64) ?TestResult {
     // Bundle a headerless default app from its own directory so main.roc sits
     // at the bundle root.
@@ -6381,6 +6390,7 @@ fn customInstallRunRoundtrip(io: std.Io, allocator: Allocator, env: *const CaseE
         .args = &.{ "install", "hello_tool", url },
         .contains = &.{.{ .stream = .stdout, .text = "Installed hello_tool" }},
     })) |failure| {
+        pokeInstallBundleServer(io, port);
         server_thread.join();
         return failure;
     }
@@ -6497,6 +6507,7 @@ fn customInstallHashMismatch(io: std.Io, allocator: Allocator, env: *const CaseE
         .exit = .{ .code = 1 },
         .contains = &.{ .{ .stream = .stderr, .text = "Failed to download from" }, .{ .stream = .stderr, .text = "HashMismatch" } },
     })) |failure| {
+        pokeInstallBundleServer(io, port);
         server_thread.join();
         return failure;
     }

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -404,6 +404,8 @@ const CustomCase = enum {
     docs_main_platform_url_package,
     build_issue_9435_hosted_nominal_return,
     bundle_complex_package,
+    install_run_roundtrip,
+    install_hash_mismatch,
     glue_debug,
     glue_debug_interpreter,
     glue_c_header,
@@ -1169,6 +1171,15 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "roc bump --expect rejects a malformed version", .body = .{ .command = .{ .args = &.{ "bump", "--no-cache", "--old", "test/bump/parser_v1", "--old-version", "1.2.3", "--expect", "v2.0.0" }, .roc_file = "test/bump/parser_v1/main.roc", .exit = .{ .code = 1 }, .contains = &.{.{ .stream = .stderr, .text = "not a valid version" }} } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc bump requires --old", .body = .{ .command = .{ .args = &.{ "bump", "--no-cache" }, .roc_file = "test/bump/parser_v1/main.roc", .exit = .failure, .contains = &.{.{ .stream = .stderr, .text = "no value was supplied for --old" }} } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc bump requires an old version for non-URL sources", .body = .{ .command = .{ .args = &.{ "bump", "--no-cache", "--old", "test/bump/parser_v1" }, .roc_file = "test/bump/parser_v1/main.roc", .exit = .{ .code = 1 }, .contains = &.{.{ .stream = .stderr, .text = "--old-version" }} } } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc install with no arguments prints usage", .body = .{ .command = .{ .args = &.{"install"}, .contains = &.{.{ .stream = .stdout, .text = "Usage: roc install" }} } } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc install rejects an invalid shorthand", .body = .{ .command = .{ .args = &.{ "install", "Bad_Name", "https://example.com/x/1.0.0/AQmoxbAY7eQfXMbi9XUxBvBGZcxZCs1tdNeFriRRkwSc.tar.zst" }, .exit = .{ .code = 1 }, .contains = &.{.{ .stream = .stderr, .text = "not a valid shorthand name" }} } } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc install rejects a URL without a content hash", .body = .{ .command = .{ .args = &.{ "install", "tool", "https://example.com/tool.tar.zst" }, .exit = .{ .code = 1 }, .contains = &.{.{ .stream = .stderr, .text = "Invalid URL format or missing hash" }} } } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc run reports an unknown shorthand", .body = .{ .command = .{ .args = &.{ "run", "nosuchtool" }, .exit = .{ .code = 1 }, .contains = &.{ .{ .stream = .stderr, .text = "Nothing is installed under the name" }, .{ .stream = .stderr, .text = "roc install nosuchtool" }, .{ .stream = .stderr, .text = "./nosuchtool" } } } } },
+    .{ .id = 0, .suite = .subcommands, .name = "bare roc rejects a shorthand and points at roc run", .body = .{ .command = .{ .args = &.{"sometool"}, .exit = .failure, .contains = &.{ .{ .stream = .stderr, .text = "roc run sometool" }, .{ .stream = .stderr, .text = "./sometool" } } } } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc run --help prints run usage", .body = .{ .command = .{ .args = &.{ "run", "--help" }, .contains = &.{.{ .stream = .stdout, .text = "Usage: roc run" }} } } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc run rejects --watch for installed shorthands", .body = .{ .command = .{ .args = &.{ "run", "sometool", "--watch" }, .exit = .failure, .contains = &.{.{ .stream = .stderr, .text = "--watch is not supported for installed shorthands" }} } } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc install/run roundtrip over loopback HTTP", .body = .{ .custom = .install_run_roundtrip } },
+    .{ .id = 0, .suite = .subcommands, .name = "roc install rejects a hash mismatch and leaves no entry", .body = .{ .custom = .install_hash_mismatch } },
     .{ .id = 0, .suite = .subcommands, .name = "roc test runs pure expects for a wasm-only platform (issue 9668)", .body = .{ .command = .{ .args = &.{ "test", "--opt=dev", "--no-cache" }, .roc_file = "test/cli/issue_9668_wasm_only_platform.roc", .exit = .success, .contains = &.{.{ .stream = .stdout, .text = "All (1) tests passed" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "shared libraries" }, .{ .stream = .stderr, .text = ".so/.dylib/.dll" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc explains wasm-only Shared output as a wasm module (issue 9668)", .body = .{ .command = .{ .args = &.{"--no-cache"}, .roc_file = "test/cli/issue_9668_wasm_only_platform.roc", .exit = .failure, .contains = &.{ .{ .stream = .stderr, .text = "targets wasm32" }, .{ .stream = .stderr, .text = ".wasm module" }, .{ .stream = .stderr, .text = "roc build" }, .{ .stream = .stderr, .text = "wasm artifact" } }, .not_contains = &.{.{ .stream = .stderr, .text = ".so/.dylib/.dll" }} } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc --opt=dev rejects non executable targets", .backend = .dev, .body = .{ .command = .{ .args = &.{ "--opt=dev", "--target=wasm32" }, .roc_file = "test/wasm/app.roc", .exit = .failure, .contains_any = &.{.{ .needles = &.{ .{ .stream = .stderr, .text = "only produces static libraries" }, .{ .stream = .stderr, .text = "TARGET NOT SUPPORTED" }, .{ .stream = .stderr, .text = "unsupported target" } } }} } } },
@@ -1468,6 +1479,7 @@ fn buildCaseEnv(io: std.Io, allocator: Allocator) CliRunnerError!CaseEnv {
     try env_map.put("ROC_CACHE_DIR", dirs.roc_cache_dir);
     try env_map.put("XDG_CACHE_HOME", dirs.roc_cache_dir);
     try env_map.put("ZIG_LOCAL_CACHE_DIR", dirs.zig_local_cache_dir);
+    try env_map.put("ROC_INSTALL_DIR", dirs.install_dir);
     try util.putIsolatedTempEnv(&env_map, dirs.temp_dir);
 
     return .{
@@ -2196,6 +2208,8 @@ fn runCustomCase(
         .docs_main_platform_url_package => customDocsMainPlatformUrlPackage(io, allocator, &env, &timer, timeout_ms),
         .build_issue_9435_hosted_nominal_return => customBuildIssue9435(io, allocator, &env, &timer, timeout_ms),
         .bundle_complex_package => customBundleComplexPackage(io, allocator, &env, &timer, timeout_ms),
+        .install_run_roundtrip => customInstallRunRoundtrip(io, allocator, &env, &timer, timeout_ms),
+        .install_hash_mismatch => customInstallHashMismatch(io, allocator, &env, &timer, timeout_ms),
         .glue_debug => customGlueDebug(io, allocator, &env, &timer, timeout_ms),
         .glue_debug_interpreter => customGlueDebugInterpreter(io, allocator, &env, &timer, timeout_ms),
         .glue_c_header => customGlueCHeader(io, allocator, &env, &timer, timeout_ms),
@@ -6261,6 +6275,236 @@ fn customBundleComplexPackage(io: std.Io, allocator: Allocator, env: *const Case
         .contains = &.{.{ .stream = .stdout, .text = "Created:" }},
         .not_contains = &.{.{ .stream = .stderr, .text = "missing from bundle" }},
     })) |failure| return failure;
+    return null;
+}
+
+/// Serves one HTTP request from a background thread: reads whatever arrives,
+/// responds with the bundle bytes, and exits. `roc install` performs exactly
+/// one download in the roundtrip below; every later step must work offline.
+const InstallBundleServer = struct {
+    server: *std.Io.net.Server,
+    bundle_data: []const u8,
+    io: std.Io,
+
+    const ServeError = std.Io.net.Server.AcceptError || std.Io.net.Stream.Reader.Error || std.Io.net.Stream.Writer.Error || std.Io.Writer.Error || error{ NoSpaceLeft, ReadFailed };
+
+    fn run(ctx: *@This()) void {
+        ctx.serveOne() catch {};
+    }
+
+    fn serveOne(ctx: *@This()) ServeError!void {
+        const stream = try ctx.server.accept(ctx.io);
+        defer stream.close(ctx.io);
+
+        var request_buf: [4096]u8 = undefined;
+        var recv_buffer: [512]u8 = undefined;
+        var conn_reader = stream.reader(ctx.io, &recv_buffer);
+        var slices = [_][]u8{request_buf[0..]};
+        _ = std.Io.Reader.readVec(&conn_reader.interface, &slices) catch |err| switch (err) {
+            error.EndOfStream => {},
+            error.ReadFailed => return error.ReadFailed,
+        };
+
+        var header_buf: [160]u8 = undefined;
+        const header = try std.fmt.bufPrint(&header_buf, "HTTP/1.1 200 OK\r\nContent-Length: {d}\r\nContent-Type: application/octet-stream\r\nConnection: close\r\n\r\n", .{ctx.bundle_data.len});
+        var write_buf: [4096]u8 = undefined;
+        var stream_writer = stream.writer(ctx.io, &write_buf);
+        try stream_writer.interface.writeAll(header);
+        try stream_writer.interface.writeAll(ctx.bundle_data);
+        try stream_writer.interface.flush();
+    }
+};
+
+fn customInstallRunRoundtrip(io: std.Io, allocator: Allocator, env: *const CaseEnv, timer: *harness.Timer, timeout_ms: u64) ?TestResult {
+    // Bundle a headerless default app from its own directory so main.roc sits
+    // at the bundle root.
+    const app_dir = createWorkSubdir(io, allocator, env, "install-app") catch |err|
+        return customInfraFailure(allocator, timer, "failed to create app dir: {}", .{err});
+    const app_main = std.fs.path.join(allocator, &.{ app_dir, "main.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate app path: {}", .{err});
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = app_main, .data = "main! = |_args| {\n    echo!(\"installed tool ran\")\n    Ok({})\n}\n" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write app main.roc: {}", .{err});
+
+    const serve_dir = createWorkSubdir(io, allocator, env, "install-serve") catch |err|
+        return customInfraFailure(allocator, timer, "failed to create serve dir: {}", .{err});
+
+    const roc_abs = if (std.fs.path.isAbsolute(roc_binary_path))
+        roc_binary_path
+    else
+        std.fs.path.join(allocator, &.{ project_root_path, roc_binary_path }) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate roc path: {}", .{err});
+
+    const bundle_timeout = childCommandTimeoutMs(timer, timeout_ms) orelse
+        return timeoutFailure(allocator, timer, .run, "case timeout exhausted before bundling");
+    const bundle_result = runRawInEnv(io, allocator, env, &.{ roc_abs, "bundle", "--output-dir", serve_dir, "main.roc" }, app_dir, null, bundle_timeout) catch |err|
+        return customInfraFailure(allocator, timer, "bundle spawn error: {}", .{err});
+    if (exitCode(bundle_result.term) != 0) {
+        return failureFromRun(allocator, timer, bundle_result, "roc bundle failed");
+    }
+    const created_prefix = "Created: ";
+    const created_idx = std.mem.find(u8, bundle_result.stdout, created_prefix) orelse
+        return failureFromRun(allocator, timer, bundle_result, "roc bundle did not report a created file");
+    const created_rest = bundle_result.stdout[created_idx + created_prefix.len ..];
+    const created_eol = std.mem.find(u8, created_rest, "\n") orelse created_rest.len;
+    const bundle_path = std.mem.trim(u8, created_rest[0..created_eol], " \r");
+    const bundle_filename = std.fs.path.basename(bundle_path);
+
+    const bundle_bytes = std.Io.Dir.cwd().readFileAlloc(io, bundle_path, allocator, .unlimited) catch |err|
+        return customInfraFailure(allocator, timer, "failed to read bundle {s}: {}", .{ bundle_path, err });
+
+    const loopback = std.Io.net.IpAddress.parse("127.0.0.1", 0) catch |err|
+        return customInfraFailure(allocator, timer, "failed to parse loopback address: {}", .{err});
+    var server = loopback.listen(io, .{ .reuse_address = true }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to listen on loopback: {}", .{err});
+    defer server.deinit(io);
+    const port = server.socket.address.getPort();
+
+    var server_ctx = InstallBundleServer{
+        .server = &server,
+        .bundle_data = bundle_bytes,
+        .io = io,
+    };
+    const server_thread = std.Thread.spawn(.{}, InstallBundleServer.run, .{&server_ctx}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to spawn server thread: {}", .{err});
+
+    const url = std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/{s}", .{ port, bundle_filename }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate url: {}", .{err});
+
+    // 1. Install: downloads (the only network access in this test), builds
+    //    with --opt=speed, and publishes the entry.
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "install", "hello_tool", url },
+        .contains = &.{.{ .stream = .stdout, .text = "Installed hello_tool" }},
+    })) |failure| {
+        server_thread.join();
+        return failure;
+    }
+    server_thread.join();
+
+    // 2. Run the installed shorthand.
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "run", "hello_tool" },
+        .contains = &.{.{ .stream = .stdout, .text = "installed tool ran" }},
+    })) |failure| return failure;
+
+    // 3. Desert island: delete the package cache; the installed tool must
+    //    still run (and must not touch the network — the server is gone).
+    std.Io.Dir.cwd().deleteTree(io, env.dirs.roc_cache_dir) catch |err|
+        return customInfraFailure(allocator, timer, "failed to delete cache dir: {}", .{err});
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "run", "hello_tool" },
+        .contains = &.{.{ .stream = .stdout, .text = "installed tool ran" }},
+    })) |failure| return failure;
+
+    // 4. Same name + same URL is an idempotent no-op (no download).
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "install", "hello_tool", url },
+        .contains = &.{.{ .stream = .stdout, .text = "already installed" }},
+    })) |failure| return failure;
+
+    // 5. Same name + different URL fails without touching the entry
+    //    (detected before any download).
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "install", "hello_tool", "https://example.com/other/1.2.3/AQmoxbAY7eQfXMbi9XUxBvBGZcxZCs1tdNeFriRRkwSc.tar.zst" },
+        .exit = .{ .code = 1 },
+        .contains = &.{.{ .stream = .stderr, .text = "already installed from a different URL" }},
+    })) |failure| return failure;
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "run", "hello_tool" },
+        .contains = &.{.{ .stream = .stdout, .text = "installed tool ran" }},
+    })) |failure| return failure;
+
+    // 6. Build flags that cannot apply to a prebuilt binary are rejected.
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "run", "hello_tool", "--opt=speed" },
+        .exit = .failure,
+        .contains = &.{.{ .stream = .stderr, .text = "--opt has no effect" }},
+    })) |failure| return failure;
+
+    return null;
+}
+
+fn customInstallHashMismatch(io: std.Io, allocator: Allocator, env: *const CaseEnv, timer: *harness.Timer, timeout_ms: u64) ?TestResult {
+    // Serve a well-formed bundle under a URL whose filename hash does not
+    // match its content: decompression succeeds but BLAKE3 verification must
+    // fail, and the failed install must leave no visible entry.
+    const app_dir = createWorkSubdir(io, allocator, env, "mismatch-app") catch |err|
+        return customInfraFailure(allocator, timer, "failed to create app dir: {}", .{err});
+    const app_main = std.fs.path.join(allocator, &.{ app_dir, "main.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate app path: {}", .{err});
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = app_main, .data = "main! = |_args| {\n    echo!(\"should never run\")\n    Ok({})\n}\n" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write app main.roc: {}", .{err});
+
+    const serve_dir = createWorkSubdir(io, allocator, env, "mismatch-serve") catch |err|
+        return customInfraFailure(allocator, timer, "failed to create serve dir: {}", .{err});
+
+    const roc_abs = if (std.fs.path.isAbsolute(roc_binary_path))
+        roc_binary_path
+    else
+        std.fs.path.join(allocator, &.{ project_root_path, roc_binary_path }) catch |err|
+            return customInfraFailure(allocator, timer, "failed to allocate roc path: {}", .{err});
+
+    const bundle_timeout = childCommandTimeoutMs(timer, timeout_ms) orelse
+        return timeoutFailure(allocator, timer, .run, "case timeout exhausted before bundling");
+    const bundle_result = runRawInEnv(io, allocator, env, &.{ roc_abs, "bundle", "--output-dir", serve_dir, "main.roc" }, app_dir, null, bundle_timeout) catch |err|
+        return customInfraFailure(allocator, timer, "bundle spawn error: {}", .{err});
+    if (exitCode(bundle_result.term) != 0) {
+        return failureFromRun(allocator, timer, bundle_result, "roc bundle failed");
+    }
+    const created_prefix = "Created: ";
+    const created_idx = std.mem.find(u8, bundle_result.stdout, created_prefix) orelse
+        return failureFromRun(allocator, timer, bundle_result, "roc bundle did not report a created file");
+    const created_rest = bundle_result.stdout[created_idx + created_prefix.len ..];
+    const created_eol = std.mem.find(u8, created_rest, "\n") orelse created_rest.len;
+    const bundle_path = std.mem.trim(u8, created_rest[0..created_eol], " \r");
+
+    const bundle_bytes = std.Io.Dir.cwd().readFileAlloc(io, bundle_path, allocator, .unlimited) catch |err|
+        return customInfraFailure(allocator, timer, "failed to read bundle {s}: {}", .{ bundle_path, err });
+
+    // A fixed valid base58 hash that cannot match this bundle's real content
+    // hash (the bundle's own filename is derived from its BLAKE3 hash, so any
+    // other valid hash string mismatches).
+    const wrong_hash_filename = "AQmoxbAY7eQfXMbi9XUxBvBGZcxZCs1tdNeFriRRkwSc.tar.zst";
+    if (std.mem.eql(u8, std.fs.path.basename(bundle_path), wrong_hash_filename)) {
+        return customInfraFailure(allocator, timer, "fixture bundle unexpectedly matches the wrong-hash filename", .{});
+    }
+
+    const loopback = std.Io.net.IpAddress.parse("127.0.0.1", 0) catch |err|
+        return customInfraFailure(allocator, timer, "failed to parse loopback address: {}", .{err});
+    var server = loopback.listen(io, .{ .reuse_address = true }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to listen on loopback: {}", .{err});
+    defer server.deinit(io);
+    const port = server.socket.address.getPort();
+
+    var server_ctx = InstallBundleServer{
+        .server = &server,
+        .bundle_data = bundle_bytes,
+        .io = io,
+    };
+    const server_thread = std.Thread.spawn(.{}, InstallBundleServer.run, .{&server_ctx}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to spawn server thread: {}", .{err});
+
+    const url = std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}/{s}", .{ port, wrong_hash_filename }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate url: {}", .{err});
+
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "install", "badtool", url },
+        .exit = .{ .code = 1 },
+        .contains = &.{ .{ .stream = .stderr, .text = "Failed to download from" }, .{ .stream = .stderr, .text = "HashMismatch" } },
+    })) |failure| {
+        server_thread.join();
+        return failure;
+    }
+    server_thread.join();
+
+    // "Nothing is installed" (rather than a corrupt-entry report) proves the
+    // failed install left no visible entry behind.
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "run", "badtool" },
+        .exit = .{ .code = 1 },
+        .contains = &.{.{ .stream = .stderr, .text = "Nothing is installed under the name" }},
+    })) |failure| return failure;
+
     return null;
 }
 

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -1611,7 +1611,7 @@ fn runInterpreterTest(
     const opt_arg = std.fmt.allocPrint(allocator, "--opt={s}", .{backend.cliName()}) catch
         return .{ .status = .infra_error, .phase = .setup, .duration_ns = timer.read(), .message = "failed to allocate opt arg" };
 
-    var argv_buf: [5][]const u8 = undefined;
+    var argv_buf: [7][]const u8 = undefined;
     var argc: usize = 0;
     argv_buf[argc] = roc_binary_path;
     argc += 1;
@@ -1619,17 +1619,22 @@ fn runInterpreterTest(
     argc += 1;
     argv_buf[argc] = opt_arg;
     argc += 1;
+    argv_buf[argc] = roc_file;
+    argc += 1;
     switch (platform.test_kind) {
         .native_run => {},
         .io_spec => |io_spec| {
-            const test_arg = std.fmt.allocPrint(allocator, "--test={s}", .{io_spec}) catch
-                return .{ .status = .infra_error, .phase = .setup, .duration_ns = timer.read(), .message = "failed to allocate IO spec arg" };
-            argv_buf[argc] = test_arg;
+            // App args go after `--` so the CLI forwards them to the host
+            // instead of parsing them; the host takes `--test <spec>` as two
+            // arguments, matching the built-executable path below.
+            argv_buf[argc] = "--";
+            argc += 1;
+            argv_buf[argc] = "--test";
+            argc += 1;
+            argv_buf[argc] = io_spec;
             argc += 1;
         },
     }
-    argv_buf[argc] = roc_file;
-    argc += 1;
 
     var run_timer = harness.Timer.start() catch return .{ .status = .infra_error, .phase = .run, .duration_ns = timer.read(), .message = "no clock" };
     const child_timeout_ms = childCommandTimeoutMs(timer, timeout_ms) orelse

--- a/src/cli/test/util.zig
+++ b/src/cli/test/util.zig
@@ -16,12 +16,16 @@ pub const default_child_timeout_ms: u64 = 5 * std.time.ms_per_min;
 pub const IsolatedCacheDirs = struct {
     roc_cache_dir: []u8,
     zig_local_cache_dir: []u8,
+    /// Persistent-install root, exported as ROC_INSTALL_DIR so `roc install`
+    /// state never leaks between tests or into the developer's real installs.
+    install_dir: []u8,
     /// Per-subprocess temp dir; see TestProcessDirs.temp_dir for why this must
     /// be isolated from the shared system temp dir.
     temp_dir: []u8,
 
     pub fn deinit(self: IsolatedCacheDirs, allocator: std.mem.Allocator) void {
         allocator.free(self.temp_dir);
+        allocator.free(self.install_dir);
         allocator.free(self.zig_local_cache_dir);
         allocator.free(self.roc_cache_dir);
     }
@@ -31,6 +35,9 @@ pub const IsolatedCacheDirs = struct {
 pub const TestProcessDirs = struct {
     roc_cache_dir: []u8,
     zig_local_cache_dir: []u8,
+    /// Persistent-install root, exported as ROC_INSTALL_DIR; see
+    /// IsolatedCacheDirs.install_dir.
+    install_dir: []u8,
     /// Per-job temp dir, exported as TEMP/TMP/TMPDIR to the roc subprocess. Roc
     /// derives its runtime-host scratch dir (`<temp>/roc/<version>/...`) from
     /// these and runs a background cleanup thread that iterates and deletes
@@ -44,6 +51,7 @@ pub const TestProcessDirs = struct {
     pub fn deinit(self: TestProcessDirs, allocator: std.mem.Allocator) void {
         allocator.free(self.work_dir);
         allocator.free(self.temp_dir);
+        allocator.free(self.install_dir);
         allocator.free(self.zig_local_cache_dir);
         allocator.free(self.roc_cache_dir);
     }
@@ -302,6 +310,10 @@ pub fn createIsolatedTestCacheDirs(io: std.Io, allocator: std.mem.Allocator) Tes
     defer allocator.free(zig_local_cache_rel);
     try std.Io.Dir.cwd().createDirPath(io, zig_local_cache_rel);
 
+    const install_rel = try std.fs.path.join(allocator, &.{ cache_root_rel, "roc-install" });
+    defer allocator.free(install_rel);
+    try std.Io.Dir.cwd().createDirPath(io, install_rel);
+
     const temp_rel = try std.fs.path.join(allocator, &.{ cache_root_rel, "tmp" });
     defer allocator.free(temp_rel);
     try std.Io.Dir.cwd().createDirPath(io, temp_rel);
@@ -309,6 +321,7 @@ pub fn createIsolatedTestCacheDirs(io: std.Io, allocator: std.mem.Allocator) Tes
     return .{
         .roc_cache_dir = try std.fs.path.join(allocator, &.{ cwd_path, roc_cache_rel }),
         .zig_local_cache_dir = try std.fs.path.join(allocator, &.{ cwd_path, zig_local_cache_rel }),
+        .install_dir = try std.fs.path.join(allocator, &.{ cwd_path, install_rel }),
         .temp_dir = try std.fs.path.join(allocator, &.{ cwd_path, temp_rel }),
     };
 }
@@ -329,6 +342,10 @@ pub fn createIsolatedTestDirs(io: std.Io, allocator: std.mem.Allocator) TestDirE
     defer allocator.free(zig_local_cache_rel);
     try std.Io.Dir.cwd().createDirPath(io, zig_local_cache_rel);
 
+    const install_rel = try std.fs.path.join(allocator, &.{ work_dir_rel, "roc-install" });
+    defer allocator.free(install_rel);
+    try std.Io.Dir.cwd().createDirPath(io, install_rel);
+
     const temp_rel = try std.fs.path.join(allocator, &.{ work_dir_rel, "tmp" });
     defer allocator.free(temp_rel);
     try std.Io.Dir.cwd().createDirPath(io, temp_rel);
@@ -336,6 +353,7 @@ pub fn createIsolatedTestDirs(io: std.Io, allocator: std.mem.Allocator) TestDirE
     return .{
         .roc_cache_dir = try std.fs.path.join(allocator, &.{ cwd_path, roc_cache_rel }),
         .zig_local_cache_dir = try std.fs.path.join(allocator, &.{ cwd_path, zig_local_cache_rel }),
+        .install_dir = try std.fs.path.join(allocator, &.{ cwd_path, install_rel }),
         .temp_dir = try std.fs.path.join(allocator, &.{ cwd_path, temp_rel }),
         .work_dir = try std.fs.path.join(allocator, &.{ cwd_path, work_dir_rel }),
     };
@@ -374,7 +392,8 @@ pub fn buildIsolatedTestEnvMap(
 
     if (env_map.get("ROC_CACHE_DIR") == null or
         env_map.get("XDG_CACHE_HOME") == null or
-        env_map.get("ZIG_LOCAL_CACHE_DIR") == null)
+        env_map.get("ZIG_LOCAL_CACHE_DIR") == null or
+        env_map.get("ROC_INSTALL_DIR") == null)
     {
         const cache_dirs = try createIsolatedTestCacheDirs(io, allocator);
         defer cache_dirs.deinit(allocator);
@@ -389,6 +408,10 @@ pub fn buildIsolatedTestEnvMap(
 
         if (env_map.get("ZIG_LOCAL_CACHE_DIR") == null) {
             try env_map.put("ZIG_LOCAL_CACHE_DIR", cache_dirs.zig_local_cache_dir);
+        }
+
+        if (env_map.get("ROC_INSTALL_DIR") == null) {
+            try env_map.put("ROC_INSTALL_DIR", cache_dirs.install_dir);
         }
 
         // Isolate the temp dir too, so roc's background temp-cleanup thread

--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -229,6 +229,13 @@ pub const BuildEnv = struct {
     synthetic_root_identity: bool = false,
     synthetic_root_platform_identity: bool = false,
 
+    /// The bundle URL the root itself came from, when the build was launched
+    /// from a URL or installed source. The URL — never the extracted path —
+    /// is then the root's package identity, so direct-URL use and installed
+    /// use of the same URL share one identity, and moving the extracted
+    /// directory cannot change it.
+    root_url: ?package_source.UrlSource = null,
+
     /// Size limits applied during package version resolution.
     resolution_config: package_resolution.Config = .{},
 
@@ -342,6 +349,8 @@ pub const BuildEnv = struct {
         }
 
         if (self.package_cache_dir) |dir| self.gpa.free(@constCast(dir));
+
+        if (self.root_url) |*url| url.deinit(self.gpa);
 
         // Deinit and free owned builtin modules. Borrowed builtins outlive this
         // BuildEnv and are released by their owner.
@@ -552,6 +561,15 @@ pub const BuildEnv = struct {
 
     pub fn setSyntheticRootPlatformPackageIdentity(self: *BuildEnv) void {
         self.synthetic_root_platform_identity = true;
+    }
+
+    /// Declare that the root being compiled came from this bundle URL; see
+    /// the `root_url` field. The URL must carry a valid trailing content
+    /// hash, matching what download validation already enforced.
+    pub fn setRootUrl(self: *BuildEnv, url: []const u8) error{ OutOfMemory, InvalidUrl }!void {
+        const parsed = base.url.parseUrlPath(url) catch return error.InvalidUrl;
+        if (self.root_url) |*existing| existing.deinit(self.gpa);
+        self.root_url = try package_source.UrlSource.init(self.gpa, .{ .url = url, .url_id = parsed.url_id });
     }
 
     pub fn setWatchInputTracking(self: *BuildEnv, enabled: bool) void {
@@ -770,12 +788,19 @@ pub const BuildEnv = struct {
         }
 
         // Create package entry keyed by stable package identity. Real roots use
-        // their canonical path; synthetic default-app roots keep the explicit
-        // synthetic identity because their temporary paths are ephemeral.
+        // their canonical path; URL-launched roots use their bundle URL because
+        // the extracted directory is a storage detail; synthetic default-app
+        // roots keep the explicit synthetic identity because their temporary
+        // paths are ephemeral.
         const root_identity = try package_identity.packageIdentityFor(
             self.gpa,
             self.filesystem,
-            if (self.synthetic_root_identity) .synthetic_app else .{ .local_path = root_abs },
+            if (self.synthetic_root_identity)
+                .synthetic_app
+            else if (self.root_url) |*root_url|
+                .{ .url = root_url.url }
+            else
+                .{ .local_path = root_abs },
         );
         defer self.gpa.free(root_identity);
 
@@ -789,6 +814,7 @@ pub const BuildEnv = struct {
             .root_file = pkg_root_file,
             .root_file_state = header_info.source_file_state,
             .root_dir = pkg_root_dir,
+            .url = if (self.root_url) |*root_url| try package_source.UrlSource.init(self.gpa, root_url.view()) else null,
         });
         self.discovered_pkg_name = key_pkg;
 
@@ -1886,6 +1912,7 @@ pub const BuildEnv = struct {
         };
         var resolver = package_resolution.Resolver.init(self.gpa, ctx_fetcher.fetcher(), self.resolution_config);
         defer resolver.deinit();
+        if (self.root_url) |*root_url| resolver.setRootUrl(root_url.url);
 
         var resolved = resolver.resolveScannedRoot(scanned_root) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,

--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -236,6 +236,12 @@ pub const BuildEnv = struct {
     /// directory cannot change it.
     root_url: ?package_source.UrlSource = null,
 
+    /// The bundle URL an explicitly supplied `--main` came from. Promoted to
+    /// `root_url` if and only if that main file becomes the discovery root
+    /// (see `buildResolvingMain`), since root identity must follow whichever
+    /// file actually roots the build.
+    main_url: ?package_source.UrlSource = null,
+
     /// Size limits applied during package version resolution.
     resolution_config: package_resolution.Config = .{},
 
@@ -351,6 +357,7 @@ pub const BuildEnv = struct {
         if (self.package_cache_dir) |dir| self.gpa.free(@constCast(dir));
 
         if (self.root_url) |*url| url.deinit(self.gpa);
+        if (self.main_url) |*url| url.deinit(self.gpa);
 
         // Deinit and free owned builtin modules. Borrowed builtins outlive this
         // BuildEnv and are released by their owner.
@@ -568,8 +575,24 @@ pub const BuildEnv = struct {
     /// hash, matching what download validation already enforced.
     pub fn setRootUrl(self: *BuildEnv, url: []const u8) error{ OutOfMemory, InvalidUrl }!void {
         const parsed = base.url.parseUrlPath(url) catch return error.InvalidUrl;
-        if (self.root_url) |*existing| existing.deinit(self.gpa);
+        if (self.root_url) |*existing| {
+            existing.deinit(self.gpa);
+            // Cleared before the fallible init so a failure cannot leave a
+            // dangling pointer for deinit to double-free.
+            self.root_url = null;
+        }
         self.root_url = try package_source.UrlSource.init(self.gpa, .{ .url = url, .url_id = parsed.url_id });
+    }
+
+    /// Declare that an explicitly supplied `--main` came from this bundle
+    /// URL; see the `main_url` field.
+    pub fn setMainUrl(self: *BuildEnv, url: []const u8) error{ OutOfMemory, InvalidUrl }!void {
+        const parsed = base.url.parseUrlPath(url) catch return error.InvalidUrl;
+        if (self.main_url) |*existing| {
+            existing.deinit(self.gpa);
+            self.main_url = null;
+        }
+        self.main_url = try package_source.UrlSource.init(self.gpa, .{ .url = url, .url_id = parsed.url_id });
     }
 
     pub fn setWatchInputTracking(self: *BuildEnv, enabled: bool) void {
@@ -673,6 +696,15 @@ pub const BuildEnv = struct {
             if (std.mem.eql(u8, root_abs, main_abs)) {
                 try self.build(root_file);
             } else {
+                // The main file is the discovery root here, so its bundle
+                // provenance — not the checked file's — is the root identity.
+                if (self.main_url) |*main_url| {
+                    if (self.root_url) |*existing| {
+                        existing.deinit(self.gpa);
+                        self.root_url = null;
+                    }
+                    self.root_url = try package_source.UrlSource.init(self.gpa, main_url.view());
+                }
                 try self.buildWithMain(root_file, main_path);
             }
             return;

--- a/src/compile/package_resolution.zig
+++ b/src/compile/package_resolution.zig
@@ -361,6 +361,13 @@ pub const Resolver = struct {
 
     diagnostics: std.ArrayListUnmanaged(Diagnostic),
 
+    /// The bundle URL the root itself came from, when the build was launched
+    /// from a URL or installed source rather than an ordinary local path. The
+    /// URL is the root's identity; the extracted path is a storage detail.
+    /// Borrowed; must outlive the resolver and have already parsed
+    /// successfully via `base.url.parseUrlPath`.
+    root_url: ?[]const u8 = null,
+
     pub fn init(gpa: Allocator, fetcher: Fetcher, config: Config) Resolver {
         return .{
             .gpa = gpa,
@@ -378,6 +385,11 @@ pub const Resolver = struct {
 
     pub fn deinit(self: *Resolver) void {
         self.arena_state.deinit();
+    }
+
+    /// Declare the bundle URL the root came from; see `root_url`.
+    pub fn setRootUrl(self: *Resolver, url: []const u8) void {
+        self.root_url = url;
     }
 
     fn arena(self: *Resolver) Allocator {
@@ -1011,14 +1023,24 @@ pub const Resolver = struct {
 
         var packages = std.ArrayListUnmanaged(Resolved.Package).empty;
 
-        // Index 0: the root.
+        // Index 0: the root. A URL-launched root carries its bundle URL as
+        // both identity and UrlInfo, exactly like a URL dependency would.
+        const root_url_info: ?Resolved.UrlInfo = if (self.root_url) |url| blk: {
+            const parsed = base.url.parseUrlPath(url) catch unreachable;
+            break :blk .{
+                .url = try out.dupe(u8, url),
+                .url_id = parsed.url_id,
+                .version = parsed.version,
+                .hash = try out.dupe(u8, parsed.hash),
+            };
+        } else null;
         try packages.append(out, .{
             .kind = root_node.kind,
-            .identity = try out.dupe(u8, root_path),
+            .identity = if (root_url_info) |info| info.url else try out.dupe(u8, root_path),
             .root_file = try out.dupe(u8, root_node.root_file),
             .root_dir = try out.dupe(u8, root_node.root_dir),
             .root_source_hash = root_node.root_source_hash,
-            .url = null,
+            .url = root_url_info,
             .deps = &.{},
         });
         const root_local_group = try std.fmt.allocPrint(self.arena(), "l@{s}", .{root_path});

--- a/src/unbundle/unbundle.zig
+++ b/src/unbundle/unbundle.zig
@@ -281,7 +281,9 @@ pub const PathValidationError = struct {
     reason: PathValidationReason,
 };
 
-const WINDOWS_RESERVED_NAMES = [_][]const u8{
+/// File and directory base names Windows reserves for devices; creating them
+/// misbehaves on Windows, so portable name validation rejects them everywhere.
+pub const WINDOWS_RESERVED_NAMES = [_][]const u8{
     "CON",  "PRN",  "AUX",  "NUL",
     "COM1", "COM2", "COM3", "COM4",
     "COM5", "COM6", "COM7", "COM8",

--- a/test/snapshots/docs_package_hides_private_modules.md
+++ b/test/snapshots/docs_package_hides_private_modules.md
@@ -1,6 +1,6 @@
 # META
 ~~~ini
-description=Issue 10077: package docs hide private modules and private type declarations
+description=Issue 10077: package docs hide private mods and private type declarations
 type=docs
 ~~~
 # SOURCE
@@ -32,10 +32,10 @@ Util :: {}
 ~~~clojure
 (package-docs
   (name "test-app")
-  (module
+  (mod
     (name "Date")
-    (package "module")
-    (kind type_module)
+    (package "mod")
+    (kind type_mod)
     (entry
       (name "Date")
       (kind opaque)
@@ -43,10 +43,10 @@ Util :: {}
       (doc "A calendar date.")
     )
   )
-  (module
+  (mod
     (name "Time")
-    (package "module")
-    (kind type_module)
+    (package "mod")
+    (kind type_mod)
     (doc "A time of day.")
     (entry
       (name "Time")

--- a/test/snapshots/issue/issue_10134_typed_frac_pattern_suffix_mismatch.md
+++ b/test/snapshots/issue/issue_10134_typed_frac_pattern_suffix_mismatch.md
@@ -48,7 +48,7 @@ EndOfFile,
 # PARSE
 ~~~clojure
 (file
-	(type-module)
+	(type-mod)
 	(statements
 		(s-type-anno (name "classify")
 			(ty-fn

--- a/test/snapshots/issue/issue_10134_typed_frac_patterns.md
+++ b/test/snapshots/issue/issue_10134_typed_frac_patterns.md
@@ -38,7 +38,7 @@ EndOfFile,
 # PARSE
 ~~~clojure
 (file
-	(type-module)
+	(type-mod)
 	(statements
 		(s-type-anno (name "classify32")
 			(ty-fn


### PR DESCRIPTION
This implements the executable half of #10265: `roc install <name> <URL>` downloads and hash-verifies a bundle, builds it with `--opt=speed` for the host target, and publishes source + optimized binary + manifest into a persistent per-compiler-version install directory (outside all caches, `ROC_INSTALL_DIR` override) using staging plus one atomic rename, so a failed or concurrent install never leaves a partial entry visible. `roc run <name>` then executes the prebuilt binary directly — no compilation, no network, and no dependence on the package cache, so installed tools keep working after caches are cleared.

Source arguments across `run`/`build`/`check`/`test`/`docs`/`bump` (and `--main`) now resolve deterministically by syntax: `https://` URLs get the npx-style flow through the ordinary package cache, bare tokens matching the shorthand grammar (`[a-z][a-z0-9_]*`, minus Windows reserved device names and `roc` itself) resolve as installed shorthands, and everything else is a local path — no filesystem probing, no fallbacks. Shorthands are only accepted in subcommand argument position: bare `roc <name>` is rejected with a pointer to `roc run`, keeping the subcommand namespace separate from user-chosen names. Same-name/same-URL reinstalls are idempotent and repair damaged entries; same-name/different-URL installs fail without touching the existing entry; `--watch` is rejected for URL and installed roots. The original bundle URL — not the extracted directory — is also plumbed through as the root's package identity (`BuildEnv.setRootUrl`, resolver root `UrlInfo`), so direct-URL use and installed use of one URL share a single identity, matching how URL dependencies are already identified.

Making `roc run` a real subcommand exposed that the CLI harness's interpreter io-spec platform cases had been invoking `roc run ...` — previously a help-text no-op that exited 0 — so every one of those cases passed vacuously without running the app. The harness now passes the file first and forwards `--test <spec>` to the host after `--`, making those 114 interpreter cases exercise the host contract runner again. A separate commit regenerates three snapshots from #10245/#10256 that raced the new semantic-audit rule banning `module` in snapshot content, which had left that audit failing on main.

Deferred to follow-ups: installing glue specs/compiler plugins as dylibs (depends on #10279), and `roc update`/uninstall.
