### PR TITLE
Fix open specialization row solving

### DIFF
--- a/design.md
+++ b/design.md
@@ -3089,10 +3089,10 @@ that constrained graph.
 The long-term invariant is:
 
 ```text
-one reachable specialization
-  -> one Monotype instantiation context
+one connected open specialization solve group
+  -> one Monotype instantiation graph
   -> one cloned/constrained checked type graph
-  -> one closed Monotype body
+  -> one or more independently identified closed Monotype bodies
 ```
 
 This is deliberately different from treating a checked expression id as a
@@ -3102,14 +3102,22 @@ that checked module. The same checked function template may therefore produce
 many Monotype bodies, and the same checked nested lambda site may produce many
 nested Monotype functions, each with a different monomorphic function type.
 
-Each specialization owns an instantiation graph: union-find nodes with
+Each connected solve group owns an instantiation graph: union-find nodes with
 explicit row-extension links, created by instantiating checked types on first
-touch. Instantiation contexts cache nodes by `(checked module id, checked type
-id)`. The address is the checked identity of the type variable/content in the
-current specialization. It is not a structural digest, source name, runtime
-layout, object symbol, or generated procedure id. Nodes begin unresolved. As
-the specialization is lowered, explicit evidence from checked data unifies
-those nodes:
+touch. A group begins with one specialization. A procedure request whose
+complete interface is already resolved remains a separate specialization and
+receives its own graph after the caller seals. A request whose interface is
+still open joins the requester's live group, because the callee body can own
+checked constraints needed to finish that interface. This grouping is the
+explicit dependency relation between specializations, not a structural guess;
+it also keeps recursive open dependencies in one fixed-point solve.
+
+Within the group, each body instantiation context caches nodes by `(checked
+module id, checked type id)`. The address is the checked identity of the type
+variable/content in that body specialization. It is not a structural digest,
+source name, runtime layout, object symbol, or generated procedure id. Nodes
+begin unresolved. As the group is lowered, explicit evidence from checked data
+unifies those nodes:
 
 - the requested root function/value type constrains the checked root type;
 - lambda and closure expected function types constrain the nested function
@@ -3192,11 +3200,12 @@ This distinction matters most for lambdas and closures. Expression-position
 functions are checked templates. Lowering a lambda or closure at an expected
 function type creates or reuses a nested Monotype function specialization keyed
 by the checked nested site, the current function digest, the checked source
-function type digest, and the monomorphic function type digest. The expected
-function type is the root constraint for that nested specialization. It is not a
-constraint on the parent expression id. This allows the same checked lambda site
-to be specialized at multiple function types without corrupting the parent body
-or depending on traversal order.
+function type digest, and the monomorphic function type digest. The complete
+checked function root is related to the expected function interface before the
+nested body lowers, and the body lowers against that exact request interface.
+The request is not a constraint on the parent expression id. This allows the
+same checked lambda site to be specialized at multiple function types without
+corrupting the parent body or depending on traversal order.
 
 Structural equality follows the same rule. The checker has already established
 that the operands are equality-compatible and has either emitted a dispatch plan
@@ -3286,15 +3295,16 @@ no type id that is visible in Monotype IR is later refilled or changed. This is
 ordinary type solving inside one stage. Once Monotype IR is output, no
 unresolved node remains reachable and no later stage may change a type.
 
-A Monotype imported into another specialization's graph is a finished
-snapshot, never a refreshable view: a specialization that needs more than its
-requested type is a unification conflict, not a silent rewrite of another
-specialization's final type. Procedure template body requests therefore defer
-to the end of the requesting specialization, when its types are final and the
-specialization key is stable. Nested functions are the exception: they share
-the requester's graph, and an inferred local procedure's body pins signature
-variables the requester's remaining body relies on, so nested bodies lower at
-their request site.
+A Monotype imported into another solve group's graph is a finished snapshot,
+never a refreshable view: a specialization that needs more than its requested
+type is a unification conflict, not a silent rewrite of another group's final
+type. A procedure-template request with a fully resolved interface therefore
+defers until the requesting group is final, when its specialization key is
+stable. A request with an unresolved interface cannot be deferred across that
+seal: the callee body may own constraints required to close the request. That
+callee joins the current live solve group and lowers at the request site, as do
+nested functions whose bodies pin signature variables used by the remaining
+group.
 
 A deferred procedure-template request has two distinct sources of type
 evidence. Caller value flow owns the request's function arguments and return;
@@ -3309,11 +3319,13 @@ callee checked root must not make those caller-owned cells aliases. The callee
 later creates its own fresh instantiation graph and constrains its complete
 checked root against the sealed request in that graph.
 
-The deferred request stores only that live caller-owned interface and a draft
-call target. Once the caller graph is frozen, the interface is sealed exactly
-once and the target maps directly to an existing specialization or to a body
-lowered in a fresh specialization-owned graph. The caller never owns a copy of
-the context-free callee body. Generated structural work may retain explicit
+A resolved deferred request stores only the caller-owned interface and a draft
+call target. Once the solve-group graph is frozen, the interface is sealed
+exactly once and the target maps directly to an existing specialization or to a
+body lowered in a fresh graph. An unresolved request instead adds the callee's
+body and definition to the current group draft; all bodies in that group seal
+together, but each procedure retains its own specialization identity, function,
+definition, and cache record. Generated structural work may retain explicit
 lexical context when that context is one of its inputs, but it follows the same
 procedure-body ownership rule; encoding and decoding do not define a separate
 specialization path.
@@ -3554,13 +3566,14 @@ lower arguments and body through that context
 emit a closed Monotype definition
 ```
 
-Calls do not mutate the callee's checked module. A call creates or reuses a
-callee specialization by constraining a fresh callee instantiation from the
-caller's instantiated argument and result types. The caller and callee contexts
-communicate only through explicit checked type relations and Monotype types.
-This is why generic functions specialize predictably across module boundaries:
-the checked body remains immutable, and every monomorphic specialization records
-its own closed instantiation.
+Calls do not mutate the callee's checked module. A closed call creates or reuses
+a callee specialization by constraining a fresh callee instantiation from the
+caller's instantiated argument and result types. An open call joins the live
+solve group described above, and its caller and callee contexts communicate
+through their shared explicit graph relations. This is why generic functions
+specialize predictably across module boundaries: the checked body remains
+immutable, and every monomorphic specialization records its own closed
+instantiation even when several bodies solve in one open group.
 
 The specialization store must make this lookup direct. It must not scan all
 specializations for a callable family and recompute recursive type digests while
@@ -3569,7 +3582,9 @@ lowering a body. A specialization request is identified by:
 ```zig
 const SpecIdentity = struct {
     callable: CallableIdentity,
+    method_scope: CheckedModuleDigest,
     source_fn_ty_digest: TypeDigest,
+    evidence_digest: EvidenceDigest,
     request_fn_ty_digest: TypeDigest,
     request_fn_ty: TypeId,
 };
@@ -3606,13 +3621,17 @@ const SpecRecord = struct {
 };
 ```
 
-`source_fn_ty_digest` records the checked source function type after
-instantiation into the requesting graph. `request_fn_ty_digest` records the
-closed function type REQUESTED by the call site that reserved the record. The
-digests make lookup fast, but they are not the only correctness check. When a
-digest match is found, the store must also verify the checked callable identity
-and exact structural equality of the closed Monotype function type. Digest
-collisions are therefore harmless.
+`method_scope` records the exact checked registry scope that selected static
+dispatch inside the body; it participates in both draft and durable lookup
+keys. `source_fn_ty_digest` records the checked source function type after
+instantiation into the requesting graph. `evidence_digest` accelerates lookup
+of the exact retained dispatch-evidence topology. `request_fn_ty_digest`
+records the closed function type REQUESTED by the call site that reserved the
+record. The digests make lookup fast, but they are not the only correctness
+check. When a digest match is found, the store must also verify the checked
+callable identity, method scope, exact evidence topology, and exact structural
+equality of the closed Monotype function type. Digest collisions are therefore
+harmless.
 
 The identity is immutable: it is written once when the record is reserved and
 never rewritten, so no structure that indexes by identity ever needs a rekey or
@@ -3658,12 +3677,19 @@ const MonoTypeNode = extern struct {
 ```
 
 The mutable instantiation graph may use union-find, row-extension links, and
-work queues while solving one specialization. Its final output is an immutable
-`TypeId` in `MonoTypeStore`. After that point, the type node is never refilled.
+work queues while solving one open specialization group. Its final output is
+an immutable `TypeId` in `MonoTypeStore`. After that point, the type node is never refilled.
 Rows are normalized once, with field and tag names in explicit sorted order,
 and the type digest is stored beside the node when the node is interned. Parent
 digests are computed from child digests, so structurally growing records and
 function types do not repeatedly walk their whole prefix.
+
+A child digest is cached only when that child's traversal introduced no cycle
+edge. The traversal tracks a monotonically increasing cycle count rather than a
+boolean "saw a cycle": after one branch reaches a recursive ancestor, a second
+branch that also reaches it must not be mistaken for a context-independent
+subtree and cached with that ancestor-relative backreference. This keeps cached
+digests stable across repeated walks of multiply connected recursive groups.
 
 The type interner enforces exact equality:
 
@@ -3681,8 +3707,8 @@ after the first request, and growing structural accumulator types add only the
 new record/function nodes instead of redigesting every previous layer.
 
 Open instantiation graphs do not write directly into final Monotype body
-sections. While a specialization is being solved, lowering writes to a
-`BodyDraft` owned by that specialization graph. A draft mirrors the final
+sections. While a solve group is active, lowering writes to a `BodyDraft` owned
+by that graph. A draft mirrors the final
 Monotype sections enough for lowering to refer to expressions, patterns, locals,
 definitions, nested definitions, side-pool spans, and function signatures, but
 all type-bearing fields use a draft type cell:
@@ -3708,7 +3734,7 @@ A `BodyDraft` may contain ordinary lowering ids, spans, and side pools while it
 is active, but those ids are draft-local. They are not cache ids and no later
 post-check stage consumes them. The draft is sealed only after:
 
-1. all checked type evidence for the specialization has been applied;
+1. all checked type evidence for every specialization in the group has been applied;
 2. deferred procedure-template requests created by this graph have been drained
    or reserved with stable closed request types;
 3. nested function bodies that share this graph have finished lowering;

--- a/src/cli/test/platform_config.zig
+++ b/src/cli/test/platform_config.zig
@@ -81,6 +81,10 @@ const fx_open_tests = [_]SimpleTestSpec{
         .roc_file = "test/fx-open/issue_9963_hosted_try_question_mark.roc",
         .description = "Regression test: hosted Try unwrapped with ? widens the closed error row at the use site (issue 9963)",
     },
+    .{
+        .roc_file = "test/fx-open/issue_10270_named_map_err_closure.roc",
+        .description = "Regression test: named closure using map_err compiles when its result is propagated with ? (issue 10270)",
+    },
 };
 
 /// Str platform test apps - test cross-module function calls

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -2028,42 +2028,75 @@ const Builder = struct {
         procedure: checked.ProcedureUseTemplate,
     ) Allocator.Error!Ast.DefId {
         const view = moduleView(self.root_view);
-        const fn_ty = try self.lowerType(view, request.checked_type);
-        const fn_data = self.functionShape(fn_ty, "procedure use root had a non-function checked type");
-        const arg_tys = self.program.types.span(fn_data.args);
-        const args = try self.allocator.alloc(Ast.TypedLocal, arg_tys.len);
+        const template_ref = self.templateRefForProcedureUse(procedure);
+        const graph = try InstGraph.create(self.allocator, &self.program.types, &self.program.names);
+        defer graph.destroy();
+        const saved_graph = self.active_graph;
+        const saved_body_draft = self.active_body_draft;
+        self.active_graph = graph;
+        defer self.active_graph = saved_graph;
+        var body_draft = BodyDraftStore.init(self.allocator);
+        self.active_body_draft = &body_draft;
+        defer self.active_body_draft = saved_body_draft;
+        defer body_draft.deinit();
+        var ctx = try BodyContext.init(self.allocator, self, view, template_ref, graph, &body_draft);
+        defer ctx.deinit();
+
+        const root_node = try ctx.instNode(request.checked_type);
+        const initial_fn = try graph.functionNodes(root_node);
+        const args = try self.allocator.alloc(DraftTypedLocal, initial_fn.args.len);
         defer self.allocator.free(args);
-        const arg_exprs = try self.allocator.alloc(Ast.ExprId, arg_tys.len);
+        const arg_exprs = try self.allocator.alloc(DraftExprId, initial_fn.args.len);
         defer self.allocator.free(arg_exprs);
 
-        for (0..GuardedList.borrowLen(arg_tys)) |i| {
-            const arg_ty = GuardedList.at(arg_tys, i);
-            const local = try self.program.addLocal(self.symbols.fresh(), arg_ty);
-            args[i] = .{ .local = local, .ty = arg_ty };
-            arg_exprs[i] = try self.program.addExpr(.{ .ty = arg_ty, .data = .{ .local = local } });
+        for (initial_fn.args, 0..) |arg_node, index| {
+            const arg_cell = DraftTypeCell.fromGraphNode(arg_node);
+            const local = try ctx.addLocalWithBinderCell(self.symbols.fresh(), arg_cell, null);
+            args[index] = .{ .local = local, .ty = arg_cell };
+            arg_exprs[index] = try ctx.addExprWithTypeCell(arg_cell, .{ .local = local });
         }
 
-        const callee = try self.fnDefForProcedureUseWithType(
-            view,
+        const draft = FinalBodyOutputGuard.begin(self);
+        const callee = try ctx.draftFnSlotForProcedureUseAtNode(
             procedure,
             request.checked_type,
+            procedure.source_fn_ty_template,
+            root_node,
+            &.{},
             request.root_evidence,
         );
-        const body = try self.program.addExpr(.{
-            .ty = fn_data.ret,
-            .data = .{ .call_proc = .{
-                .callee = Ast.procCalleeForSlot(callee),
-                .args = try self.program.addExprSpan(arg_exprs),
-            } },
+        const callee_fn_node = try ctx.draftFnSlotTypeNode(callee, root_node);
+        try relateFunctionRequestInterface(graph, root_node, callee_fn_node);
+        const completed_fn = try graph.functionNodes(root_node);
+        const ret_cell = DraftTypeCell.fromGraphNode(completed_fn.ret);
+        const body = try ctx.addExprWithTypeCell(ret_cell, .{
+            .call_proc = .{
+                .callee = draftProcCalleeForSlot(callee),
+                .args = try body_draft.addExprSpan(arg_exprs),
+            },
         });
-
-        return try self.program.addDef(.{
+        const root_def = try body_draft.reserveDef(.root);
+        body_draft.setDef(root_def, .{
             .symbol = self.symbols.fresh(),
             .fn_def = null,
-            .args = try self.program.addTypedLocalSpan(args),
+            .fn_id = null,
+            .args = try body_draft.addTypedLocalSpan(args),
             .body = .{ .roc = body },
-            .ret = fn_data.ret,
+            .ret = ret_cell,
         });
+        const draft_end = draft.end(self);
+        const sealed = try self.sealActiveBodyDraft(
+            graph,
+            &body_draft,
+            draft,
+            draft_end,
+            root_node,
+            null,
+            root_def,
+            null,
+        );
+        defer sealed.deinit(self.allocator);
+        return sealed.root_def orelse Common.invariant("procedure use root did not commit its wrapper definition");
     }
 
     fn lowerProcedureBindingRoot(
@@ -2281,6 +2314,18 @@ const Builder = struct {
             .nodes = try self.evidence_arena.allocator().dupe(check.ConstStore.ConstFnEvidence, nodes.items),
             .frames = try self.evidence_arena.allocator().dupe(check.ConstStore.ConstFnEvidenceFrame, frames.items),
             .head = parent,
+        };
+    }
+
+    fn retainStoredConstFnEvidence(
+        self: *Builder,
+        evidence: StoredConstFnEvidence,
+    ) Allocator.Error!StoredConstFnEvidence {
+        const arena = self.evidence_arena.allocator();
+        return .{
+            .nodes = try arena.dupe(check.ConstStore.ConstFnEvidence, evidence.nodes),
+            .frames = try arena.dupe(check.ConstStore.ConstFnEvidenceFrame, evidence.frames),
+            .head = evidence.head,
         };
     }
 
@@ -2883,6 +2928,15 @@ const Builder = struct {
         });
         const local_evidence_owner = specEvidenceLocalOwner(source_ctx.draft, evidence);
         const local_context_dependent = local_evidence_owner != null or structural_lexical_dependent;
+        // An unresolved procedure interface is not yet a valid durable
+        // specialization key. Its callee body must contribute all of its
+        // checked constraints before this graph applies row defaults, so the
+        // entire connected open dependency group lowers in this graph and
+        // seals together. A resolved interface remains eligible for the
+        // independent specialization-graph path below.
+        const open_group_member = resolved_request_ty == null and
+            !local_context_dependent and
+            template.target != .hosted;
         self.count("template_misses");
         const lexical_owner = local_evidence_owner orelse if (structural_lexical_dependent)
             source_ctx.draft.current_owner
@@ -2905,7 +2959,7 @@ const Builder = struct {
         const spec_index = source_ctx.draft.template_specs.items.len;
         const demand_boundary: u32 = @intCast(source_ctx.draft.runtime_value_demands.items.len);
         try source_ctx.draft.template_specs.append(self.allocator, .{
-            .state = if (local_context_dependent) .lowering else .deferred,
+            .state = if (local_context_dependent or open_group_member) .lowering else .deferred,
             .template_ref = template_ref,
             .method_scope = source_ctx.method_scope.key,
             .source_fn_ty = source_fn_ty,
@@ -2923,6 +2977,7 @@ const Builder = struct {
             .lexical = lexical,
             .lexical_context_key = lexical_context_key,
             .fn_id = fn_id,
+            .open_group_member = open_group_member,
         });
         lexical_needs_cleanup = false;
         var indexed_nodes = std.AutoHashMap(NodeId, void).init(self.allocator);
@@ -2958,7 +3013,11 @@ const Builder = struct {
         defer body_ctx.deinit();
         if (lexical) |captured| try body_ctx.restoreCodecLexicalContext(captured);
         const root_node = try body_ctx.instNode(template.checked_fn_root);
-        if (!local_context_dependent and signature_relation == .independent_roots) {
+        if (!local_context_dependent and
+            !open_group_member and
+            signature_relation == .independent_roots and
+            template.target != .hosted)
+        {
             const public_request = source_ctx.graph.requestSourceInterface(request_fn_node) orelse request_fn_node;
             try constrainDeferredTemplateTypeArguments(source_ctx.graph, root_node, public_request);
         } else {
@@ -2979,7 +3038,7 @@ const Builder = struct {
             }
         }
         try body_ctx.instantiateTemplateDispatchRelations(template, null);
-        if (!local_context_dependent) {
+        if (!local_context_dependent and !open_group_member) {
             return .{ .local = .{ .draft = fn_id } };
         }
         if (template.target == .hosted) {
@@ -3007,14 +3066,27 @@ const Builder = struct {
 
         var completed_template = source_ctx.draft.fns.items[@intFromEnum(fn_id)].source;
         completed_template.mono_fn_ty = DraftTypeCell.fromGraphNode(completed_fn_node);
-        _ = try source_ctx.draft.addNestedDef(.{
-            .symbol = symbol,
-            .fn_def = completed_template,
-            .fn_id = .{ .draft = fn_id },
-            .args = lowered.args,
-            .body = lowered.body,
-            .ret = completed_ret_cell,
-        });
+        if (open_group_member) {
+            const def_id = try source_ctx.draft.reserveDef(.{ .draft_fn = fn_id });
+            source_ctx.draft.setDef(def_id, .{
+                .symbol = symbol,
+                .fn_def = completed_template,
+                .fn_id = .{ .draft = fn_id },
+                .args = lowered.args,
+                .body = .{ .roc = lowered.body },
+                .ret = completed_ret_cell,
+            });
+            source_ctx.draft.template_specs.items[spec_index].root_def = def_id;
+        } else {
+            _ = try source_ctx.draft.addNestedDef(.{
+                .symbol = symbol,
+                .fn_def = completed_template,
+                .fn_id = .{ .draft = fn_id },
+                .args = lowered.args,
+                .body = lowered.body,
+                .ret = completed_ret_cell,
+            });
+        }
         source_ctx.draft.fns.items[@intFromEnum(fn_id)].source = completed_template;
         source_ctx.draft.template_specs.items[spec_index].request_fn_node = completed_fn_node;
         try registerTemplateSpecInterfaceLookups(
@@ -3178,20 +3250,6 @@ const Builder = struct {
         return switch (body) {
             .direct_template => |direct| self.fnDefForCallableTemplate(view, direct.template, source_fn_ty, source_fn_key, mono_fn_ty),
             .callable_eval_template => Common.invariant("callable eval template must be restored through ConstStore before Monotype lowering"),
-        };
-    }
-
-    fn fnDefForImportedBindingBody(
-        self: *Builder,
-        view: ModuleView,
-        body: checked.ImportedProcedureBindingBody,
-        source_fn_ty: checked.CheckedTypeId,
-        source_fn_key: names.TypeDigest,
-        mono_fn_ty: Type.TypeId,
-    ) Ast.FnTemplate {
-        return switch (body) {
-            .direct_template => |direct| self.fnDefForCallableTemplate(view, direct.template, source_fn_ty, source_fn_key, mono_fn_ty),
-            .callable_eval_template => Common.invariant("imported callable eval template must be restored through ConstStore before Monotype lowering"),
         };
     }
 
@@ -4093,46 +4151,53 @@ const Builder = struct {
         return false;
     }
 
-    fn fnDefForProcedureUseWithType(
+    fn templateRefForProcedureUse(
         self: *Builder,
-        source_ty_view: ModuleView,
         proc: checked.ProcedureUseTemplate,
-        source_fn_ty: checked.CheckedTypeId,
-        root_evidence: ?checked.CheckedEvidenceSpan,
-    ) Allocator.Error!Ast.FnSlot {
-        const mono_fn_ty = try self.lowerType(source_ty_view, source_fn_ty);
-        const source_fn_key = proc.source_fn_ty_template;
-        const fn_template = switch (proc.binding) {
+    ) names.ProcTemplate {
+        return switch (proc.binding) {
             .top_level => |top_level| blk: {
                 const view = self.moduleForId(checked.topLevelProcedureModuleId(top_level));
                 const binding = view.top_level_procedure_bindings.get(top_level.binding);
-                const binding_source = schemeRoot(view, binding.source_scheme, "top-level procedure binding source scheme was not output");
-                break :blk self.fnDefForProcedureBindingBody(view, binding.body, binding_source, view.types.rootKey(binding_source), mono_fn_ty);
+                break :blk switch (binding.body) {
+                    .direct_template => |direct| switch (direct.template) {
+                        .checked => |template| template,
+                        .lifted => Common.invariant("lifted direct target reached Monotype procedure use"),
+                        .synthetic => Common.invariant("synthetic direct target reached Monotype procedure use"),
+                    },
+                    .callable_eval_template => Common.invariant("callable-eval template reached Monotype procedure use"),
+                };
             },
             .imported => |imported| blk: {
                 const view = self.moduleForId(checked.importedProcedureModuleId(imported));
                 for (view.exported_procedure_bindings.bindings) |binding| {
                     if (binding.binding.def == imported.def and binding.binding.pattern == imported.pattern) {
-                        const binding_source = schemeRoot(view, binding.source_scheme, "imported procedure binding source scheme was not output");
-                        break :blk self.fnDefForImportedBindingBody(view, binding.body, binding_source, view.types.rootKey(binding_source), mono_fn_ty);
+                        break :blk switch (binding.body) {
+                            .direct_template => |direct| switch (direct.template) {
+                                .checked => |template| template,
+                                .lifted => Common.invariant("imported lifted target reached Monotype procedure use"),
+                                .synthetic => Common.invariant("imported synthetic target reached Monotype procedure use"),
+                            },
+                            .callable_eval_template => Common.invariant("imported callable-eval template reached Monotype procedure use"),
+                        };
                     }
                 }
                 Common.invariant("imported procedure binding was not exported by its checked module");
             },
-            .hosted => |hosted| blk: {
-                break :blk self.fnDefForTemplate(self.moduleForId(moduleIdFromDigest(names.procTemplateModuleDigest(hosted.template))), hosted.template, source_fn_ty, source_fn_key, mono_fn_ty);
-            },
+            .hosted => |hosted| hosted.template,
             .platform_required => |required| blk: {
-                const app_view = self.moduleForId(checked.requiredProcedureModuleId(required));
-                const binding = app_view.top_level_procedure_bindings.get(required.procedure_binding);
-                break :blk self.fnDefForProcedureBindingBody(app_view, binding.body, source_fn_ty, source_fn_key, mono_fn_ty);
+                const view = self.moduleForId(checked.requiredProcedureModuleId(required));
+                const binding = view.top_level_procedure_bindings.get(required.procedure_binding);
+                break :blk switch (binding.body) {
+                    .direct_template => |direct| switch (direct.template) {
+                        .checked => |template| template,
+                        .lifted => Common.invariant("platform lifted target reached Monotype procedure use"),
+                        .synthetic => Common.invariant("platform synthetic target reached Monotype procedure use"),
+                    },
+                    .callable_eval_template => Common.invariant("platform callable-eval template reached Monotype procedure use"),
+                };
             },
         };
-        const evidence = if (root_evidence) |evidence_ref|
-            try self.materializeRootProcedureEvidence(fn_template, evidence_ref)
-        else
-            &.{};
-        return try self.lowerFnTemplateCallTarget(source_ty_view, fn_template, evidence);
     }
 
     fn materializeRootProcedureEvidence(
@@ -4631,27 +4696,13 @@ const Builder = struct {
             );
         }
         const request_contains_generated_private = try nested_ctx.graph.containsGeneratedPrivate(request_fn_node);
-        if (signature_relation == .exact_graph) {
-            if (request_contains_generated_private) {
-                if (nested_ctx.graph.requestSourceInterface(request_fn_node)) |source_fn_node| {
-                    try relateFunctionRequestInterface(nested_ctx.graph, root_node, source_fn_node);
-                }
-                try relateFunctionRequestInterface(nested_ctx.graph, root_node, request_fn_node);
-            } else {
-                try constrainDeferredTemplateTypeArguments(nested_ctx.graph, root_node, request_fn_node);
-            }
-        } else if (request_contains_generated_private) {
+        if (request_contains_generated_private) {
             if (nested_ctx.graph.requestSourceInterface(request_fn_node)) |source_fn_node| {
                 try relateFunctionRequestInterface(nested_ctx.graph, root_node, source_fn_node);
             }
-            try relateFunctionRequestInterface(nested_ctx.graph, root_node, request_fn_node);
-        } else {
-            try constrainDeferredTemplateTypeArguments(nested_ctx.graph, root_node, request_fn_node);
         }
-        const body_fn_node = if (signature_relation == .exact_graph or request_contains_generated_private)
-            request_fn_node
-        else
-            root_node;
+        try relateFunctionRequestInterface(nested_ctx.graph, root_node, request_fn_node);
+        const body_fn_node = request_fn_node;
         const lowered = try nested_ctx.lowerNestedFunctionAtNode(expr_id, body_fn_node, capture_entry_guards);
         const completed_fn_node = try nested_ctx.completedFunctionNodeForLoweredRet(
             body_fn_node,
@@ -4809,6 +4860,7 @@ const Builder = struct {
 
     fn draftSpecIdentityEql(self: *Builder, left: Ast.SpecIdentity, right: Ast.SpecIdentity) Allocator.Error!bool {
         if (!std.meta.eql(left.callable, right.callable)) return false;
+        if (!std.mem.eql(u8, left.method_scope.bytes[0..], right.method_scope.bytes[0..])) return false;
         if (!std.mem.eql(u8, left.source_fn_ty_digest.bytes[0..], right.source_fn_ty_digest.bytes[0..])) return false;
         if (!std.meta.eql(left.evidence_digest, right.evidence_digest)) return false;
         if (!std.mem.eql(u8, left.request_fn_ty_digest.bytes[0..], right.request_fn_ty_digest.bytes[0..])) return false;
@@ -5807,6 +5859,7 @@ const Builder = struct {
             try graph.assertTypeHasNoActiveSnapshots(sealed);
             break :blk sealed;
         } else null;
+        try self.finalizeDraftTemplateSpecs(body_draft, body_ids);
         try self.markDraftNestedReady(body_draft, body_ids);
         verifyDraftTemplateSpecsResolved(body_draft);
         try self.finalizeDraftNestedSpecs(body_draft, body_ids);
@@ -5821,7 +5874,10 @@ const Builder = struct {
             .root_ty = sealed_root,
             .extra_ty = sealed_extra,
             .root_def = if (root_def) |draft_def| body_ids.def(draft_def) else null,
-            .root_fn = if (root_fn) |draft_fn| body_ids.fn_(draft_fn) else null,
+            .root_fn = if (root_fn) |draft_fn| switch (body_ids.fnSlot(draft_fn)) {
+                .local => |local| local,
+                .imported => null,
+            } else null,
             .core_maps = retained_core_maps,
         };
     }
@@ -5883,13 +5939,64 @@ const Builder = struct {
         }
     }
 
+    fn finalizeDraftTemplateSpecs(
+        self: *Builder,
+        body_draft: *const BodyDraftStore,
+        ids: FinalIdOffsets,
+    ) Allocator.Error!void {
+        for (body_draft.template_specs.items) |spec| {
+            if (spec.state != .lowered or spec.local_context_dependent) continue;
+            if (!spec.open_group_member) {
+                Common.invariant("context-free procedure body was lowered outside its open specialization group");
+            }
+            const root_def = spec.root_def orelse
+                Common.invariant("root-owned procedure specialization had no definition");
+            const fn_id = switch (ids.fnSlot(spec.fn_id)) {
+                .imported => continue,
+                .local => |local| local,
+            };
+            const fn_template = self.program.fnSource(fn_id);
+            const fn_ty = fn_template.mono_fn_ty;
+            const digest = self.specializationTypeDigest(fn_ty);
+            const evidence = programViewFnEvidence(self.program.view(), fn_template);
+            const identity = templateSpecIdentity(
+                spec.template_ref,
+                spec.method_scope,
+                spec.source_fn_key,
+                fn_template.evidence_digest,
+                fn_ty,
+                digest,
+            );
+            const existing = try self.spec_store.findLocal(identity, specializationEvidenceView(evidence));
+            if (existing != null) continue;
+            const def_id = ids.def(root_def);
+            const retained_evidence = try self.retainStoredConstFnEvidence(evidence);
+            const spec_id = try self.addTemplateSpecRecord(
+                spec.template_ref,
+                spec.method_scope,
+                spec.source_fn_key,
+                evidence,
+                fn_ty,
+                digest,
+                fn_id,
+                .lowering,
+            );
+            try self.lowered_templates.put(fn_id, .{
+                .def = def_id,
+                .spec = spec_id,
+                .evidence = spec.evidence,
+                .topology = retained_evidence,
+            });
+            try self.markTemplateReady(fn_id, fn_ty);
+        }
+    }
+
     fn verifyDraftTemplateSpecsResolved(body_draft: *const BodyDraftStore) void {
         for (body_draft.template_specs.items) |spec| {
             switch (spec.state) {
                 .resolved => {},
-                .lowered => if (!spec.local_context_dependent) {
-                    Common.invariant("context-free procedure body was lowered into its caller's draft");
-                },
+                .lowered => if (!spec.local_context_dependent and !spec.open_group_member)
+                    Common.invariant("context-free procedure body was lowered into its caller's draft"),
                 .deferred => Common.invariant("deferred template specialization reached commit before resolution"),
                 .lowering => Common.invariant("caller-owned template specialization reached commit before its body lowered"),
             }
@@ -8523,8 +8630,8 @@ const DraftSpecState = enum {
     /// The caller owns only this specialization's live request interface. Its
     /// body is lowered later in the procedure's own instantiation graph.
     deferred,
-    /// A caller-owned specialization body is currently being lowered. This is
-    /// reserved for lexical-context-dependent procedures and nested functions.
+    /// A specialization body is currently being lowered in the active graph.
+    /// This is used for lexical-context-dependent procedures and nested functions.
     lowering,
     /// A caller-owned specialization body finished lowering into this draft.
     lowered,
@@ -8897,6 +9004,10 @@ const DraftTemplateSpec = struct {
     lexical: ?DraftCodecLexicalContext = null,
     lexical_context_key: ?names.TypeDigest = null,
     fn_id: DraftFnId,
+    /// This context-free specialization joined its requester's live solve
+    /// group because its interface was not closed enough to be a durable key.
+    open_group_member: bool,
+    root_def: ?DraftDefId = null,
     resolved_slot: ?Ast.FnSlot = null,
 };
 
@@ -16332,8 +16443,8 @@ const BodyContext = struct {
                 .imported_proc,
                 .hosted_proc,
                 .promoted_top_level_proc,
-                => |proc| return try self.lowerProcedureUseValueAtNode(proc, try self.activeNodeFromType(ty), try self.evidenceForUseSite(record.expr)),
-                .platform_required_proc => |proc| return try self.lowerProcedureUseValueAtNode(proc.procedure, try self.activeNodeFromType(ty), try self.evidenceForUseSite(record.expr)),
+                => |proc| return try self.lowerProcedureUseValueAtNode(proc, try self.activeNodeFromType(ty), try self.evidenceForUseSite(record.expr), null),
+                .platform_required_proc => |proc| return try self.lowerProcedureUseValueAtNode(proc.procedure, try self.activeNodeFromType(ty), try self.evidenceForUseSite(record.expr), proc.root_evidence),
                 else => {},
             }
         }
@@ -24134,49 +24245,7 @@ const BodyContext = struct {
         evidence: []const SpecEvidence,
         root_evidence: ?checked.CheckedEvidenceSpan,
     ) Allocator.Error!DraftFnSlot {
-        const template_ref = switch (proc.binding) {
-            .top_level => |top_level| blk: {
-                const view = self.builder.moduleForId(checked.topLevelProcedureModuleId(top_level));
-                const binding = view.top_level_procedure_bindings.get(top_level.binding);
-                break :blk switch (binding.body) {
-                    .direct_template => |direct| switch (direct.template) {
-                        .checked => |checked_template| checked_template,
-                        .lifted => Common.invariant("lifted direct target reached draft function-slot lowering"),
-                        .synthetic => Common.invariant("synthetic direct target reached draft function-slot lowering"),
-                    },
-                    .callable_eval_template => Common.invariant("callable-eval template reached node-native direct call lowering"),
-                };
-            },
-            .imported => |imported| blk: {
-                const view = self.builder.moduleForId(checked.importedProcedureModuleId(imported));
-                for (view.exported_procedure_bindings.bindings) |binding| {
-                    if (binding.binding.def == imported.def and binding.binding.pattern == imported.pattern) {
-                        break :blk switch (binding.body) {
-                            .direct_template => |direct| switch (direct.template) {
-                                .checked => |checked_template| checked_template,
-                                .lifted => Common.invariant("imported lifted target reached draft function-slot lowering"),
-                                .synthetic => Common.invariant("imported synthetic target reached draft function-slot lowering"),
-                            },
-                            .callable_eval_template => Common.invariant("imported callable-eval template reached node-native direct call lowering"),
-                        };
-                    }
-                }
-                Common.invariant("imported procedure binding was not exported by its checked module");
-            },
-            .hosted => |hosted| hosted.template,
-            .platform_required => |required| blk: {
-                const view = self.builder.moduleForId(checked.requiredProcedureModuleId(required));
-                const binding = view.top_level_procedure_bindings.get(required.procedure_binding);
-                break :blk switch (binding.body) {
-                    .direct_template => |direct| switch (direct.template) {
-                        .checked => |checked_template| checked_template,
-                        .lifted => Common.invariant("platform lifted target reached draft function-slot lowering"),
-                        .synthetic => Common.invariant("platform synthetic target reached draft function-slot lowering"),
-                    },
-                    .callable_eval_template => Common.invariant("platform callable-eval template reached node-native direct call lowering"),
-                };
-            },
-        };
+        const template_ref = self.builder.templateRefForProcedureUse(proc);
         const requested_evidence = if (root_evidence) |producer_evidence|
             try self.builder.materializeCheckedProcedureEvidence(template_ref, producer_evidence)
         else
@@ -24724,8 +24793,8 @@ const BodyContext = struct {
             .imported_proc,
             .hosted_proc,
             .promoted_top_level_proc,
-            => |proc| try self.lowerProcedureUseValueAtNode(proc, try self.activeNodeFromType(ty), try self.evidenceForUseSite(record.expr)),
-            .platform_required_proc => |proc| try self.lowerProcedureUseValueAtNode(proc.procedure, try self.activeNodeFromType(ty), try self.evidenceForUseSite(record.expr)),
+            => |proc| try self.lowerProcedureUseValueAtNode(proc, try self.activeNodeFromType(ty), try self.evidenceForUseSite(record.expr), null),
+            .platform_required_proc => |proc| try self.lowerProcedureUseValueAtNode(proc.procedure, try self.activeNodeFromType(ty), try self.evidenceForUseSite(record.expr), proc.root_evidence),
             .top_level_const,
             .imported_const,
             .platform_required_const,
@@ -24840,11 +24909,13 @@ const BodyContext = struct {
                 proc,
                 expected_node,
                 try self.evidenceForUseSite(record.expr),
+                null,
             ),
             .platform_required_proc => |proc| return try self.lowerProcedureUseValueAtNode(
                 proc.procedure,
                 expected_node,
                 try self.evidenceForUseSite(record.expr),
+                proc.root_evidence,
             ),
             // The required def failed checking, so its type never resolves;
             // crash at the use site instead of materializing the expected node.
@@ -24918,6 +24989,7 @@ const BodyContext = struct {
         proc: checked.ProcedureUseTemplate,
         request_fn_node: NodeId,
         evidence: []const SpecEvidence,
+        root_evidence: ?checked.CheckedEvidenceSpan,
     ) Allocator.Error!DraftExprId {
         if (self.callableEvalForProcedureUse(proc)) |callable_eval| {
             return try self.lowerCallableEvalBindingValueAtNode(
@@ -24935,7 +25007,7 @@ const BodyContext = struct {
             proc.source_fn_ty_template,
             request_fn_node,
             evidence,
-            null,
+            root_evidence,
         );
         const fn_id = try self.requireLocalDraftSlot(slot);
         const fn_node = try self.draftFnSlotTypeNode(slot, request_fn_node);
@@ -43595,10 +43667,6 @@ fn dispatchPlanForRuntimeExpr(view: ModuleView, expr_id: checked.CheckedExprId) 
     const plan_raw = @intFromEnum(plan_id);
     if (plan_raw >= view.static_dispatch_plans.plans.len) Common.invariant("stored serialization dispatch plan is outside plan table");
     return view.static_dispatch_plans.plans[plan_raw];
-}
-
-fn moduleIdFromDigest(ref: names.CheckedModuleDigest) checked.ModuleId {
-    return .{ .bytes = ref.bytes };
 }
 
 fn moduleDigestFromId(key: checked.ModuleId) names.CheckedModuleDigest {

--- a/src/postcheck/monotype/specialize.zig
+++ b/src/postcheck/monotype/specialize.zig
@@ -156,6 +156,7 @@ const SpecEntryId = union(enum(u8)) {
 const SpecLookupAddress = struct {
     callable_kind: u8,
     module_bytes: [32]u8,
+    method_scope: [32]u8,
     index_a: u32,
     index_b: u32,
     index_c: u32,
@@ -166,6 +167,7 @@ const SpecLookupAddress = struct {
 
     fn from(
         callable: Ast.CallableIdentity,
+        method_scope: names.CheckedModuleDigest,
         source_digest: names.TypeDigest,
         evidence_digest: Ast.EvidenceDigest,
         type_digest: names.TypeDigest,
@@ -173,6 +175,7 @@ const SpecLookupAddress = struct {
         var key: SpecLookupAddress = .{
             .callable_kind = @intFromEnum(callable),
             .module_bytes = @splat(0),
+            .method_scope = method_scope.bytes,
             .index_a = 0,
             .index_b = 0,
             .index_c = 0,
@@ -303,7 +306,7 @@ pub const SpecBuilder = struct {
         });
         errdefer _ = self.loaded_records.pop();
 
-        const address = SpecLookupAddress.from(record.identity.callable, record.identity.source_fn_ty_digest, record.identity.evidence_digest, record.solved_fn_ty_digest);
+        const address = SpecLookupAddress.from(record.identity.callable, record.identity.method_scope, record.identity.source_fn_ty_digest, record.identity.evidence_digest, record.solved_fn_ty_digest);
         const gop = try self.lookup.getOrPut(address);
         if (!gop.found_existing) gop.value_ptr.* = .empty;
         try gop.value_ptr.append(self.allocator, .{ .loaded = loaded_id });
@@ -321,7 +324,7 @@ pub const SpecBuilder = struct {
         fn_id: Ast.FnId,
     ) std.mem.Allocator.Error!ReserveResult {
         if (!evidenceDigestMatches(identity, evidence)) invariant("Monotype specialization evidence digest did not match its exact topology");
-        const address = SpecLookupAddress.from(identity.callable, identity.source_fn_ty_digest, identity.evidence_digest, identity.request_fn_ty_digest);
+        const address = SpecLookupAddress.from(identity.callable, identity.method_scope, identity.source_fn_ty_digest, identity.evidence_digest, identity.request_fn_ty_digest);
         const gop = try self.lookup.getOrPut(address);
         if (!gop.found_existing) gop.value_ptr.* = .empty;
 
@@ -390,7 +393,7 @@ pub const SpecBuilder = struct {
         scope: FindScope,
     ) std.mem.Allocator.Error!?LookupResult {
         if (!evidenceDigestMatches(identity, evidence)) invariant("Monotype specialization lookup evidence digest did not match its exact topology");
-        const address = SpecLookupAddress.from(identity.callable, identity.source_fn_ty_digest, identity.evidence_digest, identity.request_fn_ty_digest);
+        const address = SpecLookupAddress.from(identity.callable, identity.method_scope, identity.source_fn_ty_digest, identity.evidence_digest, identity.request_fn_ty_digest);
         const entries = self.lookup.get(address) orelse return null;
         self.countCandidatesBy(identity.callable, entries.items.len);
         return try self.matchInBucket(entries.items, identity, evidence, scope);
@@ -499,7 +502,7 @@ pub const SpecBuilder = struct {
             if (identity_shadow_enabled) {
                 try self.refined_digest_shadow.append(self.allocator, .{ .spec = spec, .digest = request_fn_ty_digest });
             }
-            try self.appendAliasEntry(record.identity.callable, record.identity.source_fn_ty_digest, record.identity.evidence_digest, request_fn_ty_digest, spec);
+            try self.appendAliasEntry(record.identity.callable, record.identity.method_scope, record.identity.source_fn_ty_digest, record.identity.evidence_digest, request_fn_ty_digest, spec);
         }
     }
 
@@ -529,7 +532,7 @@ pub const SpecBuilder = struct {
         record.solved_fn_ty_digest = solved_fn_ty_digest;
         record.status = .ready;
         if (!digestEql(solved_fn_ty_digest, record.request_fn_ty_digest)) {
-            try self.appendAliasEntry(record.identity.callable, record.identity.source_fn_ty_digest, record.identity.evidence_digest, solved_fn_ty_digest, spec);
+            try self.appendAliasEntry(record.identity.callable, record.identity.method_scope, record.identity.source_fn_ty_digest, record.identity.evidence_digest, solved_fn_ty_digest, spec);
         }
     }
 
@@ -539,12 +542,13 @@ pub const SpecBuilder = struct {
     fn appendAliasEntry(
         self: *SpecBuilder,
         callable: Ast.CallableIdentity,
+        method_scope: names.CheckedModuleDigest,
         source_digest: names.TypeDigest,
         evidence_digest: Ast.EvidenceDigest,
         type_digest: names.TypeDigest,
         spec: Ast.SpecId,
     ) std.mem.Allocator.Error!void {
-        const address = SpecLookupAddress.from(callable, source_digest, evidence_digest, type_digest);
+        const address = SpecLookupAddress.from(callable, method_scope, source_digest, evidence_digest, type_digest);
         const gop = try self.lookup.getOrPut(address);
         if (!gop.found_existing) gop.value_ptr.* = .empty;
         for (gop.value_ptr.items) |existing| {
@@ -673,7 +677,7 @@ pub const SpecBuilder = struct {
     }
 
     fn recordReachableAt(self: *const SpecBuilder, spec: Ast.SpecId, record: Ast.SpecRecord, digest: names.TypeDigest) bool {
-        const address = SpecLookupAddress.from(record.identity.callable, record.identity.source_fn_ty_digest, record.identity.evidence_digest, digest);
+        const address = SpecLookupAddress.from(record.identity.callable, record.identity.method_scope, record.identity.source_fn_ty_digest, record.identity.evidence_digest, digest);
         const entries = self.lookup.get(address) orelse return false;
         for (entries.items) |entry_id| {
             switch (entry_id) {
@@ -686,13 +690,14 @@ pub const SpecBuilder = struct {
 
     fn addressInRecordHistory(self: *const SpecBuilder, spec: Ast.SpecId, record: Ast.SpecRecord, address: SpecLookupAddress) bool {
         const callable = record.identity.callable;
+        const method_scope = record.identity.method_scope;
         const source_digest = record.identity.source_fn_ty_digest;
-        if (std.meta.eql(address, SpecLookupAddress.from(callable, source_digest, record.identity.evidence_digest, record.identity.request_fn_ty_digest))) return true;
-        if (std.meta.eql(address, SpecLookupAddress.from(callable, source_digest, record.identity.evidence_digest, record.request_fn_ty_digest))) return true;
-        if (record.status == .ready and std.meta.eql(address, SpecLookupAddress.from(callable, source_digest, record.identity.evidence_digest, record.solved_fn_ty_digest))) return true;
+        if (std.meta.eql(address, SpecLookupAddress.from(callable, method_scope, source_digest, record.identity.evidence_digest, record.identity.request_fn_ty_digest))) return true;
+        if (std.meta.eql(address, SpecLookupAddress.from(callable, method_scope, source_digest, record.identity.evidence_digest, record.request_fn_ty_digest))) return true;
+        if (record.status == .ready and std.meta.eql(address, SpecLookupAddress.from(callable, method_scope, source_digest, record.identity.evidence_digest, record.solved_fn_ty_digest))) return true;
         for (self.refined_digest_shadow.items) |refined| {
             if (refined.spec != spec) continue;
-            if (std.meta.eql(address, SpecLookupAddress.from(callable, source_digest, record.identity.evidence_digest, refined.digest))) return true;
+            if (std.meta.eql(address, SpecLookupAddress.from(callable, method_scope, source_digest, record.identity.evidence_digest, refined.digest))) return true;
         }
         return false;
     }
@@ -898,6 +903,37 @@ test "monotype spec builder keeps checked module boundary in callable identity" 
     try std.testing.expectEqual(first.spec, repeated_first.spec);
     try std.testing.expectEqual(Ast.FnSlot{ .local = @enumFromInt(1) }, repeated_first.target);
     try std.testing.expectEqual(@as(usize, 2), builder.records.len());
+    builder.validateLookupIntegrity();
+}
+
+test "monotype spec builder keeps method scope in specialization identity" {
+    var name_store = names.NameStore.init(std.testing.allocator);
+    defer name_store.deinit();
+
+    var type_store = Type.Store.init(std.testing.allocator);
+    defer type_store.deinit();
+
+    const unit_ty = try type_store.add(.zst);
+    var first_scope = testSpecIdentity(unit_ty, digestWithFirstByte(1), digestWithFirstByte(2));
+    first_scope.method_scope = moduleDigestWithFirstByte(1);
+    var second_scope = first_scope;
+    second_scope.method_scope = moduleDigestWithFirstByte(2);
+
+    var records = Ast.ProgramList(Ast.SpecRecord, "specs").empty;
+    defer records.deinit(std.testing.allocator);
+
+    var builder = SpecBuilder.init(std.testing.allocator, &name_store, &type_store, &records);
+    defer builder.deinit();
+
+    const first = try builder.reserve(first_scope, testEvidenceView(), @enumFromInt(1));
+    const second = try builder.reserve(second_scope, testEvidenceView(), @enumFromInt(2));
+    const repeated_first = try builder.reserve(first_scope, testEvidenceView(), @enumFromInt(3));
+
+    try std.testing.expect(first.created);
+    try std.testing.expect(second.created);
+    try std.testing.expect(!repeated_first.created);
+    try std.testing.expect(first.spec != second.spec);
+    try std.testing.expectEqual(first.spec, repeated_first.spec);
     builder.validateLookupIntegrity();
 }
 

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -748,7 +748,7 @@ pub const Store = struct {
     const CachedDigestContext = struct {
         items: [digest_visiting_max]TypeId = undefined,
         len: usize = 0,
-        saw_cycle: bool = false,
+        cycle_count: u32 = 0,
     };
 
     const NamedDigestMode = enum {
@@ -836,7 +836,7 @@ pub const Store = struct {
     ) names.TypeDigest {
         for (ctx.items[0..ctx.len], 0..) |open_ty, position| {
             if (open_ty == ty) {
-                ctx.saw_cycle = true;
+                ctx.cycle_count += 1;
                 return cycleDigest(@intCast(position));
             }
         }
@@ -867,19 +867,19 @@ pub const Store = struct {
         }
 
         if (ctx.len == digest_visiting_max) {
-            ctx.saw_cycle = true;
+            ctx.cycle_count += 1;
             return deepDigest(ty);
         }
 
         ctx.items[ctx.len] = ty;
         ctx.len += 1;
-        const saw_cycle_before = ctx.saw_cycle;
+        const cycle_count_before = ctx.cycle_count;
         var hasher = std.crypto.hash.sha2.Sha256.init(.{});
         self.writeCachedTypeDigest(name_store, &hasher, ty, named_mode, ctx, stats);
         ctx.len -= 1;
 
         const digest: names.TypeDigest = .{ .bytes = hasher.finalResult() };
-        if (ctx.saw_cycle == saw_cycle_before) {
+        if (ctx.cycle_count == cycle_count_before) {
             switch (named_mode) {
                 .full => {
                     self.type_digests.set(index, digest);
@@ -2734,6 +2734,33 @@ test "monotype cached digest reuses acyclic child digests and invalidates on res
     try std.testing.expectEqual(@as(u64, 0), after_refill_stats.cache_hits);
     try std.testing.expectEqual(@as(u64, 1), after_refill_stats.cache_misses);
     try std.testing.expectEqual(@as(u64, 1), after_refill_stats.nodes_visited);
+}
+
+test "monotype cached digest stays stable across multiple edges into one recursive group" {
+    var name_store = names.NameStore.init(std.testing.allocator);
+    defer name_store.deinit();
+
+    var store = Store.init(std.testing.allocator);
+    defer store.deinit();
+
+    const first_field = try name_store.internRecordFieldLabel("first");
+    const second_field = try name_store.internRecordFieldLabel("second");
+    const recursive = try store.reserveSlot();
+    const first_fn = try store.add(.{ .func = .{ .args = Span.empty(), .ret = recursive } });
+    const second_fn = try store.add(.{ .func = .{ .args = Span.empty(), .ret = recursive } });
+    const fields = try store.addFields(&.{
+        .{ .name = first_field, .ty = first_fn },
+        .{ .name = second_field, .ty = second_fn },
+    });
+    store.fillReservedSlot(recursive, .{ .record = fields });
+
+    const first_full = store.typeDigestCached(&name_store, recursive, null);
+    const second_full = store.typeDigestCached(&name_store, recursive, null);
+    try std.testing.expect(std.mem.eql(u8, first_full.bytes[0..], second_full.bytes[0..]));
+
+    const first_specialization = store.specializationDigestCached(&name_store, recursive, null);
+    const second_specialization = store.specializationDigestCached(&name_store, recursive, null);
+    try std.testing.expect(std.mem.eql(u8, first_specialization.bytes[0..], second_specialization.bytes[0..]));
 }
 
 test "monotype type equality accepts isomorphic recursive structural types" {

--- a/src/postcheck/structural_test.zig
+++ b/src/postcheck/structural_test.zig
@@ -113,7 +113,7 @@ test "Monotype lookup lowering uses explicit resolved use nodes" {
     try expectContains(lower_expr_at_type, ".lookup_required => |resolved| return try self.lowerLookupExprAtType(expr.ty, resolved, ty)");
     try expectContains(lower_lookup_at_type, ".platform_required_const => |required| return try self.restoreConstUseAtType(");
     try expectContains(lower_lookup_at_type, "required.const_use,\n                ty,\n                try self.evidenceForUseSite(record.expr),");
-    try expectContains(lower_lookup_at_type, ".platform_required_proc => |proc| try self.lowerProcedureUseValueAtNode(proc.procedure, try self.activeNodeFromType(ty), try self.evidenceForUseSite(record.expr))");
+    try expectContains(lower_lookup_at_type, ".platform_required_proc => |proc| try self.lowerProcedureUseValueAtNode(proc.procedure, try self.activeNodeFromType(ty), try self.evidenceForUseSite(record.expr), proc.root_evidence)");
     try expectContains(lower_source, "fn lowerCallableEvalBindingValueAtNode(");
     try expectContains(lower_source, "try self.restoreConstFnAtNode(view, fn_id, request_fn_node)");
     try expectContains(lower_source, "try body_ctx.graphFunctionNode(&.{}, request_fn_node)");

--- a/test/fx-open/issue_10270_named_map_err_closure.roc
+++ b/test/fx-open/issue_10270_named_map_err_closure.roc
@@ -1,0 +1,15 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+# Repro for https://github.com/roc-lang/roc/issues/10270
+
+mk = |f| {
+	show = || f({}).map_err(|_| ShowFailed)
+	show
+}
+
+main! = |_args| {
+	f : {} -> Try({}, [Empty])
+	f = |_| Ok({})
+	mk(f)()?
+	Ok({})
+}


### PR DESCRIPTION
Keep unresolved procedure specialization interfaces in a connected live Monotype solve group so callee and nested-body constraints are applied before row defaults seal the graph. This preserves durable specialization identity across method scopes and evidence topologies, and makes recursive digest caching context-independent so the open-group implementation remains stable for multiply connected recursive types.

Fixes #10270