### PR TITLE
Ignore annotation-only declarations when building top-level value tables

### DIFF
--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -21950,6 +21950,21 @@ pub const CompileTimeRoot = struct {
     payload: CompileTimeRootPayload,
 };
 
+fn topLevelDefHasValueImplementation(
+    module: TypedCIR.Module,
+    names: *canonical.CanonicalNameStore,
+    global_value_defs: []const CIR.Def.Idx,
+    source_name: canonical.ExportNameId,
+) Allocator.Error!bool {
+    for (global_value_defs) |other_def_idx| {
+        const other_def = module.def(other_def_idx);
+        if (other_def.expr.data == .e_anno_only) continue;
+        const other_name = (try topLevelDefSourceName(module, names, other_def)) orelse continue;
+        if (other_name == source_name) return true;
+    }
+    return false;
+}
+
 /// Public `CompileTimeRootTable` declaration.
 ///
 /// This is the durable compile-time root schedule and payload table. It stores
@@ -21996,6 +22011,7 @@ pub const CompileTimeRootTable = struct {
             if (procedure_templates.lookupByDef(def_idx) != null) continue;
 
             const source_name = try topLevelDefSourceName(module, names, def) orelse continue;
+            if (def.expr.data == .e_anno_only and try topLevelDefHasValueImplementation(module, names, global_value_defs, source_name)) continue;
             const seen_source_name = try seen_source_names.getOrPut(allocator, source_name);
             if (seen_source_name.found_existing) continue;
             seen_source_name.value_ptr.* = {};
@@ -23339,6 +23355,7 @@ pub const TopLevelValueTable = struct {
             const def = module.def(def_idx);
             const checked_pattern = checkedPatternIdForSource(checked_bodies, def.pattern.idx);
             const source_name = try topLevelDefSourceName(module, names, def) orelse continue;
+            if (def.expr.data == .e_anno_only and try topLevelDefHasValueImplementation(module, names, global_value_defs, source_name)) continue;
             const seen_source_name = try seen_source_names.getOrPut(allocator, source_name);
             if (seen_source_name.found_existing) continue;
             seen_source_name.value_ptr.* = {};

--- a/src/check/mod.zig
+++ b/src/check/mod.zig
@@ -91,6 +91,7 @@ test "check tests" {
     std.testing.refAllDecls(@import("test/issue_10093_test.zig"));
     std.testing.refAllDecls(@import("test/repros_test.zig"));
     std.testing.refAllDecls(@import("test/typed_cir_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10338_test.zig"));
 
     // Cross-module monomorphization tests
     std.testing.refAllDecls(@import("test/cross_module_mono_test.zig"));

--- a/src/check/test/issue_10338_test.zig
+++ b/src/check/test/issue_10338_test.zig
@@ -1,0 +1,15 @@
+//! Regression test for issue 10338.
+
+const TestEnv = @import("./TestEnv.zig");
+
+test "issue 10338: forward referenced binding with out of order annotations does not panic checked artifact publication" {
+    const source =
+        \\t = f()
+        \\f : U
+        \\m : U
+        \\f = () != {}
+    ;
+
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+}


### PR DESCRIPTION
When a top-level type annotation is separated from its value definition by intermediate declarations, canonicalization emits an annotation-only declaration and a separate value definition.
Deduplication by source name picked up the first entry (the annotation-only declaration) and skipped the value definition.
Because references resolved to the value definition's pattern index, looking up that pattern in the top-level value table failed and panicked during constant root template sealing.

Skipped annotation-only declarations during top-level value and compile-time root table construction whenever a corresponding value definition exists in the module's top-level declarations.

Fixes #10338