### PR TITLE
Handle unbound annotations in nominal type templates

### DIFF
--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -5145,8 +5145,8 @@ fn appendCheckedTypeRootFromDeclarationAnno(
             },
             .builtin,
             .external,
+            .pending,
             => try appendCheckedTypeRoot(allocator, module, names, imports, store, active, ModuleEnv.varFrom(anno_idx)),
-            .pending => checkedArtifactInvariant("checked declaration template still contained pending lookup", .{}),
         },
         .apply => |apply| blk: {
             const actual_args = try checkedTypeIdsFromDeclarationAnnoSpan(
@@ -5203,6 +5203,7 @@ fn appendCheckedTypeRootFromDeclarationAnno(
                 },
                 .builtin,
                 .external,
+                .pending,
                 => {
                     const generic_root = try appendCheckedTypeRoot(
                         allocator,
@@ -5229,7 +5230,6 @@ fn appendCheckedTypeRootFromDeclarationAnno(
                     }
                     break :blk result;
                 },
-                .pending => checkedArtifactInvariant("checked declaration template still contained pending apply", .{}),
             }
             if (actual_args_owned) {
                 allocator.free(actual_args);
@@ -5253,7 +5253,7 @@ fn appendCheckedTypeRootFromDeclarationAnno(
         },
         .tag,
         .malformed,
-        => checkedArtifactInvariant("nominal declaration annotation was not a valid checked template", .{}),
+        => try appendCheckedTypeRoot(allocator, module, names, imports, store, active, ModuleEnv.varFrom(anno_idx)),
     };
 }
 

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -3619,6 +3619,18 @@ fn expectEscapingIterChainAllocatesNothing(source: []const u8) TestError!void {
     try expectLoweredIterChainAllocatesNothing(allocator, &optimized.lowered);
 }
 
+test "issue 10348 nominal declaration with unbound annotation does not panic" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\main : {}
+        \\main = {}
+        \\M := { f : I }
+    ;
+
+    var lowered = try lowerModule(allocator, source, .wrappers);
+    defer lowered.deinit(allocator);
+}
+
 test "iter alloc static: iterator returned from a function is zero-alloc" {
     try expectEscapingIterChainAllocatesNothing(
         \\consume : Iter(U64) -> U64


### PR DESCRIPTION
When a nominal type declaration contains an unbound or malformed type annotation, constructing checked artifacts for the module panicked on invalid declaration templates instead of publishing an error type root.
This PR routes unresolved type annotations in nominal templates to standard type root publication so checked artifact creation succeeds gracefully when user type errors exist.

Fixes #10348