### PR TITLE
Finalize failed platform requirement solutions

### DIFF
--- a/design.md
+++ b/design.md
@@ -2040,6 +2040,13 @@ sibling bindings, and a lookup at a checked-error index lowers to a runtime
 crash. There is no relation-less error fallback and no separate flow that
 "permits" user errors.
 
+Requirement rows may be allocated before their app definitions are checked, but
+they remain explicitly pending checker state until all definition checking and
+error poisoning has completed. The checker then stamps each row as successful
+or checked-error. `platformRequirementSolutionTableFromInputs` and
+`EvidencePass.run` consume that verdict directly; they never infer success by
+inspecting solved type shape or by comparing the eventual runtime value kind.
+
 A platform `provides` declaration must name a top-level value defined in the
 platform module. It cannot name a value from `requires` directly; a platform
 that wants to expose an app-provided value to its host defines an explicit

--- a/src/check/Check.zig
+++ b/src/check/Check.zig
@@ -7454,7 +7454,53 @@ fn checkFileInternal(self: *Self, skip_numeric_defaults: bool) std.mem.Allocator
 
     try self.finalizeBindingSchemeNodes();
 
+    try self.finalizePlatformRequirementSolutions();
+
     self.debugAssertNominalDeclTableComplete();
+}
+
+/// Turn every provisional platform-requirement row into the explicit
+/// successful-binding or checked-error outcome consumed by artifact
+/// publication. This runs after all checker error poisoning, while the checker
+/// still owns the exact source def and solved vars.
+fn finalizePlatformRequirementSolutions(self: *Self) Allocator.Error!void {
+    for (self.platform_requirement_solutions.items) |*solution| {
+        const def = self.cir.store.getDef(solution.def);
+        var checked_error = self.erroneous_value_exprs.contains(def.expr) or
+            self.erroneous_value_patterns.contains(def.pattern);
+
+        if (!checked_error) {
+            checked_error = try canonical_type_keys.containsError(
+                self.gpa,
+                self.types,
+                self.cir,
+                ModuleEnv.varFrom(def.expr),
+            );
+        }
+        if (!checked_error) {
+            checked_error = try canonical_type_keys.containsError(
+                self.gpa,
+                self.types,
+                self.cir,
+                solution.solved_var,
+            );
+        }
+        if (!checked_error) {
+            for (solution.identity_vars) |identity_var| {
+                if (try canonical_type_keys.containsError(
+                    self.gpa,
+                    self.types,
+                    self.cir,
+                    identity_var,
+                )) {
+                    checked_error = true;
+                    break;
+                }
+            }
+        }
+
+        solution.outcome = if (checked_error) .checked_error else .success;
+    }
 }
 
 /// Finish canonicalization's strict-demand relation with the exact local

--- a/src/check/checked_artifact.zig
+++ b/src/check/checked_artifact.zig
@@ -16934,7 +16934,12 @@ const EvidencePass = struct {
         // finished evidence vector across the checked-artifact boundary.
         for (self.platform_requirement_solutions, self.platform_requirement_root_evidence) |solution, *out| {
             out.* = .{};
-            if (!solution.is_function or try solutionVarsReachErr(self.allocator, self.module, solution)) continue;
+            switch (solution.outcome) {
+                .checked_error => continue,
+                .success => {},
+                .pending => checkedArtifactInvariant("platform requirement solution was not finalized before evidence publication", .{}),
+            }
+            if (!solution.is_function) continue;
 
             params.clearRetainingCapacity();
             try self.enumerateParams(solution.solved_var, &params);
@@ -20971,7 +20976,11 @@ fn platformRequirementSolutionTableFromInputs(
     errdefer identity_solutions.deinit(allocator);
 
     for (inputs, root_evidence) |input, evidence| {
-        if (try solutionVarsReachErr(allocator, module, input)) continue;
+        switch (input.outcome) {
+            .checked_error => continue,
+            .success => {},
+            .pending => checkedArtifactInvariant("platform requirement solution was not finalized by checking", .{}),
+        }
 
         const top_level = top_level_values.lookupByDef(input.def) orelse {
             checkedArtifactInvariant("platform requirement solution references a def with no published top-level value", .{});
@@ -21026,28 +21035,6 @@ fn platformRequirementSolutionTableFromInputs(
         .solutions = try solutions.toOwnedSlice(allocator),
         .identity_solutions = try identity_solutions.toOwnedSlice(allocator),
     };
-}
-
-fn solutionVarsReachErr(
-    allocator: Allocator,
-    module: TypedCIR.Module,
-    input: requirement_solution.SolutionInput,
-) Allocator.Error!bool {
-    if (try canonical_type_keys.containsError(
-        allocator,
-        module.typeStoreConst(),
-        module.moduleEnvConst(),
-        input.solved_var,
-    )) return true;
-    for (input.identity_vars) |identity_var| {
-        if (try canonical_type_keys.containsError(
-            allocator,
-            module.typeStoreConst(),
-            module.moduleEnvConst(),
-            identity_var,
-        )) return true;
-    }
-    return false;
 }
 
 /// Public `PlatformRequiredBinding` declaration.

--- a/src/check/requirement_solution.zig
+++ b/src/check/requirement_solution.zig
@@ -11,6 +11,12 @@ const can = @import("can");
 
 /// One solved platform requirement, produced while checking an app root.
 pub const SolutionInput = struct {
+    pub const Outcome = enum {
+        pending,
+        success,
+        checked_error,
+    };
+
     /// Index of the requirement in the platform's requires clause. Equals the
     /// platform-side `PlatformRequiredDeclarationId` by construction: both are
     /// assigned positionally over the same `requires_types` list.
@@ -23,6 +29,11 @@ pub const SolutionInput = struct {
     /// Whether the platform declares this requirement at a function type
     /// (procedure value) rather than a non-function type (const value).
     is_function: bool,
+    /// Explicit checker verdict for this requirement. Rows are created before
+    /// their app definitions are checked, then finalized after all checker
+    /// error poisoning has completed. Artifact publication only consumes the
+    /// two final states.
+    outcome: Outcome = .pending,
     /// The requirement type's identity variables (flex/rigid), instantiated
     /// into the app's store, in canonical identity-slot order—the
     /// first-encounter order the canonical type key digest assigns

--- a/src/compile/coordinator.zig
+++ b/src/compile/coordinator.zig
@@ -5861,6 +5861,76 @@ test "app artifact records platform requirement solutions from checking" {
     );
 }
 
+fn writeErroneousFunctionRequirementFixture(tmp_dir: *std.testing.TmpDir) (std.Io.Dir.CreateDirPathError || std.Io.Dir.WriteFileError)!void {
+    try tmp_dir.dir.createDirPath(std.testing.io, "app/.roc_error_platform");
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "app/main.roc",
+        .data =
+        \\app [main!] { pf: platform "./.roc_error_platform/main.roc" }
+        \\
+        \\User := { id : U32, contact : [Email(Str)] }
+        \\
+        \\main! : {} -> Try({}, {})
+        \\main! = {
+        \\    user : User
+        \\    user = { id: 10, contain: Email("user@example.com") }
+        \\
+        \\    Ok({})
+        \\}
+        ,
+    });
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "app/.roc_error_platform/main.roc",
+        .data =
+        \\platform ""
+        \\    requires {} { main! : {} -> Try({}, {}) }
+        \\    exposes []
+        \\    packages {}
+        \\    provides { "roc_entry": entry }
+        \\
+        \\entry : {} -> Try({}, {})
+        \\entry = |_| main!({})
+        ,
+    });
+}
+
+test "erroneous function requirement publishes an explicit checked-error outcome" {
+    const allocator = std.testing.allocator;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try writeErroneousFunctionRequirementFixture(&tmp_dir);
+    const app_path = try tmp_dir.dir.realPathFileAlloc(std.testing.io, "app/main.roc", allocator);
+    defer allocator.free(app_path);
+
+    const roc_ctx = CoreCtx.os(allocator, allocator, std.testing.io);
+    const builtin_modules = try sharedBuiltinModules();
+    var coord = try Coordinator.init(
+        allocator,
+        .single_threaded,
+        1,
+        roc_target.RocTarget.detectNative(),
+        builtin_modules,
+        build_options.compiler_version,
+        null,
+        roc_ctx,
+    );
+    defer coord.deinit();
+    coord.enable_hosted_transform = true;
+
+    var arena_impl = base.SingleThreadArena.init(allocator);
+    defer arena_impl.deinit();
+    const arena = arena_impl.allocator();
+
+    try coord.start();
+    try coord.discoverAppFromPath(arena, .{ .entry_path = app_path });
+    try coord.coordinatorLoop();
+    try std.testing.expect(coord.hasUserErrors());
+
+    const app_artifact = coord.appRootCheckedArtifact();
+    try std.testing.expectEqual(@as(usize, 0), app_artifact.platform_requirement_solutions.solutions.len);
+}
+
 fn writeAliasBackingRequirementFixture(tmp_dir: *std.testing.TmpDir) (std.Io.Dir.CreateDirPathError || std.Io.Dir.WriteFileError)!void {
     try tmp_dir.dir.createDirPath(std.testing.io, "app/.roc_state_platform");
     try tmp_dir.dir.writeFile(std.testing.io, .{

--- a/src/lsp/test/handler_integration_tests.zig
+++ b/src/lsp/test/handler_integration_tests.zig
@@ -117,6 +117,41 @@ fn stringField(value: std.json.Value, name: []const u8) integration_spec.SpecErr
     return field_value.string;
 }
 
+fn expectBuiltinDefinitionAtDeclaration(
+    allocator: std.mem.Allocator,
+    responses: [][]u8,
+    response_id: i64,
+    declaration: []const u8,
+) integration_spec.SpecError!void {
+    const declaration_offset = std.mem.find(u8, compiled_builtins.builtin_source, declaration) orelse
+        return error.TestUnexpectedResult;
+    if (std.mem.findPos(u8, compiled_builtins.builtin_source, declaration_offset + declaration.len, declaration) != null) {
+        return error.TestUnexpectedResult;
+    }
+
+    var expected_line: i64 = 0;
+    var expected_character: i64 = 0;
+    for (compiled_builtins.builtin_source[0..declaration_offset]) |byte| {
+        if (byte == '\n') {
+            expected_line += 1;
+            expected_character = 0;
+        } else {
+            expected_character += 1;
+        }
+    }
+
+    var response = try responseById(allocator, responses, response_id);
+    defer response.deinit();
+    const result = try response.result();
+    try std.testing.expect(result == .object);
+    const uri = try stringField(result, "uri");
+    try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
+    const range = try objectField(result, "range");
+    const start = try objectField(range, "start");
+    try std.testing.expectEqual(expected_line, try integerField(start, "line"));
+    try std.testing.expectEqual(expected_character, try integerField(start, "character"));
+}
+
 fn expectRange(
     range: std.json.Value,
     start_line: i64,
@@ -823,18 +858,7 @@ pub fn definitionHandlerNavigatesToBuiltinTypeFromTypeAnnotation() integration_s
         allocator.free(responses);
     }
 
-    var response = try responseById(allocator, responses, 2);
-    defer response.deinit();
-    const result = try response.result();
-    try std.testing.expect(result == .object);
-    const uri = try stringField(result, "uri");
-    try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
-    const range = try objectField(result, "range");
-    const start = try objectField(range, "start");
-    const start_line = try integerField(start, "line");
-    // Str is declared around line 2204 in Builtin.roc
-    try std.testing.expect(start_line > 0);
-    try std.testing.expectEqual(@as(i64, 2204), start_line);
+    try expectBuiltinDefinitionAtDeclaration(allocator, responses, 2, "Str :: [ProvidedByCompiler].{");
 }
 
 /// Verifies document symbols still work after a goto-definition request.
@@ -2258,75 +2282,16 @@ pub fn definitionHandlerNavigatesToBuiltinDeclarations() integration_spec.SpecEr
         allocator.free(responses);
     }
 
-    // Str.is_empty (id: 2) -> line 2219 (0-based)
-    {
-        var response = try responseById(allocator, responses, 2);
-        defer response.deinit();
-        const result = try response.result();
-        try std.testing.expect(result == .object);
-        const uri = try stringField(result, "uri");
-        try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
-        const range = try objectField(result, "range");
-        const start = try objectField(range, "start");
-        const start_line = try integerField(start, "line");
-        try std.testing.expectEqual(@as(i64, 2219), start_line);
-    }
-
-    // List.is_empty (id: 3) -> line 3572 (0-based)
-    {
-        var response = try responseById(allocator, responses, 3);
-        defer response.deinit();
-        const result = try response.result();
-        try std.testing.expect(result == .object);
-        const uri = try stringField(result, "uri");
-        try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
-        const range = try objectField(result, "range");
-        const start = try objectField(range, "start");
-        const start_line = try integerField(start, "line");
-        try std.testing.expectEqual(@as(i64, 3572), start_line);
-    }
-
-    // List.append (id: 4) -> line 3933 (0-based)
-    {
-        var response = try responseById(allocator, responses, 4);
-        defer response.deinit();
-        const result = try response.result();
-        try std.testing.expect(result == .object);
-        const uri = try stringField(result, "uri");
-        try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
-        const range = try objectField(result, "range");
-        const start = try objectField(range, "start");
-        const start_line = try integerField(start, "line");
-        try std.testing.expectEqual(@as(i64, 3933), start_line);
-    }
-
-    // Dict.update (id: 5) -> line 6188 (0-based)
-    {
-        var response = try responseById(allocator, responses, 5);
-        defer response.deinit();
-        const result = try response.result();
-        try std.testing.expect(result == .object);
-        const uri = try stringField(result, "uri");
-        try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
-        const range = try objectField(result, "range");
-        const start = try objectField(range, "start");
-        const start_line = try integerField(start, "line");
-        try std.testing.expectEqual(@as(i64, 6188), start_line);
-    }
-
-    // Dict prefix (id: 6) -> line 5542 (0-based)
-    {
-        var response = try responseById(allocator, responses, 6);
-        defer response.deinit();
-        const result = try response.result();
-        try std.testing.expect(result == .object);
-        const uri = try stringField(result, "uri");
-        try std.testing.expect(std.mem.endsWith(u8, uri, "Builtin.roc"));
-        const range = try objectField(result, "range");
-        const start = try objectField(range, "start");
-        const start_line = try integerField(start, "line");
-        try std.testing.expectEqual(@as(i64, 5542), start_line);
-    }
+    try expectBuiltinDefinitionAtDeclaration(allocator, responses, 2, "is_empty : Str -> Bool");
+    try expectBuiltinDefinitionAtDeclaration(allocator, responses, 3, "is_empty : List(_item) -> Bool");
+    try expectBuiltinDefinitionAtDeclaration(allocator, responses, 4, "append : List(a), a -> List(a)");
+    try expectBuiltinDefinitionAtDeclaration(
+        allocator,
+        responses,
+        5,
+        "update : Dict(k, v), k, (Try(v, [Missing]) -> Try(v, [Missing])) -> Dict(k, v)",
+    );
+    try expectBuiltinDefinitionAtDeclaration(allocator, responses, 6, "Dict(k, v) :: [");
 }
 
 /// Verifies that an ordinary workspace document whose path ends in Builtin.roc (e.g. MyBuiltin.roc)


### PR DESCRIPTION
Closes #10899.

Platform requirement solution rows were allocated before their app definitions were checked, but later consumers inferred whether those provisional rows succeeded by inspecting solved type graphs. An erroneous function entrypoint could therefore remain labeled as a procedure requirement while its published top-level value became a checked-error constant, triggering the checked-artifact value-kind invariant.

This change makes the checker finalize every provisional requirement row after error poisoning with an explicit success or checked-error verdict. Checked artifact and dispatch evidence construction consume that verdict directly. It adds a coordinator regression covering an erroneous function-valued requirement.

While verifying MiniCI, the Builtin navigation LSP test exposed stale hardcoded line numbers already present on main. Those assertions now derive exact line and character locations from the embedded Builtin source, avoiding unrelated documentation edits breaking the test.

Verification:
- zig build run-test-zig-module-compile -j2
- zig build run-test-zig-module-check -j2
- zig build run-test-zig-module-lsp_integration --summary all --color off (64/64)
- zig build minici -j2 (76/76)
- zig build run-check-zig-format
- zig build run-check-zig-lints
- zig build run-check-tidy
- zig build run-check-semantic-audit