### PR TITLE
Fix compiler regressions exposed by roc-ray migration

### DIFF
--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -2216,6 +2216,7 @@ const Inserter = struct {
                             assign.target,
                             root,
                             assign.next,
+                            segment.ctx.loop_keep,
                         );
                         complete_moved_root = !transfer.retain_target;
                     } else {
@@ -3965,10 +3966,12 @@ const Inserter = struct {
         target: LIR.LocalId,
         root: LIR.LocalId,
         next: LIR.CFStmtId,
+        loop_keep: ?LoopKeep,
     ) ResourceError!AliasBindTransfer {
         const release_old_target = self.takeRebindTarget(owned, target);
         const unit = self.unitOf(root);
-        const root_used = try self.ownershipPlaceUsedInPath(next, unit);
+        const root_used = (loop_keep != null and loop_keep.?.set.contains(unit)) or
+            try self.ownershipPlaceUsedInPath(next, unit);
         const has_unit = owned.contains(unit);
         const restitution = if (root_used)
             try self.completeProjectionRestitution(target, unit, next)
@@ -9725,6 +9728,49 @@ test "RC switch continuation merge releases branch-divergent owner at the bounda
     // the string's unit into the callee, so the merged continuation entry
     // excludes it and the default branch releases it at the boundary.
     try f.expectRc(diverged, 0, 1, 0);
+}
+
+test "RC complete field projection preserves a loop-kept root" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+    const record_layout = try f.layouts.putStructFields(&[_]layout_mod.StructField{
+        .{ .index = 0, .layout = f.list_i64 },
+    });
+    const field = try f.local(f.list_i64);
+    const record = try f.local(record_layout);
+    const state = try f.local(record_layout);
+    const extracted = try f.local(f.list_i64);
+    const appended = try f.local(f.list_i64);
+    const elem = try f.local(.i64);
+
+    const join_id = f.freshJoinPointId();
+    const continue_loop = try f.store.addCFStmt(.loop_continue);
+    const consume = try f.assignLowLevel(
+        appended,
+        &.{ extracted, elem },
+        LIR.LowLevel.RcEffect.consumesArgsReturningConsumedArgsRetainingArgs(1, 0),
+        continue_loop,
+    );
+    const take = try f.assignRefField(extracted, state, 0, consume);
+    const entry = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const initialize_state = try f.setLocal(state, record, .initialize_join_param, entry);
+    const assign_elem = try f.assignI64(elem, 1, initialize_state);
+    const assign_record = try f.assignStruct(record, &.{field}, assign_elem);
+    const remainder = try f.assignList(field, &.{}, assign_record);
+    const body = try f.store.addCFStmt(.{ .join = .{
+        .id = join_id,
+        .params = try f.span(&.{state}),
+        .body = take,
+        .remainder = remainder,
+    } });
+
+    _ = try f.addProc(&.{}, body, .i64);
+    try f.run();
+
+    // The back edge requires the root's unit on the next iteration. The
+    // complete field read therefore retains its target instead of moving
+    // that loop-kept unit away.
+    try f.expectRc(extracted, 1, 0, 0);
 }
 
 test "RC divergent field takes normalize exact residual places on each switch edge" {

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -7892,8 +7892,8 @@ const Builder = struct {
 
     fn sameMonotype(self: *Builder, lhs: Type.TypeId, rhs: Type.TypeId) bool {
         if (lhs == rhs) return true;
-        const lhs_digest = self.program.types.typeDigest(&self.program.names, lhs);
-        const rhs_digest = self.program.types.typeDigest(&self.program.names, rhs);
+        const lhs_digest = self.program.types.equalityDigest(&self.program.names, lhs);
+        const rhs_digest = self.program.types.equalityDigest(&self.program.names, rhs);
         return std.mem.eql(u8, lhs_digest.bytes[0..], rhs_digest.bytes[0..]);
     }
 

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -4321,6 +4321,18 @@ pub const InstGraph = struct {
                     try fields.appendSlice(self.allocator, tail.fields);
                     ext = self.find(tail.ext);
                 },
+                .named => |named| {
+                    const declared_backing = named.backing orelse
+                        Common.invariant("instantiation record row extended into a named type without backing");
+                    if (declared_backing.use != .inspectable) {
+                        Common.invariant("instantiation record row extended into a non-inspectable named type");
+                    }
+                    const backing = try self.structuralBackingNode(declared_backing.node, named);
+                    if (backing.recursive) {
+                        Common.invariant("instantiation record row extended into a recursive named type");
+                    }
+                    ext = self.find(backing.node);
+                },
                 .unresolved, .empty_record => break,
                 .redirect,
                 .primitive,
@@ -4330,7 +4342,6 @@ pub const InstGraph = struct {
                 .func,
                 .tag_union,
                 .empty_tag_union,
-                .named,
                 .erased,
                 .zst,
                 => Common.invariant("instantiation record row extended into a non-record type"),
@@ -7390,6 +7401,47 @@ test "named type relation to its own backing preserves the backing edge" {
     try std.testing.expectEqual(backing, retained.node);
     try std.testing.expectEqual(Type.BackingUse.runtime_layout_only, retained.use);
     try std.testing.expectEqual(@as(usize, 1), (try graph.recordConstructionNodes(named)).fields.len);
+}
+
+test "record row follows an inspectable nominal record extension" {
+    const gpa = std.testing.allocator;
+
+    var type_store = Type.Store.init(gpa);
+    defer type_store.deinit();
+
+    var name_store = names.NameStore.init(gpa);
+    defer name_store.deinit();
+
+    const graph = try InstGraph.create(gpa, &type_store, &name_store);
+    defer graph.destroy();
+
+    const module_identity = try name_store.internModuleIdentity(&([_]u8{0x29} ** 32));
+    const type_name = try name_store.internTypeName("Vec2");
+    const x = try name_store.internRecordFieldLabel("x");
+    const y = try name_store.internRecordFieldLabel("y");
+    const z = try name_store.internRecordFieldLabel("z");
+    const f32_node = try graph.newNode(.{ .primitive = .f32 });
+    const empty = try graph.newNode(.empty_record);
+    const backing_fields = try graph.arena().dupe(InstField, &.{
+        .{ .name = x, .ty = f32_node, .default = null },
+        .{ .name = y, .ty = f32_node, .default = null },
+    });
+    const backing = try graph.newNode(.{ .record = .{ .fields = backing_fields, .ext = empty } });
+    const nominal = try graph.newNode(.{ .named = .{
+        .named_type = .{ .module = .{}, .ty = testCheckedTypeId(1) },
+        .def = .{ .module = module_identity, .type_name = type_name },
+        .kind = .nominal,
+        .builtin_owner = null,
+        .args = try graph.arena().alloc(NodeId, 0),
+        .backing = .{ .node = backing, .use = .inspectable },
+    } });
+    const outer_fields = try graph.arena().dupe(InstField, &.{.{ .name = z, .ty = f32_node, .default = null }});
+    const outer = try graph.newNode(.{ .record = .{ .fields = outer_fields, .ext = nominal } });
+
+    const flattened = try graph.flattenRecordRow(outer);
+
+    try std.testing.expectEqual(@as(usize, 3), flattened.fields.len);
+    try std.testing.expectEqual(empty, flattened.ext);
 }
 
 test "opaque interface relation preserves forced-dynamic iterator identity" {

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -295,6 +295,7 @@ pub const Store = struct {
     types: StoreList(Content, "types"),
     type_digests: StoreList(?names.TypeDigest, "type_digests"),
     specialization_digests: StoreList(?names.TypeDigest, "specialization_digests"),
+    equality_digests: StoreList(?names.TypeDigest, "equality_digests"),
     /// Newly reserved recursive slots may be referenced while their content is
     /// being built, but they are not observable types until filled. Filled
     /// nodes are immutable, which makes their cached digests permanently valid.
@@ -330,6 +331,7 @@ pub const Store = struct {
             .types = .empty,
             .type_digests = .empty,
             .specialization_digests = .empty,
+            .equality_digests = .empty,
             .constructing = .empty,
             .iterator_interface_cache = .empty,
             .iterator_interface_pending = .empty,
@@ -356,6 +358,7 @@ pub const Store = struct {
         self.iterator_interface_pending.deinit(self.allocator);
         self.iterator_interface_cache.deinit(self.allocator);
         self.constructing.deinit(self.allocator);
+        self.equality_digests.deinit(self.allocator);
         self.specialization_digests.deinit(self.allocator);
         self.type_digests.deinit(self.allocator);
         self.types.deinit(self.allocator);
@@ -425,6 +428,8 @@ pub const Store = struct {
         errdefer _ = self.type_digests.pop();
         try self.specialization_digests.append(self.allocator, null);
         errdefer _ = self.specialization_digests.pop();
+        try self.equality_digests.append(self.allocator, null);
+        errdefer _ = self.equality_digests.pop();
         try self.constructing.append(self.allocator, false);
         errdefer _ = self.constructing.pop();
         try self.iterator_interface_cache.append(self.allocator, null);
@@ -605,6 +610,7 @@ pub const Store = struct {
         types_len: usize,
         type_digests_len: usize,
         specialization_digests_len: usize,
+        equality_digests_len: usize,
         constructing_len: usize,
         iterator_interface_cache_len: usize,
         iterator_interface_visit_epochs_len: usize,
@@ -619,6 +625,7 @@ pub const Store = struct {
             .types_len = self.types.len(),
             .type_digests_len = self.type_digests.len(),
             .specialization_digests_len = self.specialization_digests.len(),
+            .equality_digests_len = self.equality_digests.len(),
             .constructing_len = self.constructing.len(),
             .iterator_interface_cache_len = self.iterator_interface_cache.len(),
             .iterator_interface_visit_epochs_len = self.iterator_interface_visit_epochs.len(),
@@ -634,6 +641,7 @@ pub const Store = struct {
         self.types.restoreLen(mark_.types_len);
         self.type_digests.restoreLen(mark_.type_digests_len);
         self.specialization_digests.restoreLen(mark_.specialization_digests_len);
+        self.equality_digests.restoreLen(mark_.equality_digests_len);
         self.constructing.restoreLen(mark_.constructing_len);
         self.iterator_interface_cache.restoreLen(mark_.iterator_interface_cache_len);
         // A surviving reserved slot may have been filled after the mark with
@@ -692,6 +700,13 @@ pub const Store = struct {
     /// type?".
     pub fn specializationDigest(self: *Store, name_store: *const names.NameStore, ty: TypeId) names.TypeDigest {
         return self.specializationDigestCached(name_store, ty, null);
+    }
+
+    /// Digest of the exact equivalence relation implemented by `typeEql`.
+    /// Unlike the stored-identity digest, this unwraps aliases and omits
+    /// checked-node provenance that does not participate in type equality.
+    pub fn equalityDigest(self: *Store, name_store: *const names.NameStore, ty: TypeId) names.TypeDigest {
+        return self.computeDigest(name_store, ty, .equality, null) catch digestOutOfMemory();
     }
 
     pub const DigestStats = struct {
@@ -886,6 +901,9 @@ pub const Store = struct {
     }
 
     pub fn verify(self: *const Store, name_store: *const names.NameStore) ?VerifyError {
+        if (self.specialization_digests.len() != self.types.len() or self.equality_digests.len() != self.types.len()) {
+            return .type_digest_count_mismatch;
+        }
         return self.view().verify(name_store);
     }
 
@@ -950,6 +968,7 @@ pub const Store = struct {
     const NamedDigestMode = enum {
         full,
         identity_only,
+        equality,
     };
 
     /// Versioned digest-domain prefix written at the start of every node
@@ -960,6 +979,7 @@ pub const Store = struct {
         return switch (mode) {
             .full => "roc.monotype.type.identity.v1",
             .identity_only => "roc.monotype.type.interface.v1",
+            .equality => "roc.monotype.type.equality.v1",
         };
     }
 
@@ -1045,10 +1065,11 @@ pub const Store = struct {
         return switch (mode) {
             .full => self.type_digests.unsafeRawItemsForView()[index],
             .identity_only => self.specialization_digests.unsafeRawItemsForView()[index],
+            .equality => self.equality_digests.unsafeRawItemsForView()[index],
         };
     }
 
-    /// Sole writer of both digest caches. Digests are content-addressed, so a
+    /// Sole writer of the digest caches. Digests are content-addressed, so a
     /// re-write must agree with the existing entry.
     fn setCachedDigest(self: *Store, ty: TypeId, mode: NamedDigestMode, digest: names.TypeDigest) void {
         if (self.cachedDigest(ty, mode)) |existing| {
@@ -1058,10 +1079,22 @@ pub const Store = struct {
         switch (mode) {
             .full => self.type_digests.set(index, digest),
             .identity_only => self.specialization_digests.set(index, digest),
+            .equality => self.equality_digests.set(index, digest),
         }
     }
 
-    /// One digest implementation for both modes: serve the request from the
+    fn digestType(self: *const Store, raw_ty: TypeId, mode: NamedDigestMode) TypeId {
+        if (mode != .equality) return raw_ty;
+        var ty = raw_ty;
+        while (true) {
+            const content = self.get(ty);
+            if (content != .named or content.named.kind != .alias) return ty;
+            const backing = content.named.backing orelse return ty;
+            ty = backing.ty;
+        }
+    }
+
+    /// One digest implementation for every mode: serve the request from the
     /// cache or reduce the uncached reachable subgraph and cache every digest
     /// it settles.
     fn computeDigest(
@@ -1114,10 +1147,12 @@ pub const Store = struct {
             .named => |named| {
                 try sink.writeBytes("named");
                 try sink.writeBytes(&named.named_type.module.bytes);
-                try sink.writeU32(@intFromEnum(named.named_type.ty));
+                if (mode != .equality) try sink.writeU32(@intFromEnum(named.named_type.ty));
                 try sink.writeBytes(name_store.moduleIdentityBytes(named.def.module));
                 try sinkOptionalU32(sink, named.def.source_decl);
-                try sink.writeBytes(name_store.typeNameText(named.def.type_name));
+                if (mode != .equality or named.def.source_decl == null) {
+                    try sink.writeBytes(name_store.typeNameText(named.def.type_name));
+                }
                 try sinkOptionalDigest(sink, named.def.generated);
                 try sink.writeBytes(@tagName(named.def.iterator_representation));
                 try sink.writeBytes(@tagName(named.def.iterator_kind));
@@ -1141,6 +1176,15 @@ pub const Store = struct {
                         try encodeNamedBacking(sink, named.backing);
                     } else {
                         try sink.writeBytes("specialization-named-identity");
+                    },
+                    .equality => if (specializationUsesBacking(named.backing)) {
+                        try sink.writeBytes("equality-generated-backing");
+                        const backing = named.backing orelse unreachable;
+                        try sink.writeBytes(@tagName(backing.use));
+                        try sink.writeBytes(@tagName(backing.authority));
+                        try sink.child(backing.ty, .equality);
+                    } else {
+                        try sink.writeBytes("equality-named-identity");
                     },
                 }
             },
@@ -1173,7 +1217,7 @@ pub const Store = struct {
                 for (0..tag_slice.len) |index| {
                     const tag = GuardedList.at(tag_slice, index);
                     try sink.writeBytes(name_store.tagLabelText(tag.name));
-                    try sink.writeBytes(name_store.tagLabelText(tag.checked_name));
+                    if (mode != .equality) try sink.writeBytes(name_store.tagLabelText(tag.checked_name));
                     try self.encodeTypeSpan(sink, tag.payloads, mode);
                 }
             },
@@ -1309,7 +1353,7 @@ pub const Store = struct {
         }
 
         fn run(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!names.TypeDigest {
-            const root = try self.internNode(ty, mode);
+            const root = try self.internNode(self.store.digestType(ty, mode), mode);
             std.debug.assert(root == 0);
             var next: usize = 0;
             while (next < self.nodes.items.len) : (next += 1) {
@@ -1322,10 +1366,11 @@ pub const Store = struct {
         }
 
         fn nodeKey(ty: TypeId, mode: NamedDigestMode) u64 {
-            return (@as(u64, @intFromEnum(ty)) << 1) | @as(u64, @intFromEnum(mode));
+            return (@as(u64, @intFromEnum(ty)) << 2) | @as(u64, @intFromEnum(mode));
         }
 
-        fn internNode(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!u32 {
+        fn internNode(self: *DigestEngine, raw_ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!u32 {
+            const ty = self.store.digestType(raw_ty, mode);
             const gop = try self.node_lookup.getOrPut(nodeKey(ty, mode));
             if (gop.found_existing) return gop.value_ptr.*;
             const index: u32 = @intCast(self.nodes.items.len);
@@ -1341,7 +1386,8 @@ pub const Store = struct {
         /// Classify one child reference during discovery: already-cached
         /// children participate as finalized digests, everything else becomes
         /// a node of the discovered graph.
-        fn childLink(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!ChildLink {
+        fn childLink(self: *DigestEngine, raw_ty: TypeId, mode: NamedDigestMode) std.mem.Allocator.Error!ChildLink {
+            const ty = self.store.digestType(raw_ty, mode);
             self.store.requireConstructed(ty);
             if (self.store.cachedDigest(ty, mode)) |digest| return .{ .external = digest };
             return .{ .node = try self.internNode(ty, mode) };
@@ -1350,7 +1396,8 @@ pub const Store = struct {
         /// `childLink` for rendering passes after discovery: never grows the
         /// graph, and nodes this engine already finalized may resolve through
         /// the store cache with identical bytes.
-        fn resolvedChildLink(self: *DigestEngine, ty: TypeId, mode: NamedDigestMode) ChildLink {
+        fn resolvedChildLink(self: *DigestEngine, raw_ty: TypeId, mode: NamedDigestMode) ChildLink {
+            const ty = self.store.digestType(raw_ty, mode);
             if (self.store.cachedDigest(ty, mode)) |digest| return .{ .external = digest };
             return .{
                 .node = self.node_lookup.get(nodeKey(ty, mode)) orelse
@@ -3681,6 +3728,8 @@ test "monotype type equality treats aliases as their backing" {
 
     try std.testing.expect(try store.typeEql(&name_store, str, aliased));
     try std.testing.expect(!try store.typeEql(&name_store, str, nominal));
+    try std.testing.expectEqual(store.equalityDigest(&name_store, str), store.equalityDigest(&name_store, aliased));
+    try std.testing.expect(!std.meta.eql(store.equalityDigest(&name_store, str), store.equalityDigest(&name_store, nominal)));
 }
 
 test "monotype type equality compares exact types across stores" {

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -5175,7 +5175,7 @@ const Cloner = struct {
 
                 const base = try self.cloneExpr(update.base);
                 const base_ty = self.pass.program.getExpr(base).ty;
-                if (!sameType(self.pass.program, base_ty, expr.ty)) {
+                if (!try self.pass.program.types.typeEql(&self.pass.program.names, base_ty, expr.ty)) {
                     Common.invariant("record update base type differed from its result type in SpecConstr");
                 }
                 const base_local = try self.pass.program.addLocal(self.pass.symbols.fresh(), base_ty);
@@ -12634,6 +12634,43 @@ test "SpecConstr preserves record update ordering while exposing its final shape
     try std.testing.expectEqual(read_binding.binding.local, program.getExpr(record.fields[0].value.expr).data.local);
     try std.testing.expectEqual(b, record.fields[1].name);
     try std.testing.expectEqual(update_local, program.getExpr(record.fields[1].value.expr).data.local);
+}
+
+test "SpecConstr accepts a transparent alias record update base" {
+    const allocator = std.testing.allocator;
+    var program = emptyLiftedProgramForTest(allocator);
+    defer program.deinit();
+
+    const u8_ty = try program.types.add(.{ .primitive = .u8 });
+    const field = try program.names.internRecordFieldLabel("field");
+    const record_ty = try program.types.add(.{ .record = try program.types.addRecordFields(&program.names, &.{
+        .{ .name = field, .ty = u8_ty, .default = null },
+    }) });
+    const module_identity = try program.names.internModuleIdentity(&([_]u8{0xAB} ** 32));
+    const type_name = try program.names.internTypeName("RecordAlias");
+    const alias_ty = try program.types.add(.{ .named = .{
+        .named_type = .{ .module = .{}, .ty = @enumFromInt(1) },
+        .def = .{ .module = module_identity, .type_name = type_name },
+        .kind = .alias,
+        .args = Type.Span.empty(),
+        .backing = .{ .ty = record_ty, .use = .inspectable },
+    } });
+    const base_local = try program.addLocal(@enumFromInt(1), record_ty);
+    const update_local = try program.addLocal(@enumFromInt(2), u8_ty);
+    const base = try program.addExpr(.{ .ty = record_ty, .data = .{ .local = base_local } });
+    const update_value = try program.addExpr(.{ .ty = u8_ty, .data = .{ .local = update_local } });
+    const update = try program.addExpr(.{ .ty = alias_ty, .data = .{ .record_update = .{
+        .base = base,
+        .fields = try program.addFieldExprSpan(&.{.{ .name = field, .value = update_value }}),
+    } } });
+
+    var pass = try Pass.init(allocator, &program);
+    defer pass.deinit();
+    var cloner = Cloner.initForRewrite(&pass);
+    defer cloner.deinit();
+    const cloned = try cloner.cloneExprValue(update);
+    try std.testing.expect(cloned.value == .record);
+    try std.testing.expectEqual(record_ty, cloned.value.record.ty);
 }
 
 test "call-pattern scans direct call and function reference capture operands" {

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -8064,11 +8064,13 @@ const Cloner = struct {
 
     /// Collapse a match whose scrutinee is a known constructor to the selected
     /// branch's body. `decline_on_no_match` distinguishes the two callers: the
-    /// direct known-match collapse proves exhaustiveness (a known constructor
-    /// always selects a branch), so a miss is an invariant; case-of-case
-    /// distribution instead *offers* a value that a branch may not structurally
-    /// cover (an opaque tag payload the selection cannot verify), so it declines
-    /// and leaves the match materialized.
+    /// direct known-match collapse proves exhaustiveness for a non-empty branch
+    /// set, so a miss there is an invariant; case-of-case distribution instead
+    /// *offers* a value that a branch may not structurally cover (an opaque tag
+    /// payload the selection cannot verify), so it declines and leaves the
+    /// match materialized. An empty branch set is absurd elimination. A symbolic
+    /// structural value does not prove reachability because an eager child may
+    /// itself be an impossible expression, so that match must also remain.
     fn selectKnownMatchValue(
         self: *Cloner,
         scrutinee: Value,
@@ -8077,6 +8079,7 @@ const Cloner = struct {
         bindings: *BindingChain,
     ) Common.LowerError!?Value {
         if (scrutinee == .expr) return null;
+        if (branches_span.len == 0) return null;
         // Read each branch by stable index rather than holding a `branchSpan`
         // borrow: `cloneExprValue(branch.body)` below can append to `branches`
         // through a nested match, which would invalidate a live borrow.
@@ -13571,6 +13574,34 @@ test "known match fold aborts on undecidable branches and trips the invariant wh
             (std.posix.W.IFEXITED(raw_status) and std.posix.W.EXITSTATUS(raw_status) != 0);
         try std.testing.expect(failed);
     }
+}
+
+test "known match fold preserves absurd elimination of a structural product" {
+    const allocator = std.testing.allocator;
+    var program = emptyLiftedProgramForTest(allocator);
+    defer program.deinit();
+
+    const empty_union_ty = try program.types.add(.{ .tag_union = Type.Span.empty() });
+    const field_name = try program.names.internRecordFieldLabel("impossible");
+    const record_ty = try program.types.add(.{ .record = try program.types.addRecordFields(&program.names, &.{
+        .{ .name = field_name, .ty = empty_union_ty, .default = null },
+    }) });
+    const impossible_local = try program.addLocal(@enumFromInt(1), empty_union_ty);
+    const impossible_expr = try program.addExpr(.{ .ty = empty_union_ty, .data = .{ .local = impossible_local } });
+    const record_value = Value{ .record = .{
+        .ty = record_ty,
+        .fields = &.{.{ .name = field_name, .value = .{ .expr = impossible_expr } }},
+    } };
+
+    var pass = try Pass.init(allocator, &program);
+    defer pass.deinit();
+    var cloner = Cloner.initForRewrite(&pass);
+    defer cloner.deinit();
+    var bindings: BindingChain = .{};
+    try std.testing.expectEqual(
+        @as(?Value, null),
+        try cloner.simplifyKnownMatchValue(record_value, Ast.Span(Ast.Branch).empty(), &bindings),
+    );
 }
 
 test "call-pattern specialization declarations are referenced" {

--- a/src/postcheck/monotype_lifted/spec_constr.zig
+++ b/src/postcheck/monotype_lifted/spec_constr.zig
@@ -466,8 +466,10 @@ const FnPlan = struct {
 /// A pattern binder paired with the monomorphic type it was bound at. A single
 /// source binder is reused across every monomorphization of its binding, so the
 /// binder alone does not identify a value; the type digest completes the
-/// identity, matching the `(binder, type)` identity Monotype lowering uses for
-/// locals. See `Builder.sameLocalIdentity` in monotype/lower.zig.
+/// identity. This must use the digest of `typeEql`, not stored type identity:
+/// one monomorphization may carry distinct checked-node provenance or a
+/// transparent alias at equivalent local sites. See `Builder.sameLocalIdentity`
+/// in monotype/lower.zig.
 const BinderIdentity = struct {
     binder: check.CheckedModule.PatternBinderId,
     digest: names.TypeDigest,
@@ -4296,7 +4298,7 @@ const Subst = struct {
         const binder = local_data.binder orelse return null;
         return .{
             .binder = binder,
-            .digest = program.types.typeDigestCached(&program.names, local_data.ty, null),
+            .digest = program.types.equalityDigest(&program.names, local_data.ty),
         };
     }
 
@@ -13507,6 +13509,42 @@ test "whole-body normalization resolves binder-equivalent argument locals" {
         .hosted => return error.TestUnexpectedResult,
     };
     try std.testing.expectEqual(argument, program.getExpr(cloned_body).data.local);
+}
+
+test "substitution resolves equivalent named types with distinct checked provenance" {
+    const allocator = std.testing.allocator;
+    var program = emptyLiftedProgramForTest(allocator);
+    defer program.deinit();
+
+    const module_identity = try program.names.internModuleIdentity(&([_]u8{0xAB} ** 32));
+    const type_name = try program.names.internTypeName("Nominal");
+    const def: Type.TypeDef = .{ .module = module_identity, .type_name = type_name };
+    const first_ty = try program.types.add(.{ .named = .{
+        .named_type = .{ .module = .{}, .ty = @enumFromInt(1) },
+        .def = def,
+        .kind = .nominal,
+        .args = Type.Span.empty(),
+    } });
+    const second_ty = try program.types.add(.{ .named = .{
+        .named_type = .{ .module = .{}, .ty = @enumFromInt(2) },
+        .def = def,
+        .kind = .nominal,
+        .args = Type.Span.empty(),
+    } });
+    const binder: check.CheckedModule.PatternBinderId = @enumFromInt(1);
+    const first = try program.addLocalWithBinder(@enumFromInt(1), first_ty, binder);
+    const second = try program.addLocalWithBinder(@enumFromInt(2), second_ty, binder);
+    const replacement = try program.addLocal(@enumFromInt(3), first_ty);
+    const replacement_expr = try program.addExpr(.{ .ty = first_ty, .data = .{ .local = replacement } });
+    const second_expr = try program.addExpr(.{ .ty = second_ty, .data = .{ .local = second } });
+
+    var pass = try Pass.init(allocator, &program);
+    defer pass.deinit();
+    var cloner = Cloner.initForRewrite(&pass);
+    defer cloner.deinit();
+    try cloner.subst.put(&program, first, .{ .expr = replacement_expr });
+    const cloned = try cloner.cloneExpr(second_expr);
+    try std.testing.expectEqual(replacement, program.getExpr(cloned).data.local);
 }
 
 test "known match fold aborts on undecidable branches and trips the invariant when every branch is excluded" {


### PR DESCRIPTION
## Summary

This fixes five compiler bugs exposed while migrating the Terrocotta Screwbot showcase to roc-ray 0.10.0-rc1:

- follow inspectable nominal backings when flattening named record rows
- accept transparent alias-backed record updates during SpecConstr
- preserve absurd matches whose symbolic record shape contains a bottom child
- use structural type identity for local binders instead of provenance-sensitive full digests
- retain complete projection targets when their root unit belongs to an enclosing loop keep-set

Each fix lives in the compiler layer that owns the violated invariant and includes a focused regression test that failed before the corresponding change.

## Verification

- `zig build run-test-zig-module-lir` — 269 tests pass
- `zig fmt --check src/lir/arc.zig`
- `git diff --check origin/main...HEAD`
- built the migrated Screwbot showcase with this compiler: zero errors and zero warnings
- ran Screwbot from the Terrocotta repository root through raylib initialization, asset loading, shader setup, framebuffer creation, and the render loop

The reproducer was `examples/screwbot/main.roc` in Terrocotta using roc-ray 0.10.0-rc1. The investigation began with Roc nightly 2026-08-21-90da19f.