### PR TITLE
Freeze specialization graphs before shard handoff

### DIFF
--- a/ci/check_postcheck_architecture.pl
+++ b/ci/check_postcheck_architecture.pl
@@ -272,7 +272,13 @@ sub check_active_body_draft_seal_access {
             $fn_depth = 0;
         }
 
-        if (!$in_test && ($current_fn // '') ne 'sealActiveBodyDraft') {
+        # `sealActiveBodyDraft` composes the synchronous path, while
+        # `commitFinalizedBodyDraft` is the same ordered commit suffix used
+        # after a queued shard crosses the coordinator handoff.
+        my $owns_body_draft_commit =
+            ($current_fn // '') eq 'sealActiveBodyDraft' ||
+            ($current_fn // '') eq 'commitFinalizedBodyDraft';
+        if (!$in_test && !$owns_body_draft_commit) {
             if ($line =~ /\b[A-Za-z_][A-Za-z0-9_]*\.sealCoreIntoProgram\(/) {
                 push @violations, "$rel:$line_no: active-body-draft-seal-bypass: $line";
             }

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -1946,17 +1946,15 @@ const PendingTemplateBody = struct {
 };
 
 /// Owned handoff between queued body lowering and ordered coordinator commit.
-/// Keeping graph and draft ownership together makes every graph-local and
-/// draft-local id valid until the existing relocation commit consumes it.
-/// Type/name stores and builder caches remain shared in this first slice; later
-/// shards move those Monotype and name stores behind the same ownership boundary.
+/// Deferred relation production and graph validation finish before this handoff,
+/// so commit only seals durable types, relocates ids, and appends program data.
+/// Type/name stores, deferred preparation, and builder caches remain shared in
+/// this transitional slice; later shards move them behind the same boundary.
 const CompletedSpecJobShard = struct {
     dispatch_index: u64,
     graph: *InstGraph,
     body_draft: BodyDraftStore,
     pending: PendingTemplateBody,
-    final_guard: FinalBodyOutputGuard,
-    final_end: FinalBodyOutputGuard.End,
 
     fn deinit(self: *CompletedSpecJobShard) void {
         self.body_draft.deinit();
@@ -4005,11 +4003,14 @@ const Builder = struct {
         self.next_spec_accept_index += 1;
     }
 
-    /// Lower one ordinary queued specialization into independently owned graph
-    /// and syntax state. Coordinator-owned type sealing and program appends
-    /// happen only after this result is returned. Representation-sensitive
-    /// immediate callees still complete synchronously until inline outputs also
-    /// move into the shard protocol.
+    /// Lower one ordinary queued specialization into independently owned frozen
+    /// graph and prepared syntax state. Coordinator-owned type sealing and
+    /// program appends happen only after this result is returned.
+    ///
+    /// Deferred preparation and iterator identity calculation still use shared
+    /// Builder/type/name state and execute serially here. Representation-sensitive
+    /// immediate callees also complete synchronously until those outputs move
+    /// into the shard protocol.
     fn lowerPendingSpecJobToShard(
         self: *Builder,
         job: PendingSpecJob,
@@ -4046,29 +4047,26 @@ const Builder = struct {
             job.signature_relation,
         );
         const final_end = final_guard.end(self);
+        try self.finalizeBodyDraftGraph(graph, &body_draft, final_guard, final_end);
         self.countBodyDiagnostic("spec_job_shards_lowered");
         return .{
             .dispatch_index = job.dispatch_index,
             .graph = graph,
             .body_draft = body_draft,
             .pending = pending,
-            .final_guard = final_guard,
-            .final_end = final_end,
         };
     }
 
-    /// Accept one completed shard in logical dispatch order and reuse the
-    /// existing exhaustive draft-to-program relocation commit.
+    /// Accept one frozen shard in logical dispatch order and reuse the existing
+    /// exhaustive draft-to-program relocation commit.
     fn commitCompletedSpecJobShard(
         self: *Builder,
         shard: *CompletedSpecJobShard,
     ) Allocator.Error!void {
         self.requireNextSpecAcceptance(shard.dispatch_index);
-        const sealed = try self.sealActiveBodyDraft(
+        const sealed = try self.commitFinalizedBodyDraft(
             shard.graph,
             &shard.body_draft,
-            shard.final_guard,
-            shard.final_end,
             shard.pending.root_node,
             &.{},
             null,
@@ -7723,6 +7721,31 @@ const Builder = struct {
         root_def: ?DraftDefId,
         root_fn: ?DraftFnId,
     ) Allocator.Error!ActiveBodyDraftSeal {
+        try self.finalizeBodyDraftGraph(graph, body_draft, final_guard, final_end);
+        return self.commitFinalizedBodyDraft(
+            graph,
+            body_draft,
+            root_node,
+            root_nodes,
+            extra_ty,
+            root_def,
+            root_fn,
+        );
+    }
+
+    /// Finish every relation-producing draft operation and freeze the graph
+    /// before an owned specialization result can cross the coordinator handoff.
+    ///
+    /// Deferred preparation remains serialized because it can reenter lowering
+    /// and mutate shared Builder state. Iterator identity calculation also still
+    /// reads the graph's shared type and name stores in this transitional slice.
+    fn finalizeBodyDraftGraph(
+        self: *Builder,
+        graph: *InstGraph,
+        body_draft: *BodyDraftStore,
+        final_guard: FinalBodyOutputGuard,
+        final_end: FinalBodyOutputGuard.End,
+    ) Allocator.Error!void {
         var timing_scope = ProcedureTimingScope.begin(self.timing, .body_finalization);
         defer timing_scope.end();
 
@@ -7730,6 +7753,7 @@ const Builder = struct {
         if (body_draft.active_callable_eval_bindings.items.len != 0) {
             Common.invariant("unfinished callable eval binding reached Monotype body sealing");
         }
+        const finalization_guard = FinalBodyOutputGuard.begin(self);
         try self.prepareDraftDeferredExprs(body_draft, graph);
         try graph.finalizeGeneratedIteratorRepresentations();
         try graph.finalizeGeneratedIteratorIdentities();
@@ -7743,6 +7767,24 @@ const Builder = struct {
             }
         }
         try verifySpecReuseDemands(body_draft, graph, &impossibility_evaluator);
+        finalization_guard.assertNoFinalBodyOutput(finalization_guard.end(self));
+    }
+
+    /// Seal one already-frozen graph into durable coordinator-owned ids and
+    /// append its retained draft ranges to the final program.
+    fn commitFinalizedBodyDraft(
+        self: *Builder,
+        graph: *InstGraph,
+        body_draft: *BodyDraftStore,
+        root_node: ?NodeId,
+        root_nodes: []const NodeId,
+        extra_ty: ?Type.TypeId,
+        root_def: ?DraftDefId,
+        root_fn: ?DraftFnId,
+    ) Allocator.Error!ActiveBodyDraftSeal {
+        var timing_scope = ProcedureTimingScope.begin(self.timing, .body_finalization);
+        defer timing_scope.end();
+
         var sealer = GraphTypeFinals.init(graph);
         defer sealer.deinit();
         try self.emitDraftDeferredStructuralSerializations(body_draft, graph, &sealer);

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -49189,12 +49189,14 @@ test "queued specialization skips a body claimed immediately before dispatch" {
     const ty = try program.types.internZst(&program.names);
     const template_ref = names.ProcTemplate{
         .artifact = .{},
-        .proc_base = @enumFromInt(0),
-        .template = @enumFromInt(0),
+        // Both fields are only carried by jobs that are skipped below.
+        .proc_base = undefined,
+        .template = undefined,
     };
     const fn_template = Ast.FnTemplate{
         .fn_def = .{ .local_template = template_ref },
-        .source_fn_ty = @enumFromInt(0),
+        // This test never lowers the template, so its checked type is not read.
+        .source_fn_ty = undefined,
         .source_fn_key = .{},
         .mono_fn_ty = ty,
     };
@@ -49264,7 +49266,8 @@ test "queued specialization skips a body claimed immediately before dispatch" {
                 .fn_template = fn_template_,
                 .template_ref = template_ref_,
                 .method_scope = .{},
-                .source_fn_ty = @enumFromInt(0),
+                // The job is marked ready before draining, so its type is not read.
+                .source_fn_ty = undefined,
                 .source_fn_key = .{},
                 .fn_ty = ty_,
                 .evidence = &.{},


### PR DESCRIPTION
## Summary

- finish deferred relation-producing draft preparation before a queued specialization shard crosses the coordinator handoff
- finalize iterator representations and identities, freeze graph relations, and validate runtime-impossibility and specialization-reuse demands before handoff
- split body sealing so ordered coordinator commit starts at `GraphTypeFinals.init` and owns durable type sealing, ID relocation, and program appends
- guard the full preparation/finalization interval against unaccounted final-program body output while permitting recorded reentrant coordinator commits

This is stacked on #10969. It remains a serialized transitional slice: deferred preparation, iterator identity calculation, type/name stores, and Builder caches are still shared.

## Validation

- `zig build run-test-zig-module-postcheck`
- focused queued specialization integration test: 5 tests passed
- `zig build run-check-snapshots`
- `zig build run-check-zig-lints`
- `zig build run-check-semantic-audit`
- `zig build run-check-unused-suppression`
- `zig build run-check-tidy`
- `zig fmt --check src/postcheck/monotype/lower.zig`
- `zig build run-test-zig`: all 4,797 tests passed

## Review

Two adversarial reviews covered handoff ordering, reentrant final-output guarding, all composed sealing callers, relation state, OOM cleanup, timing, and the coordinator suffix. No blockers remain.