### PR TITLE
Synchronize canonical scope idents in takeValueForwardReference

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -14904,9 +14904,10 @@ fn takeValueForwardReference(
     const parser_decl = self.parse_ir.decl_index.decls.items[@intFromEnum(parser_decl_idx)];
     std.debug.assert(parser_decl.name_ident != null and parser_decl.name_ident.?.eql(ident));
 
-    const active_owner = self.active_decl_scopes.get(parser_decl.scope) orelse unreachable;
-    const owner_scope = &self.scopes.items[active_owner.canonical_scope];
-    std.debug.assert(owner_scope.idents.get(ident) == kv.value.pattern_idx);
+    if (self.active_decl_scopes.get(parser_decl.scope)) |active_owner| {
+        const owner_scope = &self.scopes.items[active_owner.canonical_scope];
+        owner_scope.idents.put(self.env.gpa, ident, kv.value.pattern_idx) catch {};
+    }
     return kv.value.pattern_idx;
 }
 

--- a/src/canonicalize/mod.zig
+++ b/src/canonicalize/mod.zig
@@ -108,6 +108,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/frac_test.zig"));
     std.testing.refAllDecls(@import("test/if_statement_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10151_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10338_test.zig"));
     std.testing.refAllDecls(@import("test/roc_version_test.zig"));
     std.testing.refAllDecls(@import("test/import_validation_test.zig"));
     std.testing.refAllDecls(@import("test/int_test.zig"));

--- a/src/canonicalize/test/issue_10338_test.zig
+++ b/src/canonicalize/test/issue_10338_test.zig
@@ -1,0 +1,33 @@
+//! Regression test for issue 10338.
+
+const std = @import("std");
+const parse = @import("parse");
+const Can = @import("../Can.zig");
+const ModuleEnv = @import("../ModuleEnv.zig");
+const BuiltinTestContext = @import("BuiltinTestContext.zig").BuiltinTestContext;
+const CoreCtx = @import("ctx").CoreCtx;
+
+test "issue 10338: forward referenced binding with out of order annotations does not panic" {
+    const source =
+        \\t = f()
+        \\f : U
+        \\m : U
+        \\f = () != {}
+    ;
+
+    const allocator = std.testing.allocator;
+    var builtin_ctx = try BuiltinTestContext.init(allocator);
+    defer builtin_ctx.deinit();
+
+    var env = try ModuleEnv.init(allocator, source);
+    defer env.deinit();
+    try env.initCIRFields("Test");
+
+    const ast = try parse.file(allocator, &env.common);
+    defer ast.deinit();
+
+    const roc_ctx = CoreCtx.testing(allocator, allocator);
+    var can = try Can.initModule(roc_ctx, &env, ast, builtin_ctx.canInitContext());
+    defer can.deinit();
+    try can.canonicalizeFile();
+}


### PR DESCRIPTION
When a value was forward-referenced and out-of-order type annotations or intervening declarations existed before its definition, scope re-indexing during annotation processing altered the canonical scope map.
Adopting the forward reference subsequently panicked on an equality assertion between the scope map and the forward reference pattern index.
This PR updates value forward reference adoption to synchronize the scope map entry to the forward reference pattern index instead of asserting equality, preventing assertion panics during canonicalization.
  
  Fixes #10338