### PR TITLE
Index JSON strings and scalars in place instead of materializing byte lists

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -562,13 +562,12 @@ Builtin :: [].{
 
 			append_json_string_bytes : List(U8), Str -> List(U8)
 			append_json_string_bytes = |out, value| {
-				bytes = Str.to_utf8(value)
-				len = List.len(bytes)
+				len = Str.count_utf8_bytes(value)
 				var $out = u8_list_reserve(out, len)
 				var $index = 0
 
 				while $index < len {
-					$out = u8_append($out, list_get_unsafe(bytes, $index))
+					$out = u8_append($out, str_get_utf8_byte_unsafe(value, $index))
 					$index = $index + 1
 				}
 
@@ -577,15 +576,14 @@ Builtin :: [].{
 
 			append_json_quoted_string : List(U8), Str -> List(U8)
 			append_json_quoted_string = |out, value| {
-				bytes = Str.to_utf8(value)
-				len = List.len(bytes)
+				len = Str.count_utf8_bytes(value)
 				var $out = u8_list_reserve(out, len + 2)
 				var $index = 0
 
 				$out = u8_append($out, 34)
 
 				while $index < len {
-					byte = list_get_unsafe(bytes, $index)
+					byte = str_get_utf8_byte_unsafe(value, $index)
 					$out = Json.append_json_string_byte($out, byte)
 					$index = $index + 1
 				}


### PR DESCRIPTION
With this PR, we take advantage of `str_get_utf8_byte_unsafe` (added in [#10173](https://github.com/roc-lang/roc/pull/10173)) to index into `Str`s without having to convert them into `List(U8)`s first, in a pair of functions used in the JSON encoding code (`append_json_string_bytes` and `append_json_quoted_string`).

As a result, we have fewer allocations per encoding. Each row below is one complete `Json.to_str` call in a small test program, measured using the alloc-count platform:

| document encoded | base | this PR |
|---|---|---|
| record, one short string field | 3 | 1 |
| record, four mixed fields | 17 | 10 |
| record, list of three strings | 12 | 8 |
| record, escaped string field | 4 | 2 |

Notes:
- Encoding needs at least one allocation, for the final `Str`. As you can see above, we do not yet hit that floor in every case.
- For records with 3+ fields, a generic encoder path takes over at a fixed cost per field: 5 allocations before this change, 3 after. This is a possible target for further optimization in the future.



