### PR TITLE
Fix control-flow iterator block evidence

### DIFF
--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -290,6 +290,11 @@ pub const io_spec_tests = [_]TestSpec{
         .description = "Repro: named outer direct map2 value dropped before static output",
     },
     .{
+        .roc_file = "test/fx/control_flow_selected_runtime_representation_repro.roc",
+        .io_spec = "1>ok",
+        .description = "Regression test: #10596 local if binding between iterator call and empty iterator",
+    },
+    .{
         .roc_file = "test/fx/drop_concat_unused_repro.roc",
         .io_spec = "1>done",
         .description = "Repro: dropped concat string before static output",

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -41861,11 +41861,21 @@ const BodyContext = struct {
                 expected_node,
                 .expression_lowering,
             ),
-            .field_access,
+            .field_access => try self.lowerExprTypeNode(checked_value),
+            // Lookups are use-sites. Once a generated-private request is
+            // selected, branch emission validates the lookup against that
+            // request; the prepass must not join the raw stored binding cell.
             .lookup_local,
             .lookup_external,
             .lookup_required,
-            => try self.lowerExprTypeNode(checked_value),
+            => if (try self.graph.containsGeneratedPrivate(expected_node))
+                expected_node
+            else
+                try self.lowerExprTypeNode(checked_value),
+            .block => |block| if (block.statements.len == 0)
+                try self.controlFlowResultEvidenceNode(block.final_expr, expected_node)
+            else
+                null,
             else => null,
         };
     }

--- a/test/fx/control_flow_selected_runtime_representation_repro.roc
+++ b/test/fx/control_flow_selected_runtime_representation_repro.roc
@@ -1,0 +1,19 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+text = |content| [Text(content)].iter()
+
+sidebar = |show| {
+    section = if show {
+        text("view")
+    } else {
+        [].iter()
+    }
+    section
+}
+
+main! = || {
+    _ = sidebar(True)
+    Stdout.line!("ok")
+}


### PR DESCRIPTION
## Summary
- preserve generated-private control-flow evidence through statement-free branch blocks
- treat lookup branch evidence as the selected generated-private request once selection is private, so raw local cells do not over-constrain branch preselection
- add FX regression coverage for #10596

Closes #10596.

## Test Plan
- `./zig-out/bin/roc check test/fx/control_flow_selected_runtime_representation_repro.roc`
- `./zig-out/bin/roc build --no-cache test/fx/control_flow_selected_runtime_representation_repro.roc --output=/tmp/control-flow-selected-repro`
- `/tmp/control-flow-selected-repro`
- `zig build run-test-zig-lir-inline --summary all --color off -- --test-filter "static record list iter append loop avoids direct-list append allocation" --test-filter "static primitive list iter append loop avoids direct-list append allocation"`
- `zig build run-test-zig-fx-platform`
- `zig build minici`