### PR TITLE
Fix LSP panic on negative position coordinates

### DIFF
--- a/src/lsp/handlers/completion.zig
+++ b/src/lsp/handlers/completion.zig
@@ -90,7 +90,10 @@ pub fn handler(comptime ServerType: type) type {
                 try self.sendError(id, .invalid_params, "line must be an integer");
                 return;
             }
-            const line: u32 = @intCast(line_value.integer);
+            const line: u32 = std.math.cast(u32, line_value.integer) orelse {
+                try self.sendError(id, .invalid_params, "line must be a non-negative integer");
+                return;
+            };
 
             const character_value = position_obj.get("character") orelse {
                 try self.sendError(id, .invalid_params, "missing character");
@@ -100,7 +103,10 @@ pub fn handler(comptime ServerType: type) type {
                 try self.sendError(id, .invalid_params, "character must be an integer");
                 return;
             }
-            const character: u32 = @intCast(character_value.integer);
+            const character: u32 = std.math.cast(u32, character_value.integer) orelse {
+                try self.sendError(id, .invalid_params, "character must be a non-negative integer");
+                return;
+            };
 
             // Get the document text from the store
             const doc = self.doc_store.get(uri);

--- a/src/lsp/handlers/definition.zig
+++ b/src/lsp/handlers/definition.zig
@@ -60,7 +60,10 @@ pub fn handler(comptime ServerType: type) type {
                 try self.sendError(id, .invalid_params, "line must be an integer");
                 return;
             }
-            const line: u32 = @intCast(line_value.integer);
+            const line: u32 = std.math.cast(u32, line_value.integer) orelse {
+                try self.sendError(id, .invalid_params, "line must be a non-negative integer");
+                return;
+            };
 
             const character_value = position_obj.get("character") orelse {
                 try self.sendError(id, .invalid_params, "missing character");
@@ -70,7 +73,10 @@ pub fn handler(comptime ServerType: type) type {
                 try self.sendError(id, .invalid_params, "character must be an integer");
                 return;
             }
-            const character: u32 = @intCast(character_value.integer);
+            const character: u32 = std.math.cast(u32, character_value.integer) orelse {
+                try self.sendError(id, .invalid_params, "character must be a non-negative integer");
+                return;
+            };
 
             // Get the document text from the store
             const doc = self.doc_store.get(uri);

--- a/src/lsp/handlers/document_highlight.zig
+++ b/src/lsp/handlers/document_highlight.zig
@@ -57,13 +57,30 @@ pub fn handler(comptime ServerType: type) type {
             }
             const position_obj = position_value.object;
 
-            const line: u32 = blk: {
-                const v = position_obj.get("line") orelse break :blk 0;
-                break :blk if (std.meta.activeTag(v) == .integer) @intCast(v.integer) else 0;
+            const line_value = position_obj.get("line") orelse {
+                try self.sendError(id, .invalid_params, "missing line");
+                return;
             };
-            const character: u32 = blk: {
-                const v = position_obj.get("character") orelse break :blk 0;
-                break :blk if (std.meta.activeTag(v) == .integer) @intCast(v.integer) else 0;
+            if (std.meta.activeTag(line_value) != .integer) {
+                try self.sendError(id, .invalid_params, "line must be an integer");
+                return;
+            }
+            const line: u32 = std.math.cast(u32, line_value.integer) orelse {
+                try self.sendError(id, .invalid_params, "line must be a non-negative integer");
+                return;
+            };
+
+            const character_value = position_obj.get("character") orelse {
+                try self.sendError(id, .invalid_params, "missing character");
+                return;
+            };
+            if (std.meta.activeTag(character_value) != .integer) {
+                try self.sendError(id, .invalid_params, "character must be an integer");
+                return;
+            }
+            const character: u32 = std.math.cast(u32, character_value.integer) orelse {
+                try self.sendError(id, .invalid_params, "character must be a non-negative integer");
+                return;
             };
 
             // Get the document text from the store

--- a/src/lsp/handlers/hover.zig
+++ b/src/lsp/handlers/hover.zig
@@ -60,7 +60,10 @@ pub fn handler(comptime ServerType: type) type {
                 try self.sendError(id, .invalid_params, "line must be an integer");
                 return;
             }
-            const line: u32 = @intCast(line_value.integer);
+            const line: u32 = std.math.cast(u32, line_value.integer) orelse {
+                try self.sendError(id, .invalid_params, "line must be a non-negative integer");
+                return;
+            };
 
             const character_value = position_obj.get("character") orelse {
                 try self.sendError(id, .invalid_params, "missing character");
@@ -70,7 +73,10 @@ pub fn handler(comptime ServerType: type) type {
                 try self.sendError(id, .invalid_params, "character must be an integer");
                 return;
             }
-            const character: u32 = @intCast(character_value.integer);
+            const character: u32 = std.math.cast(u32, character_value.integer) orelse {
+                try self.sendError(id, .invalid_params, "character must be a non-negative integer");
+                return;
+            };
 
             // Get the document text from the store
             const doc = self.doc_store.get(uri);

--- a/src/lsp/handlers/selection_range.zig
+++ b/src/lsp/handlers/selection_range.zig
@@ -78,18 +78,35 @@ pub fn handler(comptime ServerType: type) type {
 
             for (positions.items) |pos_value| {
                 if (std.meta.activeTag(pos_value) != .object) {
-                    try results.append(self.allocator, null);
-                    continue;
+                    try self.sendError(id, .invalid_params, "position must be an object");
+                    return;
                 }
                 const pos_obj = pos_value.object;
 
-                const line: u32 = blk: {
-                    const v = pos_obj.get("line") orelse break :blk 0;
-                    break :blk if (std.meta.activeTag(v) == .integer) @intCast(v.integer) else 0;
+                const line_value = pos_obj.get("line") orelse {
+                    try self.sendError(id, .invalid_params, "missing line");
+                    return;
                 };
-                const character: u32 = blk: {
-                    const v = pos_obj.get("character") orelse break :blk 0;
-                    break :blk if (std.meta.activeTag(v) == .integer) @intCast(v.integer) else 0;
+                if (std.meta.activeTag(line_value) != .integer) {
+                    try self.sendError(id, .invalid_params, "line must be an integer");
+                    return;
+                }
+                const line = std.math.cast(u32, line_value.integer) orelse {
+                    try self.sendError(id, .invalid_params, "line must be a non-negative integer");
+                    return;
+                };
+
+                const character_value = pos_obj.get("character") orelse {
+                    try self.sendError(id, .invalid_params, "missing character");
+                    return;
+                };
+                if (std.meta.activeTag(character_value) != .integer) {
+                    try self.sendError(id, .invalid_params, "character must be an integer");
+                    return;
+                }
+                const character = std.math.cast(u32, character_value.integer) orelse {
+                    try self.sendError(id, .invalid_params, "character must be a non-negative integer");
+                    return;
                 };
 
                 const selection_range = computeSelectionRange(self.allocator, text, line, character) catch |err| switch (err) {

--- a/src/lsp/test/handler_unit_tests.zig
+++ b/src/lsp/test/handler_unit_tests.zig
@@ -282,3 +282,133 @@ test "document highlight handler returns empty for non-identifier with test synt
     try std.testing.expect(result == .array);
     try std.testing.expectEqual(@as(usize, 0), result.array.items.len);
 }
+
+test "hover handler returns invalid_params error for negative position coordinates without panicking" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file_uri = try tempFileUri(allocator, &tmp, "hover_negative.roc");
+    defer allocator.free(file_uri);
+
+    const hover_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/hover","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":-1,"character":-1}}}}}}
+    , .{file_uri});
+    defer allocator.free(hover_body);
+    const input = try requestInput(allocator, file_uri, "x = 1", hover_body);
+    defer allocator.free(input);
+
+    var writer_buffer: [16384]u8 = undefined;
+    const run = try runUnitServer(allocator, input, &writer_buffer);
+    defer freeRun(allocator, run);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, try responseWithId(allocator, run.responses, 2), .{});
+    defer parsed.deinit();
+    const err_obj = parsed.value.object.get("error") orelse return error.MissingError;
+    try std.testing.expect(err_obj == .object);
+    const code = err_obj.object.get("code") orelse return error.MissingCode;
+    try std.testing.expectEqual(@as(i64, -32602), code.integer);
+}
+
+test "completion handler returns invalid_params error for negative position coordinates without panicking" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file_uri = try tempFileUri(allocator, &tmp, "completion_negative.roc");
+    defer allocator.free(file_uri);
+
+    const completion_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/completion","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":-1,"character":-1}}}}}}
+    , .{file_uri});
+    defer allocator.free(completion_body);
+    const input = try requestInput(allocator, file_uri, "x = 1", completion_body);
+    defer allocator.free(input);
+
+    var writer_buffer: [16384]u8 = undefined;
+    const run = try runUnitServer(allocator, input, &writer_buffer);
+    defer freeRun(allocator, run);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, try responseWithId(allocator, run.responses, 2), .{});
+    defer parsed.deinit();
+    const err_obj = parsed.value.object.get("error") orelse return error.MissingError;
+    try std.testing.expect(err_obj == .object);
+    const code = err_obj.object.get("code") orelse return error.MissingCode;
+    try std.testing.expectEqual(@as(i64, -32602), code.integer);
+}
+
+test "definition handler returns invalid_params error for negative position coordinates without panicking" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file_uri = try tempFileUri(allocator, &tmp, "def_negative.roc");
+    defer allocator.free(file_uri);
+
+    const def_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":-1,"character":-1}}}}}}
+    , .{file_uri});
+    defer allocator.free(def_body);
+    const input = try requestInput(allocator, file_uri, "x = 1", def_body);
+    defer allocator.free(input);
+
+    var writer_buffer: [16384]u8 = undefined;
+    const run = try runUnitServer(allocator, input, &writer_buffer);
+    defer freeRun(allocator, run);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, try responseWithId(allocator, run.responses, 2), .{});
+    defer parsed.deinit();
+    const err_obj = parsed.value.object.get("error") orelse return error.MissingError;
+    try std.testing.expect(err_obj == .object);
+    const code = err_obj.object.get("code") orelse return error.MissingCode;
+    try std.testing.expectEqual(@as(i64, -32602), code.integer);
+}
+
+test "document highlight handler returns invalid_params error for negative position coordinates without panicking" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file_uri = try tempFileUri(allocator, &tmp, "highlight_negative.roc");
+    defer allocator.free(file_uri);
+
+    const highlight_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/documentHighlight","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":-1,"character":-1}}}}}}
+    , .{file_uri});
+    defer allocator.free(highlight_body);
+    const input = try requestInput(allocator, file_uri, "x = 1", highlight_body);
+    defer allocator.free(input);
+
+    var writer_buffer: [16384]u8 = undefined;
+    const run = try runUnitServer(allocator, input, &writer_buffer);
+    defer freeRun(allocator, run);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, try responseWithId(allocator, run.responses, 2), .{});
+    defer parsed.deinit();
+    const err_obj = parsed.value.object.get("error") orelse return error.MissingError;
+    try std.testing.expect(err_obj == .object);
+    const code = err_obj.object.get("code") orelse return error.MissingCode;
+    try std.testing.expectEqual(@as(i64, -32602), code.integer);
+}
+
+test "selection range handler returns invalid_params error for negative position coordinates without panicking" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file_uri = try tempFileUri(allocator, &tmp, "select_negative.roc");
+    defer allocator.free(file_uri);
+
+    const select_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/selectionRange","params":{{"textDocument":{{"uri":"{s}"}},"positions":[{{"line":-1,"character":-1}}]}}}}
+    , .{file_uri});
+    defer allocator.free(select_body);
+    const input = try requestInput(allocator, file_uri, "x = 1", select_body);
+    defer allocator.free(input);
+
+    var writer_buffer: [16384]u8 = undefined;
+    const run = try runUnitServer(allocator, input, &writer_buffer);
+    defer freeRun(allocator, run);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, try responseWithId(allocator, run.responses, 2), .{});
+    defer parsed.deinit();
+    const err_obj = parsed.value.object.get("error") orelse return error.MissingError;
+    try std.testing.expect(err_obj == .object);
+    const code = err_obj.object.get("code") orelse return error.MissingCode;
+    try std.testing.expectEqual(@as(i64, -32602), code.integer);
+}


### PR DESCRIPTION
LSP request handlers panicked when receiving negative line or character numbers in request position parameters due to unvalidated integer conversion to unsigned types.

This was addressed by validating incoming position line and character integers across LSP request handlers, returning an invalid parameters error or handling out-of-range values gracefully rather than crashing.

Fixes #10854