### PR TITLE
Support BSD default-platform cross-builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6916,10 +6916,11 @@ fn addMainExe(
         exe.step.dependOn(&copy_cross_builtins_extern.step);
 
         if (!cross_is_wasm) {
-            const default_platform_root_source = if (cross_target.query.os_tag == .linux)
-                b.path("src/default_platform/linux_runtime.zig")
-            else
-                b.path("src/default_platform/c_runtime.zig");
+            const default_platform_root_source = switch (cross_target.query.os_tag orelse .freestanding) {
+                .linux => b.path("src/default_platform/linux_runtime.zig"),
+                .freebsd, .netbsd => b.path("src/default_platform/bsd_runtime.zig"),
+                else => b.path("src/default_platform/c_runtime.zig"),
+            };
 
             const default_platform_runtime_obj = b.addObject(.{
                 .name = b.fmt("roc_default_runtime_{s}", .{cross_target.name}),

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -9755,7 +9755,7 @@ pub const MonoLlvmCodeGen = struct {
         if (!std.mem.eql(u8, self.store.getString(hosted.symbol), shim_symbols.roc_default_echo_line)) return false;
 
         switch (self.target.os.tag) {
-            .linux, .macos, .windows => {},
+            .linux, .macos, .windows, .freebsd, .netbsd => {},
             else => return error.CompilationFailed,
         }
         if (arg_ptrs.len != 1 or arg_layouts.len != 1 or arg_layouts[0] != .str or ret_layout != .zst) {
@@ -9798,6 +9798,7 @@ pub const MonoLlvmCodeGen = struct {
     fn emitDefaultPlatformWriteStdout(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, len: LlvmBuilder.Value) Error!void {
         switch (self.target.os.tag) {
             .linux => try self.emitLinuxWriteStdout(ptr, len),
+            .freebsd, .netbsd => try self.emitX86_64BsdWriteStdout(ptr, len),
             .macos, .windows => try self.emitCWriteStdout(ptr, len),
             else => return error.CompilationFailed,
         }
@@ -9850,6 +9851,30 @@ pub const MonoLlvmCodeGen = struct {
             builder.string("={rax},{rax},{rdi},{rsi},{rdx},~{rcx},~{r11},~{memory}") catch return error.OutOfMemory,
             &.{
                 builder.intValue(.i64, 1) catch return error.OutOfMemory,
+                builder.intValue(.i64, 1) catch return error.OutOfMemory,
+                ptr,
+                len,
+            },
+            "",
+        ) catch return error.OutOfMemory;
+    }
+
+    fn emitX86_64BsdWriteStdout(self: *MonoLlvmCodeGen, ptr: LlvmBuilder.Value, len: LlvmBuilder.Value) Error!void {
+        if (self.target.cpu.arch != .x86_64) return error.CompilationFailed;
+
+        const builder = self.builder orelse return error.CompilationFailed;
+        const wip = self.wip orelse return error.CompilationFailed;
+        const usize_ty = self.ptrSizedIntType();
+        const fn_ty = builder.fnType(.i64, &.{ .i64, .i64, try self.ptrType(), usize_ty }, .normal) catch return error.OutOfMemory;
+
+        _ = wip.callAsm(
+            .none,
+            fn_ty,
+            .{ .sideeffect = true },
+            builder.string("syscall") catch return error.OutOfMemory,
+            builder.string("={rax},{rax},{rdi},{rsi},{rdx},~{rcx},~{r11},~{memory}") catch return error.OutOfMemory,
+            &.{
+                builder.intValue(.i64, 4) catch return error.OutOfMemory,
                 builder.intValue(.i64, 1) catch return error.OutOfMemory,
                 ptr,
                 len,

--- a/src/cli/CliProblem.zig
+++ b/src/cli/CliProblem.zig
@@ -216,6 +216,11 @@ pub const CliProblem = union(enum) {
         app_path: []const u8,
     },
 
+    /// The builtin platform cannot satisfy this target's runtime contract.
+    unsupported_default_platform_target: struct {
+        target: []const u8,
+    },
+
     /// The requested optimization level is not implemented for this command
     unsupported_opt_level: struct {
         command: []const u8,
@@ -393,6 +398,7 @@ pub const CliProblem = union(enum) {
             .platform_not_found,
             .no_platform_found,
             .build_not_supported_for_headerless,
+            .unsupported_default_platform_target,
             .unsupported_opt_level,
             .compilation_failed,
             .unreported_error,
@@ -460,6 +466,7 @@ pub const CliProblem = union(enum) {
             .absolute_platform_path => |info| try createAbsolutePlatformPathReport(allocator, info),
             .invalid_app_header => |info| try createInvalidAppHeaderReport(allocator, info),
             .build_not_supported_for_headerless => |info| try createBuildNotSupportedForHeaderlessReport(allocator, info),
+            .unsupported_default_platform_target => |info| try createUnsupportedDefaultPlatformTargetReport(allocator, info),
             .unsupported_opt_level => |info| try createUnsupportedOptLevelReport(allocator, info),
             .compilation_failed => |info| try createCompilationFailedReport(allocator, info),
             .unreported_error => |info| try createUnreportedErrorReport(allocator, info),
@@ -725,6 +732,20 @@ fn createBuildNotSupportedForHeaderlessReport(allocator: Allocator, info: anytyp
     try report.document.addLineBreak();
     try report.document.addCodeBlock(
         \\app [main!] { pf: platform "https://..." }
+    );
+
+    return report;
+}
+
+fn createUnsupportedDefaultPlatformTargetReport(allocator: Allocator, info: anytype) Allocator.Error!Report {
+    const headline = try std.fmt.allocPrint(allocator, "The builtin platform cannot build executables for {s}.", .{info.target});
+    defer allocator.free(headline);
+    var report = try Report.init(allocator, "Unsupported Default Platform Target", headline, .fatal);
+
+    try report.document.addText(
+        "OpenBSD requires its system C runtime for process startup and kernel calls. " ++
+            "Roc does not ship an OpenBSD sysroot, so the builtin platform cannot cross-link this target. " ++
+            "Use an app with an OpenBSD platform and build it natively on OpenBSD.",
     );
 
     return report;

--- a/src/cli/linker.zig
+++ b/src/cli/linker.zig
@@ -61,6 +61,8 @@ pub const TargetFormat = embedded_lld.Format;
 pub const TargetAbi = enum {
     musl,
     gnu,
+    /// No C runtime, startup objects, or program interpreter.
+    freestanding,
 
     /// Convert from RocTarget to TargetAbi
     pub fn fromRocTarget(target: RocTarget) TargetAbi {
@@ -569,7 +571,7 @@ fn buildLinkArgs(ctx: *CliCtx, config: LinkConfig) LinkError!std.array_list.Mana
             const target_abi = config.target_abi orelse if (builtin.target.abi == .musl) TargetAbi.musl else TargetAbi.gnu;
 
             switch (target_abi) {
-                .musl => {
+                .musl, .freestanding => {
                     if (is_shared_lib) {
                         // -static and -shared are mutually exclusive; a shared library
                         // is inherently a dynamic artifact even on musl targets.
@@ -743,6 +745,8 @@ fn buildLinkArgs(ctx: *CliCtx, config: LinkConfig) LinkError!std.array_list.Mana
                 // Shared libraries have no program interpreter; the loading
                 // process's dynamic linker resolves them.
                 try args.append("-shared");
+            } else if (config.target_abi == .freestanding) {
+                try args.append("-static");
             } else {
                 const interpreter = roc_target.bsdProgramInterpreter(target_os) orelse
                     return LinkError.LinkFailed;
@@ -1398,6 +1402,34 @@ test "BSD shared libraries have no program interpreter" {
 
     _ = findArg(args.items, "-shared") orelse return error.MissingSharedFlag;
     try std.testing.expectEqual(@as(?usize, null), findArg(args.items, "-dynamic-linker"));
+}
+
+test "freestanding BSD executables have no program interpreter" {
+    const cases = [_]std.Target.Os.Tag{ .freebsd, .netbsd };
+
+    for (cases) |target_os| {
+        var arena_instance = collections.SingleThreadArena.init(std.testing.allocator);
+        defer arena_instance.deinit();
+
+        var io = Io.create(std.testing.io);
+        var ctx = CliCtx.init(std.testing.allocator, arena_instance.allocator(), &io, .build);
+        ctx.initIo();
+        defer ctx.deinit();
+
+        const config = LinkConfig{
+            .target_format = .elf,
+            .target_abi = .freestanding,
+            .target_os = target_os,
+            .target_arch = .x86_64,
+            .output_path = "test_output",
+            .object_files = &.{"roc_default_platform.o"},
+        };
+
+        const args = try buildLinkArgs(&ctx, config);
+
+        _ = findArg(args.items, "-static") orelse return error.MissingStaticFlag;
+        try std.testing.expectEqual(@as(?usize, null), findArg(args.items, "-dynamic-linker"));
+    }
 }
 
 test "link error when LLVM not available" {

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -7310,6 +7310,12 @@ fn rocBuild(ctx: *CliCtx, args_in: cli_args.BuildArgs, arg0: []const u8) CliMain
 fn rocBuildDefaultApp(ctx: *CliCtx, args: cli_args.BuildArgs, original_source: []const u8) CliMainError!void {
     defer ctx.gpa.free(original_source);
 
+    if (defaultBuildTarget(args).toOsTag() == .openbsd) {
+        return ctx.fail(.{ .unsupported_default_platform_target = .{
+            .target = "x64openbsd",
+        } });
+    }
+
     const temp_dir = createUniqueTempDir(ctx) catch |err| {
         return ctx.fail(.{ .temp_dir_failed = .{ .err = err } });
     };
@@ -7372,9 +7378,7 @@ fn defaultBuildPlatformSource(args: cli_args.BuildArgs) []const u8 {
                 .arm64mac,
                 .x64win,
                 .arm64win,
-                .x64freebsd,
                 .x64openbsd,
-                .x64netbsd,
                 => echo_platform.build_c_platform_main_source,
                 .wasm32 => echo_platform.build_wasm_archive_platform_main_source,
                 else => echo_platform.build_platform_main_source,
@@ -7385,9 +7389,16 @@ fn defaultBuildPlatformSource(args: cli_args.BuildArgs) []const u8 {
     }
 
     return switch (RocTarget.detectNative().toOsTag()) {
-        .macos, .windows, .freebsd, .openbsd, .netbsd => echo_platform.build_c_platform_main_source,
+        .macos, .windows, .openbsd => echo_platform.build_c_platform_main_source,
         else => echo_platform.build_platform_main_source,
     };
+}
+
+fn defaultBuildTarget(args: cli_args.BuildArgs) RocTarget {
+    if (args.target) |target_str| {
+        if (RocTarget.fromString(target_str)) |requested| return requested.defaultCpuTarget();
+    }
+    return RocTarget.detectNative().defaultCpuTarget();
 }
 
 /// Build using the dev backend to generate native machine code.
@@ -7668,8 +7679,12 @@ fn linkerOutputKind(output: roc_target.OutputKind) linker.OutputKind {
 }
 
 fn llvmBuildLinkAbi(target: RocTarget, synthetic_default_platform: bool) linker.TargetAbi {
-    if (synthetic_default_platform and target.toOsTag() == .linux) {
-        return .musl;
+    if (synthetic_default_platform) {
+        return switch (target.toOsTag()) {
+            .linux => .musl,
+            .freebsd, .netbsd => .freestanding,
+            else => linker.TargetAbi.fromRocTarget(target),
+        };
     }
     return linker.TargetAbi.fromRocTarget(target);
 }

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -375,6 +375,9 @@ const CustomCase = enum {
     default_platform_linux_disassembly,
     default_platform_build_x64glibc,
     default_platform_build_arm64glibc,
+    default_platform_build_x64freebsd,
+    default_platform_build_x64netbsd,
+    default_platform_build_x64openbsd_rejected,
     default_platform_build_wasm32,
     default_platform_wasm32_archive_reproducible,
     macos_output_basename_reproducible,
@@ -1129,6 +1132,9 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "roc build default platform x64musl matches direct write assembly", .skip = .{ .always = "TODO: direct-write default-platform codegen" }, .body = .{ .custom = .default_platform_linux_disassembly } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build default platform x64glibc succeeds", .body = .{ .custom = .default_platform_build_x64glibc } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build default platform arm64glibc succeeds", .body = .{ .custom = .default_platform_build_arm64glibc } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10598: roc build default platform x64freebsd succeeds", .body = .{ .custom = .default_platform_build_x64freebsd } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10598: roc build default platform x64netbsd succeeds", .body = .{ .custom = .default_platform_build_x64netbsd } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10598: roc build default platform x64openbsd explains unsupported cross-link", .body = .{ .custom = .default_platform_build_x64openbsd_rejected } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build default platform wasm32 archive succeeds", .body = .{ .custom = .default_platform_build_wasm32 } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build default platform wasm32 archive output is reproducible", .body = .{ .custom = .default_platform_wasm32_archive_reproducible } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build macOS output basename does not affect bytes", .body = .{ .custom = .macos_output_basename_reproducible } },
@@ -2484,6 +2490,9 @@ fn runCustomCase(
         .default_platform_linux_disassembly => customDefaultPlatformLinuxDisassembly(io, allocator, &env, &timer, timeout_ms),
         .default_platform_build_x64glibc => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .x64glibc),
         .default_platform_build_arm64glibc => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .arm64glibc),
+        .default_platform_build_x64freebsd => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .x64freebsd),
+        .default_platform_build_x64netbsd => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .x64netbsd),
+        .default_platform_build_x64openbsd_rejected => customDefaultPlatformOpenBsdRejected(io, allocator, &env, &timer, timeout_ms),
         .default_platform_build_wasm32 => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .wasm32),
         .default_platform_wasm32_archive_reproducible => customDefaultPlatformWasm32ArchiveReproducible(io, allocator, &env, &timer, timeout_ms),
         .macos_output_basename_reproducible => customMacosOutputBasenameReproducible(io, allocator, &env, &timer, timeout_ms),
@@ -4541,6 +4550,9 @@ const DefaultPlatformTarget = enum {
     arm64mac,
     x64win,
     arm64win,
+    x64freebsd,
+    x64netbsd,
+    x64openbsd,
     wasm32,
 
     fn cliName(self: DefaultPlatformTarget) []const u8 {
@@ -4696,6 +4708,31 @@ fn customDefaultPlatformBuild(
     }
 
     return null;
+}
+
+fn customDefaultPlatformOpenBsdRejected(
+    io: std.Io,
+    allocator: Allocator,
+    env: *const CaseEnv,
+    timer: *harness.Timer,
+    timeout_ms: u64,
+) ?TestResult {
+    const app_path = std.fs.path.join(allocator, &.{ env.dirs.work_dir, "default_platform_build_x64openbsd.roc" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate default platform app path: {}", .{err});
+
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = app_path, .data = default_platform_echo_app }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write default platform app: {}", .{err});
+
+    return runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "build", "--opt=speed", "--no-cache", "--target=x64openbsd" },
+        .roc_file = app_path,
+        .exit = .failure,
+        .contains = &.{
+            .{ .stream = .stderr, .text = "UNSUPPORTED DEFAULT PLATFORM TARGET" },
+            .{ .stream = .stderr, .text = "OpenBSD requires its system C runtime" },
+        },
+        .not_contains = &.{.{ .stream = .stderr, .text = "UNREPORTED ERROR" }},
+    });
 }
 
 fn customDefaultPlatformWasm32ArchiveReproducible(

--- a/src/default_platform/bsd_runtime.zig
+++ b/src/default_platform/bsd_runtime.zig
@@ -1,0 +1,436 @@
+//! Freestanding FreeBSD and NetBSD runtime for the build-only default app platform.
+//!
+//! The runtime owns process startup and reaches the kernel directly, so default
+//! apps for these targets can be cross-linked without a BSD libc or sysroot.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const default_platform_options = @import("default_platform_options");
+
+const RocStr = @import("roc_str_view").RocStr;
+const RocList = @import("roc_str_view").RocList;
+const roc_args = @import("roc_args");
+const shim_symbols = @import("shim_symbols");
+
+pub const panic = std.debug.no_panic;
+
+const stdout_fd: usize = 1;
+const stderr_fd: usize = 2;
+const page_size: usize = 4096;
+const allocation_header_words = 3;
+const allocation_header_size = allocation_header_words * @sizeOf(usize);
+
+const syscall_number = switch (builtin.os.tag) {
+    .freebsd => struct {
+        const exit: usize = 1;
+        const write: usize = 4;
+        const munmap: usize = 73;
+        const mmap: usize = 477;
+    },
+    .netbsd => struct {
+        const exit: usize = 1;
+        const write: usize = 4;
+        const munmap: usize = 73;
+        const mmap: usize = 197;
+    },
+    else => @compileError("default platform BSD runtime must be built for FreeBSD or NetBSD"),
+};
+
+const SourceFrame = extern struct {
+    name_ptr: [*]const u8,
+    name_len: usize,
+    file_ptr: [*]const u8,
+    file_len: usize,
+    line: u32,
+    column: u32,
+};
+
+const roc_default_start_main: *const fn (RocList) callconv(.c) i32 =
+    @extern(*const fn (RocList) callconv(.c) i32, .{ .name = shim_symbols.roc_default_start_main });
+
+comptime {
+    @export(&defaultMemcpy, .{ .name = "memcpy", .linkage = .weak });
+    @export(&defaultMemmove, .{ .name = "memmove", .linkage = .weak });
+    @export(&defaultMemset, .{ .name = "memset", .linkage = .weak });
+    @export(&defaultTrunc, .{ .name = "trunc", .linkage = .weak });
+
+    @export(&runtimeInit, .{ .name = shim_symbols.roc_default_runtime_init });
+    @export(&rocDbg, .{ .name = shim_symbols.roc_dbg });
+    @export(&rocExpectFailed, .{ .name = shim_symbols.roc_expect_failed });
+    @export(&rocCrashed, .{ .name = shim_symbols.roc_crashed });
+    @export(&rocDefaultCrashedWithFrames, .{ .name = shim_symbols.roc_default_crashed_with_frames });
+    @export(&defaultEchoLine, .{ .name = shim_symbols.roc_default_echo_line });
+    @export(&defaultExit, .{ .name = shim_symbols.roc_default_exit });
+    @export(&rocAlloc, .{ .name = shim_symbols.roc_alloc });
+    @export(&rocRealloc, .{ .name = shim_symbols.roc_realloc });
+    @export(&rocDealloc, .{ .name = shim_symbols.roc_dealloc });
+
+    if (default_platform_options.include_process_entrypoint) {
+        if (builtin.cpu.arch != .x86_64) {
+            @compileError("unsupported default-platform BSD architecture");
+        }
+        @export(&bsdStartX86_64, .{ .name = "_start" });
+        @export(&bsdStartMain, .{ .name = "roc_default_bsd_start_main", .visibility = .hidden });
+    }
+
+    switch (builtin.os.tag) {
+        .freebsd => asm (
+            \\.section .note.tag,"a",@note
+            \\.p2align 2
+            \\.long 8
+            \\.long 4
+            \\.long 1
+            \\.asciz "FreeBSD"
+            \\.p2align 2
+            \\.long 1200000
+            \\.section .note.GNU-stack,"",@progbits
+        ),
+        .netbsd => asm (
+            \\.section .note.netbsd.ident,"a",@note
+            \\.p2align 2
+            \\.long 7
+            \\.long 4
+            \\.long 1
+            \\.ascii "NetBSD"
+            \\.byte 0, 0
+            \\.long 800000000
+            \\.text
+            \\.globl roc_default_netbsd_mmap
+            \\.hidden roc_default_netbsd_mmap
+            \\.type roc_default_netbsd_mmap,@function
+            \\roc_default_netbsd_mmap:
+            \\movq %rcx, %r10
+            \\movq $197, %rax
+            \\syscall
+            \\jnc 1f
+            \\negq %rax
+            \\1: retq
+            \\.size roc_default_netbsd_mmap, .-roc_default_netbsd_mmap
+            \\.section .note.GNU-stack,"",@progbits
+        ),
+        else => unreachable,
+    }
+}
+
+/// Set when an inline `expect` fails. A failed inline expect reports and lets
+/// the program continue; process exit turns an otherwise-successful status
+/// into 1, matching the other default-platform runtimes.
+var inline_expect_failed: bool = false;
+
+fn bsdStartMain(argc: usize, argv: [*][*:0]u8) callconv(.c) noreturn {
+    runtimeInit();
+    const args = roc_args.fromPosixArgv(argc, argv, &rocAlloc) orelse {
+        writeLiteral(stderr_fd, "Unable to allocate command-line arguments\n");
+        exitFailure();
+    };
+    const status = roc_default_start_main(args);
+    if (status == 0 and inline_expect_failed) rawExit(1);
+    rawExit(@intCast(status));
+}
+
+fn bsdStartX86_64() callconv(.naked) noreturn {
+    asm volatile (
+        \\movq %%rsp, %%rbx
+        \\andq $-16, %%rsp
+        \\movq (%%rbx), %%rdi
+        \\leaq 8(%%rbx), %%rsi
+        \\call roc_default_bsd_start_main
+        \\ud2
+    );
+}
+
+fn runtimeInit() callconv(.c) void {}
+
+fn rocDbg(bytes: [*]const u8, len: usize) callconv(.c) void {
+    writeLiteral(stderr_fd, "[dbg] ");
+    writeAll(stderr_fd, bytes[0..len]);
+    writeLiteral(stderr_fd, "\n");
+}
+
+fn rocExpectFailed(bytes: [*]const u8, len: usize) callconv(.c) void {
+    inline_expect_failed = true;
+    writeLiteral(stderr_fd, "Expect failed: ");
+    writeAll(stderr_fd, bytes[0..len]);
+    writeLiteral(stderr_fd, "\n");
+}
+
+fn rocCrashed(bytes: [*]const u8, len: usize) callconv(.c) noreturn {
+    writeCrashMessage(bytes[0..len]);
+    exitFailure();
+}
+
+fn rocDefaultCrashedWithFrames(
+    bytes: [*]const u8,
+    len: usize,
+    source_frames: [*]const SourceFrame,
+    source_frame_count: usize,
+) callconv(.c) noreturn {
+    writeCrashMessage(bytes[0..len]);
+    if (source_frame_count != 0) {
+        writeLiteral(stderr_fd, "Backtrace:\n");
+        for (source_frames[0..source_frame_count]) |frame| {
+            writeLiteral(stderr_fd, "  ");
+            writeAll(stderr_fd, frame.name_ptr[0..frame.name_len]);
+            if (frame.file_len != 0) {
+                writeLiteral(stderr_fd, " ");
+                writeAll(stderr_fd, frame.file_ptr[0..frame.file_len]);
+                if (frame.line != 0) {
+                    writeLiteral(stderr_fd, ":");
+                    writeUnsigned(stderr_fd, frame.line);
+                    if (frame.column != 0) {
+                        writeLiteral(stderr_fd, ":");
+                        writeUnsigned(stderr_fd, frame.column);
+                    }
+                }
+            }
+            writeLiteral(stderr_fd, "\n");
+        }
+    }
+    exitFailure();
+}
+
+fn writeCrashMessage(bytes: []const u8) void {
+    writeLiteral(stderr_fd, "Roc application crashed with this message:\n\n\t");
+    writeAll(stderr_fd, bytes);
+    writeLiteral(stderr_fd, "\n\n");
+}
+
+fn defaultEchoLine(str: RocStr) callconv(.c) void {
+    var owned = str;
+    writeAll(stdout_fd, owned.asSlice());
+    owned.decref(rocDealloc);
+}
+
+fn defaultExit(code: u8) callconv(.c) noreturn {
+    if (code == 0 and inline_expect_failed) rawExit(1);
+    rawExit(code);
+}
+
+fn rocAlloc(length: usize, alignment: usize) callconv(.c) ?*anyopaque {
+    const byte_alignment = normalizedAlignment(alignment);
+    const prefix = alignForward(allocation_header_size, byte_alignment);
+    const total = pageAlign(prefix + length);
+    const raw_addr = rawMmap(total);
+    if (isSyscallError(raw_addr)) return null;
+
+    const raw: [*]u8 = @ptrFromInt(raw_addr);
+    const user = raw + prefix;
+    storeAllocationHeader(user, prefix, total, length);
+    return @ptrCast(user);
+}
+
+fn rocRealloc(ptr: *anyopaque, new_length: usize, alignment: usize) callconv(.c) ?*anyopaque {
+    const old_user: [*]u8 = @ptrCast(ptr);
+    const old_len = allocationHeaderValue(old_user, 2);
+    const new_ptr = rocAlloc(new_length, alignment) orelse return null;
+    const new_user: [*]u8 = @ptrCast(new_ptr);
+
+    const copy_len = @min(old_len, new_length);
+    var i: usize = 0;
+    while (i < copy_len) : (i += 1) new_user[i] = old_user[i];
+    rocDealloc(ptr, alignment);
+    return new_ptr;
+}
+
+fn rocDealloc(ptr: *anyopaque, _: usize) callconv(.c) void {
+    const user: [*]u8 = @ptrCast(ptr);
+    const prefix = allocationHeaderValue(user, 0);
+    const total = allocationHeaderValue(user, 1);
+    _ = rawSyscall2(syscall_number.munmap, @intFromPtr(user - prefix), total);
+}
+
+fn rawMmap(length: usize) usize {
+    const map_private_anonymous: usize = 0x0002 | 0x1000;
+    const fd: usize = @bitCast(@as(isize, -1));
+    return switch (builtin.os.tag) {
+        .freebsd => rawSyscall6(syscall_number.mmap, 0, length, 0x01 | 0x02, map_private_anonymous, fd, 0),
+        .netbsd => rawNetBsdMmap(length, map_private_anonymous, fd),
+        else => unreachable,
+    };
+}
+
+/// NetBSD's mmap ABI has an explicit padding slot before its seventh `off_t`
+/// argument. The assembly symbol uses the C ABI so that seventh slot is at
+/// `rsp + 8`, exactly where the x86_64 kernel reads syscall arguments beyond
+/// the sixth.
+fn rawNetBsdMmap(length: usize, flags: usize, fd: usize) usize {
+    const mmap_fn = @extern(
+        *const fn (usize, usize, usize, usize, usize, usize, usize) callconv(.c) usize,
+        .{ .name = "roc_default_netbsd_mmap" },
+    );
+    return mmap_fn(0, length, 0x01 | 0x02, flags, fd, 0, 0);
+}
+
+fn rawSyscall1(number: usize, arg1: usize) usize {
+    return asm volatile (
+        \\syscall
+        \\jnc 1f
+        \\negq %%rax
+        \\1:
+        : [ret] "={rax}" (-> usize),
+        : [number] "{rax}" (number),
+          [arg1] "{rdi}" (arg1),
+        : .{ .rcx = true, .r11 = true, .memory = true });
+}
+
+fn rawSyscall2(number: usize, arg1: usize, arg2: usize) usize {
+    return asm volatile (
+        \\syscall
+        \\jnc 1f
+        \\negq %%rax
+        \\1:
+        : [ret] "={rax}" (-> usize),
+        : [number] "{rax}" (number),
+          [arg1] "{rdi}" (arg1),
+          [arg2] "{rsi}" (arg2),
+        : .{ .rcx = true, .r11 = true, .memory = true });
+}
+
+fn rawSyscall3(number: usize, arg1: usize, arg2: usize, arg3: usize) usize {
+    return asm volatile (
+        \\syscall
+        \\jnc 1f
+        \\negq %%rax
+        \\1:
+        : [ret] "={rax}" (-> usize),
+        : [number] "{rax}" (number),
+          [arg1] "{rdi}" (arg1),
+          [arg2] "{rsi}" (arg2),
+          [arg3] "{rdx}" (arg3),
+        : .{ .rcx = true, .r11 = true, .memory = true });
+}
+
+fn rawSyscall6(
+    number: usize,
+    arg1: usize,
+    arg2: usize,
+    arg3: usize,
+    arg4: usize,
+    arg5: usize,
+    arg6: usize,
+) usize {
+    return asm volatile (
+        \\syscall
+        \\jnc 1f
+        \\negq %%rax
+        \\1:
+        : [ret] "={rax}" (-> usize),
+        : [number] "{rax}" (number),
+          [arg1] "{rdi}" (arg1),
+          [arg2] "{rsi}" (arg2),
+          [arg3] "{rdx}" (arg3),
+          [arg4] "{r10}" (arg4),
+          [arg5] "{r8}" (arg5),
+          [arg6] "{r9}" (arg6),
+        : .{ .rcx = true, .r11 = true, .memory = true });
+}
+
+fn rawExit(code: usize) noreturn {
+    _ = rawSyscall1(syscall_number.exit, code);
+    unreachable;
+}
+
+fn isSyscallError(value: usize) bool {
+    return @as(isize, @bitCast(value)) < 0;
+}
+
+fn writeLiteral(fd: usize, comptime text: []const u8) void {
+    writeAll(fd, text);
+}
+
+fn writeAll(fd: usize, bytes: []const u8) void {
+    var remaining = bytes;
+    while (remaining.len != 0) {
+        const result = rawSyscall3(syscall_number.write, fd, @intFromPtr(remaining.ptr), remaining.len);
+        if (isSyscallError(result) or result == 0) return;
+        remaining = remaining[result..];
+    }
+}
+
+fn writeUnsigned(fd: usize, value: anytype) void {
+    var buf: [20]u8 = undefined;
+    var index = buf.len;
+    var n: u64 = @intCast(value);
+    if (n == 0) {
+        writeLiteral(fd, "0");
+        return;
+    }
+    while (n != 0) {
+        index -= 1;
+        buf[index] = '0' + @as(u8, @intCast(n % 10));
+        n /= 10;
+    }
+    writeAll(fd, buf[index..]);
+}
+
+fn exitFailure() noreturn {
+    rawExit(1);
+}
+
+fn storeAllocationHeader(user: [*]u8, prefix: usize, total: usize, length: usize) void {
+    allocationHeaderPtr(user, 0).* = prefix;
+    allocationHeaderPtr(user, 1).* = total;
+    allocationHeaderPtr(user, 2).* = length;
+}
+
+fn allocationHeaderValue(user: [*]u8, index: usize) usize {
+    return allocationHeaderPtr(user, index).*;
+}
+
+fn allocationHeaderPtr(user: [*]u8, index: usize) *usize {
+    const byte_offset = (allocation_header_words - index) * @sizeOf(usize);
+    return @ptrCast(@alignCast(user - byte_offset));
+}
+
+fn normalizedAlignment(alignment: usize) usize {
+    return @max(alignment, @alignOf(usize));
+}
+
+fn alignForward(value: usize, alignment: usize) usize {
+    return (value + alignment - 1) & ~(alignment - 1);
+}
+
+fn pageAlign(value: usize) usize {
+    return alignForward(value, page_size);
+}
+
+fn defaultMemcpy(dest: [*]u8, src: [*]const u8, len: usize) callconv(.c) [*]u8 {
+    var i: usize = 0;
+    while (i < len) : (i += 1) dest[i] = src[i];
+    return dest;
+}
+
+fn defaultMemmove(dest: [*]u8, src: [*]const u8, len: usize) callconv(.c) [*]u8 {
+    if (@intFromPtr(dest) <= @intFromPtr(src)) {
+        var i: usize = 0;
+        while (i < len) : (i += 1) dest[i] = src[i];
+    } else {
+        var i = len;
+        while (i != 0) {
+            i -= 1;
+            dest[i] = src[i];
+        }
+    }
+    return dest;
+}
+
+fn defaultMemset(dest: [*]u8, value: c_int, len: usize) callconv(.c) [*]u8 {
+    const byte: u8 = @bitCast(@as(i8, @truncate(value)));
+    const volatile_dest: [*]volatile u8 = dest;
+    var i: usize = 0;
+    while (i < len) : (i += 1) volatile_dest[i] = byte;
+    return dest;
+}
+
+fn defaultTrunc(value: f64) callconv(.c) f64 {
+    const bits: u64 = @bitCast(value);
+    const exponent_bits = (bits >> 52) & 0x7ff;
+    const exponent: i32 = @as(i32, @intCast(exponent_bits)) - 1023;
+
+    if (exponent >= 52) return value;
+    if (exponent < 0) return @bitCast(bits & (@as(u64, 1) << 63));
+
+    const fraction_bits: u6 = @intCast(52 - exponent);
+    const fraction_mask = (@as(u64, 1) << fraction_bits) - 1;
+    return @bitCast(bits & ~fraction_mask);
+}

--- a/src/echo_platform/mod.zig
+++ b/src/echo_platform/mod.zig
@@ -66,6 +66,10 @@ pub const build_platform_main_source =
     \\        arm64v1musl: { inputs: [app] },
     \\        x64v1glibc: { inputs: [app] },
     \\        arm64v1glibc: { inputs: [app] },
+    \\        x64freebsd: { inputs: [app] },
+    \\        x64netbsd: { inputs: [app] },
+    \\        x64v1freebsd: { inputs: [app] },
+    \\        x64v1netbsd: { inputs: [app] },
     \\    }
     \\
     \\import Echo
@@ -96,15 +100,11 @@ pub const build_c_platform_main_source =
     \\        arm64mac: { inputs: [app] },
     \\        x64win: { inputs: [app] },
     \\        arm64win: { inputs: [app] },
-    \\        x64freebsd: { inputs: [app] },
     \\        x64openbsd: { inputs: [app] },
-    \\        x64netbsd: { inputs: [app] },
     \\        x64v1mac: { inputs: [app] },
     \\        x64v1win: { inputs: [app] },
     \\        arm64v1win: { inputs: [app] },
-    \\        x64v1freebsd: { inputs: [app] },
     \\        x64v1openbsd: { inputs: [app] },
-    \\        x64v1netbsd: { inputs: [app] },
     \\    }
     \\
     \\import Echo


### PR DESCRIPTION
FreeBSD and NetBSD headerless apps now use freestanding x86-64 runtimes and static links, so `roc build` can cross-compile them without a BSD sysroot or libc. The default-platform LLVM echo path uses the BSD write syscall ABI, and the linker consumes an explicit freestanding ABI instead of attaching a program interpreter.

OpenBSD remains libc/crt-dependent by kernel design, so its builtin default-platform build now reports that limitation explicitly instead of reaching an invalid libc-less link.

Fixes #10598.