### PR TITLE
Stop deleting arbitrary roc-prefixed temp directories

### DIFF
--- a/src/compile/cache_cleanup.zig
+++ b/src/compile/cache_cleanup.zig
@@ -115,13 +115,9 @@ fn runCleanup(bases: Bases, std_io: Io) void {
     const now_ns = nowNs(std_io);
 
     // TODO: REMOVE THIS FOR THE 0.1.0 RELEASE - NOT NEEDED ANYMORE
-    // This is just to clean up people who have old stale Roc caches from before
-    // we restructured the cache directories to use roc/{version}/ structure.
-    // The legacy temp layout lived directly in the system temp dir (the parent
-    // of `<tmp>/roc`), so walk that parent.
-    if (std.fs.path.dirname(bases.tempBase())) |legacy_temp_root| {
-        cleanupLegacyTempDirs(std_io, legacy_temp_root, null);
-    }
+    // This is just to clean up people who have old stale persistent Roc caches
+    // from before we restructured the cache directories to use roc/{version}/
+    // structure.
     cleanupLegacyPersistentCache(std_io, bases.cacheBase(), null);
     // END OF LEGACY CLEANUP - REMOVE ABOVE FOR 0.1.0
 
@@ -288,31 +284,8 @@ pub fn deleteTempDir(std_io: Io, temp_dir_path: []const u8) void {
 }
 
 // TODO: REMOVE THESE FOR THE 0.1.0 RELEASE - NOT NEEDED ANYMORE
-// These clean up old cache directories from before we restructured to use
-// the roc/{version}/ directory structure.
-
-/// Clean up legacy temp directories that used the old "roc-*" prefix pattern.
-/// Old structure: <legacy_temp_root>/roc-{random}/ (directly in temp, with roc- prefix)
-/// New structure: <legacy_temp_root>/roc/{version}/{random}/
-fn cleanupLegacyTempDirs(std_io: Io, legacy_temp_root: []const u8, maybe_stats: ?*CleanupStats) void {
-    var root = Dir.cwd().openDir(std_io, legacy_temp_root, .{ .iterate = true }) catch return;
-    defer root.close(std_io);
-
-    // Look for directories matching the old "roc-*" naming convention and
-    // remove them unconditionally (this format is no longer produced).
-    var it = root.iterate();
-    while (true) {
-        const entry = (it.next(std_io) catch break) orelse break;
-        if (entry.kind != .directory) continue;
-        if (!std.mem.startsWith(u8, entry.name, "roc-")) continue;
-
-        root.deleteTree(std_io, entry.name) catch {
-            if (maybe_stats) |stats| stats.errors += 1;
-            continue;
-        };
-        if (maybe_stats) |stats| stats.temp_dirs_deleted += 1;
-    }
-}
+// This cleans up old persistent cache entries from before we restructured to
+// use the roc/{version}/ directory structure.
 
 /// Clean up legacy persistent cache that used the old flat structure.
 /// Old structure: ~/.cache/roc/{hash}/ or ~/.cache/roc/*.rcache (flat)
@@ -372,6 +345,39 @@ test "CleanupStats initializes to zero" {
     try std.testing.expectEqual(@as(u32, 0), stats.cache_files_deleted);
     try std.testing.expectEqual(@as(u32, 0), stats.empty_dirs_deleted);
     try std.testing.expectEqual(@as(u32, 0), stats.errors);
+}
+
+test "background cleanup preserves unrelated roc-prefixed temp directories" {
+    const allocator = std.testing.allocator;
+
+    var tmp_dir = std.testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const root_path = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", &tmp_dir.sub_path });
+    defer allocator.free(root_path);
+    const temp_base = try std.fs.path.join(allocator, &.{ root_path, "roc" });
+    defer allocator.free(temp_base);
+    const cache_base = try std.fs.path.join(allocator, &.{ root_path, "cache" });
+    defer allocator.free(cache_base);
+    const unrelated_dir = try std.fs.path.join(allocator, &.{ root_path, "roc-active-cache" });
+    defer allocator.free(unrelated_dir);
+    const sentinel_path = try std.fs.path.join(allocator, &.{ unrelated_dir, "sentinel" });
+    defer allocator.free(sentinel_path);
+
+    try Dir.cwd().createDirPath(std.testing.io, temp_base);
+    try Dir.cwd().createDirPath(std.testing.io, cache_base);
+    try Dir.cwd().createDirPath(std.testing.io, unrelated_dir);
+    (try Dir.cwd().createFile(std.testing.io, sentinel_path, .{})).close(std.testing.io);
+
+    var bases = Bases{};
+    @memcpy(bases.temp_buf[0..temp_base.len], temp_base);
+    bases.temp_len = temp_base.len;
+    @memcpy(bases.cache_buf[0..cache_base.len], cache_base);
+    bases.cache_len = cache_base.len;
+
+    runCleanup(bases, std.testing.io);
+
+    try Dir.cwd().access(std.testing.io, sentinel_path, .{});
 }
 
 test "deleteTempDir deletes directory and coordination file" {


### PR DESCRIPTION
## Summary

Remove the obsolete legacy system-temp sweep that recursively deleted every directory whose basename started with `roc-`.

Keep the current versioned temp cleanup and the separately scoped legacy persistent-cache migration cleanup unchanged.

## Root cause

`runCleanup` derived the parent of Roc’s current temp base and passed it to `cleanupLegacyTempDirs`. On Linux that parent is normally `/tmp`. The legacy cleanup then deleted every `roc-*` directory under that shared namespace unconditionally, without checking age, contents, ownership, or whether another process was actively using it.

I found this while testing roc-signals with an isolated package cache:

```sh
XDG_CACHE_HOME=/tmp/roc-cold-cache.XXXXXX roc build ...
```

The compiler’s background cleanup could remove that live cache while package extraction or compilation was in progress. Depending on timing, the build reported `DownloadFailed`, a missing cached `main.roc`, or a missing packaged `targets/wasm32/host.wasm`. A passive `/tmp/roc-*` sentinel was also removed by any concurrently running unfixed compiler, confirming that package and wasm validation were only downstream symptoms.

The legacy sweep was temporary migration code already marked for removal before 0.1.0. There is no safe way to infer ownership of arbitrary shared-temp directories from a broad name prefix, so this removes the sweep instead of adding another filename heuristic.

## Regression

The new test invokes `runCleanup` with controlled temp and cache roots and places a sentinel in an unrelated `roc-active-cache` sibling directory.

Before the fix:

```text
cache_cleanup.test.background cleanup preserves unrelated roc-prefixed temp directories failed
```

After removing the legacy sweep, the sentinel remains present.

## Verification

- `zig build run-test-zig-module-compile -- --test-filter "background cleanup preserves unrelated roc-prefixed temp directories"`
- `zig build run-test-zig-module-compile`
- `zig build minici`: 76/76 phases passed
- `zig fmt --check src/compile/cache_cleanup.zig`
- `git diff --check`
