### PR TITLE
Emit runtime crash when iterator dispatch resolutions fail to check

### DIFF
--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -129,6 +129,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10503_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10561_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10571_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10617_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));
     std.testing.refAllDecls(@import("test/platform_box_update_lir_test.zig"));

--- a/src/compile/test/issue_10617_test.zig
+++ b/src/compile/test/issue_10617_test.zig
@@ -1,0 +1,18 @@
+//! Regression test for issue #10617.
+
+const expectLowersToLirWithOptions = @import("lower_to_lir_harness.zig").expectLowersToLirWithOptions;
+
+test "issue 10617: for loop on invalid type does not panic monotype lowering" {
+    try expectLowersToLirWithOptions(
+        \\l : U
+        \\
+        \\a = {
+        \\    for 0 in {} 0
+        \\}
+        \\
+        \\main! = |_| {
+        \\    a
+        \\    Ok({})
+        \\}
+    , .{ .allow_user_errors = true });
+}

--- a/src/compile/test/lower_to_lir_harness.zig
+++ b/src/compile/test/lower_to_lir_harness.zig
@@ -84,6 +84,7 @@ pub const LirLoweringOptions = struct {
     list_in_place_map: bool = false,
     proc_debug_names: bool = false,
     prove_ranges: bool = false,
+    allow_user_errors: bool = false,
     /// Receives the expression count of the lifted program handed to lambda-set
     /// solving, for tests that assert on post-check program growth.
     lifted_expr_count_out: ?*usize = null,
@@ -264,10 +265,14 @@ fn lowerAppPathToLir(
     try coord.start();
     try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
     try coord.coordinatorLoop();
-    try std.testing.expect(!coord.hasUserErrors());
+    if (!opts.allow_user_errors) {
+        try std.testing.expect(!coord.hasUserErrors());
+    }
 
     try coord.finalizeExecutableArtifacts();
-    try std.testing.expect(!coord.hasUserErrors());
+    if (!opts.allow_user_errors) {
+        try std.testing.expect(!coord.hasUserErrors());
+    }
 
     const root = coord.executableRootCheckedArtifact();
     const imports = try coord.collectImportedArtifactViews(arena, root);

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -33545,7 +33545,7 @@ const BodyContext = struct {
         self: *BodyContext,
         plan: static_dispatch.StaticDispatchCallPlan,
     ) DispatchRuntimePlan {
-        if (self.dispatchCrashReason(plan)) |reason| return .{ .crash = reason };
+        if (self.dispatchCrashReason(plan.resolution)) |reason| return .{ .crash = reason };
         return .{ .callable = .{
             .plan = plan,
             .operands = plan.argsSlice(self.view.static_dispatch_plans),
@@ -33577,8 +33577,8 @@ const BodyContext = struct {
     /// dispatcher is a value no edge can supply (unreachable), or checking
     /// rejected the requirement (a reported missing method). Monotype emits an
     /// ordinary Roc runtime crash instead of a dispatch call for both cases.
-    fn dispatchCrashReason(self: *BodyContext, plan: static_dispatch.StaticDispatchCallPlan) ?DispatchCrashReason {
-        return switch (plan.resolution) {
+    fn dispatchCrashReason(self: *BodyContext, resolution: static_dispatch.CheckedCallResolution) ?DispatchCrashReason {
+        return switch (resolution) {
             .@"unreachable" => .unreachable_value,
             .checked_error => .checked_error,
             .evidence_dependent => |constraint_ref| if (self.evidence.at(constraint_ref)) |entry| switch (entry) {
@@ -43822,6 +43822,11 @@ const BodyContext = struct {
     ) Allocator.Error!BodyExprData {
         const plan_id = for_.plan orelse Common.invariant("checked iterator for reached Monotype without an iterator dispatch plan");
         const plan = self.view.static_dispatch_plans.iterator_for_plans[@intFromEnum(plan_id)];
+
+        if (self.dispatchCrashReason(plan.iter.resolution) orelse self.dispatchCrashReason(plan.next.resolution)) |reason| {
+            const message = dispatchCrashMessage(reason);
+            return .{ .crash = try self.addStringLiteral(message) };
+        }
 
         const initial_iterator = try self.lowerIteratorDispatch(plan.iter, null, null);
         const iterator_cell = self.exprTypeCell(initial_iterator);


### PR DESCRIPTION
When iterating over a value whose type does not implement the iterator interface (such as {}), the iterator dispatch plan resolutions are marked as checked errors.
During monotype lowering, loop lowering attempted to look up the iterator method without checking if the dispatch plan resolved to a checked error or unreachable state, causing an invariant crash.

Updated loop lowering to check dispatch plan resolutions for checked error or unreachable states prior to target lookup, emitting a runtime crash expression matching all other static dispatches in monotype lowering.

Fixes #10617