### PR TITLE
Speed up Zig unit tests on macOS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -340,6 +340,43 @@ const TestSuiteSpec = struct {
     default_step: bool = false,
 };
 
+/// Configures Roc's registered Zig unit tests to use Zig's stock runner with
+/// stack-trace capture controlled by `-Ddebug-gpa-traces`.
+const UnitTestRunner = struct {
+    path: std.Build.LazyPath,
+    build_options: *std.Build.Module,
+    zig_default_test_runner: *std.Build.Module,
+
+    fn configure(self: UnitTestRunner, compile: *Step.Compile) void {
+        compile.root_module.addImport("build_options", self.build_options);
+        compile.root_module.addImport("zig_default_test_runner", self.zig_default_test_runner);
+        compile.test_runner = .{
+            .path = self.path,
+            .mode = runnerMode(compile),
+        };
+    }
+
+    /// Keep in sync with `std.Build.addRunArtifact` and Zig's stock test
+    /// runner. These backends use the simple exit-code protocol; all others
+    /// use `std.zig.Server`.
+    fn runnerMode(compile: *Step.Compile) @FieldType(Step.Compile.TestRunner, "mode") {
+        if (compile.use_llvm == false) {
+            return switch (compile.rootModuleTarget().cpu.arch) {
+                .aarch64,
+                .aarch64_be,
+                .powerpc,
+                .powerpcle,
+                .powerpc64,
+                .powerpc64le,
+                .riscv64,
+                => .simple,
+                else => .server,
+            };
+        }
+        return .server;
+    }
+};
+
 /// Owns every cross-cutting edge a Zig test suite needs, so that a suite is
 /// wired up in exactly one call.
 ///
@@ -361,6 +398,7 @@ const TestSuiteRegistry = struct {
     b: *std.Build,
     summary: *TestsSummaryStep,
     build_test_zig_step: *Step,
+    unit_test_runner: UnitTestRunner,
     /// Non-null only while the test-wiring check is enumerating test binaries.
     wiring_run: ?*Step.Run,
     /// Args forwarded from `zig build -- <args>`, e.g. `--test-filter`.
@@ -368,6 +406,8 @@ const TestSuiteRegistry = struct {
 
     fn register(self: TestSuiteRegistry, spec: TestSuiteSpec) void {
         const b = self.b;
+
+        self.unit_test_runner.configure(spec.compile);
 
         // Build-side wiring, uniform for every suite.
         self.build_test_zig_step.dependOn(&spec.compile.step);
@@ -2603,7 +2643,7 @@ pub fn build(b: *std.Build) void {
     const trace_build = b.option(bool, "trace-build", "Enable detailed build pipeline tracing") orelse false;
     const debug_gpa = b.option(bool, "debug-gpa", "Use the leak-checking DebugAllocator for the roc binary even when libc is linked (default: off, so libc's malloc and its ASan/Valgrind/LD_PRELOAD tooling are used)") orelse false;
     const linker_warnings = b.option(bool, "linker-warnings", "Surface all embedded LLD linker warnings (default: off; suppressed with -w)") orelse false;
-    const debug_gpa_traces = b.option(bool, "debug-gpa-traces", "Capture an allocation-site stack trace on every DebugAllocator allocation so leak reports show where the leaked memory was allocated (default: off, because capturing traces dominates Debug-build runtime; leaks are detected either way)") orelse false;
+    const debug_gpa_traces = b.option(bool, "debug-gpa-traces", "Capture DebugAllocator allocation sites and enable Zig unit-test stack traces (default: off, because capturing traces dominates Debug-build runtime; leaks are detected either way)") orelse false;
     const shared_memory_size = b.option(u64, "shared-memory-size", "Explicitly set shared-memory arena sizes in bytes");
     const print_trmc = b.option(bool, "print-trmc", "Print one line for each transformed TRMC/TCE proc") orelse false;
     const print_ir_after_trmc = b.option(bool, "print-ir-after-trmc", "Print full LIR for each proc transformed by TRMC/TCE") orelse false;
@@ -2774,6 +2814,14 @@ pub fn build(b: *std.Build) void {
     });
 
     const roc_modules = modules.RocModules.create(b, build_options, zstd);
+    const zig_unit_test_lib_path = b.fmt("{f}", .{b.graph.zig_lib_directory});
+    const unit_test_runner = UnitTestRunner{
+        .path = b.path("src/build/unit_test_runner.zig"),
+        .build_options = roc_modules.build_options,
+        .zig_default_test_runner = b.createModule(.{
+            .root_source_file = .{ .cwd_relative = b.pathJoin(&.{ zig_unit_test_lib_path, "compiler/test_runner.zig" }) },
+        }),
+    };
 
     // Build-time compiler for builtin .roc modules
     //
@@ -4559,6 +4607,7 @@ pub fn build(b: *std.Build) void {
         .b = b,
         .summary = tests_summary,
         .build_test_zig_step = build_test_zig_step,
+        .unit_test_runner = unit_test_runner,
         .wiring_run = if (enumerate_tests_for_wiring_check) run_test_wiring else null,
         .run_args = run_args,
     };

--- a/src/build/unit_test_runner.zig
+++ b/src/build/unit_test_runner.zig
@@ -1,0 +1,28 @@
+//! Zig's stock test runner with stack-trace capture controlled by Roc's
+//! `-Ddebug-gpa-traces` option.
+//!
+//! `std.testing.allocator` always uses a leak-checking DebugAllocator with ten
+//! stack frames. Capturing those frames through Mach-O/DWARF dominates
+//! allocation-heavy test runtime on macOS arm64. The default remains traceless
+//! while preserving leak, double-free, and safety checks; pass
+//! `-Ddebug-gpa-traces` when allocation sites are needed for diagnosis.
+//!
+//! Zig exposes this through the root module's global `allow_stack_tracing`
+//! option, so the default also suppresses panic and error-return stack traces
+//! in unit-test binaries. The opt-in flag restores all of those traces.
+
+const std = @import("std");
+const build_options = @import("build_options");
+const default_test_runner = @import("zig_default_test_runner");
+
+/// Inherit Zig's stock test-runner options and only override stack tracing.
+pub const std_options: std.Options = options: {
+    var options = default_test_runner.std_options;
+    options.allow_stack_tracing = build_options.debug_gpa_traces;
+    break :options options;
+};
+
+/// Delegate test discovery, execution, and reporting to Zig's stock runner.
+pub fn main(init: std.process.Init.Minimal) void {
+    default_test_runner.main(init);
+}


### PR DESCRIPTION
## Summary

- Run every registered Zig unit-test suite through a small wrapper around Zig's stock test runner.
- Control the runner's global `allow_stack_tracing` option with Roc's existing `-Ddebug-gpa-traces` build flag.
- Keep DebugAllocator leak detection, double-free detection, and safety checks enabled in the default build while avoiding allocation-site stack capture.

## Why

This follows up on the macOS test slowdown noted in https://github.com/roc-lang/roc/pull/10266#issuecomment-5021739529.

`std.testing.allocator` is a leak-checking DebugAllocator configured with ten stack frames. In allocation-heavy Debug tests on macOS arm64, every allocation was therefore unwinding Mach-O/DWARF metadata. A local process sample showed this unwinding dominating both `module-compile` and `lir-inline`.

Roc already had `-Ddebug-gpa-traces`, but it only configured DebugAllocators created explicitly by Roc. It did not affect `std.testing.allocator`. This PR threads that same explicit build flag into all registered Zig unit-test roots via `std_options.allow_stack_tracing`.

The default test runner behavior and protocol are otherwise inherited directly from Zig's stock runner. The simple/server protocol selection remains aligned with `std.Build.addRunArtifact` and Zig's runner.

The tradeoff is intentional: default unit-test binaries do not print panic, error-return, or allocation-site stack traces. Pass `-Ddebug-gpa-traces` when those traces are needed. Leak and allocator-safety failures are still detected either way.

## Local macOS arm64 results

Warm-cache Debug runs on the same machine and revision:

| Suite | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `run-test-zig-module-compile` | 1348.01s | 88.23s | 15.3x |
| `run-test-zig-lir-inline` | 601.95s | 18.60s | 32.4x |

The post-change process sample no longer contains Mach-O/DWARF unwinding in the hot path; it instead shows ordinary compiler work. The final MiniCI run measured 88.75s and 18.69s for these suites.

For comparison, the CI run that motivated the follow-up reported macOS times of about 1428s and 701s versus Ubuntu times of about 296s and 89s: https://github.com/roc-lang/roc/actions/runs/29848682304.

## Validation

- `zig build run-check-test-wiring --summary all` (80/80 steps, all 47 registered test binaries compiled)
- `zig build run-test-zig-build-helpers --summary all`
- `zig build run-test-zig-build-helpers -Ddebug-gpa-traces --summary all`
- Manual intentional-leak probe in both modes: both report the leak; only the opt-in mode prints its allocation site
- `zig build run-test-eval --summary all --color off -- --timeout 120000` (1499/1499)
- `zig build minici` (73/73 phases)
