### PR TITLE
Stop leaving unresolvable symbols in the objects roc links

### DIFF
--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -3860,6 +3860,14 @@ pub const MonoLlvmCodeGen = struct {
                 }
             }
 
+            if (target_layout == .i128 or target_layout == .u128) {
+                if (plain_op == .num_div_by or plain_op == .num_div_trunc_by or
+                    plain_op == .num_rem_by or plain_op == .num_mod_by)
+                {
+                    break :blk try self.emitI128DivRem(plain_op, lhs, rhs, target_layout == .u128);
+                }
+            }
+
             const tag: LlvmBuilder.Function.Instruction.Tag = if (plain_op == .num_plus)
                 .add
             else if (plain_op == .num_minus)
@@ -3990,6 +3998,33 @@ pub const MonoLlvmCodeGen = struct {
         return self.combineI128Parts(low, high);
     }
 
+    /// 128-bit division, remainder and modulo, routed through the same
+    /// decomposed-to-64-bit builtins the dev and wasm backends call.
+    ///
+    /// No target Roc compiles to has a 128-bit divide instruction, so leaving a
+    /// `sdiv`/`udiv`/`srem`/`urem` on i128 in the module makes instruction
+    /// selection lower it to a compiler-rt libcall (`__divti3`, `__udivti3`,
+    /// ...). Nothing in a Roc object defines those, and a platform host is not
+    /// required to carry compiler-rt, so such an object fails to link: the
+    /// Windows test hosts, which bundle no compiler-rt, reject it outright.
+    fn emitI128DivRem(
+        self: *MonoLlvmCodeGen,
+        plain_op: lir.LowLevel,
+        lhs: LlvmBuilder.Value,
+        rhs: LlvmBuilder.Value,
+        unsigned: bool,
+    ) Error!LlvmBuilder.Value {
+        const builtin_fn = if (plain_op == .num_div_by or plain_op == .num_div_trunc_by)
+            LowLevelBuiltins.i128DivRem(false, unsigned)
+        else if (plain_op == .num_rem_by)
+            LowLevelBuiltins.i128DivRem(true, unsigned)
+        else if (plain_op == .num_mod_by)
+            LowLevelBuiltins.i128Mod(unsigned)
+        else
+            return error.UnsupportedLowLevel;
+        return self.callI128BinaryBuiltin(builtin_fn.symbolName(), lhs, rhs, true);
+    }
+
     fn emitIntegerShift(self: *MonoLlvmCodeGen, op: lir.LowLevel, lhs: LlvmBuilder.Value, rhs: LlvmBuilder.Value, target_layout: layout.Idx) Error!LlvmBuilder.Value {
         const builder = self.builder orelse return error.CompilationFailed;
         const wip = self.wip orelse return error.CompilationFailed;
@@ -4025,25 +4060,29 @@ pub const MonoLlvmCodeGen = struct {
                 // Dec multiply crashes on overflow, matching the interpreter and the
                 // dev/wasm backends; `dec_mul` takes `roc_ops` to raise the crash.
         else if (op == .num_times)
-            try self.callDecBinaryBuiltin(builtinSymbol(LowLevelBuiltins.decBinaryArith(.num_times)), lhs, rhs, true)
+            try self.callI128BinaryBuiltin(builtinSymbol(LowLevelBuiltins.decBinaryArith(.num_times)), lhs, rhs, true)
         else if (op == .num_div_by)
-            try self.callDecBinaryBuiltin(builtinSymbol(LowLevelBuiltins.decBinaryArith(.num_div_by)), lhs, rhs, true)
+            try self.callI128BinaryBuiltin(builtinSymbol(LowLevelBuiltins.decBinaryArith(.num_div_by)), lhs, rhs, true)
         else if (op == .num_div_trunc_by)
-            try self.callDecBinaryBuiltin(builtinSymbol(LowLevelBuiltins.decBinaryArith(.num_div_trunc_by)), lhs, rhs, true)
+            try self.callI128BinaryBuiltin(builtinSymbol(LowLevelBuiltins.decBinaryArith(.num_div_trunc_by)), lhs, rhs, true)
             // A Dec's payload is a scaled i128; the truncating remainder and the
             // modulo of the raw payloads are the Dec remainder and modulo, so
             // these route through the same i128 wrappers the dev/wasm backends
             // use. Both wrappers take `roc_ops`.
         else if (op == .num_rem_by)
-            try self.callDecBinaryBuiltin(builtinSymbol(LowLevelBuiltins.i128DivRem(true, false)), lhs, rhs, true)
+            try self.callI128BinaryBuiltin(builtinSymbol(LowLevelBuiltins.i128DivRem(true, false)), lhs, rhs, true)
         else if (op == .num_mod_by)
-            try self.callDecBinaryBuiltin(builtinSymbol(LowLevelBuiltins.i128Mod(false)), lhs, rhs, true)
+            try self.callI128BinaryBuiltin(builtinSymbol(LowLevelBuiltins.i128Mod(false)), lhs, rhs, true)
         else
             return error.UnsupportedLowLevel;
         try self.storeScalar(self.slot(target).ptr, .dec, result);
     }
 
-    fn callDecBinaryBuiltin(self: *MonoLlvmCodeGen, name: []const u8, lhs: LlvmBuilder.Value, rhs: LlvmBuilder.Value, pass_roc_ops: bool) Error!LlvmBuilder.Value {
+    /// Call a builtin that takes two 128-bit operands and writes a 128-bit
+    /// result, passing each operand as a 64-bit low/high pair. Dec's payload is
+    /// an i128, so its arithmetic wrappers share this shape with the plain i128
+    /// ones.
+    fn callI128BinaryBuiltin(self: *MonoLlvmCodeGen, name: []const u8, lhs: LlvmBuilder.Value, rhs: LlvmBuilder.Value, pass_roc_ops: bool) Error!LlvmBuilder.Value {
         const wip = self.wip orelse return error.CompilationFailed;
         const out_low = try self.allocEntryBlockSlot(.i64, 1, LlvmBuilder.Alignment.fromByteUnits(8), "dec_low");
         const out_high = try self.allocEntryBlockSlot(.i64, 1, LlvmBuilder.Alignment.fromByteUnits(8), "dec_high");
@@ -5170,15 +5209,20 @@ pub const MonoLlvmCodeGen = struct {
 
     /// A Dec's payload is its value scaled by 10^18, so recovering the whole
     /// part means dividing the payload by that scale before wrapping it into
-    /// the destination width. The quotient is divided at the full i128 width so
-    /// whole parts beyond i64 wrap rather than trap, and dividing by a constant
-    /// keeps the sequence foldable instead of calling into the builtins.
+    /// the destination width. The division runs at the full i128 width so whole
+    /// parts beyond i64 wrap rather than trap, and it goes through the same
+    /// i128 div-trunc builtin the dev and wasm backends call: see
+    /// `emitI128DivRem` for why the module must not contain a 128-bit divide.
     fn emitDecToIntTruncConversion(self: *MonoLlvmCodeGen, target: LocalId, arg: LocalId) Error!void {
         const builder = self.builder orelse return error.CompilationFailed;
-        const wip = self.wip orelse return error.CompilationFailed;
         const payload = try self.loadScalar(self.slot(arg).ptr, .dec);
         const scale = builder.intValue(.i128, builtins.dec.RocDec.one_point_zero_i128) catch return error.OutOfMemory;
-        const whole = wip.bin(.sdiv, payload, scale, "") catch return error.OutOfMemory;
+        const whole = try self.callI128BinaryBuiltin(
+            builtinSymbol(LowLevelBuiltins.i128DivRem(false, false)),
+            payload,
+            scale,
+            true,
+        );
         const target_layout = self.localLayout(target);
         const wrapped = try self.coerceScalar(whole, self.scalarType(target_layout), true);
         try self.storeScalar(self.slot(target).ptr, target_layout, wrapped);
@@ -8011,7 +8055,7 @@ pub const MonoLlvmCodeGen = struct {
     fn emitDecPow(self: *MonoLlvmCodeGen, target: LocalId, args: anytype) Error!void {
         const lhs = try self.loadScalar(self.slot(GuardedList.at(args, 0)).ptr, .dec);
         const rhs = try self.loadScalar(self.slot(GuardedList.at(args, 1)).ptr, .dec);
-        const result = try self.callDecBinaryBuiltin(builtinSymbol(LowLevelBuiltins.decBinaryArith(.num_pow)), lhs, rhs, true);
+        const result = try self.callI128BinaryBuiltin(builtinSymbol(LowLevelBuiltins.decBinaryArith(.num_pow)), lhs, rhs, true);
         try self.storeScalar(self.slot(target).ptr, .dec, result);
     }
 

--- a/src/builtins/static_lib.zig
+++ b/src/builtins/static_lib.zig
@@ -16,8 +16,9 @@ pub const std_options_debug_io = shim_io.io();
 /// Disables threaded debug IO to prevent the threaded vtable from being linked into user programs.
 pub const std_options_debug_threaded_io = null;
 
-/// Disables stack-trace capture; see `shim_io.std_options_no_stack_tracing`.
-pub const std_options = shim_io.std_options_no_stack_tracing;
+/// Keeps std off the symbols a roc program's link cannot resolve; see
+/// `shim_io.std_options_static_archive`.
+pub const std_options = shim_io.std_options_static_archive;
 
 const builtin_registry = @import("builtin_registry.zig");
 

--- a/src/builtins/static_lib_core.zig
+++ b/src/builtins/static_lib_core.zig
@@ -17,8 +17,9 @@ pub const std_options_debug_io = shim_io.io();
 /// Disables threaded debug IO to prevent the threaded vtable from being linked into user programs.
 pub const std_options_debug_threaded_io = null;
 
-/// Disables stack-trace capture; see `shim_io.std_options_no_stack_tracing`.
-pub const std_options = shim_io.std_options_no_stack_tracing;
+/// Keeps std off the symbols a roc program's link cannot resolve; see
+/// `shim_io.std_options_static_archive`.
+pub const std_options = shim_io.std_options_static_archive;
 
 const builtin_registry = @import("builtin_registry.zig");
 

--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -121,6 +121,11 @@ pub const io_spec_tests = [_]TestSpec{
         .description = "Every runtime Dec-to-integer width recovers the whole part, truncates toward zero, and wraps past the destination range",
     },
     .{
+        .roc_file = "test/fx/runtime_i128_div_rem_mod.roc",
+        .io_spec = "0<3|1>unsigned: 42857142857142857142 6 6|1>signed: 42857142857142857142 6 6|1>negative: -42857142857142857142 -6 1",
+        .description = "Runtime 128-bit division, remainder and modulo agree across backends and keep the operands' full width",
+    },
+    .{
         .roc_file = "test/fx/runtime_zst_list_ownership.roc",
         .io_spec = "0<3|1>append: 2|1>literal: 3|1>concat: 5|1>repeat: 3|1>first: ok",
         .description = "Zero-sized-element lists keep their length through reserve/append/concat and strand no allocation",

--- a/src/interpreter_shim/main.zig
+++ b/src/interpreter_shim/main.zig
@@ -25,8 +25,9 @@ pub const std_options_debug_io = shim_io.io();
 /// Disables threaded debug IO to prevent the threaded vtable from being linked into user programs.
 pub const std_options_debug_threaded_io = null;
 
-/// Disables stack-trace capture in the shim; panics here go through the host's RocOps.
-pub const std_options = shim_io.std_options_no_stack_tracing;
+/// Keeps std off the symbols a roc program's link cannot resolve; see
+/// `shim_io.std_options_static_archive`. Panics here go through the host's RocOps.
+pub const std_options = shim_io.std_options_static_archive;
 
 const Allocator = std.mem.Allocator;
 const RocOps = builtins.host_abi.RocOps;

--- a/src/machine_code_shim/main.zig
+++ b/src/machine_code_shim/main.zig
@@ -21,8 +21,9 @@ pub const std_options_debug_io = shim_io.io();
 /// Disables threaded debug IO to prevent the threaded vtable from being linked into user programs.
 pub const std_options_debug_threaded_io = null;
 
-/// Disables stack-trace capture in the shim; panics here go through the host's RocOps.
-pub const std_options = shim_io.std_options_no_stack_tracing;
+/// Keeps std off the symbols a roc program's link cannot resolve; see
+/// `shim_io.std_options_static_archive`. Panics here go through the host's RocOps.
+pub const std_options = shim_io.std_options_static_archive;
 
 const Allocator = std.mem.Allocator;
 const RocOps = builtins.host_abi.RocOps;

--- a/src/shim_io.zig
+++ b/src/shim_io.zig
@@ -66,14 +66,43 @@ pub fn elfDebugInfoSearchPaths(_: []const u8) if (builtin.object_format == .elf)
     return;
 }
 
-/// Shared `std.Options` value for shim and platform-host code that needs to disable
-/// std stack tracing. Zig 0.16's `std.debug.SelfInfo` on Windows references
+/// Shared `std.Options` value for the shims, the builtins static libraries and
+/// the platform hosts—every static archive roc links into a program it
+/// produces. Both settings keep std from reaching for a symbol that link cannot
+/// resolve.
+///
+/// Zig 0.16's `std.debug.SelfInfo` on Windows references
 /// `ntdll.LdrRegisterDllNotification`, which isn't linked into roc-compiled
 /// programs that embed these static archives—leaving stack tracing on would
-/// trigger an unresolved-symbol link error. Hosts that need extra fields
-/// (e.g. `logFn`, `log_level`) should declare their own `std.Options` literal
-/// rather than alias this one.
-pub const std_options_no_stack_tracing: std.Options = .{ .allow_stack_tracing = false };
+/// trigger an unresolved-symbol link error.
+///
+/// `std.heap.defaultQueryPageSize` reaches the auxiliary vector through
+/// `getauxval`; with no libc that is an extern call whose weak definition Zig
+/// emits only for executables, so a static archive is left referencing it and
+/// the `-nostdlib` link of a roc program has nothing to bind it to. Only
+/// targets whose page size is not comptime-known query it at all, which is why
+/// aarch64 Linux hits this and x86-64 does not. See `queryPageSize`.
+///
+/// Hosts that need extra fields (e.g. `logFn`, `log_level`) should declare
+/// their own `std.Options` literal rather than alias this one.
+pub const std_options_static_archive: std.Options = .{
+    .allow_stack_tracing = false,
+    .queryPageSize = queryPageSize,
+};
+
+/// Page size for code linked into roc-produced programs.
+///
+/// libc reads the auxiliary vector during its own startup, so where it is
+/// linked std's own query answers exactly. Without it these archives have no
+/// auxiliary vector to read—they are not the program's entry point, so nothing
+/// populates `std.os.linux.elf_aux_maybe`—so report the target's largest
+/// supported page size. Allocations rounded up to it stay page-aligned for
+/// whatever smaller page size the kernel actually uses, which is also what std
+/// itself settles on when the auxiliary vector is unavailable.
+fn queryPageSize() usize {
+    if (comptime builtin.link_libc) return std.heap.defaultQueryPageSize();
+    return std.heap.page_size_max;
+}
 
 const linux_vtable: std.Io.VTable = blk: {
     var vtable = std.Io.failing.vtable.*;

--- a/test/alloc-count/platform/host.zig
+++ b/test/alloc-count/platform/host.zig
@@ -10,8 +10,9 @@ const host_alloc = @import("host_alloc");
 pub const std_options_elf_debug_info_search_paths = shim_io.elfDebugInfoSearchPaths;
 pub const std_options_debug_io = shim_io.io();
 pub const std_options_debug_threaded_io = null;
-// See `shim_io.std_options_no_stack_tracing` for why stack tracing is disabled.
-pub const std_options = shim_io.std_options_no_stack_tracing;
+// See `shim_io.std_options_static_archive` for why these settings matter to a
+// static archive that roc links into a program.
+pub const std_options = shim_io.std_options_static_archive;
 
 const RocOps = builtins.host_abi.RocOps;
 const RocStr = builtins.str.RocStr;

--- a/test/archive/platform/host.zig
+++ b/test/archive/platform/host.zig
@@ -11,8 +11,9 @@ const host_alloc = @import("host_alloc");
 pub const std_options_elf_debug_info_search_paths = shim_io.elfDebugInfoSearchPaths;
 pub const std_options_debug_io = shim_io.io();
 pub const std_options_debug_threaded_io = null;
-// See `shim_io.std_options_no_stack_tracing` for why stack tracing is disabled.
-pub const std_options = shim_io.std_options_no_stack_tracing;
+// See `shim_io.std_options_static_archive` for why these settings matter to a
+// static archive that roc links into a program.
+pub const std_options = shim_io.std_options_static_archive;
 
 /// Allocation state for the host's exported runtime symbols. Under the symbol
 /// ABI no context parameter reaches these functions; the host owns its

--- a/test/dylib/platform/host.zig
+++ b/test/dylib/platform/host.zig
@@ -12,8 +12,9 @@ const shim_io = @import("shim_io");
 pub const std_options_elf_debug_info_search_paths = shim_io.elfDebugInfoSearchPaths;
 pub const std_options_debug_io = shim_io.io();
 pub const std_options_debug_threaded_io = null;
-// See `shim_io.std_options_no_stack_tracing` for why stack tracing is disabled.
-pub const std_options = shim_io.std_options_no_stack_tracing;
+// See `shim_io.std_options_static_archive` for why these settings matter to a
+// static archive that roc links into a program.
+pub const std_options = shim_io.std_options_static_archive;
 
 /// Allocation state for the host's exported runtime symbols. Under the symbol
 /// ABI no context parameter reaches these functions; the host owns its

--- a/test/fx-open/platform/host.zig
+++ b/test/fx-open/platform/host.zig
@@ -9,8 +9,9 @@ const host_alloc = @import("host_alloc");
 pub const std_options_elf_debug_info_search_paths = shim_io.elfDebugInfoSearchPaths;
 pub const std_options_debug_io = shim_io.io();
 pub const std_options_debug_threaded_io = null;
-// See `shim_io.std_options_no_stack_tracing` for why stack tracing is disabled.
-pub const std_options = shim_io.std_options_no_stack_tracing;
+// See `shim_io.std_options_static_archive` for why these settings matter to a
+// static archive that roc links into a program.
+pub const std_options = shim_io.std_options_static_archive;
 
 /// Host environment - contains DebugAllocator for leak detection
 const HostEnv = struct {

--- a/test/fx/runtime_i128_div_rem_mod.roc
+++ b/test/fx/runtime_i128_div_rem_mod.roc
@@ -1,0 +1,30 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdin
+import pf.Stdout
+
+# 128-bit division, remainder and modulo, driven by a runtime value so the
+# operations reach the backends instead of being folded at compile time. The
+# operands are past U64 range, so the results depend on the full 128-bit
+# arithmetic rather than its low half.
+
+main! = || {
+    n = match U64.from_str(Stdin.line!()) {
+        Ok(number) => number
+        Err(_) => 0
+    }
+
+    unsigned : U128
+    unsigned = n.to_u128() * 100000000000000000000
+
+    signed : I128
+    signed = unsigned.to_i128_wrap()
+
+    Stdout.line!("unsigned: ${(unsigned // 7).to_str()} ${(unsigned % 7).to_str()} ${unsigned.mod_by(7).to_str()}")
+    Stdout.line!("signed: ${(signed // 7).to_str()} ${(signed % 7).to_str()} ${signed.mod_by(7).to_str()}")
+
+    # Remainder keeps the sign of the dividend; modulo keeps the sign of the
+    # divisor, so the two disagree once the dividend is negative.
+    neg = 0 - signed
+    Stdout.line!("negative: ${(neg // 7).to_str()} ${(neg % 7).to_str()} ${neg.mod_by(7).to_str()}")
+}

--- a/test/int/platform/host.zig
+++ b/test/int/platform/host.zig
@@ -10,8 +10,9 @@ const f32str = builtins.compiler_rt_128.f32_to_str;
 pub const std_options_elf_debug_info_search_paths = shim_io.elfDebugInfoSearchPaths;
 pub const std_options_debug_io = shim_io.io();
 pub const std_options_debug_threaded_io = null;
-// See `shim_io.std_options_no_stack_tracing` for why stack tracing is disabled.
-pub const std_options = shim_io.std_options_no_stack_tracing;
+// See `shim_io.std_options_static_archive` for why these settings matter to a
+// static archive that roc links into a program.
+pub const std_options = shim_io.std_options_static_archive;
 
 var app_std_io: std.Io = shim_io.io();
 

--- a/test/str/platform/host.zig
+++ b/test/str/platform/host.zig
@@ -8,8 +8,9 @@ const host_alloc = @import("host_alloc");
 pub const std_options_elf_debug_info_search_paths = shim_io.elfDebugInfoSearchPaths;
 pub const std_options_debug_io = shim_io.io();
 pub const std_options_debug_threaded_io = null;
-// See `shim_io.std_options_no_stack_tracing` for why stack tracing is disabled.
-pub const std_options = shim_io.std_options_no_stack_tracing;
+// See `shim_io.std_options_static_archive` for why these settings matter to a
+// static archive that roc links into a program.
+pub const std_options = shim_io.std_options_static_archive;
 
 const RocOps = builtins.host_abi.RocOps;
 const RocStr = builtins.str.RocStr;


### PR DESCRIPTION
Two Nightly Gate jobs failed because something roc links into the program it produces referenced a symbol nothing in that link defines. The Windows LLVM lane could not link `test/fx/runtime_dec_to_int_wrap_widths.roc` (`undefined symbol: __udivti3`), and the aarch64 Linux lanes could not link any dev-backend run image (`undefined symbol: getauxval`). The rest of the run's red jobs were runner shutdowns mid-step, not test failures.

The LLVM backend emitted a bare `sdiv i128` for the Dec-to-integer scale division and for plain 128-bit division, remainder and modulo. No target Roc compiles to has a 128-bit divide instruction, so instruction selection turns those into compiler-rt libcalls (`__divti3`, `__udivti3`, ...) that a Roc object does not define and a platform host is not required to supply; Linux and macOS linked only because their Zig test hosts happen to bundle compiler-rt. Both paths now call the decomposed-to-64-bit `num_div_trunc_*`, `num_rem_trunc_*` and `num_mod_i128` builtins that the dev and wasm backends already use, which leaves the emitted object with no undefined compiler-rt symbol at all.

`getauxval` came from `std.heap.pageSize()`, a runtime query on targets whose page size is not comptime-known — which is why aarch64 hit it and x86-64 did not. With no libc that query reaches the auxiliary vector through an extern `getauxval` whose weak definition Zig emits only for executables, so the machine-code shim's archive was left referencing it. These archives are never the program's entry point and have no auxiliary vector to read regardless, so the `std.Options` value the shims, the builtins static libraries and the platform hosts share now answers the page size itself, reporting the target's largest supported page size when no libc is linked. That is what std settles on when the auxiliary vector is unavailable, and it is safe because allocations rounded up to it stay page-aligned for whatever smaller page size the kernel actually uses. The shared value is renamed to `std_options_static_archive` now that it covers more than stack tracing.
