### PR TITLE
Fix single quote literals emitting defaulted warning

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -189,6 +189,8 @@ builtin_types_copied: bool,
 ident_to_var_map: std.AutoHashMap(Ident.Idx, Var),
 /// Interpolation constraint function vars whose custom part checks have already run.
 checked_interpolation_part_constraints: std.AutoHashMap(Var, void),
+/// Vars that originated as single-quote (.int_unbound) literals.
+int_unbound_vars: std.AutoHashMap(Var, void),
 /// Dispatcher/method pairs already reported by `reportConstraintError`, so a
 /// constraint failing in multiple passes (or reachable through several aliased
 /// type variables) is reported once.
@@ -1510,6 +1512,7 @@ fn initAssumePrepared(
         .builtin_types_copied = false,
         .ident_to_var_map = std.AutoHashMap(Ident.Idx, Var).init(gpa),
         .checked_interpolation_part_constraints = std.AutoHashMap(Var, void).init(gpa),
+        .int_unbound_vars = std.AutoHashMap(Var, void).init(gpa),
         .reported_constraint_errors = std.AutoHashMap(ReportedConstraintError, void).init(gpa),
         .rejected_static_dispatches = rejected_static_dispatches,
         .reported_effectful_expect = std.AutoHashMap(Var, void).init(gpa),
@@ -1651,6 +1654,7 @@ pub fn deinit(self: *Self) void {
     self.imported_method_scheme_by_source.deinit(self.gpa);
     self.ident_to_var_map.deinit();
     self.checked_interpolation_part_constraints.deinit();
+    self.int_unbound_vars.deinit();
     self.reported_constraint_errors.deinit();
     self.rejected_static_dispatches.deinit();
     self.reported_effectful_expect.deinit();
@@ -4927,8 +4931,24 @@ fn checkNumeralLiteral(
     const suffix_target = self.cir.numericSuffixTargetForNode(node_idx);
     const literal = self.recordedNumeralLiteralForNode(node_idx);
     var num_literal_info = try self.exactNumeralInfoForLiteral(literal, region);
+    const is_int_unbound = switch (occurrence) {
+        .expression => blk: {
+            const expr_idx: CIR.Expr.Idx = @enumFromInt(@intFromEnum(node_idx));
+            const expr = self.cir.store.getExpr(expr_idx);
+            break :blk expr == .e_num and expr.e_num.kind == .int_unbound;
+        },
+        .pattern => blk: {
+            const pat_idx: CIR.Pattern.Idx = @enumFromInt(@intFromEnum(node_idx));
+            const pat = self.cir.store.getPattern(pat_idx);
+            break :blk pat == .num_literal and pat.num_literal.kind == .int_unbound;
+        },
+    };
+
     num_literal_info.explicit_suffix = suffix_target != null;
     const flex_var = try self.mkFlexWithFromNumeralConstraint(node_idx, num_literal_info, env);
+    if (is_int_unbound) {
+        try self.int_unbound_vars.put(self.types.resolveVar(flex_var).var_, {});
+    }
 
     if (suffix_target) |target| {
         try self.unifyLiteralWithSuffixTarget(flex_var, target, region, env);
@@ -18242,8 +18262,16 @@ const PendingBoundaryWarning = struct {
 /// still flex, with `boundary_reachable_vars` populated for the current
 /// boundary.
 fn boundaryWarningBeforeCommit(self: *Self, literal_root: Var) std.mem.Allocator.Error!PendingBoundaryWarning {
+    const root_var = self.types.resolveVar(literal_root).var_;
+    const is_int_unbound = blk: {
+        var iter = self.int_unbound_vars.keyIterator();
+        while (iter.next()) |var_ptr| {
+            if (self.types.resolveVar(var_ptr.*).var_ == root_var) break :blk true;
+        }
+        break :blk false;
+    };
     return .{
-        .leaks_into_signature = try self.boundaryDefaultLeaksIntoSignature(literal_root),
+        .leaks_into_signature = if (is_int_unbound) false else try self.boundaryDefaultLeaksIntoSignature(literal_root),
         .region = self.literalSourceRegion(literal_root) orelse self.getRegionAt(literal_root),
         // Every commit path only reaches here for a var with literal-conversion
         // provenance, and the var is still flex pre-commit, so the kind is

--- a/src/check/test/type_checking_integration.zig
+++ b/src/check/test/type_checking_integration.zig
@@ -264,6 +264,27 @@ test "check type - numeral defaulting candidate order - integer-only method comm
     } }, "I64 -> I64");
 }
 
+test "issue 10296: single quote literals do not emit defaulted warning" {
+    const source =
+        \\x = || 'M' == 'M'
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "({}) -> Bool");
+}
+
+test "issue 10296: single quote literal compared to number literal without warning" {
+    const source =
+        \\y = || 'M' == 1
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "({}) -> Bool");
+}
+
+test "issue 10296: single quote literal compared to fractional number without warning" {
+    const source =
+        \\z = || 'M' == 1.5
+    ;
+    try checkTypesModule(source, .{ .pass = .last_def }, "({}) -> Bool");
+}
+
 test "check type - is_eq operands must have same type - I64 eq I32 should fail" {
     const source =
         \\a : I64


### PR DESCRIPTION
Suppresses the LITERAL DEFAULTED warning for single-quoted character/code unit literals when defaulting, allowing them to be compared with any numeric type without warnings.

Fixes #10296