### PR TITLE
Fix Dec.lowest boundary operations

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -11271,8 +11271,8 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         }
 
         fn emitCheckedSignedLowestValue(self: *Self, loc: ValueLocation, operand_layout: layout.Idx, op: lir.LowLevel) Allocator.Error!void {
-            const message = checkedOverflowMessage(op);
-            if (operand_layout == .i128) {
+            const message = CheckedArithmetic.overflowMessageForLayout(op, operand_layout) orelse unreachable;
+            if (operand_layout == .i128 or operand_layout == .dec) {
                 const parts = try self.getI128Parts(loc, .signed);
                 const high_lowest = try self.allocTempGeneral();
                 try self.emitCmpImm(parts.low, 0);

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -4435,7 +4435,7 @@ pub const MonoLlvmCodeGen = struct {
             if (isFloatLayout(target_layout)) return error.UnsupportedLowLevel;
             const lowest = builder.intValue(value.typeOfWip(wip), CheckedArithmetic.signedLowestValue(target_layout) orelse unreachable) catch return error.OutOfMemory;
             const is_lowest = wip.icmp(.eq, value, lowest, "") catch return error.OutOfMemory;
-            try self.emitCrashIf(is_lowest, checkedOverflowMessage(checked));
+            try self.emitCrashIf(is_lowest, CheckedArithmetic.overflowMessageForLayout(checked, target_layout) orelse unreachable);
         }
         const zero = builder.zeroInitValue(value.typeOfWip(wip)) catch return error.OutOfMemory;
         const is_neg = if (isFloatLayout(target_layout))

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -5186,7 +5186,7 @@ fn emitCompositeIsSignedMinNegOne(self: *Self, lhs_local: u32, rhs_local: u32) A
     self.currentCode().append(self.allocator, Op.i32_and) catch return error.OutOfMemory;
 }
 
-fn emitCheckedCompositeSignedLowestValue(self: *Self, value_local: u32, checked_op: LIR.LowLevel) Allocator.Error!void {
+fn emitCheckedCompositeSignedLowestValue(self: *Self, value_local: u32, checked_op: LIR.LowLevel, operand_layout: layout.Idx) Allocator.Error!void {
     try self.emitLocalGet(value_local);
     try self.emitLoadOp(.i64, 0);
     try self.emitI64Const(0);
@@ -5196,7 +5196,7 @@ fn emitCheckedCompositeSignedLowestValue(self: *Self, value_local: u32, checked_
     try self.emitI64Const(std.math.minInt(i64));
     self.currentCode().append(self.allocator, Op.i64_eq) catch return error.OutOfMemory;
     self.currentCode().append(self.allocator, Op.i32_and) catch return error.OutOfMemory;
-    try self.emitCrashIfStackBool(checkedOverflowMessage(checked_op));
+    try self.emitCrashIfStackBool(CheckedArithmetic.overflowMessageForLayout(checked_op, operand_layout) orelse unreachable);
 }
 
 fn emitI128SignedAddSubOverflowCondition(self: *Self, plain_op: LIR.LowLevel, lhs_local: u32, rhs_local: u32, result_local: u32) Allocator.Error!void {
@@ -5269,11 +5269,11 @@ fn emitCheckedCompositeNumericOp(self: *Self, checked_op: LIR.LowLevel, plain_op
     if (args.len == 1) {
         switch (plain_op) {
             .num_negate => {
-                try self.emitCheckedCompositeSignedLowestValue(lhs_local, checked_op);
+                try self.emitCheckedCompositeSignedLowestValue(lhs_local, checked_op, operand_layout);
                 try self.emitCompositeI128NegateFromLocal(lhs_local);
             },
             .num_abs => {
-                try self.emitCheckedCompositeSignedLowestValue(lhs_local, checked_op);
+                try self.emitCheckedCompositeSignedLowestValue(lhs_local, checked_op, operand_layout);
                 if (operand_layout == .u128) {
                     try self.emitLocalGet(lhs_local);
                 } else {

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -14479,7 +14479,8 @@ Builtin :: [].{
 			## ```
 			negate : Dec -> Dec
 
-			## Return the absolute value of a [Dec].
+			## Return the absolute value of a [Dec]. Crashes on [Dec.lowest], since
+			## its positive magnitude does not fit in a [Dec].
 			## ```roc
 			## expect Dec.abs(3.5) == 3.5
 			##
@@ -14689,210 +14690,210 @@ Builtin :: [].{
 			## expect Dec.round_to_i8_try(3.4) == Ok(3)
 			## ```
 			round_to_i8_try : Dec -> Try(I8, [OutOfRange])
-			round_to_i8_try = |self| Dec.to_i8_try(dec_round_to_whole(self))
+			round_to_i8_try = |self| I128.to_i8_try(dec_round_to_i128(self))
 
 			## Round a [Dec] to the nearest [I16]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.round_to_i16_try(3.4) == Ok(3)
 			## ```
 			round_to_i16_try : Dec -> Try(I16, [OutOfRange])
-			round_to_i16_try = |self| Dec.to_i16_try(dec_round_to_whole(self))
+			round_to_i16_try = |self| I128.to_i16_try(dec_round_to_i128(self))
 
 			## Round a [Dec] to the nearest [I32]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.round_to_i32_try(-3.6) == Ok(-4)
 			## ```
 			round_to_i32_try : Dec -> Try(I32, [OutOfRange])
-			round_to_i32_try = |self| Dec.to_i32_try(dec_round_to_whole(self))
+			round_to_i32_try = |self| I128.to_i32_try(dec_round_to_i128(self))
 
 			## Round a [Dec] to the nearest [I64]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.round_to_i64_try(7.2) == Ok(7)
 			## ```
 			round_to_i64_try : Dec -> Try(I64, [OutOfRange])
-			round_to_i64_try = |self| Dec.to_i64_try(dec_round_to_whole(self))
+			round_to_i64_try = |self| I128.to_i64_try(dec_round_to_i128(self))
 
 			## Round a [Dec] to the nearest [I128]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.round_to_i128_try(7.2) == Ok(7)
 			## ```
 			round_to_i128_try : Dec -> Try(I128, [OutOfRange])
-			round_to_i128_try = |self| Dec.to_i128_try(dec_round_to_whole(self))
+			round_to_i128_try = |self| Ok(dec_round_to_i128(self))
 
 			## Round a [Dec] to the nearest [U8]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.round_to_u8_try(3.4) == Ok(3)
 			## ```
 			round_to_u8_try : Dec -> Try(U8, [OutOfRange])
-			round_to_u8_try = |self| Dec.to_u8_try(dec_round_to_whole(self))
+			round_to_u8_try = |self| I128.to_u8_try(dec_round_to_i128(self))
 
 			## Round a [Dec] to the nearest [U16]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.round_to_u16_try(3.4) == Ok(3)
 			## ```
 			round_to_u16_try : Dec -> Try(U16, [OutOfRange])
-			round_to_u16_try = |self| Dec.to_u16_try(dec_round_to_whole(self))
+			round_to_u16_try = |self| I128.to_u16_try(dec_round_to_i128(self))
 
 			## Round a [Dec] to the nearest [U32]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.round_to_u32_try(7.2) == Ok(7)
 			## ```
 			round_to_u32_try : Dec -> Try(U32, [OutOfRange])
-			round_to_u32_try = |self| Dec.to_u32_try(dec_round_to_whole(self))
+			round_to_u32_try = |self| I128.to_u32_try(dec_round_to_i128(self))
 
 			## Round a [Dec] to the nearest [U64]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.round_to_u64_try(7.2) == Ok(7)
 			## ```
 			round_to_u64_try : Dec -> Try(U64, [OutOfRange])
-			round_to_u64_try = |self| Dec.to_u64_try(dec_round_to_whole(self))
+			round_to_u64_try = |self| I128.to_u64_try(dec_round_to_i128(self))
 
 			## Round a [Dec] to the nearest [U128]. Halfway values round away from zero. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.round_to_u128_try(7.2) == Ok(7)
 			## ```
 			round_to_u128_try : Dec -> Try(U128, [OutOfRange])
-			round_to_u128_try = |self| Dec.to_u128_try(dec_round_to_whole(self))
+			round_to_u128_try = |self| I128.to_u128_try(dec_round_to_i128(self))
 
 			## Round a [Dec] down to an [I8]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.floor_to_i8_try(-3.2) == Ok(-4)
 			## ```
 			floor_to_i8_try : Dec -> Try(I8, [OutOfRange])
-			floor_to_i8_try = |self| Dec.to_i8_try(dec_floor_to_whole(self))
+			floor_to_i8_try = |self| I128.to_i8_try(dec_floor_to_i128(self))
 
 			## Round a [Dec] down to an [I16]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.floor_to_i16_try(-3.2) == Ok(-4)
 			## ```
 			floor_to_i16_try : Dec -> Try(I16, [OutOfRange])
-			floor_to_i16_try = |self| Dec.to_i16_try(dec_floor_to_whole(self))
+			floor_to_i16_try = |self| I128.to_i16_try(dec_floor_to_i128(self))
 
 			## Round a [Dec] down to an [I32]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.floor_to_i32_try(3.8) == Ok(3)
 			## ```
 			floor_to_i32_try : Dec -> Try(I32, [OutOfRange])
-			floor_to_i32_try = |self| Dec.to_i32_try(dec_floor_to_whole(self))
+			floor_to_i32_try = |self| I128.to_i32_try(dec_floor_to_i128(self))
 
 			## Round a [Dec] down to an [I64]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.floor_to_i64_try(3.8) == Ok(3)
 			## ```
 			floor_to_i64_try : Dec -> Try(I64, [OutOfRange])
-			floor_to_i64_try = |self| Dec.to_i64_try(dec_floor_to_whole(self))
+			floor_to_i64_try = |self| I128.to_i64_try(dec_floor_to_i128(self))
 
 			## Round a [Dec] down to an [I128]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.floor_to_i128_try(3.8) == Ok(3)
 			## ```
 			floor_to_i128_try : Dec -> Try(I128, [OutOfRange])
-			floor_to_i128_try = |self| Dec.to_i128_try(dec_floor_to_whole(self))
+			floor_to_i128_try = |self| Ok(dec_floor_to_i128(self))
 
 			## Round a [Dec] down to a [U8]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.floor_to_u8_try(3.8) == Ok(3)
 			## ```
 			floor_to_u8_try : Dec -> Try(U8, [OutOfRange])
-			floor_to_u8_try = |self| Dec.to_u8_try(dec_floor_to_whole(self))
+			floor_to_u8_try = |self| I128.to_u8_try(dec_floor_to_i128(self))
 
 			## Round a [Dec] down to a [U16]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.floor_to_u16_try(3.8) == Ok(3)
 			## ```
 			floor_to_u16_try : Dec -> Try(U16, [OutOfRange])
-			floor_to_u16_try = |self| Dec.to_u16_try(dec_floor_to_whole(self))
+			floor_to_u16_try = |self| I128.to_u16_try(dec_floor_to_i128(self))
 
 			## Round a [Dec] down to a [U32]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.floor_to_u32_try(3.8) == Ok(3)
 			## ```
 			floor_to_u32_try : Dec -> Try(U32, [OutOfRange])
-			floor_to_u32_try = |self| Dec.to_u32_try(dec_floor_to_whole(self))
+			floor_to_u32_try = |self| I128.to_u32_try(dec_floor_to_i128(self))
 
 			## Round a [Dec] down to a [U64]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.floor_to_u64_try(3.8) == Ok(3)
 			## ```
 			floor_to_u64_try : Dec -> Try(U64, [OutOfRange])
-			floor_to_u64_try = |self| Dec.to_u64_try(dec_floor_to_whole(self))
+			floor_to_u64_try = |self| I128.to_u64_try(dec_floor_to_i128(self))
 
 			## Round a [Dec] down to a [U128]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.floor_to_u128_try(3.8) == Ok(3)
 			## ```
 			floor_to_u128_try : Dec -> Try(U128, [OutOfRange])
-			floor_to_u128_try = |self| Dec.to_u128_try(dec_floor_to_whole(self))
+			floor_to_u128_try = |self| I128.to_u128_try(dec_floor_to_i128(self))
 
 			## Round a [Dec] up to an [I8]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.ceiling_to_i8_try(-3.2) == Ok(-3)
 			## ```
 			ceiling_to_i8_try : Dec -> Try(I8, [OutOfRange])
-			ceiling_to_i8_try = |self| Dec.to_i8_try(dec_ceiling_to_whole(self))
+			ceiling_to_i8_try = |self| I128.to_i8_try(dec_ceiling_to_i128(self))
 
 			## Round a [Dec] up to an [I16]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.ceiling_to_i16_try(-3.2) == Ok(-3)
 			## ```
 			ceiling_to_i16_try : Dec -> Try(I16, [OutOfRange])
-			ceiling_to_i16_try = |self| Dec.to_i16_try(dec_ceiling_to_whole(self))
+			ceiling_to_i16_try = |self| I128.to_i16_try(dec_ceiling_to_i128(self))
 
 			## Round a [Dec] up to an [I32]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.ceiling_to_i32_try(3.2) == Ok(4)
 			## ```
 			ceiling_to_i32_try : Dec -> Try(I32, [OutOfRange])
-			ceiling_to_i32_try = |self| Dec.to_i32_try(dec_ceiling_to_whole(self))
+			ceiling_to_i32_try = |self| I128.to_i32_try(dec_ceiling_to_i128(self))
 
 			## Round a [Dec] up to an [I64]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.ceiling_to_i64_try(3.2) == Ok(4)
 			## ```
 			ceiling_to_i64_try : Dec -> Try(I64, [OutOfRange])
-			ceiling_to_i64_try = |self| Dec.to_i64_try(dec_ceiling_to_whole(self))
+			ceiling_to_i64_try = |self| I128.to_i64_try(dec_ceiling_to_i128(self))
 
 			## Round a [Dec] up to an [I128]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.ceiling_to_i128_try(3.2) == Ok(4)
 			## ```
 			ceiling_to_i128_try : Dec -> Try(I128, [OutOfRange])
-			ceiling_to_i128_try = |self| Dec.to_i128_try(dec_ceiling_to_whole(self))
+			ceiling_to_i128_try = |self| Ok(dec_ceiling_to_i128(self))
 
 			## Round a [Dec] up to a [U8]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.ceiling_to_u8_try(3.2) == Ok(4)
 			## ```
 			ceiling_to_u8_try : Dec -> Try(U8, [OutOfRange])
-			ceiling_to_u8_try = |self| Dec.to_u8_try(dec_ceiling_to_whole(self))
+			ceiling_to_u8_try = |self| I128.to_u8_try(dec_ceiling_to_i128(self))
 
 			## Round a [Dec] up to a [U16]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.ceiling_to_u16_try(3.2) == Ok(4)
 			## ```
 			ceiling_to_u16_try : Dec -> Try(U16, [OutOfRange])
-			ceiling_to_u16_try = |self| Dec.to_u16_try(dec_ceiling_to_whole(self))
+			ceiling_to_u16_try = |self| I128.to_u16_try(dec_ceiling_to_i128(self))
 
 			## Round a [Dec] up to a [U32]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.ceiling_to_u32_try(3.2) == Ok(4)
 			## ```
 			ceiling_to_u32_try : Dec -> Try(U32, [OutOfRange])
-			ceiling_to_u32_try = |self| Dec.to_u32_try(dec_ceiling_to_whole(self))
+			ceiling_to_u32_try = |self| I128.to_u32_try(dec_ceiling_to_i128(self))
 
 			## Round a [Dec] up to a [U64]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.ceiling_to_u64_try(3.2) == Ok(4)
 			## ```
 			ceiling_to_u64_try : Dec -> Try(U64, [OutOfRange])
-			ceiling_to_u64_try = |self| Dec.to_u64_try(dec_ceiling_to_whole(self))
+			ceiling_to_u64_try = |self| I128.to_u64_try(dec_ceiling_to_i128(self))
 
 			## Round a [Dec] up to a [U128]. Returns `Err(OutOfRange)` if the rounded value is out of range.
 			## ```roc
 			## expect Dec.ceiling_to_u128_try(3.2) == Ok(4)
 			## ```
 			ceiling_to_u128_try : Dec -> Try(U128, [OutOfRange])
-			ceiling_to_u128_try = |self| Dec.to_u128_try(dec_ceiling_to_whole(self))
+			ceiling_to_u128_try = |self| I128.to_u128_try(dec_ceiling_to_i128(self))
 
 			## Build a [Dec] from a list of base-10 digits, most significant
 			## first. Each item of the list must be a digit in the range `0`
@@ -21712,34 +21713,34 @@ out_of_range_try = |answer|
 		Err(OutOfRange)
 	}
 
-dec_round_to_whole : Dec -> Dec
-dec_round_to_whole = |self| {
-	truncated = Dec.div_trunc_by(self, 1.0)
-	remainder = self - truncated
-	if remainder >= 0.5 {
-		truncated + 1.0
-	} else if remainder <= -0.5 {
-		truncated - 1.0
+dec_attos_per_whole : I128
+dec_attos_per_whole = 1000000000000000000
+
+dec_round_to_i128 : Dec -> I128
+dec_round_to_i128 = |self| {
+	attos = Dec.to_attos(self)
+	truncated = I128.div_trunc_by(attos, dec_attos_per_whole)
+	remainder = I128.rem_by(attos, dec_attos_per_whole)
+	if remainder >= 500000000000000000 {
+		truncated + 1
+	} else if remainder <= -500000000000000000 {
+		truncated - 1
 	} else {
 		truncated
 	}
 }
+
+dec_floor_to_i128 : Dec -> I128
+dec_floor_to_i128 = |self| I128.div_floor_by(Dec.to_attos(self), dec_attos_per_whole)
+
+dec_ceiling_to_i128 : Dec -> I128
+dec_ceiling_to_i128 = |self| I128.div_ceil_by(Dec.to_attos(self), dec_attos_per_whole)
 
 dec_floor_to_whole : Dec -> Dec
 dec_floor_to_whole = |self| {
 	truncated = Dec.div_trunc_by(self, 1.0)
 	if self < truncated {
 		truncated - 1.0
-	} else {
-		truncated
-	}
-}
-
-dec_ceiling_to_whole : Dec -> Dec
-dec_ceiling_to_whole = |self| {
-	truncated = Dec.div_trunc_by(self, 1.0)
-	if self > truncated {
-		truncated + 1.0
 	} else {
 		truncated
 	}

--- a/src/builtins/dec.zig
+++ b/src/builtins/dec.zig
@@ -2160,6 +2160,10 @@ test "div: Dec.lowest boundary operands" {
     try std.testing.expectEqual(RocDec.one_point_zero, RocDec.min.div(RocDec.min, test_env.getOps()));
     try std.testing.expectEqual(RocDec{ .num = 0 }, RocDec.one_point_zero.div(RocDec.min, test_env.getOps()));
     try expectRocDecConstant(
+        RocDec.min.div(RocDec.fromWholeInt(-2).?, test_env.getOps()),
+        "85070591730234615865.843651857942052864",
+    );
+    try expectRocDecConstant(
         RocDec.max.div(RocDec.min, test_env.getOps()),
         "-0.999999999999999999",
     );

--- a/src/builtins/dec.zig
+++ b/src/builtins/dec.zig
@@ -726,52 +726,33 @@ pub const RocDec = extern struct {
         // it in terms of positives can cause bugs when one is zero.
         const is_answer_negative = (numerator_i128 < 0) != (denominator_i128 < 0);
 
-        // Break the two i128s into two { hi: u64, lo: u64 } tuples, discarding
-        // the sign for now.
-        //
-        // We'll multiply all 4 combinations of these (hi1 x lo1, hi2 x lo2,
-        // hi1 x lo2, hi2 x lo1) and add them as appropriate, then apply the
-        // appropriate sign at the very end.
-        //
-        // We do checked_abs because if we had -i128::MAX before, this will overflow.
-
+        // Keep the sign separate while calculating with unsigned magnitudes.
+        // The magnitude of minInt(i128) is 2^127, which fits in u128 even though
+        // it does not fit in a positive i128.
         const numerator_u128 = @abs(numerator_i128);
-        if (numerator_u128 > @as(u128, @intCast(std.math.maxInt(i128)))) {
-            // Currently, if you try to do multiplication on i64::MIN, panic
-            // unless you're specifically multiplying by 0 or 1.
-            //
-            // Maybe we could support more cases in the future
-            if (denominator_i128 == one_point_zero_i128) {
-                return self;
-            } else {
-                roc_ops.crash("Decimal division overflow in numerator!");
-            }
-        }
-
         const denominator_u128 = @abs(denominator_i128);
-        if (denominator_u128 > @as(u128, @intCast(std.math.maxInt(i128)))) {
-            // Currently, if you try to do multiplication on i64::MIN, panic
-            // unless you're specifically multiplying by 0 or 1.
-            //
-            // Maybe we could support more cases in the future
-            if (numerator_i128 == one_point_zero_i128) {
-                return other;
-            } else {
-                roc_ops.crash("Decimal division overflow in denominator!");
-            }
-        }
 
         const numerator_u256: U256 = mul_u128(numerator_u128, comptime math.pow(u128, 10, decimal_places));
         const answer = div_u256_by_u128(numerator_u256, denominator_u128);
 
-        var unsigned_answer: i128 = undefined;
-        if (answer.hi == 0 and answer.lo <= math.maxInt(i128)) {
-            unsigned_answer = @as(i128, @intCast(answer.lo));
-        } else {
+        if (answer.hi != 0) {
             roc_ops.crash("Decimal division overflow!");
         }
 
-        return RocDec{ .num = if (is_answer_negative) -unsigned_answer else unsigned_answer };
+        if (is_answer_negative) {
+            const negative_limit = i128h.shl(@as(u128, 1), 127);
+            if (answer.lo > negative_limit) {
+                roc_ops.crash("Decimal division overflow!");
+            }
+
+            return RocDec{ .num = @bitCast(0 -% answer.lo) };
+        } else {
+            if (answer.lo > @as(u128, @intCast(math.maxInt(i128)))) {
+                roc_ops.crash("Decimal division overflow!");
+            }
+
+            return RocDec{ .num = @intCast(answer.lo) };
+        }
     }
 
     pub fn log(self: RocDec, roc_ops: *RocOps) RocDec {
@@ -2129,6 +2110,10 @@ test "sub: 0" {
     try std.testing.expectEqual(RocDec{ .num = 1 }, dec.sub(.{ .num = 0 }, test_env.getOps()));
 }
 
+test "abs: Dec.lowest is out of range" {
+    try std.testing.expectError(error.OutOfRange, RocDec.min.abs());
+}
+
 test "mul: by 0" {
     var test_env = TestEnv.init(std.testing.allocator);
     defer test_env.deinit();
@@ -2154,6 +2139,30 @@ test "div: 0 / 2" {
     var dec: RocDec = RocDec.fromU64(0);
 
     try std.testing.expectEqual(RocDec.fromU64(0), dec.div(RocDec.fromU64(2), test_env.getOps()));
+}
+
+// https://github.com/roc-lang/roc/issues/10563
+test "div: Dec.lowest / 2" {
+    var test_env = TestEnv.init(std.testing.allocator);
+    defer test_env.deinit();
+
+    try expectRocDecConstant(
+        RocDec.min.div(RocDec.fromU64(2), test_env.getOps()),
+        "-85070591730234615865.843651857942052864",
+    );
+}
+
+test "div: Dec.lowest boundary operands" {
+    var test_env = TestEnv.init(std.testing.allocator);
+    defer test_env.deinit();
+
+    try std.testing.expectEqual(RocDec.min, RocDec.min.div(RocDec.one_point_zero, test_env.getOps()));
+    try std.testing.expectEqual(RocDec.one_point_zero, RocDec.min.div(RocDec.min, test_env.getOps()));
+    try std.testing.expectEqual(RocDec{ .num = 0 }, RocDec.one_point_zero.div(RocDec.min, test_env.getOps()));
+    try expectRocDecConstant(
+        RocDec.max.div(RocDec.min, test_env.getOps()),
+        "-0.999999999999999999",
+    );
 }
 
 test "div: 8 / 5" {

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -6626,7 +6626,7 @@ pub const Interpreter = struct {
                 64 => val.write(f64, floatBinOp(f64, a.read(f64), b.read(f64), op)),
                 else => return self.invariantFailedError("LIR/interpreter invariant violated: unsupported float width {d}", .{bits}),
             },
-            .dec => val.write(i128, try self.decBinOp(a.read(i128), b.read(i128), op)),
+            .dec => val.write(i128, try self.decBinOp(a.read(i128), b.read(i128), op, checked_op)),
         }
         return val;
     }
@@ -7669,12 +7669,18 @@ pub const Interpreter = struct {
     }
 
     /// Dec (fixed-point i128 with 10^18 scale) binary operation.
-    fn decBinOp(self: *LirInterpreter, av: i128, bv: i128, op: NumOp) Error!i128 {
+    fn decBinOp(self: *LirInterpreter, av: i128, bv: i128, op: NumOp, checked_op: ?LIR.LowLevel) Error!i128 {
         return switch (op) {
             .add => av +% bv,
             .sub => av -% bv,
             .negate => -%av,
-            .abs => if (av < 0) -%av else av,
+            .abs => blk: {
+                if (checked_op != null and av == std.math.minInt(i128)) {
+                    const message = CheckedArithmetic.overflowMessageForLayout(checked_op.?, .dec) orelse unreachable;
+                    return self.triggerCrash(message);
+                }
+                break :blk if (av < 0) -%av else av;
+            },
             .abs_diff => if (av > bv) av -% bv else bv -% av,
             .mul => blk: {
                 const result = RocDec.mulWithOverflow(RocDec{ .num = av }, RocDec{ .num = bv });

--- a/src/eval/test/eval_low_level_tests.zig
+++ b/src/eval/test/eval_low_level_tests.zig
@@ -699,6 +699,28 @@ pub const tests = [_]TestCase{
         .expected = .{ .inspect_str = "True" },
     },
     .{
+        .name = "low_level - Dec boundary rounding to integers",
+        .source =
+        \\{
+        \\Dec.round_to_i128_try(Dec.highest) == Ok(170141183460469231732)
+        \\    and Dec.floor_to_i128_try(Dec.lowest) == Ok(-170141183460469231732)
+        \\    and Dec.ceiling_to_i128_try(Dec.highest) == Ok(170141183460469231732)
+        \\    and Dec.round_to_i64_try(Dec.highest) == Err(OutOfRange)
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec.abs lowest crashes on overflow",
+        .source = "Dec.abs(Dec.lowest)",
+        .expected = .{ .crash = {} },
+    },
+    .{
+        .name = "low_level - Dec.lowest divided by negative one crashes on overflow",
+        .source = "Dec.lowest / -1.0",
+        .expected = .{ .crash = {} },
+    },
+    .{
         .name = "low_level - Str.is_empty returns True for empty string",
         .source =
         \\{

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -3603,6 +3603,7 @@ const core_tests = [_]TestCase{
     .{ .name = "inspect: Dec minus", .source = "{ a : Dec\n    a = 10.0.Dec\n    b : Dec\n    b = 3.5.Dec\n    a - b\n}", .expected = .{ .inspect_str = "6.5" } },
     .{ .name = "inspect: Dec times", .source = "{ a : Dec\n    a = 2.5.Dec\n    b : Dec\n    b = 4.0.Dec\n    a * b\n}", .expected = .{ .inspect_str = "10.0" } },
     .{ .name = "inspect: Dec div", .source = "{ a : Dec\n    a = 10.0.Dec\n    b : Dec\n    b = 2.0.Dec\n    a / b\n}", .expected = .{ .inspect_str = "5.0" } },
+    .{ .name = "inspect: Dec.lowest div", .source = "Dec.lowest / 2", .expected = .{ .inspect_str = "-85070591730234615865.843651857942052864" } },
     .{ .name = "inspect: Dec to_str", .source = "{ a : Dec\n    a = 100.0.Dec\n    Dec.to_str(a)\n}", .expected = .{ .inspect_str = "\"100.0\"" } },
 
     // Remaining semantic ports from interpreter_style_test.zig

--- a/src/lir/checked_arithmetic.zig
+++ b/src/lir/checked_arithmetic.zig
@@ -54,20 +54,23 @@ pub fn intBits(layout_idx: layout.Idx) u16 {
     };
 }
 
-/// Returns the lowest representable value for a signed integer layout.
+/// Returns the lowest representable value for a signed numeric layout.
 pub fn signedLowestValue(layout_idx: layout.Idx) ?i128 {
     return switch (layout_idx) {
         .i8 => std.math.minInt(i8),
         .i16 => std.math.minInt(i16),
         .i32 => std.math.minInt(i32),
         .i64 => std.math.minInt(i64),
-        .i128 => std.math.minInt(i128),
+        .i128, .dec => std.math.minInt(i128),
         else => null,
     };
 }
 
-/// Returns the checked LIR operation for a plain integer arithmetic operation.
+/// Returns the checked LIR operation required by a plain numeric operation.
 pub fn checkedOp(op: LIR.LowLevel, layout_idx: layout.Idx) ?LIR.LowLevel {
+    if (layout_idx == .dec) {
+        return if (op == .num_abs) .num_abs_checked else null;
+    }
     if (!isIntegerLayout(layout_idx)) return null;
     return switch (op) {
         .num_plus => .num_plus_checked,
@@ -122,6 +125,14 @@ pub fn overflowMessage(op: LIR.LowLevel) ?[]const u8 {
         => "Integer division overflowed",
         else => null,
     };
+}
+
+/// Returns the overflow message for a checked operation and operand layout.
+pub fn overflowMessageForLayout(op: LIR.LowLevel, layout_idx: layout.Idx) ?[]const u8 {
+    if (op == .num_abs_checked and layout_idx == .dec) {
+        return "Decimal absolute value overflow!";
+    }
+    return overflowMessage(op);
 }
 
 /// Returns the canonical crash message for a checked zero-denominator operation.
@@ -184,7 +195,7 @@ fn moduloByZeroMessage(layout_idx: layout.Idx) ?[]const u8 {
     };
 }
 
-test "checkedOp maps every integer arithmetic operation and skips non-integers" {
+test "checkedOp maps integer arithmetic and checked Dec absolute value" {
     try std.testing.expectEqual(LIR.LowLevel.num_plus_checked, checkedOp(.num_plus, .u8).?);
     try std.testing.expectEqual(LIR.LowLevel.num_minus_checked, checkedOp(.num_minus, .i16).?);
     try std.testing.expectEqual(LIR.LowLevel.num_times_checked, checkedOp(.num_times, .u32).?);
@@ -194,10 +205,12 @@ test "checkedOp maps every integer arithmetic operation and skips non-integers" 
     try std.testing.expectEqual(LIR.LowLevel.num_mod_by_checked, checkedOp(.num_mod_by, .i128).?);
     try std.testing.expectEqual(LIR.LowLevel.num_negate_checked, checkedOp(.num_negate, .i32).?);
     try std.testing.expectEqual(LIR.LowLevel.num_abs_checked, checkedOp(.num_abs, .i64).?);
+    try std.testing.expectEqual(LIR.LowLevel.num_abs_checked, checkedOp(.num_abs, .dec).?);
 
     try std.testing.expectEqual(@as(?LIR.LowLevel, null), checkedOp(.num_plus, .f64));
     try std.testing.expectEqual(@as(?LIR.LowLevel, null), checkedOp(.num_abs, .u64));
     try std.testing.expectEqual(@as(?LIR.LowLevel, null), checkedOp(.num_negate, .u128));
+    try std.testing.expectEqual(@as(?LIR.LowLevel, null), checkedOp(.num_plus, .dec));
 }
 
 test "lowerOp preserves explicit wrapping arithmetic" {
@@ -206,6 +219,7 @@ test "lowerOp preserves explicit wrapping arithmetic" {
     try std.testing.expectEqual(LIR.LowLevel.num_times, lowerOp(.num_times_wrap, .u128));
     try std.testing.expectEqual(LIR.LowLevel.num_plus_checked, lowerOp(.num_plus, .u8));
     try std.testing.expectEqual(LIR.LowLevel.num_plus, lowerOp(.num_plus, .f64));
+    try std.testing.expectEqual(LIR.LowLevel.num_abs_checked, lowerOp(.num_abs, .dec));
 }
 
 test "checkedOp round trips through uncheckedOp" {
@@ -235,6 +249,7 @@ test "checked arithmetic messages are canonical and operation specific" {
     try std.testing.expectEqualStrings("Integer absolute value overflowed", overflowMessage(.num_abs_checked).?);
     try std.testing.expectEqualStrings("Integer division overflowed", overflowMessage(.num_div_by_checked).?);
     try std.testing.expectEqualStrings("Integer division overflowed", overflowMessage(.num_div_trunc_by_checked).?);
+    try std.testing.expectEqualStrings("Decimal absolute value overflow!", overflowMessageForLayout(.num_abs_checked, .dec).?);
 
     const cases = [_]struct {
         layout_idx: layout.Idx,

--- a/src/postcheck/lambda_mono/eval.zig
+++ b/src/postcheck/lambda_mono/eval.zig
@@ -1567,7 +1567,10 @@ pub const Evaluator = struct {
                 return .{ .dec = result.value.num };
             },
             .negate => return .{ .dec = -%a },
-            .abs => return .{ .dec = if (a < 0) -%a else a },
+            .abs => {
+                if (a == std.math.minInt(i128)) return self.crashAbort("Decimal absolute value overflow!");
+                return .{ .dec = if (a < 0) -a else a };
+            },
             .abs_diff => return .{ .dec = if (a > b) a -% b else b -% a },
             .div => return .{ .dec = try self.decDiv(a, b) },
             .div_trunc => return .{ .dec = decTrunc(try self.decDiv(a, b)) },
@@ -1590,26 +1593,20 @@ pub const Evaluator = struct {
         if (a == 0) return 0;
 
         const one = RocDec.one_point_zero_i128;
-        const max_i128: u128 = @intCast(std.math.maxInt(i128));
         const is_negative = (a < 0) != (b < 0);
         const numerator = absU128(a);
-        if (numerator > max_i128) {
-            if (b == one) return a;
-            return self.crashAbort("Decimal division overflow in numerator!");
-        }
-
         const denominator = absU128(b);
-        if (denominator > max_i128) {
-            if (a == one) return b;
-            return self.crashAbort("Decimal division overflow in denominator!");
-        }
 
         const scaled: u256 = @as(u256, numerator) * @as(u256, @intCast(one));
         const quotient: u256 = scaled / @as(u256, denominator);
-        if (quotient > @as(u256, max_i128)) return self.crashAbort("Decimal division overflow!");
+        const limit: u256 = if (is_negative)
+            @as(u256, 1) << 127
+        else
+            @as(u256, @intCast(std.math.maxInt(i128)));
+        if (quotient > limit) return self.crashAbort("Decimal division overflow!");
 
-        const magnitude: i128 = @intCast(quotient);
-        return if (is_negative) -magnitude else magnitude;
+        const magnitude: u128 = @intCast(quotient);
+        return if (is_negative) @bitCast(0 -% magnitude) else @intCast(magnitude);
     }
 
     // transcendental / rounding


### PR DESCRIPTION
Dec division now keeps signedness separate from its unsigned magnitude calculation, allowing `Dec.lowest` to use the existing wide arithmetic path while applying the correct sign-dependent result limits. This also makes `Dec.abs(Dec.lowest)` overflow consistently with signed integers and makes Dec-to-integer rounding operate on raw attoseconds so boundary results do not require an unrepresentable intermediate Dec.

Closes #10563.