### PR TITLE
Add issue 10595 string concat regression

### DIFF
--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -1548,6 +1548,10 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "roc test issue 9392 numeric utility expects are deterministic with no cache", .body = .{ .custom = .issue_9392_deterministic_no_cache } },
     .{ .id = 0, .suite = .subcommands, .name = "hosted try question widening rejects a non-included error row", .body = .{ .command = .{ .args = &.{ "check", "--no-cache" }, .roc_file = "test/fx-open/hosted_try_question_not_included.roc", .exit = .failure, .stderr_min_len = 1, .contains = &.{ .{ .stream = .stderr, .text = "TYPE MISMATCH" }, .{ .stream = .stderr, .text = "FallibleReject.roc" } }, .not_contains = &.{ .{ .stream = .stderr, .text = "panic" }, .{ .stream = .stderr, .text = "[ROC CRASHED]" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build hosted Try with Str error succeeds (issue 10518)", .body = .{ .command = .{ .args = &.{ "build", "--no-cache", "--opt=dev" }, .roc_file = "test/fx-open/issue_10518_hosted_try_str_error.roc", .exit = .success, .contains = &.{.{ .stream = .stdout, .text = "successfully building" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "instantiation tag-row read had a non-tag-union node" }, .{ .stream = .stderr, .text = "postcheck invariant violated" }, .{ .stream = .stderr, .text = "panic" } } } } },
+    // Repro for https://github.com/roc-lang/roc/issues/10595: concatenating a
+    // runtime-empty string onto a heap-sized literal must produce a unique
+    // result before the following concat tries to grow it.
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10595: dev interpolation copies a static prefix before appending a suffix", .backend = .dev, .body = .{ .command = .{ .args = &.{ "--opt=dev", "--no-cache" }, .roc_file = "test/fx-open/issue_10595_empty_runtime_str_concat.roc", .exit = .success, .stdout_exact = "aaaaaaaaaaaaaaaaaaaaaaaab\n" } } },
     // Non-`?` channels asking a hosted result for a wider error row: every one
     // is a type error, never an extern emitted at the wider row (design.md
     // "Host Symbol ABI"). The three mismatches are the annotated binding, the

--- a/test/fx-open/issue_10595_empty_runtime_str_concat.roc
+++ b/test/fx-open/issue_10595_empty_runtime_str_concat.roc
@@ -1,0 +1,10 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+main! : List(Str) => Try({}, [Exit(I32), ..])
+main! = |args| {
+	empty = if args.len() > 99 "z" else ""
+	Stdout.line!("aaaaaaaaaaaaaaaaaaaaaaaa${empty}b")
+	Ok({})
+}


### PR DESCRIPTION
## Summary

- add an end-to-end dev-backend regression for #10595
- keep the interpolated empty string runtime-dependent through argv
- assert that a 24-byte static prefix plus the empty string and a suffix prints successfully

## Root cause

The nightly in #10595 predates #10570. At that point, strConcat returned its left argument unchanged whenever the right argument was empty, even if the left argument was shared or static. Its RcEffect contract nevertheless promised a unique result, so ARC could treat that returned static allocation as freshly owned and let the following suffix concat take the in-place reallocation path, corrupting the heap.

#10570 already put the long-term ownership fix on main: the empty-right fast path returns the left argument only when it is exclusive, and otherwise copies into a fresh unique result. This PR pins the exact dev-backend interpolation path reported in #10595.

## Verification

- zig build run-test-cli -- --suite subcommands --filter "issue 10595"
- zig build run-check-test-asset-coverage run-test-zig-rc-conformance
- zig build minici (75/75 passed; 0 failed, 0 crashed, 0 skipped)

Closes #10595