### PR TITLE
Fix stale Lambda Solved span traversal

### DIFF
--- a/design.md
+++ b/design.md
@@ -3226,6 +3226,12 @@ Type-store ownership is explicit at each stage boundary:
   store.
 - LIR owns committed layouts, not post-check type ids.
 
+A mutable post-check type store exposes child spans as stable descriptors plus
+indexed item access, never as borrowed slices. Appending while lazily expanding
+a recursive type may relocate a packed side array, but its descriptors remain
+valid. Raw slice access belongs only to immutable stage views, where relocation
+is impossible and consumers retain packed-array iteration performance.
+
 A later stage must not reinterpret an earlier stage's type ids unless the stage
 contract says the type store is shared. When a stage changes type meaning, it
 consumes the earlier program and produces a new program whose ids are meaningful

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -958,6 +958,9 @@ const subcommand_cases = [_]CliCase{
     // Repro for https://github.com/roc-lang/roc/issues/10502: recursive,
     // parameterized nominals with annotated polymorphic methods check cleanly.
     .{ .id = 0, .suite = .subcommands, .name = "issue 10502: recursive generic nominal method checks cleanly", .timeout_ms = 10_000, .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10502_recursive_generic_nominal_map/Bar.roc", .exit = .success, .contains_any = &.{.{ .needles = &no_errors_needles }}, .not_contains = &.{ .{ .stream = .stderr, .text = "overflowed its stack" }, .{ .stream = .stderr, .text = "panic" } } } } },
+    // Repro for https://github.com/roc-lang/roc/issues/10520: callable payloads
+    // inside a concrete recursive parameterized nominal check cleanly.
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10520: recursive nominal callable payloads check cleanly", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10520_recursive_nominal_tag_callable_check.roc", .exit = .success, .contains_any = &.{.{ .needles = &no_errors_needles }}, .not_contains = &.{.{ .stream = .stderr, .text = "panic" }} } } },
     // Repro for https://github.com/roc-lang/roc/issues/10303: mutually
     // recursive function-containing values must finish Monotype lowering.
     .{ .id = 0, .suite = .subcommands, .name = "issue 10303: mutually recursive function values check cleanly", .timeout_ms = 10_000, .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10303_recursive_function_values.roc", .exit = .success, .contains_any = &.{.{ .needles = &no_errors_needles }} } } },

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -378,7 +378,8 @@ const Solver = struct {
             .func => |func| func,
             else => Common.invariant("Lambda Solved ABI boundary referenced a non-function"),
         };
-        for (self.program.types.span(func.args)) |arg| {
+        for (0..func.args.count()) |index| {
+            const arg = self.program.types.spanItem(func.args, index);
             try self.markErasedCallablesReachedByType(arg);
         }
         try self.markErasedCallablesReachedByType(func.ret);
@@ -412,13 +413,13 @@ const Solver = struct {
         active: []bool,
     ) Allocator.Error!void {
         const root = self.program.types.rootCompressed(ty);
-        const index = @intFromEnum(root);
-        if (done[index] or active[index]) return;
+        const root_index = @intFromEnum(root);
+        if (done[root_index] or active[root_index]) return;
 
-        active[index] = true;
+        active[root_index] = true;
         defer {
-            active[index] = false;
-            done[index] = true;
+            active[root_index] = false;
+            done[root_index] = true;
         }
 
         switch (self.program.types.get(root)) {
@@ -434,7 +435,8 @@ const Solver = struct {
             => {},
             .func => |func| {
                 try self.closeCallableSlot(func.callable, done, active);
-                for (self.program.types.span(func.args)) |arg| {
+                for (0..func.args.count()) |arg_index| {
+                    const arg = self.program.types.spanItem(func.args, arg_index);
                     try self.closeCallableSlotsInType(arg, done, active);
                 }
                 try self.closeCallableSlotsInType(func.ret, done, active);
@@ -442,24 +444,29 @@ const Solver = struct {
             .list => |elem| try self.closeCallableSlotsInType(elem, done, active),
             .box => |elem| try self.closeCallableSlotsInType(elem, done, active),
             .tuple => |items| {
-                for (self.program.types.span(items)) |item| {
+                for (0..items.count()) |index| {
+                    const item = self.program.types.spanItem(items, index);
                     try self.closeCallableSlotsInType(item, done, active);
                 }
             },
             .record => |fields| {
-                for (self.program.types.fieldSpan(fields)) |field| {
+                for (0..fields.count()) |index| {
+                    const field = self.program.types.fieldItem(fields, index);
                     try self.closeCallableSlotsInType(field.ty, done, active);
                 }
             },
             .tag_union => |tags| {
-                for (self.program.types.tagSpan(tags)) |tag| {
-                    for (self.program.types.span(tag.payloads)) |payload| {
+                for (0..tags.count()) |tag_index| {
+                    const tag = self.program.types.tagItem(tags, tag_index);
+                    for (0..tag.payloads.count()) |payload_index| {
+                        const payload = self.program.types.spanItem(tag.payloads, payload_index);
                         try self.closeCallableSlotsInType(payload, done, active);
                     }
                 }
             },
             .named => |named| {
-                for (self.program.types.span(named.args)) |arg| {
+                for (0..named.args.count()) |index| {
+                    const arg = self.program.types.spanItem(named.args, index);
                     try self.closeCallableSlotsInType(arg, done, active);
                 }
                 if (named.backing) |backing| {
@@ -493,8 +500,10 @@ const Solver = struct {
         done: []bool,
         active: []bool,
     ) Allocator.Error!void {
-        for (self.program.types.memberSpan(members)) |member| {
-            for (self.program.types.captureSpan(member.captures)) |capture| {
+        for (0..members.count()) |member_index| {
+            const member = self.program.types.memberItem(members, member_index);
+            for (0..member.captures.count()) |capture_index| {
+                const capture = self.program.types.captureItem(member.captures, capture_index);
                 try self.closeCallableSlotsInType(capture.ty, done, active);
             }
         }
@@ -678,15 +687,15 @@ const Solver = struct {
             .try_sequence => |sequence| {
                 const try_ty = try self.inferExpr(sequence.try_expr);
                 const tags = switch (try self.shapeContent(try_ty)) {
-                    .tag_union => |span| self.program.types.tagSpan(span),
+                    .tag_union => |span| span,
                     else => Common.invariant("try_sequence input was not a Try tag union"),
                 };
                 var ok_ty: ?Type.TypeVarId = null;
-                for (tags) |tag| {
+                for (0..tags.count()) |tag_index| {
+                    const tag = self.program.types.tagItem(tags, tag_index);
                     if (!std.mem.eql(u8, self.lifted.names.tagLabelText(tag.name), "Ok")) continue;
-                    const payloads = self.program.types.span(tag.payloads);
-                    if (payloads.len != 1) Common.invariant("try_sequence Ok tag had unexpected payload arity");
-                    ok_ty = payloads[0];
+                    if (tag.payloads.count() != 1) Common.invariant("try_sequence Ok tag had unexpected payload arity");
+                    ok_ty = self.program.types.spanItem(tag.payloads, 0);
                     break;
                 }
                 try self.unify(self.localTy(sequence.ok_local), ok_ty orelse Common.invariant("try_sequence input had no Ok tag"));
@@ -695,15 +704,15 @@ const Solver = struct {
             .try_record_sequence => |sequence| {
                 const try_ty = try self.inferExpr(sequence.try_expr);
                 const tags = switch (try self.shapeContent(try_ty)) {
-                    .tag_union => |span| self.program.types.tagSpan(span),
+                    .tag_union => |span| span,
                     else => Common.invariant("try_record_sequence input was not a Try tag union"),
                 };
                 var ok_ty: ?Type.TypeVarId = null;
-                for (tags) |tag| {
+                for (0..tags.count()) |tag_index| {
+                    const tag = self.program.types.tagItem(tags, tag_index);
                     if (!std.mem.eql(u8, self.lifted.names.tagLabelText(tag.name), "Ok")) continue;
-                    const payloads = self.program.types.span(tag.payloads);
-                    if (payloads.len != 1) Common.invariant("try_record_sequence Ok tag had unexpected payload arity");
-                    ok_ty = payloads[0];
+                    if (tag.payloads.count() != 1) Common.invariant("try_record_sequence Ok tag had unexpected payload arity");
+                    ok_ty = self.program.types.spanItem(tag.payloads, 0);
                     break;
                 }
                 const ok_record_ty = ok_ty orelse Common.invariant("try_record_sequence input had no Ok tag");
@@ -1110,20 +1119,15 @@ const Solver = struct {
             .mono => Common.invariant("lazy Monotype leaf reached erased-callable marking unexpanded"),
             .link => Common.invariant("Lambda Solved root returned a link"),
             .unbound, .forall, .primitive, .zst => {},
-            .erased => |erased| {
-                for (self.program.types.memberSpan(erased.members)) |member| {
-                    for (self.program.types.captureSpan(member.captures)) |capture| {
-                        try self.markErasedCallablesReachedByTypeInner(capture.ty, active);
-                    }
-                }
-            },
+            .erased => |erased| try self.markErasedCallablesReachedByMembers(erased.members, active),
             .func => |func| {
                 const erased = try self.program.types.add(.{ .erased = .{
                     .source_fn_ty = try self.solvedTypeDigest(root),
                     .members = .empty(),
                 } });
                 try self.unify(func.callable, erased);
-                for (self.program.types.span(func.args)) |arg| {
+                for (0..func.args.count()) |index| {
+                    const arg = self.program.types.spanItem(func.args, index);
                     try self.markErasedCallablesReachedByTypeInner(arg, active);
                 }
                 try self.markErasedCallablesReachedByTypeInner(func.ret, active);
@@ -1131,37 +1135,50 @@ const Solver = struct {
             .list => |elem| try self.markErasedCallablesReachedByTypeInner(elem, active),
             .box => |elem| try self.markErasedCallablesReachedByTypeInner(elem, active),
             .tuple => |items| {
-                for (self.program.types.span(items)) |item| {
+                for (0..items.count()) |index| {
+                    const item = self.program.types.spanItem(items, index);
                     try self.markErasedCallablesReachedByTypeInner(item, active);
                 }
             },
             .record => |fields| {
-                for (self.program.types.fieldSpan(fields)) |field| {
+                for (0..fields.count()) |index| {
+                    const field = self.program.types.fieldItem(fields, index);
                     try self.markErasedCallablesReachedByTypeInner(field.ty, active);
                 }
             },
             .tag_union => |tags| {
-                for (self.program.types.tagSpan(tags)) |tag| {
-                    for (self.program.types.span(tag.payloads)) |payload| {
+                for (0..tags.count()) |tag_index| {
+                    const tag = self.program.types.tagItem(tags, tag_index);
+                    for (0..tag.payloads.count()) |payload_index| {
+                        const payload = self.program.types.spanItem(tag.payloads, payload_index);
                         try self.markErasedCallablesReachedByTypeInner(payload, active);
                     }
                 }
             },
             .named => |named| {
-                for (self.program.types.span(named.args)) |arg| {
+                for (0..named.args.count()) |index| {
+                    const arg = self.program.types.spanItem(named.args, index);
                     try self.markErasedCallablesReachedByTypeInner(arg, active);
                 }
                 if (named.backing) |backing| {
                     try self.markErasedCallablesReachedByTypeInner(backing.ty, active);
                 }
             },
-            .lambda_set => |members| {
-                for (self.program.types.memberSpan(members)) |member| {
-                    for (self.program.types.captureSpan(member.captures)) |capture| {
-                        try self.markErasedCallablesReachedByTypeInner(capture.ty, active);
-                    }
-                }
-            },
+            .lambda_set => |members| try self.markErasedCallablesReachedByMembers(members, active),
+        }
+    }
+
+    fn markErasedCallablesReachedByMembers(
+        self: *Solver,
+        members: Type.Span,
+        active: *std.AutoHashMap(Type.TypeVarId, void),
+    ) Allocator.Error!void {
+        for (0..members.count()) |member_index| {
+            const member = self.program.types.memberItem(members, member_index);
+            for (0..member.captures.count()) |capture_index| {
+                const capture = self.program.types.captureItem(member.captures, capture_index);
+                try self.markErasedCallablesReachedByTypeInner(capture.ty, active);
+            }
         }
     }
 
@@ -1248,34 +1265,45 @@ const Solver = struct {
                 },
                 .unbound, .forall, .primitive, .zst => {},
                 .list, .box => |elem| try work.append(self.allocator, elem),
-                .tuple => |items| try work.appendSlice(self.allocator, self.program.types.span(items)),
-                .record => |fields| for (self.program.types.fieldSpan(fields)) |field| {
-                    try work.append(self.allocator, field.ty);
+                .tuple => |items| for (0..items.count()) |index| {
+                    try work.append(self.allocator, self.program.types.spanItem(items, index));
                 },
-                .tag_union => |tags| for (self.program.types.tagSpan(tags)) |tag| {
-                    try work.appendSlice(self.allocator, self.program.types.span(tag.payloads));
+                .record => |fields| for (0..fields.count()) |index| {
+                    try work.append(self.allocator, self.program.types.fieldItem(fields, index).ty);
+                },
+                .tag_union => |tags| for (0..tags.count()) |tag_index| {
+                    const tag = self.program.types.tagItem(tags, tag_index);
+                    for (0..tag.payloads.count()) |payload_index| {
+                        try work.append(self.allocator, self.program.types.spanItem(tag.payloads, payload_index));
+                    }
                 },
                 .func => |func| {
-                    try work.appendSlice(self.allocator, self.program.types.span(func.args));
+                    for (0..func.args.count()) |index| {
+                        try work.append(self.allocator, self.program.types.spanItem(func.args, index));
+                    }
                     try work.append(self.allocator, func.callable);
                     try work.append(self.allocator, func.ret);
                 },
                 .named => |named| {
-                    try work.appendSlice(self.allocator, self.program.types.span(named.args));
+                    for (0..named.args.count()) |index| {
+                        try work.append(self.allocator, self.program.types.spanItem(named.args, index));
+                    }
                     if (named.backing) |backing| try work.append(self.allocator, backing.ty);
-                    for (self.program.types.declaredFieldSpan(named.declared_order)) |declared| switch (declared) {
+                    for (0..named.declared_order.count()) |index| switch (self.program.types.declaredFieldItem(named.declared_order, index)) {
                         .named => {},
                         .padding => |padding_ty| try work.append(self.allocator, padding_ty),
                     };
                 },
-                .lambda_set => |members| for (self.program.types.memberSpan(members)) |member| {
-                    for (self.program.types.captureSpan(member.captures)) |capture| {
-                        try work.append(self.allocator, capture.ty);
+                .lambda_set => |members| for (0..members.count()) |member_index| {
+                    const member = self.program.types.memberItem(members, member_index);
+                    for (0..member.captures.count()) |capture_index| {
+                        try work.append(self.allocator, self.program.types.captureItem(member.captures, capture_index).ty);
                     }
                 },
-                .erased => |erased| for (self.program.types.memberSpan(erased.members)) |member| {
-                    for (self.program.types.captureSpan(member.captures)) |capture| {
-                        try work.append(self.allocator, capture.ty);
+                .erased => |erased| for (0..erased.members.count()) |member_index| {
+                    const member = self.program.types.memberItem(erased.members, member_index);
+                    for (0..member.captures.count()) |capture_index| {
+                        try work.append(self.allocator, self.program.types.captureItem(member.captures, capture_index).ty);
                     }
                 },
             }
@@ -1311,7 +1339,8 @@ const Solver = struct {
     fn recordField(self: *Solver, ty: Type.TypeVarId, name: Type.names.RecordFieldNameId) Allocator.Error!Type.TypeVarId {
         return switch (try self.shapeContent(ty)) {
             .record => |fields| {
-                for (self.program.types.fieldSpan(fields)) |field| {
+                for (0..fields.count()) |index| {
+                    const field = self.program.types.fieldItem(fields, index);
                     if (field.name == name) return field.ty;
                 }
                 Common.invariant("record field was absent from checked record type");
@@ -1323,7 +1352,8 @@ const Solver = struct {
     fn recordFieldByLabel(self: *Solver, ty: Type.TypeVarId, label: []const u8) Allocator.Error!Type.TypeVarId {
         return switch (try self.shapeContent(ty)) {
             .record => |fields| {
-                for (self.program.types.fieldSpan(fields)) |field| {
+                for (0..fields.count()) |index| {
+                    const field = self.program.types.fieldItem(fields, index);
                     if (std.mem.eql(u8, self.lifted.names.recordFieldLabelText(field.name), label)) return field.ty;
                 }
                 Common.invariant("low-level record result was missing a required field");
@@ -1335,7 +1365,8 @@ const Solver = struct {
     fn tagPayloadsSpan(self: *Solver, ty: Type.TypeVarId, name: Type.names.TagNameId) Allocator.Error!Type.Span {
         return switch (try self.shapeContent(ty)) {
             .tag_union => |tags| {
-                for (self.program.types.tagSpan(tags)) |tag| {
+                for (0..tags.count()) |index| {
+                    const tag = self.program.types.tagItem(tags, index);
                     if (tag.name == name) {
                         return tag.payloads;
                     }
@@ -2398,18 +2429,18 @@ const Solver = struct {
             },
             .record => |fields| {
                 writeBytes(hasher, "record");
-                const field_slice = self.program.types.fieldSpan(fields);
-                writeU32(hasher, @intCast(field_slice.len));
-                for (field_slice) |field| {
+                writeU32(hasher, @intCast(fields.count()));
+                for (0..fields.count()) |index| {
+                    const field = self.program.types.fieldItem(fields, index);
                     writeBytes(hasher, self.lifted.names.recordFieldLabelText(field.name));
                     try self.writeSolvedTypeDigest(hasher, field.ty, active);
                 }
             },
             .tag_union => |tags| {
                 writeBytes(hasher, "tag_union");
-                const tag_slice = self.program.types.tagSpan(tags);
-                writeU32(hasher, @intCast(tag_slice.len));
-                for (tag_slice) |tag| {
+                writeU32(hasher, @intCast(tags.count()));
+                for (0..tags.count()) |index| {
+                    const tag = self.program.types.tagItem(tags, index);
                     writeBytes(hasher, self.lifted.names.tagLabelText(tag.name));
                     try self.writeSolvedTypeSpanDigest(hasher, tag.payloads, active);
                 }
@@ -2431,13 +2462,13 @@ const Solver = struct {
             },
             .lambda_set => |members| {
                 writeBytes(hasher, "lambda_set");
-                const member_slice = self.program.types.memberSpan(members);
-                writeU32(hasher, @intCast(member_slice.len));
-                for (member_slice) |member| {
+                writeU32(hasher, @intCast(members.count()));
+                for (0..members.count()) |member_index| {
+                    const member = self.program.types.memberItem(members, member_index);
                     writeU32(hasher, @intFromEnum(member.lambda));
-                    const captures = self.program.types.captureSpan(member.captures);
-                    writeU32(hasher, @intCast(captures.len));
-                    for (captures) |capture| {
+                    writeU32(hasher, @intCast(member.captures.count()));
+                    for (0..member.captures.count()) |capture_index| {
+                        const capture = self.program.types.captureItem(member.captures, capture_index);
                         writeU32(hasher, @intFromEnum(capture.symbol));
                         try self.writeSolvedTypeDigest(hasher, capture.ty, active);
                     }
@@ -2452,9 +2483,9 @@ const Solver = struct {
         span: Type.Span,
         active: *std.AutoHashMap(Type.TypeVarId, void),
     ) Allocator.Error!void {
-        const values = self.program.types.span(span);
-        writeU32(hasher, @intCast(values.len));
-        for (values) |child| {
+        writeU32(hasher, @intCast(span.count()));
+        for (0..span.count()) |index| {
+            const child = self.program.types.spanItem(span, index);
             try self.writeSolvedTypeDigest(hasher, child, active);
         }
     }

--- a/src/postcheck/lambda_solved/type.zig
+++ b/src/postcheck/lambda_solved/type.zig
@@ -274,17 +274,9 @@ pub const Store = struct {
         return .{ .start = start, .len = @intCast(values.len) };
     }
 
-    pub fn span(self: *const Store, span_: Span) []const TypeVarId {
-        return self.spans.items[span_.start..][0..span_.len];
-    }
-
     pub fn spanItem(self: *const Store, span_: Span, index: usize) TypeVarId {
         if (index >= span_.count()) Common.invariant("Lambda Solved type span index out of bounds");
         return self.spans.items[@as(usize, span_.start) + index];
-    }
-
-    pub fn fieldSpan(self: *const Store, span_: Span) []const Field {
-        return self.fields.items[span_.start..][0..span_.len];
     }
 
     pub fn addDeclaredFields(self: *Store, values: []const DeclaredField) std.mem.Allocator.Error!Span {
@@ -294,17 +286,14 @@ pub const Store = struct {
         return .{ .start = start, .len = @intCast(values.len) };
     }
 
-    pub fn declaredFieldSpan(self: *const Store, span_: Span) []const DeclaredField {
-        return self.declared_fields.items[span_.start..][0..span_.len];
-    }
-
     pub fn fieldItem(self: *const Store, span_: Span, index: usize) Field {
         if (index >= span_.count()) Common.invariant("Lambda Solved field span index out of bounds");
         return self.fields.items[@as(usize, span_.start) + index];
     }
 
-    pub fn tagSpan(self: *const Store, span_: Span) []const Tag {
-        return self.tags.items[span_.start..][0..span_.len];
+    pub fn declaredFieldItem(self: *const Store, span_: Span, index: usize) DeclaredField {
+        if (index >= span_.count()) Common.invariant("Lambda Solved declared-field span index out of bounds");
+        return self.declared_fields.items[@as(usize, span_.start) + index];
     }
 
     pub fn tagItem(self: *const Store, span_: Span, index: usize) Tag {
@@ -312,17 +301,9 @@ pub const Store = struct {
         return self.tags.items[@as(usize, span_.start) + index];
     }
 
-    pub fn captureSpan(self: *const Store, span_: Span) []const Capture {
-        return self.captures.items[span_.start..][0..span_.len];
-    }
-
     pub fn captureItem(self: *const Store, span_: Span, index: usize) Capture {
         if (index >= span_.count()) Common.invariant("Lambda Solved capture span index out of bounds");
         return self.captures.items[@as(usize, span_.start) + index];
-    }
-
-    pub fn memberSpan(self: *const Store, span_: Span) []const FnMember {
-        return self.fn_members.items[span_.start..][0..span_.len];
     }
 
     pub fn memberItem(self: *const Store, span_: Span, index: usize) FnMember {
@@ -416,7 +397,7 @@ test "lambda solved function types carry callable variables" {
     const function = store.get(fn_ty).func;
     try std.testing.expectEqual(callable, function.callable);
     try std.testing.expectEqual(ret, function.ret);
-    try std.testing.expectEqual(arg, store.span(function.args)[0]);
+    try std.testing.expectEqual(arg, store.spanItem(function.args, 0));
 }
 
 test "lambda solved type variable order uses the typed id helper" {

--- a/src/postcheck/solved_inline.zig
+++ b/src/postcheck/solved_inline.zig
@@ -71,6 +71,7 @@ const Decision = union(enum) {
 const WrapperAnalyzer = struct {
     allocator: std.mem.Allocator,
     solved: *const Solved.Program,
+    solved_types: SolvedType.Store.View,
     decisions: []Decision,
     stack: std.ArrayList(Lifted.FnId),
 
@@ -85,6 +86,7 @@ const WrapperAnalyzer = struct {
         var analyzer = WrapperAnalyzer{
             .allocator = allocator,
             .solved = solved,
+            .solved_types = solved.types.view(),
             .decisions = decisions,
             .stack = .empty,
         };
@@ -176,7 +178,7 @@ const WrapperAnalyzer = struct {
 
     fn solvedCaptureCount(self: *const WrapperAnalyzer, fn_id: Lifted.FnId) usize {
         const captures = self.solvedCapturesForFn(fn_id);
-        return self.solved.types.captureSpan(captures).len;
+        return self.solved_types.captureSpan(captures).len;
     }
 
     fn solvedCapturesForFn(self: *const WrapperAnalyzer, fn_id: Lifted.FnId) SolvedType.Span {
@@ -190,7 +192,7 @@ const WrapperAnalyzer = struct {
             .erased => |erased| erased.members,
             else => Common.invariant("callable value did not have a resolved callable slot"),
         };
-        for (self.solved.types.memberSpan(callable)) |member| {
+        for (self.solved_types.memberSpan(callable)) |member| {
             if (member.lambda == fn_symbol) return member.captures;
         }
         return .empty();

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -338,6 +338,7 @@ const TypedLiftedLocal = struct {
 const Lowerer = struct {
     allocator: std.mem.Allocator,
     solved: *const Solved.Program,
+    solved_types: SolvedType.Store.View,
     types: Type.Store,
     result: LirProgram.Result,
     runtime_schemas: RuntimeSchemaStore,
@@ -437,6 +438,7 @@ const Lowerer = struct {
         return .{
             .allocator = allocator,
             .solved = solved,
+            .solved_types = solved.types.view(),
             .types = Type.Store.init(allocator),
             .result = try LirProgram.Result.init(allocator, target_usize),
             .runtime_schemas = RuntimeSchemaStore.init(allocator),
@@ -756,7 +758,7 @@ const Lowerer = struct {
             .func => |func| func,
             else => Common.invariant("direct Lambda Mono function table contains a non-function type"),
         };
-        const solved_args = self.solved.types.span(func.args);
+        const solved_args = self.solved_types.span(func.args);
         const lifted_args = self.solved.lifted.typedLocalSpan(source_fn.args);
         if (solved_args.len != lifted_args.len) Common.invariant("direct Lambda Mono function arity changed after Lambda Solved");
         if (proc_args.len < lifted_args.len) Common.invariant("direct Lambda Mono proc placeholder had too few arguments");
@@ -889,7 +891,7 @@ const Lowerer = struct {
             .func => |func| func,
             else => Common.invariant("direct Lambda Mono function table contains a non-function type"),
         };
-        const solved_args = self.solved.types.span(func.args);
+        const solved_args = self.solved_types.span(func.args);
         const lifted_args = self.solved.lifted.typedLocalSpan(source_fn.args);
         if (solved_args.len != lifted_args.len) Common.invariant("direct Lambda Mono function arity changed after Lambda Solved");
 
@@ -995,7 +997,7 @@ const Lowerer = struct {
 
     fn captureSpan(self: *const Lowerer, span: CaptureSpanId) []const SolvedType.Capture {
         return switch (span.source) {
-            .solved => self.solved.types.captureSpan(.{ .start = span.start, .len = span.len }),
+            .solved => self.solved_types.captureSpan(.{ .start = span.start, .len = span.len }),
             .own => self.own_captures.items[span.start..][0..span.len],
         };
     }
@@ -1163,7 +1165,7 @@ const Lowerer = struct {
             .erased => |erased| erased.members,
             else => Common.invariant("function reference callable slot was unresolved before direct Lambda Mono"),
         };
-        for (self.solved.types.memberSpan(members)) |member| {
+        for (self.solved_types.memberSpan(members)) |member| {
             if (member.lambda == fn_symbol) return CaptureSpanId.fromSolved(member.captures);
         }
         Common.invariant("function reference callable slot did not contain referenced function");
@@ -1287,14 +1289,14 @@ const Lowerer = struct {
             .list => |elem| .{ .list = try self.lowerType(elem) },
             .box => |elem| .{ .box = try self.lowerType(elem) },
             .tuple => |items| blk: {
-                const lowered = try self.lowerTypeSpan(self.solved.types.span(items));
+                const lowered = try self.lowerTypeSpan(self.solved_types.span(items));
                 defer self.allocator.free(lowered);
                 break :blk .{ .tuple = try self.types.addSpan(lowered) };
             },
             .record => |fields| blk: {
                 const lowered = try self.allocator.alloc(Type.Field, fields.len);
                 defer self.allocator.free(lowered);
-                for (self.solved.types.fieldSpan(fields), 0..) |field, i| {
+                for (self.solved_types.fieldSpan(fields), 0..) |field, i| {
                     lowered[i] = .{ .name = field.name, .ty = try self.lowerType(field.ty) };
                 }
                 break :blk .{ .record = try self.types.addFields(lowered) };
@@ -1302,8 +1304,8 @@ const Lowerer = struct {
             .tag_union => |tags| blk: {
                 const lowered = try self.allocator.alloc(Type.Tag, tags.len);
                 defer self.allocator.free(lowered);
-                for (self.solved.types.tagSpan(tags), 0..) |tag, i| {
-                    const payloads = try self.lowerTypeSpan(self.solved.types.span(tag.payloads));
+                for (self.solved_types.tagSpan(tags), 0..) |tag, i| {
+                    const payloads = try self.lowerTypeSpan(self.solved_types.span(tag.payloads));
                     defer self.allocator.free(payloads);
                     lowered[i] = .{
                         .name = tag.name,
@@ -1314,7 +1316,7 @@ const Lowerer = struct {
                 break :blk .{ .tag_union = try self.types.addTags(lowered) };
             },
             .named => |named| blk: {
-                const args = try self.lowerTypeSpan(self.solved.types.span(named.args));
+                const args = try self.lowerTypeSpan(self.solved_types.span(named.args));
                 defer self.allocator.free(args);
                 break :blk .{ .named = .{
                     .named_type = named.named_type,
@@ -1353,7 +1355,7 @@ const Lowerer = struct {
     /// Solved store into this lowerer's Lambda Mono store. Named entries copy the
     /// shared field-name id; padding entries re-lower their reserved type.
     fn lowerDeclaredOrder(self: *Lowerer, span: SolvedType.Span) Common.LowerError!Type.Span {
-        const source = self.solved.types.declaredFieldSpan(span);
+        const source = self.solved_types.declaredFieldSpan(span);
         if (source.len == 0) return Type.Span.empty();
         const lowered = try self.allocator.alloc(Type.DeclaredField, source.len);
         defer self.allocator.free(lowered);
@@ -1372,7 +1374,7 @@ const Lowerer = struct {
         abi: CaptureAbi,
         solved_fn_ty: SolvedType.TypeVarId,
     ) Common.LowerError!Type.Span {
-        const solved_members = self.solved.types.memberSpan(members);
+        const solved_members = self.solved_types.memberSpan(members);
         const variants = try self.allocator.alloc(Type.FnVariant, solved_members.len);
         defer self.allocator.free(variants);
         const root_fn_ty = self.solved.types.root(solved_fn_ty);
@@ -1395,7 +1397,7 @@ const Lowerer = struct {
     }
 
     fn lowerFnMembersFromOwnTypes(self: *Lowerer, members: SolvedType.Span, abi: CaptureAbi) Common.LowerError!Type.Span {
-        const solved_members = self.solved.types.memberSpan(members);
+        const solved_members = self.solved_types.memberSpan(members);
         const variants = try self.allocator.alloc(Type.FnVariant, solved_members.len);
         defer self.allocator.free(variants);
         for (solved_members, 0..) |member, i| {
@@ -1834,7 +1836,7 @@ const Lowerer = struct {
             else => Common.invariant("callable source type was not a function"),
         };
 
-        const source_args = self.solved.types.span(func.args);
+        const source_args = self.solved_types.span(func.args);
         const stored_args = try self.allocator.alloc(const_store.ConstTypeId, source_args.len);
         defer self.allocator.free(stored_args);
         for (source_args, 0..) |arg, i| {
@@ -3681,7 +3683,7 @@ const Lowerer = struct {
             .func => |func| func,
             else => Common.invariant("call argument lowering saw a non-function source type"),
         };
-        return try self.lowerTypeSpan(self.solved.types.span(func.args));
+        return try self.lowerTypeSpan(self.solved_types.span(func.args));
     }
 
     fn inlineBodyForKnownCall(self: *Lowerer, callee: Type.FnId) Common.LowerError!?Lifted.ExprId {
@@ -3711,7 +3713,7 @@ const Lowerer = struct {
             .func => |func| func,
             else => Common.invariant("direct Lambda Mono function table contains a non-function type"),
         };
-        const solved_args = self.solved.types.span(func.args);
+        const solved_args = self.solved_types.span(func.args);
         const lifted_args = self.solved.lifted.typedLocalSpan(source_fn.args);
         if (solved_args.len != lifted_args.len) Common.invariant("direct Lambda Mono function arity changed after Lambda Solved");
         if (arg_locals.len != lifted_args.len) Common.invariant("inline call argument count differed from function arity");
@@ -7985,7 +7987,7 @@ const Lowerer = struct {
             .box => |elem| try self.solvedTypeContainsCallableInner(elem, visited),
             .tuple => |items| try self.solvedTypeSpanContainsCallable(items, visited),
             .record => |fields| blk: {
-                const field_span = self.solved.types.fieldSpan(fields);
+                const field_span = self.solved_types.fieldSpan(fields);
                 for (0..field_span.len) |index| {
                     const field = GuardedList.at(field_span, index);
                     if (try self.solvedTypeContainsCallableInner(field.ty, visited)) break :blk true;
@@ -7993,7 +7995,7 @@ const Lowerer = struct {
                 break :blk false;
             },
             .tag_union => |tags| blk: {
-                const tag_span = self.solved.types.tagSpan(tags);
+                const tag_span = self.solved_types.tagSpan(tags);
                 for (0..tag_span.len) |index| {
                     const tag = GuardedList.at(tag_span, index);
                     if (try self.solvedTypeSpanContainsCallable(tag.payloads, visited)) break :blk true;
@@ -8012,7 +8014,7 @@ const Lowerer = struct {
         span: SolvedType.Span,
         visited: *std.AutoHashMap(SolvedType.TypeVarId, void),
     ) Common.LowerError!bool {
-        const values = self.solved.types.span(span);
+        const values = self.solved_types.span(span);
         for (0..values.len) |index| {
             const ty = GuardedList.at(values, index);
             if (try self.solvedTypeContainsCallableInner(ty, visited)) return true;

--- a/test/cli/issue_10520_recursive_nominal_tag_callable_check.roc
+++ b/test/cli/issue_10520_recursive_nominal_tag_callable_check.roc
@@ -1,0 +1,32 @@
+# Repro for https://github.com/roc-lang/roc/issues/10520:
+# function payloads inside a concrete recursive parameterized nominal should check.
+app [main!] { pf: platform "../fx-open/platform/main.roc" }
+
+KeyEvent : { key : Str, code : Str, ctrl : Bool, shift : Bool, alt : Bool, meta : Bool, repeat : Bool, is_composing : Bool }
+
+PointerEvent : { client_x : F64, client_y : F64, button : U8, buttons : U8, ctrl : Bool, shift : Bool, alt : Bool, meta : Bool }
+
+Attr(msg) : [
+    Boolean(Str, Bool),
+    Key(Str),
+    KeyHandler(Str, List(Str), Bool, Box(KeyEvent -> Box(msg))),
+    MsgEvent(Str, Bool, Box(msg)),
+    PointerHandler(Str, Bool, Box(PointerEvent -> Box(msg))),
+    String(Str, Str),
+    ValueEvent(Str, Box(Str -> Box(msg))),
+    Visibility(Str, Str, Box(msg)),
+]
+
+Page(msg) := [
+    Text(Str),
+    Element(Str, List(Attr(msg)), List(Page(msg))),
+].{
+    text : Str -> Page(msg)
+    text = |s| Text(s)
+}
+
+page_view : Page(Str)
+page_view = Page.text("x")
+
+main! : List(Str) => Try({}, [Exit(I32), ..])
+main! = |_args| Ok({})


### PR DESCRIPTION
Fixes #10520. Erased-callable marking retained slices into mutable Lambda Solved side arrays while recursive lazy expansion could append and relocate those arrays. This makes mutable stores expose only stable indexed access, keeps packed slice iteration on immutable stage views, updates mutation-capable traversals accordingly, and adds a focused CLI regression for recursive nominal callable payloads.