### PR TITLE
Fix duplicate Dict.iter definition that breaks the build on main

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -5941,32 +5941,6 @@ Builtin :: [].{
 			}
 		}
 
-		## Iterate over the key-value pairs of a dictionary, in the same order
-		## as [Dict.to_list].
-		## ```roc
-		## expect List.from_iter(Dict.empty()
-		##            .insert("Apples", 12.U64)
-		##            .insert("Oranges", 24)
-		##            .iter()) == [("Apples", 12), ("Oranges", 24)]
-		## ```
-		iter : Dict(k, v) -> Iter((k, v))
-		iter = |dict| match dict {
-			HashMap(data) => {
-				entries_len = List.len(data.entries)
-
-				Iter.custom(
-					0,
-					Known(entries_len),
-					|index|
-						if index == entries_len {
-							Err(NoMore)
-						} else {
-							Ok((list_get_unsafe(data.entries, index), index + 1))
-						},
-				)
-			}
-		}
-
 		## Build a value by folding through each key-value pair in the
 		## dictionary. Starting with a given `state` value, this runs the
 		## given `step` function on each pair, using its return value as


### PR DESCRIPTION
## Problem

Main does not build from a fresh checkout: compiling `Builtin.roc` fails with a DUPLICATE DEFINITION canonicalize error during the `builtin_compiler` build step.

#10680 (`9d559d6a86`) and #10735 (`7c79456e37`) each added a `Dict.iter`. Both PRs were green individually and merged without textual conflict, but together they define `iter` twice in the Dict scope.

## Fix

Keep the `List.iter`-delegating definition that pairs with the adjacent `iter_rev`, and delete the second, `Iter.custom`-based definition (they are functionally equivalent — both iterate `data.entries` in order).

Verified the builtin compile step and `zig build minici` pass with this change (as part of #10756, which carries this same commit and can be rebased once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)