### PR TITLE
Type-store queries have one implementation

### DIFF
--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -4700,7 +4700,7 @@ const Builder = struct {
         const fields = switch (self.shapeContent(ty)) {
             .record => |span| self.program.types.fieldSpan(span),
             .zst => return null,
-            _ => return null,
+            .primitive, .named, .tuple, .tag_union, .list, .box, .func, .erased => return null,
         };
         for (0..GuardedList.borrowLen(fields)) |index| {
             const field = GuardedList.at(fields, index);
@@ -29156,18 +29156,16 @@ const BodyContext = struct {
         return try self.addExprSpan(lowered);
     }
 
+    /// Forwards to the scope that owns the type store; the query itself
+    /// has one implementation.
     fn constListElemType(self: *BodyContext, ty: Type.TypeId) Type.TypeId {
-        return switch (self.builder.shapeContent(ty)) {
-            .list => |elem| elem,
-            .primitive, .named, .record, .tuple, .tag_union, .box, .func, .erased, .zst => Common.invariant("ConstStore list restored with a non-list monotype"),
-        };
+        return self.builder.constListElemType(ty);
     }
 
+    /// Forwards to the scope that owns the type store; the query itself
+    /// has one implementation.
     fn constBoxPayloadType(self: *BodyContext, ty: Type.TypeId) Type.TypeId {
-        return switch (self.builder.shapeContent(ty)) {
-            .box => |payload| payload,
-            .primitive, .named, .record, .tuple, .tag_union, .list, .func, .erased, .zst => Common.invariant("ConstStore box restored with a non-box monotype"),
-        };
+        return self.builder.constBoxPayloadType(ty);
     }
 
     fn lowerConstCaptureType(
@@ -29377,8 +29375,10 @@ const BodyContext = struct {
         };
     }
 
+    /// Forwards to the scope that owns the type store; the query itself
+    /// has one implementation.
     fn constRecordFields(self: *BodyContext, ty: Type.TypeId) Type.StoreSpanBorrow(Type.Field, "fields") {
-        return self.builder.program.types.fieldSpan(self.builder.recordFieldsSpan(ty));
+        return self.builder.constRecordFields(ty);
     }
 
     fn restoreConstFnAtNode(
@@ -31328,17 +31328,10 @@ const BodyContext = struct {
         Common.invariant("expected record field id was absent from monotype type");
     }
 
+    /// Forwards to the scope that owns the type store; the query itself
+    /// has one implementation.
     fn recordFieldByTextOptional(self: *BodyContext, ty: Type.TypeId, text: []const u8) ?Type.Field {
-        const fields = switch (self.builder.shapeContent(ty)) {
-            .record => |span| self.builder.program.types.fieldSpan(span),
-            .zst => return null,
-            .primitive, .named, .tuple, .tag_union, .list, .box, .func, .erased => return null,
-        };
-        for (0..GuardedList.borrowLen(fields)) |index| {
-            const field = GuardedList.at(fields, index);
-            if (Ident.textEql(self.builder.program.names.recordFieldLabelText(field.name), text)) return field;
-        }
-        return null;
+        return self.builder.recordFieldByTextOptional(ty, text);
     }
 
     fn iterItemType(self: *BodyContext, ty: Type.TypeId) Type.TypeId {
@@ -34462,11 +34455,10 @@ const BodyContext = struct {
         };
     }
 
+    /// Forwards to the scope that owns the type store; the query itself
+    /// has one implementation.
     fn typeHasBuiltinOwner(self: *BodyContext, ty: Type.TypeId, owner: static_dispatch.BuiltinOwner) bool {
-        return switch (methodOwnerFromType(&self.builder.program.types, ty) orelse return false) {
-            .builtin => |actual| actual == owner,
-            .nominal => false,
-        };
+        return self.builder.typeHasBuiltinOwner(ty, owner);
     }
 
     fn setPayloadType(self: *BodyContext, ty: Type.TypeId) ?Type.TypeId {


### PR DESCRIPTION
Stacked on #10936. Finishes the `monotype/lower.zig` half of `postcheck-lowerer-decomposition`.

Five pure type-store queries existed in both `Builder` and `BodyContext` with *identical signatures*: `recordFieldByTextOptional`, `typeHasBuiltinOwner`, `constListElemType`, `constBoxPayloadType`, `constRecordFields`. None emits anything — each just reads the type store, which `Builder` owns. `BodyContext`'s copies become one-line forwarders, so there is one implementation and no call site moves (`typeHasBuiltinOwner` alone has 82).

**One had drifted.** `Builder`'s `recordFieldByTextOptional` ended its `shapeContent` switch in a `_ => return null` catch-all while `BodyContext`'s listed every variant, so a new `Content` variant would have compiled clean and silently answered "no such field" on one side only. The exhaustive version survives.

**Two neighbouring pairs deliberately did not merge**, and the reason is the one this batch keeps re-learning. `bindPatLocals` (0.98) and `stmtDependsOnFreeLocal` (0.85) look like duplicates, but they walk different IRs — `Ast.PatId`/`Ast.LocalId` against `DraftPatId`/`DraftLocalId`. Same shape over different node stores is justified difference, exactly like the equality lowerings that walk a monotype span on one side and representation children on the other. Merging them would need a comptime generic over the pattern store, which costs more than the ~65 lines it would save.

That leaves the `monotype/lower.zig` scope split at its justified core: what remains between the two structs is emit-side state and IR-specific walks. Verified: postcheck tests, tidy, zig lints, semantic audit, post-check architecture check all pass.