### PR TITLE
Pass cpu_level to WinCodeGen.init in the erased callable ABI test

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -20948,7 +20948,7 @@ test "Windows erased callable ABI reads reuse pointer from caller stack" {
     const reuse_arg = try addLocal(&store, .opaque_ptr);
     const args = try store.addLocalSpan(&.{ explicit_arg, capture_arg, reuse_arg });
 
-    var codegen = try WinCodeGen.init(allocator, &store, &test_state.layout_store, &.{}, .preserve);
+    var codegen = try WinCodeGen.init(allocator, &store, &test_state.layout_store, &.{}, .preserve, .default);
     defer codegen.deinit();
 
     const InnerCodeGen = @TypeOf(codegen.codegen);


### PR DESCRIPTION
`WinCodeGen.init` gained a `cpu_level` parameter in #10565, but one test call site was not updated, so `main` does not compile. The neighbouring test passes `.default`; this matches it.

Worth noting how this reached `main`: the build workflow runs on pull requests only — pushes to `main` get CodeQL and a Markdown link check. So #10565 was green against its own base, merged, and broke `main`, with no run on `main` able to report it. The next PR to rebase is the first to find out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
