### PR TITLE
Canonicalize Monotype type digests as content identities (Phase 1)

### DIFF
--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -459,7 +459,7 @@ const DurableTypeSnapshot = struct {
     }
 };
 
-fn durableTypeSnapshot(allocator: Allocator, program: *const MonoAst.Program) Allocator.Error!DurableTypeSnapshot {
+fn durableTypeSnapshot(allocator: Allocator, program: *MonoAst.Program) Allocator.Error!DurableTypeSnapshot {
     const store_view = program.types.view();
     const type_digests = try allocator.alloc(check.CheckedNames.TypeDigest, store_view.types.len);
     errdefer allocator.free(type_digests);

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -250,8 +250,9 @@ pub fn fnTemplateIdentityEql(lhs: FnTemplate, rhs: FnTemplate) bool {
         lhs.mono_fn_ty == rhs.mono_fn_ty;
 }
 
-/// Compute a digest for a Monotype function template.
-pub fn fnTemplateDigest(template: FnTemplate, types: *const Type.Store, name_store: *const names.NameStore) names.TypeDigest {
+/// Compute a digest for a Monotype function template. Takes the type store
+/// mutable because type digests are computed through the store's cache.
+pub fn fnTemplateDigest(template: FnTemplate, types: *Type.Store, name_store: *const names.NameStore) names.TypeDigest {
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
     writeFnDef(&hasher, template.fn_def);
     writeBytes(&hasher, &template.source_fn_key.bytes);

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -3751,10 +3751,13 @@ const Builder = struct {
         final_fn_ty: Type.TypeId,
     ) Allocator.Error!void {
         // The definition records the body's solved view of the root type.
-        // Call sites embed the requested type, which digests identically
-        // because digests are alias-transparent and a solved request
-        // determines every interface slot; root-class call sites adopt this
-        // recorded template directly.
+        // Call sites embed the requested type; a solved request determines
+        // every interface slot, and root-class call sites adopt this recorded
+        // template directly rather than recomputing an identity, so the two
+        // views never race. (Interface digests are alias-opaque, so a
+        // requested and a solved view that differ only by alias wrapping
+        // would be distinct identities—acceptable because only the recorded
+        // template is consulted.)
         var def_template = pending.fn_template;
         def_template.mono_fn_ty = switch (pending.signature_relation) {
             // An exact signature keeps the producer-authored request type. The

--- a/src/postcheck/monotype/serialize.zig
+++ b/src/postcheck/monotype/serialize.zig
@@ -28,12 +28,15 @@ const TestEvidenceMappingError = std.mem.Allocator.Error || CacheError || error{
 /// Magic bytes at the start of a specialization cache file.
 pub const MAGIC: [8]u8 = .{ 'R', 'O', 'C', 'S', 'P', 'E', 'C', 0 };
 /// Serialization format version for specialization cache files.
+/// Version 12: canonical graph-based type digests (versioned digest domains,
+/// alias-opaque encoding, recursive-group canonicalization, and previously
+/// missing identity fields), which change every serialized digest byte.
 /// Version 11: field access expressions carry flattened segment spans.
 /// Version 9: function metadata records whether a signature is independent
 /// roots or one exact producer-authored graph.
 /// Version 8: specialization and function-template identity includes the
 /// SHA-256 digest of exact compile-time evidence topology.
-pub const FORMAT_VERSION: u32 = 11;
+pub const FORMAT_VERSION: u32 = 12;
 
 const SECTION_COUNT = 43;
 

--- a/src/postcheck/monotype/serialize.zig
+++ b/src/postcheck/monotype/serialize.zig
@@ -28,9 +28,9 @@ const TestEvidenceMappingError = std.mem.Allocator.Error || CacheError || error{
 /// Magic bytes at the start of a specialization cache file.
 pub const MAGIC: [8]u8 = .{ 'R', 'O', 'C', 'S', 'P', 'E', 'C', 0 };
 /// Serialization format version for specialization cache files.
-/// Version 12: canonical graph-based type digests (versioned digest domains,
-/// alias-opaque encoding, recursive-group canonicalization, and previously
-/// missing identity fields), which change every serialized digest byte.
+/// Version 12: graph-reduced type digests (versioned digest domains,
+/// alias-opaque encoding, recursive-group reduction, and previously missing
+/// identity fields), which change every serialized digest byte.
 /// Version 11: field access expressions carry flattened segment spans.
 /// Version 9: function metadata records whether a signature is independent
 /// roots or one exact producer-authored graph.

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -1328,6 +1328,24 @@ pub const InstGraph = struct {
         };
     }
 
+    /// Generated-iterator identities are representation-level: a type
+    /// nickname over the same item type must produce the same generated
+    /// iterator machinery, or an alias could duplicate that machinery and
+    /// alter unification behavior. Type digests treat aliases as opaque
+    /// nodes, so peel aliases to their backing before digesting here.
+    fn peelAliasBacking(types: *const Type.Store, ty: Type.TypeId) Type.TypeId {
+        var current = ty;
+        // Alias chains in checked output are finite, so this terminates.
+        while (true) {
+            const node = types.get(current);
+            if (node != .named) return current;
+            const named = node.named;
+            if (named.kind != .alias) return current;
+            const backing = named.backing orelse return current;
+            current = backing.ty;
+        }
+    }
+
     /// Seal producer identities for graph-owned iterator representations only
     /// after all type relations and representation decisions have been
     /// applied. Immutable Type-shaped snapshots of resolved nodes are used
@@ -1357,12 +1375,12 @@ pub const InstGraph = struct {
                     Common.invariant("forced-dynamic iterator identity did not have exactly one item argument");
                 }
                 const item = try self.provisionalTypeViewForNode(named.args[0]);
-                const item_digest = self.types.typeDigest(self.name_store, item);
+                const item_digest = self.types.typeDigest(self.name_store, peelAliasBacking(self.types, item));
                 hasher.update("roc.generated_iterator.forced_dynamic_identity");
                 hasher.update(&item_digest.bytes);
             } else {
                 const final = try self.provisionalTypeViewForNode(node);
-                const shape = self.types.typeDigest(self.name_store, final);
+                const shape = self.types.typeDigest(self.name_store, peelAliasBacking(self.types, final));
                 hasher.update("roc.generated_iterator.final_identity");
                 hasher.update(&shape.bytes);
                 if (provenance.callable_evidence) |evidence| {

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -309,6 +309,15 @@ pub const Store = struct {
     iterator_interface_visited: std.ArrayList(TypeId),
     iterator_interface_visit_epochs: StoreList(u32, "iterator_interface_visit_epochs"),
     iterator_interface_visit_epoch: u32,
+    /// One-step unfoldings of every digested recursive-group position: the
+    /// hash of a member's node encoding with all children rendered as their
+    /// finalized digests, mapped to that member's group digest. An acyclic
+    /// node whose rendering matches an entry is a rolled-out prefix of the
+    /// same infinite type and adopts the member's digest, which keeps digests
+    /// independent of how deeply a recursive knot is tied — including across
+    /// separate digest calls. Keys and values are content-addressed, so
+    /// entries stay valid across `restore` truncations and need no rollback.
+    recursive_digest_unfoldings: std.AutoHashMap([32]u8, names.TypeDigest),
     spans: StoreList(TypeId, "spans"),
     fields: StoreList(Field, "fields"),
     tags: StoreList(Tag, "tags"),
@@ -327,6 +336,7 @@ pub const Store = struct {
             .iterator_interface_visited = .empty,
             .iterator_interface_visit_epochs = .empty,
             .iterator_interface_visit_epoch = 0,
+            .recursive_digest_unfoldings = std.AutoHashMap([32]u8, names.TypeDigest).init(allocator),
             .spans = .empty,
             .fields = .empty,
             .tags = .empty,
@@ -340,6 +350,7 @@ pub const Store = struct {
         self.tags.deinit(self.allocator);
         self.fields.deinit(self.allocator);
         self.spans.deinit(self.allocator);
+        self.recursive_digest_unfoldings.deinit();
         self.iterator_interface_visit_epochs.deinit(self.allocator);
         self.iterator_interface_visited.deinit(self.allocator);
         self.iterator_interface_pending.deinit(self.allocator);
@@ -660,20 +671,22 @@ pub const Store = struct {
         };
     }
 
-    pub fn typeDigest(self: *const Store, name_store: *const names.NameStore, ty: TypeId) names.TypeDigest {
-        self.requireConstructed(ty);
-        var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-        var visiting = DigestVisiting{};
-        self.writeTypeDigest(name_store, &hasher, ty, &visiting, .full);
-        return .{ .bytes = hasher.finalResult() };
+    /// Full content-identity digest for `ty` (cached on first computation).
+    ///
+    /// Full digests answer "is this the same stored type?": every field that
+    /// deep structural comparison observes participates, and aliases digest
+    /// as opaque nodes rather than as their backing.
+    pub fn typeDigest(self: *Store, name_store: *const names.NameStore, ty: TypeId) names.TypeDigest {
+        return self.typeDigestCached(name_store, ty, null);
     }
 
-    pub fn specializationDigest(self: *const Store, name_store: *const names.NameStore, ty: TypeId) names.TypeDigest {
-        self.requireConstructed(ty);
-        var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-        var visiting = DigestVisiting{};
-        self.writeTypeDigest(name_store, &hasher, ty, &visiting, .identity_only);
-        return .{ .bytes = hasher.finalResult() };
+    /// Public-interface specialization digest for `ty` (cached on first
+    /// computation). This intentionally omits exactly declared field order
+    /// and checked-public backing details, because it answers "may these two
+    /// types share a specialization?" rather than "are these the same stored
+    /// type?".
+    pub fn specializationDigest(self: *Store, name_store: *const names.NameStore, ty: TypeId) names.TypeDigest {
+        return self.specializationDigestCached(name_store, ty, null);
     }
 
     pub const DigestStats = struct {
@@ -875,33 +888,35 @@ pub const Store = struct {
         return self.specialization_digests.unsafeRawItemsForView();
     }
 
+    /// `typeDigest` with optional cache statistics.
     pub fn typeDigestCached(
         self: *Store,
         name_store: *const names.NameStore,
         ty: TypeId,
         stats: ?*DigestStats,
     ) names.TypeDigest {
-        var ctx = CachedDigestContext{};
-        return self.cachedDigestInner(name_store, ty, .full, &ctx, stats);
+        return self.computeDigest(name_store, ty, .full, stats) catch digestOutOfMemory();
     }
 
+    /// `specializationDigest` with optional cache statistics.
     pub fn specializationDigestCached(
         self: *Store,
         name_store: *const names.NameStore,
         ty: TypeId,
         stats: ?*DigestStats,
     ) names.TypeDigest {
-        var ctx = CachedDigestContext{};
-        return self.cachedDigestInner(name_store, ty, .identity_only, &ctx, stats);
+        return self.computeDigest(name_store, ty, .identity_only, stats) catch digestOutOfMemory();
     }
 
     /// Exact structural equality for closed Monotype types.
     ///
-    /// This mirrors the intentional identity rules used by `typeDigest`:
-    /// aliases with backing compare as their backing, non-alias named types
+    /// Aliases with backing compare as their backing, non-alias named types
     /// compare by named identity and arguments, and structural rows compare by
-    /// label text and ordered children. Unlike the digest, this is authoritative
-    /// and must be checked before one specialization can reuse another.
+    /// label text and ordered children. `typeDigest` matches these rules with
+    /// one deliberate one-way exception: aliases digest as opaque nodes, so an
+    /// alias and its backing are equal here yet digest differently. Equal
+    /// digests still imply equality here; this is the authoritative check
+    /// before one specialization can reuse another.
     pub fn typeEql(
         self: *const Store,
         name_store: *const names.NameStore,
@@ -922,26 +937,23 @@ pub const Store = struct {
         return try self.view().typeMatches(self.allocator, name_store, lhs, rhs, mode);
     }
 
-    /// Stack of types currently being digested. Recursive types reference a
-    /// type already on this stack; the digest encodes such a back reference by
-    /// stack position so cyclic content digests deterministically.
-    const DigestVisiting = struct {
-        items: [digest_visiting_max]TypeId = undefined,
-        len: usize = 0,
-    };
-
-    const digest_visiting_max = 256;
-
-    const CachedDigestContext = struct {
-        items: [digest_visiting_max]TypeId = undefined,
-        len: usize = 0,
-        cycle_count: u32 = 0,
-    };
-
+    /// Which digest question is being answered. The two modes are separate
+    /// versioned domains and must never produce byte-confusable answers.
     const NamedDigestMode = enum {
         full,
         identity_only,
     };
+
+    /// Versioned digest-domain prefix written at the start of every node
+    /// encoding. Digest bytes are serialized and compared across builds, so
+    /// changing a domain (or any encoding detail) is a specialization-cache
+    /// format change.
+    fn digestDomain(mode: NamedDigestMode) []const u8 {
+        return switch (mode) {
+            .full => "roc.monotype.type.identity.v1",
+            .identity_only => "roc.monotype.type.interface.v1",
+        };
+    }
 
     fn assertMutable(self: *const Store) void {
         if (self.frozen) Common.invariant("frozen Monotype type store cannot be mutated");
@@ -1018,533 +1030,726 @@ pub const Store = struct {
         return null;
     }
 
-    fn cachedDigestInner(
-        self: *Store,
-        name_store: *const names.NameStore,
-        ty: TypeId,
-        named_mode: NamedDigestMode,
-        ctx: *CachedDigestContext,
-        stats: ?*DigestStats,
-    ) names.TypeDigest {
-        self.requireConstructed(ty);
-        for (ctx.items[0..ctx.len], 0..) |open_ty, position| {
-            if (open_ty == ty) {
-                ctx.cycle_count += 1;
-                return cycleDigest(@intCast(position));
-            }
-        }
-        if (self.openNamedCyclePosition(name_store, self.get(ty), ctx.items[0..ctx.len])) |position| {
-            ctx.cycle_count += 1;
-            return cycleDigest(@intCast(position));
-        }
-
+    /// Cache lookup for one digest mode. Filled nodes are immutable, so a
+    /// cached digest is permanently valid.
+    fn cachedDigest(self: *const Store, ty: TypeId, mode: NamedDigestMode) ?names.TypeDigest {
         const index = @intFromEnum(ty);
-        switch (named_mode) {
-            .full => {
-                if (self.type_digests.unsafeRawItemsForView()[index]) |digest| {
-                    if (stats) |s| s.cache_hits += 1;
-                    return digest;
-                }
-            },
-            .identity_only => {
-                if (self.specialization_digests.unsafeRawItemsForView()[index]) |digest| {
-                    if (stats) |s| s.cache_hits += 1;
-                    return digest;
-                }
-            },
-        }
-
-        if (stats) |s| {
-            s.cache_misses += 1;
-            s.nodes_visited += 1;
-        }
-
-        if (ctx.len == digest_visiting_max) {
-            ctx.cycle_count += 1;
-            return deepDigest(ty);
-        }
-
-        ctx.items[ctx.len] = ty;
-        ctx.len += 1;
-        const cycle_count_before = ctx.cycle_count;
-        var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-        self.writeCachedTypeDigest(name_store, &hasher, ty, named_mode, ctx, stats);
-        ctx.len -= 1;
-
-        const digest: names.TypeDigest = .{ .bytes = hasher.finalResult() };
-        if (ctx.cycle_count == cycle_count_before) {
-            switch (named_mode) {
-                .full => self.type_digests.set(index, digest),
-                .identity_only => self.specialization_digests.set(index, digest),
-            }
-        }
-        return digest;
+        return switch (mode) {
+            .full => self.type_digests.unsafeRawItemsForView()[index],
+            .identity_only => self.specialization_digests.unsafeRawItemsForView()[index],
+        };
     }
 
-    fn writeCachedChildDigest(
-        self: *Store,
-        name_store: *const names.NameStore,
-        hasher: *std.crypto.hash.sha2.Sha256,
-        child: TypeId,
-        named_mode: NamedDigestMode,
-        ctx: *CachedDigestContext,
-        stats: ?*DigestStats,
-    ) void {
-        writeBytes(hasher, "type-digest");
-        const digest = self.cachedDigestInner(name_store, child, named_mode, ctx, stats);
-        hasher.update(&digest.bytes);
-    }
-
-    fn writeCachedTypeSpanDigest(
-        self: *Store,
-        name_store: *const names.NameStore,
-        hasher: *std.crypto.hash.sha2.Sha256,
-        span_: Span,
-        named_mode: NamedDigestMode,
-        ctx: *CachedDigestContext,
-        stats: ?*DigestStats,
-    ) void {
-        const values = self.span(span_);
-        writeU32(hasher, @intCast(values.len));
-        for (0..values.len) |index| {
-            const child = GuardedList.at(values, index);
-            self.writeCachedChildDigest(name_store, hasher, child, named_mode, ctx, stats);
+    /// Sole writer of both digest caches. Digests are content-addressed, so a
+    /// re-write must agree with the existing entry.
+    fn setCachedDigest(self: *Store, ty: TypeId, mode: NamedDigestMode, digest: names.TypeDigest) void {
+        if (self.cachedDigest(ty, mode)) |existing| {
+            std.debug.assert(std.mem.eql(u8, &existing.bytes, &digest.bytes));
+        }
+        const index = @intFromEnum(ty);
+        switch (mode) {
+            .full => self.type_digests.set(index, digest),
+            .identity_only => self.specialization_digests.set(index, digest),
         }
     }
 
-    fn writeCachedTypeDigest(
+    /// One digest implementation for both modes: serve the request from the
+    /// cache or canonicalize the uncached reachable subgraph and cache every
+    /// digest it settles.
+    fn computeDigest(
         self: *Store,
         name_store: *const names.NameStore,
-        hasher: *std.crypto.hash.sha2.Sha256,
         ty: TypeId,
-        named_mode: NamedDigestMode,
-        ctx: *CachedDigestContext,
+        mode: NamedDigestMode,
         stats: ?*DigestStats,
-    ) void {
+    ) std.mem.Allocator.Error!names.TypeDigest {
+        self.requireConstructed(ty);
+        if (self.cachedDigest(ty, mode)) |digest| {
+            if (stats) |s| s.cache_hits += 1;
+            return digest;
+        }
+        var engine = DigestEngine.init(self, name_store, stats);
+        defer engine.deinit();
+        return try engine.run(ty, mode);
+    }
+
+    /// Canonical byte encoding of one type node in one digest mode.
+    ///
+    /// This is the single source of digest bytes: graph discovery, recursive
+    /// canonicalization, and final digest rendering all replay this encoding
+    /// with different child-reference sinks, so no consumer can observe two
+    /// byte encodings for the same mode. Every node starts with its versioned
+    /// digest domain, then a content-kind discriminator, every non-reference
+    /// value the mode observes, and its ordered typed edges via `sink.child`.
+    ///
+    /// Aliases are opaque named nodes rather than digesting as their backing.
+    /// `def.type_name` text is always hashed (also when `source_decl` is
+    /// present), `named_type.ty` is hashed because it survives into
+    /// `ConstStore`, and `tag.checked_name` is hashed in addition to
+    /// `tag.name`. The interface mode omits exactly declared field order and
+    /// checked-public backing details; backing children always digest in full
+    /// mode because a backing is a stored type identity, not an interface.
+    fn encodeTypeNode(
+        self: *const Store,
+        name_store: *const names.NameStore,
+        sink: anytype,
+        ty: TypeId,
+        mode: NamedDigestMode,
+    ) std.mem.Allocator.Error!void {
+        try sink.writeBytes(digestDomain(mode));
         switch (self.get(ty)) {
             .primitive => |primitive| {
-                writeBytes(hasher, "primitive");
-                writeBytes(hasher, @tagName(primitive));
+                try sink.writeBytes("primitive");
+                try sink.writeBytes(@tagName(primitive));
             },
             .named => |named| {
-                if (named.kind == .alias) {
-                    const backing = named.backing orelse {
-                        writeBytes(hasher, "alias-without-backing");
-                        return;
-                    };
-                    self.writeCachedChildDigest(name_store, hasher, backing.ty, named_mode, ctx, stats);
-                    return;
-                }
-                writeBytes(hasher, "named");
-                hasher.update(&named.named_type.module.bytes);
-                writeBytes(hasher, name_store.moduleIdentityBytes(named.def.module));
-                writeOptionalU32(hasher, named.def.source_decl);
-                if (named.def.source_decl == null) {
-                    writeBytes(hasher, name_store.typeNameText(named.def.type_name));
-                }
-                writeOptionalDigest(hasher, named.def.generated);
-                writeBytes(hasher, @tagName(named.def.iterator_representation));
-                writeBytes(hasher, @tagName(named.def.iterator_kind));
-                writeU32(hasher, named.def.iterator_depth);
-                writeIteratorTopology(hasher, name_store, named.def.iterator_topology);
-                writeBytes(hasher, @tagName(named.kind));
+                try sink.writeBytes("named");
+                try sink.writeBytes(&named.named_type.module.bytes);
+                try sink.writeU32(@intFromEnum(named.named_type.ty));
+                try sink.writeBytes(name_store.moduleIdentityBytes(named.def.module));
+                try sinkOptionalU32(sink, named.def.source_decl);
+                try sink.writeBytes(name_store.typeNameText(named.def.type_name));
+                try sinkOptionalDigest(sink, named.def.generated);
+                try sink.writeBytes(@tagName(named.def.iterator_representation));
+                try sink.writeBytes(@tagName(named.def.iterator_kind));
+                try sink.writeU32(named.def.iterator_depth);
+                try sinkIteratorTopology(sink, name_store, named.def.iterator_topology);
+                try sink.writeBytes(@tagName(named.kind));
                 if (named.builtin_owner) |owner| {
-                    writeBytes(hasher, "builtin");
-                    writeBytes(hasher, @tagName(owner));
+                    try sink.writeBytes("builtin");
+                    try sink.writeBytes(@tagName(owner));
                 } else {
-                    writeBytes(hasher, "not-builtin");
+                    try sink.writeBytes("not-builtin");
                 }
-                self.writeCachedTypeSpanDigest(name_store, hasher, named.args, named_mode, ctx, stats);
-                if (named_mode == .full) {
-                    self.writeCachedNamedBackingDigest(name_store, hasher, named.backing, ctx, stats);
-                    self.writeCachedDeclaredOrderDigest(name_store, hasher, named.declared_order, ctx, stats);
-                } else if (specializationUsesBacking(named.backing)) {
-                    writeBytes(hasher, "specialization-generated-backing");
-                    self.writeCachedNamedBackingDigest(name_store, hasher, named.backing, ctx, stats);
-                } else {
-                    writeBytes(hasher, "specialization-named-identity");
+                try self.encodeTypeSpan(sink, named.args, mode);
+                switch (mode) {
+                    .full => {
+                        try encodeNamedBacking(sink, named.backing);
+                        try self.encodeDeclaredOrder(name_store, sink, named.declared_order);
+                    },
+                    .identity_only => if (specializationUsesBacking(named.backing)) {
+                        try sink.writeBytes("specialization-generated-backing");
+                        try encodeNamedBacking(sink, named.backing);
+                    } else {
+                        try sink.writeBytes("specialization-named-identity");
+                    },
                 }
             },
             .record => |fields| {
-                writeBytes(hasher, "record");
+                try sink.writeBytes("record");
                 const field_slice = self.fieldSpan(fields);
-                writeU32(hasher, @intCast(field_slice.len));
+                try sink.writeU32(@intCast(field_slice.len));
                 for (0..field_slice.len) |index| {
                     const field = GuardedList.at(field_slice, index);
-                    writeBytes(hasher, name_store.recordFieldLabelText(field.name));
-                    writeFieldDefaultDigest(name_store, hasher, field.default);
-                    writeBytes(hasher, @tagName(field.kind_state));
+                    try sink.writeBytes(name_store.recordFieldLabelText(field.name));
+                    try sinkFieldDefault(sink, name_store, field.default);
+                    try sink.writeBytes(@tagName(field.kind_state));
                     if (field.value_ty) |value_ty| {
-                        writeBytes(hasher, "field-optional-value");
-                        self.writeCachedChildDigest(name_store, hasher, value_ty, named_mode, ctx, stats);
+                        try sink.writeBytes("field-optional-value");
+                        try sink.child(value_ty, mode);
                     } else {
-                        writeBytes(hasher, "field-inline-value");
+                        try sink.writeBytes("field-inline-value");
                     }
-                    self.writeCachedChildDigest(name_store, hasher, field.ty, named_mode, ctx, stats);
+                    try sink.child(field.ty, mode);
                 }
             },
             .tuple => |items| {
-                writeBytes(hasher, "tuple");
-                self.writeCachedTypeSpanDigest(name_store, hasher, items, named_mode, ctx, stats);
+                try sink.writeBytes("tuple");
+                try self.encodeTypeSpan(sink, items, mode);
             },
             .tag_union => |tags| {
-                writeBytes(hasher, "tag_union");
+                try sink.writeBytes("tag_union");
                 const tag_slice = self.tagSpan(tags);
-                writeU32(hasher, @intCast(tag_slice.len));
+                try sink.writeU32(@intCast(tag_slice.len));
                 for (0..tag_slice.len) |index| {
                     const tag = GuardedList.at(tag_slice, index);
-                    writeBytes(hasher, name_store.tagLabelText(tag.name));
-                    self.writeCachedTypeSpanDigest(name_store, hasher, tag.payloads, named_mode, ctx, stats);
+                    try sink.writeBytes(name_store.tagLabelText(tag.name));
+                    try sink.writeBytes(name_store.tagLabelText(tag.checked_name));
+                    try self.encodeTypeSpan(sink, tag.payloads, mode);
                 }
             },
             .list => |elem| {
-                writeBytes(hasher, "list");
-                self.writeCachedChildDigest(name_store, hasher, elem, named_mode, ctx, stats);
+                try sink.writeBytes("list");
+                try sink.child(elem, mode);
             },
             .box => |elem| {
-                writeBytes(hasher, "box");
-                self.writeCachedChildDigest(name_store, hasher, elem, named_mode, ctx, stats);
+                try sink.writeBytes("box");
+                try sink.child(elem, mode);
             },
             .func => |function| {
-                writeBytes(hasher, "func");
-                self.writeCachedTypeSpanDigest(name_store, hasher, function.args, named_mode, ctx, stats);
-                self.writeCachedChildDigest(name_store, hasher, function.ret, named_mode, ctx, stats);
+                try sink.writeBytes("func");
+                try self.encodeTypeSpan(sink, function.args, mode);
+                try sink.child(function.ret, mode);
             },
             .erased => |erased| {
-                writeBytes(hasher, "erased");
-                hasher.update(&erased.bytes);
+                try sink.writeBytes("erased");
+                try sink.writeBytes(&erased.bytes);
             },
-            .zst => writeBytes(hasher, "zst"),
+            .zst => try sink.writeBytes("zst"),
         }
     }
 
-    fn writeCachedNamedBackingDigest(
-        self: *Store,
-        name_store: *const names.NameStore,
-        hasher: *std.crypto.hash.sha2.Sha256,
-        backing: ?NamedBacking,
-        ctx: *CachedDigestContext,
-        stats: ?*DigestStats,
-    ) void {
-        writeBytes(hasher, "backing");
-        if (backing) |named_backing| {
-            writeBytes(hasher, @tagName(named_backing.use));
-            writeBytes(hasher, @tagName(named_backing.authority));
-            self.writeCachedChildDigest(name_store, hasher, named_backing.ty, .full, ctx, stats);
-        } else {
-            writeBytes(hasher, "none");
+    fn encodeTypeSpan(
+        self: *const Store,
+        sink: anytype,
+        span_: Span,
+        mode: NamedDigestMode,
+    ) std.mem.Allocator.Error!void {
+        const values = self.span(span_);
+        try sink.writeU32(@intCast(values.len));
+        for (0..values.len) |index| {
+            try sink.child(GuardedList.at(values, index), mode);
         }
     }
 
-    fn writeCachedDeclaredOrderDigest(
-        self: *Store,
+    fn encodeDeclaredOrder(
+        self: *const Store,
         name_store: *const names.NameStore,
-        hasher: *std.crypto.hash.sha2.Sha256,
+        sink: anytype,
         declared_order: Span,
-        ctx: *CachedDigestContext,
-        stats: ?*DigestStats,
-    ) void {
-        writeBytes(hasher, "declared_order");
+    ) std.mem.Allocator.Error!void {
+        try sink.writeBytes("declared_order");
         const entries = self.declaredFieldSpan(declared_order);
-        writeU32(hasher, @intCast(entries.len));
+        try sink.writeU32(@intCast(entries.len));
         for (0..entries.len) |index| {
-            const entry = GuardedList.at(entries, index);
-            switch (entry) {
+            switch (GuardedList.at(entries, index)) {
                 .named => |field_name| {
-                    writeBytes(hasher, "named");
-                    writeBytes(hasher, name_store.recordFieldLabelText(field_name));
+                    try sink.writeBytes("named");
+                    try sink.writeBytes(name_store.recordFieldLabelText(field_name));
                 },
                 .padding => |padding_ty| {
-                    writeBytes(hasher, "padding");
-                    self.writeCachedChildDigest(name_store, hasher, padding_ty, .full, ctx, stats);
+                    try sink.writeBytes("padding");
+                    try sink.child(padding_ty, .full);
                 },
             }
         }
     }
 
-    /// Hash the fields that identify which named type this node is, excluding
-    /// its arguments and backing. Two nodes agreeing here and on their
-    /// arguments denote the same named type, because a named type's backing is
-    /// a function of its declaration and arguments.
-    fn writeNamedIdentityHead(
-        name_store: *const names.NameStore,
-        hasher: *std.crypto.hash.sha2.Sha256,
-        named: NamedContent,
-    ) void {
-        hasher.update(&named.named_type.module.bytes);
-        writeBytes(hasher, name_store.moduleIdentityBytes(named.def.module));
-        writeOptionalU32(hasher, named.def.source_decl);
-        if (named.def.source_decl == null) {
-            writeBytes(hasher, name_store.typeNameText(named.def.type_name));
-        }
-        writeOptionalDigest(hasher, named.def.generated);
-        writeBytes(hasher, @tagName(named.def.iterator_representation));
-        writeBytes(hasher, @tagName(named.def.iterator_kind));
-        writeU32(hasher, named.def.iterator_depth);
-        writeIteratorTopology(hasher, name_store, named.def.iterator_topology);
-        writeBytes(hasher, @tagName(named.kind));
-        if (named.builtin_owner) |owner| {
-            writeBytes(hasher, "builtin");
-            writeBytes(hasher, @tagName(owner));
-        } else {
-            writeBytes(hasher, "not-builtin");
-        }
-    }
-
-    fn namedIdentityHead(
-        name_store: *const names.NameStore,
-        named: NamedContent,
-    ) [32]u8 {
-        var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-        writeNamedIdentityHead(name_store, &hasher, named);
-        return hasher.finalResult();
-    }
-
-    /// Whether two named nodes denote the same named type at the same
-    /// arguments. Equal argument ids already prove the arguments equal, so that
-    /// check runs first and settles the common case without hashing; arguments
-    /// whose ids differ are decided by their digests, which is the exact
-    /// comparison this store needs because it admits duplicate ids per type.
-    fn namedIdentityMatches(
-        self: *const Store,
-        name_store: *const names.NameStore,
-        lhs: NamedContent,
-        rhs: NamedContent,
-        rhs_head: [32]u8,
-    ) bool {
-        const lhs_args = self.span(lhs.args);
-        const rhs_args = self.span(rhs.args);
-        if (lhs_args.len != rhs_args.len) return false;
-        if (!std.mem.eql(u8, &namedIdentityHead(name_store, lhs), &rhs_head)) return false;
-        for (0..lhs_args.len) |index| {
-            const lhs_arg = GuardedList.at(lhs_args, index);
-            const rhs_arg = GuardedList.at(rhs_args, index);
-            if (lhs_arg == rhs_arg) continue;
-            // Both sides digest through the uncached walk even when the caller
-            // is the cached one. The two walks hash by different constructions,
-            // so mixing them here would let the cached and uncached callers
-            // reach different fold decisions and disagree about which types are
-            // the same.
-            const lhs_digest = self.typeDigest(name_store, lhs_arg);
-            const rhs_digest = self.typeDigest(name_store, rhs_arg);
-            if (!std.mem.eql(u8, &lhs_digest.bytes, &rhs_digest.bytes)) return false;
-        }
-        return true;
-    }
-
-    /// Position of an already-open named node denoting the same named type, if
-    /// any. Folding the walk here rather than only on id equality is what makes
-    /// a recursive type's digest independent of how deep its knot is tied: a
-    /// node whose recursive occurrence is a separate but equal node digests the
-    /// same as one whose occurrence is the node itself.
-    fn openNamedCyclePosition(
-        self: *const Store,
-        name_store: *const names.NameStore,
-        node: Content,
-        open: []const TypeId,
-    ) ?usize {
-        if (open.len == 0) return null;
-        if (node != .named) return null;
-        const named = node.named;
-        if (named.kind == .alias) return null;
-        const head = namedIdentityHead(name_store, named);
-        for (open, 0..) |open_ty, position| {
-            const open_content = self.get(open_ty);
-            if (open_content != .named) continue;
-            const open_named = open_content.named;
-            if (open_named.kind == .alias) continue;
-            if (self.namedIdentityMatches(name_store, open_named, named, head)) return position;
-        }
-        return null;
-    }
-
-    fn writeTypeDigest(
-        self: *const Store,
-        name_store: *const names.NameStore,
-        hasher: *std.crypto.hash.sha2.Sha256,
+    /// One digest-request node: a store type digested under one mode. The
+    /// interface mode reaches full-mode nodes through generated backings, so
+    /// the pair is the graph key, not the type id alone.
+    const DigestNode = struct {
         ty: TypeId,
-        visiting: *DigestVisiting,
-        named_mode: NamedDigestMode,
-    ) void {
-        self.requireConstructed(ty);
-        for (visiting.items[0..visiting.len], 0..) |open_ty, position| {
-            if (open_ty == ty) {
-                writeBytes(hasher, "cycle");
-                writeU32(hasher, @intCast(position));
+        mode: NamedDigestMode,
+        label: [32]u8 = undefined,
+        edge_start: u32 = 0,
+        edge_len: u32 = 0,
+        digest: names.TypeDigest = undefined,
+        resolved: bool = false,
+    };
+
+    /// A child reference during digesting: either an already-finalized digest
+    /// or a node of the currently discovered graph.
+    const ChildRef = union(enum) {
+        external: names.TypeDigest,
+        node: u32,
+    };
+
+    /// Graph-canonicalizing digest computation for one requested type.
+    ///
+    /// Discovery walks the uncached reachable subgraph iteratively, pruning
+    /// at children whose digest for the required mode is already cached.
+    /// Iterative Tarjan SCC discovery then resolves the condensation in
+    /// reverse topological order: an acyclic node hashes its encoding with
+    /// finalized child digests, and each cyclic SCC is reduced by
+    /// bisimulation refinement, linearized by the minimum-over-entry-points
+    /// rotation with group-relative back-references, and digested per reduced
+    /// position. Every settled digest is cached unconditionally, and each
+    /// reduced position publishes its one-step unfolding so later rolled-out
+    /// prefixes of the same group fold to the same digests.
+    const DigestEngine = struct {
+        store: *Store,
+        name_store: *const names.NameStore,
+        gpa: std.mem.Allocator,
+        stats: ?*DigestStats,
+        nodes: std.ArrayList(DigestNode),
+        node_lookup: std.AutoHashMap(u64, u32),
+        edge_pool: std.ArrayList(u32),
+        render_buf: std.ArrayList(u8),
+
+        const no_scc_position = std.math.maxInt(u32);
+        const unvisited = std.math.maxInt(u32);
+
+        fn init(store: *Store, name_store: *const names.NameStore, stats: ?*DigestStats) DigestEngine {
+            return .{
+                .store = store,
+                .name_store = name_store,
+                .gpa = store.allocator,
+                .stats = stats,
+                .nodes = .empty,
+                .node_lookup = std.AutoHashMap(u64, u32).init(store.allocator),
+                .edge_pool = .empty,
+                .render_buf = .empty,
+            };
+        }
+
+        fn deinit(self: *DigestEngine) void {
+            self.render_buf.deinit(self.gpa);
+            self.edge_pool.deinit(self.gpa);
+            self.node_lookup.deinit();
+            self.nodes.deinit(self.gpa);
+        }
+
+        fn run(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!names.TypeDigest {
+            const root = try self.internNode(ty, mode);
+            std.debug.assert(root == 0);
+            var next: usize = 0;
+            while (next < self.nodes.items.len) : (next += 1) {
+                try self.labelNode(@intCast(next));
+            }
+            try self.resolveSccs();
+            const root_node = self.nodes.items[root];
+            std.debug.assert(root_node.resolved);
+            return root_node.digest;
+        }
+
+        fn nodeKey(ty: TypeId, mode: NamedDigestMode) u64 {
+            return (@as(u64, @intFromEnum(ty)) << 1) | @as(u64, @intFromEnum(mode));
+        }
+
+        fn internNode(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!u32 {
+            const gop = try self.node_lookup.getOrPut(nodeKey(ty, mode));
+            if (gop.found_existing) return gop.value_ptr.*;
+            const index: u32 = @intCast(self.nodes.items.len);
+            gop.value_ptr.* = index;
+            try self.nodes.append(self.gpa, .{ .ty = ty, .mode = mode });
+            if (self.stats) |s| {
+                s.cache_misses += 1;
+                s.nodes_visited += 1;
+            }
+            return index;
+        }
+
+        /// Classify one child reference during discovery: already-cached
+        /// children participate as finalized digests, everything else becomes
+        /// a node of the discovered graph.
+        fn childRef(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!ChildRef {
+            self.store.requireConstructed(ty);
+            if (self.store.cachedDigest(ty, mode)) |digest| return .{ .external = digest };
+            return .{ .node = try self.internNode(ty, mode) };
+        }
+
+        /// `childRef` for rendering passes after discovery: never grows the
+        /// graph, and nodes this engine already finalized may resolve through
+        /// the store cache with identical bytes.
+        fn resolvedChildRef(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) ChildRef {
+            if (self.store.cachedDigest(ty, mode)) |digest| return .{ .external = digest };
+            return .{
+                .node = self.node_lookup.get(nodeKey(ty, mode)) orelse
+                    Common.invariant("Monotype digest rendering reached a child that discovery never visited"),
+            };
+        }
+
+        fn labelNode(self: *DigestEngine, index: u32) std.mem.Allocator.Error!void {
+            const ty = self.nodes.items[index].ty;
+            const mode = self.nodes.items[index].mode;
+            const edge_start: u32 = @intCast(self.edge_pool.items.len);
+            var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+            const sink = DiscoverySink{ .engine = self, .hasher = &hasher };
+            try self.store.encodeTypeNode(self.name_store, sink, ty, mode);
+            const node = &self.nodes.items[index];
+            node.label = hasher.finalResult();
+            node.edge_start = edge_start;
+            node.edge_len = @intCast(self.edge_pool.items.len - edge_start);
+        }
+
+        fn edgesOf(self: *const DigestEngine, index: u32) []const u32 {
+            const node = self.nodes.items[index];
+            return self.edge_pool.items[node.edge_start..][0..node.edge_len];
+        }
+
+        /// Discovery sink: hashes the node's local label (scalars plus
+        /// finalized external-child digests, with positional markers for
+        /// graph children) while collecting the ordered internal edges.
+        const DiscoverySink = struct {
+            engine: *DigestEngine,
+            hasher: *std.crypto.hash.sha2.Sha256,
+
+            fn writeBytes(self: DiscoverySink, bytes: []const u8) std.mem.Allocator.Error!void {
+                hashBytes(self.hasher, bytes);
+            }
+
+            fn writeU32(self: DiscoverySink, value: u32) std.mem.Allocator.Error!void {
+                hashU32(self.hasher, value);
+            }
+
+            fn child(self: DiscoverySink, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!void {
+                switch (try self.engine.childRef(ty, mode)) {
+                    .external => |digest| {
+                        hashBytes(self.hasher, "external-child");
+                        self.hasher.update(&digest.bytes);
+                        if (self.engine.stats) |s| s.cache_hits += 1;
+                    },
+                    .node => |node_index| {
+                        hashBytes(self.hasher, "node-child");
+                        try self.engine.edge_pool.append(self.engine.gpa, node_index);
+                    },
+                }
+            }
+        };
+
+        /// Group-relative reference context while rendering one cyclic SCC.
+        const SccRenderContext = struct {
+            /// Member position within the SCC per engine node, or
+            /// `no_scc_position` for nodes outside the SCC.
+            member_pos_of_node: []const u32,
+            blocks: []const u32,
+            order_of_block: []const u32,
+        };
+
+        /// Rendering sink: writes the encoding into a byte buffer, resolving
+        /// children to their finalized digests, or to group-relative
+        /// back-references inside a cyclic SCC.
+        const RenderSink = struct {
+            engine: *DigestEngine,
+            out: *std.ArrayList(u8),
+            scc: ?*const SccRenderContext,
+
+            fn writeBytes(self: RenderSink, bytes: []const u8) std.mem.Allocator.Error!void {
+                try renderBytes(self.engine.gpa, self.out, bytes);
+            }
+
+            fn writeU32(self: RenderSink, value: u32) std.mem.Allocator.Error!void {
+                try renderU32(self.engine.gpa, self.out, value);
+            }
+
+            fn child(self: RenderSink, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!void {
+                switch (self.engine.resolvedChildRef(ty, mode)) {
+                    .external => |digest| try self.emitDigest(digest),
+                    .node => |node_index| {
+                        if (self.scc) |ctx| {
+                            const member_pos = ctx.member_pos_of_node[node_index];
+                            if (member_pos != no_scc_position) {
+                                try renderBytes(self.engine.gpa, self.out, "group-ref");
+                                try renderU32(self.engine.gpa, self.out, ctx.order_of_block[ctx.blocks[member_pos]]);
+                                return;
+                            }
+                        }
+                        const node = self.engine.nodes.items[node_index];
+                        std.debug.assert(node.resolved);
+                        try self.emitDigest(node.digest);
+                    },
+                }
+            }
+
+            fn emitDigest(self: RenderSink, digest: names.TypeDigest) std.mem.Allocator.Error!void {
+                try renderBytes(self.engine.gpa, self.out, "type-digest");
+                try renderBytes(self.engine.gpa, self.out, &digest.bytes);
+            }
+        };
+
+        /// Iterative Tarjan SCC discovery. SCCs pop in reverse topological
+        /// order of the condensation, so every edge leaving a popped SCC
+        /// already points at finalized digests and it can resolve on the spot.
+        fn resolveSccs(self: *DigestEngine) std.mem.Allocator.Error!void {
+            const node_count = self.nodes.items.len;
+            const visit_index = try self.gpa.alloc(u32, node_count);
+            defer self.gpa.free(visit_index);
+            @memset(visit_index, unvisited);
+            const low_link = try self.gpa.alloc(u32, node_count);
+            defer self.gpa.free(low_link);
+            const on_stack = try self.gpa.alloc(bool, node_count);
+            defer self.gpa.free(on_stack);
+            @memset(on_stack, false);
+
+            var scc_stack: std.ArrayList(u32) = .empty;
+            defer scc_stack.deinit(self.gpa);
+            const Frame = struct { node: u32, edge_cursor: u32 };
+            var frames: std.ArrayList(Frame) = .empty;
+            defer frames.deinit(self.gpa);
+            var scc_members: std.ArrayList(u32) = .empty;
+            defer scc_members.deinit(self.gpa);
+
+            var next_visit: u32 = 0;
+            for (0..node_count) |start| {
+                if (visit_index[start] != unvisited) continue;
+                visit_index[start] = next_visit;
+                low_link[start] = next_visit;
+                next_visit += 1;
+                try scc_stack.append(self.gpa, @intCast(start));
+                on_stack[start] = true;
+                try frames.append(self.gpa, .{ .node = @intCast(start), .edge_cursor = 0 });
+
+                while (frames.items.len > 0) {
+                    const frame = &frames.items[frames.items.len - 1];
+                    const v = frame.node;
+                    const edges = self.edgesOf(v);
+                    if (frame.edge_cursor < edges.len) {
+                        const w = edges[frame.edge_cursor];
+                        frame.edge_cursor += 1;
+                        if (visit_index[w] == unvisited) {
+                            visit_index[w] = next_visit;
+                            low_link[w] = next_visit;
+                            next_visit += 1;
+                            try scc_stack.append(self.gpa, w);
+                            on_stack[w] = true;
+                            try frames.append(self.gpa, .{ .node = w, .edge_cursor = 0 });
+                        } else if (on_stack[w]) {
+                            low_link[v] = @min(low_link[v], visit_index[w]);
+                        }
+                        continue;
+                    }
+                    _ = frames.pop();
+                    if (frames.items.len > 0) {
+                        const parent = frames.items[frames.items.len - 1].node;
+                        low_link[parent] = @min(low_link[parent], low_link[v]);
+                    }
+                    if (low_link[v] != visit_index[v]) continue;
+                    scc_members.clearRetainingCapacity();
+                    while (true) {
+                        const w = scc_stack.pop() orelse
+                            Common.invariant("Monotype digest SCC stack underflowed");
+                        on_stack[w] = false;
+                        try scc_members.append(self.gpa, w);
+                        if (w == v) break;
+                    }
+                    try self.resolveScc(scc_members.items);
+                }
+            }
+        }
+
+        fn resolveScc(self: *DigestEngine, members: []const u32) std.mem.Allocator.Error!void {
+            if (members.len == 1 and !self.hasSelfEdge(members[0])) {
+                try self.resolveAcyclicNode(members[0]);
                 return;
             }
+            try self.resolveCyclicScc(members);
         }
-        if (self.openNamedCyclePosition(name_store, self.get(ty), visiting.items[0..visiting.len])) |position| {
-            writeBytes(hasher, "cycle");
-            writeU32(hasher, @intCast(position));
-            return;
+
+        fn hasSelfEdge(self: *const DigestEngine, index: u32) bool {
+            for (self.edgesOf(index)) |target| {
+                if (target == index) return true;
+            }
+            return false;
         }
-        if (visiting.len == digest_visiting_max) {
-            // Deeper nesting than the stack tracks cannot contain an
-            // unrecorded cycle shorter than the stack, so digest the type's
-            // identity instead of recursing further.
-            writeBytes(hasher, "deep");
-            writeU32(hasher, @intFromEnum(ty));
-            return;
+
+        fn resolveAcyclicNode(self: *DigestEngine, index: u32) std.mem.Allocator.Error!void {
+            self.render_buf.clearRetainingCapacity();
+            const sink = RenderSink{ .engine = self, .out = &self.render_buf, .scc = null };
+            const node = self.nodes.items[index];
+            try self.store.encodeTypeNode(self.name_store, sink, node.ty, node.mode);
+            var digest: names.TypeDigest = .{ .bytes = sha256Of(self.render_buf.items) };
+            // An acyclic store node whose one-step rendering matches a known
+            // recursive-group unfolding is a rolled-out prefix of the same
+            // infinite type: same label, and children digest-equal to the
+            // member's children. It adopts the member's digest so knot depth
+            // cannot influence identity.
+            if (self.store.recursive_digest_unfoldings.get(digest.bytes)) |member_digest| {
+                digest = member_digest;
+            }
+            self.finalizeNode(index, digest);
         }
-        visiting.items[visiting.len] = ty;
-        visiting.len += 1;
-        defer visiting.len -= 1;
-        switch (self.get(ty)) {
-            .primitive => |primitive| {
-                writeBytes(hasher, "primitive");
-                writeBytes(hasher, @tagName(primitive));
-            },
-            .named => |named| {
-                // Aliases are transparent: their digest is their backing's.
-                if (named.kind == .alias) {
-                    const backing = named.backing orelse {
-                        writeBytes(hasher, "alias-without-backing");
-                        return;
-                    };
-                    self.writeTypeDigest(name_store, hasher, backing.ty, visiting, named_mode);
-                    return;
-                }
-                writeBytes(hasher, "named");
-                hasher.update(&named.named_type.module.bytes);
-                writeBytes(hasher, name_store.moduleIdentityBytes(named.def.module));
-                writeOptionalU32(hasher, named.def.source_decl);
-                if (named.def.source_decl == null) {
-                    writeBytes(hasher, name_store.typeNameText(named.def.type_name));
-                }
-                writeOptionalDigest(hasher, named.def.generated);
-                writeBytes(hasher, @tagName(named.def.iterator_representation));
-                writeBytes(hasher, @tagName(named.def.iterator_kind));
-                writeU32(hasher, named.def.iterator_depth);
-                writeIteratorTopology(hasher, name_store, named.def.iterator_topology);
-                writeBytes(hasher, @tagName(named.kind));
-                if (named.builtin_owner) |owner| {
-                    writeBytes(hasher, "builtin");
-                    writeBytes(hasher, @tagName(owner));
-                } else {
-                    writeBytes(hasher, "not-builtin");
-                }
-                self.writeTypeSpanDigest(name_store, hasher, named.args, visiting, named_mode);
-                if (named_mode == .full) {
-                    self.writeNamedBackingDigest(name_store, hasher, named.backing, visiting);
-                    self.writeDeclaredOrderDigest(name_store, hasher, named.declared_order, visiting);
-                } else if (specializationUsesBacking(named.backing)) {
-                    writeBytes(hasher, "specialization-generated-backing");
-                    self.writeNamedBackingDigest(name_store, hasher, named.backing, visiting);
-                } else {
-                    writeBytes(hasher, "specialization-named-identity");
-                }
-            },
-            .record => |fields| {
-                writeBytes(hasher, "record");
-                const field_slice = self.fieldSpan(fields);
-                writeU32(hasher, @intCast(field_slice.len));
-                for (0..field_slice.len) |index| {
-                    const field = GuardedList.at(field_slice, index);
-                    writeBytes(hasher, name_store.recordFieldLabelText(field.name));
-                    writeFieldDefaultDigest(name_store, hasher, field.default);
-                    writeBytes(hasher, @tagName(field.kind_state));
-                    if (field.value_ty) |value_ty| {
-                        writeBytes(hasher, "field-optional-value");
-                        self.writeTypeDigest(name_store, hasher, value_ty, visiting, named_mode);
-                    } else {
-                        writeBytes(hasher, "field-inline-value");
+
+        fn finalizeNode(self: *DigestEngine, index: u32, digest: names.TypeDigest) void {
+            const node = &self.nodes.items[index];
+            std.debug.assert(!node.resolved);
+            node.digest = digest;
+            node.resolved = true;
+            self.store.setCachedDigest(node.ty, node.mode, digest);
+        }
+
+        /// Reduce one cyclic SCC by bisimulation refinement, canonicalize the
+        /// reduced graph with the minimum-over-entry-points rotation, and
+        /// digest every member as its reduced position.
+        fn resolveCyclicScc(self: *DigestEngine, members: []const u32) std.mem.Allocator.Error!void {
+            const member_count = members.len;
+            const member_pos_of_node = try self.gpa.alloc(u32, self.nodes.items.len);
+            defer self.gpa.free(member_pos_of_node);
+            @memset(member_pos_of_node, no_scc_position);
+            for (members, 0..) |node_index, pos| {
+                member_pos_of_node[node_index] = @intCast(pos);
+            }
+
+            // Refine to the stable bisimulation partition: start from local
+            // labels, then split by the partition identities reached by every
+            // ordered edge (finalized digests for edges leaving the SCC).
+            var blocks = try self.gpa.alloc(u32, member_count);
+            defer self.gpa.free(blocks);
+            var next_blocks = try self.gpa.alloc(u32, member_count);
+            defer self.gpa.free(next_blocks);
+            var block_count: u32 = 0;
+            {
+                var by_label = std.AutoHashMap([32]u8, u32).init(self.gpa);
+                defer by_label.deinit();
+                for (members, 0..) |node_index, pos| {
+                    const gop = try by_label.getOrPut(self.nodes.items[node_index].label);
+                    if (!gop.found_existing) {
+                        gop.value_ptr.* = block_count;
+                        block_count += 1;
                     }
-                    self.writeTypeDigest(name_store, hasher, field.ty, visiting, named_mode);
+                    blocks[pos] = gop.value_ptr.*;
                 }
-            },
-            .tuple => |items| {
-                writeBytes(hasher, "tuple");
-                self.writeTypeSpanDigest(name_store, hasher, items, visiting, named_mode);
-            },
-            .tag_union => |tags| {
-                writeBytes(hasher, "tag_union");
-                const tag_slice = self.tagSpan(tags);
-                writeU32(hasher, @intCast(tag_slice.len));
-                for (0..tag_slice.len) |index| {
-                    const tag = GuardedList.at(tag_slice, index);
-                    writeBytes(hasher, name_store.tagLabelText(tag.name));
-                    self.writeTypeSpanDigest(name_store, hasher, tag.payloads, visiting, named_mode);
+            }
+            while (true) {
+                var by_signature = std.AutoHashMap([32]u8, u32).init(self.gpa);
+                defer by_signature.deinit();
+                var next_count: u32 = 0;
+                for (members, 0..) |node_index, pos| {
+                    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+                    hashU32(&hasher, blocks[pos]);
+                    for (self.edgesOf(node_index)) |target| {
+                        const target_pos = member_pos_of_node[target];
+                        if (target_pos == no_scc_position) {
+                            const target_node = self.nodes.items[target];
+                            std.debug.assert(target_node.resolved);
+                            hashBytes(&hasher, "outside");
+                            hasher.update(&target_node.digest.bytes);
+                        } else {
+                            hashBytes(&hasher, "inside");
+                            hashU32(&hasher, blocks[target_pos]);
+                        }
+                    }
+                    const gop = try by_signature.getOrPut(hasher.finalResult());
+                    if (!gop.found_existing) {
+                        gop.value_ptr.* = next_count;
+                        next_count += 1;
+                    }
+                    next_blocks[pos] = gop.value_ptr.*;
                 }
-            },
-            .list => |elem| {
-                writeBytes(hasher, "list");
-                self.writeTypeDigest(name_store, hasher, elem, visiting, named_mode);
-            },
-            .box => |elem| {
-                writeBytes(hasher, "box");
-                self.writeTypeDigest(name_store, hasher, elem, visiting, named_mode);
-            },
-            .func => |function| {
-                writeBytes(hasher, "func");
-                self.writeTypeSpanDigest(name_store, hasher, function.args, visiting, named_mode);
-                self.writeTypeDigest(name_store, hasher, function.ret, visiting, named_mode);
-            },
-            .erased => |erased| {
-                writeBytes(hasher, "erased");
-                hasher.update(&erased.bytes);
-            },
-            .zst => writeBytes(hasher, "zst"),
-        }
-    }
+                const stable = next_count == block_count;
+                std.mem.swap([]u32, &blocks, &next_blocks);
+                block_count = next_count;
+                if (stable) break;
+            }
 
-    fn writeTypeSpanDigest(
-        self: *const Store,
-        name_store: *const names.NameStore,
-        hasher: *std.crypto.hash.sha2.Sha256,
-        span_: Span,
-        visiting: *DigestVisiting,
-        named_mode: NamedDigestMode,
-    ) void {
-        const values = self.span(span_);
-        writeU32(hasher, @intCast(values.len));
-        for (0..values.len) |index| {
-            const child = GuardedList.at(values, index);
-            self.writeTypeDigest(name_store, hasher, child, visiting, named_mode);
-        }
-    }
+            // Quotient graph: one representative and its ordered in-SCC block
+            // edges per block. The partition is stable, so any member
+            // represents its block.
+            const block_rep = try self.gpa.alloc(u32, block_count);
+            defer self.gpa.free(block_rep);
+            {
+                const filled = try self.gpa.alloc(bool, block_count);
+                defer self.gpa.free(filled);
+                @memset(filled, false);
+                for (members, 0..) |node_index, pos| {
+                    const block = blocks[pos];
+                    if (!filled[block]) {
+                        filled[block] = true;
+                        block_rep[block] = node_index;
+                    }
+                }
+            }
+            var block_edges_pool: std.ArrayList(u32) = .empty;
+            defer block_edges_pool.deinit(self.gpa);
+            const block_edge_start = try self.gpa.alloc(u32, block_count);
+            defer self.gpa.free(block_edge_start);
+            const block_edge_len = try self.gpa.alloc(u32, block_count);
+            defer self.gpa.free(block_edge_len);
+            for (0..block_count) |block| {
+                const start: u32 = @intCast(block_edges_pool.items.len);
+                for (self.edgesOf(block_rep[block])) |target| {
+                    const target_pos = member_pos_of_node[target];
+                    if (target_pos == no_scc_position) continue;
+                    try block_edges_pool.append(self.gpa, blocks[target_pos]);
+                }
+                block_edge_start[block] = start;
+                block_edge_len[block] = @intCast(block_edges_pool.items.len - start);
+            }
 
-    fn writeNamedBackingDigest(
-        self: *const Store,
-        name_store: *const names.NameStore,
-        hasher: *std.crypto.hash.sha2.Sha256,
-        backing: ?NamedBacking,
-        visiting: *DigestVisiting,
-    ) void {
-        writeBytes(hasher, "backing");
-        if (backing) |named_backing| {
-            writeBytes(hasher, @tagName(named_backing.use));
-            writeBytes(hasher, @tagName(named_backing.authority));
-            self.writeTypeDigest(name_store, hasher, named_backing.ty, visiting, .full);
-        } else {
-            writeBytes(hasher, "none");
-        }
-    }
+            // Canonical order: preorder DFS from every entry block, keeping
+            // the lexicographically smallest rendering. The reduced graph has
+            // no two equivalent positions, so the minimum is unique.
+            const order_of_block = try self.gpa.alloc(u32, block_count);
+            defer self.gpa.free(order_of_block);
+            const best_order = try self.gpa.alloc(u32, block_count);
+            defer self.gpa.free(best_order);
+            const DfsFrame = struct { block: u32, edge_cursor: u32 };
+            var dfs: std.ArrayList(DfsFrame) = .empty;
+            defer dfs.deinit(self.gpa);
+            var candidate_order: std.ArrayList(u32) = .empty;
+            defer candidate_order.deinit(self.gpa);
+            var candidate_buf: std.ArrayList(u8) = .empty;
+            defer candidate_buf.deinit(self.gpa);
+            var best_buf: std.ArrayList(u8) = .empty;
+            defer best_buf.deinit(self.gpa);
+            var have_best = false;
 
-    fn writeDeclaredOrderDigest(
-        self: *const Store,
-        name_store: *const names.NameStore,
-        hasher: *std.crypto.hash.sha2.Sha256,
-        declared_order: Span,
-        visiting: *DigestVisiting,
-    ) void {
-        writeBytes(hasher, "declared_order");
-        const entries = self.declaredFieldSpan(declared_order);
-        writeU32(hasher, @intCast(entries.len));
-        for (0..entries.len) |index| {
-            const entry = GuardedList.at(entries, index);
-            switch (entry) {
-                .named => |field_name| {
-                    writeBytes(hasher, "named");
-                    writeBytes(hasher, name_store.recordFieldLabelText(field_name));
-                },
-                .padding => |padding_ty| {
-                    writeBytes(hasher, "padding");
-                    self.writeTypeDigest(name_store, hasher, padding_ty, visiting, .full);
-                },
+            for (0..block_count) |entry| {
+                @memset(order_of_block, no_scc_position);
+                candidate_order.clearRetainingCapacity();
+                dfs.clearRetainingCapacity();
+                order_of_block[entry] = 0;
+                try candidate_order.append(self.gpa, @intCast(entry));
+                try dfs.append(self.gpa, .{ .block = @intCast(entry), .edge_cursor = 0 });
+                while (dfs.items.len > 0) {
+                    const frame = &dfs.items[dfs.items.len - 1];
+                    const edges = block_edges_pool.items[block_edge_start[frame.block]..][0..block_edge_len[frame.block]];
+                    if (frame.edge_cursor >= edges.len) {
+                        _ = dfs.pop();
+                        continue;
+                    }
+                    const target = edges[frame.edge_cursor];
+                    frame.edge_cursor += 1;
+                    if (order_of_block[target] != no_scc_position) continue;
+                    order_of_block[target] = @intCast(candidate_order.items.len);
+                    try candidate_order.append(self.gpa, target);
+                    try dfs.append(self.gpa, .{ .block = target, .edge_cursor = 0 });
+                }
+                if (candidate_order.items.len != block_count) {
+                    Common.invariant("Monotype digest SCC quotient was not strongly connected");
+                }
+
+                candidate_buf.clearRetainingCapacity();
+                const ctx = SccRenderContext{
+                    .member_pos_of_node = member_pos_of_node,
+                    .blocks = blocks,
+                    .order_of_block = order_of_block,
+                };
+                const sink = RenderSink{ .engine = self, .out = &candidate_buf, .scc = &ctx };
+                for (candidate_order.items) |block| {
+                    const rep = self.nodes.items[block_rep[block]];
+                    try self.store.encodeTypeNode(self.name_store, sink, rep.ty, rep.mode);
+                }
+
+                if (have_best) {
+                    // Two entry points rendering identical bytes would be
+                    // bisimilar, contradicting the reduced partition.
+                    std.debug.assert(!std.mem.eql(u8, candidate_buf.items, best_buf.items));
+                }
+                if (!have_best or std.mem.order(u8, candidate_buf.items, best_buf.items) == .lt) {
+                    std.mem.swap(std.ArrayList(u8), &candidate_buf, &best_buf);
+                    @memcpy(best_order, order_of_block);
+                    have_best = true;
+                }
+            }
+
+            // Every reduced position digests as its index in the canonical
+            // group encoding; every original member adopts its position's
+            // digest.
+            const block_digest = try self.gpa.alloc(names.TypeDigest, block_count);
+            defer self.gpa.free(block_digest);
+            for (0..block_count) |block| {
+                var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+                hashBytes(&hasher, "recursive-member");
+                hashU32(&hasher, best_order[block]);
+                hashBytes(&hasher, best_buf.items);
+                block_digest[block] = .{ .bytes = hasher.finalResult() };
+            }
+            for (members, 0..) |node_index, pos| {
+                self.finalizeNode(node_index, block_digest[blocks[pos]]);
+            }
+
+            // Publish each reduced position's one-step unfolding so later
+            // rolled-out prefixes of this group fold to the same digests.
+            // Members are finalized, so a plain rendering resolves in-SCC
+            // children to their new group digests.
+            for (0..block_count) |block| {
+                self.render_buf.clearRetainingCapacity();
+                const sink = RenderSink{ .engine = self, .out = &self.render_buf, .scc = null };
+                const rep = self.nodes.items[block_rep[block]];
+                try self.store.encodeTypeNode(self.name_store, sink, rep.ty, rep.mode);
+                const unfolding = sha256Of(self.render_buf.items);
+                const gop = try self.store.recursive_digest_unfoldings.getOrPut(unfolding);
+                if (gop.found_existing) {
+                    // Canonical group digests are intrinsic, so an equivalent
+                    // group digested earlier must agree.
+                    std.debug.assert(std.mem.eql(u8, &gop.value_ptr.bytes, &block_digest[block].bytes));
+                } else {
+                    gop.value_ptr.* = block_digest[block];
+                }
             }
         }
-    }
+    };
 };
 
 /// How `typeMatches` compares its two sides.
@@ -2550,18 +2755,12 @@ fn assertNoDuplicateTags(name_store: *const names.NameStore, tags_: []const Tag)
     }
 }
 
-fn cycleDigest(position: u32) names.TypeDigest {
-    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    writeBytes(&hasher, "cycle");
-    writeU32(&hasher, position);
-    return .{ .bytes = hasher.finalResult() };
-}
-
-fn deepDigest(ty: TypeId) names.TypeDigest {
-    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    writeBytes(&hasher, "deep");
-    writeU32(&hasher, @intFromEnum(ty));
-    return .{ .bytes = hasher.finalResult() };
+/// Digest queries back deep comparison predicates whose call chains carry no
+/// error path, so allocation failure while building digest traversal state
+/// stops the build with a defined abort in every build mode rather than
+/// threading `OutOfMemory` through every type comparison.
+fn digestOutOfMemory() noreturn {
+    std.debug.panic("out of memory while digesting a Monotype type", .{});
 }
 
 fn writeBytes(hasher: *std.crypto.hash.sha2.Sha256, bytes: []const u8) void {
@@ -2578,40 +2777,88 @@ fn writeU32(hasher: *std.crypto.hash.sha2.Sha256, value: u32) void {
     hasher.update(std.mem.asBytes(&little));
 }
 
-fn writeOptionalU32(hasher: *std.crypto.hash.sha2.Sha256, value: ?u32) void {
-    const present: u8 = if (value == null) 0 else 1;
-    hasher.update(std.mem.asBytes(&present));
-    if (value) |v| writeU32(hasher, v);
+// Digest sinks define `writeBytes`/`writeU32` methods, which shadow the
+// file-scope hasher helpers inside their bodies; these aliases keep the
+// helpers reachable there.
+const hashBytes = writeBytes;
+const hashU32 = writeU32;
+
+fn sha256Of(bytes: []const u8) [32]u8 {
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    hasher.update(bytes);
+    return hasher.finalResult();
 }
 
-fn writeOptionalDigest(hasher: *std.crypto.hash.sha2.Sha256, value: ?names.TypeDigest) void {
-    if (value) |digest| {
-        writeBytes(hasher, "digest");
-        hasher.update(&digest.bytes);
+fn renderU32(gpa: std.mem.Allocator, out: *std.ArrayList(u8), value: u32) std.mem.Allocator.Error!void {
+    const little = std.mem.nativeToLittle(u32, value);
+    try out.appendSlice(gpa, std.mem.asBytes(&little));
+}
+
+fn renderBytes(gpa: std.mem.Allocator, out: *std.ArrayList(u8), bytes: []const u8) std.mem.Allocator.Error!void {
+    try renderU32(gpa, out, @intCast(bytes.len));
+    try out.appendSlice(gpa, bytes);
+}
+
+fn sinkOptionalU32(sink: anytype, value: ?u32) std.mem.Allocator.Error!void {
+    if (value) |v| {
+        try sink.writeBytes("some-u32");
+        try sink.writeU32(v);
     } else {
-        writeBytes(hasher, "no-digest");
+        try sink.writeBytes("no-u32");
     }
 }
 
-fn writeIteratorTopology(
-    hasher: *std.crypto.hash.sha2.Sha256,
+fn sinkOptionalDigest(sink: anytype, value: ?names.TypeDigest) std.mem.Allocator.Error!void {
+    if (value) |digest| {
+        try sink.writeBytes("digest");
+        try sink.writeBytes(&digest.bytes);
+    } else {
+        try sink.writeBytes("no-digest");
+    }
+}
+
+fn sinkIteratorTopology(
+    sink: anytype,
     name_store: *const names.NameStore,
     topology: ?IteratorTopology,
-) void {
+) std.mem.Allocator.Error!void {
     const value = topology orelse {
-        writeBytes(hasher, "no-iterator-topology");
+        try sink.writeBytes("no-iterator-topology");
         return;
     };
-    writeBytes(hasher, "iterator-topology");
-    writeBytes(hasher, name_store.recordFieldLabelText(value.len_field));
-    writeBytes(hasher, name_store.recordFieldLabelText(value.step_field));
-    writeBytes(hasher, name_store.tagLabelText(value.known_tag));
-    writeBytes(hasher, name_store.tagLabelText(value.unknown_tag));
-    writeBytes(hasher, name_store.tagLabelText(value.done_tag));
-    writeBytes(hasher, name_store.tagLabelText(value.one_tag));
-    writeBytes(hasher, name_store.tagLabelText(value.skip_tag));
-    writeBytes(hasher, name_store.recordFieldLabelText(value.item_field));
-    writeBytes(hasher, name_store.recordFieldLabelText(value.rest_field));
+    try sink.writeBytes("iterator-topology");
+    try sink.writeBytes(name_store.recordFieldLabelText(value.len_field));
+    try sink.writeBytes(name_store.recordFieldLabelText(value.step_field));
+    try sink.writeBytes(name_store.tagLabelText(value.known_tag));
+    try sink.writeBytes(name_store.tagLabelText(value.unknown_tag));
+    try sink.writeBytes(name_store.tagLabelText(value.done_tag));
+    try sink.writeBytes(name_store.tagLabelText(value.one_tag));
+    try sink.writeBytes(name_store.tagLabelText(value.skip_tag));
+    try sink.writeBytes(name_store.recordFieldLabelText(value.item_field));
+    try sink.writeBytes(name_store.recordFieldLabelText(value.rest_field));
+}
+
+/// A named backing is a stored type identity, never an interface, so its
+/// child always digests in full mode regardless of the enclosing mode.
+fn encodeNamedBacking(sink: anytype, backing: ?NamedBacking) std.mem.Allocator.Error!void {
+    try sink.writeBytes("backing");
+    if (backing) |named_backing| {
+        try sink.writeBytes(@tagName(named_backing.use));
+        try sink.writeBytes(@tagName(named_backing.authority));
+        try sink.child(named_backing.ty, .full);
+    } else {
+        try sink.writeBytes("none");
+    }
+}
+
+fn sinkFieldDefault(sink: anytype, name_store: *const names.NameStore, default: ?FieldDefault) std.mem.Allocator.Error!void {
+    if (default) |field_default| {
+        try sink.writeBytes("field-default");
+        try sink.writeBytes(name_store.moduleIdentityBytes(field_default.module));
+        try sink.writeU32(field_default.expr_node);
+    } else {
+        try sink.writeBytes("field-no-default");
+    }
 }
 
 fn optionalDigestEql(lhs: ?names.TypeDigest, rhs: ?names.TypeDigest) bool {
@@ -2731,7 +2978,11 @@ test "monotype type interner preserves tag payload order" {
     try std.testing.expectEqual(second, GuardedList.at(stored_payloads, 1));
 }
 
-test "monotype type interner checks exact equality after digest match" {
+test "monotype backing-less aliases digest by their own identity" {
+    // Backing-less aliases used to be the one theoretical digest collision:
+    // every one of them digested as "alias-without-backing". Aliases are now
+    // opaque named nodes, so differently named backing-less aliases carry
+    // distinct digests and stay distinct interner entries.
     var name_store = names.NameStore.init(std.testing.allocator);
     defer name_store.deinit();
 
@@ -2757,7 +3008,7 @@ test "monotype type interner checks exact equality after digest match" {
 
     const first_digest = interner.typeDigest(first);
     const second_digest = interner.typeDigest(second);
-    try std.testing.expectEqualSlices(u8, first_digest.bytes[0..], second_digest.bytes[0..]);
+    try std.testing.expect(!std.mem.eql(u8, first_digest.bytes[0..], second_digest.bytes[0..]));
     try std.testing.expect(first != second);
 }
 
@@ -3280,7 +3531,11 @@ test "monotype type equality accepts isomorphic recursive structural types" {
     try std.testing.expect(!try store.typeEql(&name_store, rec_a, rec_c));
 }
 
-test "monotype digest treats aliases as their backing" {
+test "monotype digest keeps aliases opaque" {
+    // Aliases survive into later IR as observable nodes, so their digests are
+    // their own: a nickname is not the same stored identity as its backing,
+    // and not the same as an equally named nominal either. Structural
+    // equality still unwraps aliases; only the content identity is opaque.
     var name_store = names.NameStore.init(std.testing.allocator);
     defer name_store.deinit();
 
@@ -3310,8 +3565,27 @@ test "monotype digest treats aliases as their backing" {
     const str_digest = store.typeDigest(&name_store, str);
     const alias_digest = store.typeDigest(&name_store, aliased);
     const nominal_digest = store.typeDigest(&name_store, nominal);
-    try std.testing.expect(std.mem.eql(u8, str_digest.bytes[0..], alias_digest.bytes[0..]));
+    try std.testing.expect(!std.mem.eql(u8, str_digest.bytes[0..], alias_digest.bytes[0..]));
     try std.testing.expect(!std.mem.eql(u8, str_digest.bytes[0..], nominal_digest.bytes[0..]));
+    try std.testing.expect(!std.mem.eql(u8, alias_digest.bytes[0..], nominal_digest.bytes[0..]));
+
+    // Alias-over-nominal is likewise distinct from the nominal it wraps.
+    const alias_over_nominal = try store.add(.{ .named = .{
+        .named_type = .{ .module = .{}, .ty = checked_ty },
+        .def = .{ .module = module_identity, .type_name = type_name },
+        .kind = .alias,
+        .args = Span.empty(),
+        .backing = .{ .ty = nominal, .use = .inspectable },
+    } });
+    const alias_over_nominal_digest = store.typeDigest(&name_store, alias_over_nominal);
+    try std.testing.expect(!std.mem.eql(u8, alias_over_nominal_digest.bytes[0..], nominal_digest.bytes[0..]));
+    try std.testing.expect(!std.mem.eql(u8, alias_over_nominal_digest.bytes[0..], alias_digest.bytes[0..]));
+
+    // Structural equality still unwraps aliases; only content identity is
+    // opaque, so alias-vs-backing is the deliberate one-way exception to
+    // "structurally equal implies digest equal".
+    try std.testing.expect(try store.typeEql(&name_store, str, aliased));
+    try std.testing.expect(try store.typeEql(&name_store, nominal, alias_over_nominal));
 }
 
 test "monotype type equality treats aliases as their backing" {
@@ -3406,7 +3680,7 @@ test "monotype type equality compares exact types across stores" {
     try std.testing.expect(!try typeEqlAcrossStores(allocator, &name_store, current.view(), current_fn, loaded_durable, loaded_record));
 }
 
-test "monotype type equality rejects digest-equal aliases without backing" {
+test "monotype type equality and digests separate aliases without backing" {
     var name_store = names.NameStore.init(std.testing.allocator);
     defer name_store.deinit();
 
@@ -3434,7 +3708,7 @@ test "monotype type equality rejects digest-equal aliases without backing" {
 
     const first_digest = store.typeDigest(&name_store, first);
     const second_digest = store.typeDigest(&name_store, second);
-    try std.testing.expect(std.mem.eql(u8, first_digest.bytes[0..], second_digest.bytes[0..]));
+    try std.testing.expect(!std.mem.eql(u8, first_digest.bytes[0..], second_digest.bytes[0..]));
     try std.testing.expect(!try store.typeEql(&name_store, first, second));
 }
 
@@ -3649,6 +3923,177 @@ test "monotype named type digest includes declared field order" {
     const ab_digest = store.typeDigest(&name_store, named_ab);
     const ba_digest = store.typeDigest(&name_store, named_ba);
     try std.testing.expect(!std.mem.eql(u8, ab_digest.bytes[0..], ba_digest.bytes[0..]));
+
+    // The interface digest intentionally omits declared field order: both
+    // orders may share a specialization.
+    const ab_spec = store.specializationDigest(&name_store, named_ab);
+    const ba_spec = store.specializationDigest(&name_store, named_ba);
+    try std.testing.expect(std.mem.eql(u8, ab_spec.bytes[0..], ba_spec.bytes[0..]));
+}
+
+test "monotype digest folds a recursive knot beyond depth 300 into its unrolling" {
+    // A cycle of 350 box nodes and a self-box denote the same infinite type.
+    // The old depth-256 slot-index fallback would have made the long cycle's
+    // digest depend on its ids; graph canonicalization reduces both to the
+    // same one-node quotient.
+    var name_store = names.NameStore.init(std.testing.allocator);
+    defer name_store.deinit();
+
+    var store = Store.init(std.testing.allocator);
+    defer store.deinit();
+
+    var chain: [350]TypeId = undefined;
+    for (&chain) |*id| id.* = try store.reserveSlot();
+    for (chain, 0..) |id, index| {
+        store.fillReservedSlot(id, .{ .box = chain[(index + 1) % chain.len] });
+    }
+    const knot = try store.reserveSlot();
+    store.fillReservedSlot(knot, .{ .box = knot });
+
+    const chain_digest = store.typeDigest(&name_store, chain[0]);
+    const knot_digest = store.typeDigest(&name_store, knot);
+    try std.testing.expectEqualSlices(u8, chain_digest.bytes[0..], knot_digest.bytes[0..]);
+    // Every position of the long cycle is equivalent to every other.
+    const mid_digest = store.typeDigest(&name_store, chain[137]);
+    try std.testing.expectEqualSlices(u8, chain_digest.bytes[0..], mid_digest.bytes[0..]);
+}
+
+test "monotype digest equates bisimilar recursive graphs of different sizes" {
+    var name_store = names.NameStore.init(std.testing.allocator);
+    defer name_store.deinit();
+
+    var store = Store.init(std.testing.allocator);
+    defer store.deinit();
+
+    const x = try store.reserveSlot();
+    const y = try store.reserveSlot();
+    store.fillReservedSlot(x, .{ .list = y });
+    store.fillReservedSlot(y, .{ .list = x });
+    const z = try store.reserveSlot();
+    store.fillReservedSlot(z, .{ .list = z });
+
+    const x_digest = store.typeDigest(&name_store, x);
+    const z_digest = store.typeDigest(&name_store, z);
+    try std.testing.expectEqualSlices(u8, x_digest.bytes[0..], z_digest.bytes[0..]);
+
+    // Equivalent positions inside one SCC receive equal digests.
+    const y_digest = store.typeDigest(&name_store, y);
+    try std.testing.expectEqualSlices(u8, x_digest.bytes[0..], y_digest.bytes[0..]);
+
+    // A rolled-out prefix built after the knot's digest was cached folds to
+    // the member digest through the store's unfolding index.
+    const prefix = try store.add(.{ .list = z });
+    const prefix_digest = store.typeDigest(&name_store, prefix);
+    try std.testing.expectEqualSlices(u8, z_digest.bytes[0..], prefix_digest.bytes[0..]);
+}
+
+test "monotype digest separates tag unions by checked name" {
+    var name_store = names.NameStore.init(std.testing.allocator);
+    defer name_store.deinit();
+
+    var store = Store.init(std.testing.allocator);
+    defer store.deinit();
+
+    const runtime_name = try name_store.internTagLabel("Runtime");
+    const first_checked = try name_store.internTagLabel("FirstChecked");
+    const second_checked = try name_store.internTagLabel("SecondChecked");
+
+    const first = try store.add(.{ .tag_union = try store.addTags(&.{
+        .{ .name = runtime_name, .checked_name = first_checked, .payloads = Span.empty() },
+    }) });
+    const second = try store.add(.{ .tag_union = try store.addTags(&.{
+        .{ .name = runtime_name, .checked_name = second_checked, .payloads = Span.empty() },
+    }) });
+
+    const first_digest = store.typeDigest(&name_store, first);
+    const second_digest = store.typeDigest(&name_store, second);
+    try std.testing.expect(!std.mem.eql(u8, first_digest.bytes[0..], second_digest.bytes[0..]));
+    const first_spec = store.specializationDigest(&name_store, first);
+    const second_spec = store.specializationDigest(&name_store, second);
+    try std.testing.expect(!std.mem.eql(u8, first_spec.bytes[0..], second_spec.bytes[0..]));
+}
+
+test "monotype digest separates named types by checked type id" {
+    // `named_type.ty` survives into `ConstStore` and is later used to
+    // re-enter the checked store, so it is part of the identity.
+    var name_store = names.NameStore.init(std.testing.allocator);
+    defer name_store.deinit();
+
+    var store = Store.init(std.testing.allocator);
+    defer store.deinit();
+
+    const module_identity = try name_store.internModuleIdentity(&([_]u8{0xAB} ** 32));
+    const type_name = try name_store.internTypeName("Reentrant");
+
+    const first = try store.add(.{ .named = .{
+        .named_type = .{ .module = .{}, .ty = @enumFromInt(1) },
+        .def = .{ .module = module_identity, .type_name = type_name },
+        .kind = .nominal,
+        .args = Span.empty(),
+    } });
+    const second = try store.add(.{ .named = .{
+        .named_type = .{ .module = .{}, .ty = @enumFromInt(2) },
+        .def = .{ .module = module_identity, .type_name = type_name },
+        .kind = .nominal,
+        .args = Span.empty(),
+    } });
+
+    const first_digest = store.typeDigest(&name_store, first);
+    const second_digest = store.typeDigest(&name_store, second);
+    try std.testing.expect(!std.mem.eql(u8, first_digest.bytes[0..], second_digest.bytes[0..]));
+    const first_spec = store.specializationDigest(&name_store, first);
+    const second_spec = store.specializationDigest(&name_store, second);
+    try std.testing.expect(!std.mem.eql(u8, first_spec.bytes[0..], second_spec.bytes[0..]));
+}
+
+test "monotype full and interface digests use separate domains" {
+    var name_store = names.NameStore.init(std.testing.allocator);
+    defer name_store.deinit();
+
+    var store = Store.init(std.testing.allocator);
+    defer store.deinit();
+
+    const unit = try store.add(.zst);
+    const full = store.typeDigest(&name_store, unit);
+    const interface = store.specializationDigest(&name_store, unit);
+    try std.testing.expect(!std.mem.eql(u8, full.bytes[0..], interface.bytes[0..]));
+}
+
+test "monotype digests are independent of allocation order" {
+    var name_store = names.NameStore.init(std.testing.allocator);
+    defer name_store.deinit();
+
+    var first = Store.init(std.testing.allocator);
+    defer first.deinit();
+    var second = Store.init(std.testing.allocator);
+    defer second.deinit();
+
+    // First store: knot filled forward, root tuple built directly.
+    const first_str = try first.add(.{ .primitive = .str });
+    const first_x = try first.reserveSlot();
+    const first_y = try first.reserveSlot();
+    first.fillReservedSlot(first_x, .{ .list = first_y });
+    first.fillReservedSlot(first_y, .{ .list = first_x });
+    const first_root = try first.add(.{ .tuple = try first.addSpan(&.{ first_x, first_str }) });
+
+    // Second store: junk ids first, the knot filled in the opposite order,
+    // and the equivalent cycle entered at the other position.
+    _ = try second.add(.{ .primitive = .i64 });
+    _ = try second.add(.zst);
+    const second_y = try second.reserveSlot();
+    const second_x = try second.reserveSlot();
+    second.fillReservedSlot(second_y, .{ .list = second_x });
+    second.fillReservedSlot(second_x, .{ .list = second_y });
+    const second_str = try second.add(.{ .primitive = .str });
+    const second_root = try second.add(.{ .tuple = try second.addSpan(&.{ second_x, second_str }) });
+
+    const first_root_digest = first.typeDigest(&name_store, first_root);
+    const second_root_digest = second.typeDigest(&name_store, second_root);
+    try std.testing.expectEqualSlices(u8, first_root_digest.bytes[0..], second_root_digest.bytes[0..]);
+
+    const first_spec = first.specializationDigest(&name_store, first_root);
+    const second_spec = second.specializationDigest(&name_store, second_root);
+    try std.testing.expectEqualSlices(u8, first_spec.bytes[0..], second_spec.bytes[0..]);
 }
 
 test "monotype named type digest includes padding backing" {

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -314,7 +314,7 @@ pub const Store = struct {
     /// finalized digests, mapped to that member's group digest. An acyclic
     /// node whose rendering matches an entry is a rolled-out prefix of the
     /// same infinite type and adopts the member's digest, which keeps digests
-    /// independent of how deeply a recursive knot is tied — including across
+    /// independent of how deeply a recursive knot is tied—including across
     /// separate digest calls. Keys and values are content-addressed, so
     /// entries stay valid across `restore` truncations and need no rollback.
     recursive_digest_unfoldings: std.AutoHashMap([32]u8, names.TypeDigest),
@@ -639,6 +639,9 @@ pub const Store = struct {
         // A surviving reserved slot may have been filled after the mark with
         // children that are now truncated and whose ids can be reused. Clear
         // every retained containment answer so those new children are walked.
+        // Digest caches need no equivalent clearing only because no caller
+        // digests a mid-transaction fill before its rollback decision; the
+        // unfolding index is content-addressed and stays valid regardless.
         @memset(self.iterator_interface_cache.unsafeRawItemsMutForStore(), null);
         self.iterator_interface_visit_epochs.restoreLen(mark_.iterator_interface_visit_epochs_len);
         self.spans.restoreLen(mark_.spans_len);
@@ -655,12 +658,14 @@ pub const Store = struct {
             .named => |named| if (named.builtin_owner) |owner|
                 .{ .builtin = owner }
             else if (named.kind == .alias)
-                // Aliases are transparent for static dispatch: the owner is the
-                // backing's owner, mirroring the alias-transparent digest path
-                // above. This unwraps alias-over-alias and alias-over-nominal
-                // uniformly (the backing of an alias-over-nominal is itself a
-                // `named` node carrying the nominal's owner). The recursion
-                // terminates because alias chains in checked output are finite.
+                // Aliases are transparent for static dispatch: the owner is
+                // the backing's owner. (Content digests keep aliases opaque;
+                // dispatch is a representation question, so it unwraps.) This
+                // handles alias-over-alias and alias-over-nominal uniformly
+                // (the backing of an alias-over-nominal is itself a `named`
+                // node carrying the nominal's owner). The recursion
+                // terminates because alias chains in checked output are
+                // finite.
                 (if (named.backing) |backing|
                     self.ownerHead(backing.ty)
                 else
@@ -912,11 +917,14 @@ pub const Store = struct {
     ///
     /// Aliases with backing compare as their backing, non-alias named types
     /// compare by named identity and arguments, and structural rows compare by
-    /// label text and ordered children. `typeDigest` matches these rules with
-    /// one deliberate one-way exception: aliases digest as opaque nodes, so an
-    /// alias and its backing are equal here yet digest differently. Equal
-    /// digests still imply equality here; this is the authoritative check
-    /// before one specialization can reuse another.
+    /// label text and ordered children. Equal full digests imply equality
+    /// here—the direction interning relies on. The converse can fail one way:
+    /// aliases digest as opaque nodes (deliberately), and the digest observes
+    /// identity fields this comparison does not (`named_type.ty`,
+    /// `tag.checked_name`, `type_name` under a `source_decl`, checked-public
+    /// backing content), which production constructs consistently for equal
+    /// types. This is the authoritative check before one specialization can
+    /// reuse another.
     pub fn typeEql(
         self: *const Store,
         name_store: *const names.NameStore,
@@ -1231,15 +1239,17 @@ pub const Store = struct {
     const DigestNode = struct {
         ty: TypeId,
         mode: NamedDigestMode,
-        label: [32]u8 = undefined,
-        edge_start: u32 = 0,
-        edge_len: u32 = 0,
+        ref_start: u32 = 0,
+        ref_len: u32 = 0,
         digest: names.TypeDigest = undefined,
         resolved: bool = false,
     };
 
     /// A child reference during digesting: either an already-finalized digest
-    /// or a node of the currently discovered graph.
+    /// or a node of the currently discovered graph. Whether a child arrived as
+    /// a cache hit or as a discovered-then-resolved node must never influence
+    /// digest bytes or partitioning, so every consumer of a `ChildRef` treats
+    /// a resolved node and an external digest identically.
     const ChildRef = union(enum) {
         external: names.TypeDigest,
         node: u32,
@@ -1257,6 +1267,12 @@ pub const Store = struct {
     /// position. Every settled digest is cached unconditionally, and each
     /// reduced position publishes its one-step unfolding so later rolled-out
     /// prefixes of the same group fold to the same digests.
+    ///
+    /// Known conservative incompleteness: per-SCC reduction cannot identify
+    /// an in-SCC position with an equivalent position outside its own SCC, so
+    /// a knot entangled with a separately tied equivalent knot digests apart
+    /// from it (see the "entangled equivalent knots" test). Equal digests
+    /// still always imply structural equality; the miss only costs reuse.
     const DigestEngine = struct {
         store: *Store,
         name_store: *const names.NameStore,
@@ -1264,7 +1280,7 @@ pub const Store = struct {
         stats: ?*DigestStats,
         nodes: std.ArrayList(DigestNode),
         node_lookup: std.AutoHashMap(u64, u32),
-        edge_pool: std.ArrayList(u32),
+        ref_pool: std.ArrayList(ChildRef),
         render_buf: std.ArrayList(u8),
 
         const no_scc_position = std.math.maxInt(u32);
@@ -1278,14 +1294,14 @@ pub const Store = struct {
                 .stats = stats,
                 .nodes = .empty,
                 .node_lookup = std.AutoHashMap(u64, u32).init(store.allocator),
-                .edge_pool = .empty,
+                .ref_pool = .empty,
                 .render_buf = .empty,
             };
         }
 
         fn deinit(self: *DigestEngine) void {
             self.render_buf.deinit(self.gpa);
-            self.edge_pool.deinit(self.gpa);
+            self.ref_pool.deinit(self.gpa);
             self.node_lookup.deinit();
             self.nodes.deinit(self.gpa);
         }
@@ -1295,7 +1311,7 @@ pub const Store = struct {
             std.debug.assert(root == 0);
             var next: usize = 0;
             while (next < self.nodes.items.len) : (next += 1) {
-                try self.labelNode(@intCast(next));
+                try self.collectNode(@intCast(next));
             }
             try self.resolveSccs();
             const root_node = self.nodes.items[root];
@@ -1340,49 +1356,80 @@ pub const Store = struct {
             };
         }
 
-        fn labelNode(self: *DigestEngine, index: u32) std.mem.Allocator.Error!void {
+        fn collectNode(self: *DigestEngine, index: u32) std.mem.Allocator.Error!void {
             const ty = self.nodes.items[index].ty;
             const mode = self.nodes.items[index].mode;
-            const edge_start: u32 = @intCast(self.edge_pool.items.len);
-            var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-            const sink = DiscoverySink{ .engine = self, .hasher = &hasher };
+            const ref_start: u32 = @intCast(self.ref_pool.items.len);
+            const sink = CollectSink{ .engine = self };
             try self.store.encodeTypeNode(self.name_store, sink, ty, mode);
             const node = &self.nodes.items[index];
-            node.label = hasher.finalResult();
-            node.edge_start = edge_start;
-            node.edge_len = @intCast(self.edge_pool.items.len - edge_start);
+            node.ref_start = ref_start;
+            node.ref_len = @intCast(self.ref_pool.items.len - ref_start);
         }
 
-        fn edgesOf(self: *const DigestEngine, index: u32) []const u32 {
+        fn refsOf(self: *const DigestEngine, index: u32) []const ChildRef {
             const node = self.nodes.items[index];
-            return self.edge_pool.items[node.edge_start..][0..node.edge_len];
+            return self.ref_pool.items[node.ref_start..][0..node.ref_len];
         }
 
-        /// Discovery sink: hashes the node's local label (scalars plus
-        /// finalized external-child digests, with positional markers for
-        /// graph children) while collecting the ordered internal edges.
-        const DiscoverySink = struct {
+        /// Discovery sink: collects the node's ordered child references while
+        /// expanding the graph. Scalars are ignored here; they participate
+        /// through the rendering sinks once the graph shape is known.
+        const CollectSink = struct {
+            engine: *DigestEngine,
+
+            fn writeBytes(self: CollectSink, bytes: []const u8) std.mem.Allocator.Error!void {
+                _ = self;
+                _ = bytes;
+            }
+
+            fn writeU32(self: CollectSink, value: u32) std.mem.Allocator.Error!void {
+                _ = self;
+                _ = value;
+            }
+
+            fn child(self: CollectSink, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!void {
+                const ref = try self.engine.childRef(ty, mode);
+                if (ref == .external) {
+                    if (self.engine.stats) |s| s.cache_hits += 1;
+                }
+                try self.engine.ref_pool.append(self.engine.gpa, ref);
+            }
+        };
+
+        /// Initial-partition sink for one cyclic SCC: hashes the member's
+        /// full encoding with every out-of-SCC child rendered as its
+        /// finalized digest and every in-SCC child as a bare positional
+        /// marker. In-SCC identities are refined afterwards; folding them
+        /// into this label would bake discovery order into the partition.
+        const SccLabelSink = struct {
             engine: *DigestEngine,
             hasher: *std.crypto.hash.sha2.Sha256,
+            member_pos_of_node: []const u32,
 
-            fn writeBytes(self: DiscoverySink, bytes: []const u8) std.mem.Allocator.Error!void {
+            fn writeBytes(self: SccLabelSink, bytes: []const u8) std.mem.Allocator.Error!void {
                 hashBytes(self.hasher, bytes);
             }
 
-            fn writeU32(self: DiscoverySink, value: u32) std.mem.Allocator.Error!void {
+            fn writeU32(self: SccLabelSink, value: u32) std.mem.Allocator.Error!void {
                 hashU32(self.hasher, value);
             }
 
-            fn child(self: DiscoverySink, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!void {
-                switch (try self.engine.childRef(ty, mode)) {
+            fn child(self: SccLabelSink, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!void {
+                switch (self.engine.resolvedChildRef(ty, mode)) {
                     .external => |digest| {
-                        hashBytes(self.hasher, "external-child");
+                        hashBytes(self.hasher, "type-digest");
                         self.hasher.update(&digest.bytes);
-                        if (self.engine.stats) |s| s.cache_hits += 1;
                     },
                     .node => |node_index| {
-                        hashBytes(self.hasher, "node-child");
-                        try self.engine.edge_pool.append(self.engine.gpa, node_index);
+                        if (self.member_pos_of_node[node_index] != no_scc_position) {
+                            hashBytes(self.hasher, "in-scc");
+                            return;
+                        }
+                        const node = self.engine.nodes.items[node_index];
+                        std.debug.assert(node.resolved);
+                        hashBytes(self.hasher, "type-digest");
+                        self.hasher.update(&node.digest.bytes);
                     },
                 }
             }
@@ -1473,10 +1520,14 @@ pub const Store = struct {
                 while (frames.items.len > 0) {
                     const frame = &frames.items[frames.items.len - 1];
                     const v = frame.node;
-                    const edges = self.edgesOf(v);
-                    if (frame.edge_cursor < edges.len) {
-                        const w = edges[frame.edge_cursor];
+                    const refs = self.refsOf(v);
+                    if (frame.edge_cursor < refs.len) {
+                        const ref = refs[frame.edge_cursor];
                         frame.edge_cursor += 1;
+                        const w = switch (ref) {
+                            .external => continue,
+                            .node => |node_index| node_index,
+                        };
                         if (visit_index[w] == unvisited) {
                             visit_index[w] = next_visit;
                             low_link[w] = next_visit;
@@ -1517,8 +1568,11 @@ pub const Store = struct {
         }
 
         fn hasSelfEdge(self: *const DigestEngine, index: u32) bool {
-            for (self.edgesOf(index)) |target| {
-                if (target == index) return true;
+            for (self.refsOf(index)) |ref| {
+                switch (ref) {
+                    .external => {},
+                    .node => |target| if (target == index) return true,
+                }
             }
             return false;
         }
@@ -1560,9 +1614,12 @@ pub const Store = struct {
                 member_pos_of_node[node_index] = @intCast(pos);
             }
 
-            // Refine to the stable bisimulation partition: start from local
-            // labels, then split by the partition identities reached by every
-            // ordered edge (finalized digests for edges leaving the SCC).
+            // Refine to the stable bisimulation partition. The initial
+            // partition renders every member with its finalized out-of-SCC
+            // child digests—computed now, not at discovery, so whether a
+            // child arrived cached or was resolved in this run cannot split
+            // bisimilar members. Refinement then splits by the partition
+            // identities reached by every ordered in-SCC reference.
             var blocks = try self.gpa.alloc(u32, member_count);
             defer self.gpa.free(blocks);
             var next_blocks = try self.gpa.alloc(u32, member_count);
@@ -1572,7 +1629,15 @@ pub const Store = struct {
                 var by_label = std.AutoHashMap([32]u8, u32).init(self.gpa);
                 defer by_label.deinit();
                 for (members, 0..) |node_index, pos| {
-                    const gop = try by_label.getOrPut(self.nodes.items[node_index].label);
+                    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+                    const sink = SccLabelSink{
+                        .engine = self,
+                        .hasher = &hasher,
+                        .member_pos_of_node = member_pos_of_node,
+                    };
+                    const node = self.nodes.items[node_index];
+                    try self.store.encodeTypeNode(self.name_store, sink, node.ty, node.mode);
+                    const gop = try by_label.getOrPut(hasher.finalResult());
                     if (!gop.found_existing) {
                         gop.value_ptr.* = block_count;
                         block_count += 1;
@@ -1587,17 +1652,14 @@ pub const Store = struct {
                 for (members, 0..) |node_index, pos| {
                     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
                     hashU32(&hasher, blocks[pos]);
-                    for (self.edgesOf(node_index)) |target| {
+                    for (self.refsOf(node_index)) |ref| {
+                        const target = switch (ref) {
+                            .external => continue,
+                            .node => |node_target| node_target,
+                        };
                         const target_pos = member_pos_of_node[target];
-                        if (target_pos == no_scc_position) {
-                            const target_node = self.nodes.items[target];
-                            std.debug.assert(target_node.resolved);
-                            hashBytes(&hasher, "outside");
-                            hasher.update(&target_node.digest.bytes);
-                        } else {
-                            hashBytes(&hasher, "inside");
-                            hashU32(&hasher, blocks[target_pos]);
-                        }
+                        if (target_pos == no_scc_position) continue;
+                        hashU32(&hasher, blocks[target_pos]);
                     }
                     const gop = try by_signature.getOrPut(hasher.finalResult());
                     if (!gop.found_existing) {
@@ -1637,7 +1699,11 @@ pub const Store = struct {
             defer self.gpa.free(block_edge_len);
             for (0..block_count) |block| {
                 const start: u32 = @intCast(block_edges_pool.items.len);
-                for (self.edgesOf(block_rep[block])) |target| {
+                for (self.refsOf(block_rep[block])) |ref| {
+                    const target = switch (ref) {
+                        .external => continue,
+                        .node => |node_target| node_target,
+                    };
                     const target_pos = member_pos_of_node[target];
                     if (target_pos == no_scc_position) continue;
                     try block_edges_pool.append(self.gpa, blocks[target_pos]);
@@ -3219,9 +3285,9 @@ test "monotype recursive nominal digest ignores how deep the knot is tied" {
 }
 
 test "monotype recursive nominal digest still separates different arguments" {
-    // The unrolling-insensitive fold keys on the nominal's declaration *and*
-    // arguments, so a non-uniformly recursive occurrence at different arguments
-    // must not be folded into its parent.
+    // Unrolling insensitivity must key on the nominal's declaration *and*
+    // arguments: a non-uniformly recursive occurrence at different arguments
+    // is a different type and must not collapse into its parent.
     var name_store = names.NameStore.init(std.testing.allocator);
     defer name_store.deinit();
 
@@ -3985,6 +4051,75 @@ test "monotype digest equates bisimilar recursive graphs of different sizes" {
     const prefix = try store.add(.{ .list = z });
     const prefix_digest = store.typeDigest(&name_store, prefix);
     try std.testing.expectEqualSlices(u8, z_digest.bytes[0..], prefix_digest.bytes[0..]);
+}
+
+test "monotype digest ignores child cachedness inside a recursive group" {
+    // k1 and k2 are equivalent positions of one knot, but k1 references a str
+    // leaf whose digest was cached before the knot was digested while k2
+    // references an uncached duplicate leaf. Whether a child arrived as a
+    // cache hit must not influence the reduced partition: both members share
+    // one digest, equal to an independently tied one-node knot over a third
+    // duplicate leaf.
+    var name_store = names.NameStore.init(std.testing.allocator);
+    defer name_store.deinit();
+
+    var store = Store.init(std.testing.allocator);
+    defer store.deinit();
+
+    const cached_str = try store.add(.{ .primitive = .str });
+    _ = store.typeDigest(&name_store, cached_str);
+    const fresh_str = try store.add(.{ .primitive = .str });
+
+    const k1 = try store.reserveSlot();
+    const k2 = try store.reserveSlot();
+    store.fillReservedSlot(k1, .{ .tuple = try store.addSpan(&.{ k2, cached_str }) });
+    store.fillReservedSlot(k2, .{ .tuple = try store.addSpan(&.{ k1, fresh_str }) });
+
+    const k1_digest = store.typeDigest(&name_store, k1);
+    const k2_digest = store.typeDigest(&name_store, k2);
+    try std.testing.expectEqualSlices(u8, k1_digest.bytes[0..], k2_digest.bytes[0..]);
+
+    const third_str = try store.add(.{ .primitive = .str });
+    const solo = try store.reserveSlot();
+    store.fillReservedSlot(solo, .{ .tuple = try store.addSpan(&.{ solo, third_str }) });
+    const solo_digest = store.typeDigest(&name_store, solo);
+    try std.testing.expectEqualSlices(u8, k1_digest.bytes[0..], solo_digest.bytes[0..]);
+}
+
+test "monotype digest keeps entangled equivalent knots conservatively distinct" {
+    // b1/b2 tie a knot that also points into c, a separately tied knot of the
+    // same infinite type. Per-SCC reduction cannot identify an in-SCC
+    // position with an equivalent position outside its own SCC, so the
+    // members digest apart from c even though all three are structurally
+    // equal. This pins a KNOWN conservative incompleteness: equal digests
+    // still imply structural equality (the direction interning relies on),
+    // and a future whole-graph reduction may intentionally flip the
+    // inequality assertions below.
+    var name_store = names.NameStore.init(std.testing.allocator);
+    defer name_store.deinit();
+
+    var store = Store.init(std.testing.allocator);
+    defer store.deinit();
+
+    const c = try store.reserveSlot();
+    store.fillReservedSlot(c, .{ .tuple = try store.addSpan(&.{ c, c }) });
+    const b1 = try store.reserveSlot();
+    const b2 = try store.reserveSlot();
+    store.fillReservedSlot(b1, .{ .tuple = try store.addSpan(&.{ b2, b1 }) });
+    store.fillReservedSlot(b2, .{ .tuple = try store.addSpan(&.{ b1, c }) });
+
+    try std.testing.expect(try store.typeEql(&name_store, b1, c));
+    try std.testing.expect(try store.typeEql(&name_store, b2, c));
+
+    const c_digest = store.typeDigest(&name_store, c);
+    const b1_digest = store.typeDigest(&name_store, b1);
+    const b2_digest = store.typeDigest(&name_store, b2);
+    try std.testing.expect(!std.mem.eql(u8, b1_digest.bytes[0..], c_digest.bytes[0..]));
+    try std.testing.expect(!std.mem.eql(u8, b2_digest.bytes[0..], c_digest.bytes[0..]));
+
+    // Digests stay stable on repeat queries.
+    const b1_again = store.typeDigest(&name_store, b1);
+    try std.testing.expectEqualSlices(u8, b1_digest.bytes[0..], b1_again.bytes[0..]);
 }
 
 test "monotype digest separates tag unions by checked name" {

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -1062,8 +1062,8 @@ pub const Store = struct {
     }
 
     /// One digest implementation for both modes: serve the request from the
-    /// cache or canonicalize the uncached reachable subgraph and cache every
-    /// digest it settles.
+    /// cache or reduce the uncached reachable subgraph and cache every digest
+    /// it settles.
     fn computeDigest(
         self: *Store,
         name_store: *const names.NameStore,
@@ -1081,14 +1081,15 @@ pub const Store = struct {
         return try engine.run(ty, mode);
     }
 
-    /// Canonical byte encoding of one type node in one digest mode.
+    /// The digest byte encoding of one type node in one digest mode.
     ///
-    /// This is the single source of digest bytes: graph discovery, recursive
-    /// canonicalization, and final digest rendering all replay this encoding
-    /// with different child-reference sinks, so no consumer can observe two
-    /// byte encodings for the same mode. Every node starts with its versioned
-    /// digest domain, then a content-kind discriminator, every non-reference
-    /// value the mode observes, and its ordered typed edges via `sink.child`.
+    /// This is the single source of digest bytes: graph discovery,
+    /// recursive-group reduction, and final digest rendering all replay this
+    /// encoding with different child-reference sinks, so no consumer can
+    /// observe two byte encodings for the same mode. Every node starts with
+    /// its versioned digest domain, then a content-kind discriminator, every
+    /// non-reference value the mode observes, and its ordered typed edges via
+    /// `sink.child`.
     ///
     /// Aliases are opaque named nodes rather than digesting as their backing.
     /// `def.type_name` text is always hashed (also when `source_decl` is
@@ -1239,8 +1240,8 @@ pub const Store = struct {
     const DigestNode = struct {
         ty: TypeId,
         mode: NamedDigestMode,
-        ref_start: u32 = 0,
-        ref_len: u32 = 0,
+        link_start: u32 = 0,
+        link_len: u32 = 0,
         digest: names.TypeDigest = undefined,
         resolved: bool = false,
     };
@@ -1248,14 +1249,14 @@ pub const Store = struct {
     /// A child reference during digesting: either an already-finalized digest
     /// or a node of the currently discovered graph. Whether a child arrived as
     /// a cache hit or as a discovered-then-resolved node must never influence
-    /// digest bytes or partitioning, so every consumer of a `ChildRef` treats
+    /// digest bytes or partitioning, so every consumer of a `ChildLink` treats
     /// a resolved node and an external digest identically.
-    const ChildRef = union(enum) {
+    const ChildLink = union(enum) {
         external: names.TypeDigest,
         node: u32,
     };
 
-    /// Graph-canonicalizing digest computation for one requested type.
+    /// Graph-reducing digest computation for one requested type.
     ///
     /// Discovery walks the uncached reachable subgraph iteratively, pruning
     /// at children whose digest for the required mode is already cached.
@@ -1265,8 +1266,9 @@ pub const Store = struct {
     /// bisimulation refinement, linearized by the minimum-over-entry-points
     /// rotation with group-relative back-references, and digested per reduced
     /// position. Every settled digest is cached unconditionally, and each
-    /// reduced position publishes its one-step unfolding so later rolled-out
-    /// prefixes of the same group fold to the same digests.
+    /// reduced position's one-step unfolding enters the store's unfolding
+    /// index so later rolled-out prefixes of the same group fold to the same
+    /// digests.
     ///
     /// Known conservative incompleteness: per-SCC reduction cannot identify
     /// an in-SCC position with an equivalent position outside its own SCC, so
@@ -1280,7 +1282,7 @@ pub const Store = struct {
         stats: ?*DigestStats,
         nodes: std.ArrayList(DigestNode),
         node_lookup: std.AutoHashMap(u64, u32),
-        ref_pool: std.ArrayList(ChildRef),
+        link_pool: std.ArrayList(ChildLink),
         render_buf: std.ArrayList(u8),
 
         const no_scc_position = std.math.maxInt(u32);
@@ -1294,14 +1296,14 @@ pub const Store = struct {
                 .stats = stats,
                 .nodes = .empty,
                 .node_lookup = std.AutoHashMap(u64, u32).init(store.allocator),
-                .ref_pool = .empty,
+                .link_pool = .empty,
                 .render_buf = .empty,
             };
         }
 
         fn deinit(self: *DigestEngine) void {
             self.render_buf.deinit(self.gpa);
-            self.ref_pool.deinit(self.gpa);
+            self.link_pool.deinit(self.gpa);
             self.node_lookup.deinit();
             self.nodes.deinit(self.gpa);
         }
@@ -1339,16 +1341,16 @@ pub const Store = struct {
         /// Classify one child reference during discovery: already-cached
         /// children participate as finalized digests, everything else becomes
         /// a node of the discovered graph.
-        fn childRef(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!ChildRef {
+        fn childLink(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!ChildLink {
             self.store.requireConstructed(ty);
             if (self.store.cachedDigest(ty, mode)) |digest| return .{ .external = digest };
             return .{ .node = try self.internNode(ty, mode) };
         }
 
-        /// `childRef` for rendering passes after discovery: never grows the
+        /// `childLink` for rendering passes after discovery: never grows the
         /// graph, and nodes this engine already finalized may resolve through
         /// the store cache with identical bytes.
-        fn resolvedChildRef(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) ChildRef {
+        fn resolvedChildLink(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) ChildLink {
             if (self.store.cachedDigest(ty, mode)) |digest| return .{ .external = digest };
             return .{
                 .node = self.node_lookup.get(nodeKey(ty, mode)) orelse
@@ -1359,17 +1361,17 @@ pub const Store = struct {
         fn collectNode(self: *DigestEngine, index: u32) std.mem.Allocator.Error!void {
             const ty = self.nodes.items[index].ty;
             const mode = self.nodes.items[index].mode;
-            const ref_start: u32 = @intCast(self.ref_pool.items.len);
+            const link_start: u32 = @intCast(self.link_pool.items.len);
             const sink = CollectSink{ .engine = self };
             try self.store.encodeTypeNode(self.name_store, sink, ty, mode);
             const node = &self.nodes.items[index];
-            node.ref_start = ref_start;
-            node.ref_len = @intCast(self.ref_pool.items.len - ref_start);
+            node.link_start = link_start;
+            node.link_len = @intCast(self.link_pool.items.len - link_start);
         }
 
-        fn refsOf(self: *const DigestEngine, index: u32) []const ChildRef {
+        fn linksOf(self: *const DigestEngine, index: u32) []const ChildLink {
             const node = self.nodes.items[index];
-            return self.ref_pool.items[node.ref_start..][0..node.ref_len];
+            return self.link_pool.items[node.link_start..][0..node.link_len];
         }
 
         /// Discovery sink: collects the node's ordered child references while
@@ -1378,22 +1380,16 @@ pub const Store = struct {
         const CollectSink = struct {
             engine: *DigestEngine,
 
-            fn writeBytes(self: CollectSink, bytes: []const u8) std.mem.Allocator.Error!void {
-                _ = self;
-                _ = bytes;
-            }
+            fn writeBytes(_: CollectSink, _: []const u8) std.mem.Allocator.Error!void {}
 
-            fn writeU32(self: CollectSink, value: u32) std.mem.Allocator.Error!void {
-                _ = self;
-                _ = value;
-            }
+            fn writeU32(_: CollectSink, _: u32) std.mem.Allocator.Error!void {}
 
             fn child(self: CollectSink, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!void {
-                const ref = try self.engine.childRef(ty, mode);
+                const ref = try self.engine.childLink(ty, mode);
                 if (ref == .external) {
                     if (self.engine.stats) |s| s.cache_hits += 1;
                 }
-                try self.engine.ref_pool.append(self.engine.gpa, ref);
+                try self.engine.link_pool.append(self.engine.gpa, ref);
             }
         };
 
@@ -1416,7 +1412,7 @@ pub const Store = struct {
             }
 
             fn child(self: SccLabelSink, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!void {
-                switch (self.engine.resolvedChildRef(ty, mode)) {
+                switch (self.engine.resolvedChildLink(ty, mode)) {
                     .external => |digest| {
                         hashBytes(self.hasher, "type-digest");
                         self.hasher.update(&digest.bytes);
@@ -1461,7 +1457,7 @@ pub const Store = struct {
             }
 
             fn child(self: RenderSink, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!void {
-                switch (self.engine.resolvedChildRef(ty, mode)) {
+                switch (self.engine.resolvedChildLink(ty, mode)) {
                     .external => |digest| try self.emitDigest(digest),
                     .node => |node_index| {
                         if (self.scc) |ctx| {
@@ -1520,7 +1516,7 @@ pub const Store = struct {
                 while (frames.items.len > 0) {
                     const frame = &frames.items[frames.items.len - 1];
                     const v = frame.node;
-                    const refs = self.refsOf(v);
+                    const refs = self.linksOf(v);
                     if (frame.edge_cursor < refs.len) {
                         const ref = refs[frame.edge_cursor];
                         frame.edge_cursor += 1;
@@ -1568,7 +1564,7 @@ pub const Store = struct {
         }
 
         fn hasSelfEdge(self: *const DigestEngine, index: u32) bool {
-            for (self.refsOf(index)) |ref| {
+            for (self.linksOf(index)) |ref| {
                 switch (ref) {
                     .external => {},
                     .node => |target| if (target == index) return true,
@@ -1602,7 +1598,7 @@ pub const Store = struct {
             self.store.setCachedDigest(node.ty, node.mode, digest);
         }
 
-        /// Reduce one cyclic SCC by bisimulation refinement, canonicalize the
+        /// Reduce one cyclic SCC by bisimulation refinement, linearize the
         /// reduced graph with the minimum-over-entry-points rotation, and
         /// digest every member as its reduced position.
         fn resolveCyclicScc(self: *DigestEngine, members: []const u32) std.mem.Allocator.Error!void {
@@ -1652,7 +1648,7 @@ pub const Store = struct {
                 for (members, 0..) |node_index, pos| {
                     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
                     hashU32(&hasher, blocks[pos]);
-                    for (self.refsOf(node_index)) |ref| {
+                    for (self.linksOf(node_index)) |ref| {
                         const target = switch (ref) {
                             .external => continue,
                             .node => |node_target| node_target,
@@ -1699,7 +1695,7 @@ pub const Store = struct {
             defer self.gpa.free(block_edge_len);
             for (0..block_count) |block| {
                 const start: u32 = @intCast(block_edges_pool.items.len);
-                for (self.refsOf(block_rep[block])) |ref| {
+                for (self.linksOf(block_rep[block])) |ref| {
                     const target = switch (ref) {
                         .external => continue,
                         .node => |node_target| node_target,
@@ -1712,9 +1708,10 @@ pub const Store = struct {
                 block_edge_len[block] = @intCast(block_edges_pool.items.len - start);
             }
 
-            // Canonical order: preorder DFS from every entry block, keeping
-            // the lexicographically smallest rendering. The reduced graph has
-            // no two equivalent positions, so the minimum is unique.
+            // Deterministic order: preorder DFS from every entry block,
+            // keeping the lexicographically smallest rendering. The reduced
+            // graph has no two equivalent positions, so the minimum is
+            // unique.
             const order_of_block = try self.gpa.alloc(u32, block_count);
             defer self.gpa.free(order_of_block);
             const best_order = try self.gpa.alloc(u32, block_count);
@@ -1779,7 +1776,7 @@ pub const Store = struct {
                 }
             }
 
-            // Every reduced position digests as its index in the canonical
+            // Every reduced position digests as its index in the minimum
             // group encoding; every original member adopts its position's
             // digest.
             const block_digest = try self.gpa.alloc(names.TypeDigest, block_count);
@@ -1795,10 +1792,11 @@ pub const Store = struct {
                 self.finalizeNode(node_index, block_digest[blocks[pos]]);
             }
 
-            // Publish each reduced position's one-step unfolding so later
-            // rolled-out prefixes of this group fold to the same digests.
-            // Members are finalized, so a plain rendering resolves in-SCC
-            // children to their new group digests.
+            // Record each reduced position's one-step unfolding in the
+            // store's unfolding index so later rolled-out prefixes of this
+            // group fold to the same digests. Members are finalized, so a
+            // plain rendering resolves in-SCC children to their new group
+            // digests.
             for (0..block_count) |block| {
                 self.render_buf.clearRetainingCapacity();
                 const sink = RenderSink{ .engine = self, .out = &self.render_buf, .scc = null };
@@ -1807,7 +1805,7 @@ pub const Store = struct {
                 const unfolding = sha256Of(self.render_buf.items);
                 const gop = try self.store.recursive_digest_unfoldings.getOrPut(unfolding);
                 if (gop.found_existing) {
-                    // Canonical group digests are intrinsic, so an equivalent
+                    // Reduced-group digests are intrinsic, so an equivalent
                     // group digested earlier must agree.
                     std.debug.assert(std.mem.eql(u8, &gop.value_ptr.bytes, &block_digest[block].bytes));
                 } else {
@@ -3999,8 +3997,8 @@ test "monotype named type digest includes declared field order" {
 
 test "monotype digest folds a recursive knot beyond depth 300 into its unrolling" {
     // A cycle of 350 box nodes and a self-box denote the same infinite type.
-    // The old depth-256 slot-index fallback would have made the long cycle's
-    // digest depend on its ids; graph canonicalization reduces both to the
+    // The deleted depth-256 slot-index digest would have made the long
+    // cycle's digest depend on its ids; graph reduction collapses both to the
     // same one-node quotient.
     var name_store = names.NameStore.init(std.testing.allocator);
     defer name_store.deinit();

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -4289,8 +4289,8 @@ const Subst = struct {
     /// locals that share a binder but were monomorphized at different types are
     /// distinct bindings and must not read one another's substitution. Every
     /// local reference resolves through here, so the digest must come from the
-    /// store's memoized construction (which is why these helpers need the
-    /// program mutable); the uncached walk re-hashes the whole type per call.
+    /// store's memoized construction, which is why these helpers need the
+    /// program mutable.
     fn binderIdentityOf(program: *Ast.Program, local: Ast.LocalId) ?BinderIdentity {
         const local_data = program.getLocal(local);
         const binder = local_data.binder orelse return null;
@@ -12214,6 +12214,10 @@ fn valueType(program: *const Ast.Program, value: Value) Type.TypeId {
 /// the callee's own body) carry different ids and compare by digest. Both
 /// sides digest through the store's memoized construction, which is why this
 /// probe (and everything that reaches it) takes the program mutable.
+///
+/// The full digest treats aliases as opaque, so this deliberately answers
+/// false for an alias-wrapped type against its backing: that can miss an
+/// optimization but can never merge two representations invalidly.
 fn sameType(program: *Ast.Program, lhs: Type.TypeId, rhs: Type.TypeId) bool {
     if (lhs == rhs) return true;
     const lhs_digest = program.types.typeDigestCached(&program.names, lhs, null);

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -9826,6 +9826,13 @@ fn cloneMonoTypeStore(allocator: std.mem.Allocator, source: *const MonoType.Stor
     @memset(iterator_interface_visit_epochs.items, 0);
     cloned.iterator_interface_visit_epochs = @TypeOf(source.iterator_interface_visit_epochs).fromArrayList(iterator_interface_visit_epochs);
     iterator_interface_visit_epochs = .empty;
+    // The unfolding index must travel with the cloned digest caches: a clone
+    // holding cached recursive digests but no unfoldings would digest a new
+    // rolled-out prefix differently from the knot it unrolls.
+    var unfoldings = source.recursive_digest_unfoldings.iterator();
+    while (unfoldings.next()) |entry| {
+        try cloned.recursive_digest_unfoldings.put(entry.key_ptr.*, entry.value_ptr.*);
+    }
     cloned.spans = @TypeOf(source.spans).fromArrayList(try cloneSlice(MonoType.TypeId, allocator, view.spans));
     cloned.fields = @TypeOf(source.fields).fromArrayList(try cloneSlice(MonoType.Field, allocator, view.fields));
     cloned.tags = @TypeOf(source.tags).fromArrayList(try cloneSlice(MonoType.Tag, allocator, view.tags));


### PR DESCRIPTION
Phase 1 of the parallel-specialization plan: Monotype type digests become canonical content identities. Stacked on #10866.

## What changed

**One digest implementation.** The uncached `writeTypeDigest` walk, `deepDigest`, the depth-256 slot-index fallback, cycle-gated cache suppression, and the named-identity fold heuristic are deleted. A single canonical node encoding (`encodeTypeNode`) is replayed by graph discovery, recursive canonicalization, and final rendering through child-reference sinks, so no consumer can observe two byte encodings for the same mode.

**Two versioned digest domains.** Every node encoding starts with its domain: `roc.monotype.type.identity.v1` (full identity, drives future interning) or `roc.monotype.type.interface.v1` (specialization interface, omits exactly declared field order and checked-public backing details). The domains cannot produce byte-confusable answers.

**Missing identity fields.** The encoding now hashes `named_type.ty` (it survives into `ConstStore` and re-enters the checked store), `def.type_name` text always (also when `source_decl` is present), and `tag.checked_name` alongside `tag.name`.

**Alias-opaque encoding.** Aliases digest as opaque named nodes rather than as their backing: they remain observable in later IR, so a nickname is not the same stored identity as its backing. Structural `typeEql` still unwraps aliases; this is the deliberate one-way exception to "structurally equal implies digest-equal" (safe direction preserved: digest-equal still implies structurally equal).

**Recursive graphs, not depth-limited trees.** Digesting discovers the uncached reachable subgraph iteratively (pruning at cached children), runs iterative Tarjan SCCs, and resolves the condensation in reverse topological order. Acyclic nodes hash their encoding over finalized child digests. Each cyclic SCC is reduced by bisimulation refinement (initial partition by local label incl. finalized external-child digests; refined by the partition identities reached by every ordered edge), linearized by the minimum-over-entry-points rotation with group-relative back-references, and digested per reduced position. Equivalent recursive graphs with different node counts get equal digests; equivalent positions inside one SCC get equal digests.

**Eager unconditional caching + prefix folding.** Every settled digest is cached permanently. Each reduced position also publishes its one-step unfolding (its encoding with all children as finalized digests) in a store-level index; an acyclic node whose rendering matches an entry is a rolled-out prefix of the same infinite type and adopts the member's digest. This keeps digests independent of how deeply a recursive knot is tied — including across separate digest calls, which the per-call named-fold used to handle and per-SCC canonicalization alone cannot.

**Consumer treatments (per plan).**
- Generated-iterator identities in `monotype/solve.zig` peel aliases to their backing before digesting, preserving representation-level alias transparency so a nickname cannot duplicate generated iterator machinery.
- `spec_constr.sameType` keeps using the full identity and therefore now treats an alias-wrapped type as different from its backing — conservative: can miss an optimization, can never merge invalidly.

**Cache format.** `FORMAT_VERSION` bumps 11 → 12: every serialized digest byte changes.

**API fallout.** `typeDigest`/`specializationDigest` now take `*Store` (they cache), and `fnTemplateDigest` takes the store mutable. The engine allocates traversal state; since digest queries back deep comparison predicates with no error path (200+ call sites through `sameType`-style helpers), allocation failure aborts with a defined panic in every build mode instead of threading `OutOfMemory` through every type comparison.

## Tests

New unit tests cover the plan's checklist: a recursive knot beyond depth 300 matching a differently unrolled equivalent, bisimilar SCCs with different node counts, equivalent positions inside one SCC, rolled-out prefix folding across cached digest calls, same nominal head with different arguments staying distinct (pre-existing), alias-over-nominal differing from its backing, declared-order discrimination in full mode and omission in interface mode, `checked_name` discrimination, `named_type.ty` discrimination, separate full/interface domains, and deterministic bytes independent of allocation order (across two stores with different insertion orders).

## Validation

- `zig build run-check-snapshots && zig build run-test-zig`: all **4,631 tests pass, zero snapshot changes** (the Phase 1 acceptance gate — even the intentional SpecConstr alias distinction produced no output diffs).
- `zig build run-check-zig-lints` passes; `zig fmt --check` clean on all touched files.
- No interning or scheduler behavior changes in this phase.
