### PR TITLE
Fix order dependent container join field matching

### DIFF
--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -124,6 +124,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10271_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10395_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10508_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10503_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));
     std.testing.refAllDecls(@import("test/platform_box_update_lir_test.zig"));

--- a/src/compile/test/issue_10503_test.zig
+++ b/src/compile/test/issue_10503_test.zig
@@ -1,0 +1,41 @@
+//! Regression test for issue #10503.
+
+const expectLowersToLir = @import("lower_to_lir_harness.zig").expectLowersToLir;
+
+test "issue 10503: container join received records with different field order" {
+    try expectLowersToLir(
+        \\Node := [
+        \\    Leaf,
+        \\    NodeGroup({ inner : Node, val : U64, mode : [Cap] }),
+        \\].{
+        \\    is_eq : _
+        \\}
+        \\
+        \\State : {
+        \\    items : List(Op),
+        \\    count : U64,
+        \\}
+        \\
+        \\Op := [Step].{ is_eq : _ }
+        \\
+        \\build : Node -> State
+        \\build = |node| {
+        \\    match node {
+        \\        Leaf => { items: [], count: 0 }
+        \\        NodeGroup(g) => build_group({ items: [], count: 0 }, g)
+        \\    }
+        \\}
+        \\
+        \\build_group : State, { inner : Node, val : U64, mode : [Cap] } -> State
+        \\build_group = |st, { inner, val: _, mode: Cap }| {
+        \\    s1 = build(inner)
+        \\    { ..s1, items: List.append(st.items, Step) }
+        \\}
+        \\
+        \\main! = |_| {
+        \\    g = { inner: Leaf, val: 0, mode: Cap }
+        \\    st = build(NodeGroup(g))
+        \\    if st.count == 0 { Ok({}) } else { Err(Exit(1)) }
+        \\}
+    );
+}

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -2472,8 +2472,16 @@ pub const InstGraph = struct {
                     if (public_row.fields.len != request_row.fields.len) {
                         Common.invariant("request container join received records with different field counts");
                     }
-                    for (public_row.fields, request_row.fields) |public_field, request_field| {
-                        if (!Ident.textEql(self.fieldLabelText(public_field.name), self.fieldLabelText(request_field.name))) {
+                    for (public_row.fields) |public_field| {
+                        const wanted = self.fieldLabelText(public_field.name);
+                        var found = false;
+                        for (request_row.fields) |request_field| {
+                            if (Ident.textEql(wanted, self.fieldLabelText(request_field.name))) {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found) {
                             Common.invariant("request container join received records with different fields");
                         }
                     }
@@ -2487,10 +2495,18 @@ pub const InstGraph = struct {
                     if (public_row.tags.len != request_row.tags.len) {
                         Common.invariant("request container join received tag unions with different tag counts");
                     }
-                    for (public_row.tags, request_row.tags) |public_tag, request_tag| {
-                        if (!Ident.textEql(self.tagLabelText(public_tag.name), self.tagLabelText(request_tag.name)) or
-                            public_tag.payloads.len != request_tag.payloads.len)
-                        {
+                    for (public_row.tags) |public_tag| {
+                        const wanted = self.tagLabelText(public_tag.name);
+                        var found = false;
+                        for (request_row.tags) |request_tag| {
+                            if (Ident.textEql(wanted, self.tagLabelText(request_tag.name)) and
+                                public_tag.payloads.len == request_tag.payloads.len)
+                            {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found) {
                             Common.invariant("request container join received tag unions with different tags");
                         }
                     }


### PR DESCRIPTION
Uses label-based matching for record fields and tag variants in joinRelatedRequestContainer instead of positional array indexing.

Fixes #10503