### PR TITLE
One record equality lowering, and a corrected eq/hash claim

### DIFF
--- a/projects/big/one-value-semantics-layer.md
+++ b/projects/big/one-value-semantics-layer.md
@@ -43,18 +43,30 @@ weaker copy was dead and has been deleted rather than merged. Three
 implementations remain, and the audit's original claim that inspect
 behavior depended on which context derived it was wrong.
 
-**Structural equality and hashing—two implementations.**
-`solved_lir_lower.zig:4882` (`lowerStructuralEqInto`), `:4891`
-(`lowerStructuralHashInto`), `:4903` (`lowerHashLocalsInto`), `:4925`
-(`lowerPrimitiveHashLocalsInto`), `:6986` (`lowerEqLocalsInto`),
-`:7002` / `:7074` / `:7090` / `:7130` / `:7149` / `:7182` / `:7239`
-(the primitive/bool/record/tuple/field/tag-union/tag-payload arms)
-are each mirrored in `boxy/lower.zig` at `:28406`, `:28957`,
-`:29032`, `:28614`, `:28713`, `:28736`, `:28765`, `:28794`, `:28832`,
-`:28892`. Normalized-body similarity across those pairs ranges from
-0.96 (`lowerBoolEqLocalsInto`, still in sync) down to 0.18
-(`lowerTagPayloadEqVariant`, already diverged). These define what `==`
-and `hash` *mean* for aggregates.
+**Structural equality and hashing—two implementations that currently
+agree.** The `lowerEqLocalsInto` / `lowerHashLocalsInto` families in
+`solved_lir_lower.zig` are mirrored arm for arm in `boxy/lower.zig`:
+primitive, bool, record, tuple, field-step, tag-union, tag-payload, and
+the hash counterparts. Roughly 20 function pairs define what `==` and
+`hash` *mean* for aggregates, in two places.
+
+An earlier draft of this doc called several of those pairs "already
+diverged", citing normalized-body similarity as low as 0.18. That was
+wrong, and the way it was wrong is worth recording: the metric was
+measuring receiver plumbing (`self.result.store` versus
+`self.parent.result.store`), helper choice (`assignRefRead` versus an
+inlined `assign_ref`), and `if`-chains expanded into exhaustive
+switches. Reading the pairs shows the same algorithm on both sides—the
+same right-to-left AND fold over a shared `failed` target, the same
+ZST skip, the same SIMD-to-`u128` bit comparison, the same op tables.
+The genuine differences are forced by the input: LSS walks a monotype
+span, `.boxy` walks `RepChild` roles.
+
+So this is duplication without present divergence: a standing drift
+risk across ~20 pairs, not a live bug. It should still be single-sourced
+by step 5, but it does not carry the urgency the `Inspect` or
+`match` items do. **Text similarity is not semantic divergence**—check
+by reading, and check reachability, before filing a pair as diverged.
 
 **`match`—the shared decision-tree compiler has one user, not two.**
 `src/postcheck/mod.zig:37` documents `match_tree.zig` as the

--- a/src/postcheck/solved_lir_lower.zig
+++ b/src/postcheck/solved_lir_lower.zig
@@ -6992,7 +6992,7 @@ const Lowerer = struct {
                 break :blk try self.lowerEqLocalsInto(target, lhs, rhs, backing.ty, negated, next);
             },
             .record => |fields| try self.lowerRecordEqLocalsInto(target, lhs, rhs, self.types.fieldSpan(fields), negated, next),
-            .capture_record => |fields| try self.lowerCaptureRecordEqLocalsInto(target, lhs, rhs, self.types.captureFieldSpan(fields), negated, next),
+            .capture_record => |fields| try self.lowerRecordEqLocalsInto(target, lhs, rhs, self.types.captureFieldSpan(fields), negated, next),
             .tuple => |items| try self.lowerTupleEqLocalsInto(target, lhs, rhs, self.types.span(items), negated, next),
             .tag_union => |tags| try self.lowerTagUnionEqLocalsInto(target, lhs, rhs, self.types.tagSpan(tags), negated, next),
             .list, .box, .callable, .erased_fn, .erased_capture_ptr => Common.invariant("non-structural equality reached direct LIR structural equality lowering"),
@@ -7087,27 +7087,11 @@ const Lowerer = struct {
         } });
     }
 
+    /// Compare two aggregates field by field, right to left so the AND fold
+    /// nests later fields inside earlier ones. `fields` is any span whose
+    /// entries carry a `ty`, which is why ordinary records and capture records
+    /// share this one lowering.
     fn lowerRecordEqLocalsInto(
-        self: *Lowerer,
-        target: LIR.LocalId,
-        lhs: LIR.LocalId,
-        rhs: LIR.LocalId,
-        fields: anytype,
-        negated: bool,
-        next: LIR.CFStmtId,
-    ) Common.LowerError!LIR.CFStmtId {
-        var current = try self.assignBool(target, !negated, next);
-        const failed = try self.assignBool(target, negated, next);
-        var i = fields.len;
-        while (i > 0) {
-            i -= 1;
-            const field = GuardedList.at(fields, i);
-            current = try self.lowerFieldEqStep(lhs, rhs, field.ty, @intCast(i), current, failed);
-        }
-        return current;
-    }
-
-    fn lowerCaptureRecordEqLocalsInto(
         self: *Lowerer,
         target: LIR.LocalId,
         lhs: LIR.LocalId,


### PR DESCRIPTION
Stacked on #10932.

`lowerCaptureRecordEqLocalsInto` was byte-identical to `lowerRecordEqLocalsInto`, and both are live — `lowerEqLocalsInto` dispatches `.record` to one and `.capture_record` to the other. The function already took its fields as `anytype`, so the callers differ only in which span they pass. One lowering now serves both.

**The larger result is a correction, and it is the point of the PR.** The audit claimed the equality and hashing families in `solved_lir_lower.zig` and `boxy/lower.zig` had "already diverged", citing normalized-body similarity as low as 0.18. Reading the pairs disproves it. The metric was measuring receiver plumbing (`self.result.store` vs `self.parent.result.store`), helper choice (`assignRefRead` vs an inlined `assign_ref`), and `if` chains expanded into exhaustive switches. `lowerPrimitiveEqLocalsInto`, `lowerFieldEqStep`, `lowerTupleEqLocalsInto`, and `lowerRecordEqLocalsInto` all run the same algorithm on both sides — same right-to-left AND fold over a shared `failed` target, same ZST skip, same SIMD-to-`u128` bit comparison, same op tables. What differs is forced by the input: LSS walks a monotype span, `.boxy` walks `RepChild` roles.

The two families therefore duplicate structure without presently disagreeing: a standing drift risk across ~20 pairs, not a live bug. That lowers this item's priority relative to `Inspect` and `match` within `one-value-semantics-layer`, and the doc is corrected to say so — including why the earlier reading was wrong, since the same mistake produced three other bad findings in this batch.

Verified: postcheck tests, tidy, zig lints, semantic audit, post-check architecture check all pass; 73 equality eval cases unchanged.