### PR TITLE
Fix boxy runtime std.Options reference

### DIFF
--- a/src/boxy_runtime/main.zig
+++ b/src/boxy_runtime/main.zig
@@ -42,8 +42,9 @@ pub const std_options_debug_io = shim_io.io();
 /// Disables threaded debug IO to prevent the threaded vtable from being linked into user programs.
 pub const std_options_debug_threaded_io = null;
 
-/// Disables stack-trace capture; see `shim_io.std_options_no_stack_tracing`.
-pub const std_options = shim_io.std_options_no_stack_tracing;
+/// This object is linked into the programs roc produces, so it uses
+/// `shim_io.std_options_static_archive`.
+pub const std_options = shim_io.std_options_static_archive;
 
 /// The self-contained boxy sidecar buffer emitted by the object compiler into
 /// the linked program. `roc_boxy_sidecar_blob` is the table byte buffer,


### PR DESCRIPTION
Fixes main, which currently fails to build on every target: `src/boxy_runtime/main.zig` refers to `shim_io.std_options_no_stack_tracing`, a decl that no longer exists, so every `zig build` errors with "root source file struct 'shim_io' has no member named 'std_options_no_stack_tracing'".

This is a semantic merge conflict rather than a textual one. #10709 renamed that decl to `std_options_static_archive` when it added the `queryPageSize` field alongside `allow_stack_tracing`, and #10629 was branched before that and introduced the boxy runtime root referencing the old name. Both merged cleanly and main broke.

`std_options_static_archive` is the right value here, not just the name that compiles: the boxy runtime is an object linked into the programs roc produces, freestanding and without libc, so it needs the `queryPageSize` half too — otherwise aarch64-linux leaves the archive referencing `getauxval` with nothing to bind it to. The other four roots in that class (the two shims and the two builtins static libs) already alias it.
