### PR TITLE
Keep alias-initialized loop vars from hijacking their initializer's binder

### DIFF
--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -111,8 +111,107 @@ const issue9658ScannerSource =
     \\main = scan("kkv,kv;")
 ;
 
+// https://github.com/roc-lang/roc/issues/10703
+// A `var` initialized as a bare alias of another in-scope variable
+// (`var $line_start = cluster_start`) must not hijack the initializer's
+// binder: SpecConstr's loop-state specialization used to install the
+// loop-carried slot value under `cluster_start`'s binder, so every read of
+// `cluster_start` inside the loop tracked `$line_start` instead. Correct runs
+// sum 1 + line_start per line (40 + 780 = 820 for count 40); the corrupted
+// lowering zeroed the `start - prefix_start` term and returned 40.
+const issue10703LineLayoutSource =
+    \\{
+    \\    list_at = |items, index| match List.get(items, index) {
+    \\        Err(OutOfBounds) => crash "validated index escaped"
+    \\        Ok(value) => value
+    \\    }
+    \\
+    \\    range_end = |range| range.start + range.length
+    \\
+    \\    append_line = |total, clusters, prefix_start, start, end| {
+    \\        first = list_at(clusters, start)
+    \\        last = list_at(clusters, end - 1)
+    \\        scalar_count = range_end(last.scalars) - first.scalars.start
+    \\        total + scalar_count + (start - prefix_start)
+    \\    }
+    \\
+    \\    build_range = |clusters, boundaries, cluster_start, cluster_end| {
+    \\        var $line_start = cluster_start
+    \\        var $candidate = cluster_start + 1
+    \\        var $total = 0.U64
+    \\        while $line_start < cluster_end {
+    \\            boundary = list_at(boundaries, $candidate)
+    \\            if boundary == 1 {
+    \\                $total = append_line($total, clusters, cluster_start, $line_start, $candidate)
+    \\                $line_start = $candidate
+    \\                $candidate = $line_start + 1
+    \\            } else {
+    \\                $candidate = $candidate + 1
+    \\            }
+    \\        }
+    \\        $total
+    \\    }
+    \\
+    \\    make_clusters = |count| {
+    \\        var $clusters = []
+    \\        var $index = 0.U64
+    \\        while $index < count {
+    \\            $clusters = $clusters.append({ scalars: { length: 1.U64, start: $index } })
+    \\            $index = $index + 1
+    \\        }
+    \\        $clusters
+    \\    }
+    \\
+    \\    make_boundaries = |count| {
+    \\        var $boundaries = []
+    \\        var $index = 0.U64
+    \\        while $index <= count {
+    \\            $boundaries = $boundaries.append(1.U64)
+    \\            $index = $index + 1
+    \\        }
+    \\        $boundaries
+    \\    }
+    \\
+    \\    Str.inspect(build_range(make_clusters(40), make_boundaries(40), 0.U64, 40))
+    \\}
+;
+
+// The dual-alias variant of issue 10703: two loop variables initialized from
+// the same in-scope variable (`base`). Both slots used to claim `base`'s
+// binder and one arbitrarily won, so reads of `base` inside the loop tracked
+// that slot's carried value. Correct runs add base (3) on each of the 6
+// iterations and then the final `$mark` (8): 26; the corrupted lowering
+// tracked `$i` and returned 3+4+5+6+7+8 plus 8 = 41.
+const issue10703DualAliasSource =
+    \\{
+    \\    walk = |base, limit| {
+    \\        var $i = base
+    \\        var $mark = base
+    \\        var $total = 0.U64
+    \\        while $i < limit {
+    \\            $total = $total + base
+    \\            $mark = $i
+    \\            $i = $i + 1
+    \\        }
+    \\        $total + $mark
+    \\    }
+    \\
+    \\    Str.inspect(walk(3.U64, 9))
+    \\}
+;
+
 /// Public value `tests`.
 pub const tests = [_]TestCase{
+    .{
+        .name = "issue 10703: loop var aliasing an argument leaves argument reads loop-invariant",
+        .source = issue10703LineLayoutSource,
+        .expected = .{ .allocations_at_most = .{ .output = "820", .max_allocations = 32, .optimized = true } },
+    },
+    .{
+        .name = "issue 10703: two loop vars seeded from one variable keep its reads intact",
+        .source = issue10703DualAliasSource,
+        .expected = .{ .allocations_at_most = .{ .output = "26", .max_allocations = 4, .optimized = true } },
+    },
     .{
         .name = "issue 9658: scanner loop with merging mutable Str alias groups certifies and evaluates",
         .source_kind = .module,

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -7302,9 +7302,24 @@ const Cloner = struct {
         // actually holds, so drop those pre-loop values before cloning the body
         // and keep each slot's identity: the emitted params are installed under
         // it below, which is the only resolution path a reassigned copy has.
+        //
+        // That identity comes from the slot's initial value, which is only
+        // sound when that initial local is the pre-loop version of the slot's
+        // own variable. A variable initialized as a bare alias of another
+        // in-scope variable (`var $last_break = cluster_start`) carries the
+        // initializer's binder on its initial local instead; installing the
+        // slot's per-iteration value under that binder would make body reads
+        // of the initializer variable resolve to the loop-carried slot, which
+        // diverges from it after the first back edge. The body referencing the
+        // initial's exact local is the signature of that alias shape—a
+        // consumed pre-loop version is never read again—so claim (and drop)
+        // the carried binder only when the body does not.
         const carried_identities = try self.pass.allocator.alloc(?BinderIdentity, initial_values.len);
         defer self.pass.allocator.free(carried_identities);
         for (initial_values, carried_identities) |initial, *identity| {
+            identity.* = null;
+            const initial_local = localExpr(self.pass.program, initial) orelse continue;
+            if (exprReferencesLocal(self.pass.program, loop.body, initial_local)) continue;
             identity.* = try self.subst.dropCarriedBinder(self.pass.program, initial);
         }
 
@@ -11401,6 +11416,145 @@ fn stmtContainsReturn(program: *const Ast.Program, stmt_id: Ast.StmtId) bool {
         .expect,
         .dbg,
         => |expr| exprContainsReturn(program, expr),
+        .uninitialized,
+        .crash,
+        => false,
+    };
+}
+
+/// Whether `expr_id` contains any reference to `local`, including through
+/// nested loops, join points, and closure capture operands. Lambda and
+/// function-definition leaves reach enclosing locals only through explicit
+/// capture operands, which `fn_ref` and `call_proc` spans carry.
+fn exprReferencesLocal(program: *const Ast.Program, expr_id: Ast.ExprId, local: Ast.LocalId) bool {
+    return switch (program.getExpr(expr_id).data) {
+        .local => |referenced| referenced == local,
+        .@"unreachable",
+        .unit,
+        .int_lit,
+        .frac_f32_lit,
+        .frac_f64_lit,
+        .dec_lit,
+        .str_lit,
+        .bytes_lit,
+        .crash,
+        .comptime_exhaustiveness_failed,
+        .uninitialized,
+        .lambda,
+        .def_ref,
+        .fn_def,
+        => false,
+        .uninitialized_payload => |payload| payload.condition == local,
+        .fn_ref => |fn_ref| captureOperandSpanReferencesLocal(program, fn_ref.captures, local),
+        .return_ => |ret| exprReferencesLocal(program, ret.value, local),
+        .list,
+        .tuple,
+        => |items| exprSpanReferencesLocal(program, items, local),
+        .record => |fields| {
+            const field_exprs = program.fieldExprSpan(fields);
+            for (0..field_exprs.len) |index| {
+                const field = GuardedList.at(field_exprs, index);
+                if (exprReferencesLocal(program, field.value, local)) return true;
+            }
+            return false;
+        },
+        .record_update => |update| {
+            if (exprReferencesLocal(program, update.base, local)) return true;
+            const field_exprs = program.fieldExprSpan(update.fields);
+            for (0..field_exprs.len) |index| {
+                const field = GuardedList.at(field_exprs, index);
+                if (exprReferencesLocal(program, field.value, local)) return true;
+            }
+            return false;
+        },
+        .tag => |tag| exprSpanReferencesLocal(program, tag.payloads, local),
+        .static_data_candidate => |candidate| exprReferencesLocal(program, candidate.runtime_expr, local),
+        .nominal,
+        .dbg,
+        .expect,
+        => |child| exprReferencesLocal(program, child, local),
+        .expect_err => |expect_err| exprReferencesLocal(program, expect_err.msg, local),
+        .comptime_branch_taken => |taken| exprReferencesLocal(program, taken.body, local),
+        .let_ => |let_| exprReferencesLocal(program, let_.value, local) or exprReferencesLocal(program, let_.rest, local),
+        .call_value => |call| exprReferencesLocal(program, call.callee, local) or exprSpanReferencesLocal(program, call.args, local),
+        .call_proc => |call| exprSpanReferencesLocal(program, call.args, local) or captureOperandSpanReferencesLocal(program, call.captures, local),
+        .low_level => |call| exprSpanReferencesLocal(program, call.args, local),
+        .field_access => |field| exprReferencesLocal(program, field.receiver, local),
+        .tuple_access => |access| exprReferencesLocal(program, access.tuple, local),
+        .structural_eq => |eq| exprReferencesLocal(program, eq.lhs, local) or exprReferencesLocal(program, eq.rhs, local),
+        .structural_hash => |h| exprReferencesLocal(program, h.value, local) or exprReferencesLocal(program, h.hasher, local),
+        .match_ => |match| {
+            if (exprReferencesLocal(program, match.scrutinee, local)) return true;
+            const branches = program.branchSpan(match.branches);
+            for (0..branches.len) |index| {
+                const branch = GuardedList.at(branches, index);
+                const bindings = program.stmtSpan(branch.bindings);
+                for (0..bindings.len) |binding_index| {
+                    if (stmtReferencesLocal(program, GuardedList.at(bindings, binding_index), local)) return true;
+                }
+                if (branch.guard) |guard| {
+                    if (exprReferencesLocal(program, guard, local)) return true;
+                }
+                if (exprReferencesLocal(program, branch.body, local)) return true;
+            }
+            return false;
+        },
+        .if_ => |if_| {
+            const branches = program.ifBranchSpan(if_.branches);
+            for (0..branches.len) |index| {
+                const branch = GuardedList.at(branches, index);
+                if (exprReferencesLocal(program, branch.cond, local)) return true;
+                if (exprReferencesLocal(program, branch.body, local)) return true;
+            }
+            return exprReferencesLocal(program, if_.final_else, local);
+        },
+        .block => |block| {
+            const statements = program.stmtSpan(block.statements);
+            for (0..statements.len) |index| {
+                const stmt = GuardedList.at(statements, index);
+                if (stmtReferencesLocal(program, stmt, local)) return true;
+            }
+            return exprReferencesLocal(program, block.final_expr, local);
+        },
+        .loop_ => |loop| exprSpanReferencesLocal(program, loop.initial_values, local) or exprReferencesLocal(program, loop.body, local),
+        .break_ => |maybe| if (maybe) |value| exprReferencesLocal(program, value, local) else false,
+        .continue_ => |continue_| exprSpanReferencesLocal(program, continue_.values, local),
+        .join_point => |join_point| exprReferencesLocal(program, join_point.body, local) or exprReferencesLocal(program, join_point.remainder, local),
+        .jump => |jump| exprSpanReferencesLocal(program, jump.args, local),
+        .if_initialized_payload => |payload_switch| exprReferencesLocal(program, payload_switch.cond, local) or
+            exprReferencesLocal(program, payload_switch.initialized, local) or
+            exprReferencesLocal(program, payload_switch.uninitialized, local),
+        .try_sequence => |sequence| exprReferencesLocal(program, sequence.try_expr, local) or exprReferencesLocal(program, sequence.ok_body, local),
+        .try_record_sequence => |sequence| exprReferencesLocal(program, sequence.try_expr, local) or exprReferencesLocal(program, sequence.ok_body, local),
+    };
+}
+
+fn exprSpanReferencesLocal(program: *const Ast.Program, span: Ast.Span(Ast.ExprId), local: Ast.LocalId) bool {
+    const exprs = program.exprSpan(span);
+    for (0..exprs.len) |index| {
+        const expr = GuardedList.at(exprs, index);
+        if (exprReferencesLocal(program, expr, local)) return true;
+    }
+    return false;
+}
+
+fn captureOperandSpanReferencesLocal(program: *const Ast.Program, span: Ast.Span(Ast.CaptureOperand), local: Ast.LocalId) bool {
+    const operands = program.captureOperandSpan(span);
+    for (0..GuardedList.borrowLen(operands)) |index| {
+        const operand = GuardedList.at(operands, index);
+        if (exprReferencesLocal(program, operand.value, local)) return true;
+    }
+    return false;
+}
+
+fn stmtReferencesLocal(program: *const Ast.Program, stmt_id: Ast.StmtId, local: Ast.LocalId) bool {
+    return switch (program.getStmt(stmt_id)) {
+        .return_ => |ret| exprReferencesLocal(program, ret.value, local),
+        .let_ => |let_| exprReferencesLocal(program, let_.value, local),
+        .expr,
+        .expect,
+        .dbg,
+        => |expr| exprReferencesLocal(program, expr, local),
         .uninitialized,
         .crash,
         => false,


### PR DESCRIPTION
Fixes #10703.

## Root cause

The corruption is not in the LLVM backend at all — the LIR handed to it is already wrong, so `--opt=speed` at LLVM `-O0` reproduces it while `--opt=dev` (which skips the optimized post-check pipeline) does not.

SpecConstr's loop-state specialization (`cloneLoopValue` in `src/postcheck/monotype_lifted/spec_constr.zig`) identifies each loop slot's *carried binder* from the local read by the slot's **initial value** (`dropCarriedBinder(initial)`), then installs the slot's per-iteration value under that binder identity (`putLoopCarried`) so reassigned copies of the loop variable resolve to the carried value.

That is only sound when the initial local is the pre-loop version of the slot's own variable. A `var` initialized as a bare alias of another in-scope variable:

```roc
build_range = |clusters, boundaries, cluster_start, cluster_end| {
    var $line_start = cluster_start   # initial local carries cluster_start's binder
    ...
```

binds the loop variable's binder directly to the initializer's local (`prepareLoopCarries` creates the loop param with no binder of its own), so the slot's initial carries **`cluster_start`'s** binder. The pass then installed the loop-carried `$line_start` value under `cluster_start`'s identity — and every read of `cluster_start` inside the loop body silently tracked `$line_start` (observed at runtime as `cluster_start == $candidate - 1`, the impossible state from the issue). With several vars seeded from one variable (`$line_start`, `$last_break`), one slot's claim wins arbitrarily. Depending on surrounding arithmetic this produces checked-subtraction traps (`Integer subtraction overflowed` on `0 - 2`) or silently wrong results.

## Fix

Claim (and drop) a slot's carried binder only when the loop body never references the initial's exact local. A genuinely consumed pre-loop version is never read again inside the body, so the classic shape keeps its registration unchanged; a still-live alias source (the bug shape) keeps its own pre-loop binding and the slot carries its value without a binder-wide identity.

`exprReferencesLocal` is a full-expression walk modeled on the existing `exprContainsReturn`, including nested loops, join points, and closure capture operands.

## Regression tests

Two eval-suite cases (`src/eval/test/eval_issue_tests.zig`) compile with the optimized lowering (`allocations_at_most` + `optimized: true` is the one data-driven path that lowers with wrapper inlining and SpecConstr) and check the **returned value** on the interpreter, dev, and wasm backends, per the issue's request:

- the issue's line-layout shape: correct `820`; the unfixed compiler returns `40` (the `start - prefix_start` term collapses to zero),
- a minimal dual-alias loop: correct `26`; the unfixed compiler returns `41`.

Both fail before the fix and pass after it.

Also verified end-to-end on the original real-world reproducer (the pre-workaround `KernelLineLayout` line breaker at `roc-pdf` commit `be03097^`): `roc build tests/gate3_facade_output/main.roc --opt=speed` + `./facade-output-probe probe 2` trapped with `[ROC CRASHED] Integer subtraction overflowed` before this change; with it, probe stages 0–3 and the full `visible 0` path (previously unreachable) all complete successfully.

## Verification

- `zig build run-test-eval -- --filter "issue 10703"` — 2 passed (fails pre-fix)
- `zig build run-test-zig-module-compile` — green
- `zig build minici` — green
- real-world probe (above) — fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
