### PR TITLE
Add `List.clear`

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4175,6 +4175,15 @@ Builtin :: [].{
 			List.sublist(list, { len: n, start: 0 })
 		}
 
+		## Removes every element while preserving the current capacity.
+		## ```roc
+		## expect [1.I64, 2, 3].clear() == []
+		## ```
+		clear : List(a) -> List(a)
+		clear = |list| {
+			List.take_first(list, 0)
+		}
+
 		## Returns the given number of elements from the end of the list.
 		## ```roc
 		## expect [1, 2, 3, 4, 5, 6, 7, 8].take_last(4) == [5, 6, 7, 8]

--- a/test/snapshots/repl/list_clear.md
+++ b/test/snapshots/repl/list_clear.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=List.clear removes every element while preserving the current capacity
+type=repl
+~~~
+# SOURCE
+~~~roc
+» [1.I64, 2, 3, 4].clear()
+» original = ["keep this long heap-allocated string that will not fit inline", "and this other long heap-allocated string too"]
+» original.clear()
+» original
+~~~
+# OUTPUT
+[]
+---
+assigned `original`
+---
+[]
+---
+["keep this long heap-allocated string that will not fit inline", "and this other long heap-allocated string too"]
+# PROBLEMS
+NIL


### PR DESCRIPTION
Adds `List.clear` from #9596:

```roc
List.clear : List(a) -> List(a)
```

Removes every element while preserving the current capacity — the `List` counterpart to `Dict.clear`. It's pure Roc: `List.take_first(list, 0)`, which is exactly how `Dict.clear` empties its own entries internally, so the capacity-preserving behavior is the same (no new low-level op).

Naming (`clear` vs `emptied`) was settled on Zulip — it matches the existing `Dict.clear` and the near-universal convention across languages (Rust `Vec::clear`, Zig `clearRetainingCapacity`, C#/Java/Python/Go/…).

Tests: a doc-test plus a repl snapshot (clear a list, and a heap-allocated list re-checked afterward for immutability).
