### PR TITLE
Track re-enabling Zig layout probe

### DIFF
--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -7137,6 +7137,7 @@ fn runGlueRuntimeCase(
     // aggregate back to the stack. On arm64musl, Zig starts a 16-byte-aligned
     // Dec aggregate in x5 instead of rounding up to x6. CGlue and RustGlue
     // continue to exercise both signatures on these targets.
+    // TODO #10392: Remove this skip after Roc uses a Zig version that lowers both signatures correctly.
     if (native_target) |target| {
         if (runtime.language == .zig and std.mem.eql(u8, runtime.platform.name, "layout-probe")) {
             if (zigCompilerMislowersLayoutProbeAbi(target.roc_target)) {


### PR DESCRIPTION
Add a TODO linking #10392 at the target-specific ZigGlue skip so the x64mac and arm64musl layout-probe cells are restored once Roc uses a Zig version with corrected aggregate C ABI lowering.