### PR TITLE
Fix specialization-pipeline perf pathologies: roc-pdf `--opt=speed` build 11m38s -> 39.8s (#10758)

### DIFF
--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -308,6 +308,12 @@ pub const MonoLlvmCodeGen = struct {
     loop_break_blocks: std.ArrayList(LlvmBuilder.Function.Block.Index),
     local_slots: []LocalSlot = &.{},
     deferred_str_captures: []?DeferredStrCapture = &.{},
+    /// Indices of `deferred_str_captures` slots that may be non-null. The
+    /// slot array spans every LIR local, so the clear-all and scan-all
+    /// operations that run per jump and per call must touch only the handful
+    /// of live captures rather than the whole program's local space. Entries
+    /// go stale when a single capture is cleared; readers skip null slots.
+    deferred_str_capture_actives: std.ArrayList(u32) = .empty,
     string_counter: u32 = 0,
     /// When true the module is built with DWARF debug info: a compile unit,
     /// one subprogram per proc, and per-statement line locations from the
@@ -1695,7 +1701,10 @@ pub const MonoLlvmCodeGen = struct {
         const outer_ret_layout = self.current_ret_layout;
         const outer_slots = self.local_slots;
         const outer_deferred_str_captures = self.deferred_str_captures;
+        const outer_deferred_str_capture_actives = self.deferred_str_capture_actives;
         defer {
+            self.deferred_str_capture_actives.deinit(self.allocator);
+            self.deferred_str_capture_actives = outer_deferred_str_capture_actives;
             self.wip = outer_wip;
             self.rc_arg_scratch = outer_rc_scratch;
             self.roc_ops_arg = outer_roc_ops;
@@ -1814,7 +1823,8 @@ pub const MonoLlvmCodeGen = struct {
         defer self.allocator.free(self.local_slots);
         self.deferred_str_captures = try self.allocator.alloc(?DeferredStrCapture, self.store.localCount());
         defer self.allocator.free(self.deferred_str_captures);
-        self.clearDeferredStrCaptures();
+        self.deferred_str_capture_actives = .empty;
+        @memset(self.deferred_str_captures, null);
         try self.allocProcLocalSlots(proc);
         try self.unpackProcArgs(proc);
         if (proc.boxy_runtime_entry) try self.emitBoxyRuntimeInit();
@@ -7575,15 +7585,20 @@ pub const MonoLlvmCodeGen = struct {
     }
 
     fn clearDeferredStrCaptures(self: *MonoLlvmCodeGen) void {
-        for (self.deferred_str_captures) |*capture| {
-            capture.* = null;
+        for (self.deferred_str_capture_actives.items) |index| {
+            self.deferred_str_captures[index] = null;
         }
+        self.deferred_str_capture_actives.clearRetainingCapacity();
     }
 
     fn installDeferredStrCapture(self: *MonoLlvmCodeGen, local: LocalId, capture: DeferredStrCapture) Error!void {
         if (!self.isStrLocal(local)) return error.CompilationFailed;
         try self.prepareLocalWrite(local);
-        self.deferred_str_captures[@intFromEnum(local)] = capture;
+        const capture_slot = &self.deferred_str_captures[@intFromEnum(local)];
+        if (capture_slot.* == null) {
+            self.deferred_str_capture_actives.append(self.allocator, @intFromEnum(local)) catch return error.OutOfMemory;
+        }
+        capture_slot.* = capture;
     }
 
     fn deferredStrCapture(self: *MonoLlvmCodeGen, local: LocalId) ?DeferredStrCapture {
@@ -7619,9 +7634,10 @@ pub const MonoLlvmCodeGen = struct {
 
     fn materializeAllDeferredStrCaptures(self: *MonoLlvmCodeGen) Error!void {
         var index: usize = 0;
-        while (index < self.deferred_str_captures.len) : (index += 1) {
-            if (self.deferred_str_captures[index] != null) {
-                try self.materializeLocalIfDeferred(@enumFromInt(@as(u32, @intCast(index))));
+        while (index < self.deferred_str_capture_actives.items.len) : (index += 1) {
+            const local_index = self.deferred_str_capture_actives.items[index];
+            if (self.deferred_str_captures[local_index] != null) {
+                try self.materializeLocalIfDeferred(@enumFromInt(local_index));
             }
         }
     }
@@ -7637,10 +7653,11 @@ pub const MonoLlvmCodeGen = struct {
 
     fn materializeDeferredCapturesUsingSource(self: *MonoLlvmCodeGen, source: LocalId) Error!void {
         var index: usize = 0;
-        while (index < self.deferred_str_captures.len) : (index += 1) {
-            const capture = self.deferred_str_captures[index] orelse continue;
-            if (capture.source_local == source and index != @intFromEnum(source)) {
-                try self.materializeLocalIfDeferred(@enumFromInt(@as(u32, @intCast(index))));
+        while (index < self.deferred_str_capture_actives.items.len) : (index += 1) {
+            const local_index = self.deferred_str_capture_actives.items[index];
+            const capture = self.deferred_str_captures[local_index] orelse continue;
+            if (capture.source_local == source and local_index != @intFromEnum(source)) {
+                try self.materializeLocalIfDeferred(@enumFromInt(local_index));
             }
         }
     }

--- a/src/collections/DenseMap.zig
+++ b/src/collections/DenseMap.zig
@@ -47,6 +47,11 @@ pub fn DenseMap(comptime K: type, comptime V: type) type {
 
         allocator: Allocator,
         sparse_chunks: std.ArrayList(?*SparseChunk) = .empty,
+        /// Chunk index of `sparse_chunks.items[0]`. The chunk-pointer array
+        /// spans only the touched chunk range, so a map holding a few entries
+        /// with large IDs costs a few slots rather than a slot for every
+        /// chunk between ID zero and the highest touched ID.
+        chunk_base: usize = 0,
         active_indices: std.ArrayList(usize) = .empty,
         values: std.ArrayList(V) = .empty,
 
@@ -169,6 +174,7 @@ pub fn DenseMap(comptime K: type, comptime V: type) type {
 
         pub fn clearAndFree(self: *Self) void {
             self.freeChunks();
+            self.chunk_base = 0;
             self.sparse_chunks.clearAndFree(self.allocator);
             self.active_indices.clearAndFree(self.allocator);
             self.values.clearAndFree(self.allocator);
@@ -224,32 +230,54 @@ pub fn DenseMap(comptime K: type, comptime V: type) type {
 
         fn ensureSparseSlot(self: *Self, index: usize) Allocator.Error!*u32 {
             const chunk_index = index >> chunk_shift;
-            if (chunk_index >= self.sparse_chunks.items.len) {
+            if (self.sparse_chunks.items.len == 0) {
+                try self.sparse_chunks.append(self.allocator, null);
+                self.chunk_base = chunk_index;
+            } else if (chunk_index < self.chunk_base) {
+                // Grow toward low IDs by at least the current span so
+                // alternating low/high inserts stay amortized O(1) per slot.
+                const needed = self.chunk_base - chunk_index;
+                const grow = @min(self.chunk_base, @max(needed, self.sparse_chunks.items.len));
                 const old_len = self.sparse_chunks.items.len;
-                try self.sparse_chunks.resize(self.allocator, chunk_index + 1);
+                try self.sparse_chunks.resize(self.allocator, old_len + grow);
+                std.mem.copyBackwards(
+                    ?*SparseChunk,
+                    self.sparse_chunks.items[grow..],
+                    self.sparse_chunks.items[0..old_len],
+                );
+                @memset(self.sparse_chunks.items[0..grow], null);
+                self.chunk_base -= grow;
+            } else if (chunk_index - self.chunk_base >= self.sparse_chunks.items.len) {
+                const old_len = self.sparse_chunks.items.len;
+                try self.sparse_chunks.resize(self.allocator, chunk_index - self.chunk_base + 1);
                 @memset(self.sparse_chunks.items[old_len..], null);
             }
 
-            if (self.sparse_chunks.items[chunk_index] == null) {
+            const slot_index = chunk_index - self.chunk_base;
+            if (self.sparse_chunks.items[slot_index] == null) {
                 const chunk = try self.allocator.create(SparseChunk);
                 @memset(chunk, empty_position);
-                self.sparse_chunks.items[chunk_index] = chunk;
+                self.sparse_chunks.items[slot_index] = chunk;
             }
 
-            return &self.sparse_chunks.items[chunk_index].?[index & chunk_mask];
+            return &self.sparse_chunks.items[slot_index].?[index & chunk_mask];
         }
 
         fn sparseSlotPtr(self: *Self, index: usize) ?*u32 {
             const chunk_index = index >> chunk_shift;
-            if (chunk_index >= self.sparse_chunks.items.len) return null;
-            const chunk = self.sparse_chunks.items[chunk_index] orelse return null;
+            if (chunk_index < self.chunk_base) return null;
+            const slot_index = chunk_index - self.chunk_base;
+            if (slot_index >= self.sparse_chunks.items.len) return null;
+            const chunk = self.sparse_chunks.items[slot_index] orelse return null;
             return &chunk[index & chunk_mask];
         }
 
         fn sparseSlotPtrConst(self: *const Self, index: usize) ?*const u32 {
             const chunk_index = index >> chunk_shift;
-            if (chunk_index >= self.sparse_chunks.items.len) return null;
-            const chunk = self.sparse_chunks.items[chunk_index] orelse return null;
+            if (chunk_index < self.chunk_base) return null;
+            const slot_index = chunk_index - self.chunk_base;
+            if (slot_index >= self.sparse_chunks.items.len) return null;
+            const chunk = self.sparse_chunks.items[slot_index] orelse return null;
             return &chunk[index & chunk_mask];
         }
 
@@ -279,6 +307,58 @@ pub fn DenseMap(comptime K: type, comptime V: type) type {
             for (self.sparse_chunks.items) |maybe_chunk| {
                 if (maybe_chunk) |chunk| self.allocator.destroy(chunk);
             }
+        }
+    };
+}
+
+/// A pool of reusable `DenseMap`s for passes that repeatedly need short-lived
+/// maps over the same large ID domain. A fresh map must allocate and zero its
+/// sparse chunks on every first touch, which dominates passes that create one
+/// map per work item; pooled maps keep their chunks and dense capacity across
+/// uses, so only the live entries of each use are ever cleared. The pool hands
+/// out maps by value, so nested scopes may acquire further maps while an outer
+/// one is still in use.
+pub fn DenseMapPool(comptime K: type, comptime V: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const Map = DenseMap(K, V);
+
+        /// Maps kept beyond this many are freed on release instead of pooled.
+        const max_pooled = 8;
+
+        allocator: Allocator,
+        maps: [max_pooled]Map = undefined,
+        len: usize = 0,
+
+        pub fn init(allocator: Allocator) Self {
+            return .{ .allocator = allocator };
+        }
+
+        pub fn deinit(self: *Self) void {
+            for (self.maps[0..self.len]) |*map| map.deinit();
+            self.* = undefined;
+        }
+
+        /// An empty map, reusing a pooled map's storage when one is available.
+        pub fn acquire(self: *Self) Map {
+            if (self.len > 0) {
+                self.len -= 1;
+                return self.maps[self.len];
+            }
+            return Map.init(self.allocator);
+        }
+
+        /// Return an acquired map to the pool. The caller's map is consumed.
+        pub fn release(self: *Self, map: *Map) void {
+            if (self.len == max_pooled) {
+                map.deinit();
+                return;
+            }
+            map.clearRetainingCapacity();
+            self.maps[self.len] = map.*;
+            self.len += 1;
+            map.* = undefined;
         }
     };
 }
@@ -343,8 +423,45 @@ test "DenseMap directly indexes integer and enum IDs" {
     defer sparse_map.deinit();
     try sparse_map.put(1_000_000, 9);
     try std.testing.expectEqual(@as(?u8, 9), sparse_map.get(1_000_000));
-    try std.testing.expect(sparse_map.sparse_chunks.items.len < 4_000);
+    // The chunk-pointer array is base-offset: one entry at a large ID costs
+    // one slot, not a slot per chunk below it.
+    try std.testing.expectEqual(@as(usize, 1), sparse_map.sparse_chunks.items.len);
     try std.testing.expectEqual(@as(usize, 1), sparse_map.values.items.len);
+}
+
+test "DenseMap chunk window grows toward low and high IDs" {
+    var map = DenseMap(u32, u32).init(std.testing.allocator);
+    defer map.deinit();
+
+    try map.put(1_000_000, 1);
+    try map.put(999_000, 2);
+    try map.put(5, 3);
+    try map.put(2_000_000, 4);
+    try std.testing.expectEqual(@as(?u32, 1), map.get(1_000_000));
+    try std.testing.expectEqual(@as(?u32, 2), map.get(999_000));
+    try std.testing.expectEqual(@as(?u32, 3), map.get(5));
+    try std.testing.expectEqual(@as(?u32, 4), map.get(2_000_000));
+    try std.testing.expectEqual(@as(?u32, null), map.get(999_999));
+    try std.testing.expectEqual(@as(?u32, null), map.get(0));
+    try std.testing.expectEqual(@as(usize, 4), map.count());
+
+    try std.testing.expect(map.remove(5));
+    try std.testing.expectEqual(@as(?u32, null), map.get(5));
+    map.clearRetainingCapacity();
+    try std.testing.expectEqual(@as(?u32, null), map.get(1_000_000));
+    try map.put(1_000_000, 7);
+    try std.testing.expectEqual(@as(?u32, 7), map.get(1_000_000));
+
+    // Regression: growing toward low IDs when the window is already wider
+    // than the room below it must clamp instead of underflowing chunk_base.
+    var low_map = DenseMap(u32, u32).init(std.testing.allocator);
+    defer low_map.deinit();
+    try low_map.put(300, 1);
+    try low_map.put(5_000, 2);
+    try low_map.put(10, 3);
+    try std.testing.expectEqual(@as(?u32, 1), low_map.get(300));
+    try std.testing.expectEqual(@as(?u32, 2), low_map.get(5_000));
+    try std.testing.expectEqual(@as(?u32, 3), low_map.get(10));
 }
 
 test "DenseMap swap-removes and clears compact values" {
@@ -373,4 +490,28 @@ test "DenseMap swap-removes and clears compact values" {
     try set.put(@enumFromInt(900), {});
     try std.testing.expect(set.contains(@enumFromInt(900)));
     try std.testing.expect(set.remove(@enumFromInt(900)));
+}
+
+test "DenseMapPool reuses released map storage and supports nested acquires" {
+    const TestId = enum(u32) { _ };
+    var pool = DenseMapPool(TestId, u32).init(std.testing.allocator);
+    defer pool.deinit();
+
+    var outer = pool.acquire();
+    try outer.put(@enumFromInt(5_000), 1);
+    const outer_chunks = outer.sparse_chunks.items.len;
+
+    var inner = pool.acquire();
+    try inner.put(@enumFromInt(5_000), 2);
+    try std.testing.expectEqual(@as(?u32, 1), outer.get(@enumFromInt(5_000)));
+    pool.release(&inner);
+    pool.release(&outer);
+
+    var reused = pool.acquire();
+    defer pool.release(&reused);
+    try std.testing.expectEqual(@as(usize, 0), reused.count());
+    try std.testing.expectEqual(@as(?u32, null), reused.get(@enumFromInt(5_000)));
+    try std.testing.expectEqual(outer_chunks, reused.sparse_chunks.items.len);
+    try reused.put(@enumFromInt(5_000), 3);
+    try std.testing.expectEqual(@as(?u32, 3), reused.get(@enumFromInt(5_000)));
 }

--- a/src/collections/mod.zig
+++ b/src/collections/mod.zig
@@ -35,6 +35,7 @@ pub const GuardedList = @import("GuardedList.zig");
 pub const SafeStringHashMap = @import("safe_hash_map.zig").SafeStringHashMap;
 
 pub const DenseMap = @import("DenseMap.zig").DenseMap;
+pub const DenseMapPool = @import("DenseMap.zig").DenseMapPool;
 
 pub const SortedArrayBuilder = @import("SortedArrayBuilder.zig").SortedArrayBuilder;
 pub const ExposedItems = @import("ExposedItems.zig").ExposedItems;

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -124,6 +124,13 @@ const Solver = struct {
     /// back-references to their existing vars exactly as an eager clone's
     /// per-call memo did. Allocated on a leaf's first expansion.
     leaf_contexts: std.ArrayList(collections.DenseMap(MonoType.TypeId, Type.TypeVarId)),
+    /// Pools for the short-lived maps the solver creates per work item (clone
+    /// memos, visited sets). Their sparse chunks span the large type ID
+    /// domains, so per-item fresh maps would spend most of their time
+    /// allocating and zeroing chunks; pooled maps keep chunks across uses.
+    solved_set_pool: collections.DenseMapPool(Type.TypeVarId, void),
+    mono_set_pool: collections.DenseMapPool(MonoType.TypeId, void),
+    clone_map_pool: collections.DenseMapPool(MonoType.TypeId, Type.TypeVarId),
 
     const FunctionShape = struct {
         args: Type.Span,
@@ -235,10 +242,16 @@ const Solver = struct {
             .contains_forced_dynamic = masks.contains_forced_dynamic,
             .shared_clones = collections.DenseMap(MonoType.TypeId, Type.TypeVarId).init(allocator),
             .leaf_contexts = .empty,
+            .solved_set_pool = collections.DenseMapPool(Type.TypeVarId, void).init(allocator),
+            .mono_set_pool = collections.DenseMapPool(MonoType.TypeId, void).init(allocator),
+            .clone_map_pool = collections.DenseMapPool(MonoType.TypeId, Type.TypeVarId).init(allocator),
         };
     }
 
     fn deinit(self: *Solver) void {
+        self.clone_map_pool.deinit();
+        self.mono_set_pool.deinit();
+        self.solved_set_pool.deinit();
         for (self.leaf_contexts.items) |*ctx| ctx.deinit();
         self.leaf_contexts.deinit(self.allocator);
         self.shared_clones.deinit();
@@ -1228,8 +1241,8 @@ const Solver = struct {
     }
 
     fn markErasedCallablesReachedByType(self: *Solver, ty: Type.TypeVarId) Allocator.Error!void {
-        var active = collections.DenseMap(Type.TypeVarId, void).init(self.allocator);
-        defer active.deinit();
+        var active = self.solved_set_pool.acquire();
+        defer self.solved_set_pool.release(&active);
         try self.markErasedCallablesReachedByTypeInner(ty, &active);
     }
 
@@ -2052,8 +2065,8 @@ const Solver = struct {
     }
 
     fn typeIsProvenUninhabited(self: *Solver, ty: Type.TypeVarId) Allocator.Error!bool {
-        var visiting = collections.DenseMap(Type.TypeVarId, void).init(self.allocator);
-        defer visiting.deinit();
+        var visiting = self.solved_set_pool.acquire();
+        defer self.solved_set_pool.release(&visiting);
         return self.typeIsProvenUninhabitedInner(ty, &visiting);
     }
 
@@ -2071,8 +2084,8 @@ const Solver = struct {
             // Probe leaves against the lifted store instead of materializing:
             // uninhabitedness is a pure function of the Monotype.
             .mono => |leaf| blk: {
-                var mono_visiting = collections.DenseMap(MonoType.TypeId, void).init(self.allocator);
-                defer mono_visiting.deinit();
+                var mono_visiting = self.mono_set_pool.acquire();
+                defer self.mono_set_pool.release(&mono_visiting);
                 break :blk try self.monoProvenUninhabited(leaf.id, &mono_visiting);
             },
             .named => |named| if (named.backing) |backing|
@@ -2628,8 +2641,8 @@ const Solver = struct {
 
     fn solvedTypeDigest(self: *Solver, ty: Type.TypeVarId) Allocator.Error!Type.names.TypeDigest {
         var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-        var active = collections.DenseMap(Type.TypeVarId, void).init(self.allocator);
-        defer active.deinit();
+        var active = self.solved_set_pool.acquire();
+        defer self.solved_set_pool.release(&active);
         try self.writeSolvedTypeDigest(&hasher, ty, &active);
         return .{ .bytes = hasher.finalResult() };
     }
@@ -2905,12 +2918,12 @@ const TypeCloner = struct {
     fn init(solver: *Solver) TypeCloner {
         return .{
             .solver = solver,
-            .map = collections.DenseMap(MonoType.TypeId, Type.TypeVarId).init(solver.allocator),
+            .map = solver.clone_map_pool.acquire(),
         };
     }
 
     fn deinit(self: *TypeCloner) void {
-        self.map.deinit();
+        self.solver.clone_map_pool.release(&self.map);
     }
 
     fn lower(self: *TypeCloner, ty: MonoType.TypeId) Allocator.Error!Type.TypeVarId {
@@ -3055,8 +3068,8 @@ const TypeCloner = struct {
         owner_def: MonoType.TypeDef,
         backing: MonoType.TypeId,
     ) Allocator.Error!MonoType.TypeId {
-        var seen = collections.DenseMap(MonoType.TypeId, void).init(self.solver.allocator);
-        defer seen.deinit();
+        var seen = self.solver.mono_set_pool.acquire();
+        defer self.solver.mono_set_pool.release(&seen);
         var current = backing;
         while (true) {
             if (seen.contains(current)) return current;
@@ -3144,6 +3157,8 @@ test "lambda solved erased callable digest includes record field default identit
     solver.allocator = gpa;
     solver.program = &program;
     solver.lifted = lifted;
+    solver.solved_set_pool = collections.DenseMapPool(Type.TypeVarId, void).init(gpa);
+    defer solver.solved_set_pool.deinit();
 
     const plain_digest = try solver.solvedTypeDigest(plain_ty);
     const first_default_digest = try solver.solvedTypeDigest(first_default_ty);

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -468,6 +468,16 @@ pub const InstGraph = struct {
     containment_visit_epochs: std.ArrayList(u32),
     containment_visit_epoch: u32,
     containment_cache: collections.DenseMap(NodeId, ContainmentCacheEntry),
+    /// Scratch epoch marks for `compactRowParents`, indexed by node id. A
+    /// slot carrying the current epoch means its class root is already kept
+    /// in the list being compacted.
+    row_parent_seen_epochs: std.ArrayList(u64),
+    row_parent_seen_epoch: u64,
+    /// Pools for the visited sets the graph's walks create per query. Fresh
+    /// maps re-allocate and re-zero sparse chunks across the node/type ID
+    /// domains on every walk; pooled maps keep their chunks.
+    node_set_pool: collections.DenseMapPool(NodeId, void),
+    type_set_pool: collections.DenseMapPool(Type.TypeId, void),
     pub fn create(
         allocator: Allocator,
         types: *Type.Store,
@@ -503,6 +513,10 @@ pub const InstGraph = struct {
             .containment_visit_epochs = .empty,
             .containment_visit_epoch = 0,
             .containment_cache = collections.DenseMap(NodeId, ContainmentCacheEntry).init(allocator),
+            .row_parent_seen_epochs = .empty,
+            .row_parent_seen_epoch = 0,
+            .node_set_pool = collections.DenseMapPool(NodeId, void).init(allocator),
+            .type_set_pool = collections.DenseMapPool(Type.TypeId, void).init(allocator),
         };
         return graph;
     }
@@ -545,6 +559,9 @@ pub const InstGraph = struct {
         self.recursive_argument_slots.deinit(allocator);
         self.containment_pending.deinit(allocator);
         self.containment_visit_epochs.deinit(allocator);
+        self.row_parent_seen_epochs.deinit(allocator);
+        self.node_set_pool.deinit();
+        self.type_set_pool.deinit();
         var containment_entries = self.containment_cache.valueIterator();
         while (containment_entries.next()) |entry| {
             entry.deinit(allocator);
@@ -923,12 +940,12 @@ pub const InstGraph = struct {
         };
         var pending = std.ArrayList(Pending).empty;
         defer pending.deinit(self.allocator);
-        var seen = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer seen.deinit();
+        var seen = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&seen);
         var depths = collections.DenseMap(NodeId, u8).init(self.allocator);
         defer depths.deinit();
-        var active = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer active.deinit();
+        var active = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&active);
 
         for (self.nodes.items, 0..) |_, raw_index| {
             const node = self.find(@enumFromInt(@as(u32, @intCast(raw_index))));
@@ -1312,8 +1329,8 @@ pub const InstGraph = struct {
         const Pending = struct { node: NodeId, digest: names.TypeDigest };
         var pending = std.ArrayList(Pending).empty;
         defer pending.deinit(self.allocator);
-        var seen = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer seen.deinit();
+        var seen = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&seen);
 
         for (self.nodes.items, 0..) |_, raw_index| {
             const node = self.find(@enumFromInt(@as(u32, @intCast(raw_index))));
@@ -1404,8 +1421,8 @@ pub const InstGraph = struct {
     /// named type whose backing has not been recorded) answers `true`
     /// conservatively.
     pub fn mayFinalizeAsUninhabited(self: *InstGraph, raw_node: NodeId) Allocator.Error!bool {
-        var visiting = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer visiting.deinit();
+        var visiting = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&visiting);
         return try self.mayFinalizeAsUninhabitedInner(self.find(raw_node), &visiting);
     }
 
@@ -1470,8 +1487,8 @@ pub const InstGraph = struct {
     /// while lowering a branch; it never manufactures a durable type view.
     pub fn finalizesAsUninhabited(self: *InstGraph, raw_node: NodeId) Allocator.Error!bool {
         self.requireFrozenRelations();
-        var visiting = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer visiting.deinit();
+        var visiting = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&visiting);
         return try self.finalizesAsUninhabitedInner(self.find(raw_node), &visiting);
     }
 
@@ -1645,14 +1662,60 @@ pub const InstGraph = struct {
         }
     }
 
+    /// Short parent lists de-duplicate exactly on insert; above this length
+    /// the insert-time scan (with a `find` per element) would make merging
+    /// two classes quadratic in their parent counts, so longer lists append
+    /// unconditionally and compact when they would otherwise grow.
+    const row_parent_exact_scan_max = 16;
+
     fn addRowParent(self: *InstGraph, ext: NodeId, row: NodeId) Allocator.Error!void {
         const entry = try self.row_parents.getOrPut(self.find(ext));
         if (!entry.found_existing) entry.value_ptr.* = .empty;
+        const list = entry.value_ptr;
         const row_root = self.find(row);
-        for (entry.value_ptr.items) |existing| {
-            if (self.find(existing) == row_root) return;
+        if (list.items.len <= row_parent_exact_scan_max) {
+            for (list.items) |existing| {
+                if (self.find(existing) == row_root) return;
+            }
+        } else if (list.items.len == list.capacity) {
+            // Duplicate class entries are tolerated by every reader (each
+            // resolves entries through `find`), so de-duplication can wait
+            // until the list is about to grow. Capacity doubles between
+            // compactions, keeping the total compaction work linear in the
+            // number of inserts.
+            try self.compactRowParents(list);
+            // Guarantee at least as many appends as surviving entries before
+            // the next compaction, so compaction cost amortizes to O(1) per
+            // insert even when it reclaims almost nothing.
+            try list.ensureUnusedCapacity(self.allocator, @max(list.items.len, row_parent_exact_scan_max));
+            for (list.items) |existing| {
+                if (existing == row_root) return;
+            }
         }
-        try entry.value_ptr.append(self.allocator, row_root);
+        try list.append(self.allocator, row_root);
+    }
+
+    /// Rewrite every entry to its current class root and drop duplicate
+    /// classes, preserving order of first occurrence.
+    fn compactRowParents(self: *InstGraph, list: *std.ArrayList(NodeId)) Allocator.Error!void {
+        const epochs_len = self.nodes.items.len;
+        if (self.row_parent_seen_epochs.items.len < epochs_len) {
+            const old_len = self.row_parent_seen_epochs.items.len;
+            try self.row_parent_seen_epochs.resize(self.allocator, epochs_len);
+            @memset(self.row_parent_seen_epochs.items[old_len..], 0);
+        }
+        self.row_parent_seen_epoch += 1;
+        const epoch = self.row_parent_seen_epoch;
+        var write: usize = 0;
+        for (list.items) |existing| {
+            const existing_root = self.find(existing);
+            const slot = &self.row_parent_seen_epochs.items[@intFromEnum(existing_root)];
+            if (slot.* == epoch) continue;
+            slot.* = epoch;
+            list.items[write] = existing_root;
+            write += 1;
+        }
+        list.shrinkRetainingCapacity(write);
     }
 
     fn removeRowParent(self: *InstGraph, ext: NodeId, row: NodeId) void {
@@ -1792,8 +1855,8 @@ pub const InstGraph = struct {
     ) Allocator.Error!bool {
         var pending = std.ArrayList(NodeId).empty;
         defer pending.deinit(self.allocator);
-        var seen = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer seen.deinit();
+        var seen = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&seen);
         try pending.append(self.allocator, root);
         while (pending.pop()) |raw_node| {
             const node = self.find(raw_node);
@@ -1874,8 +1937,8 @@ pub const InstGraph = struct {
     pub fn typeCanSealFromExplicitEvidence(self: *InstGraph, root: NodeId) Allocator.Error!bool {
         var pending = std.ArrayList(NodeId).empty;
         defer pending.deinit(self.allocator);
-        var seen = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer seen.deinit();
+        var seen = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&seen);
         try pending.append(self.allocator, root);
         while (pending.pop()) |raw_node| {
             const node = self.find(raw_node);
@@ -1919,8 +1982,8 @@ pub const InstGraph = struct {
     }
 
     fn rowExtensionChainResolved(self: *InstGraph, raw_root: NodeId, kind: RowKind) Allocator.Error!bool {
-        var seen = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer seen.deinit();
+        var seen = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&seen);
         var current = self.find(raw_root);
         while (true) {
             const entry = try seen.getOrPut(current);
@@ -2094,8 +2157,8 @@ pub const InstGraph = struct {
         self.countDiagnostic("finished_mono_scans");
         var pending = std.ArrayList(NodeId).empty;
         defer pending.deinit(self.allocator);
-        var seen = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer seen.deinit();
+        var seen = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&seen);
         try pending.append(self.allocator, root);
         while (pending.pop()) |raw_node| {
             const node = self.find(raw_node);
@@ -2766,8 +2829,8 @@ pub const InstGraph = struct {
         comptime noun: []const u8,
         access: BackingAccess,
     ) Allocator.Error!NodeId {
-        var seen = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer seen.deinit();
+        var seen = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&seen);
 
         var node = self.find(raw_node);
         while (true) {
@@ -4012,8 +4075,8 @@ pub const InstGraph = struct {
         defer tags.deinit(self.allocator);
         try tags.appendSlice(self.allocator, row.tags);
 
-        var seen = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer seen.deinit();
+        var seen = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&seen);
         try seen.put(root, {});
 
         var ext = self.find(row.ext);
@@ -4071,8 +4134,8 @@ pub const InstGraph = struct {
         defer fields.deinit(self.allocator);
         try fields.appendSlice(self.allocator, row.fields);
 
-        var seen = collections.DenseMap(NodeId, void).init(self.allocator);
-        defer seen.deinit();
+        var seen = self.node_set_pool.acquire();
+        defer self.node_set_pool.release(&seen);
         try seen.put(root, {});
 
         var ext = self.find(row.ext);
@@ -4746,8 +4809,8 @@ pub const InstGraph = struct {
     }
 
     pub fn typeHasActiveSnapshots(self: *InstGraph, ty: Type.TypeId) Allocator.Error!bool {
-        var seen = collections.DenseMap(Type.TypeId, void).init(self.allocator);
-        defer seen.deinit();
+        var seen = self.type_set_pool.acquire();
+        defer self.type_set_pool.release(&seen);
         return try self.typeContainsActiveSnapshot(ty, &seen);
     }
 
@@ -4959,8 +5022,8 @@ pub const GraphTypeFinals = struct {
     }
 
     fn typeHasActiveSnapshots(self: *GraphTypeFinals, ty: Type.TypeId) Allocator.Error!bool {
-        var seen = collections.DenseMap(Type.TypeId, void).init(self.graph.allocator);
-        defer seen.deinit();
+        var seen = self.graph.type_set_pool.acquire();
+        defer self.graph.type_set_pool.release(&seen);
         return try self.graph.typeContainsActiveSnapshot(ty, &seen);
     }
 

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -1344,6 +1344,7 @@ pub const Store = struct {
         node: Content,
         open: []const TypeId,
     ) ?usize {
+        if (open.len == 0) return null;
         if (node != .named) return null;
         const named = node.named;
         if (named.kind == .alias) return null;

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -4280,19 +4280,22 @@ const Subst = struct {
     /// Identity a local's binder-scoped substitution is keyed by: the pattern
     /// binder together with the digest of the local's monomorphic type. Two
     /// locals that share a binder but were monomorphized at different types are
-    /// distinct bindings and must not read one another's substitution.
-    fn binderIdentityOf(program: *const Ast.Program, local: Ast.LocalId) ?BinderIdentity {
+    /// distinct bindings and must not read one another's substitution. Every
+    /// local reference resolves through here, so the digest must come from the
+    /// store's memoized construction (which is why these helpers need the
+    /// program mutable); the uncached walk re-hashes the whole type per call.
+    fn binderIdentityOf(program: *Ast.Program, local: Ast.LocalId) ?BinderIdentity {
         const local_data = program.getLocal(local);
         const binder = local_data.binder orelse return null;
         return .{
             .binder = binder,
-            .digest = program.types.typeDigest(&program.names, local_data.ty),
+            .digest = program.types.typeDigestCached(&program.names, local_data.ty, null),
         };
     }
 
     /// Resolve a local to its known value through the exact-local map, then the
     /// binder-wide map.
-    fn get(self: *const Subst, program: *const Ast.Program, local: Ast.LocalId) ?Value {
+    fn get(self: *const Subst, program: *Ast.Program, local: Ast.LocalId) ?Value {
         if (self.exact.get(local)) |value| return value;
         if (binderIdentityOf(program, local)) |identity| {
             if (self.binder_subst.get(identity)) |value| return value;
@@ -4302,7 +4305,7 @@ const Subst = struct {
 
     /// Resolve a local for emitted code, including the active value of a
     /// binder-equivalent Monotype local id.
-    fn getForClone(self: *const Subst, program: *const Ast.Program, local: Ast.LocalId) ?Value {
+    fn getForClone(self: *const Subst, program: *Ast.Program, local: Ast.LocalId) ?Value {
         if (self.exact.get(local)) |value| return value;
         if (binderIdentityOf(program, local)) |identity| {
             if (self.binder_aliases.get(identity)) |value| return value;
@@ -4323,7 +4326,7 @@ const Subst = struct {
         return self.changes.items.len;
     }
 
-    fn put(self: *Subst, program: *const Ast.Program, local: Ast.LocalId, value: Value) Allocator.Error!void {
+    fn put(self: *Subst, program: *Ast.Program, local: Ast.LocalId, value: Value) Allocator.Error!void {
         const previous = self.exact.get(local);
         try self.changes.append(self.allocator, .{
             .key = .{ .local = local },
@@ -4362,7 +4365,7 @@ const Subst = struct {
         try self.binder_aliases.put(identity, value);
     }
 
-    fn putLocalAlias(self: *Subst, program: *const Ast.Program, local: Ast.LocalId, value: Value) Allocator.Error!void {
+    fn putLocalAlias(self: *Subst, program: *Ast.Program, local: Ast.LocalId, value: Value) Allocator.Error!void {
         const identity = binderIdentityOf(program, local) orelse return;
         try self.putAlias(identity, value);
     }
@@ -4392,7 +4395,7 @@ const Subst = struct {
     /// binder-carrying local; the identity is returned whether or not a
     /// pre-loop entry existed, because the slot's reassigned copies resolve
     /// through it either way.
-    fn dropCarriedBinder(self: *Subst, program: *const Ast.Program, initial: Ast.ExprId) Allocator.Error!?BinderIdentity {
+    fn dropCarriedBinder(self: *Subst, program: *Ast.Program, initial: Ast.ExprId) Allocator.Error!?BinderIdentity {
         const local = localExpr(program, initial) orelse return null;
         const identity = binderIdentityOf(program, local) orelse return null;
         if (self.binder_subst.get(identity)) |previous| {
@@ -10062,7 +10065,7 @@ const Cloner = struct {
                 &self.pass.program.types,
                 &self.pass.program.names,
             ),
-            .callable_abi = self.pass.program.types.typeDigest(&self.pass.program.names, callable.ty),
+            .callable_abi = self.pass.program.types.typeDigestCached(&self.pass.program.names, callable.ty, null),
             .capture_abi = self.callableCaptureAbiDigest(source_captures, callable.captures),
         };
         if (self.pass.callable_workers.get(worker_key)) |worker_fn_id| {
@@ -10204,7 +10207,7 @@ const Cloner = struct {
                 Common.invariant("rewritten callable had no value for a source capture slot");
             std.mem.writeInt(u32, &word, @intFromEnum(id), .little);
             hasher.update(&word);
-            const digest = self.pass.program.types.typeDigest(&self.pass.program.names, valueType(self.pass.program, value));
+            const digest = self.pass.program.types.typeDigestCached(&self.pass.program.names, valueType(self.pass.program, value), null);
             hasher.update(&digest.bytes);
         }
         return .{ .bytes = hasher.finalResult() };
@@ -12159,11 +12162,13 @@ fn valueType(program: *const Ast.Program, value: Value) Type.TypeId {
 /// Whether two Monotype ids denote the same type. The type store is not
 /// interned: each specialization materializes its own ids, so structurally
 /// identical types reached from different specializations (a call site and
-/// the callee's own body) carry different ids and compare by digest.
-fn sameType(program: *const Ast.Program, lhs: Type.TypeId, rhs: Type.TypeId) bool {
+/// the callee's own body) carry different ids and compare by digest. Both
+/// sides digest through the store's memoized construction, which is why this
+/// probe (and everything that reaches it) takes the program mutable.
+fn sameType(program: *Ast.Program, lhs: Type.TypeId, rhs: Type.TypeId) bool {
     if (lhs == rhs) return true;
-    const lhs_digest = program.types.typeDigest(&program.names, lhs);
-    const rhs_digest = program.types.typeDigest(&program.names, rhs);
+    const lhs_digest = program.types.typeDigestCached(&program.names, lhs, null);
+    const rhs_digest = program.types.typeDigestCached(&program.names, rhs, null);
     return std.mem.eql(u8, &lhs_digest.bytes, &rhs_digest.bytes);
 }
 
@@ -12190,7 +12195,7 @@ fn typeTagByName(
     return null;
 }
 
-fn patternEql(program: *const Ast.Program, lhs: CallPattern, rhs: CallPattern) bool {
+fn patternEql(program: *Ast.Program, lhs: CallPattern, rhs: CallPattern) bool {
     if (lhs.args.len != rhs.args.len) return false;
     for (lhs.args, rhs.args) |lhs_arg, rhs_arg| {
         if (!shapeEql(program, lhs_arg, rhs_arg)) return false;
@@ -12198,7 +12203,7 @@ fn patternEql(program: *const Ast.Program, lhs: CallPattern, rhs: CallPattern) b
     return true;
 }
 
-fn shapeEql(program: *const Ast.Program, lhs: Shape, rhs: Shape) bool {
+fn shapeEql(program: *Ast.Program, lhs: Shape, rhs: Shape) bool {
     if (std.meta.activeTag(lhs) != std.meta.activeTag(rhs)) return false;
     return switch (lhs) {
         .any => |lhs_ty| sameType(program, lhs_ty, rhs.any),
@@ -12259,7 +12264,7 @@ fn shapeEql(program: *const Ast.Program, lhs: Shape, rhs: Shape) bool {
 /// This reads the values the caller already cloned and takes no `Cloner`, so
 /// deciding a specialization cannot clone a source argument a second time and a
 /// rejected specialization costs nothing and leaves nothing behind.
-fn callPatternMatchesValues(program: *const Ast.Program, pattern: CallPattern, values: []const Value) bool {
+fn callPatternMatchesValues(program: *Ast.Program, pattern: CallPattern, values: []const Value) bool {
     if (pattern.args.len != values.len) Common.invariant("call-pattern arity differed from direct call arity");
     for (pattern.args, values) |shape, value| {
         if (!shapeMatchesValue(program, shape, value)) return false;
@@ -12267,7 +12272,7 @@ fn callPatternMatchesValues(program: *const Ast.Program, pattern: CallPattern, v
     return true;
 }
 
-fn shapeMatchesValue(program: *const Ast.Program, shape: Shape, value: Value) bool {
+fn shapeMatchesValue(program: *Ast.Program, shape: Shape, value: Value) bool {
     const structural_value = if (value == .static_data_candidate) value.static_data_candidate.runtime.* else value;
     return switch (shape) {
         .any => true,


### PR DESCRIPTION
Fixes #10758.

Building `roc-pdf`'s `tests/gate3_facade_output/main.roc` with `--opt=speed` (the issue's repro), measured on the same machine class as the issue (Ryzen 9700X, ReleaseFast build of the compiler):

| | main (2fdd90e96a) | this PR | |
|---|---|---|---|
| **wall clock** | 11m 38s | **39.8s** | 17.5× |
| **peak RSS** | 8430 MB | **6514 MB** | −1.9 GB |
| Body Call Dispatch | 5m 43s | 5.1s | |
| SpecConstr | 1m 8s | 3.8s | |
| Lambda-Set Solving | 3m 23s | 1.6s | |
| LLVM IR Generation | 30.0s | 1.6s | |
| minor page faults | 208M | 9M | |

The build is now dominated by LLVM Optimize + Emit (19s), i.e. actual optimization work.

Note the issue's baseline was 5m30s on nightly `2026-08-12-606470f`; main has since regressed ~2× through the `addRowParent` quadratic below, which is also fixed here.

### The fixes (one commit each)

1. **`collections.DenseMapPool` + base-offset chunk windows** (`DenseMap.zig`). A reentrancy-safe acquire/release pool so passes that need a short-lived map per work item stop re-allocating and re-zeroing 1 KB sparse chunks on every use. Separately, the chunk-pointer array is now a window over the touched chunk range rather than spanning everything from ID zero — a map holding a dozen entries at large IDs previously paid a pointer slot per chunk below them (measured: **1.375 GB** of null slot prefixes across the lambda solver's 37,781 leaf-context maps, avg 14.6 entries each). This is most of the RSS win.

2. **Pool the lambda solver's scratch maps** (`lambda_solved/solve.zig`). `finalMonoClone` built a fresh `TypeCloner` map per mono leaf — the issue's dominant memset chain (18.3% of the build). The per-`unify` visited sets in `typeIsProvenUninhabited`, the erased-callable marking set, `structuralBackingForNamed`, and `solvedTypeDigest` had the same pattern. All now draw from Solver-owned pools (a pool, not a single scratch, because the marking walk re-enters through `unify`).

3. **Cached type digests in SpecConstr** (`spec_constr.zig`, `monotype/type.zig`). `binderIdentityOf` ran the uncached full-SHA-256 `typeDigest` on every local reference (the issue's 13.4%); it, `sameType`/shape probes, and the callable-worker ABI keys now use the store's memoized `typeDigestCached`. The cached and uncached constructions hash differently and must never mix within a comparison set — every set touched is pass-local, so the wholesale switch is safe. `openNamedCyclePosition` also early-returns on an empty open stack so cache hits do no hashing.

4. **Amortize `InstGraph.addRowParent`** (`monotype/solve.zig`). Insert-time dedup scanned the ext class's parent list with a `find()` per element, and `union_` re-inserts every loser parent, making class merges O(k·m). This had grown to **77.85%** of the build (vs 2.7% in the issue's nightly profile). Short lists keep the exact scan; longer lists append and compact (epoch-marked, root-rewriting) only when the list would grow, with post-compaction free-capacity reservation so the amortization is real. All readers resolve entries through `find()` and tolerate duplicate class entries. The graph's per-query visited sets are pooled as well.

5. **Sparse deferred-str-capture clearing in the LLVM backend** (`MonoLlvmCodeGen.zig`). `deferred_str_captures` spans every LIR local (36 B each) and was fully re-zeroed **on every emitted jump**. perf pinned the memset on `WipFunction.br`'s buffer growth (the issue reported it there too), but disassembly shows it's this clear, inlined adjacent to `br`. An actives list makes clearing and the materialize-all scans O(live captures); it nests across `compileProcBody` like the array itself. This was nearly the entire LLVM IR Generation phase.

### Correctness

- `zig build minici`: 75/75 phases pass
- `zig build run-test-eval`: 1930/1930 across interpreter/dev/wasm/llvm backends
- collections/postcheck/backend module tests, format, lints all green
- The gate3 app built by the patched compiler at `--opt=speed` produces a **byte-identical PDF** to roc-pdf's checked-in `snapshot.pdf`, with exactly the spec'd work counters
- New DenseMap unit tests cover the pool, the offset window, and a front-growth underflow regression the builtin compiler caught during bootstrap

### Remaining (out of scope, from a measured RSS attribution)

The surviving ~6.5 GB peak is live data, not churn: SpecConstr multiplies the lifted expression store 72.6× (201k → 14.6M rows) and lambda solving mints one 164-byte var per row. Follow-up candidates, roughly in value order: a reachability compaction (or program-level inline budget) at the end of SpecConstr, memoizing leaf vars for never-visited rows, and boxing the fat `named` payload out of `Content` (164 B → ~32 B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)