### PR TITLE
Build the roc binary for baseline x86-64

### DIFF
--- a/.github/workflows/ci_zig.yml
+++ b/.github/workflows/ci_zig.yml
@@ -284,7 +284,7 @@ jobs:
       matrix:
         include:
           - os: macos-15-intel
-            cpu_flag: -Dcpu=x86_64_v3
+            cpu_flag: ''
             target_flag: ''
             release_jobs_flag: ''
             zig_test_timeout_flag: ''
@@ -304,12 +304,12 @@ jobs:
             release_jobs_flag: -j2  # Avoid hosted ARM runner disconnects under ReleaseFast parallelism.
             zig_test_timeout_flag: ''
           - os: windows-2022
-            cpu_flag: -Dcpu=x86_64_v3
+            cpu_flag: ''
             target_flag: ''
             release_jobs_flag: ''
             zig_test_timeout_flag: --test-timeout 5m
           - os: windows-2025
-            cpu_flag: -Dcpu=x86_64_v3
+            cpu_flag: ''
             target_flag: ''
             release_jobs_flag: ''
             zig_test_timeout_flag: --test-timeout 5m
@@ -524,7 +524,7 @@ jobs:
           # entries on the full build configuration, so the valgrind build
           # (-Dvalgrind=true, musl target, ReleaseFast) hashes to different
           # entries than any other job's and cannot pick up stale artifacts.
-          command: git clean -fdx -e .zig-cache && zig build -Dvalgrind=true -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast -Dcpu=x86_64_v3 -Dtarget=x86_64-linux-musl -Dstrip=false -Dshared-memory-size=268435456
+          command: git clean -fdx -e .zig-cache && zig build -Dvalgrind=true -Dfuzz -Dsystem-afl=false -Doptimize=ReleaseFast -Dtarget=x86_64-linux-musl -Dstrip=false -Dshared-memory-size=268435456
           retry_count: 3
 
       - name: install valgrind

--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -22,6 +22,28 @@ buildcmd
 ./zig-out/bin/roc version
 ```
 
+## CPU requirements
+
+Builds target the baseline instruction set for their architecture, so the `roc`
+binary you build runs on any CPU of that architecture: baseline x86-64 (2003) or
+armv8.0-a. You do not need to pick a build for your specific CPU.
+
+To trade that portability for speed on a machine you know, pass `-Dcpu`:
+
+```
+zig build build-release -Dcpu=x86_64_v3   # AVX2, BMI2, FMA: Haswell (2013) and later, any AMD Zen
+zig build build-release -Dcpu=native      # this exact machine; the result may not run elsewhere
+```
+
+`zig build -Dcpu=...` works the same way for non-release builds. `zig build --help`
+lists the CPU names Zig accepts.
+
+A binary built for a CPU level above the one it runs on dies with `Illegal
+instruction` (SIGILL) at startup, before printing anything.
+
+This is the CPU level of the `roc` binary itself. The CPU level that compiled
+Roc *programs* target is a separate setting with its own floor.
+
 ## Windows Notes
 
 Due to a [Zig bug](https://github.com/ziglang/zig/issues/17652) related to extracting dependencies from tarball files containing symlinks (which is not allowed by default on Windows), you might encounter permission denial issues. The workaround is to enable the `Developer Mode` option on Windows, which could be found under `Settings > System > Advanced`. If that does not work, please review the aforementioned bug for any additional clues.

--- a/build.zig
+++ b/build.zig
@@ -157,30 +157,63 @@ fn withRocMacosDeploymentTarget(b: *std.Build, target: ResolvedTarget) ResolvedT
     return b.resolveTargetQuery(roc_target.macos_deployment.query(target.result.cpu.arch));
 }
 
-/// Returns the optimal target query for release builds on the current host.
+/// Returns the target query for release builds on the current host.
+///
+/// `-Dtarget` and `-Dcpu` select the release target, so a packager can trade
+/// portability for speed. With neither flag, the defaults are:
 /// - Linux: Uses musl for fully static binaries
-/// - x86_64: Uses x86_64_v3 for modern CPU features (AVX2, BMI2, etc.)
-/// - aarch64: Uses the baseline CPU so the binary runs on every aarch64 device
-fn getReleaseTargetQuery() std.Target.Query {
-    var query: std.Target.Query = .{};
+/// - x86_64 and aarch64: Uses the baseline CPU, so a single released binary
+///   runs on every CPU of that architecture
+///
+/// What that floor costs the parts of this binary which aren't declared as
+/// dependencies in build.zig.zon:
+///
+/// - Zig's standard library has no runtime CPU dispatch anywhere. Its vector
+///   width is picked at comptime by `std.simd.suggestVectorLength` from
+///   `builtin.cpu`: SSE gives 128 bits, AVX2 gives 256, AVX-512 gives 512. So a
+///   baseline build halves the width used by `std.mem`, `std.unicode`,
+///   `std.crypto.blake3` (which is what `roc bundle` hashes with),
+///   `std.compress.flate`, and `std.http.HeadParser`. It does not make them
+///   scalar.
+/// - musl has no ifunc and no x86_64 string assembly, so it is unaffected.
+/// - compiler_rt has no dispatch and nothing above baseline to give up.
+/// - Roc's own code under src/ contains no `@Vector` and no `std.simd`, so the
+///   only thing a higher floor buys it is wider autovectorization.
+///
+/// build.zig.zon carries the same accounting for each declared dependency.
+fn getReleaseTargetQuery(b: *std.Build, target: ResolvedTarget) std.Target.Query {
+    // A `-Dtarget` triple names the entire target, ABI included, so it replaces
+    // every default below.
+    if (b.user_input_options.contains("target")) return target.query;
+
+    // `-Dcpu` names only the CPU, so it carries over onto the release ABI
+    // defaults rather than replacing them.
+    const explicit_cpu = b.user_input_options.contains("cpu");
+    var query: std.Target.Query = if (explicit_cpu) target.query else .{};
 
     // Use musl on Linux for static linking
     if (builtin.target.os.tag == .linux) {
         query.abi = .musl;
     }
 
-    // An otherwise-empty query means "native CPU", which bakes the build
-    // machine's CPU features into the released binary. Pin the CPU model
-    // explicitly so releases stay portable.
-    switch (builtin.target.cpu.arch) {
-        // Use x86_64_v3 CPU model for x86_64 (enables AVX2, BMI2, etc.)
-        .x86_64 => query.cpu_model = .{ .explicit = &std.Target.x86.cpu.x86_64_v3 },
-        // Baseline aarch64 is armv8.0-a, which every aarch64 device supports.
-        // Building natively on an armv9 CI runner emitted SVE (plus LSE and
-        // RCPC) instructions, which crashed with SIGILL on older phones and
-        // Raspberry Pis. On macOS, baseline is apple_m1, i.e. all Apple Silicon.
-        .aarch64 => query.cpu_model = .baseline,
-        else => {},
+    if (!explicit_cpu) {
+        // An otherwise-empty query means "native CPU", which bakes the build
+        // machine's CPU features into the released binary. Pin the CPU model
+        // explicitly so releases stay portable.
+        switch (builtin.target.cpu.arch) {
+            // Baseline x86-64 is the 2003 instruction set, which every x86-64
+            // CPU supports. A higher floor makes the binary die of SIGILL
+            // before it can print anything on any CPU below that floor: pinning
+            // x86_64_v3 requires AVX2 and BMI2, which excludes Intel's Celeron
+            // and Pentium Silver lines along with everything pre-Haswell.
+            .x86_64 => query.cpu_model = .baseline,
+            // Baseline aarch64 is armv8.0-a, which every aarch64 device supports.
+            // Building natively on an armv9 CI runner emitted SVE (plus LSE and
+            // RCPC) instructions, which crashed with SIGILL on older phones and
+            // Raspberry Pis. On macOS, baseline is apple_m1, i.e. all Apple Silicon.
+            .aarch64 => query.cpu_model = .baseline,
+            else => {},
+        }
     }
 
     return query;
@@ -2634,11 +2667,13 @@ pub fn build(b: *std.Build) void {
             .abi = if (builtin.target.os.tag == .linux) .musl else null,
         };
 
-        // Use x86_64_v3 (AVX2, no AVX-512) for Valgrind compatibility.
-        // Valgrind 3.22 can't emulate AVX-512 EVEX instructions in musl startup code.
-        // This matches the release target (getReleaseTargetQuery) which also uses x86_64_v3.
+        // Pin baseline x86-64 instead of inheriting the build machine's CPU.
+        // This matches the release target (getReleaseTargetQuery), so a build
+        // from source runs everywhere a released binary does, and it keeps
+        // Valgrind working: Valgrind 3.22 can't emulate the AVX-512 EVEX
+        // instructions a native build emits into musl startup code.
         if (builtin.target.cpu.arch == .x86_64) {
-            default_target_query.cpu_model = .{ .explicit = &std.Target.x86.cpu.x86_64_v3 };
+            default_target_query.cpu_model = .baseline;
         }
 
         break :blk b.standardTargetOptions(.{ .default_target = default_target_query });
@@ -3278,7 +3313,7 @@ pub fn build(b: *std.Build) void {
 
     // Release build with platform-optimal settings
     {
-        const release_target = b.resolveTargetQuery(getReleaseTargetQuery());
+        const release_target = b.resolveTargetQuery(getReleaseTargetQuery(b, target));
         // Create a release-specific zstd dependency with release settings
         const release_zstd = b.dependency("zstd", .{
             .target = release_target,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,12 +2,52 @@
     .name = .roc,
     .version = "0.0.0",
     .minimum_zig_version = "0.16.0",
+    // CPU baseline notes for each dependency.
+    //
+    // Dependencies fall into two groups that behave differently under `-Dcpu`:
+    //
+    //   Prebuilt (`roc_deps_*`) arrive as compiled archives, so `-Dcpu` cannot
+    //   reach them. They run at whatever CPU floor roc-lang/roc-bootstrap built
+    //   them at.
+    //
+    //   From source (`bytebox`, `zstd`) are compiled by us against the selected
+    //   target, so they inherit `-Dcpu` exactly.
+    //
+    // Within both groups, what matters is whether a dependency does runtime CPU
+    // dispatch: run cpuid, then call one of several implementations that were
+    // each compiled at a different instruction set level. A dependency that
+    // dispatches keeps its fast paths on new CPUs while still starting on old
+    // ones, so lowering `-Dcpu` costs it nothing. A dependency that does not
+    // dispatch runs at its compiled-in floor everywhere. Each entry below
+    // records which it is, because that is what decides the cost of a lower
+    // floor.
+    //
+    // Verified by disassembling the x86_64-linux-musl archives on 2026-08-02.
+    // Re-check when bumping a dependency.
     .dependencies = .{
+        // Fuzzing only, and lazy, so it never reaches a release binary.
         .afl_kit = .{
             .url = "https://github.com/bhansconnect/zig-afl-kit/archive/c1f7353e006cf326ffab0a35b6e454cb5d8a5d7b.tar.gz",
             .hash = "afl_kit-0.1.0-NdJ3csgfAABGuiQ4P99kFuaVSy4DHMilISiGF_VKX3xl",
             .lazy = true,
         },
+        // The `roc_deps_*` archives below carry prebuilt LLVM, LLD, Binaryen and
+        // zlib. Every one of those libraries is plain baseline x86-64 except
+        // LLVM's vendored BLAKE3, which does textbook runtime dispatch:
+        // `blake3_dispatch.c` runs cpuid/xgetbv, caches the answer in
+        // `g_cpu_features`, and selects among portable/sse2/sse41/avx2/avx512
+        // implementations, so no above-baseline instruction is reachable unless
+        // its feature check passed. LLD, Binaryen and zlib contain no SIMD at
+        // all, so they have nothing to dispatch and give up nothing by running
+        // at baseline.
+        //
+        // These archives also ship a libzstd, but roc does not link it: only
+        // `z` is linked by name from these prebuilts, and `llvm_libs` in
+        // build.zig does not name zstd. Roc's zstd is the source dependency
+        // below.
+        //
+        // Net effect: these stay correct on any CPU of their architecture no
+        // matter which `-Dcpu` roc itself is built with.
         .roc_deps_aarch64_macos_none = .{
             .url = "https://github.com/roc-lang/roc-bootstrap/releases/download/zig-0.16.0-binaryen/aarch64-macos-none.tar.xz",
             .hash = "N-V-__8AAKS-VRH7JXsaDHpnFPSd-B5fSdtnDbh0XrfnncWc",
@@ -48,14 +88,31 @@
             .hash = "N-V-__8AADfFZhvsrNly3AbA2PmVP9piXKNto_CmeqLuNNsd",
             .lazy = true,
         },
+        // No runtime dispatch, and nothing that would benefit from it: every
+        // `@Vector` in bytebox implements wasm's fixed-128-bit `v128` semantics,
+        // which is already the natural SSE2 lowering. A lower `-Dcpu` costs it
+        // nothing.
         .bytebox = .{
             .url = "https://github.com/lukewilliamboswell/bytebox/archive/88a4b79230eece88030e6779f69ed9683906c02a.tar.gz",
             .hash = "bytebox-0.0.1-SXc2saRyDwDEw8AkDhp4Hfmd9ZhRmMnIzS7FfzDCmc8r",
         },
+        // Used for `roc bundle`, `roc unbundle`, and downloading .tar.zst bundles.
+        //
+        // zstd has runtime BMI2 dispatch, but it enables that dispatch only when
+        // BMI2 is *not* already on at compile time: `DYNAMIC_BMI2` in
+        // lib/common/portability_macros.h is gated on `!defined(__BMI2__)`.
+        //
+        // So building this at x86-64-v3 turns the dispatch off and hardcodes
+        // BMI2 into every entry point, while building at baseline or v2 compiles
+        // both variants and picks between them via zstd's own cpuid at runtime.
+        // Building it at v3 is therefore strictly worse than building it at
+        // baseline: it gives up portability without gaining any speed on the
+        // CPUs that do have BMI2.
         .zstd = .{
             .url = "https://github.com/allyourcodebase/zstd/archive/e1a501be57f42c541e8a5597e4b59a074dfd09a3.tar.gz", // 1.5.7-1
             .hash = "zstd-1.5.7-1-KEItkAMwAAD6OKY3m0OOmXG7aL-aLUfrDqbP5J5oYapU",
         },
+        // Coverage tooling only, and lazy, so it never reaches a release binary.
         .kcov = .{
             .url = "https://github.com/roc-lang/zig-kcov/archive/5e1954e53ce775a6ecf65abd03ae67deee64ac3c.tar.gz",
             .hash = "kcov-42.0.1-EuAG4XacCwBu0G8YHvv6sFHfbMPZuwyBuZGqcRMi8IXq",

--- a/typos.toml
+++ b/typos.toml
@@ -29,6 +29,7 @@ ANF = "ANF" # A-normal form
 ba = "ba" # Binop apply
 caf = "caf" # Part of the word "café"
 clos = "clos" # Closure
+flate = "flate" # Zig std module name for DEFLATE, as in std.compress.flate
 ful = "ful" # Suffix, as in "effectful"
 Paeth = "Paeth" # PNG filter named for Alan W. Paeth
 rela = "rela" # Relative


### PR DESCRIPTION
Roc's released x86-64 binary is built for the `x86_64_v3` CPU level, which requires AVX2 and BMI2, so on any CPU below that floor it dies of SIGILL before it can print anything. A user on Zulip hit this on an Intel Celeron N4020 with both the nightly tarball and an Alpine source build; the same failure covers Intel's Celeron and Pentium Silver lines and everything pre-Haswell. This pins baseline x86-64 for the release target and for the default build target, so one download runs on any x86-64 machine.

The `-Dcpu` escape hatch now actually works. `getReleaseTargetQuery` built its query from scratch and ignored the resolved target, so `zig build build-release -Dcpu=...` silently did nothing and there was no supported way to produce a release binary at a different floor. It now takes the resolved target: a `-Dtarget` triple replaces the release defaults outright, while `-Dcpu` layers onto them. That distinction matters because `standardTargetOptions` discards its `default_target` entirely as soon as any of `-Dtarget`/`-Dcpu`/`-Dofmt`/`-Ddynamic-linker` is set, so naively forwarding the resolved target would have dropped the musl default and shipped a glibc-linked "static" release. Anyone who wants the faster non-portable build can now ask for it with `-Dcpu=x86_64_v3` or `-Dcpu=native`.

Baseline costs less than it looks like it should, and build.zig.zon now records why for each dependency, because the answer turns on whether a dependency does runtime CPU dispatch rather than on the flag we pass it. The prebuilt roc-bootstrap archives are unaffected by `-Dcpu` and are already baseline: LLVM's vendored BLAKE3 runs cpuid/xgetbv and selects among portable/sse2/sse41/avx2/avx512 implementations, while LLD, Binaryen and zlib contain no SIMD at all. Of the dependencies we compile ourselves, bytebox has nothing to give up (its vectors are wasm's fixed-128-bit `v128` semantics, already the natural SSE2 lowering), and zstd is the interesting case: it gates `DYNAMIC_BMI2` on `!defined(__BMI2__)`, so compiling it at v3 *disables* its runtime BMI2 dispatch and hardcodes BMI2 into every entry point. Building zstd at v3 was therefore strictly worse than baseline — it gave up portability without buying speed on the CPUs that do have BMI2.

The one real cost is Zig's standard library, which has no runtime dispatch anywhere: `std.simd.suggestVectorLength` picks vector width at comptime from `builtin.cpu`, so baseline halves it from 256 to 128 bits in `std.mem`, `std.unicode`, `std.crypto.blake3`, `std.compress.flate` and `std.http.HeadParser`. Those routines stay vectorized, just narrower. Roc's own code under src/ contains no `@Vector` and no `std.simd`, so the only other thing a higher floor buys is wider autovectorization. That accounting lives next to `getReleaseTargetQuery`.

CI's per-OS `-Dcpu=x86_64_v3` pins are cleared so the matrix exercises the floor we actually ship; the `cpu_flag` column stays in place as a per-OS knob. The Valgrind constraint that motivated pinning a level is preserved, since it only requires staying below AVX-512.

Two things deliberately left alone. This changes nothing about the CPU level that compiled Roc *programs* target, which is a separate project. And `getReleaseTargetQuery` still leaves architectures other than x86-64 and aarch64 resolving to the native CPU, which is the same latent trap on any arch we start releasing for.

Worth noting for review: the published nightly is built in roc-lang/nightlies (`.github/workflows/nightly_new_compiler_all_os.yml:233`) by plain `zig build build-release`, so it picks up this default with no change needed there.
