### PR TITLE
Preserve occurrence identity for interned Monotypes

### DIFF
--- a/design.md
+++ b/design.md
@@ -6366,6 +6366,12 @@ no type id that is visible in Monotype IR is later refilled or changed. This is
 ordinary type solving inside one stage. Once Monotype IR is output, no
 unresolved node remains reachable and no later stage may change a type.
 
+Direct lowering from checked types preserves `CheckedTypeAddress` identity in
+the immutable Monotype store. The checked cache already provides the explicit
+recursive construction identity for those nodes; content interning must not
+replace it with equality identity. Compiler-produced Monotype structures that
+have no checked occurrence identity remain content-interned.
+
 Instantiation-graph row relations carry the checker's width mode explicitly.
 An exact relation rejects every field added to a closed record. A construction
 relation may instead absorb an unmatched field only when its graph field kind
@@ -6391,7 +6397,11 @@ decision.
 A Monotype imported into another specialization graph is a finished snapshot,
 never a refreshable view: a specialization that needs more than its requested
 type is a unification conflict, not a silent rewrite of another group's final
-type. Every context-free procedure-template request defers until the requesting
+type. Each explicitly independent request or restored-constant occurrence
+receives fresh mutable graph cells while preserving the snapshot's internal
+sharing and recursion within that occurrence. Repeated imports inside one
+ownership scope reconnect to its cells. Equal interned content is not occurrence
+identity; only explicit ownership selects either operation. Every context-free procedure-template request defers until the requesting
 graph is final, when its specialization key is stable. Constraints formerly
 owned only by an unresolved callee body are present in the checked interface
 program and have already participated in the request's relation closure.
@@ -7481,6 +7491,12 @@ The solver:
 - solves recursive groups as groups, not by accidental declaration order
 - verifies each lifted jump is lexically scoped and unifies its arguments with
   the corresponding join-point parameter types
+
+Structural unification, including inspectable nominal-backing relations, runs
+on one explicit work stack. A backing relation isolates an interned structural
+operand once, schedules that working variable against the backing, and defers
+its link action. Nested backing relations reuse the isolated variable instead
+of recursively entering the unifier or cloning it again at each nominal layer.
 
 Monotype may carry both the definition-private nominal view and the opaque
 interface view of one checked `TypeDef`. Lambda solving relates those views only

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -3280,6 +3280,45 @@ test "lambda solved erased callable digest includes record field default identit
     try std.testing.expect(!std.mem.eql(u8, first_default_digest.bytes[0..], second_default_digest.bytes[0..]));
 }
 
+test "inspectable backing unification isolates the structural type variable once" {
+    const allocator = std.testing.allocator;
+
+    var program: Ast.Program = undefined;
+    program.types = Type.Store.init(allocator);
+    defer program.types.deinit();
+
+    const structural = try program.types.add(.{ .primitive = .u64 });
+    var backing = try program.types.add(.{ .primitive = .u64 });
+    for (0..4) |_| {
+        backing = try program.types.add(.{ .named = .{
+            .named_type = undefined,
+            .def = undefined,
+            .kind = .nominal,
+            .args = .empty(),
+            .backing = .{ .ty = backing, .use = .inspectable },
+        } });
+    }
+    const outer_named = backing;
+    const vars_before_unify = program.types.vars.items.len;
+
+    var solver: Solver = undefined;
+    solver.allocator = allocator;
+    solver.program = &program;
+    solver.active_unifications = std.AutoHashMap(UnifyPair, void).init(allocator);
+    defer solver.active_unifications.deinit();
+    solver.unify_stack = .empty;
+    defer solver.unify_stack.deinit(allocator);
+    solver.solved_set_pool = collections.DenseMapPool(Type.TypeVarId, void).init(allocator);
+    defer solver.solved_set_pool.deinit();
+    solver.mono_set_pool = collections.DenseMapPool(MonoType.TypeId, void).init(allocator);
+    defer solver.mono_set_pool.deinit();
+
+    try solver.unify(structural, outer_named);
+
+    try std.testing.expectEqual(vars_before_unify + 1, program.types.vars.items.len);
+    try std.testing.expectEqual(program.types.root(outer_named), program.types.root(structural));
+}
+
 test "lambda solved solve declarations are referenced" {
     std.testing.refAllDecls(@This());
 }

--- a/src/postcheck/lambda_solved/solve.zig
+++ b/src/postcheck/lambda_solved/solve.zig
@@ -61,6 +61,7 @@ const UnifyFrame = union(enum) {
     process: struct {
         lhs: Type.TypeVarId,
         rhs: Type.TypeVarId,
+        structural_isolated: bool,
     },
     finish: struct {
         pair: UnifyPair,
@@ -1681,7 +1682,12 @@ const Solver = struct {
         while (self.unify_stack.items.len > base) {
             const frame = self.unify_stack.pop().?;
             switch (frame) {
-                .process => |process| try self.processUnifyPair(&self.unify_stack, process.lhs, process.rhs),
+                .process => |process| try self.processUnifyPair(
+                    &self.unify_stack,
+                    process.lhs,
+                    process.rhs,
+                    process.structural_isolated,
+                ),
                 .finish => |finish| {
                     self.applyUnifyFinish(finish.action);
                     _ = self.active_unifications.remove(finish.pair);
@@ -1696,7 +1702,24 @@ const Solver = struct {
         lhs: Type.TypeVarId,
         rhs: Type.TypeVarId,
     ) Allocator.Error!void {
-        try stack.append(self.allocator, .{ .process = .{ .lhs = lhs, .rhs = rhs } });
+        try stack.append(self.allocator, .{ .process = .{
+            .lhs = lhs,
+            .rhs = rhs,
+            .structural_isolated = false,
+        } });
+    }
+
+    fn pushIsolatedStructuralPair(
+        self: *Solver,
+        stack: *std.ArrayList(UnifyFrame),
+        structural_ty: Type.TypeVarId,
+        backing_ty: Type.TypeVarId,
+    ) Allocator.Error!void {
+        try stack.append(self.allocator, .{ .process = .{
+            .lhs = structural_ty,
+            .rhs = backing_ty,
+            .structural_isolated = true,
+        } });
     }
 
     fn processUnifyPair(
@@ -1704,6 +1727,7 @@ const Solver = struct {
         stack: *std.ArrayList(UnifyFrame),
         lhs: Type.TypeVarId,
         rhs: Type.TypeVarId,
+        structural_isolated: bool,
     ) Allocator.Error!void {
         const a = self.program.types.rootCompressed(lhs);
         const b = self.program.types.rootCompressed(rhs);
@@ -1743,7 +1767,7 @@ const Solver = struct {
         // and retires `pair` once every type it scheduled has been unified.
         const finish_index = stack.items.len;
         try stack.append(self.allocator, .{ .finish = .{ .pair = pair, .action = .none } });
-        try self.unifyRoots(stack, finish_index, a, b, left, right);
+        try self.unifyRoots(stack, finish_index, a, b, left, right, structural_isolated);
     }
 
     fn unifyRoots(
@@ -1754,6 +1778,7 @@ const Solver = struct {
         b: Type.TypeVarId,
         left: Type.Content,
         right: Type.Content,
+        structural_isolated: bool,
     ) Allocator.Error!void {
         if (transparentAliasBacking(left)) |backing| {
             stack.items[finish_index].finish.action = .{ .link_var_to_root = .{ .var_ = a, .target = backing } };
@@ -1773,8 +1798,8 @@ const Solver = struct {
             self.program.types.set(b, .{ .link = a });
             return;
         }
-        if (try self.unifyInspectableNamedBacking(a, b, left, right)) return;
-        if (try self.unifyInspectableNamedBacking(b, a, right, left)) return;
+        if (try self.unifyInspectableNamedBacking(stack, finish_index, a, b, left, right, structural_isolated)) return;
+        if (try self.unifyInspectableNamedBacking(stack, finish_index, b, a, right, left, structural_isolated)) return;
         if (try self.unifyPublicNamedBacking(a, b, right)) return;
         if (try self.unifyPublicNamedBacking(b, a, left)) return;
 
@@ -2051,10 +2076,13 @@ const Solver = struct {
 
     fn unifyInspectableNamedBacking(
         self: *Solver,
+        stack: *std.ArrayList(UnifyFrame),
+        finish_index: usize,
         structural_ty: Type.TypeVarId,
         named_ty: Type.TypeVarId,
         structural_content: Type.Content,
         named_content: Type.Content,
+        structural_isolated: bool,
     ) Allocator.Error!bool {
         const structural_tag = std.meta.activeTag(structural_content);
         if (structural_tag == .named or structural_tag == .link or structural_tag == .unbound or structural_tag == .forall) return false;
@@ -2064,13 +2092,15 @@ const Solver = struct {
         const backing = named.backing orelse return false;
         if (backing.use != .inspectable) return false;
 
-        const moved_structural = try self.program.types.add(structural_content);
-        try self.unify(moved_structural, backing.ty);
-        const structural_root = self.program.types.rootCompressed(structural_ty);
-        const named_root = self.program.types.rootCompressed(named_ty);
-        if (structural_root != named_root) {
-            self.program.types.set(structural_root, .{ .link = named_root });
-        }
+        const working_structural = if (structural_isolated)
+            structural_ty
+        else
+            try self.program.types.add(structural_content);
+        stack.items[finish_index].finish.action = .{ .link_var_to_root = .{
+            .var_ = structural_ty,
+            .target = named_ty,
+        } };
+        try self.pushIsolatedStructuralPair(stack, working_structural, backing.ty);
         return true;
     }
 

--- a/src/postcheck/monotype/lower.zig
+++ b/src/postcheck/monotype/lower.zig
@@ -2198,13 +2198,6 @@ const Builder = struct {
     symbols: Common.SymbolGen = .{},
     next_instantiation_scope: u64 = 0,
     type_cache: std.AutoHashMap(CheckedTypeAddress, Type.TypeId),
-    /// Outermost checked-type lowering owns one atomic store transaction;
-    /// recursive children only append to its speculative suffix.
-    active_type_transaction: ?Type.Store.Transaction = null,
-    /// Cache addresses inserted while `active_type_transaction` is open. The
-    /// owner remaps exactly these entries on commit and evicts exactly these
-    /// on abort, so neither path scales with the whole cache.
-    active_type_transaction_addresses: std.ArrayList(CheckedTypeAddress) = .empty,
     /// Deterministic FIFO of reserved specializations awaiting body lowering.
     /// Wave drains execute entries in dispatch order; an executing body may
     /// append new entries, which the same drain then reaches.
@@ -2419,7 +2412,6 @@ const Builder = struct {
         self.spec_store.deinit();
         self.uninhabited_type_cache.deinit();
         self.pending_spec_jobs.deinit(self.allocator);
-        self.active_type_transaction_addresses.deinit(self.allocator);
         self.generated_try_types.deinit();
         self.parse_result_ok_types.deinit();
         self.type_cache.deinit();
@@ -4701,42 +4693,6 @@ const Builder = struct {
     fn lowerType(self: *Builder, view: ModuleView, checked_ty: checked.CheckedTypeId) Allocator.Error!Type.TypeId {
         const address = checkedTypeAddress(view, checked_ty);
         if (self.type_cache.get(address)) |cached| return cached;
-        if (self.active_type_transaction != null) {
-            return try self.lowerTypeSpeculative(address, view, checked_ty);
-        }
-
-        const transaction = self.program.types.beginTransaction();
-        self.active_type_transaction = transaction;
-        defer self.active_type_transaction = null;
-        errdefer {
-            transaction.abort(&self.program.types);
-            // Evict only this transaction's entries; ids cached by earlier
-            // commits are durable and stay valid.
-            for (self.active_type_transaction_addresses.items) |cached_address| {
-                _ = self.type_cache.remove(cached_address);
-            }
-            self.active_type_transaction_addresses.clearRetainingCapacity();
-        }
-
-        const speculative = try self.lowerTypeSpeculative(address, view, checked_ty);
-        var result = try self.program.types.commitTransaction(&self.program.names, transaction, speculative);
-        defer result.deinit();
-        for (self.active_type_transaction_addresses.items) |cached_address| {
-            const cached = self.type_cache.getPtr(cached_address) orelse
-                Common.compilerBug("checked-type cache entry recorded in a transaction disappeared before commit");
-            cached.* = result.remapType(cached.*);
-        }
-        self.active_type_transaction_addresses.clearRetainingCapacity();
-        return result.root;
-    }
-
-    fn lowerTypeSpeculative(
-        self: *Builder,
-        address: CheckedTypeAddress,
-        view: ModuleView,
-        checked_ty: checked.CheckedTypeId,
-    ) Allocator.Error!Type.TypeId {
-        if (self.type_cache.get(address)) |cached| return cached;
         const raw = @intFromEnum(checked_ty);
         if (raw >= view.types.payloadCount()) Common.invariant("checked type id outside checked type store");
 
@@ -4747,11 +4703,6 @@ const Builder = struct {
             checked_ty: checked.CheckedTypeId,
 
             fn fill(context: @This(), reserved: Type.TypeId) Allocator.Error!Type.Content {
-                // Recorded before the put so a failed put leaves at worst a
-                // recorded address with no cache entry, which eviction
-                // tolerates and commit never sees; the reverse order could
-                // strand a speculative id in the cache past the owner's abort.
-                try context.builder.active_type_transaction_addresses.append(context.builder.allocator, context.address);
                 try context.builder.type_cache.put(context.address, reserved);
                 return try context.builder.lowerTypePayload(context.view, context.checked_ty, context.view.types.payload(context.checked_ty));
             }
@@ -5945,7 +5896,7 @@ const Builder = struct {
                 fn_ctx.evidence = try fn_ctx.materializeConstFnEvidence(fn_value);
                 try fn_ctx.replayStoredEvidenceRelations(fn_ctx.evidence);
                 const draft = FinalBodyOutputGuard.begin(self);
-                const request_fn_node = try graph.importMono(fn_template.mono_fn_ty);
+                const request_fn_node = try graph.importMonoIndependent(fn_template.mono_fn_ty);
                 const nested = switch (fn_template.fn_def) {
                     .nested => |value| value,
                     .local_template, .imported_template, .local_hosted, .imported_hosted, .checked_generated, .parser_runtime, .encoder_for_runtime => unreachable,
@@ -21213,7 +21164,7 @@ const BodyContext = struct {
         mono_fn_ty: Type.TypeId,
     ) Allocator.Error!NodeId {
         const checked_node = try self.instNode(checked_fn_ty);
-        const request_node = try self.graph.importMono(mono_fn_ty);
+        const request_node = try self.graph.importMonoIndependent(mono_fn_ty);
         const related = try checkedMonoRequestNode(self.graph, checked_node, request_node, .construction);
         return related;
     }
@@ -28847,7 +28798,7 @@ const BodyContext = struct {
         requested_ty: checked.CheckedTypeId,
     ) Allocator.Error!Type.TypeId {
         const stored_ty = try self.lowerConstCaptureType(store_view, stored.root_type);
-        _ = try self.relateCheckedNodeToProducedValue(try self.instNode(requested_ty), try self.graph.importMono(stored_ty));
+        _ = try self.relateCheckedNodeToProducedValue(try self.instNode(requested_ty), try self.graph.importMonoIndependent(stored_ty));
         return stored_ty;
     }
 
@@ -28864,7 +28815,7 @@ const BodyContext = struct {
         const stored_ty = try self.lowerConstCaptureType(store_view, stored.root_type);
         return try self.relateCheckedNodeToProducedValue(
             try self.instNode(requested_ty),
-            try self.graph.importMono(stored_ty),
+            try self.graph.importMonoIndependent(stored_ty),
         );
     }
 

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -7326,7 +7326,7 @@ test "construction row relation absorbs only explicit optional or defaulted fiel
     try std.testing.expectEqual(b, absorbed_empty.fields[0].name);
 }
 
-test "imported closed tag row rejects additional evidence without mutating shared import" {
+test "independent closed tag-row imports have distinct solver nodes" {
     const gpa = std.testing.allocator;
 
     var type_store = Type.Store.init(gpa);
@@ -7349,22 +7349,22 @@ test "imported closed tag row rejects additional evidence without mutating share
     defer graph.destroy();
 
     const request_node = try graph.importMono(requested);
-    const shared_request_node = try graph.importMono(requested);
-    try std.testing.expectEqual(request_node, shared_request_node);
+    const independent_request_node = try graph.importMono(requested);
+    try std.testing.expect(request_node != independent_request_node);
 
     const imported = graph.content(request_node).tag_union;
     const additional_tags = [_]InstTag{.{ .name = b, .checked_name = b, .payloads = &.{} }};
     try std.testing.expect(graph.rowAdditionConflicts(imported.ext, additional_tags.len, .tag_union));
     try std.testing.expectEqual(InstNode.empty_tag_union, graph.content(imported.ext));
 
-    const retained = graph.content(shared_request_node).tag_union;
+    const retained = graph.content(independent_request_node).tag_union;
     try std.testing.expectEqual(@as(usize, 1), retained.tags.len);
     try std.testing.expectEqual(a, retained.tags[0].name);
     try std.testing.expect(retained.tags[0].name != b);
     try std.testing.expectEqual(InstNode.empty_tag_union, graph.content(retained.ext));
 }
 
-test "imported closed record row rejects additional evidence without mutating shared import" {
+test "independent closed record-row imports have distinct solver nodes" {
     const gpa = std.testing.allocator;
 
     var type_store = Type.Store.init(gpa);
@@ -7387,8 +7387,8 @@ test "imported closed record row rejects additional evidence without mutating sh
     defer graph.destroy();
 
     const request_node = try graph.importMono(requested);
-    const shared_request_node = try graph.importMono(requested);
-    try std.testing.expectEqual(request_node, shared_request_node);
+    const independent_request_node = try graph.importMono(requested);
+    try std.testing.expect(request_node != independent_request_node);
 
     const imported = graph.content(request_node).record;
     const additional_fields = [_]InstField{.{
@@ -7399,7 +7399,7 @@ test "imported closed record row rejects additional evidence without mutating sh
     try std.testing.expect(graph.rowAdditionConflicts(imported.ext, additional_fields.len, .record));
     try std.testing.expectEqual(InstNode.empty_record, graph.content(imported.ext));
 
-    const retained = graph.content(shared_request_node).record;
+    const retained = graph.content(independent_request_node).record;
     try std.testing.expectEqual(@as(usize, 1), retained.fields.len);
     try std.testing.expectEqual(value, retained.fields[0].name);
     try std.testing.expect(retained.fields[0].name != extra);

--- a/src/postcheck/monotype/solve.zig
+++ b/src/postcheck/monotype/solve.zig
@@ -435,9 +435,12 @@ pub const InstGraph = struct {
     /// performs one exact global invalidation, coalescing mutation bursts that
     /// do not inspect an intermediate graph state.
     current_snapshots_dirty: bool,
-    /// Reverse active-snapshot links, also the import memo: a Monotype already
-    /// connected to this graph reuses its node instead of being copied.
-    linked_type_nodes: collections.DenseMap(Type.TypeId, NodeId),
+    /// Reverse links for immutable active snapshots. Finished Monotype imports
+    /// use a per-import memo instead: equal interned types at independent
+    /// occurrences must not share mutable solver nodes.
+    active_snapshot_nodes: collections.DenseMap(Type.TypeId, NodeId),
+    /// Finished Monotypes already imported into the current ownership scope.
+    imported_type_nodes: collections.DenseMap(Type.TypeId, NodeId),
     /// Exact immutable Monotype snapshot imported at each permanent node.
     /// Unlike `node_snapshots`, these are producer-owned representation
     /// witnesses. Keeping the direct node association lets consumers of an
@@ -511,7 +514,8 @@ pub const InstGraph = struct {
             .node_snapshots = collections.DenseMap(NodeId, std.ArrayList(Type.TypeId)).init(allocator),
             .current_snapshots = collections.DenseMap(NodeId, Type.TypeId).init(allocator),
             .current_snapshots_dirty = false,
-            .linked_type_nodes = collections.DenseMap(Type.TypeId, NodeId).init(allocator),
+            .active_snapshot_nodes = collections.DenseMap(Type.TypeId, NodeId).init(allocator),
+            .imported_type_nodes = collections.DenseMap(Type.TypeId, NodeId).init(allocator),
             .imported_monos = collections.DenseMap(NodeId, Type.TypeId).init(allocator),
             .row_exts = .empty,
             .row_parents = collections.DenseMap(NodeId, std.ArrayList(NodeId)).init(allocator),
@@ -580,7 +584,8 @@ pub const InstGraph = struct {
         self.row_parents.deinit();
         self.row_exts.deinit(allocator);
         self.imported_monos.deinit();
-        self.linked_type_nodes.deinit();
+        self.active_snapshot_nodes.deinit();
+        self.imported_type_nodes.deinit();
         self.processed_relations.deinit();
         self.class_member_tail.deinit(allocator);
         self.class_member_head.deinit(allocator);
@@ -4629,36 +4634,74 @@ pub const InstGraph = struct {
         }
     }
 
-    /// Import a Monotype into the graph. A Monotype already linked to a node
-    /// reconnects to it; an unlinked one copies in as closed structure, so a
-    /// later attempt to widen it is a unification conflict rather than a silent
-    /// mutation of another specialization's final type.
+    /// Import one independent occurrence of a finished Monotype. Internal
+    /// sharing and recursion are preserved by the import-local memo, while a
+    /// second root import receives distinct mutable solver nodes. Active graph
+    /// snapshots reconnect to their existing nodes.
     pub fn importMono(self: *InstGraph, ty: Type.TypeId) Allocator.Error!NodeId {
         self.requireRelationProduction();
         self.countDiagnostic("mono_import_requests");
-        if (self.linked_type_nodes.get(ty)) |existing| {
+        if (self.active_snapshot_nodes.get(ty)) |existing| {
+            self.countDiagnostic("mono_import_hits");
+            return self.find(existing);
+        }
+        if (self.imported_type_nodes.get(ty)) |existing| {
             self.countDiagnostic("mono_import_hits");
             return self.find(existing);
         }
         self.countDiagnostic("mono_import_misses");
+        return try self.importMonoInner(ty, null);
+    }
+
+    /// Import a finished Monotype root as a distinct occurrence. Descendants
+    /// reconnect through the ownership-scope memo, while a recursive edge back
+    /// to the root reconnects through the import-local memo.
+    pub fn importMonoIndependent(self: *InstGraph, ty: Type.TypeId) Allocator.Error!NodeId {
+        self.requireRelationProduction();
+        var imported = collections.DenseMap(Type.TypeId, NodeId).init(self.allocator);
+        defer imported.deinit();
+        return try self.importMonoInner(ty, &imported);
+    }
+
+    fn importMonoInner(
+        self: *InstGraph,
+        ty: Type.TypeId,
+        imported_types: ?*collections.DenseMap(Type.TypeId, NodeId),
+    ) Allocator.Error!NodeId {
+        if (imported_types) |local| {
+            if (local.get(ty)) |existing| return existing;
+            if (local.count() != 0) {
+                // Only the explicitly requested occurrence root is
+                // independent. Its component types still carry the
+                // ownership-scope identity used by checked constructor slots
+                // and their evidence.
+                return try self.importMonoInner(ty, null);
+            }
+        } else if (self.imported_type_nodes.get(ty)) |existing| {
+            return self.find(existing);
+        }
         const node = try self.newNode(.{ .unresolved = InstVariable.placeholder() });
         // One-way memo: every import is a finished Monotype from outside this
         // graph (ids materialized here hit the memo above), so it enters as a
         // snapshot. Registering a view would let this specialization's
         // evidence rewrite another specialization's final type, destabilizing
         // every digest taken from it.
-        try self.linked_type_nodes.put(ty, node);
+        if (imported_types) |local| {
+            try local.put(ty, node);
+        } else {
+            try self.imported_type_nodes.put(ty, node);
+        }
         try self.imported_monos.put(node, ty);
 
         const types = self.types;
         const imported: InstNode = switch (types.get(ty)) {
             .primitive => |primitive| .{ .primitive = primitive },
-            .list => |elem| .{ .list = try self.importMono(elem) },
-            .box => |elem| .{ .box = try self.importMono(elem) },
-            .tuple => |items| .{ .tuple = try self.importMonoSlice(types.span(items)) },
+            .list => |elem| .{ .list = try self.importMonoInner(elem, imported_types) },
+            .box => |elem| .{ .box = try self.importMonoInner(elem, imported_types) },
+            .tuple => |items| .{ .tuple = try self.importMonoSlice(types.span(items), imported_types) },
             .func => |func| .{ .func = .{
-                .args = try self.importMonoSlice(types.span(func.args)),
-                .ret = try self.importMono(func.ret),
+                .args = try self.importMonoSlice(types.span(func.args), imported_types),
+                .ret = try self.importMonoInner(func.ret, imported_types),
             } },
             .tag_union => |tags| blk: {
                 const span = types.tagSpan(tags);
@@ -4671,7 +4714,7 @@ pub const InstGraph = struct {
                     inst_tags[index] = .{
                         .name = tag.name,
                         .checked_name = tag.checked_name,
-                        .payloads = try self.importMonoSlice(types.span(tag.payloads)),
+                        .payloads = try self.importMonoSlice(types.span(tag.payloads), imported_types),
                     };
                 }
                 break :blk .{ .tag_union = .{
@@ -4689,12 +4732,12 @@ pub const InstGraph = struct {
                         Common.invariant("finished Monotype import received a provisional record field");
                     }
                     const value_ty = if (field.value_ty) |value_ty|
-                        try self.importMono(value_ty)
+                        try self.importMonoInner(value_ty, imported_types)
                     else
                         null;
                     inst_fields[index] = .{
                         .name = field.name,
-                        .ty = try self.importMono(field.ty),
+                        .ty = try self.importMonoInner(field.ty, imported_types),
                         .value_ty = value_ty,
                         .kind = if (value_ty != null)
                             .optional
@@ -4715,13 +4758,13 @@ pub const InstGraph = struct {
                 .def = named.def,
                 .kind = named.kind,
                 .builtin_owner = named.builtin_owner,
-                .args = try self.importMonoSlice(types.span(named.args)),
+                .args = try self.importMonoSlice(types.span(named.args), imported_types),
                 .backing = if (named.backing) |backing| .{
-                    .node = try self.importMono(backing.ty),
+                    .node = try self.importMonoInner(backing.ty, imported_types),
                     .use = backing.use,
                     .authority = backing.authority,
                 } else null,
-                .declared_order = try self.importDeclaredFields(named.declared_order),
+                .declared_order = try self.importDeclaredFields(named.declared_order, imported_types),
             } },
             .erased => |digest| .{ .erased = digest },
             .zst => .zst,
@@ -4880,16 +4923,24 @@ pub const InstGraph = struct {
         return out;
     }
 
-    fn importMonoSlice(self: *InstGraph, tys: anytype) Allocator.Error![]NodeId {
+    fn importMonoSlice(
+        self: *InstGraph,
+        tys: anytype,
+        imported_types: ?*collections.DenseMap(Type.TypeId, NodeId),
+    ) Allocator.Error![]NodeId {
         const out = try self.arena().alloc(NodeId, tys.len);
         for (0..tys.len) |index| {
             const ty = GuardedList.at(tys, index);
-            out[index] = try self.importMono(ty);
+            out[index] = try self.importMonoInner(ty, imported_types);
         }
         return out;
     }
 
-    fn importDeclaredFields(self: *InstGraph, span: Type.Span) Allocator.Error![]const InstDeclaredField {
+    fn importDeclaredFields(
+        self: *InstGraph,
+        span: Type.Span,
+        imported_types: ?*collections.DenseMap(Type.TypeId, NodeId),
+    ) Allocator.Error![]const InstDeclaredField {
         const fields = self.types.declaredFieldSpan(span);
         if (fields.len == 0) return &.{};
         const out = try self.arena().alloc(InstDeclaredField, fields.len);
@@ -4897,7 +4948,7 @@ pub const InstGraph = struct {
             const field = GuardedList.at(fields, index);
             out[index] = switch (field) {
                 .named => |name| .{ .named = name },
-                .padding => |ty| .{ .padding = try self.importMono(ty) },
+                .padding => |ty| .{ .padding = try self.importMonoInner(ty, imported_types) },
             };
         }
         return out;
@@ -4983,7 +5034,7 @@ pub const InstGraph = struct {
             const entry = try self.node_snapshots.getOrPut(snapshot_node);
             if (!entry.found_existing) entry.value_ptr.* = .empty;
             try entry.value_ptr.append(self.allocator, snapshot_ty);
-            try self.linked_type_nodes.put(snapshot_ty, snapshot_node);
+            try self.active_snapshot_nodes.put(snapshot_ty, snapshot_node);
             try self.current_snapshots.put(snapshot_node, snapshot_ty);
         }
         return ty;
@@ -5093,7 +5144,7 @@ pub const InstGraph = struct {
     }
 
     fn isActiveSnapshotType(self: *InstGraph, ty: Type.TypeId) bool {
-        const raw_node = self.linked_type_nodes.get(ty) orelse return false;
+        const raw_node = self.active_snapshot_nodes.get(ty) orelse return false;
         const views = self.node_snapshots.get(raw_node) orelse return false;
         for (views.items) |view| {
             if (view == ty) return true;
@@ -5104,7 +5155,7 @@ pub const InstGraph = struct {
     /// Return the current root node for a TypeId that is one of this graph's
     /// immutable active snapshots. Closed imported TypeIds return null.
     pub fn activeSnapshotNode(self: *InstGraph, ty: Type.TypeId) ?NodeId {
-        const raw_node = self.linked_type_nodes.get(ty) orelse return null;
+        const raw_node = self.active_snapshot_nodes.get(ty) orelse return null;
         const views = self.node_snapshots.get(raw_node) orelse return null;
         for (views.items) |view| {
             if (view == ty) return self.find(raw_node);
@@ -5175,7 +5226,7 @@ pub const GraphTypeFinals = struct {
     }
 
     pub fn sealType(self: *GraphTypeFinals, ty: Type.TypeId) Allocator.Error!Type.TypeId {
-        if (self.graph.linked_type_nodes.get(ty)) |raw_node| {
+        if (self.graph.active_snapshot_nodes.get(ty)) |raw_node| {
             if (self.graph.node_snapshots.get(raw_node)) |views| {
                 for (views.items) |view| {
                     if (view == ty) return try self.sealNode(raw_node);
@@ -6626,14 +6677,14 @@ test "union resolves immutable snapshot provenance without reindexing" {
     for (&snapshots, &owners) |*snapshot, *owner| {
         const node = try graph.newNode(.{ .primitive = .u64 });
         snapshot.* = try graph.activeTypeViewForNode(node);
-        owner.* = graph.linked_type_nodes.get(snapshot.*).?;
+        owner.* = graph.active_snapshot_nodes.get(snapshot.*).?;
         try graph.union_(winner, node);
     }
 
     for (snapshots, owners) |snapshot, owner| {
         // The reverse index remains stable instead of rewriting every prior
         // snapshot on each union. Root resolution happens only when queried.
-        try std.testing.expectEqual(owner, graph.linked_type_nodes.get(snapshot).?);
+        try std.testing.expectEqual(owner, graph.active_snapshot_nodes.get(snapshot).?);
         try std.testing.expectEqual(winner, graph.activeSnapshotNode(snapshot).?);
     }
 }
@@ -7348,8 +7399,8 @@ test "independent closed tag-row imports have distinct solver nodes" {
     const graph = try InstGraph.create(gpa, &type_store, &name_store);
     defer graph.destroy();
 
-    const request_node = try graph.importMono(requested);
-    const independent_request_node = try graph.importMono(requested);
+    const request_node = try graph.importMonoIndependent(requested);
+    const independent_request_node = try graph.importMonoIndependent(requested);
     try std.testing.expect(request_node != independent_request_node);
 
     const imported = graph.content(request_node).tag_union;
@@ -7386,8 +7437,8 @@ test "independent closed record-row imports have distinct solver nodes" {
     const graph = try InstGraph.create(gpa, &type_store, &name_store);
     defer graph.destroy();
 
-    const request_node = try graph.importMono(requested);
-    const independent_request_node = try graph.importMono(requested);
+    const request_node = try graph.importMonoIndependent(requested);
+    const independent_request_node = try graph.importMonoIndependent(requested);
     try std.testing.expect(request_node != independent_request_node);
 
     const imported = graph.content(request_node).record;


### PR DESCRIPTION
Closes #10965.

## Root cause

Content interning correctly makes immutable Monotypes with equal content share a TypeId. Two consumers were incorrectly treating that content identity as mutable solver-occurrence identity:

- direct checked-type lowering interned whole checked graphs, erasing distinct CheckedTypeAddress occurrences;
- finished Monotype imports reused one solver node across independent specialization requests.

That aliasing amplified inspectable named-backing unification in Lambda Solved until roc-ray-doom overflowed its stack.

## Fix

- Preserve CheckedTypeAddress identity when lowering direct checked types; compiler-derived Monotypes remain content-interned.
- Distinguish normal ownership-scope imports from explicit independent request roots. Independent roots get fresh solver cells, while their component types reconnect to the scope so constructor evidence remains exact.
- Process inspectable named backing on the existing unification work stack and isolate the structural operand exactly once at the boundary.
- Document the invariants in design.md.

The history is intentionally red-green:

1. Add regressions that fail against origin/main.
2. Apply the implementation that makes them pass.

## Verification

- Regression commit confirmed red: independent import assertion failed; Lambda clone count expected 7 but found 10.
- `zig build run-test-zig-lir-inline --summary all --color off`: 181/181 passed.
- `zig build run-test-eval --summary all --color off -- --timeout 120000`: 1992/1992 passed.
- `zig build minici`: 76/76 phases passed.
- Exact final ReleaseFast compiler built roc-ray-doom in 20.48 seconds, 3.56 GB peak RSS, with zero errors and warnings.
- The resulting RocDOOM binary initialized its window, OpenGL, audio, assets, shaders, framebuffer, and music successfully and shut down cleanly.