### PR TITLE
Report syntax errors in platform headers instead of a false missing-targets error (#10651)

### DIFF
--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -2884,11 +2884,16 @@ fn rocRunSharedMemoryShim(ctx: *CliCtx, args: cli_args.RunArgs, arg0: []const u8
                     ctx.io.stderr().print("that specifies which targets are supported and what files to link.\n", .{}) catch {};
                     return error.PlatformNotSupported;
                 },
+                error.ParseError => {
+                    // validatePlatformHeader already rendered the syntax
+                    // diagnostics; stop here so we don't fall through and
+                    // print a misleading "no compatible target" error too.
+                    return error.PlatformNotSupported;
+                },
                 error.FileReadError,
                 error.MissingFilesDirectory,
                 error.MissingTargetFile,
                 error.OutOfMemory,
-                error.ParseError,
                 error.UnsupportedTarget,
                 => {
                     std.log.debug("Could not validate platform header: {}", .{err});

--- a/src/cli/platform_validation.zig
+++ b/src/cli/platform_validation.zig
@@ -110,7 +110,10 @@ pub fn validatePlatformHeader(
 
     // Extract TargetsConfig
     const config = TargetsConfig.fromAST(allocator, ast) catch {
-        return error.ParseError;
+        // fromAST only fails on allocation failure, and nothing has been
+        // rendered at this point, so don't report it as a parse error: that
+        // path assumes diagnostics are already on screen and exits silently.
+        return error.OutOfMemory;
     } orelse {
         try renderMissingTargetsError(allocator, platform_source_path, stderr, report_config);
         return error.MissingTargetsSection;

--- a/src/cli/platform_validation.zig
+++ b/src/cli/platform_validation.zig
@@ -89,7 +89,8 @@ pub fn validatePlatformHeader(
             var report = try ast.tokenizeDiagnosticToReport(diagnostic, allocator, owned_filename);
             defer report.deinit();
             reporting.renderReportToTerminal(
-                &report, stderr,
+                &report,
+                stderr,
                 reporting.ColorUtils.getPaletteForConfig(report_config),
                 report_config,
             ) catch {};
@@ -98,7 +99,8 @@ pub fn validatePlatformHeader(
             var report = try ast.parseDiagnosticToReport(&env, diagnostic, allocator, owned_filename);
             defer report.deinit();
             reporting.renderReportToTerminal(
-                &report, stderr,
+                &report,
+                stderr,
                 reporting.ColorUtils.getPaletteForConfig(report_config),
                 report_config,
             ) catch {};

--- a/src/cli/platform_validation.zig
+++ b/src/cli/platform_validation.zig
@@ -78,6 +78,34 @@ pub fn validatePlatformHeader(
     };
     defer ast.deinit();
 
+    // The parser recovers from syntax errors and records them in the AST rather
+    // than returning them, so the catch above only fires on allocation failure.
+    // Surface those diagnostics here; otherwise a bad header falls through to
+    // fromAST and is misreported as a missing 'targets:' section (#10651).
+    if (ast.hasErrors()) {
+        const owned_filename = try allocator.dupe(u8, platform_source_path);
+        defer allocator.free(owned_filename);
+        for (ast.tokenize_diagnostics.items) |diagnostic| {
+            var report = try ast.tokenizeDiagnosticToReport(diagnostic, allocator, owned_filename);
+            defer report.deinit();
+            reporting.renderReportToTerminal(
+                &report, stderr,
+                reporting.ColorUtils.getPaletteForConfig(report_config),
+                report_config,
+            ) catch {};
+        }
+        for (ast.parse_diagnostics.items) |diagnostic| {
+            var report = try ast.parseDiagnosticToReport(&env, diagnostic, allocator, owned_filename);
+            defer report.deinit();
+            reporting.renderReportToTerminal(
+                &report, stderr,
+                reporting.ColorUtils.getPaletteForConfig(report_config),
+                report_config,
+            ) catch {};
+        }
+        return error.ParseError;
+    }
+
     // Extract TargetsConfig
     const config = TargetsConfig.fromAST(allocator, ast) catch {
         return error.ParseError;


### PR DESCRIPTION
Fixes #10651. Opening as discussed with @Anton-4 in the issue.

A platform header with a syntax error was reported as missing its `targets:` section, even when the section was right there:

```
$ roc run app.roc     # header's `requires` uses old open-record syntax
MISSING TARGETS SECTION
Platform at ./platform/main.roc does not have a 'targets:' section.
```

The parser recovers from syntax errors and stores them in the AST rather than returning them, so the `catch` on `parse.file` (`platform_validation.zig:75`) only ever fires on allocation failure. A malformed header falls through to `TargetsConfig.fromAST`, which finds no `targets:` in the damaged AST and reports it as missing.

The fix checks `ast.hasErrors()` after parsing and renders the recorded tokenize/parse diagnostics — the same reporters `ReplSession` already uses — then returns `error.ParseError`. Same example now:

```
EXPECTED CLOSING BRACE
I was parsing a `requires` section, and I expected a closing `}`.
...
For example:
    requires { main : {} => I32 }
```

**Repro** (what I ran): `test/alloc-count`, change the header's `requires {} { run! : Str => Str }` to the old `requires {} { run! : {}* }`, leave `targets:` untouched, `roc run app.roc`. Verified against a locally built `roc` on this branch.

**Testing.** I didn't see an existing negative test for platform-header validation (the `test/*/platform` dirs are working platforms, not error cases), so I kept the change to the one file rather than add a test harness that isn't there yet. Happy to add a snapshot/CLI case if you point me at the right spot.

Disclosure: I use an AI assistant in my work.
