### PR TITLE
Skip unpublished roots in public API dependency collection

### DIFF
--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -23648,9 +23648,7 @@ fn collectPublicApiDependencies(
     defer active_types.deinit();
 
     for (exported_defs) |def_idx| {
-        const root = checked_type_publication.rootForSourceVar(module, module.defType(def_idx)) orelse {
-            checkedArtifactInvariant("exported def type root was not published", .{});
-        };
+        const root = checked_type_publication.rootForSourceVar(module, module.defType(def_idx)) orelse continue;
         try appendPublicApiTypeDependencies(
             allocator,
             names,
@@ -23785,9 +23783,7 @@ fn appendExposedTypeDeclarationPublicApiDependencies(
             else => continue,
         }
 
-        const root = checked_type_publication.rootForSourceVar(module, ModuleEnv.varFrom(statement_idx)) orelse {
-            checkedArtifactInvariant("exposed type declaration root was not published", .{});
-        };
+        const root = checked_type_publication.rootForSourceVar(module, ModuleEnv.varFrom(statement_idx)) orelse continue;
         try appendPublicApiTypeDependencies(
             allocator,
             names,

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -6052,6 +6052,23 @@ test "issue 10181 explicit Str interpolation suffix checks cleanly" {
     try std.testing.expectEqual(@as(usize, 0), resources.checker.problems.problems.items.len);
 }
 
+test "issue 10401 self-referential associated type definition does not panic public api dependencies" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\main : {}
+        \\main = {}
+        \\T := [].{
+        \\    A :: T.A
+        \\}
+    ;
+
+    const resources = helpers.parseAndCanonicalizeProgram(allocator, .module, source, &.{}) catch |err| switch (err) {
+        error.TypeCheckError, error.ParseError => return,
+        else => return err,
+    };
+    defer helpers.cleanupParseAndCanonical(allocator, resources);
+}
+
 const dispatch_boundary_source =
     \\Thing := [Val(Str)].{
     \\    to_str : Thing -> Str


### PR DESCRIPTION
When collecting public API dependencies for an artifact, exposed type declarations or exported definitions that failed type resolution had unpublished type roots.
Previously, this caused an assertion panic instead of skipping the unpublished root.
This PR updates public API dependency collection to skip unpublished type roots so artifact publication succeeds when type errors exist.

Fixes #10401