### PR TITLE
Fix cross-function reuse of packed-blob data pointers

### DIFF
--- a/design.md
+++ b/design.md
@@ -3078,6 +3078,12 @@ item alignment. Static-data materialization aligns the backing to that
 maximum while keeping the Roc list length and capacity in items rather than
 bytes.
 
+LLVM codegen interns one refcounted backing global per blob for the whole
+module, but the pointer to the blob's data offset is a WipFunction
+instruction: every proc body that restores a view must emit its own GEP from
+the interned global. Caching the offset pointer itself would leak the first
+body's instruction into every later function sharing that backing.
+
 The direct LIR const plan also records the root's exact Monotype return type.
 Finalization clones that type into the durable `ConstStore` type store and saves
 its id beside the stored root node. Restoration lowers the saved root type first

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -6874,12 +6874,17 @@ pub const MonoLlvmCodeGen = struct {
 
     fn staticRefcountedBytes(self: *MonoLlvmCodeGen, backing: Base.StringLiteral.Idx) Error!LlvmBuilder.Value {
         const key: u32 = @intFromEnum(backing);
-        if (self.static_refcounted_backings.get(key)) |existing| return existing;
-
         const builder = self.builder orelse return error.CompilationFailed;
         const word_size: usize = self.targetWordSize();
         const backing_alignment = @max(word_size, @as(usize, self.store.strings.alignment(backing)));
         const data_offset = std.mem.alignForward(usize, word_size, backing_alignment);
+        // Only the backing global may be cached across proc bodies: the GEP to
+        // its data offset is an instruction in whichever WipFunction is being
+        // compiled, so it must be emitted fresh per function.
+        if (self.static_refcounted_backings.get(key)) |existing| {
+            return try self.offsetPtrValue(existing, builder.intValue(self.ptrSizedIntType(), data_offset) catch return error.OutOfMemory);
+        }
+
         const bytes = self.store.getString(backing);
         const storage = self.allocator.alloc(u8, data_offset + bytes.len) catch return error.OutOfMemory;
         defer self.allocator.free(storage);
@@ -6897,9 +6902,8 @@ pub const MonoLlvmCodeGen = struct {
         variable.setInitializer(builder.stringConst(builder.string(storage) catch return error.OutOfMemory) catch return error.OutOfMemory, builder) catch return error.OutOfMemory;
 
         const base = variable.toValue(builder);
-        const value = try self.offsetPtrValue(base, builder.intValue(self.ptrSizedIntType(), data_offset) catch return error.OutOfMemory);
-        try self.static_refcounted_backings.put(key, value);
-        return value;
+        try self.static_refcounted_backings.put(key, base);
+        return try self.offsetPtrValue(base, builder.intValue(self.ptrSizedIntType(), data_offset) catch return error.OutOfMemory);
     }
 
     fn emitStrByteSliceForLocal(self: *MonoLlvmCodeGen, local: LocalId) Error!StrByteSlice {

--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -341,6 +341,11 @@ pub const io_spec_tests = [_]TestSpec{
         .description = "Regression test: LLVM erased callable ABI preserves a sub-word first argument (issue #10364)",
     },
     .{
+        .roc_file = "test/fx/packed_list_two_bodies.roc",
+        .io_spec = "0<three|1>165|1>168",
+        .description = "Regression test: a packed compile-time list constant restored in two proc bodies must not reuse the first body's GEP instruction (issue #10697)",
+    },
+    .{
         .roc_file = "test/fx/unify_scratch_fresh_vars_rank_bug.roc",
         .io_spec = "1>ok",
         .description = "Regression test: unify scratch fresh_vars must be cleared between calls",

--- a/test/fx/packed_list_two_bodies.roc
+++ b/test/fx/packed_list_two_bodies.roc
@@ -1,0 +1,60 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdin
+import pf.Stdout
+
+# Repro for https://github.com/roc-lang/roc/issues/10697
+#
+# summarize({}) is compile-time evaluable, so its list result is stored as a
+# packed scalar blob. Both `first` and `second` (kept separate by recursion)
+# restore that constant, so LLVM codegen must not reuse the first body's GEP
+# instruction when the second body materializes the same backing.
+summarize : {} -> { table : List(U64), total : U64 }
+summarize = |_| {
+    var $table = []
+    var $index = 0
+    var $total = 0
+    while $index < 16 {
+        $table = $table.append($index * 7 % 256)
+        $total = $total + $index
+        $index = $index + 1
+    }
+    { table: $table, total: $total }
+}
+
+table_at : List(U64), U64 -> U64
+table_at = |table, n| {
+    match table.get(n % table.len()) {
+        Err(_) => table.len()
+        Ok(value) => value
+    }
+}
+
+first : U64 -> U64
+first = |n| {
+    packed = summarize({})
+    if n == 0 {
+        table_at(packed.table, n) + packed.total
+    } else {
+        first(n - 1) + table_at(packed.table, n) + 1
+    }
+}
+
+second : U64 -> U64
+second = |n| {
+    packed = summarize({})
+    if n == 0 {
+        table_at(packed.table, n) + packed.total
+    } else {
+        second(n - 1) + table_at(packed.table, n) + 2
+    }
+}
+
+main! = || {
+    n = match Stdin.line!() {
+        "three" => 3
+        _ => 0
+    }
+    Stdout.line!(first(n).to_str())
+    Stdout.line!(second(n).to_str())
+}


### PR DESCRIPTION
Fixes #10697.

## Problem

`MonoLlvmCodeGen.staticRefcountedBytes` cached the result of `offsetPtrValue(base, data_offset)` in `static_refcounted_backings`, a map that lives for the whole module codegen. That value is a `wip.gep` — an instruction belonging to whichever `WipFunction` was being compiled at the time. When a second proc body emitted a `.bytes_literal` view of the same backing, the cache handed it the first function's instruction id:

- safe builds panic `index out of bounds` in `Value.typeOfWip` (`vendor/llvm_ir/Builder.zig:4557`);
- release builds do a wild read → compiler SIGSEGV, or encode a reference to an unrelated instruction → `BITCODE PARSE ERROR` (`Invalid record` / `Assigned value does not match type of forward declaration`), or in the in-range case a silent miscompile.

Any valid program in which two or more compiled proc bodies restore the same packed compile-time list constant triggered this (regression from 556673b0, "Pack scalar compile-time lists into shared blobs").

## Fix

Cache only the backing global (a Constant, function-independent) and emit the data-offset GEP inside whichever proc body is being compiled. Added a matching note to design.md's shared-blob section. The dev and wasm backends generate code directly per function and don't cache SSA values, so they are unaffected.

## Verification

- New regression spec `test/fx/packed_list_two_bodies.roc` (+ `fx_test_specs.zig` entry): a compile-time-evaluated packed list constant restored in two recursive function bodies. Before the fix, `roc build --opt=speed` of this file panics a debug compiler at `Builder.zig:4557` (`index out of bounds: index 33, len 31`) and segfaults the released nightly; after the fix it builds, and the binary prints the expected `165` / `168` (matches the interpreter).
- `zig build run-test-zig-fx-platform` passes.
- The larger program the issue was reduced from also builds and runs correctly with a ReleaseFast build of this branch's compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
