### PR TITLE
Pin loop params exactly when cloning loop initial values

### DIFF
--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -8549,3 +8549,62 @@ test "issue 10731 mapping over a List-recursive tag union lowers under wrapper i
         \\}
     , &.{ "Wrap(1)", "[Wrap(2)]" });
 }
+
+// Repro for https://github.com/roc-lang/roc/issues/10797: a generic
+// state-threading function whose returned closure builds a `List` with a
+// counted `for` loop, specialized at a call site that supplies a known
+// generator. Cloning that closure body must keep the `var $state` parameter
+// bound in the clone, so the specialized loop's initial values still name a
+// live binding.
+test "issue 10797 SpecConstr keeps the threaded var parameter bound in a specialized loop" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\Generator(value) : U32 -> { value : value, state : U32 }
+        \\
+        \\list : Generator(a), U64 -> Generator(List(a))
+        \\list = |generator, length| {
+        \\    |var $state| {
+        \\        var $result = List.with_capacity(length)
+        \\
+        \\        for _ in 0..<length {
+        \\            { value: item, state: $state } = generator($state)
+        \\            $result = $result.append(item)
+        \\        }
+        \\
+        \\        { value: $result, state: $state }
+        \\    }
+        \\}
+        \\
+        \\step : Generator(U32)
+        \\step = |state| { value: state, state: state + 7 }
+        \\
+        \\main : U64
+        \\main = {
+        \\    { value: values, state: final } = list(step, 3)(1234)
+        \\    values.sum().to_u64() * 10000 + final.to_u64()
+        \\}
+    ;
+
+    var lifted = try liftModuleAfterSpecConstr(allocator, source);
+    defer lifted.deinit(allocator);
+
+    var optimized = try lowerModule(allocator, source, .wrappers);
+    defer optimized.deinit(allocator);
+
+    var runtime_env = eval.RuntimeHostEnv.init(allocator);
+    defer runtime_env.deinit();
+    var interpreter = try eval.Interpreter.init(
+        allocator,
+        &optimized.lowered.lir_result.store,
+        &optimized.lowered.lir_result.layouts,
+        runtime_env.get_ops(),
+        .preserve,
+    );
+    defer interpreter.deinit();
+
+    // 1234 + 1241 + 1248 = 3723, and the threaded state ends at 1255.
+    const result = try interpreter.eval(.{ .proc_id = try rootProc(&optimized.lowered) });
+    switch (result) {
+        .value => |value| try std.testing.expectEqual(@as(u64, 37231255), value.read(u64)),
+    }
+}

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -4334,12 +4334,7 @@ const Subst = struct {
     }
 
     fn put(self: *Subst, program: *Ast.Program, local: Ast.LocalId, value: Value) Allocator.Error!void {
-        const previous = self.exact.get(local);
-        try self.changes.append(self.allocator, .{
-            .key = .{ .local = local },
-            .previous = previous,
-        });
-        try self.exact.put(local, value);
+        try self.putExact(local, value);
 
         const identity = binderIdentityOf(program, local) orelse return;
         try self.putAlias(identity, value);
@@ -4361,6 +4356,22 @@ const Subst = struct {
             .previous = previous_binder,
         });
         try self.binder_subst.put(identity, value);
+    }
+
+    /// Install a substitution for one exact local id without touching its
+    /// binder's maps. A binder-wide entry claims that every version of the
+    /// variable resolves to this value, which holds only where the value is in
+    /// scope. Pinning a binding whose scope is narrower than the position being
+    /// cloned—a loop param, read from the loop's own initial values—must stay
+    /// exact, or a sibling version of the same variable resolves to a binding
+    /// that does not exist at its use site.
+    fn putExact(self: *Subst, local: Ast.LocalId, value: Value) Allocator.Error!void {
+        const previous = self.exact.get(local);
+        try self.changes.append(self.allocator, .{
+            .key = .{ .local = local },
+            .previous = previous,
+        });
+        try self.exact.put(local, value);
     }
 
     fn putAlias(self: *Subst, identity: BinderIdentity, value: Value) Allocator.Error!void {
@@ -7296,8 +7307,16 @@ const Cloner = struct {
         // its initialized-ness at the loop head. The emitted params do not
         // exist yet, so pin those references to the source param ids while
         // cloning; each emission below retargets them to its fresh params.
+        //
+        // The pin is exact, never binder-wide. A loop-carried `var` shares one
+        // binder across its pre-loop version, its param, and its post-loop
+        // version, and the slot's own initial value is that pre-loop version.
+        // Claiming the param binder-wide here would resolve that initial value
+        // to the param, so the loop would seed its slot from the binding it is
+        // about to introduce. The param becomes the binder's value only inside
+        // the loop, which is what `putLoopCarried` installs below.
         const forward_start = self.subst.watermark();
-        for (params) |param| try self.shadowLocal(param.local);
+        for (params) |param| try self.pinSourceLocal(param.local);
         for (initial_values, 0..) |initial, index| {
             values[index] = try self.cloneExprValueDemandingShapeInto(initial, bindings);
             switch (try self.pass.shapeFromValue(values[index])) {
@@ -9489,6 +9508,15 @@ const Cloner = struct {
     fn shadowLocal(self: *Cloner, local: Ast.LocalId) Common.LowerError!void {
         const ty = self.pass.program.getLocal(local).ty;
         try self.subst.put(self.pass.program, local, .{ .expr = try self.addExpr(.{ .ty = ty, .data = .{ .local = local } }) });
+    }
+
+    /// Record an identity substitution for one exact local id, leaving its
+    /// binder's other versions to resolve however they already do. This is the
+    /// pin for a binding whose scope does not cover the position being cloned,
+    /// where `shadowLocal`'s binder-wide claim would be false.
+    fn pinSourceLocal(self: *Cloner, local: Ast.LocalId) Common.LowerError!void {
+        const ty = self.pass.program.getLocal(local).ty;
+        try self.subst.putExact(local, .{ .expr = try self.addExpr(.{ .ty = ty, .data = .{ .local = local } }) });
     }
 
     fn putLocalAlias(self: *Cloner, source: Ast.LocalId, target: Ast.LocalId) Common.LowerError!void {


### PR DESCRIPTION
Fixes #10797. A compiled program that built a `List` by threading state through a counted `for` loop inside a generic function spun forever instead of terminating; in a debug build the same program tripped SpecConstr's `verifyRewrittenBodyLocals` with `references local N (\`var $state\`) bound by no enclosing scope, argument, or capture`. Both are the same defect seen through release and debug.

`Cloner.cloneLoopValue` pins the source loop params before cloning the loop's initial values, so that a forward reference from an initial value to a param (an `uninitialized_payload` condition naming the flag param at the loop head) survives until `retargetLoopForwardConditions` can retarget it to the emitted param. That pin went through `shadowLocal`, which routes to `Subst.put` and therefore also writes a binder-wide alias. A loop-carried `var` shares one binder across its pre-loop version, its loop param, and its post-loop version, and the slot's own initial value *is* that pre-loop version — so claiming the param binder-wide made the initial value resolve to the param itself. The emitted loop seeded its state slot from the binding it was about to introduce, and that dangling local id survived to code generation, where the slot started from an unassigned register.

Capture recomputation did not catch it either: `BoundSet.bindingFor` is binder-aware, so the orphaned local counted as bound because the function's same-binder argument was in scope, and no capture was added to expose the problem.

The pin is now by exact local id. The loop param becomes the binder's value only inside the loop, which is what `Subst.putLoopCarried` already installs, after the initial values have been cloned. `Subst.put` is refactored to build on the new exact-only write so there is a single place that records the exact-local entry.