### PR TITLE
Fix callable flow through List.map preparation

### DIFF
--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -133,6 +133,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10571_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10617_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10694_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10710_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));
     std.testing.refAllDecls(@import("test/platform_box_update_lir_test.zig"));

--- a/src/compile/test/issue_10710_test.zig
+++ b/src/compile/test/issue_10710_test.zig
@@ -1,0 +1,19 @@
+//! Regression test for issue #10710.
+
+const expectLowersToLir = @import("lower_to_lir_harness.zig").expectLowersToLir;
+
+test "issue 10710: compile-time constant list of functions built by List.map" {
+    try expectLowersToLir(
+        \\rules : List(() -> U8)
+        \\rules = [|| 5].map(|rule| rule)
+        \\
+        \\main! = |_args| {
+        \\    first = match rules {
+        \\        [rule, ..] => rule()
+        \\        [] => 0
+        \\    }
+        \\    echo!(first.to_str())
+        \\    Ok({})
+        \\}
+    );
+}

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -157,6 +157,7 @@ const Solver = struct {
         list_replace_unsafe,
         list_swap,
         list_prepend,
+        list_map_prepare_reuse,
         dict_pseudo_seed,
         hasher_finish,
         crypto_sha256_hash_bytes,
@@ -1594,6 +1595,10 @@ const Solver = struct {
                 expectLowLevelArity(op, args, 2);
                 try self.unify(expected, args[0]);
                 try self.unify(args[1], try self.listElem(expected));
+            },
+            .list_map_prepare_reuse => {
+                expectLowLevelArity(op, args, 1);
+                try self.unify(expected, args[0]);
             },
             .dict_pseudo_seed => expectLowLevelArity(op, args, 0),
             .hasher_finish => expectLowLevelArity(op, args, 1),


### PR DESCRIPTION
Lambda Solved did not preserve the input list type through `list_map_prepare_reuse`, so lists of functions could lose their callable members and reach ConstStore as an impossible inhabited empty function set. This preserves the operation’s exact `List(input) -> List(input)` relation so callable evidence flows through `List.map`. Fixes #10710.