### PR TITLE
Fix Nightly Gate counters and tag parser hang

### DIFF
--- a/src/base/ConcurrentU64.zig
+++ b/src/base/ConcurrentU64.zig
@@ -1,0 +1,123 @@
+//! A u64 counter that remains usable on targets without native 64-bit atomics.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const use_scalar = builtin.single_threaded or
+    builtin.target.os.tag == .freestanding or
+    builtin.target.cpu.arch == .wasm32;
+const use_atomic_u64 = !use_scalar and @bitSizeOf(usize) >= @bitSizeOf(u64);
+
+/// A full-width unsigned counter for shared timing and memory statistics.
+pub const ConcurrentU64 = if (use_scalar) struct {
+    value: u64 = 0,
+
+    pub fn init(value: u64) @This() {
+        return .{ .value = value };
+    }
+
+    pub fn load(self: *const @This()) u64 {
+        return self.value;
+    }
+
+    pub fn add(self: *@This(), amount: u64) void {
+        self.value +%= amount;
+    }
+
+    pub fn min(self: *@This(), sample: u64) void {
+        if (sample < self.value) self.value = sample;
+    }
+
+    pub fn max(self: *@This(), sample: u64) void {
+        if (sample > self.value) self.value = sample;
+    }
+} else if (use_atomic_u64) struct {
+    value: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
+
+    pub fn init(value: u64) @This() {
+        return .{ .value = std.atomic.Value(u64).init(value) };
+    }
+
+    pub fn load(self: *const @This()) u64 {
+        return self.value.load(.monotonic);
+    }
+
+    pub fn add(self: *@This(), amount: u64) void {
+        _ = self.value.fetchAdd(amount, .monotonic);
+    }
+
+    pub fn min(self: *@This(), sample: u64) void {
+        var current = self.value.load(.monotonic);
+        while (sample < current) {
+            current = self.value.cmpxchgWeak(current, sample, .monotonic, .monotonic) orelse return;
+        }
+    }
+
+    pub fn max(self: *@This(), sample: u64) void {
+        var current = self.value.load(.monotonic);
+        while (sample > current) {
+            current = self.value.cmpxchgWeak(current, sample, .monotonic, .monotonic) orelse return;
+        }
+    }
+} else struct {
+    mutex: std.atomic.Mutex = .unlocked,
+    value: u64 = 0,
+
+    pub fn init(value: u64) @This() {
+        return .{ .value = value };
+    }
+
+    pub fn load(self: *const @This()) u64 {
+        const mutable: *@This() = @constCast(self);
+        mutable.lock();
+        defer mutable.unlock();
+        return mutable.value;
+    }
+
+    pub fn add(self: *@This(), amount: u64) void {
+        self.lock();
+        defer self.unlock();
+        self.value +%= amount;
+    }
+
+    pub fn min(self: *@This(), sample: u64) void {
+        self.lock();
+        defer self.unlock();
+        if (sample < self.value) self.value = sample;
+    }
+
+    pub fn max(self: *@This(), sample: u64) void {
+        self.lock();
+        defer self.unlock();
+        if (sample > self.value) self.value = sample;
+    }
+
+    fn lock(self: *@This()) void {
+        while (!self.mutex.tryLock()) {
+            std.atomic.spinLoopHint();
+        }
+    }
+
+    fn unlock(self: *@This()) void {
+        self.mutex.unlock();
+    }
+};
+
+test "ConcurrentU64 supports totals and extrema" {
+    var total = ConcurrentU64.init(1);
+    total.add(2);
+    total.add(3);
+    try std.testing.expectEqual(@as(u64, 6), total.load());
+
+    var min_value = ConcurrentU64.init(std.math.maxInt(u64));
+    min_value.min(10);
+    min_value.min(12);
+    min_value.min(4);
+    try std.testing.expectEqual(@as(u64, 4), min_value.load());
+
+    var max_value = ConcurrentU64.init(0);
+    max_value.max(10);
+    max_value.max(4);
+    max_value.max(12);
+    try std.testing.expectEqual(@as(u64, 12), max_value.load());
+}

--- a/src/base/mod.zig
+++ b/src/base/mod.zig
@@ -12,6 +12,7 @@ pub const RegionInfo = @import("RegionInfo.zig");
 pub const SourceLoc = @import("source_loc.zig").SourceLoc;
 pub const Scratch = @import("Scratch.zig").Scratch;
 pub const parallel = @import("parallel.zig");
+pub const ConcurrentU64 = @import("ConcurrentU64.zig").ConcurrentU64;
 pub const SmallStringInterner = @import("SmallStringInterner.zig");
 pub const SerialStringInterner = @import("SerialStringInterner.zig");
 pub const ModuleIdentity = @import("module_identity.zig");
@@ -131,6 +132,7 @@ pub const Numeral = union(enum) {
 
 test "base tests" {
     std.testing.refAllDecls(@import("CommonEnv.zig"));
+    std.testing.refAllDecls(@import("ConcurrentU64.zig"));
     std.testing.refAllDecls(@import("DataSpan.zig"));
     std.testing.refAllDecls(@import("Ident.zig"));
     std.testing.refAllDecls(@import("InternedBytes.zig"));

--- a/src/eval/compile_time_finalization.zig
+++ b/src/eval/compile_time_finalization.zig
@@ -61,7 +61,7 @@ pub const Timing = struct {
     /// evaluation runs as bursts interleaved with checking, so the progress
     /// reporter cannot window-sample it; the brackets that already time each
     /// burst fold a footprint reading at the same points.
-    mem_min: MemMinCounter = .{},
+    mem_min: MemMinCounter = MemMinCounter.init(std.math.maxInt(u64)),
     mem_max: MemMaxCounter = .{},
 
     pub fn init(std_io: std.Io) Timing {
@@ -102,8 +102,8 @@ pub const Timing = struct {
         self.code_generation_ns.add(snapshot_value.code_generation_ns);
         self.execution_ns.add(snapshot_value.execution_ns);
         self.store_results_ns.add(snapshot_value.store_results_ns);
-        if (snapshot_value.mem_min != std.math.maxInt(u64)) self.mem_min.fold(snapshot_value.mem_min);
-        self.mem_max.fold(snapshot_value.mem_max);
+        if (snapshot_value.mem_min != std.math.maxInt(u64)) self.mem_min.min(snapshot_value.mem_min);
+        self.mem_max.max(snapshot_value.mem_max);
     }
 
     fn start(self: *Timing) i64 {
@@ -113,8 +113,8 @@ pub const Timing = struct {
 
     fn sampleMemory(self: *Timing) void {
         const bytes = base.process_memory.currentBytes() orelse return;
-        self.mem_min.fold(bytes);
-        self.mem_max.fold(bytes);
+        self.mem_min.min(bytes);
+        self.mem_max.max(bytes);
     }
 
     fn finish(self: *Timing, started_ns: i64, phase: TimingPhase) void {
@@ -130,77 +130,9 @@ pub const Timing = struct {
     }
 };
 
-const MemMinCounter = if (base.parallel.is_freestanding or builtin.target.cpu.arch == .wasm32) struct {
-    value: u64 = std.math.maxInt(u64),
-
-    fn load(self: *const @This()) u64 {
-        return self.value;
-    }
-
-    fn fold(self: *@This(), sample: u64) void {
-        if (sample < self.value) self.value = sample;
-    }
-} else struct {
-    value: std.atomic.Value(u64) = std.atomic.Value(u64).init(std.math.maxInt(u64)),
-
-    fn load(self: *const @This()) u64 {
-        return self.value.load(.monotonic);
-    }
-
-    fn fold(self: *@This(), sample: u64) void {
-        var current = self.value.load(.monotonic);
-        while (sample < current) {
-            current = self.value.cmpxchgWeak(current, sample, .monotonic, .monotonic) orelse return;
-        }
-    }
-};
-
-const MemMaxCounter = if (base.parallel.is_freestanding or builtin.target.cpu.arch == .wasm32) struct {
-    value: u64 = 0,
-
-    fn load(self: *const @This()) u64 {
-        return self.value;
-    }
-
-    fn fold(self: *@This(), sample: u64) void {
-        if (sample > self.value) self.value = sample;
-    }
-} else struct {
-    value: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
-
-    fn load(self: *const @This()) u64 {
-        return self.value.load(.monotonic);
-    }
-
-    fn fold(self: *@This(), sample: u64) void {
-        var current = self.value.load(.monotonic);
-        while (sample > current) {
-            current = self.value.cmpxchgWeak(current, sample, .monotonic, .monotonic) orelse return;
-        }
-    }
-};
-
-const TimingCounter = if (base.parallel.is_freestanding or builtin.target.cpu.arch == .wasm32) struct {
-    value: u64 = 0,
-
-    fn load(self: *const @This()) u64 {
-        return self.value;
-    }
-
-    fn add(self: *@This(), value: u64) void {
-        self.value +%= value;
-    }
-} else struct {
-    value: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
-
-    fn load(self: *const @This()) u64 {
-        return self.value.load(.monotonic);
-    }
-
-    fn add(self: *@This(), value: u64) void {
-        _ = self.value.fetchAdd(value, .monotonic);
-    }
-};
+const MemMinCounter = base.ConcurrentU64;
+const MemMaxCounter = base.ConcurrentU64;
+const TimingCounter = base.ConcurrentU64;
 
 /// Immutable compile-time finalization timings for progress reporting.
 pub const TimingSnapshot = struct {

--- a/src/lir/checked_pipeline.zig
+++ b/src/lir/checked_pipeline.zig
@@ -137,27 +137,7 @@ pub const Timing = struct {
     }
 };
 
-const TimingCounter = if (base.parallel.is_freestanding or builtin.target.cpu.arch == .wasm32) struct {
-    value: u64 = 0,
-
-    fn load(self: *const @This()) u64 {
-        return self.value;
-    }
-
-    fn add(self: *@This(), value: u64) void {
-        self.value +%= value;
-    }
-} else struct {
-    value: std.atomic.Value(u64) = std.atomic.Value(u64).init(0),
-
-    fn load(self: *const @This()) u64 {
-        return self.value.load(.monotonic);
-    }
-
-    fn add(self: *@This(), value: u64) void {
-        _ = self.value.fetchAdd(value, .monotonic);
-    }
-};
+const TimingCounter = base.ConcurrentU64;
 
 /// Immutable checked-to-LIR timings for progress reporting.
 pub const TimingSnapshot = struct {

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -5297,35 +5297,12 @@ const Builder = struct {
         const constructor_node = try ctx.parseTagUnionSyntheticBoundary(callable, callable.ret);
         const result = try ctx.graphParserResultNodes(callable.ret);
 
-        var added_relation = false;
-        var required_error_seen = std.AutoHashMap(NodeId, void).init(self.allocator);
-        defer required_error_seen.deinit();
-        if (try ctx.graphParserShapeNeedsRequiredFieldError(result.value, &required_error_seen)) {
-            added_relation = try ctx.ensureGraphParserMissingRequiredFieldError(constructor_node);
-            if (!added_relation and !try ctx.graphRowHasTag(result.err, "MissingRequiredField")) {
-                // Checker-closed row without the report: emission crash-maps
-                // this decode, so no format-method relations may widen it.
-                return false;
-            }
-        }
-        var invalid_value_seen = std.AutoHashMap(NodeId, void).init(self.allocator);
-        defer invalid_value_seen.deinit();
-        if (try ctx.graphParserShapeNeedsInvalidValue(result.value, result.err, &invalid_value_seen)) {
-            added_relation = try ctx.prepareParserInvalidValueCodecCall(
-                boundary.expr,
-                result.value,
-                constructor_node,
-            ) or added_relation;
-        }
-        var seen = std.AutoHashMap(NodeId, void).init(self.allocator);
-        defer seen.deinit();
-        return try ctx.prepareCustomCodecCallsAtNode(
+        return try ctx.prepareParseTagUnionPayloadCodecCalls(
             boundary.expr,
-            .parser,
             result.value,
+            result.err,
             constructor_node,
-            &seen,
-        ) or added_relation;
+        );
     }
 
     /// Phase B for deferred equality. The graph is frozen and `sealer` is the
@@ -34624,6 +34601,61 @@ const BodyContext = struct {
             boundary_callable_node,
             &seen,
         ) or added_relation;
+    }
+
+    /// `ParseTagUnionSpec.parse` decodes only the selected tag's payloads; the
+    /// enclosing format method has already consumed the tag name. Preparing a
+    /// full tag-union parser here would re-enter the same format method before
+    /// the current synthetic parser is registered.
+    fn prepareParseTagUnionPayloadCodecCalls(
+        self: *BodyContext,
+        boundary_expr: DraftExprId,
+        union_node: NodeId,
+        err_node: NodeId,
+        boundary_callable_node: NodeId,
+    ) Allocator.Error!bool {
+        var added_relation = false;
+        var missing_required_field_ready = false;
+
+        var required_error_seen = std.AutoHashMap(NodeId, void).init(self.allocator);
+        defer required_error_seen.deinit();
+        var invalid_value_seen = std.AutoHashMap(NodeId, void).init(self.allocator);
+        defer invalid_value_seen.deinit();
+        var seen = std.AutoHashMap(NodeId, void).init(self.allocator);
+        defer seen.deinit();
+
+        for ((try self.graph.tagRowNodes(union_node)).tags) |tag| {
+            for (tag.payloads) |payload| {
+                if (try self.graphParserShapeNeedsRequiredFieldError(payload, &required_error_seen)) {
+                    if (!missing_required_field_ready) {
+                        const added_missing = try self.ensureGraphParserMissingRequiredFieldError(boundary_callable_node);
+                        added_relation = added_missing or added_relation;
+                        missing_required_field_ready = added_missing or try self.graphRowHasTag(err_node, "MissingRequiredField");
+                        if (!missing_required_field_ready) {
+                            // Checker-closed row without the report: emission
+                            // crash-maps this decode, so no format-method
+                            // relations may widen it.
+                            return false;
+                        }
+                    }
+                }
+                if (try self.graphParserShapeNeedsInvalidValue(payload, err_node, &invalid_value_seen)) {
+                    added_relation = try self.prepareParserInvalidValueCodecCall(
+                        boundary_expr,
+                        payload,
+                        boundary_callable_node,
+                    ) or added_relation;
+                }
+                added_relation = try self.prepareCustomCodecCallsAtNode(
+                    boundary_expr,
+                    .parser,
+                    payload,
+                    boundary_callable_node,
+                    &seen,
+                ) or added_relation;
+            }
+        }
+        return added_relation;
     }
 
     fn resolvedPreparedCodecCallsForBoundary(


### PR DESCRIPTION
The Nightly Gate 32-bit musl cross-compile jobs failed because compile-time finalization and checked-to-LIR timing used `std.atomic.Value(u64)`, which Zig 0.16 rejects for 32-bit targets. This adds a shared `base.ConcurrentU64` counter that keeps full-width timing values across targets.

While babysitting CI, the macOS and Windows harness jobs also exposed a pre-existing recursive JSON tag-union parser preparation hang from main. `ParseTagUnionSpec.parse` now prepares helper relations only for tag payload shapes, matching the decoder body it actually emits instead of re-entering the enclosing `parse_tag_union` format method.