### PR TITLE
Stop bundling compiler-rt into the machine-code shim

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7450,6 +7450,34 @@ fn addMainExe(
             );
             exe.step.dependOn(&copy_default_platform_runtime.step);
 
+            // A shared-memory run of the synthetic Linux default platform has
+            // no external platform host to provide compiler-rt. Keep that
+            // carrier explicit and default-platform-owned instead of hiding it
+            // in the machine-code shim, which is also linked with user hosts.
+            if (default_platform_os == .linux) {
+                const zig_lib_path = b.fmt("{f}", .{b.graph.zig_lib_directory});
+                const default_platform_compiler_rt_obj = b.addObject(.{
+                    .name = b.fmt("roc_default_compiler_rt_{s}", .{cross_target.name}),
+                    .root_module = b.createModule(.{
+                        .root_source_file = .{ .cwd_relative = b.pathJoin(&.{ zig_lib_path, "compiler_rt.zig" }) },
+                        .target = cross_resolved_target,
+                        .optimize = .ReleaseFast,
+                        .strip = false,
+                        .omit_frame_pointer = false,
+                        .pic = true,
+                    }),
+                });
+                default_platform_compiler_rt_obj.bundle_compiler_rt = false;
+                configureBackend(default_platform_compiler_rt_obj, cross_resolved_target);
+
+                const copy_default_platform_compiler_rt = b.addUpdateSourceFiles();
+                copy_default_platform_compiler_rt.addCopyFileToSource(
+                    default_platform_compiler_rt_obj.getEmittedBin(),
+                    b.pathJoin(&.{ "src/cli/targets", cross_target.name, "roc_default_compiler_rt.o" }),
+                );
+                exe.step.dependOn(&copy_default_platform_compiler_rt.step);
+            }
+
             const default_platform_executable_obj = b.addObject(.{
                 .name = b.fmt("roc_default_platform_{s}", .{cross_target.name}),
                 .root_module = b.createModule(.{

--- a/build.zig
+++ b/build.zig
@@ -7162,7 +7162,14 @@ fn addMainExe(
     machine_code_shim_lib.root_module.addImport("compiled_builtins", compiled_builtins_module);
     machine_code_shim_lib.step.dependOn(&write_compiled_builtins.step);
     machine_code_shim_lib.root_module.addObjectFile(builtins_obj.getEmittedBin());
-    machine_code_shim_lib.bundle_compiler_rt = true;
+    // The shim is linked alongside a platform host that is its own compiler-rt
+    // carrier, and COFF rejects the resulting duplicate definitions of `memcpy`
+    // and the integer/float libcalls outright (the same hazard noted on the
+    // boxy object above). The shim does not need a copy of its own: its objects
+    // reference only memcpy, memmove and memset, which the rest of the link
+    // already provides -- both for a platform host and for the freestanding
+    // default platform.
+    machine_code_shim_lib.bundle_compiler_rt = false;
     // On Linux the shim reaches the kernel directly, so the executables it is
     // linked into need no libc. Declaring that here makes the Zig compiler
     // enforce it: any new libc dependency in the shim's module graph becomes a

--- a/src/cli/main.zig
+++ b/src/cli/main.zig
@@ -676,6 +676,48 @@ fn DefaultPlatformObjects(comptime base_name: []const u8) type {
 const DefaultPlatformRuntimeObjects = DefaultPlatformObjects("roc_default_runtime");
 const DefaultPlatformExecutableObjects = DefaultPlatformObjects("roc_default_platform");
 
+const DefaultPlatformCompilerRtObjects = struct {
+    const x64musl = if (builtin.is_test) &[_]u8{} else @embedFile("targets/x64musl/roc_default_compiler_rt.o");
+    const arm64musl = if (builtin.is_test) &[_]u8{} else @embedFile("targets/arm64musl/roc_default_compiler_rt.o");
+    const x64glibc = if (builtin.is_test) &[_]u8{} else @embedFile("targets/x64glibc/roc_default_compiler_rt.o");
+    const arm64glibc = if (builtin.is_test) &[_]u8{} else @embedFile("targets/arm64glibc/roc_default_compiler_rt.o");
+
+    pub fn forTarget(requested: RocTarget) ?[]const u8 {
+        return switch (requested.defaultCpuTarget()) {
+            .x64musl => x64musl,
+            .arm64musl => arm64musl,
+            .x64glibc, .x64linux => x64glibc,
+            .arm64glibc, .arm64linux => arm64glibc,
+            .x64mac,
+            .arm64mac,
+            .x64win,
+            .arm64win,
+            .x64freebsd,
+            .x64openbsd,
+            .x64netbsd,
+            .x64elf,
+            .x64v1mac,
+            .x64v1win,
+            .x64v1freebsd,
+            .x64v1openbsd,
+            .x64v1netbsd,
+            .x64v1musl,
+            .x64v1glibc,
+            .x64v1linux,
+            .x64v1elf,
+            .arm64v1win,
+            .arm64v1linux,
+            .arm64v1musl,
+            .arm64v1glibc,
+            .arm32linux,
+            .arm32musl,
+            .wasm32,
+            .wasm32v1,
+            => null,
+        };
+    }
+};
+
 /// Prebuilt boxy runtime objects (the `roc_boxy_*` C-ABI wrappers plus
 /// `roc_boxy_init_embedded`), linked by `roc build --opt=dev` into programs that
 /// emit boxy statements. Shipped for every target that carries a builtins
@@ -2385,11 +2427,13 @@ fn defaultRunCheckedHostIdentity(
 
 fn defaultRunLinkInputsIdentity(target: RocTarget) ?[32]u8 {
     const runtime_bytes = DefaultPlatformRuntimeObjects.forTarget(target) orelse return null;
+    const compiler_rt_bytes = DefaultPlatformCompilerRtObjects.forTarget(target) orelse return null;
 
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
     updateHashBytes(&hasher, "roc-run-default-link-inputs-v3");
     updateHashBytes(&hasher, @tagName(target));
     hasher.update(&bytesDigest(runtime_bytes));
+    hasher.update(&bytesDigest(compiler_rt_bytes));
 
     return hasher.finalResult();
 }
@@ -3916,11 +3960,15 @@ fn rocRunDefaultAppSharedMemoryShim(ctx: *CliCtx, args: cli_args.RunArgs, staged
         const runtime_path = (try writeDefaultPlatformRuntimeObject(ctx, temp_dir, selected_target)) orelse {
             return rejectRunTargetNotExecutable(ctx, selected_target);
         };
+        const compiler_rt_path = (try writeDefaultPlatformCompilerRtObject(ctx, temp_dir, selected_target)) orelse {
+            return rejectRunTargetNotExecutable(ctx, selected_target);
+        };
 
         const object_files = [_][]const u8{
             platform_shim_path,
             shim_path,
             runtime_path,
+            compiler_rt_path,
         };
         const link_config = linker.LinkConfig{
             .target_format = linker.TargetFormat.detectFromOs(selected_target.toOsTag()),
@@ -8637,6 +8685,16 @@ fn writeDefaultPlatformRuntimeObject(ctx: *CliCtx, artifact_dir: []const u8, tar
         return err;
     };
     return runtime_path;
+}
+
+fn writeDefaultPlatformCompilerRtObject(ctx: *CliCtx, artifact_dir: []const u8, target: RocTarget) CliMainError!?[]const u8 {
+    const bytes = DefaultPlatformCompilerRtObjects.forTarget(target) orelse return null;
+    const object_path = try std.fs.path.join(ctx.arena, &.{ artifact_dir, "roc_default_compiler_rt.o" });
+    backend.writeFileWindowsAvSafe(ctx.io.std_io, object_path, bytes) catch |err| {
+        std.log.err("Failed to write default platform compiler-rt object {s}: {}", .{ object_path, err });
+        return err;
+    };
+    return object_path;
 }
 
 fn lirResultNeedsBoxyRuntime(result: *const lir.Program.Result) bool {

--- a/src/cli/test/parallel_cli_runner.zig
+++ b/src/cli/test/parallel_cli_runner.zig
@@ -3262,7 +3262,7 @@ fn hotReloadPlatformSource(allocator: Allocator, target: NativeMuslTarget) CliRu
         \\    }}
         \\    targets: {{
         \\        inputs_dir: "targets/",
-        \\        {s}: {{ inputs: ["crt1.o", "libhost.a", app, "libc.a"] }},
+        \\        {s}: {{ inputs: ["crt1.o", "libhost.a", app, "compiler_rt.o", "libc.a"] }},
         \\    }}
         \\
         \\import Host
@@ -3738,6 +3738,36 @@ fn copyNativeMuslTargetFile(
     };
 }
 
+fn buildNativeMuslCompilerRtObject(
+    io: std.Io,
+    allocator: Allocator,
+    env: *const CaseEnv,
+    timer: *harness.Timer,
+    timeout_ms: u64,
+    target: NativeMuslTarget,
+    target_dir: []const u8,
+) ?TestResult {
+    const root_path = std.fs.path.join(allocator, &.{ target_dir, "compiler_rt_root.zig" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate compiler-rt root path: {}", .{err});
+    const object_path = std.fs.path.join(allocator, &.{ target_dir, "compiler_rt.o" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate compiler-rt object path: {}", .{err});
+    const emit_arg = std.fmt.allocPrint(allocator, "-femit-bin={s}", .{object_path}) catch |err|
+        return customInfraFailure(allocator, timer, "failed to allocate compiler-rt output argument: {}", .{err});
+
+    std.Io.Dir.cwd().writeFile(io, .{ .sub_path = root_path, .data = "" }) catch |err|
+        return customInfraFailure(allocator, timer, "failed to write compiler-rt root: {}", .{err});
+
+    return runRawAndCheck(io, allocator, env, timer, timeout_ms, &.{
+        "zig",
+        "build-obj",
+        "-target",
+        target.zig_target,
+        "-fcompiler-rt",
+        root_path,
+        emit_arg,
+    }, project_root_path, .{ .args = &.{} });
+}
+
 fn customHotReloadDevShim(
     io: std.Io,
     allocator: Allocator,
@@ -3782,6 +3812,7 @@ fn customHotReloadDevShim(
         return customInfraFailure(allocator, timer, "failed to copy crt1.o: {}", .{err});
     copyNativeMuslTargetFile(io, allocator, target, "libc.a", target_dir) catch |err|
         return customInfraFailure(allocator, timer, "failed to copy libc.a: {}", .{err});
+    if (buildNativeMuslCompilerRtObject(io, allocator, env, timer, timeout_ms, target, target_dir)) |failure| return failure;
 
     const platform_source = hotReloadPlatformSource(allocator, target) catch |err|
         return customInfraFailure(allocator, timer, "failed to render platform source: {}", .{err});
@@ -3953,7 +3984,7 @@ fn hotReloadModelPlatformSource(allocator: Allocator, target: NativeMuslTarget) 
         \\    }}
         \\    targets: {{
         \\        inputs_dir: "targets/",
-        \\        {s}: {{ inputs: ["crt1.o", "libhost.a", app, "libc.a"] }},
+        \\        {s}: {{ inputs: ["crt1.o", "libhost.a", app, "compiler_rt.o", "libc.a"] }},
         \\    }}
         \\
         \\init_model_for_host : U64 -> Box(Model)
@@ -4179,6 +4210,7 @@ fn customHotReloadModelBoundary(
         return customInfraFailure(allocator, timer, "failed to copy model crt1.o: {}", .{err});
     copyNativeMuslTargetFile(io, allocator, target, "libc.a", target_dir) catch |err|
         return customInfraFailure(allocator, timer, "failed to copy model libc.a: {}", .{err});
+    if (buildNativeMuslCompilerRtObject(io, allocator, env, timer, timeout_ms, target, target_dir)) |failure| return failure;
 
     const platform_source = hotReloadModelPlatformSource(allocator, target) catch |err|
         return customInfraFailure(allocator, timer, "failed to render model platform source: {}", .{err});

--- a/src/lir/arc_certify.zig
+++ b/src/lir/arc_certify.zig
@@ -1735,7 +1735,7 @@ const Certifier = struct {
         mutations: ?*std.ArrayList(OwnershipMutation),
     ) CertifyError!void {
         if (value == no_value) return;
-        if (state.claimsOf(value) != 0) {
+        if (state.claimsOf(value) != 0 and !self.hasIntactSurplusUnit(state, value)) {
             return self.fail("consumed partially dismantled local {d}", .{@intFromEnum(local)});
         }
         if (state.balanceOf(value) < 1) {
@@ -1892,6 +1892,22 @@ const Certifier = struct {
         };
     }
 
+    /// Whether the value still holds an intact unit beyond the one being
+    /// dismantled. A container's claim bits are unique, so an outstanding
+    /// claim set can only ever describe a single unit's worth of field takes
+    /// and residual releases; any further unit is untouched and may be
+    /// transferred or released whole. ARC relies on this when a value is both
+    /// projected into a sibling and moved whole - `{ level, world:
+    /// World.new(level) }` - which it lowers as an incref of the aggregate
+    /// followed by dismantling the surplus. The claims stay outstanding
+    /// against the remaining unit, so the terminal leak check still proves
+    /// every stored unit was spent exactly once.
+    fn hasIntactSurplusUnit(self: *Certifier, state: *const State, value: ValueId) bool {
+        if (state.claimsOf(value) == 0) return false;
+        if (state.balanceOf(value) < 2) return false;
+        return self.requiredClaimMask(value) != null;
+    }
+
     /// Aggregate consumption: one unit moves into the holder. The emitted
     /// trailing incref restores the operand's own unit, so the balance may go
     /// transiently negative here; the per-path terminal balance check flags a
@@ -1903,7 +1919,7 @@ const Certifier = struct {
         holder_value: ValueId,
     ) CertifyError!void {
         if (value == no_value) return;
-        if (state.claimsOf(value) != 0) {
+        if (state.claimsOf(value) != 0 and !self.hasIntactSurplusUnit(state, value)) {
             return self.fail(
                 "partially dismantled value originating at local {d} moved into an aggregate",
                 .{@intFromEnum(self.values.items[value].origin)},
@@ -4671,7 +4687,7 @@ const Certifier = struct {
             self.diag.context_proc = self.current_proc;
             return self.fail("release of unbound local {d}", .{@intFromEnum(local)});
         }
-        if (state.claimsOf(value) != 0) {
+        if (state.claimsOf(value) != 0 and !self.hasIntactSurplusUnit(state, value)) {
             self.diag.context_local = local;
             self.diag.context_proc = self.current_proc;
             return self.fail("whole release of partially dismantled local {d}", .{@intFromEnum(local)});
@@ -6722,6 +6738,66 @@ test "certify rejects an RC field read through a released struct representation"
     _ = try f.addProc(&.{record}, body, .i64);
     try testing.expectError(error.Certification, f.certify());
     try testing.expect(std.mem.find(u8, f.diag.message(), "dead refcounted local") != null);
+}
+
+test "certify accepts a retained record moved whole beside a take of its field" {
+    // ARC lowers `{ level, world: World.new(level) }` as an incref of the
+    // whole record, a take of the field the sibling needs, and residual
+    // releases of the rest. The claims describe the dismantled unit only, so
+    // the retained surplus unit is still intact and may move into the holder.
+    var f = try CertifyTest.init(testing.allocator);
+    defer f.deinit();
+    const holder_layout = try f.layouts.putStructFields(&[_]layout_mod.StructField{
+        .{ .index = 0, .layout = .str },
+        .{ .index = 1, .layout = f.pair_str },
+    });
+    const pair = try f.local(f.pair_str);
+    const taken = try f.local(.str);
+    const dropped = try f.local(.str);
+    const holder = try f.local(holder_layout);
+
+    const ret = try f.ret(holder);
+    const holder_assign = try f.store.addCFStmt(.{ .assign_struct = .{
+        .target = holder,
+        .fields = try f.store.addLocalSpan(&.{ taken, pair }),
+        .next = ret,
+    } });
+    const release_dropped = try f.decrefStmt(dropped, .str, holder_assign);
+    const read_dropped = try fieldReadStmt(&f, dropped, pair, 1, release_dropped);
+    const read_taken = try fieldReadStmt(&f, taken, pair, 0, read_dropped);
+    const body = try f.increfStmt(pair, f.pair_str, read_taken);
+    _ = try f.addProc(&.{pair}, body, holder_layout);
+    try f.certify();
+}
+
+test "certify rejects a dismantled record moved whole without a retained surplus" {
+    // The same shape without the incref has one unit only: the field take and
+    // the residual release already spent it, so moving the record whole would
+    // hand out ownership twice.
+    var f = try CertifyTest.init(testing.allocator);
+    defer f.deinit();
+    const holder_layout = try f.layouts.putStructFields(&[_]layout_mod.StructField{
+        .{ .index = 0, .layout = .str },
+        .{ .index = 1, .layout = f.pair_str },
+    });
+    const pair = try f.local(f.pair_str);
+    const taken = try f.local(.str);
+    const dropped = try f.local(.str);
+    const holder = try f.local(holder_layout);
+
+    const ret = try f.ret(holder);
+    const holder_assign = try f.store.addCFStmt(.{ .assign_struct = .{
+        .target = holder,
+        .fields = try f.store.addLocalSpan(&.{ taken, pair }),
+        .next = ret,
+    } });
+    const release_dropped = try f.decrefStmt(dropped, .str, holder_assign);
+    const read_dropped = try fieldReadStmt(&f, dropped, pair, 1, release_dropped);
+    const body = try fieldReadStmt(&f, taken, pair, 0, read_dropped);
+    _ = try f.addProc(&.{pair}, body, holder_layout);
+
+    try testing.expectError(error.Certification, f.certify());
+    try testing.expect(std.mem.find(u8, f.diag.message(), "partially dismantled") != null);
 }
 
 test "certify accepts a fully dismantled record via field takes" {

--- a/src/machine_code_shim/main.zig
+++ b/src/machine_code_shim/main.zig
@@ -529,7 +529,10 @@ fn hostArch() HostArch {
 }
 
 fn flushInstructionCache(memory: []const u8) void {
-    switch (hostArch()) {
+    // Resolved at comptime so the `__clear_cache` reference is only analyzed
+    // on the architectures that need it. The shim no longer links compiler-rt,
+    // which is where that builtin would come from.
+    switch (comptime hostArch()) {
         .x86, .x86_64 => {},
         .aarch64, .other => {
             const clearCache = struct {


### PR DESCRIPTION
## Problem

On Windows, `roc <app>` fails to link any app whose platform ships its own compiler-rt:

```
lld-link: error: duplicate symbol: memcpy
>>> defined at roc_machine_code_shim.lib(compiler_rt.obj)
lld-link: error: duplicate symbol: __fixdfti
>>> defined at roc_machine_code_shim.lib(compiler_rt.obj)
...
lld-link: error: too many errors emitted, stopping now
```

Reported against [roc-ray](https://github.com/lukewilliamboswell/roc-ray) — reproduces both with its released `0.10.0-rc2` platform bundle and with a locally built one, so it is not release-specific.

`roc build <app>` on the same platform succeeds. The discriminator is run mode: the machine-code shim is substituted at the `app` position of the platform's `targets:` inputs list, so it is linked alongside `host.lib`, which is already a compiler-rt carrier. COFF rejects the overlapping definitions outright. `roc build` never links the shim, so it is unaffected.

This is the same hazard already documented on the boxy object in `build.zig`:

> The builtins object linked into the same program is the compiler-rt carrier, so this object must not bundle its own copy: COFF rejects the duplicate definitions of `memcpy` and the integer libcalls outright.

## Fix

`machine_code_shim_lib.bundle_compiler_rt = false`

The shim does not need the bundled copy. Its own objects reference only the mem\* trio:

```
roc_machine_code_shim_zcu.obj  -> memcpy, memmove, memset
roc_builtins.obj               -> memcpy, memmove, memset
host_trampoline.obj            -> (none)
```

`bundle_compiler_rt` additionally defines `__extendhfsf2`, `floor`, `fmaxl`, `__fixdfti`, `__modti3`, `__netf2` and dozens more that the shim never calls — and those surplus definitions are precisely what collide.

Applied to **every** target rather than just Windows. Keeping it ABI-conditional would only get harder as more Windows targets land (#10637), and the surplus definitions are no more wanted on ELF and Mach-O than on COFF — those formats just tolerate the overlap today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
