### PR TITLE
Fix Dec's wrapping integer conversions in the LLVM and dev backends

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -3165,28 +3165,17 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                 .dec_to_i16_trunc,
                 .dec_to_i32_trunc,
                 .dec_to_i64_trunc,
+                .dec_to_i128_trunc,
                 .dec_to_u8_trunc,
                 .dec_to_u16_trunc,
                 .dec_to_u32_trunc,
                 .dec_to_u64_trunc,
+                .dec_to_u128_trunc,
                 => {
                     if (args.len < 1) unreachable;
                     const src_loc = try self.emitValueLocal(GuardedList.at(args, 0));
                     const parts = try self.getI128Parts(src_loc, .signed); // Dec is signed i128
 
-                    // Call roc_builtins_dec_to_i64_trunc(low, high) -> i64
-                    const result_reg = try self.allocTempGeneral();
-
-                    var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
-                    try builder.addRegArg(parts.low);
-                    try builder.addRegArg(parts.high);
-                    try self.callBuiltin(&builder, .dec_to_i64_trunc);
-                    const ret_reg: GeneralReg = ret_reg_0;
-                    try self.codegen.emit.movRegReg(.w64, result_reg, ret_reg);
-                    self.codegen.freeGeneral(parts.low);
-                    self.codegen.freeGeneral(parts.high);
-
-                    // Mask to target width
                     const dst_bits: u8 = if (ll.op == .dec_to_i8_trunc or ll.op == .dec_to_u8_trunc)
                         8
                     else if (ll.op == .dec_to_i16_trunc or ll.op == .dec_to_u16_trunc)
@@ -3195,53 +3184,34 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         32
                     else if (ll.op == .dec_to_i64_trunc or ll.op == .dec_to_u64_trunc)
                         64
+                    else if (ll.op == .dec_to_i128_trunc or ll.op == .dec_to_u128_trunc)
+                        128
                     else
                         unreachable;
+
+                    const stack_offset = self.codegen.allocStackSlot(16);
+                    var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
+                    try builder.addLeaArg(frame_ptr, stack_offset);
+                    try builder.addRegArg(parts.low);
+                    try builder.addRegArg(parts.high);
+                    try builder.addImmArg(@intCast(dst_bits));
+                    try builder.addImmArg(@intCast(dst_bits / 8));
+                    try self.callBuiltin(&builder, .dec_to_int_wrap);
+                    self.codegen.freeGeneral(parts.low);
+                    self.codegen.freeGeneral(parts.high);
+
+                    if (dst_bits == 128) return .{ .stack_i128 = stack_offset };
+
+                    const result_reg = try self.allocTempGeneral();
+                    try self.emitLoad(.w64, result_reg, frame_ptr, stack_offset);
+                    // The builtin wrote only the low dst_bits/8 bytes, so mask the
+                    // rest of the register off.
                     if (dst_bits < 64) {
                         const shift_amount: u8 = 64 - dst_bits;
                         try self.emitShlImm(.w64, result_reg, result_reg, shift_amount);
                         try self.emitLsrImm(.w64, result_reg, result_reg, shift_amount);
                     }
                     return .{ .general_reg = result_reg };
-                },
-
-                // ── Dec to i128 truncating ──
-                .dec_to_i128_trunc => {
-                    if (args.len < 1) unreachable;
-                    const src_loc = try self.emitValueLocal(GuardedList.at(args, 0));
-                    const parts = try self.getI128Parts(src_loc, .signed); // Dec is signed i128
-                    var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
-                    try builder.addRegArg(parts.low);
-                    try builder.addRegArg(parts.high);
-                    try self.callBuiltin(&builder, .dec_to_i64_trunc);
-                    self.codegen.freeGeneral(parts.low);
-                    self.codegen.freeGeneral(parts.high);
-
-                    // Sign-extend result from i64 to i128
-                    const stack_offset = self.codegen.allocStackSlot(16);
-                    try self.codegen.emitStoreStack(.w64, stack_offset, ret_reg_0);
-                    try self.emitAsrImm(.w64, ret_reg_0, ret_reg_0, 63);
-                    try self.codegen.emitStoreStack(.w64, stack_offset + 8, ret_reg_0);
-                    return .{ .stack_i128 = stack_offset };
-                },
-
-                // ── Dec to u128 truncating ──
-                .dec_to_u128_trunc => {
-                    if (args.len < 1) unreachable;
-                    const src_loc = try self.emitValueLocal(GuardedList.at(args, 0));
-                    const parts = try self.getI128Parts(src_loc, .signed); // Dec is signed i128
-                    var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
-                    try builder.addRegArg(parts.low);
-                    try builder.addRegArg(parts.high);
-                    try self.callBuiltin(&builder, .dec_to_i64_trunc);
-                    self.codegen.freeGeneral(parts.low);
-                    self.codegen.freeGeneral(parts.high);
-
-                    const stack_offset = self.codegen.allocStackSlot(16);
-                    try self.codegen.emitStoreStack(.w64, stack_offset, ret_reg_0);
-                    try self.codegen.emitLoadImm(ret_reg_0, 0);
-                    try self.codegen.emitStoreStack(.w64, stack_offset + 8, ret_reg_0);
-                    return .{ .stack_i128 = stack_offset };
                 },
 
                 // ── Dec to float conversions ──

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -5123,14 +5123,43 @@ pub const MonoLlvmCodeGen = struct {
                 return;
             }
         }
-        if (std.mem.find(u8, name, "_to_") != null and args.len >= 1 and
-            std.mem.find(u8, name, "_try") == null and
-            std.mem.find(u8, name, "_str") == null)
-        {
-            const value = try self.loadScalar(self.slot(GuardedList.at(args, 0)).ptr, self.localLayout(GuardedList.at(args, 0)));
-            const coerced = try self.coerceScalar(value, self.scalarType(self.localLayout(target)), self.localLayout(GuardedList.at(args, 0)).isSigned());
-            try self.storeScalar(self.slot(target).ptr, self.localLayout(target), coerced);
-            return;
+        // Coerce the operand if the layouts allow.
+        if (args.len >= 1) {
+            const src_layout = self.localLayout(GuardedList.at(args, 0));
+            const target_layout = self.localLayout(target);
+
+            const src_is_int = isIntegerLayout(src_layout);
+            const src_is_float = isFloatLayout(src_layout);
+            const dest_is_int = isIntegerLayout(target_layout);
+            const dest_is_float = isFloatLayout(target_layout);
+
+            // coerceScalar emits a single LLVM conversion instruction, chosen from
+            // the source and target types. These are the three cases where that
+            // instruction is also the semantics Roc wants.
+
+            // sext, zext, or trunc. Wrapping to N bits means keeping the low N
+            // bits, which is what trunc does.
+            const int_to_int = src_is_int and dest_is_int;
+
+            // sitofp or uitofp, defined for every integer, rounding to the nearest
+            // float or to infinity.
+            const int_to_float = src_is_int and dest_is_float;
+
+            // fpext or fptrunc, rounding as required.
+            const float_to_float = src_is_float and dest_is_float;
+
+            // The other cases would coerce too, just wrongly:
+            // - A Dec is an i128 scaled by 10^18, so you would get the stored payload
+            //   instead of the value.
+            // - Float-to-int would get fptosi or fptoui, which give poison out of
+            //   range rather than wrapping.
+
+            if (int_to_int or int_to_float or float_to_float) {
+                const value = try self.loadScalar(self.slot(GuardedList.at(args, 0)).ptr, src_layout);
+                const coerced = try self.coerceScalar(value, self.scalarType(target_layout), src_layout.isSigned());
+                try self.storeScalar(self.slot(target).ptr, target_layout, coerced);
+                return;
+            }
         }
         try self.emitCrashBytes(name);
     }

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -5052,6 +5052,16 @@ pub const MonoLlvmCodeGen = struct {
             dec_to_u32_try_unsafe,
             dec_to_u64_try_unsafe,
             dec_to_u128_try_unsafe,
+            dec_to_i8_trunc,
+            dec_to_i16_trunc,
+            dec_to_i32_trunc,
+            dec_to_i64_trunc,
+            dec_to_i128_trunc,
+            dec_to_u8_trunc,
+            dec_to_u16_trunc,
+            dec_to_u32_trunc,
+            dec_to_u64_trunc,
+            dec_to_u128_trunc,
         };
         if (std.meta.stringToEnum(SpecialConversion, name)) |conversion| switch (conversion) {
             .f32_to_i8_try_unsafe,
@@ -5092,6 +5102,20 @@ pub const MonoLlvmCodeGen = struct {
             },
             .dec_to_f32_wrap, .dec_to_f64 => {
                 try self.emitDecToFloatConversion(target, GuardedList.at(args, 0), op == .dec_to_f32_wrap);
+                return;
+            },
+            .dec_to_i8_trunc,
+            .dec_to_i16_trunc,
+            .dec_to_i32_trunc,
+            .dec_to_i64_trunc,
+            .dec_to_u8_trunc,
+            .dec_to_u16_trunc,
+            .dec_to_u32_trunc,
+            .dec_to_u64_trunc,
+            .dec_to_i128_trunc,
+            .dec_to_u128_trunc,
+            => {
+                try self.emitDecToIntTrunc(target, op, GuardedList.at(args, 0));
                 return;
             },
             .dec_to_i8_try_unsafe,
@@ -5175,6 +5199,40 @@ pub const MonoLlvmCodeGen = struct {
             &.{ parts.low, parts.high },
         );
         try self.storeScalar(self.slot(target).ptr, self.localLayout(target), result);
+    }
+
+    /// Dec to integer, truncating the fractional part toward zero and wrapping
+    /// the integer part to the target width.
+    fn emitDecToIntTrunc(self: *MonoLlvmCodeGen, target: LocalId, op: lir.LowLevel, arg: LocalId) Error!void {
+        const builder = self.builder orelse return error.CompilationFailed;
+        const dec_value = try self.loadScalar(self.slot(arg).ptr, .dec);
+        const parts = try self.splitI128Value(dec_value);
+
+        const bytes: u8 = if (op == .dec_to_i8_trunc or op == .dec_to_u8_trunc)
+            1
+        else if (op == .dec_to_i16_trunc or op == .dec_to_u16_trunc)
+            2
+        else if (op == .dec_to_i32_trunc or op == .dec_to_u32_trunc)
+            4
+        else if (op == .dec_to_i64_trunc or op == .dec_to_u64_trunc)
+            8
+        else if (op == .dec_to_i128_trunc or op == .dec_to_u128_trunc)
+            16
+        else
+            unreachable;
+
+        // The builtin divides at 128 bits, then wraps to the requested width.
+        try self.callBuiltinVoid(
+            builtinSymbol(.dec_to_int_wrap),
+            &.{ try self.ptrType(), .i64, .i64, .i32, .i32 },
+            &.{
+                self.slot(target).ptr,
+                parts.low,
+                parts.high,
+                builder.intValue(.i32, @as(u32, bytes) * 8) catch return error.OutOfMemory,
+                builder.intValue(.i32, bytes) catch return error.OutOfMemory,
+            },
+        );
     }
 
     const FloatToIntTruncInfo = struct {

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -3535,7 +3535,7 @@ pub const MonoLlvmCodeGen = struct {
             .dec_to_f32_wrap,
             .dec_to_f32_try_unsafe,
             .dec_to_f64,
-            => try self.emitNumericConversionOrCrash(target, op, arg_locals),
+            => try self.emitNumericConversion(target, op, arg_locals),
         }
     }
 
@@ -5013,7 +5013,7 @@ pub const MonoLlvmCodeGen = struct {
         try self.storeScalar(self.slot(target).ptr, target_layout, coerced);
     }
 
-    fn emitNumericConversionOrCrash(self: *MonoLlvmCodeGen, target: LocalId, op: lir.LowLevel, args: anytype) Error!void {
+    fn emitNumericConversion(self: *MonoLlvmCodeGen, target: LocalId, op: lir.LowLevel, args: anytype) Error!void {
         const name = @tagName(op);
         const SpecialConversion = enum {
             f32_to_i8_try_unsafe,
@@ -5161,7 +5161,7 @@ pub const MonoLlvmCodeGen = struct {
                 return;
             }
         }
-        try self.emitCrashBytes(name);
+        return error.UnsupportedLowLevel;
     }
 
     fn emitDecToFloatConversion(self: *MonoLlvmCodeGen, target: LocalId, arg: LocalId, is_f32: bool) Error!void {

--- a/src/builtins/builtin_registry.zig
+++ b/src/builtins/builtin_registry.zig
@@ -129,6 +129,7 @@ pub const BuiltinFn = enum {
     str_from_literal,
     dec_to_str,
     dec_to_i64_trunc,
+    dec_to_int_wrap,
     i64_to_dec,
     u64_to_dec,
     dec_to_f64,

--- a/src/builtins/dec.zig
+++ b/src/builtins/dec.zig
@@ -1407,17 +1407,6 @@ pub fn toF32Try(arg: RocDec) ?f32 {
     return toF32(arg);
 }
 
-/// Convert Dec to integer by truncating the fractional part (wrapping on overflow)
-pub fn toIntWrap(comptime T: type, arg: RocDec) T {
-    // Divide by one_point_zero_i128 to get the integer part
-    const whole_part = i128h.divTrunc_i128(arg.num, RocDec.one_point_zero_i128);
-    // Truncate to the target type (wrapping)
-    // First cast the i128 to u128, then truncate to the target size, then cast back to T if needed
-    const as_u128: u128 = @bitCast(whole_part);
-    const truncated = @as(std.meta.Int(.unsigned, @bitSizeOf(T)), @truncate(as_u128));
-    return @bitCast(truncated);
-}
-
 /// Convert Dec to integer by truncating the fractional part (returns null if out of range)
 pub fn toIntTry(comptime T: type, arg: RocDec) ?T {
     // Divide by one_point_zero_i128 to get the integer part

--- a/src/builtins/dev_wrappers.zig
+++ b/src/builtins/dev_wrappers.zig
@@ -21,6 +21,13 @@ const float_math_f64 = @import("float_math/f64.zig");
 const numeric_conversions = @import("numeric_conversions.zig");
 const simd = @import("simd.zig");
 
+// The conversion wrappers below hand back a result narrower than the u128 they
+// compute it in, by copying the first val_size bytes of its byte representation.
+// Those are the low-order bytes only on a little-endian target.
+comptime {
+    std.debug.assert(@import("builtin").cpu.arch.endian() == .little);
+}
+
 const RocStr = str.RocStr;
 const RocList = list.RocList;
 const FromUtf8Try = str.FromUtf8Try;

--- a/src/builtins/dev_wrappers.zig
+++ b/src/builtins/dev_wrappers.zig
@@ -1572,10 +1572,20 @@ pub fn roc_builtins_dec_to_str(out: *RocStr, value_low: u64, value_high: u64, ro
 
 // ── Numeric conversion wrappers ──
 
-/// Dec (i128) → i64 by truncating division
+/// Dec (i128) → i64 by truncating division. Unlike the wrapping conversions, this
+/// panics when the quotient does not fit an i64, which a Dec's integer part can
+/// exceed.
 pub fn roc_builtins_dec_to_i64_trunc(low: u64, high: u64) callconv(.c) i64 {
     const val: i128 = @bitCast(i128h.from_u64_pair(low, high));
     return @intCast(i128h.divTrunc_i128(val, dec.RocDec.one_point_zero_i128));
+}
+
+/// Dec → integer wrapping conversion (writes val_size result bytes to out)
+pub fn roc_builtins_dec_to_int_wrap(out: [*]u8, dec_low: u64, dec_high: u64, target_bits: u32, val_size: u32) callconv(.c) void {
+    const dec_val: i128 = @bitCast(i128h.from_u64_pair(dec_low, dec_high));
+    const bits = numeric_conversions.decToIntWrapBits(dec_val, target_bits);
+    const v_bytes: [16]u8 = @bitCast(bits);
+    @memcpy(out[0..val_size], v_bytes[0..val_size]);
 }
 
 /// i64 → Dec (i128) via output pointers

--- a/src/builtins/dev_wrappers.zig
+++ b/src/builtins/dev_wrappers.zig
@@ -1591,7 +1591,7 @@ pub fn roc_builtins_dec_to_i64_trunc(low: u64, high: u64) callconv(.c) i64 {
 pub fn roc_builtins_dec_to_int_wrap(out: [*]u8, dec_low: u64, dec_high: u64, target_bits: u32, val_size: u32) callconv(.c) void {
     const dec_val: i128 = @bitCast(i128h.from_u64_pair(dec_low, dec_high));
     const bits = numeric_conversions.decToIntWrapBits(dec_val, target_bits);
-    const v_bytes: [16]u8 = @bitCast(bits);
+    const v_bytes: [numeric_conversions.max_int_bytes]u8 = @bitCast(bits);
     @memcpy(out[0..val_size], v_bytes[0..val_size]);
 }
 
@@ -1765,14 +1765,14 @@ pub fn roc_builtins_f32_to_int_try_unsafe(out: [*]u8, val: f32, target_bits: u32
 /// f32 → integer wrapping conversion (writes val_size result bytes to out)
 pub fn roc_builtins_f32_to_int_wrap(out: [*]u8, val: f32, target_bits: u32, val_size: u32) callconv(.c) void {
     const bits = numeric_conversions.floatToIntWrapBits(f32, val, target_bits);
-    const v_bytes: [16]u8 = @bitCast(bits);
+    const v_bytes: [numeric_conversions.max_int_bytes]u8 = @bitCast(bits);
     @memcpy(out[0..val_size], v_bytes[0..val_size]);
 }
 
 /// f64 → integer wrapping conversion (writes val_size result bytes to out)
 pub fn roc_builtins_f64_to_int_wrap(out: [*]u8, val: f64, target_bits: u32, val_size: u32) callconv(.c) void {
     const bits = numeric_conversions.floatToIntWrapBits(f64, val, target_bits);
-    const v_bytes: [16]u8 = @bitCast(bits);
+    const v_bytes: [numeric_conversions.max_int_bytes]u8 = @bitCast(bits);
     @memcpy(out[0..val_size], v_bytes[0..val_size]);
 }
 

--- a/src/builtins/numeric_conversions.zig
+++ b/src/builtins/numeric_conversions.zig
@@ -4,6 +4,14 @@ const std = @import("std");
 const dec = @import("dec.zig");
 const i128h = @import("compiler_rt_128.zig");
 
+/// The widest integer Roc has. Every conversion here computes its result at this
+/// width before narrowing to the target, so a target wider than this cannot be
+/// represented.
+pub const max_int_bits: u32 = 128;
+
+/// `max_int_bits` as a byte count, for sizing a result's byte representation.
+pub const max_int_bytes: u32 = max_int_bits / 8;
+
 /// Exact F64 representation of the greatest finite F32 value.
 pub const f32_max_as_f64: f64 = std.math.floatMax(f32);
 
@@ -116,7 +124,7 @@ pub fn floatToIntTryBits(comptime Float: type, value: Float, target_bits: u32, t
 /// 2^target_bits. This works from the IEEE-754 representation directly so
 /// wrapping does not itself incur float rounding near a modulus boundary.
 pub fn floatToIntWrapBits(comptime Float: type, value: Float, target_bits: u32) u128 {
-    std.debug.assert(target_bits > 0 and target_bits <= 128);
+    std.debug.assert(target_bits > 0 and target_bits <= max_int_bits);
 
     const Bits = if (Float == f32)
         u32
@@ -172,7 +180,7 @@ pub fn floatToIntWrap(comptime Float: type, comptime Int: type, value: Float) In
 /// integer part wraps modulo 2^target_bits. The division runs at 128 bits
 /// because a Dec's integer part goes up to ~1.7e20, past what an i64 holds.
 pub fn decToIntWrapBits(dec_value: i128, target_bits: u32) u128 {
-    std.debug.assert(target_bits > 0 and target_bits <= 128);
+    std.debug.assert(target_bits > 0 and target_bits <= max_int_bits);
 
     const whole_part = i128h.divTrunc_i128(dec_value, dec.RocDec.one_point_zero_i128);
     const magnitude: u128 = @bitCast(whole_part);

--- a/src/builtins/numeric_conversions.zig
+++ b/src/builtins/numeric_conversions.zig
@@ -167,6 +167,19 @@ pub fn floatToIntWrap(comptime Float: type, comptime Int: type, value: Float) In
     return @bitCast(@as(U, @truncate(bits)));
 }
 
+/// Convert a Roc Dec payload to raw target integer bits using Roc's wrapping
+/// Dec-to-integer semantics: the fractional part truncates toward zero and the
+/// integer part wraps modulo 2^target_bits. The division runs at 128 bits
+/// because a Dec's integer part goes up to ~1.7e20, past what an i64 holds.
+pub fn decToIntWrapBits(dec_value: i128, target_bits: u32) u128 {
+    std.debug.assert(target_bits > 0 and target_bits <= 128);
+
+    const whole_part = i128h.divTrunc_i128(dec_value, dec.RocDec.one_point_zero_i128);
+    const magnitude: u128 = @bitCast(whole_part);
+    if (target_bits == 128) return magnitude;
+    return magnitude & (i128h.shl(1, @intCast(target_bits)) - 1);
+}
+
 /// Convert a Roc Dec payload to raw target integer bits after truncating.
 pub fn decToIntTryBits(dec_value: i128, target_bits: u32, target_signed: bool) ?u128 {
     const whole_part = i128h.divTrunc_i128(dec_value, dec.RocDec.one_point_zero_i128);

--- a/src/builtins/numeric_conversions.zig
+++ b/src/builtins/numeric_conversions.zig
@@ -188,6 +188,15 @@ pub fn decToIntWrapBits(dec_value: i128, target_bits: u32) u128 {
     return magnitude & (i128h.shl(1, @intCast(target_bits)) - 1);
 }
 
+/// Convert a Roc Dec payload to an integer using Roc's wrapping Dec-to-integer
+/// semantics (see `decToIntWrapBits`).
+pub fn decToIntWrap(comptime Int: type, dec_value: i128) Int {
+    const int_info = @typeInfo(Int).int;
+    const bits = decToIntWrapBits(dec_value, int_info.bits);
+    const U = std.meta.Int(.unsigned, int_info.bits);
+    return @bitCast(@as(U, @truncate(bits)));
+}
+
 /// Convert a Roc Dec payload to raw target integer bits after truncating.
 pub fn decToIntTryBits(dec_value: i128, target_bits: u32, target_signed: bool) ?u128 {
     const whole_part = i128h.divTrunc_i128(dec_value, dec.RocDec.one_point_zero_i128);

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -7550,8 +7550,7 @@ pub const Interpreter = struct {
 
     fn decToInt(self: *LirInterpreter, comptime Dst: type, arg: Value, ret_layout: layout_mod.Idx) Error!Value {
         const val = try self.alloc(ret_layout);
-        const dec = RocDec{ .num = arg.read(i128) };
-        val.write(Dst, builtins.dec.toIntWrap(Dst, dec));
+        val.write(Dst, builtins.numeric_conversions.decToIntWrap(Dst, arg.read(i128)));
         return val;
     }
 

--- a/src/eval/test/eval_low_level_tests.zig
+++ b/src/eval/test/eval_low_level_tests.zig
@@ -6973,4 +6973,175 @@ pub const tests = [_]TestCase{
         ,
         .expected = .{ .inspect_str = "True" },
     },
+    // Dec's wrapping integer conversions at widths up to 64 bits.
+    .{
+        .name = "low_level - Dec truncates to every integer width up to 64 bits",
+        .source =
+        \\{
+        \\Dec.to_i8_wrap(42.5) == 42
+        \\    and Dec.to_i16_wrap(42.5) == 42
+        \\    and Dec.to_i32_wrap(42.5) == 42
+        \\    and Dec.to_i64_wrap(42.5) == 42
+        \\    and Dec.to_u8_wrap(42.5) == 42
+        \\    and Dec.to_u16_wrap(42.5) == 42
+        \\    and Dec.to_u32_wrap(42.5) == 42
+        \\    and Dec.to_u64_wrap(42.5) == 42
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec truncation wraps at narrow widths",
+        .source =
+        \\{
+        \\Dec.to_i8_wrap(200.0) == -56
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec truncation keeps the sign",
+        .source =
+        \\{
+        \\Dec.to_i32_wrap(-42.5) == -42 and Dec.to_i64_wrap(-42.5) == -42
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    // Dec's wrapping conversions to the 128-bit widths, including an integer
+    // part past the I64 range.
+    .{
+        .name = "low_level - Dec truncates to an I128 past the I64 range",
+        .source =
+        \\{
+        \\big : Dec
+        \\big = 170141183460469231731.0
+        \\Dec.to_i128_wrap(big) == 170141183460469231731
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec truncates to the 128-bit widths",
+        .source =
+        \\{
+        \\Dec.to_i128_wrap(42.5) == 42
+        \\    and Dec.to_i128_wrap(-42.5) == -42
+        \\    and Dec.to_u128_wrap(42.5) == 42
+        \\    and Dec.to_u128_wrap(-42.5) == 340282366920938463463374607431768211414
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    // Every width wraps from the 128-bit quotient, so a Dec whose integer part
+    // is past the I64 range still converts.
+    .{
+        .name = "low_level - Dec wraps to a U64 from past the I64 range",
+        .source =
+        \\{
+        \\big : Dec
+        \\big = 12345678901234567890.0
+        \\Dec.to_u64_wrap(big) == 12345678901234567890
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec wraps to every width up to 64 bits from past the I64 range",
+        .source =
+        \\{
+        \\big : Dec
+        \\big = 12345678901234567890.0
+        \\Dec.to_i8_wrap(big) == -46
+        \\    and Dec.to_u8_wrap(big) == 210
+        \\    and Dec.to_i16_wrap(big) == 2770
+        \\    and Dec.to_u16_wrap(big) == 2770
+        \\    and Dec.to_i32_wrap(big) == -350287150
+        \\    and Dec.to_u32_wrap(big) == 3944680146
+        \\    and Dec.to_i64_wrap(big) == -6101065172474983726
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    // A negative Dec converted to an unsigned width, where the result's high bits
+    // come from the sign.
+    .{
+        .name = "low_level - Dec wraps a negative value to every unsigned width",
+        .source =
+        \\{
+        \\Dec.to_u8_wrap(-42.5) == 214
+        \\    and Dec.to_u16_wrap(-42.5) == 65494
+        \\    and Dec.to_u32_wrap(-42.5) == 4294967254
+        \\    and Dec.to_u64_wrap(-42.5) == 18446744073709551574
+        \\    and Dec.to_i8_wrap(-42.5) == -42
+        \\    and Dec.to_i16_wrap(-42.5) == -42
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec wraps to every width from past the I64 range, negative",
+        .source =
+        \\{
+        \\big : Dec
+        \\big = -12345678901234567890.0
+        \\Dec.to_i8_wrap(big) == 46
+        \\    and Dec.to_u8_wrap(big) == 46
+        \\    and Dec.to_i16_wrap(big) == -2770
+        \\    and Dec.to_u16_wrap(big) == 62766
+        \\    and Dec.to_i32_wrap(big) == 350287150
+        \\    and Dec.to_u32_wrap(big) == 350287150
+        \\    and Dec.to_i64_wrap(big) == 6101065172474983726
+        \\    and Dec.to_i128_wrap(big) == -12345678901234567890
+        \\    and Dec.to_u128_wrap(big) == 340282366920938463451028928530533643566
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec wraps its lowest value to the widest widths",
+        .source =
+        \\{
+        \\Dec.to_i64_wrap(Dec.lowest) == -4120486797083267187
+        \\    and Dec.to_u64_wrap(Dec.lowest) == 14326257276626284429
+        \\    and Dec.to_i128_wrap(Dec.lowest) == -170141183460469231731
+        \\    and Dec.to_u128_wrap(Dec.lowest) == 340282366920938463293233423971298979725
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    // Conversions between the float widths, and from the integer widths into
+    // them. These share the coercion path with the integer-to-integer conversions.
+    .{
+        .name = "low_level - F32.to_f64 widens to the exact same value",
+        .source = "F64.to_bits(F32.to_f64(F32.from_bits(1036831949)))",
+        .expected = .{ .inspect_str = "4591870180174331904" },
+    },
+    .{
+        .name = "low_level - F64.to_f32_wrap narrows, and overflows to infinity",
+        .source =
+        \\{
+        \\F32.to_bits(F64.to_f32_wrap(F64.from_bits(4591870180066957722))) == 1036831949
+        \\    and F32.to_bits(F64.to_f32_wrap(F64.from_bits(9094988921128908188))) == 2139095040
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - U64.to_f64 reads the source as unsigned",
+        .source = "F64.to_bits(U64.to_f64(18446744073709551615))",
+        .expected = .{ .inspect_str = "4895412794951729152" },
+    },
+    .{
+        .name = "low_level - integers convert to floats at the 16- and 32-bit widths",
+        .source =
+        \\{
+        \\F64.to_bits(U32.to_f64(4294967295)) == 4751297606873776128
+        \\    and F64.to_bits(I32.to_f64(-2147483648)) == 13970166044103278592
+        \\    and F32.to_bits(U16.to_f32(65535)) == 1199570688
+        \\    and F64.to_bits(I16.to_f64(-32768)) == 13898108450065350656
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
 };

--- a/src/postcheck/lambda_mono/eval.zig
+++ b/src/postcheck/lambda_mono/eval.zig
@@ -2840,7 +2840,7 @@ pub const Evaluator = struct {
 
     fn decToIntWrap(_: *Evaluator, comptime dst: Primitive, dec_num: i128) EvalError!Value {
         const T = intType(dst);
-        return makeInt(T, builtins.dec.toIntWrap(T, .{ .num = dec_num }));
+        return makeInt(T, builtins.numeric_conversions.decToIntWrap(T, dec_num));
     }
 
     fn zeroValue(self: *Evaluator, comptime prim: Primitive) Value {


### PR DESCRIPTION
This PR fixes a number of `Dec`-to-integer wrapping conversion bugs:
1. `Dec`'s wrapping integer conversions are broken on the LLVM backend, silently returning wrong values.
2. On the dev backend, those conversions panic if the `Dec`'s integer part is outside the `I64` range.
3. The dev backend's `U128` results are also wrong for negative `Dec`s even within the `I64` range.

(Note that the non-wrapping `Dec`-to-integer conversions that return a `Try` were already correct.)

**Causes**

- **The LLVM backend doesn't implement any of the wrapping `Dec`-to-integer conversions.**
  - None of the ten `dec_to_*_trunc` ops (the lowering behind `to_*_wrap`) appear in its numeric-conversion switch. They fall through to a fallback that matches on the op's *name*: `_to_` present, `_try` and `_str` absent. And that fallback lowers them as a plain coercion of the operand.
  - Note that that's the right lowering between two integers (which is probably why it was written that way), but a `Dec` source has to be divided by 10^18 first, so coercion is wrong for `Dec`.
- **The dev backend divides into an `i64`.**
  - The builtin that the dev backend calls for the wrapping conversions narrows the `Dec`'s integer part to an `i64` with `@intCast`, which panics when the value doesn't fit.
  - This means any wrapping `Dec`-to-int conversion breaks if the `Dec`'s integer part is outside the `I64` range, rather than just truncating the bits above 64 (that is, wrapping the value mod 2^64) like it should.
  - For example, `Dec.to_u64_wrap(12345678901234567890.0)` panics, because that number doesn't fit in an `I64`, rather than just returning that value mod 2^64 like it's supposed to.
- **The dev backend also builds its `I128` and `U128` results from that same `i64`.**
  - **What it should do:** computing the integer part of a `Dec` produces a 128-bit value, so the conversion should return all 128 bits of it.
  - **What it does instead:** it keeps the low 64 bits and rebuilds the high 64 from them.
    - For `I128` it sign-extends, which reproduces the original only if the original was in `I64`'s range.
    - For `U128` it zero-fills, which reproduces the original only if the original was in `U64`'s range.
  - The panic above hides most of this, since anything outside the `I64` range dies before reaching here. The one symptom you can observe is a negative `Dec` converted to `U128`: `Dec.to_u128_wrap(-42.5)` returns 2^64 − 42 instead of 2^128 − 42.

The interpreter and wasm backends are already correct at every width.

**Fix**

- **One new builtin, `dec_to_int_wrap`, serves every width.** It is the wrapping counterpart to the existing `dec_to_int_try_unsafe`. It takes the width as a parameter, computes the integer part at 128 bits, and wraps to the requested width, so all ten widths are one call rather than a choice of builtin.
- **The fallback matches on operand layouts, not the op's name.** Integer-to-float and float-to-float conversions are now selected that way as well, which is why this PR adds tests for them.
- **A conversion with no lowering fails the compile,** rather than crashing at run time.

Sharing one builtin removes the asymmetry behind these bugs. The checked conversions were never broken, because they already had one generic builtin. The wrapping ones had only `dec_to_i64_trunc`, too narrow for the values a `Dec` can hold.

**Verification**

These conversions had no tests anywhere. PR CI runs only a narrow LLVM check — one filtered invocation for exact float bits — so it cannot exercise most of this change. The full suite under LLVM runs in the nightly gate.

Ran locally with `--llvm`:

- **Green at the tip** — 1825 tests, 0 failures, across interpreter, dev, wasm, and LLVM.
- **Commits 1 through 3 are red on purpose** — run on their own, the same tests fail three ways as the fallback tightens: wrong values, then a crash, then a build failure.
- **Commits 5 through 7 are cleanup** and change no behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







