### PR TITLE
Use /tmp when temp environment variables are unset

### DIFF
--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -415,6 +415,7 @@ const CustomCase = enum {
     install_glue_roundtrip,
     glue_debug,
     glue_debug_dev,
+    glue_dev_without_temp_env,
     glue_dylib_cache_hit,
     glue_c_header,
     glue_c_header_compiles,
@@ -754,6 +755,7 @@ const echo_cases = [_]CliCase{
 const glue_cases = [_]CliCase{
     .{ .id = 0, .suite = .glue, .name = "glue command with DebugGlue succeeds", .body = .{ .custom = .glue_debug } },
     .{ .id = 0, .suite = .glue, .name = "glue command with DebugGlue succeeds with --opt=dev", .body = .{ .custom = .glue_debug_dev } },
+    .{ .id = 0, .suite = .glue, .name = "glue command succeeds without temp environment variables", .skip = .{ .windows = "Windows requires TEMP or TMP" }, .body = .{ .custom = .glue_dev_without_temp_env } },
     .{ .id = 0, .suite = .glue, .name = "glue command reuses cached compiler-owned dylib", .body = .{ .custom = .glue_dylib_cache_hit } },
     .{ .id = 0, .suite = .glue, .name = "glue command with CGlue generates expected C header", .body = .{ .custom = .glue_c_header } },
     .{ .id = 0, .suite = .glue, .name = "glue command generated C header compiles with zig cc", .body = .{ .custom = .glue_c_header_compiles } },
@@ -2219,6 +2221,7 @@ fn runCustomCase(
         .install_glue_roundtrip => customInstallGlueRoundtrip(io, allocator, &env, &timer, timeout_ms),
         .glue_debug => customGlueDebug(io, allocator, &env, &timer, timeout_ms),
         .glue_debug_dev => customGlueDebugDev(io, allocator, &env, &timer, timeout_ms),
+        .glue_dev_without_temp_env => customGlueDevWithoutTempEnv(io, allocator, &env, &timer, timeout_ms),
         .glue_dylib_cache_hit => customGlueDylibCacheHit(io, allocator, &env, &timer, timeout_ms),
         .glue_c_header => customGlueCHeader(io, allocator, &env, &timer, timeout_ms),
         .glue_c_header_compiles => customGlueCHeaderCompiles(io, allocator, &env, &timer, timeout_ms),
@@ -7425,6 +7428,30 @@ fn customGlueDebugDev(io: std.Io, allocator: Allocator, env: *const CaseEnv, tim
             .{ .stream = .stderr, .text = "PANIC" },
             .{ .stream = .stderr, .text = "unreachable" },
             .{ .stream = .stderr, .text = "name: \"\"" },
+        },
+    })) |failure| return failure;
+    return null;
+}
+
+fn customGlueDevWithoutTempEnv(io: std.Io, allocator: Allocator, env: *const CaseEnv, timer: *harness.Timer, timeout_ms: u64) ?TestResult {
+    var no_temp_env = CaseEnv{
+        .dirs = env.dirs,
+        .env_map = env.env_map.clone(allocator) catch |err|
+            return customInfraFailure(allocator, timer, "failed to clone environment for glue run: {}", .{err}),
+    };
+    defer no_temp_env.env_map.deinit();
+    _ = no_temp_env.env_map.swapRemove("TMPDIR");
+    _ = no_temp_env.env_map.swapRemove("TEMP");
+    _ = no_temp_env.env_map.swapRemove("TMP");
+
+    const output_dir = createWorkSubdir(io, allocator, env, "glue-no-temp-env") catch |err|
+        return customInfraFailure(allocator, timer, "failed to create glue output dir: {}", .{err});
+    if (runRocAndCheck(io, allocator, &no_temp_env, timer, timeout_ms, .{
+        .args = &.{ "glue", "--opt=dev", "src/glue/src/DebugGlue.roc", output_dir, "test/fx/platform/main.roc" },
+        .contains = &.{.{ .stream = .stderr, .text = "name: \"main!\"" }},
+        .not_contains = &.{
+            .{ .stream = .stderr, .text = "Compilation failed" },
+            .{ .stream = .stderr, .text = "PANIC" },
         },
     })) |failure| return failure;
     return null;

--- a/src/llvm_compile/compile.zig
+++ b/src/llvm_compile/compile.zig
@@ -813,6 +813,10 @@ fn getTempDir(allocator: Allocator) (Allocator.Error || error{TempDirUnavailable
         }
     }
 
+    // POSIX does not require TMPDIR to be set. Match the other compiler temp
+    // paths and standard library behavior by using the conventional location.
+    if (builtin.os.tag != .windows) return allocator.dupe(u8, "/tmp");
+
     return error.TempDirUnavailable;
 }
 

--- a/src/llvm_compile/compile.zig
+++ b/src/llvm_compile/compile.zig
@@ -815,7 +815,11 @@ fn getTempDir(allocator: Allocator) (Allocator.Error || error{TempDirUnavailable
 
     // POSIX does not require TMPDIR to be set. Match the other compiler temp
     // paths and standard library behavior by using the conventional location.
-    if (builtin.os.tag != .windows) return allocator.dupe(u8, "/tmp");
+    // Zig's createDirPath rejects macOS's /tmp symlink, so use its real path.
+    if (builtin.os.tag != .windows) return allocator.dupe(
+        u8,
+        if (builtin.os.tag == .macos) "/private/tmp" else "/tmp",
+    );
 
     return error.TempDirUnavailable;
 }


### PR DESCRIPTION
## Summary

- use `/tmp` for LLVM compilation on Unix when `TMPDIR`, `TEMP`, and `TMP` are unset
- preserve the existing environment-variable precedence and Windows error behavior
- add a CLI regression test that runs `roc glue --opt=dev` without any temp environment variables

## Root cause

`roc glue` compiles a compiler-owned host dylib through the LLVM path. That path returned `TempDirUnavailable` when none of the three temp environment variables were set, even though unset `TMPDIR` is valid on POSIX and other Roc temp paths use `/tmp`.

## Testing

- `zig build run-test-cli -- --suite glue` (48 passed)
- `zig build run-check-zig-format`
- `zig build run-check-zig-lints`
- `zig build run-check-tidy`
- `git diff --check`