### PR TITLE
Reject nominal values as constructor backings

### DIFF
--- a/design.md
+++ b/design.md
@@ -1164,6 +1164,36 @@ alias arguments, but references to the annotated value consume the annotation
 root. This is how alias spelling from annotations is preserved without making
 alias roots union-find representatives for concrete structures.
 
+## Nominal Constructor Backing Relation
+
+An explicit nominal constructor chooses the nominal wrapper itself. Its operand
+is checked against the declaration's instantiated backing through the dedicated
+`nominal_constructor_backing` root relation, not through unrestricted ordinary
+unification.
+
+At that root, the relation cannot be satisfied by implicitly lifting an already
+nominal actual value through an anonymous expected backing. For example, if
+`Wrap` has backing `{ a : U8, b : U8 }`, then `Wrap.{ ..wrap, a: 1 }` is rejected
+when the record update has already lifted to `Wrap`; the constructor requires
+its record backing, not another `Wrap`. A constructor whose declared backing is
+itself a named type may still receive that exact named type.
+
+Only the constructor's outer backing pair uses this relation. Once that pair is
+accepted, component pairs use ordinary unification, so a backing record field or
+tag payload may contain an ordinary nominal value and structural values may lift
+there according to the normal language rule. An unconstrained backing parameter
+may likewise resolve to a nominal type; that is substitution of the declaration
+parameter, not an inverse lift through a concrete structural backing.
+
+This rule is implemented inside pure unification as explicit caller-supplied
+relation data. The checker must not probe a solved operand and then mutate or
+poison the graph separately, and Monotype must not repair an invalid checked
+constructor. A rejected root relation produces the existing nominal-constructor
+type mismatch diagnostic. The rejected side is pinned by
+`test/snapshots/issue/issue_10195_nominal_record_update_rewrapped.md`; accepted
+nested-nominal and implicit-record-update controls are pinned in
+`src/check/test/type_checking_integration.zig`.
+
 ## Module Completion Boundary
 
 The compile coordinator records phase progress separately from user diagnostics.

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -3397,6 +3397,19 @@ fn unifyInContext(self: *Self, a: Var, b: Var, env: *Env, ctx: problem.Context) 
     return self.runUnify(a, b, env, .{ .context = ctx });
 }
 
+fn unifyNominalConstructorBacking(
+    self: *Self,
+    expected_backing: Var,
+    actual_backing: Var,
+    env: *Env,
+    ctx: problem.Context.NominalConstructorContext,
+) std.mem.Allocator.Error!unifier.Result {
+    return self.runUnify(expected_backing, actual_backing, env, .{
+        .context = .{ .nominal_constructor = ctx },
+        .root_relation = .nominal_constructor_backing,
+    });
+}
+
 /// Check if a variable contains an infinite type after solving a binding.
 /// This catches cases like `f = |x| f([x])` which creates `a = List(a)`.
 ///
@@ -17079,9 +17092,12 @@ fn checkNominalTypeUsage(
         //              ^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^
         // Convert CIR.Expr.NominalBackingType to Context.NominalConstructorContext.BackingType
         const context_backing_type: problem.Context.NominalConstructorContext.BackingType = @enumFromInt(@intFromEnum(backing_type));
-        const result = try self.unifyInContext(nominal_backing_var, actual_backing_var, env, .{
-            .nominal_constructor = .{ .backing_type = context_backing_type },
-        });
+        const result = try self.unifyNominalConstructorBacking(
+            nominal_backing_var,
+            actual_backing_var,
+            env,
+            .{ .backing_type = context_backing_type },
+        );
 
         // Handle the result of unification
         switch (result) {

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -4935,6 +4935,43 @@ test "consolidated - record literal lifts into record-backed nominal (control)" 
     try checkTypesModule(source, .{ .pass = .last_def }, "Point");
 }
 
+test "nominal constructor rejects an already nominal record backing" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Wrap :: { a : U8, b : U8 }.{
+        \\    inc_a : Wrap -> Wrap
+        \\    inc_a = |wrap| Wrap.{ ..wrap, a: wrap.a + 1 }
+        \\}
+    ;
+    try checkTypesModule(source, .fail_first, "Invalid Nominal Record");
+}
+
+test "nominal constructor backing allows a nested nominal value" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Inner :: { value : U8 }
+        \\Outer :: { inner : Inner }
+        \\
+        \\inner = Inner.{ value: 1 }
+        \\outer = Outer.{ inner }
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "Outer");
+}
+
+test "record update still lifts to its nominal extension" {
+    const source =
+        \\main! = |_| {}
+        \\
+        \\Wrap :: { a : U8, b : U8 }
+        \\
+        \\inc_a : Wrap -> Wrap
+        \\inc_a = |wrap| { ..wrap, a: wrap.a + 1 }
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "Wrap -> Wrap");
+}
+
 test "consolidated - record literal does not lift through a newtype chain" {
     // Structural lifting is single-level only: it does NOT compose through a
     // transparent newtype chain (`Outer := Inner := { … }`). Pinned as the

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -143,10 +143,21 @@ pub const MismatchBehavior = enum {
     write_no_report,
 };
 
-/// Per-call options. Both axes default to the common case.
+/// The semantic relation applied to the initial pair of a unification call.
+/// Child pairs always use ordinary unification.
+pub const RootRelation = enum {
+    ordinary,
+    /// An explicit nominal constructor has already chosen its wrapper. Its
+    /// outer backing pair cannot be satisfied by lifting an already-nominal
+    /// actual value through an anonymous expected backing.
+    nominal_constructor_backing,
+};
+
+/// Per-call options. All axes default to the common case.
 pub const Options = struct {
     context: Context = .none,
     on_mismatch: MismatchBehavior = .poison_to_err,
+    root_relation: RootRelation = .ordinary,
 };
 
 /// Unify two type variables.
@@ -163,7 +174,7 @@ pub fn unify(env: *const Env, a: Var, b: Var, opts: Options) std.mem.Allocator.E
 
     // Unify
     var unifier = Unifier.init(env.ident_store, env.self_module_identity, env.types, env.unify_scratch, env.occurs_scratch);
-    unifier.scheduleGuardedPair(a, b, .abort) catch |err| switch (err) {
+    unifier.scheduleRootPair(a, b, opts.root_relation, .abort) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
     };
     unifier.runWorkLoop() catch |err| {
@@ -377,6 +388,21 @@ const Unifier = struct {
         } });
     }
 
+    fn scheduleRootPair(
+        self: *Self,
+        a_var: Var,
+        b_var: Var,
+        relation: RootRelation,
+        on_mismatch: MismatchHandling,
+    ) std.mem.Allocator.Error!void {
+        _ = try self.scratch.unify_work_stack.append(self.scratch.gpa, .{ .mismatch_handler = on_mismatch });
+        _ = try self.scratch.unify_work_stack.append(self.scratch.gpa, .{ .root_pair = .{
+            .a = a_var,
+            .b = b_var,
+            .relation = relation,
+        } });
+    }
+
     fn scheduleMerge(self: *Self, vars: ResolvedVarDescs, content: Content) std.mem.Allocator.Error!void {
         _ = try self.scratch.unify_work_stack.append(self.scratch.gpa, .{ .merge = .{
             .vars = vars,
@@ -402,6 +428,7 @@ const Unifier = struct {
     fn processFrame(self: *Self, frame: WorkFrame) Error!void {
         switch (frame) {
             .mismatch_handler => {},
+            .root_pair => |pair| try self.processRootPair(pair.a, pair.b, pair.relation),
             .guarded_pair => |pair| try self.processGuardedPair(pair.a, pair.b),
             .guard_handler => |handler| {
                 self.scratch.visited_vars.items.items.len = handler.visited_vars_len;
@@ -414,6 +441,46 @@ const Unifier = struct {
             .shared_fields_after_children => |post| try self.processSharedFieldsAfterChildren(post),
             .shared_tags_after_children => |post| try self.processSharedTagsAfterChildren(post),
         }
+    }
+
+    fn processRootPair(self: *Self, a_var: Var, b_var: Var, relation: RootRelation) Error!void {
+        if (relation == .nominal_constructor_backing and try self.constructorBackingWouldInverseLift(a_var, b_var)) {
+            return error.TypeMismatch;
+        }
+        try self.processGuardedPair(a_var, b_var);
+    }
+
+    fn contentThroughAliases(self: *Self, start: Var) Error!Content {
+        var current = start;
+        var remaining = self.types_store.len();
+        while (remaining > 0) : (remaining -= 1) {
+            const content = self.types_store.resolveVar(current).desc.content;
+            switch (content) {
+                .alias => |alias| current = self.types_store.getAliasBackingVar(alias),
+                else => return content,
+            }
+        }
+        return error.TypeMismatch;
+    }
+
+    /// Whether the root constructor-backing pair would use ordinary
+    /// structural-to-nominal lifting in the inverse direction: an anonymous
+    /// expected backing accepting an already-nominal actual operand.
+    fn constructorBackingWouldInverseLift(self: *Self, expected: Var, actual: Var) Error!bool {
+        const actual_content = try self.contentThroughAliases(actual);
+        const actual_nominal = switch (actual_content) {
+            .structure => |flat| switch (flat) {
+                .nominal_type => |nominal| nominal,
+                else => return false,
+            },
+            else => return false,
+        };
+        if (self.types_store.nominalDeclIsInvalid(actual_nominal)) return false;
+
+        return switch (try self.contentThroughAliases(expected)) {
+            .structure => |flat| flat != .nominal_type,
+            else => false,
+        };
     }
 
     fn processGuardedPair(self: *Self, a_var: Var, b_var: Var) Error!void {
@@ -2861,6 +2928,11 @@ const SharedTagsAfterChildren = struct {
 
 const WorkFrame = union(enum) {
     mismatch_handler: MismatchHandling,
+    root_pair: struct {
+        a: Var,
+        b: Var,
+        relation: RootRelation,
+    },
     guarded_pair: struct {
         a: Var,
         b: Var,

--- a/test/snapshots/issue/issue_10195_nominal_record_update_rewrapped.md
+++ b/test/snapshots/issue/issue_10195_nominal_record_update_rewrapped.md
@@ -1,0 +1,112 @@
+# META
+~~~ini
+description=An explicit nominal constructor rejects a nominal record as its backing
+type=snippet
+~~~
+# SOURCE
+~~~roc
+Wrap :: { a : U8, b : U8 }.{
+	inc_a : Wrap -> Wrap
+
+	inc_a = |wrap| Wrap.{ ..wrap, a: wrap.a + 1 }
+}
+~~~
+# EXPECTED
+INVALID NOMINAL RECORD - issue_10195_nominal_record_update_rewrapped.md:4:22:4:47
+# PROBLEMS
+
+┌────────────────────────┐
+│ INVALID NOMINAL RECORD ├─ I'm having trouble with this nominal type that ───┐
+└┬───────────────────────┘  wraps a record.                                   │
+ │                                                                            │
+ │  inc_a = |wrap| Wrap.{ ..wrap, a: wrap.a + 1 }                             │
+ │                      ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                             │
+ └─────────────────────── issue_10195_nominal_record_update_rewrapped.md:4:22 ┘
+
+    The record I found is:
+
+        Wrap
+
+    But the nominal type expects:
+
+        { a: U8, b: U8 }
+
+# TOKENS
+~~~zig
+UpperIdent,OpDoubleColon,OpenCurly,LowerIdent,OpColon,UpperIdent,Comma,LowerIdent,OpColon,UpperIdent,CloseCurly,Dot,OpenCurly,
+LowerIdent,OpColon,UpperIdent,OpArrow,UpperIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,OpBar,UpperIdent,Dot,OpenCurly,DoubleDot,LowerIdent,Comma,LowerIdent,OpColon,LowerIdent,NoSpaceDotLowerIdent,OpPlus,Int,CloseCurly,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-type-decl
+			(header (name "Wrap")
+				(args))
+			(ty-record
+				(anno-record-field (name "a")
+					(ty (name "U8")))
+				(anno-record-field (name "b")
+					(ty (name "U8"))))
+			(associated
+				(s-type-anno (name "inc_a")
+					(ty-fn
+						(ty (name "Wrap"))
+						(ty (name "Wrap"))))
+				(s-decl
+					(p-ident (raw "inc_a"))
+					(e-lambda
+						(args
+							(p-ident (raw "wrap")))
+						(e-nominal-record
+							(mapper (e-tag (raw "Wrap")))
+							(backing (e-record
+									(ext
+										(e-ident (raw "wrap")))
+									(field (field "a")
+										(e-binop (op "+")
+											(e-field-access
+												(e-ident (raw "wrap"))
+												(e-ident (raw "a")))
+											(e-int (raw "1")))))))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "issue_10195_nominal_record_update_rewrapped.Wrap.inc_a"))
+		(e-lambda
+			(args
+				(p-assign (ident "wrap")))
+			(e-runtime-error (tag "erroneous_value_expr")))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-lookup (name "Wrap") (local))
+				(ty-lookup (name "Wrap") (local)))))
+	(s-nominal-decl
+		(ty-header (name "Wrap"))
+		(ty-record
+			(field (field "a")
+				(ty-lookup (name "U8") (builtin)))
+			(field (field "b")
+				(ty-lookup (name "U8") (builtin))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Wrap -> Wrap")))
+	(type_decls
+		(nominal (type "Wrap")
+			(ty-header (name "Wrap"))))
+	(expressions
+		(expr (type "Wrap -> Wrap"))))
+~~~


### PR DESCRIPTION
Explicit nominal constructors were checking their backing operands with ordinary symmetric unification, so an already-lifted nominal record could satisfy the constructor's anonymous backing and escape checking. This adds an explicit root-only constructor-backing relation, preserving ordinary child unification while producing `INVALID NOMINAL RECORD` for the invalid construction.

Fixes #10195
