### PR TITLE
Fix record destructure inference before literal defaulting

### DIFF
--- a/design.md
+++ b/design.md
@@ -4343,6 +4343,17 @@ The kind rules:
   boundary's); lower-ranked entries stay pending for the scope that owns
   them, so nested boundaries fired mid-statement never pin an enclosing
   destructure prematurely.
+  Binding a destructure can also ground a deferred static-dispatch receiver
+  without adding an ordinary equality constraint. Every literal-defaulting
+  boundary therefore begins with a ROUND-ZERO constraint quiescence: ordinary
+  constraints and every now-runnable dispatch relation alternate to a
+  fixpoint before the boundary gathers any default candidates. Defaulting may
+  only classify a literal after the method signatures selected by all
+  pre-boundary type evidence have propagated through the graph. Each defaulting
+  round runs the same joint quiescence after its commits, with default-origin
+  diagnostics enabled for relations grounded by those commits. Still-flex
+  receivers remain parked, so quiescence does not speculatively select or
+  reject a method.
   Nested sub-patterns (`{ x: Ok(y) }`) check against the binder, so on an
   optional field they see the Try. Exhaustiveness analysis consumes that
   exact checker-judged sub-pattern type for every record column, rather

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -21190,17 +21190,37 @@ fn checkNominalTypeUsage(
 
 // validate constraints //
 
-/// Check all constraints
-/// We loop here because checkStaticDispatchConstraints and add new regular
-/// constraints.
-fn checkAllConstraints(self: *Self, env: *Env) std.mem.Allocator.Error!void {
+/// Drive ordinary constraints and every runnable static-dispatch relation to
+/// quiescence. A semantic judgment can ground a dispatch receiver without
+/// adding an ordinary constraint (record-destructure binder judgment is one
+/// example), so the ordinary queue alone cannot decide whether this fixpoint
+/// has work left.
+///
+/// `anyDeferredDispatchReceiverResolved` keeps inert flex receivers parked:
+/// we only pay for a dispatch pass when at least one queued relation can make
+/// progress. Static dispatch can add ordinary constraints, and checking those
+/// constraints can ground more dispatch receivers, hence the joint loop.
+fn quiesceConstraints(
+    self: *Self,
+    env: *Env,
+    is_numeric_default_pass: bool,
+) std.mem.Allocator.Error!void {
     const trace = tracy.trace(@src());
     defer trace.end();
 
-    while (self.constraints.items.items.len > 0) {
-        try self.checkConstraints(env);
-        try self.checkStaticDispatchConstraints(env, false);
+    while (true) {
+        if (self.constraints.items.items.len > 0) {
+            try self.checkConstraints(env);
+        }
+
+        if (!try self.anyDeferredDispatchReceiverResolved(env)) return;
+        try self.checkStaticDispatchConstraints(env, is_numeric_default_pass);
     }
+}
+
+/// Check all non-defaulting constraints.
+fn checkAllConstraints(self: *Self, env: *Env) std.mem.Allocator.Error!void {
+    try self.quiesceConstraints(env, false);
 }
 
 fn poisonRecursiveNonFunctionProcessingDef(
@@ -22267,6 +22287,12 @@ const LiteralDefaultUniverse = union(enum) {
 /// `anyDeferredDispatchReceiverResolved`) and its semantic dispatch-cycle
 /// detection.
 fn runLiteralDefaultingRounds(self: *Self, env: *Env, universe: LiteralDefaultUniverse) std.mem.Allocator.Error!void {
+    // Round zero: semantic judgments immediately before this boundary can
+    // ground a deferred receiver without adding an ordinary constraint. Let
+    // every such relation propagate through its callable signature before we
+    // classify any literal as an unconstrained default candidate.
+    try self.quiesceConstraints(env, false);
+
     // Round-scoped scratch. Front-loaded as Check fields; cleared at the start
     // of each step. Safe despite cascade reentrancy: every buffer is cleared
     // before use and never read across the step-4 cascade.
@@ -22439,10 +22465,8 @@ fn runLiteralDefaultingRounds(self: *Self, env: *Env, universe: LiteralDefaultUn
             }
         }
 
-        // --- 4. Cascade the dispatches the commits unblocked. ---
-        while (try self.anyDeferredDispatchReceiverResolved(env)) {
-            try self.checkStaticDispatchConstraints(env, true);
-        }
+        // --- 4. Cascade the constraints the commits unblocked. ---
+        try self.quiesceConstraints(env, true);
     }
 }
 

--- a/test/snapshots/record_destructure_param_type_inference.md
+++ b/test/snapshots/record_destructure_param_type_inference.md
@@ -1,0 +1,285 @@
+# META
+~~~ini
+description=Destructuring a record in a lambda parameter infers the same field types as accessing the fields through a named parameter
+type=snippet
+~~~
+# SOURCE
+~~~roc
+apply : a, (a -> b) -> b
+apply = |x, f| f(x)
+
+# repro for https://github.com/roc-lang/roc/issues/10761
+# `hi` and `lo` bound by the record pattern must get the same U32 types that
+# `pair.hi` and `pair.lo` get below, so both definitions type-check cleanly.
+destructured : U64
+destructured = apply(
+	{ hi: 1.U32, lo: 2.U32 },
+	|{ hi, lo }| {
+		hi_shifted = hi.to_u64().shl_wrap(32)
+		hi_shifted.bitwise_or(lo.to_u64())
+	},
+)
+
+field_access : U64
+field_access = apply(
+	{ hi: 1.U32, lo: 2.U32 },
+	|pair| {
+		hi_shifted = pair.hi.to_u64().shl_wrap(32)
+		hi_shifted.bitwise_or(pair.lo.to_u64())
+	},
+)
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpColon,LowerIdent,Comma,OpenRound,LowerIdent,OpArrow,LowerIdent,CloseRound,OpArrow,LowerIdent,
+LowerIdent,OpAssign,OpBar,LowerIdent,Comma,LowerIdent,OpBar,LowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,LowerIdent,NoSpaceOpenRound,
+OpenCurly,LowerIdent,OpColon,Int,NoSpaceDotUpperIdent,Comma,LowerIdent,OpColon,Int,NoSpaceDotUpperIdent,CloseCurly,Comma,
+OpBar,OpenCurly,LowerIdent,Comma,LowerIdent,CloseCurly,OpBar,OpenCurly,
+LowerIdent,OpAssign,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,NoSpaceDotLowerIdent,NoSpaceOpenRound,Int,CloseRound,
+LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,CloseRound,
+CloseCurly,Comma,
+CloseRound,
+LowerIdent,OpColon,UpperIdent,
+LowerIdent,OpAssign,LowerIdent,NoSpaceOpenRound,
+OpenCurly,LowerIdent,OpColon,Int,NoSpaceDotUpperIdent,Comma,LowerIdent,OpColon,Int,NoSpaceDotUpperIdent,CloseCurly,Comma,
+OpBar,LowerIdent,OpBar,OpenCurly,
+LowerIdent,OpAssign,LowerIdent,NoSpaceDotLowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,NoSpaceDotLowerIdent,NoSpaceOpenRound,Int,CloseRound,
+LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,LowerIdent,NoSpaceDotLowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,CloseRound,
+CloseCurly,Comma,
+CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-type-anno (name "apply")
+			(ty-fn
+				(ty-var (raw "a"))
+				(ty-fn
+					(ty-var (raw "a"))
+					(ty-var (raw "b")))
+				(ty-var (raw "b"))))
+		(s-decl
+			(p-ident (raw "apply"))
+			(e-lambda
+				(args
+					(p-ident (raw "x"))
+					(p-ident (raw "f")))
+				(e-apply
+					(e-ident (raw "f"))
+					(e-ident (raw "x")))))
+		(s-type-anno (name "destructured")
+			(ty (name "U64")))
+		(s-decl
+			(p-ident (raw "destructured"))
+			(e-apply
+				(e-ident (raw "apply"))
+				(e-record
+					(field (field "hi")
+						(e-typed-int (raw "1") (type "U32")))
+					(field (field "lo")
+						(e-typed-int (raw "2") (type "U32"))))
+				(e-lambda
+					(args
+						(p-record
+							(field (name "hi") (rest false))
+							(field (name "lo") (rest false))))
+					(e-block
+						(statements
+							(s-decl
+								(p-ident (raw "hi_shifted"))
+								(e-method-call (method ".shl_wrap")
+									(receiver
+										(e-method-call (method ".to_u64")
+											(receiver
+												(e-ident (raw "hi")))
+											(args)))
+									(args
+										(e-int (raw "32")))))
+							(e-method-call (method ".bitwise_or")
+								(receiver
+									(e-ident (raw "hi_shifted")))
+								(args
+									(e-method-call (method ".to_u64")
+										(receiver
+											(e-ident (raw "lo")))
+										(args)))))))))
+		(s-type-anno (name "field_access")
+			(ty (name "U64")))
+		(s-decl
+			(p-ident (raw "field_access"))
+			(e-apply
+				(e-ident (raw "apply"))
+				(e-record
+					(field (field "hi")
+						(e-typed-int (raw "1") (type "U32")))
+					(field (field "lo")
+						(e-typed-int (raw "2") (type "U32"))))
+				(e-lambda
+					(args
+						(p-ident (raw "pair")))
+					(e-block
+						(statements
+							(s-decl
+								(p-ident (raw "hi_shifted"))
+								(e-method-call (method ".shl_wrap")
+									(receiver
+										(e-method-call (method ".to_u64")
+											(receiver
+												(e-field-access
+													(receiver
+														(e-ident (raw "pair")))
+													(segment (mode "required") (field "hi"))))
+											(args)))
+									(args
+										(e-int (raw "32")))))
+							(e-method-call (method ".bitwise_or")
+								(receiver
+									(e-ident (raw "hi_shifted")))
+								(args
+									(e-method-call (method ".to_u64")
+										(receiver
+											(e-field-access
+												(receiver
+													(e-ident (raw "pair")))
+												(segment (mode "required") (field "lo"))))
+										(args)))))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "apply"))
+		(e-lambda
+			(args
+				(p-assign (ident "x"))
+				(p-assign (ident "f")))
+			(e-call (constraint-fn-var 273)
+				(e-lookup-local
+					(p-assign (ident "f")))
+				(e-lookup-local
+					(p-assign (ident "x")))))
+		(annotation
+			(ty-fn (effectful false)
+				(ty-rigid-var (name "a"))
+				(ty-parens
+					(ty-fn (effectful false)
+						(ty-rigid-var-lookup (ty-rigid-var (name "a")))
+						(ty-rigid-var (name "b"))))
+				(ty-rigid-var-lookup (ty-rigid-var (name "b"))))))
+	(d-let
+		(p-assign (ident "destructured"))
+		(e-call (constraint-fn-var 317)
+			(e-lookup-local
+				(p-assign (ident "apply")))
+			(e-record
+				(fields
+					(field (name "hi")
+						(e-typed-int (value "1") (type "U32")))
+					(field (name "lo")
+						(e-typed-int (value "2") (type "U32")))))
+			(e-lambda
+				(args
+					(p-record-destructure
+						(destructs
+							(record-destruct (label "hi") (ident "hi")
+								(required
+									(p-assign (ident "hi"))))
+							(record-destruct (label "lo") (ident "lo")
+								(required
+									(p-assign (ident "lo")))))))
+				(e-block
+					(s-let
+						(p-assign (ident "hi_shifted"))
+						(e-dispatch-call (method "shl_wrap") (constraint-fn-var 311)
+							(receiver
+								(e-dispatch-call (method "to_u64") (constraint-fn-var 302)
+									(receiver
+										(e-lookup-local
+											(p-assign (ident "hi"))))
+									(args)))
+							(args
+								(e-num (value "32")))))
+					(e-dispatch-call (method "bitwise_or") (constraint-fn-var 315)
+						(receiver
+							(e-lookup-local
+								(p-assign (ident "hi_shifted"))))
+						(args
+							(e-dispatch-call (method "to_u64") (constraint-fn-var 313)
+								(receiver
+									(e-lookup-local
+										(p-assign (ident "lo"))))
+								(args)))))))
+		(annotation
+			(ty-lookup (name "U64") (builtin))))
+	(d-let
+		(p-assign (ident "field_access"))
+		(e-call (constraint-fn-var 365)
+			(e-lookup-local
+				(p-assign (ident "apply")))
+			(e-record
+				(fields
+					(field (name "hi")
+						(e-typed-int (value "1") (type "U32")))
+					(field (name "lo")
+						(e-typed-int (value "2") (type "U32")))))
+			(e-lambda
+				(args
+					(p-assign (ident "pair")))
+				(e-block
+					(s-let
+						(p-assign (ident "hi_shifted"))
+						(e-dispatch-call (method "shl_wrap") (constraint-fn-var 352)
+							(receiver
+								(e-dispatch-call (method "to_u64") (constraint-fn-var 343)
+									(receiver
+										(e-field-access
+											(receiver
+												(e-lookup-local
+													(p-assign (ident "pair"))))
+											(segments
+												(segment (name "hi") (mode "required")))))
+									(args)))
+							(args
+								(e-num (value "32")))))
+					(e-dispatch-call (method "bitwise_or") (constraint-fn-var 361)
+						(receiver
+							(e-lookup-local
+								(p-assign (ident "hi_shifted"))))
+						(args
+							(e-dispatch-call (method "to_u64") (constraint-fn-var 359)
+								(receiver
+									(e-field-access
+										(receiver
+											(e-lookup-local
+												(p-assign (ident "pair"))))
+										(segments
+											(segment (name "lo") (mode "required")))))
+								(args)))))))
+		(annotation
+			(ty-lookup (name "U64") (builtin)))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "a, (a -> b) -> b"))
+		(patt (type "U64"))
+		(patt (type "U64")))
+	(expressions
+		(expr (type "a, (a -> b) -> b"))
+		(expr (type "U64"))
+		(expr (type "U64"))))
+~~~


### PR DESCRIPTION
Record destructure binders can ground deferred method-dispatch receivers without adding an ordinary constraint. This drives ordinary and runnable static-dispatch work to quiescence before literal defaulting, preventing numeric literals in chained method calls from defaulting before the destructured field type propagates. Fixes #10761.