### PR TITLE
Fix compile-time validation of local destructures

### DIFF
--- a/design.md
+++ b/design.md
@@ -2091,11 +2091,11 @@ A non-exhaustive destructure in an unguarded runtime position is itself a strict
 compile-time demand when its right-hand side is top-level-equivalent. This demand
 does not depend on whether the pattern contains a binder or whether any binder is
 later referenced. The checker selects a unit-valued pattern-validation root that
-evaluates the right-hand side and matches the complete source pattern. It also
-selects the first binder extraction, when one exists, without waiting for that
-binder to become live. After solving, a concrete extraction subsumes the matching
-validation root so the right-hand side is evaluated only once; if the extraction
-cannot be stored as a concrete constant, the unit-valued validation root remains.
+evaluates the right-hand side and matches the complete source pattern. Binder
+extractions remain liveness-driven. After solving, a selected concrete extraction
+subsumes the matching validation root so a live binder does not make the
+right-hand side evaluate twice; with no selected concrete extraction, the
+unit-valued validation root remains and no dead binder value is archived.
 The pending exhaustiveness site is explicitly classified for empirical
 compile-time validation only after this root selection succeeds. No validation
 root is selected inside an ordinary top-level constant, because that enclosing

--- a/design.md
+++ b/design.md
@@ -2087,6 +2087,20 @@ right-hand side and complete scrutinee pattern. Those roots are emitted in
 dependency-first order and later lookups resolve through the selected binder,
 never as runtime-local pattern references.
 
+A non-exhaustive destructure in an unguarded runtime position is itself a strict
+compile-time demand when its right-hand side is top-level-equivalent. This demand
+does not depend on whether the pattern contains a binder or whether any binder is
+later referenced. The checker selects a unit-valued pattern-validation root that
+evaluates the right-hand side and matches the complete source pattern. It also
+selects the first binder extraction, when one exists, without waiting for that
+binder to become live. After solving, a concrete extraction subsumes the matching
+validation root so the right-hand side is evaluated only once; if the extraction
+cannot be stored as a concrete constant, the unit-valued validation root remains.
+The pending exhaustiveness site is explicitly classified for empirical
+compile-time validation only after this root selection succeeds. No validation
+root is selected inside an ordinary top-level constant, because that enclosing
+root already evaluates and owns the destructure site.
+
 Hoisted-root selection is positional as well as dependency-based. Selection may
 fire only in structurally unguarded positions of runtime bodies, and the checker
 must carry that position as explicit checking context while computing

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -3059,70 +3059,6 @@ fn recordHoistPatternExtractionProvenanceHelp(
     }
 }
 
-/// Select the first binder in source order as the compile-time owner for a
-/// refutable destructure. The checker has already recorded explicit
-/// extraction provenance for every binder before calling this helper.
-fn selectFirstHoistedPatternExtractionRoot(
-    self: *Self,
-    pattern: CIR.Pattern.Idx,
-) Allocator.Error!bool {
-    switch (self.cir.store.getPattern(pattern)) {
-        .assign => return self.ensureHoistedBindingRoot(pattern),
-        .as => |as_pattern| {
-            if (try self.ensureHoistedBindingRoot(pattern)) return true;
-            return self.selectFirstHoistedPatternExtractionRoot(as_pattern.pattern);
-        },
-        .tuple => |tuple| {
-            for (self.cir.store.slicePatterns(tuple.patterns)) |elem_pattern| {
-                if (try self.selectFirstHoistedPatternExtractionRoot(elem_pattern)) return true;
-            }
-        },
-        .record_destructure => |destructure| {
-            for (self.cir.store.sliceRecordDestructs(destructure.destructs)) |destruct_idx| {
-                const destruct = self.cir.store.getRecordDestruct(destruct_idx);
-                if (try self.selectFirstHoistedPatternExtractionRoot(destruct.kind.toPatternIdx())) return true;
-            }
-        },
-        .applied_tag => |tag| {
-            for (self.cir.store.slicePatterns(tag.args)) |arg_pattern| {
-                if (try self.selectFirstHoistedPatternExtractionRoot(arg_pattern)) return true;
-            }
-        },
-        .nominal => |nominal| return self.selectFirstHoistedPatternExtractionRoot(nominal.backing_pattern),
-        .nominal_external => |nominal| return self.selectFirstHoistedPatternExtractionRoot(nominal.backing_pattern),
-        .list => |list| {
-            for (self.cir.store.slicePatterns(list.patterns)) |elem_pattern| {
-                if (try self.selectFirstHoistedPatternExtractionRoot(elem_pattern)) return true;
-            }
-            if (list.rest_info) |rest_info| {
-                if (rest_info.pattern) |rest_pattern| {
-                    if (try self.selectFirstHoistedPatternExtractionRoot(rest_pattern)) return true;
-                }
-            }
-        },
-        .str_interpolation => |str| {
-            var step_offset: u32 = 0;
-            while (step_offset < str.steps.span.len) : (step_offset += 1) {
-                const step = self.cir.store.getStrPatternStep(str.steps, step_offset);
-                if (step.capture) |capture| {
-                    if (try self.selectFirstHoistedPatternExtractionRoot(capture)) return true;
-                }
-            }
-        },
-        .underscore,
-        .runtime_error,
-        .num_literal,
-        .num_from_numeral_literal,
-        .small_dec_literal,
-        .dec_literal,
-        .frac_f32_literal,
-        .frac_f64_literal,
-        .str_literal,
-        => {},
-    }
-    return false;
-}
-
 fn recordHoistPatternExtractionProvenance(
     self: *Self,
     pattern: CIR.Pattern.Idx,
@@ -18824,9 +18760,6 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                         try self.selectPendingDestructureValidationRoot(decl_stmt.pattern, decl_stmt.expr, expectation.hoist_position);
                     }
                     try self.recordHoistPatternProvenance(decl_stmt.pattern, decl_stmt.expr, expectation.hoist_position);
-                    if (needs_comptime_validation) {
-                        _ = try self.selectFirstHoistedPatternExtractionRoot(decl_stmt.pattern);
-                    }
                 }
                 try self.bindTypeSchemeVar(decl_expr_var, decl_pattern_var);
                 if (self.predeclared_local_scheme_vars.get(decl_stmt.pattern)) |predeclared_scheme_var| {

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -570,6 +570,9 @@ hoist_selected_bindings: std.AutoHashMapUnmanaged(CIR.Pattern.Idx, u32),
 /// expression selection and local binding selection from duplicating the same
 /// root.
 hoist_selected_exprs: std.AutoHashMapUnmanaged(CIR.Expr.Idx, u32),
+/// Unit-valued roots that validate one refutable destructure, keyed by the
+/// source destructure pattern.
+hoist_selected_pattern_validations: std.AutoHashMapUnmanaged(CIR.Pattern.Idx, u32),
 /// Expressions whose original subtrees were replaced with explicit runtime
 /// errors after hoist selection had already seen them. Selected roots and
 /// dependencies inside these subtrees must be pruned before publication.
@@ -1568,6 +1571,7 @@ const CompletedHoistResult = struct {
 };
 
 const HoistPatternExtraction = hoist_roots.PatternExtraction;
+const HoistPatternValidation = hoist_roots.PatternValidation;
 
 const HoistKnownValue = union(enum) {
     binding_rhs: CIR.Expr.Idx,
@@ -1593,6 +1597,7 @@ const HoistSelectionTransaction = struct {
     staged_roots: std.ArrayListUnmanaged(hoist_roots.SelectedHoistedRoot) = .empty,
     staged_exprs: std.AutoHashMapUnmanaged(CIR.Expr.Idx, u32) = .{},
     staged_bindings: std.AutoHashMapUnmanaged(CIR.Pattern.Idx, u32) = .{},
+    staged_pattern_validations: std.AutoHashMapUnmanaged(CIR.Pattern.Idx, u32) = .{},
     known_updates: std.ArrayListUnmanaged(HoistKnownUpdate) = .empty,
     committed: bool = false,
 
@@ -1609,6 +1614,7 @@ const HoistSelectionTransaction = struct {
         self.staged_roots.deinit(self.checker.gpa);
         self.staged_exprs.deinit(self.checker.gpa);
         self.staged_bindings.deinit(self.checker.gpa);
+        self.staged_pattern_validations.deinit(self.checker.gpa);
         self.known_updates.deinit(self.checker.gpa);
     }
 
@@ -1649,6 +1655,7 @@ const HoistSelectionTransaction = struct {
                     std.debug.assert(root.pattern != null);
                     std.debug.assert(root.pattern.? == pattern);
                 },
+                .pattern_validation => unreachable,
             }
         } else {
             const root = &self.checker.selected_hoisted_roots.items[root_index];
@@ -1720,6 +1727,24 @@ const HoistSelectionTransaction = struct {
             .body = .{ .pattern_extraction = extraction },
         });
         try self.stageBindingAssociation(pattern, root_index);
+        return root_index;
+    }
+
+    fn stagePatternValidationRoot(
+        self: *HoistSelectionTransaction,
+        validation: HoistPatternValidation,
+    ) Allocator.Error!u32 {
+        if (self.checker.hoist_selected_pattern_validations.get(validation.scrutinee_pattern)) |root_index| return root_index;
+        if (self.staged_pattern_validations.get(validation.scrutinee_pattern)) |root_index| return root_index;
+
+        try self.stageExprDependencies(validation.base_expr);
+
+        const root_index: u32 = @intCast(self.selectedRootCount() + self.staged_roots.items.len);
+        try self.staged_roots.append(self.checker.gpa, .{
+            .expr = validation.base_expr,
+            .body = .{ .pattern_validation = validation },
+        });
+        try self.staged_pattern_validations.put(self.checker.gpa, validation.scrutinee_pattern, root_index);
         return root_index;
     }
 
@@ -1960,6 +1985,7 @@ const HoistSelectionTransaction = struct {
         try self.checker.selected_hoisted_roots.ensureUnusedCapacity(self.checker.gpa, self.staged_roots.items.len);
         try self.checker.hoist_selected_exprs.ensureUnusedCapacity(self.checker.gpa, self.staged_exprs.count());
         try self.checker.hoist_selected_bindings.ensureUnusedCapacity(self.checker.gpa, self.staged_bindings.count());
+        try self.checker.hoist_selected_pattern_validations.ensureUnusedCapacity(self.checker.gpa, self.staged_pattern_validations.count());
 
         const selected_start = self.checker.selected_hoisted_roots.items.len;
         for (self.staged_roots.items, 0..) |root, offset| {
@@ -1968,7 +1994,13 @@ const HoistSelectionTransaction = struct {
             switch (root.body) {
                 .expr => self.checker.hoist_selected_exprs.putAssumeCapacityNoClobber(root.expr, root_index),
                 .pattern_extraction => {},
+                .pattern_validation => {},
             }
+        }
+
+        var validation_iter = self.staged_pattern_validations.iterator();
+        while (validation_iter.next()) |entry| {
+            self.checker.hoist_selected_pattern_validations.putAssumeCapacityNoClobber(entry.key_ptr.*, entry.value_ptr.*);
         }
 
         var binding_iter = self.staged_bindings.iterator();
@@ -2338,6 +2370,7 @@ fn initAssumePrepared(
         .hoist_contextual_binding_scope_patterns = .empty,
         .hoist_selected_bindings = .{},
         .hoist_selected_exprs = .{},
+        .hoist_selected_pattern_validations = .{},
         .hoist_invalidated_exprs = .{},
         .selected_hoisted_roots = .empty,
         .executable_root_defs = .empty,
@@ -2450,6 +2483,7 @@ pub fn deinit(self: *Self) void {
     self.hoist_contextual_binding_scope_patterns.deinit(self.gpa);
     self.hoist_selected_bindings.deinit(self.gpa);
     self.hoist_selected_exprs.deinit(self.gpa);
+    self.hoist_selected_pattern_validations.deinit(self.gpa);
     self.hoist_invalidated_exprs.deinit(self.gpa);
     for (self.selected_hoisted_roots.items) |*root| {
         hoist_roots.deinitSelectedRoot(self.gpa, root);
@@ -2570,6 +2604,7 @@ pub fn selectedHoistedRootIsTopLevel(self: *const Self, root: hoist_roots.Select
     const pattern = switch (root.body) {
         .expr => root.pattern orelse return false,
         .pattern_extraction => |extraction| extraction.scrutinee_pattern,
+        .pattern_validation => |validation| validation.scrutinee_pattern,
     };
     return self.patternIsTopLevelDef(pattern);
 }
@@ -2821,6 +2856,31 @@ fn recordHoistPatternProvenance(
     }
 }
 
+/// A pending destructure diagnostic is a strict compile-time demand on the
+/// complete scrutinee, independent of whether any binder is later referenced.
+/// Select one validation root from the same producer-proven eligibility facts
+/// used for ordinary local binding hoists.
+fn selectPendingDestructureValidationRoot(
+    self: *Self,
+    pattern: CIR.Pattern.Idx,
+    expr: CIR.Expr.Idx,
+    hoist_position: HoistPosition,
+) Allocator.Error!void {
+    const completed = self.last_hoist_result orelse return;
+    if (completed.expr != expr) return;
+    if (builtin.mode == .Debug) std.debug.assert(completed.hoist_position == hoist_position);
+    if (!completed.hoist_position.allowsSelection() or !completed.top_level_equivalent) return;
+    if (!self.exprCanBeHoistedBindingRoot(expr)) return;
+    if (isFunctionDef(&self.cir.store, self.cir.store.getExpr(expr))) return;
+    if (self.varIsFunctionType(ModuleEnv.varFrom(expr))) return;
+
+    _ = try self.ensureHoistedPatternValidationRoot(.{
+        .base_expr = expr,
+        .scrutinee_pattern = pattern,
+    });
+    self.problems.markPendingStaticExhaustivenessEmpirical(.{ .destructure_pattern = pattern });
+}
+
 fn patternCanOwnHoistedBindingRoot(self: *Self, pattern: CIR.Pattern.Idx) bool {
     return switch (self.cir.store.getPattern(pattern)) {
         .assign,
@@ -2997,6 +3057,70 @@ fn recordHoistPatternExtractionProvenanceHelp(
         .str_literal,
         => {},
     }
+}
+
+/// Select the first binder in source order as the compile-time owner for a
+/// refutable destructure. The checker has already recorded explicit
+/// extraction provenance for every binder before calling this helper.
+fn selectFirstHoistedPatternExtractionRoot(
+    self: *Self,
+    pattern: CIR.Pattern.Idx,
+) Allocator.Error!bool {
+    switch (self.cir.store.getPattern(pattern)) {
+        .assign => return self.ensureHoistedBindingRoot(pattern),
+        .as => |as_pattern| {
+            if (try self.ensureHoistedBindingRoot(pattern)) return true;
+            return self.selectFirstHoistedPatternExtractionRoot(as_pattern.pattern);
+        },
+        .tuple => |tuple| {
+            for (self.cir.store.slicePatterns(tuple.patterns)) |elem_pattern| {
+                if (try self.selectFirstHoistedPatternExtractionRoot(elem_pattern)) return true;
+            }
+        },
+        .record_destructure => |destructure| {
+            for (self.cir.store.sliceRecordDestructs(destructure.destructs)) |destruct_idx| {
+                const destruct = self.cir.store.getRecordDestruct(destruct_idx);
+                if (try self.selectFirstHoistedPatternExtractionRoot(destruct.kind.toPatternIdx())) return true;
+            }
+        },
+        .applied_tag => |tag| {
+            for (self.cir.store.slicePatterns(tag.args)) |arg_pattern| {
+                if (try self.selectFirstHoistedPatternExtractionRoot(arg_pattern)) return true;
+            }
+        },
+        .nominal => |nominal| return self.selectFirstHoistedPatternExtractionRoot(nominal.backing_pattern),
+        .nominal_external => |nominal| return self.selectFirstHoistedPatternExtractionRoot(nominal.backing_pattern),
+        .list => |list| {
+            for (self.cir.store.slicePatterns(list.patterns)) |elem_pattern| {
+                if (try self.selectFirstHoistedPatternExtractionRoot(elem_pattern)) return true;
+            }
+            if (list.rest_info) |rest_info| {
+                if (rest_info.pattern) |rest_pattern| {
+                    if (try self.selectFirstHoistedPatternExtractionRoot(rest_pattern)) return true;
+                }
+            }
+        },
+        .str_interpolation => |str| {
+            var step_offset: u32 = 0;
+            while (step_offset < str.steps.span.len) : (step_offset += 1) {
+                const step = self.cir.store.getStrPatternStep(str.steps, step_offset);
+                if (step.capture) |capture| {
+                    if (try self.selectFirstHoistedPatternExtractionRoot(capture)) return true;
+                }
+            }
+        },
+        .underscore,
+        .runtime_error,
+        .num_literal,
+        .num_from_numeral_literal,
+        .small_dec_literal,
+        .dec_literal,
+        .frac_f32_literal,
+        .frac_f64_literal,
+        .str_literal,
+        => {},
+    }
+    return false;
 }
 
 fn recordHoistPatternExtractionProvenance(
@@ -3239,6 +3363,18 @@ fn ensureHoistedPatternExtractionRoot(
     var transaction = HoistSelectionTransaction.init(self);
     defer transaction.deinit();
     const root_index = try transaction.stagePatternExtractionRoot(pattern, extraction);
+    try transaction.commit();
+    return root_index;
+}
+
+fn ensureHoistedPatternValidationRoot(
+    self: *Self,
+    validation: HoistPatternValidation,
+) Allocator.Error!u32 {
+    if (self.hoist_selected_pattern_validations.get(validation.scrutinee_pattern)) |root_index| return root_index;
+    var transaction = HoistSelectionTransaction.init(self);
+    defer transaction.deinit();
+    const root_index = try transaction.stagePatternValidationRoot(validation);
     try transaction.commit();
     return root_index;
 }
@@ -3514,11 +3650,24 @@ fn debugAssertHoistSelectionConsistent(self: *const Self) void {
         std.debug.assert(selected.pattern.? == entry.key_ptr.*);
     }
 
+    var validation_iter = self.hoist_selected_pattern_validations.iterator();
+    while (validation_iter.next()) |entry| {
+        const root_index = entry.value_ptr.*;
+        std.debug.assert(root_index < self.selected_hoisted_roots.items.len);
+        const selected = self.selected_hoisted_roots.items[root_index];
+        const validation = switch (selected.body) {
+            .pattern_validation => |value| value,
+            .expr, .pattern_extraction => unreachable,
+        };
+        std.debug.assert(validation.scrutinee_pattern == entry.key_ptr.*);
+    }
+
     for (self.selected_hoisted_roots.items, 0..) |root, i| {
         const root_index: u32 = @intCast(i);
         switch (root.body) {
             .expr => std.debug.assert(self.hoist_selected_exprs.get(root.expr) == root_index),
             .pattern_extraction => {},
+            .pattern_validation => |validation| std.debug.assert(self.hoist_selected_pattern_validations.get(validation.scrutinee_pattern) == root_index),
         }
         if (root.pattern) |pattern| {
             std.debug.assert(self.hoist_selected_bindings.get(pattern) == root_index);
@@ -3526,6 +3675,7 @@ fn debugAssertHoistSelectionConsistent(self: *const Self) void {
             switch (root.body) {
                 .expr => {},
                 .pattern_extraction => std.debug.panic("check invariant violated: pattern extraction hoisted root had no binding pattern", .{}),
+                .pattern_validation => {},
             }
         }
     }
@@ -3549,6 +3699,7 @@ const HoistSelectionTestState = struct {
         checker.hoist_contextual_binding_scope_patterns = .empty;
         checker.hoist_selected_bindings = .{};
         checker.hoist_selected_exprs = .{};
+        checker.hoist_selected_pattern_validations = .{};
         checker.hoist_invalidated_exprs = .{};
         checker.selected_hoisted_roots = .empty;
         checker.last_hoist_result = null;
@@ -3574,6 +3725,7 @@ const HoistSelectionTestState = struct {
         self.checker.hoist_contextual_binding_scope_patterns.deinit(self.allocator);
         self.checker.hoist_selected_bindings.deinit(self.allocator);
         self.checker.hoist_selected_exprs.deinit(self.allocator);
+        self.checker.hoist_selected_pattern_validations.deinit(self.allocator);
         self.checker.hoist_invalidated_exprs.deinit(self.allocator);
         for (self.checker.selected_hoisted_roots.items) |*root| {
             hoist_roots.deinitSelectedRoot(self.allocator, root);
@@ -3856,7 +4008,7 @@ test "hoisted pattern extraction root selection is atomic when binding map alloc
     try std.testing.expectEqual(@as(?u32, 0), state.checker.hoist_selected_bindings.get(result_pattern));
     const selected_extraction = switch (state.checker.selected_hoisted_roots.items[0].body) {
         .pattern_extraction => |selected| selected,
-        .expr => return error.ExpectedPatternExtractionRoot,
+        .expr, .pattern_validation => return error.ExpectedPatternExtractionRoot,
     };
     try std.testing.expectEqual(extraction.base_expr, selected_extraction.base_expr);
     try std.testing.expectEqual(extraction.scrutinee_pattern, selected_extraction.scrutinee_pattern);
@@ -7258,6 +7410,7 @@ fn pruneSelectedHoistedRootsAfterSolving(self: *Self) Allocator.Error!void {
     var kept_count: usize = 0;
     var kept_expr_count: u32 = 0;
     var kept_pattern_count: u32 = 0;
+    var kept_validation_count: u32 = 0;
     for (self.selected_hoisted_roots.items, 0..) |*root, i| {
         keep_oracle.current_root_index = i;
         const intrinsic = !self.hoistExprInvalidated(root.expr) and try self.hoistedRootIsIntrinsicallyKept(root);
@@ -7270,14 +7423,36 @@ fn pruneSelectedHoistedRootsAfterSolving(self: *Self) Allocator.Error!void {
         switch (root.body) {
             .expr => kept_expr_count += 1,
             .pattern_extraction => {},
+            .pattern_validation => kept_validation_count += 1,
         }
         if (root.pattern != null) kept_pattern_count += 1;
     }
+
+    // A kept extraction evaluates the same scrutinee and complete source
+    // pattern as its validation root. Let it own that exhaustiveness site so
+    // the right-hand side is not evaluated twice. If the extraction's result
+    // type is not concrete, pruning leaves the unit-valued validation root in
+    // place instead.
+    for (self.selected_hoisted_roots.items, 0..) |root, i| {
+        if (!keep_roots[i]) continue;
+        const extraction = switch (root.body) {
+            .pattern_extraction => |extraction| extraction,
+            .expr, .pattern_validation => continue,
+        };
+        const validation_index = self.hoist_selected_pattern_validations.get(extraction.scrutinee_pattern) orelse continue;
+        if (!keep_roots[validation_index]) continue;
+        keep_roots[validation_index] = false;
+        kept_count -= 1;
+        kept_validation_count -= 1;
+    }
+
     try self.hoist_selected_exprs.ensureTotalCapacity(self.gpa, kept_expr_count);
     try self.hoist_selected_bindings.ensureTotalCapacity(self.gpa, kept_pattern_count);
+    try self.hoist_selected_pattern_validations.ensureTotalCapacity(self.gpa, kept_validation_count);
 
     self.hoist_selected_exprs.clearRetainingCapacity();
     self.hoist_selected_bindings.clearRetainingCapacity();
+    self.hoist_selected_pattern_validations.clearRetainingCapacity();
 
     var kept: usize = 0;
     for (self.selected_hoisted_roots.items, keep_roots, 0..) |*root, keep, i| {
@@ -7294,6 +7469,7 @@ fn pruneSelectedHoistedRootsAfterSolving(self: *Self) Allocator.Error!void {
         switch (self.selected_hoisted_roots.items[kept].body) {
             .expr => self.hoist_selected_exprs.putAssumeCapacityNoClobber(self.selected_hoisted_roots.items[kept].expr, root_index),
             .pattern_extraction => {},
+            .pattern_validation => |validation| self.hoist_selected_pattern_validations.putAssumeCapacityNoClobber(validation.scrutinee_pattern, root_index),
         }
         if (self.selected_hoisted_roots.items[kept].pattern) |pattern| {
             self.hoist_selected_bindings.putAssumeCapacityNoClobber(pattern, root_index);
@@ -7311,6 +7487,11 @@ fn hoistedRootIsIntrinsicallyKept(
     self: *Self,
     root: *hoist_roots.SelectedHoistedRoot,
 ) Allocator.Error!bool {
+    if (root.body == .pattern_validation) {
+        root.value_kind = .data_constant;
+        return true;
+    }
+
     const type_var = if (root.pattern) |pattern|
         ModuleEnv.varFrom(pattern)
     else
@@ -7610,6 +7791,7 @@ const HoistedRootKeepOracle = struct {
                     entry.value_ptr.* = root_index;
                 },
                 .pattern_extraction => {},
+                .pattern_validation => {},
             }
             if (root.pattern) |pattern| {
                 const entry = oracle.pattern_roots.getOrPutAssumeCapacity(pattern);
@@ -11297,7 +11479,7 @@ fn checkDef(self: *Self, def_idx: CIR.Def.Idx, env: *Env) std.mem.Allocator.Erro
 
     if (ptrn_result.isOk()) {
         const def_region = self.cir.store.getNodeRegion(ModuleEnv.nodeIdxFrom(def.pattern));
-        try self.checkDestructureExhaustiveness(def.pattern, def.expr, expr_var, env, def_region);
+        _ = try self.checkDestructureExhaustiveness(def.pattern, def.expr, expr_var, env, def_region);
         if (self.cir.store.getPattern(def.pattern) != .assign) {
             try self.recordHoistPatternExtractionProvenanceHelp(def.pattern, def.expr, def.pattern, .immediate);
         }
@@ -18375,13 +18557,13 @@ fn checkDestructureExhaustiveness(
     value_var: Var,
     env: *Env,
     region: Region,
-) std.mem.Allocator.Error!void {
-    if (!self.patternNeedsExhaustiveness(pattern_idx)) return;
+) std.mem.Allocator.Error!bool {
+    if (!self.patternNeedsExhaustiveness(pattern_idx)) return false;
 
     self.known_empty_payload_vars_destructure.clearRetainingCapacity();
     const value_constructors_known = try self.collectKnownEmptyPayloadVarsForExpr(value_expr_idx, value_var, &self.known_empty_payload_vars_destructure);
 
-    try self.checkPatternExhaustiveness(
+    return try self.checkPatternExhaustiveness(
         pattern_idx,
         value_var,
         self.known_empty_payload_vars_destructure.items,
@@ -18403,8 +18585,8 @@ fn checkPatternExhaustiveness(
     value_constructors_known: bool,
     env: *Env,
     region: Region,
-) std.mem.Allocator.Error!void {
-    if (!self.patternNeedsExhaustiveness(pattern_idx)) return;
+) std.mem.Allocator.Error!bool {
+    if (!self.patternNeedsExhaustiveness(pattern_idx)) return false;
 
     // Same reasoning as the match-expression analysis site: the analysis and
     // its union-closing see sub-patterns through the scrutinee row, so the
@@ -18427,7 +18609,7 @@ fn checkPatternExhaustiveness(
     try self.backfillRegionsForAnalysisVars();
     const result = result_or_err catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
-        error.TypeError => return,
+        error.TypeError => return false,
     };
     defer result.deinit(self.cir.gpa);
 
@@ -18458,7 +18640,9 @@ fn checkPatternExhaustiveness(
             .value_snapshot = value_snapshot,
             .missing_patterns = missing_patterns_range,
         } });
+        return true;
     }
+    return false;
 }
 
 /// Run exhaustiveness analysis on every recorded lambda/function parameter
@@ -18498,7 +18682,7 @@ fn checkPatternExhaustivenessWithoutValue(
 
     const value_var = ModuleEnv.varFrom(pattern_idx);
     const region = self.cir.store.getNodeRegion(ModuleEnv.nodeIdxFrom(pattern_idx));
-    try self.checkPatternExhaustiveness(pattern_idx, value_var, &.{}, false, env, region);
+    _ = try self.checkPatternExhaustiveness(pattern_idx, value_var, &.{}, false, env, region);
 }
 
 // stmts //
@@ -18635,8 +18819,14 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                     try self.unify(decl_pattern_var, decl_expr_var, env);
 
                 if (decl_pattern_result.isOk()) {
-                    try self.checkDestructureExhaustiveness(decl_stmt.pattern, decl_stmt.expr, decl_expr_var, env, stmt_region);
+                    const needs_comptime_validation = try self.checkDestructureExhaustiveness(decl_stmt.pattern, decl_stmt.expr, decl_expr_var, env, stmt_region);
+                    if (needs_comptime_validation) {
+                        try self.selectPendingDestructureValidationRoot(decl_stmt.pattern, decl_stmt.expr, expectation.hoist_position);
+                    }
                     try self.recordHoistPatternProvenance(decl_stmt.pattern, decl_stmt.expr, expectation.hoist_position);
+                    if (needs_comptime_validation) {
+                        _ = try self.selectFirstHoistedPatternExtractionRoot(decl_stmt.pattern);
+                    }
                 }
                 try self.bindTypeSchemeVar(decl_expr_var, decl_pattern_var);
                 if (self.predeclared_local_scheme_vars.get(decl_stmt.pattern)) |predeclared_scheme_var| {
@@ -18716,7 +18906,7 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                 _ = try self.unify(stmt_var, var_expr, env);
 
                 if (var_pattern_result.isOk()) {
-                    try self.checkDestructureExhaustiveness(var_stmt.pattern_idx, var_stmt.expr, var_expr, env, stmt_region);
+                    _ = try self.checkDestructureExhaustiveness(var_stmt.pattern_idx, var_stmt.expr, var_expr, env, stmt_region);
                 }
 
                 // `var` statements are binding roots too (they never
@@ -18780,7 +18970,7 @@ fn checkBlockStatements(self: *Self, statements: CIR.Statement.Span, env: *Env, 
                 _ = try self.unify(stmt_var, reassign_expr_var, env);
 
                 if (reassign_pattern_result.isOk()) {
-                    try self.checkDestructureExhaustiveness(reassign.pattern_idx, reassign.expr, reassign_expr_var, env, stmt_region);
+                    _ = try self.checkDestructureExhaustiveness(reassign.pattern_idx, reassign.expr, reassign_expr_var, env, stmt_region);
                 }
             },
             .s_for => |for_stmt| {

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -4551,7 +4551,7 @@ pub const CheckedTypeStore = struct {
         names: *const canonical.CanonicalNameStore,
     ) Allocator.Error!CheckedTypeId {
         const key = try checkedTypePayloadKeyBuild(allocator, names, self, .empty_record);
-        if (self.rootForKey(key)) |existing| {
+        if (self.rootForKey(key.key)) |existing| {
             if (self.payload(existing) != .empty_record) try self.replaceTypeRootPayload(allocator, existing, .empty_record);
             return existing;
         }
@@ -10408,6 +10408,13 @@ pub const SyntheticExprOrigin = union(enum) {
         selected_root_index: u32,
         scrutinee_pattern: CheckedPatternId,
     },
+    pattern_validation_result: struct {
+        selected_root_index: u32,
+    },
+    pattern_validation_wrapper: struct {
+        selected_root_index: u32,
+        scrutinee_pattern: CheckedPatternId,
+    },
 };
 
 const SyntheticExprOriginRecord = struct {
@@ -15358,7 +15365,8 @@ fn appendSyntheticLocalLookupRefs(
                 });
                 by_checked_expr[raw_expr] = id;
             },
-            .pattern_extraction_wrapper => {
+            .pattern_validation_result => {},
+            .pattern_extraction_wrapper, .pattern_validation_wrapper => {
                 const raw_expr = @intFromEnum(origin_record.expr);
                 if (raw_expr >= checked_bodies.exprCount()) {
                     checkedArtifactInvariant("synthetic wrapper origin referenced an expression out of range", .{});
@@ -23601,7 +23609,7 @@ pub const CompileTimeRootTable = struct {
         names: *canonical.CanonicalNameStore,
         global_value_defs: []const CIR.Def.Idx,
         selected_hoisted_roots: []const hoist_roots.SelectedHoistedRoot,
-        checked_types: *const CheckedTypePublication,
+        checked_types: *CheckedTypePublication,
         checked_body_builder: *CheckedBodyStoreBuilder,
         procedure_templates: *const CheckedProcedureTemplateTable,
     ) Allocator.Error!CompileTimeRootTable {
@@ -23695,9 +23703,10 @@ pub const CompileTimeRootTable = struct {
                 else
                     .callable_binding,
             };
-            const checked_expr = try checkedExprIdForSelectedHoistedRoot(
+            const checked_root = try checkedBodyForSelectedHoistedRoot(
                 allocator,
                 module,
+                names,
                 checked_types,
                 checked_body_builder,
                 @intCast(selected_index),
@@ -23713,9 +23722,9 @@ pub const CompileTimeRootTable = struct {
                 } },
                 .source_pattern = selected.pattern,
                 .hoisted_body = hoisted_body,
-                .pattern = if (selected.pattern) |pattern| checkedPatternIdForSource(checked_bodies, pattern) else null,
-                .expr = checked_expr,
-                .checked_type = try checkedTypeIdForVar(allocator, module, checked_types, source_ty),
+                .pattern = checked_root.pattern,
+                .expr = checked_root.expr,
+                .checked_type = checked_root.checked_type,
                 .payload = .pending,
             });
         }
@@ -24428,6 +24437,16 @@ fn exhaustivenessReplacingRootForSource(
 ) ?CompileTimeRoot {
     for (compile_time_roots.roots) |root| {
         if (!compileTimeRootReplacesSourceOccurrence(root.kind)) continue;
+        switch (source) {
+            .destructure_pattern => |source_pattern| {
+                if (root.hoisted_body) |body| switch (body) {
+                    .pattern_extraction => |extraction| if (extraction.scrutinee_pattern == source_pattern) return root,
+                    .pattern_validation => |validation| if (validation.scrutinee_pattern == source_pattern) return root,
+                    .expr => {},
+                };
+            },
+            .match_expr => {},
+        }
         const contains = switch (source) {
             .match_expr => |source_expr| blk: {
                 const checked_expr = checked_bodies.exprIdForSource(source_expr) orelse break :blk false;
@@ -24821,6 +24840,7 @@ fn syntheticExprCapacityForHoistedRoots(selected_hoisted_roots: []const hoist_ro
         count += switch (root.body) {
             .expr => 0,
             .pattern_extraction => 2,
+            .pattern_validation => 2,
         };
     }
     return count;
@@ -24835,25 +24855,108 @@ fn checkedExprIdForSource(checked_bodies: *const CheckedBodyStore, expr: CIR.Exp
     };
 }
 
-fn checkedExprIdForSelectedHoistedRoot(
+const SelectedHoistedCheckedBody = struct {
+    expr: CheckedExprId,
+    pattern: ?CheckedPatternId,
+    checked_type: CheckedTypeId,
+};
+
+fn checkedBodyForSelectedHoistedRoot(
     allocator: Allocator,
     module: TypedCIR.Module,
-    checked_types: *const CheckedTypePublication,
+    names: *const canonical.CanonicalNameStore,
+    checked_types: *CheckedTypePublication,
     checked_body_builder: *CheckedBodyStoreBuilder,
     selected_index: u32,
     selected: hoist_roots.SelectedHoistedRoot,
-) Allocator.Error!CheckedExprId {
+) Allocator.Error!SelectedHoistedCheckedBody {
     const checked_bodies = checked_body_builder.storePtr();
     return switch (selected.body) {
-        .expr => checkedExprIdForSource(checked_bodies, selected.expr),
-        .pattern_extraction => |extraction| try appendCheckedPatternExtractionRootExpr(
+        .expr => .{
+            .expr = checkedExprIdForSource(checked_bodies, selected.expr),
+            .pattern = if (selected.pattern) |pattern| checkedPatternIdForSource(checked_bodies, pattern) else null,
+            .checked_type = try checkedTypeIdForVar(allocator, module, checked_types, if (selected.pattern) |pattern| ModuleEnv.varFrom(pattern) else module.exprType(selected.expr)),
+        },
+        .pattern_extraction => |extraction| blk: {
+            const checked_type = try checkedTypeIdForVar(allocator, module, checked_types, ModuleEnv.varFrom(extraction.result_pattern));
+            break :blk .{
+                .expr = try appendCheckedPatternExtractionRootExpr(
+                    allocator,
+                    module,
+                    checked_body_builder,
+                    selected_index,
+                    extraction,
+                    checked_type,
+                ),
+                .pattern = checkedPatternIdForSource(checked_bodies, extraction.result_pattern),
+                .checked_type = checked_type,
+            };
+        },
+        .pattern_validation => |validation| try appendCheckedPatternValidationRootBody(
             allocator,
             module,
+            try checked_types.store.ensureEmptyRecordRoot(allocator, names),
             checked_body_builder,
             selected_index,
-            extraction,
-            try checkedTypeIdForVar(allocator, module, checked_types, ModuleEnv.varFrom(extraction.result_pattern)),
+            validation,
         ),
+    };
+}
+
+fn appendCheckedPatternValidationRootBody(
+    allocator: Allocator,
+    module: TypedCIR.Module,
+    checked_type: CheckedTypeId,
+    checked_body_builder: *CheckedBodyStoreBuilder,
+    selected_index: u32,
+    validation: hoist_roots.PatternValidation,
+) Allocator.Error!SelectedHoistedCheckedBody {
+    const checked_bodies = checked_body_builder.storePtr();
+    const scrutinee = checkedExprIdForSource(checked_bodies, validation.base_expr);
+    const checked_source_pattern = checkedPatternIdForSource(checked_bodies, validation.scrutinee_pattern);
+    const pattern_region = module.regionAt(ModuleEnv.nodeIdxFrom(validation.scrutinee_pattern));
+    const result = try checked_body_builder.appendSyntheticExpr(allocator, .{ .pattern_validation_result = .{
+        .selected_root_index = selected_index,
+    } }, checked_type, pattern_region, .empty_record);
+
+    try checked_bodies.match_branch_pattern_pool.ensureUnusedCapacity(allocator, 1);
+    const pattern_start: u32 = @intCast(checked_bodies.match_branch_pattern_pool.items.len);
+    checked_bodies.match_branch_pattern_pool.appendAssumeCapacity(.{
+        .pattern = checked_source_pattern,
+        .degenerate = false,
+        .bn_start = 0,
+        .bn_len = 0,
+    });
+    errdefer _ = checked_bodies.match_branch_pattern_pool.pop();
+
+    const branches = try allocator.alloc(CheckedMatchBranch, 1);
+    var branches_owned = true;
+    errdefer if (branches_owned) allocator.free(branches);
+    branches[0] = .{
+        .pt_start = pattern_start,
+        .pt_len = 1,
+        .value = result,
+        .guard = null,
+    };
+
+    var data: CheckedExprData = .{ .match_ = .{
+        .cond = scrutinee,
+        .branches = branches,
+        .is_try_suffix = false,
+        .skip_exhaustiveness = false,
+        .comptime_site_kind = .destructure,
+    } };
+    branches_owned = false;
+    defer deinitCheckedExprData(allocator, &data);
+
+    const wrapper = try checked_body_builder.appendSyntheticExpr(allocator, .{ .pattern_validation_wrapper = .{
+        .selected_root_index = selected_index,
+        .scrutinee_pattern = checked_source_pattern,
+    } }, checked_type, pattern_region, data);
+    return .{
+        .expr = wrapper,
+        .pattern = null,
+        .checked_type = checked_type,
     };
 }
 
@@ -25209,6 +25312,7 @@ pub const HoistedConstTable = struct {
         allocator: Allocator,
         module: TypedCIR.Module,
         artifact_key: CheckedModuleArtifactKey,
+        checked_types: *CheckedTypeStore,
         roots: *const CompileTimeRootTable,
         const_templates: *ConstTemplateTable,
     ) Allocator.Error!HoistedConstTable {
@@ -25239,7 +25343,15 @@ pub const HoistedConstTable = struct {
                 ModuleEnv.varFrom(pattern)
             else
                 ModuleEnv.varFrom(source_expr);
-            const source_scheme = try canonical_type_keys.schemeFromVar(
+            const source_scheme = if (root.hoisted_body) |body| switch (body) {
+                .pattern_validation => try checked_types.ensureSchemeForRoot(allocator, root.checked_type),
+                .expr, .pattern_extraction => try canonical_type_keys.schemeFromVar(
+                    allocator,
+                    module.typeStoreConst(),
+                    module.moduleEnvConst(),
+                    source_var,
+                ),
+            } else try canonical_type_keys.schemeFromVar(
                 allocator,
                 module.typeStoreConst(),
                 module.moduleEnvConst(),
@@ -28919,7 +29031,8 @@ pub const CheckedModuleArtifact = struct {
     // of publishing a second root for the same checked expression.
     // Version 64 publishes iterator producer identities for `List.iter_rev`,
     // the numeric `to`/`until` ranges, and the F32/F64 range helpers.
-    const serialized_layout_version: u32 = 64;
+    // Version 65 publishes unit-valued destructure-validation hoisted roots.
+    const serialized_layout_version: u32 = 65;
 
     /// Comptime fingerprint of `Serialized`'s layout, mirroring
     /// `cache_module.MODULE_ENV_VERSION_HASH`. It is appended to the baked builtin
@@ -32435,6 +32548,7 @@ pub fn publishFromTypedModule(
         allocator,
         module,
         artifact_key,
+        checked_types,
         &compile_time_roots,
         &const_templates,
     );
@@ -33150,6 +33264,7 @@ fn expectProvidedExportKind(
         allocator,
         module,
         artifact_key,
+        checked_types,
         &compile_time_roots,
         &const_templates,
     );
@@ -35031,8 +35146,8 @@ test "SERIALIZED_VERSION_HASH golden value" {
     // change, bump `serialized_layout_version` and replace the golden bytes below with
     // the ones this assertion prints.
     const golden: [32]u8 = .{
-        0xEB, 0x44, 0x4E, 0x79, 0x79, 0x45, 0x88, 0xD2, 0x12, 0xDE, 0xFE, 0x4E, 0x3A, 0x65, 0x4D, 0xFD,
-        0x2D, 0x96, 0x1C, 0xDE, 0x40, 0x1C, 0x15, 0x9A, 0xCC, 0x90, 0xA1, 0x3C, 0x48, 0x6B, 0x1D, 0x66,
+        0x68, 0x55, 0x02, 0x0B, 0xD2, 0x47, 0xFB, 0xE8, 0x03, 0xFD, 0x4C, 0xF1, 0x1B, 0x47, 0x45, 0x4F,
+        0x97, 0xAC, 0xA0, 0x4A, 0x0F, 0xB9, 0x9B, 0xE6, 0x07, 0x6D, 0x1A, 0xDE, 0x04, 0xDE, 0x6B, 0xD5,
     };
     try std.testing.expectEqualSlices(u8, &golden, &CheckedModuleArtifact.SERIALIZED_VERSION_HASH);
 }

--- a/src/check/hoist_roots.zig
+++ b/src/check/hoist_roots.zig
@@ -7,7 +7,7 @@ const CIR = can.CIR;
 const Allocator = std.mem.Allocator;
 
 /// Version tag for the checked-stage hoisted-root selection algorithm.
-pub const selection_algorithm_version: u64 = 2;
+pub const selection_algorithm_version: u64 = 3;
 
 /// Collection of hoisted roots selected for a checked module.
 pub const SelectedHoistedRootSet = struct {
@@ -21,10 +21,17 @@ pub const PatternExtraction = struct {
     result_pattern: CIR.Pattern.Idx,
 };
 
+/// Body metadata for a unit-valued root that validates a refutable destructure.
+pub const PatternValidation = struct {
+    base_expr: CIR.Expr.Idx,
+    scrutinee_pattern: CIR.Pattern.Idx,
+};
+
 /// Shape of the body used to evaluate a selected hoisted root.
 pub const Body = union(enum) {
     expr,
     pattern_extraction: PatternExtraction,
+    pattern_validation: PatternValidation,
 };
 
 /// The runtime value shape produced by a selected root.
@@ -46,14 +53,14 @@ pub const SelectedHoistedRoot = struct {
     /// Expression that should be evaluated at checking finalization.
     ///
     /// For `.expr` bodies this is the existing source expression. For
-    /// `.pattern_extraction` bodies this is the base expression matched against
-    /// the original source pattern to materialize a binder.
+    /// `.pattern_extraction` and `.pattern_validation` bodies this is the base
+    /// expression matched against the original source pattern.
     expr: CIR.Expr.Idx,
     /// Local binding pattern whose RHS is `expr`, when this root preserves local
     /// binding sharing. Null means the expression itself is the selected root.
     pattern: ?CIR.Pattern.Idx = null,
-    /// The root body shape. Pattern extraction roots are sparse selected-root
-    /// metadata; no per-expression hoistability summary is stored.
+    /// The root body shape. Pattern extraction and validation roots are sparse
+    /// selected-root metadata; no per-expression hoistability summary is stored.
     body: Body = .expr,
     /// Whether finalization archives a data constant or an exact callable.
     value_kind: ValueKind = .data_constant,
@@ -64,6 +71,7 @@ pub fn cloneBody(_: Allocator, body: Body) Allocator.Error!Body {
     return switch (body) {
         .expr => .expr,
         .pattern_extraction => |extraction| .{ .pattern_extraction = extraction },
+        .pattern_validation => |validation| .{ .pattern_validation = validation },
     };
 }
 
@@ -72,6 +80,7 @@ pub fn deinitBody(_: Allocator, body: Body) void {
     switch (body) {
         .expr => {},
         .pattern_extraction => {},
+        .pattern_validation => {},
     }
 }
 

--- a/src/check/problem/store.zig
+++ b/src/check/problem/store.zig
@@ -153,6 +153,24 @@ pub const Store = struct {
         unreachable;
     }
 
+    /// Record that a checker-selected compile-time root will execute this site.
+    /// The pending diagnostic must therefore be decided empirically by that
+    /// root rather than flushed as an unconditionally runtime-reachable error.
+    pub fn markPendingStaticExhaustivenessEmpirical(
+        self: *Self,
+        source: ExhaustivenessSiteSource,
+    ) void {
+        for (self.pending_static_exhaustiveness.items) |*pending| {
+            if (!exhaustivenessSourcesEqual(pending.source, source)) continue;
+            pending.mode = .empirical;
+            return;
+        }
+        if (@import("builtin").mode == .Debug) {
+            std.debug.panic("checked artifact invariant violated: empirical exhaustiveness source had no pending diagnostic", .{});
+        }
+        unreachable;
+    }
+
     pub fn resolvePendingStaticExhaustiveness(self: *Self, site: CheckedExhaustivenessSiteId) void {
         var write: usize = 0;
         for (self.pending_static_exhaustiveness.items) |pending| {

--- a/src/check/test/hoist_roots_test.zig
+++ b/src/check/test/hoist_roots_test.zig
@@ -696,6 +696,57 @@ test "hoist roots selected for tag payload extraction binders" {
     try std.testing.expect(roots[1].pattern != null);
 }
 
+test "refutable closed destructure selects validation root without live binders" {
+    var test_env = try TestEnv.init("Test",
+        \\main = || {
+        \\    Ok(_) = List.get([1], 0)
+        \\    Ok({})
+        \\}
+    );
+    defer test_env.deinit();
+
+    const roots = test_env.checker.selectedHoistedRoots();
+    try std.testing.expectEqual(@as(usize, 1), roots.len);
+    const validation = switch (roots[0].body) {
+        .pattern_validation => |validation| validation,
+        .expr, .pattern_extraction => return error.ExpectedPatternValidationRoot,
+    };
+    try std.testing.expectEqual(roots[0].expr, validation.base_expr);
+    try std.testing.expectEqual(@as(?CIR.Pattern.Idx, null), roots[0].pattern);
+}
+
+test "concrete extraction subsumes refutable destructure validation root" {
+    var test_env = try TestEnv.init("Test",
+        \\main = || {
+        \\    Ok(value) = List.get([1], 0)
+        \\    Ok({})
+        \\}
+    );
+    defer test_env.deinit();
+
+    const roots = test_env.checker.selectedHoistedRoots();
+    try std.testing.expectEqual(@as(usize, 1), roots.len);
+    try expectPatternExtractionRoot(roots[0]);
+}
+
+test "non-concrete extraction retains refutable destructure validation root" {
+    var test_env = try TestEnv.init("Test",
+        \\main = || {
+        \\    Ok(value) = List.get([[]], 0)
+        \\    Ok({})
+        \\}
+    );
+    defer test_env.deinit();
+
+    const roots = test_env.checker.selectedHoistedRoots();
+    try std.testing.expectEqual(@as(usize, 1), roots.len);
+    const validation = switch (roots[0].body) {
+        .pattern_validation => |validation| validation,
+        .expr, .pattern_extraction => return error.ExpectedPatternValidationRoot,
+    };
+    try std.testing.expectEqual(roots[0].expr, validation.base_expr);
+}
+
 test "hoist roots selected for nested tag payload extraction binders" {
     var test_env = try TestEnv.init("Test",
         \\main = |arg| {
@@ -935,7 +986,7 @@ fn expectPatternExtractionRoot(root: hoist_roots.SelectedHoistedRoot) error{ Tes
     try std.testing.expect(root.pattern != null);
     const extraction = switch (root.body) {
         .pattern_extraction => |extraction| extraction,
-        .expr => return error.ExpectedPatternExtractionRoot,
+        .expr, .pattern_validation => return error.ExpectedPatternExtractionRoot,
     };
     try std.testing.expectEqual(root.expr, extraction.base_expr);
     try std.testing.expectEqual(root.pattern.?, extraction.result_pattern);
@@ -964,7 +1015,7 @@ fn countPatternExtractionRoots(roots: []const hoist_roots.SelectedHoistedRoot) u
     for (roots) |root| {
         switch (root.body) {
             .pattern_extraction => count += 1,
-            .expr => {},
+            .expr, .pattern_validation => {},
         }
     }
     return count;

--- a/src/check/test/hoist_roots_test.zig
+++ b/src/check/test/hoist_roots_test.zig
@@ -715,11 +715,29 @@ test "refutable closed destructure selects validation root without live binders"
     try std.testing.expectEqual(@as(?CIR.Pattern.Idx, null), roots[0].pattern);
 }
 
-test "concrete extraction subsumes refutable destructure validation root" {
+test "unused concrete binder retains refutable destructure validation root" {
     var test_env = try TestEnv.init("Test",
         \\main = || {
         \\    Ok(value) = List.get([1], 0)
         \\    Ok({})
+        \\}
+    );
+    defer test_env.deinit();
+
+    const roots = test_env.checker.selectedHoistedRoots();
+    try std.testing.expectEqual(@as(usize, 1), roots.len);
+    const validation = switch (roots[0].body) {
+        .pattern_validation => |validation| validation,
+        .expr, .pattern_extraction => return error.ExpectedPatternValidationRoot,
+    };
+    try std.testing.expectEqual(roots[0].expr, validation.base_expr);
+}
+
+test "live concrete extraction subsumes refutable destructure validation root" {
+    var test_env = try TestEnv.init("Test",
+        \\main = |arg| {
+        \\    Ok(value) = List.get([1.I64], 0)
+        \\    value + arg
         \\}
     );
     defer test_env.deinit();
@@ -731,9 +749,9 @@ test "concrete extraction subsumes refutable destructure validation root" {
 
 test "non-concrete extraction retains refutable destructure validation root" {
     var test_env = try TestEnv.init("Test",
-        \\main = || {
+        \\main = |arg| {
         \\    Ok(value) = List.get([[]], 0)
-        \\    Ok({})
+        \\    List.len(value) + arg
         \\}
     );
     defer test_env.deinit();

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -6346,6 +6346,7 @@ fn hashPatternExtractionRegionsForView(
         const extraction = switch (body) {
             .expr => continue,
             .pattern_extraction => |payload| payload,
+            .pattern_validation => continue,
         };
         count.* += 1;
 

--- a/src/compile/test/hoisted_constants_test.zig
+++ b/src/compile/test/hoisted_constants_test.zig
@@ -139,6 +139,8 @@ test "hoisted local constants are finalized and restored during runtime lowering
         \\    (left, right) = pair
         \\    tuple_total = left + right
         \\    Ok(tag_value) = Ok(45.I64)
+        \\    Ok(_) = List.get([1.I64], 0)
+        \\    Ok(_items) = List.get([[]], 0)
         \\    match_tuple_total = match (50.I64, 8.I64) {
         \\        (match_left, match_right) => match_left + match_right + List.len(args).to_i64_wrap()
         \\    }
@@ -970,7 +972,7 @@ test "inlined hoisted constant crash reports hoisted source region" {
     try std.testing.expect(found);
 }
 
-test "hoisted pattern extraction failure reports original destructure region" {
+test "hoisted pattern extraction and validation failures report original destructure regions" {
     const gpa = std.testing.allocator;
 
     var tmp_dir = std.testing.tmpDir(.{});
@@ -987,6 +989,7 @@ test "hoisted pattern extraction failure reports original destructure region" {
         \\main! = |args| {
         \\    x : Try(I64, Str)
         \\    x = Err("bad")
+        \\    Ok(_) = x
         \\    Ok(foo) = x
         \\    _ = foo + List.len(args).to_i64_wrap()
         \\    Echo.line!("done")
@@ -1053,17 +1056,24 @@ test "hoisted pattern extraction failure reports original destructure region" {
     try coord.coordinatorLoop();
     try std.testing.expect(coord.hasUserErrors());
 
-    var found = false;
+    var found_validation = false;
+    var found_extraction = false;
+    var diagnostic_count: usize = 0;
     var report_iter = coord.iterReports();
     while (report_iter.next()) |entry| {
         if (!std.mem.eql(u8, entry.report.title, "Non Exhaustive Destructure")) continue;
-        found = true;
+        diagnostic_count += 1;
         const region = entry.report.getRegionInfo() orelse return error.NonExhaustiveDestructureReportHadNoRegion;
-        try std.testing.expectEqual(@as(u32, 8), region.start_line_idx);
-        try std.testing.expectEqual(@as(u32, 8), region.end_line_idx);
+        if (region.start_line_idx == 8 and region.end_line_idx == 8) {
+            found_validation = true;
+        } else if (region.start_line_idx == 9 and region.end_line_idx == 9) {
+            found_extraction = true;
+        }
         try std.testing.expectEqualStrings("main", entry.module_name);
     }
-    try std.testing.expect(found);
+    try std.testing.expectEqual(@as(usize, 2), diagnostic_count);
+    try std.testing.expect(found_validation);
+    try std.testing.expect(found_extraction);
 }
 
 test "hoisted pattern extraction base match failure reports match" {
@@ -1607,6 +1617,7 @@ fn expectPatternExtractionSyntheticRegions(
         const extraction = switch (body) {
             .expr => continue,
             .pattern_extraction => |payload| payload,
+            .pattern_validation => continue,
         };
         extraction_count += 1;
 

--- a/test/snapshots/repro_issue_10722_comptime_list_get_destructure.md
+++ b/test/snapshots/repro_issue_10722_comptime_list_get_destructure.md
@@ -1,0 +1,203 @@
+# META
+~~~ini
+description=Compile-time-known List.get and List.first results satisfy refutable destructures inside functions
+type=snippet
+~~~
+# SOURCE
+~~~roc
+get_at_top_level = {
+	Ok(_) = List.get([1], 0)
+	Ok({})
+}
+
+first_at_top_level = {
+	Ok(_) = List.first([1])
+	Ok({})
+}
+
+get_in_function = || {
+	Ok(_) = List.get([1], 0)
+	Ok({})
+}
+
+first_in_function = || {
+	Ok(_) = List.first([1])
+	Ok({})
+}
+~~~
+# EXPECTED
+NIL
+# PROBLEMS
+NIL
+# TOKENS
+~~~zig
+LowerIdent,OpAssign,OpenCurly,
+UpperIdent,NoSpaceOpenRound,Underscore,CloseRound,OpAssign,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpenSquare,Int,CloseSquare,Comma,Int,CloseRound,
+UpperIdent,NoSpaceOpenRound,OpenCurly,CloseCurly,CloseRound,
+CloseCurly,
+LowerIdent,OpAssign,OpenCurly,
+UpperIdent,NoSpaceOpenRound,Underscore,CloseRound,OpAssign,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpenSquare,Int,CloseSquare,CloseRound,
+UpperIdent,NoSpaceOpenRound,OpenCurly,CloseCurly,CloseRound,
+CloseCurly,
+LowerIdent,OpAssign,OpBar,OpBar,OpenCurly,
+UpperIdent,NoSpaceOpenRound,Underscore,CloseRound,OpAssign,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpenSquare,Int,CloseSquare,Comma,Int,CloseRound,
+UpperIdent,NoSpaceOpenRound,OpenCurly,CloseCurly,CloseRound,
+CloseCurly,
+LowerIdent,OpAssign,OpBar,OpBar,OpenCurly,
+UpperIdent,NoSpaceOpenRound,Underscore,CloseRound,OpAssign,UpperIdent,NoSpaceDotLowerIdent,NoSpaceOpenRound,OpenSquare,Int,CloseSquare,CloseRound,
+UpperIdent,NoSpaceOpenRound,OpenCurly,CloseCurly,CloseRound,
+CloseCurly,
+EndOfFile,
+~~~
+# PARSE
+~~~clojure
+(file
+	(type-mod)
+	(statements
+		(s-decl
+			(p-ident (raw "get_at_top_level"))
+			(e-block
+				(statements
+					(s-decl
+						(p-tag (raw "Ok")
+							(p-underscore))
+						(e-apply
+							(e-ident (raw "List.get"))
+							(e-list
+								(e-int (raw "1")))
+							(e-int (raw "0"))))
+					(e-apply
+						(e-tag (raw "Ok"))
+						(e-record)))))
+		(s-decl
+			(p-ident (raw "first_at_top_level"))
+			(e-block
+				(statements
+					(s-decl
+						(p-tag (raw "Ok")
+							(p-underscore))
+						(e-apply
+							(e-ident (raw "List.first"))
+							(e-list
+								(e-int (raw "1")))))
+					(e-apply
+						(e-tag (raw "Ok"))
+						(e-record)))))
+		(s-decl
+			(p-ident (raw "get_in_function"))
+			(e-lambda
+				(args)
+				(e-block
+					(statements
+						(s-decl
+							(p-tag (raw "Ok")
+								(p-underscore))
+							(e-apply
+								(e-ident (raw "List.get"))
+								(e-list
+									(e-int (raw "1")))
+								(e-int (raw "0"))))
+						(e-apply
+							(e-tag (raw "Ok"))
+							(e-record))))))
+		(s-decl
+			(p-ident (raw "first_in_function"))
+			(e-lambda
+				(args)
+				(e-block
+					(statements
+						(s-decl
+							(p-tag (raw "Ok")
+								(p-underscore))
+							(e-apply
+								(e-ident (raw "List.first"))
+								(e-list
+									(e-int (raw "1")))))
+						(e-apply
+							(e-tag (raw "Ok"))
+							(e-record))))))))
+~~~
+# FORMATTED
+~~~roc
+NO CHANGE
+~~~
+# CANONICALIZE
+~~~clojure
+(can-ir
+	(d-let
+		(p-assign (ident "get_at_top_level"))
+		(e-block
+			(s-let
+				(p-applied-tag)
+				(e-call (constraint-fn-var 281)
+					(e-lookup-external
+						(builtin))
+					(e-list
+						(elems
+							(e-num (value "1"))))
+					(e-num (value "0"))))
+			(e-tag (name "Ok")
+				(args
+					(e-empty_record)))))
+	(d-let
+		(p-assign (ident "first_at_top_level"))
+		(e-block
+			(s-let
+				(p-applied-tag)
+				(e-call (constraint-fn-var 308)
+					(e-lookup-external
+						(builtin))
+					(e-list
+						(elems
+							(e-num (value "1"))))))
+			(e-tag (name "Ok")
+				(args
+					(e-empty_record)))))
+	(d-let
+		(p-assign (ident "get_in_function"))
+		(e-lambda
+			(args)
+			(e-block
+				(s-let
+					(p-applied-tag)
+					(e-call (constraint-fn-var 337)
+						(e-lookup-external
+							(builtin))
+						(e-list
+							(elems
+								(e-num (value "1"))))
+						(e-num (value "0"))))
+				(e-tag (name "Ok")
+					(args
+						(e-empty_record))))))
+	(d-let
+		(p-assign (ident "first_in_function"))
+		(e-lambda
+			(args)
+			(e-block
+				(s-let
+					(p-applied-tag)
+					(e-call (constraint-fn-var 359)
+						(e-lookup-external
+							(builtin))
+						(e-list
+							(elems
+								(e-num (value "1"))))))
+				(e-tag (name "Ok")
+					(args
+						(e-empty_record)))))))
+~~~
+# TYPES
+~~~clojure
+(inferred-types
+	(defs
+		(patt (type "[Ok({}), ..]"))
+		(patt (type "[Ok({}), ..]"))
+		(patt (type "({}) -> [Ok({}), ..]"))
+		(patt (type "({}) -> [Ok({}), ..]")))
+	(expressions
+		(expr (type "[Ok({}), ..]"))
+		(expr (type "[Ok({}), ..]"))
+		(expr (type "({}) -> [Ok({}), ..]"))
+		(expr (type "({}) -> [Ok({}), ..]"))))
+~~~


### PR DESCRIPTION
Refutable destructures inside runtime functions now explicitly request compile-time validation when their right-hand sides are top-level-equivalent, even when no binder is live. Validation uses a unit-valued root for open result types and coalesces with a concrete binder extraction so the right-hand side is evaluated only once. This fixes compile-time-known List.get and List.first destructures being reported as non-exhaustive. Fixes #10722.