### PR TITLE
Fully reset previous_build_env

### DIFF
--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -549,6 +549,7 @@ pub const SyntaxChecker = struct {
         // Release the previous_build_env owner first.
         if (self.previous_build_env) |old_prev| {
             old_prev.release(owner_previous);
+            self.previous_build_env = null;
         }
 
         // Move build_env to previous_build_env, transferring ownership tag.


### PR DESCRIPTION
Current issue:
1) If an error/OOM happens when setting up a new build, `previous_build_env` stays pointing to already released build env
2) When next time LSP tries a new build, it tries to release the `previous_build_env` again