### PR TITLE
Add Dec.to_attos and Dec.from_attos

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -2594,11 +2594,13 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 .i128_to_u32_wrap,
                 .i128_to_u64_wrap,
                 .i128_to_u128_wrap,
+                .dec_to_attos,
+                .dec_from_attos,
                 => {
                     if (args.len < 1) unreachable;
                     const src_loc = try self.emitValueLocal(GuardedList.at(args, 0));
                     const src_signedness: std.builtin.Signedness = switch (ll.op) {
-                        .i128_to_i8_wrap, .i128_to_i16_wrap, .i128_to_i32_wrap, .i128_to_i64_wrap, .i128_to_u8_wrap, .i128_to_u16_wrap, .i128_to_u32_wrap, .i128_to_u64_wrap, .i128_to_u128_wrap => .signed,
+                        .i128_to_i8_wrap, .i128_to_i16_wrap, .i128_to_i32_wrap, .i128_to_i64_wrap, .i128_to_u8_wrap, .i128_to_u16_wrap, .i128_to_u32_wrap, .i128_to_u64_wrap, .i128_to_u128_wrap, .dec_from_attos, .dec_to_attos => .signed,
                         else => .unsigned,
                     };
                     const parts = try self.getI128Parts(src_loc, src_signedness);
@@ -2608,7 +2610,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         .u128_to_i16_wrap, .u128_to_u16_wrap, .i128_to_i16_wrap, .i128_to_u16_wrap => 16,
                         .u128_to_i32_wrap, .u128_to_u32_wrap, .i128_to_i32_wrap, .i128_to_u32_wrap => 32,
                         .u128_to_i64_wrap, .u128_to_u64_wrap, .i128_to_i64_wrap, .i128_to_u64_wrap => 64,
-                        .u128_to_i128_wrap, .i128_to_u128_wrap => 128,
+                        .u128_to_i128_wrap, .i128_to_u128_wrap, .dec_from_attos, .dec_to_attos => 128,
                         else => unreachable,
                     };
 

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -3073,6 +3073,7 @@ pub const MonoLlvmCodeGen = struct {
             .u8_to_str, .i8_to_str, .u16_to_str, .i16_to_str, .u32_to_str, .i32_to_str, .u64_to_str, .i64_to_str, .u128_to_str, .i128_to_str => try self.emitIntToStr(target, GuardedList.at(arg_locals, 0)),
             .f32_to_str, .f64_to_str => try self.emitFloatToStr(target, GuardedList.at(arg_locals, 0)),
             .f32_to_bits, .f32_from_bits, .f64_to_bits, .f64_from_bits => try self.emitFloatBitCast(target, op, GuardedList.at(arg_locals, 0)),
+            .dec_from_attos, .dec_to_attos => try self.emitDecAttosMove(target, GuardedList.at(arg_locals, 0)),
             .dec_to_str => try self.emitDecToStr(target, GuardedList.at(arg_locals, 0)),
             .num_to_str => try self.emitNumToStr(target, GuardedList.at(arg_locals, 0)),
             .box_box => try self.emitBoxBox(target, GuardedList.at(arg_locals, 0)),
@@ -4749,6 +4750,11 @@ pub const MonoLlvmCodeGen = struct {
                 builder.intValue(.i32, info.value_offset) catch return error.OutOfMemory,
             },
         );
+    }
+
+    fn emitDecAttosMove(self: *MonoLlvmCodeGen, target: LocalId, arg: LocalId) Error!void {
+        const value = try self.loadScalar(self.slot(arg).ptr, self.localLayout(arg));
+        try self.storeScalar(self.slot(target).ptr, self.localLayout(target), value);
     }
 
     fn emitF64ToF32TryUnsafeConversion(self: *MonoLlvmCodeGen, target: LocalId, arg: LocalId) Error!void {

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -14311,6 +14311,8 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
         },
         .u128_to_i128_wrap,
         .i128_to_u128_wrap,
+        .dec_to_attos,
+        .dec_from_attos,
         => {
             // Same representation — just pass through (pointer stays the same)
             try self.emitProcLocal(GuardedList.at(args, 0));

--- a/src/base/LowLevel.zig
+++ b/src/base/LowLevel.zig
@@ -257,6 +257,8 @@ pub const LowLevel = enum(u16) {
     u128_from_str,
     i128_from_str,
     dec_from_str,
+    dec_to_attos,
+    dec_from_attos,
     f32_from_str,
     f64_from_str,
 
@@ -1060,6 +1062,8 @@ pub const LowLevel = enum(u16) {
             .f32_from_bits,
             .f64_to_bits,
             .f64_from_bits,
+            .dec_to_attos,
+            .dec_from_attos,
             .num_shift_left_by,
             .num_shift_right_by,
             .num_shift_right_zf_by,

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -14332,6 +14332,26 @@ Builtin :: [].{
 			tau : Dec
 			tau = 6.283185307179586476
 
+			## Convert a [Dec] to a count of attos (units of 10^-18). This operation is
+			## trivial, because a Dec is just a wrapper for an [I128] representing its
+			## value scaled by 10^18.
+			## ```roc
+			## expect Dec.to_attos(1.5) == 1500000000000000000
+			##
+			## expect Dec.to_attos(Dec.highest) == I128.highest
+			## ```
+			to_attos : Dec -> I128
+
+			## Convert a count of attos (units of 10^-18) to a [Dec]. This operation is
+			## trivial, because a Dec is just a wrapper for an [I128] representing its
+			## value scaled by 10^18.
+			## ```roc
+			## expect Dec.from_attos(1500000000000000000) == 1.5
+			##
+			## expect Dec.from_attos(Dec.to_attos(-0.25)) == -0.25
+			## ```
+			from_attos : I128 -> Dec
+
 			## Convert a [Dec] to its decimal string representation.
 			## ```roc
 			## expect Dec.to_str(42.5) == "42.5"

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -14266,7 +14266,9 @@ Builtin :: [].{
 			to_f64 : I128 -> F64
 
 			## Convert an [I128] to a [Dec], returning `Err(OutOfRange)` if the
-			## integer value does not fit in [Dec]'s fixed-point range.
+			## integer value does not fit in [Dec]'s fixed-point range. See
+			## [Dec.from_attos] to read an [I128] already scaled by 10^18, matching
+			## [Dec]'s internal representation.
 			to_dec_try : I128 -> Try(Dec, [OutOfRange])
 			to_dec_try = |num| out_of_range_try(i128_to_dec_try_unsafe(num))
 
@@ -15028,7 +15030,8 @@ Builtin :: [].{
 
 			## Convert a [Dec] to an [I128]. The fractional part is truncated
 			## toward zero. The entire integer part of any [Dec] fits in an
-			## [I128], so no wrapping occurs in practice.
+			## [I128], so no wrapping occurs in practice. See [Dec.to_attos] to get
+			## the exact value (scaled by 10^18) instead.
 			## ```roc
 			## expect Dec.to_i128_wrap(42.5) == 42
 			## ```
@@ -15036,7 +15039,8 @@ Builtin :: [].{
 
 			## Convert a [Dec] to an [I128], returning `Err(OutOfRange)` if the
 			## integer part does not fit. The fractional part is truncated toward
-			## zero.
+			## zero. See [Dec.to_attos] to get the exact value (scaled by 10^18)
+			## instead.
 			## ```roc
 			## expect Dec.to_i128_try(42.5) == Ok(42)
 			## ```

--- a/src/canonicalize/BuiltinLowLevel.zig
+++ b/src/canonicalize/BuiltinLowLevel.zig
@@ -453,6 +453,8 @@ fn replaceProvidedByCompilerLowLevels(env: *ModuleEnv) (Allocator.Error || error
     try putLowLevelFmt(&low_level_map, env, &name_scratch, "Builtin.Num.F32.from_bits", .{}, .f32_from_bits);
     try putLowLevelFmt(&low_level_map, env, &name_scratch, "Builtin.Num.F64.to_bits", .{}, .f64_to_bits);
     try putLowLevelFmt(&low_level_map, env, &name_scratch, "Builtin.Num.F64.from_bits", .{}, .f64_from_bits);
+    try putLowLevelFmt(&low_level_map, env, &name_scratch, "Builtin.Num.Dec.to_attos", .{}, .dec_to_attos);
+    try putLowLevelFmt(&low_level_map, env, &name_scratch, "Builtin.Num.Dec.from_attos", .{}, .dec_from_attos);
 
     // Numeric comparison operations (all numeric types)
     for (numeric_types) |num_type| {

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -5256,6 +5256,11 @@ pub const Interpreter = struct {
                 val.write(f64, @bitCast(args[0].read(u64)));
                 break :blk val;
             },
+            .dec_from_attos, .dec_to_attos => blk: {
+                const val = try self.alloc(ll.ret_layout);
+                val.write(i128, args[0].read(i128));
+                break :blk val;
+            },
             .num_to_str => blk: {
                 // Generic num_to_str uses arg layout to determine type
                 const size = self.helper.sizeOf(arg_layout);

--- a/src/eval/test/eval_low_level_tests.zig
+++ b/src/eval/test/eval_low_level_tests.zig
@@ -6869,4 +6869,56 @@ pub const tests = [_]TestCase{
         ,
         .expected = .{ .inspect_str = "8" },
     },
+    .{
+        .name = "low_level - Dec.to_attos reads the stored i128",
+        .source =
+        \\{
+        \\x : Dec
+        \\x = 1.5
+        \\x.to_attos()
+        \\}
+        ,
+        .expected = .{ .inspect_str = "1500000000000000000" },
+    },
+    .{
+        .name = "low_level - Dec.from_attos reinterprets rather than converts",
+        .source =
+        \\{
+        \\Dec.from_attos(1500000000000000000).to_str()
+        \\}
+        ,
+        .expected = .{ .inspect_str = "\"1.5\"" },
+    },
+    .{
+        .name = "low_level - Dec atto roundtrip preserves a negative value",
+        .source =
+        \\{
+        \\x : Dec
+        \\x = -0.25
+        \\Dec.from_attos(x.to_attos()) == x
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec and I128 meet at both extremes",
+        .source =
+        \\{
+        \\Dec.to_attos(Dec.highest) == I128.highest
+        \\    and Dec.to_attos(Dec.lowest) == I128.lowest
+        \\    and Dec.from_attos(I128.highest) == Dec.highest
+        \\    and Dec.from_attos(I128.lowest) == Dec.lowest
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - one atto is Dec's smallest step",
+        .source =
+        \\{
+        \\Dec.to_attos(0.000000000000000001) == 1
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
 };


### PR DESCRIPTION
This PR adds `Dec.to_attos` and `Dec.from_attos`, which convert a `Dec` to or from an `I128` that represents the `Dec`'s value in attos — units of 10^-18. Note that these conversions are trivial, since the `I128` count of attos is precisely how a `Dec`'s value is stored internally.

## Motivation

The impetus for adding these conversion functions came from trying to implement JSON parsing for `Dec` values w/o any allocations. The current implementation converts the run of digits in the input (shifted by an exponent, if present) to a string, before calling `Dec.from_str`. My understanding is that if that run of digits is more than 23 characters (which could be a totally valid `Dec`), then constructing that string will result in a heap allocation.

I experimented with a few different ways to do the conversion without any allocations, and while it is possible to do, the code always looked a bit convoluted to me, except for versions that introduced a new function to convert from a scaled `I128` directly to a `Dec` that has that `I128` as its internal value.

And if we're going to be adding the `from` version of the function, why not add the `to` version as well and make them public, analogous to the `from_bits` and `to_bits` functions associated with the float types.

(The change to switch JSON parsing to use `Dec.from_attos` will be in a follow-up PR.)

## Naming

Claude originally proposed `dec_from_scaled` for the from function, but I liked `dec_from_attos` better, because I think it's clearer exactly what's happening. A `Dec` is literally represented as a count of units of 10^-18, so it seems natural to have a way to convert to or from these counts of attos. And we don't have to think of the `I128` as representing some fake scaled value. It's just a real atto count.

## Tests

`eval_low_level_tests.zig` covers both directions across every enabled backend: the counts for `1.5`, the roundtrip through a negative value, both representable extremes, and the smallest step a `Dec` can take.





