### PR TITLE
Fix LSP panic on out-of-bounds float values

### DIFF
--- a/src/lsp/handlers/did_change.zig
+++ b/src/lsp/handlers/did_change.zig
@@ -23,7 +23,7 @@ pub fn handler(comptime ServerType: type) type {
             const version_value = text_doc.get("version") orelse std.json.Value{ .integer = 0 };
             const version: i64 = if (std.meta.activeTag(version_value) == .integer)
                 version_value.integer
-            else if (std.meta.activeTag(version_value) == .float)
+            else if (std.meta.activeTag(version_value) == .float and std.math.isFinite(version_value.float) and version_value.float >= @as(f64, @floatFromInt(std.math.minInt(i64))) and version_value.float < @as(f64, @floatFromInt(std.math.maxInt(i64))))
                 @intFromFloat(version_value.float)
             else
                 0;
@@ -46,7 +46,7 @@ pub fn handler(comptime ServerType: type) type {
                 var change = DocumentStore.ContentChange{ .text = text };
                 if (change_obj.get("range")) |range_value| {
                     change.range = parseRange(range_value) catch |err| {
-                        std.log.err("invalid range for {s}: {s}", .{ uri, @errorName(err) });
+                        std.log.warn("invalid range for {s}: {s}", .{ uri, @errorName(err) });
                         return;
                     };
                 }
@@ -66,7 +66,7 @@ pub fn handler(comptime ServerType: type) type {
 
             if (saw_full_change) {
                 if (parsed_changes.items.len != 1) {
-                    std.log.err("received invalid mix of full and incremental changes for {s}", .{uri});
+                    std.log.warn("received invalid mix of full and incremental changes for {s}", .{uri});
                     return;
                 }
                 try self.doc_store.upsert(uri, version, parsed_changes.items[0].text);
@@ -77,7 +77,7 @@ pub fn handler(comptime ServerType: type) type {
                     error.InvalidPosition,
                     error.InvalidRange,
                     error.NoChanges,
-                    => std.log.err("failed to apply incremental change for {s}: {s}", .{ uri, @errorName(err) }),
+                    => std.log.warn("failed to apply incremental change for {s}: {s}", .{ uri, @errorName(err) }),
                 };
             }
 
@@ -104,10 +104,14 @@ pub fn handler(comptime ServerType: type) type {
         fn parseIndex(obj: std.json.ObjectMap, field: []const u8) error{ MissingField, InvalidField }!usize {
             const value = obj.get(field) orelse return error.MissingField;
             if (std.meta.activeTag(value) == .integer) {
-                return if (value.integer < 0) error.InvalidField else @intCast(value.integer);
+                return std.math.cast(usize, value.integer) orelse error.InvalidField;
             }
             if (std.meta.activeTag(value) == .float) {
-                return if (value.float < 0) error.InvalidField else @intFromFloat(value.float);
+                const f = value.float;
+                if (!std.math.isFinite(f) or f < 0 or f >= @as(f64, @floatFromInt(std.math.maxInt(usize)))) {
+                    return error.InvalidField;
+                }
+                return @intFromFloat(f);
             }
             return error.InvalidField;
         }

--- a/src/lsp/handlers/did_open.zig
+++ b/src/lsp/handlers/did_open.zig
@@ -26,7 +26,7 @@ pub fn handler(comptime ServerType: type) type {
             const version_value = text_doc.get("version") orelse std.json.Value{ .integer = 0 };
             const version: i64 = if (std.meta.activeTag(version_value) == .integer)
                 version_value.integer
-            else if (std.meta.activeTag(version_value) == .float)
+            else if (std.meta.activeTag(version_value) == .float and std.math.isFinite(version_value.float) and version_value.float >= @as(f64, @floatFromInt(std.math.minInt(i64))) and version_value.float < @as(f64, @floatFromInt(std.math.maxInt(i64))))
                 @intFromFloat(version_value.float)
             else
                 0;

--- a/src/lsp/test/handler_unit_tests.zig
+++ b/src/lsp/test/handler_unit_tests.zig
@@ -111,6 +111,63 @@ fn responseWithId(allocator: std.mem.Allocator, responses: [][]u8, wanted_id: i6
     return error.MissingResponse;
 }
 
+test "didChange handler handles out-of-bounds float values without panicking" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file_uri = try tempFileUri(allocator, &tmp, "change_float.roc");
+    defer allocator.free(file_uri);
+
+    const change_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didChange","params":{{"textDocument":{{"uri":"{s}","version":1e100}},"contentChanges":[{{"text":"x","range":{{"start":{{"line":1e100,"character":0}},"end":{{"line":1,"character":0}}}}}}]}}}}
+    , .{file_uri});
+    defer allocator.free(change_body);
+    const input = try requestInput(allocator, file_uri, "x = 1", change_body);
+    defer allocator.free(input);
+
+    var writer_buffer: [16384]u8 = undefined;
+    const run = try runUnitServer(allocator, input, &writer_buffer);
+    defer freeRun(allocator, run);
+}
+
+test "didChange handler handles valid float range indices correctly" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file_uri = try tempFileUri(allocator, &tmp, "change_valid_float.roc");
+    defer allocator.free(file_uri);
+
+    const change_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didChange","params":{{"textDocument":{{"uri":"{s}","version":2.0}},"contentChanges":[{{"text":"x","range":{{"start":{{"line":0.0,"character":0.0}},"end":{{"line":0.0,"character":1.0}}}}}}]}}}}
+    , .{file_uri});
+    defer allocator.free(change_body);
+    const input = try requestInput(allocator, file_uri, "x = 1", change_body);
+    defer allocator.free(input);
+
+    var writer_buffer: [16384]u8 = undefined;
+    const run = try runUnitServer(allocator, input, &writer_buffer);
+    defer freeRun(allocator, run);
+}
+
+test "didOpen handler handles out-of-bounds float version without panicking" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file_uri = try tempFileUri(allocator, &tmp, "open_float.roc");
+    defer allocator.free(file_uri);
+
+    const open_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1e100,"text":"x = 1"}}}}}}
+    , .{file_uri});
+    defer allocator.free(open_body);
+    const input = try requestInput(allocator, file_uri, "x = 1", open_body);
+    defer allocator.free(input);
+
+    var writer_buffer: [16384]u8 = undefined;
+    const run = try runUnitServer(allocator, input, &writer_buffer);
+    defer freeRun(allocator, run);
+}
+
 test "formatting handler formats simple expression with test syntax driver" {
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{});


### PR DESCRIPTION
Document synchronization notification handlers panicked when converting floating-point versions or range positions that were non-finite or exceeded destination integer limits.

This was addressed by validating floating-point inputs against integer boundaries before converting them, safely falling back to default values or rejecting invalid ranges, and lowered invalid client notification logs to warnings.

Fixes #10856