### PR TITLE
Avoid allocations in numeric exclusive iterators

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -6707,27 +6707,21 @@ Builtin :: [].{
 			## ```
 			until : U8, U8 -> Iter(U8)
 			until = |start, end|
-				iter_from_step(
+				Iter.custom(
+					start,
 					if start >= end {
 						Known(0)
 					} else {
 						Known(U8.to_u64(end) - U8.to_u64(start))
 					},
-					||
-						if start < end {
-							One({
-								item: start,
-								rest: match U8.plus_try(start, 1) {
-									Ok(next) => if next < end {
-										U8.until(next, end)
-									} else {
-										range_done()
-									}
-									Err(Overflow) => range_done()
-								},
-							})
+					|current|
+						if current < end {
+							match U8.plus_try(current, 1) {
+								Ok(next) => Ok((current, next))
+								Err(Overflow) => Ok((current, end))
+							}
 						} else {
-							Done
+							Err(NoMore)
 						},
 				)
 
@@ -7416,27 +7410,21 @@ Builtin :: [].{
 			## ```
 			until : I8, I8 -> Iter(I8)
 			until = |start, end|
-				iter_from_step(
+				Iter.custom(
+					start,
 					if start >= end {
 						Known(0)
 					} else {
 						Known(I64.to_u64_wrap(I8.to_i64(end) - I8.to_i64(start)))
 					},
-					||
-						if start < end {
-							One({
-								item: start,
-								rest: match I8.plus_try(start, 1) {
-									Ok(next) => if next < end {
-										I8.until(next, end)
-									} else {
-										range_done()
-									}
-									Err(Overflow) => range_done()
-								},
-							})
+					|current|
+						if current < end {
+							match I8.plus_try(current, 1) {
+								Ok(next) => Ok((current, next))
+								Err(Overflow) => Ok((current, end))
+							}
 						} else {
-							Done
+							Err(NoMore)
 						},
 				)
 
@@ -8133,27 +8121,21 @@ Builtin :: [].{
 			## ```
 			until : U16, U16 -> Iter(U16)
 			until = |start, end|
-				iter_from_step(
+				Iter.custom(
+					start,
 					if start >= end {
 						Known(0)
 					} else {
 						Known(U16.to_u64(end) - U16.to_u64(start))
 					},
-					||
-						if start < end {
-							One({
-								item: start,
-								rest: match U16.plus_try(start, 1) {
-									Ok(next) => if next < end {
-										U16.until(next, end)
-									} else {
-										range_done()
-									}
-									Err(Overflow) => range_done()
-								},
-							})
+					|current|
+						if current < end {
+							match U16.plus_try(current, 1) {
+								Ok(next) => Ok((current, next))
+								Err(Overflow) => Ok((current, end))
+							}
 						} else {
-							Done
+							Err(NoMore)
 						},
 				)
 
@@ -8901,27 +8883,21 @@ Builtin :: [].{
 			## ```
 			until : I16, I16 -> Iter(I16)
 			until = |start, end|
-				iter_from_step(
+				Iter.custom(
+					start,
 					if start >= end {
 						Known(0)
 					} else {
 						Known(I64.to_u64_wrap(I16.to_i64(end) - I16.to_i64(start)))
 					},
-					||
-						if start < end {
-							One({
-								item: start,
-								rest: match I16.plus_try(start, 1) {
-									Ok(next) => if next < end {
-										I16.until(next, end)
-									} else {
-										range_done()
-									}
-									Err(Overflow) => range_done()
-								},
-							})
+					|current|
+						if current < end {
+							match I16.plus_try(current, 1) {
+								Ok(next) => Ok((current, next))
+								Err(Overflow) => Ok((current, end))
+							}
 						} else {
-							Done
+							Err(NoMore)
 						},
 				)
 
@@ -9633,27 +9609,21 @@ Builtin :: [].{
 			## ```
 			until : U32, U32 -> Iter(U32)
 			until = |start, end|
-				iter_from_step(
+				Iter.custom(
+					start,
 					if start >= end {
 						Known(0)
 					} else {
 						Known(U32.to_u64(end) - U32.to_u64(start))
 					},
-					||
-						if start < end {
-							One({
-								item: start,
-								rest: match U32.plus_try(start, 1) {
-									Ok(next) => if next < end {
-										U32.until(next, end)
-									} else {
-										range_done()
-									}
-									Err(Overflow) => range_done()
-								},
-							})
+					|current|
+						if current < end {
+							match U32.plus_try(current, 1) {
+								Ok(next) => Ok((current, next))
+								Err(Overflow) => Ok((current, end))
+							}
 						} else {
-							Done
+							Err(NoMore)
 						},
 				)
 
@@ -10433,27 +10403,21 @@ Builtin :: [].{
 			## ```
 			until : I32, I32 -> Iter(I32)
 			until = |start, end|
-				iter_from_step(
+				Iter.custom(
+					start,
 					if start >= end {
 						Known(0)
 					} else {
 						Known(I64.to_u64_wrap(I32.to_i64(end) - I32.to_i64(start)))
 					},
-					||
-						if start < end {
-							One({
-								item: start,
-								rest: match I32.plus_try(start, 1) {
-									Ok(next) => if next < end {
-										I32.until(next, end)
-									} else {
-										range_done()
-									}
-									Err(Overflow) => range_done()
-								},
-							})
+					|current|
+						if current < end {
+							match I32.plus_try(current, 1) {
+								Ok(next) => Ok((current, next))
+								Err(Overflow) => Ok((current, end))
+							}
 						} else {
-							Done
+							Err(NoMore)
 						},
 				)
 
@@ -11188,27 +11152,21 @@ Builtin :: [].{
 			## ```
 			until : U64, U64 -> Iter(U64)
 			until = |start, end|
-				iter_from_step(
+				Iter.custom(
+					start,
 					if start >= end {
 						Known(0)
 					} else {
 						Known(end - start)
 					},
-					||
-						if start < end {
-							One({
-								item: start,
-								rest: match U64.plus_try(start, 1) {
-									Ok(next) => if next < end {
-										U64.until(next, end)
-									} else {
-										range_done()
-									}
-									Err(Overflow) => range_done()
-								},
-							})
+					|current|
+						if current < end {
+							match U64.plus_try(current, 1) {
+								Ok(next) => Ok((current, next))
+								Err(Overflow) => Ok((current, end))
+							}
 						} else {
-							Done
+							Err(NoMore)
 						},
 				)
 
@@ -12033,7 +11991,8 @@ Builtin :: [].{
 			## ```
 			until : I64, I64 -> Iter(I64)
 			until = |start, end|
-				iter_from_step(
+				Iter.custom(
+					start,
 					if start >= end {
 						Known(0)
 					} else {
@@ -12042,21 +12001,14 @@ Builtin :: [].{
 							Err(Overflow) => Unknown
 						}
 					},
-					||
-						if start < end {
-							One({
-								item: start,
-								rest: match I64.plus_try(start, 1) {
-									Ok(next) => if next < end {
-										I64.until(next, end)
-									} else {
-										range_done()
-									}
-									Err(Overflow) => range_done()
-								},
-							})
+					|current|
+						if current < end {
+							match I64.plus_try(current, 1) {
+								Ok(next) => Ok((current, next))
+								Err(Overflow) => Ok((current, end))
+							}
 						} else {
-							Done
+							Err(NoMore)
 						},
 				)
 
@@ -12813,7 +12765,8 @@ Builtin :: [].{
 			## ```
 			until : U128, U128 -> Iter(U128)
 			until = |start, end|
-				iter_from_step(
+				Iter.custom(
+					start,
 					if start >= end {
 						Known(0)
 					} else {
@@ -12822,21 +12775,14 @@ Builtin :: [].{
 							Err(OutOfRange) => Unknown
 						}
 					},
-					||
-						if start < end {
-							One({
-								item: start,
-								rest: match U128.plus_try(start, 1) {
-									Ok(next) => if next < end {
-										U128.until(next, end)
-									} else {
-										range_done()
-									}
-									Err(Overflow) => range_done()
-								},
-							})
+					|current|
+						if current < end {
+							match U128.plus_try(current, 1) {
+								Ok(next) => Ok((current, next))
+								Err(Overflow) => Ok((current, end))
+							}
 						} else {
-							Done
+							Err(NoMore)
 						},
 				)
 
@@ -13703,7 +13649,8 @@ Builtin :: [].{
 			## ```
 			until : I128, I128 -> Iter(I128)
 			until = |start, end|
-				iter_from_step(
+				Iter.custom(
+					start,
 					if start >= end {
 						Known(0)
 					} else {
@@ -13715,21 +13662,14 @@ Builtin :: [].{
 							Err(Overflow) => Unknown
 						}
 					},
-					||
-						if start < end {
-							One({
-								item: start,
-								rest: match I128.plus_try(start, 1) {
-									Ok(next) => if next < end {
-										I128.until(next, end)
-									} else {
-										range_done()
-									}
-									Err(Overflow) => range_done()
-								},
-							})
+					|current|
+						if current < end {
+							match I128.plus_try(current, 1) {
+								Ok(next) => Ok((current, next))
+								Err(Overflow) => Ok((current, end))
+							}
 						} else {
-							Done
+							Err(NoMore)
 						},
 				)
 
@@ -14913,23 +14853,17 @@ Builtin :: [].{
 			## ```
 			until : Dec, Dec -> Iter(Dec)
 			until = |start, end|
-				iter_from_step(
+				Iter.custom(
+					start,
 					Unknown,
-					||
-						if start < end {
-							One({
-								item: start,
-								rest: match Dec.plus_try(start, 1.0) {
-									Ok(next) => if next < end {
-										Dec.until(next, end)
-									} else {
-										range_done()
-									}
-									Err(Overflow) => range_done()
-								},
-							})
+					|current|
+						if current < end {
+							match Dec.plus_try(current, 1.0) {
+								Ok(next) => Ok((current, next))
+								Err(Overflow) => Ok((current, end))
+							}
 						} else {
-							Done
+							Err(NoMore)
 						},
 				)
 
@@ -21813,11 +21747,10 @@ range_done = || iter_from_step(
 	|| Done,
 )
 
-# Shared step loop behind the numeric types' `range_exclusive` methods. Each
-# caller supplies `len_if_known` computed from its own representation; when it
-# is `Known`, it must be the exact yield count (`Iter.take_last`/`drop_last`
-# rely on that). The construction is `Iter.exclusive_range`, whose flat
-# self-recursive shape keeps a range's state unboxed when an adapter wraps it.
+# Shared state machine behind the numeric types' `range_exclusive` methods.
+# Each caller supplies `len_if_known` computed from its own representation;
+# when it is `Known`, it must be the exact yield count
+# (`Iter.take_last`/`drop_last` rely on that).
 range_exclusive_with_len : num, num, [Known(U64), Unknown] -> Iter(num)
 	where [
 		num.is_lt : num, num -> Bool,
@@ -21825,7 +21758,19 @@ range_exclusive_with_len : num, num, [Known(U64), Unknown] -> Iter(num)
 		num.from_numeral : Builtin.Num.Numeral -> Try(num, [InvalidNumeral(Str)]),
 	]
 range_exclusive_with_len = |start, end, len_if_known|
-	Iter.exclusive_range(start, end, len_if_known)
+	Iter.custom(
+		start,
+		len_if_known,
+		|current|
+			if current < end {
+				match current.plus_try(1) {
+					Ok(next) => Ok((current, next))
+					Err(Overflow) => Ok((current, end))
+				}
+			} else {
+				Err(NoMore)
+			},
+	)
 
 # Shared step loop behind the numeric types' `range_inclusive` methods; same
 # `len_if_known` contract as `range_exclusive_with_len`. The construction is

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -1153,6 +1153,10 @@ const ProcShape = struct {
     tag_assign_count: usize = 0,
     store_struct_count: usize = 0,
     store_tag_count: usize = 0,
+    incref_count: usize = 0,
+    decref_count: usize = 0,
+    decref_if_initialized_count: usize = 0,
+    free_count: usize = 0,
 };
 
 fn collectProcShape(
@@ -3230,10 +3234,22 @@ fn collectLirResultProcShape(
             .debug => |stmt| try work.append(allocator, stmt.next),
             .expect => |stmt| try work.append(allocator, stmt.next),
             .comptime_branch_taken => |stmt| try work.append(allocator, stmt.next),
-            .incref => |stmt| try work.append(allocator, stmt.next),
-            .decref => |stmt| try work.append(allocator, stmt.next),
-            .decref_if_initialized => |stmt| try work.append(allocator, stmt.next),
-            .free => |stmt| try work.append(allocator, stmt.next),
+            .incref => |stmt| {
+                shape.incref_count += 1;
+                try work.append(allocator, stmt.next);
+            },
+            .decref => |stmt| {
+                shape.decref_count += 1;
+                try work.append(allocator, stmt.next);
+            },
+            .decref_if_initialized => |stmt| {
+                shape.decref_if_initialized_count += 1;
+                try work.append(allocator, stmt.next);
+            },
+            .free => |stmt| {
+                shape.free_count += 1;
+                try work.append(allocator, stmt.next);
+            },
             .switch_stmt => |stmt| {
                 shape.switch_count += 1;
                 if (stmt.continuation) |continuation| try work.append(allocator, continuation);
@@ -3418,6 +3434,56 @@ fn expectLoweredIterStateHasNoBoxesOrErasedCallables(
     try expectReachableProcShapeFieldEqual(allocator, lowered, "box_box_count", 0);
     try expectReachableProcShapeFieldEqual(allocator, lowered, "erased_call_count", 0);
     try expectReachableProcShapeFieldEqual(allocator, lowered, "packed_erased_fn_count", 0);
+}
+
+// Repro for https://github.com/roc-lang/roc/issues/10429: numeric `until` and
+// `range_exclusive` iterators consumed directly by `for` have scalar state,
+// with no heap or ARC operations.
+test "issue 10429 numeric until and range_exclusive loops have no heap or RC operations" {
+    const allocator = std.testing.allocator;
+    const numeric_types = [_][]const u8{
+        "U8",  "I8",  "U16",  "I16",  "U32", "I32",
+        "U64", "I64", "U128", "I128", "Dec",
+    };
+
+    for (numeric_types) |numeric_type| {
+        const source = try std.fmt.allocPrint(allocator,
+            \\until_last : {s} -> {s}
+            \\until_last = |n| {{
+            \\    var $last = 0.{s}
+            \\    for i in {s}.until(0, n) {{
+            \\        $last = i
+            \\    }}
+            \\    $last
+            \\}}
+            \\
+            \\range_last : {s} -> {s}
+            \\range_last = |n| {{
+            \\    var $last = 0.{s}
+            \\    for i in {s}.range_exclusive(0, n) {{
+            \\        $last = i
+            \\    }}
+            \\    $last
+            \\}}
+            \\
+            \\main : {s} -> ({s}, {s})
+            \\main = |n| (until_last(n), range_last(n))
+        , .{
+            numeric_type, numeric_type, numeric_type, numeric_type,
+            numeric_type, numeric_type, numeric_type, numeric_type,
+            numeric_type, numeric_type, numeric_type,
+        });
+        defer allocator.free(source);
+
+        var optimized = try lowerModuleWithOptions(allocator, source, .wrappers, .{ .tag_reachability = true });
+        defer optimized.deinit(allocator);
+
+        try expectLoweredIterChainAllocatesNothing(allocator, &optimized.lowered);
+        try expectReachableProcShapeFieldEqual(allocator, &optimized.lowered, "incref_count", 0);
+        try expectReachableProcShapeFieldEqual(allocator, &optimized.lowered, "decref_count", 0);
+        try expectReachableProcShapeFieldEqual(allocator, &optimized.lowered, "decref_if_initialized_count", 0);
+        try expectReachableProcShapeFieldEqual(allocator, &optimized.lowered, "free_count", 0);
+    }
 }
 
 // Zero-allocation gate for iterator chains that escape their construction site


### PR DESCRIPTION
Numeric `until` iterators were rebuilding recursive `Iter` values for every element, which boxed and reference-counted their state in hot loops. This expresses every numeric `until` implementation and the shared exclusive-range producer as scalar `Iter.custom` state machines, preserving length and overflow semantics while allowing iterator specialization to eliminate allocations and ARC operations. Fixes #10429.