### PR TITLE
Add `List.insert`

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3694,6 +3694,36 @@ Builtin :: [].{
 			}
 		}
 
+		## Inserts an element at the given index, shifting later elements toward the end.
+		## An index equal to the length appends the element; a greater index is out of bounds.
+		## ```roc
+		## expect [1.I64, 2, 3].insert(1, 9) == Ok([1, 9, 2, 3])
+		##
+		## expect [1.I64, 2, 3].insert(5, 9) == Err(OutOfBounds)
+		## ```
+		insert : List(a), U64, a -> Try(List(a), [OutOfBounds, ..])
+		insert = |list, index, item| {
+			len = List.len(list)
+			if index > len {
+				Err(OutOfBounds)
+			} else {
+				# The two loops append exactly `index` then `len - index` elements plus
+				# the inserted one, so every unchecked append stays within `len + 1`.
+				var $result = List.with_capacity(len + 1)
+				var $i = 0
+				while $i < index {
+					$result = list_append_unsafe($result, list_get_unsafe(list, $i))
+					$i = $i + 1
+				}
+				$result = list_append_unsafe($result, item)
+				while $i < len {
+					$result = list_append_unsafe($result, list_get_unsafe(list, $i))
+					$i = $i + 1
+				}
+				Ok($result)
+			}
+		}
+
 		## Returns the reversed list.
 		## ```roc
 		## expect [1, 2, 3].rev() == [3, 2, 1]

--- a/test/snapshots/repl/list_insert.md
+++ b/test/snapshots/repl/list_insert.md
@@ -1,0 +1,31 @@
+# META
+~~~ini
+description=List.insert inserts an element at the given index
+type=repl
+~~~
+# SOURCE
+~~~roc
+» [1.I64, 2, 3, 4].insert(2, 9)
+» [1.I64, 2, 3].insert(0, 9)
+» [1.I64, 2, 3].insert(3, 9)
+» [1.I64, 2, 3].insert(5, 9)
+» items = ["a heap-allocated string long enough to avoid inline storage", "another heap string that will not be stored inline either"]
+» items.insert(1, "an inserted heap string that also needs a real allocation")
+» items
+~~~
+# OUTPUT
+Ok([1, 2, 9, 3, 4])
+---
+Ok([9, 1, 2, 3])
+---
+Ok([1, 2, 3, 9])
+---
+Err(OutOfBounds)
+---
+assigned `items`
+---
+Ok(["a heap-allocated string long enough to avoid inline storage", "an inserted heap string that also needs a real allocation", "another heap string that will not be stored inline either"])
+---
+["a heap-allocated string long enough to avoid inline storage", "another heap string that will not be stored inline either"]
+# PROBLEMS
+NIL


### PR DESCRIPTION
Adds `List.insert` from #9596:

```roc
List.insert : List(a), U64, a -> Try(List(a), [OutOfBounds, ..])
```

Inserts an element at the given index, shifting later elements toward the end. An index equal to the length appends; a greater index returns `Err(OutOfBounds)`. Pure Roc over existing primitives — `List.with_capacity(len + 1)` + `list_append_unsafe` (the known-size idiom, same as `join`), a single O(n) allocation. No new low-level ops.

Tests: a doc-test plus a repl snapshot (middle / front / append-at-end / out-of-bounds / long heap-allocated list survives re-read).
