### PR TITLE
Discard SpecConstr analysis-only lifted IR

### DIFF
--- a/src/postcheck/monotype_lifted/ast.zig
+++ b/src/postcheck/monotype_lifted/ast.zig
@@ -425,6 +425,35 @@ pub const Program = struct {
     /// Ambient checked source region recorded by `addExpr`/`addStmt`.
     current_region: base.Region,
 
+    /// Append-only section lengths at the start of a SpecConstr analysis walk.
+    ///
+    /// Value-aware pattern discovery evaluates expressions symbolically through
+    /// the same cloner used by the mutating rewrite. The cloner may need
+    /// temporary expression, pattern, statement, and local ids, but those ids
+    /// are analysis work storage and must not become durable lifted IR.
+    pub const SpecConstrAnalysisMark = struct {
+        fns: usize,
+        exprs: usize,
+        pats: usize,
+        stmts: usize,
+        locals: usize,
+        expr_ids: usize,
+        pat_ids: usize,
+        typed_locals: usize,
+        stmt_ids: usize,
+        field_exprs: usize,
+        capture_operands: usize,
+        record_destructs: usize,
+        str_pattern_steps: usize,
+        branches: usize,
+        if_branches: usize,
+        expr_locs: usize,
+        expr_regions: usize,
+        stmt_locs: usize,
+        stmt_regions: usize,
+        local_names: usize,
+    };
+
     pub fn init(
         allocator: std.mem.Allocator,
         name_store: names.NameStore,
@@ -582,6 +611,95 @@ pub const Program = struct {
             .stmt_regions = self.stmt_regions.unsafeRawItemsForView(),
             .local_names = self.local_names.unsafeRawItemsForView(),
         };
+    }
+
+    pub fn markSpecConstrAnalysis(self: *const Program) SpecConstrAnalysisMark {
+        return .{
+            .fns = self.fns.len(),
+            .exprs = self.exprs.len(),
+            .pats = self.pats.len(),
+            .stmts = self.stmts.len(),
+            .locals = self.locals.len(),
+            .expr_ids = self.expr_ids.len(),
+            .pat_ids = self.pat_ids.len(),
+            .typed_locals = self.typed_locals.len(),
+            .stmt_ids = self.stmt_ids.len(),
+            .field_exprs = self.field_exprs.len(),
+            .capture_operands = self.capture_operands.len(),
+            .record_destructs = self.record_destructs.len(),
+            .str_pattern_steps = self.str_pattern_steps.len(),
+            .branches = self.branches.len(),
+            .if_branches = self.if_branches.len(),
+            .expr_locs = self.expr_locs.len(),
+            .expr_regions = self.expr_regions.len(),
+            .stmt_locs = self.stmt_locs.len(),
+            .stmt_regions = self.stmt_regions.len(),
+            .local_names = self.local_names.len(),
+        };
+    }
+
+    /// Discard SpecConstr analysis-only appends while retaining their capacity
+    /// for the next analysis walk.
+    pub fn rewindSpecConstrAnalysis(self: *Program, mark: SpecConstrAnalysisMark) void {
+        self.assertSpecConstrAnalysisMark(mark);
+        self.freeAnalysisLocalNames(mark.local_names);
+        self.exprs.restoreLen(mark.exprs);
+        self.pats.restoreLen(mark.pats);
+        self.stmts.restoreLen(mark.stmts);
+        self.locals.restoreLen(mark.locals);
+        self.expr_ids.restoreLen(mark.expr_ids);
+        self.pat_ids.restoreLen(mark.pat_ids);
+        self.typed_locals.restoreLen(mark.typed_locals);
+        self.stmt_ids.restoreLen(mark.stmt_ids);
+        self.field_exprs.restoreLen(mark.field_exprs);
+        self.capture_operands.restoreLen(mark.capture_operands);
+        self.record_destructs.restoreLen(mark.record_destructs);
+        self.str_pattern_steps.restoreLen(mark.str_pattern_steps);
+        self.branches.restoreLen(mark.branches);
+        self.if_branches.restoreLen(mark.if_branches);
+        self.expr_locs.restoreLen(mark.expr_locs);
+        self.expr_regions.restoreLen(mark.expr_regions);
+        self.stmt_locs.restoreLen(mark.stmt_locs);
+        self.stmt_regions.restoreLen(mark.stmt_regions);
+        self.local_names.restoreLen(mark.local_names);
+    }
+
+    /// Finish a SpecConstr analysis transaction and release capacity used only
+    /// by its temporary nodes.
+    pub fn finishSpecConstrAnalysis(self: *Program, mark: SpecConstrAnalysisMark) void {
+        self.assertSpecConstrAnalysisMark(mark);
+        self.freeAnalysisLocalNames(mark.local_names);
+        self.exprs.shrinkAndFree(self.allocator, mark.exprs);
+        self.pats.shrinkAndFree(self.allocator, mark.pats);
+        self.stmts.shrinkAndFree(self.allocator, mark.stmts);
+        self.locals.shrinkAndFree(self.allocator, mark.locals);
+        self.expr_ids.shrinkAndFree(self.allocator, mark.expr_ids);
+        self.pat_ids.shrinkAndFree(self.allocator, mark.pat_ids);
+        self.typed_locals.shrinkAndFree(self.allocator, mark.typed_locals);
+        self.stmt_ids.shrinkAndFree(self.allocator, mark.stmt_ids);
+        self.field_exprs.shrinkAndFree(self.allocator, mark.field_exprs);
+        self.capture_operands.shrinkAndFree(self.allocator, mark.capture_operands);
+        self.record_destructs.shrinkAndFree(self.allocator, mark.record_destructs);
+        self.str_pattern_steps.shrinkAndFree(self.allocator, mark.str_pattern_steps);
+        self.branches.shrinkAndFree(self.allocator, mark.branches);
+        self.if_branches.shrinkAndFree(self.allocator, mark.if_branches);
+        self.expr_locs.shrinkAndFree(self.allocator, mark.expr_locs);
+        self.expr_regions.shrinkAndFree(self.allocator, mark.expr_regions);
+        self.stmt_locs.shrinkAndFree(self.allocator, mark.stmt_locs);
+        self.stmt_regions.shrinkAndFree(self.allocator, mark.stmt_regions);
+        self.local_names.shrinkAndFree(self.allocator, mark.local_names);
+    }
+
+    fn assertSpecConstrAnalysisMark(self: *const Program, mark: SpecConstrAnalysisMark) void {
+        if (self.fns.len() < mark.fns) {
+            Common.invariant("SpecConstr analysis removed a durable lifted function");
+        }
+    }
+
+    fn freeAnalysisLocalNames(self: *Program, start: usize) void {
+        for (self.local_names.unsafeRawItemsForView()[start..]) |name| {
+            if (name.len > 0) self.allocator.free(name);
+        }
     }
 
     pub fn addFn(self: *Program, fn_: Fn) std.mem.Allocator.Error!FnId {

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -543,6 +543,12 @@ const Pass = struct {
     /// an already-rewritten worker.
     callable_sources: std.AutoHashMap(Ast.FnId, Ast.FnId),
     next_join_point: u32,
+
+    const AnalysisMark = struct {
+        program: Ast.Program.SpecConstrAnalysisMark,
+        next_symbol: u32,
+        next_join_point: u32,
+    };
     fn init(allocator: Allocator, program: *Ast.Program) Allocator.Error!Pass {
         var arena = std.heap.ArenaAllocator.init(allocator);
         errdefer arena.deinit();
@@ -648,6 +654,37 @@ const Pass = struct {
         const id: Ast.JoinPointId = @enumFromInt(self.next_join_point);
         self.next_join_point += 1;
         return id;
+    }
+
+    fn markAnalysis(self: *Pass) AnalysisMark {
+        return .{
+            .program = self.program.markSpecConstrAnalysis(),
+            .next_symbol = self.symbols.next,
+            .next_join_point = self.next_join_point,
+        };
+    }
+
+    fn rewindAnalysis(self: *Pass, mark: AnalysisMark) void {
+        self.program.rewindSpecConstrAnalysis(mark.program);
+        self.restoreAnalysisIds(mark);
+    }
+
+    fn restoreAnalysisIds(self: *Pass, mark: AnalysisMark) void {
+        var next_symbol = mark.next_symbol;
+        for (mark.program.fns..self.program.fnCount()) |index| {
+            const fn_ = self.program.getFnAt(index);
+            if (fn_.body != .hosted or fn_.args.len != 0) {
+                Common.invariant("SpecConstr analysis emitted a non-reservation function");
+            }
+            next_symbol = @max(next_symbol, @intFromEnum(fn_.symbol) + 1);
+        }
+        self.symbols.next = next_symbol;
+        self.next_join_point = mark.next_join_point;
+    }
+
+    fn finishAnalysis(self: *Pass, mark: AnalysisMark) void {
+        self.program.finishSpecConstrAnalysis(mark.program);
+        self.restoreAnalysisIds(mark);
     }
 
     fn deinit(self: *Pass) void {
@@ -840,6 +877,9 @@ const Pass = struct {
     /// argument is known when it is first named by a `let`. Walk with the
     /// cloner's substitution environment so those calls still reserve workers.
     fn collectValueAwareCallPatterns(self: *Pass, original_fn_count: usize) Common.LowerError!void {
+        const analysis_mark = self.markAnalysis();
+        defer self.finishAnalysis(analysis_mark);
+
         var index: usize = 0;
         while (index < original_fn_count) : (index += 1) {
             const fn_ = self.program.getFnAt(index);
@@ -854,6 +894,7 @@ const Pass = struct {
             cloner.allow_nonrecursive_value_patterns = self.shape_demand_fns[index];
             defer cloner.deinit();
             try cloner.collectCallPatternsInExpr(fn_id, body);
+            self.rewindAnalysis(analysis_mark);
         }
     }
 
@@ -1431,22 +1472,40 @@ const Pass = struct {
     /// their strict runtime construction behind.
     fn rewriteValueAwareCalls(self: *Pass) Common.LowerError!void {
         const fn_count = self.program.fnCount();
-        for (0..fn_count) |index| {
-            const fn_ = self.program.getFnAt(index);
-            const body = switch (fn_.body) {
-                .roc => |body| body,
-                .hosted => continue,
-            };
-            const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(index)));
-            var cloner = Cloner.initForRewrite(self);
-            cloner.value_aware_detect_only = true;
-            cloner.emit_callable_workers = false;
-            cloner.allow_nonrecursive_value_patterns = index < self.shape_demand_fns.len and self.shape_demand_fns[index];
-            defer cloner.deinit();
-            try cloner.rewriteCallsWithValuesInExpr(body);
-            if (cloner.value_aware_rewrite_changed) {
-                try self.cloneFnBodyInPlace(fn_id, body);
+        const RewriteRequest = struct {
+            fn_id: Ast.FnId,
+            body: Ast.ExprId,
+        };
+        var requests = std.ArrayList(RewriteRequest).empty;
+        defer requests.deinit(self.allocator);
+
+        {
+            const analysis_mark = self.markAnalysis();
+            defer self.finishAnalysis(analysis_mark);
+
+            for (0..fn_count) |index| {
+                const fn_ = self.program.getFnAt(index);
+                const body = switch (fn_.body) {
+                    .roc => |body| body,
+                    .hosted => continue,
+                };
+                const fn_id: Ast.FnId = @enumFromInt(@as(u32, @intCast(index)));
+                const changed = changed: {
+                    var cloner = Cloner.initForRewrite(self);
+                    defer cloner.deinit();
+                    cloner.value_aware_detect_only = true;
+                    cloner.emit_callable_workers = false;
+                    cloner.allow_nonrecursive_value_patterns = index < self.shape_demand_fns.len and self.shape_demand_fns[index];
+                    try cloner.rewriteCallsWithValuesInExpr(body);
+                    break :changed cloner.value_aware_rewrite_changed;
+                };
+                if (changed) try requests.append(self.allocator, .{ .fn_id = fn_id, .body = body });
+                self.rewindAnalysis(analysis_mark);
             }
+        }
+
+        for (requests.items) |request| {
+            try self.cloneFnBodyInPlace(request.fn_id, request.body);
         }
     }
 
@@ -10083,6 +10142,50 @@ test "call-pattern scans direct call and function reference capture operands" {
     try std.testing.expect(exprContainsReturn(&program, call_proc));
     try std.testing.expectEqual(@as(usize, 1), localUseCountInExpr(&program, local, call_proc));
     try std.testing.expect(localUseBeforeEffect(&program, local, call_proc));
+}
+
+test "issue 10313 value-aware analysis does not append lifted IR" {
+    const allocator = std.testing.allocator;
+    var program = emptyLiftedProgramForTest(allocator);
+    defer program.deinit();
+
+    const unit_ty = try program.types.add(.zst);
+    const arg_local = try program.addLocal(@enumFromInt(1), unit_ty);
+    const bound_local = try program.addLocal(@enumFromInt(2), unit_ty);
+    const arg_ref = try program.addExpr(.{ .ty = unit_ty, .data = .{ .local = arg_local } });
+    const bind_pat = try program.addPat(.{ .ty = unit_ty, .data = .{ .bind = bound_local } });
+    const unit_expr = try program.addExpr(.{ .ty = unit_ty, .data = .unit });
+    const body = try program.addExpr(.{ .ty = unit_ty, .data = .{ .let_ = .{
+        .bind = bind_pat,
+        .value = arg_ref,
+        .rest = unit_expr,
+    } } });
+    _ = try program.addFn(.{
+        .symbol = @enumFromInt(3),
+        .args = try program.addTypedLocalSpan(&.{.{ .local = arg_local, .ty = unit_ty }}),
+        .captures = Ast.Span(Ast.TypedLocal).empty(),
+        .body = .{ .roc = body },
+        .ret = unit_ty,
+    });
+
+    var pass = try Pass.init(allocator, &program);
+    defer pass.deinit();
+
+    const before_collect = program.markSpecConstrAnalysis();
+    const symbol_before_collect = pass.symbols.next;
+    const join_before_collect = pass.next_join_point;
+    try pass.collectValueAwareCallPatterns(1);
+    try std.testing.expectEqualDeep(before_collect, program.markSpecConstrAnalysis());
+    try std.testing.expectEqual(symbol_before_collect, pass.symbols.next);
+    try std.testing.expectEqual(join_before_collect, pass.next_join_point);
+
+    const before_rewrite = program.markSpecConstrAnalysis();
+    const symbol_before_rewrite = pass.symbols.next;
+    const join_before_rewrite = pass.next_join_point;
+    try pass.rewriteValueAwareCalls();
+    try std.testing.expectEqualDeep(before_rewrite, program.markSpecConstrAnalysis());
+    try std.testing.expectEqual(symbol_before_rewrite, pass.symbols.next);
+    try std.testing.expectEqual(join_before_rewrite, pass.next_join_point);
 }
 
 test "issue 10168 SpecConstr clones every capture when nested cloning grows the capture store" {


### PR DESCRIPTION
## Summary

- give value-aware SpecConstr analysis an explicit scratch transaction over append-only lifted IR storage
- rewind temporary expressions, patterns, statements, locals, spans, and source metadata after every analyzed function
- separate value-aware detection from production body cloning, while preserving explicit hosted specialization reservations
- add a regression that pins both analysis passes to the no-durable-IR-growth invariant

Closes #10313.

## Root cause

The value-aware SpecConstr collectors reuse the production `Cloner` for symbolic evaluation. That cloner appends materialized intermediate nodes to `Ast.Program`. The analysis passes never referenced those nodes afterward, but they also never removed them.

On the pinned Weaver repro, the lifted program grew during analysis from 6,966 expressions to millions of unreachable expressions. Lambda Mono then assigned types to every stored node, including the dead analysis output, expanding to roughly 51 million type variables and causing the observed multi-gigabyte peak. This was before backend code generation and was unrelated to reference counting.

The transaction keeps the explicit specialization data discovered by analysis, including reserved hosted worker ids, but removes storage owned only by the symbolic walk before any later compiler stage can consume it.

## Measurement

Using compiler revision `2988994a` with this change cherry-picked and Weaver revision `56452ba` with the recursive helper from #10313:

| Build | Peak RSS | Wall time |
| --- | ---: | ---: |
| Before | 8,371,568 KiB | 9.4 s |
| After | 882,628 KiB | 5.4 s |

Command:

```sh
/usr/bin/time -v roc build examples/basic.roc --output=basic-fixed --no-cache
```

The recursive version is back in the same memory range as the fold-based baseline.

## Tests

- `zig build run-test-zig-module-postcheck`
- `zig build run-test-zig-lir-inline`
- exact Weaver reproduction above
- `zig build run-check-snapshots --summary all --color off`
- `zig build minici` — 73/73 phases passed

## Snapshot note

The snapshot check on current `main`, including a run with fresh local and global Zig caches, regenerated one stale constraint variable id in `nominal_destructure_record_decl.md` from 225 to 228. That generated one-line update is isolated in its own commit.