### PR TITLE
Fix local run argv[0] source path

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -2338,7 +2338,7 @@ fn rocRunInstalled(ctx: *CliCtx, args: cli_args.RunArgs) CliMainError!void {
         );
         return error.InvalidArguments;
     }
-    const term = try runCompiledExecutable(ctx, entry.artifact_path, args.app_args);
+    const term = try runCompiledExecutable(ctx, entry.artifact_path, entry.artifact_path, args.app_args);
     try finishCompiledRun(ctx, entry.artifact_path, term, 0);
 }
 
@@ -2933,11 +2933,11 @@ fn rocRunSharedMemoryShim(ctx: *CliCtx, args: cli_args.RunArgs, arg0: []const u8
     } else if (comptime is_windows) {
         // Windows: Use handle inheritance approach
         std.log.debug("Using Windows handle inheritance approach", .{});
-        try runWithWindowsHandleInheritance(ctx, exe_path, shm_handle, args.app_args);
+        try runWithWindowsHandleInheritance(ctx, exe_path, args.path, shm_handle, args.app_args);
     } else {
         // POSIX: Use existing file descriptor inheritance approach
         std.log.debug("Using POSIX file descriptor inheritance approach", .{});
-        try runWithPosixFdInheritance(ctx, exe_path, shm_handle, args.app_args);
+        try runWithPosixFdInheritance(ctx, exe_path, args.path, shm_handle, args.app_args);
     }
     std.log.debug("Interpreter execution completed", .{});
 
@@ -2983,7 +2983,7 @@ fn rocRunBuildAndExec(ctx: *CliCtx, args: cli_args.RunArgs, arg0: []const u8) Cl
         .root_source_url = args.root_source_url,
     }, arg0);
 
-    const term = try runCompiledExecutable(ctx, exe_path, args.app_args);
+    const term = try runCompiledExecutable(ctx, exe_path, args.path, args.app_args);
 
     compile.CacheCleanup.deleteTempDir(ctx.io.std_io, temp_dir);
     cleanup_temp_dir = false;
@@ -3002,27 +3002,10 @@ fn compiledRunOutputFilename(ctx: *CliCtx, roc_path: []const u8) Allocator.Error
 fn runCompiledExecutable(
     ctx: *CliCtx,
     exe_path: []const u8,
+    argv0: []const u8,
     app_args: []const []const u8,
 ) (CliError || error{OutOfMemory})!std.process.Child.Term {
-    const argv = ctx.arena.alloc([]const u8, 1 + app_args.len) catch {
-        return error.OutOfMemory;
-    };
-    argv[0] = exe_path;
-    for (app_args, 0..) |arg, i| {
-        argv[1 + i] = arg;
-    }
-
-    var child = std.process.spawn(ctx.io.std_io, .{
-        .argv = argv,
-        .cwd = .inherit,
-        .stdout = .inherit,
-        .stderr = .inherit,
-    }) catch |err| {
-        return ctx.fail(.{ .child_process_spawn_failed = .{
-            .command = exe_path,
-            .err = err,
-        } });
-    };
+    var child = try spawnExecutableWithArgv0(ctx, exe_path, argv0, app_args);
 
     return child.wait(ctx.io.std_io) catch |err| {
         return ctx.fail(.{ .child_process_wait_failed = .{
@@ -3030,6 +3013,114 @@ fn runCompiledExecutable(
             .err = err,
         } });
     };
+}
+
+fn spawnExecutableWithArgv0(
+    ctx: *CliCtx,
+    exe_path: []const u8,
+    argv0: []const u8,
+    app_args: []const []const u8,
+) (CliError || Allocator.Error)!std.process.Child {
+    if (comptime is_windows) {
+        const exe_path_w = std.unicode.utf8ToUtf16LeAllocZ(ctx.arena, exe_path) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.InvalidUtf8 => return ctx.fail(.{ .child_process_spawn_failed = .{
+                .command = exe_path,
+                .err = err,
+            } }),
+        };
+
+        var cmd_builder = try std.array_list.Managed(u8).initCapacity(ctx.gpa, 256);
+        defer cmd_builder.deinit();
+        try appendWindowsQuotedArg(&cmd_builder, argv0);
+        for (app_args) |arg| {
+            try cmd_builder.append(' ');
+            try appendWindowsQuotedArg(&cmd_builder, arg);
+        }
+
+        const cmd_line_w = std.unicode.utf8ToUtf16LeAllocZ(ctx.arena, cmd_builder.items) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.InvalidUtf8 => return ctx.fail(.{ .child_process_spawn_failed = .{
+                .command = exe_path,
+                .err = err,
+            } }),
+        };
+
+        var startup_info = std.mem.zeroes(windows.STARTUPINFOW);
+        startup_info.cb = @sizeOf(windows.STARTUPINFOW);
+        var process_info = std.mem.zeroes(windows.PROCESS_INFORMATION);
+
+        if (windows.CreateProcessW(
+            exe_path_w.ptr,
+            cmd_line_w.ptr,
+            null,
+            null,
+            1,
+            0,
+            null,
+            null,
+            &startup_info,
+            &process_info,
+        ) == 0) {
+            return ctx.fail(.{ .child_process_spawn_failed = .{
+                .command = exe_path,
+                .err = error.ProcessCreationFailed,
+            } });
+        }
+
+        return .{
+            .id = process_info.hProcess,
+            .thread_handle = process_info.hThread,
+            .stdin = null,
+            .stdout = null,
+            .stderr = null,
+            .request_resource_usage_statistics = false,
+        };
+    } else {
+        const Posix = struct {
+            extern "c" fn posix_spawn(
+                pid: *std.c.pid_t,
+                path: [*:0]const u8,
+                actions: ?*const anyopaque,
+                attr: ?*const anyopaque,
+                argv: [*:null]const ?[*:0]const u8,
+                env: [*:null]const ?[*:0]const u8,
+            ) c_int;
+        };
+
+        const exe_path_z = try ctx.arena.dupeZ(u8, exe_path);
+        const argv = try ctx.arena.allocSentinel(?[*:0]const u8, 1 + app_args.len, null);
+        argv[0] = (try ctx.arena.dupeZ(u8, argv0)).ptr;
+        for (app_args, 0..) |arg, i| {
+            argv[1 + i] = (try ctx.arena.dupeZ(u8, arg)).ptr;
+        }
+
+        var pid: std.c.pid_t = undefined;
+        const spawn_result = Posix.posix_spawn(
+            &pid,
+            exe_path_z.ptr,
+            null,
+            null,
+            argv.ptr,
+            @ptrCast(std.c.environ),
+        );
+        if (spawn_result != 0) {
+            std.log.err("posix_spawn failed with error code: {}", .{spawn_result});
+            return ctx.fail(.{ .child_process_spawn_failed = .{
+                .command = exe_path,
+                .err = error.ProcessCreationFailed,
+            } });
+        }
+
+        return .{
+            .id = pid,
+            .thread_handle = {},
+            .stdin = null,
+            .stdout = null,
+            .stderr = null,
+            .request_resource_usage_statistics = false,
+        };
+    }
 }
 
 const NativeRunTermination = union(enum) {
@@ -3465,9 +3556,9 @@ fn rocRunDefaultAppSharedMemoryShim(ctx: *CliCtx, args: cli_args.RunArgs, origin
     defer closeSharedMemoryHandle(shm_handle);
 
     if (comptime is_windows) {
-        try runWithWindowsHandleInheritance(ctx, exe_path, shm_handle, args.app_args);
+        try runWithWindowsHandleInheritance(ctx, exe_path, args.path, shm_handle, args.app_args);
     } else {
-        try runWithPosixFdInheritance(ctx, exe_path, shm_handle, args.app_args);
+        try runWithPosixFdInheritance(ctx, exe_path, args.path, shm_handle, args.app_args);
     }
     cleanup_temp_dir = false;
 
@@ -3511,7 +3602,13 @@ fn appendWindowsQuotedArg(cmd_builder: *std.array_list.Managed(u8), arg: []const
 }
 
 /// Run child process using Windows handle inheritance (idiomatic Windows approach)
-fn runWithWindowsHandleInheritance(ctx: *CliCtx, exe_path: []const u8, shm_handle: SharedMemoryHandle, app_args: []const []const u8) (CliError || error{OutOfMemory})!void {
+fn runWithWindowsHandleInheritance(
+    ctx: *CliCtx,
+    exe_path: []const u8,
+    source_path: []const u8,
+    shm_handle: SharedMemoryHandle,
+    app_args: []const []const u8,
+) (CliError || error{OutOfMemory})!void {
     // Make the shared memory handle inheritable
     if (windows.SetHandleInformation(@ptrCast(shm_handle.fd), windows.HANDLE_FLAG_INHERIT, windows.HANDLE_FLAG_INHERIT) == 0) {
         return ctx.fail(.{ .shared_memory_failed = .{
@@ -3565,7 +3662,7 @@ fn runWithWindowsHandleInheritance(ctx: *CliCtx, exe_path: []const u8, shm_handl
         return error.OutOfMemory;
     };
     defer cmd_builder.deinit();
-    try cmd_builder.print("\"{s}\"", .{exe_path});
+    try appendWindowsQuotedArg(&cmd_builder, source_path);
     for (app_args) |arg| {
         try cmd_builder.append(' ');
         try appendWindowsQuotedArg(&cmd_builder, arg);
@@ -3676,7 +3773,13 @@ fn runWithWindowsHandleInheritance(ctx: *CliCtx, exe_path: []const u8, shm_handl
 
 /// Run child process using POSIX file descriptor inheritance (existing approach for Unix)
 /// The exe_path should already be in a unique temp directory created by createUniqueTempDir.
-fn runWithPosixFdInheritance(ctx: *CliCtx, exe_path: []const u8, shm_handle: SharedMemoryHandle, app_args: []const []const u8) (CliError || error{OutOfMemory})!void {
+fn runWithPosixFdInheritance(
+    ctx: *CliCtx,
+    exe_path: []const u8,
+    source_path: []const u8,
+    shm_handle: SharedMemoryHandle,
+    app_args: []const []const u8,
+) (CliError || error{OutOfMemory})!void {
     // Write the coordination file (.txt) next to the executable
     // The executable is already in a unique temp directory
     std.log.debug("Writing fd coordination file for: {s}", .{exe_path});
@@ -3727,28 +3830,9 @@ fn runWithPosixFdInheritance(ctx: *CliCtx, exe_path: []const u8, shm_handle: Sha
         std.log.debug("fd={} FD_CLOEXEC cleared successfully", .{shm_handle.fd});
     }
 
-    // Build argv slice using arena allocator (memory lives until arena is freed)
-    const argv = ctx.arena.alloc([]const u8, 1 + app_args.len) catch {
-        return error.OutOfMemory;
-    };
-    argv[0] = exe_path;
-    for (app_args, 0..) |arg, i| {
-        argv[1 + i] = arg;
-    }
-
     std.log.debug("Spawning child process: {s} with {} app args", .{ exe_path, app_args.len });
     std.log.debug("Child process inherits current working directory", .{});
-    var child = std.process.spawn(ctx.io.std_io, .{
-        .argv = argv,
-        .cwd = .inherit,
-        .stdout = .inherit,
-        .stderr = .inherit,
-    }) catch |err| {
-        return ctx.fail(.{ .child_process_spawn_failed = .{
-            .command = exe_path,
-            .err = err,
-        } });
-    };
+    var child = try spawnExecutableWithArgv0(ctx, exe_path, source_path, app_args);
     std.log.debug("Child process spawned successfully (PID: {})", .{child.id});
 
     // Wait for child to complete
@@ -3851,6 +3935,7 @@ fn makeSharedMemoryHandleInheritable(ctx: *CliCtx, shm_handle: SharedMemoryHandl
 fn spawnHotShimChild(
     ctx: *CliCtx,
     exe_path: []const u8,
+    source_path: []const u8,
     shm_handle: SharedMemoryHandle,
     app_args: []const []const u8,
 ) (CliError || Allocator.Error || std.Thread.SpawnError || std.process.SpawnError)!*HotShimChild {
@@ -3868,23 +3953,7 @@ fn spawnHotShimChild(
     };
     try makeSharedMemoryHandleInheritable(ctx, shm_handle);
 
-    const argv = try ctx.arena.alloc([]const u8, 1 + app_args.len);
-    argv[0] = exe_path;
-    for (app_args, 0..) |arg, i| {
-        argv[1 + i] = arg;
-    }
-
-    const child = std.process.spawn(ctx.io.std_io, .{
-        .argv = argv,
-        .cwd = .inherit,
-        .stdout = .inherit,
-        .stderr = .inherit,
-    }) catch |err| {
-        return ctx.fail(.{ .child_process_spawn_failed = .{
-            .command = exe_path,
-            .err = err,
-        } });
-    };
+    const child = try spawnExecutableWithArgv0(ctx, exe_path, source_path, app_args);
 
     const watched = try ctx.gpa.create(HotShimChild);
     watched.* = .{
@@ -4528,7 +4597,7 @@ fn runHotReloadDevShim(
     var initial_input_set_needs_deinit = true;
     errdefer if (initial_input_set_needs_deinit) initial_input_set.deinit(ctx);
 
-    const host_child = try spawnHotShimChild(ctx, exe_path, hotReloadHostChildHandle(shm_handle), args.app_args);
+    const host_child = try spawnHotShimChild(ctx, exe_path, args.path, hotReloadHostChildHandle(shm_handle), args.app_args);
     var host_child_joined = false;
     errdefer {
         if (!host_child_joined) {

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -235,6 +235,7 @@ const FilePathMode = enum {
 const CommandCase = struct {
     args: []const []const u8,
     roc_file: ?[]const u8 = null,
+    app_args: []const []const u8 = &.{},
     file_path_mode: FilePathMode = .absolute,
     stdin: ?[]const u8 = null,
     exit: ExitExpectation = .success,
@@ -848,6 +849,11 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "roc --watch hot reloads dev shim code", .skip = .{ .windows = "generated hot-reload test platform uses POSIX host code" }, .body = .{ .custom = .hot_reload_dev_shim } },
     .{ .id = 0, .suite = .subcommands, .name = "roc --watch hot reloads app-provided Model through Box", .skip = .{ .windows = "generated hot-reload model test platform uses POSIX host code" }, .body = .{ .custom = .hot_reload_model_boundary } },
     .{ .id = 0, .suite = .subcommands, .name = "roc --watch runs headerless default app", .body = .{ .custom = .hot_reload_default_app } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10307: direct dev run passes source path as argv0", .backend = .dev, .body = .{ .command = .{ .args = &.{"--no-cache"}, .roc_file = "test/fx-open/argv0.roc", .app_args = &.{ "first", "second" }, .file_path_mode = .relative, .stdout_exact = "test/fx-open/argv0.roc|first|second\n" } } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10307: explicit run passes source path as argv0", .backend = .dev, .body = .{ .command = .{ .args = &.{ "run", "--opt=dev", "--no-cache" }, .roc_file = "test/fx-open/argv0.roc", .app_args = &.{ "first", "second" }, .file_path_mode = .relative, .stdout_exact = "test/fx-open/argv0.roc|first|second\n" } } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10307: interpreter run passes source path as argv0", .backend = .interpreter, .body = .{ .command = .{ .args = &.{ "--opt=interpreter", "--no-cache" }, .roc_file = "test/fx-open/argv0.roc", .app_args = &.{ "first", "second" }, .file_path_mode = .relative, .stdout_exact = "test/fx-open/argv0.roc|first|second\n" } } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10307: size run passes source path as argv0", .backend = .size, .body = .{ .command = .{ .args = &.{ "--opt=size", "--no-cache" }, .roc_file = "test/fx-open/argv0.roc", .app_args = &.{ "first", "second" }, .file_path_mode = .relative, .stdout_exact = "test/fx-open/argv0.roc|first|second\n" } } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10307: speed run passes source path as argv0", .backend = .speed, .body = .{ .command = .{ .args = &.{ "--opt=speed", "--no-cache" }, .roc_file = "test/fx-open/argv0.roc", .app_args = &.{ "first", "second" }, .file_path_mode = .relative, .stdout_exact = "test/fx-open/argv0.roc|first|second\n" } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build reports missing host symbols before linking", .body = .{ .command = .{ .args = &.{ "build", "--no-cache", "--target=x64musl" }, .roc_file = "test/missing-host-symbol/app.roc", .exit = .failure, .contains = &.{ .{ .stream = .stderr, .text = "MISSING HOST SYMBOLS" }, .{ .stream = .stderr, .text = "roc_host_vanish" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc check writes parse errors to stderr", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/has_parse_error.roc", .exit = .failure, .stderr_min_len = 1, .contains_any = &.{.{ .needles = &parse_error_needles }} } } },
     .{ .id = 0, .suite = .subcommands, .name = "direct roc rejects compiler-owned glue platform as hostless", .body = .{ .command = .{ .args = &.{"--no-cache"}, .roc_file = "src/glue/src/DebugGlue.roc", .exit = .failure, .stderr_min_len = 1, .contains = &.{ .{ .stream = .stderr, .text = "EMPTY TARGETS SECTION" }, .{ .stream = .stderr, .text = "roc glue" } }, .not_contains = &.{ .{ .stream = .stderr, .text = "EXPECTED PLATFORM STRING" }, .{ .stream = .stderr, .text = "PANIC" }, .{ .stream = .stderr, .text = "unreachable" } } } } },
@@ -1936,7 +1942,7 @@ fn runCommandCase(
     var run_timer = harness.Timer.start() catch return .{ .status = .infra_error, .phase = .run, .duration_ns = timer.read(), .message = "no clock" };
     const child_timeout_ms = childCommandTimeoutMs(&timer, timeout_ms) orelse
         return addPreservedWorkDirMessage(allocator, timeoutFailure(allocator, &timer, .run, "case timeout exhausted before command started"), env.dirs.work_dir);
-    const result = runRocInEnv(io, allocator, &env, command.args, command.roc_file, command.file_path_mode, command.stdin, child_timeout_ms) catch |err| {
+    const result = runRocInEnv(io, allocator, &env, command.args, command.roc_file, command.file_path_mode, command.app_args, command.stdin, child_timeout_ms) catch |err| {
         const msg = std.fmt.allocPrint(allocator, "run spawn error: {}", .{err}) catch "run spawn error";
         return addPreservedWorkDirMessage(allocator, .{
             .status = .infra_error,
@@ -1972,10 +1978,11 @@ fn runRocInEnv(
     args: []const []const u8,
     roc_file: ?[]const u8,
     file_path_mode: FilePathMode,
+    app_args: []const []const u8,
     stdin: ?[]const u8,
     timeout_ms: u64,
 ) CliRunnerError!std.process.RunResult {
-    const argv = try buildRocArgv(allocator, args, roc_file, file_path_mode);
+    const argv = try buildRocArgv(allocator, args, roc_file, file_path_mode, app_args);
     return util.runChildWithTimeout(io, allocator, argv, .{
         .cwd = project_root_path,
         .env_map = &env.env_map,
@@ -2008,6 +2015,7 @@ fn buildRocArgv(
     args: []const []const u8,
     roc_file: ?[]const u8,
     file_path_mode: FilePathMode,
+    app_args: []const []const u8,
 ) CliRunnerError![]const []const u8 {
     var argv: std.ArrayListUnmanaged([]const u8) = .empty;
     const is_glue_command = args.len > 0 and std.mem.eql(u8, args[0], "glue");
@@ -2028,6 +2036,10 @@ fn buildRocArgv(
             .relative => path,
         };
         try argv.append(allocator, resolved);
+    }
+    if (app_args.len > 0) {
+        try argv.append(allocator, "--");
+        try argv.appendSlice(allocator, app_args);
     }
     return try argv.toOwnedSlice(allocator);
 }
@@ -2312,7 +2324,7 @@ fn runRocAndCheck(
 ) ?TestResult {
     const child_timeout_ms = childCommandTimeoutMs(timer, timeout_ms) orelse
         return timeoutFailure(allocator, timer, .run, "case timeout exhausted before command started");
-    const result = runRocInEnv(io, allocator, env, command.args, command.roc_file, command.file_path_mode, command.stdin, child_timeout_ms) catch |err|
+    const result = runRocInEnv(io, allocator, env, command.args, command.roc_file, command.file_path_mode, command.app_args, command.stdin, child_timeout_ms) catch |err|
         return customInfraFailure(allocator, timer, "run spawn error: {}", .{err});
 
     if (checkCommandExpectation(allocator, result, command)) |message| {
@@ -4016,7 +4028,7 @@ fn runRocInCaseEnv(
     try case_env_map.put("ZIG_LOCAL_CACHE_DIR", zig_cache_dir);
     try util.putIsolatedTempEnv(&case_env_map, temp_dir);
 
-    const argv = try buildRocArgv(allocator, args, roc_file, .absolute);
+    const argv = try buildRocArgv(allocator, args, roc_file, .absolute, &.{});
     return util.runChildWithTimeout(io, allocator, argv, .{
         .cwd = project_root_path,
         .env_map = &case_env_map,
@@ -4655,7 +4667,7 @@ fn customListBuiltinInlined(
 
     const child_timeout_ms = childCommandTimeoutMs(timer, timeout_ms) orelse
         return timeoutFailure(allocator, timer, .run, "case timeout exhausted before roc build started");
-    const result = runRocInEnv(io, allocator, env, &.{ "build", "--opt=speed", "--no-cache", output_arg }, app_path, .absolute, null, child_timeout_ms) catch |err|
+    const result = runRocInEnv(io, allocator, env, &.{ "build", "--opt=speed", "--no-cache", output_arg }, app_path, .absolute, &.{}, null, child_timeout_ms) catch |err|
         return customInfraFailure(allocator, timer, "roc build spawn error: {}", .{err});
     if (checkCommandExpectation(allocator, result, .{ .args = &.{"build"}, .exit = .success })) |message| {
         return failureFromRun(allocator, timer, result, message);
@@ -4682,7 +4694,7 @@ fn customGeneratedModuleGraph(
             return customInfraFailure(allocator, timer, "failed to allocate cache path: {}", .{err});
         const child_timeout_ms = childCommandTimeoutMs(timer, timeout_ms) orelse
             return timeoutFailure(allocator, timer, .run, "case timeout exhausted before roc check started");
-        const result = runRocInEnv(io, allocator, env, &.{"check"}, main_path, .absolute, null, child_timeout_ms) catch |err|
+        const result = runRocInEnv(io, allocator, env, &.{"check"}, main_path, .absolute, &.{}, null, child_timeout_ms) catch |err|
             return customInfraFailure(allocator, timer, "roc check spawn error: {}", .{err});
         if (checkCommandExpectation(allocator, result, .{ .args = &.{"check"}, .exit = .success })) |message| {
             return failureFromRun(allocator, timer, result, message);
@@ -4866,7 +4878,7 @@ fn customFmtStdin(
         return customInfraFailure(allocator, timer, "failed to read stdin source: {}", .{err});
     const child_timeout_ms = childCommandTimeoutMs(timer, timeout_ms) orelse
         return timeoutFailure(allocator, timer, .run, "case timeout exhausted before roc fmt --stdin started");
-    const result = runRocInEnv(io, allocator, env, &.{ "fmt", "--stdin" }, null, .absolute, input, child_timeout_ms) catch |err|
+    const result = runRocInEnv(io, allocator, env, &.{ "fmt", "--stdin" }, null, .absolute, &.{}, input, child_timeout_ms) catch |err|
         return customInfraFailure(allocator, timer, "roc fmt --stdin spawn error: {}", .{err});
     if (checkCommandExpectation(allocator, result, .{ .args = &.{ "fmt", "--stdin" } })) |message| {
         return failureFromRun(allocator, timer, result, message);
@@ -5369,7 +5381,7 @@ fn captureRocRun(
 ) CapturedRocRun {
     const child_timeout_ms = childCommandTimeoutMs(timer, timeout_ms) orelse
         return .{ .failure = timeoutFailure(allocator, timer, .run, "case timeout exhausted before command started") };
-    const result = runRocInEnv(io, allocator, env, command.args, command.roc_file, command.file_path_mode, command.stdin, child_timeout_ms) catch |err|
+    const result = runRocInEnv(io, allocator, env, command.args, command.roc_file, command.file_path_mode, command.app_args, command.stdin, child_timeout_ms) catch |err|
         return .{ .failure = customInfraFailure(allocator, timer, "run spawn error: {}", .{err}) };
 
     if (checkCommandExpectation(allocator, result, command)) |message| {
@@ -6277,7 +6289,7 @@ fn customBuildIssue9435(io: std.Io, allocator: Allocator, env: *const CaseEnv, t
         return customInfraFailure(allocator, timer, "failed to allocate output arg: {}", .{err});
     const child_timeout_ms = childCommandTimeoutMs(timer, timeout_ms) orelse
         return timeoutFailure(allocator, timer, .run, "case timeout exhausted before roc build started");
-    const result = runRocInEnv(io, allocator, env, &.{ "build", "--opt=dev", "--no-cache", out_arg }, "test/hosted_nominal_return/repro.roc", .absolute, null, child_timeout_ms) catch |err|
+    const result = runRocInEnv(io, allocator, env, &.{ "build", "--opt=dev", "--no-cache", out_arg }, "test/hosted_nominal_return/repro.roc", .absolute, &.{}, null, child_timeout_ms) catch |err|
         return customInfraFailure(allocator, timer, "roc build spawn error: {}", .{err});
     if (result.term == .signal or (result.term == .exited and result.term.exited == 134)) {
         return failureFromRun(allocator, timer, result, "roc build panicked or aborted");

--- a/test/fx-open/argv0.roc
+++ b/test/fx-open/argv0.roc
@@ -1,0 +1,12 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+main! : List(Str) => Try({}, [Exit(I32), ..])
+main! = |args| {
+    match args {
+        [argv0, first, second] => Stdout.line!("${argv0}|${first}|${second}")
+        _ => Stdout.line!("unexpected args: ${Str.inspect(args)}")
+    }
+    Ok({})
+}


### PR DESCRIPTION
## Summary

- separate the executable path from `argv[0]` when launching compiled Roc apps on POSIX and Windows
- pass the original Roc source path through dev, interpreter, size, speed, shared-memory, and hot-reload launches while preserving installed-app and built-executable behavior
- extend the CLI test harness with application arguments and add issue #10307 regression coverage for direct and explicit runs across every optimization mode

## Testing

- `zig build minici` — 73/73 phases passed
- focused issue #10307 CLI suite — 5/5 cases passed
- full CLI subcommand suite — 470 passed, 18 skipped, 0 failed
- manual built-executable control confirmed standalone binaries still receive their executable path as `argv[0]`

Fixes #10307
