### PR TITLE
Add tests for the numeric conversions

### DIFF
--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -4394,10 +4394,12 @@ pub const MonoLlvmCodeGen = struct {
             .ptr_load => try self.emitPtrLoad(target, GuardedList.at(arg_locals, 0)),
             .ptr_cast => try self.emitPtrCast(target, GuardedList.at(arg_locals, 0)),
             .crash => try self.emitCrashBytes("Roc crashed"),
+            // Not conversions, and not lowered by this backend.
             .list_split_first,
             .list_split_last,
             .num_log,
             .num_round,
+            => return error.UnsupportedLowLevel,
             .u8_to_i8_wrap,
             .u8_to_i8_try,
             .u8_to_i16,
@@ -4644,7 +4646,7 @@ pub const MonoLlvmCodeGen = struct {
             .dec_to_f32_wrap,
             .dec_to_f32_try_unsafe,
             .dec_to_f64,
-            => try self.emitNumericConversionOrCrash(target, op, arg_locals),
+            => try self.emitNumericConversion(target, op, arg_locals),
         }
     }
 
@@ -6161,7 +6163,7 @@ pub const MonoLlvmCodeGen = struct {
         try self.storeScalar(self.slot(target).ptr, target_layout, coerced);
     }
 
-    fn emitNumericConversionOrCrash(self: *MonoLlvmCodeGen, target: LocalId, op: lir.LowLevel, args: anytype) Error!void {
+    fn emitNumericConversion(self: *MonoLlvmCodeGen, target: LocalId, op: lir.LowLevel, args: anytype) Error!void {
         const name = @tagName(op);
         const SpecialConversion = enum {
             f32_to_i8_try_unsafe,
@@ -6284,7 +6286,7 @@ pub const MonoLlvmCodeGen = struct {
             try self.storeScalar(self.slot(target).ptr, self.localLayout(target), coerced);
             return;
         }
-        try self.emitCrashBytes(name);
+        return error.UnsupportedLowLevel;
     }
 
     fn emitDecToFloatConversion(self: *MonoLlvmCodeGen, target: LocalId, arg: LocalId, is_f32: bool) Error!void {

--- a/src/builtins/dev_wrappers.zig
+++ b/src/builtins/dev_wrappers.zig
@@ -1689,6 +1689,16 @@ fn u128InTargetRange(val: u128, target_bits: u32, target_signed: bool) bool {
     return numeric_conversions.u128FitsTarget(val, target_bits, target_signed);
 }
 
+// The conversion wrappers below move results between widths assuming a value's
+// low-order bytes come first in memory: narrowing copies the value's first
+// bytes, and widening writes it into the first bytes of a larger slot. That
+// assumption holds only on a little-endian target.
+comptime {
+    if (@import("builtin").cpu.arch.endian() == .big) {
+        @compileError("the conversion wrappers assume a value's low-order bytes come first, which is false on big-endian targets");
+    }
+}
+
 /// i128 try convert
 pub fn roc_builtins_i128_try_convert(out: [*]u8, val_low: u64, val_high: u64, target_bits: u32, target_is_signed: u32, payload_size: u32, disc_offset: u32) callconv(.c) void {
     const val: i128 = @bitCast(i128h.from_u64_pair(val_low, val_high));

--- a/src/eval/test/eval_low_level_tests.zig
+++ b/src/eval/test/eval_low_level_tests.zig
@@ -6973,4 +6973,175 @@ pub const tests = [_]TestCase{
         ,
         .expected = .{ .inspect_str = "True" },
     },
+    // Dec's wrapping integer conversions at widths up to 64 bits.
+    .{
+        .name = "low_level - Dec truncates to every integer width up to 64 bits",
+        .source =
+        \\{
+        \\Dec.to_i8_wrap(42.5) == 42
+        \\    and Dec.to_i16_wrap(42.5) == 42
+        \\    and Dec.to_i32_wrap(42.5) == 42
+        \\    and Dec.to_i64_wrap(42.5) == 42
+        \\    and Dec.to_u8_wrap(42.5) == 42
+        \\    and Dec.to_u16_wrap(42.5) == 42
+        \\    and Dec.to_u32_wrap(42.5) == 42
+        \\    and Dec.to_u64_wrap(42.5) == 42
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec truncation wraps at narrow widths",
+        .source =
+        \\{
+        \\Dec.to_i8_wrap(200.0) == -56
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec truncation keeps the sign",
+        .source =
+        \\{
+        \\Dec.to_i32_wrap(-42.5) == -42 and Dec.to_i64_wrap(-42.5) == -42
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    // Dec's wrapping conversions to the 128-bit widths, including an integer
+    // part past the I64 range.
+    .{
+        .name = "low_level - Dec truncates to an I128 past the I64 range",
+        .source =
+        \\{
+        \\big : Dec
+        \\big = 170141183460469231731.0
+        \\Dec.to_i128_wrap(big) == 170141183460469231731
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec truncates to the 128-bit widths",
+        .source =
+        \\{
+        \\Dec.to_i128_wrap(42.5) == 42
+        \\    and Dec.to_i128_wrap(-42.5) == -42
+        \\    and Dec.to_u128_wrap(42.5) == 42
+        \\    and Dec.to_u128_wrap(-42.5) == 340282366920938463463374607431768211414
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    // Every width wraps from the 128-bit quotient, so a Dec whose integer part
+    // is past the I64 range still converts.
+    .{
+        .name = "low_level - Dec wraps to a U64 from past the I64 range",
+        .source =
+        \\{
+        \\big : Dec
+        \\big = 12345678901234567890.0
+        \\Dec.to_u64_wrap(big) == 12345678901234567890
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec wraps to every width up to 64 bits from past the I64 range",
+        .source =
+        \\{
+        \\big : Dec
+        \\big = 12345678901234567890.0
+        \\Dec.to_i8_wrap(big) == -46
+        \\    and Dec.to_u8_wrap(big) == 210
+        \\    and Dec.to_i16_wrap(big) == 2770
+        \\    and Dec.to_u16_wrap(big) == 2770
+        \\    and Dec.to_i32_wrap(big) == -350287150
+        \\    and Dec.to_u32_wrap(big) == 3944680146
+        \\    and Dec.to_i64_wrap(big) == -6101065172474983726
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    // A negative Dec converted to an unsigned width, where the result's high bits
+    // come from the sign.
+    .{
+        .name = "low_level - Dec wraps a negative value to every unsigned width",
+        .source =
+        \\{
+        \\Dec.to_u8_wrap(-42.5) == 214
+        \\    and Dec.to_u16_wrap(-42.5) == 65494
+        \\    and Dec.to_u32_wrap(-42.5) == 4294967254
+        \\    and Dec.to_u64_wrap(-42.5) == 18446744073709551574
+        \\    and Dec.to_i8_wrap(-42.5) == -42
+        \\    and Dec.to_i16_wrap(-42.5) == -42
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec wraps to every width from past the I64 range, negative",
+        .source =
+        \\{
+        \\big : Dec
+        \\big = -12345678901234567890.0
+        \\Dec.to_i8_wrap(big) == 46
+        \\    and Dec.to_u8_wrap(big) == 46
+        \\    and Dec.to_i16_wrap(big) == -2770
+        \\    and Dec.to_u16_wrap(big) == 62766
+        \\    and Dec.to_i32_wrap(big) == 350287150
+        \\    and Dec.to_u32_wrap(big) == 350287150
+        \\    and Dec.to_i64_wrap(big) == 6101065172474983726
+        \\    and Dec.to_i128_wrap(big) == -12345678901234567890
+        \\    and Dec.to_u128_wrap(big) == 340282366920938463451028928530533643566
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - Dec wraps its lowest value to the widest widths",
+        .source =
+        \\{
+        \\Dec.to_i64_wrap(Dec.lowest) == -4120486797083267187
+        \\    and Dec.to_u64_wrap(Dec.lowest) == 14326257276626284429
+        \\    and Dec.to_i128_wrap(Dec.lowest) == -170141183460469231731
+        \\    and Dec.to_u128_wrap(Dec.lowest) == 340282366920938463293233423971298979725
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    // Conversions between the float widths, and from the integer widths into
+    // them. These share the coercion path with the integer-to-integer conversions.
+    .{
+        .name = "low_level - F32.to_f64 widens to the exact same value",
+        .source = "F64.to_bits(F32.to_f64(F32.from_bits(1036831949)))",
+        .expected = .{ .inspect_str = "4591870180174331904" },
+    },
+    .{
+        .name = "low_level - F64.to_f32_wrap narrows, and overflows to infinity",
+        .source =
+        \\{
+        \\F32.to_bits(F64.to_f32_wrap(F64.from_bits(4591870180066957722))) == 1036831949
+        \\    and F32.to_bits(F64.to_f32_wrap(F64.from_bits(9094988921128908188))) == 2139095040
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
+        .name = "low_level - U64.to_f64 reads the source as unsigned",
+        .source = "F64.to_bits(U64.to_f64(18446744073709551615))",
+        .expected = .{ .inspect_str = "4895412794951729152" },
+    },
+    .{
+        .name = "low_level - integers convert to floats at the 16- and 32-bit widths",
+        .source =
+        \\{
+        \\F64.to_bits(U32.to_f64(4294967295)) == 4751297606873776128
+        \\    and F64.to_bits(I32.to_f64(-2147483648)) == 13970166044103278592
+        \\    and F32.to_bits(U16.to_f32(65535)) == 1199570688
+        \\    and F64.to_bits(I16.to_f64(-32768)) == 13898108450065350656
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
 };


### PR DESCRIPTION
This PR was extracted from #10664, which fixed some Dec-to-int conversion bugs that ended up being fixed independently via #10681.

The actual fix from #10664 was superseded by #10681, but a few other pieces seemed worth preserving, so this PR:

1. adds tests for the numeric conversions, run across the interpreter, dev, wasm, and LLVM backends.
2. makes a missing lowering fail the build, rather than emitting code that crashes at runtime.
3. rejects big-endian targets in the conversion wrappers, which would otherwise return the wrong result.
