### PR TITLE
Fix capture-record use-after-free and quadratic dispatch-scope publication

### DIFF
--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -13350,8 +13350,8 @@ fn sealCheckedProcedureTemplateRefs(
     templates.dispatch_ref_scopes = try allocator.dupe(DispatchScopeRef, dispatch_ref_scope_pool.items);
     templates.dispatch_relation_kinds = try dispatch_relation_kind_pool.toOwnedSlice(allocator);
     templates.dispatch_scopes = try allocator.dupe(DispatchRefScope, collector.scopes.items);
-    publishLocalProcedureDispatchScopes(resolved_value_refs, templates.dispatch_scopes);
-    publishLocalMethodDispatchScopes(method_registry, templates.dispatch_scopes);
+    publishLocalProcedureDispatchScopes(resolved_value_refs, &collector.scope_by_checked_expr);
+    publishLocalMethodDispatchScopes(method_registry, &collector.scope_by_checked_expr);
     template_iterator_refs.* = .{
         .spans = iterator_spans,
         .pool = try iterator_ref_pool.toOwnedSlice(allocator),
@@ -13373,7 +13373,7 @@ fn sealCheckedProcedureTemplateRefs(
 /// scope table rather than by evidence count.
 fn publishLocalProcedureDispatchScopes(
     resolved_value_refs: *ResolvedValueRefTable,
-    scopes: []const DispatchRefScope,
+    scope_by_checked_expr: *const std.AutoHashMap(CheckedExprId, DispatchScopeId),
 ) void {
     for (resolved_value_refs.records) |*record| {
         const local = switch (record.ref) {
@@ -13381,13 +13381,13 @@ fn publishLocalProcedureDispatchScopes(
             else => continue,
         };
 
-        local.dispatch_scope = localProcedureDispatchScope(scopes, local.expr);
+        local.dispatch_scope = scope_by_checked_expr.get(local.expr);
     }
 }
 
 fn publishLocalMethodDispatchScopes(
     method_registry: *static_dispatch.MethodRegistry,
-    scopes: []const DispatchRefScope,
+    scope_by_checked_expr: *const std.AutoHashMap(CheckedExprId, DispatchScopeId),
 ) void {
     for (method_registry.entries) |*entry| {
         const local = switch (entry.target.kind) {
@@ -13395,23 +13395,8 @@ fn publishLocalMethodDispatchScopes(
             else => continue,
         };
 
-        local.dispatch_scope = localProcedureDispatchScope(scopes, local.expr);
+        local.dispatch_scope = scope_by_checked_expr.get(local.expr);
     }
-}
-
-fn localProcedureDispatchScope(
-    scopes: []const DispatchRefScope,
-    expr: CheckedExprId,
-) ?DispatchScopeId {
-    var owned_scope: ?DispatchScopeId = null;
-    for (scopes, 0..) |scope, raw_scope| {
-        if (scope.checked_expr != expr) continue;
-        if (owned_scope != null) {
-            checkedArtifactInvariant("checked local procedure owns more than one dispatch scope", .{});
-        }
-        owned_scope = @enumFromInt(@as(u32, @intCast(raw_scope)));
-    }
-    return owned_scope;
 }
 
 /// Resolve every static-dispatch plan and instantiation-site obligation to an
@@ -28329,8 +28314,10 @@ test "local procedure uses carry exact producer-recorded dispatch scope ownershi
         .scheme_var = @enumFromInt(50),
         .checked_expr = @enumFromInt(30),
     }};
+    var scope_by_checked_expr = try nestedProcScopeMap(std.testing.allocator, &scopes);
+    defer scope_by_checked_expr.deinit();
 
-    publishLocalProcedureDispatchScopes(&refs, &scopes);
+    publishLocalProcedureDispatchScopes(&refs, &scope_by_checked_expr);
 
     try std.testing.expectEqual(
         @as(?DispatchScopeId, testIndexId(DispatchScopeId, 0)),

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -14128,7 +14128,7 @@ const EvidencePass = struct {
             .flex => |flex| return self.resolveVarObligation(resolved.var_, flex.constraints, method, structural_kind, constraint_fn_var, chain, commit_unpinned),
             .rigid => |rigid| return self.resolveVarObligation(resolved.var_, rigid.constraints, method, structural_kind, constraint_fn_var, chain, commit_unpinned),
             .alias, .structure => {
-                if (self.methodOwnerForSourceContent(resolved.var_)) |owner| {
+                if (try self.methodOwnerForSourceContent(resolved.var_)) |owner| {
                     if (self.lookupMethodTargetAcrossViews(owner, method)) |target| {
                         return try self.resolutionForMethodTarget(target, structural_kind, constraint_fn_var);
                     }
@@ -14249,7 +14249,7 @@ const EvidencePass = struct {
     /// The method owner of a settled source var, walking alias content
     /// transparently (the source-var analog of monotype lowering's
     /// dispatch-head read of published type identity).
-    fn methodOwnerForSourceContent(self: *EvidencePass, var_: Var) ?static_dispatch.MethodOwner {
+    fn methodOwnerForSourceContent(self: *EvidencePass, var_: Var) Allocator.Error!?static_dispatch.MethodOwner {
         var current = var_;
         var remaining: u64 = self.types.len();
         while (true) {
@@ -14267,8 +14267,8 @@ const EvidencePass = struct {
                         if (categorizeBuiltinNominal(self.module, self.import_views, nominal)) |builtin_nominal| {
                             if (builtin_nominal == .try_) {
                                 const idents = self.module.identStoreConst();
-                                const module_identity_id = self.names.internModuleIdentity(self.module.moduleEnvConst().moduleIdentityHash(nominal.origin_module)) catch return null;
-                                const type_name = self.names.internTypeIdent(idents, nominal.ident.ident_idx) catch return null;
+                                const module_identity_id = try self.names.internModuleIdentity(self.module.moduleEnvConst().moduleIdentityHash(nominal.origin_module));
+                                const type_name = try self.names.internTypeIdent(idents, nominal.ident.ident_idx);
                                 return .{ .nominal = .{
                                     .module = module_identity_id,
                                     .type_name = type_name,
@@ -14278,8 +14278,8 @@ const EvidencePass = struct {
                             return .{ .builtin = static_dispatch.builtinOwnerForCheckedBuiltin(builtin_nominal) };
                         }
                         const idents = self.module.identStoreConst();
-                        const module_identity_id = self.names.internModuleIdentity(self.module.moduleEnvConst().moduleIdentityHash(nominal.origin_module)) catch return null;
-                        const type_name = self.names.internTypeIdent(idents, nominal.ident.ident_idx) catch return null;
+                        const module_identity_id = try self.names.internModuleIdentity(self.module.moduleEnvConst().moduleIdentityHash(nominal.origin_module));
+                        const type_name = try self.names.internTypeIdent(idents, nominal.ident.ident_idx);
                         return .{ .nominal = .{
                             .module = module_identity_id,
                             .type_name = type_name,

--- a/src/postcheck/lambda_mono/lower.zig
+++ b/src/postcheck/lambda_mono/lower.zig
@@ -991,7 +991,12 @@ const Lowerer = struct {
         capture_operands: anytype,
         capture_ty: Type.TypeId,
     ) Allocator.Error!Ast.ExprId {
-        const captures = self.captureSpan(capture_span);
+        const captures = try GuardedList.dupe(
+            self.allocator,
+            SolvedType.Capture,
+            self.captureSpan(capture_span),
+        );
+        defer self.allocator.free(captures);
         const fields = switch (self.program.types.get(capture_ty)) {
             .capture_record => |field_span| try GuardedList.dupe(
                 self.allocator,

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -2754,6 +2754,8 @@ const Lowerer = struct {
 
         const field_locals = try self.allocator.alloc(LIR.LocalId, captures.len);
         defer self.allocator.free(field_locals);
+        const field_storage_tys = try self.allocator.alloc(Type.TypeId, captures.len);
+        defer self.allocator.free(field_storage_tys);
 
         const target_is_zst = self.isZstLocal(target);
         // Member captures, capture-record fields, and keyed operands are all in
@@ -2767,6 +2769,7 @@ const Lowerer = struct {
             }
             const capture_id = capture.capture_id orelse Common.invariant("member capture had no CaptureId");
             if (operand.id != capture_id) Common.invariant("capture operand CaptureId did not match its member capture slot");
+            field_storage_tys[i] = field.storage_ty;
             if (target_is_zst) {
                 field_locals[i] = try self.addTemp(field.storage_ty);
                 continue;
@@ -2787,8 +2790,7 @@ const Lowerer = struct {
         var i = captures.len;
         while (i > 0) {
             i -= 1;
-            const field = GuardedList.at(fields, i);
-            current = try self.lowerExprIntoAtType(field_locals[i], GuardedList.at(capture_operands, i).value, field.storage_ty, current);
+            current = try self.lowerExprIntoAtType(field_locals[i], GuardedList.at(capture_operands, i).value, field_storage_tys[i], current);
         }
         return current;
     }


### PR DESCRIPTION
Follow-up to #10259 addressing issues found while reviewing that PR: two use-after-free bugs in capture-record lowering, a quadratic dispatch-scope publication scan, and an out-of-memory path that was swallowed as a valid result.

Both capture-record constructors borrowed a capture span from a growable store and then held it across expression lowering that appends to that same store. In `buildCaptureRecordFromExprs` the `captures` slice into `own_captures` dangled once a nested capturing operand grew the list, a stale read in every build mode. In `lowerCaptureRecordFromCaptureExprsInto` the `fields` borrow into `capture_fields` dangled when `lowerExprIntoAtType` grew that store; the guarded-list generation check caught it in Debug, but Release read a stale `storage_ty`. Both now snapshot the data they need before lowering.

`publishLocalProcedureDispatchScopes` and `publishLocalMethodDispatchScopes` resolved each value-ref and method-registry entry by linearly scanning every recorded dispatch scope. They now use the `checked_expr -> scope` map the collector already maintains, turning O(entries * scopes) publication into O(entries + scopes).

Finally, `methodOwnerForSourceContent` interned module and type identities with `catch return null`, reporting an allocation failure as an absent method owner; it now propagates `Allocator.Error`.