### PR TITLE
Fix small aggregate boxing in wasm dev backend

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4815,6 +4815,17 @@ pub fn build(b: *std.Build) void {
         build_wasm_boxed_model_update_app.step.dependOn(build_test_hosts_step);
         build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_boxed_model_update_app.step);
 
+        const build_wasm_issue_10836_app = b.addRunArtifact(roc_exe);
+        build_wasm_issue_10836_app.addArgs(&.{
+            "build",
+            "test/wasm/issue_10836_boxed_low_alignment_static_lib_app.roc",
+            "--opt=dev",
+            "--target=wasm32",
+            "--output=test/wasm/issue_10836_boxed_low_alignment_static_lib_app.wasm",
+        });
+        build_wasm_issue_10836_app.step.dependOn(build_test_hosts_step);
+        build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_issue_10836_app.step);
+
         const wasm_test_exe = b.addExecutable(.{
             .name = "wasm_static_lib_test",
             .root_module = b.createModule(.{
@@ -5054,6 +5065,16 @@ pub fn build(b: *std.Build) void {
             });
             run_wasm_boxed_model_update_test.step.dependOn(build_test_wasm_static_lib_runner_step);
             run_test_wasm_static_lib_step.dependOn(&run_wasm_boxed_model_update_test.step);
+
+            const run_wasm_issue_10836_test = b.addRunArtifact(wasm_test_exe);
+            run_wasm_issue_10836_test.addArgs(&.{
+                "--wasm-path",
+                "test/wasm/issue_10836_boxed_low_alignment_static_lib_app.wasm",
+                "--expected",
+                "7,9;Inc(42)",
+            });
+            run_wasm_issue_10836_test.step.dependOn(build_test_wasm_static_lib_runner_step);
+            run_test_wasm_static_lib_step.dependOn(&run_wasm_issue_10836_test.step);
         }
         run_wasm_test.step.dependOn(build_test_wasm_static_lib_runner_step);
         run_test_wasm_static_lib_step.dependOn(&run_wasm_test.step);

--- a/build.zig
+++ b/build.zig
@@ -5071,7 +5071,7 @@ pub fn build(b: *std.Build) void {
                 "--wasm-path",
                 "test/wasm/issue_10836_boxed_low_alignment_static_lib_app.wasm",
                 "--expected",
-                "7,9;Inc(42)",
+                "7,9;11,13;Inc(42)",
             });
             run_wasm_issue_10836_test.step.dependOn(build_test_wasm_static_lib_runner_step);
             run_test_wasm_static_lib_step.dependOn(&run_wasm_issue_10836_test.step);

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -14388,6 +14388,14 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                 const box_abi = ls.builtinBoxAbi(ll.ret_layout);
                 const value_size = box_abi.elem_size;
                 const value_repr = try WasmLayout.wasmReprWithStore(self.procLocalLayoutIdx(value_expr), ls);
+                const value_vt: ValType = switch (value_repr) {
+                    .stack_memory => .i32,
+                    .primitive => |val_type| val_type,
+                };
+                const value_is_composite = switch (value_repr) {
+                    .stack_memory => true,
+                    .primitive => false,
+                };
                 if (value_size == 0) {
                     _ = try self.emitProcLocal(value_expr);
                     self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
@@ -14401,77 +14409,74 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
 
                     try self.emitProcLocal(value_expr);
 
-                    switch (value_repr) {
-                        .stack_memory => {
-                            const src_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                            try self.emitLocalSet(src_ptr);
+                    if (value_is_composite) {
+                        const src_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                        try self.emitLocalSet(src_ptr);
 
-                            if (value_size <= 16) {
-                                var offset: u32 = 0;
-                                while (offset + 4 <= value_size) : (offset += 4) {
-                                    try self.emitLocalGet(box_ptr);
-                                    try self.emitLocalGet(src_ptr);
-                                    self.currentCode().append(self.allocator, Op.i32_load) catch return error.OutOfMemory;
-                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
-                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
-                                    self.currentCode().append(self.allocator, Op.i32_store) catch return error.OutOfMemory;
-                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
-                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
-                                }
-                                while (offset < value_size) : (offset += 1) {
-                                    try self.emitLocalGet(box_ptr);
-                                    try self.emitLocalGet(src_ptr);
-                                    self.currentCode().append(self.allocator, Op.i32_load8_u) catch return error.OutOfMemory;
-                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
-                                    self.currentCode().append(self.allocator, Op.i32_store8) catch return error.OutOfMemory;
-                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
-                                }
-                            } else {
-                                const i = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                                self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                                try self.emitLocalSet(i);
-
-                                self.currentCode().append(self.allocator, Op.loop_) catch return error.OutOfMemory;
-                                self.currentCode().append(self.allocator, @intFromEnum(BlockType.void)) catch return error.OutOfMemory;
-
+                        if (value_size <= 16) {
+                            var offset: u32 = 0;
+                            while (offset + 4 <= value_size) : (offset += 4) {
                                 try self.emitLocalGet(box_ptr);
-                                try self.emitLocalGet(i);
-                                self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
                                 try self.emitLocalGet(src_ptr);
-                                try self.emitLocalGet(i);
-                                self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+                                self.currentCode().append(self.allocator, Op.i32_load) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
+                                self.currentCode().append(self.allocator, Op.i32_store) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
+                            }
+                            while (offset < value_size) : (offset += 1) {
+                                try self.emitLocalGet(box_ptr);
+                                try self.emitLocalGet(src_ptr);
                                 self.currentCode().append(self.allocator, Op.i32_load8_u) catch return error.OutOfMemory;
                                 WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
                                 self.currentCode().append(self.allocator, Op.i32_store8) catch return error.OutOfMemory;
                                 WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-
-                                try self.emitLocalGet(i);
-                                self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 1) catch return error.OutOfMemory;
-                                self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                                try self.emitLocalSet(i);
-
-                                try self.emitLocalGet(i);
-                                self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(value_size)) catch return error.OutOfMemory;
-                                self.currentCode().append(self.allocator, Op.i32_lt_u) catch return error.OutOfMemory;
-                                self.currentCode().append(self.allocator, Op.br_if) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-
-                                self.currentCode().append(self.allocator, Op.end) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
                             }
-                        },
-                        .primitive => |value_vt| {
-                            const value_local = self.storage.allocAnonymousLocal(value_vt) catch return error.OutOfMemory;
-                            try self.emitLocalSet(value_local);
-                            try self.emitLocalGet(value_local);
-                            try self.emitStoreToMemSized(box_ptr, 0, value_vt, value_size);
-                        },
+                        } else {
+                            const i = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                            self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
+                            WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                            try self.emitLocalSet(i);
+
+                            self.currentCode().append(self.allocator, Op.loop_) catch return error.OutOfMemory;
+                            self.currentCode().append(self.allocator, @intFromEnum(BlockType.void)) catch return error.OutOfMemory;
+
+                            try self.emitLocalGet(box_ptr);
+                            try self.emitLocalGet(i);
+                            self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+                            try self.emitLocalGet(src_ptr);
+                            try self.emitLocalGet(i);
+                            self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+                            self.currentCode().append(self.allocator, Op.i32_load8_u) catch return error.OutOfMemory;
+                            WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                            WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                            self.currentCode().append(self.allocator, Op.i32_store8) catch return error.OutOfMemory;
+                            WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                            WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+
+                            try self.emitLocalGet(i);
+                            self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
+                            WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 1) catch return error.OutOfMemory;
+                            self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+                            try self.emitLocalSet(i);
+
+                            try self.emitLocalGet(i);
+                            self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
+                            WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(value_size)) catch return error.OutOfMemory;
+                            self.currentCode().append(self.allocator, Op.i32_lt_u) catch return error.OutOfMemory;
+                            self.currentCode().append(self.allocator, Op.br_if) catch return error.OutOfMemory;
+                            WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+
+                            self.currentCode().append(self.allocator, Op.end) catch return error.OutOfMemory;
+                        }
+                    } else {
+                        const value_local = self.storage.allocAnonymousLocal(value_vt) catch return error.OutOfMemory;
+                        try self.emitLocalSet(value_local);
+                        try self.emitLocalGet(value_local);
+                        try self.emitStoreToMemSized(box_ptr, 0, value_vt, value_size);
                     }
 
                     try self.emitLocalGet(box_ptr);
@@ -14545,55 +14550,60 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                     try self.emitProcLocal(box_expr);
 
                     const result_repr = try WasmLayout.wasmReprWithStore(ll.ret_layout, ls);
+                    const result_vt: ValType = switch (result_repr) {
+                        .stack_memory => .i32,
+                        .primitive => |val_type| val_type,
+                    };
+                    const result_is_composite = switch (result_repr) {
+                        .stack_memory => true,
+                        .primitive => false,
+                    };
                     const result_size = try self.layoutByteSize(ll.ret_layout);
-                    switch (result_repr) {
-                        .stack_memory => {
-                            const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                            try self.emitLocalSet(src_local);
+                    if (result_is_composite) {
+                        const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                        try self.emitLocalSet(src_local);
 
-                            const result_align: u32 = @intCast(@max(self.getLayoutStore().layoutSizeAlign(self.getLayoutStore().getLayout(ll.ret_layout)).alignment.toByteUnits(), 1));
-                            const dst_offset = try self.allocStackMemory(result_size, result_align);
-                            const dst_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                            try self.emitFpOffset(dst_offset);
-                            try self.emitLocalSet(dst_local);
+                        const result_align: u32 = @intCast(@max(self.getLayoutStore().layoutSizeAlign(self.getLayoutStore().getLayout(ll.ret_layout)).alignment.toByteUnits(), 1));
+                        const dst_offset = try self.allocStackMemory(result_size, result_align);
+                        const dst_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                        try self.emitFpOffset(dst_offset);
+                        try self.emitLocalSet(dst_local);
 
-                            try self.emitMemCopy(dst_local, 0, src_local, result_size);
-                            try self.emitLocalGet(dst_local);
-                        },
-                        .primitive => |result_vt| {
-                            const box_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                            try self.emitLocalSet(box_ptr);
-                            if (result_size == 0) {
-                                switch (result_vt) {
-                                    .i32 => {
-                                        self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                                        WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                                    },
-                                    .i64 => {
-                                        self.currentCode().append(self.allocator, Op.i64_const) catch return error.OutOfMemory;
-                                        WasmModule.leb128WriteI64(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                                    },
-                                    .f32 => {
-                                        self.currentCode().append(self.allocator, Op.f32_const) catch return error.OutOfMemory;
-                                        try self.currentCode().appendSlice(self.allocator, std.mem.asBytes(&@as(f32, 0)));
-                                    },
-                                    .f64 => {
-                                        self.currentCode().append(self.allocator, Op.f64_const) catch return error.OutOfMemory;
-                                        try self.currentCode().appendSlice(self.allocator, std.mem.asBytes(&@as(f64, 0)));
-                                    },
-                                    .v128 => unreachable,
-                                }
-                            } else {
-                                const temp_offset = try self.allocStackMemory(@max(result_size, 4), 4);
-                                const temp_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                                try self.emitFpOffset(temp_offset);
-                                try self.emitLocalSet(temp_ptr);
-
-                                try self.emitMemCopy(temp_ptr, 0, box_ptr, result_size);
-                                try self.emitLocalGet(temp_ptr);
-                                try self.emitLoadOpSized(result_vt, result_size, 0);
+                        try self.emitMemCopy(dst_local, 0, src_local, result_size);
+                        try self.emitLocalGet(dst_local);
+                    } else {
+                        const box_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                        try self.emitLocalSet(box_ptr);
+                        if (result_size == 0) {
+                            switch (result_vt) {
+                                .i32 => {
+                                    self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
+                                    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                                },
+                                .i64 => {
+                                    self.currentCode().append(self.allocator, Op.i64_const) catch return error.OutOfMemory;
+                                    WasmModule.leb128WriteI64(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                                },
+                                .f32 => {
+                                    self.currentCode().append(self.allocator, Op.f32_const) catch return error.OutOfMemory;
+                                    try self.currentCode().appendSlice(self.allocator, std.mem.asBytes(&@as(f32, 0)));
+                                },
+                                .f64 => {
+                                    self.currentCode().append(self.allocator, Op.f64_const) catch return error.OutOfMemory;
+                                    try self.currentCode().appendSlice(self.allocator, std.mem.asBytes(&@as(f64, 0)));
+                                },
+                                .v128 => unreachable,
                             }
-                        },
+                        } else {
+                            const temp_offset = try self.allocStackMemory(@max(result_size, 4), 4);
+                            const temp_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                            try self.emitFpOffset(temp_offset);
+                            try self.emitLocalSet(temp_ptr);
+
+                            try self.emitMemCopy(temp_ptr, 0, box_ptr, result_size);
+                            try self.emitLocalGet(temp_ptr);
+                            try self.emitLoadOpSized(result_vt, result_size, 0);
+                        }
                     }
                 }
             }
@@ -14777,6 +14787,14 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             const value_expr = GuardedList.at(args, 1);
             const value_size = try self.layoutByteSize(self.procLocalLayoutIdx(value_expr));
             const value_repr = try WasmLayout.wasmReprWithStore(self.procLocalLayoutIdx(value_expr), self.getLayoutStore());
+            const value_vt: ValType = switch (value_repr) {
+                .stack_memory => .i32,
+                .primitive => |val_type| val_type,
+            };
+            const value_is_composite = switch (value_repr) {
+                .stack_memory => true,
+                .primitive => false,
+            };
 
             if (value_size == 0) {
                 _ = try self.emitProcLocal(GuardedList.at(args, 0));
@@ -14787,13 +14805,12 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                 try self.emitLocalSet(ptr_local);
 
                 try self.emitProcLocal(value_expr);
-                switch (value_repr) {
-                    .stack_memory => {
-                        const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                        try self.emitLocalSet(src_local);
-                        try self.emitMemCopy(ptr_local, 0, src_local, value_size);
-                    },
-                    .primitive => |value_vt| try self.emitStoreToMemSized(ptr_local, 0, value_vt, value_size),
+                if (value_is_composite) {
+                    const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                    try self.emitLocalSet(src_local);
+                    try self.emitMemCopy(ptr_local, 0, src_local, value_size);
+                } else {
+                    try self.emitStoreToMemSized(ptr_local, 0, value_vt, value_size);
                 }
             }
             self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
@@ -14804,6 +14821,14 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             // Same shape as erased_capture_load above.
             const result_size = try self.layoutByteSize(ll.ret_layout);
             const result_repr = try WasmLayout.wasmReprWithStore(ll.ret_layout, self.getLayoutStore());
+            const result_vt: ValType = switch (result_repr) {
+                .stack_memory => .i32,
+                .primitive => |val_type| val_type,
+            };
+            const result_is_composite = switch (result_repr) {
+                .stack_memory => true,
+                .primitive => false,
+            };
 
             if (result_size == 0) {
                 _ = try self.emitProcLocal(GuardedList.at(args, 0));
@@ -14815,23 +14840,20 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                 const src_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
                 try self.emitLocalSet(src_ptr);
 
-                switch (result_repr) {
-                    .stack_memory => {
-                        const ls = self.getLayoutStore();
-                        const result_align: u32 = @intCast(@max(ls.layoutSizeAlign(ls.getLayout(ll.ret_layout)).alignment.toByteUnits(), 1));
-                        const dst_offset = try self.allocStackMemory(result_size, result_align);
-                        const dst_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                        try self.emitFpOffset(dst_offset);
-                        try self.emitLocalSet(dst_local);
+                if (result_is_composite) {
+                    const ls = self.getLayoutStore();
+                    const result_align: u32 = @intCast(@max(ls.layoutSizeAlign(ls.getLayout(ll.ret_layout)).alignment.toByteUnits(), 1));
+                    const dst_offset = try self.allocStackMemory(result_size, result_align);
+                    const dst_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                    try self.emitFpOffset(dst_offset);
+                    try self.emitLocalSet(dst_local);
 
-                        try self.emitMemCopy(dst_local, 0, src_ptr, result_size);
-                        try self.emitLocalGet(dst_local);
-                    },
-                    .primitive => |result_vt| {
-                        try self.emitLocalGet(src_ptr);
-                        try self.emitLoadOpSized(result_vt, result_size, 0);
-                        try self.emitCanonicalizeScalarForLayout(ll.ret_layout);
-                    },
+                    try self.emitMemCopy(dst_local, 0, src_ptr, result_size);
+                    try self.emitLocalGet(dst_local);
+                } else {
+                    try self.emitLocalGet(src_ptr);
+                    try self.emitLoadOpSized(result_vt, result_size, 0);
+                    try self.emitCanonicalizeScalarForLayout(ll.ret_layout);
                 }
             }
         },

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -14388,6 +14388,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                 const box_abi = ls.builtinBoxAbi(ll.ret_layout);
                 const value_size = box_abi.elem_size;
                 const value_vt = try self.procLocalValType(value_expr);
+                const value_is_composite = try self.isCompositeLocal(value_expr);
                 if (value_size == 0) {
                     _ = try self.emitProcLocal(value_expr);
                     self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
@@ -14401,7 +14402,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
 
                     try self.emitProcLocal(value_expr);
 
-                    if (value_vt == .i32 and value_size > 4) {
+                    if (value_is_composite) {
                         const src_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
                         try self.emitLocalSet(src_ptr);
 
@@ -14543,7 +14544,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
 
                     const result_vt = try self.resolveValType(ll.ret_layout);
                     const result_size = try self.layoutByteSize(ll.ret_layout);
-                    if (result_vt == .i32 and result_size > 4) {
+                    if (try self.isCompositeLayout(ll.ret_layout)) {
                         const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
                         try self.emitLocalSet(src_local);
 
@@ -14768,8 +14769,10 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
         .ptr_store => {
             // ptr_store: (Ptr(T), T) -> {}. Copy sizeOf(T) bytes into *ptr.
             // Result is unit; leave a dummy i32 0 (zst convention).
-            const value_size = try self.layoutByteSize(self.procLocalLayoutIdx(GuardedList.at(args, 1)));
-            const value_vt = try self.procLocalValType(GuardedList.at(args, 1));
+            const value_expr = GuardedList.at(args, 1);
+            const value_size = try self.layoutByteSize(self.procLocalLayoutIdx(value_expr));
+            const value_vt = try self.procLocalValType(value_expr);
+            const value_is_composite = try self.isCompositeLocal(value_expr);
 
             if (value_size == 0) {
                 _ = try self.emitProcLocal(GuardedList.at(args, 0));
@@ -14779,8 +14782,8 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                 const ptr_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
                 try self.emitLocalSet(ptr_local);
 
-                try self.emitProcLocal(GuardedList.at(args, 1));
-                if (value_vt == .i32 and value_size > 4) {
+                try self.emitProcLocal(value_expr);
+                if (value_is_composite) {
                     // Composite value: arg is an i32 pointer into linear memory.
                     const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
                     try self.emitLocalSet(src_local);
@@ -14808,7 +14811,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                 const src_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
                 try self.emitLocalSet(src_ptr);
 
-                if (result_vt == .i32 and result_size > 4) {
+                if (try self.isCompositeLayout(ll.ret_layout)) {
                     const ls = self.getLayoutStore();
                     const result_align: u32 = @intCast(@max(ls.layoutSizeAlign(ls.getLayout(ll.ret_layout)).alignment.toByteUnits(), 1));
                     const dst_offset = try self.allocStackMemory(result_size, result_align);

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -14387,8 +14387,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             } else {
                 const box_abi = ls.builtinBoxAbi(ll.ret_layout);
                 const value_size = box_abi.elem_size;
-                const value_vt = try self.procLocalValType(value_expr);
-                const value_is_composite = try self.isCompositeLocal(value_expr);
+                const value_repr = try WasmLayout.wasmReprWithStore(self.procLocalLayoutIdx(value_expr), ls);
                 if (value_size == 0) {
                     _ = try self.emitProcLocal(value_expr);
                     self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
@@ -14402,74 +14401,77 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
 
                     try self.emitProcLocal(value_expr);
 
-                    if (value_is_composite) {
-                        const src_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                        try self.emitLocalSet(src_ptr);
+                    switch (value_repr) {
+                        .stack_memory => {
+                            const src_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                            try self.emitLocalSet(src_ptr);
 
-                        if (value_size <= 16) {
-                            var offset: u32 = 0;
-                            while (offset + 4 <= value_size) : (offset += 4) {
+                            if (value_size <= 16) {
+                                var offset: u32 = 0;
+                                while (offset + 4 <= value_size) : (offset += 4) {
+                                    try self.emitLocalGet(box_ptr);
+                                    try self.emitLocalGet(src_ptr);
+                                    self.currentCode().append(self.allocator, Op.i32_load) catch return error.OutOfMemory;
+                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
+                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
+                                    self.currentCode().append(self.allocator, Op.i32_store) catch return error.OutOfMemory;
+                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
+                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
+                                }
+                                while (offset < value_size) : (offset += 1) {
+                                    try self.emitLocalGet(box_ptr);
+                                    try self.emitLocalGet(src_ptr);
+                                    self.currentCode().append(self.allocator, Op.i32_load8_u) catch return error.OutOfMemory;
+                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
+                                    self.currentCode().append(self.allocator, Op.i32_store8) catch return error.OutOfMemory;
+                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                                    WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
+                                }
+                            } else {
+                                const i = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                                self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                                try self.emitLocalSet(i);
+
+                                self.currentCode().append(self.allocator, Op.loop_) catch return error.OutOfMemory;
+                                self.currentCode().append(self.allocator, @intFromEnum(BlockType.void)) catch return error.OutOfMemory;
+
                                 try self.emitLocalGet(box_ptr);
+                                try self.emitLocalGet(i);
+                                self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
                                 try self.emitLocalGet(src_ptr);
-                                self.currentCode().append(self.allocator, Op.i32_load) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
-                                self.currentCode().append(self.allocator, Op.i32_store) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
-                            }
-                            while (offset < value_size) : (offset += 1) {
-                                try self.emitLocalGet(box_ptr);
-                                try self.emitLocalGet(src_ptr);
+                                try self.emitLocalGet(i);
+                                self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
                                 self.currentCode().append(self.allocator, Op.i32_load8_u) catch return error.OutOfMemory;
                                 WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
                                 self.currentCode().append(self.allocator, Op.i32_store8) catch return error.OutOfMemory;
                                 WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), offset) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+
+                                try self.emitLocalGet(i);
+                                self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 1) catch return error.OutOfMemory;
+                                self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
+                                try self.emitLocalSet(i);
+
+                                try self.emitLocalGet(i);
+                                self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(value_size)) catch return error.OutOfMemory;
+                                self.currentCode().append(self.allocator, Op.i32_lt_u) catch return error.OutOfMemory;
+                                self.currentCode().append(self.allocator, Op.br_if) catch return error.OutOfMemory;
+                                WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+
+                                self.currentCode().append(self.allocator, Op.end) catch return error.OutOfMemory;
                             }
-                        } else {
-                            const i = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                            self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                            WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                            try self.emitLocalSet(i);
-
-                            self.currentCode().append(self.allocator, Op.loop_) catch return error.OutOfMemory;
-                            self.currentCode().append(self.allocator, @intFromEnum(BlockType.void)) catch return error.OutOfMemory;
-
-                            try self.emitLocalGet(box_ptr);
-                            try self.emitLocalGet(i);
-                            self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                            try self.emitLocalGet(src_ptr);
-                            try self.emitLocalGet(i);
-                            self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                            self.currentCode().append(self.allocator, Op.i32_load8_u) catch return error.OutOfMemory;
-                            WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                            WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                            self.currentCode().append(self.allocator, Op.i32_store8) catch return error.OutOfMemory;
-                            WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                            WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-
-                            try self.emitLocalGet(i);
-                            self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                            WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 1) catch return error.OutOfMemory;
-                            self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
-                            try self.emitLocalSet(i);
-
-                            try self.emitLocalGet(i);
-                            self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                            WasmModule.leb128WriteI32(self.allocator, self.currentCode(), @intCast(value_size)) catch return error.OutOfMemory;
-                            self.currentCode().append(self.allocator, Op.i32_lt_u) catch return error.OutOfMemory;
-                            self.currentCode().append(self.allocator, Op.br_if) catch return error.OutOfMemory;
-                            WasmModule.leb128WriteU32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-
-                            self.currentCode().append(self.allocator, Op.end) catch return error.OutOfMemory;
-                        }
-                    } else {
-                        const value_local = self.storage.allocAnonymousLocal(value_vt) catch return error.OutOfMemory;
-                        try self.emitLocalSet(value_local);
-                        try self.emitLocalGet(value_local);
-                        try self.emitStoreToMemSized(box_ptr, 0, value_vt, value_size);
+                        },
+                        .primitive => |value_vt| {
+                            const value_local = self.storage.allocAnonymousLocal(value_vt) catch return error.OutOfMemory;
+                            try self.emitLocalSet(value_local);
+                            try self.emitLocalGet(value_local);
+                            try self.emitStoreToMemSized(box_ptr, 0, value_vt, value_size);
+                        },
                     }
 
                     try self.emitLocalGet(box_ptr);
@@ -14542,53 +14544,56 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                 } else {
                     try self.emitProcLocal(box_expr);
 
-                    const result_vt = try self.resolveValType(ll.ret_layout);
+                    const result_repr = try WasmLayout.wasmReprWithStore(ll.ret_layout, ls);
                     const result_size = try self.layoutByteSize(ll.ret_layout);
-                    if (try self.isCompositeLayout(ll.ret_layout)) {
-                        const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                        try self.emitLocalSet(src_local);
+                    switch (result_repr) {
+                        .stack_memory => {
+                            const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                            try self.emitLocalSet(src_local);
 
-                        const result_align: u32 = @intCast(@max(self.getLayoutStore().layoutSizeAlign(self.getLayoutStore().getLayout(ll.ret_layout)).alignment.toByteUnits(), 1));
-                        const dst_offset = try self.allocStackMemory(result_size, result_align);
-                        const dst_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                        try self.emitFpOffset(dst_offset);
-                        try self.emitLocalSet(dst_local);
+                            const result_align: u32 = @intCast(@max(self.getLayoutStore().layoutSizeAlign(self.getLayoutStore().getLayout(ll.ret_layout)).alignment.toByteUnits(), 1));
+                            const dst_offset = try self.allocStackMemory(result_size, result_align);
+                            const dst_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                            try self.emitFpOffset(dst_offset);
+                            try self.emitLocalSet(dst_local);
 
-                        try self.emitMemCopy(dst_local, 0, src_local, result_size);
-                        try self.emitLocalGet(dst_local);
-                    } else {
-                        const box_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                        try self.emitLocalSet(box_ptr);
-                        if (result_size == 0) {
-                            switch (result_vt) {
-                                .i32 => {
-                                    self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
-                                    WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                                },
-                                .i64 => {
-                                    self.currentCode().append(self.allocator, Op.i64_const) catch return error.OutOfMemory;
-                                    WasmModule.leb128WriteI64(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
-                                },
-                                .f32 => {
-                                    self.currentCode().append(self.allocator, Op.f32_const) catch return error.OutOfMemory;
-                                    try self.currentCode().appendSlice(self.allocator, std.mem.asBytes(&@as(f32, 0)));
-                                },
-                                .f64 => {
-                                    self.currentCode().append(self.allocator, Op.f64_const) catch return error.OutOfMemory;
-                                    try self.currentCode().appendSlice(self.allocator, std.mem.asBytes(&@as(f64, 0)));
-                                },
-                                .v128 => unreachable,
+                            try self.emitMemCopy(dst_local, 0, src_local, result_size);
+                            try self.emitLocalGet(dst_local);
+                        },
+                        .primitive => |result_vt| {
+                            const box_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                            try self.emitLocalSet(box_ptr);
+                            if (result_size == 0) {
+                                switch (result_vt) {
+                                    .i32 => {
+                                        self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
+                                        WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                                    },
+                                    .i64 => {
+                                        self.currentCode().append(self.allocator, Op.i64_const) catch return error.OutOfMemory;
+                                        WasmModule.leb128WriteI64(self.allocator, self.currentCode(), 0) catch return error.OutOfMemory;
+                                    },
+                                    .f32 => {
+                                        self.currentCode().append(self.allocator, Op.f32_const) catch return error.OutOfMemory;
+                                        try self.currentCode().appendSlice(self.allocator, std.mem.asBytes(&@as(f32, 0)));
+                                    },
+                                    .f64 => {
+                                        self.currentCode().append(self.allocator, Op.f64_const) catch return error.OutOfMemory;
+                                        try self.currentCode().appendSlice(self.allocator, std.mem.asBytes(&@as(f64, 0)));
+                                    },
+                                    .v128 => unreachable,
+                                }
+                            } else {
+                                const temp_offset = try self.allocStackMemory(@max(result_size, 4), 4);
+                                const temp_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                                try self.emitFpOffset(temp_offset);
+                                try self.emitLocalSet(temp_ptr);
+
+                                try self.emitMemCopy(temp_ptr, 0, box_ptr, result_size);
+                                try self.emitLocalGet(temp_ptr);
+                                try self.emitLoadOpSized(result_vt, result_size, 0);
                             }
-                        } else {
-                            const temp_offset = try self.allocStackMemory(@max(result_size, 4), 4);
-                            const temp_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                            try self.emitFpOffset(temp_offset);
-                            try self.emitLocalSet(temp_ptr);
-
-                            try self.emitMemCopy(temp_ptr, 0, box_ptr, result_size);
-                            try self.emitLocalGet(temp_ptr);
-                            try self.emitLoadOpSized(result_vt, result_size, 0);
-                        }
+                        },
                     }
                 }
             }
@@ -14771,8 +14776,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             // Result is unit; leave a dummy i32 0 (zst convention).
             const value_expr = GuardedList.at(args, 1);
             const value_size = try self.layoutByteSize(self.procLocalLayoutIdx(value_expr));
-            const value_vt = try self.procLocalValType(value_expr);
-            const value_is_composite = try self.isCompositeLocal(value_expr);
+            const value_repr = try WasmLayout.wasmReprWithStore(self.procLocalLayoutIdx(value_expr), self.getLayoutStore());
 
             if (value_size == 0) {
                 _ = try self.emitProcLocal(GuardedList.at(args, 0));
@@ -14783,13 +14787,13 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                 try self.emitLocalSet(ptr_local);
 
                 try self.emitProcLocal(value_expr);
-                if (value_is_composite) {
-                    // Composite value: arg is an i32 pointer into linear memory.
-                    const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                    try self.emitLocalSet(src_local);
-                    try self.emitMemCopy(ptr_local, 0, src_local, value_size);
-                } else {
-                    try self.emitStoreToMemSized(ptr_local, 0, value_vt, value_size);
+                switch (value_repr) {
+                    .stack_memory => {
+                        const src_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                        try self.emitLocalSet(src_local);
+                        try self.emitMemCopy(ptr_local, 0, src_local, value_size);
+                    },
+                    .primitive => |value_vt| try self.emitStoreToMemSized(ptr_local, 0, value_vt, value_size),
                 }
             }
             self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
@@ -14799,7 +14803,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             // ptr_load: (Ptr(T)) -> T. Copy sizeOf(T) bytes out of *ptr.
             // Same shape as erased_capture_load above.
             const result_size = try self.layoutByteSize(ll.ret_layout);
-            const result_vt = try self.resolveValType(ll.ret_layout);
+            const result_repr = try WasmLayout.wasmReprWithStore(ll.ret_layout, self.getLayoutStore());
 
             if (result_size == 0) {
                 _ = try self.emitProcLocal(GuardedList.at(args, 0));
@@ -14811,20 +14815,23 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                 const src_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
                 try self.emitLocalSet(src_ptr);
 
-                if (try self.isCompositeLayout(ll.ret_layout)) {
-                    const ls = self.getLayoutStore();
-                    const result_align: u32 = @intCast(@max(ls.layoutSizeAlign(ls.getLayout(ll.ret_layout)).alignment.toByteUnits(), 1));
-                    const dst_offset = try self.allocStackMemory(result_size, result_align);
-                    const dst_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
-                    try self.emitFpOffset(dst_offset);
-                    try self.emitLocalSet(dst_local);
+                switch (result_repr) {
+                    .stack_memory => {
+                        const ls = self.getLayoutStore();
+                        const result_align: u32 = @intCast(@max(ls.layoutSizeAlign(ls.getLayout(ll.ret_layout)).alignment.toByteUnits(), 1));
+                        const dst_offset = try self.allocStackMemory(result_size, result_align);
+                        const dst_local = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+                        try self.emitFpOffset(dst_offset);
+                        try self.emitLocalSet(dst_local);
 
-                    try self.emitMemCopy(dst_local, 0, src_ptr, result_size);
-                    try self.emitLocalGet(dst_local);
-                } else {
-                    try self.emitLocalGet(src_ptr);
-                    try self.emitLoadOpSized(result_vt, result_size, 0);
-                    try self.emitCanonicalizeScalarForLayout(ll.ret_layout);
+                        try self.emitMemCopy(dst_local, 0, src_ptr, result_size);
+                        try self.emitLocalGet(dst_local);
+                    },
+                    .primitive => |result_vt| {
+                        try self.emitLocalGet(src_ptr);
+                        try self.emitLoadOpSized(result_vt, result_size, 0);
+                        try self.emitCanonicalizeScalarForLayout(ll.ret_layout);
+                    },
                 }
             }
         },

--- a/test/wasm/issue_10836_boxed_low_alignment_static_lib_app.roc
+++ b/test/wasm/issue_10836_boxed_low_alignment_static_lib_app.roc
@@ -2,12 +2,18 @@ app [main!] { pf: platform "./static-lib-platform/main.roc" }
 
 Pair : { x : U8, y : U8 }
 
+HalfwordPair : { x : U16, y : U16 }
+
 Choice : [Dec(U8), Inc(U8)]
 
 main! = |seed| {
     boxed : Box(Pair)
     boxed = Box.box({ x: 7, y: 9 + seed.to_u8_wrap() })
     pair = Box.unbox(boxed)
+
+    boxed_halfwords : Box(HalfwordPair)
+    boxed_halfwords = Box.box({ x: 11, y: 13 + seed.to_u16_wrap() })
+    halfwords = Box.unbox(boxed_halfwords)
 
     boxed_choice : Box(Choice)
     boxed_choice = if seed == 0 {
@@ -21,5 +27,5 @@ main! = |seed| {
         Inc(value) => "Inc(${value.to_str()})"
     }
 
-    "${pair.x.to_str()},${pair.y.to_str()};${choice_str}"
+    "${pair.x.to_str()},${pair.y.to_str()};${halfwords.x.to_str()},${halfwords.y.to_str()};${choice_str}"
 }

--- a/test/wasm/issue_10836_boxed_low_alignment_static_lib_app.roc
+++ b/test/wasm/issue_10836_boxed_low_alignment_static_lib_app.roc
@@ -1,0 +1,25 @@
+app [main!] { pf: platform "./static-lib-platform/main.roc" }
+
+Pair : { x : U8, y : U8 }
+
+Choice : [Dec(U8), Inc(U8)]
+
+main! = |seed| {
+    boxed : Box(Pair)
+    boxed = Box.box({ x: 7, y: 9 + seed.to_u8_wrap() })
+    pair = Box.unbox(boxed)
+
+    boxed_choice : Box(Choice)
+    boxed_choice = if seed == 0 {
+        Box.box(Inc(42))
+    } else {
+        Box.box(Dec(seed.to_u8_wrap()))
+    }
+    choice = Box.unbox(boxed_choice)
+    choice_str = match choice {
+        Dec(value) => "Dec(${value.to_str()})"
+        Inc(value) => "Inc(${value.to_str()})"
+    }
+
+    "${pair.x.to_str()},${pair.y.to_str()};${choice_str}"
+}


### PR DESCRIPTION
The dev WASM backend treated every `i32` value four bytes or smaller as scalar bits, even when the committed WASM representation used that `i32` as a pointer to aggregate stack storage. This switches box and raw-pointer memory operations to the explicit composite-layout classification, preserving small boxed records and payload tag unions.

Fixes #10836.