### PR TITLE
Fix nominal record structural field order

### DIFF
--- a/design.md
+++ b/design.md
@@ -6069,9 +6069,10 @@ the record-field label that matches the lexicographic backing row; a padding
 entry stores the ordinal of the corresponding checked padding type in
 `padding_field_types`. The padding type itself is not duplicated in the
 declared-order entry, so generic nominal instantiation substitutes padding types
-in exactly one place. When no padding entry exists, Monotype and later stages
-discard the source order and reuse the structural backing layout. When padding
-exists, they propagate the declared layout order explicitly.
+in exactly one place. Monotype preserves this field metadata because boxy
+aggregate descriptors also consume it. Layout selection is independent:
+without padding, LSS and boxy's runtime layout path reuse the structural
+backing; with padding, they propagate an explicit declared-order policy.
 
 For named types, checking outputs:
 
@@ -7329,11 +7330,12 @@ caches of explicit checked and boxy lowering data. They must not recover missing
 data from source syntax, type display strings, backend symbols, or runtime
 bytes.
 
-Boxy representation planning consumes checked nominal declared-order entries
-only when an unnamed field opts the declaration into declared-order layout. For
-usage payloads whose finalized representation points at a local or imported
-box-payload capability, the planner obtains the instantiated backing root and
-padding roots from that capability rather than treating empty
+Boxy representation planning preserves checked nominal declared-field entries
+as explicit aggregate metadata for runtime descriptor lowering. Separately, an
+unnamed field selects declared-order runtime layout. For usage payloads whose
+finalized representation points at a local or imported box-payload capability,
+the planner obtains the instantiated backing root and padding roots from that
+capability rather than treating empty
 `padding_field_types` on the usage payload as absence of padding. Imported
 capability roots are source-module checked ids; the planner maps them into the
 root checked type store by their exported checked type digests. Named declared
@@ -7341,10 +7343,12 @@ fields from imported declarations are matched against the mapped root backing
 row through checked field-label text, not by assuming equal module-local label
 ids. The planner lowers each named entry to the matching backing-row child and
 each padding entry to the instantiated padding type referenced by its ordinal.
-The boxy layout planner then emits a struct span with explicit declared-order
-policy. Without padding it reuses the structural backing representation. The
-ordinary layout store commits the selected policy; boxy does not implement a
-separate nominal layout algorithm.
+For descriptor payloads the boxy layout planner can emit a structurally ordered
+span from the declared-field metadata. For ordinary runtime layout, it emits a
+declared-order span only when padding selects that policy; without padding it
+reuses the structural backing representation. The ordinary layout store commits
+the selected policy; boxy does not implement a separate nominal layout
+algorithm.
 
 Boxy tag-union planning stores tag variants explicitly, separately from payload
 children. The representation's child span still contains payload children in
@@ -8315,10 +8319,11 @@ a single fixed order, so the declared order is not recoverable from the lowered
 record itself. Canonicalization preserves it—a nominal declaration's record
 annotation keeps its fields in source order—and checking records it as
 explicit CheckedModule data distinct from the (lexicographic) backing row,
-so later stages never rescan declarations. Monotype lowering and boxy planning
-use the presence of explicit checked padding types to select the declared-order
-policy. They propagate source order only for that policy; otherwise they reuse
-the structural backing row. The layout graph records the selected policy on the
+so later stages never rescan declarations. Monotype lowering preserves this
+metadata for boxy aggregate descriptor planning. LSS and boxy representation
+planning use the presence of explicit checked padding types to select the
+declared-order layout policy; otherwise their runtime layout path reuses the
+structural backing row. The layout graph records the selected policy on the
 struct span, and the store commits it without probing or reconstructing intent.
 Field-name resolution continues to use the lexicographic row order, independent
 of the layout offset map. The same policy is consumed by the interpreter's

--- a/design.md
+++ b/design.md
@@ -6060,17 +6060,18 @@ payloads use payload position order. Monotype lowering copies those spans
 directly. It does not sort by display text, declaration spelling, runtime
 encoding, or incidental map iteration.
 
-Nominal records additionally carry their declared field order as separate
-explicit data, because their runtime layout follows declaration order rather
-than the lexicographic row order (see Nominal Record Field Order). The
-lexicographic row order remains the identity used for field-name resolution;
-declared order feeds only layout. In CheckedModule data this is a flat
-`CheckedDeclaredField` pool. A named entry stores the record-field label that
-must be matched against the lexicographic backing row; a padding entry stores
-the ordinal of the corresponding checked padding type in
+Checked nominal records preserve their declared field order as separate
+explicit data so source-level unnamed fields are not lost when the backing row
+is sorted lexicographically (see Nominal Record Field Order). The lexicographic
+row order remains the identity used for field-name resolution. In CheckedModule
+data the source order is a flat `CheckedDeclaredField` pool. A named entry stores
+the record-field label that matches the lexicographic backing row; a padding
+entry stores the ordinal of the corresponding checked padding type in
 `padding_field_types`. The padding type itself is not duplicated in the
-declared-order entry, so generic nominal instantiation substitutes padding
-types in exactly one place. These stay two separate data.
+declared-order entry, so generic nominal instantiation substitutes padding types
+in exactly one place. When no padding entry exists, Monotype and later stages
+discard the source order and reuse the structural backing layout. When padding
+exists, they propagate the declared layout order explicitly.
 
 For named types, checking outputs:
 
@@ -7329,20 +7330,21 @@ data from source syntax, type display strings, backend symbols, or runtime
 bytes.
 
 Boxy representation planning consumes checked nominal declared-order entries
-directly. For usage payloads whose finalized representation points at a local or
-imported box-payload capability, the planner obtains the instantiated backing
-root and padding roots from that capability rather than treating empty
+only when an unnamed field opts the declaration into declared-order layout. For
+usage payloads whose finalized representation points at a local or imported
+box-payload capability, the planner obtains the instantiated backing root and
+padding roots from that capability rather than treating empty
 `padding_field_types` on the usage payload as absence of padding. Imported
 capability roots are source-module checked ids; the planner maps them into the
-root checked type store by their exported checked type digests. Named
-declared fields from imported declarations are matched against the mapped
-root backing row through checked field-label text, not by assuming equal
-module-local label ids. The planner lowers each named entry to the matching
-backing-row child and each padding entry to the instantiated padding type
-referenced by its ordinal. The boxy layout planner then emits a nominal struct
-node in that declared order and marks it with the shared layout graph's
-nominal-struct marker. The ordinary layout store verifies or repairs the field
-order; boxy does not implement a separate nominal layout algorithm.
+root checked type store by their exported checked type digests. Named declared
+fields from imported declarations are matched against the mapped root backing
+row through checked field-label text, not by assuming equal module-local label
+ids. The planner lowers each named entry to the matching backing-row child and
+each padding entry to the instantiated padding type referenced by its ordinal.
+The boxy layout planner then emits a struct span with explicit declared-order
+policy. Without padding it reuses the structural backing representation. The
+ordinary layout store commits the selected policy; boxy does not implement a
+separate nominal layout algorithm.
 
 Boxy tag-union planning stores tag variants explicitly, separately from payload
 children. The representation's child span still contains payload children in
@@ -8306,20 +8308,21 @@ alignment to the struct, so pure padding never inflates a struct's alignment.
 Using an unnamed field in a structural record type is rejected during
 canonicalization.
 
-Declared field order is explicit data. Record rows are sorted lexicographically
-by name at several stages (checking, Monotype row lowering, and Monotype
-instantiation) because field-name resolution and digests depend on a single
-fixed order, so the declared order is not recoverable from the lowered record
-itself. Canonicalization preserves it—a nominal declaration's record
+Declared field order is explicit checked data. Record rows are sorted
+lexicographically by name at several stages (checking, Monotype row lowering,
+and Monotype instantiation) because field-name resolution and digests depend on
+a single fixed order, so the declared order is not recoverable from the lowered
+record itself. Canonicalization preserves it—a nominal declaration's record
 annotation keeps its fields in source order—and checking records it as
 explicit CheckedModule data distinct from the (lexicographic) backing row,
-so later stages consume it without rescanning declarations. Monotype lowering,
-boxy planning, and layout lowering all use this checked datum. The struct
-commit uses
-it only for the unnamed-field opt-in described above; otherwise nominal records
-use the structural order of their backing row. Field-name resolution continues
-to use the lexicographic row order, independent of the layout offset map. The
-same data is consumed by the interpreter's layout store, so all backends agree.
+so later stages never rescan declarations. Monotype lowering and boxy planning
+use the presence of explicit checked padding types to select the declared-order
+policy. They propagate source order only for that policy; otherwise they reuse
+the structural backing row. The layout graph records the selected policy on the
+struct span, and the store commits it without probing or reconstructing intent.
+Field-name resolution continues to use the lexicographic row order, independent
+of the layout offset map. The same policy is consumed by the interpreter's
+layout store, so all backends agree.
 
 ### Pattern Lowering
 

--- a/src/check/const_store.zig
+++ b/src/check/const_store.zig
@@ -413,7 +413,7 @@ pub const ConstTypeStore = struct {
     field_pool: std.ArrayList(TypeField),
     /// Flat pool of tag-union variants.
     tag_pool: std.ArrayList(TypeTag),
-    /// Flat pool of nominal declared field order entries.
+    /// Flat pool of opted-in nominal declared layout order entries.
     declared_field_pool: std.ArrayList(TypeDeclaredField),
     /// True for a store reconstructed from a serialized buffer.
     serialized: bool = false,

--- a/src/check/const_store.zig
+++ b/src/check/const_store.zig
@@ -413,7 +413,7 @@ pub const ConstTypeStore = struct {
     field_pool: std.ArrayList(TypeField),
     /// Flat pool of tag-union variants.
     tag_pool: std.ArrayList(TypeTag),
-    /// Flat pool of opted-in nominal declared layout order entries.
+    /// Flat pool of nominal declared field entries.
     declared_field_pool: std.ArrayList(TypeDeclaredField),
     /// True for a store reconstructed from a serialized buffer.
     serialized: bool = false,

--- a/src/glue/checked_artifact_layout_resolver.zig
+++ b/src/glue/checked_artifact_layout_resolver.zig
@@ -458,8 +458,7 @@ pub const Resolver = struct {
         }
 
         const span = try build_state.graph.appendFields(self.allocator, graph_fields.items);
-        build_state.graph.setNode(placeholder, .{ .struct_ = span });
-        try build_state.graph.markNominalStruct(self.allocator, placeholder);
+        build_state.graph.setNode(placeholder, .{ .struct_ = build_state.graph.declaredOrder(span) });
         return true;
     }
 
@@ -487,7 +486,7 @@ pub const Resolver = struct {
                 .child = try self.buildFieldSlotRef(artifact, field, build_state),
             });
         }
-        return self.buildStructNode(build_state, graph_fields.items, false);
+        return self.buildStructNode(build_state, graph_fields.items);
     }
 
     /// The internal layout slot of one checked record field (design.md "Field
@@ -536,7 +535,7 @@ pub const Resolver = struct {
                 .child = try self.buildRefForType(artifact, item, .ordinary, build_state),
             });
         }
-        return self.buildStructNode(build_state, fields.items, false);
+        return self.buildStructNode(build_state, fields.items);
     }
 
     fn buildTagUnionRef(
@@ -581,13 +580,11 @@ pub const Resolver = struct {
         self: *Resolver,
         build_state: *BuildState,
         fields: []const GraphField,
-        nominal_struct: bool,
     ) Error!GraphRef {
         if (fields.len == 0) return .{ .canonical = .zst };
         const node_id = try build_state.graph.reserveNode(self.allocator);
         const span = try build_state.graph.appendFields(self.allocator, fields);
         build_state.graph.setNode(node_id, .{ .struct_ = span });
-        if (nominal_struct) try build_state.graph.markNominalStruct(self.allocator, node_id);
         return .{ .local = node_id };
     }
 

--- a/src/layout/field_order.zig
+++ b/src/layout/field_order.zig
@@ -4,10 +4,11 @@
 //! produced here, so both describe the same memory layout.
 //!
 //! Structural (anonymous) records and no-`_` nominal records lay their fields out
-//! by descending sort key, then ascending field name, so source order never
-//! reaches memory. The sort key is target-independent (a pointer sorts between
-//! 4- and 8-byte alignment), so the field order is identical on 32-bit and 64-bit
-//! targets. `computeStructuralFieldOrder` produces that permutation.
+//! by descending sort key, then ascending canonical semantic index, so source
+//! order never reaches memory. A record's semantic index is its alphabetical
+//! field-name rank; a tuple's is its element index. The sort key is
+//! target-independent (a pointer sorts between 4- and 8-byte alignment), so the
+//! field order is identical on 32-bit and 64-bit targets.
 //!
 //! Nominal records that opt into declared-order layout (by including an unnamed
 //! `_` field) are laid out verbatim with C-style padding directly by the layout
@@ -16,26 +17,29 @@
 const std = @import("std");
 const SortKey = @import("layout.zig").SortKey;
 
-/// The sort key and name of one structural-record field.
+/// The total ordering key of one structural field.
 pub const StructuralField = struct {
     /// Target-independent ordering key. A pointer sorts between 4- and 8-byte
     /// alignment, so the resulting field order is the same on 32-bit and 64-bit
     /// targets. Padding fields pass `.align_1`.
     sort_key: SortKey,
-    /// Field name, used only as the tie-break among equal-sort-key fields.
-    /// Pass `""` to fall back to a pure stable sort-key sort (the layout
-    /// store's pair-struct path, whose callers presort by name elsewhere).
-    name: []const u8,
+    /// Canonical semantic field index, used as the tie-break among equal sort
+    /// keys. For records this is alphabetical field-name rank; for tuples it is
+    /// the original element index.
+    semantic_index: u16,
 };
 
-/// Stable sort of structural-record fields: sort key descending, then field
-/// name ascending. Empty names degrade to a pure stable sort-key sort,
-/// preserving input order for equal sort keys (matching the layout store's
-/// existing pair-struct behavior).
+/// Whether `a` precedes `b` in canonical structural field order.
+pub fn comesBefore(a: StructuralField, b: StructuralField) bool {
+    if (a.sort_key != b.sort_key) return a.sort_key.sortsBefore(b.sort_key);
+    return a.semantic_index < b.semantic_index;
+}
+
+/// Sort structural fields by their total canonical key.
 ///
 /// `out_order` is filled with a permutation of `0..fields.len`: `out_order[k]`
 /// is the index into `fields` of the field that occupies memory slot `k`. No
-/// allocation is required (the block sort works in place).
+/// allocation is required.
 pub fn computeStructuralFieldOrder(
     fields: []const StructuralField,
     out_order: []u16,
@@ -48,15 +52,11 @@ pub fn computeStructuralFieldOrder(
         fields: []const StructuralField,
 
         pub fn lessThan(ctx: @This(), a: u16, b: u16) bool {
-            const fa = ctx.fields[a];
-            const fb = ctx.fields[b];
-            if (fa.sort_key != fb.sort_key) return fa.sort_key.sortsBefore(fb.sort_key);
-            return std.mem.order(u8, fa.name, fb.name) == .lt;
+            return comesBefore(ctx.fields[a], ctx.fields[b]);
         }
     };
 
-    // `std.sort.block` is a stable sort, so equal-key fields keep input order.
-    std.sort.block(u16, out_order, Ctx{ .fields = fields }, Ctx.lessThan);
+    std.sort.pdq(u16, out_order, Ctx{ .fields = fields }, Ctx.lessThan);
 }
 
 const testing = std.testing;
@@ -70,31 +70,29 @@ fn expectStructuralOrder(fields: []const StructuralField, expected: []const u16)
 test "structural order sorts by descending sort key" {
     // Declared [u8, u64, u16] sorts to [u64, u16, u8] by descending sort key.
     const fields = [_]StructuralField{
-        .{ .sort_key = .align_1, .name = "a" },
-        .{ .sort_key = .align_8, .name = "b" },
-        .{ .sort_key = .align_2, .name = "c" },
+        .{ .sort_key = .align_1, .semantic_index = 0 },
+        .{ .sort_key = .align_8, .semantic_index = 1 },
+        .{ .sort_key = .align_2, .semantic_index = 2 },
     };
     try expectStructuralOrder(&fields, &.{ 1, 2, 0 });
 }
 
-test "structural order tie-breaks by ascending field name" {
-    // All same sort key, so the order is purely by ascending name: c, m, z.
+test "structural order tie-breaks by ascending semantic index" {
+    // All fields have the same sort key, so semantic index decides their order.
     const fields = [_]StructuralField{
-        .{ .sort_key = .align_4, .name = "z" },
-        .{ .sort_key = .align_4, .name = "m" },
-        .{ .sort_key = .align_4, .name = "c" },
+        .{ .sort_key = .align_4, .semantic_index = 2 },
+        .{ .sort_key = .align_4, .semantic_index = 1 },
+        .{ .sort_key = .align_4, .semantic_index = 0 },
     };
     try expectStructuralOrder(&fields, &.{ 2, 1, 0 });
 }
 
-test "structural order tie-breaks by name within each sort-key band" {
-    // align-8 band {y, a} sorts to a, y; align-4 band {x, b} sorts to b, x;
-    // the align-8 band precedes the align-4 band.
+test "structural order tie-breaks by semantic index within each sort-key band" {
     const fields = [_]StructuralField{
-        .{ .sort_key = .align_8, .name = "y" },
-        .{ .sort_key = .align_4, .name = "x" },
-        .{ .sort_key = .align_8, .name = "a" },
-        .{ .sort_key = .align_4, .name = "b" },
+        .{ .sort_key = .align_8, .semantic_index = 1 },
+        .{ .sort_key = .align_4, .semantic_index = 3 },
+        .{ .sort_key = .align_8, .semantic_index = 0 },
+        .{ .sort_key = .align_4, .semantic_index = 2 },
     };
     try expectStructuralOrder(&fields, &.{ 2, 0, 3, 1 });
 }
@@ -103,26 +101,24 @@ test "structural order places a pointer between 4- and 8-byte alignment" {
     // A pointer field sorts after align-8 scalars and before align-4 scalars,
     // regardless of target—the property that makes field order target-independent.
     const fields = [_]StructuralField{
-        .{ .sort_key = .align_4, .name = "a" }, // U32
-        .{ .sort_key = .pointer, .name = "b" }, // a pointer (Box/List/Str/...)
-        .{ .sort_key = .align_8, .name = "c" }, // U64
+        .{ .sort_key = .align_4, .semantic_index = 0 }, // U32
+        .{ .sort_key = .pointer, .semantic_index = 1 }, // a pointer (Box/List/Str/...)
+        .{ .sort_key = .align_8, .semantic_index = 2 }, // U64
     };
     try expectStructuralOrder(&fields, &.{ 2, 1, 0 });
 }
 
-test "structural order with empty names is a stable sort-key sort" {
-    // Empty names degrade to a pure stable sort-key sort: equal-key fields keep
-    // their input order (matching the layout store's pair structs).
+test "structural order does not depend on input order" {
     const fields = [_]StructuralField{
-        .{ .sort_key = .align_4, .name = "" },
-        .{ .sort_key = .align_8, .name = "" },
-        .{ .sort_key = .align_4, .name = "" },
-        .{ .sort_key = .align_8, .name = "" },
+        .{ .sort_key = .align_4, .semantic_index = 2 },
+        .{ .sort_key = .align_8, .semantic_index = 1 },
+        .{ .sort_key = .align_4, .semantic_index = 0 },
+        .{ .sort_key = .align_8, .semantic_index = 3 },
     };
-    try expectStructuralOrder(&fields, &.{ 1, 3, 0, 2 });
+    try expectStructuralOrder(&fields, &.{ 1, 3, 2, 0 });
 }
 
 test "structural order of a single field is trivial" {
-    const fields = [_]StructuralField{.{ .sort_key = .align_16, .name = "only" }};
+    const fields = [_]StructuralField{.{ .sort_key = .align_16, .semantic_index = 0 }};
     try expectStructuralOrder(&fields, &.{0});
 }

--- a/src/layout/graph.zig
+++ b/src/layout/graph.zig
@@ -40,13 +40,20 @@ pub const Field = struct {
     is_padding: bool = false,
 };
 
-/// Span into a graph's contiguous field storage.
+/// Span into a graph's contiguous field storage plus the explicit policy the
+/// store uses when committing those fields.
 pub const FieldSpan = extern struct {
     start: u32,
     len: u16,
+    order: FieldOrder = .structural,
+
+    pub const FieldOrder = enum(u8) {
+        structural,
+        declared,
+    };
 
     pub fn empty() FieldSpan {
-        return .{ .start = 0, .len = 0 };
+        return .{ .start = 0, .len = 0, .order = .structural };
     }
 };
 
@@ -77,32 +84,25 @@ pub const Graph = struct {
     nodes: std.ArrayListUnmanaged(Node) = .empty,
     fields: std.ArrayListUnmanaged(Field) = .empty,
     refs: std.ArrayListUnmanaged(Ref) = .empty,
-    /// Struct nodes whose fields are in nominal-record declared order. They are
-    /// ordinary `.struct_` nodes for every graph pass (cycle detection,
-    /// refcounting, boxing); only the final commit differs, keeping declared
-    /// order (repaired for padding) instead of sorting by alignment. See
-    /// `field_order` and design.md "Nominal Record Field Order".
-    nominal_structs: std.ArrayListUnmanaged(NodeId) = .empty,
 
     /// Release all graph storage.
     pub fn deinit(self: *Graph, allocator: std.mem.Allocator) void {
         self.nodes.deinit(allocator);
         self.fields.deinit(allocator);
         self.refs.deinit(allocator);
-        self.nominal_structs.deinit(allocator);
     }
 
-    /// Mark a `.struct_` node as a nominal record laid out in declared order.
-    pub fn markNominalStruct(self: *Graph, allocator: std.mem.Allocator, id: NodeId) Allocator.Error!void {
-        try self.nominal_structs.append(allocator, id);
-    }
-
-    /// Whether `id` was marked as a nominal-record struct node.
-    pub fn isNominalStruct(self: *const Graph, id: NodeId) bool {
-        for (self.nominal_structs.items) |marked| {
-            if (marked == id) return true;
+    /// Mark a field span as declaration-ordered. Only nominal records with an
+    /// unnamed padding field may select this policy.
+    pub fn declaredOrder(self: *const Graph, span: FieldSpan) FieldSpan {
+        var has_padding = false;
+        for (self.getFields(span)) |field| {
+            has_padding = has_padding or field.is_padding;
         }
-        return false;
+        std.debug.assert(has_padding);
+        var declared = span;
+        declared.order = .declared;
+        return declared;
     }
 
     /// Reserve a local node id before its final shape is known.
@@ -126,6 +126,7 @@ pub const Graph = struct {
         return .{
             .start = start,
             .len = @intCast(fields.len),
+            .order = .structural,
         };
     }
 

--- a/src/layout/store.zig
+++ b/src/layout/store.zig
@@ -43,16 +43,6 @@ fn assertAppendIdx(expected: usize, idx: anytype) void {
     }
 }
 
-/// Whether any field is an unnamed `_` padding spacer. A nominal record opts into
-/// declared-order-plus-padding layout by including such a field; without one it
-/// lays out like a structural record.
-fn hasAnyPaddingField(fields: []const StructField) bool {
-    for (fields) |field| {
-        if (field.is_padding) return true;
-    }
-    return false;
-}
-
 /// Errors that can occur during layout computation
 /// Stores Layout instances by Idx.
 ///
@@ -561,15 +551,15 @@ pub const Store = struct {
     pub const insertTuple = insertStruct;
 
     /// Insert a record layout from field layouts in canonical record-field order.
-    /// The shared layout commit performs one stable sort by descending alignment,
-    /// preserving canonical alphabetical order among equal-alignment fields.
+    /// The shared layout commit sorts by descending sort key, then canonical
+    /// semantic index.
     pub fn putRecord(self: *Self, field_layouts: []const Layout) std.mem.Allocator.Error!Idx {
         return self.putTuple(field_layouts);
     }
 
     /// Insert a struct layout from semantic fields.
-    /// `fields[i].index` is the canonical semantic field index before the shared
-    /// stable alignment sort at layout commit.
+    /// `fields[i].index` is the canonical semantic field index used to break
+    /// ties between equal sort keys.
     pub fn putStructFields(self: *Self, fields: []const StructField) std.mem.Allocator.Error!Idx {
         const trace = tracy.traceNamed(@src(), "layoutStore.putStructFields");
         defer trace.end();
@@ -581,7 +571,7 @@ pub const Store = struct {
         var temp_fields = std.ArrayList(StructField).empty;
         defer temp_fields.deinit(self.allocator);
         try temp_fields.appendSlice(self.allocator, fields);
-        try self.stableSortStructFieldsByLayoutAlignment(temp_fields.items);
+        self.sortStructFields(temp_fields.items);
 
         const sizes = self.structSizes(temp_fields.items);
         if (sizes.get(.u64) == 0) {
@@ -631,36 +621,31 @@ pub const Store = struct {
         return self.putStructFields(temp_fields.items);
     }
 
-    /// Sort structural-record / tuple fields by descending sort key, stably.
-    /// Routes through the shared `field_order.computeStructuralFieldOrder` so the
-    /// layout store and `roc glue` order structural records by the exact same
-    /// logic. The sort key is target-independent (a pointer sorts between 4- and
-    /// 8-byte alignment), so the resulting field order is identical on 32-bit and
-    /// 64-bit targets. Empty field names keep the pure stable sort: callers
-    /// presort by name elsewhere, so equal-key fields stay in input order.
-    fn stableSortStructFieldsByLayoutAlignment(self: *Self, fields: []StructField) std.mem.Allocator.Error!void {
+    /// Sort structural-record / tuple fields by the total canonical key:
+    /// descending target-independent sort key, then ascending semantic index.
+    /// This is independent of the order in which callers present the fields.
+    fn sortStructFields(self: *Self, fields: []StructField) void {
         if (fields.len <= 1) return;
 
-        const structural = try self.allocator.alloc(field_order.StructuralField, fields.len);
-        defer self.allocator.free(structural);
-        for (fields, structural) |field, *out| {
-            out.* = .{
-                .sort_key = if (field.is_padding)
-                    .align_1
-                else
-                    self.getLayout(field.layout).sortKey(),
-                .name = "",
-            };
-        }
+        const SortContext = struct {
+            store: *const Self,
 
-        const order = try self.allocator.alloc(u16, fields.len);
-        defer self.allocator.free(order);
-        field_order.computeStructuralFieldOrder(structural, order);
+            fn key(ctx: @This(), field: StructField) field_order.StructuralField {
+                return .{
+                    .sort_key = if (field.is_padding)
+                        .align_1
+                    else
+                        ctx.store.getLayout(field.layout).sortKey(),
+                    .semantic_index = field.index,
+                };
+            }
 
-        const scratch = try self.allocator.alloc(StructField, fields.len);
-        defer self.allocator.free(scratch);
-        for (order, scratch) |src, *dst| dst.* = fields[src];
-        @memcpy(fields, scratch);
+            fn lessThan(ctx: @This(), a: StructField, b: StructField) bool {
+                return field_order.comesBefore(ctx.key(a), ctx.key(b));
+            }
+        };
+
+        std.sort.pdq(StructField, fields, SortContext{ .store = self }, SortContext.lessThan);
     }
 
     /// Create a tag union layout from pre-computed variant payload layouts.
@@ -694,7 +679,7 @@ pub const Store = struct {
         var temp_fields = std.ArrayList(StructField).empty;
         defer temp_fields.deinit(self.allocator);
         try temp_fields.appendSlice(self.allocator, input_fields);
-        try self.stableSortStructFieldsByLayoutAlignment(temp_fields.items);
+        self.sortStructFields(temp_fields.items);
 
         const sizes = self.structSizes(temp_fields.items);
         if (sizes.get(.u64) == 0) {
@@ -888,9 +873,7 @@ pub const Store = struct {
                 .struct_ => |span| {
                     try key.append(allocator, 4);
                     const fields = graph.getFields(span);
-                    var has_padding = false;
-                    for (fields) |field| has_padding = has_padding or field.is_padding;
-                    try key.append(allocator, @intFromBool(graph.isNominalStruct(node_id) and has_padding));
+                    try key.append(allocator, @intFromEnum(span.order));
                     try appendValue(key, allocator, @as(u16, @intCast(fields.len)));
                     for (fields) |field| {
                         try appendValue(key, allocator, field.index);
@@ -1113,7 +1096,9 @@ pub const Store = struct {
                             .is_padding = field.is_padding,
                         });
                     }
-                    break :blk .{ .struct_ = try working.appendFields(self.allocator, fields.items) };
+                    var translated = try working.appendFields(self.allocator, fields.items);
+                    if (span.order == .declared) translated = working.declaredOrder(translated);
+                    break :blk .{ .struct_ = translated };
                 },
                 .tag_union => |span| blk: {
                     var refs = std.ArrayList(GraphRef).empty;
@@ -1126,9 +1111,6 @@ pub const Store = struct {
                 },
             };
             working.setNode(working_node_id, translated_node);
-            if (graph.isNominalStruct(@enumFromInt(i))) {
-                try working.markNominalStruct(self.allocator, working_node_id);
-            }
         }
 
         const raw_layouts = try self.allocator.alloc(Idx, graph.nodes.items.len);
@@ -1801,12 +1783,7 @@ pub const Store = struct {
                                     });
                                 }
 
-                                // A nominal record keeps its declared order (and auto-pads)
-                                // only when it opts in with an unnamed `_` field; otherwise it
-                                // lays out exactly like a structural record (sort-key sorted).
-                                const keep_declared = self_finalizer.graph.isNominalStruct(node_id) and
-                                    hasAnyPaddingField(fields.items);
-                                break :blk_struct if (keep_declared)
+                                break :blk_struct if (span.order == .declared)
                                     try self_finalizer.store.putNominalStructFields(fields.items)
                                 else
                                     try self_finalizer.store.putStructFields(fields.items);
@@ -2643,7 +2620,7 @@ pub const Store = struct {
     }
 };
 
-test "layout store commits struct fields with a stable alignment sort" {
+test "layout store commits struct fields in canonical structural order" {
     const testing = std.testing;
 
     var store = try Store.init(testing.allocator, .u64);
@@ -2752,8 +2729,7 @@ test "commitGraph keeps a nominal struct with a `_` field in declared order" {
         .{ .index = 4, .child = .{ .canonical = .u32 } },
         .{ .index = 5, .child = .{ .canonical = .zst }, .is_padding = true },
     });
-    graph.setNode(struct_node, .{ .struct_ = fields });
-    try graph.markNominalStruct(testing.allocator, struct_node);
+    graph.setNode(struct_node, .{ .struct_ = graph.declaredOrder(fields) });
 
     var commit = try store.commitGraph(&graph, .{ .local = struct_node });
     defer commit.deinit(testing.allocator);
@@ -2765,7 +2741,7 @@ test "commitGraph keeps a nominal struct with a `_` field in declared order" {
     try testing.expectEqual(@as(u32, 8), store.getStructSize(struct_idx));
 }
 
-test "commitGraph lays out a no-padding nominal struct structurally" {
+test "commitGraph structural order ignores graph field presentation order" {
     const testing = std.testing;
 
     var store = try Store.init(testing.allocator, .u64);
@@ -2775,30 +2751,24 @@ test "commitGraph lays out a no-padding nominal struct structurally" {
     defer graph.deinit(testing.allocator);
 
     const struct_node = try graph.reserveNode(testing.allocator);
-    // Declared order { a:U8, b:U8, c:U8, d:U8, e:U32 } with no `_` field: a
-    // nominal record without an opt-in marker lays out like a structural record,
-    // so the u32 sorts to offset 0.
+    // The graph presents two equal-key fields in reverse semantic order. A
+    // structural commit must use their canonical indices, never input order.
     const fields = try graph.appendFields(testing.allocator, &[_]graph_mod.Field{
-        .{ .index = 0, .child = .{ .canonical = .u8 } },
-        .{ .index = 1, .child = .{ .canonical = .u8 } },
-        .{ .index = 2, .child = .{ .canonical = .u8 } },
-        .{ .index = 3, .child = .{ .canonical = .u8 } },
-        .{ .index = 4, .child = .{ .canonical = .u32 } },
+        .{ .index = 1, .child = .{ .canonical = .f32 } },
+        .{ .index = 0, .child = .{ .canonical = .f32 } },
     });
     graph.setNode(struct_node, .{ .struct_ = fields });
-    try graph.markNominalStruct(testing.allocator, struct_node);
 
     var commit = try store.commitGraph(&graph, .{ .local = struct_node });
     defer commit.deinit(testing.allocator);
 
     const struct_idx = store.getLayout(commit.root_idx).getStruct().idx;
-    // Structural sort hoists the u32 to offset 0.
-    try testing.expectEqual(@as(u32, 0), store.getStructFieldOffsetByOriginalIndex(struct_idx, 4));
-    try testing.expectEqual(@as(u32, 4), store.getStructFieldOffsetByOriginalIndex(struct_idx, 0));
+    try testing.expectEqual(@as(u32, 0), store.getStructFieldOffsetByOriginalIndex(struct_idx, 0));
+    try testing.expectEqual(@as(u32, 4), store.getStructFieldOffsetByOriginalIndex(struct_idx, 1));
     try testing.expectEqual(@as(u32, 8), store.getStructSize(struct_idx));
 }
 
-test "uninterned struct layouts use the same stable alignment sort as interned ones" {
+test "uninterned struct layouts use the same structural order as interned ones" {
     const testing = std.testing;
 
     var store = try Store.init(testing.allocator, .u64);

--- a/src/layout/store.zig
+++ b/src/layout/store.zig
@@ -606,9 +606,8 @@ pub const Store = struct {
         );
     }
 
-    /// Insert a tuple layout from concrete element layouts.
-    /// The shared layout commit performs one stable sort by descending alignment,
-    /// preserving original tuple index order among equal-alignment elements.
+    /// Insert a tuple layout from concrete element layouts. The shared layout
+    /// commit sorts by descending sort key, then original tuple index.
     pub fn putTuple(self: *Self, element_layouts: []const Layout) std.mem.Allocator.Error!Idx {
         var temp_fields = std.ArrayList(StructField).empty;
         defer temp_fields.deinit(self.allocator);
@@ -673,13 +672,17 @@ pub const Store = struct {
         );
     }
 
-    fn buildUninternedStructLayout(self: *Self, input_fields: []const StructField) std.mem.Allocator.Error!Layout {
+    fn buildUninternedStructLayout(
+        self: *Self,
+        input_fields: []const StructField,
+        order: graph_mod.FieldSpan.FieldOrder,
+    ) std.mem.Allocator.Error!Layout {
         std.debug.assert(input_fields.len >= 1);
 
         var temp_fields = std.ArrayList(StructField).empty;
         defer temp_fields.deinit(self.allocator);
         try temp_fields.appendSlice(self.allocator, input_fields);
-        self.sortStructFields(temp_fields.items);
+        if (order == .structural) self.sortStructFields(temp_fields.items);
 
         const sizes = self.structSizes(temp_fields.items);
         if (sizes.get(.u64) == 0) {
@@ -1569,7 +1572,7 @@ pub const Store = struct {
 
                             self_resolver.store.updateLayout(
                                 self_resolver.raw_layouts[index],
-                                try self_resolver.store.buildUninternedStructLayout(fields.items),
+                                try self_resolver.store.buildUninternedStructLayout(fields.items, span.order),
                             );
                         }
                     },
@@ -2784,7 +2787,7 @@ test "uninterned struct layouts use the same structural order as interned ones" 
 
     const interned_idx = try store.putStructFields(&semantic_fields);
     const interned_layout = store.getLayout(interned_idx);
-    const uninterned_layout = try store.buildUninternedStructLayout(&semantic_fields);
+    const uninterned_layout = try store.buildUninternedStructLayout(&semantic_fields, .structural);
 
     try testing.expectEqual(LayoutTag.struct_, interned_layout.tag);
     try testing.expectEqual(LayoutTag.struct_, uninterned_layout.tag);
@@ -2804,6 +2807,25 @@ test "uninterned struct layouts use the same structural order as interned ones" 
         try testing.expectEqual(left.index, right.index);
         try testing.expectEqual(left.layout, right.layout);
     }
+}
+
+test "uninterned struct layouts preserve explicit declared order" {
+    const testing = std.testing;
+
+    var store = try Store.init(testing.allocator, .u64);
+    defer store.deinit();
+
+    const declared_fields = [_]StructField{
+        .{ .index = 0, .layout = .u8 },
+        .{ .index = 2, .layout = .zst, .is_padding = true },
+        .{ .index = 1, .layout = .u64 },
+    };
+    const uninterned_layout = try store.buildUninternedStructLayout(&declared_fields, .declared);
+    const struct_idx = uninterned_layout.getStruct().idx;
+
+    try testing.expectEqual(@as(u32, 0), store.getStructFieldOffsetByOriginalIndex(struct_idx, 0));
+    try testing.expectEqual(@as(u32, 8), store.getStructFieldOffsetByOriginalIndex(struct_idx, 1));
+    try testing.expectEqual(@as(u32, 16), store.getStructSize(struct_idx));
 }
 
 test "layout store records explicit resolved list layout facts for boxed lists" {

--- a/src/postcheck/boxy/layouts.zig
+++ b/src/postcheck/boxy/layouts.zig
@@ -708,8 +708,8 @@ const GraphBuilder = struct {
                     if (rep.declared_fields.len != 0) {
                         const node = try self.graph.reserveNode(self.parent.allocator);
                         self.local_nodes[index] = node;
-                        self.graph.setNode(node, .{ .struct_ = try self.nominalDeclaredFields(rep) });
-                        try self.graph.markNominalStruct(self.parent.allocator, node);
+                        const fields = try self.nominalDeclaredFields(rep);
+                        self.graph.setNode(node, .{ .struct_ = self.graph.declaredOrder(fields) });
                         return .{ .local = node };
                     }
                     return try self.inputForRep(self.parent.requiredSingleChild(rep_id, .nominal_backing).rep);
@@ -774,27 +774,12 @@ const GraphBuilder = struct {
 
         const fields = try self.parent.allocator.alloc(layout.GraphField, declared_fields.len);
         defer self.parent.allocator.free(fields);
-        var has_padding = false;
         for (declared_fields, fields) |field, *out| {
-            if (field.is_padding) has_padding = true;
             out.* = .{
                 .index = field.index,
                 .child = try self.inputForRep(field.rep),
                 .is_padding = field.is_padding,
             };
-        }
-        // Without padding a nominal record lays out exactly like a structural
-        // record: the shared struct commit sorts by descending alignment and
-        // breaks ties by input order, so the fields are presented in identity
-        // index order to match how structural records (already alphabetical)
-        // are presented. Records that opt into declared order carry padding and
-        // keep their source-declared field order verbatim.
-        if (!has_padding) {
-            std.mem.sort(layout.GraphField, fields, {}, struct {
-                fn lessThan(_: void, a: layout.GraphField, b: layout.GraphField) bool {
-                    return a.index < b.index;
-                }
-            }.lessThan);
         }
         return try self.graph.appendFields(self.parent.allocator, fields);
     }
@@ -1287,6 +1272,66 @@ test "boxy layout planner commits nominal declared fields through shared layout 
     try std.testing.expectEqual(@as(u32, 0), store.getStructFieldOffsetByOriginalIndex(struct_idx, 0));
     try std.testing.expectEqual(@as(u32, 2), store.getStructFieldOffsetByOriginalIndex(struct_idx, 1));
     try std.testing.expectEqual(@as(u32, 4), store.getStructSize(struct_idx));
+}
+
+test "boxy layout planner reuses structural backing order without padding" {
+    const gpa = std.testing.allocator;
+
+    const field_a: RecordFieldLabelId = @enumFromInt(1);
+    const field_b: RecordFieldLabelId = @enumFromInt(2);
+    const record_fields = [_]checked.CheckedRecordField{
+        .{ .name = field_a, .ty = @enumFromInt(fixtureTableIndex(0)) },
+        .{ .name = field_b, .ty = @enumFromInt(fixtureTableIndex(0)) },
+    };
+    const declared_fields = [_]checked.CheckedDeclaredField{
+        .{ .named = field_b },
+        .{ .named = field_a },
+    };
+    const nominal_declarations = [_]checked.CheckedNominalDeclaration{.{
+        .id = @enumFromInt(fixtureTableIndex(0)),
+        .nominal = .{ .module = @enumFromInt(4), .type_name = @enumFromInt(3), .source_decl = null },
+        .source_statement = 0,
+        .declaration_root = @enumFromInt(3),
+        .backing = @enumFromInt(2),
+        .df_start = 0,
+        .df_len = declared_fields.len,
+    }};
+    const payloads = [_]checked.StoredCheckedTypePayload{
+        .{ .nominal = builtinNominal(.f32, @enumFromInt(fixtureTableIndex(0)), .{}) },
+        .{ .empty_record = {} },
+        .{ .record = .{ .fields = .{ .start = 0, .len = 2 }, .ext = @enumFromInt(1) } },
+        .{ .nominal = .{
+            .name = @enumFromInt(3),
+            .origin_module = @enumFromInt(4),
+            .owner_module = .{},
+            .is_opaque = false,
+            .representation = .{ .local_declaration = @enumFromInt(fixtureTableIndex(0)) },
+            .declared_fields = .{ .start = 0, .len = 2 },
+        } },
+    };
+    const view = checked.CheckedTypeStoreView{
+        .stored_payloads = &payloads,
+        .nominal_declarations = &nominal_declarations,
+        .record_field_pool = &record_fields,
+        .declared_field_pool = &declared_fields,
+    };
+
+    var program = try Plan.analyzeCheckedTypes(gpa, view, &.{@as(checked.CheckedTypeId, @enumFromInt(3))}, .{});
+    defer program.deinit();
+    const nominal = program.representations.items[@intFromEnum(program.root_reps.items[0])];
+    try std.testing.expectEqual(@as(usize, 0), program.declaredFieldSlice(nominal.declared_fields).len);
+
+    var store = try layout.Store.init(gpa, .u64);
+    defer store.deinit();
+
+    var layouts = try build(gpa, &program, &store, .{});
+    defer layouts.deinit();
+
+    const runtime = layouts.rep_layouts[@intFromEnum(program.root_reps.items[0])].worker;
+    const struct_idx = store.getLayout(runtime.layoutIdx()).getStruct().idx;
+    try std.testing.expectEqual(@as(u32, 0), store.getStructFieldOffsetByOriginalIndex(struct_idx, 0));
+    try std.testing.expectEqual(@as(u32, 4), store.getStructFieldOffsetByOriginalIndex(struct_idx, 1));
+    try std.testing.expectEqual(@as(u32, 8), store.getStructSize(struct_idx));
 }
 
 fn builtinNominal(

--- a/src/postcheck/boxy/layouts.zig
+++ b/src/postcheck/boxy/layouts.zig
@@ -705,11 +705,16 @@ const GraphBuilder = struct {
         if (rep.kind == .nominal) {
             switch (rep.kind.nominal) {
                 .transparent => {
-                    if (rep.declared_fields.len != 0) {
+                    const needs_field_node = rep.record_field_order == .declared or
+                        (self.descriptor_payload and rep.declared_fields.len != 0);
+                    if (needs_field_node) {
                         const node = try self.graph.reserveNode(self.parent.allocator);
                         self.local_nodes[index] = node;
                         const fields = try self.nominalDeclaredFields(rep);
-                        self.graph.setNode(node, .{ .struct_ = self.graph.declaredOrder(fields) });
+                        self.graph.setNode(node, .{ .struct_ = if (rep.record_field_order == .declared)
+                            self.graph.declaredOrder(fields)
+                        else
+                            fields });
                         return .{ .local = node };
                     }
                     return try self.inputForRep(self.parent.requiredSingleChild(rep_id, .nominal_backing).rep);
@@ -1260,6 +1265,8 @@ test "boxy layout planner commits nominal declared fields through shared layout 
 
     var program = try Plan.analyzeCheckedTypes(gpa, view, &.{@as(checked.CheckedTypeId, @enumFromInt(4))}, .{});
     defer program.deinit();
+    const nominal = program.representations.items[@intFromEnum(program.root_reps.items[0])];
+    try std.testing.expectEqual(Plan.RecordFieldOrder.declared, nominal.record_field_order);
 
     var store = try layout.Store.init(gpa, .u64);
     defer store.deinit();
@@ -1319,7 +1326,8 @@ test "boxy layout planner reuses structural backing order without padding" {
     var program = try Plan.analyzeCheckedTypes(gpa, view, &.{@as(checked.CheckedTypeId, @enumFromInt(3))}, .{});
     defer program.deinit();
     const nominal = program.representations.items[@intFromEnum(program.root_reps.items[0])];
-    try std.testing.expectEqual(@as(usize, 0), program.declaredFieldSlice(nominal.declared_fields).len);
+    try std.testing.expectEqual(@as(usize, 2), program.declaredFieldSlice(nominal.declared_fields).len);
+    try std.testing.expectEqual(Plan.RecordFieldOrder.structural, nominal.record_field_order);
 
     var store = try layout.Store.init(gpa, .u64);
     defer store.deinit();

--- a/src/postcheck/boxy/plan.zig
+++ b/src/postcheck/boxy/plan.zig
@@ -4338,7 +4338,11 @@ const Builder = struct {
         }
         var declared_fields = Span.empty();
         const declared_order = store.type_store.declaredFieldSpan(named.declared_order);
-        if (declared_order.len != 0) {
+        var has_declared_padding = false;
+        for (declared_order) |field| {
+            has_declared_padding = has_declared_padding or field == .padding;
+        }
+        if (has_declared_padding) {
             if (named.kind == .alias) boxyPlanInvariant("stored alias carried nominal declared field order");
             const backing = backing_rep orelse
                 boxyPlanInvariant("stored nominal declared field order had no backing representation");
@@ -4878,14 +4882,17 @@ const Builder = struct {
     }
 
     fn nominalDeclaredSource(self: *Builder, view: ModuleView, nominal: checked.CheckedNominalType) ?NominalDeclaredSource {
-        if (nominal.declared_fields.len != 0) return .{
-            .field_view = view,
-            .fields = nominal.declared_fields,
-            .padding_view = view,
-            .padding_types = nominal.padding_field_types,
-        };
+        if (nominal.declared_fields.len != 0 and nominal.padding_field_types.len != 0) {
+            return .{
+                .field_view = view,
+                .fields = nominal.declared_fields,
+                .padding_view = view,
+                .padding_types = nominal.padding_field_types,
+            };
+        }
         if (nominal.builtin != null) return null;
         const lookup = self.nominalDeclarationFor(view, nominal) orelse return null;
+        if (lookup.padding_types.len == 0) return null;
         const fields = lookup.declaration.declaredFields(lookup.view.checked_types);
         if (fields.len == 0) return null;
         return .{

--- a/src/postcheck/boxy/plan.zig
+++ b/src/postcheck/boxy/plan.zig
@@ -210,13 +210,22 @@ pub const NominalBackingArgSubstitution = struct {
     actual_rep: TypeRepId,
 };
 
+/// Runtime field-order policy selected from checked nominal metadata.
+pub const RecordFieldOrder = enum(u8) {
+    structural,
+    declared,
+};
+
 /// Planner output describing one checked type's complete representation.
 pub const TypeRepresentation = struct {
     source_type: CheckedTypeIdentity,
     kind: RepresentationKind,
     children: Span = .{},
     tag_variants: Span = .{},
+    /// Explicit nominal field metadata used by aggregate descriptor lowering.
+    /// `record_field_order` independently controls its runtime layout.
     declared_fields: Span = .{},
+    record_field_order: RecordFieldOrder = .structural,
     nominal_backing_arg_substitutions: Span = .{},
     dictionaries: Span = .{},
     descriptor: ?DescriptorRequirementId = null,
@@ -4337,12 +4346,13 @@ const Builder = struct {
             });
         }
         var declared_fields = Span.empty();
+        var record_field_order: RecordFieldOrder = .structural;
         const declared_order = store.type_store.declaredFieldSpan(named.declared_order);
         var has_declared_padding = false;
         for (declared_order) |field| {
             has_declared_padding = has_declared_padding or field == .padding;
         }
-        if (has_declared_padding) {
+        if (declared_order.len != 0) {
             if (named.kind == .alias) boxyPlanInvariant("stored alias carried nominal declared field order");
             const backing = backing_rep orelse
                 boxyPlanInvariant("stored nominal declared field order had no backing representation");
@@ -4398,6 +4408,7 @@ const Builder = struct {
             const start: u32 = @intCast(self.plan.declared_fields.items.len);
             try self.plan.declared_fields.appendSlice(self.allocator, pending.items);
             declared_fields = .{ .start = start, .len = @intCast(pending.items.len) };
+            if (has_declared_padding) record_field_order = .declared;
         }
 
         const kind: RepresentationKind = if (named.kind == .alias)
@@ -4420,6 +4431,7 @@ const Builder = struct {
             .kind = kind,
             .children = try self.commitPendingChildren(children.items),
             .declared_fields = declared_fields,
+            .record_field_order = record_field_order,
             .inspect_opaque = named.kind == .@"opaque" or
                 kind == .generated_field or
                 kind == .generated_field_names or
@@ -4717,11 +4729,12 @@ const Builder = struct {
         for (nominal.args, 0..) |arg, index| {
             try self.appendPendingChild(&children, view, .{ .nominal_arg = @intCast(index) }, arg);
         }
-        if (self.nominalPaddingSource(view, nominal)) |padding_source| {
-            for (padding_source.types, 0..) |padding, index| {
+        const padding_source = self.nominalPaddingSource(view, nominal);
+        if (padding_source) |source| {
+            for (source.types, 0..) |padding, index| {
                 try self.appendPendingChild(
                     &children,
-                    padding_source.view,
+                    source.view,
                     .{ .nominal_padding_field = @intCast(index) },
                     padding,
                 );
@@ -4745,6 +4758,7 @@ const Builder = struct {
                 .transparent },
             .children = try self.commitPendingChildren(children.items),
             .declared_fields = declared_fields,
+            .record_field_order = if (padding_source != null) .declared else .structural,
             .nominal_backing_arg_substitutions = backing_arg_substitutions,
             .inspect_opaque = nominal.is_opaque,
         };
@@ -4882,7 +4896,7 @@ const Builder = struct {
     }
 
     fn nominalDeclaredSource(self: *Builder, view: ModuleView, nominal: checked.CheckedNominalType) ?NominalDeclaredSource {
-        if (nominal.declared_fields.len != 0 and nominal.padding_field_types.len != 0) {
+        if (nominal.declared_fields.len != 0) {
             return .{
                 .field_view = view,
                 .fields = nominal.declared_fields,
@@ -4892,7 +4906,6 @@ const Builder = struct {
         }
         if (nominal.builtin != null) return null;
         const lookup = self.nominalDeclarationFor(view, nominal) orelse return null;
-        if (lookup.padding_types.len == 0) return null;
         const fields = lookup.declaration.declaredFields(lookup.view.checked_types);
         if (fields.len == 0) return null;
         return .{

--- a/src/postcheck/lambda_mono/type.zig
+++ b/src/postcheck/lambda_mono/type.zig
@@ -80,8 +80,8 @@ pub const FnVariant = struct {
     capture_ty: ?TypeId,
 };
 
-/// One entry of an opted-in nominal record's declared layout order. Mirrors
-/// `MonoType.DeclaredField`; consumed only by layout selection.
+/// One entry of a nominal record's declared fields. Mirrors
+/// `MonoType.DeclaredField`; consumed by layout and descriptor planning.
 pub const DeclaredField = union(enum) {
     named: names.RecordFieldNameId,
     padding: TypeId,
@@ -101,8 +101,7 @@ pub const Content = union(enum) {
             use: MonoType.BackingUse,
             authority: MonoType.BackingAuthority = .checked_public,
         } = null,
-        /// Declared layout order for a nominal/opaque record with unnamed
-        /// padding; empty otherwise.
+        /// Declared fields for a nominal/opaque record backing; empty otherwise.
         declared_order: Span = Span.empty(),
     },
     record: Span,

--- a/src/postcheck/lambda_mono/type.zig
+++ b/src/postcheck/lambda_mono/type.zig
@@ -80,7 +80,7 @@ pub const FnVariant = struct {
     capture_ty: ?TypeId,
 };
 
-/// One entry of a nominal record's declared layout order. Mirrors
+/// One entry of an opted-in nominal record's declared layout order. Mirrors
 /// `MonoType.DeclaredField`; consumed only by layout selection.
 pub const DeclaredField = union(enum) {
     named: names.RecordFieldNameId,
@@ -101,8 +101,8 @@ pub const Content = union(enum) {
             use: MonoType.BackingUse,
             authority: MonoType.BackingAuthority = .checked_public,
         } = null,
-        /// Declared field order for a nominal/opaque record backing; empty
-        /// otherwise.
+        /// Declared layout order for a nominal/opaque record with unnamed
+        /// padding; empty otherwise.
         declared_order: Span = Span.empty(),
     },
     record: Span,

--- a/src/postcheck/lambda_solved/type.zig
+++ b/src/postcheck/lambda_solved/type.zig
@@ -65,8 +65,8 @@ pub const FnMember = struct {
     captures: Span,
 };
 
-/// One entry of an opted-in nominal record's declared layout order; consumed
-/// only by layout selection (the backing row stays lexicographic).
+/// One entry of a nominal record's declared fields; consumed by layout and
+/// descriptor planning (the backing row stays lexicographic).
 pub const DeclaredField = union(enum) {
     named: names.RecordFieldNameId,
     padding: TypeVarId,
@@ -89,8 +89,7 @@ pub const Content = union(enum) {
             use: MonoType.BackingUse,
             authority: MonoType.BackingAuthority = .checked_public,
         } = null,
-        /// Declared layout order for a nominal/opaque record with unnamed
-        /// padding; empty otherwise.
+        /// Declared fields for a nominal/opaque record backing; empty otherwise.
         declared_order: Span = Span.empty(),
     },
     record: Span,

--- a/src/postcheck/lambda_solved/type.zig
+++ b/src/postcheck/lambda_solved/type.zig
@@ -65,8 +65,8 @@ pub const FnMember = struct {
     captures: Span,
 };
 
-/// One entry of a nominal record's declared layout order; consumed only by
-/// layout selection (the backing row stays lexicographic).
+/// One entry of an opted-in nominal record's declared layout order; consumed
+/// only by layout selection (the backing row stays lexicographic).
 pub const DeclaredField = union(enum) {
     named: names.RecordFieldNameId,
     padding: TypeVarId,
@@ -89,8 +89,8 @@ pub const Content = union(enum) {
             use: MonoType.BackingUse,
             authority: MonoType.BackingAuthority = .checked_public,
         } = null,
-        /// Declared field order for a nominal/opaque record backing; empty
-        /// otherwise.
+        /// Declared layout order for a nominal/opaque record with unnamed
+        /// padding; empty otherwise.
         declared_order: Span = Span.empty(),
     },
     record: Span,

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -5011,19 +5011,18 @@ const Builder = struct {
         };
     }
 
-    /// Builds the declared-layout-order span for a nominal/opaque record that
-    /// explicitly opts in with an unnamed padding field. Nominals without
-    /// padding return the empty span and reuse their lexicographically ordered
-    /// structural backing throughout post-check lowering.
+    /// Builds the declared-field span for a nominal/opaque record backing from
+    /// explicit checked metadata. Boxy uses it for aggregate descriptor
+    /// planning; LSS consumes it as layout order only when it contains padding.
+    /// The lowered backing row remains lexicographic.
     fn declaredOrderForNominal(self: *Builder, view: ModuleView, nominal: checked.CheckedNominalType) Allocator.Error!Type.Span {
-        if (nominal.declared_fields.len != 0 and nominal.padding_field_types.len != 0) {
+        if (nominal.declared_fields.len != 0) {
             return try self.lowerCheckedDeclaredOrder(view, nominal.declared_fields, view, nominal.padding_field_types);
         }
         const lookup = self.nominalDeclarationFor(view, nominal) orelse {
             if (!nominalHasDeclarationBacking(nominal)) return Type.Span.empty();
             Common.invariant("declaration-backed nominal reached Monotype lowering without declaration data");
         };
-        if (lookup.padding_field_tys.len == 0) return Type.Span.empty();
         const declared_fields = lookup.declaration.declaredFields(lookup.view.types);
         if (declared_fields.len != 0) {
             return try self.lowerCheckedDeclaredOrder(
@@ -16425,7 +16424,6 @@ const BodyContext = struct {
             if (!nominalHasDeclarationBacking(nominal)) return &.{};
             Common.invariant("declaration-backed nominal reached Monotype instantiation without declaration data");
         };
-        if (lookup.padding_field_tys.len == 0) return &.{};
         const fields = lookup.declaration.declaredRecordFields(lookup.view.types);
         if (fields.len == 0) return &.{};
 

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -5011,20 +5011,19 @@ const Builder = struct {
         };
     }
 
-    /// Builds the declared-field-order span for a nominal/opaque record backing
-    /// from its source declaration (the declaration backing preserves source
-    /// order, unlike the lexicographically-sorted lowered row). Returns the empty
-    /// span for non-record backings or encodings that intentionally have no
-    /// declaration backing. The span feeds layout selection only; the lowered
-    /// row stays lexicographic.
+    /// Builds the declared-layout-order span for a nominal/opaque record that
+    /// explicitly opts in with an unnamed padding field. Nominals without
+    /// padding return the empty span and reuse their lexicographically ordered
+    /// structural backing throughout post-check lowering.
     fn declaredOrderForNominal(self: *Builder, view: ModuleView, nominal: checked.CheckedNominalType) Allocator.Error!Type.Span {
-        if (nominal.declared_fields.len != 0) {
+        if (nominal.declared_fields.len != 0 and nominal.padding_field_types.len != 0) {
             return try self.lowerCheckedDeclaredOrder(view, nominal.declared_fields, view, nominal.padding_field_types);
         }
         const lookup = self.nominalDeclarationFor(view, nominal) orelse {
             if (!nominalHasDeclarationBacking(nominal)) return Type.Span.empty();
             Common.invariant("declaration-backed nominal reached Monotype lowering without declaration data");
         };
+        if (lookup.padding_field_tys.len == 0) return Type.Span.empty();
         const declared_fields = lookup.declaration.declaredFields(lookup.view.types);
         if (declared_fields.len != 0) {
             return try self.lowerCheckedDeclaredOrder(
@@ -16426,6 +16425,7 @@ const BodyContext = struct {
             if (!nominalHasDeclarationBacking(nominal)) return &.{};
             Common.invariant("declaration-backed nominal reached Monotype instantiation without declaration data");
         };
+        if (lookup.padding_field_tys.len == 0) return &.{};
         const fields = lookup.declaration.declaredRecordFields(lookup.view.types);
         if (fields.len == 0) return &.{};
 

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -150,7 +150,8 @@ pub const InstBacking = struct {
     authority: Type.BackingAuthority = .checked_public,
 };
 
-/// Declared field order while a named type is still in the instantiation graph.
+/// Declared layout order while an opted-in named record is still in the
+/// instantiation graph.
 pub const InstDeclaredField = union(enum(u8)) {
     named: names.RecordFieldNameId,
     padding: NodeId,
@@ -170,9 +171,9 @@ const InstNamed = struct {
     /// types. Imported finished Monotypes have this null and already carry
     /// their producer digest in `def.generated`.
     generated_iterator: ?InstGeneratedIterator = null,
-    /// Declared field order for a nominal/opaque record backing (empty
-    /// otherwise). Padding field types are graph nodes so sealing maps them to
-    /// immutable type ids with the rest of the named type.
+    /// Declared layout order for a nominal/opaque record with unnamed padding
+    /// (empty otherwise). Padding field types are graph nodes so sealing maps
+    /// them to immutable type ids with the rest of the named type.
     declared_order: []const InstDeclaredField = &.{},
 };
 

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -150,8 +150,8 @@ pub const InstBacking = struct {
     authority: Type.BackingAuthority = .checked_public,
 };
 
-/// Declared layout order while an opted-in named record is still in the
-/// instantiation graph.
+/// Declared nominal fields while a named record is still in the instantiation
+/// graph.
 pub const InstDeclaredField = union(enum(u8)) {
     named: names.RecordFieldNameId,
     padding: NodeId,
@@ -171,9 +171,9 @@ const InstNamed = struct {
     /// types. Imported finished Monotypes have this null and already carry
     /// their producer digest in `def.generated`.
     generated_iterator: ?InstGeneratedIterator = null,
-    /// Declared layout order for a nominal/opaque record with unnamed padding
-    /// (empty otherwise). Padding field types are graph nodes so sealing maps
-    /// them to immutable type ids with the rest of the named type.
+    /// Declared fields for a nominal/opaque record backing (empty otherwise).
+    /// Padding field types are graph nodes so sealing maps them to immutable
+    /// type ids with the rest of the named type.
     declared_order: []const InstDeclaredField = &.{},
 };
 

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -243,11 +243,10 @@ pub const MonoTypeTag = struct {
 /// Compatibility name for existing Monotype tag-union variant entries.
 pub const Tag = MonoTypeTag;
 
-/// One entry of a nominal record's declared layout order. The backing row is
-/// always lexicographic (for name resolution and digests); a nominal type
-/// additionally carries this declared order, which the layout commit consumes to
-/// place fields in source order with no internal padding. See design.md
-/// "Nominal Record Field Order".
+/// One entry of an opted-in nominal record's declared layout order. The backing
+/// row is always lexicographic; only a declaration containing an unnamed field
+/// carries this separate source order into post-check layout selection. See
+/// design.md "Nominal Record Field Order".
 pub const DeclaredField = union(enum(u8)) {
     /// A named backing field, matched against the lexicographic backing row by
     /// name at layout time.
@@ -267,8 +266,8 @@ pub const MonoTypeNode = union(enum(u8)) {
         builtin_owner: ?static_dispatch.BuiltinOwner = null,
         args: Span,
         backing: ?NamedBacking = null,
-        /// Declared field order for a nominal/opaque record backing; empty for
-        /// every other named type (consumed only by layout).
+        /// Declared layout order for a nominal/opaque record with unnamed
+        /// padding; empty for structural-layout records and other named types.
         declared_order: Span = Span.empty(),
     },
     record: Span,
@@ -3616,6 +3615,7 @@ test "monotype named type digest includes declared field order" {
     const field_b = try name_store.internRecordFieldLabel("b");
     const checked_ty: checked.CheckedTypeId = @enumFromInt(1);
     const i64_ty = try store.add(.{ .primitive = .i64 });
+    const padding_ty = try store.add(.zst);
     const fields = try store.addFields(&.{
         .{ .name = field_a, .ty = i64_ty, .default = null },
         .{ .name = field_b, .ty = i64_ty, .default = null },
@@ -3623,10 +3623,12 @@ test "monotype named type digest includes declared field order" {
     const backing = try store.add(.{ .record = fields });
     const order_ab = try store.addDeclaredFields(&.{
         .{ .named = field_a },
+        .{ .padding = padding_ty },
         .{ .named = field_b },
     });
     const order_ba = try store.addDeclaredFields(&.{
         .{ .named = field_b },
+        .{ .padding = padding_ty },
         .{ .named = field_a },
     });
 

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -243,10 +243,10 @@ pub const MonoTypeTag = struct {
 /// Compatibility name for existing Monotype tag-union variant entries.
 pub const Tag = MonoTypeTag;
 
-/// One entry of an opted-in nominal record's declared layout order. The backing
-/// row is always lexicographic; only a declaration containing an unnamed field
-/// carries this separate source order into post-check layout selection. See
-/// design.md "Nominal Record Field Order".
+/// One entry of a nominal record's declared fields. The backing row is always
+/// lexicographic; this separate source order supports boxy descriptor planning,
+/// and layout selection consumes it only when padding opts into declared order.
+/// See design.md "Nominal Record Field Order".
 pub const DeclaredField = union(enum(u8)) {
     /// A named backing field, matched against the lexicographic backing row by
     /// name at layout time.
@@ -266,8 +266,8 @@ pub const MonoTypeNode = union(enum(u8)) {
         builtin_owner: ?static_dispatch.BuiltinOwner = null,
         args: Span,
         backing: ?NamedBacking = null,
-        /// Declared layout order for a nominal/opaque record with unnamed
-        /// padding; empty for structural-layout records and other named types.
+        /// Declared fields for a nominal/opaque record backing; empty for other
+        /// named types.
         declared_order: Span = Span.empty(),
     },
     record: Span,
@@ -3615,7 +3615,6 @@ test "monotype named type digest includes declared field order" {
     const field_b = try name_store.internRecordFieldLabel("b");
     const checked_ty: checked.CheckedTypeId = @enumFromInt(1);
     const i64_ty = try store.add(.{ .primitive = .i64 });
-    const padding_ty = try store.add(.zst);
     const fields = try store.addFields(&.{
         .{ .name = field_a, .ty = i64_ty, .default = null },
         .{ .name = field_b, .ty = i64_ty, .default = null },
@@ -3623,12 +3622,10 @@ test "monotype named type digest includes declared field order" {
     const backing = try store.add(.{ .record = fields });
     const order_ab = try store.addDeclaredFields(&.{
         .{ .named = field_a },
-        .{ .padding = padding_ty },
         .{ .named = field_b },
     });
     const order_ba = try store.addDeclaredFields(&.{
         .{ .named = field_b },
-        .{ .padding = padding_ty },
         .{ .named = field_a },
     });
 

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -8943,25 +8943,20 @@ const Lowerer = struct {
                         return layout.localGraphInput(node);
                     }
 
-                    // A nominal or opaque record lays out its fields in declared
-                    // order. The declared-order channel carries that order (the
-                    // backing row stays lexicographic for name resolution); build
-                    // the struct node from it and mark it nominal so the shared
-                    // commit keeps declared order, repaired only for padding.
+                    // An unnamed field explicitly opts a nominal or opaque record
+                    // into declared-order layout. Without that marker the named
+                    // type reuses its structural backing layout directly.
                     // Reserve the node first (mapping both the named type and its
                     // backing) so a recursive backing field resolves to it.
                     if (named.kind != .alias and named.declared_order.len != 0 and
-                        self.lowerer.types.get(backing.ty) == .record)
+                        self.lowerer.types.get(backing.ty) == .record and
+                        self.declaredOrderHasPadding(named.declared_order))
                     {
                         const node = try self.graph.reserveNode(self.lowerer.allocator);
                         self.local_nodes[index] = node;
                         self.local_nodes[@intFromEnum(backing.ty)] = node;
-                        if (try self.declaredOrderStructFields(named.declared_order, backing.ty)) |field_span| {
-                            self.graph.setNode(node, .{ .struct_ = field_span });
-                            try self.graph.markNominalStruct(self.lowerer.allocator, node);
-                        } else {
-                            self.graph.setNode(node, try self.nodeForType(backing.ty));
-                        }
+                        const field_span = try self.declaredOrderStructFields(named.declared_order, backing.ty);
+                        self.graph.setNode(node, .{ .struct_ = self.graph.declaredOrder(field_span) });
                         return layout.localGraphInput(node);
                     }
 
@@ -9042,20 +9037,27 @@ const Lowerer = struct {
             return try self.graph.appendFields(self.lowerer.allocator, fields);
         }
 
-        /// Builds graph fields for a nominal record in declared order from its
-        /// declared-order channel. Each named entry maps to the matching backing
-        /// field, keeping `.index` = the field's lexicographic position so
-        /// name-resolution (which indexes the lexicographic backing row) and the
-        /// layout offset map stay consistent. Returns null when the backing is
-        /// not a record or the declared order does not cover the backing fields,
-        /// so the caller falls back to the structural path.
+        fn declaredOrderHasPadding(self: *LayoutGraphBuilder, declared_order: Type.Span) bool {
+            const entries = self.lowerer.types.declaredFieldSpan(declared_order);
+            for (0..entries.len) |i| {
+                if (GuardedList.at(entries, i) == .padding) return true;
+            }
+            return false;
+        }
+
+        /// Builds graph fields for an opted-in nominal record in declared order
+        /// from its explicit declared-order channel. Each named entry maps to the
+        /// matching backing field, keeping `.index` = the field's lexicographic
+        /// position so name-resolution (which indexes the lexicographic backing
+        /// row) and the layout offset map stay consistent. Inconsistent checked
+        /// metadata is a compiler invariant failure.
         fn declaredOrderStructFields(
             self: *LayoutGraphBuilder,
             declared_order: Type.Span,
             backing_ty: Type.TypeId,
-        ) Common.LowerError!?layout.GraphFieldSpan {
+        ) Common.LowerError!layout.GraphFieldSpan {
             const backing_content = self.lowerer.types.get(backing_ty);
-            if (backing_content != .record) return null;
+            if (backing_content != .record) return Common.invariant("declared-order nominal layout had a non-record backing");
             const backing_fields = self.lowerer.types.fieldSpan(backing_content.record);
             const entries = self.lowerer.types.declaredFieldSpan(declared_order);
 
@@ -9064,7 +9066,9 @@ const Lowerer = struct {
                 const entry = GuardedList.at(entries, entry_index);
                 if (entry == .named) named_count += 1;
             }
-            if (named_count != backing_fields.len) return null;
+            if (named_count != backing_fields.len) {
+                return Common.invariant("declared-order nominal layout did not cover its backing fields");
+            }
 
             const fields = try self.lowerer.allocator.alloc(layout.GraphField, entries.len);
             defer self.lowerer.allocator.free(fields);
@@ -9086,7 +9090,8 @@ const Lowerer = struct {
                                 break;
                             }
                         }
-                        const idx = lexicographic_index orelse return null;
+                        const idx = lexicographic_index orelse
+                            return Common.invariant("declared-order nominal field was absent from its backing record");
                         fields[i] = .{ .index = idx, .child = try self.inputForType(field_ty) };
                     },
                     .padding => |ty| {
@@ -9946,6 +9951,106 @@ test "layout lowering accepts tag payload alias backed by primitive" {
     const tag_union_info = lowerer.result.layouts.getTagUnionInfo(repro_layout);
     try std.testing.expectEqual(@as(usize, 1), tag_union_info.variants.len);
     try std.testing.expectEqual(layout.Idx.u32, tag_union_info.variants.get(0).payload_layout);
+}
+
+test "layout lowering sorts a padding-free nominal record structurally" {
+    const allocator = std.testing.allocator;
+
+    var solved = emptySolvedProgramForTest(allocator);
+    defer solved.deinit();
+
+    const module_identity = try solved.lifted.names.internModuleIdentity(&([_]u8{0x5A} ** 32));
+    const state_name = try solved.lifted.names.internTypeName("State");
+    const first_name = try solved.lifted.names.internRecordFieldLabel("first");
+    const second_name = try solved.lifted.names.internRecordFieldLabel("second");
+
+    var lowerer = try Lowerer.init(allocator, .u64, &solved, .{});
+    defer lowerer.deinit();
+
+    const f32_ty = try lowerer.types.add(.{ .primitive = .f32 });
+    // The backing row is lexicographic, as every stage stores it: `first` is
+    // original field index 0 and `second` is original field index 1.
+    const backing_fields = try lowerer.types.addFields(&.{
+        .{ .name = first_name, .ty = f32_ty, .default = null },
+        .{ .name = second_name, .ty = f32_ty, .default = null },
+    });
+    const backing_ty = try lowerer.types.add(.{ .record = backing_fields });
+    // `State := { second : F32, first : F32 }`: declared in reverse
+    // alphabetical order, with no unnamed `_` field.
+    const declared_order = try lowerer.types.addDeclaredFields(&.{
+        .{ .named = second_name },
+        .{ .named = first_name },
+    });
+    const state_ty = try lowerer.types.add(.{
+        .named = .{
+            // Layout lowering does not read checked type ids for this synthetic type.
+            .named_type = .{ .module = .{}, .ty = undefined },
+            .def = .{ .module = module_identity, .type_name = state_name },
+            .kind = .nominal,
+            .args = .empty(),
+            .backing = .{ .ty = backing_ty, .use = .inspectable },
+            .declared_order = declared_order,
+        },
+    });
+
+    // Repro for https://github.com/roc-lang/roc/issues/10649: a nominal record
+    // only opts into declared-order layout by including an unnamed `_` field.
+    // Without one it lays out exactly like its structural backing row (sort key
+    // descending, then field name ascending), which is also the order `roc glue`
+    // reports to platform authors. Both fields are F32, so the sort keys tie and
+    // the name order decides: `first` takes offset 0 and `second` offset 4.
+    const state_layout_idx = try lowerer.layoutOfType(state_ty);
+    const state_layout = lowerer.result.layouts.getLayout(state_layout_idx);
+    try std.testing.expectEqual(layout.LayoutTag.struct_, state_layout.tag);
+
+    const struct_idx = state_layout.getStruct().idx;
+    try std.testing.expectEqual(@as(u32, 8), lowerer.result.layouts.getStructSize(struct_idx));
+    try std.testing.expectEqual(@as(u32, 0), lowerer.result.layouts.getStructFieldOffsetByOriginalIndex(struct_idx, 0));
+    try std.testing.expectEqual(@as(u32, 4), lowerer.result.layouts.getStructFieldOffsetByOriginalIndex(struct_idx, 1));
+}
+
+test "layout lowering keeps opted-in nominal record declaration order" {
+    const allocator = std.testing.allocator;
+
+    var solved = emptySolvedProgramForTest(allocator);
+    defer solved.deinit();
+
+    const module_identity = try solved.lifted.names.internModuleIdentity(&([_]u8{0x5B} ** 32));
+    const state_name = try solved.lifted.names.internTypeName("State");
+    const first_name = try solved.lifted.names.internRecordFieldLabel("first");
+    const second_name = try solved.lifted.names.internRecordFieldLabel("second");
+
+    var lowerer = try Lowerer.init(allocator, .u64, &solved, .{});
+    defer lowerer.deinit();
+
+    const f32_ty = try lowerer.types.add(.{ .primitive = .f32 });
+    const padding_ty = try lowerer.types.add(.zst);
+    const backing_fields = try lowerer.types.addFields(&.{
+        .{ .name = first_name, .ty = f32_ty, .default = null },
+        .{ .name = second_name, .ty = f32_ty, .default = null },
+    });
+    const backing_ty = try lowerer.types.add(.{ .record = backing_fields });
+    const declared_order = try lowerer.types.addDeclaredFields(&.{
+        .{ .named = second_name },
+        .{ .padding = padding_ty },
+        .{ .named = first_name },
+    });
+    const state_ty = try lowerer.types.add(.{
+        .named = .{
+            .named_type = .{ .module = .{}, .ty = undefined },
+            .def = .{ .module = module_identity, .type_name = state_name },
+            .kind = .nominal,
+            .args = .empty(),
+            .backing = .{ .ty = backing_ty, .use = .inspectable },
+            .declared_order = declared_order,
+        },
+    });
+
+    const state_layout_idx = try lowerer.layoutOfType(state_ty);
+    const struct_idx = lowerer.result.layouts.getLayout(state_layout_idx).getStruct().idx;
+    try std.testing.expectEqual(@as(u32, 4), lowerer.result.layouts.getStructFieldOffsetByOriginalIndex(struct_idx, 0));
+    try std.testing.expectEqual(@as(u32, 0), lowerer.result.layouts.getStructFieldOffsetByOriginalIndex(struct_idx, 1));
+    try std.testing.expectEqual(@as(u32, 8), lowerer.result.layouts.getStructSize(struct_idx));
 }
 
 test "direct LIR lower declarations are referenced" {

--- a/test/glue/cli-main/host_wasm.rs
+++ b/test/glue/cli-main/host_wasm.rs
@@ -445,8 +445,7 @@ fn run_contract() {
         env_mut().fail("expected one log call");
     }
     if env_mut().checksum_count != 3 {
-        let count = env_mut().checksum_count;
-        env_mut().fail(format_args!("expected three checksum calls, saw {count}"));
+        env_mut().fail("expected three checksum calls");
     }
     if env_mut().allocator_error_count != 0 {
         env_mut().fail("allocator recorded errors");

--- a/test/glue/cli-main/host_wasm.zig
+++ b/test/glue/cli-main/host_wasm.zig
@@ -367,7 +367,7 @@ fn runContract() void {
         contract_env.fail("expected one log call");
     }
     if (contract_env.checksum_count != 3) {
-        contract_env.fail("expected three checksum calls, saw {}", .{contract_env.checksum_count});
+        contract_env.fail("expected three checksum calls");
     }
     if (contract_env.allocator_error_count != 0) {
         contract_env.fail("allocator recorded errors");


### PR DESCRIPTION
Nominal records without unnamed fields now reuse their structural backing order, while records with unnamed padding fields carry an explicit declared-order policy through the layout graph. Structural commitment also breaks equal layout-key ties with the canonical semantic field index, so field order cannot depend on caller presentation. This reconciles the design contract and keeps LSS, boxy, glue, and the shared layout store on the same ABI rule. Fixes #10649.