### PR TITLE
Add List.chunks_of

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4703,6 +4703,34 @@ Builtin :: [].{
 		## ```
 		sublist : List(a), { start : U64, len : U64 } -> List(a)
 
+		## Split a list into chunks of at most `chunk_size` items, in order. The
+		## final chunk is shorter when the length is not a multiple of `chunk_size`,
+		## and a `chunk_size` of 0 produces an empty list.
+		## ```roc
+		## expect [1.I64, 2, 3, 4, 5].chunks_of(2) == [[1, 2], [3, 4], [5]]
+		##
+		## expect [1.I64, 2, 3].chunks_of(10) == [[1, 2, 3]]
+		## ```
+		chunks_of : List(a), U64 -> List(List(a))
+		chunks_of = |list, chunk_size| {
+			len = List.len(list)
+
+			if chunk_size == 0 or len == 0 {
+				[]
+			} else {
+				# `(len - 1) / chunk_size + 1` is an overflow-safe ceil of `len / chunk_size`,
+				# counting exactly the chunks appended below so every unchecked append stays
+				# in bounds.
+				var $chunks = List.with_capacity((len - 1) / chunk_size + 1)
+				var $start = 0
+				while ($start < len) {
+					$chunks = list_append_unsafe($chunks, List.sublist(list, { start: $start, len: chunk_size }))
+					$start = $start + chunk_size
+				}
+				$chunks
+			}
+		}
+
 		## Return the first `n` items of the list. If the list has fewer than `n`
 		## items, the entire list is returned.
 		## ```roc

--- a/test/snapshots/repl/list_chunks_of.md
+++ b/test/snapshots/repl/list_chunks_of.md
@@ -1,0 +1,40 @@
+# META
+~~~ini
+description=List.chunks_of
+type=repl
+~~~
+# SOURCE
+~~~roc
+» [1, 2, 3, 4, 5].chunks_of(2)
+» [1, 2, 3].chunks_of(10)
+» [1, 2, 3].chunks_of(1)
+» [1, 2, 3].chunks_of(0)
+» List.chunks_of([], 2)
+» [1, 2, 3, 4].chunks_of(2)
+» [1, 2, 3].chunks_of(18446744073709551615)
+» words = ["a string long enough to be heap-allocated instead of stored inline", "another heap-allocated string in the source", "a third heap-allocated string to fill out the chunks", "a fourth heap-allocated string in the source list"]
+» words.chunks_of(2)
+» words
+~~~
+# OUTPUT
+[[1.0, 2.0], [3.0, 4.0], [5.0]]
+---
+[[1.0, 2.0, 3.0]]
+---
+[[1.0], [2.0], [3.0]]
+---
+[]
+---
+[]
+---
+[[1.0, 2.0], [3.0, 4.0]]
+---
+[[1.0, 2.0, 3.0]]
+---
+assigned `words`
+---
+[["a string long enough to be heap-allocated instead of stored inline", "another heap-allocated string in the source"], ["a third heap-allocated string to fill out the chunks", "a fourth heap-allocated string in the source list"]]
+---
+["a string long enough to be heap-allocated instead of stored inline", "another heap-allocated string in the source", "a third heap-allocated string to fill out the chunks", "a fourth heap-allocated string in the source list"]
+# PROBLEMS
+NIL


### PR DESCRIPTION
Adds `List.chunks_of : List(a), U64 -> List(List(a))` from #9596 — split a list into chunks of at most `chunk_size` items, in order (`[1, 2, 3, 4, 5].chunks_of(2) == [[1, 2], [3, 4], [5]]`); the final chunk is shorter when the length isn't a multiple.

Each window is a `List.sublist`, and the chunk count is reserved up front with an overflow-safe ceil, `(len - 1) / chunk_size + 1`, so the fill uses unchecked appends. Two total-function edges yield `[]`: a `chunk_size` of 0, and the empty list.

### Tests
`test/snapshots/repl/list_chunks_of.md` — empty / size 0 / size 1 / non-multiple / exact-multiple / size > len / a `U64`-max `chunk_size` (which a naive `len + chunk_size` ceil would overflow on) / and a heap-string case that redisplays the source after chunking to check it survives. Plus a doctest on the declaration.
