### PR TITLE
Fix wasm Json.parser_camel field-name corruption

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4802,6 +4802,17 @@ pub fn build(b: *std.Build) void {
         build_wasm_str_concat_join_app.step.dependOn(build_test_hosts_step);
         build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_str_concat_join_app.step);
 
+        const build_wasm_issue_10957_app = b.addRunArtifact(roc_exe);
+        build_wasm_issue_10957_app.addArgs(&.{
+            "build",
+            "test/wasm/issue_10957_json_camel_long_field_static_lib_app.roc",
+            "--opt=dev",
+            "--target=wasm32",
+            "--output=test/wasm/issue_10957_json_camel_long_field_static_lib_app.wasm",
+        });
+        build_wasm_issue_10957_app.step.dependOn(build_test_hosts_step);
+        build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_issue_10957_app.step);
+
         const build_wasm_str_interp_leading_literal_app = b.addRunArtifact(roc_exe);
         build_wasm_str_interp_leading_literal_app.addArgs(&.{
             "build",
@@ -5032,6 +5043,16 @@ pub fn build(b: *std.Build) void {
             });
             run_wasm_str_concat_join_test.step.dependOn(build_test_wasm_static_lib_runner_step);
             run_test_wasm_static_lib_step.dependOn(&run_wasm_str_concat_join_test.step);
+
+            const run_wasm_issue_10957_test = b.addRunArtifact(wasm_test_exe);
+            run_wasm_issue_10957_test.addArgs(&.{
+                "--wasm-path",
+                "test/wasm/issue_10957_json_camel_long_field_static_lib_app.wasm",
+                "--expected",
+                "14",
+            });
+            run_wasm_issue_10957_test.step.dependOn(build_test_wasm_static_lib_runner_step);
+            run_test_wasm_static_lib_step.dependOn(&run_wasm_issue_10957_test.step);
 
             const run_wasm_str_interp_leading_literal_test = b.addRunArtifact(wasm_test_exe);
             run_wasm_str_interp_leading_literal_test.addArgs(&.{

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -18355,9 +18355,12 @@ fn emitStrToUtf8(self: *Self, str_arg: ProcLocalId) Allocator.Error!void {
         try self.emitLocalSet(str_cap);
 
         // Non-SSO Str.to_utf8 returns a List(U8) that aliases the string bytes.
-        // Retain the shared backing so dropping the list does not invalidate the
-        // input Str that ARC still owns.
-        try self.emitDataPtrIncref(str_data, 1);
+        // A seamless string slice's data pointer points inside its allocation,
+        // so decode the allocation pointer before retaining the shared backing.
+        const alloc_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        const is_small = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitDecodeStrAllocPtr(str_ptr, alloc_ptr, is_small);
+        try self.emitDataPtrIncref(alloc_ptr, 1);
 
         try self.emitLocalGet(result_ptr);
         try self.emitLocalGet(str_data);

--- a/test/wasm/issue_10957_json_camel_long_field_static_lib_app.roc
+++ b/test/wasm/issue_10957_json_camel_long_field_static_lib_app.roc
@@ -1,0 +1,21 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.FallibleHost
+
+parse_article : Str -> Try({ favorites_count : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
+parse_article = |input| {
+    parse : Str -> Try({ favorites_count : U64 }, [InvalidJson(Str), MissingRequiredField(Str)])
+    parse = Json.parser_camel()
+    parse(input)
+}
+
+main! : () => Str
+main! = || {
+    input = FallibleHost.json_input!({})
+
+    match parse_article(input) {
+        Ok(article) => if article.favorites_count == 14 { "14" } else { "wrong-value" }
+        Err(MissingRequiredField(field)) => Str.concat("missing:", field)
+        Err(InvalidJson(message)) => Str.concat("invalid:", message)
+    }
+}

--- a/test/wasm/platform/FallibleHost.roc
+++ b/test/wasm/platform/FallibleHost.roc
@@ -1,3 +1,4 @@
 FallibleHost := [].{
     str_ok! : {} => Try(Str, [HostErr(Str)])
+    json_input! : {} => Str
 }

--- a/test/wasm/platform/host.zig
+++ b/test/wasm/platform/host.zig
@@ -127,6 +127,24 @@ export fn roc_fallible_str_ok() callconv(.c) FallibleStrResult {
     };
 }
 
+const json_input = "{\"favoritesCount\":14}";
+var json_input_storage: [@sizeOf(usize) + json_input.len]u8 align(@alignOf(usize)) =
+    ([_]u8{0} ** @sizeOf(usize)) ++ json_input.*;
+
+export fn roc_json_input() callconv(.c) RocStr {
+    const HostRocStr = extern struct {
+        bytes: ?[*]u8,
+        capacity_or_alloc_ptr: usize,
+        length: usize,
+    };
+    const bytes = json_input_storage[@sizeOf(usize)..].ptr;
+    return @bitCast(HostRocStr{
+        .bytes = bytes,
+        .capacity_or_alloc_ptr = RocStr.encodeCapacity(json_input.len),
+        .length = json_input.len,
+    });
+}
+
 fn canaryBlob(comptime marker: []const u8) [4096]u8 {
     @setEvalBranchQuota(20000);
     var blob: [4096]u8 = undefined;

--- a/test/wasm/platform/main.roc
+++ b/test/wasm/platform/main.roc
@@ -5,6 +5,7 @@ platform ""
     provides { "roc_main": main_for_host! }
     hosted {
         "roc_fallible_str_ok": FallibleHost.str_ok!,
+        "roc_json_input": FallibleHost.json_input!,
         "roc_stdout_line": Stdout.line!,
         "roc_stdout_unused_niche_feature": Stdout.unused_niche_feature!,
     }


### PR DESCRIPTION
Closes #10957.
Closes https://github.com/roc-lang/roc/issues/10958.

## Root cause

The wasm dev backend inline lowering for `Str.to_utf8` retained non-small strings by incrementing their visible data pointer. For seamless string slices, that pointer is inside the backing allocation, so the refcount write corrupted the allocation bytes. `Json.parser_camel` exposes this when camel-casing a long snake-case field: `Str.split_first` creates seamless sibling slices and `upper_first_ascii` converts the suffix through UTF-8, corrupting the prefix.

## Fix

Decode the backing allocation pointer from the complete `RocStr` representation before retaining it, using the same explicit decoding used by wasm ARC helpers.

## Regression

Add a wasm32 static-library test that constructs `Json.parser_camel()` locally and parses `{"favoritesCount":14}` into a record with `favorites_count`. Before the fix it reports the corrupted missing field `favositesCount`; after the fix it returns `14`.

## Testing

- `zig build run-test-wasm-static-lib -Doptimize=Debug`