### PR TITLE
Enforce the RcEffect ownership table

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4856,6 +4856,30 @@ pub fn build(b: *std.Build) void {
     guarded_list_violation_exe.root_module.addImport("lir", roc_modules.lir);
     guarded_list_violation_exe.root_module.addImport("postcheck", roc_modules.postcheck);
 
+    // The RcEffect structural validator promises that a row whose fields
+    // contradict each other is a compile error. This probe is a file that
+    // makes such a row; the build requires compiling it to fail, and to fail
+    // with the rule the row breaks.
+    const rc_effect_rejected_row_probe = b.addObject(.{
+        .name = "rc_effect_rejected_row_probe",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/base/rc_effect_rejected_row_probe.zig"),
+            .target = target,
+            .optimize = .Debug,
+        }),
+    });
+    rc_effect_rejected_row_probe.root_module.addImport("base", roc_modules.base);
+    rc_effect_rejected_row_probe.expect_errors = .{
+        .contains = "[rule: unique_result_without_source]",
+    };
+
+    const run_rc_effect_rejected_row_step = b.step(
+        "run-test-rc-effect-rejected-row",
+        "Check that a structurally invalid RcEffect row fails to compile",
+    );
+    run_rc_effect_rejected_row_step.dependOn(&rc_effect_rejected_row_probe.step);
+    run_test_zig_step.dependOn(run_rc_effect_rejected_row_step);
+
     const run_guarded_list_violations_step = b.step(
         "run-test-guarded-list-violations",
         "Run guarded-list expected-failure checks",
@@ -5263,6 +5287,43 @@ pub fn build(b: *std.Build) void {
         .step_suffix = "lir-inline",
         .description = "Run LIR inline Zig tests",
         .compile = lir_inline_test,
+    });
+
+    const rc_conformance_test = b.addTest(.{
+        .name = "rc_conformance_test",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/eval/test/rc_conformance_tests.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+        .filters = test_filters,
+    });
+    roc_modules.addAll(rc_conformance_test);
+    rc_conformance_test.root_module.addImport("compiled_builtins", compiled_builtins_module);
+    rc_conformance_test.step.dependOn(&write_compiled_builtins.step);
+    try addLlvmSupportToStep(
+        b,
+        rc_conformance_test,
+        target,
+        use_system_llvm,
+        user_llvm_path,
+        roc_modules,
+        llvm_codegen_module,
+        llvm_embedded_module,
+        zstd,
+    );
+    if (rc_conformance_test.root_module.resolved_target.?.result.os.tag != .windows or
+        rc_conformance_test.root_module.resolved_target.?.result.abi != .msvc)
+    {
+        rc_conformance_test.root_module.link_libcpp = true;
+    }
+    add_tracy(b, roc_modules.build_options, rc_conformance_test, target, true, flag_enable_tracy);
+
+    test_suites.register(.{
+        .step_suffix = "rc-conformance",
+        .description = "Run RcEffect conformance sweep Zig tests",
+        .compile = rc_conformance_test,
     });
 
     const trmc_lir_test = b.addTest(.{

--- a/src/base/LowLevel.zig
+++ b/src/base/LowLevel.zig
@@ -634,6 +634,54 @@ pub const LowLevel = enum(u16) {
 
     /// Reference-counting behavior exposed by this primitive before LIR ARC
     /// insertion. This is explicit primitive metadata, not backend policy.
+    ///
+    /// ## What a row promises
+    ///
+    /// Every row is a claim about the Zig builtin the op lowers to, and ARC
+    /// generates code that is correct only if the claim is true. Writing a row
+    /// means discharging these obligations for the implementation, not
+    /// pattern-matching a neighboring row:
+    ///
+    /// - `may_allocate`: the op may call `allocateWithRefcount`. A row that
+    ///   omits it promises the op never births an allocation.
+    /// - `may_retain_or_release`: the op may change some allocation's count.
+    ///   A row that omits it promises every count the op can reach is
+    ///   untouched.
+    /// - `may_runtime_uniqueness_check_args`: the op reads those arguments'
+    ///   counts to choose between mutating in place and copying. ARC may prove
+    ///   the check redundant and pass `unique_args`, which lets the builtin
+    ///   take the in-place path unconditionally — so a named position must be
+    ///   one the op consumes, and the in-place path must be sound whenever the
+    ///   argument really is unique.
+    /// - `consume_args`: the op takes one ownership unit of those arguments.
+    ///   ARC stops accounting for them at this statement, so the op must
+    ///   release each one (or move it into the result) on every path.
+    /// - `result_aliases_consumed_args`: the unit taken from those consumed
+    ///   arguments lives on in the result. Only consumed positions may appear.
+    /// - `retain_args`: the op adds one count to those arguments — typically
+    ///   because it stores a handle to them inside the result. ARC emits no
+    ///   retain of its own, so an op that declares this and does not retain
+    ///   leaves the stored handle undercounted.
+    /// - `retain_result`: the result is read out of a structure that stays
+    ///   live (an element, a box payload, a capture), so ARC retains it after
+    ///   the op rather than treating it as freshly owned.
+    /// - `result_borrows_args`: the result points into those arguments'
+    ///   payloads without owning them. ARC keeps the lender live across every
+    ///   use of the result instead of retaining the result.
+    /// - `result_shares_args`: the result is a fresh owned outer value whose
+    ///   interior shares those arguments' allocations (seamless slices, byte
+    ///   reinterpretations). Host-visibility analysis links result and
+    ///   argument in both directions.
+    /// - `result_unique`: the result's outermost allocation has count 1 on
+    ///   return, so ARC records a birth. A result that shares an argument's
+    ///   outer allocation is never unique; interior sharing is irrelevant.
+    ///
+    /// ## What checks the claims
+    ///
+    /// - `base/rc_effect_rules.zig` rejects rows whose fields contradict each
+    ///   other, over the whole table, at comptime.
+    /// - `eval/rc_conformance.zig` runs each op through the interpreter and
+    ///   compares the refcount traffic it actually produces against the row.
     pub const RcEffect = struct {
         may_allocate: bool = false,
         may_retain_or_release: bool = false,
@@ -765,14 +813,6 @@ pub const LowLevel = enum(u16) {
             };
         }
 
-        pub fn allocatesSharingArgs(mask: u64) RcEffect {
-            return .{
-                .may_allocate = true,
-                .result_shares_args = mask,
-                .result_unique = true,
-            };
-        }
-
         pub fn allocatesAndRetainsOrReleasesSharingArgs(mask: u64) RcEffect {
             return .{
                 .may_allocate = true,
@@ -805,9 +845,16 @@ pub const LowLevel = enum(u16) {
     pub fn rcEffect(self: LowLevel) RcEffect {
         return switch (self) {
             .str_concat => RcEffect.runtimeUniqueness(argMask(&.{0})),
+
+            // Trimming a shared string returns a seamless slice of it rather
+            // than copying, so the result's outermost allocation is the
+            // argument's and its count is whatever the argument's was. Same
+            // regime as the list slice ops below.
             .str_trim,
             .str_trim_start,
             .str_trim_end,
+            => RcEffect.runtimeUniquenessMaybeSharedResult(argMask(&.{0})),
+
             .str_with_ascii_lowercased,
             .str_with_ascii_uppercased,
             .str_reserve,
@@ -883,7 +930,9 @@ pub const LowLevel = enum(u16) {
             .list_get_unsafe,
             => RcEffect.retainsResultBorrowingArgs(argMask(&.{0})),
 
-            .str_split_on => RcEffect.allocatesSharingArgs(argMask(&.{0})),
+            // Allocates the list of segments, and counts the source string
+            // once per segment it slices out of it.
+            .str_split_on => RcEffect.allocatesAndRetainsOrReleasesSharingArgs(argMask(&.{0})),
 
             .str_repeat,
             .str_from_utf8_lossy,

--- a/src/base/mod.zig
+++ b/src/base/mod.zig
@@ -8,6 +8,14 @@ pub const Region = @import("Region.zig");
 pub const StringLiteral = @import("StringLiteral.zig");
 pub const LowLevel = @import("LowLevel.zig").LowLevel;
 pub const LowLevelBuiltins = @import("LowLevelBuiltins.zig");
+/// Structural rules for `LowLevel.rcEffect()` rows, enforced over the whole
+/// table by the comptime block below.
+pub const rc_effect_rules = @import("rc_effect_rules.zig");
+
+comptime {
+    rc_effect_rules.assertTableConforms();
+}
+
 pub const RegionInfo = @import("RegionInfo.zig");
 pub const SourceLoc = @import("source_loc.zig").SourceLoc;
 pub const Scratch = @import("Scratch.zig").Scratch;
@@ -143,6 +151,7 @@ test "base tests" {
     std.testing.refAllDecls(@import("parallel.zig"));
     std.testing.refAllDecls(@import("Region.zig"));
     std.testing.refAllDecls(@import("RegionInfo.zig"));
+    std.testing.refAllDecls(@import("rc_effect_rules.zig"));
     std.testing.refAllDecls(@import("safe_memory.zig"));
     std.testing.refAllDecls(@import("signal_handler.zig"));
     std.testing.refAllDecls(@import("Scratch.zig"));

--- a/src/base/rc_effect_rejected_row_probe.zig
+++ b/src/base/rc_effect_rejected_row_probe.zig
@@ -1,0 +1,22 @@
+//! Compile-failure probe for the `RcEffect` structural validator.
+//!
+//! This file must NOT compile. `zig build run-test-rc-effect-row-rejected`
+//! builds it and requires the compile to fail with the rule the row breaks, so
+//! the guarantee "a wrong row is a compile error" is itself tested rather than
+//! assumed.
+//!
+//! The row below is the one PR roc-lang/roc#10023 removed: `str_drop_prefix`
+//! returns a slice of its argument's allocation, so claiming `result_unique`
+//! alongside `result_shares_args` made ARC count a fresh birth on top of a
+//! link to the lender, leaking one reference per call.
+
+const base = @import("base");
+
+const rc_effect_rules = base.rc_effect_rules;
+const RcEffect = base.LowLevel.RcEffect;
+
+comptime {
+    var reintroduced = RcEffect.retainsSharingArgs(1);
+    reintroduced.result_unique = true;
+    rc_effect_rules.assertRowConforms("str_drop_prefix", reintroduced);
+}

--- a/src/base/rc_effect_rules.zig
+++ b/src/base/rc_effect_rules.zig
@@ -1,0 +1,261 @@
+//! Structural rules every `LowLevel.rcEffect()` row must satisfy.
+//!
+//! `RcEffect` is expressive enough to describe subtle ownership regimes, which
+//! makes it expressive enough to describe a builtin wrongly. A wrong row is
+//! not a type error and not a functional test failure — it is a silent
+//! refcount imbalance in generated code. Two layers close that gap; this file
+//! is the first one:
+//!
+//! 1. Structural rules (here): combinations no builtin can truthfully have.
+//!    `assertTableConforms` runs the whole table through them at comptime, so
+//!    a row that contradicts itself is a compile error naming the op and the
+//!    rule it broke.
+//! 2. Conformance (`eval/rc_conformance.zig`): structurally valid claims that
+//!    do not match what the Zig builtin actually does at runtime.
+//!
+//! Rules are stated as implications between fields, one per field of
+//! `RcEffect`, and are derived from the proof obligations documented on the
+//! struct itself. They reject rows; they never repair or reinterpret them.
+//!
+//! Mask-versus-arity is deliberately *not* checked here: the number of
+//! arguments an op takes is not recorded next to the table, and a second
+//! hand-written arity table would be one more unchecked claim. Argument
+//! positions are certified against the arguments an op is actually given, at
+//! the seams where the two meet — `maskExceedsArgCount` is called by the ARC
+//! borrow certifier for every low-level statement in every debug build, and by
+//! the conformance observer for every op the interpreter executes.
+
+const std = @import("std");
+
+const LowLevel = @import("LowLevel.zig").LowLevel;
+
+const RcEffect = LowLevel.RcEffect;
+
+/// A structural contradiction between the fields of one `RcEffect` row.
+pub const Rule = enum {
+    retain_args_without_rc_flag,
+    consume_args_without_rc_flag,
+    retain_result_without_rc_flag,
+    shares_args_without_effect,
+    retain_and_consume_same_arg,
+    alias_of_unconsumed_arg,
+    runtime_check_of_unconsumed_arg,
+    runtime_check_without_allocate,
+    borrow_of_consumed_arg,
+    borrow_and_share_same_arg,
+    borrow_without_result_retain,
+    unique_result_without_source,
+    unique_result_that_is_retained,
+
+    /// What the row claimed, and why those claims cannot both hold.
+    pub fn description(self: Rule) []const u8 {
+        return switch (self) {
+            .retain_args_without_rc_flag => "retain_args names an argument, so the op adjusts a refcount; may_retain_or_release must be true",
+            .consume_args_without_rc_flag => "consume_args names an argument, so the op releases or moves that argument's unit; may_retain_or_release must be true",
+            .retain_result_without_rc_flag => "retain_result adds a count to the result, so may_retain_or_release must be true",
+            .shares_args_without_effect => "result_shares_args means the result holds a handle into an argument's allocation, which requires either a fresh outer value (may_allocate) or a count adjustment (may_retain_or_release)",
+            .retain_and_consume_same_arg => "one argument is both retained and consumed; the two cancel, so the row describes a borrow and must name neither",
+            .alias_of_unconsumed_arg => "result_aliases_consumed_args names an argument the op does not consume; there is no unit to move into the result",
+            .runtime_check_of_unconsumed_arg => "may_runtime_uniqueness_check_args names an argument the op does not consume; the in-place path would mutate a value the op does not own",
+            .runtime_check_without_allocate => "a runtime uniqueness check exists to choose between mutating in place and copying, so the copy path allocates; may_allocate must be true",
+            .borrow_of_consumed_arg => "result_borrows_args names a consumed argument; the lender's unit is gone by the time the result would be read through it",
+            .borrow_and_share_same_arg => "one argument is named as both a borrow lender and an interior-sharing lender; the result either owns a handle into it or does not",
+            .borrow_without_result_retain => "result_borrows_args names a lender, but without retain_result ARC never links the result to it and the borrow is silently dropped",
+            .unique_result_without_source => "result_unique claims the result's outermost allocation has count 1, but the op neither allocates it (may_allocate) nor takes it out of a consumed argument (result_aliases_consumed_args)",
+            .unique_result_that_is_retained => "retain_result means the result is read out of a structure that stays live, so its outermost allocation cannot also be uniquely owned",
+        };
+    }
+};
+
+/// The first rule this row breaks, or null when the row is structurally valid.
+///
+/// Structural validity says nothing about whether the row matches its builtin;
+/// that is what the conformance harness measures.
+pub fn violation(effect: RcEffect) ?Rule {
+    if (effect.retain_args != 0 and !effect.may_retain_or_release) {
+        return .retain_args_without_rc_flag;
+    }
+    if (effect.consume_args != 0 and !effect.may_retain_or_release) {
+        return .consume_args_without_rc_flag;
+    }
+    if (effect.retain_result and !effect.may_retain_or_release) {
+        return .retain_result_without_rc_flag;
+    }
+    if (effect.result_shares_args != 0 and !effect.may_allocate and !effect.may_retain_or_release) {
+        return .shares_args_without_effect;
+    }
+    if ((effect.retain_args & effect.consume_args) != 0) {
+        return .retain_and_consume_same_arg;
+    }
+    if ((effect.result_aliases_consumed_args & ~effect.consume_args) != 0) {
+        return .alias_of_unconsumed_arg;
+    }
+    if ((effect.may_runtime_uniqueness_check_args & ~effect.consume_args) != 0) {
+        return .runtime_check_of_unconsumed_arg;
+    }
+    if (effect.may_runtime_uniqueness_check_args != 0 and !effect.may_allocate) {
+        return .runtime_check_without_allocate;
+    }
+    if ((effect.result_borrows_args & effect.consume_args) != 0) {
+        return .borrow_of_consumed_arg;
+    }
+    if ((effect.result_borrows_args & effect.result_shares_args) != 0) {
+        return .borrow_and_share_same_arg;
+    }
+    if (effect.result_borrows_args != 0 and !effect.retain_result) {
+        return .borrow_without_result_retain;
+    }
+    if (effect.result_unique and !effect.may_allocate and effect.result_aliases_consumed_args == 0) {
+        return .unique_result_without_source;
+    }
+    if (effect.result_unique and effect.retain_result) {
+        return .unique_result_that_is_retained;
+    }
+    return null;
+}
+
+/// The lowest argument position a mask names that the op was not given, or
+/// null when every named position exists.
+///
+/// A mask bit above the real argument count names an argument that does not
+/// exist: ARC reads it as "no such position", so whatever ownership the row
+/// meant to describe is silently dropped.
+pub fn maskExceedsArgCount(effect: RcEffect, arg_count: usize) ?u6 {
+    const named = effect.may_runtime_uniqueness_check_args |
+        effect.consume_args |
+        effect.result_aliases_consumed_args |
+        effect.retain_args |
+        effect.result_borrows_args |
+        effect.result_shares_args;
+    if (named == 0) return null;
+    if (arg_count >= 64) return null;
+
+    const in_range: u64 = if (arg_count == 0) 0 else (@as(u64, std.math.maxInt(u64)) >> @intCast(64 - arg_count));
+    const out_of_range = named & ~in_range;
+    if (out_of_range == 0) return null;
+    return @intCast(@ctz(out_of_range));
+}
+
+/// Reject one row at compile time, naming the op and the rule it broke.
+///
+/// The rule tag comes last so a build step can require it verbatim without
+/// restating the whole message; `run-test-rc-effect-rejected-row` does exactly
+/// that.
+pub fn assertRowConforms(comptime op_name: []const u8, comptime effect: RcEffect) void {
+    comptime {
+        if (violation(effect)) |rule| {
+            @compileError("RcEffect row for low-level op '" ++ op_name ++ "' is invalid: " ++
+                rule.description() ++ " [rule: " ++ @tagName(rule) ++ "]");
+        }
+    }
+}
+
+/// Reject every structurally invalid row in the table at compile time.
+///
+/// Called from `base/mod.zig`, so no build can link a compiler whose ownership
+/// table contradicts itself.
+pub fn assertTableConforms() void {
+    @setEvalBranchQuota(2_000_000);
+    comptime {
+        for (std.enums.values(LowLevel)) |op| {
+            assertRowConforms(@tagName(op), op.rcEffect());
+        }
+    }
+}
+
+test "every row in the table is structurally valid" {
+    for (std.enums.values(LowLevel)) |op| {
+        if (violation(op.rcEffect())) |rule| {
+            std.debug.print(
+                "op {s} violates {s}: {s}\n",
+                .{ @tagName(op), @tagName(rule), rule.description() },
+            );
+            return error.StructurallyInvalidRcEffectRow;
+        }
+    }
+}
+
+test "the #10023 row is rejected: a shared-interior result is not a unique allocation" {
+    // `str_drop_prefix` returns a substring of its argument's allocation. PR
+    // roc-lang/roc#10023 (issue #9953) removed `result_unique` from this
+    // constructor family after ARC counted both a fresh birth and a link to
+    // the lender, leaking one reference per call.
+    var reintroduced = RcEffect.retainsSharingArgs(1);
+    reintroduced.result_unique = true;
+
+    try std.testing.expectEqual(Rule.unique_result_without_source, violation(reintroduced).?);
+    try std.testing.expectEqual(@as(?Rule, null), violation(RcEffect.retainsSharingArgs(1)));
+}
+
+test "each rule rejects the row it names, and every rule is reachable" {
+    const cases = [_]struct { rule: Rule, effect: RcEffect }{
+        .{ .rule = .retain_args_without_rc_flag, .effect = .{ .retain_args = 1 } },
+        .{ .rule = .consume_args_without_rc_flag, .effect = .{ .consume_args = 1 } },
+        .{ .rule = .retain_result_without_rc_flag, .effect = .{ .retain_result = true } },
+        .{ .rule = .shares_args_without_effect, .effect = .{ .result_shares_args = 1 } },
+        .{ .rule = .retain_and_consume_same_arg, .effect = .{
+            .may_retain_or_release = true,
+            .retain_args = 1,
+            .consume_args = 1,
+        } },
+        .{ .rule = .alias_of_unconsumed_arg, .effect = .{
+            .may_retain_or_release = true,
+            .consume_args = 1,
+            .result_aliases_consumed_args = 0b11,
+        } },
+        .{ .rule = .runtime_check_of_unconsumed_arg, .effect = .{
+            .may_allocate = true,
+            .may_retain_or_release = true,
+            .may_runtime_uniqueness_check_args = 0b10,
+            .consume_args = 1,
+            .result_aliases_consumed_args = 1,
+        } },
+        .{ .rule = .runtime_check_without_allocate, .effect = .{
+            .may_retain_or_release = true,
+            .may_runtime_uniqueness_check_args = 1,
+            .consume_args = 1,
+            .result_aliases_consumed_args = 1,
+        } },
+        .{ .rule = .borrow_of_consumed_arg, .effect = .{
+            .may_retain_or_release = true,
+            .retain_result = true,
+            .consume_args = 1,
+            .result_aliases_consumed_args = 1,
+            .result_borrows_args = 1,
+        } },
+        .{ .rule = .borrow_and_share_same_arg, .effect = .{
+            .may_retain_or_release = true,
+            .retain_result = true,
+            .result_borrows_args = 1,
+            .result_shares_args = 1,
+        } },
+        .{ .rule = .borrow_without_result_retain, .effect = .{
+            .may_retain_or_release = true,
+            .result_borrows_args = 1,
+        } },
+        .{ .rule = .unique_result_without_source, .effect = .{ .result_unique = true } },
+        .{ .rule = .unique_result_that_is_retained, .effect = .{
+            .may_allocate = true,
+            .may_retain_or_release = true,
+            .retain_result = true,
+            .result_unique = true,
+        } },
+    };
+
+    // A rule with no row that breaks it is a rule that is not doing anything.
+    var seen = std.EnumSet(Rule).initEmpty();
+    for (cases) |case| {
+        try std.testing.expectEqual(case.rule, violation(case.effect).?);
+        seen.insert(case.rule);
+    }
+    try std.testing.expectEqual(std.enums.values(Rule).len, seen.count());
+}
+
+test "argument positions above the real argument count are rejected" {
+    const names_arg_two = RcEffect.consumesArgsRetainingArgs(0, 0b100);
+
+    try std.testing.expectEqual(@as(?u6, 2), maskExceedsArgCount(names_arg_two, 0));
+    try std.testing.expectEqual(@as(?u6, 2), maskExceedsArgCount(names_arg_two, 2));
+    try std.testing.expectEqual(@as(?u6, null), maskExceedsArgCount(names_arg_two, 3));
+    try std.testing.expectEqual(@as(?u6, null), maskExceedsArgCount(RcEffect.none(), 0));
+}

--- a/src/builtins/list.zig
+++ b/src/builtins/list.zig
@@ -1417,23 +1417,30 @@ pub fn listConcat(
     update_mode_b: UpdateMode,
     roc_ops: *RocOps,
 ) callconv(.c) RocList {
-    // Early return for empty lists - avoid unnecessary allocations
+    // Early return for empty lists - avoid unnecessary allocations.
+    //
+    // The surviving side is handed back as the result, so it has to satisfy the
+    // op's `result_unique` claim (`base/LowLevel.zig`): `makeUnique` returns it
+    // as-is when nobody else holds its allocation, and clones it when they do.
+    // Returning a shared allocation here would let ARC treat it as freshly
+    // owned and hand a later op a static in-place path into memory someone else
+    // is reading.
     if (list_a.isEmpty()) {
         if (list_b.isEmpty()) {
             // Both are empty, return list_a and clean up list_b
             list_b.decref(alignment, element_width, elements_refcounted, dec_context, dec, roc_ops);
-            return list_a;
+            return list_a.makeUnique(alignment, element_width, elements_refcounted, inc_context, inc, dec_context, dec, roc_ops);
         } else {
             // list_a is empty, list_b has elements - return list_b
             // list_a might still need decref if it has capacity
             list_a.decref(alignment, element_width, elements_refcounted, dec_context, dec, roc_ops);
-            return list_b;
+            return list_b.makeUnique(alignment, element_width, elements_refcounted, inc_context, inc, dec_context, dec, roc_ops);
         }
     } else if (list_b.isEmpty()) {
         // list_b is empty, list_a has elements - return list_a
         // list_b might still need decref if it has capacity
         list_b.decref(alignment, element_width, elements_refcounted, dec_context, dec, roc_ops);
-        return list_a;
+        return list_a.makeUnique(alignment, element_width, elements_refcounted, inc_context, inc, dec_context, dec, roc_ops);
     }
 
     // Check if both lists share the same underlying allocation.

--- a/src/builtins/str.zig
+++ b/src/builtins/str.zig
@@ -1360,8 +1360,12 @@ pub fn strConcat(
 ) RocStr {
     // NOTE: we don't special-case the first argument being empty. That is because it is owned and
     // may have sufficient capacity to store the rest of the list.
-    if (arg2.isEmpty()) {
-        // the first argument is owned, so we can return it without cloning
+    if (arg2.isEmpty() and arg1.isExclusive(update_mode)) {
+        // The first argument is owned and nobody else holds its allocation, so
+        // the result can be that value itself. Handing back a *shared* value
+        // here would break the op's `result_unique` claim (`base/LowLevel.zig`)
+        // and let ARC treat a shared allocation as freshly owned; a shared
+        // first argument falls through to the copying path below.
         return arg1;
     } else {
         const combined_length = arg1.len() + arg2.len();

--- a/src/builtins/utils.zig
+++ b/src/builtins/utils.zig
@@ -1019,8 +1019,14 @@ pub const DebugRefcountTracker = struct {
         free_from_decref,
     };
 
-    const OpKind = enum(u8) { alloc, incref, decref, free };
-    const OpEntry = struct {
+    /// What one recorded refcount operation did to an allocation.
+    ///
+    /// `realloc` is logged against the *old* address: the allocation still
+    /// exists, but its refcount now lives somewhere else, so readers holding
+    /// the old address must stop reading it.
+    pub const OpKind = enum(u8) { alloc, incref, decref, free, realloc };
+    /// One recorded refcount operation.
+    pub const OpEntry = struct {
         rc_addr: usize,
         kind: OpKind,
         /// For incref: the amount. For others: 0.
@@ -1038,15 +1044,63 @@ pub const DebugRefcountTracker = struct {
 
     var op_log: [max_ops]OpEntry = undefined;
     var op_count: usize = 0;
+    var overflowed: bool = false;
+    var shadow_diagnostics: bool = true;
 
     pub fn enable() void {
         active = true;
         count = 0;
         op_count = 0;
+        overflowed = false;
+        shadow_diagnostics = true;
+    }
+
+    /// Turn off reports about the shadow counts.
+    ///
+    /// The shadow model follows an allocation from the address it was born
+    /// with, through the increfs and decrefs that pass through this module. It
+    /// does not see a count that is written directly, and reallocation moves a
+    /// count to an address whose history starts empty — so a shadow count can
+    /// read low even when the program is balanced. Consumers that read only
+    /// the operation log (which records the events themselves, not a derived
+    /// count) turn these reports off rather than print anomalies they know are
+    /// artifacts.
+    pub fn setShadowDiagnostics(enabled: bool) void {
+        shadow_diagnostics = enabled;
     }
 
     pub fn disable() void {
         active = false;
+    }
+
+    pub fn isActive() bool {
+        return active;
+    }
+
+    /// Whether the address table is full. Once it is, new allocations go
+    /// unrecorded, so readers of the log cannot tell a missing entry from an
+    /// operation that never happened.
+    pub fn isSaturated() bool {
+        return count >= max_tracked;
+    }
+
+    /// The operations recorded since the last `clearLog`, oldest first.
+    ///
+    /// Callers that want to attribute operations to one region of execution
+    /// clear the log on entry and read it on exit. The log holds at most
+    /// `max_ops` entries and silently drops the rest, so `logOverflowed`
+    /// reports whether what is here is the whole story.
+    pub fn recordedOps() []const OpEntry {
+        return op_log[0..op_count];
+    }
+
+    pub fn clearLog() void {
+        op_count = 0;
+        overflowed = false;
+    }
+
+    pub fn logOverflowed() bool {
+        return overflowed;
     }
 
     fn logOp(rc_addr: usize, kind: OpKind, amount: isize, shadow_after: isize, site: Site) void {
@@ -1059,6 +1113,8 @@ pub const DebugRefcountTracker = struct {
                 .site = site,
             };
             op_count += 1;
+        } else {
+            overflowed = true;
         }
     }
 
@@ -1090,10 +1146,12 @@ pub const DebugRefcountTracker = struct {
         }
     }
 
-    /// Called from increfRcPtr
+    /// Called from increfRcPtr. Allocations born before tracking started are
+    /// not followed: their shadow count would start from an unknown baseline
+    /// and go negative on the first decref past it.
     pub fn onIncref(rc_addr: usize, amount: isize) void {
         if (!active) return;
-        if (findOrInsert(rc_addr)) |idx| {
+        if (find(rc_addr)) |idx| {
             shadow_rcs[idx] += amount;
             logOp(rc_addr, .incref, amount, shadow_rcs[idx], .incref_rc_ptr);
         }
@@ -1105,7 +1163,7 @@ pub const DebugRefcountTracker = struct {
         if (find(rc_addr)) |idx| {
             shadow_rcs[idx] -= 1;
             logOp(rc_addr, .decref, 0, shadow_rcs[idx], site);
-            if (shadow_rcs[idx] < 0) {
+            if (shadow_diagnostics and shadow_rcs[idx] < 0) {
                 debugPrint(
                     "DebugRefcountTracker: refcount underflow at rc_addr=0x{x}\n",
                     .{rc_addr},
@@ -1129,6 +1187,7 @@ pub const DebugRefcountTracker = struct {
         if (!active) return;
         if (old_rc_addr == new_rc_addr) return;
         if (find(old_rc_addr)) |idx| {
+            logOp(old_rc_addr, .realloc, 0, shadow_rcs[idx], .allocate_with_refcount);
             rc_addrs[idx] = new_rc_addr;
         }
     }
@@ -1152,6 +1211,7 @@ pub const DebugRefcountTracker = struct {
                             .incref => debugPrint("  incref(+{d})={d}", .{ op.amount, op.shadow_after }),
                             .decref => debugPrint("  decref={d}", .{op.shadow_after}),
                             .free => debugPrint("  free", .{}),
+                            .realloc => debugPrint("  realloc (moved)", .{}),
                         }
                         debugPrint(" via {s}\n", .{@tagName(op.site)});
                     }
@@ -1173,6 +1233,7 @@ pub const DebugRefcountTracker = struct {
                     .incref => debugPrint("  incref(+{d})={d}", .{ op.amount, op.shadow_after }),
                     .decref => debugPrint("  decref={d}", .{op.shadow_after}),
                     .free => debugPrint("  free", .{}),
+                    .realloc => debugPrint("  realloc (moved)", .{}),
                 }
                 debugPrint(" via {s}\n", .{@tagName(op.site)});
             }

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -18,6 +18,7 @@ const LirStore = lir.LirStore;
 const GuardedList = LirStore.GuardedList;
 const CheckedArithmetic = lir.CheckedArithmetic;
 const lir_value = @import("value.zig");
+const rc_conformance = @import("rc_conformance.zig");
 const backend = @import("backend");
 const host_trampoline = @import("host_trampoline.zig");
 const builtins = @import("builtins");
@@ -1916,15 +1917,22 @@ pub const Interpreter = struct {
                     const arg_locals = self.store.getLocalSpan(assign.args);
                     const arg_values = try self.collectLocalValues(frame, arg_locals);
                     const arg_layouts = try self.localLayouts(arg_locals);
+                    const ret_layout = self.store.getLocal(assign.target).layout_idx;
+                    const observation = rc_conformance.beginStatement(assign.op, arg_values.len);
+                    if (observation) |obs| self.conformanceSnapshotArgs(obs, arg_values, arg_layouts);
                     const value = try self.evalLowLevel(.{
                         .op = assign.op,
                         .args = arg_values,
                         .arg_layouts = arg_layouts,
-                        .ret_layout = self.store.getLocal(assign.target).layout_idx,
+                        .ret_layout = ret_layout,
                         .callable_proc = null,
                         .unique_args = assign.unique_args,
                         .interchangeable = assign.interchangeable,
                     });
+                    if (observation) |obs| {
+                        self.conformanceSnapshotResult(obs, value, ret_layout);
+                        rc_conformance.endStatement(obs);
+                    }
                     try self.setLocalChecked(frame, current, assign.target, value, assign.op == .box_alloc_zeroed);
                     current = assign.next;
                 },
@@ -4362,6 +4370,166 @@ pub const Interpreter = struct {
             .atomicity = atomicity,
         };
         rl.decrefElements(list_plan.elem_width, &ctx, decrefListElementCallback, &self.roc_ops);
+    }
+
+    // ── RcEffect conformance observation (debug builds only) ──
+    //
+    // These read the same layout-driven RC plans the retain/release handlers
+    // execute, but only to look: they name the allocations a value owns or
+    // reaches, so `rc_conformance` can compare what a low-level op did to what
+    // its `RcEffect` row says it does. Nothing here adjusts a count.
+
+    /// How deep the reachability walk descends before giving up. Depth only
+    /// limits what the alias rules can see; they fire on allocations found,
+    /// never on ones missed.
+    const rc_conformance_max_depth = 8;
+
+    /// The allocation a value owns directly, if its layout has one.
+    fn conformanceOuterAllocation(
+        self: *LirInterpreter,
+        val: Value,
+        layout_idx: layout_mod.Idx,
+    ) ?rc_conformance.Allocation {
+        return switch (self.conformanceRcPlan(layout_idx)) {
+            .str_decref => blk: {
+                const rs = valueToRocStr(val);
+                if (rs.isSmallStr()) break :blk null;
+                break :blk rc_conformance.allocationAt(rs.getAllocationPtr());
+            },
+            .list_decref => rc_conformance.allocationAt(valueToRocList(val).getAllocationDataPtr(&self.roc_ops)),
+            .box_decref, .erased_callable_decref => rc_conformance.allocationAt(val.read(?[*]u8)),
+            else => null,
+        };
+    }
+
+    fn conformanceRcPlan(self: *LirInterpreter, layout_idx: layout_mod.Idx) layout_mod.RcHelperPlan {
+        return self.cachedRcPlan(.{ .op = .decref, .layout_idx = layout_idx });
+    }
+
+    /// Collect every refcounted allocation reachable from a value.
+    fn conformanceCollectAllocations(
+        self: *LirInterpreter,
+        val: Value,
+        layout_idx: layout_mod.Idx,
+        sink: *rc_conformance.AllocationSet,
+    ) void {
+        self.conformanceCollectPlan(self.conformanceRcPlan(layout_idx), val, sink, 0);
+    }
+
+    fn conformanceCollectPlan(
+        self: *LirInterpreter,
+        plan: layout_mod.RcHelperPlan,
+        val: Value,
+        sink: *rc_conformance.AllocationSet,
+        depth: u32,
+    ) void {
+        if (depth > rc_conformance_max_depth) return;
+        switch (plan) {
+            // The walk always asks for decref plans, so the incref and free
+            // shapes of each plan never reach here.
+            .noop, .str_incref, .list_incref, .box_incref, .erased_callable_incref, .str_free, .list_free, .box_free, .erased_callable_free => {},
+            .str_decref => {
+                const rs = valueToRocStr(val);
+                if (rs.isSmallStr()) return;
+                if (rc_conformance.allocationAt(rs.getAllocationPtr())) |found| sink.add(found.rc_addr);
+            },
+            .list_decref => |list_plan| {
+                const rl = valueToRocList(val);
+                if (rc_conformance.allocationAt(rl.getAllocationDataPtr(&self.roc_ops))) |found| sink.add(found.rc_addr);
+                const child_key = list_plan.child orelse return;
+                const bytes = rl.bytes orelse return;
+                const child_plan = self.cachedRcPlan(child_key);
+                for (0..rl.len()) |index| {
+                    const elem = Value{ .ptr = bytes + index * list_plan.elem_width };
+                    self.conformanceCollectPlan(child_plan, elem, sink, depth + 1);
+                }
+            },
+            .box_decref => |box_plan| {
+                const alloc_ptr = val.read(?[*]u8);
+                if (rc_conformance.allocationAt(alloc_ptr)) |found| sink.add(found.rc_addr);
+                const child_key = box_plan.child orelse return;
+                const data_ptr = self.readBoxedDataPointer(val) orelse return;
+                self.conformanceCollectPlan(self.cachedRcPlan(child_key), .{ .ptr = data_ptr }, sink, depth + 1);
+            },
+            .erased_callable_decref => {
+                if (rc_conformance.allocationAt(val.read(?[*]u8))) |found| sink.add(found.rc_addr);
+            },
+            .struct_ => |struct_plan| {
+                const field_count = self.layout_store.rcHelperStructFieldCount(struct_plan);
+                var index: u32 = 0;
+                while (index < field_count) : (index += 1) {
+                    const field_plan = self.cachedStructFieldPlan(struct_plan, index) orelse continue;
+                    const field_val = Value{ .ptr = val.ptr + field_plan.offset };
+                    self.conformanceCollectPlan(self.cachedRcPlan(field_plan.child), field_val, sink, depth + 1);
+                }
+            },
+            .tag_union => |tag_plan| {
+                const variant_count = self.layout_store.rcHelperTagUnionVariantCount(tag_plan);
+                if (variant_count == 0) return;
+                const tu_data = self.layout_store.getTagUnionData(tag_plan.tag_union_idx);
+                const disc_offset = tu_data.discriminant_offset.get(self.layout_store.targetUsize());
+                const disc: u32 = switch (tu_data.discriminant_size) {
+                    0 => 0,
+                    1 => val.offset(disc_offset).read(u8),
+                    2 => val.offset(disc_offset).read(u16),
+                    else => return,
+                };
+                if (disc >= variant_count) return;
+                const child_key = self.cachedTagVariantPlan(tag_plan, disc) orelse return;
+                self.conformanceCollectPlan(self.cachedRcPlan(child_key), val, sink, depth + 1);
+            },
+            .closure => |child_key| {
+                self.conformanceCollectPlan(self.cachedRcPlan(child_key), val, sink, depth + 1);
+            },
+        }
+    }
+
+    /// Snapshot the arguments a low-level op is about to receive.
+    fn conformanceSnapshotArgs(
+        self: *LirInterpreter,
+        observation: *rc_conformance.Observation,
+        args: []const Value,
+        arg_layouts: []const layout_mod.Idx,
+    ) void {
+        const positions = @min(@min(args.len, arg_layouts.len), rc_conformance.max_observed_args);
+        for (0..positions) |index| {
+            observation.args[index] = .{
+                .outer = self.conformanceOuterAllocation(args[index], arg_layouts[index]),
+            };
+        }
+    }
+
+    /// Snapshot what the op left behind, then judge it against its row.
+    fn conformanceSnapshotResult(
+        self: *LirInterpreter,
+        observation: *rc_conformance.Observation,
+        result: Value,
+        ret_layout: layout_mod.Idx,
+    ) void {
+        const window = rc_conformance.endEventWindow();
+        observation.allocated = window.allocated;
+        observation.adjusted_counts = window.adjusted_counts;
+        observation.events_incomplete = window.incomplete;
+
+        const positions = @min(observation.arg_count, rc_conformance.max_observed_args);
+        for (observation.args[0..positions]) |*arg| {
+            const outer = arg.outer orelse continue;
+            if (window.incomplete) {
+                // Without a complete event log there is no way to know whether
+                // reading this count would touch freed memory.
+                arg.count_after = outer.count;
+                continue;
+            }
+            if (rc_conformance.wasFreedInWindow(outer.rc_addr)) {
+                arg.count_after = null;
+                continue;
+            }
+            const rc_ptr: *const isize = @ptrFromInt(outer.rc_addr);
+            arg.count_after = rc_ptr.*;
+        }
+
+        observation.result_outer = self.conformanceOuterAllocation(result, ret_layout);
+        self.conformanceCollectAllocations(result, ret_layout, &observation.result_reachable);
     }
 
     fn performErasedCallableFinalDropIfUnique(

--- a/src/eval/mod.zig
+++ b/src/eval/mod.zig
@@ -105,6 +105,8 @@ pub const wasm_runner = if (builtin.target.os.tag == .freestanding) struct {
 } else @import("wasm_runner.zig");
 /// Shared eval test helpers routed through checked artifacts.
 pub const test_helpers = @import("test_helpers.zig");
+/// Debug-only conformance check between `RcEffect` rows and builtin behavior.
+pub const rc_conformance = @import("rc_conformance.zig");
 
 test "eval tests" {
     std.testing.refAllDecls(@This());
@@ -119,6 +121,7 @@ test "eval tests" {
     std.testing.refAllDecls(@import("compile_time_host.zig"));
     std.testing.refAllDecls(@import("const_store_writer.zig"));
     std.testing.refAllDecls(@import("inspected_run.zig"));
+    std.testing.refAllDecls(@import("rc_conformance.zig"));
     std.testing.refAllDecls(@import("stack.zig"));
     std.testing.refAllDecls(@import("test_helpers.zig"));
     std.testing.refAllDecls(@import("test/host_trampoline_assembly_test.zig"));

--- a/src/eval/rc_conformance.zig
+++ b/src/eval/rc_conformance.zig
@@ -1,0 +1,643 @@
+//! Debug-only conformance check between `LowLevel.rcEffect()` and what the
+//! builtins actually do to refcounts.
+//!
+//! `base/rc_effect_rules.zig` rejects rows that contradict themselves. A row
+//! can still be structurally valid and simply false — the case that shipped as
+//! roc-lang/roc#10023, where a family of ops claimed a unique result while
+//! returning a slice of an argument's allocation, and every call leaked one
+//! reference. Nothing but running the builtin can tell those rows apart.
+//!
+//! So the interpreter reports, for every low-level statement it executes, what
+//! the op did to the refcounts it could reach: which allocations were born,
+//! which counts moved, and which of the result's allocations came from an
+//! argument. This module judges that report against the row.
+//!
+//! ## Direction of the check
+//!
+//! Every rule reads "observed behavior the row does not account for", never
+//! "declared behavior that did not happen on this path". A row is a claim
+//! about what the op *may* do, and a single execution takes one path: a
+//! copy-on-write op given a unique input never exercises its copy path. So an
+//! unexercised claim is not a finding, while an unclaimed effect always is —
+//! it is ownership traffic ARC did not plan for.
+//!
+//! The two effects that must therefore be driven in both regimes — unique
+//! input and shared input — are `result_unique` and copy-on-write. The sweep
+//! in `test/rc_conformance_tests.zig` is what supplies both.
+//!
+//! ## Who accounts for a count
+//!
+//! The rules below distinguish counts the *op* adds from counts *ARC* adds,
+//! because the row decides which is which:
+//!
+//! - `retain_args` means ARC emits the retain (`lir/arc.zig`
+//!   `retainMaskedArgs`), so the builtin must not also count the argument.
+//! - `result_shares_args` without `retain_args` means the opposite: ARC emits
+//!   nothing, so the builtin must count the argument itself for the handle it
+//!   stores in the result.
+//!
+//! An op that counts an argument ARC already counted leaks; an op that counts
+//! neither leaves a dangling handle.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const base = @import("base");
+const builtins = @import("builtins");
+
+const LowLevel = base.LowLevel;
+const RcEffect = LowLevel.RcEffect;
+const rc_effect_rules = base.rc_effect_rules;
+const DebugRefcountTracker = builtins.utils.DebugRefcountTracker;
+
+/// Observation is debug-only: release builds carry no observer, no branch on
+/// one, and no hook in the interpreter's statement loop. Freestanding targets
+/// have no refcount event log to read, so they stay out too.
+pub const enabled = builtin.mode == .Debug and builtin.target.os.tag != .freestanding;
+
+/// The most arguments one low-level statement is observed with. Every row in
+/// the table names positions 0-2; positions past this are still checked for
+/// existence by `mask_names_missing_argument`.
+pub const max_observed_args = 8;
+
+/// The most allocations collected from one value's refcounted interior.
+/// Overflow only weakens the alias rules — they fire on allocations that were
+/// found, never on ones that were not.
+pub const max_collected_allocations = 96;
+
+const max_findings = 32;
+
+/// One allocation, identified by the address of its refcount.
+pub const Allocation = struct {
+    rc_addr: usize,
+    count: isize,
+
+    /// Static data and other constant-count allocations cannot be observed:
+    /// incref and decref both leave them alone.
+    pub fn isObservable(self: Allocation) bool {
+        return !builtins.utils.rcConstant(self.count);
+    }
+};
+
+/// The refcounted allocations reachable from one value.
+pub const AllocationSet = struct {
+    addrs: [max_collected_allocations]usize = undefined,
+    len: usize = 0,
+    overflowed: bool = false,
+
+    pub fn add(self: *AllocationSet, rc_addr: usize) void {
+        for (self.addrs[0..self.len]) |existing| {
+            if (existing == rc_addr) return;
+        }
+        if (self.len == self.addrs.len) {
+            self.overflowed = true;
+            return;
+        }
+        self.addrs[self.len] = rc_addr;
+        self.len += 1;
+    }
+
+    pub fn contains(self: AllocationSet, rc_addr: usize) bool {
+        for (self.addrs[0..self.len]) |existing| {
+            if (existing == rc_addr) return true;
+        }
+        return false;
+    }
+};
+
+/// What one argument looked like before the op, and what the op did to it.
+pub const ArgObservation = struct {
+    /// The argument's own outermost allocation, before the op ran.
+    outer: ?Allocation = null,
+    /// That allocation's count after the op, or null when the op freed or
+    /// moved it.
+    count_after: ?isize = null,
+};
+
+/// One executed low-level statement, as seen from outside the op.
+pub const Observation = struct {
+    op: LowLevel,
+    arg_count: usize,
+    args: [max_observed_args]ArgObservation = [_]ArgObservation{.{}} ** max_observed_args,
+    /// The result's outermost allocation, after the op ran.
+    result_outer: ?Allocation = null,
+    /// Everything refcounted the result can reach, after the op ran.
+    result_reachable: AllocationSet = .{},
+    /// The op called `allocateWithRefcount` at least once.
+    allocated: bool = false,
+    /// The op incremented or decremented at least one count.
+    adjusted_counts: bool = false,
+    /// The refcount event log dropped entries, so `allocated` and
+    /// `adjusted_counts` may understate what happened.
+    events_incomplete: bool = false,
+};
+
+/// A row that does not match its builtin.
+pub const Rule = enum {
+    allocated_without_may_allocate,
+    adjusted_counts_without_may_retain_or_release,
+    argument_counted_by_op_and_arc,
+    argument_counted_without_claim,
+    argument_released_without_consume,
+    shared_argument_not_counted_by_op,
+    result_outlives_uniqueness_claim,
+    result_holds_unnamed_argument_allocation,
+    mask_names_missing_argument,
+
+    pub fn description(self: Rule) []const u8 {
+        return switch (self) {
+            .allocated_without_may_allocate => "the op allocated, but the row does not set may_allocate",
+            .adjusted_counts_without_may_retain_or_release => "the op changed a refcount, but the row does not set may_retain_or_release",
+            .argument_counted_by_op_and_arc => "the op counted an argument that retain_args already makes ARC count; the handle ends up one count too high",
+            .argument_counted_without_claim => "the op counted an argument that neither retain_args nor result_shares_args names",
+            .argument_released_without_consume => "the op released an argument the row does not name in consume_args; ARC releases it again",
+            .shared_argument_not_counted_by_op => "the result holds this argument's allocation under result_shares_args, which ARC does not count, but the op did not count it either",
+            .result_outlives_uniqueness_claim => "result_unique claims the result's outermost allocation has count 1, and it does not",
+            .result_holds_unnamed_argument_allocation => "the result holds an allocation reachable from an argument the row does not link it to",
+            .mask_names_missing_argument => "a mask names an argument position the op was not given",
+        };
+    }
+};
+
+/// A rule broken by one executed statement, with the numbers behind it.
+pub const Finding = struct {
+    op: LowLevel,
+    rule: Rule,
+    /// The argument position involved, when the rule is about one.
+    arg: ?usize = null,
+    /// Count before the op, for the allocation the rule is about.
+    count_before: isize = 0,
+    /// Count after the op, or null when the allocation was freed.
+    count_after: ?isize = null,
+    /// Whether this rule is about one allocation's count at all.
+    counts_apply: bool = false,
+
+    pub fn format(self: Finding, writer: *std.Io.Writer) std.Io.Writer.Error!void {
+        try writer.print("{s}: {s}", .{ @tagName(self.op), self.rule.description() });
+        if (self.arg) |position| try writer.print(" (argument {d})", .{position});
+        try writer.print(" [rule {s}", .{@tagName(self.rule)});
+        if (self.counts_apply) {
+            if (self.count_after) |after| {
+                try writer.print(", count {d} -> {d}", .{ self.count_before, after });
+            } else {
+                try writer.print(", count {d} -> freed", .{self.count_before});
+            }
+        }
+        try writer.print("]", .{});
+    }
+};
+
+/// The set of ops the sweep has executed. `std.EnumSet` over `LowLevel` is one
+/// bit per op.
+pub const OpSet = std.EnumSet(LowLevel);
+
+var active_flag: bool = false;
+var findings_buf: [max_findings]Finding = undefined;
+var findings_len: usize = 0;
+var dropped_findings: usize = 0;
+var covered_ops: OpSet = OpSet.initEmpty();
+var row_overrides: std.EnumMap(LowLevel, RcEffect) = .{};
+/// One observation at a time, reused by every statement. The interpreter is
+/// single-threaded and low-level ops do not execute other low-level
+/// statements, but `open_statements` keeps a surprise reentry from judging a
+/// half-filled observation.
+var scratch_observation: Observation = .{ .op = .crash, .arg_count = 0 };
+var open_statements: usize = 0;
+
+/// Start observing. Resets findings and coverage, and turns on the refcount
+/// event log the observation reads.
+pub fn begin() void {
+    if (!enabled) return;
+    findings_len = 0;
+    dropped_findings = 0;
+    covered_ops = OpSet.initEmpty();
+    open_statements = 0;
+    active_flag = true;
+    DebugRefcountTracker.enable();
+    // Only the operation log is read here — which allocations were born, freed,
+    // or moved during one op — never the tracker's derived shadow counts.
+    DebugRefcountTracker.setShadowDiagnostics(false);
+}
+
+/// Open an observation for one low-level statement, or null when nothing is
+/// watching. The caller fills in the arguments, runs the op, fills in the
+/// result, and closes it with `endStatement`.
+pub fn beginStatement(op: LowLevel, arg_count: usize) ?*Observation {
+    if (!enabled) return null;
+    if (!active_flag) return null;
+    if (open_statements != 0) return null;
+
+    open_statements += 1;
+    scratch_observation = .{ .op = op, .arg_count = arg_count };
+    beginEventWindow();
+    return &scratch_observation;
+}
+
+/// Judge a filled-in observation and close it.
+pub fn endStatement(observation: *Observation) void {
+    if (!enabled) return;
+    open_statements -= 1;
+    record(observation.*);
+}
+
+/// Stop observing, keeping findings and coverage for the caller to read.
+pub fn end() void {
+    if (!enabled) return;
+    active_flag = false;
+    DebugRefcountTracker.disable();
+}
+
+/// Whether observation is on right now.
+pub fn isActive() bool {
+    return enabled and active_flag;
+}
+
+/// Rows that did not match their builtin during this run, oldest first.
+pub fn findings() []const Finding {
+    return findings_buf[0..findings_len];
+}
+
+/// Findings beyond the fixed buffer. A run that drops findings still fails;
+/// this only says the printed list is partial.
+pub fn droppedFindings() usize {
+    return dropped_findings;
+}
+
+/// The ops this run executed, whatever their row said.
+pub fn covered() OpSet {
+    return covered_ops;
+}
+
+/// Judge `op` against `effect` instead of against its own row, so a test can
+/// point the harness at a row that is known to be wrong and watch it fail.
+pub fn overrideRow(op: LowLevel, effect: RcEffect) void {
+    if (!enabled) return;
+    row_overrides.put(op, effect);
+}
+
+/// Judge every op against its own row again.
+pub fn clearOverrides() void {
+    if (!enabled) return;
+    row_overrides = .{};
+}
+
+/// The row this op is judged against.
+pub fn rowFor(op: LowLevel) RcEffect {
+    if (enabled) {
+        if (row_overrides.get(op)) |override| return override;
+    }
+    return op.rcEffect();
+}
+
+/// The refcount event log, cleared so the next op's events stand alone.
+pub fn beginEventWindow() void {
+    DebugRefcountTracker.clearLog();
+}
+
+/// What the refcount event log recorded since `beginEventWindow`.
+pub const EventWindow = struct {
+    allocated: bool = false,
+    adjusted_counts: bool = false,
+    incomplete: bool = false,
+};
+
+/// Whether the op that just ran left this refcount address unreadable, by
+/// freeing the allocation or by moving it. Reading either one is a
+/// use-after-free, so every count read after an op asks this first.
+pub fn wasFreedInWindow(rc_addr: usize) bool {
+    var gone = false;
+    for (DebugRefcountTracker.recordedOps()) |event| {
+        if (event.rc_addr != rc_addr) continue;
+        switch (event.kind) {
+            .free, .realloc => gone = true,
+            // An address handed back out by a later allocation is live again.
+            .alloc => gone = false,
+            else => {},
+        }
+    }
+    return gone;
+}
+
+/// Summarize the refcount events recorded for the op that just ran.
+pub fn endEventWindow() EventWindow {
+    var window = EventWindow{ .incomplete = DebugRefcountTracker.logOverflowed() or DebugRefcountTracker.isSaturated() };
+    for (DebugRefcountTracker.recordedOps()) |event| {
+        switch (event.kind) {
+            .alloc, .realloc => window.allocated = true,
+            .incref, .decref, .free => window.adjusted_counts = true,
+        }
+    }
+    return window;
+}
+
+/// Read an allocation's current count. Returns null for the null pointer.
+pub fn allocationAt(data_ptr: ?[*]u8) ?Allocation {
+    const ptr = data_ptr orelse return null;
+    const rc_addr = @intFromPtr(ptr) - @sizeOf(usize);
+    if (rc_addr == 0) return null;
+    const rc_ptr: *const isize = @ptrFromInt(rc_addr);
+    return .{ .rc_addr = rc_addr, .count = rc_ptr.* };
+}
+
+/// Judge one executed statement and remember that its op has coverage.
+pub fn record(observation: Observation) void {
+    if (!enabled) return;
+    covered_ops.insert(observation.op);
+
+    const effect = rowFor(observation.op);
+    if (rc_effect_rules.maskExceedsArgCount(effect, observation.arg_count)) |position| {
+        addFinding(.{
+            .op = observation.op,
+            .rule = .mask_names_missing_argument,
+            .arg = position,
+        });
+    }
+
+    if (!observation.events_incomplete) {
+        if (observation.allocated and !effect.may_allocate) {
+            addFinding(.{ .op = observation.op, .rule = .allocated_without_may_allocate });
+        }
+        if (observation.adjusted_counts and !effect.may_retain_or_release) {
+            addFinding(.{ .op = observation.op, .rule = .adjusted_counts_without_may_retain_or_release });
+        }
+    }
+
+    const positions = @min(observation.arg_count, max_observed_args);
+    for (observation.args[0..positions], 0..) |arg, position| {
+        if (position >= 64) break;
+        const bit = @as(u64, 1) << @intCast(position);
+        const outer = arg.outer orelse continue;
+        if (!outer.isObservable()) continue;
+
+        const after = arg.count_after;
+        const released = after == null or after.? < outer.count;
+        const counted = after != null and after.? > outer.count;
+
+        if (counted) {
+            if ((effect.retain_args & bit) != 0) {
+                addFinding(.{
+                    .op = observation.op,
+                    .rule = .argument_counted_by_op_and_arc,
+                    .arg = position,
+                    .count_before = outer.count,
+                    .count_after = after,
+                    .counts_apply = true,
+                });
+            } else if ((effect.result_shares_args & bit) == 0) {
+                addFinding(.{
+                    .op = observation.op,
+                    .rule = .argument_counted_without_claim,
+                    .arg = position,
+                    .count_before = outer.count,
+                    .count_after = after,
+                    .counts_apply = true,
+                });
+            }
+        }
+
+        if (released and (effect.consume_args & bit) == 0) {
+            addFinding(.{
+                .op = observation.op,
+                .rule = .argument_released_without_consume,
+                .arg = position,
+                .count_before = outer.count,
+                .count_after = after,
+                .counts_apply = true,
+            });
+        }
+
+        const result_holds_it = observation.result_reachable.contains(outer.rc_addr);
+        if (result_holds_it and
+            (effect.result_shares_args & bit) != 0 and
+            (effect.retain_args & bit) == 0 and
+            !counted)
+        {
+            addFinding(.{
+                .op = observation.op,
+                .rule = .shared_argument_not_counted_by_op,
+                .arg = position,
+                .count_before = outer.count,
+                .count_after = after,
+                .counts_apply = true,
+            });
+        }
+    }
+
+    checkResultLinks(observation, effect, positions);
+
+    if (effect.result_unique) {
+        if (observation.result_outer) |result| {
+            if (result.isObservable() and result.count != 1) {
+                addFinding(.{
+                    .op = observation.op,
+                    .rule = .result_outlives_uniqueness_claim,
+                    .count_before = result.count,
+                    .count_after = result.count,
+                    .counts_apply = true,
+                });
+            }
+        }
+    }
+}
+
+/// An argument's own allocation showing up anywhere inside the result — as the
+/// result itself, or as one of its interior handles — has to be a link the row
+/// names, because that is the link ARC follows to keep the lender alive.
+///
+/// Interior allocations *of* an argument (a list's elements, a box's payload)
+/// are deliberately not checked: an op like `list_map_extract_unsafe` moves one
+/// element's ownership out of a buffer, and no flag describes that move.
+fn checkResultLinks(observation: Observation, effect: RcEffect, positions: usize) void {
+    const linked = effect.result_shares_args |
+        effect.result_borrows_args |
+        effect.result_aliases_consumed_args |
+        effect.retain_args;
+
+    for (observation.args[0..positions], 0..) |arg, position| {
+        if (position >= 64) break;
+        const bit = @as(u64, 1) << @intCast(position);
+        if ((linked & bit) != 0) continue;
+        const outer = arg.outer orelse continue;
+        if (!outer.isObservable()) continue;
+        if (!observation.result_reachable.contains(outer.rc_addr)) continue;
+        // Two arguments can be the same value; a link through any of them
+        // accounts for the allocation.
+        if (aliasOfLinkedArg(observation, linked, positions, outer.rc_addr)) continue;
+        addFinding(.{
+            .op = observation.op,
+            .rule = .result_holds_unnamed_argument_allocation,
+            .arg = position,
+        });
+    }
+}
+
+fn aliasOfLinkedArg(observation: Observation, linked: u64, positions: usize, rc_addr: usize) bool {
+    for (observation.args[0..positions], 0..) |arg, position| {
+        if (position >= 64) break;
+        const bit = @as(u64, 1) << @intCast(position);
+        if ((linked & bit) == 0) continue;
+        const outer = arg.outer orelse continue;
+        if (outer.rc_addr == rc_addr) return true;
+    }
+    return false;
+}
+
+fn addFinding(finding: Finding) void {
+    if (findings_len == findings_buf.len) {
+        dropped_findings += 1;
+        return;
+    }
+    findings_buf[findings_len] = finding;
+    findings_len += 1;
+}
+
+/// Ops with a nontrivial row that the sweep never executed.
+///
+/// A new builtin ships with a row; if no case drives it, the row is
+/// unverified. Exempt ops are ones no interpreted program can reach, and they
+/// must be listed with a reason at the exemption table.
+pub fn coverageGaps(observed: OpSet, exempt: OpSet, gaps: *OpSet) void {
+    gaps.* = OpSet.initEmpty();
+    for (std.enums.values(LowLevel)) |op| {
+        if (std.meta.eql(op.rcEffect(), RcEffect.none())) continue;
+        if (observed.contains(op)) continue;
+        if (exempt.contains(op)) continue;
+        gaps.insert(op);
+    }
+}
+
+/// Exemptions the sweep turned out to cover after all. A stale exemption hides
+/// the op from the coverage requirement for no reason.
+pub fn staleExemptions(observed: OpSet, exempt: OpSet, stale: *OpSet) void {
+    stale.* = OpSet.initEmpty();
+    var it = exempt.iterator();
+    while (it.next()) |op| {
+        if (observed.contains(op)) stale.insert(op);
+    }
+}
+
+test "coverage gaps name every uncovered nontrivial op" {
+    // Stand in for a newly added builtin: everything is covered except one op
+    // with a nontrivial row.
+    var observed = OpSet.initEmpty();
+    for (std.enums.values(LowLevel)) |op| observed.insert(op);
+    observed.remove(.str_concat);
+
+    var gaps = OpSet.initEmpty();
+    coverageGaps(observed, OpSet.initEmpty(), &gaps);
+
+    try std.testing.expectEqual(@as(usize, 1), gaps.count());
+    try std.testing.expect(gaps.contains(.str_concat));
+}
+
+test "an op with a trivial row needs no coverage" {
+    var gaps = OpSet.initEmpty();
+    coverageGaps(OpSet.initEmpty(), OpSet.initEmpty(), &gaps);
+
+    try std.testing.expect(!gaps.contains(.num_plus));
+    try std.testing.expect(gaps.contains(.str_concat));
+}
+
+test "an exemption suppresses a gap, and coverage makes it stale" {
+    var exempt = OpSet.initEmpty();
+    exempt.insert(.str_concat);
+
+    var gaps = OpSet.initEmpty();
+    coverageGaps(OpSet.initEmpty(), exempt, &gaps);
+    try std.testing.expect(!gaps.contains(.str_concat));
+
+    var observed = OpSet.initEmpty();
+    observed.insert(.str_concat);
+    var stale = OpSet.initEmpty();
+    staleExemptions(observed, exempt, &stale);
+    try std.testing.expect(stale.contains(.str_concat));
+}
+
+test "a uniqueness claim on a shared result is a finding" {
+    if (!enabled) return;
+
+    // The #10023 shape: the op returns a slice of its argument's allocation,
+    // whose count is 3 because the string is also held elsewhere.
+    var observation = Observation{ .op = .str_drop_prefix, .arg_count = 2 };
+    observation.args[0] = .{
+        .outer = .{ .rc_addr = 0x1000, .count = 3 },
+        .count_after = 3,
+    };
+    observation.result_outer = .{ .rc_addr = 0x1000, .count = 3 };
+    observation.result_reachable.add(0x1000);
+
+    begin();
+    defer end();
+
+    // The row as it stands accounts for this: shared interior, no birth.
+    record(observation);
+    try std.testing.expectEqual(@as(usize, 0), findings().len);
+
+    // The row as #10023 had it does not.
+    var reintroduced = RcEffect.retainsSharingArgs(1);
+    reintroduced.result_unique = true;
+    overrideRow(.str_drop_prefix, reintroduced);
+    defer clearOverrides();
+
+    record(observation);
+    try std.testing.expectEqual(@as(usize, 1), findings().len);
+    try std.testing.expectEqual(Rule.result_outlives_uniqueness_claim, findings()[0].rule);
+    try std.testing.expectEqual(LowLevel.str_drop_prefix, findings()[0].op);
+}
+
+test "a count the op adds on top of ARC's retain is a finding" {
+    if (!enabled) return;
+
+    var observation = Observation{ .op = .str_drop_prefix, .arg_count = 2 };
+    observation.args[0] = .{
+        .outer = .{ .rc_addr = 0x2000, .count = 1 },
+        .count_after = 2,
+    };
+
+    begin();
+    defer end();
+    record(observation);
+
+    try std.testing.expectEqual(@as(usize, 1), findings().len);
+    try std.testing.expectEqual(Rule.argument_counted_by_op_and_arc, findings()[0].rule);
+    try std.testing.expectEqual(@as(?usize, 0), findings()[0].arg);
+}
+
+test "releasing an argument the row does not consume is a finding" {
+    if (!enabled) return;
+
+    var observation = Observation{ .op = .str_drop_prefix, .arg_count = 2 };
+    observation.args[0] = .{
+        .outer = .{ .rc_addr = 0x3000, .count = 2 },
+        .count_after = 1,
+    };
+
+    begin();
+    defer end();
+    record(observation);
+
+    try std.testing.expectEqual(@as(usize, 1), findings().len);
+    try std.testing.expectEqual(Rule.argument_released_without_consume, findings()[0].rule);
+}
+
+test "static data is not observable" {
+    if (!enabled) return;
+
+    var observation = Observation{ .op = .str_drop_prefix, .arg_count = 2 };
+    observation.args[0] = .{
+        .outer = .{ .rc_addr = 0x4000, .count = builtins.utils.REFCOUNT_STATIC_DATA },
+        .count_after = builtins.utils.REFCOUNT_STATIC_DATA,
+    };
+    observation.result_outer = .{ .rc_addr = 0x4000, .count = builtins.utils.REFCOUNT_STATIC_DATA };
+
+    begin();
+    defer end();
+
+    var reintroduced = RcEffect.retainsSharingArgs(1);
+    reintroduced.result_unique = true;
+    overrideRow(.str_drop_prefix, reintroduced);
+    defer clearOverrides();
+
+    record(observation);
+    try std.testing.expectEqual(@as(usize, 0), findings().len);
+}

--- a/src/eval/test/rc_conformance_tests.zig
+++ b/src/eval/test/rc_conformance_tests.zig
@@ -1,0 +1,780 @@
+//! Per-op conformance sweep for the `RcEffect` table.
+//!
+//! Every low-level op whose `rcEffect()` is not `none()` makes a claim about
+//! refcounts that nothing else checks. This sweep runs Roc programs through the
+//! interpreter with the observer in `eval/rc_conformance.zig` watching, so each
+//! executed op is judged against its row, and then fails for any op with a
+//! nontrivial row that no case drove — a new builtin cannot ship an unverified
+//! row.
+//!
+//! Cases drive the copy-on-write ops in both uniqueness regimes. A value that
+//! is only used once is unique, so its op takes the in-place path and a wrong
+//! `result_unique` claim looks true; the same op applied to a value a list also
+//! holds runs on a count above 1, where the claim has to stand on its own.
+//! That second regime is what catches the #10023 shape.
+
+const std = @import("std");
+const base = @import("base");
+const eval = @import("eval");
+
+const helpers = eval.test_helpers;
+const rc_conformance = eval.rc_conformance;
+const Interpreter = eval.Interpreter;
+const RuntimeHostEnv = eval.RuntimeHostEnv;
+const LowLevel = base.LowLevel;
+const RcEffect = LowLevel.RcEffect;
+const Allocator = std.mem.Allocator;
+
+const SweepError = helpers.TestHelperError || eval.BuiltinModules.InitError || Interpreter.Error ||
+    RuntimeHostEnv.LeakError || error{
+    RcEffectConformanceFailed,
+    CaseSourceDoesNotCheck,
+};
+
+/// A program whose execution drives one or more nontrivial rows.
+const Case = struct {
+    name: []const u8,
+    source: []const u8,
+    source_kind: helpers.SourceKind = .expr,
+    /// Lower with wrapper inlining, the way optimized builds do. Some ops only
+    /// exist after a wrapper-shaped proc survives to the LIR passes that
+    /// rewrite it.
+    inline_wrappers: bool = false,
+    /// Allocations still live when the program returns. Cases whose value is a
+    /// number leave nothing behind; a case that returns a heap value leaves it
+    /// live, because the harness never releases the entrypoint's result.
+    expected_live_allocations: u32 = 0,
+};
+
+/// An op no interpreted Roc program can reach, with the reason it cannot.
+const Exemption = struct {
+    op: LowLevel,
+    reason: []const u8,
+};
+
+/// Strings long enough that the small-string representation cannot hold them,
+/// built at runtime so they are heap allocations rather than static data.
+/// Static data has a constant refcount, which no op can move.
+const cases = [_]Case{
+    .{
+        .name = "str copy-on-write ops, unique and shared inputs",
+        .source =
+        \\{
+        \\    shared = Str.concat("a string long enough to need the heap ", "plus a tail")
+        \\    holder = [shared, shared]
+        \\    unique_trim = Str.trim(Str.concat("   a string long enough to need the heap  ", "  "))
+        \\    shared_trim = Str.trim(shared)
+        \\    unique_start = Str.trim_start(Str.concat("   another heap string with leading space ", "tail"))
+        \\    shared_start = Str.trim_start(shared)
+        \\    unique_end = Str.trim_end(Str.concat("another heap string with trailing space  ", "  "))
+        \\    shared_end = Str.trim_end(shared)
+        \\    unique_lower = Str.with_ascii_lowercased(Str.concat("A HEAP STRING LONG ENOUGH ", "TO ALLOCATE"))
+        \\    shared_lower = Str.with_ascii_lowercased(shared)
+        \\    unique_upper = Str.with_ascii_uppercased(Str.concat("a heap string long enough ", "to allocate"))
+        \\    shared_upper = Str.with_ascii_uppercased(shared)
+        \\    unique_reserve = Str.reserve(Str.concat("a heap string long enough ", "to allocate"), 128)
+        \\    shared_reserve = Str.reserve(shared, 128)
+        \\    trimmed_capacity = Str.release_excess_capacity(unique_reserve)
+        \\    shared_capacity = Str.release_excess_capacity(shared_reserve)
+        \\    Str.count_utf8_bytes(unique_trim)
+        \\        + Str.count_utf8_bytes(shared_trim)
+        \\        + Str.count_utf8_bytes(unique_start)
+        \\        + Str.count_utf8_bytes(shared_start)
+        \\        + Str.count_utf8_bytes(unique_end)
+        \\        + Str.count_utf8_bytes(shared_end)
+        \\        + Str.count_utf8_bytes(unique_lower)
+        \\        + Str.count_utf8_bytes(shared_lower)
+        \\        + Str.count_utf8_bytes(unique_upper)
+        \\        + Str.count_utf8_bytes(shared_upper)
+        \\        + Str.count_utf8_bytes(trimmed_capacity)
+        \\        + Str.count_utf8_bytes(shared_capacity)
+        \\        + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        // Concatenating nothing onto a value is the path where a
+        // copy-on-write op can hand back its argument without either copying
+        // it or checking whether anyone else holds it.
+        .name = "concatenating an empty value onto a shared one",
+        .source =
+        \\{
+        \\    shared_str = Str.concat("a string long enough to need the heap ", "plus a tail")
+        \\    str_holder = [shared_str, shared_str]
+        \\    shared_list = List.concat(
+        \\        ["a list element long enough to allocate", "another list element long enough"],
+        \\        ["a third list element long enough to allocate"],
+        \\    )
+        \\    list_holder = [shared_list, shared_list]
+        \\    nothing_str = Str.repeat("x", 0)
+        \\    nothing_list : List(Str)
+        \\    nothing_list = List.with_capacity(0)
+        \\    str_tail = Str.concat(shared_str, nothing_str)
+        \\    list_tail = List.concat(shared_list, nothing_list)
+        \\    list_head = List.concat(nothing_list, shared_list)
+        \\    Str.count_utf8_bytes(str_tail)
+        \\        + List.len(list_tail)
+        \\        + List.len(list_head)
+        \\        + List.len(str_holder)
+        \\        + List.len(list_holder)
+        \\}
+        ,
+    },
+    .{
+        .name = "str slice ops share their argument's allocation",
+        .source =
+        \\{
+        \\    shared = Str.concat("prefix-a string long enough to need the heap ", "plus a tail")
+        \\    holder = [shared, shared]
+        \\    unique = Str.concat("prefix-another string long enough for the heap ", "and a tail")
+        \\    unique_dropped = Str.drop_prefix(unique, "prefix-")
+        \\    shared_dropped = Str.drop_prefix(shared, "prefix-")
+        \\    unique_suffix = Str.drop_suffix(unique, "a tail")
+        \\    shared_suffix = Str.drop_suffix(shared, "a tail")
+        \\    unique_caseless = Str.drop_prefix_caseless_ascii(unique, "PREFIX-").ok_or("")
+        \\    shared_caseless = Str.drop_prefix_caseless_ascii(shared, "PREFIX-").ok_or("")
+        \\    unique_first = Str.split_first(unique, "-").ok_or({ before: "", after: "" }).after
+        \\    shared_first = Str.split_first(shared, "-").ok_or({ before: "", after: "" }).after
+        \\    unique_last = Str.split_last(unique, " ").ok_or({ before: "", after: "" }).before
+        \\    shared_last = Str.split_last(shared, " ").ok_or({ before: "", after: "" }).before
+        \\    unique_sub = Str.drop_last_bytes(unique, 6).ok_or("")
+        \\    shared_sub = Str.drop_last_bytes(shared, 6).ok_or("")
+        \\    Str.count_utf8_bytes(unique_dropped)
+        \\        + Str.count_utf8_bytes(shared_dropped)
+        \\        + Str.count_utf8_bytes(unique_suffix)
+        \\        + Str.count_utf8_bytes(shared_suffix)
+        \\        + Str.count_utf8_bytes(unique_caseless)
+        \\        + Str.count_utf8_bytes(shared_caseless)
+        \\        + Str.count_utf8_bytes(unique_first)
+        \\        + Str.count_utf8_bytes(shared_first)
+        \\        + Str.count_utf8_bytes(unique_last)
+        \\        + Str.count_utf8_bytes(shared_last)
+        \\        + Str.count_utf8_bytes(unique_sub)
+        \\        + Str.count_utf8_bytes(shared_sub)
+        \\        + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        .name = "str utf8, split, and join",
+        .source =
+        \\{
+        \\    shared = Str.concat("alpha,beta,gamma,", "delta epsilon zeta eta theta")
+        \\    holder = [shared, shared]
+        \\    unique = Str.concat("alpha,beta,gamma,", "delta epsilon zeta eta iota")
+        \\    unique_bytes = Str.to_utf8(unique)
+        \\    shared_bytes = Str.to_utf8(shared)
+        \\    lossy = Str.from_utf8_lossy(shared_bytes)
+        \\    decoded = Str.from_utf8(unique_bytes).ok_or("")
+        \\    unique_parts = Str.split_on(unique, ",")
+        \\    shared_parts = Str.split_on(shared, ",")
+        \\    joined = Str.join_with(unique_parts, "-")
+        \\    repeated = Str.repeat("a string long enough to need the heap ", 3)
+        \\    empty_with_capacity = Str.with_capacity(128)
+        \\    Str.count_utf8_bytes(lossy)
+        \\        + Str.count_utf8_bytes(decoded)
+        \\        + Str.count_utf8_bytes(joined)
+        \\        + Str.count_utf8_bytes(repeated)
+        \\        + Str.count_utf8_bytes(empty_with_capacity)
+        \\        + List.len(shared_parts)
+        \\        + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        .name = "numeric to_str allocates a fresh string",
+        .source =
+        \\{
+        \\    parts = [
+        \\        U8.to_str(37),
+        \\        I8.to_str(-37),
+        \\        U16.to_str(1037),
+        \\        I16.to_str(-1037),
+        \\        U32.to_str(100037),
+        \\        I32.to_str(-100037),
+        \\        U64.to_str(10000000037),
+        \\        I64.to_str(-10000000037),
+        \\        U128.to_str(10000000037),
+        \\        I128.to_str(-10000000037),
+        \\        Dec.to_str(3.25),
+        \\        F32.to_str(3.25),
+        \\        F64.to_str(3.25),
+        \\    ]
+        \\    List.len(parts) + Str.count_utf8_bytes(Str.join_with(parts, ","))
+        \\}
+        ,
+    },
+    .{
+        .name = "list copy-on-write and slice ops, unique and shared inputs",
+        .source =
+        \\{
+        \\    shared = List.concat(
+        \\        ["a list element long enough to allocate", "another list element long enough"],
+        \\        ["a third list element long enough to allocate"],
+        \\    )
+        \\    holder = [shared, shared]
+        \\    unique = List.concat(
+        \\        ["a list element long enough to allocate", "another list element long enough"],
+        \\        ["a fourth list element long enough to allocate"],
+        \\    )
+        \\    unique_reversed = List.rev(unique)
+        \\    shared_reversed = List.rev(shared)
+        \\    unique_reserved = List.reserve(unique, 64)
+        \\    shared_reserved = List.reserve(shared, 64)
+        \\    unique_trimmed = List.release_excess_capacity(unique_reserved)
+        \\    shared_trimmed = List.release_excess_capacity(shared_reserved)
+        \\    unique_dropped = List.drop_at(unique, 1)
+        \\    shared_dropped = List.drop_at(shared, 1)
+        \\    unique_sublist = List.sublist(unique, { start: 1, len: 2 })
+        \\    shared_sublist = List.sublist(shared, { start: 1, len: 2 })
+        \\    List.len(unique_reversed)
+        \\        + List.len(shared_reversed)
+        \\        + List.len(unique_trimmed)
+        \\        + List.len(shared_trimmed)
+        \\        + List.len(unique_dropped)
+        \\        + List.len(shared_dropped)
+        \\        + List.len(unique_sublist)
+        \\        + List.len(shared_sublist)
+        \\        + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        .name = "list element ops move ownership in and out",
+        .source =
+        \\{
+        \\    shared = List.concat(
+        \\        ["a list element long enough to allocate", "another list element long enough"],
+        \\        ["a third list element long enough to allocate"],
+        \\    )
+        \\    holder = [shared, shared]
+        \\    unique = List.concat(
+        \\        ["a list element long enough to allocate", "another list element long enough"],
+        \\        ["a fourth list element long enough to allocate"],
+        \\    )
+        \\    element = Str.concat("an element long enough to allocate ", "on the heap")
+        \\    unique_prepended = List.prepend(unique, element)
+        \\    shared_prepended = List.prepend(shared, element)
+        \\    unique_appended = List.append(unique, element)
+        \\    shared_appended = List.append(shared, element)
+        \\    unique_set = List.set(unique, 0, element).ok_or([])
+        \\    shared_set = List.set(shared, 0, element).ok_or([])
+        \\    unique_replaced = List.replace(unique, 1, element).ok_or({ list: [], prev: "" })
+        \\    shared_replaced = List.replace(shared, 1, element).ok_or({ list: [], prev: "" })
+        \\    unique_swapped = List.swap(unique, 0, 1).ok_or([])
+        \\    shared_swapped = List.swap(shared, 0, 1).ok_or([])
+        \\    with_capacity : List(Str)
+        \\    with_capacity = List.with_capacity(8)
+        \\    first_len = Str.count_utf8_bytes(List.first(shared).ok_or(""))
+        \\    last_len = Str.count_utf8_bytes(List.last(shared).ok_or(""))
+        \\    got_len = Str.count_utf8_bytes(List.get(shared, 1).ok_or(""))
+        \\    List.len(unique_prepended)
+        \\        + List.len(shared_prepended)
+        \\        + List.len(unique_appended)
+        \\        + List.len(shared_appended)
+        \\        + List.len(unique_set)
+        \\        + List.len(shared_set)
+        \\        + List.len(unique_replaced.list)
+        \\        + List.len(shared_replaced.list)
+        \\        + List.len(unique_swapped)
+        \\        + List.len(shared_swapped)
+        \\        + List.len(with_capacity)
+        \\        + first_len
+        \\        + last_len
+        \\        + got_len
+        \\        + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        .name = "list map reuses or rebuilds its input allocation",
+        .source =
+        \\{
+        \\    shared = List.concat(
+        \\        ["a list element long enough to allocate", "another list element long enough"],
+        \\        ["a third list element long enough to allocate"],
+        \\    )
+        \\    holder = [shared, shared]
+        \\    unique = List.concat(
+        \\        ["a list element long enough to allocate", "another list element long enough"],
+        \\        ["a fourth list element long enough to allocate"],
+        \\    )
+        \\    unique_mapped = List.map(unique, |text| Str.concat(text, "!"))
+        \\    shared_mapped = List.map(shared, |text| Str.concat(text, "!"))
+        \\    lengths = List.map(shared, |text| Str.count_utf8_bytes(text))
+        \\    List.len(unique_mapped) + List.len(shared_mapped) + List.len(lengths) + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        .name = "boxed values are allocated, read, and updated",
+        .source =
+        \\{
+        \\    payload = Str.concat("a boxed payload long enough ", "to allocate on the heap")
+        \\    holder = [payload, payload]
+        \\    boxed = Box.box(payload)
+        \\    unboxed = Box.unbox(boxed)
+        \\    Str.count_utf8_bytes(unboxed) + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        .name = "crypto hashers allocate their state and digests",
+        .source =
+        \\{
+        \\    message = Str.to_utf8(Str.concat("a message long enough to allocate ", "on the heap"))
+        \\    sha_digest = Crypto.SHA256.hash(message)
+        \\    sha_incremental = Crypto.SHA256.Hasher.empty()
+        \\        .write(message)
+        \\        .finish()
+        \\    blake_digest = Crypto.BLAKE3.hash(message)
+        \\    blake_incremental = Crypto.BLAKE3.Hasher.empty()
+        \\        .write(message)
+        \\        .finish()
+        \\    Str.count_utf8_bytes(Crypto.SHA256.Digest.to_hex(sha_digest))
+        \\        + List.len(Crypto.SHA256.Digest.to_bytes(sha_incremental))
+        \\        + Str.count_utf8_bytes(Crypto.BLAKE3.Digest.to_hex(blake_digest))
+        \\        + List.len(Crypto.BLAKE3.Digest.to_bytes(blake_incremental))
+        \\}
+        ,
+    },
+    .{
+        .name = "list slice ops return a slice or a copy",
+        .source =
+        \\{
+        \\    shared = List.concat(
+        \\        ["a list element long enough to allocate", "another list element long enough"],
+        \\        ["a third list element long enough to allocate"],
+        \\    )
+        \\    holder = [shared, shared]
+        \\    unique = List.concat(
+        \\        ["a list element long enough to allocate", "another list element long enough"],
+        \\        ["a fourth list element long enough to allocate"],
+        \\    )
+        \\    unique_head = List.drop_first(unique, 1)
+        \\    shared_head = List.drop_first(shared, 1)
+        \\    unique_tail = List.drop_last(unique, 1)
+        \\    shared_tail = List.drop_last(shared, 1)
+        \\    unique_taken = List.take_first(unique, 2)
+        \\    shared_taken = List.take_first(shared, 2)
+        \\    unique_taken_last = List.take_last(unique, 2)
+        \\    shared_taken_last = List.take_last(shared, 2)
+        \\    unique_split = List.split_first(unique, "another list element long enough")
+        \\        .ok_or({ before: [], after: [] })
+        \\    shared_split = List.split_first(shared, "another list element long enough")
+        \\        .ok_or({ before: [], after: [] })
+        \\    unique_split_last = List.split_last(unique, "another list element long enough")
+        \\        .ok_or({ before: [], after: [] })
+        \\    shared_split_last = List.split_last(shared, "another list element long enough")
+        \\        .ok_or({ before: [], after: [] })
+        \\    List.len(unique_head)
+        \\        + List.len(shared_head)
+        \\        + List.len(unique_tail)
+        \\        + List.len(shared_tail)
+        \\        + List.len(unique_taken)
+        \\        + List.len(shared_taken)
+        \\        + List.len(unique_taken_last)
+        \\        + List.len(shared_taken_last)
+        \\        + List.len(unique_split.after)
+        \\        + List.len(shared_split.after)
+        \\        + List.len(unique_split_last.before)
+        \\        + List.len(shared_split_last.before)
+        \\        + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        .name = "inspect renders values as fresh strings",
+        .source =
+        \\{
+        \\    text = Str.concat("a value long enough to allocate ", "on the heap")
+        \\    holder = [text, text]
+        \\    rendered = Str.inspect(text)
+        \\    rendered_list = Str.inspect([text, text])
+        \\    rendered_num = Str.inspect(1234567890.I64)
+        \\    Str.count_utf8_bytes(rendered)
+        \\        + Str.count_utf8_bytes(rendered_list)
+        \\        + Str.count_utf8_bytes(rendered_num)
+        \\        + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        .name = "SIMD byte vectors load from and store into byte lists",
+        .source =
+        \\{
+        \\    bytes = Str.to_utf8(Str.concat("0123456789abcdef", "0123456789abcdef"))
+        \\    holder = [bytes, bytes]
+        \\    vector = U8x16.load(bytes, 0).ok_or(U8x16.default())
+        \\    stored_unique = U8x16.store(vector, Str.to_utf8(Str.concat("0123456789abcdef", "ghijklmnop")), 0)
+        \\        .ok_or([])
+        \\    stored_shared = U8x16.store(vector, bytes, 16).ok_or([])
+        \\    appended = U8x16.append_to(vector, Str.to_utf8(Str.concat("0123456789abcdef", "qrstuv")))
+        \\    appended_shared = U8x16.append_to(vector, bytes)
+        \\    List.len(stored_unique)
+        \\        + List.len(stored_shared)
+        \\        + List.len(appended)
+        \\        + List.len(appended_shared)
+        \\        + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        .name = "boxed payload updates reuse the box allocation",
+        .source_kind = .module,
+        .source =
+        \\grow : Box(Str) -> Box(Str)
+        \\grow = |boxed| Box.box(Str.concat(Box.unbox(boxed), "!"))
+        \\
+        \\main = || {
+        \\    payload = Str.concat("a boxed payload long enough ", "to allocate on the heap")
+        \\    unique_grown = grow(Box.box(payload))
+        \\    shared_box = Box.box(payload)
+        \\    holder = [shared_box, shared_box]
+        \\    shared_grown = grow(shared_box)
+        \\    Str.count_utf8_bytes(Box.unbox(unique_grown))
+        \\        + Str.count_utf8_bytes(Box.unbox(shared_grown))
+        \\        + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        .name = "closures carry captured allocations through erased callables",
+        .source_kind = .module,
+        .source =
+        \\apply : Box((Str -> Str)), Str -> Str
+        \\apply = |boxed, text| Box.unbox(boxed)(text)
+        \\
+        \\main = || {
+        \\    prefix = Str.concat("a captured prefix long enough ", "to allocate on the heap")
+        \\    holder = [prefix, prefix]
+        \\    prepend = Box.box(|text| Str.concat(prefix, text))
+        \\    once = apply(prepend, "one")
+        \\    twice = apply(prepend, "two")
+        \\    Str.count_utf8_bytes(once) + Str.count_utf8_bytes(twice) + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        // The TRMC pass rewrites this recursion into a loop that writes each
+        // cell through a pointer, which is where `ptr_alloca`,
+        // `box_alloc_zeroed`, and `ptr_store` come from.
+        .name = "tail-recursion modulo cons builds cells through pointer stores",
+        .source_kind = .module,
+        .source =
+        \\StrList := [Nil, Cons(Str, StrList)]
+        \\
+        \\repeat : Str, I64 -> StrList
+        \\repeat = |value, n| if n <= 0.I64 StrList.Nil else StrList.Cons(value, repeat(value, n - 1))
+        \\
+        \\length : StrList -> I64
+        \\length = |list| match list {
+        \\    Nil => 0
+        \\    Cons(_, rest) => 1 + length(rest)
+        \\}
+        \\
+        \\main = || {
+        \\    text = Str.concat("a repeated element long enough ", "to allocate on the heap")
+        \\    holder = [text, text]
+        \\    length(repeat(text, 4.I64)) + List.len(holder).to_i64_wrap()
+        \\}
+        ,
+    },
+    .{
+        // List rest patterns lower to `list_take_first`/`list_take_last` over
+        // the matched list, and to `list_get_unsafe` for the fixed elements.
+        .name = "list rest patterns slice the matched list",
+        .source_kind = .module,
+        .source =
+        \\count_tail : List(Str) -> U64
+        \\count_tail = |items| match items {
+        \\    [first, .. as rest] => Str.count_utf8_bytes(first) + List.len(rest)
+        \\    [] => 0
+        \\}
+        \\
+        \\count_middle : List(Str) -> U64
+        \\count_middle = |items| match items {
+        \\    [first, .. as rest, last] =>
+        \\        Str.count_utf8_bytes(first) + List.len(rest) + Str.count_utf8_bytes(last)
+        \\    _ => 0
+        \\}
+        \\
+        \\main = || {
+        \\    shared = List.concat(
+        \\        ["a list element long enough to allocate", "another list element long enough"],
+        \\        ["a third list element long enough to allocate"],
+        \\    )
+        \\    holder = [shared, shared]
+        \\    count_tail(shared) + count_middle(shared) + List.len(holder)
+        \\}
+        ,
+    },
+    .{
+        // A wrapper that unboxes, updates, and reboxes is rewritten by
+        // `lir/box_reuse.zig` into `box_prepare_update` plus pointer traffic.
+        .name = "boxed model updates reuse the box allocation",
+        .inline_wrappers = true,
+        // The result is the updated box, so the box and the string it holds are
+        // still live when the program returns.
+        .expected_live_allocations = 2,
+        .source =
+        \\{
+        \\    update : { tick : U64, label : Str } -> { tick : U64, label : Str }
+        \\    update = |model| {
+        \\        tick = model.tick + 1
+        \\        { ..model, tick }
+        \\    }
+        \\
+        \\    step : Box({ tick : U64, label : Str }) -> Box({ tick : U64, label : Str })
+        \\    step = |boxed| Box.box(update(Box.unbox(boxed)))
+        \\
+        \\    label = Str.concat("a model label long enough ", "to allocate on the heap")
+        \\    step(Box.box({ tick: 0, label }))
+        \\}
+        ,
+    },
+};
+
+/// Ops that no Roc program reaches. Each needs a reason; the sweep fails when
+/// one of these turns out to be covered after all, so a reason that stops being
+/// true cannot sit here unnoticed.
+///
+/// Every entry here is an op nothing produces: no name in `Builtin.roc` maps to
+/// it through `canonicalize/BuiltinLowLevel.zig`, and no lowering pass emits
+/// it. They are reachable only from a backend's switch, which is why their rows
+/// have gone unchecked. Wiring one up is what makes its row matter, and doing
+/// that removes it from this table.
+const exemptions = [_]Exemption{
+    .{ .op = .list_first, .reason = "no producer: List.first lowers through list_get_unsafe" },
+    .{ .op = .list_last, .reason = "no producer: List.last lowers through list_get_unsafe" },
+    .{ .op = .list_drop_first, .reason = "no producer: List.drop_first lowers through list_sublist" },
+    .{ .op = .list_drop_last, .reason = "no producer: List.drop_last lowers through list_sublist" },
+    .{ .op = .list_reverse, .reason = "no producer: List.rev is written in Roc over list_get_unsafe" },
+    .{ .op = .list_split_first, .reason = "no producer: List.split_first is written in Roc" },
+    .{ .op = .list_split_last, .reason = "no producer: List.split_last is written in Roc" },
+    .{ .op = .num_to_str, .reason = "no producer: each numeric type maps to its own <type>_to_str op" },
+};
+
+/// Loaded once and kept for the life of the test binary: publishing the
+/// Builtin module for every case would dominate the sweep's runtime.
+var shared_builtins: ?eval.BuiltinModules = null;
+
+fn sharedPrePublishedBuiltin(allocator: Allocator) SweepError!helpers.PrePublishedBuiltin {
+    if (shared_builtins == null) {
+        shared_builtins = try eval.BuiltinModules.init(allocator);
+    }
+    return .{
+        .env = shared_builtins.?.builtin_module.env,
+        .indices = shared_builtins.?.builtin_indices,
+        .artifact = &shared_builtins.?.checked_artifact,
+    };
+}
+
+/// Fail with rendered diagnostics when a case's source does not check.
+///
+/// A source with problems still lowers to something runnable, but not to the
+/// program the case meant to write, and its ops quietly go uncovered.
+fn assertCaseChecks(allocator: Allocator, case: Case) SweepError!void {
+    var resources = try helpers.parseAndCheckProgramForProblemsWithBuiltin(
+        allocator,
+        case.source_kind,
+        case.source,
+        &.{},
+        try sharedPrePublishedBuiltin(allocator),
+    );
+    defer resources.deinit(allocator);
+
+    const diagnostics = try resources.main.module_env.getDiagnostics();
+    defer allocator.free(diagnostics);
+
+    const problems = resources.main.parse_ast.tokenize_diagnostics.items.len +
+        resources.main.parse_ast.parse_diagnostics.items.len +
+        diagnostics.len +
+        resources.main.checker.problems.problems.items.len;
+    if (problems == 0) return;
+
+    const rendered = try helpers.renderProblems(allocator, case.source_kind, case.source);
+    defer allocator.free(rendered);
+    std.debug.print("rc conformance: [{s}] source does not check:\n{s}\n", .{ case.name, rendered });
+    return error.CaseSourceDoesNotCheck;
+}
+
+/// Compile and run one case with the observer watching every low-level op.
+fn runCase(allocator: Allocator, case: Case) SweepError!void {
+    // `compileAllocationProgram` is the only public entry that lowers with
+    // wrapper inlining, and it does not take a pre-published Builtin, so cases
+    // pay for loading one only when they need that lowering.
+    var wrapper_compiled = if (case.inline_wrappers)
+        try helpers.compileAllocationProgram(allocator, std.testing.io, case.source_kind, case.source, &.{})
+    else
+        null;
+    defer if (wrapper_compiled) |*compiled| compiled.deinit(allocator);
+
+    var plain_compiled = if (case.inline_wrappers)
+        null
+    else
+        try helpers.compileProgramForTargetWithBuiltin(
+            allocator,
+            std.testing.io,
+            case.source_kind,
+            case.source,
+            &.{},
+            .native,
+            try sharedPrePublishedBuiltin(allocator),
+        );
+    defer if (plain_compiled) |*compiled| compiled.deinit(allocator);
+
+    const lowered = if (wrapper_compiled) |*compiled| &compiled.lowered else &plain_compiled.?.lowered;
+
+    var runtime_env = RuntimeHostEnv.init(allocator);
+    defer runtime_env.deinit();
+
+    var interp = try Interpreter.init(
+        allocator,
+        &lowered.view.store,
+        &lowered.view.layouts,
+        runtime_env.get_ops(),
+        .preserve,
+    );
+    defer interp.deinit();
+
+    const arg_layouts = try helpers.mainProcArgLayouts(allocator, lowered);
+    defer allocator.free(arg_layouts);
+
+    rc_conformance.begin();
+    defer rc_conformance.end();
+
+    switch (try interp.eval(.{
+        .proc_id = lowered.mainProc(),
+        .arg_layouts = arg_layouts,
+    })) {
+        .value => {},
+    }
+
+    // A row that leaks a reference shows up here as well as in the per-op
+    // findings: whatever the program still holds when it returns is exactly
+    // what its value keeps alive, and nothing more.
+    var snapshot = try runtime_env.snapshot(allocator);
+    defer snapshot.deinit(allocator);
+    if (snapshot.allocation_count != case.expected_live_allocations) {
+        std.debug.print(
+            "rc conformance: [{s}] {d} allocations live at return, expected {d}\n",
+            .{ case.name, snapshot.allocation_count, case.expected_live_allocations },
+        );
+        return error.RcEffectConformanceFailed;
+    }
+}
+
+fn reportFindings(case_name: []const u8) usize {
+    const found = rc_conformance.findings();
+    for (found) |finding| {
+        std.debug.print("rc conformance: [{s}] {f}\n", .{ case_name, finding });
+    }
+    if (rc_conformance.droppedFindings() > 0) {
+        std.debug.print(
+            "rc conformance: [{s}] {d} further findings dropped\n",
+            .{ case_name, rc_conformance.droppedFindings() },
+        );
+    }
+    return found.len + rc_conformance.droppedFindings();
+}
+
+fn exemptOps() rc_conformance.OpSet {
+    var set = rc_conformance.OpSet.initEmpty();
+    for (exemptions) |exemption| set.insert(exemption.op);
+    return set;
+}
+
+test "rc effect conformance: every case source checks cleanly" {
+    const allocator = base.defaultGpa();
+    var failures: usize = 0;
+    for (cases) |case| {
+        assertCaseChecks(allocator, case) catch |err| {
+            std.debug.print("rc conformance: [{s}] {s}\n", .{ case.name, @errorName(err) });
+            failures += 1;
+        };
+    }
+    if (failures != 0) return error.CaseSourceDoesNotCheck;
+}
+
+test "rc effect conformance: every executed op matches its row" {
+    if (!rc_conformance.enabled) return error.SkipZigTest;
+
+    const allocator = base.defaultGpa();
+    var covered = rc_conformance.OpSet.initEmpty();
+    var failures: usize = 0;
+
+    for (cases) |case| {
+        runCase(allocator, case) catch |err| {
+            std.debug.print("rc conformance: [{s}] run failed: {s}\n", .{ case.name, @errorName(err) });
+            failures += 1;
+        };
+        covered.setUnion(rc_conformance.covered());
+        failures += reportFindings(case.name);
+    }
+
+    var gaps = rc_conformance.OpSet.initEmpty();
+    rc_conformance.coverageGaps(covered, exemptOps(), &gaps);
+    if (gaps.count() > 0) {
+        var it = gaps.iterator();
+        while (it.next()) |op| {
+            std.debug.print(
+                "rc conformance: op {s} has a nontrivial RcEffect row and no case drives it\n",
+                .{@tagName(op)},
+            );
+        }
+        failures += gaps.count();
+    }
+
+    var stale = rc_conformance.OpSet.initEmpty();
+    rc_conformance.staleExemptions(covered, exemptOps(), &stale);
+    if (stale.count() > 0) {
+        var it = stale.iterator();
+        while (it.next()) |op| {
+            std.debug.print(
+                "rc conformance: op {s} is exempt from coverage but the sweep covered it\n",
+                .{@tagName(op)},
+            );
+        }
+        failures += stale.count();
+    }
+
+    if (failures != 0) return error.RcEffectConformanceFailed;
+}
+
+test "rc effect conformance: the #10023 row fails against the real builtin" {
+    if (!rc_conformance.enabled) return error.SkipZigTest;
+
+    const allocator = base.defaultGpa();
+
+    // `Str.drop_prefix` returns a slice of its argument's allocation. Before PR
+    // roc-lang/roc#10023 its row also claimed `result_unique`, so ARC counted a
+    // birth on top of the link to the lender and every call leaked one
+    // reference to the input string.
+    var reintroduced = RcEffect.retainsSharingArgs(1);
+    reintroduced.result_unique = true;
+    rc_conformance.overrideRow(.str_drop_prefix, reintroduced);
+    defer rc_conformance.clearOverrides();
+
+    const case = Case{
+        .name = "shared input to Str.drop_prefix",
+        .source =
+        \\{
+        \\    shared = Str.concat("prefix-a string long enough to need the heap ", "plus a tail")
+        \\    holder = [shared, shared]
+        \\    dropped = Str.drop_prefix(shared, "prefix-")
+        \\    Str.count_utf8_bytes(dropped) + List.len(holder)
+        \\}
+        ,
+    };
+
+    try runCase(allocator, case);
+
+    var saw_uniqueness_finding = false;
+    for (rc_conformance.findings()) |finding| {
+        if (finding.op != .str_drop_prefix) continue;
+        if (finding.rule != .result_outlives_uniqueness_claim) continue;
+        saw_uniqueness_finding = true;
+    }
+    try std.testing.expect(saw_uniqueness_finding);
+}

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -93,9 +93,11 @@
 //! entry point panics in debug builds; release builds never run the certifier.
 
 const std = @import("std");
+const base = @import("base");
 const collections = @import("collections");
 const core = @import("lir_core");
 const layout_mod = @import("layout");
+const rc_effect_rules = base.rc_effect_rules;
 const arc_sig = @import("arc_sig.zig");
 const arc_solve = @import("arc_solve.zig");
 
@@ -3292,6 +3294,18 @@ const Certifier = struct {
 
     fn applyLowLevel(self: *Certifier, state: *State, assign: anytype) CertifyError!void {
         const arg_locals = self.store.getLocalSpan(assign.args);
+
+        // The masks in an `RcEffect` row name argument positions, but the row
+        // is written next to the op's name, not its signature. A bit above the
+        // real argument count names nothing: the ownership it describes is
+        // dropped instead of applied. This is the one place where a row and the
+        // arguments it talks about are both in hand.
+        if (rc_effect_rules.maskExceedsArgCount(assign.rc_effect, GuardedList.borrowLen(arg_locals))) |position| {
+            return self.fail(
+                "low-level op {s} has an RcEffect mask naming argument {d}, but it takes {d} arguments",
+                .{ @tagName(assign.op), position, GuardedList.borrowLen(arg_locals) },
+            );
+        }
 
         var arg_values_buffer: [64]ValueId = undefined;
         for (0..GuardedList.borrowLen(arg_locals)) |index| {


### PR DESCRIPTION
Ownership behavior for every low-level builtin lives in one central table — `RcEffect`, returned per-op by `LowLevel.rcEffect()` — and nothing checked a row against the builtin it describes. A wrong row is not a type error, not a panic, and not a failing functional test; it is a silent refcount imbalance in generated code, which is exactly how #9953 shipped. This adds two enforcement layers, and fixes the rows and builtins that those layers immediately found wrong.

`base/rc_effect_rules.zig` states the structural rules a row has to satisfy — one implication per field, derived from the proof obligations now documented on `RcEffect` itself — and a comptime sweep over the whole table turns a row whose fields contradict each other into a compile error naming the op and the rule it broke. `run-test-rc-effect-rejected-row` builds a probe file that writes such a row and requires the compile to fail, so the guarantee is tested rather than assumed. `eval/rc_conformance.zig` covers the rest: it watches every low-level statement the interpreter executes, records which allocations were born, which counts moved, and which of the result's allocations came from an argument, and judges that against the row. Every rule reads "observed behavior the row does not account for" rather than "declared behavior that did not happen", because a row describes what an op *may* do and one execution takes one path. The sweep in `eval/test/rc_conformance_tests.zig` drives every op whose row is not `none()`, in both uniqueness regimes, and fails for any op with a nontrivial row that no case drives — a new builtin cannot ship an unverified row. Ops that nothing produces (no name in `Builtin.roc` maps to them and no lowering emits them) sit in an exemption table with that reason, and the sweep fails if one of them ever becomes reachable without being removed from it. Mask-versus-arity is checked where a row and its arguments actually meet: the ARC borrow certifier, over every low-level statement in every debug build. All of it is debug-only; `rcEffect()` is untouched and release builds carry no observer.

Three rows turned out not to match their builtins. `str_trim`, `str_trim_start`, and `str_trim_end` return a seamless slice of a shared input instead of copying it, so their result's outermost allocation is the argument's, with the argument's count — they move to `runtimeUniquenessMaybeSharedResult`, the regime the analogous list slice ops already used. `str_split_on` increfs its source string once per segment it slices out, so its row now records that instead of claiming it touches no counts. Two builtins contradicted rows worth keeping: `strConcat` and `listConcat` returned an argument unchanged when the other side was empty, even when that argument was shared, while their rows claim `result_unique`. ARC takes that claim at face value and records a birth, which can hand a later op a static in-place path into an allocation another owner still holds, so both now hand the argument back only when nobody else holds it and copy otherwise. The #9953 Json.parse regression stays pinned where it was, in the runtime host-effects tests.
