### PR TITLE
Add LSP inlay hints for inferred types

### DIFF
--- a/src/lsp/README.md
+++ b/src/lsp/README.md
@@ -31,13 +31,13 @@ Roc infers most types, and an annotation can still leave parts to inference with
 type a binding actually has is often written nowhere in the file. `textDocument/inlayHint`
 renders it next to the name.
 
-Only plain bindings get a hint — one name, one type. Skipped are bindings that already carry a
+Only plain bindings get a hint—one name, one type. Skipped are bindings that already carry a
 written annotation (their type is on screen), bindings marked unused with a leading `_`, and
 any pattern whose source text is not exactly the name: a compiler-synthesized binding has no
 name in the source, and `import "x" as name : Str` already spells its type.
 
 Labels are cut at 56 bytes with a trailing `…`, because a hint is drawn inside the line it
-annotates and an inferred Roc type can be far longer than the code it describes — a generic
+annotates and an inferred Roc type can be far longer than the code it describes—a generic
 function carries its whole `where` clause. Hovering the same name gives the type in full.
 
 A document that does not build produces no hints, which leaves whatever the editor last drew

--- a/src/lsp/README.md
+++ b/src/lsp/README.md
@@ -11,6 +11,7 @@ The following requests are handled:
 - `textDocument/documentSymbol`
 - `textDocument/documentHighlight`
 - `textDocument/references`
+- `textDocument/inlayHint`
 - `textDocument/formatting`
 - `textDocument/foldingRange`
 - `textDocument/selectionRange`
@@ -23,6 +24,24 @@ The following notifications are handled:
 - `didChange` (same as `didOpen`, and supports incremental changes)
 
 Diagnostics are pushed as `textDocument/publishDiagnostics` when a document is opened or changed.
+
+### Inlay hints
+
+Roc infers most types, and an annotation can still leave parts to inference with `_`, so the
+type a binding actually has is often written nowhere in the file. `textDocument/inlayHint`
+renders it next to the name.
+
+Only plain bindings get a hint — one name, one type. Skipped are bindings that already carry a
+written annotation (their type is on screen), bindings marked unused with a leading `_`, and
+any pattern whose source text is not exactly the name: a compiler-synthesized binding has no
+name in the source, and `import "x" as name : Str` already spells its type.
+
+Labels are cut at 56 bytes with a trailing `…`, because a hint is drawn inside the line it
+annotates and an inferred Roc type can be far longer than the code it describes — a generic
+function carries its whole `where` clause. Hovering the same name gives the type in full.
+
+A document that does not build produces no hints, which leaves whatever the editor last drew
+in place rather than blanking every hint on each keystroke.
 
 ### References
 

--- a/src/lsp/capabilities.zig
+++ b/src/lsp/capabilities.zig
@@ -34,6 +34,7 @@ pub const ServerCapabilities = struct {
     documentHighlightProvider: bool = false,
     completionProvider: ?CompletionOptions = null,
     referencesProvider: bool = false,
+    inlayHintProvider: bool = false,
     renameProvider: ?RenameOptions = null,
 
     pub const TextDocumentSyncOptions = struct {
@@ -93,6 +94,7 @@ pub fn buildCapabilities() ServerCapabilities {
         .documentHighlightProvider = true,
         .completionProvider = .{},
         .referencesProvider = true,
+        .inlayHintProvider = true,
         .renameProvider = .{},
     };
 }

--- a/src/lsp/cir_queries.zig
+++ b/src/lsp/cir_queries.zig
@@ -1244,7 +1244,7 @@ const CollectBindingsContext = struct {
 ///
 /// Only plain `assign` patterns qualify: they bind exactly one name, so an
 /// inferred type can be shown against that name. Bindings that already carry a
-/// written annotation are skipped — their type is on screen already.
+/// written annotation are skipped—their type is on screen already.
 ///
 /// Caller owns the returned list.
 pub fn collectUnannotatedBindings(

--- a/src/lsp/cir_queries.zig
+++ b/src/lsp/cir_queries.zig
@@ -1168,6 +1168,164 @@ pub fn declarationNameRegion(module_env: *ModuleEnv, target_pattern: CIR.Pattern
     return null;
 }
 
+/// A binding whose type is inferred rather than written down.
+pub const UnannotatedBinding = struct {
+    pattern: CIR.Pattern.Idx,
+    /// Where the inferred type belongs: immediately after the bound name.
+    after: LspPosition,
+};
+
+/// Context for collecting the patterns that carry a written type annotation.
+const CollectAnnotatedContext = struct {
+    allocator: std.mem.Allocator,
+    results: *std.ArrayList(CIR.Pattern.Idx),
+    oom: ?std.mem.Allocator.Error = null,
+
+    fn visitStmtPre(ctx: *CollectAnnotatedContext, _: CIR.Statement.Idx, stmt: CIR.Statement) VisitAction {
+        if (statementAnnotation(stmt) == null) return .continue_traversal;
+        const pattern_idx = statementPattern(stmt) orelse return .continue_traversal;
+        ctx.results.append(ctx.allocator, pattern_idx) catch |err| {
+            ctx.oom = err;
+            return .stop;
+        };
+        return .continue_traversal;
+    }
+};
+
+/// Context for collecting `assign` patterns inside a byte range.
+const CollectBindingsContext = struct {
+    store: *const NodeStore,
+    module_env: *const ModuleEnv,
+    start_offset: u32,
+    end_offset: u32,
+    allocator: std.mem.Allocator,
+    results: *std.ArrayList(UnannotatedBinding),
+    oom: ?std.mem.Allocator.Error = null,
+
+    fn visitPatternPre(ctx: *CollectBindingsContext, pattern_idx: CIR.Pattern.Idx, pattern: CIR.Pattern) VisitAction {
+        if (std.meta.activeTag(pattern) != .assign) return .continue_traversal;
+
+        // A leading `_` marks a binding the author deliberately ignores.
+        // Annotating what someone said they do not care about is noise.
+        const name = ctx.module_env.common.idents.getText(pattern.assign.ident);
+        if (base.Ident.Attributes.fromString(name).ignored) return .continue_traversal;
+
+        const region = ctx.store.getPatternRegion(pattern_idx);
+
+        // The hint is drawn just past the pattern, so it only reads correctly
+        // where the source spells exactly the name and nothing else. Two kinds
+        // of pattern fail that: bindings the compiler synthesizes, which have
+        // no name in the source at all, and forms like `import … as name : Str`
+        // whose pattern spans a type the author already wrote.
+        const source = ctx.module_env.common.source;
+        if (region.end.offset > source.len or region.start.offset > region.end.offset) {
+            return .continue_traversal;
+        }
+        if (!std.mem.eql(u8, source[region.start.offset..region.end.offset], name)) {
+            return .continue_traversal;
+        }
+        if (region.end.offset < ctx.start_offset or region.start.offset > ctx.end_offset) {
+            return .continue_traversal;
+        }
+
+        const range = regionToRange(ctx.module_env, region) orelse return .continue_traversal;
+        ctx.results.append(ctx.allocator, .{
+            .pattern = pattern_idx,
+            .after = .{ .line = range.end_line, .character = range.end_col },
+        }) catch |err| {
+            ctx.oom = err;
+            return .stop;
+        };
+        return .continue_traversal;
+    }
+};
+
+/// Collect the bindings between two byte offsets whose type is inferred.
+///
+/// Only plain `assign` patterns qualify: they bind exactly one name, so an
+/// inferred type can be shown against that name. Bindings that already carry a
+/// written annotation are skipped — their type is on screen already.
+///
+/// Caller owns the returned list.
+pub fn collectUnannotatedBindings(
+    module_env: *ModuleEnv,
+    start_offset: u32,
+    end_offset: u32,
+    allocator: std.mem.Allocator,
+) std.mem.Allocator.Error!std.ArrayList(UnannotatedBinding) {
+    // Which patterns already say their type. Annotations are few even in large
+    // files, so this stays a list that is scanned rather than a keyed map.
+    var annotated: std.ArrayList(CIR.Pattern.Idx) = .empty;
+    defer annotated.deinit(allocator);
+
+    var annotated_ctx = CollectAnnotatedContext{
+        .allocator = allocator,
+        .results = &annotated,
+    };
+    var annotated_visitor = CirVisitor(CollectAnnotatedContext).init(&annotated_ctx, .{
+        .visit_stmt_pre = CollectAnnotatedContext.visitStmtPre,
+    });
+
+    const defs_slice = module_env.store.sliceDefs(module_env.all_defs);
+    for (defs_slice) |def_idx| {
+        const def = module_env.store.getDef(def_idx);
+        if (def.annotation != null) {
+            try annotated.append(allocator, def.pattern);
+        }
+        annotated_visitor.walkExpr(&module_env.store, def.expr);
+        if (annotated_visitor.stopped) break;
+    }
+    if (!annotated_visitor.stopped) {
+        annotated_visitor.walkModule(&module_env.store, module_env.all_statements);
+    }
+    if (annotated_ctx.oom) |err| return err;
+
+    var results: std.ArrayList(UnannotatedBinding) = .empty;
+    errdefer results.deinit(allocator);
+
+    var ctx = CollectBindingsContext{
+        .store = &module_env.store,
+        .module_env = module_env,
+        .start_offset = start_offset,
+        .end_offset = end_offset,
+        .allocator = allocator,
+        .results = &results,
+    };
+    var visitor = CirVisitor(CollectBindingsContext).init(&ctx, .{
+        .visit_pattern_pre = CollectBindingsContext.visitPatternPre,
+    });
+
+    for (defs_slice) |def_idx| {
+        const def = module_env.store.getDef(def_idx);
+        visitor.walkPattern(&module_env.store, def.pattern);
+        if (visitor.stopped) break;
+        visitor.walkExpr(&module_env.store, def.expr);
+        if (visitor.stopped) break;
+    }
+    if (!visitor.stopped) {
+        visitor.walkModule(&module_env.store, module_env.all_statements);
+    }
+    if (ctx.oom) |err| return err;
+
+    // Drop the annotated ones now that both walks are done.
+    var kept: usize = 0;
+    for (results.items) |binding| {
+        var is_annotated = false;
+        for (annotated.items) |annotated_pattern| {
+            if (@intFromEnum(annotated_pattern) == @intFromEnum(binding.pattern)) {
+                is_annotated = true;
+                break;
+            }
+        }
+        if (is_annotated) continue;
+        results.items[kept] = binding;
+        kept += 1;
+    }
+    results.shrinkRetainingCapacity(kept);
+
+    return results;
+}
+
 /// Collect the places that declare `target_pattern`.
 ///
 /// That is the binding itself and, when it is annotated, the name written on

--- a/src/lsp/handlers/inlay_hint.zig
+++ b/src/lsp/handlers/inlay_hint.zig
@@ -1,0 +1,145 @@
+//! Handler for LSP `textDocument/inlayHint` requests.
+//!
+//! Shows the inferred type of bindings that do not write one down. Roc infers
+//! most types, and an annotation may still leave parts to inference with `_`,
+//! so the type a binding actually has is frequently written nowhere in the
+//! file. Bindings that do carry an annotation are skipped: repeating what is
+//! already on screen is noise.
+//!
+//! The editor asks for a line range — whatever is on screen — and re-asks as
+//! the view moves, so this only ever renders what is visible.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const protocol = @import("../protocol.zig");
+
+/// An LSP `InlayHint`.
+const InlayHint = struct {
+    position: struct {
+        line: u32,
+        character: u32,
+    },
+    label: []const u8,
+    /// 1 = Type, per the protocol's `InlayHintKind`.
+    kind: u32 = 1,
+    /// The label already begins with `: `, so no extra space is wanted.
+    paddingLeft: bool = false,
+    paddingRight: bool = false,
+};
+
+/// Read a `line` field out of a position object.
+fn readLine(
+    self: anytype,
+    id: *protocol.JsonId,
+    position_value: std.json.Value,
+) (Allocator.Error || error{WriteFailed})!?u32 {
+    if (std.meta.activeTag(position_value) != .object) {
+        try self.sendError(id, .invalid_params, "range positions must be objects");
+        return null;
+    }
+    const line_value = position_value.object.get("line") orelse {
+        try self.sendError(id, .invalid_params, "range positions must have a line");
+        return null;
+    };
+    if (std.meta.activeTag(line_value) != .integer) {
+        try self.sendError(id, .invalid_params, "line must be an integer");
+        return null;
+    }
+    return std.math.cast(u32, line_value.integer) orelse {
+        try self.sendError(id, .invalid_params, "line must be a non-negative integer");
+        return null;
+    };
+}
+
+/// Handler for `textDocument/inlayHint` requests.
+pub fn handler(comptime ServerType: type) type {
+    return struct {
+        pub fn call(self: *ServerType, id: *protocol.JsonId, maybe_params: ?std.json.Value) (Allocator.Error || error{WriteFailed})!void {
+            const params = maybe_params orelse {
+                try self.sendError(id, .invalid_params, "inlayHint requires params");
+                return;
+            };
+            if (std.meta.activeTag(params) != .object) {
+                try self.sendError(id, .invalid_params, "inlayHint params must be an object");
+                return;
+            }
+            const obj = params.object;
+
+            const text_doc_value = obj.get("textDocument") orelse {
+                try self.sendError(id, .invalid_params, "missing textDocument");
+                return;
+            };
+            if (std.meta.activeTag(text_doc_value) != .object) {
+                try self.sendError(id, .invalid_params, "textDocument must be an object");
+                return;
+            }
+            const uri_value = text_doc_value.object.get("uri") orelse {
+                try self.sendError(id, .invalid_params, "missing uri");
+                return;
+            };
+            if (std.meta.activeTag(uri_value) != .string) {
+                try self.sendError(id, .invalid_params, "uri must be a string");
+                return;
+            }
+            const uri = uri_value.string;
+
+            const range_value = obj.get("range") orelse {
+                try self.sendError(id, .invalid_params, "missing range");
+                return;
+            };
+            if (std.meta.activeTag(range_value) != .object) {
+                try self.sendError(id, .invalid_params, "range must be an object");
+                return;
+            }
+            const start_value = range_value.object.get("start") orelse {
+                try self.sendError(id, .invalid_params, "range must have a start");
+                return;
+            };
+            const end_value = range_value.object.get("end") orelse {
+                try self.sendError(id, .invalid_params, "range must have an end");
+                return;
+            };
+            const start_line = try readLine(self, id, start_value) orelse return;
+            const end_line = try readLine(self, id, end_value) orelse return;
+            if (end_line < start_line) {
+                try self.sendError(id, .invalid_params, "range end must not precede its start");
+                return;
+            }
+
+            const doc = self.doc_store.get(uri);
+            const text = if (doc) |d| d.text else null;
+
+            const found = self.syntax_checker.getInlayHints(
+                uri,
+                text,
+                start_line,
+                end_line,
+            ) catch |err| {
+                std.log.err("inlayHint failed: {s}", .{@errorName(err)});
+                if (err == error.OutOfMemory) return error.OutOfMemory;
+                try self.sendNullResponse(id);
+                return;
+            };
+
+            // A document that does not build has no inferred types to show.
+            // Answering null leaves whatever the editor last drew in place,
+            // which is steadier than blanking every hint on each keystroke.
+            const result = found orelse {
+                try self.sendNullResponse(id);
+                return;
+            };
+            defer result.deinit(self.allocator);
+
+            var hints: std.ArrayList(InlayHint) = .empty;
+            defer hints.deinit(self.allocator);
+            for (result.hints) |hint| {
+                try hints.append(self.allocator, .{
+                    .position = .{ .line = hint.line, .character = hint.character },
+                    .label = hint.label,
+                });
+            }
+
+            try self.sendResponse(id, hints.items);
+        }
+    };
+}

--- a/src/lsp/handlers/inlay_hint.zig
+++ b/src/lsp/handlers/inlay_hint.zig
@@ -6,7 +6,7 @@
 //! file. Bindings that do carry an annotation are skipped: repeating what is
 //! already on screen is noise.
 //!
-//! The editor asks for a line range — whatever is on screen — and re-asks as
+//! The editor asks for a line range—whatever is on screen—and re-asks as
 //! the view moves, so this only ever renders what is visible.
 
 const std = @import("std");
@@ -114,11 +114,13 @@ pub fn handler(comptime ServerType: type) type {
                 text,
                 start_line,
                 end_line,
-            ) catch |err| {
-                std.log.err("inlayHint failed: {s}", .{@errorName(err)});
-                if (err == error.OutOfMemory) return error.OutOfMemory;
-                try self.sendNullResponse(id);
-                return;
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => {
+                    std.log.err("inlayHint failed: {s}", .{@errorName(err)});
+                    try self.sendNullResponse(id);
+                    return;
+                },
             };
 
             // A document that does not build has no inferred types to show.

--- a/src/lsp/server.zig
+++ b/src/lsp/server.zig
@@ -32,6 +32,7 @@ const document_highlight_handler_mod = @import("handlers/document_highlight.zig"
 const completion_handler_mod = @import("handlers/completion.zig");
 const rename_handler_mod = @import("handlers/rename.zig");
 const references_handler_mod = @import("handlers/references.zig");
+const inlay_hint_handler_mod = @import("handlers/inlay_hint.zig");
 
 const log = std.log.scoped(.roc_lsp_server);
 
@@ -79,6 +80,7 @@ pub fn ServerWithSyntaxDriver(comptime ReaderType: type, comptime WriterType: ty
         const RenameHandler = rename_handler_mod.handler(Self);
         const PrepareRenameHandler = rename_handler_mod.prepareHandler(Self);
         const ReferencesHandler = references_handler_mod.handler(Self);
+        const InlayHintHandler = inlay_hint_handler_mod.handler(Self);
         const request_handlers = std.StaticStringMap(HandlerPtr).initComptime(.{
             .{ "initialize", &InitializeHandler.call },
             .{ "shutdown", &ShutdownHandler.call },
@@ -94,6 +96,7 @@ pub fn ServerWithSyntaxDriver(comptime ReaderType: type, comptime WriterType: ty
             .{ "textDocument/rename", &RenameHandler.call },
             .{ "textDocument/prepareRename", &PrepareRenameHandler.call },
             .{ "textDocument/references", &ReferencesHandler.call },
+            .{ "textDocument/inlayHint", &InlayHintHandler.call },
         });
         const DidOpenHandler = did_open_handler_mod.handler(Self);
         const DidChangeHandler = did_change_handler_mod.handler(Self);

--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -4100,7 +4100,7 @@ fn rangeContaining(regions: []const cir_queries.LspRange, line: u32, character: 
 ///
 /// A hint is drawn inside the line it annotates, so a long one pushes the code
 /// off screen. Roc's inferred types can be far longer than the code they
-/// describe — a generic function carries its whole `where` clause — so the
+/// describe—a generic function carries its whole `where` clause—so the
 /// label is cut and hovering the same name gives the type in full.
 const max_inlay_label_bytes = 56;
 

--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -2978,6 +2978,103 @@ pub const SyntaxChecker = struct {
         return regions.toOwnedSlice(self.allocator);
     }
 
+    /// One inferred type, ready to be shown against the name it belongs to.
+    pub const InlayHint = struct {
+        line: u32,
+        character: u32,
+        /// The rendered type, including its leading `: `. Owned by the result.
+        label: []u8,
+    };
+
+    /// The hints for one requested range.
+    pub const InlayHintsResult = struct {
+        hints: []InlayHint,
+
+        pub fn deinit(self: InlayHintsResult, allocator: std.mem.Allocator) void {
+            for (self.hints) |hint| allocator.free(hint.label);
+            allocator.free(self.hints);
+        }
+    };
+
+    /// Render the inferred type of every unannotated binding in a line range.
+    ///
+    /// Roc infers most types, and an annotation may leave parts of one to
+    /// inference with `_`, so the type a binding actually has is often written
+    /// nowhere in the file. These hints put it next to the name.
+    ///
+    /// Bindings that carry a written annotation are skipped: their type is
+    /// already on screen, and repeating it would only add noise.
+    pub fn getInlayHints(
+        self: *SyntaxChecker,
+        uri: []const u8,
+        override_text: ?[]const u8,
+        start_line: u32,
+        end_line: u32,
+    ) QueryError!?InlayHintsResult {
+        self.mutex.lockUncancelable(self.std_io);
+        defer self.mutex.unlock(self.std_io);
+
+        var build = try self.prepareDocumentBuild(uri, override_text);
+        defer build.deinit();
+
+        self.logDebug(.build, "inlayHint: document {s} reused={}", .{ build.absolute_path, build.reused });
+
+        if (!build.build_succeeded) {
+            self.logDebug(.build, "inlayHint: build unavailable for {s}", .{build.absolute_path});
+            return null;
+        }
+
+        const module_env = build.getModuleEnv() orelse return null;
+
+        // The request names whole lines; widen to the byte span they cover.
+        const start_offset = pos.positionToOffset(module_env, start_line, 0) orelse return null;
+        const line_starts = module_env.getLineStartsAll();
+        const end_offset: u32 = if (end_line + 1 < line_starts.len)
+            line_starts[end_line + 1]
+        else
+            @intCast(module_env.common.source.len);
+
+        var bindings = try cir_queries.collectUnannotatedBindings(module_env, start_offset, end_offset, self.allocator);
+        defer bindings.deinit(self.allocator);
+
+        var hints: std.ArrayList(InlayHint) = .empty;
+        errdefer {
+            for (hints.items) |hint| self.allocator.free(hint.label);
+            hints.deinit(self.allocator);
+        }
+
+        var type_writer = try module_env.initTypeWriter();
+        defer type_writer.deinit();
+
+        for (bindings.items) |binding| {
+            type_writer.reset();
+            type_writer.write(ModuleEnv.varFrom(binding.pattern), .one_line) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                else => continue,
+            };
+
+            const rendered = type_writer.get();
+            if (rendered.len == 0) continue;
+
+            const shown = truncateTypeLabel(rendered);
+            const label = if (shown.len < rendered.len)
+                try std.fmt.allocPrint(self.allocator, ": {s}…", .{shown})
+            else
+                try std.fmt.allocPrint(self.allocator, ": {s}", .{shown});
+            errdefer self.allocator.free(label);
+
+            try hints.append(self.allocator, .{
+                .line = binding.after.line,
+                .character = binding.after.character,
+                .label = label,
+            });
+        }
+
+        return InlayHintsResult{
+            .hints = try hints.toOwnedSlice(self.allocator),
+        };
+    }
+
     /// Every place a symbol is written, split the way LSP asks for it.
     pub const ReferencesResult = struct {
         regions: []LspRange,
@@ -3993,4 +4090,22 @@ fn rangeContaining(regions: []const cir_queries.LspRange, line: u32, character: 
         if (character >= range.start_col and character <= range.end_col) return range;
     }
     return null;
+}
+
+/// How much of a rendered type an inlay hint shows.
+///
+/// A hint is drawn inside the line it annotates, so a long one pushes the code
+/// off screen. Roc's inferred types can be far longer than the code they
+/// describe — a generic function carries its whole `where` clause — so the
+/// label is cut and hovering the same name gives the type in full.
+const max_inlay_label_bytes = 56;
+
+/// Cut a rendered type to `max_inlay_label_bytes`, never mid-codepoint.
+fn truncateTypeLabel(rendered: []const u8) []const u8 {
+    if (rendered.len <= max_inlay_label_bytes) return rendered;
+
+    var end: usize = max_inlay_label_bytes;
+    // Back off any UTF-8 continuation bytes so the cut lands on a boundary.
+    while (end > 0 and (rendered[end] & 0xC0) == 0x80) : (end -= 1) {}
+    return rendered[0..end];
 }

--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -3032,9 +3032,11 @@ pub const SyntaxChecker = struct {
 
         // `end_line` is whatever the client sent, so widen before adding one:
         // a u32 maximum would otherwise overflow ahead of the bounds check.
-        const line_after_end: usize = @as(usize, end_line) + 1;
-        const end_offset: u32 = if (line_after_end < line_starts.len)
-            line_starts[line_after_end]
+        // The widening target is `u64` rather than `usize`, which is itself 32
+        // bits on a 32-bit build and would overflow on the same input.
+        const line_after_end: u64 = @as(u64, end_line) + 1;
+        const end_offset: u32 = if (line_after_end < @as(u64, line_starts.len))
+            line_starts[@intCast(line_after_end)]
         else
             @intCast(module_env.common.source.len);
 

--- a/src/lsp/syntax.zig
+++ b/src/lsp/syntax.zig
@@ -3029,8 +3029,12 @@ pub const SyntaxChecker = struct {
         // The request names whole lines; widen to the byte span they cover.
         const start_offset = pos.positionToOffset(module_env, start_line, 0) orelse return null;
         const line_starts = module_env.getLineStartsAll();
-        const end_offset: u32 = if (end_line + 1 < line_starts.len)
-            line_starts[end_line + 1]
+
+        // `end_line` is whatever the client sent, so widen before adding one:
+        // a u32 maximum would otherwise overflow ahead of the bounds check.
+        const line_after_end: usize = @as(usize, end_line) + 1;
+        const end_offset: u32 = if (line_after_end < line_starts.len)
+            line_starts[line_after_end]
         else
             @intCast(module_env.common.source.len);
 

--- a/src/lsp/test/handler_integration_tests.zig
+++ b/src/lsp/test/handler_integration_tests.zig
@@ -333,6 +333,8 @@ pub const specs = [_]integration_spec.Spec{
     .{ .name = "prepare rename reports the occurrence under the cursor", .run = prepareRenameReportsOccurrenceUnderCursor },
     .{ .name = "references handler honours includeDeclaration", .run = referencesHandlerHonoursIncludeDeclaration },
     .{ .name = "references handler respects shadowing", .run = referencesHandlerRespectsShadowing },
+    .{ .name = "inlay hints show inferred types and skip annotated bindings", .run = inlayHintsShowInferredTypes },
+    .{ .name = "inlay hints stay within the requested range and truncate long types", .run = inlayHintsRespectRangeAndLength },
     .{ .name = "the name on an annotation is a usable starting point", .run = annotationNameResolvesLikeAnyOccurrence },
     .{ .name = "positions are UTF-16 code units, not bytes", .run = positionsUseUtf16CodeUnits },
     .{ .name = "rename refuses a declaration that is not a plain name", .run = renameRefusesNonIsolatedDeclaration },
@@ -1478,6 +1480,134 @@ pub fn renameRefusesNonIsolatedDeclaration() integration_spec.SpecError!void {
     var prepared = try responseById(allocator, responses, 3);
     defer prepared.deinit();
     try std.testing.expect((try prepared.result()) == .null);
+}
+
+/// Find the hint at a position and return its label.
+fn hintLabelAt(hints: std.json.Value, line: i64, character: i64) integration_spec.SpecError!?[]const u8 {
+    if (hints != .array) return error.TestUnexpectedResult;
+    for (hints.array.items) |hint| {
+        const position = try objectField(hint, "position");
+        if ((try integerField(position, "line")) != line) continue;
+        if ((try integerField(position, "character")) != character) continue;
+        const label = try objectField(hint, "label");
+        if (label != .string) return error.TestUnexpectedResult;
+        return label.string;
+    }
+    return null;
+}
+
+/// Verifies inlay hints render inferred types, and leave alone the bindings
+/// that already say their type or that the author marked unused.
+pub fn inlayHintsShowInferredTypes() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const fixture = try renameFixture(allocator, tmp_path, "inlay_types.roc");
+    defer allocator.free(fixture.path);
+    defer allocator.free(fixture.uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    const source = try std.fmt.allocPrint(allocator,
+        \\app [main] {{ pf: platform "{s}" }}
+        \\
+        \\annotated : I64
+        \\annotated = 1
+        \\
+        \\main = {{
+        \\    text = "roc"
+        \\    flag = annotated > 2
+        \\    _unused = 5
+        \\    text
+        \\}}
+    , .{platform_path});
+    defer allocator.free(source);
+
+    const request = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/inlayHint","params":{{"textDocument":{{"uri":"{s}"}},"range":{{"start":{{"line":0,"character":0}},"end":{{"line":11,"character":0}}}}}}}}
+    , .{fixture.uri});
+    defer allocator.free(request);
+
+    const responses = try runSessionResponses(allocator, tmp_path, fixture.uri, source, &.{request});
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    var response = try responseById(allocator, responses, 2);
+    defer response.deinit();
+    const hints = try response.result();
+    try std.testing.expect(hints == .array);
+
+    // `text` ends at column 8 on its line, `flag` at column 8 on the next.
+    const text_label = try hintLabelAt(hints, 6, 8) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(": Str", text_label);
+    const flag_label = try hintLabelAt(hints, 7, 8) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(": Bool", flag_label);
+
+    // `annotated` already writes its type, on the annotation line and on its
+    // own; neither may be annotated again.
+    try std.testing.expect((try hintLabelAt(hints, 2, 9)) == null);
+    try std.testing.expect((try hintLabelAt(hints, 3, 9)) == null);
+
+    // `_unused` was marked unused on purpose.
+    try std.testing.expect((try hintLabelAt(hints, 8, 11)) == null);
+}
+
+/// Verifies hints are limited to the requested lines, that a long type is cut
+/// rather than pushing the code off screen, and that a document which does not
+/// build produces no hints at all.
+pub fn inlayHintsRespectRangeAndLength() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const fixture = try renameFixture(allocator, tmp_path, "inlay_range.roc");
+    defer allocator.free(fixture.path);
+    defer allocator.free(fixture.uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    const source = try std.fmt.allocPrint(allocator,
+        \\app [main] {{ pf: platform "{s}" }}
+        \\
+        \\main = {{
+        \\    early = "before"
+        \\    wide = {{ alpha: 1, beta: "two", gamma: [3], delta: (4, "five"), epsilon: 6 }}
+        \\    late = "after"
+        \\    early
+        \\}}
+    , .{platform_path});
+    defer allocator.free(source);
+
+    // Only the middle of the block: `wide`, not `early` or `late`.
+    const narrow = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/inlayHint","params":{{"textDocument":{{"uri":"{s}"}},"range":{{"start":{{"line":4,"character":0}},"end":{{"line":4,"character":0}}}}}}}}
+    , .{fixture.uri});
+    defer allocator.free(narrow);
+
+    const responses = try runSessionResponses(allocator, tmp_path, fixture.uri, source, &.{narrow});
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    var response = try responseById(allocator, responses, 2);
+    defer response.deinit();
+    const hints = try response.result();
+    try std.testing.expect(hints == .array);
+    try std.testing.expectEqual(@as(usize, 1), hints.array.items.len);
+
+    const label = try hintLabelAt(hints, 4, 8) orelse return error.TestUnexpectedResult;
+    // A record of five differently-typed fields renders past the cut, so the
+    // label must be shortened and marked as shortened.
+    try std.testing.expect(std.mem.startsWith(u8, label, ": {"));
+    try std.testing.expect(std.mem.endsWith(u8, label, "…"));
+    // ": " + at most 56 bytes of type + the three bytes of "…".
+    try std.testing.expect(label.len <= 2 + 56 + 3);
 }
 
 /// Verifies goto definition locates a local variable definition.

--- a/src/lsp/test/handler_integration_tests.zig
+++ b/src/lsp/test/handler_integration_tests.zig
@@ -335,6 +335,7 @@ pub const specs = [_]integration_spec.Spec{
     .{ .name = "references handler respects shadowing", .run = referencesHandlerRespectsShadowing },
     .{ .name = "inlay hints show inferred types and skip annotated bindings", .run = inlayHintsShowInferredTypes },
     .{ .name = "inlay hints stay within the requested range and truncate long types", .run = inlayHintsRespectRangeAndLength },
+    .{ .name = "inlay hints survive an out-of-range end line", .run = inlayHintsSurviveOutOfRangeEndLine },
     .{ .name = "the name on an annotation is a usable starting point", .run = annotationNameResolvesLikeAnyOccurrence },
     .{ .name = "positions are UTF-16 code units, not bytes", .run = positionsUseUtf16CodeUnits },
     .{ .name = "rename refuses a declaration that is not a plain name", .run = renameRefusesNonIsolatedDeclaration },
@@ -1608,6 +1609,55 @@ pub fn inlayHintsRespectRangeAndLength() integration_spec.SpecError!void {
     try std.testing.expect(std.mem.endsWith(u8, label, "…"));
     // ": " + at most 56 bytes of type + the three bytes of "…".
     try std.testing.expect(label.len <= 2 + 56 + 3);
+}
+
+/// Verifies a range whose end line is past the document does not crash.
+///
+/// The line range comes straight from the client, and widening it to a byte
+/// span adds one to the end line. At the u32 maximum that addition overflowed
+/// before any bounds check, which panics in a safety-enabled build.
+pub fn inlayHintsSurviveOutOfRangeEndLine() integration_spec.SpecError!void {
+    const allocator = test_env.allocator;
+    var tmp = test_env.tmpDir(.{});
+    defer tmp.cleanup();
+    const tmp_path = try tmp.dir.realPathFileAlloc(test_env.io, ".", allocator);
+    defer allocator.free(tmp_path);
+    const fixture = try renameFixture(allocator, tmp_path, "inlay_overflow.roc");
+    defer allocator.free(fixture.path);
+    defer allocator.free(fixture.uri);
+    const platform_path = try platformPath(allocator);
+    defer allocator.free(platform_path);
+
+    const source = try std.fmt.allocPrint(allocator,
+        \\app [main] {{ pf: platform "{s}" }}
+        \\
+        \\main = {{
+        \\    text = "roc"
+        \\    text
+        \\}}
+    , .{platform_path});
+    defer allocator.free(source);
+
+    // 4294967295 is the largest line a u32 position can name.
+    const overflowing = try std.fmt.allocPrint(allocator,
+        \\{{"jsonrpc":"2.0","id":2,"method":"textDocument/inlayHint","params":{{"textDocument":{{"uri":"{s}"}},"range":{{"start":{{"line":0,"character":0}},"end":{{"line":4294967295,"character":0}}}}}}}}
+    , .{fixture.uri});
+    defer allocator.free(overflowing);
+
+    const responses = try runSessionResponses(allocator, tmp_path, fixture.uri, source, &.{overflowing});
+    defer {
+        for (responses) |body| allocator.free(body);
+        allocator.free(responses);
+    }
+
+    // The server answers, and the range is clamped to the end of the document,
+    // so the binding inside the block is still reported.
+    var response = try responseById(allocator, responses, 2);
+    defer response.deinit();
+    const hints = try response.result();
+    try std.testing.expect(hints == .array);
+    const label = try hintLabelAt(hints, 3, 8) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings(": Str", label);
 }
 
 /// Verifies goto definition locates a local variable definition.

--- a/src/lsp/test/test_syntax_driver.zig
+++ b/src/lsp/test/test_syntax_driver.zig
@@ -25,6 +25,7 @@ pub const TestSyntaxDriver = struct {
     rename_calls: usize = 0,
     prepare_rename_calls: usize = 0,
     references_calls: usize = 0,
+    inlay_hint_calls: usize = 0,
 
     pub const CheckError = syntax.SyntaxChecker.CheckError;
     pub const QueryError = syntax.SyntaxChecker.QueryError;
@@ -171,6 +172,17 @@ pub const TestSyntaxDriver = struct {
         _: bool,
     ) QueryError!?syntax.SyntaxChecker.ReferencesResult {
         self.references_calls += 1;
+        return null;
+    }
+
+    pub fn getInlayHints(
+        self: *TestSyntaxDriver,
+        _: []const u8,
+        _: ?[]const u8,
+        _: u32,
+        _: u32,
+    ) QueryError!?syntax.SyntaxChecker.InlayHintsResult {
+        self.inlay_hint_calls += 1;
         return null;
     }
 };


### PR DESCRIPTION
Stacked on #10945 - until that merges, the diff here also shows its commits.
The last three are the inlay-hint work; everything before it belongs to #10945.

## Why

Roc infers most types, and an annotation can still leave parts to inference with
`_`, so the type a binding actually has is frequently written nowhere in the
file. `examples/main.roc` opens with

```roc
number_operators : I64, I64 -> _
```

`textDocument/inlayHint` renders the inferred type next to the name:

```roc
add : I64, I64 -> I64
add = |a: I64, b: I64| a + b
main: I64 = {
    sum: I64 = add(1, 2)
    items: List(Dec) = [1, 2, 3]
    pair: (I64, Str) = (sum, name)
}
```

Tuple destructuring gets one hint per element: `(str: Str, num: Dec) = tup`.

## What is left out

Only plain `assign` patterns qualify - they bind exactly one name, so there is a
name for the type to sit against. Then three kinds are skipped.

Bindings that already carry a written annotation, because repeating what is on
screen is noise. Bindings marked unused with a leading `_`, for the same reason.

And any pattern whose source text is not exactly the name it binds. The hint is
drawn just past the pattern, so it only reads correctly where the source spells
the name and nothing else. Two real cases fail that test, both found by running
this over `examples/main.roc`: a binding the compiler synthesizes while
desugaring `??` has no name in the source at all, and

```roc
import "README.md" as readme : Str
```

has a pattern spanning a type the author already wrote, so the hint would have
rendered `readme : Str: Str`.

## Label length

Labels are cut at 56 bytes, on a UTF-8 boundary, with a trailing ellipsis. A
hint is drawn inside the line it annotates, and an inferred Roc type can be far
longer than the code it describes - the generic functions in `examples/main.roc`
render past 300 characters once their `where` clauses are included:

```
for_loop -> c -> d where [c.iter : c -> Iter(item), d.from_numeral : Numeral -> Try(d, ...
```

Hovering the same name still gives the type in full.

## Behaviour on a broken document

Answers null rather than an empty list, which leaves whatever the editor last
drew in place instead of blanking every hint on each keystroke.


## Positions

Hint positions are UTF-16 columns, as the protocol specifies and as the server
advertises with `positionEncoding`. That comes from #10945, which fixes #10948
and which this branch sits on. Without it a hint on a line where UTF-8 and
UTF-16 lengths differ would be drawn in the wrong place: every hint after the
non-ASCII text shifts by the difference.

