### PR TITLE
WIP Expand header dependency records with more than one entry

### DIFF
--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -2584,7 +2584,7 @@ const Formatter = struct {
                     try fmt.push(' ');
                 }
                 const packages = fmt.ast.store.getCollection(a.packages);
-                const packages_multiline = fmt.collectionWillBeMultiline(AST.RecordField.Idx, a.packages);
+                const packages_multiline = fmt.headerPackagesWillBeMultiline(a.packages);
                 try fmt.push('{');
                 if (packages_multiline) {
                     fmt.curr_indent += 1;
@@ -2723,7 +2723,7 @@ const Formatter = struct {
                 const packagesItems = fmt.ast.store.recordFieldSlice(.{ .span = packages.span });
                 try fmt.formatCollection(
                     packages.region,
-                    packages.layout,
+                    if (fmt.headerPackagesWillBeMultiline(p.packages)) .expanded else packages.layout,
                     .curly,
                     AST.RecordField.Idx,
                     packagesItems,
@@ -2826,7 +2826,7 @@ const Formatter = struct {
                 }
                 try fmt.formatCollection(
                     packages.region,
-                    packages.layout,
+                    if (fmt.headerPackagesWillBeMultiline(p.packages)) .expanded else packages.layout,
                     .curly,
                     AST.RecordField.Idx,
                     fmt.ast.store.recordFieldSlice(.{ .span = packages.span }),
@@ -3847,7 +3847,7 @@ const Formatter = struct {
                 if (fmt.regionHasInteriorComment(header.to_tokenized_region())) return true;
                 switch (header) {
                     .app => |a| return fmt.collectionWillBeMultiline(AST.ExposedItem.Idx, a.provides) or
-                        fmt.collectionWillBeMultiline(AST.RecordField.Idx, a.packages),
+                        fmt.headerPackagesWillBeMultiline(a.packages),
                     .module => |m| return fmt.collectionWillBeMultiline(AST.ExposedItem.Idx, m.exposes),
                     .hosted => |h| return fmt.collectionWillBeMultiline(AST.ExposedItem.Idx, h.exposes),
                     .package => |p| {
@@ -3855,7 +3855,7 @@ const Formatter = struct {
                             return true;
                         }
 
-                        return fmt.collectionWillBeMultiline(AST.RecordField.Idx, p.packages);
+                        return fmt.headerPackagesWillBeMultiline(p.packages);
                     },
                     .platform => return true,
                     else => return false,
@@ -3922,6 +3922,15 @@ const Formatter = struct {
         }
 
         return false;
+    }
+
+    /// Whether a header's dependency record (the `{ ... }` of an `app`, `package`, or
+    /// `platform` header) is laid out multiline. Beyond the usual reasons a collection
+    /// goes multiline, more than one entry always forces it: those entries are long
+    /// package URLs, so a single line of them is unreadable.
+    fn headerPackagesWillBeMultiline(fmt: *Formatter, idx: AST.Collection.Idx) bool {
+        if (fmt.ast.store.getCollection(idx).span.len > 1) return true;
+        return fmt.collectionWillBeMultiline(AST.RecordField.Idx, idx);
     }
 
     fn collectionWillBeMultiline(fmt: *Formatter, comptime T: type, idx: AST.Collection.Idx) bool {
@@ -4013,6 +4022,56 @@ test "issue 10480: package qualifier preserved in exposed aliased imports" {
     defer std.testing.allocator.free(result);
 
     try std.testing.expectEqualStrings("module [o as n, F.s as I]\n", result);
+}
+
+test "app header dependency record expands once it has more than one entry" {
+    const single = try moduleFmtsStable(
+        std.testing.allocator,
+        "app [main!] { pf: platform \"../platform/main.roc\" }",
+        false,
+    );
+    defer std.testing.allocator.free(single);
+    try std.testing.expectEqualStrings("app [main!] { pf: platform \"../platform/main.roc\" }\n", single);
+
+    const multiple = try moduleFmtsStable(
+        std.testing.allocator,
+        "app [main!] { pf: platform \"../platform/main.roc\", json: \"../json/main.roc\" }",
+        false,
+    );
+    defer std.testing.allocator.free(multiple);
+    try std.testing.expectEqualStrings(
+        "app [main!] {\n" ++
+            "\tpf: platform \"../platform/main.roc\",\n" ++
+            "\tjson: \"../json/main.roc\",\n" ++
+            "}\n",
+        multiple,
+    );
+}
+
+test "package header dependency record expands once it has more than one entry" {
+    const single = try moduleFmtsStable(
+        std.testing.allocator,
+        "package [Foo] { json: \"../json/main.roc\" }",
+        false,
+    );
+    defer std.testing.allocator.free(single);
+    try std.testing.expectEqualStrings("package [Foo] { json: \"../json/main.roc\" }\n", single);
+
+    const multiple = try moduleFmtsStable(
+        std.testing.allocator,
+        "package [Foo] { json: \"../json/main.roc\", csv: \"../csv/main.roc\" }",
+        false,
+    );
+    defer std.testing.allocator.free(multiple);
+    try std.testing.expectEqualStrings(
+        "package\n" ++
+            "\t[Foo]\n" ++
+            "\t{\n" ++
+            "\t\tjson: \"../json/main.roc\",\n" ++
+            "\t\tcsv: \"../csv/main.roc\",\n" ++
+            "\t}\n",
+        multiple,
+    );
 }
 
 test "issue 10431: wrapped declaration has no trailing whitespace" {
@@ -4933,11 +4992,14 @@ test "fmt upgrades an app's roc version pin to a newer nightly" {
     defer std.testing.allocator.free(result);
 
     try std.testing.expectEqualStrings(
-        \\app [main!] { pf: platform "../platform/main.roc", roc: "nightly-2026-August-1-bbbbbbb" }
-        \\
-        \\main! = |_| {}
-        \\
-    , result);
+        "app [main!] {\n" ++
+            "\tpf: platform \"../platform/main.roc\",\n" ++
+            "\troc: \"nightly-2026-August-1-bbbbbbb\",\n" ++
+            "}\n" ++
+            "\n" ++
+            "main! = |_| {}\n",
+        result,
+    );
 }
 
 test "fmt upgrades a package's roc version pin" {

--- a/test/snapshots/app_header__nonempty_multiline.md
+++ b/test/snapshots/app_header__nonempty_multiline.md
@@ -39,7 +39,12 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-NO CHANGE
+app # This comment is here
+	[main!]
+	{
+		pf: platform "../main.roc",
+		somePkg: "../main.roc",
+	}
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/app_header__roc_version.md
+++ b/test/snapshots/app_header__roc_version.md
@@ -35,7 +35,10 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-NO CHANGE
+app [main!] {
+	pf: platform "../main.roc",
+	roc: "nightly-2026-July-31-123c5d7",
+}
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/app_header__roc_version_invalid.md
+++ b/test/snapshots/app_header__roc_version_invalid.md
@@ -49,7 +49,10 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-NO CHANGE
+app [main!] {
+	pf: platform "../main.roc",
+	roc: "yesterday's build",
+}
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/app_header_nonempty_singleline.md
+++ b/test/snapshots/app_header_nonempty_singleline.md
@@ -35,7 +35,10 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-NO CHANGE
+app [main!] {
+	pf: platform "../main.roc",
+	other: "../../other/main.roc",
+}
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/formatting/multiline_without_comma/app.md
+++ b/test/snapshots/formatting/multiline_without_comma/app.md
@@ -75,7 +75,10 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-app [a1!, a2!] { pf: platform "../basic-cli/main.roc", a: "a" }
+app [a1!, a2!] {
+	pf: platform "../basic-cli/main.roc",
+	a: "a",
+}
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/formatting/multiline_without_comma/package.md
+++ b/test/snapshots/formatting/multiline_without_comma/package.md
@@ -115,7 +115,12 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-package [a!, b!] { a: "a", b: "b" }
+package
+	[a!, b!]
+	{
+		a: "a",
+		b: "b",
+	}
 
 a! : Str => Str
 

--- a/test/snapshots/formatting/multiline_without_comma/platform.md
+++ b/test/snapshots/formatting/multiline_without_comma/platform.md
@@ -140,7 +140,10 @@ platform "pf"
 		[R1 : r1, R2 : r2] for main : R1 -> R2
 	}
 	exposes [E1, E2]
-	packages { pa1: "pa1", pa2: "pa2" }
+	packages {
+		pa1: "pa1",
+		pa2: "pa2",
+	}
 	provides {
 		"roc_not implemented": pr1,
 		"roc_not implemented": pr2,

--- a/test/snapshots/formatting/singleline/app.md
+++ b/test/snapshots/formatting/singleline/app.md
@@ -63,7 +63,10 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-NO CHANGE
+app [a1!, a2!] {
+	pf: platform "../basic-cli/main.roc",
+	a: "a",
+}
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/formatting/singleline/package.md
+++ b/test/snapshots/formatting/singleline/package.md
@@ -100,7 +100,16 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-NO CHANGE
+package
+	[a!, b!]
+	{
+		a: "a",
+		b: "b",
+	}
+
+a! : Str => Str
+
+b! : Str => Str
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/formatting/singleline/platform.md
+++ b/test/snapshots/formatting/singleline/platform.md
@@ -118,7 +118,10 @@ platform "pf"
 		[R1 : r1, R2 : r2] for main : R1 -> R2
 	}
 	exposes [E1, E2]
-	packages { pa1: "pa1", pa2: "pa2" }
+	packages {
+		pa1: "pa1",
+		pa2: "pa2",
+	}
 	provides { "roc_not implemented": pr1, "roc_not implemented": pr2 }
 ~~~
 # CANONICALIZE

--- a/test/snapshots/fuzz_crash/fuzz_crash_056.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_056.md
@@ -38,7 +38,11 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-app [] { f: platform "", r: "", o: "" }
+app [] {
+	f: platform "",
+	r: "",
+	o: "",
+}
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/fuzz_crash/fuzz_crash_058.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_058.md
@@ -46,7 +46,10 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-app [] { f: platform "", r: "" }
+app [] {
+	f: platform "",
+	r: "",
+}
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/package_header__roc_version.md
+++ b/test/snapshots/package_header__roc_version.md
@@ -31,7 +31,12 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-NO CHANGE
+package
+	[Foo]
+	{
+		roc: "0.1.0",
+		other: "../../other/main.roc",
+	}
 ~~~
 # CANONICALIZE
 ~~~clojure

--- a/test/snapshots/package_header_nonempty_singleline_1.md
+++ b/test/snapshots/package_header_nonempty_singleline_1.md
@@ -58,7 +58,12 @@ EndOfFile,
 ~~~
 # FORMATTED
 ~~~roc
-NO CHANGE
+package
+	[something, SomeType]
+	{
+		somePkg: "../main.roc",
+		other: "../../other/main.roc",
+	}
 ~~~
 # CANONICALIZE
 ~~~clojure


### PR DESCRIPTION
`roc fmt` collapsed an app header's `{ ... }` onto a single line whenever none of its entries individually needed a line of its own, so a header pinning both a platform and a `roc` version came out as one very long line:

    app [main!] { pf: platform "https://github.com/.../AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst", roc: "nightly-2026-August-03-94cbed3" }

Those entries are package URLs, so more than one of them on a line is unreadable regardless of how each entry formats on its own. Add `headerPackagesWillBeMultiline`, which forces the record multiline once it holds more than one entry and otherwise defers to the usual collection layout rules, and use it everywhere a header's dependency record picks a layout: `nodeWillBeMultiline` for `app` and `package`, plus the `app`, `package`, and `platform` arms of `formatHeader`. `package` and `platform` headers hold the same kind of URLs, so they get the same treatment.

A single-entry record still stays on one line, so the common `app [main!] { pf: platform "../basic-cli/main.roc" }` is unchanged.