### PR TITLE
Use interned IDs for import deduplication

### DIFF
--- a/src/canonicalize/CIR.zig
+++ b/src/canonicalize/CIR.zig
@@ -863,39 +863,30 @@ pub const Import = struct {
             self.map.deinit(allocator);
         }
 
-        /// Get or create an Import.Idx for the given module name.
-        /// The module name is first checked against existing imports by comparing strings.
-        /// New imports are initially unresolved (unresolved).
+        /// Get or create an Import.Idx for the given module name in a fresh CommonEnv.
+        /// New imports are initially unresolved.
         /// If ident_idx is provided, it will be stored for index-based lookups.
         pub fn getOrPut(self: *Store, allocator: std.mem.Allocator, common: *base.CommonEnv, module_name: []const u8) Allocator.Error!Import.Idx {
             return self.getOrPutWithIdent(allocator, common, module_name, null);
         }
 
-        /// Get or create an Import.Idx for the given module name, with an associated ident.
-        /// The module name is first checked against existing imports by comparing strings.
-        /// New imports are initially unresolved (unresolved).
+        /// Get or create an Import.Idx for the given module name in a fresh CommonEnv,
+        /// with an associated ident. New imports are initially unresolved.
         /// If ident_idx is provided, it will be stored for index-based lookups.
         pub fn getOrPutWithIdent(self: *Store, allocator: std.mem.Allocator, common: *base.CommonEnv, module_name: []const u8, ident_idx: ?base.Ident.Idx) Allocator.Error!Import.Idx {
-            // First check if we already have this module name by comparing strings
-            for (self.imports.items.items, 0..) |existing_string_idx, i| {
-                const existing_name = common.getString(existing_string_idx);
-                if (std.mem.eql(u8, existing_name, module_name)) {
-                    // Found existing import with same name
-                    // Update ident if provided and not already set
-                    if (ident_idx) |ident| {
-                        if (i < self.import_idents.len()) {
-                            const current = self.import_idents.items.items[i];
-                            if (current.isNone()) {
-                                self.import_idents.items.items[i] = ident;
-                            }
-                        }
+            const string_idx = try common.insertString(allocator, module_name);
+
+            if (self.map.get(string_idx)) |idx| {
+                if (ident_idx) |ident| {
+                    const i = @intFromEnum(idx);
+                    if (i < self.import_idents.len() and self.import_idents.items.items[i].isNone()) {
+                        self.import_idents.items.items[i] = ident;
                     }
-                    return @as(Import.Idx, @enumFromInt(i));
                 }
+
+                return idx;
             }
 
-            // Not found - create new import
-            const string_idx = try common.insertString(allocator, module_name);
             const idx = @as(Import.Idx, @enumFromInt(self.imports.len()));
 
             // Add to both the list and the map, with unresolved module initially

--- a/src/canonicalize/CIR.zig
+++ b/src/canonicalize/CIR.zig
@@ -865,7 +865,6 @@ pub const Import = struct {
 
         /// Get or create an Import.Idx for the given module name in a fresh CommonEnv.
         /// New imports are initially unresolved.
-        /// If ident_idx is provided, it will be stored for index-based lookups.
         pub fn getOrPut(self: *Store, allocator: std.mem.Allocator, common: *base.CommonEnv, module_name: []const u8) Allocator.Error!Import.Idx {
             return self.getOrPutWithIdent(allocator, common, module_name, null);
         }

--- a/src/canonicalize/test/import_store_test.zig
+++ b/src/canonicalize/test/import_store_test.zig
@@ -51,6 +51,27 @@ test "Import.Store deduplicates module names" {
     try testing.expect(storeContainsModule(&store, &common, "other.Module"));
 }
 
+test "Import.Store deduplicates through interned string indices" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+
+    var common = try CommonEnv.init(gpa, "");
+    defer common.deinit(gpa);
+
+    var store = Import.Store.init();
+    defer store.deinit(gpa);
+
+    const string_idx = try common.insertString(gpa, "test.Module");
+    const import_idx = try store.getOrPut(gpa, &common, "test.Module");
+    const ident_idx = try common.insertIdent(gpa, base.Ident.for_text("Module"));
+    const duplicate_idx = try store.getOrPutWithIdent(gpa, &common, "test.Module", ident_idx);
+
+    try testing.expectEqual(import_idx, duplicate_idx);
+    try testing.expectEqual(string_idx, store.imports.items.items[@intFromEnum(import_idx)]);
+    try testing.expectEqual(import_idx, store.map.get(string_idx).?);
+    try testing.expectEqual(ident_idx, store.getIdentIdx(import_idx).?);
+}
+
 test "Import.Store empty CompactWriter roundtrip" {
     const testing = std.testing;
     const gpa = testing.allocator;

--- a/src/compile/test/module_env_test.zig
+++ b/src/compile/test/module_env_test.zig
@@ -169,19 +169,11 @@ test "ModuleEnv.Serialized roundtrip" {
     // Verify that the map was repopulated correctly
     try testing.expectEqual(@as(usize, 2), env.imports.map.count());
 
-    // Test that deduplication still works after deserialization for existing keys.
-    // Note: the deserialized StringLiteral.Store points into the cache buffer and
-    // cannot be grown (SafeList.deserializeInto contract), so we only test lookup
-    // of already-serialized strings here.
-    var test_arena = collections.SingleThreadArena.init(gpa);
-    defer test_arena.deinit();
-    const test_alloc = test_arena.allocator();
-
-    const import4 = try env.imports.getOrPut(test_alloc, &env.common, "json.Json");
-
-    // Should find existing json.Json (deduplication)
-    try testing.expectEqual(@as(u32, 0), @intFromEnum(import4));
-    try testing.expectEqual(@as(usize, 2), env.imports.imports.len());
+    // The deserialized StringLiteral.Store is immutable, so cached import lookup
+    // uses the serialized string index rather than reinterning its bytes.
+    const json_string_idx = env.imports.imports.items.items[0];
+    const import_json_cached = env.imports.map.get(json_string_idx).?;
+    try testing.expectEqual(@as(u32, 0), @intFromEnum(import_json_cached));
 }
 
 test "ModuleEnv.Serialized finalizes method metadata tables before writing" {


### PR DESCRIPTION
Import deduplication currently scans and compares every previously imported module name even though CommonEnv already interns those bytes and Import.Store already maintains an ID-keyed map. Use the transient string builder's stable store-local ID for direct lookup during fresh canonicalization, while keeping deserialized string stores immutable and looking up their rebuilt maps by serialized ID.