### PR TITLE
Keep callable-bearing values out of compile-time roots

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -7445,7 +7445,7 @@ fn hoistedRootIsIntrinsicallyKept(
     root.value_kind = .data_constant;
     if (self.cir.store.getExpr(root.expr) == .e_runtime_error) return true;
     if (isFunctionDef(&self.cir.store, self.cir.store.getExpr(root.expr))) return false;
-    return try self.varIsConcreteSelectedRootType(type_var);
+    return try self.varIsConcreteHoistedConstType(type_var);
 }
 
 fn debugVerifyKeptHoistedRootDependencies(self: *Self) Allocator.Error!void {
@@ -7469,12 +7469,7 @@ fn debugVerifyKeptHoistedRootDependencies(self: *Self) Allocator.Error!void {
 
 fn varIsConcreteHoistedConstType(self: *Self, var_: Var) Allocator.Error!bool {
     self.var_set.clearRetainingCapacity();
-    return try self.varIsConcreteHoistedConstTypeInternal(.value_graph, .reject, var_, &self.var_set);
-}
-
-fn varIsConcreteSelectedRootType(self: *Self, var_: Var) Allocator.Error!bool {
-    self.var_set.clearRetainingCapacity();
-    return try self.varIsConcreteHoistedConstTypeInternal(.value_graph, .allow, var_, &self.var_set);
+    return try self.varIsConcreteHoistedConstTypeInternal(.value_graph, var_, &self.var_set);
 }
 
 /// Resolve a nominal application's declaration backing TEMPLATE for read-only
@@ -7508,11 +7503,6 @@ fn nominalDeclBackingTemplate(self: *const Self, nominal: types_mod.NominalType)
 /// checked, so they count as concrete).
 const HoistedConstWalk = enum { value_graph, decl_template };
 
-/// Whether the concreteness walk admits exact callable values. Ordinary
-/// hoisted-const eligibility keeps its historical data-only contract, while
-/// selected compile-time roots can archive callable identities in ConstStore.
-const HoistedCallablePolicy = enum { reject, allow };
-
 /// Copy a record's field value-type variables onto `scratch_record_field_vars`
 /// and return the start mark of the pushed batch. The batch is
 /// `[mark, scratch_record_field_vars.top())`; the caller reads it *by index* and
@@ -7539,7 +7529,6 @@ fn dupeRecordFieldTypeVars(self: *Self, presences: []const types_mod.RecordField
 fn varIsConcreteHoistedConstTypeInternal(
     self: *Self,
     comptime walk: HoistedConstWalk,
-    comptime callables: HoistedCallablePolicy,
     var_: Var,
     visited: *std.AutoHashMap(Var, void),
 ) Allocator.Error!bool {
@@ -7553,21 +7542,20 @@ fn varIsConcreteHoistedConstTypeInternal(
         .field_presence,
         => false,
         .rigid => walk == .decl_template,
-        .alias => |alias| (try self.varsAreConcreteHoistedConstTypes(walk, callables, self.types.sliceAliasArgs(alias), visited)) and
-            try self.varIsConcreteHoistedConstTypeInternal(walk, callables, self.types.getAliasBackingVar(alias), visited),
-        .structure => |flat| try self.flatTypeIsConcreteHoistedConst(walk, callables, flat, visited),
+        .alias => |alias| (try self.varsAreConcreteHoistedConstTypes(walk, self.types.sliceAliasArgs(alias), visited)) and
+            try self.varIsConcreteHoistedConstTypeInternal(walk, self.types.getAliasBackingVar(alias), visited),
+        .structure => |flat| try self.flatTypeIsConcreteHoistedConst(walk, flat, visited),
     };
 }
 
 fn varsAreConcreteHoistedConstTypes(
     self: *Self,
     comptime walk: HoistedConstWalk,
-    comptime callables: HoistedCallablePolicy,
     vars: []const Var,
     visited: *std.AutoHashMap(Var, void),
 ) Allocator.Error!bool {
     for (vars) |var_| {
-        if (!try self.varIsConcreteHoistedConstTypeInternal(walk, callables, var_, visited)) return false;
+        if (!try self.varIsConcreteHoistedConstTypeInternal(walk, var_, visited)) return false;
     }
     return true;
 }
@@ -7575,7 +7563,6 @@ fn varsAreConcreteHoistedConstTypes(
 fn flatTypeIsConcreteHoistedConst(
     self: *Self,
     comptime walk: HoistedConstWalk,
-    comptime callables: HoistedCallablePolicy,
     flat: FlatType,
     visited: *std.AutoHashMap(Var, void),
 ) Allocator.Error!bool {
@@ -7583,35 +7570,38 @@ fn flatTypeIsConcreteHoistedConst(
         .empty_record,
         .empty_tag_union,
         => true,
-        .fn_pure, .fn_effectful, .fn_unbound => |func| callables == .allow and
-            (try self.varsAreConcreteHoistedConstTypes(walk, callables, self.types.sliceVars(func.args), visited)) and
-            try self.varIsConcreteHoistedConstTypeInternal(walk, callables, func.ret, visited),
+        // Archiving a value copies it: the ConstStore holds no allocation
+        // identity, so a callable reached from an archived value is rebuilt
+        // per restore and a source value that reaches two roots becomes two
+        // runtime callables. Platforms read a boxed callable's pointer as the
+        // value's identity, so a value containing one is never archived.
+        .fn_pure, .fn_effectful, .fn_unbound => false,
         .record => |record| blk: {
             const fields = self.types.getRecordFieldsSlice(record.fields);
             for (fields.items(.presence)) |presence| {
                 const field_var = presence.typeVar();
-                if (!try self.varIsConcreteHoistedConstTypeInternal(walk, callables, field_var, visited)) break :blk false;
+                if (!try self.varIsConcreteHoistedConstTypeInternal(walk, field_var, visited)) break :blk false;
             }
-            break :blk try self.varIsConcreteHoistedConstTypeInternal(walk, callables, record.ext, visited);
+            break :blk try self.varIsConcreteHoistedConstTypeInternal(walk, record.ext, visited);
         },
         .record_unbound => |fields| blk: {
             const fields_slice = self.types.getRecordFieldsSlice(fields);
             for (fields_slice.items(.presence)) |presence| {
                 const field_var = presence.typeVar();
-                if (!try self.varIsConcreteHoistedConstTypeInternal(walk, callables, field_var, visited)) break :blk false;
+                if (!try self.varIsConcreteHoistedConstTypeInternal(walk, field_var, visited)) break :blk false;
             }
             break :blk true;
         },
-        .tuple => |tuple| try self.varsAreConcreteHoistedConstTypes(walk, callables, self.types.sliceVars(tuple.elems), visited),
+        .tuple => |tuple| try self.varsAreConcreteHoistedConstTypes(walk, self.types.sliceVars(tuple.elems), visited),
         .tag_union => |tag_union| blk: {
             const tags = self.types.getTagsSlice(tag_union.tags);
             for (tags.items(.args)) |tag_args| {
-                if (!try self.varsAreConcreteHoistedConstTypes(walk, callables, self.types.sliceVars(tag_args), visited)) break :blk false;
+                if (!try self.varsAreConcreteHoistedConstTypes(walk, self.types.sliceVars(tag_args), visited)) break :blk false;
             }
-            break :blk try self.varIsConcreteHoistedConstTypeInternal(walk, callables, tag_union.ext, visited);
+            break :blk try self.varIsConcreteHoistedConstTypeInternal(walk, tag_union.ext, visited);
         },
         .nominal_type => |nominal| blk: {
-            if (!try self.varsAreConcreteHoistedConstTypes(walk, callables, self.types.sliceNominalArgs(nominal), visited)) break :blk false;
+            if (!try self.varsAreConcreteHoistedConstTypes(walk, self.types.sliceNominalArgs(nominal), visited)) break :blk false;
             if (self.builtinNominalDeclForBuiltinSourceDecl(nominal.sourceDeclOptional())) |builtin_decl| {
                 switch (builtin_decl) {
                     .list,
@@ -7632,7 +7622,7 @@ fn flatTypeIsConcreteHoistedConst(
             // backing template. Formals in the template stand for the args
             // checked above, so the template walk admits rigids.
             const template = self.nominalDeclBackingTemplate(nominal) orelse break :blk false;
-            break :blk try self.varIsConcreteHoistedConstTypeInternal(.decl_template, callables, template, visited);
+            break :blk try self.varIsConcreteHoistedConstTypeInternal(.decl_template, template, visited);
         },
     };
 }

--- a/src/cli/test/fx_platform_test.zig
+++ b/src/cli/test/fx_platform_test.zig
@@ -385,12 +385,57 @@ test "fx platform boxed erased callable host boundary (speed backend)" {
     try runIoSpecTest("--opt=speed", fx_test_specs.host_boxed_fn_boundary_test);
 }
 
+/// Repro for https://github.com/roc-lang/roc/issues/10770: one boxed callable
+/// stored in two fields of a provided root's result is one heap allocation, so
+/// the host must receive the same erased-callable pointer for both fields.
+fn expectProvidedBoxedCallableIdentity(opt_flag: []const u8, output_basename: []const u8) FxPlatformTestError!void {
+    const allocator = testing.allocator;
+    const run_result = try runNativeBackendHostSelfTest(
+        allocator,
+        "test/provided-callable-host/app.roc",
+        opt_flag,
+        output_basename,
+        "--run-provided-boxed-callable-identity",
+    );
+    defer allocator.free(run_result.stdout);
+    defer allocator.free(run_result.stderr);
+
+    switch (run_result.term) {
+        .exited => |code| {
+            if (code != 0) {
+                std.debug.print("provided boxed callable identity test exited with code {}\n", .{code});
+                std.debug.print("STDOUT: {s}\n", .{run_result.stdout});
+                std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+                return error.UnexpectedExitCode;
+            }
+        },
+        .signal, .stopped, .unknown => {
+            std.debug.print("provided boxed callable identity test terminated abnormally: {}\n", .{run_result.term});
+            std.debug.print("STDOUT: {s}\n", .{run_result.stdout});
+            std.debug.print("STDERR: {s}\n", .{run_result.stderr});
+            return error.UnexpectedTermination;
+        },
+    }
+
+    try testing.expect(std.mem.find(u8, run_result.stderr, "provided boxed callable identity ok") != null);
+    try testing.expect(std.mem.find(u8, run_result.stderr, "[Roc Memory Info]") == null);
+    try testing.expect(std.mem.find(u8, run_result.stderr, "panic") == null);
+}
+
 test "fx platform provided root drops boxed callable (dev backend)" {
     try expectProvidedBoxedCallableDrop("--opt=dev", "fx_provided_boxed_callable_drop_dev");
 }
 
 test "fx platform provided root drops boxed callable (speed backend)" {
     try expectProvidedBoxedCallableDrop("--opt=speed", "fx_provided_boxed_callable_drop_speed");
+}
+
+test "fx platform provided root preserves boxed callable identity (dev backend)" {
+    try expectProvidedBoxedCallableIdentity("--opt=dev", "fx_provided_boxed_callable_identity_dev");
+}
+
+test "fx platform provided root preserves boxed callable identity (speed backend)" {
+    try expectProvidedBoxedCallableIdentity("--opt=speed", "fx_provided_boxed_callable_identity_speed");
 }
 
 test "fx platform direct run preserves RocOps after F32.abs before list allocation" {

--- a/test/provided-callable-host/app.roc
+++ b/test/provided-callable-host/app.roc
@@ -1,7 +1,37 @@
-app [make_boxed_callable, drop_boxed_callable] { pf: platform "./platform/main.roc" }
+app [
+    make_boxed_callable,
+    drop_boxed_callable,
+    make_aliased_boxed_callables,
+    drop_aliased_boxed_callables,
+] { pf: platform "./platform/main.roc" }
+
+AliasedCallables : { first : Box(U64 -> U64), second : Box(U64 -> U64) }
 
 make_boxed_callable : U64 -> Box(U64 -> U64)
 make_boxed_callable = |offset| Box.box(|value| value + offset)
 
 drop_boxed_callable : Box(U64 -> U64) -> {}
 drop_boxed_callable = |_callable| {}
+
+identity_probe : () -> Box(U64 -> U64)
+identity_probe = || {
+    probe : U64 -> U64
+    probe = |value| value
+
+    Box.box(probe)
+}
+
+# Repro for https://github.com/roc-lang/roc/issues/10770
+#
+# A `Box` is a reference to one heap allocation, so both fields hold the same
+# boxed callable and must reach the host as one pointer. Platforms use that
+# pointer as the value's identity.
+make_aliased_boxed_callables : () -> Box(AliasedCallables)
+make_aliased_boxed_callables = || {
+    boxed = identity_probe()
+
+    Box.box({ first: boxed, second: boxed })
+}
+
+drop_aliased_boxed_callables : Box(AliasedCallables) -> {}
+drop_aliased_boxed_callables = |_callables| {}

--- a/test/provided-callable-host/platform/host.zig
+++ b/test/provided-callable-host/platform/host.zig
@@ -38,6 +38,14 @@ const HostEnv = struct {
 
 extern fn roc_make_boxed_callable(offset: u64) callconv(.c) ?[*]u8;
 extern fn roc_drop_boxed_callable(callable: ?[*]u8) callconv(.c) void;
+extern fn roc_make_aliased_boxed_callables() callconv(.c) ?[*]u8;
+extern fn roc_drop_aliased_boxed_callables(callables: ?[*]u8) callconv(.c) void;
+
+/// Host view of the app's `{ first : Box(U64 -> U64), second : Box(U64 -> U64) }`.
+const AliasedCallables = extern struct {
+    first: ?[*]u8,
+    second: ?[*]u8,
+};
 
 var g_roc_ops: ?*RocOps = null;
 
@@ -57,8 +65,13 @@ comptime {
 fn __main() callconv(.c) void {}
 
 fn main(argc: c_int, argv: [*][*:0]u8) callconv(.c) c_int {
-    if (argc != 2 or !std.mem.eql(u8, std.mem.span(argv[1]), "--run-provided-boxed-callable-drop")) {
-        std.debug.print("usage: <app> --run-provided-boxed-callable-drop\n", .{});
+    const drop_mode = "--run-provided-boxed-callable-drop";
+    const identity_mode = "--run-provided-boxed-callable-identity";
+    const mode = if (argc == 2) std.mem.span(argv[1]) else "";
+    const run_drop = std.mem.eql(u8, mode, drop_mode);
+    const run_identity = std.mem.eql(u8, mode, identity_mode);
+    if (!run_drop and !run_identity) {
+        std.debug.print("usage: <app> {s}|{s}\n", .{ drop_mode, identity_mode });
         return 1;
     }
 
@@ -81,25 +94,52 @@ fn main(argc: c_int, argv: [*][*:0]u8) callconv(.c) c_int {
     };
     g_roc_ops = &roc_ops;
 
-    const callable = roc_make_boxed_callable(41) orelse {
-        std.debug.print("provided callable maker returned null\n", .{});
-        return 1;
-    };
-    if (host_env.alloc_count == 0) {
-        std.debug.print("provided callable maker did not allocate\n", .{});
-        return 1;
+    if (run_drop) {
+        const callable = roc_make_boxed_callable(41) orelse {
+            std.debug.print("provided callable maker returned null\n", .{});
+            return 1;
+        };
+        if (host_env.alloc_count == 0) {
+            std.debug.print("provided callable maker did not allocate\n", .{});
+            return 1;
+        }
+
+        roc_drop_boxed_callable(callable);
+        if (host_env.dealloc_count != host_env.alloc_count) {
+            std.debug.print("provided callable drop released {d} of {d} allocations\n", .{
+                host_env.dealloc_count,
+                host_env.alloc_count,
+            });
+            return 1;
+        }
+
+        std.debug.print("provided boxed callable drop ok\n", .{});
+        return 0;
     }
 
-    roc_drop_boxed_callable(callable);
+    // One boxed callable held by two record fields is one heap allocation, so
+    // both fields must reach the host as the same erased-callable pointer.
+    const aliased_ptr = roc_make_aliased_boxed_callables() orelse {
+        std.debug.print("provided aliased callable maker returned null\n", .{});
+        return 1;
+    };
+    const aliased: *const AliasedCallables = @ptrCast(@alignCast(aliased_ptr));
+    const first = aliased.first;
+    const second = aliased.second;
+    roc_drop_aliased_boxed_callables(aliased_ptr);
+    if (first != second) {
+        std.debug.print("provided aliased callables arrived as {?*} and {?*}\n", .{ first, second });
+        return 1;
+    }
     if (host_env.dealloc_count != host_env.alloc_count) {
-        std.debug.print("provided callable drop released {d} of {d} allocations\n", .{
+        std.debug.print("provided aliased callable drop released {d} of {d} allocations\n", .{
             host_env.dealloc_count,
             host_env.alloc_count,
         });
         return 1;
     }
 
-    std.debug.print("provided boxed callable drop ok\n", .{});
+    std.debug.print("provided boxed callable identity ok\n", .{});
     return 0;
 }
 

--- a/test/provided-callable-host/platform/main.roc
+++ b/test/provided-callable-host/platform/main.roc
@@ -1,13 +1,17 @@
 platform ""
 	requires {
 		make_boxed_callable : U64 -> Box(U64 -> U64),
-		drop_boxed_callable : Box(U64 -> U64) -> {}
+		drop_boxed_callable : Box(U64 -> U64) -> {},
+		make_aliased_boxed_callables : () -> Box({ first : Box(U64 -> U64), second : Box(U64 -> U64) }),
+		drop_aliased_boxed_callables : Box({ first : Box(U64 -> U64), second : Box(U64 -> U64) }) -> {}
 	}
 	exposes []
 	packages {}
 	provides {
 		"roc_make_boxed_callable": make_boxed_callable_for_host,
 		"roc_drop_boxed_callable": drop_boxed_callable_for_host,
+		"roc_make_aliased_boxed_callables": make_aliased_boxed_callables_for_host,
+		"roc_drop_aliased_boxed_callables": drop_aliased_boxed_callables_for_host,
 	}
 	targets: {
 		inputs_dir: "targets/",
@@ -27,3 +31,9 @@ make_boxed_callable_for_host = make_boxed_callable
 
 drop_boxed_callable_for_host : Box(U64 -> U64) -> {}
 drop_boxed_callable_for_host = drop_boxed_callable
+
+make_aliased_boxed_callables_for_host : () -> Box({ first : Box(U64 -> U64), second : Box(U64 -> U64) })
+make_aliased_boxed_callables_for_host = make_aliased_boxed_callables
+
+drop_aliased_boxed_callables_for_host : Box({ first : Box(U64 -> U64), second : Box(U64 -> U64) }) -> {}
+drop_aliased_boxed_callables_for_host = drop_aliased_boxed_callables


### PR DESCRIPTION
Archiving a compile-time root copies its value into the ConstStore, and the ConstStore holds no allocation identity. A callable reached from an archived value is therefore rebuilt at every restore, so one source value that reaches two roots becomes two runtime callables. Platforms read a boxed callable's pointer as that value's identity, so `roc-signals` (issue #10770) built one capability in Roc and received several distinct erased callables at the host, failing its identity checks and trapping during mount.

The concreteness walk that selects compile-time roots admitted callables nested inside a value, on the premise that ConstStore could archive a callable identity. It cannot, so the walk now rejects them and such bindings stay ordinary runtime values with a single allocation. Both callers of the walk now agree, so the `HoistedCallablePolicy` parameter is gone.

`test/provided-callable-host` gains a second provided root that hands the host one boxed callable through two record fields, and its host self-test gains a `--run-provided-boxed-callable-identity` mode asserting both fields arrive as the same pointer with balanced allocations. Before this change that root reached the host as two allocations 0x40 apart.

This does not close #10770 on its own. With the identity corruption gone, the reported app hits a second, independent pre-existing defect: a `where [a.is_eq : a, a -> Bool]` constraint satisfied by compiler-synthesized structural equality (records, tuples, structural tag unions) leaves the phantom parameter of `Capability(a)` unresolved, so the capability's closures specialize at an uninhabited type and lower to a reachable `runtime_error`. `Str`, `Bool`, `U64`, `List(Str)` and user nominals that declare their own `is_eq` all work; `{ path : Str }`, `(Str, Str)` and `[Visible, Hidden]` do not. That is tracked separately from this change.
