### PR TITLE
Walk JSON strings and scalars in place instead of materializing byte lists

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -2234,17 +2234,13 @@ Builtin :: [].{
 		## returns `Err(BadUtf8)`. Valid slices do not allocate.
 		drop_first_bytes : Str, U64 -> Try(Str, [BadUtf8, ..])
 		drop_first_bytes = |str, count| {
-			len = Str.count_utf8_bytes(str)
-			if count >= len {
-				Ok("")
-			} else {
+			if count < Str.count_utf8_bytes(str) {
 				byte = str_get_utf8_byte_unsafe(str, count)
 				if byte >= 128 and byte < 192 {
-					Err(BadUtf8)
-				} else {
-					Ok(str_substring_unsafe(str, count, len - count))
+					return Err(BadUtf8)
 				}
 			}
+			Ok(str_drop_first_bytes_unsafe(str, count))
 		}
 
 		## Drop a byte count from the end of a string. Counts at or beyond the byte
@@ -21773,6 +21769,20 @@ str_get_utf8_byte_unsafe : Str, U64 -> U8
 # Implemented by the compiler. The caller guarantees the byte range is in bounds.
 # The result shares the source string's allocation.
 str_substring_unsafe : Str, U64, U64 -> Str
+
+## Drop `count` bytes from the front of a string as a zero-copy slice ("" when
+## `count` is at or past the end). Bounds are handled; what is NOT checked is
+## that `count` falls on a UTF-8 boundary — the caller guarantees that, so the
+## slice is a valid string. (`Str.drop_first_bytes` is the checked version.)
+str_drop_first_bytes_unsafe : Str, U64 -> Str
+str_drop_first_bytes_unsafe = |s, count| {
+	len = Str.count_utf8_bytes(s)
+	if count >= len {
+		""
+	} else {
+		str_substring_unsafe(s, count, len - count)
+	}
+}
 
 # Implemented by the compiler. Returns 1 (otherwise 0) when List.map may reuse
 # the input list's allocation for its output: the input and output element

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -21517,32 +21517,23 @@ ScannedJsonString : { after : Str, body : [NoEscapes(Str), HasEscapes(Str)] }
 ## along the way.
 scan_json_string_tail : Str -> Try(ScannedJsonString, [InvalidJson(Str), ..])
 scan_json_string_tail = |tail| {
-	bytes = Str.to_utf8(tail)
-	len = List.len(bytes)
+	len = Str.count_utf8_bytes(tail)
 	var $index = 0
 	var $had_escape = False
 
-	# Walk the bytes, consuming each escape atomically, until the closing quote.
-	# Every escape must be validated so that invalid escapes are rejected as invalid JSON
-	# (even inside skipped strings).
+	# Walk the string's bytes in place, consuming each escape atomically, until the
+	# closing quote. Every escape must be validated so that invalid escapes are
+	# rejected as invalid JSON (even inside skipped strings).
 	while $index < len {
-		byte = list_get_unsafe(bytes, $index)
+		byte = str_get_utf8_byte_unsafe(tail, $index)
 		match byte {
 			# Because we consume escapes atomically, if we hit a quote we know that it's the end
 			# of the string.
 			'"' => {
-				raw = match Str.from_utf8(List.take_first(bytes, $index)) {
-					Ok(body) => body
-					# unreachable: the split point is an ASCII quote, so the prefix is always valid UTF-8
-					Err(_) => {
-						crash "Json scanner invariant violated: split at a quote was not valid UTF-8"
-					}
-				}
-
-				# Str has no index-based slicing, so recover `after` by dropping the
-				# body (a content-matched prefix of `tail`) and then the closing
-				# quote — both zero-copy slice operations.
-				after = Str.drop_prefix(Str.drop_prefix(tail, raw), "\"")
+				# The quote is ASCII, so both cut points are UTF-8 boundaries and the
+				# slices are valid strings; slicing past the quote also skips it.
+				raw = str_substring_unsafe(tail, 0, $index)
+				after = str_drop_first_bytes_unsafe(tail, $index + 1)
 
 				return Ok({ after, body: if $had_escape HasEscapes(raw) else NoEscapes(raw) })
 			}
@@ -21550,10 +21541,10 @@ scan_json_string_tail = |tail| {
 			# escape sequence atomically
 			'\\' => {
 				$had_escape = True
-				escape = parse_json_escape_sequence(List.drop_first(bytes, $index + 1))?
-				$index = $index + 1 + escape.consumed
+				escape = parse_json_escaped_code_point(tail, $index)?
+				$index = $index + escape.consumed
 			}
-			# For any other character besides a quote or a backslash, we continue.
+			# For any other byte besides a quote or a backslash, we continue.
 			_ => {
 				# JSON requires U+0000 through U+001F to be escaped inside strings.
 				if byte < 32 {
@@ -21580,20 +21571,23 @@ skip_json_string_tail = |tail| {
 
 ## Decode a JSON string body: walk it, mapping each escape sequence to its code point and
 ## copying everything else.
+##
+## The scan already validated every escape, so decoding re-parses them. This double
+## parse is deliberate: it keeps scanning allocation-free, and skipped strings and
+## clean strings never decode at all.
 decode_json_string_body : Str -> Try(Str, [InvalidJson(Str), ..])
 decode_json_string_body = |raw| {
-	bytes = Str.to_utf8(raw)
-	len = List.len(bytes)
+	len = Str.count_utf8_bytes(raw)
 	var $out = u8_list_reserve([], len)
 	var $index = 0
 
 	while $index < len {
-		byte = list_get_unsafe(bytes, $index)
+		byte = str_get_utf8_byte_unsafe(raw, $index)
 		match byte {
 			'\\' => {
-				escape = parse_json_escape_sequence(List.drop_first(bytes, $index + 1))?
+				escape = parse_json_escaped_code_point(raw, $index)?
 				$out = append_utf8_code_point($out, escape.code_point)
-				$index = $index + 1 + escape.consumed
+				$index = $index + escape.consumed
 			}
 			_ => {
 				$out = u8_append($out, byte)
@@ -21612,49 +21606,84 @@ decode_json_string_body = |raw| {
 	}
 }
 
-## Parse one JSON escape sequence. `rest` is expected to hold the bytes after a backslash.
-## Every JSON escape denotes exactly one code point (surrogate pairs combine into one), so
-## this returns that code point plus the number of bytes consumed from `rest`.
-parse_json_escape_sequence : List(U8) -> Try({ code_point : U64, consumed : U64 }, [InvalidJson(Str), ..])
-parse_json_escape_sequence = |rest| match rest {
-	['"', ..] => Ok({ code_point: '"', consumed: 1 })
-	['\\', ..] => Ok({ code_point: '\\', consumed: 1 })
-	['/', ..] => Ok({ code_point: '/', consumed: 1 })
-	# backspace
-	['b', ..] => Ok({ code_point: 8, consumed: 1 })
-	# form feed
-	['f', ..] => Ok({ code_point: 12, consumed: 1 })
-	# newline
-	['n', ..] => Ok({ code_point: 10, consumed: 1 })
-	# carriage return
-	['r', ..] => Ok({ code_point: 13, consumed: 1 })
-	# tab
-	['t', ..] => Ok({ code_point: 9, consumed: 1 })
-	# \uXXXX names a UTF-16 code unit, not a code point, so surrogates may need pairing
-	['u', h0, h1, h2, h3, .. as tail] => {
-		unit = decode_json_hex4(h0, h1, h2, h3)?
-		if unit >= 55296 and unit <= 56319 {
-			# high surrogate (U+D800..U+DBFF): a \uDC00..\uDFFF escape must follow
-			match tail {
-				['\\', 'u', h4, h5, h6, h7, ..] => {
-					low = decode_json_hex4(h4, h5, h6, h7)?
-					if low >= 56320 and low <= 57343 {
-						Ok({ code_point: 65536 + (unit - 55296) * 1024 + (low - 56320), consumed: 11 })
-					} else {
-						Err(Json.invalid_json)
-					}
-				}
-				_ => Err(Json.invalid_json)
-			}
-		} else if unit >= 56320 and unit <= 57343 {
-			# unpaired low surrogate (U+DC00..U+DFFF)
-			Err(Json.invalid_json)
-		} else {
-			Ok({ code_point: unit, consumed: 5 })
-		}
+## Parse one escaped character from string `s`, starting at byte `index`.
+##
+## `index` is expected (but not verified) to be the index of the `\` character that starts
+## the escape. (Note that we index into `s`, rather than taking a slice and starting at 0,
+## because the latter was found to be slower empirically.)
+##
+## Returns the character's code point and the number of bytes consumed, which could be:
+##   2, for simple sequences like `\n`
+##   6, for characters represented by a single UTF-16 code unit, like `\u00E9` (é)
+##  12, for characters represented by a pair of UTF-16 code units, like `\uD83D\uDE00` (😀)
+##
+## Each branch checks the length before reading; the three checks mirror the three sizes
+## above.
+parse_json_escaped_code_point : Str, U64 -> Try({ code_point : U64, consumed : U64 }, [InvalidJson(Str), ..])
+parse_json_escaped_code_point = |s, index| {
+	len = Str.count_utf8_bytes(s)
+	if index + 2 > len {
+		# the backslash ends the input: a truncated escape
+		return Err(Json.invalid_json)
 	}
-	# truncated or unknown escape
-	_ => Err(Json.invalid_json)
+
+	match str_get_utf8_byte_unsafe(s, index + 1) {
+		'"' => Ok({ code_point: '"', consumed: 2 })
+		'\\' => Ok({ code_point: '\\', consumed: 2 })
+		'/' => Ok({ code_point: '/', consumed: 2 })
+		# backspace
+		'b' => Ok({ code_point: 8, consumed: 2 })
+		# form feed
+		'f' => Ok({ code_point: 12, consumed: 2 })
+		# newline
+		'n' => Ok({ code_point: 10, consumed: 2 })
+		# carriage return
+		'r' => Ok({ code_point: 13, consumed: 2 })
+		# tab
+		't' => Ok({ code_point: 9, consumed: 2 })
+		# the four hex digits name a UTF-16 code unit
+		'u' => {
+			if index + 6 > len {
+				# truncated \uXXXX escape
+				return Err(Json.invalid_json)
+			}
+			unit = decode_json_hex4(
+				str_get_utf8_byte_unsafe(s, index + 2),
+				str_get_utf8_byte_unsafe(s, index + 3),
+				str_get_utf8_byte_unsafe(s, index + 4),
+				str_get_utf8_byte_unsafe(s, index + 5),
+			)?
+			if unit >= 0xD800 and unit <= 0xDBFF {
+				# a high surrogate (U+D800..U+DBFF) merges with the low
+				# surrogate escape that must follow
+				if index + 12 > len {
+					return Err(Json.invalid_json)
+				}
+				if str_get_utf8_byte_unsafe(s, index + 6) != '\\' or str_get_utf8_byte_unsafe(s, index + 7) != 'u' {
+					return Err(Json.invalid_json)
+				}
+				low = decode_json_hex4(
+					str_get_utf8_byte_unsafe(s, index + 8),
+					str_get_utf8_byte_unsafe(s, index + 9),
+					str_get_utf8_byte_unsafe(s, index + 10),
+					str_get_utf8_byte_unsafe(s, index + 11),
+				)?
+				if low >= 0xDC00 and low <= 0xDFFF {
+					Ok({ code_point: 0x10000 + (unit - 0xD800) * 0x400 + (low - 0xDC00), consumed: 12 })
+				} else {
+					Err(Json.invalid_json)
+				}
+			} else if unit >= 0xDC00 and unit <= 0xDFFF {
+				# unpaired low surrogate (U+DC00..U+DFFF)
+				Err(Json.invalid_json)
+			} else {
+				# a BMP code unit already is the code point
+				Ok({ code_point: unit, consumed: 6 })
+			}
+		}
+		# unknown escape
+		_ => Err(Json.invalid_json)
+	}
 }
 
 ## Combine 4 hex-digit bytes (as in \uXXXX) into their numeric value.

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -21545,7 +21545,7 @@ scan_json_string_tail = |tail| {
 			_ => {
 				# JSON requires U+0000 through U+001F to be escaped inside strings.
 				if byte < 32 {
-					return Err(Json.invalid_json)
+					return Err(InvalidJson("unescaped control character in string"))
 				} else {
 					$index = $index + 1
 				}
@@ -21554,7 +21554,7 @@ scan_json_string_tail = |tail| {
 	}
 
 	# no unescaped closing quote anywhere: the string is unterminated
-	Err(Json.invalid_json)
+	Err(InvalidJson("unterminated string"))
 }
 
 ## Find the end of a JSON string, for skipped values whose content is discarded.
@@ -21621,7 +21621,7 @@ parse_json_escaped_code_point = |s, index| {
 	len = Str.count_utf8_bytes(s)
 	if index + 2 > len {
 		# the backslash ends the input: a truncated escape
-		return Err(Json.invalid_json)
+		return Err(InvalidJson("truncated escape"))
 	}
 
 	match str_get_utf8_byte_unsafe(s, index + 1) {
@@ -21642,7 +21642,7 @@ parse_json_escaped_code_point = |s, index| {
 		'u' => {
 			if index + 6 > len {
 				# truncated \uXXXX escape
-				return Err(Json.invalid_json)
+				return Err(InvalidJson("truncated \\uXXXX escape"))
 			}
 			unit = decode_json_hex4(
 				str_get_utf8_byte_unsafe(s, index + 2),
@@ -21654,10 +21654,10 @@ parse_json_escaped_code_point = |s, index| {
 				# a high surrogate (U+D800..U+DBFF) merges with the low
 				# surrogate escape that must follow
 				if index + 12 > len {
-					return Err(Json.invalid_json)
+					return Err(InvalidJson("high surrogate escape not followed by a low surrogate escape"))
 				}
 				if str_get_utf8_byte_unsafe(s, index + 6) != '\\' or str_get_utf8_byte_unsafe(s, index + 7) != 'u' {
-					return Err(Json.invalid_json)
+					return Err(InvalidJson("high surrogate escape not followed by a low surrogate escape"))
 				}
 				low = decode_json_hex4(
 					str_get_utf8_byte_unsafe(s, index + 8),
@@ -21668,18 +21668,18 @@ parse_json_escaped_code_point = |s, index| {
 				if low >= 0xDC00 and low <= 0xDFFF {
 					Ok({ code_point: 0x10000 + (unit - 0xD800) * 0x400 + (low - 0xDC00), consumed: 12 })
 				} else {
-					Err(Json.invalid_json)
+					Err(InvalidJson("high surrogate escape not followed by a low surrogate escape"))
 				}
 			} else if unit >= 0xDC00 and unit <= 0xDFFF {
 				# unpaired low surrogate (U+DC00..U+DFFF)
-				Err(Json.invalid_json)
+				Err(InvalidJson("unpaired low surrogate escape"))
 			} else {
 				# a BMP code unit already is the code point
 				Ok({ code_point: unit, consumed: 6 })
 			}
 		}
 		# unknown escape
-		_ => Err(Json.invalid_json)
+		_ => Err(InvalidJson("unknown escape character"))
 	}
 }
 
@@ -21695,7 +21695,9 @@ decode_json_hex4 = |b0, b1, b2, b3| {
 
 decode_json_hex_digit : U8 -> Try(U64, [InvalidJson(Str), ..])
 decode_json_hex_digit = |byte|
-	hex_digit_value(byte).map_ok(|value| value.to_u64()).map_err(|_| Json.invalid_json)
+	hex_digit_value(byte)
+		.map_ok(|value| value.to_u64())
+		.map_err(|_| InvalidJson("invalid hex digit in \\uXXXX escape"))
 
 ## JSON whitespace per RFC 8259: space, tab, `\n`, or `\r`.
 is_json_whitespace : U8 -> Bool

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -1297,12 +1297,8 @@ Builtin :: [].{
 								crash "Json scalar splitter invariant violated: ASCII delimiter was not a UTF-8 boundary"
 							}
 						}
-						after = match Str.drop_first_bytes(raw, $index) {
-							Ok(v) => v
-							Err(BadUtf8) => {
-								crash "Json scalar splitter invariant violated: ASCII delimiter was not a UTF-8 boundary"
-							}
-						}
+						# the cut is at an ASCII delimiter, so it is a UTF-8 boundary
+						after = str_drop_first_bytes_unsafe(raw, $index)
 						Ok({ value, after })
 					}
 				} else if $index == 0 {
@@ -21726,12 +21722,8 @@ json_trim_start = |s| {
 	if $index == 0 {
 		s
 	} else {
-		match Str.drop_first_bytes(s, $index) {
-			Ok(trimmed) => trimmed
-			Err(BadUtf8) => {
-				crash "json_trim_start invariant violated: ASCII whitespace ended inside UTF-8"
-			}
-		}
+		# the dropped prefix is ASCII whitespace, so the cut is a UTF-8 boundary
+		str_drop_first_bytes_unsafe(s, $index)
 	}
 }
 

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -421,7 +421,7 @@ Builtin :: [].{
 					if trimmed.point > 21 or trimmed.point < -18 {
 						Err(BadNumStr)
 					} else {
-						normalized = Json.normalize_json_dec_digits(negative, trimmed.digits, trimmed.digits_len, trimmed.point)?
+						normalized = Json.normalize_json_dec_digits(negative, trimmed.digits, trimmed.point)?
 						dec_from_str(normalized)
 					}
 				}
@@ -429,9 +429,7 @@ Builtin :: [].{
 
 			json_dec_digits_are_zero : Str -> Bool
 			json_dec_digits_are_zero = |digits| {
-				bytes = Str.to_utf8(digits)
-
-				for byte in bytes {
+				for byte in Str.iter_utf8(digits) {
 					if byte != 48 {
 						return False
 					}
@@ -440,25 +438,24 @@ Builtin :: [].{
 				True
 			}
 
-			trim_json_dec_leading_zeros : Str, I64 -> { digits : Str, digits_len : U64, point : I64 }
+			trim_json_dec_leading_zeros : Str, I64 -> { digits : Str, point : I64 }
 			trim_json_dec_leading_zeros = |digits, point| {
-				bytes = Str.to_utf8(digits)
-				len = List.len(bytes)
+				len = Str.count_utf8_bytes(digits)
 				var $index = 0
 
-				while $index < len and list_get_unsafe(bytes, $index) == 48 {
+				while $index < len and str_get_utf8_byte_unsafe(digits, $index) == 48 {
 					$index = $index + 1
 				}
 
 				{
-					digits: Str.from_utf8_lossy(List.drop_first(bytes, $index)),
-					digits_len: len - $index,
+					# the dropped prefix is ASCII zeros, so the cut is a UTF-8 boundary
+					digits: str_drop_first_bytes_unsafe(digits, $index),
 					point: point - $index.to_i64_wrap(),
 				}
 			}
 
-			normalize_json_dec_digits : Bool, Str, U64, I64 -> Try(Str, [BadNumStr])
-			normalize_json_dec_digits = |negative, digits, digits_len, point| {
+			normalize_json_dec_digits : Bool, Str, I64 -> Try(Str, [BadNumStr])
+			normalize_json_dec_digits = |negative, digits, point| {
 				sign = if negative "-" else ""
 
 				if point <= 0 {
@@ -472,14 +469,15 @@ Builtin :: [].{
 					)
 				} else {
 					point_u64 = point.to_u64_wrap()
+					digits_len = Str.count_utf8_bytes(digits)
 
 					if point_u64 >= digits_len {
 						zero_count = point_u64 - digits_len
 						Ok(Str.concat(sign, Str.concat(digits, Str.repeat("0", zero_count))))
 					} else {
-						bytes = Str.to_utf8(digits)
-						before = Str.from_utf8_lossy(List.take_first(bytes, point_u64))
-						after = Str.from_utf8_lossy(List.drop_first(bytes, point_u64))
+						# digits holds only ASCII digits, so any cut is a UTF-8 boundary
+						before = str_substring_unsafe(digits, 0, point_u64)
+						after = str_drop_first_bytes_unsafe(digits, point_u64)
 
 						Ok(Str.concat(sign, Str.concat(before, Str.concat(".", after))))
 					}
@@ -1072,8 +1070,7 @@ Builtin :: [].{
 
 			is_json_number : Str -> Bool
 			is_json_number = |value| {
-				bytes = Str.to_utf8(value)
-				len = List.len(bytes)
+				len = Str.count_utf8_bytes(value)
 
 				if len == 0 {
 					return False
@@ -1081,7 +1078,7 @@ Builtin :: [].{
 
 				var $index = 0
 
-				first = list_get_unsafe(bytes, $index)
+				first = str_get_utf8_byte_unsafe(value, $index)
 
 				if first == 45 {
 					$index = $index + 1
@@ -1091,7 +1088,7 @@ Builtin :: [].{
 					}
 				}
 
-				int_first = list_get_unsafe(bytes, $index)
+				int_first = str_get_utf8_byte_unsafe(value, $index)
 
 				if int_first == 48 {
 					$index = $index + 1
@@ -1099,7 +1096,7 @@ Builtin :: [].{
 					$index = $index + 1
 
 					while $index < len {
-						byte = list_get_unsafe(bytes, $index)
+						byte = str_get_utf8_byte_unsafe(value, $index)
 
 						if Json.is_json_digit(byte) {
 							$index = $index + 1
@@ -1112,7 +1109,7 @@ Builtin :: [].{
 				}
 
 				if $index < len {
-					byte = list_get_unsafe(bytes, $index)
+					byte = str_get_utf8_byte_unsafe(value, $index)
 
 					if byte == 46 {
 						$index = $index + 1
@@ -1121,14 +1118,14 @@ Builtin :: [].{
 							return False
 						}
 
-						first_fraction_byte = list_get_unsafe(bytes, $index)
+						first_fraction_byte = str_get_utf8_byte_unsafe(value, $index)
 
 						if !Json.is_json_digit(first_fraction_byte) {
 							return False
 						}
 
 						while $index < len {
-							fraction_byte = list_get_unsafe(bytes, $index)
+							fraction_byte = str_get_utf8_byte_unsafe(value, $index)
 
 							if Json.is_json_digit(fraction_byte) {
 								$index = $index + 1
@@ -1140,7 +1137,7 @@ Builtin :: [].{
 				}
 
 				if $index < len {
-					byte = list_get_unsafe(bytes, $index)
+					byte = str_get_utf8_byte_unsafe(value, $index)
 
 					if Json.is_json_exponent_marker(byte) {
 						$index = $index + 1
@@ -1149,7 +1146,7 @@ Builtin :: [].{
 							return False
 						}
 
-						exponent_first_byte = list_get_unsafe(bytes, $index)
+						exponent_first_byte = str_get_utf8_byte_unsafe(value, $index)
 
 						if Json.is_json_sign(exponent_first_byte) {
 							$index = $index + 1
@@ -1159,14 +1156,14 @@ Builtin :: [].{
 							}
 						}
 
-						first_exponent_digit = list_get_unsafe(bytes, $index)
+						first_exponent_digit = str_get_utf8_byte_unsafe(value, $index)
 
 						if !Json.is_json_digit(first_exponent_digit) {
 							return False
 						}
 
 						while $index < len {
-							exponent_byte = list_get_unsafe(bytes, $index)
+							exponent_byte = str_get_utf8_byte_unsafe(value, $index)
 
 							if Json.is_json_digit(exponent_byte) {
 								$index = $index + 1

--- a/test/alloc-count/app.roc
+++ b/test/alloc-count/app.roc
@@ -31,6 +31,7 @@ run! = |input| {
 	check_large_to_utf8_allocs!(large)
 	check_drop_allocs!(large)
 	check_rejected_drop_allocs!(multibyte)
+	check_json_parse_allocs!(input)
 
     "sum: ${$sum.to_str()}, loop allocations: ${loop_allocs.to_str()}"
 }
@@ -68,6 +69,36 @@ check_drop_allocs! = |str| {
 	last_allocs = Host.alloc_count!() - last_before
 	expect last_allocs == 0
 	expect last == Ok(Str.drop_suffix(str, "t"))
+	{}
+}
+
+# Parsing a small (SSO) JSON document whose string fields are clean (no escapes)
+# performs zero allocations, whether the string field is decoded or skipped: the
+# scanner walks the Str in place and clean bodies decode as zero-copy slices.
+check_json_parse_allocs! : Str => {}
+check_json_parse_allocs! = |input| {
+	# first two bytes of the hosted input, so the document is runtime data
+	two = match Str.drop_last_bytes(input, Str.count_utf8_bytes(input) - 2) {
+		Ok(s) => s
+		Err(_) => {
+			crash "alloc-count harness invariant violated: input shorter than 2 bytes"
+		}
+	}
+	doc = Str.concat("{\"s\":\"", Str.concat(two, "\",\"a\":7}"))
+
+	decode_before = Host.alloc_count!()
+	decoded : Try({ s : Str, a : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
+	decoded = Json.parse(doc)
+	decode_allocs = Host.alloc_count!() - decode_before
+	expect decode_allocs == 0
+	expect decoded == Ok({ s: two, a: 7 })
+
+	skip_before = Host.alloc_count!()
+	skipped : Try({ a : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
+	skipped = Json.parse(doc)
+	skip_allocs = Host.alloc_count!() - skip_before
+	expect skip_allocs == 0
+	expect skipped == Ok({ a: 7 })
 	{}
 }
 

--- a/test/alloc-count/app.roc
+++ b/test/alloc-count/app.roc
@@ -99,6 +99,15 @@ check_json_parse_allocs! = |input| {
 	skip_allocs = Host.alloc_count!() - skip_before
 	expect skip_allocs == 0
 	expect skipped == Ok({ a: 7 })
+
+	# a skipped numeric field: scalar validation must not allocate either
+	num_doc = Str.concat("{\"z\":", Str.concat(Str.repeat("7", 1 + Str.count_utf8_bytes(input) % 3), ",\"a\":1}"))
+	skip_num_before = Host.alloc_count!()
+	skipped_num : Try({ a : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
+	skipped_num = Json.parse(num_doc)
+	skip_num_allocs = Host.alloc_count!() - skip_num_before
+	expect skip_num_allocs == 0
+	expect skipped_num == Ok({ a: 1 })
 	{}
 }
 

--- a/test/cli/JsonStringEscapes.roc
+++ b/test/cli/JsonStringEscapes.roc
@@ -551,3 +551,32 @@ expect {
 
 	round_tripped == Ok(original)
 }
+
+# the maximum code point (U+10FFFF) arrives as the highest surrogate pair
+expect {
+	result : Try(Str, [InvalidJson(Str)])
+	result = Json.parse("\"\\uDBFF\\uDFFF\"")
+
+	expected = Str.from_utf8([244, 143, 191, 191])
+
+	match (result, expected) {
+		(Ok(parsed), Ok(want)) => parsed == want
+		_ => False
+	}
+}
+
+# a surrogate pair truncated inside its second escape is rejected
+expect {
+	result : Try(Str, [InvalidJson(Str)])
+	result = Json.parse("\"\\uD83D\\uDE\"")
+
+	result == Err(Json.invalid_json)
+}
+
+# a high surrogate followed by literal characters is rejected
+expect {
+	result : Try(Str, [InvalidJson(Str)])
+	result = Json.parse("\"\\uD83Dxy\"")
+
+	result == Err(Json.invalid_json)
+}

--- a/test/cli/JsonStringEscapes.roc
+++ b/test/cli/JsonStringEscapes.roc
@@ -95,7 +95,7 @@ expect {
 		Err(_) => Err(Json.invalid_json)
 	}
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("unescaped control character in string"))
 }
 
 # the control-character boundaries: raw 0x00 and raw 0x1F are both rejected
@@ -108,7 +108,7 @@ expect {
 		Err(_) => Err(Json.invalid_json)
 	}
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("unescaped control character in string"))
 }
 
 expect {
@@ -120,7 +120,7 @@ expect {
 		Err(_) => Err(Json.invalid_json)
 	}
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("unescaped control character in string"))
 }
 
 # raw DEL (0x7F) is just past the control range and is valid unescaped
@@ -145,7 +145,7 @@ expect {
 	result : Try({ s : Str }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"s\": \"a\\xb\"}")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("unknown escape character"))
 }
 
 # input ends on a backslash
@@ -153,15 +153,16 @@ expect {
 	result : Try(Str, [InvalidJson(Str)])
 	result = Json.parse("\"a\\")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("truncated escape"))
 }
 
-# incomplete \u escape
+# a \u escape whose hex digits run past the closing quote: the scanner has no way
+# to know the string ended, so it reads the quote as a hex digit and rejects it
 expect {
 	result : Try({ s : Str }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"s\": \"a\\u12\"}")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("invalid hex digit in \\uXXXX escape"))
 }
 
 # non-hex digits in \u escape
@@ -169,7 +170,7 @@ expect {
 	result : Try({ s : Str }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"s\": \"a\\uZZZZ\"}")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("invalid hex digit in \\uXXXX escape"))
 }
 
 # unpaired high surrogate
@@ -177,7 +178,7 @@ expect {
 	result : Try({ s : Str }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"s\": \"a\\uD83Db\"}")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("high surrogate escape not followed by a low surrogate escape"))
 }
 
 # unpaired low surrogate
@@ -185,7 +186,7 @@ expect {
 	result : Try({ s : Str }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"s\": \"a\\uDE00b\"}")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("unpaired low surrogate escape"))
 }
 
 # --- escapes beyond top-level string values ---
@@ -252,7 +253,7 @@ expect {
 	result : Try(Str, [InvalidJson(Str)])
 	result = Json.parse("\"abc\\\"")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("unterminated string"))
 }
 
 # a realistic API-response payload: escaped newlines in body text, quotes in
@@ -344,7 +345,7 @@ expect {
 	result : Try({ a : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"skip\":{\"deep\":[\"ok\",\"bad\\qx\"]},\"a\":7}")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("unknown escape character"))
 }
 
 # a raw control byte inside a skipped string is still rejected
@@ -359,7 +360,7 @@ expect {
 		Err(_) => Err(Json.invalid_json)
 	}
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("unescaped control character in string"))
 }
 
 # unterminated skipped string
@@ -367,7 +368,7 @@ expect {
 	result : Try({ a : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"a\":7,\"skip\":\"abc")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("unterminated string"))
 }
 
 # skipped string ending in a lone backslash at end of input
@@ -375,7 +376,7 @@ expect {
 	result : Try({ a : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"a\":7,\"skip\":\"abc\\")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("truncated escape"))
 }
 
 # invalid escapes rejected in skipped positions, mirroring the value cases
@@ -383,35 +384,35 @@ expect {
 	result : Try({ a : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"skip\":\"a\\xb\",\"a\":7}")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("unknown escape character"))
 }
 
 expect {
 	result : Try({ a : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"skip\":\"a\\u12z\",\"a\":7}")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("invalid hex digit in \\uXXXX escape"))
 }
 
 expect {
 	result : Try({ a : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"skip\":\"a\\uZZZZ\",\"a\":7}")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("invalid hex digit in \\uXXXX escape"))
 }
 
 expect {
 	result : Try({ a : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"skip\":\"a\\uD83Db\",\"a\":7}")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("high surrogate escape not followed by a low surrogate escape"))
 }
 
 expect {
 	result : Try({ a : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
 	result = Json.parse("{\"skip\":\"a\\uDE00b\",\"a\":7}")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("unpaired low surrogate escape"))
 }
 
 # escaped key on a skipped nested object (the skip_json_object key site)
@@ -429,7 +430,7 @@ expect {
 	result : Try(Str, [InvalidJson(Str)])
 	result = Json.parse("\"\\uD83D")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("high surrogate escape not followed by a low surrogate escape"))
 }
 
 # high surrogate followed by a \u escape that is not a low surrogate
@@ -437,7 +438,7 @@ expect {
 	result : Try(Str, [InvalidJson(Str)])
 	result = Json.parse("\"\\uD83D\\u0041\"")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("high surrogate escape not followed by a low surrogate escape"))
 }
 
 # input truncated in the middle of \u hex digits
@@ -445,7 +446,7 @@ expect {
 	result : Try(Str, [InvalidJson(Str)])
 	result = Json.parse("\"\\u12")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("truncated \\uXXXX escape"))
 }
 
 # --- UTF-8 encoding tier boundaries ---
@@ -570,7 +571,7 @@ expect {
 	result : Try(Str, [InvalidJson(Str)])
 	result = Json.parse("\"\\uD83D\\uDE\"")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("high surrogate escape not followed by a low surrogate escape"))
 }
 
 # a high surrogate followed by literal characters is rejected
@@ -578,5 +579,5 @@ expect {
 	result : Try(Str, [InvalidJson(Str)])
 	result = Json.parse("\"\\uD83Dxy\"")
 
-	result == Err(Json.invalid_json)
+	result == Err(InvalidJson("high surrogate escape not followed by a low surrogate escape"))
 }


### PR DESCRIPTION
This PR makes several changes to JSON parsing:

1. Takes advantage of the helper functions added in [#10173](https://github.com/roc-lang/roc/pull/10173) (`str_get_utf8_byte_unsafe`, `str_substring_unsafe`, and `Str.iter_utf8`) to walk strings and scalars in place rather than converting them into `List(U8)` byte lists. Every unchecked read sits under a bounds check, and every slice cut lands on an ASCII byte, so indices stay in range and on UTF-8 boundaries.
2. Uses two O(1) calls to `str_substring_unsafe` to split off a scanned string from the rest of the document. The old path made three passes over the body to do the same thing: `List.take_first` to copy it, `Str.from_utf8` to revalidate it, and `Str.drop_prefix` to find where it ended.
3. Replaces the generic `Json.invalid_json` in string parsing with specific messages like "unterminated string", using [#10250](https://github.com/roc-lang/roc/pull/10250)'s new `InvalidJson` payload. Each message has a test. The same documents are accepted and rejected as before; only the message text changes.
4. Splits out and reuses a `str_drop_first_bytes_unsafe` helper function from `Str.drop_first_bytes`.
5. Uses that helper for the two remaining cuts, at leading whitespace and at scalar delimiters. Both cut points are ASCII, so the checked versions could never fail.

Together these make parsing 11–28% faster (see Benchmarks section below). Additionally, we were able to reduce the number of heap allocations required in a variety of situations (see Allocations section below).

## Benchmarks

Each run parses the document 20,000 times, decoding one string field and skipping all the others. The table shows interleaved medians for this branch vs `main`, built with `roc build --opt=speed` on macOS arm64. The harness, corpora, and raw runs are in [this gist](https://gist.github.com/ESRogs/6e60c4d37e47f9b51baea1ba0dfcead5).

| document | base | this&nbsp;PR | change |
|---|---|---|---|
| 500 short string fields | 1.22 s | 0.88 s | -28% |
| 3 × 4.9 KB string fields | 0.18 s | 0.16 s | -11% |
| 300 escape-bearing fields (validated but skipped) | 0.97 s | 0.72 s | -26% |
| 500 numeric fields (validated but skipped) | 1.22 s | 1.01 s | -17% |

Every document was measured both pretty-printed and minified. The percentages agree to within half a point, so the speedup does not depend on how the input is formatted.

## Allocations

Previously, JSON parsing converted `Str` to `List(U8)` in a bunch of places, and that resulted in allocations whenever the `Str` representing the JSON document had been inlined, since the `List(U8)` has to live on the heap. The cutoff for that inlining appears to be at 23 bytes. So the status quo before this PR is a bunch of extra allocations when parsing tiny documents, but — perhaps paradoxically — not when parsing documents of 24 bytes or more.

Additionally, parsing `Dec` values with exponents also previously resulted in allocations, because the parsing code converted the mantissa digits into a `List(U8)` in multiple places, which each required an allocation.

With this PR, we remove all those `Str` to `List(U8)` conversions, so tiny inlined documents can stay inlined, and don't need to be materialized to the heap anywhere (except in cases where that's actually required in order to build the output, like decoding escaped strings). And `Dec` parsing no longer allocates either (with one exception; see Follow-ups section below).

The table below shows the situation before and after this PR. It was generated using the alloc-count test platform. Each path parses a document holding a single field of the given type, measured once at a size that's inlined and once above the inlining limit. Documents are built at runtime so they are not evaluated at compile time. The probe and its raw output are in [this gist](https://gist.github.com/ESRogs/7c6a532cc58f53cc7fb933d481c79ccc).

| path | base,&nbsp;≤23&nbsp;B | base,&nbsp;≥24&nbsp;B | this&nbsp;PR | note |
|---|---|---|---|---|
| clean string field | 4 | 0 | 0 | |
| escaped string field | 5 | 1 | 1 | the decoded output |
| `\uXXXX` string field | 5 | 1 | 1 | the decoded output |
| integer field, `U8` through `I64` | 3 | 0 | 0 | |
| `Dec` field, no exponent | 4 | 0 | 0 | |
| `Dec` field with an exponent | 6 | 2 | 0 | base converts the mantissa digits, inline at any document size |
| `F32` or `F64` field | 4 | 0 | 0 | |
| `Bool` or `null` field | 3 | 0 | 0 | |
| nested record | 4 | 0 | 0 | |
| list of numbers | 4 | 1 | 1 | the output list |
| list of strings | 6 | 1 | 1 | the output list |
| skipped scalar or string | 4 | 0 | 0 | |
| skipped object or array | 5–6 | 0 | 0 | |
| rejected document | 1 | 0 | 0 | |

## Test changes

- Adds three escape edge-case tests: the maximum code point (U+10FFFF) as a surrogate pair, a pair truncated inside its second escape, and a lone high surrogate before literal characters.
- Updates 22 rejection tests to pin the new error messages.
- Adds allocation checks: parsing a small document with clean string fields (decoded or skipped) is expected to perform zero allocations.

## Possible follow-ups

- The new error messages say what went wrong, but not where. Adding a byte position to `InvalidJson` would complete the diagnostics.
- Encoding still converts `Str` to `List(U8)`, so it could get the same treatment as parsing.
- `Dec` parsing still round-trips through a `Str`, so values whose normalized digits exceed 23 bytes allocate once. Removing that needs a way to build a `Dec` from a scaled `I128`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (with a lot of editorial input from ESRogs)




