### PR TITLE
Fix unstable where clause formatting

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -669,13 +669,14 @@ const Formatter = struct {
                 }
                 try fmt.formatTypeAnnoDiscard(d.anno);
                 if (d.where) |w| {
-                    if (multiline) {
+                    const where_multiline = multiline or fmt.collectionWillBeMultiline(AST.WhereClause.Idx, w);
+                    if (where_multiline) {
                         try fmt.flushCommentsBeforeDiscard(anno_region.end);
                         try fmt.ensureNewline();
                         fmt.curr_indent += 1;
                         try fmt.pushIndent();
                     }
-                    try fmt.formatWhereConstraint(w, multiline);
+                    try fmt.formatWhereConstraint(w, where_multiline);
                 }
                 if (d.associated) |assoc| {
                     try fmt.pushAll(".");
@@ -720,13 +721,14 @@ const Formatter = struct {
                 }
                 try fmt.formatTypeAnnoDiscard(t.anno);
                 if (t.where) |w| {
-                    if (multiline) {
+                    const where_multiline = multiline or fmt.collectionWillBeMultiline(AST.WhereClause.Idx, w);
+                    if (where_multiline) {
                         try fmt.flushCommentsBeforeDiscard(anno_region.end);
                         try fmt.ensureNewline();
                         fmt.curr_indent += 1;
                         try fmt.pushIndent();
                     }
-                    try fmt.formatWhereConstraint(w, multiline);
+                    try fmt.formatWhereConstraint(w, where_multiline);
                 }
             },
             .expect => |e| {
@@ -4036,6 +4038,12 @@ test "function type expands when its return type is multiline" {
         "(() -> d) -> (\n" ++
         "\tc,\n" ++
         ")\n", result);
+}
+
+test "issue 10335: where clause formatting is idempotent" {
+    // Repro for https://github.com/roc-lang/roc/issues/10335
+    const result = try moduleFmtsStable(std.testing.allocator, "g:e->e where[e.B,]h=||{{([])}}", false);
+    defer std.testing.allocator.free(result);
 }
 
 test "issue 10140: nested record function type formatting is idempotent" {

--- a/test/snapshots/formatting/singleline_with_comma/everything.md
+++ b/test/snapshots/formatting/singleline_with_comma/everything.md
@@ -413,27 +413,29 @@ import I2 exposing [
 ]
 
 # Where constraint
-A(a) : a where [
-	a.a1 : (
-		a,
-		a,
-	) -> Str,
-	a.a2 : (
-		a,
-		a,
-	) -> Str,
-]
+A(a) : a
+	where [
+		a.a1 : (
+			a,
+			a,
+		) -> Str,
+		a.a2 : (
+			a,
+			a,
+		) -> Str,
+	]
 
-B(b) : b where [
-	b.b1 : (
-		b,
-		b,
-	) -> Str,
-	b.b2 : (
-		b,
-		b,
-	) -> Str,
-]
+B(b) : b
+	where [
+		b.b1 : (
+			b,
+			b,
+		) -> Str,
+		b.b2 : (
+			b,
+			b,
+		) -> Str,
+	]
 
 C(
 	a,
@@ -461,10 +463,11 @@ F : [
 	B,
 ]
 
-g : e -> e where [
-	e.A,
-	e.B,
-]
+g : e -> e
+	where [
+		e.A,
+		e.B,
+	]
 
 h = |
 	x,


### PR DESCRIPTION
Fixes instability when formatting type annotations and type declarations containing multiline where clauses.
Previously multiline checks relied solely on original source line counts rather than checking whether the where clause collection itself expands multiline, causing formatting to shift on the second pass.

Fixes #10335