### PR TITLE
Add Dict.to_inspect and Set.to_inspect

### DIFF
--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -5649,6 +5649,15 @@ Builtin :: [].{
 			}
 		}
 
+		## Returns a human-readable representation of a [Dict], with keys and values
+		## rendered using [Str.inspect].
+		## ```roc
+		## expect Str.inspect(Dict.from_list([("one", 1.I64), ("two", 2)])) ==
+		## 	"Dict.from_list([(\"one\", 1), (\"two\", 2)])"
+		## ```
+		to_inspect : Dict(k, v) -> Str
+		to_inspect = |dict| "Dict.from_list(${ Str.inspect(dict.to_list()) })"
+
 		## Returns an empty `Dict`.
 		## ```roc
 		## empty_dict = Dict.empty()
@@ -6241,6 +6250,14 @@ Builtin :: [].{
 				Hasher.write_u64(Hasher.write_u64(hasher, List.len(items)), $item_hashes)
 			}
 		}
+
+		## Returns a human-readable representation of a [Set], with items rendered
+		## using [Str.inspect].
+		## ```roc
+		## expect Str.inspect(Set.from_list([1.I64, 2, 3])) == "Set.from_list([1, 2, 3])"
+		## ```
+		to_inspect : Set(a) -> Str
+		to_inspect = |set| "Set.from_list(${ Str.inspect(set.to_list()) })"
 
 		## Creates a new empty `Set`.
 		empty : () -> Set(_item)

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -5656,7 +5656,7 @@ Builtin :: [].{
 		## 	"Dict.from_list([(\"one\", 1), (\"two\", 2)])"
 		## ```
 		to_inspect : Dict(k, v) -> Str
-		to_inspect = |dict| "Dict.from_list(${ Str.inspect(dict.to_list()) })"
+		to_inspect = |dict| "Dict.from_list(${Str.inspect(dict.to_list())})"
 
 		## Returns an empty `Dict`.
 		## ```roc
@@ -6257,7 +6257,7 @@ Builtin :: [].{
 		## expect Str.inspect(Set.from_list([1.I64, 2, 3])) == "Set.from_list([1, 2, 3])"
 		## ```
 		to_inspect : Set(a) -> Str
-		to_inspect = |set| "Set.from_list(${ Str.inspect(set.to_list()) })"
+		to_inspect = |set| "Set.from_list(${Str.inspect(set.to_list())})"
 
 		## Creates a new empty `Set`.
 		empty : () -> Set(_item)

--- a/src/cli/test/fx_test_specs.zig
+++ b/src/cli/test/fx_test_specs.zig
@@ -265,6 +265,11 @@ pub const io_spec_tests = [_]TestSpec{
         .description = "Record inspection",
     },
     .{
+        .roc_file = "test/fx/inspect_dict_set.roc",
+        .io_spec = "1>Set.from_list([1, 2, 3])|1>Dict.from_list([(\"a\", 3), (\"b\", 2)])|1>Set.from_list([])|1>Dict.from_list([])|1>{ labels: Set.from_list([\"red\", \"blue\"]), scores: Dict.from_list([(\"alice\", 10), (\"bob\", 20)]) }",
+        .description = "Dict and Set inspection uses from_list syntax for direct, empty, polymorphic, and nested values",
+    },
+    .{
         .roc_file = "test/fx/inspect_field_only_repro.roc",
         .io_spec = "1>test",
         .description = "Repro: inspect projected string field",

--- a/test/fx/inspect_dict_set.roc
+++ b/test/fx/inspect_dict_set.roc
@@ -1,0 +1,28 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Stdout
+
+inspect_any : a -> Str
+inspect_any = |value| Str.inspect(value)
+
+main! = || {
+	set = Set.from_list([1.I64, 2, 1, 3])
+	Stdout.line!(inspect_any(set))
+
+	dict = Dict.from_list([("a", 1.I64), ("b", 2), ("a", 3)])
+	Stdout.line!(inspect_any(dict))
+
+	empty_set : Set(I64)
+	empty_set = Set.empty()
+	Stdout.line!(inspect_any(empty_set))
+
+	empty_dict : Dict(Str, I64)
+	empty_dict = Dict.empty()
+	Stdout.line!(inspect_any(empty_dict))
+
+	nested = {
+		labels: Set.from_list(["red", "blue"]),
+		scores: Dict.from_list([("alice", 10.I64), ("bob", 20)]),
+	}
+	Stdout.line!(Str.inspect(nested))
+}


### PR DESCRIPTION
This PR implements `to_inspect` for `Dict` and `Set`. Here's what the output looks like:

```
» d = Dict.from_list([("one", 1), ("two", 2)])
assigned `d`
» Str.inspect(d)
"Dict.from_list([(\"one\", 1.0), (\"two\", 2.0)])"
» s = Set.from_list([4, 3, 2, 1])
assigned `s`
» Str.inspect(s)
"Set.from_list([4.0, 3.0, 2.0, 1.0])"
```

Fixes #10890
