### PR TITLE
Fix possible package cache corruption

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -6345,13 +6345,16 @@ fn resolveUrlBundle(ctx: *CliCtx, url: []const u8) (CliError || error{OutOfMemor
     };
     const package_dir_path = try std.fs.path.join(ctx.arena, &.{ cache_dir_path, base58_hash });
 
-    // 3. Check if already cached
+    const platform_source_path = try std.fs.path.join(ctx.arena, &.{ package_dir_path, "main.roc" });
+
+    // 3. Check if already cached. The check is the bundle's main.roc entry
+    // point rather than its directory: this cache is shared with the
+    // compiler's package resolution, whose rule is that a hash-named
+    // directory holds a complete bundle. A directory without its entry point
+    // is a leftover from an interrupted extraction, and gets replaced during
+    // publishing below rather than trusted.
     const already_cached = blk: {
-        var d = std.Io.Dir.cwd().openDir(ctx.io.std_io, package_dir_path, .{}) catch |err| switch (err) {
-            error.FileNotFound => break :blk false,
-            else => return ctx.fail(.{ .directory_not_found = .{ .path = package_dir_path } }),
-        };
-        d.close(ctx.io.std_io);
+        std.Io.Dir.cwd().access(ctx.io.std_io, platform_source_path, .{}) catch break :blk false;
         break :blk true;
     };
 
@@ -6366,33 +6369,36 @@ fn resolveUrlBundle(ctx: *CliCtx, url: []const u8) (CliError || error{OutOfMemor
                 .err = make_err,
             } });
         };
+        sweepStalePackageStagingDirs(ctx.io.std_io, cache_dir_path);
 
-        // Create package directory
-        std.Io.Dir.cwd().createDir(ctx.io.std_io, package_dir_path, .default_dir) catch |make_err| switch (make_err) {
-            error.PathAlreadyExists => {}, // Race condition, another process created it
-            else => {
-                return ctx.fail(.{ .directory_create_failed = .{
-                    .path = package_dir_path,
-                    .err = make_err,
-                } });
-            },
+        // Download into a staging directory and publish it with a rename, so
+        // the hash-named directory never exists half-written. Other processes
+        // read this cache while we fill it, and a directory under the hash is
+        // their only signal that the bundle is complete.
+        const staging_dir_path = try packageStagingDirPath(ctx, package_dir_path);
+        std.Io.Dir.cwd().createDir(ctx.io.std_io, staging_dir_path, .default_dir) catch |make_err| {
+            return ctx.fail(.{ .directory_create_failed = .{
+                .path = staging_dir_path,
+                .err = make_err,
+            } });
         };
 
         // Download and extract (path-based, no Dir handle needed)
         var gpa_copy = ctx.gpa;
-        _ = download.downloadAndExtract(&gpa_copy, ctx.io.std_io, url, package_dir_path, .{}) catch |download_err| {
-            std.Io.Dir.cwd().deleteTree(ctx.io.std_io, package_dir_path) catch {};
+        _ = download.downloadAndExtract(&gpa_copy, ctx.io.std_io, url, staging_dir_path, .{}) catch |download_err| {
+            std.Io.Dir.cwd().deleteTree(ctx.io.std_io, staging_dir_path) catch {};
             return ctx.fail(.{ .download_failed = .{
                 .url = url,
                 .err = download_err,
             } });
         };
 
+        try publishPackageDir(ctx, url, staging_dir_path, package_dir_path, platform_source_path);
+
         std.log.info("Bundle cached at {s}", .{package_dir_path});
     }
 
     // Platforms must have a main.roc entry point
-    const platform_source_path = try std.fs.path.join(ctx.arena, &.{ package_dir_path, "main.roc" });
     std.Io.Dir.cwd().access(ctx.io.std_io, platform_source_path, .{}) catch {
         // The problem is rendered after this frame returns, so the slice of
         // searched paths must live on the arena, not this stack frame.
@@ -6407,6 +6413,87 @@ fn resolveUrlBundle(ctx: *CliCtx, url: []const u8) (CliError || error{OutOfMemor
     return .{
         .source_path = platform_source_path,
     };
+}
+
+/// A staging path next to the final hash-named directory, so publishing is a
+/// rename within one directory rather than a copy across filesystems. The
+/// random component keeps concurrent downloads of the same bundle out of
+/// each other's way, and the `.tmp` suffix is what the stale sweep matches.
+fn packageStagingDirPath(ctx: *CliCtx, package_dir_path: []const u8) error{OutOfMemory}![]u8 {
+    var suffix: [8]u8 = undefined;
+    ctx.io.std_io.random(&suffix);
+    return std.fmt.allocPrint(ctx.arena, "{s}.{s}.tmp", .{ package_dir_path, std.fmt.bytesToHex(suffix, .lower) });
+}
+
+/// Move a finished staging directory into its hash-named slot in the package
+/// cache. Mirrors the publish step of the compiler's package resolution,
+/// which shares this cache: losing the rename to a concurrent process is
+/// success, since bundles are content-addressed and hash-verified, and a
+/// slot holding a directory with no entry point is an interrupted
+/// extraction's leftover that gets moved aside and deleted. Moving rather
+/// than deleting in place matters when a concurrent process publishes a good
+/// copy between our check and our repair: a rename cannot tear that copy
+/// out from under whoever is already reading it.
+fn publishPackageDir(
+    ctx: *CliCtx,
+    url: []const u8,
+    staging_dir_path: []const u8,
+    package_dir_path: []const u8,
+    entry_point_path: []const u8,
+) (CliError || error{OutOfMemory})!void {
+    std.Io.Dir.cwd().rename(staging_dir_path, std.Io.Dir.cwd(), package_dir_path, ctx.io.std_io) catch {
+        const entry_point_exists = exists: {
+            std.Io.Dir.cwd().access(ctx.io.std_io, entry_point_path, .{}) catch break :exists false;
+            break :exists true;
+        };
+        if (entry_point_exists) {
+            std.Io.Dir.cwd().deleteTree(ctx.io.std_io, staging_dir_path) catch {};
+            return;
+        }
+
+        const trash_dir_path = try packageStagingDirPath(ctx, package_dir_path);
+        std.Io.Dir.cwd().rename(package_dir_path, std.Io.Dir.cwd(), trash_dir_path, ctx.io.std_io) catch {};
+        defer std.Io.Dir.cwd().deleteTree(ctx.io.std_io, trash_dir_path) catch {};
+        std.Io.Dir.cwd().rename(staging_dir_path, std.Io.Dir.cwd(), package_dir_path, ctx.io.std_io) catch |rename_err| {
+            std.Io.Dir.cwd().deleteTree(ctx.io.std_io, staging_dir_path) catch {};
+            // Someone published in the gap between that move and this retry.
+            // Their copy is as good as ours.
+            const published_by_another = published: {
+                std.Io.Dir.cwd().access(ctx.io.std_io, entry_point_path, .{}) catch break :published false;
+                break :published true;
+            };
+            if (published_by_another) return;
+            return ctx.fail(.{ .download_failed = .{
+                .url = url,
+                .err = rename_err,
+            } });
+        };
+    };
+}
+
+/// Reclaim package cache staging directories stranded by processes that died
+/// mid-download. Nothing ever reads them again, and one older than a day
+/// cannot belong to a live download. The compiler's package resolution runs
+/// the same sweep over this cache with the same naming scheme, so either
+/// downloader cleans up after the other. Best-effort: any failure just
+/// leaves the sweep to a future download.
+fn sweepStalePackageStagingDirs(std_io: std.Io, cache_dir_path: []const u8) void {
+    var dir = std.Io.Dir.cwd().openDir(std_io, cache_dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(std_io);
+
+    const now_ns: i128 = std.Io.Timestamp.now(std_io, .real).nanoseconds;
+    var it = dir.iterate();
+    while (true) {
+        const entry = (it.next(std_io) catch break) orelse break;
+        if (entry.kind != .directory) continue;
+        if (!std.mem.endsWith(u8, entry.name, ".tmp")) continue;
+
+        const info = dir.statFile(std_io, entry.name, .{}) catch continue;
+        const mtime_ns: i128 = @intCast(info.mtime.nanoseconds);
+        if (now_ns - mtime_ns <= stale_staging_max_age_ns) continue;
+
+        dir.deleteTree(std_io, entry.name) catch {};
+    }
 }
 
 /// Default output basename for `roc build <url>`: the last path segment of

--- a/src/compile/package_resolution.zig
+++ b/src/compile/package_resolution.zig
@@ -1804,7 +1804,7 @@ pub const CtxFetcher = struct {
             if (!std.mem.endsWith(u8, entry.path, ".tmp")) continue;
             const info = self.fs.stat(entry.path) catch continue;
             const mtime = info.mtime_ns orelse continue;
-            if (now - mtime < stale_staging_ns) continue;
+            if (now - mtime <= stale_staging_ns) continue;
             self.fs.deleteTree(entry.path) catch {};
         }
     }

--- a/src/compile/package_resolution.zig
+++ b/src/compile/package_resolution.zig
@@ -1814,13 +1814,9 @@ pub const CtxFetcher = struct {
     /// component keeps concurrent downloads of the same package out of each
     /// other's way.
     fn stagingDirPath(self: *CtxFetcher, allocator: Allocator, package_dir: []const u8) Allocator.Error![]u8 {
-        const charset = "abcdefghijklmnopqrstuvwxyz0123456789";
-        var suffix: [16]u8 = undefined;
+        var suffix: [8]u8 = undefined;
         self.fs.std_io.random(&suffix);
-        for (&suffix) |*byte| {
-            byte.* = charset[byte.* % charset.len];
-        }
-        return std.fmt.allocPrint(allocator, "{s}.{s}.tmp", .{ package_dir, suffix });
+        return std.fmt.allocPrint(allocator, "{s}.{s}.tmp", .{ package_dir, std.fmt.bytesToHex(suffix, .lower) });
     }
 
     fn loadLocalImpl(ctx: ?*anyopaque, allocator: Allocator, root_file_abs: []const u8) FetchError!FetchedPackage {

--- a/src/compile/package_resolution.zig
+++ b/src/compile/package_resolution.zig
@@ -31,6 +31,13 @@
 //! Roc headers. Sidecars record only immutable facts about a bundle - never
 //! resolution outcomes, which are global and recomputed every build.
 //!
+//! The cache is shared with every other process on the machine, so bundles are
+//! extracted into a private staging directory and moved into their final
+//! hash-named directory with a rename. A directory named after a hash means
+//! the package under it is complete, never that some other process started
+//! downloading it. Staging directories orphaned by a killed process are
+//! swept once they are a day old.
+//!
 //! As a defense against decompression bombs, each package bundle's expanded
 //! size is limited (platforms are exempt, since an app declares exactly one
 //! platform on purpose), and the combined content size attributable to any
@@ -1665,24 +1672,7 @@ pub const CtxFetcher = struct {
         var expanded_bytes: ?u64 = null;
 
         if (!self.fs.fileExists(root_file)) {
-            if (!self.fs.fileExists(package_dir)) {
-                self.fs.makePath(cache_dir) catch return error.DownloadFailed;
-                self.fs.createDir(package_dir) catch |err| switch (err) {
-                    // Possibly a concurrent process created it; extraction
-                    // below will sort out whether it is usable.
-                    error.IoError => {},
-                    error.OutOfMemory => return error.OutOfMemory,
-                    else => return error.DownloadFailed,
-                };
-                expanded_bytes = self.fs.fetchUrl(self.gpa, url, package_dir, max_expanded_bytes) catch |err| {
-                    self.fs.deleteTree(package_dir) catch {};
-                    return switch (err) {
-                        error.OutOfMemory => error.OutOfMemory,
-                        error.ExpandedSizeLimitExceeded => error.ExpandedSizeLimitExceeded,
-                        else => error.DownloadFailed,
-                    };
-                };
-            }
+            expanded_bytes = try self.downloadAndPublish(allocator, url, cache_dir, package_dir, root_file, max_expanded_bytes);
             if (!self.fs.fileExists(root_file)) {
                 // Bundles must have a main.roc entry point.
                 return error.FileNotFound;
@@ -1707,6 +1697,130 @@ pub const CtxFetcher = struct {
         };
 
         return scanned;
+    }
+
+    /// Download `url` into a staging directory of our own and move it into
+    /// `package_dir` once it is complete.
+    ///
+    /// Extracting straight into `package_dir` would publish the package the
+    /// moment the download started rather than when it finished, and every
+    /// other process reads this cache while we write it. A concurrent `roc`
+    /// would find the directory, take it for a finished download, and either
+    /// miss `main.roc` and report the package as broken or read a module that
+    /// has not been written yet. Renaming a finished directory into place is
+    /// atomic, so `package_dir` never exists in a half-built state.
+    ///
+    /// Returns the expanded size of the bundle, or null when the package was
+    /// already in place, in which case the tar stream size is unknown and the
+    /// caller derives the size from the extracted content instead.
+    fn downloadAndPublish(
+        self: *CtxFetcher,
+        allocator: Allocator,
+        url: []const u8,
+        cache_dir: []const u8,
+        package_dir: []const u8,
+        root_file: []const u8,
+        max_expanded_bytes: ?u64,
+    ) FetchError!?u64 {
+        self.fs.makePath(cache_dir) catch return error.DownloadFailed;
+        self.sweepStaleStaging(allocator, cache_dir);
+
+        const staging_dir = try self.stagingDirPath(allocator, package_dir);
+        self.fs.createDir(staging_dir) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.DownloadFailed,
+        };
+
+        const expanded_bytes = self.fs.fetchUrl(self.gpa, url, staging_dir, max_expanded_bytes) catch |err| {
+            self.fs.deleteTree(staging_dir) catch {};
+            return switch (err) {
+                error.OutOfMemory => error.OutOfMemory,
+                error.ExpandedSizeLimitExceeded => error.ExpandedSizeLimitExceeded,
+                else => error.DownloadFailed,
+            };
+        };
+
+        const published = try self.publish(allocator, staging_dir, package_dir, root_file);
+        return if (published) expanded_bytes else null;
+    }
+
+    /// Move a finished staging directory into its final slot in the cache.
+    /// Returns false when the package turned out to be there already, in
+    /// which case the staging copy has been discarded.
+    fn publish(self: *CtxFetcher, allocator: Allocator, staging_dir: []const u8, package_dir: []const u8, root_file: []const u8) FetchError!bool {
+        self.fs.rename(staging_dir, package_dir) catch {
+            // Losing this rename means another process published the same
+            // hash first, which costs nothing: bundles are content-addressed
+            // and the hash is verified while extracting, so their bytes are
+            // our bytes.
+            if (self.fs.fileExists(root_file)) {
+                self.fs.deleteTree(staging_dir) catch {};
+                return false;
+            }
+
+            // Otherwise the slot holds a directory with no entry point in it,
+            // left by an interrupted extraction or by a compiler old enough
+            // to have extracted in place. Nothing can ever resolve against
+            // it, so replace it rather than leave the cache poisoned until
+            // someone deletes it by hand.
+            //
+            // Replace it by moving it aside, not by deleting it in place. A
+            // concurrent process may publish a good copy between the check
+            // above and here, and deleting that copy would tear it out from
+            // under whoever is already reading it, file by file. With two
+            // renames the slot is only ever empty for the instant between
+            // them.
+            const trash_dir = try self.stagingDirPath(allocator, package_dir);
+            self.fs.rename(package_dir, trash_dir) catch {};
+            defer self.fs.deleteTree(trash_dir) catch {};
+            self.fs.rename(staging_dir, package_dir) catch {
+                self.fs.deleteTree(staging_dir) catch {};
+                // Someone published in the gap between that move and this
+                // retry. Their copy is as good as ours.
+                if (self.fs.fileExists(root_file)) return false;
+                return error.DownloadFailed;
+            };
+        };
+        return true;
+    }
+
+    /// How old a staging directory must be before a sweep may delete it.
+    /// Far longer than any download lives, so age alone proves abandonment.
+    const stale_staging_ns: i128 = 24 * std.time.ns_per_hour;
+
+    /// Delete staging directories left behind by processes that died before
+    /// publishing or cleaning up. Nothing ever reads them again, they only
+    /// cost disk. Only directories older than `stale_staging_ns` go, since a
+    /// younger one may belong to a download still in flight. Best effort:
+    /// a sweep that fails costs nothing but the disk it would have freed.
+    fn sweepStaleStaging(self: *CtxFetcher, allocator: Allocator, cache_dir: []const u8) void {
+        // Staging directories only ever sit directly under the cache
+        // directory, so the sweep never needs to walk into the cached
+        // packages themselves.
+        const entries = self.fs.listDirTop(cache_dir, allocator) catch return;
+        const now = self.fs.timestampNow();
+        for (entries) |entry| {
+            if (entry.kind != .directory) continue;
+            if (!std.mem.endsWith(u8, entry.path, ".tmp")) continue;
+            const info = self.fs.stat(entry.path) catch continue;
+            const mtime = info.mtime_ns orelse continue;
+            if (now - mtime < stale_staging_ns) continue;
+            self.fs.deleteTree(entry.path) catch {};
+        }
+    }
+
+    /// A staging path next to the final one, so publishing is a rename within
+    /// a single directory rather than a copy across filesystems. The random
+    /// component keeps concurrent downloads of the same package out of each
+    /// other's way.
+    fn stagingDirPath(self: *CtxFetcher, allocator: Allocator, package_dir: []const u8) Allocator.Error![]u8 {
+        const charset = "abcdefghijklmnopqrstuvwxyz0123456789";
+        var suffix: [16]u8 = undefined;
+        self.fs.std_io.random(&suffix);
+        for (&suffix) |*byte| {
+            byte.* = charset[byte.* % charset.len];
+        }
+        return std.fmt.allocPrint(allocator, "{s}.{s}.tmp", .{ package_dir, suffix });
     }
 
     fn loadLocalImpl(ctx: ?*anyopaque, allocator: Allocator, root_file_abs: []const u8) FetchError!FetchedPackage {
@@ -3058,4 +3172,290 @@ test "the reserved 0.0.0 version is rejected" {
 
     try std.testing.expectError(error.ResolutionFailed, resolver.resolve("/app/main.roc"));
     try std.testing.expectEqualStrings("Invalid Package Version", resolver.diagnostics.items[0].title);
+}
+
+/// Stands in for a real download in the `CtxFetcher` cache tests: writes a
+/// package bundle's worth of files into whatever directory it is handed.
+///
+/// The knobs are globals because `fetchUrl` is a bare function pointer in the
+/// `CoreCtx` vtable, with nowhere to hang per-test state. The tests using them
+/// run in one thread, one after another.
+const StubDownload = struct {
+    const main_roc = "package [Thing] {}\n";
+
+    /// Number of downloads that have been attempted.
+    var attempts: usize = 0;
+    /// Whether the download should fail instead of extracting anything.
+    var fails: bool = false;
+    /// A directory to fill in before extracting, standing in for a second
+    /// process that finishes its download while ours is still running.
+    var published_by_another: ?[]const u8 = null;
+    /// A path to look for mid-download, standing in for what a second process
+    /// would see while ours is still running, and what that look found.
+    var watched: ?[]const u8 = null;
+    var watched_existed: bool = false;
+
+    fn reset() void {
+        attempts = 0;
+        fails = false;
+        published_by_another = null;
+        watched = null;
+        watched_existed = false;
+    }
+
+    fn fetchUrl(
+        _: ?*anyopaque,
+        io: std.Io,
+        allocator: Allocator,
+        _: []const u8,
+        dest_path: []const u8,
+        _: ?u64,
+    ) CoreCtx.FetchUrlError!u64 {
+        const fs = CoreCtx.default(allocator, allocator, io);
+
+        attempts += 1;
+        if (watched) |path| {
+            watched_existed = fs.fileExists(path);
+        }
+        if (fails) return error.DownloadFailed;
+
+        if (published_by_another) |dir| {
+            fs.makePath(dir) catch return error.DownloadFailed;
+            extractInto(fs, allocator, dir) catch return error.DownloadFailed;
+        }
+
+        extractInto(fs, allocator, dest_path) catch return error.DownloadFailed;
+        return main_roc.len;
+    }
+
+    fn extractInto(fs: CoreCtx, allocator: Allocator, dir: []const u8) (Allocator.Error || CoreCtx.WriteError)!void {
+        const path = try std.fs.path.join(allocator, &.{ dir, "main.roc" });
+        defer allocator.free(path);
+        try fs.writeFile(path, main_roc);
+    }
+};
+
+/// A fake clock for the cache tests, so a test can make a staging directory
+/// look abandoned without waiting a day. Starts at the real current time and
+/// only moves when a test pushes it.
+const StubClock = struct {
+    var now: i128 = 0;
+
+    fn timestampNow(_: ?*anyopaque, _: std.Io) i128 {
+        return now;
+    }
+};
+
+/// A `CtxFetcher` over a real temp directory, with downloads stubbed out.
+const CacheTestHarness = struct {
+    tmp: std.testing.TmpDir,
+    cache_dir: []const u8,
+    fetcher: CtxFetcher,
+    gpa: Allocator,
+
+    const hash = "1234567890abcdefghijkLMNOPQRSTUVWXYZ23456789";
+    const url = "https://example.com/thing/1.0.0/" ++ hash ++ ".tar.zst";
+
+    /// `gpa` must be an arena: paths here outlive the calls that make them,
+    /// and none of them are freed individually.
+    fn init(gpa: Allocator) std.Io.Dir.RealPathFileAllocError!CacheTestHarness {
+        StubDownload.reset();
+
+        var tmp = std.testing.tmpDir(.{});
+        errdefer tmp.cleanup();
+
+        const cache_dir = try tmp.dir.realPathFileAlloc(std.testing.io, ".", gpa);
+        var fs = CoreCtx.default(gpa, gpa, std.testing.io);
+        StubClock.now = fs.timestampNow();
+        fs.vtable.fetchUrl = &StubDownload.fetchUrl;
+        fs.vtable.timestampNow = &StubClock.timestampNow;
+
+        return .{
+            .tmp = tmp,
+            .cache_dir = cache_dir,
+            .fetcher = .{ .fs = fs, .gpa = gpa, .cache_packages_dir = cache_dir },
+            .gpa = gpa,
+        };
+    }
+
+    fn deinit(self: *CacheTestHarness) void {
+        self.tmp.cleanup();
+    }
+
+    fn fetch(self: *CacheTestHarness, allocator: Allocator) FetchError!FetchedPackage {
+        return CtxFetcher.fetchUrlImpl(&self.fetcher, allocator, url, hash, null);
+    }
+
+    fn packageDir(self: *CacheTestHarness, allocator: Allocator) Allocator.Error![]u8 {
+        return std.fs.path.join(allocator, &.{ self.cache_dir, hash });
+    }
+
+    /// Names of the cache directory's immediate children, so a test can assert
+    /// on what a fetch left behind rather than only on what it returned.
+    fn entryNames(self: *CacheTestHarness, allocator: Allocator) (Allocator.Error || CoreCtx.ListError)![][]const u8 {
+        const entries = try self.fetcher.fs.listDirTop(self.cache_dir, allocator);
+        var names: std.ArrayList([]const u8) = .empty;
+        for (entries) |entry| {
+            try names.append(allocator, std.fs.path.basename(entry.path));
+        }
+        return names.toOwnedSlice(allocator);
+    }
+
+    fn hasEntry(self: *CacheTestHarness, allocator: Allocator, name: []const u8) (Allocator.Error || CoreCtx.ListError)!bool {
+        for (try self.entryNames(allocator)) |entry| {
+            if (std.mem.eql(u8, entry, name)) return true;
+        }
+        return false;
+    }
+};
+
+test "a downloaded package is published under its hash" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const gpa = arena.allocator();
+
+    var harness = try CacheTestHarness.init(gpa);
+    defer harness.deinit();
+
+    const fetched = try harness.fetch(gpa);
+
+    try std.testing.expectEqual(HeaderKind.package, fetched.kind);
+    try std.testing.expect(try harness.hasEntry(gpa, CacheTestHarness.hash));
+
+    // The staging directory is an implementation detail that must not outlive
+    // the download, so nothing beyond the package and its sidecar is left.
+    const names = try harness.entryNames(gpa);
+    try std.testing.expectEqual(@as(usize, 2), names.len);
+    try std.testing.expect(try harness.hasEntry(gpa, CacheTestHarness.hash ++ ".deps.json"));
+}
+
+test "a package directory does not appear until the download is complete" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const gpa = arena.allocator();
+
+    var harness = try CacheTestHarness.init(gpa);
+    defer harness.deinit();
+
+    // Look for the package's own directory from inside the download, which is
+    // what a second `roc` racing this one would see.
+    StubDownload.watched = try harness.packageDir(gpa);
+
+    _ = try harness.fetch(gpa);
+
+    // A directory under the hash is the only signal other processes have that
+    // this package is cached and usable. It appearing while the bundle is
+    // still being written is what makes them read a package that is missing
+    // its entry point, or missing modules that arrive later in the stream.
+    try std.testing.expect(!StubDownload.watched_existed);
+}
+
+test "a failed download leaves no package directory behind" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const gpa = arena.allocator();
+
+    var harness = try CacheTestHarness.init(gpa);
+    defer harness.deinit();
+
+    StubDownload.fails = true;
+
+    try std.testing.expectError(error.DownloadFailed, harness.fetch(gpa));
+
+    // A directory named after the hash means "this package is cached and
+    // complete" to every other process on the machine, so a download that
+    // never produced one must not leave it, nor its staging directory.
+    const names = try harness.entryNames(gpa);
+    try std.testing.expectEqual(@as(usize, 0), names.len);
+}
+
+test "a package another process published first is used as-is" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const gpa = arena.allocator();
+
+    var harness = try CacheTestHarness.init(gpa);
+    defer harness.deinit();
+
+    // Publish the package while our own download is in flight, which is what
+    // a second `roc` racing us on a cold cache does.
+    StubDownload.published_by_another = try harness.packageDir(gpa);
+
+    const fetched = try harness.fetch(gpa);
+
+    try std.testing.expectEqual(HeaderKind.package, fetched.kind);
+
+    // Losing that race is not an error, and it leaves no staging directory.
+    const names = try harness.entryNames(gpa);
+    try std.testing.expectEqual(@as(usize, 2), names.len);
+    try std.testing.expect(try harness.hasEntry(gpa, CacheTestHarness.hash));
+}
+
+test "a package directory with no entry point is replaced" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const gpa = arena.allocator();
+
+    var harness = try CacheTestHarness.init(gpa);
+    defer harness.deinit();
+
+    // What killing a compiler partway through an extraction used to leave:
+    // a directory under the package's hash with no `main.roc` in it. It can
+    // never resolve, so a later build has to replace it instead of trusting
+    // the name.
+    try harness.tmp.dir.createDir(std.testing.io, CacheTestHarness.hash, .default_dir);
+    try harness.tmp.dir.writeFile(std.testing.io, .{
+        .sub_path = CacheTestHarness.hash ++ "/Partial.roc",
+        .data = "module []\n",
+    });
+
+    const fetched = try harness.fetch(gpa);
+
+    try std.testing.expectEqual(HeaderKind.package, fetched.kind);
+    try std.testing.expectEqual(@as(usize, 1), StubDownload.attempts);
+
+    // Replaced rather than merged: the half-extracted file is gone.
+    const package_dir = try harness.packageDir(gpa);
+    try std.testing.expect(harness.fetcher.fs.fileExists(try std.fs.path.join(gpa, &.{ package_dir, "main.roc" })));
+    try std.testing.expect(!harness.fetcher.fs.fileExists(try std.fs.path.join(gpa, &.{ package_dir, "Partial.roc" })));
+}
+
+test "a staging directory abandoned by a dead process is swept after a day" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const gpa = arena.allocator();
+
+    var harness = try CacheTestHarness.init(gpa);
+    defer harness.deinit();
+
+    // What a download whose process was killed leaves behind: a staging
+    // directory that nothing will ever publish or delete.
+    const orphan = CacheTestHarness.hash ++ ".orphanorphanorph.tmp";
+    try harness.tmp.dir.createDir(std.testing.io, orphan, .default_dir);
+
+    StubClock.now += 25 * std.time.ns_per_hour;
+
+    _ = try harness.fetch(gpa);
+
+    try std.testing.expect(!try harness.hasEntry(gpa, orphan));
+    try std.testing.expect(try harness.hasEntry(gpa, CacheTestHarness.hash));
+}
+
+test "a staging directory younger than a day is not swept" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const gpa = arena.allocator();
+
+    var harness = try CacheTestHarness.init(gpa);
+    defer harness.deinit();
+
+    // The same orphan, but young enough to be a download still in flight in
+    // another process. Sweeping it would break that download, so it stays.
+    const orphan = CacheTestHarness.hash ++ ".orphanorphanorph.tmp";
+    try harness.tmp.dir.createDir(std.testing.io, orphan, .default_dir);
+
+    _ = try harness.fetch(gpa);
+
+    try std.testing.expect(try harness.hasEntry(gpa, orphan));
+    try std.testing.expect(try harness.hasEntry(gpa, CacheTestHarness.hash));
 }

--- a/src/ctx/CoreCtx.zig
+++ b/src/ctx/CoreCtx.zig
@@ -60,6 +60,12 @@ pub const VTable = struct {
     /// Caller owns the returned slice and every `.path` string in it.
     listDir: *const fn (?*anyopaque, std.Io, []const u8, Allocator) ListError![]FileEntry,
 
+    /// List only the immediate children of `path`, without descending into
+    /// them. Caller owns the returned slice and every `.path` string in it.
+    /// Defaults to an error so backends with no real directory to scan
+    /// need not implement it.
+    listDirTop: *const fn (?*anyopaque, std.Io, []const u8, Allocator) ListError![]FileEntry = &missingListDirTop,
+
     /// Return the directory portion of a path, or `null` if there is none.
     /// No allocation — returns a slice into the input.
     dirName: *const fn (?*anyopaque, std.Io, []const u8) ?[]const u8,
@@ -212,6 +218,13 @@ pub fn getFileInfo(self: Self, path: []const u8) StatError!FileInfo {
 /// and every `.path` string in it (free with `allocator`).
 pub fn listDir(self: Self, path: []const u8, allocator: Allocator) ListError![]FileEntry {
     return self.vtable.listDir(self.ctx, self.std_io, path, allocator);
+}
+
+/// List only the immediate children of `path`, without descending into them.
+/// Caller owns the returned slice and every `.path` string in it (free with
+/// `allocator`).
+pub fn listDirTop(self: Self, path: []const u8, allocator: Allocator) ListError![]FileEntry {
+    return self.vtable.listDirTop(self.ctx, self.std_io, path, allocator);
 }
 
 /// Return the directory portion of a path (no allocation).
@@ -505,6 +518,7 @@ const os_vtable = VTable{
     .fileExists = &osFileExists,
     .stat = &osStat,
     .listDir = &osListDir,
+    .listDirTop = &osListDirTop,
     .dirName = &osDirName,
     .baseName = &osBaseName,
     .joinPath = &osJoinPath,
@@ -535,6 +549,7 @@ const testing_vtable = VTable{
     .fileExists = &testingFileExists,
     .stat = &testingStat,
     .listDir = &testingListDir,
+    .listDirTop = &testingListDirTop,
     .dirName = &testingDirName,
     .baseName = &testingBaseName,
     .joinPath = &testingJoinPath,
@@ -720,6 +735,39 @@ fn osListDir(_: ?*anyopaque, std_io: std.Io, path: []const u8, allocator: Alloca
     return entries.toOwnedSlice(allocator) catch return error.OutOfMemory;
 }
 
+fn osListDirTop(_: ?*anyopaque, std_io: std.Io, path: []const u8, allocator: Allocator) ListError![]FileEntry {
+    var dir = std.Io.Dir.cwd().openDir(std_io, path, .{ .iterate = true }) catch |err| return switch (err) {
+        error.FileNotFound => error.FileNotFound,
+        error.AccessDenied => error.AccessDenied,
+        else => error.IoError,
+    };
+    defer dir.close(std_io);
+
+    var entries: std.ArrayList(FileEntry) = .empty;
+    errdefer {
+        for (entries.items) |entry| allocator.free(entry.path);
+        entries.deinit(allocator);
+    }
+
+    var it = dir.iterate();
+    while (true) {
+        const next = it.next(std_io) catch return error.IoError;
+        const entry = next orelse break;
+        const kind: FileKind = switch (entry.kind) {
+            .file => .file,
+            .directory => .directory,
+            else => .other,
+        };
+        const owned_path = std.fs.path.join(allocator, &.{ path, entry.name }) catch return error.OutOfMemory;
+        entries.append(allocator, .{ .path = owned_path, .kind = kind }) catch {
+            allocator.free(owned_path);
+            return error.OutOfMemory;
+        };
+    }
+
+    return entries.toOwnedSlice(allocator) catch return error.OutOfMemory;
+}
+
 fn osDirName(_: ?*anyopaque, _: std.Io, path: []const u8) ?[]const u8 {
     return std.fs.path.dirname(path);
 }
@@ -804,6 +852,10 @@ fn osQueryEnvVar(_: ?*anyopaque, _: std.Io, key: [:0]const u8, query: EnvVarQuer
 
 fn missingEnvVarQuery(_: ?*anyopaque, _: std.Io, _: [:0]const u8, _: EnvVarQuery) bool {
     return false;
+}
+
+fn missingListDirTop(_: ?*anyopaque, _: std.Io, _: []const u8, _: Allocator) ListError![]FileEntry {
+    return error.FileNotFound;
 }
 
 /// fetchUrl is intentionally a stub in the default OS vtable.
@@ -930,6 +982,10 @@ fn testingStat(_: ?*anyopaque, _: std.Io, _: []const u8) StatError!FileInfo {
 
 fn testingListDir(_: ?*anyopaque, _: std.Io, _: []const u8, _: Allocator) ListError![]FileEntry {
     @panic("listDir should not be called in this test");
+}
+
+fn testingListDirTop(_: ?*anyopaque, _: std.Io, _: []const u8, _: Allocator) ListError![]FileEntry {
+    @panic("listDirTop should not be called in this test");
 }
 
 fn testingDirName(_: ?*anyopaque, _: std.Io, path: []const u8) ?[]const u8 {


### PR DESCRIPTION
I was noticing issues with package downloads in CI (e.g. https://github.com/niclas-ahden/roc-playwright/actions/runs/30859480366/job/91841723757).

The problem was that I had several Roc apps compiling and downloading packages at the same time. Package bundles were extracted directly into their final hash-named cache directory, so the directory existed from the moment a download started. Any other roc process racing on a cold cache would find it, assume the bundle was complete, and either fail on a missing main.roc or read modules that had not been extracted yet. A process killed mid-extraction left the directory behind permanently, poisoning the cache until someone deleted it by hand. This is the cause of the package corruption we saw in CI.

Downloads now extract into a randomly named <hash>.<rand>.tmp staging directory and are published with an atomic rename, so a hash-named directory always means a complete bundle. Losing the rename race to another process is treated as success, since bundles are content-addressed and hash-verified. A leftover directory without its entry point is repaired by moving it aside and renaming the fresh copy in, rather than deleting in place, so a concurrently published good copy is never torn out from under a reader. Both the CLI bundle resolver and the compiler's package resolution get the same scheme, since they share the cache.

Staging directories orphaned by killed processes are swept once they are older than a day, well past any live download. To keep that sweep from walking every file of every cached package, CoreCtx gains a listDirTop that lists only a directory's immediate children. The vtable field defaults to a stub so the WASM and freestanding backends need no changes.

New tests cover the invariants directly: the package directory never exists half-written (observed from inside a stubbed download), failed downloads leave nothing behind, lost races are not errors, broken entries are replaced rather than merged, and the sweep respects the age threshold via a fake clock.