### PR TITLE
Add `List.prepend_if_ok`

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3572,6 +3572,16 @@ Builtin :: [].{
 		append_if_ok : List(a), Try(a, err) -> List(a)
 		append_if_ok = |list, maybe_item| list_append_if_ok(list, maybe_item)
 
+		## Add the `Ok` payload to the beginning of a list, or leave the list unchanged
+		## if the value is `Err`.
+		## ```roc
+		## expect List.prepend_if_ok([2, 3], Ok(1)) == [1, 2, 3]
+		##
+		## expect List.prepend_if_ok([2, 3], Err(NotFound)) == [2, 3]
+		## ```
+		prepend_if_ok : List(a), Try(a, err) -> List(a)
+		prepend_if_ok = |list, maybe_item| list_prepend_if_ok(list, maybe_item)
+
 		## Add a single element to the beginning of a list.
 		## ```roc
 		## expect [2, 3, 4].prepend(1) == [1, 2, 3, 4]
@@ -21335,6 +21345,13 @@ list_append_if_ok : List(a), Try(a, err) -> List(a)
 list_append_if_ok = |list, maybe_item|
 	match maybe_item {
 		Ok(item) => List.append(list, item)
+		Err(_) => list
+	}
+
+list_prepend_if_ok : List(a), Try(a, err) -> List(a)
+list_prepend_if_ok = |list, maybe_item|
+	match maybe_item {
+		Ok(item) => List.prepend(list, item)
 		Err(_) => list
 	}
 

--- a/test/snapshots/repl/list_prepend_if_ok.md
+++ b/test/snapshots/repl/list_prepend_if_ok.md
@@ -1,0 +1,25 @@
+# META
+~~~ini
+description=List.prepend_if_ok adds the Ok payload to the front of a list, or leaves it unchanged on Err
+type=repl
+~~~
+# SOURCE
+~~~roc
+» List.prepend_if_ok([2, 3], Ok(1))
+» List.prepend_if_ok([2, 3], Err(NotFound))
+» list = ["a string long enough to be heap-allocated instead of stored inline", "another string that is long enough to require a heap allocation"]
+» List.prepend_if_ok(list, Ok("one more heap-allocated string to exercise element refcounting"))
+» list
+~~~
+# OUTPUT
+[1.0, 2.0, 3.0]
+---
+[2.0, 3.0]
+---
+assigned `list`
+---
+["one more heap-allocated string to exercise element refcounting", "a string long enough to be heap-allocated instead of stored inline", "another string that is long enough to require a heap allocation"]
+---
+["a string long enough to be heap-allocated instead of stored inline", "another string that is long enough to require a heap allocation"]
+# PROBLEMS
+NIL


### PR DESCRIPTION
Adds `List.prepend_if_ok` from #9596 — the `prepend` counterpart to the existing `List.append_if_ok`:

```roc
List.prepend_if_ok : List(a), Try(a, err) -> List(a)
```

Adds the `Ok` payload to the front of the list, or leaves the list unchanged if `Err`. Pure Roc, mirroring `append_if_ok` (delegates to a private `list_prepend_if_ok` helper built on `List.prepend`) — no new low-level ops.

Tests: a doc-test plus a repl snapshot (`Ok` prepends / `Err` leaves it unchanged / a long heap-allocated list survives re-read after the op).
