### PR TITLE
Keep loop-invariant join params out of the loop body keep

### DIFF
--- a/design.md
+++ b/design.md
@@ -9351,7 +9351,13 @@ statement scan.
 Join ownership is a must-property. Each reachable jump site contributes a
 state that can only shrink; a join summary maintains their running
 intersection incrementally, and recomputes the body keep-set from that exact
-meet plus the join parameters. A site contribution that shrinks without
+meet plus the join parameters the back edges rebind. A parameter counts as
+freshly owned in the body only when every arrival hands it a new unit: back
+edges are excluded from the general meet because they conform at emission by
+releasing down to the keep, but a parameter a back edge leaves alone re-enters
+the body still holding the value the previous iteration released, so the back
+edges maintain their own shrinking meet over the parameters and the body keep
+places only what survives it. A site contribution that shrinks without
 changing the global meet cannot schedule downstream work. Each loop identity
 records whether its solved rows consumed any keep bits. A keep change that
 supplied no boundary bits schedules no liveness work.

--- a/src/eval/test/lir_inline_test.zig
+++ b/src/eval/test/lir_inline_test.zig
@@ -3855,6 +3855,40 @@ fn expectReachableProcShapeFieldEqual(
     try std.testing.expectEqual(expected, actual);
 }
 
+// A loop-carried join param is only freshly owned inside the loop body when
+// every arrival to the join hands it a new unit. A record whose fields are
+// carried through a loop leaves the fields the back edge never rebinds holding
+// the value the entry edge produced, so releasing them in the body would run
+// one release per iteration against a value that only exists once. `state.b`
+// below is exactly such a field: the loop reads only `state.a`, and the back
+// edge rebinds only the counter and the accumulator.
+//
+// Regression: ARC placed every join param owned in the body keep unconditionally,
+// so the second iteration released an already-dead list. Debug builds catch this
+// as an `arc_certify` panic ("release of unbound local"); optimized builds
+// miscompiled into a use-after-free.
+test "ARC keeps a loop-invariant record field out of the loop body keep" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\State : { a : List(U64), b : List(U64) }
+        \\
+        \\count_from : State, U64, List(U64) -> List(U64)
+        \\count_from = |state, i, acc|
+        \\    if i == 0 acc else count_from(state, i - 1, List.append(acc, List.len(state.a)))
+        \\
+        \\main : U64
+        \\main = List.len(count_from({ a: [1, 2], b: [3, 4] }, 4, []))
+    ;
+
+    var lowered = try lowerModule(allocator, source, .wrappers);
+    defer lowered.deinit(allocator);
+
+    // Both lists and the accumulator are released exactly once each. Before the
+    // fix the invariant field's release sat inside the loop body instead.
+    const decrefs = try reachableProcShapeFieldTotal(allocator, &lowered.lowered, "decref_count");
+    try std.testing.expectEqual(@as(usize, 3), decrefs);
+}
+
 // A producer-authored concrete iterator representation must survive ordinary
 // procedure returns and all supported static-dispatch invocation forms. Each
 // case below must reach `sum_it` (the debug-name sanity probe), avoid the public

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -946,7 +946,11 @@ const ExactBitSet = struct {
 //   to units read in the shared body, then join params placed owned and
 //   maybe-initialized params placed conditionally, exactly like the
 //   emission-side keep construction. Seeded from above (all body-read units
-//   plus params) so descent stays monotone.
+//   plus params) so descent stays monotone. Params are placed only when the
+//   back edges also rebind them (`back_edge_params`): a param a back edge
+//   leaves alone re-enters the body holding the value the previous iteration
+//   already released, so treating it as freshly owned would release it once
+//   per iteration.
 // - body_reachable(J): whether any eligible jump contributed.
 // - switch common: intersection of branch exit states that reach the
 //   continuation statement without crossing a join frame.
@@ -969,6 +973,13 @@ const JoinSummary = struct {
     /// site. When one site shrinks, intersecting only that new state produces
     /// the exact new all-site meet.
     jump_common: OwnedSet,
+    /// Monotone meet of join-param ownership over the back edges (jumps that
+    /// sit inside this join's own body). A param that a back edge does not
+    /// re-initialize arrives at the body carrying the same value the previous
+    /// iteration already released, so it must not be placed owned in
+    /// `body_keep`; see `placeSolveJoinParamsInto`.
+    back_edge_params: OwnedSet,
+    back_edge_seen: bool = false,
     body_keep_seeded: bool = false,
     body_reachable: bool = false,
     loop_keep_id: u32,
@@ -3562,7 +3573,33 @@ const Inserter = struct {
         self.placeSolveJoinParamsInto(summary, &summary.body_keep);
     }
 
+    /// Places a join's params owned, skipping any the back edges leave
+    /// loop-invariant.
+    ///
+    /// A join param is only freshly owned in the body when every arrival
+    /// hands it a new unit. An entry edge always does, but a back edge that
+    /// does not re-initialize the param leaves the previous iteration's value
+    /// in place. Placing such a param owned makes the body release it once
+    /// per iteration, so the second iteration releases an already-dead value.
+    /// The back-edge meet is a shrinking accumulator seeded from the full
+    /// param set, so filtering by it keeps this placement monotone.
     fn placeSolveJoinParamsInto(self: *Inserter, summary: *const JoinSummary, keep: *OwnedSet) void {
+        const params = self.store.getLocalSpan(summary.params);
+        for (0..GuardedList.borrowLen(params)) |index| {
+            const local = GuardedList.at(params, index);
+            if (summary.back_edge_seen and !summary.back_edge_params.contains(local)) continue;
+            self.placeUnit(keep, local);
+        }
+        const maybe_params = self.store.getLocalSpan(summary.maybe_uninitialized_params);
+        for (0..GuardedList.borrowLen(maybe_params)) |index| {
+            const local = GuardedList.at(maybe_params, index);
+            if (summary.back_edge_seen and !summary.back_edge_params.contains(local)) continue;
+            self.placeConditionalUnit(keep, local);
+        }
+    }
+
+    /// Unfiltered param placement: the seed for the back-edge meet.
+    fn placeAllSolveJoinParamsInto(self: *Inserter, summary: *const JoinSummary, keep: *OwnedSet) void {
         const params = self.store.getLocalSpan(summary.params);
         for (0..GuardedList.borrowLen(params)) |index| {
             self.placeUnit(keep, GuardedList.at(params, index));
@@ -3571,6 +3608,29 @@ const Inserter = struct {
         for (0..GuardedList.borrowLen(maybe_params)) |index| {
             self.placeConditionalUnit(keep, GuardedList.at(maybe_params, index));
         }
+    }
+
+    /// Folds one back edge's state into `back_edge_params`. Returns whether
+    /// the meet shrank, which invalidates the body keep placed from it.
+    fn absorbBackEdgeParams(
+        self: *Inserter,
+        summary: *JoinSummary,
+        owned: *const OwnedSet,
+    ) bool {
+        var changed = false;
+        if (!summary.back_edge_seen) {
+            summary.back_edge_seen = true;
+            self.placeAllSolveJoinParamsInto(summary, &summary.back_edge_params);
+            changed = true;
+        }
+        var iter = summary.back_edge_params.bits.iterator(.{});
+        while (iter.next()) |index| {
+            const local = summary.back_edge_params.domain.resourceLocalAt(index);
+            if (owned.contains(local)) continue;
+            summary.back_edge_params.unset(local);
+            changed = true;
+        }
+        return changed;
     }
 
     const BodyKeepUpdate = struct {
@@ -3723,6 +3783,7 @@ const Inserter = struct {
                 .entry_keep = try OwnedSet.init(self.solve_allocator, self.domain()),
                 .body_keep = try OwnedSet.init(self.solve_allocator, self.domain()),
                 .jump_common = try OwnedSet.init(self.solve_allocator, self.domain()),
+                .back_edge_params = try OwnedSet.init(self.solve_allocator, self.domain()),
                 .loop_keep_id = self.next_loop_keep_id,
                 .remainder_plan = remainder_plan,
                 .body_plan = body_plan,
@@ -3762,7 +3823,17 @@ const Inserter = struct {
         try self.updateJumpPlan(summary, segment.plan_index, segment.cursor, &segment.owned);
         var scope = segment.ctx.body_scope;
         while (scope) |entry| {
-            if (entry.join_index == target_index) return;
+            if (entry.join_index == target_index) {
+                // A back edge does not feed the body keep's general
+                // intersection—it conforms at emission by releasing down to
+                // the keep—but it does constrain which params the body may
+                // treat as freshly owned, because a param it leaves alone
+                // still holds the value the body already released.
+                if (self.absorbBackEdgeParams(summary, &segment.owned)) {
+                    try self.applySolveBodyKeepUpdate(tasks, summary);
+                }
+                return;
+            }
             scope = entry.parent;
         }
         const site_index = self.solution.jumpSiteIndexOf(segment.cursor);
@@ -3784,6 +3855,17 @@ const Inserter = struct {
             break :blk true;
         } else intersectOwnedSetChanged(&summary.jump_common, site);
         if (!common_changed) return;
+        try self.applySolveBodyKeepUpdate(tasks, summary);
+        if (first_reach) try self.scheduleSolveBodyWalk(tasks, summary);
+    }
+
+    /// Recomputes a join's body keep and schedules whatever the shrink
+    /// invalidated.
+    fn applySolveBodyKeepUpdate(
+        self: *Inserter,
+        tasks: *std.ArrayList(SolveTask),
+        summary: *JoinSummary,
+    ) ResourceError!void {
         const update = try self.recomputeSolveBodyKeep(summary);
         if (update.purged) {
             // Liveness rows under this join's keep changed, so states
@@ -3800,9 +3882,7 @@ const Inserter = struct {
             } else {
                 try self.scheduleSolveBodyWalk(tasks, summary);
             }
-            return;
         }
-        if (first_reach) try self.scheduleSolveBodyWalk(tasks, summary);
     }
 
     fn isBindingBorrowed(self: *const Inserter, local: LIR.LocalId) bool {

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -10043,12 +10043,21 @@ test "RC join loop jump releases body-only list but keeps carried state" {
     try f.expectRc(state, 0, 0, 0);
 }
 
-test "RC join loop back edge narrows an aggregate param to its residual fields" {
-    // The first iteration moves field 0 of the carried pair into a call, so
-    // the back edge re-enters the join with the pair present but holding only
-    // field 1. The body keep must carry that exact residual, not the full
-    // ownership the param was placed with: restoring field 0 would authorize
-    // releasing a place the loop already took.
+test "RC join loop retains an aggregate param projection across the back edge" {
+    // A loop body projects field 0 of a carried pair into a call, and the back
+    // edge never rebinds the pair. ARC retains the projection rather than
+    // moving it: the take site sits inside the body, so it is itself a later
+    // use of field 0 on the next iteration, and the pair is live across the
+    // back edge. The edge therefore carries the pair's full residual mask, and
+    // the pair is released exactly once, never while partially dismantled.
+    //
+    // This pins that retain-not-move outcome. It does NOT cover the partial
+    // residual mask path in `placeSurvivingParam`/`setWithResidual`: no LIR
+    // built through this fixture reaches a back edge holding a strict subset
+    // of an aggregate's committed field places, because any projection whose
+    // aggregate survives the edge must be retained. The exact resource meet in
+    // `absorbBackEdgeParams` is what keeps that path correct if it is ever
+    // reachable; it is not relied on for the behaviour asserted below.
     var f = try ArcTest.init(testing.allocator);
     defer f.deinit();
     const first = try f.local(.str);
@@ -10094,10 +10103,6 @@ test "RC join loop back edge narrows an aggregate param to its residual fields" 
     _ = try f.addProc(&.{}, join, .i64);
     try f.run();
 
-    // The projection is retained rather than moved, because the pair is live
-    // across the back edge and the take site is itself a later use of field 0.
-    // That is what keeps the back edge's residual mask full here; the pair is
-    // then released exactly once, and never while partially dismantled.
     try f.expectRc(taken, 1, 0, 0);
     try f.expectRc(pair, 0, 1, 0);
     try testing.expectEqual(@as(usize, 2), f.countAllRc());

--- a/src/lir/arc.zig
+++ b/src/lir/arc.zig
@@ -3582,20 +3582,31 @@ const Inserter = struct {
     /// in place. Placing such a param owned makes the body release it once
     /// per iteration, so the second iteration releases an already-dead value.
     /// The back-edge meet is a shrinking accumulator seeded from the full
-    /// param set, so filtering by it keeps this placement monotone.
+    /// param set and narrowed by the lattice's exact resource intersection,
+    /// so filtering by it keeps this placement monotone and carries residual
+    /// field masks through.
     fn placeSolveJoinParamsInto(self: *Inserter, summary: *const JoinSummary, keep: *OwnedSet) void {
+        if (!summary.back_edge_seen) {
+            self.placeAllSolveJoinParamsInto(summary, keep);
+            return;
+        }
         const params = self.store.getLocalSpan(summary.params);
         for (0..GuardedList.borrowLen(params)) |index| {
-            const local = GuardedList.at(params, index);
-            if (summary.back_edge_seen and !summary.back_edge_params.contains(local)) continue;
-            self.placeUnit(keep, local);
+            placeSurvivingParam(keep, &summary.back_edge_params, GuardedList.at(params, index));
         }
         const maybe_params = self.store.getLocalSpan(summary.maybe_uninitialized_params);
         for (0..GuardedList.borrowLen(maybe_params)) |index| {
-            const local = GuardedList.at(maybe_params, index);
-            if (summary.back_edge_seen and !summary.back_edge_params.contains(local)) continue;
-            self.placeConditionalUnit(keep, local);
+            placeSurvivingParam(keep, &summary.back_edge_params, GuardedList.at(maybe_params, index));
         }
+    }
+
+    /// Copies exactly what the back-edge meet still proves for one param:
+    /// presence plus its surviving residual field mask. Placing full
+    /// ownership here would re-authorize releasing aggregate fields a back
+    /// edge already took, so the mask travels with the bit.
+    fn placeSurvivingParam(keep: *OwnedSet, meet: *const OwnedSet, local: LIR.LocalId) void {
+        if (!meet.contains(local)) return;
+        keep.setWithResidual(local, meet.residualMask(local));
     }
 
     /// Unfiltered param placement: the seed for the back-edge meet.
@@ -3623,13 +3634,10 @@ const Inserter = struct {
             self.placeAllSolveJoinParamsInto(summary, &summary.back_edge_params);
             changed = true;
         }
-        var iter = summary.back_edge_params.bits.iterator(.{});
-        while (iter.next()) |index| {
-            const local = summary.back_edge_params.domain.resourceLocalAt(index);
-            if (owned.contains(local)) continue;
-            summary.back_edge_params.unset(local);
-            changed = true;
-        }
+        // The same exact resource meet the rest of the lattice uses: a param
+        // survives only with the residual field places every back edge still
+        // proves, not merely its presence bit.
+        if (intersectOwnedSetChanged(&summary.back_edge_params, owned)) changed = true;
         return changed;
     }
 
@@ -7012,6 +7020,18 @@ const OwnedSet = struct {
         }
     }
 
+    /// Places `local` carrying exactly `mask` of its committed field places,
+    /// rather than the full ownership `set` grants. Used to copy a resource
+    /// out of a meet that may have narrowed it.
+    fn setWithResidual(self: *OwnedSet, local: LIR.LocalId, mask: u64) void {
+        const bit = self.domain.requiredResourceBitOf(local);
+        if ((mask & ~self.domain.fullResidualMaskAt(bit)) != 0) {
+            arcInvariant("ARC residual placement exceeded the committed field places");
+        }
+        self.bits.set(bit);
+        self.residual_masks[bit] = mask;
+    }
+
     fn residualMask(self: *const OwnedSet, local: LIR.LocalId) u64 {
         const bit = self.domain.resourceBitOf(local) orelse return 0;
         return self.residual_masks[bit];
@@ -10021,6 +10041,66 @@ test "RC join loop jump releases body-only list but keeps carried state" {
     try f.expectRc(scratch, 0, 1, 0);
     // The old state is consumed by the op that produces the next state.
     try f.expectRc(state, 0, 0, 0);
+}
+
+test "RC join loop back edge narrows an aggregate param to its residual fields" {
+    // The first iteration moves field 0 of the carried pair into a call, so
+    // the back edge re-enters the join with the pair present but holding only
+    // field 1. The body keep must carry that exact residual, not the full
+    // ownership the param was placed with: restoring field 0 would authorize
+    // releasing a place the loop already took.
+    var f = try ArcTest.init(testing.allocator);
+    defer f.deinit();
+    const first = try f.local(.str);
+    const second = try f.local(.str);
+    const source = try f.local(f.pair_str);
+    const pair = try f.local(f.pair_str);
+    const flag = try f.local(.i64);
+    const first_flag = try f.local(.i64);
+    const cleared_flag = try f.local(.i64);
+    const taken = try f.local(.str);
+    const sink = try f.local(.i64);
+    const result = try f.local(.i64);
+    const join_id = f.freshJoinPointId();
+
+    // Back edge: clears the flag and jumps without rebinding `pair`.
+    const back_jump = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const set_flag = try f.setLocal(flag, cleared_flag, .initialize_join_param, back_jump);
+    const clear_flag = try f.assignI64(cleared_flag, 0, set_flag);
+    const consume = try f.assignCall(sink, &.{taken}, clear_flag);
+    const take_field = try f.assignRefField(taken, pair, 0, consume);
+
+    // Exit edge.
+    const exit = try f.ret(result);
+    const assign_result = try f.assignI64(result, 7, exit);
+
+    const body = try f.switchStmt(flag, take_field, assign_result, null);
+
+    const entry_jump = try f.store.addCFStmt(.{ .jump = .{ .target = join_id } });
+    const init_flag = try f.setLocal(flag, first_flag, .initialize_join_param, entry_jump);
+    const init_pair = try f.setLocal(pair, source, .initialize_join_param, init_flag);
+    const assign_flag = try f.assignI64(first_flag, 1, init_pair);
+    const assign_pair = try f.assignStruct(source, &.{ first, second }, assign_flag);
+    const assign_second = try f.assignStr(second, "second", assign_pair);
+    const remainder = try f.assignStr(first, "first", assign_second);
+
+    const join = try f.store.addCFStmt(.{ .join = .{
+        .id = join_id,
+        .params = try f.span(&.{ pair, flag }),
+        .body = body,
+        .remainder = remainder,
+    } });
+
+    _ = try f.addProc(&.{}, join, .i64);
+    try f.run();
+
+    // The projection is retained rather than moved, because the pair is live
+    // across the back edge and the take site is itself a later use of field 0.
+    // That is what keeps the back edge's residual mask full here; the pair is
+    // then released exactly once, and never while partially dismantled.
+    try f.expectRc(taken, 1, 0, 0);
+    try f.expectRc(pair, 0, 1, 0);
+    try testing.expectEqual(@as(usize, 2), f.countAllRc());
 }
 
 test "RC join loop exit releases body-only list and preserves returned state" {


### PR DESCRIPTION
## Problem

ARC insertion placed **every** join parameter owned in a loop's `body_keep`, regardless of whether each arrival to the join actually hands that parameter a new ownership unit.

An entry edge always does. A back edge does not have to: it rebinds only the parameters the loop actually advances, and leaves the rest holding the value the entry edge produced. Placing such a loop-invariant parameter owned makes the body release it, and that release then runs **once per iteration** against a value that only ever existed once.

The parameters this bites are the ones nothing in the body reads — they are placed owned, immediately found dead, and released at the top of the body. A record whose fields are carried through a loop produces exactly this shape: reading one field is enough for the record's other fields to become loop-carried join params that the back edge never rebinds.

Symptoms:

- Debug compilers abort in `arc_certify` with `release of unbound local N`.
- Optimized builds miscompile silently into a use-after-free. Because the count only reaches zero after enough iterations, single calls look fine and the crash appears later, in `roc_llvm_rc_decref_*`, on an unrelated value that reused the freed allocation.

Minimal reproduction:

```roc
State : { a : List(U64), b : List(U64) }

count_from : State, U64, List(U64) -> List(U64)
count_from = |state, i, acc|
    if i == 0 acc else count_from(state, i - 1, List.append(acc, List.len(state.a)))

main : U64
main = List.len(count_from({ a: [1, 2], b: [3, 4] }, 4, []))
```

`state.b` is never read and never rebound by the back edge, so it was released once per iteration. Two fields are required: with a single field there is no invariant one left over.

## Fix

A join summary now maintains `back_edge_params`: a monotone meet of join-parameter ownership taken over the back edges. Back edges still stay out of `body_keep`'s general intersection — they conform at emission by releasing down to the keep — but they now constrain which parameters the body may treat as freshly owned. `body_keep` places a parameter only if it survives that meet.

The meet is seeded from the full parameter set on the first back edge and only shrinks, so the existing fixpoint stays monotone and terminating.

## Testing

- New regression test in `src/eval/test/lir_inline_test.zig`. Verified red-green: without the fix it aborts with `ARC: release of unbound local 4`; with the fix the suite is 170/170.
- `zig build run-test-zig` — 4694/4694 pass.
- `zig build run-test-eval` — 1941/1941 pass across interp, dev, and wasm.
- `zig build minici`.
- The application this was originally found in (via property fuzzing) previously segfaulted on every run and now builds clean and runs correctly.

`design.md`'s join-ownership paragraph is updated to declare the refined rule.
