### PR TITLE
Post-check duplication audit, and one definition per primitive mapping

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -170,8 +170,18 @@ already diverged in behavior, not just in text.
   two cloners over Monotype Lifted covering 29 and 44 expression
   variants; the narrower one declines the difference silently.
 
-Within this batch, the two `big` projects compose in either order.
-`boxy-rep-queries-on-the-plan` should land before or with
+Single-source primitive tables have landed (the batch's first
+project): `CheckedPrimitive`'s four post-check mappings—storage layout,
+inspect low-level op, hasher write op, and builtin owner—each have one
+definition. The first three live in `src/postcheck/common.zig`; the
+owner table lives beside `CheckedPrimitive` itself in
+`src/check/checked_artifact.zig`. A `structural_test.zig` lint fails the
+build if a second definition of any of them appears. None of the copies
+had been forced by a type barrier: `MonoType.Primitive` is a plain alias
+of `checked.CheckedPrimitive`.
+
+Within the rest of this batch, the two `big` projects compose in either
+order. `boxy-rep-queries-on-the-plan` should land before or with
 `one-value-semantics-layer`. The rest are independent.
 
 ## Recommended order

--- a/projects/README.md
+++ b/projects/README.md
@@ -124,6 +124,56 @@ independent of the earlier batches and of each other:
   module, def) plus a repro command before the stack trace, built from
   thread-local context frames pushed at existing phase boundaries.
 
+A fifth batch (2026-08-24) came out of a duplication audit of the
+stages between type checking and code generation—Monotype, Monotype
+Lifted, SpecConstr, Lambda Solved, the two LIR lowerers, the LIR
+passes, and ARC. It looked specifically for *multiple implementations
+of one semantic rule* rather than for repeated text. The recurring
+shape: `.lss` and `.boxy` were scoped by the phases they skip, but
+value semantics (equality, hashing, `Inspect`, `match` compilation)
+are not phase artifacts and got duplicated along with the phases; and
+inside each strategy, producer/consumer boundaries that design.md
+states as "record the decision, consume it later" are implemented as
+"re-derive it from the emitted shape". Several of these pairs have
+already diverged in behavior, not just in text.
+
+- [big/one-value-semantics-layer.md](big/one-value-semantics-layer.md)—
+  `Inspect` (four implementations, four copies of the format
+  strings), structural equality and hashing (two), and `match`
+  compilation (`.boxy` never adopted the shared decision-tree
+  compiler, contrary to this README and `postcheck/mod.zig`) collapse
+  onto one shape-parameterized layer, plus a standing `.lss`/`.boxy`
+  differential harness.
+- [big/postcheck-lowerer-decomposition.md](big/postcheck-lowerer-decomposition.md)—
+  the god-structs (`BodyContext` at 36.6k lines, `ProcBodyBuilder` at
+  25.1k) that force helpers to be copied rather than shared; 53 and 17
+  duplicated method names respectively, with divergence already
+  present in both.
+- [small/arc-shared-predicates.md](small/arc-shared-predicates.md)—
+  four ARC predicates defined twice, including the refcounted-local
+  predicate where the RC inserter and its own certifier already use
+  different code.
+- [small/erased-ownership-as-lir-data.md](small/erased-ownership-as-lir-data.md)—
+  the lowerer records erased ownership and the certifier re-derives it
+  with a copy of the rule; `.boxy` has no producer at all.
+- [small/boxy-rep-queries-on-the-plan.md](small/boxy-rep-queries-on-the-plan.md)—
+  ~45 representation queries duplicated between boxy planning and boxy
+  lowering; `childRolesMatch` exists three times with two different
+  exhaustiveness postures.
+- [small/lir-call-result-fusion-framework.md](small/lir-call-result-fusion-framework.md)—
+  `return_slot` and `str_append` are the same pass twice, sharing a
+  byte-identical liveness guard that nothing keeps in sync.
+- [small/postcheck-ir-store-boilerplate.md](small/postcheck-ir-store-boilerplate.md)—
+  the four post-check IR stores share 57 and 44 byte-identical
+  function bodies of flat-store mechanics.
+- [small/spec-constr-single-cloner.md](small/spec-constr-single-cloner.md)—
+  two cloners over Monotype Lifted covering 29 and 44 expression
+  variants; the narrower one declines the difference silently.
+
+Within this batch, the two `big` projects compose in either order.
+`boxy-rep-queries-on-the-plan` should land before or with
+`one-value-semantics-layer`. The rest are independent.
+
 ## Recommended order
 
 ### Start here—enforcement layers, cheap and load-bearing
@@ -184,12 +234,17 @@ Small:
   static-data and builtin-call materialization for constant/repeated
   lists, ending the one-local-per-element explosion behind issue 9898.
 
-The decision-tree match compiler has landed: both LIR pipelines lower
-`match` through one shared Maranget-style module
-(src/postcheck/match_tree.zig)—one multiway switch per tested position,
-one discriminant read, strings and list-length buckets as ordinary arms—
-with the sharing invariant documented in design.md and enforced by a debug
-statement-count lint.
+The decision-tree match compiler has landed for `.lss`: the direct
+solved-to-LIR lowering compiles `match` through one shared Maranget-style
+module (src/postcheck/match_tree.zig)—one multiway switch per tested
+position, one discriminant read, strings and list-length buckets as
+ordinary arms—with the sharing invariant documented in design.md and
+enforced by a debug statement-count lint. The 2026-08-24 audit found
+`.boxy` never adopted it (`grep -rn match_tree src/postcheck/boxy/` is
+empty; `boxy/lower.zig` folds branches into a sequential chain), so the
+"shared by both LIR lowerers" claim in `src/postcheck/mod.zig` is not yet
+true. Closing that is step 6 of
+[big/one-value-semantics-layer.md](big/one-value-semantics-layer.md).
 
 Single-source builtin registration has landed: the seven hand-typed
 `roc_builtins_*` symbol/ABI tables now derive from one comptime registry

--- a/projects/big/one-value-semantics-layer.md
+++ b/projects/big/one-value-semantics-layer.md
@@ -1,0 +1,295 @@
+# One Value-Semantics Layer for Both Lowering Strategies
+
+## Problem
+
+`Inspect` rendering, structural equality, structural hashing, and
+`match` compilation are *value semantics*: they depend on a type's
+shape, not on which post-check phase list produced it. Today each is
+implemented independently once per lowering strategy—and `Inspect` is
+implemented four times.
+
+**Inspect—four implementations, four copies of the format strings.**
+
+- `src/postcheck/monotype/lower.zig:8769-9117` (`Builder.inspectBody`,
+  `toInspectCall`, `inspectTuple`, `inspectRecord`,
+  `inspectFieldSlot`, `inspectTagUnion`, `inspectList`).
+- `src/postcheck/monotype/lower.zig:14738-15060`
+  (`BodyContext.inspectBody` and the same seven siblings).
+- `src/postcheck/boxy/lower.zig:27699-28270`
+  (`lowerInspectExprInto`, `lowerToInspectMethodInto`,
+  `lowerRecordInspectLocalsInto`, `lowerTupleInspectLocalsInto`,
+  `lowerTagUnionInspectLocalsInto`,
+  `lowerPresenceSlotInspectLocalsInto`, `lowerBoxInspectLocalsInto`,
+  `lowerListInspectLocalsInto`).
+- `src/eval/boxy_runtime.zig:5371-5800` (`appendBoxyInspect`,
+  `appendLayoutInspect`, `appendPresenceSlotInspect`,
+  `appendScalarInspect`, `appendListInspect`, `appendStructInspect`,
+  `appendTagUnionInspect`).
+
+The literals `"{ "`, `" }"`, `"{}"`, `", "`, `": "`, `"("`, `")"`,
+`"()"`, `"<missing>"`, `"<function>"`, `"Box("` are written out
+independently in each. A change to how Roc renders a record, a tuple,
+an optional field, or a boxed value must be made in four places, with
+nothing that fails if it is made in three.
+
+The two `monotype/lower.zig` copies **have already diverged on
+behavior**, not just on plumbing. `Builder.toInspectCall`
+(`:8808`) returns `null`—falling back to structural rendering—for
+`.structural` and `.local_proc` method targets, and has no
+error-payload and no capture handling. `BodyContext.toInspectCall`
+(`:14777`) routes an `err` callable payload to `runtimeCrashExpr`,
+consults `frozen_inspect_method_calls`, and passes a capture span.
+Whether a user's `to_inspect` method is honored therefore depends on
+which context derived the inspect, which is not a distinction the
+language exposes.
+
+**Structural equality and hashing—two implementations.**
+`solved_lir_lower.zig:4882` (`lowerStructuralEqInto`), `:4891`
+(`lowerStructuralHashInto`), `:4903` (`lowerHashLocalsInto`), `:4925`
+(`lowerPrimitiveHashLocalsInto`), `:6986` (`lowerEqLocalsInto`),
+`:7002` / `:7074` / `:7090` / `:7130` / `:7149` / `:7182` / `:7239`
+(the primitive/bool/record/tuple/field/tag-union/tag-payload arms)
+are each mirrored in `boxy/lower.zig` at `:28406`, `:28957`,
+`:29032`, `:28614`, `:28713`, `:28736`, `:28765`, `:28794`, `:28832`,
+`:28892`. Normalized-body similarity across those pairs ranges from
+0.96 (`lowerBoolEqLocalsInto`, still in sync) down to 0.18
+(`lowerTagPayloadEqVariant`, already diverged). These define what `==`
+and `hash` *mean* for aggregates.
+
+**`match`—the shared decision-tree compiler has one user, not two.**
+`src/postcheck/mod.zig:37` documents `match_tree.zig` as the
+"decision-tree match compiler shared by both LIR lowerers", and
+`projects/README.md` records the project as landed. Only
+`solved_lir_lower.zig:5598` uses `match_tree.Compiler`;
+`grep -rn match_tree src/postcheck/boxy/` is empty.
+`boxy/lower.zig:19865` (`lowerMatchInto`) instead folds branches into
+a reverse-order sequential chain via `lowerMatchBranchInto`, with its
+own pattern-test lowering (`lowerListPatternThen`,
+`lowerRecordPatternThen`, `lowerStrPatternArm`, `bindRecordPattern`,
+`bindTuplePattern`—all also present in `solved_lir_lower.zig`, with
+similarity as low as 0.14). Boxy gets neither the one-test-per-tested-
+position property nor the statement-count lint at
+`match_tree.zig:1097`.
+
+**Some of the duplication has no barrier at all.**
+`Common.hasherWriteOp` (`src/postcheck/common.zig:104`) is declared
+over `MonoType.Primitive`, and `boxy/lower.zig:36368` copies it over
+`checked.CheckedPrimitive`—but `monotype/type.zig:45` reads
+`pub const Primitive = checked.CheckedPrimitive`. The two signatures
+name the same type. The copy was never forced by anything.
+
+## Background
+
+design.md defines `.boxy` by the phases it skips: "It skips Monotype,
+Monotype Lifted, Lambda Solved, and Lambda Mono." That scoping is
+correct for *specialization*—boxy's whole point is reaching LIR
+without whole-program lambda-set solving. It says nothing about
+equality, hashing, inspection, or pattern-match compilation, none of
+which depend on how a type arrived. Those got duplicated along with
+the phases anyway, because both strategies emit LIR directly and each
+grew its own emit-side helpers.
+
+The repo already contains three working instances of the sharing
+pattern this project generalizes:
+
+- `match_tree.Compiler(Ctx)`—one algorithm, comptime-parameterized
+  over how the caller reads patterns and emits tests. It is the
+  template; it just has one instantiation.
+- `EqDeriver` (`monotype/lower.zig:49742`) and `HashDeriver`
+  (`:49965`)—policy structs (`leaf`, `combine`, `componentForField`,
+  `componentForTuple`, `named`, `tagUnion`, `tagBranch`) plugged into
+  one generic derivation walker. Exactly the right shape, currently
+  reachable only from `BodyContext`.
+- `layout/graph.zig` + `layout/store.zig`—four independent producers
+  (`monotype/lower.zig`, `solved_lir_lower.zig`, `boxy/layouts.zig`,
+  `glue/checked_artifact_layout_resolver.zig`) build a
+  `GraphInput`/`GraphNode` description and commit through one store.
+  This seam holds and should be the model for shape description.
+
+`src/postcheck/lambda_mono/` (6,294 lines, reachable only from
+`src/eval/test/lambda_mono_differential_runner.zig`) is the model for
+duplication that is *kept on purpose*: its header states it is "a
+derivation that shares no lowering code with the direct path", and a
+differential harness asserts the two agree on inspect string, abort
+kind and message, `dbg` transcript, and expect-failure transcript.
+That is what makes its duplication safe. Nothing equivalent exists
+between `.lss` and `.boxy`.
+
+## Evidence
+
+- `grep -rn 'match_tree' src/postcheck/boxy/`—empty, against
+  `src/postcheck/mod.zig:37`'s claim and the README's "has landed"
+  note.
+- `grep -rn '"<missing>"' src/`—`boxy/lower.zig:28047`,
+  `boxy_runtime.zig:5527`, and `Builder.optional_field_missing_render`
+  consumed at `monotype/lower.zig:8926` and `:14931`.
+- `monotype/lower.zig:8808` vs `:14777`—diff the two
+  `toInspectCall` bodies; the capability sets differ.
+- `monotype/lower.zig:8876` vs `boxy/lower.zig:27896`—`"{ "`,
+  `", "`, `": "`, `" }"` emitted by two unrelated code paths.
+- `common.zig:104` vs `boxy/lower.zig:36368` against
+  `monotype/type.zig:45`—identical parameter type, copied body.
+- Normalized-body similarity for the 70 function names shared between
+  `solved_lir_lower.zig` and `boxy/lower.zig` spans 0.05–1.00; the
+  spread is the drift already in flight.
+- The tax being paid live: PR #10834 (in review as this was written)
+  adds unset optional fields, and its lowering commit states the work
+  was done in "both lowering pipelines (monotype and boxy)"—one
+  language change, two independent lowerings, each separately
+  eval-tested across interpreter/dev/wasm. Its hunks in
+  `monotype/lower.zig` and `boxy/lower.zig` do not touch the inspect,
+  equality, hashing, or match families, so this project and that PR do
+  not collide; the point is that the next such change will pay the
+  same double cost.
+
+## Solution design
+
+1. **The unforced copies are already gone.** `hasherWriteOp`,
+   `primitiveLayout`, and `primitiveInspectLowLevelOp` have one
+   definition each in `src/postcheck/common.zig`, and the primitive-to-
+   owner table lives beside `CheckedPrimitive` in
+   `src/check/checked_artifact.zig`, with a `structural_test.zig` lint
+   holding them there. The shared walkers below consume those tables;
+   this step is a prerequisite, not part of this project's design work.
+
+2. **Define one shape-reading context.** A comptime interface in a new
+   `src/postcheck/semantics/` module, in the spirit of
+   `match_tree.Compiler(Ctx)` and `layout.GraphInput`:
+   `primitiveOf(ty)`, `recordFields(ty)`, `tupleElems(ty)`,
+   `tagVariants(ty)`, `listElem(ty)`, `boxPayload(ty)`,
+   `nominalBacking(ty)`, `optionalFieldSlot(ty)`, plus the emit hooks
+   each consumer already has (`fieldAccess`, `tagPayload`,
+   `discriminant`, `stringLiteral`, `concat`, `switch`). Three
+   instances: Monotype/Lifted types, `Plan.TypeRepresentation`, and
+   the interpreter's `BoxyTypeDesc`. The interpreter instance emits
+   bytes rather than LIR, so its hooks differ—see step 4 for the split
+   that keeps it in the shared layer anyway.
+
+3. **`InspectSpec(Ctx)`.** One walker produces an ordered part list
+   (literal | child reference | method call) from a shape. Boxy
+   already has exactly this data type—`InspectPart` and
+   `lowerInspectPartsInto` (`boxy/lower.zig:28232`)—so the part list
+   is the right currency; promote it out of boxy and make it the
+   shared output. Every format string then exists once. The
+   `to_inspect` method-target rule is decided once, at the union of
+   the two current `toInspectCall` capability sets: honor
+   `.structural` and `.local_proc` targets, handle `err` payloads,
+   carry captures.
+
+4. **The interpreter consumes the same spec.**
+   `eval/boxy_runtime.zig`'s `append*Inspect` family cannot share the
+   LIR emitters, but it can and must share the part list: given a
+   shape it renders the same ordered parts to bytes. That removes the
+   fourth copy of the format strings without pretending the runtime is
+   a lowerer.
+
+5. **`EqLower(Ctx)` / `HashLower(Ctx)`.** Hoist `EqDeriver` and
+   `HashDeriver` out of `BodyContext` into the semantics module and
+   give them a third and fourth instantiation: the direct
+   `structural_eq`/`structural_hash` lowering in
+   `solved_lir_lower.zig` and in `boxy/lower.zig`. The per-primitive
+   op choice comes from the single tables of step 1.
+
+6. **Boxy adopts `match_tree`.** Implement `MatchTreeCtx` over boxy's
+   checked patterns and representation plan, replace
+   `boxy/lower.zig:19865`'s sequential chain, and delete boxy's
+   parallel `lower*PatternThen` / `bind*Pattern` family. Then the
+   `mod.zig:37` doc comment and the README's "has landed" note become
+   true, and the statement-count lint at `match_tree.zig:1097` covers
+   both strategies.
+
+7. **The standing agreement harness.** Some duplication survives by
+   design—two strategies, two emit paths. Make the survivors safe the
+   way `lambda_mono` is: run one shared corpus under `--opt=dev` (LSS)
+   and under `.boxy`, and require identical inspect strings, `dbg`
+   transcripts, abort kinds and messages, and expect-failure
+   transcripts. `src/eval/test/parallel_cli_runner.zig:867` is a
+   single hand-written instance of this today; it becomes the general
+   harness, modeled on
+   `src/eval/test/lambda_mono_differential_runner.zig`.
+
+Order matters: steps 1 and 2 unblock everything; 3+4 and 5 are
+independent of each other; 6 is independent of 3–5; 7 should land
+early enough to protect 3–6 rather than after them.
+
+## What success looks like
+
+Every criterion below must hold; the project is not done until all do:
+
+- Every `Inspect` format literal appears exactly once under `src/`.
+  `grep -rn '"<missing>"\|"<function>"\|"Box("' src/` shows one
+  definition site each, in `src/postcheck/semantics/`.
+- `grep -rn 'fn toInspectCall' src/` shows one definition, whose
+  behavior is the union of the two current ones (structural and
+  local-proc targets honored, `err` payload handled, captures
+  carried), with a test pinning each of those three cases.
+- `grep -rn 'fn lower.*EqLocalsInto\|fn lower.*HashLocalsInto' src/`
+  shows one family, not two.
+- `grep -rn 'match_tree' src/postcheck/boxy/` is non-empty and
+  `boxy/lower.zig` has no sequential branch-chain match lowering;
+  boxy's `lower*PatternThen` / `bind*Pattern` duplicates are deleted.
+- The `mod.zig:37` doc comment and the README's decision-tree note are
+  factually true.
+- The cross-strategy differential harness is in-tree, runs the shared
+  corpus under both strategies, and is green. Constructs a strategy
+  does not support are counted and reported per reason—never silently
+  skipped (the `lambda_mono` runner's rule).
+- Snapshot output is unchanged (`git diff test/snapshots` empty) and
+  `roc check` / `roc run` output on a fixture set is byte-identical
+  before and after, under both strategies.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+A change to what `==`, `hash`, `Inspect`, or `match` *mean* is a
+change to one function, and the type system forces every consumer to
+be updated. The class of bug where two strategies render, compare, or
+match the same value differently becomes unreachable for shared
+concerns and test-detectable for the per-strategy emit hooks. Boxy
+inherits `match_tree`'s one-test-per-position property and its
+size lint instead of relying on a hand-written chain.
+
+### Performance ideal
+
+Neutral to positive, and it must be measured rather than assumed.
+Comptime-parameterized contexts monomorphize, so no dynamic dispatch
+is introduced; the shared walkers must not allocate where the current
+inline code does not. Boxy adopting `match_tree` should *reduce*
+emitted statement count on multi-arm matches (that is what the
+`match_tree.zig:1097` lint measures)—record before/after statement
+counts on a match-heavy corpus. Compile-time: track post-check phase
+timing through `checked_pipeline.zig`'s `Timing` counters over a
+fixed corpus; regressions beyond noise are a defect, not a cost of
+sharing.
+
+## Tests to add
+
+- Cross-strategy differential harness (step 7), corpus-driven, with
+  per-reason unsupported-construct counts.
+- Comptime-enumerated coverage: every shape variant the `Ctx`
+  interface exposes has at least one inspect case, one equality case,
+  and one hash case; a new variant fails the suite until covered.
+- `to_inspect` capability pins: a nominal with a structural
+  `to_inspect`, one with a local-proc `to_inspect`, one whose
+  callable payload is `err`, and one with captures—each asserted
+  under both strategies.
+- Boxy match-tree statement-count lint (the existing
+  `match_tree.zig:1097` assertion, now reached from boxy).
+- A source-text test in `src/postcheck/structural_test.zig` asserting
+  a single definition site for each consolidated predicate, so the
+  copies cannot come back.
+
+## Related projects
+
+- [postcheck-lowerer-decomposition.md](postcheck-lowerer-decomposition.md)—
+  the god-structs that make helpers uncopyable-without-copying; the
+  `Builder`/`BodyContext` inspect double is removed there or here,
+  whichever lands first.
+- [../small/boxy-rep-queries-on-the-plan.md](../small/boxy-rep-queries-on-the-plan.md)—
+  the `Ctx` instance for `Plan.TypeRepresentation` wants the plan's
+  queries to already be plan methods.
+- [../small/lambda-mono-oracle-fidelity.md](../small/lambda-mono-oracle-fidelity.md)—
+  the differential-oracle pattern step 7 generalizes.
+- [../small/cross-phase-coverage-parity-tests.md](../small/cross-phase-coverage-parity-tests.md)—
+  the parity-suite discipline this project applies across strategies.

--- a/projects/big/postcheck-lowerer-decomposition.md
+++ b/projects/big/postcheck-lowerer-decomposition.md
@@ -1,0 +1,245 @@
+# Decompose the Post-Check Lowerer God-Structs
+
+## Problem
+
+Two files in the post-check pipeline are dominated by single enormous
+structs, and each of those files contains a *second* struct that
+duplicates a large slice of the first because there is no free-function
+layer for a helper to live in.
+
+`src/postcheck/monotype/lower.zig` is 52,019 lines. Two of its
+top-level declarations account for 44,174 of them:
+
+- `const Builder`: L2124–9652 (7,528 lines, 238 methods)
+- `const BodyContext`: L13096–49742 (**36,646 lines**, 1,154 methods)
+
+They share 53 method names. Thirty-six of those pairs have ≥0.70
+normalized-body similarity, ~470 lines, in two coherent families:
+
+- **Inspect derivation**: `inspectBody` (`:8769` / `:14738`),
+  `toInspectCall` (`:8808` / `:14777`), `inspectTuple`
+  (`:8859` / `:14869`), `inspectRecord` (`:8876` / `:14886`),
+  `inspectFieldSlot` (`:8903` / `:14908`), `inspectTagUnion`
+  (`:8998` / `:14940`), `inspectList` (`:9070` / `:15012`),
+  `inspectListStep`, `inspectCall`, `inspectDefForType`,
+  `inspectTagBody`, `uninhabitedInspect`.
+- **Const restoration**: `restoreConstData` (`:8547` / `:29646`,
+  0.99 similar), `restoreConstRecord` (0.98), `restoreConstList`
+  (0.98), `restoreConstListData` (0.99), `restoreConstTuple` (0.97),
+  `restoreConstTagPayloads` (0.97).
+
+Plus scattered singles: `bindPatLocals` (`:7994` / `:15974`, 0.96),
+`stmtDependsOnFreeLocal`, `lowerCallableEvalBindingValue`,
+`recordFieldByTextOptional`, `ifExpr`, `lowLevelExpr`, `stringExpr`,
+`intLiteralExpr`, `constBoxPayloadType`, `constListElemType`,
+`typeHasBuiltinOwner`, `bindTypedLocalLocals`, `removeBoundLocals`.
+
+Most of these pairs differ only in receiver plumbing—`self.program.addExpr`
+versus `self.addExpr`, `self.symbols` versus `self.builder.symbols`. That
+is precisely the shape that stays byte-identical until one day it
+doesn't: `toInspectCall` has already diverged in capability (see
+[one-value-semantics-layer.md](one-value-semantics-layer.md)).
+
+The same structure repeats in `src/postcheck/boxy/lower.zig`
+(47,107 lines):
+
+- `const ProcedureBuilder`: L994–11713 (10,718 lines, 245 methods)
+- `const ProcBodyBuilder`: L11714–36863 (25,148 lines, 747 methods)
+
+with 17 shared method names, and again the same pattern of one copy
+being modernized while the other is not: `childRolesMatch` is a
+`std.meta.eql`-fallback `if`-chain in `ProcedureBuilder` (`:4084`)
+and an exhaustive switch in `ProcBodyBuilder` (`:36158`).
+`findMatchingTagPayloadInRep` (`:4064` / `:36138`),
+`repSubtreeHasDescriptorInner` (`:3999` / `:36031`),
+`descriptorArgumentIdentityRep` (`:4159` / `:36218`),
+`findMatchingChildBySourceType` (`:4025` / `:36078`),
+`structuralWrapperBackingRep` (`:4144` / `:35467` neighborhood),
+`recordFieldNameMatches`, `tagLabelNameMatches` complete the set.
+
+Beyond the cross-struct doubles, `monotype/lower.zig` carries 109
+function names defined more than once in the file, and ~800 lines of
+pairwise-cloned codec paths:
+`restoreConstParserRuntimeFnAtNode` (`:30653`, 176 lines) against
+`restoreConstEncoderForRuntimeFnAtNode` (`:30987`, 203 lines) at 0.88;
+`restoreConstParserRuntimeFn` (`:30521`) against
+`restoreConstEncoderForRuntimeFn` (`:30838`) at 0.84;
+`restoreConstParserRuntimeFnExpr` (`:8213`) against
+`restoreConstEncoderForRuntimeFnExpr` (`:8339`) at 0.83; and
+`lowerParseListFromState` (`:24394`) against `lowerParseDictFromState`
+(`:24556`) at 0.86.
+
+## Background
+
+The structs are large for a defensible reason: Monotype lowering
+carries a lot of scoped state (the active graph, the body draft store,
+binder maps, evidence chains, guard frames, deferred const uses), and
+methods are how that state gets threaded. `BodyContext` and `Builder`
+are two *scopes* of that state—`BodyContext` holds a
+`builder: *Builder` back-pointer—not two implementations of one thing.
+Same for `ProcBodyBuilder`, which holds `parent: *ProcedureBuilder`.
+
+That is exactly why the duplication happened: a helper written against
+`Builder`'s field set cannot be called from `BodyContext` without
+either threading the back-pointer or copying. Copying was the cheaper
+edit each time, 53 times.
+
+The fix is not to merge the structs—the scope split is real. It is to
+introduce the missing layer: helpers that take what they need as
+parameters (or via a small comptime-duck-typed emitter) instead of
+reaching into a specific receiver's fields. The file already does this
+correctly in places: `bindLocalName` (`:50120`), `moduleView`
+(`:50136`), `restoreScalar` (`:50173`), `builtinOwnerFromPrimitive`
+(`:50516`) are free functions, and `EqDeriver` (`:49742`) /
+`HashDeriver` (`:49965`) are policy structs over a generic walker.
+The pattern exists; it is just not where the bulk is.
+
+## Evidence
+
+- Container extents above, reproducible by listing top-level
+  `const X = struct {` declarations and their brace extents.
+- 53 shared method names between `Builder` and `BodyContext`; 36 at
+  ≥0.70 normalized-body similarity.
+- `monotype/lower.zig:8859` vs `:14869`—`inspectTuple`, identical but
+  for `self.program.addExpr` vs `self.addExpr`.
+- `monotype/lower.zig:8547` vs `:29646`—`restoreConstData` at 0.99.
+- `boxy/lower.zig:4084` vs `:36158`—same predicate, one exhaustive,
+  one with a `std.meta.eql` fallback.
+- 109 duplicate function-name definitions inside
+  `monotype/lower.zig`.
+
+## Solution design
+
+This is a mechanical-but-large refactor with one design decision. Do
+it family by family; each family is independently shippable and
+independently verifiable by unchanged snapshot output.
+
+1. **Decide the sharing mechanism.** Two options, and the choice
+   should be made once for the whole file rather than per family:
+   *(a)* free functions taking the pieces they need
+   (`allocator`, `*ProgramStore`, `*CanonicalNameStore`, the emit
+   target) explicitly, or *(b)* a comptime-duck-typed `Emitter`
+   parameter, where `Builder` and `BodyContext` both already satisfy
+   `addExpr` / `addPat` / `addExprSpan` / `stringExpr` / `concatExpr`
+   / `addLocal`. Option (b) is a smaller diff and matches
+   `match_tree.Compiler(Ctx)` and `EqDeriver`; option (a) is blunter
+   but leaves nothing implicit. Recommendation: (b), with the required
+   method set written down as a doc comment on the parameter, because
+   the two receivers already differ only in how they reach the store.
+
+2. **Extract the inspect family** out of both `Builder` and
+   `BodyContext`. This is the highest-value family (it is also a live
+   behavioral divergence) and the natural first cut. If
+   [one-value-semantics-layer.md](one-value-semantics-layer.md) lands
+   first, this step is already done and the inspect helpers move to
+   `src/postcheck/semantics/` instead of staying local.
+
+3. **Extract the const-restoration family** the same way. These six
+   are near-byte-identical and carry no divergence to reconcile;
+   they are the cheapest confidence-builder if the inspect family
+   looks too entangled to start with.
+
+4. **Extract the singles**: `bindPatLocals`, `stringExpr`,
+   `intLiteralExpr`, `ifExpr`, `lowLevelExpr`, `constBoxPayloadType`,
+   `constListElemType`, `typeHasBuiltinOwner`, `bindTypedLocalLocals`,
+   `removeBoundLocals`, `recordFieldByTextOptional`. Each is small
+   enough that "move it and delete the copy" is one commit.
+
+5. **Do the same for `boxy/lower.zig`.** The 17 shared
+   `ProcedureBuilder`/`ProcBodyBuilder` helpers are representation
+   queries; they should not become free functions in `lower.zig` at
+   all—they belong on `Plan.ProgramPlan`, which is what
+   [../small/boxy-rep-queries-on-the-plan.md](../small/boxy-rep-queries-on-the-plan.md)
+   does. This project's contribution there is deleting the second
+   copy once the plan owns the first, and making every `ChildRole`
+   switch exhaustive on the way through.
+
+6. **Reconcile every divergence deliberately as it is merged.** For
+   each pair, the merged version is the union of capabilities unless
+   there is a stated reason one scope must be weaker—and if there is,
+   it is a comment at the call site, not a silently different body.
+   `childRolesMatch` merges to the exhaustive switch.
+   `toInspectCall` merges to the richer `BodyContext` behavior.
+
+7. **Assess the codec pairs before touching them.** The
+   parser/encoder quadruple and the parse-list/parse-dict pair are
+   measured-similar but not verified to be semantically parallel.
+   Step one is confirming they are the same algorithm over different
+   directions/containers; only then extract a shared skeleton with a
+   direction/container policy parameter. If they turn out to be
+   genuinely different algorithms that merely rhyme, record that
+   finding and leave them alone—do not force a shared shape onto
+   them.
+
+## What success looks like
+
+Every criterion below must hold; the project is not done until all do:
+
+- No function name is defined twice inside `monotype/lower.zig` or
+  `boxy/lower.zig` with ≥0.70-similar bodies. A source-text test in
+  `src/postcheck/structural_test.zig` enforces this going forward
+  (the file already embeds and greps its own sources for exactly this
+  kind of invariant).
+- The inspect family and the const-restoration family each have one
+  definition, callable from both scopes.
+- Every `ChildRole`, `Type.Content`, and pattern-kind switch reached
+  by the moved code is exhaustive; no `std.meta.eql` or `else`
+  fallback survives in a role/variant dispatch.
+- `BodyContext` is materially smaller, and the reduction is in shared
+  helpers moved out, not in code deleted as dead—`zig build` and the
+  full snapshot suite confirm nothing was dropped.
+- Each divergence reconciled in step 6 has either a test pinning the
+  merged behavior or a call-site comment stating why one scope is
+  deliberately weaker.
+- `git diff test/snapshots` is empty and `roc check` / `roc run`
+  output on a fixture set is byte-identical before and after.
+- The codec-pair question from step 7 is answered in writing—either
+  extracted, or documented as not-actually-parallel.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+A change to how an inspect renders, a const is restored, or a pattern
+binds is one edit, and the compiler—not a reviewer's memory—finds
+every consumer. The specific failure mode already observed
+(`toInspectCall` and `childRolesMatch` diverging silently between two
+scopes of the same file) becomes structurally impossible, and the
+structural test prevents its recurrence.
+
+### Performance ideal
+
+Strictly neutral, and this must be checked rather than assumed:
+comptime-duck-typed helpers monomorphize per receiver, so the emitted
+code should be equivalent. Watch for two specific regressions—an
+extracted helper that now takes a slice where it previously indexed a
+field in place, and one that allocates a temporary that the inlined
+version did not. Compare post-check phase timings via
+`checked_pipeline.zig`'s `Timing` counters over a fixed corpus before
+and after each family extraction, not only at the end. Compile-time
+of `monotype/lower.zig` itself should improve or hold; a 52k-line
+file with a 36k-line struct is also a build-throughput cost.
+
+## Tests to add
+
+- A `structural_test.zig` lint: no two functions in
+  `src/postcheck/monotype/lower.zig` or `src/postcheck/boxy/lower.zig`
+  share a name with near-identical bodies, with an explicit shrinking
+  allowlist if the first pass cannot reach zero.
+- Behavior pins for each reconciled divergence (step 6), reachable
+  from both scopes—for `toInspectCall`, an inspect derived from the
+  `Builder` scope and one from the `BodyContext` scope must render
+  identically for the same type.
+- A comptime-enumerated exhaustiveness assertion for `ChildRole`
+  handling, so a new role fails to compile rather than falling into a
+  fallback.
+
+## Related projects
+
+- [one-value-semantics-layer.md](one-value-semantics-layer.md)—
+  removes the inspect family from both scopes by moving it out of the
+  file entirely; land whichever is convenient first, they compose.
+- [../small/boxy-rep-queries-on-the-plan.md](../small/boxy-rep-queries-on-the-plan.md)—
+  the destination for step 5's helpers.
+- [unreachable-rationale-comments.md](unreachable-rationale-comments.md)—
+  same "CI lint with a shrinking allowlist" enforcement shape.

--- a/projects/small/arc-shared-predicates.md
+++ b/projects/small/arc-shared-predicates.md
@@ -1,0 +1,159 @@
+# One Definition per ARC Predicate
+
+## Problem
+
+The ARC stage is four modules that must agree exactly—`arc_solve.zig`
+(borrow inference), `arc_dismantle.zig` (field takes), `arc.zig` (RC
+statement insertion), and `arc_certify.zig` (the debug borrow
+certifier). Four of the predicates they share are implemented twice,
+and one pair **has already diverged**.
+
+**`computeLocalContainsRefcounted`.** `src/lir/arc_solve.zig:354`
+declares it `pub`. `src/lir/arc.zig:547` declares a private copy.
+`arc_certify.zig:192` calls the `arc_solve` one; `arc.zig:280` and
+`arc.zig:7889` call their own. `arc.zig` already imports `arc_solve`
+at `:24` and calls `arc_solve.solve` eight lines below the site where
+it calls its own copy. The two bodies now differ:
+
+- `arc_solve`'s version asserts the Boxy descriptor table covers every
+  local (`solveInvariant("ARC Boxy descriptor table did not cover
+  every local")`) and falls back to `local.boxy_desc` when the table
+  is empty. `arc.zig`'s version indexes `boxy_rc_descs[index]`
+  unconditionally and has no invariant check.
+
+This is the predicate that decides whether a local is refcounted at
+all. The RC inserter and the certifier that is supposed to check the
+inserter compute it with different code.
+
+Its three helpers are duplicated alongside: `markLocalRc`,
+`markLocalRcIfSourceRc`, `markLocalRcIfSpanContainsRc` at
+`arc.zig:702, 709, 715` and `arc_solve.zig:410, 417, 423`.
+
+**`defaultOutcomeMask`.** Byte-identical bodies at `arc.zig:4791`
+(a method on `Inserter`) and `arc_dismantle.zig:607` (a free
+function). Same outcome-discriminant scan, same `restituted_params`
+intersection, same `?ParamMask` result.
+
+**`findOutcomeRefinement`.** `arc.zig:4677` and
+`arc_dismantle.zig:554`—the same alias-chain walk looking for the
+discriminant read that refines a call's outcome, written twice
+(0.88 normalized-body similarity; the differences are the arena
+plumbing and one `for` loop written two ways).
+
+**`outcomeBindingTarget` / `resultBindingTarget`.** A 50-line exact
+duplicate under two names: `arc_solve.zig:970` and
+`arc_certify.zig:1060`.
+
+## Background
+
+The module split is deliberate and documented in `arc.zig`'s own
+header: solve, then dismantle, then insert, with `arc_certify` as the
+debug checker over the result. The intended data flow is one-way—
+`arc.zig` imports `arc_sig`, `arc_solve`, `arc_certify`, and
+`arc_dismantle` (`arc.zig:23-26`), and `arc_certify` imports
+`arc_solve`. Nothing about the layering forces any of these copies;
+in three of the four cases the shared definition is already public and
+already imported at the copying site.
+
+The `arc_solve` version of `computeLocalContainsRefcounted` is the
+better one—it is the one with the coverage invariant—which also tells
+you which direction the merge goes.
+
+## Evidence
+
+- `grep -n computeLocalContainsRefcounted src/lir/*.zig`—one `pub`
+  definition (`arc_solve.zig:354`), one private definition
+  (`arc.zig:547`), three call sites split across them.
+- `arc.zig:24`—`const arc_solve = @import("arc_solve.zig");`, and
+  `arc.zig:288`—`arc_solve.solve(...)`, eight lines after
+  `arc.zig:280` calls the local copy.
+- Diff `arc.zig:547-600` against `arc_solve.zig:354-407`: the
+  `boxy_rc_descs.len` handling and the invariant differ.
+- `arc.zig:4791` against `arc_dismantle.zig:607`—identical.
+- `arc_solve.zig:970` against `arc_certify.zig:1060`—identical, 50
+  lines.
+
+## Solution design
+
+1. **Delete `arc.zig`'s `computeLocalContainsRefcounted` and its
+   three `markLocalRc*` helpers.** Point `arc.zig:280` and
+   `arc.zig:7889` at `arc_solve.computeLocalContainsRefcounted`. The
+   surviving body is `arc_solve`'s, invariant included—confirm the
+   invariant holds at both new call sites (`arc.zig` passes a
+   `computeBoxyRcDescs(store)` result, which is full-length, so it
+   should; if it does not, that is a bug this change surfaces rather
+   than causes).
+2. **Move `defaultOutcomeMask` and `findOutcomeRefinement` to a
+   single owner.** `arc_sig.zig` is the natural home for
+   `defaultOutcomeMask` (it is pure `Outcome`/`ParamMask` arithmetic);
+   `findOutcomeRefinement` is a store walk and belongs in
+   `arc_solve.zig` or `arc_dismantle.zig`. Whichever is chosen, the
+   other two modules import it and delete their copies. Reconcile the
+   two `findOutcomeRefinement` signatures deliberately—one returns
+   `?OutcomeRefinement`, the other `?LIR.CFStmtId`—rather than keeping
+   both shapes.
+3. **Delete `arc_certify.zig`'s `resultBindingTarget`** and call
+   `arc_solve.outcomeBindingTarget`, exporting it if needed.
+4. **Pin the result.** Add a source-text test in
+   `src/postcheck/structural_test.zig` (or a sibling under `src/lir/`)
+   asserting one definition each for these four predicate names across
+   `src/lir/`, so the copies cannot reappear.
+
+## What success looks like
+
+Every criterion below must hold; the project is not done until all do:
+
+- `grep -rn 'fn computeLocalContainsRefcounted\|fn markLocalRc\|fn
+  markLocalRcIfSourceRc\|fn markLocalRcIfSpanContainsRc\|fn
+  defaultOutcomeMask\|fn findOutcomeRefinement\|fn
+  outcomeBindingTarget\|fn resultBindingTarget' src/lir/` shows
+  exactly one definition per predicate.
+- The surviving `computeLocalContainsRefcounted` is the one with the
+  descriptor-coverage invariant, and that invariant is live on the
+  `arc.zig` insertion path (verified by a debug run over the corpus,
+  not by inspection).
+- The single-definition source-text test is in-tree and green.
+- ARC-related snapshots and the refcount conformance suite are
+  unchanged; `git diff test/snapshots` is empty.
+- The certifier passes on the full corpus in a Debug build, since it
+  now checks against the same predicate the inserter used.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+The inserter and its certifier cannot disagree about which locals are
+refcounted, because there is one function. The already-present
+divergence (empty descriptor table handled on one side only) is
+resolved rather than latent, and the coverage invariant now guards
+both paths. Future changes to Boxy descriptor handling land on solve,
+insert, dismantle, and certify atomically.
+
+### Performance ideal
+
+Neutral: identical work, one implementation, and the deleted copies
+were not doing anything cheaper. `computeLocalContainsRefcounted` is
+a fixpoint over all statements and runs twice per compile today
+(once in `arc.zig`, once in `arc_certify` under Debug); this project
+does not change that count. If profiling shows the double run
+matters, threading the already-computed table from `arc.zig` into
+`arc_certify` is a natural follow-up—but measure before doing it, and
+keep it a separate change.
+
+## Tests to add
+
+- Single-definition source-text lint for the four predicate names.
+- A regression case exercising the divergent branch: a program whose
+  Boxy descriptor table is empty at the `arc.zig` call site (or an
+  assertion that this cannot occur), so the merged behavior is pinned
+  rather than assumed.
+- Existing ARC certifier runs over the corpus stay green in Debug.
+
+## Related projects
+
+- [erased-ownership-as-lir-data.md](erased-ownership-as-lir-data.md)—
+  the other lowerer/certifier re-derivation in the same stage.
+- [rceffect-conformance.md](rceffect-conformance.md)—the same
+  "one ownership table, conformance-tested" discipline for `LowLevel`.
+- [cross-phase-coverage-parity-tests.md](cross-phase-coverage-parity-tests.md)—
+  the parity-suite discipline the single-definition lint complements.

--- a/projects/small/boxy-rep-queries-on-the-plan.md
+++ b/projects/small/boxy-rep-queries-on-the-plan.md
@@ -1,0 +1,182 @@
+# Boxy Lowering Consumes the Plan Instead of Re-Querying It
+
+## Problem
+
+The `.boxy` strategy is planner-plus-lowerer: `boxy/plan.zig` (14,158
+lines) analyzes checked types into an explicit representation plan, and
+`boxy/lower.zig` (47,107 lines) lowers checked CIR under that plan.
+design.md states the contract—"In `.boxy`, checked CIR is consumed
+directly with explicit boxy representation plans owned by that
+lowerer", and "Boxy planning records a generated-codec worker from the
+checked structural..."—the planner decides, the lowerer consumes.
+
+In practice the lowerer re-runs the planner's analysis. The two files
+share ~55 function names, of which roughly 45 are representation
+queries with near-identical bodies, ~390 lines:
+
+- `repSubtreeHasDescriptor` / `...InOtherChildren` / `...Inner`
+  (`lower.zig:3993, 3999` and `:35999, 36031`; `plan.zig:9011, 9017`)
+- `repSubtreeHasDictionary` / `...InOtherChildren` / `...Inner`
+  (`lower.zig:36046, 36052`; `plan.zig:9034, 9040`)
+- `repSubtreeContainsRep` / `...Inner` (`lower.zig:36005, 36015`;
+  `plan.zig:9395, 9401`)
+- `findMatchingChildByRole` (`lower.zig:4014, 36067`;
+  `plan.zig:9110`)—three copies
+- `findMatchingChildBySourceType`,
+  `findMatchingDictionaryChildBySourceType`
+- `findMatchingTagPayloadInRep` / `...InRowExtension` / `...Inner`
+  (`lower.zig:4040, 4051, 4064` and `:36138`; `plan.zig:9206, 9218,
+  9231`)
+- `descriptorArgumentIdentityRep` (`lower.zig:4159, 36218`;
+  `plan.zig:9294`), `dictionaryArgumentIdentityRep`,
+  `structuralWrapperBackingRep`
+- `workerSourceForMethodTarget`, `workerSourceForConstFnValue`,
+  `workerSourceForCallableRootExpr`,
+  `workerSourceForCallableEvalTemplate`,
+  `workerSourceForProcedureUse`
+- `topLevelProcedureBindingForExpr` (`lower.zig:311`;
+  `plan.zig:11443`), `importedProcedureBinding`,
+  `nestedCallableSiteExprForExpr`, `checkedBinderType`,
+  `checkedLambdaExprForNestedFn`, `methodOwnerFor*`,
+  `recordFieldNameMatches`, `tagLabelNameMatches`,
+  `requiredSingleChild`, `lookupMethodTarget`
+
+A further set is shared with `boxy/layouts.zig`: `functionChildren`
+(`plan.zig:9064` / `layouts.zig:329`), `functionIdentityRep`
+(`plan.zig:9089` / `layouts.zig:354`), `requiredSingleChild`,
+`builtinNominal`, `sameChildRole`.
+
+The sharpest instance is `childRolesMatch`, which exists three times
+with **two different exhaustiveness postures**:
+
+- `plan.zig:9254`—`if (target.role == .record_field) { ... }`,
+  `if (target.role == .tag_payload) { ... }`, then
+  `return std.meta.eql(target.role, candidate.role);`
+- `lower.zig:4084` (`ProcedureBuilder`)—same `if`-chain plus
+  `std.meta.eql` fallback
+- `lower.zig:36158` (`ProcBodyBuilder`)—an exhaustive `switch` over
+  every `ChildRole`, with all fourteen non-matching roles listed by
+  name in each arm
+
+Adding a `ChildRole` that needs name-based or index-based matching
+fails to compile in the third copy and silently falls into
+`std.meta.eql` in the other two. That is a wrong-answer-by-default,
+not a missing-arm error.
+
+## Background
+
+`plan.zig` already exposes the right shape in places:
+`ProgramPlan.inspectMethodForRep` (`plan.zig:1106`) is a `pub` method
+on the plan that the lowerer calls. The queries above are simply the
+ones that never got promoted—each was written as a `Builder` method
+during planning, then needed during lowering, and copied.
+
+`boxy/lower.zig`'s own internal split makes it worse: `ProcedureBuilder`
+(L994–11713) and `ProcBodyBuilder` (L11714–36862) are two scopes of the
+same lowering pass, so several queries exist twice *inside* `lower.zig`
+before you count `plan.zig`'s copy.
+
+## Evidence
+
+- The paired declarations above; a side-by-side diff of any
+  `repSubtree*` pair shows only receiver plumbing differences
+  (`self.plan.representations` vs `self.parent.plan.representations`,
+  `self.moduleForId(...)` vs `procedureModuleById(self.modules, ...)`).
+- `plan.zig:9254` vs `lower.zig:4084` vs `lower.zig:36158`—the
+  three-way `childRolesMatch` with divergent exhaustiveness.
+- `plan.zig:1106`—the pattern already in use, for one query.
+- `grep -c 'fn ' src/postcheck/boxy/lower.zig`—1,077 functions in one
+  file, which is why "just call the other one" was never the easy
+  edit.
+
+## Solution design
+
+1. **Promote the queries to `ProgramPlan` methods.** Every
+   `rep*`/`findMatching*`/`*IdentityRep`/`requiredSingleChild`/
+   `sameChildRole`/`childRolesMatch` query becomes `pub fn` on
+   `Plan.ProgramPlan`, taking only plan data. They are pure functions
+   of the plan; none needs the planner's mutable builder state or the
+   lowerer's emit state.
+2. **Delete all copies** in `plan.zig`'s `Builder`, in
+   `lower.zig`'s `ProcedureBuilder` and `ProcBodyBuilder`, and in
+   `layouts.zig`. Each becomes a call.
+3. **Make `childRolesMatch` exhaustive**—the surviving version is
+   `ProcBodyBuilder`'s switch. Sweep the same way for every other
+   `ChildRole` dispatch reached by the moved code; no
+   `std.meta.eql` fallback and no `else` may survive in a role
+   dispatch.
+4. **Resolve the name-matching signature split.** `tagLabelNameMatches`
+   takes a `checked.ModuleId` in one copy and a module view in
+   another; `recordFieldNameMatches` likewise. Pick one and thread it,
+   rather than keeping an adapter on each side.
+5. **The `workerSourceFor*` and `*BindingForExpr` families need a
+   judgment call**, not a mechanical move: these read checked CIR, not
+   just the plan. Either they become plan methods taking the checked
+   module as a parameter, or—better where it applies—the planner
+   *records* the answer in the plan and the lowerer looks it up. Prefer
+   recording: that is the design.md contract, and it removes the query
+   rather than sharing it. Decide per family and state the decision in
+   the code.
+6. **Pin it.** A source-text test asserting a single definition per
+   promoted query name across `src/postcheck/boxy/`.
+
+## What success looks like
+
+Every criterion below must hold; the project is not done until all do:
+
+- `grep -rn 'fn repSubtree\|fn findMatching\|fn childRolesMatch\|fn
+  requiredSingleChild\|fn sameChildRole\|fn .*IdentityRep' src/postcheck/boxy/`
+  shows one definition per name, all on `ProgramPlan`.
+- No `ChildRole` dispatch under `src/postcheck/boxy/` uses
+  `std.meta.eql` as a fallback or an `else` arm; adding a role is a
+  compile error at every site that must handle it.
+- Each `workerSourceFor*` / `*BindingForExpr` family is either a
+  single plan method or replaced by a recorded plan field, with the
+  choice stated in a code comment.
+- The single-definition source-text test is in-tree and green.
+- `.boxy` snapshot and CLI output are unchanged; the boxy cases in
+  `src/eval/test/parallel_cli_runner.zig` pass.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+The plan is the single answer to "what does this representation
+contain", so planning and lowering cannot reach different conclusions
+about descriptors, dictionaries, tag payloads, or child roles. A new
+`ChildRole` is a compile error at every site that must handle it,
+instead of a silent `std.meta.eql` false in two of three.
+
+### Performance ideal
+
+Neutral to positive. The queries are pure plan walks, so moving them
+changes no algorithmic cost; several are recursive subtree scans
+(`repSubtreeHasDescriptorInner`, `repSubtreeContainsRepInner`) that
+today run once per copy per call site. Where step 5 converts a query
+into a recorded plan field, that is a strict win—the walk happens once
+during planning instead of per lowering site. Measure boxy
+lowering time on a corpus before and after; a regression means a
+promoted query lost an inlining opportunity, and `inline fn` is the
+fix—applied on evidence, not preemptively.
+
+## Tests to add
+
+- Single-definition source-text lint for the promoted query names.
+- A comptime exhaustiveness assertion over `ChildRole`, so a new role
+  fails the build until every dispatch handles it.
+- Plan/lower agreement pins: for a corpus of representations, assert
+  the plan's recorded descriptor and dictionary requirements match
+  what lowering materializes—so step 5's recorded facts are checked,
+  not trusted.
+
+## Related projects
+
+- [../big/postcheck-lowerer-decomposition.md](../big/postcheck-lowerer-decomposition.md)—
+  the `ProcedureBuilder`/`ProcBodyBuilder` split that creates the
+  second copy inside `lower.zig`; this project supplies the
+  destination for its step 5.
+- [../big/one-value-semantics-layer.md](../big/one-value-semantics-layer.md)—
+  its `Plan.TypeRepresentation` shape context wants these queries to
+  already be plan methods.
+- [hoist-consumes-dispatch-evidence.md](hoist-consumes-dispatch-evidence.md)—
+  the same record-instead-of-re-derive cure, one stage earlier.

--- a/projects/small/erased-ownership-as-lir-data.md
+++ b/projects/small/erased-ownership-as-lir-data.md
@@ -1,0 +1,162 @@
+# Erased Ownership Travels as LIR Data, Not a Re-Derived Rule
+
+## Problem
+
+The direct LIR lowerer decides, for each `assign_ref`, whether the
+target is a transparent alias of its source's erased ownership, a
+fresh root, or ambiguous. It records that decision in its own state:
+
+- `src/postcheck/solved_lir_lower.zig:4519` `noteErasedOwnerDefinition`
+- `src/postcheck/solved_lir_lower.zig:4545`
+  `transparentErasedOwnershipSource`
+- `src/postcheck/solved_lir_lower.zig:4577`
+  `sameTransparentPointerRepresentation`
+- called from `:4537` `addAssignRef`
+
+The ARC borrow certifier then re-derives the same decision from the
+finished LIR with a second copy of the rule:
+
+- `src/lir/arc_certify.zig:2636` `noteErasedOwnerDefinition`
+- `src/lir/arc_certify.zig:2645`
+  `transparentErasedOwnershipSource`
+- consumed by `:2682` `resolvedErasedOwner` and `:2698`
+  `refcountedErasedOwner`, driven from `:2712-3000`
+
+The two `transparentErasedOwnershipSource` bodies are the same rule
+written twice: the same `RefOp` switch, the same variant-index-0
+condition, the same zero-discriminant tag-union condition, the same
+target-usize pointer-width comparison. They differ only in receiver
+plumbing and in the lowerer having factored the width check into a
+named helper.
+
+`grep -rn 'transparentErasedOwnershipSource\|noteErasedOwnerDefinition'
+src/` returns hits in exactly those two files. `src/postcheck/boxy/lower.zig`
+has no equivalent—so on the `.boxy` path the certifier's ownership
+model has no producer to agree with at all. It is deriving facts about
+a program whose lowerer never reasoned in those terms.
+
+This is the shape design.md's core principle names directly: "A
+consumer must not recover missing data from source syntax, names, body
+scans, display strings, runtime bytes, object symbols, backend state,
+or incidental data structure shape." The certifier is recovering the
+lowerer's decision from the incidental shape of the emitted
+`assign_ref` chain.
+
+## Background
+
+design.md's "Checked identity and runtime encoding are separate data"
+rule has a general form: the stage that commits a decision outputs the
+explicit mapping, and later stages consume it. Erased ownership is
+such a decision—the lowerer knows, at the moment it emits the
+`assign_ref`, whether it intended the target to alias the source's
+owner. Nothing about that intent is recoverable in principle from the
+statement alone; it happens to be recoverable today because the
+lowerer emits a recognizable shape.
+
+The certifier is Debug-only (`arc_certify.zig` is the debug borrow
+certifier), which bounds the blast radius: a divergence here produces
+a false certifier verdict—a spurious failure, or worse, a missed
+one—rather than a miscompile. That is why this is a small project and
+not a big one. It is still the wrong direction of information flow,
+and the boxy gap means the certifier's coverage of that strategy is
+not what it appears to be.
+
+## Evidence
+
+- `solved_lir_lower.zig:4545` against `arc_certify.zig:2645`—same
+  switch arms, same conditions, same result.
+- `grep -rn 'transparentErasedOwnershipSource' src/`—two definitions,
+  zero shared home.
+- `grep -rn 'erased_owner' src/postcheck/boxy/`—empty; the boxy
+  lowerer records nothing here.
+- `arc_certify.zig:2712-3000`—the certifier's ~20 `noteErasedOwnerDefinition`
+  call sites, one per statement kind, reconstructing per-statement
+  what the lowerer knew per-statement.
+
+## Solution design
+
+1. **Add the fact to LIR.** A per-local side table on `LirStore`
+   holding the lowerer's erased-owner state: `root`, `alias(LocalId)`,
+   or `ambiguous`—the same three-state lattice `arc_certify` already
+   models in `erased_owner_states`. Dense over locals, like the
+   existing per-local metadata.
+2. **The LSS lowerer writes it.** `solved_lir_lower.zig`'s
+   `noteErasedOwnerDefinition` becomes a store write instead of
+   private state. `transparentErasedOwnershipSource` stays in the
+   lowerer—it is the producer's rule and belongs to the producer.
+3. **The boxy lowerer writes it too.** This is the substantive part:
+   decide, for each boxy `assign_ref`-emitting site, what the erased
+   ownership actually is. Where boxy's erased-callable representation
+   makes the answer `ambiguous`, record `ambiguous` explicitly—an
+   honest coarse answer beats an absent one. Where boxy genuinely has
+   no erased values, record that the table is empty for a reason, not
+   by omission.
+4. **The certifier reads and checks.** Delete
+   `arc_certify.zig:2636` and `:2645` and the ~20 reconstruction call
+   sites. `resolvedErasedOwner` walks the recorded table. The
+   certifier's new job is to *verify* the recorded states are
+   consistent with the emitted statements—which is a real check, and a
+   different one from recomputing them.
+5. **Pin it.** A source-text test asserting one definition of
+   `transparentErasedOwnershipSource` under `src/`, and a debug
+   assertion that every `assign_ref` target has a recorded state.
+
+## What success looks like
+
+Every criterion below must hold; the project is not done until all do:
+
+- `grep -rn 'fn transparentErasedOwnershipSource\|fn
+  noteErasedOwnerDefinition' src/` shows one definition each, in the
+  producer.
+- Both lowering strategies populate the erased-owner table for every
+  `assign_ref` they emit; a Debug assertion fires if one does not.
+- `arc_certify.zig` contains no reconstruction of erased ownership—it
+  reads the table and validates it.
+- The certifier passes on the full corpus under both `.lss` and
+  `.boxy` in a Debug build. If enabling it on boxy surfaces real
+  violations, those are fixed (or filed with a scoped, commented
+  allowlist)—not worked around by leaving boxy uncovered.
+- `git diff test/snapshots` is empty; no runtime behavior changes.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+The certifier checks the lowerer's actual intent instead of a
+reconstruction of it, so the class of bug where a lowering change
+quietly stops matching the certifier's pattern-recognition cannot
+occur. `.boxy` gains real borrow-certification coverage rather than
+apparent coverage. The information flows producer-to-consumer, which
+is what design.md's post-check principles require.
+
+### Performance ideal
+
+Slightly positive on the certifier path and neutral elsewhere. The
+table is one dense per-local enum—smaller than the
+`erased_owner_states` hash map the certifier builds today—and reading
+it replaces a full statement walk with a lookup. The lowerer's write
+is one store per `assign_ref`, work it already does into private
+state. Memory: one byte per local (plus the alias id where present),
+which is noise against existing per-local metadata; confirm with a
+peak-RSS check on a large corpus program rather than assuming.
+
+## Tests to add
+
+- Single-definition source-text lint for both function names.
+- A Debug assertion (and a test that trips it under a deliberately
+  incomplete lowering) that every `assign_ref` target has a recorded
+  erased-owner state.
+- Certifier runs over the corpus under `.boxy`, newly meaningful.
+- A case per `RefOp` variant, so the recorded state for each is
+  pinned rather than incidental.
+
+## Related projects
+
+- [arc-shared-predicates.md](arc-shared-predicates.md)—the other
+  duplicated-predicate cluster in the same stage; land either first.
+- [hoist-consumes-dispatch-evidence.md](hoist-consumes-dispatch-evidence.md)—
+  the same "consume the recorded decision instead of re-deriving it"
+  cure at the checker boundary.
+- [../big/one-value-semantics-layer.md](../big/one-value-semantics-layer.md)—
+  step 3 here needs boxy's erased-callable representation understood;
+  that project touches the same ground.

--- a/projects/small/lir-call-result-fusion-framework.md
+++ b/projects/small/lir-call-result-fusion-framework.md
@@ -1,0 +1,152 @@
+# One Framework for the Call-Result Fusion Passes
+
+## Problem
+
+`src/lir/return_slot.zig` and `src/lir/str_append.zig` are the same
+pass written twice. Both run before ARC, both look for an
+`assign_call` whose single-use result feeds one specific consumer
+statement, both clone the callee proc into a cached variant with a
+rewritten return, and both replace the pair with a call to the
+variant. Only the matched consumer and the rewrite differ.
+
+The shared skeleton is literally identical:
+
+- `run`: `return_slot.zig:43` / `str_append.zig:51`, 0.95 similar
+  (same proc loop, same `VariantKey` map init and teardown).
+- `transformProc`: `return_slot.zig:68` / `str_append.zig:73`,
+  **byte-identical** 18 lines (same eligibility gate, same worklist,
+  same `DenseMap` visited set, same
+  `body_clone.appendSuccessors` walk).
+- `chainIsSingleUse`: `return_slot.zig:147` / `str_append.zig:147`,
+  **byte-identical**, including its doc comment modulo the word
+  "stored"/"concatenated".
+- `rewriteAt`: `return_slot.zig:88` / `str_append.zig:93`, 0.74
+  similar. The 25 lines of scaffolding (statement-kind check, callee
+  eligibility, `forwardLocalAliasChainInto`, single-use check, variant
+  lookup, argument prepend, `assign_call` overwrite) are the same;
+  only the middle—"the consumer is `ptr_store` into a matching `ptr`
+  layout" versus "the consumer is `str_concat` with the result on the
+  right"—differs.
+
+`src/lir/loop_append_promote.zig` (`run` at `:60`, `transformProc` at
+`:700`) and `src/lir/box_reuse.zig` (`run` at `:56`, `transformProc` at
+`:65`, `rewriteAt` at `:100`) repeat parts of the same shape: the
+`run`-over-all-procs loop, the visited-set body walk, and the
+match-then-rewrite structure.
+
+Nothing enforces that they stay aligned. A fix to `chainIsSingleUse`'s
+liveness reasoning—the guard that stops the fusion from orphaning a
+still-live local, i.e. the correctness-critical half of both passes—
+has to be applied twice, in two files, with no test that would notice
+if it were applied once.
+
+## Background
+
+`src/lir/body_clone.zig` already is the shared layer for this family
+and both passes already use it: `appendSuccessors` (`:82`),
+`forwardLocalAliasChain` / `...Into` (`:34`, `:41`),
+`countReachableReads` (`:186`), and `BodyCloner(Rewriter)` (`:396`)—a
+comptime-parameterized body cloner, which is exactly the shape this
+project extends one level up. The traversal and cloning primitives
+were factored out; the pass *skeleton* around them was not.
+
+`BodyCloner(comptime Rewriter: type)` is the in-repo precedent for the
+mechanism: one algorithm, a caller-supplied policy type.
+
+## Evidence
+
+- `return_slot.zig:68` vs `str_append.zig:73`—diff is empty.
+- `return_slot.zig:147` vs `str_append.zig:147`—diff is empty.
+- `return_slot.zig:43` vs `str_append.zig:51`—differs only in the
+  extra `layouts` field and the `VariantKey` shape.
+- `body_clone.zig:396`—`BodyCloner(Rewriter)`, the pattern to extend.
+- No test in `src/lir/` exercises the two passes' shared liveness
+  guard as one thing.
+
+## Solution design
+
+1. **Add `CallResultFusion(Rule)` to `body_clone.zig`** (or a new
+   `src/lir/call_fusion.zig`). It owns: the per-proc loop, the
+   eligibility gate (`body != null`, `hosted == null`, `abi == .roc`),
+   the visited-set body walk, the variant cache keyed by
+   `Rule.VariantKey`, `chainIsSingleUse`, the alias-chain forwarding,
+   the argument prepend, and the `assign_call` overwrite.
+2. **`Rule` supplies only what differs**: `VariantKey`,
+   `matchConsumer(store, layouts, call, forwarded) ?Match` (the
+   `ptr_store`/`str_concat` test plus the extra operand the variant
+   needs), `resultEligible(layout)`, and `cloneVariantReturn` (the
+   `cloneStructReturn`/`cloneTagReturn` vs `cloneConcatReturn`
+   difference). `ReturnSlotRule` and `StrAppendRule` become the two
+   instances; `return_slot.zig` and `str_append.zig` shrink to their
+   rules plus their tests.
+3. **Assess `loop_append_promote.zig` and `box_reuse.zig`
+   separately.** They share the outer skeleton but not the
+   clone-a-variant core—`box_reuse.zig` rewrites in place and
+   `loop_append_promote.zig` classifies helper procs first. Factor out
+   what genuinely matches (the proc loop and the visited-set walk, as
+   a small `forEachReachableStmt` helper in `body_clone.zig`) and
+   leave the rest. Do not force these two into `CallResultFusion` if
+   the fit is not clean; record the finding either way.
+4. **Test the shared guard once.** `chainIsSingleUse` is the safety
+   property both passes depend on. Move its tests to the framework and
+   make them exercise every escape it must reject: an extra read of
+   the call result, an extra read of an intermediate alias, an extra
+   read of the final value, and a read from a different branch.
+
+## What success looks like
+
+Every criterion below must hold; the project is not done until all do:
+
+- `grep -rn 'fn chainIsSingleUse\|fn transformProc' src/lir/` shows
+  one `chainIsSingleUse` and no duplicate `transformProc` between
+  `return_slot.zig` and `str_append.zig`.
+- `return_slot.zig` and `str_append.zig` each contain only their rule
+  (consumer match, eligibility, variant return clone) and their
+  tests—no traversal, no variant cache, no liveness guard.
+- The `chainIsSingleUse` escape-case tests live in the framework and
+  cover the four escapes above.
+- The `loop_append_promote` / `box_reuse` question from step 3 is
+  answered in writing—either folded in, or documented as a different
+  enough shape to stay separate.
+- `git diff test/snapshots` is empty; LIR dumps for a corpus of
+  programs exercising both fusions are byte-identical before and
+  after.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+The liveness guard that makes both fusions sound exists once, so a fix
+to it cannot land on one pass and miss the other. Adding a third
+fusion (an obvious future want—`list_concat`, `dict_insert`) is a rule
+struct rather than a third copy of the skeleton, and it inherits the
+guard and its tests for free.
+
+### Performance ideal
+
+Neutral by construction: same traversal, same variant caching, same
+number of passes over each proc. `Rule` is a comptime type parameter,
+so the framework monomorphizes per pass and the emitted code should
+match today's. Confirm with LIR-dump byte-identity on the corpus
+(which also serves as the correctness check) and with post-check phase
+timings from `checked_pipeline.zig`'s `lir_passes` counter over a
+fixed corpus. If step 3 introduces a shared `forEachReachableStmt`,
+check that it does not add an allocation the inlined walks avoided.
+
+## Tests to add
+
+- The four `chainIsSingleUse` escape cases, in the framework.
+- A rule-level test per instance: the consumer match accepts its
+  intended shape and rejects the neighboring one (a `ptr_store` whose
+  destination layout does not match, a `str_concat` with the result on
+  the left).
+- LIR-dump golden output for one program per fusion, so a future rule
+  change is visible.
+
+## Related projects
+
+- [../big/postcheck-lowerer-decomposition.md](../big/postcheck-lowerer-decomposition.md)—
+  the same "extract the shared skeleton, keep the scopes" move, one
+  stage earlier and much larger.
+- [arc-shared-predicates.md](arc-shared-predicates.md)—the other
+  `src/lir/` duplication cluster; independent.

--- a/projects/small/postcheck-ir-store-boilerplate.md
+++ b/projects/small/postcheck-ir-store-boilerplate.md
@@ -1,0 +1,166 @@
+# Generate the Post-Check IR Store Boilerplate Once
+
+## Problem
+
+The post-check pipeline has four flat IR stores, and their storage
+boilerplate is copy-pasted between them.
+
+- `src/postcheck/monotype/ast.zig` (2,464 lines, 173 functions)
+- `src/postcheck/monotype_lifted/ast.zig` (1,369 lines, 141 functions)
+- `src/postcheck/lambda_mono/ast.zig` (907 lines, 64 functions)
+- `src/postcheck/lambda_solved/ast.zig` (110 lines—this one is thin
+  and mostly a re-export)
+
+Monotype and Monotype Lifted share **69 function names, 57 of which
+have byte-identical bodies**. Lifted and Lambda Mono share 51 names
+with 44 byte-identical bodies. The identical set is the whole flat-store
+surface: `addExpr`, `addPat`, `addStmt`, `addLocal`,
+`addLocalWithBinder`, `addFn`, `addRoot`, `addStringLiteral`,
+`addLayoutRequest`, `addRuntimeSchemaRequest`, `addComptimeSite`, the
+eleven `add*Span` functions, the matching eleven `*Span` accessors,
+`getExpr`/`getPat`/`getStmt`/`getFn`/`getLocal` and their `*At`
+variants, the five `*Count` functions, the five `*View` functions,
+`exprLoc`/`exprRegion`/`stmtLoc`/`stmtRegion`, `procDebugName`,
+`setProcDebugName`, `localName`, `captureIdOfLocal`, `deinit`, `init`,
+`view`, and `Span`/`ProgramList`/`ProgramSpanBorrow`.
+
+A fifth copy of one of them lives outside `postcheck`:
+`addComptimeSite` at `src/lir/program.zig:415` is a 0.94 match for the
+`monotype/ast.zig:1752` and `lambda_mono/ast.zig:670` versions.
+
+Everything that is *actually* per-IR—the `ExprData`, `PatData`, and
+`StmtData` unions, the type ids, the stage-specific invariants—is a
+minority of each file. Each new field on a stored node, each new span
+kind, each fix to a bounds check or a `deinit` free-list means the same
+edit in three or four files, with only reviewer attention as the check.
+
+## Background
+
+The four IRs are deliberately separate types: `structural_test.zig`
+enforces that stage expression forms "only shrink checked syntax or
+add runtime encoding forms" (`structural_test.zig:240`), and that
+Monotype Lifted "owns captures and consumes Monotype expression
+storage" (`:155`). That separation is the point and must survive—this
+project does not merge the IRs.
+
+It merges only their *storage mechanics*, which are genuinely identical:
+append to an `ArrayList`, hand back a dense id, store spans as
+`(start, len)` into a flat side array, guard reads through
+`GuardedList`. Nothing about that is stage-specific.
+
+The repo already accepts comptime-driven store generation as a
+technique: `small/nodestore-serde-enrollment.md` proposes exactly this
+for the canonicalizer's `NodeStore` field lists, and
+`src/builtins/builtin_registry.zig` (a landed project) derives seven
+hand-typed tables from one comptime registry.
+
+## Evidence
+
+- Normalized-body comparison of `monotype/ast.zig` against
+  `monotype_lifted/ast.zig`: 69 shared names, 57 with identical
+  bodies.
+- Same against `lambda_mono/ast.zig`: 51 shared, 44 identical.
+- `monotype/ast.zig:1752` vs `lambda_mono/ast.zig:670` vs
+  `lir/program.zig:415`—three `addComptimeSite`.
+- `monotype_lifted/ast.zig:1037` vs `monotype/ast.zig:1809`—
+  `addLocalWithBinder`, 0.98.
+- The `deinit` triple (`monotype/ast.zig:1417`,
+  `monotype_lifted/ast.zig:603`, `lambda_mono/ast.zig:563`) at
+  0.92–0.94: the same free sequence, one list longer or shorter.
+- The tax being paid live: PR #10834 (in review as this was written)
+  widens `source_files` from `[]const u8` to `base.SourceFileEntry`.
+  Inside `monotype/ast.zig` alone that is the same field edit in
+  `Program`, `ProgramView`, and `ProgramBuilder`, plus the same
+  two-field `deinit` free loop written out twice—one change to one
+  stored table, five hand-synchronized edits.
+
+## Solution design
+
+1. **Write `FlatStore(comptime Spec: type)`** in
+   `src/postcheck/common.zig` or a new
+   `src/postcheck/flat_store.zig`. `Spec` declares the node tables
+   (`Expr`, `Pat`, `Stmt`, `Local`, `Fn`, ...) and the span tables
+   (`ExprSpan`, `PatSpan`, `BranchSpan`, ...), each with its id enum.
+   The mixin generates `add*`, `get*`, `get*At`, `set*`, `*Count`,
+   `*View`, `*Span`, `add*Span`, `init`, `deinit`, and `view` from
+   that declaration.
+2. **Each `ast.zig` keeps only what is its own**: the data unions, the
+   loc/region side tables where they differ, the stage-specific
+   accessors (`captureIdOfLocal`, `procDebugName`), and the invariants
+   `structural_test.zig` pins. Everything generated is deleted.
+3. **Fold `lir/program.zig`'s `addComptimeSite` in** if `Program` can
+   reasonably use the same mixin; if it cannot (it is an LIR store,
+   not a post-check AST store), leave it and note why—do not stretch
+   the abstraction across the LIR boundary just to absorb one
+   function.
+4. **Keep the guarded-read discipline.** The generated accessors must
+   go through `GuardedList` exactly as the hand-written ones do; the
+   existing `src/collections/guarded_list_violation_test.zig` cases
+   (`lambda_mono_expr_ids`, `lambda_mono_type_spans`) must keep
+   failing on violation after generation.
+5. **Preserve node allocation order exactly.** Snapshot output
+   contains type-variable and node indices, so any change to the order
+   or count of appends shows up as a snapshot diff. That makes
+   `git diff test/snapshots` the primary verification for this
+   refactor—if it is empty, the mechanics are equivalent.
+
+## What success looks like
+
+Every criterion below must hold; the project is not done until all do:
+
+- No function body is duplicated across the four `ast.zig` files;
+  the generated surface exists once.
+- Each `ast.zig` contains only its data unions, its stage-specific
+  accessors, and its `Spec` declaration.
+- The `guarded_list_violation_test.zig` cases still detect violations
+  through the generated accessors.
+- Every `structural_test.zig` invariant about stage IR shape still
+  holds (these embed and grep the sources, so some will need their
+  search strings updated—updating them is fine; deleting one is not).
+- `git diff test/snapshots` is empty, confirming node allocation order
+  and count are unchanged.
+- Adding a span kind to one IR is a one-line `Spec` edit, not a
+  four-function addition.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+A bounds check, a `deinit` free, or a guarded-read fix lands in one
+place for every IR at once. The four stores cannot drift into
+subtly different bounds or ownership behavior, which is a class of bug
+that would surface as a use-after-free or a silent wrong-node read
+rather than a clean failure.
+
+### Performance ideal
+
+Neutral, and worth verifying rather than assuming: comptime generation
+monomorphizes per `Spec`, so the emitted accessors should be identical
+to today's. Two things to check explicitly—that the generated `add*`
+functions keep the same `ArrayList` growth behavior (a different
+`ensureTotalCapacity` pattern changes allocation counts on large
+programs), and that Zig's compile time for the four files does not
+regress from heavy comptime reflection. Measure both: allocation
+counts on a large corpus program, and `zig build` wall time.
+
+## Tests to add
+
+- A comptime assertion per `Spec` that every declared table has a
+  matching id enum and that ids are dense from zero (the
+  "Dense IDs and structural keys" rule in design.md).
+- Round-trip tests for each store: append N nodes of each kind, read
+  them all back, assert ids and contents match.
+- Keep the existing guarded-list violation cases; add one per store so
+  all four are covered rather than only `lambda_mono`.
+
+## Related projects
+
+- [nodestore-serde-enrollment.md](nodestore-serde-enrollment.md)—the
+  same comptime-drive-the-field-lists cure for the canonicalizer's
+  `NodeStore`; land either first, they share technique.
+- [spec-constr-single-cloner.md](spec-constr-single-cloner.md)—the
+  other Monotype Lifted duplication, at the traversal layer rather
+  than the storage layer.
+- [../big/postcheck-lowerer-decomposition.md](../big/postcheck-lowerer-decomposition.md)—
+  independent; both reduce the post-check line count, neither blocks
+  the other.

--- a/projects/small/spec-constr-single-cloner.md
+++ b/projects/small/spec-constr-single-cloner.md
@@ -1,0 +1,163 @@
+# One Cloner for Monotype Lifted
+
+## Problem
+
+`src/postcheck/monotype_lifted/spec_constr.zig` (13,647 lines)
+contains two independent cloners over the same IR, each with its own
+exhaustive-ish switch over `Ast.ExprData`:
+
+- `Pass.cloneExprFresh` (`:3370`) with `cloneStmtFresh` (`:3347`),
+  `clonePatFresh` (`:3574`), `cloneExprSpanFresh` (`:3532`),
+  `cloneCaptureOperandSpanFresh` (`:3543`), `cloneFieldSpanFresh`
+  (`:3557`), `clonePatSpanFresh` (`:3621`). Covers 29 expression
+  variants and returns `?Ast.ExprId`—`null` for everything it does not
+  handle.
+- `Cloner.cloneExprPlain` (`:5727`), part of the `Cloner` struct
+  (`:4528`), with `cloneJoinPoint` (`:5916`), `cloneLetValue`
+  (`:5967`), `cloneLoopBody` (`:6176`), and the substitution-aware
+  `cloneExpr` / `cloneExprValue` family (`:5081`–`:5458`). Covers 44
+  expression variants.
+
+The 15-variant gap is the problem's shape. `cloneExprFresh` silently
+declines `break_`, `loop_`, `join_point`, `jump`, `record_update`,
+`expect`, `expect_err`, `dbg`, `try_sequence`,
+`try_record_sequence`, `if_initialized_payload`, `uninitialized`,
+`uninitialized_payload`, `comptime_branch_taken`, and
+`comptime_exhaustiveness_failed`. Because it returns an optional
+rather than switching exhaustively, adding a new `Ast.ExprData`
+variant compiles clean and is silently declined by one cloner and
+handled by the other—and "declined" here means a specialization
+opportunity is dropped, which is invisible except as a performance
+regression nobody attributes to it.
+
+`monotype_lifted/lift.zig` adds a third partial traversal of the same
+IR: `bindPat` at `lift.zig:1570` and `:2043` against
+`spec_constr.zig:10512` (0.68 and 0.89 similar respectively).
+
+## Background
+
+The two cloners genuinely do different jobs. `Cloner.cloneExprPlain`
+is the specialization cloner: it copies a function body while
+substituting known-shape arguments, tracks binding chains, and manages
+loop-exit selection. `Pass.cloneExprFresh` is the narrower "duplicate
+this subtree with fresh locals" helper used for carry duplication
+(`cloneNewCarry`, `:3234`) and in-place body cloning
+(`cloneFnBodyInPlace`, `:3636`).
+
+That difference justifies two *policies*, not two *traversals*. The
+part that must stay in lockstep with the IR—which variants exist, what
+children each has, which spans need cloning—is identical between them,
+and it is the part that a new variant changes.
+
+`src/lir/body_clone.zig:396` shows the intended shape at the LIR
+layer: `BodyCloner(comptime Rewriter: type)`—one traversal, a
+caller-supplied policy. Monotype Lifted has no equivalent.
+
+This project sits directly on top of two landed concerns:
+`project_issue_10561` (cloneCallProc cloning each argument twice,
+producing 2^depth growth on nested call chains) and
+`project_issue_9801` (a slice into `program.fns` invalidated by a
+`Cloner` append). Both were bugs in cloning mechanics. A single
+traversal is the structural answer to that class.
+
+## Evidence
+
+- `spec_constr.zig:3370` vs `:5727`—29 variants against 44, over the
+  same `Ast.ExprData`.
+- `cloneExprFresh` returns `?Ast.ExprId`; its callers treat `null` as
+  "skip this specialization", so an unhandled variant is silent.
+- `lift.zig:1570` / `lift.zig:2043` / `spec_constr.zig:10512`—three
+  `bindPat`.
+- `src/lir/body_clone.zig:396`—the pattern this project ports upward.
+
+## Solution design
+
+1. **Write `LiftedCloner(comptime Policy: type)`** in
+   `src/postcheck/monotype_lifted/`. It owns the exhaustive switch
+   over `Ast.ExprData`, `Ast.PatData`, `Ast.StmtData`, and every span
+   kind, and it dispatches to `Policy` at the points where the two
+   current cloners differ: local renaming, value substitution, join
+   retargeting, and the decision to decline.
+2. **Two policies.** `FreshPolicy` renames locals and declines what it
+   must; `SpecPolicy` substitutes known shapes and threads binding
+   chains. Both get every variant handed to them, so declining is an
+   explicit `Policy` decision at a named variant rather than an
+   omitted switch arm.
+3. **Make declining explicit and countable.** Where `FreshPolicy`
+   cannot clone a variant, it says so by name and the pass counts it.
+   The `lambda_mono` differential runner's rule applies:
+   unsupported constructs are counted and reported per reason, never
+   silently skipped. That turns today's invisible dropped
+   specializations into a number someone can look at.
+4. **Fold `bindPat`.** The three copies in `lift.zig` and
+   `spec_constr.zig` become one, in whichever module owns pattern
+   binding for the lifted IR.
+5. **Carry the existing hazards into the framework.** Two traps are
+   already documented in this file's history and must be encoded in
+   the shared traversal, not rediscovered per policy: no slice into
+   `program.fns` (or any store table) may be held across a clone
+   append, and no argument may be cloned twice on a call path. Assert
+   both in Debug.
+
+## What success looks like
+
+Every criterion below must hold; the project is not done until all do:
+
+- One exhaustive traversal of `Ast.ExprData` for cloning exists;
+  adding a variant is a compile error until both policies handle it.
+- `grep -rn 'fn cloneExprFresh\|fn cloneExprPlain' src/postcheck/` is
+  empty—both are policies over the shared traversal.
+- `grep -rn 'fn bindPat' src/postcheck/monotype_lifted/` shows one
+  definition.
+- Declined variants are counted and reportable per reason, and the
+  count is zero or explained for the corpus.
+- Debug assertions cover the store-slice-across-append and
+  double-clone hazards, with a test that trips each.
+- `git diff test/snapshots` is empty and SpecConstr's lifted program
+  size on a corpus is unchanged or smaller—measured on the lifted
+  program, not the resulting LIR.
+
+## How to evaluate the result
+
+### Correctness ideal
+
+A new Monotype Lifted expression variant cannot be half-supported. The
+two cloning *policies* stay honest about what they decline, and the
+mechanics that both bug fixes in this file's history were about—append
+invalidation and double cloning—are asserted in one place instead of
+being properties of two hand-written switches.
+
+### Performance ideal
+
+This is a compile-time-only pass, and the risk is real in both
+directions. Upside: `cloneExprFresh`'s 15 silently-declined variants
+are today's dropped specializations; handling any of them may improve
+generated code, and step 3's counter tells you which are worth
+handling. Downside: SpecConstr is a known compile-time hot spot with a
+history of superlinear blowups, so the shared traversal must not add
+per-node work or allocation. Measure lifted-program expression count
+and post-check phase timing (`checked_pipeline.zig`'s `spec_constr`
+counter) over a fixed corpus before and after, and treat any growth in
+either as a defect to explain before landing.
+
+## Tests to add
+
+- A comptime assertion that the shared traversal handles every
+  `Ast.ExprData`, `Ast.PatData`, and `Ast.StmtData` variant.
+- A test per policy asserting the decline set is exactly what is
+  intended, so a variant silently entering or leaving it fails.
+- Regression pins for the two encoded hazards: a nested call chain
+  that would double-clone, and a clone sequence that would invalidate
+  a held store slice.
+- Lifted-program-size pins on the SpecConstr corpus.
+
+## Related projects
+
+- [spec-constr-specialization-limits.md](spec-constr-specialization-limits.md)—
+  termination budgets for the same pass; land either first, but the
+  budget work is easier once there is one traversal to budget.
+- [postcheck-ir-store-boilerplate.md](postcheck-ir-store-boilerplate.md)—
+  the storage layer beneath this traversal.
+- [lift-capture-single-sourcing.md](lift-capture-single-sourcing.md)—
+  the other `monotype_lifted` single-sourcing project; `bindPat`
+  (step 4) touches the same file.

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -2972,6 +2972,37 @@ pub const CheckedPrimitive = enum(u8) {
     i64x2,
 };
 
+/// The builtin owner a primitive dispatches through. This is the single source
+/// of truth shared by every post-check consumer; call it rather than writing a
+/// second switch over `CheckedPrimitive`.
+pub fn builtinOwnerForPrimitive(primitive: CheckedPrimitive) static_dispatch.BuiltinOwner {
+    return switch (primitive) {
+        .bool => .bool,
+        .str => .str,
+        .u8 => .u8,
+        .i8 => .i8,
+        .u16 => .u16,
+        .i16 => .i16,
+        .u32 => .u32,
+        .i32 => .i32,
+        .u64 => .u64,
+        .i64 => .i64,
+        .u128 => .u128,
+        .i128 => .i128,
+        .f32 => .f32,
+        .f64 => .f64,
+        .dec => .dec,
+        .u8x16 => .u8x16,
+        .i8x16 => .i8x16,
+        .u16x8 => .u16x8,
+        .i16x8 => .i16x8,
+        .u32x4 => .u32x4,
+        .i32x4 => .i32x4,
+        .u64x2 => .u64x2,
+        .i64x2 => .i64x2,
+    };
+}
+
 /// Public `CheckedBuiltinRuntimeEncoding` declaration.
 pub const CheckedBuiltinRuntimeEncoding = union(enum) {
     primitive: CheckedPrimitive,

--- a/src/postcheck/boxy/layouts.zig
+++ b/src/postcheck/boxy/layouts.zig
@@ -10,7 +10,14 @@ const std = @import("std");
 const check = @import("check");
 const layout = @import("layout");
 
+const Common = @import("../common.zig");
 const Plan = @import("plan.zig");
+const test_fixtures = @import("test_fixtures.zig");
+
+/// Shared Boxy stage-test fixtures, aliased so every stage builds the same
+/// synthetic checked payloads from one definition.
+const fixtureTableIndex = test_fixtures.tableIndex;
+const builtinNominal = test_fixtures.builtinNominal;
 
 const Allocator = std.mem.Allocator;
 const checked = check.CheckedModule;
@@ -444,7 +451,7 @@ const Builder = struct {
                 } },
                 .host => .{ .concrete = try self.dynamicStorageLayout() },
             },
-            .primitive => |primitive| .{ .concrete = primitiveLayout(primitive) },
+            .primitive => |primitive| .{ .concrete = Common.primitiveLayout(primitive) },
             .bool_tag_union => .{ .concrete = .bool },
             .empty_record, .empty_tag_union => .{ .concrete = .zst },
             .erased_callable => .{ .concrete = try self.store.insertErasedCallable() },
@@ -879,34 +886,6 @@ const GraphBuilder = struct {
     }
 };
 
-fn primitiveLayout(primitive: checked.CheckedPrimitive) layout.Idx {
-    return switch (primitive) {
-        .bool => .bool,
-        .str => .str,
-        .u8 => .u8,
-        .i8 => .i8,
-        .u16 => .u16,
-        .i16 => .i16,
-        .u32 => .u32,
-        .i32 => .i32,
-        .u64 => .u64,
-        .i64 => .i64,
-        .u128 => .u128,
-        .i128 => .i128,
-        .f32 => .f32,
-        .f64 => .f64,
-        .dec => .dec,
-        .u8x16 => .u8x16,
-        .i8x16 => .i8x16,
-        .u16x8 => .u16x8,
-        .i16x8 => .i16x8,
-        .u32x4 => .u32x4,
-        .i32x4 => .i32x4,
-        .u64x2 => .u64x2,
-        .i64x2 => .i64x2,
-    };
-}
-
 fn repHasRecordFields(program: *const Plan.ProgramPlan, rep: Plan.TypeRepresentation) bool {
     for (program.childSlice(rep.children)) |child| {
         if (child.role == .record_field) return true;
@@ -939,11 +918,6 @@ fn boxyLayoutInvariant(comptime message: []const u8) noreturn {
         std.debug.panic("boxy layout invariant violated: {s}", .{message});
     }
     unreachable;
-}
-
-/// Convert an intentional fixture-table position while preserving enum inference.
-fn fixtureTableIndex(comptime index: u32) u32 {
-    return index;
 }
 
 test "boxy layout planner records dynamic worker boxes separately from storage layout" {
@@ -1340,20 +1314,4 @@ test "boxy layout planner reuses structural backing order without padding" {
     try std.testing.expectEqual(@as(u32, 0), store.getStructFieldOffsetByOriginalIndex(struct_idx, 0));
     try std.testing.expectEqual(@as(u32, 4), store.getStructFieldOffsetByOriginalIndex(struct_idx, 1));
     try std.testing.expectEqual(@as(u32, 8), store.getStructSize(struct_idx));
-}
-
-fn builtinNominal(
-    builtin: checked.CheckedBuiltinNominal,
-    _: checked.CheckedTypeId,
-    args: checked.CheckedTypeRange,
-) checked.StoredNominal {
-    return .{
-        .name = @enumFromInt(fixtureTableIndex(0)),
-        .origin_module = @enumFromInt(fixtureTableIndex(0)),
-        .owner_module = .{},
-        .builtin = builtin,
-        .is_opaque = false,
-        .representation = .{ .builtin = builtin },
-        .args = args,
-    };
 }

--- a/src/postcheck/boxy/lower.zig
+++ b/src/postcheck/boxy/lower.zig
@@ -17,6 +17,12 @@ const types = @import("types");
 const Common = @import("../common.zig");
 const Layouts = @import("layouts.zig");
 const Plan = @import("plan.zig");
+const test_fixtures = @import("test_fixtures.zig");
+
+/// Shared Boxy stage-test fixtures, aliased so every stage builds the same
+/// synthetic checked payloads from one definition.
+const fixtureTableIndex = test_fixtures.tableIndex;
+const builtinNominal = test_fixtures.builtinNominal;
 const solved_lir_lower = @import("../solved_lir_lower.zig");
 
 const Allocator = std.mem.Allocator;
@@ -27860,7 +27866,7 @@ const ProcBodyBuilder = struct {
         if (primitive == .bool) {
             return try self.lowerBoolInspectLocalsInto(target, source, next);
         }
-        const op = primitiveInspectLowLevelOp(primitive);
+        const op = Common.primitiveInspectLowLevelOp(primitive);
         return try self.parent.result.store.addCFStmt(.{ .assign_low_level = .{
             .target = target,
             .op = op,
@@ -29037,7 +29043,7 @@ const ProcBodyBuilder = struct {
         primitive: checked.CheckedPrimitive,
         next: LIR.CFStmtId,
     ) Allocator.Error!LIR.CFStmtId {
-        const op = hasherWriteOp(primitive);
+        const op = Common.hasherWriteOp(primitive);
         return try self.parent.result.store.addCFStmt(.{ .assign_low_level = .{
             .target = target,
             .op = op,
@@ -36365,64 +36371,6 @@ const ProcBodyBuilder = struct {
         return @intCast(count);
     }
 
-    fn hasherWriteOp(primitive: checked.CheckedPrimitive) LIR.LowLevel {
-        return switch (primitive) {
-            .bool => .hasher_write_bool,
-            .str => .hasher_write_str,
-            .u8 => .hasher_write_u8,
-            .i8 => .hasher_write_i8,
-            .u16 => .hasher_write_u16,
-            .i16 => .hasher_write_i16,
-            .u32 => .hasher_write_u32,
-            .i32 => .hasher_write_i32,
-            .u64 => .hasher_write_u64,
-            .i64 => .hasher_write_i64,
-            .u128 => .hasher_write_u128,
-            .i128 => .hasher_write_i128,
-            .f32 => .hasher_write_f32,
-            .f64 => .hasher_write_f64,
-            .dec => .hasher_write_dec,
-            .u8x16,
-            .i8x16,
-            .u16x8,
-            .i16x8,
-            .u32x4,
-            .i32x4,
-            .u64x2,
-            .i64x2,
-            => .hasher_write_u128,
-        };
-    }
-
-    fn primitiveInspectLowLevelOp(primitive: checked.CheckedPrimitive) LIR.LowLevel {
-        return switch (primitive) {
-            .bool => boxyLowerInvariant("Bool inspect must lower through tag-union inspect"),
-            .str => .str_inspect,
-            .u8 => .u8_to_str,
-            .i8 => .i8_to_str,
-            .u16 => .u16_to_str,
-            .i16 => .i16_to_str,
-            .u32 => .u32_to_str,
-            .i32 => .i32_to_str,
-            .u64 => .u64_to_str,
-            .i64 => .i64_to_str,
-            .u128 => .u128_to_str,
-            .i128 => .i128_to_str,
-            .f32 => .f32_to_str,
-            .f64 => .f64_to_str,
-            .dec => .dec_to_str,
-            .u8x16,
-            .i8x16,
-            .u16x8,
-            .i16x8,
-            .u32x4,
-            .i32x4,
-            .u64x2,
-            .i64x2,
-            => boxyLowerInvariant("SIMD inspect must lower through its explicit Builtin body"),
-        };
-    }
-
     const RecordFieldAccessInfo = struct {
         record_rep: Plan.TypeRepId,
         field_idx: u16,
@@ -37831,11 +37779,6 @@ test "descriptor materialization captures close over recursive template graphs" 
     const captures = result.store.getLocalSpan(assign.captures);
     try std.testing.expectEqual(@as(usize, 1), GuardedList.borrowLen(captures));
     try std.testing.expectEqual(captured, GuardedList.at(captures, 0));
-}
-
-/// Convert an intentional fixture-table position while preserving enum inference.
-fn fixtureTableIndex(comptime index: u32) u32 {
-    return index;
 }
 
 test "boxy lowerer returns an empty LIR program for an empty plan" {
@@ -46757,22 +46700,6 @@ fn testModuleIdentity() checked.ModuleIdentity {
         .display_module_name = @enumFromInt(fixtureTableIndex(0)),
         .qualified_module_name = @enumFromInt(fixtureTableIndex(0)),
         .kind = .module,
-    };
-}
-
-fn builtinNominal(
-    builtin: checked.CheckedBuiltinNominal,
-    _: checked.CheckedTypeId,
-    args: checked.CheckedTypeRange,
-) checked.StoredNominal {
-    return .{
-        .name = @enumFromInt(fixtureTableIndex(0)),
-        .origin_module = @enumFromInt(fixtureTableIndex(0)),
-        .owner_module = .{},
-        .builtin = builtin,
-        .is_opaque = false,
-        .representation = .{ .builtin = builtin },
-        .args = args,
     };
 }
 

--- a/src/postcheck/boxy/mod.zig
+++ b/src/postcheck/boxy/mod.zig
@@ -7,6 +7,9 @@ pub const Plan = @import("plan.zig");
 pub const Layouts = @import("layouts.zig");
 pub const Lower = @import("lower.zig");
 
+/// Shared checked-type fixtures for the Boxy stage tests.
+pub const TestFixtures = @import("test_fixtures.zig");
+
 test "boxy declarations are referenced" {
     @import("std").testing.refAllDecls(@This());
 }

--- a/src/postcheck/boxy/plan.zig
+++ b/src/postcheck/boxy/plan.zig
@@ -10,6 +10,12 @@ const can = @import("can");
 const check = @import("check");
 const collections = @import("collections");
 const Common = @import("../common.zig");
+const test_fixtures = @import("test_fixtures.zig");
+
+/// Shared Boxy stage-test fixtures, aliased so every stage builds the same
+/// synthetic checked payloads from one definition.
+const fixtureTableIndex = test_fixtures.tableIndex;
+const builtinNominal = test_fixtures.builtinNominal;
 
 const Allocator = std.mem.Allocator;
 const checked = check.CheckedModule;
@@ -12263,11 +12269,6 @@ fn boxyPlanInvariant(comptime message: []const u8) noreturn {
     unreachable;
 }
 
-/// Convert an intentional fixture-table position while preserving enum inference.
-fn fixtureTableIndex(comptime index: u32) u32 {
-    return index;
-}
-
 test "boxy planner records root wrapper plans from checked root metadata" {
     const gpa = std.testing.allocator;
 
@@ -14001,22 +14002,6 @@ test "boxy planner records imported box payload capability source modules" {
     try expectTypeRef(source_key, @enumFromInt(5), fields[1].source_type);
     try std.testing.expectEqual(@as(u16, 1), fields[2].index);
     try expectTypeRef(source_key, @enumFromInt(1), fields[2].source_type);
-}
-
-fn builtinNominal(
-    builtin: checked.CheckedBuiltinNominal,
-    _: checked.CheckedTypeId,
-    args: checked.CheckedTypeRange,
-) checked.StoredNominal {
-    return .{
-        .name = @enumFromInt(fixtureTableIndex(0)),
-        .origin_module = @enumFromInt(fixtureTableIndex(0)),
-        .owner_module = .{},
-        .builtin = builtin,
-        .is_opaque = false,
-        .representation = .{ .builtin = builtin },
-        .args = args,
-    };
 }
 
 fn moduleKey(byte: u8) checked.ModuleId {

--- a/src/postcheck/boxy/test_fixtures.zig
+++ b/src/postcheck/boxy/test_fixtures.zig
@@ -1,0 +1,30 @@
+//! Shared checked-type fixtures for the Boxy planning, layout, and lowering
+//! tests. The three stages build the same synthetic checked payloads, so the
+//! builders live here once rather than being copied into each test section.
+
+const check = @import("check");
+
+const checked = check.CheckedModule;
+
+/// Index into a fixture-local table, named so the literal reads as a table
+/// position rather than a magic number.
+pub fn tableIndex(comptime index: u32) u32 {
+    return index;
+}
+
+/// A stored nominal for a builtin type, rooted at the fixture tables.
+pub fn builtinNominal(
+    builtin: checked.CheckedBuiltinNominal,
+    _: checked.CheckedTypeId,
+    args: checked.CheckedTypeRange,
+) checked.StoredNominal {
+    return .{
+        .name = @enumFromInt(tableIndex(0)),
+        .origin_module = @enumFromInt(tableIndex(0)),
+        .owner_module = .{},
+        .builtin = builtin,
+        .is_opaque = false,
+        .representation = .{ .builtin = builtin },
+        .args = args,
+    };
+}

--- a/src/postcheck/common.zig
+++ b/src/postcheck/common.zig
@@ -3,8 +3,8 @@
 const std = @import("std");
 const base = @import("base");
 const check = @import("check");
+const layout = @import("layout");
 const lir_core = @import("lir_core");
-const MonoType = @import("monotype/type.zig");
 
 const checked = check.CheckedModule;
 const LIR = lir_core.LIR;
@@ -98,10 +98,69 @@ pub const ErasedFnsId = enum(u32) { _ };
 /// Stage-local capture slot id.
 pub const CaptureSlotId = enum(u32) { _ };
 
-/// The `Builtin.Hasher.write_*` low-level op that feeds a primitive scalar of
-/// the given monotype into a Hasher. Aggregate types are decomposed in Monotype
-/// lowering, so only primitive leaves ever reach direct hash lowering.
-pub fn hasherWriteOp(primitive: MonoType.Primitive) LIR.LowLevel {
+/// The storage layout of a primitive. This is the single source of truth
+/// shared by every post-check layout producer; call it rather than writing a
+/// second switch over `CheckedPrimitive`.
+pub fn primitiveLayout(primitive: checked.CheckedPrimitive) layout.Idx {
+    return switch (primitive) {
+        .bool => .bool,
+        .str => .str,
+        .u8 => .u8,
+        .i8 => .i8,
+        .u16 => .u16,
+        .i16 => .i16,
+        .u32 => .u32,
+        .i32 => .i32,
+        .u64 => .u64,
+        .i64 => .i64,
+        .u128 => .u128,
+        .i128 => .i128,
+        .f32 => .f32,
+        .f64 => .f64,
+        .dec => .dec,
+        .u8x16 => .u8x16,
+        .i8x16 => .i8x16,
+        .u16x8 => .u16x8,
+        .i16x8 => .i16x8,
+        .u32x4 => .u32x4,
+        .i32x4 => .i32x4,
+        .u64x2 => .u64x2,
+        .i64x2 => .i64x2,
+    };
+}
+
+/// The low-level op that renders a primitive scalar as a `Str`. This is the
+/// single source of truth shared by every post-check inspect lowering; call it
+/// rather than writing a second switch over `CheckedPrimitive`. Bool renders
+/// through ordinary tag-union inspect and the SIMD vectors render through their
+/// explicit `Builtin` bodies, so neither reaches this table.
+pub fn primitiveInspectLowLevelOp(primitive: checked.CheckedPrimitive) LIR.LowLevel {
+    return switch (primitive) {
+        .str => .str_inspect,
+        .u8 => .u8_to_str,
+        .i8 => .i8_to_str,
+        .u16 => .u16_to_str,
+        .i16 => .i16_to_str,
+        .u32 => .u32_to_str,
+        .i32 => .i32_to_str,
+        .u64 => .u64_to_str,
+        .i64 => .i64_to_str,
+        .u128 => .u128_to_str,
+        .i128 => .i128_to_str,
+        .f32 => .f32_to_str,
+        .f64 => .f64_to_str,
+        .dec => .dec_to_str,
+        .u8x16, .i8x16, .u16x8, .i16x8, .u32x4, .i32x4, .u64x2, .i64x2 => invariant("SIMD inspect must lower through its explicit Builtin body"),
+        .bool => invariant("Bool must lower as an ordinary tag union before Str.inspect"),
+    };
+}
+
+/// The `Builtin.Hasher.write_*` low-level op that feeds a primitive scalar into
+/// a Hasher. Aggregate types are decomposed before direct hash lowering, so only
+/// primitive leaves ever reach this table. This is the single source of truth
+/// shared by every post-check hash lowering; call it rather than writing a
+/// second switch over `CheckedPrimitive`.
+pub fn hasherWriteOp(primitive: checked.CheckedPrimitive) LIR.LowLevel {
     return switch (primitive) {
         .bool => .hasher_write_bool,
         .str => .hasher_write_str,

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -8879,7 +8879,7 @@ const Builder = struct {
 
     fn primitiveInspect(self: *Builder, value: Ast.ExprId, primitive: Type.Primitive, str_ty: Type.TypeId) Allocator.Error!Ast.ExprId {
         const args = [_]Ast.ExprId{value};
-        return try self.lowLevelExpr(primitiveInspectLowLevelOp(primitive), &args, str_ty);
+        return try self.lowLevelExpr(Common.primitiveInspectLowLevelOp(primitive), &args, str_ty);
     }
 
     fn inspectTuple(self: *Builder, value: Ast.ExprId, items: anytype, str_ty: Type.TypeId) Allocator.Error!Ast.ExprId {
@@ -14889,7 +14889,7 @@ const BodyContext = struct {
 
     fn primitiveInspect(self: *BodyContext, value: DraftExprId, primitive: Type.Primitive, str_ty: Type.TypeId) Allocator.Error!DraftExprId {
         const args = [_]DraftExprId{value};
-        return try self.lowLevelExpr(primitiveInspectLowLevelOp(primitive), &args, str_ty);
+        return try self.lowLevelExpr(Common.primitiveInspectLowLevelOp(primitive), &args, str_ty);
     }
 
     fn inspectTuple(self: *BodyContext, value: DraftExprId, items: anytype, str_ty: Type.TypeId) Allocator.Error!DraftExprId {
@@ -36453,7 +36453,7 @@ const BodyContext = struct {
     ) ?static_dispatch.MethodOwner {
         return switch (self.graph.content(node)) {
             .redirect => unreachable,
-            .primitive => |primitive| .{ .builtin = builtinOwnerFromPrimitive(primitive) },
+            .primitive => |primitive| .{ .builtin = checked.builtinOwnerForPrimitive(primitive) },
             .list => .{ .builtin = .list },
             .box => .{ .builtin = .box },
             .named => |named| if (named.builtin_owner) |owner|
@@ -50556,34 +50556,6 @@ fn instRecordFieldLessThan(
     return name_store.recordFieldLabelTextLessThan(lhs.name, rhs.name);
 }
 
-fn builtinOwnerFromPrimitive(primitive: Type.Primitive) static_dispatch.BuiltinOwner {
-    return switch (primitive) {
-        .bool => .bool,
-        .str => .str,
-        .u8 => .u8,
-        .i8 => .i8,
-        .u16 => .u16,
-        .i16 => .i16,
-        .u32 => .u32,
-        .i32 => .i32,
-        .u64 => .u64,
-        .i64 => .i64,
-        .u128 => .u128,
-        .i128 => .i128,
-        .f32 => .f32,
-        .f64 => .f64,
-        .dec => .dec,
-        .u8x16 => .u8x16,
-        .i8x16 => .i8x16,
-        .u16x8 => .u16x8,
-        .i16x8 => .i16x8,
-        .u32x4 => .u32x4,
-        .i32x4 => .i32x4,
-        .u64x2 => .u64x2,
-        .i64x2 => .i64x2,
-    };
-}
-
 fn nominalHasDeclarationBacking(nominal: checked.CheckedNominalType) bool {
     return switch (nominal.representation) {
         .opaque_without_backing => false,
@@ -50652,27 +50624,6 @@ fn builtinOwner(builtin: ?checked.CheckedBuiltinNominal) ?static_dispatch.Builti
         .crypto_sha256_hasher => .crypto_sha256_hasher,
         .crypto_blake3_digest => .crypto_blake3_digest,
         .crypto_blake3_hasher => .crypto_blake3_hasher,
-    };
-}
-
-fn primitiveInspectLowLevelOp(primitive: Type.Primitive) can.CIR.Expr.LowLevel {
-    return switch (primitive) {
-        .str => .str_inspect,
-        .u8 => .u8_to_str,
-        .i8 => .i8_to_str,
-        .u16 => .u16_to_str,
-        .i16 => .i16_to_str,
-        .u32 => .u32_to_str,
-        .i32 => .i32_to_str,
-        .u64 => .u64_to_str,
-        .i64 => .i64_to_str,
-        .u128 => .u128_to_str,
-        .i128 => .i128_to_str,
-        .f32 => .f32_to_str,
-        .f64 => .f64_to_str,
-        .dec => .dec_to_str,
-        .u8x16, .i8x16, .u16x8, .i16x8, .u32x4, .i32x4, .u64x2, .i64x2 => Common.invariant("SIMD inspect must lower through its explicit Builtin body"),
-        .bool => Common.invariant("Bool must lower as an ordinary tag union before Str.inspect"),
     };
 }
 

--- a/src/postcheck/monotype/type.zig
+++ b/src/postcheck/monotype/type.zig
@@ -660,7 +660,7 @@ pub const Store = struct {
 
     pub fn ownerHead(self: *const Store, ty: TypeId) OwnerHead {
         return switch (self.get(ty)) {
-            .primitive => |primitive| .{ .builtin = builtinOwner(primitive) },
+            .primitive => |primitive| .{ .builtin = checked.builtinOwnerForPrimitive(primitive) },
             .list => .{ .builtin = .list },
             .box => .{ .builtin = .box },
             .named => |named| if (named.builtin_owner) |owner|
@@ -2978,34 +2978,6 @@ fn optionalDigestEql(lhs: ?names.TypeDigest, rhs: ?names.TypeDigest) bool {
         return std.mem.eql(u8, lhs_digest.bytes[0..], rhs_digest.bytes[0..]);
     }
     return rhs == null;
-}
-
-fn builtinOwner(primitive: Primitive) static_dispatch.BuiltinOwner {
-    return switch (primitive) {
-        .bool => .bool,
-        .str => .str,
-        .u8 => .u8,
-        .i8 => .i8,
-        .u16 => .u16,
-        .i16 => .i16,
-        .u32 => .u32,
-        .i32 => .i32,
-        .u64 => .u64,
-        .i64 => .i64,
-        .u128 => .u128,
-        .i128 => .i128,
-        .f32 => .f32,
-        .f64 => .f64,
-        .dec => .dec,
-        .u8x16 => .u8x16,
-        .i8x16 => .i8x16,
-        .u16x8 => .u16x8,
-        .i16x8 => .i16x8,
-        .u32x4 => .u32x4,
-        .i32x4 => .i32x4,
-        .u64x2 => .u64x2,
-        .i64x2 => .i64x2,
-    };
 }
 
 test "monotype type declarations are referenced" {

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -9028,7 +9028,7 @@ const Lowerer = struct {
             if (self.local_nodes.get(ty)) |node| return layout.localGraphInput(node);
 
             switch (self.lowerer.types.get(ty)) {
-                .primitive => |primitive| return layout.committedGraphInput(primitiveLayout(primitive)),
+                .primitive => |primitive| return layout.committedGraphInput(Common.primitiveLayout(primitive)),
                 .zst => return layout.committedGraphInput(.zst),
                 .erased_capture_ptr => return layout.committedGraphInput(.opaque_ptr),
                 .named => |named| if (named.builtin_owner) |owner| {
@@ -9255,34 +9255,6 @@ const Lowerer = struct {
             };
         }
     };
-
-    fn primitiveLayout(primitive: MonoType.Primitive) layout.Idx {
-        return switch (primitive) {
-            .bool => .bool,
-            .str => .str,
-            .u8 => .u8,
-            .i8 => .i8,
-            .u16 => .u16,
-            .i16 => .i16,
-            .u32 => .u32,
-            .i32 => .i32,
-            .u64 => .u64,
-            .i64 => .i64,
-            .u128 => .u128,
-            .i128 => .i128,
-            .f32 => .f32,
-            .f64 => .f64,
-            .dec => .dec,
-            .u8x16 => .u8x16,
-            .i8x16 => .i8x16,
-            .u16x8 => .u16x8,
-            .i16x8 => .i16x8,
-            .u32x4 => .u32x4,
-            .i32x4 => .i32x4,
-            .u64x2 => .u64x2,
-            .i64x2 => .i64x2,
-        };
-    }
 
     fn builtinOwnerLayout(owner: check.StaticDispatchRegistry.BuiltinOwner) ?layout.Idx {
         return switch (owner) {

--- a/src/postcheck/structural_test.zig
+++ b/src/postcheck/structural_test.zig
@@ -1449,6 +1449,71 @@ test "direct LIR verification consumes producer-owned specialization identities"
     try expectContains(direct_lower, "different types for an exact function specialization");
 }
 
+fn countDefinitions(source: []const u8, decl: []const u8) usize {
+    var count: usize = 0;
+    var rest = source;
+    while (std.mem.find(u8, rest, decl)) |index| {
+        count += 1;
+        rest = rest[index + decl.len ..];
+    }
+    return count;
+}
+
+test "each primitive mapping has exactly one definition" {
+    // `MonoType.Primitive` is an alias of `checked.CheckedPrimitive`
+    // (monotype/type.zig), so nothing in the type system stops a consumer from
+    // writing a second switch over the same 24 members. These tables are the
+    // single source of truth; a copy would let two lowering paths decide a
+    // layout, hasher op, or inspect op differently for the same primitive.
+    const sources = [_][]const u8{
+        @embedFile("common.zig"),
+        @embedFile("monotype/type.zig"),
+        @embedFile("monotype/lower.zig"),
+        @embedFile("solved_lir_lower.zig"),
+        @embedFile("boxy/lower.zig"),
+        @embedFile("boxy/plan.zig"),
+        @embedFile("boxy/layouts.zig"),
+    };
+    const single_definition = [_][]const u8{
+        "fn primitiveLayout(",
+        "fn primitiveInspectLowLevelOp(",
+        "fn hasherWriteOp(",
+    };
+    for (single_definition) |decl| {
+        var total: usize = 0;
+        for (sources) |source| total += countDefinitions(source, decl);
+        try std.testing.expectEqual(@as(usize, 1), total);
+    }
+    try expectContains(@embedFile("common.zig"), "pub fn primitiveLayout(");
+    try expectContains(@embedFile("common.zig"), "pub fn primitiveInspectLowLevelOp(");
+    try expectContains(@embedFile("common.zig"), "pub fn hasherWriteOp(");
+
+    // The primitive-to-owner table lives beside `CheckedPrimitive` itself, so
+    // post-check holds no definition of it at all and consumes the checked one.
+    for (sources) |source| {
+        try expectNotContains(source, "fn builtinOwnerForPrimitive(");
+        try expectNotContains(source, "fn builtinOwnerFromPrimitive(");
+    }
+    const owner_fn = @typeInfo(@TypeOf(check.CheckedModule.builtinOwnerForPrimitive)).@"fn";
+    try std.testing.expect(owner_fn.params.len == 1);
+    try std.testing.expect(owner_fn.params[0].type.? == check.CheckedModule.CheckedPrimitive);
+    try std.testing.expect(owner_fn.return_type.? == check.StaticDispatchRegistry.BuiltinOwner);
+}
+
+test "boxy stage tests share one set of checked-type fixtures" {
+    const sources = [_][]const u8{
+        @embedFile("boxy/lower.zig"),
+        @embedFile("boxy/plan.zig"),
+        @embedFile("boxy/layouts.zig"),
+    };
+    for (sources) |source| {
+        try expectNotContains(source, "fn builtinNominal(");
+        try expectNotContains(source, "fn fixtureTableIndex(");
+    }
+    try expectContains(@embedFile("boxy/test_fixtures.zig"), "pub fn builtinNominal(");
+    try expectContains(@embedFile("boxy/test_fixtures.zig"), "pub fn tableIndex(");
+}
+
 test "post-check invariant helper is failure-only" {
     const fn_info = @typeInfo(@TypeOf(Common.invariant)).@"fn";
     try std.testing.expect(fn_info.return_type.? == noreturn);


### PR DESCRIPTION
A duplication audit of the stages between type checking and code generation, plus the first project it produced.

The audit (`projects/`) swept Monotype, Monotype Lifted, SpecConstr, Lambda Solved, both LIR lowerers, the LIR passes, and ARC looking for multiple implementations of one semantic rule rather than for repeated text. It produced two `big` projects and six `small` ones. The recurring shape is that `.lss` and `.boxy` were scoped by the phases they skip, but value semantics — equality, hashing, `Inspect`, `match` compilation — are not phase artifacts and got duplicated along with the phases; and several producer/consumer boundaries that design.md states as "record the decision, consume it later" are implemented as "re-derive it from the emitted shape". Several of the pairs found have already diverged in behavior, not only in text: `Builder.toInspectCall` and `BodyContext.toInspectCall` in `monotype/lower.zig` support different method-target kinds, `childRolesMatch` exists three times in boxy with two different exhaustiveness postures, and `arc.zig` and `arc_solve.zig` compute `computeLocalContainsRefcounted` differently. `Inspect` rendering turns out to have four independent implementations, each with its own copy of the format literals.

The audit also corrects the README's decision-tree match compiler note. That project landed for `.lss` only: `grep -rn match_tree src/postcheck/boxy/` is empty and `boxy/lower.zig` folds match branches into a sequential chain, so `src/postcheck/mod.zig`'s "shared by both LIR lowerers" comment is not yet true. Closing that gap is a step of `big/one-value-semantics-layer.md`.

The second commit implements the batch's first project. `CheckedPrimitive`'s four post-check mappings each had two definitions: `primitiveLayout` (`solved_lir_lower.zig` and `boxy/layouts.zig`, byte-identical), the primitive-to-owner table (`builtinOwner` in `monotype/type.zig` and `builtinOwnerFromPrimitive` in `monotype/lower.zig`, byte-identical under two names), `hasherWriteOp`, and `primitiveInspectLowLevelOp`. None of the copies was forced by a type barrier — `monotype/type.zig` declares `pub const Primitive = checked.CheckedPrimitive`, so every pair took the same parameter type. The concrete hazard this removes: `hasherWriteOp` routes all eight SIMD vector primitives to `hasher_write_u128`, and that decision was written twice, so hashing could come to disagree between lowering strategies. The three post-check tables move to `src/postcheck/common.zig`, which already existed for exactly this and already held one of them; the owner table moves beside `CheckedPrimitive` in `src/check/checked_artifact.zig`, since it and `BuiltinOwner` are both checker-owned. A `structural_test.zig` lint fails the build if a second definition appears. The Boxy stage tests' three byte-identical `builtinNominal`/`fixtureTableIndex` fixtures move to `boxy/test_fixtures.zig`, aliased at each use site so no call site changes.

Unrelated, but found while verifying: `zig build` is currently broken on `main`. `DefaultPlatformObjects.forTarget` (`src/cli/main.zig:704`) is missing `.x64mingw` and `.arm64mingw` arms, which `ed5841450a` added to `RocTarget`; the sibling struct below it got them and this one did not. Nothing in this branch touches that file.