### PR TITLE
Promote narrow integer arguments at hosted call boundaries

### DIFF
--- a/src/backend/dev/CallingConvention.zig
+++ b/src/backend/dev/CallingConvention.zig
@@ -21,6 +21,8 @@ const Allocator = std.mem.Allocator;
 const target_mod = @import("roc_target");
 const RocTarget = target_mod.RocTarget;
 
+const layout = @import("layout");
+
 const x86_64 = @import("x86_64/mod.zig");
 const aarch64 = @import("aarch64/mod.zig");
 
@@ -172,6 +174,56 @@ pub const CallingConvention = struct {
     }
 };
 
+/// The C promotion a narrow integer scalar owes the argument slot that carries
+/// it. A host compiled from the generated C signature reads the promoted width,
+/// so the caller must place the promotion's bits there rather than whatever the
+/// staged copy of the Roc-sized value left behind.
+pub const Promotion = enum {
+    none,
+    zero_byte,
+    sign_byte,
+    zero_halfword,
+    sign_halfword,
+
+    /// The promotion `piece` owes, as decided by the shared ABI lowering.
+    pub fn fromRegPiece(piece: layout.abi.RegPiece) Promotion {
+        return switch (piece.extend) {
+            .none => .none,
+            .zero => switch (piece.size) {
+                1 => .zero_byte,
+                2 => .zero_halfword,
+                else => unreachable,
+            },
+            .sign => switch (piece.size) {
+                1 => .sign_byte,
+                2 => .sign_halfword,
+                else => unreachable,
+            },
+        };
+    }
+
+    /// The promotion `stack_value`'s overflow slot owes.
+    pub fn fromStackValue(stack_value: layout.abi.StackValue) Promotion {
+        return switch (stack_value.extend) {
+            .none => .none,
+            .zero => switch (stack_value.size) {
+                1 => .zero_byte,
+                2 => .zero_halfword,
+                else => unreachable,
+            },
+            .sign => switch (stack_value.size) {
+                1 => .sign_byte,
+                2 => .sign_halfword,
+                else => unreachable,
+            },
+        };
+    }
+
+    /// Bytes the promoted value occupies in an outgoing stack slot. C promotes
+    /// to `int`, so a promoted argument's slot carries four meaningful bytes.
+    pub const promoted_stack_size: u8 = 4;
+};
+
 /// Call builder for setting up cross-platform function calls
 /// The Emit type must provide:
 /// - CC: Calling convention struct with PARAM_REGS, FLOAT_PARAM_REGS, etc.
@@ -200,7 +252,7 @@ pub fn CallBuilder(comptime EmitType: type) type {
         // Store LEA result: lea scratch, [base+offset]; mov [RSP+stack_offset], scratch
         from_lea: struct { base: GeneralReg, offset: i32 },
         // Store memory value: mov scratch, [base+offset]; mov [RSP+stack_offset], scratch
-        from_mem: struct { base: GeneralReg, offset: i32 },
+        from_mem: struct { base: GeneralReg, offset: i32, promote: Promotion = .none },
     };
 
     // A deferred register argument, resolved later via parallel move algorithm
@@ -337,8 +389,18 @@ pub fn CallBuilder(comptime EmitType: type) type {
         }
 
         /// Add an integer-class memory argument at its ABI-assigned register.
-        pub fn addMemArgAt(self: *Self, register_index: u16, base_reg: GeneralReg, offset: i32) void {
-            self.addDeferredRegArg(register_index, .{ .from_mem = .{ .base = base_reg, .offset = offset } });
+        pub fn addMemArgAt(
+            self: *Self,
+            register_index: u16,
+            base_reg: GeneralReg,
+            offset: i32,
+            promote: Promotion,
+        ) void {
+            self.addDeferredRegArg(register_index, .{ .from_mem = .{
+                .base = base_reg,
+                .offset = offset,
+                .promote = promote,
+            } });
         }
 
         /// Add a by-value stack argument copied from memory, rounded up to
@@ -359,7 +421,18 @@ pub fn CallBuilder(comptime EmitType: type) type {
             base_reg: GeneralReg,
             source_offset: i32,
             size: usize,
+            promote: Promotion,
         ) void {
+            if (promote != .none) {
+                // A promoted argument's slot carries the promoted width, not
+                // the Roc value's own bytes.
+                self.addStackArg(stack_byte_offset, Promotion.promoted_stack_size, .{ .from_mem = .{
+                    .base = base_reg,
+                    .offset = source_offset,
+                    .promote = promote,
+                } });
+                return;
+            }
             self.addStackMemPieces(stack_byte_offset, base_reg, source_offset, size);
         }
 
@@ -643,18 +716,42 @@ pub fn CallBuilder(comptime EmitType: type) type {
                         try self.emit.leaRegMem(dst, lea.base, lea.offset);
                     }
                 },
-                .from_mem => |mem| {
-                    if (comptime is_aarch64)
-                        try self.emit.ldrRegMemSoff(.w64, dst, mem.base, mem.offset)
-                    else
-                        try self.emit.movRegMem(.w64, dst, mem.base, mem.offset);
-                },
+                .from_mem => |mem| try self.emitLoadPromoted(dst, mem.base, mem.offset, mem.promote),
                 .from_imm => |value| {
                     if (comptime is_aarch64)
                         try self.emit.movRegImm64(dst, @bitCast(value))
                     else
                         try self.emit.movRegImm64(dst, value);
                 },
+            }
+        }
+
+        /// Load a value into `dst`, applying the C promotion it owes. An
+        /// unpromoted value fills the whole register, which is what every
+        /// register-sized value and every piece of an aggregate needs.
+        fn emitLoadPromoted(
+            self: *Self,
+            dst: GeneralReg,
+            base: GeneralReg,
+            offset: i32,
+            promote: Promotion,
+        ) Allocator.Error!void {
+            if (comptime is_aarch64) {
+                switch (promote) {
+                    .none => try self.emit.ldrRegMemSoff(.w64, dst, base, offset),
+                    .zero_byte => try self.emit.ldrbRegMemSoff(dst, base, offset),
+                    .sign_byte => try self.emit.ldrsbRegMemSoff(dst, base, offset),
+                    .zero_halfword => try self.emit.ldrhRegMemSoff(dst, base, offset),
+                    .sign_halfword => try self.emit.ldrshRegMemSoff(dst, base, offset),
+                }
+            } else {
+                switch (promote) {
+                    .none => try self.emit.movRegMem(.w64, dst, base, offset),
+                    .zero_byte => try self.emit.movzxBRegMem(dst, base, offset),
+                    .sign_byte => try self.emit.movsxBRegMem(dst, base, offset),
+                    .zero_halfword => try self.emit.movzxWRegMem(dst, base, offset),
+                    .sign_halfword => try self.emit.movsxWRegMem(dst, base, offset),
+                }
             }
         }
 
@@ -697,6 +794,11 @@ pub fn CallBuilder(comptime EmitType: type) type {
                     try self.emit.strRegMemSoff(.w64, CC_EMIT.SCRATCH_REG, CC_EMIT.STACK_PTR, stack_offset);
                 },
                 .from_mem => |mem| {
+                    if (mem.promote != .none) {
+                        try self.emitLoadPromoted(CC_EMIT.SCRATCH_REG, mem.base, mem.offset, mem.promote);
+                        try self.storeNarrowedAarch64(CC_EMIT.SCRATCH_REG, arg.size, stack_offset);
+                        return;
+                    }
                     switch (arg.size) {
                         1 => {
                             try self.emit.ldrbRegMemSoff(CC_EMIT.SCRATCH_REG, mem.base, mem.offset);
@@ -745,7 +847,11 @@ pub fn CallBuilder(comptime EmitType: type) type {
                     try self.emit.movMemReg(width, CC_EMIT.STACK_PTR, stack_offset, CC_EMIT.SCRATCH_REG);
                 },
                 .from_mem => |mem| {
-                    try self.emit.movRegMem(width, CC_EMIT.SCRATCH_REG, mem.base, mem.offset);
+                    if (mem.promote != .none) {
+                        try self.emitLoadPromoted(CC_EMIT.SCRATCH_REG, mem.base, mem.offset, mem.promote);
+                    } else {
+                        try self.emit.movRegMem(width, CC_EMIT.SCRATCH_REG, mem.base, mem.offset);
+                    }
                     try self.emit.movMemReg(width, CC_EMIT.STACK_PTR, stack_offset, CC_EMIT.SCRATCH_REG);
                 },
             }
@@ -806,7 +912,13 @@ pub fn CallBuilder(comptime EmitType: type) type {
                             try self.emit.movRegMem(.w64, CC_EMIT.SCRATCH_REG, mem.base, mem.offset);
                             try self.emit.movMemReg(.w64, CC_EMIT.BASE_PTR, save_offset, CC_EMIT.SCRATCH_REG);
                         }
-                        ra.src = .{ .from_mem = .{ .base = CC_EMIT.BASE_PTR, .offset = save_offset } };
+                        // The relocated copy is byte-identical, so the value
+                        // still owes its promotion when it is finally loaded.
+                        ra.src = .{ .from_mem = .{
+                            .base = CC_EMIT.BASE_PTR,
+                            .offset = save_offset,
+                            .promote = mem.promote,
+                        } };
                     },
                     .from_lea => |lea| {
                         if (!has_dst_reg[@intFromEnum(lea.base)]) continue;
@@ -2420,8 +2532,8 @@ test "aarch64 explicit register assignments preserve ABI alignment holes" {
 
     var stack_offset: i32 = 0;
     var builder = try Builder.init(&emit, &stack_offset);
-    builder.addMemArgAt(0, .FP, -8);
-    builder.addMemArgAt(2, .FP, -24);
+    builder.addMemArgAt(0, .FP, -8, .none);
+    builder.addMemArgAt(2, .FP, -24, .none);
 
     try std.testing.expectEqual(@as(u8, 2), builder.reg_arg_count);
     try std.testing.expectEqual(@as(u8, 0), builder.reg_args[0].dst_index);
@@ -2440,9 +2552,9 @@ test "aarch64 outgoing stack assignments preserve compact byte offsets" {
 
     var stack_offset: i32 = 0;
     var builder = try Builder.init(&emit, &stack_offset);
-    builder.addStackMemArgAt(0, .FP, -8, 1);
-    builder.addStackMemArgAt(2, .FP, -16, 2);
-    builder.addStackMemArgAt(4, .FP, -24, 4);
+    builder.addStackMemArgAt(0, .FP, -8, 1, .none);
+    builder.addStackMemArgAt(2, .FP, -16, 2, .none);
+    builder.addStackMemArgAt(4, .FP, -24, 4, .none);
 
     try std.testing.expectEqual(@as(usize, 3), builder.stack_arg_count);
     try std.testing.expectEqual(@as(u16, 8), builder.stack_arg_size);

--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -16826,14 +16826,25 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         .stack => |stack_offset| builder.addStackLeaArgAt(stack_offset, frame_ptr, slot_off),
                     },
                     .stack_value => |stack_value| {
-                        builder.addStackMemArgAt(stack_value.offset, frame_ptr, slot_off, stack_value.size);
+                        builder.addStackMemArgAt(
+                            stack_value.offset,
+                            frame_ptr,
+                            slot_off,
+                            stack_value.size,
+                            CallingConventionMod.Promotion.fromStackValue(stack_value),
+                        );
                     },
                     .registers => |pieces| {
                         for (pieces) |assigned| {
                             const piece = assigned.piece;
                             const piece_off = slot_off + @as(i32, @intCast(piece.offset));
                             switch (piece.class) {
-                                .integer => builder.addMemArgAt(assigned.register_index, frame_ptr, piece_off),
+                                .integer => builder.addMemArgAt(
+                                    assigned.register_index,
+                                    frame_ptr,
+                                    piece_off,
+                                    CallingConventionMod.Promotion.fromRegPiece(piece),
+                                ),
                                 .float, .vector => try builder.addFloatMemArgAt(assigned.register_index, frame_ptr, piece_off, piece.size),
                             }
                         }
@@ -26388,4 +26399,213 @@ test "aarch64 hosted HFA and HVA returns expose V0 through V3" {
     try std.testing.expectEqual(aarch64.FloatReg.V1, ArmCodeGen.hostedFloatResultReg(1));
     try std.testing.expectEqual(aarch64.FloatReg.V2, ArmCodeGen.hostedFloatResultReg(2));
     try std.testing.expectEqual(aarch64.FloatReg.V3, ArmCodeGen.hostedFloatResultReg(3));
+}
+
+/// Complete argument registers a hosted callee saw for its narrow parameters.
+const NarrowHostedArgRegisters = struct {
+    u8_register: u64 = 0,
+    i8_register: u64 = 0,
+    u16_register: u64 = 0,
+    i16_register: u64 = 0,
+};
+
+var narrow_hosted_arg_registers: NarrowHostedArgRegisters = .{};
+
+/// Hosted callee declared over the full argument registers, so it observes every
+/// bit the caller placed there rather than only the bits the Roc types describe.
+fn observeNarrowHostedArgs(
+    u8_register: u64,
+    i8_register: u64,
+    u16_register: u64,
+    i16_register: u64,
+) callconv(.c) i64 {
+    narrow_hosted_arg_registers = .{
+        .u8_register = u8_register,
+        .i8_register = i8_register,
+        .u16_register = u16_register,
+        .i16_register = i16_register,
+    };
+    return 0;
+}
+
+/// Values a hosted callee saw for narrow parameters that the ABI placed in the
+/// outgoing stack argument area rather than in registers.
+const OverflowHostedArgs = struct {
+    last_register: u64 = 0,
+    u8_value: u8 = 0,
+    i16_value: i16 = 0,
+};
+
+var overflow_hosted_args: OverflowHostedArgs = .{};
+
+fn observeOverflowHostedArgs(
+    _: u64,
+    _: u64,
+    _: u64,
+    _: u64,
+    _: u64,
+    _: u64,
+    _: u64,
+    last_register: u64,
+    u8_value: u8,
+    i16_value: i16,
+) callconv(.c) i64 {
+    overflow_hosted_args = .{
+        .last_register = last_register,
+        .u8_value = u8_value,
+        .i16_value = i16_value,
+    };
+    return 0;
+}
+
+/// Write a nonzero pattern over the stack the generated code is about to use, so
+/// bytes the caller leaves unwritten are observable instead of incidentally zero.
+noinline fn dirtyNativeStack() void {
+    var scratch: [16 * 1024]u8 = undefined;
+    @memset(&scratch, 0xA5);
+    std.mem.doNotOptimizeAway(&scratch);
+}
+
+/// Compile `root`, point the hosted table at `hosted`, and run it over a stack
+/// whose unwritten bytes are observable.
+fn runHostedRootOverDirtyStack(
+    store: *LirStore,
+    layout_store: *layout.Store,
+    root: lir.LIR.LirProcSpecId,
+    hosted: builtins.host_abi.HostedFn,
+) (Allocator.Error || error{ EmptyCode, MmapFailed, VirtualAllocFailed, MprotectFailed, VirtualProtectFailed, UnsupportedPlatform, UnwindRegistrationFailed })!void {
+    const allocator = std.testing.allocator;
+    const compiled = try compileRoot(store, layout_store, root, .i64);
+    defer allocator.free(compiled.code);
+    defer allocator.free(compiled.unwind_functions);
+
+    var executable = try ExecutableMemory.initWithEntryOffsetAndUnwindInfo(
+        compiled.code,
+        compiled.entry_offset,
+        compiled.unwind_functions,
+    );
+    defer executable.deinit();
+
+    var hosted_table = [_]builtins.host_abi.HostedFn{hosted};
+    var test_ops = TestRocOps.init(allocator);
+    const ops = test_ops.getOps();
+    ops.hosted_fns = .{ .count = hosted_table.len, .fns = &hosted_table };
+
+    var out: i64 = undefined;
+    const func: *const fn (*anyopaque, *anyopaque) callconv(.c) void = @ptrCast(@alignCast(executable.entryPtr()));
+    dirtyNativeStack();
+    func(@ptrCast(&out), @ptrCast(ops));
+}
+
+/// Build a hosted proc over `arg_layouts` and a root that calls it with each of
+/// `values` assigned to a matching local.
+fn addHostedCallRoot(
+    store: *LirStore,
+    symbol_name: []const u8,
+    arg_layouts: []const layout.Idx,
+    values: []const i64,
+) Allocator.Error!lir.LIR.LirProcSpecId {
+    std.debug.assert(arg_layouts.len == values.len);
+    const allocator = std.testing.allocator;
+
+    const params = try allocator.alloc(LocalId, arg_layouts.len);
+    defer allocator.free(params);
+    for (arg_layouts, params) |arg_layout, *param| param.* = try addLocal(store, arg_layout);
+
+    const hosted_proc = try store.addProcSpec(.{
+        .name = store.freshSyntheticSymbol(),
+        .args = try store.addLocalSpan(params),
+        .ret_layout = .i64,
+        .hosted = .{ .symbol = try store.insertString(symbol_name), .dispatch_index = 0 },
+    });
+
+    const args = try allocator.alloc(LocalId, arg_layouts.len);
+    defer allocator.free(args);
+    for (arg_layouts, args) |arg_layout, *arg| arg.* = try addLocal(store, arg_layout);
+
+    const observed = try addLocal(store, .i64);
+    const ret = try store.addCFStmt(.{ .ret = .{ .value = observed } });
+    var body = try store.addCFStmt(.{ .assign_call = .{
+        .target = observed,
+        .proc = hosted_proc,
+        .args = try store.addLocalSpan(args),
+        .next = ret,
+    } });
+
+    var i = arg_layouts.len;
+    while (i > 0) {
+        i -= 1;
+        body = try store.addCFStmt(.{ .assign_literal = .{
+            .target = args[i],
+            .value = .{ .i64_literal = .{ .value = values[i], .layout_idx = arg_layouts[i] } },
+            .next = body,
+        } });
+    }
+
+    return try addNoArgProc(store, body, .i64);
+}
+
+test "issue 10748: hosted call promotes narrow integer arguments in registers" {
+    if (comptime builtin.cpu.arch != .x86_64 and builtin.cpu.arch != .aarch64) {
+        return error.SkipZigTest;
+    }
+
+    const allocator = std.testing.allocator;
+    var store = LirStore.init(allocator);
+    defer store.deinit();
+    var test_state = try TestLayoutState.init(allocator);
+    defer test_state.deinit();
+
+    const root = try addHostedCallRoot(
+        &store,
+        "roc_test_observe_narrow_hosted_args",
+        &.{ .u8, .i8, .u16, .i16 },
+        &.{ 3, -3, 0x0102, -2 },
+    );
+
+    narrow_hosted_arg_registers = .{};
+    try runHostedRootOverDirtyStack(
+        &store,
+        &test_state.layout_store,
+        root,
+        builtins.host_abi.hostedFn(&observeNarrowHostedArgs),
+    );
+
+    // C promotes each of these to `int`, so the callee is entitled to read the
+    // complete low 32 bits of the register.
+    try std.testing.expectEqual(@as(u64, 3), narrow_hosted_arg_registers.u8_register);
+    try std.testing.expectEqual(@as(u64, 0xFFFF_FFFD), narrow_hosted_arg_registers.i8_register);
+    try std.testing.expectEqual(@as(u64, 0x0102), narrow_hosted_arg_registers.u16_register);
+    try std.testing.expectEqual(@as(u64, 0xFFFF_FFFE), narrow_hosted_arg_registers.i16_register);
+}
+
+test "issue 10748: hosted call promotes narrow integer arguments that overflow to the stack" {
+    if (comptime builtin.cpu.arch != .x86_64 and builtin.cpu.arch != .aarch64) {
+        return error.SkipZigTest;
+    }
+
+    const allocator = std.testing.allocator;
+    var store = LirStore.init(allocator);
+    defer store.deinit();
+    var test_state = try TestLayoutState.init(allocator);
+    defer test_state.deinit();
+
+    const root = try addHostedCallRoot(
+        &store,
+        "roc_test_observe_overflow_hosted_args",
+        &.{ .i64, .i64, .i64, .i64, .i64, .i64, .i64, .i64, .u8, .i16 },
+        &.{ 1, 2, 3, 4, 5, 6, 7, 8, 200, -300 },
+    );
+
+    overflow_hosted_args = .{};
+    try runHostedRootOverDirtyStack(
+        &store,
+        &test_state.layout_store,
+        root,
+        builtins.host_abi.hostedFn(&observeOverflowHostedArgs),
+    );
+
+    try std.testing.expectEqual(@as(u64, 8), overflow_hosted_args.last_register);
+    try std.testing.expectEqual(@as(u8, 200), overflow_hosted_args.u8_value);
+    try std.testing.expectEqual(@as(i16, -300), overflow_hosted_args.i16_value);
 }

--- a/src/backend/dev/aarch64/Emit.zig
+++ b/src/backend/dev/aarch64/Emit.zig
@@ -1149,6 +1149,65 @@ pub fn Emit(comptime target: RocTarget) type {
             try self.emit32(inst);
         }
 
+        /// LDURSB (load register byte unscaled, sign-extend) with signed offset
+        pub fn ldursbRegMem(self: *Self, dst: GeneralReg, base: GeneralReg, offset: i9) Allocator.Error!void {
+            // LDURSB <Wt>, [<Xn|SP>, #<simm>]
+            // 00 111 0 00 11 0 imm9 00 Rn Rt
+            const imm9: u9 = @bitCast(offset);
+            const inst: u32 = (0b00 << 30) | // size = 00 for byte
+                (0b111000 << 24) |
+                (0b11 << 22) | // opc = 11 for sign-extending load into Wt
+                (0 << 21) |
+                (@as(u32, imm9) << 12) |
+                (0b00 << 10) |
+                (@as(u32, base.enc()) << 5) |
+                dst.enc();
+            try self.emit32(inst);
+        }
+
+        /// LDRSB (load register byte, sign-extend) with unsigned offset
+        pub fn ldrsbRegMem(self: *Self, dst: GeneralReg, base: GeneralReg, uoffset: u12) Allocator.Error!void {
+            // LDRSB <Wt>, [<Xn|SP>, #<pimm>]
+            // 00 111 0 01 11 imm12 Rn Rt
+            const inst: u32 = (0b00 << 30) |
+                (0b111001 << 24) |
+                (0b11 << 22) |
+                (@as(u32, uoffset) << 10) |
+                (@as(u32, base.enc()) << 5) |
+                dst.enc();
+            try self.emit32(inst);
+        }
+
+        /// LDURSH (load register halfword unscaled, sign-extend) with signed offset
+        pub fn ldurshRegMem(self: *Self, dst: GeneralReg, base: GeneralReg, offset: i9) Allocator.Error!void {
+            // LDURSH <Wt>, [<Xn|SP>, #<simm>]
+            // 01 111 0 00 11 0 imm9 00 Rn Rt
+            const imm9: u9 = @bitCast(offset);
+            const inst: u32 = (0b01 << 30) | // size = 01 for halfword
+                (0b111000 << 24) |
+                (0b11 << 22) | // opc = 11 for sign-extending load into Wt
+                (0 << 21) |
+                (@as(u32, imm9) << 12) |
+                (0b00 << 10) |
+                (@as(u32, base.enc()) << 5) |
+                dst.enc();
+            try self.emit32(inst);
+        }
+
+        /// LDRSH (load register halfword, sign-extend) with unsigned offset
+        pub fn ldrshRegMem(self: *Self, dst: GeneralReg, base: GeneralReg, uoffset: u12) Allocator.Error!void {
+            // LDRSH <Wt>, [<Xn|SP>, #<pimm>]
+            // 01 111 0 01 11 imm12 Rn Rt
+            // Note: uoffset is scaled by 2 (halfword), caller must divide offset by 2
+            const inst: u32 = (0b01 << 30) |
+                (0b111001 << 24) |
+                (0b11 << 22) |
+                (@as(u32, uoffset) << 10) |
+                (@as(u32, base.enc()) << 5) |
+                dst.enc();
+            try self.emit32(inst);
+        }
+
         /// LDRH (load register halfword, zero-extend) with unsigned offset
         pub fn ldrhRegMem(self: *Self, dst: GeneralReg, base: GeneralReg, uoffset: u12) Allocator.Error!void {
             // LDRH <Wt>, [<Xn|SP>, #<pimm>]
@@ -1277,6 +1336,24 @@ pub fn Emit(comptime target: RocTarget) type {
             try self.ldurbRegMem(dst, scratch, 0);
         }
 
+        /// LDRSB with signed offset (i32).
+        /// Handles arbitrary signed offsets by choosing the shortest exact encoding.
+        pub fn ldrsbRegMemSoff(self: *Self, dst: GeneralReg, base: GeneralReg, offset: i32) Allocator.Error!void {
+            if (offset >= -256 and offset <= 255) {
+                try self.ldursbRegMem(dst, base, @intCast(offset));
+                return;
+            }
+
+            if (offset >= 0 and offset <= 4095) {
+                try self.ldrsbRegMem(dst, base, @intCast(@as(u32, @intCast(offset))));
+                return;
+            }
+
+            const scratch = addressScratchReg(base, null);
+            try self.emitAddressOffset(scratch, base, offset);
+            try self.ldursbRegMem(dst, scratch, 0);
+        }
+
         /// STRB with signed offset (i32).
         /// Handles arbitrary signed offsets by choosing the shortest exact encoding.
         pub fn strbRegMemSoff(self: *Self, src: GeneralReg, base: GeneralReg, offset: i32) Allocator.Error!void {
@@ -1317,6 +1394,30 @@ pub fn Emit(comptime target: RocTarget) type {
             const scratch = addressScratchReg(base, null);
             try self.emitAddressOffset(scratch, base, offset);
             try self.ldurhRegMem(dst, scratch, 0);
+        }
+
+        /// LDRSH with signed offset (i32).
+        /// Handles arbitrary signed offsets by choosing the shortest exact encoding.
+        pub fn ldrshRegMemSoff(self: *Self, dst: GeneralReg, base: GeneralReg, offset: i32) Allocator.Error!void {
+            if (offset >= -256 and offset <= 255) {
+                try self.ldurshRegMem(dst, base, @intCast(offset));
+                return;
+            }
+
+            if (offset >= 0) {
+                const uoff: u32 = @intCast(offset);
+                if ((uoff & 1) == 0) {
+                    const scaled = uoff >> 1;
+                    if (scaled <= 4095) {
+                        try self.ldrshRegMem(dst, base, @intCast(scaled));
+                        return;
+                    }
+                }
+            }
+
+            const scratch = addressScratchReg(base, null);
+            try self.emitAddressOffset(scratch, base, offset);
+            try self.ldurshRegMem(dst, scratch, 0);
         }
 
         /// STRH with signed offset (i32).

--- a/src/backend/dev/x86_64/Emit.zig
+++ b/src/backend/dev/x86_64/Emit.zig
@@ -837,6 +837,52 @@ pub fn Emit(comptime target: RocTarget) type {
             try self.buf.appendSlice(self.allocator, &@as([4]u8, @bitCast(disp)));
         }
 
+        /// MOVSX r32, BYTE [base + disp32] (sign-extend byte to 32 bits)
+        /// 32-bit result auto-zero-extends to 64 bits on x86_64; no REX.W needed.
+        pub fn movsxBRegMem(self: *Self, dst: GeneralReg, base: GeneralReg, disp: i32) Allocator.Error!void {
+            // REX prefix only for extended registers (R8-R15), never REX.W
+            const r: u1 = dst.rexR();
+            const b: u1 = base.rexB();
+            if (r == 1 or b == 1) {
+                try self.buf.append(self.allocator, rex(0, r, 0, b));
+            }
+            try self.buf.append(self.allocator, 0x0F);
+            try self.buf.append(self.allocator, 0xBE); // MOVSX r32, r/m8
+
+            const base_enc = base.enc();
+            if (base_enc == 4) {
+                // RSP/R12 - needs SIB byte
+                try self.buf.append(self.allocator, modRM(0b10, dst.enc(), 0b100));
+                try self.buf.append(self.allocator, 0x24);
+            } else {
+                try self.buf.append(self.allocator, modRM(0b10, dst.enc(), base_enc));
+            }
+            try self.buf.appendSlice(self.allocator, &@as([4]u8, @bitCast(disp)));
+        }
+
+        /// MOVSX r32, WORD [base + disp32] (sign-extend word to 32 bits)
+        /// 32-bit result auto-zero-extends to 64 bits on x86_64; no REX.W needed.
+        pub fn movsxWRegMem(self: *Self, dst: GeneralReg, base: GeneralReg, disp: i32) Allocator.Error!void {
+            // REX prefix only for extended registers (R8-R15), never REX.W
+            const r: u1 = dst.rexR();
+            const b: u1 = base.rexB();
+            if (r == 1 or b == 1) {
+                try self.buf.append(self.allocator, rex(0, r, 0, b));
+            }
+            try self.buf.append(self.allocator, 0x0F);
+            try self.buf.append(self.allocator, 0xBF); // MOVSX r32, r/m16
+
+            const base_enc = base.enc();
+            if (base_enc == 4) {
+                // RSP/R12 - needs SIB byte
+                try self.buf.append(self.allocator, modRM(0b10, dst.enc(), 0b100));
+                try self.buf.append(self.allocator, 0x24);
+            } else {
+                try self.buf.append(self.allocator, modRM(0b10, dst.enc(), base_enc));
+            }
+            try self.buf.appendSlice(self.allocator, &@as([4]u8, @bitCast(disp)));
+        }
+
         /// LEA reg, [base + disp32] (load effective address)
         /// LEA reg, [RIP + disp32]—compute PC-relative address
         /// disp is relative to the end of this instruction (7 bytes total).

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -11999,6 +11999,15 @@ pub const MonoLlvmCodeGen = struct {
                 const src = try self.offsetPtr(arg_ptr, piece.offset);
                 const val = wip.load(.normal, piece_ty, src, self.alignmentForLayoutOffset(arg_layout, piece.offset), "") catch return error.OutOfMemory;
                 const carrier_ty = try self.cAbiPieceLlvmType(builder, piece);
+                // A narrow C scalar owes its argument register a promotion, and
+                // LLVM performs it only for a parameter marked with it. A
+                // widened carrier already carries the promotion in its own
+                // conversion below.
+                if (carrier_ty == piece_ty) switch (piece.extend) {
+                    .none => {},
+                    .zero => try attrs.addParamAttr(param_types.items.len, .zeroext, builder),
+                    .sign => try attrs.addParamAttr(param_types.items.len, .signext, builder),
+                };
                 try param_types.append(self.allocator, carrier_ty);
                 try call_args.append(self.allocator, try self.coerceCAbiPiece(val, carrier_ty, piece, self.cAbiPieceIsSigned(arg_layout)));
             },

--- a/src/eval/host_trampoline.zig
+++ b/src/eval/host_trampoline.zig
@@ -118,6 +118,19 @@ pub fn call(
                 },
             },
             .stack_value => |stack_value| {
+                if (stack_value.extend != .none) {
+                    // The slot carries the promoted C scalar, not the Roc
+                    // value's own bytes.
+                    const end = @as(usize, stack_value.offset) + promoted_stack_size;
+                    if (end > max_stack_bytes) return Error.TooManyStackBytes;
+                    const promoted = promote(
+                        readUnaligned(u64, value, @intCast(stack_value.size)),
+                        @intCast(stack_value.size),
+                        stack_value.extend,
+                    );
+                    @memcpy(stack[stack_value.offset..end], std.mem.asBytes(&promoted)[0..promoted_stack_size]);
+                    continue;
+                }
                 const end = @as(usize, stack_value.offset) + stack_value.size;
                 if (end > max_stack_bytes) return Error.TooManyStackBytes;
                 @memcpy(stack[stack_value.offset..end], value[0..stack_value.size]);
@@ -126,7 +139,11 @@ pub fn call(
                 for (pieces) |assigned| {
                     const piece = assigned.piece;
                     switch (piece.class) {
-                        .integer => gp[assigned.register_index] = readUnaligned(u64, value + piece.offset, piece.size),
+                        .integer => gp[assigned.register_index] = promote(
+                            readUnaligned(u64, value + piece.offset, piece.size),
+                            piece.size,
+                            piece.extend,
+                        ),
                         .float, .vector => sse[assigned.register_index] = readUnaligned(u128, value + piece.offset, piece.size),
                     }
                 }
@@ -168,6 +185,21 @@ pub fn call(
             }
         },
     }
+}
+
+/// Bytes a promoted C scalar occupies in an overflow slot: C promotes to `int`.
+const promoted_stack_size: usize = 4;
+
+/// Apply the C promotion an argument owes its slot. `bits` already holds the
+/// value's own bytes zero-filled, which is what an unpromoted value and a
+/// zero-extended scalar both need.
+fn promote(bits: u64, size: u8, extend: layout.abi.RegExtension) u64 {
+    if (extend != .sign) return bits;
+    // C promotes to `int`, so the promotion fills exactly 32 bits, which is
+    // also what the compiled backends' sign-extending loads produce.
+    const shift: u5 = @intCast(32 - @as(u16, size) * 8);
+    const narrowed: i32 = @as(i32, @bitCast(@as(u32, @truncate(bits)) << shift)) >> shift;
+    return @as(u32, @bitCast(narrowed));
 }
 
 fn readUnaligned(comptime T: type, ptr: [*]const u8, size: u8) T {

--- a/src/layout/abi/call.zig
+++ b/src/layout/abi/call.zig
@@ -26,6 +26,13 @@ const Idx = layout.Idx;
 /// Which register file a piece of a value travels in.
 pub const RegClass = enum { integer, float, vector };
 
+/// How a caller must widen a value into the argument register that carries it.
+/// C promotes integer types narrower than `int` at a call boundary, which clang
+/// expresses as the `zeroext`/`signext` parameter attributes and which an
+/// ABI-correct callee is entitled to rely on. Every other value leaves the
+/// register's remaining bits unspecified.
+pub const RegExtension = enum { none, zero, sign };
+
 /// One register's worth of a value: which register file, the byte offset within the value's
 /// in-memory representation that this register carries, and how many bytes (1..16; >8 only for
 /// a 128-bit value in a single SSE register).
@@ -37,6 +44,10 @@ pub const RegPiece = struct {
     /// lowering prevents consumers from reconstructing vector type information
     /// from byte size, which would lose the natural C signature.
     vector_kind: ?layout.Vector = null,
+    /// Widening this piece's bytes must receive on their way into the register.
+    /// Only a narrow integer scalar carries one; a piece of an aggregate does
+    /// not, exactly as in the C signature the platform host is compiled from.
+    extend: RegExtension = .none,
 };
 
 /// How LLVM must preserve the logical register pieces as one C-ABI carrier.
@@ -99,6 +110,9 @@ pub const StackValue = struct {
     offset: u16,
     size: u32,
     alignment: u8,
+    /// Widening the slot's contents must receive, for an ABI whose overflow
+    /// slots carry a promoted C scalar rather than the value's own bytes.
+    extend: RegExtension = .none,
 };
 
 /// Where an ABI-mandated pointer to an indirectly passed argument travels.
@@ -404,6 +418,7 @@ pub fn assignPhysicalArgs(
                             .offset = assignWinStackSlot(&stack_size, win_position),
                             .size = size_align.size,
                             .alignment = 8,
+                            .extend = pieces[0].extend,
                         } };
                     }
                     win_position += 1;
@@ -442,12 +457,16 @@ pub fn assignPhysicalArgs(
                         // SysV and AAPCS64 allocate every register piece of one
                         // argument atomically. If either register pool cannot
                         // hold the complete argument, no registers are consumed.
-                        assigned.* = .{ .stack_value = assignStackValue(
+                        var overflow = assignStackValue(
                             &stack_size,
                             size_align.size,
                             value_alignment,
                             stack_slot_alignment,
-                        ) };
+                        );
+                        // Apple's packed overflow slot holds exactly the
+                        // value's own bytes, so nothing is promoted into it.
+                        if (target != .aarch64_macho and pieces.len == 1) overflow.extend = pieces[0].extend;
+                        assigned.* = .{ .stack_value = overflow };
                         if (aarch64_target and counts.sse != 0) {
                             // AAPCS64 rule C.5 closes the SIMD register pool once
                             // an HFA cannot be allocated in full.
@@ -503,17 +522,59 @@ fn placementFor(
     const lay = store.getLayout(idx);
     if (store.layoutSize(lay) == 0) return .none;
 
+    const extend = narrowScalarExtension(store, idx);
     return switch (target) {
-        .aarch64, .aarch64_macho, .aarch64_windows => placementAarch64(arena, store, target, idx, ctx),
-        .x86_64_sysv => placementSysV(arena, store, idx, ctx),
-        .x86_64_windows => placementWin64(arena, store, idx, ctx),
+        .aarch64, .aarch64_macho, .aarch64_windows => placementAarch64(arena, store, target, idx, ctx, extend),
+        .x86_64_sysv => placementSysV(arena, store, idx, ctx, extend),
+        .x86_64_windows => placementWin64(arena, store, idx, ctx, extend),
         .wasm32, .wasm64 => placementWasm(arena, store, idx),
     };
 }
 
-fn onePiece(arena: std.mem.Allocator, class: RegClass, offset: u16, size: u8) std.mem.Allocator.Error!Placement {
+/// The widening a C caller owes `idx`'s value. C integer types narrower than
+/// `int` are promoted at the call boundary, so a host compiled from the
+/// generated C signature reads the complete register and needs its upper bits
+/// to carry the promotion rather than whatever the caller happened to leave
+/// there. Aggregates keep C's "unspecified upper bits" rule; glue exposes them
+/// as structs, which clang never marks `zeroext`/`signext`.
+fn narrowScalarExtension(store: *const Store, idx: Idx) RegExtension {
+    const lay = store.getLayout(idx);
+    if (store.layoutSize(lay) >= 4) return .none;
+
+    return switch (lay.tag) {
+        .scalar => switch (lay.getScalar().tag) {
+            .int => switch (lay.getScalar().getInt()) {
+                .i8, .i16 => .sign,
+                .u8, .u16 => .zero,
+                .u32, .i32, .u64, .i64, .u128, .i128 => .none,
+            },
+            .frac, .vector, .str, .opaque_ptr => .none,
+        },
+        .tag_union => blk: {
+            const info = store.getTagUnionInfo(lay);
+            if (info.variants.len == 1 and info.data.discriminant_size == 0) {
+                break :blk narrowScalarExtension(store, info.variants.get(0).payload_layout);
+            }
+            // Glue exposes a payload-free tag union as its unsigned
+            // discriminant integer; anything carrying a payload is a struct.
+            for (0..info.variants.len) |i| {
+                if (store.layoutSize(store.getLayout(info.variants.get(i).payload_layout)) != 0) break :blk .none;
+            }
+            break :blk .zero;
+        },
+        .struct_, .closure, .erased_callable, .box, .box_of_zst, .list, .list_of_zst, .zst, .ptr => .none,
+    };
+}
+
+fn onePiece(
+    arena: std.mem.Allocator,
+    class: RegClass,
+    offset: u16,
+    size: u8,
+    extend: RegExtension,
+) std.mem.Allocator.Error!Placement {
     const pieces = try arena.alloc(RegPiece, 1);
-    pieces[0] = .{ .class = class, .offset = offset, .size = size };
+    pieces[0] = .{ .class = class, .offset = offset, .size = size, .extend = extend };
     return .{ .registers = .{ .pieces = pieces } };
 }
 
@@ -522,8 +583,12 @@ fn integerPieces(
     arena: std.mem.Allocator,
     size: u32,
     carrier: RegisterCarrier,
+    extend: RegExtension,
 ) std.mem.Allocator.Error!Placement {
     const count = (size + 7) / 8;
+    // Only a value narrower than one register can owe a promotion, and such a
+    // value is always a single piece.
+    std.debug.assert(extend == .none or count == 1);
     const pieces = try arena.alloc(RegPiece, count);
     var i: u32 = 0;
     while (i < count) : (i += 1) {
@@ -531,6 +596,7 @@ fn integerPieces(
             .class = .integer,
             .offset = @intCast(i * 8),
             .size = @intCast(@min(8, size - i * 8)),
+            .extend = extend,
         };
     }
     return .{ .registers = .{ .pieces = pieces, .carrier = carrier } };
@@ -542,13 +608,14 @@ fn placementAarch64(
     target: Target,
     idx: Idx,
     ctx: Context,
+    extend: RegExtension,
 ) std.mem.Allocator.Error!Placement {
     const lay = store.getLayout(idx);
     const size = store.layoutSize(lay);
     switch (aarch64.classifyType(store, idx)) {
         .memory => return .indirect,
-        .integer => return onePiece(arena, .integer, 0, @intCast(size)),
-        .double_integer => return integerPieces(arena, size, .{ .array = null }),
+        .integer => return onePiece(arena, .integer, 0, @intCast(size), extend),
+        .double_integer => return integerPieces(arena, size, .{ .array = null }, .none),
         .float_array => |fa| {
             const elem_bytes: u8 = @intCast(fa.elem_bits / 8);
             const pieces = try arena.alloc(RegPiece, fa.count);
@@ -584,9 +651,9 @@ fn placementAarch64(
                 const scalar = lay.getScalar();
                 if (scalar.tag == .frac) {
                     return switch (scalar.getFrac()) {
-                        .f32 => onePiece(arena, .float, 0, 4),
-                        .f64 => onePiece(arena, .float, 0, 8),
-                        .dec => integerPieces(arena, size, .integer),
+                        .f32 => onePiece(arena, .float, 0, 4, .none),
+                        .f64 => onePiece(arena, .float, 0, 8, .none),
+                        .dec => integerPieces(arena, size, .integer, .none),
                     };
                 }
                 if (scalar.tag == .vector) {
@@ -594,20 +661,26 @@ fn placementAarch64(
                     pieces[0] = .{ .class = .vector, .offset = 0, .size = 16, .vector_kind = scalar.getVector() };
                     return .{ .registers = .{ .pieces = pieces } };
                 }
-                return integerPieces(arena, size, if (size == 16) .integer else .piecewise);
+                return integerPieces(arena, size, if (size == 16) .integer else .piecewise, extend);
             },
-            .box, .box_of_zst, .ptr => return integerPieces(arena, size, .piecewise),
+            .box, .box_of_zst, .ptr => return integerPieces(arena, size, .piecewise, .none),
             .tag_union => {
                 const info = store.getTagUnionInfo(lay);
                 std.debug.assert(info.variants.len == 1 and info.data.discriminant_size == 0);
-                return placementAarch64(arena, store, target, info.variants.get(0).payload_layout, ctx);
+                return placementAarch64(arena, store, target, info.variants.get(0).payload_layout, ctx, extend);
             },
             .list, .list_of_zst, .struct_, .closure, .erased_callable, .zst => unreachable,
         },
     }
 }
 
-fn placementSysV(arena: std.mem.Allocator, store: *const Store, idx: Idx, ctx: Context) std.mem.Allocator.Error!Placement {
+fn placementSysV(
+    arena: std.mem.Allocator,
+    store: *const Store,
+    idx: Idx,
+    ctx: Context,
+    extend: RegExtension,
+) std.mem.Allocator.Error!Placement {
     const size = store.layoutSize(store.getLayout(idx));
     const classes = x86_64.classifySystemV(store, idx, if (ctx == .ret) .ret else .arg);
     if (classes[0] == .memory) return .indirect;
@@ -619,7 +692,12 @@ fn placementSysV(arena: std.mem.Allocator, store: *const Store, idx: Idx, ctx: C
         const offset: u16 = @intCast(i * 8);
         const piece_size: u8 = @intCast(@min(@as(u32, 8), size - offset));
         switch (classes[i]) {
-            .integer => try pieces.append(arena, .{ .class = .integer, .offset = offset, .size = piece_size }),
+            .integer => try pieces.append(arena, .{
+                .class = .integer,
+                .offset = offset,
+                .size = piece_size,
+                .extend = if (offset == 0) extend else .none,
+            }),
             .sse, .float, .float_combine => {
                 if (i + 1 < classes.len and classes[i + 1] == .sseup) {
                     try pieces.append(arena, .{
@@ -643,12 +721,18 @@ fn placementSysV(arena: std.mem.Allocator, store: *const Store, idx: Idx, ctx: C
     } };
 }
 
-fn placementWin64(arena: std.mem.Allocator, store: *const Store, idx: Idx, ctx: Context) std.mem.Allocator.Error!Placement {
+fn placementWin64(
+    arena: std.mem.Allocator,
+    store: *const Store,
+    idx: Idx,
+    ctx: Context,
+    extend: RegExtension,
+) std.mem.Allocator.Error!Placement {
     const size = store.layoutSize(store.getLayout(idx));
     switch (x86_64.classifyWindows(store, idx)) {
         .memory => return .indirect,
-        .integer => return onePiece(arena, .integer, 0, @intCast(size)),
-        .sse => return onePiece(arena, .float, 0, @intCast(@min(@as(u32, 16), size))),
+        .integer => return onePiece(arena, .integer, 0, @intCast(size), extend),
+        .sse => return onePiece(arena, .float, 0, @intCast(@min(@as(u32, 16), size)), .none),
         // Win64 passes a scalar 128-bit integer in memory but returns it in
         // XMM0 as <2 x i64>. Generated RocDec is a C aggregate instead, so it
         // is indirect in both directions.
@@ -682,14 +766,16 @@ fn placementWasm(arena: std.mem.Allocator, store: *const Store, idx: Idx) std.me
             const class: RegClass = if (is_vector) .vector else if (is_float) .float else .integer;
             if (wasm.lowerAsDoubleI64(store, direct_idx)) {
                 // A value wider than 64 bits is passed as two i64s.
-                return integerPieces(arena, size, .piecewise);
+                return integerPieces(arena, size, .piecewise, .none);
             }
             if (is_vector) {
                 const pieces = try arena.alloc(RegPiece, 1);
                 pieces[0] = .{ .class = .vector, .offset = 0, .size = @intCast(size), .vector_kind = dlay.getScalar().getVector() };
                 return .{ .registers = .{ .pieces = pieces } };
             }
-            return onePiece(arena, class, 0, @intCast(size));
+            // Wasm classification unwraps transparent aggregates, so the
+            // promotion follows the type actually passed.
+            return onePiece(arena, class, 0, @intCast(size), narrowScalarExtension(store, direct_idx));
         },
     }
 }

--- a/src/layout/abi/mod.zig
+++ b/src/layout/abi/mod.zig
@@ -25,6 +25,7 @@ pub const RegisterPlacement = call.RegisterPlacement;
 pub const RegisterCarrier = call.RegisterCarrier;
 pub const RegPiece = call.RegPiece;
 pub const RegClass = call.RegClass;
+pub const RegExtension = call.RegExtension;
 pub const Target = call.Target;
 pub const aarch64Target = call.aarch64Target;
 pub const lower = call.lower;


### PR DESCRIPTION
Fixes #10748. The C ABI requires the caller to sign- or zero-extend integer arguments narrower than `int`, and a host compiled from Roc's generated C signature is entitled to read the full promoted width. That requirement was never represented anywhere in the compiler, so none of the three consumers applied it: the dev backend staged each argument at its Roc size and then loaded a full register-sized word from the staging slot, dragging in whatever the surrounding stack held above the value; the interpreter's trampoline zero-filled every narrow argument, including signed ones; and the LLVM backend emitted a bare `i8`/`i16` parameter, which LLVM is free to pass with undefined upper bits. A platform declaring `observe! : U8, Str => {}` could therefore see `0xA5A5A5A5A5A5A503` where it expected `3`, and `253` where it expected `-3`.

The fix puts the requirement where the classification already lives. `layout.abi` now records, per register piece and per overflow stack slot, the widening the caller owes — derived from the layout, so it applies exactly to the C scalars clang marks `zeroext`/`signext` (narrow integers, `Bool`, and payload-free tag unions, which glue exposes as unsigned integers) and never to aggregate pieces, whose upper bits C leaves unspecified. The dev backend consumes it with a sign- or zero-extending load in `CallBuilder`, which needed new `LDRSB`/`LDRSH` and `MOVSX` emitters; the interpreter's trampoline sign-extends where required; and the LLVM backend attaches the matching parameter attribute, except on wasm where narrow integers already travel as explicitly extended `i32` carriers. Apple's arm64 overflow slots are excluded because they are packed at the value's natural size.

The register-argument bug reproduced on macOS arm64 and the signed variant reproduced on the LLVM backend as well; the interpreter was wrong for signed narrow arguments in the same way.