### PR TITLE
Fix erased callable argument buffer layout

### DIFF
--- a/design.md
+++ b/design.md
@@ -6101,6 +6101,16 @@ affects only whether allocation can be avoided, never the ownership contract.
 Capture bytes needed to construct the result are snapshotted before an in-place
 overwrite.
 
+The packed arguments are one fixed-arity struct whose fields remain in source
+parameter order and use each runtime representation's natural alignment. The
+struct size is rounded up to its maximum field alignment. Post-check lowering
+computes and interns the exact field offsets, size, and alignment as an erased
+call argument plan. Every erased call and erased-callable procedure names such
+a plan, and LIR certification verifies that the plan exactly matches the call
+arguments or explicit procedure parameters. Backends consume these offsets
+directly for both packing and unpacking; they must not reorder arguments, round
+individual fields to backend-private slots, or reconstruct the plan.
+
 The direct LIR builder carries the current return destination while recursively
 lowering the selected aggregate or tag payload. That producer-authored context,
 plus the explicit result-demand classification, is the only basis for selecting

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -13690,6 +13690,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self: *Self,
             closure_local: LocalId,
             call_args: LocalSpan,
+            arg_plan: lir.LIR.ErasedCallArgsPlanId,
             ret_layout: layout.Idx,
             reuse_closure: bool,
         ) Allocator.Error!ValueLocation {
@@ -13730,27 +13731,20 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 arg_layouts[i] = arg_layout;
             }
 
-            var total_args_size: u32 = 0;
-            for (arg_layouts) |arg_layout| {
-                const runtime_layout = self.runtimeRepresentationLayoutIdx(arg_layout);
-                const size_align = self.layout_store.layoutSizeAlign(self.layout_store.getLayout(runtime_layout));
-                total_args_size = std.mem.alignForward(u32, total_args_size, @intCast(@max(size_align.alignment.toByteUnits(), 1)));
-                total_args_size += size_align.size;
-            }
+            const plan = self.store.getErasedCallArgsPlan(arg_plan);
+            const arg_offsets = self.store.getErasedCallArgOffsets(plan);
+            if (arg_offsets.len != arg_refs.len) unreachable;
             const args_slot = if (arg_refs.len == 0)
                 0
             else
-                self.codegen.allocStackSlot(if (total_args_size == 0) 8 else total_args_size);
+                self.codegen.allocStackSlot(@max(plan.size, 1));
 
-            var arg_offset: u32 = 0;
-            for (arg_locs, arg_layouts) |arg_loc, arg_layout| {
+            for (arg_locs, arg_layouts, 0..) |arg_loc, arg_layout, i| {
                 const runtime_layout = self.runtimeRepresentationLayoutIdx(arg_layout);
                 const size_align = self.layout_store.layoutSizeAlign(self.layout_store.getLayout(runtime_layout));
-                arg_offset = std.mem.alignForward(u32, arg_offset, @intCast(@max(size_align.alignment.toByteUnits(), 1)));
                 if (size_align.size > 0) {
-                    try self.copyBytesToStackOffset(args_slot + @as(i32, @intCast(arg_offset)), arg_loc, size_align.size);
+                    try self.copyBytesToStackOffset(args_slot + @as(i32, @intCast(GuardedList.at(arg_offsets, i))), arg_loc, size_align.size);
                 }
-                arg_offset += size_align.size;
             }
 
             const capture_ptr_reg = try self.allocTempGeneral();
@@ -16686,7 +16680,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 self.ret_ptr_slot = self.codegen.allocStackSlot(8);
                 const ret_ptr_reg = self.getArgumentRegister(1);
                 try self.codegen.emitStoreStack(.w64, self.ret_ptr_slot.?, ret_ptr_reg);
-                try self.bindErasedCallableAdapterParams(proc.args);
+                try self.bindErasedCallableAdapterParams(proc.args, proc.erased_call_args orelse unreachable);
                 hot_reload_code_ref_slot = try self.emitHotReloadEnterForHostCallable();
             } else {
                 if (needs_ret_ptr) {
@@ -17539,7 +17533,11 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             }
         }
 
-        fn bindErasedCallableAdapterParams(self: *Self, params: LocalSpan) Allocator.Error!void {
+        fn bindErasedCallableAdapterParams(
+            self: *Self,
+            params: LocalSpan,
+            arg_plan: lir.LIR.ErasedCallArgsPlanId,
+        ) Allocator.Error!void {
             const locals = self.store.getLocalSpan(params);
             if (locals.len < 2) {
                 if (builtin.mode == .Debug) {
@@ -17565,15 +17563,15 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             try self.saveIncomingPointerArg(capture_ptr_slot, 3);
             try self.saveIncomingPointerArg(reuse_ptr_slot, 4);
 
-            var arg_offset: u32 = 0;
             const explicit_count = locals.len - 2;
+            const plan = self.store.getErasedCallArgsPlan(arg_plan);
+            const arg_offsets = self.store.getErasedCallArgOffsets(plan);
+            if (arg_offsets.len != explicit_count) unreachable;
             for (0..explicit_count) |local_index| {
                 const local = GuardedList.at(locals, local_index);
                 const local_layout = self.localLayout(local);
                 const runtime_layout = self.runtimeRepresentationLayoutIdx(local_layout);
                 const size_align = self.layout_store.layoutSizeAlign(self.layout_store.getLayout(runtime_layout));
-                const arg_align: u32 = @intCast(@max(size_align.alignment.toByteUnits(), 1));
-                arg_offset = std.mem.alignForward(u32, arg_offset, arg_align);
                 if (size_align.size == 0) {
                     try self.local_locations.put(localKey(local), .{ .immediate_i64 = 0 });
                 } else {
@@ -17584,7 +17582,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     try self.copyChunked(
                         temp_reg,
                         args_ptr_reg,
-                        @intCast(arg_offset),
+                        @intCast(GuardedList.at(arg_offsets, local_index)),
                         frame_ptr,
                         local_offset,
                         size_align.size,
@@ -17593,7 +17591,6 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     self.codegen.freeGeneral(args_ptr_reg);
                     try self.local_locations.put(localKey(local), self.stackLocationForLayout(local_layout, local_offset));
                 }
-                arg_offset += size_align.size;
             }
 
             const capture_local = GuardedList.at(locals, explicit_count);
@@ -18248,6 +18245,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                             const value_loc = try self.generateErasedCall(
                                 assign.closure,
                                 assign.args,
+                                assign.arg_plan,
                                 self.localLayout(assign.target),
                                 assign.reuse_closure,
                             );
@@ -20947,6 +20945,7 @@ test "Windows erased callable ABI reads reuse pointer from caller stack" {
     const capture_arg = try addLocal(&store, .opaque_ptr);
     const reuse_arg = try addLocal(&store, .opaque_ptr);
     const args = try store.addLocalSpan(&.{ explicit_arg, capture_arg, reuse_arg });
+    const arg_plan = try store.internErasedCallArgsPlan(&test_state.layout_store, &.{.u64});
 
     var codegen = try WinCodeGen.init(allocator, &store, &test_state.layout_store, &.{}, .preserve, .default);
     defer codegen.deinit();
@@ -20954,7 +20953,7 @@ test "Windows erased callable ABI reads reuse pointer from caller stack" {
     const InnerCodeGen = @TypeOf(codegen.codegen);
     codegen.codegen.stack_offset = -InnerCodeGen.CALLEE_SAVED_AREA_SIZE;
 
-    try codegen.bindErasedCallableAdapterParams(args);
+    try codegen.bindErasedCallableAdapterParams(args, arg_plan);
 
     _ = codegen.local_locations.get(@intFromEnum(reuse_arg)) orelse return error.TestUnexpectedResult;
     try std.testing.expect(codegen.codegen.getCode().len > 0);

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -1948,19 +1948,18 @@ pub const MonoLlvmCodeGen = struct {
     fn unpackProcArgs(self: *MonoLlvmCodeGen, proc: LirProcSpec) Error!void {
         const params = self.store.getLocalSpan(proc.args);
         const explicit_count = try explicitProcParamCount(proc.abi, params.len);
-        const arg_layouts = try self.procArgLayouts(proc, .explicit);
-        defer self.allocator.free(arg_layouts);
-        const offsets = try self.computeArgOffsets(arg_layouts, true);
-        defer self.allocator.free(offsets);
-
         const args_ptr = self.args_ptr_arg orelse return error.CompilationFailed;
-        for (0..explicit_count) |i| {
-            const param = GuardedList.at(params, i);
-            const offset = offsets[i];
-            const param_slot = self.slot(param);
-            if (param_slot.size == 0) continue;
-            const src = try self.offsetPtr(args_ptr, offset);
-            try self.copyBytes(param_slot.ptr, src, param_slot.size, param_slot.alignment);
+        if (proc.abi == .erased_callable) {
+            const plan = self.store.getErasedCallArgsPlan(proc.erased_call_args orelse return error.CompilationFailed);
+            const offsets = self.store.getErasedCallArgOffsets(plan);
+            if (offsets.len != explicit_count) return error.CompilationFailed;
+            try self.unpackProcArgsAtOffsets(params, explicit_count, args_ptr, offsets);
+        } else {
+            const arg_layouts = try self.procArgLayouts(proc, .explicit);
+            defer self.allocator.free(arg_layouts);
+            const offsets = try self.computeArgOffsets(arg_layouts, true);
+            defer self.allocator.free(offsets);
+            try self.unpackProcArgsAtOffsets(params, explicit_count, args_ptr, offsets);
         }
 
         if (proc.abi == .erased_callable) {
@@ -1970,6 +1969,22 @@ pub const MonoLlvmCodeGen = struct {
             const reuse_param = GuardedList.at(params, params.len - 1);
             const reuse_ptr = self.reuse_ptr_arg orelse return error.CompilationFailed;
             try self.storePointer(self.slot(reuse_param).ptr, reuse_ptr);
+        }
+    }
+
+    fn unpackProcArgsAtOffsets(
+        self: *MonoLlvmCodeGen,
+        params: anytype,
+        explicit_count: usize,
+        args_ptr: LlvmBuilder.Value,
+        offsets: anytype,
+    ) Error!void {
+        for (0..explicit_count) |i| {
+            const param = GuardedList.at(params, i);
+            const param_slot = self.slot(param);
+            if (param_slot.size == 0) continue;
+            const src = try self.offsetPtr(args_ptr, GuardedList.at(offsets, i));
+            try self.copyBytes(param_slot.ptr, src, param_slot.size, param_slot.alignment);
         }
     }
 
@@ -2380,7 +2395,7 @@ pub const MonoLlvmCodeGen = struct {
                 try work.append(wa, .{ .node = assign.next });
             },
             .assign_call_erased => |assign| {
-                try self.emitErasedCall(assign.target, assign.closure, assign.args, assign.reuse_closure);
+                try self.emitErasedCall(assign.target, assign.closure, assign.args, assign.arg_plan, assign.reuse_closure);
                 try work.append(wa, .{ .node = assign.next });
             },
             .assign_packed_erased_fn => |assign| {
@@ -2607,7 +2622,14 @@ pub const MonoLlvmCodeGen = struct {
         }
     }
 
-    fn emitErasedCall(self: *MonoLlvmCodeGen, target: LocalId, closure: LocalId, args: LocalSpan, reuse_closure: bool) Error!void {
+    fn emitErasedCall(
+        self: *MonoLlvmCodeGen,
+        target: LocalId,
+        closure: LocalId,
+        args: LocalSpan,
+        arg_plan: lir.LIR.ErasedCallArgsPlanId,
+        reuse_closure: bool,
+    ) Error!void {
         try self.prepareLocalWrite(target);
         try self.materializeLocalIfDeferred(closure);
         const builder = self.builder orelse return error.CompilationFailed;
@@ -2628,8 +2650,16 @@ pub const MonoLlvmCodeGen = struct {
         const args_buf = if (arg_locals.len == 0)
             builder.nullValue(ptr_ty) catch return error.OutOfMemory
         else blk: {
-            const buf = try self.allocHostedArgBuffer(arg_layouts);
-            try self.packSequentialArgsFromLocals(buf, arg_locals, arg_layouts);
+            const plan = self.store.getErasedCallArgsPlan(arg_plan);
+            const offsets = self.store.getErasedCallArgOffsets(plan);
+            if (offsets.len != arg_locals.len) return error.CompilationFailed;
+            const buf = try self.allocEntryBlockSlot(
+                .i8,
+                @max(plan.size, 1),
+                LlvmBuilder.Alignment.fromByteUnits(plan.alignment),
+                "erased_args",
+            );
+            try self.packErasedArgsFromLocals(buf, arg_locals, arg_layouts, offsets);
             break :blk buf;
         };
         const ret_ptr = if (self.slot(target).size == 0)
@@ -9358,19 +9388,6 @@ pub const MonoLlvmCodeGen = struct {
         return ptr;
     }
 
-    fn allocHostedArgBuffer(self: *MonoLlvmCodeGen, arg_layouts: []const layout.Idx) Error!LlvmBuilder.Value {
-        var total: u32 = 0;
-        for (arg_layouts) |arg_layout| {
-            const sa = self.sizeAlignOf(arg_layout);
-            total = std.mem.alignForward(u32, total, @intCast(@max(sa.alignment.toByteUnits(), 1)));
-            total += sa.size;
-        }
-        total = @max(total, 8);
-        const ptr = try self.allocEntryBlockSlot(.i8, total, LlvmBuilder.Alignment.fromByteUnits(16), "host_args");
-        try self.zeroBytes(ptr, total);
-        return ptr;
-    }
-
     fn copyEntrypointArgsToInternalBuffer(self: *MonoLlvmCodeGen, src_args: LlvmBuilder.Value, dst_args: LlvmBuilder.Value, arg_layouts: []const layout.Idx) Error!void {
         const offsets = try self.computeArgOffsets(arg_layouts, true);
         defer self.allocator.free(offsets);
@@ -9395,18 +9412,21 @@ pub const MonoLlvmCodeGen = struct {
         }
     }
 
-    fn packSequentialArgsFromLocals(self: *MonoLlvmCodeGen, dst_args: LlvmBuilder.Value, arg_locals: anytype, arg_layouts: []const layout.Idx) Error!void {
-        var offset: u32 = 0;
+    fn packErasedArgsFromLocals(
+        self: *MonoLlvmCodeGen,
+        dst_args: LlvmBuilder.Value,
+        arg_locals: anytype,
+        arg_layouts: []const layout.Idx,
+        offsets: anytype,
+    ) Error!void {
         for (0..arg_locals.len) |i| {
             const arg = GuardedList.at(arg_locals, i);
             const arg_layout = arg_layouts[i];
             try self.materializeLocalIfDeferred(arg);
             const sa = self.sizeAlignOf(arg_layout);
-            offset = std.mem.alignForward(u32, offset, @intCast(@max(sa.alignment.toByteUnits(), 1)));
             if (sa.size > 0) {
-                try self.copyBytes(try self.offsetPtr(dst_args, offset), self.slot(arg).ptr, sa.size, self.alignmentForLayout(arg_layout));
+                try self.copyBytes(try self.offsetPtr(dst_args, GuardedList.at(offsets, i)), self.slot(arg).ptr, sa.size, self.alignmentForLayout(arg_layout));
             }
-            offset += sa.size;
         }
     }
 

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -8126,7 +8126,13 @@ fn compileProcSpecBody(self: *Self, proc_id: LIR.LirProcSpecId, proc: LirProcSpe
         const args_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
         const capture_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
         const reuse_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-        try self.bindErasedCallableAdapterParams(args, args_ptr, capture_ptr, reuse_ptr);
+        try self.bindErasedCallableAdapterParams(
+            args,
+            proc.erased_call_args orelse unreachable,
+            args_ptr,
+            capture_ptr,
+            reuse_ptr,
+        );
         break :blk ret_ptr;
     } else blk: {
         // Bind parameters to locals (after roc_ops_ptr when present).
@@ -8583,6 +8589,7 @@ fn generateHostedProcWrapper(
 fn bindErasedCallableAdapterParams(
     self: *Self,
     args: anytype,
+    arg_plan: LIR.ErasedCallArgsPlanId,
     args_ptr_local: u32,
     capture_ptr_local: u32,
     reuse_ptr_local: u32,
@@ -8594,15 +8601,17 @@ fn bindErasedCallableAdapterParams(
         unreachable;
     }
 
-    var arg_offset: u32 = 0;
     const explicit_count = args.len - 2;
+    const plan = self.store.getErasedCallArgsPlan(arg_plan);
+    const arg_offsets = self.store.getErasedCallArgOffsets(plan);
+    if (arg_offsets.len != explicit_count) unreachable;
     for (0..explicit_count) |i| {
         const arg = GuardedList.at(args, i);
         const local_layout = self.procLocalLayoutIdx(arg);
         const runtime_layout = self.runtimeRepresentationLayoutIdx(local_layout);
         const size_align = self.getLayoutStore().layoutSizeAlign(self.getLayoutStore().getLayout(runtime_layout));
         const arg_align: u32 = @intCast(@max(size_align.alignment.toByteUnits(), 1));
-        arg_offset = std.mem.alignForward(u32, arg_offset, arg_align);
+        const arg_offset = GuardedList.at(arg_offsets, i);
 
         const vt = try self.resolveValType(local_layout);
         const local_idx = self.storage.allocLocal(arg, vt) catch return error.OutOfMemory;
@@ -8650,8 +8659,6 @@ fn bindErasedCallableAdapterParams(
             try self.emitLoadOpForLayout(local_layout, arg_offset);
             try self.emitLocalSet(local_idx);
         }
-
-        arg_offset += size_align.size;
     }
 
     const hidden_capture_arg = GuardedList.at(args, explicit_count);
@@ -8926,6 +8933,7 @@ fn generateCFStmtNode(self: *Self, work: *std.ArrayList(StmtWork), wa: Allocator
             try self.generateErasedCall(.{
                 .closure = assign.closure,
                 .args = assign.args,
+                .arg_plan = assign.arg_plan,
                 .ret_layout = self.procLocalLayoutIdx(assign.target),
                 .reuse_closure = assign.reuse_closure,
             });
@@ -9812,31 +9820,24 @@ fn generateErasedCall(self: *Self, c: anytype) Allocator.Error!void {
     try self.emitLocalSet(capture_ptr);
 
     const arg_refs = self.store.getLocalSpan(c.args);
-    var total_args_size: u32 = 0;
-    for (0..arg_refs.len) |i| {
-        const arg = GuardedList.at(arg_refs, i);
-        const arg_layout = self.procLocalLayoutIdx(arg);
-        const runtime_layout = self.runtimeRepresentationLayoutIdx(arg_layout);
-        const size_align = self.getLayoutStore().layoutSizeAlign(self.getLayoutStore().getLayout(runtime_layout));
-        total_args_size = std.mem.alignForward(u32, total_args_size, @intCast(@max(size_align.alignment.toByteUnits(), 1)));
-        total_args_size += size_align.size;
-    }
+    const plan = self.store.getErasedCallArgsPlan(c.arg_plan);
+    const arg_offsets = self.store.getErasedCallArgOffsets(plan);
+    if (arg_offsets.len != arg_refs.len) unreachable;
 
     const args_ptr = if (arg_refs.len == 0)
         null
     else
-        try self.allocStackMemory(if (total_args_size == 0) 1 else total_args_size, 16);
+        try self.allocStackMemory(@max(plan.size, 1), plan.alignment);
     if (args_ptr) |args_offset| {
         const args_base = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
         try self.emitFpOffset(args_offset);
         try self.emitLocalSet(args_base);
-        var offset: u32 = 0;
         for (0..arg_refs.len) |i| {
             const arg = GuardedList.at(arg_refs, i);
             const arg_layout = self.procLocalLayoutIdx(arg);
             const runtime_layout = self.runtimeRepresentationLayoutIdx(arg_layout);
             const size_align = self.getLayoutStore().layoutSizeAlign(self.getLayoutStore().getLayout(runtime_layout));
-            offset = std.mem.alignForward(u32, offset, @intCast(@max(size_align.alignment.toByteUnits(), 1)));
+            const offset = GuardedList.at(arg_offsets, i);
             if (size_align.size > 0) {
                 try self.emitProcLocal(arg);
                 if (try self.isCompositeLayout(arg_layout)) {
@@ -9847,7 +9848,6 @@ fn generateErasedCall(self: *Self, c: anytype) Allocator.Error!void {
                     try self.emitStoreToMemSized(args_base, offset, try self.resolveValType(arg_layout), size_align.size);
                 }
             }
-            offset += size_align.size;
         }
     }
 

--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -321,6 +321,11 @@ pub const io_spec_tests = [_]TestSpec{
     },
     // Bug regression tests
     .{
+        .roc_file = "test/fx/erased_small_first_arg.roc",
+        .io_spec = "1>2",
+        .description = "Regression test: LLVM erased callable ABI preserves a sub-word first argument (issue #10364)",
+    },
+    .{
         .roc_file = "test/fx/unify_scratch_fresh_vars_rank_bug.roc",
         .io_spec = "1>ok",
         .description = "Regression test: unify scratch fresh_vars must be cleared between calls",

--- a/src/layout/erased_call_abi.zig
+++ b/src/layout/erased_call_abi.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const layout = @import("layout.zig");
 const Store = @import("store.zig").Store;
 
+/// Total storage requirements for an erased-call argument buffer.
 pub const Metrics = struct {
     size: u32,
     alignment: u32,

--- a/src/layout/erased_call_abi.zig
+++ b/src/layout/erased_call_abi.zig
@@ -1,0 +1,56 @@
+//! Canonical packed-argument layout for the erased-callable ABI.
+
+const std = @import("std");
+const layout = @import("layout.zig");
+const Store = @import("store.zig").Store;
+
+pub const Metrics = struct {
+    size: u32,
+    alignment: u32,
+};
+
+/// Fill `offsets` with declaration-order, naturally aligned field offsets.
+pub fn plan(store: *const Store, arg_layouts: []const layout.Idx, offsets: []u32) Metrics {
+    std.debug.assert(arg_layouts.len == offsets.len);
+
+    var size: u32 = 0;
+    var max_alignment: u32 = 1;
+    for (arg_layouts, offsets) |arg_layout, *offset| {
+        const runtime_layout = store.runtimeRepresentationLayoutIdx(arg_layout);
+        const size_align = store.layoutSizeAlign(store.getLayout(runtime_layout));
+        const alignment: u32 = @intCast(@max(size_align.alignment.toByteUnits(), 1));
+        size = std.mem.alignForward(u32, size, alignment);
+        offset.* = size;
+        size += size_align.size;
+        max_alignment = @max(max_alignment, alignment);
+    }
+
+    return .{
+        .size = std.mem.alignForward(u32, size, max_alignment),
+        .alignment = max_alignment,
+    };
+}
+
+test "erased call arguments preserve declaration order and natural alignment" {
+    var store = try Store.init(std.testing.allocator, .u64);
+    defer store.deinit();
+
+    var offsets: [2]u32 = undefined;
+    const metrics = plan(&store, &.{ .u8, .u64 }, &offsets);
+
+    try std.testing.expectEqualSlices(u32, &.{ 0, 8 }, &offsets);
+    try std.testing.expectEqual(@as(u32, 16), metrics.size);
+    try std.testing.expectEqual(@as(u32, 8), metrics.alignment);
+}
+
+test "erased call argument plans pack adjacent sub-word fields" {
+    var store = try Store.init(std.testing.allocator, .u64);
+    defer store.deinit();
+
+    var offsets: [3]u32 = undefined;
+    const metrics = plan(&store, &.{ .u8, .u8, .u64 }, &offsets);
+
+    try std.testing.expectEqualSlices(u32, &.{ 0, 1, 8 }, &offsets);
+    try std.testing.expectEqual(@as(u32, 16), metrics.size);
+    try std.testing.expectEqual(@as(u32, 8), metrics.alignment);
+}

--- a/src/layout/mod.zig
+++ b/src/layout/mod.zig
@@ -62,6 +62,7 @@ pub const ScalarInfo = @import("layout.zig").ScalarInfo;
 
 // Per-target C-ABI parameter/return classification.
 pub const abi = @import("abi/mod.zig");
+pub const erased_call_abi = @import("erased_call_abi.zig");
 
 // Record field ordering used by the layout store when committing record
 // layouts. `roc glue` consumes the committed order rather than reordering
@@ -127,6 +128,7 @@ test "layout tests" {
     std.testing.refAllDecls(@import("layout.zig"));
     std.testing.refAllDecls(@import("graph.zig"));
     std.testing.refAllDecls(@import("rc_helper.zig"));
+    std.testing.refAllDecls(@import("erased_call_abi.zig"));
     std.testing.refAllDecls(@import("store.zig"));
     std.testing.refAllDecls(@import("field_order.zig"));
     std.testing.refAllDecls(@import("abi/mod.zig"));

--- a/src/lir/LIR.zig
+++ b/src/lir/LIR.zig
@@ -145,6 +145,26 @@ pub const U64Span = extern struct {
     }
 };
 
+/// Span into flat u32 storage.
+pub const U32Span = extern struct {
+    start: u32,
+    len: u32,
+
+    pub fn empty() U32Span {
+        return .{ .start = 0, .len = 0 };
+    }
+};
+
+/// Identifier of one interned erased-call argument layout plan.
+pub const ErasedCallArgsPlanId = enum(u32) { _ };
+
+/// Exact packed-argument struct layout shared by an erased caller and callee.
+pub const ErasedCallArgsPlan = extern struct {
+    offsets: U32Span,
+    size: u32,
+    alignment: u32,
+};
+
 /// Builtin low-level operations reused from `base`.
 pub const LowLevel = base.LowLevel;
 
@@ -457,6 +477,7 @@ pub const CFStmt = union(enum) {
         target: LocalId,
         closure: LocalId,
         args: LocalSpan,
+        arg_plan: ErasedCallArgsPlanId,
         /// Consume the allocation denoted by `closure` as the destination for
         /// an erased-callable result.
         /// The erased callee may repack it when the returned capture payload has
@@ -707,6 +728,8 @@ pub const LirProcSpec = struct {
     /// caller declines reuse. Internal Roc-ABI destination variants preserve
     /// this marker when they forward the same input.
     erased_reuse_arg: ?LocalId = null,
+    /// Packed explicit-argument layout required by the erased-callable ABI.
+    erased_call_args: ?ErasedCallArgsPlanId = null,
     frame_locals: LocalSpan = LocalSpan.empty(),
     join_points: JoinPointSpan = JoinPointSpan.empty(),
     body: ?CFStmtId = null,

--- a/src/lir/LirStore.zig
+++ b/src/lir/LirStore.zig
@@ -33,6 +33,9 @@ const LirPattern = lir_defs.LirPattern;
 const LirPatternId = lir_defs.LirPatternId;
 const LirPatternSpan = lir_defs.LirPatternSpan;
 const U64Span = lir_defs.U64Span;
+const U32Span = lir_defs.U32Span;
+const ErasedCallArgsPlan = lir_defs.ErasedCallArgsPlan;
+const ErasedCallArgsPlanId = lir_defs.ErasedCallArgsPlanId;
 
 /// Source-level name to use when presenting a specialized LIR proc in debug output.
 pub const ProcDebugName = extern struct {
@@ -60,6 +63,8 @@ join_points: GuardedList.List(JoinPoint, "LirStore.join_points"),
 locals: GuardedList.List(Local, "LirStore.locals"),
 local_ids: GuardedList.List(LocalId, "LirStore.local_ids"),
 u64s: GuardedList.List(u64, "LirStore.u64s"),
+u32s: GuardedList.List(u32, "LirStore.u32s"),
+erased_call_arg_plans: GuardedList.List(ErasedCallArgsPlan, "LirStore.erased_call_arg_plans"),
 proc_specs: GuardedList.List(LirProcSpec, "LirStore.proc_specs"),
 strings: base.StringLiteral.Store,
 string_builder: base.StringLiteral.BuilderState,
@@ -109,6 +114,8 @@ pub fn init(allocator: Allocator) Self {
         .locals = .empty,
         .local_ids = .empty,
         .u64s = .empty,
+        .u32s = .empty,
+        .erased_call_arg_plans = .empty,
         .proc_specs = .empty,
         .strings = base.StringLiteral.Store{},
         .string_builder = .{},
@@ -142,6 +149,8 @@ pub fn deinit(self: *Self) void {
     self.locals.deinit(self.allocator);
     self.local_ids.deinit(self.allocator);
     self.u64s.deinit(self.allocator);
+    self.u32s.deinit(self.allocator);
+    self.erased_call_arg_plans.deinit(self.allocator);
     self.proc_specs.deinit(self.allocator);
     self.string_builder.deinit(self.allocator);
     self.strings.deinit(self.allocator);
@@ -429,6 +438,54 @@ pub fn addU64Span(self: *Self, values: []const u64) Allocator.Error!U64Span {
 /// Resolves a u64 span to its stored slice.
 pub fn getU64Span(self: *const Self, span: U64Span) StoreSpanBorrow(u64, "u64s") {
     return self.u64s.borrowSpan(span.start, span.len);
+}
+
+fn addU32Span(self: *Self, values: []const u32) Allocator.Error!U32Span {
+    if (values.len == 0) return U32Span.empty();
+    const start: u32 = @intCast(self.u32s.len());
+    try self.u32s.appendSlice(self.allocator, values);
+    return .{ .start = start, .len = @intCast(values.len) };
+}
+
+/// Intern the canonical erased-call argument layout for an ordered signature.
+pub fn internErasedCallArgsPlan(
+    self: *Self,
+    layouts: *const layout.Store,
+    arg_layouts: []const layout.Idx,
+) Allocator.Error!ErasedCallArgsPlanId {
+    const offsets = try self.allocator.alloc(u32, arg_layouts.len);
+    defer self.allocator.free(offsets);
+    const metrics = layout.erased_call_abi.plan(layouts, arg_layouts, offsets);
+
+    for (self.erased_call_arg_plans.unsafeRawItemsForView(), 0..) |existing, index| {
+        const existing_offsets = self.u32s.unsafeRawItemsForView()[existing.offsets.start..][0..existing.offsets.len];
+        if (existing.size == metrics.size and
+            existing.alignment == metrics.alignment and
+            std.mem.eql(u32, existing_offsets, offsets))
+        {
+            return @enumFromInt(@as(u32, @intCast(index)));
+        }
+    }
+
+    const id: ErasedCallArgsPlanId = @enumFromInt(@as(u32, @intCast(self.erased_call_arg_plans.len())));
+    try self.erased_call_arg_plans.append(self.allocator, .{
+        .offsets = try self.addU32Span(offsets),
+        .size = metrics.size,
+        .alignment = metrics.alignment,
+    });
+    return id;
+}
+
+pub fn getErasedCallArgsPlan(self: *const Self, id: ErasedCallArgsPlanId) ErasedCallArgsPlan {
+    return self.erased_call_arg_plans.get(@intFromEnum(id));
+}
+
+pub fn erasedCallArgsPlanCount(self: *const Self) usize {
+    return self.erased_call_arg_plans.len();
+}
+
+pub fn getErasedCallArgOffsets(self: *const Self, plan: ErasedCallArgsPlan) StoreSpanBorrow(u32, "u32s") {
+    return self.u32s.borrowSpan(plan.offsets.start, plan.offsets.len);
 }
 
 /// Appends a statement/control-flow node and returns its id.

--- a/src/lir/LirStore.zig
+++ b/src/lir/LirStore.zig
@@ -476,14 +476,17 @@ pub fn internErasedCallArgsPlan(
     return id;
 }
 
+/// Return an interned erased-call argument layout plan.
 pub fn getErasedCallArgsPlan(self: *const Self, id: ErasedCallArgsPlanId) ErasedCallArgsPlan {
     return self.erased_call_arg_plans.get(@intFromEnum(id));
 }
 
+/// Return the number of interned erased-call argument layout plans.
 pub fn erasedCallArgsPlanCount(self: *const Self) usize {
     return self.erased_call_arg_plans.len();
 }
 
+/// Borrow the ordered field offsets named by an erased-call argument layout plan.
 pub fn getErasedCallArgOffsets(self: *const Self, plan: ErasedCallArgsPlan) StoreSpanBorrow(u32, "u32s") {
     return self.u32s.borrowSpan(plan.offsets.start, plan.offsets.len);
 }

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -1378,6 +1378,7 @@ const Inserter = struct {
                     .target = assign.target,
                     .closure = assign.closure,
                     .args = assign.args,
+                    .arg_plan = assign.arg_plan,
                     .reuse_closure = assign.reuse_closure,
                     .reuse_source = assign.reuse_source,
                     .next = next,
@@ -3470,6 +3471,7 @@ const Inserter = struct {
             .name = self.store.freshSyntheticSymbol(),
             .args = source_spec.args,
             .erased_reuse_arg = source_spec.erased_reuse_arg,
+            .erased_call_args = source_spec.erased_call_args,
             .frame_locals = source_spec.frame_locals,
             .body = self.variants.original_bodies[@intFromEnum(callee)],
             .ret_layout = source_spec.ret_layout,
@@ -5683,12 +5685,14 @@ test "ARC transfers erased call ownership from an explicit outer source" {
     const owned_callable = try f.local(erased_callable);
     const extracted_callable = try f.local(erased_callable);
     const next_callable = try f.local(erased_callable);
+    const arg_plan = try f.store.internErasedCallArgsPlan(&f.layouts, &.{});
 
     const ret = try f.ret(next_callable);
     const call = try f.store.addCFStmt(.{ .assign_call_erased = .{
         .target = next_callable,
         .closure = extracted_callable,
         .args = LIR.LocalSpan.empty(),
+        .arg_plan = arg_plan,
         .reuse_closure = true,
         .reuse_source = owned_callable,
         .next = ret,
@@ -5727,6 +5731,7 @@ test "ARC retains an erased call reuse source that is read after the call" {
     const owned_callable = try f.local(erased_callable);
     const extracted_callable = try f.local(erased_callable);
     const next_callable = try f.local(erased_callable);
+    const arg_plan = try f.store.internErasedCallArgsPlan(&f.layouts, &.{});
 
     const ret = try f.ret(next_callable);
     const later_use = try f.expectStmt(owned_callable, ret);
@@ -5734,6 +5739,7 @@ test "ARC retains an erased call reuse source that is read after the call" {
         .target = next_callable,
         .closure = extracted_callable,
         .args = LIR.LocalSpan.empty(),
+        .arg_plan = arg_plan,
         .reuse_closure = true,
         .reuse_source = owned_callable,
         .next = later_use,

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -182,7 +182,7 @@ fn certifyStoreWithWorkStats(
     diag: *Diagnostic,
     work_stats: ?*CertifierWorkStats,
 ) CertifyError!void {
-    try certifyProcAbiMetadata(store, layouts, diag);
+    try certifyProcAbiMetadata(allocator, store, layouts, diag);
 
     var rc_local = try allocator.alloc(bool, store.localCount());
     defer allocator.free(rc_local);
@@ -230,6 +230,7 @@ fn certifyStoreWithWorkStats(
 /// decrefed. Internal Roc-ABI destination variants may also carry the marker,
 /// so every non-null marker names a final erased-callable argument.
 fn certifyProcAbiMetadata(
+    allocator: Allocator,
     store: *const LirStore,
     layouts: *const layout_mod.Store,
     diag: *Diagnostic,
@@ -255,7 +256,14 @@ fn certifyProcAbiMetadata(
             }
         }
 
-        if (proc.abi != .erased_callable) continue;
+        if (proc.abi != .erased_callable) {
+            if (proc.erased_call_args != null) {
+                diag.context_proc = proc_id;
+                diag.set("proc={d}: ordinary Roc ABI proc carried an erased-call argument plan", .{proc_index});
+                return error.Certification;
+            }
+            continue;
+        }
         if (GuardedList.borrowLen(args) < 2) {
             diag.context_proc = proc_id;
             diag.set("proc={d}: erased-callable ABI requires trailing capture and reuse arguments", .{proc_index});
@@ -272,6 +280,66 @@ fn certifyProcAbiMetadata(
         if (proc.erased_reuse_arg == null) {
             diag.context_proc = proc_id;
             diag.set("proc={d}: erased-callable reuse argument must carry its ownership marker", .{proc_index});
+            return error.Certification;
+        }
+
+        const arg_plan = proc.erased_call_args orelse {
+            diag.context_proc = proc_id;
+            diag.set("proc={d}: erased-callable ABI proc lacks an argument plan", .{proc_index});
+            return error.Certification;
+        };
+        try certifyErasedCallArgsPlan(
+            allocator,
+            store,
+            layouts,
+            arg_plan,
+            proc.args,
+            GuardedList.borrowLen(args) - 2,
+            diag,
+        );
+    }
+}
+
+fn certifyErasedCallArgsPlan(
+    allocator: Allocator,
+    store: *const LirStore,
+    layouts: *const layout_mod.Store,
+    plan_id: LIR.ErasedCallArgsPlanId,
+    args_span: LIR.LocalSpan,
+    explicit_count: usize,
+    diag: *Diagnostic,
+) CertifyError!void {
+    if (@intFromEnum(plan_id) >= store.erasedCallArgsPlanCount()) {
+        diag.set("erased-call argument plan index is out of bounds", .{});
+        return error.Certification;
+    }
+
+    const args = store.getLocalSpan(args_span);
+    if (explicit_count > GuardedList.borrowLen(args)) {
+        diag.set("erased-call argument plan has more fields than the argument span", .{});
+        return error.Certification;
+    }
+    const arg_layouts = try allocator.alloc(layout_mod.Idx, explicit_count);
+    defer allocator.free(arg_layouts);
+    for (0..explicit_count) |i| {
+        arg_layouts[i] = store.getLocal(GuardedList.at(args, i)).layout_idx;
+    }
+    const expected_offsets = try allocator.alloc(u32, explicit_count);
+    defer allocator.free(expected_offsets);
+    const expected = layout_mod.erased_call_abi.plan(layouts, arg_layouts, expected_offsets);
+
+    const actual = store.getErasedCallArgsPlan(plan_id);
+    const actual_offsets = store.getErasedCallArgOffsets(actual);
+    if (actual.size != expected.size or
+        actual.alignment != expected.alignment or
+        GuardedList.borrowLen(actual_offsets) != explicit_count)
+    {
+        diag.set("erased-call argument plan metrics do not match its arguments", .{});
+        return error.Certification;
+    }
+    for (expected_offsets, 0..) |expected_offset, i| {
+        if (GuardedList.at(actual_offsets, i) != expected_offset) {
+            diag.set("erased-call argument plan offset {d} does not match its argument", .{i});
             return error.Certification;
         }
     }
@@ -2097,6 +2165,17 @@ const Certifier = struct {
                     try stack.append(self.allocator, assign.next);
                 },
                 .assign_call_erased => |assign| {
+                    self.diag.context_proc = self.current_proc;
+                    self.diag.context_stmt = current;
+                    try certifyErasedCallArgsPlan(
+                        self.allocator,
+                        self.store,
+                        self.layouts,
+                        assign.arg_plan,
+                        assign.args,
+                        self.store.getLocalSpan(assign.args).len,
+                        self.diag,
+                    );
                     try self.noteProcLocal(assign.target);
                     try self.noteErasedOwnerDefinition(assign.target, null);
                     try self.noteProcLocal(assign.closure);
@@ -3781,7 +3860,7 @@ const CertifyTest = struct {
     }
 
     fn certifyProcAbiMetadataOnly(self: *CertifyTest) CertifyError!void {
-        return certifyProcAbiMetadata(&self.store, &self.layouts, &self.diag);
+        return certifyProcAbiMetadata(self.allocator, &self.store, &self.layouts, &self.diag);
     }
 };
 
@@ -3795,10 +3874,12 @@ test "certify accepts consistent erased-callable proc ABI metadata" {
         const reuse = try f.local(erased_callable);
         const result = try f.local(.i64);
         const body = try f.ret(result);
+        const arg_plan = try f.store.internErasedCallArgsPlan(&f.layouts, &.{});
         _ = try f.store.addProcSpec(.{
             .name = f.store.freshSyntheticSymbol(),
             .args = try f.store.addLocalSpan(&.{ capture, reuse }),
             .erased_reuse_arg = reuse,
+            .erased_call_args = arg_plan,
             .body = body,
             .ret_layout = .i64,
             .abi = .erased_callable,
@@ -3815,10 +3896,12 @@ test "certify accepts consistent erased-callable proc ABI metadata" {
         const capture = try f.local(.opaque_ptr);
         const reuse = try f.local(erased_callable);
         const body = try f.ret(reuse);
+        const arg_plan = try f.store.internErasedCallArgsPlan(&f.layouts, &.{});
         _ = try f.store.addProcSpec(.{
             .name = f.store.freshSyntheticSymbol(),
             .args = try f.store.addLocalSpan(&.{ capture, reuse }),
             .erased_reuse_arg = reuse,
+            .erased_call_args = arg_plan,
             .body = body,
             .ret_layout = erased_callable,
             .abi = .erased_callable,
@@ -3933,6 +4016,57 @@ test "certify rejects erased-callable proc ABI metadata mismatches" {
     }
 }
 
+test "certify rejects an erased-call argument plan that differs from the signature" {
+    var f = try CertifyTest.init(testing.allocator);
+    defer f.deinit();
+
+    const first = try f.local(.u8);
+    const second = try f.local(.u64);
+    const capture = try f.local(.opaque_ptr);
+    const erased_callable = try f.layouts.insertErasedCallable();
+    const reuse = try f.local(erased_callable);
+    const result = try f.local(.i64);
+    const body = try f.ret(result);
+    const wrong_plan = try f.store.internErasedCallArgsPlan(&f.layouts, &.{ .u8, .u8 });
+    _ = try f.store.addProcSpec(.{
+        .name = f.store.freshSyntheticSymbol(),
+        .args = try f.store.addLocalSpan(&.{ first, second, capture, reuse }),
+        .erased_reuse_arg = reuse,
+        .erased_call_args = wrong_plan,
+        .body = body,
+        .ret_layout = .i64,
+        .abi = .erased_callable,
+    });
+
+    try testing.expectError(error.Certification, f.certifyProcAbiMetadataOnly());
+    try testing.expect(std.mem.find(u8, f.diag.message(), "plan metrics do not match") != null);
+}
+
+test "certify rejects an erased call site whose argument plan differs" {
+    var f = try CertifyTest.init(testing.allocator);
+    defer f.deinit();
+
+    const erased_callable = try f.layouts.insertErasedCallable();
+    const closure = try f.local(erased_callable);
+    const first = try f.local(.u8);
+    const second = try f.local(.u64);
+    const result = try f.local(.i64);
+    const ret = try f.ret(result);
+    const args = try f.store.addLocalSpan(&.{ first, second });
+    const wrong_plan = try f.store.internErasedCallArgsPlan(&f.layouts, &.{ .u8, .u8 });
+    const body = try f.store.addCFStmt(.{ .assign_call_erased = .{
+        .target = result,
+        .closure = closure,
+        .args = args,
+        .arg_plan = wrong_plan,
+        .next = ret,
+    } });
+    _ = try f.addProc(&.{ closure, first, second }, body, .i64);
+
+    try testing.expectError(error.Certification, f.certify());
+    try testing.expect(std.mem.find(u8, f.diag.message(), "plan metrics do not match") != null);
+}
+
 test "unique-argument certification isolates shared locals between procedures" {
     var f = try CertifyTest.init(testing.allocator);
     defer f.deinit();
@@ -4045,10 +4179,12 @@ test "certify rejects inconsistent erased call reuse fields" {
         const closure = try f.local(erased_callable);
         const result = try f.local(erased_callable);
         const ret = try f.ret(result);
+        const arg_plan = try f.store.internErasedCallArgsPlan(&f.layouts, &.{});
         const body = try f.store.addCFStmt(.{ .assign_call_erased = .{
             .target = result,
             .closure = closure,
             .args = LIR.LocalSpan.empty(),
+            .arg_plan = arg_plan,
             .reuse_closure = true,
             .reuse_source = null,
             .next = ret,
@@ -4065,10 +4201,12 @@ test "certify rejects inconsistent erased call reuse fields" {
         const closure = try f.local(erased_callable);
         const result = try f.local(erased_callable);
         const ret = try f.ret(result);
+        const arg_plan = try f.store.internErasedCallArgsPlan(&f.layouts, &.{});
         const body = try f.store.addCFStmt(.{ .assign_call_erased = .{
             .target = result,
             .closure = closure,
             .args = LIR.LocalSpan.empty(),
+            .arg_plan = arg_plan,
             .reuse_closure = false,
             .reuse_source = closure,
             .next = ret,
@@ -4087,10 +4225,12 @@ test "certify accepts erased call reuse from a transparent outer owner" {
     const closure = try f.local(erased_callable);
     const result = try f.local(erased_callable);
     const ret = try f.ret(result);
+    const arg_plan = try f.store.internErasedCallArgsPlan(&f.layouts, &.{});
     const call = try f.store.addCFStmt(.{ .assign_call_erased = .{
         .target = result,
         .closure = closure,
         .args = LIR.LocalSpan.empty(),
+        .arg_plan = arg_plan,
         .reuse_closure = true,
         .reuse_source = owner,
         .next = ret,
@@ -4112,10 +4252,12 @@ test "certify rejects erased call reuse from a different allocation" {
     const unrelated = try f.local(erased_callable);
     const result = try f.local(erased_callable);
     const ret = try f.ret(result);
+    const arg_plan = try f.store.internErasedCallArgsPlan(&f.layouts, &.{});
     const body = try f.store.addCFStmt(.{ .assign_call_erased = .{
         .target = result,
         .closure = closure,
         .args = LIR.LocalSpan.empty(),
+        .arg_plan = arg_plan,
         .reuse_closure = true,
         .reuse_source = unrelated,
         .next = ret,

--- a/src/lir/body_clone.zig
+++ b/src/lir/body_clone.zig
@@ -389,6 +389,7 @@ pub fn BodyCloner(comptime Rewriter: type) type {
                     .target = try self.mapLocal(s.target),
                     .closure = try self.mapLocal(s.closure),
                     .args = try self.mapLocalSpan(s.args),
+                    .arg_plan = s.arg_plan,
                     .reuse_closure = s.reuse_closure,
                     .reuse_source = try self.mapMaybeLocal(s.reuse_source),
                     .next = try self.cloneStmt(s.next),

--- a/src/lir/lir_image.zig
+++ b/src/lir/lir_image.zig
@@ -31,7 +31,8 @@ pub const MAGIC: u32 = 0x52494c52; // "RLIR" in little-endian bytes.
 /// v11: LocalSpan lengths are u32 for large proc frame-local spans.
 /// v12: statements carry virtual inline-scope ids and the image stores the
 ///      corresponding source-procedure/call-site graph.
-pub const FORMAT_VERSION: u32 = 12;
+/// v13: erased calls and procedures carry explicit packed-argument plans.
+pub const FORMAT_VERSION: u32 = 13;
 
 /// Public `ImageError` declaration.
 pub const ImageError = error{
@@ -97,6 +98,8 @@ pub const LirStoreImage = extern struct {
     locals: ArrayRef,
     local_ids: ArrayRef,
     u64s: ArrayRef,
+    u32s: ArrayRef,
+    erased_call_arg_plans: ArrayRef,
     proc_specs: ArrayRef,
     strings: StringLiteralStoreImage,
     next_synthetic_symbol: u64,
@@ -120,6 +123,8 @@ pub const LirStoreImage = extern struct {
             .locals = try arrayRef(base_ptr, image_size, store.locals.unsafeRawItemsForView()),
             .local_ids = try arrayRef(base_ptr, image_size, store.local_ids.unsafeRawItemsForView()),
             .u64s = try arrayRef(base_ptr, image_size, store.u64s.unsafeRawItemsForView()),
+            .u32s = try arrayRef(base_ptr, image_size, store.u32s.unsafeRawItemsForView()),
+            .erased_call_arg_plans = try arrayRef(base_ptr, image_size, store.erased_call_arg_plans.unsafeRawItemsForView()),
             .proc_specs = try arrayRef(base_ptr, image_size, store.proc_specs.unsafeRawItemsForView()),
             .strings = try StringLiteralStoreImage.fromStore(base_ptr, image_size, &store.strings),
             .next_synthetic_symbol = store.next_synthetic_symbol,
@@ -150,6 +155,8 @@ pub const LirStoreImage = extern struct {
             .locals = try copyArrayRef(allocator, base_ptr, image_capacity, store.locals.unsafeRawItemsForView()),
             .local_ids = try copyArrayRef(allocator, base_ptr, image_capacity, store.local_ids.unsafeRawItemsForView()),
             .u64s = try copyArrayRef(allocator, base_ptr, image_capacity, store.u64s.unsafeRawItemsForView()),
+            .u32s = try copyArrayRef(allocator, base_ptr, image_capacity, store.u32s.unsafeRawItemsForView()),
+            .erased_call_arg_plans = try copyArrayRef(allocator, base_ptr, image_capacity, store.erased_call_arg_plans.unsafeRawItemsForView()),
             .proc_specs = try copyArrayRef(allocator, base_ptr, image_capacity, store.proc_specs.unsafeRawItemsForView()),
             .strings = try StringLiteralStoreImage.copyFromStore(allocator, base_ptr, image_capacity, &store.strings),
             .next_synthetic_symbol = store.next_synthetic_symbol,
@@ -175,6 +182,8 @@ pub const LirStoreImage = extern struct {
             .locals = try guardedListFromRef(LIR.Local, "LirStore.locals", base_ptr, image_size, self.locals),
             .local_ids = try guardedListFromRef(LIR.LocalId, "LirStore.local_ids", base_ptr, image_size, self.local_ids),
             .u64s = try guardedListFromRef(u64, "LirStore.u64s", base_ptr, image_size, self.u64s),
+            .u32s = try guardedListFromRef(u32, "LirStore.u32s", base_ptr, image_size, self.u32s),
+            .erased_call_arg_plans = try guardedListFromRef(LIR.ErasedCallArgsPlan, "LirStore.erased_call_arg_plans", base_ptr, image_size, self.erased_call_arg_plans),
             .proc_specs = try guardedListFromRef(LIR.LirProcSpec, "LirStore.proc_specs", base_ptr, image_size, self.proc_specs),
             .strings = try self.strings.view(base_ptr, image_size),
             .string_builder = .{},
@@ -298,7 +307,7 @@ comptime {
     // this file, then update the expected field count below. A same-build
     // omission (a new store field left out of the image plumbing) is otherwise
     // silent, since `FORMAT_VERSION` only guards cross-version mismatches.
-    std.debug.assert(@typeInfo(LirStore).@"struct".fields.len == 28);
+    std.debug.assert(@typeInfo(LirStore).@"struct".fields.len == 30);
     std.debug.assert(@typeInfo(layout_mod.Store).@"struct".fields.len == 12);
     std.debug.assert(@typeInfo(base.StringLiteral.Store).@"struct".fields.len == 1);
 }
@@ -584,7 +593,7 @@ test "LIR image declarations are referenced" {
     std.testing.refAllDecls(@This());
 }
 
-/// The 18 `LirStore` array-backed lists serialized as `ArrayRef`s, in the order
+/// The 20 `LirStore` array-backed lists serialized as `ArrayRef`s, in the order
 /// they appear in `LirStoreImage`. `strings` (a sub-image) and the scalar
 /// `next_synthetic_symbol` are serialized too but exercised separately below.
 const serialized_guarded_fields = [_][]const u8{
@@ -596,6 +605,8 @@ const serialized_guarded_fields = [_][]const u8{
     "locals",
     "local_ids",
     "u64s",
+    "u32s",
+    "erased_call_arg_plans",
     "proc_specs",
     "source_file_bytes",
     "source_file_ends",

--- a/src/lir/tag_reachability.zig
+++ b/src/lir/tag_reachability.zig
@@ -1289,6 +1289,7 @@ test "tag reachability retains branches for erased call results" {
     const closure = try f.local(f.outer_layout);
     const result = try f.local(f.outer_layout);
     const disc = try f.local(.u16);
+    const arg_plan = try store.internErasedCallArgsPlan(&f.result.layouts, &.{});
 
     const ret_stmt = try store.addCFStmt(.{ .ret = .{ .value = result } });
     const bad = try store.addCFStmt(.{ .runtime_error = {} });
@@ -1306,6 +1307,7 @@ test "tag reachability retains branches for erased call results" {
         .target = result,
         .closure = closure,
         .args = LIR.LocalSpan.empty(),
+        .arg_plan = arg_plan,
         .next = disc_read,
     } });
     const proc = try store.addProcSpec(.{

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -1167,6 +1167,10 @@ const Lowerer = struct {
             .name = lirSymbol(entry.symbol),
             .args = args_span,
             .erased_reuse_arg = erased_reuse_arg,
+            .erased_call_args = if (spec.abi == .erased)
+                try self.erasedCallArgsPlan(arg_locals[0..lifted_args.len])
+            else
+                null,
             .body = null,
             .ret_layout = ret_layout,
             .abi = if (spec.abi == .erased) .erased_callable else .roc,
@@ -4246,6 +4250,7 @@ const Lowerer = struct {
             .target = call_target,
             .closure = callee,
             .args = try self.result.store.addLocalSpan(args.ids),
+            .arg_plan = try self.erasedCallArgsPlan(args.ids),
             .reuse_closure = reuse_closure,
             .reuse_source = if (reuse_closure) callee else null,
             .next = after_call,
@@ -4259,6 +4264,15 @@ const Lowerer = struct {
         var current = call_stmt;
         current = try self.prependExprsAtTypes(args, arg_tys, current);
         return try self.lowerExprIntoAtType(callee, callee_expr, callee_ty, current);
+    }
+
+    fn erasedCallArgsPlan(self: *Lowerer, args: []const LIR.LocalId) Common.LowerError!LIR.ErasedCallArgsPlanId {
+        const arg_layouts = try self.allocator.alloc(layout.Idx, args.len);
+        defer self.allocator.free(arg_layouts);
+        for (args, arg_layouts) |arg, *arg_layout| {
+            arg_layout.* = self.result.store.getLocal(arg).layout_idx;
+        }
+        return try self.result.store.internErasedCallArgsPlan(&self.result.layouts, arg_layouts);
     }
 
     /// Resolve the ownership unit consumed by erased calls from provenance

--- a/test/fx/erased_small_first_arg.roc
+++ b/test/fx/erased_small_first_arg.roc
@@ -1,0 +1,13 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+# Repro for https://github.com/roc-lang/roc/issues/10364
+bump : U8, U64 -> U8
+bump = |x, _ev| x + 1
+
+main! = || {
+    f = Box.unbox(Box.box(bump))
+
+    Stdout.line!(f(1, 99).to_str())
+}


### PR DESCRIPTION
Erased callable callers packed arguments as a source-order struct, but LLVM callees decoded them with the alignment-sorted internal Roc ABI, causing a sub-word first parameter to read the following argument. This makes the packed argument layout explicit LIR metadata produced by postcheck lowering, certified across calls and procedures, serialized in LIR images, and consumed by LLVM, dev, and Wasm. Fixes #10364.