### PR TITLE
Release displaced refcounted List.set elements

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -3456,7 +3456,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
                     const index_off = try self.ensureOnStack(index_loc, 8);
                     const elem_off = try self.ensureOnStack(elem_loc, list_abi.elem_size_align.size);
-                    // We need a scratch slot for the old element (out_element param)
+                    // listReplace moves the old element here; list_set releases that
+                    // unreturned ownership unit after the call.
                     const old_elem_slot = self.codegen.allocStackSlot(@intCast(list_abi.elem_size_align.size));
                     const elem_incref_reg = if (list_abi.elem_layout_idx) |idx| try self.emitBuiltinInternalOptionalRcHelperAddress(.incref, idx) else null;
                     defer if (elem_incref_reg) |reg| self.codegen.freeGeneral(reg);
@@ -3484,6 +3485,16 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         try builder.addRegArg(roc_ops_reg);
 
                         try self.callBuiltin(&builder, LowLevelBuiltins.listOp(.list_set));
+                    }
+
+                    if (list_abi.elem_layout_idx) |elem_layout_idx| {
+                        const helper = RcHelperVariant{
+                            .key = .{ .op = .decref, .layout_idx = elem_layout_idx },
+                            .atomicity = .atomic,
+                        };
+                        if (self.layout_store.rcHelperPlan(helper.key) != .noop) {
+                            try self.emitRcHelperCallAtStackOffset(helper, old_elem_slot, 1);
+                        }
                     }
 
                     return .{ .list_stack = .{ .struct_offset = result_offset, .data_offset = 0, .num_elements = 0 } };

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -7729,9 +7729,9 @@ pub const MonoLlvmCodeGen = struct {
 
         var call_args = try self.rocListArgs1(GuardedList.at(args, 0));
         defer call_args.deinit(self.allocator);
-        // listReplace copies the displaced element into out_element before
-        // overwriting it. list_set discards that value, but the builtin still
-        // needs a real slot to write.
+        // listReplace moves the displaced element into out_element before
+        // overwriting it. list_set does not return that ownership unit, so it
+        // needs both a real slot and a drop after the call.
         const old_elem_ptr = try self.allocEntryBlockSlot(
             .i8,
             abi.elem_size,
@@ -7749,6 +7749,11 @@ pub const MonoLlvmCodeGen = struct {
         try self.appendUpdateModeArg(&call_args, unique_args);
         try call_args.append(self.allocator, try self.ptrType(), self.rocOps());
         try self.callBuiltinVoid(builtinSymbol(LowLevelBuiltins.listOp(.list_set)), call_args.types.items, call_args.values.items);
+        if (abi.contains_refcounted) {
+            if (abi.elem_layout_idx) |elem_layout_idx| {
+                try self.emitRcHelperCall(.{ .op = .decref, .layout_idx = elem_layout_idx }, .atomic, old_elem_ptr, null);
+            }
+        }
     }
 
     fn emitListReplaceUnsafe(self: *MonoLlvmCodeGen, target: LocalId, args: anytype, unique_args: u64) Error!void {

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -18714,10 +18714,22 @@ fn generateLLListSet(self: *Self, args: anytype, ret_layout: layout.Idx, unique_
     const elem_layout_idx = list_abi.elem_layout_idx orelse unreachable;
     const index_local = try self.materializeListIndex(GuardedList.at(args, 1));
     const elem_ptr = try self.materializeElementPtr(GuardedList.at(args, 2), elem_layout_idx, elem_size, elem_align);
-    // list_set discards the displaced element; the builtin still needs a slot.
+    // listReplace moves the displaced element here; list_set releases that
+    // unreturned ownership unit after the call.
     const out_element_offset = try self.allocStackMemory(elem_size, elem_align);
 
     try self.emitListReplaceCall(list_abi, list_ptr, index_local, elem_ptr, out_element_offset, result_offset, unique_args);
+    if (list_abi.elements_refcounted) {
+        const old_elem_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitFpOffset(out_element_offset);
+        try self.emitLocalSet(old_elem_ptr);
+        try self.emitExplicitRcHelperCallForValuePtr(
+            .{ .op = .decref, .layout_idx = elem_layout_idx },
+            .atomic,
+            old_elem_ptr,
+            1,
+        );
+    }
     try self.emitFpOffset(result_offset);
 }
 

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -5430,8 +5430,8 @@ pub const Interpreter = struct {
                     .interp = self,
                     .elem_layout = self.listElemLayout(arg_layout),
                 };
-                // listReplace requires a scratch slot for the old element; we discard it here
-                // because list_set returns only the new list (replace semantics return a pair).
+                // listReplace moves the old element into a scratch slot. list_set does not
+                // return that ownership unit, so release it after the replacement.
                 const old_elem = try self.allocAlignedBytes(info.width, layout_mod.RocAlignment.fromByteUnits(@intCast(info.alignment)));
                 const result = if (updateModeForArg0(ll.unique_args) == .InPlace)
                     builtins.list.listReplaceInPlace(
@@ -5458,6 +5458,9 @@ pub const Interpreter = struct {
                         &builtins.list.copy_fallback,
                         &self.roc_ops,
                     );
+                if (elems_rc) {
+                    listElementDecref(@ptrCast(&elem_rc_ctx), @ptrCast(old_elem.ptr));
+                }
                 break :blk self.rocListToValue(result, ll.ret_layout);
             },
             .list_with_capacity => blk: {

--- a/src/eval/test/host_effects_tests.zig
+++ b/src/eval/test/host_effects_tests.zig
@@ -979,6 +979,47 @@ pub const tests = [_]TestCase{
         0,
     ),
     exprTestWithLiveAllocations(
+        "rc balance: List.set releases the displaced refcounted element",
+        \\{
+        \\    entries = [{ words: [1.U64, 2.U64, 3.U64] }]
+        \\    updated = List.set(entries, 0, { words: [] }) ?? []
+        \\    expect List.len(updated) == 1
+        \\    {}
+        \\}
+    ,
+        &.{},
+        .returned,
+        0,
+    ),
+    exprTestWithLiveAllocations(
+        "rc balance: Dict update and escaped refcounted field are fully released",
+        \\{
+        \\    step = |model| {
+        \\        key = "hello"
+        \\        (entries, used_words) = match model.entries.get(key) {
+        \\            Ok(entry) => {
+        \\                refreshed = { ..entry, generation: model.generation }
+        \\                (model.entries.insert(key, refreshed), refreshed.words)
+        \\            }
+        \\            Err(_) => {
+        \\                entry = { words: [1.U64, 2.U64, 3.U64], generation: model.generation }
+        \\                (model.entries.insert(key, entry), entry.words)
+        \\            }
+        \\        }
+        \\        { entries, generation: model.generation + 1, used_words }
+        \\    }
+        \\    initial = { entries: Dict.empty(), generation: 0.U64, used_words: [] }
+        \\    first = step(initial)
+        \\    second = step(first)
+        \\    expect List.len(second.used_words) == 3
+        \\    {}
+        \\}
+    ,
+        &.{},
+        .returned,
+        0,
+    ),
+    exprTestWithLiveAllocations(
         "rc balance: boxed list of heap strings is released after unbox",
         \\{
         \\    boxed = Box.box([


### PR DESCRIPTION
## Summary

- release the displaced element ownership produced internally by `List.set`
- apply the same explicit element-layout decref in the interpreter, dev, LLVM, and WebAssembly backends
- add direct `List.set` and `Dict` update leak regressions

## Root cause

`List.set` shares the `listReplace` implementation with `List.replace`. `listReplace` moves the old element into an output slot before overwriting it. `List.replace` returns that old value, but `List.set` wrote it to scratch storage and abandoned it without a structural decref. Replacing elements containing lists, boxes, or other refcounted values therefore leaked their children.

This manifested in Terrocotta as repeated `RocList.reallocate` leaks from updated `Dict` cache entries and a leaked boxed font from an updated layout/style value.

## Testing

- `zig build run-test-eval-host-effects` (83 passed)
- `zig build run-test-zig-module-eval run-test-zig-module-backend run-test-zig-backend-llvm`
- `zig build roc`
- built and ran Terrocotta `dict_refresh.roc`, `mini_font.roc`, and `widgets.roc` with the patched speed-optimized compiler; all exited without leak reports