### PR TITLE
Read evidence scopes and backing formals from what earlier stages recorded

### DIFF
--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -16290,6 +16290,26 @@ fn sealCheckedProcedureTemplateRefs(
     {
         const types_store = module.typeStoreConst();
 
+        // Every reference that instantiated a scheme is a record checking
+        // wrote, naming the exact scheme root it instantiated. A local
+        // definition named that way owns an evidence scope: its uses carry the
+        // evidence vector that scope schedules. Reading the records is what
+        // decides this, because the pattern var's rank answers a different
+        // question—whether let-generalization ran—and a definition whose body
+        // defers a dispatch to its caller is instantiated at its uses while
+        // that rank settles at `.outermost`.
+        var instantiated_scheme_roots = std.AutoHashMap(Var, void).init(allocator);
+        defer instantiated_scheme_roots.deinit();
+        for (module.moduleEnvConst().scheme_uses.items.items) |record| {
+            switch (@as(ModuleEnv.SchemeUseRecord.Slot, @enumFromInt(record.slot_kind))) {
+                .value_use, .shared_value_use => try instantiated_scheme_roots.put(
+                    @enumFromInt(record.scheme_root),
+                    {},
+                ),
+                .nested_function_use, .dispatch_target => {},
+            }
+        }
+
         var raw_node: u32 = 0;
         while (raw_node < module.nodeCount()) : (raw_node += 1) {
             if (module.nodeTag(@enumFromInt(raw_node)) != .statement_decl) continue;
@@ -16300,7 +16320,8 @@ fn sealCheckedProcedureTemplateRefs(
             const expr_data = module.expr(decl.expr).data;
             if (expr_data != .e_lambda and expr_data != .e_closure) continue;
             const pattern_var = ModuleEnv.varFrom(decl.pattern);
-            if (types_store.resolveVar(pattern_var).desc.rank != .generalized) continue;
+            const generalized = types_store.resolveVar(pattern_var).desc.rank == .generalized;
+            if (!generalized and !instantiated_scheme_roots.contains(pattern_var)) continue;
             const checked_expr = checked_bodies.exprIdForSource(decl.expr) orelse continue;
             try local_schemes.put(@intFromEnum(checked_expr), pattern_var);
         }

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -954,6 +954,13 @@ const invalid_llvm_debug_info_needles = [_]OutputNeedle{
 };
 
 const subcommand_cases = [_]CliCase{
+    // One descriptor template descends through the same generic nominal at more
+    // than one argument set: a backing shape is written once against its
+    // declaration's formals and reached once per instantiation, so each descent
+    // binds those formals its own way. This app's crypto digests are the shape
+    // that does it, and the hashes it prints prove each descent described its
+    // own arguments rather than an earlier descent's.
+    .{ .id = 0, .suite = .subcommands, .name = "boxy: one descriptor template binds a nominal backing formal per instantiation", .backend = .interpreter, .body = .{ .command = .{ .args = &.{ "--opt=interpreter", "--specialize=no", "--no-cache" }, .roc_file = "test/fx/app.roc", .stdin = "abc\n", .exit = .success, .contains = &.{.{ .stream = .stdout, .text = "Crypto hashes ok" }}, .not_contains = &.{ .{ .stream = .stderr, .text = "invariant violated" }, .{ .stream = .stderr, .text = "panic" } } } } },
     .{ .id = 0, .suite = .subcommands, .name = "CLI test cache roots are distinct", .body = .{ .custom = .cli_cache_roots_distinct } },
     .{ .id = 0, .suite = .subcommands, .name = "roc check watch inputs reject absolute file imports", .body = .{ .custom = .watch_inputs_reject_absolute_import } },
     .{ .id = 0, .suite = .subcommands, .name = "roc check --watch reruns when completed child snapshot is stale", .skip = .{ .windows = "watch refresh race test uses a POSIX wrapper script" }, .body = .{ .custom = .watch_completed_run_refresh_reruns } },

--- a/src/eval/test/eval_regression_repros.zig
+++ b/src/eval/test/eval_regression_repros.zig
@@ -870,4 +870,20 @@ pub const tests = [_]TestCase{
         ,
         .expected = .{ .inspect_str = "Ok(3)" },
     },
+    .{
+        // A local function returning a two-member lambda set is instantiated at
+        // its uses, so its declaration owns an evidence scope that carries the
+        // members' dispatch requirements. Checking records that instantiation
+        // whatever rank the definition's pattern var settles at.
+        .name = "regression: local function returning a two-member lambda set dispatches both members",
+        .source =
+        \\{
+        \\    pick = |flag| if flag { |x| x + 1.I64 } else { |x| x * 2.I64 }
+        \\    f = pick(True)
+        \\    g = pick(False)
+        \\    (f(10.I64), g(10.I64))
+        \\}
+        ,
+        .expected = .{ .inspect_str = "(11, 20)" },
+    },
 };

--- a/src/postcheck/boxy/lower.zig
+++ b/src/postcheck/boxy/lower.zig
@@ -11846,15 +11846,53 @@ const ProcBodyBuilder = struct {
         bindings: []LocalDescriptorEnvironmentBinding,
     };
 
+    /// One nominal backing formal bound to the argument rep a nominal supplied
+    /// for it, together with whatever that formal was bound to outside this
+    /// nominal so descending out of it restores the outer binding.
+    const DescriptorTemplateBinding = struct {
+        formal: Plan.TypeRepId,
+        outer: ?Plan.TypeRepId,
+    };
+
+    /// Identity of a substitution environment, interned as a link to the
+    /// environment it extends. Descents that bind the same formals to the same
+    /// arguments in the same order reach the same id and share descriptors.
+    const DescriptorTemplateEnvId = enum(u32) { empty = 0, _ };
+
+    const DescriptorTemplateEnvKey = struct {
+        parent: DescriptorTemplateEnvId,
+        formal: Plan.TypeRepId,
+        actual: Plan.TypeRepId,
+    };
+
+    /// A descriptor is only shared between positions that agree on both the
+    /// representation and the substitution environment it was emitted under:
+    /// one nominal's backing shape is reached once per argument instantiation.
+    const DescriptorTemplateDescKey = struct {
+        rep: Plan.TypeRepId,
+        env: DescriptorTemplateEnvId,
+    };
+
+    /// What a descent restores on the way back out.
+    const DescriptorTemplateScope = struct {
+        bindings_start: usize,
+        env: DescriptorTemplateEnvId,
+    };
+
     const DescriptorTemplateContext = struct {
-        ids: []?LIR.BoxyTypeDescId,
+        ids: std.AutoHashMap(DescriptorTemplateDescKey, LIR.BoxyTypeDescId),
+        env_ids: std.AutoHashMap(DescriptorTemplateEnvKey, DescriptorTemplateEnvId),
+        bindings: std.ArrayList(DescriptorTemplateBinding),
         forced_refs: []?LIR.LocalId,
         exact_reps: []?Plan.TypeRepId,
         exact_storage: bool,
+        env: DescriptorTemplateEnvId = .empty,
         excluded_local: ?LIR.LocalId = null,
 
-        fn deinit(self: DescriptorTemplateContext, allocator: Allocator) void {
-            allocator.free(self.ids);
+        fn deinit(self: *DescriptorTemplateContext, allocator: Allocator) void {
+            self.ids.deinit();
+            self.env_ids.deinit();
+            self.bindings.deinit(allocator);
             allocator.free(self.forced_refs);
             allocator.free(self.exact_reps);
         }
@@ -26753,16 +26791,15 @@ const ProcBodyBuilder = struct {
     }
 
     fn initDescriptorTemplateContext(self: *ProcBodyBuilder, exact_storage: bool) Allocator.Error!DescriptorTemplateContext {
-        const ids = try self.parent.allocator.alloc(?LIR.BoxyTypeDescId, self.parent.plan.representations.items.len);
-        errdefer self.parent.allocator.free(ids);
         const forced_refs = try self.parent.allocator.alloc(?LIR.LocalId, self.parent.plan.representations.items.len);
         errdefer self.parent.allocator.free(forced_refs);
         const exact_reps = try self.parent.allocator.alloc(?Plan.TypeRepId, self.parent.plan.representations.items.len);
-        @memset(ids, null);
         @memset(forced_refs, null);
         @memset(exact_reps, null);
         return .{
-            .ids = ids,
+            .ids = std.AutoHashMap(DescriptorTemplateDescKey, LIR.BoxyTypeDescId).init(self.parent.allocator),
+            .env_ids = std.AutoHashMap(DescriptorTemplateEnvKey, DescriptorTemplateEnvId).init(self.parent.allocator),
+            .bindings = std.ArrayList(DescriptorTemplateBinding).empty,
             .forced_refs = forced_refs,
             .exact_reps = exact_reps,
             .exact_storage = exact_storage,
@@ -26788,24 +26825,65 @@ const ProcBodyBuilder = struct {
         return current;
     }
 
-    fn recordDescriptorTemplateExactReps(
+    /// Bind this representation's nominal backing formals to the arguments it
+    /// supplies, for the descriptors nested inside it.
+    ///
+    /// A backing shape is written once against its declaration's formals and
+    /// reached once per instantiation, so one template can descend through the
+    /// same nominal at two argument sets and each descent binds the formals its
+    /// own way. The bindings therefore last exactly as long as the descent that
+    /// made them, and the returned scope is what undoes them.
+    fn pushDescriptorTemplateExactReps(
         self: *const ProcBodyBuilder,
         rep_id: Plan.TypeRepId,
         context: *DescriptorTemplateContext,
-    ) void {
-        if (!context.exact_storage) return;
+    ) Allocator.Error!DescriptorTemplateScope {
+        const scope = DescriptorTemplateScope{
+            .bindings_start = context.bindings.items.len,
+            .env = context.env,
+        };
+        if (!context.exact_storage) return scope;
 
         const rep = self.parent.plan.representations.items[@intFromEnum(rep_id)];
         for (self.parent.plan.nominalBackingArgSubstitutionSlice(rep.nominal_backing_arg_substitutions)) |substitution| {
+            if (substitution.formal_rep == substitution.actual_rep) continue;
             const slot = &context.exact_reps[@intFromEnum(substitution.formal_rep)];
             if (slot.*) |existing| {
-                if (existing != substitution.actual_rep) {
-                    boxyLowerInvariant("boxy exact descriptor template assigned one backing formal to two actual reps");
-                }
-            } else {
-                slot.* = substitution.actual_rep;
+                if (existing == substitution.actual_rep) continue;
             }
+            try context.bindings.append(self.parent.allocator, .{
+                .formal = substitution.formal_rep,
+                .outer = slot.*,
+            });
+            slot.* = substitution.actual_rep;
+
+            const key = DescriptorTemplateEnvKey{
+                .parent = context.env,
+                .formal = substitution.formal_rep,
+                .actual = substitution.actual_rep,
+            };
+            const entry = try context.env_ids.getOrPut(key);
+            if (!entry.found_existing) {
+                entry.value_ptr.* = @enumFromInt(@as(u32, @intCast(context.env_ids.count())));
+            }
+            context.env = entry.value_ptr.*;
         }
+        return scope;
+    }
+
+    /// Restore the bindings and environment a descent replaced.
+    fn popDescriptorTemplateExactReps(
+        context: *DescriptorTemplateContext,
+        scope: DescriptorTemplateScope,
+    ) void {
+        var index = context.bindings.items.len;
+        while (index > scope.bindings_start) {
+            index -= 1;
+            const binding = context.bindings.items[index];
+            context.exact_reps[@intFromEnum(binding.formal)] = binding.outer;
+        }
+        context.bindings.shrinkRetainingCapacity(scope.bindings_start);
+        context.env = scope.env;
     }
 
     fn descriptorTemplateRefForRep(
@@ -26854,11 +26932,13 @@ const ProcBodyBuilder = struct {
         context: *DescriptorTemplateContext,
     ) Allocator.Error!LIR.BoxyTypeDescId {
         const rep_index = @intFromEnum(rep_id);
-        self.recordDescriptorTemplateExactReps(rep_id, context);
-        if (context.ids[rep_index]) |existing| return existing;
+        const scope = try self.pushDescriptorTemplateExactReps(rep_id, context);
+        defer popDescriptorTemplateExactReps(context, scope);
+        const desc_key = DescriptorTemplateDescKey{ .rep = rep_id, .env = context.env };
+        if (context.ids.get(desc_key)) |existing| return existing;
 
         const desc_id: LIR.BoxyTypeDescId = @enumFromInt(@as(u32, @intCast(self.parent.result.boxy_type_descs.items.len)));
-        context.ids[rep_index] = desc_id;
+        try context.ids.put(desc_key, desc_id);
         try self.parent.result.boxy_type_descs.append(self.parent.allocator, .{
             .payload_layout = .zst,
             .contains_refcounted = false,


### PR DESCRIPTION
Two post-check stages re-derived something a checked module already states, and each derivation disagreed with the statement, so both aborted the compiler on ordinary programs.

`roc check` aborted with `local procedure without a checked evidence scope received use evidence` on a local function returning a two-member lambda set — `pick = |flag| if flag { |x| x } else { |x| x + 1 }` reached through `pick(True)(10)` is enough. Checking instantiates that definition at its uses and writes a scheme-use record naming the scheme root it instantiated, which is exactly why those uses carry the lambda-set members' dispatch requirements. The table that gives a definition the evidence scope those requirements land in was built instead from the definition's pattern var rank. Rank answers a different question — whether let-generalization ran — and settles at `.outermost` for a definition whose body defers a dispatch to its caller, so the declaration owned no scope while its uses carried evidence. That table is now built from the recorded scheme uses.

Lowering without specialization aborted with `boxy exact descriptor template assigned one backing formal to two actual reps` whenever a single descriptor template descends through the same generic nominal at more than one argument set; `test/fx/app.roc` reaches that through its crypto digests, which is why running it with `--specialize=no` aborted. A backing shape is written once against its declaration's formals and reached once per instantiation, so each descent binds those formals its own way — already how the sibling walk over the same substitutions in boxy's plan reads them. The template walk instead accumulated every binding into one map for the whole template and asserted that a formal never changed. Bindings now last exactly as long as the descent that made them, and a descriptor is shared only between positions that agree on both the representation and the substitution environment it was emitted under.

Neither failure was reachable from PR CI: the first is only exercised by the Lambda Mono differential harness, which `ci_zig.yml` gates on `inputs.full-run`, and the second by a `--specialize=no` run of an app that no test covered.
