### PR TITLE
Replace crashing round_to/floor_to/ceiling_to with _try variants

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -14032,215 +14032,215 @@ Builtin :: [].{
 			## ```
 			abs_diff : Dec, Dec -> Dec
 
-			## Round a [Dec] to the nearest [I8]. Halfway values round away from zero. Crashes if the rounded value is out of range.
+			## Round a [Dec] to the nearest [I8]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.round_to_i8(3.4) == 3
+			## expect Dec.round_to_i8_try(3.4) == Ok(3)
 			## ```
-			round_to_i8 : Dec -> I8
-			round_to_i8 = |self| out_of_range_or_crash(Dec.to_i8_try(dec_round_to_whole(self)))
+			round_to_i8_try : Dec -> Try(I8, [OutOfRange])
+			round_to_i8_try = |self| Dec.to_i8_try(dec_round_to_whole(self))
 
-			## Round a [Dec] to the nearest [I16]. Halfway values round away from zero. Crashes if the rounded value is out of range.
+			## Round a [Dec] to the nearest [I16]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.round_to_i16(3.4) == 3
+			## expect Dec.round_to_i16_try(3.4) == Ok(3)
 			## ```
-			round_to_i16 : Dec -> I16
-			round_to_i16 = |self| out_of_range_or_crash(Dec.to_i16_try(dec_round_to_whole(self)))
+			round_to_i16_try : Dec -> Try(I16, [OutOfRange])
+			round_to_i16_try = |self| Dec.to_i16_try(dec_round_to_whole(self))
 
-			## Round a [Dec] to the nearest [I32]. Halfway values round away from zero. Crashes if the rounded value is out of range.
+			## Round a [Dec] to the nearest [I32]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.round_to_i32(-3.6) == -4
+			## expect Dec.round_to_i32_try(-3.6) == Ok(-4)
 			## ```
-			round_to_i32 : Dec -> I32
-			round_to_i32 = |self| out_of_range_or_crash(Dec.to_i32_try(dec_round_to_whole(self)))
+			round_to_i32_try : Dec -> Try(I32, [OutOfRange])
+			round_to_i32_try = |self| Dec.to_i32_try(dec_round_to_whole(self))
 
-			## Round a [Dec] to the nearest [I64]. Halfway values round away from zero. Crashes if the rounded value is out of range.
+			## Round a [Dec] to the nearest [I64]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.round_to_i64(7.2) == 7
+			## expect Dec.round_to_i64_try(7.2) == Ok(7)
 			## ```
-			round_to_i64 : Dec -> I64
-			round_to_i64 = |self| out_of_range_or_crash(Dec.to_i64_try(dec_round_to_whole(self)))
+			round_to_i64_try : Dec -> Try(I64, [OutOfRange])
+			round_to_i64_try = |self| Dec.to_i64_try(dec_round_to_whole(self))
 
-			## Round a [Dec] to the nearest [I128]. Halfway values round away from zero. Crashes if the rounded value is out of range.
+			## Round a [Dec] to the nearest [I128]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.round_to_i128(7.2) == 7
+			## expect Dec.round_to_i128_try(7.2) == Ok(7)
 			## ```
-			round_to_i128 : Dec -> I128
-			round_to_i128 = |self| out_of_range_or_crash(Dec.to_i128_try(dec_round_to_whole(self)))
+			round_to_i128_try : Dec -> Try(I128, [OutOfRange])
+			round_to_i128_try = |self| Dec.to_i128_try(dec_round_to_whole(self))
 
-			## Round a [Dec] to the nearest [U8]. Halfway values round away from zero. Crashes if the rounded value is out of range.
+			## Round a [Dec] to the nearest [U8]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.round_to_u8(3.4) == 3
+			## expect Dec.round_to_u8_try(3.4) == Ok(3)
 			## ```
-			round_to_u8 : Dec -> U8
-			round_to_u8 = |self| out_of_range_or_crash(Dec.to_u8_try(dec_round_to_whole(self)))
+			round_to_u8_try : Dec -> Try(U8, [OutOfRange])
+			round_to_u8_try = |self| Dec.to_u8_try(dec_round_to_whole(self))
 
-			## Round a [Dec] to the nearest [U16]. Halfway values round away from zero. Crashes if the rounded value is out of range.
+			## Round a [Dec] to the nearest [U16]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.round_to_u16(3.4) == 3
+			## expect Dec.round_to_u16_try(3.4) == Ok(3)
 			## ```
-			round_to_u16 : Dec -> U16
-			round_to_u16 = |self| out_of_range_or_crash(Dec.to_u16_try(dec_round_to_whole(self)))
+			round_to_u16_try : Dec -> Try(U16, [OutOfRange])
+			round_to_u16_try = |self| Dec.to_u16_try(dec_round_to_whole(self))
 
-			## Round a [Dec] to the nearest [U32]. Halfway values round away from zero. Crashes if the rounded value is out of range.
+			## Round a [Dec] to the nearest [U32]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.round_to_u32(7.2) == 7
+			## expect Dec.round_to_u32_try(7.2) == Ok(7)
 			## ```
-			round_to_u32 : Dec -> U32
-			round_to_u32 = |self| out_of_range_or_crash(Dec.to_u32_try(dec_round_to_whole(self)))
+			round_to_u32_try : Dec -> Try(U32, [OutOfRange])
+			round_to_u32_try = |self| Dec.to_u32_try(dec_round_to_whole(self))
 
-			## Round a [Dec] to the nearest [U64]. Halfway values round away from zero. Crashes if the rounded value is out of range.
+			## Round a [Dec] to the nearest [U64]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.round_to_u64(7.2) == 7
+			## expect Dec.round_to_u64_try(7.2) == Ok(7)
 			## ```
-			round_to_u64 : Dec -> U64
-			round_to_u64 = |self| out_of_range_or_crash(Dec.to_u64_try(dec_round_to_whole(self)))
+			round_to_u64_try : Dec -> Try(U64, [OutOfRange])
+			round_to_u64_try = |self| Dec.to_u64_try(dec_round_to_whole(self))
 
-			## Round a [Dec] to the nearest [U128]. Halfway values round away from zero. Crashes if the rounded value is out of range.
+			## Round a [Dec] to the nearest [U128]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.round_to_u128(7.2) == 7
+			## expect Dec.round_to_u128_try(7.2) == Ok(7)
 			## ```
-			round_to_u128 : Dec -> U128
-			round_to_u128 = |self| out_of_range_or_crash(Dec.to_u128_try(dec_round_to_whole(self)))
+			round_to_u128_try : Dec -> Try(U128, [OutOfRange])
+			round_to_u128_try = |self| Dec.to_u128_try(dec_round_to_whole(self))
 
-			## Round a [Dec] down to an [I8]. Crashes if the rounded value is out of range.
+			## Round a [Dec] down to an [I8]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.floor_to_i8(-3.2) == -4
+			## expect Dec.floor_to_i8_try(-3.2) == Ok(-4)
 			## ```
-			floor_to_i8 : Dec -> I8
-			floor_to_i8 = |self| out_of_range_or_crash(Dec.to_i8_try(dec_floor_to_whole(self)))
+			floor_to_i8_try : Dec -> Try(I8, [OutOfRange])
+			floor_to_i8_try = |self| Dec.to_i8_try(dec_floor_to_whole(self))
 
-			## Round a [Dec] down to an [I16]. Crashes if the rounded value is out of range.
+			## Round a [Dec] down to an [I16]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.floor_to_i16(-3.2) == -4
+			## expect Dec.floor_to_i16_try(-3.2) == Ok(-4)
 			## ```
-			floor_to_i16 : Dec -> I16
-			floor_to_i16 = |self| out_of_range_or_crash(Dec.to_i16_try(dec_floor_to_whole(self)))
+			floor_to_i16_try : Dec -> Try(I16, [OutOfRange])
+			floor_to_i16_try = |self| Dec.to_i16_try(dec_floor_to_whole(self))
 
-			## Round a [Dec] down to an [I32]. Crashes if the rounded value is out of range.
+			## Round a [Dec] down to an [I32]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.floor_to_i32(3.8) == 3
+			## expect Dec.floor_to_i32_try(3.8) == Ok(3)
 			## ```
-			floor_to_i32 : Dec -> I32
-			floor_to_i32 = |self| out_of_range_or_crash(Dec.to_i32_try(dec_floor_to_whole(self)))
+			floor_to_i32_try : Dec -> Try(I32, [OutOfRange])
+			floor_to_i32_try = |self| Dec.to_i32_try(dec_floor_to_whole(self))
 
-			## Round a [Dec] down to an [I64]. Crashes if the rounded value is out of range.
+			## Round a [Dec] down to an [I64]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.floor_to_i64(3.8) == 3
+			## expect Dec.floor_to_i64_try(3.8) == Ok(3)
 			## ```
-			floor_to_i64 : Dec -> I64
-			floor_to_i64 = |self| out_of_range_or_crash(Dec.to_i64_try(dec_floor_to_whole(self)))
+			floor_to_i64_try : Dec -> Try(I64, [OutOfRange])
+			floor_to_i64_try = |self| Dec.to_i64_try(dec_floor_to_whole(self))
 
-			## Round a [Dec] down to an [I128]. Crashes if the rounded value is out of range.
+			## Round a [Dec] down to an [I128]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.floor_to_i128(3.8) == 3
+			## expect Dec.floor_to_i128_try(3.8) == Ok(3)
 			## ```
-			floor_to_i128 : Dec -> I128
-			floor_to_i128 = |self| out_of_range_or_crash(Dec.to_i128_try(dec_floor_to_whole(self)))
+			floor_to_i128_try : Dec -> Try(I128, [OutOfRange])
+			floor_to_i128_try = |self| Dec.to_i128_try(dec_floor_to_whole(self))
 
-			## Round a [Dec] down to a [U8]. Crashes if the rounded value is out of range.
+			## Round a [Dec] down to a [U8]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.floor_to_u8(3.8) == 3
+			## expect Dec.floor_to_u8_try(3.8) == Ok(3)
 			## ```
-			floor_to_u8 : Dec -> U8
-			floor_to_u8 = |self| out_of_range_or_crash(Dec.to_u8_try(dec_floor_to_whole(self)))
+			floor_to_u8_try : Dec -> Try(U8, [OutOfRange])
+			floor_to_u8_try = |self| Dec.to_u8_try(dec_floor_to_whole(self))
 
-			## Round a [Dec] down to a [U16]. Crashes if the rounded value is out of range.
+			## Round a [Dec] down to a [U16]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.floor_to_u16(3.8) == 3
+			## expect Dec.floor_to_u16_try(3.8) == Ok(3)
 			## ```
-			floor_to_u16 : Dec -> U16
-			floor_to_u16 = |self| out_of_range_or_crash(Dec.to_u16_try(dec_floor_to_whole(self)))
+			floor_to_u16_try : Dec -> Try(U16, [OutOfRange])
+			floor_to_u16_try = |self| Dec.to_u16_try(dec_floor_to_whole(self))
 
-			## Round a [Dec] down to a [U32]. Crashes if the rounded value is out of range.
+			## Round a [Dec] down to a [U32]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.floor_to_u32(3.8) == 3
+			## expect Dec.floor_to_u32_try(3.8) == Ok(3)
 			## ```
-			floor_to_u32 : Dec -> U32
-			floor_to_u32 = |self| out_of_range_or_crash(Dec.to_u32_try(dec_floor_to_whole(self)))
+			floor_to_u32_try : Dec -> Try(U32, [OutOfRange])
+			floor_to_u32_try = |self| Dec.to_u32_try(dec_floor_to_whole(self))
 
-			## Round a [Dec] down to a [U64]. Crashes if the rounded value is out of range.
+			## Round a [Dec] down to a [U64]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.floor_to_u64(3.8) == 3
+			## expect Dec.floor_to_u64_try(3.8) == Ok(3)
 			## ```
-			floor_to_u64 : Dec -> U64
-			floor_to_u64 = |self| out_of_range_or_crash(Dec.to_u64_try(dec_floor_to_whole(self)))
+			floor_to_u64_try : Dec -> Try(U64, [OutOfRange])
+			floor_to_u64_try = |self| Dec.to_u64_try(dec_floor_to_whole(self))
 
-			## Round a [Dec] down to a [U128]. Crashes if the rounded value is out of range.
+			## Round a [Dec] down to a [U128]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.floor_to_u128(3.8) == 3
+			## expect Dec.floor_to_u128_try(3.8) == Ok(3)
 			## ```
-			floor_to_u128 : Dec -> U128
-			floor_to_u128 = |self| out_of_range_or_crash(Dec.to_u128_try(dec_floor_to_whole(self)))
+			floor_to_u128_try : Dec -> Try(U128, [OutOfRange])
+			floor_to_u128_try = |self| Dec.to_u128_try(dec_floor_to_whole(self))
 
-			## Round a [Dec] up to an [I8]. Crashes if the rounded value is out of range.
+			## Round a [Dec] up to an [I8]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.ceiling_to_i8(-3.2) == -3
+			## expect Dec.ceiling_to_i8_try(-3.2) == Ok(-3)
 			## ```
-			ceiling_to_i8 : Dec -> I8
-			ceiling_to_i8 = |self| out_of_range_or_crash(Dec.to_i8_try(dec_ceiling_to_whole(self)))
+			ceiling_to_i8_try : Dec -> Try(I8, [OutOfRange])
+			ceiling_to_i8_try = |self| Dec.to_i8_try(dec_ceiling_to_whole(self))
 
-			## Round a [Dec] up to an [I16]. Crashes if the rounded value is out of range.
+			## Round a [Dec] up to an [I16]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.ceiling_to_i16(-3.2) == -3
+			## expect Dec.ceiling_to_i16_try(-3.2) == Ok(-3)
 			## ```
-			ceiling_to_i16 : Dec -> I16
-			ceiling_to_i16 = |self| out_of_range_or_crash(Dec.to_i16_try(dec_ceiling_to_whole(self)))
+			ceiling_to_i16_try : Dec -> Try(I16, [OutOfRange])
+			ceiling_to_i16_try = |self| Dec.to_i16_try(dec_ceiling_to_whole(self))
 
-			## Round a [Dec] up to an [I32]. Crashes if the rounded value is out of range.
+			## Round a [Dec] up to an [I32]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.ceiling_to_i32(3.2) == 4
+			## expect Dec.ceiling_to_i32_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_i32 : Dec -> I32
-			ceiling_to_i32 = |self| out_of_range_or_crash(Dec.to_i32_try(dec_ceiling_to_whole(self)))
+			ceiling_to_i32_try : Dec -> Try(I32, [OutOfRange])
+			ceiling_to_i32_try = |self| Dec.to_i32_try(dec_ceiling_to_whole(self))
 
-			## Round a [Dec] up to an [I64]. Crashes if the rounded value is out of range.
+			## Round a [Dec] up to an [I64]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.ceiling_to_i64(3.2) == 4
+			## expect Dec.ceiling_to_i64_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_i64 : Dec -> I64
-			ceiling_to_i64 = |self| out_of_range_or_crash(Dec.to_i64_try(dec_ceiling_to_whole(self)))
+			ceiling_to_i64_try : Dec -> Try(I64, [OutOfRange])
+			ceiling_to_i64_try = |self| Dec.to_i64_try(dec_ceiling_to_whole(self))
 
-			## Round a [Dec] up to an [I128]. Crashes if the rounded value is out of range.
+			## Round a [Dec] up to an [I128]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.ceiling_to_i128(3.2) == 4
+			## expect Dec.ceiling_to_i128_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_i128 : Dec -> I128
-			ceiling_to_i128 = |self| out_of_range_or_crash(Dec.to_i128_try(dec_ceiling_to_whole(self)))
+			ceiling_to_i128_try : Dec -> Try(I128, [OutOfRange])
+			ceiling_to_i128_try = |self| Dec.to_i128_try(dec_ceiling_to_whole(self))
 
-			## Round a [Dec] up to a [U8]. Crashes if the rounded value is out of range.
+			## Round a [Dec] up to a [U8]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.ceiling_to_u8(3.2) == 4
+			## expect Dec.ceiling_to_u8_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u8 : Dec -> U8
-			ceiling_to_u8 = |self| out_of_range_or_crash(Dec.to_u8_try(dec_ceiling_to_whole(self)))
+			ceiling_to_u8_try : Dec -> Try(U8, [OutOfRange])
+			ceiling_to_u8_try = |self| Dec.to_u8_try(dec_ceiling_to_whole(self))
 
-			## Round a [Dec] up to a [U16]. Crashes if the rounded value is out of range.
+			## Round a [Dec] up to a [U16]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.ceiling_to_u16(3.2) == 4
+			## expect Dec.ceiling_to_u16_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u16 : Dec -> U16
-			ceiling_to_u16 = |self| out_of_range_or_crash(Dec.to_u16_try(dec_ceiling_to_whole(self)))
+			ceiling_to_u16_try : Dec -> Try(U16, [OutOfRange])
+			ceiling_to_u16_try = |self| Dec.to_u16_try(dec_ceiling_to_whole(self))
 
-			## Round a [Dec] up to a [U32]. Crashes if the rounded value is out of range.
+			## Round a [Dec] up to a [U32]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.ceiling_to_u32(3.2) == 4
+			## expect Dec.ceiling_to_u32_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u32 : Dec -> U32
-			ceiling_to_u32 = |self| out_of_range_or_crash(Dec.to_u32_try(dec_ceiling_to_whole(self)))
+			ceiling_to_u32_try : Dec -> Try(U32, [OutOfRange])
+			ceiling_to_u32_try = |self| Dec.to_u32_try(dec_ceiling_to_whole(self))
 
-			## Round a [Dec] up to a [U64]. Crashes if the rounded value is out of range.
+			## Round a [Dec] up to a [U64]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.ceiling_to_u64(3.2) == 4
+			## expect Dec.ceiling_to_u64_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u64 : Dec -> U64
-			ceiling_to_u64 = |self| out_of_range_or_crash(Dec.to_u64_try(dec_ceiling_to_whole(self)))
+			ceiling_to_u64_try : Dec -> Try(U64, [OutOfRange])
+			ceiling_to_u64_try = |self| Dec.to_u64_try(dec_ceiling_to_whole(self))
 
-			## Round a [Dec] up to a [U128]. Crashes if the rounded value is out of range.
+			## Round a [Dec] up to a [U128]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
-			## expect Dec.ceiling_to_u128(3.2) == 4
+			## expect Dec.ceiling_to_u128_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u128 : Dec -> U128
-			ceiling_to_u128 = |self| out_of_range_or_crash(Dec.to_u128_try(dec_ceiling_to_whole(self)))
+			ceiling_to_u128_try : Dec -> Try(U128, [OutOfRange])
+			ceiling_to_u128_try = |self| Dec.to_u128_try(dec_ceiling_to_whole(self))
 
 			## Build a [Dec] from a list of base-10 digits, most significant
 			## first. Each element of the list must be a digit in the range `0`
@@ -15039,215 +15039,215 @@ Builtin :: [].{
 			## ```
 			abs_diff : F32, F32 -> F32
 
-			## Round an [F32] to the nearest [I8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] to the nearest [I8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.round_to_i8(3.4) == 3
+			## expect F32.round_to_i8_try(3.4) == Ok(3)
 			## ```
-			round_to_i8 : F32 -> I8
-			round_to_i8 = |self| out_of_range_or_crash(F32.to_i8_try(f32_round_to_whole(self)))
+			round_to_i8_try : F32 -> Try(I8, [OutOfRange])
+			round_to_i8_try = |self| F32.to_i8_try(f32_round_to_whole(self))
 
-			## Round an [F32] to the nearest [I16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] to the nearest [I16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.round_to_i16(3.4) == 3
+			## expect F32.round_to_i16_try(3.4) == Ok(3)
 			## ```
-			round_to_i16 : F32 -> I16
-			round_to_i16 = |self| out_of_range_or_crash(F32.to_i16_try(f32_round_to_whole(self)))
+			round_to_i16_try : F32 -> Try(I16, [OutOfRange])
+			round_to_i16_try = |self| F32.to_i16_try(f32_round_to_whole(self))
 
-			## Round an [F32] to the nearest [I32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] to the nearest [I32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.round_to_i32(-3.6) == -4
+			## expect F32.round_to_i32_try(-3.6) == Ok(-4)
 			## ```
-			round_to_i32 : F32 -> I32
-			round_to_i32 = |self| out_of_range_or_crash(F32.to_i32_try(f32_round_to_whole(self)))
+			round_to_i32_try : F32 -> Try(I32, [OutOfRange])
+			round_to_i32_try = |self| F32.to_i32_try(f32_round_to_whole(self))
 
-			## Round an [F32] to the nearest [I64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] to the nearest [I64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.round_to_i64(7.2) == 7
+			## expect F32.round_to_i64_try(7.2) == Ok(7)
 			## ```
-			round_to_i64 : F32 -> I64
-			round_to_i64 = |self| out_of_range_or_crash(F32.to_i64_try(f32_round_to_whole(self)))
+			round_to_i64_try : F32 -> Try(I64, [OutOfRange])
+			round_to_i64_try = |self| F32.to_i64_try(f32_round_to_whole(self))
 
-			## Round an [F32] to the nearest [I128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] to the nearest [I128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.round_to_i128(7.2) == 7
+			## expect F32.round_to_i128_try(7.2) == Ok(7)
 			## ```
-			round_to_i128 : F32 -> I128
-			round_to_i128 = |self| out_of_range_or_crash(F32.to_i128_try(f32_round_to_whole(self)))
+			round_to_i128_try : F32 -> Try(I128, [OutOfRange])
+			round_to_i128_try = |self| F32.to_i128_try(f32_round_to_whole(self))
 
-			## Round an [F32] to the nearest [U8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] to the nearest [U8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.round_to_u8(3.4) == 3
+			## expect F32.round_to_u8_try(3.4) == Ok(3)
 			## ```
-			round_to_u8 : F32 -> U8
-			round_to_u8 = |self| out_of_range_or_crash(F32.to_u8_try(f32_round_to_whole(self)))
+			round_to_u8_try : F32 -> Try(U8, [OutOfRange])
+			round_to_u8_try = |self| F32.to_u8_try(f32_round_to_whole(self))
 
-			## Round an [F32] to the nearest [U16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] to the nearest [U16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.round_to_u16(3.4) == 3
+			## expect F32.round_to_u16_try(3.4) == Ok(3)
 			## ```
-			round_to_u16 : F32 -> U16
-			round_to_u16 = |self| out_of_range_or_crash(F32.to_u16_try(f32_round_to_whole(self)))
+			round_to_u16_try : F32 -> Try(U16, [OutOfRange])
+			round_to_u16_try = |self| F32.to_u16_try(f32_round_to_whole(self))
 
-			## Round an [F32] to the nearest [U32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] to the nearest [U32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.round_to_u32(7.2) == 7
+			## expect F32.round_to_u32_try(7.2) == Ok(7)
 			## ```
-			round_to_u32 : F32 -> U32
-			round_to_u32 = |self| out_of_range_or_crash(F32.to_u32_try(f32_round_to_whole(self)))
+			round_to_u32_try : F32 -> Try(U32, [OutOfRange])
+			round_to_u32_try = |self| F32.to_u32_try(f32_round_to_whole(self))
 
-			## Round an [F32] to the nearest [U64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] to the nearest [U64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.round_to_u64(7.2) == 7
+			## expect F32.round_to_u64_try(7.2) == Ok(7)
 			## ```
-			round_to_u64 : F32 -> U64
-			round_to_u64 = |self| out_of_range_or_crash(F32.to_u64_try(f32_round_to_whole(self)))
+			round_to_u64_try : F32 -> Try(U64, [OutOfRange])
+			round_to_u64_try = |self| F32.to_u64_try(f32_round_to_whole(self))
 
-			## Round an [F32] to the nearest [U128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] to the nearest [U128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.round_to_u128(7.2) == 7
+			## expect F32.round_to_u128_try(7.2) == Ok(7)
 			## ```
-			round_to_u128 : F32 -> U128
-			round_to_u128 = |self| out_of_range_or_crash(F32.to_u128_try(f32_round_to_whole(self)))
+			round_to_u128_try : F32 -> Try(U128, [OutOfRange])
+			round_to_u128_try = |self| F32.to_u128_try(f32_round_to_whole(self))
 
-			## Round an [F32] down to an [I8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] down to an [I8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.floor_to_i8(-3.2) == -4
+			## expect F32.floor_to_i8_try(-3.2) == Ok(-4)
 			## ```
-			floor_to_i8 : F32 -> I8
-			floor_to_i8 = |self| out_of_range_or_crash(F32.to_i8_try(f32_floor_unsafe(self)))
+			floor_to_i8_try : F32 -> Try(I8, [OutOfRange])
+			floor_to_i8_try = |self| F32.to_i8_try(f32_floor_unsafe(self))
 
-			## Round an [F32] down to an [I16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] down to an [I16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.floor_to_i16(-3.2) == -4
+			## expect F32.floor_to_i16_try(-3.2) == Ok(-4)
 			## ```
-			floor_to_i16 : F32 -> I16
-			floor_to_i16 = |self| out_of_range_or_crash(F32.to_i16_try(f32_floor_unsafe(self)))
+			floor_to_i16_try : F32 -> Try(I16, [OutOfRange])
+			floor_to_i16_try = |self| F32.to_i16_try(f32_floor_unsafe(self))
 
-			## Round an [F32] down to an [I32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] down to an [I32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.floor_to_i32(3.8) == 3
+			## expect F32.floor_to_i32_try(3.8) == Ok(3)
 			## ```
-			floor_to_i32 : F32 -> I32
-			floor_to_i32 = |self| out_of_range_or_crash(F32.to_i32_try(f32_floor_unsafe(self)))
+			floor_to_i32_try : F32 -> Try(I32, [OutOfRange])
+			floor_to_i32_try = |self| F32.to_i32_try(f32_floor_unsafe(self))
 
-			## Round an [F32] down to an [I64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] down to an [I64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.floor_to_i64(3.8) == 3
+			## expect F32.floor_to_i64_try(3.8) == Ok(3)
 			## ```
-			floor_to_i64 : F32 -> I64
-			floor_to_i64 = |self| out_of_range_or_crash(F32.to_i64_try(f32_floor_unsafe(self)))
+			floor_to_i64_try : F32 -> Try(I64, [OutOfRange])
+			floor_to_i64_try = |self| F32.to_i64_try(f32_floor_unsafe(self))
 
-			## Round an [F32] down to an [I128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] down to an [I128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.floor_to_i128(3.8) == 3
+			## expect F32.floor_to_i128_try(3.8) == Ok(3)
 			## ```
-			floor_to_i128 : F32 -> I128
-			floor_to_i128 = |self| out_of_range_or_crash(F32.to_i128_try(f32_floor_unsafe(self)))
+			floor_to_i128_try : F32 -> Try(I128, [OutOfRange])
+			floor_to_i128_try = |self| F32.to_i128_try(f32_floor_unsafe(self))
 
-			## Round an [F32] down to a [U8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] down to a [U8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.floor_to_u8(3.8) == 3
+			## expect F32.floor_to_u8_try(3.8) == Ok(3)
 			## ```
-			floor_to_u8 : F32 -> U8
-			floor_to_u8 = |self| out_of_range_or_crash(F32.to_u8_try(f32_floor_unsafe(self)))
+			floor_to_u8_try : F32 -> Try(U8, [OutOfRange])
+			floor_to_u8_try = |self| F32.to_u8_try(f32_floor_unsafe(self))
 
-			## Round an [F32] down to a [U16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] down to a [U16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.floor_to_u16(3.8) == 3
+			## expect F32.floor_to_u16_try(3.8) == Ok(3)
 			## ```
-			floor_to_u16 : F32 -> U16
-			floor_to_u16 = |self| out_of_range_or_crash(F32.to_u16_try(f32_floor_unsafe(self)))
+			floor_to_u16_try : F32 -> Try(U16, [OutOfRange])
+			floor_to_u16_try = |self| F32.to_u16_try(f32_floor_unsafe(self))
 
-			## Round an [F32] down to a [U32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] down to a [U32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.floor_to_u32(3.8) == 3
+			## expect F32.floor_to_u32_try(3.8) == Ok(3)
 			## ```
-			floor_to_u32 : F32 -> U32
-			floor_to_u32 = |self| out_of_range_or_crash(F32.to_u32_try(f32_floor_unsafe(self)))
+			floor_to_u32_try : F32 -> Try(U32, [OutOfRange])
+			floor_to_u32_try = |self| F32.to_u32_try(f32_floor_unsafe(self))
 
-			## Round an [F32] down to a [U64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] down to a [U64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.floor_to_u64(3.8) == 3
+			## expect F32.floor_to_u64_try(3.8) == Ok(3)
 			## ```
-			floor_to_u64 : F32 -> U64
-			floor_to_u64 = |self| out_of_range_or_crash(F32.to_u64_try(f32_floor_unsafe(self)))
+			floor_to_u64_try : F32 -> Try(U64, [OutOfRange])
+			floor_to_u64_try = |self| F32.to_u64_try(f32_floor_unsafe(self))
 
-			## Round an [F32] down to a [U128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] down to a [U128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.floor_to_u128(3.8) == 3
+			## expect F32.floor_to_u128_try(3.8) == Ok(3)
 			## ```
-			floor_to_u128 : F32 -> U128
-			floor_to_u128 = |self| out_of_range_or_crash(F32.to_u128_try(f32_floor_unsafe(self)))
+			floor_to_u128_try : F32 -> Try(U128, [OutOfRange])
+			floor_to_u128_try = |self| F32.to_u128_try(f32_floor_unsafe(self))
 
-			## Round an [F32] up to an [I8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] up to an [I8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.ceiling_to_i8(-3.2) == -3
+			## expect F32.ceiling_to_i8_try(-3.2) == Ok(-3)
 			## ```
-			ceiling_to_i8 : F32 -> I8
-			ceiling_to_i8 = |self| out_of_range_or_crash(F32.to_i8_try(f32_ceiling_unsafe(self)))
+			ceiling_to_i8_try : F32 -> Try(I8, [OutOfRange])
+			ceiling_to_i8_try = |self| F32.to_i8_try(f32_ceiling_unsafe(self))
 
-			## Round an [F32] up to an [I16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] up to an [I16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.ceiling_to_i16(-3.2) == -3
+			## expect F32.ceiling_to_i16_try(-3.2) == Ok(-3)
 			## ```
-			ceiling_to_i16 : F32 -> I16
-			ceiling_to_i16 = |self| out_of_range_or_crash(F32.to_i16_try(f32_ceiling_unsafe(self)))
+			ceiling_to_i16_try : F32 -> Try(I16, [OutOfRange])
+			ceiling_to_i16_try = |self| F32.to_i16_try(f32_ceiling_unsafe(self))
 
-			## Round an [F32] up to an [I32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] up to an [I32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.ceiling_to_i32(3.2) == 4
+			## expect F32.ceiling_to_i32_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_i32 : F32 -> I32
-			ceiling_to_i32 = |self| out_of_range_or_crash(F32.to_i32_try(f32_ceiling_unsafe(self)))
+			ceiling_to_i32_try : F32 -> Try(I32, [OutOfRange])
+			ceiling_to_i32_try = |self| F32.to_i32_try(f32_ceiling_unsafe(self))
 
-			## Round an [F32] up to an [I64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] up to an [I64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.ceiling_to_i64(3.2) == 4
+			## expect F32.ceiling_to_i64_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_i64 : F32 -> I64
-			ceiling_to_i64 = |self| out_of_range_or_crash(F32.to_i64_try(f32_ceiling_unsafe(self)))
+			ceiling_to_i64_try : F32 -> Try(I64, [OutOfRange])
+			ceiling_to_i64_try = |self| F32.to_i64_try(f32_ceiling_unsafe(self))
 
-			## Round an [F32] up to an [I128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] up to an [I128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.ceiling_to_i128(3.2) == 4
+			## expect F32.ceiling_to_i128_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_i128 : F32 -> I128
-			ceiling_to_i128 = |self| out_of_range_or_crash(F32.to_i128_try(f32_ceiling_unsafe(self)))
+			ceiling_to_i128_try : F32 -> Try(I128, [OutOfRange])
+			ceiling_to_i128_try = |self| F32.to_i128_try(f32_ceiling_unsafe(self))
 
-			## Round an [F32] up to a [U8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] up to a [U8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.ceiling_to_u8(3.2) == 4
+			## expect F32.ceiling_to_u8_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u8 : F32 -> U8
-			ceiling_to_u8 = |self| out_of_range_or_crash(F32.to_u8_try(f32_ceiling_unsafe(self)))
+			ceiling_to_u8_try : F32 -> Try(U8, [OutOfRange])
+			ceiling_to_u8_try = |self| F32.to_u8_try(f32_ceiling_unsafe(self))
 
-			## Round an [F32] up to a [U16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] up to a [U16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.ceiling_to_u16(3.2) == 4
+			## expect F32.ceiling_to_u16_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u16 : F32 -> U16
-			ceiling_to_u16 = |self| out_of_range_or_crash(F32.to_u16_try(f32_ceiling_unsafe(self)))
+			ceiling_to_u16_try : F32 -> Try(U16, [OutOfRange])
+			ceiling_to_u16_try = |self| F32.to_u16_try(f32_ceiling_unsafe(self))
 
-			## Round an [F32] up to a [U32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] up to a [U32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.ceiling_to_u32(3.2) == 4
+			## expect F32.ceiling_to_u32_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u32 : F32 -> U32
-			ceiling_to_u32 = |self| out_of_range_or_crash(F32.to_u32_try(f32_ceiling_unsafe(self)))
+			ceiling_to_u32_try : F32 -> Try(U32, [OutOfRange])
+			ceiling_to_u32_try = |self| F32.to_u32_try(f32_ceiling_unsafe(self))
 
-			## Round an [F32] up to a [U64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] up to a [U64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.ceiling_to_u64(3.2) == 4
+			## expect F32.ceiling_to_u64_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u64 : F32 -> U64
-			ceiling_to_u64 = |self| out_of_range_or_crash(F32.to_u64_try(f32_ceiling_unsafe(self)))
+			ceiling_to_u64_try : F32 -> Try(U64, [OutOfRange])
+			ceiling_to_u64_try = |self| F32.to_u64_try(f32_ceiling_unsafe(self))
 
-			## Round an [F32] up to a [U128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F32] up to a [U128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F32.ceiling_to_u128(3.2) == 4
+			## expect F32.ceiling_to_u128_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u128 : F32 -> U128
-			ceiling_to_u128 = |self| out_of_range_or_crash(F32.to_u128_try(f32_ceiling_unsafe(self)))
+			ceiling_to_u128_try : F32 -> Try(U128, [OutOfRange])
+			ceiling_to_u128_try = |self| F32.to_u128_try(f32_ceiling_unsafe(self))
 
 			## Build an [F32] from a list of base-10 digits, most significant
 			## first. Each element of the list must be a digit in the range `0`
@@ -15986,215 +15986,215 @@ Builtin :: [].{
 			## ```
 			abs_diff : F64, F64 -> F64
 
-			## Round an [F64] to the nearest [I8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] to the nearest [I8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.round_to_i8(3.4) == 3
+			## expect F64.round_to_i8_try(3.4) == Ok(3)
 			## ```
-			round_to_i8 : F64 -> I8
-			round_to_i8 = |self| out_of_range_or_crash(F64.to_i8_try(f64_round_to_whole(self)))
+			round_to_i8_try : F64 -> Try(I8, [OutOfRange])
+			round_to_i8_try = |self| F64.to_i8_try(f64_round_to_whole(self))
 
-			## Round an [F64] to the nearest [I16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] to the nearest [I16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.round_to_i16(3.4) == 3
+			## expect F64.round_to_i16_try(3.4) == Ok(3)
 			## ```
-			round_to_i16 : F64 -> I16
-			round_to_i16 = |self| out_of_range_or_crash(F64.to_i16_try(f64_round_to_whole(self)))
+			round_to_i16_try : F64 -> Try(I16, [OutOfRange])
+			round_to_i16_try = |self| F64.to_i16_try(f64_round_to_whole(self))
 
-			## Round an [F64] to the nearest [I32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] to the nearest [I32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.round_to_i32(-3.6) == -4
+			## expect F64.round_to_i32_try(-3.6) == Ok(-4)
 			## ```
-			round_to_i32 : F64 -> I32
-			round_to_i32 = |self| out_of_range_or_crash(F64.to_i32_try(f64_round_to_whole(self)))
+			round_to_i32_try : F64 -> Try(I32, [OutOfRange])
+			round_to_i32_try = |self| F64.to_i32_try(f64_round_to_whole(self))
 
-			## Round an [F64] to the nearest [I64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] to the nearest [I64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.round_to_i64(7.2) == 7
+			## expect F64.round_to_i64_try(7.2) == Ok(7)
 			## ```
-			round_to_i64 : F64 -> I64
-			round_to_i64 = |self| out_of_range_or_crash(F64.to_i64_try(f64_round_to_whole(self)))
+			round_to_i64_try : F64 -> Try(I64, [OutOfRange])
+			round_to_i64_try = |self| F64.to_i64_try(f64_round_to_whole(self))
 
-			## Round an [F64] to the nearest [I128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] to the nearest [I128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.round_to_i128(7.2) == 7
+			## expect F64.round_to_i128_try(7.2) == Ok(7)
 			## ```
-			round_to_i128 : F64 -> I128
-			round_to_i128 = |self| out_of_range_or_crash(F64.to_i128_try(f64_round_to_whole(self)))
+			round_to_i128_try : F64 -> Try(I128, [OutOfRange])
+			round_to_i128_try = |self| F64.to_i128_try(f64_round_to_whole(self))
 
-			## Round an [F64] to the nearest [U8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] to the nearest [U8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.round_to_u8(3.4) == 3
+			## expect F64.round_to_u8_try(3.4) == Ok(3)
 			## ```
-			round_to_u8 : F64 -> U8
-			round_to_u8 = |self| out_of_range_or_crash(F64.to_u8_try(f64_round_to_whole(self)))
+			round_to_u8_try : F64 -> Try(U8, [OutOfRange])
+			round_to_u8_try = |self| F64.to_u8_try(f64_round_to_whole(self))
 
-			## Round an [F64] to the nearest [U16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] to the nearest [U16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.round_to_u16(3.4) == 3
+			## expect F64.round_to_u16_try(3.4) == Ok(3)
 			## ```
-			round_to_u16 : F64 -> U16
-			round_to_u16 = |self| out_of_range_or_crash(F64.to_u16_try(f64_round_to_whole(self)))
+			round_to_u16_try : F64 -> Try(U16, [OutOfRange])
+			round_to_u16_try = |self| F64.to_u16_try(f64_round_to_whole(self))
 
-			## Round an [F64] to the nearest [U32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] to the nearest [U32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.round_to_u32(7.2) == 7
+			## expect F64.round_to_u32_try(7.2) == Ok(7)
 			## ```
-			round_to_u32 : F64 -> U32
-			round_to_u32 = |self| out_of_range_or_crash(F64.to_u32_try(f64_round_to_whole(self)))
+			round_to_u32_try : F64 -> Try(U32, [OutOfRange])
+			round_to_u32_try = |self| F64.to_u32_try(f64_round_to_whole(self))
 
-			## Round an [F64] to the nearest [U64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] to the nearest [U64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.round_to_u64(7.2) == 7
+			## expect F64.round_to_u64_try(7.2) == Ok(7)
 			## ```
-			round_to_u64 : F64 -> U64
-			round_to_u64 = |self| out_of_range_or_crash(F64.to_u64_try(f64_round_to_whole(self)))
+			round_to_u64_try : F64 -> Try(U64, [OutOfRange])
+			round_to_u64_try = |self| F64.to_u64_try(f64_round_to_whole(self))
 
-			## Round an [F64] to the nearest [U128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] to the nearest [U128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.round_to_u128(7.2) == 7
+			## expect F64.round_to_u128_try(7.2) == Ok(7)
 			## ```
-			round_to_u128 : F64 -> U128
-			round_to_u128 = |self| out_of_range_or_crash(F64.to_u128_try(f64_round_to_whole(self)))
+			round_to_u128_try : F64 -> Try(U128, [OutOfRange])
+			round_to_u128_try = |self| F64.to_u128_try(f64_round_to_whole(self))
 
-			## Round an [F64] down to an [I8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] down to an [I8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.floor_to_i8(-3.2) == -4
+			## expect F64.floor_to_i8_try(-3.2) == Ok(-4)
 			## ```
-			floor_to_i8 : F64 -> I8
-			floor_to_i8 = |self| out_of_range_or_crash(F64.to_i8_try(f64_floor_unsafe(self)))
+			floor_to_i8_try : F64 -> Try(I8, [OutOfRange])
+			floor_to_i8_try = |self| F64.to_i8_try(f64_floor_unsafe(self))
 
-			## Round an [F64] down to an [I16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] down to an [I16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.floor_to_i16(-3.2) == -4
+			## expect F64.floor_to_i16_try(-3.2) == Ok(-4)
 			## ```
-			floor_to_i16 : F64 -> I16
-			floor_to_i16 = |self| out_of_range_or_crash(F64.to_i16_try(f64_floor_unsafe(self)))
+			floor_to_i16_try : F64 -> Try(I16, [OutOfRange])
+			floor_to_i16_try = |self| F64.to_i16_try(f64_floor_unsafe(self))
 
-			## Round an [F64] down to an [I32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] down to an [I32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.floor_to_i32(3.8) == 3
+			## expect F64.floor_to_i32_try(3.8) == Ok(3)
 			## ```
-			floor_to_i32 : F64 -> I32
-			floor_to_i32 = |self| out_of_range_or_crash(F64.to_i32_try(f64_floor_unsafe(self)))
+			floor_to_i32_try : F64 -> Try(I32, [OutOfRange])
+			floor_to_i32_try = |self| F64.to_i32_try(f64_floor_unsafe(self))
 
-			## Round an [F64] down to an [I64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] down to an [I64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.floor_to_i64(3.8) == 3
+			## expect F64.floor_to_i64_try(3.8) == Ok(3)
 			## ```
-			floor_to_i64 : F64 -> I64
-			floor_to_i64 = |self| out_of_range_or_crash(F64.to_i64_try(f64_floor_unsafe(self)))
+			floor_to_i64_try : F64 -> Try(I64, [OutOfRange])
+			floor_to_i64_try = |self| F64.to_i64_try(f64_floor_unsafe(self))
 
-			## Round an [F64] down to an [I128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] down to an [I128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.floor_to_i128(3.8) == 3
+			## expect F64.floor_to_i128_try(3.8) == Ok(3)
 			## ```
-			floor_to_i128 : F64 -> I128
-			floor_to_i128 = |self| out_of_range_or_crash(F64.to_i128_try(f64_floor_unsafe(self)))
+			floor_to_i128_try : F64 -> Try(I128, [OutOfRange])
+			floor_to_i128_try = |self| F64.to_i128_try(f64_floor_unsafe(self))
 
-			## Round an [F64] down to a [U8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] down to a [U8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.floor_to_u8(3.8) == 3
+			## expect F64.floor_to_u8_try(3.8) == Ok(3)
 			## ```
-			floor_to_u8 : F64 -> U8
-			floor_to_u8 = |self| out_of_range_or_crash(F64.to_u8_try(f64_floor_unsafe(self)))
+			floor_to_u8_try : F64 -> Try(U8, [OutOfRange])
+			floor_to_u8_try = |self| F64.to_u8_try(f64_floor_unsafe(self))
 
-			## Round an [F64] down to a [U16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] down to a [U16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.floor_to_u16(3.8) == 3
+			## expect F64.floor_to_u16_try(3.8) == Ok(3)
 			## ```
-			floor_to_u16 : F64 -> U16
-			floor_to_u16 = |self| out_of_range_or_crash(F64.to_u16_try(f64_floor_unsafe(self)))
+			floor_to_u16_try : F64 -> Try(U16, [OutOfRange])
+			floor_to_u16_try = |self| F64.to_u16_try(f64_floor_unsafe(self))
 
-			## Round an [F64] down to a [U32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] down to a [U32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.floor_to_u32(3.8) == 3
+			## expect F64.floor_to_u32_try(3.8) == Ok(3)
 			## ```
-			floor_to_u32 : F64 -> U32
-			floor_to_u32 = |self| out_of_range_or_crash(F64.to_u32_try(f64_floor_unsafe(self)))
+			floor_to_u32_try : F64 -> Try(U32, [OutOfRange])
+			floor_to_u32_try = |self| F64.to_u32_try(f64_floor_unsafe(self))
 
-			## Round an [F64] down to a [U64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] down to a [U64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.floor_to_u64(3.8) == 3
+			## expect F64.floor_to_u64_try(3.8) == Ok(3)
 			## ```
-			floor_to_u64 : F64 -> U64
-			floor_to_u64 = |self| out_of_range_or_crash(F64.to_u64_try(f64_floor_unsafe(self)))
+			floor_to_u64_try : F64 -> Try(U64, [OutOfRange])
+			floor_to_u64_try = |self| F64.to_u64_try(f64_floor_unsafe(self))
 
-			## Round an [F64] down to a [U128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] down to a [U128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.floor_to_u128(3.8) == 3
+			## expect F64.floor_to_u128_try(3.8) == Ok(3)
 			## ```
-			floor_to_u128 : F64 -> U128
-			floor_to_u128 = |self| out_of_range_or_crash(F64.to_u128_try(f64_floor_unsafe(self)))
+			floor_to_u128_try : F64 -> Try(U128, [OutOfRange])
+			floor_to_u128_try = |self| F64.to_u128_try(f64_floor_unsafe(self))
 
-			## Round an [F64] up to an [I8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] up to an [I8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.ceiling_to_i8(-3.2) == -3
+			## expect F64.ceiling_to_i8_try(-3.2) == Ok(-3)
 			## ```
-			ceiling_to_i8 : F64 -> I8
-			ceiling_to_i8 = |self| out_of_range_or_crash(F64.to_i8_try(f64_ceiling_unsafe(self)))
+			ceiling_to_i8_try : F64 -> Try(I8, [OutOfRange])
+			ceiling_to_i8_try = |self| F64.to_i8_try(f64_ceiling_unsafe(self))
 
-			## Round an [F64] up to an [I16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] up to an [I16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.ceiling_to_i16(-3.2) == -3
+			## expect F64.ceiling_to_i16_try(-3.2) == Ok(-3)
 			## ```
-			ceiling_to_i16 : F64 -> I16
-			ceiling_to_i16 = |self| out_of_range_or_crash(F64.to_i16_try(f64_ceiling_unsafe(self)))
+			ceiling_to_i16_try : F64 -> Try(I16, [OutOfRange])
+			ceiling_to_i16_try = |self| F64.to_i16_try(f64_ceiling_unsafe(self))
 
-			## Round an [F64] up to an [I32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] up to an [I32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.ceiling_to_i32(3.2) == 4
+			## expect F64.ceiling_to_i32_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_i32 : F64 -> I32
-			ceiling_to_i32 = |self| out_of_range_or_crash(F64.to_i32_try(f64_ceiling_unsafe(self)))
+			ceiling_to_i32_try : F64 -> Try(I32, [OutOfRange])
+			ceiling_to_i32_try = |self| F64.to_i32_try(f64_ceiling_unsafe(self))
 
-			## Round an [F64] up to an [I64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] up to an [I64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.ceiling_to_i64(3.2) == 4
+			## expect F64.ceiling_to_i64_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_i64 : F64 -> I64
-			ceiling_to_i64 = |self| out_of_range_or_crash(F64.to_i64_try(f64_ceiling_unsafe(self)))
+			ceiling_to_i64_try : F64 -> Try(I64, [OutOfRange])
+			ceiling_to_i64_try = |self| F64.to_i64_try(f64_ceiling_unsafe(self))
 
-			## Round an [F64] up to an [I128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] up to an [I128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.ceiling_to_i128(3.2) == 4
+			## expect F64.ceiling_to_i128_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_i128 : F64 -> I128
-			ceiling_to_i128 = |self| out_of_range_or_crash(F64.to_i128_try(f64_ceiling_unsafe(self)))
+			ceiling_to_i128_try : F64 -> Try(I128, [OutOfRange])
+			ceiling_to_i128_try = |self| F64.to_i128_try(f64_ceiling_unsafe(self))
 
-			## Round an [F64] up to a [U8]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] up to a [U8]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.ceiling_to_u8(3.2) == 4
+			## expect F64.ceiling_to_u8_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u8 : F64 -> U8
-			ceiling_to_u8 = |self| out_of_range_or_crash(F64.to_u8_try(f64_ceiling_unsafe(self)))
+			ceiling_to_u8_try : F64 -> Try(U8, [OutOfRange])
+			ceiling_to_u8_try = |self| F64.to_u8_try(f64_ceiling_unsafe(self))
 
-			## Round an [F64] up to a [U16]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] up to a [U16]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.ceiling_to_u16(3.2) == 4
+			## expect F64.ceiling_to_u16_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u16 : F64 -> U16
-			ceiling_to_u16 = |self| out_of_range_or_crash(F64.to_u16_try(f64_ceiling_unsafe(self)))
+			ceiling_to_u16_try : F64 -> Try(U16, [OutOfRange])
+			ceiling_to_u16_try = |self| F64.to_u16_try(f64_ceiling_unsafe(self))
 
-			## Round an [F64] up to a [U32]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] up to a [U32]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.ceiling_to_u32(3.2) == 4
+			## expect F64.ceiling_to_u32_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u32 : F64 -> U32
-			ceiling_to_u32 = |self| out_of_range_or_crash(F64.to_u32_try(f64_ceiling_unsafe(self)))
+			ceiling_to_u32_try : F64 -> Try(U32, [OutOfRange])
+			ceiling_to_u32_try = |self| F64.to_u32_try(f64_ceiling_unsafe(self))
 
-			## Round an [F64] up to a [U64]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] up to a [U64]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.ceiling_to_u64(3.2) == 4
+			## expect F64.ceiling_to_u64_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u64 : F64 -> U64
-			ceiling_to_u64 = |self| out_of_range_or_crash(F64.to_u64_try(f64_ceiling_unsafe(self)))
+			ceiling_to_u64_try : F64 -> Try(U64, [OutOfRange])
+			ceiling_to_u64_try = |self| F64.to_u64_try(f64_ceiling_unsafe(self))
 
-			## Round an [F64] up to a [U128]. Crashes if the rounded value is out of range, `NaN`, or infinite.
+			## Round an [F64] up to a [U128]. Returns `Err(OutOfRange)` if the rounded value is out of range, `NaN`, or infinite.
 			## ```roc
-			## expect F64.ceiling_to_u128(3.2) == 4
+			## expect F64.ceiling_to_u128_try(3.2) == Ok(4)
 			## ```
-			ceiling_to_u128 : F64 -> U128
-			ceiling_to_u128 = |self| out_of_range_or_crash(F64.to_u128_try(f64_ceiling_unsafe(self)))
+			ceiling_to_u128_try : F64 -> Try(U128, [OutOfRange])
+			ceiling_to_u128_try = |self| F64.to_u128_try(f64_ceiling_unsafe(self))
 
 			## Build an [F64] from a list of base-10 digits, most significant
 			## first. Each element of the list must be a digit in the range `0`
@@ -20938,15 +20938,6 @@ out_of_range_try = |answer|
 		Ok(answer.val_or_memory_garbage)
 	} else {
 		Err(OutOfRange)
-	}
-
-out_of_range_or_crash : Try(item, [OutOfRange]) -> item
-out_of_range_or_crash = |answer|
-	match answer {
-		Ok(value) => value
-		Err(OutOfRange) => {
-			crash "number is out of range"
-		}
 	}
 
 dec_round_to_whole : Dec -> Dec

--- a/src/eval/test/eval_low_level_tests.zig
+++ b/src/eval/test/eval_low_level_tests.zig
@@ -444,12 +444,12 @@ pub const tests = [_]TestCase{
         .name = "low_level - F32 rounding to integers",
         .source =
         \\{
-        \\F32.round_to_i32(3.4) == 3
-        \\    and F32.round_to_i32(-3.6) == -4
-        \\    and F32.round_to_i32(2.5) == 3
-        \\    and F32.round_to_i32(-2.5) == -3
-        \\    and F32.floor_to_i32(-3.2) == -4
-        \\    and F32.ceiling_to_u32(3.2) == 4
+        \\F32.round_to_i32_try(3.4) == Ok(3)
+        \\    and F32.round_to_i32_try(-3.6) == Ok(-4)
+        \\    and F32.round_to_i32_try(2.5) == Ok(3)
+        \\    and F32.round_to_i32_try(-2.5) == Ok(-3)
+        \\    and F32.floor_to_i32_try(-3.2) == Ok(-4)
+        \\    and F32.ceiling_to_u32_try(3.2) == Ok(4)
         \\}
         ,
         .expected = .{ .inspect_str = "True" },
@@ -458,12 +458,12 @@ pub const tests = [_]TestCase{
         .name = "low_level - F64 rounding to integers",
         .source =
         \\{
-        \\F64.round_to_i32(3.4) == 3
-        \\    and F64.round_to_i32(-3.6) == -4
-        \\    and F64.round_to_i32(2.5) == 3
-        \\    and F64.round_to_i32(-2.5) == -3
-        \\    and F64.floor_to_i32(-3.2) == -4
-        \\    and F64.ceiling_to_u32(3.2) == 4
+        \\F64.round_to_i32_try(3.4) == Ok(3)
+        \\    and F64.round_to_i32_try(-3.6) == Ok(-4)
+        \\    and F64.round_to_i32_try(2.5) == Ok(3)
+        \\    and F64.round_to_i32_try(-2.5) == Ok(-3)
+        \\    and F64.floor_to_i32_try(-3.2) == Ok(-4)
+        \\    and F64.ceiling_to_u32_try(3.2) == Ok(4)
         \\}
         ,
         .expected = .{ .inspect_str = "True" },
@@ -504,57 +504,57 @@ pub const tests = [_]TestCase{
     // backend must pass the float `val` through its CallBuilder so the
     // following integer args land in the right registers on Windows x64).
     .{
-        .name = "low_level - F32 floor_to_i32 returns signed value",
+        .name = "low_level - F32 floor_to_i32_try returns signed value",
         .source =
-        \\F32.floor_to_i32(-3.2)
+        \\F32.floor_to_i32_try(-3.2)
         ,
-        .expected = .{ .inspect_str = "-4" },
+        .expected = .{ .inspect_str = "Ok(-4)" },
     },
     .{
-        .name = "low_level - F32 ceiling_to_u32 returns unsigned value",
+        .name = "low_level - F32 ceiling_to_u32_try returns unsigned value",
         .source =
-        \\F32.ceiling_to_u32(3.2)
+        \\F32.ceiling_to_u32_try(3.2)
         ,
-        .expected = .{ .inspect_str = "4" },
+        .expected = .{ .inspect_str = "Ok(4)" },
     },
     .{
-        .name = "low_level - F32 round_to_i32 returns signed value",
+        .name = "low_level - F32 round_to_i32_try returns signed value",
         .source =
-        \\F32.round_to_i32(2.5)
+        \\F32.round_to_i32_try(2.5)
         ,
-        .expected = .{ .inspect_str = "3" },
+        .expected = .{ .inspect_str = "Ok(3)" },
     },
     .{
-        .name = "low_level - F64 floor_to_i32 returns signed value",
+        .name = "low_level - F64 floor_to_i32_try returns signed value",
         .source =
-        \\F64.floor_to_i32(-3.2)
+        \\F64.floor_to_i32_try(-3.2)
         ,
-        .expected = .{ .inspect_str = "-4" },
+        .expected = .{ .inspect_str = "Ok(-4)" },
     },
     .{
-        .name = "low_level - F64 ceiling_to_u32 returns unsigned value",
+        .name = "low_level - F64 ceiling_to_u32_try returns unsigned value",
         .source =
-        \\F64.ceiling_to_u32(3.2)
+        \\F64.ceiling_to_u32_try(3.2)
         ,
-        .expected = .{ .inspect_str = "4" },
+        .expected = .{ .inspect_str = "Ok(4)" },
     },
     .{
-        .name = "low_level - F64 round_to_i32 returns signed value",
+        .name = "low_level - F64 round_to_i32_try returns signed value",
         .source =
-        \\F64.round_to_i32(2.5)
+        \\F64.round_to_i32_try(2.5)
         ,
-        .expected = .{ .inspect_str = "3" },
+        .expected = .{ .inspect_str = "Ok(3)" },
     },
     .{
         .name = "low_level - Dec rounding to integers",
         .source =
         \\{
-        \\Dec.round_to_i32(3.4) == 3
-        \\    and Dec.round_to_i32(-3.6) == -4
-        \\    and Dec.round_to_i32(2.5) == 3
-        \\    and Dec.round_to_i32(-2.5) == -3
-        \\    and Dec.floor_to_i32(-3.2) == -4
-        \\    and Dec.ceiling_to_u32(3.2) == 4
+        \\Dec.round_to_i32_try(3.4) == Ok(3)
+        \\    and Dec.round_to_i32_try(-3.6) == Ok(-4)
+        \\    and Dec.round_to_i32_try(2.5) == Ok(3)
+        \\    and Dec.round_to_i32_try(-2.5) == Ok(-3)
+        \\    and Dec.floor_to_i32_try(-3.2) == Ok(-4)
+        \\    and Dec.ceiling_to_u32_try(3.2) == Ok(4)
         \\}
         ,
         .expected = .{ .inspect_str = "True" },

--- a/test/cli/DevFloatHelpersLink.roc
+++ b/test/cli/DevFloatHelpersLink.roc
@@ -12,16 +12,16 @@ main! = || {
 	if F64.div_trunc_by($f64, 2.0) != -3.0 {
 		crash "wrong F64 div_trunc_by result"
 	}
-	if F32.floor_to_i32($f32) != -8 {
+	if F32.floor_to_i32_try($f32) != Ok(-8) {
 		crash "wrong F32 floor result"
 	}
-	if F64.floor_to_i32($f64) != -8 {
+	if F64.floor_to_i32_try($f64) != Ok(-8) {
 		crash "wrong F64 floor result"
 	}
-	if F32.ceiling_to_i32($f32) != -7 {
+	if F32.ceiling_to_i32_try($f32) != Ok(-7) {
 		crash "wrong F32 ceiling result"
 	}
-	if F64.ceiling_to_i32($f64) != -7 {
+	if F64.ceiling_to_i32_try($f64) != Ok(-7) {
 		crash "wrong F64 ceiling result"
 	}
 	if $u128.shl_wrap(3) != 128 {

--- a/test/snapshots/repl/frac_round_to_try.md
+++ b/test/snapshots/repl/frac_round_to_try.md
@@ -1,0 +1,37 @@
+# META
+~~~ini
+description=round_to/floor_to/ceiling_to _try variants return Ok in range and Err(OutOfRange) otherwise, across Dec/F32/F64
+type=repl
+~~~
+# SOURCE
+~~~roc
+» Dec.round_to_i32_try(3.5)
+» F32.floor_to_i16_try(-2.7)
+» F64.ceiling_to_i8_try(3.2)
+» F64.round_to_u8_try(-1.0)
+» Dec.ceiling_to_u16_try(-2.0)
+» F32.floor_to_i8_try(1000.0)
+» F64.round_to_u8_try(999.0)
+» F64.round_to_i8_try(F64.nan)
+» F32.round_to_i8_try(F32.infinity)
+~~~
+# OUTPUT
+Ok(4)
+---
+Ok(-3)
+---
+Ok(4)
+---
+Err(OutOfRange)
+---
+Err(OutOfRange)
+---
+Err(OutOfRange)
+---
+Err(OutOfRange)
+---
+Err(OutOfRange)
+---
+Err(OutOfRange)
+# PROBLEMS
+NIL


### PR DESCRIPTION
Replaces the crashing `round_to_*` / `floor_to_*` / `ceiling_to_*` float→int conversions (all routed through `out_of_range_or_crash`) with fallible `_try` variants returning `Try(Int, [OutOfRange])`, and drops the now-unused helper.

Per discussion in #contributing ("basic-cli good first issues"): rounding conversions shouldn't crash, and since the conversion already goes through a conditional, the honest total answer is `_try` — the `_wrap` variants stay as the explicit total escape hatch. Confirmed by @rtfeldman: one PR for all three families, naming `<op>_to_<int>_try`.

**Scope:** 90 fns — {round,floor,ceiling}_to_{i8,i16,i32,i64,i128,u8,u16,u32,u64,u128} × {Dec, F32, F64}.

**Notes:**
- Pure Roc — no new low-level ops or backend changes; bodies just drop the `out_of_range_or_crash` wrapper.
- The out-of-range/NaN/inf path is now testable (it crashed before): added `test/snapshots/repl/frac_round_to_try.md` covering it, updated the `eval_low_level_tests.zig` cases and all doc-tests.
