### PR TITLE
Support shebangs in `roc fmt`

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -3246,13 +3246,13 @@ const Formatter = struct {
     fn flushCommentsBeforeMin(fmt: *Formatter, tokenIdx: Token.Idx, min_leading_newlines: u8) error{WriteFailed}!bool {
         const start = if (tokenIdx == 0) 0 else fmt.ast.tokens.resolve(tokenIdx - 1).end.offset;
         const end = fmt.ast.tokens.resolve(tokenIdx).start.offset;
-        return fmt.flushComments(fmt.ast.env.source[start..end], min_leading_newlines);
+        return fmt.flushComments(start, fmt.ast.env.source[start..end], min_leading_newlines);
     }
 
     fn flushCommentsAfter(fmt: *Formatter, tokenIdx: Token.Idx) error{WriteFailed}!bool {
         const start = fmt.ast.tokens.resolve(tokenIdx).end.offset;
         const end = fmt.ast.tokens.resolve(tokenIdx + 1).start.offset;
-        return fmt.flushComments(fmt.ast.env.source[start..end], 0);
+        return fmt.flushComments(start, fmt.ast.env.source[start..end], 0);
     }
 
     fn flushCommentsEOF(fmt: *Formatter) error{WriteFailed}!void {
@@ -3282,7 +3282,7 @@ const Formatter = struct {
                 try fmt.push('#');
                 const comment_text = between_text[comment_start..comment_end];
                 // Add space after # unless next char is space or # (preserves ## doc comments and ### separators)
-                if (comment_text.len > 0 and comment_text[0] != ' ' and comment_text[0] != '#') {
+                if (!isShebang(start + i, comment_text) and comment_text.len > 0 and comment_text[0] != ' ' and comment_text[0] != '#') {
                     try fmt.push(' ');
                 }
                 try fmt.pushAll(comment_text);
@@ -3299,7 +3299,17 @@ const Formatter = struct {
         try fmt.ensureNewline();
     }
 
-    fn flushComments(fmt: *Formatter, between_text: []const u8, min_leading_newlines: u8) error{WriteFailed}!bool {
+    /// A `#!` at the very start of a file is a shebang, so the formatter must leave
+    /// it alone. Inserting the usual space after the `#` would stop the shell from
+    /// recognizing it, breaking executable Roc scripts.
+    /// `offset` is the absolute source offset of the comment's `#`, and
+    /// `comment_text` is everything after that `#` up to the end of the line.
+    fn isShebang(offset: usize, comment_text: []const u8) bool {
+        return offset == 0 and comment_text.len > 0 and comment_text[0] == '!';
+    }
+
+    /// `start_offset` is the absolute source offset that `between_text` begins at.
+    fn flushComments(fmt: *Formatter, start_offset: usize, between_text: []const u8, min_leading_newlines: u8) error{WriteFailed}!bool {
         var newline_count: usize = 0;
         var prev_was_comment: bool = false;
         // True once we've either upgraded a source newline into a blank line
@@ -3348,7 +3358,7 @@ const Formatter = struct {
                 try fmt.push('#');
                 const comment_text = between_text[comment_start..comment_end];
                 // Add space after # unless next char is space or # (preserves ## doc comments and ### separators)
-                if (comment_text.len > 0 and comment_text[0] != ' ' and comment_text[0] != '#') {
+                if (!isShebang(start_offset + i, comment_text) and comment_text.len > 0 and comment_text[0] != ' ' and comment_text[0] != '#') {
                     try fmt.push(' ');
                 }
                 try fmt.pushAll(comment_text);
@@ -4952,4 +4962,33 @@ test "fmt upgrades a roc version pin that has a comment written inside it" {
     defer std.testing.allocator.free(result);
 
     try std.testing.expect(std.mem.find(u8, result, "nightly-2026-August-1-bbbbbbb") != null);
+}
+
+test "fmt preserves a shebang on the first line" {
+    const input = "#!/usr/bin/env roc\n" ++
+        "app [main!] { pf: platform \"./platform/main.roc\" }\n";
+    const result = try moduleFmtsStable(std.testing.allocator, input, false);
+    defer std.testing.allocator.free(result);
+
+    try std.testing.expectEqualStrings(input, result);
+}
+
+test "fmt preserves a shebang in a file with no header" {
+    const input = "#!/usr/bin/env roc\n" ++
+        "x = 1\n";
+    const result = try moduleFmtsStable(std.testing.allocator, input, false);
+    defer std.testing.allocator.free(result);
+
+    try std.testing.expectEqualStrings(input, result);
+}
+
+test "fmt spaces out a #! that is not on the first line" {
+    // Only the very first line of a file can be a shebang, so `#!` anywhere else
+    // is an ordinary comment and gets the usual space after the `#`.
+    const input = "x = 1\n" ++
+        "#!/usr/bin/env roc\n";
+    const result = try moduleFmtsStable(std.testing.allocator, input, false);
+    defer std.testing.allocator.free(result);
+
+    try std.testing.expectEqualStrings("x = 1\n# !/usr/bin/env roc\n", result);
 }


### PR DESCRIPTION
`roc fmt` used to break shebangs by inserting a space between `#!` like so `# !`. Since Roc is great for scripting, we want those shebangs intact.