### PR TITLE
Add issue 10560 generated iterator regression

### DIFF
--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -966,6 +966,9 @@ const subcommand_cases = [_]CliCase{
     // Repro for https://github.com/roc-lang/roc/issues/10520: callable payloads
     // inside a concrete recursive parameterized nominal check cleanly.
     .{ .id = 0, .suite = .subcommands, .name = "issue 10520: recursive nominal callable payloads check cleanly", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10520_recursive_nominal_tag_callable_check.roc", .exit = .success, .contains_any = &.{.{ .needles = &no_errors_needles }}, .not_contains = &.{.{ .stream = .stderr, .text = "panic" }} } } },
+    // Repro for https://github.com/roc-lang/roc/issues/10560: complete checked
+    // interface relations must reach a generated iterator before Lambda Solved.
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10560: generated iterator preserves nested named callable types", .body = .{ .command = .{ .args = &.{ "test", "--no-cache" }, .roc_file = "test/cli/issue_10560_generated_iterator_evidence.roc", .exit = .success, .contains = &.{.{ .stream = .stdout, .text = "All (1) tests passed" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "postcheck invariant violated" }, .{ .stream = .stderr, .text = "Segmentation fault" } } } } },
     // Repro for https://github.com/roc-lang/roc/issues/10303: mutually
     // recursive function-containing values must finish Monotype lowering.
     .{ .id = 0, .suite = .subcommands, .name = "issue 10303: mutually recursive function values check cleanly", .timeout_ms = 10_000, .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/cli/issue_10303_recursive_function_values.roc", .exit = .success, .contains_any = &.{.{ .needles = &no_errors_needles }} } } },

--- a/test/cli/issue_10560_generated_iterator_evidence.roc
+++ b/test/cli/issue_10560_generated_iterator_evidence.roc
@@ -1,0 +1,32 @@
+# Repro for https://github.com/roc-lang/roc/issues/10560:
+# a generated iterator must preserve named type structure inside callable
+# payloads while specializing an open generic procedure interface.
+app [main!] { pf: platform "../fx/platform/main.roc" }
+
+Sizing : [Grow]
+
+LayoutConfig : {
+	width : Sizing,
+}
+
+default_layout : LayoutConfig
+default_layout = {
+	width: Grow,
+}
+
+style = { layout: default_layout }
+
+box = |style_fn, events| {
+	[].fold(Iter.single(Open(style_fn, events)), |acc, _child| acc).append(Close)
+}
+
+main! = || {}
+
+expect {
+	view = box(|_status| style, [])
+
+	match view.collect() {
+		[Open(_, []), Close] => Bool.True
+		_ => Bool.False
+	}
+}


### PR DESCRIPTION
## Summary

- add the exact `roc test` regression from #10560
- run it in the CLI integration suite without cache-dependent behavior
- pin preservation of nested named types in generated iterator evidence

## Root cause

At the reported revision, Monotype could seal an open, context-free specialization before the complete transitive checked interface relations had reached its graph. In this case, the generated-private `Iter` backing recorded the raw `[Grow]` tag union while the checked-public backing retained the named `Sizing` alias. Lambda Solved correctly rejected that structural mismatch in Debug builds; the same mismatch became the reported generated-code segfault in Release builds.

#10562 fixed the producer boundary by publishing and replaying the exact checked interface-relation closure before specialization sealing. That long-term fix is already on `main`, so this PR adds the missing issue-specific regression rather than a downstream repair or fallback.

Fixes #10560.

## Testing

- confirmed the fixture panics at `a8ef66c5a9` with `generated-private evidence relation received different type structure`
- `zig build run-test-cli -- --suite subcommands --filter "issue 10560"`
- `zig build minici -- --minici-from run-test-cli --minici-to run-test-cli`
- `zig build minici` (75/75 passed)
