### PR TITLE
Preserve pipe try suffix precedence

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -1136,6 +1136,11 @@ const Formatter = struct {
         no_additional_indent_on_access,
     };
 
+    const ExprFormatContext = struct {
+        behavior: ExprFormatBehavior = .normal,
+        question_suffix_follows: bool = false,
+    };
+
     fn formatStringInterpolation(fmt: *Formatter, idx: AST.Expr.Idx) FormatAstError!void {
         try fmt.pushAll("${");
         const part_region = fmt.nodeRegion(@intFromEnum(idx));
@@ -1188,7 +1193,7 @@ const Formatter = struct {
     };
 
     fn formatExprWithInfo(fmt: *Formatter, ei: AST.Expr.Idx) FormatAstError!FormattedExpr {
-        return formatExprInner(fmt, ei, .normal);
+        return formatExprInner(fmt, ei, .{});
     }
 
     fn adjustMultilineAccessIndent(fmt: *Formatter, format_behavior: ExprFormatBehavior) void {
@@ -1219,7 +1224,7 @@ const Formatter = struct {
     }
 
     fn formatExprInnerDiscard(fmt: *Formatter, ei: AST.Expr.Idx, format_behavior: ExprFormatBehavior) FormatAstError!void {
-        const formatted = try fmt.formatExprInner(ei, format_behavior);
+        const formatted = try fmt.formatExprInner(ei, .{ .behavior = format_behavior });
         Formatter.discardRegion(formatted.region);
     }
 
@@ -1288,11 +1293,12 @@ const Formatter = struct {
         return formatted;
     }
 
-    fn formatExprInner(fmt: *Formatter, ei: AST.Expr.Idx, format_behavior: ExprFormatBehavior) FormatAstError!FormattedExpr {
+    fn formatExprInner(fmt: *Formatter, ei: AST.Expr.Idx, format_context: ExprFormatContext) FormatAstError!FormattedExpr {
         const expr = fmt.ast.store.getExpr(ei);
         const region = fmt.nodeRegion(@intFromEnum(ei));
         var formatted = FormattedExpr{ .region = region };
         const multiline = fmt.nodeWillBeMultiline(AST.Expr.Idx, ei);
+        const format_behavior = format_context.behavior;
         const indent_modifier: u32 = @intFromBool(format_behavior != .normal and fmt.curr_indent > 0);
         const curr_indent: u32 = fmt.curr_indent - indent_modifier;
         defer {
@@ -1492,11 +1498,12 @@ const Formatter = struct {
                         const args = fmt.ast.store.exprSlice(apply.args);
 
                         // A direct empty argument list contributes no arguments
-                        // beyond the piped value, so remove it whenever doing so
-                        // does not expose another application as the pipe RHS.
+                        // beyond the piped value. Remove it unless a following
+                        // `?` needs the call syntax to own the completed pipe, or
+                        // doing so would expose another application as the RHS.
                         // (`value |> make()()` must remain distinct from
                         // `value |> make()`.)
-                        if (args.len == 0 and apply_fn != .apply) {
+                        if (args.len == 0 and apply_fn != .apply and !format_context.question_suffix_follows) {
                             const right_region = fmt.nodeRegion(@intFromEnum(ld.right));
                             const closing_token = right_region.end - 1;
                             if (fmt.hasCommentBefore(closing_token) and try fmt.flushCommentsBefore(closing_token)) {
@@ -1730,10 +1737,19 @@ const Formatter = struct {
                 }
             },
             .suffix_single_question => |s| {
-                const body = switch (format_behavior) {
-                    .normal => try fmt.formatExprWithInfo(s.expr),
-                    .no_indent_on_access, .no_additional_indent_on_access => try fmt.formatExprInner(s.expr, .no_additional_indent_on_access),
+                const child_behavior: ExprFormatBehavior = switch (format_behavior) {
+                    .normal => .normal,
+                    .no_indent_on_access, .no_additional_indent_on_access => .no_additional_indent_on_access,
                 };
+                const child_expr = fmt.ast.store.getExpr(s.expr);
+                const pipe_needs_parens = child_expr == .arrow_call and fmt.ast.store.getExpr(child_expr.arrow_call.right) != .apply;
+                const body = if (pipe_needs_parens)
+                    try fmt.formatParenthesizedExpr(null, s.expr, fmt.nodeWillBeMultiline(AST.Expr.Idx, s.expr))
+                else
+                    try fmt.formatExprInner(s.expr, .{
+                        .behavior = child_behavior,
+                        .question_suffix_follows = child_expr == .arrow_call,
+                    });
                 _ = try fmt.continueAfterMultilineStringLine(body);
                 try fmt.push('?');
             },
@@ -4206,6 +4222,31 @@ test "pipe targets ending in question marks stay unparenthesized" {
     defer std.testing.allocator.free(result);
 
     try std.testing.expectEqualStrings(input, result);
+}
+
+test "issue 10510: empty call controls pipe question suffix precedence" {
+    // Repro for https://github.com/roc-lang/roc/issues/10510
+    const result = try moduleFmtsStable(std.testing.allocator,
+        \\from_arrow = a->f()?
+        \\with_call = a |> f()?
+        \\without_call = a |> f?
+        \\parenthesized_result = (a |> f)?
+        \\chain = a->f()?->g()?->h()?
+    , false);
+    defer std.testing.allocator.free(result);
+
+    try std.testing.expectEqualStrings(
+        "from_arrow = a |> f()?\n" ++
+            "\n" ++
+            "with_call = a |> f()?\n" ++
+            "\n" ++
+            "without_call = a |> f?\n" ++
+            "\n" ++
+            "parenthesized_result = (a |> f)?\n" ++
+            "\n" ++
+            "chain = a |> f()? |> g()? |> h()?\n",
+        result,
+    );
 }
 
 test "parenthesized pipe receivers drop direct empty target arguments" {

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -4256,6 +4256,12 @@ fn runExprStatementKernel(
                                 .region = .{ .start = apply_state.start, .end = self.pos },
                             } });
                             self.store.setCollectionLayout(expr, layout);
+                            // A direct target call makes the following `?` apply
+                            // to the completed pipe rather than to its RHS.
+                            if (self.peek() == .NoSpaceOpQuestion and open_syntax.peekExpr() == .expr_pipe_rhs) {
+                                last_expr = expr;
+                                continue :expr_kernel .complete;
+                            }
                             expr_finish_state = .{ .start = apply_state.start, .min_bp = apply_state.min_bp, .expr = expr };
                             continue :expr_kernel .suffix;
                         },

--- a/src/parse/mod.zig
+++ b/src/parse/mod.zig
@@ -175,6 +175,44 @@ test "deeply nested parentheses parse stack-safely" {
     try std.testing.expectEqual(@as(usize, 0), ast.parse_diagnostics.items.len);
 }
 
+test "pipe question suffix precedence distinguishes empty call" {
+    // Repro for https://github.com/roc-lang/roc/issues/10510
+    const gpa = std.testing.allocator;
+    const source = "(a |> f()?, a |> f?, a |> f(x)?)";
+
+    var env = try CommonEnv.init(gpa, source);
+    defer env.deinit(gpa);
+
+    const ast = try expr(gpa, &env);
+    defer ast.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), ast.tokenize_diagnostics.items.len);
+    try std.testing.expectEqual(@as(usize, 0), ast.parse_diagnostics.items.len);
+
+    const root = ast.store.getExpr(@enumFromInt(ast.root_node_idx));
+    try std.testing.expectEqual(.tuple, std.meta.activeTag(root));
+    const items = ast.store.exprSlice(root.tuple.items);
+    try std.testing.expectEqual(@as(usize, 3), items.len);
+
+    // `a |> f()?` is `(a |> f)?`: the question suffix owns the pipe.
+    const called_target = ast.store.getExpr(items[0]);
+    try std.testing.expectEqual(.suffix_single_question, std.meta.activeTag(called_target));
+    const called_target_pipe = ast.store.getExpr(called_target.suffix_single_question.expr);
+    try std.testing.expectEqual(.arrow_call, std.meta.activeTag(called_target_pipe));
+
+    // `a |> f?` is `a |> (f?)`: the pipe owns the question-suffixed target.
+    const suffixed_target = ast.store.getExpr(items[1]);
+    try std.testing.expectEqual(.arrow_call, std.meta.activeTag(suffixed_target));
+    const target = ast.store.getExpr(suffixed_target.arrow_call.right);
+    try std.testing.expectEqual(.suffix_single_question, std.meta.activeTag(target));
+
+    // Explicit target arguments are also inside the pipe result being unwrapped.
+    const target_with_arg = ast.store.getExpr(items[2]);
+    try std.testing.expectEqual(.suffix_single_question, std.meta.activeTag(target_with_arg));
+    const target_with_arg_pipe = ast.store.getExpr(target_with_arg.suffix_single_question.expr);
+    try std.testing.expectEqual(.arrow_call, std.meta.activeTag(target_with_arg_pipe));
+}
+
 test "dollar-prefixed record field names are rejected with a single diagnostic" {
     const gpa = std.testing.allocator;
 


### PR DESCRIPTION
Treat a direct pipe-target call followed by `?` as applying the suffix to the completed pipe, while keeping `a |> f?` scoped to the target. The formatter now preserves load-bearing empty argument lists during legacy-arrow migration and parenthesizes pipe results when needed to keep formatting semantics-preserving.\n\nFixes #10510