### PR TITLE
Keep tracy out of the boxy runtime object

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7235,7 +7235,6 @@ fn addMainExe(
                 b.fmt("roc_boxy_runtime_{s}", .{cross_target.name}),
                 b.path("src/boxy_runtime/main.zig"),
             );
-            add_tracy(b, roc_modules.build_options, cross_boxy_runtime_obj, b.graph.host, false, flag_enable_tracy);
             const boxy_runtime_artifact = if (cross_is_wasm)
                 wasmObjectArtifact(b, cross_boxy_runtime_obj)
             else

--- a/src/boxy_runtime/eval_main.zig
+++ b/src/boxy_runtime/eval_main.zig
@@ -9,6 +9,7 @@ const runtime = @import("main.zig");
 /// Configure the shared runtime root for evaluator-vtable host calls.
 pub const roc_host_call_mode: builtins.host_abi.HostCallMode = .vtable;
 pub const roc_omit_wasm_compiler_rt_exports = runtime.roc_omit_wasm_compiler_rt_exports;
+pub const roc_disable_tracy = runtime.roc_disable_tracy;
 pub const panic = runtime.panic;
 pub const std_options_elf_debug_info_search_paths = runtime.std_options_elf_debug_info_search_paths;
 pub const std_options_debug_io = runtime.std_options_debug_io;

--- a/src/boxy_runtime/main.zig
+++ b/src/boxy_runtime/main.zig
@@ -28,6 +28,9 @@ pub const roc_host_call_mode: builtins.host_abi.HostCallMode = .extern_symbols;
 /// The wasm builtins object owns compiler-rt symbols in standalone programs.
 /// Suppress the duplicate exports pulled in through `compiler_rt_128` here.
 pub const roc_omit_wasm_compiler_rt_exports = true;
+/// This object is linked into the programs roc produces, not into the compiler,
+/// so it carries no tracy instrumentation.
+pub const roc_disable_tracy = true;
 
 /// Route runtime panics through the Roc host crash callback.
 pub const panic = std.debug.FullPanic(panicImpl);

--- a/src/build/tracy.zig
+++ b/src/build/tracy.zig
@@ -10,8 +10,17 @@ const std = @import("std");
 const builtin = @import("builtin");
 const build_options = @import("build_options");
 
+/// Selected by the root module (like `std_options`): declaring
+/// `pub const roc_disable_tracy = true;` at the root keeps the tracy client out
+/// of that compilation. Objects that are linked into compiled Roc programs
+/// rather than into the compiler declare it: the profiler client is a
+/// compiler-side dependency, so instrumenting them would both bundle it into
+/// every Roc program and require it to build for every target roc ships to.
+const disabled_by_root = @hasDecl(@import("root"), "roc_disable_tracy") and
+    @import("root").roc_disable_tracy;
+
 /// Whether or not tracy profiling is enabled.
-pub const enable = if (builtin.is_test) false else build_options.enable_tracy;
+pub const enable = if (builtin.is_test or disabled_by_root) false else build_options.enable_tracy;
 /// Whether recording allocations and frees with tracy is enabled.
 pub const enable_allocation = enable and build_options.enable_tracy_allocation;
 /// Whether sampling callstacks at each zone and allocatino is enabled (expensive).


### PR DESCRIPTION
The nightly gate's `zig check` step (`zig build -Dno-bin -Dfuzz -Dtracy=./tracy`) has been failing because the per-target `roc_boxy_runtime_*` objects get the tracy client compiled into them. That was survivable while the boxy runtime was built only for x64musl, x64glibc, and wasm32, but now that it ships for every target that carries builtins, tracy has to build for all of them too — and it can't. Its client uses `sysctlbyname`, `KERN_PROC_PATHNAME`, and `_lwp_self` on the BSDs, and merging its C++ objects into a single relocatable object is rejected outright for COFF ("coff does not support linking multiple objects into one").

Tracy does not belong in that object in the first place: it is linked into the programs roc produces, not into the compiler, so instrumenting it both bundles the profiler client into every Roc program and forces tracy to build for every target roc ships to. `src/build/tracy.zig` now honors a `roc_disable_tracy` root declaration, in the same style as `roc_host_call_mode` and `roc_omit_wasm_compiler_rt_exports`, and both boxy runtime roots declare it. With tracy compiled out of that object at comptime, the `add_tracy` call on the cross-compiled object is gone.