### PR TITLE
Fix dbg statement when inspectee is a runtime error

### DIFF
--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -137,4 +137,5 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/range_prove_test.zig"));
     std.testing.refAllDecls(@import("test/match_corpus_test.zig"));
     std.testing.refAllDecls(@import("test/url_package_test.zig"));
+    std.testing.refAllDecls(@import("test/dbg_runtime_error_test.zig"));
 }

--- a/src/compile/test/dbg_runtime_error_test.zig
+++ b/src/compile/test/dbg_runtime_error_test.zig
@@ -1,0 +1,12 @@
+//! Regression test for dbg statements containing runtime error expressions.
+
+const expectLowersToLirWithOptions = @import("lower_to_lir_harness.zig").expectLowersToLirWithOptions;
+
+test "dbg statement inspecting identifier not in scope lowers to runtime error LIR without compiler panic" {
+    try expectLowersToLirWithOptions(
+        \\main! = |_| {
+        \\    dbg undefined_variable
+        \\    Ok({})
+        \\}
+    , .{ .allow_user_errors = true });
+}

--- a/src/compile/test/lower_to_lir_harness.zig
+++ b/src/compile/test/lower_to_lir_harness.zig
@@ -84,6 +84,7 @@ pub const LirLoweringOptions = struct {
     list_in_place_map: bool = false,
     proc_debug_names: bool = false,
     prove_ranges: bool = false,
+    allow_user_errors: bool = false,
     /// Receives the expression count of the lifted program handed to lambda-set
     /// solving, for tests that assert on post-check program growth.
     lifted_expr_count_out: ?*usize = null,
@@ -264,10 +265,14 @@ fn lowerAppPathToLir(
     try coord.start();
     try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
     try coord.coordinatorLoop();
-    try std.testing.expect(!coord.hasUserErrors());
+    if (!opts.allow_user_errors) {
+        try std.testing.expect(!coord.hasUserErrors());
+    }
 
     try coord.finalizeExecutableArtifacts();
-    try std.testing.expect(!coord.hasUserErrors());
+    if (!opts.allow_user_errors) {
+        try std.testing.expect(!coord.hasUserErrors());
+    }
 
     const root = coord.executableRootCheckedArtifact();
     const imports = try coord.collectImportedArtifactViews(arena, root);

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -18229,6 +18229,9 @@ const BodyContext = struct {
         child: checked.CheckedExprId,
         str_ty: Type.TypeId,
     ) Allocator.Error!DraftExprId {
+        if (self.view.bodies.expr(child).data == .runtime_error) {
+            return try self.lowerExprWithType(child, str_ty);
+        }
         const value_node = try self.lowerExprTypeNode(child);
         const value = try self.lowerExprAtTypeCell(child, DraftTypeCell.fromGraphNode(value_node));
         return if (try self.graph.typeIsResolved(value_node))


### PR DESCRIPTION
When lowering a dbg statement, the compiler attempted to instantiate the type graph node of the inspected child expression.
If child failed type or scope resolution, its checked type in the AST is `.err`.
Instantiating an .err checked type triggered an internal compiler invariant panic (erroneous checked type reached Monotype instantiation) instead of lowering the runtime_error node into an executable crash payload.

Updated lowerInspectedExpr to check if the child expression is a `.runtime_error`.
When a runtime error expression is inspected, monotype lowering bypasses type node instantiation and directly lowers the child into a runtime error expression.

Fixes #10656