### PR TITLE
Build the boxy runtime object independently of the compiler's optimize mode

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3173,7 +3173,6 @@ pub fn build(b: *std.Build) void {
         b,
         roc_modules,
         wasm32_resolved_target,
-        optimize,
         strip,
         omit_frame_pointer,
         "roc_boxy_runtime_wasm32_eval",
@@ -6624,16 +6623,23 @@ fn addMacosAflFuzzExe(
 /// Build a Boxy runtime object for `target`: the `roc_boxy_*` C-ABI wrappers
 /// plus `roc_boxy_init_embedded`. The selected root configures standalone
 /// extern-symbol calls or evaluator-vtable calls.
+///
+/// This object is linked into user programs, so its optimize mode is pinned
+/// rather than following the compiler's own. A `Debug` compiler would otherwise
+/// emit a `Debug` runtime into every generic program it builds, which enables
+/// builtins' hosted debug diagnostics and grows this object by an order of
+/// magnitude. `strip` still follows the build, so debug info for the runtime
+/// remains available wherever the rest of the build carries it.
 fn buildBoxyRuntimeObject(
     b: *std.Build,
     roc_modules: modules.RocModules,
     target: ResolvedTarget,
-    optimize: OptimizeMode,
     strip: bool,
     omit_frame_pointer: ?bool,
     name: []const u8,
     root_source_file: std.Build.LazyPath,
 ) *Step.Compile {
+    const optimize: OptimizeMode = .ReleaseFast;
     const obj = b.addObject(.{
         .name = name,
         .root_module = b.createModule(.{
@@ -7126,7 +7132,6 @@ fn addMainExe(
                 b,
                 roc_modules,
                 cross_resolved_target,
-                optimize,
                 strip,
                 omit_frame_pointer,
                 b.fmt("roc_boxy_runtime_{s}", .{cross_target.name}),

--- a/src/eval/boxy_abi.zig
+++ b/src/eval/boxy_abi.zig
@@ -586,22 +586,78 @@ fn abiCrash(g: *GlobalBoxyRuntime, comptime what: []const u8) noreturn {
     unreachable;
 }
 
+/// Fixed-buffer message builder for the crash paths below.
+///
+/// These messages carry ids and keys that are worth having in a crash report,
+/// but `std.fmt` instantiates a distinct formatter per argument tuple, and
+/// `{any}` over a slice of structs instantiates one per field shape. In an
+/// object whose only output is `RocOps.crash`, that links the entire `std.Io`
+/// writer stack. Appending decimal digits directly keeps the diagnostics and
+/// leaves the object free of the formatter. Writes past the buffer are dropped,
+/// so a long id list truncates rather than failing the crash report.
+const CrashMessage = struct {
+    buf: [256]u8 = undefined,
+    len: usize = 0,
+
+    fn str(self: *CrashMessage, chunk: []const u8) void {
+        const room = self.buf.len - self.len;
+        const n = @min(room, chunk.len);
+        @memcpy(self.buf[self.len..][0..n], chunk[0..n]);
+        self.len += n;
+    }
+
+    fn uint(self: *CrashMessage, value: u64) void {
+        var digits: [20]u8 = undefined;
+        var i: usize = digits.len;
+        var v = value;
+        while (true) {
+            i -= 1;
+            digits[i] = '0' + @as(u8, @intCast(v % 10));
+            v /= 10;
+            if (v == 0) break;
+        }
+        self.str(digits[i..]);
+    }
+
+    fn keyList(self: *CrashMessage, keys: []const LIR.ErasedArgDescKey) void {
+        self.str("[");
+        for (keys, 0..) |key, index| {
+            if (index != 0) self.str(", ");
+            self.str("(");
+            self.uint(key.arg_index);
+            self.str(", ");
+            self.uint(key.descriptor_index);
+            self.str(")");
+        }
+        self.str("]");
+    }
+
+    fn uintList(self: *CrashMessage, values: []const u32) void {
+        self.str("[");
+        for (values, 0..) |value, index| {
+            if (index != 0) self.str(", ");
+            self.uint(value);
+        }
+        self.str("]");
+    }
+
+    fn text(self: *const CrashMessage) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
+
 fn abiCrashMissingDescriptorCapture(
     g: *GlobalBoxyRuntime,
     local: LIR.LocalId,
     supplied_null: bool,
 ) noreturn {
-    var buffer: [256]u8 = undefined;
-    const message = std.fmt.bufPrint(
-        &buffer,
-        "boxy runtime descriptor capture local {d} was {s}; supplied capture ids={any}",
-        .{
-            @intFromEnum(local),
-            if (supplied_null) "null" else "missing",
-            g.capture_ids,
-        },
-    ) catch "boxy runtime descriptor capture binding failed";
-    g.runtime.roc_ops.crash(message);
+    var message: CrashMessage = .{};
+    message.str("boxy runtime descriptor capture local ");
+    message.uint(@intFromEnum(local));
+    message.str(if (supplied_null) " was null" else " was missing");
+    message.str("; supplied capture ids=");
+    message.uintList(g.capture_ids);
+    g.runtime.roc_ops.crash(message.text());
     unreachable;
 }
 
@@ -610,13 +666,15 @@ fn abiCrashNullErasedArgDescriptor(
     proc_id: u32,
     key: LIR.ErasedArgDescKey,
 ) noreturn {
-    var buffer: [192]u8 = undefined;
-    const message = std.fmt.bufPrint(
-        &buffer,
-        "boxy runtime erased call supplied a null descriptor to proc {d} for key ({d}, {d})",
-        .{ proc_id, key.arg_index, key.descriptor_index },
-    ) catch "boxy runtime erased call supplied a null argument descriptor";
-    g.runtime.roc_ops.crash(message);
+    var message: CrashMessage = .{};
+    message.str("boxy runtime erased call supplied a null descriptor to proc ");
+    message.uint(proc_id);
+    message.str(" for key (");
+    message.uint(key.arg_index);
+    message.str(", ");
+    message.uint(key.descriptor_index);
+    message.str(")");
+    g.runtime.roc_ops.crash(message.text());
     unreachable;
 }
 
@@ -626,13 +684,16 @@ fn abiCrashMissingErasedArgDescriptor(
     key: LIR.ErasedArgDescKey,
     supplied_keys: []const LIR.ErasedArgDescKey,
 ) noreturn {
-    var buffer: [256]u8 = undefined;
-    const message = std.fmt.bufPrint(
-        &buffer,
-        "boxy runtime erased proc {d} required descriptor key ({d}, {d}); supplied keys={any}",
-        .{ proc_id, key.arg_index, key.descriptor_index, supplied_keys },
-    ) catch "boxy runtime erased call omitted a required argument descriptor";
-    g.runtime.roc_ops.crash(message);
+    var message: CrashMessage = .{};
+    message.str("boxy runtime erased proc ");
+    message.uint(proc_id);
+    message.str(" required descriptor key (");
+    message.uint(key.arg_index);
+    message.str(", ");
+    message.uint(key.descriptor_index);
+    message.str("); supplied keys=");
+    message.keyList(supplied_keys);
+    g.runtime.roc_ops.crash(message.text());
     unreachable;
 }
 
@@ -641,13 +702,15 @@ fn abiCrashDuplicateErasedArgDescriptor(
     proc_id: u32,
     key: LIR.ErasedArgDescKey,
 ) noreturn {
-    var buffer: [192]u8 = undefined;
-    const message = std.fmt.bufPrint(
-        &buffer,
-        "boxy runtime erased call supplied duplicate descriptors to proc {d} for key ({d}, {d})",
-        .{ proc_id, key.arg_index, key.descriptor_index },
-    ) catch "boxy runtime erased call supplied duplicate argument descriptors";
-    g.runtime.roc_ops.crash(message);
+    var message: CrashMessage = .{};
+    message.str("boxy runtime erased call supplied duplicate descriptors to proc ");
+    message.uint(proc_id);
+    message.str(" for key (");
+    message.uint(key.arg_index);
+    message.str(", ");
+    message.uint(key.descriptor_index);
+    message.str(")");
+    g.runtime.roc_ops.crash(message.text());
     unreachable;
 }
 

--- a/src/eval/boxy_runtime.zig
+++ b/src/eval/boxy_runtime.zig
@@ -1096,8 +1096,8 @@ pub const BoxyRuntime = struct {
             .static => {},
         }
 
-        var copied = std.AutoHashMap(usize, u32).init(self.scratch);
-        defer copied.deinit();
+        var copied = std.AutoHashMapUnmanaged(usize, u32){};
+        defer copied.deinit(self.scratch);
         const runtime_ref = try self.copyBoxyDescRefToRuntime(hooks, desc_ref, &copied, captures.len == 0);
         return try hooks.resolveDescRef(runtime_ref);
     }
@@ -1233,8 +1233,8 @@ pub const BoxyRuntime = struct {
             return specialized;
         }
 
-        var merged = std.AutoHashMap(AdapterDescMergeKey, u32).init(self.scratch);
-        defer merged.deinit();
+        var merged = std.AutoHashMapUnmanaged(AdapterDescMergeKey, u32){};
+        defer merged.deinit(self.scratch);
         var changed = false;
         const id = try self.mergeAdapterTargetDesc(hooks, source, target, &merged, &changed);
         const specialized = if (changed) self.runtime_boxy_type_descs.items[id] else target;
@@ -1248,8 +1248,8 @@ pub const BoxyRuntime = struct {
         source: *const LirProgram.BoxyTypeDesc,
         target: *const LirProgram.BoxyTypeDesc,
     ) Error!bool {
-        var visited = std.AutoHashMap(AdapterDescMergeKey, void).init(self.scratch);
-        defer visited.deinit();
+        var visited = std.AutoHashMapUnmanaged(AdapterDescMergeKey, void){};
+        defer visited.deinit(self.scratch);
         return try self.descriptorsUseSameStorageConventionInner(hooks, source, target, &visited);
     }
 
@@ -1266,7 +1266,7 @@ pub const BoxyRuntime = struct {
         hooks: anytype,
         source: *const LirProgram.BoxyTypeDesc,
         target: *const LirProgram.BoxyTypeDesc,
-        visited: *std.AutoHashMap(AdapterDescMergeKey, void),
+        visited: *std.AutoHashMapUnmanaged(AdapterDescMergeKey, void),
     ) Error!bool {
         if (source == target) return true;
         if (source.payload_layout != target.payload_layout or
@@ -1277,7 +1277,7 @@ pub const BoxyRuntime = struct {
         }
 
         const key = AdapterDescMergeKey{ .source = @intFromPtr(source), .target = @intFromPtr(target) };
-        const entry = try visited.getOrPut(key);
+        const entry = try visited.getOrPut(self.scratch, key);
         if (entry.found_existing) return true;
 
         const source_names = self.requireBoxyFieldNames(source.field_names);
@@ -1345,7 +1345,7 @@ pub const BoxyRuntime = struct {
         hooks: anytype,
         source: *const LirProgram.BoxyTypeDesc,
         target: *const LirProgram.BoxyTypeDesc,
-        merged: *std.AutoHashMap(AdapterDescMergeKey, u32),
+        merged: *std.AutoHashMapUnmanaged(AdapterDescMergeKey, u32),
         changed: *bool,
     ) Error!u32 {
         const key = AdapterDescMergeKey{ .source = @intFromPtr(source), .target = @intFromPtr(target) };
@@ -1353,7 +1353,7 @@ pub const BoxyRuntime = struct {
         const result = try self.descriptor_arena.create(LirProgram.BoxyTypeDesc);
         result.* = target.*;
         const id = try self.appendRuntimeBoxyTypeDesc(result);
-        try merged.put(key, id);
+        try merged.put(self.scratch, key, id);
 
         const target_layout = self.layout_store.getLayout(target.payload_layout);
         const source_layout = self.layout_store.getLayout(source.payload_layout);
@@ -1558,7 +1558,7 @@ pub const BoxyRuntime = struct {
         self: *const BoxyRuntime,
         hooks: anytype,
         desc_ref: LIR.BoxyDescRef,
-        copied: *std.AutoHashMap(usize, u32),
+        copied: *std.AutoHashMapUnmanaged(usize, u32),
         allow_global_reuse: bool,
     ) Error!LIR.BoxyDescRef {
         if (desc_ref == .runtime) return desc_ref;
@@ -1579,7 +1579,7 @@ pub const BoxyRuntime = struct {
             .debug_checked_type = source.debug_checked_type,
         };
         const runtime_id = try self.appendRuntimeBoxyTypeDesc(target);
-        try copied.put(source_key, runtime_id);
+        try copied.put(self.scratch, source_key, runtime_id);
 
         target.nested_descs = try self.copyBoxyDescRefSpanToRuntime(hooks, source.nested_descs, copied, allow_global_reuse);
         target.tag_variants = try self.copyBoxyTagVariantSpanToRuntime(hooks, source.tag_variants, copied, allow_global_reuse);
@@ -1604,7 +1604,7 @@ pub const BoxyRuntime = struct {
         self: *const BoxyRuntime,
         hooks: anytype,
         span: LIR.BoxySpan,
-        copied: *std.AutoHashMap(usize, u32),
+        copied: *std.AutoHashMapUnmanaged(usize, u32),
         allow_global_reuse: bool,
     ) Error!LIR.BoxySpan {
         if (runtimeBoxySpanStart(span) != null) return span;
@@ -1630,7 +1630,7 @@ pub const BoxyRuntime = struct {
         self: *const BoxyRuntime,
         hooks: anytype,
         span: LIR.BoxySpan,
-        copied: *std.AutoHashMap(usize, u32),
+        copied: *std.AutoHashMapUnmanaged(usize, u32),
         allow_global_reuse: bool,
     ) Error!LIR.BoxySpan {
         if (runtimeBoxySpanStart(span) != null) return span;
@@ -1661,7 +1661,7 @@ pub const BoxyRuntime = struct {
         self: *const BoxyRuntime,
         hooks: anytype,
         span: LIR.BoxySpan,
-        copied: *std.AutoHashMap(usize, u32),
+        copied: *std.AutoHashMapUnmanaged(usize, u32),
         allow_global_reuse: bool,
     ) Error!LIR.BoxySpan {
         if (runtimeBoxySpanStart(span) != null) return span;
@@ -1689,7 +1689,7 @@ pub const BoxyRuntime = struct {
         self: *const BoxyRuntime,
         hooks: anytype,
         span: LIR.BoxySpan,
-        copied: *std.AutoHashMap(usize, u32),
+        copied: *std.AutoHashMapUnmanaged(usize, u32),
         allow_global_reuse: bool,
     ) Error!LIR.BoxySpan {
         if (runtimeBoxySpanStart(span) != null) return span;
@@ -5276,59 +5276,57 @@ pub const BoxyRuntime = struct {
         value: Value,
         layout_idx: layout_mod.Idx,
     ) Error!void {
-        // Roc's own Ryu formatter rather than `{d}`: std's float formatting
-        // divides a 128-bit intermediate by ten, which lowers to the
-        // `__udivti3`/`__umodti3` compiler-rt libcalls. Ryu stays within 64-bit
-        // arithmetic, so the standalone runtime object keeps no undefined
-        // compiler-rt references, and inspect output matches how Roc renders
-        // fractions everywhere else.
+        // Fractions render through Roc's own Ryu formatter and integers widen
+        // to 128 bits and render through `compiler_rt_128`, both rather than
+        // `{d}`. Two reasons. std's formatting divides a 128-bit intermediate
+        // by ten, which lowers to the `__udivti3`/`__umodti3` compiler-rt
+        // libcalls the standalone runtime object must not reference; these
+        // helpers stay within 64-bit arithmetic. And `std.fmt` instantiates a
+        // separate formatter per argument type, so one `{d}` per integer width
+        // links the whole `std.Io` writer stack into an object whose only
+        // output path is the host crash callback. Ryu also matches how Roc
+        // renders fractions everywhere else.
         var float_buf: [builtins.compiler_rt_128.float_string_capacity]u8 = undefined;
-        const text = switch (self.helper.sizeOf(layout_idx)) {
-            1 => if (isUnsigned(layout_idx))
-                try std.fmt.allocPrint(self.eval_arena, "{d}", .{value.read(u8)})
-            else
-                try std.fmt.allocPrint(self.eval_arena, "{d}", .{value.read(i8)}),
-            2 => if (isUnsigned(layout_idx))
-                try std.fmt.allocPrint(self.eval_arena, "{d}", .{value.read(u16)})
-            else
-                try std.fmt.allocPrint(self.eval_arena, "{d}", .{value.read(i16)}),
-            4 => blk: {
-                const layout_val = self.layout_store.getLayout(layout_idx);
-                break :blk if (layout_val.tag == .scalar and layout_val.getScalar().tag == .frac)
-                    try self.eval_arena.dupe(u8, builtins.compiler_rt_128.f32_to_str(&float_buf, value.read(f32)))
-                else if (isUnsigned(layout_idx))
-                    try std.fmt.allocPrint(self.eval_arena, "{d}", .{value.read(u32)})
-                else
-                    try std.fmt.allocPrint(self.eval_arena, "{d}", .{value.read(i32)});
-            },
-            8 => blk: {
-                const layout_val = self.layout_store.getLayout(layout_idx);
-                break :blk if (layout_val.tag == .scalar and layout_val.getScalar().tag == .frac)
-                    try self.eval_arena.dupe(u8, builtins.compiler_rt_128.f64_to_str(&float_buf, value.read(f64)))
-                else if (isUnsigned(layout_idx))
-                    try std.fmt.allocPrint(self.eval_arena, "{d}", .{value.read(u64)})
-                else
-                    try std.fmt.allocPrint(self.eval_arena, "{d}", .{value.read(i64)});
-            },
-            16 => blk: {
-                const layout_val = self.layout_store.getLayout(layout_idx);
-                if (layout_val.tag == .scalar and layout_val.getScalar().tag == .frac) {
-                    var dec_buf: [builtins.dec.RocDec.max_str_length]u8 = undefined;
-                    const dec = builtins.dec.RocDec{ .num = value.read(i128) };
-                    break :blk try self.eval_arena.dupe(u8, dec.format_to_buf(&dec_buf));
+        var int_buf: [builtins.compiler_rt_128.int_string_capacity(i128)]u8 = undefined;
+        const size = self.helper.sizeOf(layout_idx);
+        const text = switch (size) {
+            1, 2, 4, 8, 16 => blk: {
+                // Only 4, 8, and 16 byte scalars can carry a fraction; the
+                // narrower widths are integers whatever the layout says.
+                if (size >= 4) {
+                    const layout_val = self.layout_store.getLayout(layout_idx);
+                    if (layout_val.tag == .scalar and layout_val.getScalar().tag == .frac) {
+                        break :blk switch (size) {
+                            4 => try self.eval_arena.dupe(u8, builtins.compiler_rt_128.f32_to_str(&float_buf, value.read(f32))),
+                            8 => try self.eval_arena.dupe(u8, builtins.compiler_rt_128.f64_to_str(&float_buf, value.read(f64))),
+                            else => dec: {
+                                var dec_buf: [builtins.dec.RocDec.max_str_length]u8 = undefined;
+                                const dec = builtins.dec.RocDec{ .num = value.read(i128) };
+                                break :dec try self.eval_arena.dupe(u8, dec.format_to_buf(&dec_buf));
+                            },
+                        };
+                    }
                 }
-                // `compiler_rt_128` rather than `{d}`: std's integer formatting
-                // divides the 128-bit value by ten, which lowers to the
-                // `__udivti3`/`__umodti3` compiler-rt libcalls. These helpers
-                // decompose to 64-bit arithmetic, so the standalone runtime
-                // object stays free of undefined compiler-rt references.
-                var int_buf: [builtins.compiler_rt_128.int_string_capacity(i128)]u8 = undefined;
-                break :blk if (isUnsigned(layout_idx))
-                    try self.eval_arena.dupe(u8, builtins.compiler_rt_128.u128_to_str(&int_buf, value.read(u128)).str)
-                else
-                    try self.eval_arena.dupe(u8, builtins.compiler_rt_128.i128_to_str(&int_buf, value.read(i128)).str);
+                if (isUnsigned(layout_idx)) {
+                    const widened: u128 = switch (size) {
+                        1 => value.read(u8),
+                        2 => value.read(u16),
+                        4 => value.read(u32),
+                        8 => value.read(u64),
+                        else => value.read(u128),
+                    };
+                    break :blk try self.eval_arena.dupe(u8, builtins.compiler_rt_128.u128_to_str(&int_buf, widened).str);
+                }
+                const widened: i128 = switch (size) {
+                    1 => value.read(i8),
+                    2 => value.read(i16),
+                    4 => value.read(i32),
+                    8 => value.read(i64),
+                    else => value.read(i128),
+                };
+                break :blk try self.eval_arena.dupe(u8, builtins.compiler_rt_128.i128_to_str(&int_buf, widened).str);
             },
-            else => try std.fmt.allocPrint(self.eval_arena, "0", .{}),
+            else => try self.eval_arena.dupe(u8, "0"),
         };
         defer self.eval_arena.free(text);
         try out.appendSlice(self.eval_arena, text);
@@ -5344,9 +5342,13 @@ pub const BoxyRuntime = struct {
                 '\r' => try out.appendSlice(self.eval_arena, "\\r"),
                 '\t' => try out.appendSlice(self.eval_arena, "\\t"),
                 else => if (byte < 0x20) {
-                    const escaped = try std.fmt.allocPrint(self.eval_arena, "\\u({x})", .{byte});
-                    defer self.eval_arena.free(escaped);
-                    try out.appendSlice(self.eval_arena, escaped);
+                    // Hand-written hex rather than `{x}`: see `appendScalarInspect`
+                    // for why this object links no `std.fmt` formatter.
+                    const hex_digits = "0123456789abcdef";
+                    try out.appendSlice(self.eval_arena, "\\u(");
+                    if (byte >= 0x10) try out.append(self.eval_arena, hex_digits[byte >> 4]);
+                    try out.append(self.eval_arena, hex_digits[byte & 0xf]);
+                    try out.append(self.eval_arena, ')');
                 } else {
                     try out.append(self.eval_arena, byte);
                 },
@@ -6929,8 +6931,8 @@ pub const BoxyRuntime = struct {
         hooks: anytype,
         desc: *const LirProgram.BoxyTypeDesc,
     ) Error!bool {
-        var visited = std.AutoHashMap(*const LirProgram.BoxyTypeDesc, void).init(self.scratch);
-        defer visited.deinit();
+        var visited = std.AutoHashMapUnmanaged(*const LirProgram.BoxyTypeDesc, void){};
+        defer visited.deinit(self.scratch);
         return try self.descriptorContainsUnspecifiedBoxInner(hooks, desc, &visited);
     }
 
@@ -6938,9 +6940,9 @@ pub const BoxyRuntime = struct {
         self: *const BoxyRuntime,
         hooks: anytype,
         desc: *const LirProgram.BoxyTypeDesc,
-        visited: *std.AutoHashMap(*const LirProgram.BoxyTypeDesc, void),
+        visited: *std.AutoHashMapUnmanaged(*const LirProgram.BoxyTypeDesc, void),
     ) Error!bool {
-        const entry = try visited.getOrPut(desc);
+        const entry = try visited.getOrPut(self.scratch, desc);
         if (entry.found_existing) return false;
 
         const layout_value = self.layout_store.getLayout(desc.payload_layout);


### PR DESCRIPTION
The standalone boxy runtime object is linked into user programs, but `buildBoxyRuntimeObject` took the compiler's own optimize mode, so a `Debug` compiler emitted a `Debug` runtime into every generic program it built. `Debug` enables builtins' hosted debug diagnostics, and because these objects target macOS/Linux/Windows rather than freestanding, every `os.tag != .freestanding` guard in `builtins/utils.zig` fails open and pulls in `std.debug.print` along with the whole `std.Io` writer stack. That came to 3.1 MB in a Debug build against 247 KB in a release one, embedded once per supported target in the compiler binary and linked into every generic program. The object is now pinned to `ReleaseFast` so it is byte-identical however the compiler is built; `strip` still follows the build.

Two paths in the runtime also reached `std.fmt` directly, which costs in any build mode. `appendScalarInspect` called `allocPrint("{d}")` once per integer width, and `std.fmt` instantiates a separate formatter per argument type; integers now widen to 128 bits and render through the `compiler_rt_128` helpers the 128-bit case already used. Four crash paths used `bufPrint` with `{d}`/`{s}`/`{any}`, where `{any}` over a slice of structs instantiates one formatter per field shape; they now build their messages through a fixed-buffer helper that keeps every id and key in the report. Measured separately against the release object, those remove 8.7 KB and 9.1 KB, taking it to 238,672 bytes with `std.Io` down to four vtable stubs.

The scratch descriptor maps also move from managed to unmanaged hash maps, matching the persistent maps they sit alongside. That one is for consistency rather than size: it measured at about 100 bytes, because the managed wrapper is thin and the weight is the eight distinct key/value instantiations. Collapsing those would mean type-punning values into `u64` across maps with different meanings for roughly 2% of text, which did not look like a good trade on the descriptor-identity path. For the same reason `boxy_runtime` itself is untouched — it has zero duplicate generic instantiations, so its 92.6 KB is genuine non-duplicated descriptor logic rather than anything mechanically removable.