### PR TITLE
Reject static dispatches targeting annotation-only method declarations

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -21020,6 +21020,11 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
                     const method_binding = method_lookup.binding;
                     const def_idx = method_binding.def_idx;
                     const def = method_env.store.getDef(def_idx);
+                    if (method_env.store.getExpr(def.expr) == .e_anno_only) {
+                        try self.poisonConstraintFailure(deferred_constraint.var_, constraint, env, failure_expr);
+                        try self.markStaticDispatchRejected(constraint);
+                        continue;
+                    }
                     // Track whether we just processed or referenced a cycle participant.
                     var cycle_method_expr_var: ?Var = null;
 

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -125,6 +125,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10298_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10368_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10395_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10346_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10508_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10503_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10561_test.zig"));

--- a/src/compile/test/issue_10346_test.zig
+++ b/src/compile/test/issue_10346_test.zig
@@ -1,0 +1,22 @@
+//! Regression test for issue #10346.
+
+const expectLowersToLirWithOptions = @import("lower_to_lir_harness.zig").expectLowersToLirWithOptions;
+
+test "issue 10346: numeric literal dispatching to annotation-only method does not panic publication or lowering" {
+    try expectLowersToLirWithOptions(
+        \\MyNum := U64.{
+        \\    from_numeral : _
+        \\}
+        \\
+        \\a = {
+        \\    x : MyNum
+        \\    x = 42
+        \\    x
+        \\}
+        \\
+        \\main! = |_| {
+        \\    a
+        \\    Ok({})
+        \\}
+    , .{ .allow_user_errors = true });
+}

--- a/src/compile/test/lower_to_lir_harness.zig
+++ b/src/compile/test/lower_to_lir_harness.zig
@@ -84,6 +84,7 @@ pub const LirLoweringOptions = struct {
     list_in_place_map: bool = false,
     proc_debug_names: bool = false,
     prove_ranges: bool = false,
+    allow_user_errors: bool = false,
     /// Receives the expression count of the lifted program handed to lambda-set
     /// solving, for tests that assert on post-check program growth.
     lifted_expr_count_out: ?*usize = null,
@@ -264,10 +265,14 @@ fn lowerAppPathToLir(
     try coord.start();
     try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
     try coord.coordinatorLoop();
-    try std.testing.expect(!coord.hasUserErrors());
+    if (!opts.allow_user_errors) {
+        try std.testing.expect(!coord.hasUserErrors());
+    }
 
     try coord.finalizeExecutableArtifacts();
-    try std.testing.expect(!coord.hasUserErrors());
+    if (!opts.allow_user_errors) {
+        try std.testing.expect(!coord.hasUserErrors());
+    }
 
     const root = coord.executableRootCheckedArtifact();
     const imports = try coord.collectImportedArtifactViews(arena, root);

--- a/test/snapshots/issue/method_call_inspect_defined.md
+++ b/test/snapshots/issue/method_call_inspect_defined.md
@@ -63,13 +63,9 @@ EndOfFile,
 			(e-literal (string "hello"))))
 	(s-expr
 		(e-runtime-error (tag "expr_not_canonicalized")))
-	(e-dispatch-call (method "inspect") (constraint-fn-var 209)
-		(receiver
-			(e-lookup-local
-				(p-assign (ident "x"))))
-		(args)))
+	(e-runtime-error (tag "erroneous_value_expr")))
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Str"))
+(expr (type "_a"))
 ~~~


### PR DESCRIPTION
When a static dispatch plan (such as literal from_numeral conversions) targets a method declaration that has a type annotation but no implementation body (`.e_anno_only`), constraint resolution recorded the target without verifying it was a function implementation.
During checked artifact publication, callable specialization failed to extract a function payload and panicked.

Updated static dispatch resolution to check whether target method declarations are annotation-only.
When an annotation-only method target is encountered, the dispatch is marked as rejected so type checking reports the missing implementation diagnostic instead of panicking during publication.

Fixes #10346