### PR TITLE
Reduce SIMD differential shift work

### DIFF
--- a/design.md
+++ b/design.md
@@ -11047,14 +11047,15 @@ and verifies direct and nested vector values in both call directions.
 standalone dev and LLVM programs, optimized compile-time tests, every evaluator
 backend, and the Lambda Mono comparison in sequence. The corpus contains 294
 operation/type cases, fixed boundary values, algebraic properties, and at least
-64 deterministic generated inputs per applicable case. Every shift operation is
-checked directly against the scalar oracle for every count from zero through one
-less than the lane width,
-then all 256 possible `U8` counts are proven equal to their oracle-checked
-modulo-lane-width count. This targeted loop does not repeat count-independent
-cases. Checked memory access pins the final valid 16-byte window, the first
-invalid offset, and `U64.highest`; every public
-lane accessor pins its exact first-invalid index. The corpus is opt-in to
+64 deterministic generated inputs per applicable case. Every generated input
+checks each shift operation directly against the scalar oracle at its generated
+count. A separate pinned vector with populated high and low bits in every lane
+checks each in-range count directly against the oracle, then proves all 256
+possible `U8` counts equal to their oracle-checked modulo-lane-width count. This
+keeps the exhaustive count proof out of the generated-input Cartesian product
+and does not repeat count-independent cases. Checked memory access pins the
+final valid 16-byte window, the first invalid offset, and `U64.highest`; every
+public lane accessor pins its exact first-invalid index. The corpus is opt-in to
 ordinary test enumeration so the normal eval and Lambda Mono steps do not run
 it twice, but MiniCI runs the dedicated no-skip gate explicitly.
 The full Lambda Mono body-lowering differential sweep over the ordinary eval

--- a/test/simd/SimdDifferential.roc
+++ b/test/simd/SimdDifferential.roc
@@ -2,7 +2,8 @@
 # independent scalar { bits : U128 } oracle. Every invocation checks every
 # supported low-level/type combination over 64 deterministic pseudo-random
 # vectors and the pinned edge corpus. Shift operations additionally cover all
-# 256 possible U8 counts without repeating count-independent operations.
+# 256 possible U8 counts on a pinned vector whose lanes distinguish every
+# effective count, without taking the Cartesian product with generated inputs.
 
 import oracle.SimdOracle
 
@@ -1320,6 +1321,24 @@ SimdDifferential := [].{
 		{}
 	}
 
+	check_shift_count_corpus : {} -> {}
+	check_shift_count_corpus = |_| {
+		# Repeated 0x81 bytes give every signed and unsigned lane width populated
+		# high and low bits, so each effective left, logical-right, and
+		# arithmetic-right count has a distinct result.
+		bits = 0x81818181818181818181818181818181.U128
+		var $count = 0.U64
+		while $count < 256 {
+			count = $count.to_u8_wrap()
+			if count < 64 {
+				check_shift_reference_count(bits, count)
+			} else {}
+			check_shift_masked_count(bits, count)
+			$count = $count + 1
+		}
+		{}
+	}
+
 	check_load_store_out_of_bounds : U128, List(U8), U64 -> {}
 	check_load_store_out_of_bounds = |bits, bytes, index| {
 		match U8x16.load(bytes, index) {
@@ -1653,6 +1672,7 @@ SimdDifferential := [].{
 	run_corpus : U128 -> Bool
 	run_corpus = |seed| {
 		check_edge_corpus({})
+		check_shift_count_corpus({})
 		var $state = seed
 		var $i = 0.U64
 		while $i < 64 {
@@ -1667,18 +1687,6 @@ SimdDifferential := [].{
 			# Count-independent operations, lane access, concat, and memory
 			# operations run once for each generated vector.
 			check_all(a, b, c, a.to_u8_wrap(), bytes)
-			# Shift semantics accept U8, so this loop proves every possible count.
-			# Canonical counts are checked directly against the scalar oracle; all
-			# other counts are proven equal to their checked modulo-width count.
-			var $count = 0.U64
-			while $count < 256 {
-				count = $count.to_u8_wrap()
-				if count < 64 {
-					check_shift_reference_count(a, count)
-				} else {}
-				check_shift_masked_count(a, count)
-				$count = $count + 1
-			}
 			$i = $i + 1
 		}
 		Bool.True


### PR DESCRIPTION
The SIMD differential corpus currently takes the Cartesian product of 64 generated vectors and all 256 shift counts in every compiler consumer, which can exceed the evaluator's per-case timeout on noisy CI runners. This keeps every generated-vector comparison and the exhaustive 0–255 count proof, but runs the latter once on a pinned vector whose lanes distinguish every effective shift count.