### PR TITLE
wasm: size initial memory when no minimum is given

### DIFF
--- a/src/cli/cli_args.zig
+++ b/src/cli/cli_args.zig
@@ -223,7 +223,7 @@ pub const BuildArgs = struct {
     watch: bool = false, // rebuild when source inputs change
     watch_inputs_file: ?[]const u8 = null, // internal: write watch input paths and byte states here
     max_threads: ?usize = null, // max worker threads (null = auto, 1 = single-threaded)
-    wasm_memory: ?usize = null, // initial memory size for WASM targets (default: 64MB)
+    wasm_memory: ?usize = null, // initial memory size for WASM targets (default: sized from data segments plus the stack)
     wasm_stack_size: ?usize = null, // stack size for WASM targets (default: 8MB)
     require_executable_output: bool = false, // reject static/shared library targets
     require_host_runnable_output: bool = false, // internal: reject targets that cannot run on this host
@@ -592,7 +592,7 @@ fn parseBuild(args: []const []const u8) CliArgs {
             \\      --no-cache                     Disable compilation caching
             \\      --watch                        Rebuild when source inputs change
             \\  -j, --jobs=<N>                     Max worker threads for parallel compilation (default: auto-detect CPU count)
-            \\      --wasm-memory=<bytes>          Initial memory size for WASM targets in bytes (default: 67108864 = 64MB)
+            \\      --wasm-memory=<bytes>          Initial memory size for WASM targets in bytes (default: sized from data segments plus the stack)
             \\      --wasm-stack-size=<bytes>      Stack size for WASM targets in bytes (default: 8388608 = 8MB)
             \\      -h, --help                     Print help
             \\

--- a/src/cli/linker.zig
+++ b/src/cli/linker.zig
@@ -86,9 +86,6 @@ pub const WasmOptimizeMode = enum {
     speed,
 };
 
-/// Default WASM initial memory: 64MB
-pub const DEFAULT_WASM_INITIAL_MEMORY: usize = 64 * 1024 * 1024;
-
 /// Default WASM stack size: 8MB
 pub const DEFAULT_WASM_STACK_SIZE: usize = 8 * 1024 * 1024;
 
@@ -150,7 +147,8 @@ pub const LinkConfig = struct {
 
     /// Initial memory size for WASM targets (bytes). This is the amount of linear memory
     /// available to the WASM module at runtime. Must be a multiple of 64KB (WASM page size).
-    wasm_initial_memory: usize = DEFAULT_WASM_INITIAL_MEMORY,
+    /// Null lets wasm-ld size memory itself from the data segments plus the stack.
+    wasm_initial_memory: ?usize = null,
 
     /// Maximum memory size for WASM targets (bytes), when the runtime contract needs one.
     wasm_maximum_memory: ?usize = null,
@@ -710,10 +708,13 @@ fn buildLinkArgs(ctx: *CliCtx, config: LinkConfig) LinkError!std.array_list.Mana
                 try args.append("--import-memory");
             }
 
-            // Set initial memory size (configurable, default 64MB)
-            // Must be a multiple of 64KB (WASM page size)
-            const initial_memory_str = std.fmt.allocPrint(ctx.arena, "--initial-memory={d}", .{config.wasm_initial_memory}) catch return LinkError.OutOfMemory;
-            try args.append(initial_memory_str);
+            // Set initial memory size when one was configured. Must be a
+            // multiple of 64KB (WASM page size). Without the flag wasm-ld
+            // sizes memory itself from the data segments plus the stack.
+            if (config.wasm_initial_memory) |initial_memory| {
+                const initial_memory_str = std.fmt.allocPrint(ctx.arena, "--initial-memory={d}", .{initial_memory}) catch return LinkError.OutOfMemory;
+                try args.append(initial_memory_str);
+            }
 
             if (config.wasm_maximum_memory) |maximum_memory| {
                 const maximum_memory_str = std.fmt.allocPrint(ctx.arena, "--max-memory={d}", .{maximum_memory}) catch return LinkError.OutOfMemory;
@@ -1194,6 +1195,15 @@ fn findArg(args: []const []const u8, needle: []const u8) ?usize {
     return null;
 }
 
+/// Whether `args` contains an argument starting with `prefix`, for the linker
+/// options that are spelled as a single `--flag=value` argument.
+fn findArgWithPrefix(args: []const []const u8, prefix: []const u8) ?usize {
+    for (args, 0..) |arg, i| {
+        if (std.mem.startsWith(u8, arg, prefix)) return i;
+    }
+    return null;
+}
+
 /// Whether `args` contains `flag` immediately followed by `value`, for the
 /// linker options that are spelled as two separate arguments.
 fn hasArgPair(args: []const []const u8, flag: []const u8, value: []const u8) bool {
@@ -1245,6 +1255,41 @@ test "size wasm strips final target feature metadata" {
 
     const v1 = binaryenConfig(.{ .output_path = "out.wasm", .object_files = &.{}, .wasm_optimize = .speed, .wasm_cpu_level = .v1 });
     try std.testing.expectEqual(@as(u8, 0), v1.simd128);
+}
+
+test "wasm initial memory reaches wasm-ld only when configured" {
+    var arena_instance = collections.SingleThreadArena.init(std.testing.allocator);
+    defer arena_instance.deinit();
+
+    var io = Io.create(std.testing.io);
+    var ctx = CliCtx.init(std.testing.allocator, arena_instance.allocator(), &io, .build);
+    ctx.initIo();
+    defer ctx.deinit();
+
+    // Unconfigured: no --initial-memory at all, so wasm-ld sizes memory
+    // itself from the data segments plus the stack.
+    const auto_config = LinkConfig{
+        .target_format = .wasm,
+        .target_os = .freestanding,
+        .target_arch = .wasm32,
+        .output_path = "test_output.wasm",
+        .object_files = &.{"app.o"},
+    };
+    const auto_args = try buildLinkArgs(&ctx, auto_config);
+    try std.testing.expectEqual(@as(?usize, null), findArgWithPrefix(auto_args.items, "--initial-memory="));
+
+    // Configured: the exact value reaches wasm-ld.
+    const sized_config = LinkConfig{
+        .target_format = .wasm,
+        .target_os = .freestanding,
+        .target_arch = .wasm32,
+        .output_path = "test_output.wasm",
+        .object_files = &.{"app.o"},
+        .wasm_initial_memory = 1114112,
+    };
+    const sized_args = try buildLinkArgs(&ctx, sized_config);
+    const idx = findArgWithPrefix(sized_args.items, "--initial-memory=") orelse return error.MissingInitialMemory;
+    try std.testing.expectEqualStrings("--initial-memory=1114112", sized_args.items[idx]);
 }
 
 test "force undefined symbols use target linker spelling" {

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -9084,12 +9084,16 @@ fn configuredWasmStackBytes(args: cli_args.BuildArgs, wasm: ?roc_target.WasmTarg
     return linker.DEFAULT_WASM_STACK_SIZE;
 }
 
-fn configuredWasmMinimumMemory(args: cli_args.BuildArgs, wasm: ?roc_target.WasmTargetConfig) usize {
+/// The configured initial wasm memory, or null when neither the CLI nor the
+/// platform's targets config specifies one. Null lets the linker size memory
+/// from the data segments plus the stack, which is always sufficient for
+/// those regions. The host must grow memory for its heap independently.
+fn configuredWasmMinimumMemory(args: cli_args.BuildArgs, wasm: ?roc_target.WasmTargetConfig) ?usize {
     if (args.wasm_memory) |bytes| return bytes;
     if (wasm) |config| {
         if (config.minimum_memory) |bytes| return bytes;
     }
-    return linker.DEFAULT_WASM_INITIAL_MEMORY;
+    return null;
 }
 
 /// Whether linked wasm output may assume linear memory starts zero-filled.


### PR DESCRIPTION
Wasm builds always passed `--initial-memory=67108864` (64MB) to `wasm-ld`, so every wasm binary used 64MB of linear memory even when it needed much less.

Now, when neither `--wasm-memory` nor the platform's `minimum_memory` targets config is set, the flag is omitted and `wasm-ld` gets to size the memory from the data segments plus the stack. The dev backend already computed this itself when no minimum was configured.