### PR TITLE
Expose List.capacity function

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -1905,6 +1905,12 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     const ls = self.layout_store;
                     const list_abi = builtinInternalListAbi(ls, "dev.list_with_capacity.builtin_list_abi", ll.ret_layout);
 
+                    // Zero-width elements need no storage, so a reservation
+                    // allocates nothing and the result stays the empty list.
+                    if (list_abi.elem_size_align.size == 0) {
+                        return self.emitZstList(null);
+                    }
+
                     // Allocate stack space for result (RocList = 24 bytes)
                     const result_offset = self.codegen.allocStackSlot(roc_str_size);
 
@@ -2505,6 +2511,28 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
                     const list_a_off = try self.ensureOnStack(list_a_loc, roc_list_size);
                     const list_b_off = try self.ensureOnStack(list_b_loc, roc_list_size);
+
+                    // Zero-sized elements have no bytes to concatenate, so the
+                    // result carries only the summed length and owns no
+                    // allocation: null data pointer and a stored capacity of zero.
+                    if (list_abi.elem_size_align.size == 0) {
+                        const zst_result_offset = self.codegen.allocStackSlot(roc_str_size);
+                        const zst_len_reg = try self.allocTempGeneral();
+                        const zst_rhs_len_reg = try self.allocTempGeneral();
+                        const zst_zero_reg = try self.allocTempGeneral();
+                        try self.emitLoad(.w64, zst_len_reg, frame_ptr, list_a_off + 8);
+                        try self.emitLoad(.w64, zst_rhs_len_reg, frame_ptr, list_b_off + 8);
+                        try self.emitAddRegs(.w64, zst_len_reg, zst_len_reg, zst_rhs_len_reg);
+                        try self.codegen.emitLoadImm(zst_zero_reg, 0);
+                        try self.emitStore(.w64, frame_ptr, zst_result_offset, zst_zero_reg);
+                        try self.emitStore(.w64, frame_ptr, zst_result_offset + 8, zst_len_reg);
+                        try self.emitStore(.w64, frame_ptr, zst_result_offset + 16, zst_zero_reg);
+                        self.codegen.freeGeneral(zst_zero_reg);
+                        self.codegen.freeGeneral(zst_rhs_len_reg);
+                        self.codegen.freeGeneral(zst_len_reg);
+                        return .{ .list_stack = .{ .struct_offset = zst_result_offset, .data_offset = 0, .num_elements = 0 } };
+                    }
+
                     const result_offset = self.codegen.allocStackSlot(roc_str_size);
                     const elem_incref_reg = if (list_abi.elem_layout_idx) |idx| try self.emitBuiltinInternalOptionalRcHelperAddress(.incref, idx) else null;
                     defer if (elem_incref_reg) |reg| self.codegen.freeGeneral(reg);
@@ -2800,6 +2828,13 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     const list_abi = builtinInternalListAbi(ls, "dev.list_prepend.builtin_list_abi", ll.ret_layout);
 
                     const list_off = try self.ensureOnStack(list_loc, roc_list_size);
+
+                    // A zero-width element has no bytes to place at the front,
+                    // so prepending one only bumps the length.
+                    if (list_abi.elem_size_align.size == 0) {
+                        return self.emitZstListOneLonger(list_off);
+                    }
+
                     const elem_off = try self.ensureOnStack(elem_loc, list_abi.elem_size_align.size);
                     const result_offset = self.codegen.allocStackSlot(roc_str_size);
                     const elem_incref_reg = if (list_abi.elem_layout_idx) |idx| try self.emitBuiltinInternalOptionalRcHelperAddress(.incref, idx) else null;
@@ -4284,6 +4319,13 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     const list_abi = builtinInternalListAbi(ls, "dev.list_swap.builtin_list_abi", ll.ret_layout);
 
                     const list_off = try self.ensureOnStack(list_loc, roc_list_size);
+
+                    // Zero-width elements are indistinguishable, so swapping two
+                    // of them leaves the list exactly as it was.
+                    if (list_abi.elem_size_align.size == 0) {
+                        return self.emitZstListWithSameLen(list_off);
+                    }
+
                     const index_1_off = try self.ensureOnStack(index_1_loc, 8);
                     const index_2_off = try self.ensureOnStack(index_2_loc, 8);
                     const result_offset = self.codegen.allocStackSlot(roc_str_size);
@@ -8377,6 +8419,12 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             self.codegen.freeGeneral(n_reg);
             self.codegen.freeGeneral(len_reg);
 
+            // Zero-width elements have no bytes to slice, so the result is a
+            // length computed from the window alone.
+            if (list_abi.elem_size_align.size == 0) {
+                return self.emitZstSublist(list_off, start_slot, len_slot);
+            }
+
             // Call roc_builtins_list_sublist(out, list_bytes, list_len, list_cap,
             // alignment, element_width, start, len, elements_refcounted, roc_ops)
             const result_offset = self.codegen.allocStackSlot(roc_str_size);
@@ -8462,6 +8510,12 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const list_off = try self.ensureOnStack(list_loc, roc_list_size);
             const record_off = try self.ensureOnStack(record_loc, record_size);
 
+            // Zero-width elements have no bytes to slice, so the result is a
+            // length computed from the window alone.
+            if (list_abi.elem_size_align.size == 0) {
+                return self.emitZstSublist(list_off, record_off + start_field_off, record_off + len_field_off);
+            }
+
             const result_offset = self.codegen.allocStackSlot(roc_str_size);
             if (op == .list_sublist_borrowed) {
                 var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
@@ -8522,6 +8576,13 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
 
             const list_off = try self.ensureOnStack(list_loc, roc_list_size);
             const index_off = try self.ensureOnStack(index_loc, 8);
+
+            // Zero-width elements have no bytes to move, so dropping one only
+            // shortens the length, and only when the index is in bounds.
+            if (list_abi.elem_size_align.size == 0) {
+                return self.emitZstDropAt(list_off, index_off);
+            }
+
             const result_offset = self.codegen.allocStackSlot(roc_str_size);
             if (try self.boxyListElementDescForLocals(list_abi, &.{list_local}, ll.target)) |boxy_elem| {
                 var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
@@ -8911,6 +8972,13 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const list_abi = builtinInternalListAbi(ls, "dev.callListReserveOp.builtin_list_abi", ll.ret_layout);
 
             const list_off = try self.ensureOnStack(list_loc, roc_list_size);
+
+            // Zero-width elements need no storage, so there is nothing to
+            // reserve and the list passes through unchanged.
+            if (list_abi.elem_size_align.size == 0) {
+                return self.emitZstListWithSameLen(list_off);
+            }
+
             const spare_off = try self.ensureOnStack(spare_loc, 8);
             const result_offset = self.codegen.allocStackSlot(roc_str_size);
             if (try self.boxyListElementDescForLocals(list_abi, &.{list_local}, ll.target)) |boxy_elem| {
@@ -8961,6 +9029,13 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const list_abi = builtinInternalListAbi(ls, "dev.callListReleaseExcessCapOp.builtin_list_abi", ll.ret_layout);
 
             const list_off = try self.ensureOnStack(list_loc, roc_list_size);
+
+            // A zero-width list holds no allocation, so it has no excess to
+            // release and passes through unchanged.
+            if (list_abi.elem_size_align.size == 0) {
+                return self.emitZstListWithSameLen(list_off);
+            }
+
             const result_offset = self.codegen.allocStackSlot(roc_str_size);
             if (try self.boxyListElementDescForLocals(list_abi, &.{list_local}, ll.target)) |boxy_elem| {
                 var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
@@ -15804,17 +15879,26 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const elem_size: u32 = list_abi.elem_size_align.size;
             const num_elems: u32 = @intCast(elems.len);
             const total_data_bytes: usize = @as(usize, elem_size) * @as(usize, num_elems);
-            const roc_ops_reg = self.roc_ops_reg orelse unreachable;
             const heap_ptr_slot: i32 = self.codegen.allocStackSlot(8);
 
-            var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
-            try builder.addImmArg(@intCast(total_data_bytes));
-            try builder.addImmArg(@intCast(list_abi.alignment_bytes));
-            try builder.addImmArg(if (list_abi.elements_refcounted) 1 else 0);
-            try builder.addRegArg(roc_ops_reg);
-            try self.callBuiltinWithAdapter(&builder, @intFromPtr(&allocateWithRefcountC), .allocate_with_refcount);
+            if (elem_size == 0) {
+                // Zero-sized elements occupy no storage, so the list owns no
+                // allocation and its data pointer stays null.
+                const null_reg = try self.allocTempGeneral();
+                try self.codegen.emitLoadImm(null_reg, 0);
+                try self.emitStore(.w64, frame_ptr, heap_ptr_slot, null_reg);
+                self.codegen.freeGeneral(null_reg);
+            } else {
+                const roc_ops_reg = self.roc_ops_reg orelse unreachable;
+                var builder = try Builder.init(&self.codegen.emit, &self.codegen.stack_offset);
+                try builder.addImmArg(@intCast(total_data_bytes));
+                try builder.addImmArg(@intCast(list_abi.alignment_bytes));
+                try builder.addImmArg(if (list_abi.elements_refcounted) 1 else 0);
+                try builder.addRegArg(roc_ops_reg);
+                try self.callBuiltinWithAdapter(&builder, @intFromPtr(&allocateWithRefcountC), .allocate_with_refcount);
 
-            try self.emitStore(.w64, frame_ptr, heap_ptr_slot, ret_reg_0);
+                try self.emitStore(.w64, frame_ptr, heap_ptr_slot, ret_reg_0);
+            }
 
             for (0..elems.len) |i| {
                 const elem_id = GuardedList.at(elems, i);
@@ -15843,9 +15927,13 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             const len_reg = try self.allocTempGeneral();
             const cap_reg = try self.allocTempGeneral();
 
+            // A list of zero-sized elements holds no allocation, so its stored
+            // capacity is zero however many elements it carries.
+            const encoded_capacity: u64 = if (elem_size == 0) 0 else @as(u64, num_elems) << 1;
+
             try self.emitLoad(.w64, ptr_reg, frame_ptr, heap_ptr_slot);
             try self.codegen.emitLoadImm(len_reg, @intCast(num_elems));
-            try self.codegen.emitLoadImm(cap_reg, @intCast(@as(u64, num_elems) << 1));
+            try self.codegen.emitLoadImm(cap_reg, @intCast(encoded_capacity));
 
             try self.emitStore(.w64, frame_ptr, list_struct_offset, ptr_reg);
             try self.emitStore(.w64, frame_ptr, list_struct_offset + 8, len_reg);
@@ -18037,6 +18125,88 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
         /// Allocate a short-lived general register used only during instruction selection.
         /// Semantic values are materialized to `local_locations`; exhausting this pool
         /// therefore indicates an internal lifetime bug rather than source-level pressure.
+        /// Emit the canonical value for a list of zero-width elements: such a
+        /// list owns no allocation, so its data pointer is null and its stored
+        /// capacity is zero, and it carries nothing but a length. `len_reg` is
+        /// null for a length of zero.
+        fn emitZstList(self: *Self, len_reg: ?GeneralReg) Allocator.Error!ValueLocation {
+            const slot = self.codegen.allocStackSlot(roc_str_size);
+            const zero_reg = try self.allocTempGeneral();
+            try self.codegen.emitLoadImm(zero_reg, 0);
+            try self.emitStore(.w64, frame_ptr, slot, zero_reg);
+            try self.emitStore(.w64, frame_ptr, slot + 8, len_reg orelse zero_reg);
+            try self.emitStore(.w64, frame_ptr, slot + 16, zero_reg);
+            self.codegen.freeGeneral(zero_reg);
+            return .{ .list_stack = .{ .struct_offset = slot, .data_offset = 0, .num_elements = 0 } };
+        }
+
+        /// Emit the canonical zero-width list one element longer than the list
+        /// value at `list_off`.
+        fn emitZstListOneLonger(self: *Self, list_off: i32) Allocator.Error!ValueLocation {
+            const len_reg = try self.allocTempGeneral();
+            try self.emitLoad(.w64, len_reg, frame_ptr, list_off + 8);
+            try self.emitAddImm(len_reg, len_reg, 1);
+            const result = try self.emitZstList(len_reg);
+            self.codegen.freeGeneral(len_reg);
+            return result;
+        }
+
+        /// Emit the zero-width result of a sublist-shaped op. The surviving
+        /// length is `min(len, size -| start)`, built from saturating
+        /// subtraction alone because `min(x, y)` is `y -| (y -| x)`.
+        fn emitZstSublist(self: *Self, list_off: i32, start_at: i32, len_at: i32) Allocator.Error!ValueLocation {
+            const avail_reg = try self.allocTempGeneral();
+            const start_reg = try self.allocTempGeneral();
+            const want_reg = try self.allocTempGeneral();
+            const tmp_reg = try self.allocTempGeneral();
+            try self.emitLoad(.w64, avail_reg, frame_ptr, list_off + 8);
+            try self.emitLoad(.w64, start_reg, frame_ptr, start_at);
+            try self.emitLoad(.w64, want_reg, frame_ptr, len_at);
+            try self.emitSaturatingSub(avail_reg, avail_reg, start_reg);
+            try self.emitSaturatingSub(tmp_reg, avail_reg, want_reg);
+            try self.emitSaturatingSub(avail_reg, avail_reg, tmp_reg);
+            self.codegen.freeGeneral(tmp_reg);
+            self.codegen.freeGeneral(want_reg);
+            self.codegen.freeGeneral(start_reg);
+            const result = try self.emitZstList(avail_reg);
+            self.codegen.freeGeneral(avail_reg);
+            return result;
+        }
+
+        /// Emit the zero-width result of dropping the element at `index_at`:
+        /// one shorter when the index is in bounds, unchanged when it is not.
+        fn emitZstDropAt(self: *Self, list_off: i32, index_at: i32) Allocator.Error!ValueLocation {
+            const size_reg = try self.allocTempGeneral();
+            const index_reg = try self.allocTempGeneral();
+            const one_reg = try self.allocTempGeneral();
+            const flag_reg = try self.allocTempGeneral();
+            try self.emitLoad(.w64, size_reg, frame_ptr, list_off + 8);
+            try self.emitLoad(.w64, index_reg, frame_ptr, index_at);
+            try self.codegen.emitLoadImm(one_reg, 1);
+            // flag = min(size -| index, 1): one when the index is in bounds.
+            // Each destination stays distinct from the subtrahend, because
+            // emitSaturatingSub computes into its destination in place.
+            try self.emitSaturatingSub(flag_reg, size_reg, index_reg);
+            try self.emitSaturatingSub(index_reg, one_reg, flag_reg);
+            try self.emitSaturatingSub(flag_reg, one_reg, index_reg);
+            try self.emitSaturatingSub(size_reg, size_reg, flag_reg);
+            self.codegen.freeGeneral(flag_reg);
+            self.codegen.freeGeneral(one_reg);
+            self.codegen.freeGeneral(index_reg);
+            const result = try self.emitZstList(size_reg);
+            self.codegen.freeGeneral(size_reg);
+            return result;
+        }
+
+        /// Emit the canonical zero-width list carrying the length held in the
+        /// list value at `list_off`, unchanged.
+        fn emitZstListWithSameLen(self: *Self, list_off: i32) Allocator.Error!ValueLocation {
+            const len_reg = try self.allocTempGeneral();
+            defer self.codegen.freeGeneral(len_reg);
+            try self.emitLoad(.w64, len_reg, frame_ptr, list_off + 8);
+            return self.emitZstList(len_reg);
+        }
+
         fn allocTempGeneral(self: *Self) Allocator.Error!GeneralReg {
             return self.codegen.allocGeneral() orelse std.debug.panic(
                 "LirCodeGen invariant violated: bounded instruction selection exhausted the general-register pool",

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -9669,10 +9669,29 @@ pub const MonoLlvmCodeGen = struct {
         try self.callBuiltinOut(builtinSymbol(LowLevelBuiltins.listOp(.list_append_sublist)), call_args.types.items, call_args.values.items);
     }
 
+    /// Store the canonical value for a list of zero-width elements into
+    /// `target`: such a list owns no allocation, so its data pointer is null
+    /// and its stored capacity is zero, and it carries nothing but `len`.
+    fn storeZstList(self: *MonoLlvmCodeGen, target: LocalId, len: LlvmBuilder.Value) Error!void {
+        const builder = self.builder orelse return error.CompilationFailed;
+        const out_ptr = self.slot(target).ptr;
+        try self.storePointer(out_ptr, builder.nullValue(try self.ptrType()) catch return error.OutOfMemory);
+        try self.storeListLen(out_ptr, len);
+        try self.storeListCapacity(out_ptr, builder.intValue(self.ptrSizedIntType(), 0) catch return error.OutOfMemory);
+    }
+
     fn emitListPrepend(self: *MonoLlvmCodeGen, target: LocalId, args: anytype, unique_args: u64) Error!void {
         const builder = self.builder orelse return error.CompilationFailed;
         const list_local = GuardedList.at(args, 0);
         const abi = self.boxyAwareBuiltinListAbi(self.localLayout(list_local));
+        // A zero-width element has no bytes to place at the front, so
+        // prepending one only bumps the length.
+        if (abi.elem_size == 0) {
+            const len = try self.loadUsize(try self.offsetPtr(self.slot(list_local).ptr, self.rocListLenOffset()));
+            const one = builder.intValue(self.ptrSizedIntType(), 1) catch return error.OutOfMemory;
+            const grown = (self.wip orelse return error.CompilationFailed).bin(.add, len, one, "") catch return error.OutOfMemory;
+            return self.storeZstList(target, grown);
+        }
         var call_args = try self.rocListArgs1(list_local);
         defer call_args.deinit(self.allocator);
         try call_args.prepend(self.allocator, try self.ptrType(), self.slot(target).ptr);
@@ -9721,6 +9740,19 @@ pub const MonoLlvmCodeGen = struct {
             try self.loadSublistStartLen(GuardedList.at(args, 1))
         else
             return error.UnsupportedLowLevel;
+
+        // Zero-width elements have no bytes to slice, so the result is the
+        // window length alone: min(len, size -| start).
+        if (abi.elem_size == 0) {
+            const wip = self.wip orelse return error.CompilationFailed;
+            const past_end = wip.icmp(.uge, slice.start, len, "") catch return error.OutOfMemory;
+            const remaining = wip.bin(.sub, len, slice.start, "") catch return error.OutOfMemory;
+            const avail = wip.select(.normal, past_end, zero, remaining, "") catch return error.OutOfMemory;
+            const wants_more = wip.icmp(.ugt, slice.len, avail, "") catch return error.OutOfMemory;
+            const kept = wip.select(.normal, wants_more, avail, slice.len, "") catch return error.OutOfMemory;
+            return self.storeZstList(target, kept);
+        }
+
         var call_args = try self.rocListArgs1(GuardedList.at(args, 0));
         defer call_args.deinit(self.allocator);
         try call_args.prepend(self.allocator, try self.ptrType(), self.slot(target).ptr);
@@ -9796,6 +9828,18 @@ pub const MonoLlvmCodeGen = struct {
         const builder = self.builder orelse return error.CompilationFailed;
         const list_local = GuardedList.at(args, 0);
         const abi = self.boxyAwareBuiltinListAbi(self.localLayout(list_local));
+        // Zero-width elements have no bytes to move, so dropping one only
+        // shortens the length, and only when the index is in bounds.
+        if (abi.elem_size == 0) {
+            const wip = self.wip orelse return error.CompilationFailed;
+            const len = try self.loadUsize(try self.offsetPtr(self.slot(list_local).ptr, self.rocListLenOffset()));
+            const index = try self.loadIntegerLocalAsUsize(GuardedList.at(args, 1));
+            const one = builder.intValue(self.ptrSizedIntType(), 1) catch return error.OutOfMemory;
+            const out_of_bounds = wip.icmp(.uge, index, len, "") catch return error.OutOfMemory;
+            const shortened = wip.bin(.sub, len, one, "") catch return error.OutOfMemory;
+            const kept = wip.select(.normal, out_of_bounds, len, shortened, "") catch return error.OutOfMemory;
+            return self.storeZstList(target, kept);
+        }
         var call_args = try self.rocListArgs1(list_local);
         defer call_args.deinit(self.allocator);
         try call_args.prepend(self.allocator, try self.ptrType(), self.slot(target).ptr);
@@ -10063,6 +10107,12 @@ pub const MonoLlvmCodeGen = struct {
         const builder = self.builder orelse return error.CompilationFailed;
         const list_local = GuardedList.at(args, 0);
         const abi = self.boxyAwareBuiltinListAbi(self.localLayout(list_local));
+        // A zero-width list holds no allocation, so it has no excess to release
+        // and passes through unchanged.
+        if (abi.elem_size == 0) {
+            const len = try self.loadUsize(try self.offsetPtr(self.slot(list_local).ptr, self.rocListLenOffset()));
+            return self.storeZstList(target, len);
+        }
         var call_args = try self.rocListArgs1(list_local);
         defer call_args.deinit(self.allocator);
         try call_args.prepend(self.allocator, try self.ptrType(), self.slot(target).ptr);

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -10137,6 +10137,7 @@ fn generateCFStmtNode(self: *Self, work: *std.ArrayList(StmtWork), wa: Allocator
         .assign_list => |assign| {
             try self.generateList(.{
                 .elems = assign.elems,
+                .list_layout = self.procLocalLayoutIdx(assign.target),
                 .elem_layout = self.listElemLayout(self.procLocalLayoutIdx(assign.target)),
             });
             try self.bindAssignedLocal(assign.target);
@@ -12159,6 +12160,60 @@ fn generateStoreAggregateValue(self: *Self, dest: ProcLocalId, value_layout: lay
 /// Generate a discriminant switch expression.
 /// Evaluates the tag union value, loads its discriminant, and generates
 /// cascading if/else branches indexed by discriminant value.
+/// Emit the canonical value for a list of zero-width elements: such a list owns
+/// no allocation, so its data pointer is null and its stored capacity is zero,
+/// and it carries nothing but the length held in `len_local`. Leaves a pointer
+/// to the list value on the operand stack.
+fn emitZstListWithLen(self: *Self, len_local: u32) Allocator.Error!void {
+    const offset = try self.allocStackMemory(12, 4);
+    const list_base = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitFpOffset(offset);
+    try self.emitLocalSet(list_base);
+    try self.emitZeroInit(list_base, 12);
+    try self.emitLocalGet(len_local);
+    try self.emitStoreToMem(list_base, 4, .i32);
+    try self.emitLocalGet(list_base);
+}
+
+/// Emit the canonical zero-width list carrying the length currently on the
+/// operand stack.
+fn emitZstListFromStackLen(self: *Self) Allocator.Error!void {
+    const len_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitLocalSet(len_local);
+    try self.emitZstListWithLen(len_local);
+}
+
+/// Read the length out of the list value pointed to by `list_local`.
+fn emitListLenLocal(self: *Self, list_local: u32) Allocator.Error!u32 {
+    const len_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+    try self.emitLocalGet(list_local);
+    try self.emitLoadOp(.i32, 4);
+    try self.emitLocalSet(len_local);
+    return len_local;
+}
+
+/// Push `a -| b` for the unsigned i32 locals `a` and `b`.
+fn emitU32SaturatingSub(self: *Self, a: u32, b: u32) Allocator.Error!void {
+    try self.emitLocalGet(a);
+    try self.emitLocalGet(b);
+    self.currentCode().append(self.allocator, Op.i32_sub) catch return error.OutOfMemory;
+    try self.emitI32Const(0);
+    try self.emitLocalGet(a);
+    try self.emitLocalGet(b);
+    self.currentCode().append(self.allocator, Op.i32_ge_u) catch return error.OutOfMemory;
+    self.currentCode().append(self.allocator, Op.select) catch return error.OutOfMemory;
+}
+
+/// Push `@min(a, b)` for the unsigned i32 locals `a` and `b`.
+fn emitU32Min(self: *Self, a: u32, b: u32) Allocator.Error!void {
+    try self.emitLocalGet(a);
+    try self.emitLocalGet(b);
+    try self.emitLocalGet(a);
+    try self.emitLocalGet(b);
+    self.currentCode().append(self.allocator, Op.i32_lt_u) catch return error.OutOfMemory;
+    self.currentCode().append(self.allocator, Op.select) catch return error.OutOfMemory;
+}
+
 fn generateList(self: *Self, l: anytype) Allocator.Error!void {
     const ls = self.getLayoutStore();
     const elems = self.store.getLocalSpan(l.elems);
@@ -12176,9 +12231,12 @@ fn generateList(self: *Self, l: anytype) Allocator.Error!void {
         return;
     }
 
-    // Get element layout and size
-    const elem_size: u32 = try self.layoutStorageByteSize(l.elem_layout);
-    const elem_align: u32 = try self.layoutStorageByteAlign(l.elem_layout);
+    // Get element layout and size. `listElemLayout` hands back the list layout
+    // itself for a list of zero-sized elements, so read the element width from
+    // the list layout's tag instead of measuring that stand-in layout.
+    const elems_are_zero_sized = ls.getLayout(l.list_layout).tag == .list_of_zst;
+    const elem_size: u32 = if (elems_are_zero_sized) 0 else try self.layoutStorageByteSize(l.elem_layout);
+    const elem_align: u32 = if (elems_are_zero_sized) 1 else try self.layoutStorageByteAlign(l.elem_layout);
 
     // Allocate space for all elements on the heap so list literals remain valid
     // when returned from functions (callee stack frames are reclaimed on return).
@@ -12237,9 +12295,11 @@ fn generateList(self: *Self, l: anytype) Allocator.Error!void {
     WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(elems.len)) catch return error.OutOfMemory;
     try self.emitStoreToMem(list_base, 4, .i32);
 
-    // Store encoded capacity (offset 8).
+    // Store encoded capacity (offset 8). A list of zero-sized elements holds no
+    // allocation, so its stored capacity is zero however many elements it carries.
+    const encoded_capacity: u32 = if (elem_size == 0) 0 else @as(u32, @intCast(elems.len)) << 1;
     self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(elems.len << 1)) catch return error.OutOfMemory;
+    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(encoded_capacity)) catch return error.OutOfMemory;
     try self.emitStoreToMem(list_base, 8, .i32);
 
     // Push pointer to the RocList struct
@@ -13185,6 +13245,15 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             const list_abi = self.builtinInternalListAbi("wasm.list_drop_first.builtin_list_abi", ll.ret_layout);
             const elem_size = list_abi.elem_size;
 
+            // Zero-width elements have no bytes to skip past, so dropping a
+            // prefix only shortens the length of an unallocated list.
+            if (elem_size == 0) {
+                const len_local = try self.emitListLenLocal(list_local);
+                try self.emitU32SaturatingSub(len_local, count_local);
+                try self.emitZstListFromStackLen();
+                return;
+            }
+
             // new_ptr = old_ptr + count * elem_size
             self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
             WasmModule.leb128WriteU32(self.allocator, self.currentCode(), result_local) catch return error.OutOfMemory;
@@ -13240,6 +13309,18 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             self.currentCode().append(self.allocator, Op.local_set) catch return error.OutOfMemory;
             WasmModule.leb128WriteU32(self.allocator, self.currentCode(), count_local) catch return error.OutOfMemory;
 
+            // Zero-width elements have no bytes to drop, so removing a suffix
+            // only shortens the length of an unallocated list.
+            {
+                const drop_abi = self.builtinInternalListAbi("wasm.list_drop_last.builtin_list_abi", ll.ret_layout);
+                if (drop_abi.elem_size == 0) {
+                    const len_local = try self.emitListLenLocal(list_local);
+                    try self.emitU32SaturatingSub(len_local, count_local);
+                    try self.emitZstListFromStackLen();
+                    return;
+                }
+            }
+
             // Allocate result RocList (12 bytes)
             const result_offset = try self.allocStackMemory(12, 4);
             const result_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
@@ -13293,6 +13374,18 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             const count_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
             self.currentCode().append(self.allocator, Op.local_set) catch return error.OutOfMemory;
             WasmModule.leb128WriteU32(self.allocator, self.currentCode(), count_local) catch return error.OutOfMemory;
+
+            // Zero-width elements have no bytes to keep, so taking a prefix
+            // only shortens the length of an unallocated list.
+            {
+                const take_abi = self.builtinInternalListAbi("wasm.list_take_first.builtin_list_abi", ll.ret_layout);
+                if (take_abi.elem_size == 0) {
+                    const len_local = try self.emitListLenLocal(list_local);
+                    try self.emitU32Min(count_local, len_local);
+                    try self.emitZstListFromStackLen();
+                    return;
+                }
+            }
 
             const result_offset = try self.allocStackMemory(12, 4);
             const result_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
@@ -13385,6 +13478,14 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
 
             const list_abi = self.builtinInternalListAbi("wasm.list_take_last.builtin_list_abi", ll.ret_layout);
             const elem_size = list_abi.elem_size;
+
+            // Zero-width elements have no bytes to keep, so taking a suffix
+            // only shortens the length of an unallocated list.
+            if (elem_size == 0) {
+                try self.emitU32Min(count_local, len_local);
+                try self.emitZstListFromStackLen();
+                return;
+            }
 
             // new_ptr = old_ptr + (len - actual_count) * elem_size
             self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
@@ -13551,6 +13652,29 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             WasmModule.leb128WriteU32(self.allocator, self.currentCode(), rec_local) catch return error.OutOfMemory;
 
             const boxy_list_abi = self.builtinInternalListAbi("wasm.list_sublist.boxy_list_abi", ll.ret_layout);
+
+            // Zero-width elements have no bytes to slice, so the result is the
+            // window length alone: min(len, size -| start).
+            if (boxy_list_abi.elem_size == 0) {
+                const size_local = try self.emitListLenLocal(list_local);
+                const start_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                try self.emitLocalGet(rec_local);
+                try self.emitLoadOp(.i64, start_field_off);
+                self.currentCode().append(self.allocator, Op.i32_wrap_i64) catch return error.OutOfMemory;
+                try self.emitLocalSet(start_local);
+                const want_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                try self.emitLocalGet(rec_local);
+                try self.emitLoadOp(.i64, len_field_off);
+                self.currentCode().append(self.allocator, Op.i32_wrap_i64) catch return error.OutOfMemory;
+                try self.emitLocalSet(want_local);
+                const avail_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                try self.emitU32SaturatingSub(size_local, start_local);
+                try self.emitLocalSet(avail_local);
+                try self.emitU32Min(want_local, avail_local);
+                try self.emitZstListFromStackLen();
+                return;
+            }
+
             const boxy_elem = if (self.external_calls == .builtin_relocs)
                 self.boxyListElementDescForLocals(boxy_list_abi, &.{GuardedList.at(args, 0)}, ll.target)
             else
@@ -20229,6 +20353,18 @@ fn generateLLListPrepend(self: *Self, args: anytype, ret_layout: layout.Idx, tar
     try self.emitProcLocal(GuardedList.at(args, 0));
     const list_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
     try self.emitLocalSet(list_ptr);
+
+    // A zero-width element has no bytes to place at the front, so prepending
+    // one only bumps the length.
+    if (elem_size == 0) {
+        const len_local = try self.emitListLenLocal(list_ptr);
+        try self.emitLocalGet(len_local);
+        try self.emitI32Const(1);
+        self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+        try self.emitZstListFromStackLen();
+        return;
+    }
+
     const list_local = GuardedList.at(args, 0);
     if (self.external_calls == .builtin_relocs) {
         if (self.boxyListElementDescForLocals(list_abi, &.{list_local}, target)) |boxy_elem| {
@@ -20695,7 +20831,9 @@ fn generateLLListConcat(self: *Self, args: anytype, ret_layout: layout.Idx, targ
         WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
         try self.emitLocalSet(zero);
 
-        try self.buildRocListWithCap(zero, new_len, new_len);
+        // Zero-width elements own no allocation, so the joined list carries a
+        // length and a stored capacity of zero.
+        try self.buildRocListWithCap(zero, new_len, zero);
         return;
     }
 
@@ -20766,6 +20904,30 @@ fn generateLLListDropAt(self: *Self, args: anytype, ret_layout: layout.Idx, targ
     try self.emitConversion(try self.procLocalValType(GuardedList.at(args, 1)), .i64);
     const index_local = self.storage.allocAnonymousLocal(.i64) catch return error.OutOfMemory;
     try self.emitLocalSet(index_local);
+
+    // Zero-width elements have no bytes to move, so dropping one only shortens
+    // the length, and only when the index is in bounds.
+    if (elem_size == 0) {
+        const len_local = try self.emitListLenLocal(list_ptr);
+        const index_i32 = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitLocalGet(index_local);
+        self.currentCode().append(self.allocator, Op.i32_wrap_i64) catch return error.OutOfMemory;
+        try self.emitLocalSet(index_i32);
+        const one_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitI32Const(1);
+        try self.emitLocalSet(one_local);
+        const dropped = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitU32SaturatingSub(len_local, index_i32);
+        try self.emitLocalSet(dropped);
+        // dropped is nonzero exactly when the index is in bounds, so removing
+        // min(dropped, 1) elements covers both the in- and out-of-bounds cases.
+        const shrink = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitU32Min(dropped, one_local);
+        try self.emitLocalSet(shrink);
+        try self.emitU32SaturatingSub(len_local, shrink);
+        try self.emitZstListFromStackLen();
+        return;
+    }
 
     const result_offset = try self.allocStackMemory(12, 4);
     switch (self.external_calls) {
@@ -20924,6 +21086,17 @@ fn buildRocListWithCap(self: *Self, data_local: u32, len_local: u32, cap_local: 
 fn generateLLListWithCapacity(self: *Self, args: anytype, ret_layout: layout.Idx) Allocator.Error!void {
     const list_abi = self.builtinInternalListAbi("wasm.generateLLListWithCapacity.builtin_list_abi", ret_layout);
     const elem_size = list_abi.elem_size;
+
+    // Zero-width elements need no storage, so a reservation allocates nothing
+    // and the result is the canonical empty list.
+    if (elem_size == 0) {
+        const zero_len = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitI32Const(0);
+        try self.emitLocalSet(zero_len);
+        try self.emitZstListWithLen(zero_len);
+        return;
+    }
+
     const elem_align = list_abi.elem_align;
 
     // Generate capacity arg (may be i64 from MonoIR layout; convert to i32 for wasm32)
@@ -21276,6 +21449,14 @@ fn generateLLListSwap(self: *Self, args: anytype, ret_layout: layout.Idx, target
 fn generateLLListReserve(self: *Self, args: anytype, ret_layout: layout.Idx, target: ?ProcLocalId, unique_args: u64) Allocator.Error!void {
     const list_abi = self.builtinInternalListAbi("wasm.generateLLListReserve.builtin_list_abi", ret_layout);
     const elem_size = list_abi.elem_size;
+
+    // Zero-width elements need no storage, so there is nothing to reserve and
+    // the list passes through unchanged.
+    if (elem_size == 0) {
+        try self.emitProcLocal(GuardedList.at(args, 0));
+        return;
+    }
+
     const elem_align = list_abi.elem_align;
 
     try self.emitProcLocal(GuardedList.at(args, 0));
@@ -21335,6 +21516,14 @@ fn generateLLListReserve(self: *Self, args: anytype, ret_layout: layout.Idx, tar
 fn generateLLListReleaseExcessCapacity(self: *Self, args: anytype, ret_layout: layout.Idx, target: ?ProcLocalId, unique_args: u64) Allocator.Error!void {
     const list_abi = self.builtinInternalListAbi("wasm.generateLLListReleaseExcessCapacity.builtin_list_abi", ret_layout);
     const elem_size = list_abi.elem_size;
+
+    // A zero-width list holds no allocation, so it has no excess to release and
+    // passes through unchanged.
+    if (elem_size == 0) {
+        try self.emitProcLocal(GuardedList.at(args, 0));
+        return;
+    }
+
     const elem_align = list_abi.elem_align;
 
     // Generate list arg

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3565,7 +3565,9 @@ Builtin :: [].{
 		len : List(_item) -> U64
 
 		## Returns the number of items the list can hold without triggering a memory allocation.
-		## The capacity is always greater than or equal to the [List.len].
+		## The capacity is always greater than or equal to the [List.len], with one exception:
+		## a list of zero-sized items, such as `{}`, never allocates at all, so its capacity is
+		## always 0 no matter how many items it holds.
 		capacity : List(_item) -> U64
 
 		##  Check if the list is empty.

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3564,6 +3564,10 @@ Builtin :: [].{
 		## This means the #U64 this function returns can always be safely converted to #I64 or #I32, depending on the target.
 		len : List(_item) -> U64
 
+		## Returns the number of items the list can hold without triggering a memory allocation.
+		## The capacity is always greater than or equal to the [List.len].
+		capacity : List(_item) -> U64
+
 		##  Check if the list is empty.
 		## ```roc
 		## [1, 2, 3].is_empty()

--- a/src/canonicalize/BuiltinLowLevel.zig
+++ b/src/canonicalize/BuiltinLowLevel.zig
@@ -295,6 +295,9 @@ fn replaceProvidedByCompilerLowLevels(env: *ModuleEnv) (Allocator.Error || error
     if (env.common.findIdent("Builtin.List.len")) |list_len_ident| {
         try low_level_map.put(list_len_ident, .list_len);
     }
+    if (env.common.findIdent("Builtin.List.capacity")) |list_cap_ident| {
+        try low_level_map.put(list_cap_ident, .list_capacity);
+    }
     if (env.common.findIdent("u8_list_len")) |ident| {
         try low_level_map.put(ident, .list_len);
     }

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -6282,11 +6282,10 @@ pub const Interpreter = struct {
             .list_capacity => blk: {
                 const rl = self.valueToRocListForLayout(args[0], arg_layout);
                 const val = try self.alloc(ll.ret_layout);
-                // Canonical zero-width lists carry no allocation, so their
-                // stored capacity is zero even when they hold elements; every
-                // held element is trivially within capacity.
-                const capacity = @max(rl.getCapacity(), rl.len());
-                val.write(u64, @intCast(capacity));
+                // A list of zero-width elements never allocates, so its stored
+                // capacity is zero however many elements it holds. Report the
+                // stored capacity as it is.
+                val.write(u64, @intCast(rl.getCapacity()));
                 break :blk val;
             },
             .list_slack_unique => blk: {

--- a/src/eval/test/eval_low_level_tests.zig
+++ b/src/eval/test/eval_low_level_tests.zig
@@ -1679,6 +1679,280 @@ pub const tests = [_]TestCase{
         .expected = .{ .inspect_str = "True" },
     },
     .{
+        .name = "low_level - List.capacity of zero-sized items stays zero on every backend",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\(List.len(x), List.capacity(x))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(3, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list concat reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.concat(x, [{}, {}])
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(5, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list rev reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.rev(x)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(3, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list sublist reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.sublist(x, { start: 1, len: 2 })
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(2, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list drop_at reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.drop_at(x, 0)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(2, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list drop_swap reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.drop_swap(x, 0)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(2, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list prepend reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.prepend(x, {})
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(4, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list append reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.append(x, {})
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(4, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list insert reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.insert(x, 1, {}).ok_or([])
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(4, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list set reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.set(x, 1, {}).ok_or([])
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(3, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list swap reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.swap(x, 0, 2).ok_or([])
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(3, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list take_first reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.take_first(x, 2)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(2, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list take_last reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.take_last(x, 2)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(2, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list drop_first reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.drop_first(x, 1)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(2, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list drop_last reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.drop_last(x, 1)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(2, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list clear reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.clear(x)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(0, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list release_excess_capacity reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.release_excess_capacity(x)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(3, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list reserve reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.reserve(x, 4)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(3, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list repeat reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.repeat({}, 3)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(3, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list split_at reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.split_at(x, 1).others
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(2, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list join reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.join([x, x])
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(6, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list map reports zero capacity",
+        .source =
+        \\{
+        \\x : List({})
+        \\x = [{}, {}, {}]
+        \\r = List.map(x, |e| e)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(3, 0)" },
+    },
+    .{
+        .name = "low_level - zero-sized list with_capacity reports zero capacity",
+        .source =
+        \\{
+        \\r : List({})
+        \\r = List.with_capacity(5)
+        \\(List.len(r), List.capacity(r))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(0, 0)" },
+    },
+    .{
         .name = "low_level - List.append on non-empty list",
         .source =
         \\{

--- a/src/eval/test/eval_low_level_tests.zig
+++ b/src/eval/test/eval_low_level_tests.zig
@@ -1668,6 +1668,17 @@ pub const tests = [_]TestCase{
         .expected = .{ .inspect_str = "0" },
     },
     .{
+        .name = "low_level - List.capacity reports reserved capacity",
+        .source =
+        \\{
+        \\x : List(U64)
+        \\x = List.with_capacity(10)
+        \\List.capacity(x) >= 10
+        \\}
+        ,
+        .expected = .{ .inspect_str = "True" },
+    },
+    .{
         .name = "low_level - List.append on non-empty list",
         .source =
         \\{


### PR DESCRIPTION
This PR exposes the `List.capacity` builtin (mentioned in #9596)