### PR TITLE
Support directory-qualified local modules

### DIFF
--- a/docs/langref/modules.md
+++ b/docs/langref/modules.md
@@ -245,8 +245,9 @@ import Internal.Http.Client exposing [send]
 ```
 
 These imports load `Src/Widget.roc` and `Internal/Http/Client.roc`,
-respectively. The source-visible module name is the final path segment, so
-`Src/Widget.roc` defines the nominal type `Widget`.
+respectively, relative to the directory containing the importing `.roc` file.
+The source-visible module name is the final path segment, so `Src/Widget.roc`
+defines the nominal type `Widget`.
 
 The explicit clause disambiguates a directory path from a nested type import.
 Without one, `import Url.ParseErr` imports the nested `ParseErr` type from

--- a/docs/langref/modules.md
+++ b/docs/langref/modules.md
@@ -234,6 +234,33 @@ import Color as CC
 import json.Parser as JP
 ```
 
+### Modules in subdirectories
+
+An uppercase dotted module path maps to source subdirectories when the import has
+an explicit `as` or `exposing` clause. For example:
+
+```roc
+import Src.Widget as Widget
+import Internal.Http.Client exposing [send]
+```
+
+These imports load `Src/Widget.roc` and `Internal/Http/Client.roc`,
+respectively. The source-visible module name is the final path segment, so
+`Src/Widget.roc` defines the nominal type `Widget`.
+
+The explicit clause disambiguates a directory path from a nested type import.
+Without one, `import Url.ParseErr` imports the nested `ParseErr` type from
+`Url.roc`; it does not load `Url/ParseErr.roc`.
+
+A package can expose a module stored in a subdirectory by naming its import
+alias in the package header:
+
+```roc
+package [Widget] {}
+
+import Src.Widget as Widget
+```
+
 ### Importing types from packages
 
 Packages contain a collection of modules that are imported by applications, platforms or packages. Package dependencies are specified in the module header:

--- a/src/base/module_path.zig
+++ b/src/base/module_path.zig
@@ -39,6 +39,16 @@ pub fn getModuleNameAlloc(
     return try allocator.dupe(u8, getModuleName(path));
 }
 
+/// Return the source-visible module name from a dotted local module path.
+///
+/// Examples:
+///   "Widget" -> "Widget"
+///   "Src.Widget" -> "Widget"
+pub fn getModuleBasename(module_path: []const u8) []const u8 {
+    const dot = std.mem.findScalarLast(u8, module_path, '.') orelse return module_path;
+    return module_path[dot + 1 ..];
+}
+
 test "getModuleName strips .roc extension" {
     try std.testing.expectEqualStrings("Module", getModuleName("path/to/Module.roc"));
     try std.testing.expectEqualStrings("Module", getModuleName("Module.roc"));
@@ -59,6 +69,11 @@ test "getModuleNameAlloc allocates correctly" {
     const result = try getModuleNameAlloc(allocator, "path/to/Module.roc");
     defer allocator.free(result);
     try std.testing.expectEqualStrings("Module", result);
+}
+
+test "getModuleBasename returns the final dotted segment" {
+    try std.testing.expectEqualStrings("Widget", getModuleBasename("Widget"));
+    try std.testing.expectEqualStrings("Widget", getModuleBasename("Src.Widget"));
 }
 
 /// Result of parsing a qualified import name like "pf.Wrapper"

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -366,8 +366,6 @@ scratch_block_local_defs: base.Scratch(BlockLocalDef),
 scratch_local_type_decls: std.ArrayList(CIR.Statement.Idx),
 /// Module-global value definitions produced by canonicalization.
 scratch_global_value_defs: std.ArrayList(CIR.Def.Idx),
-/// Counter for generating unique malformed import placeholder names
-malformed_import_count: u32 = 0,
 /// Counter for generating unique anonymous open extension rigid var names
 anon_open_ext_count: u32 = 0,
 /// Counter for generating unique closure tag names (e.g., "Closure_addX_1", "Closure_addX_2")
@@ -554,14 +552,6 @@ fn scratchAppendSlice(self: *Self, bytes: []const u8) std.mem.Allocator.Error!vo
 
 fn scratchAppendByte(self: *Self, byte: u8) std.mem.Allocator.Error!void {
     try self.scratch_bytes.append(byte);
-}
-
-fn scratchFmt(self: *Self, comptime fmt: []const u8, args: anytype) std.mem.Allocator.Error![]const u8 {
-    const top = self.scratchBytesTop();
-    const len = std.fmt.count(fmt, args);
-    try self.scratch_bytes.items.resize(@as(usize, top) + len);
-    _ = std.fmt.bufPrint(self.scratch_bytes.items.items[top..], fmt, args) catch unreachable;
-    return self.scratchBytesFrom(top);
 }
 
 fn appendQualifiedText(scratch: *base.Scratch(u8), parent: []const u8, child: []const u8) std.mem.Allocator.Error![]const u8 {
@@ -6173,7 +6163,9 @@ fn importAliased(
     // "Exposed But Not Defined" for re-exported imports. The ident text must be
     // fetched fresh here: the import processing above interns new idents, which
     // can grow the interner's byte buffer and invalidate any earlier text slice.
-    _ = self.exposed_type_texts.remove(self.env.getIdent(module_name));
+    // Package headers expose the source-visible alias, not the dependency's
+    // complete import path.
+    _ = self.exposed_type_texts.remove(self.env.getIdent(alias));
 
     return import_idx;
 }
@@ -6245,6 +6237,44 @@ fn importUnaliased(
     return import_idx;
 }
 
+/// Intern the normalized module path selected by the parser. Import layout may
+/// put whitespace between dotted segments, so semantic names are assembled
+/// from identifier tokens instead of slicing the original source.
+fn normalizedImportModuleIdent(
+    self: *Self,
+    import_stmt: @TypeOf(@as(AST.Statement, undefined).import),
+) std.mem.Allocator.Error!Ident.Idx {
+    const scratch_top = self.scratchBytesTop();
+    defer self.clearScratchBytesFrom(scratch_top);
+
+    if (import_stmt.qualifier_tok) |qualifier_tok| {
+        try self.scratchAppendSlice(self.parse_ir.resolve(qualifier_tok));
+        try self.scratchAppendByte('.');
+    }
+
+    const first_raw = self.parse_ir.resolve(import_stmt.module_name_tok);
+    const first = if (first_raw.len > 0 and first_raw[0] == '.') first_raw[1..] else first_raw;
+    try self.scratchAppendSlice(first);
+
+    if (!import_stmt.nested_import) {
+        const tags = self.parse_ir.tokens.tokens.items(.tag);
+        var tok = import_stmt.module_name_tok + 1;
+        while (tok < tags.len) : (tok += 1) {
+            switch (tags[tok]) {
+                .NoSpaceDotUpperIdent, .DotUpperIdent => {
+                    const raw = self.parse_ir.resolve(tok);
+                    const segment = if (raw.len > 0 and raw[0] == '.') raw[1..] else raw;
+                    try self.scratchAppendByte('.');
+                    try self.scratchAppendSlice(segment);
+                },
+                else => break,
+            }
+        }
+    }
+
+    return try self.env.insertIdent(base.Ident.for_text(self.scratchBytesFrom(scratch_top)));
+}
+
 /// Canonicalize an import statement, handling both top-level file imports and statement imports
 fn canonicalizeImportStatement(
     self: *Self,
@@ -6253,64 +6283,12 @@ fn canonicalizeImportStatement(
     const trace = tracy.trace(@src());
     defer trace.end();
 
-    // 1. Build the full module name (e.g., "json.Json")
-    const module_name = blk: {
-        if (self.parse_ir.tokens.resolveIdentifier(import_stmt.module_name_tok) == null) {
-            const region = self.parse_ir.tokenizedRegionToRegion(import_stmt.region);
-            const feature = try self.env.insertString("resolve import module name token");
-            try self.env.pushDiagnostic(Diagnostic{ .not_implemented = .{
-                .feature = feature,
-                .region = region,
-            } });
-            return null;
-        }
-
-        if (import_stmt.qualifier_tok) |qualifier_tok| {
-            if (self.parse_ir.tokens.resolveIdentifier(qualifier_tok) == null) {
-                const region = self.parse_ir.tokenizedRegionToRegion(import_stmt.region);
-                const feature = try self.env.insertString("resolve import qualifier token");
-                try self.env.pushDiagnostic(Diagnostic{ .not_implemented = .{
-                    .feature = feature,
-                    .region = region,
-                } });
-                return null;
-            }
-
-            // Slice from original source to get "qualifier.ModuleName"
-            const qualifier_region = self.parse_ir.tokens.resolve(qualifier_tok);
-            const module_region = self.parse_ir.tokens.resolve(import_stmt.module_name_tok);
-            const full_name = self.parse_ir.env.source[qualifier_region.start.offset..module_region.end.offset];
-
-            // Validate the full_name using Ident.from_bytes
-            if (base.Ident.from_bytes(full_name)) |valid_ident| {
-                break :blk try self.env.insertIdent(valid_ident);
-            } else |err| {
-                // Invalid identifier - create diagnostic and use placeholder
-                const region = self.parse_ir.tokenizedRegionToRegion(import_stmt.region);
-                const error_msg = switch (err) {
-                    base.Ident.Error.EmptyText => "malformed import module name is empty",
-                    base.Ident.Error.ContainsNullByte => "malformed import module name contains null bytes",
-                    base.Ident.Error.ContainsControlCharacters => "malformed import module name contains invalid control characters",
-                };
-                const feature = try self.env.insertString(error_msg);
-                try self.env.pushDiagnostic(Diagnostic{ .not_implemented = .{
-                    .feature = feature,
-                    .region = region,
-                } });
-
-                // Use a unique placeholder identifier that starts with '#' to ensure it can't
-                // collide with user-defined identifiers (# starts a comment in Roc)
-                const scratch_top = self.scratchBytesTop();
-                defer self.clearScratchBytesFrom(scratch_top);
-                const placeholder_text = try self.scratchFmt("#malformed_import_{d}", .{self.malformed_import_count});
-                self.malformed_import_count += 1;
-                break :blk try self.env.insertIdent(base.Ident.for_text(placeholder_text));
-            }
-        } else {
-            // No qualifier, just use the module name directly
-            break :blk self.parse_ir.tokens.resolveIdentifier(import_stmt.module_name_tok).?;
-        }
-    };
+    // 1. Build the complete module name selected by the parser.
+    if (self.parse_ir.tokens.resolveIdentifier(import_stmt.module_name_tok) == null) return null;
+    if (import_stmt.qualifier_tok) |qualifier_tok| {
+        if (self.parse_ir.tokens.resolveIdentifier(qualifier_tok) == null) return null;
+    }
+    const module_name = try self.normalizedImportModuleIdent(import_stmt);
 
     // 2. Convert exposed items to CIR
     const scratch_start = self.env.store.scratchExposedItemTop();
@@ -19860,15 +19838,11 @@ fn ensureParserImportAlias(self: *Self, alias_name: Ident.Idx) std.mem.Allocator
     };
     if (import_stmt.nested_import) return;
 
-    const base_module_name = self.parse_ir.tokens.resolveIdentifier(import_stmt.module_name_tok) orelse return;
-    const module_name = if (import_stmt.qualifier_tok) |qualifier_tok| blk: {
+    if (self.parse_ir.tokens.resolveIdentifier(import_stmt.module_name_tok) == null) return;
+    if (import_stmt.qualifier_tok) |qualifier_tok| {
         if (self.parse_ir.tokens.resolveIdentifier(qualifier_tok) == null) return;
-        const qualifier_region = self.parse_ir.tokens.resolve(qualifier_tok);
-        const module_region = self.parse_ir.tokens.resolve(import_stmt.module_name_tok);
-        const full_name = self.parse_ir.env.source[qualifier_region.start.offset..module_region.end.offset];
-        const valid_ident = base.Ident.from_bytes(full_name) catch return;
-        break :blk try self.env.insertIdent(valid_ident);
-    } else base_module_name;
+    }
+    const module_name = try self.normalizedImportModuleIdent(import_stmt);
 
     const resolved_alias = try self.resolveModuleAlias(import_stmt.alias_tok, module_name) orelse return;
     if (!resolved_alias.eql(alias_name)) return;

--- a/src/canonicalize/test/node_store_test.zig
+++ b/src/canonicalize/test/node_store_test.zig
@@ -31,7 +31,7 @@ fn rand_idx_u16(comptime T: type) T {
 /// Helper to create a `DataSpan` from raw start and length positions.
 fn rand_span() base.DataSpan {
     const start = rand.random().int(u32);
-    const len = rand.random().int(u30); // Constrain len to fit within u30 (used by ImportRhs.num_exposes)
+    const len = rand.random().int(u30);
     return base.DataSpan{
         .start = start,
         .len = len,

--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -1879,3 +1879,28 @@ test "default app resolves a sibling type module imported with exposing" {
 
     try testing.expectEqualStrings("", result.stdout);
 }
+
+test "directory-qualified local modules resolve from source subdirectories" {
+    const allocator = testing.allocator;
+
+    const app_result = try util.runRoc(
+        std.testing.io,
+        allocator,
+        &.{"--opt=interpreter"},
+        "test/fx/directory_qualified_local_module/main.roc",
+    );
+    defer allocator.free(app_result.stdout);
+    defer allocator.free(app_result.stderr);
+    try util.checkSuccess(app_result);
+    try testing.expectEqualStrings("directory-qualified local module\n", app_result.stdout);
+
+    const package_result = try util.runRoc(
+        std.testing.io,
+        allocator,
+        &.{ "check", "--no-cache" },
+        "test/fx/directory_qualified_local_module/package/main.roc",
+    );
+    defer allocator.free(package_result.stdout);
+    defer allocator.free(package_result.stderr);
+    try util.checkSuccess(package_result);
+}

--- a/src/compile/compile_package.zig
+++ b/src/compile/compile_package.zig
@@ -324,14 +324,14 @@ pub fn canonicalizeAndTypeCheckModule(
 /// returns the type declaration statement index so Can.zig uses qualified lookup.
 /// For regular modules (where members are stored under plain names like "to_str"),
 /// returns null so Can.zig uses bare-name lookup.
-fn computeSiblingStatementIdx(sibling_env: *const ModuleEnv, sibling_name: []const u8) ?can.CIR.Statement.Idx {
+fn computeSiblingStatementIdx(sibling_env: *const ModuleEnv) ?can.CIR.Statement.Idx {
     // Only type modules store associated functions under qualified names.
     // Regular modules (deprecated_module, etc.) store them under plain names.
     switch (sibling_env.module_kind) {
         .type_module => {},
         else => return null,
     }
-    const type_ident_in_module = sibling_env.common.findIdent(sibling_name) orelse return null;
+    const type_ident_in_module = sibling_env.common.findIdent(sibling_env.module_name) orelse return null;
     const type_node_idx = sibling_env.getExposedTypeNodeIndexById(type_ident_in_module) orelse return null;
     return @enumFromInt(type_node_idx);
 }
@@ -391,25 +391,16 @@ pub fn canonicalizeModuleWithSiblings(
         if (std.mem.eql(u8, sibling_name, env.module_name)) continue;
 
         const sibling_ident = try env.insertIdent(base.Ident.for_text(sibling_name));
-        const qualified_ident = try env.insertIdent(base.Ident.for_text(sibling_name));
-
-        // Check if sibling file exists (via Io abstraction)
-        const file_name = try std.fmt.allocPrint(gpa, "{s}.roc", .{sibling_name});
-        defer gpa.free(file_name);
-        const file_path = try std.fs.path.join(gpa, &.{ root_dir, file_name });
-        defer gpa.free(file_path);
-        const exists = roc_ctx.fileExists(file_path);
-        if (!exists) continue;
-
         // Check pre-resolved imports first (e.g., from coordinator's built dependency list)
         const pre_resolved_env = resolved_import_envs.get(sibling_name);
 
         if (pre_resolved_env) |sibling_env| {
-            const statement_idx = computeSiblingStatementIdx(sibling_env, sibling_name);
+            const type_ident = try env.insertIdent(base.Ident.for_text(sibling_env.module_name));
+            const statement_idx = computeSiblingStatementIdx(sibling_env);
             try module_envs_map.put(sibling_ident, .{
                 .env = sibling_env,
                 .statement_idx = statement_idx,
-                .qualified_type_ident = qualified_ident,
+                .qualified_type_ident = type_ident,
                 .import_identity = .{ .module = sibling_ident },
             });
             continue;

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -4425,14 +4425,17 @@ pub const Coordinator = struct {
 
         env.* = try ModuleEnv.init(module_alloc, src);
         env_initialized = true;
-        try env.initCIRFields(task.module_name);
+        const display_module_name = base.module_path.getModuleBasename(task.module_name);
+        try env.initCIRFields(display_module_name);
         env.module_role = task.module_role;
 
         // Set qualified_module_ident to a package-qualified identifier (e.g., "app.main", "pf.Stdout")
         // to ensure module identity is unique across packages. Without this, two modules with
         // the same filename in different packages (e.g., app's main.roc and platform's main.roc)
         // get the same identity, causing nominal type origin_module collisions.
-        // display_module_name_idx stays as the bare name (for type module validation, error messages, etc.)
+        // display_module_name_idx stays as the bare final segment (for type
+        // module validation, error messages, etc.), while the qualified identity
+        // preserves any directory segments in task.module_name.
         {
             const qname = try std.fmt.allocPrint(task_allocs.scratch, "{s}.{s}", .{ task.package_name, task.module_name });
             env.qualified_module_ident = try env.insertIdent(base.Ident.for_text(qname));

--- a/src/compile/module_discovery.zig
+++ b/src/compile/module_discovery.zig
@@ -38,6 +38,7 @@ pub fn extractImportsFromDeclIndex(
 
     // Modules listed in a `package [...]` header are auto-imported.
     for (parse_ast.decl_index.package_header_modules.items) |package_module| {
+        if (parse_ast.decl_index.hasExplicitUnqualifiedImport(package_module.module_name)) continue;
         try appendModuleName(gpa, &result, parse_ast.env.getIdent(package_module.module_name), false);
     }
 
@@ -120,6 +121,11 @@ test "module discovery consumes parser import inventory" {
         \\import Foo
         \\import Builtin
         \\import pf.Stdout
+        \\import Src.Widget as Widget
+        \\import Data.Codec exposing [decode]
+        \\import Nested.Type
+        \\import pf.IO.Stream as Stream
+        \\import Layout .Path as LayoutPath
         \\import lower
         \\
         \\main = {}
@@ -134,16 +140,44 @@ test "module discovery consumes parser import inventory" {
         for (local_imports) |item| gpa.free(item);
         gpa.free(local_imports);
     }
-    try std.testing.expectEqual(@as(usize, 3), local_imports.len);
+    try std.testing.expectEqual(@as(usize, 7), local_imports.len);
     try std.testing.expectEqualStrings("Auto", local_imports[0]);
     try std.testing.expectEqualStrings("Foo", local_imports[1]);
     try std.testing.expectEqualStrings("Builtin", local_imports[2]);
+    try std.testing.expectEqualStrings("Src.Widget", local_imports[3]);
+    try std.testing.expectEqualStrings("Data.Codec", local_imports[4]);
+    try std.testing.expectEqualStrings("Nested", local_imports[5]);
+    try std.testing.expectEqualStrings("Layout.Path", local_imports[6]);
 
     const qualified_imports = try extractQualifiedImportsFromDeclIndex(ast, gpa);
     defer {
         for (qualified_imports) |item| gpa.free(item);
         gpa.free(qualified_imports);
     }
-    try std.testing.expectEqual(@as(usize, 1), qualified_imports.len);
+    try std.testing.expectEqual(@as(usize, 2), qualified_imports.len);
     try std.testing.expectEqualStrings("pf.Stdout", qualified_imports[0]);
+    try std.testing.expectEqualStrings("pf.IO.Stream", qualified_imports[1]);
+}
+
+test "explicit directory import supplies a package-header module alias" {
+    const gpa = std.testing.allocator;
+    var env = try @import("base").CommonEnv.init(gpa,
+        \\package [Widget, Auto] {}
+        \\import Src.Widget as Widget
+        \\
+        \\main = {}
+    );
+    defer env.deinit(gpa);
+
+    const ast = try parse.file(gpa, &env);
+    defer ast.deinit();
+
+    const local_imports = try extractImportsFromDeclIndex(ast, gpa);
+    defer {
+        for (local_imports) |item| gpa.free(item);
+        gpa.free(local_imports);
+    }
+    try std.testing.expectEqual(@as(usize, 2), local_imports.len);
+    try std.testing.expectEqualStrings("Auto", local_imports[0]);
+    try std.testing.expectEqualStrings("Src.Widget", local_imports[1]);
 }

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -514,7 +514,7 @@ const Formatter = struct {
                     fmt.curr_indent += 1;
                     try fmt.pushIndent();
                 }
-                const path_result = try fmt.formatModulePath(i.module_name_tok, i.qualifier_tok, i.exposes);
+                const path_result = try fmt.formatModulePath(i.module_name_tok, i.qualifier_tok);
                 const last_module_tok = path_result.last_tok;
                 if (multiline and (i.alias_tok != null or i.exposes.span.len > 0)) {
                     flushed = try fmt.flushCommentsAfter(last_module_tok);
@@ -554,10 +554,10 @@ const Formatter = struct {
                         flushed = try fmt.flushCommentsAfter(a);
                     }
                 }
-                // Output exposing clause if there are exposed items, OR if there was unusual
-                // spacing (DotUpperIdent) in the module path - in the latter case, we need
-                // to output "exposing []" to prevent auto-expose on re-format.
-                const needs_exposing = i.exposes.span.len > 0 or path_result.has_unusual_spacing;
+                // Nested imports store their final segment in `exposes`, but it is
+                // still part of the dotted source path rather than a source
+                // `exposing` clause.
+                const needs_exposing = !i.nested_import and i.exposes.span.len > 0;
                 if (needs_exposing) {
                     if (flushed) {
                         fmt.curr_indent += 1;
@@ -871,37 +871,18 @@ const Formatter = struct {
         try fmt.pushTokenText(ident);
     }
 
-    /// Formats a module path for an import statement.
-    /// For auto-expose imports (like `import A.B.C` becoming `import A.B exposing [C]`),
-    /// module_name_tok points to the second-to-last token.
-    /// For explicit clause imports (like `import A.B.C as D`), module_name_tok points to
-    /// the first token and we iterate through consecutive uppercase tokens.
+    /// Formats the complete dotted path written in an import statement.
+    ///
+    /// Whether that path selects a directory-qualified module or a nested type
+    /// is explicit on the import node and does not affect path formatting.
     const ModulePathResult = struct {
         last_tok: Token.Idx,
-        has_unusual_spacing: bool, // True if DotUpperIdent (space before dot) was encountered
     };
 
-    fn formatModulePath(fmt: *Formatter, module_name_tok: Token.Idx, qualifier: ?Token.Idx, exposes: AST.ExposedItem.Span) (Allocator.Error || error{WriteFailed})!ModulePathResult {
+    fn formatModulePath(fmt: *Formatter, module_name_tok: Token.Idx, qualifier: ?Token.Idx) (Allocator.Error || error{WriteFailed})!ModulePathResult {
         const curr_indent = fmt.curr_indent;
         defer {
             fmt.curr_indent = curr_indent;
-        }
-
-        var has_unusual_spacing = false;
-
-        // Get the first exposed token if any (for auto-expose detection)
-        var first_exposed_tok: ?Token.Idx = null;
-        if (exposes.span.len > 0) {
-            const exposed_slice = fmt.ast.store.exposedItemSlice(exposes);
-            if (exposed_slice.len > 0) {
-                const first_exposed = fmt.ast.store.getExposedItem(exposed_slice[0]);
-                first_exposed_tok = switch (first_exposed) {
-                    .lower_ident => |i| i.ident,
-                    .upper_ident => |i| i.ident,
-                    .upper_ident_star => |i| i.ident,
-                    .malformed => null,
-                };
-            }
         }
 
         // Output qualifier if present
@@ -914,11 +895,7 @@ const Formatter = struct {
         try fmt.pushTokenText(module_name_tok);
         var last_tok = module_name_tok;
 
-        // Iterate through consecutive uppercase tokens in the module path.
-        // For auto-expose, stop before the exposed token (which is part of the path).
-        // For explicit exposes, the exposed token is in the [] list, not the path, so we iterate fully.
-        // DotUpperIdent (space before dot) is formatted with a newline to preserve the structure
-        // and make malformed code visually obvious.
+        // Normalize every dotted path segment to no whitespace before the dot.
         var tok = module_name_tok + 1;
         const tags = fmt.ast.tokens.tokens.items(.tag);
         while (tok < tags.len) {
@@ -926,25 +903,13 @@ const Formatter = struct {
             if (tag != .NoSpaceDotUpperIdent and tag != .DotUpperIdent) {
                 break;
             }
-            // For auto-expose, stop before the exposed token
-            if (first_exposed_tok) |exp_tok| {
-                if (tok == exp_tok) break;
-            }
-            // DotUpperIdent has space before the dot - format with newline to preserve structure
-            if (tag == .DotUpperIdent) {
-                has_unusual_spacing = true;
-                try fmt.ensureNewline();
-                fmt.curr_indent += 1;
-                try fmt.pushIndent();
-                fmt.curr_indent -= 1;
-            }
             try fmt.push('.');
             try fmt.pushTokenText(tok);
             last_tok = tok;
             tok += 1;
         }
 
-        return .{ .last_tok = last_tok, .has_unusual_spacing = has_unusual_spacing };
+        return .{ .last_tok = last_tok };
     }
 
     const Braces = enum {
@@ -4008,10 +3973,22 @@ test "parenthesized type application with leading newline is idempotent" {
     try std.testing.expectEqualStrings("\ne : [(N()), ()]\n", result);
 }
 
-test "import alias after comment stays separated from synthetic exposing clause" {
+test "import alias after comment stays separated" {
     const result = try moduleFmtsStable(std.testing.allocator, "import A .B as#\nX", false);
     defer std.testing.allocator.free(result);
-    try std.testing.expectEqualStrings("import A\n\t.B as #\nX exposing []\n", result);
+    try std.testing.expectEqualStrings("import A.B as #\nX\n", result);
+}
+
+test "import path spacing is normalized" {
+    const result = try moduleFmtsStable(std.testing.allocator, "import Layout .Path as LayoutPath", false);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("import Layout.Path as LayoutPath\n", result);
+}
+
+test "nested import path remains nested after formatting" {
+    const result = try moduleFmtsStable(std.testing.allocator, "import Root .Nested .Leaf", false);
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("import Root.Nested.Leaf\n", result);
 }
 
 test "issue 8894: typed integer literal formats correctly" {

--- a/src/parse/AST.zig
+++ b/src/parse/AST.zig
@@ -783,33 +783,13 @@ pub fn resolveQualifiedName(
     }
 }
 
-/// Resolves the full module path for an import statement.
-/// For auto-expose imports, module_name_tok points to the second-to-last token.
-/// For explicit clause imports, module_name_tok points to the first token and
-/// we iterate through consecutive uppercase tokens.
-pub fn resolveImportModulePath(self: *const AST, module_name_tok: Token.Idx, qualifier_tok: ?Token.Idx, exposes: ExposedItem.Span) []const u8 {
+/// Resolves the module path selected by the parser for an import statement.
+///
+/// A nested import such as `import Url.ParseErr` resolves to module `Url`.
+/// An import with an explicit clause, such as
+/// `import Src.Widget exposing [message]`, resolves to module `Src.Widget`.
+pub fn resolveImportModulePath(self: *const AST, module_name_tok: Token.Idx, qualifier_tok: ?Token.Idx, nested_import: bool) []const u8 {
     const tags = self.tokens.tokens.items(.tag);
-
-    // Check if this is auto-expose by seeing if the first exposed item's token
-    // immediately follows module_name_tok
-    var is_auto_expose = false;
-    if (exposes.span.len > 0) {
-        const exposed_slice = self.store.exposedItemSlice(exposes);
-        if (exposed_slice.len > 0) {
-            const first_exposed = self.store.getExposedItem(exposed_slice[0]);
-            const first_exposed_tok: ?Token.Idx = switch (first_exposed) {
-                .lower_ident => |i| i.ident,
-                .upper_ident => |i| i.ident,
-                .upper_ident_star => |i| i.ident,
-                .malformed => null,
-            };
-            if (first_exposed_tok) |tok| {
-                if (tok == module_name_tok + 1) {
-                    is_auto_expose = true;
-                }
-            }
-        }
-    }
 
     // Get start position (qualifier or first module segment)
     const start_offset: usize = if (qualifier_tok) |q|
@@ -819,8 +799,7 @@ pub fn resolveImportModulePath(self: *const AST, module_name_tok: Token.Idx, qua
 
     // Find the end token
     var end_tok = module_name_tok;
-    if (!is_auto_expose) {
-        // For explicit clauses, iterate through consecutive uppercase tokens
+    if (!nested_import) {
         var tok = module_name_tok + 1;
         while (tok < tags.len) {
             const tag = tags[tok];
@@ -845,8 +824,9 @@ pub const ImportRhs = packed struct {
     aliased: u1,
     /// 1 in case the import is qualified, e.g. `pf` in `import pf.Stdout ...`
     qualified: u1,
-    /// The number of things in the exposes list. e.g. 3 in `import SomeModule exposing [a1, a2, a3]`
-    num_exposes: u30,
+    /// 1 when the final uppercase segment is an auto-exposed nested type.
+    nested: u1,
+    reserved: u29 = 0,
 };
 
 // Check that all packed structs are 4 bytes size as they as cast to
@@ -1017,7 +997,7 @@ pub const Statement = union(enum) {
                 try ast.appendRegionInfoToSexprTree(env, tree, import.region);
 
                 // Reconstruct full qualified module name using the new helper
-                const full_module_name = ast.resolveImportModulePath(import.module_name_tok, import.qualifier_tok, import.exposes);
+                const full_module_name = ast.resolveImportModulePath(import.module_name_tok, import.qualifier_tok, import.nested_import);
                 try tree.pushStringPair("raw", full_module_name);
 
                 // alias e.g. `OUT` in `import pf.Stdout as OUT`

--- a/src/parse/DeclIndex.zig
+++ b/src/parse/DeclIndex.zig
@@ -162,6 +162,8 @@ pub const PackageHeaderModule = struct {
 
 /// Explicit source import recorded by the parser.
 pub const Import = struct {
+    /// Complete uppercase module path, excluding any lowercase package qualifier.
+    /// Nested imports contain only the root module selected by the parser.
     module_name: Ident.Idx,
     qualifier: ?Ident.Idx,
     nested: bool,

--- a/src/parse/Node.zig
+++ b/src/parse/Node.zig
@@ -109,10 +109,9 @@ pub const Tag = enum {
     /// An import statement
     /// Example: `import pf.Stdout`
     /// * main_token - first token in module ident
-    /// * lhs - extra_data description - struct(packed){ aliased: u1, num_exposes: u31 }
-    /// * rhs - extra_data index or 0 if lhs is 0
-    /// * extra_data format(if aliased == 1): [alias upper_ident node index, [exposed node index]{num_exposes}]
-    /// * extra_data format(if aliased == 0): [[exposed node index]{num_exposes}]
+    /// * lhs - extra_data index
+    /// * rhs - packed alias, qualifier, and nested-import flags
+    /// * extra_data - [exposes start, exposes len, qualifier token?, alias token?]
     import,
     /// A file import statement
     /// Example: `import "README.md" as readme : Str`

--- a/src/parse/NodeStore.zig
+++ b/src/parse/NodeStore.zig
@@ -625,7 +625,8 @@ pub fn addStatement(store: *NodeStore, statement: AST.Statement) std.mem.Allocat
             var rhs = AST.ImportRhs{
                 .aliased = 0,
                 .qualified = 0,
-                .num_exposes = @as(u30, @intCast(i.exposes.span.len)),
+                .nested = @intFromBool(i.nested_import),
+                .reserved = 0,
             };
 
             // Store all import data in a flat format:
@@ -1640,7 +1641,7 @@ pub fn getStatement(store: *const NodeStore, statement_idx: AST.Statement.Idx) A
                     .start = exposes_start,
                     .len = exposes_len,
                 } },
-                .nested_import = false,
+                .nested_import = rhs.nested == 1,
                 .region = node.region,
             } };
         },

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -431,14 +431,13 @@ fn recordStatementDecl(
             .region = .{ .start = v.region.start, .end = v.region.end },
         },
         .import => |i| blk: {
-            if (self.tok_buf.resolveIdentifier(i.module_name_tok)) |module_name| {
-                try self.decl_index.addImport(.{
-                    .module_name = module_name,
-                    .qualifier = if (i.qualifier_tok) |qualifier_tok| self.tok_buf.resolveIdentifier(qualifier_tok) else null,
-                    .nested = i.nested_import,
-                    .region = .{ .start = i.region.start, .end = i.region.end },
-                });
-            }
+            const module_name = try self.importModulePathIdent(i.module_name_tok, i.nested_import);
+            try self.decl_index.addImport(.{
+                .module_name = module_name,
+                .qualifier = if (i.qualifier_tok) |qualifier_tok| self.tok_buf.resolveIdentifier(qualifier_tok) else null,
+                .nested = i.nested_import,
+                .region = .{ .start = i.region.start, .end = i.region.end },
+            });
             break :blk DeclIndex.Decl{
                 .scope = scope_idx,
                 .statement = @intFromEnum(statement_idx),
@@ -629,6 +628,35 @@ fn addTypeDeclStatement(
 fn tokenText(self: *const Parser, token: Token.Idx) []const u8 {
     const region = self.tok_buf.resolve(token);
     return self.tok_buf.env.source[region.start.offset..region.end.offset];
+}
+
+/// Intern the normalized module path selected by import parsing, excluding a
+/// lowercase package qualifier. Building from tokens keeps layout whitespace
+/// out of the semantic path.
+fn importModulePathIdent(self: *Parser, module_name_tok: Token.Idx, nested_import: bool) std.mem.Allocator.Error!base.Ident.Idx {
+    var path = std.ArrayList(u8).empty;
+    defer path.deinit(self.gpa);
+
+    const first_raw = self.tokenText(module_name_tok);
+    const first = if (first_raw.len > 0 and first_raw[0] == '.') first_raw[1..] else first_raw;
+    try path.appendSlice(self.gpa, first);
+
+    if (!nested_import) {
+        var tok = module_name_tok + 1;
+        while (tok < self.tok_buf.tokens.len) : (tok += 1) {
+            switch (self.tok_buf.tokens.items(.tag)[tok]) {
+                .NoSpaceDotUpperIdent, .DotUpperIdent => {
+                    const raw = self.tokenText(tok);
+                    const segment = if (raw.len > 0 and raw[0] == '.') raw[1..] else raw;
+                    try path.append(self.gpa, '.');
+                    try path.appendSlice(self.gpa, segment);
+                },
+                else => break,
+            }
+        }
+    }
+
+    return try self.tok_buf.env.insertIdent(self.gpa, base.Ident.for_text(path.items));
 }
 
 fn recordPackageHeaderModules(self: *Parser, exposes: AST.ExposedItem.Span) std.mem.Allocator.Error!void {
@@ -1046,9 +1074,11 @@ fn parseImportStatementTokens(self: *Parser) std.mem.Allocator.Error!AST.Stateme
     } });
     self.store.setCollectionLayout(statement_idx, exposes_layout);
     if (qualifier == null and !nested_import) {
-        if (self.tok_buf.resolveIdentifier(module_name_tok)) |module_ident| {
-            try self.decl_index.addExplicitUnqualifiedImport(module_ident);
-        }
+        const introduced_name_tok = alias_tok orelse last_upper_tok;
+        const raw_name = self.tokenText(introduced_name_tok);
+        const introduced_name = if (raw_name.len > 0 and raw_name[0] == '.') raw_name[1..] else raw_name;
+        const introduced_ident = try self.tok_buf.env.insertIdent(self.gpa, base.Ident.for_text(introduced_name));
+        try self.decl_index.addExplicitUnqualifiedImport(introduced_ident);
     }
     return statement_idx;
 }

--- a/src/parse/test/ast_node_store_test.zig
+++ b/src/parse/test/ast_node_store_test.zig
@@ -45,7 +45,7 @@ fn rand_region(random: std.Random) AST.TokenizedRegion {
 /// Helper to create a `DataSpan` from raw start and length positions.
 fn rand_span(random: std.Random) base.DataSpan {
     const start = random.int(u32);
-    const len = random.int(u30); // Constrain len to fit within u30 (used by ImportRhs.num_exposes)
+    const len = random.int(u32);
     return base.DataSpan{
         .start = start,
         .len = len,
@@ -240,7 +240,7 @@ test "NodeStore round trip - Statement" {
             .qualifier_tok = rand_token_idx(random),
             .region = rand_region(random),
             .exposes = AST.ExposedItem.Span{ .span = rand_span(random) },
-            .nested_import = false,
+            .nested_import = true,
         },
     });
     // Import with both qualifier and alias

--- a/src/playground_wasm/main.zig
+++ b/src/playground_wasm/main.zig
@@ -879,7 +879,7 @@ fn replDefinitionIdentity(line: []const u8) std.mem.Allocator.Error!?ReplDefinit
         },
         .import => |import| .{
             .kind = .import,
-            .name = ast.resolveImportModulePath(import.module_name_tok, import.qualifier_tok, import.exposes),
+            .name = ast.resolveImportModulePath(import.module_name_tok, import.qualifier_tok, import.nested_import),
         },
         .file_import => |file_import| .{ .kind = .file_import, .name = ast.resolve(file_import.name_tok) },
         else => null,

--- a/src/snapshot_tool/main.zig
+++ b/src/snapshot_tool/main.zig
@@ -4469,7 +4469,7 @@ fn snapshotReplDefinitionIdentity(allocator: Allocator, line: []const u8) Alloca
         },
         .import => |import| .{
             .kind = .import,
-            .name = ast.resolveImportModulePath(import.module_name_tok, import.qualifier_tok, import.exposes),
+            .name = ast.resolveImportModulePath(import.module_name_tok, import.qualifier_tok, import.nested_import),
         },
         .file_import => |file_import| .{ .kind = .file_import, .name = ast.resolve(file_import.name_tok) },
         else => null,

--- a/test/fx/directory_qualified_local_module/Src/Widget.roc
+++ b/test/fx/directory_qualified_local_module/Src/Widget.roc
@@ -1,0 +1,3 @@
+Widget := [].{
+    message = |_| "directory-qualified local module"
+}

--- a/test/fx/directory_qualified_local_module/main.roc
+++ b/test/fx/directory_qualified_local_module/main.roc
@@ -1,0 +1,6 @@
+app [main!] { pf: platform "../platform/main.roc" }
+
+import pf.Stdout
+import Src.Widget as Widget
+
+main! = || Stdout.line!(Widget.message({}))

--- a/test/fx/directory_qualified_local_module/package/Src/Widget.roc
+++ b/test/fx/directory_qualified_local_module/package/Src/Widget.roc
@@ -1,0 +1,3 @@
+Widget := [].{
+    message = |_| "directory-qualified package module"
+}

--- a/test/fx/directory_qualified_local_module/package/main.roc
+++ b/test/fx/directory_qualified_local_module/package/main.roc
@@ -1,0 +1,3 @@
+package [Widget] {}
+
+import Src.Widget as Widget

--- a/test/snapshots/can_import_nested_modules.md
+++ b/test/snapshots/can_import_nested_modules.md
@@ -31,12 +31,12 @@ validateAuth : HttpAuth.Credentials -> Try(HttpAuth.Token, HttpAuth.Error)
 validateAuth = |creds| HttpAuth.validate(creds)
 ~~~
 # EXPECTED
-MOD NOT IMPORTED - can_import_nested_mods.md:6:15:6:30
+MISSING NESTED TYPE - can_import_nested_mods.md:6:15:6:30
 DOES NOT EXIST - can_import_nested_mods.md:7:26:7:41
 MOD NOT FOUND - can_import_nested_mods.md:10:36:10:42
 NAME NOT IN SCOPE - can_import_nested_mods.md:11:29:11:43
-MOD NOT IMPORTED - can_import_nested_mods.md:14:15:14:37
-MOD NOT IMPORTED - can_import_nested_mods.md:14:55:14:74
+MISSING NESTED TYPE - can_import_nested_mods.md:14:15:14:37
+MISSING NESTED TYPE - can_import_nested_mods.md:14:55:14:74
 DOES NOT EXIST - can_import_nested_mods.md:16:5:16:37
 NAME NOT IN SCOPE - can_import_nested_mods.md:20:23:20:30
 DOES NOT EXIST - can_import_nested_mods.md:20:37:20:58
@@ -47,8 +47,8 @@ NAME NOT IN SCOPE - can_import_nested_mods.md:24:24:24:41
 # PROBLEMS
 
 ┌─────────────────────┐
-│ MOD NOT IMPORTED ├─ There is no mod with the name `Config` imported ──┐
-└┬────────────────────┘  into this Roc file.                                  │
+│ MISSING NESTED TYPE ├─ `Config` is in scope, but it doesn't have a nested ──┐
+└┬────────────────────┘  type named `Settings`.                               │
  │                                                                            │
  │  parseConfig : Config.Settings -> Str                                      │
  │                ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                             │
@@ -64,11 +64,12 @@ NAME NOT IN SCOPE - can_import_nested_mods.md:24:24:24:41
  │                           ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                  │
  └───────────────────────────────────────── can_import_nested_mods.md:7:26 ┘
 
+    `Config` is in scope, but it has no associated `toString`.
 
 
 ┌──────────────────┐
-│ MOD NOT FOUND ├─ This `Token` type is declared to be in `http.Client`, ──┐
-└┬─────────────────┘  which does not exist.                                   │
+│ MOD NOT FOUND ├─ This `Token` type is declared to be in ─────────────────┐
+└┬─────────────────┘  `http.Client.Auth`, which does not exist.               │
  │                                                                            │
  │  authenticate : Str, Str -> HttpAuth.Token                                 │
  │                                     ‾‾‾‾‾‾                                 │
@@ -88,8 +89,8 @@ NAME NOT IN SCOPE - can_import_nested_mods.md:24:24:24:41
 
 
 ┌─────────────────────┐
-│ MOD NOT IMPORTED ├─ There is no mod with the name `Config.Parser` ────┐
-└┬────────────────────┘  imported into this Roc file.                         │
+│ MISSING NESTED TYPE ├─ `Config` is in scope, but it doesn't have a nested ──┐
+└┬────────────────────┘  type named `Advanced`.                               │
  │                                                                            │
  │  processData : Config.Parser.Advanced, Str -> Try(Str, Config.Parser.Error)│
  │                ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                      │
@@ -98,8 +99,8 @@ NAME NOT IN SCOPE - can_import_nested_mods.md:24:24:24:41
 
 
 ┌─────────────────────┐
-│ MOD NOT IMPORTED ├─ There is no mod with the name `Config.Parser` ────┐
-└┬────────────────────┘  imported into this Roc file.                         │
+│ MISSING NESTED TYPE ├─ `Config` is in scope, but it doesn't have a nested ──┐
+└┬────────────────────┘  type named `Error`.                                  │
  │                                                                            │
  │  processData : Config.Parser.Advanced, Str -> Try(Str, Config.Parser.Error)│
  │                                                        ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾ │
@@ -115,6 +116,7 @@ NAME NOT IN SCOPE - can_import_nested_mods.md:24:24:24:41
  │  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                          │
  └───────────────────────────────────────── can_import_nested_mods.md:16:5 ┘
 
+    `Config.Parser.Advanced` is in scope, but it has no associated `parseWith`.
 
 
 ┌───────────────────┐
@@ -136,11 +138,12 @@ NAME NOT IN SCOPE - can_import_nested_mods.md:24:24:24:41
  │                                      ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                 │
  └──────────────────────────────────────── can_import_nested_mods.md:20:37 ┘
 
+    `Config` is in scope, but it has no associated `defaultPadding`.
 
 
 ┌──────────────────┐
 │ MOD NOT FOUND ├─ This `Credentials` type is declared to be in ───────────┐
-└┬─────────────────┘  `http.Client`, which does not exist.                    │
+└┬─────────────────┘  `http.Client.Auth`, which does not exist.               │
  │                                                                            │
  │  validateAuth : HttpAuth.Credentials -> Try(HttpAuth.Token, HttpAuth.Error)│
  │                         ‾‾‾‾‾‾‾‾‾‾‾‾                                       │
@@ -149,8 +152,8 @@ NAME NOT IN SCOPE - can_import_nested_mods.md:24:24:24:41
 
 
 ┌──────────────────┐
-│ MOD NOT FOUND ├─ This `Token` type is declared to be in `http.Client`, ──┐
-└┬─────────────────┘  which does not exist.                                   │
+│ MOD NOT FOUND ├─ This `Token` type is declared to be in ─────────────────┐
+└┬─────────────────┘  `http.Client.Auth`, which does not exist.               │
  │                                                                            │
  │  validateAuth : HttpAuth.Credentials -> Try(HttpAuth.Token, HttpAuth.Error)│
  │                                                     ‾‾‾‾‾‾                 │
@@ -159,8 +162,8 @@ NAME NOT IN SCOPE - can_import_nested_mods.md:24:24:24:41
 
 
 ┌──────────────────┐
-│ MOD NOT FOUND ├─ This `Error` type is declared to be in `http.Client`, ──┐
-└┬─────────────────┘  which does not exist.                                   │
+│ MOD NOT FOUND ├─ This `Error` type is declared to be in ─────────────────┐
+└┬─────────────────┘  `http.Client.Auth`, which does not exist.               │
  │                                                                            │
  │  validateAuth : HttpAuth.Credentials -> Try(HttpAuth.Token, HttpAuth.Error)│
  │                                                                     ‾‾‾‾‾‾ │
@@ -374,9 +377,9 @@ validateAuth = |creds| HttpAuth.validate(creds)
 	(s-import (mod "json.Parser")
 		(exposes
 			(exposed (name "Config") (wildcard false))))
-	(s-import (mod "http.Client")
+	(s-import (mod "http.Client.Auth")
 		(exposes))
-	(s-import (mod "utils.String")
+	(s-import (mod "utils.String.Format")
 		(exposes
 			(exposed (name "padLeft") (wildcard false)))))
 ~~~

--- a/test/snapshots/can_import_nested_modules.md
+++ b/test/snapshots/can_import_nested_modules.md
@@ -288,7 +288,7 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-import json.Parser exposing [Config]
+import json.Parser.Config
 import http.Client.Auth as HttpAuth
 import utils.String.Format exposing [padLeft]
 

--- a/test/snapshots/fmt_empty_auto_expose_multiline_issue_9373.md
+++ b/test/snapshots/fmt_empty_auto_expose_multiline_issue_9373.md
@@ -37,15 +37,9 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-import A
-	.B as X1 exposing []
-import A
-	.B
-	.C as X2 exposing []
-import A
-	.B
-	.C
-	.D as X3 exposing []
+import A.B as X1
+import A.B.C as X2
+import A.B.C.D as X3
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/fmt_empty_auto_expose_multiline_issue_9373.md
+++ b/test/snapshots/fmt_empty_auto_expose_multiline_issue_9373.md
@@ -50,11 +50,11 @@ import A
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(s-import (mod "A")
+	(s-import (mod "A.B")
 		(exposes))
-	(s-import (mod "A")
+	(s-import (mod "A.B.C")
 		(exposes))
-	(s-import (mod "A")
+	(s-import (mod "A.B.C.D")
 		(exposes)))
 ~~~
 # TYPES

--- a/test/snapshots/fuzz_crash/fuzz_crash_023.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_023.md
@@ -218,7 +218,6 @@ EXPECTED RECORD ACCESSOR - fuzz_crash_023.md:154:2:154:5
 EXPECTED RECORD FIELD - fuzz_crash_023.md:178:37:178:38
 UNEXPECTED EXPRESSION SYNTAX - fuzz_crash_023.md:178:45:178:46
 EXPECTED FUNCTION ARROW - fuzz_crash_023.md:178:52:178:54
-NOT IMPLEMENTED - fuzz_crash_023.md:6:1:12:4
 MOD NOT FOUND - fuzz_crash_023.md:16:1:16:27
 MOD NOT FOUND - fuzz_crash_023.md:17:1:20:20
 UNDECLARED TYPE - fuzz_crash_023.md:36:8:36:11
@@ -356,24 +355,6 @@ MISSING METHOD - fuzz_crash_023.md:189:26:189:66
     I found `Ok` here.
     Names that start with uppercase letters are used for tags, type names, and
     mod names in Roc.
-
-
-┌─────────────────┐
-│ NOT IMPLEMENTED ├─ This feature is not yet implemented: malformed import ───┐
-└┬────────────────┘  mod name contains invalid control characters.         │
- │                                                                            │
- │  import # Comment after import keyword                                     │
- │      pf # Comment after qualifier                                          │
- │          .StdoutMultiline # Comment after ident                            │
- │          exposing [ # Comment after exposing open                          │
- │              line!, # Comment after exposed item                           │
- │              write!, # Another after exposed item                          │
- │          ] # Comment after exposing close                                  │
- │                                                                            │
- └───────────────────────────────────────────────────── fuzz_crash_023.md:6:1 ┘
-
-    This error doesn't have a proper diagnostic report yet. Let us know if you
-    want to help improve Roc's error messages!
 
 
 ┌──────────────────┐
@@ -2196,7 +2177,7 @@ expect {
 							(p-assign (ident "#interp_0"))
 							(e-lookup-local
 								(p-assign (ident "world"))))
-						(e-interpolation (constraint-fn-var 1860) (dispatcher-var 374)
+						(e-interpolation (constraint-fn-var 1859) (dispatcher-var 373)
 							(first
 								(e-literal (string "Hello, ")))
 							(parts
@@ -2214,7 +2195,7 @@ expect {
 							(e-runtime-error (tag "erroneous_value_expr")))
 						(s-reassign
 							(p-assign (ident "number"))
-							(e-dispatch-call (method "plus") (constraint-fn-var 1942)
+							(e-dispatch-call (method "plus") (constraint-fn-var 1941)
 								(receiver
 									(e-runtime-error (tag "erroneous_value_use")))
 								(args
@@ -2239,7 +2220,7 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 2066)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 2065)
 									(receiver
 										(e-match
 											(match
@@ -2262,7 +2243,7 @@ expect {
 														(value
 															(e-num (value "12"))))))))
 									(args
-										(e-dispatch-call (method "times") (constraint-fn-var 2063)
+										(e-dispatch-call (method "times") (constraint-fn-var 2062)
 											(receiver
 												(e-num (value "5")))
 											(args
@@ -2277,18 +2258,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 2099)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 2098)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 2089)
+															(e-dispatch-call (method "plus") (constraint-fn-var 2088)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 2126)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 2125)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 2116)
+															(e-dispatch-call (method "minus") (constraint-fn-var 2115)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2303,11 +2284,11 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 2163)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 2162)
 										(receiver
 											(e-num (value "12")))
 										(args
-											(e-dispatch-call (method "div_by") (constraint-fn-var 2160)
+											(e-dispatch-call (method "div_by") (constraint-fn-var 2159)
 												(receiver
 													(e-num (value "3")))
 												(args
@@ -2322,12 +2303,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 2221)
+													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 2220)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 2192)
+																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 2191)
 																			(receiver
 																				(e-match
 																					(match
@@ -2470,7 +2451,7 @@ expect {
 		(exposes
 			(exposed (name "line!") (wildcard false))
 			(exposed (name "write!") (wildcard false))))
-	(s-import (mod "#malformed_import_0")
+	(s-import (mod "pf.StdoutMultiline")
 		(exposes
 			(exposed (name "line!") (wildcard false))
 			(exposed (name "write!") (wildcard false))))

--- a/test/snapshots/issue/issue_9056.md
+++ b/test/snapshots/issue/issue_9056.md
@@ -32,7 +32,7 @@ NO CHANGE
 # CANONICALIZE
 ~~~clojure
 (can-ir
-	(s-import (mod "a.B")
+	(s-import (mod "a.B.C")
 		(exposes
 			(exposed (name "E") (wildcard false)))))
 ~~~

--- a/test/snapshots/multi_qualified_import.md
+++ b/test/snapshots/multi_qualified_import.md
@@ -219,7 +219,7 @@ data = .encode("hello")
 		(e-runtime-error (tag "expr_not_canonicalized"))
 		(annotation
 			(ty-malformed)))
-	(s-import (mod "json.Core")
+	(s-import (mod "json.Core.Utf8")
 		(exposes
 			(exposed (name "Encoder") (wildcard false)))))
 ~~~

--- a/test/snapshots/nominal/nominal_import_long_package.md
+++ b/test/snapshots/nominal/nominal_import_long_package.md
@@ -56,7 +56,7 @@ NO CHANGE
 		(e-not-implemented)
 		(annotation
 			(ty-malformed)))
-	(s-import (mod "design.Styles")
+	(s-import (mod "design.Styles.Color")
 		(exposes
 			(exposed (name "Encoder") (alias "CE") (wildcard false)))))
 ~~~

--- a/test/snapshots/qualified_type_canonicalization.md
+++ b/test/snapshots/qualified_type_canonicalization.md
@@ -437,7 +437,7 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-import Basics exposing [Try]
+import Basics.Try
 import Color
 import ModA.ModB exposing [TypeC]
 import ExternalMod as ExtMod

--- a/test/snapshots/qualified_type_canonicalization.md
+++ b/test/snapshots/qualified_type_canonicalization.md
@@ -53,7 +53,7 @@ MOD NOT FOUND - qualified_type_canonicalization.md:7:24:7:28
 MOD NOT FOUND - qualified_type_canonicalization.md:8:19:8:24
 MOD NOT FOUND - qualified_type_canonicalization.md:11:26:11:35
 MOD NOT FOUND - qualified_type_canonicalization.md:12:26:12:35
-MOD NOT FOUND - qualified_type_canonicalization.md:15:32:15:38
+MOD NOT IMPORTED - qualified_type_canonicalization.md:15:23:15:38
 DOES NOT EXIST - qualified_type_canonicalization.md:16:23:16:32
 MISSING NESTED TYPE - qualified_type_canonicalization.md:19:14:19:21
 MOD NOT FOUND - qualified_type_canonicalization.md:23:23:23:27
@@ -63,7 +63,7 @@ UNUSED VARIABLE - qualified_type_canonicalization.md:28:17:28:22
 MISSING NESTED TYPE - qualified_type_canonicalization.md:32:13:32:20
 MOD NOT FOUND - qualified_type_canonicalization.md:32:26:32:30
 MOD NOT FOUND - qualified_type_canonicalization.md:32:38:32:44
-MOD NOT FOUND - qualified_type_canonicalization.md:32:58:32:64
+MOD NOT IMPORTED - qualified_type_canonicalization.md:32:49:32:64
 DOES NOT EXIST - qualified_type_canonicalization.md:35:24:35:39
 DOES NOT EXIST - qualified_type_canonicalization.md:36:25:36:38
 UNUSED VARIABLE - qualified_type_canonicalization.md:36:17:36:20
@@ -105,8 +105,8 @@ UNUSED VARIABLE - qualified_type_canonicalization.md:36:17:36:20
 
 
 ┌──────────────────┐
-│ MOD NOT FOUND ├─ The mod `ModA` was not found in this Roc project. ───┐
-└┬─────────────────┘                                                          │
+│ MOD NOT FOUND ├─ The mod `ModA.ModB` was not found in this Roc ───────┐
+└┬─────────────────┘  project.                                                │
  │                                                                            │
  │  import ModA.ModB exposing [TypeC]                                         │
  │  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                         │
@@ -164,13 +164,13 @@ UNUSED VARIABLE - qualified_type_canonicalization.md:36:17:36:20
 
 
 
-┌──────────────────┐
-│ MOD NOT FOUND ├─ This `ModB.TypeC` type is declared to be in `ModA`, ────┐
-└┬─────────────────┘  which does not exist.                                   │
+┌─────────────────────┐
+│ MOD NOT IMPORTED ├─ There is no mod with the name `ModA.ModB` ────────┐
+└┬────────────────────┘  imported into this Roc file.                         │
  │                                                                            │
  │  multiLevelQualified : ModA.ModB.TypeC                                     │
- │                                 ‾‾‾‾‾‾                                     │
- └────────────────────────────────── qualified_type_canonicalization.md:15:32 ┘
+ │                        ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                     │
+ └────────────────────────────────── qualified_type_canonicalization.md:15:23 ┘
 
 
 
@@ -266,13 +266,13 @@ UNUSED VARIABLE - qualified_type_canonicalization.md:36:17:36:20
 
 
 
-┌──────────────────┐
-│ MOD NOT FOUND ├─ This `ModB.TypeC` type is declared to be in `ModA`, ────┐
-└┬─────────────────┘  which does not exist.                                   │
+┌─────────────────────┐
+│ MOD NOT IMPORTED ├─ There is no mod with the name `ModA.ModB` ────────┐
+└┬────────────────────┘  imported into this Roc file.                         │
  │                                                                            │
  │  transform : Try.Try(Color.RGB, ExtMod.Error) -> ModA.ModB.TypeC           │
- │                                                           ‾‾‾‾‾‾           │
- └────────────────────────────────── qualified_type_canonicalization.md:32:58 ┘
+ │                                                  ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾           │
+ └────────────────────────────────── qualified_type_canonicalization.md:32:49 ┘
 
 
 
@@ -538,7 +538,7 @@ transform = |result|
 			(exposed (name "Try") (wildcard false))))
 	(s-import (mod "Color")
 		(exposes))
-	(s-import (mod "ModA")
+	(s-import (mod "ModA.ModB")
 		(exposes
 			(exposed (name "TypeC") (wildcard false))))
 	(s-import (mod "ExternalMod")

--- a/test/snapshots/syntax_grab_bag.md
+++ b/test/snapshots/syntax_grab_bag.md
@@ -215,7 +215,6 @@ expect {
 ~~~
 # EXPECTED
 EXPECTED RECORD ACCESSOR - syntax_grab_bag.md:154:2:154:5
-NOT IMPLEMENTED - syntax_grab_bag.md:6:1:12:4
 MOD NOT FOUND - syntax_grab_bag.md:16:1:16:27
 MOD NOT FOUND - syntax_grab_bag.md:17:1:20:20
 UNDECLARED TYPE - syntax_grab_bag.md:36:8:36:11
@@ -293,24 +292,6 @@ MISSING METHOD - syntax_grab_bag.md:189:26:189:66
         pair.0
 
     I found `...` here.
-
-
-┌─────────────────┐
-│ NOT IMPLEMENTED ├─ This feature is not yet implemented: malformed import ───┐
-└┬────────────────┘  mod name contains invalid control characters.         │
- │                                                                            │
- │  import # Comment after import keyword                                     │
- │      pf # Comment after qualifier                                          │
- │          .StdoutMultiline # Comment after ident                            │
- │          exposing [ # Comment after exposing open                          │
- │              line!, # Comment after exposed item                           │
- │              write!, # Another after exposed item                          │
- │          ] # Comment after exposing close                                  │
- │                                                                            │
- └──────────────────────────────────────────────────── syntax_grab_bag.md:6:1 ┘
-
-    This error doesn't have a proper diagnostic report yet. Let us know if you
-    want to help improve Roc's error messages!
 
 
 ┌──────────────────┐
@@ -2079,7 +2060,7 @@ expect {
 							(p-assign (ident "#interp_0"))
 							(e-lookup-local
 								(p-assign (ident "world"))))
-						(e-interpolation (constraint-fn-var 1858) (dispatcher-var 374)
+						(e-interpolation (constraint-fn-var 1857) (dispatcher-var 373)
 							(first
 								(e-literal (string "Hello, ")))
 							(parts
@@ -2097,7 +2078,7 @@ expect {
 							(e-runtime-error (tag "erroneous_value_expr")))
 						(s-reassign
 							(p-assign (ident "number"))
-							(e-dispatch-call (method "plus") (constraint-fn-var 1940)
+							(e-dispatch-call (method "plus") (constraint-fn-var 1939)
 								(receiver
 									(e-runtime-error (tag "erroneous_value_use")))
 								(args
@@ -2117,7 +2098,7 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 2076)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 2075)
 									(receiver
 										(e-match
 											(match
@@ -2140,7 +2121,7 @@ expect {
 														(value
 															(e-num (value "12"))))))))
 									(args
-										(e-dispatch-call (method "times") (constraint-fn-var 2073)
+										(e-dispatch-call (method "times") (constraint-fn-var 2072)
 											(receiver
 												(e-num (value "5")))
 											(args
@@ -2155,18 +2136,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 2109)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 2108)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 2099)
+															(e-dispatch-call (method "plus") (constraint-fn-var 2098)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 2136)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 2135)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 2126)
+															(e-dispatch-call (method "minus") (constraint-fn-var 2125)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2181,11 +2162,11 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 2173)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 2172)
 										(receiver
 											(e-num (value "12")))
 										(args
-											(e-dispatch-call (method "div_by") (constraint-fn-var 2170)
+											(e-dispatch-call (method "div_by") (constraint-fn-var 2169)
 												(receiver
 													(e-num (value "3")))
 												(args
@@ -2200,12 +2181,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 2231)
+													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 2230)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 2202)
+																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 2201)
 																			(receiver
 																				(e-match
 																					(match
@@ -2348,7 +2329,7 @@ expect {
 		(exposes
 			(exposed (name "line!") (wildcard false))
 			(exposed (name "write!") (wildcard false))))
-	(s-import (mod "#malformed_import_0")
+	(s-import (mod "pf.StdoutMultiline")
 		(exposes
 			(exposed (name "line!") (wildcard false))
 			(exposed (name "write!") (wildcard false))))


### PR DESCRIPTION
## Summary

- preserve the parser's explicit nested-import decision through the AST node
  store and declaration index
- retain normalized dotted module paths through discovery and canonicalization
- keep dotted dependency identity separate from a type module's final-segment
  display name
- allow an explicit directory import alias to satisfy a package-header
  exposure
- document and test the syntax distinction:
  - `import Url.ParseErr` imports nested type `ParseErr` from `Url.roc`
  - `import Src.Widget as Widget` loads `Src/Widget.roc`

This fixes the information loss between parsing and module discovery rather
than probing the filesystem or guessing whether a dotted name is local.

## Verification

- `zig build run-test-zig-module-base run-test-zig-module-parse run-test-zig-module-compile run-test-zig-module-can`
- `zig build run-test-zig-fx-platform -- --test-filter "directory-qualified local modules"`
- `zig build run-check-snapshots --summary all --color off`
- `zig build minici` — 73/73 phases passed

Fixes #10448.
