### PR TITLE
Fix optimized recursive tag-union mapping overflow

### DIFF
--- a/design.md
+++ b/design.md
@@ -3564,7 +3564,7 @@ When the continuation observes only part of a compiler-generated tuple loop
 result, SpecConstr may narrow the loop's exit ABI without narrowing its
 back-edge state. Exit selection is a distinct final clone phase after the
 specialization graph is complete. Ordinary specialization and body-rewrite
-clones never initiate it. The projection clone keeps calls opaque, does not
+clones never initiate it. The exit-selection clone keeps calls opaque, does not
 rewrite call patterns, and cannot emit callable workers, so it cannot reopen
 the specialization graph through recursive call edges. Its recursive input is
 limited to the selected function's finite, acyclic expression ownership.
@@ -3575,8 +3575,9 @@ owned by that loop wherever it occurs (including inside mixed value-producing
 branch arms and statement values), and pushes an explicit null selection while
 cloning a nested loop body. Initial values remain in the enclosing lexical loop
 context. Re-cloned output breaks carry an explicit SpecConstr-owned selected-ABI
-stamp, so the projection clone's internal normalization propagates the already
-completed transfer instead of trying to recognize it from its scalar shape.
+stamp, so the exit-selection clone's internal normalization propagates the
+already completed transfer instead of trying to recognize it from its scalar
+shape.
 It is invalid to change the loop result type after rewriting only a terminating
 spine or a subset of exits; every selected exit must transfer exactly the
 explicitly selected tuple items.

--- a/design.md
+++ b/design.md
@@ -3562,13 +3562,19 @@ a known iterator constructor, SpecConstr can:
 
 When the continuation observes only part of a compiler-generated tuple loop
 result, SpecConstr may narrow the loop's exit ABI without narrowing its
-back-edge state. That rewrite is lexical: the ordinary full expression clone
-carries the selected exit ABI while cloning the owning loop body, rewrites
-every `break` owned by that loop wherever it occurs (including inside mixed
-value-producing branch arms and statement values), and pushes an explicit null
-selection while cloning a nested loop body. Initial values remain in the
-enclosing lexical loop context. Re-cloned output breaks carry an explicit
-SpecConstr-owned selected-ABI stamp, so normalization propagates the already
+back-edge state. Exit selection is a distinct final clone phase after the
+specialization graph is complete. Ordinary specialization and body-rewrite
+clones never initiate it. The projection clone keeps calls opaque, does not
+rewrite call patterns, and cannot emit callable workers, so it traverses only
+the finite expression ownership already present in each selected function.
+
+That rewrite is lexical: the dedicated full expression clone carries the
+selected exit ABI while cloning the owning loop body, rewrites every `break`
+owned by that loop wherever it occurs (including inside mixed value-producing
+branch arms and statement values), and pushes an explicit null selection while
+cloning a nested loop body. Initial values remain in the enclosing lexical loop
+context. Re-cloned output breaks carry an explicit SpecConstr-owned selected-ABI
+stamp, so the projection clone's internal normalization propagates the already
 completed transfer instead of trying to recognize it from its scalar shape.
 It is invalid to change the loop result type after rewriting only a terminating
 spine or a subset of exits; every selected exit must transfer exactly the

--- a/design.md
+++ b/design.md
@@ -3565,8 +3565,9 @@ result, SpecConstr may narrow the loop's exit ABI without narrowing its
 back-edge state. Exit selection is a distinct final clone phase after the
 specialization graph is complete. Ordinary specialization and body-rewrite
 clones never initiate it. The projection clone keeps calls opaque, does not
-rewrite call patterns, and cannot emit callable workers, so it traverses only
-the finite expression ownership already present in each selected function.
+rewrite call patterns, and cannot emit callable workers, so it cannot reopen
+the specialization graph through recursive call edges. Its recursive input is
+limited to the selected function's finite, acyclic expression ownership.
 
 That rewrite is lexical: the dedicated full expression clone carries the
 selected exit ABI while cloning the owning loop body, rewrites every `break`

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -8528,3 +8528,23 @@ test "issue 10409 duplicate top-level value defs do not panic constant root look
     var lowered = try lowerModule(allocator, source, .wrappers);
     defer lowered.deinit(allocator);
 }
+
+test "issue 10731 mapping over a List-recursive tag union lowers under wrapper inlining" {
+    try expectOptimizedDbgEvents(
+        \\Tree(a) := [Node(a, List(Tree(a)))]
+        \\
+        \\tree_map : Tree(a), (a -> b) -> Tree(b)
+        \\tree_map = |tree, f|
+        \\    match tree {
+        \\        Node(value, children) => Node(f(value), children.map(|child| tree_map(child, f)))
+        \\    }
+        \\
+        \\main : {}
+        \\main = {
+        \\    Node(root, children) = tree_map(Node(1.U64, [Node(2.U64, [])]), |value| Wrap(value))
+        \\    dbg root
+        \\    dbg children.map(|Node(value, _)| value)
+        \\    {}
+        \\}
+    , &.{ "Wrap(1)", "[Wrap(2)]" });
+}

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -680,14 +680,14 @@ const SpecAdmission = enum {
     denied_spec_count,
 };
 
-/// The phase that owns a clone. Loop-exit projection is deliberately separate
+/// The phase that owns a clone. Loop-exit selection is deliberately separate
 /// from specialization and ordinary rewrites: their full lexical clones can
 /// expose another projectable loop through an inlined callee, so only the final
-/// call-opaque projection phase may initiate another selected exit ABI.
+/// call-opaque exit-selection phase may initiate another selected exit ABI.
 const ClonePurpose = enum {
     specialization,
     rewrite,
-    loop_exit_projection,
+    loop_exit_selection,
 };
 
 const InlineCallMode = enum {
@@ -3679,7 +3679,7 @@ const Pass = struct {
             const aggregate_projectable = try self.bodyHasAggregateProjectableLoopResult(body);
             if (!tuple_projectable and !aggregate_projectable) continue;
 
-            var cloner = Cloner.initForLoopExitProjection(self);
+            var cloner = Cloner.initForLoopExitSelection(self);
             defer cloner.deinit();
             const cloned = try cloner.cloneExpr(body);
             self.program.setFn(fn_id, .{
@@ -4671,9 +4671,9 @@ const Cloner = struct {
         };
     }
 
-    fn initForLoopExitProjection(pass: *Pass) Cloner {
+    fn initForLoopExitSelection(pass: *Pass) Cloner {
         var cloner = initForRewrite(pass);
-        cloner.purpose = .loop_exit_projection;
+        cloner.purpose = .loop_exit_selection;
         cloner.inline_calls = .none;
         cloner.rewrite_call_patterns = false;
         cloner.emit_callable_workers = false;
@@ -5952,7 +5952,7 @@ const Cloner = struct {
     }
 
     fn cloneLetValue(self: *Cloner, let_: anytype, bindings: *BindingChain) Common.LowerError!Value {
-        if (self.purpose == .loop_exit_projection) {
+        if (self.purpose == .loop_exit_selection) {
             if (try self.loopWithSelectedExitValues(let_)) |selected| return try self.cloneExprValueInto(selected, bindings);
         }
 
@@ -12528,7 +12528,7 @@ fn emptyLiftedProgramForTest(allocator: Allocator) Ast.Program {
     );
 }
 
-test "loop exit projection clone is isolated from ordinary rewrites" {
+test "loop exit selection clone is isolated from ordinary rewrites" {
     const allocator = std.testing.allocator;
     var program = emptyLiftedProgramForTest(allocator);
     defer program.deinit();
@@ -12543,12 +12543,12 @@ test "loop exit projection clone is isolated from ordinary rewrites" {
     try std.testing.expect(rewrite.rewrite_call_patterns);
     try std.testing.expect(rewrite.emit_callable_workers);
 
-    var projection = Cloner.initForLoopExitProjection(&pass);
-    defer projection.deinit();
-    try std.testing.expectEqual(ClonePurpose.loop_exit_projection, projection.purpose);
-    try std.testing.expectEqual(InlineCallMode.none, projection.inline_calls);
-    try std.testing.expect(!projection.rewrite_call_patterns);
-    try std.testing.expect(!projection.emit_callable_workers);
+    var exit_selection = Cloner.initForLoopExitSelection(&pass);
+    defer exit_selection.deinit();
+    try std.testing.expectEqual(ClonePurpose.loop_exit_selection, exit_selection.purpose);
+    try std.testing.expectEqual(InlineCallMode.none, exit_selection.inline_calls);
+    try std.testing.expect(!exit_selection.rewrite_call_patterns);
+    try std.testing.expect(!exit_selection.emit_callable_workers);
 }
 
 test "SpecConstr preserves record update ordering while exposing its final shape" {

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -681,9 +681,9 @@ const SpecAdmission = enum {
 };
 
 /// The phase that owns a clone. Loop-exit projection is deliberately separate
-/// from specialization and ordinary rewrites: its full lexical clone may
-/// revisit calls, so only the final call-opaque projection phase may initiate
-/// another selected exit ABI.
+/// from specialization and ordinary rewrites: their full lexical clones can
+/// expose another projectable loop through an inlined callee, so only the final
+/// call-opaque projection phase may initiate another selected exit ABI.
 const ClonePurpose = enum {
     specialization,
     rewrite,

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -680,6 +680,16 @@ const SpecAdmission = enum {
     denied_spec_count,
 };
 
+/// The phase that owns a clone. Loop-exit projection is deliberately separate
+/// from specialization and ordinary rewrites: its full lexical clone may
+/// revisit calls, so only the final call-opaque projection phase may initiate
+/// another selected exit ABI.
+const ClonePurpose = enum {
+    specialization,
+    rewrite,
+    loop_exit_projection,
+};
+
 const InlineCallMode = enum {
     all,
     iterator_fusion,
@@ -3669,11 +3679,8 @@ const Pass = struct {
             const aggregate_projectable = try self.bodyHasAggregateProjectableLoopResult(body);
             if (!tuple_projectable and !aggregate_projectable) continue;
 
-            var cloner = Cloner.initForRewrite(self);
+            var cloner = Cloner.initForLoopExitProjection(self);
             defer cloner.deinit();
-            cloner.inline_calls = .none;
-            cloner.rewrite_call_patterns = false;
-            cloner.emit_callable_workers = false;
             const cloned = try cloner.cloneExpr(body);
             self.program.setFn(fn_id, .{
                 .symbol = fn_.symbol,
@@ -4507,6 +4514,7 @@ const Subst = struct {
 
 const Cloner = struct {
     pass: *Pass,
+    purpose: ClonePurpose,
     /// Symbolic values, shapes, and strict-binding chains owned by this clone.
     /// Accepted call patterns are copied into the pass-wide arena before this
     /// short-lived scratch arena is released.
@@ -4600,6 +4608,7 @@ const Cloner = struct {
     fn init(pass: *Pass, source_fn: Ast.FnId, pattern: CallPattern) Cloner {
         return .{
             .pass = pass,
+            .purpose = .specialization,
             .arena = std.heap.ArenaAllocator.init(pass.allocator),
             .source_fn = source_fn,
             .pattern = pattern,
@@ -4632,6 +4641,7 @@ const Cloner = struct {
     fn initForRewrite(pass: *Pass) Cloner {
         return .{
             .pass = pass,
+            .purpose = .rewrite,
             .arena = std.heap.ArenaAllocator.init(pass.allocator),
             .source_fn = undefined, // initForRewrite never calls buildArgs, which is the only reader.
             .pattern = .{ .args = &.{} },
@@ -4659,6 +4669,15 @@ const Cloner = struct {
             .current_region = Region.zero(),
             .current_inline_scope = Ast.InlineScopeId.none,
         };
+    }
+
+    fn initForLoopExitProjection(pass: *Pass) Cloner {
+        var cloner = initForRewrite(pass);
+        cloner.purpose = .loop_exit_projection;
+        cloner.inline_calls = .none;
+        cloner.rewrite_call_patterns = false;
+        cloner.emit_callable_workers = false;
+        return cloner;
     }
 
     fn deinit(self: *Cloner) void {
@@ -5933,7 +5952,9 @@ const Cloner = struct {
     }
 
     fn cloneLetValue(self: *Cloner, let_: anytype, bindings: *BindingChain) Common.LowerError!Value {
-        if (try self.loopWithSelectedExitValues(let_)) |selected| return try self.cloneExprValueInto(selected, bindings);
+        if (self.purpose == .loop_exit_projection) {
+            if (try self.loopWithSelectedExitValues(let_)) |selected| return try self.cloneExprValueInto(selected, bindings);
+        }
 
         var value_bindings: BindingChain = .{};
         const value = try self.cloneExprValueInto(let_.value, &value_bindings);
@@ -12505,6 +12526,29 @@ fn emptyLiftedProgramForTest(allocator: Allocator) Ast.Program {
         .empty, // comptime_sites
         0, // next_symbol
     );
+}
+
+test "loop exit projection clone is isolated from ordinary rewrites" {
+    const allocator = std.testing.allocator;
+    var program = emptyLiftedProgramForTest(allocator);
+    defer program.deinit();
+
+    var pass = try Pass.init(allocator, &program);
+    defer pass.deinit();
+
+    var rewrite = Cloner.initForRewrite(&pass);
+    defer rewrite.deinit();
+    try std.testing.expectEqual(ClonePurpose.rewrite, rewrite.purpose);
+    try std.testing.expectEqual(InlineCallMode.all, rewrite.inline_calls);
+    try std.testing.expect(rewrite.rewrite_call_patterns);
+    try std.testing.expect(rewrite.emit_callable_workers);
+
+    var projection = Cloner.initForLoopExitProjection(&pass);
+    defer projection.deinit();
+    try std.testing.expectEqual(ClonePurpose.loop_exit_projection, projection.purpose);
+    try std.testing.expectEqual(InlineCallMode.none, projection.inline_calls);
+    try std.testing.expect(!projection.rewrite_call_patterns);
+    try std.testing.expect(!projection.emit_callable_workers);
 }
 
 test "SpecConstr preserves record update ordering while exposing its final shape" {


### PR DESCRIPTION
SpecConstr was projecting unused loop results during ordinary body normalization, allowing a full projection clone to rediscover and inline another recursive List mapping until the compiler exhausted its stack. This makes loop-exit projection an explicit final, call-opaque clone phase, preserving exact exit-ABI narrowing without reopening specialization, and adds regression coverage for issue #10731.

Fixes #10731