### PR TITLE
Publish callable top-level destructure binders

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -7028,7 +7028,7 @@ fn pruneSelectedHoistedRootsAfterSolving(self: *Self) Allocator.Error!void {
     var kept_count: usize = 0;
     var kept_expr_count: u32 = 0;
     var kept_pattern_count: u32 = 0;
-    for (self.selected_hoisted_roots.items, 0..) |root, i| {
+    for (self.selected_hoisted_roots.items, 0..) |*root, i| {
         keep_oracle.current_root_index = i;
         const intrinsic = !self.hoistExprInvalidated(root.expr) and try self.hoistedRootIsIntrinsicallyKept(root);
         const deps = intrinsic and try self.hoistedRootDependenciesAreKept(root.expr, &keep_oracle);
@@ -7079,16 +7079,26 @@ fn pruneSelectedHoistedRootsAfterSolving(self: *Self) Allocator.Error!void {
 
 fn hoistedRootIsIntrinsicallyKept(
     self: *Self,
-    root: hoist_roots.SelectedHoistedRoot,
+    root: *hoist_roots.SelectedHoistedRoot,
 ) Allocator.Error!bool {
     const type_var = if (root.pattern) |pattern|
         ModuleEnv.varFrom(pattern)
     else
         ModuleEnv.varFrom(root.expr);
+
+    if (root.body == .pattern_extraction and self.selectedHoistedRootIsTopLevel(root.*)) {
+        root.value_kind = if (self.varIsFunctionType(type_var)) .callable_binding else .data_constant;
+        return true;
+    }
+
+    if (self.varIsFunctionType(type_var)) {
+        return false;
+    }
+
+    root.value_kind = .data_constant;
     if (self.cir.store.getExpr(root.expr) == .e_runtime_error) return true;
     if (isFunctionDef(&self.cir.store, self.cir.store.getExpr(root.expr))) return false;
-    if (self.varIsFunctionType(type_var)) return false;
-    return try self.varIsConcreteHoistedConstType(type_var);
+    return try self.varIsConcreteSelectedRootType(type_var);
 }
 
 fn debugVerifyKeptHoistedRootDependencies(self: *Self) Allocator.Error!void {
@@ -7112,7 +7122,12 @@ fn debugVerifyKeptHoistedRootDependencies(self: *Self) Allocator.Error!void {
 
 fn varIsConcreteHoistedConstType(self: *Self, var_: Var) Allocator.Error!bool {
     self.var_set.clearRetainingCapacity();
-    return try self.varIsConcreteHoistedConstTypeInternal(.value_graph, var_, &self.var_set);
+    return try self.varIsConcreteHoistedConstTypeInternal(.value_graph, .reject, var_, &self.var_set);
+}
+
+fn varIsConcreteSelectedRootType(self: *Self, var_: Var) Allocator.Error!bool {
+    self.var_set.clearRetainingCapacity();
+    return try self.varIsConcreteHoistedConstTypeInternal(.value_graph, .allow, var_, &self.var_set);
 }
 
 /// Resolve a nominal application's declaration backing TEMPLATE for read-only
@@ -7146,6 +7161,11 @@ fn nominalDeclBackingTemplate(self: *const Self, nominal: types_mod.NominalType)
 /// checked, so they count as concrete).
 const HoistedConstWalk = enum { value_graph, decl_template };
 
+/// Whether the concreteness walk admits exact callable values. Ordinary
+/// hoisted-const eligibility keeps its historical data-only contract, while
+/// selected compile-time roots can archive callable identities in ConstStore.
+const HoistedCallablePolicy = enum { reject, allow };
+
 /// Copy a record's field value-type variables onto `scratch_record_field_vars`
 /// and return the start mark of the pushed batch. The batch is
 /// `[mark, scratch_record_field_vars.top())`; the caller reads it *by index* and
@@ -7172,6 +7192,7 @@ fn dupeRecordFieldTypeVars(self: *Self, presences: []const types_mod.RecordField
 fn varIsConcreteHoistedConstTypeInternal(
     self: *Self,
     comptime walk: HoistedConstWalk,
+    comptime callables: HoistedCallablePolicy,
     var_: Var,
     visited: *std.AutoHashMap(Var, void),
 ) Allocator.Error!bool {
@@ -7185,20 +7206,21 @@ fn varIsConcreteHoistedConstTypeInternal(
         .field_presence,
         => false,
         .rigid => walk == .decl_template,
-        .alias => |alias| (try self.varsAreConcreteHoistedConstTypes(walk, self.types.sliceAliasArgs(alias), visited)) and
-            try self.varIsConcreteHoistedConstTypeInternal(walk, self.types.getAliasBackingVar(alias), visited),
-        .structure => |flat| try self.flatTypeIsConcreteHoistedConst(walk, flat, visited),
+        .alias => |alias| (try self.varsAreConcreteHoistedConstTypes(walk, callables, self.types.sliceAliasArgs(alias), visited)) and
+            try self.varIsConcreteHoistedConstTypeInternal(walk, callables, self.types.getAliasBackingVar(alias), visited),
+        .structure => |flat| try self.flatTypeIsConcreteHoistedConst(walk, callables, flat, visited),
     };
 }
 
 fn varsAreConcreteHoistedConstTypes(
     self: *Self,
     comptime walk: HoistedConstWalk,
+    comptime callables: HoistedCallablePolicy,
     vars: []const Var,
     visited: *std.AutoHashMap(Var, void),
 ) Allocator.Error!bool {
     for (vars) |var_| {
-        if (!try self.varIsConcreteHoistedConstTypeInternal(walk, var_, visited)) return false;
+        if (!try self.varIsConcreteHoistedConstTypeInternal(walk, callables, var_, visited)) return false;
     }
     return true;
 }
@@ -7206,6 +7228,7 @@ fn varsAreConcreteHoistedConstTypes(
 fn flatTypeIsConcreteHoistedConst(
     self: *Self,
     comptime walk: HoistedConstWalk,
+    comptime callables: HoistedCallablePolicy,
     flat: FlatType,
     visited: *std.AutoHashMap(Var, void),
 ) Allocator.Error!bool {
@@ -7213,36 +7236,35 @@ fn flatTypeIsConcreteHoistedConst(
         .empty_record,
         .empty_tag_union,
         => true,
-        .fn_pure,
-        .fn_effectful,
-        .fn_unbound,
-        => false,
+        .fn_pure, .fn_effectful, .fn_unbound => |func| callables == .allow and
+            (try self.varsAreConcreteHoistedConstTypes(walk, callables, self.types.sliceVars(func.args), visited)) and
+            try self.varIsConcreteHoistedConstTypeInternal(walk, callables, func.ret, visited),
         .record => |record| blk: {
             const fields = self.types.getRecordFieldsSlice(record.fields);
             for (fields.items(.presence)) |presence| {
                 const field_var = presence.typeVar();
-                if (!try self.varIsConcreteHoistedConstTypeInternal(walk, field_var, visited)) break :blk false;
+                if (!try self.varIsConcreteHoistedConstTypeInternal(walk, callables, field_var, visited)) break :blk false;
             }
-            break :blk try self.varIsConcreteHoistedConstTypeInternal(walk, record.ext, visited);
+            break :blk try self.varIsConcreteHoistedConstTypeInternal(walk, callables, record.ext, visited);
         },
         .record_unbound => |fields| blk: {
             const fields_slice = self.types.getRecordFieldsSlice(fields);
             for (fields_slice.items(.presence)) |presence| {
                 const field_var = presence.typeVar();
-                if (!try self.varIsConcreteHoistedConstTypeInternal(walk, field_var, visited)) break :blk false;
+                if (!try self.varIsConcreteHoistedConstTypeInternal(walk, callables, field_var, visited)) break :blk false;
             }
             break :blk true;
         },
-        .tuple => |tuple| try self.varsAreConcreteHoistedConstTypes(walk, self.types.sliceVars(tuple.elems), visited),
+        .tuple => |tuple| try self.varsAreConcreteHoistedConstTypes(walk, callables, self.types.sliceVars(tuple.elems), visited),
         .tag_union => |tag_union| blk: {
             const tags = self.types.getTagsSlice(tag_union.tags);
             for (tags.items(.args)) |tag_args| {
-                if (!try self.varsAreConcreteHoistedConstTypes(walk, self.types.sliceVars(tag_args), visited)) break :blk false;
+                if (!try self.varsAreConcreteHoistedConstTypes(walk, callables, self.types.sliceVars(tag_args), visited)) break :blk false;
             }
-            break :blk try self.varIsConcreteHoistedConstTypeInternal(walk, tag_union.ext, visited);
+            break :blk try self.varIsConcreteHoistedConstTypeInternal(walk, callables, tag_union.ext, visited);
         },
         .nominal_type => |nominal| blk: {
-            if (!try self.varsAreConcreteHoistedConstTypes(walk, self.types.sliceNominalArgs(nominal), visited)) break :blk false;
+            if (!try self.varsAreConcreteHoistedConstTypes(walk, callables, self.types.sliceNominalArgs(nominal), visited)) break :blk false;
             if (self.builtinNominalDeclForBuiltinSourceDecl(nominal.sourceDeclOptional())) |builtin_decl| {
                 switch (builtin_decl) {
                     .list,
@@ -7263,7 +7285,7 @@ fn flatTypeIsConcreteHoistedConst(
             // backing template. Formals in the template stand for the args
             // checked above, so the template walk admits rigids.
             const template = self.nominalDeclBackingTemplate(nominal) orelse break :blk false;
-            break :blk try self.varIsConcreteHoistedConstTypeInternal(.decl_template, template, visited);
+            break :blk try self.varIsConcreteHoistedConstTypeInternal(.decl_template, callables, template, visited);
         },
     };
 }

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -4068,6 +4068,7 @@ pub const CheckedTypeStore = struct {
         imports: []const PublishImportArtifact,
         available: []const ImportedModuleView,
         source_nodes: *const CheckedSourceNodes,
+        selected_hoisted_roots: []const hoist_roots.SelectedHoistedRoot,
     ) Allocator.Error!CheckedTypePublication {
         const import_views = CheckedImportViews{
             .current_owner = current_owner,
@@ -4288,6 +4289,32 @@ pub const CheckedTypeStore = struct {
                 module.typeStoreConst(),
                 module.moduleEnvConst(),
                 module.defType(def_idx),
+            );
+            if (findCheckedTypeScheme(store.schemes.items, scheme_key) == null) {
+                const scheme_id: CheckedTypeSchemeId = @enumFromInt(@as(u32, @intCast(store.schemes.items.len)));
+                try store.schemes.append(allocator, .{
+                    .id = scheme_id,
+                    .key = scheme_key,
+                    .root = root,
+                });
+            }
+        }
+
+        // Selected roots own source schemes just like ordinary top-level
+        // values. Publish them explicitly so const and callable templates can
+        // name the exact scheme without relying on an unrelated definition
+        // having the same canonical key.
+        for (selected_hoisted_roots) |selected| {
+            const source_var = if (selected.pattern) |pattern|
+                ModuleEnv.varFrom(pattern)
+            else
+                module.exprType(selected.expr);
+            const root = try appendCheckedTypeRoot(allocator, module, names, import_views, &store, &active, source_var);
+            const scheme_key = try canonical_type_keys.schemeFromVar(
+                allocator,
+                module.typeStoreConst(),
+                module.moduleEnvConst(),
+                source_var,
             );
             if (findCheckedTypeScheme(store.schemes.items, scheme_key) == null) {
                 const scheme_id: CheckedTypeSchemeId = @enumFromInt(@as(u32, @intCast(store.schemes.items.len)));
@@ -8612,7 +8639,7 @@ fn expectSingleNominalBackingPayload(allocator: Allocator, module_name: []const 
     var source_nodes = try CheckedSourceNodes.init(allocator, module);
     defer source_nodes.deinit(allocator);
 
-    var publication = try CheckedTypeStore.fromModule(allocator, module, &names, artifact_key, &.{}, &.{}, &source_nodes);
+    var publication = try CheckedTypeStore.fromModule(allocator, module, &names, artifact_key, &.{}, &.{}, &source_nodes, &.{});
     defer publication.deinit(allocator);
 
     const nominal_stmt = for (module_env.store.sliceStatements(module_env.all_statements)) |statement_idx| {
@@ -14906,6 +14933,81 @@ pub const CallableEvalTemplateTable = struct {
     }
 };
 
+/// Publication-only index for callable values produced by selected pattern
+/// extraction roots. The durable identity lives in the compile-time root,
+/// callable-eval template, and top-level procedure binding tables; this index
+/// only connects source lookups to those identities while resolved refs are
+/// being published.
+const SelectedHoistedCallableTable = struct {
+    by_pattern: []?TopLevelProcedureBindingRef = &.{},
+
+    fn fromRoots(
+        allocator: Allocator,
+        module: TypedCIR.Module,
+        checked_bodies: *const CheckedBodyStore,
+        roots: *const CompileTimeRootTable,
+        callable_eval_templates: *CallableEvalTemplateTable,
+        procedure_bindings: *TopLevelProcedureBindingTable,
+    ) Allocator.Error!SelectedHoistedCallableTable {
+        const by_pattern = try allocator.alloc(?TopLevelProcedureBindingRef, checked_bodies.patternCount());
+        errdefer allocator.free(by_pattern);
+        @memset(by_pattern, null);
+
+        for (roots.roots) |root| {
+            if (root.kind != .callable_binding) continue;
+            switch (root.source) {
+                .hoisted => {},
+                .def, .expr, .statement, .required_binding => continue,
+            }
+
+            const source_pattern = root.source_pattern orelse
+                checkedArtifactInvariant("selected callable root had no source pattern", .{});
+            if (!sourceTypeIsFunction(module, ModuleEnv.varFrom(source_pattern))) {
+                checkedArtifactInvariant("selected callable root source pattern was not function-typed", .{});
+            }
+            const checked_pattern = root.pattern orelse
+                checkedArtifactInvariant("selected callable root had no checked pattern", .{});
+            const source_scheme = try canonical_type_keys.schemeFromVar(
+                allocator,
+                module.typeStoreConst(),
+                module.moduleEnvConst(),
+                ModuleEnv.varFrom(source_pattern),
+            );
+            const callable_template = try callable_eval_templates.append(
+                allocator,
+                module.moduleIndex(),
+                checked_pattern,
+                root.id,
+                source_scheme,
+                root.checked_type,
+            );
+            const binding = try procedure_bindings.appendCallableEval(
+                allocator,
+                source_scheme,
+                callable_template,
+            );
+            const slot = &by_pattern[@intFromEnum(checked_pattern)];
+            if (slot.* != null) {
+                checkedArtifactInvariant("selected callable pattern was published more than once", .{});
+            }
+            slot.* = binding;
+        }
+
+        return .{ .by_pattern = by_pattern };
+    }
+
+    fn lookupByPattern(self: *const SelectedHoistedCallableTable, pattern: CheckedPatternId) ?TopLevelProcedureBindingRef {
+        const raw = @intFromEnum(pattern);
+        if (raw >= self.by_pattern.len) return null;
+        return self.by_pattern[raw];
+    }
+
+    fn deinit(self: *SelectedHoistedCallableTable, allocator: Allocator) void {
+        allocator.free(self.by_pattern);
+        self.* = .{};
+    }
+};
+
 /// Public `ImportedProcedureBindingRef` declaration.
 pub const ImportedProcedureBindingRef = struct {
     artifact: CheckedModuleArtifactKey,
@@ -15042,6 +15144,7 @@ pub const ResolvedValueRefTable = struct {
         platform_required_declarations: *const PlatformRequiredDeclarationTable,
         platform_required_bindings: *const PlatformRequiredBindingTable,
         top_level_values: *const TopLevelValueTable,
+        selected_hoisted_callables: *const SelectedHoistedCallableTable,
         hoisted_constants: *const HoistedConstTable,
         checked_types: *const CheckedTypePublication,
         checked_bodies: *const CheckedBodyStore,
@@ -15083,6 +15186,7 @@ pub const ResolvedValueRefTable = struct {
                 platform_required_declarations,
                 platform_required_bindings,
                 top_level_values,
+                selected_hoisted_callables,
                 hoisted_constants,
                 &local_pattern_roles,
                 checked_bodies,
@@ -15116,6 +15220,7 @@ pub const ResolvedValueRefTable = struct {
             &records,
             by_checked_expr,
             checked_bodies,
+            selected_hoisted_callables,
             hoisted_constants,
             synthetic_expr_origins,
         );
@@ -15208,6 +15313,7 @@ fn appendSyntheticLocalLookupRefs(
     records: *std.ArrayList(ResolvedValueRefRecord),
     by_checked_expr: []?ResolvedValueRefId,
     checked_bodies: *const CheckedBodyStore,
+    selected_hoisted_callables: *const SelectedHoistedCallableTable,
     hoisted_constants: *const HoistedConstTable,
     synthetic_expr_origins: []const SyntheticExprOriginRecord,
 ) Allocator.Error!void {
@@ -15236,14 +15342,17 @@ fn appendSyntheticLocalLookupRefs(
                 const binder = checked_bodies.patternBinderForCheckedPattern(origin.result_pattern) orelse {
                     checkedArtifactInvariant("synthetic lookup local referenced a pattern without a checked binder", .{});
                 };
-                const hoisted = hoisted_constants.lookupByPattern(origin.result_pattern) orelse {
-                    checkedArtifactInvariant("synthetic pattern-extraction lookup had no selected hoisted const entry", .{});
-                };
+                const resolved_ref: ResolvedValueRef = if (selected_hoisted_callables.lookupByPattern(origin.result_pattern) != null)
+                    .{ .pattern_binder = .{ .binder = binder } }
+                else if (hoisted_constants.lookupByPattern(origin.result_pattern)) |hoisted|
+                    selectedHoistedConstUse(hoisted, .{ .binder = binder })
+                else
+                    checkedArtifactInvariant("synthetic pattern-extraction lookup had no selected root entry", .{});
 
                 const id: ResolvedValueRefId = @enumFromInt(@as(u32, @intCast(records.items.len)));
                 try records.append(allocator, .{
                     .expr = expr.id,
-                    .ref = selectedHoistedConstUse(hoisted, .{ .binder = binder }),
+                    .ref = resolved_ref,
                     .checked_ty = expr.ty,
                     .scope_depth = 0,
                 });
@@ -15292,6 +15401,7 @@ fn categorizeValueRef(
     platform_required_declarations: *const PlatformRequiredDeclarationTable,
     platform_required_bindings: *const PlatformRequiredBindingTable,
     top_level_values: *const TopLevelValueTable,
+    selected_hoisted_callables: *const SelectedHoistedCallableTable,
     hoisted_constants: *const HoistedConstTable,
     local_pattern_roles: *const LocalPatternRoleIndex,
     checked_bodies: *const CheckedBodyStore,
@@ -15304,6 +15414,7 @@ fn categorizeValueRef(
             local.pattern_idx,
             hosted_procs,
             top_level_values,
+            selected_hoisted_callables,
             hoisted_constants,
             local_pattern_roles,
             checked_bodies,
@@ -15456,6 +15567,7 @@ fn categorizeLocalValueRef(
     pattern: CIR.Pattern.Idx,
     hosted_procs: *const HostedProcTable,
     top_level_values: *const TopLevelValueTable,
+    selected_hoisted_callables: *const SelectedHoistedCallableTable,
     hoisted_constants: *const HoistedConstTable,
     local_pattern_roles: *const LocalPatternRoleIndex,
     checked_bodies: *const CheckedBodyStore,
@@ -15493,6 +15605,17 @@ fn categorizeLocalValueRef(
         }
         unreachable;
     };
+
+    if (selected_hoisted_callables.lookupByPattern(checked_pattern)) |binding| {
+        return .{ .top_level_proc = .{
+            .binding = .{ .top_level = .{
+                .artifact = artifact_key,
+                .binding = binding,
+            } },
+            .source_fn_ty_template = .{},
+            .runtime_result_provenance = null,
+        } };
+    }
 
     if (hoisted_constants.lookupByPattern(checked_pattern)) |hoisted| {
         return selectedHoistedConstUse(hoisted, .{ .binder = binder });
@@ -23561,9 +23684,17 @@ pub const CompileTimeRootTable = struct {
                 ModuleEnv.varFrom(pattern)
             else
                 module.exprType(selected.expr);
-            if (sourceTypeIsFunction(module, source_ty)) {
-                checkedArtifactInvariant("function-typed selected hoisted root reached data-constant publication", .{});
-            }
+            const source_is_function = sourceTypeIsFunction(module, source_ty);
+            const kind: CompileTimeRootKind = switch (selected.value_kind) {
+                .data_constant => if (source_is_function)
+                    checkedArtifactInvariant("function-typed selected root was classified as a data constant", .{})
+                else
+                    .hoisted_constant,
+                .callable_binding => if (!source_is_function)
+                    checkedArtifactInvariant("non-function selected root was classified as a callable binding", .{})
+                else
+                    .callable_binding,
+            };
             const checked_expr = try checkedExprIdForSelectedHoistedRoot(
                 allocator,
                 module,
@@ -23575,7 +23706,7 @@ pub const CompileTimeRootTable = struct {
             const hoisted_body = try hoist_roots.cloneBody(allocator, selected.body);
             try appendCompileTimeRoot(&roots, allocator, .{
                 .module_idx = module.moduleIndex(),
-                .kind = .hoisted_constant,
+                .kind = kind,
                 .source = .{ .hoisted = .{
                     .index = @intCast(selected_index),
                     .expr = selected.expr,
@@ -32143,7 +32274,7 @@ pub fn publishFromTypedModule(
     var source_nodes = try CheckedSourceNodes.init(allocator, module);
     defer source_nodes.deinit(allocator);
 
-    var checked_type_publication = try CheckedTypeStore.fromModule(allocator, module, &canonical_names, artifact_key, inputs.imports, inputs.available_artifacts, &source_nodes);
+    var checked_type_publication = try CheckedTypeStore.fromModule(allocator, module, &canonical_names, artifact_key, inputs.imports, inputs.available_artifacts, &source_nodes, inputs.hoisted_roots);
     defer checked_type_publication.deinitIndex(allocator);
     errdefer checked_type_publication.store.deinit(allocator);
     const checked_types = &checked_type_publication.store;
@@ -32309,6 +32440,16 @@ pub fn publishFromTypedModule(
     );
     errdefer hoisted_constants.deinit(allocator);
 
+    var selected_hoisted_callables = try SelectedHoistedCallableTable.fromRoots(
+        allocator,
+        module,
+        checked_bodies,
+        &compile_time_roots,
+        &callable_eval_templates,
+        &top_level_procedure_bindings,
+    );
+    defer selected_hoisted_callables.deinit(allocator);
+
     var resolved_value_refs = try ResolvedValueRefTable.fromModule(
         allocator,
         modules,
@@ -32321,6 +32462,7 @@ pub fn publishFromTypedModule(
         &platform_required_declarations,
         &platform_required_bindings,
         &top_level_values,
+        &selected_hoisted_callables,
         &hoisted_constants,
         &checked_type_publication,
         checked_bodies,
@@ -32736,7 +32878,7 @@ fn expectProvidedExportKind(
     );
     var builtin_source_nodes = try CheckedSourceNodes.init(allocator, builtin_module);
     defer builtin_source_nodes.deinit(allocator);
-    var builtin_checked_type_publication = try CheckedTypeStore.fromModule(allocator, builtin_module, &builtin_names, builtin_key, &.{}, &.{}, &builtin_source_nodes);
+    var builtin_checked_type_publication = try CheckedTypeStore.fromModule(allocator, builtin_module, &builtin_names, builtin_key, &.{}, &.{}, &builtin_source_nodes, &.{});
     defer builtin_checked_type_publication.deinit(allocator);
     const empty_checked_bodies = CheckedBodyStore{};
     const empty_checked_const_bodies = CheckedConstBodyTable{};
@@ -32867,7 +33009,7 @@ fn expectProvidedExportKind(
     var source_nodes = try CheckedSourceNodes.init(allocator, module);
     defer source_nodes.deinit(allocator);
 
-    var checked_type_publication = try CheckedTypeStore.fromModule(allocator, module, &canonical_names, artifact_key, &builtin_imports, &.{}, &source_nodes);
+    var checked_type_publication = try CheckedTypeStore.fromModule(allocator, module, &canonical_names, artifact_key, &builtin_imports, &.{}, &source_nodes, &.{});
     defer checked_type_publication.deinit(allocator);
     const checked_types = &checked_type_publication.store;
 
@@ -33013,6 +33155,16 @@ fn expectProvidedExportKind(
     );
     defer hoisted_constants.deinit(allocator);
 
+    var selected_hoisted_callables = try SelectedHoistedCallableTable.fromRoots(
+        allocator,
+        module,
+        checked_bodies,
+        &compile_time_roots,
+        &callable_eval_templates,
+        &top_level_procedure_bindings,
+    );
+    defer selected_hoisted_callables.deinit(allocator);
+
     const provides = try publishProvidesMetadata(allocator, module, &canonical_names);
     defer allocator.free(provides);
 
@@ -33028,6 +33180,7 @@ fn expectProvidedExportKind(
         &platform_required_declarations,
         &platform_required_bindings,
         &top_level_values,
+        &selected_hoisted_callables,
         &hoisted_constants,
         &checked_type_publication,
         checked_bodies,

--- a/src/check/hoist_roots.zig
+++ b/src/check/hoist_roots.zig
@@ -30,8 +30,8 @@ pub const Body = union(enum) {
 /// The runtime value shape produced by a selected root.
 ///
 /// This is decided by the checker after solving and consumed directly by
-/// checked artifact publication. Later stages must not recover it from the
-/// source expression or checked type.
+/// checked artifact publication. Source expressions and checked types are
+/// validation inputs, not alternate sources for this fact.
 pub const ValueKind = enum(u8) {
     data_constant,
     callable_binding,

--- a/src/check/hoist_roots.zig
+++ b/src/check/hoist_roots.zig
@@ -7,7 +7,7 @@ const CIR = can.CIR;
 const Allocator = std.mem.Allocator;
 
 /// Version tag for the checked-stage hoisted-root selection algorithm.
-pub const selection_algorithm_version: u64 = 1;
+pub const selection_algorithm_version: u64 = 2;
 
 /// Collection of hoisted roots selected for a checked module.
 pub const SelectedHoistedRootSet = struct {
@@ -25,6 +25,16 @@ pub const PatternExtraction = struct {
 pub const Body = union(enum) {
     expr,
     pattern_extraction: PatternExtraction,
+};
+
+/// The runtime value shape produced by a selected root.
+///
+/// This is decided by the checker after solving and consumed directly by
+/// checked artifact publication. Later stages must not recover it from the
+/// source expression or checked type.
+pub const ValueKind = enum(u8) {
+    data_constant,
+    callable_binding,
 };
 
 /// A root selected during checking for compile-time evaluation.
@@ -45,6 +55,8 @@ pub const SelectedHoistedRoot = struct {
     /// The root body shape. Pattern extraction roots are sparse selected-root
     /// metadata; no per-expression hoistability summary is stored.
     body: Body = .expr,
+    /// Whether finalization archives a data constant or an exact callable.
+    value_kind: ValueKind = .data_constant,
 };
 
 /// Clones a hoisted-root body into the caller's allocator when needed.
@@ -69,6 +81,7 @@ pub fn cloneSelectedRoot(allocator: Allocator, root: SelectedHoistedRoot) Alloca
         .expr = root.expr,
         .pattern = root.pattern,
         .body = try cloneBody(allocator, root.body),
+        .value_kind = root.value_kind,
     };
 }
 

--- a/src/check/test/hoist_roots_test.zig
+++ b/src/check/test/hoist_roots_test.zig
@@ -756,17 +756,28 @@ test "hoist roots publish top-level destructure binders used by executable roots
         \\s = { req: 7, other: 1 }
         \\{ req, .. } = s
         \\(a, b) = (1, 2)
-        \\main = req
+        \\ops : { scale : U64 -> U64, other : U64 }
+        \\ops = { scale: |x| x * 2, other: 0 }
+        \\{ scale, .. } = ops
+        \\main = scale(21)
     , &.{"main"});
     defer test_env.deinit();
 
     try test_env.assertNoErrors();
     const roots = test_env.checker.selectedHoistedRoots();
-    try std.testing.expectEqual(@as(usize, 3), roots.len);
+    try std.testing.expectEqual(@as(usize, 4), roots.len);
+    var data_constant_count: usize = 0;
+    var callable_binding_count: usize = 0;
     for (roots) |root| {
         try expectPatternExtractionRoot(root);
         try std.testing.expect(test_env.checker.selectedHoistedRootIsTopLevel(root));
+        switch (root.value_kind) {
+            .data_constant => data_constant_count += 1,
+            .callable_binding => callable_binding_count += 1,
+        }
     }
+    try std.testing.expectEqual(@as(usize, 3), data_constant_count);
+    try std.testing.expectEqual(@as(usize, 1), callable_binding_count);
 }
 
 test "hoist roots selected for single-branch match tuple binders" {

--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -3195,6 +3195,22 @@ test "Repl - top-level destructure definitions publish their binders" {
     defer testing.allocator.free(tuple_sum);
     try testing.expectEqualStrings("3.0", tuple_sum);
 
+    const funcs_anno = try repl.step("funcs : { scale : U64 -> U64, other : U64 }");
+    defer testing.allocator.free(funcs_anno);
+    try testing.expectEqualStrings("", funcs_anno);
+
+    const funcs_assigned = try repl.step("funcs = { scale: |x| x * 2, other: 0 }");
+    defer testing.allocator.free(funcs_assigned);
+    try testing.expectEqualStrings("assigned `funcs`", funcs_assigned);
+
+    const funcs_destructure = try repl.step("{ scale, .. } = funcs");
+    defer testing.allocator.free(funcs_destructure);
+    try testing.expectEqualStrings("assigned `scale`", funcs_destructure);
+
+    const scaled = try repl.step("scale(21)");
+    defer testing.allocator.free(scaled);
+    try testing.expectEqualStrings("42", scaled);
+
     const config = reporting.ReportingConfig.initForTesting();
     const req_type = try repl.executeCommandWithConfig(.{ .type_of = "req" }, config);
     defer req_type.deinit(testing.allocator);

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -2465,8 +2465,11 @@ pub const Coordinator = struct {
         for (artifact.compile_time_roots.roots) |root| {
             switch (root.kind) {
                 .hoisted_constant => count += 1,
+                .callable_binding => switch (root.source) {
+                    .hoisted => count += 1,
+                    .def, .expr, .statement, .required_binding => {},
+                },
                 .constant,
-                .callable_binding,
                 .expect,
                 .numeral_conversion,
                 .quote_conversion,
@@ -2487,8 +2490,11 @@ pub const Coordinator = struct {
         for (artifact.compile_time_roots.roots) |root| {
             switch (root.kind) {
                 .hoisted_constant => {},
+                .callable_binding => switch (root.source) {
+                    .hoisted => {},
+                    .def, .expr, .statement, .required_binding => continue,
+                },
                 .constant,
-                .callable_binding,
                 .expect,
                 .numeral_conversion,
                 .quote_conversion,
@@ -2501,14 +2507,24 @@ pub const Coordinator = struct {
                 .expr,
                 .statement,
                 .required_binding,
-                => coordinatorInvariant("hoisted constant root had non-expression source", .{}),
+                => coordinatorInvariant("selected hoisted root had non-expression source", .{}),
             };
             const body = root.hoisted_body orelse
-                coordinatorInvariant("hoisted constant root was missing selected-root body", .{});
+                coordinatorInvariant("selected hoisted root was missing its body", .{});
             roots[i] = .{
                 .expr = source_expr,
                 .pattern = root.source_pattern,
                 .body = try check.HoistRoots.cloneBody(allocator, body),
+                .value_kind = switch (root.kind) {
+                    .hoisted_constant => .data_constant,
+                    .callable_binding => .callable_binding,
+                    .constant,
+                    .expect,
+                    .numeral_conversion,
+                    .quote_conversion,
+                    .field_default,
+                    => unreachable,
+                },
             };
             initialized += 1;
             i += 1;
@@ -5377,6 +5393,9 @@ const PatternExtractionRegionStatsError = error{
     PatternExtractionValueWasNotSyntheticLookup,
     PatternExtractionLookupPatternMismatch,
     PatternExtractionLookupWasNotResolved,
+    PatternExtractionResolvedRefMissing,
+    PatternExtractionCallableLookupWasNotLexical,
+    PatternExtractionConstantLookupWasNotHoisted,
 };
 
 var shared_test_builtins: ?eval.BuiltinModules = null;
@@ -6309,7 +6328,20 @@ fn hashPatternExtractionRegionsForView(
     view: check.CheckedArtifact.ImportedModuleView,
 ) PatternExtractionRegionStatsError!void {
     for (view.compile_time_roots.roots) |root| {
-        if (root.kind != .hoisted_constant) continue;
+        const is_selected_root = switch (root.kind) {
+            .hoisted_constant => true,
+            .callable_binding => switch (root.source) {
+                .hoisted => true,
+                .def, .expr, .statement, .required_binding => false,
+            },
+            .constant,
+            .expect,
+            .numeral_conversion,
+            .quote_conversion,
+            .field_default,
+            => false,
+        };
+        if (!is_selected_root) continue;
         const body = root.hoisted_body orelse continue;
         const extraction = switch (body) {
             .expr => continue,
@@ -6353,6 +6385,19 @@ fn hashPatternExtractionRegionsForView(
         const lookup = synthetic_lookup.data.lookup_local;
         if (lookup.pattern != root_pattern) return error.PatternExtractionLookupPatternMismatch;
         if (lookup.resolved == null) return error.PatternExtractionLookupWasNotResolved;
+        const resolved_index = @intFromEnum(lookup.resolved.?);
+        if (resolved_index >= view.resolved_value_refs.records.len) return error.PatternExtractionResolvedRefMissing;
+        const resolved = view.resolved_value_refs.records[resolved_index].ref;
+        switch (root.kind) {
+            .callable_binding => if (resolved != .pattern_binder) return error.PatternExtractionCallableLookupWasNotLexical,
+            .hoisted_constant => if (resolved != .selected_hoisted_const) return error.PatternExtractionConstantLookupWasNotHoisted,
+            .constant,
+            .expect,
+            .numeral_conversion,
+            .quote_conversion,
+            .field_default,
+            => unreachable,
+        }
 
         hasher.update(&view.key.bytes);
         hashU32IntoSha256(hasher, @intFromEnum(root.id));
@@ -6634,11 +6679,15 @@ test "Coordinator checked module cache preserves hoisted roots on hit" {
         \\    Ok(value) => value
         \\}
         \\
+        \\ops : { scale : I64 -> I64, other : I64 }
+        \\ops = { scale: |x| x + 2.I64, other: 0 }
+        \\{ scale, .. } = ops
+        \\
         \\main! = |args| {
         \\    pair = (top, 2.I64)
         \\    (left, right) = pair
         \\    Ok(tag_value) = Ok(45.I64)
-        \\    _ = left + right + tag_value + List.len(args).to_i64_wrap()
+        \\    _ = scale(left + right) + tag_value + List.len(args).to_i64_wrap()
         \\    Echo.line!(message)
         \\    Ok({})
         \\}
@@ -6681,7 +6730,7 @@ test "Coordinator checked module cache preserves hoisted roots on hit" {
 
     const first = try compileAppWithCheckedModuleCache(allocator, cache_dir, app_path);
     try std.testing.expect(first.hoisted_constants >= 2);
-    try std.testing.expect(first.pattern_extraction_regions.count >= 3);
+    try std.testing.expect(first.pattern_extraction_regions.count >= 4);
     try std.testing.expect(first.exhaustiveness_sites.count > 0);
 
     const second = try compileAppWithCheckedModuleCache(allocator, cache_dir, app_path);

--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -925,4 +925,32 @@ pub const tests = [_]TestCase{
         ,
         .expected = .{ .crash = {} },
     },
+    .{
+        // https://github.com/roc-lang/roc/issues/10483
+        .name = "issue 10483: top-level record destructure binder is callable from another root",
+        .source_kind = .module,
+        .source =
+        \\s : { scale : U64 -> U64, other : U64 }
+        \\s = { scale: |x| x * 2, other: 0 }
+        \\
+        \\{ scale, .. } = s
+        \\
+        \\main = scale(21)
+        ,
+        .expected = .{ .inspect_str = "42" },
+    },
+    .{
+        // https://github.com/roc-lang/roc/issues/10483
+        .name = "issue 10483: top-level destructure preserves callable values nested in data",
+        .source_kind = .module,
+        .source =
+        \\s : { ops : { scale : U64 -> U64 }, other : U64 }
+        \\s = { ops: { scale: |x| x * 2 }, other: 0 }
+        \\
+        \\{ ops, .. } = s
+        \\
+        \\main = ops.scale(21)
+        ,
+        .expected = .{ .inspect_str = "42" },
+    },
 };

--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -949,7 +949,8 @@ pub const tests = [_]TestCase{
         \\
         \\{ ops, .. } = s
         \\
-        \\main = ops.scale(21)
+        \\scale = ops.scale
+        \\main = scale(21)
         ,
         .expected = .{ .inspect_str = "42" },
     },


### PR DESCRIPTION
Top-level destructuring now publishes function-valued binders as explicit callable compile-time roots, so cross-root uses consume stable checked identities instead of falling through to lexical pattern binders. The same producer metadata survives checked-artifact cache republishing, while the synthetic extraction match keeps its internal lookup lexical and CTFE archives the exact callable value.

Fixes #10483.