### PR TITLE
Turn "Declaration Has No Value" into a warning

### DIFF
--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -3868,7 +3868,7 @@ pub const ReportBuilder = struct {
     }
 
     fn buildAnnotationOnlyValueReport(self: *Self, data: AnnotationOnlyValue) Allocator.Error!Report {
-        var report = try Report.init(self.gpa, "Declaration Has No Value", "This declaration has a type annotation but no implementation.", .runtime_error);
+        var report = try Report.init(self.gpa, "Declaration Has No Value", "This declaration has a type annotation but no implementation.", .warning);
         errdefer report.deinit();
 
         try self.addSourceHighlightRegion(&report, data.region);


### PR DESCRIPTION
## Summary

Closes #10041.

A top-level declaration with a type annotation but no implementation (`e_anno_only`) is currently reported at `.runtime_error` severity, which blocks compilation entirely. This changes the severity of that report to `.warning`, matching the behavior requested in the issue.

The value itself is still unified to an error type (`unifyWith(expr_var, .err, env)` in `Check.zig` is unchanged), so nothing about runtime soundness changes — if the annotation-only declaration is ever actually evaluated, it still produces a runtime crash. The only change is that it no longer counts toward the error total that blocks `roc check` / `roc build` / `roc run` from proceeding, consistent with how `Severity.warning` is documented and how `Literal Defaulted` already uses `.warning` for a similar "reported but non-blocking" diagnostic.

Verified manually:
```
$ roc check module.roc   # module.roc has `hey : U64 -> U64` with no body
...
Found 0 error(s) and 2 warning(s) in ...
```
(Previously this was `Found 1 error(s)`.)

## Test plan
- `zig build run-test-zig -- --test-filter "annotation_only"` — 4/4 pass
- `zig build run-check-snapshots` — all existing snapshots (including `type_alias_anno_only.md`, `type_annotation_missing_parens.md`, etc.) still match; the report title/text is unchanged, only severity changed
- Manually reproduced the issue's example with a local build and confirmed the diagnostic now reports as a warning and no longer blocks compilation