### PR TITLE
Keep open dispatch results graph-backed

### DIFF
--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -132,6 +132,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10561_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10571_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10617_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10694_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));
     std.testing.refAllDecls(@import("test/platform_box_update_lir_test.zig"));

--- a/src/compile/test/issue_10694_test.zig
+++ b/src/compile/test/issue_10694_test.zig
@@ -1,0 +1,32 @@
+//! Regression test for issue #10694.
+
+const expectLowersToLir = @import("lower_to_lir_harness.zig").expectLowersToLir;
+
+test "issue 10694: open dispatch result stays graph-backed until final sealing" {
+    try expectLowersToLir(
+        \\limit : U64
+        \\limit = 16
+        \\
+        \\read : Str -> Try(I64, [BadInput])
+        \\read = |s| if Str.is_empty(s) { Err(BadInput) } else { Ok(16) }
+        \\
+        \\decode : Str -> Try(I64, _)
+        \\decode = |body| {
+        \\    n = read(body) ? |_e| BadRead
+        \\    limit_i64 = limit.to_i64_try() ?? 0
+        \\    if n != limit_i64 { Err(Mismatch) } else { Ok(n) }
+        \\}
+        \\
+        \\main! = |args| {
+        \\    body = match args {
+        \\        [first, ..] => first
+        \\        [] => "x"
+        \\    }
+        \\    match decode(body) {
+        \\        Ok(n) => echo!(n.to_str())
+        \\        Err(_) => echo!("err")
+        \\    }
+        \\    Ok({})
+        \\}
+    );
+}

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -16018,10 +16018,6 @@ const BodyContext = struct {
         return try self.graph.importMono(ty);
     }
 
-    fn activeTypeFromType(self: *BodyContext, ty: Type.TypeId) Allocator.Error!Type.TypeId {
-        return try self.activeTypeFromNode(try self.activeNodeFromType(ty));
-    }
-
     fn lowerTypeCell(self: *BodyContext, checked_ty: checked.CheckedTypeId) Allocator.Error!DraftTypeCell {
         return DraftTypeCell.fromGraphNode(try self.lowerTypeNode(checked_ty));
     }
@@ -34026,17 +34022,9 @@ const BodyContext = struct {
                 .op = op,
                 .args = args,
             } });
-            // Only equality/hash result modes inspect the result type; a
-            // `.value` low-level result may still be an unresolved open row
-            // (e.g. an open error union) with no Monotype view yet.
-            return switch (plan.result_mode) {
-                .value, .parser_for, .encoder_for, .map, .map_effectful => call_expr,
-                .equality, .hash => try self.applyDispatchResultMode(
-                    plan.result_mode,
-                    call_expr,
-                    try self.activeTypeFromNode(plan_ret_node),
-                ),
-            };
+            // Result modes consume the graph-backed call type directly because
+            // the return node may still be an unresolved open row here.
+            return try self.applyDispatchResultMode(plan.result_mode, call_expr);
         }
         const call_data = if (direct_graph_call)
             try self.lowerResolvedDirectDispatchAtNode(plan, resolved, callable_node, self, pre_lowered.items)
@@ -34050,17 +34038,7 @@ const BodyContext = struct {
             call_ret_cell,
             call_data,
         );
-        return switch (plan.result_mode) {
-            .value, .parser_for, .encoder_for, .map, .map_effectful => call_expr,
-            .equality, .hash => blk: {
-                const ret_ty = try self.activeTypeFromNode(plan_ret_node);
-                if (expected_ret_ty) |expected| {
-                    const expected_ty = try self.activeTypeFromType(expected);
-                    if (!self.sameType(expected_ty, ret_ty)) Common.invariant("checked dispatch expression lowered at a type different from its call operand type");
-                }
-                break :blk try self.applyDispatchResultMode(plan.result_mode, call_expr, ret_ty);
-            },
-        };
+        return try self.applyDispatchResultMode(plan.result_mode, call_expr);
     }
 
     fn lowerClosedDirectLowLevelDispatch(
@@ -34104,7 +34082,7 @@ const BodyContext = struct {
             .op = op,
             .args = lowered,
         } });
-        return try self.applyDispatchResultMode(plan.result_mode, call, function.ret);
+        return try self.applyDispatchResultMode(plan.result_mode, call);
     }
 
     fn lowerClosedDispatchOperandsAtTypes(
@@ -34274,11 +34252,7 @@ const BodyContext = struct {
             .args = lowered,
             .captures = try self.methodTargetCaptureSpan(lookup),
         } });
-        const result_ty = if (completed_ret_is_private)
-            try self.activeTypeFromNode(completed_function.ret)
-        else
-            function.ret;
-        return try self.applyDispatchResultMode(plan.result_mode, call, result_ty);
+        return try self.applyDispatchResultMode(plan.result_mode, call);
     }
 
     const ClosedDispatchOperands = union(enum) {
@@ -34368,7 +34342,6 @@ const BodyContext = struct {
         self: *BodyContext,
         mode: static_dispatch.StaticDispatchResultMode,
         expr: DraftExprId,
-        expr_ty: Type.TypeId,
     ) Allocator.Error!DraftExprId {
         return switch (mode) {
             .value => expr,
@@ -34377,11 +34350,32 @@ const BodyContext = struct {
             .map => expr,
             .map_effectful => expr,
             .equality => |eq| if (eq.negated) blk: {
-                if (!self.typeHasBuiltinOwner(expr_ty, .bool)) Common.invariant("checked equality dispatch returned a non-Bool value");
-                break :blk try self.lowLevelExpr(.bool_not, &.{expr}, expr_ty);
+                if (!self.typeCellHasBuiltinOwner(self.exprTypeCell(expr), .bool)) {
+                    Common.invariant("checked equality dispatch returned a non-Bool value");
+                }
+                break :blk try self.lowLevelExpr(
+                    .bool_not,
+                    &.{expr},
+                    try self.builder.primitiveType(.bool),
+                );
             } else expr,
             // A resolved `to_hash` dispatch returns its Hasher result directly.
             .hash => expr,
+        };
+    }
+
+    fn typeCellHasBuiltinOwner(
+        self: *BodyContext,
+        cell: DraftTypeCell,
+        expected: static_dispatch.BuiltinOwner,
+    ) bool {
+        const owner = switch (cell) {
+            .graph_node => |node| self.methodOwnerFromNode(node),
+            .sealed => |ty| methodOwnerFromType(&self.builder.program.types, ty),
+        } orelse return false;
+        return switch (owner) {
+            .builtin => |actual| actual == expected,
+            .nominal => false,
         };
     }
 

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -34350,14 +34350,14 @@ const BodyContext = struct {
             .map => expr,
             .map_effectful => expr,
             .equality => |eq| if (eq.negated) blk: {
-                if (!self.typeCellHasBuiltinOwner(self.exprTypeCell(expr), .bool)) {
+                const result_cell = self.exprTypeCell(expr);
+                if (!self.typeCellHasBuiltinOwner(result_cell, .bool)) {
                     Common.invariant("checked equality dispatch returned a non-Bool value");
                 }
-                break :blk try self.lowLevelExpr(
-                    .bool_not,
-                    &.{expr},
-                    try self.builder.primitiveType(.bool),
-                );
+                break :blk try self.addExprWithTypeCell(result_cell, .{ .low_level = .{
+                    .op = .bool_not,
+                    .args = try self.addExprSpan(&.{expr}),
+                } });
             } else expr,
             // A resolved `to_hash` dispatch returns its Hasher result directly.
             .hash => expr,

--- a/src/postcheck/structural_test.zig
+++ b/src/postcheck/structural_test.zig
@@ -593,8 +593,10 @@ test "Monotype dispatch result modes retain graph-backed result types" {
         "fn typeCellHasBuiltinOwner(",
     );
     try expectContains(result_mode, "self.exprTypeCell(expr)");
+    try expectContains(result_mode, "self.addExprWithTypeCell(result_cell");
     try expectNotContains(result_mode, "Type.TypeId");
     try expectNotContains(result_mode, "activeTypeFrom");
+    try expectNotContains(result_mode, "primitiveType(.bool)");
 }
 
 test "Monotype const type lookup remains graph-native" {

--- a/src/postcheck/structural_test.zig
+++ b/src/postcheck/structural_test.zig
@@ -577,6 +577,26 @@ test "Monotype gates divergent relations and crash dispatches before type instan
     try expectNotContains(relation_gate, "checkedTypeContainsError");
 }
 
+test "Monotype dispatch result modes retain graph-backed result types" {
+    const lower_source = @embedFile("monotype/lower.zig");
+    const parametric_low_level = sourceSliceBetween(
+        lower_source,
+        "if (direct_parametric_low_level) |op| {",
+        "const call_data = if (direct_graph_call)",
+    );
+    try expectContains(parametric_low_level, "applyDispatchResultMode(plan.result_mode, call_expr)");
+    try expectNotContains(parametric_low_level, "activeTypeFromNode(plan_ret_node)");
+
+    const result_mode = sourceSliceBetween(
+        lower_source,
+        "fn applyDispatchResultMode(",
+        "fn typeCellHasBuiltinOwner(",
+    );
+    try expectContains(result_mode, "self.exprTypeCell(expr)");
+    try expectNotContains(result_mode, "Type.TypeId");
+    try expectNotContains(result_mode, "activeTypeFrom");
+}
+
 test "Monotype const type lookup remains graph-native" {
     const lower_source = @embedFile("monotype/lower.zig");
     try expectContains(lower_source, "fn constUseTypeNode");


### PR DESCRIPTION
Monotype dispatch lowering eagerly materialized every direct parametric low-level result as a TypeId, even for ordinary value mode where the type was unused. This panicked for U64.to_i64_try because its open error-row default must remain in the instantiation graph until final sealing. Keep dispatch result-mode handling graph-native, preserve the Bool check for negated equality using explicit graph owner data, and add regression coverage. Fixes #10694.