### PR TITLE
fixes #10660; treat digit separators consistently when parsing floats

### DIFF
--- a/src/builtins/num.zig
+++ b/src/builtins/num.zig
@@ -1426,6 +1426,31 @@ test "powi128 handles signed magnitude and overflow boundaries" {
     try std.testing.expectError(error.Overflow, powi128(u128, std.math.maxInt(u128), 2));
 }
 
+fn expectSeparatorsIgnored(comptime T: type, with_separators: []const u8, roc_ops: *RocOps) NumTestHelperError!void {
+    var buf: [512]u8 = undefined;
+    var n: usize = 0;
+    for (with_separators) |c| {
+        if (c != '_') {
+            buf[n] = c;
+            n += 1;
+        }
+    }
+
+    const RocStrT = @import("str.zig").RocStr;
+    const with_str = RocStrT.fromSlice(with_separators, roc_ops);
+    defer with_str.decref(roc_ops);
+    const without_str = RocStrT.fromSlice(buf[0..n], roc_ops);
+    defer without_str.decref(roc_ops);
+
+    const with = parseFloatFromStr(T, with_str);
+    const without = parseFloatFromStr(T, without_str);
+    try std.testing.expectEqual(@as(u8, 0), with.errorcode);
+    try std.testing.expectEqual(@as(u8, 0), without.errorcode);
+
+    const Bits = std.meta.Int(.unsigned, @bitSizeOf(T));
+    try std.testing.expectEqual(@as(Bits, @bitCast(without.value)), @as(Bits, @bitCast(with.value)));
+}
+
 test "parseFloatFromStr matches IEEE bit fixtures for finite edge cases" {
     var test_env = TestEnv.init(std.testing.allocator);
     defer test_env.deinit();
@@ -1452,6 +1477,32 @@ test "parseFloatFromStr matches IEEE bit fixtures for finite edge cases" {
         .{ .text = "0x1.921fb54442d18p+1", .bits = 0x400921fb54442d18 },
     }) |text| {
         try expectParseFloatBits(f64, text.text, text.bits, test_env.getOps());
+    }
+}
+
+test "parseFloatFromStr ignores digit separators wherever they appear issue 10660" {
+    var test_env = TestEnv.init(std.testing.allocator);
+    defer test_env.deinit();
+
+    // `_` is a separator, so a literal must parse identically with and without it.
+    // The last case is the fuzzer-found input from the issue: leading zero groups mixed
+    // with separators moved the decimal point by 163 orders of magnitude, which sent the
+    // slow path into minutes of shifting before returning a wrong value.
+    inline for (&[_][]const u8{
+        "1_000",
+        "1_000.5",
+        "0.5_5",
+        "0_0.1",
+        "1_0e1_0",
+        "-1_2.3_4",
+        "0_0000_0000.0000_1",
+        "1_2_3_4_5.6_7_8_9",
+        "0.000_000_000_000_000_1",
+        "1_000e-1_0",
+        "123_456.789_012e1_2",
+        "0_0000_0000.00_000_0_000000_00000_00_00_00_0_000000_0000_0_00000_00000_00_00_00_000_0_0_000000_00000_0_000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000013478162400000000000",
+    }) |text| {
+        try expectSeparatorsIgnored(f64, text, test_env.getOps());
     }
 }
 

--- a/vendor/parse_float/FloatStream.zig
+++ b/vendor/parse_float/FloatStream.zig
@@ -90,7 +90,10 @@ pub fn advance(self: *FloatStream, n: usize) void {
 
 /// Skip all leading bytes that match one of `cs`.
 pub fn skipChars(self: *FloatStream, comptime cs: []const u8) void {
-    while (self.firstIs(cs)) : (self.advance(1)) {}
+    while (self.firstIs(cs)) {
+        if (self.slice[self.offset] == '_') self.underscore_count += 1;
+        self.advance(1);
+    }
 }
 
 /// Read the next 8 bytes as little-endian u64 without checking bounds.

--- a/vendor/parse_float/decimal.zig
+++ b/vendor/parse_float/decimal.zig
@@ -254,7 +254,9 @@ pub fn Decimal(comptime T: type) type {
 
                 // Skip leading zeroes
                 if (d.num_digits == 0) {
-                    stream.skipChars("0");
+                    // Underscores are separators, not digits: skipping only "0" stops at the
+                    // first one, so the remaining leading zeros are counted as significant.
+                    stream.skipChars("0_");
                 }
 
                 while (stream.hasLen(8) and d.num_digits + 8 < max_digits) {
@@ -275,11 +277,13 @@ pub fn Decimal(comptime T: type) type {
             if (d.num_digits != 0) {
                 // Ignore trailing zeros if any
                 var n_trailing_zeros: usize = 0;
-                var i = stream.offsetTrue() - 1;
+                // `offsetTrue` excludes consumed underscores, but `s` still contains them,
+                // so indexing `s` with it walks back into the middle of the literal.
+                var i = stream.offset - 1;
                 while (true) {
                     if (s[i] == '0') {
                         n_trailing_zeros += 1;
-                    } else if (s[i] != '.') {
+                    } else if (s[i] != '.' and s[i] != '_') {
                         break;
                     }
 


### PR DESCRIPTION
Reproduced the hang from the issue and found it comes from an inconsistency rather than from the slow path being slow: `_` is a separator everywhere in a float literal, but three places in the parser disagreed about that, so the same digits parse as a different number depending on whether separators are present.

- `FloatStream.skipChars` advanced the offset without counting the underscores it skipped. `offsetTrue` is defined as offset minus consumed underscores, and callers use it to measure digit positions, so every later position shifted and the decimal point moved with them.
- The leading-zero skip in the fractional part used `skipChars("0")`, which stops at the first separator, so the remaining leading zeros were counted as significant digits.
- The trailing-zero scan indexed the original string with `offsetTrue`. Since the string still contains the underscores, that walks back into the middle of the literal, and the scan also stopped at the first separator it met.

On the input from the issue the combination put the decimal point at -2 instead of -165 and reported 89 significant digits instead of 9. `convertSlow` then had to reconcile a 163-order-of-magnitude difference by shifting, which is where the minutes went. With the fix that input parses as fast as its separator-free spelling and returns the same value, `1.34781624e-166`.

The test asserts the invariant rather than the symptom: a literal must parse to the same bits with and without separators. It covers separators in the integer part, the fraction, the exponent, negatives, and the fuzzer-found input itself. I checked it fails without the fix — it aborts on that last case — and passes with it.

`zig build run-test-zig`: 4410/4410 pass with the fix (4409 before, plus the new one). Reverting only the parser change and keeping the test gives 4409/4411 with 1 crashed, which is the new test.

fixes #10660

Disclosure: I work with an AI assistant (Claude Code, Anthropic). It did the bisection, wrote the patch and the test, and ran the builds; I checked the reasoning against `decimal.zig` and `FloatStream.zig` and verified the before/after runs myself.
