### PR TITLE
Fix List.set mutation through call-built records

### DIFF
--- a/design.md
+++ b/design.md
@@ -9543,7 +9543,13 @@ ownership places. The place graph is solved to a fixpoint, so a nested read
 chain such as tag payload to struct field keeps the root aggregate's unit key.
 If the final read result binds owned, that read moves the unit only when the
 root unit is present and the ownership place has no later RC-bearing use on
-that path; otherwise it retains exactly as an ordinary read would. A pure
+that path; otherwise it retains exactly as an ordinary read would. This use
+query is definition-sensitive: a `set_local` that writes the root ends the
+current place definition after its value operand is read. Uses reached through
+the following jump belong to the newly written join value and cannot keep the
+previous definition alive. Conversely, reaching an implicit `loop_continue`
+without such a rebind keeps the current definition live into the next
+iteration. A pure
 same-value alias followed only by non-refcounted field reads is
 representation-only: an inline struct's scalar bytes remain available after
 its stored RC units move or are released, so such reads do not keep the

--- a/design.md
+++ b/design.md
@@ -9548,8 +9548,8 @@ query is definition-sensitive: a `set_local` that writes the root ends the
 current place definition after its value operand is read. Uses reached through
 the following jump belong to the newly written join value and cannot keep the
 previous definition alive. Conversely, reaching an implicit `loop_continue`
-without such a rebind keeps the current definition live into the next
-iteration. A pure
+or `loop_break` without such a rebind keeps the current definition live across
+the loop boundary. A pure
 same-value alias followed only by non-refcounted field reads is
 representation-only: an inline struct's scalar bytes remain available after
 its stored RC units move or are released, so such reads do not keep the

--- a/src/compile/mod.zig
+++ b/src/compile/mod.zig
@@ -141,6 +141,7 @@ test "compile tests" {
     std.testing.refAllDecls(@import("test/issue_10765_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10792_test.zig"));
     std.testing.refAllDecls(@import("test/issue_10831_test.zig"));
+    std.testing.refAllDecls(@import("test/issue_10848_test.zig"));
     std.testing.refAllDecls(@import("test/tce_capture_test.zig"));
     std.testing.refAllDecls(@import("test/list_map_target_independent_lir_test.zig"));
     std.testing.refAllDecls(@import("test/platform_box_update_lir_test.zig"));

--- a/src/compile/test/issue_10848_test.zig
+++ b/src/compile/test/issue_10848_test.zig
@@ -1,0 +1,177 @@
+//! Regression test for issue #10848.
+
+const std = @import("std");
+const collections = @import("collections");
+const layout = @import("layout");
+const lir = @import("lir");
+const harness = @import("lower_to_lir_harness.zig");
+
+const GuardedList = collections.GuardedList;
+
+const ReachTask = union(enum) {
+    proc: lir.LIR.LirProcSpecId,
+    stmt: lir.LIR.CFStmtId,
+};
+
+fn expectCallBuiltRecordListSetHasNoRetain(
+    store: *const lir.LirStore,
+    _: *const layout.Store,
+) harness.LowerToLirHarnessError!void {
+    const allocator = std.testing.allocator;
+    const seen_procs = try allocator.alloc(bool, store.procSpecCount());
+    defer allocator.free(seen_procs);
+    @memset(seen_procs, false);
+    const seen_stmts = try allocator.alloc(bool, store.cfStmtCount());
+    defer allocator.free(seen_stmts);
+    @memset(seen_stmts, false);
+    var stack = std.ArrayList(ReachTask).empty;
+    defer stack.deinit(allocator);
+    for (0..store.procSpecCount()) |proc_index| {
+        const proc_id: lir.LIR.LirProcSpecId = @enumFromInt(@as(u32, @intCast(proc_index)));
+        const name = store.procDebugName(proc_id) orelse continue;
+        if (std.mem.eql(u8, name, "main_for_host!")) {
+            try stack.append(allocator, .{ .proc = proc_id });
+        }
+    }
+
+    var saw_root = false;
+    var saw_list_set = false;
+    var retained_list_sets: usize = 0;
+    while (stack.pop()) |task| switch (task) {
+        .proc => |proc_id| {
+            const index = @intFromEnum(proc_id);
+            if (seen_procs[index]) continue;
+            seen_procs[index] = true;
+            saw_root = true;
+            if (store.getProcSpec(proc_id).body) |body| {
+                try stack.append(allocator, .{ .stmt = body });
+            }
+        },
+        .stmt => |stmt_id| {
+            const index = @intFromEnum(stmt_id);
+            if (seen_stmts[index]) continue;
+            seen_stmts[index] = true;
+            switch (store.getCFStmt(stmt_id)) {
+                .assign_low_level => |assign| {
+                    if (assign.op == .list_set) {
+                        saw_list_set = true;
+                    }
+                    try stack.append(allocator, .{ .stmt = assign.next });
+                },
+                .incref => |stmt| {
+                    const next = store.getCFStmt(stmt.next);
+                    if (next == .assign_low_level and next.assign_low_level.op == .list_set) {
+                        const args = store.getLocalSpan(next.assign_low_level.args);
+                        if (GuardedList.borrowLen(args) > 0 and
+                            GuardedList.at(args, 0) == stmt.value)
+                        {
+                            retained_list_sets += 1;
+                        }
+                    }
+                    try stack.append(allocator, .{ .stmt = stmt.next });
+                },
+                .assign_call => |assign| {
+                    try stack.append(allocator, .{ .proc = assign.proc });
+                    try stack.append(allocator, .{ .stmt = assign.next });
+                },
+                .switch_stmt => |switch_stmt| {
+                    const branches = store.getCFSwitchBranches(switch_stmt.branches);
+                    for (0..GuardedList.borrowLen(branches)) |branch_index| {
+                        try stack.append(allocator, .{ .stmt = GuardedList.at(branches, branch_index).body });
+                    }
+                    try stack.append(allocator, .{ .stmt = switch_stmt.default_branch });
+                    if (switch_stmt.continuation) |continuation| {
+                        try stack.append(allocator, .{ .stmt = continuation });
+                    }
+                },
+                .switch_initialized_payload => |switch_stmt| {
+                    try stack.append(allocator, .{ .stmt = switch_stmt.initialized_branch });
+                    try stack.append(allocator, .{ .stmt = switch_stmt.uninitialized_branch });
+                },
+                .str_match => |str_match| {
+                    try stack.append(allocator, .{ .stmt = str_match.on_match });
+                    try stack.append(allocator, .{ .stmt = str_match.on_miss });
+                },
+                .str_match_set => |str_match_set| {
+                    const arms = store.getStrMatchArms(str_match_set.arms);
+                    for (0..GuardedList.borrowLen(arms)) |arm_index| {
+                        try stack.append(allocator, .{ .stmt = GuardedList.at(arms, arm_index).on_match });
+                    }
+                    try stack.append(allocator, .{ .stmt = str_match_set.on_miss });
+                },
+                .boxy_tag_match => |tag_match| {
+                    try stack.append(allocator, .{ .stmt = tag_match.on_match });
+                    try stack.append(allocator, .{ .stmt = tag_match.on_miss });
+                },
+                .join => |join_stmt| {
+                    try stack.append(allocator, .{ .stmt = join_stmt.body });
+                    try stack.append(allocator, .{ .stmt = join_stmt.remainder });
+                },
+                inline .assign_ref,
+                .assign_literal,
+                .init_uninitialized,
+                .assign_call_erased,
+                .assign_packed_erased_fn,
+                .assign_boxy_desc_ref,
+                .assign_boxy_dict_ref,
+                .assign_boxy_box,
+                .assign_boxy_reuse_box,
+                .assign_boxy_unbox,
+                .assign_boxy_adapt,
+                .assign_boxy_inspect,
+                .assign_boxy_eq,
+                .assign_boxy_tag,
+                .assign_boxy_tag_payload,
+                .assign_call_dict,
+                .assign_list,
+                .assign_struct,
+                .assign_tag,
+                .store_struct,
+                .store_tag,
+                .set_local,
+                .debug,
+                .expect,
+                .comptime_branch_taken,
+                .decref,
+                .decref_if_initialized,
+                .free,
+                => |stmt| try stack.append(allocator, .{ .stmt = stmt.next }),
+                .ret,
+                .jump,
+                .crash,
+                .expect_err,
+                .runtime_error,
+                .comptime_exhaustiveness_failed,
+                .loop_continue,
+                .loop_break,
+                => {},
+            }
+        },
+    };
+
+    try std.testing.expect(saw_root);
+    try std.testing.expect(saw_list_set);
+    try std.testing.expectEqual(@as(usize, 0), retained_list_sets);
+}
+
+test "issue 10848: a helper-built record does not retain List.set's list" {
+    // Repro for https://github.com/roc-lang/roc/issues/10848.
+    try harness.expectLirInspectionWithOptions(
+        \\new = |n| { x: List.repeat(0.U64, n), y: 0 }
+        \\
+        \\read = |s| s.x.get(s.y) ?? 0
+        \\
+        \\main! = |args| {
+        \\    len = U64.from_str(args.get(0)?)?
+        \\    n = U64.from_str(args.get(1)?)?
+        \\    var $s = new(len)
+        \\    var $i = 0
+        \\    while $i < n {
+        \\        $s = { ..$s, x: $s.x.set(0, $i) ?? $s.x }
+        \\        $i = $i + 1
+        \\    }
+        \\    echo!(read($s).to_str())
+        \\    Ok({})
+        \\}
+    , .{ .inline_mode = .wrappers, .proc_debug_names = true }, expectCallBuiltRecordListSetHasNoRetain);
+}

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -2216,7 +2216,6 @@ const Inserter = struct {
                             assign.target,
                             root,
                             assign.next,
-                            segment.ctx.loop_keep,
                         );
                         complete_moved_root = !transfer.retain_target;
                     } else {
@@ -3966,12 +3965,14 @@ const Inserter = struct {
         target: LIR.LocalId,
         root: LIR.LocalId,
         next: LIR.CFStmtId,
-        loop_keep: ?LoopKeep,
     ) ResourceError!AliasBindTransfer {
         const release_old_target = self.takeRebindTarget(owned, target);
         const unit = self.unitOf(root);
-        const root_used = (loop_keep != null and loop_keep.?.set.contains(unit)) or
-            try self.ownershipPlaceUsedInPath(next, unit);
+        // The path query follows loop edges itself and stops at a rebind of
+        // this exact place definition. A loop keep-set cannot make that
+        // distinction: it intentionally merges the old and next-iteration
+        // bindings under the same LocalId.
+        const root_used = try self.ownershipPlaceUsedInPath(next, unit);
         const has_unit = owned.contains(unit);
         const restitution = if (root_used)
             try self.completeProjectionRestitution(target, unit, next)
@@ -5040,6 +5041,11 @@ const Inserter = struct {
                 },
                 .set_local => |assign| {
                     if (self.isAliasOfOwnershipPlace(assign.value, root)) return true;
+                    // Rebinding the place ends this definition. Uses reached
+                    // through the following jump belong to the newly written
+                    // join value, not to the value whose projection is being
+                    // considered here.
+                    if (assign.target == root) continue;
                     try stack.append(self.emission_allocator, assign.next);
                 },
                 .debug => |stmt| {
@@ -5078,7 +5084,11 @@ const Inserter = struct {
                 },
                 .ret => |stmt| if (self.isAliasOfOwnershipPlace(stmt.value, root)) return true,
                 .crash, .expect_err => return true,
-                .runtime_error, .comptime_exhaustiveness_failed, .loop_continue, .loop_break => {},
+                // An implicit continue edge reaches the next iteration with
+                // this definition still live. A root rebind encountered
+                // earlier stopped this path before it could get here.
+                .loop_continue => return true,
+                .runtime_error, .comptime_exhaustiveness_failed, .loop_break => {},
             }
         }
         return false;
@@ -9771,6 +9781,52 @@ test "RC complete field projection preserves a loop-kept root" {
     // complete field read therefore retains its target instead of moving
     // that loop-kept unit away.
     try f.expectRc(extracted, 1, 0, 0);
+}
+
+test "RC complete field projection moves a join binding replaced before the back edge" {
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+    const record_layout = try f.layouts.putStructFields(&[_]layout_mod.StructField{
+        .{ .index = 0, .layout = f.list_i64 },
+    });
+    const initial_list = try f.local(f.list_i64);
+    const initial_record = try f.local(record_layout);
+    const state = try f.local(record_layout);
+    const extracted = try f.local(f.list_i64);
+    const updated = try f.local(f.list_i64);
+    const next_record = try f.local(record_layout);
+    const elem = try f.local(.i64);
+
+    const join_id = f.freshJoinPointId();
+    const jump = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const set_next = try f.setLocal(state, next_record, .initialize_join_param, jump);
+    const build_next = try f.assignStruct(next_record, &.{updated}, set_next);
+    const consume = try f.assignLowLevel(
+        updated,
+        &.{ extracted, elem },
+        LIR.LowLevel.RcEffect.consumesArgsReturningConsumedArgsRetainingArgs(1, 0),
+        build_next,
+    );
+    const take = try f.assignRefField(extracted, state, 0, consume);
+    const enter = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const initialize_state = try f.setLocal(state, initial_record, .initialize_join_param, enter);
+    const assign_elem = try f.assignI64(elem, 1, initialize_state);
+    const assign_record = try f.assignStruct(initial_record, &.{initial_list}, assign_elem);
+    const remainder = try f.assignList(initial_list, &.{}, assign_record);
+    const body = try f.store.addCFStmt(.{ .join = .{
+        .id = join_id,
+        .params = try f.span(&.{state}),
+        .body = take,
+        .remainder = remainder,
+    } });
+
+    _ = try f.addProc(&.{}, body, .i64);
+    try f.run();
+
+    // The state cell is explicitly rebound before the back edge. The next
+    // iteration's state is a new definition, so the current record's sole RC
+    // field moves into `extracted` without an incref.
+    try f.expectRc(extracted, 0, 0, 0);
 }
 
 test "RC divergent field takes normalize exact residual places on each switch edge" {

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -5084,11 +5084,12 @@ const Inserter = struct {
                 },
                 .ret => |stmt| if (self.isAliasOfOwnershipPlace(stmt.value, root)) return true,
                 .crash, .expect_err => return true,
-                // An implicit continue edge reaches the next iteration with
-                // this definition still live. A root rebind encountered
-                // earlier stopped this path before it could get here.
-                .loop_continue => return true,
-                .runtime_error, .comptime_exhaustiveness_failed, .loop_break => {},
+                // An implicit loop boundary hands the kept value to either
+                // the next iteration or the code after the loop. A root
+                // rebind encountered earlier stopped this path before it
+                // could get here.
+                .loop_continue, .loop_break => return true,
+                .runtime_error, .comptime_exhaustiveness_failed => {},
             }
         }
         return false;
@@ -9740,47 +9741,49 @@ test "RC switch continuation merge releases branch-divergent owner at the bounda
     try f.expectRc(diverged, 0, 1, 0);
 }
 
-test "RC complete field projection preserves a loop-kept root" {
-    var f = try ArcTest.init(testing.allocator);
-    defer f.deinit();
-    const record_layout = try f.layouts.putStructFields(&[_]layout_mod.StructField{
-        .{ .index = 0, .layout = f.list_i64 },
-    });
-    const field = try f.local(f.list_i64);
-    const record = try f.local(record_layout);
-    const state = try f.local(record_layout);
-    const extracted = try f.local(f.list_i64);
-    const appended = try f.local(f.list_i64);
-    const elem = try f.local(.i64);
+test "RC complete field projection preserves a root at implicit loop boundaries" {
+    for ([_]LIR.CFStmt{ .loop_continue, .loop_break }) |terminal| {
+        var f = try ArcTest.init(testing.allocator);
+        defer f.deinit();
+        const record_layout = try f.layouts.putStructFields(&[_]layout_mod.StructField{
+            .{ .index = 0, .layout = f.list_i64 },
+        });
+        const field = try f.local(f.list_i64);
+        const record = try f.local(record_layout);
+        const state = try f.local(record_layout);
+        const extracted = try f.local(f.list_i64);
+        const appended = try f.local(f.list_i64);
+        const elem = try f.local(.i64);
 
-    const join_id = f.freshJoinPointId();
-    const continue_loop = try f.store.addCFStmt(.loop_continue);
-    const consume = try f.assignLowLevel(
-        appended,
-        &.{ extracted, elem },
-        LIR.LowLevel.RcEffect.consumesArgsReturningConsumedArgsRetainingArgs(1, 0),
-        continue_loop,
-    );
-    const take = try f.assignRefField(extracted, state, 0, consume);
-    const entry = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
-    const initialize_state = try f.setLocal(state, record, .initialize_join_param, entry);
-    const assign_elem = try f.assignI64(elem, 1, initialize_state);
-    const assign_record = try f.assignStruct(record, &.{field}, assign_elem);
-    const remainder = try f.assignList(field, &.{}, assign_record);
-    const body = try f.store.addCFStmt(.{ .join = .{
-        .id = join_id,
-        .params = try f.span(&.{state}),
-        .body = take,
-        .remainder = remainder,
-    } });
+        const join_id = f.freshJoinPointId();
+        const boundary = try f.store.addCFStmt(terminal);
+        const consume = try f.assignLowLevel(
+            appended,
+            &.{ extracted, elem },
+            LIR.LowLevel.RcEffect.consumesArgsReturningConsumedArgsRetainingArgs(1, 0),
+            boundary,
+        );
+        const take = try f.assignRefField(extracted, state, 0, consume);
+        const entry = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+        const initialize_state = try f.setLocal(state, record, .initialize_join_param, entry);
+        const assign_elem = try f.assignI64(elem, 1, initialize_state);
+        const assign_record = try f.assignStruct(record, &.{field}, assign_elem);
+        const remainder = try f.assignList(field, &.{}, assign_record);
+        const body = try f.store.addCFStmt(.{ .join = .{
+            .id = join_id,
+            .params = try f.span(&.{state}),
+            .body = take,
+            .remainder = remainder,
+        } });
 
-    _ = try f.addProc(&.{}, body, .i64);
-    try f.run();
+        _ = try f.addProc(&.{}, body, .i64);
+        try f.run();
 
-    // The back edge requires the root's unit on the next iteration. The
-    // complete field read therefore retains its target instead of moving
-    // that loop-kept unit away.
-    try f.expectRc(extracted, 1, 0, 0);
+        // Both loop terminals hand the kept root to an enclosing iteration
+        // engine. The complete field read must retain its target instead of
+        // moving that unit away.
+        try f.expectRc(extracted, 1, 0, 0);
+    }
 }
 
 test "RC complete field projection moves a join binding replaced before the back edge" {


### PR DESCRIPTION
ARC treated a loop join's keep-set as proof that the current record binding survived into the next iteration, even when `set_local` replaced it before the back edge. That forced a retain of the record's sole list field before `List.set`, keeping the count above one and copying the list on every write. This makes ownership-place liveness definition-sensitive at rebinds while preserving implicit loop boundaries, and adds regression coverage for #10848.

Closes #10848.
