### PR TITLE
Fix ARC owned field-take specialization

### DIFF
--- a/design.md
+++ b/design.md
@@ -5657,16 +5657,26 @@ The proc call graph is derived from the lifted `assign_call` statements. The
 parameter/return solver projects local definitions and static demands,
 pure-alias edges, direct-call argument dependencies, reachable return locals,
 and join bodies from the same lift. No signature round rescans a proc body.
+`RcSig` represents procedure argument positions zero through fifteen in one
+`u16`; every refcounted parameter at position sixteen or later has the exact
+all-owned signature. Functions retain arbitrary arity. The all-owned tail is a
+declared ARC capability boundary: it consumes and releases every unit exactly,
+but does not participate in borrow inference, borrowed-return lender masks,
+unique-parameter seeding, or mode specialization. A return whose only possible
+lender is in that tail therefore remains owned. Low-level `RcEffect` argument
+masks are a separate `u64` domain and do not inherit this boundary.
+
 Signatures solve in two phases:
 
 1. Parameter modes reach a fixpoint with returns treated as owned: non-pinned
-   refcounted parameter positions start borrowed and flip to owned when any
-   occurrence demands a unit under the current signatures. One work item is
-   one exact `(callee, parameter position)` bit that just flipped. Its reverse
-   adjacency contains precisely the caller argument locals newly demanded by
-   that flip; those demands propagate through explicit pure-alias edges and
-   may enqueue their owning parameter bits. Every bit flips at most once, so
-   the borrowed set only shrinks and the worklist terminates.
+   refcounted parameter positions within the represented prefix start borrowed
+   and flip to owned when any occurrence demands a unit under the current
+   signatures. One work item is one exact `(callee, parameter position)` bit
+   that just flipped. Its reverse adjacency contains precisely the caller
+   argument locals newly demanded by that flip; those demands propagate through
+   explicit pure-alias edges and may enqueue their owning parameter bits. Every
+   bit flips at most once, so the borrowed set only shrinks and the worklist
+   terminates.
 2. With parameter modes final, a return becomes borrowed when every `ret`
    in the proc returns a borrow anchored on a borrowed parameter of that
    proc, with the parameter positions recorded as the return's lenders. A
@@ -5851,17 +5861,20 @@ deleted, and an owned use of a borrowed return pays an `incref`. Mode
 specialization removes that adaptation cost by emitting one proc variant per
 demanded mode vector.
 
-A demand vector assigns each refcounted param position a mode at or above
-the solved signature (pointwise more owned). Return positions are never
+A demand vector assigns each represented refcounted param position a mode at
+or above the solved signature (pointwise more owned); tail positions remain
+owned. Return positions are never
 demanded: a borrowed return that the caller needs owned pays one retain, and
 that retain costs the same whether it is emitted in the caller or inside an
 owned-returning variant, so no variant exists to save it. Specialization is
 a worklist keyed by `(proc, demand vector)`:
 
 1. Every proc is emitted once at its solved signature (the base variant).
-2. While emitting any proc, each `assign_call` site upgrades a borrowed
-   position to an owned demand exactly when the argument is an owned final
-   occurrence there: the upgrade turns a borrow-plus-later-drop into a move.
+2. While emitting any proc, an `assign_call` site with an owned final argument
+   upgrades a borrowed position exactly when ownership changes runtime work in
+   the callee: it owns a borrowed return, seeds a reachable uniqueness check,
+   or activates an exact owned-only field take. A release-only relocation does
+   not create a variant.
 3. The call site targets the `(callee, vector)` variant, creating it if new
    and re-emitting it from the callee's ownership-neutral body under the
    demanded vector. Inside the variant, demanded positions override the
@@ -5923,7 +5936,10 @@ A proc parameter solved borrowed qualifies conditionally: its takes are
 solved once against the shared ownership-neutral body but recorded as
 owned-only, applying exactly in emissions whose demand vector overrides that
 parameter to owned — the mode-specialized variants callers with dying
-arguments select. The base emission keeps the borrowed schedule untouched.
+arguments select. Dismantle analysis outputs the exact per-procedure `u16`
+parameter-benefit mask consumed by variant admission; the caller does not
+rediscover the benefit from field reads or uniqueness checks. The base emission
+keeps the borrowed schedule untouched.
 
 A field read of a qualifying container becomes a take when its result binding
 is owned, its result never flows into join-carried state, and the read lies

--- a/design.md
+++ b/design.md
@@ -5854,12 +5854,13 @@ certifier, never by weakening what it checks.
 
 ### Mode Specialization
 
-A proc's solved `RcSig` is the most-borrowed signature its body admits.
-Callers can always adapt to it, but adaptation has a cost: passing an owned
-value to a borrowed param keeps a caller-side drop that a move would have
-deleted, and an owned use of a borrowed return pays an `incref`. Mode
-specialization removes that adaptation cost by emitting one proc variant per
-demanded mode vector.
+Within its represented prefix, a proc's solved `RcSig` is the most-borrowed
+signature its body admits; its tail is all-owned by the declared boundary
+above. Callers can always adapt to the inferred prefix, but adaptation has a
+cost: passing an owned value to a borrowed param keeps a caller-side drop that
+a move would have deleted, and an owned use of a borrowed return pays an
+`incref`. Mode specialization removes that adaptation cost by emitting one proc
+variant per demanded mode vector.
 
 A demand vector assigns each represented refcounted param position a mode at
 or above the solved signature (pointwise more owned); tail positions remain

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -382,11 +382,11 @@ pub fn insert(store: *LirStore, layouts: *const layout_mod.Store, options: Inser
         const emit_params_for_overrides = store.getLocalSpan(emit_args);
         for (0..GuardedList.borrowLen(emit_params_for_overrides)) |position| {
             const param = GuardedList.at(emit_params_for_overrides, position);
-            if (position >= 64) break;
+            const bit = arc_sig.paramBit(position) orelse break;
             if (solved_sig.paramMode(position) == .borrowed and emit_sig.paramMode(position) == .owned) {
                 owned_param_override.set(param);
             }
-            if ((emit_sig.unique_params >> @as(u6, @intCast(position))) & 1 != 0) {
+            if ((emit_sig.unique_params & bit) != 0) {
                 unique_param_override.set(param);
             }
         }
@@ -456,10 +456,10 @@ pub fn insert(store: *LirStore, layouts: *const layout_mod.Store, options: Inser
 
 const VariantSelector = struct {
     source: LIR.LirProcSpecId,
-    borrowed_params: u64,
+    borrowed_params: arc_sig.ParamMask,
     ret_mode: arc_sig.Mode,
     /// Parameter positions the demand vector seeds born-unique.
-    unique_params: u64,
+    unique_params: arc_sig.ParamMask,
 };
 
 const QueuedVariant = struct {
@@ -3519,8 +3519,8 @@ const Inserter = struct {
         proc_id: LIR.LirProcSpecId,
         position: usize,
     ) bool {
-        if (position >= 64) return false;
-        return (self.solution.uniqueSeedMaskOf(proc_id) & argMaskBit(position)) != 0;
+        const bit = arc_sig.paramBit(position) orelse return false;
+        return (self.solution.uniqueSeedMaskOf(proc_id) & bit) != 0;
     }
 
     fn callArgOwnership(
@@ -3548,17 +3548,20 @@ const Inserter = struct {
                 // post-call release into a clone preserves the same RC work
                 // while growing live code.
                 if (!self.variants.enabled) continue;
-                if (position >= 64) continue;
+                const bit = arc_sig.paramBit(position) orelse continue;
                 const used_after_call = local != target and try self.groupUsedInPath(next, local, loop_keep);
                 const owner = self.solution.unitLocalOf(local);
                 const can_transfer = owned.contains(owner) and !used_after_call;
                 if (!can_transfer) continue;
-                const bit = @as(u64, 1) << @as(u6, @intCast(position));
                 const return_borrows_param = callee_sig.ret_mode == .borrowed and (callee_sig.ret_lenders & bit) != 0;
                 const seed_can_reach_check = if (callee) |direct| self.procParamCanUseUniqueSeed(direct, position) else false;
                 const seeds_unique_param = unique_demand and seed_can_reach_check and self.isLocalUniqueHere(local) and
                     !self.groupSharesOtherOperand(locals, position, local);
-                if (!return_borrows_param and !seeds_unique_param) continue;
+                const enables_field_take = if (callee) |direct|
+                    (self.dismantles.ownedOnlyParamBenefits(direct) & bit) != 0
+                else
+                    false;
+                if (!return_borrows_param and !seeds_unique_param and !enables_field_take) continue;
                 demanded.borrowed_params &= ~bit;
                 if (return_borrows_param) {
                     demanded.ret_mode = .owned;
@@ -3580,14 +3583,14 @@ const Inserter = struct {
                 // statically unique with no borrow live at the call demands
                 // a variant whose parameter is seeded born-unique, so
                 // checked ops it reaches in the body go check-free.
-                const seed_can_reach_check = if (position < 64) blk: {
+                const seed_can_reach_check = if (position < arc_sig.tracked_param_count) blk: {
                     const direct = callee orelse break :blk false;
                     break :blk self.procParamCanUseUniqueSeed(direct, position);
                 } else false;
                 if (unique_demand and seed_can_reach_check and self.isLocalUniqueHere(local) and
                     !self.groupSharesOtherOperand(locals, position, local))
                 {
-                    demanded.unique_params |= @as(u64, 1) << @as(u6, @intCast(position));
+                    demanded.unique_params |= arc_sig.paramBit(position).?;
                 }
                 owned.unset(owner);
             } else {
@@ -8703,6 +8706,71 @@ test "RC specialization: borrowed final argument does not clone for release-only
     try testing.expectEqual(base_proc_count, f.store.procSpecCount());
     try f.expectRc(value, 0, 1, 0);
     try f.expectRc(param, 0, 0, 0);
+}
+
+test "RC signature: position 16 uses the all-owned tail" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+
+    var params: [17]LIR.LocalId = undefined;
+    for (&params) |*param| param.* = try f.local(.str);
+    const result = try f.local(.i64);
+    const ret = try f.ret(result);
+    const body = try f.assignI64(result, 1, ret);
+    _ = try f.addProc(&params, body, .i64);
+
+    try f.run();
+
+    // Position 15 participates in inference and remains borrowed. Position
+    // 16 is outside RcSig's represented prefix and follows all-owned ARC.
+    try f.expectRc(params[15], 0, 0, 0);
+    try f.expectRc(params[16], 0, 1, 0);
+}
+
+test "RC specialization: owned-only field take demands an owned variant" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+
+    // Repro for https://github.com/roc-lang/roc/issues/10635: the callee's
+    // aggregate parameter solves borrowed, but an owned variant can take its
+    // nested list field instead of retaining it before the uniqueness check.
+    const param = try f.local(f.pair_list);
+    const field = try f.local(f.list_i64);
+    const elem = try f.local(.i64);
+    const appended = try f.local(f.list_i64);
+    const callee_result = try f.local(.i64);
+    const callee_ret = try f.ret(callee_result);
+    const result_assign = try f.assignI64(callee_result, 1, callee_ret);
+    const append = try f.assignLowLevel(appended, &.{ field, elem }, LIR.LowLevel.RcEffect.runtimeUniqueness(1), result_assign);
+    const elem_assign = try f.assignI64(elem, 5, append);
+    const field_read = try f.assignRefField(field, param, 0, elem_assign);
+    const callee = try f.addProc(&.{param}, field_read, .i64);
+
+    const first = try f.local(f.list_i64);
+    const second = try f.local(f.list_i64);
+    const pair = try f.local(f.pair_list);
+    const caller_result = try f.local(.i64);
+    const caller_ret = try f.ret(caller_result);
+    const call = try f.store.addCFStmt(.{ .assign_call = .{
+        .target = caller_result,
+        .proc = callee,
+        .args = try f.span(&.{pair}),
+        .next = caller_ret,
+    } });
+    const pair_assign = try f.assignStruct(pair, &.{ first, second }, call);
+    const second_assign = try f.assignList(second, &.{}, pair_assign);
+    const caller_body = try f.assignList(first, &.{}, second_assign);
+    _ = try f.addProc(&.{}, caller_body, .i64);
+
+    const base_proc_count = f.store.procSpecCount();
+    try insert(&f.store, &f.layouts, .{ .specialize = true });
+
+    // The caller moves the dying pair into an owned variant. The base proc
+    // retains the borrowed field once; the variant takes it without another
+    // retain, and dismantles only the pair's residual field.
+    try testing.expectEqual(base_proc_count + 1, f.store.procSpecCount());
+    try f.expectRc(pair, 0, 0, 0);
+    try testing.expectEqual(@as(usize, 1), f.countRc(field, .incref));
 }
 
 test "RC specialization: caller body survives variant proc append" {

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -490,9 +490,9 @@ fn paramSeededUnique(sig: arc_sig.RcSig, params: anytype, local: LIR.LocalId) bo
     if (sig.unique_params == 0) return false;
     for (0..GuardedList.borrowLen(params)) |position| {
         const param = GuardedList.at(params, position);
-        if (position >= 64) break;
+        const bit = arc_sig.paramBit(position) orelse break;
         if (param != local) continue;
-        return (sig.unique_params >> @as(u6, @intCast(position))) & 1 != 0;
+        return (sig.unique_params & bit) != 0;
     }
     return false;
 }
@@ -3533,7 +3533,7 @@ const Certifier = struct {
     ) CertifyError!void {
         const arg_locals = self.store.getLocalSpan(args);
 
-        var arg_values_buffer: [64]ValueId = undefined;
+        var arg_values_buffer: [arc_sig.tracked_param_count]ValueId = undefined;
         for (0..GuardedList.borrowLen(arg_locals)) |index| {
             const arg = GuardedList.at(arg_locals, index);
             const value = try self.requireLive(state, arg);
@@ -3559,12 +3559,11 @@ const Certifier = struct {
             switch (callee_sig.ret_mode) {
                 .owned => _ = try self.bindFresh(state, target, 1, &.{}),
                 .borrowed => {
-                    var lenders_buffer: [64]ValueId = undefined;
+                    var lenders_buffer: [arc_sig.tracked_param_count]ValueId = undefined;
                     var lender_count: usize = 0;
                     for (0..GuardedList.borrowLen(arg_locals)) |index| {
                         const arg = GuardedList.at(arg_locals, index);
-                        if (index >= 64) break;
-                        const bit = @as(u64, 1) << @as(u6, @intCast(index));
+                        const bit = arc_sig.paramBit(index) orelse break;
                         if ((callee_sig.ret_lenders & bit) == 0) continue;
                         if (!self.isRc(arg)) continue;
                         const value = arg_values_buffer[index];

--- a/src/lir/arc_dismantle.zig
+++ b/src/lir/arc_dismantle.zig
@@ -95,10 +95,17 @@ pub const Dismantles = struct {
 
     pub fn ownedOnlyParamBenefits(self: *const Dismantles, proc: LIR.LirProcSpecId) arc_sig.ParamMask {
         const index = @intFromEnum(proc);
-        if (index >= self.owned_only_param_benefits.len) return 0;
+        if (index >= self.owned_only_param_benefits.len) {
+            dismantleInvariant("ARC owned-only benefit lookup exceeded the analyzed source-procedure table");
+        }
         return self.owned_only_param_benefits[index];
     }
 };
+
+fn dismantleInvariant(comptime message: []const u8) noreturn {
+    if (@import("builtin").mode == .Debug) std.debug.panic(message, .{});
+    unreachable;
+}
 
 const State = enum(u8) {
     unknown,

--- a/src/lir/arc_dismantle.zig
+++ b/src/lir/arc_dismantle.zig
@@ -22,6 +22,7 @@ const std = @import("std");
 const collections = @import("collections");
 const core = @import("lir_core");
 const layout_mod = @import("layout");
+const arc_sig = @import("arc_sig.zig");
 const arc_solve = @import("arc_solve.zig");
 
 const LIR = core.LIR;
@@ -63,6 +64,9 @@ pub const Dismantles = struct {
     owned_only_takes: std.AutoHashMapUnmanaged(LIR.CFStmtId, LIR.LocalId),
     /// Containers behind `owned_only_takes`, keyed by the parameter local.
     owned_only_containers: std.AutoHashMapUnmanaged(LIR.LocalId, Container),
+    /// Parameter positions whose owned variant activates an exact field take,
+    /// indexed directly by source procedure id.
+    owned_only_param_benefits: []arc_sig.ParamMask,
 
     pub fn deinit(self: *Dismantles) void {
         const gpa = self.arena.child_allocator;
@@ -87,6 +91,12 @@ pub const Dismantles = struct {
 
     pub fn ownedOnlyContainerOf(self: *const Dismantles, local: LIR.LocalId) ?Container {
         return self.owned_only_containers.get(local);
+    }
+
+    pub fn ownedOnlyParamBenefits(self: *const Dismantles, proc: LIR.LirProcSpecId) arc_sig.ParamMask {
+        const index = @intFromEnum(proc);
+        if (index >= self.owned_only_param_benefits.len) return 0;
+        return self.owned_only_param_benefits[index];
     }
 };
 
@@ -716,8 +726,11 @@ pub fn compute(
         .containers = .empty,
         .owned_only_takes = .empty,
         .owned_only_containers = .empty,
+        .owned_only_param_benefits = &.{},
     };
     errdefer result.deinit();
+    result.owned_only_param_benefits = try result.arena.allocator().alloc(arc_sig.ParamMask, store.procSpecCount());
+    @memset(result.owned_only_param_benefits, 0);
 
     var spine_pending = std.AutoHashMapUnmanaged(LIR.CFStmtId, void).empty;
     defer spine_pending.deinit(gpa);
@@ -891,6 +904,20 @@ pub fn compute(
             try result.owned_only_containers.put(gpa, local, .{ .residual = stored_residual });
         } else {
             try result.containers.put(gpa, local, .{ .residual = stored_residual });
+        }
+    }
+
+    // Variant admission consumes the exact owned-only benefit without
+    // rescanning bodies or reconstructing parameter identity from statements.
+    for (0..store.procSpecCount()) |proc_index| {
+        const proc_id: LIR.LirProcSpecId = @enumFromInt(@as(u32, @intCast(proc_index)));
+        const params = store.getLocalSpan(store.getProcSpec(proc_id).args);
+        for (0..GuardedList.borrowLen(params)) |position| {
+            const bit = arc_sig.paramBit(position) orelse break;
+            const param = GuardedList.at(params, position);
+            if (result.owned_only_containers.contains(param)) {
+                result.owned_only_param_benefits[proc_index] |= bit;
+            }
         }
     }
 

--- a/src/lir/arc_sig.zig
+++ b/src/lir/arc_sig.zig
@@ -13,6 +13,18 @@ const core = @import("lir_core");
 
 const LIR = core.LIR;
 
+/// Parameter positions represented in inferred signatures and mode demands.
+/// Later positions follow the exact all-owned schedule.
+pub const ParamMask = u16;
+/// Number of procedure argument positions represented by `ParamMask`.
+pub const tracked_param_count = @bitSizeOf(ParamMask);
+
+/// Returns the represented bit for one procedure argument position.
+pub fn paramBit(index: usize) ?ParamMask {
+    if (index >= tracked_param_count) return null;
+    return @as(ParamMask, 1) << @as(u4, @intCast(index));
+}
+
 /// Ownership mode of one refcounted position.
 pub const Mode = enum(u1) {
     borrowed,
@@ -22,15 +34,15 @@ pub const Mode = enum(u1) {
 /// Solved ownership signature of one proc.
 ///
 /// Argument positions are indexed by position in the proc's `args` span.
-/// Positions at or beyond 64 are always owned. Non-refcounted positions are
+/// Positions at or beyond `tracked_param_count` are always owned. Non-refcounted positions are
 /// reported as owned; their mode is never consulted.
 pub const RcSig = struct {
     /// Bit i set means argument position i is borrowed.
-    borrowed_params: u64 = 0,
+    borrowed_params: ParamMask = 0,
     ret_mode: Mode = .owned,
     /// For a borrowed return, bit i set means the result may borrow from
     /// argument position i. Unused when `ret_mode` is owned.
-    ret_lenders: u64 = 0,
+    ret_lenders: ParamMask = 0,
     /// The returned value's outermost allocation has count 1 on return:
     /// every `ret` in the proc returns a born-unique value that survives to
     /// the return with no other holder, so the return is the value's single
@@ -41,20 +53,19 @@ pub const RcSig = struct {
     /// runtime uniqueness checks that consume the parameter go check-free.
     /// Only mode-specialized variants carry these bits; solved base
     /// signatures and pinned signatures are always zero.
-    unique_params: u64 = 0,
+    unique_params: ParamMask = 0,
 
     pub const all_owned: RcSig = .{};
 
     pub fn paramMode(self: RcSig, index: usize) Mode {
-        if (index >= 64) return .owned;
-        const bit = @as(u64, 1) << @as(u6, @intCast(index));
+        const bit = paramBit(index) orelse return .owned;
         return if ((self.borrowed_params & bit) != 0) .borrowed else .owned;
     }
 
     pub fn withBorrowedParam(self: RcSig, index: usize) RcSig {
-        if (index >= 64) return self;
+        const bit = paramBit(index) orelse return self;
         var updated = self;
-        updated.borrowed_params |= @as(u64, 1) << @as(u6, @intCast(index));
+        updated.borrowed_params |= bit;
         return updated;
     }
 };
@@ -76,26 +87,28 @@ pub const SigTable = struct {
 test "all-owned signature reports owned for every position" {
     const sig = RcSig.all_owned;
     try std.testing.expectEqual(Mode.owned, sig.paramMode(0));
-    try std.testing.expectEqual(Mode.owned, sig.paramMode(63));
+    try std.testing.expectEqual(Mode.owned, sig.paramMode(15));
+    try std.testing.expectEqual(Mode.owned, sig.paramMode(16));
     try std.testing.expectEqual(Mode.owned, sig.paramMode(200));
     try std.testing.expectEqual(Mode.owned, sig.ret_mode);
     try std.testing.expectEqual(false, sig.ret_unique);
-    try std.testing.expectEqual(@as(u64, 0), sig.unique_params);
+    try std.testing.expectEqual(@as(ParamMask, 0), sig.unique_params);
 }
 
 test "borrowed param bits round-trip" {
-    const sig = RcSig.all_owned.withBorrowedParam(0).withBorrowedParam(3);
+    const sig = RcSig.all_owned.withBorrowedParam(0).withBorrowedParam(3).withBorrowedParam(15).withBorrowedParam(16);
     try std.testing.expectEqual(Mode.borrowed, sig.paramMode(0));
     try std.testing.expectEqual(Mode.owned, sig.paramMode(1));
     try std.testing.expectEqual(Mode.borrowed, sig.paramMode(3));
-    try std.testing.expectEqual(Mode.owned, sig.paramMode(64));
+    try std.testing.expectEqual(Mode.borrowed, sig.paramMode(15));
+    try std.testing.expectEqual(Mode.owned, sig.paramMode(16));
 }
 
 test "empty signature table answers all-owned" {
     const table = SigTable.all_owned;
     const sig = table.get(@enumFromInt(7));
-    try std.testing.expectEqual(@as(u64, 0), sig.borrowed_params);
+    try std.testing.expectEqual(@as(ParamMask, 0), sig.borrowed_params);
     try std.testing.expectEqual(Mode.owned, sig.ret_mode);
     try std.testing.expectEqual(false, sig.ret_unique);
-    try std.testing.expectEqual(@as(u64, 0), sig.unique_params);
+    try std.testing.expectEqual(@as(ParamMask, 0), sig.unique_params);
 }

--- a/src/lir/arc_sig.zig
+++ b/src/lir/arc_sig.zig
@@ -34,8 +34,9 @@ pub const Mode = enum(u1) {
 /// Solved ownership signature of one proc.
 ///
 /// Argument positions are indexed by position in the proc's `args` span.
-/// Positions at or beyond `tracked_param_count` are always owned. Non-refcounted positions are
-/// reported as owned; their mode is never consulted.
+/// Positions at or beyond `tracked_param_count` are always owned.
+/// Non-refcounted positions are reported as owned; their mode is never
+/// consulted.
 pub const RcSig = struct {
     /// Bit i set means argument position i is borrowed.
     borrowed_params: ParamMask = 0,

--- a/src/lir/arc_solve.zig
+++ b/src/lir/arc_solve.zig
@@ -99,7 +99,7 @@ pub const Solution = struct {
     sigs: []arc_sig.RcSig,
     /// Parameter positions whose values can reach a consuming low-level
     /// runtime uniqueness check in this proc's ownership-neutral body.
-    unique_seed_masks: []u64,
+    unique_seed_masks: []arc_sig.ParamMask,
     /// Flat join-body facts per source proc, indexed through the adjacent
     /// offsets and lengths.
     join_body_offsets: []u32,
@@ -259,7 +259,7 @@ pub const Solution = struct {
         return self.sigTable().get(proc);
     }
 
-    pub fn uniqueSeedMaskOf(self: *const Solution, proc: LIR.LirProcSpecId) u64 {
+    pub fn uniqueSeedMaskOf(self: *const Solution, proc: LIR.LirProcSpecId) arc_sig.ParamMask {
         const index = @intFromEnum(proc);
         if (index >= self.unique_seed_masks.len) solveInvariant("ARC uniqueness-seed lookup exceeded the solved proc table");
         return self.unique_seed_masks[index];
@@ -428,7 +428,7 @@ const Solver = struct {
     rc_local: []const bool,
     domain: *const ArcLocalDomain,
     sigs: []arc_sig.RcSig,
-    unique_seed_masks: []u64,
+    unique_seed_masks: []arc_sig.ParamMask,
     pinned: std.bit_set.DynamicBitSetUnmanaged,
     /// Call-graph SCC id per proc, for the tail-call rule.
     scc: []u32,
@@ -443,7 +443,7 @@ const Solver = struct {
     /// through instead of paying a retain/release pair.
     alias_source: []u32,
     /// Parameter position per local when the local is a proc parameter
-    /// (positions >= 64 are recorded as owned-only).
+    /// (positions beyond the signature mask are recorded as owned-only).
     param_position: []u32,
     /// Proc owning each parameter local.
     param_proc: []u32,
@@ -500,7 +500,7 @@ pub fn solve(
         .rc_local = rc_local,
         .domain = &domain,
         .sigs = try allocator.alloc(arc_sig.RcSig, proc_count),
-        .unique_seed_masks = try allocator.alloc(u64, proc_count),
+        .unique_seed_masks = try allocator.alloc(arc_sig.ParamMask, proc_count),
         .pinned = try std.bit_set.DynamicBitSetUnmanaged.initEmpty(allocator, proc_count),
         .scc = try allocator.alloc(u32, proc_count),
         .defs = try allocator.alloc(DefKind, arc_local_count),
@@ -608,7 +608,7 @@ pub fn solve(
                 const param_index = domain.indexOf(param) orelse continue;
                 solver.param_position[param_index] = @intCast(position);
                 solver.param_proc[param_index] = @intCast(proc_index);
-                if (position < 64) {
+                if (position < arc_sig.tracked_param_count) {
                     sig = sig.withBorrowedParam(position);
                 }
             }
@@ -895,7 +895,7 @@ fn paramIsBorrowed(solver: *const Solver, local_index: u32) bool {
     const proc_index = solver.param_proc[local_index];
     if (proc_index == no_local) return false;
     const position = solver.param_position[local_index];
-    if (position >= 64) return false;
+    if (position >= arc_sig.tracked_param_count) return false;
     return solver.sigs[proc_index].paramMode(position) == .borrowed;
 }
 
@@ -927,8 +927,8 @@ fn retLenders(
     solver: *const Solver,
     binding: *const BindingResult,
     proc_index: usize,
-) ?u64 {
-    var lenders: u64 = 0;
+) ?arc_sig.ParamMask {
+    var lenders: arc_sig.ParamMask = 0;
     const returns = solver.proc_returns[proc_index].items;
     if (returns.len == 0) return null;
     for (returns) |value_local| {
@@ -943,8 +943,8 @@ fn retLenders(
         if (solver.param_proc[leader] != proc_index) return null;
         if (solver.demand[value_index]) return null;
         const position = solver.param_position[leader];
-        if (position >= 64) return null;
-        lenders |= @as(u64, 1) << @as(u6, @intCast(position));
+        const bit = arc_sig.paramBit(position) orelse return null;
+        lenders |= bit;
     }
 
     if (lenders == 0) return null;
@@ -1267,20 +1267,20 @@ fn lowLevelUniqueSeedMask(
     params_span: LIR.LocalSpan,
     args_span: LIR.LocalSpan,
     rc_effect: LIR.LowLevel.RcEffect,
-) u64 {
+) arc_sig.ParamMask {
     const check_mask = rc_effect.may_runtime_uniqueness_check_args & rc_effect.consume_args;
     if (check_mask == 0) return 0;
 
     const params = store.getLocalSpan(params_span);
     const args = store.getLocalSpan(args_span);
-    var mask: u64 = 0;
+    var mask: arc_sig.ParamMask = 0;
     for (0..GuardedList.borrowLen(args)) |arg_position| {
         if (arg_position >= 64) break;
         if ((check_mask & (@as(u64, 1) << @as(u6, @intCast(arg_position)))) == 0) continue;
         const arg = GuardedList.at(args, arg_position);
-        for (0..@min(GuardedList.borrowLen(params), 64)) |param_position| {
+        for (0..@min(GuardedList.borrowLen(params), arc_sig.tracked_param_count)) |param_position| {
             if (arg != GuardedList.at(params, param_position)) continue;
-            mask |= @as(u64, 1) << @as(u6, @intCast(param_position));
+            mask |= arc_sig.paramBit(param_position).?;
             break;
         }
     }
@@ -1458,8 +1458,8 @@ fn collectAll(solver: *Solver) SolveError!void {
         for (0..GuardedList.borrowLen(args)) |position| {
             const arg = GuardedList.at(args, position);
             const argument = solver.domain.indexOf(arg) orelse continue;
-            if (!tail_call and position < 64) {
-                const key = @intFromEnum(call.callee) * 64 + position;
+            if (!tail_call and position < arc_sig.tracked_param_count) {
+                const key = @intFromEnum(call.callee) * arc_sig.tracked_param_count + position;
                 try solver.param_uses.append(solver.allocator, .{
                     .key = @intCast(key),
                     .argument = argument,
@@ -1481,7 +1481,7 @@ fn solveParameterModes(solver: *Solver) SolveError!void {
     // Compact the collected edge facts into dense offsets. This preserves
     // exact dependency lookup without one allocation-capable list object for
     // every possible proc/parameter pair.
-    const key_count = solver.sigs.len * 64;
+    const key_count = solver.sigs.len * arc_sig.tracked_param_count;
     const offsets = try solver.allocator.alloc(u32, key_count + 1);
     defer solver.allocator.free(offsets);
     @memset(offsets, 0);
@@ -1517,13 +1517,13 @@ fn flipParamIfRequired(solver: *Solver, local_index: u32, work: *std.ArrayList(u
     const proc_index = solver.param_proc[local_index];
     if (proc_index == no_local) return;
     const position = solver.param_position[local_index];
-    if (position >= 64) return;
+    if (position >= arc_sig.tracked_param_count) return;
     var sig = &solver.sigs[proc_index];
     if (sig.paramMode(position) == .owned) return;
     const required = solver.demand[local_index] or solver.defs[local_index] == .multi;
     if (!required) return;
-    sig.borrowed_params &= ~(@as(u64, 1) << @as(u6, @intCast(position)));
-    try work.append(solver.allocator, proc_index * 64 + position);
+    sig.borrowed_params &= ~arc_sig.paramBit(position).?;
+    try work.append(solver.allocator, proc_index * arc_sig.tracked_param_count + position);
 }
 
 /// Adds one ownership demand and propagates it through the exact pure-alias
@@ -2096,8 +2096,7 @@ fn callRetBorrowSource(solver: *const Solver, callee_sig: arc_sig.RcSig, args: a
     var source: u32 = no_local;
     for (0..GuardedList.borrowLen(args)) |position| {
         const arg = GuardedList.at(args, position);
-        if (position >= 64) break;
-        const bit = @as(u64, 1) << @as(u6, @intCast(position));
+        const bit = arc_sig.paramBit(position) orelse break;
         if ((callee_sig.ret_lenders & bit) == 0) continue;
         const arg_index = solver.domain.indexOf(arg) orelse continue;
         if (source != no_local and source != arg_index) return no_local;


### PR DESCRIPTION
Teach ARC mode specialization to request an owned callee variant when dismantle analysis proves that it enables a field take, preserving nested list uniqueness across retained calls. ARC ownership signatures now explicitly track the first 16 parameters with an exact all-owned tail, reducing signature and variant state while keeping arbitrary function arity.