### PR TITLE
Keep match branch patterns consistent when the scrutinee is erroneous

### DIFF
--- a/design.md
+++ b/design.md
@@ -1328,6 +1328,19 @@ Checker sites that own a reported error use `markErroneous` to poison the owning
 solved class directly. No successful ordinary unification propagates an
 existing `.err` into a type that already carries information.
 
+Because `.err` no longer merges, it also no longer relates the operands unified
+against it. A checker site that relies on one variable to carry a relation
+between several others has to supply that relation itself once the carrier is
+erroneous. `match` is the one such site: every branch pattern describes the same
+scrutinee value, and that mutual consistency normally travels through the
+scrutinee's variable. When the scrutinee is already erroneous, the patterns
+unify against a shared fresh variable instead, so a disagreement between two
+patterns is still reported at the pattern that disagrees rather than surfacing
+later as an unexplained branch-body mismatch. The scrutinee's own error is not
+re-reported, the patterns are never related back to it, and the first
+disagreement poisons the shared variable so later patterns short-circuit exactly
+as they do when the scrutinee carries the relation.
+
 ## Type Alias Invariant
 
 Source type aliases are transparent views of their backing type. An alias root
@@ -3281,6 +3294,11 @@ Other solved-graph mutations:
   an already-reported error. It marks the checker node's solved class directly,
   preserving the class-wide cascade suppression previously provided by
   unifying that node with a fresh error variable.
+- `checkMatchExpr`'s branch-pattern target—mechanism: diagnostic recovery after
+  an already-reported error. An erroneous scrutinee cannot relate the branch
+  patterns to each other, so they unify against a shared fresh variable instead
+  of the scrutinee's. An error-free program never reaches the probe, so no
+  program's typechecking or checked-module output changes.
 - `resetAnnotationNodes` (`resetVarToUnbound`)—mechanism: recycles
   annotation node vars after the scheme was copied off as a disjoint orphan.
 - `finalizeTypeDeclarationValidity` and occurs-check poisoning

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -16598,6 +16598,20 @@ fn checkMatchExpr(
         try self.warnIfComptimeConditionalExpr(match.cond, .match_scrutinee, expected);
     }
 
+    // Every branch pattern describes the same scrutinee value, so the patterns
+    // must stay mutually consistent. That relation normally travels through
+    // `cond_var`. An already-erroneous scrutinee cannot carry it: unification
+    // against `.err` is accepted without merging, so each pattern would be
+    // solved in isolation and the bindings they share would only collide later,
+    // in the branch bodies, far from the pattern that disagrees. Tie the
+    // patterns to a class of their own instead. The first disagreement poisons
+    // that class to `.err`, so later patterns short-circuit exactly as they do
+    // when the scrutinee itself carries the relation.
+    const ptrn_target_var = if (self.types.resolveVar(cond_var).desc.content == .err)
+        try self.fresh(env, expr_region)
+    else
+        cond_var;
+
     // Manually check the 1st branch
     // The type of the branch's body becomes the var other branch bodies must unify
     // against.
@@ -16612,7 +16626,7 @@ fn checkMatchExpr(
         const first_branch_ptrn_idxs = self.cir.store.sliceMatchBranchPatterns(first_branch.patterns);
 
         // Check each of the first branch's patterns and unify it with the
-        // condition type. (A failed unify poisons cond_var to .err, so subsequent
+        // condition type. (A failed unify poisons the target to .err, so subsequent
         // pattern unifications short-circuit rather than cascading.)
         for (first_branch_ptrn_idxs, 0..) |branch_ptrn_idx, cur_ptrn_index| {
             const branch_ptrn = self.cir.store.getMatchBranchPattern(branch_ptrn_idx);
@@ -16620,7 +16634,7 @@ fn checkMatchExpr(
 
             if (!cond_always_crashes) {
                 const branch_ptrn_var = ModuleEnv.varFrom(branch_ptrn.pattern);
-                const ptrn_result = try self.unifyInContext(cond_var, branch_ptrn_var, env, .{ .match_pattern = .{
+                const ptrn_result = try self.unifyInContext(ptrn_target_var, branch_ptrn_var, env, .{ .match_pattern = .{
                     .branch_index = 0,
                     .pattern_index = @intCast(cur_ptrn_index),
                     .num_branches = @intCast(match.branches.span.len),
@@ -16683,7 +16697,7 @@ fn checkMatchExpr(
             // Check the pattern against the cond
             if (!cond_always_crashes) {
                 const branch_ptrn_var = ModuleEnv.varFrom(branch_ptrn.pattern);
-                const ptrn_result = try self.unifyInContext(cond_var, branch_ptrn_var, env, .{ .match_pattern = .{
+                const ptrn_result = try self.unifyInContext(ptrn_target_var, branch_ptrn_var, env, .{ .match_pattern = .{
                     .branch_index = @intCast(branch_cur_index),
                     .pattern_index = @intCast(cur_ptrn_index),
                     .num_branches = @intCast(match.branches.span.len),
@@ -16750,7 +16764,7 @@ fn checkMatchExpr(
                         // Check the pattern against the cond
                         if (!cond_always_crashes) {
                             const other_branch_ptrn_var = ModuleEnv.varFrom(other_branch_ptrn.pattern);
-                            _ = try self.unifyInContext(cond_var, other_branch_ptrn_var, env, .{ .match_pattern = .{
+                            _ = try self.unifyInContext(ptrn_target_var, other_branch_ptrn_var, env, .{ .match_pattern = .{
                                 .branch_index = @intCast(other_branch_cur_index),
                                 .pattern_index = @intCast(other_cur_ptrn_index),
                                 .num_branches = @intCast(match.branches.span.len),

--- a/test/snapshots/eval/issue8738_question_on_non_try.md
+++ b/test/snapshots/eval/issue8738_question_on_non_try.md
@@ -149,7 +149,7 @@ NO CHANGE
 						(e-empty_record))))))
 	(d-let
 		(p-assign (ident "result"))
-		(e-call (constraint-fn-var 324)
+		(e-call (constraint-fn-var 325)
 			(e-lookup-local
 				(p-assign (ident "do_something"))))))
 ~~~

--- a/test/snapshots/fuzz_crash/fuzz_crash_023.md
+++ b/test/snapshots/fuzz_crash/fuzz_crash_023.md
@@ -2295,12 +2295,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 1932)
+													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 1933)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 1903)
+																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 1904)
 																			(receiver
 																				(e-runtime-error (tag "erroneous_value_expr")))
 																			(args)))

--- a/test/snapshots/match_expr/branch_scoping.md
+++ b/test/snapshots/match_expr/branch_scoping.md
@@ -100,7 +100,7 @@ match result {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 229)
+					(e-dispatch-call (method "plus") (constraint-fn-var 230)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "value"))))
@@ -111,7 +111,7 @@ match result {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "minus") (constraint-fn-var 239)
+					(e-dispatch-call (method "minus") (constraint-fn-var 243)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "value"))))
@@ -122,7 +122,7 @@ match result {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "times") (constraint-fn-var 249)
+					(e-dispatch-call (method "times") (constraint-fn-var 254)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "different"))))
@@ -133,7 +133,7 @@ match result {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "div_by") (constraint-fn-var 259)
+					(e-dispatch-call (method "div_by") (constraint-fn-var 265)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "different"))))

--- a/test/snapshots/match_expr/complex_list_tags.md
+++ b/test/snapshots/match_expr/complex_list_tags.md
@@ -197,7 +197,7 @@ match events {
 							(p-assign (ident "#interp_3"))
 							(e-call
 								(e-runtime-error (tag "qualified_ident_does_not_exist"))
-								(e-call (constraint-fn-var 371)
+								(e-call (constraint-fn-var 375)
 									(e-lookup-external
 										(builtin))
 									(e-lookup-local

--- a/test/snapshots/match_expr/erroneous_scrutinee_pattern_consistency.md
+++ b/test/snapshots/match_expr/erroneous_scrutinee_pattern_consistency.md
@@ -1,54 +1,52 @@
 # META
 ~~~ini
-description=Simple record destructuring in match expression
+description=Branch patterns stay mutually consistent when the scrutinee is erroneous
 type=expr
 ~~~
 # SOURCE
 ~~~roc
-match person {
+match undefined_scrutinee {
     { name } => name
-    { age } => age
+    { name, age } => age
 }
 ~~~
 # EXPECTED
-TYPE MISMATCH - simple_record.md:1:1:1:1
+TYPE MISMATCH - erroneous_scrutinee_pattern_consistency.md:1:1:1:1
 # PROBLEMS
 
 ┌───────────────┐
 │ TYPE MISMATCH ├─ The second branch of this `match` does not match the ──────┐
 └┬──────────────┘  previous ones.                                             │
  │                                                                            │
- │  match person {                                                            │
+ │  match undefined_scrutinee {                                               │
  │      { name } => name                                                      │
- │      { age } => age                                                        │
+ │      { name, age } => age                                                  │
  │  }                                                                         │
  │                                                                            │
- └────────────────────────────────────────────────────── simple_record.md:1:5 ┘
+ └──────────────────────────── erroneous_scrutinee_pattern_consistency.md:1:5 ┘
 
     This second branch is trying to match:
 
-        { age: _field }
+        { age: _field, name: _field2 }
 
     But the expression between the `match` parenthesis has the type:
 
         { name: _field }
 
     These can never match! Either the pattern or expression has a problem.
-    Hint: This pattern doesn't bind the `name` field. Match it explicitly with
-    `name: _`, or add `..` to match all the remaining fields.
 
 # TOKENS
 ~~~zig
 KwMatch,LowerIdent,OpenCurly,
 OpenCurly,LowerIdent,CloseCurly,OpFatArrow,LowerIdent,
-OpenCurly,LowerIdent,CloseCurly,OpFatArrow,LowerIdent,
+OpenCurly,LowerIdent,Comma,LowerIdent,CloseCurly,OpFatArrow,LowerIdent,
 CloseCurly,
 EndOfFile,
 ~~~
 # PARSE
 ~~~clojure
 (e-match
-	(e-ident (raw "person"))
+	(e-ident (raw "undefined_scrutinee"))
 	(branches
 		(branch
 			(p-record
@@ -56,14 +54,15 @@ EndOfFile,
 			(e-ident (raw "name")))
 		(branch
 			(p-record
+				(field (name "name") (rest false))
 				(field (name "age") (rest false)))
 			(e-ident (raw "age")))))
 ~~~
 # FORMATTED
 ~~~roc
-match person {
+match undefined_scrutinee {
 	{ name } => name
-	{ age } => age
+	{ name, age } => age
 }
 ~~~
 # CANONICALIZE
@@ -89,6 +88,9 @@ match person {
 					(pattern (degenerate false)
 						(p-record-destructure
 							(destructs
+								(record-destruct (label "name") (ident "name")
+									(required
+										(p-assign (ident "name"))))
 								(record-destruct (label "age") (ident "age")
 									(required
 										(p-assign (ident "age"))))))))

--- a/test/snapshots/match_expr/list_destructure_scoping.md
+++ b/test/snapshots/match_expr/list_destructure_scoping.md
@@ -85,7 +85,7 @@ match list {
 								(p-assign (ident "first"))
 								(p-assign (ident "second"))))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 206)
+					(e-dispatch-call (method "plus") (constraint-fn-var 207)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "first"))))

--- a/test/snapshots/match_expr/list_destructure_variations.md
+++ b/test/snapshots/match_expr/list_destructure_variations.md
@@ -15,9 +15,63 @@ match list {
 }
 ~~~
 # EXPECTED
-NIL
+MISSING METHOD - list_destructure_variations.md:4:24:4:38
+MISSING METHOD - list_destructure_variations.md:2:11:2:12
+MISSING METHOD - list_destructure_variations.md:6:31:6:32
+MISSING METHOD - list_destructure_variations.md:7:30:7:35
 # PROBLEMS
-NIL
+
+┌────────────────┐
+│ MISSING METHOD ├─ This `plus` method is being called on a value whose ──────┐
+└┬───────────────┘  type doesn't have that method.                            │
+ │                                                                            │
+ │  [first, second] => first + second                                         │
+ │                     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾                                         │
+ └─────────────────────────────────────── list_destructure_variations.md:4:24 ┘
+
+    The value's type, which does not have a method named `plus`, is:
+
+        [One, Two, ..]
+
+
+┌────────────────┐
+│ MISSING METHOD ├─ This `from_numeral` method is being called on a value ────┐
+└┬───────────────┘  whose type doesn't have that method.                      │
+ │                                                                            │
+ │  [] => 0                                                                   │
+ │        ‾                                                                   │
+ └─────────────────────────────────────── list_destructure_variations.md:2:11 ┘
+
+    The value's type, which does not have a method named `from_numeral`, is:
+
+        [One, Two, ..]
+
+
+┌────────────────┐
+│ MISSING METHOD ├─ This `from_numeral` method is being called on a value ────┐
+└┬───────────────┘  whose type doesn't have that method.                      │
+ │                                                                            │
+ │  [One, Two, .. as rest] => 3                                               │
+ │                            ‾                                               │
+ └─────────────────────────────────────── list_destructure_variations.md:6:31 ┘
+
+    The value's type, which does not have a method named `from_numeral`, is:
+
+        [One, Two, ..]
+
+
+┌────────────────┐
+│ MISSING METHOD ├─ This `plus` method is being called on a value whose ──────┐
+└┬───────────────┘  type doesn't have that method.                            │
+ │                                                                            │
+ │  [x, y, z, .. as more] => x + y + z                                        │
+ │                           ‾‾‾‾‾                                            │
+ └─────────────────────────────────────── list_destructure_variations.md:7:30 ┘
+
+    The value's type, which does not have a method named `plus`, is:
+
+        [One, Two, ..]
+
 # TOKENS
 ~~~zig
 KwMatch,LowerIdent,OpenCurly,
@@ -96,7 +150,7 @@ match list {
 						(p-list
 							(patterns))))
 				(value
-					(e-num (value "0"))))
+					(e-runtime-error (tag "erroneous_value_expr"))))
 			(branch
 				(patterns
 					(pattern (degenerate false)
@@ -114,13 +168,7 @@ match list {
 								(p-assign (ident "first"))
 								(p-assign (ident "second"))))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 246)
-						(receiver
-							(e-lookup-local
-								(p-assign (ident "first"))))
-						(args
-							(e-lookup-local
-								(p-assign (ident "second")))))))
+					(e-runtime-error (tag "erroneous_value_expr"))))
 			(branch
 				(patterns
 					(pattern (degenerate false)
@@ -142,7 +190,7 @@ match list {
 							(rest-at (index 2)
 								(p-assign (ident "rest"))))))
 				(value
-					(e-num (value "3"))))
+					(e-runtime-error (tag "erroneous_value_expr"))))
 			(branch
 				(patterns
 					(pattern (degenerate false)
@@ -154,20 +202,9 @@ match list {
 							(rest-at (index 3)
 								(p-assign (ident "more"))))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 262)
-						(receiver
-							(e-dispatch-call (method "plus") (constraint-fn-var 260)
-								(receiver
-									(e-lookup-local
-										(p-assign (ident "x"))))
-								(args
-									(e-lookup-local
-										(p-assign (ident "y"))))))
-						(args
-							(e-lookup-local
-								(p-assign (ident "z"))))))))))
+					(e-runtime-error (tag "erroneous_value_expr")))))))
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Dec"))
+(expr (type "[One, Two, ..]"))
 ~~~

--- a/test/snapshots/match_expr/list_rest_scoping.md
+++ b/test/snapshots/match_expr/list_rest_scoping.md
@@ -122,7 +122,7 @@ match items {
 							(rest-at (index 1)
 								(p-assign (ident "rest"))))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 228)
+					(e-dispatch-call (method "plus") (constraint-fn-var 229)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "first"))))
@@ -137,7 +137,7 @@ match items {
 							(rest-at (index 0)
 								(p-assign (ident "rest"))))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 237)
+					(e-dispatch-call (method "plus") (constraint-fn-var 238)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "last"))))
@@ -153,7 +153,7 @@ match items {
 							(rest-at (index 1)
 								(p-assign (ident "rest"))))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 239)
+					(e-dispatch-call (method "plus") (constraint-fn-var 240)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "x"))))

--- a/test/snapshots/match_expr/list_rest_scoping_variables.md
+++ b/test/snapshots/match_expr/list_rest_scoping_variables.md
@@ -173,7 +173,7 @@ match data {
 							(rest-at (index 1)
 								(p-assign (ident "items"))))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 231)
+					(e-dispatch-call (method "plus") (constraint-fn-var 232)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "first"))))

--- a/test/snapshots/match_expr/list_underscore_patterns.md
+++ b/test/snapshots/match_expr/list_underscore_patterns.md
@@ -135,7 +135,7 @@ match items {
 								(p-underscore)
 								(p-assign (ident "y"))))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 236)
+					(e-dispatch-call (method "plus") (constraint-fn-var 237)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "x"))))

--- a/test/snapshots/match_expr/middle_rest.md
+++ b/test/snapshots/match_expr/middle_rest.md
@@ -86,7 +86,7 @@ match items {
 								(p-assign (ident "last")))
 							(rest-at (index 1)))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 226)
+					(e-dispatch-call (method "plus") (constraint-fn-var 227)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "first"))))
@@ -105,11 +105,11 @@ match items {
 							(rest-at (index 2)
 								(p-assign (ident "middle"))))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 232)
+					(e-dispatch-call (method "plus") (constraint-fn-var 233)
 						(receiver
-							(e-dispatch-call (method "plus") (constraint-fn-var 230)
+							(e-dispatch-call (method "plus") (constraint-fn-var 231)
 								(receiver
-									(e-dispatch-call (method "plus") (constraint-fn-var 228)
+									(e-dispatch-call (method "plus") (constraint-fn-var 229)
 										(receiver
 											(e-lookup-local
 												(p-assign (ident "a"))))

--- a/test/snapshots/match_expr/mixed_pattern_scoping.md
+++ b/test/snapshots/match_expr/mixed_pattern_scoping.md
@@ -103,7 +103,7 @@ match data {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 225)
+					(e-dispatch-call (method "plus") (constraint-fn-var 226)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "x"))))
@@ -115,7 +115,7 @@ match data {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "minus") (constraint-fn-var 235)
+					(e-dispatch-call (method "minus") (constraint-fn-var 239)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "x"))))
@@ -126,7 +126,7 @@ match data {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "times") (constraint-fn-var 245)
+					(e-dispatch-call (method "times") (constraint-fn-var 250)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "x"))))
@@ -137,7 +137,7 @@ match data {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "div_by") (constraint-fn-var 255)
+					(e-dispatch-call (method "div_by") (constraint-fn-var 261)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "y"))))

--- a/test/snapshots/match_expr/nested_list_scoping.md
+++ b/test/snapshots/match_expr/nested_list_scoping.md
@@ -26,7 +26,7 @@ POLYMORPHIC VALUE - nested_list_scoping.md:1:1:5:2
 
     The value's type, which does not have a method named `times`, is:
 
-        List(_a)
+        List(a) where [a.minus : a, a -> a, a.plus : a, a -> a]
 
     Hint: The `*` operator calls a method named `times` on the value preceding
     it, passing the value after the operator as the one argument.
@@ -115,7 +115,7 @@ match nestedList {
 									(patterns
 										(p-assign (ident "y"))))))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 221)
+					(e-dispatch-call (method "plus") (constraint-fn-var 222)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "x"))))
@@ -132,7 +132,7 @@ match nestedList {
 										(p-assign (ident "x"))
 										(p-assign (ident "y"))))))))
 				(value
-					(e-dispatch-call (method "minus") (constraint-fn-var 223)
+					(e-dispatch-call (method "minus") (constraint-fn-var 224)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "x"))))

--- a/test/snapshots/match_expr/nested_patterns.md
+++ b/test/snapshots/match_expr/nested_patterns.md
@@ -86,12 +86,12 @@ match data {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 242)
+					(e-dispatch-call (method "plus") (constraint-fn-var 243)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "x"))))
 						(args
-							(e-call (constraint-fn-var 241)
+							(e-call (constraint-fn-var 242)
 								(e-lookup-external
 									(builtin))
 								(e-lookup-local
@@ -107,7 +107,7 @@ match data {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 260)
+					(e-dispatch-call (method "plus") (constraint-fn-var 264)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "value"))))

--- a/test/snapshots/match_expr/pattern_as_nested.md
+++ b/test/snapshots/match_expr/pattern_as_nested.md
@@ -11,29 +11,31 @@ match person {
 }
 ~~~
 # EXPECTED
-TYPE MISMATCH - pattern_as_nested.md:3:33:3:64
+TYPE MISMATCH - pattern_as_nested.md:1:1:1:1
 # PROBLEMS
 
 ┌───────────────┐
 │ TYPE MISMATCH ├─ The second branch of this `match` does not match the ──────┐
-└┬──────────────┘  previous branch .                                          │
+└┬──────────────┘  previous ones.                                             │
  │                                                                            │
- │  { name } as simplePerson => (simplePerson, name, "unknown")               │
- │                              ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾               │
- └───────────────────────────────────────────────── pattern_as_nested.md:3:33 ┘
+ │  match person {                                                            │
+ │      { name, address: { city } as addr } as fullPerson => (fullPerson, ad… │
+ │      { name } as simplePerson => (simplePerson, name, "unknown")           │
+ │  }                                                                         │
+ │                                                                            │
+ └────────────────────────────────────────────────── pattern_as_nested.md:1:5 ┘
 
-    The second branch is:
+    This second branch is trying to match:
 
-        ({ name: a }, a, b) where [b.from_quote : Str -> Try(b,
-        [BadQuotedBytes(Str)])]
+        { name: _field }
 
-    But the previous branch results in:
+    But the expression between the `match` parenthesis has the type:
 
-        ({ address: { city: a }, name: _field }, { city: a }, a)
+        { address: { city: _field }, name: _field2 }
 
-    All branches in a `match` must have compatible types.
-    Note: You can wrap branches values in a tag to make them compatible.
-    To learn about tags, see <https://www.roc-lang.org/tutorial#tags>
+    These can never match! Either the pattern or expression has a problem.
+    Hint: This pattern doesn't bind the `address` field. Match it explicitly
+    with `address: _`, or add `..` to match all the remaining fields.
 
 # TOKENS
 ~~~zig
@@ -154,5 +156,5 @@ match person {
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Error"))
+(expr (type "({ address: { city: a }, name: _field }, { city: a }, a)"))
 ~~~

--- a/test/snapshots/match_expr/single_branch.md
+++ b/test/snapshots/match_expr/single_branch.md
@@ -10,9 +10,23 @@ match value {
 }
 ~~~
 # EXPECTED
-NIL
+POLYMORPHIC VALUE - single_branch.md:1:1:3:2
 # PROBLEMS
-NIL
+
+┌───────────────────┐
+│ POLYMORPHIC VALUE ├─ This top-level value still has an unresolved ──────────┐
+└┬──────────────────┘  polymorphic type.                                      │
+ │                                                                            │
+ │  match value {                                                             │
+ │      x => x + 1                                                            │
+ │  }                                                                         │
+ │                                                                            │
+ └────────────────────────────────────────────────────── single_branch.md:1:1 ┘
+
+    Its type is:
+    a where [a.plus : a, Dec -> a]
+    Add an annotation or use this value in a way that fixes its concrete type.
+
 # TOKENS
 ~~~zig
 KwMatch,LowerIdent,OpenCurly,
@@ -49,7 +63,7 @@ match value {
 					(pattern (degenerate false)
 						(p-assign (ident "x"))))
 				(value
-					(e-dispatch-call (method "plus") (constraint-fn-var 206)
+					(e-dispatch-call (method "plus") (constraint-fn-var 207)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "x"))))
@@ -58,5 +72,5 @@ match value {
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Error"))
+(expr (type "a where [a.plus : a, Dec -> a]"))
 ~~~

--- a/test/snapshots/match_expr/tag_with_payload.md
+++ b/test/snapshots/match_expr/tag_with_payload.md
@@ -74,9 +74,9 @@ match shape {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "times") (constraint-fn-var 230)
+					(e-dispatch-call (method "times") (constraint-fn-var 231)
 						(receiver
-							(e-dispatch-call (method "times") (constraint-fn-var 228)
+							(e-dispatch-call (method "times") (constraint-fn-var 229)
 								(receiver
 									(e-dec-small (numerator "314") (denominator-power-of-ten "2") (value "3.14")))
 								(args
@@ -90,7 +90,7 @@ match shape {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "times") (constraint-fn-var 233)
+					(e-dispatch-call (method "times") (constraint-fn-var 237)
 						(receiver
 							(e-lookup-local
 								(p-assign (ident "width"))))
@@ -102,9 +102,9 @@ match shape {
 					(pattern (degenerate false)
 						(p-applied-tag)))
 				(value
-					(e-dispatch-call (method "times") (constraint-fn-var 245)
+					(e-dispatch-call (method "times") (constraint-fn-var 252)
 						(receiver
-							(e-dispatch-call (method "times") (constraint-fn-var 243)
+							(e-dispatch-call (method "times") (constraint-fn-var 250)
 								(receiver
 									(e-dec-small (numerator "5") (denominator-power-of-ten "1") (value "0.5")))
 								(args

--- a/test/snapshots/match_expr/tuple_patterns.md
+++ b/test/snapshots/match_expr/tuple_patterns.md
@@ -13,9 +13,21 @@ match coord {
 }
 ~~~
 # EXPECTED
-NIL
+MISSING METHOD - tuple_patterns.md:2:21:2:29
 # PROBLEMS
-NIL
+
+┌────────────────┐
+│ MISSING METHOD ├─ This `from_quote` method is being called on a value ──────┐
+└┬───────────────┘  whose type doesn't have that method.                      │
+ │                                                                            │
+ │  (Zero, Zero) => "origin"                                                  │
+ │                  ‾‾‾‾‾‾‾‾                                                  │
+ └──────────────────────────────────────────────────── tuple_patterns.md:2:21 ┘
+
+    The value's type, which does not have a method named `from_quote`, is:
+
+        [Zero, ..]
+
 # TOKENS
 ~~~zig
 KwMatch,LowerIdent,OpenCurly,
@@ -77,8 +89,7 @@ match coord {
 								(p-applied-tag)
 								(p-applied-tag)))))
 				(value
-					(e-string
-						(e-literal (string "origin")))))
+					(e-runtime-error (tag "erroneous_value_expr"))))
 			(branch
 				(patterns
 					(pattern (degenerate false)
@@ -112,5 +123,5 @@ match coord {
 ~~~
 # TYPES
 ~~~clojure
-(expr (type "Str"))
+(expr (type "[Zero, ..]"))
 ~~~

--- a/test/snapshots/records/pattern_destructure_nested.md
+++ b/test/snapshots/records/pattern_destructure_nested.md
@@ -114,7 +114,7 @@ match person {
 							(p-assign (ident "#interp_2"))
 							(e-lookup-local
 								(p-assign (ident "city"))))
-						(e-interpolation (constraint-fn-var 245) (dispatcher-var 30)
+						(e-interpolation (constraint-fn-var 246) (dispatcher-var 30)
 							(first
 								(e-literal (string "")))
 							(parts

--- a/test/snapshots/records/pattern_destructure_rename.md
+++ b/test/snapshots/records/pattern_destructure_rename.md
@@ -73,12 +73,12 @@ match person {
 								(p-assign (ident "userName"))))
 						(s-let
 							(p-assign (ident "#interp_1"))
-							(e-dispatch-call (method "to_str") (constraint-fn-var 215)
+							(e-dispatch-call (method "to_str") (constraint-fn-var 216)
 								(receiver
 									(e-lookup-local
 										(p-assign (ident "userAge"))))
 								(args)))
-						(e-interpolation (constraint-fn-var 234) (dispatcher-var 20)
+						(e-interpolation (constraint-fn-var 235) (dispatcher-var 20)
 							(first
 								(e-literal (string "User ")))
 							(parts

--- a/test/snapshots/records/pattern_destructure_with_rest.md
+++ b/test/snapshots/records/pattern_destructure_with_rest.md
@@ -99,7 +99,7 @@ match person {
 									(rest-pattern
 										(p-assign (ident "others"))))))))
 				(value
-					(e-dispatch-call (method "is_gt") (constraint-fn-var 214)
+					(e-dispatch-call (method "is_gt") (constraint-fn-var 215)
 						(receiver
 							(e-call
 								(e-runtime-error (tag "nested_value_not_found"))

--- a/test/snapshots/syntax_grab_bag.md
+++ b/test/snapshots/syntax_grab_bag.md
@@ -2173,12 +2173,12 @@ expect {
 										(e-match
 											(match
 												(cond
-													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 1943)
+													(e-dispatch-call (method "next_static_dispatch_method") (constraint-fn-var 1944)
 														(receiver
 															(e-match
 																(match
 																	(cond
-																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 1914)
+																		(e-dispatch-call (method "static_dispatch_method") (constraint-fn-var 1915)
 																			(receiver
 																				(e-runtime-error (tag "erroneous_value_expr")))
 																			(args)))


### PR DESCRIPTION
Stacked on #10683, which regenerates the snapshots this builds on.

Every branch pattern in a `match` describes the same scrutinee value, so the patterns have to stay mutually consistent, and that relation normally travels through the scrutinee's variable. Since #10674 a unification against an existing `.err` is accepted without merging, so an already-erroneous scrutinee no longer carries it: each pattern gets solved in isolation, and the bindings they share only collide later, in the branch bodies, far from the pattern that actually disagrees. `test/snapshots/match_expr/pattern_as_nested.md` is the case that surfaced this — a `{ name }` pattern that fails to bind a field its sibling pattern binds was reported as a tuple-shaped "second branch does not match the previous branch" mismatch instead of the pattern-level message with the "this pattern doesn't bind the `address` field" hint.

When the scrutinee's type resolves to `.err`, the branch patterns now unify against a shared fresh variable rather than the scrutinee's. The scrutinee's own error is not re-reported and the patterns are never related back to it, so nothing poisons the good types #10674 set out to protect; the first disagreement between two patterns poisons the shared variable, which keeps the short-circuiting that later patterns already relied on. design.md records this in the Rewrite Inventory as mechanism recovery: an error-free program never reaches the probe, so no program's typechecking or checked-module output changes.

Five snapshots change diagnostics and the other seventeen are `constraint-fn-var` renumbering from the one extra variable. Four of the five went from `NIL` to a real error, and those errors were always latent in the fixtures — each one has an undefined scrutinee whose `Error` type used to swallow it. Running the same four sources with the scrutinee replaced by a lambda parameter (a path this change does not touch) reports exactly the same diagnostics, so they are properties of the fixture code rather than of the new pattern class: `simple_record` matches `{ name }` against `{ age }` with closed record patterns, `tuple_patterns` returns a `Str` from one branch and a tag union from the next, `list_destructure_variations` mixes numeral branches with an element type its `[One, Two, ..]` branch pins to a tag union, and `single_branch` is a genuinely polymorphic top-level value. `erroneous_scrutinee_pattern_consistency.md` pins the invariant directly.
