### PR TITLE
Derive JSON codecs for opaque types with a scalar backing

### DIFF
--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -961,6 +961,9 @@ const subcommand_cases = [_]CliCase{
     // Repro for https://github.com/roc-lang/roc/issues/10162: compiler-derived
     // codec method markers in a platform module remain structural methods.
     .{ .id = 0, .suite = .subcommands, .name = "issue 10162: platform derived codec methods are not hosted functions", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10162_platform_derived_codec/platform/main.roc", .exit = .success, .contains_any = &.{.{ .needles = &no_errors_needles }}, .not_contains = &.{ .{ .stream = .stderr, .text = "INVALID HOSTED SECTION" }, .{ .stream = .stderr, .text = "EFFECTFUL FUNCTION NAME" } } } } },
+    // Repro for https://github.com/roc-lang/roc/issues/10425: a derived JSON codec for a
+    // primitive-backed nominal (`Username := Str`) encodes and parses as its backing scalar.
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10425: derived codec round-trips a primitive-backed nominal", .body = .{ .command = .{ .args = &.{ "test", "--no-cache" }, .roc_file = "test/cli/JsonNominalScalarRoundTrip.roc", .exit = .success, .contains = &.{.{ .stream = .stdout, .text = "All (4) tests passed" }} } } },
     // Repro for https://github.com/roc-lang/roc/issues/10315: an error in a
     // nominal's owner module must be reported without aborting later dispatch.
     .{ .id = 0, .suite = .subcommands, .name = "issue 10315: static dispatch reports failed nominal owner module errors", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10315_static_dispatch_failed_owner/app.roc", .exit = .failure, .stderr_min_len = 1, .contains = &.{ .{ .stream = .stderr, .text = "NAME NOT IN SCOPE" }, .{ .stream = .stderr, .text = "missing_name" } }, .not_contains = &.{ .{ .stream = .stderr, .text = "type checker invariant violated" }, .{ .stream = .stderr, .text = "panic" } } } } },

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -20316,6 +20316,13 @@ const BodyContext = struct {
         ret_ty: Type.TypeId,
         precomputed_plan: ?*const ParserPrecomputedPlan,
     ) Allocator.Error!DraftExprId {
+        // A nominal opaque with a scalar backing and no custom parser (e.g. `Username := Str`)
+        // parses its backing scalar, then rewraps the value in the nominal.
+        if (self.builder.nominalExprBackingType(shape_ty)) |backing_ty| {
+            if (self.parseScalarMethodName(backing_ty) != null) {
+                return try self.lowerParseNominalScalarFromState(shape_ty, backing_ty, encoding_expr, encoding_ty, state_expr, state_ty, ret_ty, precomputed_plan);
+            }
+        }
         const selected = self.parseShapeSelection(shape_ty);
         if (Ident.textEql(selected.tag_text, "Record")) {
             const precomputed = if (precomputed_plan) |plan| self.parserPlanGet(plan, shape_ty) else null;
@@ -20392,6 +20399,42 @@ const BodyContext = struct {
                 .captures = try self.methodTargetCaptureSpan(parse_lookup),
             } },
         });
+    }
+
+    fn lowerParseNominalScalarFromState(
+        self: *BodyContext,
+        nominal_ty: Type.TypeId,
+        backing_ty: Type.TypeId,
+        encoding_expr: DraftExprId,
+        encoding_ty: Type.TypeId,
+        state_expr: DraftExprId,
+        state_ty: Type.TypeId,
+        ret_ty: Type.TypeId,
+        precomputed_plan: ?*const ParserPrecomputedPlan,
+    ) Allocator.Error!DraftExprId {
+        const ret_info = self.tryInfo(ret_ty);
+        const backing_parse_ok_ty = try self.parseResultOkType(backing_ty, state_ty);
+        const backing_parse_ret_ty = try self.tryTypeLike(ret_ty, backing_parse_ok_ty, ret_info.err_ty);
+        const backing_parse = try self.lowerParseShapeHelperCall(
+            backing_ty,
+            encoding_expr,
+            encoding_ty,
+            state_expr,
+            state_ty,
+            backing_parse_ret_ty,
+            precomputed_plan,
+        );
+
+        const value_name = try self.builder.program.names.internRecordFieldLabel("value");
+        const rest_name = try self.builder.program.names.internRecordFieldLabel("rest");
+        const backing_local = try self.addLocal(self.builder.symbols.fresh(), backing_ty);
+        const rest_local = try self.addLocal(self.builder.symbols.fresh(), state_ty);
+        const nominal_value = try self.addExpr(.{
+            .ty = nominal_ty,
+            .data = .{ .nominal = try self.localExpr(backing_local, backing_ty) },
+        });
+        const ok_body = try self.parseResultOk(ret_ty, nominal_value, try self.localExpr(rest_local, state_ty), state_ty);
+        return try self.sequenceTryRecord(backing_parse, backing_parse_ret_ty, backing_local, value_name, rest_local, rest_name, ok_body, ret_ty);
     }
 
     fn lowerParseRecordFromState(
@@ -33374,7 +33417,11 @@ const BodyContext = struct {
         if (runtime_arg_tys.len != 1) Common.invariant("structural parser runtime function must have one state argument");
 
         const top_level_null_try = self.tryNullInfo(shape_ty);
-        if (self.parseScalarMethodName(shape_ty) == null and top_level_null_try == null) {
+        const nominal_scalar_backing = if (self.builder.nominalExprBackingType(shape_ty)) |backing_ty|
+            self.parseScalarMethodName(backing_ty) != null
+        else
+            false;
+        if (self.parseScalarMethodName(shape_ty) == null and top_level_null_try == null and !nominal_scalar_backing) {
             if (self.setPayloadType(shape_ty)) |elem_ty| {
                 if (!try self.parseFieldTypeIsSupported(elem_ty, false)) Common.invariant("structural parser set element type was not supported");
             } else if (self.dictEntryShape(shape_ty)) |dict| {
@@ -33641,6 +33688,34 @@ const BodyContext = struct {
         }
         if (self.encodeScalarMethodName(shape_ty)) |method_name| {
             return try self.lowerEncodeFormatMethod(method_name, &.{ value_expr, state_expr }, &.{ shape_ty, state_ty }, encoding_ty, ret_ty);
+        }
+        // A nominal opaque with a scalar backing and no custom encoder (e.g. `Username := Str`)
+        // encodes as its backing: unwrap one nominal layer and encode the scalar.
+        if (self.builder.nominalExprBackingType(shape_ty)) |backing_ty| {
+            if (self.encodeScalarMethodName(backing_ty) != null) {
+                const value_local = try self.addLocal(self.builder.symbols.fresh(), shape_ty);
+                const backing_local = try self.addLocal(self.builder.symbols.fresh(), backing_ty);
+                const encoded_backing = try self.lowerEncodeShapeToState(
+                    backing_ty,
+                    try self.localExpr(backing_local, backing_ty),
+                    encoding_expr,
+                    encoding_ty,
+                    state_expr,
+                    state_ty,
+                    ret_ty,
+                    precomputed_plan,
+                );
+                const unwrap_pat = try self.addPat(.{
+                    .ty = shape_ty,
+                    .data = .{ .nominal = try self.bindPat(backing_local, backing_ty) },
+                });
+                const branch = DraftBranch{ .pat = unwrap_pat, .body = encoded_backing };
+                const matched = try self.addExpr(.{ .ty = ret_ty, .data = .{ .match_ = .{
+                    .scrutinee = try self.localExpr(value_local, shape_ty),
+                    .branches = try self.addBranchSpan(&[_]DraftBranch{branch}),
+                } } });
+                return try self.wrapLet(value_local, shape_ty, value_expr, matched, ret_ty);
+            }
         }
         return switch (self.builder.shapeContent(shape_ty)) {
             .record, .zst => try self.lowerEncodeRecordToState(shape_ty, value_expr, encoding_expr, encoding_ty, state_expr, state_ty, ret_ty, precomputed_plan),
@@ -35590,6 +35665,9 @@ const BodyContext = struct {
             return try self.parseFieldTypeIsSupported(info.ok_payload_ty, false);
         }
         if ((try self.customParserLookup(ty)) != null) return true;
+        if (self.builder.nominalExprBackingType(ty)) |backing_ty| {
+            if (self.parseScalarMethodName(backing_ty) != null) return true;
+        }
         if (self.setPayloadType(ty)) |payload_ty| return try self.parseFieldTypeIsSupported(payload_ty, false);
         if (self.dictEntryShape(ty)) |dict| {
             const key_ok = self.dictKeyIsStringRendered(dict.key_ty) or try self.parseFieldTypeIsSupported(dict.key_ty, false);
@@ -35638,6 +35716,9 @@ const BodyContext = struct {
             return try self.encodeFieldTypeIsSupported(info.ok_payload_ty, encoding_ty);
         }
         if ((try self.customEncoderForLookup(ty)) != null) return true;
+        if (self.builder.nominalExprBackingType(ty)) |backing_ty| {
+            if (self.encodeScalarMethodName(backing_ty) != null) return true;
+        }
         if (self.setPayloadType(ty)) |payload_ty| return try self.encodeFieldTypeIsSupported(payload_ty, encoding_ty);
         if (self.dictEntryShape(ty)) |dict| {
             const key_ok = self.dictKeyIsStringRendered(dict.key_ty) or try self.encodeFieldTypeIsSupported(dict.key_ty, encoding_ty);
@@ -37530,6 +37611,21 @@ const BodyContext = struct {
                 boundary_callable_node,
                 method_name,
             );
+        }
+
+        // A nominal opaque with a scalar backing (e.g. `Username := Str`) prepares the codec for
+        // its backing scalar; the encoder/parser reaches it after unwrapping the nominal.
+        switch (self.graph.content(shape_node)) {
+            .named => |named| if (named.backing) |backing| {
+                const backing_is_scalar = if (kind == .parser)
+                    self.graphJsonParseScalarMethodName(backing.node) != null
+                else
+                    self.graphJsonEncodeScalarMethodName(backing.node) != null;
+                if (backing_is_scalar) {
+                    return try self.prepareCustomCodecCallsAtNode(boundary_expr, kind, backing.node, boundary_callable_node, seen);
+                }
+            },
+            else => {},
         }
 
         if (self.graphNodeIsBuiltinTry(shape_node)) {

--- a/test/cli/JsonNominalScalarRoundTrip.roc
+++ b/test/cli/JsonNominalScalarRoundTrip.roc
@@ -1,0 +1,49 @@
+JsonNominalScalarRoundTrip :: [].{}
+
+Username := Str.{
+	encoder_for : _
+	parser_for : _
+}
+
+Age := I64.{
+	encoder_for : _
+	parser_for : _
+}
+
+# A refined string encodes as its backing string, not as `{}`.
+expect {
+	value : Username
+	value = Username.("ada")
+
+	Str.is_eq(Json.to_str(value), "\"ada\"")
+}
+
+# A refined integer encodes as its backing integer.
+expect {
+	value : Age
+	value = Age.(42)
+
+	Str.is_eq(Json.to_str(value), "42")
+}
+
+# The same holds for a refined field inside a record.
+expect {
+	value : { name : Username, age : Age }
+	value = { name: Username.("a heap allocated username value"), age: Age.(7) }
+
+	Str.is_eq(Json.to_str(value), "{\"age\":7,\"name\":\"a heap allocated username value\"}")
+}
+
+# Round-trip: parsing a refined string yields the nominal, which re-encodes to the input.
+# `u_to_str`'s signature forces the parse target to `Username` without naming the error type.
+u_to_str : Username -> Str
+u_to_str = |name| Json.to_str(name)
+
+username_round_trips : Str -> Bool
+username_round_trips = |json|
+	match Json.parse(json) {
+		Ok(name) => Str.is_eq(u_to_str(name), json)
+		Err(_) => Bool.False
+	}
+
+expect username_round_trips("\"a heap allocated username value\"")

--- a/test/snapshots/repl/json_nominal_scalar_codec.md
+++ b/test/snapshots/repl/json_nominal_scalar_codec.md
@@ -1,0 +1,46 @@
+# META
+~~~ini
+description=Derived JSON codec for a primitive-backed nominal encodes/parses as its backing scalar, and the value survives
+type=repl
+~~~
+# SOURCE
+~~~roc
+» Username := Str.{ encoder_for : _ }
+» name = Username.("a heap allocated username value")
+» Json.to_str(name)
+» name
+» Age := I64.{ encoder_for : _ }
+» Json.to_str(Age.(42))
+» Flag := Bool.{ encoder_for : _ }
+» Json.to_str(Flag.(Bool.True))
+» Price := Dec.{ encoder_for : _ }
+» Json.to_str(Price.(19.95))
+» Token := Str.{ parser_for : _ }
+» match Json.parse("\"parsed token\"") { Ok(t) => t, Err(_) => Token.("parse failed") }
+~~~
+# OUTPUT
+assigned `Username`
+---
+assigned `name`
+---
+"\"a heap allocated username value\""
+---
+"a heap allocated username value"
+---
+assigned `Age`
+---
+"42"
+---
+assigned `Flag`
+---
+"true"
+---
+assigned `Price`
+---
+"19.95"
+---
+assigned `Token`
+---
+"parsed token"
+# PROBLEMS
+NIL


### PR DESCRIPTION
A derived `encoder_for : _` / `parser_for : _` on an opaque whose backing is a scalar (`Username := Str`, `Age := I64`) panicked in Monotype lowering — the scalar-method check looked at the nominal (owned by the user module) instead of the primitive's builtin owner, so it fell through to structural dispatch (no scalar case), and the graph sealer never prepared the backing scalar's codec.

### Fix

Mirror the existing record-backing path: when an opaque has a scalar backing and no custom codec, unwrap one `.nominal` layer, encode/parse the backing scalar, rewrap the value across the nominal boundary, and prepare the backing scalar's codec during graph sealing. Custom `encoder_for`/`parser_for` bodies still take precedence.

### Scope

Covers the **infallible** scalar backings — `Str`, `Bool`, every integer width, and `Dec`. Two cases are intentionally left for a follow-up:

- **F32/F64 backings** — their encoders are fallible (`NaN`/`Infinity`), so a derived infallible `encoder_for` over them is really a checker-level question: the checker already rejects a bare `F64` under `Json.to_str`, and it should reject the opaque the same way. These still panic today; I'd send that checker-side fix separately.
- **Nested `A := B := Str`** — only the single primitive layer this issue describes is handled.

### Tests

- `test/snapshots/repl/json_nominal_scalar_codec.md` — encode of `Str`/`I64`/`Bool`/`Dec`-backed nominals (the value survives re-encoding) and parse of a `Str`-backed nominal.
- `test/cli/JsonNominalScalarRoundTrip.roc` (wired into `parallel_cli_runner.zig`) — `Str`/`I64` encode, a record with two refined fields, and a full `Json.parse(Json.to_str(x))` round-trip.
- `run-check-snapshots` is green (no other codec snapshot drifts); `run-check-tidy` / `run-check-zig-lints` pass. Reverting the `lower.zig` change makes both new tests fail with the original panic.

Part of #10425.
