### PR TITLE
Prevent mismatch poisoning inside solver savepoints

### DIFF
--- a/design.md
+++ b/design.md
@@ -1423,6 +1423,16 @@ adopting the redirect destination's descriptor and checked representative; it
 must not directly graft one storage root beneath another and recreate an
 unbounded chain.
 
+A solver savepoint runs only non-poisoning unification. Successful speculative
+relations may be committed in place, but a mismatch returns without poisoning
+either top-level operand so the savepoint owner can roll the relation back.
+Occurrence-directed mismatch poisoning is permanent recovery against the live
+equivalence classes; running it inside a savepoint would both do work whose
+result must be discarded and make correctness depend on the queried
+occurrence's current representative. The commit-probe API fixes the
+non-poisoning behavior for every relation it runs, and ordinary poisoning
+unification asserts that no savepoint is active.
+
 A failed unification is different from a successful class union. Its first
 operand can be one checked occurrence already connected to a shared binding;
 error recovery must poison that exact occurrence without making the binding or

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -4699,17 +4699,22 @@ fn fieldPresenceRelationForContext(
     return if (row_width_relation == .exact) .committed_value else .ordinary;
 }
 
-/// Unify two types with a context for error reporting.
-fn unifyInContext(self: *Self, a: Var, b: Var, env: *Env, ctx: problem.Context) std.mem.Allocator.Error!unifier.Result {
+fn unifyOptionsForContext(ctx: problem.Context, on_mismatch: unifier.MismatchBehavior) unifier.Options {
     const row_width_relation: unifier.RowWidthRelation = if (std.meta.activeTag(ctx) == .platform_requirement)
         .exact
     else
         .construction;
-    return self.runUnify(a, b, env, .{
+    return .{
         .context = ctx,
+        .on_mismatch = on_mismatch,
         .row_width_relation = row_width_relation,
         .field_presence_relation = fieldPresenceRelationForContext(ctx, row_width_relation),
-    });
+    };
+}
+
+/// Unify two types with a context for error reporting.
+fn unifyInContext(self: *Self, a: Var, b: Var, env: *Env, ctx: problem.Context) std.mem.Allocator.Error!unifier.Result {
+    return self.runUnify(a, b, env, unifyOptionsForContext(ctx, .poison_to_err));
 }
 
 fn exprIsFreshRecordConstruction(self: *const Self, expr_idx: CIR.Expr.Idx) bool {
@@ -16250,7 +16255,7 @@ fn checkExpr(self: *Self, expr_idx: CIR.Expr.Idx, env: *Env, expected: Expected)
                     var commit_probe = try self.beginCommitProbe(env);
                     var committed = false;
                     defer if (!committed) commit_probe.rollback();
-                    const result = try self.unify(expected_copy, seed_list_var, env);
+                    const result = try commit_probe.unify(expected_copy, seed_list_var);
                     if (!result.isEstablished()) break :seed null;
                     committed = true;
                     commit_probe.commit();
@@ -22363,13 +22368,12 @@ fn beginProbe(self: *Self, env: ?*Env) std.mem.Allocator.Error!Probe {
 /// throwaway problem/snapshot stores precisely because they never survive), a
 /// commit-probe runs its unifications through the REAL `runUnify` wrapper—full
 /// bookkeeping: fresh vars ranked into the caller env's var pool, regions
-/// stamped, and deferred dispatch constraints copied out. A caller that owns its
-/// mismatch diagnostic uses `.write_no_report`, because occurrence-directed
-/// mismatch poisoning cannot run under a type-store savepoint. On failure the
+/// stamped, and deferred dispatch constraints copied out. Its unification
+/// methods hardcode `.write_no_report`: a failed speculative relation is rolled
+/// back before its caller reports or poisons anything. The ordinary poisoning
+/// wrappers assert if called while this savepoint is active. On failure the
 /// probe must rewind everything that bookkeeping grew:
-///   - problems / snapshots recorded by failed in-probe unifications (the
-///     store savepoint already un-poisons the `.err`-merged vars themselves;
-///     this drops the reports, restoring the throwaway-store behavior);
+///   - problems / snapshots recorded by any other in-probe operation;
 ///   - the caller env's var-pool rank lists (entries for vars the savepoint
 ///     rollback just discarded would dangle into the generalizer);
 ///   - the caller env's deferred dispatch constraints (their receivers and
@@ -22382,6 +22386,14 @@ const CommitProbe = struct {
     extra_strings_len: usize,
     missing_patterns_len: usize,
     snapshots_mark: SnapshotStore.Mark,
+
+    fn unify(self: *CommitProbe, a: Var, b: Var) std.mem.Allocator.Error!unifier.Result {
+        return self.check.runUnify(a, b, self.env, .{ .on_mismatch = .write_no_report });
+    }
+
+    fn unifyInContext(self: *CommitProbe, a: Var, b: Var, ctx: problem.Context) std.mem.Allocator.Error!unifier.Result {
+        return self.check.runUnify(a, b, self.env, unifyOptionsForContext(ctx, .write_no_report));
+    }
 
     fn rollback(self: *CommitProbe) void {
         std.debug.assert(self.check.commit_probe_active);
@@ -23573,7 +23585,7 @@ fn commitLiteralGroupDefault(self: *Self, drivers: []const Var, component_fits: 
                 .quote, .interpolation => try self.freshStr(env, self.getRegionAt(driver)),
             };
             try self.literal_defaulting_candidate_vars.append(self.gpa, candidate_var);
-            const unify_result = try self.unify(driver, candidate_var, env);
+            const unify_result = try commit_probe.unify(driver, candidate_var);
             if (!unify_result.isEstablished()) continue :candidate;
         }
 
@@ -24821,7 +24833,7 @@ fn quoteDefaultSatisfiesConstraints(
     defer commit_probe.rollback();
 
     const candidate_var = try self.freshStr(env, self.getRegionAt(literal_var));
-    const unify_result = try self.unify(literal_var, candidate_var, env);
+    const unify_result = try commit_probe.unify(literal_var, candidate_var);
     if (!unify_result.isEstablished()) return false;
     return try self.candidateSatisfiesRangeConstraints(&commit_probe, constraint_range, candidate_var, env);
 }
@@ -25052,7 +25064,7 @@ fn tryCommitNumeralCandidate(
         env,
         self.getRegionAt(literal_var),
     );
-    const unify_result = try self.unify(literal_var, candidate_var, env);
+    const unify_result = try commit_probe.unify(literal_var, candidate_var);
     if (!unify_result.isEstablished()) return null;
 
     if (!try self.candidateSatisfiesRangeConstraints(&commit_probe, constraint_range, candidate_var, env)) return null;
@@ -25091,12 +25103,11 @@ fn literalInfoAcceptsBuiltinNumKind(lit: StaticDispatchConstraint.LiteralInfo, n
 /// way or the other.
 fn staticDispatchConstraintAcceptsCandidate(
     self: *Self,
-    _: *CommitProbe,
+    probe: *CommitProbe,
     constraint: StaticDispatchConstraint,
     candidate_var: Var,
     env: *Env,
 ) Allocator.Error!bool {
-    // Scope-proof token only; not otherwise consulted.
     const candidate_resolved = self.types.resolveVar(candidate_var);
     const nominal_type = candidate_resolved.desc.content.unwrapNominalType() orelse return false;
     const owner_env, _ = self.ownerEnvForOriginModule(
@@ -25125,7 +25136,7 @@ fn staticDispatchConstraintAcceptsCandidate(
     // path this merge (and its rank/region/deferred-constraint bookkeeping) is
     // kept. The probe owns failure, so a mismatch must not run occurrence-directed
     // poisoning while the store savepoint is active.
-    const result = try self.runUnify(method_var, constraint.fn_var, env, .{ .on_mismatch = .write_no_report });
+    const result = try probe.unify(method_var, constraint.fn_var);
     return result.isEstablished();
 }
 
@@ -26855,7 +26866,15 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
                         },
                     };
                     const fn_result = fn_result: {
-                        if (self.probe_depth != 0 or !self.varIsConflictedDefaultLiteral(deferred_constraint.var_)) {
+                        if (self.probe_depth != 0) {
+                            break :fn_result try self.runUnify(
+                                method_var,
+                                constraint.fn_var,
+                                env,
+                                unifyOptionsForContext(fn_ctx, .write_no_report),
+                            );
+                        }
+                        if (!self.varIsConflictedDefaultLiteral(deferred_constraint.var_)) {
                             break :fn_result try self.unifyInContext(method_var, constraint.fn_var, env, fn_ctx);
                         }
                         // This receiver's type is the documented head default,
@@ -26870,10 +26889,9 @@ fn checkStaticDispatchConstraints(self: *Self, env: *Env, is_numeric_default_pas
                         // never runs under an active savepoint; the problem
                         // and snapshots it records live outside the type store
                         // and survive the rollback. Success commits—a default
-                        // target that satisfies a constraint is real. (Inside
-                        // an enclosing probe the ordinary path is fine: the
-                        // outer speculation never commits a nested dispatch
-                        // failure.)
+                        // target that satisfies a constraint is real. An
+                        // enclosing probe takes the explicit non-poisoning path
+                        // above instead of nesting another savepoint.
                         self.probe_var_pool_lens.clearRetainingCapacity();
                         const rank_count = @intFromEnum(env.rank()) + 1;
                         try self.probe_var_pool_lens.ensureTotalCapacity(self.gpa, rank_count);
@@ -27528,7 +27546,7 @@ fn constrainInterpolationPartToStr(self: *Self, part: InterpolationPartMetadata,
 
         // Keep successful writes for the commit path, but leave mismatch
         // reporting and recovery to this function after the probe rolls back.
-        const result = try self.runUnify(expected_str_var, part.var_, env, .{ .on_mismatch = .write_no_report });
+        const result = try probe.unify(expected_str_var, part.var_);
         if (!result.isEstablished()) break :blk false;
         if (!try self.interpolationPartConstraintsAcceptBuiltinStr(&probe, constraints_range, expected_str_var, env)) {
             break :blk false;
@@ -33449,7 +33467,7 @@ fn checkFlexVarConstraintCompatibility(
             // The mismatch is reported below, after the rollback, against the
             // pristine relation—occurrence-directed poisoning must not run
             // under the savepoint.
-            const result = try self.runUnify(method_var, constraint.fn_var, env, .{ .on_mismatch = .write_no_report });
+            const result = try commit_probe.unify(method_var, constraint.fn_var);
             if (!result.isEstablished()) break :accepted false;
 
             committed = true;
@@ -33616,7 +33634,7 @@ fn checkBranchBodyAgainstExpected(
         var committed = false;
         defer if (!committed) commit_probe.rollback();
 
-        const result = try self.unifyInContext(body_var, acc, env, ctx);
+        const result = try commit_probe.unifyInContext(body_var, acc, ctx);
         if (result.isEstablished()) {
             committed = true;
             commit_probe.commit();

--- a/src/check/mod.zig
+++ b/src/check/mod.zig
@@ -92,6 +92,7 @@ test "check tests" {
     std.testing.refAllDecls(@import("test/repros_test.zig"));
     std.testing.refAllDecls(@import("test/typed_cir_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10338_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10690_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10695_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10759_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10804_test.zig"));

--- a/src/check/test/issue_10690_test.zig
+++ b/src/check/test/issue_10690_test.zig
@@ -1,0 +1,25 @@
+//! Regression test for issue 10690.
+
+const TestEnv = @import("./TestEnv.zig");
+
+test "issue 10690: match branch mismatch through wrapped try reports a type mismatch" {
+    const source =
+        \\wrapped : (Str -> Try(Str, [FetchFailed(Str), ..])), Str -> Try(Str, _)
+        \\wrapped = |fetch, key| {
+        \\    v = fetch(key) ? Wrap
+        \\    Ok(v)
+        \\}
+        \\
+        \\dispatch : (Str -> Try(Str, [FetchFailed(Str), ..])), Str -> Try(Str, _)
+        \\dispatch = |fetch, path|
+        \\    match path {
+        \\        "a" => fetch("x")
+        \\        _ => wrapped(fetch, "y")
+        \\    }
+    ;
+
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+
+    try test_env.assertFirstTypeError("Type Mismatch");
+}

--- a/src/check/unify.zig
+++ b/src/check/unify.zig
@@ -284,6 +284,14 @@ pub fn unify(env: *const Env, a: Var, b: Var, opts: Options) std.mem.Allocator.E
     const trace = tracy.trace(@src());
     defer trace.end();
 
+    // A speculative caller owns rollback and any diagnostic/recovery after the
+    // store is pristine again. Requiring the non-poisoning mode at entry makes
+    // that contract independent of whether this particular relation happens to
+    // mismatch or whether its first operand is a checked representative.
+    if (opts.on_mismatch == .poison_to_err) {
+        env.types.assertNoSavepointActive();
+    }
+
     // First reset the scratch store
     env.unify_scratch.reset();
 

--- a/src/types/store.zig
+++ b/src/types/store.zig
@@ -452,6 +452,13 @@ pub const Store = struct {
         }
     }
 
+    /// Assert that no speculative solver transaction is open. Mismatch
+    /// poisoning is permanent error recovery and must never run speculatively;
+    /// callers that unify under a savepoint use the non-poisoning relation API.
+    pub fn assertNoSavepointActive(self: *const Self) void {
+        std.debug.assert(!self.savepoint_active);
+    }
+
     /// Undo everything done since `savepoint` was created.
     pub fn rollbackToSavepoint(self: *Self, savepoint: *Savepoint) void {
         // Replay journaled in-place writes in reverse so each pre-existing entry


### PR DESCRIPTION
Commit probes now expose only non-poisoning unification, and ordinary poisoning unification asserts that no solver savepoint is active. This lets speculative branch-accumulator mismatches roll back before diagnostic recovery, preventing the panic in #10690 while preserving the single-pass commit-on-success path, and applies the same contract to every commit-probe caller.