### PR TITLE
Fix Boxy runtime linking for Wasm builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2334,6 +2334,9 @@ fn buildAndCopyWasmHostObject(
     // Per-function/data sections so wasm final-link DCE can strip unused host code.
     obj.link_function_sections = true;
     obj.link_data_sections = true;
+    // Match production Rust hosts, which contribute weak compiler-rt symbols.
+    // Wasm LLD must resolve these against Roc's strong builtins definitions.
+    obj.bundle_compiler_rt = true;
 
     const dest_path = "test/wasm/platform/targets/wasm32/host.wasm";
     const copy_step = b.addUpdateSourceFiles();
@@ -6753,7 +6756,10 @@ fn buildBoxyRuntimeObject(
             .optimize = optimize,
             .strip = strip,
             .omit_frame_pointer = omit_frame_pointer,
-            .pic = true,
+            // Native runtime objects can participate in shared-library links.
+            // Wasm uses direct data-symbol relocations so a prepared host can
+            // retain its app-specific Boxy sidecar references across `-r`.
+            .pic = target.result.cpu.arch != .wasm32,
         }),
     });
     const boxy_eval_module = b.createModule(.{

--- a/design.md
+++ b/design.md
@@ -7883,7 +7883,10 @@ ordered input's bytes and the selected runtime variant; changing any input or
 the explicit LIR requirement produces a different prepared host. The cached
 object preserves only the platform's original function exports, leaving
 builtins and Boxy runtime functions internal and eligible for dead-code
-elimination during the surgical link. The standalone Wasm runtime uses direct
+elimination during the surgical link. Preparation is serialized per content
+identity across compiler processes and remains available when application
+compilation caching is disabled: it is an exact platform artifact, not a
+cached application result. The standalone Wasm runtime uses direct
 data-symbol relocations rather than PIC GOT
 globals, so the partial link preserves its unresolved sidecar references for
 the later surgical merge. Entrypoint wrappers initialize the embedded runtime

--- a/design.md
+++ b/design.md
@@ -7880,8 +7880,11 @@ when LIR explicitly requires Boxy, the relocatable Boxy runtime object. Later
 builds load that cached prepared-host variant and surgically merge only the
 generated app code and its exact sidecar. The cache identity includes every
 ordered input's bytes and the selected runtime variant; changing any input or
-the explicit LIR requirement produces a different prepared host. The
-standalone Wasm runtime uses direct data-symbol relocations rather than PIC GOT
+the explicit LIR requirement produces a different prepared host. The cached
+object preserves only the platform's original function exports, leaving
+builtins and Boxy runtime functions internal and eligible for dead-code
+elimination during the surgical link. The standalone Wasm runtime uses direct
+data-symbol relocations rather than PIC GOT
 globals, so the partial link preserves its unresolved sidecar references for
 the later surgical merge. Entrypoint wrappers initialize the embedded runtime
 before calling Roc code. Dictionary worker thunks and erased-callable

--- a/design.md
+++ b/design.md
@@ -7871,13 +7871,23 @@ reaching `assign_boxy_adapt` is never treated as unsupported.
 
 Machine-code backends lower the complete Boxy statement surface to the shared
 `roc_boxy_*` C ABI. Native LLVM links the target's standalone Boxy runtime
-object and an object containing the serialized sidecar. Wasm merges the
-relocatable Boxy runtime object and a static-data module containing that same
-sidecar into either the final surgical-link module or the emitted relocatable
-object. Entrypoint wrappers initialize the embedded runtime before calling Roc
-code. Dictionary worker thunks and erased-callable registrations expose only
-the proc ids, layouts, descriptor sources, and ownership metadata already
-present in LIR; backend code does not derive any of them from procedure bodies.
+object and an object containing the serialized sidecar. Optimized Wasm links
+the relocatable Boxy runtime object and a static-data module containing that
+same sidecar into the emitted app object, then resolves the complete app and
+host link with Wasm LLD. Standalone Wasm dev builds prepare each distinct host
+through a content-addressed relocatable LLD link with the builtins object and,
+when LIR explicitly requires Boxy, the relocatable Boxy runtime object. Later
+builds load that cached prepared-host variant and surgically merge only the
+generated app code and its exact sidecar. The cache identity includes every
+ordered input's bytes and the selected runtime variant; changing any input or
+the explicit LIR requirement produces a different prepared host. The
+standalone Wasm runtime uses direct data-symbol relocations rather than PIC GOT
+globals, so the partial link preserves its unresolved sidecar references for
+the later surgical merge. Entrypoint wrappers initialize the embedded runtime
+before calling Roc code. Dictionary worker thunks and erased-callable
+registrations expose only the proc ids, layouts, descriptor sources, and
+ownership metadata already present in LIR; backend code does not derive any of
+them from procedure bodies.
 
 In-process test invocation context is also an explicit execution ABI input. It
 is threaded through ordinary procedures, Boxy dictionary calls and their
@@ -7904,8 +7914,10 @@ Every linked Wasm image has exactly one provider for compiler runtime libcalls.
 Standalone Wasm obtains them from the builtins object and the standalone Boxy
 runtime suppresses its copies. Evaluator Wasm has no companion builtins object,
 so its vtable-mode Boxy runtime exports the small required libcall set itself.
-Runtime-object construction must preserve this ownership split; duplicate weak
-or strong exports are not resolved by link order.
+Runtime-object construction must preserve this ownership split. LLD resolves
+the strong/weak and COMDAT rules while preparing a surgical-link host or
+producing an optimized final image; the surgical linker never guesses among
+duplicate weak or strong definitions and link order never chooses the owner.
 
 Dynamic RC in boxy LIR is explicit. A local whose boxy runtime layout is a
 dynamic value has a pointer-sized committed storage layout, but its nested

--- a/design.md
+++ b/design.md
@@ -7884,9 +7884,10 @@ the explicit LIR requirement produces a different prepared host. The cached
 object preserves only the platform's original function exports, leaving
 builtins and Boxy runtime functions internal and eligible for dead-code
 elimination during the surgical link. Preparation is serialized per content
-identity across compiler processes and remains available when application
-compilation caching is disabled: it is an exact platform artifact, not a
-cached application result. The standalone Wasm runtime uses direct
+identity across compiler processes and remains available when the checked
+module cache and generated app-object cache are disabled: it is the exact
+prepared platform link output, not a cached app result. The
+standalone Wasm runtime uses direct
 data-symbol relocations rather than PIC GOT
 globals, so the partial link preserves its unresolved sidecar references for
 the later surgical merge. Entrypoint wrappers initialize the embedded runtime

--- a/design.md
+++ b/design.md
@@ -7874,19 +7874,20 @@ Machine-code backends lower the complete Boxy statement surface to the shared
 object and an object containing the serialized sidecar. Optimized Wasm links
 the relocatable Boxy runtime object and a static-data module containing that
 same sidecar into the emitted app object, then resolves the complete app and
-host link with Wasm LLD. Standalone Wasm dev builds prepare each distinct host
-through a content-addressed relocatable LLD link with the builtins object and,
-when LIR explicitly requires Boxy, the relocatable Boxy runtime object. Later
-builds load that cached prepared-host variant and surgically merge only the
-generated app code and its exact sidecar. The cache identity includes every
-ordered input's bytes and the selected runtime variant; changing any input or
-the explicit LIR requirement produces a different prepared host. The cached
-object preserves only the platform's original function exports, leaving
-builtins and Boxy runtime functions internal and eligible for dead-code
-elimination during the surgical link. Preparation is serialized per content
-identity across compiler processes and remains available when the checked
-module cache and generated app-object cache are disabled: it is the exact
-prepared platform link output, not a cached app result. The
+host link with Wasm LLD. When standalone Wasm dev LIR explicitly requires
+Boxy, the build prepares each distinct host through a content-addressed
+relocatable LLD link with the builtins object and relocatable Boxy runtime
+object. Later builds load that cached prepared-host variant and surgically
+merge only the generated app code and its exact sidecar. Non-Boxy dev builds
+directly use the fast surgical merge because no runtime object needs LLD
+symbol resolution. The cache identity includes every ordered input's bytes;
+changing any input produces a different prepared host. The cached object
+preserves only the platform's original function exports, leaving builtins and
+Boxy runtime functions internal and eligible for dead-code elimination during
+the surgical link. Preparation is serialized per content identity across
+compiler processes and remains available when the checked module cache and
+generated app-object cache are disabled: it is the exact prepared platform
+link output, not a cached app result. The
 standalone Wasm runtime uses direct
 data-symbol relocations rather than PIC GOT
 globals, so the partial link preserves its unresolved sidecar references for

--- a/src/backend/wasm/BoxyRuntimeLink.zig
+++ b/src/backend/wasm/BoxyRuntimeLink.zig
@@ -6,6 +6,9 @@ const lir = @import("lir");
 const StaticDataExport = @import("../dev/StaticDataExport.zig").StaticDataExport;
 const WasmModule = @import("WasmModule.zig");
 
+/// Reserved function-symbol namespace provided by the Boxy runtime object.
+pub const function_namespace = "roc_boxy_";
+
 /// Runtime object and exact serialized sidecar merged into one Wasm module.
 pub const Input = struct {
     runtime_object: []const u8,
@@ -13,10 +16,35 @@ pub const Input = struct {
     sidecar_desc: lir.LirImage.BoxySidecar,
 };
 
-/// Errors possible while constructing and merging the two relocatable modules.
-pub const Error = WasmModule.StaticDataError || WasmModule.ParseError || WasmModule.MergeError;
+/// Errors possible while constructing, merging, and verifying the two
+/// relocatable modules.
+pub const Error = WasmModule.StaticDataError || WasmModule.ParseError || WasmModule.MergeError || error{UnresolvedBuiltinImport};
 
-/// Merge sidecar definitions before the PIC runtime so its GOT globals resolve
+/// Merge the exact descriptor, layout, and string tables for this LIR.
+///
+/// A cached prepared host already contains the runtime, so standalone dev
+/// builds use this entrypoint without merging the runtime a second time.
+pub fn mergeSidecar(
+    allocator: std.mem.Allocator,
+    module: *WasmModule,
+    sidecar_blob: []const u8,
+    sidecar_desc: lir.LirImage.BoxySidecar,
+    mode: WasmModule.MergeMode,
+) Error!void {
+    const blob_len: u64 = @intCast(sidecar_blob.len);
+    const exports = [_]StaticDataExport{
+        .{ .symbol_name = "roc_boxy_sidecar_blob", .bytes = sidecar_blob, .alignment = 16, .is_global = true },
+        .{ .symbol_name = "roc_boxy_sidecar_blob_len", .bytes = std.mem.asBytes(&blob_len), .alignment = 8, .is_global = true },
+        .{ .symbol_name = "roc_boxy_sidecar_desc", .bytes = std.mem.asBytes(&sidecar_desc), .alignment = 8, .is_global = true },
+    };
+
+    var sidecar_module = try WasmModule.staticDataModule(allocator, &exports);
+    defer sidecar_module.deinit();
+    var sidecar_merge = try module.mergeModuleMode(&sidecar_module, mode);
+    sidecar_merge.deinit();
+}
+
+/// Merge sidecar definitions before the runtime so its relocations resolve
 /// directly to the exact descriptor, layout, and string tables for this LIR.
 pub fn merge(
     allocator: std.mem.Allocator,
@@ -24,20 +52,11 @@ pub fn merge(
     input: Input,
     mode: WasmModule.MergeMode,
 ) Error!void {
-    const blob_len: u64 = @intCast(input.sidecar_blob.len);
-    const exports = [_]StaticDataExport{
-        .{ .symbol_name = "roc_boxy_sidecar_blob", .bytes = input.sidecar_blob, .alignment = 16, .is_global = true },
-        .{ .symbol_name = "roc_boxy_sidecar_blob_len", .bytes = std.mem.asBytes(&blob_len), .alignment = 8, .is_global = true },
-        .{ .symbol_name = "roc_boxy_sidecar_desc", .bytes = std.mem.asBytes(&input.sidecar_desc), .alignment = 8, .is_global = true },
-    };
-
-    var sidecar_module = try WasmModule.staticDataModule(allocator, &exports);
-    defer sidecar_module.deinit();
-    var sidecar_merge = try module.mergeModuleMode(&sidecar_module, mode);
-    sidecar_merge.deinit();
+    try mergeSidecar(allocator, module, input.sidecar_blob, input.sidecar_desc, mode);
 
     var runtime_module = try WasmModule.preload(allocator, input.runtime_object, true);
     defer runtime_module.deinit();
     var runtime_merge = try module.mergeModuleMode(&runtime_module, mode);
     runtime_merge.deinit();
+    try module.verifyNoUndefinedFunctionSymbolsInNamespace(function_namespace);
 }

--- a/src/backend/wasm/WasmModule.zig
+++ b/src/backend/wasm/WasmModule.zig
@@ -2358,14 +2358,20 @@ fn patchResolvedRelocation(
                 .table_index_rel_sleb,
                 => {
                     const sym = try self.relocationSymbol(idx.symbol_index);
-                    const value = sym.index;
-                    const table_idx = self.findTableIndex(value) orelse value;
+                    if (!sym.isFunction()) return logInvalidRelocation(
+                        "table index relocation references a {s} symbol",
+                        .{@tagName(sym.kind)},
+                    );
+                    const table_idx = try self.ensureTableElement(sym.index);
                     overwritePaddedI32(target_bytes, patch_offset, @intCast(table_idx));
                 },
                 .table_index_i32 => {
                     const sym = try self.relocationSymbol(idx.symbol_index);
-                    const value = sym.index;
-                    const table_idx = self.findTableIndex(value) orelse value;
+                    if (!sym.isFunction()) return logInvalidRelocation(
+                        "table index relocation references a {s} symbol",
+                        .{@tagName(sym.kind)},
+                    );
+                    const table_idx = try self.ensureTableElement(sym.index);
                     writeRawU32Relocation(target_bytes, patch_offset, table_idx);
                 },
                 .global_index_i32 => {
@@ -2432,28 +2438,6 @@ pub fn resolveCodeRelocations(self: *Self) RelocationError!void {
 
 /// Resolve all data relocations in place.
 pub fn resolveDataRelocations(self: *Self) RelocationError!void {
-    // First pass: ensure functions referenced by table_index_* relocations
-    // are present in the element section. This is needed because data segments
-    // can store function pointers (e.g. hosted_function_ptrs) which need valid
-    // table indices, and the functions must be in the table for call_indirect.
-    for (self.reloc_data.entries.items) |entry| {
-        switch (entry) {
-            .index => |idx| {
-                if (idx.type_id == .table_index_i32 or
-                    idx.type_id == .table_index_sleb or
-                    idx.type_id == .table_index_rel_sleb)
-                {
-                    const sym = self.linking.symbol_table.items[idx.symbol_index];
-                    if (sym.isFunction()) {
-                        _ = try self.ensureTableElement(sym.index);
-                    }
-                }
-            },
-            .offset => {},
-        }
-    }
-
-    // Second pass: patch data bytes with resolved values.
     for (self.reloc_data.entries.items) |entry| {
         const segment_idx = switch (entry) {
             .index => |idx| idx.data_segment_index,
@@ -6491,6 +6475,39 @@ test "resolveCodeRelocations—table_index_sleb resolves to table index not func
     // Should be patched to table index 2 (position in table_func_indices), NOT function index 4
     var expected = [_]u8{0} ** 5;
     overwritePaddedI32(&expected, 0, 2);
+    try std.testing.expectEqualSlices(u8, &expected, module.code_bytes.items[3..8]);
+}
+
+test "resolveCodeRelocations—table index relocation materializes a missing element" {
+    const allocator = std.testing.allocator;
+    var module = Self.init(allocator);
+    defer module.deinit();
+
+    _ = try module.addFuncType(&.{}, &.{});
+    try module.func_type_indices.append(allocator, 0);
+
+    try module.code_bytes.appendSlice(allocator, &.{ 0x08, 0x00, Op.i32_const });
+    try appendPaddedU32(allocator, &module.code_bytes, 99);
+    try module.code_bytes.append(allocator, Op.end);
+    try module.function_offsets.append(allocator, 0);
+
+    try module.linking.symbol_table.append(allocator, .{
+        .kind = .function,
+        .flags = WasmLinking.SymFlag.BINDING_WEAK,
+        .name = "address_taken_fn",
+        .index = 0,
+    });
+    try module.reloc_code.entries.append(allocator, .{ .index = .{
+        .type_id = .table_index_sleb,
+        .offset = 3,
+        .symbol_index = 0,
+    } });
+
+    try module.resolveCodeRelocations();
+
+    try std.testing.expectEqualSlices(u32, &.{0}, module.table_func_indices.items);
+    var expected = [_]u8{0} ** 5;
+    overwritePaddedI32(&expected, 0, 0);
     try std.testing.expectEqualSlices(u8, &expected, module.code_bytes.items[3..8]);
 }
 

--- a/src/backend/wasm/WasmModule.zig
+++ b/src/backend/wasm/WasmModule.zig
@@ -2548,19 +2548,37 @@ pub fn materializeFuncBodies(self: *Self) Allocator.Error!void {
 /// `roc_panic` is also tolerated because current host platforms still import it
 /// behind the `roc_crashed` wrapper, and verification runs before DCE.
 pub fn verifyNoBuiltinImports(self: *const Self) error{UnresolvedBuiltinImport}!void {
-    const allowed = shim_symbols.runtime_set ++ [_][:0]const u8{"roc_panic"};
     for (self.imports.items) |imp| {
-        var is_allowed = false;
-        for (allowed) |name| {
-            if (std.mem.eql(u8, imp.field_name, name)) {
-                is_allowed = true;
-                break;
-            }
-        }
-        if (!is_allowed and std.mem.startsWith(u8, imp.field_name, "roc_")) {
+        if (!isAllowedBuiltinImport(imp.field_name) and std.mem.startsWith(u8, imp.field_name, "roc_")) {
             return error.UnresolvedBuiltinImport;
         }
     }
+}
+
+/// Verify that a relocatable object's undefined function symbols contain no
+/// references in an explicitly owned ABI namespace. Resolved symbols can leave
+/// dead import entries until the final linker compacts function indices, so
+/// symbol state—not the raw import list—is the correctness boundary for an
+/// object.
+pub fn verifyNoUndefinedFunctionSymbolsInNamespace(
+    self: *const Self,
+    namespace: []const u8,
+) error{UnresolvedBuiltinImport}!void {
+    for (self.linking.symbol_table.items) |sym| {
+        if (sym.kind != .function or !sym.isUndefined()) continue;
+        const name = sym.resolveName(self.imports.items, self.global_imports.items, self.table_imports.items) orelse continue;
+        if (std.mem.startsWith(u8, name, namespace)) {
+            return error.UnresolvedBuiltinImport;
+        }
+    }
+}
+
+fn isAllowedBuiltinImport(name: []const u8) bool {
+    const allowed = shim_symbols.runtime_set ++ [_][:0]const u8{"roc_panic"};
+    for (allowed) |allowed_name| {
+        if (std.mem.eql(u8, name, allowed_name)) return true;
+    }
+    return false;
 }
 
 /// Errors reported when a wasm no-link object violates its public linking contract.
@@ -2957,18 +2975,6 @@ fn traceLiveFunctions(
 
 // --- Phase 5: Memory, Table, and Stack Pointer Ownership ---
 
-/// Setup step (called after preload, before code generation):
-/// Validate that memory and table ownership is correctly configured.
-///
-/// In relocatable WASM objects, memory, table, and __stack_pointer are imported.
-/// Our parser already strips non-function imports from the imports array—only
-/// function imports are stored. Memory and table state is tracked via `has_memory`
-/// and `has_table` flags, and will be emitted as defined sections (not imports)
-/// when the module is encoded.
-///
-/// The __stack_pointer global import is handled implicitly: it exists in the
-/// symbol table for relocation resolution and will become a defined global
-/// during `finalizeMemoryAndTable()`.
 /// Promote globally-visible, defined function symbols from the linking section
 /// to actual WASM exports. In relocatable objects, `export fn` in Zig generates
 /// symbols with `binding=global vis=default`, but no Export section exists.
@@ -2996,10 +3002,13 @@ pub fn exportGlobalSymbols(self: *Self) Allocator.Error!void {
     }
 }
 
-/// No-op: memory and table imports are already stored in separate lists
-/// during parsing (has_memory, has_table flags). This method only asserts
-/// that the host module declared memory.
-pub fn removeMemoryAndTableImports(self: *Self) void {
+/// Prepare the explicit Wasm object ABI symbols for a final surgical link.
+///
+/// Memory and table ownership is already represented by module state. Imported
+/// `__stack_pointer`, `__memory_base`, `__table_base`, and table symbols must be
+/// promoted to their final definitions so relocations cannot keep object-file
+/// indices that do not exist in the encoded final module.
+pub fn prepareObjectAbiForFinalLink(self: *Self) (Allocator.Error || error{ UnexpectedGlobalImport, UnexpectedTableImport })!void {
     // The parser separates function imports from memory/table/global imports.
     // Non-function imports are NOT in self.imports, so import_fn_count is correct.
     // Memory and table flags were set during parseImportSection.
@@ -3008,6 +3017,108 @@ pub fn removeMemoryAndTableImports(self: *Self) void {
     std.debug.assert(self.has_memory);
     // Note: has_table may not be set if the host doesn't use indirect calls yet.
     // Table will be set during finalization if table_func_indices are populated.
+
+    for (self.global_imports.items, 0..) |imp, import_index| {
+        const is_stack = std.mem.eql(u8, imp.field_name, "__stack_pointer");
+        const is_base = std.mem.eql(u8, imp.field_name, "__memory_base") or
+            std.mem.eql(u8, imp.field_name, "__table_base");
+        if (!std.mem.eql(u8, imp.module_name, "env") or
+            imp.val_type != @intFromEnum(ValType.i32) or
+            !(is_stack or is_base) or
+            (is_stack and !imp.mutable))
+        {
+            return error.UnexpectedGlobalImport;
+        }
+
+        var has_symbol = false;
+        for (self.linking.symbol_table.items) |sym| {
+            if (sym.kind == .global and sym.isUndefined() and sym.index == import_index) {
+                has_symbol = true;
+                break;
+            }
+        }
+        if (!has_symbol) return error.UnexpectedGlobalImport;
+    }
+
+    for (self.table_imports.items, 0..) |imp, import_index| {
+        if (!std.mem.eql(u8, imp.module_name, "env") or
+            !std.mem.eql(u8, imp.field_name, "__indirect_function_table"))
+        {
+            return error.UnexpectedTableImport;
+        }
+
+        var has_symbol = false;
+        for (self.linking.symbol_table.items) |sym| {
+            if (sym.kind == .table and sym.isUndefined() and sym.index == import_index) {
+                has_symbol = true;
+                break;
+            }
+        }
+        if (!has_symbol) return error.UnexpectedTableImport;
+    }
+
+    var memory_base_index: ?u32 = null;
+    var memory_base_mutable: ?bool = null;
+    var table_base_index: ?u32 = null;
+    var table_base_mutable: ?bool = null;
+    for (self.linking.symbol_table.items) |*sym| {
+        if (sym.kind != .global or !sym.isUndefined()) continue;
+        const name = sym.resolveName(self.imports.items, self.global_imports.items, self.table_imports.items) orelse
+            return error.UnexpectedGlobalImport;
+        if (sym.index >= self.global_imports.items.len or
+            !std.mem.eql(u8, self.global_imports.items[sym.index].field_name, name))
+        {
+            return error.UnexpectedGlobalImport;
+        }
+        const imported = self.global_imports.items[sym.index];
+
+        const final_index = if (std.mem.eql(u8, name, "__stack_pointer")) blk: {
+            self.enableStackPointer(self.stack_pointer_init);
+            break :blk 0;
+        } else if (std.mem.eql(u8, name, "__memory_base")) blk: {
+            if (memory_base_index == null) {
+                memory_base_index = try self.addDefinedGlobal(@intFromEnum(ValType.i32), imported.mutable, 0);
+                memory_base_mutable = imported.mutable;
+            }
+            if (memory_base_mutable.? != imported.mutable) return error.UnexpectedGlobalImport;
+            break :blk memory_base_index.?;
+        } else if (std.mem.eql(u8, name, "__table_base")) blk: {
+            if (table_base_index == null) {
+                table_base_index = try self.addDefinedGlobal(@intFromEnum(ValType.i32), imported.mutable, 0);
+                table_base_mutable = imported.mutable;
+            }
+            if (table_base_mutable.? != imported.mutable) return error.UnexpectedGlobalImport;
+            break :blk table_base_index.?;
+        } else {
+            return error.UnexpectedGlobalImport;
+        };
+
+        sym.flags &= ~WasmLinking.SymFlag.UNDEFINED;
+        sym.flags |= WasmLinking.SymFlag.EXPLICIT_NAME;
+        sym.name = name;
+        sym.index = final_index;
+    }
+
+    for (self.linking.symbol_table.items) |*sym| {
+        if (sym.kind != .table or !sym.isUndefined()) continue;
+        const name = sym.resolveName(self.imports.items, self.global_imports.items, self.table_imports.items) orelse
+            return error.UnexpectedTableImport;
+        if (sym.index >= self.table_imports.items.len or
+            !std.mem.eql(u8, self.table_imports.items[sym.index].field_name, name) or
+            !std.mem.eql(u8, name, "__indirect_function_table"))
+        {
+            return error.UnexpectedTableImport;
+        }
+
+        sym.flags &= ~WasmLinking.SymFlag.UNDEFINED;
+        sym.flags |= WasmLinking.SymFlag.EXPLICIT_NAME;
+        sym.name = name;
+        sym.index = 0;
+    }
+
+    self.global_imports.clearRetainingCapacity();
+    self.import_global_count = 0;
+    self.table_imports.clearRetainingCapacity();
 }
 
 /// Memory settings used when finalizing a wasm module after code generation.
@@ -5261,6 +5372,12 @@ fn buildPhase5TestModule(allocator: Allocator) Allocator.Error!Self {
     module.has_table = true;
 
     // Simulate a __stack_pointer global import
+    try module.global_imports.append(allocator, .{
+        .module_name = "env",
+        .field_name = "__stack_pointer",
+        .val_type = @intFromEnum(ValType.i32),
+        .mutable = true,
+    });
     module.import_global_count = 1;
 
     // One defined function
@@ -5290,12 +5407,12 @@ fn buildPhase5TestModule(allocator: Allocator) Allocator.Error!Self {
     return module;
 }
 
-test "setup—memory and table imports removed from host module" {
+test "setup—function imports survive object ABI preparation" {
     const allocator = std.testing.allocator;
     var module = try buildPhase5TestModule(allocator);
     defer module.deinit();
 
-    module.removeMemoryAndTableImports();
+    try module.prepareObjectAbiForFinalLink();
 
     // After setup, the imports array should only contain function imports
     try std.testing.expectEqual(@as(usize, 2), module.imports.items.len);
@@ -5307,13 +5424,40 @@ test "setup—memory and table imports removed from host module" {
     try std.testing.expect(module.has_table);
 }
 
-test "setup—import_fn_count unchanged after removing non-function imports" {
+test "setup—object ABI globals become valid final global indices" {
+    const allocator = std.testing.allocator;
+    var module = Self.init(allocator);
+    defer module.deinit();
+    module.has_memory = true;
+
+    _ = try module.addGlobalImportWithSymbol("env", "__stack_pointer", .i32, true);
+    _ = try module.addGlobalImportWithSymbol("env", "__memory_base", .i32, true);
+    _ = try module.addGlobalImportWithSymbol("env", "__table_base", .i32, false);
+    const table_symbol = try module.addTableImportWithSymbol();
+
+    try module.prepareObjectAbiForFinalLink();
+
+    try std.testing.expect(module.has_stack_pointer);
+    try std.testing.expectEqual(@as(usize, 0), module.global_imports.items.len);
+    try std.testing.expectEqual(@as(u32, 0), module.import_global_count);
+    try std.testing.expectEqual(@as(usize, 0), module.table_imports.items.len);
+    try std.testing.expectEqual(@as(usize, 2), module.extra_globals.items.len);
+    for (module.linking.symbol_table.items[0..3], 0..) |sym, expected_index| {
+        try std.testing.expect(!sym.isUndefined());
+        try std.testing.expectEqual(@as(u32, @intCast(expected_index)), sym.index);
+    }
+    const table = module.linking.symbol_table.items[table_symbol.raw()];
+    try std.testing.expect(!table.isUndefined());
+    try std.testing.expectEqual(@as(u32, 0), table.index);
+}
+
+test "setup—object ABI preparation leaves function import count unchanged" {
     const allocator = std.testing.allocator;
     var module = try buildPhase5TestModule(allocator);
     defer module.deinit();
 
     const fn_count_before = module.import_fn_count;
-    module.removeMemoryAndTableImports();
+    try module.prepareObjectAbiForFinalLink();
 
     // import_fn_count should be unchanged—it only counts function imports
     try std.testing.expectEqual(fn_count_before, module.import_fn_count);
@@ -5325,7 +5469,7 @@ test "setup—__stack_pointer global defined with correct initial value" {
     var module = try buildPhase5TestModule(allocator);
     defer module.deinit();
 
-    module.removeMemoryAndTableImports();
+    try module.prepareObjectAbiForFinalLink();
     try module.finalizeMemoryAndTable(1024); // 1KB stack
 
     // __stack_pointer should be defined (not imported)
@@ -5340,7 +5484,7 @@ test "setup—memory section has correct minimum pages" {
     var module = try buildPhase5TestModule(allocator);
     defer module.deinit();
 
-    module.removeMemoryAndTableImports();
+    try module.prepareObjectAbiForFinalLink();
 
     // Data segment: 12 bytes at offset 1024 → data_end = 1036
     // data_offset is 1024 (init default), data_end = max(1024, 1036) = 1036
@@ -5367,7 +5511,7 @@ test "setup—table size matches element count after finalization" {
     try module.table_func_indices.append(allocator, 3); // another fn
     try module.table_func_indices.append(allocator, 4); // another fn
 
-    module.removeMemoryAndTableImports();
+    try module.prepareObjectAbiForFinalLink();
     try module.finalizeMemoryAndTable(1024);
 
     // Encode and verify the table section uses the correct size
@@ -5411,7 +5555,7 @@ test "setup—memory exported as 'memory'" {
     defer module.deinit();
 
     const exports_before = module.exports.items.len;
-    module.removeMemoryAndTableImports();
+    try module.prepareObjectAbiForFinalLink();
     try module.finalizeMemoryAndTable(1024);
 
     // Should have one more export than before
@@ -5445,7 +5589,7 @@ test "setup—finalized module encodes and re-parses as valid WASM" {
     // Add table entries for encoding
     try module.table_func_indices.append(allocator, 2);
 
-    module.removeMemoryAndTableImports();
+    try module.prepareObjectAbiForFinalLink();
     try module.finalizeMemoryAndTable(4096);
 
     // Encode to final WASM binary
@@ -5476,7 +5620,7 @@ test "setup—finalized module encodes and re-parses as valid WASM" {
     try std.testing.expect(decoded.has_stack_pointer);
 }
 
-test "phase5—real host module: removeMemoryAndTableImports preserves function imports" {
+test "phase5—real host object ABI preparation preserves function imports" {
     const allocator = std.testing.allocator;
     const host_bytes = @import("wasm_host_fixture").host_wasm;
 
@@ -5486,7 +5630,7 @@ test "phase5—real host module: removeMemoryAndTableImports preserves function 
     const fn_count_before = module.import_fn_count;
     const imports_before = module.imports.items.len;
 
-    module.removeMemoryAndTableImports();
+    try module.prepareObjectAbiForFinalLink();
 
     // Function imports should be completely unchanged
     try std.testing.expectEqual(fn_count_before, module.import_fn_count);
@@ -5504,7 +5648,7 @@ test "phase5—real host module: full setup and finalization produces valid WASM
     defer module.deinit();
 
     // Phase 5 setup
-    module.removeMemoryAndTableImports();
+    try module.prepareObjectAbiForFinalLink();
 
     // Phase 5 finalization with 64KB stack
     try module.finalizeMemoryAndTable(65536);
@@ -6706,6 +6850,23 @@ test "verifyNoBuiltinImports—allows roc_panic platform import" {
     _ = try module.addImport("env", "roc_panic", 0);
 
     try module.verifyNoBuiltinImports();
+}
+
+test "verifyNoUndefinedFunctionSymbolsInNamespace—uses relocatable symbol resolution state" {
+    const allocator = std.testing.allocator;
+    var module = Self.init(allocator);
+    defer module.deinit();
+
+    const type_idx = try module.addFuncType(&.{}, &.{});
+    const imported = try module.addFunctionImportWithSymbol("env", "roc_boxy_register_proc", type_idx);
+    try std.testing.expectError(
+        error.UnresolvedBuiltinImport,
+        module.verifyNoUndefinedFunctionSymbolsInNamespace("roc_boxy_"),
+    );
+
+    const symbol = &module.linking.symbol_table.items[imported.symbol.raw()];
+    symbol.flags &= ~WasmLinking.SymFlag.UNDEFINED;
+    try module.verifyNoUndefinedFunctionSymbolsInNamespace("roc_boxy_");
 }
 
 test "verifyNoLinkObjectContract - allows only env wasm object ABI imports" {

--- a/src/build/zig_binaryen.cpp
+++ b/src/build/zig_binaryen.cpp
@@ -16,6 +16,7 @@ typedef struct RocBinaryenOptimizeConfig {
     uint8_t strip_debug;
     uint8_t strip_producers;
     uint8_t strip_target_features;
+    uint8_t simd128;
     uint8_t validate;
 } RocBinaryenOptimizeConfig;
 
@@ -81,10 +82,26 @@ extern "C" int RocBinaryenOptimizeWasm(
     BinaryenSetZeroFilledMemory(config.zero_filled_memory != 0);
     BinaryenSetDebugInfo(config.debug_info != 0);
 
+    // This is Roc's explicit Wasm codegen contract. LLD's target_features
+    // section can omit features used by linked code, while FeatureAll lets
+    // optimization introduce proposals outside the selected target.
+    BinaryenFeatures features =
+        BinaryenFeatureMVP() |
+        BinaryenFeatureMutableGlobals() |
+        BinaryenFeatureNontrappingFPToInt() |
+        BinaryenFeatureBulkMemory() |
+        BinaryenFeatureSignExt() |
+        BinaryenFeatureMultivalue() |
+        BinaryenFeatureExtendedConst() |
+        BinaryenFeatureBulkMemoryOpt() |
+        BinaryenFeatureCallIndirectOverlong();
+    if (config.simd128 != 0) {
+        features |= BinaryenFeatureSIMD128();
+    }
     BinaryenModuleRef module = BinaryenModuleReadWithFeatures(
         reinterpret_cast<char*>(const_cast<uint8_t*>(input)),
         input_len,
-        BinaryenFeatureAll()
+        features
     );
     if (module == nullptr) {
         return RocBinaryenStatusReadFailed;

--- a/src/cli/linker.zig
+++ b/src/cli/linker.zig
@@ -36,6 +36,7 @@ const RocBinaryenOptimizeConfig = extern struct {
     strip_debug: u8,
     strip_producers: u8,
     strip_target_features: u8,
+    simd128: u8,
     validate: u8,
 };
 
@@ -169,6 +170,10 @@ pub const LinkConfig = struct {
 
     /// Whether to run Binaryen over linked wasm output.
     wasm_optimize: WasmOptimizeMode = .none,
+
+    /// The selected Wasm CPU contract whose instruction features Binaryen may
+    /// preserve or introduce while optimizing the linked module.
+    wasm_cpu_level: roc_target.CpuLevel = .default,
 
     /// Optional data/global base for freestanding WASM links.
     wasm_global_base: ?u32 = null,
@@ -1084,6 +1089,7 @@ fn binaryenConfig(config: LinkConfig) RocBinaryenOptimizeConfig {
         .strip_debug = @intFromBool(!config.wasm_debug_info),
         .strip_producers = 1,
         .strip_target_features = @intFromBool(config.wasm_optimize == .size and !config.wasm_debug_info),
+        .simd128 = @intFromBool(config.wasm_cpu_level == .default),
         .validate = 1,
     };
 }
@@ -1342,6 +1348,10 @@ test "size wasm strips final target feature metadata" {
 
     const speed = binaryenConfig(.{ .output_path = "out.wasm", .object_files = &.{}, .wasm_optimize = .speed });
     try std.testing.expectEqual(@as(u8, 0), speed.strip_target_features);
+    try std.testing.expectEqual(@as(u8, 1), speed.simd128);
+
+    const v1 = binaryenConfig(.{ .output_path = "out.wasm", .object_files = &.{}, .wasm_optimize = .speed, .wasm_cpu_level = .v1 });
+    try std.testing.expectEqual(@as(u8, 0), v1.simd128);
 }
 
 test "force undefined symbols use target linker spelling" {

--- a/src/cli/linker.zig
+++ b/src/cli/linker.zig
@@ -1017,6 +1017,45 @@ pub fn link(ctx: *CliCtx, config: LinkConfig) LinkError!void {
     }
 }
 
+/// Combine Wasm objects and archives into one relocatable object.
+///
+/// This is the one-time correctness link used to prepare a platform host for
+/// later surgical dev links. Whole-archive preserves the surgical linker's
+/// previous contract of loading every declared archive member, while LLD owns
+/// normal strong/weak and COMDAT resolution.
+pub fn linkWasmRelocatable(
+    ctx: *CliCtx,
+    output_path: []const u8,
+    input_paths: []const []const u8,
+) LinkError!void {
+    if (comptime !llvm_available) {
+        return LinkError.LLVMNotAvailable;
+    }
+
+    var args = std.array_list.Managed([]const u8).initCapacity(ctx.arena, input_paths.len + 7) catch
+        return LinkError.OutOfMemory;
+    try args.append("wasm-ld");
+    try args.append("-r");
+    try args.append("-o");
+    try args.append(output_path);
+    try args.append("--whole-archive");
+    try args.appendSlice(input_paths);
+    try args.append("--no-whole-archive");
+
+    std.log.debug("Relocatable Wasm linker command:", .{});
+    for (args.items) |arg| {
+        std.log.debug("  {s}", .{arg});
+    }
+
+    embedded_lld.link(ctx.arena, .wasm, args.items, .{
+        .can_exit_early = false,
+        .disable_output = false,
+    }) catch |err| switch (err) {
+        error.OutOfMemory => return LinkError.OutOfMemory,
+        error.LinkFailed => return LinkError.LinkFailed,
+    };
+}
+
 fn binaryenStatusName(status: c_int) []const u8 {
     return switch (status) {
         1 => "invalid arguments",

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -304,6 +304,7 @@ const CliMainError =
     std.Io.Dir.StatFileError ||
     std.Io.Dir.WriteFileError ||
     std.Io.File.OpenError ||
+    std.Io.File.LockError ||
     std.Io.File.ReadPositionalError ||
     std.Io.File.ReadStreamingError ||
     std.Io.File.Reader.Error ||
@@ -8600,6 +8601,25 @@ fn loadPreparedWasmHost(
         return .{ .cached = cached };
     }
 
+    try cache_manager.ensureCacheSubdirIn(cache_key, cache_dir);
+    const cache_path = try cache_manager.computeCacheFilePath(cache_key, cache_dir);
+    defer ctx.gpa.free(cache_path);
+    const lock_path = try std.fmt.allocPrint(ctx.gpa, "{s}.lock", .{cache_path});
+    defer ctx.gpa.free(lock_path);
+    var lock_file = try std.Io.Dir.createFileAbsolute(ctx.io.std_io, lock_path, .{
+        .read = true,
+        .truncate = false,
+    });
+    defer lock_file.close(ctx.io.std_io);
+    try lock_file.lock(ctx.io.std_io, .exclusive);
+    defer lock_file.unlock(ctx.io.std_io);
+
+    // Another process may have prepared this exact host while this process
+    // waited for the content-addressed lock.
+    if (cache_manager.loadRawBytesMapped(cache_key, cache_dir)) |cached| {
+        return .{ .cached = cached };
+    }
+
     var platform_exports = std.array_list.Managed([]const u8).init(ctx.arena);
     for (link_inputs.platform_files_pre, host_inputs.items[0..pre_end]) |path, bytes| {
         try appendWasmInputBytesExportNames(ctx, &platform_exports, path, bytes);
@@ -9186,6 +9206,7 @@ fn rocBuildWasmSurgical(
             .wasm_zero_filled_memory = configuredWasmZeroFilledMemory(link_inputs.wasm),
             .wasm_debug_info = args.debug,
             .wasm_optimize = wasmOptimizeMode(args.opt),
+            .wasm_cpu_level = target.cpuLevel(),
             .wasm_global_base = if (link_inputs.wasm) |wasm| wasm.global_base else null,
             .wasm_exports = wasm_exports,
             .platform_files_dir = link_inputs.platform_files_dir,
@@ -9648,6 +9669,7 @@ fn writeCombinedLlvmWasmObject(
 fn rocBuildWasmLlvm(
     ctx: *CliCtx,
     args: cli_args.BuildArgs,
+    target: RocTarget,
     link_type: roc_target.OutputKind,
     final_output_path: []const u8,
     platform_dir: []const u8,
@@ -9667,7 +9689,7 @@ fn rocBuildWasmLlvm(
     const app_object = try compileLlvmAppObject(
         ctx,
         args,
-        .wasm32,
+        target,
         link_type,
         lowered,
         entrypoints,
@@ -9684,12 +9706,12 @@ fn rocBuildWasmLlvm(
     var owned_inputs: std.ArrayList([]u8) = .empty;
     defer freeOwnedWasmInputs(ctx, &owned_inputs);
 
-    const link_inputs = try collectPlatformLinkInputs(ctx, platform_dir, targets_config, .wasm32, link_type);
+    const link_inputs = try collectPlatformLinkInputs(ctx, platform_dir, targets_config, target, link_type);
     if (link_type == .archive) {
         // Archives package whatever inputs the platform declared (possibly
         // just the app); no platform wasm file is required.
         const combined_obj = try writeCombinedLlvmWasmObject(ctx, app_object.artifact_dir, app_object.object_path, &lowered.lir_result, static_data_exports, args.opt, &owned_inputs);
-        try writeArchiveOutput(ctx, .wasm32, final_output_path, link_inputs, &.{combined_obj});
+        try writeArchiveOutput(ctx, target, final_output_path, link_inputs, &.{combined_obj});
         return;
     }
 
@@ -9722,6 +9744,7 @@ fn rocBuildWasmLlvm(
         .wasm_zero_filled_memory = configuredWasmZeroFilledMemory(link_inputs.wasm),
         .wasm_debug_info = args.debug,
         .wasm_optimize = wasmOptimizeMode(args.opt),
+        .wasm_cpu_level = target.cpuLevel(),
         .wasm_global_base = if (link_inputs.wasm) |wasm| wasm.global_base else null,
         .wasm_exports = wasm_exports,
         .platform_files_dir = link_inputs.platform_files_dir,
@@ -9915,6 +9938,7 @@ fn rocBuildLlvm(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!BuildResult
         try rocBuildWasmLlvm(
             ctx,
             args,
+            target,
             link_type,
             final_output_path,
             platform_dir,
@@ -10081,6 +10105,11 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!BuildResu
         .roc_ctx = ctx.coreCtx(),
     };
     var cache_manager = CacheManager.init(ctx.gpa, cache_config, ctx.coreCtx());
+    var prepared_host_cache_manager = CacheManager.init(ctx.gpa, .{
+        .enabled = true,
+        .verbose = args.verbose,
+        .roc_ctx = ctx.coreCtx(),
+    }, ctx.coreCtx());
     const cache_dir = try cache_manager.config.getCacheEntriesDir(ctx.arena);
     const build_cache_dir = try std.fs.path.join(ctx.arena, &.{ cache_dir, "roc_build" });
     const wasm_host_cache_dir = try cache_manager.config.getWasmHostCacheDir(ctx.arena);
@@ -10266,7 +10295,7 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!BuildResu
             link_type,
             final_output_path,
             build_cache_dir,
-            &cache_manager,
+            &prepared_host_cache_manager,
             wasm_host_cache_dir,
             platform_dir,
             resolved_targets_config,
@@ -10690,6 +10719,7 @@ fn rocBuildEmbedded(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!BuildRe
             .wasm_zero_filled_memory = configuredWasmZeroFilledMemory(link_inputs.wasm),
             .wasm_debug_info = args.debug,
             .wasm_optimize = wasmOptimizeMode(args.opt),
+            .wasm_cpu_level = target.cpuLevel(),
             .wasm_global_base = if (link_inputs.wasm) |wasm| wasm.global_base else null,
             .platform_files_dir = link_inputs.platform_files_dir,
             .scratch_dir = build_cache_dir,

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -8514,7 +8514,7 @@ fn preparedWasmHostCacheKey(
     boxy_runtime_bytes: ?[]const u8,
 ) [32]u8 {
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    updateHashBytes(&hasher, "roc-prepared-wasm-host-v1");
+    updateHashBytes(&hasher, "roc-prepared-wasm-host-v2");
     updateHashU32(&hasher, @intCast(platform_files_pre.len));
     for (platform_files_pre) |bytes| updateHashBytes(&hasher, bytes);
     updateHashU32(&hasher, @intCast(platform_files_post.len));
@@ -8600,6 +8600,14 @@ fn loadPreparedWasmHost(
         return .{ .cached = cached };
     }
 
+    var platform_exports = std.array_list.Managed([]const u8).init(ctx.arena);
+    for (link_inputs.platform_files_pre, host_inputs.items[0..pre_end]) |path, bytes| {
+        try appendWasmInputBytesExportNames(ctx, &platform_exports, path, bytes);
+    }
+    for (link_inputs.platform_files_post, host_inputs.items[pre_end..post_end]) |path, bytes| {
+        try appendWasmInputBytesExportNames(ctx, &platform_exports, path, bytes);
+    }
+
     const temp_dir = try createUniqueTempDir(ctx);
     defer std.Io.Dir.cwd().deleteTree(ctx.io.std_io, temp_dir) catch {};
 
@@ -8653,7 +8661,13 @@ fn loadPreparedWasmHost(
         } });
     };
 
-    const prepared_bytes = try std.Io.Dir.cwd().readFileAlloc(ctx.io.std_io, prepared_path, ctx.gpa, .unlimited);
+    const linked_bytes = try std.Io.Dir.cwd().readFileAlloc(ctx.io.std_io, prepared_path, ctx.gpa, .unlimited);
+    defer ctx.gpa.free(linked_bytes);
+
+    var prepared_module = try preloadWasmObject(ctx, prepared_path, null, linked_bytes);
+    defer prepared_module.deinit();
+    try exportWasmFunctionsByName(&prepared_module, platform_exports.items);
+    const prepared_bytes = try prepared_module.encodeRelocatable(ctx.gpa);
     cache_manager.storeRawBytes(cache_key, prepared_bytes, cache_dir);
     return .{ .owned = prepared_bytes };
 }
@@ -8893,8 +8907,23 @@ fn configureWasmDataBase(module: *backend.wasm.WasmModule, wasm: ?roc_target.Was
     }
 }
 
-fn exportConfiguredWasmEntrypoints(module: *backend.wasm.WasmModule) CliMainError!void {
-    try module.exportGlobalSymbols();
+fn exportWasmFunctionsByName(
+    module: *backend.wasm.WasmModule,
+    names: []const []const u8,
+) CliMainError!void {
+    for (names) |name| {
+        var already_exported = false;
+        for (module.exports.items) |exp| {
+            if (exp.kind == .func and std.mem.eql(u8, exp.name, name)) {
+                already_exported = true;
+                break;
+            }
+        }
+        if (already_exported) continue;
+
+        const function_index = try module.findDefinedFunctionIndexExact(name);
+        try module.addExport(name, .func, function_index);
+    }
 }
 
 fn appendUniqueWasmExportName(exports: *std.array_list.Managed([]const u8), name: []const u8) Allocator.Error!void {
@@ -8930,6 +8959,15 @@ fn appendWasmInputExportNames(
 ) CliMainError!void {
     const bytes = try appendOwnedWasmInput(ctx, owned_inputs, path);
 
+    try appendWasmInputBytesExportNames(ctx, exports, path, bytes);
+}
+
+fn appendWasmInputBytesExportNames(
+    ctx: *CliCtx,
+    exports: *std.array_list.Managed([]const u8),
+    path: []const u8,
+    bytes: []const u8,
+) CliMainError!void {
     if (backend.wasm.ObjectArchive.isWasmObject(bytes)) {
         try appendWasmObjectExportNames(ctx, exports, path, null, bytes);
         return;
@@ -9177,7 +9215,6 @@ fn rocBuildWasmSurgical(
     configureWasmDataBase(&wasm_module, link_inputs.wasm);
     errdefer if (loaded_module) wasm_module.deinit();
 
-    try exportConfiguredWasmEntrypoints(&wasm_module);
     try wasm_module.prepareObjectAbiForFinalLink();
     try mergeBoxySidecarWasm(ctx, &wasm_module, &lowered.lir_result, .final_link);
 

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -468,7 +468,7 @@ const BuiltinsObjects = struct {
     const x64glibc = if (builtin.is_test) &[_]u8{} else @embedFile("targets/x64glibc/roc_builtins.o");
     const arm64glibc = if (builtin.is_test) &[_]u8{} else @embedFile("targets/arm64glibc/roc_builtins.o");
 
-    /// WebAssembly target builtins (wasm32-freestanding) - not used by dev backend
+    /// WebAssembly target builtins (wasm32-freestanding)
     const wasm32 = if (builtin.is_test) &[_]u8{} else @embedFile("targets/wasm32/roc_builtins.o");
 
     /// Cross-compilation target builtins (Windows targets)
@@ -8485,6 +8485,179 @@ fn mergeBoxyRuntimeWasm(
     };
 }
 
+fn mergeBoxySidecarWasm(
+    ctx: *CliCtx,
+    module: *backend.wasm.WasmModule,
+    lir_result: *const lir.Program.Result,
+    mode: backend.wasm.WasmModule.MergeMode,
+) CliMainError!void {
+    if (!lirResultNeedsBoxyRuntime(lir_result)) return;
+
+    var sidecar_blob = lir.LirImage.buildSidecarBlob(ctx.gpa, lir_result) catch return error.NativeCompilationFailed;
+    defer sidecar_blob.deinit(ctx.gpa);
+    backend.wasm.BoxyRuntimeLink.mergeSidecar(
+        ctx.gpa,
+        module,
+        sidecar_blob.bytes,
+        sidecar_blob.sidecar,
+        mode,
+    ) catch |err| {
+        std.log.err("Failed to merge wasm Boxy sidecar: {}", .{err});
+        return err;
+    };
+}
+
+fn preparedWasmHostCacheKey(
+    platform_files_pre: []const []const u8,
+    platform_files_post: []const []const u8,
+    builtins_bytes: []const u8,
+    boxy_runtime_bytes: ?[]const u8,
+) [32]u8 {
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    updateHashBytes(&hasher, "roc-prepared-wasm-host-v1");
+    updateHashU32(&hasher, @intCast(platform_files_pre.len));
+    for (platform_files_pre) |bytes| updateHashBytes(&hasher, bytes);
+    updateHashU32(&hasher, @intCast(platform_files_post.len));
+    for (platform_files_post) |bytes| updateHashBytes(&hasher, bytes);
+    updateHashBytes(&hasher, builtins_bytes);
+    updateHashBool(&hasher, boxy_runtime_bytes != null);
+    if (boxy_runtime_bytes) |bytes| updateHashBytes(&hasher, bytes);
+    return hasher.finalResult();
+}
+
+test "prepared Wasm host cache key covers ordered inputs and runtime variant" {
+    const pre = [_][]const u8{ "host-a", "host-b" };
+    const reversed_pre = [_][]const u8{ "host-b", "host-a" };
+    const post = [_][]const u8{"host-post"};
+    const baseline_key = preparedWasmHostCacheKey(&pre, &post, "builtins", null);
+    const repeated_key = preparedWasmHostCacheKey(&pre, &post, "builtins", null);
+    const reordered_key = preparedWasmHostCacheKey(&reversed_pre, &post, "builtins", null);
+    const regrouped_key = preparedWasmHostCacheKey(&post, &pre, "builtins", null);
+    const changed_builtins_key = preparedWasmHostCacheKey(&pre, &post, "other-builtins", null);
+    const boxy_key = preparedWasmHostCacheKey(&pre, &post, "builtins", "boxy-runtime");
+
+    try std.testing.expectEqual(baseline_key, repeated_key);
+    try std.testing.expect(!std.mem.eql(u8, &baseline_key, &reordered_key));
+    try std.testing.expect(!std.mem.eql(u8, &baseline_key, &regrouped_key));
+    try std.testing.expect(!std.mem.eql(u8, &baseline_key, &changed_builtins_key));
+    try std.testing.expect(!std.mem.eql(u8, &baseline_key, &boxy_key));
+}
+
+const PreparedWasmHost = union(enum) {
+    cached: compile.manager.CacheModule.CacheData,
+    owned: []u8,
+
+    fn bytes(self: PreparedWasmHost) []const u8 {
+        return switch (self) {
+            .cached => |data| data.data(),
+            .owned => |data| data,
+        };
+    }
+
+    fn deinit(self: PreparedWasmHost, allocator: Allocator) void {
+        switch (self) {
+            .cached => |data| data.deinit(allocator),
+            .owned => |data| allocator.free(data),
+        }
+    }
+};
+
+/// Run the platform inputs through a real relocatable link exactly once for
+/// each content-addressed base/Boxy variant. The returned object has already
+/// had Wasm's strong/weak and COMDAT rules applied, so later surgical links do
+/// not need to reconstruct linker semantics.
+fn loadPreparedWasmHost(
+    ctx: *CliCtx,
+    cache_manager: *CacheManager,
+    cache_dir: []const u8,
+    link_inputs: PlatformLinkInputs,
+    needs_boxy_runtime: bool,
+) CliMainError!PreparedWasmHost {
+    var host_inputs: std.ArrayList([]u8) = .empty;
+    defer freeOwnedWasmInputs(ctx, &host_inputs);
+
+    for (link_inputs.platform_files_pre) |path| {
+        _ = try appendOwnedWasmInput(ctx, &host_inputs, path);
+    }
+    const pre_end = host_inputs.items.len;
+    for (link_inputs.platform_files_post) |path| {
+        _ = try appendOwnedWasmInput(ctx, &host_inputs, path);
+    }
+    const post_end = host_inputs.items.len;
+
+    const builtins_bytes = BuiltinsObjects.forTargetExtern(.wasm32);
+    const runtime_bytes = if (needs_boxy_runtime)
+        BoxyRuntimeObjects.forTarget(.wasm32) orelse return error.UnsupportedTarget
+    else
+        null;
+    const cache_key = preparedWasmHostCacheKey(
+        host_inputs.items[0..pre_end],
+        host_inputs.items[pre_end..post_end],
+        builtins_bytes,
+        runtime_bytes,
+    );
+    if (cache_manager.loadRawBytesMapped(cache_key, cache_dir)) |cached| {
+        return .{ .cached = cached };
+    }
+
+    const temp_dir = try createUniqueTempDir(ctx);
+    defer std.Io.Dir.cwd().deleteTree(ctx.io.std_io, temp_dir) catch {};
+
+    var linker_inputs = try std.array_list.Managed([]const u8).initCapacity(
+        ctx.arena,
+        link_inputs.platform_files_pre.len + link_inputs.platform_files_post.len + 2,
+    );
+
+    for (host_inputs.items[0..pre_end], 0..) |bytes, i| {
+        const extension = if (backend.wasm.ObjectArchive.isArchive(bytes)) ".a" else ".o";
+        const filename = try std.fmt.allocPrint(ctx.arena, "platform-pre-{d}{s}", .{ i, extension });
+        const path = try std.fs.path.join(ctx.arena, &.{ temp_dir, filename });
+        backend.writeFileWindowsAvSafe(ctx.io.std_io, path, bytes) catch |err| {
+            std.log.err("Failed to stage Wasm host input for preparation: {}", .{err});
+            return error.WasmOutputWriteFailed;
+        };
+        linker_inputs.appendAssumeCapacity(path);
+    }
+
+    const builtins_path = try std.fs.path.join(ctx.arena, &.{ temp_dir, "roc_builtins.o" });
+    backend.writeFileWindowsAvSafe(ctx.io.std_io, builtins_path, builtins_bytes) catch |err| {
+        std.log.err("Failed to write Wasm builtins for prepared host: {}", .{err});
+        return error.WasmOutputWriteFailed;
+    };
+    linker_inputs.appendAssumeCapacity(builtins_path);
+
+    if (runtime_bytes) |bytes| {
+        const runtime_path = try std.fs.path.join(ctx.arena, &.{ temp_dir, "roc_boxy_runtime.o" });
+        backend.writeFileWindowsAvSafe(ctx.io.std_io, runtime_path, bytes) catch |err| {
+            std.log.err("Failed to write Boxy runtime for prepared host: {}", .{err});
+            return error.WasmOutputWriteFailed;
+        };
+        linker_inputs.appendAssumeCapacity(runtime_path);
+    }
+    for (host_inputs.items[pre_end..post_end], 0..) |bytes, i| {
+        const extension = if (backend.wasm.ObjectArchive.isArchive(bytes)) ".a" else ".o";
+        const filename = try std.fmt.allocPrint(ctx.arena, "platform-post-{d}{s}", .{ i, extension });
+        const path = try std.fs.path.join(ctx.arena, &.{ temp_dir, filename });
+        backend.writeFileWindowsAvSafe(ctx.io.std_io, path, bytes) catch |err| {
+            std.log.err("Failed to stage Wasm host input for preparation: {}", .{err});
+            return error.WasmOutputWriteFailed;
+        };
+        linker_inputs.appendAssumeCapacity(path);
+    }
+
+    const prepared_path = try std.fs.path.join(ctx.arena, &.{ temp_dir, "roc_prepared_host.o" });
+    linker.linkWasmRelocatable(ctx, prepared_path, linker_inputs.items) catch |err| {
+        return ctx.fail(.{ .linker_failed = .{
+            .err = err,
+            .target = link_inputs.target_name,
+        } });
+    };
+
+    const prepared_bytes = try std.Io.Dir.cwd().readFileAlloc(ctx.io.std_io, prepared_path, ctx.gpa, .unlimited);
+    cache_manager.storeRawBytes(cache_key, prepared_bytes, cache_dir);
+    return .{ .owned = prepared_bytes };
+}
+
 fn writeDefaultPlatformExecutableObject(ctx: *CliCtx, artifact_dir: []const u8, target: RocTarget) CliMainError!?[]const u8 {
     const bytes = DefaultPlatformExecutableObjects.forTarget(target) orelse return null;
     const runtime_path = try std.fs.path.join(ctx.arena, &.{ artifact_dir, DefaultPlatformExecutableObjects.filename(target) });
@@ -8724,69 +8897,6 @@ fn exportConfiguredWasmEntrypoints(module: *backend.wasm.WasmModule) CliMainErro
     try module.exportGlobalSymbols();
 }
 
-fn addWasmObject(
-    ctx: *CliCtx,
-    module: *backend.wasm.WasmModule,
-    path: []const u8,
-    member_name: ?[]const u8,
-    bytes: []const u8,
-    loaded_module: *bool,
-) (backend.wasm.WasmModule.ParseError || backend.wasm.WasmModule.MergeError)!void {
-    var next_module = try preloadWasmObject(ctx, path, member_name, bytes);
-
-    if (!loaded_module.*) {
-        module.* = next_module;
-        loaded_module.* = true;
-        return;
-    }
-
-    defer next_module.deinit();
-
-    var merge_result = try module.mergeModule(&next_module);
-    merge_result.deinit();
-}
-
-fn addWasmInput(
-    ctx: *CliCtx,
-    module: *backend.wasm.WasmModule,
-    owned_inputs: *std.ArrayList([]u8),
-    path: []const u8,
-    loaded_module: *bool,
-) CliMainError!void {
-    const bytes = try appendOwnedWasmInput(ctx, owned_inputs, path);
-
-    if (backend.wasm.ObjectArchive.isWasmObject(bytes)) {
-        try addWasmObject(ctx, module, path, null, bytes, loaded_module);
-        return;
-    }
-
-    if (!backend.wasm.ObjectArchive.isArchive(bytes)) {
-        std.log.err("Failed to preload wasm input {s}: {}", .{ path, error.InvalidMagic });
-        return error.InvalidMagic;
-    }
-
-    var member_count: usize = 0;
-    var iter = backend.wasm.ObjectArchive.Iterator.init(bytes) catch |err| {
-        std.log.err("Failed to read wasm archive {s}: {}", .{ path, err });
-        return err;
-    };
-
-    while (true) {
-        const maybe_member = iter.next() catch |err| {
-            std.log.err("Failed to read wasm archive {s}: {}", .{ path, err });
-            return err;
-        };
-        const member = maybe_member orelse break;
-        member_count += 1;
-        try addWasmObject(ctx, module, path, member.name, member.bytes, loaded_module);
-    }
-
-    if (member_count == 0) {
-        std.log.err("Wasm archive {s} does not contain object members", .{path});
-        return error.EmptyArchive;
-    }
-}
-
 fn appendUniqueWasmExportName(exports: *std.array_list.Managed([]const u8), name: []const u8) Allocator.Error!void {
     for (exports.items) |existing| {
         if (std.mem.eql(u8, existing, name)) return;
@@ -8980,6 +9090,8 @@ fn rocBuildWasmSurgical(
     link_type: roc_target.OutputKind,
     final_output_path: []const u8,
     build_cache_dir: []const u8,
+    cache_manager: *CacheManager,
+    wasm_host_cache_dir: []const u8,
     platform_dir: []const u8,
     targets_config: roc_target.TargetsConfig,
     lowered: *const lir.CheckedPipeline.LoweredProgram,
@@ -9051,33 +9163,23 @@ fn rocBuildWasmSurgical(
         return;
     }
 
+    const prepared_host = try loadPreparedWasmHost(
+        ctx,
+        cache_manager,
+        wasm_host_cache_dir,
+        link_inputs,
+        lirResultNeedsBoxyRuntime(&lowered.lir_result),
+    );
+    defer prepared_host.deinit(ctx.gpa);
+
     var loaded_module = true;
-    var wasm_module = backend.wasm.WasmModule.init(ctx.gpa);
+    var wasm_module = try preloadWasmObject(ctx, "prepared Wasm host", null, prepared_host.bytes());
     configureWasmDataBase(&wasm_module, link_inputs.wasm);
     errdefer if (loaded_module) wasm_module.deinit();
 
-    for (link_inputs.platform_files_pre) |path| {
-        try addWasmInput(ctx, &wasm_module, &owned_inputs, path, &loaded_module);
-    }
-    for (link_inputs.platform_files_post) |path| {
-        try addWasmInput(ctx, &wasm_module, &owned_inputs, path, &loaded_module);
-    }
-
     try exportConfiguredWasmEntrypoints(&wasm_module);
-    wasm_module.removeMemoryAndTableImports();
-
-    const builtins_bytes = BuiltinsObjects.forTargetExtern(.wasm32);
-    if (builtins_bytes.len > 0) {
-        var builtins_module = backend.wasm.WasmModule.preload(ctx.gpa, builtins_bytes, true) catch |err| {
-            std.log.err("Failed to preload wasm builtins: {}", .{err});
-            return err;
-        };
-        defer builtins_module.deinit();
-
-        var merge_result = try wasm_module.mergeModule(&builtins_module);
-        merge_result.deinit();
-    }
-    try mergeBoxyRuntimeWasm(ctx, &wasm_module, &lowered.lir_result, .final_link);
+    try wasm_module.prepareObjectAbiForFinalLink();
+    try mergeBoxySidecarWasm(ctx, &wasm_module, &lowered.lir_result, .final_link);
 
     const builtin_symbols = backend.wasm.BuiltinSignatures.populateForRelocs(&wasm_module) catch |err| {
         std.log.err("Failed to locate wasm builtin symbols after merge: {}", .{err});
@@ -9472,6 +9574,7 @@ fn writeCombinedLlvmWasmObject(
     ctx: *CliCtx,
     artifact_dir: []const u8,
     app_object_path: []const u8,
+    lir_result: *const lir.Program.Result,
     static_data_exports: []const backend.StaticDataExport,
     opt: cli_args.OptLevel,
     owned_inputs: *std.ArrayList([]u8),
@@ -9488,6 +9591,7 @@ fn writeCombinedLlvmWasmObject(
     var app_merge = try wasm_module.mergeModuleForObject(&app_module);
     app_merge.deinit();
 
+    try mergeBoxyRuntimeWasm(ctx, &wasm_module, lir_result, .relocatable_object);
     try mergeStaticDataWasmModule(ctx, &wasm_module, static_data_exports, .relocatable_object);
     try wasm_module.verifyNoLinkObjectContract();
 
@@ -9547,7 +9651,7 @@ fn rocBuildWasmLlvm(
     if (link_type == .archive) {
         // Archives package whatever inputs the platform declared (possibly
         // just the app); no platform wasm file is required.
-        const combined_obj = try writeCombinedLlvmWasmObject(ctx, app_object.artifact_dir, app_object.object_path, static_data_exports, args.opt, &owned_inputs);
+        const combined_obj = try writeCombinedLlvmWasmObject(ctx, app_object.artifact_dir, app_object.object_path, &lowered.lir_result, static_data_exports, args.opt, &owned_inputs);
         try writeArchiveOutput(ctx, .wasm32, final_output_path, link_inputs, &.{combined_obj});
         return;
     }
@@ -9557,104 +9661,42 @@ fn rocBuildWasmLlvm(
         return error.UnsupportedTarget;
     }
 
-    if (link_inputs.wasm != null) {
-        const combined_obj = try writeCombinedLlvmWasmObject(ctx, app_object.artifact_dir, app_object.object_path, static_data_exports, args.opt, &owned_inputs);
-        const object_files = try ctx.arena.alloc([]const u8, 1);
-        object_files[0] = combined_obj;
-        const wasm_exports = try collectWasmPlatformExports(ctx, link_inputs, &owned_inputs);
+    const combined_obj = try writeCombinedLlvmWasmObject(ctx, app_object.artifact_dir, app_object.object_path, &lowered.lir_result, static_data_exports, args.opt, &owned_inputs);
+    const object_files = try ctx.arena.alloc([]const u8, 1);
+    object_files[0] = combined_obj;
+    const wasm_exports = try collectWasmPlatformExports(ctx, link_inputs, &owned_inputs);
 
-        const link_config = linker.LinkConfig{
-            .target_format = .wasm,
-            .target_abi = null,
-            .target_os = .freestanding,
-            .target_arch = .wasm32,
-            .output_path = final_output_path,
-            .object_files = object_files,
-            .platform_files_pre = link_inputs.platform_files_pre,
-            .platform_files_post = link_inputs.platform_files_post,
-            .extra_args = &.{},
-            .can_exit_early = false,
-            .disable_output = false,
-            .wasm_initial_memory = configuredWasmMinimumMemory(args, link_inputs.wasm),
-            .wasm_maximum_memory = if (link_inputs.wasm) |wasm| wasm.maximum_memory else null,
-            .wasm_stack_size = configuredWasmStackBytes(args, link_inputs.wasm),
-            .wasm_import_memory = if (link_inputs.wasm) |wasm| wasm.import_memory.importsMemory() else false,
-            .wasm_zero_filled_memory = configuredWasmZeroFilledMemory(link_inputs.wasm),
-            .wasm_debug_info = args.debug,
-            .wasm_optimize = wasmOptimizeMode(args.opt),
-            .wasm_global_base = if (link_inputs.wasm) |wasm| wasm.global_base else null,
-            .wasm_exports = wasm_exports,
-            .platform_files_dir = link_inputs.platform_files_dir,
-            .scratch_dir = app_object.artifact_dir,
-        };
-
-        linker.link(ctx, link_config) catch |err| {
-            return ctx.fail(.{ .linker_failed = .{
-                .err = err,
-                .target = link_inputs.target_name,
-            } });
-        };
-        return;
-    }
-
-    var loaded_module = true;
-    var wasm_module = backend.wasm.WasmModule.init(ctx.gpa);
-    configureWasmDataBase(&wasm_module, link_inputs.wasm);
-    errdefer if (loaded_module) wasm_module.deinit();
-
-    for (link_inputs.platform_files_pre) |path| {
-        try addWasmInput(ctx, &wasm_module, &owned_inputs, path, &loaded_module);
-    }
-    for (link_inputs.platform_files_post) |path| {
-        try addWasmInput(ctx, &wasm_module, &owned_inputs, path, &loaded_module);
-    }
-
-    try exportConfiguredWasmEntrypoints(&wasm_module);
-    wasm_module.removeMemoryAndTableImports();
-
-    const app_bytes = try appendOwnedWasmInput(ctx, &owned_inputs, app_object.object_path);
-    var app_module = try preloadWasmObject(ctx, app_object.object_path, null, app_bytes);
-    defer app_module.deinit();
-    var app_merge = try wasm_module.mergeModule(&app_module);
-    app_merge.deinit();
-
-    try mergeStaticDataWasmModule(ctx, &wasm_module, static_data_exports, .final_link);
-
-    var host_to_app_map: std.ArrayList(backend.wasm.WasmModule.HostToAppEntry) = .empty;
-    defer host_to_app_map.deinit(ctx.gpa);
-    try host_to_app_map.ensureTotalCapacity(ctx.gpa, entrypoints.len);
-
-    for (entrypoints) |entry| {
-        const fn_index = try wasm_module.findDefinedFunctionIndexExact(entry.symbol_name);
-        host_to_app_map.appendAssumeCapacity(.{
-            .name = entry.symbol_name,
-            .fn_index = fn_index,
-        });
-    }
-
-    try wasm_module.linkHostToAppCalls(host_to_app_map.items);
-
-    const memory_config = configuredWasmMemory(args, link_inputs.wasm);
-    try wasm_module.finalizeMemoryAndTableWithConfig(memory_config);
-    try wasm_module.resolveRelocations();
-
-    const called_fns = try ctx.gpa.alloc(bool, wasm_module.liveFunctionCount());
-    defer ctx.gpa.free(called_fns);
-    @memset(called_fns, false);
-    try wasm_module.eliminateDeadCode(called_fns);
-
-    try wasm_module.verifyNoBuiltinImports();
-    try wasm_module.materializeFuncBodies();
-
-    const wasm_bytes = try wasm_module.encode(ctx.gpa);
-    defer ctx.gpa.free(wasm_bytes);
-    backend.writeFileWindowsAvSafe(ctx.io.std_io, final_output_path, wasm_bytes) catch |err| {
-        std.log.err("Failed to write wasm output: {}", .{err});
-        return error.WasmOutputWriteFailed;
+    const link_config = linker.LinkConfig{
+        .target_format = .wasm,
+        .target_abi = null,
+        .target_os = .freestanding,
+        .target_arch = .wasm32,
+        .output_path = final_output_path,
+        .object_files = object_files,
+        .platform_files_pre = link_inputs.platform_files_pre,
+        .platform_files_post = link_inputs.platform_files_post,
+        .extra_args = &.{},
+        .can_exit_early = false,
+        .disable_output = false,
+        .wasm_initial_memory = configuredWasmMinimumMemory(args, link_inputs.wasm),
+        .wasm_maximum_memory = if (link_inputs.wasm) |wasm| wasm.maximum_memory else null,
+        .wasm_stack_size = configuredWasmStackBytes(args, link_inputs.wasm),
+        .wasm_import_memory = if (link_inputs.wasm) |wasm| wasm.import_memory.importsMemory() else false,
+        .wasm_zero_filled_memory = configuredWasmZeroFilledMemory(link_inputs.wasm),
+        .wasm_debug_info = args.debug,
+        .wasm_optimize = wasmOptimizeMode(args.opt),
+        .wasm_global_base = if (link_inputs.wasm) |wasm| wasm.global_base else null,
+        .wasm_exports = wasm_exports,
+        .platform_files_dir = link_inputs.platform_files_dir,
+        .scratch_dir = app_object.artifact_dir,
     };
 
-    wasm_module.deinit();
-    loaded_module = false;
+    linker.link(ctx, link_config) catch |err| {
+        return ctx.fail(.{ .linker_failed = .{
+            .err = err,
+            .target = link_inputs.target_name,
+        } });
+    };
 }
 
 fn rocBuildLlvm(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!BuildResult {
@@ -9997,13 +10039,14 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!BuildResu
         try base.module_path.getModuleNameAlloc(ctx.arena, args.path);
 
     const cache_config = CacheConfig{
-        .enabled = true,
-        .verbose = false,
+        .enabled = !args.no_cache,
+        .verbose = args.verbose,
         .roc_ctx = ctx.coreCtx(),
     };
     var cache_manager = CacheManager.init(ctx.gpa, cache_config, ctx.coreCtx());
     const cache_dir = try cache_manager.config.getCacheEntriesDir(ctx.arena);
     const build_cache_dir = try std.fs.path.join(ctx.arena, &.{ cache_dir, "roc_build" });
+    const wasm_host_cache_dir = try cache_manager.config.getWasmHostCacheDir(ctx.arena);
     ensureCompilerCacheDirExists(ctx.io.std_io, build_cache_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         error.AccessDenied,
@@ -10186,6 +10229,8 @@ fn rocBuildNative(ctx: *CliCtx, args: cli_args.BuildArgs) CliMainError!BuildResu
             link_type,
             final_output_path,
             build_cache_dir,
+            &cache_manager,
+            wasm_host_cache_dir,
             platform_dir,
             resolved_targets_config,
             &lowered,

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -8512,36 +8512,35 @@ fn preparedWasmHostCacheKey(
     platform_files_pre: []const []const u8,
     platform_files_post: []const []const u8,
     builtins_bytes: []const u8,
-    boxy_runtime_bytes: ?[]const u8,
+    boxy_runtime_bytes: []const u8,
 ) [32]u8 {
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    updateHashBytes(&hasher, "roc-prepared-wasm-host-v2");
+    updateHashBytes(&hasher, "roc-prepared-wasm-host-v3");
     updateHashU32(&hasher, @intCast(platform_files_pre.len));
     for (platform_files_pre) |bytes| updateHashBytes(&hasher, bytes);
     updateHashU32(&hasher, @intCast(platform_files_post.len));
     for (platform_files_post) |bytes| updateHashBytes(&hasher, bytes);
     updateHashBytes(&hasher, builtins_bytes);
-    updateHashBool(&hasher, boxy_runtime_bytes != null);
-    if (boxy_runtime_bytes) |bytes| updateHashBytes(&hasher, bytes);
+    updateHashBytes(&hasher, boxy_runtime_bytes);
     return hasher.finalResult();
 }
 
-test "prepared Wasm host cache key covers ordered inputs and runtime variant" {
+test "prepared Wasm host cache key covers ordered inputs and Boxy runtime bytes" {
     const pre = [_][]const u8{ "host-a", "host-b" };
     const reversed_pre = [_][]const u8{ "host-b", "host-a" };
     const post = [_][]const u8{"host-post"};
-    const baseline_key = preparedWasmHostCacheKey(&pre, &post, "builtins", null);
-    const repeated_key = preparedWasmHostCacheKey(&pre, &post, "builtins", null);
-    const reordered_key = preparedWasmHostCacheKey(&reversed_pre, &post, "builtins", null);
-    const regrouped_key = preparedWasmHostCacheKey(&post, &pre, "builtins", null);
-    const changed_builtins_key = preparedWasmHostCacheKey(&pre, &post, "other-builtins", null);
-    const boxy_key = preparedWasmHostCacheKey(&pre, &post, "builtins", "boxy-runtime");
+    const baseline_key = preparedWasmHostCacheKey(&pre, &post, "builtins", "boxy-runtime");
+    const repeated_key = preparedWasmHostCacheKey(&pre, &post, "builtins", "boxy-runtime");
+    const reordered_key = preparedWasmHostCacheKey(&reversed_pre, &post, "builtins", "boxy-runtime");
+    const regrouped_key = preparedWasmHostCacheKey(&post, &pre, "builtins", "boxy-runtime");
+    const changed_builtins_key = preparedWasmHostCacheKey(&pre, &post, "other-builtins", "boxy-runtime");
+    const changed_runtime_key = preparedWasmHostCacheKey(&pre, &post, "builtins", "other-runtime");
 
     try std.testing.expectEqual(baseline_key, repeated_key);
     try std.testing.expect(!std.mem.eql(u8, &baseline_key, &reordered_key));
     try std.testing.expect(!std.mem.eql(u8, &baseline_key, &regrouped_key));
     try std.testing.expect(!std.mem.eql(u8, &baseline_key, &changed_builtins_key));
-    try std.testing.expect(!std.mem.eql(u8, &baseline_key, &boxy_key));
+    try std.testing.expect(!std.mem.eql(u8, &baseline_key, &changed_runtime_key));
 }
 
 const PreparedWasmHost = union(enum) {
@@ -8563,16 +8562,15 @@ const PreparedWasmHost = union(enum) {
     }
 };
 
-/// Run the platform inputs through a real relocatable link exactly once for
-/// each content-addressed base/Boxy variant. The returned object has already
-/// had Wasm's strong/weak and COMDAT rules applied, so later surgical links do
-/// not need to reconstruct linker semantics.
+/// Link the platform, builtins, and Boxy runtime exactly once for each
+/// content-addressed input set. The returned object has already had Wasm's
+/// strong/weak and COMDAT rules applied, so later surgical links do not need
+/// to reconstruct linker semantics.
 fn loadPreparedWasmHost(
     ctx: *CliCtx,
     cache_manager: *CacheManager,
     cache_dir: []const u8,
     link_inputs: PlatformLinkInputs,
-    needs_boxy_runtime: bool,
 ) CliMainError!PreparedWasmHost {
     var host_inputs: std.ArrayList([]u8) = .empty;
     defer freeOwnedWasmInputs(ctx, &host_inputs);
@@ -8587,10 +8585,7 @@ fn loadPreparedWasmHost(
     const post_end = host_inputs.items.len;
 
     const builtins_bytes = BuiltinsObjects.forTargetExtern(.wasm32);
-    const runtime_bytes = if (needs_boxy_runtime)
-        BoxyRuntimeObjects.forTarget(.wasm32) orelse return error.UnsupportedTarget
-    else
-        null;
+    const runtime_bytes = BoxyRuntimeObjects.forTarget(.wasm32) orelse return error.UnsupportedTarget;
     const cache_key = preparedWasmHostCacheKey(
         host_inputs.items[0..pre_end],
         host_inputs.items[pre_end..post_end],
@@ -8654,14 +8649,12 @@ fn loadPreparedWasmHost(
     };
     linker_inputs.appendAssumeCapacity(builtins_path);
 
-    if (runtime_bytes) |bytes| {
-        const runtime_path = try std.fs.path.join(ctx.arena, &.{ temp_dir, "roc_boxy_runtime.o" });
-        backend.writeFileWindowsAvSafe(ctx.io.std_io, runtime_path, bytes) catch |err| {
-            std.log.err("Failed to write Boxy runtime for prepared host: {}", .{err});
-            return error.WasmOutputWriteFailed;
-        };
-        linker_inputs.appendAssumeCapacity(runtime_path);
-    }
+    const runtime_path = try std.fs.path.join(ctx.arena, &.{ temp_dir, "roc_boxy_runtime.o" });
+    backend.writeFileWindowsAvSafe(ctx.io.std_io, runtime_path, runtime_bytes) catch |err| {
+        std.log.err("Failed to write Boxy runtime for prepared host: {}", .{err});
+        return error.WasmOutputWriteFailed;
+    };
+    linker_inputs.appendAssumeCapacity(runtime_path);
     for (host_inputs.items[pre_end..post_end], 0..) |bytes, i| {
         const extension = if (backend.wasm.ObjectArchive.isArchive(bytes)) ".a" else ".o";
         const filename = try std.fmt.allocPrint(ctx.arena, "platform-post-{d}{s}", .{ i, extension });
@@ -8924,6 +8917,59 @@ fn configureWasmDataBase(module: *backend.wasm.WasmModule, wasm: ?roc_target.Was
         if (config.global_base) |global_base| {
             module.setDataBase(global_base);
         }
+    }
+}
+
+fn addWasmObject(
+    ctx: *CliCtx,
+    module: *backend.wasm.WasmModule,
+    path: []const u8,
+    member_name: ?[]const u8,
+    bytes: []const u8,
+) (backend.wasm.WasmModule.ParseError || backend.wasm.WasmModule.MergeError)!void {
+    var next_module = try preloadWasmObject(ctx, path, member_name, bytes);
+    defer next_module.deinit();
+
+    var merge_result = try module.mergeModule(&next_module);
+    merge_result.deinit();
+}
+
+fn addWasmInput(
+    ctx: *CliCtx,
+    module: *backend.wasm.WasmModule,
+    owned_inputs: *std.ArrayList([]u8),
+    path: []const u8,
+) CliMainError!void {
+    const bytes = try appendOwnedWasmInput(ctx, owned_inputs, path);
+
+    if (backend.wasm.ObjectArchive.isWasmObject(bytes)) {
+        try addWasmObject(ctx, module, path, null, bytes);
+        return;
+    }
+
+    if (!backend.wasm.ObjectArchive.isArchive(bytes)) {
+        std.log.err("Failed to preload wasm input {s}: {}", .{ path, error.InvalidMagic });
+        return error.InvalidMagic;
+    }
+
+    var member_count: usize = 0;
+    var iter = backend.wasm.ObjectArchive.Iterator.init(bytes) catch |err| {
+        std.log.err("Failed to read wasm archive {s}: {}", .{ path, err });
+        return err;
+    };
+
+    while (true) {
+        const member = (iter.next() catch |err| {
+            std.log.err("Failed to read wasm archive {s}: {}", .{ path, err });
+            return err;
+        }) orelse break;
+        member_count += 1;
+        try addWasmObject(ctx, module, path, member.name, member.bytes);
+    }
+
+    if (member_count == 0) {
+        std.log.err("Wasm archive {s} does not contain object members", .{path});
+        return error.EmptyArchive;
     }
 }
 
@@ -9222,21 +9268,48 @@ fn rocBuildWasmSurgical(
         return;
     }
 
-    const prepared_host = try loadPreparedWasmHost(
-        ctx,
-        cache_manager,
-        wasm_host_cache_dir,
-        link_inputs,
-        lirResultNeedsBoxyRuntime(&lowered.lir_result),
-    );
-    defer prepared_host.deinit(ctx.gpa);
+    const needs_boxy_runtime = lirResultNeedsBoxyRuntime(&lowered.lir_result);
+    var prepared_host: ?PreparedWasmHost = null;
+    defer if (prepared_host) |host| host.deinit(ctx.gpa);
+    var wasm_module_owned_here = true;
+    var wasm_module = if (needs_boxy_runtime) blk: {
+        prepared_host = try loadPreparedWasmHost(
+            ctx,
+            cache_manager,
+            wasm_host_cache_dir,
+            link_inputs,
+        );
+        break :blk try preloadWasmObject(ctx, "Boxy-prepared Wasm host", null, prepared_host.?.bytes());
+    } else backend.wasm.WasmModule.init(ctx.gpa);
+    errdefer if (wasm_module_owned_here) wasm_module.deinit();
 
-    var loaded_module = true;
-    var wasm_module = try preloadWasmObject(ctx, "prepared Wasm host", null, prepared_host.bytes());
+    if (needs_boxy_runtime) {
+        try wasm_module.prepareObjectAbiForFinalLink();
+    } else {
+        for (link_inputs.platform_files_pre) |path| {
+            try addWasmInput(ctx, &wasm_module, &owned_inputs, path);
+        }
+        for (link_inputs.platform_files_post) |path| {
+            try addWasmInput(ctx, &wasm_module, &owned_inputs, path);
+        }
+
+        try wasm_module.exportGlobalSymbols();
+        try wasm_module.prepareObjectAbiForFinalLink();
+
+        const builtins_bytes = BuiltinsObjects.forTargetExtern(.wasm32);
+        if (builtins_bytes.len > 0) {
+            var builtins_module = backend.wasm.WasmModule.preload(ctx.gpa, builtins_bytes, true) catch |err| {
+                std.log.err("Failed to preload wasm builtins: {}", .{err});
+                return err;
+            };
+            defer builtins_module.deinit();
+
+            var merge_result = try wasm_module.mergeModule(&builtins_module);
+            merge_result.deinit();
+        }
+    }
     configureWasmDataBase(&wasm_module, link_inputs.wasm);
-    errdefer if (loaded_module) wasm_module.deinit();
 
-    try wasm_module.prepareObjectAbiForFinalLink();
     try mergeBoxySidecarWasm(ctx, &wasm_module, &lowered.lir_result, .final_link);
 
     const builtin_symbols = backend.wasm.BuiltinSignatures.populateForRelocs(&wasm_module) catch |err| {
@@ -9254,7 +9327,7 @@ fn rocBuildWasmSurgical(
         target.cpuLevel(),
     );
     defer codegen.deinit();
-    loaded_module = false;
+    wasm_module_owned_here = false;
     codegen.configureBuiltinRelocs(builtin_symbols);
     codegen.configureStaticDataAddressTracking();
 
@@ -9264,7 +9337,7 @@ fn rocBuildWasmSurgical(
     try codegen.registerIndirectCallTypes();
     codegen.configureSymbolAbi();
     try codegen.registerHostedSymbolTargets(lowered.lir_result.store.getProcSpecs());
-    if (lirResultNeedsBoxyRuntime(&lowered.lir_result)) try codegen.registerBoxySymbolTargets();
+    if (needs_boxy_runtime) try codegen.registerBoxySymbolTargets();
     try codegen.compileAllProcSpecs(lowered.lir_result.store.getProcSpecs());
     try codegen.compileStaticDataRcHelpers(static_rc_helpers);
 

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -5114,7 +5114,7 @@ fn customIssue10733WasmBoxyDevCache(
         .{ .stream = .stderr, .text = "panic" },
     };
     if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
-        .args = &.{ "build", "--target=wasm32", "--opt=dev", first_output_arg },
+        .args = &.{ "build", "--target=wasm32", "--opt=dev", "--no-cache", first_output_arg },
         .roc_file = "test/wasm/boxed_closure_app.roc",
         .exit = .success,
         .contains = &contains,
@@ -5123,7 +5123,7 @@ fn customIssue10733WasmBoxyDevCache(
     if (validateIssue10733Wasm(io, allocator, timer, first_path)) |failure| return failure;
 
     if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
-        .args = &.{ "build", "--target=wasm32", "--opt=dev", second_output_arg },
+        .args = &.{ "build", "--target=wasm32", "--opt=dev", "--no-cache", second_output_arg },
         .roc_file = "test/wasm/boxed_closure_app.roc",
         .exit = .success,
         .contains = &contains,

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -5140,6 +5140,14 @@ fn customIssue10733WasmBoxyDevCache(
     if (!std.mem.eql(u8, first_bytes, second_bytes)) {
         return customFailure(allocator, timer, "cached prepared host changed the final wasm bytes", .{});
     }
+    if (std.mem.find(u8, first_bytes, "wasm_main") == null) {
+        return customFailure(allocator, timer, "prepared host lost its platform export", .{});
+    }
+    if (std.mem.find(u8, first_bytes, "roc_boxy_init_embedded") != null or
+        std.mem.find(u8, first_bytes, "roc_builtins_str_concat") != null)
+    {
+        return customFailure(allocator, timer, "prepared host leaked runtime internals into final wasm exports", .{});
+    }
 
     return null;
 }

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -381,6 +381,7 @@ const CustomCase = enum {
     default_platform_build_x64openbsd_rejected,
     default_platform_build_wasm32,
     default_platform_wasm32_archive_reproducible,
+    issue_10733_wasm_boxy_dev_cache,
     macos_output_basename_reproducible,
     default_platform_crash_x64musl,
     default_platform_crash_arm64musl,
@@ -1389,6 +1390,9 @@ const subcommand_cases = [_]CliCase{
     .{ .id = 0, .suite = .subcommands, .name = "roc build fails with invalid target error", .body = .{ .command = .{ .args = &.{ "build", "--target=invalid_target_name" }, .roc_file = "test/int/app.roc", .exit = .failure, .contains_any = &.{.{ .needles = &.{ .{ .stream = .stderr, .text = "Invalid target" }, .{ .stream = .stderr, .text = "invalid" } } }} } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build wasm32 shared module succeeds for list builtins", .body = .{ .command = .{ .args = &.{ "build", "--target=wasm32", "--no-cache" }, .roc_file = "test/wasm/list_builtin_static_lib_app.roc", .contains = &.{.{ .stream = .stdout, .text = "successfully building" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "FunctionTypeMismatch" }, .{ .stream = .stderr, .text = "panic" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build wasm32 schedules field defaults before explicit platform roots", .body = .{ .command = .{ .args = &.{ "build", "--target=wasm32", "--no-cache" }, .roc_file = "test/wasm/field_default_root_order/app.roc", .exit = .success, .contains = &.{.{ .stream = .stdout, .text = "successfully building" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "compile-time root request order placed a root before its field defaults or another dependency" }, .{ .stream = .stderr, .text = "panic" } } } } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10733: dev wasm32 caches a valid Boxy-prepared compiler-rt host", .backend = .dev, .body = .{ .custom = .issue_10733_wasm_boxy_dev_cache } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10733: LLVM size wasm32 links the Boxy runtime", .backend = .size, .body = .{ .command = .{ .args = &.{ "build", "--target=wasm32", "--opt=size", "--no-cache", "--output=boxed_closure_size.wasm" }, .roc_file = "test/wasm/boxed_closure_app.roc", .exit = .success, .contains = &.{.{ .stream = .stdout, .text = "successfully building" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "UnresolvedBuiltinImport" }, .{ .stream = .stderr, .text = "panic" } } } } },
+    .{ .id = 0, .suite = .subcommands, .name = "issue 10733: LLVM speed wasm32 links the Boxy runtime", .backend = .speed, .body = .{ .command = .{ .args = &.{ "build", "--target=wasm32", "--opt=speed", "--no-cache", "--output=boxed_closure_speed.wasm" }, .roc_file = "test/wasm/boxed_closure_app.roc", .exit = .success, .contains = &.{.{ .stream = .stdout, .text = "successfully building" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "UnresolvedBuiltinImport" }, .{ .stream = .stderr, .text = "panic" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build glibc target gives helpful error on non-Linux", .body = .{ .custom = .build_glibc_target_non_linux_error } },
     .{ .id = 0, .suite = .subcommands, .name = "roc build Shared output links a Windows DLL", .body = .{ .custom = .build_windows_shared_library } },
     .{ .id = 0, .suite = .subcommands, .name = "roc test caches passing results (interpreter)", .backend = .interpreter, .body = .{ .custom = .cache_passing_results } },
@@ -2609,6 +2613,7 @@ fn runCustomCase(
         .default_platform_build_x64openbsd_rejected => customDefaultPlatformOpenBsdRejected(io, allocator, &env, &timer, timeout_ms),
         .default_platform_build_wasm32 => customDefaultPlatformBuild(io, allocator, &env, &timer, timeout_ms, .wasm32),
         .default_platform_wasm32_archive_reproducible => customDefaultPlatformWasm32ArchiveReproducible(io, allocator, &env, &timer, timeout_ms),
+        .issue_10733_wasm_boxy_dev_cache => customIssue10733WasmBoxyDevCache(io, allocator, &env, &timer, timeout_ms),
         .macos_output_basename_reproducible => customMacosOutputBasenameReproducible(io, allocator, &env, &timer, timeout_ms),
         .default_platform_crash_x64musl => customDefaultPlatformDebugBacktrace(io, allocator, &env, &timer, timeout_ms, .x64musl, .crash),
         .default_platform_crash_arm64musl => customDefaultPlatformDebugBacktrace(io, allocator, &env, &timer, timeout_ms, .arm64musl, .crash),
@@ -5059,6 +5064,81 @@ fn customDefaultPlatformWasm32ArchiveReproducible(
         if (!std.mem.eql(u8, first, second)) {
             return customFailure(allocator, timer, "default wasm {s} archive bytes were not reproducible", .{opt});
         }
+    }
+
+    return null;
+}
+
+fn validateIssue10733Wasm(
+    io: std.Io,
+    allocator: Allocator,
+    timer: *harness.Timer,
+    path: []const u8,
+) ?TestResult {
+    const wasm_bytes = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .unlimited) catch |err|
+        return customInfraFailure(allocator, timer, "failed to read wasm output {s}: {}", .{ path, err });
+    defer allocator.free(wasm_bytes);
+
+    var module_def = bytebox.createModuleDefinition(allocator, .{ .debug_name = "issue_10733_boxy" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to create wasm validator: {}", .{err});
+    defer module_def.destroy();
+    module_def.decode(wasm_bytes) catch |err|
+        return customFailure(allocator, timer, "generated invalid wasm {s}: {}", .{ path, err });
+    return null;
+}
+
+fn customIssue10733WasmBoxyDevCache(
+    io: std.Io,
+    allocator: Allocator,
+    env: *const CaseEnv,
+    timer: *harness.Timer,
+    timeout_ms: u64,
+) ?TestResult {
+    const first_path = std.fs.path.join(allocator, &.{ env.dirs.work_dir, "boxed-first.wasm" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate first wasm output path: {}", .{err});
+    defer allocator.free(first_path);
+    const second_path = std.fs.path.join(allocator, &.{ env.dirs.work_dir, "boxed-second.wasm" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate second wasm output path: {}", .{err});
+    defer allocator.free(second_path);
+    const first_output_arg = outputArg(allocator, first_path) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate first wasm output argument: {}", .{err});
+    defer allocator.free(first_output_arg);
+    const second_output_arg = outputArg(allocator, second_path) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate second wasm output argument: {}", .{err});
+    defer allocator.free(second_output_arg);
+
+    const contains = [_]OutputNeedle{.{ .stream = .stdout, .text = "successfully building" }};
+    const not_contains = [_]OutputNeedle{
+        .{ .stream = .stderr, .text = "DuplicateSymbol" },
+        .{ .stream = .stderr, .text = "UnresolvedBuiltinImport" },
+        .{ .stream = .stderr, .text = "panic" },
+    };
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "build", "--target=wasm32", "--opt=dev", first_output_arg },
+        .roc_file = "test/wasm/boxed_closure_app.roc",
+        .exit = .success,
+        .contains = &contains,
+        .not_contains = &not_contains,
+    })) |failure| return failure;
+    if (validateIssue10733Wasm(io, allocator, timer, first_path)) |failure| return failure;
+
+    if (runRocAndCheck(io, allocator, env, timer, timeout_ms, .{
+        .args = &.{ "build", "--target=wasm32", "--opt=dev", second_output_arg },
+        .roc_file = "test/wasm/boxed_closure_app.roc",
+        .exit = .success,
+        .contains = &contains,
+        .not_contains = &not_contains,
+    })) |failure| return failure;
+    if (validateIssue10733Wasm(io, allocator, timer, second_path)) |failure| return failure;
+
+    const first_bytes = std.Io.Dir.cwd().readFileAlloc(io, first_path, allocator, .unlimited) catch |err|
+        return customInfraFailure(allocator, timer, "failed to reread first wasm output: {}", .{err});
+    defer allocator.free(first_bytes);
+    const second_bytes = std.Io.Dir.cwd().readFileAlloc(io, second_path, allocator, .unlimited) catch |err|
+        return customInfraFailure(allocator, timer, "failed to reread cached wasm output: {}", .{err});
+    defer allocator.free(second_bytes);
+    if (!std.mem.eql(u8, first_bytes, second_bytes)) {
+        return customFailure(allocator, timer, "cached prepared host changed the final wasm bytes", .{});
     }
 
     return null;

--- a/src/compile/cache_cleanup.zig
+++ b/src/compile/cache_cleanup.zig
@@ -2,7 +2,7 @@
 //!
 //! This module provides background cleanup functionality that:
 //! - Removes temporary runtime directories older than 5 minutes
-//! - Removes persistent cache files (mod/, exe/, and test/) older than 30 days
+//! - Removes persistent cache files (mod/, exe/, test/, and wasm-host/) older than 30 days
 //!
 //! The cleanup runs on a single background thread that is fire-and-forget:
 //! it exits automatically when done, and if the main process exits first,
@@ -202,7 +202,7 @@ fn cleanupTempDirs(std_io: Io, temp_base: []const u8, now_ns: i128, maybe_stats:
 
 /// Clean up persistent cache files older than 30 days.
 ///
-/// Layout: `<cache_base>/<version>/{mod,exe,test}/...`.
+/// Layout: `<cache_base>/<version>/{mod,exe,test,wasm-host}/...`.
 fn cleanupPersistentCache(std_io: Io, cache_base: []const u8, now_ns: i128, maybe_stats: ?*CleanupStats) void {
     var base_dir = Dir.cwd().openDir(std_io, cache_base, .{ .iterate = true }) catch return;
     defer base_dir.close(std_io);
@@ -215,6 +215,7 @@ fn cleanupPersistentCache(std_io: Io, cache_base: []const u8, now_ns: i128, mayb
         .{ .name = "mod", .nested_directory_depth = 1 },
         .{ .name = "exe", .nested_directory_depth = 1 },
         .{ .name = "test", .nested_directory_depth = 1 },
+        .{ .name = "wasm-host", .nested_directory_depth = 1 },
         .{ .name = "glue-dylib", .nested_directory_depth = 2 },
     };
 
@@ -239,7 +240,7 @@ fn cleanupPersistentCache(std_io: Io, cache_base: []const u8, now_ns: i128, mayb
 
 /// Clean up files in a cache subdirectory older than 30 days. The caller passes
 /// the exact nested directory depth for the cache family: one bucket level for
-/// mod/exe/test and target/opt levels for glue dylibs.
+/// mod/exe/test/wasm-host and target/opt levels for glue dylibs.
 fn cleanupCacheSubdir(std_io: Io, subdir: Dir, now_ns: i128, maybe_stats: ?*CleanupStats, nested_directory_depth: u8) void {
     var it = subdir.iterate();
     while (true) {
@@ -472,7 +473,7 @@ test "cleanupCacheSubdir deletes old files and keeps new files" {
     };
 }
 
-test "cleanupPersistentCache deletes old glue dylib files at target opt depth" {
+test "cleanupPersistentCache deletes old cache files at each family depth" {
     const allocator = std.testing.allocator;
 
     var tmp_dir = std.testing.tmpDir(.{});
@@ -486,9 +487,12 @@ test "cleanupPersistentCache deletes old glue dylib files at target opt depth" {
 
     const mod_dir = std.fs.path.join(allocator, &.{ cache_base, "0.0.0-test", "mod", "aa" }) catch unreachable;
     defer allocator.free(mod_dir);
+    const wasm_host_dir = std.fs.path.join(allocator, &.{ cache_base, "0.0.0-test", "wasm-host", "bb" }) catch unreachable;
+    defer allocator.free(wasm_host_dir);
 
     Dir.cwd().createDirPath(std.testing.io, glue_dir) catch unreachable;
     Dir.cwd().createDirPath(std.testing.io, mod_dir) catch unreachable;
+    Dir.cwd().createDirPath(std.testing.io, wasm_host_dir) catch unreachable;
 
     const glue_file = std.fs.path.join(allocator, &.{ glue_dir, "old.dylib" }) catch unreachable;
     defer allocator.free(glue_file);
@@ -496,17 +500,20 @@ test "cleanupPersistentCache deletes old glue dylib files at target opt depth" {
     defer allocator.free(glue_tmp);
     const mod_file = std.fs.path.join(allocator, &.{ mod_dir, "old.rcache" }) catch unreachable;
     defer allocator.free(mod_file);
+    const wasm_host_file = std.fs.path.join(allocator, &.{ wasm_host_dir, "old-host" }) catch unreachable;
+    defer allocator.free(wasm_host_file);
 
     (Dir.cwd().createFile(std.testing.io, glue_file, .{}) catch unreachable).close(std.testing.io);
     (Dir.cwd().createFile(std.testing.io, glue_tmp, .{}) catch unreachable).close(std.testing.io);
     (Dir.cwd().createFile(std.testing.io, mod_file, .{}) catch unreachable).close(std.testing.io);
+    (Dir.cwd().createFile(std.testing.io, wasm_host_file, .{}) catch unreachable).close(std.testing.io);
 
     const now_ns = nowNs(std.testing.io);
     const far_future_ns: i128 = now_ns + Config.PERSISTENT_MAX_AGE_NS + std.time.ns_per_s;
     var stats = CleanupStats{};
     cleanupPersistentCache(std.testing.io, cache_base, far_future_ns, &stats);
 
-    try std.testing.expectEqual(@as(u32, 3), stats.cache_files_deleted);
+    try std.testing.expectEqual(@as(u32, 4), stats.cache_files_deleted);
 
     Dir.cwd().access(std.testing.io, glue_file, .{}) catch |err| {
         try std.testing.expectEqual(error.FileNotFound, err);
@@ -515,6 +522,9 @@ test "cleanupPersistentCache deletes old glue dylib files at target opt depth" {
         try std.testing.expectEqual(error.FileNotFound, err);
     };
     Dir.cwd().access(std.testing.io, mod_file, .{}) catch |err| {
+        try std.testing.expectEqual(error.FileNotFound, err);
+    };
+    Dir.cwd().access(std.testing.io, wasm_host_file, .{}) catch |err| {
         try std.testing.expectEqual(error.FileNotFound, err);
     };
 }

--- a/src/compile/cache_cleanup.zig
+++ b/src/compile/cache_cleanup.zig
@@ -247,6 +247,10 @@ fn cleanupCacheSubdir(std_io: Io, subdir: Dir, now_ns: i128, maybe_stats: ?*Clea
         const entry = (it.next(std_io) catch break) orelse break;
 
         if (entry.kind == .file) {
+            // A lock file names a stable cache identity. Removing it while a
+            // process holds the lock would let another process create a new
+            // inode and enter the same critical section concurrently.
+            if (std.mem.endsWith(u8, entry.name, ".lock")) continue;
             deleteCacheFileIfOld(std_io, subdir, entry.name, now_ns, maybe_stats);
         } else if (entry.kind == .directory and nested_directory_depth > 0) {
             var child = subdir.openDir(std_io, entry.name, .{ .iterate = true }) catch continue;
@@ -502,11 +506,14 @@ test "cleanupPersistentCache deletes old cache files at each family depth" {
     defer allocator.free(mod_file);
     const wasm_host_file = std.fs.path.join(allocator, &.{ wasm_host_dir, "old-host" }) catch unreachable;
     defer allocator.free(wasm_host_file);
+    const wasm_host_lock = std.fs.path.join(allocator, &.{ wasm_host_dir, "old-host.lock" }) catch unreachable;
+    defer allocator.free(wasm_host_lock);
 
     (Dir.cwd().createFile(std.testing.io, glue_file, .{}) catch unreachable).close(std.testing.io);
     (Dir.cwd().createFile(std.testing.io, glue_tmp, .{}) catch unreachable).close(std.testing.io);
     (Dir.cwd().createFile(std.testing.io, mod_file, .{}) catch unreachable).close(std.testing.io);
     (Dir.cwd().createFile(std.testing.io, wasm_host_file, .{}) catch unreachable).close(std.testing.io);
+    (Dir.cwd().createFile(std.testing.io, wasm_host_lock, .{}) catch unreachable).close(std.testing.io);
 
     const now_ns = nowNs(std.testing.io);
     const far_future_ns: i128 = now_ns + Config.PERSISTENT_MAX_AGE_NS + std.time.ns_per_s;
@@ -527,4 +534,5 @@ test "cleanupPersistentCache deletes old cache files at each family depth" {
     Dir.cwd().access(std.testing.io, wasm_host_file, .{}) catch |err| {
         try std.testing.expectEqual(error.FileNotFound, err);
     };
+    try Dir.cwd().access(std.testing.io, wasm_host_lock, .{});
 }

--- a/src/compile/cache_config.zig
+++ b/src/compile/cache_config.zig
@@ -259,6 +259,14 @@ pub const CacheConfig = struct {
         return std.fs.path.join(allocator, &[_][]const u8{ version_dir, "test" });
     }
 
+    /// Get the prepared Wasm host cache directory.
+    pub fn getWasmHostCacheDir(self: Self, allocator: Allocator) (Allocator.Error || error{NoHomeDirectory})![]u8 {
+        const version_dir = try self.getVersionCacheDir(allocator);
+        defer allocator.free(version_dir);
+
+        return std.fs.path.join(allocator, &[_][]const u8{ version_dir, "wasm-host" });
+    }
+
     /// Get the cache entries directory (alias for module cache dir).
     pub fn getCacheEntriesDir(self: Self, allocator: Allocator) (Allocator.Error || error{NoHomeDirectory})![]u8 {
         return self.getModuleCacheDir(allocator);

--- a/test/wasm/boxed_closure_app.roc
+++ b/test/wasm/boxed_closure_app.roc
@@ -1,0 +1,3 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+main! = || Box.unbox(Box.box(|| "ok"))()


### PR DESCRIPTION
Fixes #10733.

Wasm dev builds now cache a content-addressed relocatable host prepared by LLD with Roc builtins and the explicitly required Boxy runtime, leaving app code and its exact sidecar for the fast surgical link. This gives LLD sole ownership of weak/strong compiler-rt and COMDAT resolution. Optimized Wasm builds now include the Boxy runtime and sidecar in their combined app object and always use the final Wasm LLD path.

The standalone Wasm Boxy runtime uses direct sidecar relocations so they survive host preparation, and surgical finalization explicitly promotes Wasm object ABI globals and the indirect-function table to valid final definitions.