### PR TITLE
Fix LSP ownership of cwd in build env

### DIFF
--- a/src/lsp/build_env_handle.zig
+++ b/src/lsp/build_env_handle.zig
@@ -14,6 +14,7 @@ const BuildEnv = compile.BuildEnv;
 pub const BuildEnvHandle = struct {
     allocator: Allocator,
     env: BuildEnv,
+    cwd: [:0]const u8,
     ref_count: usize = 0,
     debug: bool = false,
     owners: std.StringHashMapUnmanaged(usize) = .{},
@@ -22,11 +23,12 @@ pub const BuildEnvHandle = struct {
     document_has_reports: bool = true,
 
     /// Create a new handle with a single owner.
-    pub fn create(allocator: Allocator, env: BuildEnv, owner: []const u8, debug: bool) Allocator.Error!*BuildEnvHandle {
+    pub fn create(allocator: Allocator, env: BuildEnv, cwd: [:0]const u8, owner: []const u8, debug: bool) Allocator.Error!*BuildEnvHandle {
         const handle = try allocator.create(BuildEnvHandle);
         handle.* = .{
             .allocator = allocator,
             .env = env,
+            .cwd = cwd,
             .ref_count = 1,
             .debug = debug,
         };
@@ -92,6 +94,7 @@ pub const BuildEnvHandle = struct {
             }
             self.owners.deinit(self.allocator);
             self.env.deinit();
+            self.allocator.free(self.cwd);
             self.allocator.destroy(self);
         }
     }

--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -562,7 +562,7 @@ pub const SyntaxChecker = struct {
         // Create a fresh BuildEnv. The LSP reuses one pre-published Builtin
         // across checks; each BuildEnv borrows it and never deinitializes it.
         const cwd = try std.Io.Dir.cwd().realPathFileAlloc(self.std_io, ".", self.allocator);
-        defer self.allocator.free(cwd);
+        errdefer self.allocator.free(cwd);
         const builtin_modules = try self.sharedBuiltinModules();
         var env = BuildEnv.initBorrowingBuiltinModules(
             self.allocator,
@@ -583,7 +583,7 @@ pub const SyntaxChecker = struct {
         }
 
         const debug_handles = self.debug.build or self.debug.syntax or self.debug.server;
-        const handle = try BuildEnvHandle.create(self.allocator, env, owner_build, debug_handles);
+        const handle = try BuildEnvHandle.create(self.allocator, env, cwd, owner_build, debug_handles);
         self.build_env = handle;
         return handle;
     }


### PR DESCRIPTION
**Issue:** `BuildEnv` borrows `cwd`, but cwd was cleaned up by the end of the scope. Potential use-after-free?
**Fix:** make `BuildEnvHandle` own `cwd`.