### PR TITLE
Match rendered lowercase diagnostic titles in nightly-only tests

### DIFF
--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -418,7 +418,7 @@ pub const io_spec_tests = [_]TestSpec{
     .{
         .roc_file = "test/fx/dbg_corrupts_recursive_tag_union.roc",
         .io_spec = "1>Child is Text: hello",
-        .expected_build_stderr_contains = &.{"`DBG` IN OPTIMIZED BUILD"},
+        .expected_build_stderr_contains = &.{"`dbg` in optimized build"},
         .description = "Regression test: dbg on recursive tag union preserves variant discriminant (issue #8804)",
     },
     .{

--- a/test/echo-wasm-test/main.zig
+++ b/test/echo-wasm-test/main.zig
@@ -241,7 +241,7 @@ pub fn main(init: std.process.Init) anyerror!void {
         std.process.exit(1);
     }
 
-    requireContains(bad_stderr, "TYPE MISMATCH", "diagnostic stderr");
+    requireContains(bad_stderr, "type mismatch", "diagnostic stderr");
     requireContains(bad_stderr, "\xE2\x94", "diagnostic stderr");
     requireContains(bad_stderr, "main.roc", "diagnostic stderr");
     requireNotContains(bad_stderr, "/app/main.roc", "diagnostic stderr");
@@ -267,7 +267,7 @@ pub fn main(init: std.process.Init) anyerror!void {
         std.process.exit(1);
     }
 
-    requireContains(malformed_stderr, "SYNTAX", "syntax diagnostic stderr");
+    requireContains(malformed_stderr, "syntax", "syntax diagnostic stderr");
     requireContains(malformed_stderr, "main.roc", "syntax diagnostic stderr");
     requireNotContains(malformed_stderr, "echo: step", "syntax diagnostic stderr");
 


### PR DESCRIPTION
The Nightly Gate was failing in nine jobs from two stale test expectations. Diagnostic reports render their titles lowercased in the terminal/plain output (snapshots keep the uppercase form because they go through the markdown renderer), but two tests that match against rendered stderr were still looking for the uppercase title text. The echo.wasm integration test required `TYPE MISMATCH` and `SYNTAX`, and the `dbg_corrupts_recursive_tag_union.roc` fx spec required `` `DBG` IN OPTIMIZED BUILD ``; the compiler now emits `type mismatch`, `unexpected expression syntax`, and `` `dbg` in optimized build `` respectively.

These two only run in the nightly gate, which is why they went unnoticed: the fx spec's expected build stderr is only checked for optimized backends, and the platforms suite runs interpreter and dev natively, so `` `dbg` in optimized build `` is exercised solely by the cross-compile jobs. That single spec accounted for all eight cross-compile job failures.
