### PR TITLE
Fix wasm Str.to_utf8 seamless slice retain

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4791,6 +4791,17 @@ pub fn build(b: *std.Build) void {
         build_wasm_hosted_try_widen_app.step.dependOn(build_test_hosts_step);
         build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_hosted_try_widen_app.step);
 
+        const build_wasm_issue_10958_app = b.addRunArtifact(roc_exe);
+        build_wasm_issue_10958_app.addArgs(&.{
+            "build",
+            "test/wasm/issue_10958_hosted_payload_decode_static_lib_app.roc",
+            "--opt=dev",
+            "--target=wasm32",
+            "--output=test/wasm/issue_10958_hosted_payload_decode_static_lib_app.wasm",
+        });
+        build_wasm_issue_10958_app.step.dependOn(build_test_hosts_step);
+        build_test_wasm_static_lib_runner_step.dependOn(&build_wasm_issue_10958_app.step);
+
         const build_wasm_str_concat_join_app = b.addRunArtifact(roc_exe);
         build_wasm_str_concat_join_app.addArgs(&.{
             "build",
@@ -5020,6 +5031,19 @@ pub fn build(b: *std.Build) void {
             });
             run_wasm_hosted_try_widen_test.step.dependOn(build_test_wasm_static_lib_runner_step);
             run_test_wasm_static_lib_step.dependOn(&run_wasm_hosted_try_widen_test.step);
+
+            const run_wasm_issue_10958_test = b.addRunArtifact(wasm_test_exe);
+            run_wasm_issue_10958_test.addArgs(&.{
+                "--wasm-path",
+                "test/wasm/issue_10958_hosted_payload_decode_static_lib_app.wasm",
+                "--expected",
+                "ok",
+                "--assert-alloc-balanced",
+                "--min-allocs",
+                "1",
+            });
+            run_wasm_issue_10958_test.step.dependOn(build_test_wasm_static_lib_runner_step);
+            run_test_wasm_static_lib_step.dependOn(&run_wasm_issue_10958_test.step);
 
             const run_wasm_str_concat_join_test = b.addRunArtifact(wasm_test_exe);
             run_wasm_str_concat_join_test.addArgs(&.{

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -18355,9 +18355,12 @@ fn emitStrToUtf8(self: *Self, str_arg: ProcLocalId) Allocator.Error!void {
         try self.emitLocalSet(str_cap);
 
         // Non-SSO Str.to_utf8 returns a List(U8) that aliases the string bytes.
-        // Retain the shared backing so dropping the list does not invalidate the
-        // input Str that ARC still owns.
-        try self.emitDataPtrIncref(str_data, 1);
+        // A seamless slice's data pointer is interior to its allocation, so
+        // retain the explicit allocation pointer encoded in the string header.
+        const str_alloc_ptr = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        const str_is_small = self.storage.allocAnonymousLocal(.i32) catch return error.OutOfMemory;
+        try self.emitDecodeStrAllocPtr(str_ptr, str_alloc_ptr, str_is_small);
+        try self.emitDataPtrIncref(str_alloc_ptr, 1);
 
         try self.emitLocalGet(result_ptr);
         try self.emitLocalGet(str_data);

--- a/test/wasm/issue_10958_hosted_payload_decode_static_lib_app.roc
+++ b/test/wasm/issue_10958_hosted_payload_decode_static_lib_app.roc
@@ -1,0 +1,27 @@
+app [main!] { pf: platform "./platform/main.roc" }
+
+import pf.Task
+
+field_at : List(Str), U64 -> Str
+field_at = |parts, index|
+    match parts.get(index) {
+        Ok(value) => value
+        Err(_) => ""
+    }
+
+main! : () => Str
+main! = || {
+    payload = Task.payload!({})
+    parts = payload.split_on(",")
+    depart = field_at(parts, 2)
+
+    # `depart` is a seamless slice into `payload`. Converting it to bytes
+    # creates another owner of that backing allocation, while the comparison
+    # below keeps the string owner live too.
+    bytes = depart.to_utf8()
+    if bytes.len() > 0 and depart != "" {
+        "ok"
+    } else {
+        "bad"
+    }
+}

--- a/test/wasm/platform/Task.roc
+++ b/test/wasm/platform/Task.roc
@@ -1,0 +1,3 @@
+Task := [].{
+    payload! : {} => Str
+}

--- a/test/wasm/platform/host.zig
+++ b/test/wasm/platform/host.zig
@@ -20,6 +20,8 @@ const std = @import("std");
 const builtins = @import("builtins");
 const host_alloc = @import("host_alloc");
 
+pub const roc_host_call_mode: builtins.host_abi.HostCallMode = .extern_symbols;
+
 const shim_symbols = builtins.shim_symbols;
 
 const RocStr = builtins.str.RocStr;
@@ -125,6 +127,10 @@ export fn roc_fallible_str_ok() callconv(.c) FallibleStrResult {
         .payload = .{ .ok = RocStr.fromSliceSmall("ok") },
         .tag = .ok,
     };
+}
+
+export fn roc_task_payload() callconv(.c) RocStr {
+    return RocStr.fromSlice("zero,one,this field is long enough", undefined);
 }
 
 fn canaryBlob(comptime marker: []const u8) [4096]u8 {

--- a/test/wasm/platform/main.roc
+++ b/test/wasm/platform/main.roc
@@ -1,10 +1,11 @@
 platform ""
     requires {} { main! : () => Str }
-    exposes [Stdout, FallibleHost]
+    exposes [Stdout, FallibleHost, Task]
     packages {}
     provides { "roc_main": main_for_host! }
     hosted {
         "roc_fallible_str_ok": FallibleHost.str_ok!,
+        "roc_task_payload": Task.payload!,
         "roc_stdout_line": Stdout.line!,
         "roc_stdout_unused_niche_feature": Stdout.unused_niche_feature!,
     }
@@ -18,6 +19,7 @@ platform ""
 
 import Stdout
 import FallibleHost
+import Task
 
 main_for_host! : () => Str
 main_for_host! = main!


### PR DESCRIPTION
Fixes #10958.

## Root cause

The wasm dev backend lowers non-SSO `Str.to_utf8` by returning a `List(U8)` that aliases the string allocation and retaining the shared backing. For seamless strings, it retained the interior bytes pointer instead of the allocation pointer explicitly encoded in `capacity_or_alloc_ptr`. The returned list correctly carried the encoded allocation pointer and therefore released the real allocation, leaving one unmatched release and eventually double-freeing the hosted task payload.

## Fix

Decode and retain the string allocation pointer before constructing the aliasing byte list. This follows the same explicit seamless-slice representation already used by wasm RC helpers.

## Regression test

Add a wasm static-lib cart that returns a heap string from a hosted function, takes a seamless slice with `split_on`, converts that slice with `to_utf8` while keeping the string live, and asserts canonical allocation/deallocation balance. Before the fix it reports `alloc=2, dealloc=3`; after the fix it passes.

## Verification

- `zig build run-test-wasm-static-lib`
- `zig build run-test-zig-module-backend`
- `zig build run-check-zig-format`
- `zig build run-check-zig-lints`
- `zig build run-check-tidy`
- `zig build run-check-test-wiring`