### PR TITLE
Improve LSP navigation for file imports, builtin types, and members

### DIFF
--- a/src/canonicalize/Can.zig
+++ b/src/canonicalize/Can.zig
@@ -6808,7 +6808,13 @@ fn canonicalizeFileImport(self: *Self, fi: @TypeOf(@as(AST.Statement, undefined)
         return;
     }
 
-    const dependency_idx = try self.env.recordFileDependency(path_text);
+    const path_token_region = self.parse_ir.tokens.resolve(fi.path_tok);
+    const has_leading_quote = path_token_region.start.offset > 0 and self.parse_ir.env.source[path_token_region.start.offset - 1] == '"';
+    const has_trailing_quote = path_token_region.end.offset < self.parse_ir.env.source.len and self.parse_ir.env.source[path_token_region.end.offset] == '"';
+    const start_offset = if (has_leading_quote) path_token_region.start.offset - 1 else path_token_region.start.offset;
+    const end_offset = if (has_trailing_quote) path_token_region.end.offset + 1 else path_token_region.end.offset;
+
+    const dependency_idx = try self.env.recordFileDependency(path_text, start_offset, end_offset);
 
     // File imports require filesystem access, which is not available on wasm32.
     if (comptime builtin.cpu.arch == .wasm32) {

--- a/src/canonicalize/ModuleEnv.zig
+++ b/src/canonicalize/ModuleEnv.zig
@@ -1086,10 +1086,19 @@ pub const FileDependencyState = enum(u8) {
 pub const FileDependency = extern struct {
     relative_path: StringLiteral.Idx,
     state: FileDependencyState,
-    _padding: [3]u8,
+    _padding: [3]u8 = .{ 0, 0, 0 },
     content_hash: [32]u8,
+    start_offset: u32,
+    end_offset: u32,
 
     pub const SafeList = collections.SafeList(@This());
+
+    pub fn region(self: @This()) Region {
+        return .{
+            .start = .{ .offset = self.start_offset },
+            .end = .{ .offset = self.end_offset },
+        };
+    }
 };
 
 /// Relocate all pointers in the ModuleEnv by the given offset.
@@ -1367,13 +1376,15 @@ pub fn deinitCachedModule(self: *Self) void {
 }
 
 /// Record a relative file dependency before its final read state is known.
-pub fn recordFileDependency(self: *Self, relative_path: []const u8) Allocator.Error!FileDependency.SafeList.Idx {
+pub fn recordFileDependency(self: *Self, relative_path: []const u8, start_offset: u32, end_offset: u32) Allocator.Error!FileDependency.SafeList.Idx {
     const path_idx = try self.insertString(relative_path);
     return try self.file_dependencies.append(self.gpa, .{
         .relative_path = path_idx,
         .state = .pending,
         ._padding = .{ 0, 0, 0 },
         .content_hash = [_]u8{0} ** 32,
+        .start_offset = start_offset,
+        .end_offset = end_offset,
     });
 }
 

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -35140,7 +35140,7 @@ test "module source input hash uses explicit file dependency state" {
     var missing_env = try ModuleEnv.init(gpa, "");
     defer missing_env.deinit();
     try missing_env.initCIRFields("Test");
-    const missing_idx = try missing_env.recordFileDependency("data.txt");
+    const missing_idx = try missing_env.recordFileDependency("data.txt", 0, 0);
     missing_env.setFileDependencyMissing(missing_idx);
     const missing_hash = hashModuleSourceInputs(&missing_env);
 
@@ -35151,14 +35151,14 @@ test "module source input hash uses explicit file dependency state" {
     var unreadable_env = try ModuleEnv.init(gpa, "");
     defer unreadable_env.deinit();
     try unreadable_env.initCIRFields("Test");
-    const unreadable_idx = try unreadable_env.recordFileDependency("data.txt");
+    const unreadable_idx = try unreadable_env.recordFileDependency("data.txt", 0, 0);
     unreadable_env.setFileDependencyUnreadable(unreadable_idx);
     const unreadable_hash = hashModuleSourceInputs(&unreadable_env);
 
     var present_env = try ModuleEnv.init(gpa, "");
     defer present_env.deinit();
     try present_env.initCIRFields("Test");
-    const present_idx = try present_env.recordFileDependency("data.txt");
+    const present_idx = try present_env.recordFileDependency("data.txt", 0, 0);
     present_env.setFileDependencyContentHash(present_idx, [_]u8{0} ** 32);
     const present_hash = hashModuleSourceInputs(&present_env);
 

--- a/src/compile/compile_build.zig
+++ b/src/compile/compile_build.zig
@@ -2367,6 +2367,20 @@ pub const BuildEnv = struct {
         return false;
     }
 
+    pub fn findModuleByQualifiedName(self: *BuildEnv, qualified_name: []const u8) ?*coordinator_mod.ModuleState {
+        const coord = self.coordinator orelse return null;
+        if (std.mem.find(u8, qualified_name, ".")) |dot_pos| {
+            const pkg_name = qualified_name[0..dot_pos];
+            const mod_name = qualified_name[dot_pos + 1 ..];
+            if (coord.packages.get(pkg_name)) |pkg| {
+                if (pkg.getModuleId(mod_name) orelse pkg.getPublicModuleId(mod_name)) |id| {
+                    return pkg.getModule(id);
+                }
+            }
+        }
+        return self.findModuleByName(qualified_name);
+    }
+
     pub fn findModuleByName(self: *BuildEnv, module_name: []const u8) ?*coordinator_mod.ModuleState {
         const coord = self.coordinator orelse return null;
         var pkg_it = coord.packages.iterator();
@@ -3464,7 +3478,7 @@ test "BuildEnv collectWatchInputStates resolves file dependencies from module so
     const module_env = try allocator.create(ModuleEnv);
     module_env.* = try ModuleEnv.init(allocator, source);
     try module_env.initCIRFields("App");
-    const dep_idx = try module_env.recordFileDependency("data.txt");
+    const dep_idx = try module_env.recordFileDependency("data.txt", 0, 0);
     const dep_hash = [_]u8{3} ** 32;
     module_env.setFileDependencyContentHash(dep_idx, dep_hash);
     coord_mod.semantic = .{ .module_env = module_env, .checked_artifact = null };

--- a/src/compile/test/module_env_test.zig
+++ b/src/compile/test/module_env_test.zig
@@ -246,14 +246,14 @@ test "ModuleEnv.Serialized roundtrip preserves file dependency states" {
 
     try original.initCIRFields("Test");
 
-    const present_idx = try original.recordFileDependency("data.txt");
+    const present_idx = try original.recordFileDependency("data.txt", 0, 0);
     const present_hash = [_]u8{0x11} ** 32;
     original.setFileDependencyContentHash(present_idx, present_hash);
 
-    const missing_idx = try original.recordFileDependency("missing.txt");
+    const missing_idx = try original.recordFileDependency("missing.txt", 0, 0);
     original.setFileDependencyMissing(missing_idx);
 
-    const unreadable_idx = try original.recordFileDependency("denied.txt");
+    const unreadable_idx = try original.recordFileDependency("denied.txt", 0, 0);
     original.setFileDependencyUnreadable(unreadable_idx);
 
     var arena = collections.SingleThreadArena.init(gpa);

--- a/src/lsp/cir_queries.zig
+++ b/src/lsp/cir_queries.zig
@@ -594,6 +594,67 @@ pub fn findLookupAtOffset(module_env: *ModuleEnv, offset: u32) ?LookupResult {
     return ctx.result;
 }
 
+const FindTagAtOffsetContext = struct {
+    store: *const NodeStore,
+    common: *const base.CommonEnv,
+    target_offset: u32,
+    result_tag_name: ?[]const u8 = null,
+
+    fn visitExprPre(ctx: *FindTagAtOffsetContext, expr_idx: CIR.Expr.Idx, expr: CIR.Expr) VisitAction {
+        const region = ctx.store.getExprRegion(expr_idx);
+        if (!regionContainsOffset(region, ctx.target_offset)) {
+            return .skip_children;
+        }
+        if (expr == .e_tag) {
+            const tag = expr.e_tag;
+            ctx.result_tag_name = ctx.common.idents.getText(tag.name);
+        }
+        return .continue_traversal;
+    }
+
+    fn visitPatternPre(ctx: *FindTagAtOffsetContext, pattern_idx: CIR.Pattern.Idx, pattern: CIR.Pattern) VisitAction {
+        const node_idx: CIR.Node.Idx = @enumFromInt(@intFromEnum(pattern_idx));
+        const region = ctx.store.getRegionAt(node_idx);
+        if (!regionContainsOffset(region, ctx.target_offset)) {
+            return .skip_children;
+        }
+        if (pattern == .applied_tag) {
+            const tag = pattern.applied_tag;
+            ctx.result_tag_name = ctx.common.idents.getText(tag.name);
+        }
+        return .continue_traversal;
+    }
+};
+
+/// Find a tag name in an expression or pattern at the given offset.
+pub fn findTagAtOffset(module_env: *ModuleEnv, offset: u32) ?[]const u8 {
+    var ctx = FindTagAtOffsetContext{
+        .store = &module_env.store,
+        .common = &module_env.common,
+        .target_offset = offset,
+    };
+
+    var visitor = CirVisitor(FindTagAtOffsetContext).init(&ctx, .{
+        .visit_expr_pre = FindTagAtOffsetContext.visitExprPre,
+        .visit_pattern_pre = FindTagAtOffsetContext.visitPatternPre,
+    });
+
+    const defs_slice = module_env.store.sliceDefs(module_env.all_defs);
+    for (defs_slice) |def_idx| {
+        const def = module_env.store.getDef(def_idx);
+        visitor.walkExpr(&module_env.store, def.expr);
+        if (ctx.result_tag_name != null) return ctx.result_tag_name;
+        visitor.walkPattern(&module_env.store, def.pattern);
+        if (ctx.result_tag_name != null) return ctx.result_tag_name;
+    }
+
+    if (!visitor.stopped) {
+        visitor.walkModule(&module_env.store, module_env.all_statements);
+    }
+
+    return ctx.result_tag_name;
+}
+
 /// Collect all references to a specific pattern (variable binding).
 ///
 /// This finds all e_lookup_local expressions that reference the target pattern,

--- a/src/lsp/handlers/definition.zig
+++ b/src/lsp/handlers/definition.zig
@@ -132,24 +132,61 @@ pub fn handler(comptime ServerType: type) type {
             if (def_result) |result| {
                 defer result.deinit(self.allocator);
 
-                // Build the Location response
-                const LocationResponse = struct {
-                    uri: []const u8,
-                    range: struct {
-                        start: struct { line: u32, character: u32 },
-                        end: struct { line: u32, character: u32 },
-                    },
-                };
+                if (result.origin_selection_range) |origin| {
+                    const LocationLink = struct {
+                        originSelectionRange: struct {
+                            start: struct { line: u32, character: u32 },
+                            end: struct { line: u32, character: u32 },
+                        },
+                        targetUri: []const u8,
+                        targetRange: struct {
+                            start: struct { line: u32, character: u32 },
+                            end: struct { line: u32, character: u32 },
+                        },
+                        targetSelectionRange: struct {
+                            start: struct { line: u32, character: u32 },
+                            end: struct { line: u32, character: u32 },
+                        },
+                    };
 
-                const response = LocationResponse{
-                    .uri = result.uri,
-                    .range = .{
-                        .start = .{ .line = result.range.start_line, .character = result.range.start_col },
-                        .end = .{ .line = result.range.end_line, .character = result.range.end_col },
-                    },
-                };
+                    const link = LocationLink{
+                        .originSelectionRange = .{
+                            .start = .{ .line = origin.start_line, .character = origin.start_col },
+                            .end = .{ .line = origin.end_line, .character = origin.end_col },
+                        },
+                        .targetUri = result.uri,
+                        .targetRange = .{
+                            .start = .{ .line = result.range.start_line, .character = result.range.start_col },
+                            .end = .{ .line = result.range.end_line, .character = result.range.end_col },
+                        },
+                        .targetSelectionRange = .{
+                            .start = .{ .line = result.range.start_line, .character = result.range.start_col },
+                            .end = .{ .line = result.range.end_line, .character = result.range.end_col },
+                        },
+                    };
 
-                try self.sendResponse(id, response);
+                    const response = [1]LocationLink{link};
+                    try self.sendResponse(id, response[0..]);
+                } else {
+                    // Build the Location response
+                    const LocationResponse = struct {
+                        uri: []const u8,
+                        range: struct {
+                            start: struct { line: u32, character: u32 },
+                            end: struct { line: u32, character: u32 },
+                        },
+                    };
+
+                    const response = LocationResponse{
+                        .uri = result.uri,
+                        .range = .{
+                            .start = .{ .line = result.range.start_line, .character = result.range.start_col },
+                            .end = .{ .line = result.range.end_line, .character = result.range.end_col },
+                        },
+                    };
+
+                    try self.sendResponse(id, response);
+                }
             } else {
                 try self.sendNullResponse(id);
             }

--- a/src/lsp/handlers/selection_range.zig
+++ b/src/lsp/handlers/selection_range.zig
@@ -65,13 +65,11 @@ pub fn handler(comptime ServerType: type) type {
             };
 
             // Process each position
-            var results: std.ArrayList(?SelectionRange) = .empty;
+            var results: std.ArrayList(SelectionRange) = .empty;
             defer {
                 // Free the linked list nodes
-                for (results.items) |maybe_range| {
-                    if (maybe_range) |range| {
-                        freeSelectionRange(self.allocator, range);
-                    }
+                for (results.items) |range| {
+                    freeSelectionRange(self.allocator, range);
                 }
                 results.deinit(self.allocator);
             }
@@ -114,7 +112,13 @@ pub fn handler(comptime ServerType: type) type {
                     error.InvalidPosition,
                     error.NoRangeFound,
                     error.ParseFailed,
-                    => null,
+                    => SelectionRange{
+                        .range = .{
+                            .start = .{ .line = line, .character = character },
+                            .end = .{ .line = line, .character = character },
+                        },
+                        .parent = null,
+                    },
                 };
                 try results.append(self.allocator, selection_range);
             }

--- a/src/lsp/handlers/semantic_tokens.zig
+++ b/src/lsp/handlers/semantic_tokens.zig
@@ -87,12 +87,18 @@ pub fn handler(comptime ServerType: type) type {
                 }
             }
 
+            const roc_ctx_opt = if (@hasField(@TypeOf(self.syntax_checker), "cache_config"))
+                self.syntax_checker.cache_config.roc_ctx
+            else
+                null;
+
             // Extract semantic tokens using CIR with cross-module context
             const tokens = try semantic_tokens.extractSemanticTokensWithImports(
                 self.allocator,
                 doc.text,
                 &info,
                 imported_envs,
+                roc_ctx_opt,
             );
             defer self.allocator.free(tokens);
 

--- a/src/lsp/module_lookup.zig
+++ b/src/lsp/module_lookup.zig
@@ -119,6 +119,7 @@ pub fn getDeclarationPattern(statement: CIR.Statement) ?CIR.Pattern.Idx {
 /// Find a definition by name, searching through all_defs and all_statements.
 /// Returns information about the first matching definition found.
 pub fn findDefinitionByName(module_env: *ModuleEnv, name: []const u8) ?DefinitionInfo {
+    const mod_name = module_env.module_name;
     // Search through all_defs first
     const defs_slice = module_env.store.sliceDefs(module_env.all_defs);
     for (defs_slice) |def_idx| {
@@ -126,6 +127,17 @@ pub fn findDefinitionByName(module_env: *ModuleEnv, name: []const u8) ?Definitio
         if (extractIdentFromPattern(&module_env.store, def.pattern)) |ident_idx| {
             const ident_name = module_env.getIdentText(ident_idx);
             if (std.mem.eql(u8, ident_name, name)) {
+                return DefinitionInfo{
+                    .pattern_idx = def.pattern,
+                    .expr_idx = def.expr,
+                    .ident_idx = ident_idx,
+                };
+            }
+            if (mod_name.len > 0 and ident_name.len == mod_name.len + 1 + name.len and
+                std.mem.startsWith(u8, ident_name, mod_name) and
+                ident_name[mod_name.len] == '.' and
+                std.mem.eql(u8, ident_name[mod_name.len + 1 ..], name))
+            {
                 return DefinitionInfo{
                     .pattern_idx = def.pattern,
                     .expr_idx = def.expr,
@@ -151,6 +163,17 @@ pub fn findDefinitionByName(module_env: *ModuleEnv, name: []const u8) ?Definitio
                         .ident_idx = ident_idx,
                     };
                 }
+                if (mod_name.len > 0 and ident_name.len == mod_name.len + 1 + name.len and
+                    std.mem.startsWith(u8, ident_name, mod_name) and
+                    ident_name[mod_name.len] == '.' and
+                    std.mem.eql(u8, ident_name[mod_name.len + 1 ..], name))
+                {
+                    return DefinitionInfo{
+                        .pattern_idx = pattern_idx,
+                        .expr_idx = parts.expr,
+                        .ident_idx = ident_idx,
+                    };
+                }
             }
         }
     }
@@ -158,26 +181,9 @@ pub fn findDefinitionByName(module_env: *ModuleEnv, name: []const u8) ?Definitio
     return null;
 }
 
-/// Find a definition by name, also matching unqualified names against qualified ones.
-/// For example, name "concat" will match a definition named "Str.concat".
-/// This is useful for resolving external lookups where the caller knows only the
-/// unqualified function name.
+/// Find a definition by exact name in the module.
 pub fn findDefinitionByUnqualifiedName(module_env: *ModuleEnv, name: []const u8) ?DefinitionInfo {
-    // Try exact match first
-    if (findDefinitionByName(module_env, name)) |info| return info;
-
-    // Fall back to suffix matching: "name" matches "Module.name"
-    var iter = iterateDefinitions(module_env);
-    while (iter.next()) |def_info| {
-        const def_name = module_env.getIdentText(def_info.ident_idx);
-        if (def_name.len > name.len and
-            std.mem.endsWith(u8, def_name, name) and
-            def_name[def_name.len - name.len - 1] == '.')
-        {
-            return def_info;
-        }
-    }
-    return null;
+    return findDefinitionByName(module_env, name);
 }
 
 /// Find the Def that owns a specific pattern index.

--- a/src/lsp/semantic_tokens.zig
+++ b/src/lsp/semantic_tokens.zig
@@ -153,16 +153,6 @@ pub fn extractSemanticTokens(
     return tokens.toOwnedSlice(allocator);
 }
 
-/// Extracts semantic tokens using the Canonicalized IR for richer semantic information.
-/// Falls back to token-only extraction on canonicalization errors.
-pub fn extractSemanticTokensWithCIR(
-    allocator: std.mem.Allocator,
-    source: []const u8,
-    info: *const LineInfo,
-) Allocator.Error![]SemanticToken {
-    return extractSemanticTokensWithImports(allocator, source, info, null);
-}
-
 /// Extracts semantic tokens with cross-module import context.
 /// When imported_envs is provided, can distinguish Module.function from record.field.
 pub fn extractSemanticTokensWithImports(
@@ -170,6 +160,7 @@ pub fn extractSemanticTokensWithImports(
     source: []const u8,
     info: *const LineInfo,
     imported_envs: ?[]*ModuleEnv,
+    roc_ctx_opt: ?CoreCtx,
 ) Allocator.Error![]SemanticToken {
     // Create ModuleEnv with source
     var module_env = ModuleEnv.init(allocator, source) catch return error.OutOfMemory;
@@ -191,7 +182,7 @@ pub fn extractSemanticTokensWithImports(
     defer builtin_module.deinit();
 
     // Create canonicalizer and run
-    const roc_ctx = CoreCtx.testing(allocator, allocator);
+    const roc_ctx = roc_ctx_opt orelse CoreCtx.testing(allocator, allocator);
     var canonicalizer = can.Can.initModule(roc_ctx, &module_env, parse_ast, .{
         .builtin_types = .{
             .builtin_module_env = builtin_module.env,

--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -138,15 +138,31 @@ pub const SyntaxChecker = struct {
             if (self.identity) |*identity| {
                 identity.deinit(self.checker.allocator);
             }
+            self.checker.allocator.free(self.absolute_path);
         }
 
         fn getModuleEnv(self: *DocumentBuild) ?*ModuleEnv {
             if (self.reused) {
                 return self.checker.getModuleEnvByPathInEnv(self.env, self.absolute_path);
             }
-            return self.session.?.getModuleEnv();
+            if (self.session) |*s| {
+                return s.getModuleEnv();
+            }
+            return null;
         }
     };
+
+    fn isCompilerOwnedBuiltin(self: *const SyntaxChecker, path: []const u8) bool {
+        const filename = std.fs.path.basename(path);
+        if (!std.mem.eql(u8, filename, "Builtin.roc")) return false;
+        if (self.cache_config.getModuleCacheDir(self.allocator)) |cache_dir| {
+            defer self.allocator.free(cache_dir);
+            const builtin_cache_path = std.fs.path.join(self.allocator, &.{ cache_dir, "Builtin.roc" }) catch return false;
+            defer self.allocator.free(builtin_cache_path);
+            return std.mem.eql(u8, path, builtin_cache_path);
+        } else |_| {}
+        return false;
+    }
 
     pub fn init(allocator: std.mem.Allocator, std_io: std.Io, debug: DebugFlags, log_file: ?std.Io.File) SyntaxChecker {
         var cache_config = CacheConfig{ .roc_ctx = CoreCtx.default(allocator, allocator, std_io) };
@@ -233,7 +249,7 @@ pub const SyntaxChecker = struct {
         }
     }
 
-    fn documentIdentityFromText(self: *SyntaxChecker, uri: []const u8, text: []const u8) Allocator.Error!DocumentIdentity {
+    fn documentIdentityFromText(self: *SyntaxChecker, uri: []const u8, text: []const u8) std.mem.Allocator.Error!DocumentIdentity {
         const path = try uri_util.uriToPath(self.allocator, uri);
         defer self.allocator.free(path);
 
@@ -288,17 +304,37 @@ pub const SyntaxChecker = struct {
         if (identity) |document| {
             if (self.matchingBuildEnvHandle(document.absolute_path, document.content_hash)) |handle| {
                 const env = handle.envPtr();
+                const abs_path = try self.allocator.dupe(u8, document.absolute_path);
                 return .{
                     .checker = self,
                     .identity = identity,
                     .session = null,
                     .env = env,
-                    .absolute_path = document.absolute_path,
+                    .absolute_path = abs_path,
                     .build_succeeded = self.getModuleEnvByPathInEnv(env, document.absolute_path) != null,
                     .has_reports = handle.hasDocumentReports(),
                     .reused = true,
                 };
             }
+        }
+
+        const path = try uri_util.uriToPath(self.allocator, uri);
+        defer self.allocator.free(path);
+
+        if (self.isCompilerOwnedBuiltin(path)) {
+            const env_handle = try self.createFreshBuildEnv();
+            const env = env_handle.envPtr();
+            const abs_path = try self.allocator.dupe(u8, path);
+            return .{
+                .checker = self,
+                .identity = identity,
+                .session = null,
+                .env = env,
+                .absolute_path = abs_path,
+                .build_succeeded = false,
+                .has_reports = false,
+                .reused = false,
+            };
         }
 
         const env_handle = try self.createFreshBuildEnv();
@@ -315,12 +351,13 @@ pub const SyntaxChecker = struct {
             };
         }
 
+        const abs_path = try self.allocator.dupe(u8, session.absolute_path);
         return .{
             .checker = self,
             .identity = identity,
             .session = session,
             .env = env,
-            .absolute_path = session.absolute_path,
+            .absolute_path = abs_path,
             .build_succeeded = session.build_succeeded,
             .has_reports = has_reports,
             .reused = false,
@@ -333,6 +370,13 @@ pub const SyntaxChecker = struct {
         defer self.mutex.unlock(self.std_io);
 
         try self.updateWorkspaceRoot(workspace_root);
+
+        const check_path = try uri_util.uriToPath(self.allocator, uri);
+        defer self.allocator.free(check_path);
+
+        if (self.isCompilerOwnedBuiltin(check_path)) {
+            return try self.allocator.alloc(Diagnostics.PublishDiagnostics, 0);
+        }
 
         // Check if content has changed using hash comparison BEFORE building.
         // This avoids unnecessary rebuilds on focus/blur events.
@@ -983,6 +1027,7 @@ pub const SyntaxChecker = struct {
     pub const DefinitionResult = struct {
         uri: []const u8,
         range: LspRange,
+        origin_selection_range: ?LspRange = null,
 
         pub fn deinit(self: DefinitionResult, allocator: std.mem.Allocator) void {
             allocator.free(self.uri);
@@ -1595,12 +1640,49 @@ pub const SyntaxChecker = struct {
             }
         }
 
+        const file_deps = module_env.file_dependencies.items.items;
+        for (file_deps) |dep| {
+            if (cir_queries.regionContainsOffset(dep.region(), target_offset)) {
+                const path_text = module_env.getString(dep.relative_path);
+                const doc_path = uri_util.uriToPath(self.allocator, current_uri) catch |err| {
+                    oom.* = err;
+                    return null;
+                };
+                defer self.allocator.free(doc_path);
+
+                const doc_dir = std.fs.path.dirname(doc_path) orelse ".";
+                const target_abs_path = std.fs.path.join(self.allocator, &.{ doc_dir, path_text }) catch |err| {
+                    oom.* = err;
+                    return null;
+                };
+                defer self.allocator.free(target_abs_path);
+
+                const target_uri = uri_util.pathToUri(self.allocator, target_abs_path) catch |err| {
+                    oom.* = err;
+                    return null;
+                };
+
+                const origin_range = cir_queries.regionToRange(module_env, dep.region());
+
+                return DefinitionResult{
+                    .uri = target_uri,
+                    .range = .{
+                        .start_line = 0,
+                        .start_col = 0,
+                        .end_line = 0,
+                        .end_col = 0,
+                    },
+                    .origin_selection_range = origin_range,
+                };
+            }
+        }
+
         // Also check statements
         const local_statements_slice = module_env.store.sliceStatements(module_env.all_statements);
         for (local_statements_slice) |stmt_idx| {
             const stmt = module_env.store.getStatement(stmt_idx);
 
-            // Handle import statements specially - navigate to the imported module
+            // Handle import statements specially - navigate to the imported module or exposed item
             if (stmt == .s_import) {
                 const import_stmt = stmt.s_import;
                 const stmt_region = module_env.store.getStatementRegion(stmt_idx);
@@ -1608,6 +1690,18 @@ pub const SyntaxChecker = struct {
                 if (cir_queries.regionContainsOffset(stmt_region, target_offset)) {
                     // Get the module name from the import
                     const module_name = module_env.common.idents.getText(import_stmt.module_name_tok);
+
+                    // Check if the click is on one of the exposed items
+                    const exposed_slice = module_env.store.sliceExposedItems(import_stmt.exposes);
+                    for (exposed_slice) |exposed_item_idx| {
+                        const exposed_node_idx: CIR.Node.Idx = @enumFromInt(@intFromEnum(exposed_item_idx));
+                        const item_region = module_env.store.getRegionAt(exposed_node_idx);
+                        if (cir_queries.regionContainsOffset(item_region, target_offset)) {
+                            const exposed_item = module_env.store.getExposedItem(exposed_item_idx);
+                            const member_name = module_env.getIdentText(exposed_item.name);
+                            return self.findDefinitionInModule(module_name, member_name, oom);
+                        }
+                    }
 
                     // Try to find the module in the coordinator state.
                     if (self.findModuleByName(module_name, oom)) |result| {
@@ -1686,16 +1780,58 @@ pub const SyntaxChecker = struct {
             }
             if (expr_tag == .e_lookup_external) {
                 const lookup = expr.e_lookup_external;
-                // External lookup - resolve to the module file
-                // Extract module name from source text (handles builtins correctly)
+                const import_idx_int = @intFromEnum(lookup.module_idx);
+                if (import_idx_int >= module_env.imports.imports.len()) return null;
+
+                const string_idx = module_env.imports.imports.items.items[import_idx_int];
+                const module_name = module_env.common.getString(string_idx);
+                const member_name = module_env.getIdentText(lookup.ident_idx);
+
                 const region_text = module_env.getSource(lookup.region);
-                // Module.function format - extract the module name (before the dot)
                 if (std.mem.find(u8, region_text, ".")) |dot_pos| {
-                    const module_name = region_text[0..dot_pos];
-                    self.logDebug(.build, "[DEF] e_lookup_external: extracted module='{s}' from '{s}'", .{ module_name, region_text });
-                    return self.findModuleByName(module_name, oom);
+                    const prefix = region_text[0..dot_pos];
+                    const suffix = region_text[dot_pos + 1 ..];
+                    const dot_offset = lookup.region.start.offset + @as(u32, @intCast(dot_pos));
+                    if (target_offset < dot_offset) {
+                        if (completion_builtins.isBuiltinType(prefix)) {
+                            return self.findBuiltinDefinition(prefix, null, oom);
+                        }
+                        return self.findDefinitionInModule(module_name, null, oom);
+                    } else {
+                        if (completion_builtins.isBuiltinType(prefix)) {
+                            return self.findBuiltinDefinition(prefix, suffix, oom);
+                        }
+                    }
                 }
-                self.logDebug(.build, "[DEF] e_lookup_external: could not extract module name from '{s}'", .{region_text});
+                return self.findDefinitionInModule(module_name, member_name, oom);
+            }
+            if (expr_tag == .e_lookup_associated) {
+                const lookup = expr.e_lookup_associated;
+                const member_name = module_env.getIdentText(lookup.item_ident);
+                const import_idx_int = @intFromEnum(lookup.module_idx);
+                if (import_idx_int < module_env.imports.imports.len()) {
+                    const string_idx = module_env.imports.imports.items.items[import_idx_int];
+                    const module_name = module_env.common.getString(string_idx);
+                    const expr_node_idx: CIR.Node.Idx = @enumFromInt(@intFromEnum(expr_idx));
+                    const expr_region = module_env.store.getRegionAt(expr_node_idx);
+                    const region_text = module_env.getSource(expr_region);
+                    if (std.mem.find(u8, region_text, ".")) |dot_pos| {
+                        const prefix = region_text[0..dot_pos];
+                        const suffix = region_text[dot_pos + 1 ..];
+                        const dot_offset = expr_region.start.offset + @as(u32, @intCast(dot_pos));
+                        if (target_offset < dot_offset) {
+                            if (completion_builtins.isBuiltinType(prefix)) {
+                                return self.findBuiltinDefinition(prefix, null, oom);
+                            }
+                            return self.findDefinitionInModule(module_name, null, oom);
+                        } else {
+                            if (completion_builtins.isBuiltinType(prefix)) {
+                                return self.findBuiltinDefinition(prefix, suffix, oom);
+                            }
+                        }
+                    }
+                    return self.findDefinitionInModule(module_name, member_name, oom);
+                }
                 return null;
             }
             if (expr_tag == .e_dispatch_call) {
@@ -1724,103 +1860,447 @@ pub const SyntaxChecker = struct {
 
                 // Extract the base type name (e.g., "Str" from complex type)
                 const base_type = extractBaseTypeName(type_str);
+                const method_name = module_env.common.idents.getText(method_call.method_name);
 
-                self.logDebug(.build, "[DEF] e_dispatch_call type_str='{s}', base_type='{s}'", .{ type_str, base_type });
+                self.logDebug(.build, "[DEF] e_dispatch_call type_str='{s}', base_type='{s}', method_name='{s}'", .{ type_str, base_type, method_name });
 
-                // Find the module for this type
-                // TODO: Also navigate to the specific method definition within the module
-                const result = self.findModuleByName(base_type, oom);
+                // Find the module for this type and navigate to the specific method definition
+                const result = self.findDefinitionInModule(base_type, method_name, oom);
                 if (result == null) {
-                    self.logDebug(.build, "[DEF] findModuleByName returned null for '{s}'", .{base_type});
+                    self.logDebug(.build, "[DEF] findDefinitionInModule returned null for '{s}.{s}'", .{ base_type, method_name });
                 }
                 return result;
             }
             return null;
         }
 
+        // Check for tag expression or pattern (e.g. `WaitingForInit` in pattern `WaitingForInit =>` or expr `WaitingForInit`)
+        if (cir_queries.findTagAtOffset(module_env, target_offset)) |tag_name| {
+            return self.findTagDefinition(module_env, tag_name, current_uri, oom);
+        }
+
         return null;
     }
 
-    // isBuiltinType moved to completion/builtins.zig module
+    fn findTagInTypeAnno(store: *const can.NodeStore, common: *const base.CommonEnv, type_anno_idx: CIR.TypeAnno.Idx, tag_name: []const u8) ?Region {
+        const type_anno = store.getTypeAnno(type_anno_idx);
+        switch (type_anno) {
+            .tag_union => |tu| {
+                const tags_slice = store.sliceTypeAnnos(tu.tags);
+                for (tags_slice) |tag_idx| {
+                    const tag = store.getTypeAnno(tag_idx);
+                    if (tag == .tag) {
+                        const name = common.idents.getText(tag.tag.name);
+                        if (std.mem.eql(u8, name, tag_name)) {
+                            return store.getTypeAnnoRegion(tag_idx);
+                        }
+                    }
+                }
+                if (tu.ext) |ext_idx| {
+                    if (findTagInTypeAnno(store, common, ext_idx, tag_name)) |r| return r;
+                }
+            },
+            .tag => |t| {
+                const name = common.idents.getText(t.name);
+                if (std.mem.eql(u8, name, tag_name)) {
+                    return store.getTypeAnnoRegion(type_anno_idx);
+                }
+            },
+            .apply,
+            .rigid_var,
+            .rigid_var_lookup,
+            .underscore,
+            .lookup,
+            .tuple,
+            .record,
+            .@"fn",
+            .parens,
+            .malformed,
+            => {},
+        }
+        return null;
+    }
 
-    /// Helper function to find a module by name and return a DefinitionResult pointing to it
-    fn findModuleByName(self: *SyntaxChecker, module_name: []const u8, oom: *?Allocator.Error) ?DefinitionResult {
+    fn findTagInModuleEnv(mod_env: *ModuleEnv, tag_name: []const u8) ?Region {
+        const statements_slice = mod_env.store.sliceStatements(mod_env.all_statements);
+        for (statements_slice) |stmt_idx| {
+            const stmt = mod_env.store.getStatement(stmt_idx);
+            const maybe_anno: ?CIR.TypeAnno.Idx = switch (stmt) {
+                .s_alias_decl => |a| a.anno,
+                .s_nominal_decl => |n| n.anno,
+                .s_decl,
+                .s_var,
+                .s_var_uninitialized,
+                .s_reassign,
+                .s_crash,
+                .s_dbg,
+                .s_expr,
+                .s_expect,
+                .s_for,
+                .s_while,
+                .s_infinite_loop,
+                .s_breakable_loop,
+                .s_break,
+                .s_return,
+                .s_import,
+                .s_where_alias_decl,
+                .s_type_anno,
+                .s_type_var_alias,
+                .s_runtime_error,
+                => null,
+            };
+            if (maybe_anno) |anno_idx| {
+                if (findTagInTypeAnno(&mod_env.store, &mod_env.common, anno_idx, tag_name)) |r| {
+                    return r;
+                }
+            }
+        }
+        return null;
+    }
+
+    /// Helper function to find a tag declaration (e.g., `WaitingForInit` in `LoopState : [WaitingForInit, ...]`)
+    fn findTagDefinition(
+        self: *SyntaxChecker,
+        module_env: *ModuleEnv,
+        tag_name: []const u8,
+        current_uri: []const u8,
+        oom: *?Allocator.Error,
+    ) ?DefinitionResult {
+        // 1. Search in current module
+        if (findTagInModuleEnv(module_env, tag_name)) |tag_region| {
+            const range = cir_queries.regionToRange(module_env, tag_region) orelse return null;
+            const uri_copy = self.allocator.dupe(u8, current_uri) catch |err| {
+                oom.* = err;
+                return null;
+            };
+            return DefinitionResult{
+                .uri = uri_copy,
+                .range = range,
+            };
+        }
+
+        // 2. Search in imported modules
         const env = self.getModuleLookupEnv() orelse return null;
+        const statements_slice = module_env.store.sliceStatements(module_env.all_statements);
+        for (statements_slice) |stmt_idx| {
+            const stmt = module_env.store.getStatement(stmt_idx);
+            if (stmt == .s_import) {
+                const import_stmt = stmt.s_import;
+                const module_name = module_env.common.idents.getText(import_stmt.module_name_tok);
+                const base_name = if (std.mem.findLast(u8, module_name, ".")) |dot_pos|
+                    module_name[dot_pos + 1 ..]
+                else
+                    module_name;
 
+                if (env.findModuleByName(base_name)) |mod_state| {
+                    if (mod_state.moduleEnv()) |mod_env| {
+                        if (findTagInModuleEnv(mod_env, tag_name)) |tag_region| {
+                            const range = cir_queries.regionToRange(mod_env, tag_region) orelse continue;
+                            const module_uri = uri_util.pathToUri(self.allocator, mod_state.path) catch |err| {
+                                oom.* = err;
+                                return null;
+                            };
+                            return DefinitionResult{
+                                .uri = module_uri,
+                                .range = range,
+                            };
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// Helper function to find a builtin definition/type in Builtin.roc
+    fn findBuiltinDefinition(
+        self: *SyntaxChecker,
+        base_name: []const u8,
+        member_name: ?[]const u8,
+        oom: *?Allocator.Error,
+    ) ?DefinitionResult {
+        // Write embedded builtin source to roc cache
+        const cache_dir = self.cache_config.getModuleCacheDir(self.allocator) catch |err| switch (err) {
+            error.OutOfMemory => {
+                oom.* = error.OutOfMemory;
+                return null;
+            },
+            error.NoHomeDirectory => return null,
+        };
+        const builtin_cache_path = std.fs.path.join(self.allocator, &.{ cache_dir, "Builtin.roc" }) catch |err| {
+            self.allocator.free(cache_dir);
+            oom.* = err;
+            return null;
+        };
+        self.allocator.free(cache_dir);
+
+        // Write file if it doesn't exist
+        if (std.Io.Dir.cwd().access(self.std_io, builtin_cache_path, .{})) |_| {
+            // Already exists
+        } else |_| {
+            // Create parent dirs and write embedded source
+            if (std.fs.path.dirname(builtin_cache_path)) |dir| {
+                std.Io.Dir.cwd().createDirPath(self.std_io, dir) catch {};
+            }
+            const file = std.Io.Dir.cwd().createFile(self.std_io, builtin_cache_path, .{}) catch {
+                self.allocator.free(builtin_cache_path);
+                return null;
+            };
+            defer file.close(self.std_io);
+            file.writeStreamingAll(self.std_io, compiled_builtins.builtin_source) catch {
+                self.allocator.free(builtin_cache_path);
+                return null;
+            };
+        }
+
+        const module_uri = uri_util.pathToUri(self.allocator, builtin_cache_path) catch |err| {
+            self.allocator.free(builtin_cache_path);
+            oom.* = err;
+            return null;
+        };
+        self.allocator.free(builtin_cache_path);
+
+        var builtin_module = can.BuiltinStatic.moduleView(
+            self.allocator,
+            compiled_builtins.builtin_bin[0..],
+            "Builtin",
+            compiled_builtins.builtin_source,
+        ) catch {
+            return DefinitionResult{
+                .uri = module_uri,
+                .range = .{ .start_line = 0, .start_col = 0, .end_line = 0, .end_col = 0 },
+            };
+        };
+        defer builtin_module.deinit();
+
+        const benv = builtin_module.env;
+
+        // Find the type declaration region and end offset (the start of the next builtin type)
+        var type_decl_start_offset: ?u32 = null;
+        var type_decl_end_offset: u32 = std.math.maxInt(u32);
+        var type_decl_range: ?LspRange = null;
+
+        const builtin_indices = compiled_builtins.builtinIndices(CIR);
+        inline for (CIR.builtin_type_specs) |spec| {
+            if (std.mem.eql(u8, spec.display_name, base_name) or std.mem.eql(u8, spec.qualified_name, base_name)) {
+                const stmt_idx = @field(builtin_indices, spec.type_field);
+                const decl_region = benv.store.getStatementRegion(stmt_idx);
+                type_decl_start_offset = decl_region.start.offset;
+                type_decl_range = cir_queries.regionToRange(benv, decl_region);
+            }
+        }
+
+        if (type_decl_start_offset) |start_off| {
+            inline for (CIR.builtin_type_specs) |spec| {
+                if (spec.lookup == .top_level) {
+                    const stmt_idx = @field(builtin_indices, spec.type_field);
+                    const decl_region = benv.store.getStatementRegion(stmt_idx);
+                    if (decl_region.start.offset > start_off and decl_region.start.offset < type_decl_end_offset) {
+                        type_decl_end_offset = decl_region.start.offset;
+                    }
+                }
+            }
+        }
+
+        if (member_name) |member| {
+            const start = type_decl_start_offset orelse 0;
+            const end = @min(type_decl_end_offset, @as(u32, @intCast(compiled_builtins.builtin_source.len)));
+            if (start < end) {
+                const search_slice = compiled_builtins.builtin_source[start..end];
+                var line_it = std.mem.splitScalar(u8, search_slice, '\n');
+                var current_line_offset: usize = 0;
+                while (line_it.next()) |line| {
+                    defer current_line_offset += line.len + 1;
+
+                    var col: usize = 0;
+                    while (col < line.len and (line[col] == '\t' or line[col] == ' ')) : (col += 1) {}
+
+                    if (col < line.len and line[col] == '#') {
+                        continue;
+                    }
+
+                    const remaining = line[col..];
+                    if (std.mem.startsWith(u8, remaining, member)) {
+                        const after = remaining[member.len..];
+                        var after_idx: usize = 0;
+                        while (after_idx < after.len and (after[after_idx] == '\t' or after[after_idx] == ' ')) : (after_idx += 1) {}
+
+                        // A declaration header must be followed by ':' or '=' (e.g. `append :`, `append =`, `append ::`)
+                        if (after_idx < after.len and (after[after_idx] == ':' or after[after_idx] == '=')) {
+                            const abs_offset: u32 = start + @as(u32, @intCast(current_line_offset + col));
+                            const match_region = Region{
+                                .start = .{ .offset = abs_offset },
+                                .end = .{ .offset = abs_offset + @as(u32, @intCast(member.len)) },
+                            };
+                            if (cir_queries.regionToRange(benv, match_region)) |r| {
+                                return DefinitionResult{
+                                    .uri = module_uri,
+                                    .range = r,
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (type_decl_range) |r| {
+            return DefinitionResult{
+                .uri = module_uri,
+                .range = r,
+            };
+        }
+
+        return DefinitionResult{
+            .uri = module_uri,
+            .range = .{ .start_line = 0, .start_col = 0, .end_line = 0, .end_col = 0 },
+        };
+    }
+
+    fn findMemberRangeInModuleEnv(mod_env: *ModuleEnv, base_name: []const u8, member: []const u8) ?LspRange {
+        var qualified_buf: [128]u8 = undefined;
+        const qualified = std.fmt.bufPrint(&qualified_buf, "{s}.{s}", .{ base_name, member }) catch null;
+
+        const maybe_def = module_lookup.findDefinitionByName(mod_env, member) orelse
+            (if (qualified) |q| module_lookup.findDefinitionByName(mod_env, q) else null);
+
+        if (maybe_def) |def_info| {
+            const pattern_node_idx: CIR.Node.Idx = @enumFromInt(@intFromEnum(def_info.pattern_idx));
+            const def_region = mod_env.store.getRegionAt(pattern_node_idx);
+            return cir_queries.regionToRange(mod_env, def_region);
+        }
+
+        const statements_slice = mod_env.store.sliceStatements(mod_env.all_statements);
+        for (statements_slice) |stmt_idx| {
+            const stmt = mod_env.store.getStatement(stmt_idx);
+            const header_idx: ?CIR.TypeHeader.Idx = switch (stmt) {
+                .s_alias_decl => |a| a.header,
+                .s_nominal_decl => |n| n.header,
+                .s_decl,
+                .s_var,
+                .s_var_uninitialized,
+                .s_reassign,
+                .s_crash,
+                .s_dbg,
+                .s_expr,
+                .s_expect,
+                .s_for,
+                .s_while,
+                .s_infinite_loop,
+                .s_breakable_loop,
+                .s_break,
+                .s_return,
+                .s_import,
+                .s_where_alias_decl,
+                .s_type_anno,
+                .s_type_var_alias,
+                .s_runtime_error,
+                => null,
+            };
+            if (header_idx) |h_idx| {
+                const header = mod_env.store.getTypeHeader(h_idx);
+                const header_name = mod_env.getIdentText(header.name);
+                if (std.mem.eql(u8, header_name, member) or (qualified != null and std.mem.eql(u8, header_name, qualified.?))) {
+                    const decl_region = mod_env.store.getStatementRegion(stmt_idx);
+                    return cir_queries.regionToRange(mod_env, decl_region);
+                }
+            }
+        }
+        return null;
+    }
+
+    /// Helper function to find a definition in a module by module name and optional member name
+    fn findDefinitionInModule(
+        self: *SyntaxChecker,
+        module_name: []const u8,
+        member_name: ?[]const u8,
+        oom: *?Allocator.Error,
+    ) ?DefinitionResult {
         // Extract the base module name (e.g., "Stdout" from "pf.Stdout")
         const base_name = if (std.mem.findLast(u8, module_name, ".")) |dot_pos|
             module_name[dot_pos + 1 ..]
         else
             module_name;
 
+        // Check if member is a builtin type member (e.g., "Str.is_empty" or "List.is_empty")
+        if (member_name) |member| {
+            if (std.mem.find(u8, member, ".")) |dot_pos| {
+                const prefix = member[0..dot_pos];
+                const suffix = member[dot_pos + 1 ..];
+                if (completion_builtins.isBuiltinType(prefix)) {
+                    return self.findBuiltinDefinition(prefix, suffix, oom);
+                }
+            }
+        }
+
         // Check if this is a builtin type - use embedded Builtin.roc source
         if (completion_builtins.isBuiltinType(base_name)) {
             self.logDebug(.build, "[DEF] '{s}' is a builtin type", .{base_name});
-
-            // Write embedded builtin source to roc cache
-            const cache_dir = self.cache_config.getModuleCacheDir(self.allocator) catch |err| switch (err) {
-                error.OutOfMemory => {
-                    oom.* = error.OutOfMemory;
-                    return null;
-                },
-                error.NoHomeDirectory,
-                => return null,
-            };
-            const builtin_cache_path = std.fs.path.join(self.allocator, &.{ cache_dir, "Builtin.roc" }) catch |err| {
-                self.allocator.free(cache_dir);
-                oom.* = err;
-                return null;
-            };
-            self.allocator.free(cache_dir);
-
-            // Write file if it doesn't exist
-            if (std.Io.Dir.cwd().access(self.std_io, builtin_cache_path, .{})) |_| {
-                // Already exists
-            } else |_| {
-                // Create parent dirs and write embedded source
-                if (std.fs.path.dirname(builtin_cache_path)) |dir| {
-                    std.Io.Dir.cwd().createDirPath(self.std_io, dir) catch {};
-                }
-                const file = std.Io.Dir.cwd().createFile(self.std_io, builtin_cache_path, .{}) catch {
-                    self.allocator.free(builtin_cache_path);
-                    return null;
-                };
-                defer file.close(self.std_io);
-                file.writeStreamingAll(self.std_io, compiled_builtins.builtin_source) catch {
-                    self.allocator.free(builtin_cache_path);
-                    return null;
-                };
-            }
-
-            const module_uri = uri_util.pathToUri(self.allocator, builtin_cache_path) catch |err| {
-                self.allocator.free(builtin_cache_path);
-                oom.* = err;
-                return null;
-            };
-            self.allocator.free(builtin_cache_path);
-
-            return DefinitionResult{
-                .uri = module_uri,
-                .range = .{ .start_line = 0, .start_col = 0, .end_line = 0, .end_col = 0 },
-            };
+            return self.findBuiltinDefinition(base_name, member_name, oom);
         }
 
-        if (env.findModuleByName(base_name)) |mod_state| {
+        if (std.mem.eql(u8, base_name, "Builtin")) {
+            if (member_name) |member| {
+                if (std.mem.find(u8, member, ".")) |dot_pos| {
+                    const prefix = member[0..dot_pos];
+                    const suffix = member[dot_pos + 1 ..];
+                    return self.findBuiltinDefinition(prefix, suffix, oom);
+                }
+                if (completion_builtins.isBuiltinType(member)) {
+                    return self.findBuiltinDefinition(member, null, oom);
+                }
+            }
+        }
+
+        const env = self.getModuleLookupEnv() orelse return null;
+        if (env.findModuleByQualifiedName(module_name) orelse env.findModuleByName(base_name)) |mod_state| {
             const module_uri = uri_util.pathToUri(self.allocator, mod_state.path) catch |err| {
                 oom.* = err;
                 return null;
             };
+
+            var range = LspRange{
+                .start_line = 0,
+                .start_col = 0,
+                .end_line = 0,
+                .end_col = 0,
+            };
+
+            if (member_name) |member| {
+                var found_range: ?LspRange = null;
+                const mod_env_opt = mod_state.moduleEnv() orelse self.getModuleEnvByPath(mod_state.path);
+                if (mod_env_opt) |mod_env| {
+                    found_range = findMemberRangeInModuleEnv(mod_env, base_name, member);
+                }
+                if (found_range == null) {
+                    if (self.getSnapshotEnv()) |snap_env| {
+                        if (snap_env.findModuleByQualifiedName(module_name) orelse snap_env.findModuleByName(base_name)) |snap_mod_state| {
+                            if (snap_mod_state.moduleEnv()) |snap_mod_env| {
+                                found_range = findMemberRangeInModuleEnv(snap_mod_env, base_name, member);
+                            }
+                        }
+                    }
+                }
+                if (found_range) |r| {
+                    range = r;
+                } else {
+                    range = .{ .start_line = 0, .start_col = 0, .end_line = 0, .end_col = 0 };
+                }
+            }
+
             return DefinitionResult{
                 .uri = module_uri,
-                .range = .{
-                    .start_line = 0,
-                    .start_col = 0,
-                    .end_line = 0,
-                    .end_col = 0,
-                },
+                .range = range,
             };
         }
+
         return null;
+    }
+
+    /// Helper function to find a module by name and return a DefinitionResult pointing to it
+    fn findModuleByName(self: *SyntaxChecker, module_name: []const u8, oom: *?Allocator.Error) ?DefinitionResult {
+        return self.findDefinitionInModule(module_name, null, oom);
     }
 
     /// Extract the base type name from a type string (e.g., "Str" from "Str", "List a" -> "List")
@@ -1844,6 +2324,50 @@ pub const SyntaxChecker = struct {
 
     // findLookupAtOffset moved to cir_queries module
 
+    fn resolveTypeBase(
+        self: *SyntaxChecker,
+        module_env: *ModuleEnv,
+        base_info: CIR.TypeAnno.LocalOrExternal,
+        type_name: []const u8,
+        oom: *?Allocator.Error,
+    ) ?DefinitionResult {
+        switch (base_info) {
+            .local => |local| {
+                // Local type definition - navigate to the statement where it's declared
+                const decl_region = module_env.store.getStatementRegion(local.decl_idx);
+                const range = cir_queries.regionToRange(module_env, decl_region) orelse return null;
+                return DefinitionResult{
+                    .uri = "", // Empty URI means same file - caller should fill in
+                    .range = range,
+                };
+            },
+            .external => |ext| {
+                const import_idx_int = @intFromEnum(ext.module_idx);
+                if (import_idx_int < module_env.imports.imports.len()) {
+                    const string_idx = module_env.imports.imports.items.items[import_idx_int];
+                    const module_name = module_env.common.getString(string_idx);
+                    return self.findDefinitionInModule(module_name, type_name, oom);
+                }
+                return self.findModuleByName(type_name, oom);
+            },
+            .pending => |pend| {
+                const import_idx_int = @intFromEnum(pend.module_idx);
+                if (import_idx_int < module_env.imports.imports.len()) {
+                    const string_idx = module_env.imports.imports.items.items[import_idx_int];
+                    const module_name = module_env.common.getString(string_idx);
+                    return self.findDefinitionInModule(module_name, type_name, oom);
+                }
+                return self.findModuleByName(type_name, oom);
+            },
+            .builtin => {
+                if (completion_builtins.isBuiltinType(type_name)) {
+                    return self.findBuiltinDefinition(type_name, null, oom);
+                }
+                return self.findModuleByName(type_name, oom);
+            },
+        }
+    }
+
     /// Find the type annotation at the given offset and return a DefinitionResult.
     /// This recursively walks type annotation trees to find the most specific type at the cursor.
     fn findTypeAnnoAtOffset(
@@ -1864,25 +2388,7 @@ pub const SyntaxChecker = struct {
                     type_name,
                     @tagName(lookup.base),
                 });
-
-                switch (lookup.base) {
-                    .local => |local| {
-                        // Local type definition - navigate to the statement where it's declared
-                        const decl_region = module_env.store.getStatementRegion(local.decl_idx);
-                        const range = cir_queries.regionToRange(module_env, decl_region) orelse return null;
-                        // For local definitions, we need the current file URI
-                        // Since we don't have it here, we return null and let the caller handle it
-                        // Actually, we can construct a result with a marker that means "same file"
-                        return DefinitionResult{
-                            .uri = "", // Empty URI means same file - caller should fill in
-                            .range = range,
-                        };
-                    },
-                    .builtin, .external, .pending => {
-                        // Builtin, external, or pending type - find the module
-                        return self.findModuleByName(type_name, oom);
-                    },
-                }
+                return self.resolveTypeBase(module_env, lookup.base, type_name, oom);
             },
             .apply => |apply| {
                 // Type with args like `List(Str)` - check args first, then the base type
@@ -1898,22 +2404,7 @@ pub const SyntaxChecker = struct {
                     type_name,
                     @tagName(apply.base),
                 });
-
-                switch (apply.base) {
-                    .local => |local| {
-                        // Local type definition - navigate to the statement where it's declared
-                        const decl_region = module_env.store.getStatementRegion(local.decl_idx);
-                        const range = cir_queries.regionToRange(module_env, decl_region) orelse return null;
-                        return DefinitionResult{
-                            .uri = "", // Empty URI means same file - caller should fill in
-                            .range = range,
-                        };
-                    },
-                    .builtin, .external, .pending => {
-                        // Builtin, external, or pending type - find the module
-                        return self.findModuleByName(type_name, oom);
-                    },
-                }
+                return self.resolveTypeBase(module_env, apply.base, type_name, oom);
             },
             .record => |rec| {
                 // Check record field types

--- a/src/lsp/test/handler_integration_tests.zig
+++ b/src/lsp/test/handler_integration_tests.zig
@@ -9,7 +9,10 @@ const server_module = @import("lsp").server;
 const helpers = @import("helpers.zig");
 const integration_spec = @import("integration_spec.zig");
 const test_env = @import("integration_env.zig");
-
+const compile = @import("compile");
+const CacheConfig = compile.CacheConfig;
+const CoreCtx = @import("ctx").CoreCtx;
+const compiled_builtins = @import("compiled_builtins");
 const frame = helpers.frame;
 const uriFromPath = helpers.uriFromPath;
 
@@ -222,6 +225,17 @@ pub const specs = [_]integration_spec.Spec{
     .{ .name = "definition handler returns null for undefined symbol", .run = definitionHandlerReturnsNullForUndefinedSymbol },
     .{ .name = "hover handler handles type annotation request", .run = hoverHandlerReturnsTypeInfoForTypeAnnotation },
     .{ .name = "definition handler handles builtin type annotation request", .run = definitionHandlerNavigatesToBuiltinTypeFromTypeAnnotation },
+    .{ .name = "definition handler navigates to builtin declarations", .run = definitionHandlerNavigatesToBuiltinDeclarations },
+    .{ .name = "definition handler navigates to external module members", .run = definitionHandlerNavigatesToExternalModuleMembers },
+    .{ .name = "definition handler navigates to exposed import member in import statement", .run = definitionHandlerNavigatesToExposedImportMemberInImportStatement },
+    .{ .name = "definition handler navigates to unqualified exposed import function call", .run = definitionHandlerNavigatesToUnqualifiedExposedImportFunctionCall },
+    .{ .name = "definition handler navigates to tag declaration in pattern match", .run = definitionHandlerNavigatesToTagDeclarationInPatternMatch },
+    .{ .name = "definition handler navigates to exposed type alias in type annotation", .run = definitionHandlerNavigatesToExposedTypeAliasInTypeAnnotation },
+    .{ .name = "definition handler navigates to file import path", .run = definitionHandlerNavigatesToFileImportPath },
+    .{ .name = "definition handler navigates to default app echo platform definition", .run = definitionHandlerNavigatesToEchoPlatformDefinition },
+    .{ .name = "semantic tokens handler handles file imports without crashing", .run = semanticTokensHandlerHandlesFileImportsWithoutCrashing },
+    .{ .name = "workspace document ending in Builtin.roc builds and produces diagnostics", .run = workspaceDocumentEndingInBuiltinRocBuildsAndProducesDiagnostics },
+    .{ .name = "opening Builtin.roc does not panic", .run = openingBuiltinRocDoesNotPanic },
     .{ .name = "document symbols works after goto definition (regression test)", .run = documentSymbolsWorksAfterGotoDefinitionRegressionTest },
     .{ .name = "multiple goto definition calls don't break document symbols", .run = multipleGotoDefinitionCallsDontBreakDocumentSymbols },
     .{ .name = "document symbol handler returns symbols with correct names", .run = documentSymbolHandlerReturnsSymbolsWithCorrectNames },
@@ -809,7 +823,12 @@ pub fn definitionHandlerNavigatesToBuiltinTypeFromTypeAnnotation() integration_s
     try std.testing.expect(result == .object);
     const uri = try stringField(result, "uri");
     try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
-    try expectRange(try objectField(result, "range"), 0, 0, 0, 0);
+    const range = try objectField(result, "range");
+    const start = try objectField(range, "start");
+    const start_line = try integerField(start, "line");
+    // Str is declared around line 2204 in Builtin.roc
+    try std.testing.expect(start_line > 0);
+    try std.testing.expectEqual(@as(i64, 2204), start_line);
 }
 
 /// Verifies document symbols still work after a goto-definition request.
@@ -2113,4 +2132,1220 @@ pub fn completionHandlerReturnsRecordFieldsAfterDot() integration_spec.SpecError
             try std.testing.expectEqual(@as(i64, 5), try integerField(item, "kind"));
         }
     }
+}
+
+/// Verifies goto definition on builtin member functions (Str.is_empty, List.is_empty, List.append, Dict.update)
+/// and builtin type prefixes (Dict) resolve to their exact declarations in Builtin.roc.
+pub fn definitionHandlerNavigatesToBuiltinDeclarations() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const main_path = try std.fs.path.join(allocator, &.{ tmp_path, "main.roc" });
+    defer allocator.free(main_path);
+    const main_uri = try uriFromPath(allocator, main_path);
+    defer allocator.free(main_uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    const init_body =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+    ;
+    const init_msg = try frame(allocator, init_body);
+    defer allocator.free(init_msg);
+
+    const initialized_body =
+        \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+    ;
+    const initialized_msg = try frame(allocator, initialized_body);
+    defer allocator.free(initialized_msg);
+
+    const open_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"app [check] {{ pf: platform \"{s}\" }}\n\ns_empty = Str.is_empty(\"\")\nl_empty = List.is_empty([])\nappend_check = List.append([1], 2)\ndict_check = Dict.update(Dict.empty({{}}), 1, |v| v)"}}}}}}
+    , .{ main_uri, platform_path });
+    defer allocator.free(open_body);
+    const open_msg = try frame(allocator, open_body);
+    defer allocator.free(open_msg);
+
+    // Line 2: s_empty = Str.is_empty("") -> character 16 is on 'is_empty'
+    const def_str_empty_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":2,"character":16}}}}}}
+    , .{main_uri});
+    defer allocator.free(def_str_empty_body);
+    const def_str_empty_msg = try frame(allocator, def_str_empty_body);
+    defer allocator.free(def_str_empty_msg);
+
+    // Line 3: l_empty = List.is_empty([]) -> character 16 is on 'is_empty'
+    const def_list_empty_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":3,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":3,"character":16}}}}}}
+    , .{main_uri});
+    defer allocator.free(def_list_empty_body);
+    const def_list_empty_msg = try frame(allocator, def_list_empty_body);
+    defer allocator.free(def_list_empty_msg);
+
+    // Line 4: append_check = List.append([1], 2) -> character 22 is on 'append'
+    const def_append_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":4,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":4,"character":22}}}}}}
+    , .{main_uri});
+    defer allocator.free(def_append_body);
+    const def_append_msg = try frame(allocator, def_append_body);
+    defer allocator.free(def_append_msg);
+
+    // Line 5: dict_check = Dict.update(...) -> character 19 is on 'update'
+    const def_update_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":5,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":5,"character":19}}}}}}
+    , .{main_uri});
+    defer allocator.free(def_update_body);
+    const def_update_msg = try frame(allocator, def_update_body);
+    defer allocator.free(def_update_msg);
+
+    // Line 5: dict_check = Dict.update(...) -> character 14 is on 'Dict' (prefix)
+    const def_dict_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":6,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":5,"character":14}}}}}}
+    , .{main_uri});
+    defer allocator.free(def_dict_body);
+    const def_dict_msg = try frame(allocator, def_dict_body);
+    defer allocator.free(def_dict_msg);
+
+    const shutdown_body =
+        \\{"jsonrpc":"2.0","id":7,"method":"shutdown"}
+    ;
+    const shutdown_msg = try frame(allocator, shutdown_body);
+    defer allocator.free(shutdown_msg);
+
+    const exit_body =
+        \\{"jsonrpc":"2.0","method":"exit"}
+    ;
+    const exit_msg = try frame(allocator, exit_body);
+    defer allocator.free(exit_msg);
+
+    var builder: std.ArrayList(u8) = .empty;
+    defer builder.deinit(allocator);
+    try builder.appendSlice(allocator, init_msg);
+    try builder.appendSlice(allocator, initialized_msg);
+    try builder.appendSlice(allocator, open_msg);
+    try builder.appendSlice(allocator, def_str_empty_msg);
+    try builder.appendSlice(allocator, def_list_empty_msg);
+    try builder.appendSlice(allocator, def_append_msg);
+    try builder.appendSlice(allocator, def_update_msg);
+    try builder.appendSlice(allocator, def_dict_msg);
+    try builder.appendSlice(allocator, shutdown_msg);
+    try builder.appendSlice(allocator, exit_msg);
+    const combined = try builder.toOwnedSlice(allocator);
+    defer allocator.free(combined);
+
+    const reader_stream: std.Io.Reader = .fixed(combined);
+    var writer_buffer: [16384]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    const ReaderType = std.Io.Reader;
+    const WriterType = std.Io.Writer;
+    var server = try server_module.Server(ReaderType, WriterType).init(allocator, test_env.io, reader_stream, writer_stream, null, .{});
+    test_env.configureChecker(&server.syntax_checker, tmp_path);
+    defer server.deinit();
+    try server.run();
+
+    const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    // Str.is_empty (id: 2) -> line 2219 (0-based)
+    {
+        var response = try responseById(allocator, responses, 2);
+        defer response.deinit();
+        const result = try response.result();
+        try std.testing.expect(result == .object);
+        const uri = try stringField(result, "uri");
+        try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
+        const range = try objectField(result, "range");
+        const start = try objectField(range, "start");
+        const start_line = try integerField(start, "line");
+        try std.testing.expectEqual(@as(i64, 2219), start_line);
+    }
+
+    // List.is_empty (id: 3) -> line 3572 (0-based)
+    {
+        var response = try responseById(allocator, responses, 3);
+        defer response.deinit();
+        const result = try response.result();
+        try std.testing.expect(result == .object);
+        const uri = try stringField(result, "uri");
+        try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
+        const range = try objectField(result, "range");
+        const start = try objectField(range, "start");
+        const start_line = try integerField(start, "line");
+        try std.testing.expectEqual(@as(i64, 3572), start_line);
+    }
+
+    // List.append (id: 4) -> line 3933 (0-based)
+    {
+        var response = try responseById(allocator, responses, 4);
+        defer response.deinit();
+        const result = try response.result();
+        try std.testing.expect(result == .object);
+        const uri = try stringField(result, "uri");
+        try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
+        const range = try objectField(result, "range");
+        const start = try objectField(range, "start");
+        const start_line = try integerField(start, "line");
+        try std.testing.expectEqual(@as(i64, 3933), start_line);
+    }
+
+    // Dict.update (id: 5) -> line 6188 (0-based)
+    {
+        var response = try responseById(allocator, responses, 5);
+        defer response.deinit();
+        const result = try response.result();
+        try std.testing.expect(result == .object);
+        const uri = try stringField(result, "uri");
+        try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
+        const range = try objectField(result, "range");
+        const start = try objectField(range, "start");
+        const start_line = try integerField(start, "line");
+        try std.testing.expectEqual(@as(i64, 6188), start_line);
+    }
+
+    // Dict prefix (id: 6) -> line 5542 (0-based)
+    {
+        var response = try responseById(allocator, responses, 6);
+        defer response.deinit();
+        const result = try response.result();
+        try std.testing.expect(result == .object);
+        const uri = try stringField(result, "uri");
+        try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
+        const range = try objectField(result, "range");
+        const start = try objectField(range, "start");
+        const start_line = try integerField(start, "line");
+        try std.testing.expectEqual(@as(i64, 5542), start_line);
+    }
+}
+
+/// Verifies that an ordinary workspace document whose path ends in Builtin.roc (e.g. MyBuiltin.roc)
+/// is built normally and publishes diagnostics.
+pub fn workspaceDocumentEndingInBuiltinRocBuildsAndProducesDiagnostics() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const my_builtin_path = try std.fs.path.join(allocator, &.{ tmp_path, "MyBuiltin.roc" });
+    defer allocator.free(my_builtin_path);
+    const my_builtin_uri = try uriFromPath(allocator, my_builtin_path);
+    defer allocator.free(my_builtin_uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    const init_body =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+    ;
+    const init_msg = try frame(allocator, init_body);
+    defer allocator.free(init_msg);
+
+    const initialized_body =
+        \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+    ;
+    const initialized_msg = try frame(allocator, initialized_body);
+    defer allocator.free(initialized_msg);
+
+    // MyBuiltin.roc with invalid code to trigger diagnostics
+    const open_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"module [bad]\n\nbad : Str\nbad = 123"}}}}}}
+    , .{my_builtin_uri});
+    defer allocator.free(open_body);
+    const open_msg = try frame(allocator, open_body);
+    defer allocator.free(open_msg);
+
+    const shutdown_body =
+        \\{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+    ;
+    const shutdown_msg = try frame(allocator, shutdown_body);
+    defer allocator.free(shutdown_msg);
+
+    const exit_body =
+        \\{"jsonrpc":"2.0","method":"exit"}
+    ;
+    const exit_msg = try frame(allocator, exit_body);
+    defer allocator.free(exit_msg);
+
+    var builder: std.ArrayList(u8) = .empty;
+    defer builder.deinit(allocator);
+    try builder.appendSlice(allocator, init_msg);
+    try builder.appendSlice(allocator, initialized_msg);
+    try builder.appendSlice(allocator, open_msg);
+    try builder.appendSlice(allocator, shutdown_msg);
+    try builder.appendSlice(allocator, exit_msg);
+    const combined = try builder.toOwnedSlice(allocator);
+    defer allocator.free(combined);
+
+    const reader_stream: std.Io.Reader = .fixed(combined);
+    var writer_buffer: [16384]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    const ReaderType = std.Io.Reader;
+    const WriterType = std.Io.Writer;
+    var server = try server_module.Server(ReaderType, WriterType).init(allocator, test_env.io, reader_stream, writer_stream, null, .{});
+    test_env.configureChecker(&server.syntax_checker, tmp_path);
+    defer server.deinit();
+    try server.run();
+
+    const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    var found_diag = false;
+    for (responses) |resp_bytes| {
+        var parsed = try std.json.parseFromSlice(std.json.Value, allocator, resp_bytes, .{});
+        defer parsed.deinit();
+        if (parsed.value == .object) {
+            if (parsed.value.object.get("method")) |method| {
+                if (method == .string and std.mem.eql(u8, method.string, "textDocument/publishDiagnostics")) {
+                    if (parsed.value.object.get("params")) |params| {
+                        if (params.object.get("diagnostics")) |diags| {
+                            if (diags.array.items.len > 0) {
+                                found_diag = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    try std.testing.expect(found_diag);
+}
+
+/// Verifies that opening Builtin.roc directly as a document does not crash or panic.
+pub fn openingBuiltinRocDoesNotPanic() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+
+    var cache_config = CacheConfig{ .roc_ctx = CoreCtx.default(allocator, allocator, test_env.io) };
+    cache_config.cache_dir = tmp_path;
+    const cache_dir = cache_config.getModuleCacheDir(allocator) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.NoHomeDirectory => return,
+    };
+    defer allocator.free(cache_dir);
+    const builtin_path = try std.fs.path.join(allocator, &.{ cache_dir, "Builtin.roc" });
+    defer allocator.free(builtin_path);
+    const builtin_uri = try uriFromPath(allocator, builtin_path);
+    defer allocator.free(builtin_uri);
+
+    const init_body =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+    ;
+    const init_msg = try frame(allocator, init_body);
+    defer allocator.free(init_msg);
+
+    const initialized_body =
+        \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+    ;
+    const initialized_msg = try frame(allocator, initialized_body);
+    defer allocator.free(initialized_msg);
+
+    var json_writer: std.Io.Writer.Allocating = .init(allocator);
+    defer json_writer.deinit();
+    try std.json.Stringify.value(std.json.Value{ .string = compiled_builtins.builtin_source }, .{}, &json_writer.writer);
+    const escaped_source = json_writer.written();
+
+    const open_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":{s}}}}}}}
+    , .{ builtin_uri, escaped_source });
+    defer allocator.free(open_body);
+    const open_msg = try frame(allocator, open_body);
+    defer allocator.free(open_msg);
+
+    const shutdown_body =
+        \\{"jsonrpc":"2.0","id":2,"method":"shutdown"}
+    ;
+    const shutdown_msg = try frame(allocator, shutdown_body);
+    defer allocator.free(shutdown_msg);
+
+    const exit_body =
+        \\{"jsonrpc":"2.0","method":"exit"}
+    ;
+    const exit_msg = try frame(allocator, exit_body);
+    defer allocator.free(exit_msg);
+
+    var builder: std.ArrayList(u8) = .empty;
+    defer builder.deinit(allocator);
+    try builder.appendSlice(allocator, init_msg);
+    try builder.appendSlice(allocator, initialized_msg);
+    try builder.appendSlice(allocator, open_msg);
+    try builder.appendSlice(allocator, shutdown_msg);
+    try builder.appendSlice(allocator, exit_msg);
+    const combined = try builder.toOwnedSlice(allocator);
+    defer allocator.free(combined);
+
+    const reader_stream: std.Io.Reader = .fixed(combined);
+    var writer_buffer: [16384]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    const ReaderType = std.Io.Reader;
+    const WriterType = std.Io.Writer;
+    var server = try server_module.Server(ReaderType, WriterType).init(allocator, test_env.io, reader_stream, writer_stream, null, .{});
+    test_env.configureChecker(&server.syntax_checker, tmp_path);
+    defer server.deinit();
+    try server.run();
+}
+
+/// Verifies goto definition on external module members (both annotated and unannotated) reaches the exact declaration.
+pub fn definitionHandlerNavigatesToExternalModuleMembers() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const helper_path = try std.fs.path.join(allocator, &.{ tmp_path, "ComputeHelper.roc" });
+    defer allocator.free(helper_path);
+    const helper_uri = try uriFromPath(allocator, helper_path);
+    defer allocator.free(helper_uri);
+    const main_path = try std.fs.path.join(allocator, &.{ tmp_path, "main.roc" });
+    defer allocator.free(main_path);
+    const main_uri = try uriFromPath(allocator, main_path);
+    defer allocator.free(main_uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    const helper_source =
+        \\module [greet, compute]
+        \\
+        \\greet : Str -> Str
+        \\greet = |name| "Hello, "
+        \\
+        \\compute = |x| x + 1
+    ;
+    try tmp.dir.writeFile(test_env.io, .{ .sub_path = "ComputeHelper.roc", .data = helper_source });
+
+    const init_body =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+    ;
+    const init_msg = try frame(allocator, init_body);
+    defer allocator.free(init_msg);
+
+    const initialized_body =
+        \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+    ;
+    const initialized_msg = try frame(allocator, initialized_body);
+    defer allocator.free(initialized_msg);
+
+    const open_main_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"app [result] {{ pf: platform \"{s}\" }}\n\nimport ComputeHelper\n\nresult = ComputeHelper.greet(\"World\")\nans = ComputeHelper.compute(42)"}}}}}}
+    , .{ main_uri, platform_path });
+    defer allocator.free(open_main_body);
+    const open_main_msg = try frame(allocator, open_main_body);
+    defer allocator.free(open_main_msg);
+
+    // Line 4: result = ComputeHelper.greet("World") -> character 27 is on 'greet'
+    const def_greet_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":4,"character":27}}}}}}
+    , .{main_uri});
+    defer allocator.free(def_greet_body);
+    const def_greet_msg = try frame(allocator, def_greet_body);
+    defer allocator.free(def_greet_msg);
+
+    // Line 5: ans = ComputeHelper.compute(42) -> character 24 is on 'compute'
+    const def_compute_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":3,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":5,"character":24}}}}}}
+    , .{main_uri});
+    defer allocator.free(def_compute_body);
+    const def_compute_msg = try frame(allocator, def_compute_body);
+    defer allocator.free(def_compute_msg);
+
+    const shutdown_body =
+        \\{"jsonrpc":"2.0","id":4,"method":"shutdown"}
+    ;
+    const shutdown_msg = try frame(allocator, shutdown_body);
+    defer allocator.free(shutdown_msg);
+
+    const exit_body =
+        \\{"jsonrpc":"2.0","method":"exit"}
+    ;
+    const exit_msg = try frame(allocator, exit_body);
+    defer allocator.free(exit_msg);
+
+    var builder: std.ArrayList(u8) = .empty;
+    defer builder.deinit(allocator);
+    try builder.appendSlice(allocator, init_msg);
+    try builder.appendSlice(allocator, initialized_msg);
+    try builder.appendSlice(allocator, open_main_msg);
+    try builder.appendSlice(allocator, def_greet_msg);
+    try builder.appendSlice(allocator, def_compute_msg);
+    try builder.appendSlice(allocator, shutdown_msg);
+    try builder.appendSlice(allocator, exit_msg);
+    const combined = try builder.toOwnedSlice(allocator);
+    defer allocator.free(combined);
+
+    const reader_stream: std.Io.Reader = .fixed(combined);
+    var writer_buffer: [16384]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    const ReaderType = std.Io.Reader;
+    const WriterType = std.Io.Writer;
+    var server = try server_module.Server(ReaderType, WriterType).init(allocator, test_env.io, reader_stream, writer_stream, null, .{});
+    test_env.configureChecker(&server.syntax_checker, tmp_path);
+    defer server.deinit();
+    try server.run();
+
+    const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    // greet definition in ComputeHelper.roc is at line 3 (0-based)
+    {
+        var response = try responseById(allocator, responses, 2);
+        defer response.deinit();
+        const result = try response.result();
+        try std.testing.expect(result == .object);
+        const uri = try stringField(result, "uri");
+        try std.testing.expect(std.mem.endsWith(u8, uri, "ComputeHelper.roc"));
+        const range = try objectField(result, "range");
+        const start = try objectField(range, "start");
+        const start_line = try integerField(start, "line");
+        try std.testing.expectEqual(@as(i64, 3), start_line);
+    }
+
+    // compute definition in ComputeHelper.roc is at line 5 (0-based)
+    {
+        var response = try responseById(allocator, responses, 3);
+        defer response.deinit();
+        const result = try response.result();
+        try std.testing.expect(result == .object);
+        const uri = try stringField(result, "uri");
+        try std.testing.expect(std.mem.endsWith(u8, uri, "ComputeHelper.roc"));
+        const range = try objectField(result, "range");
+        const start = try objectField(range, "start");
+        const start_line = try integerField(start, "line");
+        try std.testing.expectEqual(@as(i64, 5), start_line);
+    }
+}
+
+/// Verifies goto definition on an exposed item in an import statement (e.g. `import Helpers exposing [decode_json]`).
+pub fn definitionHandlerNavigatesToExposedImportMemberInImportStatement() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const helper_path = try std.fs.path.join(allocator, &.{ tmp_path, "Helpers.roc" });
+    defer allocator.free(helper_path);
+    const helper_uri = try uriFromPath(allocator, helper_path);
+    defer allocator.free(helper_uri);
+    const main_path = try std.fs.path.join(allocator, &.{ tmp_path, "main.roc" });
+    defer allocator.free(main_path);
+    const main_uri = try uriFromPath(allocator, main_path);
+    defer allocator.free(main_uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    const helper_source =
+        \\Helpers :: [].{
+        \\    encode_json : Str -> Str
+        \\    encode_json = |str| str
+        \\
+        \\    decode_json : Str -> Str
+        \\    decode_json = |str| str
+        \\}
+    ;
+    try tmp.dir.writeFile(test_env.io, .{ .sub_path = "Helpers.roc", .data = helper_source });
+
+    const init_body =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+    ;
+    const init_msg = try frame(allocator, init_body);
+    defer allocator.free(init_msg);
+
+    const initialized_body =
+        \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+    ;
+    const initialized_msg = try frame(allocator, initialized_body);
+    defer allocator.free(initialized_msg);
+
+    const open_main_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"app [result] {{ pf: platform \"{s}\" }}\n\nimport Helpers exposing [encode_json, decode_json]\n\nresult = decode_json(\"hi\")"}}}}}}
+    , .{ main_uri, platform_path });
+    defer allocator.free(open_main_body);
+    const open_main_msg = try frame(allocator, open_main_body);
+    defer allocator.free(open_main_msg);
+
+    // Line 2: import Helpers exposing [encode_json, decode_json] -> character 42 is on 'decode_json'
+    const definition_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":2,"character":42}}}}}}
+    , .{main_uri});
+    defer allocator.free(definition_body);
+    const definition_msg = try frame(allocator, definition_body);
+    defer allocator.free(definition_msg);
+
+    const shutdown_body =
+        \\{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+    ;
+    const shutdown_msg = try frame(allocator, shutdown_body);
+    defer allocator.free(shutdown_msg);
+
+    const exit_body =
+        \\{"jsonrpc":"2.0","method":"exit"}
+    ;
+    const exit_msg = try frame(allocator, exit_body);
+    defer allocator.free(exit_msg);
+
+    var builder: std.ArrayList(u8) = .empty;
+    defer builder.deinit(allocator);
+    try builder.appendSlice(allocator, init_msg);
+    try builder.appendSlice(allocator, initialized_msg);
+    try builder.appendSlice(allocator, open_main_msg);
+    try builder.appendSlice(allocator, definition_msg);
+    try builder.appendSlice(allocator, shutdown_msg);
+    try builder.appendSlice(allocator, exit_msg);
+    const combined = try builder.toOwnedSlice(allocator);
+    defer allocator.free(combined);
+
+    const reader_stream: std.Io.Reader = .fixed(combined);
+    var writer_buffer: [16384]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    const ReaderType = std.Io.Reader;
+    const WriterType = std.Io.Writer;
+    var server = try server_module.Server(ReaderType, WriterType).init(allocator, test_env.io, reader_stream, writer_stream, null, .{});
+    test_env.configureChecker(&server.syntax_checker, tmp_path);
+    defer server.deinit();
+    try server.run();
+
+    const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    var response = try responseById(allocator, responses, 2);
+    defer response.deinit();
+    const result = try response.result();
+    try std.testing.expect(result == .object);
+    const uri = try stringField(result, "uri");
+    try std.testing.expect(std.mem.endsWith(u8, uri, "Helpers.roc"));
+    const range = try objectField(result, "range");
+    const start = try objectField(range, "start");
+    const start_line = try integerField(start, "line");
+    // decode_json definition in Helpers.roc is at line 5 (0-based)
+    try std.testing.expectEqual(@as(i64, 5), start_line);
+}
+
+/// Verifies goto definition on an unqualified function call imported via `exposing` (e.g. `decode_json(input)`).
+pub fn definitionHandlerNavigatesToUnqualifiedExposedImportFunctionCall() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const helper_path = try std.fs.path.join(allocator, &.{ tmp_path, "Helpers.roc" });
+    defer allocator.free(helper_path);
+    const helper_uri = try uriFromPath(allocator, helper_path);
+    defer allocator.free(helper_uri);
+    const main_path = try std.fs.path.join(allocator, &.{ tmp_path, "main.roc" });
+    defer allocator.free(main_path);
+    const main_uri = try uriFromPath(allocator, main_path);
+    defer allocator.free(main_uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    const helper_source =
+        \\Helpers :: [].{
+        \\    encode_json : Str -> Str
+        \\    encode_json = |str| str
+        \\
+        \\    decode_json : Str -> Str
+        \\    decode_json = |str| str
+        \\}
+    ;
+    try tmp.dir.writeFile(test_env.io, .{ .sub_path = "Helpers.roc", .data = helper_source });
+
+    const init_body =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+    ;
+    const init_msg = try frame(allocator, init_body);
+    defer allocator.free(init_msg);
+
+    const initialized_body =
+        \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+    ;
+    const initialized_msg = try frame(allocator, initialized_body);
+    defer allocator.free(initialized_msg);
+
+    const open_main_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"app [result] {{ pf: platform \"{s}\" }}\n\nimport Helpers exposing [decode_json]\n\nresult = decode_json(\"hi\")"}}}}}}
+    , .{ main_uri, platform_path });
+    defer allocator.free(open_main_body);
+    const open_main_msg = try frame(allocator, open_main_body);
+    defer allocator.free(open_main_msg);
+
+    // Line 4: result = decode_json("hi") -> character 14 is on 'decode_json'
+    const definition_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":4,"character":14}}}}}}
+    , .{main_uri});
+    defer allocator.free(definition_body);
+    const definition_msg = try frame(allocator, definition_body);
+    defer allocator.free(definition_msg);
+
+    const shutdown_body =
+        \\{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+    ;
+    const shutdown_msg = try frame(allocator, shutdown_body);
+    defer allocator.free(shutdown_msg);
+
+    const exit_body =
+        \\{"jsonrpc":"2.0","method":"exit"}
+    ;
+    const exit_msg = try frame(allocator, exit_body);
+    defer allocator.free(exit_msg);
+
+    var builder: std.ArrayList(u8) = .empty;
+    defer builder.deinit(allocator);
+    try builder.appendSlice(allocator, init_msg);
+    try builder.appendSlice(allocator, initialized_msg);
+    try builder.appendSlice(allocator, open_main_msg);
+    try builder.appendSlice(allocator, definition_msg);
+    try builder.appendSlice(allocator, shutdown_msg);
+    try builder.appendSlice(allocator, exit_msg);
+    const combined = try builder.toOwnedSlice(allocator);
+    defer allocator.free(combined);
+
+    const reader_stream: std.Io.Reader = .fixed(combined);
+    var writer_buffer: [16384]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    const ReaderType = std.Io.Reader;
+    const WriterType = std.Io.Writer;
+    var server = try server_module.Server(ReaderType, WriterType).init(allocator, test_env.io, reader_stream, writer_stream, null, .{});
+    test_env.configureChecker(&server.syntax_checker, tmp_path);
+    defer server.deinit();
+    try server.run();
+
+    const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    var response = try responseById(allocator, responses, 2);
+    defer response.deinit();
+    const result = try response.result();
+    try std.testing.expect(result == .object);
+    const uri = try stringField(result, "uri");
+    try std.testing.expect(std.mem.endsWith(u8, uri, "Helpers.roc"));
+    const range = try objectField(result, "range");
+    const start = try objectField(range, "start");
+    const start_line = try integerField(start, "line");
+    // decode_json definition in Helpers.roc is at line 5 (0-based)
+    try std.testing.expectEqual(@as(i64, 5), start_line);
+}
+
+/// Verifies goto definition on a tag in pattern matching (e.g. `WaitingForInit => ...`) navigates to the tag union declaration.
+pub fn definitionHandlerNavigatesToTagDeclarationInPatternMatch() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const main_path = try std.fs.path.join(allocator, &.{ tmp_path, "main.roc" });
+    defer allocator.free(main_path);
+    const main_uri = try uriFromPath(allocator, main_path);
+    defer allocator.free(main_uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    const init_body =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+    ;
+    const init_msg = try frame(allocator, init_body);
+    defer allocator.free(init_msg);
+
+    const initialized_body =
+        \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+    ;
+    const initialized_msg = try frame(allocator, initialized_body);
+    defer allocator.free(initialized_msg);
+
+    const open_main_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"app [handle] {{ pf: platform \"{s}\" }}\n\nLoopState : [WaitingForInit, Running(Str)]\n\nhandle = |state|\n    match state {{\n        WaitingForInit => \"init\",\n        Running(s) => s,\n    }}"}}}}}}
+    , .{ main_uri, platform_path });
+    defer allocator.free(open_main_body);
+    const open_main_msg = try frame(allocator, open_main_body);
+    defer allocator.free(open_main_msg);
+
+    // Line 6: WaitingForInit => "init" -> character 12 is on 'WaitingForInit'
+    const definition_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":6,"character":12}}}}}}
+    , .{main_uri});
+    defer allocator.free(definition_body);
+    const definition_msg = try frame(allocator, definition_body);
+    defer allocator.free(definition_msg);
+
+    const shutdown_body =
+        \\{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+    ;
+    const shutdown_msg = try frame(allocator, shutdown_body);
+    defer allocator.free(shutdown_msg);
+
+    const exit_body =
+        \\{"jsonrpc":"2.0","method":"exit"}
+    ;
+    const exit_msg = try frame(allocator, exit_body);
+    defer allocator.free(exit_msg);
+
+    var builder: std.ArrayList(u8) = .empty;
+    defer builder.deinit(allocator);
+    try builder.appendSlice(allocator, init_msg);
+    try builder.appendSlice(allocator, initialized_msg);
+    try builder.appendSlice(allocator, open_main_msg);
+    try builder.appendSlice(allocator, definition_msg);
+    try builder.appendSlice(allocator, shutdown_msg);
+    try builder.appendSlice(allocator, exit_msg);
+    const combined = try builder.toOwnedSlice(allocator);
+    defer allocator.free(combined);
+
+    const reader_stream: std.Io.Reader = .fixed(combined);
+    var writer_buffer: [16384]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    const ReaderType = std.Io.Reader;
+    const WriterType = std.Io.Writer;
+    var server = try server_module.Server(ReaderType, WriterType).init(allocator, test_env.io, reader_stream, writer_stream, null, .{});
+    test_env.configureChecker(&server.syntax_checker, tmp_path);
+    defer server.deinit();
+    try server.run();
+
+    const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    var response = try responseById(allocator, responses, 2);
+    defer response.deinit();
+    const result = try response.result();
+    try std.testing.expect(result == .object);
+    const uri = try stringField(result, "uri");
+    try std.testing.expect(std.mem.endsWith(u8, uri, "main.roc"));
+    const range = try objectField(result, "range");
+    const start = try objectField(range, "start");
+    const start_line = try integerField(start, "line");
+    // LoopState declaration with WaitingForInit is on line 2 (0-based)
+    try std.testing.expectEqual(@as(i64, 2), start_line);
+}
+
+/// Verifies goto definition on an exposed type alias (e.g. `Payload(...)`) in a local type annotation navigates to its declaration in the imported module.
+pub fn definitionHandlerNavigatesToExposedTypeAliasInTypeAnnotation() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const main_path = try std.fs.path.join(allocator, &.{ tmp_path, "main.roc" });
+    defer allocator.free(main_path);
+    const main_uri = try uriFromPath(allocator, main_path);
+    defer allocator.free(main_uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    const helper_source =
+        \\module [Payload]
+        \\
+        \\Payload(a) : {
+        \\    type : Str,
+        \\    body : a,
+        \\}
+    ;
+    try tmp.dir.writeFile(test_env.io, .{ .sub_path = "Helpers.roc", .data = helper_source });
+
+    const init_body =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+    ;
+    const init_msg = try frame(allocator, init_body);
+    defer allocator.free(init_msg);
+
+    const initialized_body =
+        \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+    ;
+    const initialized_msg = try frame(allocator, initialized_body);
+    defer allocator.free(initialized_msg);
+
+    const open_main_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"app [handle] {{ pf: platform \"{s}\" }}\n\nimport Helpers exposing [Payload]\n\nhandle = |input| {{\n    p : Payload(Str)\n    p = {{ type: \"test\", body: input }}\n    p\n}}"}}}}}}
+    , .{ main_uri, platform_path });
+    defer allocator.free(open_main_body);
+    const open_main_msg = try frame(allocator, open_main_body);
+    defer allocator.free(open_main_msg);
+
+    // Line 5: p : Payload(Str) -> character 10 is on 'Payload'
+    const definition_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":5,"character":10}}}}}}
+    , .{main_uri});
+    defer allocator.free(definition_body);
+    const definition_msg = try frame(allocator, definition_body);
+    defer allocator.free(definition_msg);
+
+    const shutdown_body =
+        \\{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+    ;
+    const shutdown_msg = try frame(allocator, shutdown_body);
+    defer allocator.free(shutdown_msg);
+
+    const exit_body =
+        \\{"jsonrpc":"2.0","method":"exit"}
+    ;
+    const exit_msg = try frame(allocator, exit_body);
+    defer allocator.free(exit_msg);
+
+    var builder: std.ArrayList(u8) = .empty;
+    defer builder.deinit(allocator);
+    try builder.appendSlice(allocator, init_msg);
+    try builder.appendSlice(allocator, initialized_msg);
+    try builder.appendSlice(allocator, open_main_msg);
+    try builder.appendSlice(allocator, definition_msg);
+    try builder.appendSlice(allocator, shutdown_msg);
+    try builder.appendSlice(allocator, exit_msg);
+    const combined = try builder.toOwnedSlice(allocator);
+    defer allocator.free(combined);
+
+    const reader_stream: std.Io.Reader = .fixed(combined);
+    var writer_buffer: [16384]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    const ReaderType = std.Io.Reader;
+    const WriterType = std.Io.Writer;
+    var server = try server_module.Server(ReaderType, WriterType).init(allocator, test_env.io, reader_stream, writer_stream, null, .{});
+    test_env.configureChecker(&server.syntax_checker, tmp_path);
+    defer server.deinit();
+    try server.run();
+
+    const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    var response = try responseById(allocator, responses, 2);
+    defer response.deinit();
+    const result = try response.result();
+    try std.testing.expect(result == .object);
+    const uri = try stringField(result, "uri");
+    try std.testing.expect(std.mem.endsWith(u8, uri, "Helpers.roc"));
+    const range = try objectField(result, "range");
+    const start = try objectField(range, "start");
+    const start_line = try integerField(start, "line");
+    // Payload declaration in Helpers.roc is on line 2 (0-based)
+    try std.testing.expectEqual(@as(i64, 2), start_line);
+}
+
+/// Verifies semantic tokens handler handles file imports (e.g. `import "inputs/1.txt" as input : Str`) without crashing (Issue #10861).
+pub fn semanticTokensHandlerHandlesFileImportsWithoutCrashing() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const main_path = try std.fs.path.join(allocator, &.{ tmp_path, "main.roc" });
+    defer allocator.free(main_path);
+    const main_uri = try uriFromPath(allocator, main_path);
+    defer allocator.free(main_uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    // Create the input file to import
+    try tmp.dir.writeFile(test_env.io, .{ .sub_path = "input.txt", .data = "hello roc" });
+
+    const init_body =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+    ;
+    const init_msg = try frame(allocator, init_body);
+    defer allocator.free(init_msg);
+
+    const initialized_body =
+        \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+    ;
+    const initialized_msg = try frame(allocator, initialized_body);
+    defer allocator.free(initialized_msg);
+
+    const open_main_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"app [main!] {{ pf: platform \"{s}\" }}\n\nimport \"input.txt\" as input : Str\n\nmain! = |_|\n    echo!(input)"}}}}}}
+    , .{ main_uri, platform_path });
+    defer allocator.free(open_main_body);
+    const open_main_msg = try frame(allocator, open_main_body);
+    defer allocator.free(open_main_msg);
+
+    // Request semantic tokens full
+    const tokens_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/semanticTokens/full","params":{{"textDocument":{{"uri":"{s}"}}}}}}
+    , .{main_uri});
+    defer allocator.free(tokens_body);
+    const tokens_msg = try frame(allocator, tokens_body);
+    defer allocator.free(tokens_msg);
+
+    const shutdown_body =
+        \\{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+    ;
+    const shutdown_msg = try frame(allocator, shutdown_body);
+    defer allocator.free(shutdown_msg);
+
+    const exit_body =
+        \\{"jsonrpc":"2.0","method":"exit"}
+    ;
+    const exit_msg = try frame(allocator, exit_body);
+    defer allocator.free(exit_msg);
+
+    var builder: std.ArrayList(u8) = .empty;
+    defer builder.deinit(allocator);
+    try builder.appendSlice(allocator, init_msg);
+    try builder.appendSlice(allocator, initialized_msg);
+    try builder.appendSlice(allocator, open_main_msg);
+    try builder.appendSlice(allocator, tokens_msg);
+    try builder.appendSlice(allocator, shutdown_msg);
+    try builder.appendSlice(allocator, exit_msg);
+    const combined = try builder.toOwnedSlice(allocator);
+    defer allocator.free(combined);
+
+    const reader_stream: std.Io.Reader = .fixed(combined);
+    var writer_buffer: [16384]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    const ReaderType = std.Io.Reader;
+    const WriterType = std.Io.Writer;
+    var server = try server_module.Server(ReaderType, WriterType).init(allocator, test_env.io, reader_stream, writer_stream, null, .{});
+    test_env.configureChecker(&server.syntax_checker, tmp_path);
+    defer server.deinit();
+    try server.run();
+
+    const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    var response = try responseById(allocator, responses, 2);
+    defer response.deinit();
+    const result = try response.result();
+    try std.testing.expect(result == .object);
+    const data_val = try objectField(result, "data");
+    try std.testing.expect(data_val == .array);
+    try std.testing.expect(data_val.array.items.len > 0);
+}
+
+/// Verifies goto definition on a file import path (`import "input.txt" as input : Str`) navigates to the imported file.
+pub fn definitionHandlerNavigatesToFileImportPath() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const main_path = try std.fs.path.join(allocator, &.{ tmp_path, "main.roc" });
+    defer allocator.free(main_path);
+    const main_uri = try uriFromPath(allocator, main_path);
+    defer allocator.free(main_uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    // Create the target input file
+    try tmp.dir.writeFile(test_env.io, .{ .sub_path = "input.txt", .data = "hello roc" });
+
+    const init_body =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+    ;
+    const init_msg = try frame(allocator, init_body);
+    defer allocator.free(init_msg);
+
+    const initialized_body =
+        \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+    ;
+    const initialized_msg = try frame(allocator, initialized_body);
+    defer allocator.free(initialized_msg);
+
+    const open_main_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"# Mentioning \"input.txt\" in comment\napp [main!] {{ pf: platform \"{s}\" }}\n\nimport \"input.txt\" as input : Str\n\nmain! = |_|\n    echo!(input)"}}}}}}
+    , .{ main_uri, platform_path });
+    defer allocator.free(open_main_body);
+    const open_main_msg = try frame(allocator, open_main_body);
+    defer allocator.free(open_main_msg);
+
+    // Line 0: # Mentioning "input.txt" in comment -> character 16 is on 'input.txt' inside the comment
+    // Must NOT navigate to the file import (non-heuristic explicit token check)
+    const comment_def_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":0,"character":16}}}}}}
+    , .{main_uri});
+    defer allocator.free(comment_def_body);
+    const comment_def_msg = try frame(allocator, comment_def_body);
+    defer allocator.free(comment_def_msg);
+
+    // Line 3: import "input.txt" as input : Str
+    // Position on "input.txt" (character 10)
+    const definition_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":3,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":3,"character":10}}}}}}
+    , .{main_uri});
+    defer allocator.free(definition_body);
+    const definition_msg = try frame(allocator, definition_body);
+    defer allocator.free(definition_msg);
+
+    const shutdown_body =
+        \\{"jsonrpc":"2.0","id":4,"method":"shutdown"}
+    ;
+    const shutdown_msg = try frame(allocator, shutdown_body);
+    defer allocator.free(shutdown_msg);
+
+    const exit_body =
+        \\{"jsonrpc":"2.0","method":"exit"}
+    ;
+    const exit_msg = try frame(allocator, exit_body);
+    defer allocator.free(exit_msg);
+
+    var builder: std.ArrayList(u8) = .empty;
+    defer builder.deinit(allocator);
+    try builder.appendSlice(allocator, init_msg);
+    try builder.appendSlice(allocator, initialized_msg);
+    try builder.appendSlice(allocator, open_main_msg);
+    try builder.appendSlice(allocator, comment_def_msg);
+    try builder.appendSlice(allocator, definition_msg);
+    try builder.appendSlice(allocator, shutdown_msg);
+    try builder.appendSlice(allocator, exit_msg);
+    const combined = try builder.toOwnedSlice(allocator);
+    defer allocator.free(combined);
+
+    const reader_stream: std.Io.Reader = .fixed(combined);
+    var writer_buffer: [16384]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    const ReaderType = std.Io.Reader;
+    const WriterType = std.Io.Writer;
+    var server = try server_module.Server(ReaderType, WriterType).init(allocator, test_env.io, reader_stream, writer_stream, null, .{});
+    test_env.configureChecker(&server.syntax_checker, tmp_path);
+    defer server.deinit();
+    try server.run();
+
+    const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    // Comment position (id: 2) must return null
+    {
+        var response = try responseById(allocator, responses, 2);
+        defer response.deinit();
+        const result = try response.result();
+        try std.testing.expect(result == .null);
+    }
+
+    // Real file import position (id: 3) must return LocationLink
+    {
+        var response = try responseById(allocator, responses, 3);
+        defer response.deinit();
+        const result = try response.result();
+        try std.testing.expect(result == .array);
+        try std.testing.expectEqual(@as(usize, 1), result.array.items.len);
+        const link = result.array.items[0].object;
+        const target_uri_value = link.get("targetUri") orelse return error.TestUnexpectedResult;
+        try std.testing.expect(std.mem.endsWith(u8, target_uri_value.string, "input.txt"));
+        const origin_range = (link.get("originSelectionRange") orelse return error.TestUnexpectedResult).object;
+        const origin_start = (origin_range.get("start") orelse return error.TestUnexpectedResult).object;
+        const origin_end = (origin_range.get("end") orelse return error.TestUnexpectedResult).object;
+        // Line 3: import "input.txt" as input : Str
+        // origin range covers "input.txt" as a single unit
+        try std.testing.expectEqual(@as(i64, 3), (origin_start.get("line") orelse return error.TestUnexpectedResult).integer);
+        try std.testing.expectEqual(@as(i64, 7), (origin_start.get("character") orelse return error.TestUnexpectedResult).integer);
+        try std.testing.expectEqual(@as(i64, 3), (origin_end.get("line") orelse return error.TestUnexpectedResult).integer);
+        try std.testing.expectEqual(@as(i64, 18), (origin_end.get("character") orelse return error.TestUnexpectedResult).integer);
+    }
+}
+
+/// Verifies goto definition on `echo!` in a default app navigates to the default app Echo.roc platform definition.
+pub fn definitionHandlerNavigatesToEchoPlatformDefinition() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const main_path = try std.fs.path.join(allocator, &.{ tmp_path, "main.roc" });
+    defer allocator.free(main_path);
+    const main_uri = try uriFromPath(allocator, main_path);
+    defer allocator.free(main_uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    const init_body =
+        \\{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":1,"clientInfo":{"name":"test"},"capabilities":{}}}
+    ;
+    const init_msg = try frame(allocator, init_body);
+    defer allocator.free(init_msg);
+
+    const initialized_body =
+        \\{"jsonrpc":"2.0","method":"initialized","params":{}}
+    ;
+    const initialized_msg = try frame(allocator, initialized_body);
+    defer allocator.free(initialized_msg);
+
+    const open_main_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{{"textDocument":{{"uri":"{s}","version":1,"text":"app [main!] {{ pf: platform \"{s}\" }}\n\nmain! = |_|\n    echo!(\"hello\")"}}}}}}
+    , .{ main_uri, platform_path });
+    defer allocator.free(open_main_body);
+    const open_main_msg = try frame(allocator, open_main_body);
+    defer allocator.free(open_main_msg);
+
+    // Line 3: echo!("hello") -> position on 'echo!' (character 5)
+    const definition_body = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/definition","params":{{"textDocument":{{"uri":"{s}"}},"position":{{"line":3,"character":5}}}}}}
+    , .{main_uri});
+    defer allocator.free(definition_body);
+    const definition_msg = try frame(allocator, definition_body);
+    defer allocator.free(definition_msg);
+
+    const shutdown_body =
+        \\{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+    ;
+    const shutdown_msg = try frame(allocator, shutdown_body);
+    defer allocator.free(shutdown_msg);
+
+    const exit_body =
+        \\{"jsonrpc":"2.0","method":"exit"}
+    ;
+    const exit_msg = try frame(allocator, exit_body);
+    defer allocator.free(exit_msg);
+
+    var builder: std.ArrayList(u8) = .empty;
+    defer builder.deinit(allocator);
+    try builder.appendSlice(allocator, init_msg);
+    try builder.appendSlice(allocator, initialized_msg);
+    try builder.appendSlice(allocator, open_main_msg);
+    try builder.appendSlice(allocator, definition_msg);
+    try builder.appendSlice(allocator, shutdown_msg);
+    try builder.appendSlice(allocator, exit_msg);
+    const combined = try builder.toOwnedSlice(allocator);
+    defer allocator.free(combined);
+
+    const reader_stream: std.Io.Reader = .fixed(combined);
+    var writer_buffer: [16384]u8 = undefined;
+    const writer_stream: std.Io.Writer = .fixed(&writer_buffer);
+
+    const ReaderType = std.Io.Reader;
+    const WriterType = std.Io.Writer;
+    var server = try server_module.Server(ReaderType, WriterType).init(allocator, test_env.io, reader_stream, writer_stream, null, .{});
+    test_env.configureChecker(&server.syntax_checker, tmp_path);
+    defer server.deinit();
+    try server.run();
+
+    const responses = try collectResponses(allocator, writer_buffer[0..server.transport.writer.end]);
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    var response = try responseById(allocator, responses, 2);
+    defer response.deinit();
+    const result = try response.result();
+    try std.testing.expect(result == .null);
 }

--- a/src/lsp/test/syntax_test.zig
+++ b/src/lsp/test/syntax_test.zig
@@ -420,6 +420,7 @@ pub fn recordFieldCompletionInSubModule() integration_spec.SpecError!void {
         \\  rec = {{ foo: "hello", bar: 42 }}
         \\}}
         \\
+        \\main = "ok"
         \\
     );
     defer h.allocator.free(clean);

--- a/src/lsp/test/test_syntax_driver.zig
+++ b/src/lsp/test/test_syntax_driver.zig
@@ -41,6 +41,7 @@ pub const TestSyntaxDriver = struct {
     pub const DefinitionResult = struct {
         uri: []const u8,
         range: LspRange,
+        origin_selection_range: ?LspRange = null,
 
         pub fn deinit(self: DefinitionResult, allocator: std.mem.Allocator) void {
             allocator.free(self.uri);


### PR DESCRIPTION
Improve LSP goto definition accuracy and reliability for file imports, builtin types, and module members.

- Opens the referenced file when clicking a file import path, highlighting the entire path as a single clickable unit
- Navigates to the type definition when clicking the type prefix in qualified calls (e.g. Dict in Dict.update)
- Navigates to the exact function definition when clicking a builtin method (e.g. append in List.append), ignoring doc comments
- Resolves cross-module member definitions consistently across both annotated and unannotated declarations
- Adds semantic token support for file imports without re-parsing files
- Simplifies document path memory management in the syntax checker

Fixes #10840
Fixes #10861