### PR TITLE
Avoid invalidated tag slices in codec validation

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -30948,11 +30948,10 @@ fn validateDerivedParseTagUnion(
         .unsupported, .reported_error => |result| return result,
     }
 
-    const tags = self.types.getTagsSlice(tag_union.tags);
-    for (tags.items(.args)) |tag_args_range| {
-        const tag_args = try self.gpa.dupe(Var, self.types.sliceVars(tag_args_range));
-        defer self.gpa.free(tag_args);
-        for (tag_args) |tag_arg| {
+    for (0..tag_union.tags.count) |tag_offset| {
+        const tag_args_range = self.types.getTagAt(tag_union.tags, @intCast(tag_offset)).args;
+        for (0..tag_args_range.count) |tag_arg_offset| {
+            const tag_arg = self.types.getVarAt(tag_args_range, @intCast(tag_arg_offset));
             switch (try self.validateDerivedParseVar(tag_arg, encoding_var, state_var, err_var, constraint, env, region, visited, .shape, failure_expr)) {
                 .ok => {},
                 .unsupported, .reported_error => |result| return result,
@@ -31469,11 +31468,10 @@ fn validateDerivedEncodeTagUnion(
         .unsupported, .unresolved => return .unsupported,
     }
 
-    const tags = self.types.getTagsSlice(tag_union.tags);
-    for (tags.items(.args)) |tag_args_range| {
-        const tag_args = try self.gpa.dupe(Var, self.types.sliceVars(tag_args_range));
-        defer self.gpa.free(tag_args);
-        for (tag_args) |tag_arg| {
+    for (0..tag_union.tags.count) |tag_offset| {
+        const tag_args_range = self.types.getTagAt(tag_union.tags, @intCast(tag_offset)).args;
+        for (0..tag_args_range.count) |tag_arg_offset| {
+            const tag_arg = self.types.getVarAt(tag_args_range, @intCast(tag_arg_offset));
             switch (try self.validateDerivedEncodeVar(tag_arg, encoding_var, state_var, err_var, constraint, env, region, visited)) {
                 .ok => {},
                 .unsupported, .reported_error => |result| return result,

--- a/src/check/mod.zig
+++ b/src/check/mod.zig
@@ -92,6 +92,7 @@ test "check tests" {
     std.testing.refAllDecls(@import("test/repros_test.zig"));
     std.testing.refAllDecls(@import("test/typed_cir_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10338_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10695_test.zig"));
 
     // Cross-module monomorphization tests
     std.testing.refAllDecls(@import("test/cross_module_mono_test.zig"));

--- a/src/check/test/issue_10695_test.zig
+++ b/src/check/test/issue_10695_test.zig
@@ -1,0 +1,26 @@
+//! Regression test for issue 10695.
+
+const TestEnv = @import("./TestEnv.zig");
+
+test "issue 10695: derived parse of repeated aliased tag union fields checks cleanly" {
+    const source =
+        \\Profile : { a : Str, b : Str, c : Str, d : Str, images : [Bar({ source : Str, small : Str }), Foo] }
+        \\
+        \\Model : { group : { primary : [Bar(Profile), Foo], secondary : [Bar(Profile), Foo] } }
+        \\
+        \\main = |json| {
+        \\    parsed : Try({ payload : Model }, _)
+        \\    parsed = Json.parse(json)
+        \\
+        \\    match parsed {
+        \\        Ok(_) => {}
+        \\        Err(_) => {}
+        \\    }
+        \\}
+    ;
+
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertNoErrors();
+}


### PR DESCRIPTION
Derived parser validation held a borrowed tag-range slice across recursive type-store growth, so reallocation could corrupt the next tag's argument range and crash. Traverse tag and argument spans through stable indexed store access in both derived parse and encode validation, which also removes temporary per-tag allocations. Fixes #10695.