### PR TITLE
Add hints for Num.to_str and Inspect.to_str does-not-exist errors

### DIFF
--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -1545,6 +1545,25 @@ pub fn diagnosticToReport(self: *Self, diagnostic: CIR.Diagnostic, allocator: st
                 self.getLineStartsAll(),
             );
 
+            if (std.mem.eql(u8, ident_name, "Num.to_str")) {
+                try report.document.addLineBreak();
+                try report.document.addLineBreak();
+                try report.document.addAnnotated("Hint:", .emphasized);
+                try report.document.addReflowingText(" Instead of ");
+                try report.document.addInlineCode("Num.to_str(value)");
+                try report.document.addReflowingText(", use method syntax: ");
+                try report.document.addInlineCode("value.to_str()");
+            } else if (std.mem.eql(u8, ident_name, "Inspect.to_str")) {
+                try report.document.addLineBreak();
+                try report.document.addLineBreak();
+                try report.document.addAnnotated("Hint:", .emphasized);
+                try report.document.addReflowingText(" ");
+                try report.document.addInlineCode("Inspect.to_str");
+                try report.document.addReflowingText(" has been renamed to ");
+                try report.document.addInlineCode("Str.inspect");
+                try report.document.addReflowingText(".");
+            }
+
             break :blk report;
         },
         .exposed_but_not_implemented => |data| blk: {

--- a/test/snapshots/can_does_not_exist_inspect_to_str_hint.md
+++ b/test/snapshots/can_does_not_exist_inspect_to_str_hint.md
@@ -1,0 +1,59 @@
+# META
+~~~ini
+description=Hint for Inspect.to_str renamed to Str.inspect
+type=snippet
+~~~
+# SOURCE
+~~~roc
+result = Inspect.to_str("hello")
+~~~
+# EXPECTED
+DOES NOT EXIST - can_does_not_exist_inspect_to_str_hint.md:1:10:1:24
+# PROBLEMS
+
+┌────────────────┐
+│ DOES NOT EXIST ├─ `Inspect.to_str` does not exist. ─────────────────────────┐
+└┬───────────────┘                                                            │
+ │                                                                            │
+ │  result = Inspect.to_str("hello")                                          │
+ │           ‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                                   │
+ └──────────────────────────── can_does_not_exist_inspect_to_str_hint.md:1:10 ┘
+
+    Hint: `Inspect.to_str` has been renamed to `Str.inspect`.
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,StringStart,StringPart,StringEnd,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-decl
+			(p-ident (raw "result"))
+			(e-apply
+				(e-ident (raw "Inspect.to_str"))
+				(e-string
+					(e-string-part (raw "hello")))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "result"))
+		(e-runtime-error (tag "erroneous_value_expr"))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Error")))
+	(expressions
+		(expr (type "Error"))))
+~~~

--- a/test/snapshots/plume_package/Color.md
+++ b/test/snapshots/plume_package/Color.md
@@ -104,6 +104,7 @@ MISSING METHOD - Color.md:48:32:48:38
  │           ‾‾‾‾‾‾‾‾‾‾                                                       │
  └──────────────────────────────────────────────────────────── Color.md:41:34 ┘
 
+    Hint: Instead of `Num.to_str(value)`, use method syntax: `value.to_str()`
 
 
 ┌────────────────┐
@@ -114,6 +115,7 @@ MISSING METHOD - Color.md:48:32:48:38
  │           ‾‾‾‾‾‾‾‾‾‾                                                       │
  └──────────────────────────────────────────────────────────── Color.md:41:52 ┘
 
+    Hint: Instead of `Num.to_str(value)`, use method syntax: `value.to_str()`
 
 
 ┌────────────────┐
@@ -124,6 +126,7 @@ MISSING METHOD - Color.md:48:32:48:38
  │           ‾‾‾‾‾‾‾‾‾‾                                                       │
  └──────────────────────────────────────────────────────────── Color.md:41:70 ┘
 
+    Hint: Instead of `Num.to_str(value)`, use method syntax: `value.to_str()`
 
 
 ┌────────────────┐
@@ -134,6 +137,7 @@ MISSING METHOD - Color.md:48:32:48:38
  │           ‾‾‾‾‾‾‾‾‾‾                                                       │
  └──────────────────────────────────────────────────────────── Color.md:42:39 ┘
 
+    Hint: Instead of `Num.to_str(value)`, use method syntax: `value.to_str()`
 
 
 ┌────────────────┐
@@ -144,6 +148,7 @@ MISSING METHOD - Color.md:48:32:48:38
  │           ‾‾‾‾‾‾‾‾‾‾                                                       │
  └──────────────────────────────────────────────────────────── Color.md:42:57 ┘
 
+    Hint: Instead of `Num.to_str(value)`, use method syntax: `value.to_str()`
 
 
 ┌────────────────┐
@@ -154,6 +159,7 @@ MISSING METHOD - Color.md:48:32:48:38
  │           ‾‾‾‾‾‾‾‾‾‾                                                       │
  └──────────────────────────────────────────────────────────── Color.md:42:75 ┘
 
+    Hint: Instead of `Num.to_str(value)`, use method syntax: `value.to_str()`
 
 
 ┌────────────────┐
@@ -164,6 +170,7 @@ MISSING METHOD - Color.md:48:32:48:38
  │           ‾‾‾‾‾‾‾‾‾‾                                                       │
  └──────────────────────────────────────────────────────────── Color.md:42:93 ┘
 
+    Hint: Instead of `Num.to_str(value)`, use method syntax: `value.to_str()`
 
 
 ┌────────────────┐


### PR DESCRIPTION
## Summary

- When a user writes `Num.to_str(value)`, the "Does Not Exist" error now hints to use method syntax `value.to_str()` instead
- When a user writes `Inspect.to_str(value)`, the error now hints that it was renamed to `Str.inspect`
- Follows the existing hint pattern in `ModuleEnv.zig` (e.g. `addAnnotated("Hint:", .emphasized)`)

## Verification

- `zig build run-snapshot-tool -- test/snapshots/can_does_not_exist_inspect_to_str_hint.md`
- `zig build run-check-snapshots`
- `zig build run-test-zig -- --test-filter "qualified_ident"` — all 4 tests passed
- Updated existing snapshot `test/snapshots/plume_package/Color.md` (now shows the hint)

Fixes #9191
Fixes #9192