### PR TITLE
Fix LSP memory leak on goto definition

### DIFF
--- a/src/lsp/handlers/definition.zig
+++ b/src/lsp/handlers/definition.zig
@@ -124,6 +124,8 @@ pub fn handler(comptime ServerType: type) type {
             };
 
             if (def_result) |result| {
+                defer result.deinit(self.allocator);
+
                 // Build the Location response
                 const LocationResponse = struct {
                     uri: []const u8,

--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -981,6 +981,10 @@ pub const SyntaxChecker = struct {
     pub const DefinitionResult = struct {
         uri: []const u8,
         range: LspRange,
+
+        pub fn deinit(self: DefinitionResult, allocator: std.mem.Allocator) void {
+            allocator.free(self.uri);
+        }
     };
 
     /// Returns true when a byte can be part of a Roc identifier token used for
@@ -1117,6 +1121,7 @@ pub const SyntaxChecker = struct {
             const def_loc_opt = self.findDefinitionAtOffset(module_env, target_offset, uri, &def_oom);
             if (def_oom) |e| return e;
             if (def_loc_opt) |def_loc| {
+                defer def_loc.deinit(self.allocator);
                 if (std.mem.eql(u8, def_loc.uri, uri)) {
                     if (pos.positionToOffset(module_env, def_loc.range.start_line, def_loc.range.start_col)) |def_offset| {
                         if (cir_queries.findPatternAtOffset(module_env, def_offset)) |pattern_idx| {
@@ -1559,8 +1564,12 @@ pub const SyntaxChecker = struct {
                 if (self.findTypeAnnoAtOffset(module_env, annotation.anno, target_offset, oom)) |result| {
                     // If URI is empty, it's a local type - use current file
                     if (result.uri.len == 0) {
+                        const uri_copy = self.allocator.dupe(u8, current_uri) catch |err| {
+                            oom.* = err;
+                            return null;
+                        };
                         return DefinitionResult{
-                            .uri = current_uri,
+                            .uri = uri_copy,
                             .range = result.range,
                         };
                     }
@@ -1612,8 +1621,12 @@ pub const SyntaxChecker = struct {
                 if (self.findTypeAnnoAtOffset(module_env, type_anno_idx, target_offset, oom)) |result| {
                     // If URI is empty, it's a local type - use current file
                     if (result.uri.len == 0) {
+                        const uri_copy = self.allocator.dupe(u8, current_uri) catch |err| {
+                            oom.* = err;
+                            return null;
+                        };
                         return DefinitionResult{
-                            .uri = current_uri,
+                            .uri = uri_copy,
                             .range = result.range,
                         };
                     }
@@ -1660,8 +1673,12 @@ pub const SyntaxChecker = struct {
                 const pattern_node_idx: CIR.Node.Idx = @enumFromInt(@intFromEnum(lookup.pattern_idx));
                 const def_region = module_env.store.getRegionAt(pattern_node_idx);
                 const range = cir_queries.regionToRange(module_env, def_region) orelse return null;
+                const uri_copy = self.allocator.dupe(u8, current_uri) catch |err| {
+                    oom.* = err;
+                    return null;
+                };
                 return DefinitionResult{
-                    .uri = current_uri,
+                    .uri = uri_copy,
                     .range = range,
                 };
             }
@@ -1990,8 +2007,12 @@ pub const SyntaxChecker = struct {
                     if (maybe_type_anno) |type_anno_idx| {
                         if (self.findTypeAnnoAtOffset(module_env, type_anno_idx, target_offset, oom)) |result| {
                             if (result.uri.len == 0) {
+                                const uri_copy = self.allocator.dupe(u8, current_uri) catch |err| {
+                                    oom.* = err;
+                                    return null;
+                                };
                                 return DefinitionResult{
-                                    .uri = current_uri,
+                                    .uri = uri_copy,
                                     .range = result.range,
                                 };
                             }

--- a/src/lsp/test/handler_integration_tests.zig
+++ b/src/lsp/test/handler_integration_tests.zig
@@ -747,17 +747,17 @@ pub fn definitionHandlerNavigatesToBuiltinTypeFromTypeAnnotation() integration_s
     const initialized_msg = try frame(allocator, initialized_body);
     defer allocator.free(initialized_msg);
 
-    // Document with type annotation. Position (2, 4) is on the 'U' of 'U64'.
+    // Document with type annotation. Position (1, 20) is on 'Str'.
     const open_body = try std.fmt.allocPrint(allocator,
-        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"app [x] {{ pf: platform \"{s}\" }}\\n\\nx : U64\\nx = 42"}}}}}}
-    , .{ file_uri, platform_path });
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"Helpers :: [].{{\n\tencode_json : a -> Str where [a.encoder_for : _ -> (a, _ -> Try(_, _))]\n\tencode_json = |a| Json.to_str(a)\n}}\n"}}}}}}
+    , .{file_uri});
     defer allocator.free(open_body);
     const open_msg = try frame(allocator, open_body);
     defer allocator.free(open_msg);
 
-    // Request definition for 'U64' on line 2, character 4 (the type in the annotation).
+    // Request definition for 'Str' on line 1, character 20.
     const definition_body = try std.fmt.allocPrint(allocator,
-        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":2,"character":4}}}}}}
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":1,"character":20}}}}}}
     , .{file_uri});
     defer allocator.free(definition_body);
     const definition_msg = try frame(allocator, definition_body);
@@ -806,13 +806,10 @@ pub fn definitionHandlerNavigatesToBuiltinTypeFromTypeAnnotation() integration_s
     var response = try responseById(allocator, responses, 2);
     defer response.deinit();
     const result = try response.result();
-    if (result == .object) {
-        const uri = try stringField(result, "uri");
-        try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
-        try expectRange(try objectField(result, "range"), 0, 0, 0, 0);
-    } else {
-        try std.testing.expect(result == .null);
-    }
+    try std.testing.expect(result == .object);
+    const uri = try stringField(result, "uri");
+    try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
+    try expectRange(try objectField(result, "range"), 0, 0, 0, 0);
 }
 
 /// Verifies document symbols still work after a goto-definition request.

--- a/src/lsp/test/test_syntax_driver.zig
+++ b/src/lsp/test/test_syntax_driver.zig
@@ -41,6 +41,10 @@ pub const TestSyntaxDriver = struct {
     pub const DefinitionResult = struct {
         uri: []const u8,
         range: LspRange,
+
+        pub fn deinit(self: DefinitionResult, allocator: std.mem.Allocator) void {
+            allocator.free(self.uri);
+        }
     };
 
     pub const HighlightResult = struct {


### PR DESCRIPTION
Goto-definition queries returning URIs to external or built-in modules dynamically allocated memory that was never released by the handler or internal query fallbacks, resulting in a memory leak detected during server shutdown.

This was addressed by establishing an explicit ownership and cleanup lifecycle for definition query results across the definition handler and hover resolution fallback.

Fixes #10857