### PR TITLE
Add List.intersperse

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3826,6 +3826,34 @@ Builtin :: [].{
 			$joined
 		}
 
+		## Insert a separator between every pair of elements in a list.
+		## ```roc
+		## expect [1.I64, 2, 3].intersperse(0) == [1, 0, 2, 0, 3]
+		##
+		## expect [1.I64].intersperse(0) == [1]
+		## ```
+		intersperse : List(a), a -> List(a)
+		intersperse = |list, separator| {
+			len = List.len(list)
+
+			if len < 2 {
+				list
+			} else {
+				# `2 * len - 1` counts exactly the items appended below, so every
+				# unchecked append stays in bounds.
+				var $new_list = List.with_capacity(2 * len - 1)
+				var $index = 0
+				for item in list {
+					if $index > 0 {
+						$new_list = list_append_unsafe($new_list, separator)
+					}
+					$new_list = list_append_unsafe($new_list, item)
+					$index = $index + 1
+				}
+				$new_list
+			}
+		}
+
 		## Create a list with space for at least capacity items
 		with_capacity : U64 -> List(item)
 

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3826,7 +3826,7 @@ Builtin :: [].{
 			$joined
 		}
 
-		## Insert a separator between every pair of elements in a list.
+		## Insert a separator between every pair of items in a list.
 		## ```roc
 		## expect [1.I64, 2, 3].intersperse(0) == [1, 0, 2, 0, 3]
 		##

--- a/test/snapshots/repl/list_intersperse.md
+++ b/test/snapshots/repl/list_intersperse.md
@@ -1,0 +1,34 @@
+# META
+~~~ini
+description=List.intersperse
+type=repl
+~~~
+# SOURCE
+~~~roc
+» [1, 2, 3].intersperse(0)
+» [42].intersperse(0)
+» List.intersperse([], 0)
+» words = ["a string long enough to be heap-allocated instead of stored inline", "another heap-allocated string in the source list"]
+» sep = "a heap-allocated separator that gets duplicated between the elements"
+» words.intersperse(sep)
+» words
+» sep
+~~~
+# OUTPUT
+[1.0, 0.0, 2.0, 0.0, 3.0]
+---
+[42.0]
+---
+[]
+---
+assigned `words`
+---
+assigned `sep`
+---
+["a string long enough to be heap-allocated instead of stored inline", "a heap-allocated separator that gets duplicated between the elements", "another heap-allocated string in the source list"]
+---
+["a string long enough to be heap-allocated instead of stored inline", "another heap-allocated string in the source list"]
+---
+"a heap-allocated separator that gets duplicated between the elements"
+# PROBLEMS
+NIL


### PR DESCRIPTION
Adds `List.intersperse : List(a), a -> List(a)` from #9596 — inserts a separator between every pair of elements (`[1, 2, 3].intersperse(0) == [1, 0, 2, 0, 3]`).

Mirrors `List.join`: reserve the exact result size (`2 * len - 1`) then fill with unchecked appends. Lists with fewer than 2 elements pass through unchanged — which is also what keeps the `2 * len - 1` from underflowing at length 0.

### Tests
- `test/snapshots/repl/list_intersperse.md` — empty / single / many, plus a heap-string case that redisplays the source list and the separator after the call to exercise element refcounting (the separator is reused between every pair).
- A doctest on the declaration.

`#9596` tracks this as a `List` function and I kept that shape. Happy to reshape it toward `Iter` if that's preferred now that the iterator aggregates have landed.
