### PR TITLE
Add table literal sugar for lists of records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+## Unreleased
+
+### Table literals
+
+Table literals are row-oriented sugar for a list of records. Column names are
+written once; each body line is a row. After parsing, the compiler desugars
+them to `List({ ... })`, so later compiler stages never see a table type.
+
+The [homepage](https://www.roc-lang.org/) examples currently build that list by
+repeating every field name on every row:
+
+```roc
+print_remaining! = |todos|
+    todos
+        .keep_if(|todo| todo.status != Done)
+        .for_each!(|todo| echo!("- ${todo.name}\n"))
+
+main! = |_args| {
+    todos = [
+        { name: "Learn Roc",       status: Done },
+        { name: "Buy groceries",   status: Done },
+        { name: "Write blog post", status: InProgress },
+        { name: "Call mom",        status: NotStarted },
+    ]
+    print_remaining!(todos)
+    Ok({})
+}
+```
+
+The same program with a table literal keeps the filtering and printing, and
+writes the data as a grid:
+
+```roc
+print_remaining! = |todos|
+    todos
+        .keep_if(|todo| todo.status != Done)
+        .for_each!(|todo| echo!("- ${todo.name}\n"))
+
+main! = |_args| {
+    todos = table name, status {
+        "Learn Roc",       Done,
+        "Buy groceries",   Done,
+        "Write blog post", InProgress,
+        "Call mom",        NotStarted,
+    }
+    print_remaining!(todos)
+    Ok({})
+}
+```
+
+Columns can optionally be typed (`table name : Str, status { ... }`) so numeric
+literals pick up the column type instead of defaulting to `Dec`. `table` is a
+contextual keyword: `table(x)`, `table = …`, and `foo.table` stay ordinary
+names.
+
+See [Table literals](docs/langref/expressions.md#table-literals) in the language
+reference.

--- a/docs/langref/expressions.md
+++ b/docs/langref/expressions.md
@@ -23,6 +23,7 @@ Here are all the different types of expressions in Roc:
 - Number literals, e.g. `1` or `2.34` or `0.123e4`
 - List literals, e.g. `[1, 2]` or `[]` or `["foo"]`
 - Record literals, e.g. `{ x: 1, y: 2 }` or `{}` or `{ x, y, ..other_record }`
+- [Table literals](#table-literals), e.g. `table name, age { "Ada", 36 }` — sugar for a list of records
 - Tag literals, e.g. `Foo` or `Foo(bar)`
 - Tuple literals, e.g. `(a, b, "foo")`
 - Function literals (aka "lambdas"), e.g. `|a, b| a + b` or `|| c + d`
@@ -32,6 +33,48 @@ Here are all the different types of expressions in Roc:
 - [Block expressions](#block-expressions), e.g. `{ foo() }`
 
 There are no other types of expressions in the language.
+
+## [Table Literals](#table-literals) {#table-literals}
+
+A table literal is row-oriented syntax sugar for a [list](lists) of [records](records).
+After parsing, the compiler desugars it to that list; later compiler stages never see tables.
+
+```roc
+people = table name, age, favorite_color {
+    "Bob", 12, "blue",
+    "Alice", 17, "green",
+    "Eve", 13, "red",
+}
+```
+
+This is the same as:
+
+```roc
+people = [
+    { name: "Bob", age: 12, favorite_color: "blue" },
+    { name: "Alice", age: 17, favorite_color: "green" },
+    { name: "Eve", age: 13, favorite_color: "red" },
+]
+```
+
+Column names are lowercase identifiers. A column may optionally have a type:
+
+```roc
+people = table name : Str, age : U8, favorite_color : Str {
+    "Bob", 12, "blue",
+}
+```
+
+Typed columns are applied to the whole list so numeric literals pick up the column type
+(here `12` is a `U8` rather than the default `Dec`). An empty body is allowed when the
+columns are typed: `table name : Str, age : U8 {}`.
+
+`table` is a contextual keyword. `table(x)`, `table = …`, and `foo.table` keep using `table`
+as an ordinary name. A table needs at least one column; `table {}` is invalid.
+
+Each body line is one row of comma-separated expressions. A newline at table-body depth
+ends the row. Newlines inside `()`, `[]`, `{}`, or a lambda do not. Trailing commas before
+a newline or `}` are allowed.
 
 ## [Values](#values) {#values}
 

--- a/docs/langref/expressions.md
+++ b/docs/langref/expressions.md
@@ -69,8 +69,10 @@ Typed columns are applied to the whole list so numeric literals pick up the colu
 (here `12` is a `U8` rather than the default `Dec`). An empty body is allowed when the
 columns are typed: `table name : Str, age : U8 {}`.
 
-`table` is a contextual keyword. `table(x)`, `table = …`, and `foo.table` keep using `table`
-as an ordinary name. A table needs at least one column; `table {}` is invalid.
+`table` is a contextual keyword. A table literal starts only when `table` is followed on
+the same line by a column name or `{`. `table(x)`, `table = …`, `foo.table`, and a bare
+`table` at the end of a line keep using `table` as an ordinary name. A table needs at
+least one column; `table {}` is invalid.
 
 Each body line is one row of comma-separated expressions. A newline at table-body depth
 ends the row. Newlines inside `()`, `[]`, `{}`, or a lambda do not. Trailing commas before

--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -7424,6 +7424,153 @@ pub fn canonicalizeExpr(
     return self.runExprKernel(ast_expr_idx);
 }
 
+fn desugarTableLiteral(
+    self: *Self,
+    table: @FieldType(AST.Expr, "table"),
+    region: Region,
+) std.mem.Allocator.Error!CanonicalizedExpr {
+    const columns = self.parse_ir.store.tableColumnSlice(table.columns);
+    const rows = self.parse_ir.store.tableRowSlice(table.rows);
+    if (columns.len == 0) {
+        return try self.canonicalizedMalformedExpr(Diagnostic{ .expr_not_canonicalized = .{ .region = region } });
+    }
+
+    const seen_top = self.scratch_seen_record_fields.top();
+    defer self.scratch_seen_record_fields.clearFrom(seen_top);
+    for (columns) |column_idx| {
+        const column = self.parse_ir.store.getTableColumn(column_idx);
+        const name = self.parse_ir.tokens.resolveIdentifier(column.name) orelse {
+            return try self.canonicalizedMalformedExpr(Diagnostic{ .expr_not_canonicalized = .{ .region = region } });
+        };
+        const name_region = self.parse_ir.tokens.resolve(column.name);
+        for (self.scratch_seen_record_fields.sliceFromStart(seen_top)) |seen_field| {
+            if (name.eql(seen_field.ident)) {
+                return try self.canonicalizedMalformedExpr(Diagnostic{ .expr_not_canonicalized = .{ .region = region } });
+            }
+        }
+        try self.scratch_seen_record_fields.append(SeenRecordField{
+            .ident = name,
+            .region = name_region,
+        });
+    }
+
+    const items_top = self.parse_ir.store.scratchExprTop();
+    for (rows) |row_idx| {
+        const row = self.parse_ir.store.getTableRow(row_idx);
+        const cells = self.parse_ir.store.exprSlice(row.items);
+        if (cells.len != columns.len) {
+            self.parse_ir.store.clearScratchExprsFrom(items_top);
+            return try self.canonicalizedMalformedExpr(Diagnostic{ .expr_not_canonicalized = .{ .region = region } });
+        }
+
+        const fields_top = self.parse_ir.store.scratchRecordFieldTop();
+        for (columns, cells) |column_idx, cell| {
+            const column = self.parse_ir.store.getTableColumn(column_idx);
+            const field = try self.parse_ir.store.addRecordField(.{
+                .name = column.name,
+                .value = cell,
+                .region = row.region,
+            });
+            try self.parse_ir.store.addScratchRecordField(field);
+        }
+        const fields = try self.parse_ir.store.recordFieldSpanFrom(fields_top);
+        const record = try self.parse_ir.store.addExpr(.{ .record = .{
+            .fields = fields,
+            .ext = null,
+            .region = row.region,
+        } });
+        try self.parse_ir.store.addScratchExpr(record);
+    }
+
+    const items = try self.parse_ir.store.exprSpanFrom(items_top);
+    const list_ast = try self.parse_ir.store.addExpr(.{ .list = .{
+        .items = items,
+        .region = table.region,
+    } });
+    const list_can = (try self.canonicalizeExpr(list_ast)) orelse {
+        return try self.canonicalizedMalformedExpr(Diagnostic{ .expr_not_canonicalized = .{ .region = region } });
+    };
+    return try self.wrapTableWithColumnTypes(list_can, table.columns, region);
+}
+
+fn wrapTableWithColumnTypes(
+    self: *Self,
+    list_expr: CanonicalizedExpr,
+    columns: AST.TableColumn.Span,
+    region: Region,
+) std.mem.Allocator.Error!CanonicalizedExpr {
+    const column_slice = self.parse_ir.store.tableColumnSlice(columns);
+    var any_typed = false;
+    for (column_slice) |column_idx| {
+        if (self.parse_ir.store.getTableColumn(column_idx).ty != null) {
+            any_typed = true;
+            break;
+        }
+    }
+    if (!any_typed) return list_expr;
+
+    try self.scopeEnter(self.env.gpa, false);
+    defer self.scopeExit(self.env.gpa) catch |err| self.recordScopeExitError(err);
+
+    const fields_top = self.env.store.scratchAnnoRecordFieldTop();
+    for (column_slice) |column_idx| {
+        const column = self.parse_ir.store.getTableColumn(column_idx);
+        const name = self.parse_ir.tokens.resolveIdentifier(column.name) orelse {
+            self.env.store.clearScratchAnnoRecordFieldsFrom(fields_top);
+            return try self.canonicalizedMalformedExpr(Diagnostic{ .expr_not_canonicalized = .{ .region = region } });
+        };
+        const field_ty = if (column.ty) |ty|
+            try self.canonicalizeTypeAnno(ty, .local_anno)
+        else
+            try self.env.addTypeAnno(.{ .underscore = {} }, region);
+        const field_cir = try self.env.addAnnoRecordField(.{
+            .name = name,
+            .ty = field_ty,
+            .is_optional = false,
+        }, region);
+        try self.env.store.addScratchAnnoRecordField(field_cir);
+    }
+    const record_fields = try self.env.store.annoRecordFieldSpanFrom(fields_top);
+    const record_anno = try self.env.addTypeAnno(.{ .record = .{
+        .fields = record_fields,
+        .ext = null,
+    } }, region);
+
+    const args_top = self.env.store.scratchTypeAnnoTop();
+    try self.env.store.addScratchTypeAnno(record_anno);
+    const args = try self.env.store.typeAnnoSpanFrom(args_top);
+    const list_anno = try self.env.addTypeAnno(.{ .apply = .{
+        .name = self.env.idents.list,
+        .base = .{ .builtin = .list },
+        .args = args,
+    } }, region);
+
+    const annotation_idx = try self.createAnnotationFromTypeAnno(list_anno, null, region);
+    const ident = try self.generateClosureTagName(null);
+    const pattern_idx = try self.env.addPattern(.{ .assign = .{ .ident = ident } }, region);
+    _ = try self.scopeIntroduceInternal(self.env.gpa, .ident, ident, pattern_idx, false, true);
+
+    const stmts_top = self.env.store.scratchTop("statements");
+    const decl_stmt = try self.env.addStatement(Statement{ .s_decl = .{
+        .pattern = pattern_idx,
+        .expr = list_expr.idx,
+        .anno = annotation_idx,
+    } }, region);
+    try self.env.store.addScratchStatement(decl_stmt);
+    const stmts = try self.env.store.statementSpanFrom(stmts_top);
+
+    const lookup = try self.canonicalizedLocalLookup(pattern_idx, region);
+    const block = try self.env.addExpr(CIR.Expr{ .e_block = .{
+        .stmts = stmts,
+        .final_expr = lookup.idx,
+    } }, region);
+
+    return CanonicalizedExpr{
+        .idx = block,
+        .free_vars = list_expr.free_vars,
+    };
+}
+
 fn canonicalizedMalformedExpr(self: *Self, diagnostic: Diagnostic) std.mem.Allocator.Error!CanonicalizedExpr {
     return CanonicalizedExpr{
         .idx = try self.env.pushMalformed(Expr.Idx, diagnostic),
@@ -10612,6 +10759,11 @@ fn runExprKernel(
                     else
                         try self.env.addExpr(Expr{ .e_break = .{} }, region);
                     try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, CanonicalizedExpr{ .idx = break_expr, .free_vars = DataSpan.empty() });
+                },
+                .table => |e| {
+                    const region = self.parse_ir.tokenizedRegionToRegion(e.region);
+                    const can_expr = try self.desugarTableLiteral(e, region);
+                    try storeExprKernelOutput(&last_expr, &child_slots, frame_allocator, current_result_target, can_expr);
                 },
                 .list => |e| {
                     const region = self.parse_ir.tokenizedRegionToRegion(e.region);

--- a/src/fmt/fmt.zig
+++ b/src/fmt/fmt.zig
@@ -1743,6 +1743,7 @@ const Formatter = struct {
                     .@"break",
                     .@"return",
                     .block,
+                    .table,
                     .for_expr,
                     .malformed,
                     => {
@@ -2130,6 +2131,51 @@ const Formatter = struct {
             .block => |b| {
                 try fmt.formatBlock(b);
             },
+            .table => |t| {
+                const columns = fmt.ast.store.tableColumnSlice(t.columns);
+                const rows = fmt.ast.store.tableRowSlice(t.rows);
+                const table_multiline = rows.len > 0 or fmt.ast.store.getCollectionLayout(ei) == .expanded or fmt.regionHasInteriorComment(t.region);
+
+                try fmt.pushAll("table");
+                for (columns, 0..) |column_idx, i| {
+                    const column = fmt.ast.store.getTableColumn(column_idx);
+                    if (i == 0) {
+                        try fmt.push(' ');
+                    } else {
+                        try fmt.pushAll(", ");
+                    }
+                    try fmt.pushTokenText(column.name);
+                    if (column.ty) |ty| {
+                        try fmt.pushAll(" : ");
+                        try fmt.formatTypeAnnoDiscard(ty);
+                    }
+                }
+
+                if (table_multiline) {
+                    try fmt.pushAll(" {");
+                    fmt.curr_indent += 1;
+                    try fmt.flushCommentsAfterDiscard(t.region.start);
+                    for (rows) |row_idx| {
+                        const row = fmt.ast.store.getTableRow(row_idx);
+                        const items = fmt.ast.store.exprSlice(row.items);
+                        try fmt.ensureNewline();
+                        try fmt.pushIndent();
+                        for (items, 0..) |item_idx, i| {
+                            if (i > 0) {
+                                try fmt.pushAll(", ");
+                            }
+                            try fmt.formatExprDiscard(item_idx);
+                        }
+                        try fmt.push(',');
+                    }
+                    fmt.curr_indent -= 1;
+                    try fmt.ensureNewline();
+                    try fmt.pushIndent();
+                    try fmt.push('}');
+                } else {
+                    try fmt.pushAll(" {}");
+                }
+            },
             .for_expr => |f| {
                 try fmt.pushAll("for ");
                 try fmt.formatPatternDiscard(f.patt);
@@ -2272,6 +2318,7 @@ const Formatter = struct {
                     .@"break",
                     .@"return",
                     .block,
+                    .table,
                     .for_expr,
                     .malformed,
                     => {
@@ -3851,6 +3898,7 @@ const Formatter = struct {
             .nominal_record,
             .ellipsis,
             .block,
+            .table,
             .for_expr,
             .@"break",
             .@"return",
@@ -3872,7 +3920,7 @@ const Formatter = struct {
         const expr_tag = std.meta.activeTag(expr);
         const owns_collection = expr_tag == .list or expr_tag == .tuple or expr_tag == .record or
             expr_tag == .record_builder or expr_tag == .apply or expr_tag == .method_call or
-            expr_tag == .nominal_apply or expr_tag == .lambda;
+            expr_tag == .nominal_apply or expr_tag == .lambda or expr_tag == .table;
         if (owns_collection and fmt.regionHasInteriorComment(expr.to_tokenized_region())) return true;
 
         return switch (expr) {
@@ -3919,6 +3967,8 @@ const Formatter = struct {
             .crash => |c| fmt.groupedExprWillBeMultiline(c.expr),
             .@"return" => |r| fmt.groupedExprWillBeMultiline(r.expr),
             .for_expr => |f| fmt.groupedExprWillBeMultiline(f.expr) or fmt.groupedExprWillBeMultiline(f.body),
+            .table => |t| fmt.ast.store.tableRowSlice(t.rows).len > 0 or
+                fmt.ast.store.getCollectionLayout(expr_idx) == .expanded,
             .int,
             .frac,
             .typed_int,
@@ -3951,7 +4001,7 @@ const Formatter = struct {
             const expr_tag = std.meta.activeTag(expr);
             const owns_collection = expr_tag == .list or expr_tag == .tuple or expr_tag == .record or
                 expr_tag == .record_builder or expr_tag == .apply or expr_tag == .method_call or
-                expr_tag == .nominal_apply or expr_tag == .lambda;
+                expr_tag == .nominal_apply or expr_tag == .lambda or expr_tag == .table;
             if (owns_collection and fmt.regionHasInteriorComment(expr.to_tokenized_region())) return true;
             if (!owns_collection and fmt.ast.regionIsMultiline(expr.to_tokenized_region())) {
                 return true;
@@ -4075,6 +4125,10 @@ const Formatter = struct {
                     }
 
                     return fmt.nodeWillBeMultiline(AST.Expr.Idx, f.body);
+                },
+                .table => |t| {
+                    return fmt.ast.store.tableRowSlice(t.rows).len > 0 or
+                        fmt.ast.store.getCollectionLayout(item) == .expanded;
                 },
                 .int,
                 .frac,

--- a/src/lsp/handlers/selection_range.zig
+++ b/src/lsp/handlers/selection_range.zig
@@ -486,6 +486,14 @@ fn collectContainingRegionsFromExpr(
             try collectContainingRegionsFromExpr(allocator, ast, f.expr, target_offset, regions);
             try collectContainingRegionsFromExpr(allocator, ast, f.body, target_offset, regions);
         },
+        .table => |t| {
+            for (ast.store.tableRowSlice(t.rows)) |row_idx| {
+                const row = ast.store.getTableRow(row_idx);
+                for (ast.store.exprSlice(row.items)) |item| {
+                    try collectContainingRegionsFromExpr(allocator, ast, item, target_offset, regions);
+                }
+            }
+        },
         .@"return" => |r| {
             try collectContainingRegionsFromExpr(allocator, ast, r.expr, target_offset, regions);
         },

--- a/src/parse/AST.zig
+++ b/src/parse/AST.zig
@@ -494,6 +494,12 @@ pub fn parseDiagnosticToReport(self: *AST, env: *const CommonEnv, diagnostic: Di
         .expected_close_curly_at_end_of_match => reportParseProblem(ctx, "Unclosed Match", "I was parsing a match expression, and the file ended before the closing `}`.", "Add a closing brace after the final match branch.", .{ .example = "match value {\n    Ok(x) => x\n}" }),
         .expected_open_curly_after_match => reportParseProblem(ctx, "Expected Match Body", "I was parsing a match expression, and I expected `{` after the matched value.", "Match branches are written inside braces after the expression being matched.", .{ .example = "match result {\n    Ok(x) => x\n    Err(_) => 0\n}" }),
         .expr_unexpected_token => reportParseProblem(ctx, "Unexpected Expression Syntax", "I was parsing an expression, and this token cannot start an expression here.", "Expressions can be names, literals, tags, records, lists, tuples, lambdas, blocks, conditionals, matches, or function calls.", .{ .example = "add(1, 2)" }),
+        .table_expected_column_name => reportParseProblem(ctx, "Expected Table Column", "I was parsing a table literal, and I expected a lowercase column name.", "A table starts with `table` followed by one or more column names, then a `{` body. Each column can optionally have a type after `:`.", .{ .example = "table name, age {\n    \"Ada\", 36,\n}" }),
+        .table_expected_open_curly => reportParseProblem(ctx, "Expected Table Body", "I was parsing a table literal, and I expected `{` after the column names.", "Table rows are written inside braces after the column header.", .{ .example = "table name, age {\n    \"Ada\", 36,\n}" }),
+        .table_expected_close_curly => reportParseProblem(ctx, "Unclosed Table", "I was parsing a table literal, and I expected `}` to close the body.", "Close the table with `}` after the last row.", .{ .example = "table name, age {\n    \"Ada\", 36,\n}" }),
+        .table_duplicate_column => reportParseProblem(ctx, "Duplicate Table Column", "I was parsing a table literal, and this column name is already used.", "Each column name in a table must be unique.", .{ .example = "table name, age {\n    \"Ada\", 36,\n}" }),
+        .table_row_width_mismatch => reportParseProblem(ctx, "Table Row Width", "I was parsing a table row, and it does not have the same number of values as there are columns.", "Each row must have one value per column, separated by commas. A newline starts the next row.", .{ .example = "table name, age {\n    \"Ada\", 36,\n    \"Alan\", 42,\n}" }),
+        .table_row_expected_separator => reportParseProblem(ctx, "Expected Table Row Separator", "I was parsing a table row, and I expected a comma or a new row here.", "Separate values in a row with commas. A newline at table-body depth starts the next row.", .{ .example = "table name, age {\n    \"Ada\", 36,\n    \"Alan\", 42,\n}" }),
         .return_outside_function => reportParseProblem(ctx, "Return Outside Function", "I was parsing a statement, and `return` appeared outside a function body.", "`return` exits from the current function. Move it inside a function body, or remove it if this code is already the final expression.", .{ .example = "foo = |x| {\n    if x < 0 { return Err(Negative) }\n    Ok(x)\n}" }),
         .expected_expr_record_field_name => reportParseProblem(ctx, "Expected Record Field", "I was parsing a record expression, and I expected a lowercase field name.", "Record fields start with lowercase names. After the name, either write `: value` or omit the value to use field punning.", .{ .example = "{ name: \"Ada\", age }" }),
         .record_field_name_cannot_be_var => reportParseProblem(ctx, "Invalid Record Field Name", "Record field names cannot start with a dollar sign.", "Names that start with `$` are reassignable variables declared with the `var` keyword, so they cannot be used as record field names.", .{ .show_found = false }),
@@ -634,6 +640,12 @@ pub const Diagnostic = struct {
         expected_close_curly_at_end_of_match,
         expected_open_curly_after_match,
         expr_unexpected_token,
+        table_expected_column_name,
+        table_expected_open_curly,
+        table_expected_close_curly,
+        table_duplicate_column,
+        table_row_width_mismatch,
+        table_row_expected_separator,
         return_outside_function,
         expected_expr_record_field_name,
         /// `$name` idents are reassignable variables and cannot name record fields
@@ -2995,6 +3007,13 @@ pub const Expr = union(enum) {
         body: Expr.Idx,
         region: TokenizedRegion,
     },
+    /// Row-oriented sugar for a list of records. Canonicalize desugars this
+    /// to `List({ ... })`; later compiler stages never see tables.
+    table: struct {
+        columns: TableColumn.Span,
+        rows: TableRow.Span,
+        region: TokenizedRegion,
+    },
     malformed: struct {
         reason: Diagnostic.Tag,
         region: TokenizedRegion,
@@ -3061,6 +3080,7 @@ pub const Expr = union(enum) {
             .@"break" => |e| e.region,
             .@"return" => |e| e.region,
             .for_expr => |e| e.region,
+            .table => |e| e.region,
             .malformed => |e| e.region,
             .string_part => |e| e.region,
             .single_quote => |e| e.region,
@@ -3578,6 +3598,30 @@ pub const Expr = union(enum) {
 
                 try tree.endNode(begin, attrs);
             },
+            .table => |t| {
+                const begin = tree.beginNode();
+                try tree.pushStaticAtom("e-table");
+                try ast.appendRegionInfoToSexprTree(env, tree, t.region);
+                const attrs = tree.beginNode();
+
+                const columns = tree.beginNode();
+                try tree.pushStaticAtom("columns");
+                const columns_attrs = tree.beginNode();
+                for (ast.store.tableColumnSlice(t.columns)) |column_idx| {
+                    try ast.store.getTableColumn(column_idx).pushToSExprTree(gpa, env, ast, tree);
+                }
+                try tree.endNode(columns, columns_attrs);
+
+                const rows = tree.beginNode();
+                try tree.pushStaticAtom("rows");
+                const rows_attrs = tree.beginNode();
+                for (ast.store.tableRowSlice(t.rows)) |row_idx| {
+                    try ast.store.getTableRow(row_idx).pushToSExprTree(gpa, env, ast, tree);
+                }
+                try tree.endNode(rows, rows_attrs);
+
+                try tree.endNode(begin, attrs);
+            },
         }
     }
 };
@@ -3592,6 +3636,52 @@ pub const PatternRecordField = struct {
 
     pub const Idx = enum(u32) { _ };
     pub const Span = struct { span: base.DataSpan };
+};
+
+/// A column header in a table literal: `name` or `name : Str`.
+pub const TableColumn = struct {
+    name: Token.Idx,
+    ty: ?TypeAnno.Idx,
+    region: TokenizedRegion,
+
+    pub const Idx = enum(u32) { _ };
+    pub const Span = struct { span: base.DataSpan };
+
+    pub fn pushToSExprTree(self: @This(), gpa: std.mem.Allocator, env: *const CommonEnv, ast: *const AST, tree: *SExprTree) std.mem.Allocator.Error!void {
+        const begin = tree.beginNode();
+        try tree.pushStaticAtom("table-column");
+        try ast.appendRegionInfoToSexprTree(env, tree, self.region);
+        try tree.pushStringPair("name", ast.resolve(self.name));
+        const attrs = tree.beginNode();
+
+        if (self.ty) |ty| {
+            try ast.store.getTypeAnno(ty).pushToSExprTree(gpa, env, ast, tree);
+        }
+
+        try tree.endNode(begin, attrs);
+    }
+};
+
+/// One row of a table literal: comma-separated expressions.
+pub const TableRow = struct {
+    items: Expr.Span,
+    region: TokenizedRegion,
+
+    pub const Idx = enum(u32) { _ };
+    pub const Span = struct { span: base.DataSpan };
+
+    pub fn pushToSExprTree(self: @This(), gpa: std.mem.Allocator, env: *const CommonEnv, ast: *const AST, tree: *SExprTree) std.mem.Allocator.Error!void {
+        const begin = tree.beginNode();
+        try tree.pushStaticAtom("table-row");
+        try ast.appendRegionInfoToSexprTree(env, tree, self.region);
+        const attrs = tree.beginNode();
+
+        for (ast.store.exprSlice(self.items)) |item_idx| {
+            try ast.store.getExpr(item_idx).pushToSExprTree(gpa, env, ast, tree);
+        }
+
+        try tree.endNode(begin, attrs);
+    }
 };
 
 /// TODO

--- a/src/parse/Node.zig
+++ b/src/parse/Node.zig
@@ -517,6 +517,10 @@ pub const Tag = enum {
     /// * lhs - node index for loop initializing expression
     /// * rhs - node index for loop body expression
     for_expr,
+    /// A table literal: `table name, age { "Ada", 36 }`
+    /// * lhs - extra_data index of [columns.span.start, columns.span.len, rows.span.start, rows.span.len]
+    /// * rhs - ignored
+    table,
     /// A break expression.
     /// * lhs - ignored
     /// * rhs - ignored
@@ -536,6 +540,15 @@ pub const Tag = enum {
     /// * lhs - Pattern index
     /// * rhs - Body index
     branch,
+    /// A table column header: `name` or `name : Type`
+    /// * main_token - column name token
+    /// * lhs - packed optional TypeAnno index (0 = untyped)
+    /// * rhs - ignored
+    table_column,
+    /// A table row of comma-separated expressions
+    /// * lhs - items.span.start
+    /// * rhs - items.span.len
+    table_row,
 
     /// Collections
     /// Collection of exposed items

--- a/src/parse/NodeStore.zig
+++ b/src/parse/NodeStore.zig
@@ -117,6 +117,7 @@ const ExprNodeTag = enum {
     block,
     ellipsis,
     for_expr,
+    table,
     break_expr,
     return_expr,
     malformed,
@@ -177,6 +178,8 @@ scratch_pattern_string_parts: base.Scratch(AST.PatternStringPart.Idx),
 scratch_record_fields: base.Scratch(AST.RecordField.Idx),
 scratch_pattern_record_fields: base.Scratch(AST.PatternRecordField.Idx),
 scratch_match_branches: base.Scratch(AST.MatchBranch.Idx),
+scratch_table_columns: base.Scratch(AST.TableColumn.Idx),
+scratch_table_rows: base.Scratch(AST.TableRow.Idx),
 scratch_type_annos: base.Scratch(AST.TypeAnno.Idx),
 scratch_anno_record_fields: base.Scratch(AST.AnnoRecordField.Idx),
 scratch_exposed_items: base.Scratch(AST.ExposedItem.Idx),
@@ -325,6 +328,10 @@ pub fn initCapacity(gpa: std.mem.Allocator, capacity: usize) std.mem.Allocator.E
     errdefer scratch_pattern_record_fields.deinit();
     var scratch_match_branches = try base.Scratch(AST.MatchBranch.Idx).init(gpa);
     errdefer scratch_match_branches.deinit();
+    var scratch_table_columns = try base.Scratch(AST.TableColumn.Idx).init(gpa);
+    errdefer scratch_table_columns.deinit();
+    var scratch_table_rows = try base.Scratch(AST.TableRow.Idx).init(gpa);
+    errdefer scratch_table_rows.deinit();
     var scratch_type_annos = try base.Scratch(AST.TypeAnno.Idx).init(gpa);
     errdefer scratch_type_annos.deinit();
     var scratch_anno_record_fields = try base.Scratch(AST.AnnoRecordField.Idx).init(gpa);
@@ -368,6 +375,8 @@ pub fn initCapacity(gpa: std.mem.Allocator, capacity: usize) std.mem.Allocator.E
         .scratch_record_fields = scratch_record_fields,
         .scratch_pattern_record_fields = scratch_pattern_record_fields,
         .scratch_match_branches = scratch_match_branches,
+        .scratch_table_columns = scratch_table_columns,
+        .scratch_table_rows = scratch_table_rows,
         .scratch_type_annos = scratch_type_annos,
         .scratch_anno_record_fields = scratch_anno_record_fields,
         .scratch_exposed_items = scratch_exposed_items,
@@ -415,6 +424,8 @@ pub fn deinit(store: *NodeStore) void {
     store.scratch_record_fields.deinit();
     store.scratch_pattern_record_fields.deinit();
     store.scratch_match_branches.deinit();
+    store.scratch_table_columns.deinit();
+    store.scratch_table_rows.deinit();
     store.scratch_type_annos.deinit();
     store.scratch_anno_record_fields.deinit();
     store.scratch_exposed_items.deinit();
@@ -443,6 +454,8 @@ pub fn emptyScratch(store: *NodeStore) void {
     store.scratch_record_fields.clearFrom(0);
     store.scratch_pattern_record_fields.clearFrom(0);
     store.scratch_match_branches.clearFrom(0);
+    store.scratch_table_columns.clearFrom(0);
+    store.scratch_table_rows.clearFrom(0);
     store.scratch_type_annos.clearFrom(0);
     store.scratch_anno_record_fields.clearFrom(0);
     store.scratch_exposed_items.clearFrom(0);
@@ -474,6 +487,8 @@ pub fn debugTo(store: *NodeStore, writer: *std.Io.Writer) error{WriteFailed}!voi
     try writer.print("Scratch record fields: {any}\n", .{store.scratch_record_fields.items});
     try writer.print("Scratch pattern record fields: {any}\n", .{store.scratch_pattern_record_fields.items});
     try writer.print("Scratch match branches: {any}\n", .{store.scratch_match_branches.items});
+    try writer.print("Scratch table columns: {any}\n", .{store.scratch_table_columns.items});
+    try writer.print("Scratch table rows: {any}\n", .{store.scratch_table_rows.items});
     try writer.print("Scratch type annos: {any}\n", .{store.scratch_type_annos.items});
     try writer.print("Scratch anno record fields: {any}\n", .{store.scratch_anno_record_fields.items});
     try writer.print("Scratch exposes items: {any}\n", .{store.scratch_exposed_items.items});
@@ -1294,6 +1309,17 @@ pub fn addExpr(store: *NodeStore, expr: AST.Expr) std.mem.Allocator.Error!AST.Ex
             node.data.lhs = @intFromEnum(f.expr);
             node.data.rhs = @intFromEnum(f.body);
         },
+        .table => |t| {
+            node.tag = .table;
+            node.region = t.region;
+            // Store [columns.span.start, columns.span.len, rows.span.start, rows.span.len]
+            const data_start = @as(u32, @intCast(store.extra_data.items.len));
+            try store.extra_data.append(store.gpa, t.columns.span.start);
+            try store.extra_data.append(store.gpa, t.columns.span.len);
+            try store.extra_data.append(store.gpa, t.rows.span.start);
+            try store.extra_data.append(store.gpa, t.rows.span.len);
+            node.data.lhs = data_start;
+        },
         .@"break" => |b| {
             node.tag = .break_expr;
             node.region = b.region;
@@ -1375,6 +1401,36 @@ pub fn addMatchBranch(store: *NodeStore, branch: AST.MatchBranch) std.mem.Alloca
             .rhs = @intFromEnum(branch.body),
         },
         .region = branch.region,
+    };
+
+    const nid = try store.nodes.append(store.gpa, node);
+    return @enumFromInt(@intFromEnum(nid));
+}
+
+pub fn addTableColumn(store: *NodeStore, column: AST.TableColumn) std.mem.Allocator.Error!AST.TableColumn.Idx {
+    const node = Node{
+        .tag = .table_column,
+        .main_token = column.name,
+        .data = .{
+            .lhs = try packOptionalIndex(column.ty),
+            .rhs = 0,
+        },
+        .region = column.region,
+    };
+
+    const nid = try store.nodes.append(store.gpa, node);
+    return @enumFromInt(@intFromEnum(nid));
+}
+
+pub fn addTableRow(store: *NodeStore, row: AST.TableRow) std.mem.Allocator.Error!AST.TableRow.Idx {
+    const node = Node{
+        .tag = .table_row,
+        .main_token = 0,
+        .data = .{
+            .lhs = row.items.span.start,
+            .rhs = row.items.span.len,
+        },
+        .region = row.region,
     };
 
     const nid = try store.nodes.append(store.gpa, node);
@@ -2564,6 +2620,20 @@ pub fn getExpr(store: *const NodeStore, expr_idx: AST.Expr.Idx) AST.Expr {
                 .region = node.region,
             } };
         },
+        .table => {
+            const extra = node.data.lhs;
+            return .{ .table = .{
+                .columns = .{ .span = .{
+                    .start = store.extra_data.items[extra],
+                    .len = store.extra_data.items[extra + 1],
+                } },
+                .rows = .{ .span = .{
+                    .start = store.extra_data.items[extra + 2],
+                    .len = store.extra_data.items[extra + 3],
+                } },
+                .region = node.region,
+            } };
+        },
         .break_expr => {
             return .{ .@"break" = .{
                 .region = node.region,
@@ -2662,6 +2732,26 @@ pub fn getBranch(store: *const NodeStore, branch_idx: AST.MatchBranch.Idx) AST.M
         .pattern = @enumFromInt(node.data.lhs),
         .body = @enumFromInt(node.data.rhs),
         .guard = unpackOptionalIndex(AST.Expr.Idx, node.main_token),
+    };
+}
+
+pub fn getTableColumn(store: *const NodeStore, column_idx: AST.TableColumn.Idx) AST.TableColumn {
+    const node = store.nodes.get(@enumFromInt(@intFromEnum(column_idx)));
+    return .{
+        .name = node.main_token,
+        .ty = unpackOptionalIndex(AST.TypeAnno.Idx, node.data.lhs),
+        .region = node.region,
+    };
+}
+
+pub fn getTableRow(store: *const NodeStore, row_idx: AST.TableRow.Idx) AST.TableRow {
+    const node = store.nodes.get(@enumFromInt(@intFromEnum(row_idx)));
+    return .{
+        .items = .{ .span = .{
+            .start = node.data.lhs,
+            .len = node.data.rhs,
+        } },
+        .region = node.region,
     };
 }
 
@@ -3174,6 +3264,62 @@ pub fn clearScratchMatchBranchesFrom(store: *NodeStore, start: u32) void {
 /// all items in the span.
 pub fn matchBranchSlice(store: *const NodeStore, span: AST.MatchBranch.Span) []AST.MatchBranch.Idx {
     return store.sliceFromSpan(AST.MatchBranch.Idx, span.span);
+}
+
+pub fn scratchTableColumnTop(store: *NodeStore) u32 {
+    return store.scratch_table_columns.top();
+}
+
+pub fn addScratchTableColumn(store: *NodeStore, idx: AST.TableColumn.Idx) std.mem.Allocator.Error!void {
+    try store.scratch_table_columns.append(idx);
+}
+
+pub fn tableColumnSpanFrom(store: *NodeStore, start: u32) std.mem.Allocator.Error!AST.TableColumn.Span {
+    const end = store.scratch_table_columns.top();
+    defer store.scratch_table_columns.clearFrom(start);
+    var i = @as(usize, @intCast(start));
+    const ed_start = @as(u32, @intCast(store.extra_data.items.len));
+    while (i < end) {
+        try store.extra_data.append(store.gpa, @intFromEnum(store.scratch_table_columns.items.items[i]));
+        i += 1;
+    }
+    return .{ .span = .{ .start = ed_start, .len = @as(u32, @intCast(end)) - start } };
+}
+
+pub fn clearScratchTableColumnsFrom(store: *NodeStore, start: u32) void {
+    store.scratch_table_columns.clearFrom(start);
+}
+
+pub fn tableColumnSlice(store: *const NodeStore, span: AST.TableColumn.Span) []AST.TableColumn.Idx {
+    return store.sliceFromSpan(AST.TableColumn.Idx, span.span);
+}
+
+pub fn scratchTableRowTop(store: *NodeStore) u32 {
+    return store.scratch_table_rows.top();
+}
+
+pub fn addScratchTableRow(store: *NodeStore, idx: AST.TableRow.Idx) std.mem.Allocator.Error!void {
+    try store.scratch_table_rows.append(idx);
+}
+
+pub fn tableRowSpanFrom(store: *NodeStore, start: u32) std.mem.Allocator.Error!AST.TableRow.Span {
+    const end = store.scratch_table_rows.top();
+    defer store.scratch_table_rows.clearFrom(start);
+    var i = @as(usize, @intCast(start));
+    const ed_start = @as(u32, @intCast(store.extra_data.items.len));
+    while (i < end) {
+        try store.extra_data.append(store.gpa, @intFromEnum(store.scratch_table_rows.items.items[i]));
+        i += 1;
+    }
+    return .{ .span = .{ .start = ed_start, .len = @as(u32, @intCast(end)) - start } };
+}
+
+pub fn clearScratchTableRowsFrom(store: *NodeStore, start: u32) void {
+    store.scratch_table_rows.clearFrom(start);
+}
+
+pub fn tableRowSlice(store: *const NodeStore, span: AST.TableRow.Span) []AST.TableRow.Idx {
+    return store.sliceFromSpan(AST.TableRow.Idx, span.span);
 }
 
 /// Returns the start position for a new Span of typeAnnoIdxs in scratch

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -282,6 +282,7 @@ const ExprParentKind = enum(u16) {
     expr_for_body = 0x247c,
     expr_lambda_body = 0xdca0,
     type_record_field_default = 0x61f2,
+    expr_table_cell = 0xa81c,
 };
 
 const PatternParentKind = enum(u16) {
@@ -312,6 +313,7 @@ const TypeParentKind = enum(u16) {
     type_tag_union_item = 0x4fa1,
     type_fn_arg = 0x670c,
     type_fn_ret = 0xb2f6,
+    expr_table_column_type = 0x5e3d,
 };
 
 const WhereParentKind = enum(u16) {
@@ -646,6 +648,80 @@ fn addTypeDeclStatement(
 fn tokenText(self: *const Parser, token: Token.Idx) []const u8 {
     const region = self.tok_buf.resolve(token);
     return self.tok_buf.env.source[region.start.offset..region.end.offset];
+}
+
+fn newlineBeforeCurrent(self: *Parser) bool {
+    if (self.pos == 0) return false;
+    const prev_end = self.tok_buf.resolve(self.pos - 1).end.offset;
+    const curr_start = self.tok_buf.resolve(self.pos).start.offset;
+    if (prev_end >= curr_start) return false;
+    const between = self.tok_buf.env.source[prev_end..curr_start];
+    return std.mem.indexOfScalar(u8, between, '\n') != null or std.mem.indexOfScalar(u8, between, '\r') != null;
+}
+
+fn recoverTableCloseCurly(self: *Parser) void {
+    var depth: u32 = 1;
+    while (self.peek() != .EndOfFile) {
+        switch (self.peek()) {
+            .OpenCurly => {
+                depth += 1;
+                self.advance();
+            },
+            .CloseCurly => {
+                self.advance();
+                if (depth == 1) return;
+                depth -= 1;
+            },
+            else => self.advance(),
+        }
+    }
+}
+
+fn tokenRegion(pos: Token.Idx) AST.TokenizedRegion {
+    return .{ .start = pos, .end = pos + 1 };
+}
+
+fn abortTable(
+    self: *Parser,
+    start: Token.Idx,
+    tag: AST.Diagnostic.Tag,
+    diagnostic: AST.TokenizedRegion,
+    columns_scratch_top: u32,
+    rows_scratch_top: u32,
+    row_expr_scratch_top: ?u32,
+    in_body: bool,
+) std.mem.Allocator.Error!AST.Expr.Idx {
+    self.store.clearScratchTableColumnsFrom(columns_scratch_top);
+    self.store.clearScratchTableRowsFrom(rows_scratch_top);
+    if (row_expr_scratch_top) |top| {
+        self.store.clearScratchExprsFrom(top);
+    }
+    const diagnostic_region = if (diagnostic.end > diagnostic.start)
+        diagnostic
+    else
+        tokenRegion(diagnostic.start);
+    try self.pushDiagnostic(tag, diagnostic_region);
+    if (in_body) {
+        self.recoverTableCloseCurly();
+    } else {
+        while (self.peek() != .EndOfFile and self.peek() != .OpenCurly) {
+            self.advance();
+        }
+        if (self.peek() == .OpenCurly) {
+            self.advance();
+            self.recoverTableCloseCurly();
+        }
+    }
+    return try self.store.addMalformed(AST.Expr.Idx, tag, .{ .start = start, .end = self.pos });
+}
+
+fn tableColumnNameIsDuplicate(self: *Parser, name: Token.Idx, columns_scratch_top: u32) bool {
+    const items = self.store.scratch_table_columns.items.items[columns_scratch_top..];
+    for (items) |col_idx| {
+        const col = self.store.getTableColumn(col_idx);
+        if (self.tokenIdentsEqual(col.name, name)) return true;
+    }
+    return false;
 }
 
 /// Intern the source module target selected by import parsing, excluding nested
@@ -2574,6 +2650,34 @@ const ExprAfterExprState = struct {
     min_bp: u8,
 };
 
+const ExprTableState = struct {
+    start: Token.Idx,
+    min_bp: u8,
+    columns_scratch_top: u32,
+    rows_scratch_top: u32,
+    columns: AST.TableColumn.Span,
+    row_start: Token.Idx,
+    row_expr_scratch_top: u32,
+};
+
+const ExprTableColumnTypeState = struct {
+    start: Token.Idx,
+    min_bp: u8,
+    columns_scratch_top: u32,
+    rows_scratch_top: u32,
+    name: Token.Idx,
+    column_start: Token.Idx,
+};
+
+const ExprTableCellState = struct {
+    start: Token.Idx,
+    min_bp: u8,
+    columns: AST.TableColumn.Span,
+    rows_scratch_top: u32,
+    row_start: Token.Idx,
+    row_expr_scratch_top: u32,
+};
+
 const ExprIfAfterThenState = struct {
     start: Token.Idx,
     min_bp: u8,
@@ -2696,6 +2800,8 @@ const OpenSyntaxStack = struct {
     type_tag_union_item: std.ArrayList(TypeTagUnionItemState) = .empty,
     type_fn_arg: std.ArrayList(TypeFnArgsState) = .empty,
     type_fn_ret: std.ArrayList(TypeFnAfterRetState) = .empty,
+    expr_table_cell: std.ArrayList(ExprTableCellState) = .empty,
+    expr_table_column_type: std.ArrayList(ExprTableColumnTypeState) = .empty,
 
     fn deinit(self: *OpenSyntaxStack, allocator: std.mem.Allocator) void {
         inline for (std.meta.fields(OpenSyntaxStack)) |field| {
@@ -3160,6 +3266,8 @@ fn runExprStatementKernel(
         record_fields_next,
         record_finish,
         match_branch_next,
+        table_columns_next,
+        table_row_next,
         block_next,
         block_finish,
         pattern_root_next,
@@ -3203,6 +3311,7 @@ fn runExprStatementKernel(
     var expr_record_state: ExprRecordState = undefined;
     const expr_lambda_body_stack = &expr_scratch.lambda_body;
     var expr_match_branch_state: ExprMatchBranchState = undefined;
+    var expr_table_state: ExprTableState = undefined;
     const expr_blocks = &expr_scratch.blocks;
     var last_expr: ?AST.Expr.Idx = null;
     var pattern_root_state = PatternRootState{
@@ -3385,6 +3494,22 @@ fn runExprStatementKernel(
             } else if (tok_int < @intFromEnum(Token.Tag.OpPlus)) {
                 if (tok == .LowerIdent or tok == .NamedUnderscore) {
                     const start = self.pos;
+                    if (tok == .LowerIdent and
+                        std.mem.eql(u8, self.tokenText(start), "table") and
+                        (self.peekNext() == .LowerIdent or self.peekNext() == .OpenCurly))
+                    {
+                        self.advance();
+                        expr_table_state = .{
+                            .start = start,
+                            .min_bp = expr_state.min_bp,
+                            .columns_scratch_top = self.store.scratchTableColumnTop(),
+                            .rows_scratch_top = self.store.scratchTableRowTop(),
+                            .columns = .{ .span = .{ .start = 0, .len = 0 } },
+                            .row_start = start,
+                            .row_expr_scratch_top = 0,
+                        };
+                        continue :expr_kernel .table_columns_next;
+                    }
                     self.advance();
                     const empty_qualifiers = try self.store.tokenSpanFrom(self.store.scratchTokenTop());
                     const expr = try self.store.addExpr(.{ .ident = .{
@@ -4001,6 +4126,122 @@ fn runExprStatementKernel(
                         }
                         continue :expr_kernel .collection_next;
                     },
+                    .expr_table_cell => {
+                        const state = open_syntax.popExprPayload(.expr_table_cell, ExprTableCellState);
+                        last_expr = null;
+                        try self.store.addScratchExpr(completed);
+                        expr_table_state = .{
+                            .start = state.start,
+                            .min_bp = state.min_bp,
+                            .columns_scratch_top = 0,
+                            .rows_scratch_top = state.rows_scratch_top,
+                            .columns = state.columns,
+                            .row_start = state.row_start,
+                            .row_expr_scratch_top = state.row_expr_scratch_top,
+                        };
+
+                        const finish_row = struct {
+                            fn run(parser: *Parser, table: *ExprTableState) std.mem.Allocator.Error!union(enum) { ok, abort: AST.Expr.Idx } {
+                                const items = try parser.store.exprSpanFrom(table.row_expr_scratch_top);
+                                if (items.span.len != table.columns.span.len) {
+                                    return .{ .abort = try parser.abortTable(
+                                        table.start,
+                                        .table_row_width_mismatch,
+                                        .{ .start = table.row_start, .end = parser.pos },
+                                        parser.store.scratchTableColumnTop(),
+                                        table.rows_scratch_top,
+                                        table.row_expr_scratch_top,
+                                        true,
+                                    ) };
+                                }
+                                const row = try parser.store.addTableRow(.{
+                                    .items = items,
+                                    .region = .{ .start = table.row_start, .end = parser.pos },
+                                });
+                                try parser.store.addScratchTableRow(row);
+                                return .ok;
+                            }
+                        };
+
+                        if (self.peek() == .CloseCurly) {
+                            switch (try finish_row.run(self, &expr_table_state)) {
+                                .abort => |expr| {
+                                    expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                                    continue :expr_kernel .suffix;
+                                },
+                                .ok => {},
+                            }
+                            self.advance();
+                            const rows = try self.store.tableRowSpanFrom(expr_table_state.rows_scratch_top);
+                            const expr = try self.store.addExpr(.{ .table = .{
+                                .columns = expr_table_state.columns,
+                                .rows = rows,
+                                .region = .{ .start = expr_table_state.start, .end = self.pos },
+                            } });
+                            self.store.setCollectionLayout(expr, if (rows.span.len > 0) .expanded else .compact);
+                            expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                            continue :expr_kernel .suffix;
+                        }
+
+                        if (self.peek() == .Comma) {
+                            self.advance();
+                            if (self.peek() == .CloseCurly or self.newlineBeforeCurrent()) {
+                                switch (try finish_row.run(self, &expr_table_state)) {
+                                    .abort => |expr| {
+                                        expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                                        continue :expr_kernel .suffix;
+                                    },
+                                    .ok => {},
+                                }
+                                if (self.peek() == .CloseCurly) {
+                                    self.advance();
+                                    const rows = try self.store.tableRowSpanFrom(expr_table_state.rows_scratch_top);
+                                    const expr = try self.store.addExpr(.{ .table = .{
+                                        .columns = expr_table_state.columns,
+                                        .rows = rows,
+                                        .region = .{ .start = expr_table_state.start, .end = self.pos },
+                                    } });
+                                    self.store.setCollectionLayout(expr, if (rows.span.len > 0) .expanded else .compact);
+                                    expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                                    continue :expr_kernel .suffix;
+                                }
+                                continue :expr_kernel .table_row_next;
+                            }
+                            try open_syntax.pushExpr(open_allocator, .expr_table_cell, ExprTableCellState, .{
+                                .start = expr_table_state.start,
+                                .min_bp = expr_table_state.min_bp,
+                                .columns = expr_table_state.columns,
+                                .rows_scratch_top = expr_table_state.rows_scratch_top,
+                                .row_start = expr_table_state.row_start,
+                                .row_expr_scratch_top = expr_table_state.row_expr_scratch_top,
+                            });
+                            expr_state = .{ .start = self.pos, .min_bp = 0 };
+                            continue :expr_kernel .prefix;
+                        }
+
+                        if (self.newlineBeforeCurrent()) {
+                            switch (try finish_row.run(self, &expr_table_state)) {
+                                .abort => |expr| {
+                                    expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                                    continue :expr_kernel .suffix;
+                                },
+                                .ok => {},
+                            }
+                            continue :expr_kernel .table_row_next;
+                        }
+
+                        const expr = try self.abortTable(
+                            expr_table_state.start,
+                            .table_row_expected_separator,
+                            tokenRegion(self.pos),
+                            self.store.scratchTableColumnTop(),
+                            expr_table_state.rows_scratch_top,
+                            expr_table_state.row_expr_scratch_top,
+                            true,
+                        );
+                        expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                        continue :expr_kernel .suffix;
+                    },
                     .expr_binary_rhs => {
                         open_syntax.popExprMarker(.expr_binary_rhs);
                         const state = expr_binary_rhs_stack.leave();
@@ -4557,6 +4798,126 @@ fn runExprStatementKernel(
                 expr_state = .{ .start = self.pos, .min_bp = 0 };
                 continue :expr_kernel .prefix;
             }
+        },
+        .table_columns_next => {
+            if (self.peek() == .OpenCurly) {
+                const column_count = self.store.scratchTableColumnTop() - expr_table_state.columns_scratch_top;
+                if (column_count == 0) {
+                    const expr = try self.abortTable(
+                        expr_table_state.start,
+                        .table_expected_column_name,
+                        tokenRegion(self.pos),
+                        expr_table_state.columns_scratch_top,
+                        expr_table_state.rows_scratch_top,
+                        null,
+                        false,
+                    );
+                    expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                    continue :expr_kernel .suffix;
+                }
+                expr_table_state.columns = try self.store.tableColumnSpanFrom(expr_table_state.columns_scratch_top);
+                self.advance();
+                expr_table_state.rows_scratch_top = self.store.scratchTableRowTop();
+                continue :expr_kernel .table_row_next;
+            }
+            if (self.peek() == .EndOfFile or self.peek() != .LowerIdent) {
+                const tag: AST.Diagnostic.Tag = if (self.peek() == .EndOfFile or self.peek() != .LowerIdent)
+                    if (self.store.scratchTableColumnTop() == expr_table_state.columns_scratch_top)
+                        .table_expected_column_name
+                    else
+                        .table_expected_open_curly
+                else
+                    .table_expected_column_name;
+                const expr = try self.abortTable(
+                    expr_table_state.start,
+                    tag,
+                    tokenRegion(self.pos),
+                    expr_table_state.columns_scratch_top,
+                    expr_table_state.rows_scratch_top,
+                    null,
+                    false,
+                );
+                expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                continue :expr_kernel .suffix;
+            }
+            const name = self.pos;
+            const column_start = self.pos;
+            if (self.tableColumnNameIsDuplicate(name, expr_table_state.columns_scratch_top)) {
+                const expr = try self.abortTable(
+                    expr_table_state.start,
+                    .table_duplicate_column,
+                    tokenRegion(name),
+                    expr_table_state.columns_scratch_top,
+                    expr_table_state.rows_scratch_top,
+                    null,
+                    false,
+                );
+                expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                continue :expr_kernel .suffix;
+            }
+            self.advance();
+            if (self.peek() == .OpColon) {
+                self.advance();
+                try open_syntax.pushType(open_allocator, .expr_table_column_type, ExprTableColumnTypeState, .{
+                    .start = expr_table_state.start,
+                    .min_bp = expr_table_state.min_bp,
+                    .columns_scratch_top = expr_table_state.columns_scratch_top,
+                    .rows_scratch_top = expr_table_state.rows_scratch_top,
+                    .name = name,
+                    .column_start = column_start,
+                });
+                type_args = .looking_for_type_arg;
+                continue :expr_kernel .type_prefix;
+            }
+            const column = try self.store.addTableColumn(.{
+                .name = name,
+                .ty = null,
+                .region = .{ .start = column_start, .end = self.pos },
+            });
+            try self.store.addScratchTableColumn(column);
+            if (self.peek() == .Comma) {
+                self.advance();
+            }
+            continue :expr_kernel .table_columns_next;
+        },
+        .table_row_next => {
+            if (self.peek() == .CloseCurly) {
+                self.advance();
+                const rows = try self.store.tableRowSpanFrom(expr_table_state.rows_scratch_top);
+                const expr = try self.store.addExpr(.{ .table = .{
+                    .columns = expr_table_state.columns,
+                    .rows = rows,
+                    .region = .{ .start = expr_table_state.start, .end = self.pos },
+                } });
+                self.store.setCollectionLayout(expr, if (rows.span.len > 0) .expanded else .compact);
+                expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                continue :expr_kernel .suffix;
+            }
+            if (self.peek() == .EndOfFile) {
+                const expr = try self.abortTable(
+                    expr_table_state.start,
+                    .table_expected_close_curly,
+                    tokenRegion(self.pos),
+                    expr_table_state.columns_scratch_top,
+                    expr_table_state.rows_scratch_top,
+                    null,
+                    true,
+                );
+                expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                continue :expr_kernel .suffix;
+            }
+            expr_table_state.row_start = self.pos;
+            expr_table_state.row_expr_scratch_top = self.store.scratchExprTop();
+            try open_syntax.pushExpr(open_allocator, .expr_table_cell, ExprTableCellState, .{
+                .start = expr_table_state.start,
+                .min_bp = expr_table_state.min_bp,
+                .columns = expr_table_state.columns,
+                .rows_scratch_top = expr_table_state.rows_scratch_top,
+                .row_start = expr_table_state.row_start,
+                .row_expr_scratch_top = expr_table_state.row_expr_scratch_top,
+            });
+            expr_state = .{ .start = self.pos, .min_bp = 0 };
+            continue :expr_kernel .prefix;
         },
         .string_next => {
             const string_tag = self.peek();
@@ -5140,6 +5501,42 @@ fn runExprStatementKernel(
                             .effectful = state.effectful,
                         } });
                         continue :expr_kernel .type_complete;
+                    },
+                    .expr_table_column_type => {
+                        const state = open_syntax.popTypePayload(.expr_table_column_type, ExprTableColumnTypeState);
+                        last_type_anno = null;
+                        if (self.tableColumnNameIsDuplicate(state.name, state.columns_scratch_top)) {
+                            const expr = try self.abortTable(
+                                state.start,
+                                .table_duplicate_column,
+                                tokenRegion(state.name),
+                                state.columns_scratch_top,
+                                state.rows_scratch_top,
+                                null,
+                                false,
+                            );
+                            expr_finish_state = .{ .start = state.start, .min_bp = state.min_bp, .expr = expr };
+                            continue :expr_kernel .suffix;
+                        }
+                        const column = try self.store.addTableColumn(.{
+                            .name = state.name,
+                            .ty = completed,
+                            .region = .{ .start = state.column_start, .end = self.pos },
+                        });
+                        try self.store.addScratchTableColumn(column);
+                        expr_table_state = .{
+                            .start = state.start,
+                            .min_bp = state.min_bp,
+                            .columns_scratch_top = state.columns_scratch_top,
+                            .rows_scratch_top = state.rows_scratch_top,
+                            .columns = .{ .span = .{ .start = 0, .len = 0 } },
+                            .row_start = state.start,
+                            .row_expr_scratch_top = 0,
+                        };
+                        if (self.peek() == .Comma) {
+                            self.advance();
+                        }
+                        continue :expr_kernel .table_columns_next;
                     },
                     .where_clause_alias => {
                         const state = open_syntax.popTypePayload(.where_clause_alias, WhereClauseAliasState);

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -4183,6 +4183,20 @@ fn runExprStatementKernel(
                             continue :expr_kernel .suffix;
                         }
 
+                        // A body-depth newline ends the row even when the next token is a
+                        // comma. Checking this after `peek() == .Comma` would consume that
+                        // comma and merge the following line's values into this row.
+                        if (self.newlineBeforeCurrent()) {
+                            switch (try finish_row.run(self, &expr_table_state)) {
+                                .abort => |expr| {
+                                    expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
+                                    continue :expr_kernel .suffix;
+                                },
+                                .ok => {},
+                            }
+                            continue :expr_kernel .table_row_next;
+                        }
+
                         if (self.peek() == .Comma) {
                             self.advance();
                             if (self.peek() == .CloseCurly or self.newlineBeforeCurrent()) {
@@ -4217,17 +4231,6 @@ fn runExprStatementKernel(
                             });
                             expr_state = .{ .start = self.pos, .min_bp = 0 };
                             continue :expr_kernel .prefix;
-                        }
-
-                        if (self.newlineBeforeCurrent()) {
-                            switch (try finish_row.run(self, &expr_table_state)) {
-                                .abort => |expr| {
-                                    expr_finish_state = .{ .start = expr_table_state.start, .min_bp = expr_table_state.min_bp, .expr = expr };
-                                    continue :expr_kernel .suffix;
-                                },
-                                .ok => {},
-                            }
-                            continue :expr_kernel .table_row_next;
                         }
 
                         const expr = try self.abortTable(

--- a/src/parse/Parser.zig
+++ b/src/parse/Parser.zig
@@ -650,13 +650,28 @@ fn tokenText(self: *const Parser, token: Token.Idx) []const u8 {
     return self.tok_buf.env.source[region.start.offset..region.end.offset];
 }
 
-fn newlineBeforeCurrent(self: *Parser) bool {
-    if (self.pos == 0) return false;
-    const prev_end = self.tok_buf.resolve(self.pos - 1).end.offset;
-    const curr_start = self.tok_buf.resolve(self.pos).start.offset;
+fn newlineBeforeToken(self: *const Parser, pos: Token.Idx) bool {
+    if (pos == 0 or pos >= self.tok_buf.tokens.len) return false;
+    const prev_end = self.tok_buf.resolve(pos - 1).end.offset;
+    const curr_start = self.tok_buf.resolve(pos).start.offset;
     if (prev_end >= curr_start) return false;
     const between = self.tok_buf.env.source[prev_end..curr_start];
     return std.mem.indexOfScalar(u8, between, '\n') != null or std.mem.indexOfScalar(u8, between, '\r') != null;
+}
+
+fn newlineBeforeCurrent(self: *const Parser) bool {
+    return self.newlineBeforeToken(self.pos);
+}
+
+fn startsTableLiteral(self: *Parser) bool {
+    if (self.peek() != .LowerIdent) return false;
+    if (!std.mem.eql(u8, self.tokenText(self.pos), "table")) return false;
+    const next = self.peekNext();
+    if (next != .LowerIdent and next != .OpenCurly) return false;
+    // `table` is only a table literal when the header continues on the same
+    // line. A following lowercase name on the next line is an ordinary ident,
+    // e.g. `table_for_host = table` then `names_for_host = names`.
+    return !self.newlineBeforeToken(self.pos + 1);
 }
 
 fn recoverTableCloseCurly(self: *Parser) void {
@@ -3494,10 +3509,7 @@ fn runExprStatementKernel(
             } else if (tok_int < @intFromEnum(Token.Tag.OpPlus)) {
                 if (tok == .LowerIdent or tok == .NamedUnderscore) {
                     const start = self.pos;
-                    if (tok == .LowerIdent and
-                        std.mem.eql(u8, self.tokenText(start), "table") and
-                        (self.peekNext() == .LowerIdent or self.peekNext() == .OpenCurly))
-                    {
+                    if (self.startsTableLiteral()) {
                         self.advance();
                         expr_table_state = .{
                             .start = start,

--- a/src/parse/mod.zig
+++ b/src/parse/mod.zig
@@ -1053,3 +1053,30 @@ test "parser does not create a type path for malformed associated type headers" 
         }
     }
 }
+
+test "table cell newline before comma is a row end, not a same-row separator" {
+    const gpa = std.testing.allocator;
+    const source =
+        \\table name, age {
+        \\    "Bob"
+        \\    , 12,
+        \\    "Alice", 17,
+        \\}
+    ;
+
+    var env = try CommonEnv.init(gpa, source);
+    defer env.deinit(gpa);
+
+    const ast = try expr(gpa, &env);
+    defer ast.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), ast.tokenize_diagnostics.items.len);
+    try std.testing.expectEqual(@as(usize, 1), ast.parse_diagnostics.items.len);
+    try std.testing.expectEqual(
+        AST.Diagnostic.Tag.table_row_width_mismatch,
+        ast.parse_diagnostics.items[0].tag,
+    );
+
+    const expr_idx: AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
+    try std.testing.expectEqual(.malformed, std.meta.activeTag(ast.store.getExpr(expr_idx)));
+}

--- a/src/parse/mod.zig
+++ b/src/parse/mod.zig
@@ -1080,3 +1080,22 @@ test "table cell newline before comma is a row end, not a same-row separator" {
     const expr_idx: AST.Expr.Idx = @enumFromInt(ast.root_node_idx);
     try std.testing.expectEqual(.malformed, std.meta.activeTag(ast.store.getExpr(expr_idx)));
 }
+
+test "bare table ident is not a table literal when the next line starts with a lowercase name" {
+    const gpa = std.testing.allocator;
+    const source =
+        \\table_for_host = table
+        \\
+        \\names_for_host : List(Str)
+        \\names_for_host = names
+    ;
+
+    var env = try CommonEnv.init(gpa, source);
+    defer env.deinit(gpa);
+
+    const ast = try file(gpa, &env);
+    defer ast.deinit();
+
+    try std.testing.expectEqual(@as(usize, 0), ast.tokenize_diagnostics.items.len);
+    try std.testing.expectEqual(@as(usize, 0), ast.parse_diagnostics.items.len);
+}

--- a/src/parse/test/ast_node_store_test.zig
+++ b/src/parse/test/ast_node_store_test.zig
@@ -920,6 +920,13 @@ test "NodeStore round trip - Expr" {
         },
     });
     try expressions.append(gpa, AST.Expr{
+        .table = .{
+            .columns = AST.TableColumn.Span{ .span = rand_span(random) },
+            .rows = AST.TableRow.Span{ .span = rand_span(random) },
+            .region = rand_region(random),
+        },
+    });
+    try expressions.append(gpa, AST.Expr{
         .@"break" = .{ .region = rand_region(random) },
     });
     try expressions.append(gpa, AST.Expr{

--- a/test/snapshots/eval/table_literal_field_access.md
+++ b/test/snapshots/eval/table_literal_field_access.md
@@ -1,0 +1,221 @@
+# META
+~~~ini
+description=Table literal desugars to a list of records
+type=snippet
+~~~
+# SOURCE
+~~~roc
+people = table name : Str, age : U8 {
+    "Bob", 12,
+    "Alice", 17,
+}
+
+first = match List.first(people) {
+    Ok(person) => person
+    Err(_) => { name: "", age: 0 }
+}
+
+expect first.name == "Bob"
+expect first.age == 12
+expect people.len() == 2
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,LowerIdent,LowerIdent,OpColon,UpperIdent,Comma,LowerIdent,OpColon,UpperIdent,OpenCurly,
+StringStart,StringPart,StringEnd,Comma,Int,Comma,
+StringStart,StringPart,StringEnd,Comma,Int,Comma,
+CloseCurly,
+LowerIdent,OpAssign,KwMatch,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpenCurly,
+UpperIdent,NoSpaceOpenRound,LowerIdent,CloseRound,OpFatArrow,LowerIdent,
+UpperIdent,NoSpaceOpenRound,Underscore,CloseRound,OpFatArrow,OpenCurly,LowerIdent,OpColon,StringStart,StringPart,StringEnd,Comma,LowerIdent,OpColon,Int,CloseCurly,
+CloseCurly,
+KwExpect,LowerIdent,NoSpaceDotLowerIdent,OpEquals,StringStart,StringPart,StringEnd,
+KwExpect,LowerIdent,NoSpaceDotLowerIdent,OpEquals,Int,
+KwExpect,LowerIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,CloseRound,OpEquals,Int,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-decl
+			(p-ident (raw "people"))
+			(e-table
+				(columns
+					(table-column (name "name")
+						(ty (name "Str")))
+					(table-column (name "age")
+						(ty (name "U8"))))
+				(rows
+					(table-row
+						(e-string
+							(e-string-part (raw "Bob")))
+						(e-int (raw "12")))
+					(table-row
+						(e-string
+							(e-string-part (raw "Alice")))
+						(e-int (raw "17"))))))
+		(s-decl
+			(p-ident (raw "first"))
+			(e-match
+				(e-apply
+					(e-ident (raw "List.first"))
+					(e-ident (raw "people")))
+				(branches
+					(branch
+						(p-tag (raw "Ok")
+							(p-ident (raw "person")))
+						(e-ident (raw "person")))
+					(branch
+						(p-tag (raw "Err")
+							(p-underscore))
+						(e-record
+							(field (field "name")
+								(e-string
+									(e-string-part (raw ""))))
+							(field (field "age")
+								(e-int (raw "0"))))))))
+		(s-expect
+			(e-binop (op "==")
+				(e-field-access
+					(receiver
+						(e-ident (raw "first")))
+					(segment (mode "required") (field "name")))
+				(e-string
+					(e-string-part (raw "Bob")))))
+		(s-expect
+			(e-binop (op "==")
+				(e-field-access
+					(receiver
+						(e-ident (raw "first")))
+					(segment (mode "required") (field "age")))
+				(e-int (raw "12"))))
+		(s-expect
+			(e-binop (op "==")
+				(e-method-call (method ".len")
+					(receiver
+						(e-ident (raw "people")))
+					(args))
+				(e-int (raw "2"))))))
+~~~
+# FORMATTED
+~~~roc
+people = table name : Str, age : U8 {
+	"Bob", 12,
+	"Alice", 17,
+}
+
+first = match List.first(people) {
+	Ok(person) => person
+	Err(_) => { name: "", age: 0 }
+}
+
+expect first.name == "Bob"
+expect first.age == 12
+expect people.len() == 2
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "people"))
+		(e-block
+			(s-let
+				(p-assign (ident "#1"))
+				(e-list
+					(elems
+						(e-record
+							(fields
+								(field (name "name")
+									(e-string
+										(e-literal (string "Bob"))))
+								(field (name "age")
+									(e-num (value "12")))))
+						(e-record
+							(fields
+								(field (name "name")
+									(e-string
+										(e-literal (string "Alice"))))
+								(field (name "age")
+									(e-num (value "17"))))))))
+			(e-lookup-local
+				(p-assign (ident "#1")))))
+	(d-let
+		(p-assign (ident "first"))
+		(e-match
+			(match
+				(cond
+					(e-call (constraint-fn-var 333)
+						(e-lookup-external
+							(builtin))
+						(e-lookup-local
+							(p-assign (ident "people")))))
+				(branches
+					(branch
+						(patterns
+							(pattern (degenerate false)
+								(p-applied-tag)))
+						(value
+							(e-lookup-local
+								(p-assign (ident "person")))))
+					(branch
+						(patterns
+							(pattern (degenerate false)
+								(p-applied-tag)))
+						(value
+							(e-record
+								(fields
+									(field (name "name")
+										(e-string
+											(e-literal (string ""))))
+									(field (name "age")
+										(e-num (value "0")))))))))))
+	(s-expect
+		(e-method-eq (negated "false")
+			(lhs
+				(e-field-access
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "first"))))
+					(segments
+						(segment (name "name") (mode "required")))))
+			(rhs
+				(e-string
+					(e-literal (string "Bob"))))))
+	(s-expect
+		(e-method-eq (negated "false")
+			(lhs
+				(e-field-access
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "first"))))
+					(segments
+						(segment (name "age") (mode "required")))))
+			(rhs
+				(e-num (value "12")))))
+	(s-expect
+		(e-method-eq (negated "false")
+			(lhs
+				(e-dispatch-call (method "len") (constraint-fn-var 409)
+					(receiver
+						(e-lookup-local
+							(p-assign (ident "people"))))
+					(args)))
+			(rhs
+				(e-num (value "2"))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "List({ age: U8, name: Str })"))
+		(patt (type "{ age: U8, name: Str }")))
+	(expressions
+		(expr (type "List({ age: U8, name: Str })"))
+		(expr (type "{ age: U8, name: Str }"))))
+~~~

--- a/test/snapshots/expr/table_call_not_literal.md
+++ b/test/snapshots/expr/table_call_not_literal.md
@@ -1,0 +1,38 @@
+# META
+~~~ini
+description=table(x) remains an ordinary call, not a table literal
+type=expr
+~~~
+# SOURCE
+~~~roc
+table(x)
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,NoSpaceOpenRound,LowerIdent,CloseRound,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-apply
+	(e-ident (raw "table"))
+	(e-ident (raw "x")))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-call
+	(e-runtime-error (tag "ident_not_in_scope"))
+	(e-runtime-error (tag "ident_not_in_scope")))
+~~~
+# TYPES
+~~~clojure
+(expr (type "Error"))
+~~~

--- a/test/snapshots/expr/table_duplicate_column.md
+++ b/test/snapshots/expr/table_duplicate_column.md
@@ -1,0 +1,57 @@
+# META
+~~~ini
+description=Table with a duplicate column name
+type=expr
+~~~
+# SOURCE
+~~~roc
+table name, name {
+    "Bob", "Robert",
+}
+~~~
+# EXPECTED
+DUPLICATE TABLE COLUMN - table_duplicate_column.md:1:13:1:17
+# PROBLEMS
+── ✗ duplicate table column ───────────────────── table_duplicate_column.md:1:13
+
+I was parsing a table literal, and this column name is already used.
+
+table name, name {
+            ^^^^
+
+Each column name in a table must be unique.
+
+For example:
+    table name, age {
+        "Ada", 36,
+    }
+
+I found name here.
+Names that start with lowercase letters are value names or record field names,
+depending on the surrounding syntax.
+
+# TOKENS
+~~~zig
+LowerIdent,LowerIdent,Comma,LowerIdent,OpenCurly,
+StringStart,StringPart,StringEnd,Comma,StringStart,StringPart,StringEnd,Comma,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-malformed (reason "table_duplicate_column"))
+~~~
+# FORMATTED
+~~~roc
+
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir (empty true))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(expressions))
+~~~

--- a/test/snapshots/expr/table_ident_next_line.md
+++ b/test/snapshots/expr/table_ident_next_line.md
@@ -1,0 +1,84 @@
+# META
+~~~ini
+description=bare table ident then a lowercase name on the next line is not a table literal
+type=snippet
+~~~
+# SOURCE
+~~~roc
+table_for_host = table
+
+names_for_host : List(Str)
+names_for_host = names
+~~~
+# EXPECTED
+NAME NOT IN SCOPE - table_ident_next_line.md:1:18:1:23
+NAME NOT IN SCOPE - table_ident_next_line.md:4:18:4:23
+# PROBLEMS
+── ✗ name not in scope ─────────────────────────── table_ident_next_line.md:1:18
+
+Nothing is named table in this scope.
+
+table_for_host = table
+                 ^^^^^
+
+Is it misspelled, or is there an import missing?
+
+── ✗ name not in scope ─────────────────────────── table_ident_next_line.md:4:18
+
+Nothing is named names in this scope.
+
+names_for_host = names
+                 ^^^^^
+
+Is it misspelled, or is there an import missing?
+
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,LowerIdent,
+LowerIdent,OpColon,UpperIdent,NoSpaceOpenRound,UpperIdent,CloseRound,
+LowerIdent,OpAssign,LowerIdent,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-decl
+			(p-ident (raw "table_for_host"))
+			(e-ident (raw "table")))
+		(s-type-anno (name "names_for_host")
+			(ty-apply
+				(ty (name "List"))
+				(ty (name "Str"))))
+		(s-decl
+			(p-ident (raw "names_for_host"))
+			(e-ident (raw "names")))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "table_for_host"))
+		(e-runtime-error (tag "ident_not_in_scope")))
+	(d-let
+		(p-assign (ident "names_for_host"))
+		(e-runtime-error (tag "ident_not_in_scope"))
+		(annotation
+			(ty-apply (name "List") (builtin)
+				(ty-lookup (name "Str") (builtin))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "Error"))
+		(patt (type "List(Str)")))
+	(expressions
+		(expr (type "Error"))
+		(expr (type "List(Str)"))))
+~~~

--- a/test/snapshots/expr/table_literal.md
+++ b/test/snapshots/expr/table_literal.md
@@ -1,0 +1,100 @@
+# META
+~~~ini
+description=Untyped table literal of people
+type=expr
+~~~
+# SOURCE
+~~~roc
+table name, age, favorite_color {
+    "Bob", 12, "blue",
+    "Alice", 17, "green",
+    "Eve", 13, "red",
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,LowerIdent,Comma,LowerIdent,Comma,LowerIdent,OpenCurly,
+StringStart,StringPart,StringEnd,Comma,Int,Comma,StringStart,StringPart,StringEnd,Comma,
+StringStart,StringPart,StringEnd,Comma,Int,Comma,StringStart,StringPart,StringEnd,Comma,
+StringStart,StringPart,StringEnd,Comma,Int,Comma,StringStart,StringPart,StringEnd,Comma,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-table
+	(columns
+		(table-column (name "name"))
+		(table-column (name "age"))
+		(table-column (name "favorite_color")))
+	(rows
+		(table-row
+			(e-string
+				(e-string-part (raw "Bob")))
+			(e-int (raw "12"))
+			(e-string
+				(e-string-part (raw "blue"))))
+		(table-row
+			(e-string
+				(e-string-part (raw "Alice")))
+			(e-int (raw "17"))
+			(e-string
+				(e-string-part (raw "green"))))
+		(table-row
+			(e-string
+				(e-string-part (raw "Eve")))
+			(e-int (raw "13"))
+			(e-string
+				(e-string-part (raw "red"))))))
+~~~
+# FORMATTED
+~~~roc
+table name, age, favorite_color {
+	"Bob", 12, "blue",
+	"Alice", 17, "green",
+	"Eve", 13, "red",
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(e-list
+	(elems
+		(e-record
+			(fields
+				(field (name "name")
+					(e-string
+						(e-literal (string "Bob"))))
+				(field (name "age")
+					(e-num (value "12")))
+				(field (name "favorite_color")
+					(e-string
+						(e-literal (string "blue"))))))
+		(e-record
+			(fields
+				(field (name "name")
+					(e-string
+						(e-literal (string "Alice"))))
+				(field (name "age")
+					(e-num (value "17")))
+				(field (name "favorite_color")
+					(e-string
+						(e-literal (string "green"))))))
+		(e-record
+			(fields
+				(field (name "name")
+					(e-string
+						(e-literal (string "Eve"))))
+				(field (name "age")
+					(e-num (value "13")))
+				(field (name "favorite_color")
+					(e-string
+						(e-literal (string "red"))))))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "List({ age: Dec, favorite_color: Str, name: Str })"))
+~~~

--- a/test/snapshots/expr/table_literal_empty.md
+++ b/test/snapshots/expr/table_literal_empty.md
@@ -1,0 +1,45 @@
+# META
+~~~ini
+description=Empty typed table literal
+type=expr
+~~~
+# SOURCE
+~~~roc
+table name : Str, age : U8 {}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,LowerIdent,OpColon,UpperIdent,Comma,LowerIdent,OpColon,UpperIdent,OpenCurly,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-table
+	(columns
+		(table-column (name "name")
+			(ty (name "Str")))
+		(table-column (name "age")
+			(ty (name "U8"))))
+	(rows))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(e-block
+	(s-let
+		(p-assign (ident "#1"))
+		(e-empty_list))
+	(e-lookup-local
+		(p-assign (ident "#1"))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "List({ age: U8, name: Str })"))
+~~~

--- a/test/snapshots/expr/table_literal_typed.md
+++ b/test/snapshots/expr/table_literal_typed.md
@@ -1,0 +1,77 @@
+# META
+~~~ini
+description=Table literal with typed columns
+type=expr
+~~~
+# SOURCE
+~~~roc
+table name : Str, age : U8 {
+    "Bob", 12,
+    "Alice", 17,
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,LowerIdent,OpColon,UpperIdent,Comma,LowerIdent,OpColon,UpperIdent,OpenCurly,
+StringStart,StringPart,StringEnd,Comma,Int,Comma,
+StringStart,StringPart,StringEnd,Comma,Int,Comma,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-table
+	(columns
+		(table-column (name "name")
+			(ty (name "Str")))
+		(table-column (name "age")
+			(ty (name "U8"))))
+	(rows
+		(table-row
+			(e-string
+				(e-string-part (raw "Bob")))
+			(e-int (raw "12")))
+		(table-row
+			(e-string
+				(e-string-part (raw "Alice")))
+			(e-int (raw "17")))))
+~~~
+# FORMATTED
+~~~roc
+table name : Str, age : U8 {
+	"Bob", 12,
+	"Alice", 17,
+}
+~~~
+# CANONICALIZE
+~~~clojure
+(e-block
+	(s-let
+		(p-assign (ident "#1"))
+		(e-list
+			(elems
+				(e-record
+					(fields
+						(field (name "name")
+							(e-string
+								(e-literal (string "Bob"))))
+						(field (name "age")
+							(e-num (value "12")))))
+				(e-record
+					(fields
+						(field (name "name")
+							(e-string
+								(e-literal (string "Alice"))))
+						(field (name "age")
+							(e-num (value "17"))))))))
+	(e-lookup-local
+		(p-assign (ident "#1"))))
+~~~
+# TYPES
+~~~clojure
+(expr (type "List({ age: U8, name: Str })"))
+~~~

--- a/test/snapshots/expr/table_newline_before_comma.md
+++ b/test/snapshots/expr/table_newline_before_comma.md
@@ -1,0 +1,62 @@
+# META
+~~~ini
+description=Body-depth newline before a comma ends the table row (width error, not a silent merge)
+type=expr
+~~~
+# SOURCE
+~~~roc
+table name, age {
+    "Bob"
+    , 12,
+    "Alice", 17,
+}
+~~~
+# EXPECTED
+TABLE ROW WIDTH - table_newline_before_comma.md:2:5:2:10
+# PROBLEMS
+── ✗ table row width ───────────────────────── table_newline_before_comma.md:2:5
+
+I was parsing a table row, and it does not have the same number of values as
+there are columns.
+
+"Bob"
+^^^^^
+
+Each row must have one value per column, separated by commas. A newline starts
+the next row.
+
+For example:
+    table name, age {
+        "Ada", 36,
+        "Alan", 42,
+    }
+
+I found "Bob" here.
+
+# TOKENS
+~~~zig
+LowerIdent,LowerIdent,Comma,LowerIdent,OpenCurly,
+StringStart,StringPart,StringEnd,
+Comma,Int,Comma,
+StringStart,StringPart,StringEnd,Comma,Int,Comma,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-malformed (reason "table_row_width_mismatch"))
+~~~
+# FORMATTED
+~~~roc
+
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir (empty true))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(expressions))
+~~~

--- a/test/snapshots/expr/table_no_columns.md
+++ b/test/snapshots/expr/table_no_columns.md
@@ -1,0 +1,52 @@
+# META
+~~~ini
+description=table {} is invalid because a table needs at least one column
+type=expr
+~~~
+# SOURCE
+~~~roc
+table {}
+~~~
+# EXPECTED
+EXPECTED TABLE COLUMN - table_no_columns.md:1:7:1:8
+# PROBLEMS
+── ✗ expected table column ───────────────────────────── table_no_columns.md:1:7
+
+I was parsing a table literal, and I expected a lowercase column name.
+
+table {}
+      ^
+
+A table starts with table followed by one or more column names, then a { body.
+Each column can optionally have a type after :.
+
+For example:
+    table name, age {
+        "Ada", 36,
+    }
+
+I found { here.
+
+# TOKENS
+~~~zig
+LowerIdent,OpenCurly,CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-malformed (reason "table_expected_column_name"))
+~~~
+# FORMATTED
+~~~roc
+
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir (empty true))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(expressions))
+~~~

--- a/test/snapshots/expr/table_row_width_mismatch.md
+++ b/test/snapshots/expr/table_row_width_mismatch.md
@@ -1,0 +1,58 @@
+# META
+~~~ini
+description=Table row with the wrong number of values
+type=expr
+~~~
+# SOURCE
+~~~roc
+table name, age {
+    "Bob", 12, "extra",
+}
+~~~
+# EXPECTED
+TABLE ROW WIDTH - table_row_width_mismatch.md:2:5:2:24
+# PROBLEMS
+── ✗ table row width ─────────────────────────── table_row_width_mismatch.md:2:5
+
+I was parsing a table row, and it does not have the same number of values as
+there are columns.
+
+"Bob", 12, "extra",
+^^^^^^^^^^^^^^^^^^^
+
+Each row must have one value per column, separated by commas. A newline starts
+the next row.
+
+For example:
+    table name, age {
+        "Ada", 36,
+        "Alan", 42,
+    }
+
+I found "Bob", 12, "extra", here.
+
+# TOKENS
+~~~zig
+LowerIdent,LowerIdent,Comma,LowerIdent,OpenCurly,
+StringStart,StringPart,StringEnd,Comma,Int,Comma,StringStart,StringPart,StringEnd,Comma,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(e-malformed (reason "table_row_width_mismatch"))
+~~~
+# FORMATTED
+~~~roc
+
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir (empty true))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs)
+	(expressions))
+~~~


### PR DESCRIPTION
Sorry about the original contents of this post, Cursor jumped a little ahead -- I ran out of Claude Code earlier today and have been trying the new old tool again :-) The below is human edited.

I had Claude add a table syntax to Roc's syntax, because I like tables, and I wondered if it was possible without knowing Roc to modify it.

## Why tables matter

I think tables are critical to the future of computing. Some references:

- [A Data-Centric Introduction to Computing with Shriram Krishnamurthi ](https://youtu.be/HwPM0xMdiNU?t=684) (jump to 11:24)

or in text form:
- [*A Data-Centric Introduction to Computing*](https://dcic-world.org/), especially [Our Perspective on Data](https://dcic-world.org/2025-08-27/booklet_intro.html#%28part._.Our_.Perspective_on_.Data%29) — tabular data as the ideal way to think about collections of records, and one of the oldest:

<img width="821" height="583" alt="image" src="https://github.com/user-attachments/assets/fc1b4295-6d37-4319-966d-7db74bfd79ed" />


The homepage todos example (couldn't find the source) is the kind of thing that currently repeats every field name on every row. A table literal makes that more convenient, IMO:

## Suggested syntax (taken from Pyret)

[Homepage](https://roc-lang.org/) writes:

```
    todos = [
        { name: "Learn Roc",       status: Done },
        { name: "Buy groceries",   status: Done },
        { name: "Write blog post", status: InProgress },
        { name: "Call mom",        status: NotStarted },
    ]
```

The suggested change in idiom is:

```roc
todos = table name, status {
    "Learn Roc",       Done,
    "Buy groceries",   Done,
    "Write blog post", InProgress,
    "Call mom",        NotStarted,
}
```

**The most obvious difference compared to Pyret's choice is the lack of `row`.** Pyret's `row:` would enable a single logical row span multiple source lines, I guess. Without it, my intuition is that each table row can only be one row in the source text.
Claude says that in the impl vibecoded, newlines at table-body depth end the row; newlines inside `()`, `[]`, `{}`, or a lambda do not.
I don't have an opinion on that tradeoff, it's just what fell out.

`table` is a contextual keyword (`table(x)` stays valid, i.e. table is not reserved). Columns may take types (`table name : Str, age : U8 { ... }`) so numerals pick up the column type instead of defaulting to `Dec`.

## Implementation

This PR is an allegedly working implementation of the suggested syntax that Claude wrote. I have not personally used it yet, I wanted to discuss the idea more before sinking in more time. I had claude write an impl mostly to see if it was possible.

It claims that this is tested:
>parse + format + canonicalize desugar, with snapshots. Invalid tables (duplicate columns, width mismatch, zero columns) fail at parse so later stages never see a bad table.