### PR TITLE
Fix Tracy-enabled eval test runner build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3738,6 +3738,7 @@ pub fn build(b: *std.Build) void {
     {
         eval_test_exe.root_module.link_libcpp = true;
     }
+    add_tracy(b, roc_modules.build_options, eval_test_exe, target, true, flag_enable_tracy);
     // Build eval runner args: forward all --test-filter values as --filter args.
     const eval_run_args = if (test_filters.len > 0) blk: {
         var eval_args_list = std.ArrayList([]const u8).empty;


### PR DESCRIPTION
The Tracy-enabled nightly build now reaches instrumented code in the eval test runner, but that executable imported the Tracy module without linking the Tracy client implementation, leaving the emitted Tracy symbols unresolved. Route the runner through the existing Tracy setup so the final executable owns the required client definitions.