### PR TITLE
Fix selected loop exit when break payload is a local binder

### DIFF
--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -127,6 +127,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10395_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10508_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10503_test.zig"));
+    std.testing.refAllDecls(@import("test/loop_selected_exit_local_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10561_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10571_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));

--- a/src/compile/test/loop_selected_exit_local_test.zig
+++ b/src/compile/test/loop_selected_exit_local_test.zig
@@ -1,0 +1,29 @@
+//! Regression test for loop exit selection carrying local binder state.
+
+const expectLowersToLir = @import("lower_to_lir_harness.zig").expectLowersToLir;
+
+test "selected loop exit carrying substituted local binder state lowers to LIR" {
+    try expectLowersToLir(
+        \\walk_closure = |s, v| {
+        \\    v_num = match U64.from_str(v) { Ok(n) => n, _ => 0 }
+        \\    match s {
+        \\        (Unknown(Undefined), _) => Continue((Unknown(Value(v_num)), 0))
+        \\        (Unknown(Value(prev)), _) =>
+        \\            if v_num > prev {
+        \\                Continue((Ascending(v_num), 0))
+        \\            } else {
+        \\                Break((Unknown(Undefined), 1))
+        \\            }
+        \\        (Ascending(_), _) => Break((Unknown(Undefined), 1))
+        \\    }
+        \\}
+        \\
+        \\main! = |_| {
+        \\    (s, _) = List.fold_until(Str.split_on("", ""), (Unknown(Undefined), 0), walk_closure)
+        \\    match s {
+        \\        Unknown(_) => Ok({})
+        \\        Ascending(_) => Ok({})
+        \\    }
+        \\}
+    );
+}

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -6176,28 +6176,27 @@ const Cloner = struct {
         value_expr: Ast.ExprId,
         selection: LoopExitSelection,
     ) Common.LowerError!Ast.ExprId {
-        const value_data = self.pass.program.getExpr(value_expr).data;
-        if (value_data != .tuple) Common.invariant("selected loop exit did not carry compiler-generated tuple state");
-        const tuple = try GuardedList.dupe(self.pass.allocator, Ast.ExprId, self.pass.program.exprSpan(value_data.tuple));
-        defer self.pass.allocator.free(tuple);
-        if (tuple.len != selection.source_arity) {
+        var bindings: BindingChain = .{};
+        const exit_value = try self.cloneExprValueDemandingShapeInto(value_expr, &bindings);
+        const tuple = tupleFromValue(exit_value) orelse Common.invariant("selected loop exit did not carry compiler-generated tuple state");
+        if (tuple.items.len != selection.source_arity) {
             Common.invariant("selected loop exit tuple arity differed from its source ABI");
         }
 
-        return switch (selection.transfer) {
+        const projected = switch (selection.transfer) {
             .break_value => blk: {
                 if (selection.kept_indices.len != 1) Common.invariant("direct loop exit selection did not contain one value");
-                const projected = try self.addExpr(.{
+                const projected_expr = try self.addExpr(.{
                     .ty = break_ty,
-                    .data = .{ .break_ = try self.cloneExpr(tuple[selection.kept_indices[0]]) },
+                    .data = .{ .break_ = try self.materialize(tuple.items[selection.kept_indices[0]]) },
                 });
-                try self.selected_loop_exit_tys.put(projected, selection.result_ty);
-                break :blk projected;
+                try self.selected_loop_exit_tys.put(projected_expr, selection.result_ty);
+                break :blk projected_expr;
             },
             .jump => |jump_transfer| blk: {
                 const args = try self.pass.allocator.alloc(Ast.ExprId, selection.kept_indices.len);
                 defer self.pass.allocator.free(args);
-                for (selection.kept_indices, args) |index, *out| out.* = try self.cloneExpr(tuple[index]);
+                for (selection.kept_indices, args) |index, *out| out.* = try self.materialize(tuple.items[index]);
                 const jump = try self.addExpr(.{
                     .ty = break_ty,
                     .data = .{ .jump = .{
@@ -6209,6 +6208,8 @@ const Cloner = struct {
                 break :blk jump;
             },
         };
+
+        return try self.wrapBindings(bindings, projected);
     }
 
     fn inlineLoopExitAtSite(


### PR DESCRIPTION
When narrowing a loop's exit representation to discard unused carried values, the optimizer expected the loop's break payload to be a literal tuple node in the raw syntax tree.
If earlier case-of-case optimization or variable substitution had bound the state tuple to a local variable, inspecting the raw syntax tree instead of the evaluated specialization environment mistook the variable alias for an invalid loop state, triggering an invariant panic.

Evaluated the break payload through the specialization environment before extracting tuple elements, properly resolving variable bindings to their underlying tuple values.

Fixes #10496