### PR TITLE
Fix phantom where-alias argument failing to unify

### DIFF
--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -11960,7 +11960,14 @@ fn collectAnnotationTypeAnnos(
                     }
                     try pending.append(allocator, method.ret);
                 },
-                .w_alias, .w_malformed => {},
+                // A where alias reference's arguments are generated in place
+                // (`generateWhereAliasReferenceArgs`), so its node tree must be
+                // reset like any other. This matters when an argument's rigid
+                // var occurs nowhere else in the annotation: its node is the
+                // primary occurrence, and a stale rigid left behind here fails
+                // to re-unify on the body pass.
+                .w_alias => |alias| try pending.append(allocator, alias.alias),
+                .w_malformed => {},
             }
         }
     }

--- a/src/check/test/where_clause_test.zig
+++ b/src/check/test/where_clause_test.zig
@@ -576,6 +576,26 @@ test "where alias - imported under a module qualifier" {
     try test_env_b.assertLastDefType("a -> Str where [a.to_str : a -> Str]");
 }
 
+test "where alias - phantom alias argument appears nowhere else in the signature" {
+    // The alias argument `b` is pinned by neither the referencing signature's
+    // arguments nor its return type, so the where clause's `b` node is the
+    // rigid var's primary occurrence. The annotation pre-pass must reset that
+    // node along with the rest of the annotation, or the body pass finds a
+    // stale rigid and reports `b` is not `b` (#10884-style phantom alias arg).
+    const source =
+        \\a.Conv(b) : where [a.conv : a -> b]
+        \\
+        \\phantom : a -> {} where [a.Conv(b)]
+        \\phantom = |x| {
+        \\    _ = x.conv()
+        \\    {}
+        \\}
+    ;
+    var test_env = try TestEnv.init("Test", source);
+    defer test_env.deinit();
+    try test_env.assertLastDefType("a -> {} where [a.conv : a -> b]");
+}
+
 test "where alias - parameterized alias substitutes its argument" {
     const source =
         \\a.Encodable(fmt) : where [a.encode : a, fmt -> fmt]


### PR DESCRIPTION
A def annotation using a where alias whose argument is pinned by nothing else in the signature, e.g.

    a.Conv(b) : where [a.conv : a -> b]
    phantom : a -> {} where [a.Conv(b)]

failed with a nonsensical mismatch:

    ── ✗ type mismatch ─
    phantom_alias : a -> {} where [a.Conv(b)]
                                   ^^^^^^^^^
    It has the type:    b
    But you are trying to use it as:    b

The annotation pre-pass (predeclareAnnotatedDefSchemes) generates the annotation, orphan-copies it into a scheme, then resets the annotation's type-anno vars so the body pass regenerates them fresh. collectAnnotationTypeAnnos skipped w_alias clauses, so an alias reference argument whose rigid var occurs nowhere else kept its rigid content from the pre-pass, and the body pass's fresh rigid failed to unify with the stale one. Now the collector walks the alias reference node so its argument nodes are reset too.