### PR TITLE
Add Dict.subscript, Dict.fold_until, Dict.iter, Dict.from_iter

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -5920,6 +5920,32 @@ Builtin :: [].{
 			}
 		}
 
+		## Iterate over the key-value pairs of a dictionary, in the same order
+		## as [Dict.to_list].
+		## ```roc
+		## expect List.from_iter(Dict.empty()
+		##            .insert("Apples", 12.U64)
+		##            .insert("Oranges", 24)
+		##            .iter()) == [("Apples", 12), ("Oranges", 24)]
+		## ```
+		iter : Dict(k, v) -> Iter((k, v))
+		iter = |dict| match dict {
+			HashMap(data) => {
+				entries_len = List.len(data.entries)
+
+				Iter.custom(
+					0,
+					Known(entries_len),
+					|index|
+						if index == entries_len {
+							Err(NoMore)
+						} else {
+							Ok((list_get_unsafe(data.entries, index), index + 1))
+						},
+				)
+			}
+		}
+
 		## Build a value by folding through each key-value pair in the
 		## dictionary. Starting with a given `state` value, this runs the
 		## given `step` function on each pair, using its return value as

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -5886,6 +5886,37 @@ Builtin :: [].{
 		from_list = |list|
 			List.fold(list, Dict.with_capacity(List.len(list)), |dict, (k, v)| Dict.insert(dict, k, v))
 
+		## Create a `Dict` from an [Iter] of key-value pairs. If the iterator
+		## yields duplicate keys, later values overwrite earlier ones.
+		## ```roc
+		## expect Dict.from_iter([(1, "One"), (2, "Two")].iter()) ==
+		## 	Dict.single(1, "One").insert(2, "Two")
+		## ```
+		from_iter : Iter((k, v)) -> Dict(k, v)
+			where [k.is_eq : k, k -> Bool, k.to_hash : k, Hasher -> Hasher]
+		from_iter = |iterator| {
+			var $dict = match iterator.len_if_known {
+				Known(n) => Dict.with_capacity(n)
+				Unknown => Dict.empty()
+			}
+			var $rest = iterator
+			while Bool.True {
+				match Iter.next($rest) {
+					Done => {
+						break
+					}
+					Skip({ rest }) => {
+						$rest = rest
+					}
+					One({ item: (key, value), rest }) => {
+						$dict = Dict.insert($dict, key, value)
+						$rest = rest
+					}
+				}
+			}
+			$dict
+		}
+
 		## Returns the keys of a dictionary as a `List`.
 		## ```roc
 		## expect Dict.single(1, "One")

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -5941,6 +5941,36 @@ Builtin :: [].{
 			}
 		}
 
+		## Same as [Dict.fold], except you can stop folding early.
+		## ```roc
+		## expect Dict.empty()
+		##            .insert("Apples", 12.U64)
+		##            .insert("Oranges", 24)
+		##            .fold_until(0, |count, _key, qty| if count + qty >= 30 {
+		##                Break(count + qty)
+		##            } else {
+		##                Continue(count + qty)
+		##            }) == 36
+		## ```
+		fold_until : Dict(k, v), state, (state, k, v -> [Continue(state), Break(state)]) -> state
+		fold_until = |dict, init, step| match dict {
+			HashMap(data) => {
+				var $state = init
+				for (key, value) in data.entries {
+					match step($state, key, value) {
+						Continue(new_state) => {
+							$state = new_state
+						}
+						Break(final_state) => {
+							$state = final_state
+							break
+						}
+					}
+				}
+				$state
+			}
+		}
+
 		## Run the given function on each key-value pair of a dictionary, and
 		## return a dictionary with just the pairs for which the function
 		## returned `Bool.True`.

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -5795,6 +5795,23 @@ Builtin :: [].{
 			}
 		}
 
+		## Alias for [Dict.get], enabling the future `dict[key]` subscript operator.
+		## Returns the value for a given key.
+		##
+		## Returns `Err KeyNotFound` if the dictionary has no value for the key.
+		## ```roc
+		## expect Dict.empty()
+		##            .insert("Apples", 12.U64)
+		##            .subscript("Apples") == Ok(12)
+		##
+		## expect Dict.empty()
+		##            .insert("Apples", 12.U64)
+		##            .subscript("Oranges") == Err(KeyNotFound)
+		## ```
+		subscript : Dict(k, v), k -> Try(v, [KeyNotFound, ..])
+			where [k.is_eq : k, k -> Bool, k.to_hash : k, Hasher -> Hasher]
+		subscript = |dict, key| Dict.get(dict, key)
+
 		## Check if the dictionary has a value for a specified key.
 		## ```roc
 		## expect Dict.empty().insert(1234, "5678").contains(1234)

--- a/test/snapshots/repl/dict_fold_until.md
+++ b/test/snapshots/repl/dict_fold_until.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=Dict.fold_until folds until the step returns Break, and full folds otherwise
+type=repl
+~~~
+# SOURCE
+~~~roc
+» d = Dict.empty().insert("alice", 10.I64).insert("bob", 20).insert("charlie", 30)
+» d.fold_until(0, |acc, _k, v| if acc + v >= 20 { Break(acc + v) } else { Continue(acc + v) })
+» d.fold_until(0, |acc, _k, v| Continue(acc + v))
+» d.len()
+~~~
+# OUTPUT
+assigned `d`
+---
+30
+---
+60
+---
+3
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/dict_from_iter.md
+++ b/test/snapshots/repl/dict_from_iter.md
@@ -1,0 +1,37 @@
+# META
+~~~ini
+description=Dict.from_iter builds a dictionary from an iterator of key-value pairs
+type=repl
+~~~
+# SOURCE
+~~~roc
+» l = [("alice", "a heap allocated value"), ("bob", "another heap value")]
+» d = Dict.from_iter(l.iter())
+» d.get("alice")
+» d.get("missing")
+» l
+» d.len()
+» Dict.from_iter([("alice", "first"), ("alice", "second")].iter()).get("alice")
+» Dict.from_iter([("alice", 1.I64), ("bob", 2)].iter()).to_list()
+» Dict.from_iter([("alice", 1.I64), ("bob", 2)].iter().keep_if(|(_k, v)| v == 2)).to_list()
+~~~
+# OUTPUT
+assigned `l`
+---
+assigned `d`
+---
+Ok("a heap allocated value")
+---
+Err(KeyNotFound)
+---
+[("alice", "a heap allocated value"), ("bob", "another heap value")]
+---
+2
+---
+Ok("second")
+---
+[("alice", 1), ("bob", 2)]
+---
+[("bob", 2)]
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/dict_iter.md
+++ b/test/snapshots/repl/dict_iter.md
@@ -1,0 +1,22 @@
+# META
+~~~ini
+description=Dict.iter yields the key-value pairs in the same order as Dict.to_list
+type=repl
+~~~
+# SOURCE
+~~~roc
+» d = Dict.empty().insert("alice", "a heap allocated value").insert("bob", "another heap value")
+» List.from_iter(d.iter())
+» List.from_iter(Dict.empty().iter())
+» d.len()
+~~~
+# OUTPUT
+assigned `d`
+---
+[("alice", "a heap allocated value"), ("bob", "another heap value")]
+---
+[]
+---
+2
+# PROBLEMS
+NIL

--- a/test/snapshots/repl/dict_subscript.md
+++ b/test/snapshots/repl/dict_subscript.md
@@ -1,0 +1,25 @@
+# META
+~~~ini
+description=Dict.subscript returns the value for a key, or Err(KeyNotFound) for absent keys
+type=repl
+~~~
+# SOURCE
+~~~roc
+» d = Dict.empty().insert("alice", "a heap allocated value").insert("bob", "another heap value")
+» d.subscript("alice")
+» d.subscript("missing")
+» d.subscript("bob")
+» d.len()
+~~~
+# OUTPUT
+assigned `d`
+---
+Ok("a heap allocated value")
+---
+Err(KeyNotFound)
+---
+Ok("another heap value")
+---
+2
+# PROBLEMS
+NIL


### PR DESCRIPTION
Part of #9596: the four remaining Dict builtins, mirroring their existing List counterparts.

- `Dict.subscript` — alias for `Dict.get`
- `Dict.fold_until` — stops folding early, mirroring `List.fold_until`
- `Dict.iter` — lazy iteration via `Iter.custom` with an exact `Known` length
- `Dict.from_iter` — builds from an iterator, pre-sizing when the length is known

One commit per method, each with a doc-test and a repl snapshot (refcounting, order, and duplicate keys are covered behaviorally).

Note: `Dict.from_iter` carries `where [k.is_eq, k.to_hash]` since it builds via `Dict.insert`; the checklist signature in #9596 omits the clause.