### PR TITLE
Support exponent notation in integer and Dec from_str

### DIFF
--- a/src/builtins/dec.zig
+++ b/src/builtins/dec.zig
@@ -6,6 +6,7 @@
 //! without floating-point precision issues.
 const std = @import("std");
 const i128h = @import("compiler_rt_128.zig");
+const decimal_parse = @import("decimal_parse.zig");
 
 const U256 = @import("num.zig").U256;
 const TestEnv = @import("utils.zig").TestEnv;
@@ -213,83 +214,7 @@ pub const RocDec = extern struct {
 
     // This a separate function because the compiler uses it.
     pub fn fromNonemptySlice(roc_str_slice: []const u8) ?RocDec {
-        const length = roc_str_slice.len;
-        const is_negative: bool = roc_str_slice[0] == '-';
-        const initial_index: usize = @intFromBool(is_negative);
-
-        var point_index: ?usize = null;
-        var index: usize = initial_index;
-        while (index < length) {
-            const byte: u8 = roc_str_slice[index];
-            if (byte == '.' and point_index == null) {
-                point_index = index;
-                index += 1;
-                continue;
-            }
-
-            if (!isDigit(byte)) {
-                return null;
-            }
-            index += 1;
-        }
-
-        // Sign is folded into the magnitude before multiplication and addition,
-        // rather than negating at the end. This is required for the lowest Dec
-        // value: its magnitude is 2^127, which overflows positive i128 even
-        // though -2^127 is itself representable.
-        var before_str_length = length;
-        var after_val_i128: ?i128 = null;
-        if (point_index) |point_idx| {
-            before_str_length = point_idx;
-
-            const after_str_len = (length - 1) - point_idx;
-            if (after_str_len > decimal_places) {
-                // More than 18 fractional digits cannot be represented exactly.
-                return null;
-            }
-            const diff_decimal_places = decimal_places - after_str_len;
-
-            const after_str = roc_str_slice[point_idx + 1 .. length];
-            const after_u64 = @import("num.zig").parseUnsignedDecimal(u64, after_str);
-            if (after_u64) |f| {
-                const unsigned = i128h.mul_i128(@as(i128, @intCast(f)), i128h.pow10_i128(@intCast(diff_decimal_places)));
-                after_val_i128 = if (is_negative) -unsigned else unsigned;
-            }
-        }
-
-        const before_str = roc_str_slice[initial_index..before_str_length];
-        var before_val_i128: ?i128 = null;
-        if (before_str.len > 0) {
-            const before = @import("num.zig").parseUnsignedDecimal(i128, before_str) orelse return null;
-            const signed_before: i128 = if (is_negative) -before else before;
-            const mul_ans = @import("num.zig").mulWithOverflow(i128, signed_before, one_point_zero_i128);
-            if (mul_ans.has_overflowed) {
-                // The whole-number part is outside Dec's scaled i128 range.
-                return null;
-            }
-            before_val_i128 = mul_ans.value;
-        }
-
-        if (before_val_i128) |before| {
-            if (after_val_i128) |after| {
-                const answer = @addWithOverflow(before, after);
-                if (answer[1] == 1) {
-                    // Combining whole and fractional parts exceeded Dec's range.
-                    return null;
-                }
-                return .{ .num = answer[0] };
-            } else {
-                return .{ .num = before };
-            }
-        } else if (after_val_i128) |after| {
-            return .{ .num = after };
-        } else {
-            return null;
-        }
-    }
-
-    inline fn isDigit(c: u8) bool {
-        return (c -% 48) <= 9;
+        return .{ .num = decimal_parse.parseScaledI128(roc_str_slice, decimal_places) orelse return null };
     }
 
     /// Format this Dec value into the provided buffer, returning the slice containing the result.
@@ -1847,6 +1772,14 @@ test "F32 and Dec convert directly without binary64 intermediates" {
     );
 }
 
+fn expectParseDecText(text: []const u8, expected: ?i128, roc_ops: *RocOps) error{TestExpectedEqual}!void {
+    const roc_str = RocStr.fromSlice(text, roc_ops);
+    defer roc_str.decref(roc_ops);
+
+    const expected_dec: ?RocDec = if (expected) |num| .{ .num = num } else null;
+    try std.testing.expectEqual(expected_dec, RocDec.fromStr(roc_str));
+}
+
 test "fromStr: empty" {
     var test_env = TestEnv.init(std.testing.allocator);
     defer test_env.deinit();
@@ -1875,6 +1808,52 @@ test "fromStr: 123.45" {
     const dec = RocDec.fromStr(roc_str);
 
     try std.testing.expectEqual(RocDec{ .num = 123450000000000000000 }, dec.?);
+}
+
+test "fromStr: decimal exponent notation issue 10550" {
+    var test_env = TestEnv.init(std.testing.allocator);
+    defer test_env.deinit();
+
+    // Repro for https://github.com/roc-lang/roc/issues/10550.
+    try expectParseDecText("2e5", 200_000_000_000_000_000_000_000, test_env.getOps());
+    try expectParseDecText("+2E5", 200_000_000_000_000_000_000_000, test_env.getOps());
+    try expectParseDecText("2_0e4", 200_000_000_000_000_000_000_000, test_env.getOps());
+    try expectParseDecText("1.25e2", 125_000_000_000_000_000_000, test_env.getOps());
+    try expectParseDecText("1e-18", 1, test_env.getOps());
+    try expectParseDecText("10e-19", 1, test_env.getOps());
+    try expectParseDecText("1e-19", null, test_env.getOps());
+    try expectParseDecText("0e999999999999999999999999999999999999", 0, test_env.getOps());
+    try expectParseDecText("0e-999999999999999999999999999999999999", 0, test_env.getOps());
+}
+
+test "fromStr: exponent notation preserves exact Dec boundaries" {
+    var test_env = TestEnv.init(std.testing.allocator);
+    defer test_env.deinit();
+
+    try expectParseDecText("170141183460469231731687303715884105727e-18", std.math.maxInt(i128), test_env.getOps());
+    try expectParseDecText("-170141183460469231731687303715884105728e-18", std.math.minInt(i128), test_env.getOps());
+    try expectParseDecText("170141183460469231731687303715884105728e-18", null, test_env.getOps());
+    try expectParseDecText("-170141183460469231731687303715884105729e-18", null, test_env.getOps());
+
+    try expectParseDecText(
+        "0.123456789012345678000000000000000000000000000000000000000000",
+        123_456_789_012_345_678,
+        test_env.getOps(),
+    );
+    try expectParseDecText(
+        "0.123456789012345678000000000000000000000000000000000000000001",
+        null,
+        test_env.getOps(),
+    );
+}
+
+test "fromStr: rejects malformed decimal exponent notation" {
+    var test_env = TestEnv.init(std.testing.allocator);
+    defer test_env.deinit();
+
+    inline for (.{ "e5", ".e5", "2e", "2e+", "2_e5", "2e_5", "2e5_", "2ee5", "2e5.0" }) |text| {
+        try expectParseDecText(text, null, test_env.getOps());
+    }
 }
 
 test "fromStr: .45" {

--- a/src/builtins/decimal_parse.zig
+++ b/src/builtins/decimal_parse.zig
@@ -1,0 +1,254 @@
+//! Allocation-free parsing and exact conversion of decimal text.
+
+const std = @import("std");
+
+const max_u128_before_mul_10 = std.math.maxInt(u128) / 10;
+const max_u128_last_digit = std.math.maxInt(u128) % 10;
+
+const ParsedDecimal = struct {
+    negative: bool,
+    had_decimal_point: bool,
+    mantissa_end: usize,
+    coefficient_digits: usize,
+    fractional_digits: usize,
+    leading_zero_digits: usize,
+    trailing_zero_digits: usize,
+    coefficient: u128,
+    coefficient_overflow: bool,
+    exponent_negative: bool,
+    exponent_magnitude: u64,
+    exponent_overflow: bool,
+
+    fn isZero(self: ParsedDecimal) bool {
+        return self.leading_zero_digits == self.coefficient_digits;
+    }
+};
+
+/// Parse decimal syntax into exact coefficient-and-scale facts.
+/// Underscores are accepted only between decimal digits.
+fn scan(bytes: []const u8) ?ParsedDecimal {
+    if (bytes.len == 0) return null;
+
+    var index: usize = 0;
+    const negative = bytes[index] == '-';
+    if (bytes[index] == '-' or bytes[index] == '+') {
+        index += 1;
+        if (index == bytes.len) return null;
+    }
+
+    var had_decimal_point = false;
+    var saw_digit = false;
+    var previous_was_digit = false;
+    var coefficient_digits: usize = 0;
+    var fractional_digits: usize = 0;
+    var leading_zero_digits: usize = 0;
+    var trailing_zero_digits: usize = 0;
+    var saw_nonzero = false;
+    var coefficient: u128 = 0;
+    var coefficient_overflow = false;
+
+    while (index < bytes.len) : (index += 1) {
+        const byte = bytes[index];
+        switch (byte) {
+            '0'...'9' => {
+                const digit = byte - '0';
+                saw_digit = true;
+                previous_was_digit = true;
+                coefficient_digits += 1;
+                if (had_decimal_point) fractional_digits += 1;
+
+                if (!saw_nonzero and digit == 0) {
+                    leading_zero_digits += 1;
+                } else {
+                    saw_nonzero = true;
+                }
+                trailing_zero_digits = if (digit == 0) trailing_zero_digits + 1 else 0;
+
+                if (!coefficient_overflow) {
+                    if (coefficient > max_u128_before_mul_10 or
+                        (coefficient == max_u128_before_mul_10 and digit > max_u128_last_digit))
+                    {
+                        coefficient_overflow = true;
+                    } else {
+                        coefficient = coefficient * 10 + digit;
+                    }
+                }
+            },
+            '_' => {
+                if (!previous_was_digit or index + 1 == bytes.len or !isDigit(bytes[index + 1])) return null;
+                previous_was_digit = false;
+            },
+            '.' => {
+                if (had_decimal_point or (!previous_was_digit and saw_digit)) return null;
+                had_decimal_point = true;
+                previous_was_digit = false;
+            },
+            'e', 'E' => break,
+            else => return null,
+        }
+    }
+
+    if (!saw_digit or (index > 0 and bytes[index - 1] == '_')) return null;
+    const mantissa_end = index;
+
+    var exponent_negative = false;
+    var exponent_magnitude: u64 = 0;
+    var exponent_overflow = false;
+    if (index < bytes.len) {
+        index += 1;
+        if (index == bytes.len) return null;
+        if (bytes[index] == '-' or bytes[index] == '+') {
+            exponent_negative = bytes[index] == '-';
+            index += 1;
+            if (index == bytes.len) return null;
+        }
+
+        var exponent_saw_digit = false;
+        previous_was_digit = false;
+        while (index < bytes.len) : (index += 1) {
+            const byte = bytes[index];
+            if (isDigit(byte)) {
+                const digit = byte - '0';
+                exponent_saw_digit = true;
+                previous_was_digit = true;
+                if (!exponent_overflow) {
+                    if (exponent_magnitude > (std.math.maxInt(u64) - @as(u64, digit)) / 10) {
+                        exponent_overflow = true;
+                    } else {
+                        exponent_magnitude = exponent_magnitude * 10 + digit;
+                    }
+                }
+            } else if (byte == '_') {
+                if (!previous_was_digit or index + 1 == bytes.len or !isDigit(bytes[index + 1])) return null;
+                previous_was_digit = false;
+            } else {
+                return null;
+            }
+        }
+        if (!exponent_saw_digit or !previous_was_digit) return null;
+    }
+
+    return .{
+        .negative = negative,
+        .had_decimal_point = had_decimal_point,
+        .mantissa_end = mantissa_end,
+        .coefficient_digits = coefficient_digits,
+        .fractional_digits = fractional_digits,
+        .leading_zero_digits = leading_zero_digits,
+        .trailing_zero_digits = trailing_zero_digits,
+        .coefficient = coefficient,
+        .coefficient_overflow = coefficient_overflow,
+        .exponent_negative = exponent_negative,
+        .exponent_magnitude = exponent_magnitude,
+        .exponent_overflow = exponent_overflow,
+    };
+}
+
+fn isDigit(byte: u8) bool {
+    return byte >= '0' and byte <= '9';
+}
+
+fn appendDecimalZeros(comptime limit: u128, initial: u128, count: usize) ?u128 {
+    const max_before_mul = limit / 10;
+    var value = initial;
+    if (value > limit) return null;
+
+    var remaining = count;
+    while (remaining > 0) : (remaining -= 1) {
+        if (value > max_before_mul) return null;
+        value *= 10;
+    }
+    return value;
+}
+
+fn parseCoefficientPrefix(comptime limit: u128, bytes: []const u8, parsed: ParsedDecimal, keep_digits: usize) ?u128 {
+    var index: usize = @intFromBool(bytes[0] == '-' or bytes[0] == '+');
+    var consumed: usize = 0;
+    var value: u128 = 0;
+    const max_before_mul = limit / 10;
+    const max_digit = limit % 10;
+
+    while (index < parsed.mantissa_end and consumed < keep_digits) : (index += 1) {
+        const byte = bytes[index];
+        if (!isDigit(byte)) continue;
+        const digit = byte - '0';
+        if (value > max_before_mul or (value == max_before_mul and digit > max_digit)) return null;
+        value = value * 10 + digit;
+        consumed += 1;
+    }
+    std.debug.assert(consumed == keep_digits);
+    return value;
+}
+
+fn positiveExponent(parsed: ParsedDecimal) ?usize {
+    if (parsed.exponent_negative and (parsed.exponent_overflow or parsed.exponent_magnitude != 0)) return null;
+    if (parsed.exponent_overflow or parsed.exponent_magnitude > 38) return null;
+    return @intCast(parsed.exponent_magnitude);
+}
+
+/// Parse an exact integer. Decimal points and negative effective exponents are
+/// rejected, matching Roc numeric-literal integer conversion semantics.
+pub fn parseInt(comptime T: type, bytes: []const u8) ?T {
+    const info = @typeInfo(T).int;
+    const parsed = scan(bytes) orelse return null;
+    if (parsed.had_decimal_point) return null;
+
+    const zeros = positiveExponent(parsed) orelse {
+        if (!parsed.exponent_negative and parsed.isZero()) return 0;
+        return null;
+    };
+    if (parsed.coefficient_overflow) return null;
+
+    const positive_limit: u128 = @intCast(std.math.maxInt(T));
+    const magnitude = if (info.signedness == .signed and parsed.negative)
+        appendDecimalZeros(positive_limit + 1, parsed.coefficient, zeros) orelse return null
+    else
+        appendDecimalZeros(positive_limit, parsed.coefficient, zeros) orelse return null;
+
+    if (info.signedness == .unsigned) {
+        if (parsed.negative and magnitude != 0) return null;
+        return @intCast(magnitude);
+    }
+    if (!parsed.negative) return @intCast(magnitude);
+
+    const negative_limit = positive_limit + 1;
+    if (magnitude == negative_limit) return std.math.minInt(T);
+    return -@as(T, @intCast(magnitude));
+}
+
+fn scaledMagnitude(comptime limit: u128, bytes: []const u8, parsed: ParsedDecimal, decimal_places: u8) ?u128 {
+    if (parsed.isZero()) return 0;
+    if (parsed.exponent_overflow) return null;
+
+    const exponent: i128 = if (parsed.exponent_negative)
+        -@as(i128, @intCast(parsed.exponent_magnitude))
+    else
+        @intCast(parsed.exponent_magnitude);
+    const scale = exponent - @as(i128, @intCast(parsed.fractional_digits)) + decimal_places;
+
+    if (scale >= 0) {
+        if (scale > 38 or parsed.coefficient_overflow) return null;
+        return appendDecimalZeros(limit, parsed.coefficient, @intCast(scale));
+    }
+
+    const drop: i128 = -scale;
+    if (drop > @as(i128, @intCast(parsed.trailing_zero_digits))) return null;
+    const drop_digits: usize = @intCast(drop);
+    const keep_digits = parsed.coefficient_digits - drop_digits;
+    return parseCoefficientPrefix(limit, bytes, parsed, keep_digits);
+}
+
+/// Parse a decimal value into a signed i128 scaled by `10^decimal_places`.
+/// Values are accepted only when the scaled result is exact and in range.
+pub fn parseScaledI128(bytes: []const u8, comptime decimal_places: u8) ?i128 {
+    const parsed = scan(bytes) orelse return null;
+    const positive_limit: u128 = @intCast(std.math.maxInt(i128));
+    const magnitude = if (parsed.negative)
+        scaledMagnitude(positive_limit + 1, bytes, parsed, decimal_places) orelse return null
+    else
+        scaledMagnitude(positive_limit, bytes, parsed, decimal_places) orelse return null;
+
+    if (!parsed.negative) return @intCast(magnitude);
+    if (magnitude == positive_limit + 1) return std.math.minInt(i128);
+    return -@as(i128, @intCast(magnitude));
+}

--- a/src/builtins/mod.zig
+++ b/src/builtins/mod.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 
 pub const builtin_registry = @import("builtin_registry.zig");
 pub const compiler_rt_128 = @import("compiler_rt_128.zig");
+pub const decimal_parse = @import("decimal_parse.zig");
 pub const native_runtime_libcalls = @import("native_runtime_libcalls.zig");
 pub const host_abi = @import("host_abi.zig");
 pub const shim_symbols = @import("shim_symbols.zig");
@@ -26,6 +27,7 @@ test "builtins tests" {
     std.testing.refAllDecls(@import("builtin_registry.zig"));
     std.testing.refAllDecls(@import("crypto.zig"));
     std.testing.refAllDecls(@import("dec.zig"));
+    std.testing.refAllDecls(@import("decimal_parse.zig"));
     std.testing.refAllDecls(@import("dev_wrappers.zig"));
     std.testing.refAllDecls(@import("erased_callable.zig"));
     std.testing.refAllDecls(@import("float_bits.zig"));

--- a/src/builtins/num.zig
+++ b/src/builtins/num.zig
@@ -8,6 +8,7 @@
 const std = @import("std");
 const i128h = @import("compiler_rt_128.zig");
 const parse_float = @import("vendor_parse_float");
+const decimal_parse = @import("decimal_parse.zig");
 const float_bits = @import("float_bits.zig");
 const float_math_f32 = @import("float_math/f32.zig");
 const float_math_f64 = @import("float_math/f64.zig");
@@ -88,7 +89,15 @@ pub fn mul_u128(a: u128, b: u128) U256 {
 
 /// Parses an integer from a RocStr
 pub fn parseIntFromStr(comptime T: type, buf: RocStr) NumParseResult(T) {
-    if (parseIntNoFmt(T, buf.asSlice())) |success| {
+    const bytes = buf.asSlice();
+    const parsed = if (hasExplicitRadix(bytes))
+        parseIntNoFmt(T, bytes)
+    else if (decimal_parse.parseInt(T, bytes)) |value|
+        value
+    else
+        error.InvalidCharacter;
+
+    if (parsed) |success| {
         return .{ .errorcode = 0, .value = success };
     } else |_| {
         return .{ .errorcode = 1, .value = 0 };
@@ -99,6 +108,16 @@ const ParseIntError = error{
     InvalidCharacter,
     Overflow,
 };
+
+fn hasExplicitRadix(bytes: []const u8) bool {
+    if (bytes.len == 0) return false;
+    const start: usize = @intFromBool(bytes[0] == '-' or bytes[0] == '+');
+    if (bytes.len - start < 2 or bytes[start] != '0') return false;
+    return switch (bytes[start + 1]) {
+        'b', 'B', 'o', 'O', 'x', 'X' => true,
+        else => false,
+    };
+}
 
 fn parseIntNoFmt(comptime T: type, bytes: []const u8) ParseIntError!T {
     if (bytes.len == 0) return error.InvalidCharacter;
@@ -1329,6 +1348,43 @@ test "parseIntFromStr validates radix prefixes and underscores at boundaries" {
     try expectParseIntReject(i32, "_1", test_env.getOps());
     try expectParseIntReject(i32, "1__0", test_env.getOps());
     try expectParseIntReject(i32, "10_", test_env.getOps());
+}
+
+test "parseIntFromStr accepts decimal exponent notation issue 10550" {
+    var test_env = TestEnv.init(std.testing.allocator);
+    defer test_env.deinit();
+
+    // Repro for https://github.com/roc-lang/roc/issues/10550.
+    try expectParseIntText(u32, "2e5", 200_000, test_env.getOps());
+
+    inline for (.{ u8, u16, u32, u64, u128, i8, i16, i32, i64, i128 }) |T| {
+        try expectParseIntText(T, "2e1", 20, test_env.getOps());
+        try expectParseIntText(T, "+2E1", 20, test_env.getOps());
+    }
+
+    inline for (.{ i8, i16, i32, i64, i128 }) |T| {
+        try expectParseIntText(T, "-2e1", -20, test_env.getOps());
+    }
+
+    try expectParseIntText(u64, "2e1_0", 20_000_000_000, test_env.getOps());
+    try expectParseIntText(u32, "4294967295e0", std.math.maxInt(u32), test_env.getOps());
+    try expectParseIntText(i128, "-170141183460469231731687303715884105728e0", std.math.minInt(i128), test_env.getOps());
+    try expectParseIntText(u128, "340282366920938463463374607431768211455e0", std.math.maxInt(u128), test_env.getOps());
+    try expectParseIntText(u8, "0e999999999999999999999999999999999999", 0, test_env.getOps());
+}
+
+test "parseIntFromStr rejects fractional malformed and overflowing exponent notation" {
+    var test_env = TestEnv.init(std.testing.allocator);
+    defer test_env.deinit();
+
+    inline for (.{ "2e-1", "20e-1", "2.0e5", "2e", "2e+", "2_e5", "2e_5", "2e5_", "2ee5" }) |text| {
+        try expectParseIntReject(i64, text, test_env.getOps());
+    }
+
+    try expectParseIntReject(u32, "4294967296e0", test_env.getOps());
+    try expectParseIntReject(u32, "4294967295e1", test_env.getOps());
+    try expectParseIntReject(i128, "-170141183460469231731687303715884105729e0", test_env.getOps());
+    try expectParseIntReject(u128, "340282366920938463463374607431768211456e0", test_env.getOps());
 }
 
 test "integer overflow helpers match Zig overflow intrinsics across widths" {

--- a/src/eval/test/eval_low_level_tests.zig
+++ b/src/eval/test/eval_low_level_tests.zig
@@ -1990,6 +1990,23 @@ pub const tests = [_]TestCase{
         .expected = .{ .inspect_str = "\"12.5\"" },
     },
     .{
+        .name = "low_level - exact from_str accepts exponent notation issue 10550",
+        .source =
+        \\{
+        \\u32 = match U32.from_str("2e5") {
+        \\    Ok(value) => U32.to_str(value)
+        \\    Err(_) => "bad int"
+        \\}
+        \\dec = match Dec.from_str("2e5") {
+        \\    Ok(value) => Dec.to_str(value)
+        \\    Err(_) => "bad dec"
+        \\}
+        \\"${u32}:${dec}"
+        \\}
+        ,
+        .expected = .{ .inspect_str = "\"200000:200000.0\"" },
+    },
+    .{
         .name = "low_level - I64.from_str preserves explicit error path",
         .source =
         \\{


### PR DESCRIPTION
Integer and Dec `from_str` now accept base-10 exponent notation consistently with numeric literals. This introduces an allocation-free exact decimal scanner that checks target bounds and applies Dec scaling directly, while preserving radix-prefixed integer parsing and rejecting fractional integer values, inexact Dec values, malformed input, and overflow.

Fixes #10550