### PR TITLE
Regenerate snapshots after erroneous-type poisoning fix

### DIFF
--- a/test/snapshots/can_list_rest_types.md
+++ b/test/snapshots/can_list_rest_types.md
@@ -71,5 +71,5 @@ match numbers {
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Error"))
+(expr (type "List(_a)"))
 ~~~

--- a/test/snapshots/can_var_scoping_regular_var.md
+++ b/test/snapshots/can_var_scoping_regular_var.md
@@ -133,13 +133,68 @@ NO CHANGE
 (can-ir
 	(d-let
 		(p-assign (ident "processItems"))
-		(e-runtime-error (tag "erroneous_value_expr"))))
+		(e-lambda
+			(args
+				(p-assign (ident "items")))
+			(e-block
+				(s-var
+					(p-assign (ident "count_"))
+					(e-num (value "0")))
+				(s-var
+					(p-assign (ident "total_"))
+					(e-num (value "0")))
+				(s-reassign
+					(p-assign (ident "count_"))
+					(e-dispatch-call (method "plus") (constraint-fn-var 253)
+						(receiver
+							(e-lookup-local
+								(p-assign (ident "count_"))))
+						(args
+							(e-num (value "1")))))
+				(s-reassign
+					(p-assign (ident "total_"))
+					(e-dispatch-call (method "plus") (constraint-fn-var 262)
+						(receiver
+							(e-lookup-local
+								(p-assign (ident "total_"))))
+						(args
+							(e-num (value "10")))))
+				(s-let
+					(p-assign (ident "nestedFunc"))
+					(e-closure
+						(captures
+							(capture (ident "count_")))
+						(e-lambda
+							(args
+								(p-underscore))
+							(e-block
+								(s-reassign
+									(p-assign (ident "count_"))
+									(e-runtime-error (tag "var_across_function_boundary")))
+								(s-reassign
+									(p-assign (ident "total_"))
+									(e-runtime-error (tag "var_across_function_boundary")))
+								(e-lookup-local
+									(p-assign (ident "count_")))))))
+				(s-let
+					(p-assign (ident "result"))
+					(e-call (constraint-fn-var 266)
+						(e-lookup-local
+							(p-assign (ident "nestedFunc")))
+						(e-empty_record)))
+				(e-dispatch-call (method "plus") (constraint-fn-var 267)
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "total_"))))
+					(args
+						(e-lookup-local
+							(p-assign (ident "result")))))))))
 ~~~
 # TYPES
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "_arg -> Error")))
+		(patt (type "_arg -> a where [a.from_numeral : Numeral -> Try(a, [InvalidNumeral(Str)]), a.plus : a, b -> a, b.from_numeral : Numeral -> Try(b, [InvalidNumeral(Str)]), b.plus : b, c -> b, c.from_numeral : Numeral -> Try(c, [InvalidNumeral(Str)])]")))
 	(expressions
-		(expr (type "_arg -> Error"))))
+		(expr (type "_arg -> a where [a.from_numeral : Numeral -> Try(a, [InvalidNumeral(Str)]), a.plus : a, b -> a, b.from_numeral : Numeral -> Try(b, [InvalidNumeral(Str)]), b.plus : b, c -> b, c.from_numeral : Numeral -> Try(c, [InvalidNumeral(Str)])]"))))
 ~~~

--- a/test/snapshots/formatting/multiline/everything.md
+++ b/test/snapshots/formatting/multiline/everything.md
@@ -695,7 +695,7 @@ NO CHANGE
 												(p-assign (ident "y"))))))))))
 				(s-let
 					(p-assign (ident "h2"))
-					(e-call (constraint-fn-var 346)
+					(e-call (constraint-fn-var 344)
 						(e-lookup-local
 							(p-assign (ident "h")))
 						(e-lookup-local

--- a/test/snapshots/formatting/multiline_without_comma/everything.md
+++ b/test/snapshots/formatting/multiline_without_comma/everything.md
@@ -732,7 +732,7 @@ h = |x, y| {
 												(p-assign (ident "y"))))))))))
 				(s-let
 					(p-assign (ident "h2"))
-					(e-call (constraint-fn-var 346)
+					(e-call (constraint-fn-var 344)
 						(e-lookup-local
 							(p-assign (ident "h")))
 						(e-lookup-local

--- a/test/snapshots/formatting/singleline/everything.md
+++ b/test/snapshots/formatting/singleline/everything.md
@@ -491,7 +491,7 @@ NO CHANGE
 												(p-assign (ident "y"))))))))))
 				(s-let
 					(p-assign (ident "h2"))
-					(e-call (constraint-fn-var 351)
+					(e-call (constraint-fn-var 349)
 						(e-lookup-local
 							(p-assign (ident "h")))
 						(e-lookup-local

--- a/test/snapshots/formatting/singleline_with_comma/everything.md
+++ b/test/snapshots/formatting/singleline_with_comma/everything.md
@@ -599,7 +599,7 @@ h = |
 												(p-assign (ident "y"))))))))))
 				(s-let
 					(p-assign (ident "h2"))
-					(e-call (constraint-fn-var 346)
+					(e-call (constraint-fn-var 344)
 						(e-lookup-local
 							(p-assign (ident "h")))
 						(e-lookup-local

--- a/test/snapshots/fuzz_crash/fuzz_crash_023.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_023.md
@@ -1080,7 +1080,8 @@ MISSING METHOD - fuzz_crash_023.md:189:26:189:66
 
     The `match_time` function has the type:
 
-        [Blue, Green, Red, ..], _arg -> Error
+        [Blue, Green, Red, ..], _arg -> d
+          where [d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]
 
     Are there any missing commas?
 
@@ -2130,7 +2131,11 @@ expect {
 				(ty-lookup (name "U64") (builtin)))))
 	(d-let
 		(p-assign (ident "match_time"))
-		(e-runtime-error (tag "erroneous_value_expr")))
+		(e-lambda
+			(args
+				(p-assign (ident "a"))
+				(p-assign (ident "b")))
+			(e-runtime-error (tag "erroneous_value_expr"))))
 	(d-let
 		(p-assign (ident "qux"))
 		(e-anno-only)
@@ -2173,7 +2178,8 @@ expect {
 					(p-assign (ident "tag_with_payload"))
 					(e-tag (name "Ok")
 						(args
-							(e-runtime-error (tag "erroneous_value_use")))))
+							(e-lookup-local
+								(p-assign (ident "number"))))))
 				(s-let
 					(p-assign (ident "interpolated"))
 					(e-block
@@ -2181,7 +2187,7 @@ expect {
 							(p-assign (ident "#interp_0"))
 							(e-lookup-local
 								(p-assign (ident "world"))))
-						(e-interpolation (constraint-fn-var 1535) (dispatcher-var 376)
+						(e-interpolation (constraint-fn-var 1572) (dispatcher-var 376)
 							(first
 								(e-literal (string "Hello, ")))
 							(parts
@@ -2199,9 +2205,10 @@ expect {
 							(e-runtime-error (tag "erroneous_value_expr")))
 						(s-reassign
 							(p-assign (ident "number"))
-							(e-dispatch-call (method "plus") (constraint-fn-var 1617)
+							(e-dispatch-call (method "plus") (constraint-fn-var 1654)
 								(receiver
-									(e-runtime-error (tag "erroneous_value_use")))
+									(e-lookup-local
+										(p-assign (ident "number"))))
 								(args
 									(e-runtime-error (tag "erroneous_value_use")))))
 						(e-empty_record)))
@@ -2224,11 +2231,11 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 1741)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 1777)
 									(receiver
 										(e-runtime-error (tag "erroneous_value_expr")))
 									(args
-										(e-dispatch-call (method "times") (constraint-fn-var 1738)
+										(e-dispatch-call (method "times") (constraint-fn-var 1774)
 											(receiver
 												(e-num (value "5")))
 											(args
@@ -2243,18 +2250,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 1774)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 1810)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 1764)
+															(e-dispatch-call (method "plus") (constraint-fn-var 1800)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 1801)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 1837)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 1791)
+															(e-dispatch-call (method "minus") (constraint-fn-var 1827)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2269,11 +2276,11 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 1838)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 1874)
 										(receiver
 											(e-num (value "12")))
 										(args
-											(e-dispatch-call (method "div_by") (constraint-fn-var 1835)
+											(e-dispatch-call (method "div_by") (constraint-fn-var 1871)
 												(receiver
 													(e-num (value "3")))
 												(args
@@ -2288,12 +2295,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 1896)
+													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 1932)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 1867)
+																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 1903)
 																			(receiver
 																				(e-runtime-error (tag "erroneous_value_expr")))
 																			(args)))
@@ -2519,7 +2526,7 @@ expect {
 	(defs
 		(patt (type "Bool -> d where [d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]"))
 		(patt (type "U64 -> U64"))
-		(patt (type "[Blue, Green, Red, ..], _arg -> Error"))
+		(patt (type "[Blue, Green, Red, ..], _arg -> d where [d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]"))
 		(patt (type "Error"))
 		(patt (type "List(Error) -> Try({}, _d)"))
 		(patt (type "{}"))
@@ -2566,7 +2573,7 @@ expect {
 	(expressions
 		(expr (type "Bool -> d where [d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]"))
 		(expr (type "U64 -> U64"))
-		(expr (type "[Blue, Green, Red, ..], _arg -> Error"))
+		(expr (type "[Blue, Green, Red, ..], _arg -> d where [d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]"))
 		(expr (type "Error"))
 		(expr (type "List(Error) -> Try({}, _d)"))
 		(expr (type "{}"))

--- a/test/snapshots/fuzz_crash/fuzz_crash_027.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_027.md
@@ -1874,7 +1874,7 @@ main! = |_| { # Yeah Ie
 							(p-assign (ident "#interp_0"))
 							(e-lookup-local
 								(p-assign (ident "world"))))
-						(e-interpolation (constraint-fn-var 1107) (dispatcher-var 318)
+						(e-interpolation (constraint-fn-var 1148) (dispatcher-var 318)
 							(first
 								(e-literal (string "Hello, ")))
 							(parts

--- a/test/snapshots/fuzz_crash/fuzz_crash_101.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_101.md
@@ -40,7 +40,7 @@ TYPE MISMATCH - fuzz_crash_101.md:2:3:2:13
 
     But the annotation says it should be:
 
-        (), (({}) -> Error), (({}) -> d) -> Error
+        (), (({}) -> c), (({}) -> d) -> c
 
     Hint: This function expects 3 arguments but got 1.
 

--- a/test/snapshots/fuzz_crash/fuzz_hang_004.md
+++ b/test/snapshots/fuzz_crash/fuzz_hang_004.md
@@ -140,7 +140,26 @@ a = || {}
 (can-ir
 	(d-let
 		(p-assign (ident "s"))
-		(e-runtime-error (tag "erroneous_value_expr")))
+		(e-block
+			(e-match
+				(match
+					(cond
+						(e-runtime-error (tag "erroneous_value_expr")))
+					(branches
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-list
+										(patterns))))
+							(value
+								(e-empty_list)))
+						(branch
+							(patterns
+								(pattern (degenerate false)
+									(p-list
+										(patterns))))
+							(value
+								(e-runtime-error (tag "erroneous_value_expr")))))))))
 	(d-let
 		(p-assign (ident "a"))
 		(e-lambda
@@ -151,9 +170,9 @@ a = || {}
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "Error"))
+		(patt (type "List(_b)"))
 		(patt (type "({}) -> {}")))
 	(expressions
-		(expr (type "Error"))
+		(expr (type "List(_b)"))
 		(expr (type "({}) -> {}"))))
 ~~~

--- a/test/snapshots/local_let_mutual_recursion.md
+++ b/test/snapshots/local_let_mutual_recursion.md
@@ -140,21 +140,21 @@ EndOfFile,
 								(builtin)
 								(e-tag (name "False")))))
 					(if-else
-						(e-call (constraint-fn-var 291)
+						(e-call (constraint-fn-var 290)
 							(e-lookup-local
 								(p-assign (ident "is_even")))
-							(e-dispatch-call (method "minus") (constraint-fn-var 289)
+							(e-dispatch-call (method "minus") (constraint-fn-var 288)
 								(receiver
 									(e-lookup-local
 										(p-assign (ident "n"))))
 								(args
 									(e-num (value "1")))))))))
-		(e-call (constraint-fn-var 309)
+		(e-call (constraint-fn-var 307)
 			(e-lookup-local
 				(p-assign (ident "is_even")))
 			(e-num (value "4")))))
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "_arg -> Error"))
+(expr (type "_arg -> Bool"))
 ~~~

--- a/test/snapshots/match_expr/complex_list_tags.md
+++ b/test/snapshots/match_expr/complex_list_tags.md
@@ -197,7 +197,7 @@ match events {
 							(p-assign (ident "#interp_3"))
 							(e-call
 								(e-runtime-error (tag "qualified_ident_does_not_exist"))
-								(e-call
+								(e-call (constraint-fn-var 371)
 									(e-lookup-external
 										(builtin))
 									(e-lookup-local
@@ -315,5 +315,5 @@ match events {
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Error"))
+(expr (type "Str"))
 ~~~

--- a/test/snapshots/match_expr/nested_list_scoping.md
+++ b/test/snapshots/match_expr/nested_list_scoping.md
@@ -13,6 +13,7 @@ match nestedList {
 ~~~
 # EXPECTED
 MISSING METHOD - nested_list_scoping.md:4:17:4:22
+POLYMORPHIC VALUE - nested_list_scoping.md:1:1:5:2
 # PROBLEMS
 
 ┌────────────────┐
@@ -29,6 +30,23 @@ MISSING METHOD - nested_list_scoping.md:4:17:4:22
 
     Hint: The `*` operator calls a method named `times` on the value preceding
     it, passing the value after the operator as the one argument.
+
+
+┌───────────────────┐
+│ POLYMORPHIC VALUE ├─ This top-level value still has an unresolved ──────────┐
+└┬──────────────────┘  polymorphic type.                                      │
+ │                                                                            │
+ │  match nestedList {                                                        │
+ │      [[x], [y]] => x + y                                                   │
+ │      [[x, y]] => x - y                                                     │
+ │      [x, [y]] => x * y                                                     │
+ │  }                                                                         │
+ │                                                                            │
+ └──────────────────────────────────────────────── nested_list_scoping.md:1:1 ┘
+
+    Its type is:
+    a where [a.minus : a, a -> a, a.plus : a, a -> a]
+    Add an annotation or use this value in a way that fixes its concrete type.
 
 # TOKENS
 ~~~zig
@@ -139,5 +157,5 @@ match nestedList {
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Error"))
+(expr (type "a where [a.minus : a, a -> a, a.plus : a, a -> a]"))
 ~~~

--- a/test/snapshots/match_expr/pattern_as_nested.md
+++ b/test/snapshots/match_expr/pattern_as_nested.md
@@ -11,9 +11,30 @@ match person {
 }
 ~~~
 # EXPECTED
-NIL
+TYPE MISMATCH - pattern_as_nested.md:3:33:3:64
 # PROBLEMS
-NIL
+
+┌───────────────┐
+│ TYPE MISMATCH ├─ The second branch of this `match` does not match the ──────┐
+└┬──────────────┘  previous branch .                                          │
+ │                                                                            │
+ │  { name } as simplePerson => (simplePerson, name, "unknown")               │
+ │                              ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾               │
+ └───────────────────────────────────────────────── pattern_as_nested.md:3:33 ┘
+
+    The second branch is:
+
+        ({ name: a }, a, b) where [b.from_quote : Str -> Try(b,
+        [BadQuotedBytes(Str)])]
+
+    But the previous branch results in:
+
+        ({ address: { city: a }, name: _field }, { city: a }, a)
+
+    All branches in a `match` must have compatible types.
+    Note: You can wrap branches values in a tag to make them compatible.
+    To learn about tags, see <https://www.roc-lang.org/tutorial#tags>
+
 # TOKENS
 ~~~zig
 KwMatch,LowerIdent,OpenCurly,
@@ -133,5 +154,5 @@ match person {
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "(Error, { city: Str }, Str)"))
+(expr (type "Error"))
 ~~~

--- a/test/snapshots/match_expr/variable_shadowing.md
+++ b/test/snapshots/match_expr/variable_shadowing.md
@@ -11,9 +11,24 @@ match (value, other) {
 }
 ~~~
 # EXPECTED
-NIL
+POLYMORPHIC VALUE - variable_shadowing.md:1:1:4:2
 # PROBLEMS
-NIL
+
+┌───────────────────┐
+│ POLYMORPHIC VALUE ├─ This top-level value still has an unresolved ──────────┐
+└┬──────────────────┘  polymorphic type.                                      │
+ │                                                                            │
+ │  match (value, other) {                                                    │
+ │      (Some(x), y) => x + y                                                 │
+ │      (None, x) => x * 2                                                    │
+ │  }                                                                         │
+ │                                                                            │
+ └───────────────────────────────────────────────── variable_shadowing.md:1:1 ┘
+
+    Its type is:
+    a where [a.plus : a, _arg -> a, a.times : a, Dec -> a]
+    Add an annotation or use this value in a way that fixes its concrete type.
+
 # TOKENS
 ~~~zig
 KwMatch,OpenRound,LowerIdent,Comma,LowerIdent,CloseRound,OpenCurly,
@@ -94,5 +109,5 @@ match (value, other) {
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Error"))
+(expr (type "a where [a.plus : a, _arg -> a, a.times : a, Dec -> a]"))
 ~~~

--- a/test/snapshots/question_in_top_level_def_error.md
+++ b/test/snapshots/question_in_top_level_def_error.md
@@ -104,7 +104,8 @@ result = f(3)?
 						(if-branch
 							(e-dispatch-call (method "is_lt") (constraint-fn-var 265)
 								(receiver
-									(e-runtime-error (tag "erroneous_value_use")))
+									(e-lookup-local
+										(p-assign (ident "x"))))
 								(args
 									(e-num (value "0"))))
 							(e-block
@@ -115,7 +116,8 @@ result = f(3)?
 						(e-block
 							(e-tag (name "Ok")
 								(args
-									(e-runtime-error (tag "erroneous_value_use")))))))))
+									(e-lookup-local
+										(p-assign (ident "x"))))))))))
 		(annotation
 			(ty-fn (effectful false)
 				(ty-lookup (name "I64") (builtin))
@@ -125,15 +127,37 @@ result = f(3)?
 						(ty-tag-name (name "IsNegative")))))))
 	(d-let
 		(p-assign (ident "result"))
-		(e-runtime-error (tag "erroneous_value_expr"))))
+		(e-match
+			(match
+				(cond
+					(e-call (constraint-fn-var 291)
+						(e-lookup-local
+							(p-assign (ident "f")))
+						(e-num (value "3"))))
+				(branches
+					(branch
+						(patterns
+							(pattern (degenerate false)
+								(p-nominal-external (builtin)
+									(p-applied-tag))))
+						(value
+							(e-lookup-local
+								(p-assign (ident "#ok")))))
+					(branch
+						(patterns
+							(pattern (degenerate false)
+								(p-nominal-external (builtin)
+									(p-applied-tag))))
+						(value
+							(e-runtime-error (tag "return_outside_fn")))))))))
 ~~~
 # TYPES
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "Error -> Try(Error, [IsNegative])"))
-		(patt (type "Error")))
+		(patt (type "I64 -> Try(I64, [IsNegative])"))
+		(patt (type "I64")))
 	(expressions
-		(expr (type "Error -> Try(Error, [IsNegative])"))
-		(expr (type "Error"))))
+		(expr (type "I64 -> Try(I64, [IsNegative])"))
+		(expr (type "I64"))))
 ~~~

--- a/test/snapshots/static_dispatch_scheme_position_matrix.md
+++ b/test/snapshots/static_dispatch_scheme_position_matrix.md
@@ -326,7 +326,7 @@ roundtrip = parse_show("hi")
 		(e-lambda
 			(args
 				(p-assign (ident "x")))
-			(e-dispatch-call (method "to_i128") (constraint-fn-var 330)
+			(e-dispatch-call (method "to_i128") (constraint-fn-var 329)
 				(receiver
 					(e-lookup-local
 						(p-assign (ident "x"))))
@@ -342,7 +342,7 @@ roundtrip = parse_show("hi")
 					(ty-lookup (name "I128") (builtin))))))
 	(d-let
 		(p-assign (ident "ok_arg"))
-		(e-call (constraint-fn-var 342)
+		(e-call (constraint-fn-var 341)
 			(e-lookup-local
 				(p-assign (ident "via_arg")))
 			(e-typed-int (value "5") (type "U8"))))
@@ -366,7 +366,7 @@ roundtrip = parse_show("hi")
 												(p-assign (ident "x")))
 											(rest-at (index 1)))))
 								(value
-									(e-dispatch-call (method "to_i128") (constraint-fn-var 358)
+									(e-dispatch-call (method "to_i128") (constraint-fn-var 357)
 										(receiver
 											(e-lookup-local
 												(p-assign (ident "x"))))
@@ -390,7 +390,7 @@ roundtrip = parse_show("hi")
 					(ty-lookup (name "I128") (builtin))))))
 	(d-let
 		(p-assign (ident "ok_data"))
-		(e-call (constraint-fn-var 379)
+		(e-call (constraint-fn-var 378)
 			(e-lookup-local
 				(p-assign (ident "via_data")))
 			(e-list
@@ -416,7 +416,7 @@ roundtrip = parse_show("hi")
 					(ty-rigid-var-lookup (ty-rigid-var (name "a")))))))
 	(d-let
 		(p-assign (ident "unpinned_ret"))
-		(e-call (constraint-fn-var 399)
+		(e-call (constraint-fn-var 398)
 			(e-lookup-local
 				(p-assign (ident "gen")))
 			(e-empty_record)))
@@ -431,7 +431,7 @@ roundtrip = parse_show("hi")
 				(s-let
 					(p-assign (ident "v"))
 					(e-runtime-error (tag "erroneous_value_expr")))
-				(e-dispatch-call (method "show") (constraint-fn-var 409)
+				(e-dispatch-call (method "show") (constraint-fn-var 407)
 					(receiver
 						(e-lookup-local
 							(p-assign (ident "v"))))

--- a/test/snapshots/syntax_grab_bag.md
+++ b/test/snapshots/syntax_grab_bag.md
@@ -972,7 +972,8 @@ MISSING METHOD - syntax_grab_bag.md:189:26:189:66
 
     The `match_time` function has the type:
 
-        [Blue, Green, Red, ..], _arg -> Error
+        [Blue, Green, Red, ..], _arg -> d
+          where [d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]
 
     Are there any missing commas?
 
@@ -2018,7 +2019,11 @@ expect {
 				(ty-lookup (name "U64") (builtin)))))
 	(d-let
 		(p-assign (ident "match_time"))
-		(e-runtime-error (tag "erroneous_value_expr")))
+		(e-lambda
+			(args
+				(p-assign (ident "a"))
+				(p-assign (ident "b")))
+			(e-runtime-error (tag "erroneous_value_expr"))))
 	(d-let
 		(p-assign (ident "main!"))
 		(e-lambda
@@ -2056,7 +2061,8 @@ expect {
 					(p-assign (ident "tag_with_payload"))
 					(e-tag (name "Ok")
 						(args
-							(e-runtime-error (tag "erroneous_value_use")))))
+							(e-lookup-local
+								(p-assign (ident "number"))))))
 				(s-let
 					(p-assign (ident "interpolated"))
 					(e-block
@@ -2064,7 +2070,7 @@ expect {
 							(p-assign (ident "#interp_0"))
 							(e-lookup-local
 								(p-assign (ident "world"))))
-						(e-interpolation (constraint-fn-var 1533) (dispatcher-var 376)
+						(e-interpolation (constraint-fn-var 1570) (dispatcher-var 376)
 							(first
 								(e-literal (string "Hello, ")))
 							(parts
@@ -2082,9 +2088,10 @@ expect {
 							(e-runtime-error (tag "erroneous_value_expr")))
 						(s-reassign
 							(p-assign (ident "number"))
-							(e-dispatch-call (method "plus") (constraint-fn-var 1615)
+							(e-dispatch-call (method "plus") (constraint-fn-var 1652)
 								(receiver
-									(e-runtime-error (tag "erroneous_value_use")))
+									(e-lookup-local
+										(p-assign (ident "number"))))
 								(args
 									(e-runtime-error (tag "erroneous_value_use")))))
 						(e-empty_record)))
@@ -2102,11 +2109,11 @@ expect {
 					(e-if
 						(if-branches
 							(if-branch
-								(e-dispatch-call (method "is_gt") (constraint-fn-var 1751)
+								(e-dispatch-call (method "is_gt") (constraint-fn-var 1788)
 									(receiver
 										(e-runtime-error (tag "erroneous_value_expr")))
 									(args
-										(e-dispatch-call (method "times") (constraint-fn-var 1748)
+										(e-dispatch-call (method "times") (constraint-fn-var 1785)
 											(receiver
 												(e-num (value "5")))
 											(args
@@ -2121,18 +2128,18 @@ expect {
 										(e-if
 											(if-branches
 												(if-branch
-													(e-dispatch-call (method "is_lt") (constraint-fn-var 1784)
+													(e-dispatch-call (method "is_lt") (constraint-fn-var 1821)
 														(receiver
-															(e-dispatch-call (method "plus") (constraint-fn-var 1774)
+															(e-dispatch-call (method "plus") (constraint-fn-var 1811)
 																(receiver
 																	(e-num (value "13")))
 																(args
 																	(e-num (value "2")))))
 														(args
 															(e-num (value "5"))))
-													(e-dispatch-call (method "is_gte") (constraint-fn-var 1811)
+													(e-dispatch-call (method "is_gte") (constraint-fn-var 1848)
 														(receiver
-															(e-dispatch-call (method "minus") (constraint-fn-var 1801)
+															(e-dispatch-call (method "minus") (constraint-fn-var 1838)
 																(receiver
 																	(e-num (value "10")))
 																(args
@@ -2147,11 +2154,11 @@ expect {
 											(builtin)
 											(e-tag (name "True")))))
 								(if-else
-									(e-dispatch-call (method "is_lte") (constraint-fn-var 1848)
+									(e-dispatch-call (method "is_lte") (constraint-fn-var 1885)
 										(receiver
 											(e-num (value "12")))
 										(args
-											(e-dispatch-call (method "div_by") (constraint-fn-var 1845)
+											(e-dispatch-call (method "div_by") (constraint-fn-var 1882)
 												(receiver
 													(e-num (value "3")))
 												(args
@@ -2166,12 +2173,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 1906)
+													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 1943)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 1877)
+																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 1914)
 																			(receiver
 																				(e-runtime-error (tag "erroneous_value_expr")))
 																			(args)))
@@ -2397,7 +2404,7 @@ expect {
 	(defs
 		(patt (type "Bool -> d where [d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]"))
 		(patt (type "U64 -> U64"))
-		(patt (type "[Blue, Green, Red, ..], _arg -> Error"))
+		(patt (type "[Blue, Green, Red, ..], _arg -> d where [d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]"))
 		(patt (type "List(Error) -> Try({}, _d)"))
 		(patt (type "{}"))
 		(patt (type "Error")))
@@ -2443,7 +2450,7 @@ expect {
 	(expressions
 		(expr (type "Bool -> d where [d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]"))
 		(expr (type "U64 -> U64"))
-		(expr (type "[Blue, Green, Red, ..], _arg -> Error"))
+		(expr (type "[Blue, Green, Red, ..], _arg -> d where [d.from_numeral : Numeral -> Try(d, [InvalidNumeral(Str)])]"))
 		(expr (type "List(Error) -> Try({}, _d)"))
 		(expr (type "{}"))
 		(expr (type "Error"))))

--- a/test/snapshots/type_local_scope_vars.md
+++ b/test/snapshots/type_local_scope_vars.md
@@ -237,7 +237,11 @@ main! = |_| {}
 							(p-assign (ident "a")))))
 				(s-let
 					(p-assign (ident "_result4"))
-					(e-runtime-error (tag "erroneous_value_expr")))
+					(e-call (constraint-fn-var 273)
+						(e-lookup-local
+							(p-assign (ident "g")))
+						(e-lookup-local
+							(p-assign (ident "b")))))
 				(e-lookup-local
 					(p-assign (ident "result")))))
 		(annotation


### PR DESCRIPTION
`main` is red: the nightly gate's `run-check-snapshots` step fails because 19 tracked snapshots no longer match what the compiler generates. The stale snapshots date from #10674, which landed with that exact check already failing on its own PR run — `markErroneous` plus the new `ErroneousType` early-out in `unify` changed a lot of solved output, and the regenerated `.md` files were never committed. This commit is that regeneration (CAN IR, TYPES, PROBLEMS, and the three EXPECTED sections that moved), produced by `zig build run-snapshot-tool -- --update-expected`; the result is byte-identical to what CI generated on Linux, blob hashes included.

The regenerated output is overwhelmingly the improvement #10674 was after: types that used to collapse to `Error` now solve concretely (`local_let_mutual_recursion` goes from `_arg -> Error` to `_arg -> Bool`, `question_in_top_level_def_error` from `Error -> Try(Error, [IsNegative])` to `I64 -> Try(I64, [IsNegative])`), whole defs that used to be replaced by `erroneous_value_expr` now canonicalize normally, and the remaining churn is `constraint-fn-var` renumbering from the vars that are no longer allocated.

Three snapshots gain diagnostics, and all three are real. `nested_list_scoping` and `variable_shadowing` now report POLYMORPHIC VALUE because their types are genuinely polymorphic instead of poisoned. `pattern_as_nested` now reports a TYPE MISMATCH: its second branch destructures `{ name }` out of a value the first branch destructures as `{ name, address: ... }`, and record patterns are closed, so that program can never type check — checking the same source against an annotated scrutinee reports it too, with the sharper "this pattern doesn't bind the `address` field" wording. It was previously silent only because the undefined `person` scrutinee poisoned every pattern to `Error`. Worth noting for follow-up: because an erroneous scrutinee no longer merges with the branch patterns, that error now surfaces at the branch body rather than at the pattern, which is the less useful of the two messages.
