### PR TITLE
Fix formatting of package-qualified exposed items

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -2268,6 +2268,10 @@ const Formatter = struct {
         switch (item) {
             .lower_ident => |i| {
                 region = i.region;
+                for (fmt.ast.store.tokenSlice(i.qualifiers)) |qualifier| {
+                    try fmt.pushTokenText(qualifier);
+                    try fmt.push('.');
+                }
                 try fmt.pushTokenText(i.ident);
                 if (i.as) |a| {
                     try fmt.pushAll(" as ");
@@ -2276,6 +2280,10 @@ const Formatter = struct {
             },
             .upper_ident => |i| {
                 region = i.region;
+                for (fmt.ast.store.tokenSlice(i.qualifiers)) |qualifier| {
+                    try fmt.pushTokenText(qualifier);
+                    try fmt.push('.');
+                }
                 try fmt.pushTokenText(i.ident);
                 if (i.as) |a| {
                     try fmt.pushAll(" as ");
@@ -3995,6 +4003,14 @@ fn parseAndFmt(gpa: std.mem.Allocator, input: []const u8, debug: bool) FormatPar
         std.debug.print("Formatted:\n==========\n{s}\n==========\n\n", .{result.written()});
     }
     return try result.toOwnedSlice();
+}
+
+test "issue 10480: package qualifier preserved in exposed aliased imports" {
+    // Repro for https://github.com/roc-lang/roc/issues/10480
+    const result = try moduleFmtsStable(std.testing.allocator, "module[o as n,F.s as I]", false);
+    defer std.testing.allocator.free(result);
+
+    try std.testing.expectEqualStrings("module [o as n, F.s as I]\n", result);
 }
 
 test "issue 10431: wrapped declaration has no trailing whitespace" {

--- a/src/parse/AST.zig
+++ b/src/parse/AST.zig
@@ -2104,11 +2104,13 @@ pub const ExposedItem = union(enum) {
     lower_ident: struct {
         as: ?Token.Idx,
         ident: Token.Idx,
+        qualifiers: Token.Span,
         region: TokenizedRegion,
     },
     upper_ident: struct {
         as: ?Token.Idx,
         ident: Token.Idx,
+        qualifiers: Token.Span,
         region: TokenizedRegion,
     },
     upper_ident_star: struct {

--- a/src/parse/NodeStore.zig
+++ b/src/parse/NodeStore.zig
@@ -524,7 +524,14 @@ pub fn addExposedItem(store: *NodeStore, item: AST.ExposedItem) std.mem.Allocato
         .lower_ident => |i| {
             node.tag = .exposed_item_lower;
             node.main_token = i.ident;
-            if (i.as) |a| {
+            if (i.qualifiers.span.len > 0) {
+                const extra_start = @as(u32, @intCast(store.extra_data.items.len));
+                try store.extra_data.append(store.gpa, i.qualifiers.span.start);
+                try store.extra_data.append(store.gpa, i.qualifiers.span.len);
+                try store.extra_data.append(store.gpa, if (i.as) |a| a else 0);
+                node.data.lhs = extra_start;
+                node.data.rhs = 2;
+            } else if (i.as) |a| {
                 std.debug.assert(a > 0);
                 node.data.lhs = a;
                 node.data.rhs = 1;
@@ -534,7 +541,14 @@ pub fn addExposedItem(store: *NodeStore, item: AST.ExposedItem) std.mem.Allocato
         .upper_ident => |i| {
             node.tag = .exposed_item_upper;
             node.main_token = i.ident;
-            if (i.as) |a| {
+            if (i.qualifiers.span.len > 0) {
+                const extra_start = @as(u32, @intCast(store.extra_data.items.len));
+                try store.extra_data.append(store.gpa, i.qualifiers.span.start);
+                try store.extra_data.append(store.gpa, i.qualifiers.span.len);
+                try store.extra_data.append(store.gpa, if (i.as) |a| a else 0);
+                node.data.lhs = extra_start;
+                node.data.rhs = 2;
+            } else if (i.as) |a| {
                 std.debug.assert(a > 0);
                 node.data.lhs = a;
                 node.data.rhs = 1;
@@ -1566,30 +1580,56 @@ pub fn getExposedItem(store: *const NodeStore, exposed_item_idx: AST.ExposedItem
     const node = store.nodes.get(@enumFromInt(@intFromEnum(exposed_item_idx)));
     switch (node.tag) {
         .exposed_item_lower => {
-            if (node.data.rhs == 1) {
+            if (node.data.rhs == 2) {
+                const extra_start = node.data.lhs;
+                const q_start = store.extra_data.items[extra_start];
+                const q_len = store.extra_data.items[extra_start + 1];
+                const as_tok = store.extra_data.items[extra_start + 2];
                 return .{ .lower_ident = .{
                     .region = node.region,
                     .ident = node.main_token,
+                    .qualifiers = .{ .span = .{ .start = q_start, .len = q_len } },
+                    .as = if (as_tok != 0) as_tok else null,
+                } };
+            } else if (node.data.rhs == 1) {
+                return .{ .lower_ident = .{
+                    .region = node.region,
+                    .ident = node.main_token,
+                    .qualifiers = .{ .span = base.DataSpan.empty() },
                     .as = node.data.lhs,
                 } };
             }
             return .{ .lower_ident = .{
                 .region = node.region,
                 .ident = node.main_token,
+                .qualifiers = .{ .span = base.DataSpan.empty() },
                 .as = null,
             } };
         },
         .exposed_item_upper => {
-            if (node.data.rhs == 1) {
+            if (node.data.rhs == 2) {
+                const extra_start = node.data.lhs;
+                const q_start = store.extra_data.items[extra_start];
+                const q_len = store.extra_data.items[extra_start + 1];
+                const as_tok = store.extra_data.items[extra_start + 2];
                 return .{ .upper_ident = .{
                     .region = node.region,
                     .ident = node.main_token,
+                    .qualifiers = .{ .span = .{ .start = q_start, .len = q_len } },
+                    .as = if (as_tok != 0) as_tok else null,
+                } };
+            } else if (node.data.rhs == 1) {
+                return .{ .upper_ident = .{
+                    .region = node.region,
+                    .ident = node.main_token,
+                    .qualifiers = .{ .span = base.DataSpan.empty() },
                     .as = node.data.lhs,
                 } };
             }
             return .{ .upper_ident = .{
                 .region = node.region,
                 .ident = node.main_token,
+                .qualifiers = .{ .span = base.DataSpan.empty() },
                 .as = null,
             } };
         },

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -849,6 +849,7 @@ fn parseExposedItemTokens(self: *Parser) std.mem.Allocator.Error!AST.ExposedItem
             return try self.store.addExposedItem(.{ .lower_ident = .{
                 .region = .{ .start = start, .end = self.pos },
                 .ident = start,
+                .qualifiers = .{ .span = base.DataSpan.empty() },
                 .as = as,
             } });
         },
@@ -857,12 +858,21 @@ fn parseExposedItemTokens(self: *Parser) std.mem.Allocator.Error!AST.ExposedItem
             const qual_result = try self.readQualificationChain(.all_segments);
             self.pos = qual_result.final_token + 1;
             const ident = qual_result.final_token;
+            const is_lower = self.tok_buf.tokens.items(.tag)[ident] == .LowerIdent;
             if (self.peek() == .KwAs) {
                 self.advance();
                 as = self.pos;
-                self.expect(.UpperIdent) catch {
-                    return try self.pushMalformed(AST.ExposedItem.Idx, .expected_upper_name_after_exposed_item_as, start);
-                };
+                if (is_lower) {
+                    if (self.peek() == .LowerIdent or self.peek() == .UpperIdent) {
+                        self.advance();
+                    } else {
+                        return try self.pushMalformed(AST.ExposedItem.Idx, .expected_lower_name_after_exposed_item_as, start);
+                    }
+                } else {
+                    self.expect(.UpperIdent) catch {
+                        return try self.pushMalformed(AST.ExposedItem.Idx, .expected_upper_name_after_exposed_item_as, start);
+                    };
+                }
             } else if (self.peek() == .DotStar) {
                 self.advance();
                 return try self.store.addExposedItem(.{ .upper_ident_star = .{
@@ -871,11 +881,21 @@ fn parseExposedItemTokens(self: *Parser) std.mem.Allocator.Error!AST.ExposedItem
                     .qualifiers = qual_result.qualifiers,
                 } });
             }
-            return try self.store.addExposedItem(.{ .upper_ident = .{
-                .region = .{ .start = start, .end = self.pos },
-                .ident = ident,
-                .as = as,
-            } });
+            if (is_lower) {
+                return try self.store.addExposedItem(.{ .lower_ident = .{
+                    .region = .{ .start = start, .end = self.pos },
+                    .ident = ident,
+                    .qualifiers = qual_result.qualifiers,
+                    .as = as,
+                } });
+            } else {
+                return try self.store.addExposedItem(.{ .upper_ident = .{
+                    .region = .{ .start = start, .end = self.pos },
+                    .ident = ident,
+                    .qualifiers = qual_result.qualifiers,
+                    .as = as,
+                } });
+            }
         },
         else => return try self.pushMalformed(AST.ExposedItem.Idx, .exposed_item_unexpected_token, start),
     }


### PR DESCRIPTION
Preserves package qualifiers on module exposed items when formatting.
Previously qualifiers were stripped during AST node construction, resulting in invalid code on re-parsing.
Added unit test coverage for package-qualified exposed items.

Fixes #10480