### PR TITLE
Replace builtin ordering API

### DIFF
--- a/src/backend/dev/LirCodeGen.zig
+++ b/src/backend/dev/LirCodeGen.zig
@@ -5006,16 +5006,16 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                     if (args.len != 2) unreachable;
                     const operand_layout = self.valueLayout(GuardedList.at(args, 0));
 
-                    const gt_loc = if (operand_layout == .dec or operand_layout == .i128 or operand_layout == .u128) blk: {
+                    const same_loc = if (operand_layout == .dec or operand_layout == .i128 or operand_layout == .u128) blk: {
                         const lhs_loc = try self.emitValueLocal(GuardedList.at(args, 0));
                         const rhs_loc = try self.emitValueLocal(GuardedList.at(args, 1));
                         const adj_lhs = if (lhs_loc == .stack) ValueLocation{ .stack_i128 = lhs_loc.stack.offset } else lhs_loc;
                         const adj_rhs = if (rhs_loc == .stack) ValueLocation{ .stack_i128 = rhs_loc.stack.offset } else rhs_loc;
-                        break :blk try self.generateI128Binop(.num_is_gt, adj_lhs, adj_rhs, operand_layout);
+                        break :blk try self.generateI128Binop(.num_is_eq, adj_lhs, adj_rhs, operand_layout);
                     } else blk: {
                         const lhs_loc = try self.emitValueLocal(GuardedList.at(args, 0));
                         const rhs_loc = try self.emitValueLocal(GuardedList.at(args, 1));
-                        break :blk try self.generateIntBinop(.num_is_gt, lhs_loc, rhs_loc, operand_layout);
+                        break :blk try self.generateIntBinop(.num_is_eq, lhs_loc, rhs_loc, operand_layout);
                     };
 
                     const lt_loc = if (operand_layout == .dec or operand_layout == .i128 or operand_layout == .u128) blk: {
@@ -5030,12 +5030,12 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
                         break :blk try self.generateIntBinop(.num_is_lt, lhs_loc, rhs_loc, operand_layout);
                     };
 
-                    const gt_reg = try self.ensureInGeneralReg(gt_loc);
+                    const same_reg = try self.ensureInGeneralReg(same_loc);
                     const lt_reg = try self.ensureInGeneralReg(lt_loc);
-                    try self.emitShlImm(.w64, gt_reg, gt_reg, 1);
-                    try self.emitAddRegs(.w64, gt_reg, gt_reg, lt_reg);
+                    try self.emitShlImm(.w64, same_reg, same_reg, 1);
+                    try self.emitAddRegs(.w64, same_reg, same_reg, lt_reg);
                     self.codegen.freeGeneral(lt_reg);
-                    return .{ .general_reg = gt_reg };
+                    return .{ .general_reg = same_reg };
                 },
 
                 // Resolved before backend codegen: builtin `from_numeral` is
@@ -13505,7 +13505,7 @@ pub fn LirCodeGen(comptime target: RocTarget) type {
             try self.codegen.emitNeg(.w64, neg_reg, reg);
 
             if (comptime target.toCpuArch() == .aarch64) {
-                // CMP reg, #0; CSEL result, neg_reg, reg, FirstBeforeSecond
+                // CMP reg, #0; CSEL result, neg_reg, reg, Before
                 try self.codegen.emit.cmpRegImm12(.w64, reg, 0);
                 try self.codegen.emit.csel(.w64, neg_reg, neg_reg, reg, .lt);
             } else {

--- a/src/backend/llvm/MonoLlvmCodeGen.zig
+++ b/src/backend/llvm/MonoLlvmCodeGen.zig
@@ -4945,12 +4945,12 @@ pub const MonoLlvmCodeGen = struct {
         const lhs = try self.loadScalar(self.slot(GuardedList.at(args, 0)).ptr, layout_idx);
         const rhs = try self.loadScalar(self.slot(GuardedList.at(args, 1)).ptr, layout_idx);
         const signed = layout_idx.isSigned();
-        const gt_cond: LlvmBuilder.Value = wip.icmp(if (signed) .sgt else .ugt, lhs, rhs, "") catch return error.OutOfMemory;
+        const same_cond: LlvmBuilder.Value = wip.icmp(.eq, lhs, rhs, "") catch return error.OutOfMemory;
         const lt_cond: LlvmBuilder.Value = wip.icmp(if (signed) .slt else .ult, lhs, rhs, "") catch return error.OutOfMemory;
-        const gt = wip.conv(.unsigned, gt_cond, .i8, "") catch return error.OutOfMemory;
+        const same = wip.conv(.unsigned, same_cond, .i8, "") catch return error.OutOfMemory;
         const lt = wip.conv(.unsigned, lt_cond, .i8, "") catch return error.OutOfMemory;
-        const gt_tag = wip.bin(.mul, gt, builder.intValue(.i8, 2) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
-        const tag = wip.bin(.add, lt, gt_tag, "") catch return error.OutOfMemory;
+        const same_tag = wip.bin(.mul, same, builder.intValue(.i8, 2) catch return error.OutOfMemory, "") catch return error.OutOfMemory;
+        const tag = wip.bin(.add, lt, same_tag, "") catch return error.OutOfMemory;
         try self.storeIntToLayout(self.slot(target).ptr, tag, self.localLayout(target));
     }
 

--- a/src/backend/wasm/WasmCodeGen.zig
+++ b/src/backend/wasm/WasmCodeGen.zig
@@ -7139,7 +7139,7 @@ fn emitI128Mul(self: *Self, lhs_local: u32, rhs_local: u32) Allocator.Error!void
     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), result_local) catch return error.OutOfMemory;
 }
 
-const I128CmpOp = enum { lt, lte, gt, gte };
+const I128CmpOp = enum { eq, lt, lte, gt, gte };
 
 fn emitI128CompareWithSignedness(self: *Self, lhs_local: u32, rhs_local: u32, cmp_op: I128CmpOp, is_signed: bool) Allocator.Error!void {
     // Signed i128 comparison strategy:
@@ -7186,6 +7186,7 @@ fn emitI128CompareWithSignedness(self: *Self, lhs_local: u32, rhs_local: u32, cm
     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), rhs_local) catch return error.OutOfMemory;
     try self.emitLoadOp(.i64, 0);
     const low_cmp: u8 = switch (cmp_op) {
+        .eq => Op.i64_eq,
         .lt => Op.i64_lt_u,
         .lte => Op.i64_le_u,
         .gt => Op.i64_gt_u,
@@ -7200,6 +7201,7 @@ fn emitI128CompareWithSignedness(self: *Self, lhs_local: u32, rhs_local: u32, cm
     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), b_high) catch return error.OutOfMemory;
     const high_cmp: u8 = switch (cmp_op) {
+        .eq => Op.i64_eq,
         .lt => if (is_signed) Op.i64_lt_s else Op.i64_lt_u,
         .lte => if (is_signed) Op.i64_le_s else Op.i64_le_u,
         .gt => if (is_signed) Op.i64_gt_s else Op.i64_gt_u,
@@ -15102,7 +15104,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
             try self.emitProcLocal(GuardedList.at(args, 0));
         },
 
-        // Compare—returns Ordering enum (Equivalent=0, FirstBeforeSecond=1, SecondBeforeFirst=2)
+        // Compare—returns Ordering enum (After=0, Before=1, Same=2)
         .compare => {
             try self.emitProcLocal(GuardedList.at(args, 0));
             try self.emitProcLocal(GuardedList.at(args, 1));
@@ -15129,7 +15131,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                         .u128, .i128, .dec => {
                             const is_signed = arg_layout == .i128 or arg_layout == .dec;
                             try self.emitI128CompareWithSignedness(a, b, .lt, is_signed);
-                            try self.emitI128CompareWithSignedness(a, b, .gt, is_signed);
+                            try self.emitI128CompareWithSignedness(a, b, .eq, is_signed);
                             self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
                             WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
                             self.currentCode().append(self.allocator, Op.i32_mul) catch return error.OutOfMemory;
@@ -15139,23 +15141,22 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                         .bool, .str, .u8, .i8, .u16, .i16, .u32, .i32, .u64, .i64, .f32, .f64, .opaque_ptr, .zst, .u8x16, .i8x16, .u16x8, .i16x8, .u32x4, .i32x4, .u64x2, .i64x2, _ => {},
                     }
 
-                    // gt_flag = (a > b) ? 1 : 0
-                    // gt_flag
+                    // before_flag = (a < b) ? 1 : 0
                     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), a) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), b) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, if (is_unsigned) Op.i32_lt_u else Op.i32_lt_s) catch return error.OutOfMemory;
-                    // lt_flag * 2
+                    // same_flag * 2
                     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), a) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), b) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, if (is_unsigned) Op.i32_gt_u else Op.i32_gt_s) catch return error.OutOfMemory;
+                    self.currentCode().append(self.allocator, Op.i32_eq) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
                     WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.i32_mul) catch return error.OutOfMemory;
-                    // result = gt_flag + lt_flag * 2
+                    // result = before_flag + same_flag * 2
                     self.currentCode().append(self.allocator, Op.i32_add) catch return error.OutOfMemory;
                 },
                 .i64 => {
@@ -15174,7 +15175,7 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), a) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), b) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, if (is_unsigned) Op.i64_gt_u else Op.i64_gt_s) catch return error.OutOfMemory;
+                    self.currentCode().append(self.allocator, Op.i64_eq) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
                     WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.i32_mul) catch return error.OutOfMemory;
@@ -15191,12 +15192,12 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), a) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), b) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.f32_gt) catch return error.OutOfMemory;
+                    self.currentCode().append(self.allocator, Op.f32_lt) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), a) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), b) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.f32_lt) catch return error.OutOfMemory;
+                    self.currentCode().append(self.allocator, Op.f32_eq) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
                     WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.i32_mul) catch return error.OutOfMemory;
@@ -15213,12 +15214,12 @@ fn generateLowLevel(self: *Self, ll: anytype) Allocator.Error!void {
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), a) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), b) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.f64_gt) catch return error.OutOfMemory;
+                    self.currentCode().append(self.allocator, Op.f64_lt) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), a) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.local_get) catch return error.OutOfMemory;
                     WasmModule.leb128WriteU32(self.allocator, self.currentCode(), b) catch return error.OutOfMemory;
-                    self.currentCode().append(self.allocator, Op.f64_lt) catch return error.OutOfMemory;
+                    self.currentCode().append(self.allocator, Op.f64_eq) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.i32_const) catch return error.OutOfMemory;
                     WasmModule.leb128WriteI32(self.allocator, self.currentCode(), 2) catch return error.OutOfMemory;
                     self.currentCode().append(self.allocator, Op.i32_mul) catch return error.OutOfMemory;

--- a/src/build/roc/Builtin.roc
+++ b/src/build/roc/Builtin.roc
@@ -3565,10 +3565,10 @@ Builtin :: [].{
 	}
 
 	## A type has a default sort order when its module provides
-	## `default_cmp : item, item -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]`.
+	## `order_relative_to : item, item -> [Before, Same, After]`.
 	## These tags say which argument comes first; they deliberately do not tie
 	## sorting to "less than" or to the `<` and `>` operators.
-	item.Sort :  where [item.default_cmp : item, item -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]]
+	item.Sort :  where [item.order_relative_to : item, item -> [Before, Same, After]]
 
 	List(_item) :: [ProvidedByCompiler].{
 		parser_for : _
@@ -3866,7 +3866,7 @@ Builtin :: [].{
 		## Sort a list using its items' default ordering.
 		sort : List(item) -> List(item)
 			where [item.Sort]
-		sort = |list| sort_impl(list, |left, right| left.default_cmp(right))
+		sort = |list| sort_impl(list, |left, right| left.order_relative_to(right))
 
 		## Sort a list by a projected field. The projection is evaluated once per item,
 		## and items with equal fields retain their input order.
@@ -3874,18 +3874,18 @@ Builtin :: [].{
 			where [field.Sort]
 		sort_by = |list, project| {
 			decorated = List.map(list, |item| (project(item), item))
-			sorted = sort_impl(decorated, |(left, _), (right, _)| left.default_cmp(right))
+			sorted = sort_impl(decorated, |(left, _), (right, _)| left.order_relative_to(right))
 			List.map(sorted, |(_, item)| item)
 		}
 
 		## Sort a list using a custom three-way comparison function.
-		sort_with : List(item), (item, item -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]) -> List(item)
+		sort_with : List(item), (item, item -> [Before, Same, After]) -> List(item)
 		sort_with = |list, compare_items| sort_impl(list, compare_items)
 
 		## Sort a list in reverse using its items' default ordering.
 		sort_reversed : List(item) -> List(item)
 			where [item.Sort]
-		sort_reversed = |list| sort_impl(list, |left, right| reverse_order(left.default_cmp(right)))
+		sort_reversed = |list| sort_impl(list, |left, right| reverse_order(left.order_relative_to(right)))
 
 		## Sort a list in reverse by a projected field. The projection is evaluated
 		## once per item, and items with equal fields retain their input order.
@@ -3893,12 +3893,12 @@ Builtin :: [].{
 			where [field.Sort]
 		sort_by_reversed = |list, project| {
 			decorated = List.map(list, |item| (project(item), item))
-			sorted = sort_impl(decorated, |(left, _), (right, _)| reverse_order(left.default_cmp(right)))
+			sorted = sort_impl(decorated, |(left, _), (right, _)| reverse_order(left.order_relative_to(right)))
 			List.map(sorted, |(_, item)| item)
 		}
 
 		## Sort a list in reverse using a custom three-way comparison function.
-		sort_with_reversed : List(item), (item, item -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]) -> List(item)
+		sort_with_reversed : List(item), (item, item -> [Before, Same, After]) -> List(item)
 		sort_with_reversed = |list, compare_items|
 			sort_impl(list, |left, right| reverse_order(compare_items(left, right)))
 
@@ -6732,18 +6732,14 @@ Builtin :: [].{
 
 			## Compare two [U8] values and return their ordering.
 			## ```roc
-			## expect U8.compare(1, 2) == FirstBeforeSecond
+			## expect U8.order_relative_to(1, 2) == Before
 			##
-			## expect U8.compare(2, 2) == Equivalent
+			## expect U8.order_relative_to(2, 2) == Same
 			##
-			## expect U8.compare(3, 2) == SecondBeforeFirst
+			## expect U8.order_relative_to(3, 2) == After
 			## ```
-			compare : U8, U8 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			compare = |a, b| numeric_compare(a, b)
-
-			## Default ordering used by [List.sort].
-			default_cmp : U8, U8 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			default_cmp = |a, b| numeric_compare(a, b)
+			order_relative_to : U8, U8 -> [Before, Same, After]
+			order_relative_to = |a, b| numeric_compare(a, b)
 
 			## Returns `Bool.True` if the value is evenly divisible by `2`.
 			## ```roc
@@ -7403,18 +7399,14 @@ Builtin :: [].{
 
 			## Compare two [I8] values and return their ordering.
 			## ```roc
-			## expect I8.compare(1, 2) == FirstBeforeSecond
+			## expect I8.order_relative_to(1, 2) == Before
 			##
-			## expect I8.compare(2, 2) == Equivalent
+			## expect I8.order_relative_to(2, 2) == Same
 			##
-			## expect I8.compare(3, 2) == SecondBeforeFirst
+			## expect I8.order_relative_to(3, 2) == After
 			## ```
-			compare : I8, I8 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			compare = |a, b| numeric_compare(a, b)
-
-			## Default ordering used by [List.sort].
-			default_cmp : I8, I8 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			default_cmp = |a, b| numeric_compare(a, b)
+			order_relative_to : I8, I8 -> [Before, Same, After]
+			order_relative_to = |a, b| numeric_compare(a, b)
 
 			## Returns `Bool.True` if the value is evenly divisible by `2`.
 			## ```roc
@@ -8193,18 +8185,14 @@ Builtin :: [].{
 
 			## Compare two [U16] values and return their ordering.
 			## ```roc
-			## expect U16.compare(1, 2) == FirstBeforeSecond
+			## expect U16.order_relative_to(1, 2) == Before
 			##
-			## expect U16.compare(2, 2) == Equivalent
+			## expect U16.order_relative_to(2, 2) == Same
 			##
-			## expect U16.compare(3, 2) == SecondBeforeFirst
+			## expect U16.order_relative_to(3, 2) == After
 			## ```
-			compare : U16, U16 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			compare = |a, b| numeric_compare(a, b)
-
-			## Default ordering used by [List.sort].
-			default_cmp : U16, U16 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			default_cmp = |a, b| numeric_compare(a, b)
+			order_relative_to : U16, U16 -> [Before, Same, After]
+			order_relative_to = |a, b| numeric_compare(a, b)
 
 			## Returns `Bool.True` if the value is evenly divisible by `2`.
 			## ```roc
@@ -8923,18 +8911,14 @@ Builtin :: [].{
 
 			## Compare two [I16] values and return their ordering.
 			## ```roc
-			## expect I16.compare(1, 2) == FirstBeforeSecond
+			## expect I16.order_relative_to(1, 2) == Before
 			##
-			## expect I16.compare(2, 2) == Equivalent
+			## expect I16.order_relative_to(2, 2) == Same
 			##
-			## expect I16.compare(3, 2) == SecondBeforeFirst
+			## expect I16.order_relative_to(3, 2) == After
 			## ```
-			compare : I16, I16 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			compare = |a, b| numeric_compare(a, b)
-
-			## Default ordering used by [List.sort].
-			default_cmp : I16, I16 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			default_cmp = |a, b| numeric_compare(a, b)
+			order_relative_to : I16, I16 -> [Before, Same, After]
+			order_relative_to = |a, b| numeric_compare(a, b)
 
 			## Returns `Bool.True` if the value is evenly divisible by `2`.
 			## ```roc
@@ -9754,18 +9738,14 @@ Builtin :: [].{
 
 			## Compare two [U32] values and return their ordering.
 			## ```roc
-			## expect U32.compare(1, 2) == FirstBeforeSecond
+			## expect U32.order_relative_to(1, 2) == Before
 			##
-			## expect U32.compare(2, 2) == Equivalent
+			## expect U32.order_relative_to(2, 2) == Same
 			##
-			## expect U32.compare(3, 2) == SecondBeforeFirst
+			## expect U32.order_relative_to(3, 2) == After
 			## ```
-			compare : U32, U32 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			compare = |a, b| numeric_compare(a, b)
-
-			## Default ordering used by [List.sort].
-			default_cmp : U32, U32 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			default_cmp = |a, b| numeric_compare(a, b)
+			order_relative_to : U32, U32 -> [Before, Same, After]
+			order_relative_to = |a, b| numeric_compare(a, b)
 
 			## Returns `Bool.True` if the value is evenly divisible by `2`.
 			## ```roc
@@ -10516,18 +10496,14 @@ Builtin :: [].{
 
 			## Compare two [I32] values and return their ordering.
 			## ```roc
-			## expect I32.compare(1, 2) == FirstBeforeSecond
+			## expect I32.order_relative_to(1, 2) == Before
 			##
-			## expect I32.compare(2, 2) == Equivalent
+			## expect I32.order_relative_to(2, 2) == Same
 			##
-			## expect I32.compare(3, 2) == SecondBeforeFirst
+			## expect I32.order_relative_to(3, 2) == After
 			## ```
-			compare : I32, I32 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			compare = |a, b| numeric_compare(a, b)
-
-			## Default ordering used by [List.sort].
-			default_cmp : I32, I32 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			default_cmp = |a, b| numeric_compare(a, b)
+			order_relative_to : I32, I32 -> [Before, Same, After]
+			order_relative_to = |a, b| numeric_compare(a, b)
 
 			## Returns `Bool.True` if the value is evenly divisible by `2`.
 			## ```roc
@@ -11364,18 +11340,14 @@ Builtin :: [].{
 
 			## Compare two [U64] values and return their ordering.
 			## ```roc
-			## expect U64.compare(1, 2) == FirstBeforeSecond
+			## expect U64.order_relative_to(1, 2) == Before
 			##
-			## expect U64.compare(2, 2) == Equivalent
+			## expect U64.order_relative_to(2, 2) == Same
 			##
-			## expect U64.compare(3, 2) == SecondBeforeFirst
+			## expect U64.order_relative_to(3, 2) == After
 			## ```
-			compare : U64, U64 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			compare = |a, b| numeric_compare(a, b)
-
-			## Default ordering used by [List.sort].
-			default_cmp : U64, U64 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			default_cmp = |a, b| numeric_compare(a, b)
+			order_relative_to : U64, U64 -> [Before, Same, After]
+			order_relative_to = |a, b| numeric_compare(a, b)
 
 			## Returns `Bool.True` if the value is evenly divisible by `2`.
 			## ```roc
@@ -12188,18 +12160,14 @@ Builtin :: [].{
 
 			## Compare two [I64] values and return their ordering.
 			## ```roc
-			## expect I64.compare(1, 2) == FirstBeforeSecond
+			## expect I64.order_relative_to(1, 2) == Before
 			##
-			## expect I64.compare(2, 2) == Equivalent
+			## expect I64.order_relative_to(2, 2) == Same
 			##
-			## expect I64.compare(3, 2) == SecondBeforeFirst
+			## expect I64.order_relative_to(3, 2) == After
 			## ```
-			compare : I64, I64 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			compare = |a, b| numeric_compare(a, b)
-
-			## Default ordering used by [List.sort].
-			default_cmp : I64, I64 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			default_cmp = |a, b| numeric_compare(a, b)
+			order_relative_to : I64, I64 -> [Before, Same, After]
+			order_relative_to = |a, b| numeric_compare(a, b)
 
 			## Returns `Bool.True` if the value is evenly divisible by `2`.
 			## ```roc
@@ -13059,18 +13027,14 @@ Builtin :: [].{
 
 			## Compare two [U128] values and return their ordering.
 			## ```roc
-			## expect U128.compare(1, 2) == FirstBeforeSecond
+			## expect U128.order_relative_to(1, 2) == Before
 			##
-			## expect U128.compare(2, 2) == Equivalent
+			## expect U128.order_relative_to(2, 2) == Same
 			##
-			## expect U128.compare(3, 2) == SecondBeforeFirst
+			## expect U128.order_relative_to(3, 2) == After
 			## ```
-			compare : U128, U128 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			compare = |a, b| numeric_compare(a, b)
-
-			## Default ordering used by [List.sort].
-			default_cmp : U128, U128 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			default_cmp = |a, b| numeric_compare(a, b)
+			order_relative_to : U128, U128 -> [Before, Same, After]
+			order_relative_to = |a, b| numeric_compare(a, b)
 
 			## Returns `Bool.True` if the value is evenly divisible by `2`.
 			## ```roc
@@ -13896,18 +13860,14 @@ Builtin :: [].{
 
 			## Compare two [I128] values and return their ordering.
 			## ```roc
-			## expect I128.compare(1, 2) == FirstBeforeSecond
+			## expect I128.order_relative_to(1, 2) == Before
 			##
-			## expect I128.compare(2, 2) == Equivalent
+			## expect I128.order_relative_to(2, 2) == Same
 			##
-			## expect I128.compare(3, 2) == SecondBeforeFirst
+			## expect I128.order_relative_to(3, 2) == After
 			## ```
-			compare : I128, I128 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			compare = |a, b| numeric_compare(a, b)
-
-			## Default ordering used by [List.sort].
-			default_cmp : I128, I128 -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			default_cmp = |a, b| numeric_compare(a, b)
+			order_relative_to : I128, I128 -> [Before, Same, After]
+			order_relative_to = |a, b| numeric_compare(a, b)
 
 			## Returns `Bool.True` if the value is evenly divisible by `2`.
 			## ```roc
@@ -14855,18 +14815,14 @@ Builtin :: [].{
 
 			## Compare two [Dec] values and return their ordering.
 			## ```roc
-			## expect Dec.compare(1.0, 2.0) == FirstBeforeSecond
+			## expect Dec.order_relative_to(1.0, 2.0) == Before
 			##
-			## expect Dec.compare(2.0, 2.0) == Equivalent
+			## expect Dec.order_relative_to(2.0, 2.0) == Same
 			##
-			## expect Dec.compare(3.0, 2.0) == SecondBeforeFirst
+			## expect Dec.order_relative_to(3.0, 2.0) == After
 			## ```
-			compare : Dec, Dec -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			compare = |a, b| numeric_compare(a, b)
-
-			## Default ordering used by [List.sort].
-			default_cmp : Dec, Dec -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
-			default_cmp = |a, b| numeric_compare(a, b)
+			order_relative_to : Dec, Dec -> [Before, Same, After]
+			order_relative_to = |a, b| numeric_compare(a, b)
 
 			## Returns the greater of two [Dec] values.
 			## ```roc
@@ -22209,15 +22165,15 @@ bytes_to_str = |bytes|
 		Err(_) => Err(OutOfRange)
 	}
 
-reverse_order : [FirstBeforeSecond, Equivalent, SecondBeforeFirst] -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
+reverse_order : [Before, Same, After] -> [Before, Same, After]
 reverse_order = |order|
 	match order {
-		FirstBeforeSecond => SecondBeforeFirst
-		Equivalent => Equivalent
-		SecondBeforeFirst => FirstBeforeSecond
+		Before => After
+		Same => Same
+		After => Before
 	}
 
-sort_impl : List(item), (item, item -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]) -> List(item)
+sort_impl : List(item), (item, item -> [Before, Same, After]) -> List(item)
 sort_impl = |list, compare_items| list_sort_with(list, Box.box(compare_items))
 
 unsigned_plus_try : item, item -> Try(item, [Overflow, ..])
@@ -22644,7 +22600,7 @@ signed_is_multiple_of = |zero, neg_one, value, divisor|
 		value.rem_by(divisor) == zero
 	}
 
-numeric_compare : item, item -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
+numeric_compare : item, item -> [Before, Same, After]
 
 range_with_step : num, num, num, [Exclusive, Inclusive], [To, From] -> Num.Range(num)
 	where [num.range_len_if_known : num, num, num, [Exclusive, Inclusive] -> [Known(U64), Unknown]]
@@ -23266,7 +23222,7 @@ list_release_excess_capacity : List(item) -> List(item)
 
 # Implemented by the compiler. Consumes the list and sorts it stably using the
 # boxed comparator. The comparator allocation is borrowed for the whole call.
-list_sort_with : List(item), Box((item, item -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst])) -> List(item)
+list_sort_with : List(item), Box((item, item -> [Before, Same, After])) -> List(item)
 
 # Unsafe conversion functions - these return simple records instead of Try types
 # They are low-level operations that get replaced by the compiler

--- a/src/builtins/fuzz_sort.zig
+++ b/src/builtins/fuzz_sort.zig
@@ -73,15 +73,11 @@ fn test_i64_compare_refcounted(count_ptr: Opaque, a_ptr: Opaque, b_ptr: Opaque) 
     const a = @as(*i64, @ptrCast(@alignCast(a_ptr))).*;
     const b = @as(*i64, @ptrCast(@alignCast(b_ptr))).*;
 
-    const gt = @as(u8, @intFromBool(a > b));
-    const lt = @as(u8, @intFromBool(a < b));
-
     std.debug.assert(@as(*isize, @ptrCast(@alignCast(count_ptr))).* > 0);
     @as(*isize, @ptrCast(@alignCast(count_ptr))).* -= 1;
-    // Eq = 0
-    // FirstBeforeSecond = 1
-    // SecondBeforeFirst = 2
-    return lt + gt + gt;
+    if (a < b) return @intFromEnum(utils.Ordering.Before);
+    if (a > b) return @intFromEnum(utils.Ordering.After);
+    return @intFromEnum(utils.Ordering.Same);
 }
 
 fn test_i64_copy(dst_ptr: Opaque, src_ptr: Opaque) callconv(.c) void {

--- a/src/builtins/num.zig
+++ b/src/builtins/num.zig
@@ -1011,22 +1011,22 @@ pub fn shiftRightZeroFillU128(self: u128, other: u8) callconv(.c) u128 {
 /// Compares two i128 values, returning ordering.
 pub fn compareI128(self: i128, other: i128) callconv(.c) Ordering {
     if (self == other) {
-        return Ordering.Equivalent;
+        return Ordering.Same;
     } else if (self < other) {
-        return Ordering.FirstBeforeSecond;
+        return Ordering.Before;
     } else {
-        return Ordering.SecondBeforeFirst;
+        return Ordering.After;
     }
 }
 
 /// Compares two u128 values, returning ordering.
 pub fn compareU128(self: u128, other: u128) callconv(.c) Ordering {
     if (self == other) {
-        return Ordering.Equivalent;
+        return Ordering.Same;
     } else if (self < other) {
-        return Ordering.FirstBeforeSecond;
+        return Ordering.Before;
     } else {
-        return Ordering.SecondBeforeFirst;
+        return Ordering.After;
     }
 }
 
@@ -1629,9 +1629,9 @@ test "compareI128 functionality" {
     const b: i128 = 2000000000000000000;
     const c: i128 = 1000000000000000000;
 
-    try std.testing.expectEqual(@import("utils.zig").Ordering.FirstBeforeSecond, compareI128(a, b));
-    try std.testing.expectEqual(@import("utils.zig").Ordering.SecondBeforeFirst, compareI128(b, a));
-    try std.testing.expectEqual(@import("utils.zig").Ordering.Equivalent, compareI128(a, c));
+    try std.testing.expectEqual(@import("utils.zig").Ordering.Before, compareI128(a, b));
+    try std.testing.expectEqual(@import("utils.zig").Ordering.After, compareI128(b, a));
+    try std.testing.expectEqual(@import("utils.zig").Ordering.Same, compareI128(a, c));
 }
 
 test "compareU128 functionality" {
@@ -1639,9 +1639,9 @@ test "compareU128 functionality" {
     const b: u128 = 2000000000000000000;
     const c: u128 = 1000000000000000000;
 
-    try std.testing.expectEqual(@import("utils.zig").Ordering.FirstBeforeSecond, compareU128(a, b));
-    try std.testing.expectEqual(@import("utils.zig").Ordering.SecondBeforeFirst, compareU128(b, a));
-    try std.testing.expectEqual(@import("utils.zig").Ordering.Equivalent, compareU128(a, c));
+    try std.testing.expectEqual(@import("utils.zig").Ordering.Before, compareU128(a, b));
+    try std.testing.expectEqual(@import("utils.zig").Ordering.After, compareU128(b, a));
+    try std.testing.expectEqual(@import("utils.zig").Ordering.Same, compareU128(a, c));
 }
 
 test "128-bit comparison functions" {

--- a/src/builtins/sort.zig
+++ b/src/builtins/sort.zig
@@ -7,7 +7,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-const SecondBeforeFirst = Ordering.SecondBeforeFirst;
+const After = Ordering.After;
 const utils = @import("utils.zig");
 const Ordering = utils.Ordering;
 const RocOps = @import("host_abi.zig").RocOps;
@@ -183,19 +183,19 @@ fn flux_analyze(
 
     if (quad1 < quad2) {
         // Must inc here, due to being in a branch.
-        const gt = compare_inc(cmp, cmp_data, ptr_b, ptr_b + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst;
+        const gt = compare_inc(cmp, cmp_data, ptr_b, ptr_b + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After;
         balance_b += @intFromBool(gt);
         ptr_b += element_width;
     }
     if (quad1 < quad3) {
         // Must inc here, due to being in a branch.
-        const gt = compare_inc(cmp, cmp_data, ptr_c, ptr_c + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst;
+        const gt = compare_inc(cmp, cmp_data, ptr_c, ptr_c + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After;
         balance_c += @intFromBool(gt);
         ptr_c += element_width;
     }
     if (quad1 < quad4) {
         // Must inc here, due to being in a branch.
-        balance_d += @intFromBool(compare_inc(cmp, cmp_data, ptr_d, ptr_d + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst);
+        balance_d += @intFromBool(compare_inc(cmp, cmp_data, ptr_d, ptr_d + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After);
         ptr_d += element_width;
     }
 
@@ -210,13 +210,13 @@ fn flux_analyze(
         var sum_c: u8 = 0;
         var sum_d: u8 = 0;
         for (0..32) |_| {
-            sum_a += @intFromBool(compare(cmp, cmp_data, ptr_a, ptr_a + element_width, indirect) == SecondBeforeFirst);
+            sum_a += @intFromBool(compare(cmp, cmp_data, ptr_a, ptr_a + element_width, indirect) == After);
             ptr_a += element_width;
-            sum_b += @intFromBool(compare(cmp, cmp_data, ptr_b, ptr_b + element_width, indirect) == SecondBeforeFirst);
+            sum_b += @intFromBool(compare(cmp, cmp_data, ptr_b, ptr_b + element_width, indirect) == After);
             ptr_b += element_width;
-            sum_c += @intFromBool(compare(cmp, cmp_data, ptr_c, ptr_c + element_width, indirect) == SecondBeforeFirst);
+            sum_c += @intFromBool(compare(cmp, cmp_data, ptr_c, ptr_c + element_width, indirect) == After);
             ptr_c += element_width;
-            sum_d += @intFromBool(compare(cmp, cmp_data, ptr_d, ptr_d + element_width, indirect) == SecondBeforeFirst);
+            sum_d += @intFromBool(compare(cmp, cmp_data, ptr_d, ptr_d + element_width, indirect) == After);
             ptr_d += element_width;
         }
         balance_a += sum_a;
@@ -253,13 +253,13 @@ fn flux_analyze(
         }
     }
     while (count > 7) : (count -= 4) {
-        balance_a += @intFromBool(compare(cmp, cmp_data, ptr_a, ptr_a + element_width, indirect) == SecondBeforeFirst);
+        balance_a += @intFromBool(compare(cmp, cmp_data, ptr_a, ptr_a + element_width, indirect) == After);
         ptr_a += element_width;
-        balance_b += @intFromBool(compare(cmp, cmp_data, ptr_b, ptr_b + element_width, indirect) == SecondBeforeFirst);
+        balance_b += @intFromBool(compare(cmp, cmp_data, ptr_b, ptr_b + element_width, indirect) == After);
         ptr_b += element_width;
-        balance_c += @intFromBool(compare(cmp, cmp_data, ptr_c, ptr_c + element_width, indirect) == SecondBeforeFirst);
+        balance_c += @intFromBool(compare(cmp, cmp_data, ptr_c, ptr_c + element_width, indirect) == After);
         ptr_c += element_width;
-        balance_d += @intFromBool(compare(cmp, cmp_data, ptr_d, ptr_d + element_width, indirect) == SecondBeforeFirst);
+        balance_d += @intFromBool(compare(cmp, cmp_data, ptr_d, ptr_d + element_width, indirect) == After);
         ptr_d += element_width;
     }
 
@@ -267,9 +267,9 @@ fn flux_analyze(
 
     if (count == 0) {
         // The whole list may be ordered. Cool!
-        if (compare_inc(cmp, cmp_data, ptr_a, ptr_a + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and
-            compare_inc(cmp, cmp_data, ptr_b, ptr_b + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and
-            compare_inc(cmp, cmp_data, ptr_c, ptr_c + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst)
+        if (compare_inc(cmp, cmp_data, ptr_a, ptr_a + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and
+            compare_inc(cmp, cmp_data, ptr_b, ptr_b + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and
+            compare_inc(cmp, cmp_data, ptr_c, ptr_c + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After)
             return;
     }
 
@@ -285,9 +285,9 @@ fn flux_analyze(
         if (data_is_owned) {
             inc_n_data(inc_n_context, cmp_data, 3);
         }
-        const span1: u3 = @intFromBool(reversed_a and reversed_b) * @intFromBool(compare(cmp, cmp_data, ptr_a, ptr_a + element_width, indirect) == SecondBeforeFirst);
-        const span2: u3 = @intFromBool(reversed_b and reversed_c) * @intFromBool(compare(cmp, cmp_data, ptr_b, ptr_b + element_width, indirect) == SecondBeforeFirst);
-        const span3: u3 = @intFromBool(reversed_c and reversed_d) * @intFromBool(compare(cmp, cmp_data, ptr_c, ptr_c + element_width, indirect) == SecondBeforeFirst);
+        const span1: u3 = @intFromBool(reversed_a and reversed_b) * @intFromBool(compare(cmp, cmp_data, ptr_a, ptr_a + element_width, indirect) == After);
+        const span2: u3 = @intFromBool(reversed_b and reversed_c) * @intFromBool(compare(cmp, cmp_data, ptr_b, ptr_b + element_width, indirect) == After);
+        const span3: u3 = @intFromBool(reversed_c and reversed_d) * @intFromBool(compare(cmp, cmp_data, ptr_c, ptr_c + element_width, indirect) == After);
 
         switch (span1 | (span2 << 1) | (span3 << 2)) {
             0 => {},
@@ -441,9 +441,9 @@ fn flux_analyze(
         },
     }
     // Final Merging of sorted partitions.
-    if (compare_inc(cmp, cmp_data, ptr_a, ptr_a + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
-        if (compare_inc(cmp, cmp_data, ptr_c, ptr_c + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
-            if (compare_inc(cmp, cmp_data, ptr_b, ptr_b + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+    if (compare_inc(cmp, cmp_data, ptr_a, ptr_a + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
+        if (compare_inc(cmp, cmp_data, ptr_c, ptr_c + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
+            if (compare_inc(cmp, cmp_data, ptr_b, ptr_b + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
                 // Lucky us, everything sorted.
                 return;
             }
@@ -454,7 +454,7 @@ fn flux_analyze(
             @memcpy(swap[0..(half1 * element_width)], array[0..(half1 * element_width)]);
         }
     } else {
-        if (compare_inc(cmp, cmp_data, ptr_c, ptr_c + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+        if (compare_inc(cmp, cmp_data, ptr_c, ptr_c + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
             // First half needs merge, second half sorted.
             @memcpy((swap + half1 * element_width)[0..(half2 * element_width)], (array + half1 * element_width)[0..(half2 * element_width)]);
             cross_merge(swap, array, quad1, quad2, cmp, cmp_data, element_width, copy, data_is_owned, inc_n_context, inc_n_data, indirect);
@@ -510,7 +510,7 @@ fn flux_partition(
             }
         }
 
-        if (arr_len != 0 and compare_inc(cmp, cmp_data, pivot_ptr + element_width, pivot_ptr, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+        if (arr_len != 0 and compare_inc(cmp, cmp_data, pivot_ptr + element_width, pivot_ptr, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
             // pivot equals the last pivot, reverse partition and everything is done.
             flux_reverse_partition(array, swap, array, pivot_ptr, len, cmp, cmp_data, element_width, copy, data_is_owned, inc_n_context, inc_n_data, indirect);
             return;
@@ -586,7 +586,7 @@ pub fn flux_default_partition(
     var a: usize = 8;
     while (a <= len) : (a += 8) {
         inline for (0..8) |_| {
-            const from = if (compare(cmp, cmp_data, x_ptr, pivot_ptr, indirect) != SecondBeforeFirst) &arr_ptr else &swap_ptr;
+            const from = if (compare(cmp, cmp_data, x_ptr, pivot_ptr, indirect) != After) &arr_ptr else &swap_ptr;
             copy(from.*, x_ptr, element_width);
             from.* += element_width;
             x_ptr += element_width;
@@ -596,7 +596,7 @@ pub fn flux_default_partition(
             run = a;
     }
     for (0..(len % 8)) |_| {
-        const from = if (compare(cmp, cmp_data, x_ptr, pivot_ptr, indirect) != SecondBeforeFirst) &arr_ptr else &swap_ptr;
+        const from = if (compare(cmp, cmp_data, x_ptr, pivot_ptr, indirect) != After) &arr_ptr else &swap_ptr;
         copy(from.*, x_ptr, element_width);
         from.* += element_width;
         x_ptr += element_width;
@@ -654,14 +654,14 @@ pub fn flux_reverse_partition(
     }
     for (0..(len / 8)) |_| {
         inline for (0..8) |_| {
-            const from = if (compare(cmp, cmp_data, pivot_ptr, x_ptr, indirect) == SecondBeforeFirst) &arr_ptr else &swap_ptr;
+            const from = if (compare(cmp, cmp_data, pivot_ptr, x_ptr, indirect) == After) &arr_ptr else &swap_ptr;
             copy(from.*, x_ptr, element_width);
             from.* += element_width;
             x_ptr += element_width;
         }
     }
     for (0..(len % 8)) |_| {
-        const from = if (compare(cmp, cmp_data, pivot_ptr, x_ptr, indirect) == SecondBeforeFirst) &arr_ptr else &swap_ptr;
+        const from = if (compare(cmp, cmp_data, pivot_ptr, x_ptr, indirect) == After) &arr_ptr else &swap_ptr;
         copy(from.*, x_ptr, element_width);
         from.* += element_width;
         x_ptr += element_width;
@@ -720,7 +720,7 @@ pub fn median_of_cube_root(
     quadsort_swap(swap_ptr, cbrt, swap_ptr + cbrt * 2 * element_width, cbrt, cmp, cmp_data, element_width, copy, data_is_owned, inc_n_context, inc_n_data, indirect);
     quadsort_swap(swap_ptr + cbrt * element_width, cbrt, swap_ptr + cbrt * 2 * element_width, cbrt, cmp, cmp_data, element_width, copy, data_is_owned, inc_n_context, inc_n_data, indirect);
 
-    generic.* = compare_inc(cmp, cmp_data, swap_ptr + (cbrt * 2 - 1) * element_width, swap_ptr, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, swap_ptr + (cbrt - 1) * element_width, swap_ptr, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst;
+    generic.* = compare_inc(cmp, cmp_data, swap_ptr + (cbrt * 2 - 1) * element_width, swap_ptr, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, swap_ptr + (cbrt - 1) * element_width, swap_ptr, data_is_owned, inc_n_context, inc_n_data, indirect) != After;
 
     binary_median(swap_ptr, swap_ptr + cbrt * element_width, cbrt, cmp, cmp_data, element_width, copy, data_is_owned, inc_n_context, inc_n_data, out, indirect);
 }
@@ -764,9 +764,9 @@ pub fn median_of_nine(
     if (data_is_owned) {
         inc_n_data(inc_n_context, cmp_data, 3);
     }
-    const x: usize = @intFromBool(compare(cmp, cmp_data, swap_ptr + 0 * element_width, swap_ptr + 1 * element_width, indirect) == SecondBeforeFirst);
-    const y: usize = @intFromBool(compare(cmp, cmp_data, swap_ptr + 0 * element_width, swap_ptr + 2 * element_width, indirect) == SecondBeforeFirst);
-    const z: usize = @intFromBool(compare(cmp, cmp_data, swap_ptr + 1 * element_width, swap_ptr + 2 * element_width, indirect) == SecondBeforeFirst);
+    const x: usize = @intFromBool(compare(cmp, cmp_data, swap_ptr + 0 * element_width, swap_ptr + 1 * element_width, indirect) == After);
+    const y: usize = @intFromBool(compare(cmp, cmp_data, swap_ptr + 0 * element_width, swap_ptr + 2 * element_width, indirect) == After);
+    const z: usize = @intFromBool(compare(cmp, cmp_data, swap_ptr + 1 * element_width, swap_ptr + 2 * element_width, indirect) == After);
 
     const index = @intFromBool(x == y) + (x ^ z);
     copy(out, swap_ptr + index * element_width, element_width);
@@ -794,7 +794,7 @@ pub fn trim_four(
     }
     var ptr_a = initial_ptr_a;
     {
-        const gt = compare(cmp, cmp_data, ptr_a, ptr_a + element_width, indirect) == SecondBeforeFirst;
+        const gt = compare(cmp, cmp_data, ptr_a, ptr_a + element_width, indirect) == After;
         const x = if (gt) element_width else 0;
         const not_x = if (!gt) element_width else 0;
         copy(tmp_ptr, ptr_a + not_x, element_width);
@@ -803,7 +803,7 @@ pub fn trim_four(
         ptr_a += 2 * element_width;
     }
     {
-        const gt = compare(cmp, cmp_data, ptr_a, ptr_a + element_width, indirect) == SecondBeforeFirst;
+        const gt = compare(cmp, cmp_data, ptr_a, ptr_a + element_width, indirect) == After;
         const x = if (gt) element_width else 0;
         const not_x = if (!gt) element_width else 0;
         copy(tmp_ptr, ptr_a + not_x, element_width);
@@ -812,13 +812,13 @@ pub fn trim_four(
         ptr_a -= 2 * element_width;
     }
     {
-        const lte = compare(cmp, cmp_data, ptr_a, ptr_a + 2 * element_width, indirect) != SecondBeforeFirst;
+        const lte = compare(cmp, cmp_data, ptr_a, ptr_a + 2 * element_width, indirect) != After;
         const x = if (lte) 2 * element_width else 0;
         copy(ptr_a + 2 * element_width, ptr_a + x, element_width);
         ptr_a += element_width;
     }
     {
-        const gt = compare(cmp, cmp_data, ptr_a, ptr_a + 2 * element_width, indirect) == SecondBeforeFirst;
+        const gt = compare(cmp, cmp_data, ptr_a, ptr_a + 2 * element_width, indirect) == After;
         const x = if (gt) 2 * element_width else 0;
         copy(ptr_a, ptr_a + x, element_width);
     }
@@ -850,13 +850,13 @@ pub fn binary_median(
     var ptr_b = initial_ptr_b;
     len /= 2;
     while (len != 0) : (len /= 2) {
-        if (compare(cmp, cmp_data, ptr_a, ptr_b, indirect) != SecondBeforeFirst) {
+        if (compare(cmp, cmp_data, ptr_a, ptr_b, indirect) != After) {
             ptr_a += len * element_width;
         } else {
             ptr_b += len * element_width;
         }
     }
-    const from = if (compare(cmp, cmp_data, ptr_a, ptr_b, indirect) == SecondBeforeFirst) ptr_a else ptr_b;
+    const from = if (compare(cmp, cmp_data, ptr_a, ptr_b, indirect) == After) ptr_a else ptr_b;
     copy(out, from, element_width);
 }
 
@@ -1044,7 +1044,7 @@ fn rotate_merge_block(
     if (data_is_owned) {
         inc_n_data(inc_n_context, cmp_data, 1);
     }
-    if (compare(cmp, cmp_data, array + (left_block - 1) * element_width, array + left_block * element_width, indirect) != SecondBeforeFirst) {
+    if (compare(cmp, cmp_data, array + (left_block - 1) * element_width, array + left_block * element_width, indirect) != After) {
         // Lucky us, already sorted.
         return;
     }
@@ -1115,13 +1115,13 @@ pub fn monobound_binary_first(
     while (top > 1) {
         const mid = top / 2;
 
-        if (compare(cmp, cmp_data, value_ptr, end_ptr - mid * element_width, indirect) != SecondBeforeFirst) {
+        if (compare(cmp, cmp_data, value_ptr, end_ptr - mid * element_width, indirect) != After) {
             end_ptr -= mid * element_width;
         }
         top -= mid;
     }
 
-    if (compare(cmp, cmp_data, value_ptr, end_ptr - element_width, indirect) != SecondBeforeFirst) {
+    if (compare(cmp, cmp_data, value_ptr, end_ptr - element_width, indirect) != After) {
         end_ptr -= element_width;
     }
     return (@intFromPtr(end_ptr) - @intFromPtr(array)) / element_width;
@@ -1352,7 +1352,7 @@ pub fn partial_backwards_merge(
     if (data_is_owned) {
         inc_n_data(inc_n_context, cmp_data, 1);
     }
-    if (compare(cmp, cmp_data, left_tail, left_tail + element_width, indirect) != SecondBeforeFirst) {
+    if (compare(cmp, cmp_data, left_tail, left_tail + element_width, indirect) != After) {
         // Lucky case, blocks happen to be sorted.
         return;
     }
@@ -1375,7 +1375,7 @@ pub fn partial_backwards_merge(
     // For backwards, we first try to do really large chunks, of 16 elements.
     outer: while (@intFromPtr(left_tail) > @intFromPtr(array + 16 * element_width) and @intFromPtr(right_tail) > @intFromPtr(swap + 16 * element_width)) {
         // Due to if looping, these must use `compare_inc`
-        while (compare_inc(cmp, cmp_data, left_tail, right_tail - 15 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+        while (compare_inc(cmp, cmp_data, left_tail, right_tail - 15 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
             inline for (0..16) |_| {
                 copy(dest_tail, right_tail, element_width);
                 dest_tail -= element_width;
@@ -1385,7 +1385,7 @@ pub fn partial_backwards_merge(
                 break :outer;
         }
         // Due to if looping, these must use `compare_inc`
-        while (compare_inc(cmp, cmp_data, left_tail - 15 * element_width, right_tail, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+        while (compare_inc(cmp, cmp_data, left_tail - 15 * element_width, right_tail, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
             inline for (0..16) |_| {
                 copy(dest_tail, left_tail, element_width);
                 dest_tail -= element_width;
@@ -1398,13 +1398,13 @@ pub fn partial_backwards_merge(
         var loops: usize = 8;
         while (true) {
             // Due to if else chain and uncertain calling, these must use `compare_inc`
-            if (compare_inc(cmp, cmp_data, left_tail, right_tail - element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+            if (compare_inc(cmp, cmp_data, left_tail, right_tail - element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
                 inline for (0..2) |_| {
                     copy(dest_tail, right_tail, element_width);
                     dest_tail -= element_width;
                     right_tail -= element_width;
                 }
-            } else if (compare_inc(cmp, cmp_data, left_tail - element_width, right_tail, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+            } else if (compare_inc(cmp, cmp_data, left_tail - element_width, right_tail, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
                 inline for (0..2) |_| {
                     copy(dest_tail, left_tail, element_width);
                     dest_tail -= element_width;
@@ -1416,7 +1416,7 @@ pub fn partial_backwards_merge(
                 if (data_is_owned) {
                     inc_n_data(inc_n_context, cmp_data, 2);
                 }
-                const lte = compare(cmp, cmp_data, left_tail, right_tail, indirect) != SecondBeforeFirst;
+                const lte = compare(cmp, cmp_data, left_tail, right_tail, indirect) != After;
                 const x = if (lte) element_width else 0;
                 const not_x = if (!lte) element_width else 0;
                 dest_tail -= element_width;
@@ -1451,7 +1451,7 @@ pub fn partial_backwards_merge(
             inc_n_data(inc_n_context, cmp_data, 2);
         }
         // Couldn't move two elements, do a cross swap and continue.
-        const lte = compare(cmp, cmp_data, left_tail, right_tail, indirect) != SecondBeforeFirst;
+        const lte = compare(cmp, cmp_data, left_tail, right_tail, indirect) != After;
         const x = if (lte) element_width else 0;
         const not_x = if (!lte) element_width else 0;
         dest_tail -= element_width;
@@ -1498,7 +1498,7 @@ fn partial_forward_merge_right_tail_2(
     inc_n_data: IncN,
     comptime indirect: bool,
 ) bool {
-    if (compare_inc(cmp, cmp_data, left_tail.*, right_tail.* - element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+    if (compare_inc(cmp, cmp_data, left_tail.*, right_tail.* - element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
         inline for (0..2) |_| {
             copy(dest.*, right_tail.*, element_width);
             dest.* -= element_width;
@@ -1509,7 +1509,7 @@ fn partial_forward_merge_right_tail_2(
         }
         return true;
     }
-    if (compare_inc(cmp, cmp_data, left_tail.* - element_width, right_tail.*, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+    if (compare_inc(cmp, cmp_data, left_tail.* - element_width, right_tail.*, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
         inline for (0..2) |_| {
             copy(dest.*, left_tail.*, element_width);
             dest.* -= element_width;
@@ -1538,7 +1538,7 @@ fn partial_forward_merge_left_tail_2(
     inc_n_data: IncN,
     comptime indirect: bool,
 ) bool {
-    if (compare_inc(cmp, cmp_data, left_tail.* - element_width, right_tail.*, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+    if (compare_inc(cmp, cmp_data, left_tail.* - element_width, right_tail.*, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
         inline for (0..2) |_| {
             copy(dest.*, left_tail.*, element_width);
             dest.* -= element_width;
@@ -1549,7 +1549,7 @@ fn partial_forward_merge_left_tail_2(
         }
         return true;
     }
-    if (compare_inc(cmp, cmp_data, left_tail.*, right_tail.* - element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+    if (compare_inc(cmp, cmp_data, left_tail.*, right_tail.* - element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
         inline for (0..2) |_| {
             copy(dest.*, right_tail.*, element_width);
             dest.* -= element_width;
@@ -1594,7 +1594,7 @@ pub fn partial_forward_merge(
     if (data_is_owned) {
         inc_n_data(inc_n_context, cmp_data, 1);
     }
-    if (compare(cmp, cmp_data, right_head - element_width, right_head, indirect) != SecondBeforeFirst) {
+    if (compare(cmp, cmp_data, right_head - element_width, right_head, indirect) != After) {
         // Lucky case, blocks happen to be sorted.
         return;
     }
@@ -1621,7 +1621,7 @@ pub fn partial_forward_merge(
             inc_n_data(inc_n_context, cmp_data, 2);
         }
         // Couldn't move two elements, do a cross swap and continue.
-        const lte = compare(cmp, cmp_data, left_head, right_head, indirect) != SecondBeforeFirst;
+        const lte = compare(cmp, cmp_data, left_head, right_head, indirect) != After;
         const x = if (lte) element_width else 0;
         const not_x = if (!lte) element_width else 0;
         copy(dest_head + x, right_head, element_width);
@@ -1667,7 +1667,7 @@ fn partial_forward_merge_right_head_2(
     inc_n_data: IncN,
     comptime indirect: bool,
 ) bool {
-    if (compare_inc(cmp, cmp_data, left_head.*, right_head.* + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+    if (compare_inc(cmp, cmp_data, left_head.*, right_head.* + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
         inline for (0..2) |_| {
             copy(dest.*, right_head.*, element_width);
             dest.* += element_width;
@@ -1678,7 +1678,7 @@ fn partial_forward_merge_right_head_2(
         }
         return true;
     }
-    if (compare_inc(cmp, cmp_data, left_head.* + element_width, right_head.*, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+    if (compare_inc(cmp, cmp_data, left_head.* + element_width, right_head.*, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
         inline for (0..2) |_| {
             copy(dest.*, left_head.*, element_width);
             dest.* += element_width;
@@ -1707,7 +1707,7 @@ fn partial_forward_merge_left_head_2(
     inc_n_data: IncN,
     comptime indirect: bool,
 ) bool {
-    if (compare_inc(cmp, cmp_data, left_head.* + element_width, right_head.*, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+    if (compare_inc(cmp, cmp_data, left_head.* + element_width, right_head.*, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
         inline for (0..2) |_| {
             copy(dest.*, left_head.*, element_width);
             dest.* += element_width;
@@ -1718,7 +1718,7 @@ fn partial_forward_merge_left_head_2(
         }
         return true;
     }
-    if (compare_inc(cmp, cmp_data, left_head.*, right_head.* + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+    if (compare_inc(cmp, cmp_data, left_head.*, right_head.* + element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
         inline for (0..2) |_| {
             copy(dest.*, right_head.*, element_width);
             dest.* += element_width;
@@ -1799,8 +1799,8 @@ pub fn quad_merge_block(
     if (data_is_owned) {
         inc_n_data(inc_n_context, cmp_data, 2);
     }
-    const in_order_1_2: u2 = @intFromBool(compare(cmp, cmp_data, block2 - element_width, block2, indirect) != SecondBeforeFirst);
-    const in_order_3_4: u2 = @intFromBool(compare(cmp, cmp_data, block4 - element_width, block4, indirect) != SecondBeforeFirst);
+    const in_order_1_2: u2 = @intFromBool(compare(cmp, cmp_data, block2 - element_width, block2, indirect) != After);
+    const in_order_3_4: u2 = @intFromBool(compare(cmp, cmp_data, block4 - element_width, block4, indirect) != After);
 
     switch (in_order_1_2 | (in_order_3_4 << 1)) {
         0 => {
@@ -1823,7 +1823,7 @@ pub fn quad_merge_block(
             if (data_is_owned) {
                 inc_n_data(inc_n_context, cmp_data, 1);
             }
-            const in_order_2_3 = compare(cmp, cmp_data, block3 - element_width, block3, indirect) != SecondBeforeFirst;
+            const in_order_2_3 = compare(cmp, cmp_data, block3 - element_width, block3, indirect) != After;
             if (in_order_2_3)
                 // Lucky, all sorted.
                 return;
@@ -1862,7 +1862,7 @@ pub fn cross_merge(
     if (left_len + 1 >= right_len and right_len + 1 >= left_len and left_len >= 32) {
         const offset = 15 * element_width;
         // Due to short circuit logic, these must use `compare_inc`
-        if (compare_inc(cmp, cmp_data, left_head + offset, right_head, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst and compare_inc(cmp, cmp_data, left_head, right_head + offset, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, left_tail, right_tail - offset, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst and compare_inc(cmp, cmp_data, left_tail - offset, right_tail, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+        if (compare_inc(cmp, cmp_data, left_head + offset, right_head, data_is_owned, inc_n_context, inc_n_data, indirect) == After and compare_inc(cmp, cmp_data, left_head, right_head + offset, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, left_tail, right_tail - offset, data_is_owned, inc_n_context, inc_n_data, indirect) == After and compare_inc(cmp, cmp_data, left_tail - offset, right_tail, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
             parity_merge(dest, src, left_len, right_len, cmp, cmp_data, element_width, copy, data_is_owned, inc_n_context, inc_n_data, indirect);
             return;
         }
@@ -1876,7 +1876,7 @@ pub fn cross_merge(
         if (@as(isize, @intCast(@intFromPtr(left_tail))) - @as(isize, @intCast(@intFromPtr(left_head))) > @as(isize, @intCast(8 * element_width))) {
             // 8 elements all less than or equal to and can be moved together.
             // Due to looping, these must use `compare_inc`
-            while (compare_inc(cmp, cmp_data, left_head + 7 * element_width, right_head, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+            while (compare_inc(cmp, cmp_data, left_head + 7 * element_width, right_head, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
                 inline for (0..8) |_| {
                     copy(dest_head, left_head, element_width);
                     dest_head += element_width;
@@ -1889,7 +1889,7 @@ pub fn cross_merge(
             // Attempt to do the same from the tail.
             // 8 elements all greater than and can be moved together.
             // Due to looping, these must use `compare_inc`
-            while (compare_inc(cmp, cmp_data, left_tail - 7 * element_width, right_tail, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+            while (compare_inc(cmp, cmp_data, left_tail - 7 * element_width, right_tail, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
                 inline for (0..8) |_| {
                     copy(dest_tail, left_tail, element_width);
                     dest_tail -= element_width;
@@ -1905,7 +1905,7 @@ pub fn cross_merge(
         if (@as(isize, @intCast(@intFromPtr(right_tail))) - @as(isize, @intCast(@intFromPtr(right_head))) > @as(isize, @intCast(8 * element_width))) {
             // left greater than 8 elements right and can be moved together.
             // Due to looping, these must use `compare_inc`
-            while (compare_inc(cmp, cmp_data, left_head, right_head + 7 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+            while (compare_inc(cmp, cmp_data, left_head, right_head + 7 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
                 inline for (0..8) |_| {
                     copy(dest_head, right_head, element_width);
                     dest_head += element_width;
@@ -1918,7 +1918,7 @@ pub fn cross_merge(
             // Attempt to do the same from the tail.
             // left less than or equalt to 8 elements right and can be moved together.
             // Due to looping, these must use `compare_inc`
-            while (compare_inc(cmp, cmp_data, left_tail, right_tail - 7 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+            while (compare_inc(cmp, cmp_data, left_tail, right_tail - 7 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
                 inline for (0..8) |_| {
                     copy(dest_tail, right_tail, element_width);
                     dest_tail -= element_width;
@@ -2036,10 +2036,10 @@ pub fn quad_swap(
         if (data_is_owned) {
             inc_n_data(inc_n_context, cmp_data, 4);
         }
-        var v1: u4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 0 * element_width, arr_ptr + 1 * element_width, indirect) == SecondBeforeFirst);
-        var v2: u4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 2 * element_width, arr_ptr + 3 * element_width, indirect) == SecondBeforeFirst);
-        var v3: u4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 4 * element_width, arr_ptr + 5 * element_width, indirect) == SecondBeforeFirst);
-        var v4: u4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 6 * element_width, arr_ptr + 7 * element_width, indirect) == SecondBeforeFirst);
+        var v1: u4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 0 * element_width, arr_ptr + 1 * element_width, indirect) == After);
+        var v2: u4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 2 * element_width, arr_ptr + 3 * element_width, indirect) == After);
+        var v3: u4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 4 * element_width, arr_ptr + 5 * element_width, indirect) == After);
+        var v4: u4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 6 * element_width, arr_ptr + 7 * element_width, indirect) == After);
 
         // This is an attempt at computed gotos in zig.
         // Not yet sure if it will optimize as well as the raw gotos in C.
@@ -2049,7 +2049,7 @@ pub fn quad_swap(
                 0 => {
                     // potentially already ordered, check rest!
                     // Due to short circuit logic, these must use `compare_inc`
-                    if (compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+                    if (compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
                         break :switch_state .ordered;
                     }
                     // 16 guaranteed compares.
@@ -2064,7 +2064,7 @@ pub fn quad_swap(
                 15 => {
                     // potentially already reverse ordered, check rest!
                     // Due to short circuit logic, these must use `compare_inc`
-                    if (compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+                    if (compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
                         reverse_head = arr_ptr;
                         break :switch_state .reversed;
                     }
@@ -2107,14 +2107,14 @@ pub fn quad_swap(
                         if (data_is_owned) {
                             inc_n_data(inc_n_context, cmp_data, 4);
                         }
-                        v1 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 0 * element_width, arr_ptr + 1 * element_width, indirect) == SecondBeforeFirst);
-                        v2 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 2 * element_width, arr_ptr + 3 * element_width, indirect) == SecondBeforeFirst);
-                        v3 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 4 * element_width, arr_ptr + 5 * element_width, indirect) == SecondBeforeFirst);
-                        v4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 6 * element_width, arr_ptr + 7 * element_width, indirect) == SecondBeforeFirst);
+                        v1 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 0 * element_width, arr_ptr + 1 * element_width, indirect) == After);
+                        v2 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 2 * element_width, arr_ptr + 3 * element_width, indirect) == After);
+                        v3 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 4 * element_width, arr_ptr + 5 * element_width, indirect) == After);
+                        v4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 6 * element_width, arr_ptr + 7 * element_width, indirect) == After);
                         if (v1 | v2 | v3 | v4 != 0) {
                             // Sadly not ordered still, maybe reversed though?
                             // Due to short circuit logic, these must use `compare_inc`
-                            if (v1 + v2 + v3 + v4 == 4 and compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+                            if (v1 + v2 + v3 + v4 == 4 and compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
                                 reverse_head = arr_ptr;
                                 state = .reversed;
                                 continue;
@@ -2123,7 +2123,7 @@ pub fn quad_swap(
                             continue;
                         }
                         // Due to short circuit logic, these must use `compare_inc`
-                        if (compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+                        if (compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
                             state = .ordered;
                             continue;
                         }
@@ -2148,17 +2148,17 @@ pub fn quad_swap(
                         if (data_is_owned) {
                             inc_n_data(inc_n_context, cmp_data, 4);
                         }
-                        v1 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 0 * element_width, arr_ptr + 1 * element_width, indirect) != SecondBeforeFirst);
-                        v2 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 2 * element_width, arr_ptr + 3 * element_width, indirect) != SecondBeforeFirst);
-                        v3 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 4 * element_width, arr_ptr + 5 * element_width, indirect) != SecondBeforeFirst);
-                        v4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 6 * element_width, arr_ptr + 7 * element_width, indirect) != SecondBeforeFirst);
+                        v1 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 0 * element_width, arr_ptr + 1 * element_width, indirect) != After);
+                        v2 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 2 * element_width, arr_ptr + 3 * element_width, indirect) != After);
+                        v3 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 4 * element_width, arr_ptr + 5 * element_width, indirect) != After);
+                        v4 = @intFromBool(compare(cmp, cmp_data, arr_ptr + 6 * element_width, arr_ptr + 7 * element_width, indirect) != After);
                         if (v1 | v2 | v3 | v4 != 0) {
                             // Sadly not still reversed.
                             // So we just need to reverse upto this point, but not the current 8 element block.
                         } else {
                             // This also checks the boundary between this and the last block.
                             // Due to short circuit logic, these must use `compare_inc`
-                            if (compare_inc(cmp, cmp_data, arr_ptr - 1 * element_width, arr_ptr + 0 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+                            if (compare_inc(cmp, cmp_data, arr_ptr - 1 * element_width, arr_ptr + 0 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After and compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
                                 // Row multiple reversed blocks in a row!
                                 state = .reversed;
                                 continue;
@@ -2169,12 +2169,12 @@ pub fn quad_swap(
 
                         // Since we already have v1 to v4, check the next block state.
                         // Due to short circuit logic, these must use `compare_inc`
-                        if (v1 + v2 + v3 + v4 == 4 and compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+                        if (v1 + v2 + v3 + v4 == 4 and compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
                             state = .ordered;
                             continue;
                         }
                         // Due to short circuit logic, these must use `compare_inc`
-                        if (v1 + v2 + v3 + v4 == 0 and compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+                        if (v1 + v2 + v3 + v4 == 0 and compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
                             reverse_head = arr_ptr;
                             state = .reversed;
                             continue;
@@ -2192,7 +2192,7 @@ pub fn quad_swap(
                         arr_ptr -= 8 * element_width;
 
                         // Due to short circuit logic, these must use `compare_inc`
-                        if (compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst or compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst or compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == SecondBeforeFirst) {
+                        if (compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After or compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After or compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) == After) {
                             // 16 guaranteed compares.
                             if (data_is_owned) {
                                 inc_n_data(inc_n_context, cmp_data, 16);
@@ -2207,19 +2207,19 @@ pub fn quad_swap(
                     const rem = len % 8;
                     reverse_block: {
                         // Due to chance of breaking and not running, must use `compare_inc`.
-                        if (rem == 7 and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst)
+                        if (rem == 7 and compare_inc(cmp, cmp_data, arr_ptr + 5 * element_width, arr_ptr + 6 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After)
                             break :reverse_block;
-                        if (rem >= 6 and compare_inc(cmp, cmp_data, arr_ptr + 4 * element_width, arr_ptr + 5 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst)
+                        if (rem >= 6 and compare_inc(cmp, cmp_data, arr_ptr + 4 * element_width, arr_ptr + 5 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After)
                             break :reverse_block;
-                        if (rem >= 5 and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst)
+                        if (rem >= 5 and compare_inc(cmp, cmp_data, arr_ptr + 3 * element_width, arr_ptr + 4 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After)
                             break :reverse_block;
-                        if (rem >= 4 and compare_inc(cmp, cmp_data, arr_ptr + 2 * element_width, arr_ptr + 3 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst)
+                        if (rem >= 4 and compare_inc(cmp, cmp_data, arr_ptr + 2 * element_width, arr_ptr + 3 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After)
                             break :reverse_block;
-                        if (rem >= 3 and compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst)
+                        if (rem >= 3 and compare_inc(cmp, cmp_data, arr_ptr + 1 * element_width, arr_ptr + 2 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After)
                             break :reverse_block;
-                        if (rem >= 2 and compare_inc(cmp, cmp_data, arr_ptr + 0 * element_width, arr_ptr + 1 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst)
+                        if (rem >= 2 and compare_inc(cmp, cmp_data, arr_ptr + 0 * element_width, arr_ptr + 1 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After)
                             break :reverse_block;
-                        if (rem >= 1 and compare_inc(cmp, cmp_data, arr_ptr - 1 * element_width, arr_ptr + 0 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst)
+                        if (rem >= 1 and compare_inc(cmp, cmp_data, arr_ptr - 1 * element_width, arr_ptr + 0 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After)
                             break :reverse_block;
                         quad_reversal(reverse_head, arr_ptr + rem * element_width - element_width, element_width, copy);
 
@@ -2250,7 +2250,7 @@ pub fn quad_swap(
         arr_ptr += 32 * element_width;
     }) {
         // Due to short circuit logic, these must use `compare_inc`
-        if (compare_inc(cmp, cmp_data, arr_ptr + 7 * element_width, arr_ptr + 8 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 15 * element_width, arr_ptr + 16 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr + 23 * element_width, arr_ptr + 24 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+        if (compare_inc(cmp, cmp_data, arr_ptr + 7 * element_width, arr_ptr + 8 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, arr_ptr + 15 * element_width, arr_ptr + 16 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, arr_ptr + 23 * element_width, arr_ptr + 24 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
             // Already in order.
             continue;
         }
@@ -2375,7 +2375,7 @@ pub fn tail_swap(
     tail_swap(arr_ptr, quad4, swap, cmp, cmp_data, element_width, copy, data_is_owned, inc_n_context, inc_n_data, indirect);
 
     // Due to short circuit logic, these must use `compare_inc`
-    if (compare_inc(cmp, cmp_data, array + (quad1 - 1) * element_width, array + quad1 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, array + (half1 - 1) * element_width, array + half1 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst and compare_inc(cmp, cmp_data, arr_ptr - 1 * element_width, arr_ptr, data_is_owned, inc_n_context, inc_n_data, indirect) != SecondBeforeFirst) {
+    if (compare_inc(cmp, cmp_data, array + (quad1 - 1) * element_width, array + quad1 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, array + (half1 - 1) * element_width, array + half1 * element_width, data_is_owned, inc_n_context, inc_n_data, indirect) != After and compare_inc(cmp, cmp_data, arr_ptr - 1 * element_width, arr_ptr, data_is_owned, inc_n_context, inc_n_data, indirect) != After) {
         return;
     }
 
@@ -2500,7 +2500,7 @@ inline fn head_guarded_merge(
     // exactly as [head_branchless_merge] would spend it.
     const probe_left = if (left_available) left.* else right.*;
     const probe_right = if (right_available) right.* else left.*;
-    const lte = compare(cmp, cmp_data, probe_left, probe_right, indirect) != SecondBeforeFirst;
+    const lte = compare(cmp, cmp_data, probe_left, probe_right, indirect) != After;
 
     const take_left = if (!right_available) true else if (!left_available) false else lte;
     const from = if (take_left) left else right;
@@ -2532,7 +2532,7 @@ inline fn tail_guarded_merge(
     // See [head_guarded_merge] for why a spent run is not read.
     const probe_left = if (left_available) left.* else right.*;
     const probe_right = if (right_available) right.* else left.*;
-    const gt = compare(cmp, cmp_data, probe_left, probe_right, indirect) == SecondBeforeFirst;
+    const gt = compare(cmp, cmp_data, probe_left, probe_right, indirect) == After;
 
     const take_left = if (!right_available) true else if (!left_available) false else gt;
     const from = if (take_left) left else right;
@@ -2627,7 +2627,7 @@ fn parity_swap_four(
     swap_branchless(arr_ptr, tmp_ptr, cmp, cmp_data, element_width, copy, indirect);
     arr_ptr -= element_width;
 
-    const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == SecondBeforeFirst;
+    const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == After;
     if (gt) {
         // 3 guaranteed compares.
         if (data_is_owned) {
@@ -2718,7 +2718,7 @@ fn parity_swap_six(
     arr_ptr = array;
 
     {
-        const lte = compare(cmp, cmp_data, arr_ptr + 2 * element_width, arr_ptr + 3 * element_width, indirect) != SecondBeforeFirst;
+        const lte = compare(cmp, cmp_data, arr_ptr + 2 * element_width, arr_ptr + 3 * element_width, indirect) != After;
         if (lte) {
             // 2 guaranteed compares.
             if (data_is_owned) {
@@ -2736,7 +2736,7 @@ fn parity_swap_six(
         inc_n_data(inc_n_context, cmp_data, 8);
     }
     {
-        const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == SecondBeforeFirst;
+        const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == After;
         const x = if (gt) element_width else 0;
         const not_x = if (!gt) element_width else 0;
         copy(swap, arr_ptr + x, element_width);
@@ -2745,7 +2745,7 @@ fn parity_swap_six(
         arr_ptr += 4 * element_width;
     }
     {
-        const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == SecondBeforeFirst;
+        const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == After;
         const x = if (gt) element_width else 0;
         const not_x = if (!gt) element_width else 0;
         copy(swap + 4 * element_width, arr_ptr + x, element_width);
@@ -2822,7 +2822,7 @@ fn parity_swap_seven(
     arr_ptr = array;
 
     {
-        const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == SecondBeforeFirst;
+        const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == After;
         const x = if (gt) element_width else 0;
         const not_x = if (!gt) element_width else 0;
         copy(swap, arr_ptr + x, element_width);
@@ -2831,7 +2831,7 @@ fn parity_swap_seven(
         arr_ptr += 3 * element_width;
     }
     {
-        const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == SecondBeforeFirst;
+        const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == After;
         const x = if (gt) element_width else 0;
         const not_x = if (!gt) element_width else 0;
         copy(swap + 3 * element_width, arr_ptr + x, element_width);
@@ -2839,7 +2839,7 @@ fn parity_swap_seven(
         arr_ptr += 2 * element_width;
     }
     {
-        const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == SecondBeforeFirst;
+        const gt = compare(cmp, cmp_data, arr_ptr, arr_ptr + element_width, indirect) == After;
         const x = if (gt) element_width else 0;
         const not_x = if (!gt) element_width else 0;
         copy(swap + 5 * element_width, arr_ptr + x, element_width);
@@ -2974,7 +2974,7 @@ pub inline fn head_branchless_merge(
     // Note equivalent c code:
     //    *pt_d++ = cmp(pt_l, ptr) <= 0 ? *pt_l++ : *pt_r++;
     // While not guaranteed branchless, tested in godbolt for x86_64, aarch32, aarch64, riscv64, and wasm32.
-    const lte = compare(cmp, cmp_data, left.*, right.*, indirect) != SecondBeforeFirst;
+    const lte = compare(cmp, cmp_data, left.*, right.*, indirect) != After;
     const from = if (lte) left else right;
     copy(dest.*, from.*, element_width);
     from.* += element_width;
@@ -2999,7 +2999,7 @@ pub inline fn tail_branchless_merge(
     // Note equivalent c code:
     //    *tpd-- = cmp(tpl, tpr) > 0 ? *tpl-- : *tpr--;
     // While not guaranteed branchless, tested in godbolt for x86_64, aarch32, aarch64, riscv64, and wasm32.
-    const gt = compare(cmp, cmp_data, left.*, right.*, indirect) == SecondBeforeFirst;
+    const gt = compare(cmp, cmp_data, left.*, right.*, indirect) == After;
     const from = if (gt) left else right;
     copy(dest.*, from.*, element_width);
     from.* -= element_width;
@@ -3037,7 +3037,7 @@ inline fn swap_branchless_return_gt(
     comptime indirect: bool,
 ) u8 {
     // While not guaranteed branchless, tested in godbolt for x86_64, aarch32, aarch64, riscv64, and wasm32.
-    const gt = compare(cmp, cmp_data, ptr, ptr + element_width, indirect) == SecondBeforeFirst;
+    const gt = compare(cmp, cmp_data, ptr, ptr + element_width, indirect) == After;
     const x = if (gt) element_width else 0;
     const from = if (gt) ptr else ptr + element_width;
     copy(tmp, from, element_width);
@@ -3097,28 +3097,20 @@ fn test_i64_compare(_: Opaque, a_ptr: Opaque, b_ptr: Opaque) callconv(.c) u8 {
     const a: *const i64 = utils.alignedPtrCast(*const i64, a_ptr.?, @src());
     const b: *const i64 = utils.alignedPtrCast(*const i64, b_ptr.?, @src());
 
-    const gt = @as(u8, @intFromBool(a.* > b.*));
-    const lt = @as(u8, @intFromBool(a.* < b.*));
-
-    // Eq = 0
-    // FirstBeforeSecond = 1
-    // SecondBeforeFirst = 2
-    return lt + gt + gt;
+    if (a.* < b.*) return @intFromEnum(Ordering.Before);
+    if (a.* > b.*) return @intFromEnum(Ordering.After);
+    return @intFromEnum(Ordering.Same);
 }
 
 fn test_i64_compare_refcounted(count_ptr: Opaque, a_ptr: Opaque, b_ptr: Opaque) callconv(.c) u8 {
     const a: *const i64 = utils.alignedPtrCast(*const i64, a_ptr.?, @src());
     const b: *const i64 = utils.alignedPtrCast(*const i64, b_ptr.?, @src());
 
-    const gt = @as(u8, @intFromBool(a.* > b.*));
-    const lt = @as(u8, @intFromBool(a.* < b.*));
-
     const count: *isize = utils.alignedPtrCast(*isize, count_ptr.?, @src());
     count.* -= 1;
-    // Eq = 0
-    // FirstBeforeSecond = 1
-    // SecondBeforeFirst = 2
-    return lt + gt + gt;
+    if (a.* < b.*) return @intFromEnum(Ordering.Before);
+    if (a.* > b.*) return @intFromEnum(Ordering.After);
+    return @intFromEnum(Ordering.Same);
 }
 
 fn test_i64_copy(dst_ptr: Opaque, src_ptr: Opaque, _: usize) callconv(.c) void {
@@ -3140,9 +3132,9 @@ const StableItem = struct {
 fn test_stable_item_compare(_: Opaque, a_ptr: Opaque, b_ptr: Opaque) callconv(.c) u8 {
     const a = utils.alignedPtrCast(*const StableItem, a_ptr.?, @src());
     const b = utils.alignedPtrCast(*const StableItem, b_ptr.?, @src());
-    if (a.key < b.key) return @intFromEnum(Ordering.FirstBeforeSecond);
-    if (a.key > b.key) return @intFromEnum(Ordering.SecondBeforeFirst);
-    return @intFromEnum(Ordering.Equivalent);
+    if (a.key < b.key) return @intFromEnum(Ordering.Before);
+    if (a.key > b.key) return @intFromEnum(Ordering.After);
+    return @intFromEnum(Ordering.Same);
 }
 
 fn test_stable_item_compare_refcounted(count_ptr: Opaque, a_ptr: Opaque, b_ptr: Opaque) callconv(.c) u8 {
@@ -3170,9 +3162,9 @@ comptime {
 fn test_large_stable_item_compare(_: Opaque, a_ptr: Opaque, b_ptr: Opaque) callconv(.c) u8 {
     const a = utils.alignedPtrCast(*const LargeStableItem, a_ptr.?, @src());
     const b = utils.alignedPtrCast(*const LargeStableItem, b_ptr.?, @src());
-    if (a.item.key < b.item.key) return @intFromEnum(Ordering.FirstBeforeSecond);
-    if (a.item.key > b.item.key) return @intFromEnum(Ordering.SecondBeforeFirst);
-    return @intFromEnum(Ordering.Equivalent);
+    if (a.item.key < b.item.key) return @intFromEnum(Ordering.Before);
+    if (a.item.key > b.item.key) return @intFromEnum(Ordering.After);
+    return @intFromEnum(Ordering.Same);
 }
 
 fn test_large_stable_item_copy(dst_ptr: Opaque, src_ptr: Opaque, _: usize) callconv(.c) void {
@@ -3314,9 +3306,9 @@ const Probe32 = struct {
 fn probe32Compare(_: Opaque, a_ptr: Opaque, b_ptr: Opaque) callconv(.c) u8 {
     const a = utils.alignedPtrCast(*const Probe32, a_ptr.?, @src());
     const b = utils.alignedPtrCast(*const Probe32, b_ptr.?, @src());
-    if (a.key < b.key) return @intFromEnum(Ordering.FirstBeforeSecond);
-    if (a.key > b.key) return @intFromEnum(Ordering.SecondBeforeFirst);
-    return @intFromEnum(Ordering.Equivalent);
+    if (a.key < b.key) return @intFromEnum(Ordering.Before);
+    if (a.key > b.key) return @intFromEnum(Ordering.After);
+    return @intFromEnum(Ordering.Same);
 }
 
 fn probe32CompareOwned(count_ptr: Opaque, a_ptr: Opaque, b_ptr: Opaque) callconv(.c) u8 {
@@ -3423,9 +3415,9 @@ fn test_hostile_compare(seed_ptr: Opaque, a_ptr: Opaque, b_ptr: Opaque) callconv
     const seed = utils.alignedPtrCast(*const u64, seed_ptr.?, @src()).*;
     const mixed = a.key *% 31 +% b.key *% 7 +% seed;
     return switch (mixed % 3) {
-        0 => @intFromEnum(Ordering.FirstBeforeSecond),
-        1 => @intFromEnum(Ordering.Equivalent),
-        else => @intFromEnum(Ordering.SecondBeforeFirst),
+        0 => @intFromEnum(Ordering.Before),
+        1 => @intFromEnum(Ordering.Same),
+        else => @intFromEnum(Ordering.After),
     };
 }
 
@@ -3435,9 +3427,9 @@ fn test_hostile_large_compare(seed_ptr: Opaque, a_ptr: Opaque, b_ptr: Opaque) ca
     const seed = utils.alignedPtrCast(*const u64, seed_ptr.?, @src()).*;
     const mixed = a.item.key *% 31 +% b.item.key *% 7 +% seed;
     return switch (mixed % 3) {
-        0 => @intFromEnum(Ordering.FirstBeforeSecond),
-        1 => @intFromEnum(Ordering.Equivalent),
-        else => @intFromEnum(Ordering.SecondBeforeFirst),
+        0 => @intFromEnum(Ordering.Before),
+        1 => @intFromEnum(Ordering.Same),
+        else => @intFromEnum(Ordering.After),
     };
 }
 

--- a/src/builtins/utils.zig
+++ b/src/builtins/utils.zig
@@ -965,9 +965,9 @@ pub fn unsafeReallocate(
 /// States which comparison argument comes first, without coupling ordering to
 /// "less than" or to Roc's `<` and `>` operators.
 pub const Ordering = enum(u8) {
-    Equivalent = 0,
-    FirstBeforeSecond = 1,
-    SecondBeforeFirst = 2,
+    After = 0,
+    Before = 1,
+    Same = 2,
 };
 
 /// Specifies whether updates should create new data or modify existing data

--- a/src/canonicalize/Statement.zig
+++ b/src/canonicalize/Statement.zig
@@ -192,7 +192,7 @@ pub const Statement = union(enum) {
     /// A where alias declaration, naming a reusable set of method constraints.
     ///
     /// ```roc
-    /// a.Sortable : where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]]
+    /// a.Sortable : where [a.order_relative_to : a -> [Before, Same, After]]
     /// ```
     ///
     /// The declaration's type is `receiver`: a rigid variable carrying every

--- a/src/check/report.zig
+++ b/src/check/report.zig
@@ -2136,7 +2136,7 @@ pub const ReportBuilder = struct {
 
         try D.renderSlice(&.{
             D.bytes("A where alias names a set of method constraints, declared like"),
-            D.bytes("a.Sortable : where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]]").withAnnotation(.inline_code),
+            D.bytes("a.Sortable : where [a.order_relative_to : a -> [Before, Same, After]]").withAnnotation(.inline_code),
             D.bytes("and written in a where clause as"),
             D.bytes("where [a.Sortable]").withAnnotation(.inline_code),
         }, self, &report);

--- a/src/cli/ReplSession.zig
+++ b/src/cli/ReplSession.zig
@@ -3085,8 +3085,8 @@ test "Repl - range_to" {
 }
 
 test "Repl - list_sort_with lengths" {
-    try expectAllNative("List.len(List.sort_with([3, 1, 2], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))", "3");
-    try expectAllNative("List.len(List.sort_with([5, 2, 8, 1, 9], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))", "5");
+    try expectAllNative("List.len(List.sort_with([3, 1, 2], |a, b| if a < b Before else if a > b After else Same))", "3");
+    try expectAllNative("List.len(List.sort_with([5, 2, 8, 1, 9], |a, b| if a < b Before else if a > b After else Same))", "5");
 }
 
 test "Repl - list_sort_with empty" {
@@ -3094,13 +3094,13 @@ test "Repl - list_sort_with empty" {
         \\{
         \\    xs : List(I64)
         \\    xs = []
-        \\    List.len(List.sort_with(xs, |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
+        \\    List.len(List.sort_with(xs, |a, b| if a < b Before else if a > b After else Same))
         \\}
     , "0");
 }
 
 test "Repl - list_sort_with single" {
-    try expectAllNative("List.len(List.sort_with([42], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))", "1");
+    try expectAllNative("List.len(List.sort_with([42], |a, b| if a < b Before else if a > b After else Same))", "1");
 }
 
 test "Repl - list fold with concat" {

--- a/src/eval/interpreter.zig
+++ b/src/eval/interpreter.zig
@@ -7946,7 +7946,7 @@ pub const Interpreter = struct {
 
     fn evalCompare(self: *LirInterpreter, a: Value, b: Value, arg_layout: layout_mod.Idx, ret_layout: layout_mod.Idx) Error!Value {
         const val = try self.alloc(ret_layout);
-        // Runtime tag order for [FirstBeforeSecond, Equivalent, SecondBeforeFirst]: Equivalent=0, FirstBeforeSecond=1, SecondBeforeFirst=2.
+        // Runtime tag order for [Before, Same, After]: After=0, Before=1, Same=2.
         const result: u8 = switch (try self.numericOperandKind(arg_layout)) {
             .unsigned_int => |bits| switch (bits) {
                 8 => cmpOrder(u8, a.read(u8), b.read(u8)),
@@ -9041,9 +9041,9 @@ pub const Interpreter = struct {
     }
 
     fn cmpOrder(comptime T: type, av: T, bv: T) u8 {
-        if (av == bv) return 0; // Equivalent
-        if (av < bv) return 1; // FirstBeforeSecond
-        return 2; // SecondBeforeFirst
+        if (av == bv) return 2; // Same
+        if (av < bv) return 1; // Before
+        return 0; // After
     }
 
     fn shiftOp(comptime T: type, av: T, amount: u8, op: ShiftOp) T {

--- a/src/eval/test/eval_issue_tests.zig
+++ b/src/eval/test/eval_issue_tests.zig
@@ -304,11 +304,11 @@ pub const tests = [_]TestCase{
             \\sort_desc = |list| {
             \\    list.sort_with(
             \\        |a, b| if a < b {
-            \\            SecondBeforeFirst
+            \\            After
             \\        } else if a > b {
-            \\            FirstBeforeSecond
+            \\            Before
             \\        } else {
-            \\            Equivalent
+            \\            Same
             \\        },
             \\    )
             \\}

--- a/src/eval/test/eval_low_level_tests.zig
+++ b/src/eval/test/eval_low_level_tests.zig
@@ -5004,7 +5004,7 @@ pub const tests = [_]TestCase{
         .name = "low_level - List.sort_with basic ascending sort",
         .source =
         \\{
-        \\x = List.sort_with([3, 1, 2], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent)
+        \\x = List.sort_with([3, 1, 2], |a, b| if a < b Before else if a > b After else Same)
         \\first = List.first(x)
         \\first
         \\}
@@ -5015,7 +5015,7 @@ pub const tests = [_]TestCase{
         .name = "low_level - List.sort_with preserves length",
         .source =
         \\{
-        \\x = List.sort_with([5, 2, 8, 1, 9], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent)
+        \\x = List.sort_with([5, 2, 8, 1, 9], |a, b| if a < b Before else if a > b After else Same)
         \\len = List.len(x)
         \\len
         \\}
@@ -5026,7 +5026,7 @@ pub const tests = [_]TestCase{
         .name = "low_level - List.sort_with nested in len defaults literal item type",
         .source =
         \\{
-        \\List.len(List.sort_with([3, 1, 2], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
+        \\List.len(List.sort_with([3, 1, 2], |a, b| if a < b Before else if a > b After else Same))
         \\}
         ,
         .expected = .{ .inspect_str = "3" },
@@ -5035,7 +5035,7 @@ pub const tests = [_]TestCase{
         .name = "low_level - List.sort_with with larger list",
         .source =
         \\{
-        \\x = List.sort_with([5, 2, 8, 1, 9, 3, 7, 4, 6], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent)
+        \\x = List.sort_with([5, 2, 8, 1, 9, 3, 7, 4, 6], |a, b| if a < b Before else if a > b After else Same)
         \\first = List.first(x)
         \\first
         \\}
@@ -5046,7 +5046,7 @@ pub const tests = [_]TestCase{
         .name = "low_level - List.sort_with with two elements",
         .source =
         \\{
-        \\x = List.sort_with([2, 1], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent)
+        \\x = List.sort_with([2, 1], |a, b| if a < b Before else if a > b After else Same)
         \\first = List.first(x)
         \\first
         \\}
@@ -5057,7 +5057,7 @@ pub const tests = [_]TestCase{
         .name = "low_level - List.sort_with descending order",
         .source =
         \\{
-        \\x = List.sort_with([1, 3, 2], |a, b| if a > b FirstBeforeSecond else if a < b SecondBeforeFirst else Equivalent)
+        \\x = List.sort_with([1, 3, 2], |a, b| if a > b Before else if a < b After else Same)
         \\first = List.first(x)
         \\first
         \\}
@@ -5069,7 +5069,7 @@ pub const tests = [_]TestCase{
         .source =
         \\{
         \\x : List(U64)
-        \\x = List.sort_with([], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent)
+        \\x = List.sort_with([], |a, b| if a < b Before else if a > b After else Same)
         \\len = List.len(x)
         \\len
         \\}
@@ -5080,7 +5080,7 @@ pub const tests = [_]TestCase{
         .name = "low_level - List.sort_with single element",
         .source =
         \\{
-        \\x = List.sort_with([42], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent)
+        \\x = List.sort_with([42], |a, b| if a < b Before else if a > b After else Same)
         \\first = List.first(x)
         \\first
         \\}
@@ -5091,7 +5091,7 @@ pub const tests = [_]TestCase{
         .name = "low_level - List.sort_with already sorted",
         .source =
         \\{
-        \\x = List.sort_with([1, 2, 3, 4, 5], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent)
+        \\x = List.sort_with([1, 2, 3, 4, 5], |a, b| if a < b Before else if a > b After else Same)
         \\first = List.first(x)
         \\first
         \\}
@@ -5102,7 +5102,7 @@ pub const tests = [_]TestCase{
         .name = "low_level - List.sort_with reverse sorted",
         .source =
         \\{
-        \\x = List.sort_with([5, 4, 3, 2, 1], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent)
+        \\x = List.sort_with([5, 4, 3, 2, 1], |a, b| if a < b Before else if a > b After else Same)
         \\first = List.first(x)
         \\first
         \\}
@@ -5156,7 +5156,7 @@ pub const tests = [_]TestCase{
     .{
         .name = "low_level - List.sort_with_reversed reverses a custom comparator",
         .source =
-        \\List.sort_with_reversed([3, 1, 2], |a, b| a.compare(b))
+        \\List.sort_with_reversed([3, 1, 2], |a, b| a.order_relative_to(b))
         ,
         .expected = .{ .inspect_str = "[3.0, 2.0, 1.0]" },
     },
@@ -5165,7 +5165,7 @@ pub const tests = [_]TestCase{
         .source =
         \\{
         \\descending = True
-        \\cmp = |a, b| if descending { if a > b FirstBeforeSecond else if a < b SecondBeforeFirst else Equivalent } else { a.compare(b) }
+        \\cmp = |a, b| if descending { if a > b Before else if a < b After else Same } else { a.order_relative_to(b) }
         \\List.sort_with([1, 3, 2], cmp)
         \\}
         ,
@@ -5176,7 +5176,7 @@ pub const tests = [_]TestCase{
         .source =
         \\{
         \\items = ["pear", "apple", "banana", "apple"]
-        \\List.sort_with(items, |a, b| a.count_utf8_bytes().default_cmp(b.count_utf8_bytes()))
+        \\List.sort_with(items, |a, b| a.count_utf8_bytes().order_relative_to(b.count_utf8_bytes()))
         \\}
         ,
         .expected = .{ .inspect_str = "[\"pear\", \"apple\", \"apple\", \"banana\"]" },
@@ -5190,7 +5190,7 @@ pub const tests = [_]TestCase{
         \\    { key: 1.U64, index: 1.U64, a: "a", b: "b", c: "c", d: "d", e: "e", f: "f", g: "g" },
         \\    { key: 2.U64, index: 2.U64, a: "a", b: "b", c: "c", d: "d", e: "e", f: "f", g: "g" },
         \\]
-        \\sorted = List.sort_with(items, |a, b| a.key.default_cmp(b.key))
+        \\sorted = List.sort_with(items, |a, b| a.key.order_relative_to(b.key))
         \\List.map(sorted, |item| item.index)
         \\}
         ,
@@ -5201,7 +5201,7 @@ pub const tests = [_]TestCase{
         .source =
         \\{
         \\items = List.repeat(1.U64, 140)
-        \\List.len(List.sort_with(items, |a, b| a.default_cmp(b)))
+        \\List.len(List.sort_with(items, |a, b| a.order_relative_to(b)))
         \\}
         ,
         .expected = .{ .inspect_str = "140" },
@@ -5213,7 +5213,7 @@ pub const tests = [_]TestCase{
             .name = "Sorter",
             .source =
             \\Sorter := [].{
-            \\    sort : List(a), (a, a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]) -> List(a)
+            \\    sort : List(a), (a, a -> [Before, Same, After]) -> List(a)
             \\    sort = |items, cmp| List.sort_with(items, cmp)
             \\}
             \\
@@ -5222,7 +5222,7 @@ pub const tests = [_]TestCase{
         .source =
         \\import Sorter
         \\
-        \\main = Sorter.sort(["pear", "a", "banana"], |a, b| a.count_utf8_bytes().default_cmp(b.count_utf8_bytes()))
+        \\main = Sorter.sort(["pear", "a", "banana"], |a, b| a.count_utf8_bytes().order_relative_to(b.count_utf8_bytes()))
         ,
         .expected = .{ .inspect_str = "[\"a\", \"pear\", \"banana\"]" },
     },

--- a/src/eval/test/eval_tests.zig
+++ b/src/eval/test/eval_tests.zig
@@ -6323,17 +6323,17 @@ const core_tests = [_]TestCase{
         .source =
         \\{
         \\    (
-        \\        U8.compare(0, U8.highest) == FirstBeforeSecond and U8.compare(U8.highest, U8.highest) == Equivalent and U8.compare(U8.highest, 0) == SecondBeforeFirst,
-        \\        I8.compare(I8.lowest, 0) == FirstBeforeSecond and I8.compare(0, 0) == Equivalent and I8.compare(I8.highest, 0) == SecondBeforeFirst,
-        \\        U16.compare(0, U16.highest) == FirstBeforeSecond and U16.compare(U16.highest, U16.highest) == Equivalent and U16.compare(U16.highest, 0) == SecondBeforeFirst,
-        \\        I16.compare(I16.lowest, 0) == FirstBeforeSecond and I16.compare(0, 0) == Equivalent and I16.compare(I16.highest, 0) == SecondBeforeFirst,
-        \\        U32.compare(0, U32.highest) == FirstBeforeSecond and U32.compare(U32.highest, U32.highest) == Equivalent and U32.compare(U32.highest, 0) == SecondBeforeFirst,
-        \\        I32.compare(I32.lowest, 0) == FirstBeforeSecond and I32.compare(0, 0) == Equivalent and I32.compare(I32.highest, 0) == SecondBeforeFirst,
-        \\        U64.compare(0, U64.highest) == FirstBeforeSecond and U64.compare(U64.highest, U64.highest) == Equivalent and U64.compare(U64.highest, 0) == SecondBeforeFirst,
-        \\        I64.compare(I64.lowest, 0) == FirstBeforeSecond and I64.compare(0, 0) == Equivalent and I64.compare(I64.highest, 0) == SecondBeforeFirst,
-        \\        U128.compare(0, U128.highest) == FirstBeforeSecond and U128.compare(U128.highest, U128.highest) == Equivalent and U128.compare(U128.highest, 0) == SecondBeforeFirst,
-        \\        I128.compare(I128.lowest, 0) == FirstBeforeSecond and I128.compare(0, 0) == Equivalent and I128.compare(I128.highest, 0) == SecondBeforeFirst,
-        \\        Dec.compare(Dec.lowest, 0.0) == FirstBeforeSecond and Dec.compare(0.0, 0.0) == Equivalent and Dec.compare(Dec.highest, 0.0) == SecondBeforeFirst,
+        \\        U8.order_relative_to(0, U8.highest) == Before and U8.order_relative_to(U8.highest, U8.highest) == Same and U8.order_relative_to(U8.highest, 0) == After,
+        \\        I8.order_relative_to(I8.lowest, 0) == Before and I8.order_relative_to(0, 0) == Same and I8.order_relative_to(I8.highest, 0) == After,
+        \\        U16.order_relative_to(0, U16.highest) == Before and U16.order_relative_to(U16.highest, U16.highest) == Same and U16.order_relative_to(U16.highest, 0) == After,
+        \\        I16.order_relative_to(I16.lowest, 0) == Before and I16.order_relative_to(0, 0) == Same and I16.order_relative_to(I16.highest, 0) == After,
+        \\        U32.order_relative_to(0, U32.highest) == Before and U32.order_relative_to(U32.highest, U32.highest) == Same and U32.order_relative_to(U32.highest, 0) == After,
+        \\        I32.order_relative_to(I32.lowest, 0) == Before and I32.order_relative_to(0, 0) == Same and I32.order_relative_to(I32.highest, 0) == After,
+        \\        U64.order_relative_to(0, U64.highest) == Before and U64.order_relative_to(U64.highest, U64.highest) == Same and U64.order_relative_to(U64.highest, 0) == After,
+        \\        I64.order_relative_to(I64.lowest, 0) == Before and I64.order_relative_to(0, 0) == Same and I64.order_relative_to(I64.highest, 0) == After,
+        \\        U128.order_relative_to(0, U128.highest) == Before and U128.order_relative_to(U128.highest, U128.highest) == Same and U128.order_relative_to(U128.highest, 0) == After,
+        \\        I128.order_relative_to(I128.lowest, 0) == Before and I128.order_relative_to(0, 0) == Same and I128.order_relative_to(I128.highest, 0) == After,
+        \\        Dec.order_relative_to(Dec.lowest, 0.0) == Before and Dec.order_relative_to(0.0, 0.0) == Same and Dec.order_relative_to(Dec.highest, 0.0) == After,
         \\    )
         \\}
         ,

--- a/src/glue/platform/GlueInput.roc
+++ b/src/glue/platform/GlueInput.roc
@@ -55,14 +55,14 @@ GlueInput := {
 		}
 	}
 
-	compare_by_index : HostedFunctionInfo, HostedFunctionInfo -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]
+	compare_by_index : HostedFunctionInfo, HostedFunctionInfo -> [Before, Same, After]
 	compare_by_index = |a, b| {
 		if a.index < b.index {
-			return FirstBeforeSecond
+			return Before
 		}
 		if a.index > b.index {
-			return SecondBeforeFirst
+			return After
 		}
-		Equivalent
+		Same
 	}
 }

--- a/src/parse/AST.zig
+++ b/src/parse/AST.zig
@@ -531,8 +531,8 @@ pub fn parseDiagnosticToReport(self: *AST, env: *const CommonEnv, diagnostic: Di
         .file_import_invalid_type => reportParseProblem(ctx, "Invalid File Import Type", "I was parsing a file import type, and only `Str` or `List(U8)` is allowed.", "Use `Str` for text files and `List(U8)` for raw bytes.", .{ .example = "import \"data.txt\" as data : Str" }),
         .nominal_associated_cannot_have_final_expression => reportParseProblem(ctx, "Unexpected Associated Expression", "I was parsing associated items for a nominal type, and I found a plain final expression.", "Associated item blocks can contain associated types and values. Remove the trailing expression or turn it into a named associated value.", .{ .example = "Id := U64 implements [\n    zero = @Id 0\n]" }),
         .type_alias_cannot_have_associated => reportParseProblem(ctx, "Type Alias With Associated Items", "I was parsing a type alias, but only nominal types can have associated items.", "Use `:=` to define a nominal type with associated items, or remove the associated item block from this alias.", .{ .example = "Id := U64 implements [\n    zero = @Id 0\n]" }),
-        .where_alias_cannot_have_associated => reportParseProblem(ctx, "Where Alias With Associated Items", "I was parsing a where alias, but only nominal types can have associated items.", "A where alias names a set of method constraints, so it has no associated items. Remove the associated item block.", .{ .example = "a.Sortable : where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]]" }),
-        .where_alias_expected_where => reportParseProblem(ctx, "Expected Where Clause", "I was parsing a where alias declaration, and I expected `where` after the `:`.", "A where alias is declared by naming a type variable and giving it a set of method constraints.", .{ .example = "a.Sortable : where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]]" }),
+        .where_alias_cannot_have_associated => reportParseProblem(ctx, "Where Alias With Associated Items", "I was parsing a where alias, but only nominal types can have associated items.", "A where alias names a set of method constraints, so it has no associated items. Remove the associated item block.", .{ .example = "a.Sortable : where [a.order_relative_to : a -> [Before, Same, After]]" }),
+        .where_alias_expected_where => reportParseProblem(ctx, "Expected Where Clause", "I was parsing a where alias declaration, and I expected `where` after the `:`.", "A where alias is declared by naming a type variable and giving it a set of method constraints.", .{ .example = "a.Sortable : where [a.order_relative_to : a -> [Before, Same, After]]" }),
         .deprecated_number_suffix => reportDeprecatedNumberSuffix(ctx),
         .expected_targets_colon => reportParseProblem(ctx, "Expected Targets Colon", "I was parsing a `targets` section, and I expected `:` after `targets`.", "The targets section starts with `targets:` followed by a configuration record.", .{ .example = "targets: { linux: { inputs: [app] } }" }),
         .expected_targets_open_curly => reportParseProblem(ctx, "Expected Targets Record", "I was parsing a `targets` section, and I expected `{`.", "Targets are configured with fields inside a record.", .{ .example = "targets: { linux: { inputs: [app] } }" }),
@@ -2733,7 +2733,7 @@ pub const WhereClause = union(enum) {
     ///
     /// Example:
     /// ```roc
-    /// elem.Sort : where [elem.order : elem -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]]
+    /// elem.Sort : where [elem.order : elem -> [Before, Same, After]]
     ///
     /// sort : List(elem) -> List(elem) where [elem.Sort]
     /// ```

--- a/src/parse/Node.zig
+++ b/src/parse/Node.zig
@@ -147,7 +147,7 @@ pub const Tag = enum {
     /// * extra_data format (if has_where == 0): [[type_arg node index]{num_type_args}, type_term node_index]
     type_decl_opaque,
     /// A where alias declaration, naming a reusable set of method constraints
-    /// Example: `a.Sortable : where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]]`
+    /// Example: `a.Sortable : where [a.order_relative_to : a -> [Before, Same, After]]`
     /// * main_token - extra_data token (0 when there is neither a where clause nor an associated block)
     /// * lhs - type header node index (its name token is the dotted upper ident)
     /// * rhs - receiver type variable node index

--- a/src/postcheck/lambda_mono/eval.zig
+++ b/src/postcheck/lambda_mono/eval.zig
@@ -1741,15 +1741,15 @@ pub const Evaluator = struct {
             .str => return self.unsupported_("compare on string"),
             .u8x16, .i8x16, .u16x8, .i16x8, .u32x4, .i32x4, .u64x2, .i64x2 => return self.unsupported_("compare on SIMD vector"),
         };
-        // Result ordering tag union sorts as Equivalent, SecondBeforeFirst, FirstBeforeSecond (alphabetical), matching
-        // the interpreter's runtime discriminants Equivalent=0, FirstBeforeSecond=1, SecondBeforeFirst=2.
+        // Result ordering tag union sorts as After, Before, Same (alphabetical), matching
+        // the interpreter's runtime discriminants After=0, Before=1, Same=2.
         return .{ .tag = .{ .discriminant = order, .payloads = &.{} } };
     }
 
     fn cmpOrder(comptime T: type, a: T, b: T) u8 {
-        if (a == b) return 0; // Equivalent
-        if (a < b) return 1; // FirstBeforeSecond
-        return 2; // SecondBeforeFirst
+        if (a == b) return 2; // Same
+        if (a < b) return 1; // Before
+        return 0; // After
     }
 
     // numeric arithmetic

--- a/test/cli/Issue9388SortWithTopLevelExpect.roc
+++ b/test/cli/Issue9388SortWithTopLevelExpect.roc
@@ -1,3 +1,3 @@
 Issue9388SortWithTopLevelExpect :: [].{}
 
-expect [3, 1, 2].sort_with(|a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent) == [1, 2, 3]
+expect [3, 1, 2].sort_with(|a, b| if a < b Before else if a > b After else Same) == [1, 2, 3]

--- a/test/cli/issue_10620_optimized_sublist_import/Sublist.roc
+++ b/test/cli/issue_10620_optimized_sublist_import/Sublist.roc
@@ -1,8 +1,8 @@
 Sublist :: {}.{
 	sublist : List(U8), List(U8) -> [Equal, Sublist, Superlist, Unequal]
 	sublist = |list1, list2| {
-		match list1.len().compare(list2.len()) {
-			SecondBeforeFirst => {
+		match list1.len().order_relative_to(list2.len()) {
+			After => {
 				match sublist(list2, list1) {
 					Sublist => Superlist
 					Unequal => Unequal
@@ -11,7 +11,7 @@ Sublist :: {}.{
 				}
 			}
 
-			Equivalent => {
+			Same => {
 				if list1 == list2 {
 					Equal
 				} else {
@@ -19,7 +19,7 @@ Sublist :: {}.{
 				}
 			}
 
-			FirstBeforeSecond => {
+			Before => {
 				length_diff = list2.len() - list1.len()
 				maybe_equal_index =
 					(0..=length_diff)

--- a/test/cli/issue_9889_roc_parser/Numbers.roc
+++ b/test/cli/issue_9889_roc_parser/Numbers.roc
@@ -39,7 +39,7 @@ largest : List(List(U64)) -> U64
 largest = |numbers|
 	numbers
 		.map(List.sum)
-		.sort_with(|a, b| if a < b SecondBeforeFirst else if b > a FirstBeforeSecond else Equivalent)
+		.sort_with(|a, b| if a < b After else if b > a Before else Same)
 		.first()
 		?? 0
 

--- a/test/snapshots/formatting/multiline/everything.md
+++ b/test/snapshots/formatting/multiline/everything.md
@@ -275,8 +275,8 @@ e.A,
  ^^
 
 A where alias names a set of method constraints, declared like a.Sortable :
-where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]] and
-written in a where clause as where [a.Sortable]
+where [a.order_relative_to : a -> [Before, Same, After]] and written in a where
+clause as where [a.Sortable]
 
 ── ✗ not a where alias ────────────────────────────────────── everything.md:65:4
 
@@ -286,8 +286,8 @@ e.B,
  ^^
 
 A where alias names a set of method constraints, declared like a.Sortable :
-where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]] and
-written in a where clause as where [a.Sortable]
+where [a.order_relative_to : a -> [Before, Same, After]] and written in a where
+clause as where [a.Sortable]
 
 ── ● declaration has no value ─────────────────────────────── everything.md:62:1
 

--- a/test/snapshots/formatting/multiline_without_comma/everything.md
+++ b/test/snapshots/formatting/multiline_without_comma/everything.md
@@ -271,8 +271,8 @@ e.A,
  ^^
 
 A where alias names a set of method constraints, declared like a.Sortable :
-where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]] and
-written in a where clause as where [a.Sortable]
+where [a.order_relative_to : a -> [Before, Same, After]] and written in a where
+clause as where [a.Sortable]
 
 ── ✗ not a where alias ────────────────────────────────────── everything.md:61:4
 
@@ -282,8 +282,8 @@ e.B
  ^^
 
 A where alias names a set of method constraints, declared like a.Sortable :
-where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]] and
-written in a where clause as where [a.Sortable]
+where [a.order_relative_to : a -> [Before, Same, After]] and written in a where
+clause as where [a.Sortable]
 
 ── ● declaration has no value ─────────────────────────────── everything.md:58:1
 

--- a/test/snapshots/formatting/singleline/everything.md
+++ b/test/snapshots/formatting/singleline/everything.md
@@ -174,8 +174,8 @@ g : e -> e where [e.A, e.B]
                    ^^
 
 A where alias names a set of method constraints, declared like a.Sortable :
-where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]] and
-written in a where clause as where [a.Sortable]
+where [a.order_relative_to : a -> [Before, Same, After]] and written in a where
+clause as where [a.Sortable]
 
 ── ✗ not a where alias ───────────────────────────────────── everything.md:20:25
 
@@ -185,8 +185,8 @@ g : e -> e where [e.A, e.B]
                         ^^
 
 A where alias names a set of method constraints, declared like a.Sortable :
-where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]] and
-written in a where clause as where [a.Sortable]
+where [a.order_relative_to : a -> [Before, Same, After]] and written in a where
+clause as where [a.Sortable]
 
 ── ● declaration has no value ─────────────────────────────── everything.md:20:1
 

--- a/test/snapshots/formatting/singleline_with_comma/everything.md
+++ b/test/snapshots/formatting/singleline_with_comma/everything.md
@@ -168,8 +168,8 @@ g : e -> e where [e.A, e.B,]
                    ^^
 
 A where alias names a set of method constraints, declared like a.Sortable :
-where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]] and
-written in a where clause as where [a.Sortable]
+where [a.order_relative_to : a -> [Before, Same, After]] and written in a where
+clause as where [a.Sortable]
 
 ── ✗ not a where alias ───────────────────────────────────── everything.md:14:25
 
@@ -179,8 +179,8 @@ g : e -> e where [e.A, e.B,]
                         ^^
 
 A where alias names a set of method constraints, declared like a.Sortable :
-where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]] and
-written in a where clause as where [a.Sortable]
+where [a.order_relative_to : a -> [Before, Same, After]] and written in a where
+clause as where [a.Sortable]
 
 ── ● declaration has no value ─────────────────────────────── everything.md:14:1
 

--- a/test/snapshots/repl/list_sort_with.md
+++ b/test/snapshots/repl/list_sort_with.md
@@ -5,17 +5,17 @@ type=repl
 ~~~
 # SOURCE
 ~~~roc
-» List.len(List.sort_with([3, 1, 2], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
-» List.len(List.sort_with([5, 2, 8, 1, 9], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
-» List.len(List.sort_with(List.drop_first([0], 1), |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
-» List.len(List.sort_with([42], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
-» List.first(List.sort_with([3, 1, 2], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
-» List.first(List.sort_with([5, 2, 8, 1, 9], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
-» List.first(List.sort_with([5, 4, 3, 2, 1], |a, b| if a > b FirstBeforeSecond else if a < b SecondBeforeFirst else Equivalent))
-» List.len(List.sort_with([1, 1, 1, 1], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
-» List.first(List.sort_with([1, 1, 1, 1], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
-» List.len(List.sort_with([2, 1], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
-» List.first(List.sort_with([2, 1], |a, b| if a < b FirstBeforeSecond else if a > b SecondBeforeFirst else Equivalent))
+» List.len(List.sort_with([3, 1, 2], |a, b| if a < b Before else if a > b After else Same))
+» List.len(List.sort_with([5, 2, 8, 1, 9], |a, b| if a < b Before else if a > b After else Same))
+» List.len(List.sort_with(List.drop_first([0], 1), |a, b| if a < b Before else if a > b After else Same))
+» List.len(List.sort_with([42], |a, b| if a < b Before else if a > b After else Same))
+» List.first(List.sort_with([3, 1, 2], |a, b| if a < b Before else if a > b After else Same))
+» List.first(List.sort_with([5, 2, 8, 1, 9], |a, b| if a < b Before else if a > b After else Same))
+» List.first(List.sort_with([5, 4, 3, 2, 1], |a, b| if a > b Before else if a < b After else Same))
+» List.len(List.sort_with([1, 1, 1, 1], |a, b| if a < b Before else if a > b After else Same))
+» List.first(List.sort_with([1, 1, 1, 1], |a, b| if a < b Before else if a > b After else Same))
+» List.len(List.sort_with([2, 1], |a, b| if a < b Before else if a > b After else Same))
+» List.first(List.sort_with([2, 1], |a, b| if a < b Before else if a > b After else Same))
 ~~~
 # OUTPUT
 3

--- a/test/snapshots/where_alias/where_alias_composition.md
+++ b/test/snapshots/where_alias/where_alias_composition.md
@@ -7,7 +7,7 @@ type=snippet
 ~~~roc
 a.Showable : where [a.to_str : a -> Str]
 
-a.Comparable : where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]]
+a.Comparable : where [a.order_relative_to : a -> [Before, Same, After]]
 
 a.Sortable : where [a.Showable, a.Comparable]
 
@@ -46,14 +46,14 @@ EndOfFile,
 				(args))
 			(ty-var (raw "a"))
 			(where
-				(method (mod-of "a") (name "compare")
+				(method (mod-of "a") (name "order_relative_to")
 					(args
 						(ty-var (raw "a")))
 					(ty-tag-union
 						(tags
-							(ty (name "FirstBeforeSecond"))
-							(ty (name "Equivalent"))
-							(ty (name "SecondBeforeFirst")))))))
+							(ty (name "Before"))
+							(ty (name "Same"))
+							(ty (name "After")))))))
 		(s-type-decl
 			(header (name ".Sortable")
 				(args))
@@ -84,7 +84,7 @@ EndOfFile,
 ~~~roc
 a.Showable :  where [a.to_str : a -> Str]
 
-a.Comparable :  where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]]
+a.Comparable :  where [a.order_relative_to : a -> [Before, Same, After]]
 
 a.Sortable :  where [a.Showable, a.Comparable]
 
@@ -124,13 +124,13 @@ describe = |value| value.to_str()
 		(ty-header (name "Comparable"))
 		(ty-rigid-var (name "a"))
 		(where
-			(method (ty-rigid-var-lookup (ty-rigid-var (name "a"))) (name "compare")
+			(method (ty-rigid-var-lookup (ty-rigid-var (name "a"))) (name "order_relative_to")
 				(args
 					(ty-rigid-var-lookup (ty-rigid-var (name "a"))))
 				(ty-tag-union
-					(ty-tag-name (name "FirstBeforeSecond"))
-					(ty-tag-name (name "Equivalent"))
-					(ty-tag-name (name "SecondBeforeFirst"))))))
+					(ty-tag-name (name "Before"))
+					(ty-tag-name (name "Same"))
+					(ty-tag-name (name "After"))))))
 	(s-where-alias-decl
 		(ty-header (name "Sortable"))
 		(ty-rigid-var (name "a"))
@@ -146,14 +146,14 @@ describe = |value| value.to_str()
 ~~~clojure
 (inferred-types
 	(defs
-		(patt (type "a -> Str where [a.compare : a -> [Equivalent, FirstBeforeSecond, SecondBeforeFirst], a.to_str : a -> Str]")))
+		(patt (type "a -> Str where [a.order_relative_to : a -> [After, Before, Same], a.to_str : a -> Str]")))
 	(type_decls
 		(where-alias (type "a where [a.to_str : a -> Str]")
 			(ty-header (name "Showable")))
-		(where-alias (type "a where [a.compare : a -> [Equivalent, FirstBeforeSecond, SecondBeforeFirst]]")
+		(where-alias (type "a where [a.order_relative_to : a -> [After, Before, Same]]")
 			(ty-header (name "Comparable")))
-		(where-alias (type "a where [a.compare : a -> [Equivalent, FirstBeforeSecond, SecondBeforeFirst], a.to_str : a -> Str]")
+		(where-alias (type "a where [a.order_relative_to : a -> [After, Before, Same], a.to_str : a -> Str]")
 			(ty-header (name "Sortable"))))
 	(expressions
-		(expr (type "a -> Str where [a.compare : a -> [Equivalent, FirstBeforeSecond, SecondBeforeFirst], a.to_str : a -> Str]"))))
+		(expr (type "a -> Str where [a.order_relative_to : a -> [After, Before, Same], a.to_str : a -> Str]"))))
 ~~~

--- a/test/snapshots/where_alias/where_alias_not_a_where_alias.md
+++ b/test/snapshots/where_alias/where_alias_not_a_where_alias.md
@@ -21,8 +21,8 @@ describe : a -> Str where [a.Wrapper]
                             ^^^^^^^^
 
 A where alias names a set of method constraints, declared like a.Sortable :
-where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]] and
-written in a where clause as where [a.Sortable]
+where [a.order_relative_to : a -> [Before, Same, After]] and written in a where
+clause as where [a.Sortable]
 
 # TOKENS
 ~~~zig

--- a/test/snapshots/where_alias/where_alias_qualified_builtin_nested_type.md
+++ b/test/snapshots/where_alias/where_alias_qualified_builtin_nested_type.md
@@ -19,8 +19,8 @@ describe : a -> Str where [a.Str.Utf8Problem]
                             ^^^^^^^^^^^^^^^^
 
 A where alias names a set of method constraints, declared like a.Sortable :
-where [a.compare : a -> [FirstBeforeSecond, Equivalent, SecondBeforeFirst]] and
-written in a where clause as where [a.Sortable]
+where [a.order_relative_to : a -> [Before, Same, After]] and written in a where
+clause as where [a.Sortable]
 
 # TOKENS
 ~~~zig


### PR DESCRIPTION
## Summary

- replace the builtin `compare`/`default_cmp` ordering surface with `order_relative_to`
- replace `[FirstBeforeSecond, Equivalent, SecondBeforeFirst]` with `[Before, Same, After]`
- emit the new tag discriminants directly in interpreter, compile-time evaluation, and native/WASM/LLVM backends
- migrate list sorting, diagnostics, fixtures, and snapshots

## Verification

- `zig build run-check-builtin-format`
- `zig build run-test-zig-module-builtins` (404 passed)
- `zig build run-test-zig-module-eval`
- `zig build minici` (76/76 phases passed)