### PR TITLE
Add Windows target to issue 10403 CLI fixture

### DIFF
--- a/test/postcheck/issue_10403_unannotated_record_closure/platform/main.roc
+++ b/test/postcheck/issue_10403_unannotated_record_closure/platform/main.roc
@@ -13,6 +13,7 @@ platform ""
         inputs_dir: "targets/",
         x64glibc: { inputs: [app], output: Archive },
         arm64mac: { inputs: [app], output: Archive },
+        x64win: { inputs: [app], output: Archive },
     }
 
 run_for_host : Str -> Str


### PR DESCRIPTION
Without an explicit --target, roc build selects a platform target matching the native host. The issue 10403 fixture declared Linux and macOS targets but not x64win, so Windows MiniCI failed before exercising the regression. This adds the matching x64win archive target.