### PR TITLE
Use milliseconds consistently in CLI timing breakdowns

### DIFF
--- a/src/cli/progress.zig
+++ b/src/cli/progress.zig
@@ -732,14 +732,14 @@ test "padName pads short names and leaves long names" {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
     try aw.writer.print("[{f}]", .{padName("Parsing")});
-    try testing.expectEqualStrings("[Parsing                     ]", aw.written());
+    try testing.expectEqualStrings("[Parsing                              ]", aw.written());
 }
 
 test "full-width phase name remains separated from its duration" {
     var aw: std.Io.Writer.Allocating = .init(testing.allocator);
     defer aw.deinit();
     try aw.writer.print("{f} {s}", .{ padName("arm64 Instruction Generation"), "4ms" });
-    try testing.expectEqualStrings("arm64 Instruction Generation 4ms", aw.written());
+    try testing.expectEqualStrings("arm64 Instruction Generation          4ms", aw.written());
 }
 
 fn collectStatic(buf: *std.Io.Writer.Allocating, timings_flag: bool) void {

--- a/src/cli/progress.zig
+++ b/src/cli/progress.zig
@@ -50,6 +50,10 @@ const max_subphases: usize = 24;
 const max_counter_groups: usize = 8;
 const max_counters_per_group: usize = 24;
 
+/// Wide enough for at least seven digits, their grouping underscores, and the ms suffix.
+/// This accommodates durations up to tens of minutes (5_999_000ms is just under 100 minutes).
+const min_completed_duration_width: usize = 11;
+
 const spinner_frames = [_][]const u8{
     "\u{280B}", "\u{2819}", "\u{2839}", "\u{2838}", "\u{283C}",
     "\u{2834}", "\u{2826}", "\u{2827}", "\u{2807}", "\u{280F}",
@@ -566,6 +570,7 @@ const DurationStyle = enum {
     final,
 };
 
+/// Format duration as human-readable string.
 /// Format a nanosecond duration into `buf`, returning the written slice.
 fn formatDuration(buf: []u8, ns: u64, style: DurationStyle) []const u8 {
     const total_secs = ns / std.time.ns_per_s;
@@ -596,6 +601,51 @@ fn formatDuration(buf: []u8, ns: u64, style: DurationStyle) []const u8 {
             return std.fmt.bufPrint(buf, "{d:.1}s", .{secs_f}) catch buf[0..0];
         },
     }
+}
+
+/// Format duration as consistent [space padding|grouped number|ms]
+/// Format a nanosecond duration into `buf`, returning the written slice.
+fn formatCompletedRowDuration(buf: []u8, ns: u64) []const u8 {
+    var total_ms = ns / std.time.ns_per_ms;
+    if (ns % std.time.ns_per_ms >= std.time.ns_per_ms / 2) total_ms += 1;
+
+    const digit_count = countDigits(total_ms);
+    const number_length = digit_count + (digit_count - 1) / 3;
+    const content_length = number_length + "ms".len;
+    const output_length = @max(min_completed_duration_width, content_length);
+    if (output_length > buf.len) return buf[0..0];
+
+    const padding_length = output_length - content_length;
+    @memset(buf[0..padding_length], ' ');
+
+    const number_end = padding_length + number_length;
+    var cursor = number_end;
+    var remaining = total_ms;
+    var digits_written: usize = 0;
+    while (digits_written < digit_count) {
+        cursor -= 1;
+        buf[cursor] = '0' + @as(u8, @intCast(remaining % 10));
+        remaining /= 10;
+        digits_written += 1;
+        if (digits_written % 3 == 0 and digits_written < digit_count) {
+            cursor -= 1;
+            buf[cursor] = '_';
+        }
+    }
+
+    @memcpy(buf[number_end .. number_end + "ms".len], "ms");
+
+    return buf[0..output_length];
+}
+
+fn countDigits(value: u64) usize {
+    var remaining = value;
+    var result: usize = 1;
+    while (remaining >= 10) {
+        remaining /= 10;
+        result += 1;
+    }
+    return result;
 }
 
 /// Format `, RSS 123MB - 456MB` for a sampled range, or an empty string when
@@ -663,6 +713,19 @@ test "formatDuration final: ms and seconds" {
     try testing.expectEqualStrings("999ms", formatDuration(&buf, 999 * std.time.ns_per_ms, .final));
     try testing.expectEqualStrings("1.2s", formatDuration(&buf, 1200 * std.time.ns_per_ms, .final));
     try testing.expectEqualStrings("1m 5s", formatDuration(&buf, 65 * std.time.ns_per_s, .final));
+}
+
+test "formatCompletedRowDuration pads and groups milliseconds" {
+    var buf: [32]u8 = undefined;
+    try testing.expectEqualStrings("        0ms", formatCompletedRowDuration(&buf, 100_000));
+    try testing.expectEqualStrings("       12ms", formatCompletedRowDuration(&buf, 12 * std.time.ns_per_ms));
+    try testing.expectEqualStrings("      999ms", formatCompletedRowDuration(&buf, 999_499_999));
+    try testing.expectEqualStrings("    1_000ms", formatCompletedRowDuration(&buf, 999_500_000));
+    try testing.expectEqualStrings("    1_200ms", formatCompletedRowDuration(&buf, 1200 * std.time.ns_per_ms));
+    try testing.expectEqualStrings("   65_000ms", formatCompletedRowDuration(&buf, 65 * std.time.ns_per_s));
+    try testing.expectEqualStrings("  100_500ms", formatCompletedRowDuration(&buf, 100 * std.time.ns_per_s + 500 * std.time.ns_per_ms));
+    try testing.expectEqualStrings("6_000_000ms", formatCompletedRowDuration(&buf, 100 * std.time.ns_per_min));
+    try testing.expectEqualStrings("60_000_000ms", formatCompletedRowDuration(&buf, 1000 * std.time.ns_per_min));
 }
 
 test "padName pads short names and leaves long names" {

--- a/src/cli/progress.zig
+++ b/src/cli/progress.zig
@@ -39,7 +39,7 @@ const default_threshold_ns: u64 = std.time.ns_per_s;
 
 /// Minimum width of the phase-name column. A separator is always emitted after
 /// the padded name so a future longer label cannot run into its duration.
-const name_width: usize = 28;
+const name_width: usize = 37;
 
 /// Maximum number of top-level phases a single operation reports.
 const max_phases: usize = 16;

--- a/src/cli/progress.zig
+++ b/src/cli/progress.zig
@@ -52,7 +52,7 @@ const max_counters_per_group: usize = 24;
 
 /// Wide enough for at least seven digits, their grouping underscores, and the ms suffix.
 /// This accommodates durations up to tens of minutes (5_999_000ms is just under 100 minutes).
-const min_completed_duration_width: usize = 11;
+const min_completed_duration_width: usize = "5_999_000ms".len;
 
 const spinner_frames = [_][]const u8{
     "\u{280B}", "\u{2819}", "\u{2839}", "\u{2838}", "\u{283C}",
@@ -488,12 +488,12 @@ pub const Reporter = struct {
             if (show_parent) {
                 var parent_buf: [32]u8 = undefined;
                 const total = (p.end_ns orelse self.elapsedNs()) - p.start_ns;
-                const parent_dur = formatDuration(&parent_buf, total, .final);
+                const parent_dur = formatCompletedRowDuration(&parent_buf, total);
                 self.writer.print("  {s} {f} {s}{s}\n", .{ check, padName(p.name), parent_dur, mem }) catch {};
             }
             for (p.sub[0..p.sub_len], 0..) |s, sub_index| {
                 var buf: [32]u8 = undefined;
-                const dur = formatDuration(&buf, s.ns, .final);
+                const dur = formatCompletedRowDuration(&buf, s.ns);
                 var sub_mem_buf: [48]u8 = undefined;
                 const sub_range = p.sub_mem[sub_index];
                 const sub_mem = formatMemRange(&sub_mem_buf, sub_range.min, sub_range.max);
@@ -507,7 +507,7 @@ pub const Reporter = struct {
         }
         const total = (p.end_ns orelse self.elapsedNs()) - p.start_ns;
         var buf: [32]u8 = undefined;
-        const dur = formatDuration(&buf, total, .final);
+        const dur = formatCompletedRowDuration(&buf, total);
         self.writer.print("  {s} {f} {s}{s}\n", .{ check, padName(p.name), dur, mem }) catch {};
     }
 
@@ -566,11 +566,11 @@ pub fn writeDuration(writer: *std.Io.Writer, ns: u64) std.Io.Writer.Error!void {
 const DurationStyle = enum {
     /// Whole-second granularity, for the live ticking counter.
     live,
-    /// Sub-second precision, for finished phases.
+    /// Human-friendly formatting with sub-second precision, for finished phases.
     final,
 };
 
-/// Format duration as human-readable string.
+/// Format a duration in human-readable units.
 /// Format a nanosecond duration into `buf`, returning the written slice.
 fn formatDuration(buf: []u8, ns: u64, style: DurationStyle) []const u8 {
     const total_secs = ns / std.time.ns_per_s;
@@ -603,7 +603,7 @@ fn formatDuration(buf: []u8, ns: u64, style: DurationStyle) []const u8 {
     }
 }
 
-/// Format duration as consistent [space padding|grouped number|ms]
+/// Format a duration as rounded, right-aligned, grouped milliseconds.
 /// Format a nanosecond duration into `buf`, returning the written slice.
 fn formatCompletedRowDuration(buf: []u8, ns: u64) []const u8 {
     var total_ms = ns / std.time.ns_per_ms;
@@ -797,7 +797,7 @@ test "static breakdown lists every phase with the timings flag" {
     try testing.expect(std.mem.find(u8, out, "Type Inference") != null);
     try testing.expect(std.mem.find(u8, out, "Compile-Time Evaluation") != null);
     try testing.expect(std.mem.find(u8, out, "Monotype Lowering") != null);
-    try testing.expect(std.mem.find(u8, out, "40ms") != null);
+    try testing.expect(std.mem.find(u8, out, "       40ms") != null);
     try testing.expect(std.mem.find(u8, out, "LIR Passes") != null);
     try testing.expect(std.mem.find(u8, out, "ARC") != null);
     try testing.expect(std.mem.find(u8, out, "Store Results") != null);


### PR DESCRIPTION
Closes #10885

Note that this also changes the `name_width` from 28 to 37 to make everything more aligned. **This is how it looks now:**

```
roc build                            17.7s, peak RSS 391MB
  ✓ Resolving Dependencies                        5ms, RSS 17MB
  ✓ Type Checking                             9_013ms, RSS 17MB - 280MB
      Parsing                                    50ms
      Name Resolution                           142ms
      Type Inference                          2_265ms
  ✓ Compile-Time Evaluation                   6_539ms, RSS 36MB - 79MB
      Monotype Lowering                       4_931ms
      LIR Generation                            326ms
      LIR Passes                                227ms
      ARC                                       322ms
      Static Data                                 3ms
      arm64 Instruction Generation              672ms
      Execution                                  52ms
      Store Results                               0ms
  ✓ Specializing                              6_614ms, RSS 63MB - 391MB
      Monotype Setup                              0ms
      Root + Wrapper Setup                       17ms, RSS 65MB
      Specialization Lookup + Reservation       159ms, RSS 67MB - 83MB
      Dispatch Evidence                         421ms
      Body Graph Setup                           85ms
      Body Traversal + Binding                  411ms
      Body Type Graph                         1_373ms
      Body Call Dispatch                      2_443ms
      Body Draft IR Construction                 14ms
      Body Reachability + Proofs                 27ms
      Body Source Mapping                         3ms
      Body Local Procedure Context                5ms
      Body Sealing + Commit                     171ms
      Procedure Completion                       11ms
      Layout Requests                             0ms
      Static Data Requests                        0ms
      Monotype Finalization                      11ms
      Closure Lifting                            12ms
      SpecConstr                                320ms
      Lambda-Set Solving                        175ms
      Inline Planning                             1ms
      LIR Generation                            310ms
      LIR Passes                                415ms
      ARC                                       224ms
  ✓ Static Data                                   0ms
  ✓ LLVM IR Generation                          402ms
  ✓ LLVM Optimize + Emit                      1_599ms
  ✓ Linking                                      16ms
```

### Alternatives 

The straightforward approach (without touching the `name_width`) worked, but it was a bit ugly with longer names:

```
roc build
  ✓ Resolving Dependencies              10ms, RSS 17MB - 18MB
  ✓ Type Checking                    9_204ms, RSS 17MB - 279MB
      Parsing                           52ms
      Name Resolution                  151ms
      Type Inference                 2_319ms
  ✓ Compile-Time Evaluation          6_661ms, RSS 36MB - 79MB
      Monotype Lowering              5_019ms
      LIR Generation                   342ms
      LIR Passes                       229ms
      ARC                              328ms
      Static Data                        3ms
      arm64 Instruction Generation       681ms
      Execution                         53ms
      Store Results                      1ms
  ✓ Specializing                     6_675ms, RSS 63MB - 391MB
      Monotype Setup                     0ms
      Root + Wrapper Setup              19ms, RSS 65MB
      Specialization Lookup + Reservation       164ms, RSS 67MB - 85MB
      Dispatch Evidence                417ms, RSS 86MB - 136MB
      Body Graph Setup                  84ms, RSS 138MB - 145MB
      Body Traversal + Binding         412ms, RSS 147MB - 199MB
      Body Type Graph                1_369ms, RSS 200MB - 311MB
      Body Call Dispatch             2_449ms, RSS 189MB - 391MB
      Body Draft IR Construction        14ms, RSS 209MB
      Body Reachability + Proofs        27ms, RSS 210MB - 213MB
      Body Source Mapping                3ms
      Body Local Procedure Context         5ms
      Body Sealing + Commit            172ms, RSS 214MB - 241MB
      Procedure Completion              10ms, RSS 234MB
      Layout Requests                    0ms
      Static Data Requests               0ms
      Monotype Finalization             13ms, RSS 189MB
      Closure Lifting                   13ms, RSS 166MB
      SpecConstr                       337ms, RSS 106MB - 116MB
      Lambda-Set Solving               189ms, RSS 114MB - 145MB
      Inline Planning                    1ms
      LIR Generation                   331ms, RSS 98MB - 211MB
      LIR Passes                       417ms, RSS 70MB - 74MB
      ARC                              223ms, RSS 71MB - 89MB
  ✓ Static Data                          0ms, RSS 74MB
  ✓ LLVM IR Generation                 407ms, RSS 74MB - 82MB
  ✓ LLVM Optimize + Emit             1_680ms, RSS 75MB - 119MB
  ✓ Linking                             22ms, RSS 114MB - 118MB
```

I also tried duration first, but it also feels weird:

```
roc build                   17.8s, peak RSS 391MB
  ✓         5ms Resolving Dependencies, RSS 17MB - 18MB
  ✓     9_032ms Type Checking, RSS 18MB - 279MB
           49ms   Parsing
          140ms   Name Resolution
        2_251ms   Type Inference
  ✓     6_575ms Compile-Time Evaluation, RSS 36MB - 79MB
        4_960ms   Monotype Lowering
          332ms   LIR Generation
          227ms   LIR Passes
          321ms   ARC
            3ms   Static Data
          673ms   arm64 Instruction Generation
           52ms   Execution
            0ms   Store Results
  ✓     6_710ms Specializing, RSS 63MB - 391MB
            0ms   Monotype Setup
           19ms   Root + Wrapper Setup, RSS 66MB
          165ms   Specialization Lookup + Reservation
          426ms   Dispatch Evidence
           85ms   Body Graph Setup
          416ms   Body Traversal + Binding
        1_381ms   Body Type Graph
        2_457ms   Body Call Dispatch
           14ms   Body Draft IR Construction
           28ms   Body Reachability + Proofs
            3ms   Body Source Mapping
            5ms   Body Local Procedure Context
          174ms   Body Sealing + Commit
           11ms   Procedure Completion
            0ms   Layout Requests
            0ms   Static Data Requests
           14ms   Monotype Finalization
           13ms   Closure Lifting
          334ms   SpecConstr
          189ms   Lambda-Set Solving
            1ms   Inline Planning
          329ms   LIR Generation
          418ms   LIR Passes
          225ms   ARC
  ✓         0ms Static Data
  ✓       399ms LLVM IR Generation
  ✓     1_611ms LLVM Optimize + Emit
  ✓        18ms Linking
```
