### PR TITLE
Add `List.map3` and `List.map4`

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3782,6 +3782,54 @@ Builtin :: [].{
 			$result
 		}
 
+		## Apply a ternary function to triples of elements from three lists, returning a list of results.
+		## The result's length is the length of the shortest input list.
+		## ```
+		## expect [1, 2, 3].map3([10, 20, 30], [100, 200, 300], |a, b, c| a + b + c) == [111, 222, 333]
+		## expect [1, 2, 3, 4, 5].map3([10, 20], [100, 200, 300], |a, b, c| a + b + c) == [111, 222]
+		## ```
+		map3 : List(a), List(b), List(c), (a, b, c -> d) -> List(d)
+		map3 = |a_list, b_list, c_list, transform| {
+			var $result = []
+			var $index = 0
+			while ($index < a_list.len() and $index < b_list.len() and $index < c_list.len()) {
+				match (a_list.get($index), b_list.get($index), c_list.get($index)) {
+					(Ok(a), Ok(b), Ok(c)) => {
+						$result = $result.append(transform(a, b, c))
+					}
+					_ => {
+						break
+					}
+				}
+				$index = $index + 1
+			}
+			$result
+		}
+
+		## Apply a quaternary function to groups of elements from four lists, returning a list of results.
+		## The result's length is the length of the shortest input list.
+		## ```
+		## expect [1, 2, 3].map4([10, 20, 30], [100, 200, 300], [1000, 2000, 3000], |a, b, c, d| a + b + c + d) == [1111, 2222, 3333]
+		## expect [1, 2, 3, 4, 5].map4([10, 20], [100, 200, 300], [1000, 2000, 3000, 4000], |a, b, c, d| a + b + c + d) == [1111, 2222]
+		## ```
+		map4 : List(a), List(b), List(c), List(d), (a, b, c, d -> e) -> List(e)
+		map4 = |a_list, b_list, c_list, d_list, transform| {
+			var $result = []
+			var $index = 0
+			while ($index < a_list.len() and $index < b_list.len() and $index < c_list.len() and $index < d_list.len()) {
+				match (a_list.get($index), b_list.get($index), c_list.get($index), d_list.get($index)) {
+					(Ok(a), Ok(b), Ok(c), Ok(d)) => {
+						$result = $result.append(transform(a, b, c, d))
+					}
+					_ => {
+						break
+					}
+				}
+				$index = $index + 1
+			}
+			$result
+		}
+
 		## Run the given function on each element of a list, and return all the
 		## elements for which the function returned `Bool.True`.
 		## ```roc

--- a/test/snapshots/repl/list_map3.md
+++ b/test/snapshots/repl/list_map3.md
@@ -1,0 +1,25 @@
+# META
+~~~ini
+description=List.map3 applies a ternary function elementwise over three lists, clamping to the shortest
+type=repl
+~~~
+# SOURCE
+~~~roc
+» List.map3([1, 2, 3], [10, 20, 30], [100, 200, 300], |a, b, c| a + b + c)
+» List.map3([1, 2, 3, 4, 5], [10, 20], [100, 200, 300], |a, b, c| a + b + c)
+» xs = ["a string long enough to be heap-allocated instead of stored inline", "another string that is long enough to require a heap allocation"]
+» List.map3(xs, ["a second heap-allocated string used to exercise refcounting", "yet another heap-allocated string for the refcount test"], ["a third heap-allocated string in the map3 refcount check", "one final heap-allocated string to exercise element refcounting"], |a, b, c| Str.concat(a, Str.concat(b, c)))
+» xs
+~~~
+# OUTPUT
+[111.0, 222.0, 333.0]
+---
+[111.0, 222.0]
+---
+assigned `xs`
+---
+["a string long enough to be heap-allocated instead of stored inlinea second heap-allocated string used to exercise refcountinga third heap-allocated string in the map3 refcount check", "another string that is long enough to require a heap allocationyet another heap-allocated string for the refcount testone final heap-allocated string to exercise element refcounting"]
+---
+["a string long enough to be heap-allocated instead of stored inline", "another string that is long enough to require a heap allocation"]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/list_map4.md
+++ b/test/snapshots/repl/list_map4.md
@@ -1,0 +1,25 @@
+# META
+~~~ini
+description=List.map4 applies a quaternary function elementwise over four lists, clamping to the shortest
+type=repl
+~~~
+# SOURCE
+~~~roc
+» List.map4([1, 2, 3], [10, 20, 30], [100, 200, 300], [1000, 2000, 3000], |a, b, c, d| a + b + c + d)
+» List.map4([1, 2, 3, 4, 5], [10, 20], [100, 200, 300], [1000, 2000, 3000, 4000], |a, b, c, d| a + b + c + d)
+» xs = ["a string long enough to be heap-allocated instead of stored inline", "another string that is long enough to require a heap allocation"]
+» List.map4(xs, ["a second heap-allocated string used to exercise refcounting", "yet another heap-allocated string for the refcount test"], ["a third heap-allocated string in the map4 refcount check", "a fourth heap-allocated string in the map4 refcount check"], ["one final heap-allocated string to exercise element refcounting", "and one more heap-allocated string for the map4 refcount test"], |a, b, c, d| Str.concat(a, Str.concat(b, Str.concat(c, d))))
+» xs
+~~~
+# OUTPUT
+[1111.0, 2222.0, 3333.0]
+---
+[1111.0, 2222.0]
+---
+assigned `xs`
+---
+["a string long enough to be heap-allocated instead of stored inlinea second heap-allocated string used to exercise refcountinga third heap-allocated string in the map4 refcount checkone final heap-allocated string to exercise element refcounting", "another string that is long enough to require a heap allocationyet another heap-allocated string for the refcount testa fourth heap-allocated string in the map4 refcount checkand one more heap-allocated string for the map4 refcount test"]
+---
+["a string long enough to be heap-allocated instead of stored inline", "another string that is long enough to require a heap allocation"]
+# PROBLEMS
+NIL


### PR DESCRIPTION
Adds `List.map3` and `List.map4` from #9596, following on from `List.map2`:

```roc
List.map3 : List(a), List(b), List(c), (a, b, c -> d) -> List(d)
List.map4 : List(a), List(b), List(c), List(d), (a, b, c, d -> e) -> List(e)
```

Apply an n-ary function elementwise across 3 / 4 lists; the result length is the shortest input list. Pure Roc, mirroring `map2`'s existing idiom exactly (same `while` + `get`/`append`/`break` loop, no new low-level ops).

Tests: doc-tests plus a repl snapshot for each (basic / clamp-to-shortest / long heap-allocated strings survive re-read).
