### PR TITLE
Don't warn about roc version pins on builds from source

### DIFF
--- a/src/base/roc_version.zig
+++ b/src/base/roc_version.zig
@@ -124,8 +124,15 @@ pub fn shouldUpgrade(pinned: []const u8, current: []const u8) bool {
 ///
 /// A pin the compiler cannot read is not a mismatch: parsing already rejected
 /// it, and one mistake should not produce two diagnostics.
+///
+/// Neither is anything a mismatch when the running compiler reports a local
+/// development version (e.g. `debug-c6dfe61b`): a build from source is not a
+/// version any header could pin, so no pin can name it, and `roc fmt` will not
+/// write it either. Reporting every pinned file the developer touches would
+/// only be noise.
 pub fn isMismatch(pinned: []const u8, current: []const u8) bool {
     if (parse(pinned) == null) return false;
+    if (parse(current) == null) return false;
     return !std.mem.eql(u8, pinned, current);
 }
 
@@ -242,13 +249,15 @@ test "nightly date ordering" {
 test "report a pin that does not name the running compiler" {
     try std.testing.expect(isMismatch("nightly-2026-July-30-aaaaaaa", "nightly-2026-July-31-bbbbbbb"));
     try std.testing.expect(isMismatch("0.1.0", "nightly-2026-July-31-bbbbbbb"));
-    try std.testing.expect(isMismatch("nightly-2026-July-31-aaaaaaa", "debug-c6dfe61b"));
 }
 
 test "stay quiet when there is nothing to report about a pin" {
     try std.testing.expect(!isMismatch("nightly-2026-July-31-aaaaaaa", "nightly-2026-July-31-aaaaaaa"));
     // Already reported as an invalid version by the parser.
     try std.testing.expect(!isMismatch("nonsense", "nightly-2026-July-31-bbbbbbb"));
+    // No pin can name a build from source, so none disagrees with one.
+    try std.testing.expect(!isMismatch("nightly-2026-July-31-aaaaaaa", "debug-c6dfe61b"));
+    try std.testing.expect(!isMismatch("0.1.0", "release-fast-7fdb318d"));
 }
 
 test "upgrade a pin to a newer nightly" {

--- a/src/canonicalize/test/roc_version_test.zig
+++ b/src/canonicalize/test/roc_version_test.zig
@@ -66,6 +66,12 @@ test "a pin that names the running compiler is not reported" {
     try std.testing.expect(found == null);
 }
 
+test "a pin is not reported when the running compiler was built from source" {
+    const allocator = std.testing.allocator;
+    try std.testing.expect(try mismatchDiagnostic(allocator, pinned_app, "debug-c6dfe61b") == null);
+    try std.testing.expect(try mismatchDiagnostic(allocator, pinned_app, "release-fast-7fdb318d") == null);
+}
+
 test "a pin is not checked when the caller does not say which compiler is running" {
     const allocator = std.testing.allocator;
     const found = try mismatchDiagnostic(allocator, pinned_app, null);


### PR DESCRIPTION
A locally built compiler reports `<build mode>-<git short sha>` (e.g. `debug-c6dfe61b`, `release-fast-7fdb318d`), which is deliberately not a form a header may pin. Every pinned file checked with such a build got:

    ROC VERSION MISMATCH - This header pins Roc version
    nightly-2026-August-03-94cbed3, but you are running
    release-fast-7fdb318d.

along with advice to "run roc fmt to update the pin, or switch to the pinned version of the compiler" - neither of which applies, since no pin can name a build from source and `shouldUpgrade` already refuses to write one. So `isMismatch` now stays quiet whenever the running version is not itself pinnable, making it symmetric with `shouldUpgrade`.