### PR TITLE
Add parens to funcs in return position of docs rendered type annotations

### DIFF
--- a/src/docs/render_html.zig
+++ b/src/docs/render_html.zig
@@ -2161,7 +2161,7 @@ fn renderDocTypeHtml(
                         if (item.needs_parens) try frames.append(gpa, .{ .html = ")" });
                         try frames.append(gpa, .{ .doc_type = .{
                             .value = func.ret,
-                            .needs_parens = false,
+                            .needs_parens = true,
                             .indent = item.indent,
                         } });
                         try frames.append(gpa, .{ .html = if (func.effectful)
@@ -2306,7 +2306,7 @@ fn renderDocTypeHtml(
                                 try frames.append(gpa, .{ .html = ",\n" });
                                 try frames.append(gpa, .{ .doc_type = .{
                                     .value = tup.elems[i],
-                                    .needs_parens = false,
+                                    .needs_parens = true,
                                     .indent = item.indent + 1,
                                 } });
                                 try frames.append(gpa, .{ .indent = item.indent + 1 });
@@ -2318,7 +2318,7 @@ fn renderDocTypeHtml(
                                 i -= 1;
                                 try frames.append(gpa, .{ .doc_type = .{
                                     .value = tup.elems[i],
-                                    .needs_parens = false,
+                                    .needs_parens = true,
                                     .indent = item.indent,
                                 } });
                                 if (i > 0) try frames.append(gpa, .{ .html = ", " });
@@ -2337,7 +2337,7 @@ fn renderDocTypeHtml(
                                 try frames.append(gpa, .{ .html = ",\n" });
                                 try frames.append(gpa, .{ .doc_type = .{
                                     .value = app.args[i],
-                                    .needs_parens = false,
+                                    .needs_parens = true,
                                     .indent = item.indent + 1,
                                 } });
                                 try frames.append(gpa, .{ .indent = item.indent + 1 });
@@ -2349,7 +2349,7 @@ fn renderDocTypeHtml(
                                 i -= 1;
                                 try frames.append(gpa, .{ .doc_type = .{
                                     .value = app.args[i],
-                                    .needs_parens = false,
+                                    .needs_parens = true,
                                     .indent = item.indent,
                                 } });
                                 if (i > 0) try frames.append(gpa, .{ .html = ", " });
@@ -2464,7 +2464,7 @@ fn renderDocTypeHtml(
                             try frames.append(gpa, .{ .html = ",\n" });
                             try frames.append(gpa, .{ .doc_type = .{
                                 .value = item.value.args[i],
-                                .needs_parens = false,
+                                .needs_parens = true,
                                 .indent = item.indent + 1,
                             } });
                             try frames.append(gpa, .{ .indent = item.indent + 1 });
@@ -2476,7 +2476,7 @@ fn renderDocTypeHtml(
                             i -= 1;
                             try frames.append(gpa, .{ .doc_type = .{
                                 .value = item.value.args[i],
-                                .needs_parens = false,
+                                .needs_parens = true,
                                 .indent = item.indent,
                             } });
                             if (i > 0) try frames.append(gpa, .{ .html = ", " });


### PR DESCRIPTION
([Zulip thread](https://roc.zulipchat.com/#narrow/channel/463736-bugs/topic/roc.20docs.20-.20incorrect.20generated.20annotation/with/613843281))

Before, if a function returned a function, the return type that was rendered to the docs was not surrounded with parentheses, leading to the following invalid syntax:
`tagged_value : a -> b -> SqliteStmt => Try(...`
(Example from [basic-cli docs](https://roc-lang.github.io/basic-cli/0.21.0-rc4/Sqlite/#Sqlite.tagged_value))

Similarly, functions in tag payloads would not be parenthesized in the docs. The following returns a binary function enclosed in `Foo`
`f = || Foo(|a, b| a + b)`
but leads to the below type in the docs, regardless of whether the type was inferred or manually annotated in the source:
```
f : () -> [
    Foo(
        Dec, Dec -> Dec,
    ),
]
```
This describes a different type: a tag `Foo` having a payload with two fields, one `Dec` and one `Dec -> Dec`.

---

`needs_parens` was flipped to true for the arguments of tuples, tag payloads, and function return types, which ensures safe wrapping, although it now leads to redundant parentheses in the docs with unary functions in tags and tuples.
```
h : () -> [
    Bar(
        (a -> a), # Extra level of nested parens
    ),
]
```