### PR TITLE
Fix declaration identity for value forward references

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -84,6 +84,7 @@ const ActiveDeclScope = struct {
 
 const ActiveDeclValueEntry = struct {
     ident: Ident.Idx,
+    decl_idx: AST.DeclIndex.DeclIdx,
     binding: ActiveDeclBinding,
     previous: ?usize,
 };
@@ -206,6 +207,10 @@ decl_scope_stack: std.ArrayListUnmanaged(ActiveDeclScope) = .empty,
 active_decl_values: std.AutoHashMapUnmanaged(Ident.Idx, usize) = .{},
 /// Change log backing active_decl_values so scope exit restores shadowed names.
 active_decl_value_entries: std.ArrayListUnmanaged(ActiveDeclValueEntry) = .empty,
+/// Value forward references keyed by the exact parser declaration they target.
+/// The declaration-specific canonicalization path is the only consumer that
+/// may adopt one of these placeholder patterns.
+value_forward_references: std.AutoHashMapUnmanaged(AST.DeclIndex.DeclIdx, Scope.ForwardReference) = .{},
 /// Active parser declaration scopes keyed by parser scope index.
 active_decl_scopes: std.AutoHashMapUnmanaged(AST.DeclIndex.ScopeIdx, ActiveDeclBinding) = .{},
 /// Top active declaration owner for each whole-scope type name.
@@ -581,6 +586,11 @@ pub fn deinit(
     self.decl_scope_stack.deinit(gpa);
     self.active_decl_values.deinit(gpa);
     self.active_decl_value_entries.deinit(gpa);
+    var value_fr_iter = self.value_forward_references.valueIterator();
+    while (value_fr_iter.next()) |forward_ref| {
+        forward_ref.reference_regions.deinit(gpa);
+    }
+    self.value_forward_references.deinit(gpa);
     self.active_decl_scopes.deinit(gpa);
     self.active_decl_types.deinit(gpa);
     self.active_decl_type_entries.deinit(gpa);
@@ -676,6 +686,7 @@ fn initInternal(
         .import_indices = std.AutoHashMapUnmanaged(Ident.Idx, Import.Idx){},
         .alias_cycle_references = std.AutoHashMapUnmanaged(AST.Statement.Idx, AST.Statement.Idx){},
         .alias_cycle_scopes = std.AutoHashMapUnmanaged(AST.DeclIndex.ScopeIdx, void){},
+        .value_forward_references = std.AutoHashMapUnmanaged(AST.DeclIndex.DeclIdx, Scope.ForwardReference){},
         .assoc_value_patterns = std.AutoHashMapUnmanaged(AST.DeclIndex.AssocValue, Pattern.Idx){},
         .assoc_forward_references = std.AutoHashMapUnmanaged(AST.DeclIndex.AssocValue, Scope.ForwardReference){},
         .assoc_forward_pattern_keys = std.AutoHashMapUnmanaged(Pattern.Idx, AST.DeclIndex.AssocValue){},
@@ -1193,11 +1204,12 @@ fn declScopeEnter(self: *Self, scope_idx: AST.DeclIndex.ScopeIdx) std.mem.Alloca
     var value_iter = parser_scope.value_decls.iterator();
     while (value_iter.next()) |entry| {
         const ident = entry.key_ptr.*;
-        if (!self.valueBucketIsForwardVisible(parser_scope, entry.value_ptr.*)) continue;
+        const decl_idx = self.forwardVisibleValueDecl(parser_scope, entry.value_ptr.*) orelse continue;
         const previous = self.active_decl_values.get(ident);
         const value_entry_idx = self.active_decl_value_entries.items.len;
         try self.active_decl_value_entries.append(self.env.gpa, .{
             .ident = ident,
+            .decl_idx = decl_idx,
             .binding = active_binding,
             .previous = previous,
         });
@@ -1281,22 +1293,33 @@ fn valueDeclKindResolvesAsValue(self: *const Self, kind: AST.DeclIndex.DeclKind)
     };
 }
 
-fn valueBucketHasImplementation(self: *const Self, bucket: AST.DeclIndex.NameBucket) bool {
-    var iter = bucket.iter();
-    while (iter.next()) |decl_idx| {
-        const decl = self.parse_ir.decl_index.decls.items[@intFromEnum(decl_idx)];
-        if (self.valueDeclKindResolvesAsValue(decl.kind)) return true;
-    }
-    return false;
-}
-
-fn valueBucketIsForwardVisible(
+fn forwardVisibleValueDecl(
     self: *const Self,
     parser_scope: AST.DeclIndex.Scope,
     bucket: AST.DeclIndex.NameBucket,
-) bool {
-    if (parser_scope.forward_policy != .whole_scope) return false;
-    return self.valueBucketHasImplementation(bucket);
+) ?AST.DeclIndex.DeclIdx {
+    if (parser_scope.forward_policy != .whole_scope) return null;
+
+    var annotation_only: ?AST.DeclIndex.DeclIdx = null;
+    var iter = bucket.iter();
+    while (iter.next()) |decl_idx| {
+        const decl = self.parse_ir.decl_index.decls.items[@intFromEnum(decl_idx)];
+        switch (decl.kind) {
+            .value, .var_decl => return decl_idx,
+            .value_anno, .var_anno => {
+                if (self.annoOnlyDeclsResolveAsValues() and decl.paired_decl == null and annotation_only == null) {
+                    annotation_only = decl_idx;
+                }
+            },
+            .type_alias,
+            .nominal,
+            .@"opaque",
+            .import,
+            .file_import,
+            => {},
+        }
+    }
+    return annotation_only;
 }
 
 fn activeDeclScopeDeclaresType(self: *Self, ident: Ident.Idx) ?ActiveDeclTypeEntry {
@@ -3835,7 +3858,7 @@ fn canonicalizeAssociatedItems(
                     const def_idx = if (adopted_pattern_idx) |adopted|
                         try self.createAnnotationDefWithPattern(adopted, qualified_idx, type_anno_idx, derived_method_kind, where_clauses, region)
                     else
-                        try self.createAnnotationDef(qualified_idx, type_anno_idx, derived_method_kind, where_clauses, region);
+                        try self.createAnnotationDef(qualified_idx, type_anno_idx, derived_method_kind, where_clauses, region, null);
 
                     if (owner_is_module_visible) {
                         try self.env.setExposedValueNodeIndexById(qualified_idx, @intFromEnum(def_idx));
@@ -4313,7 +4336,8 @@ pub fn canonicalizeFile(
                             } else {
                                 // Names don't match - create an anno-only def for this annotation
                                 // and let the next iteration handle the decl normally
-                                const def_idx = try self.createAnnotationDef(name_ident, type_anno_idx, null, where_clauses, region);
+                                const parser_decl_idx = self.parse_ir.decl_index.declForStatement(@intFromEnum(stmt_id));
+                                const def_idx = try self.createAnnotationDef(name_ident, type_anno_idx, null, where_clauses, region, parser_decl_idx);
                                 try self.env.store.addScratchDef(def_idx);
                                 try self.recordGlobalValueDef(def_idx);
 
@@ -4328,7 +4352,8 @@ pub fn canonicalizeFile(
                         else => {
                             // If the next non-malformed stmt is not a decl,
                             // create a Def with an e_anno_only body
-                            const def_idx = try self.createAnnotationDef(name_ident, type_anno_idx, null, where_clauses, region);
+                            const parser_decl_idx = self.parse_ir.decl_index.declForStatement(@intFromEnum(stmt_id));
+                            const def_idx = try self.createAnnotationDef(name_ident, type_anno_idx, null, where_clauses, region, parser_decl_idx);
                             try self.env.store.addScratchDef(def_idx);
                             try self.recordGlobalValueDef(def_idx);
 
@@ -4346,7 +4371,8 @@ pub fn canonicalizeFile(
                 // If we didn't find any next statement, create an anno-only def
                 // (This handles the case where the type annotation is the last statement in the file)
                 if (next_i >= ast_stmt_idxs.len) {
-                    const def_idx = try self.createAnnotationDef(name_ident, type_anno_idx, null, where_clauses, region);
+                    const parser_decl_idx = self.parse_ir.decl_index.declForStatement(@intFromEnum(stmt_id));
+                    const def_idx = try self.createAnnotationDef(name_ident, type_anno_idx, null, where_clauses, region, parser_decl_idx);
                     try self.env.store.addScratchDef(def_idx);
                     try self.recordGlobalValueDef(def_idx);
 
@@ -4633,11 +4659,18 @@ fn createAnnotationDef(
     derived_method_kind: ?CIR.DerivedMethodKind,
     where_clauses: ?WhereClause.Span,
     region: Region,
+    parser_decl_idx: ?AST.DeclIndex.DeclIdx,
 ) std.mem.Allocator.Error!CIR.Def.Idx {
     // If a placeholder pattern was previously registered for this ident in a
     // parent scope (e.g. by builtin hierarchical name registration), reuse it
     // instead of introducing a fresh one.
-    const pattern_idx = if (self.isPlaceholder(ident)) placeholder_check: {
+    const value_forward_pattern = if (parser_decl_idx) |decl_idx|
+        self.takeValueForwardReference(decl_idx, ident)
+    else
+        null;
+    const pattern_idx = if (value_forward_pattern) |forward_pattern|
+        forward_pattern
+    else if (self.isPlaceholder(ident)) placeholder_check: {
         // Use scopeLookup to search up the scope chain for the placeholder
         switch (self.scopeLookup(.ident, ident)) {
             .found => |existing_pattern| {
@@ -4658,7 +4691,36 @@ fn createAnnotationDef(
                 break :placeholder_check try self.env.addPattern(pattern, region);
             },
         }
-    } else create_new: {
+    } else try self.createAnnotationPattern(ident, region);
+
+    // Note: We don't update placeholders here. For associated items, the calling code
+    // (canonicalizeAssociatedItems) will update all three identifiers (qualified,
+    // type-qualified, unqualified). For top-level items, there are no placeholders to update.
+
+    const annotation_expr = try self.addAnnotationExpr(ident, derived_method_kind, region);
+
+    // Create the annotation structure
+    const annotation = CIR.Annotation{
+        .anno = type_anno_idx,
+        .where = where_clauses,
+    };
+    const annotation_idx = try self.env.addAnnotation(annotation, region);
+
+    // Create and return the def
+    return try self.env.addDef(.{
+        .pattern = pattern_idx,
+        .expr = annotation_expr,
+        .annotation = annotation_idx,
+        .kind = .let,
+    }, region);
+}
+
+fn createAnnotationPattern(
+    self: *Self,
+    ident: Ident.Idx,
+    region: Region,
+) std.mem.Allocator.Error!Pattern.Idx {
+    return create_new: {
         // If an earlier reference parked a forward-reference placeholder for
         // this ident, adopt that pattern instead of creating a new one — all
         // existing e_lookup_local nodes already point at it, so the def must
@@ -4704,27 +4766,6 @@ fn createAnnotationDef(
         }
         break :create_new new_pattern_idx;
     };
-
-    // Note: We don't update placeholders here. For associated items, the calling code
-    // (canonicalizeAssociatedItems) will update all three identifiers (qualified,
-    // type-qualified, unqualified). For top-level items, there are no placeholders to update.
-
-    const annotation_expr = try self.addAnnotationExpr(ident, derived_method_kind, region);
-
-    // Create the annotation structure
-    const annotation = CIR.Annotation{
-        .anno = type_anno_idx,
-        .where = where_clauses,
-    };
-    const annotation_idx = try self.env.addAnnotation(annotation, region);
-
-    // Create and return the def
-    return try self.env.addDef(.{
-        .pattern = pattern_idx,
-        .expr = annotation_expr,
-        .annotation = annotation_idx,
-        .kind = .let,
-    }, region);
 }
 
 /// Build an annotation-only or derived-method def reusing a pre-existing pattern (typically a
@@ -4781,8 +4822,15 @@ fn canonicalizeStmtDecl(
         }
     }
 
+    const parser_decl_idx = self.parse_ir.decl_index.declForStatement(@intFromEnum(ast_stmt_idx));
+
     // Canonicalize the decl (with the validated anno)
-    const def_idx = try self.canonicalizeDeclWithAnnotation(decl, mb_validated_anno, self.parserValueDeclIsLambda(ast_stmt_idx));
+    const def_idx = try self.canonicalizeDeclWithAnnotation(
+        decl,
+        parser_decl_idx,
+        mb_validated_anno,
+        self.parserValueDeclIsLambda(ast_stmt_idx),
+    );
     try self.env.store.addScratchDef(def_idx);
     try self.recordGlobalValueDef(def_idx);
 
@@ -6759,20 +6807,24 @@ fn introduceItemsUnaliased(
 fn canonicalizeDeclWithAnnotation(
     self: *Self,
     decl: AST.Statement.Decl,
+    parser_decl_idx: ?AST.DeclIndex.DeclIdx,
     mb_anno_idx: ?Annotation.Idx,
     is_lambda: bool,
 ) std.mem.Allocator.Error!CIR.Def.Idx {
     const trace = tracy.trace(@src());
     defer trace.end();
 
-    // For an ident pattern, reuse any forward-reference placeholder pattern
-    // that earlier statements already produced for this name; otherwise let
-    // `canonicalizePattern` introduce a fresh one. `canonicalizePattern`
-    // itself drains the matching `forward_references` entry and reuses the
-    // pattern, so a single source-order walk converges on one pattern shared
-    // by every reference to the name.
+    // Only this exact parser declaration may adopt its forward-reference
+    // placeholder. Nested patterns with the same spelling are separate binders.
     const reassign_targets_start = self.scratch_reassign_targets.top();
-    const pattern_idx = try self.canonicalizePatternOrMalformed(decl.pattern);
+    const forward_pattern = if (parser_decl_idx) |decl_idx|
+        self.adoptValueForwardReference(decl_idx, decl.pattern)
+    else
+        null;
+    const pattern_idx = if (forward_pattern) |pattern|
+        pattern
+    else
+        try self.canonicalizePatternOrMalformed(decl.pattern);
     if (self.currentScopeIdx() == 0) {
         try self.markBoundPatternsGloballyResolvable(pattern_idx);
     }
@@ -7510,7 +7562,7 @@ fn canonicalizeUnqualifiedIdentExpr(
             // the name resolves ONLY to the item being defined, that is a
             // self-referential definition.
             var skipped_defining_item = false;
-            const active_decl_scope = blk: {
+            const active_decl_entry = blk: {
                 var maybe_entry_idx = self.active_decl_values.get(ident);
                 while (maybe_entry_idx) |entry_idx| {
                     const entry = self.active_decl_value_entries.items[entry_idx];
@@ -7519,7 +7571,7 @@ fn canonicalizeUnqualifiedIdentExpr(
                         maybe_entry_idx = entry.previous;
                         continue;
                     }
-                    break :blk entry.binding;
+                    break :blk entry;
                 }
                 break :blk null;
             } orelse {
@@ -7535,6 +7587,7 @@ fn canonicalizeUnqualifiedIdentExpr(
                 } });
             };
 
+            const active_decl_scope = active_decl_entry.binding;
             const parser_decl_scope = self.parse_ir.decl_index.scopes.items[@intFromEnum(active_decl_scope.parser_scope)];
             if (parser_decl_scope.kind == .associated) {
                 if (parser_decl_scope.owner_type_path) |owner_path| {
@@ -7565,7 +7618,7 @@ fn canonicalizeUnqualifiedIdentExpr(
             std.debug.assert(owner_scope_idx < self.scopes.items.len);
 
             const owner_scope = &self.scopes.items[owner_scope_idx];
-            const gop = try owner_scope.forward_references.getOrPut(self.env.gpa, ident);
+            const gop = try self.value_forward_references.getOrPut(self.env.gpa, active_decl_entry.decl_idx);
             const ref_pattern_idx = if (gop.found_existing) blk: {
                 try gop.value_ptr.reference_regions.append(self.env.gpa, region);
                 break :blk gop.value_ptr.pattern_idx;
@@ -8558,7 +8611,7 @@ fn createBlockAnnoOnlyStatement(
     where_clauses: ?WhereClause.Span,
     region: Region,
 ) std.mem.Allocator.Error!CanonicalizedStatement {
-    const def_idx = try self.createAnnotationDef(ident, type_anno_idx, null, where_clauses, region);
+    const def_idx = try self.createAnnotationDef(ident, type_anno_idx, null, where_clauses, region, null);
     try self.env.store.addScratchDef(def_idx);
 
     const def = self.env.store.getDef(def_idx);
@@ -14592,6 +14645,39 @@ fn canonicalizePatternOrMalformed(
     }
 }
 
+fn adoptValueForwardReference(
+    self: *Self,
+    parser_decl_idx: AST.DeclIndex.DeclIdx,
+    ast_pattern_idx: AST.Pattern.Idx,
+) ?Pattern.Idx {
+    if (!self.value_forward_references.contains(parser_decl_idx)) return null;
+
+    const parser_decl = self.parse_ir.decl_index.decls.items[@intFromEnum(parser_decl_idx)];
+    std.debug.assert(parser_decl.pattern == @intFromEnum(ast_pattern_idx));
+    const ast_pattern = self.parse_ir.store.getPattern(ast_pattern_idx);
+    std.debug.assert(ast_pattern == .ident);
+    const ident = self.parse_ir.tokens.resolveIdentifier(ast_pattern.ident.ident_tok) orelse unreachable;
+    return self.takeValueForwardReference(parser_decl_idx, ident);
+}
+
+fn takeValueForwardReference(
+    self: *Self,
+    parser_decl_idx: AST.DeclIndex.DeclIdx,
+    ident: Ident.Idx,
+) ?Pattern.Idx {
+    const kv = self.value_forward_references.fetchRemove(parser_decl_idx) orelse return null;
+    var reference_regions = kv.value.reference_regions;
+    reference_regions.deinit(self.env.gpa);
+
+    const parser_decl = self.parse_ir.decl_index.decls.items[@intFromEnum(parser_decl_idx)];
+    std.debug.assert(parser_decl.name_ident != null and parser_decl.name_ident.?.eql(ident));
+
+    const active_owner = self.active_decl_scopes.get(parser_decl.scope) orelse unreachable;
+    const owner_scope = &self.scopes.items[active_owner.canonical_scope];
+    std.debug.assert(owner_scope.idents.get(ident) == kv.value.pattern_idx);
+    return kv.value.pattern_idx;
+}
+
 fn finishTagPattern(
     self: *Self,
     qualifiers: Token.Span,
@@ -16376,35 +16462,6 @@ pub fn canonicalizePattern(
                         // Placeholders are tracked in the placeholder_idents hash map
                         const current_scope = &self.scopes.items[self.scopes.items.len - 1];
                         const placeholder_exists = self.isPlaceholder(ident_idx);
-
-                        // Forward references for top-level / associated-block names are
-                        // parked in the module scope's `forward_references`. Drain a
-                        // matching entry from any ancestor scope (current_scope first,
-                        // then walking outward) so this definition reuses the placeholder
-                        // pattern earlier references already pointed at.
-                        var forward_reference_pattern_idx: ?Pattern.Idx = null;
-                        {
-                            var s_idx = self.scopes.items.len;
-                            while (s_idx > 0) {
-                                s_idx -= 1;
-                                const scope_ptr = &self.scopes.items[s_idx];
-                                if (scope_ptr.forward_references.fetchRemove(ident_idx)) |kv| {
-                                    var mut_regions = kv.value.reference_regions;
-                                    mut_regions.deinit(self.env.gpa);
-                                    const current_scope_idx = self.scopes.items.len - 1;
-                                    if (s_idx != current_scope_idx) {
-                                        _ = scope_ptr.idents.remove(ident_idx);
-                                    }
-                                    try self.scopes.items[current_scope_idx].idents.put(self.env.gpa, ident_idx, kv.value.pattern_idx);
-                                    forward_reference_pattern_idx = kv.value.pattern_idx;
-                                    break;
-                                }
-                            }
-                        }
-                        if (forward_reference_pattern_idx) |pattern_idx| {
-                            last_pattern = pattern_idx;
-                            continue :patternkernel_loop .dispatch;
-                        }
 
                         // Create a Pattern node for our identifier
                         const pattern_idx = try self.env.addPattern(Pattern{ .assign = .{
@@ -19388,11 +19445,10 @@ pub fn scopeIntroduceInternal(
         return Scope.IntroduceResult{ .top_level_var_error = {} };
     }
 
-    // Forward-reference draining is the caller's responsibility — see
-    // `canonicalizePattern` and `createAnnotationDef`, which fetch the
-    // forward-reference pattern and use it as the def's pattern so existing
-    // e_lookup_local nodes stay consistent. By the time we get here, any
-    // such drain has already happened, so we don't try again.
+    // Forward-reference adoption is declaration-specific. Ordinary value
+    // declarations use `adoptValueForwardReference`; associated declarations
+    // use their structural owner key. Generic scope introduction must not infer
+    // ownership from identifier text.
 
     // Check for existing identifier in any scope level for shadowing detection
     if (self.scopeContains(item_kind, ident_idx)) |existing| {

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -748,6 +748,7 @@ const echo_cases = [_]CliCase{
     .{ .id = 0, .suite = .echo, .name = "echo platform: all_syntax_test.roc prints expected output (dev backend)", .backend = .dev, .body = .{ .command = .{ .args = &.{"--opt=dev"}, .roc_file = "test/echo/all_syntax_test.roc", .stdout_exact = all_syntax_expected_stdout, .stderr_exact = all_syntax_expected_stderr } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: roc test all_syntax_test.roc passes", .body = .{ .command = .{ .args = &.{ "test", "--no-cache" }, .roc_file = "test/echo/all_syntax_test.roc", .contains = &.{.{ .stream = .stdout, .text = "passed" }} } } },
     .{ .id = 0, .suite = .echo, .name = "echo platform: statically dispatched, propagated, open error union does not crash (regression test #9588)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--no-cache"}, .roc_file = "test/echo/issue_9588.roc", .exit = .success, .not_contains = &.{ .{ .stream = .stderr, .text = "panic" }, .{ .stream = .stderr, .text = "invariant violated" } } } } },
+    .{ .id = 0, .suite = .echo, .name = "echo platform: forward helper reports nested binder shadowing without panic (issue 10327)", .backend = .interpreter, .body = .{ .command = .{ .args = &.{"--no-cache"}, .roc_file = "test/echo/issue_10327.roc", .exit = .failure, .contains = &.{.{ .stream = .stderr, .text = "DUPLICATE DEFINITION" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "local lookup referenced an unbound pattern binder" }, .{ .stream = .stderr, .text = "panic" } } } } },
 };
 
 // Glue suite cases

--- a/test/echo/issue_10327.roc
+++ b/test/echo/issue_10327.roc
@@ -1,0 +1,39 @@
+# Repro for https://github.com/roc-lang/roc/issues/10327.
+# This declaration order is significant. The nested `next` binder shadows the
+# later top-level declaration, so canonicalization must report that diagnostic
+# instead of corrupting the lookup identity and panicking in postcheck.
+Message : [AuthOk, Other]
+
+connect! : {} => Try(U64, _)
+connect! = |_|
+    message_loop!(
+        0,
+        |msg, state| match msg {
+            AuthOk => next(state)
+            _ => Ok(Done(99))
+        },
+    )
+
+loop! : state, (state => Try([Step(state), Done(done)], err)) => Try(done, err)
+loop! = |state, fn!| match fn!(state) {
+    Err(err) => Err(err)
+    Ok(Done(done)) => Ok(done)
+    Ok(Step(next)) => loop!(next, fn!)
+}
+
+message_loop! : state, (Message, state => Try([Done(done), Step(state)], _)) => Try(done, _)
+message_loop! = |init_state, step_fn!|
+    loop!(
+        init_state,
+        |state| match state {
+            _ => step_fn!(Other, state)
+        },
+    )
+
+next : a -> Try([Step(a), ..], _)
+next = |state| Ok(Step(state))
+
+main! = |_args| {
+    _client = connect!({})?
+    Ok({})
+}


### PR DESCRIPTION
Forward value lookups now key placeholders by their exact parser declaration identity, and only that declaration can adopt the placeholder. This prevents an unrelated nested binder with the same spelling from corrupting lookup identity, so the issue #10327 reproducer reports the expected duplicate-definition diagnostic instead of panicking in postcheck. Closes #10327.