### PR TITLE
Fix specialization reuse for equivalent checked types

### DIFF
--- a/design.md
+++ b/design.md
@@ -6636,12 +6636,12 @@ equality of the closed Monotype function type. Digest collisions are therefore
 harmless.
 
 Checked callable type ids inside dispatch evidence are relation-replay payload,
-not specialization identity: generalized scheme uses deliberately publish fresh
-identity-bearing roots. Evidence hashing and exact topology equality use each
-callable root's producer-authored canonical checked type key instead. The
+not specialization identity: separate generalized scheme uses deliberately
+contain distinct identity-bearing roots. Evidence hashing and exact topology
+equality use each callable root's producer-authored checked type key instead. The
 owning checked module remains part of the identity, and the raw root id remains
 alongside the key solely so Monotype can replay the exact checked relation.
-Thus fresh instantiations with the same canonical identity-variable topology
+Thus instantiations with the same checked identity-variable topology
 reuse one specialization, while different callable shapes remain distinct.
 
 The identity is immutable: it is written once when the record is reserved and

--- a/design.md
+++ b/design.md
@@ -6635,6 +6635,15 @@ callable identity, method scope, exact evidence topology, and exact structural
 equality of the closed Monotype function type. Digest collisions are therefore
 harmless.
 
+Checked callable type ids inside dispatch evidence are relation-replay payload,
+not specialization identity: generalized scheme uses deliberately publish fresh
+identity-bearing roots. Evidence hashing and exact topology equality use each
+callable root's producer-authored canonical checked type key instead. The
+owning checked module remains part of the identity, and the raw root id remains
+alongside the key solely so Monotype can replay the exact checked relation.
+Thus fresh instantiations with the same canonical identity-variable topology
+reuse one specialization, while different callable shapes remain distinct.
+
 The identity is immutable: it is written once when the record is reserved and
 never rewritten, so no structure that indexes by identity ever needs a rekey or
 a second synchronized entry. Later refinements are data on the record. The

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -29209,7 +29209,9 @@ pub const CheckedModuleArtifact = struct {
     // Version 69 records in the checking-context identity how a module's
     // compile-time roots were established, so an app root checked without its
     // entrypoint contract cannot share a cache entry with one checked under it.
-    const serialized_layout_version: u32 = 69;
+    // Version 70 retains canonical callable type keys in stored function
+    // evidence so specialization identity does not depend on fresh checked ids.
+    const serialized_layout_version: u32 = 70;
 
     /// Comptime fingerprint of `Serialized`'s layout, mirroring
     /// `cache_module.MODULE_ENV_VERSION_HASH`. It is appended to the baked builtin
@@ -35361,8 +35363,8 @@ test "SERIALIZED_VERSION_HASH golden value" {
     // change, bump `serialized_layout_version` and replace the golden bytes below with
     // the ones this assertion prints.
     const golden: [32]u8 = .{
-        0xF7, 0x81, 0xEC, 0xFE, 0xB4, 0x4E, 0xEE, 0xD7, 0x62, 0xAE, 0xC1, 0x92, 0xBB, 0x16, 0xAF, 0xAB,
-        0x31, 0xB7, 0x4F, 0xF9, 0xB6, 0x87, 0x92, 0x31, 0xC2, 0x1D, 0xCF, 0x7E, 0xF5, 0x43, 0x05, 0x89,
+        0xF4, 0x44, 0xBF, 0x73, 0x28, 0x33, 0x3B, 0x3E, 0x4E, 0xD1, 0xF6, 0x56, 0x8D, 0x7E, 0x27, 0x88,
+        0x5A, 0x77, 0x16, 0xA5, 0xA3, 0x94, 0xB2, 0x00, 0xA8, 0xD6, 0xCA, 0xB1, 0x7B, 0x8C, 0x8E, 0x54,
     };
     try std.testing.expectEqualSlices(u8, &golden, &CheckedModuleArtifact.SERIALIZED_VERSION_HASH);
 }

--- a/src/check/const_store.zig
+++ b/src/check/const_store.zig
@@ -243,7 +243,7 @@ pub const ConstFnNestedEvidence = union(enum(u8)) {
 /// Exact checked callable relation attached to a stored target edge.
 pub const ConstFnCallableInstantiation = struct {
     view: names.CheckedModuleDigest,
-    /// Stable semantic identity of `callable_ty`. The raw checked id remains
+    /// Stable checked identity of `callable_ty`. The raw checked id remains
     /// replay payload and may differ between equivalent fresh instantiations.
     callable_key: names.CanonicalTypeKey,
     callable_ty: checked_ids.CheckedTypeId,
@@ -256,7 +256,7 @@ pub const ConstFnEvidence = union(enum(u8)) {
     target: struct {
         view: names.CheckedModuleDigest,
         method: static_dispatch.MethodTarget,
-        /// Stable semantic identity of `method.callable_ty`.
+        /// Stable checked identity of `method.callable_ty`.
         method_callable_key: names.CanonicalTypeKey,
         instantiation: ?ConstFnCallableInstantiation,
         nested: ConstFnNestedEvidence,

--- a/src/check/const_store.zig
+++ b/src/check/const_store.zig
@@ -243,6 +243,9 @@ pub const ConstFnNestedEvidence = union(enum(u8)) {
 /// Exact checked callable relation attached to a stored target edge.
 pub const ConstFnCallableInstantiation = struct {
     view: names.CheckedModuleDigest,
+    /// Stable semantic identity of `callable_ty`. The raw checked id remains
+    /// replay payload and may differ between equivalent fresh instantiations.
+    callable_key: names.CanonicalTypeKey,
     callable_ty: checked_ids.CheckedTypeId,
 };
 
@@ -253,6 +256,8 @@ pub const ConstFnEvidence = union(enum(u8)) {
     target: struct {
         view: names.CheckedModuleDigest,
         method: static_dispatch.MethodTarget,
+        /// Stable semantic identity of `method.callable_ty`.
+        method_callable_key: names.CanonicalTypeKey,
         instantiation: ?ConstFnCallableInstantiation,
         nested: ConstFnNestedEvidence,
     },
@@ -868,6 +873,7 @@ pub const ConstStore = struct {
         const evidence = [_]ConstFnEvidence{.{ .target = .{
             .view = .{},
             .method = undefined,
+            .method_callable_key = .{},
             .instantiation = null,
             .nested = .from_callable,
         } }};
@@ -1191,6 +1197,10 @@ test "ConstStore: build, serialize/relocate, and read back values, fns, strings"
     target_view.bytes[0] = 0xA1;
     var instantiation_view: names.CheckedModuleDigest = .{};
     instantiation_view.bytes[0] = 0xB2;
+    var method_callable_key: names.CanonicalTypeKey = .{};
+    method_callable_key.bytes[0] = 0xC3;
+    var instantiation_callable_key: names.CanonicalTypeKey = .{};
+    instantiation_callable_key.bytes[0] = 0xD4;
     const evidence = [_]ConstFnEvidence{
         .{ .target = .{
             .view = target_view,
@@ -1204,7 +1214,12 @@ test "ConstStore: build, serialize/relocate, and read back values, fns, strings"
                 } },
                 .callable_ty = @enumFromInt(6),
             },
-            .instantiation = .{ .view = instantiation_view, .callable_ty = @enumFromInt(7) },
+            .method_callable_key = method_callable_key,
+            .instantiation = .{
+                .view = instantiation_view,
+                .callable_key = instantiation_callable_key,
+                .callable_ty = @enumFromInt(7),
+            },
             .nested = .{ .resolved = .{ .count = 1, .subtree_len = 1 } },
         } },
         .{ .structural = .equality },
@@ -1272,8 +1287,10 @@ test "ConstStore: build, serialize/relocate, and read back values, fns, strings"
     try std.testing.expectEqual(@as(u32, 5), @intFromEnum(loaded_target.method.def_idx));
     try std.testing.expectEqual(evidence[0].target.method.kind, loaded_target.method.kind);
     try std.testing.expectEqual(@as(checked_ids.CheckedTypeId, @enumFromInt(6)), loaded_target.method.callable_ty);
+    try std.testing.expectEqual(method_callable_key, loaded_target.method_callable_key);
     const loaded_instantiation = loaded_target.instantiation.?;
     try std.testing.expectEqualSlices(u8, &instantiation_view.bytes, &loaded_instantiation.view.bytes);
+    try std.testing.expectEqual(instantiation_callable_key, loaded_instantiation.callable_key);
     try std.testing.expectEqual(@as(checked_ids.CheckedTypeId, @enumFromInt(7)), loaded_instantiation.callable_ty);
     const loaded_nested = loaded_target.nested.resolved;
     try std.testing.expectEqual(@as(u32, 1), loaded_nested.count);

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -140,6 +140,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10724_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10765_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10792_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10831_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));
     std.testing.refAllDecls(@import("test/platform_box_update_lir_test.zig"));

--- a/src/compile/test/issue_10831_test.zig
+++ b/src/compile/test/issue_10831_test.zig
@@ -6,7 +6,7 @@ const lir = @import("lir");
 
 const harness = @import("lower_to_lir_harness.zig");
 
-fn expectOneRefreshSpecialization(
+fn expectSingleSourceRefreshSpecialization(
     store: *const lir.LirStore,
     _: *const layout.Store,
 ) harness.LowerToLirHarnessError!void {
@@ -54,5 +54,5 @@ test "issue 10831: repeated annotated calls reuse one specialization" {
         \\    echo!(if final.items.len() == 1 { "ok" } else { "bad" })
         \\    Ok({})
         \\}
-    , .{ .proc_debug_names = true }, expectOneRefreshSpecialization);
+    , .{ .proc_debug_names = true }, expectSingleSourceRefreshSpecialization);
 }

--- a/src/compile/test/issue_10831_test.zig
+++ b/src/compile/test/issue_10831_test.zig
@@ -1,0 +1,58 @@
+//! Regression test for issue #10831.
+
+const std = @import("std");
+const layout = @import("layout");
+const lir = @import("lir");
+
+const harness = @import("lower_to_lir_harness.zig");
+
+fn expectOneRefreshSpecialization(
+    store: *const lir.LirStore,
+    _: *const layout.Store,
+) harness.LowerToLirHarnessError!void {
+    var refresh_count: usize = 0;
+    for (0..store.procSpecCount()) |index| {
+        const proc: lir.LIR.LirProcSpecId = @enumFromInt(@as(u32, @intCast(index)));
+        const name = store.procDebugName(proc) orelse continue;
+        if (std.mem.eql(u8, name, "refresh")) refresh_count += 1;
+    }
+
+    // One source-level specialization lowers to two LIR procedures. Both
+    // calls have the same closed type, so they must stay at that baseline.
+    try std.testing.expectEqual(@as(usize, 2), refresh_count);
+}
+
+test "issue 10831: repeated annotated calls reuse one specialization" {
+    // Repro for https://github.com/roc-lang/roc/issues/10831.
+    try harness.expectLirInspectionWithOptions(
+        \\Item : { value : F64, summary : Str }
+        \\
+        \\Store : { items : List(Item) }
+        \\
+        \\refresh = |store| { ..store, items: store.items.map(run_item) }
+        \\
+        \\update : Store, Str -> (Store, Str)
+        \\update = |store, _msg| (refresh(refresh(store)), "")
+        \\
+        \\run_item = |item| match compute(item) {
+        \\    Ok(text) => { ..item, summary: text }
+        \\    Err(_) => item
+        \\}
+        \\
+        \\compute = |item| match item.value > 0 {
+        \\    True => Ok(describe([item.value]))
+        \\    False => Ok(describe([item.value]))
+        \\}
+        \\
+        \\describe = |points| {
+        \\    texts = points.map(|p| "{ x: ${p.to_str()}, y: ${p.to_str()} }")
+        \\    "points: [${Str.join_with(texts, ", ")}], n: ${texts.len().to_str()}"
+        \\}
+        \\
+        \\main! = |args| {
+        \\    final = (update({ items: [{ value: 0, summary: "" }] }, args.len().to_str())).0
+        \\    echo!(if final.items.len() == 1 { "ok" } else { "bad" })
+        \\    Ok({})
+        \\}
+    , .{ .proc_debug_names = true }, expectOneRefreshSpecialization);
+}

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -262,8 +262,8 @@ pub fn fnTemplateDigest(template: FnTemplate, types: *Type.Store, name_store: *c
     return .{ .bytes = hasher.finalResult() };
 }
 
-/// Compute the stable digest used in specialization identity from the exact
-/// durable evidence nodes and lexical frames carried by a function template.
+/// Compute the stable specialization digest from durable evidence topology,
+/// canonical callable keys, and lexical frames carried by a function template.
 pub fn fnEvidenceDigest(
     evidence: []const check.ConstStore.ConstFnEvidence,
     frames: []const check.ConstStore.ConstFnEvidenceFrame,
@@ -444,6 +444,11 @@ test "function evidence identity uses canonical callable keys" {
     try std.testing.expectEqual(fnEvidenceDigest(&left, &frames, 0), fnEvidenceDigest(&right, &frames, 0));
 
     right[0].target.method_callable_key.bytes[0] = 9;
+    try std.testing.expect(!fnEvidenceEql(&left, &frames, 0, &right, &frames, 0));
+    try std.testing.expect(!std.meta.eql(fnEvidenceDigest(&left, &frames, 0), fnEvidenceDigest(&right, &frames, 0)));
+
+    right[0].target.method_callable_key = method_key;
+    right[0].target.instantiation.?.callable_key.bytes[0] = 9;
     try std.testing.expect(!fnEvidenceEql(&left, &frames, 0, &right, &frames, 0));
     try std.testing.expect(!std.meta.eql(fnEvidenceDigest(&left, &frames, 0), fnEvidenceDigest(&right, &frames, 0)));
 }

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -270,18 +270,18 @@ pub fn fnEvidenceDigest(
     head: ?u32,
 ) EvidenceDigest {
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    writeBytes(&hasher, "roc.monotype.fn_evidence.v1");
+    writeBytes(&hasher, "roc.monotype.fn_evidence.v2");
     writeU32(&hasher, @intCast(evidence.len));
     for (evidence) |entry| {
         writeU8(&hasher, @intFromEnum(entry));
         switch (entry) {
             .target => |target| {
                 writeBytes(&hasher, &target.view.bytes);
-                writeMethodTarget(&hasher, target.method);
+                writeMethodTarget(&hasher, target.method, target.method_callable_key);
                 if (target.instantiation) |instantiation| {
                     writeU8(&hasher, 1);
                     writeBytes(&hasher, &instantiation.view.bytes);
-                    writeU32(&hasher, @intFromEnum(instantiation.callable_ty));
+                    writeBytes(&hasher, &instantiation.callable_key.bytes);
                 } else writeU8(&hasher, 0);
                 writeU8(&hasher, @intFromEnum(target.nested));
                 switch (target.nested) {
@@ -311,7 +311,67 @@ pub fn fnEvidenceDigest(
     return .{ .bytes = hasher.finalResult() };
 }
 
-fn writeMethodTarget(hasher: *std.crypto.hash.sha2.Sha256, target: static_dispatch.MethodTarget) void {
+/// Exact semantic equality for retained function evidence. Checked callable
+/// ids are replay payload; their canonical keys are the durable identity.
+pub fn fnEvidenceEql(
+    left_evidence: []const check.ConstStore.ConstFnEvidence,
+    left_frames: []const check.ConstStore.ConstFnEvidenceFrame,
+    left_head: ?u32,
+    right_evidence: []const check.ConstStore.ConstFnEvidence,
+    right_frames: []const check.ConstStore.ConstFnEvidenceFrame,
+    right_head: ?u32,
+) bool {
+    if (left_head != right_head or left_evidence.len != right_evidence.len or left_frames.len != right_frames.len) return false;
+    for (left_evidence, right_evidence) |left, right| {
+        switch (left) {
+            .target => |left_target| switch (right) {
+                .target => |right_target| {
+                    if (!fnEvidenceTargetEql(left_target, right_target)) return false;
+                },
+                .structural, .unreachable_value, .checked_error => return false,
+            },
+            .structural => |left_structural| switch (right) {
+                .structural => |right_structural| if (!std.meta.eql(left_structural, right_structural)) return false,
+                .target, .unreachable_value, .checked_error => return false,
+            },
+            .unreachable_value => if (right != .unreachable_value) return false,
+            .checked_error => if (right != .checked_error) return false,
+        }
+    }
+    for (left_frames, right_frames) |left, right| {
+        if (!std.meta.eql(left, right)) return false;
+    }
+    return true;
+}
+
+fn fnEvidenceTargetEql(left: anytype, right: @TypeOf(left)) bool {
+    if (!std.meta.eql(left.view, right.view)) return false;
+    if (!methodTargetIdentityEql(left.method, left.method_callable_key, right.method, right.method_callable_key)) return false;
+    if (left.instantiation) |left_instantiation| {
+        const right_instantiation = right.instantiation orelse return false;
+        if (!std.meta.eql(left_instantiation.view, right_instantiation.view)) return false;
+        if (!std.meta.eql(left_instantiation.callable_key, right_instantiation.callable_key)) return false;
+    } else if (right.instantiation != null) return false;
+    return std.meta.eql(left.nested, right.nested);
+}
+
+fn methodTargetIdentityEql(
+    left: static_dispatch.MethodTarget,
+    left_callable_key: names.CanonicalTypeKey,
+    right: static_dispatch.MethodTarget,
+    right_callable_key: names.CanonicalTypeKey,
+) bool {
+    return left.module_idx == right.module_idx and
+        left.def_idx == right.def_idx and
+        std.meta.eql(left.kind, right.kind) and
+        std.meta.eql(left_callable_key, right_callable_key);
+}
+
+fn writeMethodTarget(
+    hasher: *std.crypto.hash.sha2.Sha256,
+    target: static_dispatch.MethodTarget,
+    callable_key: names.CanonicalTypeKey,
+) void {
     writeU32(hasher, target.module_idx);
     writeU32(hasher, @intFromEnum(target.def_idx));
     writeU8(hasher, @intFromEnum(target.kind));
@@ -331,7 +391,7 @@ fn writeMethodTarget(hasher: *std.crypto.hash.sha2.Sha256, target: static_dispat
         },
         .structural => |kind| writeU8(hasher, @intFromEnum(kind)),
     }
-    writeU32(hasher, @intFromEnum(target.callable_ty));
+    writeBytes(hasher, &callable_key.bytes);
 }
 
 fn writeStructuralDerivation(hasher: *std.crypto.hash.sha2.Sha256, derivation: static_dispatch.StructuralDerivation) void {
@@ -350,6 +410,42 @@ fn writeOptionalU32(hasher: *std.crypto.hash.sha2.Sha256, value: ?u32) void {
         writeU8(hasher, 1);
         writeU32(hasher, actual);
     } else writeU8(hasher, 0);
+}
+
+test "function evidence identity uses canonical callable keys" {
+    var method_key: names.CanonicalTypeKey = .{};
+    method_key.bytes[0] = 1;
+    var instantiation_key: names.CanonicalTypeKey = .{};
+    instantiation_key.bytes[0] = 2;
+    const frames = [_]check.ConstStore.ConstFnEvidenceFrame{
+        check.ConstStore.ConstFnEvidenceFrame.init(.root, null, 0, 1),
+    };
+    const left = [_]check.ConstStore.ConstFnEvidence{.{ .target = .{
+        .view = .{},
+        .method = .{
+            .module_idx = 3,
+            .def_idx = @enumFromInt(4),
+            .kind = .{ .structural = .parser },
+            .callable_ty = @enumFromInt(5),
+        },
+        .method_callable_key = method_key,
+        .instantiation = .{
+            .view = .{},
+            .callable_key = instantiation_key,
+            .callable_ty = @enumFromInt(6),
+        },
+        .nested = .from_callable,
+    } }};
+    var right = left;
+    right[0].target.method.callable_ty = @enumFromInt(7);
+    right[0].target.instantiation.?.callable_ty = @enumFromInt(8);
+
+    try std.testing.expect(fnEvidenceEql(&left, &frames, 0, &right, &frames, 0));
+    try std.testing.expectEqual(fnEvidenceDigest(&left, &frames, 0), fnEvidenceDigest(&right, &frames, 0));
+
+    right[0].target.method_callable_key.bytes[0] = 9;
+    try std.testing.expect(!fnEvidenceEql(&left, &frames, 0, &right, &frames, 0));
+    try std.testing.expect(!std.meta.eql(fnEvidenceDigest(&left, &frames, 0), fnEvidenceDigest(&right, &frames, 0)));
 }
 
 fn writeFnDef(hasher: *std.crypto.hash.sha2.Sha256, fn_def: FnDef) void {

--- a/src/postcheck/monotype/ast.zig
+++ b/src/postcheck/monotype/ast.zig
@@ -263,7 +263,7 @@ pub fn fnTemplateDigest(template: FnTemplate, types: *Type.Store, name_store: *c
 }
 
 /// Compute the stable specialization digest from durable evidence topology,
-/// canonical callable keys, and lexical frames carried by a function template.
+/// checked callable type keys, and lexical frames carried by a function template.
 pub fn fnEvidenceDigest(
     evidence: []const check.ConstStore.ConstFnEvidence,
     frames: []const check.ConstStore.ConstFnEvidenceFrame,
@@ -311,8 +311,8 @@ pub fn fnEvidenceDigest(
     return .{ .bytes = hasher.finalResult() };
 }
 
-/// Exact semantic equality for retained function evidence. Checked callable
-/// ids are replay payload; their canonical keys are the durable identity.
+/// Exact checked-identity equality for retained function evidence. Checked
+/// callable ids are replay payload; their type keys are the durable identity.
 pub fn fnEvidenceEql(
     left_evidence: []const check.ConstStore.ConstFnEvidence,
     left_frames: []const check.ConstStore.ConstFnEvidenceFrame,
@@ -412,7 +412,7 @@ fn writeOptionalU32(hasher: *std.crypto.hash.sha2.Sha256, value: ?u32) void {
     } else writeU8(hasher, 0);
 }
 
-test "function evidence identity uses canonical callable keys" {
+test "function evidence identity uses checked callable type keys" {
     var method_key: names.CanonicalTypeKey = .{};
     method_key.bytes[0] = 1;
     var instantiation_key: names.CanonicalTypeKey = .{};

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -1466,12 +1466,15 @@ fn specEvidenceEql(a: SpecEvidence, b: SpecEvidence) bool {
         .target => |a_target| switch (b) {
             .target => |b_target| blk: {
                 if (!std.meta.eql(a_target.view.key, b_target.view.key)) break :blk false;
-                if (!std.meta.eql(a_target.target, b_target.target)) break :blk false;
+                if (!specMethodTargetEql(a_target, b_target)) break :blk false;
                 if (a_target.local_proc_context != b_target.local_proc_context) break :blk false;
                 if (a_target.instantiation) |a_instantiation| {
                     const b_instantiation = b_target.instantiation orelse break :blk false;
                     if (!std.meta.eql(a_instantiation.view.key, b_instantiation.view.key)) break :blk false;
-                    if (a_instantiation.callable_ty != b_instantiation.callable_ty) break :blk false;
+                    if (!std.meta.eql(
+                        a_instantiation.view.types.rootKey(a_instantiation.callable_ty),
+                        b_instantiation.view.types.rootKey(b_instantiation.callable_ty),
+                    )) break :blk false;
                 } else if (b_target.instantiation != null) {
                     break :blk false;
                 }
@@ -1502,6 +1505,16 @@ fn specEvidenceEql(a: SpecEvidence, b: SpecEvidence) bool {
         .unreachable_value => b == .unreachable_value,
         .checked_error => b == .checked_error,
     };
+}
+
+fn specMethodTargetEql(left: *const SpecEvidenceTarget, right: *const SpecEvidenceTarget) bool {
+    return left.target.module_idx == right.target.module_idx and
+        left.target.def_idx == right.target.def_idx and
+        std.meta.eql(left.target.kind, right.target.kind) and
+        std.meta.eql(
+            left.view.types.rootKey(left.target.callable_ty),
+            right.view.types.rootKey(right.target.callable_ty),
+        );
 }
 
 fn specEvidenceVectorEql(a: []const SpecEvidence, b: []const SpecEvidence) bool {
@@ -1811,14 +1824,7 @@ fn specializationEvidenceView(evidence: StoredConstFnEvidence) specialize.Eviden
 }
 
 fn storedConstFnEvidenceEql(left: StoredConstFnEvidence, right: StoredConstFnEvidence) bool {
-    if (left.head != right.head or left.nodes.len != right.nodes.len or left.frames.len != right.frames.len) return false;
-    for (left.nodes, right.nodes) |left_node, right_node| {
-        if (!std.meta.eql(left_node, right_node)) return false;
-    }
-    for (left.frames, right.frames) |left_frame, right_frame| {
-        if (!std.meta.eql(left_frame, right_frame)) return false;
-    }
-    return true;
+    return Ast.fnEvidenceEql(left.nodes, left.frames, left.head, right.nodes, right.frames, right.head);
 }
 
 fn programViewFnEvidence(program: Ast.ProgramView, template: Ast.FnTemplate) StoredConstFnEvidence {
@@ -3331,8 +3337,10 @@ const Builder = struct {
                 nodes.items[target_index] = .{ .target = .{
                     .view = .{ .bytes = target.view.key.bytes },
                     .method = target.target,
+                    .method_callable_key = target.view.types.rootKey(target.target.callable_ty),
                     .instantiation = if (target.instantiation) |instantiation| .{
                         .view = .{ .bytes = instantiation.view.key.bytes },
+                        .callable_key = instantiation.view.types.rootKey(instantiation.callable_ty),
                         .callable_ty = instantiation.callable_ty,
                     } else null,
                     .nested = nested,
@@ -49568,18 +49576,31 @@ test "graph constructor representation follows aliases and preserves nominal lay
 }
 
 test "specialization evidence equality includes exact target instantiation" {
+    var roots: [11]checked.CheckedTypeRoot = undefined;
+    for (&roots, 0..) |*root, index| {
+        root.* = .{ .id = @enumFromInt(@as(u32, @intCast(index))), .key = .{} };
+        root.key.bytes[0] = @intCast(index);
+    }
+    // A fresh checked identity may have a distinct raw id while retaining the
+    // same canonical type topology.
+    roots[10].key = roots[8].key;
+
     var target_view: ModuleView = undefined;
     target_view.key = .{};
     target_view.key.bytes[0] = 1;
+    target_view.types = .{ .roots = &roots };
     var other_target_view: ModuleView = undefined;
     other_target_view.key = .{};
     other_target_view.key.bytes[0] = 2;
+    other_target_view.types = .{ .roots = &roots };
     var instantiation_view: ModuleView = undefined;
     instantiation_view.key = .{};
     instantiation_view.key.bytes[0] = 3;
+    instantiation_view.types = .{ .roots = &roots };
     var other_instantiation_view: ModuleView = undefined;
     other_instantiation_view.key = .{};
     other_instantiation_view.key.bytes[0] = 4;
+    other_instantiation_view.types = .{ .roots = &roots };
 
     const method: static_dispatch.MethodTarget = .{
         .module_idx = 5,
@@ -49610,6 +49631,10 @@ test "specialization evidence equality includes exact target instantiation" {
     var different_callable = exact;
     different_callable.instantiation.?.callable_ty = @enumFromInt(9);
     try std.testing.expect(!specEvidenceEql(.{ .target = &exact }, .{ .target = &different_callable }));
+
+    var equivalent_fresh_callable = exact;
+    equivalent_fresh_callable.instantiation.?.callable_ty = @enumFromInt(10);
+    try std.testing.expect(specEvidenceEql(.{ .target = &exact }, .{ .target = &equivalent_fresh_callable }));
 
     var unresolved_nested = exact;
     unresolved_nested.nested = .synthesize;

--- a/src/postcheck/monotype/serialize.zig
+++ b/src/postcheck/monotype/serialize.zig
@@ -29,7 +29,7 @@ const TestEvidenceMappingError = std.mem.Allocator.Error || CacheError || error{
 pub const MAGIC: [8]u8 = .{ 'R', 'O', 'C', 'S', 'P', 'E', 'C', 0 };
 /// Serialization format version for specialization cache files.
 /// Version 13: retained function evidence identifies callable types by their
-/// canonical checked keys while preserving raw checked ids for relation replay.
+/// checked type keys while preserving raw checked ids for relation replay.
 /// Version 12: graph-reduced type digests (versioned digest domains,
 /// alias-opaque encoding, recursive-group reduction, and previously missing
 /// identity fields), which change every serialized digest byte.

--- a/src/postcheck/monotype/serialize.zig
+++ b/src/postcheck/monotype/serialize.zig
@@ -28,6 +28,8 @@ const TestEvidenceMappingError = std.mem.Allocator.Error || CacheError || error{
 /// Magic bytes at the start of a specialization cache file.
 pub const MAGIC: [8]u8 = .{ 'R', 'O', 'C', 'S', 'P', 'E', 'C', 0 };
 /// Serialization format version for specialization cache files.
+/// Version 13: retained function evidence identifies callable types by their
+/// canonical checked keys while preserving raw checked ids for relation replay.
 /// Version 12: graph-reduced type digests (versioned digest domains,
 /// alias-opaque encoding, recursive-group reduction, and previously missing
 /// identity fields), which change every serialized digest byte.
@@ -36,7 +38,7 @@ pub const MAGIC: [8]u8 = .{ 'R', 'O', 'C', 'S', 'P', 'E', 'C', 0 };
 /// roots or one exact producer-authored graph.
 /// Version 8: specialization and function-template identity includes the
 /// SHA-256 digest of exact compile-time evidence topology.
-pub const FORMAT_VERSION: u32 = 12;
+pub const FORMAT_VERSION: u32 = 13;
 
 const SECTION_COUNT = 43;
 
@@ -469,6 +471,7 @@ test "specialization cache evidence topology accepts callable-derived targets" {
     const evidence = [_]check.ConstStore.ConstFnEvidence{.{ .target = .{
         .view = .{},
         .method = testMethodTarget(),
+        .method_callable_key = .{},
         .instantiation = null,
         .nested = .from_callable,
     } }};
@@ -2736,6 +2739,7 @@ test "monotype specialization cache rejects corrupt function evidence topology b
                 // Evidence topology validation reads only the explicit nested
                 // count/subtree metadata from this target node.
                 .method = testMethodTarget(),
+                .method_callable_key = .{},
                 .instantiation = null,
                 .nested = .{ .resolved = .{ .count = 1, .subtree_len = 0 } },
             },

--- a/src/postcheck/monotype/specialize.zig
+++ b/src/postcheck/monotype/specialize.zig
@@ -113,10 +113,7 @@ const OwnedEvidence = struct {
 };
 
 fn evidenceEql(left: EvidenceView, right: EvidenceView) bool {
-    if (left.head != right.head or left.nodes.len != right.nodes.len or left.frames.len != right.frames.len) return false;
-    for (left.nodes, right.nodes) |a, b| if (!std.meta.eql(a, b)) return false;
-    for (left.frames, right.frames) |a, b| if (!std.meta.eql(a, b)) return false;
-    return true;
+    return Ast.fnEvidenceEql(left.nodes, left.frames, left.head, right.nodes, right.frames, right.head);
 }
 
 fn evidenceDigestMatches(identity: Ast.SpecIdentity, evidence: EvidenceView) bool {


### PR DESCRIPTION
Fresh checked callable roots can have distinct local IDs even when their canonical type topology is identical. This makes specialization evidence identity use the precomputed canonical checked keys while retaining raw IDs strictly for relation replay, so equivalent calls reuse one specialization without conflating different evidence shapes.

Fixes #10831.