### PR TITLE
Keep named callable lookups graph-native

### DIFF
--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -123,6 +123,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10218_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10271_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10395_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10508_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));
     std.testing.refAllDecls(@import("test/platform_box_update_lir_test.zig"));

--- a/src/compile/test/issue_10508_test.zig
+++ b/src/compile/test/issue_10508_test.zig
@@ -1,0 +1,19 @@
+//! Regression test for issue #10508.
+
+const expectLowersToLir = @import("lower_to_lir_harness.zig").expectLowersToLir;
+
+test "issue 10508: unannotated named tag wrapper passed to List.map lowers to LIR" {
+    // Repro for https://github.com/roc-lang/roc/issues/10508.
+    // Passing an unannotated named function directly to List.map must lower.
+    try expectLowersToLir(
+        \\wrap = |x| Wrapped(x)
+        \\
+        \\main! = |args| {
+        \\    tags = args.map(wrap)
+        \\    match tags.len() {
+        \\        0 => Ok({})
+        \\        _ => Ok({})
+        \\    }
+        \\}
+    );
+}

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -24883,7 +24883,7 @@ const BodyContext = struct {
             .platform_required_const => |required| return try self.constUseTypeNode(checked_ty, required.const_use),
             else => {},
         }
-        return try self.activeNodeFromType(try self.lookupExprMonoType(checked_ty, ref_id));
+        return try self.lowerTypeNode(checked_ty);
     }
 
     fn lookupExprMonoType(

--- a/src/postcheck/structural_test.zig
+++ b/src/postcheck/structural_test.zig
@@ -103,6 +103,7 @@ test "Monotype lookup lowering uses explicit resolved use nodes" {
     const lower_expr_type = sourceSliceBetween(lower_source, "fn lowerExprType", "fn lowerExpr(self:");
     const lower_expr_at_type = sourceSliceBetween(lower_source, "fn lowerExprAtType", "fn sameType");
     const lower_lookup_at_type = sourceSliceBetween(lower_source, "fn lowerLookupExprAtType", "fn lowerProcedureUseValue");
+    const lookup_type_node = sourceSliceBetween(lower_source, "fn lookupExprTypeNode", "fn lookupExprMonoType");
 
     try expectContains(lower_call, "if (try self.indirectCalleeMonoType(call.func, call.args, expected_ret_ty)) |fn_ty| {");
     try expectContains(lower_call, "var fn_node = try call_ctx.instantiateCallNodeFromCallerAtNode(");
@@ -111,6 +112,8 @@ test "Monotype lookup lowering uses explicit resolved use nodes" {
 
     try expectContains(lower_expr_type, ".lookup_required => |resolved| try self.lookupExprTypeNode(expr.ty, resolved)");
     try expectContains(lower_expr_at_type, ".lookup_required => |resolved| return try self.lowerLookupExprAtType(expr.ty, resolved, ty)");
+    try expectContains(lookup_type_node, "return try self.lowerTypeNode(checked_ty);");
+    try std.testing.expect(std.mem.find(u8, lookup_type_node, "lookupExprMonoType") == null);
     try expectContains(lower_lookup_at_type, ".platform_required_const => |required| return try self.restoreConstUseAtType(");
     try expectContains(lower_lookup_at_type, "required.const_use,\n                ty,\n                try self.evidenceForUseSite(record.expr),");
     try expectContains(lower_lookup_at_type, ".platform_required_proc => |proc| try self.lowerProcedureUseValueAtNode(proc.procedure, try self.activeNodeFromType(ty), try self.evidenceForUseSite(record.expr), proc.root_evidence)");


### PR DESCRIPTION
Unannotated named functions passed to builtin higher-order methods could reach Monotype dispatch before their type variables were related, while lookup lowering tried to materialize an immutable type from the still-open graph node. This keeps ordinary lookup type queries graph-native until final sealing and adds focused behavioral and structural regression coverage. Fixes #10508.