### PR TITLE
Check for error diagnostics before lowering inspected programs to LIR

### DIFF
--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -7022,3 +7022,15 @@ test "SpecConstr rewrites nested match breaks with the selected loop exit ABI" {
     var lowered = try lowerModule(allocator, source, .wrappers);
     defer lowered.deinit(allocator);
 }
+
+test "issue 10354 undefined identifier in expression does not panic monotype lowering" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\undefined
+    ;
+
+    _ = lowerModule(allocator, source, .wrappers) catch |err| switch (err) {
+        error.TypeCheckError, error.ParseError => {},
+        else => return err,
+    };
+}

--- a/src/eval/test_helpers.zig
+++ b/src/eval/test_helpers.zig
@@ -1006,6 +1006,10 @@ fn compileInspectedProgramForTargetImpl(
     );
     errdefer cleanupParseAndCanonical(allocator, resources);
 
+    if (try parsedResourcesHaveErrorDiagnostics(allocator, &resources)) {
+        return error.TypeCheckError;
+    }
+
     const lowered = try lowerParsedProgramToLir(allocator, io, &resources, target_usize);
     errdefer {
         var owned = lowered;


### PR DESCRIPTION
When compiling an interactive or inspected program for evaluation, the evaluation helper invoked LIR lowering unconditionally even when checking produced error-severity diagnostics. Because error-containing programs produce no valid executable roots, postcheck lowering panicked.
This PR checks for error-severity diagnostics before attempting LIR lowering and returns a type check error to allow callers to render clean diagnostics.

Fixes #10354