### PR TITLE
Emit native SIMD in dev backends

### DIFF
--- a/ci/check_simd_codegen.sh
+++ b/ci/check_simd_codegen.sh
@@ -17,14 +17,49 @@ tmp_dir="$(mktemp -d)"
 trap 'rm -rf -- "$tmp_dir"' EXIT
 
 cd "$repo_root"
-"$roc_bin" build --opt=speed --no-cache --output="$tmp_dir/simd-smoke" test/cli/runtime_simd_smoke.roc >/dev/null
-objdump -d --no-show-raw-insn "$tmp_dir/simd-smoke" >"$tmp_dir/disassembly"
+"$roc_bin" build --opt=speed --no-cache --output="$tmp_dir/simd-smoke-speed" test/cli/runtime_simd_smoke.roc >/dev/null
+objdump -d --no-show-raw-insn "$tmp_dir/simd-smoke-speed" >"$tmp_dir/speed-disassembly"
 
 for instruction in vpaddb vpmaddwd vpshufb vpclmullqlqdq; do
-    if ! grep -Eq "[[:space:]]${instruction}[[:space:]]" "$tmp_dir/disassembly"; then
+    if ! grep -Eq "[[:space:]]${instruction}[[:space:]]" "$tmp_dir/speed-disassembly"; then
         echo "optimized integer SIMD smoke is missing ${instruction}" >&2
         exit 1
     fi
 done
 
-echo "integer SIMD codegen contains vpaddb, vpmaddwd, vpshufb, and vpclmullqlqdq"
+"$roc_bin" build --opt=dev --no-cache --output="$tmp_dir/simd-smoke-dev" test/cli/runtime_simd_smoke.roc >/dev/null
+objdump -d --no-show-raw-insn "$tmp_dir/simd-smoke-dev" >"$tmp_dir/dev-disassembly"
+
+if grep -Eq "[[:space:]]call[[:space:]].*<roc_builtins_simd_eval>" "$tmp_dir/dev-disassembly"; then
+    echo "dev integer SIMD smoke calls scalar roc_builtins_simd_eval" >&2
+    exit 1
+fi
+
+for instruction in paddb pmaddwd pshufb pclmullqlqdq; do
+    if ! grep -Eq "[[:space:]]v?${instruction}[[:space:]]" "$tmp_dir/dev-disassembly"; then
+        echo "dev integer SIMD smoke is missing native ${instruction}" >&2
+        exit 1
+    fi
+done
+
+for forbidden_symbol in roc_builtins_simd_eval roc_builtins_simd_load_16; do
+    if strings "$tmp_dir/simd-smoke-dev" | grep -Fq "$forbidden_symbol"; then
+        echo "dev x86-64 integer SIMD binary still links deleted helper ${forbidden_symbol}" >&2
+        exit 1
+    fi
+done
+
+# Instantiate the exhaustive source corpus through the other dev backend too.
+# This exercises every supported low-level/type pairing, not merely the four
+# smoke-test instruction classes above. The target binary is not executable on
+# this runner, so semantic execution remains covered by the shared differential
+# corpus on native builders and the byte-exact AArch64 emitter unit tests.
+"$roc_bin" build --opt=dev --target=arm64musl --no-cache --output="$tmp_dir/simd-differential-aarch64" test/simd/differential.roc >/dev/null
+for forbidden_symbol in roc_builtins_simd_eval roc_builtins_simd_load_16; do
+    if strings "$tmp_dir/simd-differential-aarch64" | grep -Fq "$forbidden_symbol"; then
+        echo "dev AArch64 integer SIMD binary still links deleted helper ${forbidden_symbol}" >&2
+        exit 1
+    fi
+done
+
+echo "optimized x86-64 and both dev backends contain native packed SIMD lowering"

--- a/design.md
+++ b/design.md
@@ -5424,12 +5424,23 @@ parallel insertion paths at any point:
 ## Dev Backend Register Lifetimes
 
 `LirCodeGen` is the sole authority for LIR local locations. Every assigned
-LIR local is materialized into a stable location—a stack slot for represented
-runtime data—before statement generation continues. Architecture-specific code
-generators own only architecture register masks for short-lived
-instruction-selection temporaries; they do not
-own a second local-location map, move live values between registers and stack,
-or reload LIR local values independently.
+LIR local has one authoritative stable location. Ordinary represented values
+use stack slots. A first-class 128-bit integer vector may instead occupy a
+`vector_reg` location for its straight-line live range. `LirCodeGen` owns the
+live range, register assignment, spill slot, and every transition between the
+two; architecture-specific code generators own only the one physical
+floating-point/vector register mask and instruction encoding. They do not own
+a second local-location map or independently move semantic values.
+
+Floating-point and vector locations draw from the same physical register mask:
+XMM registers alias on x86-64 and V registers alias on AArch64. Vector locals
+remain in registers across chained operations and spill only under actual
+register pressure, at control-flow environment boundaries, or before a call
+whose ABI may clobber them. SysV x86-64 treats every XMM register as volatile.
+Windows x64 allocates only its volatile XMM subset unless full-width save and
+restore is emitted. AArch64 does not treat V8-V15 as a persistent 128-bit
+vector resource because its ABI preserves only their low 64 bits; a live Q
+value is spilled before a call.
 
 The number of simultaneously live instruction-selection temporaries must be
 bounded by the emitted operation, never by source or layout nesting depth.
@@ -6709,17 +6720,22 @@ dev backends, wasm, the interpreter, and the Lambda Mono evaluator. Compile-time
 evaluation uses the same vector layouts and dev lowering as runtime dev code,
 and `ConstStore` preserves all 16 vector bytes under the checked vector type.
 
-The correctness-oriented native consumers use the exhaustive bit-level SIMD
-evaluator in `src/builtins/simd.zig`. Dev code passes the operation descriptor,
-explicit source/destination lane kinds, and operand bits through its ordinary
-internal call ABI; x86-64 and AArch64 wrappers preserve the corresponding
-two-register vector values and AArch64 has native Q-register movement. The
-interpreter and Lambda Mono evaluator invoke the same operation contract from
-their explicit layouts. A Lambda Mono value that does not have an integer bit
-representation is rejected explicitly rather than being replaced with zero.
-Wasm instead emits `v128` operations and exact helper
-sequences, including software carryless multiplication where simd128 has no
-instruction.
+The exhaustive bit-level SIMD evaluator in `src/builtins/simd.zig` is the
+correctness oracle for the interpreter, Lambda Mono evaluator, and differential
+tests. Both native dev backends instead dispatch exhaustively on the static LIR
+operation and its explicit source/destination lane kinds and emit native
+packed-integer instruction sequences. There is no compiled scalar evaluator,
+runtime operation descriptor, or fallback call. Missing native coverage is a
+compile-time exhaustiveness failure. A Lambda Mono value that does not have an
+integer bit representation is rejected explicitly rather than being replaced
+with zero. Wasm emits `v128` operations and exact helper sequences, including
+software carryless multiplication where simd128 has no instruction.
+
+Unchecked 16-byte loads are native vector loads. Stores use the explicit LIR
+uniqueness decision: the in-place path emits a native vector store, while the
+non-unique path may call the allocation-aware list-clone primitive before that
+store. This is mechanical consumption of earlier ARC output, never backend
+reference-count inference.
 
 Structural equality treats vectors as ordinary value leaves. Solved-to-LIR
 lowering converts each vector operand to its complete 128-bit bit image and
@@ -6763,9 +6779,12 @@ it twice, but MiniCI runs the dedicated no-skip gate explicitly.
 The full Lambda Mono body-lowering differential sweep over the ordinary eval
 corpus runs once per day on Ubuntu through `nightly_gate.yml`; it is not part of
 PR MiniCI. This does not remove the dedicated SIMD gate's Lambda Mono lane.
-`zig build run-check-simd-codegen` separately requires optimized
+`zig build run-check-simd-codegen` separately requires both optimized and dev
 x86-64 output to contain representative byte-add, pairwise-dot, table-shuffle,
-and carryless-multiply instructions. `zig build run-check-glue-abi` compiles
+and carryless-multiply instructions, rejects deleted scalar-evaluator and load
+helpers from dev binaries, and cross-builds the exhaustive corpus through the
+AArch64 dev backend so every supported operation/type lowering is instantiated.
+`zig build run-check-glue-abi` compiles
 generated Zig and C declarations for x86-64 and AArch64 Linux/macOS/Windows plus
 wasm, compiles Rust for native and wasm, and the native/wasm glue runtime matrix
 calls the generated contracts in both directions.

--- a/design.md
+++ b/design.md
@@ -5428,11 +5428,11 @@ LIR local has one authoritative stable location. Ordinary represented values
 use stack slots. A first-class 128-bit integer vector may instead occupy a
 `vector_reg` location for its straight-line live range. `LirCodeGen` owns the
 live range, register assignment, spill slot, and every transition between the
-two; architecture-specific code generators own only the one physical
-floating-point/vector register mask and instruction encoding. They do not own
-a second local-location map or independently move semantic values.
+two; architecture-specific code generators own only the one
+floating-point/vector register-allocation mask and instruction encoding. They
+do not own a second local-location map or independently move LIR local values.
 
-Floating-point and vector locations draw from the same physical register mask:
+Floating-point and vector locations draw from the same register-allocation mask:
 XMM registers alias on x86-64 and V registers alias on AArch64. Vector locals
 remain in registers across chained operations and spill only under actual
 register pressure, at control-flow environment boundaries, or before a call

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -843,12 +843,20 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             width: FloatWidth,
         };
 
+        const VectorLocation = struct {
+            reg: FloatReg,
+            kind: builtins.simd.Kind,
+        };
+
         /// Where a value is stored
         pub const ValueLocation = union(enum) {
             /// Value is in a general-purpose register
             general_reg: GeneralReg,
             /// Value is in a float register at its actual Roc precision.
             float_reg: FloatLocation,
+            /// A first-class 128-bit integer vector in the architecture's
+            /// shared floating-point/vector register file.
+            vector_reg: VectorLocation,
             /// Value is on the stack at given offset from frame pointer.
             /// `layout_idx` preserves the semantic interpretation for narrow integer loads.
             stack: struct {
@@ -1122,6 +1130,9 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         };
 
         fn captureStmtEnv(self: *Self) Allocator.Error!StmtEnvSnapshot {
+            // Branch environments must not depend on a volatile physical
+            // vector register containing the value produced along one path.
+            try self.spillAllVectorLocals();
             return .{
                 .local_locations = try self.local_locations.clone(),
             };
@@ -4299,11 +4310,6 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 .simd_load_16_unchecked => return self.generateSimdLoad(ll, args),
                 .simd_store_16_unchecked => return self.generateSimdStore(ll, args),
                 .simd_append_16 => return self.generateSimdAppend(ll, args),
-                .simd_splat,
-                .simd_get_lane_unchecked,
-                .simd_with_lane_unchecked,
-                .simd_to_u128_bits,
-                .simd_from_u128_bits,
                 .simd_add_wrap,
                 .simd_sub_wrap,
                 .simd_add_sat,
@@ -4314,14 +4320,6 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 .simd_max,
                 .simd_abs_diff,
                 .simd_avg_rounded,
-                .simd_mul_wrap,
-                .simd_mul_high,
-                .simd_mul_q15_sat,
-                .simd_mul_wide_lo,
-                .simd_mul_wide_hi,
-                .simd_dot_pairs,
-                .simd_dot_pairs_sat,
-                .simd_sad,
                 .simd_and,
                 .simd_or,
                 .simd_xor,
@@ -4330,28 +4328,48 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 .simd_eq_lanes,
                 .simd_gt_lanes,
                 .simd_gte_lanes,
-                .simd_bitmask,
+                .simd_interleave_lo,
+                .simd_interleave_hi,
+                => return self.generateBasicSimdVector(ll, args),
+                .simd_splat => return self.generateSimdSplat(ll, args),
+                .simd_get_lane_unchecked => return self.generateSimdGetLane(ll, args),
+                .simd_with_lane_unchecked => return self.generateSimdWithLane(ll, args),
+                .simd_to_u128_bits => return self.generateSimdToBits(ll, args),
+                .simd_from_u128_bits => return self.generateSimdFromBits(ll, args),
+                .simd_mul_wrap,
+                .simd_mul_high,
+                .simd_mul_q15_sat,
+                .simd_mul_wide_lo,
+                .simd_mul_wide_hi,
+                => return self.generateSimdMultiply(ll, args),
+                .simd_dot_pairs,
+                .simd_dot_pairs_sat,
+                .simd_sad,
+                => return self.generateSimdDot(ll, args),
+                .simd_bitmask => return self.generateSimdBitmask(ll, args),
                 .simd_shl_wrap,
                 .simd_shr_wrap,
                 .simd_shr_zf_wrap,
-                .simd_shr_rounded,
-                .simd_interleave_lo,
-                .simd_interleave_hi,
+                => return self.generateSimdShift(ll, args),
+                .simd_shr_rounded => return self.generateSimdRoundedShift(ll, args),
                 .simd_even_lanes,
                 .simd_odd_lanes,
                 .simd_reverse_lanes,
-                .simd_table_lookup,
-                .simd_concat_shift_bytes,
+                => return self.generateSimdRearrange(ll, args),
+                .simd_table_lookup => return self.generateSimdTableLookup(ll, args),
+                .simd_concat_shift_bytes => return self.generateSimdConcatShift(ll, args),
                 .simd_widen_lo,
                 .simd_widen_hi,
                 .simd_pairwise_add_widen,
                 .simd_narrow_wrap,
                 .simd_narrow_sat,
+                => return self.generateSimdWidthChange(ll, args),
                 .simd_sum_lanes,
                 .simd_sum_lanes_wrap,
+                => return self.generateSimdSum(ll, args),
                 .simd_clmul_lo,
                 .simd_clmul_hi,
-                => return self.generateSimdLowLevel(ll, args),
+                => return self.generateSimdClmul(ll, args),
                 .erased_capture_load => {
                     const elem_layout_idx = ll.ret_layout;
                     const elem_layout_data = self.layout_store.getLayout(elem_layout_idx);
@@ -4583,6 +4601,1186 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             };
         }
 
+        const AcquiredVector = struct {
+            reg: FloatReg,
+            temporary: bool,
+        };
+
+        fn acquireVectorLocal(
+            self: *Self,
+            local: LocalId,
+            expected_kind: builtins.simd.Kind,
+            protected_mask: u32,
+        ) Allocator.Error!AcquiredVector {
+            const actual_kind = self.simdKindForLayout(self.localLayout(local)) orelse std.debug.panic(
+                "LIR/codegen invariant violated: SIMD operand has a non-vector layout",
+                .{},
+            );
+            if (actual_kind != expected_kind) {
+                std.debug.panic(
+                    "LIR/codegen invariant violated: expected {s} SIMD operand, found {s}",
+                    .{ @tagName(expected_kind), @tagName(actual_kind) },
+                );
+            }
+
+            return switch (try self.emitValueLocal(local)) {
+                .vector_reg => |vector| blk: {
+                    if (vector.kind != expected_kind) unreachable;
+                    break :blk .{ .reg = vector.reg, .temporary = false };
+                },
+                .stack => |stack_loc| blk: {
+                    const reg = try self.allocTempVector(protected_mask);
+                    try self.codegen.emitLoadStackV128(reg, stack_loc.offset);
+                    break :blk .{ .reg = reg, .temporary = true };
+                },
+                else => |loc| std.debug.panic(
+                    "LIR/codegen invariant violated: SIMD operand has unsupported location {s}",
+                    .{@tagName(loc)},
+                ),
+            };
+        }
+
+        fn releaseAcquiredVector(self: *Self, vector: AcquiredVector) void {
+            if (vector.temporary) self.codegen.freeFloat(vector.reg);
+        }
+
+        fn materializeVectorConstant(
+            self: *Self,
+            bits: u128,
+            protected_mask: u32,
+        ) Allocator.Error!AcquiredVector {
+            const result = try self.allocTempVector(protected_mask);
+            const low_reg = try self.allocTempGeneral();
+            defer self.codegen.freeGeneral(low_reg);
+            const high_reg = try self.allocTempGeneral();
+            defer self.codegen.freeGeneral(high_reg);
+            const low: u64 = @truncate(bits);
+            const high: u64 = @truncate(bits >> 64);
+            try self.codegen.emitLoadImm(low_reg, @bitCast(low));
+            try self.codegen.emitLoadImm(high_reg, @bitCast(high));
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.codegen.emit.movVectorFromGeneral(result, low_reg, true);
+                try self.codegen.emit.insertQword(result, high_reg, 1);
+            } else {
+                try self.codegen.emit.duplicateGeneralToVector(result, low_reg, 64);
+                try self.codegen.emit.insertGeneralVectorLane(result, high_reg, 64, 1);
+            }
+            return .{ .reg = result, .temporary = true };
+        }
+
+        fn simdLaneIndexBytes(kind: builtins.simd.Kind) u128 {
+            const lane_bytes: u8 = @intCast(kind.laneBits() / 8);
+            var bits: u128 = 0;
+            for (0..16) |byte_index| {
+                bits |= @as(u128, @intCast(byte_index / lane_bytes)) << @intCast(byte_index * 8);
+            }
+            return bits;
+        }
+
+        fn simdByteRamp() u128 {
+            var bits: u128 = 0;
+            for (0..16) |byte_index| {
+                bits |= @as(u128, @intCast(byte_index)) << @intCast(byte_index * 8);
+            }
+            return bits;
+        }
+
+        fn simdReverseByteIndices(kind: builtins.simd.Kind) u128 {
+            const lane_bytes: usize = @intCast(kind.laneBits() / 8);
+            const lane_count: usize = @intCast(kind.laneCount());
+            var bits: u128 = 0;
+            for (0..16) |output_byte| {
+                const output_lane = output_byte / lane_bytes;
+                const byte_in_lane = output_byte % lane_bytes;
+                const input_byte = (lane_count - 1 - output_lane) * lane_bytes + byte_in_lane;
+                bits |= @as(u128, @intCast(input_byte)) << @intCast(output_byte * 8);
+            }
+            return bits;
+        }
+
+        fn simdParityByteIndices(kind: builtins.simd.Kind, odd: bool, high_half: bool) u128 {
+            const lane_bytes: usize = @intCast(kind.laneBits() / 8);
+            const half_lanes: usize = @intCast(kind.laneCount() / 2);
+            const invalid: u8 = 0x80;
+            var bytes: [16]u8 = @splat(invalid);
+            for (0..half_lanes) |output_lane_in_half| {
+                const output_lane = (if (high_half) half_lanes else 0) + output_lane_in_half;
+                const input_lane = 2 * output_lane_in_half + @intFromBool(odd);
+                for (0..lane_bytes) |byte_in_lane| {
+                    bytes[output_lane * lane_bytes + byte_in_lane] = @intCast(input_lane * lane_bytes + byte_in_lane);
+                }
+            }
+            return @bitCast(bytes);
+        }
+
+        fn simdNarrowByteIndices(
+            source_kind: builtins.simd.Kind,
+            destination_kind: builtins.simd.Kind,
+            high_half: bool,
+        ) u128 {
+            const source_lane_bytes: usize = @intCast(source_kind.laneBits() / 8);
+            const destination_lane_bytes: usize = @intCast(destination_kind.laneBits() / 8);
+            const source_lanes: usize = @intCast(source_kind.laneCount());
+            var bytes: [16]u8 = @splat(0x80);
+            for (0..source_lanes) |lane| {
+                const output_lane = (if (high_half) source_lanes else 0) + lane;
+                for (0..destination_lane_bytes) |byte_in_lane| {
+                    bytes[output_lane * destination_lane_bytes + byte_in_lane] = @intCast(lane * source_lane_bytes + byte_in_lane);
+                }
+            }
+            return @bitCast(bytes);
+        }
+
+        fn simdLaneWeights(kind: builtins.simd.Kind) u128 {
+            var bits: u128 = 0;
+            for (0..kind.laneCount()) |lane| {
+                bits = builtins.simd.withLane(bits, kind, @intCast(lane), @as(u64, 1) << @intCast(lane));
+            }
+            return bits;
+        }
+
+        fn emitSimdSplatFromGeneral(
+            self: *Self,
+            dst: FloatReg,
+            src: GeneralReg,
+            kind: builtins.simd.Kind,
+        ) Allocator.Error!void {
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.codegen.emit.movVectorFromGeneral(dst, src, kind.laneBits() == 64);
+                try self.codegen.emit.vexRegReg(
+                    .map_0f38,
+                    .p66,
+                    false,
+                    x86PackedOpcode(kind, 0x78, 0x79, 0x58, 0x59),
+                    dst,
+                    dst,
+                );
+            } else {
+                try self.codegen.emit.duplicateGeneralToVector(dst, src, kind.laneBits());
+            }
+        }
+
+        fn generateSimdSplat(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const kind = self.simdKindForLayout(ll.ret_layout) orelse unreachable;
+            const scalar_loc = try self.emitValueLocal(GuardedList.at(args, 0));
+            const scalar = try self.ensureInGeneralReg(scalar_loc);
+            defer self.codegen.freeGeneral(scalar);
+            const result = try self.allocTempVector(0);
+            try self.emitSimdSplatFromGeneral(result, scalar, kind);
+            return .{ .vector_reg = .{ .reg = result, .kind = kind } };
+        }
+
+        fn generateSimdFromBits(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const kind = self.simdKindForLayout(ll.ret_layout) orelse unreachable;
+            const loc = try self.emitValueLocal(GuardedList.at(args, 0));
+            const result = try self.allocTempVector(0);
+            switch (loc) {
+                .stack_i128 => |offset| try self.codegen.emitLoadStackV128(result, offset),
+                .stack => |stack_loc| try self.codegen.emitLoadStackV128(result, stack_loc.offset),
+                .immediate_i128 => |value| {
+                    self.codegen.freeFloat(result);
+                    const materialized = try self.materializeVectorConstant(@bitCast(value), 0);
+                    return .{ .vector_reg = .{ .reg = materialized.reg, .kind = kind } };
+                },
+                else => std.debug.panic(
+                    "LIR/codegen invariant violated: SIMD from_u128_bits received {s}",
+                    .{@tagName(loc)},
+                ),
+            }
+            return .{ .vector_reg = .{ .reg = result, .kind = kind } };
+        }
+
+        fn generateSimdToBits(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            _ = ll;
+            const vector_local = GuardedList.at(args, 0);
+            const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
+            const vector = try self.acquireVectorLocal(vector_local, kind, 0);
+            defer self.releaseAcquiredVector(vector);
+            const slot = self.codegen.allocStackSlot(16);
+            try self.codegen.emitStoreStackV128(slot, vector.reg);
+            return .{ .stack_i128 = slot };
+        }
+
+        fn generateSimdGetLane(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            _ = ll;
+            const vector_local = GuardedList.at(args, 0);
+            const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
+            const vector = try self.acquireVectorLocal(vector_local, kind, 0);
+            defer self.releaseAcquiredVector(vector);
+            var protected = floatRegMask(vector.reg);
+            const index_loc = try self.emitValueLocal(GuardedList.at(args, 1));
+            const index = try self.ensureInGeneralReg(index_loc);
+            defer self.codegen.freeGeneral(index);
+            const lane_bytes: u8 = @intCast(kind.laneBits() / 8);
+            if (lane_bytes > 1) try self.emitShlImm(.w64, index, index, @ctz(lane_bytes));
+
+            const indices = try self.allocTempVector(protected);
+            defer self.codegen.freeFloat(indices);
+            protected |= floatRegMask(indices);
+            try self.emitSimdSplatFromGeneral(indices, index, .u8x16);
+            const ramp = try self.materializeVectorConstant(simdByteRamp(), protected);
+            defer self.releaseAcquiredVector(ramp);
+            protected |= floatRegMask(ramp.reg);
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.emitX86PackedBinary(.map_0f, 0xFC, indices, indices, ramp.reg);
+            } else {
+                try self.codegen.emit.simdThreeReg(0x4E208400, indices, indices, ramp.reg);
+            }
+            const shuffled = try self.allocTempVector(protected);
+            defer self.codegen.freeFloat(shuffled);
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x00, shuffled, vector.reg, indices);
+            } else {
+                try self.codegen.emit.simdThreeReg(0x4E000000, shuffled, vector.reg, indices);
+            }
+            const result = try self.allocTempGeneral();
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.codegen.emit.movGeneralFromVector(result, shuffled, kind.laneBits() == 64);
+            } else {
+                try self.codegen.emit.extractVectorLaneUnsigned(result, shuffled, kind.laneBits(), 0);
+            }
+            return .{ .general_reg = result };
+        }
+
+        fn generateSimdWithLane(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const vector_local = GuardedList.at(args, 0);
+            const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
+            std.debug.assert(self.simdKindForLayout(ll.ret_layout) == kind);
+            const vector = try self.acquireVectorLocal(vector_local, kind, 0);
+            defer self.releaseAcquiredVector(vector);
+            var protected = floatRegMask(vector.reg);
+            const index_loc = try self.emitValueLocal(GuardedList.at(args, 1));
+            const index = try self.ensureInGeneralReg(index_loc);
+            defer self.codegen.freeGeneral(index);
+            const scalar_loc = try self.emitValueLocal(GuardedList.at(args, 2));
+            const scalar = try self.ensureInGeneralReg(scalar_loc);
+            defer self.codegen.freeGeneral(scalar);
+
+            const index_vector = try self.allocTempVector(protected);
+            defer self.codegen.freeFloat(index_vector);
+            protected |= floatRegMask(index_vector);
+            try self.emitSimdSplatFromGeneral(index_vector, index, .u8x16);
+            const lane_indices = try self.materializeVectorConstant(simdLaneIndexBytes(kind), protected);
+            defer self.releaseAcquiredVector(lane_indices);
+            protected |= floatRegMask(lane_indices.reg);
+            const mask = try self.allocTempVector(protected);
+            defer self.codegen.freeFloat(mask);
+            protected |= floatRegMask(mask);
+            try self.emitBasicSimdVector(.simd_eq_lanes, .u8x16, mask, lane_indices.reg, index_vector, null, protected);
+
+            const splat = try self.allocTempVector(protected);
+            defer self.codegen.freeFloat(splat);
+            protected |= floatRegMask(splat);
+            try self.emitSimdSplatFromGeneral(splat, scalar, kind);
+            const result = try self.allocTempVector(protected);
+            protected |= floatRegMask(result);
+            try self.emitBasicSimdVector(.simd_bit_select, kind, result, mask, splat, vector.reg, protected);
+            return .{ .vector_reg = .{ .reg = result, .kind = kind } };
+        }
+
+        fn generateSimdRearrange(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const lhs_local = GuardedList.at(args, 0);
+            const kind = self.simdKindForLayout(self.localLayout(lhs_local)) orelse unreachable;
+            const lhs = try self.acquireVectorLocal(lhs_local, kind, 0);
+            defer self.releaseAcquiredVector(lhs);
+            var protected = floatRegMask(lhs.reg);
+            var rhs: ?AcquiredVector = null;
+            if (ll.op != .simd_reverse_lanes) {
+                rhs = try self.acquireVectorLocal(GuardedList.at(args, 1), kind, protected);
+                protected |= floatRegMask(rhs.?.reg);
+            }
+            defer if (rhs) |value| self.releaseAcquiredVector(value);
+            const result = try self.allocTempVector(protected);
+            protected |= floatRegMask(result);
+
+            if (comptime target.toCpuArch() == .aarch64) {
+                switch (ll.op) {
+                    .simd_even_lanes => try self.codegen.emit.simdThreeReg(0x4E001800 | neonSizeBits(kind), result, lhs.reg, rhs.?.reg),
+                    .simd_odd_lanes => try self.codegen.emit.simdThreeReg(0x4E005800 | neonSizeBits(kind), result, lhs.reg, rhs.?.reg),
+                    .simd_reverse_lanes => {
+                        if (kind.laneBits() == 64) {
+                            try self.codegen.emit.simdThreeReg(0x6E004000, result, lhs.reg, lhs.reg);
+                        } else {
+                            try self.codegen.emit.simdTwoReg(0x4E200800 | neonSizeBits(kind), result, lhs.reg);
+                            try self.codegen.emit.simdThreeReg(0x6E004000, result, result, result);
+                        }
+                    },
+                    else => unreachable,
+                }
+            } else switch (ll.op) {
+                .simd_reverse_lanes => {
+                    const control = try self.materializeVectorConstant(simdReverseByteIndices(kind), protected);
+                    defer self.releaseAcquiredVector(control);
+                    try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x00, result, lhs.reg, control.reg);
+                },
+                .simd_even_lanes, .simd_odd_lanes => {
+                    const odd = ll.op == .simd_odd_lanes;
+                    const low_control = try self.materializeVectorConstant(simdParityByteIndices(kind, odd, false), protected);
+                    try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x00, result, lhs.reg, low_control.reg);
+                    self.releaseAcquiredVector(low_control);
+                    const high_control = try self.materializeVectorConstant(simdParityByteIndices(kind, odd, true), protected);
+                    defer self.releaseAcquiredVector(high_control);
+                    const tmp = try self.allocTempVector(protected | floatRegMask(high_control.reg));
+                    defer self.codegen.freeFloat(tmp);
+                    try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x00, tmp, rhs.?.reg, high_control.reg);
+                    try self.emitX86PackedBinary(.map_0f, 0xEB, result, result, tmp);
+                },
+                else => unreachable,
+            }
+            return .{ .vector_reg = .{ .reg = result, .kind = kind } };
+        }
+
+        fn generateSimdTableLookup(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const kind = self.simdKindForLayout(ll.ret_layout) orelse unreachable;
+            std.debug.assert(kind == .u8x16);
+            const table = try self.acquireVectorLocal(GuardedList.at(args, 0), .u8x16, 0);
+            defer self.releaseAcquiredVector(table);
+            var protected = floatRegMask(table.reg);
+            const indices = try self.acquireVectorLocal(GuardedList.at(args, 1), .u8x16, protected);
+            defer self.releaseAcquiredVector(indices);
+            protected |= floatRegMask(indices.reg);
+            const result = try self.allocTempVector(protected);
+            protected |= floatRegMask(result);
+            if (comptime target.toCpuArch() == .aarch64) {
+                try self.codegen.emit.simdThreeReg(0x4E000000, result, table.reg, indices.reg);
+            } else {
+                const fixup = try self.allocTempVector(protected);
+                defer self.codegen.freeFloat(fixup);
+                const seventy = try self.allocTempGeneral();
+                defer self.codegen.freeGeneral(seventy);
+                try self.codegen.emitLoadImm(seventy, 0x70);
+                try self.emitSimdSplatFromGeneral(fixup, seventy, .u8x16);
+                try self.emitX86PackedBinary(.map_0f, 0xDC, fixup, indices.reg, fixup);
+                try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x00, result, table.reg, fixup);
+            }
+            return .{ .vector_reg = .{ .reg = result, .kind = .u8x16 } };
+        }
+
+        fn generateSimdConcatShift(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const kind = self.simdKindForLayout(ll.ret_layout) orelse unreachable;
+            std.debug.assert(kind == .u8x16);
+            const lhs = try self.acquireVectorLocal(GuardedList.at(args, 0), .u8x16, 0);
+            defer self.releaseAcquiredVector(lhs);
+            var protected = floatRegMask(lhs.reg);
+            const rhs = try self.acquireVectorLocal(GuardedList.at(args, 1), .u8x16, protected);
+            defer self.releaseAcquiredVector(rhs);
+            protected |= floatRegMask(rhs.reg);
+            const count_loc = try self.emitValueLocal(GuardedList.at(args, 2));
+            const count = try self.ensureInGeneralReg(count_loc);
+            defer self.codegen.freeGeneral(count);
+            const result = try self.allocTempVector(protected);
+
+            var case_patches: [16]usize = undefined;
+            for (0..16) |shift| {
+                try self.emitCmpImm(count, @intCast(shift));
+                case_patches[shift] = try self.emitJumpIfEqual();
+            }
+            try self.codegen.emitMoveV128(result, rhs.reg);
+            var done_patches: [16]usize = undefined;
+            const default_done = try self.codegen.emitJump();
+            for (0..16) |shift| {
+                self.codegen.patchJump(case_patches[shift], self.codegen.currentOffset());
+                if (shift == 0) {
+                    try self.codegen.emitMoveV128(result, lhs.reg);
+                } else if (comptime target.toCpuArch() == .x86_64) {
+                    try self.codegen.emit.vexRegRegRegImm8(.map_0f3a, .p66, false, 0x0F, result, rhs.reg, lhs.reg, @intCast(shift));
+                } else {
+                    try self.codegen.emit.simdThreeReg(0x6E000000 | (@as(u32, @intCast(shift)) << 11), result, lhs.reg, rhs.reg);
+                }
+                done_patches[shift] = try self.codegen.emitJump();
+            }
+            const done = self.codegen.currentOffset();
+            self.codegen.patchJump(default_done, done);
+            for (done_patches) |patch| self.codegen.patchJump(patch, done);
+            return .{ .vector_reg = .{ .reg = result, .kind = .u8x16 } };
+        }
+
+        fn emitSimdWiden(
+            self: *Self,
+            dst: FloatReg,
+            src: FloatReg,
+            source_kind: builtins.simd.Kind,
+            high: bool,
+            protected_mask: u32,
+        ) Allocator.Error!void {
+            if (comptime target.toCpuArch() == .aarch64) {
+                const size_opcode: u32 = switch (source_kind.laneBits()) {
+                    8 => 0x00080000,
+                    16 => 0x00100000,
+                    32 => 0x00200000,
+                    else => unreachable,
+                };
+                const signed_base: u32 = if (source_kind.isSigned()) 0x0F00A400 else 0x2F00A400;
+                try self.codegen.emit.simdTwoReg(signed_base | size_opcode | (if (high) @as(u32, 0x40000000) else 0), dst, src);
+            } else {
+                const widened_source = if (high) blk: {
+                    const shifted = try self.allocTempVector(protected_mask);
+                    try self.codegen.emit.vexPackedShiftImm8(0x73, 3, shifted, src, 8);
+                    break :blk shifted;
+                } else src;
+                defer if (high) self.codegen.freeFloat(widened_source);
+                const opcode: u8 = switch (source_kind) {
+                    .u8x16 => 0x30,
+                    .i8x16 => 0x20,
+                    .u16x8 => 0x33,
+                    .i16x8 => 0x23,
+                    .u32x4 => 0x35,
+                    .i32x4 => 0x25,
+                    else => unreachable,
+                };
+                try self.codegen.emit.vexRegReg(.map_0f38, .p66, false, opcode, dst, widened_source);
+            }
+        }
+
+        fn emitX86MulWide32To64(
+            self: *Self,
+            dst: FloatReg,
+            lhs: FloatReg,
+            rhs: FloatReg,
+            signed: bool,
+            high: bool,
+            protected_mask: u32,
+        ) Allocator.Error!void {
+            const odd_lhs = try self.allocTempVector(protected_mask);
+            defer self.codegen.freeFloat(odd_lhs);
+            const odd_rhs = try self.allocTempVector(protected_mask | floatRegMask(odd_lhs));
+            defer self.codegen.freeFloat(odd_rhs);
+            const odd_product = try self.allocTempVector(protected_mask | floatRegMask(odd_lhs) | floatRegMask(odd_rhs));
+            defer self.codegen.freeFloat(odd_product);
+            try self.codegen.emit.vexRegRegImm8(.map_0f, .p66, false, 0x70, odd_lhs, lhs, 0xF5);
+            try self.codegen.emit.vexRegRegImm8(.map_0f, .p66, false, 0x70, odd_rhs, rhs, 0xF5);
+            if (signed) {
+                try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x28, dst, lhs, rhs);
+                try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x28, odd_product, odd_lhs, odd_rhs);
+            } else {
+                try self.emitX86PackedBinary(.map_0f, 0xF4, dst, lhs, rhs);
+                try self.emitX86PackedBinary(.map_0f, 0xF4, odd_product, odd_lhs, odd_rhs);
+            }
+            try self.emitX86PackedBinary(.map_0f, if (high) 0x6D else 0x6C, dst, dst, odd_product);
+        }
+
+        fn generateSimdMultiply(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const lhs_local = GuardedList.at(args, 0);
+            const source_kind = self.simdKindForLayout(self.localLayout(lhs_local)) orelse unreachable;
+            const destination_kind = self.simdKindForLayout(ll.ret_layout) orelse source_kind;
+            const lhs = try self.acquireVectorLocal(lhs_local, source_kind, 0);
+            defer self.releaseAcquiredVector(lhs);
+            var protected = floatRegMask(lhs.reg);
+            const rhs = try self.acquireVectorLocal(GuardedList.at(args, 1), source_kind, protected);
+            defer self.releaseAcquiredVector(rhs);
+            protected |= floatRegMask(rhs.reg);
+            const result = try self.allocTempVector(protected);
+            protected |= floatRegMask(result);
+
+            if (comptime target.toCpuArch() == .aarch64) {
+                switch (ll.op) {
+                    .simd_mul_wrap => try self.codegen.emit.simdThreeReg(0x4E209C00 | neonSizeBits(source_kind), result, lhs.reg, rhs.reg),
+                    .simd_mul_q15_sat => try self.codegen.emit.simdThreeReg(0x6E20B400 | neonSizeBits(source_kind), result, lhs.reg, rhs.reg),
+                    .simd_mul_wide_lo, .simd_mul_wide_hi => {
+                        const multiply_base: u32 = if (source_kind.isSigned()) 0x0E20C000 else 0x2E20C000;
+                        try self.codegen.emit.simdThreeReg(
+                            multiply_base | neonSizeBits(source_kind) | (if (ll.op == .simd_mul_wide_hi) @as(u32, 0x40000000) else 0),
+                            result,
+                            lhs.reg,
+                            rhs.reg,
+                        );
+                    },
+                    .simd_mul_high => {
+                        const low_product = try self.allocTempVector(protected);
+                        defer self.codegen.freeFloat(low_product);
+                        const multiply_base: u32 = if (source_kind.isSigned()) 0x0E20C000 else 0x2E20C000;
+                        try self.codegen.emit.simdThreeReg(multiply_base | neonSizeBits(source_kind), low_product, lhs.reg, rhs.reg);
+                        try self.codegen.emit.simdThreeReg(multiply_base | neonSizeBits(source_kind) | 0x40000000, result, lhs.reg, rhs.reg);
+                        try self.codegen.emit.simdThreeReg(0x4E005800 | neonSizeBits(source_kind), result, low_product, result);
+                    },
+                    else => unreachable,
+                }
+            } else switch (ll.op) {
+                .simd_mul_wrap => {
+                    const multiply_map: @TypeOf(self.codegen.emit).VexMap = if (source_kind.laneBits() == 32) .map_0f38 else .map_0f;
+                    try self.emitX86PackedBinary(
+                        multiply_map,
+                        x86PackedOpcode(source_kind, 0, 0xD5, 0x40, 0),
+                        result,
+                        lhs.reg,
+                        rhs.reg,
+                    );
+                },
+                .simd_mul_high => try self.emitX86PackedBinary(
+                    .map_0f,
+                    if (source_kind.isSigned()) 0xE5 else 0xE4,
+                    result,
+                    lhs.reg,
+                    rhs.reg,
+                ),
+                .simd_mul_q15_sat => {
+                    try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x0B, result, lhs.reg, rhs.reg);
+                    const minimum = try self.allocTempVector(protected);
+                    defer self.codegen.freeFloat(minimum);
+                    const corner = try self.allocTempVector(protected | floatRegMask(minimum));
+                    defer self.codegen.freeFloat(corner);
+                    try self.emitX86PackedBinary(.map_0f, 0x75, minimum, lhs.reg, lhs.reg);
+                    try self.codegen.emit.vexPackedShiftImm8(0x71, 6, minimum, minimum, 15);
+                    try self.emitX86PackedBinary(.map_0f, 0x75, corner, lhs.reg, minimum);
+                    try self.emitX86PackedBinary(.map_0f, 0x75, minimum, rhs.reg, minimum);
+                    try self.emitX86PackedBinary(.map_0f, 0xDB, corner, corner, minimum);
+                    try self.emitX86PackedBinary(.map_0f, 0xFD, result, result, corner);
+                },
+                .simd_mul_wide_lo, .simd_mul_wide_hi => {
+                    const high = ll.op == .simd_mul_wide_hi;
+                    if (source_kind.laneBits() == 32) {
+                        try self.emitX86MulWide32To64(result, lhs.reg, rhs.reg, source_kind.isSigned(), high, protected);
+                    } else {
+                        try self.emitSimdWiden(result, lhs.reg, source_kind, high, protected);
+                        const wide_rhs = try self.allocTempVector(protected);
+                        defer self.codegen.freeFloat(wide_rhs);
+                        try self.emitSimdWiden(wide_rhs, rhs.reg, source_kind, high, protected | floatRegMask(wide_rhs));
+                        const multiply_map: @TypeOf(self.codegen.emit).VexMap = if (destination_kind.laneBits() == 32) .map_0f38 else .map_0f;
+                        try self.emitX86PackedBinary(
+                            multiply_map,
+                            x86PackedOpcode(destination_kind, 0, 0xD5, 0x40, 0),
+                            result,
+                            result,
+                            wide_rhs,
+                        );
+                    }
+                },
+                else => unreachable,
+            }
+            return .{ .vector_reg = .{ .reg = result, .kind = destination_kind } };
+        }
+
+        fn generateSimdWidthChange(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const lhs_local = GuardedList.at(args, 0);
+            const source_kind = self.simdKindForLayout(self.localLayout(lhs_local)) orelse unreachable;
+            const destination_kind = self.simdKindForLayout(ll.ret_layout) orelse unreachable;
+            const lhs = try self.acquireVectorLocal(lhs_local, source_kind, 0);
+            defer self.releaseAcquiredVector(lhs);
+            var protected = floatRegMask(lhs.reg);
+            var rhs: ?AcquiredVector = null;
+            if (ll.op == .simd_narrow_wrap or ll.op == .simd_narrow_sat) {
+                rhs = try self.acquireVectorLocal(GuardedList.at(args, 1), source_kind, protected);
+                protected |= floatRegMask(rhs.?.reg);
+            }
+            defer if (rhs) |value| self.releaseAcquiredVector(value);
+            const result = try self.allocTempVector(protected);
+            protected |= floatRegMask(result);
+
+            switch (ll.op) {
+                .simd_widen_lo, .simd_widen_hi => try self.emitSimdWiden(
+                    result,
+                    lhs.reg,
+                    source_kind,
+                    ll.op == .simd_widen_hi,
+                    protected,
+                ),
+                .simd_pairwise_add_widen => if (comptime target.toCpuArch() == .aarch64) {
+                    try self.codegen.emit.simdTwoReg(
+                        (if (source_kind.isSigned()) @as(u32, 0x4E202800) else 0x6E202800) | neonSizeBits(source_kind),
+                        result,
+                        lhs.reg,
+                    );
+                } else {
+                    try self.emitSimdWiden(result, lhs.reg, source_kind, false, protected);
+                    const high = try self.allocTempVector(protected);
+                    defer self.codegen.freeFloat(high);
+                    try self.emitSimdWiden(high, lhs.reg, source_kind, true, protected | floatRegMask(high));
+                    try self.codegen.emit.vexRegRegReg(
+                        .map_0f38,
+                        .p66,
+                        false,
+                        if (destination_kind.laneBits() == 16) 0x01 else 0x02,
+                        result,
+                        result,
+                        high,
+                    );
+                },
+                .simd_narrow_wrap => if (comptime target.toCpuArch() == .aarch64) {
+                    const size = neonSizeBits(destination_kind);
+                    try self.codegen.emit.simdTwoReg(0x0E212800 | size, result, lhs.reg);
+                    try self.codegen.emit.simdTwoReg(0x4E212800 | size, result, rhs.?.reg);
+                } else {
+                    const low_control = try self.materializeVectorConstant(simdNarrowByteIndices(source_kind, destination_kind, false), protected);
+                    try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x00, result, lhs.reg, low_control.reg);
+                    self.releaseAcquiredVector(low_control);
+                    const high_control = try self.materializeVectorConstant(simdNarrowByteIndices(source_kind, destination_kind, true), protected);
+                    defer self.releaseAcquiredVector(high_control);
+                    const high = try self.allocTempVector(protected | floatRegMask(high_control.reg));
+                    defer self.codegen.freeFloat(high);
+                    try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x00, high, rhs.?.reg, high_control.reg);
+                    try self.emitX86PackedBinary(.map_0f, 0xEB, result, result, high);
+                },
+                .simd_narrow_sat => if (comptime target.toCpuArch() == .aarch64) {
+                    const size = neonSizeBits(destination_kind);
+                    const low_base: u32 = if (destination_kind.isSigned())
+                        0x0E214800
+                    else if (source_kind.isSigned())
+                        0x2E212800
+                    else
+                        0x2E214800;
+                    try self.codegen.emit.simdTwoReg(low_base | size, result, lhs.reg);
+                    try self.codegen.emit.simdTwoReg((low_base | 0x40000000) | size, result, rhs.?.reg);
+                } else {
+                    var pack_lhs = lhs.reg;
+                    var pack_rhs = rhs.?.reg;
+                    var clamped_lhs: ?FloatReg = null;
+                    var clamped_rhs: ?FloatReg = null;
+                    defer if (clamped_lhs) |reg| self.codegen.freeFloat(reg);
+                    defer if (clamped_rhs) |reg| self.codegen.freeFloat(reg);
+                    if (!source_kind.isSigned()) {
+                        const maximum = try self.allocTempVector(protected);
+                        defer self.codegen.freeFloat(maximum);
+                        const scalar = try self.allocTempGeneral();
+                        defer self.codegen.freeGeneral(scalar);
+                        const max_value: i64 = switch (destination_kind.laneBits()) {
+                            8 => 0xFF,
+                            16 => 0xFFFF,
+                            else => unreachable,
+                        };
+                        try self.codegen.emitLoadImm(scalar, max_value);
+                        try self.emitSimdSplatFromGeneral(maximum, scalar, source_kind);
+                        clamped_lhs = try self.allocTempVector(protected | floatRegMask(maximum));
+                        clamped_rhs = try self.allocTempVector(protected | floatRegMask(maximum) | floatRegMask(clamped_lhs.?));
+                        try self.emitX86PackedBinary(
+                            .map_0f38,
+                            if (source_kind.laneBits() == 16) 0x3A else 0x3B,
+                            clamped_lhs.?,
+                            lhs.reg,
+                            maximum,
+                        );
+                        try self.emitX86PackedBinary(
+                            .map_0f38,
+                            if (source_kind.laneBits() == 16) 0x3A else 0x3B,
+                            clamped_rhs.?,
+                            rhs.?.reg,
+                            maximum,
+                        );
+                        pack_lhs = clamped_lhs.?;
+                        pack_rhs = clamped_rhs.?;
+                    }
+                    const map: @TypeOf(self.codegen.emit).VexMap = if (source_kind.laneBits() == 32 and !destination_kind.isSigned()) .map_0f38 else .map_0f;
+                    const opcode: u8 = if (destination_kind.isSigned())
+                        (if (destination_kind.laneBits() == 8) 0x63 else 0x6B)
+                    else if (destination_kind.laneBits() == 8)
+                        0x67
+                    else
+                        0x2B;
+                    try self.emitX86PackedBinary(map, opcode, result, pack_lhs, pack_rhs);
+                },
+                else => unreachable,
+            }
+            return .{ .vector_reg = .{ .reg = result, .kind = destination_kind } };
+        }
+
+        fn generateSimdDot(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const lhs_local = GuardedList.at(args, 0);
+            const lhs_kind = self.simdKindForLayout(self.localLayout(lhs_local)) orelse unreachable;
+            const rhs_local = GuardedList.at(args, 1);
+            const rhs_kind = self.simdKindForLayout(self.localLayout(rhs_local)) orelse unreachable;
+            const result_kind = self.simdKindForLayout(ll.ret_layout) orelse unreachable;
+            const lhs = try self.acquireVectorLocal(lhs_local, lhs_kind, 0);
+            defer self.releaseAcquiredVector(lhs);
+            var protected = floatRegMask(lhs.reg);
+            const rhs = try self.acquireVectorLocal(rhs_local, rhs_kind, protected);
+            defer self.releaseAcquiredVector(rhs);
+            protected |= floatRegMask(rhs.reg);
+            const result = try self.allocTempVector(protected);
+            protected |= floatRegMask(result);
+
+            if (comptime target.toCpuArch() == .x86_64) {
+                switch (ll.op) {
+                    .simd_dot_pairs => try self.emitX86PackedBinary(.map_0f, 0xF5, result, lhs.reg, rhs.reg),
+                    .simd_dot_pairs_sat => try self.emitX86PackedBinary(.map_0f38, 0x04, result, lhs.reg, rhs.reg),
+                    .simd_sad => try self.emitX86PackedBinary(.map_0f, 0xF6, result, lhs.reg, rhs.reg),
+                    else => unreachable,
+                }
+            } else switch (ll.op) {
+                .simd_dot_pairs => {
+                    const low = try self.allocTempVector(protected);
+                    defer self.codegen.freeFloat(low);
+                    try self.codegen.emit.simdThreeReg(0x0E60C000, low, lhs.reg, rhs.reg);
+                    try self.codegen.emit.simdThreeReg(0x4E60C000, result, lhs.reg, rhs.reg);
+                    try self.codegen.emit.simdThreeReg(0x4E20BC00 | neonSizeBits(.i32x4), result, low, result);
+                },
+                .simd_dot_pairs_sat => {
+                    const a = try self.allocTempVector(protected);
+                    defer self.codegen.freeFloat(a);
+                    const b = try self.allocTempVector(protected | floatRegMask(a));
+                    defer self.codegen.freeFloat(b);
+                    try self.emitSimdWiden(a, lhs.reg, .u8x16, false, protected | floatRegMask(a) | floatRegMask(b));
+                    try self.emitSimdWiden(b, rhs.reg, .i8x16, false, protected | floatRegMask(a) | floatRegMask(b));
+                    try self.codegen.emit.simdThreeReg(0x4E209C00 | neonSizeBits(.i16x8), a, a, b);
+                    try self.codegen.emit.simdTwoReg(0x4E202800 | neonSizeBits(.i16x8), result, a);
+
+                    try self.emitSimdWiden(a, lhs.reg, .u8x16, true, protected | floatRegMask(a) | floatRegMask(b));
+                    try self.emitSimdWiden(b, rhs.reg, .i8x16, true, protected | floatRegMask(a) | floatRegMask(b));
+                    try self.codegen.emit.simdThreeReg(0x4E209C00 | neonSizeBits(.i16x8), a, a, b);
+                    try self.codegen.emit.simdTwoReg(0x4E202800 | neonSizeBits(.i16x8), a, a);
+                    try self.codegen.emit.simdTwoReg(0x0E214800 | neonSizeBits(.i16x8), result, result);
+                    try self.codegen.emit.simdTwoReg(0x4E214800 | neonSizeBits(.i16x8), result, a);
+                },
+                .simd_sad => {
+                    const low = try self.allocTempVector(protected);
+                    defer self.codegen.freeFloat(low);
+                    try self.codegen.emit.simdThreeReg(0x2E207000, low, lhs.reg, rhs.reg);
+                    try self.codegen.emit.simdThreeReg(0x6E207000, result, lhs.reg, rhs.reg);
+                    try self.codegen.emit.simdTwoReg(0x6E303800 | neonSizeBits(.u16x8), low, low);
+                    try self.codegen.emit.simdTwoReg(0x6E303800 | neonSizeBits(.u16x8), result, result);
+                    const low_sum = try self.allocTempGeneral();
+                    defer self.codegen.freeGeneral(low_sum);
+                    const high_sum = try self.allocTempGeneral();
+                    defer self.codegen.freeGeneral(high_sum);
+                    try self.codegen.emit.extractVectorLaneUnsigned(low_sum, low, 32, 0);
+                    try self.codegen.emit.extractVectorLaneUnsigned(high_sum, result, 32, 0);
+                    try self.codegen.emit.duplicateGeneralToVector(result, low_sum, 64);
+                    try self.codegen.emit.insertGeneralVectorLane(result, high_sum, 64, 1);
+                },
+                else => unreachable,
+            }
+            return .{ .vector_reg = .{ .reg = result, .kind = result_kind } };
+        }
+
+        fn emitNeonShiftRightImmediate(
+            self: *Self,
+            dst: FloatReg,
+            src: FloatReg,
+            lane_bits: u7,
+            amount: u7,
+        ) Allocator.Error!void {
+            std.debug.assert(amount > 0 and amount < lane_bits);
+            const encoded_imm: u8 = @intCast(@as(u16, lane_bits) * 2 - amount);
+            try self.codegen.emit.simdTwoReg(0x6F000400 | (@as(u32, encoded_imm) << 16), dst, src);
+        }
+
+        fn generateSimdBitmask(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            _ = ll;
+            const vector_local = GuardedList.at(args, 0);
+            const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
+            const vector = try self.acquireVectorLocal(vector_local, kind, 0);
+            defer self.releaseAcquiredVector(vector);
+            const result = try self.allocTempGeneral();
+
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.codegen.emit.packedMoveMask(result, vector.reg, kind.laneBits());
+                if (kind.laneBits() == 16) {
+                    const mask = try self.allocTempGeneral();
+                    defer self.codegen.freeGeneral(mask);
+                    try self.codegen.emitLoadImm(mask, 0xAAAA);
+                    try self.codegen.emit.pext(result, result, mask);
+                }
+                return .{ .general_reg = result };
+            }
+
+            if (kind.laneBits() == 64) {
+                const shifted = try self.allocTempVector(floatRegMask(vector.reg));
+                defer self.codegen.freeFloat(shifted);
+                try self.emitNeonShiftRightImmediate(shifted, vector.reg, 64, 63);
+                const high = try self.allocTempGeneral();
+                defer self.codegen.freeGeneral(high);
+                try self.codegen.emit.extractVectorLaneUnsigned(result, shifted, 64, 0);
+                try self.codegen.emit.extractVectorLaneUnsigned(high, shifted, 64, 1);
+                try self.emitShlImm(.w64, high, high, 1);
+                try self.emitOrRegs(.w64, result, result, high);
+                return .{ .general_reg = result };
+            }
+
+            const shifted = try self.allocTempVector(floatRegMask(vector.reg));
+            defer self.codegen.freeFloat(shifted);
+            try self.emitNeonShiftRightImmediate(shifted, vector.reg, kind.laneBits(), kind.laneBits() - 1);
+            if (kind.laneBits() == 8) {
+                const low = try self.allocTempVector(floatRegMask(vector.reg) | floatRegMask(shifted));
+                defer self.codegen.freeFloat(low);
+                const high = try self.allocTempVector(floatRegMask(vector.reg) | floatRegMask(shifted) | floatRegMask(low));
+                defer self.codegen.freeFloat(high);
+                try self.emitSimdWiden(low, shifted, .u8x16, false, 0);
+                try self.emitSimdWiden(high, shifted, .u8x16, true, 0);
+                const weights = try self.materializeVectorConstant(simdLaneWeights(.u16x8), floatRegMask(vector.reg) | floatRegMask(shifted) | floatRegMask(low) | floatRegMask(high));
+                defer self.releaseAcquiredVector(weights);
+                try self.codegen.emit.simdThreeReg(0x4E209C00 | neonSizeBits(.u16x8), low, low, weights.reg);
+                try self.codegen.emit.simdThreeReg(0x4E209C00 | neonSizeBits(.u16x8), high, high, weights.reg);
+                try self.codegen.emit.simdTwoReg(0x6E303800 | neonSizeBits(.u16x8), low, low);
+                try self.codegen.emit.simdTwoReg(0x6E303800 | neonSizeBits(.u16x8), high, high);
+                const high_bits = try self.allocTempGeneral();
+                defer self.codegen.freeGeneral(high_bits);
+                try self.codegen.emit.extractVectorLaneUnsigned(result, low, 32, 0);
+                try self.codegen.emit.extractVectorLaneUnsigned(high_bits, high, 32, 0);
+                try self.emitShlImm(.w64, high_bits, high_bits, 8);
+                try self.emitOrRegs(.w64, result, result, high_bits);
+            } else {
+                const weights = try self.materializeVectorConstant(simdLaneWeights(kind), floatRegMask(vector.reg) | floatRegMask(shifted));
+                defer self.releaseAcquiredVector(weights);
+                try self.codegen.emit.simdThreeReg(0x4E209C00 | neonSizeBits(kind), shifted, shifted, weights.reg);
+                try self.codegen.emit.simdTwoReg(0x6E303800 | neonSizeBits(kind), shifted, shifted);
+                try self.codegen.emit.extractVectorLaneUnsigned(result, shifted, kind.laneBits() * 2, 0);
+            }
+            return .{ .general_reg = result };
+        }
+
+        fn signExtendGeneral(
+            self: *Self,
+            reg: GeneralReg,
+            source_bits: u7,
+        ) Allocator.Error!void {
+            const shift: u8 = @intCast(64 - source_bits);
+            try self.emitShlImm(.w64, reg, reg, shift);
+            try self.emitAsrImm(.w64, reg, reg, shift);
+        }
+
+        fn generateSimdShift(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const vector_local = GuardedList.at(args, 0);
+            const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
+            const vector = try self.acquireVectorLocal(vector_local, kind, 0);
+            defer self.releaseAcquiredVector(vector);
+            var protected = floatRegMask(vector.reg);
+            const raw_count_loc = try self.emitValueLocal(GuardedList.at(args, 1));
+            const raw_count = try self.ensureInGeneralReg(raw_count_loc);
+            defer self.codegen.freeGeneral(raw_count);
+            const count = try self.allocTempGeneral();
+            defer self.codegen.freeGeneral(count);
+            try self.emitMovRegReg(count, raw_count);
+            const count_mask = try self.allocTempGeneral();
+            defer self.codegen.freeGeneral(count_mask);
+            try self.codegen.emitLoadImm(count_mask, kind.laneBits() - 1);
+            try self.emitAndRegs(.w64, count, count, count_mask);
+
+            const result = try self.allocTempVector(protected);
+            protected |= floatRegMask(result);
+            if (comptime target.toCpuArch() == .aarch64) {
+                if (ll.op != .simd_shl_wrap) {
+                    const zero = try self.allocTempGeneral();
+                    defer self.codegen.freeGeneral(zero);
+                    try self.codegen.emitLoadImm(zero, 0);
+                    try self.emitSubRegs(.w64, count, zero, count);
+                }
+                const counts = try self.allocTempVector(protected);
+                defer self.codegen.freeFloat(counts);
+                try self.emitSimdSplatFromGeneral(counts, count, kind);
+                try self.codegen.emit.simdThreeReg(
+                    (if (ll.op == .simd_shr_wrap and kind.isSigned()) @as(u32, 0x4E204400) else 0x6E204400) | neonSizeBits(kind),
+                    result,
+                    vector.reg,
+                    counts,
+                );
+                return .{ .vector_reg = .{ .reg = result, .kind = kind } };
+            }
+
+            const counts = try self.allocTempVector(protected);
+            defer self.codegen.freeFloat(counts);
+            protected |= floatRegMask(counts);
+            try self.codegen.emit.movVectorFromGeneral(counts, count, true);
+            if (kind.laneBits() == 8) {
+                if (ll.op == .simd_shr_wrap and kind.isSigned()) {
+                    const low = try self.allocTempVector(protected);
+                    defer self.codegen.freeFloat(low);
+                    const high = try self.allocTempVector(protected | floatRegMask(low));
+                    defer self.codegen.freeFloat(high);
+                    try self.emitSimdWiden(low, vector.reg, .i8x16, false, protected | floatRegMask(low) | floatRegMask(high));
+                    try self.emitSimdWiden(high, vector.reg, .i8x16, true, protected | floatRegMask(low) | floatRegMask(high));
+                    try self.emitX86PackedBinary(.map_0f, 0xE1, low, low, counts);
+                    try self.emitX86PackedBinary(.map_0f, 0xE1, high, high, counts);
+                    try self.emitX86PackedBinary(.map_0f, 0x63, result, low, high);
+                } else {
+                    try self.emitX86PackedBinary(.map_0f, if (ll.op == .simd_shl_wrap) 0xF1 else 0xD1, result, vector.reg, counts);
+                    const byte_mask = try self.allocTempGeneral();
+                    defer self.codegen.freeGeneral(byte_mask);
+                    try self.codegen.emitLoadImm(byte_mask, 0xFF);
+                    if (ll.op == .simd_shl_wrap) {
+                        try self.emitShlReg(.w64, byte_mask, byte_mask, count);
+                    } else {
+                        try self.emitLsrReg(.w64, byte_mask, byte_mask, count);
+                    }
+                    const masks = try self.allocTempVector(protected);
+                    defer self.codegen.freeFloat(masks);
+                    try self.emitSimdSplatFromGeneral(masks, byte_mask, .u8x16);
+                    try self.emitX86PackedBinary(.map_0f, 0xDB, result, result, masks);
+                }
+            } else if (ll.op == .simd_shr_wrap and kind.isSigned() and kind.laneBits() == 64) {
+                const zero = try self.allocTempVector(protected);
+                defer self.codegen.freeFloat(zero);
+                const sign = try self.allocTempVector(protected | floatRegMask(zero));
+                defer self.codegen.freeFloat(sign);
+                try self.emitX86PackedBinary(.map_0f, 0xEF, zero, vector.reg, vector.reg);
+                try self.emitX86PackedBinary(.map_0f38, 0x37, sign, zero, vector.reg);
+                try self.emitX86PackedBinary(.map_0f, 0xD3, result, vector.reg, counts);
+                const inverse = try self.allocTempGeneral();
+                defer self.codegen.freeGeneral(inverse);
+                try self.codegen.emitLoadImm(inverse, 64);
+                try self.emitSubRegs(.w64, inverse, inverse, count);
+                try self.codegen.emit.movVectorFromGeneral(counts, inverse, true);
+                try self.emitX86PackedBinary(.map_0f, 0xF3, sign, sign, counts);
+                try self.emitX86PackedBinary(.map_0f, 0xEB, result, result, sign);
+            } else {
+                const opcode = if (ll.op == .simd_shl_wrap)
+                    x86PackedOpcode(kind, 0, 0xF1, 0xF2, 0xF3)
+                else if (ll.op == .simd_shr_wrap and kind.isSigned())
+                    x86PackedOpcode(kind, 0, 0xE1, 0xE2, 0)
+                else
+                    x86PackedOpcode(kind, 0, 0xD1, 0xD2, 0xD3);
+                try self.emitX86PackedBinary(.map_0f, opcode, result, vector.reg, counts);
+            }
+            return .{ .vector_reg = .{ .reg = result, .kind = kind } };
+        }
+
+        fn emitX86ArithmeticShiftQwords(
+            self: *Self,
+            dst: FloatReg,
+            src: FloatReg,
+            count_vector: FloatReg,
+            count: GeneralReg,
+            protected_mask: u32,
+        ) Allocator.Error!void {
+            const zero = try self.allocTempVector(protected_mask);
+            defer self.codegen.freeFloat(zero);
+            const sign = try self.allocTempVector(protected_mask | floatRegMask(zero));
+            defer self.codegen.freeFloat(sign);
+            try self.emitX86PackedBinary(.map_0f, 0xEF, zero, src, src);
+            try self.emitX86PackedBinary(.map_0f38, 0x37, sign, zero, src);
+            try self.emitX86PackedBinary(.map_0f, 0xD3, dst, src, count_vector);
+            const inverse = try self.allocTempGeneral();
+            defer self.codegen.freeGeneral(inverse);
+            try self.codegen.emitLoadImm(inverse, 64);
+            try self.emitSubRegs(.w64, inverse, inverse, count);
+            try self.codegen.emit.movVectorFromGeneral(count_vector, inverse, true);
+            try self.emitX86PackedBinary(.map_0f, 0xF3, sign, sign, count_vector);
+            try self.emitX86PackedBinary(.map_0f, 0xEB, dst, dst, sign);
+            try self.codegen.emit.movVectorFromGeneral(count_vector, count, true);
+        }
+
+        fn emitX86NarrowWrapRegisters(
+            self: *Self,
+            dst: FloatReg,
+            low: FloatReg,
+            high: FloatReg,
+            source_kind: builtins.simd.Kind,
+            destination_kind: builtins.simd.Kind,
+            protected_mask: u32,
+        ) Allocator.Error!void {
+            const low_control = try self.materializeVectorConstant(simdNarrowByteIndices(source_kind, destination_kind, false), protected_mask);
+            try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x00, dst, low, low_control.reg);
+            self.releaseAcquiredVector(low_control);
+            const high_control = try self.materializeVectorConstant(simdNarrowByteIndices(source_kind, destination_kind, true), protected_mask);
+            defer self.releaseAcquiredVector(high_control);
+            const narrowed_high = try self.allocTempVector(protected_mask | floatRegMask(high_control.reg));
+            defer self.codegen.freeFloat(narrowed_high);
+            try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, 0x00, narrowed_high, high, high_control.reg);
+            try self.emitX86PackedBinary(.map_0f, 0xEB, dst, dst, narrowed_high);
+        }
+
+        fn generateSimdRoundedShift(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const vector_local = GuardedList.at(args, 0);
+            const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
+            std.debug.assert(kind == .i16x8 or kind == .i32x4);
+            const vector = try self.acquireVectorLocal(vector_local, kind, 0);
+            defer self.releaseAcquiredVector(vector);
+            var protected = floatRegMask(vector.reg);
+            const raw_count_loc = try self.emitValueLocal(GuardedList.at(args, 1));
+            const count = try self.ensureInGeneralReg(raw_count_loc);
+            defer self.codegen.freeGeneral(count);
+            const result = try self.allocTempVector(protected);
+            protected |= floatRegMask(result);
+
+            try self.emitCmpImm(count, 0);
+            const zero_count_patch = try self.emitJumpIfEqual();
+            try self.emitCmpImm(count, kind.laneBits());
+            const out_of_range_patch = try self.codegen.emitCondJump(condAboveOrEqual());
+
+            const wide_kind: builtins.simd.Kind = if (kind == .i16x8) .i32x4 else .i64x2;
+            try self.emitSimdWiden(result, vector.reg, kind, false, protected);
+            const high = try self.allocTempVector(protected);
+            protected |= floatRegMask(high);
+            try self.emitSimdWiden(high, vector.reg, kind, true, protected);
+            const bias_scalar = try self.allocTempGeneral();
+            defer self.codegen.freeGeneral(bias_scalar);
+            try self.codegen.emitLoadImm(bias_scalar, 1);
+            const bias_shift = try self.allocTempGeneral();
+            defer self.codegen.freeGeneral(bias_shift);
+            try self.emitMovRegReg(bias_shift, count);
+            const one = try self.allocTempGeneral();
+            defer self.codegen.freeGeneral(one);
+            try self.codegen.emitLoadImm(one, 1);
+            try self.emitSubRegs(.w64, bias_shift, bias_shift, one);
+            try self.emitShlReg(.w64, bias_scalar, bias_scalar, bias_shift);
+            const bias = try self.allocTempVector(protected);
+            try self.emitSimdSplatFromGeneral(bias, bias_scalar, wide_kind);
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.emitX86PackedBinary(.map_0f, x86PackedOpcode(wide_kind, 0, 0, 0xFE, 0xD4), result, result, bias);
+                try self.emitX86PackedBinary(.map_0f, x86PackedOpcode(wide_kind, 0, 0, 0xFE, 0xD4), high, high, bias);
+            } else {
+                try self.codegen.emit.simdThreeReg(0x4E208400 | neonSizeBits(wide_kind), result, result, bias);
+                try self.codegen.emit.simdThreeReg(0x4E208400 | neonSizeBits(wide_kind), high, high, bias);
+            }
+            self.codegen.freeFloat(bias);
+
+            const counts = try self.allocTempVector(protected);
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.codegen.emit.movVectorFromGeneral(counts, count, true);
+                if (wide_kind.laneBits() == 32) {
+                    try self.emitX86PackedBinary(.map_0f, 0xE2, result, result, counts);
+                    try self.emitX86PackedBinary(.map_0f, 0xE2, high, high, counts);
+                } else {
+                    try self.emitX86ArithmeticShiftQwords(result, result, counts, count, protected | floatRegMask(high) | floatRegMask(counts));
+                    try self.emitX86ArithmeticShiftQwords(high, high, counts, count, protected | floatRegMask(high) | floatRegMask(counts));
+                }
+            } else {
+                const negative_count = try self.allocTempGeneral();
+                defer self.codegen.freeGeneral(negative_count);
+                const zero = try self.allocTempGeneral();
+                defer self.codegen.freeGeneral(zero);
+                try self.codegen.emitLoadImm(zero, 0);
+                try self.emitSubRegs(.w64, negative_count, zero, count);
+                try self.emitSimdSplatFromGeneral(counts, negative_count, wide_kind);
+                try self.codegen.emit.simdThreeReg(0x4E204400 | neonSizeBits(wide_kind), result, result, counts);
+                try self.codegen.emit.simdThreeReg(0x4E204400 | neonSizeBits(wide_kind), high, high, counts);
+            }
+            self.codegen.freeFloat(counts);
+
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.emitX86NarrowWrapRegisters(result, result, high, wide_kind, kind, protected | floatRegMask(high));
+            } else {
+                try self.codegen.emit.simdTwoReg(0x0E212800 | neonSizeBits(kind), result, result);
+                try self.codegen.emit.simdTwoReg(0x4E212800 | neonSizeBits(kind), result, high);
+            }
+            self.codegen.freeFloat(high);
+            const normal_done = try self.codegen.emitJump();
+
+            self.codegen.patchJump(out_of_range_patch, self.codegen.currentOffset());
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.emitX86PackedBinary(.map_0f, 0xEF, result, result, result);
+            } else {
+                try self.codegen.emit.simdThreeReg(0x6E201C00, result, result, result);
+            }
+            const range_done = try self.codegen.emitJump();
+
+            self.codegen.patchJump(zero_count_patch, self.codegen.currentOffset());
+            try self.codegen.emitMoveV128(result, vector.reg);
+            const done = self.codegen.currentOffset();
+            self.codegen.patchJump(normal_done, done);
+            self.codegen.patchJump(range_done, done);
+            _ = ll;
+            return .{ .vector_reg = .{ .reg = result, .kind = kind } };
+        }
+
+        fn generateSimdSum(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            _ = ll;
+            const vector_local = GuardedList.at(args, 0);
+            const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
+            const vector = try self.acquireVectorLocal(vector_local, kind, 0);
+            defer self.releaseAcquiredVector(vector);
+            const result = try self.allocTempGeneral();
+
+            if (comptime target.toCpuArch() == .aarch64) {
+                if (kind.laneBits() == 64) {
+                    const high = try self.allocTempGeneral();
+                    defer self.codegen.freeGeneral(high);
+                    try self.codegen.emit.extractVectorLaneUnsigned(result, vector.reg, 64, 0);
+                    try self.codegen.emit.extractVectorLaneUnsigned(high, vector.reg, 64, 1);
+                    try self.emitAddRegs(.w64, result, result, high);
+                } else {
+                    const reduced = try self.allocTempVector(floatRegMask(vector.reg));
+                    defer self.codegen.freeFloat(reduced);
+                    try self.codegen.emit.simdTwoReg(
+                        (if (kind.isSigned()) @as(u32, 0x4E303800) else 0x6E303800) | neonSizeBits(kind),
+                        reduced,
+                        vector.reg,
+                    );
+                    const result_bits: u7 = kind.laneBits() * 2;
+                    try self.codegen.emit.extractVectorLaneUnsigned(result, reduced, result_bits, 0);
+                    if (kind.isSigned() and result_bits < 32) try self.signExtendGeneral(result, result_bits);
+                }
+                return .{ .general_reg = result };
+            }
+
+            if (kind.laneBits() <= 16) {
+                const pairs_kind: builtins.simd.Kind = switch (kind) {
+                    .u8x16 => .u16x8,
+                    .i8x16 => .i16x8,
+                    .u16x8 => .u32x4,
+                    .i16x8 => .i32x4,
+                    else => unreachable,
+                };
+                const pairs = try self.allocTempVector(floatRegMask(vector.reg));
+                defer self.codegen.freeFloat(pairs);
+                try self.emitSimdWiden(pairs, vector.reg, kind, false, floatRegMask(vector.reg) | floatRegMask(pairs));
+                const high = try self.allocTempVector(floatRegMask(vector.reg) | floatRegMask(pairs));
+                defer self.codegen.freeFloat(high);
+                try self.emitSimdWiden(high, vector.reg, kind, true, floatRegMask(vector.reg) | floatRegMask(pairs) | floatRegMask(high));
+                try self.codegen.emit.vexRegRegReg(
+                    .map_0f38,
+                    .p66,
+                    false,
+                    if (pairs_kind.laneBits() == 16) 0x01 else 0x02,
+                    pairs,
+                    pairs,
+                    high,
+                );
+                const horizontal_opcode: u8 = if (pairs_kind.laneBits() == 16) 0x01 else 0x02;
+                try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, horizontal_opcode, pairs, pairs, pairs);
+                try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, horizontal_opcode, pairs, pairs, pairs);
+                if (pairs_kind.laneBits() == 16) {
+                    try self.codegen.emit.vexRegRegReg(.map_0f38, .p66, false, horizontal_opcode, pairs, pairs, pairs);
+                }
+                try self.codegen.emit.movGeneralFromVector(result, pairs, false);
+                if (kind == .i8x16) {
+                    try self.signExtendGeneral(result, 16);
+                } else if (kind == .u8x16) {
+                    const mask = try self.allocTempGeneral();
+                    defer self.codegen.freeGeneral(mask);
+                    try self.codegen.emitLoadImm(mask, 0xFFFF);
+                    try self.emitAndRegs(.w64, result, result, mask);
+                }
+            } else if (kind.laneBits() == 32) {
+                const low = try self.allocTempVector(floatRegMask(vector.reg));
+                defer self.codegen.freeFloat(low);
+                const high = try self.allocTempVector(floatRegMask(vector.reg) | floatRegMask(low));
+                defer self.codegen.freeFloat(high);
+                try self.emitSimdWiden(low, vector.reg, kind, false, floatRegMask(vector.reg) | floatRegMask(low) | floatRegMask(high));
+                try self.emitSimdWiden(high, vector.reg, kind, true, floatRegMask(vector.reg) | floatRegMask(low) | floatRegMask(high));
+                try self.emitX86PackedBinary(.map_0f, 0xD4, low, low, high);
+                const other = try self.allocTempGeneral();
+                defer self.codegen.freeGeneral(other);
+                try self.codegen.emit.movGeneralFromVector(result, low, true);
+                try self.codegen.emit.extractQword(other, low, 1);
+                try self.emitAddRegs(.w64, result, result, other);
+            } else {
+                const high = try self.allocTempGeneral();
+                defer self.codegen.freeGeneral(high);
+                try self.codegen.emit.movGeneralFromVector(result, vector.reg, true);
+                try self.codegen.emit.extractQword(high, vector.reg, 1);
+                try self.emitAddRegs(.w64, result, result, high);
+            }
+            return .{ .general_reg = result };
+        }
+
+        fn generateSimdClmul(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            const lhs = try self.acquireVectorLocal(GuardedList.at(args, 0), .u64x2, 0);
+            defer self.releaseAcquiredVector(lhs);
+            var protected = floatRegMask(lhs.reg);
+            const rhs = try self.acquireVectorLocal(GuardedList.at(args, 1), .u64x2, protected);
+            defer self.releaseAcquiredVector(rhs);
+            protected |= floatRegMask(rhs.reg);
+            const result = try self.allocTempVector(protected);
+            if (comptime target.toCpuArch() == .x86_64) {
+                try self.codegen.emit.vexRegRegRegImm8(
+                    .map_0f3a,
+                    .p66,
+                    false,
+                    0x44,
+                    result,
+                    lhs.reg,
+                    rhs.reg,
+                    if (ll.op == .simd_clmul_hi) 0x11 else 0,
+                );
+            } else {
+                try self.codegen.emit.simdThreeReg(
+                    if (ll.op == .simd_clmul_hi) 0x4EE0E000 else 0x0EE0E000,
+                    result,
+                    lhs.reg,
+                    rhs.reg,
+                );
+            }
+            return .{ .vector_reg = .{ .reg = result, .kind = .u64x2 } };
+        }
+
         fn simdArgParts(self: *Self, local: LocalId) Allocator.Error!I128Parts {
             const arg_layout = self.localLayout(local);
             const arg_size = self.layout_store.layoutSize(self.layout_store.getLayout(arg_layout));
@@ -4601,58 +5799,249 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             return .{ .low = low, .high = high };
         }
 
-        fn generateSimdLowLevel(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+        fn neonSizeBits(kind: builtins.simd.Kind) u32 {
+            return switch (kind.laneBits()) {
+                8 => 0,
+                16 => 1 << 22,
+                32 => 2 << 22,
+                64 => 3 << 22,
+                else => unreachable,
+            };
+        }
+
+        fn x86PackedOpcode(kind: builtins.simd.Kind, b: u8, h: u8, s: u8, d: u8) u8 {
+            return switch (kind.laneBits()) {
+                8 => b,
+                16 => h,
+                32 => s,
+                64 => d,
+                else => unreachable,
+            };
+        }
+
+        fn emitX86PackedBinary(
+            self: *Self,
+            map: anytype,
+            opcode: u8,
+            dst: FloatReg,
+            lhs: FloatReg,
+            rhs: FloatReg,
+        ) Allocator.Error!void {
+            try self.codegen.emit.vexRegRegReg(map, .p66, false, opcode, dst, lhs, rhs);
+        }
+
+        fn emitBasicSimdVector(
+            self: *Self,
+            op: lir.LowLevel,
+            kind: builtins.simd.Kind,
+            dst: FloatReg,
+            lhs: FloatReg,
+            rhs: ?FloatReg,
+            third: ?FloatReg,
+            protected_mask: u32,
+        ) Allocator.Error!void {
+            if (comptime target.toCpuArch() == .x86_64) {
+                const r = rhs;
+                const compare_map: @TypeOf(self.codegen.emit).VexMap = if (kind.laneBits() == 64) .map_0f38 else .map_0f;
+                switch (op) {
+                    .simd_add_wrap => try self.emitX86PackedBinary(.map_0f, x86PackedOpcode(kind, 0xFC, 0xFD, 0xFE, 0xD4), dst, lhs, r.?),
+                    .simd_sub_wrap => try self.emitX86PackedBinary(.map_0f, x86PackedOpcode(kind, 0xF8, 0xF9, 0xFA, 0xFB), dst, lhs, r.?),
+                    .simd_add_sat => try self.emitX86PackedBinary(
+                        .map_0f,
+                        if (kind.isSigned()) x86PackedOpcode(kind, 0xEC, 0xED, 0, 0) else x86PackedOpcode(kind, 0xDC, 0xDD, 0, 0),
+                        dst,
+                        lhs,
+                        r.?,
+                    ),
+                    .simd_sub_sat => try self.emitX86PackedBinary(
+                        .map_0f,
+                        if (kind.isSigned()) x86PackedOpcode(kind, 0xE8, 0xE9, 0, 0) else x86PackedOpcode(kind, 0xD8, 0xD9, 0, 0),
+                        dst,
+                        lhs,
+                        r.?,
+                    ),
+                    .simd_neg_wrap => {
+                        try self.codegen.emit.vexRegRegReg(.map_0f, .p66, false, 0xEF, dst, lhs, lhs);
+                        try self.emitX86PackedBinary(.map_0f, x86PackedOpcode(kind, 0xF8, 0xF9, 0xFA, 0xFB), dst, dst, lhs);
+                    },
+                    .simd_abs_wrap => try self.codegen.emit.vexRegReg(.map_0f38, .p66, false, x86PackedOpcode(kind, 0x1C, 0x1D, 0x1E, 0), dst, lhs),
+                    .simd_min, .simd_max => {
+                        const is_max = op == .simd_max;
+                        const map: @TypeOf(self.codegen.emit).VexMap = switch (kind) {
+                            .u8x16, .i16x8 => .map_0f,
+                            else => .map_0f38,
+                        };
+                        const opcode: u8 = switch (kind) {
+                            .u8x16 => if (is_max) 0xDE else 0xDA,
+                            .i8x16 => if (is_max) 0x3C else 0x38,
+                            .u16x8 => if (is_max) 0x3E else 0x3A,
+                            .i16x8 => if (is_max) 0xEE else 0xEA,
+                            .u32x4 => if (is_max) 0x3F else 0x3B,
+                            .i32x4 => if (is_max) 0x3D else 0x39,
+                            else => unreachable,
+                        };
+                        try self.emitX86PackedBinary(map, opcode, dst, lhs, r.?);
+                    },
+                    .simd_abs_diff => {
+                        const tmp = try self.allocTempVector(protected_mask);
+                        defer self.codegen.freeFloat(tmp);
+                        const opcode = x86PackedOpcode(kind, 0xD8, 0xD9, 0, 0);
+                        try self.emitX86PackedBinary(.map_0f, opcode, dst, lhs, r.?);
+                        try self.emitX86PackedBinary(.map_0f, opcode, tmp, r.?, lhs);
+                        try self.emitX86PackedBinary(.map_0f, 0xEB, dst, dst, tmp);
+                    },
+                    .simd_avg_rounded => try self.emitX86PackedBinary(.map_0f, x86PackedOpcode(kind, 0xE0, 0xE3, 0, 0), dst, lhs, r.?),
+                    .simd_and => try self.emitX86PackedBinary(.map_0f, 0xDB, dst, lhs, r.?),
+                    .simd_or => try self.emitX86PackedBinary(.map_0f, 0xEB, dst, lhs, r.?),
+                    .simd_xor => try self.emitX86PackedBinary(.map_0f, 0xEF, dst, lhs, r.?),
+                    .simd_not => {
+                        if (dst == lhs) {
+                            const tmp = try self.allocTempVector(protected_mask);
+                            defer self.codegen.freeFloat(tmp);
+                            try self.emitX86PackedBinary(.map_0f, 0x76, tmp, lhs, lhs);
+                            try self.emitX86PackedBinary(.map_0f, 0xEF, dst, tmp, lhs);
+                        } else {
+                            try self.emitX86PackedBinary(.map_0f, 0x76, dst, lhs, lhs);
+                            try self.emitX86PackedBinary(.map_0f, 0xEF, dst, dst, lhs);
+                        }
+                    },
+                    .simd_bit_select => {
+                        const tmp = try self.allocTempVector(protected_mask);
+                        defer self.codegen.freeFloat(tmp);
+                        try self.emitX86PackedBinary(.map_0f, 0xDB, dst, lhs, r.?);
+                        try self.emitX86PackedBinary(.map_0f, 0xDF, tmp, lhs, third.?);
+                        try self.emitX86PackedBinary(.map_0f, 0xEB, dst, dst, tmp);
+                    },
+                    .simd_eq_lanes => try self.emitX86PackedBinary(
+                        compare_map,
+                        x86PackedOpcode(kind, 0x74, 0x75, 0x76, 0x29),
+                        dst,
+                        lhs,
+                        r.?,
+                    ),
+                    .simd_gt_lanes => if (kind.isSigned()) {
+                        try self.emitX86PackedBinary(
+                            compare_map,
+                            x86PackedOpcode(kind, 0x64, 0x65, 0x66, 0x37),
+                            dst,
+                            lhs,
+                            r.?,
+                        );
+                    } else {
+                        const sign = try self.allocTempVector(protected_mask);
+                        defer self.codegen.freeFloat(sign);
+                        const biased_rhs = try self.allocTempVector(protected_mask | floatRegMask(sign));
+                        defer self.codegen.freeFloat(biased_rhs);
+                        try self.emitX86PackedBinary(.map_0f, 0x76, sign, lhs, lhs);
+                        if (kind.laneBits() == 8) {
+                            inline for (0..7) |_| {
+                                try self.emitX86PackedBinary(.map_0f, 0xFC, sign, sign, sign);
+                            }
+                        } else {
+                            try self.codegen.emit.vexPackedShiftImm8(
+                                x86PackedOpcode(kind, 0, 0x71, 0x72, 0x73),
+                                6,
+                                sign,
+                                sign,
+                                @intCast(kind.laneBits() - 1),
+                            );
+                        }
+                        try self.emitX86PackedBinary(.map_0f, 0xEF, dst, lhs, sign);
+                        try self.emitX86PackedBinary(.map_0f, 0xEF, biased_rhs, r.?, sign);
+                        try self.emitX86PackedBinary(
+                            compare_map,
+                            x86PackedOpcode(kind, 0x64, 0x65, 0x66, 0x37),
+                            dst,
+                            dst,
+                            biased_rhs,
+                        );
+                    },
+                    .simd_gte_lanes => {
+                        try self.emitBasicSimdVector(
+                            .simd_gt_lanes,
+                            kind,
+                            dst,
+                            r.?,
+                            lhs,
+                            null,
+                            protected_mask,
+                        );
+                        try self.emitBasicSimdVector(.simd_not, kind, dst, dst, null, null, protected_mask);
+                    },
+                    .simd_interleave_lo => try self.emitX86PackedBinary(.map_0f, x86PackedOpcode(kind, 0x60, 0x61, 0x62, 0x6C), dst, lhs, r.?),
+                    .simd_interleave_hi => try self.emitX86PackedBinary(.map_0f, x86PackedOpcode(kind, 0x68, 0x69, 0x6A, 0x6D), dst, lhs, r.?),
+                    else => unreachable,
+                }
+                return;
+            }
+
+            const size = neonSizeBits(kind);
+            const r = rhs;
+            switch (op) {
+                .simd_add_wrap => try self.codegen.emit.simdThreeReg(0x4E208400 | size, dst, lhs, r.?),
+                .simd_sub_wrap => try self.codegen.emit.simdThreeReg(0x6E208400 | size, dst, lhs, r.?),
+                .simd_add_sat => try self.codegen.emit.simdThreeReg((if (kind.isSigned()) @as(u32, 0x4E200C00) else 0x6E200C00) | size, dst, lhs, r.?),
+                .simd_sub_sat => try self.codegen.emit.simdThreeReg((if (kind.isSigned()) @as(u32, 0x4E202C00) else 0x6E202C00) | size, dst, lhs, r.?),
+                .simd_neg_wrap => try self.codegen.emit.simdTwoReg(0x6E20B800 | size, dst, lhs),
+                .simd_abs_wrap => try self.codegen.emit.simdTwoReg(0x4E20B800 | size, dst, lhs),
+                .simd_min => try self.codegen.emit.simdThreeReg((if (kind.isSigned()) @as(u32, 0x4E206C00) else 0x6E206C00) | size, dst, lhs, r.?),
+                .simd_max => try self.codegen.emit.simdThreeReg((if (kind.isSigned()) @as(u32, 0x4E206400) else 0x6E206400) | size, dst, lhs, r.?),
+                .simd_abs_diff => try self.codegen.emit.simdThreeReg(0x6E207400 | size, dst, lhs, r.?),
+                .simd_avg_rounded => try self.codegen.emit.simdThreeReg(0x6E201400 | size, dst, lhs, r.?),
+                .simd_and => try self.codegen.emit.simdThreeReg(0x4E201C00, dst, lhs, r.?),
+                .simd_or => try self.codegen.emit.simdThreeReg(0x4EA01C00, dst, lhs, r.?),
+                .simd_xor => try self.codegen.emit.simdThreeReg(0x6E201C00, dst, lhs, r.?),
+                .simd_not => try self.codegen.emit.simdTwoReg(0x6E205800, dst, lhs),
+                .simd_bit_select => {
+                    try self.codegen.emitMoveV128(dst, lhs);
+                    try self.codegen.emit.simdThreeReg(0x6E601C00, dst, r.?, third.?);
+                },
+                .simd_eq_lanes => try self.codegen.emit.simdThreeReg(0x6E208C00 | size, dst, lhs, r.?),
+                .simd_gt_lanes => try self.codegen.emit.simdThreeReg((if (kind.isSigned()) @as(u32, 0x4E203400) else 0x6E203400) | size, dst, lhs, r.?),
+                .simd_gte_lanes => try self.codegen.emit.simdThreeReg((if (kind.isSigned()) @as(u32, 0x4E203C00) else 0x6E203C00) | size, dst, lhs, r.?),
+                .simd_interleave_lo => try self.codegen.emit.simdThreeReg(0x4E003800 | size, dst, lhs, r.?),
+                .simd_interleave_hi => try self.codegen.emit.simdThreeReg(0x4E007800 | size, dst, lhs, r.?),
+                else => unreachable,
+            }
+        }
+
+        fn generateBasicSimdVector(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
             var source_kind: ?builtins.simd.Kind = null;
             for (0..args.len) |arg_index| {
-                const arg_local = GuardedList.at(args, arg_index);
-                source_kind = self.simdKindForLayout(self.localLayout(arg_local)) orelse continue;
+                source_kind = self.simdKindForLayout(self.localLayout(GuardedList.at(args, arg_index))) orelse continue;
                 break;
             }
-            const result_kind = self.simdKindForLayout(ll.ret_layout);
-            const arg_kind = source_kind orelse result_kind orelse unreachable;
-            const ret_kind = result_kind orelse arg_kind;
+            const kind = source_kind orelse self.simdKindForLayout(ll.ret_layout) orelse unreachable;
+            const lhs = try self.acquireVectorLocal(GuardedList.at(args, 0), kind, 0);
+            defer self.releaseAcquiredVector(lhs);
+            var protected = floatRegMask(lhs.reg);
 
-            var parts: [3]I128Parts = undefined;
-            var initialized: usize = 0;
-            defer for (parts[0..initialized]) |value| {
-                self.codegen.freeGeneral(value.low);
-                self.codegen.freeGeneral(value.high);
-            };
-            while (initialized < 3) : (initialized += 1) {
-                if (initialized < args.len) {
-                    parts[initialized] = try self.simdArgParts(GuardedList.at(args, initialized));
-                } else {
-                    const low = try self.allocTempGeneral();
-                    const high = try self.allocTempGeneral();
-                    try self.codegen.emitLoadImm(low, 0);
-                    try self.codegen.emitLoadImm(high, 0);
-                    parts[initialized] = .{ .low = low, .high = high };
-                }
+            var rhs: ?AcquiredVector = null;
+            if (args.len >= 2 and self.simdKindForLayout(self.localLayout(GuardedList.at(args, 1))) != null) {
+                rhs = try self.acquireVectorLocal(GuardedList.at(args, 1), kind, protected);
+                protected |= floatRegMask(rhs.?.reg);
             }
+            defer if (rhs) |value| self.releaseAcquiredVector(value);
 
-            const result_slot = self.codegen.allocStackSlot(16);
-            const inputs_slot = self.codegen.allocStackSlot(48);
-            inline for (0..3) |i| {
-                try self.codegen.emitStoreStack(.w64, inputs_slot + @as(i32, @intCast(i * 16)), parts[i].low);
-                try self.codegen.emitStoreStack(.w64, inputs_slot + @as(i32, @intCast(i * 16 + 8)), parts[i].high);
+            var third: ?AcquiredVector = null;
+            if (args.len >= 3 and self.simdKindForLayout(self.localLayout(GuardedList.at(args, 2))) != null) {
+                third = try self.acquireVectorLocal(GuardedList.at(args, 2), kind, protected);
+                protected |= floatRegMask(third.?.reg);
             }
-            var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
-            try builder.addLeaArg(frame_ptr, result_slot);
-            const descriptor = @as(u32, ll.op.simdOpIndex() orelse unreachable) |
-                (@as(u32, @intFromEnum(arg_kind)) << 8) |
-                (@as(u32, @intFromEnum(ret_kind)) << 16);
-            try builder.addImmArg(descriptor);
-            try builder.addLeaArg(frame_ptr, inputs_slot);
-            try self.callBuiltin(&builder, .simd_eval);
+            defer if (third) |value| self.releaseAcquiredVector(value);
 
-            const ret_size = self.layout_store.layoutSize(self.layout_store.getLayout(ll.ret_layout));
-            if (ret_size == 16) {
-                if (result_kind != null) return .{ .stack = .{ .offset = result_slot, .layout_idx = ll.ret_layout } };
-                return .{ .stack_i128 = result_slot };
-            }
-            const result_reg = try self.allocTempGeneral();
-            try self.emitSizedLoadStack(result_reg, result_slot, ValueSize.fromByteCount(ret_size));
-            return .{ .general_reg = result_reg };
+            const result = try self.allocTempVector(protected);
+            protected |= floatRegMask(result);
+            try self.emitBasicSimdVector(
+                ll.op,
+                kind,
+                result,
+                lhs.reg,
+                if (rhs) |value| value.reg else null,
+                if (third) |value| value.reg else null,
+                protected,
+            );
+            return .{ .vector_reg = .{ .reg = result, .kind = kind } };
         }
 
         fn simdListOffset(self: *Self, local: LocalId) Allocator.Error!i32 {
@@ -4669,16 +6058,35 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const index_loc = try self.emitValueLocal(GuardedList.at(args, 1));
             const index_reg = try self.ensureInGeneralReg(index_loc);
             defer self.codegen.freeGeneral(index_reg);
-            const result_slot = self.codegen.allocStackSlot(16);
-            var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
-            try builder.addLeaArg(frame_ptr, result_slot);
-            try builder.addMemArg(frame_ptr, list_offset);
-            try builder.addRegArg(index_reg);
-            try self.callBuiltin(&builder, .simd_load_16);
-            return .{ .stack = .{ .offset = result_slot, .layout_idx = ll.ret_layout } };
+            const bytes_reg = try self.allocTempGeneral();
+            defer self.codegen.freeGeneral(bytes_reg);
+            try self.emitLoad(.w64, bytes_reg, frame_ptr, list_offset);
+            try self.emitAddRegs(.w64, bytes_reg, bytes_reg, index_reg);
+
+            const kind = self.simdKindForLayout(ll.ret_layout) orelse unreachable;
+            const result_reg = try self.allocTempVector(0);
+            try self.codegen.emitLoadV128(result_reg, bytes_reg, 0);
+            return .{ .vector_reg = .{ .reg = result_reg, .kind = kind } };
         }
 
         fn generateSimdStore(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+            if ((ll.unique_args & 2) != 0) {
+                const vector_local = GuardedList.at(args, 0);
+                const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
+                const vector = try self.acquireVectorLocal(vector_local, kind, 0);
+                defer self.releaseAcquiredVector(vector);
+                const list_offset = try self.simdListOffset(GuardedList.at(args, 1));
+                const index_loc = try self.emitValueLocal(GuardedList.at(args, 2));
+                const index_reg = try self.ensureInGeneralReg(index_loc);
+                defer self.codegen.freeGeneral(index_reg);
+                const bytes_reg = try self.allocTempGeneral();
+                defer self.codegen.freeGeneral(bytes_reg);
+                try self.emitLoad(.w64, bytes_reg, frame_ptr, list_offset);
+                try self.emitAddRegs(.w64, bytes_reg, bytes_reg, index_reg);
+                try self.codegen.emitStoreV128(bytes_reg, 0, vector.reg);
+                return try self.emitValueLocal(GuardedList.at(args, 1));
+            }
+
             const vector = try self.simdArgParts(GuardedList.at(args, 0));
             defer self.codegen.freeGeneral(vector.low);
             defer self.codegen.freeGeneral(vector.high);
@@ -4696,7 +6104,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             try builder.addMemArg(frame_ptr, list_offset + 8);
             try builder.addMemArg(frame_ptr, list_offset + 16);
             try builder.addRegArg(index_reg);
-            try builder.addImmArg(updateModeImmForArg1(ll.unique_args));
+            try builder.addImmArg(@intFromEnum(builtins.utils.UpdateMode.Immutable));
             try builder.addRegArg(roc_ops_reg);
             try self.callBuiltin(&builder, .simd_store_16);
             return .{ .list_stack = .{ .struct_offset = result_offset, .data_offset = 0, .num_elements = 0 } };
@@ -5897,6 +7305,21 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 return;
             }
 
+            if (value_loc == .vector_reg) {
+                const expected_kind = self.simdKindForLayout(local_layout) orelse std.debug.panic(
+                    "LIR/codegen invariant violated: vector register assigned to non-vector local",
+                    .{},
+                );
+                if (value_loc.vector_reg.kind != expected_kind) {
+                    std.debug.panic(
+                        "LIR/codegen invariant violated: {s} register assigned to {s} local",
+                        .{ @tagName(value_loc.vector_reg.kind), @tagName(expected_kind) },
+                    );
+                }
+                try self.local_locations.put(key, value_loc);
+                return;
+            }
+
             const stable_loc = try self.materializeValueToStackForLayout(value_loc, local_layout);
             try self.local_locations.put(key, stable_loc);
             try self.emitNormalizeFloatNanInStableLocation(stable_loc, local_layout);
@@ -6143,6 +7566,22 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
             switch (stable_loc) {
                 .stack => |stack_loc| try self.copyBytesToStackOffset(stack_loc.offset, normalized, size),
+                .vector_reg => |destination| switch (normalized) {
+                    .vector_reg => |source| {
+                        if (source.kind != destination.kind) {
+                            std.debug.panic(
+                                "LIR/codegen invariant violated: cannot assign {s} vector register to {s} vector register",
+                                .{ @tagName(source.kind), @tagName(destination.kind) },
+                            );
+                        }
+                        try self.codegen.emitMoveV128(destination.reg, source.reg);
+                    },
+                    .stack => |source| try self.codegen.emitLoadStackV128(destination.reg, source.offset),
+                    else => std.debug.panic(
+                        "LIR/codegen invariant violated: cannot assign {s} to vector register",
+                        .{@tagName(normalized)},
+                    ),
+                },
                 .stack_i128 => |offset| {
                     const runtime_layout_idx = self.runtimeRepresentationLayoutIdx(layout_idx);
                     try self.storeWideScalarToStackOffset(
@@ -6161,7 +7600,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 .stack_str => |offset| try self.copyBytesToStackOffset(offset, normalized, roc_str_size),
                 .list_stack => |list_loc| try self.copyBytesToStackOffset(list_loc.struct_offset, normalized, roc_list_size),
                 else => std.debug.panic(
-                    "LirCodeGen invariant violated: assigned locals must use stack-backed stable locations, found {s}",
+                    "LirCodeGen invariant violated: assigned local has unsupported stable location {s}",
                     .{@tagName(stable_loc)},
                 ),
             }
@@ -6653,6 +8092,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         }
 
         fn ensureStableLocationsForStmtReads(self: *Self, stmt_id: CFStmtId) Allocator.Error!void {
+            try self.spillAllVectorLocals();
             var locals = std.AutoHashMap(u64, LocalId).init(self.allocator);
             defer locals.deinit();
             var visited = std.AutoHashMap(u32, void).init(self.allocator);
@@ -11829,6 +13269,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
         /// Generate code for a direct proc call.
         fn generateCall(self: *Self, call: anytype) Allocator.Error!ValueLocation {
+            try self.spillAllVectorLocals();
             const proc_spec = self.store.getProcSpec(call.proc);
             const arg_refs = self.store.getLocalSpan(call.args);
             const param_refs = self.store.getLocalSpan(proc_spec.args);
@@ -11877,6 +13318,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             call_args: LocalSpan,
             ret_layout: layout.Idx,
         ) Allocator.Error!ValueLocation {
+            try self.spillAllVectorLocals();
             const closure_layout = self.localLayout(closure_local);
             const runtime_closure_layout = self.runtimeRepresentationLayoutIdx(closure_layout);
             const closure_layout_val = self.layout_store.getLayout(runtime_closure_layout);
@@ -12725,6 +14167,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         try self.codegen.emitLoadStack(.w64, target_reg, slot);
                     }
                 },
+                .vector_reg => unreachable,
                 .immediate_f32 => |val| {
                     const bits: u32 = @bitCast(val);
                     try self.codegen.emitLoadImm(target_reg, bits);
@@ -12937,6 +14380,65 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             );
         }
 
+        fn floatRegMask(reg: FloatReg) u32 {
+            return @as(u32, 1) << @intFromEnum(reg);
+        }
+
+        fn spillVectorLocalEntry(
+            self: *Self,
+            local_key: u32,
+            value_ptr: *ValueLocation,
+        ) Allocator.Error!void {
+            const vector = switch (value_ptr.*) {
+                .vector_reg => |value| value,
+                else => return,
+            };
+            const local: LocalId = @enumFromInt(local_key);
+            const layout_idx = self.localLayout(local);
+            const slot = self.codegen.allocStackSlot(16);
+            try self.codegen.emitStoreStackV128(slot, vector.reg);
+            value_ptr.* = .{ .stack = .{
+                .offset = slot,
+                .size = .qword,
+                .layout_idx = layout_idx,
+            } };
+            self.codegen.freeFloat(vector.reg);
+        }
+
+        /// Spill every persistent vector local at a control-flow or call ABI
+        /// boundary. Scalar floating-point temporaries use the same physical
+        /// mask but never persist in `local_locations`.
+        fn spillAllVectorLocals(self: *Self) Allocator.Error!void {
+            var it = self.local_locations.iterator();
+            while (it.next()) |entry| {
+                try self.spillVectorLocalEntry(entry.key_ptr.*, entry.value_ptr);
+            }
+        }
+
+        /// Allocate a vector temporary, spilling one persistent vector live
+        /// range only when the shared FP/vector register file is genuinely
+        /// exhausted. Registers in `protected_mask` are operands of the
+        /// instruction currently being selected and cannot be spill victims.
+        fn allocTempVector(self: *Self, protected_mask: u32) Allocator.Error!FloatReg {
+            if (self.codegen.allocFloat()) |reg| return reg;
+
+            var it = self.local_locations.iterator();
+            while (it.next()) |entry| {
+                const reg = switch (entry.value_ptr.*) {
+                    .vector_reg => |value| value.reg,
+                    else => continue,
+                };
+                if ((protected_mask & floatRegMask(reg)) != 0) continue;
+                try self.spillVectorLocalEntry(entry.key_ptr.*, entry.value_ptr);
+                return self.codegen.allocFloat() orelse unreachable;
+            }
+
+            std.debug.panic(
+                "LirCodeGen invariant violated: bounded SIMD instruction selection exhausted the shared FP/vector register pool",
+                .{},
+            );
+        }
+
         /// Call a builtin function using either direct function pointer (native mode)
         /// or symbol reference (object file mode) depending on generation_mode.
         ///
@@ -12947,6 +14449,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         /// The native address is derived from `builtin_fn` itself, so native and object
         /// builds always target the same registry member.
         fn callBuiltin(self: *Self, builder: *Builder, builtin_fn: BuiltinFn) Allocator.Error!void {
+            try self.spillAllVectorLocals();
             switch (self.generation_mode) {
                 .native_execution => {
                     try builder.call(builtin_fn.wrapperAddress());
@@ -12971,6 +14474,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         /// `builtin_fn.wrapperAddress()`; the object-file symbol and relocation still
         /// target `builtin_fn`, so both build modes resolve to the same registry member.
         fn callBuiltinWithAdapter(self: *Self, builder: *Builder, adapter_addr: usize, builtin_fn: BuiltinFn) Allocator.Error!void {
+            try self.spillAllVectorLocals();
             switch (self.generation_mode) {
                 .native_execution => {
                     try builder.call(adapter_addr);
@@ -13029,6 +14533,17 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     const slot = self.codegen.allocStackSlot(@intCast(size));
                     try self.emitStore(.w64, frame_ptr, slot, reg);
                     self.codegen.freeGeneral(reg);
+                    break :blk slot;
+                },
+                .vector_reg => |vector| blk: {
+                    if (builtin.mode == .Debug and size != 16) {
+                        std.debug.panic(
+                            "LIR/codegen invariant violated: vector stack materialization has size {d}",
+                            .{size},
+                        );
+                    }
+                    const slot = self.codegen.allocStackSlot(16);
+                    try self.codegen.emitStoreStackV128(slot, vector.reg);
                     break :blk slot;
                 },
                 .immediate_i64 => |val| blk: {
@@ -13117,6 +14632,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     }
                     return reg;
                 },
+                .vector_reg => unreachable,
                 .immediate_f32 => |val| {
                     const reg = try self.allocTempGeneral();
                     const bits: u32 = @bitCast(val);
@@ -13261,7 +14777,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
         fn coerceImmediateForStackCopy(self: *Self, loc: ValueLocation, size: u32) Allocator.Error!ValueLocation {
             return switch (loc) {
-                .general_reg, .float_reg => loc,
+                .general_reg, .float_reg, .vector_reg => loc,
                 .immediate_f32, .immediate_f64 => blk: {
                     const width: FloatWidth = switch (size) {
                         4 => .f32,
@@ -13369,7 +14885,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     else
                         .{ .immediate_f64 = @as(f64, @floatFromInt(val)) };
                 },
-                .general_reg, .immediate_i128, .stack_i128, .stack_str, .list_stack => {
+                .general_reg, .vector_reg, .immediate_i128, .stack_i128, .stack_str, .list_stack => {
                     unreachable;
                 },
                 .noreturn => unreachable,
@@ -13902,6 +15418,15 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         },
                         else => unreachable,
                     }
+                },
+                .vector_reg => |vector| {
+                    if (size != 16) {
+                        std.debug.panic(
+                            "LIR/codegen invariant violated: copying vector register into {d}-byte stack slot",
+                            .{size},
+                        );
+                    }
+                    try self.codegen.emitStoreStackV128(dest_offset, vector.reg);
                 },
                 else => unreachable,
             }
@@ -17407,6 +18932,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         }
 
         fn emitRocStaticMessageCallShared(self: *Self, field_offset: i32, msg: []const u8, shared: bool) Allocator.Error!void {
+            try self.spillAllVectorLocals();
             const roc_ops_reg = self.roc_ops_reg orelse unreachable;
 
             const msg_aligned_size: u32 = std.mem.alignForward(u32, @intCast(msg.len), 8);
@@ -17498,6 +19024,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             site: lir.LIR.ComptimeSiteId,
             branch_index: u32,
         ) Allocator.Error!void {
+            try self.spillAllVectorLocals();
             var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
             try builder.addRegArg(self.roc_ops_reg orelse unreachable);
             try builder.addImmArg(@intCast(@intFromEnum(site)));
@@ -17510,6 +19037,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             hooks: ComptimeHooks,
             site: lir.LIR.ComptimeSiteId,
         ) Allocator.Error!void {
+            try self.spillAllVectorLocals();
             var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
             try builder.addRegArg(self.roc_ops_reg orelse unreachable);
             try builder.addImmArg(@intCast(@intFromEnum(site)));
@@ -17524,6 +19052,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const roc_ops_reg = self.roc_ops_reg orelse return;
             const region = self.store.stmtRegion(stmt_id);
             if (region.isEmpty()) return;
+            try self.spillAllVectorLocals();
             var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
             try builder.addRegArg(roc_ops_reg);
             try builder.addImmArg(@intCast(region.start.offset));
@@ -17539,6 +19068,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const roc_ops_reg = self.roc_ops_reg orelse return false;
             const region = self.store.stmtRegion(stmt_id);
             if (region.isEmpty()) return false;
+            try self.spillAllVectorLocals();
             var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
             try builder.addRegArg(roc_ops_reg);
             try builder.addImmArg(@intCast(region.start.offset));
@@ -17552,6 +19082,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             hooks: ComptimeHooks,
         ) Allocator.Error!void {
             const roc_ops_reg = self.roc_ops_reg orelse return;
+            try self.spillAllVectorLocals();
             var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
             try builder.addRegArg(roc_ops_reg);
             try builder.call(@intFromPtr(hooks.call_exit));

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -4332,9 +4332,9 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 .simd_interleave_hi,
                 => return self.generateBasicSimdVector(ll, args),
                 .simd_splat => return self.generateSimdSplat(ll, args),
-                .simd_get_lane_unchecked => return self.generateSimdGetLane(ll, args),
+                .simd_get_lane_unchecked => return self.generateSimdGetLane(args),
                 .simd_with_lane_unchecked => return self.generateSimdWithLane(ll, args),
-                .simd_to_u128_bits => return self.generateSimdToBits(ll, args),
+                .simd_to_u128_bits => return self.generateSimdToBits(args),
                 .simd_from_u128_bits => return self.generateSimdFromBits(ll, args),
                 .simd_mul_wrap,
                 .simd_mul_high,
@@ -4346,12 +4346,12 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 .simd_dot_pairs_sat,
                 .simd_sad,
                 => return self.generateSimdDot(ll, args),
-                .simd_bitmask => return self.generateSimdBitmask(ll, args),
+                .simd_bitmask => return self.generateSimdBitmask(args),
                 .simd_shl_wrap,
                 .simd_shr_wrap,
                 .simd_shr_zf_wrap,
                 => return self.generateSimdShift(ll, args),
-                .simd_shr_rounded => return self.generateSimdRoundedShift(ll, args),
+                .simd_shr_rounded => return self.generateSimdRoundedShift(args),
                 .simd_even_lanes,
                 .simd_odd_lanes,
                 .simd_reverse_lanes,
@@ -4366,7 +4366,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 => return self.generateSimdWidthChange(ll, args),
                 .simd_sum_lanes,
                 .simd_sum_lanes_wrap,
-                => return self.generateSimdSum(ll, args),
+                => return self.generateSimdSum(args),
                 .simd_clmul_lo,
                 .simd_clmul_hi,
                 => return self.generateSimdClmul(ll, args),
@@ -4790,8 +4790,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             return .{ .vector_reg = .{ .reg = result, .kind = kind } };
         }
 
-        fn generateSimdToBits(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
-            _ = ll;
+        fn generateSimdToBits(self: *Self, args: anytype) Allocator.Error!ValueLocation {
             const vector_local = GuardedList.at(args, 0);
             const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
             const vector = try self.acquireVectorLocal(vector_local, kind, 0);
@@ -4801,8 +4800,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             return .{ .stack_i128 = slot };
         }
 
-        fn generateSimdGetLane(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
-            _ = ll;
+        fn generateSimdGetLane(self: *Self, args: anytype) Allocator.Error!ValueLocation {
             const vector_local = GuardedList.at(args, 0);
             const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
             const vector = try self.acquireVectorLocal(vector_local, kind, 0);
@@ -4856,17 +4854,32 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const scalar = try self.ensureInGeneralReg(scalar_loc);
             defer self.codegen.freeGeneral(scalar);
 
-            const index_vector = try self.allocTempVector(protected);
-            defer self.codegen.freeFloat(index_vector);
-            protected |= floatRegMask(index_vector);
-            try self.emitSimdSplatFromGeneral(index_vector, index, .u8x16);
-            const lane_indices = try self.materializeVectorConstant(simdLaneIndexBytes(kind), protected);
-            defer self.releaseAcquiredVector(lane_indices);
-            protected |= floatRegMask(lane_indices.reg);
-            const mask = try self.allocTempVector(protected);
+            // The index vectors are only needed to construct the mask. Releasing
+            // them here keeps the remaining instruction sequence within the six
+            // volatile XMM registers available under the Windows x64 ABI.
+            const mask = mask: {
+                var mask_protected = protected;
+                const index_vector = try self.allocTempVector(mask_protected);
+                defer self.codegen.freeFloat(index_vector);
+                mask_protected |= floatRegMask(index_vector);
+                try self.emitSimdSplatFromGeneral(index_vector, index, .u8x16);
+                const lane_indices = try self.materializeVectorConstant(simdLaneIndexBytes(kind), mask_protected);
+                defer self.releaseAcquiredVector(lane_indices);
+                mask_protected |= floatRegMask(lane_indices.reg);
+                const result = try self.allocTempVector(mask_protected);
+                try self.emitBasicSimdVector(
+                    .simd_eq_lanes,
+                    .u8x16,
+                    result,
+                    lane_indices.reg,
+                    index_vector,
+                    null,
+                    mask_protected | floatRegMask(result),
+                );
+                break :mask result;
+            };
             defer self.codegen.freeFloat(mask);
             protected |= floatRegMask(mask);
-            try self.emitBasicSimdVector(.simd_eq_lanes, .u8x16, mask, lane_indices.reg, index_vector, null, protected);
 
             const splat = try self.allocTempVector(protected);
             defer self.codegen.freeFloat(splat);
@@ -5352,8 +5365,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             try self.codegen.emit.simdTwoReg(0x6F000400 | (@as(u32, encoded_imm) << 16), dst, src);
         }
 
-        fn generateSimdBitmask(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
-            _ = ll;
+        fn generateSimdBitmask(self: *Self, args: anytype) Allocator.Error!ValueLocation {
             const vector_local = GuardedList.at(args, 0);
             const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
             const vector = try self.acquireVectorLocal(vector_local, kind, 0);
@@ -5566,7 +5578,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             try self.emitX86PackedBinary(.map_0f, 0xEB, dst, dst, narrowed_high);
         }
 
-        fn generateSimdRoundedShift(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
+        fn generateSimdRoundedShift(self: *Self, args: anytype) Allocator.Error!ValueLocation {
             const vector_local = GuardedList.at(args, 0);
             const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
             std.debug.assert(kind == .i16x8 or kind == .i32x4);
@@ -5656,12 +5668,10 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const done = self.codegen.currentOffset();
             self.codegen.patchJump(normal_done, done);
             self.codegen.patchJump(range_done, done);
-            _ = ll;
             return .{ .vector_reg = .{ .reg = result, .kind = kind } };
         }
 
-        fn generateSimdSum(self: *Self, ll: anytype, args: anytype) Allocator.Error!ValueLocation {
-            _ = ll;
+        fn generateSimdSum(self: *Self, args: anytype) Allocator.Error!ValueLocation {
             const vector_local = GuardedList.at(args, 0);
             const kind = self.simdKindForLayout(self.localLayout(vector_local)) orelse unreachable;
             const vector = try self.acquireVectorLocal(vector_local, kind, 0);

--- a/src/backend/dev/aarch64/CodeGen.zig
+++ b/src/backend/dev/aarch64/CodeGen.zig
@@ -473,6 +473,18 @@ pub fn CodeGen(comptime target: RocTarget) type {
             try self.emit.strQRegMemSoff(src, .FP, offset);
         }
 
+        pub fn emitMoveV128(self: *Self, dst: FloatReg, src: FloatReg) Allocator.Error!void {
+            if (dst != src) try self.emit.movVectorRegReg(dst, src);
+        }
+
+        pub fn emitLoadV128(self: *Self, dst: FloatReg, base: GeneralReg, offset: i32) Allocator.Error!void {
+            try self.emit.ldrQRegMemSoff(dst, base, offset);
+        }
+
+        pub fn emitStoreV128(self: *Self, base: GeneralReg, offset: i32, src: FloatReg) Allocator.Error!void {
+            try self.emit.strQRegMemSoff(src, base, offset);
+        }
+
         // Immediate loading
 
         /// Load immediate value into register
@@ -716,6 +728,19 @@ test "float allocation never relocates an allocated register" {
     try std.testing.expectEqual(code_len, cg.getCode().len);
 
     for (regs[0..count]) |reg| cg.freeFloat(reg);
+}
+
+test "vector allocation excludes AAPCS64 partial-width callee-saved registers" {
+    var cg = LinuxCodeGen.init(std.testing.allocator);
+    defer cg.deinit();
+
+    const count: usize = @popCount(LinuxCodeGen.INITIAL_FREE_FLOAT);
+    for (0..count) |_| {
+        const reg = cg.allocFloat().?;
+        const index = @intFromEnum(reg);
+        try std.testing.expect(index <= 7 or index >= 16);
+    }
+    try std.testing.expectEqual(@as(?FloatReg, null), cg.allocFloat());
 }
 
 test "general allocation reports exhaustion after all allocatable registers" {

--- a/src/backend/dev/aarch64/Emit.zig
+++ b/src/backend/dev/aarch64/Emit.zig
@@ -1420,6 +1420,100 @@ pub fn Emit(comptime target: RocTarget) type {
             try self.emit32(inst);
         }
 
+        /// MOV Vd.16B, Vn.16B (alias of ORR Vd.16B, Vn.16B, Vn.16B).
+        pub fn movVectorRegReg(self: *Self, dst: FloatReg, src: FloatReg) Allocator.Error!void {
+            const inst: u32 = 0x4EA01C00 |
+                (@as(u32, src.enc()) << 16) |
+                (@as(u32, src.enc()) << 5) |
+                dst.enc();
+            try self.emit32(inst);
+        }
+
+        /// Emit a register-only Advanced SIMD instruction whose opcode bits
+        /// are supplied without Rm, Rn, or Rd.
+        pub fn simdThreeReg(
+            self: *Self,
+            opcode: u32,
+            dst: FloatReg,
+            lhs: FloatReg,
+            rhs: FloatReg,
+        ) Allocator.Error!void {
+            std.debug.assert((opcode & 0x001F03FF) == 0);
+            try self.emit32(opcode |
+                (@as(u32, rhs.enc()) << 16) |
+                (@as(u32, lhs.enc()) << 5) |
+                dst.enc());
+        }
+
+        /// Emit a register-only Advanced SIMD instruction whose opcode bits
+        /// are supplied without Rn or Rd.
+        pub fn simdTwoReg(
+            self: *Self,
+            opcode: u32,
+            dst: FloatReg,
+            src: FloatReg,
+        ) Allocator.Error!void {
+            std.debug.assert((opcode & 0x000003FF) == 0);
+            try self.emit32(opcode |
+                (@as(u32, src.enc()) << 5) |
+                dst.enc());
+        }
+
+        fn simdElementImm5(lane_bits: u7, index: u4) u5 {
+            return switch (lane_bits) {
+                8 => (@as(u5, index) << 1) | 1,
+                16 => (@as(u5, index) << 2) | 2,
+                32 => (@as(u5, index) << 3) | 4,
+                64 => (@as(u5, index) << 4) | 8,
+                else => unreachable,
+            };
+        }
+
+        pub fn duplicateGeneralToVector(
+            self: *Self,
+            dst: FloatReg,
+            src: GeneralReg,
+            lane_bits: u7,
+        ) Allocator.Error!void {
+            const opcode: u32 = switch (lane_bits) {
+                8 => 0x4E010C00,
+                16 => 0x4E020C00,
+                32 => 0x4E040C00,
+                64 => 0x4E080C00,
+                else => unreachable,
+            };
+            try self.emit32(opcode | (@as(u32, src.enc()) << 5) | dst.enc());
+        }
+
+        pub fn insertGeneralVectorLane(
+            self: *Self,
+            dst: FloatReg,
+            src: GeneralReg,
+            lane_bits: u7,
+            index: u4,
+        ) Allocator.Error!void {
+            const imm5 = simdElementImm5(lane_bits, index);
+            try self.emit32(0x4E001C00 |
+                (@as(u32, imm5) << 16) |
+                (@as(u32, src.enc()) << 5) |
+                dst.enc());
+        }
+
+        pub fn extractVectorLaneUnsigned(
+            self: *Self,
+            dst: GeneralReg,
+            src: FloatReg,
+            lane_bits: u7,
+            index: u4,
+        ) Allocator.Error!void {
+            const imm5 = simdElementImm5(lane_bits, index);
+            const opcode: u32 = if (lane_bits == 64) 0x4E003C00 else 0x0E003C00;
+            try self.emit32(opcode |
+                (@as(u32, imm5) << 16) |
+                (@as(u32, src.enc()) << 5) |
+                dst.enc());
+        }
+
         /// FMOV from general register to float register
         pub fn fmovFloatFromGen(self: *Self, ftype: FloatType, dst: FloatReg, src: GeneralReg) Allocator.Error!void {
             // FMOV <Sd>, <Wn> (single) or FMOV <Dd>, <Xn> (double)
@@ -1884,6 +1978,39 @@ test "fadd" {
     // fadd d0, d1, d2 (0x1E622820)
     try asm_buf.faddRegRegReg(.double, .V0, .V1, .V2);
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x20, 0x28, 0x62, 0x1E }, asm_buf.buf.items);
+}
+
+test "packed integer vector encodings" {
+    var asm_buf = LinuxEmit.init(std.testing.allocator);
+    defer asm_buf.deinit();
+
+    // mov v3.16b, v7.16b
+    try asm_buf.movVectorRegReg(.V3, .V7);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xE3, 0x1C, 0xA7, 0x4E }, asm_buf.buf.items);
+
+    asm_buf.buf.clearRetainingCapacity();
+    // add v3.16b, v7.16b, v12.16b
+    try asm_buf.simdThreeReg(0x4E208400, .V3, .V7, .V12);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xE3, 0x84, 0x2C, 0x4E }, asm_buf.buf.items);
+}
+
+test "packed integer scalar lane bridges" {
+    var asm_buf = LinuxEmit.init(std.testing.allocator);
+    defer asm_buf.deinit();
+
+    // dup v9.4s, w10
+    try asm_buf.duplicateGeneralToVector(.V9, .X10, 32);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x49, 0x0D, 0x04, 0x4E }, asm_buf.buf.items);
+
+    asm_buf.buf.clearRetainingCapacity();
+    // ins v9.s[3], w10
+    try asm_buf.insertGeneralVectorLane(.V9, .X10, 32, 3);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x49, 0x1D, 0x1C, 0x4E }, asm_buf.buf.items);
+
+    asm_buf.buf.clearRetainingCapacity();
+    // umov w10, v9.h[5]
+    try asm_buf.extractVectorLaneUnsigned(.X10, .V9, 16, 5);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x2A, 0x3D, 0x16, 0x0E }, asm_buf.buf.items);
 }
 
 test "signed-offset memory helpers use exact byte offsets" {

--- a/src/backend/dev/x86_64/CodeGen.zig
+++ b/src/backend/dev/x86_64/CodeGen.zig
@@ -587,6 +587,26 @@ pub fn CodeGen(comptime target: RocTarget) type {
             try self.emit.movssRegMem(dst, .RBP, offset);
         }
 
+        pub fn emitLoadStackV128(self: *Self, dst: FloatReg, offset: i32) Allocator.Error!void {
+            try self.emit.movdquRegMem(dst, .RBP, offset);
+        }
+
+        pub fn emitStoreStackV128(self: *Self, offset: i32, src: FloatReg) Allocator.Error!void {
+            try self.emit.movdquMemReg(.RBP, offset, src);
+        }
+
+        pub fn emitMoveV128(self: *Self, dst: FloatReg, src: FloatReg) Allocator.Error!void {
+            if (dst != src) try self.emit.movdqaRegReg(dst, src);
+        }
+
+        pub fn emitLoadV128(self: *Self, dst: FloatReg, base: GeneralReg, offset: i32) Allocator.Error!void {
+            try self.emit.movdquRegMem(dst, base, offset);
+        }
+
+        pub fn emitStoreV128(self: *Self, base: GeneralReg, offset: i32, src: FloatReg) Allocator.Error!void {
+            try self.emit.movdquMemReg(base, offset, src);
+        }
+
         /// Store float32 to stack slot.
         pub fn emitStoreStackF32(self: *Self, offset: i32, src: FloatReg) Allocator.Error!void {
             try self.emit.movssMemReg(.RBP, offset, src);
@@ -745,6 +765,16 @@ test "float allocation never relocates an allocated register" {
     try std.testing.expectEqual(code_len, cg.getCode().len);
 
     for (regs[0..count]) |reg| cg.freeFloat(reg);
+}
+
+test "Windows vector allocation excludes nonvolatile XMM registers" {
+    var cg = WinCodeGen.init(std.testing.allocator);
+    defer cg.deinit();
+
+    for (0..6) |index| {
+        try std.testing.expectEqual(@as(FloatReg, @enumFromInt(index)), cg.allocFloat().?);
+    }
+    try std.testing.expectEqual(@as(?FloatReg, null), cg.allocFloat());
 }
 
 test "allocate caller-saved registers first" {

--- a/src/backend/dev/x86_64/Emit.zig
+++ b/src/backend/dev/x86_64/Emit.zig
@@ -866,6 +866,197 @@ pub fn Emit(comptime target: RocTarget) type {
             }
         }
 
+        pub const VexMap = enum(u5) {
+            map_0f = 1,
+            map_0f38 = 2,
+            map_0f3a = 3,
+        };
+
+        pub const VexPrefix = enum(u2) {
+            none = 0,
+            p66 = 1,
+            pf3 = 2,
+            pf2 = 3,
+        };
+
+        fn emitVex3Prefix(
+            self: *Self,
+            map: VexMap,
+            prefix: VexPrefix,
+            w: bool,
+            dst: FloatReg,
+            src1: ?FloatReg,
+            rm_high: u1,
+        ) Allocator.Error!void {
+            const inv_r: u1 = 1 - dst.rexB();
+            const inv_b: u1 = 1 - rm_high;
+            const byte2: u8 = (@as(u8, inv_r) << 7) |
+                (@as(u8, 1) << 6) | // no index register: inverted X = 1
+                (@as(u8, inv_b) << 5) |
+                @intFromEnum(map);
+            const encoded_vvvv: u4 = if (src1) |reg|
+                @truncate(~@as(u4, @intCast(@intFromEnum(reg))))
+            else
+                0xF;
+            const byte3: u8 = (@as(u8, @intFromBool(w)) << 7) |
+                (@as(u8, encoded_vvvv) << 3) |
+                @intFromEnum(prefix); // L=0: 128-bit operation
+            try self.buf.appendSlice(self.allocator, &.{ 0xC4, byte2, byte3 });
+        }
+
+        /// Generic three-register 128-bit VEX instruction.
+        pub fn vexRegRegReg(
+            self: *Self,
+            map: VexMap,
+            prefix: VexPrefix,
+            w: bool,
+            opcode: u8,
+            dst: FloatReg,
+            src1: FloatReg,
+            src2: FloatReg,
+        ) Allocator.Error!void {
+            try self.emitVex3Prefix(map, prefix, w, dst, src1, src2.rexB());
+            try self.buf.append(self.allocator, opcode);
+            try self.buf.append(self.allocator, modRM(0b11, dst.enc(), src2.enc()));
+        }
+
+        /// Generic three-register 128-bit VEX instruction with an immediate.
+        pub fn vexRegRegRegImm8(
+            self: *Self,
+            map: VexMap,
+            prefix: VexPrefix,
+            w: bool,
+            opcode: u8,
+            dst: FloatReg,
+            src1: FloatReg,
+            src2: FloatReg,
+            imm: u8,
+        ) Allocator.Error!void {
+            try self.vexRegRegReg(map, prefix, w, opcode, dst, src1, src2);
+            try self.buf.append(self.allocator, imm);
+        }
+
+        /// Generic unary 128-bit VEX instruction (VEX.vvvv is reserved).
+        pub fn vexRegReg(
+            self: *Self,
+            map: VexMap,
+            prefix: VexPrefix,
+            w: bool,
+            opcode: u8,
+            dst: FloatReg,
+            src: FloatReg,
+        ) Allocator.Error!void {
+            try self.emitVex3Prefix(map, prefix, w, dst, null, src.rexB());
+            try self.buf.append(self.allocator, opcode);
+            try self.buf.append(self.allocator, modRM(0b11, dst.enc(), src.enc()));
+        }
+
+        pub fn vexRegRegImm8(
+            self: *Self,
+            map: VexMap,
+            prefix: VexPrefix,
+            w: bool,
+            opcode: u8,
+            dst: FloatReg,
+            src: FloatReg,
+            imm: u8,
+        ) Allocator.Error!void {
+            try self.vexRegReg(map, prefix, w, opcode, dst, src);
+            try self.buf.append(self.allocator, imm);
+        }
+
+        /// VEX packed shift by immediate. These encodings place the
+        /// destination in VEX.vvvv and the source in ModR/M.r/m; ModR/M.reg
+        /// selects the shift operation.
+        pub fn vexPackedShiftImm8(
+            self: *Self,
+            opcode: u8,
+            digit: u3,
+            dst: FloatReg,
+            src: FloatReg,
+            imm: u8,
+        ) Allocator.Error!void {
+            const inv_b: u1 = 1 - src.rexB();
+            const byte2: u8 = 0xC0 | (@as(u8, inv_b) << 5) | @intFromEnum(VexMap.map_0f);
+            const encoded_vvvv: u4 = @truncate(~@as(u4, @intCast(@intFromEnum(dst))));
+            const byte3: u8 = (@as(u8, encoded_vvvv) << 3) | @intFromEnum(VexPrefix.p66);
+            try self.buf.appendSlice(self.allocator, &.{
+                0xC4,
+                byte2,
+                byte3,
+                opcode,
+                modRM(0b11, digit, src.enc()),
+                imm,
+            });
+        }
+
+        pub fn movVectorFromGeneral(self: *Self, dst: FloatReg, src: GeneralReg, qword: bool) Allocator.Error!void {
+            try self.buf.append(self.allocator, 0x66);
+            const w: u1 = @intFromBool(qword);
+            const r: u1 = dst.rexB();
+            const b: u1 = src.rexB();
+            if (w != 0 or r != 0 or b != 0) try self.buf.append(self.allocator, rex(w, r, 0, b));
+            try self.buf.appendSlice(self.allocator, &.{ 0x0F, 0x6E, modRM(0b11, dst.enc(), src.enc()) });
+        }
+
+        pub fn movGeneralFromVector(self: *Self, dst: GeneralReg, src: FloatReg, qword: bool) Allocator.Error!void {
+            try self.buf.append(self.allocator, 0x66);
+            const w: u1 = @intFromBool(qword);
+            const r: u1 = src.rexB();
+            const b: u1 = dst.rexB();
+            if (w != 0 or r != 0 or b != 0) try self.buf.append(self.allocator, rex(w, r, 0, b));
+            try self.buf.appendSlice(self.allocator, &.{ 0x0F, 0x7E, modRM(0b11, src.enc(), dst.enc()) });
+        }
+
+        pub fn insertQword(self: *Self, dst: FloatReg, src: GeneralReg, index: u1) Allocator.Error!void {
+            try self.buf.append(self.allocator, 0x66);
+            try self.buf.append(self.allocator, rex(1, dst.rexB(), 0, src.rexB()));
+            try self.buf.appendSlice(self.allocator, &.{
+                0x0F,
+                0x3A,
+                0x22,
+                modRM(0b11, dst.enc(), src.enc()),
+                index,
+            });
+        }
+
+        pub fn extractQword(self: *Self, dst: GeneralReg, src: FloatReg, index: u1) Allocator.Error!void {
+            try self.buf.append(self.allocator, 0x66);
+            try self.buf.append(self.allocator, rex(1, src.rexB(), 0, dst.rexB()));
+            try self.buf.appendSlice(self.allocator, &.{
+                0x0F,
+                0x3A,
+                0x16,
+                modRM(0b11, src.enc(), dst.enc()),
+                index,
+            });
+        }
+
+        pub fn packedMoveMask(self: *Self, dst: GeneralReg, src: FloatReg, lane_bits: u7) Allocator.Error!void {
+            if (lane_bits <= 16 or lane_bits == 64) try self.buf.append(self.allocator, 0x66);
+            const r: u1 = dst.rexB();
+            const b: u1 = src.rexB();
+            if (r != 0 or b != 0) try self.buf.append(self.allocator, rex(0, r, 0, b));
+            try self.buf.append(self.allocator, 0x0F);
+            try self.buf.append(self.allocator, if (lane_bits <= 16) 0xD7 else 0x50);
+            try self.buf.append(self.allocator, modRM(0b11, dst.enc(), src.enc()));
+        }
+
+        pub fn pext(self: *Self, dst: GeneralReg, value: GeneralReg, mask: GeneralReg) Allocator.Error!void {
+            const inv_r: u1 = 1 - dst.rexR();
+            const inv_b: u1 = 1 - mask.rexB();
+            const byte2: u8 = (@as(u8, inv_r) << 7) | 0x40 | (@as(u8, inv_b) << 5) | 2;
+            const encoded_vvvv: u4 = @truncate(~@as(u4, @intCast(@intFromEnum(value))));
+            const byte3: u8 = 0x80 | (@as(u8, encoded_vvvv) << 3) | 2;
+            try self.buf.appendSlice(self.allocator, &.{
+                0xC4,
+                byte2,
+                byte3,
+                0xF5,
+                modRM(0b11, dst.enc(), mask.enc()),
+            });
+        }
+
         /// MOVSD xmm, xmm (move scalar double)
         pub fn movsdRegReg(self: *Self, dst: FloatReg, src: FloatReg) Allocator.Error!void {
             try self.buf.append(self.allocator, 0xF2); // REPNE prefix for MOVSD
@@ -881,6 +1072,15 @@ pub fn Emit(comptime target: RocTarget) type {
             try self.emitFloatRex(dst, src);
             try self.buf.append(self.allocator, 0x0F);
             try self.buf.append(self.allocator, 0x10);
+            try self.buf.append(self.allocator, modRM(0b11, dst.enc(), src.enc()));
+        }
+
+        /// MOVDQA xmm, xmm (move an entire 128-bit register)
+        pub fn movdqaRegReg(self: *Self, dst: FloatReg, src: FloatReg) Allocator.Error!void {
+            try self.buf.append(self.allocator, 0x66);
+            try self.emitFloatRex(dst, src);
+            try self.buf.append(self.allocator, 0x0F);
+            try self.buf.append(self.allocator, 0x6F);
             try self.buf.append(self.allocator, modRM(0b11, dst.enc(), src.enc()));
         }
 
@@ -1552,6 +1752,47 @@ test "movdqu load and store unaligned 128-bit values" {
     emit.buf.clearRetainingCapacity();
     try emit.movdquMemReg(.RBP, -16, .XMM0);
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0xF3, 0x0F, 0x7F, 0x85, 0xF0, 0xFF, 0xFF, 0xFF }, emit.buf.items);
+}
+
+test "packed integer VEX encodings" {
+    var emit = LinuxEmit.init(std.testing.allocator);
+    defer emit.deinit();
+
+    // vpaddb xmm3, xmm12, xmm7. The generic emitter deliberately uses the
+    // always-valid three-byte VEX form, including when a two-byte form exists.
+    try emit.vexRegRegReg(.map_0f, .p66, false, 0xFC, .XMM3, .XMM12, .XMM7);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xC4, 0xE1, 0x19, 0xFC, 0xDF }, emit.buf.items);
+
+    emit.buf.clearRetainingCapacity();
+    // vpshufb xmm9, xmm2, xmm15
+    try emit.vexRegRegReg(.map_0f38, .p66, false, 0x00, .XMM9, .XMM2, .XMM15);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xC4, 0x42, 0x69, 0x00, 0xCF }, emit.buf.items);
+
+    emit.buf.clearRetainingCapacity();
+    // vpclmulqdq xmm10, xmm11, xmm13, 0x11
+    try emit.vexRegRegRegImm8(.map_0f3a, .p66, false, 0x44, .XMM10, .XMM11, .XMM13, 0x11);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xC4, 0x43, 0x21, 0x44, 0xD5, 0x11 }, emit.buf.items);
+}
+
+test "packed integer scalar bridges and masks" {
+    var emit = LinuxEmit.init(std.testing.allocator);
+    defer emit.deinit();
+
+    try emit.movVectorFromGeneral(.XMM9, .R10, true);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x66, 0x4D, 0x0F, 0x6E, 0xCA }, emit.buf.items);
+
+    emit.buf.clearRetainingCapacity();
+    try emit.movGeneralFromVector(.R10, .XMM9, true);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x66, 0x4D, 0x0F, 0x7E, 0xCA }, emit.buf.items);
+
+    emit.buf.clearRetainingCapacity();
+    // PMOVMSKB's mandatory 0x66 prefix is part of the integer encoding.
+    try emit.packedMoveMask(.R10, .XMM14, 16);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x66, 0x45, 0x0F, 0xD7, 0xD6 }, emit.buf.items);
+
+    emit.buf.clearRetainingCapacity();
+    try emit.pext(.R9, .R10, .R11);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xC4, 0x42, 0xAA, 0xF5, 0xCB }, emit.buf.items);
 }
 
 test "addsd xmm, xmm - all combinations" {

--- a/src/base/LowLevel.zig
+++ b/src/base/LowLevel.zig
@@ -561,8 +561,8 @@ pub const LowLevel = enum(u16) {
     crash,
 
     /// Index into `builtins.simd.Op`. The SIMD entries are intentionally one
-    /// contiguous, order-pinned block so compiler artifacts and dependency-
-    /// light runtime payloads share a compact operation identifier without a
+    /// contiguous, order-pinned block so the interpreter and compile-time
+    /// evaluator share the semantic oracle's operation vocabulary without a
     /// module cycle.
     pub fn simdOpIndex(self: LowLevel) ?u8 {
         return switch (self) {

--- a/src/builtins/builtin_registry.zig
+++ b/src/builtins/builtin_registry.zig
@@ -24,8 +24,6 @@ pub const symbol_prefix = "roc_builtins_";
 pub const BuiltinFn = enum {
     hasher_write_u64,
     hasher_write_u128,
-    simd_eval,
-    simd_load_16,
     simd_store_16,
     simd_append_16,
     hasher_write_f32_bits,

--- a/src/builtins/dev_wrappers.zig
+++ b/src/builtins/dev_wrappers.zig
@@ -19,7 +19,6 @@ const i128h = @import("compiler_rt_128.zig");
 const float_math_f32 = @import("float_math/f32.zig");
 const float_math_f64 = @import("float_math/f64.zig");
 const numeric_conversions = @import("numeric_conversions.zig");
-const simd = @import("simd.zig");
 
 const RocStr = str.RocStr;
 const RocList = list.RocList;
@@ -71,26 +70,6 @@ pub fn roc_builtins_hasher_write_u128(seed: u64, domain: u8, low: u64, high: u64
     return hash.hasher_write_u128(seed, domain, low, high);
 }
 
-/// Bit-exact SIMD helper for the correctness-oriented dev backends. The
-/// optimizing LLVM and wasm backends lower the same low-level operations to
-/// native vector instructions instead of calling this function.
-pub fn roc_builtins_simd_eval(
-    out: *u128,
-    descriptor: u32,
-    inputs: *const [3]u128,
-) callconv(.c) void {
-    const op: simd.Op = @enumFromInt(@as(u8, @truncate(descriptor)));
-    const arg_kind: simd.Kind = @enumFromInt(@as(u3, @truncate(descriptor >> 8)));
-    const ret_kind: simd.Kind = @enumFromInt(@as(u3, @truncate(descriptor >> 16)));
-    out.* = simd.eval(op, arg_kind, ret_kind, inputs[0], inputs[1], inputs[2]);
-}
-
-/// Load 16 consecutive list bytes into a bit-exact SIMD value.
-pub fn roc_builtins_simd_load_16(out: *u128, bytes: ?[*]u8, index: u64) callconv(.c) void {
-    const source = bytes.? + @as(usize, @intCast(index));
-    @memcpy(std.mem.asBytes(out), source[0..16]);
-}
-
 /// Store a bit-exact SIMD value into 16 consecutive list bytes, cloning first
 /// when the update mode does not permit mutation in place.
 pub fn roc_builtins_simd_store_16(
@@ -131,17 +110,6 @@ pub fn roc_builtins_simd_append_16(
         result = list.listAppendUnsafe(result, @ptrCast(@constCast(byte)), 1, &list.copy_fallback);
     }
     out.* = result;
-}
-
-test "SIMD dev wrapper descriptor and input block" {
-    const equal_op = @intFromEnum(simd.Op.eq_lanes);
-    const byte_kind = @intFromEnum(simd.Kind.u8x16);
-    const descriptor = @as(u32, equal_op) | (@as(u32, byte_kind) << 8) | (@as(u32, byte_kind) << 16);
-    const bytes: u128 = 0x38383838383838383838383838383838;
-    var inputs = [3]u128{ bytes, bytes, 0 };
-    var out: u128 = undefined;
-    roc_builtins_simd_eval(&out, descriptor, &inputs);
-    try std.testing.expectEqual(@as(u128, ~@as(u128, 0)), out);
 }
 
 /// C ABI wrapper for hashing raw F32 bits.

--- a/src/builtins/simd.zig
+++ b/src/builtins/simd.zig
@@ -1,13 +1,13 @@
 //! Bit-exact, target-independent meaning of Roc's 128-bit integer SIMD ops.
 //!
-//! Optimizing backends lower these operations to native vector instructions.
-//! The evaluators and dev-backend helpers use this implementation directly so
-//! every execution path has the same edge-case behavior.
+//! Compiled backends lower these operations to native vector instructions.
+//! The interpreter, compile-time evaluator, and differential tests use this
+//! implementation as their target-independent semantic oracle.
 
 const std = @import("std");
 
-/// Runtime-side SIMD vocabulary. `base.LowLevel.simdOpIndex` is the explicit
-/// compiler-to-runtime mapping and pins this declaration order.
+/// Evaluator-side SIMD vocabulary. `base.LowLevel.simdOpIndex` is the explicit
+/// low-level-to-oracle mapping and pins this declaration order.
 pub const Op = enum(u8) {
     load_16_unchecked,
     store_16_unchecked,


### PR DESCRIPTION
Dev-mode SIMD currently routes every operation through a scalar runtime helper, making the default development backend produce misleading performance results. This adds first-class vector-register allocation and exhaustive native x86-64/AArch64 lowering, keeps vectors in registers across chained operations, makes load and unique-store paths native, and removes the scalar compiled-program fallback while retaining the evaluator as the interpreter and compile-time oracle.

The lowering preserves the pinned cross-ISA semantics for shifts, table lookup, saturated Q15 multiplication, narrowing, and the other emulated cases. The SIMD codegen gate now checks native dev output and instantiates the exhaustive corpus through the AArch64 backend.

Fixes #10428.