### PR TITLE
Fix List.map reuse ownership check

### DIFF
--- a/design.md
+++ b/design.md
@@ -5965,13 +5965,25 @@ that disagree on either would make a later free reconstruct the wrong
 allocation pointer.
 
 The decision has a compile-time half and a runtime half. `List.map`'s body
-in Builtin.roc matches on the `list_map_can_reuse` primitive, whose runtime
-meaning is "uniquely owned and not a seamless slice" — a slice's buffer
-points into the middle of an allocation whose header bookkeeping covers the
-whole allocation, so a unique slice still copies. At direct LIR lowering,
-where layouts exist, the primitive lowers to a constant 0 whenever the
-layouts are not interchangeable (or the optimization is off), so the
-runtime check never runs for a pair it could corrupt.
+in Builtin.roc first calls the consuming `list_map_prepare_reuse` primitive,
+then matches on `list_map_can_reuse` for the returned list. The prepare
+primitive is an ownership-only identity: its LIR `RcEffect` consumes the input
+list and declares that the result aliases that consumed ownership unit, while
+its runtime implementation only copies the list handle. This forces ARC to
+preserve every later use before the transfer. The subsequent reuse query can
+therefore observe the refcount only after all live ownership units are present;
+leaving the query on the original, unconsumed argument would allow ARC to move
+a preservation retain after that observation and incorrectly report a shared
+buffer as unique.
+
+The runtime meaning of `list_map_can_reuse` is "uniquely owned and not a
+seamless slice" — a slice's buffer points into the middle of an allocation
+whose header bookkeeping covers the whole allocation, so a unique slice still
+copies. At direct LIR lowering, where layouts exist, the primitive lowers to a
+constant 0 whenever the layouts are not interchangeable (or the optimization
+is off), so the runtime check never runs for a pair it could corrupt.
+Target-independent LIR carries this eligibility for both pointer widths and
+each backend resolves the bit for its target.
 
 The in-place branch itself is dropped before it reaches LIR whenever the
 item layouts are not interchangeable or the optimization is disabled

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -1831,6 +1831,12 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     result_loc = try self.stabilize(result_loc);
                     return result_loc;
                 },
+                .list_map_prepare_reuse => {
+                    // Ownership-only identity; binding the result supplies any
+                    // storage stabilization the target needs.
+                    std.debug.assert(args.len == 1);
+                    return self.emitValueLocal(GuardedList.at(args, 0));
+                },
                 .list_map_can_reuse => {
                     // list_map_can_reuse(list, transform) -> U8; only the list is inspected.
                     std.debug.assert(args.len == 2);

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -2990,6 +2990,7 @@ pub const MonoLlvmCodeGen = struct {
             .list_swap => try self.emitListSwap(target, arg_locals, unique_args),
             .list_set => try self.emitListSet(target, arg_locals, unique_args),
             .list_replace_unsafe => try self.emitListReplaceUnsafe(target, arg_locals, unique_args),
+            .list_map_prepare_reuse => try self.copyBytes(self.slot(target).ptr, self.slot(GuardedList.at(arg_locals, 0)).ptr, self.slot(target).size, self.slot(target).alignment),
             .list_map_can_reuse => try self.emitListMapCanReuse(target, arg_locals, interchangeable),
             .list_map_cast_unsafe => try self.copyBytes(self.slot(target).ptr, self.slot(GuardedList.at(arg_locals, 0)).ptr, self.slot(target).size, self.slot(target).alignment),
             .list_map_extract_unsafe => try self.emitListMapExtractUnsafe(target, arg_locals),

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -11586,6 +11586,12 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             }
         },
 
+        .list_map_prepare_reuse => {
+            // Ownership-only identity; binding the result stabilizes the
+            // composite value in the target's storage.
+            try self.emitProcLocal(GuardedList.at(args, 0));
+        },
+
         .list_map_can_reuse => {
             // On a width where the element layouts are not interchangeable, the
             // in-place branch is statically dead, so the result is a constant 0

--- a/src/base/LowLevel.zig
+++ b/src/base/LowLevel.zig
@@ -78,6 +78,7 @@ pub const LowLevel = enum(u16) {
     list_release_excess_capacity,
     list_split_first,
     list_split_last,
+    list_map_prepare_reuse,
     list_map_can_reuse,
     list_map_cast_unsafe,
     list_map_extract_unsafe,
@@ -838,6 +839,16 @@ pub const LowLevel = enum(u16) {
                 .result_unique = true,
             };
         }
+
+        /// Move consumed ownership units into the result without claiming that
+        /// their allocations are unique.
+        pub fn consumesArgsReturningConsumedArgs(mask: u64) RcEffect {
+            return .{
+                .may_retain_or_release = mask != 0,
+                .consume_args = mask,
+                .result_aliases_consumed_args = mask,
+            };
+        }
     };
 
     /// Return the explicit RC metadata for this primitive. The masks identify
@@ -900,7 +911,12 @@ pub const LowLevel = enum(u16) {
 
             .list_append_unsafe => RcEffect.consumesArgsReturningConsumedArgsRetainingArgs(argMask(&.{0}), argMask(&.{1})),
 
-            // Reads the list's refcount (and slice bit) without changing it.
+            // Moves the list's ownership unit into a new local before the
+            // reuse query, forcing ARC to preserve every later use first.
+            .list_map_prepare_reuse => RcEffect.consumesArgsReturningConsumedArgs(argMask(&.{0})),
+
+            // Reads the prepared list's refcount (and slice bit) without
+            // changing it.
             .list_map_can_reuse => RcEffect.none(),
 
             // Retypes a unique non-slice list to the output element type,

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -4169,10 +4169,11 @@ Builtin :: [].{
 		## ```
 		map : List(a), (a -> b) -> List(b)
 		map = |list, transform| {
-			match list_map_can_reuse(list, transform) {
+			prepared_list = list_map_prepare_reuse(list)
+			match list_map_can_reuse(prepared_list, transform) {
 				1 => {
-					len = list.len()
-					var $out = list_map_cast_unsafe(list)
+					len = prepared_list.len()
+					var $out = list_map_cast_unsafe(prepared_list)
 					var $index = 0
 					while $index < len {
 						item = list_map_extract_unsafe($out, $index)
@@ -4182,8 +4183,8 @@ Builtin :: [].{
 					$out
 				}
 				_ => {
-					var $new_list = List.with_capacity(list.len())
-					for item in list {
+					var $new_list = List.with_capacity(prepared_list.len())
+					for item in prepared_list {
 						$new_list = list_append_unsafe($new_list, transform(item))
 					}
 					$new_list
@@ -22571,8 +22572,12 @@ str_drop_first_bytes_unsafe = |s, count| {
 	}
 }
 
+# Implemented by the compiler. Moves the input list's ownership into the
+# returned list before List.map tests whether it can reuse the allocation.
+list_map_prepare_reuse : List(input) -> List(input)
+
 # Implemented by the compiler. Returns 1 (otherwise 0) when List.map may reuse
-# the input list's allocation for its output: the input and output item
+# the prepared list's allocation for its output: the input and output item
 # layouts are interchangeable, and at runtime the list is uniquely owned and
 # not a seamless slice. Lowered to a constant 0 when the layouts are not
 # interchangeable, which lets lowering drop the in-place branch entirely.

--- a/src/canonicalize/BuiltinLowLevel.zig
+++ b/src/canonicalize/BuiltinLowLevel.zig
@@ -338,6 +338,9 @@ fn replaceProvidedByCompilerLowLevels(env: *ModuleEnv) (Allocator.Error || error
     if (env.common.findIdent("list_swap_unsafe")) |list_swap_unsafe_ident| {
         try low_level_map.put(list_swap_unsafe_ident, .list_swap);
     }
+    if (env.common.findIdent("list_map_prepare_reuse")) |list_map_prepare_reuse_ident| {
+        try low_level_map.put(list_map_prepare_reuse_ident, .list_map_prepare_reuse);
+    }
     if (env.common.findIdent("list_map_can_reuse")) |list_map_can_reuse_ident| {
         try low_level_map.put(list_map_can_reuse_ident, .list_map_can_reuse);
     }

--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -336,6 +336,11 @@ pub const io_spec_tests = [_]TestSpec{
         .description = "Regression test: List.map with fallible function (U64.from_str)",
     },
     .{
+        .roc_file = "test/fx/issue_10368_list_map_reuse.roc",
+        .io_spec = "1>one map 0803c9e914002577bbfa01bae7cf9e32a7ef9d1c9e07d19542be4df2c190cbaf|1>two maps f0e5e7a2abe3428a08147f2fbb9eaad2261990945cbfbfcaf37149c6002e215d",
+        .description = "Regression test: optimized List.map reuse preserves a shared parameter-derived input",
+    },
+    .{
         .roc_file = "test/fx/list_append_stdin_uaf.roc",
         .io_spec = "0<000000010000000100000001|1>000000010000000100000001",
         .description = "Regression test: List.append with effectful call on big string (24+ chars)",

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -122,6 +122,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10132_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10218_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10271_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10368_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10395_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10508_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10503_test.zig"));

--- a/src/compile/test/issue_10368_test.zig
+++ b/src/compile/test/issue_10368_test.zig
@@ -1,0 +1,110 @@
+//! Regression coverage for ownership ordering before `List.map` reuse checks.
+
+const std = @import("std");
+const collections = @import("collections");
+const layout = @import("layout");
+const lir = @import("lir");
+const harness = @import("lower_to_lir_harness.zig");
+
+const GuardedList = collections.GuardedList;
+
+fn retainReachesPrepare(
+    store: *const lir.LirStore,
+    start: lir.LIR.CFStmtId,
+    retained: lir.LIR.LocalId,
+) bool {
+    var current = start;
+    var retained_alias = retained;
+    var remaining = store.cfStmtCount() + 1;
+    while (remaining > 0) : (remaining -= 1) {
+        switch (store.getCFStmt(current)) {
+            .assign_low_level => |assign| {
+                if (assign.op == .list_map_prepare_reuse) {
+                    const args = store.getLocalSpan(assign.args);
+                    return GuardedList.at(args, 0) == retained_alias;
+                }
+                if (assign.target == retained_alias) return false;
+                current = assign.next;
+            },
+            .decref => |release| {
+                if (release.value == retained_alias) return false;
+                current = release.next;
+            },
+            .decref_if_initialized => |release| {
+                if (release.value == retained_alias) return false;
+                current = release.next;
+            },
+            .free => |release| {
+                if (release.value == retained_alias) return false;
+                current = release.next;
+            },
+            .assign_ref => |assign| {
+                switch (assign.op) {
+                    .local => |source| if (source == retained_alias) {
+                        retained_alias = assign.target;
+                    } else if (assign.target == retained_alias) {
+                        return false;
+                    },
+                    else => if (assign.target == retained_alias) return false,
+                }
+                current = assign.next;
+            },
+            inline .assign_literal,
+            .init_uninitialized,
+            .assign_call,
+            .assign_call_erased,
+            .assign_packed_erased_fn,
+            .assign_list,
+            .assign_struct,
+            .assign_tag,
+            => |assign| {
+                if (assign.target == retained_alias) return false;
+                current = assign.next;
+            },
+            .set_local => |assign| {
+                if (assign.target == retained_alias) return false;
+                current = assign.next;
+            },
+            inline .store_struct,
+            .store_tag,
+            .debug,
+            .expect,
+            .comptime_branch_taken,
+            .incref,
+            => |stmt| current = stmt.next,
+            else => return false,
+        }
+    }
+    return false;
+}
+
+fn inspect(store: *const lir.LirStore, _: *const layout.Store) harness.LowerToLirHarnessError!void {
+    var prepare_count: usize = 0;
+    var retained_prepare_count: usize = 0;
+
+    for (store.getCFStmts()) |stmt| switch (stmt) {
+        .assign_low_level => |assign| if (assign.op == .list_map_prepare_reuse) {
+            prepare_count += 1;
+            try std.testing.expectEqual(@as(u64, 1), assign.rc_effect.consume_args);
+            try std.testing.expectEqual(@as(u64, 1), assign.rc_effect.result_aliases_consumed_args);
+        },
+        .incref => |retain| if (retainReachesPrepare(store, retain.next, retain.value)) {
+            retained_prepare_count += 1;
+        },
+        else => {},
+    };
+
+    try std.testing.expect(prepare_count >= 2);
+    // The first map over the list shared with the second map must preserve the
+    // second ownership unit before the runtime uniqueness observation.
+    try std.testing.expect(retained_prepare_count >= 1);
+}
+
+test "issue 10368: shared List.map input is retained before reuse preparation" {
+    // Repro for https://github.com/roc-lang/roc/issues/10368.
+    try harness.runAppPathLirInspection(
+        "test/fx/issue_10368_list_map_reuse.roc",
+        .{ .list_in_place_map = true, .inline_mode = .wrappers, .proc_debug_names = true },
+        inspect,
+    );
+}

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -5411,6 +5411,7 @@ pub const Interpreter = struct {
                 );
                 break :blk self.rocListToValue(result, ll.ret_layout);
             },
+            .list_map_prepare_reuse => args[0],
             .list_map_can_reuse => blk: {
                 const val = try self.alloc(ll.ret_layout);
                 if (!ll.interchangeable.get(self.layout_store.targetUsize())) {

--- a/src/postcheck/lambda_mono/eval.zig
+++ b/src/postcheck/lambda_mono/eval.zig
@@ -1320,6 +1320,7 @@ pub const Evaluator = struct {
             .list_release_excess_capacity,
             .list_split_first,
             .list_split_last,
+            .list_map_prepare_reuse,
             .list_map_can_reuse,
             => self.evalListOp(op, args, arg_types, result_ty),
 
@@ -2237,6 +2238,7 @@ pub const Evaluator = struct {
             .list_last => return try self.listFirstLast(result_ty, args[0].list, false),
             .list_split_first => return try self.listSplit(result_ty, args[0].list, true),
             .list_split_last => return try self.listSplit(result_ty, args[0].list, false),
+            .list_map_prepare_reuse => return args[0],
             .list_map_can_reuse => {
                 // In-place map reuse is disabled on the compared compile.
                 const prim = self.primitiveOf(result_ty) orelse .u8;

--- a/test/fx/issue_10368_list_map_reuse.roc
+++ b/test/fx/issue_10368_list_map_reuse.roc
@@ -1,0 +1,28 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+# Repro for https://github.com/roc-lang/roc/issues/10368
+# Both maps must read the original parameter-derived padded list.
+one_map : List(U8) -> Str
+one_map = |p| {
+    padded = List.concat(p, List.repeat(0, 64 - List.len(p)))
+    mapped = List.map(padded, |b| U8.bitwise_xor(b, 0x36))
+    first = Crypto.SHA256.hash(List.concat(mapped, Str.to_utf8("x"))).to_bytes()
+    Crypto.SHA256.hash(List.concat(mapped, first)).to_hex()
+}
+
+two_maps : List(U8) -> Str
+two_maps = |p| {
+    padded = List.concat(p, List.repeat(0, 64 - List.len(p)))
+    mapped1 = List.map(padded, |b| U8.bitwise_xor(b, 0x36))
+    mapped2 = List.map(padded, |b| U8.bitwise_xor(b, 0x5c))
+    first = Crypto.SHA256.hash(List.concat(mapped1, Str.to_utf8("x"))).to_bytes()
+    Crypto.SHA256.hash(List.concat(mapped2, first)).to_hex()
+}
+
+main! = || {
+    key = List.repeat(0x0b, 20)
+    Stdout.line!("one map ${one_map(key)}")
+    Stdout.line!("two maps ${two_maps(key)}")
+}


### PR DESCRIPTION
Fixes #10368 by inserting a consuming, ownership-only `list_map_prepare_reuse` operation before the existing scalar reuse query. This makes ARC preserve every later ownership unit before runtime observes the refcount, while retaining the existing layout-aware dead-branch fold and allocation-reuse fast path.

The old scalar-query shape allowed wrapper inlining to place a preservation retain after the uniqueness check, so optimized LLVM code could observe refcount 1 and overwrite a list still needed by a later map. The new operation moves the input ownership unit into its unchanged result without allocating, changing a refcount, or adding a runtime call; backends implement it as an identity or a copy that LLVM can eliminate.